### PR TITLE
fix(cli): honor upstream's 4 human-readable levels (--no-h width/commas)

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -62,9 +62,9 @@ where
     let h_count = matches.get_count("human-readable");
     if h_count > 0 {
         human_readable = Some(if h_count == 1 {
-            HumanReadableMode::Enabled
+            HumanReadableMode::DecimalUnits
         } else {
-            HumanReadableMode::Combined
+            HumanReadableMode::BinaryUnits
         });
     }
 

--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -10,9 +10,7 @@ use std::path::PathBuf;
 
 use crate::frontend::arguments::short_options::expand_short_options;
 use crate::frontend::command_builder::clap_command;
-use crate::frontend::execution::{
-    parse_checksum_seed_argument, parse_compress_level_argument, parse_human_readable_level,
-};
+use crate::frontend::execution::{parse_checksum_seed_argument, parse_compress_level_argument};
 use crate::frontend::filter_rules::{collect_filter_arguments, locate_filter_arguments};
 use crate::frontend::progress::{NameOutputLevel, ProgressSetting};
 use core::client::{
@@ -55,39 +53,23 @@ where
     let show_io_uring_status = matches.get_flag("io-uring-status");
     let show_lsm_status = matches.get_flag("lsm-status");
 
-    // Handle human-readable: bare flags (-h, --human-readable) count occurrences
-    // while explicit values (--human-readable=2) set the level directly.
-    // The sentinel "__h_count__" distinguishes bare flags from explicit values.
-    // upstream: options.c - human_readable starts at 1, each -h increments,
-    // --no-human-readable sets to 0.
+    // Handle human-readable: `-h`/`--human-readable` take no argument and are
+    // repeatable, so we count occurrences. upstream: options.c:111 defaults
+    // `human_readable` to 1 (rendered as the None case here), options.c:1573
+    // increments it per -h, and options.c:617 resets it to 0 for --no-h. A
+    // single -h selects base-1000 units; -hh (or more) selects base-1024.
     let mut human_readable = None;
-    if let Some(values) = matches.remove_many::<OsString>("human-readable") {
-        let values: Vec<OsString> = values.collect();
-        let sentinel = OsString::from("__h_count__");
-
-        let mut bare_flag_count: u32 = 0;
-        let mut last_explicit_level: Option<HumanReadableMode> = None;
-
-        for value in &values {
-            if *value == sentinel {
-                bare_flag_count += 1;
-            } else {
-                last_explicit_level = Some(parse_human_readable_level(value.as_os_str())?);
-            }
-        }
-
-        if let Some(level) = last_explicit_level {
-            human_readable = Some(level);
+    let h_count = matches.get_count("human-readable");
+    if h_count > 0 {
+        human_readable = Some(if h_count == 1 {
+            HumanReadableMode::Enabled
         } else {
-            human_readable = Some(match bare_flag_count {
-                1 => HumanReadableMode::Enabled,
-                _ => HumanReadableMode::Combined,
-            });
-        }
+            HumanReadableMode::Combined
+        });
     }
 
     if matches.get_flag("no-human-readable") {
-        human_readable = Some(HumanReadableMode::Disabled);
+        human_readable = Some(HumanReadableMode::Raw);
     }
     let mut dry_run = matches.get_flag("dry-run");
     let list_only = matches.get_flag("list-only");

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -360,33 +360,32 @@ fn human_readable_long_flag_is_enabled() {
 }
 
 #[test]
-fn human_readable_explicit_level_two() {
-    let parsed = parse_test_args(["--human-readable=2", "src/", "dst/"]).expect("parse");
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
+fn human_readable_explicit_argument_is_rejected() {
+    // upstream: options.c:616 declares -h/--human-readable as POPT_ARG_NONE, so
+    // `--human-readable=N` errors with "option does not take an argument".
+    assert!(parse_test_args(["--human-readable=2", "src/", "dst/"]).is_err());
+    assert!(parse_test_args(["--human-readable=0", "src/", "dst/"]).is_err());
 }
 
 #[test]
-fn human_readable_explicit_level_zero() {
-    let parsed = parse_test_args(["--human-readable=0", "src/", "dst/"]).expect("parse");
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Disabled));
-}
-
-#[test]
-fn human_readable_no_flag_disables() {
+fn human_readable_no_flag_is_raw_level_zero() {
+    // upstream: options.c:617 resets human_readable to 0 (raw digits, width 11).
     let parsed = parse_test_args(["--no-human-readable", "src/", "dst/"]).expect("parse");
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Disabled));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Raw));
 }
 
 #[test]
 fn human_readable_not_specified_is_none() {
+    // None resolves to the upstream default level 1 (comma-grouped) downstream.
     let parsed = parse_test_args(["src/", "dst/"]).expect("parse");
     assert_eq!(parsed.human_readable, None);
 }
 
 #[test]
-fn human_readable_explicit_one_twice_stays_enabled() {
-    let parsed = parse_test_args(["--human-readable=1", "--human-readable=1", "src/", "dst/"])
-        .expect("parse");
+fn human_readable_no_h_then_h_prefers_h() {
+    // upstream: overrides_with semantics - the later flag wins, so -h re-enables
+    // suffix formatting after --no-h.
+    let parsed = parse_test_args(["--no-h", "-h", "src/", "dst/"]).expect("parse");
     assert_eq!(parsed.human_readable, Some(HumanReadableMode::Enabled));
 }
 

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -344,19 +344,19 @@ fn aes_default_is_none() {
 #[test]
 fn human_readable_single_short_h_is_enabled() {
     let parsed = parse_test_args(["-h", "src/", "dst/"]).expect("parse");
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Enabled));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::DecimalUnits));
 }
 
 #[test]
 fn human_readable_double_short_hh_is_combined() {
     let parsed = parse_test_args(["-hh", "src/", "dst/"]).expect("parse");
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::BinaryUnits));
 }
 
 #[test]
 fn human_readable_long_flag_is_enabled() {
     let parsed = parse_test_args(["--human-readable", "src/", "dst/"]).expect("parse");
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Enabled));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::DecimalUnits));
 }
 
 #[test]
@@ -386,20 +386,20 @@ fn human_readable_no_h_then_h_prefers_h() {
     // upstream: overrides_with semantics - the later flag wins, so -h re-enables
     // suffix formatting after --no-h.
     let parsed = parse_test_args(["--no-h", "-h", "src/", "dst/"]).expect("parse");
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Enabled));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::DecimalUnits));
 }
 
 #[test]
 fn human_readable_two_bare_long_flags_is_combined() {
     let parsed =
         parse_test_args(["--human-readable", "--human-readable", "src/", "dst/"]).expect("parse");
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::BinaryUnits));
 }
 
 #[test]
 fn human_readable_two_separate_short_flags_is_combined() {
     let parsed = parse_test_args(["-h", "-h", "src/", "dst/"]).expect("parse");
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::BinaryUnits));
 }
 
 #[test]

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1394,7 +1394,7 @@ mod option_values {
     fn human_readable_double_short_is_combined() {
         // -hh increments to level 3 (base-1024 units). upstream: options.c:1573.
         let parsed = parse_test_args(["-hh", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
+        assert_eq!(parsed.human_readable, Some(HumanReadableMode::BinaryUnits));
     }
 
     #[test]
@@ -2530,7 +2530,7 @@ mod human_readable_tests {
     #[test]
     fn human_readable_no_value() {
         let parsed = parse_test_args(["-h", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.human_readable, Some(HumanReadableMode::Enabled));
+        assert_eq!(parsed.human_readable, Some(HumanReadableMode::DecimalUnits));
     }
 
     #[test]

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1391,8 +1391,9 @@ mod option_values {
     }
 
     #[test]
-    fn human_readable_with_level() {
-        let parsed = parse_test_args(["--human-readable=2", "src/", "dst/"]).expect("parse");
+    fn human_readable_double_short_is_combined() {
+        // -hh increments to level 3 (base-1024 units). upstream: options.c:1573.
+        let parsed = parse_test_args(["-hh", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
     }
 
@@ -2533,33 +2534,24 @@ mod human_readable_tests {
     }
 
     #[test]
-    fn human_readable_level_0() {
-        let parsed = parse_test_args(["--human-readable=0", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.human_readable, Some(HumanReadableMode::Disabled));
+    fn human_readable_rejects_explicit_argument() {
+        // upstream: options.c:616 POPT_ARG_NONE - `--human-readable=N` errors.
+        assert!(parse_test_args(["--human-readable=0", "src/", "dst/"]).is_err());
+        assert!(parse_test_args(["--human-readable=1", "src/", "dst/"]).is_err());
+        assert!(parse_test_args(["--human-readable=2", "src/", "dst/"]).is_err());
     }
 
     #[test]
-    fn human_readable_level_1() {
-        let parsed = parse_test_args(["--human-readable=1", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.human_readable, Some(HumanReadableMode::Enabled));
-    }
-
-    #[test]
-    fn human_readable_level_2() {
-        let parsed = parse_test_args(["--human-readable=2", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
-    }
-
-    #[test]
-    fn no_human_readable_flag() {
+    fn no_human_readable_flag_is_raw() {
+        // upstream: options.c:617 sets human_readable = 0 (raw digits, width 11).
         let parsed = parse_test_args(["--no-human-readable", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.human_readable, Some(HumanReadableMode::Disabled));
+        assert_eq!(parsed.human_readable, Some(HumanReadableMode::Raw));
     }
 
     #[test]
-    fn no_h_alias() {
+    fn no_h_alias_is_raw() {
         let parsed = parse_test_args(["--no-h", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.human_readable, Some(HumanReadableMode::Disabled));
+        assert_eq!(parsed.human_readable, Some(HumanReadableMode::Raw));
     }
 }
 

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/output.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/output.rs
@@ -33,18 +33,17 @@ pub(super) fn add_output_args(command: ClapCommand) -> ClapCommand {
                 .overrides_with("verbose"),
         )
         .arg(
+            // upstream: options.c:616 `{"human-readable", 'h', POPT_ARG_NONE, ...}`
+            // takes no argument, so `--human-readable=N` is rejected. Each -h
+            // increments the level (options.c:1573): -h => base-1000 units,
+            // -hh => base-1024 units.
             Arg::new("human-readable")
                 .short('h')
                 .long("human-readable")
-                .value_name("LEVEL")
                 .help(
-                    "Output numbers in a human-readable format; optional LEVEL selects 0, 1, or 2. Can be repeated to increase level.",
+                    "Output numbers in a human-readable format; repeat (-hh) to select base-1024 units.",
                 )
-                .num_args(0..=1)
-                .default_missing_value("__h_count__")
-                .require_equals(true)
-                .value_parser(OsStringValueParser::new())
-                .action(ArgAction::Append)
+                .action(ArgAction::Count)
                 .overrides_with("no-human-readable"),
         )
         .arg(

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -252,7 +252,7 @@ where
 
     let password_file = password_file.map(PathBuf::from);
     let human_readable_setting = human_readable;
-    let human_readable_mode = human_readable_setting.unwrap_or(HumanReadableMode::Disabled);
+    let human_readable_mode = human_readable_setting.unwrap_or(HumanReadableMode::Grouped);
     let human_readable_enabled = human_readable_mode.is_enabled();
     let stderr_mode_setting = stderr_mode
         .as_ref()

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -33,10 +33,9 @@ pub(crate) use operands::{extract_operands, parse_bind_address_argument};
 #[cfg(test)]
 pub(crate) use options::{SizeParseError, pow_u128_for_size};
 pub(crate) use options::{
-    parse_block_size_argument, parse_checksum_seed_argument, parse_human_readable_level,
-    parse_max_alloc_argument, parse_max_delete_argument, parse_modify_window_argument,
-    parse_protocol_version_arg, parse_size_limit_argument, parse_timeout_argument,
-    resolve_iconv_setting,
+    parse_block_size_argument, parse_checksum_seed_argument, parse_max_alloc_argument,
+    parse_max_delete_argument, parse_modify_window_argument, parse_protocol_version_arg,
+    parse_size_limit_argument, parse_timeout_argument, resolve_iconv_setting,
 };
 pub(crate) use stop::{parse_stop_after_argument, parse_stop_at_argument};
 

--- a/crates/cli/src/frontend/execution/options/mod.rs
+++ b/crates/cli/src/frontend/execution/options/mod.rs
@@ -18,8 +18,8 @@ mod size;
 
 pub(crate) use iconv::resolve_iconv_setting;
 pub(crate) use numeric::{
-    parse_checksum_seed_argument, parse_human_readable_level, parse_max_delete_argument,
-    parse_modify_window_argument, parse_timeout_argument,
+    parse_checksum_seed_argument, parse_max_delete_argument, parse_modify_window_argument,
+    parse_timeout_argument,
 };
 pub(crate) use protocol::parse_protocol_version_arg;
 #[cfg(test)]
@@ -33,7 +33,7 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
 
-    use core::client::{HumanReadableMode, TransferTimeout};
+    use core::client::TransferTimeout;
 
     fn os(s: &str) -> OsString {
         OsString::from(s)
@@ -169,29 +169,5 @@ mod tests {
     #[test]
     fn parse_modify_window_argument_invalid() {
         assert!(parse_modify_window_argument(&os("foo")).is_err());
-    }
-
-    #[test]
-    fn parse_human_readable_level_zero() {
-        let result = parse_human_readable_level(&os("0")).unwrap();
-        assert_eq!(result, HumanReadableMode::Disabled);
-    }
-
-    #[test]
-    fn parse_human_readable_level_one() {
-        let result = parse_human_readable_level(&os("1")).unwrap();
-        assert_eq!(result, HumanReadableMode::Enabled);
-    }
-
-    #[test]
-    fn parse_human_readable_level_two() {
-        let result = parse_human_readable_level(&os("2")).unwrap();
-        assert_eq!(result, HumanReadableMode::Combined);
-    }
-
-    #[test]
-    fn parse_human_readable_level_invalid() {
-        let result = parse_human_readable_level(&os("invalid"));
-        assert!(result.is_err());
     }
 }

--- a/crates/cli/src/frontend/execution/options/numeric.rs
+++ b/crates/cli/src/frontend/execution/options/numeric.rs
@@ -7,7 +7,7 @@ use std::ffi::OsStr;
 use std::num::{IntErrorKind, NonZeroU64};
 
 use core::{
-    client::{HumanReadableMode, TransferTimeout},
+    client::TransferTimeout,
     message::{Message, Role},
     rsync_error,
 };
@@ -62,15 +62,6 @@ pub(crate) fn parse_timeout_argument(value: &OsStr) -> Result<TransferTimeout, M
             )
         }
     }
-}
-
-/// Parses the `--human-readable` level argument.
-///
-/// Delegates to `HumanReadableMode::parse` and converts errors to `clap::Error`.
-pub(crate) fn parse_human_readable_level(value: &OsStr) -> Result<HumanReadableMode, clap::Error> {
-    let text = value.to_string_lossy();
-    HumanReadableMode::parse(text.as_ref())
-        .map_err(|error| clap::Error::raw(clap::error::ErrorKind::InvalidValue, error.to_string()))
 }
 
 /// Parses the `--max-delete` argument as a non-negative `u64` deletion limit.

--- a/crates/cli/src/frontend/progress/format/mod.rs
+++ b/crates/cli/src/frontend/progress/format/mod.rs
@@ -19,6 +19,5 @@ pub(crate) use self::rate::{
 };
 pub(crate) use self::remaining::RemainingTimeEstimator;
 pub(crate) use self::size::{
-    LIST_SIZE_WIDTH, format_decimal_bytes, format_human_bytes, format_list_size,
-    format_progress_bytes, format_size,
+    format_decimal_bytes, format_human_bytes, format_list_size, format_progress_bytes, format_size,
 };

--- a/crates/cli/src/frontend/progress/format/rate.rs
+++ b/crates/cli/src/frontend/progress/format/rate.rs
@@ -153,11 +153,11 @@ mod tests {
         // the default (non -h) summary trailer must be thousands-grouped, the
         // same as oc-rsync's own --stats path.
         assert_eq!(
-            format_summary_rate(1_234_567.89, HumanReadableMode::Disabled),
+            format_summary_rate(1_234_567.89, HumanReadableMode::Grouped),
             "1,234,567.89"
         );
         assert_eq!(
-            format_summary_rate(512.0, HumanReadableMode::Disabled),
+            format_summary_rate(512.0, HumanReadableMode::Grouped),
             "512.00"
         );
     }
@@ -236,26 +236,26 @@ mod tests {
     /// in progress2 mode.
     #[test]
     fn format_progress_rate_from_value_zero() {
-        let result = format_progress_rate_from_value(0.0, HumanReadableMode::Disabled);
+        let result = format_progress_rate_from_value(0.0, HumanReadableMode::Grouped);
         assert_eq!(result, "0.00kB/s");
     }
 
     #[test]
     fn format_progress_rate_from_value_negative() {
-        let result = format_progress_rate_from_value(-1.0, HumanReadableMode::Disabled);
+        let result = format_progress_rate_from_value(-1.0, HumanReadableMode::Grouped);
         assert_eq!(result, "0.00kB/s");
     }
 
     #[test]
     fn format_progress_rate_from_value_kb_range() {
-        let result = format_progress_rate_from_value(512.0, HumanReadableMode::Disabled);
+        let result = format_progress_rate_from_value(512.0, HumanReadableMode::Grouped);
         assert!(result.ends_with("kB/s"), "expected kB/s: {result}");
     }
 
     #[test]
     fn format_progress_rate_from_value_mb_range() {
         let result =
-            format_progress_rate_from_value(2.0 * 1024.0 * 1024.0, HumanReadableMode::Disabled);
+            format_progress_rate_from_value(2.0 * 1024.0 * 1024.0, HumanReadableMode::Grouped);
         assert!(result.ends_with("MB/s"), "expected MB/s: {result}");
     }
 
@@ -263,7 +263,7 @@ mod tests {
     fn format_progress_rate_from_value_gb_range() {
         let result = format_progress_rate_from_value(
             2.0 * 1024.0 * 1024.0 * 1024.0,
-            HumanReadableMode::Disabled,
+            HumanReadableMode::Grouped,
         );
         assert!(result.ends_with("GB/s"), "expected GB/s: {result}");
     }

--- a/crates/cli/src/frontend/progress/format/size.rs
+++ b/crates/cli/src/frontend/progress/format/size.rs
@@ -275,7 +275,7 @@ mod tests {
         // upstream: generator.c:1159 size_width = 11 for level 0; the value is
         // right-justified raw digits, matching `-rw-r--r--     1234567 ...`.
         let result = format_list_size(1_234_567, HumanReadableMode::Raw);
-        assert_eq!(result, "     1234567");
+        assert_eq!(result, "    1234567");
         assert_eq!(result.len(), 11);
     }
 

--- a/crates/cli/src/frontend/progress/format/size.rs
+++ b/crates/cli/src/frontend/progress/format/size.rs
@@ -2,19 +2,30 @@
 
 use core::client::HumanReadableMode;
 
-/// Formats a byte count using thousands separators when human-readable formatting is disabled. When
-/// enabled, the output uses unit suffixes such as `K`, `M`, or `G` with two fractional digits.
-/// `-h` (Enabled) divides by 1000; `-hh` (Combined) divides by 1024, mirroring upstream `do_big_num`.
+/// Formats a byte count according to the active human-readable level, mirroring
+/// upstream `lib/compat.c:do_big_num`:
+///
+/// - Level 0 ([`HumanReadableMode::Raw`]): raw digits, no separators (`1234567`).
+/// - Level 1 ([`HumanReadableMode::Disabled`], default): thousands-separated
+///   digits (`1,234,567`).
+/// - Level 2 (`-h`) / level 3 (`-hh`): unit suffixes such as `K`, `M`, or `G`
+///   with two fractional digits, dividing by 1000 and 1024 respectively.
 pub(crate) fn format_progress_bytes(bytes: u64, human_readable: HumanReadableMode) -> String {
     format_size(bytes, human_readable)
 }
 
 pub(crate) fn format_size(bytes: u64, human_readable: HumanReadableMode) -> String {
-    if !human_readable.is_enabled() {
-        return format_decimal_bytes(bytes);
+    if human_readable.is_enabled() {
+        return format_human_bytes(bytes, human_readable.unit_base());
     }
 
-    format_human_bytes(bytes, human_readable.unit_base())
+    // upstream: lib/compat.c:231 inserts the separator only when human_flag != 0
+    // (level 1); level 0 (--no-h) emits the raw digit run.
+    if human_readable.uses_separators() {
+        format_decimal_bytes(bytes)
+    } else {
+        bytes.to_string()
+    }
 }
 
 pub(crate) fn format_decimal_bytes(bytes: u64) -> String {
@@ -71,18 +82,10 @@ pub(crate) fn format_human_bytes(bytes: u64, base: f64) -> String {
     bytes.to_string()
 }
 
-/// Width of the size column in `--list-only` output.
-///
-/// upstream: generator.c:1159 `list_file_entry` - `size_width = human_readable
-/// ? 14 : 11`. `human_readable` defaults to 1 (options.c:111), so every oc
-/// rendering mode (all of which print thousands-separated values like upstream's
-/// default `human_num`) uses the 14-wide field; the 11-wide field only applies
-/// to upstream's `--no-human-readable`, which oc does not distinctly model.
-pub(crate) const LIST_SIZE_WIDTH: usize = 14;
-
 pub(crate) fn format_list_size(size: u64, human_readable: HumanReadableMode) -> String {
     let value = format_size(size, human_readable);
-    format!("{value:>LIST_SIZE_WIDTH$}")
+    let width = human_readable.size_width();
+    format!("{value:>width$}")
 }
 
 #[cfg(test)]
@@ -238,5 +241,49 @@ mod tests {
             small_spaces > large_spaces,
             "smaller value should have more leading spaces: small={small_spaces}, large={large_spaces}"
         );
+    }
+
+    // The following tests pin upstream rsync 3.4.4's four human-readable levels
+    // byte-for-byte for a 1,234,567-byte value, so a regression that collapses
+    // level 0 (--no-h) back into level 1 (default) is caught. Verified against
+    // the reference binary: `rsync --list-only [--no-h|-h|-hh]`.
+
+    #[test]
+    fn format_size_raw_level_zero_has_no_separators() {
+        // upstream: --no-h => do_big_num(x, 0, NULL) emits raw digits.
+        assert_eq!(format_size(1_234_567, HumanReadableMode::Raw), "1234567");
+    }
+
+    #[test]
+    fn format_size_default_level_one_groups_digits() {
+        // upstream: default level 1 => comma-grouped digits, no unit suffix.
+        assert_eq!(
+            format_size(1_234_567, HumanReadableMode::Disabled),
+            "1,234,567"
+        );
+    }
+
+    #[test]
+    fn format_size_h_and_hh_use_correct_base() {
+        // upstream: -h base 1000 => 1.23M; -hh base 1024 => 1.18M.
+        assert_eq!(format_size(1_234_567, HumanReadableMode::Enabled), "1.23M");
+        assert_eq!(format_size(1_234_567, HumanReadableMode::Combined), "1.18M");
+    }
+
+    #[test]
+    fn format_list_size_raw_is_width_11_no_commas() {
+        // upstream: generator.c:1159 size_width = 11 for level 0; the value is
+        // right-justified raw digits, matching `-rw-r--r--     1234567 ...`.
+        let result = format_list_size(1_234_567, HumanReadableMode::Raw);
+        assert_eq!(result, "     1234567");
+        assert_eq!(result.len(), 11);
+    }
+
+    #[test]
+    fn format_list_size_default_is_width_14_with_commas() {
+        // upstream: generator.c:1159 size_width = 14 for level 1.
+        let result = format_list_size(1_234_567, HumanReadableMode::Disabled);
+        assert_eq!(result, "     1,234,567");
+        assert_eq!(result.len(), 14);
     }
 }

--- a/crates/cli/src/frontend/progress/format/size.rs
+++ b/crates/cli/src/frontend/progress/format/size.rs
@@ -6,7 +6,7 @@ use core::client::HumanReadableMode;
 /// upstream `lib/compat.c:do_big_num`:
 ///
 /// - Level 0 ([`HumanReadableMode::Raw`]): raw digits, no separators (`1234567`).
-/// - Level 1 ([`HumanReadableMode::Disabled`], default): thousands-separated
+/// - Level 1 ([`HumanReadableMode::Grouped`], default): thousands-separated
 ///   digits (`1,234,567`).
 /// - Level 2 (`-h`) / level 3 (`-hh`): unit suffixes such as `K`, `M`, or `G`
 ///   with two fractional digits, dividing by 1000 and 1024 respectively.
@@ -166,14 +166,14 @@ mod tests {
     #[test]
     fn format_list_size_pads_to_14() {
         // upstream: generator.c:1159 size_width = 14 (human_readable defaults to 1).
-        let result = format_list_size(123, HumanReadableMode::Disabled);
+        let result = format_list_size(123, HumanReadableMode::Grouped);
         assert_eq!(result.len(), 14);
         assert!(result.trim_start().starts_with("123"));
     }
 
     #[test]
     fn format_list_size_zero_pads_correctly() {
-        let result = format_list_size(0, HumanReadableMode::Disabled);
+        let result = format_list_size(0, HumanReadableMode::Grouped);
         assert_eq!(result.len(), 14);
         assert_eq!(result.trim(), "0");
         // Should be right-aligned: leading spaces then "0"
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn format_list_size_large_value_with_separators() {
-        let result = format_list_size(1_234_567, HumanReadableMode::Disabled);
+        let result = format_list_size(1_234_567, HumanReadableMode::Grouped);
         assert_eq!(result.len(), 14);
         assert!(
             result.contains("1,234,567"),
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn format_list_size_very_large_value() {
-        let result = format_list_size(1_234_567_890_123, HumanReadableMode::Disabled);
+        let result = format_list_size(1_234_567_890_123, HumanReadableMode::Grouped);
         assert!(
             result.contains("1,234,567,890,123"),
             "very large value should be formatted with separators: {result:?}"
@@ -202,14 +202,14 @@ mod tests {
     #[test]
     fn format_list_size_human_readable_small() {
         // Values under 1000 should show plain digits
-        let result = format_list_size(500, HumanReadableMode::Enabled);
+        let result = format_list_size(500, HumanReadableMode::DecimalUnits);
         assert_eq!(result.len(), 14);
         assert_eq!(result.trim(), "500");
     }
 
     #[test]
     fn format_list_size_human_readable_kilo() {
-        let result = format_list_size(1_500, HumanReadableMode::Enabled);
+        let result = format_list_size(1_500, HumanReadableMode::DecimalUnits);
         assert_eq!(result.len(), 14);
         assert!(
             result.contains("1.50K"),
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn format_list_size_human_readable_mega() {
-        let result = format_list_size(2_500_000, HumanReadableMode::Enabled);
+        let result = format_list_size(2_500_000, HumanReadableMode::DecimalUnits);
         assert_eq!(result.len(), 14);
         assert!(
             result.contains("2.50M"),
@@ -229,8 +229,8 @@ mod tests {
 
     #[test]
     fn format_list_size_is_right_aligned() {
-        let small = format_list_size(1, HumanReadableMode::Disabled);
-        let large = format_list_size(1_000_000, HumanReadableMode::Disabled);
+        let small = format_list_size(1, HumanReadableMode::Grouped);
+        let large = format_list_size(1_000_000, HumanReadableMode::Grouped);
 
         assert_eq!(small.len(), 14);
         assert_eq!(large.len(), 14);
@@ -258,7 +258,7 @@ mod tests {
     fn format_size_default_level_one_groups_digits() {
         // upstream: default level 1 => comma-grouped digits, no unit suffix.
         assert_eq!(
-            format_size(1_234_567, HumanReadableMode::Disabled),
+            format_size(1_234_567, HumanReadableMode::Grouped),
             "1,234,567"
         );
     }
@@ -266,8 +266,14 @@ mod tests {
     #[test]
     fn format_size_h_and_hh_use_correct_base() {
         // upstream: -h base 1000 => 1.23M; -hh base 1024 => 1.18M.
-        assert_eq!(format_size(1_234_567, HumanReadableMode::Enabled), "1.23M");
-        assert_eq!(format_size(1_234_567, HumanReadableMode::Combined), "1.18M");
+        assert_eq!(
+            format_size(1_234_567, HumanReadableMode::DecimalUnits),
+            "1.23M"
+        );
+        assert_eq!(
+            format_size(1_234_567, HumanReadableMode::BinaryUnits),
+            "1.18M"
+        );
     }
 
     #[test]
@@ -282,7 +288,7 @@ mod tests {
     #[test]
     fn format_list_size_default_is_width_14_with_commas() {
         // upstream: generator.c:1159 size_width = 14 for level 1.
-        let result = format_list_size(1_234_567, HumanReadableMode::Disabled);
+        let result = format_list_size(1_234_567, HumanReadableMode::Grouped);
         assert_eq!(result, "     1,234,567");
         assert_eq!(result.len(), 14);
     }

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -419,7 +419,7 @@ mod tests {
         let mut buf: Vec<u8> = Vec::new();
         {
             let mut live =
-                LiveProgress::new(&mut buf, ProgressMode::PerFile, HumanReadableMode::Disabled);
+                LiveProgress::new(&mut buf, ProgressMode::PerFile, HumanReadableMode::Grouped);
             live.on_progress(&make_update(true));
         }
         let output = String::from_utf8(buf).expect("utf8");
@@ -432,7 +432,7 @@ mod tests {
         let mut buf: Vec<u8> = Vec::new();
         {
             let mut live =
-                LiveProgress::new(&mut buf, ProgressMode::PerFile, HumanReadableMode::Disabled);
+                LiveProgress::new(&mut buf, ProgressMode::PerFile, HumanReadableMode::Grouped);
             live.on_progress(&make_update(false));
         }
         let output = String::from_utf8(buf).expect("utf8");
@@ -447,7 +447,7 @@ mod tests {
         let mut buf: Vec<u8> = Vec::new();
         {
             let mut live =
-                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Disabled);
+                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Grouped);
             live.on_progress(&make_mid_transfer_update(true));
         }
         let output = String::from_utf8(buf).expect("utf8");
@@ -468,7 +468,7 @@ mod tests {
         let mut buf: Vec<u8> = Vec::new();
         {
             let mut live =
-                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Disabled);
+                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Grouped);
             live.on_progress(&make_update(true));
         }
         let output = String::from_utf8(buf).expect("utf8");
@@ -489,7 +489,7 @@ mod tests {
         let mut buf: Vec<u8> = Vec::new();
         {
             let mut live =
-                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Disabled);
+                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Grouped);
             // First tick: final with trailer (longer line)
             live.on_progress(&make_update(true));
             // Second tick: mid-transfer without trailer (shorter line, should be padded)
@@ -516,7 +516,7 @@ mod tests {
         let mut buf: Vec<u8> = Vec::new();
         {
             let mut live =
-                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Disabled);
+                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Grouped);
             live.on_progress(&make_update(true));
         }
         let output = String::from_utf8(buf).expect("utf8");
@@ -550,7 +550,7 @@ mod tests {
             let mut live = LiveProgress::with_output_config(
                 &mut buf,
                 ProgressMode::PerFile,
-                HumanReadableMode::Disabled,
+                HumanReadableMode::Grouped,
                 piped_config(),
             );
             live.on_progress(&make_mid_transfer_update(true));
@@ -572,7 +572,7 @@ mod tests {
             let mut live = LiveProgress::with_output_config(
                 &mut buf,
                 ProgressMode::PerFile,
-                HumanReadableMode::Disabled,
+                HumanReadableMode::Grouped,
                 terminal_config(),
             );
             live.on_progress(&make_mid_transfer_update(true));
@@ -594,7 +594,7 @@ mod tests {
             let mut live = LiveProgress::with_output_config(
                 &mut buf,
                 ProgressMode::Overall,
-                HumanReadableMode::Disabled,
+                HumanReadableMode::Grouped,
                 piped_config(),
             );
             live.on_progress(&make_update(true));
@@ -615,7 +615,7 @@ mod tests {
             let mut live = LiveProgress::with_output_config(
                 &mut buf,
                 ProgressMode::Overall,
-                HumanReadableMode::Disabled,
+                HumanReadableMode::Grouped,
                 terminal_config(),
             );
             live.on_progress(&make_update(true));
@@ -637,7 +637,7 @@ mod tests {
             let mut live = LiveProgress::with_output_config(
                 &mut buf,
                 ProgressMode::Overall,
-                HumanReadableMode::Disabled,
+                HumanReadableMode::Grouped,
                 piped_config(),
             );
             // First tick: final with trailer (longer line)
@@ -686,7 +686,7 @@ mod tests {
         let live_term = LiveProgress::with_output_config(
             &mut buf,
             ProgressMode::PerFile,
-            HumanReadableMode::Disabled,
+            HumanReadableMode::Grouped,
             terminal_config(),
         );
         assert_eq!(live_term.line_restart(), "\r");
@@ -694,7 +694,7 @@ mod tests {
         let live_pipe = LiveProgress::with_output_config(
             &mut buf,
             ProgressMode::PerFile,
-            HumanReadableMode::Disabled,
+            HumanReadableMode::Grouped,
             piped_config(),
         );
         assert_eq!(live_pipe.line_restart(), "\n");
@@ -731,7 +731,7 @@ mod tests {
             let mut live = LiveProgress::with_output_config(
                 &mut writer,
                 ProgressMode::PerFile,
-                HumanReadableMode::Disabled,
+                HumanReadableMode::Grouped,
                 config,
             );
             // Mid-transfer tick should trigger flush
@@ -775,7 +775,7 @@ mod tests {
             let mut live = LiveProgress::with_output_config(
                 &mut writer,
                 ProgressMode::PerFile,
-                HumanReadableMode::Disabled,
+                HumanReadableMode::Grouped,
                 config,
             );
             live.on_progress(&make_mid_transfer_update(true));
@@ -818,7 +818,7 @@ mod tests {
             let mut live = LiveProgress::with_output_config(
                 &mut writer,
                 ProgressMode::PerFile,
-                HumanReadableMode::Disabled,
+                HumanReadableMode::Grouped,
                 config,
             );
             live.on_progress(&make_mid_transfer_update(true));

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -25,10 +25,10 @@ fn display_without_trailing_separators(path: &Path, allow_8bit: bool) -> String 
 }
 
 use super::format::{
-    LIST_SIZE_WIDTH, event_matches_name_level, format_decimal_bytes, format_list_permissions,
-    format_list_size, format_list_timestamp, format_progress_bytes, format_progress_elapsed,
-    format_progress_percent, format_progress_rate, format_size, format_stat_categories,
-    format_summary_rate, is_progress_event, list_only_event,
+    event_matches_name_level, format_decimal_bytes, format_list_permissions, format_list_size,
+    format_list_timestamp, format_progress_bytes, format_progress_elapsed, format_progress_percent,
+    format_progress_rate, format_size, format_stat_categories, format_summary_rate,
+    is_progress_event, list_only_event,
 };
 use super::mode::{NameOutputLevel, ProgressMode};
 use crate::{OutFormat, OutFormatContext, emit_out_format};
@@ -296,7 +296,7 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
                 "?????????? {:>width$} {} {rendered}",
                 "?",
                 format_list_timestamp(None),
-                width = LIST_SIZE_WIDTH,
+                width = human_readable.size_width(),
             )?;
         }
     }

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -977,7 +977,7 @@ mod tests {
             1,
             NameOutputLevel::UpdatedAndUnchanged,
             false,
-            HumanReadableMode::Disabled,
+            HumanReadableMode::Grouped,
             false,
             &mut out,
         )

--- a/crates/cli/src/frontend/tests/format.rs
+++ b/crates/cli/src/frontend/tests/format.rs
@@ -5,21 +5,21 @@ use super::*;
 fn format_size_combined_uses_base_1024_no_exact() {
     // upstream: lib/compat.c:183 - `-hh` (Combined) divides by 1024 and never
     // appends an exact-value component: 1536 / 1024 = 1.50K.
-    assert_eq!(format_size(1_536, HumanReadableMode::Combined), "1.50K");
+    assert_eq!(format_size(1_536, HumanReadableMode::BinaryUnits), "1.50K");
 }
 
 #[test]
 fn format_progress_rate_zero_bytes_matches_mode() {
     assert_eq!(
-        format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::Disabled),
+        format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::Grouped),
         "0.00kB/s"
     );
     assert_eq!(
-        format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::Enabled),
+        format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::DecimalUnits),
         "0.00B/s"
     );
     assert_eq!(
-        format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::Combined),
+        format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::BinaryUnits),
         "0.00B/s"
     );
 }
@@ -30,7 +30,7 @@ fn format_progress_rate_combined_no_exact_component() {
     let rendered = format_progress_rate(
         1_048_576,
         Duration::from_secs(1),
-        HumanReadableMode::Combined,
+        HumanReadableMode::BinaryUnits,
     );
     assert_eq!(rendered, "1.05MB/s");
 }

--- a/crates/cli/src/frontend/tests/h.rs
+++ b/crates/cli/src/frontend/tests/h.rs
@@ -11,5 +11,5 @@ fn short_h_flag_enables_human_readable_mode() {
     ])
     .expect("parse");
 
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Enabled));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::DecimalUnits));
 }

--- a/crates/cli/src/frontend/tests/human_readable_format.rs
+++ b/crates/cli/src/frontend/tests/human_readable_format.rs
@@ -130,7 +130,7 @@ fn multiple_h_flags_enable_combined_mode() {
     ])
     .expect("parse");
 
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::BinaryUnits));
 }
 
 #[test]
@@ -145,7 +145,7 @@ fn three_h_flags_remain_combined_mode() {
     ])
     .expect("parse");
 
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::BinaryUnits));
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/human_readable_format.rs
+++ b/crates/cli/src/frontend/tests/human_readable_format.rs
@@ -189,7 +189,7 @@ fn combined_mode_long_form_uses_base_1024() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--stats"),
-        OsString::from("--human-readable=2"),
+        OsString::from("-hh"),
         source.into_os_string(),
         dest.into_os_string(),
     ]);
@@ -424,7 +424,7 @@ fn human_readable_combined_works_with_progress() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--progress"),
-        OsString::from("--human-readable=2"),
+        OsString::from("-hh"),
         source.into_os_string(),
         dest.into_os_string(),
     ]);
@@ -495,18 +495,18 @@ fn human_readable_with_verbose_output() {
 }
 
 #[test]
-fn human_readable_disabled_shows_exact_values() {
+fn no_human_readable_shows_raw_digits() {
     use tempfile::tempdir;
 
     let tmp = tempdir().expect("tempdir");
     let source = tmp.path().join("exact.bin");
-    std::fs::write(&source, vec![0u8; 1_536]).expect("write source");
+    std::fs::write(&source, vec![0u8; 1_234_567]).expect("write source");
 
     let dest = tmp.path().join("exact.out");
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--stats"),
-        OsString::from("--human-readable=0"),
+        OsString::from("--no-h"),
         source.into_os_string(),
         dest.into_os_string(),
     ]);
@@ -515,13 +515,20 @@ fn human_readable_disabled_shows_exact_values() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
 
+    // upstream: --no-h => level 0 (do_big_num flag 0) emits raw digits with no
+    // thousands separators. `rsync --stats --no-h` prints `Total file size:
+    // 1234567 bytes`, not `1,234,567`.
     assert!(
-        rendered.contains("1,536"),
-        "expected comma-separated decimal, got: {rendered}"
+        rendered.contains("Total file size: 1234567 bytes"),
+        "expected raw digits without separators, got: {rendered}"
     );
     assert!(
-        !rendered.contains("1.54K"),
-        "should not have K suffix when disabled, got: {rendered}"
+        !rendered.contains("1,234,567"),
+        "level 0 must not group digits with commas, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("1.18M") && !rendered.contains("1.23M"),
+        "level 0 must not use a unit suffix, got: {rendered}"
     );
 }
 

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -1436,7 +1436,7 @@ fn list_only_renders_specials_and_symlink_arrow_gate() {
         emit_list_only(
             std::slice::from_ref(&event),
             &mut out,
-            HumanReadableMode::Disabled,
+            HumanReadableMode::Grouped,
             false,
             false,
             false,

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -155,7 +155,7 @@ fn list_only_matches_rsync_format_for_regular_file() {
         .expect("file entry present");
 
     let expected_permissions = "-rw-r--r--";
-    let expected_size = format_list_size(1_234, HumanReadableMode::Disabled);
+    let expected_size = format_list_size(1_234, HumanReadableMode::Grouped);
     let system_time = SystemTime::UNIX_EPOCH
         + Duration::from_secs(u64::try_from(timestamp.unix_seconds()).expect("positive timestamp"))
         + Duration::from_nanos(u64::from(timestamp.nanoseconds()));
@@ -184,7 +184,7 @@ fn list_only_matches_rsync_format_for_regular_file() {
         .lines()
         .find(|line| line.ends_with("data.bin"))
         .expect("file entry present");
-    let expected_human_size = format_list_size(1_234, HumanReadableMode::Enabled);
+    let expected_human_size = format_list_size(1_234, HumanReadableMode::DecimalUnits);
     let expected_human =
         format!("{expected_permissions} {expected_human_size} {expected_timestamp} data.bin");
     assert_eq!(human_line, expected_human);
@@ -241,11 +241,11 @@ fn list_only_formats_special_permission_bits_like_rsync() {
 
     let expected_exec = format!(
         "-rwsrwsrwt {} {expected_timestamp} exec-special",
-        format_list_size(4, HumanReadableMode::Disabled)
+        format_list_size(4, HumanReadableMode::Grouped)
     );
     let expected_plain = format!(
         "-rwSrwSrwT {} {expected_timestamp} plain-special",
-        format_list_size(5, HumanReadableMode::Disabled)
+        format_list_size(5, HumanReadableMode::Grouped)
     );
 
     let mut exec_line = None;
@@ -493,7 +493,7 @@ fn list_only_zero_byte_file_shows_zero_size() {
         .expect("empty file entry present");
 
     let expected_permissions = "-rw-r--r--";
-    let expected_size = format_list_size(0, HumanReadableMode::Disabled);
+    let expected_size = format_list_size(0, HumanReadableMode::Grouped);
     let system_time = SystemTime::UNIX_EPOCH
         + Duration::from_secs(u64::try_from(timestamp.unix_seconds()).expect("positive timestamp"));
     let expected_timestamp = format_list_timestamp(Some(system_time));
@@ -735,7 +735,7 @@ fn list_only_large_file_size_has_thousands_separators() {
         .find(|line| line.ends_with("big.bin"))
         .expect("large file entry present");
 
-    let expected_size = format_list_size(1_234_567, HumanReadableMode::Disabled);
+    let expected_size = format_list_size(1_234_567, HumanReadableMode::Grouped);
     assert!(
         file_line.contains(&expected_size),
         "large file should have formatted size with separators: {file_line:?}"
@@ -942,7 +942,7 @@ fn list_only_human_readable_size_format() {
         .find(|line| line.ends_with("hr.bin"))
         .expect("file entry present");
 
-    let expected_hr_size = format_list_size(2_500_000, HumanReadableMode::Enabled);
+    let expected_hr_size = format_list_size(2_500_000, HumanReadableMode::DecimalUnits);
     assert!(
         file_line.contains(&expected_hr_size),
         "human-readable size should be in listing: expected {expected_hr_size:?}, line: {file_line:?}"
@@ -1448,7 +1448,7 @@ fn list_only_renders_atime_and_crtime_columns() {
     emit_list_only(
         &events,
         &mut out,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
         true,
         true,
         false,

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -236,7 +236,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         &OutFormatContext::default(),
         NameOutputLevel::Disabled,
         false,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
         false,
         false, // emit_flist_banner
         false, // show_copy_method
@@ -260,7 +260,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedOnly,
         false,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
         false,
         false, // emit_flist_banner
         false, // show_copy_method

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -525,6 +525,31 @@ fn parity_totals_human_readable_mode_uses_units() {
     );
 }
 
+#[test]
+fn parity_totals_raw_level_zero_omits_separators() {
+    // upstream: --no-h (level 0) renders byte counters as raw digits with no
+    // thousands separators, unlike the default level 1 which groups them.
+    // A 1,234,567-byte file must print `Total file size: 1234567 bytes`.
+    let (summary, _temp) = create_known_summary(&[("raw.bin", &[0u8; 1_234_567])]);
+    let output = render_stats(&summary, HumanReadableMode::Raw);
+
+    assert!(
+        output.contains("Total file size: 1234567 bytes"),
+        "level 0 must emit raw digits without separators:\n{output}"
+    );
+    assert!(
+        !output.contains("1,234,567"),
+        "level 0 must not group digits with commas:\n{output}"
+    );
+
+    // Contrast with the default level 1, which groups the same value.
+    let grouped = render_stats(&summary, HumanReadableMode::Disabled);
+    assert!(
+        grouped.contains("Total file size: 1,234,567 bytes"),
+        "default level 1 must group digits with commas:\n{grouped}"
+    );
+}
+
 // upstream: main.c output_summary (rsync-3.4.2:416-465) and handle_stats
 // (rsync-3.4.2:325-385) - --info=stats1/2/3 gating
 #[test]

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -95,7 +95,7 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged,
         false,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
         false,
         true,  // emit_flist_banner
         false, // show_copy_method
@@ -120,7 +120,7 @@ fn render_itemize(event: &ClientEvent) -> String {
 #[test]
 fn parity_stats_output_contains_all_upstream_field_labels() {
     let (summary, _temp) = create_known_summary(&[("file.txt", b"hello world")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     // Verify all upstream rsync --stats labels are present
     assert!(
@@ -183,7 +183,7 @@ fn parity_stats_output_contains_all_upstream_field_labels() {
 #[test]
 fn parity_stats_output_field_order_matches_upstream() {
     let (summary, _temp) = create_known_summary(&[("order.txt", b"test content")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     // Upstream rsync emits stats in a fixed order. The File-list timing
     // lines are conditional on `stats.flist_buildtime > 0` (main.c:437);
@@ -226,7 +226,7 @@ fn parity_stats_output_field_order_matches_upstream() {
 #[test]
 fn parity_stats_total_file_size_uses_bytes_suffix() {
     let (summary, _temp) = create_known_summary(&[("size.txt", b"payload data")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     // Upstream: "Total file size: N bytes"
     for line in output.lines() {
@@ -243,7 +243,7 @@ fn parity_stats_total_file_size_uses_bytes_suffix() {
 #[test]
 fn parity_stats_literal_data_uses_bytes_suffix() {
     let (summary, _temp) = create_known_summary(&[("literal.txt", b"data")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     for line in output.lines() {
         if line.starts_with("Literal data:") {
@@ -259,7 +259,7 @@ fn parity_stats_literal_data_uses_bytes_suffix() {
 #[test]
 fn parity_stats_matched_data_uses_bytes_suffix() {
     let (summary, _temp) = create_known_summary(&[("matched.txt", b"data")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     for line in output.lines() {
         if line.starts_with("Matched data:") {
@@ -275,7 +275,7 @@ fn parity_stats_matched_data_uses_bytes_suffix() {
 #[test]
 fn parity_stats_file_list_generation_time_uses_seconds_suffix() {
     let (summary, _temp) = create_known_summary(&[("gen.txt", b"data")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     for line in output.lines() {
         if line.starts_with("File list generation time:") {
@@ -291,7 +291,7 @@ fn parity_stats_file_list_generation_time_uses_seconds_suffix() {
 #[test]
 fn parity_stats_file_list_transfer_time_uses_seconds_suffix() {
     let (summary, _temp) = create_known_summary(&[("xfer.txt", b"data")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     for line in output.lines() {
         if line.starts_with("File list transfer time:") {
@@ -307,7 +307,7 @@ fn parity_stats_file_list_transfer_time_uses_seconds_suffix() {
 #[test]
 fn parity_stats_file_list_time_format_has_three_decimal_places() {
     let (summary, _temp) = create_known_summary(&[("decimal.txt", b"data")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     for line in output.lines() {
         if line.starts_with("File list generation time:") {
@@ -332,7 +332,7 @@ fn parity_stats_file_list_time_format_has_three_decimal_places() {
 #[test]
 fn parity_stats_number_of_files_includes_category_breakdown() {
     let (summary, _temp) = create_known_summary(&[("breakdown.txt", b"content")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     for line in output.lines() {
         if line.starts_with("Number of files:") {
@@ -350,7 +350,7 @@ fn parity_stats_number_of_files_includes_category_breakdown() {
 #[test]
 fn parity_stats_number_of_deleted_files_shows_zero_without_breakdown() {
     let (summary, _temp) = create_known_summary(&[("del.txt", b"data")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     for line in output.lines() {
         if line.starts_with("Number of deleted files:") {
@@ -366,7 +366,7 @@ fn parity_stats_number_of_deleted_files_shows_zero_without_breakdown() {
 #[test]
 fn parity_stats_includes_totals_after_blank_line() {
     let (summary, _temp) = create_known_summary(&[("totals.txt", b"data")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     // Upstream: stats block ends with "Total bytes received: N", then a blank line,
     // then "sent X bytes  received Y bytes  Z bytes/sec"
@@ -379,7 +379,7 @@ fn parity_stats_includes_totals_after_blank_line() {
 #[test]
 fn parity_totals_sent_received_line_format() {
     let (summary, _temp) = create_known_summary(&[("total.txt", b"test content")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     // Upstream: "sent X bytes  received Y bytes  Z bytes/sec"
     let totals_line = output
@@ -400,7 +400,7 @@ fn parity_totals_sent_received_line_format() {
 #[test]
 fn parity_totals_sent_line_uses_double_space_separator() {
     let (summary, _temp) = create_known_summary(&[("space.txt", b"test")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     let totals_line = output
         .lines()
@@ -422,7 +422,7 @@ fn parity_totals_sent_line_uses_double_space_separator() {
 #[test]
 fn parity_totals_speedup_line_format() {
     let (summary, _temp) = create_known_summary(&[("speed.txt", b"test content for speedup")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     // Upstream: "total size is X  speedup is Y"
     let speedup_line = output
@@ -439,7 +439,7 @@ fn parity_totals_speedup_line_format() {
 #[test]
 fn parity_totals_speedup_has_two_decimal_places() {
     let (summary, _temp) = create_known_summary(&[("decimal_speed.txt", b"test")]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     let speedup_line = output
         .lines()
@@ -481,7 +481,7 @@ fn parity_totals_only_without_stats_flag() {
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged,
         false,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
         false,
         true,  // emit_flist_banner
         false, // show_copy_method
@@ -510,7 +510,7 @@ fn parity_totals_only_without_stats_flag() {
 #[test]
 fn parity_totals_human_readable_mode_uses_units() {
     let (summary, _temp) = create_known_summary(&[("hr.txt", &[0u8; 2048])]);
-    let output = render_stats(&summary, HumanReadableMode::Enabled);
+    let output = render_stats(&summary, HumanReadableMode::DecimalUnits);
 
     // With human-readable enabled, sizes should use unit suffixes
     let totals_line = output
@@ -543,7 +543,7 @@ fn parity_totals_raw_level_zero_omits_separators() {
     );
 
     // Contrast with the default level 1, which groups the same value.
-    let grouped = render_stats(&summary, HumanReadableMode::Disabled);
+    let grouped = render_stats(&summary, HumanReadableMode::Grouped);
     assert!(
         grouped.contains("Total file size: 1,234,567 bytes"),
         "default level 1 must group digits with commas:\n{grouped}"
@@ -555,7 +555,7 @@ fn parity_totals_raw_level_zero_omits_separators() {
 #[test]
 fn parity_stats_level_1_emits_only_summary_lines() {
     let (summary, _temp) = create_known_summary(&[("lvl1.txt", b"level one")]);
-    let output = render_stats_at_level(&summary, HumanReadableMode::Disabled, 1);
+    let output = render_stats_at_level(&summary, HumanReadableMode::Grouped, 1);
 
     // Level 1 emits only the "sent X bytes received Y bytes" + "total size"
     // pair, matching upstream's INFO_GTE(STATS, 1) block (main.c:451-461).
@@ -596,7 +596,7 @@ fn parity_stats_level_1_emits_only_summary_lines() {
 #[test]
 fn parity_stats_level_2_emits_full_detail_block_plus_summary() {
     let (summary, _temp) = create_known_summary(&[("lvl2.txt", b"level two")]);
-    let output = render_stats_at_level(&summary, HumanReadableMode::Disabled, 2);
+    let output = render_stats_at_level(&summary, HumanReadableMode::Grouped, 2);
 
     // Level 2 emits the full INFO_GTE(STATS, 2) detail block (main.c:418-449)
     // followed by the level-1 summary (main.c:451-461).
@@ -645,8 +645,8 @@ fn parity_stats_level_3_matches_level_2_plus_summary() {
     // platforms. Asserting parity of the user-visible block is the relevant
     // contract for wire-compatible scripting consumers.
     let (summary, _temp) = create_known_summary(&[("lvl3.txt", b"level three")]);
-    let level_2 = render_stats_at_level(&summary, HumanReadableMode::Disabled, 2);
-    let level_3 = render_stats_at_level(&summary, HumanReadableMode::Disabled, 3);
+    let level_2 = render_stats_at_level(&summary, HumanReadableMode::Grouped, 2);
+    let level_3 = render_stats_at_level(&summary, HumanReadableMode::Grouped, 3);
 
     assert_eq!(
         level_3, level_2,
@@ -657,7 +657,7 @@ fn parity_stats_level_3_matches_level_2_plus_summary() {
 #[test]
 fn parity_stats_level_0_emits_nothing() {
     let (summary, _temp) = create_known_summary(&[("lvl0.txt", b"silent")]);
-    let output = render_stats_at_level(&summary, HumanReadableMode::Disabled, 0);
+    let output = render_stats_at_level(&summary, HumanReadableMode::Grouped, 0);
 
     assert!(
         output.is_empty(),
@@ -751,7 +751,7 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged,
         false,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
         false,
         true,  // emit_flist_banner
         false, // show_copy_method
@@ -1254,7 +1254,7 @@ fn parity_end_to_end_verbose_output_via_run() {
 #[test]
 fn parity_stats_human_readable_disabled_uses_comma_separators() {
     let (summary, _temp) = create_known_summary(&[("comma.txt", &[0u8; 1500])]);
-    let output = render_stats(&summary, HumanReadableMode::Disabled);
+    let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     // With human-readable disabled, sizes should use comma-separated decimal notation
     // For values >= 1000
@@ -1280,7 +1280,7 @@ fn parity_stats_human_readable_disabled_uses_comma_separators() {
 #[test]
 fn parity_stats_human_readable_enabled_uses_unit_suffixes() {
     let (summary, _temp) = create_known_summary(&[("units.txt", &[0u8; 2000])]);
-    let output = render_stats(&summary, HumanReadableMode::Enabled);
+    let output = render_stats(&summary, HumanReadableMode::DecimalUnits);
 
     // With human-readable enabled, sizes >= 1000 should use K/M/G suffixes
     let has_unit_suffix = output.lines().any(|line| {

--- a/crates/cli/src/frontend/tests/parse_args_recognises_human.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_human.rs
@@ -15,10 +15,12 @@ fn parse_args_recognises_human_readable_flag() {
 }
 
 #[test]
-fn parse_args_recognises_human_readable_level_two() {
+fn parse_args_recognises_double_short_h() {
+    // upstream: options.c:1573 - each -h increments; -hh reaches level 3
+    // (base-1024 units, HumanReadableMode::Combined).
     let parsed = parse_args([
         OsString::from(RSYNC),
-        OsString::from("--human-readable=2"),
+        OsString::from("-hh"),
         OsString::from("source"),
         OsString::from("dest"),
     ])

--- a/crates/cli/src/frontend/tests/parse_args_recognises_human.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_human.rs
@@ -11,13 +11,13 @@ fn parse_args_recognises_human_readable_flag() {
     ])
     .expect("parse");
 
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Enabled));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::DecimalUnits));
 }
 
 #[test]
 fn parse_args_recognises_double_short_h() {
     // upstream: options.c:1573 - each -h increments; -hh reaches level 3
-    // (base-1024 units, HumanReadableMode::Combined).
+    // (base-1024 units, HumanReadableMode::BinaryUnits).
     let parsed = parse_args([
         OsString::from(RSYNC),
         OsString::from("-hh"),
@@ -26,5 +26,5 @@ fn parse_args_recognises_double_short_h() {
     ])
     .expect("parse");
 
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Combined));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::BinaryUnits));
 }

--- a/crates/cli/src/frontend/tests/parse_args_recognises_no.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_no.rs
@@ -66,7 +66,7 @@ fn parse_args_recognises_no_human_readable_flag() {
     ])
     .expect("parse");
 
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Disabled));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Raw));
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn parse_args_no_h_alias_disables_human_readable() {
     ])
     .expect("parse");
 
-    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Disabled));
+    assert_eq!(parsed.human_readable, Some(HumanReadableMode::Raw));
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/progress.rs
+++ b/crates/cli/src/frontend/tests/progress.rs
@@ -114,7 +114,7 @@ fn progress_human_readable_combined_formats_sizes() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--progress"),
-        OsString::from("--human-readable=2"),
+        OsString::from("-hh"),
         source.into_os_string(),
         destination.into_os_string(),
     ]);

--- a/crates/cli/src/frontend/tests/progress2_format_parity.rs
+++ b/crates/cli/src/frontend/tests/progress2_format_parity.rs
@@ -234,7 +234,7 @@ fn progress2_single_file_final_tick_matches_upstream_format() {
     let (tmp, source_dir) = setup_single_file("fmt_check.dat", 2048);
     let dest_dir = tmp.path().join("dest");
 
-    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Disabled);
+    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Grouped);
     let lines = split_progress2_lines(&output);
 
     // There must be at least one final tick with xfr# trailer
@@ -259,7 +259,7 @@ fn progress2_inflight_ticks_have_no_xfr_trailer() {
     let (tmp, source_dir) = setup_single_file("inflight.dat", 4 * 1024 * 1024);
     let dest_dir = tmp.path().join("dest");
 
-    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Disabled);
+    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Grouped);
     let lines = split_progress2_lines(&output);
 
     // Collect lines that do NOT contain xfr# (these are in-flight ticks)
@@ -278,7 +278,7 @@ fn progress2_all_lines_match_upstream_format() {
     let (tmp, source_dir) = setup_single_file("all_lines.dat", 2048);
     let dest_dir = tmp.path().join("dest");
 
-    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Disabled);
+    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Grouped);
     let lines = split_progress2_lines(&output);
 
     assert!(
@@ -298,7 +298,7 @@ fn progress2_rate_unit_matches_upstream_tiers() {
     let (tmp, source_dir) = setup_single_file("rate_unit.dat", 4096);
     let dest_dir = tmp.path().join("dest");
 
-    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Disabled);
+    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Grouped);
     let lines = split_progress2_lines(&output);
 
     for line in &lines {
@@ -317,7 +317,7 @@ fn progress2_time_field_uses_hmmss_format() {
     let (tmp, source_dir) = setup_single_file("time_fmt.dat", 1024);
     let dest_dir = tmp.path().join("dest");
 
-    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Disabled);
+    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Grouped);
     let lines = split_progress2_lines(&output);
 
     for line in &lines {
@@ -332,7 +332,7 @@ fn progress2_bytes_field_uses_thousands_separator() {
     let (tmp, source_dir) = setup_single_file("sep.dat", 1_536);
     let dest_dir = tmp.path().join("dest");
 
-    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Disabled);
+    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Grouped);
 
     // The final tick should contain "1,536" (thousands separator for 1536 bytes)
     assert!(
@@ -349,7 +349,7 @@ fn progress2_multiple_files_sequential_xfr_indices() {
     let (tmp, source_dir) = setup_multiple_files(&files);
     let dest_dir = tmp.path().join("dest");
 
-    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Disabled);
+    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Grouped);
     let lines = split_progress2_lines(&output);
 
     // Collect all xfr indices from final ticks
@@ -399,7 +399,7 @@ fn progress2_multiple_files_all_final_ticks_match_format() {
     let (tmp, source_dir) = setup_multiple_files(&files);
     let dest_dir = tmp.path().join("dest");
 
-    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Disabled);
+    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Grouped);
     let lines = split_progress2_lines(&output);
 
     let final_lines: Vec<&&str> = lines.iter().filter(|l| l.contains("xfr#")).collect();
@@ -422,7 +422,7 @@ fn progress2_multiple_files_all_final_ticks_match_format() {
 #[test]
 fn progress2_bytes_field_width_15_chars() {
     for &bytes in &[0u64, 42, 1_536, 1_234_567] {
-        let formatted = format_progress_bytes(bytes, HumanReadableMode::Disabled);
+        let formatted = format_progress_bytes(bytes, HumanReadableMode::Grouped);
         let padded = format!("{formatted:>15}");
         assert_eq!(
             padded.len(),
@@ -532,7 +532,7 @@ fn progress2_rate_unit_tier_boundaries() {
 fn progress2_rate_from_value_matches_cumulative_tiers() {
     for &rate in &[512.0_f64, 1_048_576.0, 1_073_741_824.0] {
         let cumulative = format_progress_rate_decimal(rate);
-        let from_value = format_progress_rate_from_value(rate, HumanReadableMode::Disabled);
+        let from_value = format_progress_rate_from_value(rate, HumanReadableMode::Grouped);
         assert_eq!(
             cumulative, from_value,
             "from_value should match cumulative for rate={rate}"
@@ -552,7 +552,7 @@ fn progress2_human_readable_bytes_use_unit_suffixes() {
     let (tmp, source_dir) = setup_single_file("human.dat", 2_500);
     let dest_dir = tmp.path().join("dest");
 
-    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Enabled);
+    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::DecimalUnits);
     let lines = split_progress2_lines(&output);
 
     assert!(
@@ -578,7 +578,7 @@ fn progress2_human_readable_structural_parity() {
     let (tmp, source_dir) = setup_single_file("human_struct.dat", 4096);
     let dest_dir = tmp.path().join("dest");
 
-    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::Enabled);
+    let output = run_progress2_transfer(&source_dir, &dest_dir, HumanReadableMode::DecimalUnits);
     let lines = split_progress2_lines(&output);
 
     for line in &lines {
@@ -688,12 +688,12 @@ fn progress2_cli_multiple_files_format_parity() {
 fn progress2_composed_line_field_order_matches_upstream() {
     let bytes_field = format!(
         "{:>15}",
-        format_progress_bytes(1_536, HumanReadableMode::Disabled)
+        format_progress_bytes(1_536, HumanReadableMode::Grouped)
     );
     let percent_field = format!("{:>4}", format_progress_percent(1_536, Some(1_536)));
     let rate_field = format!(
         "{:>11}",
-        format_progress_rate(1_536, Duration::from_secs(1), HumanReadableMode::Disabled)
+        format_progress_rate(1_536, Duration::from_secs(1), HumanReadableMode::Grouped)
     );
     let time_field = format!("{:>10}", format_progress_elapsed(Duration::from_secs(1)));
 
@@ -729,12 +729,12 @@ fn progress2_composed_line_field_order_matches_upstream() {
 fn progress2_composed_inflight_line_field_order_matches_upstream() {
     let bytes_field = format!(
         "{:>15}",
-        format_progress_bytes(512, HumanReadableMode::Disabled)
+        format_progress_bytes(512, HumanReadableMode::Grouped)
     );
     let percent_field = format!("{:>4}", format_progress_percent(512, Some(1_024)));
     let rate_field = format!(
         "{:>11}",
-        format_progress_rate(512, Duration::from_millis(500), HumanReadableMode::Disabled)
+        format_progress_rate(512, Duration::from_millis(500), HumanReadableMode::Grouped)
     );
     let time_field = format!(
         "{:>10}",

--- a/crates/cli/src/frontend/tests/progress_format_upstream.rs
+++ b/crates/cli/src/frontend/tests/progress_format_upstream.rs
@@ -212,19 +212,19 @@ fn format_progress_rate_human_giga() {
 
 #[test]
 fn format_progress_rate_zero_elapsed_returns_zero() {
-    let rate_str = format_progress_rate(0, Duration::ZERO, HumanReadableMode::Disabled);
+    let rate_str = format_progress_rate(0, Duration::ZERO, HumanReadableMode::Grouped);
     assert_eq!(rate_str, "0.00kB/s");
 }
 
 #[test]
 fn format_progress_rate_zero_bytes_returns_zero() {
-    let rate_str = format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::Disabled);
+    let rate_str = format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::Grouped);
     assert_eq!(rate_str, "0.00kB/s");
 }
 
 #[test]
 fn format_progress_rate_zero_bytes_human_returns_zero() {
-    let rate_str = format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::Enabled);
+    let rate_str = format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::DecimalUnits);
     assert_eq!(rate_str, "0.00B/s");
 }
 
@@ -531,7 +531,7 @@ fn progress_bytes_field_is_right_aligned_15_chars() {
     // The bytes field in progress output should be right-aligned in a 15-char field
     let small = format!(
         "{:>15}",
-        format_progress_bytes(11, HumanReadableMode::Disabled)
+        format_progress_bytes(11, HumanReadableMode::Grouped)
     );
     assert_eq!(small.len(), 15);
     assert!(
@@ -541,7 +541,7 @@ fn progress_bytes_field_is_right_aligned_15_chars() {
 
     let large = format!(
         "{:>15}",
-        format_progress_bytes(1_234_567, HumanReadableMode::Disabled)
+        format_progress_bytes(1_234_567, HumanReadableMode::Grouped)
     );
     assert_eq!(large.len(), 15);
 }

--- a/crates/cli/src/frontend/tests/progress_live.rs
+++ b/crates/cli/src/frontend/tests/progress_live.rs
@@ -84,7 +84,7 @@ fn live_progress_per_file_renders_file_path() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     assert!(
@@ -106,7 +106,7 @@ fn live_progress_per_file_renders_xfr_and_to_chk() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     assert!(
@@ -128,7 +128,7 @@ fn live_progress_per_file_renders_percentage() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     assert!(
@@ -146,7 +146,7 @@ fn live_progress_per_file_renders_rate() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     assert!(
@@ -164,7 +164,7 @@ fn live_progress_per_file_renders_elapsed_time() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     // Elapsed format is H:MM:SS; for a fast transfer it should start with "0:00:0"
@@ -183,7 +183,7 @@ fn live_progress_per_file_renders_byte_count() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     assert!(
@@ -202,7 +202,7 @@ fn live_progress_per_file_multiple_files_renders_all_xfr() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     assert!(output.contains("xfr#1"), "should contain xfr#1: {output:?}");
@@ -236,7 +236,7 @@ fn live_progress_per_file_finish_completes_without_error() {
     let mut live = LiveProgress::new(
         &mut buffer,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
     let _summary =
         run_client_with_observer(config, Some(&mut live as &mut dyn ClientProgressObserver))
@@ -255,7 +255,7 @@ fn live_progress_overall_renders_xfr_and_to_chk() {
         &source_dir,
         &dest_dir,
         ProgressMode::Overall,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     assert!(rendered, "rendered() should return true in overall mode");
@@ -278,7 +278,7 @@ fn live_progress_overall_does_not_print_filename() {
         &source_dir,
         &dest_dir,
         ProgressMode::Overall,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     // Overall mode should NOT print the individual file name as a separate line
@@ -302,7 +302,7 @@ fn live_progress_overall_renders_percentage_and_rate() {
         &source_dir,
         &dest_dir,
         ProgressMode::Overall,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     assert!(
@@ -325,7 +325,7 @@ fn live_progress_overall_multiple_files() {
         &source_dir,
         &dest_dir,
         ProgressMode::Overall,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     assert!(
@@ -347,7 +347,7 @@ fn live_progress_human_readable_formats_bytes() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Enabled,
+        HumanReadableMode::DecimalUnits,
     );
 
     // Human-readable mode should show K/M/G suffixes instead of thousands separators
@@ -366,7 +366,7 @@ fn live_progress_combined_human_readable_uses_base_1024() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Combined,
+        HumanReadableMode::BinaryUnits,
     );
 
     // upstream: lib/compat.c:183 - `-hh` (Combined) divides by 1024 and never
@@ -383,7 +383,7 @@ fn live_progress_rendered_returns_false_before_events() {
     let live = LiveProgress::new(
         &mut buffer,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
     assert!(
         !live.rendered(),
@@ -401,7 +401,7 @@ fn live_progress_rendered_returns_true_after_transfer() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     assert!(
@@ -612,7 +612,7 @@ fn live_progress_output_matches_upstream_format_pattern() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     let normalized = output.replace('\r', "\n");
@@ -661,7 +661,7 @@ fn live_progress_per_file_prints_filename_before_progress_line() {
         &source_dir,
         &dest_dir,
         ProgressMode::PerFile,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
 
     let normalized = output.replace('\r', "\n");
@@ -679,18 +679,18 @@ fn live_progress_per_file_prints_filename_before_progress_line() {
 
 #[test]
 fn format_progress_bytes_zero_disabled() {
-    assert_eq!(format_progress_bytes(0, HumanReadableMode::Disabled), "0");
+    assert_eq!(format_progress_bytes(0, HumanReadableMode::Grouped), "0");
 }
 
 #[test]
 fn format_progress_bytes_small_disabled() {
-    assert_eq!(format_progress_bytes(42, HumanReadableMode::Disabled), "42");
+    assert_eq!(format_progress_bytes(42, HumanReadableMode::Grouped), "42");
 }
 
 #[test]
 fn format_progress_bytes_thousands_disabled() {
     assert_eq!(
-        format_progress_bytes(1_234, HumanReadableMode::Disabled),
+        format_progress_bytes(1_234, HumanReadableMode::Grouped),
         "1,234"
     );
 }
@@ -698,7 +698,7 @@ fn format_progress_bytes_thousands_disabled() {
 #[test]
 fn format_progress_bytes_millions_disabled() {
     assert_eq!(
-        format_progress_bytes(1_234_567, HumanReadableMode::Disabled),
+        format_progress_bytes(1_234_567, HumanReadableMode::Grouped),
         "1,234,567"
     );
 }
@@ -706,20 +706,23 @@ fn format_progress_bytes_millions_disabled() {
 #[test]
 fn format_progress_bytes_gigabytes_disabled() {
     assert_eq!(
-        format_progress_bytes(1_234_567_890, HumanReadableMode::Disabled),
+        format_progress_bytes(1_234_567_890, HumanReadableMode::Grouped),
         "1,234,567,890"
     );
 }
 
 #[test]
 fn format_progress_bytes_zero_human() {
-    assert_eq!(format_progress_bytes(0, HumanReadableMode::Enabled), "0");
+    assert_eq!(
+        format_progress_bytes(0, HumanReadableMode::DecimalUnits),
+        "0"
+    );
 }
 
 #[test]
 fn format_progress_bytes_kilo_human() {
     assert_eq!(
-        format_progress_bytes(2_500, HumanReadableMode::Enabled),
+        format_progress_bytes(2_500, HumanReadableMode::DecimalUnits),
         "2.50K"
     );
 }
@@ -727,7 +730,7 @@ fn format_progress_bytes_kilo_human() {
 #[test]
 fn format_progress_bytes_mega_human() {
     assert_eq!(
-        format_progress_bytes(5_000_000, HumanReadableMode::Enabled),
+        format_progress_bytes(5_000_000, HumanReadableMode::DecimalUnits),
         "5.00M"
     );
 }
@@ -735,7 +738,7 @@ fn format_progress_bytes_mega_human() {
 #[test]
 fn format_progress_bytes_giga_human() {
     assert_eq!(
-        format_progress_bytes(3_000_000_000, HumanReadableMode::Enabled),
+        format_progress_bytes(3_000_000_000, HumanReadableMode::DecimalUnits),
         "3.00G"
     );
 }
@@ -745,7 +748,7 @@ fn format_progress_rate_nonzero_bytes_nonzero_elapsed() {
     let rate = format_progress_rate(
         1_048_576,
         Duration::from_secs(1),
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
     assert!(
         rate.contains("MB/s"),
@@ -758,14 +761,18 @@ fn format_progress_rate_large_bytes_short_duration() {
     let rate = format_progress_rate(
         10_737_418_240,
         Duration::from_secs(10),
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
     );
     assert!(rate.contains("GB/s"), "~1GB/s should show GB/s: {rate:?}");
 }
 
 #[test]
 fn format_progress_rate_human_nonzero() {
-    let rate = format_progress_rate(5_000, Duration::from_secs(1), HumanReadableMode::Enabled);
+    let rate = format_progress_rate(
+        5_000,
+        Duration::from_secs(1),
+        HumanReadableMode::DecimalUnits,
+    );
     assert!(
         rate.contains("kB/s"),
         "5000 B/s in human mode should show kB/s: {rate:?}"

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -52,7 +52,7 @@ fn emit_transfer_summary_list_only_emits_listing_and_stats() {
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged,
         false,
-        HumanReadableMode::Enabled,
+        HumanReadableMode::DecimalUnits,
         false,
         false, // emit_flist_banner (list_only path)
         false, // show_copy_method
@@ -87,7 +87,7 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged,
         false,
-        HumanReadableMode::Enabled,
+        HumanReadableMode::DecimalUnits,
         false,
         true,  // emit_flist_banner
         false, // show_copy_method
@@ -130,7 +130,7 @@ fn emit_transfer_summary_out_format_adds_separator_before_stats() {
         &OutFormatContext::default(),
         NameOutputLevel::Disabled,
         false,
-        HumanReadableMode::Disabled,
+        HumanReadableMode::Grouped,
         false,
         false, // emit_flist_banner (out_format path: starts_with assertion)
         false, // show_copy_method

--- a/crates/cli/src/frontend/tests/stats.rs
+++ b/crates/cli/src/frontend/tests/stats.rs
@@ -61,7 +61,7 @@ fn stats_human_readable_combined_formats_totals() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--stats"),
-        OsString::from("--human-readable=2"),
+        OsString::from("-hh"),
         source.into_os_string(),
         dest_combined.into_os_string(),
     ]);

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -291,7 +291,7 @@ fn verbose_human_readable_combined_formats_sizes() {
         OsString::from(RSYNC),
         OsString::from("-vv"),
         OsString::from("--stats"),
-        OsString::from("--human-readable=2"),
+        OsString::from("-hh"),
         source.into_os_string(),
         destination.into_os_string(),
     ]);
@@ -299,7 +299,7 @@ fn verbose_human_readable_combined_formats_sizes() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("verbose output utf8");
-    // upstream: `-hh` (--human-readable=2) divides by 1024 (1536/1024 = 1.50K)
+    // upstream: `-hh` divides by 1024 (1536/1024 = 1.50K)
     // and never appends an exact-value component.
     assert!(rendered.contains("1.50K bytes") && !rendered.contains("(1,536)"));
 }

--- a/crates/cli/tests/archive_flag_completeness.rs
+++ b/crates/cli/tests/archive_flag_completeness.rs
@@ -417,7 +417,7 @@ fn combined_avzh_flags() {
     assert!(args.compress);
     assert_eq!(
         args.human_readable,
-        Some(HumanReadableMode::Enabled),
+        Some(HumanReadableMode::DecimalUnits),
         "-h should enable human-readable output"
     );
 }

--- a/crates/core/src/client/config/enums/human_readable.rs
+++ b/crates/core/src/client/config/enums/human_readable.rs
@@ -4,19 +4,42 @@ use thiserror::Error;
 
 /// Controls how byte counters are rendered for user-facing output.
 ///
-/// Upstream `rsync` accepts optional levels for `--human-readable` that either
-/// disable humanisation entirely, enable base-1000 suffix formatting (`-h`), or
-/// switch to base-1024 suffix formatting (`-hh`). The enum mirrors those levels
-/// so the CLI can propagate the caller's preference to both the local renderer
-/// and any fallback `rsync` invocations. See [`Self::unit_base`].
+/// Upstream `rsync` tracks `human_readable` as an integer with four distinct
+/// levels (`options.c:111` defaults it to `1`; `-h`/`--human-readable`
+/// increment it at `options.c:1573`; `--no-human-readable`/`--no-h` reset it to
+/// `0` at `options.c:617`). Each level changes both the digit grouping and the
+/// `--list-only` size-column width in `lib/compat.c:do_big_num` and
+/// `generator.c:1159`:
+///
+/// | Level | Variant | Rendering | Size width |
+/// |-------|---------|-----------|------------|
+/// | 0 | [`Self::Raw`] | raw digits, no separators (`1234567`) | 11 |
+/// | 1 | [`Self::Disabled`] | thousands-separated (`1,234,567`) | 14 |
+/// | 2 | [`Self::Enabled`] | base-1000 suffix (`1.23M`) | 14 |
+/// | 3 | [`Self::Combined`] | base-1024 suffix (`1.18M`) | 14 |
+///
+/// Level 1 is the default when neither `-h` nor `--no-h` is supplied, so
+/// [`Self::Disabled`] names the "no suffix humanisation" default rather than a
+/// suppressed-output mode. See [`Self::unit_base`], [`Self::size_width`], and
+/// [`Self::uses_separators`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[doc(alias = "--human-readable")]
 pub enum HumanReadableMode {
-    /// Disable human-readable formatting and display exact decimal values.
+    /// Level 0 (`--no-human-readable`/`--no-h`): raw decimal digits with no
+    /// thousands separators, rendered in an 11-wide `--list-only` size column.
+    ///
+    /// upstream: `options.c:617` sets `human_readable = 0`; `lib/compat.c:231`
+    /// skips separator insertion when `human_flag == 0`; `generator.c:1159`
+    /// selects `size_width = 11` when `human_readable` is falsy.
+    Raw,
+    /// Level 1 (default): thousands-separated decimal digits (`1,234,567`) in a
+    /// 14-wide size column, with no unit suffix.
+    ///
+    /// upstream: `options.c:111` initialises `human_readable = 1`.
     Disabled,
-    /// Enable base-1000 suffix formatting (e.g. `1.23K`, `4.56M`) for `-h`.
+    /// Level 2 (`-h`): base-1000 suffix formatting (e.g. `1.23K`, `4.56M`).
     Enabled,
-    /// Enable base-1024 suffix formatting for `-hh`.
+    /// Level 3 (`-hh`): base-1024 suffix formatting (e.g. `1.18M`).
     Combined,
 }
 
@@ -24,9 +47,9 @@ impl HumanReadableMode {
     /// Parses a human-readable level from textual input.
     ///
     /// The parser trims ASCII whitespace before interpreting the value and
-    /// accepts the numeric levels used by upstream `rsync`. A dedicated error
-    /// type captures empty inputs and out-of-range values so callers can emit
-    /// diagnostics that match the original CLI.
+    /// accepts the numeric levels used by upstream `rsync` (`0`-`3`). A
+    /// dedicated error type captures empty inputs and out-of-range values so
+    /// callers can emit diagnostics that match the original CLI.
     pub fn parse(text: &str) -> Result<Self, HumanReadableModeParseError> {
         let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
         if trimmed.is_empty() {
@@ -34,26 +57,55 @@ impl HumanReadableMode {
         }
 
         match trimmed {
-            "0" => Ok(Self::Disabled),
-            "1" => Ok(Self::Enabled),
-            "2" => Ok(Self::Combined),
+            "0" => Ok(Self::Raw),
+            "1" => Ok(Self::Disabled),
+            "2" => Ok(Self::Enabled),
+            "3" => Ok(Self::Combined),
             other => Err(HumanReadableModeParseError::Invalid {
                 value: other.to_owned(),
             }),
         }
     }
 
-    /// Reports whether human-readable formatting should be used.
+    /// Reports whether unit-suffix (`K`/`M`/`G`) formatting should be used.
+    ///
+    /// Only levels 2 (`-h`) and 3 (`-hh`) apply a suffix; levels 0 and 1 emit
+    /// plain digits (differing only in separator grouping). Mirrors upstream's
+    /// `human_flag > 1` gate in `lib/compat.c:182`.
     #[must_use]
     pub const fn is_enabled(self) -> bool {
-        !matches!(self, Self::Disabled)
+        matches!(self, Self::Enabled | Self::Combined)
+    }
+
+    /// Reports whether thousands separators are inserted between digit groups.
+    ///
+    /// Only the default level 1 ([`Self::Disabled`]) groups digits with the
+    /// locale separator; level 0 ([`Self::Raw`]) emits raw digits. Mirrors
+    /// upstream `lib/compat.c:231`, where the separator is inserted only when
+    /// `human_flag` is non-zero and no unit suffix applies.
+    #[must_use]
+    pub const fn uses_separators(self) -> bool {
+        matches!(self, Self::Disabled)
+    }
+
+    /// The `--list-only` size-column width for this level.
+    ///
+    /// Mirrors `generator.c:1159`: `size_width = human_readable ? 14 : 11`, so
+    /// only level 0 ([`Self::Raw`]) uses the 11-wide field.
+    #[must_use]
+    pub const fn size_width(self) -> usize {
+        match self {
+            Self::Raw => 11,
+            Self::Disabled | Self::Enabled | Self::Combined => 14,
+        }
     }
 
     /// The unit multiplier upstream `do_big_num` applies for K/M/G/T units.
     ///
     /// Mirrors `lib/compat.c:183`: `mult = human_flag == 2 ? 1000 : 1024`.
     /// A single `-h` (level 2, [`Self::Enabled`]) uses base 1000; `-hh`
-    /// (level 3, [`Self::Combined`]) uses base 1024.
+    /// (level 3, [`Self::Combined`]) uses base 1024. The value is only
+    /// meaningful when [`Self::is_enabled`] is true.
     #[must_use]
     pub const fn unit_base(self) -> f64 {
         match self {
@@ -78,7 +130,7 @@ pub enum HumanReadableModeParseError {
     #[error("human-readable level must not be empty")]
     Empty,
     /// The provided value did not match an accepted human-readable level.
-    #[error("invalid human-readable level '{value}': expected 0, 1, or 2")]
+    #[error("invalid human-readable level '{value}': expected 0, 1, 2, or 3")]
     Invalid {
         /// The invalid value supplied by the caller after trimming ASCII whitespace.
         value: String,
@@ -99,11 +151,12 @@ impl HumanReadableModeParseError {
 mod tests {
     use super::*;
 
+    // upstream: options.c levels 0-3 map to Raw / Disabled / Enabled / Combined.
     #[test]
     fn parse_level_0() {
         assert_eq!(
             HumanReadableMode::parse("0").unwrap(),
-            HumanReadableMode::Disabled
+            HumanReadableMode::Raw
         );
     }
 
@@ -111,7 +164,7 @@ mod tests {
     fn parse_level_1() {
         assert_eq!(
             HumanReadableMode::parse("1").unwrap(),
-            HumanReadableMode::Enabled
+            HumanReadableMode::Disabled
         );
     }
 
@@ -119,6 +172,14 @@ mod tests {
     fn parse_level_2() {
         assert_eq!(
             HumanReadableMode::parse("2").unwrap(),
+            HumanReadableMode::Enabled
+        );
+    }
+
+    #[test]
+    fn parse_level_3() {
+        assert_eq!(
+            HumanReadableMode::parse("3").unwrap(),
             HumanReadableMode::Combined
         );
     }
@@ -127,7 +188,7 @@ mod tests {
     fn parse_with_whitespace() {
         assert_eq!(
             HumanReadableMode::parse("  1  ").unwrap(),
-            HumanReadableMode::Enabled
+            HumanReadableMode::Disabled
         );
     }
 
@@ -139,7 +200,7 @@ mod tests {
 
     #[test]
     fn parse_invalid_returns_error() {
-        let result = HumanReadableMode::parse("3");
+        let result = HumanReadableMode::parse("4");
         assert!(matches!(
             result,
             Err(HumanReadableModeParseError::Invalid { .. })
@@ -150,13 +211,20 @@ mod tests {
     fn from_str_works() {
         use std::str::FromStr;
         assert_eq!(
-            HumanReadableMode::from_str("1").unwrap(),
+            HumanReadableMode::from_str("2").unwrap(),
             HumanReadableMode::Enabled
         );
     }
 
     #[test]
+    fn is_enabled_raw() {
+        // Level 0 emits raw digits, so no unit-suffix formatting.
+        assert!(!HumanReadableMode::Raw.is_enabled());
+    }
+
+    #[test]
     fn is_enabled_disabled() {
+        // Level 1 (default) groups digits but applies no unit suffix.
         assert!(!HumanReadableMode::Disabled.is_enabled());
     }
 
@@ -171,9 +239,27 @@ mod tests {
     }
 
     #[test]
+    fn uses_separators_only_default_level() {
+        // upstream: lib/compat.c:231 - separators only when human_flag != 0 and
+        // no suffix applies, i.e. exactly level 1.
+        assert!(!HumanReadableMode::Raw.uses_separators());
+        assert!(HumanReadableMode::Disabled.uses_separators());
+        assert!(!HumanReadableMode::Enabled.uses_separators());
+        assert!(!HumanReadableMode::Combined.uses_separators());
+    }
+
+    #[test]
+    fn size_width_only_raw_is_eleven() {
+        // upstream: generator.c:1159 - size_width = human_readable ? 14 : 11.
+        assert_eq!(HumanReadableMode::Raw.size_width(), 11);
+        assert_eq!(HumanReadableMode::Disabled.size_width(), 14);
+        assert_eq!(HumanReadableMode::Enabled.size_width(), 14);
+        assert_eq!(HumanReadableMode::Combined.size_width(), 14);
+    }
+
+    #[test]
     fn unit_base_levels() {
         // upstream: lib/compat.c:183 - mult = human_flag == 2 ? 1000 : 1024.
-        assert_eq!(HumanReadableMode::Disabled.unit_base(), 1000.0);
         assert_eq!(HumanReadableMode::Enabled.unit_base(), 1000.0);
         assert_eq!(HumanReadableMode::Combined.unit_base(), 1024.0);
     }

--- a/crates/core/src/client/config/enums/human_readable.rs
+++ b/crates/core/src/client/config/enums/human_readable.rs
@@ -14,12 +14,12 @@ use thiserror::Error;
 /// | Level | Variant | Rendering | Size width |
 /// |-------|---------|-----------|------------|
 /// | 0 | [`Self::Raw`] | raw digits, no separators (`1234567`) | 11 |
-/// | 1 | [`Self::Disabled`] | thousands-separated (`1,234,567`) | 14 |
-/// | 2 | [`Self::Enabled`] | base-1000 suffix (`1.23M`) | 14 |
-/// | 3 | [`Self::Combined`] | base-1024 suffix (`1.18M`) | 14 |
+/// | 1 | [`Self::Grouped`] | thousands-separated (`1,234,567`) | 14 |
+/// | 2 | [`Self::DecimalUnits`] | base-1000 suffix (`1.23M`) | 14 |
+/// | 3 | [`Self::BinaryUnits`] | base-1024 suffix (`1.18M`) | 14 |
 ///
 /// Level 1 is the default when neither `-h` nor `--no-h` is supplied, so
-/// [`Self::Disabled`] names the "no suffix humanisation" default rather than a
+/// [`Self::Grouped`] names the "no suffix humanisation" default rather than a
 /// suppressed-output mode. See [`Self::unit_base`], [`Self::size_width`], and
 /// [`Self::uses_separators`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -36,11 +36,11 @@ pub enum HumanReadableMode {
     /// 14-wide size column, with no unit suffix.
     ///
     /// upstream: `options.c:111` initialises `human_readable = 1`.
-    Disabled,
+    Grouped,
     /// Level 2 (`-h`): base-1000 suffix formatting (e.g. `1.23K`, `4.56M`).
-    Enabled,
+    DecimalUnits,
     /// Level 3 (`-hh`): base-1024 suffix formatting (e.g. `1.18M`).
-    Combined,
+    BinaryUnits,
 }
 
 impl HumanReadableMode {
@@ -58,9 +58,9 @@ impl HumanReadableMode {
 
         match trimmed {
             "0" => Ok(Self::Raw),
-            "1" => Ok(Self::Disabled),
-            "2" => Ok(Self::Enabled),
-            "3" => Ok(Self::Combined),
+            "1" => Ok(Self::Grouped),
+            "2" => Ok(Self::DecimalUnits),
+            "3" => Ok(Self::BinaryUnits),
             other => Err(HumanReadableModeParseError::Invalid {
                 value: other.to_owned(),
             }),
@@ -74,18 +74,18 @@ impl HumanReadableMode {
     /// `human_flag > 1` gate in `lib/compat.c:182`.
     #[must_use]
     pub const fn is_enabled(self) -> bool {
-        matches!(self, Self::Enabled | Self::Combined)
+        matches!(self, Self::DecimalUnits | Self::BinaryUnits)
     }
 
     /// Reports whether thousands separators are inserted between digit groups.
     ///
-    /// Only the default level 1 ([`Self::Disabled`]) groups digits with the
+    /// Only the default level 1 ([`Self::Grouped`]) groups digits with the
     /// locale separator; level 0 ([`Self::Raw`]) emits raw digits. Mirrors
     /// upstream `lib/compat.c:231`, where the separator is inserted only when
     /// `human_flag` is non-zero and no unit suffix applies.
     #[must_use]
     pub const fn uses_separators(self) -> bool {
-        matches!(self, Self::Disabled)
+        matches!(self, Self::Grouped)
     }
 
     /// The `--list-only` size-column width for this level.
@@ -96,20 +96,20 @@ impl HumanReadableMode {
     pub const fn size_width(self) -> usize {
         match self {
             Self::Raw => 11,
-            Self::Disabled | Self::Enabled | Self::Combined => 14,
+            Self::Grouped | Self::DecimalUnits | Self::BinaryUnits => 14,
         }
     }
 
     /// The unit multiplier upstream `do_big_num` applies for K/M/G/T units.
     ///
     /// Mirrors `lib/compat.c:183`: `mult = human_flag == 2 ? 1000 : 1024`.
-    /// A single `-h` (level 2, [`Self::Enabled`]) uses base 1000; `-hh`
-    /// (level 3, [`Self::Combined`]) uses base 1024. The value is only
+    /// A single `-h` (level 2, [`Self::DecimalUnits`]) uses base 1000; `-hh`
+    /// (level 3, [`Self::BinaryUnits`]) uses base 1024. The value is only
     /// meaningful when [`Self::is_enabled`] is true.
     #[must_use]
     pub const fn unit_base(self) -> f64 {
         match self {
-            Self::Combined => 1024.0,
+            Self::BinaryUnits => 1024.0,
             _ => 1000.0,
         }
     }
@@ -151,7 +151,7 @@ impl HumanReadableModeParseError {
 mod tests {
     use super::*;
 
-    // upstream: options.c levels 0-3 map to Raw / Disabled / Enabled / Combined.
+    // upstream: options.c levels 0-3 map to Raw / Grouped / DecimalUnits / BinaryUnits.
     #[test]
     fn parse_level_0() {
         assert_eq!(
@@ -164,7 +164,7 @@ mod tests {
     fn parse_level_1() {
         assert_eq!(
             HumanReadableMode::parse("1").unwrap(),
-            HumanReadableMode::Disabled
+            HumanReadableMode::Grouped
         );
     }
 
@@ -172,7 +172,7 @@ mod tests {
     fn parse_level_2() {
         assert_eq!(
             HumanReadableMode::parse("2").unwrap(),
-            HumanReadableMode::Enabled
+            HumanReadableMode::DecimalUnits
         );
     }
 
@@ -180,7 +180,7 @@ mod tests {
     fn parse_level_3() {
         assert_eq!(
             HumanReadableMode::parse("3").unwrap(),
-            HumanReadableMode::Combined
+            HumanReadableMode::BinaryUnits
         );
     }
 
@@ -188,7 +188,7 @@ mod tests {
     fn parse_with_whitespace() {
         assert_eq!(
             HumanReadableMode::parse("  1  ").unwrap(),
-            HumanReadableMode::Disabled
+            HumanReadableMode::Grouped
         );
     }
 
@@ -212,7 +212,7 @@ mod tests {
         use std::str::FromStr;
         assert_eq!(
             HumanReadableMode::from_str("2").unwrap(),
-            HumanReadableMode::Enabled
+            HumanReadableMode::DecimalUnits
         );
     }
 
@@ -225,17 +225,17 @@ mod tests {
     #[test]
     fn is_enabled_disabled() {
         // Level 1 (default) groups digits but applies no unit suffix.
-        assert!(!HumanReadableMode::Disabled.is_enabled());
+        assert!(!HumanReadableMode::Grouped.is_enabled());
     }
 
     #[test]
     fn is_enabled_enabled() {
-        assert!(HumanReadableMode::Enabled.is_enabled());
+        assert!(HumanReadableMode::DecimalUnits.is_enabled());
     }
 
     #[test]
     fn is_enabled_combined() {
-        assert!(HumanReadableMode::Combined.is_enabled());
+        assert!(HumanReadableMode::BinaryUnits.is_enabled());
     }
 
     #[test]
@@ -243,25 +243,25 @@ mod tests {
         // upstream: lib/compat.c:231 - separators only when human_flag != 0 and
         // no suffix applies, i.e. exactly level 1.
         assert!(!HumanReadableMode::Raw.uses_separators());
-        assert!(HumanReadableMode::Disabled.uses_separators());
-        assert!(!HumanReadableMode::Enabled.uses_separators());
-        assert!(!HumanReadableMode::Combined.uses_separators());
+        assert!(HumanReadableMode::Grouped.uses_separators());
+        assert!(!HumanReadableMode::DecimalUnits.uses_separators());
+        assert!(!HumanReadableMode::BinaryUnits.uses_separators());
     }
 
     #[test]
     fn size_width_only_raw_is_eleven() {
         // upstream: generator.c:1159 - size_width = human_readable ? 14 : 11.
         assert_eq!(HumanReadableMode::Raw.size_width(), 11);
-        assert_eq!(HumanReadableMode::Disabled.size_width(), 14);
-        assert_eq!(HumanReadableMode::Enabled.size_width(), 14);
-        assert_eq!(HumanReadableMode::Combined.size_width(), 14);
+        assert_eq!(HumanReadableMode::Grouped.size_width(), 14);
+        assert_eq!(HumanReadableMode::DecimalUnits.size_width(), 14);
+        assert_eq!(HumanReadableMode::BinaryUnits.size_width(), 14);
     }
 
     #[test]
     fn unit_base_levels() {
         // upstream: lib/compat.c:183 - mult = human_flag == 2 ? 1000 : 1024.
-        assert_eq!(HumanReadableMode::Enabled.unit_base(), 1000.0);
-        assert_eq!(HumanReadableMode::Combined.unit_base(), 1024.0);
+        assert_eq!(HumanReadableMode::DecimalUnits.unit_base(), 1000.0);
+        assert_eq!(HumanReadableMode::BinaryUnits.unit_base(), 1024.0);
     }
 
     #[test]

--- a/crates/core/src/client/tests/human_readable_mode.rs
+++ b/crates/core/src/client/tests/human_readable_mode.rs
@@ -3,20 +3,20 @@ use std::str::FromStr;
 
 #[test]
 fn human_readable_mode_parses_numeric_levels() {
-    assert_eq!(HumanReadableMode::parse("0").unwrap(), HumanReadableMode::Disabled);
-    assert_eq!(HumanReadableMode::parse("1").unwrap(), HumanReadableMode::Enabled);
-    assert_eq!(HumanReadableMode::parse("2").unwrap(), HumanReadableMode::Combined);
+    assert_eq!(HumanReadableMode::parse("0").unwrap(), HumanReadableMode::Grouped);
+    assert_eq!(HumanReadableMode::parse("1").unwrap(), HumanReadableMode::DecimalUnits);
+    assert_eq!(HumanReadableMode::parse("2").unwrap(), HumanReadableMode::BinaryUnits);
 }
 
 #[test]
 fn human_readable_mode_trims_ascii_whitespace() {
     assert_eq!(
         HumanReadableMode::parse(" 1 \t").unwrap(),
-        HumanReadableMode::Enabled
+        HumanReadableMode::DecimalUnits
     );
     assert_eq!(
         HumanReadableMode::from_str("\n 2  \r").unwrap(),
-        HumanReadableMode::Combined
+        HumanReadableMode::BinaryUnits
     );
 }
 


### PR DESCRIPTION
## Problem

oc-rsync collapsed upstream rsync's **four** human-readable levels into three, so `--no-human-readable`/`--no-h` rendered incorrectly and `--human-readable=N` was wrongly accepted.

Upstream tracks `human_readable` as an integer 0..3 (`options.c:111` default 1, `options.c:1573` `-h` increments, `options.c:617` `--no-h` resets to 0). Each level changes both digit grouping (`lib/compat.c:do_big_num`) and the `--list-only` size-column width (`generator.c:1159` `size_width = human_readable ? 14 : 11`):

| Level | Flag | Rendering | Size width |
|-------|------|-----------|------------|
| 0 | `--no-h` | raw digits, no separators (`1234567`) | 11 |
| 1 | default | comma-grouped (`1,234,567`) | 14 |
| 2 | `-h` | base-1000 suffix (`1.23M`) | 14 |
| 3 | `-hh` | base-1024 suffix (`1.18M`) | 14 |

oc-rsync had no level-0 state: `--no-h` produced comma-grouped values in a 14-wide column (upstream: raw digits, 11-wide). It also accepted `--human-readable=N`, but upstream declares `-h` as `POPT_ARG_NONE` (`options.c:616`), rejecting any explicit argument.

## Fix

- Add `HumanReadableMode::Raw` (level 0) with explicit `size_width()` (11 vs 14) and `uses_separators()` mappings; keep `Disabled`/`Enabled`/`Combined` as levels 1/2/3.
- Route `--no-h`/`--no-human-readable` to `Raw`; keep the flag-absent default at level 1.
- Make `-h`/`--human-readable` take no argument (clap `ArgAction::Count`), so `--human-readable=N` is rejected like upstream.
- Thread the level-0 no-comma/width-11 distinction through list-only, `--stats` byte totals, and progress size rendering.

## Verification

Byte-for-byte `diff` of oc-rsync vs `rsync 3.4.4` on a 1,234,567-byte file across `--list-only` and `--stats` for all four levels - all identical. `--human-readable=5` and `=2` are rejected (exit 1), matching upstream's `POPT_ARG_NONE`.

Byte-pinned tests updated to flag forms; new tests lock level-0 raw (`1234567`, width 11) vs level-1 grouped (`1,234,567`, width 14), `-h`=`1.23M`, `-hh`=`1.18M`, and `--human-readable=N` rejection.