### PR TITLE
docs(filters): fix misplaced rustdoc and prune noise comments

### DIFF
--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -756,17 +756,6 @@ struct InlineDirMerge {
     abs_path: bool,
 }
 
-/// Splits parsed rules into ordinary entries plus dir-merge descriptors.
-///
-/// Standard [`FilterSet`] compilation discards [`FilterAction::DirMerge`]
-/// rules because they neither match paths nor encode a single decision.
-/// Pull them out here so the caller can load each referenced file inline,
-/// mirroring upstream's `:` directive that registers a fresh per-directory
-/// merge from inside another merge file.
-///
-/// upstream: exclude.c:1419-1428 - `FILTRULE_PERDIR_MERGE` inside
-/// `parse_filter_str()` adds a new per-dir rule rather than expanding the
-/// file at parse time.
 /// Joins a relative path's normal components with `/`, ignoring any leading
 /// `./`, `..`, or root components. Produces the module-root-relative directory
 /// string used to re-anchor merge-file rules.
@@ -799,6 +788,17 @@ fn reanchor_merge_rule(mut rule: FilterRule, rel_dir: Option<&str>) -> FilterRul
     rule
 }
 
+/// Splits parsed rules into ordinary entries plus dir-merge descriptors.
+///
+/// Standard [`FilterSet`] compilation discards [`FilterAction::DirMerge`]
+/// rules because they neither match paths nor encode a single decision.
+/// Pull them out here so the caller can load each referenced file inline,
+/// mirroring upstream's `:` directive that registers a fresh per-directory
+/// merge from inside another merge file.
+///
+/// upstream: exclude.c:1419-1428 - `FILTRULE_PERDIR_MERGE` inside
+/// `parse_filter_str()` adds a new per-dir rule rather than expanding the
+/// file at parse time.
 fn split_dir_merge_rules(rules: Vec<FilterRule>) -> (Vec<FilterRule>, Vec<InlineDirMerge>) {
     let mut keep = Vec::with_capacity(rules.len());
     let mut dir_merges = Vec::new();

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -49,7 +49,6 @@ impl CompiledRule {
     /// When `negate` is true, the match result is inverted: returns true when
     /// the pattern does NOT match. This mirrors upstream rsync's `!` modifier
     /// behavior from `exclude.c` line 906.
-    /// Tests whether a path matches this rule's pattern.
     ///
     /// When `check_descendants` is false, only direct matchers are evaluated -
     /// descendant matchers are skipped. This matches upstream rsync's

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -109,8 +109,6 @@ pub mod cvs;
 /// Structured tracing for filter rule evaluation and statistics.
 pub mod debug_filter;
 mod decision;
-/// Generic filter evaluation for `FileEntryAccessor` implementors.
-///
 mod error;
 /// Merge-file reader and parser for filter rules.
 pub mod merge;


### PR DESCRIPTION
## Summary

Documentation-only cleanup for the `filters` crate as part of the per-crate comment-cleanup initiative. No logic, signatures, or behavior changed.

The crate already builds under `#![deny(missing_docs)]`, so every public item was documented. This pass repairs three genuine documentation defects found while auditing:

- **lib.rs** - removed a stale doc comment misattached to `mod error` that described a nonexistent `FileEntryAccessor` type (leftover from a removed module). The other private modules carry no doc comment, so this restores consistency.
- **chain/mod.rs** - the `split_dir_merge_rules` doc block had been fused onto the following `path_to_forward_slash` function, leaving `split_dir_merge_rules` undocumented. Moved the block back to its own function.
- **compiled/rule.rs** - removed a duplicated summary line (`Tests whether a path matches this rule's pattern.`) on `CompiledRule::matches`.

All upstream-reference (`exclude.c` / `wildmatch.c`) comments and the filter-rule-semantics comments (anchoring, `dir-merge`/`:` per-dir behavior, `!` negation, modifier flags, first-match-wins chain, dowild quirks) are preserved verbatim.

## Verification

- `cargo fmt --all` clean
- `cargo clippy -p filters --all-targets --all-features --no-deps -- -D warnings` - no issues
- `cargo check -p filters --all-features` - ok
- `cargo doc -p filters --no-deps --all-features` - builds (validates `deny(rustdoc::broken_intra_doc_links)` after moving the block with `[FilterSet]`/`[FilterAction::DirMerge]` links)