### PR TITLE
fix(core): match upstream role/format for raw exit-code errors

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -185,7 +185,36 @@ pub(crate) fn invalid_argument_error(text: &str, exit_code: i32) -> ClientError 
 /// Creates an invalid argument error with a typed exit code.
 #[cold]
 pub(crate) fn invalid_argument_error_typed(text: &str, exit_code: ExitCode) -> ClientError {
-    let message = rsync_error!(exit_code.as_i32(), "{}", text).with_role(Role::Client);
+    invalid_argument_error_typed_with_role(text, exit_code, Role::Client)
+}
+
+/// Creates a typed-exit-code error tagged with an explicit trailer role.
+///
+/// upstream: log.c:912 log_exit() tags the diagnostic with who_am_i()
+/// (rsync.c:823), the local process role, never a bare "client". Remote SSH
+/// paths pass the direction-derived role so a push reports `[sender]` and a
+/// pull `[receiver]`.
+#[cold]
+pub(crate) fn invalid_argument_error_typed_with_role(
+    text: &str,
+    exit_code: ExitCode,
+    role: Role,
+) -> ClientError {
+    let message = rsync_error!(exit_code.as_i32(), "{}", text).with_role(role);
+    ClientError::with_code(exit_code, message)
+}
+
+/// Builds the final `rsync error:` line for a remote/child process exit.
+///
+/// upstream: log.c:890-914 log_exit() renders the winning exit code by its
+/// rerr_name (log.c:903) - or "unexplained error" for an unknown raw code
+/// (log.c:904-905) - as `rsync error: <name> (code N) at ... [<role>=<ver>]`.
+/// The role is who_am_i() (rsync.c:823): the local process role, not "client".
+/// `context` carries any captured remote stderr and is appended verbatim.
+#[cold]
+pub(crate) fn remote_exit_error(exit_code: ExitCode, role: Role, context: &str) -> ClientError {
+    let text = format!("{}{context}", exit_code.description());
+    let message = rsync_error!(exit_code.as_i32(), "{}", text).with_role(role);
     ClientError::with_code(exit_code, message)
 }
 
@@ -710,6 +739,62 @@ mod tests {
             let rendered = error.to_string();
             assert!(rendered.contains("(42 bytes received so far)"));
             assert!(rendered.contains("[sender="));
+        }
+
+        /// A raw remote/child exit (`ExitCode::Other`) must render upstream's
+        /// canonical `log_exit()` line: the rerr_name fallback "unexplained
+        /// error" plus the raw `(code N)` suffix, tagged with the local process
+        /// role - never a bare `[client]`.
+        ///
+        /// upstream: log.c:912 - `rsync error: %s (code %d) at %s(%d) [%s=%s]`
+        /// where the name comes from rerr_name()/"unexplained error" (log.c:903)
+        /// and the role from who_am_i() (rsync.c:823).
+        #[test]
+        fn remote_exit_error_renders_unexplained_error_with_sender_role() {
+            let error = remote_exit_error(ExitCode::Other(42), Role::Sender, "");
+
+            assert_eq!(error.exit_code(), 42);
+            assert_eq!(error.code(), ExitCode::Other(42));
+
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains("unexplained error (code 42)"),
+                "missing upstream phrasing: {rendered}"
+            );
+            assert!(
+                rendered.contains("[sender="),
+                "must carry the local role, not [client]: {rendered}"
+            );
+            assert!(
+                !rendered.contains("connection unexpectedly closed"),
+                "must not merge the EOF whine into the error line: {rendered}"
+            );
+        }
+
+        /// A pull tags the diagnostic with the receiver role, and a named exit
+        /// code (here RERR_STREAMIO) renders its rerr_name, mirroring
+        /// `log_exit()` for both winning-code paths.
+        #[test]
+        fn remote_exit_error_uses_receiver_role_and_named_rerr() {
+            let error = remote_exit_error(ExitCode::StreamIo, Role::Receiver, "");
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains("error in rsync protocol data stream (code 12)"),
+                "missing rerr_name: {rendered}"
+            );
+            assert!(rendered.contains("[receiver="), "missing role: {rendered}");
+        }
+
+        /// Captured remote stderr context is appended after the rerr_name so
+        /// the leading upstream phrasing still matches.
+        #[test]
+        fn remote_exit_error_appends_stderr_context() {
+            let error = remote_exit_error(ExitCode::Other(42), Role::Sender, ": boom");
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains("unexplained error: boom (code 42)"),
+                "context must trail the rerr_name: {rendered}"
+            );
         }
 
         #[test]

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -17,7 +17,7 @@ use rsync_io::ssh::SshConnection;
 
 use super::super::super::config::ClientConfig;
 use super::super::super::error::{
-    ClientError, invalid_argument_error, invalid_argument_error_typed,
+    ClientError, invalid_argument_error, invalid_argument_error_typed_with_role, remote_exit_error,
 };
 use super::super::super::progress::ClientProgressObserver;
 use super::super::super::summary::ClientSummary;
@@ -33,7 +33,22 @@ use super::parse::{parse_remote_operands, parse_single_remote};
 use super::progress::ServerProgressAdapter;
 use super::server_config::{build_server_config_for_generator, build_server_config_for_receiver};
 use crate::exit_code::ExitCode;
+use crate::message::Role;
 use crate::server::{ServerConfig, ServerRole, TransferProgressCallback};
+
+/// Maps the local client's server-infrastructure role to its trailer role.
+///
+/// upstream: who_am_i() (rsync.c:823) - a client push runs under `am_sender`
+/// (`[sender]`), a client pull is the pre-forked receiver (`[Receiver]`). The
+/// client drives the server flow as a `ServerRole::Generator` on a push (local
+/// sends) and as a `ServerRole::Receiver` on a pull (local receives), matching
+/// the `is_sender = role == Generator` split used for batch recording.
+const fn local_client_role(server_role: ServerRole) -> Role {
+    match server_role {
+        ServerRole::Generator => Role::Sender,
+        ServerRole::Receiver => Role::Receiver,
+    }
+}
 
 /// Executes a transfer over SSH transport.
 ///
@@ -263,6 +278,11 @@ fn run_server_over_ssh_connection(
     // on the SSH pipe.
     let mut reader = BufReader::with_capacity(32768, reader);
 
+    // upstream: who_am_i() (rsync.c:823) - the local client's role for any exit
+    // diagnostic. Captured before `config` is consumed by the handshake so both
+    // the handshake-failure and post-transfer child-exit paths can tag it.
+    let local_role = local_client_role(config.role);
+
     let batch_recording = batch_ctx.as_ref().map(|ctx| {
         let is_sender = config.role == ServerRole::Generator;
         build_batch_recording(ctx, is_sender)
@@ -296,11 +316,15 @@ fn run_server_over_ssh_connection(
             } else {
                 ExitCode::StartClient
             };
-            let worst = if child_exit.as_i32() > base.as_i32() {
-                child_exit
-            } else {
-                base
-            };
+            let child_overrides = child_exit.as_i32() > base.as_i32();
+            if child_overrides {
+                // upstream: log.c:912 log_exit() - when the remote/child's raw
+                // exit status outranks the local base code (cleanup.c:150-152),
+                // the final `rsync error:` line reports that winning code by its
+                // rerr_name, or "unexplained error" for an unknown raw code
+                // (log.c:903-905), not the EOF whine text.
+                return Err(remote_exit_error(child_exit, local_role, &stderr_text));
+            }
             let detail = if base == ExitCode::StreamIo {
                 // upstream: io.c:228-232 - the EOF whine omits the underlying
                 // error and reports the byte count received so far.
@@ -308,7 +332,9 @@ fn run_server_over_ssh_connection(
             } else {
                 format!("handshake failed: {e}{stderr_text}")
             };
-            return Err(invalid_argument_error_typed(&detail, worst));
+            return Err(invalid_argument_error_typed_with_role(
+                &detail, base, local_role,
+            ));
         }
     };
 
@@ -349,25 +375,15 @@ fn run_server_over_ssh_connection(
             if child_exit_code.is_success() {
                 Ok((stats, negotiated_protocol))
             } else {
-                Err(invalid_argument_error_typed(
-                    &format!(
-                        "remote process exited with error: {}{stderr_text}",
-                        child_exit_code.description()
-                    ),
-                    child_exit_code,
-                ))
+                // upstream: log.c:912 log_exit() renders the winning child code
+                // by its rerr_name tagged with the local role, not "client".
+                Err(remote_exit_error(child_exit_code, local_role, &stderr_text))
             }
         }
         Err(transfer_error) => {
             let transfer_exit = ExitCode::from_io_error(&transfer_error);
             if child_exit_code.as_i32() > transfer_exit.as_i32() {
-                Err(invalid_argument_error_typed(
-                    &format!(
-                        "transfer failed and remote process exited with error: {}{stderr_text}",
-                        child_exit_code.description()
-                    ),
-                    child_exit_code,
-                ))
+                Err(remote_exit_error(child_exit_code, local_role, &stderr_text))
             } else {
                 Err(invalid_argument_error(
                     &format!("transfer failed: {transfer_error}{stderr_text}"),


### PR DESCRIPTION
## Summary

Follow-up to #6378 (which added `ExitCode::Other(i32)` so raw child/remote exit codes propagate). The `(code N)` suffix was correct, but the surrounding error line still diverged from upstream: oc emitted a single `[client]`-tagged line that folded the EOF whine text into the diagnostic, e.g.

```
oc-rsync error: connection unexpectedly closed (0 bytes received so far) (code 42) at error.rs(188) [client=0.6.3]
```

Upstream's `log_exit()` (log.c:912) instead reports the winning exit code by its `rerr_name` - or `"unexplained error"` for an unknown raw code (log.c:903-905) - tagged with `who_am_i()` (rsync.c:823), the local process role:

```
rsync error: unexplained error (code 42) at io.c(232) [sender=3.4.4]
```

## Change

- New `remote_exit_error(code, role, context)` helper in `client/error.rs` renders upstream's canonical `log_exit()` line (code description + `(code N)` + role trailer).
- New `local_client_role()` in the SSH transfer drive derives the trailer role from the transfer direction (push -> sender, pull -> receiver), matching the existing `is_sender = role == Generator` split.
- All three remote/child-exit paths in `run_server_over_ssh_connection` (handshake-failure override, post-transfer success-with-child-error, transfer-failed-with-worse-child) now route through the helper instead of a hardcoded `[client]` line.
- `invalid_argument_error_typed` now delegates to a role-aware `invalid_argument_error_typed_with_role`, keeping the trailer logic single-sourced.

## Verification (macOS, vs Homebrew rsync 3.4.4)

Remote exit forced via a local rsh wrapper + `--rsync-path` script:

| case | upstream | oc (after) |
|------|----------|------------|
| push, exit 42 | `unexplained error (code 42) ... [sender=3.4.4]` | `unexplained error (code 42) ... [sender=0.6.3]` |
| pull, exit 42 | `unexplained error (code 42) ... [Receiver=3.4.4]` | `unexplained error (code 42) ... [receiver=0.6.3]` |
| push, exit 23 | `some files/attrs were not transferred (see previous errors) (code 23) ... [sender=3.4.4]` | same, `[sender=0.6.3]` |

Matches modulo version string and impl file:line. Residual: on a pull, upstream renders the pre-fork receiver as capital `Receiver` (a `who_am_i()` fallback quirk); oc uses its uniform lowercase `receiver` role convention.

fmt + `clippy -p core` clean; targeted `nextest -p core` (53 tests) green; `cargo check --workspace --all-targets` green.