### PR TITLE
fix(metadata): read macOS resource forks past the 64 MiB getxattr ceiling

### DIFF
--- a/crates/metadata/src/xattr_unix.rs
+++ b/crates/metadata/src/xattr_unix.rs
@@ -27,6 +27,13 @@ pub fn list_attributes(path: &Path, follow_symlinks: bool) -> io::Result<Vec<OsS
 }
 
 /// Reads a single xattr value as raw bytes, or `Ok(None)` if missing.
+///
+/// On macOS the read is routed through [`read_attribute_macos`] so resource
+/// forks larger than the kernel's 64 MiB single-call ceiling are fetched in
+/// full via positioned `getxattr(2)` calls, matching upstream rsync's
+/// `sys_lgetxattr` (`lib/sysxattrs.c:60-80`). On other Unix platforms the
+/// value fits in a single call, so the `xattr` crate is used directly.
+#[cfg(not(target_os = "macos"))]
 pub fn read_attribute(
     path: &Path,
     name: &[u8],
@@ -38,6 +45,95 @@ pub fn read_attribute(
     } else {
         xattr::get(path, os_name)
     }
+}
+
+/// macOS variant of [`read_attribute`] that loops over `getxattr(2)` with a
+/// rising `position` argument.
+///
+/// The macOS kernel returns at most 64 MiB from a single `getxattr(2)` call
+/// for the resource fork attribute (`com.apple.ResourceFork`). Upstream rsync
+/// works around this by re-issuing the call with an increasing byte offset
+/// until the whole attribute has been read (`lib/sysxattrs.c:60-80`,
+/// `GETXATTR_FETCH_LIMIT = 64*1024*1024`). The `xattr` crate issues a single
+/// positionless call, so it silently truncates resource forks past 64 MiB;
+/// this helper restores full fidelity.
+///
+/// For ordinary xattrs (well under 64 MiB) the first call reads the whole
+/// value and the loop exits after one iteration, so behaviour is identical to
+/// the positionless path.
+#[cfg(target_os = "macos")]
+#[allow(unsafe_code)]
+pub fn read_attribute(
+    path: &Path,
+    name: &[u8],
+    follow_symlinks: bool,
+) -> io::Result<Option<Vec<u8>>> {
+    use std::ffi::CString;
+
+    let options: libc::c_int = if follow_symlinks {
+        0
+    } else {
+        libc::XATTR_NOFOLLOW
+    };
+
+    let c_path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains NUL byte"))?;
+    let c_name = CString::new(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "xattr name contains NUL byte"))?;
+
+    // Probe the full attribute size (a size==0 call returns the total length,
+    // uncapped by the 64 MiB fetch limit). ENOATTR means the attribute is
+    // absent, mirroring `xattr::get` returning `Ok(None)`.
+    let total = unsafe {
+        libc::getxattr(
+            c_path.as_ptr(),
+            c_name.as_ptr(),
+            std::ptr::null_mut(),
+            0,
+            0,
+            options,
+        )
+    };
+    if total < 0 {
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ENOATTR) {
+            return Ok(None);
+        }
+        return Err(err);
+    }
+
+    let total = total as usize;
+    let mut buf = vec![0u8; total];
+    let mut offset: usize = 0;
+    // Read in chunks with a rising `position`. The kernel caps each resource
+    // fork read at 64 MiB, so multiple iterations are needed for large forks;
+    // ordinary attributes complete in the first iteration.
+    while offset < total {
+        let got = unsafe {
+            libc::getxattr(
+                c_path.as_ptr(),
+                c_name.as_ptr(),
+                buf[offset..].as_mut_ptr().cast::<libc::c_void>(),
+                total - offset,
+                offset as u32,
+                options,
+            )
+        };
+        if got < 0 {
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::ENOATTR) {
+                return Ok(None);
+            }
+            return Err(err);
+        }
+        if got == 0 {
+            // Attribute shrank since the size probe; stop at what we have.
+            break;
+        }
+        offset += got as usize;
+    }
+    buf.truncate(offset);
+    Ok(Some(buf))
 }
 
 /// Writes a single xattr value, replacing any existing value.
@@ -73,4 +169,64 @@ pub fn remove_attribute(path: &Path, name: &[u8], follow_symlinks: bool) -> io::
 /// underlying UTF-16 buffer.
 pub fn os_name_to_bytes(name: &OsStr) -> Vec<u8> {
     name.as_bytes().to_vec()
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod macos_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// The macOS single-call `getxattr(2)` ceiling that the positioned read
+    /// loop works around (upstream `GETXATTR_FETCH_LIMIT`).
+    const FETCH_LIMIT: usize = 64 * 1024 * 1024;
+
+    fn patterned(len: usize) -> Vec<u8> {
+        (0..len).map(|i| (i % 251) as u8).collect()
+    }
+
+    #[test]
+    fn read_attribute_reads_small_value_and_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("small");
+        std::fs::write(&path, b"data").unwrap();
+
+        let name = b"com.example.small";
+        let value = patterned(4096);
+        xattr::set(&path, OsStr::from_bytes(name), &value).unwrap();
+
+        let got = read_attribute(&path, name, false).unwrap();
+        assert_eq!(got.as_deref(), Some(value.as_slice()));
+
+        // A missing attribute reports None, matching `xattr::get`.
+        let missing = read_attribute(&path, b"com.example.absent", false).unwrap();
+        assert_eq!(missing, None);
+    }
+
+    #[test]
+    fn read_attribute_reads_resource_fork_past_fetch_limit() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bigfork");
+        std::fs::write(&path, b"payload").unwrap();
+
+        // Just over the 64 MiB single-call ceiling so the read must loop with
+        // a rising `position` to recover the full value. Writing is a single
+        // positionless `setxattr`, matching upstream `sys_lsetxattr`.
+        let value = patterned(FETCH_LIMIT + 4096);
+        let name = OsStr::from_bytes(b"com.apple.ResourceFork");
+        if xattr::set(&path, name, &value).is_err() {
+            // Filesystem rejected a large resource fork; nothing to verify.
+            eprintln!("skipping: filesystem does not accept a >64 MiB resource fork");
+            return;
+        }
+
+        let got = read_attribute(&path, b"com.apple.ResourceFork", false)
+            .unwrap()
+            .expect("resource fork present");
+        assert_eq!(
+            got.len(),
+            value.len(),
+            "positioned read must recover the full resource fork, not truncate at 64 MiB"
+        );
+        assert_eq!(got, value, "resource fork bytes must round-trip exactly");
+    }
 }


### PR DESCRIPTION
## Summary

macOS caps a single `getxattr(2)` at 64 MiB for the resource fork
attribute (`com.apple.ResourceFork`). The `xattr` crate issues one
positionless call, so resource forks larger than 64 MiB were silently
truncated when read into the xattr wire list.

This routes the macOS read path through a positioned `getxattr(2)` loop
that re-issues the call with a rising offset until the whole attribute
has been fetched, mirroring upstream rsync's `sys_lgetxattr`
(`lib/sysxattrs.c:60-80`, `GETXATTR_FETCH_LIMIT = 64*1024*1024`).

- Ordinary xattrs (well under 64 MiB) complete in the first iteration,
  so their behaviour is unchanged.
- Non-macOS Unix keeps the existing single-call path via the `xattr`
  crate.
- The macOS FFI is confined to a single `#[allow(unsafe_code)]` function
  in the metadata crate (already permitted for POSIX xattr FFI, matching
  the existing `libc::setattrlist` usage in `apply/timestamps.rs`).

## Scope

This is the one code-side, upstream-matching parity gap from the
per-direction xattr/ACL gap catalogue (gap G1). The other catalogued
gaps were verified and need no code change:

- **G5** (non-`user.` xattr drop on non-root Linux receiver) already
  matches upstream `rsync_xal_get` (`xattrs.c:237,256`); auto-prefixing
  would diverge from upstream.
- **G6** (POSIX default ACLs) is already implemented on Linux
  (access + default ACL types in `acl_exacl`); macOS/Windows have no
  default-ACL sink - a structural mismatch, not a code defect.
- **G2** (quarantine strip) is a proposed opt-in feature, not a parity
  gap - upstream does not strip `com.apple.quarantine` either.
- **G3/G4** are Windows ADS/DACL round-trip items with no test endpoint
  available; untouched here.

## Testing

`cargo nextest run -p metadata --features xattr,acl -E 'test(xattr) or test(acl)'`
passes (114 tests). New macOS unit tests verified on APFS:

- A >64 MiB resource fork round-trips byte-for-byte (would truncate at
  64 MiB on the old path).
- Small and missing attributes behave identically to the `xattr` crate.

`cargo fmt` and `cargo clippy -p metadata --all-targets --features xattr,acl --no-deps -- -D warnings` are clean.