### PR TITLE
refactor(filters): single source for default CVS-ignore patterns

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -56,6 +56,7 @@ async-daemon = ["daemon/async-daemon"]
 clap = { workspace = true }
 core = { path = "../core", default-features = false }
 engine = { path = "../engine", default-features = false }
+filters = { path = "../filters" }
 logging = { path = "../logging", features = ["tracing"] }
 logging-sink = { path = "../logging-sink" }
 protocol = { path = "../protocol" }
@@ -97,7 +98,6 @@ predicates = "3.1"
 filetime = { workspace = true }
 tempfile = { workspace = true }
 test-support = { path = "../test-support" }
-filters = { path = "../filters" }
 rustix = { workspace = true, features = ["fs"] }
 base64 = { workspace = true }
 libc = { workspace = true }

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -36,44 +36,10 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
 pub(super) const ITEMIZE_CHANGES_FORMAT: &str = "%i %n%L";
 
 /// Default patterns excluded by `--cvs-exclude`.
-pub(super) const CVS_EXCLUDE_PATTERNS: &[&str] = &[
-    "RCS",
-    "SCCS",
-    "CVS",
-    "CVS.adm",
-    "RCSLOG",
-    "cvslog.*",
-    "tags",
-    "TAGS",
-    ".make.state",
-    ".nse_depinfo",
-    "*~",
-    "#*",
-    ".#*",
-    ",*",
-    "_$*",
-    "*$",
-    "*.old",
-    "*.bak",
-    "*.BAK",
-    "*.orig",
-    "*.rej",
-    ".del-*",
-    "*.a",
-    "*.olb",
-    "*.o",
-    "*.obj",
-    "*.so",
-    "*.exe",
-    "*.Z",
-    "*.elc",
-    "*.ln",
-    "core",
-    ".svn/",
-    ".git/",
-    ".hg/",
-    ".bzr/",
-];
+///
+/// Re-exported from the `filters` crate so there is a single canonical
+/// definition of the built-in CVS-ignore list (see [`filters::DEFAULT_CVSIGNORE`]).
+pub(super) use filters::DEFAULT_CVSIGNORE as CVS_EXCLUDE_PATTERNS;
 
 /// Default patterns excluded by `--apple-double-skip` (macOS AppleDouble sidecars).
 ///

--- a/crates/filters/src/cvs.rs
+++ b/crates/filters/src/cvs.rs
@@ -30,50 +30,50 @@
 
 /// Default CVS exclusion patterns.
 ///
-/// These patterns are space-separated and match rsync's built-in defaults
-/// from `exclude.c:get_cvs_excludes()`. The patterns use rsync's filter
-/// syntax:
+/// This is the single canonical definition of rsync's built-in `--cvs-exclude`
+/// defaults from `exclude.c:get_cvs_excludes()`. The patterns use rsync's
+/// filter syntax:
 /// - Simple names match files/directories at any level
 /// - `*` matches any characters except `/`
 /// - Trailing `/` marks directory-only patterns
-pub const DEFAULT_CVSIGNORE: &str = concat!(
-    "RCS ",
-    "SCCS ",
-    "CVS ",
-    "CVS.adm ",
-    "RCSLOG ",
-    "cvslog.* ",
-    "tags ",
-    "TAGS ",
-    ".make.state ",
-    ".nse_depinfo ",
-    "*~ ",
-    "#* ",
-    ".#* ",
-    ",* ",
-    "_$* ",
-    "*$ ",
-    "*.old ",
-    "*.bak ",
-    "*.BAK ",
-    "*.orig ",
-    "*.rej ",
-    ".del-* ",
-    "*.a ",
-    "*.olb ",
-    "*.o ",
-    "*.obj ",
-    "*.so ",
-    "*.exe ",
-    "*.Z ",
-    "*.elc ",
-    "*.ln ",
-    "core ",
-    ".svn/ ",
-    ".git/ ",
-    ".hg/ ",
+pub const DEFAULT_CVSIGNORE: &[&str] = &[
+    "RCS",
+    "SCCS",
+    "CVS",
+    "CVS.adm",
+    "RCSLOG",
+    "cvslog.*",
+    "tags",
+    "TAGS",
+    ".make.state",
+    ".nse_depinfo",
+    "*~",
+    "#*",
+    ".#*",
+    ",*",
+    "_$*",
+    "*$",
+    "*.old",
+    "*.bak",
+    "*.BAK",
+    "*.orig",
+    "*.rej",
+    ".del-*",
+    "*.a",
+    "*.olb",
+    "*.o",
+    "*.obj",
+    "*.so",
+    "*.exe",
+    "*.Z",
+    "*.elc",
+    "*.ln",
+    "core",
+    ".svn/",
+    ".git/",
+    ".hg/",
     ".bzr/",
-);
+];
 
 /// Returns an iterator over the default CVS exclusion patterns.
 ///
@@ -89,9 +89,7 @@ pub const DEFAULT_CVSIGNORE: &str = concat!(
 /// assert!(patterns.contains(&".git/"));
 /// ```
 pub fn default_patterns() -> impl Iterator<Item = &'static str> {
-    DEFAULT_CVSIGNORE
-        .split_whitespace()
-        .filter(|s| !s.is_empty())
+    DEFAULT_CVSIGNORE.iter().copied()
 }
 
 /// Returns the number of default CVS exclusion patterns in


### PR DESCRIPTION
## Summary

The 36-pattern default CVS-ignore list (used by `--cvs-exclude` / `-C`) was
duplicated byte-for-byte in two crates:

- `crates/filters/src/cvs.rs` — `DEFAULT_CVSIGNORE`
- `crates/cli/src/frontend/defaults.rs` — `CVS_EXCLUDE_PATTERNS`

Both were identical and correct, but the duplication is a maintenance
hazard: editing one and not the other would silently diverge.

## Change

- `crates/filters` is now the single canonical source. `DEFAULT_CVSIGNORE`
  is defined once as a `&[&str]` slice; `default_patterns()` iterates it
  directly instead of splitting a space-separated string.
- `crates/cli/src/frontend/defaults.rs` drops the duplicate literal and
  re-exports the canonical definition:
  `pub(super) use filters::DEFAULT_CVSIGNORE as CVS_EXCLUDE_PATTERNS;`
- `filters` becomes a direct dependency of `cli` (it was already a
  transitive dependency via `core`/`protocol` and a dev-dependency).

No behavior change: the effective pattern list is identical (same 36
patterns, same order). All cli use-sites keep the `CVS_EXCLUDE_PATTERNS`
name and `&[&str]` shape, so nothing downstream changed.

## Verification

- `cargo check -p filters -p cli --all-features` — clean
- `cargo clippy -p filters -p cli --all-features --no-deps -- -D warnings` — clean
- `cargo fmt --all` — clean
- `cargo nextest run -p filters -E 'test(cvs)'` — 89 passed
- `cargo nextest run -p cli -E 'test(cvs)'` — 36 passed