### PR TITLE
docs(batch): fix stale create_symlink doc comment

### DIFF
--- a/crates/batch/src/replay/fs_ops.rs
+++ b/crates/batch/src/replay/fs_ops.rs
@@ -85,8 +85,8 @@ pub(super) fn apply_symlink_entry_metadata(
 
 /// Create a symlink at `dest_path` pointing to the given `target`.
 ///
-/// On Unix, creates a symbolic link. On other platforms, falls back to
-/// file copy (symlink creation is platform-specific).
+/// Any existing entry at `dest_path` is removed first, mirroring upstream
+/// rsync's replace-on-conflict behavior.
 #[cfg(unix)]
 pub(super) fn create_symlink(target: &Path, dest_path: &Path) -> BatchResult<()> {
     // Remove existing entry if present, to mirror upstream rsync behavior


### PR DESCRIPTION
## Summary

Rustdoc-first comment cleanup pass over the `batch` crate.

The crate is already in excellent shape: `#![deny(missing_docs)]` guarantees every public item is documented, upstream/wire-format references are intact throughout, and there are no banner/divider comments, commented-out code, or TODO/FIXME markers to prune.

The one issue found and fixed is a stale/contradictory doc comment on the `#[cfg(unix)]` `create_symlink` helper. Its rustdoc claimed "On other platforms, falls back to file copy", but that function is Unix-only and the non-unix implementation does not fall back to a file copy (it uses `symlink_file` on Windows and returns an `Unsupported` error on other targets). The comment now accurately describes this function's behavior.

## Verification

- Docs-only change (no code, signatures, or behavior touched)
- `cargo fmt --all` clean
- `cargo clippy -p batch --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo check -p batch --all-features` clean