### PR TITLE
fix(daemon): emit MOTD after greeting with upstream trailing newline

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/listing.rs
+++ b/crates/daemon/src/daemon/sections/module_access/listing.rs
@@ -1,8 +1,8 @@
 // Module listing - formats and sends the list of available modules to clients.
 //
 // When a client sends `#list` as its module request, the daemon responds with
-// the MOTD lines followed by one `%-15s\t%s\n` line per listable module,
-// terminated by `@RSYNCD: EXIT`.
+// one `%-15s\t%s\n` line per listable module, terminated by `@RSYNCD: EXIT`.
+// The MOTD is emitted earlier, right after the greeting.
 //
 // upstream: clientserver.c:1246-1254 - `rsync_module()` handles the `#list`
 // request by iterating `lp_numservices()` and printing each listable module.
@@ -19,29 +19,22 @@ fn format_module_listing_line(name: &str, comment: &str) -> String {
 
 /// Sends the list of available modules to a client.
 ///
-/// This responds to a module listing request by sending the MOTD (message of the
-/// day) lines followed by the names and comments of modules the peer is allowed
-/// to access. Only modules marked as listable and that permit the peer's IP
-/// address are included in the response.
+/// This responds to a module listing request by sending the names and comments
+/// of modules the peer is allowed to access. Only modules marked as listable and
+/// that permit the peer's IP address are included in the response. The MOTD is
+/// emitted earlier, right after the greeting, matching upstream's
+/// `exchange_protocols()` (clientserver.c:158-170).
 fn respond_with_module_list(
     stream: &mut DaemonStream,
     limiter: &mut Option<BandwidthLimiter>,
     modules: &[ModuleRuntime],
-    motd_lines: &[String],
     peer_ip: IpAddr,
     reverse_lookup: bool,
     messages: &LegacyMessageCache,
 ) -> io::Result<()> {
-    // upstream: clientserver.c:1246-1252 - MOTD lines are sent as raw text,
-    // not wrapped in @RSYNCD: protocol frames.
-    for line in motd_lines {
-        write_limited(stream, limiter, line.as_bytes())?;
-        write_limited(stream, limiter, b"\n")?;
-    }
-
-    // upstream: clientserver.c does NOT send @RSYNCD: OK before the module
-    // listing. The listing goes straight from MOTD/capabilities to module
-    // names followed by @RSYNCD: EXIT.
+    // upstream: clientserver.c:1266-1272 send_listing() - the listing goes
+    // straight to the module names followed by @RSYNCD: EXIT. It does NOT send
+    // @RSYNCD: OK first, and the MOTD was already emitted after the greeting.
 
     let mut hostname_cache: Option<Option<String>> = None;
     for module in modules {

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -240,6 +240,20 @@ fn handle_legacy_session(
         cached_legacy_daemon_greeting(),
     )?;
 
+    // upstream: clientserver.c:158-170 exchange_protocols() - immediately after
+    // the greeting the daemon dumps the MOTD file verbatim and appends a single
+    // trailing newline (write_sbuf(f_out, "\n")), before reading the client's
+    // version/module request. Emitting it here (rather than only in the module
+    // listing) mirrors upstream: the MOTD precedes every response, including an
+    // @ERROR refusal for an unknown module.
+    if !motd_lines.is_empty() {
+        for line in motd_lines {
+            write_limited(reader.get_mut(), &mut limiter, line.as_bytes())?;
+            write_limited(reader.get_mut(), &mut limiter, b"\n")?;
+        }
+        write_limited(reader.get_mut(), &mut limiter, b"\n")?;
+    }
+
     let mut request = None;
     let mut refused_options = Vec::new();
     let mut negotiated_protocol = None;
@@ -316,7 +330,6 @@ fn handle_legacy_session(
             reader.get_mut(),
             &mut limiter,
             modules,
-            motd_lines,
             peer_addr.ip(),
             reverse_lookup,
             messages,

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -213,6 +213,7 @@ include!("tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs");
 include!("tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs");
 include!("tests/chunks/run_daemon_requests_authentication_for_protected_module.rs");
 include!("tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs");
+include!("tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs");
 include!("tests/chunks/run_daemon_serves_single_legacy_connection.rs");
 include!("tests/chunks/run_daemon_writes_and_removes_pid_file.rs");
 include!("tests/chunks/run_daemon_pid_file_contains_correct_pid.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
@@ -54,6 +54,14 @@ fn run_daemon_lists_modules_with_motd_lines() {
     reader.read_line(&mut line).expect("motd line 3");
     assert_eq!(line.trim_end(), "Additional notice");
 
+    // upstream: clientserver.c:169 exchange_protocols() appends a single
+    // unconditional `write_sbuf(f_out, "\n")` after the MOTD body, producing a
+    // blank separator line before the module listing. A daemon that omits it
+    // desynchronises byte-for-byte from upstream's greeting/MOTD framing.
+    line.clear();
+    reader.read_line(&mut line).expect("motd trailing blank");
+    assert_eq!(line, "\n");
+
     // upstream: no @RSYNCD: OK before module listing
 
     line.clear();

--- a/crates/daemon/src/tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs
@@ -1,0 +1,65 @@
+#[test]
+fn run_daemon_sends_motd_before_unknown_module_error() {
+    // Wire/text fidelity: upstream emits the MOTD inside exchange_protocols()
+    // (clientserver.c:158-170), immediately after the greeting and before it
+    // reads the client's module request. The MOTD therefore precedes *every*
+    // response, including an @ERROR refusal for an unknown module - not just
+    // the module listing. A client parsing the daemon stream byte-for-byte
+    // must see: greeting, MOTD body, blank separator, then @ERROR.
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (port, held_listener) = allocate_test_port();
+
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--motd-line"),
+            OsString::from("Welcome to rsyncd"),
+            OsString::from("--module"),
+            OsString::from(format!("docs={module_path}")),
+            OsString::from("--once"),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let expected_greeting = legacy_daemon_greeting();
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert_eq!(line, expected_greeting);
+
+    stream
+        .write_all(b"@RSYNCD: 32.0\n")
+        .expect("send handshake response");
+    stream.flush().expect("flush handshake response");
+
+    stream
+        .write_all(b"nosuchmod\n")
+        .expect("send module request");
+    stream.flush().expect("flush module request");
+
+    // upstream: MOTD body precedes the refusal.
+    line.clear();
+    reader.read_line(&mut line).expect("motd line");
+    assert_eq!(line, "Welcome to rsyncd\n");
+
+    // upstream: clientserver.c:169 - single trailing blank line after the MOTD.
+    line.clear();
+    reader.read_line(&mut line).expect("motd trailing blank");
+    assert_eq!(line, "\n");
+
+    // upstream: clientserver.c:730 - "@ERROR: Unknown module '%s'\n"
+    line.clear();
+    reader.read_line(&mut line).expect("error message");
+    assert_eq!(line, "@ERROR: Unknown module 'nosuchmod'\n");
+
+    drop(reader);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary

Verified the daemon's protocol/text output against upstream rsync 3.4.4 by running both daemons on macOS and comparing raw bytes. The greeting, module-listing line format (`%-15s\t%s\n`), and `@RSYNCD: EXIT` all matched. The MOTD emission diverged.

### Divergence (fixed)
Upstream emits the MOTD inside `exchange_protocols()` (clientserver.c:158-170), immediately after the greeting and before reading the client's module request, then appends one unconditional `write_sbuf(f_out, "\n")`. oc-rsync instead emitted the MOTD only in the module-listing path and omitted the trailing blank line, so:

- the module listing was missing the blank separator line after the MOTD, and
- an `@ERROR: Unknown module` refusal was sent with no MOTD at all.

### Fix
Move MOTD emission to immediately follow the greeting (guarded on a non-empty MOTD) and append upstream's trailing newline. Remove the now-redundant MOTD loop from the listing path. Byte-for-byte verification after the fix:

- Module listing: **identical** to upstream 3.4.4.
- Unknown-module `@ERROR`: MOTD now precedes the refusal, matching upstream.

### Tests
- Updated `run_daemon_lists_modules_with_motd_lines` to assert the trailing blank line, citing clientserver.c:169.
- Added `run_daemon_sends_motd_before_unknown_module_error` asserting greeting -> MOTD -> blank line -> `@ERROR: Unknown module` byte order.

### Note (out of scope)
oc-rsync also appends `@RSYNCD: EXIT\n` after an `@ERROR` line, which upstream does not (clientserver.c treats `@ERROR` as fatal and returns without EXIT; the client bails at clientserver.c:381-385 before ever reading it). This is benign and deliberately asserted across several existing tests, so it is left unchanged here to keep this change surgical.