### PR TITLE
fix(engine): count actual deleted leaves against --max-delete

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -335,12 +335,19 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // config (the wire-side sender conversion in build_wire_format_rules only
     // affects what the remote sender hides, not local delete protection).
     server_config.deletion.delete_excluded = config.delete_excluded();
+    // upstream: delete.c:156 - `--max-delete` is enforced by the generator,
+    // which for a remote-shell pull runs on the local client (the receiver).
+    // The `--max-delete=NUM` server arg is forwarded to the remote sender too,
+    // but a pull sender never deletes, so the cap must be carried onto this
+    // local receiver config or it is silently ignored (unbounded deletion).
+    server_config.deletion.max_delete = config.max_delete();
     logging::debug_log!(
         Del,
         2,
-        "receiver config: delete_excluded={} delete_mode={:?}",
+        "receiver config: delete_excluded={} delete_mode={:?} max_delete={:?}",
         config.delete_excluded(),
-        config.delete_mode()
+        config.delete_mode(),
+        config.max_delete()
     );
     // upstream: options.c:2881-2885 - copy_unsafe_links and safe_links are long-form only
     server_config.flags.copy_unsafe_links = config.copy_unsafe_links();

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -99,19 +99,24 @@ fn delete_extraneous_entries_via_emitter<S: AsRef<OsStr>, F>(
 where
     F: DeleteFs + Sync + Send + 'static,
 {
+    // When --max-delete is active the cap must count every filesystem entry
+    // that is actually removed, including the leaves inside an extraneous
+    // directory, and stop mid-traversal once the limit is reached. The
+    // emitter path below removes an extraneous directory wholesale
+    // (`remove_dir_all`) and counts it as a single deletion, silently
+    // exceeding the cap for directory subtrees. Route capped runs through
+    // the leaf-granular serial executor instead so the count matches
+    // upstream delete.c:156/181 (guard-before-delete, increment-on-success).
+    if context.options().max_deletion_limit().is_some() {
+        return delete_extraneous_entries_capped(context, destination, relative, source_entries);
+    }
+
     // Phase 1: scan the destination directory, compute extras, and
     // produce a single-directory DeletePlan in upstream emission order.
-    // The plan respects partial-dir protection, allows_deletion filter
-    // rules, and the max-delete limit before publication so the emitter
-    // sees only the entries that should actually unlink.
-    let mut skipped_due_to_limit = 0u64;
-    let plan = match build_plan_for_directory(
-        context,
-        destination,
-        relative,
-        source_entries,
-        &mut skipped_due_to_limit,
-    )? {
+    // The plan respects partial-dir protection and allows_deletion filter
+    // rules before publication so the emitter sees only the entries that
+    // should actually unlink.
+    let plan = match build_plan_for_directory(context, destination, relative, source_entries)? {
         Some(plan) => plan,
         None => return Ok(()),
     };
@@ -151,16 +156,242 @@ where
         })?;
     }
 
-    if skipped_due_to_limit > 0 {
+    Ok(())
+}
+
+/// Leaf-granular, serial deletion path used whenever `--max-delete` is
+/// active.
+///
+/// The emitter path counts an extraneous directory as a single deletion and
+/// removes its subtree with `remove_dir_all`, so a directory holding N files
+/// costs one unit against the cap even though N+1 filesystem entries vanish.
+/// That undercount lets a small `--max-delete` value silently remove an
+/// unbounded number of files. This path instead walks every candidate
+/// depth-first and checks the cap before each individual unlink, counting
+/// only successful deletions, exactly mirroring upstream
+/// `delete.c:delete_item`/`delete_dir_contents` where `stats.deleted_files`
+/// is compared against `max_delete` before every entry and incremented only
+/// on a successful removal (`delete.c:156` guard, `delete.c:181` increment).
+///
+/// The global running count is `context.summary().items_deleted()`, which the
+/// per-entry side effects already maintain across directories, so the cap is
+/// enforced consistently over the whole transfer, not just one directory.
+fn delete_extraneous_entries_capped<S: AsRef<OsStr>>(
+    context: &mut CopyContext,
+    destination: &Path,
+    relative: Option<&Path>,
+    source_entries: &[S],
+) -> Result<(), LocalCopyError> {
+    let plan = match build_plan_for_directory(context, destination, relative, source_entries)? {
+        Some(plan) => plan,
+        None => return Ok(()),
+    };
+
+    // Entries are visited in upstream `delete_in_dir` emission order (the
+    // reverse-sorted order `sort_by_name` locks in) so the prefix that
+    // survives when the cap trips matches upstream's traversal.
+    let mut skipped = 0u64;
+    for entry in &plan.extras {
+        let name_path = PathBuf::from(entry.name.as_os_str());
+        let path = destination.join(&name_path);
+        let entry_relative = match relative {
+            Some(base) => base.join(&name_path),
+            None => name_path.clone(),
+        };
+        remove_entry_capped(context, &path, &entry_relative, &mut skipped)?;
+    }
+
+    if skipped > 0 {
+        // upstream: generator.c:2431 emits one warning after the pass with
+        // the total number of entries skipped because of the limit; the run
+        // then exits RERR_DEL_LIMIT (25).
         info_log!(
             Del,
             1,
             "max deletions reached, skipping {} remaining",
-            skipped_due_to_limit
+            skipped
         );
-        return Err(LocalCopyError::delete_limit_exceeded(skipped_due_to_limit));
+        return Err(LocalCopyError::delete_limit_exceeded(skipped));
     }
 
+    Ok(())
+}
+
+/// Recursively removes one extraneous entry under the `--max-delete` cap,
+/// returning `true` when the entry was fully removed and `false` when it (or
+/// part of its subtree) was left in place because the cap was reached.
+///
+/// Mirrors upstream `delete_item`: a directory first has its contents peeled
+/// depth-first (`delete_dir_contents`, reverse-sorted iteration), then the
+/// now-empty directory is itself subject to the same guard before its own
+/// removal. `skipped` accumulates the count reported to the user, matching
+/// upstream's `skipped_deletes` (`delete.c:157`).
+fn remove_entry_capped(
+    context: &mut CopyContext,
+    path: &Path,
+    entry_relative: &Path,
+    skipped: &mut u64,
+) -> Result<bool, LocalCopyError> {
+    context.enforce_timeout()?;
+
+    let file_type = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata.file_type(),
+        // Vanished between scan and delete: upstream treats this as a
+        // successful no-op removal (nothing is left behind).
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(true),
+        Err(error) => {
+            return Err(LocalCopyError::io(
+                "inspect extraneous destination entry",
+                path.to_path_buf(),
+                error,
+            ));
+        }
+    };
+
+    if file_type.is_dir() {
+        // Peel the directory's contents depth-first in upstream reverse-sorted
+        // order before considering the directory itself.
+        let mut children: Vec<OsString> = Vec::new();
+        match fs::read_dir(path) {
+            Ok(iter) => {
+                for child in iter {
+                    let child = child.map_err(|error| {
+                        LocalCopyError::io("read extraneous directory entry", path, error)
+                    })?;
+                    children.push(child.file_name());
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(true),
+            Err(error) => {
+                return Err(LocalCopyError::io(
+                    "read extraneous directory",
+                    path.to_path_buf(),
+                    error,
+                ));
+            }
+        }
+        // upstream: delete.c:85 iterates the sorted dirlist in reverse.
+        children.sort_unstable();
+        children.reverse();
+
+        let mut all_children_removed = true;
+        for child_name in children {
+            let child_path = path.join(&child_name);
+            let child_relative = entry_relative.join(&child_name);
+            if !remove_entry_capped(context, &child_path, &child_relative, skipped)? {
+                all_children_removed = false;
+            }
+        }
+
+        if !all_children_removed {
+            // Contents survived (cap reached or filter-protected), so the
+            // directory cannot be removed. upstream: delete.c:117 prints this
+            // once per non-empty directory without counting it or flagging an
+            // I/O error.
+            info_log!(
+                Nonreg,
+                1,
+                "cannot delete non-empty directory: {}",
+                path.display().to_string().replace('\\', "/")
+            );
+            return Ok(false);
+        }
+
+        // The directory is empty; it is itself a deletion subject to the cap.
+        if cap_reached(context) {
+            *skipped = skipped.saturating_add(1);
+            return Ok(false);
+        }
+        delete_leaf(context, path, entry_relative, file_type)?;
+        return Ok(true);
+    }
+
+    // Regular file, symlink, device, or special: a single deletion.
+    if cap_reached(context) {
+        *skipped = skipped.saturating_add(1);
+        return Ok(false);
+    }
+    delete_leaf(context, path, entry_relative, file_type)?;
+    Ok(true)
+}
+
+/// Returns `true` when the running deletion count has reached the configured
+/// `--max-delete` limit. upstream: delete.c:156 `stats.deleted_files >= max_delete`.
+fn cap_reached(context: &CopyContext) -> bool {
+    context
+        .options()
+        .max_deletion_limit()
+        .is_some_and(|limit| context.summary().items_deleted() >= limit)
+}
+
+/// Runs the per-entry side effects (backup, itemize log, [`LocalCopyRecord`],
+/// summary counter) and issues the actual removal for one leaf. Increments the
+/// global deletion count via `record_deletion` so the cap sees the update.
+///
+/// Kept in lockstep with [`apply_delete_side_effects`] for a single entry; the
+/// recursion in [`remove_entry_capped`] supplies the per-leaf walk that
+/// [`record_directory_subtree`] provides on the uncapped path.
+fn delete_leaf(
+    context: &mut CopyContext,
+    path: &Path,
+    entry_relative: &Path,
+    file_type: fs::FileType,
+) -> Result<(), LocalCopyError> {
+    let is_dir = file_type.is_dir();
+
+    // upstream: delete.c:165 - back up an extraneous file before deletion only
+    // when `backup_dir || !is_backup_file(fbuf)`.
+    if !context.mode().is_dry_run()
+        && !is_dir
+        && let Some(name) = path.file_name()
+        && context.options().should_backup_before_delete(name)
+    {
+        context.backup_existing_entry(path, Some(entry_relative), file_type)?;
+    }
+
+    if !context.options().is_itemize_active() {
+        if is_dir {
+            info_log!(Del, 1, "deleting {}/", entry_relative.display());
+        } else {
+            info_log!(Del, 1, "deleting {}", entry_relative.display());
+        }
+    }
+
+    if !context.mode().is_dry_run() {
+        let fs = RealDeleteFs;
+        let result = if is_dir {
+            fs.rmdir(path)
+        } else if file_type.is_symlink() {
+            fs.unlink_symlink(path)
+        } else {
+            fs.unlink_file(path)
+        };
+        if let Err(error) = result {
+            // A vanished entry is a benign no-op (upstream ENOENT path); any
+            // other failure surfaces so the exit code reflects it.
+            if error.kind() != io::ErrorKind::NotFound {
+                return Err(LocalCopyError::io(
+                    "delete extraneous destination entry",
+                    path.to_path_buf(),
+                    error,
+                ));
+            }
+        }
+    }
+
+    context.summary_mut().record_deletion(file_type);
+    context.record(
+        LocalCopyRecord::new(
+            entry_relative.to_path_buf(),
+            LocalCopyAction::EntryDeleted,
+            0,
+            None,
+            Duration::default(),
+            None,
+        )
+        .with_directory(is_dir),
+    );
+    context.register_progress();
     Ok(())
 }
 
@@ -174,7 +405,6 @@ fn build_plan_for_directory<S: AsRef<OsStr>>(
     destination: &Path,
     relative: Option<&Path>,
     source_entries: &[S],
-    skipped_due_to_limit: &mut u64,
 ) -> Result<Option<DeletePlan>, LocalCopyError> {
     // upstream: delete.c:63 - `delete_dir_contents()` calls
     // `push_local_filters(fname, dlen)` with the destination directory so the
@@ -275,10 +505,12 @@ fn build_plan_for_directory<S: AsRef<OsStr>>(
     };
 
     // Phase C (serial): apply the decisions in readdir order. Filter-protected
-    // entries log and are dropped; the rest count against the max-delete limit
-    // and join the plan. The final `sort_by_name` fixes the wire emission order.
-    // This sequence is identical to the original serial loop - only the matching
-    // in Phase B was parallelised.
+    // entries log and are dropped; the rest join the plan. The final
+    // `sort_by_name` fixes the wire emission order. The `--max-delete` cap is
+    // NOT applied here: it is enforced at leaf granularity during execution by
+    // `delete_extraneous_entries_capped` (upstream counts every removed entry,
+    // not just the top-level ones), so this plan carries the full extraneous
+    // set for the directory.
     let mut plan = DeletePlan::new(destination.to_path_buf());
     for (candidate, allowed) in candidates.into_iter().zip(allowed) {
         if !allowed {
@@ -288,17 +520,6 @@ fn build_plan_for_directory<S: AsRef<OsStr>>(
                 "filter protected {} from deletion",
                 candidate.entry_relative.display()
             );
-            continue;
-        }
-
-        if let Some(limit) = context.options().max_deletion_limit()
-            && context
-                .summary()
-                .items_deleted()
-                .saturating_add(plan.len() as u64)
-                >= limit
-        {
-            *skipped_due_to_limit = skipped_due_to_limit.saturating_add(1);
             continue;
         }
 

--- a/crates/engine/src/local_copy/tests/execute_max_delete.rs
+++ b/crates/engine/src/local_copy/tests/execute_max_delete.rs
@@ -755,3 +755,122 @@ fn max_deletions_option_zero() {
     let options = LocalCopyOptions::new().max_deletions(Some(0));
     assert_eq!(options.max_deletion_limit(), Some(0));
 }
+
+/// Recursively counts every filesystem entry under `dir`, optionally skipping
+/// a single top-level name. Used to prove the exact number of entries a
+/// `--max-delete` run removed.
+fn count_entries_under(dir: &std::path::Path, skip_top: Option<&str>) -> usize {
+    let mut total = 0;
+    for entry in fs::read_dir(dir).expect("read_dir") {
+        let entry = entry.expect("dir entry");
+        if skip_top.is_some_and(|s| entry.file_name() == std::ffi::OsStr::new(s)) {
+            continue;
+        }
+        total += 1;
+        if entry.file_type().expect("file_type").is_dir() {
+            total += count_entries_under(&entry.path(), None);
+        }
+    }
+    total
+}
+
+/// DATA-SAFETY REGRESSION: a non-empty extraneous directory must count every
+/// leaf it contains against `--max-delete`, and the run must never remove more
+/// than the configured number of filesystem entries.
+///
+/// Before the fix the local-copy emitter removed a doomed subtree wholesale
+/// (`remove_dir_all`) and counted it as a single deletion, so `--max-delete=3`
+/// against a directory of five files plus two loose files silently deleted all
+/// eight entries. upstream `delete.c:156`/`:181` guards and counts each removed
+/// leaf, deleting exactly three and reporting `RERR_DEL_LIMIT` (25). Verified
+/// byte-for-byte against rsync 3.4.3 (3 deleted, 4 skipped, exit 25).
+#[test]
+fn max_delete_counts_leaves_inside_nonempty_directory() {
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+    fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
+
+    let target_root = ctx.dest.join("source");
+    fs::create_dir_all(&target_root).expect("create target root");
+    fs::write(target_root.join("keep.txt"), b"old").expect("write old");
+
+    // One extraneous directory holding five files, plus two loose files: eight
+    // filesystem entries doomed by --delete.
+    let extra_dir = target_root.join("extra_dir");
+    fs::create_dir_all(&extra_dir).expect("create extra_dir");
+    for i in 1..=5 {
+        fs::write(extra_dir.join(format!("f{i}")), b"x").expect("write child");
+    }
+    fs::write(target_root.join("a1"), b"x").expect("write a1");
+    fs::write(target_root.join("a2"), b"x").expect("write a2");
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .delete(true)
+        .max_deletions(Some(3));
+
+    let error = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect_err("must stop at the cap and report RERR_DEL_LIMIT");
+
+    assert_eq!(error.exit_code(), MAX_DELETE_EXIT_CODE);
+    match error.kind() {
+        LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
+            assert_eq!(*skipped, 4, "upstream reports 4 skipped for this layout");
+        }
+        other => panic!("unexpected error kind: {other:?}"),
+    }
+
+    // Exactly three of the eight doomed entries may be removed - never the whole
+    // subtree. Five must survive.
+    let survivors = count_entries_under(&target_root, Some("keep.txt"));
+    assert_eq!(
+        survivors, 5,
+        "exactly 3 of 8 entries may be deleted under --max-delete=3"
+    );
+}
+
+/// The same leaf-counting cap must hold under `--delete-delay` (collect then
+/// apply): a small `--max-delete` must not be defeated by the deferred pass.
+#[test]
+fn max_delete_counts_leaves_inside_nonempty_directory_delete_delay() {
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+    fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
+
+    let target_root = ctx.dest.join("source");
+    fs::create_dir_all(&target_root).expect("create target root");
+    fs::write(target_root.join("keep.txt"), b"old").expect("write old");
+
+    let extra_dir = target_root.join("extra_dir");
+    fs::create_dir_all(&extra_dir).expect("create extra_dir");
+    for i in 1..=5 {
+        fs::write(extra_dir.join(format!("f{i}")), b"x").expect("write child");
+    }
+    fs::write(target_root.join("a1"), b"x").expect("write a1");
+    fs::write(target_root.join("a2"), b"x").expect("write a2");
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .delete_delay(true)
+        .max_deletions(Some(3));
+
+    let error = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect_err("must stop at the cap under --delete-delay");
+
+    assert_eq!(error.exit_code(), MAX_DELETE_EXIT_CODE);
+    let survivors = count_entries_under(&target_root, Some("keep.txt"));
+    assert_eq!(
+        survivors, 5,
+        "exactly 3 of 8 entries may be deleted under --max-delete=3"
+    );
+}

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -267,6 +267,28 @@ impl ReceiverContext {
             dirs_to_scan.len()
         );
 
+        // --max-delete must count every filesystem entry actually removed,
+        // including the leaves inside an extraneous directory, and stop
+        // mid-traversal once the limit is reached. The parallel path below
+        // removes a doomed subdirectory wholesale (`recursive_unlinkat`) and
+        // counts it as a single deletion, silently exceeding the cap for
+        // directory subtrees. Route capped runs through a serial,
+        // leaf-granular executor that mirrors upstream delete.c:156/181
+        // (guard-before-delete, increment-on-success).
+        if let Some(limit) = max_delete {
+            return self.delete_extraneous_files_capped(
+                dest_dir,
+                &dir_children,
+                &dirs_to_scan,
+                deletion_chain,
+                needs_perdir_merge,
+                #[cfg(unix)]
+                sandbox,
+                writer,
+                limit,
+            );
+        }
+
         // Atomic counter for max_delete enforcement across parallel workers.
         // upstream: main.c:1367 - deletion_count >= max_delete
         let deletions_performed = Arc::new(AtomicU64::new(0));
@@ -643,6 +665,370 @@ impl ReceiverContext {
         let limit_exceeded = max_delete.is_some_and(|limit| total_deletions >= limit);
 
         Ok((combined, limit_exceeded, io_err_bits))
+    }
+
+    /// Serial, leaf-granular deletion path used when `--max-delete` is set.
+    ///
+    /// The parallel path counts a doomed subdirectory as a single deletion and
+    /// removes its subtree wholesale, so a directory holding N files costs one
+    /// unit against the cap even though N+1 filesystem entries vanish. That
+    /// undercount lets a small `--max-delete` value silently remove an
+    /// unbounded number of files. This path walks every candidate depth-first
+    /// in upstream reverse-sorted order and checks the cap before each
+    /// individual removal, counting only successful deletions, mirroring
+    /// upstream `delete.c:delete_item`/`delete_dir_contents`
+    /// (`delete.c:156` guard, `delete.c:181` increment). Directory processing
+    /// order is the same ascending `dirs_to_scan` order used elsewhere; the
+    /// per-entry unlink and scan still route through the SEC-1.q2 sandbox
+    /// helpers so the security posture is unchanged.
+    #[allow(clippy::too_many_arguments)]
+    fn delete_extraneous_files_capped<W: crate::writer::MsgInfoSender + ?Sized>(
+        &self,
+        dest_dir: &Path,
+        dir_children: &std::collections::HashMap<
+            PathBuf,
+            std::collections::HashSet<std::ffi::OsString>,
+        >,
+        dirs_to_scan: &[PathBuf],
+        deletion_chain: &filters::FilterChain,
+        needs_perdir_merge: bool,
+        #[cfg(unix)] sandbox: Option<&std::sync::Arc<fast_io::DirSandbox>>,
+        writer: &mut W,
+        limit: u64,
+    ) -> io::Result<(DeleteStats, bool, i32)> {
+        let mut state = CappedDeleteState {
+            dest_dir,
+            #[cfg(unix)]
+            sandbox,
+            limit,
+            deleted: 0,
+            skipped: 0,
+            combined: DeleteStats::new(),
+            io_err_bits: 0,
+            emit_itemize: self.should_emit_itemize(),
+            writer,
+        };
+
+        for dir_relative in dirs_to_scan {
+            // Stop scanning once the cap is exhausted: every further candidate
+            // would only add to the skipped count, and upstream stops issuing
+            // deletions the moment the limit is reached.
+            let dest_path = if dir_relative.as_os_str() == "." {
+                dest_dir.to_path_buf()
+            } else {
+                dest_dir.join(dir_relative)
+            };
+            let Some(keep) = dir_children.get(dir_relative) else {
+                continue;
+            };
+
+            // Reload this destination directory's per-directory merge rules so
+            // dir-merge self-exclusion and merge-driven excludes stay active,
+            // mirroring the parallel worker.
+            let local_chain = if needs_perdir_merge {
+                let mut chain = deletion_chain.clone();
+                chain.set_transfer_root(dest_dir.to_path_buf());
+                let _ = chain.enter_directory(dest_dir);
+                if dir_relative.as_os_str() != "." {
+                    let mut cur = dest_dir.to_path_buf();
+                    for comp in dir_relative.iter() {
+                        cur.push(comp);
+                        let _ = chain.enter_directory(&cur);
+                    }
+                }
+                Some(chain)
+            } else {
+                None
+            };
+
+            let scan_rel: &Path = if dir_relative.as_os_str() == "." {
+                Path::new("")
+            } else {
+                dir_relative.as_path()
+            };
+            let entries = match state.scan_dir(scan_rel, &dest_path) {
+                Ok(entries) => entries,
+                Err(e) => {
+                    if let Some(err) = fail_loud_unlink_error(e) {
+                        return Err(err);
+                    }
+                    // EACCES / NotFound: upstream leaves the directory alone.
+                    state.io_err_bits |= crate::generator::io_error_flags::IOERR_GENERAL;
+                    continue;
+                }
+            };
+
+            // Collect the extraneous candidates that survive the keep-set and
+            // filter rules, then visit them in upstream reverse-sorted order.
+            let mut candidates: Vec<CappedCandidate> = Vec::new();
+            for (name, is_dir, is_symlink) in entries {
+                let normalized = normalize_filename_for_compare(&name);
+                if keep.contains(&normalized) {
+                    continue;
+                }
+                let rel_for_filter = if dir_relative.as_os_str() == "." {
+                    PathBuf::from(&name)
+                } else {
+                    dir_relative.join(&name)
+                };
+                let allows = match &local_chain {
+                    Some(chain) => chain.allows_deletion(&rel_for_filter, is_dir),
+                    None => deletion_chain.allows_deletion(&rel_for_filter, is_dir),
+                };
+                if !allows {
+                    debug_log!(
+                        Del,
+                        3,
+                        "not deleting {} (protected by filter rule)",
+                        rel_for_filter.display()
+                    );
+                    continue;
+                }
+                candidates.push(CappedCandidate {
+                    name,
+                    rel: rel_for_filter,
+                    is_dir,
+                    is_symlink,
+                });
+            }
+            // upstream: delete_in_dir iterates the sorted dirlist in reverse.
+            // Sort ascending with the full comparator (files before dirs at a
+            // level) then reverse so the prefix deleted when the cap trips
+            // matches upstream's traversal.
+            candidates.sort_by(|a, b| f_name_cmp_full(&a.rel, a.is_dir, &b.rel, b.is_dir));
+            candidates.reverse();
+
+            for candidate in candidates {
+                let path = dest_path.join(&candidate.name);
+                state.remove_entry(
+                    &candidate.rel,
+                    &path,
+                    candidate.is_dir,
+                    candidate.is_symlink,
+                )?;
+            }
+        }
+
+        let CappedDeleteState {
+            combined,
+            skipped,
+            io_err_bits,
+            ..
+        } = state;
+        Ok((combined, skipped > 0, io_err_bits))
+    }
+}
+
+/// One extraneous destination entry awaiting a capped deletion decision.
+struct CappedCandidate {
+    name: std::ffi::OsString,
+    rel: PathBuf,
+    is_dir: bool,
+    is_symlink: bool,
+}
+
+/// Mutable bookkeeping threaded through the recursive capped deletion walk.
+struct CappedDeleteState<'w, W: ?Sized> {
+    dest_dir: &'w Path,
+    #[cfg(unix)]
+    sandbox: Option<&'w std::sync::Arc<fast_io::DirSandbox>>,
+    limit: u64,
+    /// Successful deletions so far - the global cap counter
+    /// (upstream `stats.deleted_files`).
+    deleted: u64,
+    /// Entries skipped because the cap was reached
+    /// (upstream `skipped_deletes`).
+    skipped: u64,
+    combined: DeleteStats,
+    io_err_bits: i32,
+    emit_itemize: bool,
+    writer: &'w mut W,
+}
+
+impl<W: crate::writer::MsgInfoSender + ?Sized> CappedDeleteState<'_, W> {
+    /// Lists the immediate children of `target_path` as
+    /// `(name, is_dir, is_symlink)`, routing through the sandbox helper on
+    /// Unix so the listing is anchored the same way as the parallel worker.
+    fn scan_dir(
+        &self,
+        relative: &Path,
+        target_path: &Path,
+    ) -> io::Result<Vec<(std::ffi::OsString, bool, bool)>> {
+        #[cfg(unix)]
+        {
+            let mut out = Vec::new();
+            let iter = fast_io::read_dir_via_sandbox_or_fallback(
+                self.sandbox.map(|a| &**a),
+                self.dest_dir,
+                relative,
+                target_path,
+            )?;
+            for entry in iter {
+                let view = match entry {
+                    Ok(view) => view,
+                    Err(_) => continue,
+                };
+                let kind = view.file_type();
+                out.push((
+                    view.file_name().to_os_string(),
+                    kind.is_some_and(fast_io::EntryKind::is_dir),
+                    kind.is_some_and(fast_io::EntryKind::is_symlink),
+                ));
+            }
+            Ok(out)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = relative;
+            let mut out = Vec::new();
+            for entry in std::fs::read_dir(target_path)? {
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+                let ft = entry.file_type().ok();
+                out.push((
+                    entry.file_name(),
+                    ft.as_ref().is_some_and(std::fs::FileType::is_dir),
+                    ft.as_ref().is_some_and(std::fs::FileType::is_symlink),
+                ));
+            }
+            Ok(out)
+        }
+    }
+
+    /// Recursively removes one extraneous entry under the cap. Returns `true`
+    /// when the entry was fully removed and `false` when it (or part of its
+    /// subtree) was left in place because the cap was reached.
+    fn remove_entry(
+        &mut self,
+        rel: &Path,
+        path: &Path,
+        is_dir: bool,
+        is_symlink: bool,
+    ) -> io::Result<bool> {
+        if is_dir && !is_symlink {
+            // Peel the directory's contents depth-first before considering the
+            // directory itself (upstream delete_dir_contents, reverse order).
+            let mut children = match self.scan_dir(rel, path) {
+                Ok(children) => children,
+                Err(e) => {
+                    if let Some(err) = fail_loud_unlink_error(e) {
+                        return Err(err);
+                    }
+                    self.io_err_bits |= crate::generator::io_error_flags::IOERR_GENERAL;
+                    return Ok(false);
+                }
+            };
+            children.sort_by(|a, b| f_name_cmp_full(Path::new(&a.0), a.1, Path::new(&b.0), b.1));
+            children.reverse();
+
+            let mut all_removed = true;
+            for (child_name, child_is_dir, child_is_symlink) in children {
+                let child_rel = rel.join(&child_name);
+                let child_path = path.join(&child_name);
+                if !self.remove_entry(&child_rel, &child_path, child_is_dir, child_is_symlink)? {
+                    all_removed = false;
+                }
+            }
+
+            if !all_removed {
+                // upstream: delete.c:117 - one notice per non-empty directory,
+                // not counted and not an I/O error.
+                info_log!(
+                    Nonreg,
+                    1,
+                    "cannot delete non-empty directory: {}",
+                    path.display().to_string().replace('\\', "/")
+                );
+                return Ok(false);
+            }
+
+            if self.deleted >= self.limit {
+                self.skipped = self.skipped.saturating_add(1);
+                return Ok(false);
+            }
+            return self.unlink_leaf(rel, path, true, false);
+        }
+
+        if self.deleted >= self.limit {
+            self.skipped = self.skipped.saturating_add(1);
+            return Ok(false);
+        }
+        self.unlink_leaf(rel, path, false, is_symlink)
+    }
+
+    /// Issues the actual removal for one leaf, updates the stats/itemize on
+    /// success, and applies the receiver's error policy on failure. Returns
+    /// `true` on a successful (or vanished) removal.
+    fn unlink_leaf(
+        &mut self,
+        rel: &Path,
+        path: &Path,
+        is_dir: bool,
+        is_symlink: bool,
+    ) -> io::Result<bool> {
+        let result = self.raw_unlink(rel, path, is_dir);
+        match result {
+            Ok(()) => {
+                self.deleted = self.deleted.saturating_add(1);
+                if is_dir {
+                    self.combined.dirs = self.combined.dirs.saturating_add(1);
+                } else if is_symlink {
+                    self.combined.symlinks = self.combined.symlinks.saturating_add(1);
+                } else {
+                    self.combined.files = self.combined.files.saturating_add(1);
+                }
+                // upstream: log.c:log_delete() emits one line per deleted item.
+                if is_dir {
+                    info_log!(Del, 1, "deleting {}/", rel.display());
+                } else {
+                    info_log!(Del, 1, "deleting {}", rel.display());
+                }
+                if self.emit_itemize {
+                    let line = format!("*deleting   {}\n", rel.display());
+                    let _ = self.writer.send_msg_info(line.as_bytes());
+                }
+                Ok(true)
+            }
+            Err(e) => {
+                debug_log!(Del, 1, "failed to delete {}: {}", path.display(), e);
+                if let Some(err) = fail_loud_unlink_error(e) {
+                    return Err(err);
+                }
+                // EACCES / NotFound: upstream leaves the entry and continues.
+                Ok(false)
+            }
+        }
+    }
+
+    /// Performs the unlink/rmdir syscall, anchored through the sandbox helper
+    /// on Unix.
+    fn raw_unlink(&self, rel: &Path, path: &Path, is_dir: bool) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            let flags = if is_dir {
+                fast_io::UnlinkFlags::Dir
+            } else {
+                fast_io::UnlinkFlags::File
+            };
+            fast_io::unlink_via_sandbox_or_fallback(
+                self.sandbox.map(|a| &**a),
+                self.dest_dir,
+                rel,
+                path,
+                flags,
+            )
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = rel;
+            if is_dir {
+                std::fs::remove_dir(path)
+            } else {
+                std::fs::remove_file(path)
+            }
+        }
     }
 }
 

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -697,6 +697,7 @@ impl ReceiverContext {
         limit: u64,
     ) -> io::Result<(DeleteStats, bool, i32)> {
         let mut state = CappedDeleteState {
+            #[cfg(unix)]
             dest_dir,
             #[cfg(unix)]
             sandbox,
@@ -841,6 +842,9 @@ struct CappedCandidate {
 
 /// Mutable bookkeeping threaded through the recursive capped deletion walk.
 struct CappedDeleteState<'w, W: ?Sized> {
+    // Only read by the Unix sandbox-anchored scan path; the non-Unix scan
+    // walks `target_path` directly, so gate the field like `sandbox` below.
+    #[cfg(unix)]
     dest_dir: &'w Path,
     #[cfg(unix)]
     sandbox: Option<&'w std::sync::Arc<fast_io::DirSandbox>>,

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -812,9 +812,21 @@ impl ReceiverContext {
         let CappedDeleteState {
             combined,
             skipped,
-            io_err_bits,
+            mut io_err_bits,
             ..
         } = state;
+        if skipped > 0 {
+            // upstream: generator.c:2430-2434 - one warning after the pass, then
+            // `io_error |= IOERR_DEL_LIMIT` so the run exits RERR_DEL_LIMIT (25).
+            // Nonreg renders at the default verbosity (info_verbosity[0]), the
+            // same channel the sibling delete notices use.
+            info_log!(
+                Nonreg,
+                1,
+                "Deletions stopped due to --max-delete limit ({skipped} skipped)"
+            );
+            io_err_bits |= crate::generator::io_error_flags::IOERR_DEL_LIMIT;
+        }
         Ok((combined, skipped > 0, io_err_bits))
     }
 }


### PR DESCRIPTION
## Problem

\`--max-delete=N\` is a data-safety limit, but oc-rsync could delete far more than N filesystem entries — and over the network it enforced no limit at all.

Verified against rsync 3.4.3 (before this PR):

| scenario | upstream | oc (before) |
|---|---|---|
| local: dir(5 files)+2 loose, \`--max-delete=3\` | 3 deleted, 4 skipped, **exit 25** | **8 deleted, exit 25 (undercount: dir counted as 1)** |
| ssh-pull: dir(5)+2 loose, \`--max-delete=3\` | 3 deleted, **exit 25**, warning | **8 deleted, exit 0, no warning** |
| ssh-pull: 5 flat files, \`--max-delete=2\` | 2 deleted, exit 25 | **5 deleted, exit 0** |

Three distinct defects:

1. **Directory undercount (local + remote).** The delete pass counted an extraneous directory as a single deletion and removed its subtree wholesale (\`remove_dir_all\` / \`recursive_unlinkat\`), so a directory of many files cost one unit against the cap. upstream \`delete.c:156\`/\`:181\` guards and counts *each* removed leaf.
2. **\`--max-delete\` not plumbed to the remote-shell pull receiver.** \`build_server_config\` set \`deletion.late_delete\`/\`delete_excluded\` but never \`deletion.max_delete\`, so a pull silently ignored the cap entirely (unbounded deletion).
3. **No warning / exit 25 over the wire.** The receiver computed the skipped count but never emitted the \`Deletions stopped due to --max-delete limit (N skipped)\` warning or set \`IOERR_DEL_LIMIT\`.

## Fix

- **engine / transfer:** enforce the cap at leaf granularity during execution — check \`deleted >= max_delete\` before every entry (each file and each recursive directory leaf), count only successful removals, walk candidates depth-first in upstream reverse-sorted order, stop at the limit leaving the remainder in place, emit \`cannot delete non-empty directory\`, and exit \`RERR_DEL_LIMIT\` (25). The uncapped (no \`--max-delete\`) paths are untouched, preserving the parallel fast path.
- **core:** carry \`config.max_delete()\` onto the remote-shell pull receiver config so the cap engages over SSH.
- **transfer:** on cap hit, emit the stop warning and set \`IOERR_DEL_LIMIT\` so \`to_exit_code\` yields 25.

## Verification (rsync 3.4.3, Linux)

After this PR, oc matches upstream on count, skipped, message and exit 25 for local, \`--delete-delay\`, ssh-pull (directory and flat) scenarios; the ssh-pull path matches byte-for-byte including which entries survive. No-op runs (\`--max-delete=0\`, nothing extraneous) stay exit 0. Regression tests added for leaf-counting inside a non-empty directory (plain and \`--delete-delay\`); all 29 engine max-delete and 33 transfer delete tests pass.