### PR TITLE
fix(engine): copy link-dest match_level-2 basis instead of hard-linking

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -178,6 +178,48 @@ pub(super) fn process_links(
         ignore_times_enabled,
         checksum_enabled,
     )? {
+        let preserve_xattrs_flag = {
+            #[cfg(all(unix, feature = "xattr"))]
+            {
+                preserve_xattrs
+            }
+            #[cfg(not(all(unix, feature = "xattr")))]
+            {
+                false
+            }
+        };
+        // upstream: generator.c:967-1054 try_dests_reg() - a LINK_DEST candidate
+        // that passes the quick-check (data matches) is hard-linked only when its
+        // preserved attributes also match the source (match_level 3). When the
+        // attributes differ (match_level 2) upstream does NOT hard-link: it falls
+        // through to try_a_copy -> copy_altdest_file(), copying the basis contents
+        // into a fresh destination inode and reapplying the source attributes via
+        // set_file_attrs. Hard-linking a match_level-2 file would share the basis
+        // inode, so reapplying the differing attrs (e.g. a changed -X value under
+        // --fake-super) would corrupt the basis and leave the file carrying an
+        // extra hard link.
+        let attrs_match = link_dest_attrs_unchanged(
+            &link_target,
+            source,
+            metadata,
+            &metadata_options,
+            preserve_xattrs_flag,
+        );
+        // On Unix a match_level-2 basis is routed through the same reference-copy
+        // path used by --copy-dest. The non-Unix stub cannot evaluate the
+        // fake-super/xattr channel (it returns false), so it keeps the legacy
+        // hard-link-then-reapply flow rather than degrading every match to a copy.
+        #[cfg(unix)]
+        if !attrs_match {
+            return Ok(LinkOutcome {
+                copy_source_override: Some(link_target.clone()),
+                reference_basis: Some(link_target),
+                completed: false,
+            });
+        }
+
+        // match_level 3 (Unix): data and attributes both match - hard-link the
+        // basis. Non-Unix: hard-link and reapply metadata below.
         let mut attempted_commit = false;
         loop {
             match fast_io::hard_link(&link_target, destination) {
@@ -263,30 +305,13 @@ pub(super) fn process_links(
             destination_previously_existed,
         );
         remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
-        // upstream: generator.c:995-1024 try_dests_reg() - for a LINK_DEST match
-        // at match_level 3 (data AND attrs already match the basis) the file is
-        // only hard-linked; set_file_attrs runs *only* under --atimes. Rewriting
-        // metadata unconditionally would, under --fake-super, write a
-        // `user.rsync.%stat` xattr onto the shared basis inode that upstream
-        // never creates. At match_level 2 (attrs differ) upstream does rewrite,
-        // so gate the reapply on whether the basis attributes already match.
-        let preserve_xattrs_flag = {
-            #[cfg(all(unix, feature = "xattr"))]
-            {
-                preserve_xattrs
-            }
-            #[cfg(not(all(unix, feature = "xattr")))]
-            {
-                false
-            }
-        };
-        let attrs_match = link_dest_attrs_unchanged(
-            &link_target,
-            source,
-            metadata,
-            &metadata_options,
-            preserve_xattrs_flag,
-        );
+        // upstream: generator.c:1006-1007 try_dests_reg() - at match_level 3 the
+        // file is only hard-linked; set_file_attrs runs *only* under --atimes.
+        // Rewriting metadata unconditionally would, under --fake-super, write a
+        // `user.rsync.%stat` xattr onto the shared basis inode that upstream never
+        // creates. On Unix a match_level-2 basis (attrs differ) is handled by the
+        // reference-copy path above, so `attrs_match` is always true here; the
+        // non-Unix stub cannot evaluate attrs, so it reapplies as before.
         if !attrs_match || metadata_options.atimes() {
             apply_file_metadata_with_options(destination, metadata, &metadata_options)
                 .map_err(map_metadata_error)?;

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -1194,10 +1194,16 @@ fn link_dest_permission_mismatch_with_perms_enabled() {
 
 #[cfg(all(unix, feature = "xattr"))]
 #[test]
-fn link_dest_match_reapplies_differing_xattrs() {
-    // upstream: generator.c try_dests_reg() - a --link-dest DATA match whose
-    // attributes differ still runs set_file_attrs, so the linked inode ends
-    // with the source's xattrs.
+fn link_dest_copies_when_only_xattrs_differ() {
+    // upstream: generator.c:967-1054 try_dests_reg() - a --link-dest basis that
+    // matches the source's DATA (quick_check_ok) but whose preserved attributes
+    // differ is match_level 2, NOT match_level 3. Upstream does not hard-link a
+    // match_level-2 basis: it falls through to copy_altdest_file() + set_file_attrs,
+    // producing a fresh destination inode carrying the source's xattrs while the
+    // basis is left untouched. Hard-linking it and reapplying the source xattr
+    // would corrupt the shared basis inode and leave both files with an extra hard
+    // link - the failure the upstream `xattrs` conformance test catches when a
+    // single -X value on file1 is changed under --fake-super --link-dest.
     let temp = tempdir().expect("tempdir");
     let source_dir = temp.path().join("source");
     fs::create_dir_all(&source_dir).expect("create source");
@@ -1213,7 +1219,7 @@ fn link_dest_match_reapplies_differing_xattrs() {
     fs::write(&link_dest_file, b"identical content").expect("write link-dest");
     xattr::set(&link_dest_file, "user.k", b"v1").expect("set basis xattr");
 
-    // Same data + mtime so the basis is a DATA match.
+    // Same data + mtime so the basis is a DATA match (quick-check passes).
     let mtime = fs::metadata(&source_file)
         .expect("meta")
         .modified()
@@ -1234,17 +1240,30 @@ fn link_dest_match_reapplies_differing_xattrs() {
         .times(true)
         .xattrs(true)
         .extend_link_dests([link_dest_dir]);
-    plan.execute_with_options(LocalCopyExecution::Apply, options)
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // The source xattr (v2) wins, not the basis xattr (v1).
+    // The destination carries the source xattr (v2), copied from the basis data.
     let got = xattr::get(&dest_file, "user.k")
         .expect("read")
         .expect("present");
-    assert_eq!(got, b"v2", "differing link-dest xattr must be corrected");
+    assert_eq!(got, b"v2", "destination must carry the source xattr");
 
-    // Still hard-linked to the basis.
+    // match_level 2: the file is copied, not hard-linked.
     let dest_meta = fs::metadata(&dest_file).expect("dest meta");
     let basis_meta = fs::metadata(&link_dest_file).expect("basis meta");
-    assert_eq!(dest_meta.ino(), basis_meta.ino(), "must remain hard-linked");
+    assert_ne!(
+        dest_meta.ino(),
+        basis_meta.ino(),
+        "a match_level-2 basis (attrs differ) must be copied, not hard-linked"
+    );
+    assert_eq!(dest_meta.nlink(), 1, "copied file must not gain a hard link");
+    assert_eq!(summary.hard_links_created(), 0, "no hard link at match_level 2");
+
+    // The basis inode is left untouched - its xattr is not overwritten.
+    let basis_xattr = xattr::get(&link_dest_file, "user.k")
+        .expect("read basis")
+        .expect("basis xattr present");
+    assert_eq!(basis_xattr, b"v1", "link-dest basis must not be modified");
 }


### PR DESCRIPTION
## Problem

Under `--fake-super --link-dest`, the upstream `xattrs-hlink` conformance test fails with `Too many hard links on file1!`.

`file1` has one extended attribute changed relative to the `--link-dest` basis but is otherwise identical (same size/mtime/content). It must therefore be copied, not hard-linked to the basis. oc-rsync instead hard-linked it, then wrote the source's xattr onto the now-shared basis inode - corrupting the basis and leaving both files with an extra hard link.

## Root cause

Upstream `generator.c:try_dests_reg()` assigns a `--link-dest` candidate a match level:

- **match_level 3** - data (quick-check) *and* preserved attributes (`unchanged_attrs()`: perms, owner, mtime, ACLs, xattrs) match: hard-link the basis; `set_file_attrs` runs only under `--atimes`.
- **match_level 2** - data matches but attributes differ: do *not* hard-link; fall through to `try_a_copy` -> `copy_altdest_file()` + `set_file_attrs`, producing a fresh destination inode carrying the source attributes while the basis is left untouched.

oc-rsync's local-copy `process_links` hard-linked *every* quick-check match and used the attribute comparison only to decide whether to reapply metadata afterward. A match_level-2 basis (e.g. a changed `-X` value under `--fake-super`) was therefore hard-linked and had the source xattr reapplied onto the shared basis inode.

## Fix

Evaluate the attribute match *before* linking. On a match_level-2 result, route the file through the same reference-copy path used by `--copy-dest` (`copy_source_override` + `reference_basis`), which copies the basis contents into a fresh inode and reapplies the source attributes. match_level 3 still hard-links, with metadata reapply gated to `--atimes` only, matching upstream. Non-Unix (which cannot evaluate the fake-super/xattr channel) keeps the prior hard-link-then-reapply behavior.

## Validation (lxhost, sudo root, upstream testsuite)

- `xattrs-hlink`: **master FAIL** (`Too many hard links on file1!`) -> **fixed PASS**.
- `xattrs` and all other `--link-dest` / `--copy-dest` / hard-link / `--fake-super` legs: pass.
- The remaining pre-existing suite failures (`chmod-option`, `daemon-auth`, `devices-fake`, `partial`, `partial_nowrite`) are identical on the master and fixed binaries and use no `--link-dest`; the changed code executes only inside the `--link-dest` path, so they are unaffected.
- `cargo fmt` clean, `cargo clippy -p engine --all-features -- -D warnings` clean, engine `link_dest` tests pass (39), including a new regression test asserting a match_level-2 basis is copied (not hard-linked), the basis xattr is preserved, and the destination has link count 1.

upstream: `generator.c:967-1054` `try_dests_reg()`, `hlink.c` `hard_link_one()`