### PR TITLE
fix(filters): emit only C for CVS dir-merge modifier on the wire

### DIFF
--- a/crates/protocol/src/filters/prefix.rs
+++ b/crates/protocol/src/filters/prefix.rs
@@ -133,23 +133,30 @@ fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -
         prefix.push('!');
     }
 
+    // upstream: exclude.c:1548-1561 get_rule_prefix() - when FILTRULE_CVS_IGNORE
+    // is set, emit ONLY `C`; the no-inherit/word-split/no-prefixes flags it
+    // implies must not also be emitted. The remote parser re-derives them from
+    // `C` (exclude.c:1248-1254) and rejects a redundant `-` after `C` because
+    // the `C` case already set NO_PREFIXES (exclude.c:1249 -> `invalid`), so
+    // emitting `:Cnw-` makes upstream fail with "invalid modifier '-'".
     if rule.cvs_exclude {
         prefix.push('C');
-    }
+    } else {
+        if rule.no_inherit {
+            prefix.push('n');
+        }
 
-    if rule.no_inherit {
-        prefix.push('n');
-    }
+        if rule.word_split {
+            prefix.push('w');
+        }
 
-    if rule.word_split {
-        prefix.push('w');
-    }
-
-    // upstream: exclude.c:1555-1560 - on a merge/dir-merge rule, emit `-` when
-    // FILTRULE_NO_PREFIXES is set and `+` when FILTRULE_NO_PREFIXES|FILTRULE_INCLUDE
-    // are both set. Order matches upstream: between `w` and `e`.
-    if rule.no_prefixes && matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) {
-        prefix.push(if rule.no_prefixes_include { '+' } else { '-' });
+        // upstream: exclude.c:1555-1560 - on a merge/dir-merge rule, emit `-`
+        // when FILTRULE_NO_PREFIXES is set and `+` when
+        // FILTRULE_NO_PREFIXES|FILTRULE_INCLUDE are both set. Order matches
+        // upstream: between `w` and `e`.
+        if rule.no_prefixes && matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) {
+            prefix.push(if rule.no_prefixes_include { '+' } else { '-' });
+        }
     }
 
     if rule.exclude_from_merge {
@@ -243,9 +250,34 @@ mod tests {
         rule.cvs_exclude = true;
 
         // The anchor no longer appears as a `/` prefix modifier on a plain
-        // exclude; it rides in the pattern body (serialize_rule).
+        // exclude; it rides in the pattern body (serialize_rule). With
+        // FILTRULE_CVS_IGNORE set, upstream get_rule_prefix() emits only `C`
+        // and suppresses the implied `n` (exclude.c:1548-1561), so the remote
+        // parser re-derives no-inherit from `C` rather than seeing `Cn`.
         let prefix = build_rule_prefix(&rule, protocol).unwrap();
-        assert_eq!(prefix, "-Cn ");
+        assert_eq!(prefix, "-C ");
+    }
+
+    #[test]
+    fn cvs_dir_merge_emits_only_c_modifier() {
+        // Regression: a `:C` dir-merge carries cvs_exclude + the implied
+        // no_inherit/word_split/no_prefixes flags. Upstream emits just `:C`
+        // (exclude.c:1548-1561); emitting `:Cnw-` makes the remote parser
+        // reject the redundant `-` after `C` ("invalid modifier '-'"), which
+        // aborts daemon/remote transfers using a CVS-style per-dir merge.
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        let rule = FilterRuleWireFormat {
+            rule_type: RuleType::DirMerge,
+            pattern: ".cvsignore".to_owned(),
+            cvs_exclude: true,
+            no_inherit: true,
+            word_split: true,
+            no_prefixes: true,
+            ..FilterRuleWireFormat::default()
+        };
+
+        let prefix = build_rule_prefix(&rule, protocol).unwrap();
+        assert_eq!(prefix, ":C ");
     }
 
     #[test]
@@ -330,9 +362,12 @@ mod tests {
         rule.perishable = true;
 
         // The `/` anchor is no longer a prefix modifier for a non-merge rule;
-        // it moves into the pattern body (serialize_rule).
+        // it moves into the pattern body (serialize_rule). With
+        // FILTRULE_CVS_IGNORE set, upstream get_rule_prefix() emits only `C`
+        // and suppresses the implied `n`/`w` (exclude.c:1548-1561), so they do
+        // not appear even though no_inherit/word_split are set on the rule.
         let prefix = build_rule_prefix(&rule, protocol).unwrap();
-        assert_eq!(prefix, "-!Cnwexsrp ");
+        assert_eq!(prefix, "-!Cexsrp ");
     }
 
     #[test]

--- a/docs/interop-status.md
+++ b/docs/interop-status.md
@@ -117,8 +117,8 @@ the codec.
 | Permissions | `-rlpv` | Pass | Pass | Pass |
 | Numeric IDs | `-av --numeric-ids` | Pass | Pass | Pass |
 | Devices | `-avD` | - | - | Pass |
-| ACLs | `-avA` | Known limitation | Known limitation | Known limitation |
-| Extended attrs | `-avX` | - | - | Known limitation |
+| ACLs | `-avA` | Skipped (proto < 30) | Sender verified; receiver gap | Sender verified; receiver gap |
+| Extended attrs | `-avX` | - | - | Verified when supported |
 | Itemize changes | `-avi` | Pass | Pass | Pass |
 
 ### Links
@@ -341,8 +341,8 @@ schedule. It validates:
 
 | Feature | Description |
 |---------|-------------|
-| ACLs | Transfer succeeds but ACL metadata may be incomplete depending on platform and upstream build options |
-| Extended attrs | Transfer succeeds but xattr handling depends on platform |
+| ACLs | `-avA` sender interop is verified against upstream when the upstream binary advertises ACL support and the host filesystem supports POSIX ACLs (oc client -> upstream daemon round-trips the named-user ACL + mask exactly); skipped when unsupported. Receiver gap: the oc daemon/wire receiver (upstream client -> oc daemon) drops named-user ACL entries and the mask, keeping only the base user/group/other - the oc local copy path preserves them, so the gap is specific to applying a wire-decoded ACL |
+| Extended attrs | `-avX` round-trip is verified against upstream in both directions when the upstream binary advertises xattr support and the host filesystem supports user xattrs; skipped (not failed) otherwise |
 | `--info=progress2` | Output format not fully implemented |
 | `--iconv` | Charset conversion not implemented |
 | 2 GB+ daemon transfer | Not yet validated end-to-end |

--- a/tools/ci/known_failures.conf
+++ b/tools/ci/known_failures.conf
@@ -47,6 +47,20 @@ is_known_failure_from_conf() {
     [[ "$kf" == "$key" ]] && return 0
   done
 
+  # oc-rsync RECEIVER over the wire (daemon/remote) drops named-user POSIX ACL
+  # entries and the ACL mask, keeping only the base user/group/other. The
+  # oc-rsync LOCAL copy path and the oc-rsync SENDER path both preserve them
+  # (verified: oc client -avA -> upstream daemon round-trips the named-user
+  # ACL + mask exactly), so the divergence is specific to applying an ACL
+  # decoded from the wire on the receiving side. Only the "up" direction
+  # (upstream client -> oc daemon, oc = receiver) is affected; the "oc"
+  # direction (oc client -> upstream daemon, oc = sender) passes and is left
+  # ungated so it keeps verifying oc's ACL sender interop. Tracked as an
+  # oc-rsync receiver-side ACL gap; xattrs are unaffected.
+  if [[ "$direction" == "up" && "$name" == "acls" ]]; then
+    return 0
+  fi
+
   # PROTOCOL < 30 KNOWN FAILURES (up direction only)
   # These are all upstream rsync limitations - upstream itself fails identically
   # when negotiating these features at protocol versions below 30. The protocol
@@ -119,8 +133,11 @@ DASHBOARD_ENTRIES=(
 
   # --- Proto <= 29: upstream hard-rejects features that need proto 30+ wire format ---
 
-  # ACLs: upstream compat.c:655-661 hard-exits with RERR_PROTOCOL
-  "up:acls|ACLs at proto <= 29 (upstream compat.c:655-661 hard error, no ACL wire format)|daemon"
+  # ACLs (up = upstream client -> oc daemon, oc = receiver): oc-rsync's wire
+  # receiver drops named-user ACL entries + mask (oc local copy and oc sender
+  # both preserve them). At proto <= 29 the same leg is additionally an
+  # upstream limitation (compat.c:655-661 hard error, no ACL wire format).
+  "up:acls|oc daemon/wire receiver drops named-user ACL entries + mask (oc local + oc sender preserve them); at proto <= 29 also upstream compat.c:655-661 hard error|daemon"
   # Xattrs: upstream compat.c:662-668 hard-exits with RERR_PROTOCOL
   "up:xattrs|xattrs at proto <= 29 (upstream compat.c:662-668 hard error, no xattr wire format)|daemon"
   # Compression algorithm choice: no vstring negotiation at proto < 30

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -1257,6 +1257,18 @@ comp_run_scenario() {
       # Place a .rsync-filter merge file in source that excludes *.dat files
       printf 'exclude *.dat\n' > "$sdir/.rsync-filter"
       ;;
+    acls)
+      # Attach an extended (named-user) ACL to a source file so -avA has real
+      # ACL data to transfer. The named-user entry forces a non-trivial ACL
+      # plus a mask, which upstream encodes on the wire (rsync ACL flist
+      # fields). Verified in the acls) case below via getfacl src-vs-dst.
+      setfacl -m "u:$(id -u):rwx" "$sdir/hello.txt" 2>/dev/null || true
+      ;;
+    xattrs)
+      # Attach a user.* xattr to a source file so -avX has real xattr data to
+      # transfer. Verified in the xattrs) case below via getfattr src-vs-dst.
+      setfattr -n user.interop_test -v verifyme "$sdir/hello.txt" 2>/dev/null || true
+      ;;
     # parallel-threshold setup removed pending PIP-7 fix of parallel-receive-delta
     # receiver corruption (tracking #4720 follow-up). Re-add when the receiver
     # corruption fix lands and parallel-receive-delta returns to default features.
@@ -1264,6 +1276,9 @@ comp_run_scenario() {
 
   # shellcheck disable=SC2086
   local transfer_log="${log}.transfer"
+  # ACL/xattr signatures captured from the source pre-cleanup, asserted in the
+  # acls/xattrs verify arms below.
+  local src_acl_sig="" src_xattr_sig=""
   # Resolve --files-from path to absolute (file placed in dest dir during prep)
   local resolved_flags="$flags"
   if [[ "$resolved_flags" == *"--files-from=filelist.txt"* ]]; then
@@ -1294,6 +1309,17 @@ comp_run_scenario() {
     safe-links) rm -f "$sdir/unsafe_link.txt" ;;
     sparse) rm -f "$sdir/sparse_test.bin" ;;
     merge-filter) rm -f "$sdir/.rsync-filter" ;;
+    acls)
+      # Capture the source ACL before stripping so the verify below can assert
+      # the destination round-tripped it (source is reused across scenarios, so
+      # its extended ACL must not linger and perturb later perm comparisons).
+      src_acl_sig=$(getfacl -cn "$sdir/hello.txt" 2>/dev/null)
+      setfacl -b "$sdir/hello.txt" 2>/dev/null || true
+      ;;
+    xattrs)
+      src_xattr_sig=$(getfattr -d -m user.interop_test "$sdir/hello.txt" 2>/dev/null | grep '^user\.')
+      setfattr -x user.interop_test "$sdir/hello.txt" 2>/dev/null || true
+      ;;
     # parallel-threshold cleanup removed pending PIP-7 fix (#4720 follow-up).
   esac
 
@@ -1510,8 +1536,18 @@ comp_run_scenario() {
       return 0
       ;;
     acls)
-      # ACLs transfer should not break the transfer itself
+      # -avA must round-trip the named-user ACL attached to the source (the
+      # scenario is only registered when both the upstream binary and the host
+      # filesystem support ACLs, so this arm always has real ACL data).
       comp_verify_transfer "$sdir" "$ddir" || return 1
+      local dst_acl_sig
+      dst_acl_sig=$(getfacl -cn "$ddir/hello.txt" 2>/dev/null)
+      if [[ "$src_acl_sig" != "$dst_acl_sig" ]]; then
+        echo "    -avA: ACL not preserved on hello.txt"
+        echo "      src ACL: ${src_acl_sig//$'\n'/ | }"
+        echo "      dst ACL: ${dst_acl_sig//$'\n'/ | }"
+        return 1
+      fi
       return 0
       ;;
     compare-dest)
@@ -1628,8 +1664,18 @@ comp_run_scenario() {
       return 0
       ;;
     xattrs)
-      # -X transfer should not break the transfer itself
+      # -avX must round-trip the user.interop_test xattr attached to the source
+      # (scenario registered only when the upstream binary and host filesystem
+      # support xattrs, so this arm always has real xattr data).
       comp_verify_transfer "$sdir" "$ddir" || return 1
+      local dst_xattr_sig
+      dst_xattr_sig=$(getfattr -d -m user.interop_test "$ddir/hello.txt" 2>/dev/null | grep '^user\.')
+      if [[ "$src_xattr_sig" != "$dst_xattr_sig" ]]; then
+        echo "    -avX: xattr not preserved on hello.txt"
+        echo "      src xattr: ${src_xattr_sig:-<none>}"
+        echo "      dst xattr: ${dst_xattr_sig:-<none>}"
+        return 1
+      fi
       return 0
       ;;
     itemize)
@@ -10800,6 +10846,12 @@ CONF
   fmm_case_merge "merge-e"   ".rules" "- b.txt"           ":e .rules"
   fmm_case_merge "merge-w"   ".rules" "a.txt b.txt"       ":w- .rules"
   fmm_case_merge "merge-w-p" ".rules" "-_a.txt	-_b.txt" ":w .rules"
+  # C: CVS-style per-dir merge. The `C` modifier implies no-prefixes +
+  # word-split + no-inherit + cvs-ignore (upstream exclude.c:1248-1254), so the
+  # whitespace-separated tokens "a.txt b.txt" become two bare excludes parsed
+  # from `.cvsignore`. The PUSH leg gives oc's own `:C` dir-merge parse teeth
+  # (crates/filters/src/merge/parse.rs `C` modifier + chain cvs-token parse).
+  fmm_case_merge "merge-C"   ".cvsignore" "a.txt b.txt"   ":C .cvsignore"
 
   stop_upstream_daemon
 
@@ -11176,6 +11228,50 @@ run_standalone_interop_tests() {
   return "$unexpected"
 }
 
+# Detect whether the host toolchain and the workdir filesystem can actually
+# set and read back POSIX ACLs / user xattrs. Without this, -avA/-avX legs
+# would transfer nothing meaningful (source carries no ACL/xattr) and the
+# verify would degrade to a bare tree compare. Cached in HOST_ACL_OK /
+# HOST_XATTR_OK (1 = usable, 0 = not). Linux tooling (setfacl/getfacl,
+# setfattr/getfattr) - the interop harness runs on Linux CI hosts.
+detect_host_acl_xattr_support() {
+  [[ -n "${HOST_ACL_OK:-}" ]] && return
+  HOST_ACL_OK=0
+  HOST_XATTR_OK=0
+  local probe="${workdir}/.acl-xattr-probe"
+  if ! : > "$probe" 2>/dev/null; then
+    return
+  fi
+  if command -v setfacl >/dev/null 2>&1 && command -v getfacl >/dev/null 2>&1; then
+    if setfacl -m "u:$(id -u):rwx" "$probe" 2>/dev/null \
+        && getfacl -cn "$probe" 2>/dev/null | grep -q '^user:[0-9]'; then
+      HOST_ACL_OK=1
+    fi
+  fi
+  if command -v setfattr >/dev/null 2>&1 && command -v getfattr >/dev/null 2>&1; then
+    if setfattr -n user.acl_xattr_probe -v ok "$probe" 2>/dev/null \
+        && getfattr -n user.acl_xattr_probe "$probe" 2>/dev/null | grep -q 'acl_xattr_probe'; then
+      HOST_XATTR_OK=1
+    fi
+  fi
+  rm -f "$probe"
+}
+
+# Return 0 if the given upstream binary advertises ACL support in its
+# capability line. Upstream prints "ACLs" when SUPPORT_ACLS is compiled in and
+# "no ACLs" otherwise (upstream usage.c:104-107 print_info_flags).
+upstream_supports_acl() {
+  local caps; caps=$("$1" --version 2>&1 || true)
+  grep -qiw "ACLs" <<<"$caps" && ! grep -qi "no ACLs" <<<"$caps"
+}
+
+# Return 0 if the given upstream binary advertises xattr support (upstream
+# usage.c:109-112; "xattrs" vs "no xattrs").
+upstream_supports_xattr() {
+  local caps; caps=$("$1" --version 2>&1 || true)
+  grep -qiw "xattrs" <<<"$caps" && ! grep -qi "no xattrs" <<<"$caps"
+}
+
 # Uses global $comp_src, $oc_client, $up_identity, $hard_timeout.
 run_comprehensive_interop_case() {
   local version=$1 upstream_binary=$2 oc_port=$3 upstream_port=$4
@@ -11226,7 +11322,10 @@ run_comprehensive_interop_case() {
     "exclude|-av --exclude=*.log|exclude"
     "permissions|-rlpv|perms"
     "itemize|-avi|itemize"
-    "acls|-avA|acls"
+    # acls / xattrs are registered below, gated on both the upstream binary's
+    # advertised capability and the host filesystem actually supporting the
+    # feature (detect_host_acl_xattr_support). When unsupported the leg is
+    # honestly skipped rather than run as a no-op tree compare.
     # parallel-threshold-trip matrix entry removed pending PIP-7 fix of
     # parallel-receive-delta receiver corruption (tracking #4720 follow-up).
     # Re-add when the receiver corruption fix lands and parallel-receive-delta
@@ -11239,7 +11338,6 @@ run_comprehensive_interop_case() {
   # but may lack --enable-xattr-support).
   if [[ "${version}" == "3.4.4" ]]; then
     scenarios+=(
-      "xattrs|-avX|xattrs"
       "one-file-system|-avx|basic"
       "whole-file-replace|-avW|whole-file-replace"
       "delay-updates|-av --delay-updates|basic"
@@ -11317,6 +11415,40 @@ run_comprehensive_interop_case() {
   local fp=""; [[ -n "$protocol_flag" ]] && fp="${protocol_flag##*=}"
   if [[ -z "$fp" || "$fp" -ge 30 ]]; then
     scenarios+=("inc-recursive|-av --inc-recursive|inc-recursive")
+  fi
+
+  # Effective protocol for this run: forced value if set, else the version's
+  # native protocol. ACL/xattr wire formats require protocol >= 30 (upstream
+  # compat.c:655-668), so the legs below only apply at proto 30+.
+  local eff_proto="$fp"
+  if [[ -z "$eff_proto" ]]; then
+    case "$version" in
+      3.0.*) eff_proto=28 ;;
+      3.1.*) eff_proto=31 ;;
+      *) eff_proto=32 ;;
+    esac
+  fi
+
+  # ACL / xattr legs gated on real capability: protocol >= 30, the upstream
+  # binary must advertise the feature, AND the host filesystem must let us
+  # set+read the attribute. Only then does the leg run a real -avA/-avX
+  # transfer and assert the ACL/xattr round-trips (comp_run_scenario
+  # acls/xattrs verify). When unsupported the leg is skipped honestly instead
+  # of masquerading as a pass against an ACL/xattr-less peer.
+  detect_host_acl_xattr_support
+  if [[ "$eff_proto" -ge 30 && "${HOST_ACL_OK}" == 1 ]] && upstream_supports_acl "$upstream_binary"; then
+    scenarios+=("acls|-avA|acls")
+  else
+    echo "  [info] proto ${eff_proto} / upstream ${version} / host lacks ACL support, skipping acls"
+  fi
+  # xattrs only runs against the newest upstream (3.4.4) as before, now also
+  # capability- and protocol-gated.
+  if [[ "${version}" == "3.4.4" ]]; then
+    if [[ "$eff_proto" -ge 30 && "${HOST_XATTR_OK}" == 1 ]] && upstream_supports_xattr "$upstream_binary"; then
+      scenarios+=("xattrs|-avX|xattrs")
+    else
+      echo "  [info] proto ${eff_proto} / upstream ${version} / host lacks xattr support, skipping xattrs"
+    fi
   fi
 
   local total=0 passed=0 known=0 unexpected=0


### PR DESCRIPTION
## Summary

Two interop-coverage items, plus a real wire-serialization fix surfaced by the first.

### Item A - `:C` CVS per-dir merge (fix + coverage)

The `:C` dir-merge modifier is honored locally, but the filter **wire serializer** emitted the C-implied modifiers after `C`, producing `:Cnw-`. Upstream rejects that with `invalid modifier '-'` (the `C` case already sets `NO_PREFIXES`, exclude.c:1249), so any **daemon/remote** transfer using a CVS-style per-dir merge aborted (exit 23).

Fix mirrors upstream `get_rule_prefix` (exclude.c:1548-1561): with `FILTRULE_CVS_IGNORE` set, emit only `C` and let the remote re-derive the implied no-inherit / word-split / no-prefixes flags.

- `crates/protocol/src/filters/prefix.rs` - suppress implied modifiers when `cvs_exclude`.
- Updated `multiple_modifiers` test (was pinning the buggy `-Cn`) and added `cvs_dir_merge_emits_only_c_modifier`.
- `tools/ci/run_interop.sh` - new `merge-C` case (`:C .cvsignore`) compared oc-vs-upstream in PULL and PUSH.

Verified on aarch64 Linux vs rsync 3.4.x: merge-C PULL and PUSH byte-for-byte identical.

### Item B - ACL / xattr interop legs actually run + assert

The `-avA` / `-avX` legs previously did a bare tree compare with no ACL/xattr on the source, so they never verified attribute preservation. They now:

- probe host capability (setfacl/getfacl, setfattr/getfattr, live FS probe) and upstream `--version` capabilities;
- register only when protocol >= 30 and both sides support the feature (skip honestly otherwise);
- set a named-user ACL / `user.*` xattr on the source, run a real transfer, and assert the destination round-trips it (`getfacl -cn` / `getfattr -d`).

**Results against an ACL/xattr-capable upstream (rsync 3.4.x):**

- xattrs round-trip in **both** directions - PASS.
- ACL **sender** interop (oc client -> upstream daemon) round-trips the named-user ACL + mask - PASS.
- ACL **wire receiver** (upstream client -> oc daemon) **drops named-user ACL entries + the mask**, keeping only base user/group/other. The oc **local-copy** path preserves them, so the gap is specific to applying a wire-decoded ACL on the receiving side. This is a genuine oc-rsync receiver-side ACL gap, disclosed (not masked) as a documented known limitation in `known_failures.conf` and `docs/interop-status.md`.

### Files

- `crates/protocol/src/filters/prefix.rs`
- `tools/ci/run_interop.sh`
- `tools/ci/known_failures.conf`
- `docs/interop-status.md`