### PR TITLE
fix(engine): compare directory mtime in whole seconds for itemize

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -287,6 +287,7 @@ fn copy_directory_recursive_inner(
                 context.omit_dir_times_enabled(),
                 false,
                 false,
+                context.options().modify_window(),
             ))
         } else {
             record.with_creation(true)
@@ -326,6 +327,7 @@ fn copy_directory_recursive_inner(
             context.omit_dir_times_enabled(),
             false,
             false,
+            context.options().modify_window(),
         );
         context.record(
             LocalCopyRecord::new(
@@ -394,6 +396,7 @@ fn copy_directory_recursive_inner(
                     context.omit_dir_times_enabled(),
                     false,
                     false,
+                    context.options().modify_window(),
                 ))
             } else {
                 record.with_creation(true)

--- a/crates/engine/src/local_copy/plan/change_set/detection.rs
+++ b/crates/engine/src/local_copy/plan/change_set/detection.rs
@@ -153,6 +153,7 @@ impl LocalCopyChangeSet {
         omit_dir_times: bool,
         xattrs_enabled: bool,
         acls_enabled: bool,
+        modify_window: Duration,
     ) -> Self {
         let mut change_set = Self::new();
 
@@ -160,8 +161,15 @@ impl LocalCopyChangeSet {
         if times_preserved {
             let new_mtime = metadata_modified_time(source);
             let old_mtime = metadata_modified_time(existing);
+            // upstream: generator.c:526 - itemize() sets ITEM_REPORT_TIME via
+            // `!same_time(file->modtime, 0, &sxp->st)`. same_time() (util1.c:1478)
+            // compares whole seconds under `--modify-window`, so a sub-second
+            // mtime drift on a directory must NOT light the `t` glyph. This is
+            // type-agnostic in upstream: directories use the same same_time()
+            // path as files.
             match (new_mtime, old_mtime) {
-                (Some(new_value), Some(old_value)) if new_value == old_value => {}
+                (Some(new_value), Some(old_value))
+                    if system_time_within_window(new_value, old_value, modify_window) => {}
                 _ => {
                     change_set = change_set.with_time_change(Some(TimeChange::Modified));
                 }

--- a/crates/engine/src/local_copy/plan/change_set/tests.rs
+++ b/crates/engine/src/local_copy/plan/change_set/tests.rs
@@ -685,11 +685,57 @@ fn for_existing_directory_flags_time_change_when_mtimes_differ() {
 
     let options = MetadataOptions::new().preserve_times(true);
     let change_set = LocalCopyChangeSet::for_existing_directory(
-        &src_meta, &dst_meta, &options, false, false, false,
+        &src_meta,
+        &dst_meta,
+        &options,
+        false,
+        false,
+        false,
+        Duration::ZERO,
     );
 
     assert_eq!(change_set.time_change(), Some(TimeChange::Modified));
     assert!(change_set.has_any_change());
+}
+
+/// upstream: generator.c:526 via same_time() (util1.c:1478) - directory
+/// itemize compares whole seconds under modify_window == 0, so a sub-second
+/// mtime drift within the same whole second must NOT report a time change.
+/// This mirrors the file/symlink paths, which already ignore sub-second drift.
+#[cfg(unix)]
+#[test]
+fn for_existing_directory_ignores_sub_second_mtime_drift() {
+    use filetime::{FileTime, set_file_mtime};
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src_dir = temp.path().join("src");
+    let dst_dir = temp.path().join("dst");
+    fs::create_dir(&src_dir).expect("create src");
+    fs::create_dir(&dst_dir).expect("create dst");
+
+    // Same whole second, different nanoseconds: upstream same_time() treats
+    // these as equal, so no `t` glyph.
+    set_file_mtime(&src_dir, FileTime::from_unix_time(1_500_000, 500_000_000))
+        .expect("set src mtime");
+    set_file_mtime(&dst_dir, FileTime::from_unix_time(1_500_000, 100_000_000))
+        .expect("set dst mtime");
+
+    let src_meta = fs::metadata(&src_dir).expect("src meta");
+    let dst_meta = fs::metadata(&dst_dir).expect("dst meta");
+
+    let options = MetadataOptions::new().preserve_times(true);
+    let change_set = LocalCopyChangeSet::for_existing_directory(
+        &src_meta,
+        &dst_meta,
+        &options,
+        false,
+        false,
+        false,
+        Duration::ZERO,
+    );
+
+    assert_eq!(change_set.time_change(), None);
+    assert!(!change_set.has_any_change());
 }
 
 #[cfg(unix)]
@@ -712,7 +758,13 @@ fn for_existing_directory_no_change_when_mtimes_match() {
 
     let options = MetadataOptions::new().preserve_times(true);
     let change_set = LocalCopyChangeSet::for_existing_directory(
-        &src_meta, &dst_meta, &options, false, false, false,
+        &src_meta,
+        &dst_meta,
+        &options,
+        false,
+        false,
+        false,
+        Duration::ZERO,
     );
 
     assert_eq!(change_set.time_change(), None);
@@ -738,7 +790,13 @@ fn for_existing_directory_omit_dir_times_suppresses_time_flag() {
 
     let options = MetadataOptions::new().preserve_times(true);
     let change_set = LocalCopyChangeSet::for_existing_directory(
-        &src_meta, &dst_meta, &options, true, false, false,
+        &src_meta,
+        &dst_meta,
+        &options,
+        true,
+        false,
+        false,
+        Duration::ZERO,
     );
 
     assert_eq!(change_set.time_change(), None);


### PR DESCRIPTION
## Problem

Under `-ii`, an existing directory whose mtime differs from the source by only a **sub-second** amount was wrongly itemized with a time-change glyph:

```
oc (before):  .d..t...... ./
upstream:     .d          ./
```

Regular files and symlinks already ignored sub-second drift; only directories over-reported.

## Root cause

`for_existing_directory()` in `crates/engine/src/local_copy/plan/change_set/detection.rs` compared modification times with raw nanosecond `SystemTime` equality (`new_value == old_value`). The file path in the same module already compares correctly via `system_time_within_window()`, which mirrors upstream `same_time()` (util1.c:1478): timestamps are truncated to whole seconds under `--modify-window`, so a sub-second drift within the same whole second is treated as equal.

Upstream derives `ITEM_REPORT_TIME` for directories through the same `same_time()` path as files (generator.c:526); `itemize()` is type-agnostic for the time slot (log.c:722 `c[4]`).

## Fix

Route the directory mtime comparison through `system_time_within_window()`, threading `modify_window` from `context.options().modify_window()` at the three call sites. Only the directory mtime compare changes; file and symlink paths are untouched.

## Validation (byte-for-byte vs upstream rsync 3.4.3)

Sub-second dir mtime diff (same whole second):

```
upstream:   .d          ./
oc before:  .d..t...... ./
oc fixed:   .d          ./   <- now matches upstream
```

Full >= 1s dir mtime diff (no regression):

```
upstream / oc before / oc fixed:   .d..t...... ./
```

Files and symlinks unchanged in all cases.

Added a regression test asserting an existing directory with sub-second-newer mtime reports no time change, alongside the existing whole-second and omit-dir-times cases. `cargo fmt`, `cargo clippy -p engine -D warnings`, and the targeted tests pass.