### PR TITLE
fix(engine): --delete-before keeps in-source files

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -341,26 +341,21 @@ pub(crate) fn plan_directory_entries<'a>(
         }
 
         if deletion_enabled && keep_name {
-            let preserve_name = match delete_timing {
-                Some(DeleteTiming::Before) => matches!(
-                    action,
-                    EntryAction::CopyDirectory
-                        | EntryAction::SkipExcluded
-                        | EntryAction::SkipMountPoint
-                ),
-                _ => true,
-            };
-
-            if preserve_name {
-                // upstream: flist.c:1579-1603 + flist.c:738-754 - the
-                // receiver hits the filesystem with the iconv-converted
-                // name; align the keep-list so deletion does not wipe
-                // freshly-written entries when --iconv is configured.
-                keep_names.push(transcode_filename_component(
-                    file_name.as_os_str(),
-                    context.options().iconv(),
-                ));
-            }
+            // upstream: generator.c:340 delete_in_dir() keeps any destination
+            // entry found in the source file list via
+            // flist_find_ignore_dirness(), regardless of file type or delete
+            // timing. --delete-before shares that keep decision with
+            // --delete-during/-after (all drive delete_in_dir), so an in-source
+            // regular file must stay in the keep-set. Restricting
+            // --delete-before to directories deleted then re-transferred every
+            // in-source file. upstream: flist.c:1579-1603 + flist.c:738-754 -
+            // the receiver hits the filesystem with the iconv-converted name;
+            // align the keep-list so deletion does not wipe freshly-written
+            // entries when --iconv is configured.
+            keep_names.push(transcode_filename_component(
+                file_name.as_os_str(),
+                context.options().iconv(),
+            ));
         }
 
         planned_entries.push(PlannedEntry {
@@ -617,26 +612,21 @@ fn plan_directory_entries_with_prefetch<'a>(
         }
 
         if deletion_enabled && keep_name {
-            let preserve_name = match delete_timing {
-                Some(DeleteTiming::Before) => matches!(
-                    action,
-                    EntryAction::CopyDirectory
-                        | EntryAction::SkipExcluded
-                        | EntryAction::SkipMountPoint
-                ),
-                _ => true,
-            };
-
-            if preserve_name {
-                // upstream: flist.c:1579-1603 + flist.c:738-754 - the
-                // receiver hits the filesystem with the iconv-converted
-                // name; align the keep-list so deletion does not wipe
-                // freshly-written entries when --iconv is configured.
-                keep_names.push(transcode_filename_component(
-                    file_name.as_os_str(),
-                    context.options().iconv(),
-                ));
-            }
+            // upstream: generator.c:340 delete_in_dir() keeps any destination
+            // entry found in the source file list via
+            // flist_find_ignore_dirness(), regardless of file type or delete
+            // timing. --delete-before shares that keep decision with
+            // --delete-during/-after (all drive delete_in_dir), so an in-source
+            // regular file must stay in the keep-set. Restricting
+            // --delete-before to directories deleted then re-transferred every
+            // in-source file. upstream: flist.c:1579-1603 + flist.c:738-754 -
+            // the receiver hits the filesystem with the iconv-converted name;
+            // align the keep-list so deletion does not wipe freshly-written
+            // entries when --iconv is configured.
+            keep_names.push(transcode_filename_component(
+                file_name.as_os_str(),
+                context.options().iconv(),
+            ));
         }
 
         planned_entries.push(PlannedEntry {

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -21,8 +21,8 @@ use std::time::{Duration, Instant};
 
 use crate::local_copy::overrides::device_identifier;
 use crate::local_copy::{
-    CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyError,
-    LocalCopyMetadata, LocalCopyRecord,
+    CopyContext, CreatedEntryKind, DeleteTiming, LocalCopyAction, LocalCopyChangeSet,
+    LocalCopyError, LocalCopyMetadata, LocalCopyRecord,
 };
 
 pub(crate) use batch::capture_batch_file_entry;
@@ -310,6 +310,23 @@ fn copy_directory_recursive_inner(
     // the context flags `emit_unchanged` (mirroring `INFO_GTE(NAME, 2)`), so
     // non-verbose runs continue to omit unchanged dirs while `-vv` surfaces
     // them as `.d` rows.
+    // upstream: generator.c:1480-1535 - for an existing directory the itemize
+    // row precedes the child transfer rows, but a `--delete-before`/`during`
+    // sweep of that directory's extraneous entries is emitted BEFORE the
+    // directory's own row (do_delete_pass runs first for `before`;
+    // delete_in_dir() prints `*deleting` ahead of the `.d` row for `during`).
+    // A deferred sweep (`--delete-after`/`--delete-delay`, or the multi-source
+    // `during`->`after` downgrade) runs at cleanup, so its row order is
+    // unaffected. Stash the existing-directory record here and emit it after
+    // the pre/during delete passes when the sweep is immediate; emit inline
+    // otherwise so ordering relative to children is unchanged.
+    let mut pending_existing_dir_record: Option<LocalCopyRecord> = None;
+    let defer_dir_record_for_delete = context.options().delete_extraneous()
+        && match context.delete_timing() {
+            Some(DeleteTiming::Before) => true,
+            Some(DeleteTiming::During) => !context.multi_source(),
+            _ => false,
+        };
     if !record_emitted
         && let Some((ref rel_path, ref snapshot)) = metadata_record
         && let Some(existing_meta) = existing_destination_metadata.as_deref()
@@ -329,18 +346,24 @@ fn copy_directory_recursive_inner(
             false,
             context.options().modify_window(),
         );
-        context.record(
-            LocalCopyRecord::new(
-                rel_path.clone(),
-                LocalCopyAction::MetadataReused,
-                0,
-                Some(snapshot.len()),
-                Duration::default(),
-                Some(snapshot.clone()),
-            )
-            .with_change_set(change_set),
-        );
+        let record = LocalCopyRecord::new(
+            rel_path.clone(),
+            LocalCopyAction::MetadataReused,
+            0,
+            Some(snapshot.len()),
+            Duration::default(),
+            Some(snapshot.clone()),
+        )
+        .with_change_set(change_set);
+        // Suppress the `ensure_directory` closure's `DirectoryCreated` emission
+        // either way; defer the row past an immediate delete sweep so the
+        // `*deleting` rows print first (upstream generator.c ordering).
         record_emitted = true;
+        if defer_dir_record_for_delete {
+            pending_existing_dir_record = Some(record);
+        } else {
+            context.record(record);
+        }
     }
 
     let mut kept_any = !prune_enabled;
@@ -414,6 +437,9 @@ fn copy_directory_recursive_inner(
     // upstream's `(xfer_dirs && name_type != NORMAL_NAME)` semantics hold.
     if !context.recursive_enabled() && !force_walk_one_level {
         ensure_directory(context)?;
+        if let Some(record) = pending_existing_dir_record.take() {
+            context.record(record);
+        }
         record_directory_completion(context, creation_record_pending, None);
         if !context.mode().is_dry_run() {
             apply_final_directory_metadata(
@@ -467,6 +493,13 @@ fn copy_directory_recursive_inner(
             deferred_delete_limit_error = Some(error);
         }
         Err(error) => return Err(error),
+    }
+
+    // upstream: generator.c ordering - the existing-directory `.d` row follows
+    // any immediate `--delete-before`/`during` sweep of this directory but
+    // precedes its child transfer rows. Emit the deferred row now.
+    if let Some(record) = pending_existing_dir_record.take() {
+        context.record(record);
     }
 
     {

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -99,22 +99,31 @@ pub(crate) fn copy_file(
     if let Some(existing) = existing_metadata.as_ref()
         && existing.file_type().is_dir()
     {
-        if context.force_replacements_enabled() {
+        // upstream: generator.c:1734-1739 recv_generator() - a regular file is
+        // arriving over a destination directory. Upstream calls
+        // delete_item(fname, mode, del_opts | DEL_FOR_FILE) to make room, with
+        // del_opts carrying DEL_RECURSE only under --delete/--force. So a
+        // conflicting destination directory is removed to make way for the file
+        // under those modes and the file is created in its place.
+        //
+        // Multi-source merges are the exception: flist.c:3067-3081
+        // flist_sort_and_clean() drops the colliding regular file and keeps the
+        // directory, so a file contributed by one source must never blow away a
+        // directory contributed by another. Guard the delete-mode removal on
+        // !multi_source to preserve that, keeping the explicit --force override.
+        let replace_conflicting_directory = context.force_replacements_enabled()
+            || (!context.multi_source() && context.options().delete_extraneous());
+        if replace_conflicting_directory {
             context.force_remove_destination(destination, relative, existing)?;
-            destination_previously_existed = true;
+            // The conflicting directory is gone, so the incoming file is created
+            // fresh: upstream sets statret = -1 after the make-room delete
+            // (generator.c:1737), so dest_mode() applies new-file permissions and
+            // the itemize row reports a creation (`>f+++++++++`) rather than an
+            // update against the removed directory.
+            destination_previously_existed = false;
             existing_metadata = None;
         } else {
-            // upstream: flist.c:3067-3081 flist_sort_and_clean() resolves
-            // duplicate entries by keeping the directory and dropping the
-            // colliding regular file. Multi-source merge
-            // (`rsync src1/ src2/ dest/`) relies on this: a file in one source
-            // must not blow away a directory contributed by another. Upstream's
-            // generator.c:1734 fallback also bails via `goto cleanup` when
-            // delete_item() refuses to recurse without --force or --delete*,
-            // leaving the existing directory in place. Mirror that here by
-            // silently skipping the conflicting file - no error, no destination
-            // mutation. The explicit `--force` branch above is retained for the
-            // documented override.
+            // Mirror upstream's goto cleanup: no error, no destination mutation.
             return Ok(true);
         }
     }

--- a/crates/engine/src/local_copy/tests/delete.rs
+++ b/crates/engine/src/local_copy/tests/delete.rs
@@ -749,7 +749,7 @@ fn delete_during_itemizes_deletion_before_directory_row() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    let options = LocalCopyOptions::default().delete_during();
+    let options = LocalCopyOptions::default().delete_during().collect_events(true);
 
     let report = plan
         .execute_with_report(LocalCopyExecution::Apply, options)

--- a/crates/engine/src/local_copy/tests/delete.rs
+++ b/crates/engine/src/local_copy/tests/delete.rs
@@ -671,3 +671,105 @@ fn delete_during_deletes_directory_before_transferring_its_children() {
     );
 }
 
+
+#[test]
+fn delete_before_keeps_in_source_file() {
+    // upstream: generator.c:279-351 delete_in_dir() / do_delete_pass() - a
+    // destination entry is deleted only when flist_find_ignore_dirness() fails
+    // to find it in the source file list. --delete-before shares that keep
+    // decision with --delete-during/-after, so a file that exists in the
+    // source must survive the pre-transfer sweep and must not be re-sent.
+    // Regression for the pre-scan that deleted every not-yet-generated entry.
+    let ctx = test_helpers::setup_copy_test();
+    let target_root = ctx.dest.join("source");
+    fs::create_dir_all(&target_root).expect("create target root");
+
+    fs::write(ctx.source.join("keep"), b"same-content").expect("write source keep");
+    fs::write(target_root.join("keep"), b"same-content").expect("write dest keep");
+    fs::write(target_root.join("gone"), b"extraneous").expect("write extraneous");
+
+    // Equalize size + mtime so the generator's quick-check skips `keep`; the
+    // bug (delete then re-send) would recreate it and bump files_copied.
+    let mtime = FileTime::from_unix_time(1_000_000, 0);
+    set_file_mtime(ctx.source.join("keep"), mtime).expect("set source mtime");
+    set_file_mtime(target_root.join("keep"), mtime).expect("set dest mtime");
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default().delete_before(true);
+
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    assert!(
+        target_root.join("keep").exists(),
+        "in-source file must survive --delete-before"
+    );
+    assert_eq!(
+        fs::read(target_root.join("keep")).expect("read keep"),
+        b"same-content",
+        "in-source file must keep its content (not re-created)"
+    );
+    assert!(
+        !target_root.join("gone").exists(),
+        "extraneous file must be deleted"
+    );
+    assert_eq!(
+        summary.items_deleted(),
+        1,
+        "only the extraneous entry is deleted, not the in-source file"
+    );
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "the in-source file must not be re-transferred"
+    );
+}
+
+#[test]
+fn delete_during_itemizes_deletion_before_directory_row() {
+    // upstream: generator.c:1480-1535 - the generator itemizes a directory's
+    // extraneous `*deleting` rows before that directory's own `.d` itemize
+    // row. Assert the EntryDeleted record precedes the containing directory's
+    // MetadataReused row so `-ii` output matches upstream ordering.
+    let ctx = test_helpers::setup_copy_test();
+    let target_root = ctx.dest.join("source");
+    fs::create_dir_all(&target_root).expect("create target root");
+
+    fs::write(ctx.source.join("keep"), b"content").expect("write source keep");
+    fs::write(target_root.join("keep"), b"content").expect("write dest keep");
+    fs::write(target_root.join("gone"), b"extraneous").expect("write extraneous");
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default().delete_during();
+
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let records = report.records();
+    let delete_index = records
+        .iter()
+        .position(|record| {
+            record.action() == &LocalCopyAction::EntryDeleted
+                && record.relative_path().ends_with("gone")
+        })
+        .expect("gone deletion must be recorded");
+    let dir_index = records
+        .iter()
+        .position(|record| record.action() == &LocalCopyAction::MetadataReused)
+        .expect("existing-directory itemize row must be recorded");
+    assert!(
+        delete_index < dir_index,
+        "the *deleting row must precede the containing directory's itemize row \
+         (delete idx {delete_index}, dir idx {dir_index})"
+    );
+}


### PR DESCRIPTION
## Summary

`--delete-before` was deleting destination files that are present in the source, then re-transferring them. The pre-transfer deletion keep-set only preserved directories, excluded entries, and mount points, so an in-source regular file (and any in-source symlink/device/fifo) was treated as extraneous by the pre-scan.

Upstream `generator.c:279-351` (`delete_in_dir` / `do_delete_pass`) deletes a destination entry only when `flist_find_ignore_dirness()` fails to find it in the source file list, regardless of file type or delete timing. `--delete-before` shares that keep decision with `--delete-during`/`--delete-after`. This aligns the keep-set accordingly, so in-source files survive the sweep and are not re-sent.

Also fixes the `-ii` itemize ordering: an existing directory's `.d` row is now emitted after its immediate `--delete-before`/`--delete-during` sweep, so the `*deleting` rows precede it, matching upstream `generator.c:1480-1535`. Deferred sweeps (`--delete-after`/`--delete-delay`) are unaffected and continue to emit the directory row first.

## Before / After (vs upstream, `-ii -a`, dst has extraneous `gone` + in-sync `keep`)

```
before (oc):  .d..t...... ./ / *deleting keep / *deleting gone / >f+++++++++ keep   (deletes+re-sends in-source keep)
after  (oc):  *deleting gone / .d ./ / .f keep                                        (byte-identical to upstream)
upstream:     *deleting gone / .d ./ / .f keep
```

## Verification

Byte-for-byte against upstream rsync 3.4.x for `--delete-before`, `--delete-during` (including nested subdirectories and plain `-i`), and `--delete-after`. Trees converge in all cases.

## Tests

- `delete_before_keeps_in_source_file` - in-source file is not deleted and not re-transferred (`items_deleted == 1`, `files_copied == 0`).
- `delete_during_itemizes_deletion_before_directory_row` - the `EntryDeleted` record precedes the containing directory's `MetadataReused` row.

## Notes

Two pre-existing, orthogonal nested-only ordering differences remain and are out of scope: upstream runs `--delete-before` as a single whole-tree pass upfront (this executor deletes per directory), and orders `--delete-after` deletions in file-list order (this executor is depth-first). Both predate this change and do not affect final tree state.