### PR TITLE
fix(engine): make hardlink data-holder the last name-sorted member

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -395,6 +395,131 @@ pub(crate) fn plan_directory_entries<'a>(
     })
 }
 
+/// Reorders each hard-link cohort so the *last* name-sorted member is the
+/// transferred data-holder and the earlier members follow it as aliases.
+///
+/// upstream: `hlink.c:match_gnums()` sorts a cohort by group number then by
+/// name-sorted index and links the members into a list "from last to first",
+/// tagging the highest-index (last name-sorted) member `FLAG_HLINK_LAST`.
+/// `generator.c:1803-1806` then defers every non-last member whose destination
+/// is absent (`statret != 0 && F_HLINK_NOT_LAST`) and only transfers the last
+/// member; `finish_hard_link()` (`hlink.c:474-521`) walks the `F_HL_PREV` chain
+/// (last -> ... -> first) creating the aliases, so the itemize stream emits the
+/// holder first (`>f`) followed by the remaining members in descending name
+/// order, each pointing at the holder (`hf ... => <holder>`).
+///
+/// This reorder reproduces that ordering for the local-copy executor, whose
+/// per-inode [`HardLinkTracker`](crate::local_copy::HardLinkTracker) otherwise
+/// makes the first-processed (first name-sorted) member the data-holder.
+///
+/// The deferral is gated on the destination being absent, mirroring upstream's
+/// `statret != 0` guard: on a no-change rerun every member's destination exists,
+/// so upstream processes them in name order with the first member itemized `.f`
+/// and the rest blank `hf`. Only cohorts with two or more members whose
+/// destinations are missing are reordered.
+///
+/// The reorder is skipped entirely when a `--link-dest`/`--copy-dest`/
+/// `--compare-dest` basis is configured. Upstream's LAST-member deferral lives
+/// at `generator.c:1803`, *after* the alt-dest handling (`generator.c:995-1052`
+/// try_dests_reg); a cohort member satisfied from a basis is placed in name
+/// order and never reaches the deferral, so the FIRST name-sorted member stays
+/// the holder (e.g. `hf f1` / `hf f2 => f1`). Reordering those would swap the
+/// holder name while leaving the alt-dest followers correctly blank, so it is
+/// suppressed to preserve upstream fidelity.
+#[cfg(unix)]
+pub(crate) fn reorder_hardlink_group_holders(
+    hard_links_enabled: bool,
+    has_reference_directories: bool,
+    destination: &Path,
+    planned: &mut Vec<PlannedEntry<'_>>,
+) {
+    use std::os::unix::fs::MetadataExt;
+
+    use rustc_hash::FxHashMap;
+
+    if !hard_links_enabled || has_reference_directories {
+        return;
+    }
+
+    // Group regular-file copies with more than one link by (device, inode),
+    // preserving the name-sorted index order the planner already produced.
+    let mut groups: FxHashMap<(u64, u64), Vec<usize>> = FxHashMap::default();
+    for (idx, entry) in planned.iter().enumerate() {
+        if !matches!(entry.action, EntryAction::CopyFile) {
+            continue;
+        }
+        let meta = entry.metadata();
+        if meta.file_type().is_file() && meta.nlink() > 1 {
+            groups
+                .entry((meta.dev(), meta.ino()))
+                .or_default()
+                .push(idx);
+        }
+    }
+
+    // For each cohort, keep only the members whose destination is missing
+    // (upstream's `statret != 0` deferral guard). The last such member is the
+    // data-holder; the earlier ones are deferred to immediately after it.
+    let mut holder_followers: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
+    let mut deferred: FxHashMap<usize, ()> = FxHashMap::default();
+    for indices in groups.values() {
+        let fresh: Vec<usize> = indices
+            .iter()
+            .copied()
+            .filter(|&i| {
+                fs::symlink_metadata(destination.join(&planned[i].entry.file_name)).is_err()
+            })
+            .collect();
+        if fresh.len() < 2 {
+            continue;
+        }
+        let (holder, followers) = fresh.split_last().expect("fresh has >= 2 members");
+        for &follower in followers {
+            deferred.insert(follower, ());
+        }
+        holder_followers.insert(*holder, followers.to_vec());
+    }
+
+    if deferred.is_empty() {
+        return;
+    }
+
+    // Rebuild the plan: drop each deferred member from its natural slot and, when
+    // the holder is reached, emit it followed by its deferred members in
+    // descending name order (the `F_HL_PREV` walk order).
+    let mut slots: Vec<Option<PlannedEntry<'_>>> = planned.drain(..).map(Some).collect();
+    let mut reordered = Vec::with_capacity(slots.len());
+    for idx in 0..slots.len() {
+        if deferred.contains_key(&idx) {
+            continue;
+        }
+        if let Some(entry) = slots[idx].take() {
+            reordered.push(entry);
+        }
+        if let Some(followers) = holder_followers.get(&idx) {
+            for &follower in followers.iter().rev() {
+                if let Some(entry) = slots[follower].take() {
+                    reordered.push(entry);
+                }
+            }
+        }
+    }
+
+    *planned = reordered;
+}
+
+/// No-op on platforms without inode metadata: source-side hard-link cohorts are
+/// not detected there (see [`HardLinkTracker`](crate::local_copy::HardLinkTracker)),
+/// so there is no holder to reorder.
+#[cfg(not(unix))]
+pub(crate) fn reorder_hardlink_group_holders(
+    _hard_links_enabled: bool,
+    _has_reference_directories: bool,
+    _destination: &Path,
+    _planned: &mut Vec<PlannedEntry<'_>>,
+) {
+}
+
 /// Applies pre-transfer deletions when `--delete-before` is active.
 // upstream: generator.c:do_delete_pass() - pre-transfer deletion
 pub(crate) fn apply_pre_transfer_deletions(

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -34,7 +34,9 @@ use destination::{check_destination_state, record_skipped_missing_destination};
 use dir_metadata::{apply_final_directory_metadata, record_directory_completion};
 use entry::process_planned_entry;
 
-use super::planner::{apply_pre_transfer_deletions, plan_directory_entries};
+use super::planner::{
+    apply_pre_transfer_deletions, plan_directory_entries, reorder_hardlink_group_holders,
+};
 use super::support::read_directory_entries_sorted_reuse;
 
 /// Maximum directory nesting depth the recursive executor descends before
@@ -466,7 +468,17 @@ fn copy_directory_recursive_inner(
         ensure_directory(context)?;
     }
 
-    let plan = plan_directory_entries(context, &entries, relative, root_device)?;
+    let mut plan = plan_directory_entries(context, &entries, relative, root_device)?;
+    // upstream: hlink.c:match_gnums / generator.c:1803-1806 - the last name-sorted
+    // member of a hard-link cohort is the transferred data-holder; earlier members
+    // follow it as `hf ... => <holder>` aliases. Reorder the plan so the executor's
+    // per-inode tracker records the holder first and every alias points at it.
+    reorder_hardlink_group_holders(
+        context.options().hard_links_enabled(),
+        !context.reference_directories().is_empty(),
+        destination,
+        &mut plan.planned_entries,
+    );
     apply_pre_transfer_deletions(context, destination, relative, &plan)?;
     // upstream: generator.c:1532-1537 - a non-INC_RECURSE `--delete-during`
     // sweep runs while the generator itemizes the directory entry, before it

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -497,7 +497,13 @@ pub(super) fn process_links(
         // status alongside the freshly-linked alias.
         info_log!(Name, 2, "{} is uptodate", record_path.display());
 
-        context.record_hard_link(metadata, destination);
+        // upstream: hlink.c:474-521 finish_hard_link() - every alias in a cohort
+        // is linked against the group's data-holder (`our_name` stays fixed for
+        // the whole `F_HL_PREV` walk), so all aliases itemize `=> <holder>` (a
+        // star), never chaining to the most recently created alias. The holder is
+        // already recorded in the tracker (it was transferred first), so a
+        // follower must NOT overwrite that mapping with its own path; doing so
+        // would point later followers at this alias instead of the holder.
         context.summary_mut().record_hard_link();
         // upstream: hlink.c:237 + log.c:643-654 - thread the leader's
         // relative path through the snapshot's `symlink_target` slot so the

--- a/crates/engine/src/local_copy/tests/itemize_changes.rs
+++ b/crates/engine/src/local_copy/tests/itemize_changes.rs
@@ -502,6 +502,114 @@ fn itemize_new_hard_link_follower_marked_created() {
     );
 }
 
+// upstream: hlink.c:match_gnums / generator.c:1803-1806 / hlink.c:474-521
+// finish_hard_link() - the LAST name-sorted member of a hard-link cohort is the
+// transferred data-holder; every earlier member is deferred and then linked to
+// the holder, so the itemize stream is `>f <last>` followed by the remaining
+// members in descending name order, each pointing at the holder
+// (`hf ... => <last>`). Regression guard: oc previously made the first-processed
+// (first name-sorted) member the data-holder and chained aliases to the most
+// recent one (`c => b`, `b => a`) instead of the star `b => c`, `a => c`.
+#[cfg(unix)]
+#[test]
+fn itemize_hard_link_data_holder_is_last_name_sorted_member() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    let dest_dir = temp.path().join("dest");
+
+    fs::create_dir(&source_dir).expect("create source dir");
+    fs::create_dir(&dest_dir).expect("create dest dir");
+
+    // Three-member cohort {a, b, c} sharing one inode, created into an empty
+    // destination.
+    let a = source_dir.join("a");
+    let b = source_dir.join("b");
+    let c = source_dir.join("c");
+    fs::write(&a, b"shared content").expect("write a");
+    fs::hard_link(&a, &b).expect("hard link b -> a");
+    fs::hard_link(&a, &c).expect("hard link c -> a");
+
+    // A trailing slash on the source keeps the records at bare `a`/`b`/`c`
+    // instead of a `source/`-prefixed relative path.
+    let mut source_operand = source_dir.into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest_dir.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .hard_links(true)
+        .collect_events(true);
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let records = report.records();
+
+    let base = |r: &LocalCopyRecord| -> String {
+        r.relative_path()
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("utf8 basename")
+            .to_string()
+    };
+
+    // The data-holder is the last name-sorted member `c`, itemized as a new
+    // data copy (`>f+++++++++`).
+    let holder = records
+        .iter()
+        .find(|r| r.action() == &LocalCopyAction::DataCopied)
+        .expect("data-holder record");
+    assert_eq!(
+        base(holder),
+        "c",
+        "data-holder must be the last name-sorted member"
+    );
+    assert!(holder.was_created(), "holder must itemize as created");
+
+    // The remaining members `b` and `a` are followers, both pointing at the
+    // holder `c` (a star, not a chain), and each itemized `hf+++++++++`.
+    let followers: Vec<&_> = records
+        .iter()
+        .filter(|r| r.action() == &LocalCopyAction::HardLink)
+        .collect();
+    assert_eq!(followers.len(), 2, "two hard-link followers expected");
+    for follower in &followers {
+        assert!(
+            matches!(base(follower).as_str(), "a" | "b"),
+            "unexpected follower name: {:?}",
+            follower.relative_path()
+        );
+        assert!(
+            follower.was_created(),
+            "new hard-link follower must itemize hf+++++++++"
+        );
+        let leader = follower
+            .metadata()
+            .and_then(|m| m.symlink_target())
+            .expect("follower carries a => holder trailer");
+        assert_eq!(
+            leader.file_name().and_then(|n| n.to_str()),
+            Some("c"),
+            "every follower must point at the data-holder `c`, not a chained alias"
+        );
+    }
+
+    // Emission order mirrors upstream: holder first, then followers in
+    // descending name order (`c`, `b`, `a`).
+    let order: Vec<String> = records
+        .iter()
+        .filter(|r| {
+            matches!(
+                r.action(),
+                LocalCopyAction::DataCopied | LocalCopyAction::HardLink
+            )
+        })
+        .map(base)
+        .collect();
+    assert_eq!(order, ["c", "b", "a"], "holder-then-descending order");
+}
+
 // upstream: hlink.c:385-414 hard_link_check() + generator.c:995-1052
 // try_dests_reg() - when a hard-link follower's destination is absent but its
 // name matches a --copy-dest basis (quick_check_ok), statret is bumped from < 0


### PR DESCRIPTION
## Problem

For a local `-aH` copy of a hardlink cohort into a new destination, the itemize
leader name was mirror-swapped versus upstream rsync. For a group `{a, b}` both
new, upstream itemizes the last name-sorted member as the transferred data-holder
and points earlier members at it:

```
upstream:  >f+++++++++ b     then  hf+++++++++ a => b
oc (before): >f+++++++++ a   then  hf+++++++++ b => a
```

For three members the divergence also chained the aliases instead of pointing
them all at the holder:

```
upstream:    >f+++++++++ c / hf+++++++++ b => c / hf+++++++++ a => c   (star)
oc (before): >f+++++++++ a / hf+++++++++ b => a / hf+++++++++ c => b   (chain)
```

Trees converge in every case; only the itemized data-holder name and the
`=> leader` targets differed.

## Upstream rule

`hlink.c:match_gnums()` sorts each cohort by group number then name-sorted index
and links the members into a list "from last to first", tagging the last
name-sorted member `FLAG_HLINK_LAST`. `generator.c:1803-1806` then defers every
non-last member whose destination is absent (`statret != 0 && F_HLINK_NOT_LAST`)
and transfers only the last member; `finish_hard_link()` (`hlink.c:474-521`)
walks the `F_HL_PREV` chain creating the aliases with a fixed `our_name`, so the
stream is `>f <last>` followed by the remaining members in descending name order,
each pointing at the holder.

## Fix

- Reorder each cohort in the directory plan so the last name-sorted member is the
  transferred data-holder and earlier members follow it in descending name order.
  The deferral is gated on the destination being absent (upstream's `statret != 0`
  guard), so a no-change rerun keeps name order with the first member itemized
  `.f`; it is skipped when a `--link-dest`/`--copy-dest`/`--compare-dest` basis is
  configured, because a basis-satisfied member is placed in name order and never
  reaches the deferral (upstream keeps the first member as holder there).
- Stop a follower from overwriting the per-inode tracker's holder mapping, so
  every alias itemizes `=> <holder>` (a star) rather than chaining to the
  previous alias.

The group-ordering decision lives once in the plan layer; the executor just
transfers the designated holder.

## Validation

Byte-for-byte against upstream rsync on Linux:

- 2-member `{a,b}` new -> `>f+++++++++ b` / `hf+++++++++ a => b`.
- 3-member `{a,b,c}` new -> `>f+++++++++ c` / `hf+++++++++ b => c` / `hf+++++++++ a => c`.
- No-change rerun -> `.f          a` / `hf          b` / `hf          c`.
- `--link-dest` / `--copy-dest` cohort holder stays the first member with blank
  followers (`hf          f2 => f1`), matching upstream.
- Destination inodes shared; trees identical.

The upstream `itemize`, `hardlinks`, and `hardlinks-deep` testsuites pass with
this binary as the primary rsync. Added an engine regression test asserting the
last name-sorted member is the data-holder and every follower points at it.
`cargo fmt`, `cargo clippy -p engine -D warnings`, and the targeted engine
hardlink/link-dest/itemize suite (193 tests) are clean.