### PR TITLE
fix: pass raw filename bytes to output under --8-bit-output

### DIFF
--- a/crates/cli/src/frontend/escape.rs
+++ b/crates/cli/src/frontend/escape.rs
@@ -46,21 +46,25 @@ fn should_escape_byte(byte: u8, eight_bit: bool) -> bool {
 ///
 /// Literal `\#ddd` sequences (where each `d` is an ASCII digit) in the
 /// input are also escaped to prevent ambiguity with the escape notation.
-pub(crate) fn escape_for_output(input: &[u8], allow_8bit: bool) -> String {
-    // Fast path: all bytes ASCII-printable or tab (0x09, 0x20-0x7E) -> already
-    // valid UTF-8 with no byte needing escaping in either mode, so return as-is.
+///
+/// The return value is a raw byte buffer, not a `String`: upstream
+/// `filtered_fwrite` writes filename bytes to the output fd unmodified, so a
+/// lone invalid-UTF-8 byte (e.g. `0x80`) passed through under `--8-bit-output`
+/// must survive verbatim. A `String` cannot hold arbitrary invalid UTF-8, so
+/// returning `Vec<u8>` and writing it directly to a byte sink is the only way
+/// to reach byte-for-byte parity with upstream on that edge case.
+pub(crate) fn escape_for_output(input: &[u8], allow_8bit: bool) -> Vec<u8> {
+    // Fast path: all bytes ASCII-printable or tab (0x09, 0x20-0x7E) -> no byte
+    // needs escaping in either mode and there is no literal `\#ddd` to guard,
+    // so return the bytes verbatim.
     //
     // DEL (0x7F) and high bytes (0x80-0xFF) are deliberately excluded here so
     // they always take the slow path, which applies the correct per-mode
-    // handling: escape as \#ooo when !allow_8bit, or pass through as the Latin-1
-    // code point when allow_8bit. A previous `from_utf8_lossy` 8-bit fast path
-    // was wrong - it replaced high bytes with U+FFFD instead of preserving them.
+    // handling: escape as \#ooo when !allow_8bit, or pass through raw when
+    // allow_8bit.
     let all_safe = input.iter().all(|&b| is_c_print(b) || b == b'\t');
     if all_safe && !has_literal_escape_sequence(input) {
-        // SAFETY: all bytes are 0x09 or 0x20-0x7E, which is valid ASCII/UTF-8.
-        if let Ok(s) = String::from_utf8(input.to_vec()) {
-            return s;
-        }
+        return input.to_vec();
     }
 
     escape_bytes_slow(input, allow_8bit)
@@ -85,16 +89,15 @@ fn has_literal_escape_sequence(input: &[u8]) -> bool {
     false
 }
 
-/// Slow path: escapes bytes one at a time into a byte buffer.
+/// Slow path: escapes bytes one at a time into a raw byte buffer.
 ///
 /// Non-escaped bytes are emitted raw (upstream `filtered_fwrite` copies the
 /// input byte verbatim). This matters under `-8`: a multi-byte UTF-8 filename
-/// such as `café` (bytes `63 61 66 c3 a9`) must pass through as the original
-/// bytes `c3 a9`, not be re-encoded. A previous `push(byte as char)` mapped
-/// each byte to a Unicode code point and re-encoded it as UTF-8, producing
-/// mojibake (`c3 83 c2 a9` = `Ã©`). The buffer is converted with
-/// `from_utf8_lossy` at the end so valid UTF-8 sequences round-trip exactly.
-fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> String {
+/// such as `café` (bytes `63 61 66 c3 a9`) passes through as the original bytes
+/// `c3 a9`, and a lone invalid byte such as `0x80` passes through as the single
+/// byte `80` - neither is re-encoded nor replaced with U+FFFD. Escaped bytes
+/// are written as their ASCII `\#ooo` form.
+fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> Vec<u8> {
     let mut output: Vec<u8> = Vec::with_capacity(input.len() + input.len() / 4);
     let len = input.len();
     let mut i = 0;
@@ -125,15 +128,17 @@ fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> String {
         i += 1;
     }
 
-    String::from_utf8_lossy(&output).into_owned()
+    output
 }
 
-/// Escapes a path for display output.
+/// Escapes a path for display output, returning raw bytes.
 ///
 /// On Unix, operates on the raw bytes of the path to faithfully represent
 /// non-UTF-8 filenames. On other platforms, falls back to `to_string_lossy()`
-/// before escaping.
-pub(crate) fn escape_path(path: &Path, allow_8bit: bool) -> String {
+/// before escaping. The bytes are meant to be written directly to a byte sink
+/// (stdout/stderr); interpolating them through a `String` would replace lone
+/// invalid bytes with U+FFFD, diverging from upstream `filtered_fwrite`.
+pub(crate) fn escape_path(path: &Path, allow_8bit: bool) -> Vec<u8> {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;
@@ -146,13 +151,13 @@ pub(crate) fn escape_path(path: &Path, allow_8bit: bool) -> String {
     }
 }
 
-/// Escapes a string for display output.
+/// Escapes a string for display output, returning raw bytes.
 ///
 /// Convenience wrapper for already-converted strings (e.g. from
 /// `to_string_lossy()`). Escapes non-printable bytes in the UTF-8
 /// representation.
 #[cfg(test)]
-fn escape_str(s: &str, allow_8bit: bool) -> String {
+fn escape_str(s: &str, allow_8bit: bool) -> Vec<u8> {
     escape_for_output(s.as_bytes(), allow_8bit)
 }
 
@@ -165,93 +170,101 @@ mod tests {
     #[test]
     fn ascii_printable_passes_through() {
         let input = b"hello_world.txt";
-        assert_eq!(escape_for_output(input, false), "hello_world.txt");
+        assert_eq!(escape_for_output(input, false), b"hello_world.txt".to_vec());
     }
 
     #[test]
     fn space_passes_through() {
         let input = b"hello world.txt";
-        assert_eq!(escape_for_output(input, false), "hello world.txt");
+        assert_eq!(escape_for_output(input, false), b"hello world.txt".to_vec());
     }
 
     #[test]
     fn tab_passes_through() {
         let input = b"before\tafter";
-        assert_eq!(escape_for_output(input, false), "before\tafter");
+        assert_eq!(escape_for_output(input, false), b"before\tafter".to_vec());
     }
 
     #[test]
     fn control_char_0x01_escaped() {
-        assert_eq!(escape_for_output(&[0x01], false), "\\#001");
+        assert_eq!(escape_for_output(&[0x01], false), b"\\#001".to_vec());
     }
 
     #[test]
     fn del_0x7f_escaped() {
-        assert_eq!(escape_for_output(&[0x7F], false), "\\#177");
+        assert_eq!(escape_for_output(&[0x7F], false), b"\\#177".to_vec());
     }
 
     #[test]
     fn high_bit_0x80_escaped_in_default_mode() {
-        assert_eq!(escape_for_output(&[0x80], false), "\\#200");
+        // upstream: default mode (use_isprint=1) octal-escapes a lone high byte.
+        assert_eq!(escape_for_output(&[0x80], false), b"\\#200".to_vec());
     }
 
     #[test]
     fn high_bit_0xff_escaped_in_default_mode() {
-        assert_eq!(escape_for_output(&[0xFF], false), "\\#377");
+        assert_eq!(escape_for_output(&[0xFF], false), b"\\#377".to_vec());
     }
 
     #[test]
     fn null_byte_escaped() {
-        assert_eq!(escape_for_output(&[0x00], false), "\\#000");
+        assert_eq!(escape_for_output(&[0x00], false), b"\\#000".to_vec());
     }
 
     #[test]
     fn mixed_printable_and_control() {
         let input = b"file\x01name\x7f.txt";
-        assert_eq!(escape_for_output(input, false), "file\\#001name\\#177.txt");
+        assert_eq!(
+            escape_for_output(input, false),
+            b"file\\#001name\\#177.txt".to_vec()
+        );
     }
 
     #[test]
     fn all_specified_bytes_escaped_correctly() {
         // Verify the exact values from the task description.
-        assert_eq!(escape_for_output(&[0x01], false), "\\#001");
-        assert_eq!(escape_for_output(&[0x7F], false), "\\#177");
-        assert_eq!(escape_for_output(&[0x80], false), "\\#200");
-        assert_eq!(escape_for_output(&[0xFF], false), "\\#377");
+        assert_eq!(escape_for_output(&[0x01], false), b"\\#001".to_vec());
+        assert_eq!(escape_for_output(&[0x7F], false), b"\\#177".to_vec());
+        assert_eq!(escape_for_output(&[0x80], false), b"\\#200".to_vec());
+        assert_eq!(escape_for_output(&[0xFF], false), b"\\#377".to_vec());
     }
 
     // -- escape_for_output: 8-bit mode (allow_8bit = true) --
 
     #[test]
     fn control_char_escaped_in_8bit_mode() {
-        assert_eq!(escape_for_output(&[0x01], true), "\\#001");
+        assert_eq!(escape_for_output(&[0x01], true), b"\\#001".to_vec());
     }
 
     #[test]
     fn del_0x7f_passes_through_in_8bit_mode() {
         // upstream: with use_isprint=0 (allow_8bit=1), the condition is
         // byte != '\t' && byte < ' ', which excludes 0x7F.
-        assert_eq!(escape_for_output(&[0x7F], true), "\x7F");
+        assert_eq!(escape_for_output(&[0x7F], true), vec![0x7F]);
     }
 
     #[test]
-    fn lone_high_byte_0x80_is_not_escaped_in_8bit_mode() {
-        // A lone 0x80 is not octal-escaped under -8 (upstream passes it raw),
-        // but it is invalid UTF-8 on its own and cannot live in a Rust String,
-        // so from_utf8_lossy yields U+FFFD. Valid multi-byte UTF-8 filenames
-        // (the realistic case) round-trip exactly - see
-        // `multibyte_utf8_passes_raw_in_8bit_mode`.
-        assert_eq!(escape_for_output(&[0x80], true), "\u{FFFD}");
+    fn lone_high_byte_0x80_is_raw_in_8bit_mode() {
+        // upstream: `filtered_fwrite` writes the raw byte to the output fd when
+        // allow_8bit_chars is set (log.c:225-246). A lone 0x80 is invalid UTF-8
+        // and cannot live in a Rust String, so the escape layer returns raw
+        // bytes and the writer emits exactly one byte, matching `rsync -8`
+        // byte-for-byte. Previously the `from_utf8_lossy` return type yielded
+        // U+FFFD here.
+        assert_eq!(escape_for_output(&[0x80], true), vec![0x80]);
+        // Exactly one byte reaches the sink - no U+FFFD (ef bf bd) expansion.
+        assert_eq!(escape_for_output(&[0x80], true).len(), 1);
     }
 
     #[test]
-    fn lone_high_byte_0xff_is_not_escaped_in_8bit_mode() {
-        assert_eq!(escape_for_output(&[0xFF], true), "\u{FFFD}");
+    fn lone_high_byte_0xff_is_raw_in_8bit_mode() {
+        assert_eq!(escape_for_output(&[0xFF], true), vec![0xFF]);
+        assert_eq!(escape_for_output(&[0xFF], true).len(), 1);
     }
 
     #[test]
     fn tab_passes_through_in_8bit_mode() {
-        assert_eq!(escape_for_output(b"\t", true), "\t");
+        assert_eq!(escape_for_output(b"\t", true), b"\t".to_vec());
     }
 
     #[test]
@@ -262,8 +275,7 @@ mod tests {
         // would re-encode to c3 83 c2 a9 (mojibake `Ã©`).
         let input = b"caf\xc3\xa9";
         let out = escape_for_output(input, true);
-        assert_eq!(out.as_bytes(), b"caf\xc3\xa9");
-        assert_eq!(out, "café");
+        assert_eq!(out, b"caf\xc3\xa9".to_vec());
     }
 
     #[test]
@@ -271,14 +283,14 @@ mod tests {
         // WHY: default mode (use_isprint=1) escapes every non-printable byte,
         // so each UTF-8 continuation byte of `café` becomes its own \#ooo.
         let input = b"caf\xc3\xa9";
-        assert_eq!(escape_for_output(input, false), "caf\\#303\\#251");
+        assert_eq!(escape_for_output(input, false), b"caf\\#303\\#251".to_vec());
     }
 
     #[test]
     fn only_control_chars_escaped_in_8bit_mode() {
         // 0x01 and 0x7F: only 0x01 is escaped (< 0x20)
         let input = &[0x01, 0x7F];
-        assert_eq!(escape_for_output(input, true), "\\#001\x7F");
+        assert_eq!(escape_for_output(input, true), b"\\#001\x7F".to_vec());
     }
 
     // -- Literal \#ddd sequence escaping --
@@ -287,27 +299,33 @@ mod tests {
     fn literal_escape_sequence_is_escaped() {
         // A filename containing literal \#001 should escape the backslash.
         let input = b"file\\#001.txt";
-        assert_eq!(escape_for_output(input, false), "file\\#134#001.txt");
+        assert_eq!(
+            escape_for_output(input, false),
+            b"file\\#134#001.txt".to_vec()
+        );
     }
 
     #[test]
     fn literal_escape_sequence_escaped_in_8bit_mode() {
         let input = b"file\\#999.txt";
-        assert_eq!(escape_for_output(input, true), "file\\#134#999.txt");
+        assert_eq!(
+            escape_for_output(input, true),
+            b"file\\#134#999.txt".to_vec()
+        );
     }
 
     #[test]
     fn non_digit_after_hash_not_escaped() {
         // \#abc is not a valid escape sequence - leave it alone.
         let input = b"file\\#abc.txt";
-        assert_eq!(escape_for_output(input, false), "file\\#abc.txt");
+        assert_eq!(escape_for_output(input, false), b"file\\#abc.txt".to_vec());
     }
 
     #[test]
     fn partial_escape_sequence_at_end_not_escaped() {
         // \#12 at end (only 2 digits) - not an escape sequence.
         let input = b"file\\#12";
-        assert_eq!(escape_for_output(input, false), "file\\#12");
+        assert_eq!(escape_for_output(input, false), b"file\\#12".to_vec());
     }
 
     // -- escape_path --
@@ -315,25 +333,25 @@ mod tests {
     #[test]
     fn escape_path_ascii() {
         let path = Path::new("src/main.rs");
-        assert_eq!(escape_path(path, false), "src/main.rs");
+        assert_eq!(escape_path(path, false), b"src/main.rs".to_vec());
     }
 
     #[test]
     fn escape_path_with_directory_separator() {
         let path = Path::new("foo/bar/baz.txt");
-        assert_eq!(escape_path(path, false), "foo/bar/baz.txt");
+        assert_eq!(escape_path(path, false), b"foo/bar/baz.txt".to_vec());
     }
 
     // -- escape_str --
 
     #[test]
     fn escape_str_passes_printable() {
-        assert_eq!(escape_str("hello.txt", false), "hello.txt");
+        assert_eq!(escape_str("hello.txt", false), b"hello.txt".to_vec());
     }
 
     #[test]
     fn escape_str_escapes_control() {
-        assert_eq!(escape_str("a\x01b", false), "a\\#001b");
+        assert_eq!(escape_str("a\x01b", false), b"a\\#001b".to_vec());
     }
 
     // -- Fast path coverage --
@@ -343,13 +361,13 @@ mod tests {
         let input = b"abcdefghijklmnopqrstuvwxyz/0123456789";
         assert_eq!(
             escape_for_output(input, false),
-            "abcdefghijklmnopqrstuvwxyz/0123456789"
+            b"abcdefghijklmnopqrstuvwxyz/0123456789".to_vec()
         );
     }
 
     #[test]
     fn empty_input() {
-        assert_eq!(escape_for_output(b"", false), "");
-        assert_eq!(escape_for_output(b"", true), "");
+        assert_eq!(escape_for_output(b"", false), Vec::<u8>::new());
+        assert_eq!(escape_for_output(b"", true), Vec::<u8>::new());
     }
 }

--- a/crates/cli/src/frontend/out_format/render/format.rs
+++ b/crates/cli/src/frontend/out_format/render/format.rs
@@ -91,21 +91,32 @@ fn format_with_separator(value: i64) -> String {
 }
 
 /// Applies width and alignment formatting to a rendered placeholder value.
-pub(super) fn apply_placeholder_format(mut value: String, format: &PlaceholderFormat) -> String {
-    if let Some(width) = format.width() {
-        let capped_width = width.min(MAX_PLACEHOLDER_WIDTH);
-        let len = value.chars().count();
-        if len < capped_width {
-            let padding = " ".repeat(capped_width - len);
-            if format.align() == PlaceholderAlignment::Left {
-                value.push_str(&padding);
-            } else {
-                value.insert_str(0, &padding);
-            }
-        }
+///
+/// The value is a raw byte buffer so filename placeholders (`%n`/`%f`/`%L`)
+/// carry their bytes verbatim. Padding is measured in characters (matching the
+/// prior behavior for valid-UTF-8 values) via a lossy view used only for the
+/// length count; the value bytes themselves are never round-tripped through a
+/// String, so a lone invalid byte survives unchanged. Padding adds ASCII
+/// spaces only.
+pub(super) fn apply_placeholder_format(value: Vec<u8>, format: &PlaceholderFormat) -> Vec<u8> {
+    let Some(width) = format.width() else {
+        return value;
+    };
+    let capped_width = width.min(MAX_PLACEHOLDER_WIDTH);
+    let len = String::from_utf8_lossy(&value).chars().count();
+    if len >= capped_width {
+        return value;
     }
-
-    value
+    let pad = capped_width - len;
+    if format.align() == PlaceholderAlignment::Left {
+        let mut padded = value;
+        padded.extend(std::iter::repeat_n(b' ', pad));
+        padded
+    } else {
+        let mut padded = vec![b' '; pad];
+        padded.extend_from_slice(&value);
+        padded
+    }
 }
 
 #[cfg(test)]
@@ -214,7 +225,10 @@ mod tests {
     #[test]
     fn apply_placeholder_format_no_width() {
         let format = PlaceholderFormat::new(None, PlaceholderAlignment::Right, HumanizeMode::None);
-        assert_eq!(apply_placeholder_format("test".to_owned(), &format), "test");
+        assert_eq!(
+            apply_placeholder_format(b"test".to_vec(), &format),
+            b"test".to_vec()
+        );
     }
 
     #[test]
@@ -222,8 +236,8 @@ mod tests {
         let format =
             PlaceholderFormat::new(Some(10), PlaceholderAlignment::Right, HumanizeMode::None);
         assert_eq!(
-            apply_placeholder_format("test".to_owned(), &format),
-            "      test"
+            apply_placeholder_format(b"test".to_vec(), &format),
+            b"      test".to_vec()
         );
     }
 
@@ -232,8 +246,8 @@ mod tests {
         let format =
             PlaceholderFormat::new(Some(10), PlaceholderAlignment::Left, HumanizeMode::None);
         assert_eq!(
-            apply_placeholder_format("test".to_owned(), &format),
-            "test      "
+            apply_placeholder_format(b"test".to_vec(), &format),
+            b"test      ".to_vec()
         );
     }
 
@@ -241,14 +255,20 @@ mod tests {
     fn apply_placeholder_format_exact_width() {
         let format =
             PlaceholderFormat::new(Some(4), PlaceholderAlignment::Right, HumanizeMode::None);
-        assert_eq!(apply_placeholder_format("test".to_owned(), &format), "test");
+        assert_eq!(
+            apply_placeholder_format(b"test".to_vec(), &format),
+            b"test".to_vec()
+        );
     }
 
     #[test]
     fn apply_placeholder_format_exceed_width() {
         let format =
             PlaceholderFormat::new(Some(2), PlaceholderAlignment::Right, HumanizeMode::None);
-        assert_eq!(apply_placeholder_format("test".to_owned(), &format), "test");
+        assert_eq!(
+            apply_placeholder_format(b"test".to_vec(), &format),
+            b"test".to_vec()
+        );
     }
 
     #[test]
@@ -259,8 +279,20 @@ mod tests {
             PlaceholderAlignment::Right,
             HumanizeMode::None,
         );
-        let result = apply_placeholder_format("x".to_owned(), &format);
+        let result = apply_placeholder_format(b"x".to_vec(), &format);
         assert_eq!(result.len(), MAX_PLACEHOLDER_WIDTH);
+    }
+
+    #[test]
+    fn apply_placeholder_format_preserves_lone_invalid_byte() {
+        // A `%n` value carrying a lone invalid-UTF-8 byte under -8 must keep the
+        // raw byte through width padding (padding is ASCII spaces only).
+        let format =
+            PlaceholderFormat::new(Some(4), PlaceholderAlignment::Right, HumanizeMode::None);
+        assert_eq!(
+            apply_placeholder_format(vec![0x80], &format),
+            vec![b' ', b' ', b' ', 0x80]
+        );
     }
 
     #[test]

--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -29,23 +29,27 @@ impl OutFormat {
         context: &OutFormatContext,
         writer: &mut W,
     ) -> io::Result<()> {
-        let mut buffer = String::new();
+        // The buffer is raw bytes, not a String: `%n`/`%f`/`%L` render filename
+        // bytes verbatim (see `escape_path`), so a lone invalid-UTF-8 byte under
+        // `--8-bit-output` must reach the writer unmodified. Interpolating
+        // through a String would replace it with U+FFFD.
+        let mut buffer: Vec<u8> = Vec::new();
         for token in self.tokens() {
             match token {
-                OutFormatToken::Literal(text) => buffer.push_str(text),
+                OutFormatToken::Literal(text) => buffer.extend_from_slice(text.as_bytes()),
                 OutFormatToken::Placeholder(spec) => {
                     if let Some(rendered) = render_placeholder_value(event, context, spec) {
                         let formatted = apply_placeholder_format(rendered, &spec.format);
-                        buffer.push_str(&formatted);
+                        buffer.extend_from_slice(&formatted);
                     }
                 }
             }
         }
 
-        if buffer.ends_with('\n') {
-            writer.write_all(buffer.as_bytes())
+        if buffer.last() == Some(&b'\n') {
+            writer.write_all(&buffer)
         } else {
-            writer.write_all(buffer.as_bytes())?;
+            writer.write_all(&buffer)?;
             writer.write_all(b"\n")
         }
     }
@@ -158,11 +162,11 @@ pub(crate) fn emit_out_format<W: Write + ?Sized>(
         // of `-i`/`-ii`.
         if matches!(event.kind(), ClientEventKind::SkippedNewerDestination) {
             if info_gte(InfoFlag::Skip, 1) {
-                writeln!(
-                    writer,
-                    "{} is newer",
-                    escape_path(event.relative_path(), context.eight_bit_output)
-                )?;
+                writer.write_all(&escape_path(
+                    event.relative_path(),
+                    context.eight_bit_output,
+                ))?;
+                writer.write_all(b" is newer\n")?;
             }
             continue;
         }

--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -37,14 +37,17 @@ fn symlink_target_connector(event: &ClientEvent) -> &'static str {
     }
 }
 
-/// Resolves a placeholder token to its string value for the given event and context.
+/// Resolves a placeholder token to its raw byte value for the given event and context.
 ///
-/// Returns `None` when the placeholder is inapplicable (e.g., symlink target on a regular file).
+/// Returns `None` when the placeholder is inapplicable (e.g., symlink target on
+/// a regular file). Path placeholders (`%n`/`%f`/`%L`) carry raw filename bytes
+/// so a lone invalid-UTF-8 byte under `--8-bit-output` survives verbatim to the
+/// writer; all other placeholders are valid UTF-8 rendered into bytes.
 pub(super) fn render_placeholder_value(
     event: &ClientEvent,
     context: &OutFormatContext,
     spec: &PlaceholderToken,
-) -> Option<String> {
+) -> Option<Vec<u8>> {
     let allow_8bit = context.eight_bit_output;
     match spec.kind {
         OutFormatPlaceholder::FileName => Some(render_path(event, true, allow_8bit)),
@@ -54,39 +57,49 @@ pub(super) fn render_placeholder_value(
                 .metadata()
                 .and_then(ClientEntryMetadata::symlink_target)
             {
-                rendered.push_str(symlink_target_connector(event));
-                rendered.push_str(&escape_path(target, allow_8bit));
+                rendered.extend_from_slice(symlink_target_connector(event).as_bytes());
+                rendered.extend_from_slice(&escape_path(target, allow_8bit));
             }
             Some(rendered)
         }
         OutFormatPlaceholder::FullPath => Some(render_path(event, false, allow_8bit)),
         OutFormatPlaceholder::ItemizedChanges => {
-            Some(format_itemized_changes(event, context.is_sender))
+            Some(format_itemized_changes(event, context.is_sender).into_bytes())
         }
         OutFormatPlaceholder::FileLength => {
             let length = event.metadata().map_or(0, ClientEntryMetadata::length);
-            Some(format_numeric_value(length as i64, &spec.format))
+            Some(format_numeric_value(length as i64, &spec.format).into_bytes())
         }
-        OutFormatPlaceholder::BytesTransferred => Some(format_numeric_value(
-            transfer_byte_count(event, context.is_sender, false) as i64,
-            &spec.format,
-        )),
-        OutFormatPlaceholder::ChecksumBytes => Some(format_numeric_value(
-            transfer_byte_count(event, context.is_sender, true) as i64,
-            &spec.format,
-        )),
-        OutFormatPlaceholder::Operation => Some(describe_event_kind(event.kind()).to_owned()),
-        OutFormatPlaceholder::ModifyTime => Some(format_out_format_mtime(event.metadata())),
+        OutFormatPlaceholder::BytesTransferred => Some(
+            format_numeric_value(
+                transfer_byte_count(event, context.is_sender, false) as i64,
+                &spec.format,
+            )
+            .into_bytes(),
+        ),
+        OutFormatPlaceholder::ChecksumBytes => Some(
+            format_numeric_value(
+                transfer_byte_count(event, context.is_sender, true) as i64,
+                &spec.format,
+            )
+            .into_bytes(),
+        ),
+        OutFormatPlaceholder::Operation => {
+            Some(describe_event_kind(event.kind()).to_owned().into_bytes())
+        }
+        OutFormatPlaceholder::ModifyTime => {
+            Some(format_out_format_mtime(event.metadata()).into_bytes())
+        }
         OutFormatPlaceholder::PermissionString => {
-            Some(format_out_format_permissions(event.metadata()))
+            Some(format_out_format_permissions(event.metadata()).into_bytes())
         }
         OutFormatPlaceholder::SymlinkTarget => match event
             .metadata()
             .and_then(ClientEntryMetadata::symlink_target)
         {
             Some(target) => {
-                let mut rendered = String::from(symlink_target_connector(event));
-                rendered.push_str(&escape_path(target, allow_8bit));
+                let mut rendered = symlink_target_connector(event).as_bytes().to_vec();
+                rendered.extend_from_slice(&escape_path(target, allow_8bit));
                 Some(rendered)
             }
             // upstream: log.c:648-654 - the `case 'L'` else-branch sets n = ""
@@ -98,16 +111,17 @@ pub(super) fn render_placeholder_value(
             None => spec
                 .format
                 .width()
-                .map(|width| " ".repeat(4 + width.min(MAX_PLACEHOLDER_WIDTH))),
+                .map(|width| vec![b' '; 4 + width.min(MAX_PLACEHOLDER_WIDTH)]),
         },
-        OutFormatPlaceholder::CurrentTime => Some(format_current_timestamp()),
-        OutFormatPlaceholder::OwnerName => Some(format_owner_name(event.metadata())),
-        OutFormatPlaceholder::GroupName => Some(format_group_name(event.metadata())),
+        OutFormatPlaceholder::CurrentTime => Some(format_current_timestamp().into_bytes()),
+        OutFormatPlaceholder::OwnerName => Some(format_owner_name(event.metadata()).into_bytes()),
+        OutFormatPlaceholder::GroupName => Some(format_group_name(event.metadata()).into_bytes()),
         OutFormatPlaceholder::OwnerUid => Some(
             event
                 .metadata()
                 .and_then(ClientEntryMetadata::uid)
-                .map_or_else(|| "0".to_owned(), |value| value.to_string()),
+                .map_or_else(|| "0".to_owned(), |value| value.to_string())
+                .into_bytes(),
         ),
         // upstream: log.c:574-576 - `case 'G'` renders the literal "DEFAULT"
         // when `!gid_ndx || file->flags & FLAG_SKIP_GROUP`; only an available
@@ -117,26 +131,23 @@ pub(super) fn render_placeholder_value(
             event
                 .metadata()
                 .and_then(ClientEntryMetadata::gid)
-                .map_or_else(|| "DEFAULT".to_owned(), |value| value.to_string()),
+                .map_or_else(|| "DEFAULT".to_owned(), |value| value.to_string())
+                .into_bytes(),
         ),
-        OutFormatPlaceholder::ProcessId => Some(std::process::id().to_string()),
-        OutFormatPlaceholder::RemoteHost => Some(remote_placeholder_value(
-            context.remote_host.as_deref(),
-            'h',
-        )),
-        OutFormatPlaceholder::RemoteAddress => Some(remote_placeholder_value(
-            context.remote_address.as_deref(),
-            'a',
-        )),
-        OutFormatPlaceholder::ModuleName => Some(remote_placeholder_value(
-            context.module_name.as_deref(),
-            'm',
-        )),
-        OutFormatPlaceholder::ModulePath => Some(remote_placeholder_value(
-            context.module_path.as_deref(),
-            'P',
-        )),
-        OutFormatPlaceholder::FullChecksum => Some(format_full_checksum(event)),
+        OutFormatPlaceholder::ProcessId => Some(std::process::id().to_string().into_bytes()),
+        OutFormatPlaceholder::RemoteHost => {
+            Some(remote_placeholder_value(context.remote_host.as_deref(), 'h').into_bytes())
+        }
+        OutFormatPlaceholder::RemoteAddress => {
+            Some(remote_placeholder_value(context.remote_address.as_deref(), 'a').into_bytes())
+        }
+        OutFormatPlaceholder::ModuleName => {
+            Some(remote_placeholder_value(context.module_name.as_deref(), 'm').into_bytes())
+        }
+        OutFormatPlaceholder::ModulePath => {
+            Some(remote_placeholder_value(context.module_path.as_deref(), 'P').into_bytes())
+        }
+        OutFormatPlaceholder::FullChecksum => Some(format_full_checksum(event).into_bytes()),
     }
 }
 
@@ -184,8 +195,9 @@ fn transfer_byte_count(event: &ClientEvent, is_sender: bool, want_checksum: bool
     }
 }
 
-/// Renders the path from an event, optionally appending a trailing slash for directories.
-fn render_path(event: &ClientEvent, ensure_trailing_slash: bool, allow_8bit: bool) -> String {
+/// Renders the path from an event as raw bytes, optionally appending a trailing
+/// slash for directories.
+fn render_path(event: &ClientEvent, ensure_trailing_slash: bool, allow_8bit: bool) -> Vec<u8> {
     let mut rendered = escape_path(event.relative_path(), allow_8bit);
     // upstream: flist.c / log.c - itemize and out-format paths use POSIX
     // forward-slash separators regardless of host OS. Normalize Windows
@@ -193,10 +205,14 @@ fn render_path(event: &ClientEvent, ensure_trailing_slash: bool, allow_8bit: boo
     // the platform-native form.
     #[cfg(windows)]
     {
-        rendered = rendered.replace('\\', "/");
+        for byte in rendered.iter_mut() {
+            if *byte == b'\\' {
+                *byte = b'/';
+            }
+        }
     }
     if ensure_trailing_slash
-        && !rendered.ends_with('/')
+        && rendered.last() != Some(&b'/')
         && event.metadata().map(ClientEntryMetadata::kind).map_or_else(
             // upstream: log.c:639-640 - %n appends `/` for any directory entry.
             // `EntryDeleted` rows carry no metadata snapshot, so fall back to the
@@ -206,7 +222,7 @@ fn render_path(event: &ClientEvent, ensure_trailing_slash: bool, allow_8bit: boo
             ClientEntryKind::is_directory,
         )
     {
-        rendered.push('/');
+        rendered.push(b'/');
     }
     rendered
 }

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -8,14 +8,32 @@ use core::client::{
 
 use crate::frontend::escape::escape_path;
 
-/// Renders a path string with any trailing platform path separators trimmed,
-/// mirroring upstream rsync's `*cp = '\0'` slash-lopping in `main.c:789`
+/// Writes `<prefix><escaped path><suffix>\n` to a byte sink.
+///
+/// The escaped path is written as raw bytes so a lone invalid-UTF-8 byte under
+/// `--8-bit-output` reaches the sink unmodified, matching upstream
+/// `filtered_fwrite`; interpolating it through a `String` would replace it with
+/// U+FFFD.
+fn writeln_wrapped<W: Write + ?Sized>(
+    stdout: &mut W,
+    prefix: &str,
+    path: &Path,
+    allow_8bit: bool,
+    suffix: &str,
+) -> io::Result<()> {
+    stdout.write_all(prefix.as_bytes())?;
+    stdout.write_all(&escape_path(path, allow_8bit))?;
+    stdout.write_all(suffix.as_bytes())?;
+    stdout.write_all(b"\n")
+}
+
+/// Renders a path with any trailing platform path separators trimmed as raw
+/// bytes, mirroring upstream rsync's `*cp = '\0'` slash-lopping in `main.c:789`
 /// before the `created directory %s\n` print.
-fn display_without_trailing_separators(path: &Path, allow_8bit: bool) -> String {
+fn display_without_trailing_separators(path: &Path, allow_8bit: bool) -> Vec<u8> {
     let mut rendered = escape_path(path, allow_8bit);
     while rendered.len() > 1
         && rendered
-            .as_bytes()
             .last()
             .is_some_and(|&b| b == b'/' || (cfg!(windows) && b == b'\\'))
     {
@@ -124,11 +142,12 @@ pub(crate) fn emit_transfer_summary(
         && (out_format.is_some() || verbosity > 0)
         && let Some(dest_root) = events.iter().map(ClientEvent::destination_root).next()
     {
-        writeln!(
-            writer,
-            "created directory {}",
-            display_without_trailing_separators(dest_root, eight_bit_output)
-        )?;
+        writer.write_all(b"created directory ")?;
+        writer.write_all(&display_without_trailing_separators(
+            dest_root,
+            eight_bit_output,
+        ))?;
+        writer.write_all(b"\n")?;
     }
 
     let formatted_rendered = if let Some(format) = out_format {
@@ -289,23 +308,29 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
                 && metadata.kind().is_symlink()
                 && let Some(target) = metadata.symlink_target()
             {
-                rendered.push_str(" -> ");
-                rendered.push_str(&escape_path(target, eight_bit_output));
+                rendered.extend_from_slice(b" -> ");
+                rendered.extend_from_slice(&escape_path(target, eight_bit_output));
             }
 
-            writeln!(
+            // The columns are ASCII; the filename bytes follow raw so an invalid
+            // byte under -8 survives to the sink.
+            write!(
                 stdout,
-                "{permissions} {size} {timestamp}{atime_field}{crtime_field} {rendered}"
+                "{permissions} {size} {timestamp}{atime_field}{crtime_field} "
             )?;
+            stdout.write_all(&rendered)?;
+            stdout.write_all(b"\n")?;
         } else {
             let rendered = escape_path(event.relative_path(), eight_bit_output);
-            writeln!(
+            write!(
                 stdout,
-                "?????????? {:>width$} {} {rendered}",
+                "?????????? {:>width$} {} ",
                 "?",
                 format_list_timestamp(None),
                 width = human_readable.size_width(),
             )?;
+            stdout.write_all(&rendered)?;
+            stdout.write_all(b"\n")?;
         }
     }
 
@@ -351,10 +376,16 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
 
         // upstream: flist.c f_name() emits POSIX forward-slash separators
         // regardless of host OS. Normalize Windows native backslashes here.
-        let name = escape_path(event.relative_path(), eight_bit_output);
+        #[cfg_attr(not(windows), allow(unused_mut))]
+        let mut name = escape_path(event.relative_path(), eight_bit_output);
         #[cfg(windows)]
-        let name = name.replace('\\', "/");
-        writeln!(stdout, "{name}")?;
+        for byte in name.iter_mut() {
+            if *byte == b'\\' {
+                *byte = b'/';
+            }
+        }
+        stdout.write_all(&name)?;
+        stdout.write_all(b"\n")?;
 
         let bytes = event.bytes_transferred();
         // Field widths mirror upstream rsync's `rprint_progress` format string
@@ -655,25 +686,27 @@ fn is_deferred_hardlink_event(event: &ClientEvent) -> bool {
 ///
 /// upstream: log.c:639-640 - the `%n` token strlcat()s a `/` for S_ISDIR
 /// entries; the transfer root is listed as `./`.
-fn verbose_listing_name(event: &ClientEvent, eight_bit_output: bool) -> String {
+fn verbose_listing_name(event: &ClientEvent, eight_bit_output: bool) -> Vec<u8> {
     let path = event.relative_path();
     let is_dir = matches!(
         event.metadata().map(ClientEntryMetadata::kind),
         Some(ClientEntryKind::Directory)
     );
     if is_dir && path.as_os_str() == "." {
-        return String::from("./");
+        return b"./".to_vec();
     }
     let mut rendered = escape_path(path, eight_bit_output);
     // upstream: flist.c f_name() emits POSIX forward-slash separators
     // regardless of host OS. Normalize Windows native backslashes at the
     // rendering boundary; storage retains the platform-native form.
     #[cfg(windows)]
-    {
-        rendered = rendered.replace('\\', "/");
+    for byte in rendered.iter_mut() {
+        if *byte == b'\\' {
+            *byte = b'/';
+        }
     }
     if is_dir {
-        rendered.push('/');
+        rendered.push(b'/');
     }
     rendered
 }
@@ -736,10 +769,12 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 {
                     continue;
                 }
-                writeln!(
+                writeln_wrapped(
                     stdout,
-                    "{} is uptodate",
-                    escape_path(event.relative_path(), eight_bit_output)
+                    "",
+                    event.relative_path(),
+                    eight_bit_output,
+                    " is uptodate",
                 )?;
                 continue;
             }
@@ -749,10 +784,11 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 && let Some(metadata) = event.metadata()
                 && let Some(target) = metadata.symlink_target()
             {
-                rendered.push_str(" -> ");
-                rendered.push_str(&escape_path(target, eight_bit_output));
+                rendered.extend_from_slice(b" -> ");
+                rendered.extend_from_slice(&escape_path(target, eight_bit_output));
             }
-            writeln!(stdout, "{rendered}")?;
+            stdout.write_all(&rendered)?;
+            stdout.write_all(b"\n")?;
             continue;
         }
 
@@ -765,34 +801,42 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // upstream: generator.c:1409 - `rprintf(FINFO, "%s exists\n",
                 // fname)` for an --ignore-existing skip: the bare relative name
                 // followed by " exists", no descriptor and no quotes.
-                writeln!(
+                writeln_wrapped(
                     stdout,
-                    "{} exists",
-                    escape_path(event.relative_path(), eight_bit_output)
+                    "",
+                    event.relative_path(),
+                    eight_bit_output,
+                    " exists",
                 )?;
                 continue;
             }
             ClientEventKind::SkippedMissingDestination => {
-                writeln!(
+                writeln_wrapped(
                     stdout,
-                    "skipping non-existent destination file \"{}\"",
-                    escape_path(event.relative_path(), eight_bit_output)
+                    "skipping non-existent destination file \"",
+                    event.relative_path(),
+                    eight_bit_output,
+                    "\"",
                 )?;
                 continue;
             }
             ClientEventKind::SkippedNewerDestination => {
-                writeln!(
+                writeln_wrapped(
                     stdout,
-                    "skipping newer destination file \"{}\"",
-                    escape_path(event.relative_path(), eight_bit_output)
+                    "skipping newer destination file \"",
+                    event.relative_path(),
+                    eight_bit_output,
+                    "\"",
                 )?;
                 continue;
             }
             ClientEventKind::SkippedNonRegular => {
-                writeln!(
+                writeln_wrapped(
                     stdout,
-                    "skipping non-regular file \"{}\"",
-                    escape_path(event.relative_path(), eight_bit_output)
+                    "skipping non-regular file \"",
+                    event.relative_path(),
+                    eight_bit_output,
+                    "\"",
                 )?;
                 continue;
             }
@@ -801,32 +845,36 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // `rprintf(FINFO, "skipping directory %s\n", ...)`: the bare
                 // relative name with no surrounding quotes and no trailing
                 // "(no recursion)" suffix.
-                writeln!(
+                writeln_wrapped(
                     stdout,
-                    "skipping directory {}",
-                    escape_path(event.relative_path(), eight_bit_output)
+                    "skipping directory ",
+                    event.relative_path(),
+                    eight_bit_output,
+                    "",
                 )?;
                 continue;
             }
             ClientEventKind::SkippedUnsafeSymlink => {
-                let mut rendered = format!(
-                    "ignoring unsafe symlink \"{}\"",
-                    escape_path(event.relative_path(), eight_bit_output)
-                );
+                let mut rendered = b"ignoring unsafe symlink \"".to_vec();
+                rendered.extend_from_slice(&escape_path(event.relative_path(), eight_bit_output));
+                rendered.push(b'"');
                 if let Some(metadata) = event.metadata()
                     && let Some(target) = metadata.symlink_target()
                 {
-                    rendered.push_str(" -> ");
-                    rendered.push_str(&escape_path(target, eight_bit_output));
+                    rendered.extend_from_slice(b" -> ");
+                    rendered.extend_from_slice(&escape_path(target, eight_bit_output));
                 }
-                writeln!(stdout, "{rendered}")?;
+                stdout.write_all(&rendered)?;
+                stdout.write_all(b"\n")?;
                 continue;
             }
             ClientEventKind::SkippedMountPoint => {
-                writeln!(
+                writeln_wrapped(
                     stdout,
-                    "skipping mount point \"{}\"",
-                    escape_path(event.relative_path(), eight_bit_output)
+                    "skipping mount point \"",
+                    event.relative_path(),
+                    eight_bit_output,
+                    "\"",
                 )?;
                 continue;
             }
@@ -856,10 +904,12 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                     continue;
                 }
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(
+                    writeln_wrapped(
                         stdout,
-                        "{} is uptodate",
-                        escape_path(event.relative_path(), eight_bit_output)
+                        "",
+                        event.relative_path(),
+                        eight_bit_output,
+                        " is uptodate",
                     )?;
                 }
                 continue;
@@ -871,10 +921,12 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // the bare path. Mirror the same gate so `-vv` without `-i`
                 // matches the upstream `testsuite/itemize.test` golden.
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(
+                    writeln_wrapped(
                         stdout,
-                        "{} is uptodate",
-                        escape_path(event.relative_path(), eight_bit_output)
+                        "",
+                        event.relative_path(),
+                        eight_bit_output,
+                        " is uptodate",
                     )?;
                 }
                 continue;
@@ -890,10 +942,12 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // `was_created`, so they fall through to the bare-path emission.
             ClientEventKind::ReferenceCopied => {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(
+                    writeln_wrapped(
                         stdout,
-                        "{} is uptodate",
-                        escape_path(event.relative_path(), eight_bit_output)
+                        "",
+                        event.relative_path(),
+                        eight_bit_output,
+                        " is uptodate",
                     )?;
                 }
                 continue;
@@ -902,10 +956,12 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // hard-linked from the basis prints `"%s is uptodate"` at NAME>=2.
             ClientEventKind::HardLink if is_hardlinked_symlink_event(event) => {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(
+                    writeln_wrapped(
                         stdout,
-                        "{} is uptodate",
-                        escape_path(event.relative_path(), eight_bit_output)
+                        "",
+                        event.relative_path(),
+                        eight_bit_output,
+                        " is uptodate",
                     )?;
                 }
                 continue;
@@ -914,10 +970,12 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 if !event.was_created() && !event.change_set().has_any_change() =>
             {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(
+                    writeln_wrapped(
                         stdout,
-                        "{}/ is uptodate",
-                        escape_path(event.relative_path(), eight_bit_output)
+                        "",
+                        event.relative_path(),
+                        eight_bit_output,
+                        "/ is uptodate",
                     )?;
                 }
                 continue;
@@ -926,10 +984,12 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 if !event.was_created() && !event.change_set().has_any_change() =>
             {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(
+                    writeln_wrapped(
                         stdout,
-                        "{} is uptodate",
-                        escape_path(event.relative_path(), eight_bit_output)
+                        "",
+                        event.relative_path(),
+                        eight_bit_output,
+                        " is uptodate",
                     )?;
                 }
                 continue;
@@ -942,24 +1002,25 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             && let Some(metadata) = event.metadata()
             && let Some(target) = metadata.symlink_target()
         {
-            rendered.push_str(" -> ");
-            rendered.push_str(&escape_path(target, eight_bit_output));
+            rendered.extend_from_slice(b" -> ");
+            rendered.extend_from_slice(&escape_path(target, eight_bit_output));
         } else if matches!(kind, ClientEventKind::HardLink)
             && let Some(metadata) = event.metadata()
             && let Some(leader) = metadata.symlink_target()
         {
             // upstream: hlink.c:236 - a freshly-linked alias prints
             // `"%s => %s"` with the group leader's relative path.
-            rendered.push_str(" => ");
-            rendered.push_str(&escape_path(leader, eight_bit_output));
+            rendered.extend_from_slice(b" => ");
+            rendered.extend_from_slice(&escape_path(leader, eight_bit_output));
         }
 
         // upstream: log.c:log_formatted() emits the default `%n%L` per-file
         // line at every verbosity tier (set in options.c:2372). The rendered
-        // string already includes the `-> target` suffix for symlinks; higher
+        // bytes already include the `-> target` suffix for symlinks; higher
         // tiers only add ancillary log messages, never a per-file descriptor
         // prefix or byte-count wrapper.
-        writeln!(stdout, "{rendered}")?;
+        stdout.write_all(&rendered)?;
+        stdout.write_all(b"\n")?;
     }
     Ok(())
 }


### PR DESCRIPTION
Filename display escaping converted its byte buffer to a `String` via `from_utf8_lossy` before returning, so a lone invalid-UTF-8 byte (a bare `0x80` or `0xFF`, not part of a valid multibyte sequence) rendered as U+FFFD instead of upstream's raw byte passthrough. Upstream `filtered_fwrite` (log.c:225-246) writes the raw byte to the output fd unchanged when `allow_8bit_chars` is set; only control bytes below 0x20 (except tab) are octal-escaped.

## Root cause
`String` cannot hold arbitrary invalid UTF-8, so any lone high byte was lost at the `from_utf8_lossy` boundary. The realistic multibyte case (`café`) already round-tripped; only the lone-invalid-byte edge diverged.

## Fix
- `escape_for_output` / `escape_bytes_slow` / `escape_path` now return `Vec<u8>` (raw bytes) and drop the lossy conversion.
- The `--out-format` render buffer is now `Vec<u8>`; placeholder values carry raw bytes and width padding operates on bytes (padding stays ASCII spaces; width still measured by char count for valid-UTF-8 parity). So `%n`/`%f`/`%L` filenames reach the writer verbatim, including under `-i`.
- Every progress / verbose / list-only / `created directory` / `is newer` / skip / `is uptodate` caller writes the escaped path bytes directly to its byte sink instead of interpolating through a `String`.

The output sinks were already byte sinks (`W: Write`); only the intermediate `String` assembly and width-formatting needed converting, so the path is bytes-clean end-to-end.

## Behavior
- Lone `0x80` under `-8`: was U+FFFD (3 bytes `ef bf bd`) -> now exactly one raw byte `0x80`. Under default mode: `\#200`.
- Unchanged: valid multibyte `café` passes raw `c3 a9`; default mode octal-escapes high bytes as `\#ooo`; control chars `\#001`; DEL under `-8` passes raw `0x7F`; literal `\#ddd` still escaped.

## Tests
`cargo fmt` and `cargo clippy -p cli` clean; cli stays unsafe-free. Escape unit tests updated to assert raw bytes (`escape_for_output(&[0x80], true) == vec![0x80]`, `&[0xFF] == vec![0xFF]`) plus a new one-byte-length assertion; added `apply_placeholder_format_preserves_lone_invalid_byte`. Full cli lib suite green (one pre-existing timezone-dependent test in `progress/format/list.rs`, untouched here, fails on non-UTC hosts).

Fixes #180