### PR TITLE
chore(deps): bump zlib-rs 0.6.4 -> 0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4682,9 +4682,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"


### PR DESCRIPTION
Bumps the transitive `zlib-rs` dependency (pure-Rust zlib backend, pulled via the optional `flate2/zlib-rs` feature) from 0.6.4 to 0.6.6.

**Why:** 0.6.6 fixes an unsound return lifetime on `WeakSliceMut::as_mut_slice()` (a genuine memory-safety correction, relevant to `--features zlib-rs` builds) and adds zlib 1.3.2 API coverage (`deflateUsed`, `usize`-length `_z` variants). Semver-compatible 0.6.x patch.

**Scope:** `Cargo.lock` only - no source, no public API, no default-feature change (default backend remains miniz_oxide).