### PR TITLE
fix(transfer): itemize push transfers with sender direction

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -215,12 +215,18 @@ where
         config.write.delay_updates = true;
     }
 
-    // upstream: options.c:2327-2338 - server parses --log-format to determine
-    // whether itemize data is needed. %i or %I in the format sets
-    // stdout_format_has_i, which controls generator itemize output.
+    // upstream: options.c:2345-2348 - the server parses --log-format to set
+    // stdout_format_has_i, which controls generator itemize output. `%i` sets
+    // has_i = 1 (itemize significant items); `%I` sets has_i = 2, the `-ii`
+    // level that also itemizes unchanged entries. The client forwards
+    // `--log-format=%i%I` for `-ii` (options.c:164-175 server_options), so a
+    // server that sees `%I` must also emit unchanged rows.
     if let Some(fmt) = &long_flags.log_format {
         if fmt.contains("%i") || fmt.contains("%I") {
             config.flags.info_flags.itemize = true;
+        }
+        if fmt.contains("%I") {
+            config.flags.info_flags.itemize_unchanged = true;
         }
     }
 

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -220,11 +220,17 @@ pub(super) fn build_full_daemon_args(
 
     let we_are_sender = !is_sender;
 
-    // upstream: options.c:2750-2762 - server needs the log-format to generate
-    // itemize output via MSG_INFO frames. Only sent when client is sender
-    // (push), matching upstream am_sender guard.
+    // upstream: options.c:164-175 server_options - the server needs the
+    // log-format to generate itemize output. Only sent when the client is the
+    // sender (push), matching upstream's `stdout_format && am_sender` guard.
+    // `%i%I` is the `-ii` form (stdout_format_has_i > 1) that itemizes
+    // unchanged entries too; `%i` alone is the `-i` form.
     if we_are_sender && config.itemize_changes() {
-        args.push("--log-format=%i".to_owned());
+        if config.itemize_unchanged() {
+            args.push("--log-format=%i%I".to_owned());
+        } else {
+            args.push("--log-format=%i".to_owned());
+        }
     }
 
     // upstream: options.c:2800-2805 - compress choice is only forwarded when

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -425,6 +425,29 @@ mod protect_args_daemon_tests {
     }
 
     #[test]
+    fn build_full_args_uses_ii_log_format_for_itemize_unchanged_push() {
+        // upstream: options.c:164-175 server_options - `-ii`
+        // (stdout_format_has_i > 1) forwards `--log-format=%i%I` so the daemon
+        // receiver also itemizes unchanged entries. `-i` alone forwards `%i`.
+        let config = ClientConfig::builder()
+            .itemize_changes(true)
+            .itemize_unchanged(true)
+            .build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, false);
+
+        assert!(
+            args.iter().any(|a| a == "--log-format=%i%I"),
+            "push with -ii should forward --log-format=%i%I: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "--log-format=%i"),
+            "the -i form must not also appear: {args:?}"
+        );
+    }
+
+    #[test]
     fn build_full_args_omits_log_format_without_itemize() {
         let config = ClientConfig::default();
         let request = test_daemon_request();

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -3,7 +3,6 @@
 //! Orchestrates the transfer lifecycle by configuring server infrastructure,
 //! establishing the handshake result, and delegating to `run_server_with_handshake`.
 
-use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
@@ -142,15 +141,12 @@ pub(crate) fn run_push_transfer(
         .as_mut()
         .map(|a| a as &mut dyn TransferProgressCallback);
 
-    // upstream: log.c:330-340 - when !am_server, rwrite() sends itemize to
-    // FCLIENT (stdout); the callback writes directly to process stdout.
-    let wants_itemize = config.itemize_changes();
-    let stdout_handle = std::io::stdout();
-    let mut itemize_cb = move |line: &str| {
-        let mut out = stdout_handle.lock();
-        let _ = out.write_all(line.as_bytes());
-    };
-
+    // upstream: log.c:818-826 log_item() - the client-visible itemize row is
+    // produced exactly once, by the remote receiver's generator, and forwarded
+    // as a MSG_INFO frame (rwrite when `am_server`). The local sender must NOT
+    // also emit a row from the bare wire iflags it echoes back, or every pushed
+    // file itemizes twice. Passing `None` here mirrors the SSH push path
+    // (ssh_transfer/drive.rs) so both transports emit a single row.
     let result = crate::server::run_server_with_handshake(
         server_config,
         handshake,
@@ -158,11 +154,7 @@ pub(crate) fn run_push_transfer(
         writer,
         progress,
         batch_recording,
-        if wants_itemize {
-            Some(&mut itemize_cb as &mut dyn crate::server::ItemizeCallback)
-        } else {
-            None
-        },
+        None,
     );
 
     match result {

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -512,12 +512,16 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--preallocate"));
         }
 
-        // upstream: options.c:2750-2762 - itemize-changes is forwarded as
-        // --log-format=%i, not as a compact flag character. Upstream also
-        // supports --log-format=%i%I when stdout_format_has_i > 1, but we
-        // use the simpler single-%i form that covers the common case.
+        // upstream: options.c:164-175 server_options - itemize-changes is
+        // forwarded as --log-format, not as a compact flag character. `%i%I` is
+        // the `-ii` form (stdout_format_has_i > 1) that itemizes unchanged
+        // entries too; `%i` alone is the `-i` form.
         if self.config.itemize_changes() {
-            args.push(OsString::from("--log-format=%i"));
+            if self.config.itemize_unchanged() {
+                args.push(OsString::from("--log-format=%i%I"));
+            } else {
+                args.push(OsString::from("--log-format=%i"));
+            }
         }
 
         // upstream: options.c:2962-2974 - `if (files_from && (!am_sender ||

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -224,6 +224,31 @@ fn includes_log_format_for_itemize() {
 }
 
 #[test]
+fn includes_ii_log_format_for_itemize_unchanged() {
+    // upstream: options.c:164-175 server_options - `-ii` forwards
+    // `--log-format=%i%I` so the remote generator also itemizes unchanged rows.
+    let config = ClientConfig::builder()
+        .itemize_changes(true)
+        .itemize_unchanged(true)
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
+    let args = builder.build("/path");
+
+    let args_str: Vec<_> = args
+        .iter()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        args_str.contains(&"--log-format=%i%I".to_string()),
+        "expected --log-format=%i%I in args: {args_str:?}"
+    );
+    assert!(
+        !args_str.contains(&"--log-format=%i".to_string()),
+        "the -i form must not also appear: {args_str:?}"
+    );
+}
+
+#[test]
 fn omits_log_format_when_itemize_disabled() {
     let config = ClientConfig::builder().itemize_changes(false).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -295,14 +295,19 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                     config.file_selection.from0 = true;
                 // upstream: options.c:773,963 - --log-format is the deprecated
                 // alias for --out-format. The server parses it to set
-                // stdout_format_has_i (options.c:2327-2331) which drives itemize
-                // emission. We only need the %i presence, not the full format.
+                // stdout_format_has_i (options.c:2345-2348): `%i` sets has_i = 1
+                // (itemize significant items) and `%I` sets has_i = 2, the `-ii`
+                // level that also itemizes unchanged entries. The client
+                // forwards `--log-format=%i%I` for `-ii` (options.c:164-175).
                 } else if let Some(fmt) = arg
                     .strip_prefix("--log-format=")
                     .or_else(|| arg.strip_prefix("--out-format="))
                 {
                     if fmt.contains("%i") {
                         config.flags.info_flags.itemize = true;
+                    }
+                    if fmt.contains("%I") {
+                        config.flags.info_flags.itemize_unchanged = true;
                     }
                 } else if unknown.is_none() && is_client_only_flag_reaching_daemon(arg) {
                     // upstream: options.c:1444-1449 - the daemon's popt loop

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -292,6 +292,32 @@ mod module_access_tests {
         assert_eq!(mapping.spec(), "*:1234");
     }
 
+    // upstream: options.c:2345-2348 - the daemon parses the client-forwarded
+    // --log-format to set stdout_format_has_i. `%i` enables itemize of
+    // significant items; `%i%I` is the `-ii` level that also itemizes unchanged
+    // entries. Without the `%I` -> itemize_unchanged mapping a `-ii` push to an
+    // oc daemon drops every unchanged row.
+    #[test]
+    fn apply_long_form_args_maps_log_format_itemize_levels() {
+        let single = vec!["--log-format=%i".to_owned()];
+        let mut cfg = ServerConfig::default();
+        assert!(apply_long_form_args(&single, &mut cfg).is_none());
+        assert!(cfg.flags.info_flags.itemize, "%i enables itemize");
+        assert!(
+            !cfg.flags.info_flags.itemize_unchanged,
+            "%i alone must not itemize unchanged entries",
+        );
+
+        let double = vec!["--log-format=%i%I".to_owned()];
+        let mut cfg2 = ServerConfig::default();
+        assert!(apply_long_form_args(&double, &mut cfg2).is_none());
+        assert!(cfg2.flags.info_flags.itemize, "%i%I enables itemize");
+        assert!(
+            cfg2.flags.info_flags.itemize_unchanged,
+            "%I raises the itemize level to -ii (unchanged rows)",
+        );
+    }
+
     // UTS-8.REOPEN regression: the client's actual phase-1 wire for
     // secluded-args daemon push is `[--server, --sender, --secluded-args]`
     // (no standalone `.` or bare `-s`), and phase 2 carries the real

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -59,8 +59,9 @@ impl ReceiverContext {
     /// Emits a MSG_INFO frame with itemize output for a file entry.
     ///
     /// Formats the itemize string (`"%i %n%L\n"`) and sends it as a MSG_INFO
-    /// multiplexed message. Uses `is_sender: false` since the daemon is receiving
-    /// files (producing `>` direction indicator).
+    /// multiplexed message. The direction glyph follows upstream `log.c:707-710`:
+    /// a server-mode receiver is the remote end of a push (client is the sender)
+    /// and renders `<`; a client-mode receiver is a local pull and renders `>`.
     ///
     /// Suppresses output when `iflags` has no significant flags set (the file is
     /// completely unchanged), matching upstream's gate in `itemize()` at
@@ -114,8 +115,20 @@ impl ReceiverContext {
             *iflags
         };
         let ctx = self.itemize_context();
-        let line =
-            crate::generator::itemize::format_itemize_line(&effective_iflags, entry, false, &ctx);
+        // upstream: log.c:707-710 - the direction glyph is `<` when
+        // `!local_server && *op == 's'` (this side's peer is the sender's
+        // client) and `>` otherwise. `op` is `am_sender ? "send" : "recv"`
+        // (log.c:820), and the client-visible itemize is always produced by the
+        // non-`am_server` side. A server-mode receiver is only ever the remote
+        // end of a push (the client is the sender), so it renders `<`; a
+        // client-mode receiver is a local pull and renders `>`.
+        let is_sender = !self.config.connection.client_mode;
+        let line = crate::generator::itemize::format_itemize_line(
+            &effective_iflags,
+            entry,
+            is_sender,
+            &ctx,
+        );
         self.emit_info_line(writer, &line)
     }
 }

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -64,8 +64,9 @@ fn emit_itemize_new_file_transfer() {
 
     assert_eq!(writer.messages.len(), 1);
     let msg = String::from_utf8_lossy(&writer.messages[0]);
-    // Receiver uses is_sender=false, producing '>' prefix
-    assert_eq!(msg, ">f+++++++++ docs/readme.txt\n");
+    // upstream: log.c:707-710 - a server-mode receiver is the remote end of a
+    // push (the client is the sender), so the transfer glyph is `<`.
+    assert_eq!(msg, "<f+++++++++ docs/readme.txt\n");
 }
 
 #[test]
@@ -82,7 +83,8 @@ fn emit_itemize_updated_file_transfer() {
 
     assert_eq!(writer.messages.len(), 1);
     let msg = String::from_utf8_lossy(&writer.messages[0]);
-    assert_eq!(msg, ">f......... data.bin\n");
+    // upstream: log.c:707-710 - server-mode receiver renders the push `<` glyph.
+    assert_eq!(msg, "<f......... data.bin\n");
 }
 
 #[test]


### PR DESCRIPTION
## Problem

A remote **push** (client is the sender) itemized every transferred file with the receive glyph `>` instead of the send glyph `<`, dropped unchanged rows under `-ii`, and on the daemon path emitted each row twice (a blank `<f.........` line plus a `>f+++++++++` line).

Observed for `-ii -a` (both SSH and daemon):

```
oc (before):  >f..t...... chg      >f+++++++++ new     (unchanged rows dropped; daemon doubled)
upstream:     .d          ./       <f..t...... chg     <f+++++++++ new     .f          same
```

Pull already matched upstream (`>`).

## Root causes and fixes

**Direction glyph.** Upstream `log.c:707-710` selects `<` when `!local_server && *op == 's'`, where `op` is `am_sender ? "send" : "recv"` (`log.c:820`) and the client-visible itemize is always produced by the non-`am_server` side. A server-mode receiver is only ever the remote end of a push (the client is the sender), so it renders `<`; a client-mode receiver is a local pull and renders `>`. The receiver forward hardcoded `is_sender = false`; it now derives the glyph from `client_mode`.

**Unchanged rows.** Upstream `options.c:164-175` (`server_options`) forwards `--log-format=%i%I` for `-ii` (`stdout_format_has_i > 1`) and `--log-format=%i` for `-i`; the server maps `%I` to the `-ii` level (`options.c:2345-2348`) that itemizes unchanged entries. We now forward `%i%I` when `-ii` and map `%I` to `itemize_unchanged` in both the `--server` and daemon argument parsers.

**Daemon double-emit.** The client-visible row is produced once, by the remote receiver's generator, forwarded as a `MSG_INFO` frame (upstream `log.c:818-826` reaches the client only when `!am_server`). The local sender must not also print a row from the bare wire iflags it echoes back. The redundant local-sender callback is suppressed on daemon push, matching the SSH push path.

## Validation (vs upstream `rsync`)

`oc -ii -a` push over SSH and daemon is now byte-identical to upstream: correct `<`, unchanged rows present, single emission. Pull is unchanged on both transports. Covered cases: new (`<f+++++++++`), changed (`<f..t......`), unchanged (`.f          `), directory (`.d          ./` / `cd+++++++++ ./`).

## Tests

- Receiver itemize now asserts `<` for server-mode (push) direction.
- Client forwards `--log-format=%i%I` under `-ii` (SSH and daemon arg builders).
- Daemon argument parser maps `%I` to `itemize_unchanged`.