### PR TITLE
fix: reject strict-modes secrets with @ERROR and stop client EOF busy-loop

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -287,13 +287,25 @@ pub(crate) fn perform_daemon_handshake<R: std::io::Read, W: Write>(
     // @RSYNCD: EXIT. Other lines are MOTD output.
     loop {
         let mut line = String::new();
-        reader.read_line(&mut line).map_err(|e| {
+        let bytes = reader.read_line(&mut line).map_err(|e| {
             socket_error(
                 "read response from",
                 request.address.socket_addr_display(),
                 e,
             )
         })?;
+
+        // upstream: clientserver.c:359-361 - `read_line_old()` returns 0 (false)
+        // when the daemon closes the control socket without a proper terminator,
+        // and rsync fails with "didn't get server startup line". A 0-byte read is
+        // EOF: without this guard `trim()` yields an empty string that matches no
+        // branch below, so the loop would spin forever printing blank MOTD lines.
+        if bytes == 0 {
+            return Err(daemon_error(
+                "connection unexpectedly closed by daemon: didn't get server startup line",
+                CLIENT_SERVER_PROTOCOL_EXIT_CODE,
+            ));
+        }
 
         let trimmed = line.trim();
 

--- a/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
@@ -498,6 +498,53 @@ mod handle_at_error_tests {
         assert_eq!(err.exit_code(), CLIENT_SERVER_PROTOCOL_EXIT_CODE);
     }
 
+    /// Regression: an unexpected daemon disconnect during the module-response
+    /// phase must fail promptly, not busy-loop printing blank lines.
+    ///
+    /// A daemon that detects a fatal condition (e.g. a strict-modes secrets
+    /// violation) and drops the socket without a proper `@RSYNCD:`/`@ERROR`
+    /// line leaves the client's response reader at EOF. Before the fix, the
+    /// `read_line` loop ignored the 0-byte return, `trim()` produced an empty
+    /// string matching no branch, and the loop spun forever emitting empty
+    /// MOTD lines. The guard must convert EOF into a clean protocol error.
+    ///
+    /// upstream: clientserver.c:359-361 - `read_line_old()` returning false
+    /// yields "didn't get server startup line" and `return -1` (RERR_PROTOCOL).
+    #[test]
+    fn handshake_errors_on_daemon_eof_instead_of_looping() {
+        use std::io::{BufReader, Cursor};
+
+        let request = DaemonTransferRequest {
+            address: DaemonAddress::new("127.0.0.1".to_owned(), 873).unwrap(),
+            module: "mod".to_owned(),
+            path: String::new(),
+            username: None,
+        };
+
+        // Valid greeting, then EOF: the daemon accepted the greeting but closed
+        // the control socket before replying to the module request.
+        let mut reader = BufReader::new(Cursor::new(b"@RSYNCD: 32.0\n".to_vec()));
+        let mut writer: Vec<u8> = Vec::new();
+
+        let result = perform_daemon_handshake(
+            &mut reader,
+            &mut writer,
+            &request,
+            true,
+            &[],
+            None,
+            None,
+            None,
+        );
+
+        let err = result.expect_err("EOF mid-handshake must be an error, not a hang");
+        assert_eq!(
+            err.exit_code(),
+            CLIENT_SERVER_PROTOCOL_EXIT_CODE,
+            "daemon EOF must map to the client-server protocol exit code"
+        );
+    }
+
     #[test]
     fn ghsa_rjfm_3w2m_jf4f_payload_renders_intact() {
         // The exact wire string the daemon emits for the GHSA-rjfm-3w2m-jf4f

--- a/crates/daemon/src/daemon/sections/module_access/authentication.rs
+++ b/crates/daemon/src/daemon/sections/module_access/authentication.rs
@@ -164,11 +164,23 @@ fn verify_secret_response(
         None => return Ok(false),
     };
 
-    if module.strict_modes {
-        check_secrets_file_permissions(secrets_path)?;
+    // upstream: authenticate.c:119-131 check_secret() - a strict-modes
+    // violation (other-accessible secrets, or non-root ownership when
+    // running as root) sets `ok = 0` and returns the "ignoring secrets file"
+    // error string; an unreadable secrets file returns "no secrets file".
+    // In every case auth_server() reports an auth failure and the client
+    // still receives `@ERROR: auth failed on module X`. check_secret() never
+    // aborts the connection. Treat these as a denial (Ok(false)) rather than
+    // propagating an io::Error, so the daemon emits the @ERROR line via
+    // send_auth_failed() instead of dropping the socket mid-handshake.
+    if module.strict_modes && check_secrets_file_permissions(secrets_path).is_err() {
+        return Ok(false);
     }
 
-    let contents = fs::read_to_string(secrets_path)?;
+    let contents = match fs::read_to_string(secrets_path) {
+        Ok(contents) => contents,
+        Err(_) => return Ok(false),
+    };
 
     for raw_line in contents.lines() {
         let line = raw_line.trim_end_matches('\r');

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -775,9 +775,16 @@ mod module_access_tests {
             ..Default::default()
         };
 
-        let err = verify_secret_response(&module, "alice", "challenge", "response", None)
-            .expect_err("strict modes should reject other-accessible secrets");
-        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        // upstream: authenticate.c:119-131 check_secret() - a strict-modes
+        // violation is an auth denial, not a fatal error: verify returns
+        // Ok(false) so the daemon emits `@ERROR: auth failed on module X`
+        // rather than dropping the socket mid-handshake.
+        let result = verify_secret_response(&module, "alice", "challenge", "response", None)
+            .expect("strict-modes violation must be a denial, not an io error");
+        assert!(
+            !result,
+            "other-accessible secrets under strict modes must deny auth"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Problem

An rsync daemon module configured with `auth users` + a `secrets file` and the default `strict modes = yes` must reject a world-/other-accessible secrets file. Upstream `check_secret()` (authenticate.c:100, the strict-modes gate at authenticate.c:119-131) treats such a violation as an auth failure: it returns an error string, `auth_server()` returns `NULL`, and the caller emits `@ERROR: auth failed on module %s\n` (clientserver.c:762) before closing the connection.

Two defects caused a strict-modes rejection to hang the client for the full timeout (300s) while flooding stdout with tens of millions of blank lines:

1. **Daemon side.** The secrets-permission check ran during module authentication (`verify_secret_response`), but a failure was propagated as an `io::Error` via `?`. That error unwound out of the handshake worker, which simply dropped the socket without sending the protocol `@ERROR` line the client blocks on. Unlike upstream, no rejection was ever written.

2. **Client side.** The `@RSYNCD` response reader ignored `read_line`'s `0`-byte EOF return. On an unexpected daemon disconnect the empty line matched no branch, fell through to the MOTD `println!`, and the loop spun forever printing blank lines until timeout.

## Fix

- `verify_secret_response` now treats a strict-modes permission failure (and an unreadable secrets file) as an auth denial, returning `Ok(false)` so the existing `send_auth_failed()` path emits `@ERROR: auth failed on module X` and closes cleanly - matching upstream `check_secret()`/`auth_server()`, which never abort the connection over a secrets-file problem.
- The client response loop converts a `0`-byte read into a clean client-server protocol error (exit code 5), mirroring upstream clientserver.c:359-361 (`read_line_old()` returning false -> "didn't get server startup line", `return -1`).

## Validation

Reproduced and fixed on Linux (aarch64) against upstream rsync 3.4.3:

- Before (oc daemon + oc client): client `rc=124` (hang), ~27.9M blank lines flooding stdout, no `@ERROR`.
- After: `rc=5`, no hang, daemon sends `@ERROR: auth failed on module auth`, zero blank-line output.
- `daemon-auth` upstream-testsuite passes with oc as the primary binary (oc client vs upstream daemon) and with oc as the daemon (upstream client vs oc daemon). Valid auth and wrong-password rejection are unaffected.
- Added regression tests: client handshake errors on daemon EOF instead of looping; strict-modes violation is an auth denial, not a fatal error.
- fmt, clippy (`-D warnings`), and check clean for the touched crates; daemon/core stay unsafe-free.