### PR TITLE
fix(engine): itemize new hardlink followers as created

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -3,6 +3,7 @@
 //! Orchestrates the transfer lifecycle by configuring server infrastructure,
 //! establishing the handshake result, and delegating to `run_server_with_handshake`.
 
+use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
@@ -141,12 +142,23 @@ pub(crate) fn run_push_transfer(
         .as_mut()
         .map(|a| a as &mut dyn TransferProgressCallback);
 
-    // upstream: log.c:818-826 log_item() - the client-visible itemize row is
-    // produced exactly once, by the remote receiver's generator, and forwarded
-    // as a MSG_INFO frame (rwrite when `am_server`). The local sender must NOT
-    // also emit a row from the bare wire iflags it echoes back, or every pushed
-    // file itemizes twice. Passing `None` here mirrors the SSH push path
-    // (ssh_transfer/drive.rs) so both transports emit a single row.
+    // upstream: sender.c:461 log_item(FCLIENT) - on a push the client is the
+    // sender, and the client-visible itemize row is printed by the SENDER from
+    // the iflags the remote receiver's generator writes over the wire
+    // (generator.c:583-599 write_shortint(sock_f_out, iflags) for protocol >=
+    // 29). The remote generator's own log_item never reaches the client because
+    // log.c:822 gates the FCLIENT write on `!am_server`. So the local sender is
+    // the single source of push itemize; the remote receiver must not forward a
+    // pre-rendered MSG_INFO line (see receiver::emit_itemize). This restores
+    // output for oc-client -> upstream-daemon pushes, where upstream never
+    // forwards oc's itemize.
+    let wants_itemize = config.itemize_changes();
+    let stdout_handle = std::io::stdout();
+    let mut itemize_cb = move |line: &str| {
+        let mut out = stdout_handle.lock();
+        let _ = out.write_all(line.as_bytes());
+    };
+
     let result = crate::server::run_server_with_handshake(
         server_config,
         handshake,
@@ -154,7 +166,11 @@ pub(crate) fn run_push_transfer(
         writer,
         progress,
         batch_recording,
-        None,
+        if wants_itemize {
+            Some(&mut itemize_cb as &mut dyn crate::server::ItemizeCallback)
+        } else {
+            None
+        },
     );
 
     match result {

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -5,7 +5,7 @@
 //! server over the SSH pipes and reaps the remote child. This mirrors the flow
 //! in upstream `main.c:do_cmd()` / `main.c:client_run()`.
 
-use std::io::BufReader;
+use std::io::{BufReader, Write};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -347,6 +347,21 @@ fn run_server_over_ssh_connection(
         ));
     }
     let negotiated_protocol = handshake.protocol.as_u8();
+
+    // upstream: sender.c:461 log_item(FCLIENT) - on an SSH push the local side
+    // is the sender (ServerRole::Generator) and prints the client-visible
+    // itemize row from the iflags the remote receiver's generator writes over
+    // the wire (generator.c:583-599). The remote generator never forwards the
+    // row itself (log.c:822 gates FCLIENT on `!am_server`). On a pull the local
+    // side is the receiver, which itemizes to its own stdout via
+    // receiver::emit_itemize, so no sender callback is needed there.
+    let wants_itemize = config.role == ServerRole::Generator && config.flags.info_flags.itemize;
+    let stdout_handle = std::io::stdout();
+    let mut itemize_cb = move |line: &str| {
+        let mut out = stdout_handle.lock();
+        let _ = out.write_all(line.as_bytes());
+    };
+
     let transfer_result = crate::server::run_server_with_handshake(
         config,
         handshake,
@@ -354,7 +369,11 @@ fn run_server_over_ssh_connection(
         &mut writer,
         progress,
         batch_recording,
-        None,
+        if wants_itemize {
+            Some(&mut itemize_cb as &mut dyn crate::server::ItemizeCallback)
+        } else {
+            None
+        },
     );
 
     // Close the writer to signal EOF so the remote process can exit.

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -542,17 +542,27 @@ pub(super) fn process_links(
             change_set =
                 change_set.with_time_change(Some(crate::local_copy::TimeChange::TransferTime));
         }
-        context.record(
-            LocalCopyRecord::new(
-                record_path.to_path_buf(),
-                LocalCopyAction::HardLink,
-                0,
-                total_bytes,
-                Duration::default(),
-                Some(metadata_snapshot),
-            )
-            .with_change_set(change_set),
-        );
+        let mut record = LocalCopyRecord::new(
+            record_path.to_path_buf(),
+            LocalCopyAction::HardLink,
+            0,
+            total_bytes,
+            Duration::default(),
+            Some(metadata_snapshot),
+        )
+        .with_change_set(change_set);
+        // upstream: hlink.c:228-234 maybe_hard_link() - a freshly linked
+        // follower is itemized through atomic_create() with the follower's
+        // *own* statret, which is < 0 when its destination did not yet exist.
+        // log.c:736-738 then sets ITEM_IS_NEW, filling attribute slots 2-10
+        // with '+' so the row renders `hf+++++++++`. The already-shared-inode
+        // (uptodate) alias is handled by the `is_already_hardlinked` branch
+        // above and stays blank, so only a genuinely new follower is marked
+        // created here.
+        if !destination_previously_existed {
+            record = record.with_creation(true);
+        }
+        context.record(record);
         context.register_created_path(
             destination,
             CreatedEntryKind::HardLink,

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -559,7 +559,32 @@ pub(super) fn process_links(
         // (uptodate) alias is handled by the `is_already_hardlinked` branch
         // above and stays blank, so only a genuinely new follower is marked
         // created here.
-        if !destination_previously_existed {
+        //
+        // upstream: hlink.c:385-414 hard_link_check() - before that itemize,
+        // when the follower's own destination is absent (statret < 0) and an
+        // alt-dest basis is configured (`basis_dir[0] != NULL`), the follower's
+        // name is quick_check_ok()'d against the --copy-dest/--link-dest tree.
+        // A match bumps statret to 1, so the itemize above never sets
+        // ITEM_IS_NEW and the follower renders blank (`hf          `) - mirroring
+        // the leader that was itself satisfied from the alt-dest tree
+        // (generator.c:995-1052 try_dests_reg). Mark the follower created only
+        // when its destination is new AND no alt-dest basis satisfies it, so a
+        // fresh local group still renders `hf+++++++++`.
+        let matched_from_dests = !context.reference_directories().is_empty()
+            && find_reference_action(
+                context,
+                ReferenceQuery {
+                    destination,
+                    relative: record_path,
+                    source,
+                    metadata,
+                    size_only: size_only_enabled,
+                    ignore_times: ignore_times_enabled,
+                    checksum: checksum_enabled,
+                },
+            )?
+            .is_some();
+        if !destination_previously_existed && !matched_from_dests {
             record = record.with_creation(true);
         }
         context.record(record);

--- a/crates/engine/src/local_copy/tests/itemize_changes.rs
+++ b/crates/engine/src/local_copy/tests/itemize_changes.rs
@@ -502,6 +502,82 @@ fn itemize_new_hard_link_follower_marked_created() {
     );
 }
 
+// upstream: hlink.c:385-414 hard_link_check() + generator.c:995-1052
+// try_dests_reg() - when a hard-link follower's destination is absent but its
+// name matches a --copy-dest basis (quick_check_ok), statret is bumped from < 0
+// to 1, so the itemize (log.c:736-738) never sets ITEM_IS_NEW: the follower
+// renders blank (`hf          `), mirroring the leader that was itself satisfied
+// from the copy-dest tree. Regression guard so the empty-destination
+// new-follower fix does not wrongly mark a copy-dest-matched follower created.
+#[cfg(unix)]
+#[test]
+fn itemize_copy_dest_hard_link_follower_not_marked_created() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    let copy_dest_dir = temp.path().join("copy_dest");
+    let dest_dir = temp.path().join("dest");
+
+    fs::create_dir(&source_dir).expect("create source dir");
+    fs::create_dir(&copy_dest_dir).expect("create copy_dest dir");
+    fs::create_dir(&dest_dir).expect("create dest dir");
+
+    // Source group leader and follower share one inode.
+    let leader = source_dir.join("config1");
+    let follower = source_dir.join("extra");
+    fs::write(&leader, b"shared content").expect("write leader");
+    fs::hard_link(&leader, &follower).expect("hard link extra -> config1");
+
+    // The destination mirrors the source directory name (`dest/source/...`),
+    // so the copy-dest basis is resolved at the same relative path. Hold
+    // matching content for both names so the quick-check passes for the
+    // follower's own basis.
+    let copy_dest_source = copy_dest_dir.join("source");
+    fs::create_dir(&copy_dest_source).expect("create copy_dest/source");
+    let copy_leader = copy_dest_source.join("config1");
+    let copy_follower = copy_dest_source.join("extra");
+    fs::write(&copy_leader, b"shared content").expect("write copy_dest leader");
+    fs::write(&copy_follower, b"shared content").expect("write copy_dest follower");
+
+    let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
+    set_file_mtime(&leader, timestamp).expect("source leader mtime");
+    set_file_mtime(&follower, timestamp).expect("source follower mtime");
+    set_file_mtime(&copy_leader, timestamp).expect("copy_dest leader mtime");
+    set_file_mtime(&copy_follower, timestamp).expect("copy_dest follower mtime");
+
+    let operands = vec![
+        source_dir.into_os_string(),
+        dest_dir.into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .times(true)
+        .hard_links(true)
+        .collect_events(true)
+        .extend_reference_directories([ReferenceDirectory::new(
+            ReferenceDirectoryKind::Copy,
+            &copy_dest_dir,
+        )]);
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let records = report.records();
+
+    // The follower is hard-linked to a leader that was itself matched from
+    // --copy-dest, so upstream leaves ITEM_IS_NEW unset: it must render blank
+    // (`hf          `), never `hf+++++++++`.
+    let follower_record = records
+        .iter()
+        .find(|r| r.action() == &LocalCopyAction::HardLink)
+        .expect("follower hard-link record");
+    assert!(
+        !follower_record.was_created(),
+        "copy-dest hard-link follower must stay blank, not marked created"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn itemize_size_change_detected_correctly() {

--- a/crates/engine/src/local_copy/tests/itemize_changes.rs
+++ b/crates/engine/src/local_copy/tests/itemize_changes.rs
@@ -445,6 +445,63 @@ fn itemize_hard_link_shows_correct_action() {
     assert!(hard_link_record.is_some(), "should have hard link record");
 }
 
+// upstream: hlink.c:228-234 maybe_hard_link() + log.c:736-738 - a hard-link
+// follower whose destination does not yet exist is itemized through
+// atomic_create() with the follower's own negative statret, which sets
+// ITEM_IS_NEW and renders `hf+++++++++`. Regression guard for the follower
+// that previously collapsed to blank attribute slots when created into an
+// empty destination.
+#[cfg(unix)]
+#[test]
+fn itemize_new_hard_link_follower_marked_created() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    let dest_dir = temp.path().join("dest");
+
+    fs::create_dir(&source_dir).expect("create source dir");
+    fs::create_dir(&dest_dir).expect("create dest dir");
+
+    let file1 = source_dir.join("a");
+    let file2 = source_dir.join("b");
+    fs::write(&file1, b"linked content").expect("write a");
+    fs::hard_link(&file1, &file2).expect("hard link b -> a");
+
+    let operands = vec![
+        source_dir.into_os_string(),
+        dest_dir.into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .hard_links(true)
+        .collect_events(true);
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let records = report.records();
+
+    // The data-holder leader is a genuinely new file (`>f+++++++++`).
+    let leader = records
+        .iter()
+        .find(|r| r.action() == &LocalCopyAction::DataCopied)
+        .expect("leader data-copy record");
+    assert!(leader.was_created(), "leader must itemize as created");
+
+    // The follower is hard-linked into a previously empty destination, so
+    // its own destination did not exist: upstream marks ITEM_IS_NEW and it
+    // must render `hf+++++++++`, not a blank attribute run.
+    let follower = records
+        .iter()
+        .find(|r| r.action() == &LocalCopyAction::HardLink)
+        .expect("follower hard-link record");
+    assert!(
+        follower.was_created(),
+        "new hard-link follower must be marked created so it itemizes hf+++++++++"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn itemize_size_change_detected_correctly() {

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -395,13 +395,16 @@ impl GeneratorContext {
         }
         // upstream: generator.c:582-583 - the gate is the OR of four
         // conditions. Significant flags is the common case; INFO_GTE(NAME, 2)
-        // makes `-vv` surface unchanged entries; ITEM_XNAME_FOLLOWS forces
-        // emission when an alternate basis name trails. `stdout_format_has_i
-        // > 1` is the `-ii` "show even unchanged" knob; oc-rsync does not
-        // distinguish single vs double `-i` yet, so that fourth condition is
-        // omitted here and the other three are honored.
-        let force_emit =
-            info_gte(InfoFlag::Name, 2) || iflags.raw() & ItemFlags::ITEM_XNAME_FOLLOWS != 0;
+        // makes `-vv` surface unchanged entries; `stdout_format_has_i > 1` is
+        // the `-ii` "show even unchanged" knob (tracked as
+        // `info_flags.itemize_unchanged`); ITEM_XNAME_FOLLOWS forces emission
+        // when an alternate basis name trails. On a push the sender owns the
+        // client-visible itemize (the remote generator forwards iflags over the
+        // wire, generator.c:583-599), so honoring `itemize_unchanged` here keeps
+        // `-ii` unchanged rows on the sole client-side print path.
+        let force_emit = info_gte(InfoFlag::Name, 2)
+            || self.config.flags.info_flags.itemize_unchanged
+            || iflags.raw() & ItemFlags::ITEM_XNAME_FOLLOWS != 0;
         if !iflags.has_significant_flags() && !force_emit {
             return Ok(());
         }

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -11,12 +11,12 @@ impl ReceiverContext {
     ///
     /// Whether itemize-changes output should be produced for this transfer.
     ///
-    /// Emitted whenever the user requested `--itemize-changes` (`-i`). The
-    /// destination of each line depends on the role (see [`Self::emit_info_line`]):
-    /// a server receiver multiplexes it as a `MSG_INFO` frame to the client,
-    /// while a client receiver (a pull, where oc is the generator) writes it to
-    /// its own stdout - mirroring upstream `log.c:rwrite()` which sends
-    /// `MSG_INFO` only when `am_server` and otherwise writes to the client fd.
+    /// Emitted whenever the user requested `--itemize-changes` (`-i`). Only a
+    /// client receiver (a pull, where oc is the generator/receiver on the
+    /// client) writes the row to its own stdout (see [`Self::emit_itemize`]); a
+    /// server receiver (the remote end of a push) produces no client-visible
+    /// row, since upstream `log.c:822` gates the `FCLIENT` write on `!am_server`
+    /// and the push row is printed by the client's sender instead.
     #[must_use]
     pub(in crate::receiver) const fn should_emit_itemize(&self) -> bool {
         self.config.flags.info_flags.itemize
@@ -56,31 +56,25 @@ impl ReceiverContext {
         }
     }
 
-    /// Emits a MSG_INFO frame with itemize output for a file entry.
+    /// Renders the itemize line for a file entry, or `None` when the entry is
+    /// completely unchanged and the itemize level does not request unchanged
+    /// rows.
     ///
-    /// Formats the itemize string (`"%i %n%L\n"`) and sends it as a MSG_INFO
-    /// multiplexed message. The direction glyph follows upstream `log.c:707-710`:
-    /// a server-mode receiver is the remote end of a push (client is the sender)
-    /// and renders `<`; a client-mode receiver is a local pull and renders `>`.
-    ///
-    /// Suppresses output when `iflags` has no significant flags set (the file is
-    /// completely unchanged), matching upstream's gate in `itemize()` at
-    /// `generator.c:574-576`.
+    /// Pure formatting: applies the created-root-directory override and the
+    /// significance gate, then formats via `format_itemize_line`. Routing to a
+    /// sink (stdout vs MSG_INFO vs suppression) is the caller's concern - see
+    /// [`Self::emit_itemize`].
     ///
     /// # Upstream Reference
     ///
     /// - `generator.c:574-576` - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
-    /// - `generator.c:2260` - `itemize()` in receiver's generator context
-    /// - `log.c:330-340` - `rwrite()` converts to `send_msg(MSG_INFO)` when `am_server`
-    pub(in crate::receiver) fn emit_itemize<W: crate::writer::MsgInfoSender + ?Sized>(
+    /// - `main.c:794-796` - `FLAG_DIR_CREATED` for a pre-flight-mkdir'd root
+    /// - `log.c:707-710` - direction glyph selection
+    pub(in crate::receiver) fn render_itemize_line(
         &self,
-        writer: &mut W,
         iflags: &crate::generator::ItemFlags,
         entry: &protocol::flist::FileEntry,
-    ) -> std::io::Result<()> {
-        if !self.should_emit_itemize() {
-            return Ok(());
-        }
+    ) -> Option<String> {
         // upstream: main.c:794-796 - when the receiver pre-flight-mkdirs the
         // destination root, `flist->files[0]->flags |= FLAG_DIR_CREATED`. The
         // generator's `itemize()` then sees `statret < 0` for the root entry,
@@ -100,7 +94,7 @@ impl ReceiverContext {
         let show_unchanged =
             self.config.flags.info_flags.itemize_unchanged || self.config.flags.verbose_level > 1;
         if !is_created_root_dir && !show_unchanged && !iflags.has_significant_flags() {
-            return Ok(());
+            return None;
         }
         let effective_iflags = if is_created_root_dir && !iflags.has_significant_flags() {
             // upstream: generator.c:1468-1471 + generator.c:566-572 - itemize()
@@ -123,12 +117,47 @@ impl ReceiverContext {
         // end of a push (the client is the sender), so it renders `<`; a
         // client-mode receiver is a local pull and renders `>`.
         let is_sender = !self.config.connection.client_mode;
-        let line = crate::generator::itemize::format_itemize_line(
+        Some(crate::generator::itemize::format_itemize_line(
             &effective_iflags,
             entry,
             is_sender,
             &ctx,
-        );
-        self.emit_info_line(writer, &line)
+        ))
+    }
+
+    /// Emits itemize output for a file entry to the client-visible sink.
+    ///
+    /// A client-mode receiver (a pull, where oc is the generator/receiver on the
+    /// client) writes the row to its own stdout. A server-mode receiver (the
+    /// remote end of a push) writes NOTHING: upstream `log.c:822` gates the
+    /// `FCLIENT` write on `!am_server`, so the remote receiver's generator never
+    /// prints the client-visible row. Instead it writes the iflags over the wire
+    /// (`generator.c:583-599 write_shortint(sock_f_out, iflags)`) and the
+    /// client's SENDER prints them (`sender.c:461 log_item(FCLIENT)`). Forwarding
+    /// a pre-rendered MSG_INFO row from here would double every pushed file
+    /// against the client sender's own row.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:818-826` - `log_item()` only writes `FCLIENT` when `!am_server`
+    /// - `generator.c:583-599` - the generator forwards iflags over the wire
+    /// - `sender.c:461` - the sender prints the push itemize row
+    pub(in crate::receiver) fn emit_itemize<W: crate::writer::MsgInfoSender + ?Sized>(
+        &self,
+        writer: &mut W,
+        iflags: &crate::generator::ItemFlags,
+        entry: &protocol::flist::FileEntry,
+    ) -> std::io::Result<()> {
+        if !self.should_emit_itemize() {
+            return Ok(());
+        }
+        let Some(line) = self.render_itemize_line(iflags, entry) else {
+            return Ok(());
+        };
+        if self.config.connection.client_mode {
+            self.emit_info_line(writer, &line)
+        } else {
+            Ok(())
+        }
     }
 }

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -51,87 +51,78 @@ fn receiver_config_with_itemize() -> ServerConfig {
 }
 
 #[test]
-fn emit_itemize_new_file_transfer() {
+fn render_itemize_new_file_transfer() {
     let handshake = test_handshake();
     let config = receiver_config_with_itemize();
     let ctx = ReceiverContext::new_for_test(&handshake, config);
-    let mut writer = MockMsgInfoWriter::new();
 
     let entry = FileEntry::new_file("docs/readme.txt".into(), 1024, 0o644);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
 
-    ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
-
-    assert_eq!(writer.messages.len(), 1);
-    let msg = String::from_utf8_lossy(&writer.messages[0]);
     // upstream: log.c:707-710 - a server-mode receiver is the remote end of a
     // push (the client is the sender), so the transfer glyph is `<`.
-    assert_eq!(msg, "<f+++++++++ docs/readme.txt\n");
+    assert_eq!(
+        ctx.render_itemize_line(&iflags, &entry).as_deref(),
+        Some("<f+++++++++ docs/readme.txt\n")
+    );
 }
 
 #[test]
-fn emit_itemize_updated_file_transfer() {
+fn render_itemize_updated_file_transfer() {
     let handshake = test_handshake();
     let config = receiver_config_with_itemize();
     let ctx = ReceiverContext::new_for_test(&handshake, config);
-    let mut writer = MockMsgInfoWriter::new();
 
     let entry = FileEntry::new_file("data.bin".into(), 512, 0o644);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER);
 
-    ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
-
-    assert_eq!(writer.messages.len(), 1);
-    let msg = String::from_utf8_lossy(&writer.messages[0]);
     // upstream: log.c:707-710 - server-mode receiver renders the push `<` glyph.
-    assert_eq!(msg, "<f......... data.bin\n");
+    assert_eq!(
+        ctx.render_itemize_line(&iflags, &entry).as_deref(),
+        Some("<f......... data.bin\n")
+    );
 }
 
 #[test]
-fn emit_itemize_directory_creation() {
+fn render_itemize_directory_creation() {
     let handshake = test_handshake();
     let config = receiver_config_with_itemize();
     let ctx = ReceiverContext::new_for_test(&handshake, config);
-    let mut writer = MockMsgInfoWriter::new();
 
     let entry = FileEntry::new_directory("subdir".into(), 0o755);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
-    ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
-
-    assert_eq!(writer.messages.len(), 1);
-    let msg = String::from_utf8_lossy(&writer.messages[0]);
-    assert_eq!(msg, "cd+++++++++ subdir/\n");
+    assert_eq!(
+        ctx.render_itemize_line(&iflags, &entry).as_deref(),
+        Some("cd+++++++++ subdir/\n")
+    );
 }
 
 #[test]
-fn emit_itemize_root_directory_emits_creation_glyph_when_freshly_created() {
+fn render_itemize_root_directory_emits_creation_glyph_when_freshly_created() {
     // Regression: upstream `testsuite/itemize.test` expects `cd+++++++++ ./`
     // as the second line of `-iplr from/ to/` against a non-existent dest.
-    // The root entry (path == ".") arrives at emit_itemize with iflags == 0
-    // because oc-rsync's create_directory_incremental cannot observe the
-    // pre-flight mkdir performed by `ensure_dest_root_exists`. When that
-    // pre-flight actually created the root (`dest_root_created == true`),
-    // mirror upstream main.c:794-796 FLAG_DIR_CREATED by forcing the
-    // created-directory glyph for the root entry.
+    // The root entry (path == ".") arrives with iflags == 0 because oc-rsync's
+    // create_directory_incremental cannot observe the pre-flight mkdir
+    // performed by `ensure_dest_root_exists`. When that pre-flight actually
+    // created the root (`dest_root_created == true`), mirror upstream
+    // main.c:794-796 FLAG_DIR_CREATED by forcing the created-directory glyph.
     let handshake = test_handshake();
     let config = receiver_config_with_itemize();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
     ctx.dest_root_created = true;
-    let mut writer = MockMsgInfoWriter::new();
 
     let entry = FileEntry::new_directory(".".into(), 0o755);
     let iflags = ItemFlags::from_raw(0);
 
-    ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
-
-    assert_eq!(writer.messages.len(), 1);
-    let msg = String::from_utf8_lossy(&writer.messages[0]);
-    assert_eq!(msg, "cd+++++++++ ./\n");
+    assert_eq!(
+        ctx.render_itemize_line(&iflags, &entry).as_deref(),
+        Some("cd+++++++++ ./\n")
+    );
 }
 
 #[test]
-fn emit_itemize_root_directory_no_glyph_when_dest_root_preexisted() {
+fn render_itemize_root_directory_no_glyph_when_dest_root_preexisted() {
     // upstream main.c:794-796 only sets FLAG_DIR_CREATED when the receiver
     // had to mkdir the destination root. When the root already existed
     // (e.g. `up1/ -> up2/` where up2 is present), the flag stays clear and
@@ -142,32 +133,47 @@ fn emit_itemize_root_directory_no_glyph_when_dest_root_preexisted() {
     let config = receiver_config_with_itemize();
     let ctx = ReceiverContext::new_for_test(&handshake, config);
     // dest_root_created defaults to false (root pre-existed).
-    let mut writer = MockMsgInfoWriter::new();
 
     let entry = FileEntry::new_directory(".".into(), 0o755);
     let iflags = ItemFlags::from_raw(0);
 
-    ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
-
-    assert!(writer.messages.is_empty());
+    assert_eq!(ctx.render_itemize_line(&iflags, &entry), None);
 }
 
 #[test]
-fn emit_itemize_up_to_date_file() {
+fn render_itemize_up_to_date_file() {
     let handshake = test_handshake();
     let config = receiver_config_with_itemize();
     let ctx = ReceiverContext::new_for_test(&handshake, config);
-    let mut writer = MockMsgInfoWriter::new();
 
     let entry = FileEntry::new_file("unchanged.txt".into(), 256, 0o644);
     // No flags - file is up-to-date, no changes
     let iflags = ItemFlags::from_raw(0);
 
+    // upstream: generator.c:574-576 - no line when iflags has no significant
+    // flags (file is completely unchanged)
+    assert_eq!(ctx.render_itemize_line(&iflags, &entry), None);
+}
+
+#[test]
+fn emit_itemize_server_mode_does_not_forward_msg_info() {
+    // upstream: log.c:822 gates the FCLIENT itemize write on `!am_server`, and
+    // generator.c:583-599 writes the iflags over the wire so the client's
+    // SENDER prints the push row (sender.c:461). A server-mode receiver (the
+    // remote end of a push) must therefore forward NO pre-rendered MSG_INFO
+    // row, or every pushed file would itemize twice against the sender's own
+    // row.
+    let handshake = test_handshake();
+    let config = receiver_config_with_itemize();
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+    let mut writer = MockMsgInfoWriter::new();
+
+    let entry = FileEntry::new_file("docs/readme.txt".into(), 1024, 0o644);
+    let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
+
     ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
 
-    // upstream: generator.c:574-576 - no output when iflags has no significant
-    // flags (file is completely unchanged)
-    assert_eq!(writer.messages.len(), 0);
+    assert!(writer.messages.is_empty());
 }
 
 #[test]
@@ -208,20 +214,18 @@ fn emit_itemize_skipped_without_itemize_flag() {
 }
 
 #[test]
-fn emit_itemize_symlink_with_target() {
+fn render_itemize_symlink_with_target() {
     let handshake = test_handshake();
     let config = receiver_config_with_itemize();
     let ctx = ReceiverContext::new_for_test(&handshake, config);
-    let mut writer = MockMsgInfoWriter::new();
 
     let entry = FileEntry::new_symlink("mylink".into(), "target".into());
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
-    ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
-
-    assert_eq!(writer.messages.len(), 1);
-    let msg = String::from_utf8_lossy(&writer.messages[0]);
-    assert_eq!(msg, "cL+++++++++ mylink -> target\n");
+    assert_eq!(
+        ctx.render_itemize_line(&iflags, &entry).as_deref(),
+        Some("cL+++++++++ mylink -> target\n")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Itemize fixes: new hardlink followers + push transfers

### New hardlink followers
A freshly-linked hardlink follower into an empty destination was itemized with blank attribute columns instead of `hf+++++++++`. Fixed by marking the follower record newly-created when its own destination did not previously exist (upstream hlink.c:228-234 / log.c:736-738). A follower whose data-holder was matched from `--copy-dest`/`--link-dest` correctly stays blank (`hf          `), gated on the alt-dest match check (upstream hard_link_check statret bump).

### Push transfers print itemize on the client sender
A push (client is the sender) itemized nothing when the remote was an upstream rsync daemon: the local sender itemize callback had been suppressed in favour of the remote receiver forwarding a pre-rendered row, but upstream never does that. On a push the remote generator writes the iflags over the wire (generator.c:583-599) and the client sender prints them (sender.c:461 log_item(FCLIENT)); the remote generator log_item never reaches the client because log.c:822 gates the client write on !am_server. Restored the local sender itemize callback on the daemon and SSH push paths and stopped the server-mode receiver from forwarding a pre-rendered MSG_INFO row, so oc-to-oc and oc-to-upstream pushes each print a single client-visible row matching upstream byte-for-byte. Client-mode pulls unchanged; -ii unchanged rows survive on the client print path.

Validated byte-for-byte against upstream rsync on Linux, including the interop itemize matrix (native + protocol 28/29).