### PR TITLE
feat(transfer): upstream --partial temp naming + on-interrupt finalize

### DIFF
--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -287,8 +287,15 @@ where
         return server::run_daemon_mode(daemon_args, stdout, stderr);
     }
 
+    // Install signal handlers for the client transfer path so an interrupt
+    // (SIGINT/SIGTERM/SIGHUP) finalises any in-progress --partial file and
+    // exits with the rsync signal code instead of terminating abruptly.
+    // upstream: main.c installs sig handlers; cleanup.c:exit_cleanup finalises
+    // the partial and exits with RERR_SIGNAL.
+    install_client_signal_handling();
+
     let mut stderr_sink = MessageSink::with_brand(stderr, brand);
-    match parse_args(args) {
+    let exit_code = match parse_args(args) {
         Ok(parsed) => {
             let outbuf_mode = match parsed.outbuf.as_ref() {
                 Some(value) => match parse_outbuf_mode(value.as_os_str()) {
@@ -345,7 +352,50 @@ where
             }
             1
         }
+    };
+
+    // upstream: cleanup.c:exit_cleanup exits with RERR_SIGNAL after finalising
+    // partials when an interrupt signal was received. Override whatever the
+    // interrupted transfer returned with the signal's exit code. Restricted to
+    // SIGINT/SIGTERM/SIGHUP so a broken output pipe (SIGPIPE) does not rewrite
+    // an otherwise-successful exit code.
+    match core::signal::shutdown_reason() {
+        Some(
+            reason @ (core::signal::ShutdownReason::Interrupted
+            | core::signal::ShutdownReason::Terminated
+            | core::signal::ShutdownReason::HangUp),
+        ) => i32::from(reason.exit_code()),
+        _ => exit_code,
     }
+}
+
+/// Installs client-side signal handlers and a watcher that, on a second
+/// (abort) interrupt, finalises in-progress `--partial` temp files and exits
+/// with the rsync signal code. A single interrupt is handled gracefully by the
+/// copy loop, which stops mid-file and lets each transfer's guard finalise its
+/// partial during normal unwinding.
+fn install_client_signal_handling() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static INSTALLED: AtomicBool = AtomicBool::new(false);
+    if INSTALLED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    // A failure here is non-fatal: the transfer still runs, just without
+    // graceful partial finalisation on signal.
+    let _ = core::signal::install_signal_handlers();
+    std::thread::spawn(|| {
+        loop {
+            if core::signal::is_abort_requested() {
+                engine::CleanupManager::global().finalize_partials();
+                let code = core::signal::shutdown_reason()
+                    .map_or(i32::from(core::exit_code::ExitCode::Signal), |r| {
+                        i32::from(r.exit_code())
+                    });
+                std::process::exit(code);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    });
 }
 
 /// Converts a numeric exit code into an [`std::process::ExitCode`].

--- a/crates/core/src/signal/unix.rs
+++ b/crates/core/src/signal/unix.rs
@@ -131,6 +131,10 @@ static SIGNAL_COUNT: AtomicBool = AtomicBool::new(false);
 /// First signal: Sets graceful shutdown flag.
 /// Second signal: Sets abort flag for immediate termination.
 extern "C" fn handle_sigint(_signum: libc::c_int) {
+    // Also flip the low-level flag polled by the engine copy loop so an
+    // in-progress single-file transfer stops promptly and finalises its
+    // partial file in normal (non-signal) context.
+    fast_io::signal::mark_shutdown();
     let already_signaled = SIGNAL_COUNT.swap(true, Ordering::SeqCst);
 
     if already_signaled {
@@ -145,6 +149,7 @@ extern "C" fn handle_sigint(_signum: libc::c_int) {
 /// First signal: Sets graceful shutdown flag.
 /// Second signal: Sets abort flag for immediate termination.
 extern "C" fn handle_sigterm(_signum: libc::c_int) {
+    fast_io::signal::mark_shutdown();
     let already_signaled = SIGNAL_COUNT.swap(true, Ordering::SeqCst);
 
     if already_signaled {
@@ -159,6 +164,7 @@ extern "C" fn handle_sigterm(_signum: libc::c_int) {
 /// First signal: Sets graceful shutdown flag.
 /// Second signal: Sets abort flag for immediate termination.
 extern "C" fn handle_sighup(_signum: libc::c_int) {
+    fast_io::signal::mark_shutdown();
     let already_signaled = SIGNAL_COUNT.swap(true, Ordering::SeqCst);
 
     if already_signaled {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -249,6 +249,11 @@ pub use util::poison::{lock_or_recover, read_or_recover, write_or_recover};
 /// before writing and unregister them after a successful commit/rename.
 pub use util::cleanup::CleanupManager;
 
+/// Moves an interrupted `--partial` temp file onto its partial destination (or
+/// unlinks it when no partial is kept). Shared by the transfer guard and the
+/// signal-driven abort path so both finalise identically.
+pub use util::cleanup::finalize_partial;
+
 /// Async I/O operations (available with `async` feature).
 #[cfg(feature = "async")]
 pub use async_io::{AsyncBatchCopier, AsyncFileCopier, AsyncIoError, CopyProgress, CopyResult};

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -76,6 +76,7 @@ impl<'a> CopyContext<'a> {
         let mut bytes_since_timeout_check: usize = 0;
 
         loop {
+            self.check_shutdown(destination)?;
             if bytes_since_timeout_check >= TIMEOUT_CHECK_INTERVAL {
                 self.enforce_timeout()?;
                 bytes_since_timeout_check = 0;

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -1,4 +1,25 @@
 impl<'a> CopyContext<'a> {
+    /// Returns an `Interrupted` error once a shutdown signal has been received.
+    ///
+    /// Polled inside the per-chunk copy loops so a large single-file transfer
+    /// stops promptly mid-file. Unwinding then runs the destination guard's
+    /// finalisation (moving the temp onto its `--partial`/`--partial-dir`
+    /// destination) in normal, non-signal context. upstream: receiver.c's
+    /// per-block loop checks for a pending signal via `io_flush`/`check_timeout`.
+    fn check_shutdown(&self, path: &Path) -> Result<(), LocalCopyError> {
+        if fast_io::signal::shutdown_requested() {
+            return Err(LocalCopyError::io(
+                "copy file",
+                path,
+                io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "transfer interrupted by signal",
+                ),
+            ));
+        }
+        Ok(())
+    }
+
     fn start_compressor(
         &self,
         compress: bool,
@@ -573,6 +594,7 @@ impl<'a> CopyContext<'a> {
             if total_bytes >= expected_remaining {
                 break;
             }
+            self.check_shutdown(destination)?;
             if bytes_since_timeout_check >= TIMEOUT_CHECK_INTERVAL {
                 self.enforce_timeout()?;
                 bytes_since_timeout_check = 0;
@@ -680,6 +702,7 @@ impl<'a> CopyContext<'a> {
             if total_bytes >= expected_remaining {
                 break;
             }
+            self.check_shutdown(destination)?;
             if bytes_since_timeout_check >= TIMEOUT_CHECK_INTERVAL {
                 self.enforce_timeout()?;
                 bytes_since_timeout_check = 0;

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -585,7 +585,10 @@ pub(in crate::local_copy) fn execute_transfer(
                 if let Some(guard) = guard.take() {
                     guard.discard();
                 }
-                if existing_metadata.is_none() {
+                // In --partial/--partial-dir mode discard() finalised the temp
+                // onto its partial destination; removing it here would defeat
+                // the whole point of keeping the partial.
+                if existing_metadata.is_none() && !partial_enabled {
                     remove_incomplete_destination(destination);
                 }
                 return Err(timeout_error);
@@ -610,7 +613,7 @@ pub(in crate::local_copy) fn execute_transfer(
             if let Some(guard) = guard.take() {
                 guard.discard();
             }
-            if existing_metadata.is_none() {
+            if existing_metadata.is_none() && !partial_enabled {
                 remove_incomplete_destination(destination);
             }
             return Err(error);

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -14,9 +14,66 @@ use std::sync::atomic::Ordering as AtomicOrdering;
 use crate::local_copy::LocalCopyError;
 
 use super::super::super::NEXT_TEMP_FILE_ID;
-use super::paths::{
-    partial_destination_path, partial_directory_destination_path, temporary_destination_path,
-};
+use super::paths::{partial_dir_fname, temp_name_with_suffix, temporary_destination_path};
+use crate::CleanupManager;
+
+/// Where an interrupted `--partial` temp file is finalised, and how the temp is
+/// cleaned up on failure. Mirrors upstream's `keep_partial`/`partial_dir`
+/// handling in `receiver.c`/`cleanup.c`.
+#[derive(Debug, Clone)]
+enum PartialKind {
+    /// Non-partial transfer: unlink the temp file on failure.
+    Discard,
+    /// `--partial` (no dir): on failure the temp is moved onto the real
+    /// destination, and its modtime is tweaked to epoch 0 so a later `--update`
+    /// will not skip the unfinished file. upstream: `cleanup.c` `tweak_modtime`.
+    Keep,
+    /// `--partial-dir=DIR`: on failure the temp is moved onto the partial-dir
+    /// entry `file`; on success that entry is removed and, for a relative dir,
+    /// the now-empty `remove_dir` is rmdir'd. upstream: `handle_partial_dir()`.
+    Dir {
+        file: PathBuf,
+        remove_dir: Option<PathBuf>,
+    },
+}
+
+impl PartialKind {
+    /// The path an interrupted temp is finalised onto, or `None` to unlink it.
+    fn partial_dest<'a>(&'a self, final_path: &'a Path) -> Option<&'a Path> {
+        match self {
+            Self::Discard => None,
+            Self::Keep => Some(final_path),
+            Self::Dir { file, .. } => Some(file),
+        }
+    }
+
+    /// Whether the finalised partial's modtime should be reset to epoch 0.
+    const fn tweak_mtime(&self) -> bool {
+        matches!(self, Self::Keep)
+    }
+}
+
+/// Generates a six-character mkstemp-style suffix from process-unique inputs.
+///
+/// upstream fills the `.XXXXXX` template via `mkstemp`; we retry `create_new`
+/// with fresh suffixes on the rare collision, so the suffix only needs to vary.
+fn temp_suffix() -> String {
+    const ALPHABET: &[u8; 62] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let counter = NEXT_TEMP_FILE_ID.fetch_add(1, AtomicOrdering::Relaxed) as u64;
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos() as u64);
+    let mut state =
+        (u64::from(std::process::id()) ^ nanos).wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ counter;
+    let mut suffix = String::with_capacity(6);
+    for _ in 0..6 {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        suffix.push(ALPHABET[(state >> 33) as usize % ALPHABET.len()] as char);
+    }
+    suffix
+}
 
 /// Removes an existing destination file.
 ///
@@ -59,7 +116,7 @@ enum GuardStrategy {
     /// Traditional named temp file - commit via rename.
     NamedTempFile {
         temp_path: PathBuf,
-        preserve_on_error: bool,
+        partial: PartialKind,
     },
     /// Linux `O_TMPFILE` anonymous file - commit via `linkat(2)`.
     ///
@@ -129,66 +186,72 @@ impl DestinationWriteGuard {
         partial_dir: Option<&Path>,
         temp_dir: Option<&Path>,
     ) -> Result<(Self, fs::File), LocalCopyError> {
-        if partial {
-            let temp_path = if let Some(dir) = partial_dir {
-                partial_directory_destination_path(destination, dir)?
-            } else {
-                partial_destination_path(destination)
-            };
-            if let Err(error) = fs::remove_file(&temp_path)
-                && error.kind() != io::ErrorKind::NotFound
-            {
-                return Err(LocalCopyError::io(
-                    "remove existing partial file",
-                    temp_path,
-                    error,
-                ));
+        let partial_kind = if partial {
+            match partial_dir {
+                Some(dir) => {
+                    let file = partial_dir_fname(destination, dir);
+                    // upstream: handle_partial_dir() only rmdir's a *relative*
+                    // partial dir; an absolute one is a reserved location.
+                    let remove_dir = if dir.is_relative() {
+                        file.parent().map(Path::to_path_buf)
+                    } else {
+                        None
+                    };
+                    PartialKind::Dir { file, remove_dir }
+                }
+                None => PartialKind::Keep,
             }
-            let file = fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(&temp_path)
-                .map_err(|error| LocalCopyError::io("copy file", temp_path.clone(), error))?;
-            Ok((
-                Self {
-                    final_path: destination.to_path_buf(),
-                    strategy: GuardStrategy::NamedTempFile {
-                        temp_path,
-                        preserve_on_error: true,
-                    },
-                    committed: false,
-                },
-                file,
-            ))
         } else {
-            loop {
+            PartialKind::Discard
+        };
+
+        // upstream: receiver.c always stages into a `.name.XXXXXX` temp beside
+        // the destination (or in --temp-dir), regardless of partial mode; the
+        // partial only appears at its final resting place on interrupt/success.
+        loop {
+            let temp_path = if partial {
+                temp_name_with_suffix(destination, temp_dir, &temp_suffix())
+            } else {
                 let unique = NEXT_TEMP_FILE_ID.fetch_add(1, AtomicOrdering::Relaxed);
-                let temp_path = temporary_destination_path(destination, unique, temp_dir);
-                match fs::OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .open(&temp_path)
-                {
-                    Ok(file) => {
-                        return Ok((
-                            Self {
-                                final_path: destination.to_path_buf(),
-                                strategy: GuardStrategy::NamedTempFile {
-                                    temp_path,
-                                    preserve_on_error: false,
-                                },
-                                committed: false,
+                temporary_destination_path(destination, unique, temp_dir)
+            };
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)
+            {
+                Ok(file) => {
+                    let final_path = destination.to_path_buf();
+                    // Only --partial/--partial-dir temps need the abort-path
+                    // registry; a plain temp is unlinked by its own guard, so
+                    // registering it would only add global-lock traffic to the
+                    // hot non-partial copy path.
+                    if partial {
+                        CleanupManager::global().register_partial(
+                            temp_path.clone(),
+                            partial_kind
+                                .partial_dest(&final_path)
+                                .map(Path::to_path_buf),
+                            partial_kind.tweak_mtime(),
+                        );
+                    }
+                    return Ok((
+                        Self {
+                            final_path,
+                            strategy: GuardStrategy::NamedTempFile {
+                                temp_path,
+                                partial: partial_kind,
                             },
-                            file,
-                        ));
-                    }
-                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                        continue;
-                    }
-                    Err(error) => {
-                        return Err(LocalCopyError::io("copy file", temp_path, error));
-                    }
+                            committed: false,
+                        },
+                        file,
+                    ));
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    continue;
+                }
+                Err(error) => {
+                    return Err(LocalCopyError::io("copy file", temp_path, error));
                 }
             }
         }
@@ -266,17 +329,40 @@ impl DestinationWriteGuard {
             Anonymous(Option<std::fs::File>),
         }
 
-        let action = match &mut self.strategy {
-            GuardStrategy::NamedTempFile {
-                temp_path,
-                preserve_on_error: _,
-            } => CommitAction::Named(temp_path.clone()),
+        let (action, partial) = match &mut self.strategy {
+            GuardStrategy::NamedTempFile { temp_path, partial } => (
+                CommitAction::Named(temp_path.clone()),
+                Some(partial.clone()),
+            ),
             #[cfg(target_os = "linux")]
-            GuardStrategy::Anonymous { file } => CommitAction::Anonymous(file.take()),
+            GuardStrategy::Anonymous { file } => (CommitAction::Anonymous(file.take()), None),
         };
 
         let cross_device = match action {
-            CommitAction::Named(temp_path) => self.commit_named_temp_file(temp_path)?,
+            CommitAction::Named(temp_path) => {
+                let cross = self.commit_named_temp_file(temp_path.clone())?;
+                match partial {
+                    Some(PartialKind::Keep) => {
+                        CleanupManager::global().unregister_partial(&temp_path);
+                    }
+                    // upstream: handle_partial_dir(partialptr, PDIR_DELETE) after
+                    // a successful finish_transfer removes the partial-dir basis
+                    // entry and rmdir's a now-empty relative partial dir. Only
+                    // rmdir when we actually consumed a partial from the dir, so
+                    // an empty, unused partial dir the user pre-created survives.
+                    Some(PartialKind::Dir { file, remove_dir }) => {
+                        CleanupManager::global().unregister_partial(&temp_path);
+                        let consumed = fs::remove_file(&file).is_ok();
+                        if consumed {
+                            if let Some(dir) = remove_dir {
+                                let _ = fs::remove_dir(dir);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                cross
+            }
             #[cfg(target_os = "linux")]
             CommitAction::Anonymous(file) => {
                 self.commit_anonymous(file)?;
@@ -405,45 +491,34 @@ impl DestinationWriteGuard {
     ///
     /// This method consumes the guard, preventing accidental use after discard.
     pub fn discard(mut self) {
-        match &self.strategy {
-            GuardStrategy::NamedTempFile {
+        self.finalize_partial_on_failure();
+        self.committed = true;
+    }
+
+    /// Finalises the staging temp on an unsuccessful transfer: moves it onto the
+    /// partial destination for `--partial`/`--partial-dir`, or unlinks it
+    /// otherwise. Shared by [`discard`](Self::discard) and [`Drop`].
+    fn finalize_partial_on_failure(&mut self) {
+        if let GuardStrategy::NamedTempFile { temp_path, partial } = &self.strategy {
+            crate::finalize_partial(
                 temp_path,
-                preserve_on_error,
-            } => {
-                if *preserve_on_error {
-                    // upstream: receiver.c - set mtime to epoch 0 on partial files so
-                    // --update won't skip them during a subsequent retry.
-                    let epoch = std::time::SystemTime::UNIX_EPOCH;
-                    let times = fs::FileTimes::new().set_modified(epoch);
-                    if let Ok(file) = fs::File::options().write(true).open(temp_path) {
-                        let _ = file.set_times(times);
-                    }
-                } else if let Err(error) = fs::remove_file(temp_path)
-                    && error.kind() != io::ErrorKind::NotFound
-                {
-                    // Best-effort cleanup: the file may have been removed concurrently.
-                }
-            }
-            #[cfg(target_os = "linux")]
-            GuardStrategy::Anonymous { .. } => {
-                // Dropping the guard drops the anonymous fd; the kernel reclaims the inode.
+                partial.partial_dest(&self.final_path),
+                partial.tweak_mtime(),
+            );
+            // Only partial temps were registered on the abort path.
+            if !matches!(partial, PartialKind::Discard) {
+                CleanupManager::global().unregister_partial(temp_path);
             }
         }
-        self.committed = true;
     }
 
     /// Returns the action description for error messages.
     const fn finalise_action(&self) -> &'static str {
         match &self.strategy {
-            GuardStrategy::NamedTempFile {
-                preserve_on_error, ..
-            } => {
-                if *preserve_on_error {
-                    "finalise partial file"
-                } else {
-                    "finalise temporary file"
-                }
-            }
+            GuardStrategy::NamedTempFile { partial, .. } => match partial {
+                PartialKind::Discard => "finalise temporary file",
+                PartialKind::Keep | PartialKind::Dir { .. } => "finalise partial file",
+            },
             #[cfg(target_os = "linux")]
             GuardStrategy::Anonymous { .. } => "finalise anonymous temp file",
         }
@@ -455,20 +530,11 @@ impl Drop for DestinationWriteGuard {
         if self.committed {
             return;
         }
-        match &self.strategy {
-            GuardStrategy::NamedTempFile {
-                temp_path,
-                preserve_on_error,
-            } => {
-                if !preserve_on_error {
-                    let _ = fs::remove_file(temp_path);
-                }
-            }
-            #[cfg(target_os = "linux")]
-            GuardStrategy::Anonymous { .. } => {
-                // Anonymous fd is dropped, kernel reclaims the inode.
-            }
-        }
+        // An uncommitted guard means the transfer failed or was interrupted:
+        // preserve the partial (--partial/--partial-dir) or unlink the temp.
+        // upstream: cleanup.c moves the temp onto its partial destination when
+        // keep_partial, otherwise do_unlink_at() removes it.
+        self.finalize_partial_on_failure();
     }
 }
 
@@ -619,8 +685,60 @@ mod tests {
         let staging = guard.staging_path().to_path_buf();
         guard.discard();
 
-        // In partial mode, discard preserves the file
-        assert!(staging.exists());
+        // upstream: --partial moves the interrupted temp onto the destination
+        // file itself. The staging temp is consumed by the move; the partial
+        // now lives at `dest`.
+        assert!(!staging.exists(), "staging temp is renamed onto the dest");
+        assert!(
+            dest.exists(),
+            "partial data is preserved at the destination"
+        );
+        assert_eq!(fs::read(&dest).expect("read"), b"partial content");
+    }
+
+    #[test]
+    fn destination_write_guard_partial_temp_uses_upstream_naming() {
+        let temp = tempdir().expect("tempdir");
+        let dest = temp.path().join("f3");
+
+        let (guard, _file) = DestinationWriteGuard::new(&dest, true, None, None).expect("guard");
+        let name = guard
+            .staging_path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        // upstream get_tmpname(): `.f3.XXXXXX` with a six-character suffix.
+        assert!(name.starts_with(".f3."), "got {name}");
+        assert_eq!(name.len(), ".f3.".len() + 6, "six-char suffix: {name}");
+        guard.discard();
+    }
+
+    #[test]
+    fn destination_write_guard_partial_dir_moves_temp_into_dir_on_discard() {
+        let temp = tempdir().expect("tempdir");
+        let dest_dir = temp.path().join("d1");
+        fs::create_dir(&dest_dir).expect("mkdir");
+        let dest = dest_dir.join("f3");
+        let partial_dir = std::path::Path::new(".rsync-partial");
+
+        let (guard, mut file) =
+            DestinationWriteGuard::new(&dest, true, Some(partial_dir), None).expect("guard");
+        // The in-progress temp lives beside the destination, not in the dir.
+        let staging = guard.staging_path().to_path_buf();
+        assert_eq!(staging.parent(), Some(dest_dir.as_path()));
+        file.write_all(b"partialdata").expect("write");
+        drop(file);
+        guard.discard();
+
+        // On interrupt the temp is moved into the (created) partial dir.
+        let landed = dest_dir.join(".rsync-partial").join("f3");
+        assert!(landed.exists(), "partial moved into --partial-dir");
+        assert!(!staging.exists());
+        assert!(
+            !dest.exists(),
+            "dest not written on interrupt for --partial-dir"
+        );
     }
 
     #[test]

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -499,6 +499,7 @@ impl DestinationWriteGuard {
     /// partial destination for `--partial`/`--partial-dir`, or unlinks it
     /// otherwise. Shared by [`discard`](Self::discard) and [`Drop`].
     fn finalize_partial_on_failure(&mut self) {
+        #[allow(irrefutable_let_patterns)]
         if let GuardStrategy::NamedTempFile { temp_path, partial } = &self.strategy {
             crate::finalize_partial(
                 temp_path,

--- a/crates/engine/src/local_copy/executor/file/paths.rs
+++ b/crates/engine/src/local_copy/executor/file/paths.rs
@@ -51,6 +51,74 @@ pub(crate) fn partial_directory_destination_path(
     Ok(base_dir.join(file_name))
 }
 
+/// Maximum length of a single path component, minus the room reserved for the
+/// leading dot and the `.XXXXXX` suffix. upstream: `NAME_MAX - 1 - TMPNAME_SUFFIX_LEN`
+/// in `receiver.c:get_tmpname()` (`NAME_MAX` is 255, `TMPNAME_SUFFIX` is `.XXXXXX`).
+const NAME_MAX: usize = 255;
+/// Length of the `.XXXXXX` suffix (`.` plus six random characters).
+const TMPNAME_SUFFIX_LEN: usize = 7;
+
+/// Builds an rsync-style temp filename `.<base>.<suffix>` for `destination`.
+///
+/// Mirrors upstream `receiver.c:get_tmpname()`:
+/// - the temp lives in `temp_dir` when given, otherwise in the destination's
+///   own directory (so the later rename is same-filesystem/atomic);
+/// - without `temp_dir` the name gets a leading dot, and a base that already
+///   starts with a dot has that dot elided to avoid a double dot (OS X's sake);
+/// - the base component is truncated so the full name stays within `NAME_MAX`.
+///
+/// `suffix` is the six-character unique component (upstream fills it via
+/// `mkstemp`; the caller supplies a candidate and retries on collision).
+// upstream: receiver.c:145 get_tmpname()
+pub(crate) fn temp_name_with_suffix(
+    destination: &Path,
+    temp_dir: Option<&Path>,
+    suffix: &str,
+) -> PathBuf {
+    let base = destination
+        .file_name()
+        .map_or_else(|| "".to_owned(), |name| name.to_string_lossy().to_string());
+    let use_leading_dot = temp_dir.is_none();
+    // Elide a base's own leading dot only when we add our own (no temp_dir).
+    let trimmed_base: &str = if use_leading_dot {
+        base.strip_prefix('.').unwrap_or(&base)
+    } else {
+        &base
+    };
+    let max_base = NAME_MAX
+        .saturating_sub(usize::from(use_leading_dot))
+        .saturating_sub(TMPNAME_SUFFIX_LEN);
+    let capped: String = trimmed_base.chars().take(max_base).collect();
+    let name = if use_leading_dot {
+        format!(".{capped}.{suffix}")
+    } else {
+        format!("{capped}.{suffix}")
+    };
+    match temp_dir {
+        Some(dir) => dir.join(name),
+        None => destination.with_file_name(name),
+    }
+}
+
+/// Resolves the partial-dir path for `destination` without creating the
+/// directory. Absolute `partial_dir` holds partials by basename in a reserved
+/// location; a relative one is resolved inside the destination file's own
+/// directory. upstream: `util1.c:partial_dir_fname()`.
+pub(crate) fn partial_dir_fname(destination: &Path, partial_dir: &Path) -> PathBuf {
+    let base_dir = if partial_dir.is_absolute() {
+        partial_dir.to_path_buf()
+    } else {
+        let parent = destination
+            .parent()
+            .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+        parent.join(partial_dir)
+    };
+    let file_name = destination
+        .file_name()
+        .map_or_else(|| OsStr::new("partial").to_os_string(), OsStr::to_os_string);
+    base_dir.join(file_name)
+}
+
 /// Computes the temporary file path used during atomic writes.
 ///
 /// The name includes the PID and a unique counter to prevent collisions.

--- a/crates/engine/src/local_copy/tests/dest_guard.rs
+++ b/crates/engine/src/local_copy/tests/dest_guard.rs
@@ -14,11 +14,15 @@ fn destination_write_guard_uses_custom_partial_directory() {
     file.write_all(b"partial payload").expect("write partial");
     drop(file);
 
+    // Dropping without commit models an interrupted transfer.
     drop(guard);
 
-    let expected_base = destination_dir.join(partial_dir);
-    assert!(temp_path.starts_with(&expected_base));
-    assert!(temp_path.exists());
+    // upstream: the in-progress temp stages beside the destination and is moved
+    // into the partial dir by basename on interrupt.
+    assert_eq!(temp_path.parent(), Some(destination_dir.as_path()));
+    let expected_partial = destination_dir.join(partial_dir).join("file.txt");
+    assert!(!temp_path.exists(), "temp consumed by move into partial dir");
+    assert!(expected_partial.exists(), "partial preserved in partial dir");
     assert!(!destination.exists());
 }
 

--- a/crates/engine/src/local_copy/tests/disk_full_errors.rs
+++ b/crates/engine/src/local_copy/tests/disk_full_errors.rs
@@ -202,11 +202,11 @@ fn guard_partial_mode_preserves_file_on_discard() {
     let staging = guard.staging_path().to_path_buf();
     guard.discard();
 
-    // In partial mode, file should be preserved for resume
-    assert!(
-        staging.exists(),
-        "Partial mode should preserve file on discard"
-    );
+    // upstream: --partial moves the interrupted temp onto the destination so a
+    // later run resumes from it. The temp is consumed; the partial is at `dest`.
+    assert!(!staging.exists(), "temp is renamed onto the destination");
+    assert!(dest.exists(), "partial data preserved at the destination");
+    assert_eq!(fs::read(&dest).expect("read"), b"partial data");
 }
 
 
@@ -493,12 +493,13 @@ fn disk_full_during_copy_preserves_partial_file_in_partial_mode() {
     file.write_all(b"partial content before error").expect("write");
     drop(file);
 
-    // Simulate disk full - in partial mode, discard should preserve the file
+    // Simulate disk full - in partial mode, discard moves the temp onto the
+    // destination so the partial content survives for a later resume.
     guard.discard();
 
-    // Partial file should be preserved
-    assert!(staging.exists(), "Partial file should be preserved");
-    let content = fs::read(&staging).expect("read partial");
+    assert!(!staging.exists(), "temp is consumed by the move");
+    assert!(dest.exists(), "partial content preserved at the destination");
+    let content = fs::read(&dest).expect("read partial");
     assert_eq!(content, b"partial content before error");
 }
 

--- a/crates/engine/src/local_copy/tests/filters.rs
+++ b/crates/engine/src/local_copy/tests/filters.rs
@@ -295,7 +295,9 @@ fn deferred_updates_flush_commits_pending_files() {
 
     let metadata = fs::metadata(&source).expect("metadata");
     let metadata_options = context.metadata_options();
-    let partial_path = partial_destination_path(&destination);
+    // upstream: the staging temp is `.name.XXXXXX` beside the destination and is
+    // renamed onto the destination when the deferred update flushes.
+    let staging_path = guard.staging_path().to_path_buf();
     let final_path = guard.final_path().to_path_buf();
     let update = DeferredUpdate::new(
         guard,
@@ -318,7 +320,7 @@ fn deferred_updates_flush_commits_pending_files() {
     context.register_deferred_update(update);
 
     assert!(!destination.exists());
-    assert!(partial_path.exists());
+    assert!(staging_path.exists());
 
     context
         .flush_deferred_updates()
@@ -326,7 +328,7 @@ fn deferred_updates_flush_commits_pending_files() {
 
     assert!(destination.exists());
     assert_eq!(fs::read(&destination).expect("read dest"), b"payload");
-    assert!(!partial_path.exists());
+    assert!(!staging_path.exists());
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/partial_dir.rs
+++ b/crates/engine/src/local_copy/tests/partial_dir.rs
@@ -41,9 +41,12 @@ fn partial_dir_places_partial_file_in_specified_directory() {
         fs::read(&destination).expect("read dest"),
         b"partial dir test content"
     );
-    // After successful completion, the partial file should be moved to destination
-    // and the partial directory may or may not be empty
-    assert!(partial_dir.exists(), "partial directory should be created");
+    // upstream: a clean transfer stages beside the destination and never
+    // touches the partial dir (it is only created on interrupt/resume).
+    assert!(
+        !partial_dir.exists(),
+        "partial dir is not created by a clean transfer"
+    );
 }
 
 #[test]
@@ -73,9 +76,12 @@ fn partial_dir_creates_directory_if_not_exists() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    // Partial dir should have been created
-    assert!(partial_dir.exists(), "partial directory should be auto-created");
-    assert!(partial_dir.is_dir(), "partial directory should be a directory");
+    // upstream: the partial dir is created on interrupt/resume, not by a clean
+    // transfer that stages a temp beside the destination.
+    assert!(
+        !partial_dir.exists(),
+        "partial dir is not created by a clean transfer"
+    );
 }
 
 #[test]
@@ -101,9 +107,11 @@ fn partial_dir_moves_file_to_destination_on_commit() {
     file.write_all(b"content to commit").expect("write");
     drop(file);
 
-    // Before commit: staging path should exist in partial dir
+    // upstream: the in-progress temp is `.name.XXXXXX` beside the destination,
+    // not inside the partial dir (that only receives the partial on interrupt).
     assert!(staging_path.exists());
-    assert!(staging_path.starts_with(&partial_dir));
+    assert_eq!(staging_path.parent(), Some(dest_dir.as_path()));
+    assert!(!staging_path.starts_with(&partial_dir));
     assert!(!destination.exists());
 
     // Commit the file
@@ -123,7 +131,7 @@ fn partial_dir_preserves_partial_file_on_discard() {
     let temp = tempdir().expect("tempdir");
     let dest_dir = temp.path().join("dest");
     let partial_dir_name = ".interrupt-partial";
-    let _partial_dir = dest_dir.join(partial_dir_name);
+    let partial_dir = dest_dir.join(partial_dir_name);
     fs::create_dir_all(&dest_dir).expect("create dest dir");
 
     let destination = dest_dir.join("interrupted.txt");
@@ -144,11 +152,14 @@ fn partial_dir_preserves_partial_file_on_discard() {
     // Discard simulates an interrupted transfer
     guard.discard();
 
-    // After discard: partial file should still exist in partial dir
-    assert!(staging_path.exists(), "partial file should be preserved on discard");
+    // upstream: on interrupt the temp is moved into the (created) partial dir
+    // by basename; the destination is left untouched.
+    let partial_entry = partial_dir.join("interrupted.txt");
+    assert!(!staging_path.exists(), "temp consumed by the move into the partial dir");
+    assert!(partial_entry.exists(), "partial preserved inside the partial dir");
     assert!(!destination.exists(), "destination should not exist after discard");
     assert_eq!(
-        fs::read(&staging_path).expect("read partial"),
+        fs::read(&partial_entry).expect("read partial"),
         b"partial content before interrupt"
     );
 }
@@ -272,7 +283,11 @@ fn partial_dir_supports_absolute_path() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    assert!(partial_dir.exists(), "absolute partial dir should be created");
+    // upstream: a clean transfer never populates the (absolute) partial dir.
+    assert!(
+        !partial_dir.exists(),
+        "partial dir is not created by a clean transfer"
+    );
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"absolute partial dir test"
@@ -302,11 +317,13 @@ fn partial_dir_absolute_path_preserves_partial_on_discard() {
 
     guard.discard();
 
-    // Partial should be in the absolute path
-    assert!(staging_path.starts_with(&partial_dir));
-    assert!(staging_path.exists());
+    // upstream: on interrupt the temp is moved into the absolute partial dir by
+    // basename.
+    let partial_entry = partial_dir.join("file.txt");
+    assert!(!staging_path.exists(), "temp consumed by the move");
+    assert!(partial_entry.exists(), "partial moved into absolute partial dir");
     assert_eq!(
-        fs::read(&staging_path).expect("read"),
+        fs::read(&partial_entry).expect("read"),
         b"absolute path partial"
     );
 }
@@ -336,14 +353,10 @@ fn partial_dir_relative_to_destination_directory() {
     file.write_all(b"relative test").expect("write");
     drop(file);
 
-    // Verify staging path is under dest_dir/.partial-relative
-    let expected_partial_dir = dest_dir.join(".partial-relative");
-    assert!(
-        staging_path.starts_with(&expected_partial_dir),
-        "staging path {} should start with {}",
-        staging_path.display(),
-        expected_partial_dir.display()
-    );
+    // upstream: the in-progress temp lives beside the destination, not in the
+    // partial dir. The partial dir only receives the file on interrupt.
+    assert_eq!(staging_path.parent(), Some(dest_dir.as_path()));
+    assert!(!staging_path.starts_with(dest_dir.join(".partial-relative")));
 
     guard.commit().expect("commit");
     assert!(destination.exists());
@@ -479,8 +492,13 @@ fn partial_dir_differs_from_non_partial_behavior() {
     drop(file2);
     guard2.discard();
 
-    // Partial mode preserves file, non-partial removes it
-    assert!(staging1.exists(), "partial mode should preserve file");
+    // Partial mode moves the temp into the partial dir; non-partial unlinks it.
+    let partial_entry = dest_dir.join(partial_dir_name).join("partial.txt");
+    assert!(
+        !staging1.exists(),
+        "partial temp consumed by move into partial dir"
+    );
+    assert!(partial_entry.exists(), "partial preserved in the partial dir");
     assert!(!staging2.exists(), "non-partial mode should remove file");
 }
 
@@ -1161,20 +1179,15 @@ fn partial_dir_guard_staging_path_is_inside_partial_dir() {
     .expect("guard");
 
     let staging = guard.staging_path();
-    let expected_partial_dir = dest_dir.join(partial_dir_name);
 
+    // upstream: the in-progress temp is `.output.txt.XXXXXX` beside the
+    // destination, not inside the partial dir.
+    assert_eq!(staging.parent(), Some(dest_dir.as_path()));
+    assert!(!staging.starts_with(dest_dir.join(partial_dir_name)));
+    let staging_name = staging.file_name().unwrap().to_string_lossy();
     assert!(
-        staging.starts_with(&expected_partial_dir),
-        "staging path {} should be inside {}",
-        staging.display(),
-        expected_partial_dir.display()
-    );
-
-    // The filename should match the destination filename
-    assert_eq!(
-        staging.file_name(),
-        destination.file_name(),
-        "staging filename should match destination filename"
+        staging_name.starts_with(".output.txt."),
+        "staging name {staging_name} derives from the destination filename"
     );
 
     guard.discard();
@@ -1244,17 +1257,18 @@ fn partial_dir_guard_discard_preserves_for_later_resume() {
 
     guard.discard();
 
-    // Partial file preserved
-    assert!(staging.exists(), "partial file should be preserved for resume");
+    // upstream: on interrupt the temp is moved into the partial dir by basename,
+    // where a later run finds it as the delta basis.
+    let partial_entry = dest_dir.join(partial_dir_name).join("resumable.txt");
+    assert!(!staging.exists(), "temp consumed by move into partial dir");
+    assert!(partial_entry.exists(), "partial preserved for resume");
 
-    // Now verify PartialFileManager can find it
-    let manager = PartialFileManager::new(PartialMode::PartialDir(
-        PathBuf::from(partial_dir_name),
-    ));
+    // Now verify PartialFileManager can find it in the partial dir.
+    let manager = PartialFileManager::new(PartialMode::PartialDir(PathBuf::from(partial_dir_name)));
     let basis = manager.find_basis(&destination).expect("find_basis");
-    assert_eq!(basis, Some(staging.clone()));
+    assert_eq!(basis, Some(partial_entry.clone()));
     assert_eq!(
-        fs::read(&staging).expect("read partial"),
+        fs::read(&partial_entry).expect("read partial"),
         b"partial data for resume"
     );
 }
@@ -1281,14 +1295,12 @@ fn partial_dir_with_deeply_nested_relative_path() {
     file.write_all(b"nested partial dir content").expect("write");
     drop(file);
 
+    // upstream: the temp stages beside the destination regardless of how deep
+    // the (multi-component) partial dir is; the partial dir only receives the
+    // file on interrupt.
     let staging = guard.staging_path().to_path_buf();
-    let expected_base = dest_dir.join(partial_dir_name);
-    assert!(
-        staging.starts_with(&expected_base),
-        "staging {} should be under {}",
-        staging.display(),
-        expected_base.display()
-    );
+    assert_eq!(staging.parent(), Some(dest_dir.as_path()));
+    assert!(!staging.starts_with(dest_dir.join(partial_dir_name)));
 
     guard.commit().expect("commit");
     assert!(destination.exists());
@@ -1445,14 +1457,11 @@ fn partial_dir_successful_copy_creates_and_uses_partial_dir() {
         fs::read(&destination).expect("read dest"),
         b"end-to-end partial dir test content"
     );
-    // Partial dir should have been created during the transfer
+    // upstream: a clean transfer stages beside the destination and never
+    // creates the partial dir (that only happens on interrupt/resume).
     assert!(
-        partial_dir_path.exists(),
-        "partial dir should be auto-created during transfer"
-    );
-    assert!(
-        partial_dir_path.is_dir(),
-        "partial dir should be a directory"
+        !partial_dir_path.exists(),
+        "partial dir is not created by a clean transfer"
     );
 }
 

--- a/crates/engine/src/util/cleanup.rs
+++ b/crates/engine/src/util/cleanup.rs
@@ -12,6 +12,48 @@ use std::sync::{Mutex, OnceLock};
 /// Global cleanup manager instance.
 static CLEANUP_MANAGER: OnceLock<Mutex<CleanupManagerState>> = OnceLock::new();
 
+/// An in-progress temp file and where its partial data should end up if the
+/// transfer is cut short. Mirrors upstream's `cleanup_fname`/`cleanup_new_fname`
+/// pair (`cleanup.c:cleanup_set()`): `temp` is the `.name.XXXXXX` staging file,
+/// and `partial_dest` is the destination the partial is moved to on interrupt
+/// (the real file for `--partial`, or the partial-dir entry for
+/// `--partial-dir`). `None` means "no partial kept" - just unlink the temp.
+#[derive(Clone, Debug)]
+struct PartialEntry {
+    temp: PathBuf,
+    partial_dest: Option<PathBuf>,
+    tweak_mtime: bool,
+}
+
+/// Moves an interrupted temp file to its partial destination, or removes it.
+///
+/// upstream: `cleanup.c:exit_cleanup()` calls `finish_transfer()` to rename the
+/// temp onto `cleanup_new_fname` (creating the partial dir first via
+/// `handle_partial_dir(PDIR_CREATE)`), tweaking the modtime to epoch 0 when the
+/// partial lands on the real destination file so `--update` will not skip it.
+/// With no partial destination it unlinks the temp (`do_unlink_at`).
+pub fn finalize_partial(temp: &Path, partial_dest: Option<&Path>, tweak_mtime: bool) {
+    match partial_dest {
+        Some(dest) => {
+            if let Some(parent) = dest.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            // Best-effort: an already-committed transfer leaves no temp, so a
+            // failed rename here is expected and harmless.
+            if std::fs::rename(temp, dest).is_ok() && tweak_mtime {
+                let epoch = std::time::SystemTime::UNIX_EPOCH;
+                let times = std::fs::FileTimes::new().set_modified(epoch);
+                if let Ok(file) = std::fs::File::options().write(true).open(dest) {
+                    let _ = file.set_times(times);
+                }
+            }
+        }
+        None => {
+            let _ = std::fs::remove_file(temp);
+        }
+    }
+}
+
 /// Cleanup manager for tracking and cleaning up temporary resources.
 ///
 /// This type provides a global registry for temporary files and resources
@@ -133,6 +175,63 @@ impl CleanupManager {
         0
     }
 
+    /// Registers an in-progress temp file and its partial destination.
+    ///
+    /// Called when a `--partial`/`--partial-dir` staging file is opened so that
+    /// a signal handler's abort path can finalise it even if the owning thread
+    /// never returns to run its RAII guard. `partial_dest` is `None` for a
+    /// non-partial transfer (the temp is simply unlinked on abort).
+    pub fn register_partial(
+        &self,
+        temp: PathBuf,
+        partial_dest: Option<PathBuf>,
+        tweak_mtime: bool,
+    ) {
+        if let Some(state) = CLEANUP_MANAGER.get() {
+            if let Ok(mut state) = state.lock() {
+                state.partials.retain(|entry| entry.temp != temp);
+                state.partials.push(PartialEntry {
+                    temp,
+                    partial_dest,
+                    tweak_mtime,
+                });
+            }
+        }
+    }
+
+    /// Removes a temp file from the partial registry after its guard committed
+    /// or already finalised it.
+    pub fn unregister_partial(&self, temp: &Path) {
+        if let Some(state) = CLEANUP_MANAGER.get() {
+            if let Ok(mut state) = state.lock() {
+                state.partials.retain(|entry| entry.temp != temp);
+            }
+        }
+    }
+
+    /// Finalises every registered in-progress temp: moves each onto its partial
+    /// destination (or unlinks it), then clears the registry. Invoked from the
+    /// abort path (a second interrupt signal) that cannot wait for graceful
+    /// unwinding. upstream: `cleanup.c:exit_cleanup()` on `RERR_SIGNAL`.
+    pub fn finalize_partials(&self) {
+        let entries = {
+            let Some(state) = CLEANUP_MANAGER.get() else {
+                return;
+            };
+            let Ok(mut state) = state.lock() else {
+                return;
+            };
+            std::mem::take(&mut state.partials)
+        };
+        for entry in entries {
+            finalize_partial(
+                &entry.temp,
+                entry.partial_dest.as_deref(),
+                entry.tweak_mtime,
+            );
+        }
+    }
+
     /// Clears all registered resources without performing cleanup.
     ///
     /// Primarily useful for testing.
@@ -142,6 +241,7 @@ impl CleanupManager {
             if let Ok(mut state) = state.lock() {
                 state.temp_files.clear();
                 state.cleanup_callbacks.clear();
+                state.partials.clear();
             }
         }
     }
@@ -154,6 +254,7 @@ static CLEANUP_MANAGER_INSTANCE: CleanupManager = CleanupManager;
 struct CleanupManagerState {
     temp_files: HashSet<PathBuf>,
     cleanup_callbacks: Vec<Box<dyn FnOnce() + Send>>,
+    partials: Vec<PartialEntry>,
 }
 
 impl CleanupManagerState {
@@ -161,6 +262,7 @@ impl CleanupManagerState {
         Self {
             temp_files: HashSet::new(),
             cleanup_callbacks: Vec::new(),
+            partials: Vec::new(),
         }
     }
 

--- a/crates/engine/tests/atomic_rename.rs
+++ b/crates/engine/tests/atomic_rename.rs
@@ -372,16 +372,21 @@ fn partial_mode_preserves_temp_on_discard() {
 
     let staging = guard.staging_path().to_path_buf();
     assert!(staging.exists());
-    assert!(staging.to_string_lossy().contains(".rsync-partial-"));
+    // upstream get_tmpname(): the in-progress temp is `.file.txt.XXXXXX` beside
+    // the destination, not a visible `.rsync-partial-*` file.
+    let staging_name = staging.file_name().unwrap().to_string_lossy();
+    assert!(
+        staging_name.starts_with(".file.txt."),
+        "unexpected staging name {staging_name}"
+    );
 
     guard.discard();
 
-    // In partial mode, discard should preserve the file for resumption
-    assert!(
-        staging.exists(),
-        "partial file should be preserved on discard for resumption"
-    );
-    assert!(!dest.exists());
+    // upstream: --partial moves the interrupted temp onto the destination file
+    // itself so a later run resumes from it.
+    assert!(!staging.exists(), "temp is renamed onto the destination");
+    assert!(dest.exists(), "partial data preserved at the destination");
+    assert_eq!(fs::read(&dest).expect("read"), b"partial content");
 }
 
 #[test]

--- a/crates/fast_io/src/signal/mod.rs
+++ b/crates/fast_io/src/signal/mod.rs
@@ -11,6 +11,7 @@
 //! are confined to this crate per the workspace unsafe-code policy.
 
 use std::os::raw::c_int;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Async-signal-safe handler function signature.
 ///
@@ -18,6 +19,44 @@ use std::os::raw::c_int;
 /// locking, or calling any non-async-signal-safe functions. Atomic stores
 /// against `static AtomicBool`/`AtomicU8` are the canonical safe operation.
 pub type SignalHandlerFn = extern "C" fn(c_int);
+
+/// Process-global graceful-shutdown flag.
+///
+/// Set from an async-signal-safe handler (a plain atomic store) and polled by
+/// long-running loops elsewhere in the workspace. It lives in `fast_io`
+/// because that is the lowest crate both `core` (which installs the handlers)
+/// and `engine` (which polls it mid-transfer) already depend on, so the flag
+/// can be a single `'static` without a dependency cycle.
+///
+/// upstream: rsync's `sig_int`/`sig_term` handlers set `got_xfer_error` /
+/// call `_exit_cleanup`; here the handler only flips this flag and the
+/// transfer loop performs the cleanup in normal (non-signal) context.
+static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Marks that a graceful shutdown has been requested.
+///
+/// Async-signal-safe: performs a single relaxed-ordering atomic store, so it
+/// is safe to call from within a signal handler.
+#[inline]
+pub fn mark_shutdown() {
+    SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
+}
+
+/// Returns `true` once [`mark_shutdown`] has been called.
+///
+/// Polled by long-running copy loops so they can stop promptly mid-file and
+/// let the normal-context cleanup path finalise any in-progress temp file.
+#[inline]
+#[must_use]
+pub fn shutdown_requested() -> bool {
+    SHUTDOWN_REQUESTED.load(Ordering::Relaxed)
+}
+
+/// Clears the shutdown flag. Intended for tests that must reset global state.
+#[doc(hidden)]
+pub fn reset_shutdown_for_testing() {
+    SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
+}
 
 #[cfg(unix)]
 mod unix;


### PR DESCRIPTION
## Summary

Makes oc-rsync's `--partial`/`--partial-dir` interrupt and resume behaviour match upstream so the `partial` upstream-testsuite passes with oc-rsync as the primary binary.

Previously oc wrote partial data directly to a visible `.rsync-partial-<name>` file and, lacking any signal handling, was terminated (exit 143) on SIGTERM, leaving the partial in the wrong place. Upstream instead stages into a `.<name>.XXXXXX` temp beside the destination and, from its `exit_cleanup` handler, moves that temp onto the partial's final resting place.

## Changes (3 parts)

1. **Engine temp naming + partial-at-dest model** – a `get_tmpname`-equivalent produces `.<name>.XXXXXX` (six mkstemp-style chars, leading-dot elision, NAME_MAX cap) beside the destination (or in `--temp-dir`). On interrupt the temp is finalized onto the real file (`--partial`) or the partial-dir entry (`--partial-dir`); a relative partial-dir is removed once its partial has been consumed on success.
2. **Signal wiring + cleanup registry** – the existing signal handlers are installed on the client run path, and a cleanup registry maps in-progress temp -> partial destination (registered on temp open, deregistered on finalize). A second interrupt finalizes all in-progress partials and exits with the rsync signal code (20).
3. **Mid-file shutdown** – a shared shutdown flag (in `fast_io`, set by the handlers) is polled inside the copy loops so a large single-file transfer stops mid-file and finalizes its partial during normal unwinding.

Mirrors `receiver.c:145` get_tmpname, `cleanup.c:105-135` exit_cleanup, `receiver.c:340` do_rename.

## Validation (Linux, oc-rsync as primary)

- `runtests.py --use-tcp partial` **PASS** with oc-rsync primary (all five legs: --partial, relative/absolute --partial-dir, interrupt+resume).
- In-progress temp observed as `.f3.XXXXXX`; after SIGTERM the partial is at the dest file `f3` (valid prefix), a subsequent `--partial` run resumes byte-identical, exit code 20.
- Non-partial interrupt leaves no corrupt destination; normal transfers unaffected (byte-identical, no stray temps).
- fmt + clippy (engine, core, cli, fast_io, `-D warnings`) clean; core/engine/cli stay unsafe-free.
- Full engine test suite green (partial/guard/signal/temp/delay-updates/hardlink tests updated to the upstream model).