### PR TITLE
docs(rsync_io): prune decorative divider comments

### DIFF
--- a/crates/rsync_io/src/ssh/embedded/connect.rs
+++ b/crates/rsync_io/src/ssh/embedded/connect.rs
@@ -591,9 +591,7 @@ mod tests {
         assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::BrokenPipe);
     }
 
-    // -----------------------------------------------------------------------
     // Tests for optimized client config construction.
-    // -----------------------------------------------------------------------
 
     #[test]
     fn build_client_config_enables_nodelay() {

--- a/crates/rsync_io/src/ssh/embedded/sync_bridge.rs
+++ b/crates/rsync_io/src/ssh/embedded/sync_bridge.rs
@@ -672,7 +672,6 @@ mod tests {
         assert!(received.is_none(), "sender drop should close the channel");
     }
 
-    // -----------------------------------------------------------------------
     // Wire-byte parity: SyncAsyncBridge (async-native) vs channel-pump
     // (spawn_blocking) bridging strategies (RUSSH-12).
     //
@@ -680,7 +679,6 @@ mod tests {
     // These tests verify that the bytes observed on the sync side are
     // identical regardless of which bridge is used, for payloads ranging
     // from trivial to multi-chunk.
-    // -----------------------------------------------------------------------
 
     /// Sends `payload` through the `SyncAsyncBridge` path and returns the
     /// bytes the sync reader observes after a round-trip through an echo


### PR DESCRIPTION
## Summary

Comment-cleanup pass on the `rsync_io` crate (the former `transport` crate; renamed to mirror upstream `io.c`).

The crate already enforces `#![deny(missing_docs)]`, so every public type, trait, function, and method carries rustdoc, and prior documentation passes had already cleaned the bulk of the inline comments. This pass audited the whole crate for comment noise and found it clean apart from decorative dashed-line dividers wrapping two test-section headers.

## Changes

- Removed the pure `// ----` divider lines around test-section labels in `ssh/embedded/connect.rs` and `ssh/embedded/sync_bridge.rs`.
- Preserved the informative label text, including the RUSSH-12 wire-byte-parity rationale.

## Preserved

- All timeout, back-pressure, exit-code, and SSH process-management rationale comments (watchdog wake/join, zombie prevention, EOF handling, blocking-I/O unblocking).
- Upstream-reference comments.

## Verification

- Diff is comment-only (4 deleted lines); no code, signature, or behavior change.
- `cargo fmt --all` clean.
- `cargo clippy -p rsync_io --all-targets --all-features --no-deps -- -D warnings`: no issues.
- `cargo check -p rsync_io --all-features`: clean.