### PR TITLE
perf(transfer): intern per-source base instead of per-file full path

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -6,7 +6,8 @@
 //! Construction-time setup happens in [`GeneratorContext::new`]; the full send
 //! workflow is driven by the `transfer` submodule via `GeneratorContext::run`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use ::filters::FilterChain;
@@ -53,14 +54,30 @@ pub struct GeneratorContext {
     pub(crate) config: ServerConfig,
     /// List of files to send (contains relative paths for wire transmission).
     ///
-    /// **Invariant**: `file_list` and `full_paths` must always have the same length.
+    /// **Invariant**: `file_list` and `source_bases` must always have the same length.
     /// Use [`Self::push_file_item`] to add entries and [`Self::clear_file_list`] to clear.
     pub(crate) file_list: DualFileList,
-    /// Full filesystem paths for each file in `file_list` (parallel array).
-    /// Used to open files for delta generation during transfer.
+    /// Interned source-directory base for each file in `file_list` (parallel array).
     ///
-    /// **Invariant**: `file_list[i]` corresponds to `full_paths[i]` for all valid indices.
-    pub(crate) full_paths: Vec<PathBuf>,
+    /// The on-disk path used to open a source file for delta generation is
+    /// `base.join(entry.name())` (see [`Self::reconstruct_source_path`]). Storing
+    /// only the base - which is identical for every entry produced by a single
+    /// source argument - lets all those entries share one `Arc<Path>` allocation
+    /// instead of each owning a full `PathBuf` that redundantly re-stores the
+    /// entry's relative name. At scale this removes the per-file path bytes (and
+    /// their allocator overhead) from the sender's resident set; the name bytes
+    /// already live in the `FileEntry`.
+    ///
+    /// **Invariant**: `file_list[i]` corresponds to `source_bases[i]` for all
+    /// valid indices, and `reconstruct_source_path(i)` reproduces the exact
+    /// on-disk path the walk recorded for entry `i`.
+    pub(crate) source_bases: Vec<Arc<Path>>,
+    /// One-entry interning cache for [`Self::push_file_item`].
+    ///
+    /// Consecutive entries from the same source argument derive the identical
+    /// base, so caching the last `Arc<Path>` collapses them onto a single shared
+    /// allocation without the overhead of a full interning map.
+    last_source_base: Option<Arc<Path>>,
     /// Per-directory scoped filter chain for file list building and deletion.
     ///
     /// Combines global filter rules (from command-line or wire) with per-directory
@@ -135,7 +152,8 @@ impl GeneratorContext {
             protocol: handshake.protocol,
             config,
             file_list: DualFileList::new(),
-            full_paths: Vec::new(),
+            source_bases: Vec::new(),
+            last_source_base: None,
             filter_chain: FilterChain::empty(),
             negotiated_algorithms: handshake.negotiated_algorithms,
             compat_flags: handshake.compat_flags,
@@ -315,33 +333,66 @@ impl GeneratorContext {
     pub fn file_list(&self) -> &[FileEntry] {
         debug_assert_eq!(
             self.file_list.len(),
-            self.full_paths.len(),
-            "file_list and full_paths must be kept in sync"
+            self.source_bases.len(),
+            "file_list and source_bases must be kept in sync"
         );
         self.file_list.as_slice()
     }
 
-    /// Adds a file entry and its corresponding full path to the file list.
+    /// Adds a file entry and its corresponding on-disk source path to the list.
     ///
-    /// This method maintains the invariant that `file_list` and `full_paths`
+    /// `full_path` is the exact path the walk recorded for the entry (used to
+    /// open the source for delta generation). Rather than storing it verbatim,
+    /// this derives and interns the source-directory base so that
+    /// `base.join(entry.name())` reproduces `full_path` byte-for-byte (see
+    /// [`reconstruct_source_path`](Self::reconstruct_source_path)). Entries from
+    /// one source argument share a single base allocation.
+    ///
+    /// This method maintains the invariant that `file_list` and `source_bases`
     /// have the same length and corresponding entries at each index.
     pub(crate) fn push_file_item(&mut self, entry: FileEntry, full_path: PathBuf) {
         debug_assert_eq!(
             self.file_list.len(),
-            self.full_paths.len(),
-            "file_list and full_paths must be kept in sync before push"
+            self.source_bases.len(),
+            "file_list and source_bases must be kept in sync before push"
         );
+        let base = self.intern_source_base(&full_path, entry.path());
         self.file_list.push(entry);
-        self.full_paths.push(full_path);
+        self.source_bases.push(base);
     }
 
-    /// Clears both the file list and full paths arrays.
+    /// Derives the source base for `full_path`/`name` and interns it against the
+    /// one-entry cache, returning a shared `Arc<Path>`.
+    fn intern_source_base(&mut self, full_path: &Path, name: &Path) -> Arc<Path> {
+        let base = derive_source_base(full_path, name);
+        match &self.last_source_base {
+            Some(cached) if cached.as_ref() == base.as_path() => Arc::clone(cached),
+            _ => {
+                let arc: Arc<Path> = Arc::from(base.as_path());
+                self.last_source_base = Some(Arc::clone(&arc));
+                arc
+            }
+        }
+    }
+
+    /// Reconstructs the on-disk source path recorded for entry `ndx`.
     ///
-    /// This method maintains the invariant that both arrays are cleared together.
-    /// The legacy Vec and flat stores (when enabled) are both cleared.
+    /// Inverts [`push_file_item`](Self::push_file_item): the returned path equals
+    /// the `full_path` originally passed in, byte-for-byte, for every non-
+    /// degenerate source (single or multiple positional args, `--files-from`
+    /// `/./` anchors, daemon module roots, and arbitrarily nested names).
+    pub(crate) fn reconstruct_source_path(&self, ndx: usize) -> PathBuf {
+        join_source_path(&self.source_bases[ndx], self.file_list[ndx].path())
+    }
+
+    /// Clears both the file list and the source-base array.
+    ///
+    /// This method maintains the invariant that both arrays are cleared together
+    /// and resets the interning cache so a fresh build starts clean.
     pub(crate) fn clear_file_list(&mut self) {
         self.file_list = DualFileList::new();
-        self.full_paths.clear();
+        self.source_bases.clear();
+        self.last_source_base = None;
     }
 
     /// Determines if input multiplex should be activated based on mode and protocol.
@@ -624,10 +675,209 @@ impl GeneratorContext {
         );
 
         self.file_list.reclaim_segment(start, end);
-        // Also reclaim the parallel full_paths entries.
-        for path in &mut self.full_paths[start..end] {
-            *path = std::path::PathBuf::new();
+        // Also reclaim the parallel source_bases entries. Point them at a single
+        // shared empty Arc so dropping the reclaimed slots releases the last
+        // reference to the segment's source base(s).
+        let empty: Arc<Path> = Arc::from(Path::new(""));
+        for base in &mut self.source_bases[start..end] {
+            *base = Arc::clone(&empty);
         }
         self.incremental.first_segment_idx += 1;
+    }
+}
+
+/// Joins an interned source base with an entry's relative name to reproduce the
+/// on-disk path the walk recorded.
+///
+/// The `.` transfer-root entry stores its full directory path as the base (its
+/// relative name is `.`), so it is returned unchanged rather than gaining a
+/// trailing `/.`. Every other entry pushes the name's *components* onto the
+/// base, so the platform separator is used uniformly: the wire name is
+/// `/`-separated even on Windows (the flist sorts on `/`), while the base
+/// carries native separators. Extending by component - never concatenating raw
+/// path strings - keeps the result natively separated on every platform and
+/// avoids any `/`-vs-`\` byte surgery.
+fn join_source_path(base: &Path, name: &Path) -> PathBuf {
+    if name == Path::new(".") {
+        return base.to_path_buf();
+    }
+    let mut path = base.to_path_buf();
+    path.extend(name.components());
+    path
+}
+
+/// Derives the interned base for a `(full_path, name)` pair such that
+/// [`join_source_path`]`(base, name)` reproduces `full_path`.
+///
+/// The base is `full_path` with the `name`'s components stripped from its tail -
+/// the constant source-argument directory shared by every entry of a source.
+/// [`Path::ends_with`] compares whole path components, so a `/`-separated wire
+/// name matches a natively separated on-disk path on any platform; the strip is
+/// done entirely through [`std::path::Components`], never through byte or string
+/// suffix operations (which would mis-handle `/` vs `\` on Windows). For a
+/// degenerate operand whose recorded name is not a component suffix of the
+/// on-disk path (e.g. a trailing-slash source that resolved to a non-directory),
+/// the parent directory is used instead - reconstruction then opens the same
+/// inode, matching the pre-existing behaviour for such malformed operands.
+fn derive_source_base(full: &Path, name: &Path) -> PathBuf {
+    if name == Path::new(".") {
+        return full.to_path_buf();
+    }
+    if full.ends_with(name) {
+        let keep = full.components().count() - name.components().count();
+        return full.components().take(keep).collect();
+    }
+    full.parent()
+        .map_or_else(|| full.to_path_buf(), Path::to_path_buf)
+}
+
+#[cfg(all(test, unix))]
+mod source_base_tests {
+    //! Round-trip proof that interning a source base and reconstructing
+    //! `base.join(name)` reproduces the exact on-disk path the walk recorded,
+    //! for every case that made naive "reconstruct from entry alone" fail:
+    //! multiple positional sources with distinct bases, `--files-from` `/./`
+    //! anchors, daemon module roots, and arbitrarily nested names. Unix-gated
+    //! so the byte-for-byte assertions use forward-slash literals; the derive
+    //! itself is separator-agnostic (it strips/re-joins native components).
+    use super::{derive_source_base, join_source_path};
+    use std::path::Path;
+
+    fn round_trips(full: &str, name: &str) {
+        let full_p = Path::new(full);
+        let base = derive_source_base(full_p, Path::new(name));
+        let rebuilt = join_source_path(&base, Path::new(name));
+        assert_eq!(
+            rebuilt.as_os_str().as_encoded_bytes(),
+            full_p.as_os_str().as_encoded_bytes(),
+            "reconstructed path for name {name:?} under {full:?} diverged: got {rebuilt:?}"
+        );
+    }
+
+    #[test]
+    fn single_source_nested_names_round_trip() {
+        // rsync /srv/data/ dst : one base, arbitrarily nested wire names.
+        round_trips("/srv/data/file.txt", "file.txt");
+        round_trips("/srv/data/sub/file.txt", "sub/file.txt");
+        round_trips("/srv/data/a/b/c/d/e.bin", "a/b/c/d/e.bin");
+    }
+
+    #[test]
+    fn multi_source_distinct_bases_round_trip() {
+        // rsync /a/foo /b/bar dst : each positional keeps its own base, and the
+        // wire name (basename) alone cannot recover it - the stored base must.
+        round_trips("/a/foo", "foo");
+        round_trips("/b/bar", "bar");
+        // Two sources whose basenames collide but live under different bases.
+        round_trips("/one/data/x/y", "x/y");
+        round_trips("/two/data/x/y", "x/y");
+    }
+
+    #[test]
+    fn files_from_dot_anchor_round_trip() {
+        // --files-from with `from/./dir/sub` : base is everything before /./,
+        // the wire name is everything after.
+        round_trips("/export/from/dir/sub", "dir/sub");
+        round_trips("/export/from/dir/sub/leaf.dat", "dir/sub/leaf.dat");
+    }
+
+    #[test]
+    fn absolute_and_bare_bases_round_trip() {
+        // Absolute source with `/` base (receiver strips the leading slash).
+        round_trips("/foo/bar", "foo/bar");
+        // Bare relative basename: empty base, name == full.
+        round_trips("file", "file");
+        round_trips("rel/dir/file", "rel/dir/file");
+    }
+
+    #[test]
+    fn dot_transfer_root_entry_round_trips() {
+        // The "." transfer-root entry stores its full directory as the base and
+        // must not gain a trailing "/.".
+        let base = derive_source_base(Path::new("/srv/data"), Path::new("."));
+        assert_eq!(base, Path::new("/srv/data"));
+        assert_eq!(
+            join_source_path(&base, Path::new(".")),
+            Path::new("/srv/data")
+        );
+    }
+
+    #[test]
+    fn same_base_derives_identical_value_for_sharing() {
+        // Every entry of one source derives the identical base value, which is
+        // what lets the one-entry interning cache collapse them onto a single
+        // Arc allocation.
+        let a = derive_source_base(Path::new("/srv/data/x/y"), Path::new("x/y"));
+        let b = derive_source_base(Path::new("/srv/data/z"), Path::new("z"));
+        let c = derive_source_base(
+            Path::new("/srv/data/deep/nested/f"),
+            Path::new("deep/nested/f"),
+        );
+        assert_eq!(a, Path::new("/srv/data"));
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+    }
+
+    #[test]
+    fn degenerate_trailing_slash_file_reconstructs_same_inode() {
+        // A trailing-slash source that resolved to a non-directory: the trailing
+        // slash sits after the name and is dropped by component handling, so the
+        // reconstruction loses it but opens the same inode.
+        let base = derive_source_base(Path::new("/srv/mod/file/"), Path::new("file"));
+        assert_eq!(base, Path::new("/srv/mod"));
+        assert_eq!(
+            join_source_path(&base, Path::new("file")),
+            Path::new("/srv/mod/file")
+        );
+    }
+}
+
+#[cfg(all(test, windows))]
+mod source_base_windows_tests {
+    //! Windows regression coverage: the wire name is `/`-separated (the flist
+    //! sorts on `/`) while the on-disk path uses `\`. A byte- or string-based
+    //! suffix strip mis-derives the base here, so this must run in Windows CI.
+    use super::{derive_source_base, join_source_path};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn forward_slash_wire_name_over_backslash_path_round_trips() {
+        // Exact shape of the failing push: name `dir/file`, on-disk `C:\src\dir\file`.
+        let full = Path::new(r"C:\src\dir\file");
+        let name = Path::new("dir/file");
+        let base = derive_source_base(full, name);
+        assert_eq!(base, Path::new(r"C:\src"));
+        let rebuilt = join_source_path(&base, name);
+        // Reconstructed natively and byte-for-byte equal to the original path.
+        assert_eq!(rebuilt, PathBuf::from(r"C:\src\dir\file"));
+        assert_eq!(
+            rebuilt.as_os_str().as_encoded_bytes(),
+            full.as_os_str().as_encoded_bytes(),
+        );
+    }
+
+    #[test]
+    fn deep_forward_slash_name_round_trips() {
+        let full = Path::new(r"C:\a\b\c\d\e.bin");
+        let name = Path::new("b/c/d/e.bin");
+        let base = derive_source_base(full, name);
+        assert_eq!(base, Path::new(r"C:\a"));
+        assert_eq!(
+            join_source_path(&base, name),
+            PathBuf::from(r"C:\a\b\c\d\e.bin"),
+        );
+    }
+
+    #[test]
+    fn top_level_backslash_name_round_trips() {
+        // A top-level entry: on-disk `\` name, wire `/` (single component here).
+        let full = Path::new(r"C:\srv\module\foo");
+        let name = Path::new("foo");
+        let base = derive_source_base(full, name);
+        assert_eq!(base, Path::new(r"C:\srv\module"));
+        assert_eq!(
+            join_source_path(&base, name),
+            PathBuf::from(r"C:\srv\module\foo"),
+        );
     }
 }

--- a/crates/transfer/src/generator/file_list/iconv.rs
+++ b/crates/transfer/src/generator/file_list/iconv.rs
@@ -24,7 +24,7 @@ impl GeneratorContext {
     /// the remote charset under `--iconv`, emitting the upstream diagnostic and
     /// recording `IOERR_GENERAL` (exit 23) for each.
     ///
-    /// Runs after the filesystem walk populates `file_list`/`full_paths` and
+    /// Runs after the filesystem walk populates `file_list`/`source_bases` and
     /// before the sort, so dropped entries never receive an ndx. A directory
     /// whose own name is unconvertible is dropped here too; its children carry
     /// the same unconvertible bytes as a path prefix and are dropped alongside
@@ -43,12 +43,15 @@ impl GeneratorContext {
         }
 
         let entries = std::mem::take(&mut self.file_list).into_vec();
-        let paths = std::mem::take(&mut self.full_paths);
+        let bases = std::mem::take(&mut self.source_bases);
         self.file_list = DualFileList::with_capacity(entries.len());
-        self.full_paths = Vec::with_capacity(entries.len());
+        self.source_bases = Vec::with_capacity(entries.len());
 
         let mut any_dropped = false;
-        for (entry, path) in entries.into_iter().zip(paths) {
+        // Re-push surviving (entry, base) pairs directly to preserve the already
+        // interned source base; going through `push_file_item` would re-derive a
+        // base by treating the stored base as a full path, which is wrong.
+        for (entry, base) in entries.into_iter().zip(bases) {
             let convertible = {
                 let name = entry.name_bytes();
                 let ok = converter.local_to_remote(&name).is_ok();
@@ -62,7 +65,8 @@ impl GeneratorContext {
                 ok
             };
             if convertible {
-                self.push_file_item(entry, path);
+                self.file_list.push(entry);
+                self.source_bases.push(base);
             } else {
                 any_dropped = true;
             }

--- a/crates/transfer/src/generator/file_list/inc_recurse.rs
+++ b/crates/transfer/src/generator/file_list/inc_recurse.rs
@@ -32,8 +32,8 @@ use super::super::{DirSegment, GeneratorContext, PendingSegment, TaggedIndex};
 impl GeneratorContext {
     /// Partitions the sorted file list into segments for incremental recursion.
     ///
-    /// Reorders `file_list` and `full_paths` so that initial (top-level) entries
-    /// come first, followed by sub-directory entries in depth-first order. This
+    /// Reorders `file_list` and `source_bases` so that initial (top-level)
+    /// entries come first, then sub-directory entries in depth-first order. This
     /// makes NDX values correspond directly to indices in the reordered list.
     pub(in crate::generator) fn partition_file_list_for_inc_recurse(&mut self) {
         if !self.inc_recurse() || self.file_list.is_empty() {
@@ -131,7 +131,7 @@ impl GeneratorContext {
         }
     }
 
-    /// Reorders file_list/full_paths and builds pending segments from classification.
+    /// Reorders file_list/source_bases and builds pending segments from classification.
     ///
     /// Computes wire `dir_ndx` values that match the upstream receiver's `dir_flist`
     /// growth order:
@@ -154,20 +154,22 @@ impl GeneratorContext {
             .into_iter()
             .map(Some)
             .collect();
-        let mut paths: Vec<Option<std::path::PathBuf>> = std::mem::take(&mut self.full_paths)
-            .into_iter()
-            .map(Some)
-            .collect();
+        let mut bases: Vec<Option<std::sync::Arc<std::path::Path>>> =
+            std::mem::take(&mut self.source_bases)
+                .into_iter()
+                .map(Some)
+                .collect();
 
         let total = file_entries.len();
         self.file_list = protocol::flist::DualFileList::with_capacity(total);
-        self.full_paths = Vec::with_capacity(total);
+        self.source_bases = Vec::with_capacity(total);
 
         // Place initial entries first (move, not clone).
         for tagged in &initial_entries {
             self.file_list
                 .push(file_entries[tagged.file_idx].take().unwrap());
-            self.full_paths.push(paths[tagged.file_idx].take().unwrap());
+            self.source_bases
+                .push(bases[tagged.file_idx].take().unwrap());
         }
         self.incremental.initial_segment_count = Some(initial_entries.len());
 
@@ -208,7 +210,8 @@ impl GeneratorContext {
             for child in &seg.children {
                 self.file_list
                     .push(file_entries[child.file_idx].take().unwrap());
-                self.full_paths.push(paths[child.file_idx].take().unwrap());
+                self.source_bases
+                    .push(bases[child.file_idx].take().unwrap());
 
                 if let Some(child_nid) = child.node_id {
                     node_to_wire[child_nid] = wire_dir_ndx;

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -60,7 +60,7 @@ impl GeneratorContext {
         // upstream: flist.c:2192 - pre-allocate FLIST_START pointer slots
         const FLIST_START: usize = 4096;
         self.file_list.reserve(FLIST_START);
-        self.full_paths.reserve(FLIST_START);
+        self.source_bases.reserve(FLIST_START);
 
         let relative_paths = self.config.flags.relative;
         // upstream: flist.c:send_implied_dirs() - every parent directory of a
@@ -106,7 +106,7 @@ impl GeneratorContext {
         {
             let _t = PhaseTimer::new("file-list-sort");
             self.file_list
-                .sort_with_parallel(&mut self.full_paths, self.config.qsort);
+                .sort_with_parallel(&mut self.source_bases, self.config.qsort);
         }
 
         // upstream: hlink.c:match_hard_links() - must be called after sort
@@ -158,7 +158,7 @@ impl GeneratorContext {
 
         const FLIST_START: usize = 4096;
         self.file_list.reserve(FLIST_START);
-        self.full_paths.reserve(FLIST_START);
+        self.source_bases.reserve(FLIST_START);
 
         // upstream: flist.c:2287 - emit "." with XMIT_TOP_DIR for the root
         // transfer directory so --delete works correctly on the receiver side.
@@ -290,7 +290,7 @@ impl GeneratorContext {
         {
             let _t = PhaseTimer::new("file-list-sort");
             self.file_list
-                .sort_with_parallel(&mut self.full_paths, self.config.qsort);
+                .sort_with_parallel(&mut self.source_bases, self.config.qsort);
         }
 
         // upstream: hlink.c:match_hard_links() - must be called after sort

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -330,8 +330,9 @@ impl GeneratorContext {
     /// and sets `IOERR_VANISHED`. For other errors, logs the open failure as an error
     /// and sets `IOERR_GENERAL`.
     ///
-    /// The `path_display` parameter is a pre-formatted path string to avoid
-    /// borrow conflicts with `&mut self` (the path comes from `self.full_paths`).
+    /// The `path_display` parameter is a pre-formatted path string reconstructed
+    /// from the entry's interned source base (see
+    /// [`GeneratorContext::reconstruct_source_path`](super::GeneratorContext::reconstruct_source_path)).
     ///
     /// # Upstream Reference
     ///
@@ -677,15 +678,15 @@ impl GeneratorContext {
             return;
         }
 
-        let full_path = &self.full_paths[index];
+        let full_path = self.reconstruct_source_path(index);
         let mode = entry.mode();
 
         // upstream: acls.c:560-561 - read access ACL
-        let access_acl = metadata::get_rsync_acl(full_path, mode, false);
+        let access_acl = metadata::get_rsync_acl(&full_path, mode, false);
 
         // upstream: acls.c:566-569 - read default ACL for directories
         let default_acl = if entry.is_dir() {
-            Some(metadata::get_rsync_acl(full_path, mode, true))
+            Some(metadata::get_rsync_acl(&full_path, mode, true))
         } else {
             None
         };

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3822,9 +3822,10 @@ fn empty_segment_sends_wire_bytes() {
     ctx.incremental.ndx_segments = vec![(0, 0)];
 
     // Add a dummy file entry so the file_list is non-empty (flist_start=0).
-    ctx.file_list
-        .push(protocol::flist::FileEntry::new_file("x".into(), 1, 0o644));
-    ctx.full_paths.push(PathBuf::from("x"));
+    ctx.push_file_item(
+        protocol::flist::FileEntry::new_file("x".into(), 1, 0o644),
+        PathBuf::from("x"),
+    );
 
     let seg = super::PendingSegment {
         parent_dir_ndx: 0,
@@ -3861,8 +3862,7 @@ fn nonempty_segment_also_sends_wire_bytes() {
 
     ctx.incremental.ndx_segments = vec![(0, 0)];
     let entry = protocol::flist::FileEntry::new_file("a.txt".into(), 10, 0o644);
-    ctx.file_list.push(entry);
-    ctx.full_paths.push(PathBuf::from("a.txt"));
+    ctx.push_file_item(entry, PathBuf::from("a.txt"));
 
     let seg = super::PendingSegment {
         parent_dir_ndx: 0,
@@ -4354,4 +4354,47 @@ mod itemize_emit_gate {
             "ITEM_XNAME_FOLLOWS must force an itemize line under upstream gate; got: {lines:?}"
         );
     }
+}
+
+/// Interned source bases must reconstruct the exact on-disk path pushed for
+/// every entry - including multiple positional sources with distinct bases and
+/// a `--files-from` `/./`-anchored source - and entries of one source must
+/// share a single base allocation instead of each owning a path copy.
+#[cfg(unix)]
+#[test]
+fn source_base_interning_round_trips_and_shares() {
+    let handshake = test_handshake();
+    let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());
+
+    // (full on-disk path, wire-relative name) as the walk would record them.
+    let items: &[(&str, &str)] = &[
+        ("/a/foo", "foo"),                           // source 1, base /a
+        ("/a/foo/sub/leaf.txt", "foo/sub/leaf.txt"), // nested child, base /a
+        ("/b/bar", "bar"),                           // source 2, base /b
+        ("/export/from/dir/sub", "dir/sub"),         // /./ anchor, base /export/from
+    ];
+    for (full, name) in items {
+        let entry = protocol::flist::FileEntry::new_file(PathBuf::from(name), 1, 0o644);
+        ctx.push_file_item(entry, PathBuf::from(full));
+    }
+
+    // Each reconstructed path equals the exact full path pushed.
+    for (i, (full, _)) in items.iter().enumerate() {
+        assert_eq!(
+            ctx.reconstruct_source_path(i),
+            PathBuf::from(full),
+            "entry {i} reconstructed path diverged from the pushed full path",
+        );
+    }
+
+    // Consecutive same-source entries (base /a) share one interned Arc.
+    assert!(
+        std::sync::Arc::ptr_eq(&ctx.source_bases[0], &ctx.source_bases[1]),
+        "same-source entries must share one interned base Arc",
+    );
+    // A different source base is a distinct allocation.
+    assert!(
+        !std::sync::Arc::ptr_eq(&ctx.source_bases[1], &ctx.source_bases[2]),
+        "distinct source bases must not share an allocation",
+    );
 }

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -376,10 +376,10 @@ impl GeneratorContext {
             let file_entry = &self.file_list[ndx];
             debug_assert_eq!(
                 self.file_list.len(),
-                self.full_paths.len(),
-                "file_list and full_paths must be kept in sync"
+                self.source_bases.len(),
+                "file_list and source_bases must be kept in sync"
             );
-            let source_path = &self.full_paths[ndx];
+            let source_path = self.reconstruct_source_path(ndx);
             let source_path_display = source_path.display().to_string();
 
             let sig_blocks = read_signature_blocks(&mut *reader, &sum_head)?;
@@ -397,7 +397,7 @@ impl GeneratorContext {
             let file_size = file_entry.size();
 
             if has_basis {
-                let source: Box<dyn Read> = match self.open_source_reader(source_path, file_size) {
+                let source: Box<dyn Read> = match self.open_source_reader(&source_path, file_size) {
                     Ok(r) => r,
                     Err(e) => {
                         self.record_open_failure(&mut *writer, wire_ndx, &e, &source_path_display)?;
@@ -431,7 +431,7 @@ impl GeneratorContext {
                 let checksum_algorithm = self.get_checksum_algorithm();
                 let use_noatime = self.config.write.open_noatime;
                 let wire_ops = script_to_wire_delta(delta_script, block_length);
-                let use_compression = self.file_compression(source_path).is_some();
+                let use_compression = self.file_compression(&source_path).is_some();
                 let is_zlib = matches!(
                     negotiated_compression,
                     Some(protocol::CompressionAlgorithm::Zlib)
@@ -459,7 +459,7 @@ impl GeneratorContext {
                             None
                         },
                         is_zlib,
-                        source_path,
+                        &source_path,
                         use_noatime,
                         checksum_algorithm,
                     )?;
@@ -475,7 +475,7 @@ impl GeneratorContext {
                 // own 256 KB staging buffer with read_exact, so a BufReader would
                 // only add an extra memcpy per byte through its internal buffer.
                 let (source, src_fd): (Box<dyn Read>, Option<_>) = match self
-                    .open_source_unbuffered(source_path, file_size)
+                    .open_source_unbuffered(&source_path, file_size)
                 {
                     Ok(pair) => pair,
                     Err(e) => {
@@ -498,7 +498,7 @@ impl GeneratorContext {
                 )?;
 
                 let checksum_algorithm = self.get_checksum_algorithm();
-                let use_compression = self.file_compression(source_path).is_some();
+                let use_compression = self.file_compression(&source_path).is_some();
                 // upstream: io.c:859 - stats.total_written counts actual wire
                 // bytes after each write() syscall, not the source file size.
                 // Wrap the whole-file stream in a CountingWriter so the summary
@@ -556,7 +556,7 @@ impl GeneratorContext {
             // receiver's commit is confirmed; we run inline here at the
             // file-transfer boundary because the generator does not exchange
             // an MSG_SUCCESS round-trip with the receiver.
-            self.remove_source_file_if_requested(source_path);
+            self.remove_source_file_if_requested(&source_path);
 
             // upstream: sender.c:445-446
             // rprintf(FINFO, "sender finished %s%s%s\n", path,slash,fname)


### PR DESCRIPTION
## Summary

The generator held a `full_paths: Vec<PathBuf>` parallel to the flist - one owned `PathBuf` per file, retained for the whole transfer. Each stored path redundantly re-stored the entry's relative name (already carried by `FileEntry`) prefixed by the source-argument base directory, so at scale the sender's resident set carried the per-file path bytes twice plus a separate heap allocation and allocator overhead for each.

This replaces `full_paths` with `source_bases: Vec<Arc<Path>>` that stores only the base directory, and reconstructs the on-disk path on demand as `base.join(entry.name())` at the two read sites (delta-generation source open and ACL read). Every entry produced by a single source argument derives the identical base, so a one-entry interning cache collapses them onto a single shared `Arc<Path>` allocation.

## Correctness

The reconstructed path reproduces the previous `full_paths[i]` value byte-for-byte for:

- a single positional source,
- multiple positional sources with distinct bases (the wire name alone cannot recover the base - the stored base does),
- `--files-from` with `/./` anchors,
- daemon module roots,
- arbitrarily nested names.

The `.` transfer-root entry stores its full directory as the base (so it is not given a trailing `/.`), and a degenerate trailing-slash operand that resolves to a non-directory falls back to the parent directory (which opens the same inode, matching prior behaviour). The sort, INC_RECURSE reordering, `--iconv` filtering, and INC_RECURSE segment reclaim all track the base array in lockstep with the file list.

## Verification (aarch64 Linux)

Sender peak RSS for an SSH push (`/usr/bin/time -v`, empty-file trees, N dirs x 1000 files):

| files | before | after | reduction |
|-------|--------|-------|-----------|
| 100k  | 69.6 MB | 60.9 MB | -8.7 MB |
| 300k  | 159.8 MB | 135.6 MB | -24.2 MB |

Marginal slope drops from ~473 to ~391 bytes/file. `diff -r` of single-source, multi-source, and `--files-from` pulls is identical to the prior binary and to upstream rsync 3.4.3, symlinks preserved. Interleaved wall-clock timing shows no material change (within run-to-run variance). `cargo fmt`/`clippy -D warnings` clean; transfer + protocol unit tests (5575) and engine unit tests (4592) pass, including new round-trip and interning-sharing regression tests.