### PR TITLE
docs: align incremental recursion status with default-on code

### DIFF
--- a/docs/UPSTREAM_COMPARISON.md
+++ b/docs/UPSTREAM_COMPARISON.md
@@ -786,13 +786,13 @@ struct SparseWriteState {
 |-----------|--------|-------|
 | CF_INC_RECURSE flag | ✅ Defined | Bit 0 |
 | NDX_FLIST_OFFSET | ✅ Defined | -101 |
-| Flag negotiation | ✅ Implemented | Exchanged but gated |
-| Directory queue | ❌ Not implemented | Requires segmented flist |
-| Segmented transmission | ❌ Not implemented | Single flist only |
+| Flag negotiation | ✅ Implemented | 'i' advertised for sender + receiver |
+| Directory queue | ✅ Implemented | Per-directory segments (`PendingSegment`) |
+| Segmented transmission | ✅ Implemented | Depth-first per-directory sub-lists |
 
-**Current behavior:** `allow_inc_recurse=false` gates the feature. File lists are sent as a single batch.
+**Current behavior:** Incremental recursion is enabled by default (`allow_inc_recurse=true`), matching upstream rsync 3.4.x. File lists are partitioned into per-directory segments and sent incrementally for both sender and receiver roles. `--no-inc-recursive` overrides to a single batch.
 
-**Source:** `crates/transfer/src/setup.rs` (search for `allow_inc_recurse`)
+**Source:** `crates/transfer/src/setup/capability.rs` (capability string), `crates/transfer/src/generator/file_list/inc_recurse.rs` (segmentation), `crates/core/src/client/config/builder/mod.rs` (`inc_recursive_send` default)
 
 ---
 
@@ -844,7 +844,7 @@ The Rust rsync implementation achieves **full wire protocol compatibility** with
 |-----------|--------|--------|
 | SIMD optimization | Performance only | Identical results |
 | Pure Rust crypto | No C dependencies | RustCrypto ecosystem |
-| Incremental recursion | Not enabled | Gate set to false |
+| Incremental recursion | Enabled by default | Matches upstream (sender + receiver advertise 'i') |
 
 ### Why Custom Implementations?
 


### PR DESCRIPTION
## Summary

`docs/UPSTREAM_COMPARISON.md` described incremental recursion (INC_RECURSE) as disabled, contradicting the code. Sender-side INC_RECURSE is now default-on: the config builder sets `inc_recursive_send.unwrap_or(true)` and the capability string advertises `'i'` for both sender and receiver, with per-directory segmented flist transmission implemented (`PendingSegment`, `partition_file_list_for_inc_recurse`).

Per the project convention that code is authoritative over documentation, this aligns the stale doc to the code. Docs-only change; no behavior change.

## Changes

- Implementation-differences table: `Incremental recursion | Not enabled | Gate set to false` -> `Enabled by default | Matches upstream (sender + receiver advertise 'i')`.
- Section 24 status table: `Directory queue` and `Segmented transmission` marked implemented; negotiation note and current-behavior paragraph updated to reflect default-on incremental sending with `--no-inc-recursive` as the single-batch override.
- Refreshed the source pointers to the current module paths.

## Validation

- Docs-only edit; no `.rs` files touched.
- Verified against code: `crates/core/src/client/config/builder/mod.rs` (`inc_recursive_send` default), `crates/transfer/src/setup/capability.rs` ('i' advertised), `crates/transfer/src/generator/file_list/inc_recurse.rs` (segmentation).