### PR TITLE
fix: use xxh128 for local --checksum to match upstream negotiation

### DIFF
--- a/crates/core/src/client/config/enums/checksum.rs
+++ b/crates/core/src/client/config/enums/checksum.rs
@@ -7,7 +7,15 @@ use engine::signature::SignatureAlgorithm;
 /// Enumerates the strong checksum algorithms recognised by the client.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StrongChecksumAlgorithm {
-    /// Automatically selects the negotiated algorithm (locally resolved to MD5).
+    /// Automatically selects the negotiated algorithm.
+    ///
+    /// Mirrors upstream `checksum.c` negotiation (`negotiate_the_strings`,
+    /// `parse_checksum_choice`): when no explicit `--checksum-choice` is given
+    /// and both peers advertise it, the strongest mutually supported checksum
+    /// wins. For a local copy - where upstream still negotiates over the forked
+    /// child's pipe with `do_negotiated_strings` set (protocol 31+) - that is
+    /// `xxh128` (`CSUM_XXH3_128`). MD5/MD4 remain the fallback for peers too old
+    /// to negotiate, reached via an explicit `--checksum-choice`.
     Auto,
     /// No transfer checksum; disables delta and forces whole-file transfers.
     ///
@@ -35,11 +43,15 @@ impl StrongChecksumAlgorithm {
     pub const fn to_signature_algorithm(self) -> SignatureAlgorithm {
         use checksums::strong::Md5Seed;
         match self {
-            StrongChecksumAlgorithm::Auto | StrongChecksumAlgorithm::Md5 => {
-                SignatureAlgorithm::Md5 {
-                    seed_config: Md5Seed::none(),
-                }
-            }
+            // `auto` resolves to the strongest mutually negotiated checksum,
+            // which for a modern (protocol 31+) transfer is xxh128. Upstream
+            // `parse_checksum_choice` sets `file_sum_nni` to the negotiated
+            // `valid_checksums.negotiated_nni`, whose ordering lists
+            // `CSUM_XXH3_128` first (`checksum.c`).
+            StrongChecksumAlgorithm::Auto => SignatureAlgorithm::Xxh3_128 { seed: 0 },
+            StrongChecksumAlgorithm::Md5 => SignatureAlgorithm::Md5 {
+                seed_config: Md5Seed::none(),
+            },
             // `none` disables delta (whole_file is forced upstream), but a
             // signature algorithm is still required by the engine's type
             // signature. MD4 matches upstream's default fallback semantics
@@ -233,6 +245,36 @@ mod tests {
         }
 
         #[test]
+        fn auto_resolves_to_xxh128() {
+            // upstream: checksum.c negotiate_the_strings/parse_checksum_choice -
+            // the negotiated (auto) checksum is the strongest mutually supported,
+            // which for a modern local copy is xxh128, not md5.
+            assert_eq!(
+                StrongChecksumAlgorithm::Auto.to_signature_algorithm(),
+                SignatureAlgorithm::Xxh3_128 { seed: 0 }
+            );
+        }
+
+        #[test]
+        fn explicit_md5_override_is_preserved() {
+            // An explicit --checksum-choice=md5 must still force MD5, not xxh128.
+            assert_eq!(
+                StrongChecksumAlgorithm::Md5.to_signature_algorithm(),
+                SignatureAlgorithm::Md5 {
+                    seed_config: checksums::strong::Md5Seed::none(),
+                }
+            );
+        }
+
+        #[test]
+        fn explicit_md4_override_is_preserved() {
+            assert_eq!(
+                StrongChecksumAlgorithm::Md4.to_signature_algorithm(),
+                SignatureAlgorithm::Md4
+            );
+        }
+
+        #[test]
         fn clone_and_copy() {
             let alg = StrongChecksumAlgorithm::Md5;
             let cloned = alg;
@@ -345,7 +387,34 @@ mod tests {
         #[test]
         fn file_signature_algorithm() {
             let choice = StrongChecksumChoice::parse("md5").unwrap();
-            let _ = choice.file_signature_algorithm();
+            assert_eq!(
+                choice.file_signature_algorithm(),
+                SignatureAlgorithm::Md5 {
+                    seed_config: checksums::strong::Md5Seed::none(),
+                }
+            );
+        }
+
+        #[test]
+        fn default_file_signature_algorithm_is_xxh128() {
+            // The default (Auto) --checksum whole-file compare uses xxh128,
+            // matching upstream's negotiated strongest checksum for a local copy.
+            let choice = StrongChecksumChoice::default();
+            assert_eq!(
+                choice.file_signature_algorithm(),
+                SignatureAlgorithm::Xxh3_128 { seed: 0 }
+            );
+        }
+
+        #[test]
+        fn explicit_md5_file_signature_algorithm_is_md5() {
+            let choice = StrongChecksumChoice::parse("md5").unwrap();
+            assert_eq!(
+                choice.file_signature_algorithm(),
+                SignatureAlgorithm::Md5 {
+                    seed_config: checksums::strong::Md5Seed::none(),
+                }
+            );
         }
     }
 }

--- a/crates/core/tests/compression_integration.rs
+++ b/crates/core/tests/compression_integration.rs
@@ -298,10 +298,11 @@ fn local_copy_emits_nstr_summaries_under_debug_nstr() {
         });
 
         // Checksum summary always fires. oc's default strong checksum choice
-        // (`Auto`) resolves locally to MD5, so that is the reported name -
-        // matching the algorithm the local delta path actually uses.
+        // (`Auto`) resolves to the strongest mutually negotiated checksum,
+        // which for a modern local copy is xxh128 - matching upstream's
+        // negotiated `file_sum_nni` (checksum.c parse_checksum_choice).
         assert!(
-            messages.iter().any(|m| m == "Client checksum: md5"),
+            messages.iter().any(|m| m == "Client checksum: xxh128"),
             "expected NSTR checksum summary for local copy: {messages:?}"
         );
         // Compress fires because -z is active. upstream calls


### PR DESCRIPTION
## Summary

The default `--checksum` whole-file compare resolved the `Auto` checksum choice to **MD5** for a local copy, diverging from upstream rsync (3.4.x), which uses **xxh128**. This corrects the algorithm selection so local `--checksum` matches upstream and runs faster (xxh128 is faster than MD5).

## Root cause

`StrongChecksumAlgorithm::Auto` mapped to `SignatureAlgorithm::Md5` in `to_signature_algorithm()`. That value flows into the local `--checksum` whole-file comparison via `ClientConfig::checksum_signature_algorithm()` -> `LocalCopyOptions::with_checksum_algorithm()`.

Upstream negotiates the strongest mutually supported checksum for every transfer. Even a local copy forks a child that sets `do_negotiated_strings` (protocol 31+), so `negotiate_the_strings()` selects `xxh128` (`CSUM_XXH3_128`, first in `valid_checksums`) and `parse_checksum_choice()` assigns it to `file_sum_nni` - the sum used for the pre-transfer `--checksum` compare (checksum.c).

## Change

Resolve `Auto` to `SignatureAlgorithm::Xxh3_128`. Explicit `--checksum-choice=md5`/`md4` overrides and the old-peer MD5/MD4 fallback are preserved. The remote negotiation path was already correct (preference order `xxh128 > xxh3 > xxh64 > md5 > md4`) and is untouched. The compare stays symmetric, so no files change their skip/transfer decision.

## Validation (against rsync 3.4.3)

- Upstream local `--checksum --debug=NSTR` reports `xxh128`; `--checksum-choice=md5` reports `md5`.
- After fix: local `--checksum` reports `xxh128` (was `md5`); `--checksum-choice=md5` still `md5`.
- Content change with matching size+mtime is still detected (`>fc` re-transfer) under default xxh128 and under `--checksum-choice=md4`.
- New unit tests cover `Auto -> xxh128`, explicit `md5`/`md4` preserved, and default file-signature = xxh128. fmt + clippy (`-D warnings`) clean on `core`.

## Note

Upstream prints `Client negotiated checksum: xxh128` (with the "negotiated" qualifier) for the auto case, while the local NSTR path here omits "negotiated". That qualifier is a separate, pre-existing output-fidelity detail in the local NSTR rendering and is out of scope here; this change corrects only the algorithm.