### PR TITLE
fix(transfer): report signal aborts as RERR_SIGNAL not per-file partial

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -290,7 +290,25 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
             let msg = rsync_error!(code.as_i32(), "{}", message).with_role(Role::Client);
             ClientError::with_code(code, msg)
         }
+        LocalCopyErrorKind::Interrupted => signal_interrupt_error(),
     }
+}
+
+/// Builds the single signal-abort diagnostic emitted when a transfer is
+/// interrupted by SIGINT/SIGTERM/SIGHUP.
+///
+/// upstream: `rsync.c:sig_int()` calls `exit_cleanup(RERR_SIGNAL)` (20), and
+/// `cleanup.c:_exit_cleanup()` routes it through `log.c:log_exit()`, which
+/// renders the fixed `rerr_names` entry for `RERR_SIGNAL` (log.c:95) as
+/// `rsync error: received SIGINT, SIGTERM, or SIGHUP (code 20) at ... [<role>]`.
+/// The three interrupt signals share one message; upstream never names the
+/// specific signal here. who_am_i() tags the sending half `[sender]`.
+#[cold]
+pub(crate) fn signal_interrupt_error() -> ClientError {
+    let code = ExitCode::Signal;
+    let message =
+        rsync_error!(code.as_i32(), "received SIGINT, SIGTERM, or SIGHUP").with_role(Role::Sender);
+    ClientError::with_code(code, message)
 }
 
 #[cold]
@@ -685,6 +703,36 @@ mod tests {
             let msg = client_error.to_string();
             assert!(msg.contains("link_stat \"/tmp/nope\" failed"), "{msg}");
             assert!(!msg.contains("file has vanished"), "{msg}");
+        }
+
+        /// upstream: rsync.c:sig_int -> exit_cleanup(RERR_SIGNAL) (20);
+        /// log.c:log_exit renders the fixed log.c:95 rerr_names entry
+        /// `received SIGINT, SIGTERM, or SIGHUP (code 20)` once, tagged with the
+        /// sending half's role. The per-file RERR_PARTIAL (23) must not leak
+        /// into the code shown, and the wording must not read "interrupted by
+        /// signal".
+        #[test]
+        fn map_interrupted_uses_signal_code_and_upstream_wording() {
+            let client_error = map_local_copy_error(LocalCopyError::interrupted());
+
+            assert_eq!(client_error.code(), ExitCode::Signal);
+            assert_eq!(client_error.exit_code(), 20);
+            let msg = client_error.to_string();
+            assert!(msg.contains("received SIGINT, SIGTERM, or SIGHUP"), "{msg}");
+            assert!(msg.contains("(code 20)"), "{msg}");
+            assert!(msg.contains("[sender="), "{msg}");
+            assert!(!msg.contains("interrupted by signal"), "{msg}");
+            assert!(!msg.contains("(code 23)"), "{msg}");
+        }
+
+        #[test]
+        fn signal_interrupt_error_matches_map_output() {
+            let direct = signal_interrupt_error();
+            assert_eq!(direct.code(), ExitCode::Signal);
+            assert_eq!(
+                direct.to_string(),
+                map_local_copy_error(LocalCopyError::interrupted()).to_string()
+            );
         }
 
         #[test]

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -76,7 +76,7 @@ impl<'a> CopyContext<'a> {
         let mut bytes_since_timeout_check: usize = 0;
 
         loop {
-            self.check_shutdown(destination)?;
+            self.check_shutdown()?;
             if bytes_since_timeout_check >= TIMEOUT_CHECK_INTERVAL {
                 self.enforce_timeout()?;
                 bytes_since_timeout_check = 0;

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -1,21 +1,19 @@
 impl<'a> CopyContext<'a> {
-    /// Returns an `Interrupted` error once a shutdown signal has been received.
+    /// Returns an interrupt-signal error once a shutdown signal has been
+    /// received.
     ///
     /// Polled inside the per-chunk copy loops so a large single-file transfer
     /// stops promptly mid-file. Unwinding then runs the destination guard's
     /// finalisation (moving the temp onto its `--partial`/`--partial-dir`
     /// destination) in normal, non-signal context. upstream: receiver.c's
     /// per-block loop checks for a pending signal via `io_flush`/`check_timeout`.
-    fn check_shutdown(&self, path: &Path) -> Result<(), LocalCopyError> {
+    ///
+    /// The abort is reported as [`LocalCopyError::interrupted`] (exit code 20,
+    /// `RERR_SIGNAL`), not a per-file `RERR_PARTIAL`, so the single diagnostic
+    /// matches upstream's `received SIGINT, SIGTERM, or SIGHUP (code 20)` line.
+    fn check_shutdown(&self) -> Result<(), LocalCopyError> {
         if fast_io::signal::shutdown_requested() {
-            return Err(LocalCopyError::io(
-                "copy file",
-                path,
-                io::Error::new(
-                    io::ErrorKind::Interrupted,
-                    "transfer interrupted by signal",
-                ),
-            ));
+            return Err(LocalCopyError::interrupted());
         }
         Ok(())
     }
@@ -594,7 +592,7 @@ impl<'a> CopyContext<'a> {
             if total_bytes >= expected_remaining {
                 break;
             }
-            self.check_shutdown(destination)?;
+            self.check_shutdown()?;
             if bytes_since_timeout_check >= TIMEOUT_CHECK_INTERVAL {
                 self.enforce_timeout()?;
                 bytes_since_timeout_check = 0;
@@ -702,7 +700,7 @@ impl<'a> CopyContext<'a> {
             if total_bytes >= expected_remaining {
                 break;
             }
-            self.check_shutdown(destination)?;
+            self.check_shutdown()?;
             if bytes_since_timeout_check >= TIMEOUT_CHECK_INTERVAL {
                 self.enforce_timeout()?;
                 bytes_since_timeout_check = 0;

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, SystemTime};
 use thiserror::Error;
 
 use super::filter_program::{
-    INVALID_OPERAND_EXIT_CODE, MAX_DELETE_EXIT_CODE, MISSING_OPERANDS_EXIT_CODE, TIMEOUT_EXIT_CODE,
-    VANISHED_EXIT_CODE,
+    INVALID_OPERAND_EXIT_CODE, MAX_DELETE_EXIT_CODE, MISSING_OPERANDS_EXIT_CODE, SIGNAL_EXIT_CODE,
+    TIMEOUT_EXIT_CODE, VANISHED_EXIT_CODE,
 };
 
 /// Formats an [`io::Error`] the way upstream rsync's `rsyserr()` does:
@@ -105,6 +105,21 @@ impl LocalCopyError {
         })
     }
 
+    /// Constructs an error representing an interrupt-signal abort (exit code
+    /// 20, `RERR_SIGNAL`).
+    ///
+    /// Raised when the per-chunk copy loop observes a pending SIGINT/SIGTERM/
+    /// SIGHUP and stops mid-file so the destination guard can finalise its
+    /// `--partial` file during normal unwinding.
+    ///
+    /// upstream: `rsync.c:sig_int()` calls `exit_cleanup(RERR_SIGNAL)`, which
+    /// `log.c:log_exit()` renders as `received SIGINT, SIGTERM, or SIGHUP`
+    /// (the fixed `rerr_names` entry for `RERR_SIGNAL`, log.c:95).
+    #[must_use]
+    pub const fn interrupted() -> Self {
+        Self::new(LocalCopyErrorKind::Interrupted)
+    }
+
     /// Constructs a partial-transfer error (exit code 23, `RERR_PARTIAL`).
     ///
     /// Raised at the end of a copy that skipped one or more entries without a
@@ -172,6 +187,7 @@ impl LocalCopyError {
             LocalCopyErrorKind::DeleteLimitExceeded { .. } => MAX_DELETE_EXIT_CODE,
             LocalCopyErrorKind::FilterSyntax { .. } => MISSING_OPERANDS_EXIT_CODE,
             LocalCopyErrorKind::PartialTransfer => INVALID_OPERAND_EXIT_CODE,
+            LocalCopyErrorKind::Interrupted => SIGNAL_EXIT_CODE,
         }
     }
 
@@ -197,6 +213,7 @@ impl LocalCopyError {
             LocalCopyErrorKind::DeleteLimitExceeded { .. } => "RERR_DEL_LIMIT",
             LocalCopyErrorKind::FilterSyntax { .. } => "RERR_SYNTAX",
             LocalCopyErrorKind::PartialTransfer => "RERR_PARTIAL",
+            LocalCopyErrorKind::Interrupted => "RERR_SIGNAL",
         }
     }
 
@@ -329,6 +346,14 @@ pub enum LocalCopyErrorKind {
     /// (see previous errors)` when `io_error` is set at exit.
     #[error("some files/attrs were not transferred (see previous errors)")]
     PartialTransfer,
+    /// The transfer was aborted by an interrupt signal (SIGINT/SIGTERM/SIGHUP),
+    /// exiting `RERR_SIGNAL` (20). The copy loop stopped mid-file so the
+    /// destination guard could finalise its `--partial` file.
+    ///
+    /// upstream: `log.c:95` maps `RERR_SIGNAL` to the fixed diagnostic
+    /// `received SIGINT, SIGTERM, or SIGHUP`, emitted once by `log.c:log_exit()`.
+    #[error("received SIGINT, SIGTERM, or SIGHUP")]
+    Interrupted,
 }
 
 impl LocalCopyErrorKind {
@@ -482,6 +507,20 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("read"));
         assert!(message.contains("/test/file.txt"));
+    }
+
+    #[test]
+    fn local_copy_error_interrupted_is_signal_exit() {
+        // upstream: rsync.c:sig_int -> exit_cleanup(RERR_SIGNAL) (20); the
+        // diagnostic is log.c:95's fixed `received SIGINT, SIGTERM, or SIGHUP`,
+        // not a per-file RERR_PARTIAL (23).
+        let error = LocalCopyError::interrupted();
+        assert_eq!(error.exit_code(), SIGNAL_EXIT_CODE);
+        assert_eq!(error.exit_code(), 20);
+        assert_eq!(error.code_name(), "RERR_SIGNAL");
+        assert_eq!(error.to_string(), "received SIGINT, SIGTERM, or SIGHUP");
+        assert!(matches!(error.kind(), LocalCopyErrorKind::Interrupted));
+        assert!(!error.is_io_error());
     }
 
     #[test]

--- a/crates/engine/src/local_copy/filter_program/mod.rs
+++ b/crates/engine/src/local_copy/filter_program/mod.rs
@@ -16,7 +16,7 @@ pub use options::{DirMergeEnforcedKind, DirMergeOptions};
 #[cfg_attr(not(test), allow(unused_imports))]
 pub(crate) use program::{
     CONNECTION_TIMEOUT_EXIT_CODE, INVALID_OPERAND_EXIT_CODE, MAX_DELETE_EXIT_CODE,
-    MISSING_OPERANDS_EXIT_CODE, TIMEOUT_EXIT_CODE, VANISHED_EXIT_CODE,
+    MISSING_OPERANDS_EXIT_CODE, SIGNAL_EXIT_CODE, TIMEOUT_EXIT_CODE, VANISHED_EXIT_CODE,
 };
 pub use program::{FilterProgram, FilterProgramEntry, FilterProgramError};
 

--- a/crates/engine/src/local_copy/filter_program/program.rs
+++ b/crates/engine/src/local_copy/filter_program/program.rs
@@ -25,6 +25,13 @@ pub(crate) const INVALID_OPERAND_EXIT_CODE: i32 = 23;
 /// Maps to upstream rsync's `RERR_SYNTAX` (1) and `core::exit_code::ExitCode::Syntax`.
 pub(crate) const MISSING_OPERANDS_EXIT_CODE: i32 = 1;
 
+/// Exit code returned when the transfer is aborted by SIGINT/SIGTERM/SIGHUP.
+///
+/// Maps to upstream rsync's `RERR_SIGNAL` (20) and `core::exit_code::ExitCode::Signal`.
+/// upstream: cleanup.c:_exit_cleanup exits with `RERR_SIGNAL` after finalising
+/// partials when `sig_int` (rsync.c) requests a controlled shutdown.
+pub(crate) const SIGNAL_EXIT_CODE: i32 = 20;
+
 /// Exit code returned when the transfer exceeds the configured timeout.
 ///
 /// Maps to upstream rsync's `RERR_TIMEOUT` (30) and `core::exit_code::ExitCode::Timeout`.


### PR DESCRIPTION
## Problem

On SIGINT/SIGTERM/SIGHUP during a transfer, the per-chunk copy loop stopped
mid-file and surfaced the abort as a per-file I/O error. This rendered:

```
oc-rsync error: failed to copy file '<path>': transfer interrupted by signal (code 23) at ... [sender=...]
```

Two defects:

1. **Wrong code** - the line showed `(code 23)` (`RERR_PARTIAL`) while the
   process correctly exited `20` (`RERR_SIGNAL`), so the printed code
   contradicted the real exit code.
2. **Wrong wording** - `interrupted by signal` instead of the upstream
   signal-exit diagnostic.

## Upstream behaviour

`rsync.c:sig_int()` calls `exit_cleanup(RERR_SIGNAL)` (20). `cleanup.c:_exit_cleanup()`
finalises partials and routes the code through `log.c:log_exit()`, which prints
the fixed `rerr_names` entry for `RERR_SIGNAL` (`log.c:95`):

```
rsync error: received SIGINT, SIGTERM, or SIGHUP (code 20) at rsync.c(716) [sender=...]
```

The three interrupt signals share one message; upstream never names the
specific signal here, and the shown code equals the exit code (20).

## Fix

- Add `LocalCopyError::interrupted()` - a dedicated `RERR_SIGNAL` (20) error.
- `check_shutdown()` returns it instead of an `ErrorKind::Interrupted` I/O error.
- `map_local_copy_error()` routes it through a new `signal_interrupt_error()`
  that reuses the existing error-format machinery with the `[sender]` role.

Text only: the partial-file finalisation, the process exit code, and normal
(uninterrupted) transfers are all unchanged. One signal-exit line, no
double-report.

## Validation (aarch64 Linux, vs upstream 3.4.3-149)

SIGTERM / SIGINT / SIGHUP mid-transfer, `-a --partial --bwlimit`:

| | line body | code | exit | partial |
|---|---|---|---|---|
| upstream | `received SIGINT, SIGTERM, or SIGHUP` | 20 | 20 | lands |
| oc (after) | `received SIGINT, SIGTERM, or SIGHUP` | 20 | 20 | lands |

Message body and code now match upstream byte-for-byte. The prefix
(`oc-rsync error:`), source location, and version are the project's uniform
conventions applied to every diagnostic line.

`cargo fmt --all --check`, `cargo clippy -p engine -p core -p cli
--all-targets --all-features --no-deps -D warnings`, and a release build all
pass. `engine`/`core`/`cli` remain unsafe-free.
