### PR TITLE
fix(filters): gate e/n/w/s/r merge-file modifiers to match upstream

### DIFF
--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -23,12 +23,14 @@
 //! - `r` - Receiver-side only
 //! - `x` - Xattr filtering only
 //! - `e` - Exclude-self (merge rules only: exclude the merge file's own name)
-//! - `n` - No-inherit (for merge rules, don't inherit parent rules)
-//! - `w` - Word-split (split pattern on whitespace into multiple rules)
+//! - `n` - No-inherit (merge rules only: don't inherit parent rules)
+//! - `w` - Word-split (merge rules only: split the merge file at whitespace)
 //! - `C` - CVS mode (add CVS exclusion patterns)
 //!
+//! The `e`, `n`, and `w` modifiers are valid only on a merge / dir-merge rule
+//! (upstream `FILTRULE_MERGE_FILE`); on any other rule they are a syntax error.
+//!
 //! Example: `-!p *.tmp` excludes files NOT matching `*.tmp`, marked perishable.
-//! Example: `-w foo bar baz` creates three exclude rules for "foo", "bar", "baz".
 //!
 //! Lines starting with `#` or `;` are comments. Empty lines are ignored.
 //!

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -46,8 +46,7 @@ pub fn parse_rules(content: &str, source_path: &Path) -> Result<Vec<FilterRule>,
             continue;
         }
 
-        let line_rules = parse_rule_line_expanded(line, source_path, line_num)?;
-        rules.extend(line_rules);
+        rules.push(parse_rule_line(line, source_path, line_num)?);
     }
 
     Ok(rules)
@@ -98,71 +97,6 @@ pub(crate) fn parse_rules_no_prefixes(
     rules
 }
 
-/// Parses a single filter rule line, potentially expanding into multiple rules.
-///
-/// The `w` (word-split) modifier causes the pattern to be split on whitespace,
-/// creating multiple rules with the same action and modifiers.
-fn parse_rule_line_expanded(
-    line: &str,
-    source_path: &Path,
-    line_num: usize,
-) -> Result<Vec<FilterRule>, MergeFileError> {
-    let (action_char, rest) = if let Some(rest) = line.strip_prefix('+') {
-        ('+', rest)
-    } else if let Some(rest) = line.strip_prefix('-') {
-        ('-', rest)
-    } else if let Some(rest) = line.strip_prefix('P') {
-        ('P', rest)
-    } else if let Some(rest) = line.strip_prefix('R') {
-        ('R', rest)
-    } else if let Some(rest) = line.strip_prefix('H') {
-        ('H', rest)
-    } else if let Some(rest) = line.strip_prefix('S') {
-        ('S', rest)
-    } else {
-        return Ok(vec![parse_rule_line(line, source_path, line_num)?]);
-    };
-
-    // These action characters are never merge-file rules, so `is_merge` is false.
-    let (mods, pattern) = parse_modifiers(rest, false, line, source_path, line_num)?;
-
-    if mods.word_split && !pattern.is_empty() {
-        validate_side_modifiers(action_char, &mods, line, source_path, line_num)?;
-        // These prefixes are never merge-file rules, so `e` is always invalid.
-        validate_exclude_self_modifier(false, &mods, line, source_path, line_num)?;
-        let patterns: Vec<&str> = pattern.split_whitespace().collect();
-        if patterns.is_empty() {
-            return Err(MergeFileError::parse_error(
-                source_path,
-                line_num,
-                "word-split pattern is empty",
-            ));
-        }
-
-        let mods_for_expanded = RuleModifiers {
-            word_split: false,
-            ..mods
-        };
-
-        let mut rules = Vec::with_capacity(patterns.len());
-        for pat in patterns {
-            let base_rule = match action_char {
-                '+' => FilterRule::include(pat),
-                '-' => FilterRule::exclude(pat),
-                'P' => FilterRule::protect(pat),
-                'R' => FilterRule::risk(pat),
-                'H' => FilterRule::hide(pat),
-                'S' => FilterRule::show(pat),
-                _ => unreachable!(),
-            };
-            rules.push(mods_for_expanded.apply(base_rule));
-        }
-        return Ok(rules);
-    }
-
-    Ok(vec![parse_rule_line(line, source_path, line_num)?])
-}
-
 /// Modifiers parsed from a rule prefix.
 ///
 /// These mirror upstream rsync's rule modifiers from `exclude.c` (lines 1220-1288).
@@ -178,8 +112,8 @@ fn parse_rule_line_expanded(
 /// | `r` | `receiver_only` | Apply on receiver side only |
 /// | `x` | `xattr_only` | Match xattr names only |
 /// | `e` | `exclude_self` | Exclude the merge file's own name (merge rules only) |
-/// | `n` | `no_inherit` | Don't inherit parent rules (merge) |
-/// | `w` | `word_split` | Split pattern on whitespace |
+/// | `n` | `no_inherit` | Don't inherit rules into subdirectories (merge rules only) |
+/// | `w` | `word_split` | Split the merge file at whitespace (merge rules only) |
 /// | `C` | `cvs_mode` | Add CVS exclusion patterns |
 /// | `/` | `abs_path` | Anchor merged rules to the transfer root (merge rules only) |
 /// | `-` | `no_prefixes` | Merged lines are literal excludes (merge rules only) |
@@ -234,87 +168,29 @@ impl RuleModifiers {
     }
 }
 
-/// Rejects `s` or `r` modifiers when the rule prefix already implies a side.
-///
-/// Matches upstream's `prefix_specifies_side` guard: prefixes `H`/`S`
-/// (sender-side hide/show) and `P`/`R` (receiver-side protect/risk) bind the
-/// rule to a single side, so combining them with the modifier counterpart is a
-/// syntax error.
-///
-/// upstream: exclude.c parse_filter_str (rsync-3.4.2) lines 1269-1278
-fn validate_side_modifiers(
-    action_char: char,
-    mods: &RuleModifiers,
-    line: &str,
-    source_path: &Path,
-    line_num: usize,
-) -> Result<(), MergeFileError> {
-    let prefix_side = matches!(action_char, 'H' | 'S' | 'P' | 'R');
-    if !prefix_side {
-        return Ok(());
-    }
-    let conflict = if mods.sender_only {
-        Some('s')
-    } else if mods.receiver_only {
-        Some('r')
-    } else {
-        None
-    };
-    if let Some(ch) = conflict {
-        return Err(MergeFileError::parse_error(
-            source_path,
-            line_num,
-            format!("invalid modifier '{ch}' on side-specific filter rule: {line}"),
-        ));
-    }
-    Ok(())
-}
-
-/// Rejects the `e` (exclude-self) modifier on a non-merge rule.
-///
-/// Upstream only permits `e` on a merge-file rule (`.`/`:`/`merge`/`dir-merge`),
-/// where it sets `FILTRULE_EXCLUDE_SELF` so the merge file's own basename is
-/// excluded. On an include/exclude/protect/risk/hide/show rule upstream jumps to
-/// the `invalid` label and reports a parse error; oc-rsync previously accepted
-/// it silently and stored it in a flag no matching logic read, so the modifier
-/// was a no-op that diverged from upstream on malformed input.
-///
-/// upstream: exclude.c:1256-1259 - `case 'e': if (!(rule->rflags &
-/// FILTRULE_MERGE_FILE)) goto invalid;`
-fn validate_exclude_self_modifier(
-    is_merge: bool,
-    mods: &RuleModifiers,
-    line: &str,
-    source_path: &Path,
-    line_num: usize,
-) -> Result<(), MergeFileError> {
-    if mods.exclude_self && !is_merge {
-        return Err(MergeFileError::parse_error(
-            source_path,
-            line_num,
-            format!("invalid modifier 'e' on non-merge filter rule: {line}"),
-        ));
-    }
-    Ok(())
-}
-
 /// Parses modifiers from a string following the action character.
 ///
 /// Returns the parsed modifiers and the remaining string (pattern). Modifiers
 /// are single characters that can appear in any order before the pattern.
 ///
 /// `is_merge` indicates whether the rule is a merge / dir-merge rule
-/// (`FILTRULE_MERGE_FILE`), which gates the `/`, `-`, and `+` modifiers.
-/// `full_line` and `line_num`/`source_path` are used only for error messages.
+/// (`FILTRULE_MERGE_FILE`), which gates the `e`, `n`, `w`, `/`, `-`, and `+`
+/// modifiers. `prefix_specifies_side` indicates the rule prefix already binds a
+/// side (H/S/P/R), which gates the `s` and `r` modifiers. `full_line` and
+/// `line_num`/`source_path` are used only for error messages.
+///
+/// Modifiers are validated left-to-right in a single pass, so the first invalid
+/// modifier is the one reported - matching upstream's single `switch` loop.
 ///
 /// Any character that is not a recognised modifier is a syntax error, matching
 /// upstream's `invalid:` label rather than silently treating it as the start of
 /// the pattern.
 ///
-/// upstream: exclude.c:1175-1227 - the modifier loop and its `invalid:` label.
+/// upstream: exclude.c:1215-1289 - the modifier loop and its `invalid:` label.
 pub(crate) fn parse_modifiers<'a>(
     s: &'a str,
     is_merge: bool,
+    prefix_specifies_side: bool,
     full_line: &str,
     source_path: &Path,
     line_num: usize,
@@ -332,12 +208,49 @@ pub(crate) fn parse_modifiers<'a>(
                 mods.negate = true;
             }
             'p' => mods.perishable = true,
-            's' => mods.sender_only = true,
-            'r' => mods.receiver_only = true,
+            // upstream: exclude.c:1269-1277 - `s`/`r` are invalid when the rule
+            // prefix already binds a side (H/S sender, P/R receiver), i.e.
+            // `prefix_specifies_side`.
+            's' => {
+                if prefix_specifies_side {
+                    return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
+                }
+                mods.sender_only = true;
+            }
+            'r' => {
+                if prefix_specifies_side {
+                    return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
+                }
+                mods.receiver_only = true;
+            }
             'x' => mods.xattr_only = true,
-            'e' => mods.exclude_self = true,
-            'n' => mods.no_inherit = true,
-            'w' => mods.word_split = true,
+            // upstream: exclude.c:1256-1260 - `e` (FILTRULE_EXCLUDE_SELF) is
+            // valid only on a merge-file rule; on any other rule upstream
+            // jumps to `invalid`.
+            'e' => {
+                if !is_merge {
+                    return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
+                }
+                mods.exclude_self = true;
+            }
+            // upstream: exclude.c:1261-1264 - `n` (FILTRULE_NO_INHERIT) is
+            // valid only on a merge-file rule; on any other rule upstream
+            // jumps to `invalid`.
+            'n' => {
+                if !is_merge {
+                    return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
+                }
+                mods.no_inherit = true;
+            }
+            // upstream: exclude.c:1279-1283 - `w` (FILTRULE_WORD_SPLIT) is
+            // valid only on a merge-file rule; on any other rule upstream
+            // jumps to `invalid`.
+            'w' => {
+                if !is_merge {
+                    return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
+                }
+                mods.word_split = true;
+            }
             'C' => mods.cvs_mode = true,
             // upstream: exclude.c:1215-1216 - `/` sets FILTRULE_ABS_PATH.
             '/' => mods.abs_path = true,
@@ -470,22 +383,28 @@ fn try_parse_short_form(
         return Ok(None);
     };
 
-    let (mods, pattern) = parse_modifiers(rest, action.is_merge(), line, source_path, line_num)?;
+    // upstream: exclude.c:1136 - `prefix_specifies_side` is set for the H/S
+    // (sender) and P/R (receiver) prefixes, gating the `s`/`r` modifiers.
+    let prefix_specifies_side = matches!(prefix_char, 'H' | 'S' | 'P' | 'R');
+    let (mods, pattern) = parse_modifiers(
+        rest,
+        action.is_merge(),
+        prefix_specifies_side,
+        line,
+        source_path,
+        line_num,
+    )?;
     if pattern.is_empty() {
         // upstream: exclude.c:1404-1408 - a merge / dir-merge rule with the
         // `C` (CVS-ignore) modifier and an empty pattern defaults to the
         // filename `.cvsignore`. Without `C`, an empty pattern remains
         // unrecognised here and falls through to long-form parsing.
         if mods.cvs_mode && matches!(action, ShortFormAction::Merge | ShortFormAction::DirMerge) {
-            validate_side_modifiers(prefix_char, &mods, line, source_path, line_num)?;
-            validate_exclude_self_modifier(action.is_merge(), &mods, line, source_path, line_num)?;
             let rule = action.to_rule(".cvsignore");
             return Ok(Some(mods.apply(rule)));
         }
         return Ok(None);
     }
-    validate_side_modifiers(prefix_char, &mods, line, source_path, line_num)?;
-    validate_exclude_self_modifier(action.is_merge(), &mods, line, source_path, line_num)?;
 
     let rule = action.to_rule(pattern);
     Ok(Some(if action.supports_mods() {

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -380,7 +380,7 @@ fn rule_modifiers_default() {
 
 #[test]
 fn parse_modifiers_empty_string() {
-    let (mods, pattern) = parse_modifiers("", false, "", Path::new("test"), 1).unwrap();
+    let (mods, pattern) = parse_modifiers("", false, false, "", Path::new("test"), 1).unwrap();
     assert!(!mods.negate);
     assert_eq!(pattern, "");
 }
@@ -388,17 +388,45 @@ fn parse_modifiers_empty_string() {
 #[test]
 fn parse_modifiers_space_only() {
     let (mods, pattern) =
-        parse_modifiers(" pattern", false, " pattern", Path::new("test"), 1).unwrap();
+        parse_modifiers(" pattern", false, false, " pattern", Path::new("test"), 1).unwrap();
     assert!(!mods.negate);
     assert_eq!(pattern, "pattern");
 }
 
+/// The merge-only modifiers (`e`, `n`, `w`, plus `C`) parse together on a
+/// merge-file rule. `!` is excluded because upstream rejects negation on a
+/// merge rule (exclude.c:1241-1246); it is covered by the non-merge test.
 #[test]
 fn parse_modifiers_all_flags() {
     let (mods, pattern) = parse_modifiers(
-        "!psrxenC pattern",
+        "psrxenwC pattern",
+        true,
         false,
-        "-!psrxenC pattern",
+        ":psrxenwC pattern",
+        Path::new("test"),
+        1,
+    )
+    .unwrap();
+    assert!(mods.perishable);
+    assert!(mods.sender_only);
+    assert!(mods.receiver_only);
+    assert!(mods.xattr_only);
+    assert!(mods.exclude_self);
+    assert!(mods.no_inherit);
+    assert!(mods.word_split);
+    assert!(mods.cvs_mode);
+    assert_eq!(pattern, "pattern");
+}
+
+/// The non-merge modifiers (`!`, `p`, `s`, `r`, `x`, `C`) parse together on
+/// an ordinary rule; the merge-only `e`/`n`/`w` are rejected separately.
+#[test]
+fn parse_modifiers_non_merge_flags() {
+    let (mods, pattern) = parse_modifiers(
+        "!psrxC pattern",
+        false,
+        false,
+        "-!psrxC pattern",
         Path::new("test"),
         1,
     )
@@ -408,8 +436,6 @@ fn parse_modifiers_all_flags() {
     assert!(mods.sender_only);
     assert!(mods.receiver_only);
     assert!(mods.xattr_only);
-    assert!(mods.exclude_self);
-    assert!(mods.no_inherit);
     assert!(mods.cvs_mode);
     assert_eq!(pattern, "pattern");
 }
@@ -460,51 +486,77 @@ fn parse_exclude_self_modifier_accepted_on_merge_rule() {
     assert_eq!(rules[0].pattern(), "rules.txt");
 }
 
+/// `n` (FILTRULE_NO_INHERIT) is valid only on a merge-file rule. On an
+/// ordinary exclude/include rule upstream jumps to `invalid`
+/// (exclude.c:1261-1264: `case 'n': if (!(rule->rflags &
+/// FILTRULE_MERGE_FILE)) goto invalid;`). oc-rsync previously accepted
+/// `-n *.tmp` and stored a no-inherit flag no path honoured, so a malformed
+/// rule silently diverged from upstream's syntax error.
 #[test]
-fn parse_no_inherit_modifier() {
-    let rules = parse_rules("-n *.tmp", Path::new("test")).unwrap();
+fn parse_no_inherit_modifier_rejected_on_non_merge_rule() {
+    let err = parse_rules("-n *.tmp", Path::new("test")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier 'n'"),
+        "unexpected error: {err}"
+    );
+}
+
+/// `n` parses on a dir-merge rule, where it maps to FILTRULE_NO_INHERIT.
+#[test]
+fn parse_no_inherit_modifier_accepted_on_dir_merge_rule() {
+    let rules = parse_rules(":n .rsync-filter", Path::new("test")).unwrap();
     assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::DirMerge);
     assert!(rules[0].is_no_inherit());
 }
 
+/// `w` (FILTRULE_WORD_SPLIT) is valid only on a merge-file rule
+/// (exclude.c:1279-1283: `case 'w': if (!(rule->rflags &
+/// FILTRULE_MERGE_FILE)) goto invalid;`). oc-rsync previously expanded
+/// `-w foo bar baz` into three excludes, but upstream rejects `w` on an
+/// exclude rule as a syntax error; word-split applies only to merge-file
+/// bodies. Verified: `rsync -rn --filter='-w foo bar baz'` exits 1 with
+/// "invalid modifier 'w'".
 #[test]
-fn parse_word_split_modifier() {
-    let rules = parse_rules("-w foo bar baz", Path::new("test")).unwrap();
-    assert_eq!(rules.len(), 3);
-    assert_eq!(rules[0].pattern(), "foo");
-    assert_eq!(rules[1].pattern(), "bar");
-    assert_eq!(rules[2].pattern(), "baz");
-    for rule in &rules {
-        assert_eq!(rule.action(), FilterAction::Exclude);
-    }
+fn parse_word_split_modifier_rejected_on_non_merge_rule() {
+    let err = parse_rules("-w foo bar baz", Path::new("test")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier 'w'"),
+        "unexpected error: {err}"
+    );
 }
 
+/// `w` on an include rule is equally invalid.
 #[test]
-fn parse_word_split_with_other_modifiers() {
-    let rules = parse_rules("-!pw one two", Path::new("test")).unwrap();
-    assert_eq!(rules.len(), 2);
-    assert_eq!(rules[0].pattern(), "one");
-    assert_eq!(rules[1].pattern(), "two");
-    for rule in &rules {
-        assert!(rule.is_negated());
-        assert!(rule.is_perishable());
-    }
+fn parse_word_split_include_rejected_on_non_merge_rule() {
+    let err = parse_rules("+w *.rs *.toml", Path::new("test")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier 'w'"),
+        "unexpected error: {err}"
+    );
 }
 
+/// `w` parses on a dir-merge rule (FILTRULE_WORD_SPLIT), the only context
+/// upstream permits it.
 #[test]
-fn parse_word_split_include() {
-    let rules = parse_rules("+w *.rs *.toml", Path::new("test")).unwrap();
-    assert_eq!(rules.len(), 2);
-    assert_eq!(rules[0].action(), FilterAction::Include);
-    assert_eq!(rules[1].action(), FilterAction::Include);
-    assert_eq!(rules[0].pattern(), "*.rs");
-    assert_eq!(rules[1].pattern(), "*.toml");
+fn parse_word_split_modifier_accepted_on_dir_merge_rule() {
+    let rules = parse_rules(":w .rsync-filter", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    assert_eq!(rules[0].pattern(), ".rsync-filter");
 }
 
 #[test]
 fn parse_cvs_mode_modifier() {
-    let (mods, pattern) =
-        parse_modifiers("C pattern", false, "-C pattern", Path::new("test"), 1).unwrap();
+    let (mods, pattern) = parse_modifiers(
+        "C pattern",
+        false,
+        false,
+        "-C pattern",
+        Path::new("test"),
+        1,
+    )
+    .unwrap();
     assert!(mods.cvs_mode);
     assert_eq!(pattern, "pattern");
 }

--- a/crates/filters/tests/exclude_from_file_parsing.rs
+++ b/crates/filters/tests/exclude_from_file_parsing.rs
@@ -914,18 +914,23 @@ mod rule_modifiers_from_file {
         assert!(!rules[0].applies_to_receiver());
     }
 
-    /// Test: Word-split modifier from file.
+    /// Test: the `w` word-split modifier is valid only on a merge-file rule.
+    ///
+    /// upstream: exclude.c:1279-1283 - `case 'w': if (!(rule->rflags &
+    /// FILTRULE_MERGE_FILE)) goto invalid;`. On an ordinary exclude rule
+    /// upstream reports "invalid modifier 'w'"; oc-rsync mirrors the error
+    /// rather than expanding the line into per-word excludes.
     #[test]
-    fn word_split_modifier() {
+    fn word_split_modifier_rejected_on_non_merge_rule() {
         let dir = create_tempdir();
         let path = dir.path().join("excludes.txt");
         fs::write(&path, "-w *.tmp *.bak *.log\n").expect("write");
 
-        let rules = read_rules(&path).expect("read rules");
-        assert_eq!(rules.len(), 3);
-        assert_eq!(rules[0].pattern(), "*.tmp");
-        assert_eq!(rules[1].pattern(), "*.bak");
-        assert_eq!(rules[2].pattern(), "*.log");
+        let err = read_rules(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier 'w'"),
+            "unexpected error: {err}"
+        );
     }
 }
 

--- a/crates/filters/tests/filter_rule_syntax.rs
+++ b/crates/filters/tests/filter_rule_syntax.rs
@@ -148,16 +148,16 @@ mod include_rules {
         assert!(!rules[0].applies_to_receiver());
     }
 
+    // upstream: exclude.c:1279-1283 - `w` (word-split) is valid only on a
+    // merge-file rule; on an include rule upstream reports "invalid modifier
+    // 'w'". oc-rsync mirrors the rejection.
     #[test]
-    fn include_with_word_split() {
-        let rules = parse_rules("+w *.rs *.toml *.md", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 3);
-        assert_eq!(rules[0].pattern(), "*.rs");
-        assert_eq!(rules[1].pattern(), "*.toml");
-        assert_eq!(rules[2].pattern(), "*.md");
-        for rule in &rules {
-            assert_eq!(rule.action(), FilterAction::Include);
-        }
+    fn include_with_word_split_rejected() {
+        let err = parse_rules("+w *.rs *.toml *.md", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier 'w'"),
+            "unexpected error: {err}"
+        );
     }
 }
 
@@ -275,33 +275,35 @@ mod exclude_rules {
         );
     }
 
+    // upstream: exclude.c:1261-1264 / 1279-1283 - `n` and `w` are valid only
+    // on a merge-file rule (FILTRULE_MERGE_FILE). On an ordinary exclude rule
+    // upstream jumps to `invalid`; oc-rsync mirrors that syntax error rather
+    // than silently accepting the modifier.
     #[test]
-    fn exclude_with_no_inherit_modifier() {
-        let rules = parse_rules("-n *.tmp", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert!(rules[0].is_no_inherit());
+    fn exclude_with_no_inherit_modifier_rejected() {
+        let err = parse_rules("-n *.tmp", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier 'n'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
-    fn exclude_with_word_split() {
-        let rules = parse_rules("-w *.tmp *.bak *.swp", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 3);
-        assert_eq!(rules[0].pattern(), "*.tmp");
-        assert_eq!(rules[1].pattern(), "*.bak");
-        assert_eq!(rules[2].pattern(), "*.swp");
-        for rule in &rules {
-            assert_eq!(rule.action(), FilterAction::Exclude);
-        }
+    fn exclude_with_word_split_rejected() {
+        let err = parse_rules("-w *.tmp *.bak *.swp", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier 'w'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
-    fn exclude_with_combined_modifiers_and_word_split() {
-        let rules = parse_rules("-!pw *.o *.obj", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 2);
-        for rule in &rules {
-            assert!(rule.is_negated());
-            assert!(rule.is_perishable());
-        }
+    fn exclude_with_combined_modifiers_and_word_split_rejected() {
+        let err = parse_rules("-!pw *.o *.obj", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier 'w'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/filters/tests/proptest_fuzz.rs
+++ b/crates/filters/tests/proptest_fuzz.rs
@@ -771,27 +771,34 @@ fn cvs_exclusion_rules_are_all_valid() {
     assert!(result.is_ok());
 }
 
+// upstream: exclude.c:1279-1283 - `w` (word-split) is valid only on a
+// merge-file rule. On an exclude rule upstream reports "invalid modifier
+// 'w'"; oc-rsync mirrors that rejection regardless of the trailing pattern.
 #[test]
-fn parse_word_split_empty_pattern() {
-    // -w with only whitespace after
-    let _ = parse_rules("-w   ", Path::new("<test>"));
+fn parse_word_split_empty_pattern_rejected() {
+    let err = parse_rules("-w   ", Path::new("<test>")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier 'w'"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]
-fn parse_word_split_single_word() {
-    let result = parse_rules("-w single", Path::new("<test>"));
-    assert!(result.is_ok());
-    let rules = result.unwrap();
-    assert_eq!(rules.len(), 1);
-    assert_eq!(rules[0].pattern(), "single");
+fn parse_word_split_single_word_rejected() {
+    let err = parse_rules("-w single", Path::new("<test>")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier 'w'"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]
-fn parse_word_split_many_words() {
+fn parse_word_split_many_words_rejected() {
     let words: Vec<String> = (0..100).map(|i| format!("word{i}")).collect();
     let input = format!("-w {}", words.join(" "));
-    let result = parse_rules(&input, Path::new("<test>"));
-    assert!(result.is_ok());
-    let rules = result.unwrap();
-    assert_eq!(rules.len(), 100);
+    let err = parse_rules(&input, Path::new("<test>")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier 'w'"),
+        "unexpected error: {err}"
+    );
 }


### PR DESCRIPTION
## Summary

The merge-file rule-word parser (`crates/filters/src/merge/parse.rs`) accepted the `w` (word-split) and `n` (no-inherit) modifiers on ordinary include/exclude rules, expanding `-w foo bar` into three excludes and silently storing an unused no-inherit flag. Upstream `exclude.c` gates `w`, `n`, and `e` on `FILTRULE_MERGE_FILE` and `s`, `r` on `prefix_specifies_side`, reporting the first invalid modifier left-to-right and exiting with a syntax error.

## Changes

- Gate `e`, `n`, `w` (merge-only) and `s`, `r` (side-prefix) inline in a single left-to-right `parse_modifiers` pass, so the first invalid modifier is the one reported - matching upstream's single `switch` loop (`exclude.c:1215-1289`).
- Remove the two post-pass validators and the now-unreachable non-merge word-split expansion.
- Update tests to encode the upstream-parity rejection.

## Verification

Against rsync 3.4.4: a `.rsync-filter` body of `-w foo bar` or `-n *.tmp` now errors with `invalid modifier 'w'`/`'n'` on both tools; ordering matches (`-ew` reports `e`, `-we` reports `w`, `Hsw` reports `s`). Valid `:e` (exclude-self), `:n` (no-inherit), and `:` (inherit) dir-merge effects remain byte-identical. All 1371 filters tests pass; `fmt` and `clippy -D warnings` clean.