### PR TITLE
docs: clarify mmap vs SQPOLL exclusion and default basis-read path

### DIFF
--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -469,6 +469,28 @@ impl IoUringConfig {
     /// the wiring fails with a downgrade-class errno at submission time, the
     /// refusal here remains the safety net: the ring is built without
     /// SQPOLL and `SQPOLL_FALLBACK` is set so callers see the degrade.
+    ///
+    /// # Default-configuration behaviour (which optimisation is actually live)
+    ///
+    /// The mmap-vs-SQPOLL refusal is *inert in a stock build*, and mmap and
+    /// SQPOLL are never simultaneously active by default - not because they are
+    /// forbidden from pairing, but because SQPOLL is opt-in:
+    ///
+    /// - [`sqpoll`](Self::sqpoll) defaults to `false` on every constructor
+    ///   ([`default`](Self::default), [`for_large_files`](Self::for_large_files),
+    ///   [`for_small_files`](Self::for_small_files)), and the production
+    ///   reader/writer paths all build from `IoUringConfig::default()`. A
+    ///   default transfer therefore never requests the SQPOLL kthread, so
+    ///   `sqpoll_requested` is `false` and this refusal is never reached.
+    /// - The large-basis read path runs on mmap - the default signature-read
+    ///   backend (io_uring `READ_FIXED` basis slurp is gated behind the
+    ///   non-default `iouring-data-reads` feature). So in a stock build mmap is
+    ///   the active big-I/O optimisation and SQPOLL simply stays off.
+    /// - When an operator *does* opt into SQPOLL, the default feature set still
+    ///   includes `sqpoll-mlock-basis`, so `sqpoll_safe` stays `true` even with
+    ///   an mmap'd basis: the wired-window pin above lets SQPOLL and mmap
+    ///   coexist. The two are only genuinely mutually exclusive once that
+    ///   feature is compiled out, at which point this refusal trips.
     pub(crate) fn build_ring(&self) -> io::Result<RawIoUring> {
         let policy_disabled = is_sqpoll_disabled_by_policy();
         let rootless_skip = self.sqpoll && !policy_disabled && should_skip_sqpoll_due_to_rootless();

--- a/crates/fast_io/src/io_uring_common.rs
+++ b/crates/fast_io/src/io_uring_common.rs
@@ -107,10 +107,13 @@ pub struct IoUringConfig {
     /// and may share buffers with this ring.
     ///
     /// Set by the caller before constructing the ring when the upstream
-    /// selector cannot guarantee `BufferedMap` for the basis file. The
-    /// Linux backend uses this to defensively disable SQPOLL when paired
-    /// with mmap'd basis files. The stub stores the flag for parity but
-    /// never acts on it.
+    /// selector cannot guarantee `BufferedMap` for the basis file. On Linux
+    /// this only disables SQPOLL when the default `sqpoll-mlock-basis` feature
+    /// is compiled out; with the feature on (the default) the basis window is
+    /// mlock-pinned so SQPOLL and an mmap'd basis coexist. Note SQPOLL is off
+    /// by default (`sqpoll` is `false`), so this flag has no effect in a stock
+    /// build. See `IoUringConfig::build_ring` for the full rule. The stub
+    /// stores the flag for parity but never acts on it.
     pub mmap_basis_active: bool,
     /// Whether to register fixed buffers
     /// (`IORING_REGISTER_BUFFERS` + `READ_FIXED` / `WRITE_FIXED`).

--- a/docs/design/io-acceleration-parity-matrix.md
+++ b/docs/design/io-acceleration-parity-matrix.md
@@ -63,6 +63,35 @@ compiled with runtime detection.
 | mmap (`MapFile` / adaptive / mmap strategy) | WIRED | WIRED | n/a (unix-only) | runtime | n/a | yes - `transfer/.../map_file/` |
 | sequential-read-hint (`posix_fadvise` Linux / `F_NOCACHE` macOS) | WIRED | WIRED | n/a | runtime | n/a | yes - `transfer/.../map_file/buffered.rs` |
 
+### mmap vs SQPOLL on the basis read
+
+Two big-I/O optimisations compete on the delta basis read: mmap of the basis
+file and an io_uring SQPOLL ring reading it. They interact but are **not**
+simultaneously active in a default build, which routinely confuses readers about
+which one is engaged.
+
+- **SQPOLL is opt-in.** `IoUringConfig::sqpoll` defaults to `false` on every
+  constructor, and the production reader/writer paths build from
+  `IoUringConfig::default()`. A stock transfer never requests the SQPOLL kthread,
+  so the default large-basis read runs on **mmap** (io_uring `READ_FIXED` basis
+  slurp is itself gated behind the non-default `iouring-data-reads` feature).
+- **The mmap+SQPOLL refusal is a backstop, not the default gate.** Pairing a
+  SQPOLL kthread with a file-backed mmap is a kernel hazard (the kthread has no
+  user `mm` context, so cold-page faults bounce to `task_work` and concurrent
+  truncation surfaces as in-kernel `SIGBUS`; see
+  `docs/audits/io-uring-sqpoll-mmap-interaction.md`). `IoUringConfig::build_ring`
+  refuses SQPOLL when `mmap_basis_active` is set **only** if the default
+  `sqpoll-mlock-basis` feature is compiled out.
+- **With the default feature set they coexist.** `sqpoll-mlock-basis` (a default
+  feature) pins each basis window via `mlock(2)` before submission
+  (`fast_io/src/sqpoll_basis.rs`), closing the fault race, so an operator who
+  opts into SQPOLL keeps it even against an mmap'd basis. Mutual exclusion only
+  reappears if that feature is disabled.
+
+Net: in the default configuration mmap is the live basis-read acceleration and
+SQPOLL is off - they never run together because SQPOLL is not requested, not
+because the code forbids the pairing.
+
 ## Network send
 
 Every kernel-async network-send path is built but not wired: production transport


### PR DESCRIPTION
## Summary

Documents the mmap-vs-SQPOLL interaction on the delta basis read and, crucially, what the **default** build actually does - a point that was undocumented and repeatedly confused readers about which big-I/O optimisation is live.

## What the code actually does (verified)

- `IoUringConfig::sqpoll` defaults to `false` on every constructor (`default`, `for_large_files`, `for_small_files`), and the production reader/writer paths build from `IoUringConfig::default()`. **SQPOLL is opt-in and never requested in a stock build.**
- The default large-basis read runs on **mmap** (the io_uring `READ_FIXED` basis slurp is gated behind the non-default `iouring-data-reads` feature).
- The `sqpoll-mlock-basis` feature is **on by default**. When an operator opts into SQPOLL, each basis window is pinned via `mlock(2)` (`fast_io/src/sqpoll_basis.rs`), closing the SQPOLL-kthread page-fault race, so SQPOLL and an mmap'd basis **coexist**.
- The defensive mmap+SQPOLL refusal in `IoUringConfig::build_ring` only trips when SQPOLL is opted in **and** `sqpoll-mlock-basis` is compiled out.

So mmap and SQPOLL are never simultaneously active by default - not because the code forbids the pairing, but because SQPOLL is off by default. The earlier framing of a hard "mutual exclusion in the default config" was imprecise and is corrected here.

## Changes (documentation only, no behaviour change)

- `crates/fast_io/src/io_uring/config.rs`: new "Default-configuration behaviour" section on `build_ring` explaining which optimisation is live by default and when the exclusion actually applies.
- `crates/fast_io/src/io_uring_common.rs`: corrected the `mmap_basis_active` field doc, which previously implied an unconditional SQPOLL disable; now states the `sqpoll-mlock-basis` caveat and that SQPOLL is off by default.
- `docs/design/io-acceleration-parity-matrix.md`: new "mmap vs SQPOLL on the basis read" subsection under Disk read.

## Verification

- `cargo fmt -p fast_io -- --check`: clean
- `cargo clippy -p fast_io --all-features --no-deps -- -D warnings`: clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p fast_io --no-deps --all-features`: clean (intra-doc links resolve)