### PR TITLE
fix(daemon): don't send @RSYNCD: EXIT after @ERROR

### DIFF
--- a/crates/daemon/src/daemon/async_session/session.rs
+++ b/crates/daemon/src/daemon/async_session/session.rs
@@ -201,11 +201,12 @@ pub(super) async fn handle_async_session(
 
     // Async path only emits an `@ERROR:` placeholder for now; full module
     // handling lives in the sync `legacy_session` path.
+    // upstream: clientserver.c:381-385 - the client treats `@ERROR` as fatal
+    // and returns before reading further, so no `@RSYNCD: EXIT` follows.
     let error_msg = "@ERROR: daemon functionality limited in async mode\n";
     writer.write_all(error_msg.as_bytes()).await?;
-    writer.write_all(b"@RSYNCD: EXIT\n").await?;
     writer.flush().await?;
-    bytes_sent += error_msg.len() as u64 + 14;
+    bytes_sent += error_msg.len() as u64;
 
     #[cfg(feature = "concurrent-sessions")]
     {

--- a/crates/daemon/src/daemon/sections/module_access/authentication.rs
+++ b/crates/daemon/src/daemon/sections/module_access/authentication.rs
@@ -54,7 +54,7 @@ fn perform_module_authentication(
     let response = if let Some(line) = read_trimmed_line(reader)? {
         line
     } else {
-        send_auth_failed(reader.get_mut(), module, limiter, messages)?;
+        send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied);
     };
 
@@ -65,26 +65,26 @@ fn perform_module_authentication(
     });
 
     if username.is_empty() || digest.is_empty() {
-        send_auth_failed(reader.get_mut(), module, limiter, messages)?;
+        send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied);
     }
 
     let auth_user = match module.get_auth_user(username) {
         Some(user) => user,
         None => {
-            send_auth_failed(reader.get_mut(), module, limiter, messages)?;
+            send_auth_failed(reader.get_mut(), module, limiter)?;
             return Ok(AuthenticationStatus::Denied);
         }
     };
 
     if !verify_secret_response(module, username, &challenge, digest, protocol_version)? {
-        send_auth_failed(reader.get_mut(), module, limiter, messages)?;
+        send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied);
     }
 
     // Check for explicit deny access level
     if auth_user.access_level == UserAccessLevel::Deny {
-        send_auth_failed(reader.get_mut(), module, limiter, messages)?;
+        send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied);
     }
 
@@ -208,9 +208,8 @@ fn send_auth_failed(
     stream: &mut DaemonStream,
     module: &ModuleDefinition,
     limiter: &mut Option<BandwidthLimiter>,
-    messages: &LegacyMessageCache,
 ) -> io::Result<()> {
     let module_display = sanitize_module_identifier(&module.name);
     let payload = AUTH_FAILED_PAYLOAD.replace("{module}", module_display.as_ref());
-    send_error_and_exit(stream, limiter, messages, &payload)
+    send_error(stream, limiter, &payload)
 }

--- a/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
@@ -209,7 +209,7 @@ fn read_and_log_client_args(
         Ok(args) => args,
         Err(err) => {
             let payload = format!("@ERROR: failed to read client arguments: {err}");
-            send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+            send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
             return Ok(None);
         }
     };
@@ -250,7 +250,7 @@ fn read_and_log_client_args(
             Ok(full_args) => merge_secluded_args(phase1_args, full_args),
             Err(err) => {
                 let payload = format!("@ERROR: failed to read secluded args: {err}");
-                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
                 return Ok(None);
             }
         }

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -95,7 +95,7 @@ fn build_server_config(
             None => {
                 let payload =
                     "@ERROR: requested path resolves outside module root".to_owned();
-                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
                 return Ok(None);
             }
         }
@@ -108,7 +108,7 @@ fn build_server_config(
             None => {
                 let payload =
                     "@ERROR: requested path resolves outside module root".to_owned();
-                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
                 return Ok(None);
             }
         }
@@ -143,7 +143,7 @@ fn build_server_config(
                 }
                 let payload =
                     format!("@ERROR: {offender}: unrecognized option (in daemon mode)");
-                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
                 return Ok(None);
             }
 
@@ -248,10 +248,9 @@ fn build_server_config(
                 }
                 Err(err) => {
                     let payload = format!("@ERROR: {err}");
-                    send_error_and_exit(
+                    send_error(
                         ctx.reader.get_mut(),
                         ctx.limiter,
-                        ctx.messages,
                         &payload,
                     )?;
                     return Ok(None);
@@ -269,7 +268,7 @@ fn build_server_config(
         }
         Err(err) => {
             let payload = format!("@ERROR: failed to configure server: {err}");
-            send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+            send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
             Ok(None)
         }
     }

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -47,7 +47,14 @@ impl<'a> ModuleRequestContext<'a> {
     }
 }
 
-/// Sends an error message and exit marker to the client.
+/// Sends a fatal `@ERROR:` refusal line to the client and closes the session.
+///
+/// Writes exactly `<payload>\n` and nothing more. Upstream never follows an
+/// `@ERROR:` line with `@RSYNCD: EXIT`: the client treats `@ERROR` as fatal
+/// and returns immediately without reading further
+/// (upstream: clientserver.c:381-385 - `strncmp(line, "@ERROR", 6) == 0` ->
+/// `return -1`), so the server just emits the line and lets the socket close.
+/// Only the successful module-listing path emits `@RSYNCD: EXIT`.
 ///
 /// This is the pre-handshake form: the daemon has not yet emitted
 /// `@RSYNCD: OK` so the client still reads raw `@RSYNCD:`-style text.
@@ -55,15 +62,13 @@ impl<'a> ModuleRequestContext<'a> {
 /// and any further raw bytes are mis-parsed as multiplex frame headers
 /// (e.g. the 'T' of "The server..." surfaces as `unexpected tag 77`).
 /// Use [`send_multiplexed_error_and_exit`] once OK has been written.
-fn send_error_and_exit(
+fn send_error(
     stream: &mut DaemonStream,
     limiter: &mut Option<BandwidthLimiter>,
-    messages: &LegacyMessageCache,
     payload: &str,
 ) -> io::Result<()> {
     write_limited(stream, limiter, payload.as_bytes())?;
     write_limited(stream, limiter, b"\n")?;
-    messages.write_exit(stream, limiter)?;
     stream.flush()
 }
 
@@ -111,7 +116,6 @@ fn deny_module(
     peer_ip: IpAddr,
     host: Option<&str>,
     limiter: &mut Option<BandwidthLimiter>,
-    messages: &LegacyMessageCache,
 ) -> io::Result<()> {
     let module_display = sanitize_module_identifier(&module.name);
     let payload = if !module.listable {
@@ -125,7 +129,7 @@ fn deny_module(
             .replace("{host}", host_display)
             .replace("{addr}", &addr_str)
     };
-    send_error_and_exit(stream, limiter, messages, &payload)
+    send_error(stream, limiter, &payload)
 }
 
 /// Sends the "@RSYNCD: OK" acknowledgment to the client.
@@ -150,7 +154,7 @@ fn handle_max_connections_exceeded(
     limit: NonZeroU32,
 ) -> io::Result<()> {
     let payload = MODULE_MAX_CONNECTIONS_PAYLOAD.replace("{limit}", &limit.get().to_string());
-    send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
     if let Some(log) = ctx.log_sink {
         let current = module
             .active_connections
@@ -171,10 +175,9 @@ fn handle_max_connections_exceeded(
 ///
 /// Sends an error message and logs the lock failure.
 fn handle_lock_error(ctx: &mut ModuleRequestContext<'_>, error: &io::Error) -> io::Result<()> {
-    send_error_and_exit(
+    send_error(
         ctx.reader.get_mut(),
         ctx.limiter,
-        ctx.messages,
         MODULE_LOCK_ERROR_PAYLOAD,
     )?;
     if let Some(log) = ctx.log_sink {
@@ -190,7 +193,7 @@ fn handle_lock_error(ctx: &mut ModuleRequestContext<'_>, error: &io::Error) -> i
 /// `@RSYNCD: OK`; at this point the client still reads raw text.
 fn handle_refused_option(ctx: &mut ModuleRequestContext<'_>, refused: &str) -> io::Result<()> {
     let payload = format!("@ERROR: The server is configured to refuse {refused}");
-    send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
     if let Some(log) = ctx.log_sink {
         log_module_refused_option(log, ctx.effective_host(), ctx.peer_ip, ctx.request, refused);
     }
@@ -436,7 +439,6 @@ fn handle_authentication(
 fn handle_unknown_module(
     stream: &mut DaemonStream,
     limiter: &mut Option<BandwidthLimiter>,
-    messages: &LegacyMessageCache,
     request: &str,
     peer_ip: IpAddr,
     session_peer_host: Option<&str>,
@@ -449,7 +451,7 @@ fn handle_unknown_module(
         log_unknown_module(log, session_peer_host, peer_ip, request);
     }
 
-    send_error_and_exit(stream, limiter, messages, &payload)
+    send_error(stream, limiter, &payload)
 }
 
 /// Handles a denied module access.
@@ -469,7 +471,6 @@ fn handle_module_denied(
         ctx.peer_ip,
         host,
         ctx.limiter,
-        ctx.messages,
     )
 }
 
@@ -504,7 +505,6 @@ fn respond_with_module_request(
         return handle_unknown_module(
             reader.get_mut(),
             limiter,
-            messages,
             request,
             peer_ip,
             session_peer_host,

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -41,7 +41,7 @@ fn process_approved_module(
                 Ok(()) => {}
                 Err(err) => {
                     let payload = format!("@ERROR: invalid daemon param: {err}");
-                    send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
                     return Ok(());
                 }
             }
@@ -94,7 +94,7 @@ fn process_approved_module(
                 }
                 Ok(Err(error_msg)) => {
                     let payload = format!("@ERROR: {error_msg}");
-                    send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
                     return Ok(());
                 }
                 Err(err) => {
@@ -102,7 +102,7 @@ fn process_approved_module(
                         "@ERROR: failed to run early exec command for module '{}': {err}",
                         ctx.request
                     );
-                    send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
                     return Ok(());
                 }
             }
@@ -142,19 +142,17 @@ fn process_approved_module(
     // A read-only module must reject pushes; a write-only module must reject pulls.
     let role = determine_server_role(&client_args);
     if module.read_only && matches!(role, ServerRole::Receiver) {
-        send_error_and_exit(
+        send_error(
             ctx.reader.get_mut(),
             ctx.limiter,
-            ctx.messages,
             MODULE_READ_ONLY_PAYLOAD,
         )?;
         return Ok(());
     }
     if module.write_only && matches!(role, ServerRole::Generator) {
-        send_error_and_exit(
+        send_error(
             ctx.reader.get_mut(),
             ctx.limiter,
-            ctx.messages,
             MODULE_WRITE_ONLY_PAYLOAD,
         )?;
         return Ok(());
@@ -205,7 +203,7 @@ fn process_approved_module(
             Ok(nc) => Some(install_name_converter(nc)),
             Err(err) => {
                 let payload = format!("@ERROR: name-converter exec failed: {err}");
-                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
                 return Ok(());
             }
         }
@@ -238,7 +236,7 @@ fn process_approved_module(
         Ok(rules) => config.daemon_filter_rules = rules,
         Err(err) => {
             let payload = format!("@ERROR: failed to load module filter rules: {err}");
-            send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+            send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
             return Ok(());
         }
     }
@@ -361,7 +359,7 @@ fn process_approved_module(
                     write_limited(ctx.reader.get_mut(), ctx.limiter, b"\n")?;
                 }
                 let payload = format!("@ERROR: {}", err.message);
-                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
                 if let Some(log) = ctx.log_sink {
                     let message = rsync_error!(1, err.message).with_role(Role::Daemon);
                     log_message(log, &message);
@@ -374,7 +372,7 @@ fn process_approved_module(
                     ctx.request
                 );
                 let payload = format!("@ERROR: {error_msg}");
-                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
                 if let Some(log) = ctx.log_sink {
                     let message = rsync_error!(1, error_msg).with_role(Role::Daemon);
                     log_message(log, &message);

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -43,7 +43,7 @@ fn apply_privilege_restrictions_with_upstream_errors(
             } else {
                 CHROOT_FAILED_PAYLOAD
             };
-            send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, payload)?;
+            send_error(ctx.reader.get_mut(), ctx.limiter, payload)?;
             return Ok(false);
         }
     }
@@ -60,7 +60,7 @@ fn apply_privilege_restrictions_with_upstream_errors(
             } else {
                 SETGID_FAILED_PAYLOAD
             };
-            send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, payload)?;
+            send_error(ctx.reader.get_mut(), ctx.limiter, payload)?;
             return Ok(false);
         }
     }
@@ -84,7 +84,7 @@ fn validate_module_path(
         sanitize_module_identifier(ctx.request),
         module.path.display()
     );
-    send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+    send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
 
     if let Some(log) = ctx.log_sink {
         let text = format!(

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -206,7 +206,7 @@ fn setup_transfer_streams(
         Ok(s) => s,
         Err(err) => {
             let payload = format!("@ERROR: failed to clone stream: {err}");
-            send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+            send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
             return Ok(None);
         }
     };

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -780,26 +780,31 @@ fn refuse_emits_at_error_raw_pre_handshake() {
     // Pre-handshake path: client has not yet seen `@RSYNCD: OK`, so multiplex
     // IN has not started. The raw `@ERROR: ...\n` text is the correct wire
     // encoding here.
+    //
+    // Upstream emits exactly the `@ERROR: <msg>\n` line and nothing more: the
+    // client treats `@ERROR` as fatal and returns before reading further
+    // (upstream: clientserver.c:381-385 - `strncmp(line, "@ERROR", 6) == 0` ->
+    // `return -1`), so no trailing `@RSYNCD: EXIT` is sent. Matching that
+    // byte-for-byte matters because two interoperating tools must agree on the
+    // exact refusal wire bytes; a stray EXIT line is a divergence from upstream.
     let (mut stream, capture) = build_stdio_stream_with_capture();
     let mut limiter: Option<BandwidthLimiter> = None;
-    let messages = LegacyMessageCache::shared();
-    send_error_and_exit(
+    send_error(
         &mut stream,
         &mut limiter,
-        messages,
         "@ERROR: The server is configured to refuse --delete",
     )
     .expect("send pre-handshake error");
 
     let bytes = capture.lock().unwrap().clone();
     let text = String::from_utf8_lossy(&bytes);
-    assert!(
-        text.starts_with("@ERROR: The server is configured to refuse --delete\n"),
-        "pre-handshake refusal must be raw @ERROR text, got: {text:?}"
+    assert_eq!(
+        text, "@ERROR: The server is configured to refuse --delete\n",
+        "pre-handshake refusal must be exactly the raw @ERROR line with no trailing EXIT, got: {text:?}"
     );
     assert!(
-        text.contains("@RSYNCD: EXIT"),
-        "pre-handshake refusal must end with @RSYNCD: EXIT, got: {text:?}"
+        !text.contains("@RSYNCD: EXIT"),
+        "upstream never follows @ERROR with @RSYNCD: EXIT, got: {text:?}"
     );
 }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -160,9 +160,10 @@
 //! line.clear();
 //! reader.read_line(&mut line)?;
 //! assert!(line.starts_with("@ERROR:"));
+//! // Upstream never follows @ERROR with @RSYNCD: EXIT: the client treats
+//! // @ERROR as fatal (clientserver.c:381-385), so the socket just closes.
 //! line.clear();
-//! reader.read_line(&mut line)?;
-//! assert_eq!(line, "@RSYNCD: EXIT\n");
+//! assert_eq!(reader.read_line(&mut line)?, 0);
 //!
 //! handle.join().expect("thread").expect("daemon run succeeds");
 //! # Ok(())

--- a/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
+++ b/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
@@ -92,32 +92,38 @@ fn daemon_error_payloads_match_upstream_wording() {
     );
 }
 
-/// Verifies that `send_error_and_exit` writes the payload followed by `\n`
-/// and then `@RSYNCD: EXIT\n`, matching upstream's protocol framing.
+/// Verifies that `send_error` writes exactly the payload followed by `\n`
+/// and nothing more, matching upstream's protocol framing.
 ///
 /// upstream: every `io_printf(f_out, "@ERROR: ...\n")` in clientserver.c is
-/// followed by `return -1` which triggers `send_listing` -> `@RSYNCD: EXIT\n`
-/// on the server side, and the client treats `@ERROR` as fatal.
+/// followed by `return -1`; the server then closes the socket without emitting
+/// `@RSYNCD: EXIT`. The client treats `@ERROR` as fatal and returns before
+/// reading further (clientserver.c:381-385), so a trailing EXIT is a
+/// divergence from upstream. Only the successful module-listing path sends
+/// `@RSYNCD: EXIT`.
 #[test]
-fn send_error_and_exit_framing_matches_upstream() {
+fn send_error_framing_matches_upstream() {
     use crate::daemon::UNKNOWN_MODULE_PAYLOAD;
 
     // Build a concrete payload from the template.
     let payload = UNKNOWN_MODULE_PAYLOAD.replace("{module}", "testmod");
     assert_eq!(payload, "@ERROR: Unknown module 'testmod'");
 
-    // Verify the framing invariant: payload + "\n" + "@RSYNCD: EXIT\n"
-    // The send_error_and_exit function writes:
+    // Verify the framing invariant: payload + "\n", with no trailing EXIT.
+    // The send_error function writes:
     //   1. payload bytes
     //   2. b"\n"
-    //   3. @RSYNCD: EXIT (via messages.write_exit)
-    //   4. flush
+    //   3. flush
     // This matches upstream's io_printf(f_out, "@ERROR: ...\n") followed by
-    // the EXIT marker sent when start_daemon/rsync_module returns -1.
+    // a socket close (no EXIT marker) when start_daemon/rsync_module returns -1.
     let expected_wire = format!("{payload}\n");
     assert!(expected_wire.starts_with("@ERROR: "));
     assert!(expected_wire.ends_with('\n'));
     assert!(!expected_wire.ends_with("\n\n"), "must not double-terminate");
+    assert!(
+        !expected_wire.contains("@RSYNCD: EXIT"),
+        "refusal wire must not contain a trailing EXIT marker"
+    );
 }
 
 /// Verifies that `deny_module` for non-listable modules sends

--- a/crates/daemon/src/tests/chunks/daemon_max_connections_wire_bytes_match_upstream.rs
+++ b/crates/daemon/src/tests/chunks/daemon_max_connections_wire_bytes_match_upstream.rs
@@ -30,7 +30,7 @@ fn daemon_max_connections_wire_bytes_match_upstream() {
     // Pin the exact wire bytes (template + concrete limit + trailing
     // newline) the daemon writes to the socket. The newline is part of
     // upstream's `io_printf` format and is appended by both call sites:
-    //   - per-module: `send_error_and_exit` writes `payload` then `\n`.
+    //   - per-module: `send_error` writes `payload` then `\n`.
     //   - global cap: `format!("... ({limit}) ... later\n")`.
     let cases: &[(u32, &[u8])] = &[
         (

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
@@ -48,10 +48,12 @@ fn daemon_negotiation_error_unknown_module() {
         "Expected unknown module error, got: {line}"
     );
 
-    // Should receive EXIT
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
@@ -403,8 +405,13 @@ fn daemon_negotiation_error_sanitizes_module_name_in_response() {
 }
 
 #[test]
-fn daemon_negotiation_error_sends_exit_after_error() {
-    // Verify that EXIT is sent after error messages.
+fn daemon_negotiation_error_no_exit_after_error() {
+    // Verify that no `@RSYNCD: EXIT` follows an `@ERROR:` refusal. Upstream
+    // sends only the `@ERROR: <msg>\n` line and closes the socket: the client
+    // treats `@ERROR` as fatal and returns before reading further
+    // (upstream: clientserver.c:381-385 - `strncmp(line, "@ERROR", 6) == 0`
+    // -> `return -1`). A trailing EXIT would be a byte-level divergence from
+    // upstream that two interoperating tools must not exhibit.
     let _lock = ENV_LOCK.lock().expect("env lock");
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
@@ -442,12 +449,17 @@ fn daemon_negotiation_error_sends_exit_after_error() {
     reader.read_line(&mut line).expect("error");
     assert!(line.contains("@ERROR:"), "Expected error, got: {line}");
 
-    // Read EXIT
+    // No `@RSYNCD: EXIT` follows: the daemon closes the socket, so the next
+    // read returns EOF (zero bytes) with no further wire text.
     line.clear();
-    reader.read_line(&mut line).expect("exit");
+    let read = reader.read_line(&mut line).expect("eof after error");
     assert_eq!(
-        line, "@RSYNCD: EXIT\n",
-        "Expected EXIT after error, got: {line}"
+        read, 0,
+        "upstream sends only the @ERROR line then closes; got trailing bytes: {line:?}"
+    );
+    assert!(
+        !line.contains("@RSYNCD: EXIT"),
+        "upstream never follows @ERROR with @RSYNCD: EXIT, got: {line:?}"
     );
 
     drop(reader);

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
@@ -58,10 +58,12 @@ fn daemon_negotiation_error_host_allow_blocks_unlisted() {
         "Expected access denied when hosts allow does not include loopback, got: {line}"
     );
 
-    // Should receive EXIT
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/daemon_per_module_cap_wire_bytes_match_global_path.rs
+++ b/crates/daemon/src/tests/chunks/daemon_per_module_cap_wire_bytes_match_global_path.rs
@@ -8,7 +8,7 @@
 //
 //   - per-module path (`module_access/request.rs:99`) - substitutes
 //     `{limit}` into `MODULE_MAX_CONNECTIONS_PAYLOAD` and relies on
-//     `send_error_and_exit` to append the trailing `\n`.
+//     `send_error` to append the trailing `\n`.
 //   - daemon-global path (`server_runtime/connection.rs:135`) - uses
 //     `format!("@ERROR: max connections ({limit}) reached -- try again later\n")`
 //     inline.
@@ -28,7 +28,7 @@ fn daemon_per_module_cap_wire_bytes_match_global_path() {
     for &limit in cases {
         // Per-module path: template substitution + appended newline,
         // mirroring `handle_max_connections_exceeded` +
-        // `send_error_and_exit` in `module_access/request.rs`.
+        // `send_error` in `module_access/request.rs`.
         let mut per_module = crate::daemon::MODULE_MAX_CONNECTIONS_PAYLOAD
             .replace("{limit}", &limit.to_string())
             .into_bytes();

--- a/crates/daemon/src/tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs
+++ b/crates/daemon/src/tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs
@@ -75,9 +75,12 @@ fn daemon_pre_xfer_exec_rejects_on_nonzero_exit() {
         "expected stderr content in error, got: {line}"
     );
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
@@ -100,9 +100,12 @@ fn run_daemon_auth_failure_rejects_wrong_credentials() {
         "@ERROR: auth failed on module protected"
     );
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
@@ -59,9 +59,12 @@ fn run_daemon_denies_module_when_host_not_allowed() {
         "Expected upstream-format access denied message, got: {trimmed}"
     );
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
@@ -92,11 +92,14 @@ fn run_daemon_enforces_module_connection_limit() {
         "@ERROR: max connections (1) reached -- try again later"
     );
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so no @RSYNCD: EXIT follows the refusal;
+    // the socket just closes (next read is EOF).
     line.clear();
-    second_reader
+    let read = second_reader
         .read_line(&mut line)
-        .expect("second exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+        .expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     first_stream
         .write_all(b"\n")
@@ -111,11 +114,14 @@ fn run_daemon_enforces_module_connection_limit() {
     // "@ERROR: auth failed on module %s\n"
     assert!(line.starts_with("@ERROR: auth failed on module"));
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so no @RSYNCD: EXIT follows the refusal;
+    // the socket just closes (next read is EOF).
     line.clear();
-    first_reader
+    let read = first_reader
         .read_line(&mut line)
-        .expect("first exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+        .expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(second_reader);
     drop(second_stream);

--- a/crates/daemon/src/tests/chunks/run_daemon_handles_parallel_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_handles_parallel_sessions.rs
@@ -45,9 +45,12 @@ fn run_daemon_handles_parallel_sessions() {
             reader.read_line(&mut line).expect("error message");
             assert!(line.starts_with("@ERROR:"));
 
+            // upstream: clientserver.c:381-385 - the client treats @ERROR as
+            // fatal and returns before reading further, so no @RSYNCD: EXIT
+            // follows the refusal; the socket just closes (next read is EOF).
             line.clear();
-            reader.read_line(&mut line).expect("exit message");
-            assert_eq!(line, "@RSYNCD: EXIT\n");
+            let read = reader.read_line(&mut line).expect("eof after error");
+            assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
         }));
     }
 

--- a/crates/daemon/src/tests/chunks/run_daemon_honours_max_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_honours_max_sessions.rs
@@ -43,9 +43,12 @@ fn run_daemon_honours_max_sessions() {
         reader.read_line(&mut line).expect("error message");
         assert!(line.starts_with("@ERROR:"));
 
+        // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal
+        // and returns before reading further, so no @RSYNCD: EXIT follows the
+        // refusal; the socket just closes (next read is EOF).
         line.clear();
-        reader.read_line(&mut line).expect("exit message");
-        assert_eq!(line, "@RSYNCD: EXIT\n");
+        let read = reader.read_line(&mut line).expect("eof after error");
+        assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
     }
 
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
@@ -30,8 +30,8 @@ fn run_daemon_panic_isolation_keeps_daemon_alive() {
     let daemon_handle = thread::spawn(move || run_daemon(config));
 
     // The daemon reads the greeting it sent, parses the garbage as a module
-    // name, replies with @ERROR: and @RSYNCD: EXIT, then keeps the accept
-    // loop running because catch_unwind isolates per-connection errors.
+    // name, replies with @ERROR: and closes the connection, then keeps the
+    // accept loop running because catch_unwind isolates per-connection errors.
     {
         let mut bad = connect_with_retries(port);
         let mut bad_reader = BufReader::new(bad.try_clone().expect("clone bad stream"));
@@ -44,19 +44,20 @@ fn run_daemon_panic_isolation_keeps_daemon_alive() {
 
         // Send an ASCII garbage line in place of a valid @RSYNCD: response.
         // The daemon will interpret this as a module request, discover no
-        // such module exists, and reply with @ERROR: + @RSYNCD: EXIT.
+        // such module exists, reply with @ERROR:, and close the connection.
         bad.write_all(b"NOT_A_VALID_RSYNCD_LINE\n")
             .expect("send garbage line");
         bad.flush().expect("flush garbage");
 
         // Drain the daemon response so the worker thread finishes before
-        // the second connection arrives.
+        // the second connection arrives. Upstream sends only the @ERROR line
+        // then closes (clientserver.c:381-385), so the drain ends at EOF.
         discard.clear();
         loop {
             let n = bad_reader
                 .read_line(&mut discard)
                 .expect("read daemon response to garbage");
-            if n == 0 || discard.contains("@RSYNCD: EXIT") {
+            if n == 0 {
                 break;
             }
             discard.clear();
@@ -98,11 +99,14 @@ fn run_daemon_panic_isolation_keeps_daemon_alive() {
             "expected @ERROR: for unknown module, got: {line:?}"
         );
 
+        // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal
+        // and returns before reading further, so no @RSYNCD: EXIT follows the
+        // refusal; the socket just closes (next read is EOF).
         line.clear();
-        good_reader
+        let read = good_reader
             .read_line(&mut line)
-            .expect("exit from good connection");
-        assert_eq!(line, "@RSYNCD: EXIT\n");
+            .expect("eof after error from good connection");
+        assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
     } // good stream dropped here
 
     let result = daemon_handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs
@@ -114,11 +114,14 @@ fn run_daemon_per_module_cap_overrides_global_max_connections() {
         "@ERROR: max connections (1) reached -- try again later",
     );
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so no @RSYNCD: EXIT follows the refusal;
+    // the socket just closes (next read is EOF).
     line.clear();
-    second_reader
+    let read = second_reader
         .read_line(&mut line)
-        .expect("second exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+        .expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     first_stream
         .write_all(b"\n")
@@ -131,11 +134,14 @@ fn run_daemon_per_module_cap_overrides_global_max_connections() {
         .expect("first denial message");
     assert!(line.starts_with("@ERROR: auth failed on module"));
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so no @RSYNCD: EXIT follows the refusal;
+    // the socket just closes (next read is EOF).
     line.clear();
-    first_reader
+    let read = first_reader
         .read_line(&mut line)
-        .expect("first exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+        .expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(second_reader);
     drop(second_stream);

--- a/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
@@ -53,9 +53,12 @@ fn run_daemon_records_log_file_entries() {
     reader.read_line(&mut line).expect("module response");
     assert!(line.starts_with("@ERROR:"));
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit line");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     // Bound the join: on Windows the daemon accept loop can linger past the

--- a/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
@@ -55,9 +55,12 @@ fn run_daemon_refuses_disallowed_module_options() {
         "@ERROR: The server is configured to refuse --compress",
     );
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
@@ -72,9 +72,12 @@ fn run_daemon_rejects_push_to_default_read_only_module() {
     reader.read_line(&mut line).expect("error message");
     assert_eq!(line.trim_end(), "@ERROR: module is read only");
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
@@ -71,9 +71,12 @@ fn run_daemon_rejects_push_to_read_only_module() {
     reader.read_line(&mut line).expect("error message");
     assert_eq!(line.trim_end(), "@ERROR: module is read only");
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
@@ -80,9 +80,12 @@ fn run_daemon_requests_authentication_for_protected_module() {
         "@ERROR: auth failed on module secure"
     );
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_serves_single_legacy_connection.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_serves_single_legacy_connection.rs
@@ -35,9 +35,12 @@ fn run_daemon_serves_single_legacy_connection() {
     reader.read_line(&mut line).expect("error message");
     assert!(line.starts_with("@ERROR:"));
 
+    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
+    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
+    // the refusal; the socket just closes (next read is EOF).
     line.clear();
-    reader.read_line(&mut line).expect("exit message");
-    assert_eq!(line, "@RSYNCD: EXIT\n");
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/tests/connection_lifecycle_fsm.rs
+++ b/crates/daemon/tests/connection_lifecycle_fsm.rs
@@ -154,7 +154,8 @@ fn lifecycle_list_modules() {
 ///
 /// The daemon receives the version (Greeting -> ModuleSelect), then the
 /// client requests a non-existent module. The daemon sends @ERROR and
-/// @RSYNCD: EXIT, transitioning ModuleSelect -> Closing.
+/// closes with no @RSYNCD: EXIT (upstream clientserver.c:381-385: the client
+/// treats @ERROR as fatal), transitioning ModuleSelect -> Closing.
 #[test]
 fn lifecycle_unknown_module() {
     let (port, listener) = allocate_listener();
@@ -190,7 +191,10 @@ fn lifecycle_unknown_module() {
         }
     }
     assert!(saw_error, "daemon should send @ERROR for unknown module");
-    assert!(saw_exit, "daemon should send @RSYNCD: EXIT after error");
+    assert!(
+        !saw_exit,
+        "upstream sends no @RSYNCD: EXIT after @ERROR (clientserver.c:381)"
+    );
 
     drop(writer);
     drop(reader);
@@ -283,7 +287,7 @@ fn lifecycle_multiple_sequential_connections() {
         writer.write_all(module.as_bytes()).expect("send module");
         writer.flush().expect("flush module");
 
-        let mut saw_exit = false;
+        let mut saw_error = false;
         loop {
             let mut line = String::new();
             match reader.read_line(&mut line) {
@@ -291,12 +295,21 @@ fn lifecycle_multiple_sequential_connections() {
                 Err(_) => break,
                 Ok(_) => {}
             }
-            if line.trim() == "@RSYNCD: EXIT" {
-                saw_exit = true;
-                break;
+            if line.starts_with("@ERROR") {
+                saw_error = true;
             }
+            // upstream clientserver.c:381-385: the client treats @ERROR as fatal
+            // and returns, so the daemon sends no @RSYNCD: EXIT after a refusal.
+            assert_ne!(
+                line.trim(),
+                "@RSYNCD: EXIT",
+                "connection {i}: no @RSYNCD: EXIT after @ERROR"
+            );
         }
-        assert!(saw_exit, "connection {i}: daemon should send @RSYNCD: EXIT");
+        assert!(
+            saw_error,
+            "connection {i}: daemon should send @ERROR for unknown module"
+        );
 
         drop(writer);
         drop(reader);
@@ -354,7 +367,7 @@ fn lifecycle_max_connections_sequential_no_leak() {
         writer.write_all(module.as_bytes()).expect("send module");
         writer.flush().expect("flush module");
 
-        let mut saw_exit = false;
+        let mut saw_error = false;
         loop {
             let mut line = String::new();
             match reader.read_line(&mut line) {
@@ -362,12 +375,21 @@ fn lifecycle_max_connections_sequential_no_leak() {
                 Err(_) => break,
                 Ok(_) => {}
             }
-            if line.trim() == "@RSYNCD: EXIT" {
-                saw_exit = true;
-                break;
+            if line.starts_with("@ERROR") {
+                saw_error = true;
             }
+            // upstream clientserver.c:381-385: the client treats @ERROR as fatal
+            // and returns, so the daemon sends no @RSYNCD: EXIT after a refusal.
+            assert_ne!(
+                line.trim(),
+                "@RSYNCD: EXIT",
+                "connection {i}: no @RSYNCD: EXIT after @ERROR"
+            );
         }
-        assert!(saw_exit, "connection {i}: daemon should send @RSYNCD: EXIT");
+        assert!(
+            saw_error,
+            "connection {i}: daemon should send @ERROR for unknown module"
+        );
 
         drop(writer);
         drop(reader);


### PR DESCRIPTION
## Problem

oc's daemon appended `@RSYNCD: EXIT\n` after every `@ERROR: ...` refusal line. Upstream rsync never does this: the client treats `@ERROR` as fatal and returns before reading further (clientserver.c:381-385, `strncmp(line, "@ERROR", 6) == 0` -> `return -1`), so the server sends only the `@ERROR: <msg>` line and lets the socket close. The trailing EXIT is benign (the client ignores it) but is a byte-level divergence from upstream, and two interoperating tools must agree on the exact refusal wire bytes.

## Fix

- Removed the trailing `@RSYNCD: EXIT` from the shared refusal helper. Since it no longer exits, it is renamed `send_error_and_exit` -> `send_error`, and the now-dead `LegacyMessageCache` argument is dropped from it and its callers (`deny_module`, `handle_unknown_module`, `send_auth_failed`).
- All pre-handshake refusals now send exactly `@ERROR: <msg>\n` and close: unknown module, access denied, auth failure, max connections (per-module and global already omitted EXIT), lock failure, refused options, and read-only/write-only rejections.
- The successful module-listing path still emits `@RSYNCD: EXIT` (unchanged).
- The async placeholder path was aligned to the same behaviour.

## Tests

Updated the affected daemon tests (unit + integration) to assert the upstream-correct bytes: exactly the `@ERROR:` line followed by EOF (socket close), with no trailing EXIT. Each test encodes why (upstream sends only `@ERROR` then closes; the client treats `@ERROR` as fatal). Listing-path EXIT assertions are untouched.

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`: clean
- Targeted daemon nextest (refusal + listing paths): 21 tests passed
- Daemon doctests: pass