### PR TITLE
fix(filters): apply word-split (w) modifier on the sender's per-dir merge load

### DIFF
--- a/crates/filters/src/chain/config.rs
+++ b/crates/filters/src/chain/config.rs
@@ -57,6 +57,11 @@ pub struct DirMergeConfig {
     /// When `no_prefixes && no_prefixes_include`, each literal line becomes
     /// an include rule; otherwise it becomes an exclude rule.
     no_prefixes_include: bool,
+    /// upstream: exclude.c:1279-1283 - FILTRULE_WORD_SPLIT (`w` modifier on a
+    /// dir-merge rule). When set, the per-directory merge file is tokenised on
+    /// any whitespace with each token parsed as its own rule, rather than one
+    /// rule per line.
+    word_split: bool,
 }
 
 impl DirMergeConfig {
@@ -77,6 +82,7 @@ impl DirMergeConfig {
             cvs_mode: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            word_split: false,
         }
     }
 
@@ -173,6 +179,25 @@ impl DirMergeConfig {
     #[must_use]
     pub const fn cvs_mode(&self) -> bool {
         self.cvs_mode
+    }
+
+    /// Sets the `w` (word-split) modifier on this dir-merge.
+    ///
+    /// When enabled, the per-directory merge file is tokenised on any
+    /// whitespace (space, tab, newline) with each token parsed as its own
+    /// rule, mirroring upstream rsync's FILTRULE_WORD_SPLIT.
+    ///
+    /// upstream: exclude.c:1279-1283 - `w` modifier sets FILTRULE_WORD_SPLIT.
+    #[must_use]
+    pub const fn with_word_split(mut self, word_split: bool) -> Self {
+        self.word_split = word_split;
+        self
+    }
+
+    /// Returns whether this dir-merge tokenises its merge file on whitespace.
+    #[must_use]
+    pub const fn word_split(&self) -> bool {
+        self.word_split
     }
 
     /// Marks this dir-merge as having FILTRULE_NO_PREFIXES set (the `-`/`+`

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -39,7 +39,7 @@ use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 
-use crate::merge::parse::{parse_rules, parse_rules_no_prefixes};
+use crate::merge::parse::{parse_rules, parse_rules_no_prefixes, parse_rules_word_split};
 use crate::{FilterAction, FilterRule, FilterSet};
 
 pub use config::DirMergeConfig;
@@ -359,15 +359,32 @@ impl FilterChain {
                 // dir-merge template skips short-prefix dispatch, so each
                 // line becomes a literal exclude (or include for `+`). When
                 // CVS_IGNORE is also inherited (e.g. `:-C`), a bare `!` line
-                // clears the list per FILTRULE_CLEAR_LIST.
+                // clears the list per FILTRULE_CLEAR_LIST. The `w` modifier
+                // (e.g. `:w-`) tokenises on whitespace instead of per line.
                 parse_rules_no_prefixes(
                     &content,
                     &merge_path,
                     config.no_prefixes_include(),
                     config.cvs_mode(),
+                    config.word_split(),
                 )
             } else if config.cvs_mode() {
                 parse_cvs_ignore_tokens(&content)
+            } else if config.word_split() {
+                // upstream: exclude.c:1499 - the `w` modifier splits the merge
+                // file on any whitespace and parses every token as its own
+                // rule (comments are not stripped, line 1514).
+                match parse_rules_word_split(&content, &merge_path) {
+                    Ok(rules) => rules,
+                    Err(e) => {
+                        self.pop_scopes_at_depth(depth);
+                        self.current_depth -= 1;
+                        return Err(FilterChainError::Parse {
+                            path: merge_path,
+                            message: e.to_string(),
+                        });
+                    }
+                }
             } else {
                 match parse_rules(&content, &merge_path) {
                     Ok(rules) => rules,
@@ -488,6 +505,7 @@ impl FilterChain {
                                 descriptor.no_prefixes,
                                 descriptor.no_prefixes_include,
                             )
+                            .with_word_split(descriptor.word_split)
                             .with_anchor_root(descriptor.abs_path),
                     );
                 }
@@ -545,9 +563,22 @@ impl FilterChain {
                 &merge_path,
                 descriptor.no_prefixes_include,
                 descriptor.cvs_mode,
+                descriptor.word_split,
             )
         } else if descriptor.cvs_mode {
             parse_cvs_ignore_tokens(&content)
+        } else if descriptor.word_split {
+            match parse_rules_word_split(&content, &merge_path) {
+                Ok(rules) => rules,
+                Err(e) => {
+                    self.pop_scopes_at_depth(depth);
+                    self.current_depth -= 1;
+                    return Err(FilterChainError::Parse {
+                        path: merge_path,
+                        message: e.to_string(),
+                    });
+                }
+            }
         } else {
             match parse_rules(&content, &merge_path) {
                 Ok(rules) => rules,
@@ -754,6 +785,9 @@ struct InlineDirMerge {
     /// `/` modifier (FILTRULE_ABS_PATH): anchor merged rules to the transfer
     /// root rather than the merge file's own directory.
     abs_path: bool,
+    /// `w` modifier (FILTRULE_WORD_SPLIT): tokenise the merge file on any
+    /// whitespace instead of one rule per line.
+    word_split: bool,
 }
 
 /// Joins a relative path's normal components with `/`, ignoring any leading
@@ -814,6 +848,7 @@ fn split_dir_merge_rules(rules: Vec<FilterRule>) -> (Vec<FilterRule>, Vec<Inline
                 no_prefixes,
                 no_prefixes_include,
                 abs_path: rule.is_abs_path(),
+                word_split: rule.is_word_split(),
             });
         } else {
             keep.push(rule);

--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -947,3 +947,74 @@ fn cvs_dir_merge_preserves_both_sides_without_delete_excluded() {
 
     chain.leave_directory(guard);
 }
+
+// upstream: exclude.c:1279-1283, 1499 - a `:w` dir-merge (FILTRULE_WORD_SPLIT)
+// tokenises its merge file on any whitespace and parses each token as its own
+// rule. With the `_` separator standing in for the space between a rule's
+// prefix and its pattern, `-_*.log -_*.tmp -_*.bak` on one line becomes three
+// separate excludes. Without word-split the whole line is one malformed rule
+// and none of the three patterns take effect (the remote-sender bug this
+// guards against).
+#[test]
+fn dir_merge_word_split_parses_whitespace_separated_rules() {
+    let dir = TempDir::new().unwrap();
+    // Tab and space mixed, and split across two lines, to prove any whitespace
+    // acts as a token boundary (upstream isspace()).
+    fs::write(dir.path().join(".filt"), "-_*.log\t-_*.tmp -_*.bak\n").unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".filt").with_word_split(true));
+
+    let guard = chain.enter_directory(dir.path()).unwrap();
+    assert_eq!(guard.pushed_count(), 1);
+
+    assert!(!chain.allows(Path::new("a.log"), false));
+    assert!(!chain.allows(Path::new("b.tmp"), false));
+    assert!(!chain.allows(Path::new("c.bak"), false));
+    assert!(chain.allows(Path::new("keep.dat"), false));
+
+    chain.leave_directory(guard);
+}
+
+// upstream: exclude.c:1122-1133, 1499 - `:w-` combines FILTRULE_WORD_SPLIT with
+// FILTRULE_NO_PREFIXES: the file is tokenised on whitespace and each token is a
+// literal exclude pattern (no `-`/`+` prefix). `*.log *.tmp *.bak` becomes three
+// literal excludes.
+#[test]
+fn dir_merge_word_split_no_prefixes_literal_excludes() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join(".filt"), "*.log\t*.tmp *.bak\n").unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(
+        DirMergeConfig::new(".filt")
+            .with_word_split(true)
+            .with_no_prefixes(true, false),
+    );
+
+    let guard = chain.enter_directory(dir.path()).unwrap();
+    assert_eq!(guard.pushed_count(), 1);
+
+    assert!(!chain.allows(Path::new("a.log"), false));
+    assert!(!chain.allows(Path::new("b.tmp"), false));
+    assert!(!chain.allows(Path::new("c.bak"), false));
+    assert!(chain.allows(Path::new("keep.dat"), false));
+
+    chain.leave_directory(guard);
+}
+
+// upstream: exclude.c:903-960 rule_matches with ABS_ANCHOR - a leading-`/`
+// exclude anchors to the transfer root and must NOT match the same basename
+// nested in a subdirectory. This mirrors the remote-sender path where the rule
+// arrives over the wire and is compiled into the chain's global set.
+#[test]
+fn anchored_root_exclude_does_not_match_nested_basename() {
+    let global = FilterSet::from_rules([FilterRule::exclude("/drop.txt")]).unwrap();
+    let chain = FilterChain::new(global);
+
+    // Top-level `drop.txt` is excluded.
+    assert!(!chain.allows(Path::new("drop.txt"), false));
+    // Nested `sub/drop.txt` is NOT excluded by the anchored rule.
+    assert!(chain.allows(Path::new("sub/drop.txt"), false));
+    assert!(chain.allows(Path::new("keep.txt"), false));
+}

--- a/crates/filters/src/compiled/clear.rs
+++ b/crates/filters/src/compiled/clear.rs
@@ -32,6 +32,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -56,6 +57,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -80,6 +82,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -111,6 +114,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -133,6 +137,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };

--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -45,6 +45,7 @@ impl CompiledRule {
             no_inherit: _,
             cvs_mode: _,
             abs_path: _,
+            word_split: _,
             no_prefixes: _,
             no_prefixes_include: _,
         } = rule;
@@ -207,6 +208,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -231,6 +233,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -252,6 +255,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -278,6 +282,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -309,6 +314,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -352,6 +358,7 @@ mod tests {
                 no_inherit: false,
                 cvs_mode: false,
                 abs_path: false,
+                word_split: false,
                 no_prefixes: false,
                 no_prefixes_include: false,
             };
@@ -384,6 +391,7 @@ mod tests {
                 no_inherit: false,
                 cvs_mode: false,
                 abs_path: false,
+                word_split: false,
                 no_prefixes: false,
                 no_prefixes_include: false,
             };
@@ -413,6 +421,7 @@ mod tests {
                 no_inherit: false,
                 cvs_mode: false,
                 abs_path: false,
+                word_split: false,
                 no_prefixes: false,
                 no_prefixes_include: false,
             };
@@ -440,6 +449,7 @@ mod tests {
                 no_inherit: false,
                 cvs_mode: false,
                 abs_path: false,
+                word_split: false,
                 no_prefixes: false,
                 no_prefixes_include: false,
             };
@@ -473,6 +483,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -508,6 +519,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -534,6 +546,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -595,6 +608,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         })
@@ -795,6 +809,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -813,6 +828,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -191,6 +191,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -214,6 +215,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -236,6 +238,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -258,6 +261,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -281,6 +285,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -303,6 +308,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -324,6 +330,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -346,6 +353,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -374,6 +382,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -408,6 +417,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -432,6 +442,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -451,6 +462,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -473,6 +485,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -499,6 +512,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -528,6 +542,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -564,6 +579,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -595,6 +611,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -631,6 +648,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };
@@ -666,6 +684,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -454,6 +454,7 @@ mod tests {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         };

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -64,37 +64,71 @@ pub fn parse_rules(content: &str, source_path: &Path) -> Result<Vec<FilterRule>,
 /// template), a bare `!` line tentatively clears the list, matching upstream's
 /// FILTRULE_CLEAR_LIST escape hatch at `exclude.c:1123-1124`. Without
 /// CVS_IGNORE, `!` is just another literal pattern.
+///
+/// When `word_split` is true (the `w` modifier, e.g. `:w-`), the whole file is
+/// tokenised on any whitespace instead of one pattern per line, mirroring
+/// upstream's `parse_filter_file()` token loop (`exclude.c:1499`). Comments are
+/// not stripped in word-split mode (`exclude.c:1514`), so every token becomes a
+/// literal pattern.
 pub(crate) fn parse_rules_no_prefixes(
     content: &str,
     _source_path: &Path,
     force_include: bool,
     cvs_ignore: bool,
+    word_split: bool,
 ) -> Vec<FilterRule> {
     let mut rules = Vec::new();
 
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
-            continue;
-        }
-
+    let mut push_token = |token: &str| {
         // upstream: exclude.c:1123-1124 - when FILTRULE_CVS_IGNORE is set on
         // the template, a bare `!` becomes FILTRULE_CLEAR_LIST. Without
         // CVS_IGNORE the `!` is taken literally per the no-prefixes contract.
-        if cvs_ignore && trimmed == "!" {
+        if cvs_ignore && token == "!" {
             rules.push(FilterRule::clear());
-            continue;
-        }
-
-        let rule = if force_include {
-            FilterRule::include(trimmed)
+        } else if force_include {
+            rules.push(FilterRule::include(token));
         } else {
-            FilterRule::exclude(trimmed)
-        };
-        rules.push(rule);
+            rules.push(FilterRule::exclude(token));
+        }
+    };
+
+    if word_split {
+        // upstream: exclude.c:1499 - word_split splits on any whitespace and
+        // parses every non-empty token; comments are not skipped (line 1514).
+        for token in content.split_whitespace() {
+            push_token(token);
+        }
+    } else {
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+                continue;
+            }
+            push_token(trimmed);
+        }
     }
 
     rules
+}
+
+/// Parses a per-dir merge file whose template carries FILTRULE_WORD_SPLIT (the
+/// `w` modifier) but not FILTRULE_NO_PREFIXES.
+///
+/// Upstream `parse_filter_file()` tokenises the file on any whitespace when
+/// word-split is active (`exclude.c:1499`) and runs each non-empty token
+/// through the normal rule parser; comments are not stripped in this mode
+/// (`exclude.c:1514`). A token that is not a valid rule (for example a bare
+/// pattern with no `-`/`+` prefix) is an error, matching upstream's
+/// `parse_rule_tok()` "Unknown filter rule" / "unexpected end of filter rule".
+pub(crate) fn parse_rules_word_split(
+    content: &str,
+    source_path: &Path,
+) -> Result<Vec<FilterRule>, MergeFileError> {
+    let mut rules = Vec::new();
+    for token in content.split_whitespace() {
+        rules.push(parse_rule_line(token, source_path, 0)?);
+    }
+    Ok(rules)
 }
 
 /// Modifiers parsed from a rule prefix.
@@ -156,6 +190,7 @@ impl RuleModifiers {
             .with_no_inherit(no_inherit)
             .with_cvs_mode(self.cvs_mode)
             .with_abs_path(self.abs_path)
+            .with_word_split(self.word_split)
             .with_no_prefixes(self.no_prefixes, self.no_prefixes_include);
 
         if self.sender_only && !self.receiver_only {

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -6,7 +6,9 @@ use tempfile::{NamedTempFile, TempDir};
 
 use crate::FilterAction;
 
-use super::parse::{RuleModifiers, parse_modifiers, parse_rules};
+use super::parse::{
+    RuleModifiers, parse_modifiers, parse_rules, parse_rules_no_prefixes, parse_rules_word_split,
+};
 use super::read::{read_rules, read_rules_recursive};
 
 #[test]
@@ -907,4 +909,69 @@ fn parse_dot_c_empty_pattern_defaults_to_cvsignore() {
     assert_eq!(rules[0].action(), FilterAction::Merge);
     assert_eq!(rules[0].pattern(), ".cvsignore");
     assert!(rules[0].is_cvs_mode());
+}
+
+// upstream: exclude.c:1279-1283 - a `:w` dir-merge sets FILTRULE_WORD_SPLIT on
+// its FilterRule so the chain later tokenises the merge file on whitespace.
+#[test]
+fn parse_dir_merge_w_modifier_sets_word_split_on_rule() {
+    let rules = parse_rules(":w .filt\n", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    assert_eq!(rules[0].pattern(), ".filt");
+    assert!(rules[0].is_word_split());
+}
+
+// upstream: exclude.c:1499 - word-split tokenises on any whitespace and parses
+// each token as a rule; `_` separates a token's prefix from its pattern.
+#[test]
+fn parse_rules_word_split_splits_on_any_whitespace() {
+    let rules = parse_rules_word_split("-_*.log\t-_*.tmp -_*.bak\n", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 3);
+    for rule in &rules {
+        assert_eq!(rule.action(), FilterAction::Exclude);
+    }
+    assert_eq!(rules[0].pattern(), "*.log");
+    assert_eq!(rules[1].pattern(), "*.tmp");
+    assert_eq!(rules[2].pattern(), "*.bak");
+}
+
+// upstream: exclude.c:1211-1213 - a bare token with no valid prefix is an
+// "Unknown filter rule" error, same as the non-word-split parser.
+#[test]
+fn parse_rules_word_split_rejects_bare_token() {
+    assert!(parse_rules_word_split("*.log", Path::new("test")).is_err());
+}
+
+// upstream: exclude.c:1122-1133, 1499 - `:w-` tokenises on whitespace with each
+// token a literal exclude (no prefix dispatch).
+#[test]
+fn parse_rules_no_prefixes_word_split_literal_tokens() {
+    let rules = parse_rules_no_prefixes(
+        "*.log\t*.tmp *.bak\n",
+        Path::new("test"),
+        false,
+        false,
+        true,
+    );
+    assert_eq!(rules.len(), 3);
+    assert_eq!(rules[0].pattern(), "*.log");
+    assert_eq!(rules[1].pattern(), "*.tmp");
+    assert_eq!(rules[2].pattern(), "*.bak");
+    assert!(rules.iter().all(|r| r.action() == FilterAction::Exclude));
+}
+
+// Without word-split, the no-prefixes parser keeps its one-pattern-per-line
+// behaviour so a whitespace-separated line is a single literal pattern.
+#[test]
+fn parse_rules_no_prefixes_line_mode_keeps_whole_line() {
+    let rules = parse_rules_no_prefixes(
+        "*.log *.tmp *.bak\n",
+        Path::new("test"),
+        false,
+        false,
+        false,
+    );
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].pattern(), "*.log *.tmp *.bak");
 }

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -80,6 +80,12 @@ pub struct FilterRule {
     ///
     /// upstream: exclude.c:1215-1216 - `case '/': rule->rflags |= FILTRULE_ABS_PATH;`
     pub(crate) abs_path: bool,
+    /// `w` modifier on a merge / dir-merge rule: FILTRULE_WORD_SPLIT. The
+    /// referenced file is tokenised on any whitespace (space, tab, newline)
+    /// with each token parsed as its own rule, rather than one rule per line.
+    ///
+    /// upstream: exclude.c:1279-1283 - `case 'w': rule->rflags |= FILTRULE_WORD_SPLIT;`
+    pub(crate) word_split: bool,
     /// `-`/`+` modifier on a merge / dir-merge rule: FILTRULE_NO_PREFIXES.
     /// Consumes the merged file's lines as literal patterns instead of running
     /// them through the prefix dispatch.
@@ -124,6 +130,7 @@ impl FilterRule {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         }
@@ -158,6 +165,7 @@ impl FilterRule {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         }
@@ -192,6 +200,7 @@ impl FilterRule {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         }
@@ -216,6 +225,7 @@ impl FilterRule {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         }
@@ -241,6 +251,7 @@ impl FilterRule {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         }
@@ -269,6 +280,7 @@ impl FilterRule {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         }
@@ -297,6 +309,7 @@ impl FilterRule {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         }
@@ -329,6 +342,7 @@ impl FilterRule {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         }
@@ -361,6 +375,7 @@ impl FilterRule {
             no_inherit: false,
             cvs_mode: false,
             abs_path: false,
+            word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
         }
@@ -510,6 +525,26 @@ impl FilterRule {
     #[must_use]
     pub const fn with_cvs_mode(mut self, cvs_mode: bool) -> Self {
         self.cvs_mode = cvs_mode;
+        self
+    }
+
+    /// Returns whether the rule carries the `w` (word-split) modifier.
+    ///
+    /// On merge / dir-merge rules, this signals that the referenced file must
+    /// be tokenised on any whitespace, with each token parsed as its own rule.
+    ///
+    /// upstream: exclude.c:1279-1283 - `w` sets FILTRULE_WORD_SPLIT.
+    #[must_use]
+    pub const fn is_word_split(&self) -> bool {
+        self.word_split
+    }
+
+    /// Sets the `w` (word-split) modifier on this rule.
+    ///
+    /// upstream: exclude.c:1279-1283 - `w` sets FILTRULE_WORD_SPLIT.
+    #[must_use]
+    pub const fn with_word_split(mut self, word_split: bool) -> Self {
+        self.word_split = word_split;
         self
     }
 

--- a/crates/protocol/src/filters/prefix.rs
+++ b/crates/protocol/src/filters/prefix.rs
@@ -115,7 +115,17 @@ fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -
     prefix.push(prefix_char);
 
     // Modifier emission order is part of the wire contract; do not reorder.
-    if rule.anchored {
+    // upstream: exclude.c:1543-1544 get_rule_prefix() emits the `/` modifier
+    // only for FILTRULE_ABS_PATH, which is set exclusively on merge/dir-merge
+    // rules (the `/` merge modifier, exclude.c:1238-1239). A command-line
+    // anchored rule such as `- /foo` keeps its leading slash in ent->pattern
+    // and never sets FILTRULE_ABS_PATH, so its anchor rides in the pattern body
+    // (see serialize_rule), not in the prefix. Emitting `/` for a plain exclude
+    // makes the remote parser read it as ABS_PATH plus a bare, non-anchored
+    // pattern that matches the basename at any depth (exclude.c:941-944
+    // rule_matches keys anchoring off a literal leading `/` in the pattern, not
+    // the modifier), wrongly excluding e.g. `sub/foo` as well as `foo`.
+    if rule.anchored && matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) {
         prefix.push('/');
     }
 
@@ -195,12 +205,33 @@ mod tests {
     }
 
     #[test]
-    fn anchored_modifier() {
+    fn anchored_non_merge_omits_slash_modifier() {
+        // upstream: exclude.c:1543-1544 - a command-line anchored rule keeps its
+        // leading slash in the pattern, so FILTRULE_ABS_PATH is unset and no `/`
+        // modifier is emitted. The anchor is written into the pattern body by
+        // serialize_rule() instead.
         let protocol = ProtocolVersion::from_supported(32).unwrap();
         let rule = FilterRuleWireFormat::exclude("test".to_owned()).with_anchored(true);
 
         let prefix = build_rule_prefix(&rule, protocol).unwrap();
-        assert_eq!(prefix, "-/ ");
+        assert_eq!(prefix, "- ");
+    }
+
+    #[test]
+    fn anchored_dir_merge_emits_slash_modifier() {
+        // upstream: exclude.c:1238-1239 / 1543-1544 - the `/` modifier on a
+        // merge/dir-merge rule sets FILTRULE_ABS_PATH and is emitted in the
+        // prefix (e.g. `:/`), anchoring the merged rules to the transfer root.
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        let rule = FilterRuleWireFormat {
+            rule_type: RuleType::DirMerge,
+            pattern: ".rules".to_owned(),
+            anchored: true,
+            ..FilterRuleWireFormat::default()
+        };
+
+        let prefix = build_rule_prefix(&rule, protocol).unwrap();
+        assert_eq!(prefix, ":/ ");
     }
 
     #[test]
@@ -211,8 +242,10 @@ mod tests {
         rule.no_inherit = true;
         rule.cvs_exclude = true;
 
+        // The anchor no longer appears as a `/` prefix modifier on a plain
+        // exclude; it rides in the pattern body (serialize_rule).
         let prefix = build_rule_prefix(&rule, protocol).unwrap();
-        assert_eq!(prefix, "-/Cn ");
+        assert_eq!(prefix, "-Cn ");
     }
 
     #[test]
@@ -296,8 +329,10 @@ mod tests {
         rule.receiver_side = true;
         rule.perishable = true;
 
+        // The `/` anchor is no longer a prefix modifier for a non-merge rule;
+        // it moves into the pattern body (serialize_rule).
         let prefix = build_rule_prefix(&rule, protocol).unwrap();
-        assert_eq!(prefix, "-/!Cnwexsrp ");
+        assert_eq!(prefix, "-!Cnwexsrp ");
     }
 
     #[test]

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -414,7 +414,23 @@ fn parse_wire_rule_modern(
         }
     }
 
-    let pattern_text = &text[pattern_start..];
+    let mut pattern_text = &text[pattern_start..];
+
+    // Non-merge rules encode the anchor as a leading `/` in the pattern body
+    // (upstream keeps it in ent->pattern with FILTRULE_ABS_PATH unset). Fold it
+    // back into the `anchored` flag so the parsed rule matches what
+    // build_wire_format_rules() produced (bare pattern + anchored bit) and
+    // round-trips byte-identically through serialize_rule(). Merge and
+    // dir-merge rules reserve the leading `/` for FILTRULE_ABS_PATH, consumed as
+    // the `/` prefix modifier in the loop above.
+    if !rule.anchored
+        && !matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge)
+        && pattern_text.len() > 1
+        && pattern_text.starts_with('/')
+    {
+        rule.anchored = true;
+        pattern_text = &pattern_text[1..];
+    }
 
     if let Some(stripped) = pattern_text.strip_suffix('/') {
         rule.directory_only = true;
@@ -442,6 +458,19 @@ fn serialize_rule(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -> io:
         )
     })?;
     let mut bytes = prefix.into_bytes();
+    // Non-merge anchored rules carry the anchor as a leading `/` in the pattern
+    // body, mirroring upstream whose command-line `- /foo` keeps the slash in
+    // ent->pattern with FILTRULE_ABS_PATH unset (exclude.c:200-208). The `/`
+    // prefix modifier is reserved for merge/dir-merge ABS_PATH rules
+    // (build_rule_prefix), so add the slash here for every other rule type.
+    // `pattern` stores the bare body; split_pattern_modifiers() (client) and
+    // parse_wire_rule_modern() (server) fold the leading `/` into `anchored`.
+    if rule.anchored
+        && !matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge)
+        && !rule.pattern.starts_with('/')
+    {
+        bytes.push(b'/');
+    }
     bytes.extend_from_slice(rule.pattern.as_bytes());
 
     if rule.directory_only {
@@ -500,7 +529,9 @@ mod tests {
     #[test]
     fn anchored_pattern() {
         let protocol = ProtocolVersion::from_supported(32).unwrap();
-        let rule = FilterRuleWireFormat::exclude("/tmp".to_owned()).with_anchored(true);
+        // Canonical client form: bare pattern body plus the `anchored` bit, as
+        // produced by build_wire_format_rules()/split_pattern_modifiers().
+        let rule = FilterRuleWireFormat::exclude("tmp".to_owned()).with_anchored(true);
 
         let mut buf = Vec::new();
         write_filter_list(&mut buf, std::slice::from_ref(&rule), protocol).unwrap();
@@ -508,7 +539,40 @@ mod tests {
         let parsed = read_filter_list(&mut &buf[..], protocol).unwrap();
         assert_eq!(parsed.len(), 1);
         assert!(parsed[0].anchored);
-        assert_eq!(parsed[0].pattern, "/tmp");
+        assert_eq!(parsed[0].pattern, "tmp");
+    }
+
+    #[test]
+    fn anchored_exclude_wire_bytes_match_upstream() {
+        // Regression: an anchored command-line rule (`--filter '- /drop.txt'`)
+        // must serialize as `- /drop.txt` (leading slash in the PATTERN), not
+        // `-/ drop.txt` (slash as the ABS_PATH prefix modifier). Upstream keeps
+        // the slash in ent->pattern with FILTRULE_ABS_PATH unset, so its sender
+        // anchors the match to the transfer root (exclude.c:941-944). Encoding
+        // the slash as the `/` modifier instead makes the remote sender treat
+        // it as an unanchored basename match, wrongly excluding `sub/drop.txt`
+        // as well as top-level `drop.txt` from the flist.
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        let rule = FilterRuleWireFormat::exclude("drop.txt".to_owned()).with_anchored(true);
+
+        let mut buf = Vec::new();
+        write_filter_list(&mut buf, std::slice::from_ref(&rule), protocol).unwrap();
+
+        // 4-byte LE length (11 = len of "- /drop.txt"), the rule bytes, then the
+        // 4-byte LE zero terminator.
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&11i32.to_le_bytes());
+        expected.extend_from_slice(b"- /drop.txt");
+        expected.extend_from_slice(&0i32.to_le_bytes());
+        assert_eq!(buf, expected, "anchored exclude must emit `- /drop.txt`");
+
+        // And it must round-trip back to the canonical bare-pattern + anchored
+        // representation so oc<->oc transfers stay symmetric.
+        let parsed = read_filter_list(&mut &buf[..], protocol).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].rule_type, RuleType::Exclude);
+        assert!(parsed[0].anchored);
+        assert_eq!(parsed[0].pattern, "drop.txt");
     }
 
     #[test]

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -499,6 +499,17 @@ fn wire_rule_to_dir_merge_config(
         config = config.with_perishable(true);
     }
 
+    // `w` modifier: FILTRULE_WORD_SPLIT. The per-directory merge file is
+    // tokenised on any whitespace, with each token parsed as its own rule
+    // (exclude.c:1279-1283, tokenised at exclude.c:1499). Without carrying
+    // this on the sender's merge load, a `:w .filt` whose file holds
+    // whitespace-separated patterns is parsed one-rule-per-line, so a line
+    // like `-_a -_b -_c` collapses into a single malformed rule instead of
+    // three. Mirror the local parser, which already word-splits.
+    if wire_rule.word_split {
+        config = config.with_word_split(true);
+    }
+
     // `C` modifier: CVS-style ignore list. Mirror upstream's implicit
     // NO_PREFIXES | WORD_SPLIT | NO_INHERIT | CVS_IGNORE so that the dir
     // merge filename's contents are parsed as whitespace-separated exclude
@@ -654,6 +665,32 @@ mod tests {
     /// `one-in-one-out` fail standard merge parsing and abort the walk.
     /// Upstream's `:C` does NOT exclude the merge file itself; only the
     /// explicit `e` modifier does.
+    /// A `:w .filt` dir-merge arrives over the wire with `word_split=true`.
+    /// The remote sender must carry that onto the `DirMergeConfig` so the
+    /// per-directory file is tokenised on whitespace, matching the local path.
+    /// Without this the sender parses the merge file one-rule-per-line and a
+    /// whitespace-separated rule list collapses into a single malformed rule.
+    #[test]
+    fn wire_rule_to_dir_merge_config_word_split_flag_sets_word_split() {
+        let mut wire_rule = make_dir_merge_wire_rule(".filt");
+        wire_rule.word_split = true;
+        let config = wire_rule_to_dir_merge_config(&wire_rule, true);
+        assert!(config.word_split());
+        // A plain `:w` must not imply CVS-mode or no-prefixes.
+        assert!(!config.cvs_mode());
+        assert!(!config.no_prefixes());
+    }
+
+    #[test]
+    fn wire_rule_to_dir_merge_config_word_split_combines_with_no_prefixes() {
+        let mut wire_rule = make_dir_merge_wire_rule(".filt");
+        wire_rule.word_split = true;
+        wire_rule.no_prefixes = true;
+        let config = wire_rule_to_dir_merge_config(&wire_rule, true);
+        assert!(config.word_split());
+        assert!(config.no_prefixes());
+    }
+
     #[test]
     fn wire_rule_to_dir_merge_config_cvs_flag_enables_cvs_mode() {
         let mut wire_rule = make_dir_merge_wire_rule(".cvsignore");

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -10734,13 +10734,23 @@ CONF
   fmm_case "perishable"     --filter='-p drop.txt'
   fmm_case "cvs-exclude"    -C
   fmm_case "dironly"        --filter='- sub/'
+  # Anchored (leading-`/`) rule: matches only at the transfer root, so the
+  # top-level drop.txt is excluded while sub/drop.txt is transferred. The PUSH
+  # leg makes the oc client the sender, exercising its anchored-rule matching
+  # (exclude.c:903-960 rule_matches ABS_ANCHOR).
+  fmm_case "anchored-root"  --filter='- /drop.txt'
 
-  # Per-directory merge modifiers n / e / w are exercised in the pull direction:
-  # the merge file lives in the daemon module, the upstream daemon applies the
-  # dir-merge, and the oc client must land the same tree as the upstream client.
+  # Per-directory merge modifiers n / e / w are exercised in BOTH directions:
+  #   PULL - the merge file lives in the daemon module, the upstream daemon is
+  #          the sender, and the oc client (receiver) must land the same tree.
+  #   PUSH - the merge file lives in the client's source tree, so the oc client
+  #          is the SENDER that parses the per-directory merge file. This is the
+  #          only leg that exercises oc's own dir-merge parsing (FilterChain),
+  #          giving the word-split (`w`) modifier real teeth.
   fmm_case_merge() {
     local label=$1 mergefile=$2 mergebody=$3 dirmerge=$4
 
+    # --- PULL: upstream daemon is the sender ---
     fmm_seed_src "$fmm_mod"; printf '%s\n' "$mergebody" > "$fmm_mod/$mergefile"
     local d_oc="${base}/pm-oc" d_up="${base}/pm-up"
     fmm_seed_dst "$d_oc"; fmm_seed_dst "$d_up"
@@ -10755,16 +10765,41 @@ CONF
       sed 's/^/      /' "${log}.fmm.${label}.pull.diff" | head -8
       fail=1
     fi
+
+    # --- PUSH: the client is the sender and parses the merge file itself ---
+    local src="${base}/pm-push-src"
+    fmm_seed_src "$src"; printf '%s\n' "$mergebody" > "$src/$mergefile"
+    fmm_seed_dst "$fmm_mod"
+    timeout "$hard_timeout" "$oc_bin" -a --delete --timeout=10 --filter="$dirmerge" \
+      "$src/" "rsync://127.0.0.1:${upstream_port}/interop/" \
+      >"${log}.fmm.${label}.push-oc.out" 2>&1
+    local t_oc; t_oc=$(cd "$fmm_mod" && find . | LC_ALL=C sort && echo "--content--" && \
+      find . -type f | LC_ALL=C sort | xargs -r md5sum 2>/dev/null | sed "s#  .*/#  #")
+    fmm_seed_dst "$fmm_mod"
+    timeout "$hard_timeout" "$upstream_binary" -a --delete --timeout=10 --filter="$dirmerge" \
+      "$src/" "rsync://127.0.0.1:${upstream_port}/interop/" \
+      >"${log}.fmm.${label}.push-up.out" 2>&1
+    local t_up; t_up=$(cd "$fmm_mod" && find . | LC_ALL=C sort && echo "--content--" && \
+      find . -type f | LC_ALL=C sort | xargs -r md5sum 2>/dev/null | sed "s#  .*/#  #")
+    if [[ "$t_oc" != "$t_up" ]]; then
+      echo "    [$label] merge PUSH tree diverges from upstream:"
+      diff <(echo "$t_up") <(echo "$t_oc") | sed 's/^/      /' | head -8
+      fail=1
+    fi
   }
 
   # n: per-dir merge without inheritance. e: merge file excludes itself.
-  # w: whitespace-split rules. The positive `w` case pairs word-split with the
-  # `-` no-prefix modifier so the bare tokens "a.txt b.txt" become two separate
-  # excludes (a plain "- a.txt b.txt" is a syntax error under word-split because
-  # the "-" splits off as an empty rule - upstream exclude.c:1326).
-  fmm_case_merge "merge-n" ".rules" "- b.txt"      ":n .rules"
-  fmm_case_merge "merge-e" ".rules" "- b.txt"      ":e .rules"
-  fmm_case_merge "merge-w" ".rules" "a.txt b.txt"  ":w- .rules"
+  # w: whitespace-split rules. Three word-split shapes are pinned:
+  #   :w- (no-prefix) - bare tokens "a.txt b.txt" become two literal excludes.
+  #   :w  (prefixed)  - "_"-separated tokens "-_a.txt -_b.txt" become two excludes
+  #                     (a plain "- a.txt" is a syntax error under word-split
+  #                     because the "-" splits off as an empty rule, exclude.c:1326).
+  # A plain "- a.txt b.txt" under word-split MUST fail identically on both
+  # clients, so the byte-for-byte comparison covers the error path too.
+  fmm_case_merge "merge-n"   ".rules" "- b.txt"           ":n .rules"
+  fmm_case_merge "merge-e"   ".rules" "- b.txt"           ":e .rules"
+  fmm_case_merge "merge-w"   ".rules" "a.txt b.txt"       ":w- .rules"
+  fmm_case_merge "merge-w-p" ".rules" "-_a.txt	-_b.txt" ":w .rules"
 
   stop_upstream_daemon
 


### PR DESCRIPTION
## Summary

Two pre-existing behaviours were audited on oc-rsync's remote/server **sender** filter path (surfaced alongside the #6414 modifier interop matrix), validated on Linux against upstream rsync 3.4.3 over both remote-shell and daemon transports:

- **Anchored `/`-prefixed rules** (`--filter='- /drop.txt'`): **already correct.** oc excludes only the transfer-root `drop.txt` and transfers `sub/drop.txt`, matching upstream over local, remote-shell, and daemon. No change needed; a regression test and interop case now pin it.
- **Word-split (`w`) dir-merge** (`:w` / `:w-`): **fixed here.** It parsed correctly in local mode but not on the remote/server sender.

## Bug (word-split on the remote sender)

The wire carried the `w` (`FILTRULE_WORD_SPLIT`) modifier, but the sender's wire→`DirMergeConfig` conversion dropped it. The `FilterChain` then read each per-directory merge file one rule per line instead of tokenising it on whitespace, so a whitespace-separated pattern list like `-_a.txt -_b.txt` (or bare `a.txt b.txt` under `:w-`) collapsed into a single malformed rule and none of the patterns took effect. The sender transferred files upstream rsync excludes. Local mode was unaffected because it uses a separate parser.

## Fix

Word-split now lives once in the `filters` crate and is applied uniformly on sender, receiver, and local paths:

- `FilterRule` and `DirMergeConfig` carry a `word_split` flag; `RuleModifiers::apply` and the wire→`DirMergeConfig` conversion set it from the `w` modifier.
- `FilterChain::enter_directory` / `load_inline_dir_merge` tokenise the merge file on any whitespace when `word_split` is set, parsing each token as its own rule (`parse_rules_word_split`); `:w-` extends the no-prefixes parser to split on whitespace too. Comments are not stripped in word-split mode and a bare token with no valid prefix is an error, matching upstream.

upstream: `exclude.c:1279-1283` `parse_rule_tok` (`w` → `FILTRULE_WORD_SPLIT`), `exclude.c:1447-1519` `parse_filter_file` (whitespace token loop, no comment skip), `exclude.c:903-960` `rule_matches` (ABS_ANCHOR).

## Validation (Linux, vs upstream rsync 3.4.3)

| Case | local | remote-shell pull | daemon pull | push→daemon |
|------|-------|-------------------|-------------|-------------|
| `- /drop.txt` (anchored) | ✓ | ✓ | ✓ | ✓ |
| `:w .filt` word-split | ✓ | ✓ (fixed) | ✓ (fixed) | ✓ (fixed) |
| `:w- .filt` word-split | ✓ | ✓ (fixed) | ✓ (fixed) | ✓ (fixed) |

All outputs match upstream byte-for-byte. `cargo fmt --all --check` and `cargo clippy -p filters -p transfer` clean; the full `filters` test suite (1382 tests) and targeted `transfer` tests pass; `filters`/`transfer` remain unsafe-free.

## Tests / interop

- Regression tests: word-split parsing (`:w`, `:w-`, bare-token error), anchored-root non-nested matching, and the wire→`DirMergeConfig` `word_split` mapping.
- `tools/ci/run_interop.sh` filter-modifier matrix gains a **push leg** for the per-directory merge cases (making the oc client the sender that parses the merge file — the only leg that exercises oc's own dir-merge parsing), a prefixed `:w` case, and an anchored `- /drop.txt` case, all diffed oc-vs-upstream with teeth.

