### PR TITLE
fix(daemon): match auth users via wildmatch and @group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,7 @@ dependencies = [
  "exacl",
  "fast_io",
  "filetime",
+ "filters",
  "fs2",
  "libc",
  "logging",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -73,6 +73,7 @@ base64 = { workspace = true }
 dns-lookup = "3.0"
 compress = { path = "../compress" }
 core = { path = "../core", default-features = false }
+filters = { path = "../filters" }
 metadata = { path = "../metadata", default-features = false }
 platform = { path = "../platform" }
 protocol = { path = "../protocol" }

--- a/crates/daemon/src/daemon/module_state/auth.rs
+++ b/crates/daemon/src/daemon/module_state/auth.rs
@@ -50,3 +50,138 @@ impl AuthUser {
         }
     }
 }
+
+/// Resolves whether an authenticating user belongs to a named system group.
+///
+/// This is a seam over the system group database so that `auth users = @group`
+/// matching can be exercised hermetically in tests. Production authentication
+/// uses [`SystemGroupMembership`]; tests inject a deterministic resolver.
+pub(crate) trait GroupMembership {
+    /// Returns whether `user` is a member of the group named `group`.
+    fn is_member(&self, user: &str, group: &str) -> bool;
+}
+
+/// Production [`GroupMembership`] backed by the host group database.
+///
+/// Membership is resolved from the group's member list (`getgrnam_r` on Unix,
+/// `NetLocalGroupGetMembers` on Windows) via `platform::group`. On platforms
+/// without a group database the lookup yields no members and every check is
+/// `false`.
+///
+/// upstream: authenticate.c:276 `auth_server()` authorizes an `@group` token by
+/// checking the authenticating user's group membership.
+pub(crate) struct SystemGroupMembership;
+
+impl GroupMembership for SystemGroupMembership {
+    fn is_member(&self, user: &str, group: &str) -> bool {
+        matches!(
+            crate::daemon::lookup_group_members(group),
+            Ok(Some(members)) if members.iter().any(|member| member == user)
+        )
+    }
+}
+
+/// Returns the first `auth users` entry that authorizes `username`, or `None`
+/// when no entry matches.
+///
+/// Mirrors the token loop in upstream `auth_server`: entries are evaluated in
+/// configuration order and the first match wins. A plain token matches the
+/// username via shell-wildcard `wildmatch` (which subsumes an exact literal
+/// match); a token starting with `@` authorizes any user who is a member of the
+/// named group. The matched entry's access suffix (`:ro`/`:rw`/`:deny`) then
+/// governs access downstream, so a matching `:deny` entry still denies.
+///
+/// upstream: authenticate.c:276 `auth_server()` - `if (wildmatch(tok, line))`
+/// for plain tokens and group membership for `@group` tokens.
+pub(crate) fn authorize_auth_user<'a, G: GroupMembership>(
+    entries: &'a [AuthUser],
+    username: &str,
+    groups: &G,
+) -> Option<&'a AuthUser> {
+    entries
+        .iter()
+        .find(|entry| match entry.username.strip_prefix('@') {
+            Some(group) => groups.is_member(username, group),
+            None => filters::wildmatch(entry.username.as_bytes(), username.as_bytes()),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Deterministic [`GroupMembership`] for hermetic `@group` tests. Maps a
+    /// group name to the set of member usernames, so authorization does not
+    /// depend on the host's `/etc/group`.
+    struct MockGroups(HashMap<&'static str, Vec<&'static str>>);
+
+    impl GroupMembership for MockGroups {
+        fn is_member(&self, user: &str, group: &str) -> bool {
+            self.0
+                .get(group)
+                .is_some_and(|members| members.contains(&user))
+        }
+    }
+
+    fn entries(tokens: &[&str]) -> Vec<AuthUser> {
+        tokens
+            .iter()
+            .map(|token| AuthUser::new((*token).to_owned()))
+            .collect()
+    }
+
+    /// Exact literal tokens still authorize the named user and reject others,
+    /// matching upstream's `wildmatch("bob", line)` for a metacharacter-free
+    /// token.
+    #[test]
+    fn exact_token_authorizes_only_that_user() {
+        let list = entries(&["bob"]);
+        let groups = MockGroups(HashMap::new());
+        assert!(authorize_auth_user(&list, "bob", &groups).is_some());
+        assert!(authorize_auth_user(&list, "alice", &groups).is_none());
+    }
+
+    /// A wildcard token authorizes matching usernames and rejects the rest,
+    /// mirroring upstream `wildmatch("user*", line)`.
+    #[test]
+    fn wildcard_token_matches_by_pattern() {
+        let list = entries(&["user*"]);
+        let groups = MockGroups(HashMap::new());
+        assert!(authorize_auth_user(&list, "user1", &groups).is_some());
+        assert!(authorize_auth_user(&list, "user-admin", &groups).is_some());
+        assert!(authorize_auth_user(&list, "admin", &groups).is_none());
+    }
+
+    /// An `@group` token authorizes members of the group and rejects
+    /// non-members, mirroring upstream's group-membership check.
+    #[test]
+    fn group_token_authorizes_members_only() {
+        let list = entries(&["@wheel"]);
+        let groups = MockGroups(HashMap::from([("wheel", vec!["carol", "dave"])]));
+        assert!(authorize_auth_user(&list, "carol", &groups).is_some());
+        assert!(authorize_auth_user(&list, "mallory", &groups).is_none());
+    }
+
+    /// First match wins across a mixed list, and the matched entry's access
+    /// level is the one returned, matching upstream's first-token-wins loop.
+    #[test]
+    fn first_match_wins_and_returns_matched_entry() {
+        let list = vec![
+            AuthUser::with_access("bob".to_owned(), UserAccessLevel::Deny),
+            AuthUser::with_access("bob".to_owned(), UserAccessLevel::ReadWrite),
+        ];
+        let groups = MockGroups(HashMap::new());
+        let matched = authorize_auth_user(&list, "bob", &groups).expect("bob matches");
+        assert_eq!(matched.access_level, UserAccessLevel::Deny);
+    }
+
+    /// A non-matching user against a mixed exact/wildcard/@group list is
+    /// rejected outright.
+    #[test]
+    fn non_matching_user_is_rejected() {
+        let list = entries(&["alice", "team*", "@staff"]);
+        let groups = MockGroups(HashMap::from([("staff", vec!["carol"])]));
+        assert!(authorize_auth_user(&list, "intruder", &groups).is_none());
+    }
+}

--- a/crates/daemon/src/daemon/module_state/definition.rs
+++ b/crates/daemon/src/daemon/module_state/definition.rs
@@ -239,10 +239,14 @@ impl ModuleDefinition {
     }
 
     /// Returns the AuthUser if the username is authorized for this module.
+    ///
+    /// Delegates to [`authorize_auth_user`], which evaluates `auth users`
+    /// tokens in configuration order (wildcard match for plain tokens, group
+    /// membership for `@group` tokens), first match wins.
+    ///
+    /// upstream: authenticate.c:276 `auth_server()`.
     pub(crate) fn get_auth_user(&self, username: &str) -> Option<&AuthUser> {
-        self.auth_users
-            .iter()
-            .find(|auth| auth.username == username)
+        super::authorize_auth_user(&self.auth_users, username, &super::SystemGroupMembership)
     }
 
     /// Returns the maximum number of concurrent connections allowed.

--- a/crates/daemon/src/daemon/module_state/mod.rs
+++ b/crates/daemon/src/daemon/module_state/mod.rs
@@ -20,7 +20,7 @@ mod test_support;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use auth::{AuthUser, UserAccessLevel};
+pub(crate) use auth::{AuthUser, SystemGroupMembership, UserAccessLevel, authorize_auth_user};
 pub(crate) use connection_limiter::{ConnectionLimiter, ConnectionLockGuard};
 pub(crate) use definition::ModuleDefinition;
 pub(crate) use hostname::module_peer_hostname;

--- a/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
@@ -40,7 +40,9 @@ where
 /// Parses a comma/whitespace-separated list of usernames with deduplication.
 ///
 /// Usernames are case-preserved but deduplicated case-insensitively.
-/// Group references using `@group` syntax are expanded to their member usernames.
+/// Group references using `@group` syntax are stored verbatim and resolved to
+/// membership at authentication time (see `authorize_auth_user`), matching
+/// upstream `auth_server`.
 ///
 /// # Access Level Suffixes
 ///
@@ -49,12 +51,13 @@ where
 /// - `:rw` - Read-write access (overrides module's read_only setting)
 /// - `:deny` - Deny access (authentication succeeds but access is blocked)
 ///
-/// # Group Expansion
+/// # Group Tokens
 ///
-/// Entries starting with `@` are treated as system group names. The `@` prefix
-/// is stripped and the group's members are looked up via `getgrnam_r`. All
-/// members are added with the same access level as the @group entry.
-/// Unknown groups are silently skipped (matching upstream rsync behavior).
+/// Entries starting with `@` name a system group. The token is kept verbatim
+/// (`@group`) and, at authentication time, authorizes any connecting user who
+/// is a member of that group. This mirrors upstream `auth_server`, which
+/// resolves group membership per authenticating user rather than expanding the
+/// group to a fixed member list at config load.
 ///
 /// # Examples
 ///
@@ -91,29 +94,17 @@ pub(crate) fn parse_auth_user_list(value: &str) -> Result<Vec<AuthUser>, String>
             continue;
         }
 
-        if let Some(group_name) = name_part.strip_prefix('@') {
-            if group_name.is_empty() {
-                continue;
-            }
-            // upstream: expand @group references to member usernames
-            match lookup_group_members(group_name) {
-                Ok(Some(members)) => {
-                    for member in members {
-                        let key = member.to_ascii_lowercase();
-                        if seen.insert(key) {
-                            result.push(AuthUser::with_access(member, access_level));
-                        }
-                    }
-                }
-                Ok(None) | Err(_) => {
-                    // Group not found - silently skip (upstream behavior)
-                }
-            }
-        } else {
-            let key = name_part.to_ascii_lowercase();
-            if seen.insert(key) {
-                result.push(AuthUser::with_access(name_part.to_owned(), access_level));
-            }
+        // A bare `@` names no group and cannot authorize anyone; skip it.
+        if name_part == "@" {
+            continue;
+        }
+
+        // upstream: authenticate.c:276 keeps each token verbatim (including
+        // `@group`) and matches it at auth time via wildmatch / group
+        // membership. Do not expand `@group` to member usernames here.
+        let key = name_part.to_ascii_lowercase();
+        if seen.insert(key) {
+            result.push(AuthUser::with_access(name_part.to_owned(), access_level));
         }
     }
 

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -126,6 +126,7 @@ pub use error::FilterError;
 pub use merge::{MergeFileError, parse_rules, read_rules, read_rules_recursive};
 pub use rule::FilterRule;
 pub use set::{FilterSet, FilterSetError, apple_double_exclusion_rules, cvs_exclusion_rules};
+pub use wildmatch::wildmatch;
 
 #[cfg(test)]
 mod tests;

--- a/crates/filters/src/wildmatch.rs
+++ b/crates/filters/src/wildmatch.rs
@@ -249,7 +249,7 @@ fn dowild(p: &[u8], text: &[u8]) -> i32 {
 ///
 /// upstream: `lib/wildmatch.c:288` `int wildmatch(const char *pattern, const
 /// char *text)`.
-pub(crate) fn wildmatch(pattern: &[u8], text: &[u8]) -> bool {
+pub fn wildmatch(pattern: &[u8], text: &[u8]) -> bool {
     dowild(pattern, text) == TRUE
 }
 


### PR DESCRIPTION
## Summary

Upstream `auth_server` (`authenticate.c:276`) matches each `auth users` token with `wildmatch(tok, user)` and authorizes `@group` tokens by the connecting user's group membership, evaluated in configuration order with first match winning. oc-rsync previously matched entries with exact string equality and expanded `@group` to a fixed member list at config load, so:

- wildcard tokens (`auth users = user*`) were wrongly rejected, and
- `@group` missed users whose membership is via their primary group.

## Change

- Keep `@group` tokens verbatim at config load; resolve membership at authentication time (mirrors upstream, which resolves per authenticating user rather than snapshotting a member list).
- New `authorize_auth_user` matcher evaluates tokens in order, first match wins:
  - plain token: `wildmatch(token, user)` (subsumes exact literal matches),
  - `@group` token: authorized when the user is a member of the named group.
  - A matching `:deny` entry still denies (first-match-wins preserves the deny/access suffix).
- Group lookup goes through a `GroupMembership` seam. Production uses `SystemGroupMembership` over `platform::group` (getgrnam_r on Unix, NetLocalGroupGetMembers on Windows, no-op stub elsewhere - unix-only real lookup with cross-platform fallback). Tests inject a deterministic resolver so `@group` matching is hermetic.
- Reuse the faithful `wildmatch`/`dowild` port already in the `filters` crate (now re-exported) rather than reimplementing globbing. `filters` is already a transitive dependency of `daemon`, so the direct dependency adds no new compilation.

The challenge-response auth crypto is untouched.

## Tests

Added matcher unit tests (hermetic via the resolver seam): exact token authorizes only that user; wildcard token matches by pattern and rejects non-matches; `@group` authorizes members only; first match wins and returns the matched entry's access level; non-matching user against a mixed list is rejected.

## Verification

`cargo fmt --all --check`, `cargo clippy -p daemon -p filters --all-targets --all-features --no-deps -D warnings`, `cargo check -p daemon --all-features` (native and `x86_64-pc-windows-gnu`), and targeted `daemon` nextest all pass.