### PR TITLE
refactor(compress): single source for default skip-compress suffixes

### DIFF
--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -89,7 +89,7 @@ pub mod zstd;
 pub use common::CountingSink;
 pub use skip_compress::{
     AdaptiveCompressor, CompressionDecider, CompressionDecision, DEFAULT_COMPRESSION_THRESHOLD,
-    DEFAULT_SAMPLE_SIZE, FileCategory, Suffix,
+    DEFAULT_SAMPLE_SIZE, DEFAULT_SKIP_COMPRESS_SUFFIXES, FileCategory, Suffix,
 };
 #[cfg(feature = "lz4")]
 pub use strategy::Lz4Strategy;

--- a/crates/compress/src/skip_compress/defaults.rs
+++ b/crates/compress/src/skip_compress/defaults.rs
@@ -17,9 +17,13 @@ use super::Suffix;
 /// Upstream default suffixes that skip compression.
 ///
 /// This is the exact set from upstream `default-dont-compress.h`
-/// (`DEFAULT_DONT_COMPRESS`), stored without the leading `*.` and lowercased to
-/// match upstream's case-insensitive suffix comparison.
-const DEFAULT_DONT_COMPRESS: &[&str] = &[
+/// (`DEFAULT_DONT_COMPRESS`, generated from the `--skip-compress` default list
+/// documented in `rsync.1.md`; loaded via `token.c:init_set_compression()`),
+/// stored without the leading `*.` and lowercased to match upstream's
+/// case-insensitive suffix comparison. This is the single source of truth for
+/// the default skip-compress suffixes across the workspace - other crates
+/// reference this const rather than maintaining their own copy.
+pub const DEFAULT_SKIP_COMPRESS_SUFFIXES: &[&str] = &[
     "3g2", "3gp", "7z", "aac", "ace", "apk", "avi", "bz2", "deb", "dmg", "ear", "f4v", "flac",
     "flv", "gpg", "gz", "iso", "jar", "jpeg", "jpg", "lrz", "lz", "lz4", "lzma", "lzo", "m1a",
     "m1v", "m2a", "m2ts", "m2v", "m4a", "m4b", "m4p", "m4r", "m4v", "mka", "mkv", "mov", "mp1",
@@ -36,8 +40,8 @@ const DEFAULT_DONT_COMPRESS: &[&str] = &[
 /// upstream `DEFAULT_DONT_COMPRESS` set.
 #[must_use]
 pub fn default_skip_extensions() -> HashSet<Suffix> {
-    let mut set = HashSet::with_capacity(DEFAULT_DONT_COMPRESS.len());
-    for ext in DEFAULT_DONT_COMPRESS {
+    let mut set = HashSet::with_capacity(DEFAULT_SKIP_COMPRESS_SUFFIXES.len());
+    for ext in DEFAULT_SKIP_COMPRESS_SUFFIXES {
         set.insert(Suffix::new(ext));
     }
     set
@@ -55,9 +59,9 @@ mod tests {
         let exts = default_skip_extensions();
         assert_eq!(
             exts.len(),
-            DEFAULT_DONT_COMPRESS.len(),
-            "default skip set must equal upstream DEFAULT_DONT_COMPRESS ({} suffixes)",
-            DEFAULT_DONT_COMPRESS.len(),
+            DEFAULT_SKIP_COMPRESS_SUFFIXES.len(),
+            "default skip set must equal upstream DEFAULT_SKIP_COMPRESS_SUFFIXES ({} suffixes)",
+            DEFAULT_SKIP_COMPRESS_SUFFIXES.len(),
         );
     }
 
@@ -66,7 +70,7 @@ mod tests {
     #[test]
     fn default_set_contains_every_upstream_suffix() {
         let exts = default_skip_extensions();
-        for expected in DEFAULT_DONT_COMPRESS {
+        for expected in DEFAULT_SKIP_COMPRESS_SUFFIXES {
             assert!(
                 exts.contains(*expected),
                 "missing upstream suffix: {expected}"
@@ -86,7 +90,7 @@ mod tests {
         ] {
             assert!(
                 !exts.contains(*unexpected),
-                "suffix {unexpected} is not in upstream DEFAULT_DONT_COMPRESS and must not be skipped",
+                "suffix {unexpected} is not in upstream DEFAULT_SKIP_COMPRESS_SUFFIXES and must not be skipped",
             );
         }
     }

--- a/crates/compress/src/skip_compress/mod.rs
+++ b/crates/compress/src/skip_compress/mod.rs
@@ -55,6 +55,7 @@ mod types;
 
 pub use adaptive::AdaptiveCompressor;
 pub use decider::CompressionDecider;
+pub use defaults::DEFAULT_SKIP_COMPRESS_SUFFIXES;
 pub use magic::{KNOWN_SIGNATURES, MagicSignature};
 pub use types::{CompressionDecision, FileCategory, Suffix};
 

--- a/crates/engine/src/local_copy/skip_compress.rs
+++ b/crates/engine/src/local_copy/skip_compress.rs
@@ -1,18 +1,7 @@
 use std::path::Path;
 
+use compress::DEFAULT_SKIP_COMPRESS_SUFFIXES;
 use thiserror::Error;
-
-/// Default suffixes that should not be compressed when compression is enabled.
-const DEFAULT_SKIP_SUFFIXES: &[&str] = &[
-    "3g2", "3gp", "7z", "aac", "ace", "apk", "avi", "bz2", "deb", "dmg", "ear", "f4v", "flac",
-    "flv", "gpg", "gz", "iso", "jar", "jpeg", "jpg", "lrz", "lz", "lz4", "lzma", "lzo", "m1a",
-    "m1v", "m2a", "m2ts", "m2v", "m4a", "m4b", "m4p", "m4r", "m4v", "mka", "mkv", "mov", "mp1",
-    "mp2", "mp3", "mp4", "mpa", "mpeg", "mpg", "mpv", "mts", "odb", "odf", "odg", "odi", "odm",
-    "odp", "ods", "odt", "oga", "ogg", "ogm", "ogv", "ogx", "opus", "otg", "oth", "otp", "ots",
-    "ott", "oxt", "png", "qt", "rar", "rpm", "rz", "rzip", "spx", "squashfs", "sxc", "sxd", "sxg",
-    "sxm", "sxw", "sz", "tbz", "tbz2", "tgz", "tlz", "ts", "txz", "tzo", "vob", "war", "webm",
-    "webp", "xz", "z", "zip", "zst",
-];
 
 /// Errors that can occur when parsing a `--skip-compress` specification.
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
@@ -85,7 +74,7 @@ impl SkipCompressList {
 
 impl Default for SkipCompressList {
     fn default() -> Self {
-        let patterns = DEFAULT_SKIP_SUFFIXES
+        let patterns = DEFAULT_SKIP_COMPRESS_SUFFIXES
             .iter()
             .filter_map(|suffix| SkipCompressPattern::parse(suffix).ok())
             .collect();


### PR DESCRIPTION
## Summary

The default `--skip-compress` suffix list (the file extensions rsync does not compress by default: `gz`, `zip`, `jpg`, `mp3`, ...) was duplicated verbatim across two crates:

- `crates/compress/src/skip_compress/defaults.rs`
- `crates/engine/src/local_copy/skip_compress.rs`

Two copies of the same 96-entry list are two sources of truth that can silently drift, changing which files get compressed on the wire versus upstream rsync (a latent bug).

## Change

Consolidate to one authoritative definition (DRY / single responsibility):

- `compress` owns the canonical list as the public const `DEFAULT_SKIP_COMPRESS_SUFFIXES` (re-exported from the crate root). It is lower in the dependency graph and already owns the `skip_compress` module.
- `engine` already depends on `compress`, so it now references the const instead of keeping its own copy - no new dependency edge, no dependency cycle.

## Upstream fidelity

Both copies were already byte-identical to each other and to upstream's default set: 96 suffixes, verified against rsync 3.4.4 (`default-dont-compress.h`, generated from the `--skip-compress` default list in `rsync.1.md`, loaded via `token.c:init_set_compression()`). No divergence found, so this is a pure DRY refactor with no behavior change. The existing drift-guard tests in `compress` continue to pin the list to the upstream set; because `engine` now references the same const, drift between the two crates is structurally impossible.

## Verification

- `cargo fmt --all` clean
- `cargo clippy -p compress -p engine --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo check --workspace --all-features` clean (no dep cycle)
- Targeted `cargo nextest run -p compress -p engine` (skip/suffix/default tests): all pass