### PR TITLE
fix: skip unconvertible --iconv filenames strictly instead of lossy

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -271,6 +271,20 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
                 rsync_error!(code.as_i32(), "stopping at requested limit").with_role(Role::Client);
             ClientError::with_code(code, message)
         }
+        LocalCopyErrorKind::PartialTransfer => {
+            // upstream: main.c:1356 - `some files/attrs were not transferred
+            // (see previous errors)` is printed by the sending half when
+            // `io_error` is set (e.g. an unconvertible --iconv filename), so
+            // who_am_i() tags the diagnostic `[sender]`. The per-entry cause
+            // was already emitted at the skip site.
+            let code = ExitCode::PartialTransfer;
+            let message = rsync_error!(
+                code.as_i32(),
+                "some files/attrs were not transferred (see previous errors)"
+            )
+            .with_role(Role::Sender);
+            ClientError::with_code(code, message)
+        }
         LocalCopyErrorKind::FilterSyntax { message } => {
             let code = ExitCode::Syntax;
             let msg = rsync_error!(code.as_i32(), "{}", message).with_role(Role::Client);

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -141,6 +141,12 @@ pub(crate) struct CopyContext<'a> {
     /// general I/O error occurred without `--ignore-errors`.
     // upstream: generator.c:299 static int already_warned
     io_error_delete_warning_emitted: bool,
+    /// Set when an `--iconv` filename could not be strictly transcoded to the
+    /// remote charset and its entry was skipped. Drives the final
+    /// `RERR_PARTIAL` (exit 23) exit code, mirroring upstream's
+    /// `io_error |= IOERR_GENERAL` on a failed `iconvbufs(ic_send, ...)`.
+    // upstream: flist.c:1631 send_file1()
+    iconv_conversion_error: bool,
     /// `true` when the active plan carries more than one source operand.
     /// Used to switch `--delete-during` to a deferred sweep so the per-source
     /// keep lists can be merged before any extraneous unlink fires; upstream

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -155,6 +155,15 @@ impl<'a> CopyContext<'a> {
     /// times independently of the generator's delayed-deletion phase.
     // upstream: generator.c:2419 do_delayed_deletions() runs after generate_files()
     pub(super) fn flush_deferred_deletions(&mut self) -> Result<(), LocalCopyError> {
+        // Nothing queued means no delete pass ran, so there is no notice to
+        // emit - upstream only prints the skip notice from inside delete_in_dir
+        // when a deletion was actually pending. Checking this first avoids a
+        // spurious "IO error encountered -- skipping file deletion" when an
+        // I/O error occurred (e.g. an unconvertible --iconv name) but --delete
+        // was not requested.
+        if self.deferred_ops.deletions.is_empty() {
+            return Ok(());
+        }
         if self.delete_pass_blocked_by_io_error() {
             // I/O errors occurred and --ignore-errors is not set; suppress
             // deletions to prevent data loss and emit the one-shot skip

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -143,6 +143,7 @@ impl<'a> CopyContext<'a> {
             checksum_cache: None,
             io_errors_occurred: false,
             io_error_delete_warning_emitted: false,
+            iconv_conversion_error: false,
             multi_source: false,
             verified_parents: HashSet::new(),
             batch_flist_writer,
@@ -1047,6 +1048,23 @@ impl<'a> CopyContext<'a> {
     /// deletion operations are suppressed to prevent data loss.
     pub(super) fn record_io_error(&mut self) {
         self.io_errors_occurred = true;
+    }
+
+    /// Records that an `--iconv` filename could not be strictly transcoded and
+    /// its entry was skipped.
+    ///
+    /// Also suppresses deletions like any other general I/O error, matching
+    /// upstream where `io_error |= IOERR_GENERAL` gates the delete pass.
+    // upstream: flist.c:1631 send_file1() sets io_error |= IOERR_GENERAL.
+    pub(super) fn record_iconv_conversion_error(&mut self) {
+        self.iconv_conversion_error = true;
+        self.io_errors_occurred = true;
+    }
+
+    /// Reports whether any `--iconv` filename conversion was skipped, so the
+    /// transfer can finish with exit code 23 (`RERR_PARTIAL`).
+    pub(super) const fn iconv_conversion_error_occurred(&self) -> bool {
+        self.iconv_conversion_error
     }
 
     /// Reports whether deletions should proceed despite I/O errors.

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -105,6 +105,21 @@ impl LocalCopyError {
         })
     }
 
+    /// Constructs a partial-transfer error (exit code 23, `RERR_PARTIAL`).
+    ///
+    /// Raised at the end of a copy that skipped one or more entries without a
+    /// per-source error to propagate - for example an `--iconv` filename that
+    /// could not be transcoded to the remote charset. The per-entry diagnostic
+    /// is emitted at the skip site; this error only carries the exit code and
+    /// the summary message.
+    ///
+    /// upstream: `main.c:1338-1345` `log_exit()` maps `io_error &
+    /// IOERR_GENERAL` to `RERR_PARTIAL`.
+    #[must_use]
+    pub const fn partial_transfer() -> Self {
+        Self::new(LocalCopyErrorKind::PartialTransfer)
+    }
+
     /// Constructs an error representing an inactivity timeout.
     #[must_use]
     pub const fn timeout(duration: Duration) -> Self {
@@ -156,6 +171,7 @@ impl LocalCopyError {
             }
             LocalCopyErrorKind::DeleteLimitExceeded { .. } => MAX_DELETE_EXIT_CODE,
             LocalCopyErrorKind::FilterSyntax { .. } => MISSING_OPERANDS_EXIT_CODE,
+            LocalCopyErrorKind::PartialTransfer => INVALID_OPERAND_EXIT_CODE,
         }
     }
 
@@ -180,6 +196,7 @@ impl LocalCopyError {
             }
             LocalCopyErrorKind::DeleteLimitExceeded { .. } => "RERR_DEL_LIMIT",
             LocalCopyErrorKind::FilterSyntax { .. } => "RERR_SYNTAX",
+            LocalCopyErrorKind::PartialTransfer => "RERR_PARTIAL",
         }
     }
 
@@ -304,6 +321,14 @@ pub enum LocalCopyErrorKind {
         /// Human-readable error message (already formatted to match upstream).
         message: String,
     },
+    /// One or more entries were skipped, so the transfer completes with
+    /// `RERR_PARTIAL` (exit 23). The per-entry cause was already reported at
+    /// the skip site (e.g. an unconvertible `--iconv` filename).
+    ///
+    /// upstream: `main.c:1356` prints `some files/attrs were not transferred
+    /// (see previous errors)` when `io_error` is set at exit.
+    #[error("some files/attrs were not transferred (see previous errors)")]
+    PartialTransfer,
 }
 
 impl LocalCopyErrorKind {

--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -16,7 +16,10 @@ use crate::local_copy::{
     follow_symlink_metadata,
 };
 
-use super::super::{non_empty_path, symlink_target_is_safe, transcode_filename_component};
+use super::super::{
+    emit_cannot_convert_filename, name_is_convertible, non_empty_path, symlink_target_is_safe,
+    transcode_filename_component,
+};
 use super::support::{DirectoryEntry, is_device, is_fifo};
 
 /// Action to take for a directory entry during recursive copy.
@@ -249,6 +252,21 @@ pub(crate) fn plan_directory_entries<'a>(
         } else {
             PathBuf::from(Path::new(&file_name))
         };
+
+        // upstream: flist.c:1614-1638 send_file1() - a name that cannot be
+        // strictly transcoded under --iconv is dropped from the flist with a
+        // diagnostic and io_error |= IOERR_GENERAL. Detecting it during planning
+        // sets io_error before this directory's delete pass runs, so deletions
+        // are suppressed exactly as upstream's build-then-generate order does;
+        // the entry never enters the plan (no copy, no keep-name, no ndx).
+        if !name_is_convertible(file_name.as_os_str(), context.options().iconv()) {
+            emit_cannot_convert_filename(relative_path.as_os_str());
+            context.record_iconv_conversion_error();
+            if let Some(buf) = &mut relative_buf {
+                buf.pop();
+            }
+            continue;
+        }
         context.record_file_list_entry(non_empty_path(relative_path.as_path()));
 
         let mut keep_name = true;
@@ -500,6 +518,21 @@ fn plan_directory_entries_with_prefetch<'a>(
         } else {
             PathBuf::from(Path::new(&file_name))
         };
+
+        // upstream: flist.c:1614-1638 send_file1() - a name that cannot be
+        // strictly transcoded under --iconv is dropped from the flist with a
+        // diagnostic and io_error |= IOERR_GENERAL. Detecting it during planning
+        // sets io_error before this directory's delete pass runs, so deletions
+        // are suppressed exactly as upstream's build-then-generate order does;
+        // the entry never enters the plan (no copy, no keep-name, no ndx).
+        if !name_is_convertible(file_name.as_os_str(), context.options().iconv()) {
+            emit_cannot_convert_filename(relative_path.as_os_str());
+            context.record_iconv_conversion_error();
+            if let Some(buf) = &mut relative_buf {
+                buf.pop();
+            }
+            continue;
+        }
         context.record_file_list_entry(non_empty_path(relative_path.as_path()));
 
         let mut keep_name = true;

--- a/crates/engine/src/local_copy/executor/iconv.rs
+++ b/crates/engine/src/local_copy/executor/iconv.rs
@@ -112,6 +112,45 @@ pub(crate) fn transcode_filename_component<'a>(
     }
 }
 
+/// Reports whether `name` can be strictly transcoded LOCAL -> REMOTE under
+/// the configured converter.
+///
+/// Returns `true` when no converter is configured, the converter is an
+/// identity mapping, or the round-trip succeeds without loss. Returns `false`
+/// only when the converter is active and the name contains bytes that cannot
+/// be represented in the remote charset - the case upstream rsync skips.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:1614-1638` `send_file1()` - `iconvbufs(ic_send, ..., ICB_INIT)`
+///   uses the strict (non-`ICB_INCLUDE_BAD`) mode; a `< 0` return skips the
+///   file rather than substituting replacement bytes.
+#[must_use]
+pub(crate) fn name_is_convertible(name: &OsStr, converter: Option<&FilenameConverter>) -> bool {
+    match converter {
+        Some(conv) if !conv.is_identity() => conv.local_to_remote(os_str_to_bytes(name)).is_ok(),
+        _ => true,
+    }
+}
+
+/// Emits the upstream `cannot convert filename` diagnostic to stderr.
+///
+/// The `who_am_i()` role for the sending half of a local copy is `sender`, so
+/// the message is unconditionally prefixed `[sender]`. Message formatting is
+/// shared with the flist sender/receiver via
+/// [`protocol::iconv::cannot_convert_filename_message`].
+///
+/// # Upstream Reference
+///
+/// - `flist.c:1631` `send_file1()` - `rprintf(FERROR_XFER, "[%s] cannot convert
+///   filename: %s (%s)\n", who_am_i(), f_name(file, fbuf), strerror(errno))`.
+pub(crate) fn emit_cannot_convert_filename(display: &OsStr) {
+    eprintln!(
+        "{}",
+        protocol::iconv::cannot_convert_filename_message("sender", os_str_to_bytes(display))
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,5 +210,26 @@ mod tests {
         let conv = FilenameConverter::new("UTF-8", "ISO-8859-1").expect("ctor");
         let out = transcode_filename_component(bad, Some(&conv));
         assert_eq!(out.as_bytes(), b"bad?name");
+    }
+
+    #[test]
+    fn convertible_without_converter_is_true() {
+        assert!(name_is_convertible(OsStr::new("caf\u{e9}.txt"), None));
+    }
+
+    #[cfg(all(unix, feature = "iconv"))]
+    #[test]
+    fn unconvertible_name_is_rejected_by_strict_check() {
+        use std::os::unix::ffi::OsStrExt;
+
+        // Byte 0xe9 alone is not valid UTF-8, so LOCAL=UTF-8 -> REMOTE=Latin-1
+        // strict conversion must fail: this is the entry upstream skips.
+        let bad = OsStr::from_bytes(b"caf\xe9.txt");
+        let conv = FilenameConverter::new("UTF-8", "ISO-8859-1").expect("ctor");
+        assert!(!name_is_convertible(bad, Some(&conv)));
+
+        // A clean name still round-trips.
+        let good = OsStr::from_bytes(b"caf\xc3\xa9.txt");
+        assert!(name_is_convertible(good, Some(&conv)));
     }
 }

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -34,7 +34,9 @@ pub(crate) use file::{
     files_checksum_match, maybe_preallocate_destination, partial_destination_path,
     temporary_destination_path,
 };
-pub(crate) use iconv::transcode_filename_component;
+pub(crate) use iconv::{
+    emit_cannot_convert_filename, name_is_convertible, transcode_filename_component,
+};
 pub(crate) use reference::{
     ReferenceDecision, ReferenceQuery, find_compare_dest_symlink, find_copy_dest_basis,
     find_copy_dest_symlink, find_reference_action,

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -225,6 +225,9 @@ pub(crate) fn copy_sources(
                 if let Some(error) = first_io_error {
                     return Err(error);
                 }
+                if context.iconv_conversion_error_occurred() {
+                    return Err(LocalCopyError::partial_transfer());
+                }
                 return Ok(());
             }
 
@@ -232,6 +235,13 @@ pub(crate) fn copy_sources(
 
             if let Some(error) = first_io_error {
                 return Err(error);
+            }
+            // upstream: flist.c:1631 send_file1() sets io_error |= IOERR_GENERAL
+            // when a filename cannot be transcoded under --iconv; main.c:1356
+            // then exits RERR_PARTIAL (23). The per-entry diagnostic was already
+            // printed at the skip site, so surface only the summary error here.
+            if context.iconv_conversion_error_occurred() {
+                return Err(LocalCopyError::partial_transfer());
             }
             Ok(())
         })()

--- a/crates/protocol/src/flist/read/name.rs
+++ b/crates/protocol/src/flist/read/name.rs
@@ -131,38 +131,54 @@ impl FileListReader {
     /// Applies iconv encoding conversion to a filename.
     ///
     /// When `--iconv` is used, filenames are converted from the remote encoding
-    /// to the local encoding. Unconvertible bytes are replaced rather than
-    /// causing the transfer to abort, matching upstream rsync's behaviour of
-    /// warning and continuing.
+    /// to the local encoding using the strict converter. A name that cannot be
+    /// represented in the local charset is reported unconditionally, records
+    /// `IOERR_GENERAL` (exit 23), and is kept with a lossy-degraded name rather
+    /// than dropped - the entry must remain so the receiver's ndx stays aligned
+    /// with the sender's.
     ///
     /// # Upstream Reference
     ///
-    /// `flist.c:738-754` `recv_file_entry()` runs the freshly-read filename
-    /// through `iconvbufs(ic_recv, ...)` before `clean_fname()`. On failure,
-    /// upstream sets `io_error |= IOERR_GENERAL`, emits an `FERROR_UTF8`
-    /// warning, and zeroes the output length (effectively skipping the
-    /// entry). We use lossy conversion instead, which replaces unconvertible
-    /// bytes with `?` and warns via `trace_conversion_warning`.
+    /// `flist.c:749-763` `recv_file_entry()` runs the freshly-read filename
+    /// through `iconvbufs(ic_recv, ..., ICB_INIT)` (strict). On failure upstream
+    /// sets `io_error |= IOERR_GENERAL`, prints `[%s] cannot convert filename:
+    /// %s (%s)` via `FERROR_UTF8`, and zeroes the output length. We surface the
+    /// same message and error but degrade the name lossily to preserve ndx
+    /// alignment.
     ///
     /// The prefix-compression buffer (`lastname` / `state.prev_name()`)
     /// intentionally retains the wire bytes so subsequent entries can share
     /// the prefix before any conversion is applied.
-    pub(super) fn apply_encoding_conversion(&self, name: Vec<u8>) -> io::Result<Vec<u8>> {
-        if let Some(ref converter) = self.iconv {
-            let outcome = converter.remote_to_local_lossy(&name);
-            if outcome.had_replacements {
-                // upstream: flist.c:746-749 - warn about unconvertible filename
-                crate::iconv::trace_conversion_warning(
-                    crate::iconv::IconvRole::Client,
-                    &String::from_utf8_lossy(&name),
-                    converter.remote_encoding_name(),
-                    converter.local_encoding_name(),
-                );
-            }
-            Ok(outcome.output.into_owned())
-        } else {
-            Ok(name)
+    pub(super) fn apply_encoding_conversion(&mut self, name: Vec<u8>) -> io::Result<Vec<u8>> {
+        if self.iconv.is_none() {
+            return Ok(name);
         }
+
+        let (result, failed) = {
+            // Safe: `self.iconv` was just checked to be `Some`.
+            let converter = self.iconv.as_ref().expect("iconv present");
+            match converter.remote_to_local(&name) {
+                Ok(converted) => (converted.into_owned(), false),
+                Err(_) => {
+                    // upstream: flist.c:757 - unconditional FERROR_UTF8 message.
+                    eprintln!(
+                        "{}",
+                        crate::iconv::cannot_convert_filename_message("receiver", &name)
+                    );
+                    (
+                        converter.remote_to_local_lossy(&name).output.into_owned(),
+                        true,
+                    )
+                }
+            }
+        };
+
+        if failed {
+            // upstream: flist.c:759 - io_error |= IOERR_GENERAL (rsync.h: 1).
+            self.io_error |= 1;
+        }
+
+        Ok(result)
     }
 
     /// Cleans and validates a filename received from the sender.

--- a/crates/protocol/src/iconv/mod.rs
+++ b/crates/protocol/src/iconv/mod.rs
@@ -29,6 +29,8 @@
 mod converter;
 mod error;
 mod pair;
+/// Diagnostics for filenames skipped because they cannot be transcoded.
+pub mod skip;
 /// `--debug=ICONV` producer emissions for charset setup.
 pub mod trace;
 
@@ -37,6 +39,7 @@ pub use converter::{
 };
 pub use error::{ConversionError, EncodingError};
 pub use pair::EncodingPair;
+pub use skip::{cannot_convert_filename_message, escape_filename};
 pub use trace::{
     IconvRole, trace_conversion_warning, trace_msg_checking_charset,
     trace_msg_checking_via_isprint, trace_peer_charset,

--- a/crates/protocol/src/iconv/skip.rs
+++ b/crates/protocol/src/iconv/skip.rs
@@ -1,0 +1,106 @@
+//! Diagnostics for filenames skipped because they cannot be transcoded.
+//!
+//! When `--iconv` is active and a filename (or symlink target) cannot be
+//! strictly converted to the peer charset, upstream rsync skips the entry,
+//! sets `io_error |= IOERR_GENERAL`, and prints a `cannot convert filename`
+//! diagnostic. This module renders that message identically across the local
+//! copy, the flist sender, and the flist receiver so all three paths emit the
+//! same bytes.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:1631` `send_file1()` - sender: `rprintf(FERROR_XFER, "[%s]
+//!   cannot convert filename: %s (%s)\n", who_am_i(), f_name(file, fbuf),
+//!   strerror(errno))`.
+//! - `flist.c:757` `recv_file_entry()` - receiver: same message via
+//!   `rprintf(FERROR_UTF8, ...)`.
+//! - `log.c:239` `filtered_fwrite()` - non-printable bytes render as `\#%03o`.
+
+/// Formats the upstream `cannot convert filename` diagnostic for `name_bytes`.
+///
+/// `role` is the `who_am_i()` token (`"sender"` or `"receiver"`). The name is
+/// escaped the way upstream renders non-printable bytes on the terminal, and
+/// the parenthetical is `strerror(EILSEQ)` - the errno `iconv(3)` sets when a
+/// byte sequence has no representation in the target charset.
+#[must_use]
+pub fn cannot_convert_filename_message(role: &str, name_bytes: &[u8]) -> String {
+    format!(
+        "[{}] cannot convert filename: {} ({})",
+        role,
+        escape_filename(name_bytes),
+        eilseq_strerror()
+    )
+}
+
+/// Escapes non-printable bytes in a filename for terminal output, matching
+/// upstream rsync's `filtered_fwrite()` octal escape (`log.c:239` `"\#%03o"`).
+///
+/// Printable ASCII (`0x20..=0x7e`) and horizontal tab pass through verbatim;
+/// every other byte is rendered as a three-digit octal escape.
+#[must_use]
+pub fn escape_filename(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len());
+    for &b in bytes {
+        if b == b'\t' || (0x20..=0x7e).contains(&b) {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("\\#{b:03o}"));
+        }
+    }
+    out
+}
+
+/// Returns the platform `strerror(EILSEQ)` text used in the parenthetical of
+/// the `cannot convert filename` diagnostic.
+///
+/// `iconv(3)` sets `errno` to `EILSEQ` when an input byte sequence has no
+/// representation in the target charset; upstream prints `strerror(errno)`.
+/// The errno value differs per platform, so it is resolved from the OS.
+#[must_use]
+pub fn eilseq_strerror() -> String {
+    #[cfg(target_os = "linux")]
+    const EILSEQ: i32 = 84;
+    #[cfg(target_os = "macos")]
+    const EILSEQ: i32 = 92;
+    #[cfg(windows)]
+    const EILSEQ: i32 = 42;
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    const EILSEQ: i32 = 84;
+
+    let err = std::io::Error::from_raw_os_error(EILSEQ);
+    let full = err.to_string();
+    full.strip_suffix(&format!(" (os error {EILSEQ})"))
+        .map(str::to_owned)
+        .unwrap_or(full)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_matches_upstream_octal_form() {
+        // Byte 0xe9 (0o351) renders as "\#351"; printable ASCII is verbatim.
+        assert_eq!(escape_filename(b"caf\xe9.txt"), "caf\\#351.txt");
+        assert_eq!(escape_filename(b"plain.txt"), "plain.txt");
+        // Control byte 0x0a escapes; tab passes through unescaped.
+        assert_eq!(escape_filename(b"a\nb\tc"), "a\\#012b\tc");
+    }
+
+    #[test]
+    fn strerror_is_non_empty_without_os_error_suffix() {
+        let s = eilseq_strerror();
+        assert!(!s.is_empty());
+        assert!(!s.contains("os error"), "{s}");
+    }
+
+    #[test]
+    fn message_shape_matches_upstream() {
+        let msg = cannot_convert_filename_message("sender", b"caf\xe9.txt");
+        assert!(
+            msg.starts_with("[sender] cannot convert filename: caf\\#351.txt ("),
+            "{msg}"
+        );
+        assert!(msg.ends_with(')'), "{msg}");
+    }
+}

--- a/crates/transfer/src/generator/file_list/iconv.rs
+++ b/crates/transfer/src/generator/file_list/iconv.rs
@@ -1,0 +1,76 @@
+//! Strict `--iconv` validation of built file-list entries.
+//!
+//! Upstream rsync transcodes every filename through `iconvbufs(ic_send, ...,
+//! ICB_INIT)` in `send_file1()`. `ICB_INIT` is the strict mode: a byte
+//! sequence that cannot be represented in the peer charset makes the call
+//! return `< 0`, whereupon upstream sets `io_error |= IOERR_GENERAL`, prints a
+//! `cannot convert filename` diagnostic, and `return NULL`s so the entry never
+//! enters the file list. Because the same flist backs both the wire and the
+//! data phase, the drop must happen at build time - before ndx assignment and
+//! INC_RECURSE segmentation - or sender/receiver ndx values would desync.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:1614-1638` `send_file1()` - strict `ic_send` conversion + skip.
+//! - `flist.c:757` `recv_file_entry()` - the receiver mirrors this.
+
+use protocol::flist::DualFileList;
+
+use super::super::GeneratorContext;
+use super::super::io_error_flags;
+
+impl GeneratorContext {
+    /// Drops file-list entries whose names cannot be strictly transcoded to
+    /// the remote charset under `--iconv`, emitting the upstream diagnostic and
+    /// recording `IOERR_GENERAL` (exit 23) for each.
+    ///
+    /// Runs after the filesystem walk populates `file_list`/`full_paths` and
+    /// before the sort, so dropped entries never receive an ndx. A directory
+    /// whose own name is unconvertible is dropped here too; its children carry
+    /// the same unconvertible bytes as a path prefix and are dropped alongside
+    /// it, keeping the surviving list self-consistent.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:1631` `send_file1()` - `rprintf(FERROR_XFER, "[%s] cannot
+    ///   convert filename: %s (%s)\n", ...)` then `return NULL`.
+    pub(super) fn drop_unconvertible_entries(&mut self) {
+        let Some(converter) = self.config.connection.iconv.clone() else {
+            return;
+        };
+        if converter.is_identity() {
+            return;
+        }
+
+        let entries = std::mem::take(&mut self.file_list).into_vec();
+        let paths = std::mem::take(&mut self.full_paths);
+        self.file_list = DualFileList::with_capacity(entries.len());
+        self.full_paths = Vec::with_capacity(entries.len());
+
+        let mut any_dropped = false;
+        for (entry, path) in entries.into_iter().zip(paths) {
+            let convertible = {
+                let name = entry.name_bytes();
+                let ok = converter.local_to_remote(&name).is_ok();
+                if !ok {
+                    // upstream: flist.c:1631 - unconditional FERROR_XFER message.
+                    eprintln!(
+                        "{}",
+                        protocol::iconv::cannot_convert_filename_message("sender", &name)
+                    );
+                }
+                ok
+            };
+            if convertible {
+                self.push_file_item(entry, path);
+            } else {
+                any_dropped = true;
+            }
+        }
+
+        if any_dropped {
+            // upstream: flist.c:1633 - io_error |= IOERR_GENERAL -> exit 23.
+            self.add_io_error(io_error_flags::IOERR_GENERAL);
+        }
+    }
+}

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -21,6 +21,7 @@
 mod batch_stat;
 mod entry;
 mod hardlinks;
+mod iconv;
 mod inc_recurse;
 mod walk;
 
@@ -94,6 +95,11 @@ impl GeneratorContext {
                 self.emit_implied_parents(&base, &path, &mut implied_ancestors)?;
             }
         }
+
+        // upstream: flist.c:1614-1638 send_file1() - drop entries whose names
+        // cannot be strictly transcoded under --iconv before ndx assignment and
+        // INC_RECURSE segmentation, so sender/receiver ndx values stay aligned.
+        self.drop_unconvertible_entries();
 
         // upstream: flist.c:f_name_cmp() - sort both arrays via indirect permutation.
         // --qsort uses unstable sort (flist.c:2991).

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -52,6 +52,14 @@ impl ReceiverContext {
             count += 1;
         }
 
+        // upstream: flist.c:757-759 recv_file_entry() - a filename that cannot
+        // be strictly transcoded under --iconv sets io_error |= IOERR_GENERAL on
+        // the receiver. Fold the reader's accumulated flag into the receiver's
+        // so the transfer exits 23, unless --ignore-errors suppresses it.
+        if !self.config.deletion.ignore_errors {
+            self.flist_io_error |= flist_reader.io_error();
+        }
+
         // upstream: flist.c:2726-2727 - recv_id_list() called when !inc_recurse
         let inc_recurse = self
             .compat_flags


### PR DESCRIPTION
## Problem

With `--iconv=SPEC`, a filename that cannot be represented in the peer charset was **silently lossy-converted** and the transfer exited 0. For example, `caf<0xe9>.txt` under `--iconv=utf-8,latin1` landed on the destination as `caf?.txt` with no error - silent data corruption.

Upstream rsync converts every name with `iconvbufs(..., ICB_INIT)` (strict mode). On failure it prints `[<role>] cannot convert filename: <name> (<err>)`, sets `io_error |= IOERR_GENERAL`, and skips the entry (`return NULL`), exiting 23. Only `--files-from` list reading uses the lenient `ICB_INCLUDE_BAD` path.

- `flist.c:1631` `send_file1()` - strict sender conversion + skip
- `flist.c:757` `recv_file_entry()` - strict receiver conversion
- `crates/protocol/src/iconv/converter.rs:206` - existing strict converter API used by the fix

## Fix

Match upstream across all three transfer paths, with the critical constraint that the skip happens at **build/enumeration time** (before ndx assignment / INC_RECURSE segmentation), never at serialize time - otherwise sender/receiver ndx values desync and the wire and data phases disagree.

- **Local copy:** reject unconvertible names during directory planning, before the per-directory delete pass runs, so `io_error` is set in time to suppress deletions exactly as upstream's build-then-generate order does. The entry never enters the plan (no copy, no keep-name).
- **Flist sender:** drop unconvertible entries at file-list build time, before ndx assignment and INC_RECURSE segmentation.
- **Flist receiver:** strict-convert incoming names; on failure emit the diagnostic and set `io_error`, keeping the entry (ndx must stay aligned) with a degraded name.

Each path emits the upstream diagnostic and drives exit code 23. A shared `iconv::skip` helper renders the message and octal escaping (`log.c:239`) identically everywhere. Also stops emitting the "IO error encountered -- skipping file deletion" notice when no deletions are queued, matching upstream.

## Validation (vs upstream rsync 3.4.3 on Linux/aarch64, byte-for-byte)

A tree mixing convertible and unconvertible names under `--iconv=utf-8,latin1`:

| | oc-rsync | upstream |
|---|---|---|
| message | `[sender] cannot convert filename: caf\#351.txt (Invalid or incomplete multibyte or wide character)` | identical |
| nested message | `[sender] cannot convert filename: sub/na\#357ve.txt (...)` | identical |
| exit code | 23 | 23 |
| destination | unconvertible names skipped; convertible names present | identical (`DEST IDENTICAL`) |

- No ndx desync: mixed tree completes without protocol error; destination matches upstream exactly.
- `--delete` + unconvertible name: deletions suppressed (extraneous file kept), matching upstream.
- Convertible names still round-trip; default (no `--iconv`) path unchanged (exit 0, identical dest).

`cargo fmt`, `cargo clippy --no-deps -D warnings`, and `cargo check` are clean on the touched crates (protocol, engine, transfer, core), which remain unsafe-free.