### PR TITLE
perf(engine): cache parent device id to drop redundant per-file statx

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -1,7 +1,7 @@
 //! Execution context and helper types for local filesystem copies.
 
 use std::cell::RefCell;
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Read, Seek, SeekFrom, Write};
@@ -51,6 +51,9 @@ use compress::zlib::CompressionLevel;
 use filters::FilterRule;
 use logging::info_log;
 use protocol::flist::FileListWriter;
+
+#[cfg(target_os = "linux")]
+use super::overrides::{cached_parent_device, same_filesystem};
 
 /// Aggregated result of a local copy operation, containing the transfer
 /// summary, optional per-file event records, and the destination root path.
@@ -152,10 +155,15 @@ pub(crate) struct CopyContext<'a> {
     /// keep lists can be merged before any extraneous unlink fires; upstream
     /// achieves the same result by sharing a single flist across sources.
     multi_source: bool,
-    /// Cache of parent directories whose existence has been verified.
-    /// Eliminates redundant `statx` syscalls when many files share the
-    /// same parent (e.g. 10K files in one directory → 1 stat instead of 10K).
-    verified_parents: HashSet<PathBuf>,
+    /// Cache of parent directories whose existence has been verified, mapping
+    /// each verified parent to its filesystem device id once resolved.
+    /// Eliminates redundant `statx` syscalls when many files share the same
+    /// parent (e.g. 10K files in one directory → 1 stat instead of 10K): the
+    /// existence check is skipped on cache hit, and the parent's device id -
+    /// invariant across sibling files - is memoized for the Linux FICLONE fast
+    /// path's same-filesystem gate. `None` means verified but device not yet
+    /// resolved.
+    verified_parents: HashMap<PathBuf, Option<u64>>,
     /// Protocol flist encoder for batch mode.
     ///
     /// When batch mode is active, file entries are encoded using the protocol

--- a/crates/engine/src/local_copy/context_impl/options/dirs.rs
+++ b/crates/engine/src/local_copy/context_impl/options/dirs.rs
@@ -138,7 +138,7 @@ impl<'a> CopyContext<'a> {
 
         // Fast path: skip stat if this parent was already verified as a directory.
         // With 10K files in one directory, this avoids 9,999 redundant statx calls.
-        if self.verified_parents.contains(parent) {
+        if self.verified_parents.contains_key(parent) {
             return Ok(());
         }
 
@@ -277,8 +277,32 @@ impl<'a> CopyContext<'a> {
         };
 
         if result.is_ok() {
-            self.verified_parents.insert(parent.to_path_buf());
+            // Insert with an unresolved device id; the FICLONE fast path fills
+            // it in on the first sibling file that needs it.
+            self.verified_parents.insert(parent.to_path_buf(), None);
         }
         result
+    }
+
+    /// Returns whether `source` shares a filesystem with `destination`, reusing
+    /// the verified-parent device cache so sibling files in one directory do
+    /// not each re-`statx` the parent directory.
+    ///
+    /// The parent's device id is invariant across siblings and was already
+    /// verified to exist by [`prepare_parent_directory`](Self::prepare_parent_directory)
+    /// this transfer, so it is memoized rather than re-resolved per file.
+    /// Delegates the comparison to [`same_filesystem`]; returns `None` when
+    /// either device id is unavailable so the FICLONE fast path still attempts
+    /// the reflink and falls back on `EXDEV`.
+    #[cfg(target_os = "linux")]
+    pub(super) fn same_filesystem_as_source(
+        &mut self,
+        source: &Path,
+        source_metadata: &fs::Metadata,
+        destination: &Path,
+    ) -> Option<bool> {
+        let parent = destination.parent()?;
+        let parent_device = cached_parent_device(&mut self.verified_parents, parent);
+        same_filesystem(source, source_metadata, parent_device)
     }
 }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -145,7 +145,7 @@ impl<'a> CopyContext<'a> {
             io_error_delete_warning_emitted: false,
             iconv_conversion_error: false,
             multi_source: false,
-            verified_parents: HashSet::new(),
+            verified_parents: HashMap::new(),
             batch_flist_writer,
             batch_delta_buf,
             batch_delta_entries: Vec::new(),

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
@@ -22,7 +22,6 @@ use logging::debug_log;
 
 use ::metadata::MetadataOptions;
 
-use crate::local_copy::overrides::same_filesystem;
 use crate::local_copy::{
     CopyContext, CopyMethodKind, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet,
     LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
@@ -117,10 +116,12 @@ pub(super) fn try_clone(
     // filesystem and fails with EXDEV across mounts - but not before
     // File::create() has already materialised an empty destination inode that
     // we then have to unlink. Comparing st_dev up front avoids that wasted
-    // create/ioctl/unlink round-trip on cross-filesystem copies. When the
-    // device ids cannot be determined the helper returns None and we fall
-    // through to let try_ficlone decide.
-    if same_filesystem(source, metadata, destination) == Some(false) {
+    // create/ioctl/unlink round-trip on cross-filesystem copies. The parent's
+    // device id is served from the verified-parent cache, so sibling files in
+    // one directory do not each re-statx the parent. When the device ids
+    // cannot be determined the helper returns None and we fall through to let
+    // try_ficlone decide.
+    if context.same_filesystem_as_source(source, metadata, destination) == Some(false) {
         return Ok(false);
     }
 

--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -2,6 +2,11 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+#[cfg(target_os = "linux")]
+use std::collections::HashMap;
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
+
 #[cfg(test)]
 use std::cell::RefCell;
 
@@ -159,91 +164,162 @@ pub(super) fn device_identifier(path: &Path, metadata: &fs::Metadata) -> Option<
     }
 }
 
-/// Returns whether `source` and `destination` reside on the same filesystem.
+/// Returns whether `source` shares a filesystem with a destination whose
+/// parent directory has device id `dest_parent_device`.
 ///
-/// Compares the device id of `source` against the device id of
-/// `destination`'s parent directory - the destination file itself may not
-/// exist yet, so its filesystem is the parent's. Returns `None` when either
-/// device id cannot be determined (e.g. the parent cannot be stat'd), letting
-/// callers fall back to attempting the operation. Used to gate reflink fast
-/// paths (`ioctl(FICLONE)`/`FICLONERANGE`) that only clone within a single
-/// filesystem and otherwise fail with `EXDEV`.
+/// The destination file itself may not exist yet, so its filesystem is the
+/// parent's; callers resolve the parent device - ideally from a cache to avoid
+/// a redundant per-file `statx` - and pass it here. Returns `None` when either
+/// device id is unavailable, letting callers attempt the operation and fall
+/// back on `EXDEV`. Used to gate reflink fast paths (`ioctl(FICLONE)`/
+/// `FICLONERANGE`) that only clone within a single filesystem.
 #[cfg(target_os = "linux")]
 pub(super) fn same_filesystem(
     source: &Path,
     source_metadata: &fs::Metadata,
-    destination: &Path,
+    dest_parent_device: Option<u64>,
 ) -> Option<bool> {
     let source_dev = device_identifier(source, source_metadata)?;
-    let parent = destination.parent()?;
-    let parent_metadata = fs::symlink_metadata(parent).ok()?;
-    let dest_dev = device_identifier(parent, &parent_metadata)?;
+    let dest_dev = dest_parent_device?;
     Some(source_dev == dest_dev)
+}
+
+/// Resolves the device id of `parent`, memoizing it in the verified-parent
+/// cache so sibling files in one directory pay a single `statx`.
+///
+/// `parent` is normally already present in `cache` (inserted by
+/// `prepare_parent_directory` with a `None` device placeholder). On a cache
+/// hit with a resolved device the stored id is returned with no syscall; on a
+/// placeholder the directory is stat'd once and the id written back. When the
+/// parent is absent from the cache - only reachable outside the normal
+/// per-file flow - the directory is stat'd without caching, matching the prior
+/// uncached behaviour. Returns `None` when the directory cannot be stat'd or
+/// its device id is unavailable.
+#[cfg(target_os = "linux")]
+pub(super) fn cached_parent_device(
+    cache: &mut HashMap<PathBuf, Option<u64>>,
+    parent: &Path,
+) -> Option<u64> {
+    if let Some(Some(dev)) = cache.get(parent) {
+        return Some(*dev);
+    }
+    let metadata = fs::symlink_metadata(parent).ok()?;
+    let dev = device_identifier(parent, &metadata)?;
+    // Only fill an existing verified entry, so an unverified parent is never
+    // recorded as verified. A FICLONE-path parent has already been through
+    // prepare_parent_directory, so the entry exists in the common case.
+    if let Some(slot) = cache.get_mut(parent) {
+        *slot = Some(dev);
+    }
+    Some(dev)
 }
 
 #[cfg(all(test, target_os = "linux"))]
 mod same_filesystem_tests {
-    use super::{same_filesystem, with_device_id_override};
+    use super::{
+        cached_parent_device, device_identifier, same_filesystem, with_device_id_override,
+    };
+    use std::collections::HashMap;
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     #[test]
     fn reports_same_device_when_ids_match() {
-        // Source and destination parent both resolve to device 1: the helper
-        // must report Some(true) so the FICLONE fast path proceeds.
+        // Source device 1 and a resolved parent device 1: the helper must
+        // report Some(true) so the FICLONE fast path proceeds.
         let temp = tempdir().expect("tempdir");
         let source = temp.path().join("src");
-        let dest = temp.path().join("dst");
         std::fs::write(&source, b"data").expect("write source");
         let source_meta = std::fs::symlink_metadata(&source).expect("source metadata");
 
         let verdict = with_device_id_override(
             |_path, _meta| Some(1),
-            || same_filesystem(&source, &source_meta, &dest),
+            || same_filesystem(&source, &source_meta, Some(1)),
         );
         assert_eq!(verdict, Some(true));
     }
 
     #[test]
     fn reports_cross_device_when_ids_differ() {
-        // Source resolves to device 1, the destination's parent to device 2:
-        // the helper must report Some(false) so the caller skips the doomed
-        // cross-filesystem FICLONE ioctl entirely.
-        let source_dir = tempdir().expect("source tempdir");
-        let dest_dir = tempdir().expect("dest tempdir");
-        let source = source_dir.path().join("src");
-        let dest = dest_dir.path().join("dst");
+        // Source device 1, parent device 2: the helper must report Some(false)
+        // so the caller skips the doomed cross-filesystem FICLONE ioctl.
+        let temp = tempdir().expect("tempdir");
+        let source = temp.path().join("src");
         std::fs::write(&source, b"data").expect("write source");
         let source_meta = std::fs::symlink_metadata(&source).expect("source metadata");
 
-        let dest_parent = dest_dir.path().to_path_buf();
         let verdict = with_device_id_override(
-            move |path, _meta| {
-                if path == dest_parent.as_path() {
-                    Some(2)
-                } else {
-                    Some(1)
-                }
-            },
-            || same_filesystem(&source, &source_meta, &dest),
+            |_path, _meta| Some(1),
+            || same_filesystem(&source, &source_meta, Some(2)),
         );
         assert_eq!(verdict, Some(false));
     }
 
     #[test]
-    fn reports_none_when_destination_parent_missing() {
-        // A destination whose parent directory does not exist cannot be
-        // stat'd, so the helper returns None and the caller falls through to
-        // try_ficlone rather than wrongly skipping it.
+    fn reports_none_when_parent_device_unknown() {
+        // An unresolved parent device makes the filesystem indeterminate, so
+        // the helper returns None and the caller falls through to try_ficlone
+        // rather than wrongly skipping it.
         let temp = tempdir().expect("tempdir");
         let source = temp.path().join("src");
         std::fs::write(&source, b"data").expect("write source");
         let source_meta = std::fs::symlink_metadata(&source).expect("source metadata");
-        let dest = temp.path().join("missing").join("dst");
 
         let verdict = with_device_id_override(
             |_path, _meta| Some(1),
-            || same_filesystem(&source, &source_meta, &dest),
+            || same_filesystem(&source, &source_meta, None),
         );
         assert_eq!(verdict, None);
+    }
+
+    #[test]
+    fn cached_parent_device_returns_stored_id_without_statting() {
+        // A verified parent whose device is already resolved must be served
+        // from the cache alone: the path does not exist on disk, so any statx
+        // would fail and yield None. A hit proves no syscall occurred - the
+        // per-file redundant parent statx is eliminated.
+        let mut cache: HashMap<PathBuf, Option<u64>> = HashMap::new();
+        let parent = PathBuf::from("/nonexistent/verified/parent");
+        cache.insert(parent.clone(), Some(4242));
+
+        assert_eq!(cached_parent_device(&mut cache, &parent), Some(4242));
+    }
+
+    #[test]
+    fn cached_parent_device_resolves_once_then_memoizes() {
+        // First call on a placeholder entry stats the directory and writes the
+        // device back; a second call is served from the cache even after the
+        // directory is removed, proving the stat happens once per directory,
+        // not once per file.
+        let temp = tempdir().expect("tempdir");
+        let parent = temp.path().to_path_buf();
+        let mut cache: HashMap<PathBuf, Option<u64>> = HashMap::new();
+        cache.insert(parent.clone(), None);
+
+        let expected = device_identifier(
+            &parent,
+            &std::fs::symlink_metadata(&parent).expect("parent metadata"),
+        )
+        .expect("device id");
+        let first = cached_parent_device(&mut cache, &parent).expect("device resolved");
+        assert_eq!(first, expected);
+        assert_eq!(cache.get(&parent), Some(&Some(expected)));
+
+        // Remove the directory: a re-stat would now fail, so a cache miss would
+        // return None. The cached value must still be returned.
+        drop(temp);
+        assert_eq!(cached_parent_device(&mut cache, &parent), Some(expected));
+    }
+
+    #[test]
+    fn cached_parent_device_does_not_cache_unverified_parent() {
+        // A parent absent from the cache (not verified this transfer) is stat'd
+        // but not inserted, so it never masquerades as a verified directory.
+        let temp = tempdir().expect("tempdir");
+        let parent = temp.path().to_path_buf();
+        let mut cache: HashMap<PathBuf, Option<u64>> = HashMap::new();
+
+        assert!(cached_parent_device(&mut cache, &parent).is_some());
+        assert!(cache.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

On a first copy the Linux FICLONE fast path issued an extra `statx(dst/PARENT, NOFOLLOW)` per file. This came from the same-filesystem guard in `ficlone::try_clone`, which resolved the destination parent's device id (to skip a doomed cross-filesystem reflink) by re-statting the parent for every file. The parent's device id is invariant across sibling files in one directory, and the parent had already been verified this transfer via `prepare_parent_directory`, so the second per-file parent stat was pure overhead not routed through the existing cache.

## Fix

Extend the existing `verified_parents` cache from a `HashSet<PathBuf>` to a `HashMap<PathBuf, Option<u64>>`, storing each verified parent's device id once resolved. The FICLONE gate now reads the device id from that cache (`same_filesystem_as_source` → `cached_parent_device`), so a directory is stat'd once instead of once per file. No second cache is introduced; the freshness-required dest-existence quick-check and the post-write readback are untouched, and the cross-filesystem skip still works (device compared from cache, `None` falls through to attempt the reflink).

## Measurements

`strace -f -c -e trace=statx,newfstatat,lstat oc-rsync -a src/ dst/` on a 1640-file, 41-directory fresh tree (aarch64 Linux):

| | statx |
|---|---|
| before | 8336 |
| after | 6737 |
| upstream rsync | 6735 (newfstatat) |

1599 fewer statx (one retained per directory), bringing the count in line with upstream.

## Correctness

- Resulting tree byte-for-byte identical to before and to upstream.
- Verified unchanged: nested missing-parent creation, `--delete`, replaced-dir-with-file (make-room), `--partial` (temp-file rename path), and incremental no-change re-run.
- New regression tests assert a verified parent's device is served from the cache without a stat, and that a directory is resolved once then memoized (stat once per transfer, not per file).
- fmt + `clippy -p engine -D warnings` clean on macOS and Linux.