### PR TITLE
fix(interop): encode end-of-run stats as legacy longint for protocol < 30

### DIFF
--- a/crates/protocol/src/stats/tests.rs
+++ b/crates/protocol/src/stats/tests.rs
@@ -51,6 +51,109 @@ fn test_transfer_stats_roundtrip_proto28() {
     assert_eq!(decoded.flist_xfertime, 0);
 }
 
+/// A real protocol-29 peer (rsync 2.6.9, or upstream `--protocol=29`) reads the
+/// end-of-run sender stats with `read_longint()` (io.h:29 `read_varlong30` ->
+/// `read_longint` for protocol < 30), i.e. 4 bytes per small value. Emitting the
+/// protocol >= 30 varlong form (3 bytes) leaves the peer's `handle_stats()` read
+/// short, so it never relays its final MSG_DONE and the goodbye exchange
+/// deadlocks. This pins the wire bytes to the legacy `write_longint` encoding so
+/// that regression cannot recur.
+#[test]
+fn test_transfer_stats_proto29_uses_legacy_longint_encoding() {
+    let stats = TransferStats {
+        total_read: 1024,
+        total_written: 2048,
+        total_size: 10000,
+        flist_buildtime: 500000,
+        flist_xfertime: 100000,
+        ..Default::default()
+    };
+
+    let mut buf = Vec::new();
+    stats.write_to(&mut buf, ProtocolVersion::V29).unwrap();
+
+    // 5 fields x write_longint (4 bytes each for values that fit in i32).
+    let expected: Vec<u8> = [1024i32, 2048, 10000, 500000, 100000]
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+    assert_eq!(
+        buf, expected,
+        "proto-29 stats must be legacy 4-byte write_longint values"
+    );
+    assert_eq!(buf.len(), 20, "proto-29 stats: 5 fields x 4 bytes");
+}
+
+/// Protocol 28 omits the two flist-time fields (added at 29), so a proto-28 peer
+/// reads exactly 3 legacy `write_longint` values.
+#[test]
+fn test_transfer_stats_proto28_legacy_three_fields() {
+    let stats = TransferStats {
+        total_read: 5000,
+        total_written: 3000,
+        total_size: 50000,
+        flist_buildtime: 12345,
+        flist_xfertime: 67890,
+        ..Default::default()
+    };
+
+    let mut buf = Vec::new();
+    stats.write_to(&mut buf, ProtocolVersion::V28).unwrap();
+
+    let expected: Vec<u8> = [5000i32, 3000, 50000]
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+    assert_eq!(buf, expected, "proto-28 omits flist times; 3 legacy fields");
+    assert_eq!(buf.len(), 12);
+}
+
+/// Protocol 30+ must remain byte-unchanged: the fix only redirects protocol < 30
+/// to the legacy encoding. Values that fit in `min_bytes=3` varlong stay 3 bytes.
+#[test]
+fn test_transfer_stats_proto30_varlong_bytes_unchanged() {
+    let stats = TransferStats {
+        total_read: 1024,
+        total_written: 2048,
+        total_size: 10000,
+        flist_buildtime: 500000,
+        flist_xfertime: 100000,
+        ..Default::default()
+    };
+
+    let mut buf = Vec::new();
+    stats.write_to(&mut buf, ProtocolVersion::V30).unwrap();
+
+    // 5 fields x varlong(min_bytes=3) = 15 bytes for these values.
+    assert_eq!(buf.len(), 15, "proto-30 stays on the varlong encoding");
+    assert_ne!(buf.len(), 20, "proto-30 must not use the legacy encoding");
+}
+
+/// Large values (> i32) exercise the `write_longint` 12-byte marker form on the
+/// legacy path and must round-trip against `read_from` at protocol 29.
+#[test]
+fn test_transfer_stats_proto29_large_value_roundtrip() {
+    let stats = TransferStats {
+        total_read: 5_000_000_000,
+        total_written: 3000,
+        total_size: 50000,
+        flist_buildtime: 12345,
+        flist_xfertime: 67890,
+        ..Default::default()
+    };
+
+    let mut buf = Vec::new();
+    stats.write_to(&mut buf, ProtocolVersion::V29).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+    let decoded = TransferStats::read_from(&mut cursor, ProtocolVersion::V29).unwrap();
+    assert_eq!(decoded.total_read, 5_000_000_000);
+    assert_eq!(decoded.total_written, 3000);
+    assert_eq!(decoded.total_size, 50000);
+    assert_eq!(decoded.flist_buildtime, 12345);
+    assert_eq!(decoded.flist_xfertime, 67890);
+}
+
 #[test]
 fn test_transfer_stats_swap_perspective() {
     let stats = TransferStats {

--- a/crates/protocol/src/stats/transfer.rs
+++ b/crates/protocol/src/stats/transfer.rs
@@ -14,8 +14,42 @@
 
 use std::io::{self, Read, Write};
 
-use crate::varint::{read_varlong30, write_varlong30};
+use crate::varint::{read_longint, read_varlong, write_longint, write_varlong};
 use crate::version::ProtocolVersion;
+
+/// Writes one stats field using upstream's `write_varlong30` macro semantics.
+///
+/// upstream: io.h:46 `write_varlong30()` - protocol < 30 uses the legacy
+/// `write_longint()` (4-byte little-endian, widening to 12 bytes for values
+/// that do not fit in a signed 32-bit int); protocol >= 30 uses the
+/// variable-length `write_varlong()` with `min_bytes`. A proto-29 peer reads
+/// these via `read_longint()`, so emitting the varlong form desyncs its
+/// end-of-run `handle_stats()` read and deadlocks the goodbye exchange.
+fn write_stat<W: Write>(
+    writer: &mut W,
+    value: i64,
+    min_bytes: u8,
+    protocol: ProtocolVersion,
+) -> io::Result<()> {
+    if protocol.as_u8() < 30 {
+        write_longint(writer, value)
+    } else {
+        write_varlong(writer, value, min_bytes)
+    }
+}
+
+/// Reads one stats field using upstream's `read_varlong30` macro semantics.
+///
+/// upstream: io.h:29 `read_varlong30()` - the read-side counterpart to
+/// [`write_stat`]; protocol < 30 uses `read_longint()`, protocol >= 30 uses
+/// `read_varlong()` with `min_bytes`.
+fn read_stat<R: Read>(reader: &mut R, min_bytes: u8, protocol: ProtocolVersion) -> io::Result<i64> {
+    if protocol.as_u8() < 30 {
+        read_longint(reader)
+    } else {
+        read_varlong(reader, min_bytes)
+    }
+}
 
 /// Transfer statistics exchanged between rsync processes.
 ///
@@ -197,13 +231,13 @@ impl TransferStats {
     ///
     /// Returns an error if writing to the stream fails.
     pub fn write_to<W: Write>(&self, writer: &mut W, protocol: ProtocolVersion) -> io::Result<()> {
-        write_varlong30(writer, self.total_read as i64, 3)?;
-        write_varlong30(writer, self.total_written as i64, 3)?;
-        write_varlong30(writer, self.total_size as i64, 3)?;
+        write_stat(writer, self.total_read as i64, 3, protocol)?;
+        write_stat(writer, self.total_written as i64, 3, protocol)?;
+        write_stat(writer, self.total_size as i64, 3, protocol)?;
 
         if protocol.supports_flist_times() {
-            write_varlong30(writer, self.flist_buildtime as i64, 3)?;
-            write_varlong30(writer, self.flist_xfertime as i64, 3)?;
+            write_stat(writer, self.flist_buildtime as i64, 3, protocol)?;
+            write_stat(writer, self.flist_xfertime as i64, 3, protocol)?;
         }
 
         Ok(())
@@ -217,13 +251,13 @@ impl TransferStats {
     ///
     /// Returns an error if reading from the stream fails.
     pub fn read_from<R: Read>(reader: &mut R, protocol: ProtocolVersion) -> io::Result<Self> {
-        let total_read = read_varlong30(reader, 3)? as u64;
-        let total_written = read_varlong30(reader, 3)? as u64;
-        let total_size = read_varlong30(reader, 3)? as u64;
+        let total_read = read_stat(reader, 3, protocol)? as u64;
+        let total_written = read_stat(reader, 3, protocol)? as u64;
+        let total_size = read_stat(reader, 3, protocol)? as u64;
 
         let (flist_buildtime, flist_xfertime) = if protocol.supports_flist_times() {
-            let buildtime = read_varlong30(reader, 3)? as u64;
-            let xfertime = read_varlong30(reader, 3)? as u64;
+            let buildtime = read_stat(reader, 3, protocol)? as u64;
+            let xfertime = read_stat(reader, 3, protocol)? as u64;
             (buildtime, xfertime)
         } else {
             (0, 0)

--- a/crates/protocol/tests/golden_handshakes.rs
+++ b/crates/protocol/tests/golden_handshakes.rs
@@ -682,13 +682,16 @@ fn golden_stats_zero_proto30() {
 
 #[test]
 fn golden_stats_zero_proto28() {
-    // Protocol 28 only sends 3 core stats, no flist times
+    // Protocol 28 only sends 3 core stats, no flist times.
+    // upstream: io.h:46 write_varlong30() routes protocol < 30 through
+    // io.c:2222 write_longint(), which writes each small (0..=0x7FFFFFFF)
+    // value as a fixed 4-byte little-endian int. A zero value is 4 zero bytes.
     let stats = TransferStats::new();
     let mut buf = Vec::new();
     stats.write_to(&mut buf, ProtocolVersion::V28).unwrap();
 
-    // 3 core stats * 3 bytes = 9 bytes
-    assert_eq!(buf.len(), 9);
+    // 3 core stats * 4 bytes (legacy longint) = 12 bytes
+    assert_eq!(buf.len(), 12);
     assert!(buf.iter().all(|&b| b == 0));
 
     let mut cursor = Cursor::new(&buf);

--- a/crates/protocol/tests/golden_protocol_v28_mplex_delta_stats.rs
+++ b/crates/protocol/tests/golden_protocol_v28_mplex_delta_stats.rs
@@ -487,8 +487,8 @@ fn golden_v28_stats_exact_wire_bytes_known_values() {
 
 #[test]
 fn golden_v28_stats_vs_v29_different_length() {
-    // Protocol 28: 3 varlong30 fields.
-    // Protocol 29: 5 varlong30 fields (adds flist_buildtime, flist_xfertime).
+    // Protocol 28: 3 legacy longint fields.
+    // Protocol 29: 5 legacy longint fields (adds flist_buildtime, flist_xfertime).
     let stats = TransferStats::with_bytes(100, 200, 300).with_flist_times(500_000, 100_000);
 
     let v28 = proto28();

--- a/crates/protocol/tests/golden_protocol_v28_mplex_delta_stats.rs
+++ b/crates/protocol/tests/golden_protocol_v28_mplex_delta_stats.rs
@@ -457,24 +457,17 @@ fn golden_v28_ndx_sequence_roundtrip() {
 }
 
 // ---------------------------------------------------------------------------
-// Transfer stats exact wire bytes (protocol 28 - varlong30 encoding detail)
-// upstream: main.c:handle_stats() + io.c:write_varlong()
+// Transfer stats exact wire bytes (protocol 28 - legacy longint encoding)
+// upstream: main.c:handle_stats() + io.h:46 write_varlong30() -> io.c:2222 write_longint()
 // ---------------------------------------------------------------------------
 
 #[test]
 fn golden_v28_stats_exact_wire_bytes_known_values() {
-    // Protocol 28: 3 fields (total_read, total_written, total_size) as
-    // varlong30 with min_bytes=3. No flist timing fields.
-    //
-    // varlong30(1024, min_bytes=3):
-    //   value = 1024 = 0x0400
-    //   LE bytes = [0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-    //   cnt starts at 8, strip trailing zeros to min_bytes=3:
-    //     bytes[7..3] are all 0x00, so cnt goes 8->7->6->5->4->3 (stop at min)
-    //   leading byte = bytes[2] = 0x00
-    //   bit threshold = 1 << (7 + 3 - 3) = 0x80
-    //   0x00 < 0x80, cnt == min_bytes -> no extra byte needed
-    //   Output: [leading=0x00] + bytes[0..2] = [0x00, 0x00, 0x04]
+    // Protocol 28: 3 fields (total_read, total_written, total_size). No flist
+    // timing fields. upstream io.h:46 write_varlong30() routes protocol < 30
+    // through io.c:2222 write_longint(), which writes each small value
+    // (0..=0x7FFFFFFF) as a fixed 4-byte little-endian int:
+    //   longint(1024) = 1024 as i32 LE = [0x00, 0x04, 0x00, 0x00]
     let stats = TransferStats::with_bytes(1024, 2048, 4096);
     let mut buf = Vec::new();
     stats.write_to(&mut buf, proto28()).unwrap();

--- a/crates/protocol/tests/golden_protocol_v28_wire.rs
+++ b/crates/protocol/tests/golden_protocol_v28_wire.rs
@@ -732,7 +732,7 @@ fn golden_v28_stats_no_flist_times() {
     let mut buf = Vec::new();
     stats.write_to(&mut buf, proto28()).unwrap();
 
-    // Protocol 28: only 3 core stats, each as varlong30(min_bytes=3)
+    // Protocol 28: only 3 core stats, each via legacy write_longint.
     // No flist_buildtime or flist_xfertime.
     let mut cursor = Cursor::new(&buf);
     let decoded = TransferStats::read_from(&mut cursor, proto28()).unwrap();
@@ -1100,28 +1100,25 @@ fn golden_v28_mixed_hardlink_and_plain_roundtrip() {
 }
 
 // ---------------------------------------------------------------------------
-// Transfer stats exact wire bytes (protocol 28 - varlong30 only, no flist times)
-// upstream: main.c:handle_stats() - protocol < 29 omits flist times
+// Transfer stats exact wire bytes (protocol 28 - legacy longint, no flist times)
+// upstream: main.c:handle_stats() -> io.h:46 write_varlong30() routes protocol
+// < 30 through io.c write_longint() (4-byte LE for values <= 0x7FFFFFFF).
+// Protocol < 29 additionally omits flist_buildtime/flist_xfertime.
 // ---------------------------------------------------------------------------
 
 #[test]
 fn golden_v28_stats_wire_bytes_small_values() {
-    // Protocol 28 stats: 3 varlong30 fields with min_bytes=3.
-    // For small values that fit in 3 bytes, each is encoded as:
-    //   leading_byte + 3 value bytes (total 4 bytes per field).
-    //
-    // varlong30 with min_bytes=3 for value=4096 (0x1000):
-    //   bytes = [0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-    //   cnt starts at 8, strips trailing zeros to min_bytes=3
-    //   bytes[2] = 0x00, bit = 1<<(7+3-3) = 0x80
-    //   0x00 < 0x80 and cnt == min_bytes, so leading = bytes[2] = 0x00
-    //   output: [0x00] + bytes[0..2] = [0x00, 0x00, 0x10]
+    // Protocol 28 stats: 3 legacy longint fields.
+    // upstream: io.h:46 write_varlong30() routes protocol < 30 through
+    // io.c write_longint(), which writes each value <= 0x7FFFFFFF as a
+    // 4-byte little-endian i32. value=4096 (0x1000) => [0x00, 0x10, 0x00, 0x00].
     let stats = TransferStats::with_bytes(4096, 8192, 65536);
     let mut buf = Vec::new();
     stats.write_to(&mut buf, proto28()).unwrap();
 
-    // 3 fields, each varlong30 with min_bytes=3 for values fitting in 3 bytes
+    // 3 fields, each write_longint (4 bytes for values <= 0x7FFFFFFF) = 12 bytes.
     // No flist times for protocol 28.
+    assert_eq!(buf.len(), 12, "3 small longint fields = 12 bytes");
     let mut cursor = Cursor::new(&buf[..]);
     let decoded = TransferStats::read_from(&mut cursor, proto28()).unwrap();
 
@@ -1141,38 +1138,45 @@ fn golden_v28_stats_wire_bytes_small_values() {
 
 #[test]
 fn golden_v28_stats_wire_bytes_zero() {
-    // Zero-value stats: varlong30(0, min_bytes=3)
-    // bytes = [0,0,0,0,0,0,0,0], cnt=3 (min), leading = bytes[2]=0, output = [0x00, 0x00, 0x00]
+    // Zero-value stats via legacy longint (protocol < 30).
+    // upstream: io.h:46 write_varlong30() routes protocol < 30 through
+    // io.c write_longint(); value 0 fits in a signed 32-bit int, so each
+    // field is a 4-byte little-endian i32 zero.
     let stats = TransferStats::with_bytes(0, 0, 0);
     let mut buf = Vec::new();
     stats.write_to(&mut buf, proto28()).unwrap();
 
-    // 3 fields of varlong30(0, 3): each is [0x00, 0x00, 0x00] = 3 bytes
+    // 3 fields of write_longint(0): each is [0x00, 0x00, 0x00, 0x00] = 4 bytes
     assert_eq!(
         buf.len(),
-        9,
-        "3 zero-value varlong30(min=3) = 9 bytes total"
+        12,
+        "3 zero-value longint fields = 12 bytes total"
     );
 
     #[rustfmt::skip]
     let expected: &[u8] = &[
-        // total_read = 0: varlong30(0, 3)
-        0x00, 0x00, 0x00,
-        // total_written = 0: varlong30(0, 3)
-        0x00, 0x00, 0x00,
-        // total_size = 0: varlong30(0, 3)
-        0x00, 0x00, 0x00,
+        // total_read = 0: write_longint(0) = 4-byte LE
+        0x00, 0x00, 0x00, 0x00,
+        // total_written = 0: write_longint(0) = 4-byte LE
+        0x00, 0x00, 0x00, 0x00,
+        // total_size = 0: write_longint(0) = 4-byte LE
+        0x00, 0x00, 0x00, 0x00,
     ];
-    assert_eq!(buf, expected, "zero stats must be 9 bytes of zeros");
+    assert_eq!(buf, expected, "zero stats must be 12 bytes of zeros");
 }
 
 #[test]
 fn golden_v28_stats_wire_bytes_large() {
-    // Large transfer stats that require more than 3 bytes.
-    // total_read = 10_000_000_000 (~9.3 GB) requires 5 bytes in varlong30.
+    // Large transfer stats that exceed the signed 32-bit inline range.
+    // upstream: io.c write_longint() emits values > 0x7FFFFFFF as the
+    // 0xFFFFFFFF marker (4 bytes) followed by the full 8-byte LE i64 = 12 bytes.
+    // total_read/total_size = 10_000_000_000 (~9.3 GB) => 12 bytes each;
+    // total_written = 500 fits inline => 4 bytes. Total = 28 bytes.
     let stats = TransferStats::with_bytes(10_000_000_000, 500, 10_000_000_000);
     let mut buf = Vec::new();
     stats.write_to(&mut buf, proto28()).unwrap();
+
+    assert_eq!(buf.len(), 28, "two 12-byte longints + one 4-byte longint");
 
     let mut cursor = Cursor::new(&buf[..]);
     let decoded = TransferStats::read_from(&mut cursor, proto28()).unwrap();

--- a/crates/protocol/tests/golden_protocol_v29_wire.rs
+++ b/crates/protocol/tests/golden_protocol_v29_wire.rs
@@ -2,11 +2,11 @@
 //!
 //! Protocol 29 is the first version to include flist build/transfer time
 //! fields in transfer statistics. It shares the same file list encoding as
-//! protocol 28 (fixed-width, no varint) but adds two varlong30 timing
+//! protocol 28 (fixed-width, no varint) but adds two legacy-longint timing
 //! fields after the core stats.
 //!
 //! Key protocol 29 characteristics:
-//! - Transfer stats include flist_buildtime and flist_xfertime (varlong30)
+//! - Transfer stats include flist_buildtime and flist_xfertime (legacy longint)
 //! - File list encoding identical to protocol 28 (fixed 4-byte LE integers)
 //! - No incremental recursion (introduced in v30)
 //! - No varint flist flags (introduced in v30)
@@ -36,12 +36,12 @@ fn v29() -> ProtocolVersion {
 
 /// Verifies that protocol 29 transfer stats include flist timing fields.
 ///
-/// Wire layout (all varlong30 with min_bytes=3):
-///   total_read      : varlong30
-///   total_written   : varlong30
-///   total_size      : varlong30
-///   flist_buildtime : varlong30 (microseconds, protocol >= 29 only)
-///   flist_xfertime  : varlong30 (microseconds, protocol >= 29 only)
+/// Wire layout (protocol < 30 routes write_varlong30 through legacy longint):
+///   total_read      : longint
+///   total_written   : longint
+///   total_size      : longint
+///   flist_buildtime : longint (microseconds, protocol >= 29 only)
+///   flist_xfertime  : longint (microseconds, protocol >= 29 only)
 #[test]
 fn golden_v29_stats_with_flist_times() {
     let stats = TransferStats::with_bytes(4096, 8192, 100_000).with_flist_times(500_000, 100_000);
@@ -50,7 +50,7 @@ fn golden_v29_stats_with_flist_times() {
     let mut buf = Vec::new();
     stats.write_to(&mut buf, protocol).unwrap();
 
-    // Protocol 29 encodes 5 fields (3 core + 2 flist times), each as varlong30(min_bytes=3).
+    // Protocol 29 encodes 5 fields (3 core + 2 flist times), each via legacy longint.
     // Verify round-trip decodes all 5 fields correctly.
     let mut cursor = Cursor::new(&buf[..]);
     let decoded = TransferStats::read_from(&mut cursor, protocol).unwrap();

--- a/crates/protocol/tests/golden_protocol_v29_wire.rs
+++ b/crates/protocol/tests/golden_protocol_v29_wire.rs
@@ -86,38 +86,33 @@ fn golden_v29_stats_zero_flist_times() {
 
 /// Verifies exact wire bytes for protocol 29 transfer stats.
 ///
-/// Each field uses varlong30 encoding with min_bytes=3:
-///   - Leading byte encodes the number of significant bytes
-///   - Followed by min_bytes-1 (=2) bytes of the LE value
-///
-/// For small values that fit in 3 bytes (values < 2^23 with bit 7 of
-/// byte 2 clear), the encoding is: [byte2, byte0, byte1] where
-/// byte0..byte2 are the LE representation.
+/// Protocol 29 is below 30, so upstream io.h:46 write_varlong30() routes each
+/// field through io.c:2222 write_longint(): a small value (0..=0x7FFFFFFF) is
+/// written as a fixed 4-byte little-endian int. A zero field is 4 zero bytes.
 #[test]
 fn golden_v29_stats_exact_wire_bytes() {
-    // Use values where we can predict the exact varlong30 encoding.
-    // varlong30(0, min_bytes=3): leading=0x00, then 2 zero bytes -> [0x00, 0x00, 0x00]
+    // varlong30 defers to write_longint for protocol < 30; longint(0) = [0,0,0,0].
     let stats = TransferStats::with_bytes(0, 0, 0);
 
     let protocol = v29();
     let mut buf = Vec::new();
     stats.write_to(&mut buf, protocol).unwrap();
 
-    // 5 fields, each 3 bytes (all zeros) = 15 bytes total
-    assert_eq!(buf.len(), 15, "5 zero-valued varlong30 fields = 15 bytes");
+    // 5 fields, each 4 bytes (legacy longint, all zeros) = 20 bytes total
+    assert_eq!(buf.len(), 20, "5 zero-valued longint fields = 20 bytes");
 
     #[rustfmt::skip]
     let expected: &[u8] = &[
         // total_read = 0
-        0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
         // total_written = 0
-        0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
         // total_size = 0
-        0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
         // flist_buildtime = 0
-        0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
         // flist_xfertime = 0
-        0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
     ];
 
     assert_eq!(buf, expected, "all-zero stats wire bytes");


### PR DESCRIPTION
## Problem

An oc-rsync daemon acting as **sender** deadlocked in the end-of-transfer goodbye phase against **any protocol-29 client** (rsync 2.6.9, or upstream rsync `--protocol=29`). Every proto-29 pull transferred all files correctly, then both peers blocked in `read` until timeout. Proto 30/31/32 pulls completed in ~0s; only proto <= 29 hung.

## Root cause

The sender emits its end-of-run transfer stats through `TransferStats::write_to`, which always used the modern varlong encoding (`write_varlong`) regardless of protocol. Upstream's `write_varlong30` macro (`io.h`) uses `write_longint` for **protocol < 30** - 4 bytes per small value, not the 3-byte varlong.

A protocol-29 receiver reads the sender stats back with `read_longint` in `handle_stats()` (`main.c`), expecting **20 bytes** for the 5 fields (`total_read`, `total_written`, `total_size`, `flist_buildtime`, `flist_xfertime`). oc sent only **15 bytes** (3-byte varlong x 5). The receiver blocked reading the 5 missing bytes, so it never relayed its final `MSG_DONE` to the generator, and the generator hung in `generate_files` phase 3 waiting for `msgdone_cnt` to reach 3 - a whole-pipeline deadlock. Confirmed by gdb (sender parked in a `recvfrom` poll), tcpdump (15-byte stats frame the last bytes on the wire), and a proto-30-vs-29 boundary bisect.

## Fix

`TransferStats::write_to` / `read_from` now dispatch on protocol version, mirroring upstream's `write_varlong30` / `read_varlong30` (`io.h:29,46`):

- **protocol < 30**: `write_longint` / `read_longint` (legacy, what a real proto-28/29 peer reads)
- **protocol >= 30**: unchanged `write_varlong` / `read_varlong` with `min_bytes = 3`

Protocol 30, 31 and 32 wire bytes are **byte-for-byte identical** to before - only protocol 28/29 switch to the legacy encoding. No extra round-trip is added, so there is no new latency at any protocol.

## Verification (aarch64 Linux, vs upstream rsync 3.4.3 and rsync 2.6.9)

- **rsync 2.6.9 native client** (negotiates proto 29): pull + push both `rc=0`, trees byte-identical.
- upstream `--protocol=29` pull (whole-file and delta): `rc=0`, byte-identical (previously hung 124/timeout).
- **No regression** proto 30/31/32: `rc=0`, byte-identical, same ~220ms latency as before.
- RP28.e.2 harness: the 8 goodbye-affected fixtures (D1/D2/D4/D5/D6/D7/D8/D9) now pass.
- New unit tests: proto-29 stats pinned to the exact 20-byte legacy longint layout; proto-30 asserted to stay on the 15-byte varlong form; large-value longint round-trip.

`cargo fmt --check`, `cargo clippy -p protocol -D warnings`, and the 23 `transfer_stats` tests are clean.

## Out of scope

Two RP28.e fixtures still fail with a different, earlier symptom ("connection unexpectedly closed, ~82 bytes received", well before the flist/stats phase): D3 (`-z` zlib) and D10 (1 MiB delta). These are separate pre-existing protocol-29 issues in the compression and large-delta paths, not the goodbye deadlock. The RP28.e timeout guard is therefore left in place.