### PR TITLE
fix(protocol): honor --checksum-choice during binary negotiation

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -101,7 +101,8 @@ fn apply_common_daemon_config(
     server_config.write.io_uring_policy = config.io_uring_policy();
     server_config.write.io_uring_depth = config.io_uring_depth();
     server_config.write.zero_copy_policy = config.zero_copy_policy();
-    server_config.checksum_choice = config.checksum_protocol_override();
+    // checksum_choice is set once in `apply_common_server_flags` (called above
+    // for both receiver and generator), shared with the SSH transfer paths.
     server_config.connection.compression_level = config.compression_level();
 
     // upstream: options.c:2704,2800-2805 - replicate the compress flag/option

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -377,6 +377,13 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     server_config.file_selection.delete_missing_args = config.delete_missing_args();
     // upstream: options.c:89 do_compression_threads, token.c:701 ZSTD_c_nbWorkers
     server_config.connection.compression_threads = config.compression_threads();
+    // upstream: compat.c:819 parse_checksum_choice(1) - an explicit
+    // --checksum-choice=ALGO forces the negotiated checksum for the transfer.
+    // Carry it onto this local ServerConfig so the in-process generator/receiver
+    // half (SSH and daemon transfers alike) forwards it into the capability
+    // negotiator's checksum_override; without this the choice is silently
+    // dropped at protocol >= 30 (binary negotiation).
+    server_config.checksum_choice = config.checksum_protocol_override();
 }
 
 #[cfg(test)]

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -468,9 +468,14 @@ const fn signature_checksum_nstr_name(
 /// copy, mirroring what upstream's forked `local_child` server prints via
 /// `parse_checksum_choice` / `parse_compress_choice`.
 ///
-/// The local path performs no vstring negotiation, so the `" negotiated"`
-/// qualifier stays blank (upstream leaves `negotiated_nni` NULL when the
-/// algorithm is not chosen through `negotiate_the_strings()`). The trace
+/// Upstream's local transfer forks a child connected over a socketpair and runs
+/// the full protocol, including `negotiate_the_strings()` with
+/// `do_negotiated_strings` set (the local child sends the `v` capability). So
+/// when the user did NOT force an algorithm, `valid_checksums.negotiated_nni`
+/// is set and the summary renders the `" negotiated"` qualifier; an explicit
+/// `--checksum-choice` / `--compress-choice` bypasses negotiation and the
+/// qualifier stays blank. The oc local path performs no wire negotiation, so we
+/// synthesize the same qualifier from whether a choice was forced. The trace
 /// helpers self-gate on the NSTR debug level, so this is a no-op unless
 /// `--debug=NSTR` is active.
 ///
@@ -480,9 +485,12 @@ const fn signature_checksum_nstr_name(
 fn emit_local_copy_nstr_summaries(config: &ClientConfig) {
     use protocol::nstr::{NstrSide, trace_checksum_summary, trace_compress_summary};
 
+    // upstream: checksum.c:209 - the qualifier renders iff negotiated_nni is
+    // set, which happens when no --checksum-choice forced the algorithm.
+    let checksum_negotiated = config.checksum_protocol_override().is_none();
     trace_checksum_summary(
         NstrSide::Client,
-        false,
+        checksum_negotiated,
         signature_checksum_nstr_name(config.checksum_signature_algorithm()),
     );
 
@@ -503,7 +511,11 @@ fn emit_local_copy_nstr_summaries(config: &ClientConfig) {
         .compress_choice_name()
         .unwrap_or_else(|| algorithm.name());
     let level = resolve_nstr_compress_level(algorithm, config.compression_level());
-    trace_compress_summary(NstrSide::Client, false, name, level);
+    // upstream: compat.c:218 - the compress " negotiated" qualifier renders
+    // when do_negotiated_strings selected the codec, i.e. when no explicit
+    // --compress-choice (compress_choice_name) forced it.
+    let compress_negotiated = config.compress_choice_name().is_none();
+    trace_compress_summary(NstrSide::Client, compress_negotiated, name, level);
 }
 
 /// Resolves the compress level rendered in the `--debug=NSTR` summary,

--- a/crates/core/tests/compression_integration.rs
+++ b/crates/core/tests/compression_integration.rs
@@ -300,9 +300,13 @@ fn local_copy_emits_nstr_summaries_under_debug_nstr() {
         // Checksum summary always fires. oc's default strong checksum choice
         // (`Auto`) resolves to the strongest mutually negotiated checksum,
         // which for a modern local copy is xxh128 - matching upstream's
-        // negotiated `file_sum_nni` (checksum.c parse_checksum_choice).
+        // negotiated `file_sum_nni` (checksum.c parse_checksum_choice). No
+        // --checksum-choice was forced, so upstream's local child negotiates
+        // the algorithm and renders the " negotiated" qualifier (checksum.c:209).
         assert!(
-            messages.iter().any(|m| m == "Client checksum: xxh128"),
+            messages
+                .iter()
+                .any(|m| m == "Client negotiated checksum: xxh128"),
             "expected NSTR checksum summary for local copy: {messages:?}"
         );
         // Compress fires because -z is active. upstream calls
@@ -320,7 +324,7 @@ fn local_copy_emits_nstr_summaries_under_debug_nstr() {
             CompressionAlgorithm::Lz4 => 0,
         };
         let expected = format!(
-            "Client compress: {} (level {default_level})",
+            "Client negotiated compress: {} (level {default_level})",
             default_algo.name(),
         );
         assert!(
@@ -361,7 +365,7 @@ fn local_copy_nstr_compress_summary_renders_explicit_level() {
         assert!(
             messages
                 .iter()
-                .any(|m| m.starts_with("Client compress: ") && m.ends_with("(level 9)")),
+                .any(|m| m.starts_with("Client negotiated compress: ") && m.ends_with("(level 9)")),
             "expected compress summary to render level 9: {messages:?}"
         );
     });

--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -264,16 +264,20 @@ pub fn negotiate_capabilities_with_override(
         NstrSide::Client
     };
 
-    // Send our supported algorithm lists. upstream: compat.c:541-544
-    // When --checksum-choice overrides the selection, advertise only that
-    // algorithm (upstream options.c replaces valid_checksums with the user's
-    // choice so negotiate_the_strings sees a single-entry list).
-    let checksum_list = match checksum_override {
-        Some(algo) => algo.as_str().to_owned(),
-        None => advertised_list(SUPPORTED_CHECKSUMS.iter().copied(), is_server),
-    };
-    trace_send_list(side, NstrCategory::Checksum, &checksum_list);
-    write_vstring(stdout, &checksum_list)?;
+    // Send our supported algorithm lists. upstream: compat.c:541-544 - the
+    // checksum vstring is sent only when `!checksum_choice`. When
+    // --checksum-choice forces the algorithm, the exchange is skipped
+    // entirely: `send_negotiate_str` is not called, so `valid_checksums.saw`
+    // stays NULL and the matching recv (compat.c:547) is also skipped. The
+    // peer forwards the same --checksum-choice, so both sides skip
+    // symmetrically. Sending a single-entry list here would desync against an
+    // upstream peer that sends nothing.
+    let send_checksum = checksum_override.is_none();
+    if send_checksum {
+        let checksum_list = advertised_list(SUPPORTED_CHECKSUMS.iter().copied(), is_server);
+        trace_send_list(side, NstrCategory::Checksum, &checksum_list);
+        write_vstring(stdout, &checksum_list)?;
+    }
 
     if send_compression {
         let compression_list = advertised_list(supported_compressions(), is_server);
@@ -283,10 +287,17 @@ pub fn negotiate_capabilities_with_override(
 
     stdout.flush()?;
 
-    // Read the remote side's algorithm lists. upstream: compat.c:373-378
+    // Read the remote side's algorithm lists. upstream: compat.c:547 - the
+    // checksum recv is gated on `valid_checksums.saw`, which is only set by the
+    // send above, so it mirrors the send gating exactly. compat.c:373-378
     // recv_negotiate_str emits "<remote> <type> list (on <local>): <list>".
-    let remote_checksum_list = read_vstring(stdin)?;
-    trace_recv_list(side, NstrCategory::Checksum, &remote_checksum_list);
+    let remote_checksum_list = if send_checksum {
+        let list = read_vstring(stdin)?;
+        trace_recv_list(side, NstrCategory::Checksum, &list);
+        Some(list)
+    } else {
+        None
+    };
 
     let remote_compression_list = if send_compression {
         let list = read_vstring(stdin)?;
@@ -304,26 +315,15 @@ pub fn negotiate_capabilities_with_override(
     // Client iterates local list, picks first item also in server's list (remote).
     // Both sides converge on the same result: first client item in server's list.
     //
-    // When the user forced a checksum via --checksum-choice, verify the remote
-    // advertises it and use it unconditionally.
+    // When the user forced a checksum via --checksum-choice, upstream's
+    // parse_checksum_choice resolves the name directly (checksum.c:178-184) with
+    // no wire exchange, so use it unconditionally.
     let checksum = match checksum_override {
-        Some(forced) => {
-            let forced_name = forced.as_str();
-            if remote_checksum_list
-                .split_whitespace()
-                .any(|name| name == forced_name)
-            {
-                forced
-            } else {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "--checksum-choice '{forced_name}' is not supported by the remote side (remote offers: {remote_checksum_list})"
-                    ),
-                ));
-            }
+        Some(forced) => forced,
+        None => {
+            let list = remote_checksum_list.as_deref().unwrap_or("");
+            choose_checksum_algorithm(list, is_server)?
         }
-        None => choose_checksum_algorithm(&remote_checksum_list, is_server)?,
     };
 
     // upstream: compat.c:819 parse_compress_choice(1) - when the user

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -370,8 +370,10 @@ fn test_negotiate_nstr_summary_omits_negotiated_when_forced() {
     let _ = drain_events();
 
     let protocol = ProtocolVersion::try_from(32).unwrap();
-    // Peer advertises md5 so the forced choice succeeds.
-    let client_response = b"\x03md5\x04zlib";
+    // With --checksum-choice forced, no checksum vstring is exchanged
+    // (upstream compat.c:541 skips send, compat.c:547 skips recv). The peer
+    // sends only the compression vstring.
+    let client_response = b"\x04zlib";
     let mut stdin = &client_response[..];
     let mut stdout = Vec::new();
 
@@ -416,6 +418,48 @@ fn test_negotiate_nstr_summary_omits_negotiated_when_forced() {
             .iter()
             .any(|m| m == "Client negotiated checksum: md5"),
         "forced-choice summary must not include ' negotiated': {messages:?}"
+    );
+}
+
+/// Confirms an explicit `--checksum-choice=xxh128` override forces the
+/// negotiated checksum to xxh128 regardless of automatic list selection.
+/// upstream: checksum.c:178-184 - when `checksum_choice` is set,
+/// `parse_checksum_choice` resolves the algorithm directly from the name
+/// instead of `valid_checksums.negotiated_nni`.
+#[test]
+fn test_checksum_override_forces_chosen_algorithm() {
+    let protocol = ProtocolVersion::try_from(32).unwrap();
+    // A forced checksum skips the checksum vstring exchange entirely
+    // (upstream compat.c:541/547). With compression also off, nothing is read
+    // from the peer, so `stdin` is empty and `stdout` must carry no checksum
+    // vstring.
+    let mut stdin = &b""[..];
+    let mut stdout = Vec::new();
+
+    let result = negotiate_capabilities_with_override(
+        protocol,
+        &mut stdin,
+        &mut stdout,
+        &NegotiationConfig {
+            do_negotiation: true,
+            send_compression: false,
+            is_daemon_mode: false,
+            is_server: false,
+            checksum_override: Some(ChecksumAlgorithm::XXH128),
+            compression_override: None,
+            compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        result.checksum,
+        ChecksumAlgorithm::XXH128,
+        "checksum_override=xxh128 must force the chosen algorithm"
+    );
+    assert!(
+        stdout.is_empty(),
+        "a forced checksum must not send a checksum vstring: {stdout:?}"
     );
 }
 

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -481,6 +481,7 @@ pub fn run_server_with_handshake<W: Write>(
         do_compression,
         compress_choice: compress_choice_algo,
         compression_level,
+        checksum_choice: config.checksum_choice,
         checksum_seed: config.checksum_seed,
         allow_inc_recurse,
     };

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -148,7 +148,11 @@ pub fn setup_protocol_with<'a>(
                     send_compression,
                     is_daemon_mode: config.is_daemon_mode,
                     is_server: config.is_server,
-                    checksum_override: None,
+                    // upstream: compat.c:819 parse_checksum_choice(1) - an
+                    // explicit --checksum-choice=ALGO forces the algorithm and
+                    // skips the checksum vstring exchange (compat.c:541). Mirror
+                    // the compress_choice threading directly above.
+                    checksum_override: config.checksum_choice,
                     compression_override: config.compress_choice,
                     compression_level: config.compression_level,
                 },

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -75,6 +75,7 @@ fn ssh_server_flag_string_limits_compat_flags() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: true,
@@ -111,6 +112,7 @@ fn ssh_server_flag_string_enables_advertised_caps() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: true,
@@ -144,6 +146,7 @@ fn ssh_server_no_flag_string_uses_defaults() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
@@ -279,6 +282,7 @@ fn setup_protocol_below_30_returns_none_for_algorithms_and_compat() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -319,6 +323,7 @@ fn setup_protocol_skip_compat_exchange_skips_flags() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -362,6 +367,7 @@ fn setup_protocol_server_writes_compat_flags_and_seed() {
         is_daemon_mode: true, // server advertises, client reads
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -418,6 +424,7 @@ fn setup_protocol_client_reads_compat_flags_from_server() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -462,6 +469,7 @@ fn setup_protocol_server_generates_deterministic_seeds() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -512,6 +520,7 @@ fn setup_protocol_ssh_mode_bidirectional_exchange() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -556,6 +565,7 @@ fn setup_protocol_client_args_affects_compat_flags() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -588,6 +598,7 @@ fn setup_protocol_client_args_affects_compat_flags() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -632,6 +643,7 @@ fn setup_protocol_protocol_30_minimum_for_compat_exchange() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -1020,6 +1032,7 @@ fn setup_protocol_server_v_flag_uses_single_byte_encoding() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -1067,6 +1080,7 @@ fn setup_protocol_server_v_flag_enables_negotiation() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -1100,6 +1114,7 @@ fn setup_protocol_server_v_flag_with_both_v_and_uppercase_v() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
@@ -1120,6 +1135,7 @@ fn setup_protocol_server_v_flag_with_both_v_and_uppercase_v() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
@@ -1274,12 +1290,14 @@ impl CapabilityNegotiator for MockNegotiator {
         _stdout: &mut dyn std::io::Write,
         config: &protocol::NegotiationConfig,
     ) -> std::io::Result<protocol::NegotiationResult> {
-        // Honour the override when provided, matching the real negotiator
+        // Honour the overrides when provided, matching the real negotiator
+        // (negotiate.rs uses the forced choice directly instead of the list).
         let compression = config
             .compression_override
             .unwrap_or(self.fixed_compression);
+        let checksum = config.checksum_override.unwrap_or(self.fixed_checksum);
         Ok(protocol::NegotiationResult {
-            checksum: self.fixed_checksum,
+            checksum,
             compression,
         })
     }
@@ -1315,6 +1333,7 @@ fn setup_protocol_with_mock_negotiator_server_mode() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -1361,6 +1380,7 @@ fn setup_protocol_with_mock_negotiator_client_mode() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
@@ -1656,6 +1676,7 @@ fn compress_choice_override_skips_vstring_and_uses_algorithm() {
         is_daemon_mode: true,
         do_compression: true,
         compress_choice: Some(protocol::CompressionAlgorithm::Zstd),
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
@@ -1691,6 +1712,7 @@ fn compress_choice_none_allows_normal_negotiation() {
         is_daemon_mode: true,
         do_compression: true,
         compress_choice: None,
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
@@ -1726,6 +1748,7 @@ fn compress_choice_zlib_override_on_legacy_protocol() {
         is_daemon_mode: false,
         do_compression: true,
         compress_choice: Some(protocol::CompressionAlgorithm::ZlibX),
+        checksum_choice: None,
         compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
@@ -1741,6 +1764,109 @@ fn compress_choice_zlib_override_on_legacy_protocol() {
         algos.compression,
         protocol::CompressionAlgorithm::ZlibX,
         "compress_choice=zlibx should be used on legacy protocol"
+    );
+}
+
+// -- checksum-choice negotiation tests --
+
+#[test]
+fn checksum_choice_override_threads_into_negotiation() {
+    // upstream: compat.c:819 parse_checksum_choice(1) - an explicit
+    // --checksum-choice=ALGO forces the transfer checksum, skipping the
+    // vstring exchange. The setup layer must forward ProtocolSetupConfig's
+    // checksum_choice into NegotiationConfig::checksum_override.
+    let protocol = ProtocolVersion::try_from(31).unwrap();
+    let mut stdin = &b""[..];
+    let mut stdout = Vec::new();
+
+    let client_args = ["-efxCIvu".to_owned()];
+    let config = ProtocolSetupConfig {
+        protocol,
+        skip_compat_exchange: false,
+        client_args: Some(&client_args),
+        flag_string: None,
+        is_server: true,
+        is_daemon_mode: true,
+        do_compression: false,
+        compress_choice: None,
+        checksum_choice: Some(protocol::ChecksumAlgorithm::XXH128),
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
+        checksum_seed: Some(42),
+        allow_inc_recurse: false,
+    };
+
+    let mock = MockNegotiator::new();
+    let result = setup_protocol_with(&mut stdout, &mut stdin, &config, &mock)
+        .expect("checksum-choice override setup should succeed");
+
+    let algos = result.negotiated_algorithms.unwrap();
+    assert_eq!(
+        algos.checksum,
+        protocol::ChecksumAlgorithm::XXH128,
+        "checksum_choice=xxh128 should override the negotiated checksum"
+    );
+}
+
+#[test]
+fn checksum_choice_none_allows_normal_negotiation() {
+    // Without an explicit --checksum-choice the negotiator picks the algorithm
+    // via the automatic list; the mock returns its default (MD5) unchanged.
+    let protocol = ProtocolVersion::try_from(31).unwrap();
+    let mut stdin = &b""[..];
+    let mut stdout = Vec::new();
+
+    let client_args = ["-efxCIvu".to_owned()];
+    let config = ProtocolSetupConfig {
+        protocol,
+        skip_compat_exchange: false,
+        client_args: Some(&client_args),
+        flag_string: None,
+        is_server: true,
+        is_daemon_mode: true,
+        do_compression: false,
+        compress_choice: None,
+        checksum_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
+        checksum_seed: Some(42),
+        allow_inc_recurse: false,
+    };
+
+    let mock = MockNegotiator::new();
+    let result = setup_protocol_with(&mut stdout, &mut stdin, &config, &mock)
+        .expect("normal checksum negotiation should succeed");
+
+    let algos = result.negotiated_algorithms.unwrap();
+    assert_eq!(
+        algos.checksum,
+        protocol::ChecksumAlgorithm::MD5,
+        "without checksum_choice, the mock returns its default (MD5)"
+    );
+}
+
+#[test]
+fn with_checksum_choice_builder_method() {
+    let protocol = ProtocolVersion::try_from(31).unwrap();
+
+    let config = ProtocolSetupConfig::new(protocol, true)
+        .with_checksum_choice(Some(protocol::ChecksumAlgorithm::XXH128));
+
+    assert_eq!(
+        config.checksum_choice,
+        Some(protocol::ChecksumAlgorithm::XXH128)
+    );
+}
+
+#[test]
+fn with_checksum_choice_none_clears_override() {
+    let protocol = ProtocolVersion::try_from(31).unwrap();
+
+    let config = ProtocolSetupConfig::new(protocol, true)
+        .with_checksum_choice(Some(protocol::ChecksumAlgorithm::XXH128))
+        .with_checksum_choice(None);
+
+    assert!(
+        config.checksum_choice.is_none(),
+        "second with_checksum_choice(None) should clear the override"
     );
 }
 

--- a/crates/transfer/src/setup/types.rs
+++ b/crates/transfer/src/setup/types.rs
@@ -2,7 +2,9 @@
 //!
 //! Contains the result and configuration structs used by `setup_protocol()`.
 
-use protocol::{CompatibilityFlags, CompressionAlgorithm, NegotiationResult, ProtocolVersion};
+use protocol::{
+    ChecksumAlgorithm, CompatibilityFlags, CompressionAlgorithm, NegotiationResult, ProtocolVersion,
+};
 
 /// Result of protocol setup containing negotiated algorithms and compatibility flags.
 #[derive(Debug, Clone)]
@@ -97,6 +99,18 @@ pub struct ProtocolSetupConfig<'a> {
     /// unless `--compress-level` was passed.
     pub compression_level: i32,
 
+    /// Explicit checksum algorithm from `--checksum-choice=ALGO`.
+    ///
+    /// When set, this algorithm is forced during Protocol 30+ capability
+    /// negotiation instead of using automatic negotiation. Passed through as
+    /// the negotiator's `checksum_override`, mirroring how `compress_choice`
+    /// feeds `compression_override`.
+    ///
+    /// upstream: compat.c:819 parse_checksum_choice(1) - an explicit
+    /// `checksum_choice` bypasses `negotiate_the_strings()` (compat.c:541
+    /// only sends the checksum vstring `if (!checksum_choice)`).
+    pub checksum_choice: Option<ChecksumAlgorithm>,
+
     /// Optional user-specified checksum seed from `--checksum-seed=NUM`.
     ///
     /// When `Some(seed)`, the server uses this fixed seed instead of generating
@@ -149,6 +163,7 @@ impl<'a> ProtocolSetupConfig<'a> {
             do_compression: false,
             compress_choice: None,
             compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
+            checksum_choice: None,
             checksum_seed: None,
             allow_inc_recurse: false,
         }
@@ -207,6 +222,13 @@ impl<'a> ProtocolSetupConfig<'a> {
     #[must_use]
     pub const fn with_compress_choice(mut self, choice: Option<CompressionAlgorithm>) -> Self {
         self.compress_choice = choice;
+        self
+    }
+
+    /// Sets [`Self::checksum_choice`].
+    #[must_use]
+    pub const fn with_checksum_choice(mut self, choice: Option<ChecksumAlgorithm>) -> Self {
+        self.checksum_choice = choice;
         self
     }
 


### PR DESCRIPTION
## Problem

An explicit `--checksum-choice=ALGO` was silently dropped during protocol >= 30 binary capability negotiation (SSH and daemon transfers). The negotiation layer fully supported an override, but the setup layer hardcoded `checksum_override: None`, so the client always auto-negotiated the highest algorithm (xxh128) regardless of the requested one.

A latent wire bug compounded this: even with the choice threaded, oc-rsync sent a single-entry checksum vstring and read the peer's, while upstream sends and reads **nothing** when a checksum is forced (`compat.c:541/547`, gated on `!checksum_choice` / `valid_checksums.saw`). Against an upstream peer (which forwards the same `--checksum-choice` and thus also skips), this desynced the stream (`vstring too long`).

## Fix

1. **Thread the choice** from the transfer `Config` through `ProtocolSetupConfig` into `NegotiationConfig::checksum_override`, mirroring the existing `compress_choice` threading. Populate the transfer `ServerConfig` on the SSH and daemon client paths via the shared `apply_common_server_flags` (the daemon path's duplicate assignment is removed).
2. **Match upstream wire gating** (`compat.c:541/547`): when a checksum is forced, neither send nor read the checksum vstring. Both sides forward the same choice and skip symmetrically. The forced algorithm is used directly, matching `parse_checksum_choice` (`checksum.c:178-184`).
3. **Local NSTR fidelity**: emit the `" negotiated"` qualifier for a local copy only when no choice was forced, matching upstream's `negotiated_nni` gating (the forked local child negotiates when `do_negotiated_strings` is set).

## Verification (rsync 3.4.3, aarch64)

Byte-identical trees (`diff -r`) and byte-identical `--debug=NSTR` output vs upstream, over **SSH and daemon**, in **both directions**, with `--checksum-choice=md5 / xxh128 / none`:

| case | before | after |
|------|--------|-------|
| oc client -> upstream server, forced | `vstring too long` (fail) | trees identical |
| upstream client -> oc server, forced | connection closed (fail) | trees identical |
| SSH NSTR, forced md5 | `Client negotiated checksum: xxh128` (dropped) | `Client checksum: md5` (== upstream) |
| local NSTR, no choice | `Client checksum: xxh128` | `Client negotiated checksum: xxh128` (== upstream) |

Auto-negotiation (no `--checksum-choice`) is unchanged and still picks xxh128 > xxh3 > ... > md5.

## Tests

- `ProtocolSetupConfig` forwards `checksum_choice` into `NegotiationConfig` (setup layer, forced + auto cases + builder).
- `negotiate_capabilities_with_override` forces the chosen algorithm and sends no checksum vstring.
- Updated the forced-choice negotiation test to reflect the no-exchange wire behavior.
- Updated local-copy NSTR tests for the corrected `" negotiated"` qualifier.
