### PR TITLE
fix(protocol): unseed xattr abbreviation checksum to match upstream

### DIFF
--- a/crates/protocol/src/xattr/wire/decode.rs
+++ b/crates/protocol/src/xattr/wire/decode.rs
@@ -277,17 +277,19 @@ pub fn recv_xattr_values<R: Read>(reader: &mut R, list: &mut XattrList) -> io::R
 
 /// Compares an abbreviated xattr checksum against a local value.
 ///
-/// Computes the seeded MD5 digest of `local_value` using `checksum_seed` and
-/// compares it byte-for-byte with `checksum`. Returns `true` if they match,
-/// indicating the remote and local xattr values are identical and the full
-/// value does not need to be transferred.
+/// Computes the abbreviation digest of `local_value` (see
+/// `compute_xattr_checksum` - the MD5 default of protocol 30-32 is unseeded)
+/// and compares it byte-for-byte with `checksum`. Returns `true` if they
+/// match, indicating the remote and local xattr values are identical and the
+/// full value does not need to be transferred.
 ///
 /// Returns `false` if `checksum` is not exactly [`MAX_XATTR_DIGEST_LEN`] bytes.
 ///
 /// # Upstream Reference
 ///
-/// Used during the abbreviation protocol in `xattrs.c` to determine which
-/// abbreviated values the receiver needs to request from the sender.
+/// `xattrs.c:xattr_diff()` compares the sender's `datum + 1` abbreviation
+/// against the receiver's locally computed digest to decide which values
+/// must be requested from the sender.
 #[must_use]
 pub fn checksum_matches(checksum: &[u8], local_value: &[u8], checksum_seed: i32) -> bool {
     if checksum.len() != MAX_XATTR_DIGEST_LEN {

--- a/crates/protocol/src/xattr/wire/encode.rs
+++ b/crates/protocol/src/xattr/wire/encode.rs
@@ -17,8 +17,11 @@ use crate::xattr::{MAX_FULL_DATUM, MAX_XATTR_DIGEST_LEN, XattrList};
 
 /// Sends xattr data to the wire.
 ///
-/// The `checksum_seed` is mixed into the hash for abbreviated xattr values,
-/// matching upstream rsync's `sum_init(xattr_sum_nni, checksum_seed)` behavior.
+/// Abbreviated values (larger than `MAX_FULL_DATUM`) are replaced by the
+/// checksum computed via `compute_xattr_checksum`. For the MD5 default of
+/// protocol 30-32 this digest is unseeded, matching upstream's
+/// `sum_init(xattr_sum_nni, checksum_seed)` whose `CSUM_MD5` path ignores the
+/// seed (`checksum.c:588`).
 ///
 /// # Wire Format
 ///
@@ -31,7 +34,7 @@ use crate::xattr::{MAX_FULL_DATUM, MAX_XATTR_DIGEST_LEN, XattrList};
 ///     datum_len  : varint  // original value length
 ///     name       : bytes[name_len]
 ///     If datum_len > MAX_FULL_DATUM:
-///       checksum : bytes[MAX_XATTR_DIGEST_LEN]  // seeded hash of value
+///       checksum : bytes[MAX_XATTR_DIGEST_LEN]  // unseeded MD5 of value
 ///     Else:
 ///       value    : bytes[datum_len]
 /// ```
@@ -197,22 +200,38 @@ pub fn send_sender_xattr_response<W: Write>(
     Ok(())
 }
 
-/// Computes the seeded MD5 checksum for an xattr value.
+/// Computes the abbreviation checksum for a large xattr value.
 ///
-/// Includes the `checksum_seed` in the hash to match upstream rsync's
-/// `sum_init(xattr_sum_nni, checksum_seed)` + `sum_update()` + `sum_end()`
-/// pattern. The seed bytes are hashed before the data.
+/// Upstream abbreviates values larger than `MAX_FULL_DATUM` with
+/// `sum_init(xattr_sum_nni, checksum_seed)` + `sum_update(value)` +
+/// `sum_end()`. For protocol versions 30-32 the negotiated `xattr_sum_nni`
+/// is always MD5 (`compat.c:824` hardcodes `parse_csum_name(NULL, 0)`, which
+/// returns md5 for protocol >= 30), and the streaming `sum_init()` path for
+/// `CSUM_MD5` does `md5_begin()` only - it does NOT fold `checksum_seed` into
+/// the digest. Only the MD4-family cases feed the seed via
+/// `SIVAL(s, 0, seed); sum_update(s, 4)`. The result is therefore the plain
+/// MD5 of the value bytes, and it must be computed unseeded to interoperate
+/// with upstream: a seeded digest would never match the receiver's locally
+/// computed abbreviation, forcing a redundant full-value transfer on every
+/// large xattr.
+///
+/// `checksum_seed` is retained to mirror upstream's `sum_init(nni, seed)`
+/// signature and to leave room for a future negotiated MD4-family algorithm;
+/// the MD5 default deliberately ignores it, exactly as `sum_init()` does.
 ///
 /// # Upstream Reference
 ///
-/// See `xattrs.c` - large xattr values are abbreviated using a seeded hash.
+/// - `xattrs.c:275-281` - `sum_init(xattr_sum_nni, checksum_seed)` over the datum.
+/// - `checksum.c:588-597` - `sum_init()` `CSUM_MD5` case: `md5_begin()`, no seed.
+/// - `compat.c:824-825` - `xattr_sum_nni` / `xattr_sum_len` fixed to md5 (16 bytes).
 pub(super) fn compute_xattr_checksum(
     data: &[u8],
     checksum_seed: i32,
 ) -> [u8; MAX_XATTR_DIGEST_LEN] {
+    // upstream: the CSUM_MD5 branch of sum_init() ignores the seed; only the
+    // MD4-family branches fold it in. Keep the parameter for signature parity.
+    let _ = checksum_seed;
     let mut hasher = Md5::new();
-    // upstream: sum_init() feeds the seed into the hash first
-    hasher.update(checksum_seed.to_le_bytes());
     hasher.update(data);
     let result = hasher.finalize();
     let mut checksum = [0u8; MAX_XATTR_DIGEST_LEN];

--- a/crates/protocol/src/xattr/wire/tests.rs
+++ b/crates/protocol/src/xattr/wire/tests.rs
@@ -448,14 +448,34 @@ fn checksum_verification() {
     assert!(!checksum_matches(&checksum, b"different value", seed));
 }
 
+/// The abbreviation digest of protocol 30-32 is the plain, unseeded MD5 of the
+/// value. Upstream computes it via `sum_init(xattr_sum_nni, checksum_seed)`,
+/// but the `CSUM_MD5` case of `sum_init()` does `md5_begin()` with no seed
+/// (`checksum.c:588`); only the MD4-family cases fold the seed in. A seeded
+/// digest here would never equal the receiver's locally computed value, so
+/// upstream would re-request every large xattr in full. This locks the digest
+/// to seed-independent plain MD5 so oc-rsync stays byte-compatible.
 #[test]
-fn checksum_seed_affects_result() {
+fn abbreviation_checksum_is_unseeded_md5() {
+    use md5::{Digest, Md5};
+
     let value = b"same data different seeds";
+
+    // The seed must not change the digest.
     let checksum_a = compute_xattr_checksum(value, 100);
     let checksum_b = compute_xattr_checksum(value, 200);
-    assert_ne!(checksum_a, checksum_b);
-    assert!(checksum_matches(&checksum_a, value, 100));
-    assert!(!checksum_matches(&checksum_a, value, 200));
+    let checksum_zero = compute_xattr_checksum(value, 0);
+    assert_eq!(checksum_a, checksum_b);
+    assert_eq!(checksum_a, checksum_zero);
+
+    // The digest is exactly the plain MD5 of the value, matching upstream's
+    // unseeded sum_init(CSUM_MD5) over the datum.
+    let expected: [u8; MAX_XATTR_DIGEST_LEN] = Md5::digest(value).into();
+    assert_eq!(checksum_a, expected);
+
+    // Any nonzero seed still verifies, since the seed is ignored.
+    assert!(checksum_matches(&checksum_a, value, 200));
+    assert!(!checksum_matches(&checksum_a, b"different value", 200));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes a wire-encoding divergence in the extended-attribute (`-X`) abbreviation protocol that breaks interop with upstream rsync for xattr values larger than `MAX_FULL_DATUM` (32 bytes).

oc-rsync computed the abbreviation digest as a **seeded** MD5 (`checksum_seed` prepended to the value). Upstream computes it via `sum_init(xattr_sum_nni, checksum_seed)` + `sum_update(value)` + `sum_end()`, but for protocol 30-32 `xattr_sum_nni` is always MD5, and the streaming `sum_init()` `CSUM_MD5` case does `md5_begin()` only - it **never folds the seed in**. Only the MD4-family cases feed the seed.

- `xattrs.c:275-281` - `sum_init(xattr_sum_nni, checksum_seed)` over the datum
- `checksum.c:588-597` - `sum_init()` `CSUM_MD5` case is unseeded
- `compat.c:824-825` - `xattr_sum_nni`/`xattr_sum_len` fixed to md5 (16 bytes)

### Impact

The seeded digest never matches the receiver's locally computed value, so an interoperating upstream peer re-requests every large xattr in full, defeating the abbreviation optimization. This live-fires on the flist send path (`crates/protocol/src/flist/write/mod.rs` passes the negotiated seed to `send_xattr`).

### Fix

Compute the plain, unseeded MD5. The `checksum_seed` parameter is retained to mirror upstream's `sum_init(nni, seed)` signature and to leave room for a future negotiated MD4-family algorithm.

### Verification

- The rest of the xattr wire (ndx+1, count, name_len incl. NUL, datum_len, cache index) and the full ACL wire (`send_rsync_acl`/`send_ida_entries`, XMIT_* flags, id-then-access ordering, XFLAG name encoding) were audited field-by-field and already match upstream - no changes there.
- Updated the abbreviation test to assert seed-independence and byte-equality to plain `MD5(value)`, encoding the interop requirement.
- `cargo fmt`, `cargo clippy -p protocol --all-targets --all-features -- -D warnings`, and the 54 `xattr::wire` lib tests all pass.