### PR TITLE
refactor: collapse transitional SlotBarrier adapter in parallel apply

### DIFF
--- a/crates/engine/benches/br_3j_f_dashmap_cores_vs_throughput.rs
+++ b/crates/engine/benches/br_3j_f_dashmap_cores_vs_throughput.rs
@@ -37,7 +37,7 @@
 //! across a large rayon pool. This is the path the pre-DashMap
 //! single-mutex map serialised end-to-end; the bench surfaces whether the
 //! shard layout actually lets N workers register/finish in parallel or
-//! whether some other lock (e.g. the per-file [`SlotBarrier`]) is now the
+//! whether some other lock (e.g. the per-file slot mutex) is now the
 //! gate. Numbers from this group complement - they do not replace - the
 //! main cores-vs-throughput sweep.
 //!

--- a/crates/engine/src/concurrent_delta/parallel_apply/applier.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/applier.rs
@@ -27,7 +27,7 @@ use super::chunk::{DeltaChunk, VerifiedChunk};
 use super::error::ParallelApplyError;
 use super::file_slot::{FileSlot, IngestError};
 use super::handle::SlotHandle;
-use super::slot_barrier::{SlotBarrier, SlotEntry};
+use super::slot_barrier::SlotEntry;
 use super::{ring_cap_env, shard_sizing};
 
 /// Parallel receive-side delta applier.
@@ -50,14 +50,12 @@ pub struct ParallelDeltaApplier {
     /// [`std::sync::Mutex<FileSlot>`]) and the per-file bookkeeping
     /// (an [`Arc<slot_barrier::BarrierState>`] holding the in-flight
     /// counter and [`std::sync::Condvar`] that back FFB-2's
-    /// `flush_workers` barrier). DG-3.b (#2569) swapped the value type
-    /// from [`Arc<SlotBarrier>`] to [`SlotEntry`]; DG-3.c retyped
-    /// [`DecrementGuard`] to consume an
-    /// [`Arc<slot_barrier::BarrierState>`] sourced via
-    /// [`SlotBarrier::barrier`], and [`SlotHandle`] keeps its
-    /// [`Arc<SlotBarrier>`] adapter (minted by
-    /// [`SlotBarrier::from_entry`]) until a follow-on DG-3.x task
-    /// retypes the handle. The BR-3j.a audit (see
+    /// `flush_workers` barrier). [`SlotHandle`] consumes a [`SlotEntry`]
+    /// clone directly: it keeps the payload
+    /// [`Arc<slot_barrier::SlotData>`] for the lock path and hands the
+    /// bookkeeping [`Arc<slot_barrier::BarrierState>`] to
+    /// [`DecrementGuard`], so the two halves have disjoint strong-count
+    /// trajectories. The BR-3j.a audit (see
     /// `docs/audits/br-3j-a-dashmap-vs-sharded-2026-05-20.md`) selected
     /// DashMap as the right fit for the access pattern: short guard
     /// windows, no iteration in the hot path, and write rates that scale
@@ -77,9 +75,7 @@ pub struct ParallelDeltaApplier {
     /// [`slot_barrier::SlotData`]: super::slot_barrier::SlotData
     /// [`slot_barrier::BarrierState`]: super::slot_barrier::BarrierState
     /// [`DecrementGuard`]: super::decrement_guard::DecrementGuard
-    /// [`SlotBarrier::barrier`]: super::slot_barrier::SlotBarrier::barrier
-    /// [`SlotBarrier::from_entry`]: super::slot_barrier::SlotBarrier::from_entry
-    /// [`Arc<SlotBarrier>`]: std::sync::Arc
+    /// [`SlotHandle`]: super::handle::SlotHandle
     /// [`Arc<slot_barrier::SlotData>`]: std::sync::Arc
     /// [`Arc<slot_barrier::BarrierState>`]: std::sync::Arc
     pub(super) files: DashMap<FileNdx, SlotEntry>,
@@ -367,9 +363,9 @@ impl ParallelDeltaApplier {
     /// submissions), or the per-chunk strong-checksum verification fails
     /// when [`DeltaChunk::expected_strong`] was attached.
     pub fn apply_one_chunk(&self, chunk: DeltaChunk) -> io::Result<()> {
-        // `slot_for` returns a [`SlotHandle`] (RAII guard around an
-        // `Arc<SlotBarrier>` clone) and drops the DashMap shard guard
-        // before returning, so the rayon verify below never blocks
+        // `slot_for` returns a `SlotHandle` (RAII guard holding the
+        // per-file `Arc<SlotData>` clone) and drops the DashMap shard
+        // guard before returning, so the rayon verify below never blocks
         // shard-mates on unrelated NDX values. The handle's drop fires
         // `flush_workers`-visible decrement once this call returns.
         let ndx = chunk.ndx;
@@ -436,29 +432,21 @@ impl ParallelDeltaApplier {
     }
 
     pub(super) fn slot_for(&self, ndx: FileNdx) -> io::Result<SlotHandle> {
-        // Clone the per-file [`SlotEntry`] (two `Arc::clone` calls) while
+        // Clone the per-file `SlotEntry` (two `Arc::clone` calls) while
         // the shard read guard is alive, then drop the guard at the end
         // of this expression. Callers never see the DashMap guard, so
         // they cannot accidentally hold it across the per-file mutex lock
-        // or a rayon dispatch. The bridge below builds a fresh
-        // [`Arc<SlotBarrier>`] adapter from the entry's two inner Arcs.
-        // After DG-3.c the [`DecrementGuard`] no longer rides on the
-        // adapter: [`SlotHandle::new`] sources the bookkeeping
-        // [`Arc<BarrierState>`] through [`SlotBarrier::barrier`] and
-        // hands that clone to the guard, leaving the adapter Arc to
-        // bound the lock path only. The follow-on DG-3.x task retypes
-        // [`SlotHandle`] and deletes the adapter entirely. The adapter
-        // Arc is unique to this call site; the underlying [`SlotData`]
-        // and [`BarrierState`] Arcs are shared with every other adapter
-        // minted from the same entry, so the in-flight counter and
-        // Condvar remain coherent.
+        // or a rayon dispatch. `SlotHandle::new` consumes the entry
+        // directly: it hands the bookkeeping `Arc<BarrierState>` to the
+        // `DecrementGuard` and keeps the payload `Arc<SlotData>` for the
+        // lock path, sharing both with the DashMap entry so the in-flight
+        // counter and Condvar remain coherent across workers.
         let entry = self
             .files
             .get(&ndx)
             .map(|guard| guard.value().clone())
             .ok_or_else(|| io::Error::other(format!("parallel applier file {ndx} unknown")))?;
-        let barrier = Arc::new(SlotBarrier::from_entry(&entry));
-        Ok(SlotHandle::new(barrier))
+        Ok(SlotHandle::new(entry))
     }
 
     /// Pure CPU step that the rayon worker runs.

--- a/crates/engine/src/concurrent_delta/parallel_apply/batch.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/batch.rs
@@ -1,7 +1,7 @@
 //! Batched parallel apply path for the receive-side delta applier (SPL-38.d).
 //!
 //! Extracted from `parallel_apply/mod.rs` as part of the SPL-38 module
-//! decomposition. Sibling to [`super::slot_barrier::SlotBarrier`] and
+//! decomposition. Sibling to [`super::handle::SlotHandle`] and
 //! [`super::decrement_guard::DecrementGuard`]; reuses both via the per-slot
 //! handle returned by [`ParallelDeltaApplier::slot_for`].
 //!

--- a/crates/engine/src/concurrent_delta/parallel_apply/decrement_guard.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/decrement_guard.rs
@@ -4,21 +4,17 @@
 //! decomposition; sibling to [`super::slot_barrier::BarrierState`]. The
 //! guard is the only call site of [`BarrierState::decrement_inflight`]
 //! and pairs with [`BarrierState::increment_inflight`] (invoked from
-//! [`super::SlotHandle::new`] via the [`super::slot_barrier::SlotBarrier`]
-//! adapter) so the FFB-1 invariant ("every Arc outstanding is reflected
-//! in the inflight counter") holds across early returns, `?`
-//! propagations, and panics.
+//! [`super::handle::SlotHandle::new`]) so the FFB-1 invariant ("every
+//! Arc outstanding is reflected in the inflight counter") holds across
+//! early returns, `?` propagations, and panics.
 //!
-//! DG-3.c retyped the guard's `barrier` field from `Arc<SlotBarrier>`
-//! to `Arc<BarrierState>` per the DG-2.a Option-B spec
-//! (`docs/design/dg-2a-option-b-spec.md` section 2). The payload Arc
-//! ([`super::slot_barrier::SlotData`]) and the notify-bearing Arc
-//! ([`BarrierState`]) now have independent strong-count trajectories,
-//! so the worker's lingering decrement-guard Arc no longer extends the
-//! payload Arc's strong count past the flusher's `Arc::try_unwrap`. The
-//! `SlotHandle` retype is deferred to a later DG-3.x task; the
-//! [`super::slot_barrier::SlotBarrier`] adapter stays as a bridge until
-//! then.
+//! The guard's `barrier` field holds an `Arc<BarrierState>` per the
+//! DG-2.a Option-B spec (`docs/design/dg-2a-option-b-spec.md` section
+//! 2). The payload Arc ([`super::slot_barrier::SlotData`]) and the
+//! notify-bearing Arc ([`BarrierState`]) have independent strong-count
+//! trajectories, so the worker's lingering decrement-guard Arc never
+//! extends the payload Arc's strong count past the flusher's
+//! `Arc::try_unwrap`.
 //!
 //! [`BarrierState`]: super::slot_barrier::BarrierState
 //! [`BarrierState::decrement_inflight`]: super::slot_barrier::BarrierState::decrement_inflight
@@ -34,11 +30,11 @@ use super::slot_barrier::BarrierState;
 /// panics mid-write or returns early via `?`, the counter still drops
 /// back to its pre-handoff value and `flush_workers` unblocks.
 ///
-/// The field holds [`Arc<BarrierState>`] (DG-3.c) rather than the
-/// previous `Arc<SlotBarrier>` adapter so the worker's lingering clone
-/// on drop lives on a strong-count graph disjoint from the payload Arc
-/// the flusher unwraps. See `docs/design/dg-2a-option-b-spec.md`
-/// section 2 for the wider rationale.
+/// The field holds [`Arc<BarrierState>`] so the worker's lingering
+/// clone on drop lives on a strong-count graph disjoint from the
+/// payload Arc the flusher unwraps. See
+/// `docs/design/dg-2a-option-b-spec.md` section 2 for the wider
+/// rationale.
 ///
 /// [`SlotHandle`]: super::SlotHandle
 /// [`Arc<BarrierState>`]: std::sync::Arc

--- a/crates/engine/src/concurrent_delta/parallel_apply/handle.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/handle.rs
@@ -1,13 +1,14 @@
 //! Per-file slot handle returned from [`ParallelDeltaApplier::slot_for`].
 //!
 //! Extracted from `parallel_apply/mod.rs` as part of the module
-//! decomposition. [`SlotHandle`] wraps an [`Arc<SlotBarrier>`] so callers
-//! can lock the per-file slot mutex, while a companion
-//! [`super::decrement_guard::DecrementGuard`] keeps the slot's in-flight
-//! counter accurate for the whole lifetime of the handle (including early
-//! returns and panics).
+//! decomposition. [`SlotHandle`] holds the per-file payload
+//! [`Arc<SlotData>`] so callers can lock the per-file slot mutex, while a
+//! companion [`super::decrement_guard::DecrementGuard`] keeps the slot's
+//! in-flight counter accurate for the whole lifetime of the handle
+//! (including early returns and panics).
 //!
 //! [`ParallelDeltaApplier::slot_for`]: super::ParallelDeltaApplier::slot_for
+//! [`Arc<SlotData>`]: std::sync::Arc
 
 use std::io;
 use std::sync::{Arc, MutexGuard};
@@ -15,23 +16,37 @@ use std::sync::{Arc, MutexGuard};
 use super::super::types::FileNdx;
 use super::decrement_guard::DecrementGuard;
 use super::file_slot::FileSlot;
-use super::slot_barrier::SlotBarrier;
+use super::slot_barrier::{SlotData, SlotEntry};
 
 /// Handle returned from [`ParallelDeltaApplier::slot_for`].
 ///
-/// Wraps an [`Arc<SlotBarrier>`] so callers can lock the per-file slot
-/// mutex via [`SlotHandle::lock_slot`]. The companion [`DecrementGuard`]
-/// keeps the slot's in-flight counter accurate for the entire lifetime of
-/// the handle, including early returns and panics: the counter increments
-/// when [`SlotHandle::new`] runs and decrements when the handle drops.
+/// Holds the per-file payload [`Arc<SlotData>`] so callers can lock the
+/// per-file slot mutex via [`SlotHandle::lock_slot`]. The companion
+/// [`DecrementGuard`] keeps the slot's in-flight counter accurate for the
+/// entire lifetime of the handle, including early returns and panics: the
+/// counter increments when [`SlotHandle::new`] runs and decrements when
+/// the handle drops.
+///
+/// Field declaration order is load-bearing: [`Self::data`] drops first,
+/// releasing the worker's payload [`Arc<SlotData>`] clone, and only then
+/// does `_decrement` fire `notify_all`. That ordering keeps the payload
+/// Arc's strong-count trajectory disjoint from the notify-bearing
+/// [`Arc<super::slot_barrier::BarrierState>`], so `finish_file`'s
+/// `Arc::try_unwrap` on the payload never observes the worker's lingering
+/// bookkeeping clone (the DG-1 release race).
 ///
 /// The handle deliberately does not expose the bare [`Arc`] - callers go
 /// through [`SlotHandle::lock_slot`] so the FFB-1 invariant ("every clone
 /// outstanding is reflected in the inflight counter") cannot be bypassed.
 ///
 /// [`ParallelDeltaApplier::slot_for`]: super::ParallelDeltaApplier::slot_for
+/// [`Arc<SlotData>`]: std::sync::Arc
+/// [`Arc<super::slot_barrier::BarrierState>`]: std::sync::Arc
 pub(super) struct SlotHandle {
-    barrier: Arc<SlotBarrier>,
+    /// Per-file payload Arc. Dropped first when the handle goes out of
+    /// scope so the worker's clone is gone before `_decrement` fires the
+    /// Condvar notify.
+    data: Arc<SlotData>,
     _decrement: DecrementGuard,
 }
 
@@ -39,22 +54,20 @@ impl SlotHandle {
     /// Bumps the slot's in-flight counter and returns the handle. The
     /// counter is decremented when the returned handle is dropped.
     ///
-    /// DG-3.c routes the [`DecrementGuard`]'s clone through the
-    /// adapter's inner `Arc<BarrierState>` (see [`SlotBarrier::barrier`])
-    /// so the worker's lingering decrement-guard Arc no longer extends
-    /// the payload Arc's strong count past the flusher's
-    /// `Arc::try_unwrap`. The handle's own `barrier` field still carries
-    /// the [`Arc<SlotBarrier>`] adapter until a future DG-3.x task
-    /// retypes [`SlotHandle`].
+    /// Consumes a [`SlotEntry`] clone (two `Arc`s). The bookkeeping
+    /// [`Arc<super::slot_barrier::BarrierState>`] is handed to the
+    /// [`DecrementGuard`] so the worker's lingering decrement-guard Arc
+    /// rides a strong-count graph disjoint from the payload
+    /// [`Arc<SlotData>`] the flusher unwraps.
     ///
-    /// [`SlotBarrier::barrier`]: super::slot_barrier::SlotBarrier::barrier
-    pub(super) fn new(barrier: Arc<SlotBarrier>) -> Self {
+    /// [`Arc<SlotData>`]: std::sync::Arc
+    /// [`Arc<super::slot_barrier::BarrierState>`]: std::sync::Arc
+    pub(super) fn new(entry: SlotEntry) -> Self {
+        let SlotEntry { data, barrier } = entry;
         barrier.increment_inflight();
-        let decrement = DecrementGuard {
-            barrier: Arc::clone(barrier.barrier()),
-        };
+        let decrement = DecrementGuard { barrier };
         Self {
-            barrier,
+            data,
             _decrement: decrement,
         }
     }
@@ -67,6 +80,6 @@ impl SlotHandle {
         ndx: FileNdx,
         kind: &'static str,
     ) -> io::Result<MutexGuard<'_, FileSlot>> {
-        self.barrier.lock_slot(ndx, kind)
+        self.data.lock_slot(ndx, kind)
     }
 }

--- a/crates/engine/src/concurrent_delta/parallel_apply/slot_barrier.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/slot_barrier.rs
@@ -1,29 +1,18 @@
-//! Per-slot synchronisation primitive backing FFB-1 / FFB-2.
+//! Per-slot synchronisation primitives backing FFB-1 / FFB-2.
 //!
-//! Extracted from `parallel_apply.rs` as part of SPL-38.b. The DG-2.a/DG-3
-//! spec at `docs/design/dg-2a-option-b-spec.md` plans to split the per-slot
-//! state across [`BarrierState`] (in-flight counter + [`Condvar`]) and
-//! [`SlotData`] (per-file [`Mutex<FileSlot>`]) so [`SlotHandle`] and
-//! `finish_file` can hold independent Arc graphs.
+//! Extracted from `parallel_apply.rs` as part of SPL-38.b. The per-slot
+//! state is split across [`BarrierState`] (in-flight counter +
+//! [`Condvar`]) and [`SlotData`] (per-file [`Mutex<FileSlot>`]), stored
+//! together as a [`SlotEntry`] in the [`super::ParallelDeltaApplier`]
+//! [`DashMap`]. The split lets [`super::SlotHandle`] (the payload
+//! [`Arc<SlotData>`]) and `finish_file`'s writer reclaim
+//! ([`Arc::try_unwrap`] on the same payload Arc) hold independent Arc
+//! graphs from the notify-bearing [`Arc<BarrierState>`] the
+//! [`super::DecrementGuard`] carries, per the Option-B spec at
+//! `docs/design/dg-2a-option-b-spec.md`.
 //!
-//! DG-3.a (PR #4826) added the post-split types alongside the existing
-//! [`SlotBarrier`]. DG-3.b (PR #4841) swapped the
-//! [`super::ParallelDeltaApplier`] [`DashMap`] value type from
-//! [`Arc<SlotBarrier>`] to [`SlotEntry`] and reshaped [`SlotBarrier`]
-//! into a thin adapter that wraps shared [`Arc<SlotData>`] +
-//! [`Arc<BarrierState>`] handles. DG-3.c (this commit) retypes
-//! [`super::DecrementGuard`] to hold [`Arc<BarrierState>`] directly,
-//! sourced from the adapter via [`SlotBarrier::barrier`], and removes
-//! the now-dead forwarding `SlotBarrier::decrement_inflight`. The
-//! [`super::SlotHandle`] retype is deferred; the adapter survives only
-//! as that handle's bridge until a follow-on DG-3.x task collapses it
-//! and points the handle fields at [`Arc<SlotData>`] /
-//! [`Arc<BarrierState>`] directly.
-//!
-//! [`Arc<SlotBarrier>`]: std::sync::Arc
 //! [`Arc<SlotData>`]: std::sync::Arc
 //! [`Arc<BarrierState>`]: std::sync::Arc
-//! [`Arc`]: std::sync::Arc
 //! [`DashMap`]: dashmap::DashMap
 
 use std::io;
@@ -32,88 +21,6 @@ use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use super::super::types::FileNdx;
 use super::{FileSlot, ParallelApplyError};
 
-/// Transitional adapter that preserves the [`Arc<SlotBarrier>`] shape
-/// [`super::SlotHandle`] still consumes.
-///
-/// Originally colocated the file's [`Mutex<FileSlot>`], the in-flight
-/// counter, and the [`Condvar`] in one allocation. DG-3.b moves the
-/// canonical state into [`SlotData`] + [`BarrierState`] (stored together
-/// as [`SlotEntry`] in the DashMap) and leaves this struct as a thin
-/// wrapper that forwards through cloned [`Arc`] handles. New instances
-/// are minted by [`super::ParallelDeltaApplier::slot_for`] on each
-/// lookup; sibling adapters share the same underlying
-/// [`Arc<SlotData>`] + [`Arc<BarrierState>`] state, so the in-flight
-/// counter and Condvar remain coherent across workers.
-///
-/// DG-3.c retyped [`super::DecrementGuard`] to hold its own
-/// [`Arc<BarrierState>`] clone (sourced via [`Self::barrier`]) so the
-/// guard's strong-count trajectory is disjoint from the adapter's
-/// payload Arc. The adapter survives only as the bridge for
-/// [`super::SlotHandle`]; a future DG-3.x task retypes the handle and
-/// deletes this struct.
-///
-/// Holding the per-slot [`Arc<SlotBarrier>`] adapter is no longer the
-/// unit of "in-flight"; the counter inside [`BarrierState`] is. The
-/// adapter's lifetime continues to bound when [`super::SlotHandle`]
-/// drops, which keeps the lock-path FFB-1 invariant intact even though
-/// the decrement path now lives on [`Arc<BarrierState>`] directly.
-///
-/// [`Arc`]: std::sync::Arc
-/// [`Arc<SlotBarrier>`]: std::sync::Arc
-/// [`Arc<SlotData>`]: std::sync::Arc
-/// [`Arc<BarrierState>`]: std::sync::Arc
-/// [`SlotHandle`]: super::SlotHandle
-pub(super) struct SlotBarrier {
-    data: Arc<SlotData>,
-    barrier: Arc<BarrierState>,
-}
-
-impl SlotBarrier {
-    /// Builds an adapter that shares its inner state with `entry`.
-    /// Clones the entry's two Arcs so the adapter participates in the
-    /// same in-flight bookkeeping and per-file mutex as every other
-    /// adapter minted from the same entry.
-    pub(super) fn from_entry(entry: &SlotEntry) -> Self {
-        Self {
-            data: Arc::clone(&entry.data),
-            barrier: Arc::clone(&entry.barrier),
-        }
-    }
-
-    /// Locks the per-file slot mutex, mapping a poisoned mutex to the
-    /// typed [`ParallelApplyError::SlotPoisoned`] error.
-    pub(super) fn lock_slot(
-        &self,
-        ndx: FileNdx,
-        kind: &'static str,
-    ) -> io::Result<MutexGuard<'_, FileSlot>> {
-        self.data.lock_slot(ndx, kind)
-    }
-
-    /// Bumps the in-flight counter for this slot. Called by
-    /// [`super::SlotHandle::new`] once the caller has obtained an
-    /// [`Arc<SlotBarrier>`] clone from
-    /// [`super::ParallelDeltaApplier::slot_for`].
-    ///
-    /// [`Arc<SlotBarrier>`]: std::sync::Arc
-    pub(super) fn increment_inflight(&self) {
-        self.barrier.increment_inflight();
-    }
-
-    /// Returns the adapter's inner [`Arc<BarrierState>`] so the caller
-    /// can hand the bookkeeping Arc to [`super::DecrementGuard`] without
-    /// extending the adapter Arc's lifetime. DG-3.c routes the guard's
-    /// strong-count trajectory through this accessor; [`super::SlotHandle`]
-    /// keeps its own [`Arc<SlotBarrier>`] clone for the lock path until
-    /// a future DG-3.x task retypes the handle.
-    ///
-    /// [`Arc<BarrierState>`]: std::sync::Arc
-    /// [`Arc<SlotBarrier>`]: std::sync::Arc
-    pub(super) fn barrier(&self) -> &Arc<BarrierState> {
-        &self.barrier
-    }
-}
-
 /// Per-slot in-flight counter and [`Condvar`] (DG-3.a, Option B).
 ///
 /// Carries exactly the bookkeeping that the worker's drop path touches:
@@ -121,7 +28,7 @@ impl SlotBarrier {
 /// that wakes a parked `flush_workers`. Defined per the DG-2.a spec at
 /// `docs/design/dg-2a-option-b-spec.md` section 2.
 ///
-/// # Why split this out of [`SlotBarrier`]?
+/// # Why a dedicated bookkeeping type?
 ///
 /// The DG-1 audit (`docs/design/decrementguard-audit.md`, section 4)
 /// traced the `finish_file` release race to one [`Arc`] graph being
@@ -143,10 +50,9 @@ impl SlotBarrier {
 ///   re-checks the predicate after waking observes a consistent value.
 /// - The counter is monotonic per slot-lifetime: every
 ///   `increment_inflight` is matched 1:1 with a `decrement_inflight`
-///   via the [`super::DecrementGuard`] RAII pairing. DG-3.c retyped
-///   the guard's field to [`Arc<BarrierState>`] so the pairing now
-///   travels on this allocation directly rather than through the
-///   [`SlotBarrier`] adapter.
+///   via the [`super::DecrementGuard`] RAII pairing. The guard holds an
+///   [`Arc<BarrierState>`] so the pairing travels on this allocation
+///   directly.
 ///
 /// [`Arc<BarrierState>`]: std::sync::Arc
 ///
@@ -166,8 +72,8 @@ pub(super) struct BarrierState {
 impl BarrierState {
     /// Constructs a fresh bookkeeping primitive with a zero in-flight
     /// counter. The counter is bumped by [`Self::increment_inflight`]
-    /// once a [`SlotHandle`] is handed out and dropped back by
-    /// [`Self::decrement_inflight`] when the matching
+    /// once a [`super::handle::SlotHandle`] is handed out and dropped
+    /// back by [`Self::decrement_inflight`] when the matching
     /// [`super::DecrementGuard`] retires.
     pub(super) fn new() -> Self {
         Self {
@@ -176,9 +82,9 @@ impl BarrierState {
         }
     }
 
-    /// Bumps the in-flight counter. Body is verbatim from
-    /// [`SlotBarrier::increment_inflight`] so the DG-3.c retype is a
-    /// pure field-type swap with no behaviour change.
+    /// Bumps the in-flight counter under its mutex. Called from
+    /// [`super::handle::SlotHandle::new`] when a slot handle is handed
+    /// out.
     pub(super) fn increment_inflight(&self) {
         let mut guard = self
             .inflight
@@ -196,9 +102,7 @@ impl BarrierState {
     /// chance to re-evaluate the predicate; spurious wakeups are
     /// filtered by [`Self::wait_until_idle`]'s `wait_while` loop.
     ///
-    /// Invoked exclusively from [`super::DecrementGuard::drop`] (DG-3.c
-    /// retired the [`SlotBarrier`] forwarding shim that previously
-    /// stood between the guard and this method).
+    /// Invoked exclusively from [`super::DecrementGuard::drop`].
     pub(super) fn decrement_inflight(&self) {
         let mut guard = self
             .inflight
@@ -209,8 +113,7 @@ impl BarrierState {
     }
 
     /// Blocks until the in-flight counter reaches zero. Spurious
-    /// wakeups are filtered by the loop predicate. Body is verbatim
-    /// from [`SlotBarrier::wait_until_idle`].
+    /// wakeups are filtered by the loop predicate.
     pub(super) fn wait_until_idle(&self, ndx: FileNdx, kind: &'static str) -> io::Result<()> {
         let guard = self
             .inflight
@@ -232,7 +135,7 @@ impl BarrierState {
 /// writer at end-of-file. Defined per the DG-2.a spec at
 /// `docs/design/dg-2a-option-b-spec.md` section 2.
 ///
-/// # Why split this out of [`SlotBarrier`]?
+/// # Why a dedicated payload type?
 ///
 /// Together with [`BarrierState`], this type is the second half of the
 /// Option-B split that fixes the DG-1 release race. By keeping the
@@ -251,8 +154,8 @@ impl BarrierState {
 ///   sibling [`BarrierState`] in the same [`SlotEntry`]) before
 ///   removing the entry from the DashMap.
 /// - A poisoned mutex is mapped to the typed
-///   [`ParallelApplyError::SlotPoisoned`] so the io-error surface
-///   matches the existing [`SlotBarrier::lock_slot`] behaviour.
+///   [`ParallelApplyError::SlotPoisoned`] so the io-error surface is
+///   consistent across the lock and reclaim paths.
 ///
 /// # Visibility
 ///
@@ -263,8 +166,7 @@ pub(super) struct SlotData {
 }
 
 impl SlotData {
-    /// Wraps a [`FileSlot`] in its own mutex. Mirrors
-    /// [`SlotBarrier::new`] for the payload half of the split.
+    /// Wraps a [`FileSlot`] in its own mutex.
     pub(super) fn new(slot: FileSlot) -> Self {
         Self {
             slot: Mutex::new(slot),
@@ -272,8 +174,7 @@ impl SlotData {
     }
 
     /// Locks the per-file slot mutex, mapping a poisoned mutex to the
-    /// typed [`ParallelApplyError::SlotPoisoned`] error. Body is
-    /// verbatim from [`SlotBarrier::lock_slot`].
+    /// typed [`ParallelApplyError::SlotPoisoned`] error.
     pub(super) fn lock_slot(
         &self,
         ndx: FileNdx,
@@ -295,8 +196,7 @@ impl SlotData {
     }
 }
 
-/// DashMap value carrying both Arcs that together replace
-/// [`Arc<SlotBarrier>`] under Option B (DG-3.a).
+/// DashMap value carrying the two per-slot Arcs under Option B (DG-3.a).
 ///
 /// Cloning a [`SlotEntry`] clones both inner Arcs, keeping the
 /// register/lookup paths symmetric: producers insert one
@@ -313,9 +213,9 @@ impl SlotData {
 ///   without the other.
 /// - Strong counts are tracked separately: the payload Arc only flows
 ///   to `SlotHandle.data` and `finish_file`'s local binding; the
-///   barrier Arc additionally flows to `SlotHandle.barrier` and
-///   `DecrementGuard.barrier`. See DG-2.a spec section 3 for the
-///   steady-state strong-count table.
+///   barrier Arc flows to `DecrementGuard.barrier` and `flush_workers`'s
+///   local wait clone. See DG-2.a spec section 3 for the steady-state
+///   strong-count table.
 ///
 /// # Visibility
 ///
@@ -335,95 +235,14 @@ pub(super) struct SlotEntry {
 
 impl SlotEntry {
     /// Wraps a fresh [`FileSlot`] in the two Option-B Arcs. The
-    /// in-flight counter starts at zero; the first [`SlotHandle`]
-    /// constructed from a clone of this entry will bump it via
-    /// [`BarrierState::increment_inflight`].
+    /// in-flight counter starts at zero; the first
+    /// [`super::handle::SlotHandle`] constructed from a clone of this
+    /// entry will bump it via [`BarrierState::increment_inflight`].
     pub(super) fn new(slot: FileSlot) -> Self {
         Self {
             data: Arc::new(SlotData::new(slot)),
             barrier: Arc::new(BarrierState::new()),
         }
-    }
-}
-
-/// Post-split handle returned from `slot_for` once a future DG-3.x
-/// task lands the mod-level [`super::SlotHandle`] retype.
-///
-/// Holds one [`Arc<SlotData>`] for the payload lock plus one
-/// [`Arc<BarrierState>`] so the increment+decrement bookkeeping stays
-/// co-located with the lock site. Field declaration order is
-/// load-bearing: per the DG-2.a spec section 6, [`Self::data`] is
-/// dropped first (releasing the worker's payload Arc clone), then
-/// [`Self::barrier`], and finally a future `_decrement` field. That
-/// order keeps the payload Arc's strong-count trajectory disjoint from
-/// the notify-bearing Arc's, which is the invariant DG-1 found
-/// violated by the original [`SlotBarrier`] shape.
-///
-/// # Why a parallel type instead of editing the mod-level [`super::SlotHandle`]?
-///
-/// DG-3.a/b/c are sequenced so the mod-level [`super::SlotHandle`]
-/// keeps compiling against the [`SlotBarrier`] adapter while the
-/// underlying types migrate piece by piece. DG-3.c (this commit)
-/// retyped [`super::DecrementGuard`] only; the handle retype is
-/// deferred to a later task that renames this type into the mod-level
-/// slot.
-///
-/// # Missing field
-///
-/// The DG-2.a spec section 6 also calls for a third field,
-/// `_decrement: super::DecrementGuard`. Attaching that field here is
-/// possible now that DG-3.c has retyped the guard to
-/// [`Arc<BarrierState>`], but it is deferred to the same future task
-/// that retypes the mod-level [`super::SlotHandle`] so this struct
-/// stays inert until its call sites are ready.
-///
-/// # Visibility
-///
-/// `pub(super)` so the parent module can wire it in during the
-/// follow-on migration. Not exposed beyond `parallel_apply`. The
-/// mod-level [`super::SlotHandle`] is unaffected by this type's
-/// existence: neither shadows the other because `mod.rs` does not
-/// `use slot_barrier::SlotHandle`.
-//
-// `dead_code` allow: same rationale as `BarrierState`. The follow-on
-// task renames this type into the mod-level slot once its call sites
-// are ready.
-#[allow(dead_code)]
-pub(super) struct SlotHandle {
-    /// Per-file payload Arc. Dropped first when the handle goes out
-    /// of scope so the worker's clone is gone before any barrier
-    /// bookkeeping runs.
-    pub(super) data: Arc<SlotData>,
-    /// Per-file bookkeeping Arc. Dropped after `data` but before the
-    /// future `_decrement` field, keeping the lock path
-    /// ([`SlotData::lock_slot`]) and the counter path
-    /// ([`BarrierState::increment_inflight`]) co-located in the same
-    /// handle.
-    pub(super) barrier: Arc<BarrierState>,
-}
-
-#[allow(dead_code)]
-impl SlotHandle {
-    /// Bumps the entry's in-flight counter and constructs the handle.
-    /// Mirrors the DG-2.a spec section 6 constructor, modulo the
-    /// `_decrement` field deferred to the follow-on task that retypes
-    /// the mod-level [`super::SlotHandle`].
-    pub(super) fn new(entry: SlotEntry) -> Self {
-        entry.barrier.increment_inflight();
-        Self {
-            data: entry.data,
-            barrier: entry.barrier,
-        }
-    }
-
-    /// Locks the per-file slot mutex for the duration of the returned
-    /// guard. Delegates to [`SlotData::lock_slot`].
-    pub(super) fn lock_slot(
-        &self,
-        ndx: FileNdx,
-        kind: &'static str,
-    ) -> io::Result<MutexGuard<'_, FileSlot>> {
-        self.data.lock_slot(ndx, kind)
     }
 }
 
@@ -435,7 +254,8 @@ mod dg_3a_tests {
 
     use super::super::super::types::FileNdx;
     use super::super::FileSlot;
-    use super::{BarrierState, SlotData, SlotEntry, SlotHandle};
+    use super::super::handle::SlotHandle;
+    use super::{BarrierState, SlotData, SlotEntry};
 
     fn dummy_file_slot() -> FileSlot {
         FileSlot::new(Box::new(Vec::<u8>::new()), 4)
@@ -480,30 +300,29 @@ mod dg_3a_tests {
         assert!(slot.drained());
     }
 
-    /// Smoke test: building a [`SlotHandle`] from a [`SlotEntry`]
-    /// bumps the in-flight counter on the entry's barrier. Verifies
-    /// the constructor wires the increment side of the bookkeeping
-    /// even though the matching decrement (DG-3.c's retyped
-    /// `_decrement` field) is not attached yet.
+    /// Smoke test: building a [`SlotHandle`] from a [`SlotEntry`] bumps
+    /// the in-flight counter, and dropping the handle returns it to zero
+    /// via the companion `DecrementGuard`. Verifies the collapsed handle
+    /// wires both the increment (construction) and decrement (drop)
+    /// sides of the bookkeeping so a parked `wait_until_idle` unblocks.
     #[test]
-    fn slot_handle_constructor_increments_inflight() {
+    fn slot_handle_increments_then_decrements_on_drop() {
         let entry = SlotEntry::new(dummy_file_slot());
         let barrier = Arc::clone(&entry.barrier);
         let handle = SlotHandle::new(entry);
-        // Counter is now 1: a parked waiter must still see the
-        // predicate as non-idle. Probe by trying to lock the slot
-        // through the handle - this exercises the payload path - and
-        // by explicitly decrementing once so the counter returns to
-        // zero and a subsequent `wait_until_idle` resolves promptly.
+        // Counter is now 1. Probe the payload path by locking the slot
+        // through the handle.
         let guard = handle
             .lock_slot(FileNdx::new(3), "slot_handle_smoke")
-            .expect("lock_slot through the new handle should succeed");
+            .expect("lock_slot through the handle should succeed");
         assert_eq!(guard.bytes_written(), 0);
         drop(guard);
+        // Dropping the handle fires the DecrementGuard, returning the
+        // counter to zero so `wait_until_idle` resolves promptly without
+        // any manual decrement.
         drop(handle);
-        barrier.decrement_inflight();
         barrier
             .wait_until_idle(FileNdx::new(3), "slot_handle_smoke")
-            .expect("counter should be idle after manual decrement");
+            .expect("counter should be idle after handle drop");
     }
 }

--- a/crates/engine/src/concurrent_delta/parallel_apply/tests.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/tests.rs
@@ -415,8 +415,8 @@ fn finish_file_payload_arc_uncontended_after_worker_drop() {
     });
 
     // Wait until the worker owns the SlotHandle. While it is held the
-    // payload Arc strong count is at least 2 (DashMap + adapter's
-    // clone via SlotBarrier::from_entry) and would block `try_unwrap`.
+    // payload Arc strong count is at least 2 (DashMap + the handle's
+    // `data` clone) and would block `try_unwrap`.
     acquired_rx
         .recv_timeout(std::time::Duration::from_secs(5))
         .expect("worker acquired SlotHandle");
@@ -434,9 +434,8 @@ fn finish_file_payload_arc_uncontended_after_worker_drop() {
     // SlotHandle (including the DecrementGuard's drop body). The
     // dropped_tx send happens after `drop(handle)` returns, so by
     // the time we receive on `dropped_rx` every field of the handle
-    // - including the payload Arc clone the SlotBarrier adapter
-    // carried and the bookkeeping Arc the DecrementGuard carried -
-    // has been released.
+    // - including the payload Arc clone the handle held and the
+    // bookkeeping Arc the DecrementGuard carried - has been released.
     release_tx.send(()).expect("release send");
     dropped_rx
         .recv_timeout(std::time::Duration::from_secs(5))


### PR DESCRIPTION
## What

Collapses the transitional `SlotBarrier` adapter in the parallel-delta-apply slot lifecycle, removing one heap `Arc` allocation per slot handout.

`SlotBarrier` was a thin wrapper holding a shared `Arc<SlotData>` + `Arc<BarrierState>`; `slot_for` minted a fresh `Arc<SlotBarrier>` on every handout purely to bridge the old `SlotHandle` field shape. The bookkeeping had already migrated onto `SlotData` (payload) + `BarrierState` (in-flight counter + condvar), with `DecrementGuard` retyped to `Arc<BarrierState>` directly, so the adapter carried no state of its own.

## Change

- `SlotHandle` now holds the payload `Arc<SlotData>` directly plus its companion `DecrementGuard`, and its constructor consumes a `SlotEntry` clone.
- `slot_for` builds the handle straight from the entry - no more `Arc::new(SlotBarrier::from_entry(&entry))`.
- Deleted the `SlotBarrier` struct/impl and the parallel dead-code post-split `SlotHandle` placeholder it was standing in for.

Before: `SlotHandle` transitively held `Arc<SlotBarrier>` (a fresh allocation) + `Arc<SlotData>` + two `Arc<BarrierState>` clones.
After: `SlotHandle` holds `Arc<SlotData>` + one `Arc<BarrierState>` (in the guard). Net: one fewer heap allocation and one fewer refcount clone per handout.

## Correctness

The slot lifecycle is a concurrency hot path (multi-producer chunk apply + verify). The invariants are preserved exactly:

- Field declaration order (`data` then `_decrement`) keeps the payload `Arc<SlotData>` dropping before `DecrementGuard::drop` fires `notify_all`, so `finish_file`'s `Arc::try_unwrap` on the payload never observes the worker's lingering bookkeeping clone. The payload and notify-bearing Arcs keep disjoint strong-count trajectories.
- Acquire/release ordering, the RAII decrement-guard drop semantics, and `Send + Sync` bounds are unchanged. No new `unsafe`.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo clippy -p engine --all-targets --all-features --no-deps -- -D warnings` clean.
- Targeted suite green: `-E 'test(parallel_apply) or test(concurrent_delta) or test(slot)'` (488 passed).
- The 1000-thread x 10K-iter release-race stress test passes (20.8s).

The placeholder handle's unit test was repointed at the live `SlotHandle`, and now also asserts the drop-path decrement (which the inert placeholder could not exercise).
