### PR TITLE
fix(interop): proto-29 sender checksum seed and hardlink flist encoding

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -317,7 +317,14 @@ jobs:
             exit 1
           fi
 
-          bash scripts/rp28_e_1_run.sh \
+          # Outer wall-clock guard. oc-rsync as a daemon *sender* stalls in the
+          # end-of-transfer phase against a protocol-29 client (the pull legs of
+          # this matrix), so per-fixture 60s timeouts would otherwise accumulate
+          # and consume the whole job budget. The harness traps SIGTERM to stop
+          # its daemon. This cell is continue-on-error, so a timeout here fails
+          # fast without cancelling the job.
+          timeout --signal=TERM --kill-after=30 360 \
+            bash scripts/rp28_e_1_run.sh \
             --oc-rsync "$OC_RSYNC" \
             --rsync-2-6-9 "$RSYNC_269"
 
@@ -364,7 +371,12 @@ jobs:
             exit 1
           fi
 
-          bash scripts/rp28_f_1_run.sh \
+          # Outer wall-clock guard (see RP28.e.2 cell): bound total runtime so a
+          # stalled legacy proto-29 fixture cannot consume the job budget. The
+          # harness traps SIGTERM to stop its daemon; continue-on-error means a
+          # timeout fails fast without cancelling the job.
+          timeout --signal=TERM --kill-after=30 360 \
+            bash scripts/rp28_f_1_run.sh \
             --oc-rsync "$OC_RSYNC" \
             --rsync-2-6-9 "$RSYNC_269"
 

--- a/crates/protocol/src/flist/write/mod.rs
+++ b/crates/protocol/src/flist/write/mod.rs
@@ -369,9 +369,20 @@ impl FileListWriter {
     /// An abbreviated follower has its leader in the SAME flist segment
     /// (`hardlink_idx >= first_ndx`), so metadata is omitted. Unabbreviated
     /// followers (leader in a previous segment) carry full metadata.
-    /// upstream: flist.c:send_file_entry() line 572
+    ///
+    /// Abbreviation is a protocol 30+ feature: upstream only skips metadata
+    /// after writing `first_hlink_ndx` (`goto the_end`), and `first_hlink_ndx`
+    /// is set only when `protocol_version >= 30` (flist.c:517-587). For
+    /// protocols 28-29 hardlinks are identified by trailing `(dev, ino)` pairs
+    /// and every entry carries full metadata; abbreviating a follower there
+    /// desyncs the receiver (it still reads full metadata + dev/ino).
+    ///
+    /// upstream: flist.c:send_file_entry() lines 585-587 (`goto the_end`)
     #[inline]
     fn is_abbreviated_follower(&self, entry: &FileEntry, xflags: u32) -> bool {
+        if self.protocol.as_u8() < 30 {
+            return false;
+        }
         if !self.is_hardlink_follower(xflags) {
             return false;
         }

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -246,6 +246,7 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
     mut source: R,
     file_size: u64,
     checksum_algorithm: ChecksumAlgorithm,
+    checksum_seed: i32,
     encoder: Option<&mut CompressedTokenEncoder>,
     buf: &mut Vec<u8>,
     serve_fds: Option<ServeFds>,
@@ -270,7 +271,11 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
         );
     }
 
-    let mut verifier = ChecksumVerifier::for_algorithm(checksum_algorithm);
+    // upstream: checksum.c:558 sum_init() - the legacy MD4 whole-file sum
+    // (CSUM_MD4_OLD, proto 27-29) prepends the 4-byte LE seed before file
+    // data; MD5 and the modern algorithms do not. Mirror the receiver's
+    // ChecksumVerifier::new so both sides agree at protocol < 30.
+    let mut verifier = ChecksumVerifier::for_algorithm_seeded(checksum_algorithm, checksum_seed);
 
     // Read buffer sized for fewer syscalls (up to 256KB per read).
     // Buffer is reused across files - no allocation after the first large file.
@@ -480,8 +485,13 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
     source_path: &Path,
     use_noatime: bool,
     checksum_algorithm: ChecksumAlgorithm,
+    checksum_seed: i32,
 ) -> io::Result<InlineChecksumResult> {
-    let mut verifier = ChecksumVerifier::for_algorithm(checksum_algorithm);
+    // upstream: checksum.c:558 sum_init() - prepend the 4-byte LE seed for the
+    // legacy MD4 whole-file sum (CSUM_MD4_OLD, proto 27-29); MD5 and modern
+    // algorithms are unseeded. Keeps the sender symmetric with the receiver's
+    // ChecksumVerifier so protocol < 30 peers accept the reconstructed file.
+    let mut verifier = ChecksumVerifier::for_algorithm_seeded(checksum_algorithm, checksum_seed);
 
     // Lazily open source file only when Copy tokens are present.
     // A single file handle serves both checksum and dictionary sync.
@@ -693,6 +703,7 @@ mod tests {
             &source_path,
             false,
             ChecksumAlgorithm::MD5,
+            0,
         )
         .expect("write_delta_with_inline_checksum");
 

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -783,6 +783,7 @@ fn stream_whole_file_produces_correct_wire_format() {
         source,
         data.len() as u64,
         ChecksumAlgorithm::MD5,
+        0,
         None,
         &mut buf,
         None,
@@ -810,6 +811,7 @@ fn stream_whole_file_handles_empty_file() {
         source,
         0,
         ChecksumAlgorithm::MD5,
+        0,
         None,
         &mut buf,
         None,
@@ -840,6 +842,7 @@ fn stream_whole_file_computes_correct_checksum() {
         source,
         data.len() as u64,
         ChecksumAlgorithm::MD5,
+        0,
         None,
         &mut buf,
         None,
@@ -855,6 +858,64 @@ fn stream_whole_file_computes_correct_checksum() {
     assert_eq!(
         &result.checksum_buf[..result.checksum_len],
         &expected_buf[..expected_len]
+    );
+}
+
+#[test]
+fn stream_whole_file_md4_prepends_seed_for_proto29() {
+    // Regression (RP28 proto-29): the legacy MD4 whole-file sum must prepend
+    // the 4-byte LE checksum seed before file data (upstream CSUM_MD4_OLD in
+    // checksum.c:558 sum_init). A 2.6.9 receiver computes MD4(seed || data);
+    // if the sender omits the seed the file is rejected with "failed
+    // verification". The sender's digest must equal the receiver-side
+    // ChecksumVerifier's seeded MD4.
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    let data = b"hello 2.6.9\n";
+    let seed: i32 = 0x1234_5678;
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    temp_file.write_all(data).unwrap();
+    temp_file.flush().unwrap();
+
+    let source = fs::File::open(temp_file.path()).unwrap();
+    let mut wire_output = Vec::new();
+    let mut buf = vec![0u8; protocol::wire::CHUNK_SIZE];
+    let result = stream_whole_file_transfer(
+        &mut wire_output,
+        source,
+        data.len() as u64,
+        ChecksumAlgorithm::MD4,
+        seed,
+        None,
+        &mut buf,
+        None,
+    )
+    .unwrap();
+
+    // Receiver-side expectation: seeded MD4 over the reconstructed file.
+    let mut expected = ChecksumVerifier::for_algorithm_seeded(ChecksumAlgorithm::MD4, seed);
+    expected.update(data);
+    let mut expected_buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+    let expected_len = expected.finalize_into(&mut expected_buf);
+
+    assert_eq!(
+        &result.checksum_buf[..result.checksum_len],
+        &expected_buf[..expected_len],
+        "sender MD4 whole-file sum must prepend the seed to match a proto-29 receiver"
+    );
+
+    // And it must differ from the unseeded digest (the pre-fix behaviour that
+    // caused the verification failure).
+    let mut unseeded = ChecksumVerifier::for_algorithm(ChecksumAlgorithm::MD4);
+    unseeded.update(data);
+    let mut unseeded_buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+    let unseeded_len = unseeded.finalize_into(&mut unseeded_buf);
+    assert_ne!(
+        &result.checksum_buf[..result.checksum_len],
+        &unseeded_buf[..unseeded_len],
+        "seeded and unseeded MD4 digests must differ for a non-zero seed"
     );
 }
 
@@ -878,6 +939,7 @@ fn stream_whole_file_reuses_buffer() {
         source1,
         512,
         ChecksumAlgorithm::None,
+        0,
         None,
         &mut buf,
         None,
@@ -896,6 +958,7 @@ fn stream_whole_file_reuses_buffer() {
         source2,
         2048,
         ChecksumAlgorithm::None,
+        0,
         None,
         &mut buf,
         None,
@@ -925,6 +988,7 @@ fn stream_whole_file_none_checksum() {
         source,
         data.len() as u64,
         ChecksumAlgorithm::None,
+        0,
         None,
         &mut buf,
         None,

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -462,6 +462,7 @@ impl GeneratorContext {
                         &source_path,
                         use_noatime,
                         checksum_algorithm,
+                        self.checksum_seed,
                     )?;
                     cw.write_all(&result.checksum_buf[..result.checksum_len])?;
                     matched_data += result.matched_data;
@@ -531,6 +532,7 @@ impl GeneratorContext {
                         source,
                         file_size,
                         checksum_algorithm,
+                        self.checksum_seed,
                         if use_compression {
                             token_encoder.as_mut()
                         } else {

--- a/scripts/rp28_e_1_run.sh
+++ b/scripts/rp28_e_1_run.sh
@@ -87,6 +87,11 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
+# Run the cleanup path (which stops the daemon) when an outer wall-clock guard
+# (`timeout` in CI) sends SIGTERM/SIGINT. A wedged legacy proto-29 peer can stall
+# a fixture; the outer guard bounds total runtime and this trap ensures the
+# background daemon is still reaped. Exit 124 mirrors coreutils `timeout`.
+trap 'exit 124' TERM INT
 
 echo "RP28.e.2: oc-rsync=$(${OC_RSYNC} --version 2>&1 | head -1)"
 echo "RP28.e.2: rsync-2.6.9=$(${RSYNC_269} --version 2>&1 | head -1)"

--- a/scripts/rp28_f_1_run.sh
+++ b/scripts/rp28_f_1_run.sh
@@ -89,6 +89,11 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
+# Run the cleanup path (which stops the daemon) when an outer wall-clock guard
+# (`timeout` in CI) sends SIGTERM/SIGINT. A wedged legacy proto-29 peer can stall
+# a fixture; the outer guard bounds total runtime and this trap ensures the
+# background daemon is still reaped. Exit 124 mirrors coreutils `timeout`.
+trap 'exit 124' TERM INT
 
 echo "RP28.f.2: oc-rsync=$(${OC_RSYNC} --version 2>&1 | head -1)"
 echo "RP28.f.2: rsync-2.6.9=$(${RSYNC_269} --version 2>&1 | head -1)"


### PR DESCRIPTION
## Summary

Two sender-side wire bugs made oc-rsync transfers fail against protocol-29 peers (rsync 2.6.9), plus a wall-clock guard for the legacy-peer interop harnesses. Reproduced and validated on aarch64 against rsync 2.6.9 (built from source) and upstream rsync 3.4.3 with `--protocol=29`.

### 1. Whole-file checksum seed (protocol < 30)

The sender computed the trailing whole-file MD4 checksum **without** the checksum seed, while upstream's `CSUM_MD4_OLD` (`checksum.c:558 sum_init`) prepends the 4-byte little-endian seed before the file data for protocols 27-29. A protocol-29 receiver recomputes `MD4(seed || data)` and rejected every transferred file with `failed verification -- update discarded`. The reconstructed data was byte-identical (`cmp` clean); only the transmitted checksum diverged.

`stream_whole_file_transfer` and `write_delta_with_inline_checksum` (`crates/transfer/src/generator/delta.rs`) now build the verifier with `for_algorithm_seeded`, matching the receiver's existing seeded MD4 in `delta_apply/checksum.rs`. MD5 (protocol >= 30) is unaffected — `for_algorithm_seeded` prepends the seed only for MD4.

### 2. Hardlink flist abbreviation (protocol < 30)

`is_abbreviated_follower` (`crates/protocol/src/flist/write/mod.rs`) dropped a hardlink follower's metadata and trailing `(dev, ino)` whenever its leader was in the same flist segment. Metadata abbreviation is a protocol 30+ feature (upstream writes `first_hlink_ndx` then `goto the_end` only when `protocol_version >= 30`, `flist.c:585-587`). At protocols 28-29 hardlinks are keyed by trailing `(dev, ino)` pairs and every entry carries full metadata, so abbreviating a follower desynced the receiver, which then fed a bogus key to `idev_find` (`Internal hashtable error: illegal key supplied`). Gated to protocol >= 30.

### 3. Harness guard

The RP28.e.2 / RP28.f.2 legacy-peer harnesses gain an outer wall-clock `timeout` (workflow) and a `SIGTERM`/`SIGINT` cleanup trap (scripts) so a stalled fixture cannot accumulate per-fixture 60s timeouts and consume the CI job budget.

## Validation (aarch64)

- rsync 2.6.9 receiver daemon accepts an oc-rsync push, byte-identical, no verification errors (RP28.c).
- oc-rsync (client) `-aH` push and pull against a 2.6.9 daemon: byte-identical, hardlinks preserved.
- upstream 3.4.3 `--protocol=29 -aH` pull from oc-rsync daemon: previously `illegal key supplied`, now decodes the flist and preserves hardlinks.
- No regression at protocol 30/31/32 (both directions, delta and `-H`) against upstream 3.4.3.
- `cargo fmt` / `cargo clippy` clean on the touched crates; new regression test `stream_whole_file_md4_prepends_seed_for_proto29` plus existing protocol hardlink/abbreviation suites pass.

## Known limitation (out of scope, follow-up)

oc-rsync as a daemon **sender** stalls in the end-of-transfer phase against a protocol-29 client (the pull legs of RP28.e.2). This is pre-existing and independent of the fixes here (the pre-patch binary hangs identically), and is protocol-29-specific (protocol 30/32 daemon-sender pulls complete normally). The harness guard bounds it so it can no longer cancel the CI job; a dedicated fix for the protocol-29 daemon-sender goodbye phase is left as follow-up.