### PR TITLE
fix(filters): evaluate CLI filter rules in true command-line order

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -9,6 +9,7 @@ use core::client::{
 
 use super::bandwidth::BandwidthArgument;
 use super::program_name::ProgramName;
+use crate::frontend::filter_rules::FilterOrderToken;
 use crate::frontend::progress::{NameOutputLevel, ProgressSetting};
 
 /// Parsed command-line arguments for the rsync frontend.
@@ -390,6 +391,11 @@ pub struct ParsedArgs {
 
     /// `--filter`, `-f` - general filter rules.
     pub filters: Vec<OsString>,
+
+    /// Every filter-producing option (`--include`/`--exclude`/`--filter`/
+    /// `--include-from`/`--exclude-from`/`-C`/`-F`) captured in true
+    /// command-line order for first-match-wins evaluation.
+    pub filter_order: Vec<FilterOrderToken>,
 
     /// `--cvs-exclude`, `-C` - use CVS-style ignore patterns.
     pub cvs_exclude: bool,

--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -13,7 +13,7 @@ use compress::algorithm::CompressionAlgorithm;
 use crate::frontend::arguments::short_options::expand_short_options;
 use crate::frontend::command_builder::clap_command;
 use crate::frontend::execution::{parse_checksum_seed_argument, parse_compress_level_argument};
-use crate::frontend::filter_rules::{collect_filter_arguments, locate_filter_arguments};
+use crate::frontend::filter_rules::{FilterOrderToken, build_filter_order};
 use crate::frontend::progress::{NameOutputLevel, ProgressSetting};
 use core::client::{
     AddressMode, DeleteMode, HumanReadableMode, StrongChecksumChoice, TcpFastOpenMode,
@@ -47,8 +47,7 @@ where
 
     let command = clap_command(program_name.as_str());
     let args = expand_short_options(&command, args);
-    let (filter_indices, rsync_filter_indices) = locate_filter_arguments(&args);
-    let mut matches = command.try_get_matches_from(args)?;
+    let mut matches = command.try_get_matches_from(args.clone())?;
 
     let show_help = matches.get_flag("help");
     let show_version = matches.get_count("version");
@@ -661,6 +660,11 @@ where
             .remove_one::<OsString>("bwlimit")
             .map(BandwidthArgument::Limit)
     };
+    // Capture every filter-producing option in true command-line order before
+    // the per-option values below are drained. upstream: options.c dispatches
+    // each --include/--exclude/--filter/--include-from/--exclude-from/-C/-F at
+    // its argv position, so evaluation is first-match-wins over encounter order.
+    let filter_order = build_filter_order(&matches, &args);
     let excludes = matches
         .remove_many::<OsString>("exclude")
         .map(Iterator::collect)
@@ -685,12 +689,17 @@ where
         .remove_many::<OsString>("include-from")
         .map(Iterator::collect)
         .unwrap_or_default();
-    let filters: Vec<OsString> = matches
-        .remove_many::<OsString>("filter")
-        .map(Iterator::collect)
-        .unwrap_or_default();
-    let rsync_filter_shortcuts = rsync_filter_indices.len();
-    let filter_args = collect_filter_arguments(&filters, &filter_indices, &rsync_filter_indices);
+    let _ = matches.remove_many::<OsString>("filter");
+    let rsync_filter_shortcuts = matches.get_count("rsync-filter") as usize;
+    // parsed.filters is the ordered stream's `--filter`/`-f`/`-F` directives,
+    // preserving their command-line position relative to each other.
+    let filter_args: Vec<OsString> = filter_order
+        .iter()
+        .filter_map(|token| match token {
+            FilterOrderToken::Filter(rule) => Some(rule.clone()),
+            _ => None,
+        })
+        .collect();
     let cvs_exclude = matches.get_flag("cvs-exclude");
     let apple_double_skip = matches.get_flag("apple-double-skip");
     let files_from = matches
@@ -911,6 +920,7 @@ where
         exclude_from,
         include_from,
         filters: filter_args,
+        filter_order,
         cvs_exclude,
         apple_double_skip,
         rsync_filter_shortcuts,

--- a/crates/cli/src/frontend/execution/drive/filters.rs
+++ b/crates/cli/src/frontend/execution/drive/filters.rs
@@ -11,23 +11,27 @@ use logging_sink::MessageSink;
 
 use super::messages::fail_with_message;
 use crate::frontend::filter_rules::{
-    FilterDirective, append_apple_double_exclude_rules, append_cvs_exclude_rules,
+    FilterDirective, FilterOrderToken, append_apple_double_exclude_rules, append_cvs_exclude_rules,
     append_filter_rules_from_files, apply_merge_directive, cvs_default_exclude_rules,
     merge_directive_options, os_string_to_pattern, parse_filter_directive, parse_old_prefix_rule,
 };
 
 /// Filter configuration supplied by the command line.
+///
+/// The ordered token stream preserves the argv position of every
+/// filter-producing option so evaluation is first-match-wins over encounter
+/// order, mirroring upstream options.c.
 pub(crate) struct FilterInputs {
-    pub(crate) exclude_from: Vec<OsString>,
-    pub(crate) include_from: Vec<OsString>,
-    pub(crate) excludes: Vec<OsString>,
-    pub(crate) includes: Vec<OsString>,
-    pub(crate) filters: Vec<OsString>,
-    pub(crate) cvs_exclude: bool,
-    pub(crate) apple_double_skip: bool,
+    pub(crate) order: Vec<FilterOrderToken>,
 }
 
 /// Applies CLI-provided filter rules to the [`ClientConfigBuilder`].
+///
+/// Rules are appended in command-line order so the filter engine's
+/// first-match-wins evaluation matches upstream rsync, where each
+/// `--include`/`--exclude`/`--filter`/`--include-from`/`--exclude-from`/`-C`/
+/// `-F` is fed to the rule list at its argv position (exclude.c:parse_filter_str
+/// appends in encounter order).
 pub(crate) fn apply_filters<Err>(
     mut builder: ClientConfigBuilder,
     inputs: FilterInputs,
@@ -37,74 +41,40 @@ where
     Err: std::io::Write,
 {
     let mut filter_rules = Vec::new();
-    if let Err(message) = append_filter_rules_from_files(
-        &mut filter_rules,
-        &inputs.include_from,
-        FilterRuleKind::Include,
-    ) {
-        return Err(fail_with_message(message, stderr));
-    }
-
-    for pattern in inputs.includes {
-        if let Err(message) =
-            push_old_prefix_rule(&mut filter_rules, pattern, FilterRuleKind::Include)
-        {
-            return Err(fail_with_message(message, stderr));
-        }
-    }
-
-    if let Err(message) = append_filter_rules_from_files(
-        &mut filter_rules,
-        &inputs.exclude_from,
-        FilterRuleKind::Exclude,
-    ) {
-        return Err(fail_with_message(message, stderr));
-    }
-
-    for pattern in inputs.excludes {
-        if let Err(message) =
-            push_old_prefix_rule(&mut filter_rules, pattern, FilterRuleKind::Exclude)
-        {
-            return Err(fail_with_message(message, stderr));
-        }
-    }
-
-    if inputs.cvs_exclude
-        && let Err(message) = append_cvs_exclude_rules(&mut filter_rules)
-    {
-        return Err(fail_with_message(message, stderr));
-    }
-
-    if inputs.apple_double_skip
-        && let Err(message) = append_apple_double_exclude_rules(&mut filter_rules)
-    {
-        return Err(fail_with_message(message, stderr));
-    }
-
     let mut merge_stack = HashSet::new();
     let merge_base = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    for filter in &inputs.filters {
-        match parse_filter_directive(filter.as_os_str()) {
-            Ok(FilterDirective::Rule(spec)) => filter_rules.push(spec),
-            Ok(FilterDirective::Merge(directive)) => {
-                let effective_options =
-                    merge_directive_options(&DirMergeOptions::default(), &directive);
-                let directive = directive.with_options(effective_options);
-                if let Err(message) = apply_merge_directive(
-                    directive,
-                    merge_base.as_path(),
-                    &mut filter_rules,
-                    &mut merge_stack,
-                ) {
-                    return Err(fail_with_message(message, stderr));
-                }
+
+    for token in inputs.order {
+        let result = match token {
+            FilterOrderToken::Include(pattern) => {
+                push_old_prefix_rule(&mut filter_rules, pattern, FilterRuleKind::Include)
             }
-            Ok(FilterDirective::Clear) => filter_rules.clear(),
-            Ok(FilterDirective::CvsDefaults) => match cvs_default_exclude_rules() {
-                Ok(rules) => filter_rules.extend(rules),
-                Err(message) => return Err(fail_with_message(message, stderr)),
-            },
-            Err(message) => return Err(fail_with_message(message, stderr)),
+            FilterOrderToken::Exclude(pattern) => {
+                push_old_prefix_rule(&mut filter_rules, pattern, FilterRuleKind::Exclude)
+            }
+            FilterOrderToken::IncludeFrom(file) => append_filter_rules_from_files(
+                &mut filter_rules,
+                std::slice::from_ref(&file),
+                FilterRuleKind::Include,
+            ),
+            FilterOrderToken::ExcludeFrom(file) => append_filter_rules_from_files(
+                &mut filter_rules,
+                std::slice::from_ref(&file),
+                FilterRuleKind::Exclude,
+            ),
+            FilterOrderToken::Filter(rule) => push_filter_directive(
+                &mut filter_rules,
+                &rule,
+                merge_base.as_path(),
+                &mut merge_stack,
+            ),
+            FilterOrderToken::CvsExclude => append_cvs_exclude_rules(&mut filter_rules),
+            FilterOrderToken::AppleDoubleSkip => {
+                append_apple_double_exclude_rules(&mut filter_rules)
+            }
+        };
+        if let Err(message) = result {
+            return Err(fail_with_message(message, stderr));
         }
     }
 
@@ -113,6 +83,27 @@ where
     }
 
     Ok(builder)
+}
+
+/// Parses one `--filter`/`-f`/`-F` directive and appends its rules.
+fn push_filter_directive(
+    filter_rules: &mut Vec<FilterRuleSpec>,
+    rule: &OsString,
+    merge_base: &std::path::Path,
+    merge_stack: &mut HashSet<PathBuf>,
+) -> Result<(), Message> {
+    match parse_filter_directive(rule.as_os_str())? {
+        FilterDirective::Rule(spec) => filter_rules.push(spec),
+        FilterDirective::Merge(directive) => {
+            let effective_options =
+                merge_directive_options(&DirMergeOptions::default(), &directive);
+            let directive = directive.with_options(effective_options);
+            apply_merge_directive(directive, merge_base, filter_rules, merge_stack)?;
+        }
+        FilterDirective::Clear => filter_rules.clear(),
+        FilterDirective::CvsDefaults => filter_rules.extend(cvs_default_exclude_rules()?),
+    }
+    Ok(())
 }
 
 /// Adds a CLI-supplied `--exclude`/`--include` pattern to `destination`,

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -123,16 +123,17 @@ where
         atimes,
         crtimes,
         acls,
-        excludes,
-        includes,
+        excludes: _,
+        includes: _,
         compare_destinations,
         copy_destinations,
         link_destinations,
-        exclude_from,
-        include_from,
-        filters,
-        cvs_exclude,
-        apple_double_skip,
+        exclude_from: _,
+        include_from: _,
+        filters: _,
+        filter_order,
+        cvs_exclude: _,
+        apple_double_skip: _,
         rsync_filter_shortcuts: _,
         files_from,
         from0,
@@ -951,13 +952,7 @@ where
     let builder = config::build_base_config(config_inputs);
 
     let filter_inputs = filters::FilterInputs {
-        exclude_from,
-        include_from,
-        excludes,
-        includes,
-        filters,
-        cvs_exclude,
-        apple_double_skip,
+        order: filter_order,
     };
 
     let builder = match filters::apply_filters(builder, filter_inputs, stderr) {

--- a/crates/cli/src/frontend/filter_rules/arguments.rs
+++ b/crates/cli/src/frontend/filter_rules/arguments.rs
@@ -1,107 +1,217 @@
 use std::collections::VecDeque;
 use std::ffi::OsString;
 
-pub(crate) fn locate_filter_arguments(args: &[OsString]) -> (Vec<usize>, Vec<usize>) {
-    let mut filter_indices = Vec::new();
-    let mut rsync_filter_indices = Vec::new();
+use clap::ArgMatches;
+
+/// A single filter directive captured in command-line (argv) order.
+///
+/// upstream: options.c feeds each `--include`/`--exclude`/`--filter`/
+/// `--include-from`/`--exclude-from`/`-C`/`-F` to `parse_filter_str`,
+/// `parse_filter_file`, or the CVS defaults at the argv position where it
+/// appears. Rule evaluation is strictly first-match-wins over encounter order
+/// (exclude.c:parse_filter_str appends each rule to the tail of the list), so
+/// the CLI must preserve command-line order across every filter-producing
+/// option rather than grouping includes ahead of excludes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FilterOrderToken {
+    /// `--exclude PATTERN`
+    Exclude(OsString),
+    /// `--include PATTERN`
+    Include(OsString),
+    /// `--exclude-from FILE`
+    ExcludeFrom(OsString),
+    /// `--include-from FILE`
+    IncludeFrom(OsString),
+    /// `--filter RULE` / `-f RULE` (also the directive an `-F` expands to)
+    Filter(OsString),
+    /// `--cvs-exclude` / `-C`
+    CvsExclude,
+    /// `--apple-double-skip`
+    AppleDoubleSkip,
+}
+
+/// Builds the filter directive stream in true command-line (argv) order.
+///
+/// The argv scan runs over the short-option-expanded arguments and records
+/// every filter-producing option in the order it appears. Parsed values come
+/// from clap (so `--opt=VALUE`, `-f VALUE`, and non-UTF-8 paths are handled
+/// exactly as clap parsed them); the scan supplies only the ordering, which
+/// clap cannot express for the repeatable `-F` flag. The resulting stream is
+/// evaluated first-match-wins, mirroring how upstream options.c dispatches each
+/// option at its argv position.
+pub(crate) fn build_filter_order(matches: &ArgMatches, args: &[OsString]) -> Vec<FilterOrderToken> {
+    let mut excludes = value_queue(matches, "exclude");
+    let mut includes = value_queue(matches, "include");
+    let mut exclude_from = value_queue(matches, "exclude-from");
+    let mut include_from = value_queue(matches, "include-from");
+    let mut filters = value_queue(matches, "filter");
+
+    let mut tokens = Vec::new();
+    let mut f_occurrence = 0usize;
     let mut after_double_dash = false;
-    let mut expect_filter_value = false;
+    let mut expect_value = false;
 
-    for (index, arg) in args.iter().enumerate().skip(1) {
+    for arg in args.iter().skip(1) {
         if after_double_dash {
+            break;
+        }
+        if expect_value {
+            expect_value = false;
             continue;
         }
 
-        if expect_filter_value {
-            expect_filter_value = false;
-            continue;
-        }
+        // Option names are ASCII; only values (which are skipped via
+        // `expect_value` or the inline `=VALUE`) can be non-UTF-8, so a lossy
+        // conversion is safe for recognizing which option a token is.
+        let text = arg.to_string_lossy();
 
-        if arg == "--" {
+        if text == "--" {
             after_double_dash = true;
             continue;
         }
 
-        if arg == "--filter" || arg == "-f" {
-            filter_indices.push(index);
-            expect_filter_value = true;
+        if let Some(token) = long_value_option(&text, &mut excludes, &mut includes)
+            .or_else(|| long_from_option(&text, &mut exclude_from, &mut include_from))
+        {
+            expect_value = true;
+            if let Some(token) = token {
+                tokens.push(token);
+            }
             continue;
         }
 
-        let value = arg.to_string_lossy();
-
-        if value.starts_with("--filter=") {
-            filter_indices.push(index);
+        if text == "--filter" || text == "-f" {
+            expect_value = true;
+            if let Some(value) = filters.pop_front() {
+                tokens.push(FilterOrderToken::Filter(value));
+            }
             continue;
         }
 
-        if value.starts_with('-') && !value.starts_with("--") && value.len() > 1 {
-            for ch in value[1..].chars() {
-                if ch == 'F' {
-                    rsync_filter_indices.push(index);
+        if let Some(token) = long_inline_option(&text, &mut excludes, &mut includes)
+            .or_else(|| inline_from_option(&text, &mut exclude_from, &mut include_from))
+            .or_else(|| inline_filter_option(&text, &mut filters))
+        {
+            if let Some(token) = token {
+                tokens.push(token);
+            }
+            continue;
+        }
+
+        if text == "--cvs-exclude" {
+            tokens.push(FilterOrderToken::CvsExclude);
+            continue;
+        }
+        if text == "--apple-double-skip" {
+            tokens.push(FilterOrderToken::AppleDoubleSkip);
+            continue;
+        }
+
+        // Short-option cluster: `-F` and `-C` may ride alongside other flags.
+        // upstream: options.c:1589-1598 - each `-F` expands to a filter
+        // directive (first: dir-merge, second: exclude) at its argv position.
+        if text.starts_with('-') && !text.starts_with("--") && text.len() > 1 {
+            for ch in text[1..].chars() {
+                match ch {
+                    'F' => {
+                        if let Some(directive) = rsync_filter_shortcut_directive(f_occurrence) {
+                            tokens.push(FilterOrderToken::Filter(directive));
+                        }
+                        f_occurrence += 1;
+                    }
+                    'C' => tokens.push(FilterOrderToken::CvsExclude),
+                    _ => {}
                 }
             }
         }
     }
 
-    (filter_indices, rsync_filter_indices)
+    tokens
 }
 
-pub(crate) fn collect_filter_arguments(
-    filters: &[OsString],
-    filter_indices: &[usize],
-    rsync_filter_indices: &[usize],
-) -> Vec<OsString> {
-    if rsync_filter_indices.is_empty() {
-        return filters.to_vec();
-    }
-
-    let mut raw_queue: VecDeque<(usize, &OsString)> =
-        filter_indices.iter().copied().zip(filters.iter()).collect();
-    let mut alias_queue: VecDeque<(usize, usize)> = rsync_filter_indices
-        .iter()
-        .copied()
-        .enumerate()
-        .map(|(occurrence, position)| (position, occurrence))
-        .collect();
-    let mut merged = Vec::with_capacity(raw_queue.len() + alias_queue.len() * 2);
-
-    while !raw_queue.is_empty() || !alias_queue.is_empty() {
-        match (raw_queue.front(), alias_queue.front()) {
-            (Some((raw_index, _)), Some((alias_index, _))) => {
-                if alias_index <= raw_index {
-                    let (_, occurrence) = alias_queue.pop_front().unwrap();
-                    push_rsync_filter_shortcut(&mut merged, occurrence);
-                } else {
-                    let (_, value) = raw_queue.pop_front().unwrap();
-                    merged.push(value.clone());
-                }
-            }
-            (Some(_), None) => {
-                let (_, value) = raw_queue.pop_front().unwrap();
-                merged.push(value.clone());
-            }
-            (None, Some(_)) => {
-                let (_, occurrence) = alias_queue.pop_front().unwrap();
-                push_rsync_filter_shortcut(&mut merged, occurrence);
-            }
-            (None, None) => break,
-        }
-    }
-
-    merged
+/// Collects a value-bearing option's parsed values in argv order.
+fn value_queue(matches: &ArgMatches, id: &str) -> VecDeque<OsString> {
+    matches
+        .get_many::<OsString>(id)
+        .map(|values| values.cloned().collect())
+        .unwrap_or_default()
 }
 
-/// Pushes filter rules for the `-F` shortcut flag.
+/// Recognizes `--exclude`/`--include` (value in the following token).
+fn long_value_option(
+    text: &str,
+    excludes: &mut VecDeque<OsString>,
+    includes: &mut VecDeque<OsString>,
+) -> Option<Option<FilterOrderToken>> {
+    match text {
+        "--exclude" => Some(excludes.pop_front().map(FilterOrderToken::Exclude)),
+        "--include" => Some(includes.pop_front().map(FilterOrderToken::Include)),
+        _ => None,
+    }
+}
+
+/// Recognizes `--exclude-from`/`--include-from` (value in the following token).
+fn long_from_option(
+    text: &str,
+    exclude_from: &mut VecDeque<OsString>,
+    include_from: &mut VecDeque<OsString>,
+) -> Option<Option<FilterOrderToken>> {
+    match text {
+        "--exclude-from" => Some(exclude_from.pop_front().map(FilterOrderToken::ExcludeFrom)),
+        "--include-from" => Some(include_from.pop_front().map(FilterOrderToken::IncludeFrom)),
+        _ => None,
+    }
+}
+
+/// Recognizes `--exclude=VALUE`/`--include=VALUE` (inline value).
+fn long_inline_option(
+    text: &str,
+    excludes: &mut VecDeque<OsString>,
+    includes: &mut VecDeque<OsString>,
+) -> Option<Option<FilterOrderToken>> {
+    if text.starts_with("--exclude=") {
+        Some(excludes.pop_front().map(FilterOrderToken::Exclude))
+    } else if text.starts_with("--include=") {
+        Some(includes.pop_front().map(FilterOrderToken::Include))
+    } else {
+        None
+    }
+}
+
+/// Recognizes `--exclude-from=VALUE`/`--include-from=VALUE` (inline value).
+fn inline_from_option(
+    text: &str,
+    exclude_from: &mut VecDeque<OsString>,
+    include_from: &mut VecDeque<OsString>,
+) -> Option<Option<FilterOrderToken>> {
+    if text.starts_with("--exclude-from=") {
+        Some(exclude_from.pop_front().map(FilterOrderToken::ExcludeFrom))
+    } else if text.starts_with("--include-from=") {
+        Some(include_from.pop_front().map(FilterOrderToken::IncludeFrom))
+    } else {
+        None
+    }
+}
+
+/// Recognizes `--filter=VALUE` (inline value).
+fn inline_filter_option(
+    text: &str,
+    filters: &mut VecDeque<OsString>,
+) -> Option<Option<FilterOrderToken>> {
+    text.starts_with("--filter=")
+        .then(|| filters.pop_front().map(FilterOrderToken::Filter))
+}
+
+/// Maps an `-F` occurrence to the filter directive it expands to.
 ///
-/// upstream: options.c:1589-1598 - first `-F` adds `: /.rsync-filter`
-/// (dir-merge), second `-F` adds `- .rsync-filter` (exclude). Third+
+/// upstream: options.c:1589-1598 - the first `-F` adds `: /.rsync-filter`
+/// (dir-merge), the second adds `- .rsync-filter` (exclude); third and later
 /// occurrences are ignored.
-fn push_rsync_filter_shortcut(target: &mut Vec<OsString>, occurrence: usize) {
+fn rsync_filter_shortcut_directive(occurrence: usize) -> Option<OsString> {
     match occurrence {
-        0 => target.push(OsString::from("dir-merge /.rsync-filter")),
-        1 => target.push(OsString::from("exclude .rsync-filter")),
-        _ => {}
+        0 => Some(OsString::from("dir-merge /.rsync-filter")),
+        1 => Some(OsString::from("exclude .rsync-filter")),
+        _ => None,
     }
 }
 
@@ -109,133 +219,16 @@ fn push_rsync_filter_shortcut(target: &mut Vec<OsString>, occurrence: usize) {
 mod tests {
     use super::*;
 
-    fn os(s: &str) -> OsString {
-        OsString::from(s)
-    }
-
     #[test]
-    fn locate_filter_arguments_empty() {
-        let args: Vec<OsString> = vec![os("rsync")];
-        let (filter_indices, rsync_filter_indices) = locate_filter_arguments(&args);
-        assert!(filter_indices.is_empty());
-        assert!(rsync_filter_indices.is_empty());
-    }
-
-    #[test]
-    fn locate_filter_arguments_finds_filter() {
-        let args = vec![os("rsync"), os("--filter"), os("- *.bak")];
-        let (filter_indices, rsync_filter_indices) = locate_filter_arguments(&args);
-        assert_eq!(filter_indices, vec![1]);
-        assert!(rsync_filter_indices.is_empty());
-    }
-
-    #[test]
-    fn locate_filter_arguments_finds_filter_equals() {
-        let args = vec![os("rsync"), os("--filter=- *.bak")];
-        let (filter_indices, _) = locate_filter_arguments(&args);
-        assert_eq!(filter_indices, vec![1]);
-    }
-
-    #[test]
-    fn locate_filter_arguments_finds_short_f() {
-        let args = vec![os("rsync"), os("-avF")];
-        let (filter_indices, rsync_filter_indices) = locate_filter_arguments(&args);
-        assert!(filter_indices.is_empty());
-        assert_eq!(rsync_filter_indices, vec![1]);
-    }
-
-    #[test]
-    fn locate_filter_arguments_multiple_f() {
-        let args = vec![os("rsync"), os("-F"), os("-F")];
-        let (_, rsync_filter_indices) = locate_filter_arguments(&args);
-        assert_eq!(rsync_filter_indices, vec![1, 2]);
-    }
-
-    #[test]
-    fn locate_filter_arguments_stops_at_double_dash() {
-        let args = vec![os("rsync"), os("--"), os("--filter"), os("pattern")];
-        let (filter_indices, _) = locate_filter_arguments(&args);
-        assert!(filter_indices.is_empty());
-    }
-
-    #[test]
-    fn locate_filter_arguments_mixed() {
-        let args = vec![
-            os("rsync"),
-            os("-avF"),
-            os("--filter"),
-            os("- *.tmp"),
-            os("-F"),
-        ];
-        let (filter_indices, rsync_filter_indices) = locate_filter_arguments(&args);
-        assert_eq!(filter_indices, vec![2]);
-        assert_eq!(rsync_filter_indices, vec![1, 4]);
-    }
-
-    #[test]
-    fn collect_filter_arguments_no_aliases() {
-        let filters = vec![os("- *.bak"), os("+ *.txt")];
-        let filter_indices = vec![1, 2];
-        let rsync_filter_indices: Vec<usize> = vec![];
-        let result = collect_filter_arguments(&filters, &filter_indices, &rsync_filter_indices);
-        assert_eq!(result, filters);
-    }
-
-    #[test]
-    fn collect_filter_arguments_first_f_alias() {
-        let filters: Vec<OsString> = vec![];
-        let filter_indices: Vec<usize> = vec![];
-        let rsync_filter_indices = vec![1];
-        let result = collect_filter_arguments(&filters, &filter_indices, &rsync_filter_indices);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0], os("dir-merge /.rsync-filter"));
-    }
-
-    #[test]
-    fn collect_filter_arguments_second_f_alias() {
-        // upstream: options.c:1589-1598 - first -F adds dir-merge, second adds exclude
-        let filters: Vec<OsString> = vec![];
-        let filter_indices: Vec<usize> = vec![];
-        let rsync_filter_indices = vec![1, 2];
-        let result = collect_filter_arguments(&filters, &filter_indices, &rsync_filter_indices);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0], os("dir-merge /.rsync-filter"));
-        assert_eq!(result[1], os("exclude .rsync-filter"));
-    }
-
-    #[test]
-    fn collect_filter_arguments_interleaved() {
-        let filters = vec![os("- *.bak")];
-        let filter_indices = vec![3];
-        let rsync_filter_indices = vec![1];
-        let result = collect_filter_arguments(&filters, &filter_indices, &rsync_filter_indices);
-        // -F at position 1 comes before --filter at position 3
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0], os("dir-merge /.rsync-filter"));
-        assert_eq!(result[1], os("- *.bak"));
-    }
-
-    #[test]
-    fn push_rsync_filter_shortcut_first() {
-        let mut target = Vec::new();
-        push_rsync_filter_shortcut(&mut target, 0);
-        assert_eq!(target.len(), 1);
-        assert_eq!(target[0], os("dir-merge /.rsync-filter"));
-    }
-
-    #[test]
-    fn push_rsync_filter_shortcut_second() {
-        let mut target = Vec::new();
-        push_rsync_filter_shortcut(&mut target, 1);
-        assert_eq!(target.len(), 1);
-        assert_eq!(target[0], os("exclude .rsync-filter"));
-    }
-
-    #[test]
-    fn push_rsync_filter_shortcut_third_ignored() {
-        // upstream: options.c:1589 - only first two -F flags have effect
-        let mut target = Vec::new();
-        push_rsync_filter_shortcut(&mut target, 2);
-        assert!(target.is_empty());
+    fn rsync_filter_shortcut_directive_maps_first_two_occurrences() {
+        assert_eq!(
+            rsync_filter_shortcut_directive(0),
+            Some(OsString::from("dir-merge /.rsync-filter"))
+        );
+        assert_eq!(
+            rsync_filter_shortcut_directive(1),
+            Some(OsString::from("exclude .rsync-filter"))
+        );
+        assert_eq!(rsync_filter_shortcut_directive(2), None);
     }
 }

--- a/crates/cli/src/frontend/filter_rules/mod.rs
+++ b/crates/cli/src/frontend/filter_rules/mod.rs
@@ -9,7 +9,7 @@ mod parsing;
 mod sources;
 
 pub(crate) use apple_double::append_apple_double_exclude_rules;
-pub(crate) use arguments::{collect_filter_arguments, locate_filter_arguments};
+pub(crate) use arguments::{FilterOrderToken, build_filter_order};
 pub(crate) use cvs::{append_cvs_exclude_rules, cvs_default_exclude_rules};
 pub(crate) use directive::{FilterDirective, merge_directive_options, os_string_to_pattern};
 pub(crate) use merge::apply_merge_directive;

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -148,7 +148,7 @@ pub(crate) use filter_rules::MergeDirective;
 #[cfg(test)]
 pub(crate) use filter_rules::{
     FilterDirective, append_filter_rules_from_files, apply_merge_directive,
-    collect_filter_arguments, merge_directive_options, parse_filter_directive,
+    merge_directive_options, parse_filter_directive,
 };
 use help::help_text;
 use lsm_status::render_lsm_status;

--- a/crates/cli/src/frontend/tests/collect.rs
+++ b/crates/cli/src/frontend/tests/collect.rs
@@ -1,19 +1,28 @@
 use super::common::*;
 use super::*;
 
+/// `-F` shortcuts interleave with `--filter`/`-f` rules at their argv position.
+///
+/// upstream: options.c:1589-1598 - the first `-F` adds `dir-merge
+/// /.rsync-filter`, the second adds `exclude .rsync-filter`; each is inserted
+/// where the flag appears on the command line.
 #[test]
-fn collect_filter_arguments_merges_shortcuts_with_filters() {
-    use std::ffi::OsString;
+fn short_f_shortcuts_interleave_with_filters_in_argv_order() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("-F"),
+        OsString::from("--filter"),
+        OsString::from("+ foo"),
+        OsString::from("-F"),
+        OsString::from("--filter"),
+        OsString::from("- bar"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
 
-    let filters = vec![OsString::from("+ foo"), OsString::from("- bar")];
-    let filter_indices = vec![5_usize, 9_usize];
-    let rsync_indices = vec![1_usize, 7_usize];
-
-    let merged = collect_filter_arguments(&filters, &filter_indices, &rsync_indices);
-
-    // upstream: options.c:1589-1598 - first -F adds dir-merge, second adds exclude
     assert_eq!(
-        merged,
+        parsed.filters,
         vec![
             OsString::from("dir-merge /.rsync-filter"),
             OsString::from("+ foo"),
@@ -23,17 +32,21 @@ fn collect_filter_arguments_merges_shortcuts_with_filters() {
     );
 }
 
+/// Two `-F` flags with no explicit `--filter` rules still expand to the
+/// dir-merge and exclude directives in occurrence order.
 #[test]
-fn collect_filter_arguments_handles_shortcuts_without_filters() {
-    use std::ffi::OsString;
+fn short_f_shortcuts_expand_without_explicit_filters() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("-F"),
+        OsString::from("-F"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
 
-    let filters: Vec<OsString> = Vec::new();
-    let filter_indices: Vec<usize> = Vec::new();
-    let merged = collect_filter_arguments(&filters, &filter_indices, &[2_usize, 4_usize]);
-
-    // upstream: options.c:1589-1598 - first -F adds dir-merge, second adds exclude
     assert_eq!(
-        merged,
+        parsed.filters,
         vec![
             OsString::from("dir-merge /.rsync-filter"),
             OsString::from("exclude .rsync-filter"),

--- a/crates/cli/src/frontend/tests/filter_behavior_comprehensive.rs
+++ b/crates/cli/src/frontend/tests/filter_behavior_comprehensive.rs
@@ -380,6 +380,93 @@ fn transfer_with_short_f_include_then_exclude_all() {
     assert!(!dest_root.join("skip.log").exists());
 }
 
+/// Sets up a source tree with a nested `sub/note.log` and returns the
+/// trailing-slash source operand plus destination root for filter-order tests.
+#[cfg(test)]
+fn setup_nested_log_transfer(tmp: &std::path::Path) -> (OsString, std::path::PathBuf) {
+    let source_root = tmp.join("source");
+    let dest_root = tmp.join("dest");
+    std::fs::create_dir_all(source_root.join("sub")).expect("create source sub");
+    std::fs::create_dir_all(&dest_root).expect("create dest root");
+    std::fs::write(source_root.join("sub/note.log"), b"note").expect("write nested log");
+
+    let mut source_operand = source_root.into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    (source_operand, dest_root)
+}
+
+/// upstream: options.c feeds `--exclude` then `--include` in argv order, so the
+/// earlier `- *.log` wins first-match and `sub/note.log` is excluded.
+#[test]
+fn transfer_exclude_before_include_excludes_nested_match() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let (source_operand, dest_root) = setup_nested_log_transfer(tmp.path());
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-r"),
+        OsString::from("--exclude"),
+        OsString::from("*.log"),
+        OsString::from("--include"),
+        OsString::from("sub/note.log"),
+        source_operand,
+        dest_root.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(!dest_root.join("sub/note.log").exists());
+}
+
+/// The reverse order re-includes the file before the exclude is evaluated, so
+/// `sub/note.log` is kept.
+#[test]
+fn transfer_include_before_exclude_keeps_nested_match() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let (source_operand, dest_root) = setup_nested_log_transfer(tmp.path());
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-r"),
+        OsString::from("--include"),
+        OsString::from("sub/note.log"),
+        OsString::from("--exclude"),
+        OsString::from("*.log"),
+        source_operand,
+        dest_root.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(dest_root.join("sub/note.log").exists());
+}
+
+/// A `-f '- *.log'` exclude ahead of `--include` also wins first-match, mirroring
+/// upstream's argv-order dispatch of `--filter` and `--include`.
+#[test]
+fn transfer_filter_exclude_before_include_excludes_nested_match() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let (source_operand, dest_root) = setup_nested_log_transfer(tmp.path());
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-r"),
+        OsString::from("-f"),
+        OsString::from("- *.log"),
+        OsString::from("--include"),
+        OsString::from("sub/note.log"),
+        source_operand,
+        dest_root.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(!dest_root.join("sub/note.log").exists());
+}
+
 #[test]
 fn transfer_with_short_f_clear_resets_rules() {
     use tempfile::tempdir;
@@ -673,78 +760,61 @@ fn exclude_from_and_filter_merge_produce_same_result() {
 }
 
 #[test]
-fn locate_filter_arguments_finds_short_f() {
-    use crate::frontend::filter_rules::locate_filter_arguments;
-
-    let args: Vec<OsString> = vec![
-        OsString::from("rsync"),
-        OsString::from("-f"),
-        OsString::from("- *.bak"),
-    ];
-    let (filter_indices, rsync_filter_indices) = locate_filter_arguments(&args);
-    assert_eq!(filter_indices, vec![1]);
-    assert!(rsync_filter_indices.is_empty());
-}
-
-#[test]
-fn locate_filter_arguments_finds_short_f_and_long_filter() {
-    use crate::frontend::filter_rules::locate_filter_arguments;
-
-    let args: Vec<OsString> = vec![
-        OsString::from("rsync"),
+fn filter_order_preserves_short_f_and_long_filter_sequence() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
         OsString::from("-f"),
         OsString::from("- *.bak"),
         OsString::from("--filter"),
         OsString::from("+ *.txt"),
-    ];
-    let (filter_indices, _) = locate_filter_arguments(&args);
-    assert_eq!(filter_indices, vec![1, 3]);
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert_eq!(
+        parsed.filters,
+        vec![OsString::from("- *.bak"), OsString::from("+ *.txt")]
+    );
 }
 
 #[test]
-fn locate_filter_arguments_short_f_stops_at_double_dash() {
-    use crate::frontend::filter_rules::locate_filter_arguments;
-
-    let args: Vec<OsString> = vec![
-        OsString::from("rsync"),
+fn filter_order_stops_at_double_dash() {
+    // After `--`, `-f` is a positional operand, not a filter option.
+    let parsed = parse_args([
+        OsString::from(RSYNC),
         OsString::from("--"),
         OsString::from("-f"),
-        OsString::from("- *.bak"),
-    ];
-    let (filter_indices, _) = locate_filter_arguments(&args);
-    assert!(filter_indices.is_empty());
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(parsed.filters.is_empty());
 }
 
 #[test]
-fn locate_filter_arguments_short_f_skips_value() {
-    use crate::frontend::filter_rules::locate_filter_arguments;
-
-    // After -f, the next argument is the value and should be skipped
-    let args: Vec<OsString> = vec![
-        OsString::from("rsync"),
-        OsString::from("-f"),
-        OsString::from("- *.bak"),
-        OsString::from("-f"),
-        OsString::from("+ *.txt"),
-    ];
-    let (filter_indices, _) = locate_filter_arguments(&args);
-    assert_eq!(filter_indices, vec![1, 3]);
-}
-
-#[test]
-fn locate_filter_arguments_interleaves_short_f_and_uppercase_f() {
-    use crate::frontend::filter_rules::locate_filter_arguments;
-
-    let args: Vec<OsString> = vec![
-        OsString::from("rsync"),
+fn filter_order_interleaves_short_f_and_uppercase_f() {
+    // upstream: options.c:1589-1598 - `-F` expands to a directive inserted at
+    // its argv position, so it interleaves with explicit `-f` rules in order.
+    let parsed = parse_args([
+        OsString::from(RSYNC),
         OsString::from("-F"),
         OsString::from("-f"),
         OsString::from("- *.bak"),
         OsString::from("-F"),
-    ];
-    let (filter_indices, rsync_filter_indices) = locate_filter_arguments(&args);
-    assert_eq!(filter_indices, vec![2]);
-    assert_eq!(rsync_filter_indices, vec![1, 4]);
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert_eq!(
+        parsed.filters,
+        vec![
+            OsString::from("dir-merge /.rsync-filter"),
+            OsString::from("- *.bak"),
+            OsString::from("exclude .rsync-filter"),
+        ]
+    );
 }
 
 #[test]

--- a/tests/integration_filters.rs
+++ b/tests/integration_filters.rs
@@ -254,7 +254,7 @@ fn filter_with_wildcards() {
 }
 
 #[test]
-fn later_filter_rule_wins() {
+fn first_matching_filter_rule_wins() {
     let test_dir = TestDir::new().expect("create test dir");
     let src_dir = test_dir.mkdir("src").unwrap();
     let dest_dir = test_dir.mkdir("dest").unwrap();
@@ -266,16 +266,19 @@ fn later_filter_rule_wins() {
     cmd.args([
         "-r",
         "--exclude=*.log",
-        "--include=file.log", // Include after exclude, so include wins (last rule wins)
+        // file.log already matches the earlier --exclude=*.log; rsync filters are
+        // first-match-wins (upstream exclude.c), so this later --include never fires.
+        "--include=file.log",
         &format!("{}/", src_dir.display()),
         &format!("{}/", dest_dir.display()),
     ]);
     cmd.assert_success();
 
-    // Last matching rule wins in rsync filter processing
+    // First matching rule wins: the earlier --exclude=*.log matched file.log first,
+    // so the later --include=file.log does not resurrect it (matches upstream rsync).
     assert!(
-        dest_dir.join("file.log").exists(),
-        "later include should override earlier exclude"
+        !dest_dir.join("file.log").exists(),
+        "earlier exclude matches first; a later include must not override it"
     );
     assert!(dest_dir.join("file.txt").exists());
 }


### PR DESCRIPTION
## Problem

oc-rsync assembled CLI filter rules in a fixed group order (include-from, includes, exclude-from, excludes, cvs, apple, filters) regardless of where each option appeared on the command line. This violated rsync's strict first-match-wins semantics.

Verified against upstream rsync 3.4.3:

| Args | upstream | oc (before) |
|------|----------|-------------|
| `--exclude '*.log' --include 'sub/note.log'` | excluded | **kept** (wrong) |
| `-f '- *.log' --include 'sub/note.log'` | excluded | **kept** (wrong) |
| `--exclude-from F --include 'sub/note.log'` | excluded | **kept** (wrong) |

## Root cause

`crates/cli/src/frontend/execution/drive/filters.rs::apply_filters` appended rules by group, not by argv position. The filters crate parser (faithful first-match-wins) was correct; only the CLI fed rules in the wrong order.

## Upstream reference

`options.c` feeds each `--include`/`--exclude`/`--filter`/`--include-from`/`--exclude-from`/`-C`/`-F` to `parse_filter_str`/`parse_filter_file` at its argv position; `exclude.c:parse_filter_str` appends each rule to the tail of the rule list, so evaluation is first-match-wins over encounter order.

## Fix

Capture every filter-producing option into one command-line-ordered token stream (`FilterOrderToken`) built from an argv scan of the short-option-expanded arguments, pulling parsed values from clap. `apply_filters` walks that single stream in order, dispatching each token to the existing rule helpers. `-F` shortcuts, `--cvs-exclude`/`-C` placement, and the apple-double rules are all positioned at their argv index. The `filters` crate is untouched; the CLI stays unsafe-free.

## Validation (oc vs `rsync` 3.4.3, aarch64 Linux)

All interleave cases now match upstream byte-for-byte: space forms, inline `=` forms, `--exclude-from`/`--include-from`, `-C` interleave, and `-F` interleave (10/10 MATCH, with unrelated files still transferred). Full `cli` lib test suite: 3130 passed. Existing group-order unit tests updated to argv-order behavioral assertions; regression tests added for `--exclude X --include Y` (Y excluded), `--include Y --exclude X` (Y kept), and `-f '- X' --include Y` (Y excluded).