### PR TITLE
fix: itemize --fake-super device placeholders as their real type

### DIFF
--- a/crates/cli/src/frontend/out_format/render/itemize.rs
+++ b/crates/cli/src/frontend/out_format/render/itemize.rs
@@ -22,15 +22,40 @@ pub(super) fn format_itemized_changes(event: &ClientEvent, is_sender: bool) -> S
 
     let mut fields = ['.'; 11];
 
+    let entry_kind = event
+        .metadata()
+        .map(ClientEntryMetadata::kind)
+        .unwrap_or_else(|| match event.kind() {
+            DirectoryCreated => ClientEntryKind::Directory,
+            SymlinkCopied => ClientEntryKind::Symlink,
+            FifoCopied => ClientEntryKind::Fifo,
+            DeviceCopied => ClientEntryKind::CharDevice,
+            HardLink
+            | DataCopied
+            | ReferenceCopied
+            | MetadataReused
+            | SkippedExisting
+            | SkippedMissingDestination
+            | SkippedNewerDestination => ClientEntryKind::File,
+            _ => ClientEntryKind::Other,
+        });
+    let is_regular = matches!(entry_kind, ClientEntryKind::File);
+
     // upstream: log.c:704 - '<' when am_sender && !am_server, '>' otherwise
     fields[0] = match event.kind() {
-        DataCopied => {
+        // upstream: log.c:704-710 - the transfer direction ('<'/'>') is only
+        // emitted for a regular-file data transfer (ITEM_TRANSFER). A
+        // non-regular entry - including a --fake-super device/FIFO/socket
+        // placeholder whose real type comes from the `%stat` xattr - carries
+        // no data and itemizes as a local change ('c', ITEM_LOCAL_CHANGE).
+        DataCopied if is_regular => {
             if is_sender {
                 '<'
             } else {
                 '>'
             }
         }
+        DataCopied => 'c',
         HardLink => 'h',
         // upstream: generator.c:1039 - copy-dest reconstruction itemizes with
         // ITEM_LOCAL_CHANGE, rendered as 'c' by log.c:707-708.
@@ -47,23 +72,7 @@ pub(super) fn format_itemized_changes(event: &ClientEvent, is_sender: bool) -> S
         _ => '.',
     };
 
-    fields[1] = match event
-        .metadata()
-        .map(ClientEntryMetadata::kind)
-        .unwrap_or_else(|| match event.kind() {
-            DirectoryCreated => ClientEntryKind::Directory,
-            SymlinkCopied => ClientEntryKind::Symlink,
-            FifoCopied => ClientEntryKind::Fifo,
-            DeviceCopied => ClientEntryKind::CharDevice,
-            HardLink
-            | DataCopied
-            | ReferenceCopied
-            | MetadataReused
-            | SkippedExisting
-            | SkippedMissingDestination
-            | SkippedNewerDestination => ClientEntryKind::File,
-            _ => ClientEntryKind::Other,
-        }) {
+    fields[1] = match entry_kind {
         ClientEntryKind::File => 'f',
         ClientEntryKind::Directory => 'd',
         ClientEntryKind::Symlink => 'L',
@@ -78,7 +87,6 @@ pub(super) fn format_itemized_changes(event: &ClientEvent, is_sender: bool) -> S
         return fields.iter().collect();
     }
 
-    let is_symlink = fields[1] == 'L';
     let change_set = event.change_set();
 
     // upstream: log.c:730-734 - ITEM_MISSING_DATA fills attribute positions with '?'
@@ -94,8 +102,10 @@ pub(super) fn format_itemized_changes(event: &ClientEvent, is_sender: bool) -> S
         attr[0] = 'c';
     }
 
-    // upstream: log.c:706 - symlinks never report size changes
-    if !is_symlink && change_set.size_changed() {
+    // upstream: log.c:706 - only regular files report size changes; symlinks,
+    // devices, FIFOs, and sockets (including --fake-super placeholders that
+    // virtualise to those types) never set the 's' column.
+    if is_regular && change_set.size_changed() {
         attr[1] = 's';
     }
 

--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -205,6 +205,40 @@ pub(crate) struct CopyComparison<'a> {
     pub(crate) prefetched_match: Option<bool>,
 }
 
+/// Returns `true` when a `--fake-super` source placeholder and its
+/// destination describe different device/special nodes.
+///
+/// Under `--fake-super` a device/FIFO/socket is stored as a regular
+/// placeholder whose `user.rsync.%stat` xattr carries the real mode and rdev.
+/// The placeholder contents (and hence size/mtime) can be identical while the
+/// encoded device numbers differ, so upstream's `unchanged_file()` compares
+/// the virtualised `st_mode`/`st_rdev` rather than the on-disk file. This
+/// helper reproduces that comparison so the quick-check and itemize columns
+/// react to an rdev/type change. Regular `%stat` shims fall back to the normal
+/// size+time check by returning `false`.
+///
+/// # Upstream Reference
+///
+/// - `generator.c:unchanged_file()` - compares `st_rdev` for `IS_DEVICE`.
+/// - `xattrs.c:1135 get_stat_xattr()` - source of the virtualised stat.
+#[cfg(all(unix, feature = "xattr"))]
+pub(crate) fn fake_super_stat_differs(source: &Path, destination: &Path) -> bool {
+    let Ok(Some(src)) = ::metadata::load_fake_super(source) else {
+        return false;
+    };
+    // Only devices and special files use the rdev/type comparison; a regular
+    // (or type-less) placeholder keeps the standard size+time quick-check.
+    let src_ifmt = src.mode & 0o170000;
+    if src_ifmt == 0 || src_ifmt == 0o100000 {
+        return false;
+    }
+    match ::metadata::load_fake_super(destination) {
+        Ok(Some(dst)) => src.mode != dst.mode || src.rdev != dst.rdev,
+        // A destination lacking the shim cannot match the encoded node.
+        _ => true,
+    }
+}
+
 /// Determines whether a file copy should be skipped.
 ///
 /// Returns `true` if the destination file is already in sync with the source

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -283,7 +283,8 @@ pub(super) fn process_links(
             });
         context.record_hard_link(metadata, destination);
         context.summary_mut().record_hard_link();
-        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, leader_display);
+        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, leader_display)
+            .virtualize_fake_super(source, metadata_options.fake_super_enabled());
         let total_bytes = Some(metadata_snapshot.len());
         context.record(
             LocalCopyRecord::new(
@@ -419,7 +420,8 @@ pub(super) fn process_links(
             // Tagging the record as HardLink keeps position 0 at 'h'
             // instead of '.'; omitting `.with_creation(true)` keeps
             // positions 2-10 as deltas instead of `+++++++++`.
-            let reuse_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+            let reuse_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+                .virtualize_fake_super(source, metadata_options.fake_super_enabled());
             context.record(
                 LocalCopyRecord::new(
                     record_path.to_path_buf(),
@@ -508,7 +510,8 @@ pub(super) fn process_links(
             .map(std::path::Path::to_path_buf)
             .unwrap_or_else(|_| existing_target.clone());
         let metadata_snapshot =
-            LocalCopyMetadata::from_metadata(metadata, Some(link_target_display));
+            LocalCopyMetadata::from_metadata(metadata, Some(link_target_display))
+                .virtualize_fake_super(source, metadata_options.fake_super_enabled());
         let total_bytes = Some(metadata_snapshot.len());
         // upstream: hlink.c:218-222 - `itemize(..., ITEM_LOCAL_CHANGE, ...)`
         // is emitted whether the alias was created from scratch or the
@@ -662,7 +665,8 @@ pub(super) fn process_links(
                 let basis_metadata = fs::symlink_metadata(&basis).map_err(|error| {
                     LocalCopyError::io("inspect compare-dest basis", basis.clone(), error)
                 })?;
-                let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+                let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+                    .virtualize_fake_super(source, metadata_options.fake_super_enabled());
                 let total_bytes = Some(metadata_snapshot.len());
                 let change_set = LocalCopyChangeSet::for_file(
                     metadata,
@@ -793,7 +797,8 @@ pub(super) fn process_links(
                     info_log!(Name, 1, "{} => {}", record_path.display(), path.display());
                     context.record_hard_link(metadata, destination);
                     context.summary_mut().record_hard_link();
-                    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+                    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+                        .virtualize_fake_super(source, metadata_options.fake_super_enabled());
                     let total_bytes = Some(metadata_snapshot.len());
                     context.record(LocalCopyRecord::new(
                         record_path.to_path_buf(),

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -130,7 +130,8 @@ pub(crate) fn copy_file(
 
     if context.existing_only_enabled() && existing_metadata.is_none() {
         context.summary_mut().record_regular_file_skipped_missing();
-        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+            .virtualize_fake_super(source, metadata_options.fake_super_enabled());
         let total_bytes = Some(metadata_snapshot.len());
         context.record(LocalCopyRecord::new(
             record_path.clone(),

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -169,7 +169,8 @@ pub(super) fn try_clone(
         .record_copy_method(CopyMethodKind::from_platform(clone_method));
     context.summary_mut().record_elapsed(start.elapsed());
 
-    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+        .virtualize_fake_super(source, metadata_options.fake_super_enabled());
     let total_bytes = Some(metadata_snapshot.len());
     let change_set = LocalCopyChangeSet::for_file(
         metadata,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
@@ -155,7 +155,8 @@ pub(super) fn try_clone(
         .record_copy_method(CopyMethodKind::Ficlone);
     context.summary_mut().record_elapsed(start.elapsed());
 
-    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+        .virtualize_fake_super(source, metadata_options.fake_super_enabled());
     let total_bytes = Some(metadata_snapshot.len());
     let change_set = LocalCopyChangeSet::for_file(
         metadata,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
@@ -123,7 +123,8 @@ pub(super) fn try_dispatch(
         .summary_mut()
         .record_copy_method(CopyMethodKind::IoUring);
     context.summary_mut().record_elapsed(elapsed);
-    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+        .virtualize_fake_super(source, metadata_options.fake_super_enabled());
     let total_bytes = Some(metadata_snapshot.len());
     let change_set = LocalCopyChangeSet::for_file(
         metadata,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -695,6 +695,25 @@ pub(in crate::local_copy) fn execute_transfer(
         flags.checksum_enabled,
         context.options().modify_window(),
     );
+    // upstream: generator.c itemizes a recreated --fake-super device with
+    // ITEM_REPORT_CHANGE ('c') when its %stat rdev/type differs from the
+    // destination's, even though the placeholder bytes are identical. The node
+    // is recreated, so ITEM_REPORT_TIME is set too - rendered 'T' when times
+    // are not preserved (the mtime is reset to the transfer time).
+    #[cfg(all(unix, feature = "xattr"))]
+    let change_set = if metadata_options.fake_super_enabled()
+        && destination_previously_existed
+        && super::super::super::comparison::fake_super_stat_differs(source, destination)
+    {
+        let change_set = change_set.with_checksum_changed(true);
+        if metadata_options.times() {
+            change_set
+        } else {
+            change_set.with_time_change(Some(crate::local_copy::TimeChange::TransferTime))
+        }
+    } else {
+        change_set
+    };
     let action = if is_reference_copy {
         LocalCopyAction::ReferenceCopied
     } else {

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -297,7 +297,8 @@ pub(in crate::local_copy) fn execute_transfer(
     if matches!(append_mode, AppendMode::Skip) {
         context.record_hard_link(metadata, destination);
         context.summary_mut().record_regular_file_matched();
-        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+            .virtualize_fake_super(source, metadata_options.fake_super_enabled());
         let total_bytes = Some(metadata_snapshot.len());
         context.record(LocalCopyRecord::new(
             record_path.to_path_buf(),
@@ -655,7 +656,8 @@ pub(in crate::local_copy) fn execute_transfer(
         .record_copy_method(CopyMethodKind::Standard);
     context.summary_mut().record_elapsed(elapsed);
 
-    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+        .virtualize_fake_super(source, metadata_options.fake_super_enabled());
     let total_bytes = Some(metadata_snapshot.len());
     let wrote_data = outcome.literal_bytes() > 0 || append_offset > 0;
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
@@ -65,6 +65,18 @@ pub(super) fn try_skip_up_to_date(
         prefetched_match,
     });
 
+    // upstream: generator.c:unchanged_file() compares st_rdev for devices. A
+    // --fake-super placeholder can have identical content and mtime while its
+    // %stat encodes a different device, so force a transfer when the encoded
+    // node changed.
+    #[cfg(all(unix, feature = "xattr"))]
+    if skip
+        && metadata_options.fake_super_enabled()
+        && super::super::super::super::comparison::fake_super_stat_differs(source, destination)
+    {
+        skip = false;
+    }
+
     if skip {
         let requires_content_verification =
             existing.is_file() && !flags.checksum_enabled && context.options().backup_enabled();

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
@@ -160,7 +160,8 @@ pub(super) fn record_metadata_only_skip(
 
     context.record_hard_link(metadata, destination);
     context.summary_mut().record_regular_file_matched();
-    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+        .virtualize_fake_super(source, metadata_options.fake_super_enabled());
     let total_bytes = Some(metadata_snapshot.len());
     let change_set = LocalCopyChangeSet::for_file(
         metadata,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -160,7 +160,8 @@ pub(super) fn try_copy(
     #[cfg(feature = "xattr")]
     reconcile_copied_ads(context, source, destination, flags)?;
 
-    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+        .virtualize_fake_super(source, metadata_options.fake_super_enabled());
     let total_bytes = Some(metadata_snapshot.len());
     let change_set = LocalCopyChangeSet::for_file(
         metadata,

--- a/crates/engine/src/local_copy/plan/metadata.rs
+++ b/crates/engine/src/local_copy/plan/metadata.rs
@@ -166,6 +166,7 @@ impl LocalCopyMetadata {
     /// - `xattrs.c:1135 get_stat_xattr()` - overrides `st_mode`/`st_rdev` from
     ///   the `%stat` xattr on the sender when `am_root < 0` (fake-super).
     #[must_use]
+    #[cfg_attr(not(all(unix, feature = "xattr")), allow(unused_mut))]
     pub(in crate::local_copy) fn virtualize_fake_super(
         mut self,
         source: &Path,

--- a/crates/engine/src/local_copy/plan/metadata.rs
+++ b/crates/engine/src/local_copy/plan/metadata.rs
@@ -61,6 +61,26 @@ impl LocalCopyFileKind {
         Self::Other
     }
 
+    /// Maps a POSIX `st_mode` (including the `S_IFMT` type bits) to the file
+    /// kind, returning `None` for a regular file or an unrecognised type.
+    ///
+    /// Used by the fake-super reporting override so a regular placeholder is
+    /// itemized as the virtual type its `user.rsync.%stat` xattr encodes,
+    /// while a `%stat` that still describes a regular file leaves the kind
+    /// untouched.
+    #[cfg(all(unix, feature = "xattr"))]
+    fn from_stat_mode(mode: u32) -> Option<Self> {
+        match mode & 0o170000 {
+            0o040000 => Some(Self::Directory),
+            0o120000 => Some(Self::Symlink),
+            0o010000 => Some(Self::Fifo),
+            0o020000 => Some(Self::CharDevice),
+            0o060000 => Some(Self::BlockDevice),
+            0o140000 => Some(Self::Socket),
+            _ => None,
+        }
+    }
+
     /// Returns whether the kind represents a directory.
     #[must_use]
     pub const fn is_directory(self) -> bool {
@@ -127,6 +147,46 @@ impl LocalCopyMetadata {
             nlink,
             symlink_target: target,
         }
+    }
+
+    /// Applies the upstream fake-super `st_mode` override for reporting.
+    ///
+    /// Under `--fake-super`, a device/FIFO/socket is stored on disk as a
+    /// regular placeholder file that carries the real mode and device numbers
+    /// in its `user.rsync.%stat` xattr. Upstream's sender virtualises the stat
+    /// via `get_stat_xattr()` before itemizing, so the placeholder is reported
+    /// as its true type. This mirrors that override for the local-copy path:
+    /// when `fake_super` is active and this snapshot describes a regular file
+    /// whose source `%stat` decodes to a non-regular type, the reported kind
+    /// and mode are replaced. The on-disk file and the copied destination stay
+    /// regular placeholders; only the itemized type char and mode change.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `xattrs.c:1135 get_stat_xattr()` - overrides `st_mode`/`st_rdev` from
+    ///   the `%stat` xattr on the sender when `am_root < 0` (fake-super).
+    #[must_use]
+    pub(in crate::local_copy) fn virtualize_fake_super(
+        mut self,
+        source: &Path,
+        fake_super: bool,
+    ) -> Self {
+        #[cfg(all(unix, feature = "xattr"))]
+        {
+            if fake_super
+                && matches!(self.kind, LocalCopyFileKind::File)
+                && let Ok(Some(stat)) = ::metadata::load_fake_super(source)
+                && let Some(kind) = LocalCopyFileKind::from_stat_mode(stat.mode)
+            {
+                self.kind = kind;
+                self.mode = Some(stat.mode);
+            }
+        }
+        #[cfg(not(all(unix, feature = "xattr")))]
+        {
+            let _ = (source, fake_super);
+        }
+        self
     }
 
     /// Returns the entry kind associated with the metadata.
@@ -281,5 +341,80 @@ mod tests {
         );
         assert_ne!(LocalCopyFileKind::BlockDevice, LocalCopyFileKind::Socket);
         assert_ne!(LocalCopyFileKind::Socket, LocalCopyFileKind::Other);
+    }
+
+    // Under --fake-super a device/FIFO/socket is stored as a regular
+    // placeholder file whose `user.rsync.%stat` xattr encodes the real
+    // st_mode. The reporting override must map those mode bits back to the
+    // virtual kind (so the itemized type char matches upstream's
+    // get_stat_xattr sender override, xattrs.c:1135) while leaving a %stat
+    // that still describes a regular file untouched.
+    #[cfg(all(unix, feature = "xattr"))]
+    #[test]
+    fn from_stat_mode_maps_type_bits_to_kind() {
+        assert_eq!(
+            LocalCopyFileKind::from_stat_mode(0o020644),
+            Some(LocalCopyFileKind::CharDevice)
+        );
+        assert_eq!(
+            LocalCopyFileKind::from_stat_mode(0o060660),
+            Some(LocalCopyFileKind::BlockDevice)
+        );
+        assert_eq!(
+            LocalCopyFileKind::from_stat_mode(0o010644),
+            Some(LocalCopyFileKind::Fifo)
+        );
+        assert_eq!(
+            LocalCopyFileKind::from_stat_mode(0o140755),
+            Some(LocalCopyFileKind::Socket)
+        );
+        assert_eq!(
+            LocalCopyFileKind::from_stat_mode(0o120777),
+            Some(LocalCopyFileKind::Symlink)
+        );
+        // A regular file leaves the kind unchanged (returns None).
+        assert_eq!(LocalCopyFileKind::from_stat_mode(0o100644), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn virtualize_fake_super_is_noop_when_disabled() {
+        use std::fs;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("placeholder");
+        fs::write(&path, b"x").unwrap();
+        let meta = fs::symlink_metadata(&path).unwrap();
+        let snapshot = LocalCopyMetadata::from_metadata(&meta, None);
+        // fake_super = false must never consult the xattr or change the kind.
+        let virtualized = snapshot.virtualize_fake_super(&path, false);
+        assert_eq!(virtualized.kind(), LocalCopyFileKind::File);
+    }
+
+    // A regular placeholder carrying a device `%stat` xattr must report as a
+    // device once fake-super virtualisation runs, matching the upstream
+    // sender itemize (`cD` instead of `>f`). Skips gracefully on filesystems
+    // that reject `user.*` xattrs so CI on such hosts does not flake.
+    #[cfg(all(unix, feature = "xattr"))]
+    #[test]
+    fn virtualize_fake_super_promotes_placeholder_to_device() {
+        use std::fs;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("char");
+        fs::write(&path, b"").unwrap();
+        let stat = ::metadata::FakeSuperStat {
+            mode: 0o020644,
+            uid: 0,
+            gid: 0,
+            rdev: Some((41, 67)),
+        };
+        if ::metadata::store_fake_super(&path, &stat).is_err() {
+            eprintln!("skipping: user.* xattrs unsupported on test filesystem");
+            return;
+        }
+        let meta = fs::symlink_metadata(&path).unwrap();
+        let snapshot =
+            LocalCopyMetadata::from_metadata(&meta, None).virtualize_fake_super(&path, true);
+        assert_eq!(snapshot.kind(), LocalCopyFileKind::CharDevice);
+        assert_eq!(snapshot.mode(), Some(0o020644));
     }
 }


### PR DESCRIPTION
## Summary

Under `--fake-super`, a device, FIFO, or socket is stored on disk as a regular placeholder file whose `user.rsync.%stat` xattr encodes the real `st_mode` and device numbers. Upstream's sender virtualises the stat via `get_stat_xattr()` (xattrs.c:1135) before itemizing, so the placeholder is reported as its true type (`cD`, `cS`). The protocol sender already mirrors this, but the **local-copy** path classified the placeholder from its on-disk `fs::FileType` and itemized it as a regular file (`>f` instead of `cD`) on both single-file-arg and recursive transfers.

## Changes

- **engine**: `LocalCopyMetadata::virtualize_fake_super` overrides the reported kind/mode from the source `%stat` when `--fake-super` is active and the snapshot describes a regular file whose xattr decodes to a non-regular type. Applied at the local-copy transfer and hard-link record sites. Reporting-only: routing, the on-disk placeholder, and the reconstructed destination are unchanged.
- **cli**: a virtualised placeholder is copied via the regular-file path (`DataCopied`), so the itemize update-type char is a local change (`c`, ITEM_LOCAL_CHANGE) rather than a data transfer (`>`/`<`), and the size column is never set for a non-regular entry (log.c:704-710).
- **engine**: `comparison::fake_super_stat_differs` compares the decoded `%stat` mode/rdev of a device/special source against the destination, so a device replacing another device (identical placeholder bytes, differing rdev) is transferred and itemized with `ITEM_REPORT_CHANGE`/`ITEM_REPORT_TIME` (`cDc.T.`) instead of being quick-check-skipped.

Regular placeholders and non-fake-super files keep the standard size+time comparison and `>f` itemize.

## Validation

Validated on Linux (aarch64) against upstream rsync 3.4.x, byte-for-byte:

- `devices-fake` upstream testsuite: **PASS** with oc-rsync as the primary binary (previously FAIL).
- `--fake-super` device placeholder now itemizes `cD+++++++++` on single-file-arg and recursive transfers, matching upstream.
- Received trees match upstream; `itemize` and `xattrs` testsuites still PASS; normal fake-super regular files and non-fake-super transfers unchanged (`>f`).
- New unit tests for `from_stat_mode`, `virtualize_fake_super`, plus `fmt`/`clippy -D warnings` clean on touched crates.