### PR TITLE
docs(matching): fix unresolved intra-doc link breaking Pages build

### DIFF
--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -618,7 +618,7 @@ impl DeltaSignatureIndex {
     /// same (partial) length.
     ///
     /// The full-length matchers reject any window whose length differs from
-    /// `block_length`, and [`populate_index`] deliberately excludes partial
+    /// `block_length`, and `populate_index` deliberately excludes partial
     /// blocks from the tag/bithash/lookup tables. That leaves the basis file's
     /// final short block unmatchable through the fast paths, so the sender
     /// would always emit the source file's trailing partial block as literal


### PR DESCRIPTION
The `populate_index` reference in the partial-tail matcher doc (crates/matching/src/index/mod.rs) pointed at a private free function in `index/builder.rs`, which rustdoc cannot resolve as an intra-doc link. Under `RUSTDOCFLAGS=-D warnings` (the Pages workflow) this aborted the whole-workspace doc build with `could not document matching`, turning the master Pages deployment red.

Fix: demote the reference to a plain code span (backtick-only), matching how other private-helper references in the crate are written. Verified `cargo doc -p matching --no-deps --all-features` builds clean with warnings-as-errors.

No behavior change; documentation only.