### PR TITLE
fix(core): propagate raw child/remote exit codes like upstream

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -114,6 +114,9 @@ impl ErrorCodification for ClientError {
             ExitCode::CommandKilled => 12500,
             ExitCode::CommandRun => 12600,
             ExitCode::CommandNotFound => 12700,
+            // A raw child/remote status with no named RERR_* code; encode the
+            // raw value into a distinct diagnostic range.
+            ExitCode::Other(code) => 900_000u32.wrapping_add(code as u32),
         }
     }
 
@@ -150,6 +153,8 @@ impl ErrorCodification for ClientError {
             ExitCode::CommandKilled => "RERR_CMD_KILLED",
             ExitCode::CommandRun => "RERR_CMD_RUN",
             ExitCode::CommandNotFound => "RERR_CMD_NOTFOUND",
+            // upstream: log.c:905 - an unrecognized code has no RERR_* name.
+            ExitCode::Other(_) => "RERR_UNKNOWN",
         }
     }
 }

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -271,17 +271,44 @@ fn run_server_over_ssh_connection(
     let handshake = match crate::server::perform_handshake(&mut reader, &mut writer) {
         Ok(h) => h,
         Err(e) => {
-            // Capture SSH stderr - the remote process likely wrote diagnostic
-            // output (e.g., "Connection refused") that explains the failure.
+            // Close our writer so the remote can finish exiting, then reap the
+            // child to learn its real exit status. The child's raw exit code
+            // (e.g. a remote rsync/command exiting 42, or an SSH connection
+            // failure exiting 255) must survive rather than be masked by the
+            // handshake error.
             drop(writer);
-            let stderr_text = match child_handle.wait_with_stderr() {
-                Ok((_, stderr_bytes)) => format_stderr_context(&stderr_bytes),
-                Err(_) => String::new(),
+            let (child_exit, stderr_text) = match child_handle.wait_with_stderr() {
+                Ok((status, stderr_bytes)) => (
+                    map_child_exit_status(status),
+                    format_stderr_context(&stderr_bytes),
+                ),
+                Err(_) => (ExitCode::WaitChild, String::new()),
             };
-            return Err(invalid_argument_error(
-                &format!("handshake failed: {e}{stderr_text}"),
-                5,
-            ));
+
+            // upstream: io.c:232 whine_about_eof() maps an unexpected EOF
+            // during setup to RERR_STREAMIO (12); other handshake failures keep
+            // the client/server-startup code (5). exit_cleanup() then takes the
+            // worst of that base and the child's raw exit status
+            // (cleanup.c:150), so an arbitrary remote exit code propagates
+            // verbatim.
+            let base = if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                ExitCode::StreamIo
+            } else {
+                ExitCode::StartClient
+            };
+            let worst = if child_exit.as_i32() > base.as_i32() {
+                child_exit
+            } else {
+                base
+            };
+            let detail = if base == ExitCode::StreamIo {
+                // upstream: io.c:228-232 - the EOF whine omits the underlying
+                // error and reports the byte count received so far.
+                format!("connection unexpectedly closed (0 bytes received so far){stderr_text}")
+            } else {
+                format!("handshake failed: {e}{stderr_text}")
+            };
+            return Err(invalid_argument_error_typed(&detail, worst));
         }
     };
 

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -76,13 +76,19 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
 
 /// Maps an SSH child process exit status to an rsync exit code.
 ///
-/// Mirrors upstream rsync's `wait_process_with_flush()` logic in `main.c`:
-/// - Exit 0: success
-/// - Exit 127: command not found (`RERR_CMD_NOTFOUND`)
-/// - Exit 255: SSH connection failure (`RERR_CMD_FAILED`)
-/// - Killed by signal: `RERR_CMD_KILLED`
-/// - Other rsync exit codes: passed through directly
-/// - Unknown codes: fall back to `PartialTransfer`
+/// Mirrors upstream rsync's `wait_process_with_flush()` in `main.c:194`:
+/// - Normal exit: `WEXITSTATUS(status)` is propagated raw. Known RERR_*
+///   codes keep their named variant; any other status (for example a remote
+///   rsync exit 42 or an SSH connection failure exit 255) round-trips
+///   verbatim via [`ExitCode::Other`].
+/// - Killed by signal with a core dump: `RERR_CRASHED` (15).
+/// - Killed by signal without a core dump: `RERR_TERMINATED` (16).
+/// - `waitpid()` failure / did not exit normally: `RERR_WAITCHILD` (21).
+///
+/// The resulting raw i32 flows unchanged into the worst-wins comparison
+/// (cleanup.c:150) and ultimately to `process::exit`.
+///
+/// upstream: main.c:194 `wait_process_with_flush()`; cleanup.c:150.
 pub(in crate::client::remote) fn map_child_exit_status(
     status: std::process::ExitStatus,
 ) -> ExitCode {
@@ -93,17 +99,21 @@ pub(in crate::client::remote) fn map_child_exit_status(
     #[cfg(unix)]
     {
         use std::os::unix::process::ExitStatusExt;
+        // upstream: main.c:208-217 - a child that did not exit normally maps to
+        // RERR_CRASHED (core dump) or RERR_TERMINATED (killed by signal).
         if status.signal().is_some() {
-            return ExitCode::CommandKilled;
+            return if status.core_dumped() {
+                ExitCode::Crashed
+            } else {
+                ExitCode::Terminated
+            };
         }
     }
 
     match status.code() {
-        // upstream: main.c:1591 - shell exit codes mapped to RERR_CMD_*
-        Some(126) => ExitCode::CommandRun,
-        Some(127) => ExitCode::CommandNotFound,
-        Some(255) => ExitCode::CommandFailed,
-        Some(code) => ExitCode::from_i32(code).unwrap_or(ExitCode::PartialTransfer),
+        // upstream: main.c:221 - WEXITSTATUS is returned raw, never collapsed.
+        Some(code) => ExitCode::from_raw(code),
+        // upstream: main.c:206/218 - a failed waitpid() maps to RERR_WAITCHILD.
         None => ExitCode::WaitChild,
     }
 }

--- a/crates/core/src/client/remote/ssh_transfer/mod.rs
+++ b/crates/core/src/client/remote/ssh_transfer/mod.rs
@@ -299,9 +299,14 @@ mod tests {
 
         #[cfg(unix)]
         #[test]
-        fn maps_exit_255_to_command_failed() {
+        fn maps_exit_255_raw_not_command_failed() {
+            // upstream: main.c:221 wait_process_with_flush() returns
+            // WEXITSTATUS raw. An SSH connection failure exits 255, which must
+            // propagate as 255, not collapse to RERR_CMD_FAILED (124).
             let status = exit_status_for_code(255);
-            assert_eq!(map_child_exit_status(status), ExitCode::CommandFailed);
+            let mapped = map_child_exit_status(status);
+            assert_eq!(mapped, ExitCode::Other(255));
+            assert_eq!(mapped.as_i32(), 255);
         }
 
         #[cfg(unix)]
@@ -320,21 +325,28 @@ mod tests {
 
         #[cfg(unix)]
         #[test]
-        fn maps_unknown_exit_code_to_partial_transfer() {
+        fn maps_unknown_exit_code_to_raw_other() {
+            // upstream: main.c:221 - an arbitrary remote status (e.g. a remote
+            // rsync/command exiting 42) is propagated verbatim, not collapsed
+            // to RERR_PARTIAL (23).
             let status = exit_status_for_code(42);
-            assert_eq!(map_child_exit_status(status), ExitCode::PartialTransfer);
+            let mapped = map_child_exit_status(status);
+            assert_eq!(mapped, ExitCode::Other(42));
+            assert_eq!(mapped.as_i32(), 42);
         }
 
         #[cfg(unix)]
         #[test]
-        fn maps_signal_killed_to_command_killed() {
+        fn maps_signal_killed_to_terminated() {
+            // upstream: main.c:213-215 - a child killed by a signal without a
+            // core dump maps to RERR_TERMINATED (16), not RERR_CMD_KILLED.
             let mut child = std::process::Command::new("sh")
                 .arg("-c")
                 .arg("kill -9 $$")
                 .spawn()
                 .expect("spawn");
             let status = child.wait().expect("wait");
-            assert_eq!(map_child_exit_status(status), ExitCode::CommandKilled);
+            assert_eq!(map_child_exit_status(status), ExitCode::Terminated);
         }
     }
 }

--- a/crates/core/src/exit_code/codes.rs
+++ b/crates/core/src/exit_code/codes.rs
@@ -131,13 +131,53 @@ pub enum ExitCode {
     ///
     /// Returned when the remote shell or rsync binary is not found.
     CommandNotFound = 127,
+
+    /// A raw exit status that does not map to a named RERR_* code.
+    ///
+    /// Upstream rsync propagates a child or remote process exit status
+    /// verbatim (`WEXITSTATUS`) rather than collapsing unrecognized values.
+    /// This variant preserves that raw code so it survives round-trips to
+    /// `process::exit` and worst-wins comparisons unchanged.
+    ///
+    /// upstream: main.c:221 `wait_process_with_flush()` returns
+    /// `WEXITSTATUS(status)` raw for a normally-exited child.
+    Other(i32),
 }
 
 impl ExitCode {
     /// Returns the numeric exit code value.
     #[must_use]
     pub const fn as_i32(self) -> i32 {
-        self as i32
+        match self {
+            Self::Ok => 0,
+            Self::Syntax => 1,
+            Self::Protocol => 2,
+            Self::FileSelect => 3,
+            Self::Unsupported => 4,
+            Self::StartClient => 5,
+            Self::LogFileAppend => 6,
+            Self::SocketIo => 10,
+            Self::FileIo => 11,
+            Self::StreamIo => 12,
+            Self::MessageIo => 13,
+            Self::Ipc => 14,
+            Self::Crashed => 15,
+            Self::Terminated => 16,
+            Self::Signal1 => 19,
+            Self::Signal => 20,
+            Self::WaitChild => 21,
+            Self::Malloc => 22,
+            Self::PartialTransfer => 23,
+            Self::Vanished => 24,
+            Self::DeleteLimit => 25,
+            Self::Timeout => 30,
+            Self::ConnectionTimeout => 35,
+            Self::CommandFailed => 124,
+            Self::CommandKilled => 125,
+            Self::CommandRun => 126,
+            Self::CommandNotFound => 127,
+            Self::Other(code) => code,
+        }
     }
 
     /// Returns a human-readable description of this exit code.
@@ -173,6 +213,9 @@ impl ExitCode {
             Self::CommandKilled => "remote shell killed",
             Self::CommandRun => "remote command could not be run",
             Self::CommandNotFound => "remote command not found",
+            // upstream: log.c:905 log_exit() - an unrecognized code renders as
+            // "unexplained error" (rerr_name() returned NULL).
+            Self::Other(_) => "unexplained error",
         }
     }
 
@@ -243,6 +286,30 @@ impl ExitCode {
             126 => Some(Self::CommandRun),
             127 => Some(Self::CommandNotFound),
             _ => None,
+        }
+    }
+
+    /// Maps a raw process exit status to an `ExitCode`, preserving
+    /// unrecognized values verbatim via [`ExitCode::Other`].
+    ///
+    /// Unlike [`from_i32`](Self::from_i32), which answers "is this a known
+    /// RERR_* code?" and returns `None` for anything else, this converter
+    /// never discards the numeric value. Known codes keep their named
+    /// variant; any other status (for example a remote rsync exit 42 or an
+    /// SSH connection failure exit 255) round-trips unchanged.
+    ///
+    /// Use this at the child/remote process boundary, where upstream rsync
+    /// propagates the status verbatim. Internal error construction should keep
+    /// using [`from_i32`](Self::from_i32) so a genuinely invalid code still
+    /// falls back to a defined RERR_* value rather than leaking out raw.
+    ///
+    /// upstream: main.c:221 `wait_process_with_flush()` returns
+    /// `WEXITSTATUS(status)` raw; cleanup.c:150 propagates the worst raw code.
+    #[must_use]
+    pub const fn from_raw(value: i32) -> Self {
+        match Self::from_i32(value) {
+            Some(code) => code,
+            None => Self::Other(value),
         }
     }
 

--- a/crates/core/src/exit_code/tests.rs
+++ b/crates/core/src/exit_code/tests.rs
@@ -57,6 +57,32 @@ fn from_i32_returns_none_for_unknown() {
 }
 
 #[test]
+fn from_raw_preserves_unknown_codes() {
+    // upstream: main.c:221 wait_process_with_flush() returns WEXITSTATUS raw.
+    // A recognized code keeps its named variant; anything else round-trips
+    // verbatim through ExitCode::Other so the raw value survives to
+    // process::exit and worst-wins comparisons.
+    assert_eq!(ExitCode::from_raw(23), ExitCode::PartialTransfer);
+    assert_eq!(ExitCode::from_raw(127), ExitCode::CommandNotFound);
+    assert_eq!(ExitCode::from_raw(255), ExitCode::Other(255));
+    assert_eq!(ExitCode::from_raw(42), ExitCode::Other(42));
+    assert_eq!(ExitCode::from_raw(200), ExitCode::Other(200));
+    assert_eq!(ExitCode::from_raw(42).as_i32(), 42);
+    assert_eq!(ExitCode::from_raw(255).as_i32(), 255);
+}
+
+#[test]
+fn other_renders_as_unexplained_error() {
+    // upstream: log.c:905 log_exit() - a code with no RERR_* name renders as
+    // "unexplained error" while keeping its raw value in the "(code N)" suffix.
+    assert_eq!(ExitCode::Other(42).description(), "unexplained error");
+    assert_eq!(ExitCode::Other(42).as_i32(), 42);
+    assert!(!ExitCode::Other(42).is_success());
+    assert!(!ExitCode::Other(42).is_fatal());
+    assert!(!ExitCode::Other(42).is_partial());
+}
+
+#[test]
 fn is_success_only_for_ok() {
     assert!(ExitCode::Ok.is_success());
     assert!(!ExitCode::Syntax.is_success());

--- a/crates/core/tests/ssh_transfer.rs
+++ b/crates/core/tests/ssh_transfer.rs
@@ -99,9 +99,15 @@ fn run_client_with_retry(config_fn: impl Fn() -> ClientConfig) -> Result<(), Cli
             Err(e) => {
                 let code = e.code();
                 // Only retry on transient connection failures.
+                // ssh exits 255 on a transient connection failure, which now
+                // propagates raw as ExitCode::Other(255) instead of the old
+                // collapsed CommandFailed (124).
                 let is_transient = matches!(
                     code,
-                    ExitCode::SocketIo | ExitCode::CommandFailed | ExitCode::Ipc
+                    ExitCode::SocketIo
+                        | ExitCode::CommandFailed
+                        | ExitCode::Ipc
+                        | ExitCode::Other(255)
                 );
                 if is_transient && attempt < MAX_SSH_RETRIES {
                     eprintln!(
@@ -330,11 +336,14 @@ fn ssh_command_not_found_exit_code() {
     });
 }
 
-/// Verify that SSH connection failure produces a connection-related exit code.
+/// Verify that SSH connection failure propagates ssh's raw exit code.
 ///
-/// Uses a deliberately unreachable host to trigger a connection timeout or
-/// refused error. The exit code should map to `CommandFailed` (124) or
-/// `SocketIo` (10).
+/// Uses a deliberately unreachable host to trigger a connection refused or
+/// timeout. ssh exits 255 on any connection failure, which upstream rsync
+/// propagates verbatim: the setup read hits EOF (RERR_STREAMIO = 12) and
+/// exit_cleanup() takes the worst of that base and ssh's raw 255
+/// (main.c:194 wait_process_with_flush, cleanup.c:150). The result must be
+/// 255, not the old collapsed RERR_CMD_FAILED (124).
 #[test]
 fn ssh_connection_failure_exit_code() {
     run_with_timeout(SSH_TIMEOUT, || {
@@ -367,14 +376,13 @@ fn ssh_connection_failure_exit_code() {
 
         let err = result.expect_err("transfer to unreachable host should fail");
         let code = err.code().as_i32();
-        // SSH connection failure can surface as CommandFailed (124 - exit 255 from ssh),
-        // SocketIo (10), Ipc (14), or StartClient (5).
+        // upstream: ssh exits 255 on any connection failure; that raw code wins
+        // the worst-wins comparison against the RERR_STREAMIO (12) EOF base and
+        // propagates verbatim. RERR_SOCKETIO (10) is accepted for the direct
+        // rsync:// TCP path when no ssh child is involved.
         assert!(
-            code == ExitCode::CommandFailed.as_i32()
-                || code == ExitCode::SocketIo.as_i32()
-                || code == ExitCode::Ipc.as_i32()
-                || code == ExitCode::StartClient.as_i32(),
-            "expected connection-failure exit code (124, 10, 14, or 5); got {code}: {err}"
+            code == ExitCode::Other(255).as_i32() || code == ExitCode::SocketIo.as_i32(),
+            "expected raw ssh connection-failure exit code (255 or 10); got {code}: {err}"
         );
     });
 }

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -106,6 +106,9 @@ impl ErrorCodification for DaemonError {
             ExitCode::CommandKilled => 22500,
             ExitCode::CommandRun => 22600,
             ExitCode::CommandNotFound => 22700,
+            // A raw child/remote status with no named RERR_* code; encode the
+            // raw value into a distinct diagnostic range.
+            ExitCode::Other(code) => 910_000u32.wrapping_add(code as u32),
         }
     }
 
@@ -142,6 +145,8 @@ impl ErrorCodification for DaemonError {
             ExitCode::CommandKilled => "RERR_CMD_KILLED",
             ExitCode::CommandRun => "RERR_CMD_RUN",
             ExitCode::CommandNotFound => "RERR_CMD_NOTFOUND",
+            // upstream: log.c:905 - an unrecognized code has no RERR_* name.
+            ExitCode::Other(_) => "RERR_UNKNOWN",
         }
     }
 }


### PR DESCRIPTION
## Problem

Child and remote process exit codes were collapsed onto the named `ExitCode` enum, so any status with no `RERR_*` mapping was lost. Verified divergences vs rsync 3.4.4:

| Case | upstream | oc (before) |
|------|----------|-------------|
| ssh connection failure (255) | 255 | 124 (`RERR_CMD_FAILED`) |
| arbitrary remote exit (42) | 42 | 23 (`RERR_PARTIAL`) |
| signal death | 16 (`RERR_TERMINATED`) | 125 (`RERR_CMD_KILLED`) |
| core dump | 15 (`RERR_CRASHED`) | 125 |

The lossy `ExitCode` enum had no representation for a raw child code, and the SSH handshake-failure path returned exit 5 without ever consulting the child's status.

## Fix

- Add `ExitCode::Other(i32)` to preserve an unrecognized raw status; `as_i32()` returns it verbatim so worst-wins MAX still works on raw `i32`.
- Add `ExitCode::from_raw()` used at the child/remote boundary. `from_i32()` keeps its `Option` "is this a known RERR code?" semantics so internal error construction still falls back to a defined code rather than leaking a raw value.
- `map_child_exit_status` now mirrors `main.c:194 wait_process_with_flush`: `WEXITSTATUS` raw, core dump -> `RERR_CRASHED` (15), signal -> `RERR_TERMINATED` (16), failed `waitpid` -> `RERR_WAITCHILD` (21). Fixed a stale `main.c:1591` citation.
- SSH handshake-failure path reaps the child and takes the worst of the `RERR_STREAMIO` (12) EOF base and the child's raw status (`cleanup.c:150`).

## Verification

Byte-for-byte exit-code comparison against rsync 3.4.4:

| remote exit | upstream | oc (after) |
|-------------|----------|------------|
| 0 / 1 / 2 / 5 | 12 | 12 |
| 13 | 13 | 13 |
| 23 | 23 | 23 |
| 42 | 42 | 42 |
| 99 | 99 | 99 |
| 127 | 127 | 127 |
| 200 | 200 | 200 |
| 255 | 255 | 255 |
| closed rsync:// port | 10 | 10 |

All match exactly. `fmt` + `clippy -D warnings` clean; targeted core/daemon exit-code tests pass.