### PR TITLE
perf(engine): dedupe redundant destination statx in --checksum local copy

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -134,6 +134,13 @@ pub(crate) struct CopyContext<'a> {
     deferred_sync: DeferredSync,
     /// Cache of prefetched file checksums for parallel checksum mode.
     checksum_cache: Option<super::executor::ChecksumCache>,
+    /// Destination `lstat` metadata gathered during checksum-mode prefetch,
+    /// keyed by on-disk destination path. In `--checksum` mode the prefetch
+    /// already lstats every candidate destination to read its size; storing it
+    /// here lets `copy_file` reuse that lstat instead of issuing a second one,
+    /// matching upstream's single generator `link_stat` per destination. Empty
+    /// outside checksum mode, so the non-checksum path keeps its own lstat.
+    destination_metadata_cache: HashMap<PathBuf, fs::Metadata>,
     /// Tracks whether any I/O errors occurred during the transfer.
     /// When set to `true` and `--ignore-errors` is not enabled, deletions
     /// are suppressed to prevent data loss.

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -141,6 +141,7 @@ impl<'a> CopyContext<'a> {
             buffer_pool,
             deferred_sync,
             checksum_cache: None,
+            destination_metadata_cache: HashMap::new(),
             io_errors_occurred: false,
             io_error_delete_warning_emitted: false,
             iconv_conversion_error: false,
@@ -644,6 +645,23 @@ impl<'a> CopyContext<'a> {
             .and_then(|cache| cache.lookup(source))
     }
 
+    /// Stores destination `lstat` metadata gathered during checksum-mode
+    /// prefetch so `copy_file` can reuse it instead of re-lstat'ing.
+    pub(super) fn set_destination_metadata_cache(
+        &mut self,
+        cache: HashMap<PathBuf, fs::Metadata>,
+    ) {
+        self.destination_metadata_cache = cache;
+    }
+
+    /// Removes and returns the cached destination `lstat` metadata for `dest`,
+    /// if the checksum-mode prefetch recorded it. Returns `None` when absent
+    /// (non-checksum mode, a non-regular destination, or already consumed), in
+    /// which case the caller performs its own `lstat`.
+    pub(super) fn take_cached_destination_metadata(&mut self, dest: &Path) -> Option<fs::Metadata> {
+        self.destination_metadata_cache.remove(dest)
+    }
+
     /// Returns a mutable reference to the reusable readdir buffer.
     ///
     /// Callers should `clear()` the buffer before filling it. The Vec's heap
@@ -658,6 +676,7 @@ impl<'a> CopyContext<'a> {
         if let Some(ref mut cache) = self.checksum_cache {
             cache.clear();
         }
+        self.destination_metadata_cache.clear();
     }
 
     /// Queues a deferred update for `--delay-updates` and records the hard-link

--- a/crates/engine/src/local_copy/executor/directory/recursive/checksum.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/checksum.rs
@@ -3,8 +3,9 @@
 //! When `--checksum` mode is active, pre-computes whole-file checksums for
 //! source/destination pairs in parallel using rayon, populating a cache
 //! that the per-file comparison step consults.
+use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::local_copy::CopyContext;
 
@@ -12,6 +13,23 @@ use super::super::super::transcode_filename_component;
 use super::super::parallel_checksum::{ChecksumCache, FilePair};
 use super::super::planner::{DirectoryPlan, EntryAction};
 use protocol::iconv::FilenameConverter;
+
+/// Returns `true` when the destination has exactly one hard link, so its
+/// `lstat` cannot be mutated through a shared inode by an earlier sibling in
+/// the same directory pass and is therefore safe to cache and reuse.
+#[cfg(unix)]
+fn destination_link_count_is_one(metadata: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    metadata.nlink() == 1
+}
+
+/// Non-Unix platforms expose no portable link count through `std`. Skip the
+/// reuse optimization entirely so the per-file copy always performs its own
+/// fresh `lstat`, matching the pre-optimization behaviour.
+#[cfg(not(unix))]
+fn destination_link_count_is_one(_metadata: &fs::Metadata) -> bool {
+    false
+}
 
 /// Collects file pairs for parallel checksum prefetching.
 ///
@@ -35,12 +53,19 @@ use protocol::iconv::FilenameConverter;
 /// from LOCAL to REMOTE so the lookup hits the same on-disk path the
 /// executor will later write to. With `None` this is a zero-overhead
 /// pass-through that mirrors the pre-iconv behaviour.
+///
+/// Alongside the pairs this returns a map of destination path to its `lstat`
+/// metadata for every regular-file destination inspected. The per-file copy
+/// step consumes that map so `copy_file` reuses this single `lstat` instead of
+/// issuing a second one, matching upstream's one generator `link_stat` per
+/// destination (upstream: generator.c:recv_generator()).
 pub(crate) fn collect_file_pairs_for_checksum(
     plan: &DirectoryPlan<'_>,
     destination: &Path,
     converter: Option<&FilenameConverter>,
-) -> Vec<FilePair> {
+) -> (Vec<FilePair>, HashMap<PathBuf, fs::Metadata>) {
     let mut pairs = Vec::new();
+    let mut destination_metadata = HashMap::new();
 
     for planned in &plan.planned_entries {
         if !matches!(planned.action, EntryAction::CopyFile) {
@@ -52,11 +77,25 @@ pub(crate) fn collect_file_pairs_for_checksum(
         let target_path = destination.join(Path::new(&*dest_name));
         let source_size = planned.metadata().len();
 
-        // Check if destination exists and get its size
-        let destination_size = match fs::metadata(&target_path) {
-            Ok(meta) if meta.file_type().is_file() => meta.len(),
-            _ => continue, // Skip if destination doesn't exist or isn't a file
+        // upstream: generator.c:recv_generator() lstats the destination once
+        // (link_stat). Use a nofollow lstat here: a symlink destination is not a
+        // regular-file checksum candidate (upstream removes it and writes the
+        // file), so file_type().is_file() must be false for a symlink.
+        let dest_metadata = match fs::symlink_metadata(&target_path) {
+            Ok(meta) if meta.file_type().is_file() => meta,
+            _ => continue, // Skip if destination doesn't exist or isn't a regular file
         };
+        let destination_size = dest_metadata.len();
+
+        // Cache the lstat for copy_file to reuse only when the destination has a
+        // single link. A destination hardlinked to a sibling that copy_file
+        // updates earlier in this same directory pass would see its shared
+        // inode's mtime change mid-loop, making this pre-pass stat stale and
+        // shifting itemize output. Multi-link destinations therefore fall back
+        // to copy_file's own fresh lstat, keeping itemize byte-identical.
+        if destination_link_count_is_one(&dest_metadata) {
+            destination_metadata.insert(target_path.clone(), dest_metadata);
+        }
 
         // Only prefetch if sizes match (different sizes = guaranteed different content)
         if source_size == destination_size {
@@ -69,7 +108,7 @@ pub(crate) fn collect_file_pairs_for_checksum(
         }
     }
 
-    pairs
+    (pairs, destination_metadata)
 }
 
 /// Prefetches file checksums in parallel for a directory.
@@ -90,7 +129,7 @@ pub(crate) fn collect_file_pairs_for_checksum(
 /// A populated [`ChecksumCache`] if checksum mode is enabled and there are
 /// eligible file pairs, or an empty cache otherwise.
 pub(crate) fn prefetch_directory_checksums(
-    context: &CopyContext,
+    context: &mut CopyContext,
     plan: &DirectoryPlan<'_>,
     destination: &Path,
 ) -> ChecksumCache {
@@ -99,7 +138,14 @@ pub(crate) fn prefetch_directory_checksums(
         return ChecksumCache::new();
     }
 
-    let pairs = collect_file_pairs_for_checksum(plan, destination, context.options().iconv());
+    let (pairs, destination_metadata) =
+        collect_file_pairs_for_checksum(plan, destination, context.options().iconv());
+
+    // Hand the destination lstat results to copy_file so it reuses them instead
+    // of re-lstat'ing each destination (one generator link_stat, upstream).
+    if !destination_metadata.is_empty() {
+        context.set_destination_metadata_cache(destination_metadata);
+    }
 
     // Skip prefetching if no eligible pairs
     if pairs.is_empty() {

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -700,7 +700,7 @@ mod tests {
             delete_timing: None,
         };
 
-        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
+        let (pairs, _dest_meta) = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
 
         assert_eq!(pairs.len(), 2);
         assert!(pairs.iter().any(|p| p.source.ends_with("file1.txt")));
@@ -732,7 +732,7 @@ mod tests {
             delete_timing: None,
         };
 
-        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
+        let (pairs, _dest_meta) = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
 
         assert!(pairs.is_empty());
     }
@@ -764,7 +764,7 @@ mod tests {
             delete_timing: None,
         };
 
-        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
+        let (pairs, _dest_meta) = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
 
         assert!(pairs.is_empty());
     }
@@ -796,10 +796,110 @@ mod tests {
             delete_timing: None,
         };
 
-        let pairs = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
+        let (pairs, dest_meta) = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
 
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].source_size, 100);
         assert_eq!(pairs[0].destination_size, 100);
+        // The regular-file destination lstat is cached for copy_file to reuse,
+        // avoiding a second lstat of the same path.
+        let cached = dest_meta
+            .get(&dest_dir.join("file.txt"))
+            .expect("destination metadata cached");
+        assert_eq!(cached.len(), 100);
+    }
+
+    // upstream: generator.c:recv_generator() lstats the destination; a symlink
+    // destination is never treated as a regular-file checksum candidate. The
+    // nofollow lstat must therefore exclude a symlink dest from both the pair
+    // list and the reusable metadata cache, even when it points at a same-size
+    // regular file (which a FOLLOW stat would have wrongly accepted).
+    #[cfg(unix)]
+    #[test]
+    fn collect_file_pairs_excludes_symlink_destination() {
+        let dir = create_tempdir();
+        let source_dir = dir.path().join("src");
+        let dest_dir = dir.path().join("dst");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::create_dir_all(&dest_dir).unwrap();
+
+        let entry = create_test_entry(source_dir.join("file.txt"), "file.txt", 100);
+
+        // A same-size regular file the destination symlink points at.
+        let referent = dest_dir.join("referent.bin");
+        std::fs::write(&referent, vec![0u8; 100]).unwrap();
+        std::os::unix::fs::symlink(&referent, dest_dir.join("file.txt")).unwrap();
+
+        let entries = [entry];
+        let planned: Vec<PlannedEntry> = vec![PlannedEntry {
+            entry: &entries[0],
+            relative: PathBuf::from("file.txt"),
+            action: EntryAction::CopyFile,
+            metadata_override: None,
+        }];
+
+        let plan = DirectoryPlan {
+            planned_entries: planned,
+            keep_names: Vec::new(),
+            deletion_enabled: false,
+            delete_timing: None,
+        };
+
+        let (pairs, dest_meta) = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
+
+        assert!(pairs.is_empty(), "symlink dest is not a checksum candidate");
+        assert!(
+            !dest_meta.contains_key(&dest_dir.join("file.txt")),
+            "symlink dest metadata must not be cached as a regular file"
+        );
+    }
+
+    // A destination hardlinked to a sibling can have its shared inode's mtime
+    // mutated by copy_file when that sibling is updated earlier in the same
+    // directory pass, so its pre-pass lstat must NOT be cached for reuse (that
+    // would replay a stale mtime and add a phantom itemized time change). The
+    // destination still stays a checksum candidate; only the reuse cache skips
+    // it, so copy_file performs its own fresh lstat.
+    #[cfg(unix)]
+    #[test]
+    fn collect_file_pairs_excludes_hardlinked_destination_from_cache() {
+        let dir = create_tempdir();
+        let source_dir = dir.path().join("src");
+        let dest_dir = dir.path().join("dst");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::create_dir_all(&dest_dir).unwrap();
+
+        let entry = create_test_entry(source_dir.join("file.txt"), "file.txt", 100);
+
+        // A same-size regular destination with two links (nlink == 2).
+        std::fs::write(dest_dir.join("file.txt"), vec![0u8; 100]).unwrap();
+        std::fs::hard_link(dest_dir.join("file.txt"), dest_dir.join("alias.txt")).unwrap();
+
+        let entries = [entry];
+        let planned: Vec<PlannedEntry> = vec![PlannedEntry {
+            entry: &entries[0],
+            relative: PathBuf::from("file.txt"),
+            action: EntryAction::CopyFile,
+            metadata_override: None,
+        }];
+
+        let plan = DirectoryPlan {
+            planned_entries: planned,
+            keep_names: Vec::new(),
+            deletion_enabled: false,
+            delete_timing: None,
+        };
+
+        let (pairs, dest_meta) = collect_file_pairs_for_checksum(&plan, &dest_dir, None);
+
+        assert_eq!(
+            pairs.len(),
+            1,
+            "hardlinked dest is still a checksum candidate"
+        );
+        assert!(
+            !dest_meta.contains_key(&dest_dir.join("file.txt")),
+            "hardlinked dest metadata must not be cached (mtime can change mid-pass)"
+        );
     }
 }

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -801,12 +801,22 @@ mod tests {
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].source_size, 100);
         assert_eq!(pairs[0].destination_size, 100);
-        // The regular-file destination lstat is cached for copy_file to reuse,
-        // avoiding a second lstat of the same path.
-        let cached = dest_meta
-            .get(&dest_dir.join("file.txt"))
-            .expect("destination metadata cached");
-        assert_eq!(cached.len(), 100);
+        // On unix the single-link regular-file destination lstat is cached for
+        // copy_file to reuse, avoiding a second lstat of the same path. There is
+        // no portable nlink on non-unix, so the reuse cache is never populated
+        // and copy_file fresh-stats instead (matching upstream's per-file lstat
+        // and pre-dedup master behaviour).
+        #[cfg(unix)]
+        {
+            let cached = dest_meta
+                .get(&dest_dir.join("file.txt"))
+                .expect("destination metadata cached");
+            assert_eq!(cached.len(), 100);
+        }
+        #[cfg(not(unix))]
+        {
+            assert!(dest_meta.is_empty());
+        }
     }
 
     // upstream: generator.c:recv_generator() lstats the destination; a symlink

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -82,16 +82,22 @@ pub(crate) fn copy_file(
         return Ok(false);
     }
 
-    let mut existing_metadata = match fs::symlink_metadata(destination) {
-        Ok(existing) => Some(existing),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-        Err(error) => {
-            return Err(LocalCopyError::io(
-                "inspect existing destination",
-                destination.to_path_buf(),
-                error,
-            ));
-        }
+    // Reuse the destination lstat gathered by the checksum-mode prefetch when
+    // present; otherwise lstat here. This keeps checksum mode at one generator
+    // link_stat per destination instead of two. upstream: generator.c:recv_generator().
+    let mut existing_metadata = match context.take_cached_destination_metadata(destination) {
+        Some(cached) => Some(cached),
+        None => match fs::symlink_metadata(destination) {
+            Ok(existing) => Some(existing),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(LocalCopyError::io(
+                    "inspect existing destination",
+                    destination.to_path_buf(),
+                    error,
+                ));
+            }
+        },
     };
 
     let mut destination_previously_existed = existing_metadata.is_some();


### PR DESCRIPTION
## What

In `--checksum` local-copy mode the engine issued **2 destination `statx` per file** (a FOLLOW stat in the checksum prefetch + the NOFOLLOW decision lstat in `copy_file`). Upstream's generator does **one** `link_stat` (lstat, NOFOLLOW) per destination — `generator.c:1356`. This PR dedupes oc to a single NOFOLLOW lstat, matching upstream.

Cosmetic only (zero measurable wall-clock — oc is already faster than upstream in checksum mode); the value is matching upstream's syscall profile and generator semantics.

## Status: fixing an itemize regression to match upstream exactly

The first cut (`1259163c2`) switched the prefetch eligibility stat from `fs::metadata` (FOLLOW) to `fs::symlink_metadata` (NOFOLLOW). NOFOLLOW is the **correct** direction (upstream never follows the dest here), but it surfaced a regression in the upstream `itemize` interop test — meaning oc's decision/itemize path is wrongly **coupled** to the checksum-prefetch cache (which must be a pure optimization).

Target behavior, matching upstream **`generator.c:1732-1738`** exactly:

```c
fnamecmp_type = FNAMECMP_FNAME;
if (statret == 0 && !(stype == FT_REG || (write_devices && stype == FT_DEVICE))) {
    delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_FILE);
    statret = -1;            /* treat as if dest doesn't exist */
    stat_errno = ENOENT;
}
```

i.e. a **symlink / non-regular destination is deleted and treated as new** (itemized as a created/changed transfer), and **only a regular-file destination is checksum-compared**. The fix decouples oc's itemize decision from the prefetch cache so the itemized output equals upstream's for that case — without reverting to FOLLOW (which would diverge from upstream).

## Merge gate

Merge only when the upstream `itemize` test passes **because oc matches upstream** (not by masking). If the prefetch cannot be cleanly decoupled, this cosmetic PR is closed instead — an itemize regression is not worth eliminating one harmless syscall.

## Tests
- New engine unit test: symlink destination excluded from the checksum pair list + metadata cache.
- Checksum prefetch/collect unit tests green.
- lxhost strace: destination statx/file 2 -> 1 (NOFOLLOW only), matching upstream rsync's single generator lstat.