### PR TITLE
docs(transfer): fix unresolved intra-doc links breaking Pages build

### DIFF
--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -465,7 +465,7 @@ impl SenderAttrs {
     /// Reads the receiver's per-file sender-response header
     /// (NDX + iflags + optional basis-type / xname / xattr-abbreviation data)
     /// off an [`AsyncRead`](tokio::io::AsyncRead), driving the same
-    /// [`NdxCodecEnum::read_ndx_async`] and [`read_varint_async`] leaves plus
+    /// `NdxCodecEnum::read_ndx_async` and `read_varint_async` leaves plus
     /// the shared sans-io decode helpers ([`parse_fnamecmp_type`],
     /// [`xname_len_from_bytes`], [`check_xname_len`], [`want_xattr_read`]) as
     /// the sync leaf. For the same wire bytes it yields the same
@@ -750,7 +750,7 @@ fn check_xattr_datum_len(raw_len: i32) -> io::Result<usize> {
 ///
 /// Reads the identical `(rel_pos, datum_len, value)` sequence (`.await`-driven)
 /// through the same shared bounds helpers ([`accumulate_xattr_num`],
-/// [`check_xattr_datum_len`]) and [`read_varint_async`], so it returns the same
+/// [`check_xattr_datum_len`]) and `read_varint_async`, so it returns the same
 /// `(num, value)` pairs and consumes the same bytes as the sync leaf. Gated on
 /// `tokio-transfer`.
 #[cfg(feature = "tokio-transfer")]


### PR DESCRIPTION
Follow-up to #6418. `cargo doc` aborts on the first crate with a broken link, so #6418 (which fixed `matching`) revealed the next: `crates/transfer/src/receiver/wire.rs` doc comments linked `NdxCodecEnum::read_ndx_async` and `read_varint_async`, whose definitions live in the `protocol` crate and are not in scope in `transfer`. Under `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links` (the Pages workflow) this failed the whole-workspace doc build with `could not document transfer`, keeping the master Pages deployment red.

These async twins are `#[cfg(feature = "tokio-transfer")]`-gated, so a plain `-D warnings` build does not surface them. Fix: demote both references to plain code spans (backtick-only), matching how the sync-leaf references are written. Documentation only, no behavior change.