### PR TITLE
perf: memoize uid/gid name lookups during flist build

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
@@ -11,7 +11,7 @@ use std::time::UNIX_EPOCH;
 
 use crate::local_copy::{CopyContext, LocalCopyError};
 #[cfg(unix)]
-use metadata::id_lookup::{lookup_group_name, lookup_user_name};
+use metadata::id_lookup::{lookup_group_name_cached, lookup_user_name_cached};
 
 /// Builds a protocol [`FileEntry`](protocol::flist::FileEntry) from filesystem metadata.
 ///
@@ -95,12 +95,12 @@ fn build_protocol_file_entry(
         // are set. The FileListWriter xflags computation checks whether the
         // entry has a name set via these accessors.
         if !numeric_ids {
-            if let Some(name) = lookup_user_name(uid).ok().flatten() {
+            if let Some(name) = lookup_user_name_cached(uid).ok().flatten() {
                 if let Ok(s) = String::from_utf8(name) {
                     entry.set_user_name(s);
                 }
             }
-            if let Some(name) = lookup_group_name(gid).ok().flatten() {
+            if let Some(name) = lookup_group_name_cached(gid).ok().flatten() {
                 if let Ok(s) = String::from_utf8(name) {
                     entry.set_group_name(s);
                 }

--- a/crates/metadata/src/id_lookup/converter.rs
+++ b/crates/metadata/src/id_lookup/converter.rs
@@ -49,3 +49,12 @@ pub fn clear_name_converter() {
         *slot.borrow_mut() = None;
     });
 }
+
+/// Reports whether a name converter is installed on the current thread.
+///
+/// The process-wide name memo bypasses caching when this returns `true`,
+/// because converter results are thread-local and must not be shared across
+/// threads.
+pub(super) fn has_name_converter() -> bool {
+    NAME_CONVERTER_SLOT.with(|slot| slot.borrow().is_some())
+}

--- a/crates/metadata/src/id_lookup/mod.rs
+++ b/crates/metadata/src/id_lookup/mod.rs
@@ -24,6 +24,7 @@
 #[cfg(unix)]
 mod cache;
 mod converter;
+mod name_cache;
 #[cfg(unix)]
 mod nss;
 #[cfg(not(unix))]
@@ -32,6 +33,7 @@ mod nss_stub;
 #[cfg(unix)]
 pub use cache::{map_gid, map_uid};
 pub use converter::{NameConverterCallbacks, clear_name_converter, set_name_converter};
+pub use name_cache::{lookup_group_name_cached, lookup_user_name_cached};
 #[cfg(unix)]
 pub use nss::{lookup_group_by_name, lookup_group_name, lookup_user_by_name, lookup_user_name};
 #[cfg(not(unix))]
@@ -60,6 +62,9 @@ pub fn map_gid(gid: u32, _numeric_ids: bool) -> Option<u32> {
 #[cfg(test)]
 #[cfg(unix)]
 pub use cache::{clear_id_caches, gid_cache_size, uid_cache_size};
+
+#[cfg(test)]
+pub use name_cache::{clear_name_caches, nss_lookup_count, reset_nss_lookup_count};
 
 #[cfg(test)]
 mod tests;

--- a/crates/metadata/src/id_lookup/name_cache.rs
+++ b/crates/metadata/src/id_lookup/name_cache.rs
@@ -1,0 +1,124 @@
+//! Process-wide memoization of UID/GID to name resolution.
+//!
+//! Upstream rsync records each distinct uid/gid the first time it appears while
+//! building the file list, so a transfer of N files with K distinct owners
+//! performs K name lookups, not N. This module mirrors that behaviour: a
+//! process-global id to name memo backs the per-file flist name lookups so that
+//! glibc's `getpwuid_r`/`getgrgid_r` (which reopen and reparse `/etc/passwd` and
+//! `/etc/group` on every call) run at most once per distinct id per process.
+//!
+//! The memo caches the "no such name" (`None`) outcome as well, and stores the
+//! resolved bytes verbatim so a cached lookup is byte-for-byte identical to the
+//! uncached one. When a thread-local name converter is installed the cache is
+//! bypassed, because converter results are per-thread and must not be shared.
+//!
+//! upstream: uidlist.c:456-480 - add_uid()/add_gid() cache each id once.
+
+use super::converter::has_name_converter;
+use super::{lookup_group_name, lookup_user_name};
+use std::collections::HashMap;
+use std::io;
+use std::sync::{LazyLock, RwLock};
+
+/// Id to resolved-name memo. The `None` value caches a "no such name" outcome.
+type NameMemo = LazyLock<RwLock<HashMap<u32, Option<Box<[u8]>>>>>;
+
+/// Process-wide UID to username memo.
+///
+/// Uses `RwLock` because the map is read once per file but written only once
+/// per distinct uid.
+static UID_NAME_CACHE: NameMemo = LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Process-wide GID to group-name memo.
+static GID_NAME_CACHE: NameMemo = LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Counts underlying NSS lookups on the miss path (test-only).
+#[cfg(test)]
+static NSS_LOOKUP_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Records a miss-path NSS lookup for the regression counter.
+#[cfg(test)]
+fn record_nss_lookup() {
+    NSS_LOOKUP_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// No-op outside tests.
+#[cfg(not(test))]
+fn record_nss_lookup() {}
+
+/// Looks up the username for `uid`, memoizing the result process-wide.
+///
+/// Behaviourally identical to [`super::lookup_user_name`], including the cached
+/// `None` result for unknown ids, but performs at most one NSS query per
+/// distinct uid for the lifetime of the process. Bypasses the cache when a
+/// thread-local name converter is installed.
+pub fn lookup_user_name_cached(uid: u32) -> Result<Option<Vec<u8>>, io::Error> {
+    if has_name_converter() {
+        return lookup_user_name(uid);
+    }
+
+    if let Ok(cache) = UID_NAME_CACHE.read() {
+        if let Some(entry) = cache.get(&uid) {
+            return Ok(entry.as_deref().map(<[u8]>::to_vec));
+        }
+    }
+
+    record_nss_lookup();
+    let name = lookup_user_name(uid)?;
+
+    if let Ok(mut cache) = UID_NAME_CACHE.write() {
+        cache.insert(uid, name.as_deref().map(Box::<[u8]>::from));
+    }
+
+    Ok(name)
+}
+
+/// Looks up the group name for `gid`, memoizing the result process-wide.
+///
+/// Behaviourally identical to [`super::lookup_group_name`], including the cached
+/// `None` result for unknown ids, but performs at most one NSS query per
+/// distinct gid for the lifetime of the process. Bypasses the cache when a
+/// thread-local name converter is installed.
+pub fn lookup_group_name_cached(gid: u32) -> Result<Option<Vec<u8>>, io::Error> {
+    if has_name_converter() {
+        return lookup_group_name(gid);
+    }
+
+    if let Ok(cache) = GID_NAME_CACHE.read() {
+        if let Some(entry) = cache.get(&gid) {
+            return Ok(entry.as_deref().map(<[u8]>::to_vec));
+        }
+    }
+
+    record_nss_lookup();
+    let name = lookup_group_name(gid)?;
+
+    if let Ok(mut cache) = GID_NAME_CACHE.write() {
+        cache.insert(gid, name.as_deref().map(Box::<[u8]>::from));
+    }
+
+    Ok(name)
+}
+
+/// Clears the name memos. Test-only; production caches live for the process.
+#[cfg(test)]
+pub fn clear_name_caches() {
+    if let Ok(mut cache) = UID_NAME_CACHE.write() {
+        cache.clear();
+    }
+    if let Ok(mut cache) = GID_NAME_CACHE.write() {
+        cache.clear();
+    }
+}
+
+/// Resets the miss-path NSS lookup counter. Test-only.
+#[cfg(test)]
+pub fn reset_nss_lookup_count() {
+    NSS_LOOKUP_COUNT.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Returns the miss-path NSS lookup count since the last reset. Test-only.
+#[cfg(test)]
+pub fn nss_lookup_count() -> u64 {
+    NSS_LOOKUP_COUNT.load(std::sync::atomic::Ordering::Relaxed)
+}

--- a/crates/metadata/src/id_lookup/tests.rs
+++ b/crates/metadata/src/id_lookup/tests.rs
@@ -1,12 +1,18 @@
 //! Tests for UID/GID lookup and mapping.
 
 use super::*;
-#[cfg(unix)]
 use std::sync::{Mutex, OnceLock};
 
 /// Global lock to serialize tests that modify shared caches.
 #[cfg(unix)]
 fn cache_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Global lock serializing tests that touch the process-wide name memo and its
+/// miss counter (both are shared mutable state).
+fn name_cache_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
 }
@@ -351,4 +357,139 @@ fn non_unix_map_uid_numeric_ids_flag_ignored() {
 #[test]
 fn non_unix_map_gid_numeric_ids_flag_ignored() {
     assert_eq!(map_gid(42, true), map_gid(42, false));
+}
+
+// Process-wide name memo (name_cache): each distinct id must trigger at most one
+// underlying NSS lookup, mirroring upstream add_uid()/add_gid().
+
+#[test]
+fn cached_user_name_looks_up_once_per_distinct_id() {
+    let _lock = name_cache_lock().lock().unwrap();
+    clear_name_caches();
+    reset_nss_lookup_count();
+
+    let first = lookup_user_name_cached(0).unwrap();
+    for _ in 0..8 {
+        let repeat = lookup_user_name_cached(0).unwrap();
+        assert_eq!(repeat, first, "cached name must be byte-for-byte identical");
+    }
+
+    assert_eq!(
+        nss_lookup_count(),
+        1,
+        "a distinct uid must hit NSS at most once"
+    );
+}
+
+#[test]
+fn cached_group_name_looks_up_once_per_distinct_id() {
+    let _lock = name_cache_lock().lock().unwrap();
+    clear_name_caches();
+    reset_nss_lookup_count();
+
+    let first = lookup_group_name_cached(0).unwrap();
+    for _ in 0..8 {
+        let repeat = lookup_group_name_cached(0).unwrap();
+        assert_eq!(repeat, first, "cached name must be byte-for-byte identical");
+    }
+
+    assert_eq!(
+        nss_lookup_count(),
+        1,
+        "a distinct gid must hit NSS at most once"
+    );
+}
+
+#[test]
+fn cached_user_name_matches_uncached_bytes() {
+    let _lock = name_cache_lock().lock().unwrap();
+    clear_name_caches();
+
+    let uncached = lookup_user_name(0).unwrap();
+    let cached = lookup_user_name_cached(0).unwrap();
+    assert_eq!(cached, uncached);
+}
+
+#[test]
+fn cached_group_name_matches_uncached_bytes() {
+    let _lock = name_cache_lock().lock().unwrap();
+    clear_name_caches();
+
+    let uncached = lookup_group_name(0).unwrap();
+    let cached = lookup_group_name_cached(0).unwrap();
+    assert_eq!(cached, uncached);
+}
+
+#[test]
+fn cached_lookup_memoizes_missing_id() {
+    let _lock = name_cache_lock().lock().unwrap();
+    clear_name_caches();
+    reset_nss_lookup_count();
+
+    // A non-existent id resolves to None; the None outcome must be cached too so
+    // repeated misses do not re-hit NSS.
+    let first = lookup_user_name_cached(999_999_999).unwrap();
+    let second = lookup_user_name_cached(999_999_999).unwrap();
+    assert_eq!(first, second);
+    assert_eq!(
+        nss_lookup_count(),
+        1,
+        "a cached None must not re-trigger NSS lookups"
+    );
+}
+
+#[test]
+fn cached_lookup_distinct_ids_each_look_up() {
+    let _lock = name_cache_lock().lock().unwrap();
+    clear_name_caches();
+    reset_nss_lookup_count();
+
+    let _ = lookup_user_name_cached(0).unwrap();
+    let _ = lookup_user_name_cached(999_999_998).unwrap();
+    assert_eq!(
+        nss_lookup_count(),
+        2,
+        "two distinct ids must each trigger exactly one NSS lookup"
+    );
+}
+
+struct FixedConverter;
+
+impl NameConverterCallbacks for FixedConverter {
+    fn uid_to_name(&mut self, _uid: u32) -> Option<String> {
+        Some("converted-user".to_string())
+    }
+    fn gid_to_name(&mut self, _gid: u32) -> Option<String> {
+        Some("converted-group".to_string())
+    }
+    fn name_to_uid(&mut self, _name: &str) -> Option<u32> {
+        None
+    }
+    fn name_to_gid(&mut self, _name: &str) -> Option<u32> {
+        None
+    }
+}
+
+#[test]
+fn cached_lookup_bypasses_cache_when_converter_installed() {
+    let _lock = name_cache_lock().lock().unwrap();
+    clear_name_caches();
+    reset_nss_lookup_count();
+
+    set_name_converter(Box::new(FixedConverter));
+
+    // The converter's per-thread result must win and must not consult or
+    // populate the process-wide memo.
+    let user = lookup_user_name_cached(4242).unwrap();
+    assert_eq!(user, Some(b"converted-user".to_vec()));
+    let group = lookup_group_name_cached(4242).unwrap();
+    assert_eq!(group, Some(b"converted-group".to_vec()));
+
+    assert_eq!(
+        nss_lookup_count(),
+        0,
+        "converter path must not touch the memo miss counter"
+    );
+
+    clear_name_converter();
 }

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -261,7 +261,7 @@ impl GeneratorContext {
             // sending via XMIT_USER_NAME_FOLLOWS when INC_RECURSE is active.
             // Without names, the receiver can't map uid->name on the remote.
             if !self.config.flags.numeric_ids {
-                if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_user_name(uid) {
+                if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_user_name_cached(uid) {
                     if let Ok(name) = String::from_utf8(name_bytes) {
                         entry.set_user_name(name);
                     }
@@ -277,7 +277,7 @@ impl GeneratorContext {
             // upstream: flist.c:476-480 - add_gid() looks up name for inline
             // sending via XMIT_GROUP_NAME_FOLLOWS when INC_RECURSE is active.
             if !self.config.flags.numeric_ids {
-                if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_group_name(gid) {
+                if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_group_name_cached(gid) {
                     if let Ok(name) = String::from_utf8(name_bytes) {
                         entry.set_group_name(name);
                     }

--- a/crates/transfer/src/generator/file_list/hardlinks.rs
+++ b/crates/transfer/src/generator/file_list/hardlinks.rs
@@ -83,7 +83,7 @@ impl GeneratorContext {
     /// - `uidlist.c:add_uid()` / `add_gid()` - called during file list building
     #[cfg(unix)]
     pub fn collect_id_mappings(&mut self) {
-        use metadata::id_lookup::{lookup_group_name, lookup_user_name};
+        use metadata::id_lookup::{lookup_group_name_cached, lookup_user_name_cached};
 
         // Skip if numeric_ids is set - no name mapping needed
         if self.config.flags.numeric_ids {
@@ -99,7 +99,7 @@ impl GeneratorContext {
                 if let Some(uid) = entry.uid() {
                     // Skip expensive lookup if we already have this UID
                     if !self.uid_list.contains(uid) {
-                        let name = lookup_user_name(uid).ok().flatten();
+                        let name = lookup_user_name_cached(uid).ok().flatten();
                         self.uid_list.add_id(uid, name);
                     }
                 }
@@ -110,7 +110,7 @@ impl GeneratorContext {
                 if let Some(gid) = entry.gid() {
                     // Skip expensive lookup if we already have this GID
                     if !self.gid_list.contains(gid) {
-                        let name = lookup_group_name(gid).ok().flatten();
+                        let name = lookup_group_name_cached(gid).ok().flatten();
                         self.gid_list.add_id(gid, name);
                     }
                 }

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -99,7 +99,7 @@ impl GeneratorContext {
     /// or when the sender-side ACL cache is unavailable.
     #[cfg(unix)]
     pub(crate) fn collect_acl_id_mappings(&mut self) {
-        use metadata::id_lookup::{lookup_group_name, lookup_user_name};
+        use metadata::id_lookup::{lookup_group_name_cached, lookup_user_name_cached};
 
         if self.config.flags.numeric_ids || !self.config.flags.acls {
             return;
@@ -121,11 +121,11 @@ impl GeneratorContext {
         for (id, is_user) in named {
             if is_user {
                 if !self.uid_list.contains(id) {
-                    let name = lookup_user_name(id).ok().flatten();
+                    let name = lookup_user_name_cached(id).ok().flatten();
                     self.uid_list.add_id(id, name);
                 }
             } else if !self.gid_list.contains(id) {
-                let name = lookup_group_name(id).ok().flatten();
+                let name = lookup_group_name_cached(id).ok().flatten();
                 self.gid_list.add_id(id, name);
             }
         }


### PR DESCRIPTION
## Problem

A no-change push over SSH of a ~42k-file tree runs ~2.3x slower than upstream rsync. Root cause: the sender resolves each file's owner and group name with an uncached `getpwuid_r`/`getgrgid_r` while building the file list. glibc reopens and reparses `/etc/passwd` and `/etc/group` on every one of those calls, so the sender performs ~42k `/etc/passwd` opens (upstream: 8). `--numeric-ids`, which skips the name lookup, was already at parity, confirming the lookups are the cost.

## Fix

Upstream records each distinct id the first time it appears while building the flist (`uidlist.c` `add_uid`/`add_gid`), so it resolves K distinct owners rather than N files. This mirrors that: a process-wide id->name memo in the `metadata` crate (`RwLock<HashMap>`, `LazyLock`, no unsafe) backs the per-file flist name lookups, so each distinct uid/gid triggers at most one NSS query per process.

- New `crates/metadata/src/id_lookup/name_cache.rs`: `lookup_user_name_cached` / `lookup_group_name_cached`. Caches the "no such name" (`None`) outcome too and stores/returns bytes verbatim, so a cached lookup is byte-for-byte identical to the uncached one. When a thread-local name converter is installed the memo is bypassed (converter results are per-thread).
- Rerouted the per-file flist name-lookup sites: `generator/file_list/entry/create.rs`, `generator/file_list/hardlinks.rs`, `generator/protocol_io.rs`, and `engine/.../directory/recursive/batch.rs`.

No wire-format change. `--numeric-ids` still bypasses name lookup entirely.

## Tests

Added regression tests in the `id_lookup` suite asserting each distinct id triggers at most one underlying NSS lookup (call counter), that the `None` outcome is memoized, that cached bytes equal uncached bytes, and that an installed converter bypasses the memo.