### PR TITLE
fix: silence make-room removals to match upstream DEL_MAKE_ROOM

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -36,7 +36,8 @@ use super::{
     LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary, NestedDirMerge, ReferenceDirectory,
     SparseWriteState, compute_backup_path, copy_entry_to_backup, delete_extraneous_entries,
     filter_program_local_error, follow_symlink_metadata, load_dir_merge_rules_recursive,
-    map_metadata_error, remove_source_entry_if_requested, resolve_dir_merge_path, should_skip_copy,
+    map_metadata_error, record_directory_subtree, remove_source_entry_if_requested,
+    resolve_dir_merge_path, should_skip_copy,
     symlink_target_is_safe, trace_make_backup_copy, trace_make_backup_rename,
     trace_make_backup_symlink, write_sparse_chunk,
 };

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -37,9 +37,8 @@ use super::{
     SparseWriteState, compute_backup_path, copy_entry_to_backup, delete_extraneous_entries,
     filter_program_local_error, follow_symlink_metadata, load_dir_merge_rules_recursive,
     map_metadata_error, record_directory_subtree, remove_source_entry_if_requested,
-    resolve_dir_merge_path, should_skip_copy,
-    symlink_target_is_safe, trace_make_backup_copy, trace_make_backup_rename,
-    trace_make_backup_symlink, write_sparse_chunk,
+    resolve_dir_merge_path, should_skip_copy, symlink_target_is_safe, trace_make_backup_copy,
+    trace_make_backup_rename, trace_make_backup_symlink, write_sparse_chunk,
 };
 use crate::delta::DeltaSignatureIndex;
 use crate::signature::SignatureBlock;

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -887,8 +887,18 @@ impl<'a> CopyContext<'a> {
         Ok(())
     }
 
-    /// Forcibly removes a destination entry (backing it up first if needed),
-    /// and records the deletion in the summary.
+    /// Forcibly removes a type-conflicting destination entry (backing it up
+    /// first if needed) to make room for an incoming item of a different type.
+    ///
+    /// upstream: generator.c:1240 recv_generator() clears the conflicting
+    /// destination with `delete_item(fname, mode, del_opts | DEL_FOR_FILE)`.
+    /// delete.c:178-194 `delete_item()` suppresses `log_delete()` and the
+    /// `stats.deleted_files` bump whenever `flags & DEL_MAKE_ROOM` is set, so
+    /// the make-room removal of the conflicting entry itself is silent and
+    /// uncounted (unlike a genuine delete-pass deletion). When that entry is a
+    /// directory, `delete_dir_contents()` (delete.c:83) recurses with
+    /// DEL_MAKE_ROOM stripped, so its contents are itemized (`*deleting`) and
+    /// counted like ordinary deletions while the directory node stays silent.
     pub(super) fn force_remove_destination(
         &mut self,
         destination: &Path,
@@ -898,22 +908,18 @@ impl<'a> CopyContext<'a> {
         let file_type = metadata.file_type();
 
         if self.mode.is_dry_run() {
-            self.summary_mut().record_deletion(file_type);
-            if let Some(path) = relative {
-                self.record(LocalCopyRecord::new(
-                    path.to_path_buf(),
-                    LocalCopyAction::EntryDeleted,
-                    0,
-                    None,
-                    Duration::default(),
-                    None,
-                ));
+            if file_type.is_dir() {
+                self.record_make_room_contents(destination, relative)?;
             }
             self.register_progress();
             return Ok(());
         }
 
         self.backup_existing_entry(destination, relative, file_type)?;
+
+        if file_type.is_dir() {
+            self.record_make_room_contents(destination, relative)?;
+        }
 
         let context = if file_type.is_dir() {
             "remove existing directory"
@@ -939,20 +945,29 @@ impl<'a> CopyContext<'a> {
             }
         }
 
-        self.summary_mut().record_deletion(file_type);
-        if let Some(path) = relative {
-            self.record(LocalCopyRecord::new(
-                path.to_path_buf(),
-                LocalCopyAction::EntryDeleted,
-                0,
-                None,
-                Duration::default(),
-                None,
-            ));
-        }
         self.register_progress();
 
         Ok(())
+    }
+
+    /// Itemizes and counts the contents of a conflicting directory that is
+    /// being cleared to make room for an incoming item, mirroring upstream's
+    /// `delete_dir_contents()` recursion (delete.c:83): the children are
+    /// reported like delete-pass deletions (DEL_MAKE_ROOM stripped) while the
+    /// directory node itself is removed silently by the caller.
+    fn record_make_room_contents(
+        &mut self,
+        destination: &Path,
+        relative: Option<&Path>,
+    ) -> Result<(), LocalCopyError> {
+        let mut subtree_path = destination.to_path_buf();
+        let mut subtree_relative = relative.map(Path::to_path_buf).unwrap_or_else(|| {
+            destination
+                .file_name()
+                .map(PathBuf::from)
+                .unwrap_or_default()
+        });
+        record_directory_subtree(self, &mut subtree_path, &mut subtree_relative)
     }
 
     /// Commits a single deferred update: moves the staged file to its final

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -439,7 +439,7 @@ fn apply_delete_side_effects(
 ///
 /// Uses `PathBuf::push`/`pop` on reusable buffers to avoid per-entry
 /// allocations from `Path::join` in the recursive traversal.
-fn record_directory_subtree(
+pub(crate) fn record_directory_subtree(
     context: &mut CopyContext,
     path_buf: &mut PathBuf,
     relative_buf: &mut PathBuf,

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -9,7 +9,9 @@ mod sources;
 mod special;
 mod util;
 
-pub(crate) use cleanup::{delete_extraneous_entries, remove_source_entry_if_requested};
+pub(crate) use cleanup::{
+    delete_extraneous_entries, record_directory_subtree, remove_source_entry_if_requested,
+};
 pub(crate) use directory::ChecksumCache;
 pub(crate) use directory::{
     capture_batch_file_entry, copy_directory_recursive, copy_directory_walk_one_level, is_device,

--- a/crates/engine/src/local_copy/tests/execute_directories.rs
+++ b/crates/engine/src/local_copy/tests/execute_directories.rs
@@ -271,7 +271,11 @@ fn execute_with_delete_before_removes_conflicting_entries() {
     assert_eq!(fs::read(&target).expect("read copied file"), b"fresh");
     assert!(target.is_file());
     assert_eq!(summary.files_copied(), 1);
-    assert!(summary.items_deleted() >= 1);
+    // upstream: generator.c:1240 clears the conflicting (empty) directory with
+    // DEL_FOR_FILE, which delete.c:179 delete_item() removes silently and
+    // without a stats.deleted_files bump. The directory has no contents to
+    // recurse over, so no deletions are counted for the make-room replacement.
+    assert_eq!(summary.items_deleted(), 0);
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_force.rs
+++ b/crates/engine/src/local_copy/tests/execute_force.rs
@@ -286,7 +286,7 @@ fn force_dry_run_does_not_modify_directory() {
 }
 
 #[test]
-fn force_dry_run_reports_deletion_for_replaced_directory() {
+fn force_dry_run_make_room_for_empty_directory_is_silent() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("item");
     fs::write(&source, b"replacement").expect("write source");
@@ -308,7 +308,15 @@ fn force_dry_run_reports_deletion_for_replaced_directory() {
         .expect("dry-run succeeds");
 
     let summary = report.summary();
-    assert_eq!(summary.items_deleted(), 1, "should report one deletion");
+    // upstream: generator.c:1240 clears the conflicting directory with
+    // DEL_FOR_FILE; delete.c:179 delete_item() removes the make-room target
+    // silently and uncounted. An empty directory has no contents to recurse
+    // over, so no deletion is itemized or counted.
+    assert_eq!(
+        summary.items_deleted(),
+        0,
+        "make-room removal of an empty directory is silent and uncounted"
+    );
     assert_eq!(summary.files_copied(), 1, "should report one file copy");
 }
 
@@ -546,7 +554,14 @@ fn force_replacement_counts_deletion() {
         .expect("forced replacement succeeds");
 
     let summary = report.summary();
-    assert!(summary.items_deleted() >= 1, "should count at least one deletion for the replaced directory");
+    // upstream: the make-room removal of the conflicting directory node is
+    // silent (DEL_FOR_FILE), but delete.c:83 delete_dir_contents() recurses
+    // with DEL_MAKE_ROOM stripped, so its non-empty contents are counted like
+    // ordinary deletions.
+    assert!(
+        summary.items_deleted() >= 1,
+        "should count the conflicting directory's contents as deletions"
+    );
     assert_eq!(summary.files_copied(), 1, "should count the file copy");
 }
 


### PR DESCRIPTION
## Problem

When oc-rsync clears a type-conflicting destination entry to make room for an incoming item (the `--force` / make-room path, e.g. a regular file arriving over a destination directory), it emitted a `*deleting <name>` itemize record and incremented `items_deleted` / the `--stats` "Number of deleted files". Upstream treats these removals as silent and uncounted, so oc over-reported the deleted-file count and printed a spurious `*deleting` row.

## Upstream reference

- `generator.c:1240` `recv_generator()` clears the conflicting destination with `delete_item(fname, mode, del_opts | DEL_FOR_FILE)`.
- `delete.c:178-194` `delete_item()` skips `log_delete()` and the `stats.deleted_files` bump whenever `flags & DEL_MAKE_ROOM` is set, so the make-room removal of the conflicting entry itself is silent and uncounted (unlike a genuine delete-pass deletion).
- `delete.c:83` `delete_dir_contents()` recurses with `DEL_MAKE_ROOM` stripped, so when the conflicting entry is a directory its **contents** are itemized (`*deleting`) and counted like ordinary deletions while the directory node itself stays silent.

## Change

`force_remove_destination` no longer records a `*deleting` itemize record or bumps the deleted-files counter for the make-room target. When the target is a directory it now itemizes and counts only that directory's contents (reusing the existing `record_directory_subtree` recursion) and removes the directory node silently. Genuine delete-pass (`--delete`) deletions are unchanged.

## Validation (vs upstream rsync 3.4.3)

Byte-for-byte parity confirmed for `-ai --stats`:

| Scenario | Upstream | oc-rsync (after) |
|----------|----------|------------------|
| Empty dir replaced by file (`--force`) | `>f+++++++++ item`, deleted files: 0 | identical |
| Non-empty dir replaced by file (`--force`) | `*deleting item/inner`, deleted files: 1 (reg: 1) | identical |
| Genuine extraneous `--delete` (control) | `*deleting extra`, deleted files: 1 (reg: 1) | identical |

- Updated `execute_with_delete_before_removes_conflicting_entries` and `force_dry_run_make_room_for_empty_directory_is_silent` to expect 0 deletions for the empty make-room replacement; `force_replacement_counts_deletion` keeps counting the conflicting directory's contents.
- Targeted engine tests (force / delete / deletion / conflict / replace / extraneous): 519 passed.
- `cargo fmt` and `cargo clippy -p engine --all-features -D warnings`: clean.