### PR TITLE
fix(filters): honor receiver-side, exclude and perishable rules in --delete

### DIFF
--- a/crates/engine/src/local_copy/filter_program/segments.rs
+++ b/crates/engine/src/local_copy/filter_program/segments.rs
@@ -82,6 +82,13 @@ impl FilterSegment {
         // deletion-only descendant matchers; the Transfer path must NOT see
         // those (it would re-trip the #6015 `foo/*/` over-exclusion).
         let for_deletion = matches!(context, FilterContext::Deletion);
+        // upstream: exclude.c:1044 check_filter() only skips a perishable rule
+        // when `ignore_perishable` is set, which happens exclusively while
+        // deleting the contents of a directory being wholly removed
+        // (delete.c:147). The top-level delete scan runs with it unset, so a
+        // perishable rule still matches and protects a candidate here; the
+        // wholly-deleted-directory case never reaches this evaluator because
+        // the local-copy delete pass removes such directories en masse.
         let rule_matches = |rule: &CompiledRule, path: &Path, is_dir: bool| {
             if for_deletion {
                 rule.matches_for_deletion(path, is_dir, check_descendants)
@@ -96,9 +103,6 @@ impl FilterSegment {
             if rule_matches(rule, path, is_dir) {
                 if matches!(context, FilterContext::Deletion) && rule.applies_to_receiver {
                     outcome.set_delete_excluded(matches!(rule.action, FilterAction::Exclude));
-                }
-                if matches!(context, FilterContext::Deletion) && rule.perishable {
-                    continue;
                 }
                 match context {
                     FilterContext::Transfer => {
@@ -128,9 +132,6 @@ impl FilterSegment {
             // overwrite it (last-match-wins).
             if outcome.protection_decided() {
                 break;
-            }
-            if matches!(context, FilterContext::Deletion) && rule.perishable {
-                continue;
             }
             if rule_matches(rule, path, is_dir) {
                 let applies = match context {
@@ -305,7 +306,6 @@ struct CompiledRule {
     deletion_descendant_matchers: Vec<GlobMatcher>,
     applies_to_sender: bool,
     applies_to_receiver: bool,
-    perishable: bool,
     /// upstream: exclude.c:906 - `ret_match = ex->rflags & FILTRULE_NEGATE ? 0 : 1`.
     /// When set, the rule fires on paths that do NOT match the pattern.
     negate: bool,
@@ -384,7 +384,6 @@ impl CompiledRule {
             deletion_descendant_matchers: compile_patterns(deletion_descendant_patterns, &pattern)?,
             applies_to_sender,
             applies_to_receiver,
-            perishable: rule.is_perishable(),
             negate,
             pattern,
         })

--- a/crates/engine/src/local_copy/filter_program_internal_tests.rs
+++ b/crates/engine/src/local_copy/filter_program_internal_tests.rs
@@ -119,7 +119,7 @@ fn filter_segment_apply_updates_transfer_and_deletion_outcomes() {
 }
 
 #[test]
-fn perishable_rules_are_ignored_for_deletion_context() {
+fn perishable_rules_protect_top_level_deletion_context() {
     let mut segment = FilterSegment::default();
     segment
         .push_rule(FilterRule::exclude("*.tmp").with_perishable(true))
@@ -134,6 +134,9 @@ fn perishable_rules_are_ignored_for_deletion_context() {
     );
     assert!(!transfer.allows_transfer());
 
+    // upstream: exclude.c:1044 / delete.c:147 - the top-level delete scan runs
+    // with `ignore_perishable` unset, so a perishable exclude protects a
+    // matching candidate just like a plain exclude.
     let mut deletion = FilterOutcome::default();
     segment.apply(
         Path::new("note.tmp"),
@@ -141,7 +144,7 @@ fn perishable_rules_are_ignored_for_deletion_context() {
         &mut deletion,
         FilterContext::Deletion,
     );
-    assert!(deletion.allows_deletion());
+    assert!(!deletion.allows_deletion());
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_filter_program.rs
+++ b/crates/engine/src/local_copy/tests/execute_filter_program.rs
@@ -847,7 +847,7 @@ fn filter_segment_delete_excluded_protected_path() {
 }
 
 #[test]
-fn filter_segment_perishable_exclude_ignored_in_deletion() {
+fn filter_segment_perishable_exclude_protects_top_level_deletion() {
     let mut segment = FilterSegment::default();
     segment
         .push_rule(FilterRule::exclude("*.tmp").with_perishable(true))
@@ -866,7 +866,9 @@ fn filter_segment_perishable_exclude_ignored_in_deletion() {
         "perishable exclude must block transfer"
     );
 
-    // Deletion: perishable rules are skipped.
+    // Deletion: the top-level scan runs with `ignore_perishable` unset
+    // (upstream exclude.c:1044 / delete.c:147), so a perishable exclude
+    // protects a matching candidate just like a plain exclude.
     let mut deletion_outcome = FilterOutcome::default();
     segment.apply(
         Path::new("data.tmp"),
@@ -875,13 +877,13 @@ fn filter_segment_perishable_exclude_ignored_in_deletion() {
         FilterContext::Deletion,
     );
     assert!(
-        deletion_outcome.allows_deletion(),
-        "perishable exclude must be ignored in deletion context"
+        !deletion_outcome.allows_deletion(),
+        "perishable exclude must protect a matching entry from deletion"
     );
 }
 
 #[test]
-fn filter_segment_perishable_protect_ignored_in_deletion() {
+fn filter_segment_perishable_protect_applies_in_deletion() {
     let mut segment = FilterSegment::default();
     segment
         .push_rule(FilterRule::protect("*.tmp").with_perishable(true))
@@ -894,11 +896,11 @@ fn filter_segment_perishable_protect_ignored_in_deletion() {
         &mut outcome,
         FilterContext::Deletion,
     );
-    // Perishable protect should be skipped in deletion context, so the path
-    // remains deletable.
+    // A perishable protect is honoured at the top-level delete scan (upstream
+    // exclude.c:1044 / delete.c:147), so the path is protected.
     assert!(
-        outcome.allows_deletion(),
-        "perishable protect must be skipped in deletion context"
+        !outcome.allows_deletion(),
+        "perishable protect must protect a matching entry from deletion"
     );
 }
 

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -21,7 +21,11 @@ impl FilterSetInner {
     ///
     /// The evaluation context determines which side's rules are consulted:
     /// - `Transfer` checks sender-side include/exclude rules.
-    /// - `Deletion` checks receiver-side rules with perishable rules excluded.
+    /// - `Deletion` checks receiver-side rules. Perishable rules are honoured
+    ///   here because the top-level delete scan runs with `ignore_perishable`
+    ///   unset (upstream delete.c:147); they are only skipped inside a
+    ///   directory being wholly removed, which the receiver deletes en masse
+    ///   without re-filtering.
     ///
     /// upstream: exclude.c:check_filter()
     pub(crate) fn decision(
@@ -86,7 +90,7 @@ impl FilterSetInner {
                 path,
                 is_dir,
                 |rule| rule.applies_to_receiver,
-                false,
+                true,
                 check_descendants,
                 true,
             ),
@@ -146,7 +150,7 @@ impl FilterSetInner {
                 path,
                 is_dir,
                 |rule| rule.applies_to_receiver,
-                false,
+                true,
                 check_descendants,
                 true,
             ),
@@ -189,7 +193,12 @@ impl FilterSetInner {
             DecisionContext::Transfer => |rule| rule.applies_to_sender,
             DecisionContext::Deletion => |rule| rule.applies_to_receiver,
         };
-        let include_perishable = matches!(context, DecisionContext::Transfer);
+        // upstream: exclude.c:1044 check_filter() only skips perishable rules
+        // when `ignore_perishable` is set, which happens exclusively inside a
+        // directory being wholly deleted (delete.c:147). The receiver's
+        // top-level delete scan runs with `ignore_perishable == 0`, so a
+        // perishable rule still matches (and therefore protects) a candidate.
+        let include_perishable = true;
         let for_deletion = matches!(context, DecisionContext::Deletion);
         if first_matching_rule(
             &self.include_exclude,
@@ -292,9 +301,10 @@ where
 
 /// Whether a filter evaluation is for the transfer or deletion phase.
 ///
-/// Transfer checks use sender-side rules and include perishable rules.
-/// Deletion checks use receiver-side rules and skip perishable rules,
-/// matching upstream rsync's `--delete` semantics.
+/// Transfer checks use sender-side rules; Deletion checks use receiver-side
+/// rules. Both honour perishable rules: the top-level delete scan runs with
+/// upstream's `ignore_perishable` unset (delete.c:147), so a perishable rule
+/// still protects a matching destination entry from `--delete`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum DecisionContext {
     Transfer,

--- a/crates/filters/src/tests.rs
+++ b/crates/filters/src/tests.rs
@@ -163,13 +163,56 @@ fn protect_rule_blocks_deletion_without_affecting_transfer() {
 }
 
 #[test]
-fn perishable_rule_ignored_for_deletion_checks() {
+fn perishable_rule_protects_from_deletion_at_top_level() {
+    // upstream: exclude.c:1044 check_filter() only skips perishable rules when
+    // `ignore_perishable` is set (delete.c:147), which happens exclusively
+    // inside a directory being wholly deleted. The top-level delete scan runs
+    // with it unset, so a perishable exclude protects a matching destination
+    // entry from `--delete` exactly like a plain exclude. `--delete-excluded`
+    // still removes it.
     let rule = FilterRule::exclude("*.tmp").with_perishable(true);
     let set = FilterSet::from_rules([rule]).expect("compiled");
 
     assert!(!set.allows(Path::new("note.tmp"), false));
-    assert!(set.allows_deletion(Path::new("note.tmp"), false));
+    assert!(!set.allows_deletion(Path::new("note.tmp"), false));
     assert!(set.allows_deletion_when_excluded_removed(Path::new("note.tmp"), false));
+}
+
+/// Regression (D2): a plain exclude that matches a destination entry protects
+/// it from `--delete`, mirroring upstream generator.c:delete_in_dir() where an
+/// excluded name never enters the get_dirlist() candidate set. It is still
+/// excluded from transfer on the sender side.
+#[test]
+fn plain_exclude_protects_matching_dest_from_deletion() {
+    let set = FilterSet::from_rules([FilterRule::exclude("drop.txt")]).expect("compiled");
+    assert!(!set.allows(Path::new("drop.txt"), false));
+    assert!(!set.allows_deletion(Path::new("drop.txt"), false));
+    // An unmatched extraneous entry is still deletable (upstream parity: only
+    // filter-matched names are protected).
+    assert!(set.allows_deletion(Path::new("extra.txt"), false));
+}
+
+/// Regression (D1): a receiver-side (`r`) rule affects DELETION only. Upstream
+/// rsync.1.md:4191-4206 - a receiver-side rule must not exclude a file from the
+/// transfer, but it does protect a matching destination entry from `--delete`.
+#[test]
+fn receiver_side_rule_gates_deletion_not_transfer() {
+    let set = FilterSet::from_rules([FilterRule::exclude("drop.txt").with_sides(false, true)])
+        .expect("compiled");
+    // Transfer: receiver-side rule is inert on the sender, so the file transfers.
+    assert!(set.allows(Path::new("drop.txt"), false));
+    // Deletion: the receiver-side rule protects the matching dest entry.
+    assert!(!set.allows_deletion(Path::new("drop.txt"), false));
+}
+
+/// Counterpart of the above (regression guard): a sender-side (`s`) rule
+/// excludes from transfer but does NOT protect the dest entry from `--delete`.
+#[test]
+fn sender_side_rule_gates_transfer_not_deletion() {
+    let set = FilterSet::from_rules([FilterRule::exclude("drop.txt").with_sides(true, false)])
+        .expect("compiled");
+    assert!(!set.allows(Path::new("drop.txt"), false));
+    assert!(set.allows_deletion(Path::new("drop.txt"), false));
 }
 
 #[test]

--- a/crates/filters/tests/apple_double.rs
+++ b/crates/filters/tests/apple_double.rs
@@ -106,13 +106,15 @@ fn explicit_include_overrides_apple_double() {
     assert!(!set.allows(Path::new("._other"), false));
 }
 
-/// Perishable rules continue to apply during transfers but are skipped during
-/// deletion passes, matching `--cvs-exclude` semantics.
+/// Perishable rules apply during transfers and also protect a matching entry
+/// from the top-level `--delete` scan, matching `--cvs-exclude` semantics
+/// (upstream exclude.c:1044 only skips perishable rules once `ignore_perishable`
+/// is set inside a wholly-deleted directory, delete.c:147).
 #[test]
-fn perishable_rules_skip_deletion_pass() {
+fn perishable_rules_protect_top_level_deletion() {
     let set = FilterSet::from_rules_with_apple_double(Vec::<FilterRule>::new(), true).unwrap();
     assert!(!set.allows(Path::new("._notes.txt"), false));
-    assert!(set.allows_deletion(Path::new("._notes.txt"), false));
+    assert!(!set.allows_deletion(Path::new("._notes.txt"), false));
 }
 
 /// Non-perishable rules apply to both transfer and deletion passes.

--- a/crates/filters/tests/complex_combinations.rs
+++ b/crates/filters/tests/complex_combinations.rs
@@ -331,11 +331,11 @@ fn perishable_exclude_with_protect() {
     assert!(!set.allows(Path::new("temp/scratch.txt"), false));
     assert!(!set.allows(Path::new("temp/keep/important.txt"), false));
 
-    // For deletion: perishable exclude ignored
-    // temp/scratch: no protection, deletable
-    assert!(set.allows_deletion(Path::new("temp/scratch.txt"), false));
+    // For deletion: the top-level scan runs with `ignore_perishable` unset
+    // (upstream delete.c:147), so the perishable exclude protects temp/scratch.
+    assert!(!set.allows_deletion(Path::new("temp/scratch.txt"), false));
 
-    // temp/keep: protected, not deletable
+    // temp/keep: protected by both the exclude and the protect rule.
     assert!(!set.allows_deletion(Path::new("temp/keep/important.txt"), false));
 }
 

--- a/crates/filters/tests/cvs_exclude.rs
+++ b/crates/filters/tests/cvs_exclude.rs
@@ -300,7 +300,8 @@ fn complex_explicit_rules_with_cvs() {
     assert!(!set.allows(Path::new(".git/config"), false));
 }
 
-/// Verifies perishable CVS rules affect transfer but not deletion.
+/// Verifies perishable CVS rules affect transfer and also protect a matching
+/// entry from the top-level `--delete` scan.
 #[test]
 fn perishable_cvs_rules_transfer_vs_deletion() {
     let set = FilterSet::from_rules_with_cvs(vec![], true).unwrap();
@@ -309,9 +310,12 @@ fn perishable_cvs_rules_transfer_vs_deletion() {
     assert!(!set.allows(Path::new("main.o"), false));
     assert!(!set.allows(Path::new("file.bak"), false));
 
-    // Deletion: perishable rules ignored, defaults to allow
-    assert!(set.allows_deletion(Path::new("main.o"), false));
-    assert!(set.allows_deletion(Path::new("file.bak"), false));
+    // Deletion: the top-level scan runs with `ignore_perishable` unset
+    // (upstream delete.c:147), so perishable CVS rules protect a matching
+    // destination entry from `--delete` exactly like `--cvs-exclude --delete`
+    // preserves a pre-existing `*.o` at the transfer root.
+    assert!(!set.allows_deletion(Path::new("main.o"), false));
+    assert!(!set.allows_deletion(Path::new("file.bak"), false));
 }
 
 /// Verifies non-perishable CVS rules affect both transfer and deletion.

--- a/crates/filters/tests/cvs_patterns_advanced.rs
+++ b/crates/filters/tests/cvs_patterns_advanced.rs
@@ -255,14 +255,17 @@ fn cvs_with_wildcard_exclude() {
 }
 
 #[test]
-fn perishable_cvs_ignored_for_deletion_context() {
+fn perishable_cvs_protects_deletion_context() {
     let set = FilterSet::from_rules_with_cvs(vec![], true).unwrap();
 
     // For transfer (sender context): perishable patterns apply
     assert!(!set.allows(Path::new("main.o"), false));
 
-    // For deletion (receiver context): perishable patterns ignored
-    assert!(set.allows_deletion(Path::new("main.o"), false));
+    // For deletion (receiver context): the top-level scan runs with
+    // `ignore_perishable` unset (upstream exclude.c:1044 / delete.c:147), so
+    // perishable CVS patterns protect a matching entry - `--cvs-exclude
+    // --delete` preserves a pre-existing `*.o` at the transfer root.
+    assert!(!set.allows_deletion(Path::new("main.o"), false));
 }
 
 #[test]
@@ -284,7 +287,7 @@ fn perishable_cvs_with_explicit_protect() {
     // Transfer: excluded by perishable CVS
     assert!(!set.allows(Path::new("main.o"), false));
 
-    // Deletion: perishable ignored, but protected
+    // Deletion: protected by the explicit protect rule
     assert!(!set.allows_deletion(Path::new("main.o"), false));
 }
 
@@ -311,7 +314,8 @@ fn perishable_cvs_delete_excluded_behavior() {
     // Transfer: .o excluded
     assert!(!set.allows(Path::new("main.o"), false));
 
-    // Delete-excluded: should allow (perishable ignored)
+    // Delete-excluded removes an excluded entry: the excluded-removed decision
+    // already considers perishable rules, so `--delete-excluded` clears it.
     assert!(set.allows_deletion_when_excluded_removed(Path::new("main.o"), false));
 }
 

--- a/crates/filters/tests/filter_precedence.rs
+++ b/crates/filters/tests/filter_precedence.rs
@@ -454,7 +454,8 @@ fn perishable_in_precedence() {
     // Other files: excluded from transfer (perishable exclude matches)
     assert!(!set.allows(Path::new("other.txt"), false));
 
-    // For deletion: perishable exclude is skipped, so no rule matches,
-    // defaults to include (transfer_allowed = true), so deletable
-    assert!(set.allows_deletion(Path::new("other.txt"), false));
+    // For deletion: the top-level scan runs with `ignore_perishable` unset
+    // (upstream delete.c:147), so the perishable exclude `*` matches and
+    // protects other.txt from --delete.
+    assert!(!set.allows_deletion(Path::new("other.txt"), false));
 }

--- a/crates/filters/tests/filter_rule_syntax.rs
+++ b/crates/filters/tests/filter_rule_syntax.rs
@@ -1137,15 +1137,17 @@ mod rule_ordering {
     }
 
     #[test]
-    fn perishable_rules_skipped_for_deletion() {
+    fn perishable_rules_protect_top_level_deletion() {
         let rules = parse_rules("-p *.tmp\n+ keep/**", Path::new("test")).unwrap();
         let set = FilterSet::from_rules(rules).unwrap();
 
         // Transfer: perishable exclude applies
         assert!(!set.allows(Path::new("file.tmp"), false));
 
-        // Deletion: perishable exclude skipped, defaults to allow
-        assert!(set.allows_deletion(Path::new("file.tmp"), false));
+        // Deletion: the top-level scan runs with `ignore_perishable` unset
+        // (upstream exclude.c:1044 / delete.c:147), so the perishable exclude
+        // protects a matching entry exactly like a plain exclude.
+        assert!(!set.allows_deletion(Path::new("file.tmp"), false));
     }
 }
 

--- a/crates/filters/tests/perishable_rules.rs
+++ b/crates/filters/tests/perishable_rules.rs
@@ -1,29 +1,30 @@
 //! Integration tests for perishable filter rules.
 //!
-//! These tests verify the behavior of perishable rules (`p` modifier) which
-//! are ignored during deletion checks. Perishable rules are useful for
-//! excluding files that should be skipped during transfer but not protected
-//! from deletion during `--delete` operations.
-//!
-//! Reference: rsync 3.4.1 exclude.c lines 1044-1045 for perishable handling.
+//! Perishable rules (`p` modifier) are excluded from transfer like any other
+//! rule and ALSO protect a matching destination entry from the top-level
+//! `--delete` scan. Upstream rsync only skips a perishable rule once
+//! `ignore_perishable` is set (exclude.c:1044), which happens exclusively
+//! while removing the contents of a directory being deleted wholesale
+//! (delete.c:147); the top-level scan runs with it unset, so perishable rules
+//! behave identically to non-perishable rules for the deletion decision.
 
 use filters::{FilterRule, FilterSet};
 use std::path::Path;
 
-/// Verifies perishable exclude is ignored during deletion checks.
+/// Verifies a perishable exclude protects a matching entry from deletion.
 ///
-/// From rsync man page: "The p is for perishable, which means that this
-/// rule does not apply during deletion."
+/// upstream: exclude.c:1044 / delete.c:147 - a perishable rule is only skipped
+/// inside a wholly-deleted directory, never during the top-level scan.
 #[test]
-fn perishable_exclude_ignored_during_deletion() {
+fn perishable_exclude_protects_during_top_level_deletion() {
     let rule = FilterRule::exclude("*.tmp").with_perishable(true);
     let set = FilterSet::from_rules([rule]).unwrap();
 
     // Transfer is excluded (perishable still applies to transfer)
     assert!(!set.allows(Path::new("scratch.tmp"), false));
 
-    // Deletion is allowed (perishable is ignored)
-    assert!(set.allows_deletion(Path::new("scratch.tmp"), false));
+    // Deletion is blocked: the perishable exclude protects like a plain exclude.
+    assert!(!set.allows_deletion(Path::new("scratch.tmp"), false));
 }
 
 /// Verifies non-perishable rules work normally.
@@ -48,9 +49,9 @@ fn perishable_flag_tracked() {
     assert!(!non_perishable.is_perishable());
 }
 
-/// Verifies perishable include is ignored during deletion.
+/// Verifies a perishable include is honoured during deletion (first-match-wins).
 #[test]
-fn perishable_include_ignored_during_deletion() {
+fn perishable_include_honoured_during_deletion() {
     // With first-match-wins, include comes before exclude
     let rules = [
         FilterRule::include("keep/**").with_perishable(true),
@@ -61,9 +62,9 @@ fn perishable_include_ignored_during_deletion() {
     // Transfer includes keep/** (perishable include applies first)
     assert!(set.allows(Path::new("keep/file.txt"), false));
 
-    // Deletion: perishable include is ignored, so exclude * applies
-    // This means the file can be deleted
-    assert!(!set.allows_deletion(Path::new("keep/file.txt"), false));
+    // Deletion: the perishable include matches first, so the entry is included
+    // (not excluded) and therefore a deletion candidate.
+    assert!(set.allows_deletion(Path::new("keep/file.txt"), false));
 }
 
 /// Verifies perishable and non-perishable includes interact correctly.
@@ -84,8 +85,9 @@ fn perishable_and_non_perishable_includes() {
     // For deletion: permanent/** matches (non-perishable), deletable
     assert!(set.allows_deletion(Path::new("permanent/file.txt"), false));
 
-    // For temporary: perishable include is skipped, exclude * matches, transfer_allowed=false
-    assert!(!set.allows_deletion(Path::new("temporary/file.txt"), false));
+    // For temporary: the perishable include matches first, so the entry is
+    // included and remains a deletion candidate.
+    assert!(set.allows_deletion(Path::new("temporary/file.txt"), false));
 }
 
 /// Verifies perishable affects delete-excluded behavior.
@@ -120,8 +122,8 @@ fn perishable_exclude_before_include() {
 
     // Temp txt files excluded from transfer (perishable applies on sender first)
     assert!(!set.allows(Path::new("temp_scratch.txt"), false));
-    // For deletion: perishable exclude skipped, include *.txt matches, deletable
-    assert!(set.allows_deletion(Path::new("temp_scratch.txt"), false));
+    // For deletion: the perishable exclude matches first and protects the entry.
+    assert!(!set.allows_deletion(Path::new("temp_scratch.txt"), false));
 
     // Regular txt files included in transfer (second rule)
     assert!(set.allows(Path::new("document.txt"), false));
@@ -146,8 +148,10 @@ fn non_perishable_exclude_before_perishable_include() {
     // Regular txt files included in transfer (second rule)
     assert!(set.allows(Path::new("document.txt"), false));
 
-    // But deletion: perishable include is ignored, so exclude * applies
-    assert!(!set.allows_deletion(Path::new("document.txt"), false));
+    // Deletion: the perishable include *.txt matches first, so the entry is
+    // included and remains a deletion candidate (the catch-all exclude never
+    // fires).
+    assert!(set.allows_deletion(Path::new("document.txt"), false));
 }
 
 /// Verifies perishable with directory pattern.
@@ -160,9 +164,9 @@ fn perishable_directory_pattern() {
     assert!(!set.allows(Path::new("cache"), true));
     assert!(!set.allows(Path::new("cache/file.dat"), false));
 
-    // But deletable
-    assert!(set.allows_deletion(Path::new("cache"), true));
-    assert!(set.allows_deletion(Path::new("cache/file.dat"), false));
+    // And protected from deletion (perishable exclude behaves like a plain one).
+    assert!(!set.allows_deletion(Path::new("cache"), true));
+    assert!(!set.allows_deletion(Path::new("cache/file.dat"), false));
 }
 
 /// Verifies perishable with nested directory patterns.
@@ -178,8 +182,9 @@ fn perishable_nested_directory() {
     assert!(!set.allows(Path::new("build/debug/file"), false));
     assert!(!set.allows(Path::new("build/release/binary"), false));
 
-    // Debug is deletable (perishable parent), release is not (non-perishable)
-    assert!(set.allows_deletion(Path::new("build/debug/file"), false));
+    // Both protected from deletion: the perishable `build/` exclude matches
+    // first for either path (its descendants) and protects them.
+    assert!(!set.allows_deletion(Path::new("build/debug/file"), false));
     assert!(!set.allows_deletion(Path::new("build/release/binary"), false));
 }
 
@@ -198,9 +203,9 @@ fn perishable_with_protect() {
     // Protected from deletion (protect applies regardless of perishable)
     assert!(!set.allows_deletion(Path::new("important.tmp"), false));
 
-    // Other tmp files excluded and deletable
+    // Other tmp files are excluded and now protected too (perishable exclude).
     assert!(!set.allows(Path::new("scratch.tmp"), false));
-    assert!(set.allows_deletion(Path::new("scratch.tmp"), false));
+    assert!(!set.allows_deletion(Path::new("scratch.tmp"), false));
 }
 
 /// Verifies perishable interacts correctly with risk.
@@ -218,8 +223,10 @@ fn perishable_with_risk() {
     assert!(!set.allows(Path::new("archive/current/file"), false));
     assert!(!set.allows(Path::new("archive/old/file"), false));
 
-    // Old is at risk (first protection rule matched), current is protected (second)
-    assert!(set.allows_deletion(Path::new("archive/old/file"), false));
+    // Deletion: the perishable `archive/` exclude now matches first for both
+    // paths, so the include/exclude chain reports them excluded and they are
+    // protected regardless of the risk/protect ordering.
+    assert!(!set.allows_deletion(Path::new("archive/old/file"), false));
     assert!(!set.allows_deletion(Path::new("archive/current/file"), false));
 }
 
@@ -234,7 +241,8 @@ fn perishable_sender_only() {
     // Excluded from transfer (sender side)
     assert!(!set.allows(Path::new("file.tmp"), false));
 
-    // Deletable (no receiver rule, and perishable anyway)
+    // Deletable: the rule is sender-only, so it never applies to the receiver's
+    // delete pass.
     assert!(set.allows_deletion(Path::new("file.tmp"), false));
 }
 
@@ -249,8 +257,8 @@ fn perishable_receiver_only() {
     // Transfer allowed (no sender rule)
     assert!(set.allows(Path::new("file.tmp"), false));
 
-    // Deletion: perishable is ignored, so file is deletable
-    assert!(set.allows_deletion(Path::new("file.tmp"), false));
+    // Deletion: the receiver-side perishable exclude matches and protects.
+    assert!(!set.allows_deletion(Path::new("file.tmp"), false));
 }
 
 /// Verifies clear removes perishable rules.
@@ -279,9 +287,9 @@ fn perishable_after_clear() {
     // Old rule cleared
     assert!(set.allows(Path::new("file.old"), false));
 
-    // New perishable rule works
+    // New perishable rule works: excluded from transfer and protected from delete.
     assert!(!set.allows(Path::new("file.tmp"), false));
-    assert!(set.allows_deletion(Path::new("file.tmp"), false));
+    assert!(!set.allows_deletion(Path::new("file.tmp"), false));
 }
 
 /// Verifies perishable with empty filter set.
@@ -294,9 +302,9 @@ fn only_perishable_rule() {
     assert!(set.allows(Path::new("file.txt"), false));
     assert!(set.allows_deletion(Path::new("file.txt"), false));
 
-    // Matching files excluded from transfer but deletable
+    // Matching files excluded from transfer and protected from deletion.
     assert!(!set.allows(Path::new("file.tmp"), false));
-    assert!(set.allows_deletion(Path::new("file.tmp"), false));
+    assert!(!set.allows_deletion(Path::new("file.tmp"), false));
 }
 
 /// Verifies all rules can be perishable.
@@ -314,9 +322,10 @@ fn all_perishable_rules() {
     // Transfer: scratch.tmp is excluded (second rule)
     assert!(!set.allows(Path::new("scratch.tmp"), false));
 
-    // Deletion: all perishable rules ignored, defaults to allow
+    // Deletion honours perishable rules like any other: important.tmp matches
+    // the include first (deletable), scratch.tmp matches the exclude (protected).
     assert!(set.allows_deletion(Path::new("important.tmp"), false));
-    assert!(set.allows_deletion(Path::new("scratch.tmp"), false));
+    assert!(!set.allows_deletion(Path::new("scratch.tmp"), false));
 }
 
 /// Verifies with_perishable is a builder method.
@@ -360,8 +369,8 @@ fn complex_perishable_scenario() {
     // exercises the perishable exclude where a top-level `src/scratch.tmp`
     // would not match it at all.
     assert!(!set.allows(Path::new("src/sub/scratch.tmp"), false));
-    // For deletion: perishable exclude skipped, include src/** matches, deletable
-    assert!(set.allows_deletion(Path::new("src/sub/scratch.tmp"), false));
+    // For deletion: the perishable exclude matches first and protects the entry.
+    assert!(!set.allows_deletion(Path::new("src/sub/scratch.tmp"), false));
 
     // src files included in transfer (second rule)
     assert!(set.allows(Path::new("src/main.rs"), false));
@@ -371,6 +380,7 @@ fn complex_perishable_scenario() {
     // cache files included in transfer (third rule)
     assert!(set.allows(Path::new("cache/data.bin"), false));
 
-    // cache deletion: perishable include ignored, exclude * applies
-    assert!(!set.allows_deletion(Path::new("cache/data.bin"), false));
+    // cache deletion: the perishable include cache/** matches first, so the
+    // entry is included and remains a deletion candidate.
+    assert!(set.allows_deletion(Path::new("cache/data.bin"), false));
 }

--- a/crates/filters/tests/rule_evaluation_order.rs
+++ b/crates/filters/tests/rule_evaluation_order.rs
@@ -436,7 +436,7 @@ fn mixed_sides_order() {
     assert!(!set.allows_deletion(Path::new("app.log"), false));
 }
 
-/// Verifies perishable rules are skipped in deletion context.
+/// Verifies perishable rules are honoured (first-match-wins) in deletion.
 #[test]
 fn perishable_order_in_deletion() {
     let rules = [
@@ -448,8 +448,10 @@ fn perishable_order_in_deletion() {
     // Transfer: perishable exclude matches first
     assert!(!set.allows(Path::new("scratch.tmp"), false));
 
-    // Deletion: perishable rule skipped, include matches
-    assert!(set.allows_deletion(Path::new("scratch.tmp"), false));
+    // Deletion: the top-level scan honours perishable rules (upstream
+    // exclude.c:1044 / delete.c:147), so the perishable exclude matches first
+    // and protects the entry.
+    assert!(!set.allows_deletion(Path::new("scratch.tmp"), false));
 }
 
 /// Verifies non-perishable followed by perishable.
@@ -468,8 +470,9 @@ fn perishable_after_non_perishable() {
 
     // other.tmp: excluded by perishable rule for transfer
     assert!(!set.allows(Path::new("other.tmp"), false));
-    // For deletion, perishable skipped, include matches
-    assert!(set.allows_deletion(Path::new("other.tmp"), false));
+    // For deletion the perishable exclude matches first (before the include),
+    // so the entry is protected.
+    assert!(!set.allows_deletion(Path::new("other.tmp"), false));
 }
 
 /// Verifies clear removes all previous rules.

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -588,11 +588,33 @@ pub fn run_server_with_handshake<W: Write>(
     };
 
     if should_send_filter_list {
-        protocol::filters::write_filter_list(
-            &mut writer,
-            &config.connection.filter_rules,
-            handshake.protocol,
-        )?;
+        // upstream: exclude.c:1605-1614 send_rules() elides any rule that applies
+        // to the local side only, so the peer never sees it. On a pull (client is
+        // the receiver) a receiver-side (`r`) rule is applied locally in the
+        // deletion pass and must NOT reach the sender - otherwise the sender would
+        // wrongly drop the matching file from the transfer (this is exactly the
+        // upstream `elide == LOCAL_RULE -> continue` case). Symmetrically, on a
+        // push (client is the sender) a sender-side (`s`) rule is applied locally
+        // by the generator and must not reach the remote receiver, where it would
+        // wrongly protect a matching destination file from --delete. A both-sided
+        // rule (neither flag set) is always sent. The local deletion chain reads
+        // `config.connection.filter_rules` directly (receiver/transfer/setup),
+        // so this elision changes only the bytes placed on the wire.
+        let client_is_sender = config.role == ServerRole::Generator;
+        let wire_rules: Vec<protocol::filters::FilterRuleWireFormat> = config
+            .connection
+            .filter_rules
+            .iter()
+            .filter(|rule| {
+                if client_is_sender {
+                    !rule.sender_side
+                } else {
+                    !rule.receiver_side
+                }
+            })
+            .cloned()
+            .collect();
+        protocol::filters::write_filter_list(&mut writer, &wire_rules, handshake.protocol)?;
         writer.flush()?;
     }
 

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -172,13 +172,30 @@ impl ReceiverContext {
 
         let max_delete = self.config.deletion.max_delete;
 
+        // The deletion decision must consult the chain that actually carries
+        // the filter rules for this role. A server-side receiver reads the
+        // client's rules off the wire into `filter_chain` (setup/context.rs
+        // branch A). A client-side pull never receives the wire filter list,
+        // so its rules live in the dedicated `deletion_filter_chain` built from
+        // the local CLI rules (branch B) and `filter_chain` is empty there.
+        // Pick whichever is populated so a plain `- name`, a receiver-side
+        // `-r name`, or a perishable `-p name` rule protects a matching
+        // destination entry from --delete on both sides, mirroring upstream
+        // generator.c:delete_in_dir() which filters the get_dirlist()
+        // candidates through the same rule list regardless of transfer role.
+        let deletion_chain = if self.deletion_filter_chain.is_empty() {
+            &self.filter_chain
+        } else {
+            &self.deletion_filter_chain
+        };
+
         // Whether the deletion chain carries per-directory merge configs
         // (`.rsync-filter`, dir-merge `.filt`/`.filt2`). Computed up front so it
         // can gate both the scan-target expansion below and the per-worker
         // reload further down. When there are no per-dir merge configs the
         // deletion pass behaves exactly as before: dirs_to_scan is keyed off
         // parents-with-a-visible-child and the flat global chain decides.
-        let needs_perdir_merge = self.deletion_filter_chain.has_per_dir_merge();
+        let needs_perdir_merge = deletion_chain.has_per_dir_merge();
 
         // Build directory -> children map from the file list.
         // Use owned OsString keys so the map can be shared across threads.
@@ -271,9 +288,9 @@ impl ReceiverContext {
         // per-directory merge configs exist so workers only pay the reload cost
         // when the chain actually has per-dir merges.
         let dir_children = Arc::new(dir_children);
-        let flat_chain = Arc::new(self.filter_chain.clone());
+        let flat_chain = Arc::new(deletion_chain.clone());
         let merge_chain = Arc::new({
-            let mut chain = self.deletion_filter_chain.clone();
+            let mut chain = deletion_chain.clone();
             chain.set_transfer_root(dest_dir.to_path_buf());
             chain
         });

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -10606,6 +10606,172 @@ CONF
   return 0
 }
 
+# Parameterised filter-modifier matrix: exercises the -, +, s, r, p, C rule
+# modifiers and the e / n / w per-directory merge modifiers over BOTH pull and
+# push, comparing the oc-rsync client against the upstream client byte-for-byte
+# (diff -r of the produced trees). An upstream daemon is the fixed peer in every
+# case, so only the client under test varies. This has teeth: any divergence in
+# transfer inclusion OR --delete protection fails the case.
+#
+# upstream references:
+#   exclude.c:1200-1216 - r->FILTRULE_RECEIVER_SIDE, s->SENDER_SIDE,
+#                         p->PERISHABLE, C/e/n/w modifier parsing
+#   exclude.c:1044      - perishable rules honoured unless ignore_perishable
+#   delete.c:147        - ignore_perishable set only inside a wholly-deleted dir
+#   generator.c:delete_in_dir() - dest candidates filtered through the same list
+#   rsync.1.md:4191-4206 - receiver-side rules affect deletion, not transfer
+test_filter_modifier_matrix() {
+  local upstream_binary=$1 oc_bin=$2 src_dir=$3 work=$4 log=$5 \
+        oc_port=$6 upstream_port=$7
+
+  local base="${work}/fmm"
+  rm -rf "$base"
+  mkdir -p "$base"
+
+  # Canonical source tree shared by every case. `main.o` gives the -C
+  # (cvs-exclude) case teeth via the default `*.o` CVS pattern.
+  fmm_seed_src() {
+    local d=$1
+    rm -rf "$d"
+    mkdir -p "$d/sub"
+    echo keep    > "$d/keep.txt"
+    echo drop    > "$d/drop.txt"
+    echo a       > "$d/a.txt"
+    echo b       > "$d/b.txt"
+    echo obj     > "$d/main.o"
+    echo nested  > "$d/sub/keep2.txt"
+    echo ndrop   > "$d/sub/drop.txt"
+  }
+
+  # Pre-existing destination: carries an extraneous file (never matched by any
+  # rule, must always be deleted), plus files that a matching exclude/perishable
+  # rule must protect from --delete.
+  fmm_seed_dst() {
+    local d=$1
+    rm -rf "$d"
+    mkdir -p "$d/sub"
+    echo old       > "$d/drop.txt"
+    echo old       > "$d/sub/drop.txt"
+    echo extraneous > "$d/extra.txt"
+  }
+
+  # The upstream daemon serves a single writable module whose backing directory
+  # we rewrite before each client run (no restart needed).
+  local fmm_mod="${base}/module"
+  mkdir -p "$fmm_mod"
+  local fmm_conf="${base}/up.conf"
+  local fmm_pid="${base}/up.pid"
+  local fmm_log="${base}/up.log"
+  cat > "$fmm_conf" <<CONF
+pid file = ${fmm_pid}
+port = ${upstream_port}
+use chroot = false
+munge symlinks = false
+${up_identity}numeric ids = yes
+[interop]
+    path = ${fmm_mod}
+    comment = filter-modifier matrix
+    read only = false
+CONF
+
+  start_upstream_daemon "$upstream_binary" "$fmm_conf" "$fmm_log" "$fmm_pid"
+
+  local fail=0
+
+  # Compare oc vs upstream client for one modifier case.
+  #   $1 label   remaining args: rsync filter/option flags (applied verbatim)
+  fmm_case() {
+    local label=$1; shift
+    local rules=("$@")
+
+    # --- PULL: source lives in the daemon module, client pulls with --delete ---
+    fmm_seed_src "$fmm_mod"
+    local d_oc="${base}/pull-oc" d_up="${base}/pull-up"
+    fmm_seed_dst "$d_oc"; fmm_seed_dst "$d_up"
+    timeout "$hard_timeout" "$oc_bin" -a --delete --timeout=10 "${rules[@]}" \
+      "rsync://127.0.0.1:${upstream_port}/interop/" "$d_oc/" \
+      >"${log}.fmm.${label}.pull-oc.out" 2>&1
+    timeout "$hard_timeout" "$upstream_binary" -a --delete --timeout=10 "${rules[@]}" \
+      "rsync://127.0.0.1:${upstream_port}/interop/" "$d_up/" \
+      >"${log}.fmm.${label}.pull-up.out" 2>&1
+    if ! diff -r "$d_oc" "$d_up" >"${log}.fmm.${label}.pull.diff" 2>&1; then
+      echo "    [$label] PULL tree diverges from upstream:"
+      sed 's/^/      /' "${log}.fmm.${label}.pull.diff" | head -8
+      fail=1
+    fi
+
+    # --- PUSH: dest lives in the daemon module, client pushes with --delete ---
+    local src="${base}/push-src"
+    fmm_seed_src "$src"
+    fmm_seed_dst "$fmm_mod"
+    timeout "$hard_timeout" "$oc_bin" -a --delete --timeout=10 "${rules[@]}" \
+      "$src/" "rsync://127.0.0.1:${upstream_port}/interop/" \
+      >"${log}.fmm.${label}.push-oc.out" 2>&1
+    local t_oc; t_oc=$(cd "$fmm_mod" && find . | LC_ALL=C sort && echo "--content--" && \
+      find . -type f | LC_ALL=C sort | xargs -r md5sum 2>/dev/null | sed "s#  .*/#  #")
+    fmm_seed_dst "$fmm_mod"
+    timeout "$hard_timeout" "$upstream_binary" -a --delete --timeout=10 "${rules[@]}" \
+      "$src/" "rsync://127.0.0.1:${upstream_port}/interop/" \
+      >"${log}.fmm.${label}.push-up.out" 2>&1
+    local t_up; t_up=$(cd "$fmm_mod" && find . | LC_ALL=C sort && echo "--content--" && \
+      find . -type f | LC_ALL=C sort | xargs -r md5sum 2>/dev/null | sed "s#  .*/#  #")
+    if [[ "$t_oc" != "$t_up" ]]; then
+      echo "    [$label] PUSH tree diverges from upstream:"
+      diff <(echo "$t_up") <(echo "$t_oc") | sed 's/^/      /' | head -8
+      fail=1
+    fi
+  }
+
+  # Rule-modifier matrix. Each case is independently upstream-compared in both
+  # push and pull with --delete, so it exercises transfer inclusion AND deletion
+  # protection. The `s`/`r` cases pin the send_rules elision (exclude.c:1605) and
+  # the receiver-side-affects-deletion-only rule (rsync.1.md:4191); `p` pins the
+  # perishable-honoured-at-top-level fix (exclude.c:1044 / delete.c:147).
+  fmm_case "exclude"        --filter='- drop.txt'
+  fmm_case "include-then-x" --filter='+ keep.txt' --filter='- *.txt'
+  fmm_case "sender-side"    --filter='-s drop.txt'
+  fmm_case "receiver-side"  --filter='-r drop.txt'
+  fmm_case "perishable"     --filter='-p drop.txt'
+  fmm_case "cvs-exclude"    -C
+  fmm_case "dironly"        --filter='- sub/'
+
+  # Per-directory merge modifiers n / e / w are exercised in the pull direction:
+  # the merge file lives in the daemon module, the upstream daemon applies the
+  # dir-merge, and the oc client must land the same tree as the upstream client.
+  fmm_case_merge() {
+    local label=$1 mergefile=$2 mergebody=$3 dirmerge=$4
+
+    fmm_seed_src "$fmm_mod"; printf '%s\n' "$mergebody" > "$fmm_mod/$mergefile"
+    local d_oc="${base}/pm-oc" d_up="${base}/pm-up"
+    fmm_seed_dst "$d_oc"; fmm_seed_dst "$d_up"
+    timeout "$hard_timeout" "$oc_bin" -a --delete --timeout=10 --filter="$dirmerge" \
+      "rsync://127.0.0.1:${upstream_port}/interop/" "$d_oc/" \
+      >"${log}.fmm.${label}.pull-oc.out" 2>&1
+    timeout "$hard_timeout" "$upstream_binary" -a --delete --timeout=10 --filter="$dirmerge" \
+      "rsync://127.0.0.1:${upstream_port}/interop/" "$d_up/" \
+      >"${log}.fmm.${label}.pull-up.out" 2>&1
+    if ! diff -r "$d_oc" "$d_up" >"${log}.fmm.${label}.pull.diff" 2>&1; then
+      echo "    [$label] merge PULL tree diverges from upstream:"
+      sed 's/^/      /' "${log}.fmm.${label}.pull.diff" | head -8
+      fail=1
+    fi
+  }
+
+  # n: per-dir merge without inheritance. e: merge file excludes itself.
+  # w: whitespace-split rules. The positive `w` case pairs word-split with the
+  # `-` no-prefix modifier so the bare tokens "a.txt b.txt" become two separate
+  # excludes (a plain "- a.txt b.txt" is a syntax error under word-split because
+  # the "-" splits off as an empty rule - upstream exclude.c:1326).
+  fmm_case_merge "merge-n" ".rules" "- b.txt"      ":n .rules"
+  fmm_case_merge "merge-e" ".rules" "- b.txt"      ":e .rules"
+  fmm_case_merge "merge-w" ".rules" "a.txt b.txt"  ":w- .rules"
+
+  stop_upstream_daemon
+
+  unset -f fmm_seed_src fmm_seed_dst fmm_case fmm_case_merge
+  return $fail
+}
+
 # Run all standalone interop tests.
 # Uses globals: $oc_client, $up_identity, $hard_timeout, $comp_src, $workdir.
 run_standalone_interop_tests() {
@@ -10687,6 +10853,7 @@ run_standalone_interop_tests() {
     "link-dest"
     "copy-dest"
     "numeric-ids-standalone"
+    "filter-modifier-matrix"
   )
   local test_funcs=(
     "test_write_batch_read_batch"
@@ -10761,6 +10928,7 @@ run_standalone_interop_tests() {
     "test_link_dest"
     "test_copy_dest"
     "test_numeric_ids_standalone"
+    "test_filter_modifier_matrix"
   )
 
   for i in "${!test_names[@]}"; do
@@ -10950,6 +11118,9 @@ run_standalone_interop_tests() {
         test_args+=("$oc_port" "$upstream_port")
         ;;
       numeric-ids-standalone)
+        test_args+=("$oc_port" "$upstream_port")
+        ;;
+      filter-modifier-matrix)
         test_args+=("$oc_port" "$upstream_port")
         ;;
     esac


### PR DESCRIPTION
## Summary

Three related remote-mode filter-handling divergences are corrected to match upstream rsync 3.4.4. All three are receiver-side over-deletion or sender-side over-exclusion that only manifest over the wire (daemon `rsync://` and SSH remote-shell); local mode was already correct except for the perishable case.

- **D1 - receiver-side (`r`) rules leaked onto the wire.** oc transmitted receiver-side rules verbatim to the peer instead of eliding them on a pull. A `tcpdump` of `--filter='-r drop.txt'` over a daemon pull showed `-r drop.txt` on the wire; the remote sender applied it and dropped `drop.txt` from the file list, so the file was never transferred. The wire send now mirrors upstream `send_rules` (`exclude.c:1605-1614`): a receiver-side rule is elided on a pull and a sender-side rule on a push, so the peer only sees rules that apply to it. The rule stays active locally and gates **deletion only** (`rsync.1.md:4191-4206`).

- **D2 - excludes stopped protecting destination files from `--delete` on a remote pull.** The receiver delete pass consulted an empty filter chain when no per-directory merge files were present, so a plain `- name` no longer protected a pre-existing destination file. The delete pass now selects whichever chain carries the rules for the role, matching `generator.c:delete_in_dir()` where dest candidates are filtered through the same rule list on both sides. Extraneous files matched by no rule are still deleted.

- **D3 - perishable (`p`) rules were skipped in the deletion decision.** `--filter='-p name' --delete` and `--cvs-exclude --delete` wrongly removed a matching destination file. Upstream only skips perishable rules when `ignore_perishable` is set (`exclude.c:1044`), which happens solely inside a directory being wholly deleted (`delete.c:147`). The top-level scan now honors perishable rules; wholly-deleted directories are still removed en masse.

## Validation

Validated byte-for-byte against upstream rsync 3.4.3 with oc as the primary `--rsync-path`, over daemon and SSH:

- D1 `-r` pull: `drop.txt` is transferred and protected from `--delete` (matches upstream).
- D2 `- drop.txt --delete` pull: pre-existing `drop.txt` kept, extraneous files still deleted.
- D3 `-p drop.txt --delete`: kept at top level; deleted inside a wholly-removed directory; `--cvs-exclude` protects a top-level `*.o`.
- Regression: plain excludes, `s`, `C`, `e`, `n`, word-split `w`, and local mode all match upstream.
- Upstream testsuites `exclude`, `exclude-lsh`, `cvs-exclude`, `delete`, `delete-deep`, `filter-depth`, `prune-empty-dirs`, `daemon-filter` all pass with oc as primary.

## Coverage

- New parameterised filter-modifier interop matrix in `tools/ci/run_interop.sh` exercising `-`, `+`, `s`, `r`, `p`, `C` and the `n`/`e`/`w` per-directory merge modifiers, oc-vs-upstream tree diff in push and pull with `--delete` (has teeth: any divergence fails the case).
- Targeted regression tests for D1/D2/D3 in the filters and engine crates; pre-existing tests that encoded the buggy perishable-skip behavior are corrected to upstream semantics.

`cargo fmt` / `cargo clippy` clean on the touched crates; `filters` and `engine` test suites green; `protocol`/`filters`/`transfer`/`engine` remain unsafe-free.