### PR TITLE
fix(compress): clamp --compress-level to codec range like upstream

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -8,6 +8,8 @@ use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
+use compress::algorithm::CompressionAlgorithm;
+
 use crate::frontend::arguments::short_options::expand_short_options;
 use crate::frontend::command_builder::clap_command;
 use crate::frontend::execution::{parse_checksum_seed_argument, parse_compress_level_argument};
@@ -324,8 +326,12 @@ where
 
     let compress_level_opt = matches.get_one::<OsString>("compress-level").cloned();
     if let Some(ref value) = compress_level_opt
-        && let Ok(setting) = parse_compress_level_argument(value.as_os_str())
+        && let Ok(setting) =
+            parse_compress_level_argument(value.as_os_str(), CompressionAlgorithm::Zlib)
     {
+        // The codec here is only a base estimate for the `compress` flag; the
+        // authoritative codec-aware level is finalised in
+        // `parse_compression_settings()` once `--compress-choice` is known.
         compress = !setting.is_disabled();
     }
     let iconv = matches.remove_one::<OsString>("iconv");

--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -18,7 +18,6 @@ pub(crate) enum CompressLevelArg {
 enum CompressionLevelParseError {
     Empty { original: String },
     Invalid { original: String, trimmed: String },
-    OutOfRange { trimmed: String, value: i32 },
 }
 
 impl CompressionLevelParseError {
@@ -27,31 +26,18 @@ impl CompressionLevelParseError {
             Self::Empty { original } | Self::Invalid { original, .. } => {
                 rsync_error!(1, "--compress-level={} is invalid", original).with_role(Role::Client)
             }
-            Self::OutOfRange { trimmed, .. } => {
-                rsync_error!(1, "--compress-level={} must be between 0 and 9", trimmed)
-                    .with_role(Role::Client)
-            }
         }
     }
 
     fn into_argument_message(self) -> Message {
         match self {
-            Self::Empty { .. } => rsync_error!(
-                1,
-                "compression level value must not be empty"
-            )
-            .with_role(Role::Client),
+            Self::Empty { .. } => {
+                rsync_error!(1, "compression level value must not be empty").with_role(Role::Client)
+            }
             Self::Invalid { trimmed, .. } => rsync_error!(
                 1,
                 format!(
-                    "invalid compression level '{trimmed}': compression level must be an integer between 0 and 9"
-                )
-            )
-            .with_role(Role::Client),
-            Self::OutOfRange { trimmed, value } => rsync_error!(
-                1,
-                format!(
-                    "invalid compression level '{trimmed}': compression level {value} is outside the supported range 0-9"
+                    "invalid compression level '{trimmed}': compression level must be an integer"
                 )
             )
             .with_role(Role::Client),
@@ -59,34 +45,41 @@ impl CompressionLevelParseError {
     }
 }
 
-fn parse_compress_level_value(
-    argument: &OsStr,
-) -> Result<CompressLevelArg, CompressionLevelParseError> {
+/// Parses the raw numeric `--compress-level` value.
+///
+/// Only genuinely malformed input (empty or non-numeric) is rejected, matching
+/// upstream: `--compress-level` is a `POPT_ARG_INT`, so any integer is accepted
+/// and only later clamped into the codec's range by
+/// `token.c:init_compression_level()`.
+fn parse_raw_level(argument: &OsStr) -> Result<i32, CompressionLevelParseError> {
     let original = argument.to_string_lossy().into_owned();
-    let trimmed_owned = original.trim().to_owned();
+    let trimmed = original.trim().to_owned();
 
-    if trimmed_owned.is_empty() {
+    if trimmed.is_empty() {
         return Err(CompressionLevelParseError::Empty { original });
     }
 
-    match trimmed_owned.parse::<i32>() {
-        Ok(0) => Ok(CompressLevelArg::Disable),
-        Ok(value @ 1..=9) => Ok(CompressLevelArg::Level(
-            NonZeroU8::new(value as u8).expect("range guarantees non-zero"),
-        )),
-        Ok(value) => Err(CompressionLevelParseError::OutOfRange {
-            trimmed: trimmed_owned,
-            value,
-        }),
-        Err(_) => Err(CompressionLevelParseError::Invalid {
-            original,
-            trimmed: trimmed_owned,
-        }),
+    trimmed
+        .parse::<i32>()
+        .map_err(|_| CompressionLevelParseError::Invalid { original, trimmed })
+}
+
+/// Clamps a raw level into `codec`'s range, mirroring
+/// `token.c:init_compression_level()`. Never rejects an out-of-range value.
+fn clamp_level(codec: CompressionAlgorithm, raw: i32) -> CompressLevelArg {
+    match codec.clamp_level(raw) {
+        Some(level) => CompressLevelArg::Level(level),
+        None => CompressLevelArg::Disable,
     }
 }
 
-pub(crate) fn parse_compress_level(argument: &OsStr) -> Result<CompressLevelArg, Message> {
-    parse_compress_level_value(argument).map_err(CompressionLevelParseError::into_flag_message)
+pub(crate) fn parse_compress_level(
+    argument: &OsStr,
+    codec: CompressionAlgorithm,
+) -> Result<CompressLevelArg, Message> {
+    parse_raw_level(argument)
+        .map(|raw| clamp_level(codec, raw))
+        .map_err(CompressionLevelParseError::into_flag_message)
 }
 
 pub(crate) fn parse_compress_choice(
@@ -204,8 +197,11 @@ pub(crate) fn parse_compress_threads(argument: &OsStr) -> Result<Option<NonZeroU
     }
 }
 
-pub(crate) fn parse_compress_level_argument(value: &OsStr) -> Result<CompressionSetting, Message> {
-    match parse_compress_level_value(value) {
+pub(crate) fn parse_compress_level_argument(
+    value: &OsStr,
+    codec: CompressionAlgorithm,
+) -> Result<CompressionSetting, Message> {
+    match parse_raw_level(value).map(|raw| clamp_level(codec, raw)) {
         Ok(CompressLevelArg::Disable) => Ok(CompressionSetting::disabled()),
         Ok(CompressLevelArg::Level(level)) => {
             Ok(CompressionSetting::level(CompressionLevel::precise(level)))

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -14,9 +14,8 @@ use logging_sink::MessageSink;
 
 use super::super::{
     parse_bandwidth_limit, parse_block_size_argument, parse_compress_choice, parse_compress_level,
-    parse_compress_level_argument, parse_compress_threads, parse_debug_flags, parse_info_flags,
-    parse_max_alloc_argument, parse_max_delete_argument, parse_modify_window_argument,
-    parse_size_limit_argument,
+    parse_compress_threads, parse_debug_flags, parse_info_flags, parse_max_alloc_argument,
+    parse_max_delete_argument, parse_modify_window_argument, parse_size_limit_argument,
 };
 use super::messages::fail_with_message;
 use crate::frontend::{
@@ -393,21 +392,19 @@ where
     let mut compression_level_override = None;
     let mut compression_algorithm = None;
     let mut compress_choice_name = None;
+    let mut compress_level_setting: Option<CompressLevelArg> = None;
+    let mut compress_disabled_by_choice = false;
 
-    let mut compress_level_setting = match compress_level {
-        Some(value) => match parse_compress_level(value.as_os_str()) {
-            Ok(setting) => Some(setting),
-            Err(message) => return Err(fail_with_message(message, stderr)),
-        },
-        None => None,
-    };
-
+    // Parse `--compress-choice` before `--compress-level` so the level is
+    // clamped against the selected codec's range. This mirrors upstream, where
+    // `token.c:init_compression_level()` runs once `do_compression` is known.
     if let Some(choice) = compress_choice.as_ref() {
         match parse_compress_choice(choice.as_os_str()) {
             Ok(None) => {
                 compress = false;
                 compression_level_override = None;
                 compress_level_setting = Some(CompressLevelArg::Disable);
+                compress_disabled_by_choice = true;
             }
             Ok(Some(algorithm)) => {
                 compression_algorithm = Some(algorithm);
@@ -419,6 +416,15 @@ where
                     compress = true;
                 }
             }
+            Err(message) => return Err(fail_with_message(message, stderr)),
+        }
+    }
+
+    let codec = compression_algorithm.unwrap_or(CompressionAlgorithm::Zlib);
+
+    if !compress_disabled_by_choice && let Some(value) = compress_level {
+        match parse_compress_level(value.as_os_str(), codec) {
+            Ok(setting) => compress_level_setting = Some(setting),
             Err(message) => return Err(fail_with_message(message, stderr)),
         }
     }
@@ -467,21 +473,7 @@ where
         Some(CompressLevelArg::Level(level)) => {
             CompressionSetting::level(CompressionLevel::precise(level))
         }
-        None => {
-            if let Some(value) = compress_level {
-                match parse_compress_level_argument(value.as_os_str()) {
-                    Ok(setting) => {
-                        compress = !setting.is_disabled();
-                        setting
-                    }
-                    Err(message) => {
-                        return Err(fail_with_message(message, stderr));
-                    }
-                }
-            } else {
-                CompressionSetting::default()
-            }
-        }
+        None => CompressionSetting::default(),
     };
 
     Ok(CompressionResult {

--- a/crates/cli/src/frontend/tests/compress_level_upstream.rs
+++ b/crates/cli/src/frontend/tests/compress_level_upstream.rs
@@ -167,58 +167,42 @@ fn compress_level_without_z_flag_enables_compression() {
 }
 
 #[test]
-fn compress_level_negative_reports_error() {
-    let (code, stdout, stderr) = run_with_args([
+fn compress_level_negative_is_clamped_not_rejected() {
+    // upstream: token.c:init_compression_level() clamps out-of-range levels
+    // instead of erroring; -1 maps to the zlib default and enables compression.
+    let parsed = parse_args([
         OsString::from(RSYNC),
         OsString::from("--compress-level=-1"),
         OsString::from("source"),
         OsString::from("dest"),
-    ]);
+    ])
+    .expect("--compress-level=-1 should clamp, not error");
 
-    assert_eq!(code, 1);
-    assert!(stdout.is_empty());
-    let rendered = String::from_utf8(stderr).expect("diagnostic is valid UTF-8");
     assert!(
-        rendered.contains("--compress-level=-1"),
-        "error should reference the flag value: {rendered}"
+        parsed.compress,
+        "--compress-level=-1 should enable compression"
     );
+    assert_eq!(parsed.compress_level, Some(OsString::from("-1")));
 }
 
 #[test]
-fn compress_level_10_reports_error() {
-    let (code, stdout, stderr) = run_with_args([
-        OsString::from(RSYNC),
-        OsString::from("--compress-level=10"),
-        OsString::from("source"),
-        OsString::from("dest"),
-    ]);
+fn compress_level_above_max_is_clamped_not_rejected() {
+    // upstream saturates values above max_level (9) rather than rejecting them.
+    for level in ["10", "99"] {
+        let parsed = parse_args([
+            OsString::from(RSYNC),
+            OsString::from(format!("--compress-level={level}")),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .unwrap_or_else(|_| panic!("--compress-level={level} should clamp, not error"));
 
-    assert_eq!(code, 1);
-    assert!(stdout.is_empty());
-    let rendered = String::from_utf8(stderr).expect("diagnostic is valid UTF-8");
-    assert!(
-        rendered.contains("--compress-level=10"),
-        "error should reference the flag value: {rendered}"
-    );
-    assert!(
-        rendered.contains("between 0 and 9"),
-        "error should mention valid range: {rendered}"
-    );
-}
-
-#[test]
-fn compress_level_99_reports_error() {
-    let (code, stdout, stderr) = run_with_args([
-        OsString::from(RSYNC),
-        OsString::from("--compress-level=99"),
-        OsString::from("source"),
-        OsString::from("dest"),
-    ]);
-
-    assert_eq!(code, 1);
-    assert!(stdout.is_empty());
-    let rendered = String::from_utf8(stderr).expect("diagnostic is valid UTF-8");
-    assert!(rendered.contains("between 0 and 9"));
+        assert!(
+            parsed.compress,
+            "--compress-level={level} should enable compression"
+        );
+        assert_eq!(parsed.compress_level, Some(OsString::from(level)));
+    }
 }
 
 #[test]
@@ -318,9 +302,11 @@ fn compress_flag_alone_uses_default_level() {
 
 #[test]
 fn parse_compress_level_argument_accepts_all_valid_levels() {
+    use compress::algorithm::CompressionAlgorithm;
+
     for level in 0..=9 {
         let value = format!("{level}");
-        let result = parse_compress_level_argument(OsStr::new(&value));
+        let result = parse_compress_level_argument(OsStr::new(&value), CompressionAlgorithm::Zlib);
         assert!(
             result.is_ok(),
             "parse_compress_level_argument should accept level {level}"
@@ -342,30 +328,82 @@ fn parse_compress_level_argument_accepts_all_valid_levels() {
 }
 
 #[test]
-fn parse_compress_level_argument_rejects_10() {
-    let result = parse_compress_level_argument(OsStr::new("10"));
-    assert!(result.is_err(), "level 10 should be rejected");
-    let msg = result.unwrap_err().to_string();
-    assert!(
-        msg.contains("outside the supported range"),
-        "error should mention supported range: {msg}"
+fn parse_compress_level_argument_clamps_above_zlib_max() {
+    use compress::algorithm::CompressionAlgorithm;
+    use compress::zlib::CompressionLevel;
+
+    // upstream: token.c:init_compression_level() saturates to max_level (9)
+    // rather than rejecting the value.
+    for value in ["10", "22", "99"] {
+        let setting = parse_compress_level_argument(OsStr::new(value), CompressionAlgorithm::Zlib)
+            .unwrap_or_else(|_| panic!("level {value} should clamp, not error"));
+        assert_eq!(
+            setting.level_or_default(),
+            CompressionLevel::from_numeric(9).unwrap(),
+            "zlib level {value} should clamp to 9"
+        );
+    }
+}
+
+#[test]
+fn parse_compress_level_argument_maps_negative_one_to_zlib_default() {
+    use compress::algorithm::CompressionAlgorithm;
+    use compress::zlib::CompressionLevel;
+
+    // upstream: token.c - Z_DEFAULT_COMPRESSION (-1) remaps to the real default.
+    let setting = parse_compress_level_argument(OsStr::new("-1"), CompressionAlgorithm::Zlib)
+        .expect("-1 should map to the zlib default, not error");
+    assert_eq!(
+        setting.level_or_default(),
+        CompressionLevel::from_numeric(6).unwrap(),
+        "zlib -1 should map to default level 6"
     );
 }
 
 #[test]
-fn parse_compress_level_argument_rejects_negative() {
-    let result = parse_compress_level_argument(OsStr::new("-1"));
-    assert!(result.is_err(), "level -1 should be rejected");
-    let msg = result.unwrap_err().to_string();
-    assert!(
-        msg.contains("outside the supported range"),
-        "error should mention supported range: {msg}"
+fn parse_compress_level_argument_clamps_large_negative_to_min() {
+    use compress::algorithm::CompressionAlgorithm;
+    use compress::zlib::CompressionLevel;
+
+    // upstream: token.c saturates values below min_level (1).
+    let setting = parse_compress_level_argument(OsStr::new("-5"), CompressionAlgorithm::Zlib)
+        .expect("-5 should clamp, not error");
+    assert_eq!(
+        setting.level_or_default(),
+        CompressionLevel::from_numeric(1).unwrap(),
+        "zlib -5 should clamp to min level 1"
     );
+}
+
+#[cfg(feature = "zstd")]
+#[test]
+fn parse_compress_level_argument_clamps_to_zstd_range() {
+    use compress::algorithm::CompressionAlgorithm;
+    use compress::zlib::CompressionLevel;
+    use std::num::NonZeroU8;
+
+    // upstream: token.c zstd branch - max_level is ZSTD_maxCLevel() (22) and 0
+    // selects ZSTD_CLEVEL_DEFAULT (3) rather than disabling compression.
+    let expect = |raw: &str, level: u8| {
+        let setting = parse_compress_level_argument(OsStr::new(raw), CompressionAlgorithm::Zstd)
+            .unwrap_or_else(|_| panic!("zstd level {raw} should clamp, not error"));
+        assert_eq!(
+            setting.level_or_default(),
+            CompressionLevel::precise(NonZeroU8::new(level).unwrap()),
+            "zstd level {raw} should resolve to {level}"
+        );
+    };
+    expect("0", 3);
+    expect("22", 22);
+    expect("99", 22);
+    expect("15", 15);
 }
 
 #[test]
 fn parse_compress_level_argument_rejects_empty() {
-    let result = parse_compress_level_argument(OsStr::new(""));
+    use compress::algorithm::CompressionAlgorithm;
+
+    let result = parse_compress_level_argument(OsStr::new(""), CompressionAlgorithm::Zlib);
     assert!(result.is_err(), "empty value should be rejected");
     let msg = result.unwrap_err().to_string();
     assert!(
@@ -376,14 +414,18 @@ fn parse_compress_level_argument_rejects_empty() {
 
 #[test]
 fn parse_compress_level_argument_rejects_float() {
-    let result = parse_compress_level_argument(OsStr::new("3.5"));
+    use compress::algorithm::CompressionAlgorithm;
+
+    let result = parse_compress_level_argument(OsStr::new("3.5"), CompressionAlgorithm::Zlib);
     assert!(result.is_err(), "float value should be rejected");
 }
 
 #[test]
 fn parse_compress_level_argument_trims_whitespace() {
+    use compress::algorithm::CompressionAlgorithm;
+
     // Whitespace around the value should be handled
-    let result = parse_compress_level_argument(OsStr::new(" 6 "));
+    let result = parse_compress_level_argument(OsStr::new(" 6 "), CompressionAlgorithm::Zlib);
     assert!(result.is_ok(), "whitespace-padded value should be accepted");
     let setting = result.unwrap();
     assert!(setting.is_enabled());

--- a/crates/cli/src/frontend/tests/compression.rs
+++ b/crates/cli/src/frontend/tests/compression.rs
@@ -91,14 +91,22 @@ fn compress_threads_negative_reports_error() {
 }
 
 #[test]
-fn compress_level_out_of_range_reports_error() {
-    let (code, stdout, stderr) =
-        run_with_args([OsString::from(RSYNC), OsString::from("--compress-level=12")]);
+fn compress_level_out_of_range_is_clamped() {
+    // upstream: token.c:init_compression_level() clamps out-of-range levels to
+    // the codec's valid range instead of rejecting them.
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--compress-level=12"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("--compress-level=12 should clamp, not error");
 
-    assert_eq!(code, 1);
-    assert!(stdout.is_empty());
-    let rendered = String::from_utf8(stderr).expect("diagnostic is valid UTF-8");
-    assert!(rendered.contains("--compress-level=12 must be between 0 and 9"));
+    assert!(
+        parsed.compress,
+        "--compress-level=12 should enable compression"
+    );
+    assert_eq!(parsed.compress_level, Some(OsString::from("12")));
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -2739,9 +2739,10 @@ fn parity_compress_level_accepted_without_error() {
     fs::create_dir(&dest_dir).expect("create dest");
     fs::write(&source, b"compress level test").expect("write");
 
-    // Test various compression levels (upstream rsync supports 1-9)
-    for level in [1, 5, 9] {
-        let dest = temp.path().join(format!("dest{level}"));
+    // Valid levels plus out-of-range values that upstream clamps rather than
+    // rejecting (upstream: token.c:init_compression_level()).
+    for (index, level) in ["1", "5", "9", "-1", "22", "99"].iter().enumerate() {
+        let dest = temp.path().join(format!("dest{index}"));
         fs::create_dir(&dest).expect("create dest");
 
         let (code, _stdout, stderr) = run_with_args([

--- a/crates/cli/src/frontend/tests/parse_compress.rs
+++ b/crates/cli/src/frontend/tests/parse_compress.rs
@@ -1,14 +1,24 @@
 use super::common::*;
 use super::*;
 
+use compress::algorithm::CompressionAlgorithm;
+
 #[test]
-fn parse_compress_level_argument_rejects_invalid_value() {
-    let error = parse_compress_level_argument(OsStr::new("fast")).unwrap_err();
+fn parse_compress_level_argument_rejects_non_numeric_value() {
+    let error =
+        parse_compress_level_argument(OsStr::new("fast"), CompressionAlgorithm::Zlib).unwrap_err();
     let rendered = error.to_string();
     assert!(rendered.contains("invalid compression level"));
     assert!(rendered.contains("integer"));
+}
 
-    let range_error = parse_compress_level_argument(OsStr::new("12")).unwrap_err();
-    let rendered_range = range_error.to_string();
-    assert!(rendered_range.contains("outside the supported range"));
+#[test]
+fn parse_compress_level_argument_clamps_out_of_range_value() {
+    // upstream: token.c:init_compression_level() clamps rather than rejecting.
+    let setting =
+        parse_compress_level_argument(OsStr::new("12"), CompressionAlgorithm::Zlib).unwrap();
+    assert!(
+        setting.is_enabled(),
+        "level 12 should clamp to a valid level"
+    );
 }

--- a/crates/compress/src/algorithm.rs
+++ b/crates/compress/src/algorithm.rs
@@ -4,12 +4,17 @@
 //! algorithm, matching upstream rsync defaults.
 
 use ::core::str::FromStr;
+use std::num::NonZeroU8;
 
 use thiserror::Error;
 
 /// Default zlib compression level matching upstream rsync.
 /// upstream: token.c - `Z_DEFAULT_COMPRESSION` resolves to 6.
 pub const ZLIB_DEFAULT_LEVEL: i32 = 6;
+
+/// Maximum zstd compression level accepted by `--compress-level`.
+/// upstream: token.c:74 - `ZSTD_maxCLevel()` returns 22 (ultra levels enabled).
+pub const ZSTD_MAX_LEVEL: i32 = 22;
 
 /// Default zstd compression level.
 /// upstream: token.c - `ZSTD_CLEVEL_DEFAULT` is 3.
@@ -104,6 +109,60 @@ impl CompressionAlgorithm {
             ALGORITHMS
         }
     }
+
+    /// Clamps a requested `--compress-level` value into this codec's valid
+    /// range, mirroring upstream `token.c:init_compression_level()`.
+    ///
+    /// Upstream never rejects an out-of-range level - it saturates the value to
+    /// the codec's `min_level`/`max_level` ("We don't bother with any errors or
+    /// warnings -- just make sure that the values are valid."). Returns `None`
+    /// when the level disables compression (zlib `off_level` of `0`); `Some`
+    /// with the clamped level otherwise.
+    #[must_use]
+    pub fn clamp_level(self, level: i32) -> Option<NonZeroU8> {
+        match self {
+            CompressionAlgorithm::Zlib => clamp_zlib_level(level),
+            #[cfg(feature = "lz4")]
+            // upstream: token.c:81-87 - lz4 forces min/max/def to 0 and never
+            // disables; oc represents this as the fastest expressible level.
+            CompressionAlgorithm::Lz4 => Some(clamped(1)),
+            #[cfg(feature = "zstd")]
+            CompressionAlgorithm::Zstd => Some(clamp_zstd_level(level)),
+        }
+    }
+}
+
+/// Wraps an already-clamped, guaranteed non-zero level.
+fn clamped(level: u8) -> NonZeroU8 {
+    NonZeroU8::new(level).expect("clamped level is non-zero")
+}
+
+/// Clamps into the zlib range, mirroring `token.c:59-70`.
+///
+/// `Z_DEFAULT_COMPRESSION` (`-1`) remaps to the real default level (6); `0` is
+/// upstream's `off_level` and disables compression; all other values saturate
+/// to `1..=9`.
+fn clamp_zlib_level(level: i32) -> Option<NonZeroU8> {
+    if level == -1 {
+        return Some(clamped(ZLIB_DEFAULT_LEVEL as u8));
+    }
+    if level == 0 {
+        return None;
+    }
+    Some(clamped(level.clamp(1, 9) as u8))
+}
+
+/// Clamps into the zstd range, mirroring `token.c:72-79`.
+///
+/// `0` selects `ZSTD_CLEVEL_DEFAULT` (3); zstd's `off_level` is
+/// `CLVL_NOT_SPECIFIED`, so `0` never disables. The representable range is
+/// `1..=ZSTD_MAX_LEVEL`.
+#[cfg(feature = "zstd")]
+fn clamp_zstd_level(level: i32) -> NonZeroU8 {
+    if level == 0 {
+        return clamped(ZSTD_DEFAULT_LEVEL as u8);
+    }
+    clamped(level.clamp(1, ZSTD_MAX_LEVEL) as u8)
 }
 
 impl Default for CompressionAlgorithm {
@@ -141,6 +200,42 @@ mod tests {
     fn available_algorithms_only_include_zlib_when_no_optional_features_enabled() {
         let available = CompressionAlgorithm::available();
         assert_eq!(available, &[CompressionAlgorithm::Zlib]);
+    }
+
+    fn level(algorithm: CompressionAlgorithm, raw: i32) -> Option<u8> {
+        algorithm.clamp_level(raw).map(NonZeroU8::get)
+    }
+
+    #[test]
+    fn zlib_clamp_saturates_and_disables_like_upstream() {
+        // upstream: token.c:init_compression_level() zlib branch.
+        assert_eq!(level(CompressionAlgorithm::Zlib, 0), None, "0 disables");
+        assert_eq!(
+            level(CompressionAlgorithm::Zlib, -1),
+            Some(6),
+            "-1 = default"
+        );
+        assert_eq!(level(CompressionAlgorithm::Zlib, -5), Some(1), "below min");
+        assert_eq!(level(CompressionAlgorithm::Zlib, 5), Some(5), "in range");
+        assert_eq!(level(CompressionAlgorithm::Zlib, 9), Some(9), "max");
+        assert_eq!(level(CompressionAlgorithm::Zlib, 10), Some(9), "above max");
+        assert_eq!(
+            level(CompressionAlgorithm::Zlib, 99),
+            Some(9),
+            "far above max"
+        );
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn zstd_clamp_uses_wider_range_like_upstream() {
+        // upstream: token.c:init_compression_level() zstd branch - 0 selects the
+        // default (3), max_level is ZSTD_maxCLevel() (22), and 0 never disables.
+        assert_eq!(level(CompressionAlgorithm::Zstd, 0), Some(3), "0 = default");
+        assert_eq!(level(CompressionAlgorithm::Zstd, 15), Some(15), "in range");
+        assert_eq!(level(CompressionAlgorithm::Zstd, 22), Some(22), "max");
+        assert_eq!(level(CompressionAlgorithm::Zstd, 99), Some(22), "above max");
+        assert_eq!(level(CompressionAlgorithm::Zstd, -5), Some(1), "below min");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`--compress-level` handling errored on out-of-range values where upstream rsync **clamps** them. Upstream `token.c:init_compression_level()` saturates the level to the selected codec's `[min_level, max_level]` and never rejects an out-of-range integer ("We don't bother with any errors or warnings -- just make sure that the values are valid.").

Previously `oc-rsync --compress-level=99` (and `-1`, `15`, `22`) failed with `--compress-level=N must be between 0 and 9`, while upstream accepts and clamps them.

## Upstream behaviour (token.c)

- **zlib/zlibx**: range `1..=9`, default `6`; `Z_DEFAULT_COMPRESSION` (`-1`) maps to `6`; `0` is the `off_level` and disables compression.
- **zstd**: range `1..=ZSTD_maxCLevel()` (`22`), default `3`; `0` selects the default and never disables (`off_level` is `CLVL_NOT_SPECIFIED`).

## Change

- Add `CompressionAlgorithm::clamp_level()` in the `compress` crate: a single codec-aware clamp mirroring `init_compression_level()`.
- At the CLI/options boundary, parse `--compress-choice` before `--compress-level` so the level is clamped against the selected codec, then clamp instead of erroring.
- Malformed input (empty or non-numeric) is still rejected, matching upstream's `POPT_ARG_INT` parse. `CompressionLevel::from_numeric` stays a strict internal `0..=9` validator.

## Validation (vs upstream rsync 3.4.3 on Linux/aarch64)

| value | upstream | oc-rsync (after) |
|-------|----------|------------------|
| 99, -1, 0, 9, 15, 22 | accept (exit 0) | accept (exit 0) |
| abc, 3.5 | error (exit 1) | error (exit 1) |

- Round-trip transfers with clamped levels (zlib 99/-1, zstd 22/99/0) produce byte-identical output.
- oc client `--compress-level=99` forwarding the clamped level to an upstream rsync server over SSH: exit 0, content identical.
- Targeted `compress` and `cli` tests pass; `cargo clippy`/fmt clean on both crates.