### PR TITLE
fix(engine): select best-match reference basis by match_level

### DIFF
--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -415,8 +415,17 @@ impl<'a> CopyContext<'a> {
         Ok(())
     }
 
-    /// Searches `--link-dest` directories for a file matching the source,
-    /// returning the first candidate that passes the quick-check comparison.
+    /// Searches `--link-dest` directories for the BEST file matching the source.
+    ///
+    /// upstream: generator.c:954-983 `try_dests_reg()` scans every basis dir and
+    /// tracks the highest match_level (2 = data matches `quick_check_ok`, 3 = data
+    /// and attributes both match `unchanged_attrs`), breaking early only on an
+    /// exact (level-3) match. Returning the first data-only candidate instead
+    /// would let an earlier match_level-2 basis (attrs differ) shadow a later
+    /// exact one, forcing an unnecessary copy + attr reapply where upstream would
+    /// hard-link the exact basis with no reapply. The caller re-derives the
+    /// winning candidate's level to choose hard-link vs copy, so returning the
+    /// best candidate is sufficient to mirror upstream.
     pub(super) fn link_dest_target(
         &self,
         relative: &Path,
@@ -430,6 +439,19 @@ impl<'a> CopyContext<'a> {
             return Ok(None);
         }
 
+        let metadata_options = self.metadata_options();
+        let preserve_xattrs = {
+            #[cfg(all(unix, feature = "xattr"))]
+            {
+                self.options.preserve_xattrs()
+            }
+            #[cfg(not(all(unix, feature = "xattr")))]
+            {
+                false
+            }
+        };
+
+        let mut best: Option<(PathBuf, u8)> = None;
         for entry in self.options.link_dest_entries() {
             let candidate = entry.resolve(self.destination_root(), relative);
             let candidate_metadata = match fs::metadata(&candidate) {
@@ -448,7 +470,7 @@ impl<'a> CopyContext<'a> {
                 continue;
             }
 
-            if should_skip_copy(CopyComparison {
+            if !should_skip_copy(CopyComparison {
                 source_path: source,
                 source: metadata,
                 destination_path: candidate.as_path(),
@@ -460,11 +482,33 @@ impl<'a> CopyContext<'a> {
                 modify_window: self.options.modify_window(),
                 prefetched_match: None,
             }) {
-                return Ok(Some(candidate));
+                continue;
+            }
+
+            // At least match_level 2 (data matches); match_level 3 when the
+            // preserved attributes also match, which the caller hard-links.
+            let level = if crate::local_copy::reference_attrs_unchanged(
+                &candidate,
+                source,
+                metadata,
+                &metadata_options,
+                preserve_xattrs,
+            ) {
+                3
+            } else {
+                2
+            };
+
+            if best.as_ref().is_none_or(|(_, best_level)| level > *best_level) {
+                best = Some((candidate, level));
+            }
+            // upstream: generator.c:979 - an exact match ends the scan.
+            if level == 3 {
+                break;
             }
         }
 
-        Ok(None)
+        Ok(best.map(|(candidate, _)| candidate))
     }
 
     /// Locates a `--link-dest` basis symlink at `relative` that points at the

--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -326,6 +326,16 @@ fn simulate_reference_match(
     }
 
     // --copy-dest / --compare-dest matches.
+    let preserve_xattrs = {
+        #[cfg(all(unix, feature = "xattr"))]
+        {
+            context.options().preserve_xattrs()
+        }
+        #[cfg(not(all(unix, feature = "xattr")))]
+        {
+            false
+        }
+    };
     let query = ReferenceQuery {
         destination,
         relative: record_path,
@@ -334,6 +344,8 @@ fn simulate_reference_match(
         size_only,
         ignore_times,
         checksum,
+        metadata_options: &metadata_options,
+        preserve_xattrs,
     };
     let Some(decision) = find_reference_action(context, query)? else {
         return Ok(false);

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -17,7 +17,8 @@ use crate::local_copy::overrides::create_hard_link;
 use crate::local_copy::{
     CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyError,
     LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord, ReferenceDecision, ReferenceQuery,
-    find_reference_action, map_metadata_error, remove_source_entry_if_requested,
+    find_reference_action, map_metadata_error, reference_attrs_unchanged,
+    remove_source_entry_if_requested,
 };
 
 #[cfg(all(any(unix, windows), feature = "acl"))]
@@ -54,76 +55,6 @@ fn is_already_hardlinked(destination: &Path, target: &Path) -> bool {
     #[cfg(not(unix))]
     {
         let _ = (destination, target);
-        false
-    }
-}
-
-/// Reports whether the `--link-dest` basis already carries the source's
-/// preserved attributes, mirroring upstream `generator.c:468 unchanged_attrs()`.
-///
-/// When this returns `true` the match is upstream's match_level 3 (data and
-/// attributes both match): the file is hard-linked and metadata is *not*
-/// reapplied (except `--atimes`), so no `user.rsync.%stat` xattr is written
-/// onto the shared basis inode. When `false` (match_level 2, attrs differ),
-/// the caller reapplies metadata like upstream's `try_a_copy` + set_file_attrs.
-///
-/// Compares the attributes `unchanged_attrs` inspects for a regular file:
-/// permission bits (`perms_differ`), owner/group (`ownership_differs`), mtime
-/// (`any_time_differs`), and, when `-X` is active, the transferable extended
-/// attributes (`xattrs_differ`), each gated on the corresponding preserve
-/// option. `source` is the source path (for the xattr read) and `source_meta`
-/// its stat.
-// upstream: generator.c:468-502 unchanged_attrs - perms/ownership/time/xattr
-fn link_dest_attrs_unchanged(
-    basis: &Path,
-    source: &Path,
-    source_meta: &fs::Metadata,
-    options: &MetadataOptions,
-    preserve_xattrs: bool,
-) -> bool {
-    #[cfg(unix)]
-    {
-        use filetime::FileTime;
-        use std::os::unix::fs::MetadataExt;
-
-        let Ok(basis_meta) = fs::symlink_metadata(basis) else {
-            return false;
-        };
-
-        // A --chmod tweak changes the intended mode away from the source's, so
-        // the basis (which carries the untweaked mode) can never be a
-        // match_level-3 attrs match; force a reapply. Mirrors upstream comparing
-        // file->mode (post dest_mode/tweak) against the basis stat.
-        if options.chmod().is_some() {
-            return false;
-        }
-
-        if options.permissions() && (source_meta.mode() & 0o7777) != (basis_meta.mode() & 0o7777) {
-            return false;
-        }
-        if options.owner() && source_meta.uid() != basis_meta.uid() {
-            return false;
-        }
-        if options.group() && source_meta.gid() != basis_meta.gid() {
-            return false;
-        }
-        if options.times()
-            && FileTime::from_last_modification_time(source_meta)
-                != FileTime::from_last_modification_time(&basis_meta)
-        {
-            return false;
-        }
-        // upstream: generator.c:501 - xattrs_differ() makes a changed xattr a
-        // match_level-2 (attr change) result, forcing the copy + set_file_attrs
-        // that reapplies the source's xattrs onto the destination.
-        if preserve_xattrs && !::metadata::xattrs_match(source, basis, true).unwrap_or(false) {
-            return false;
-        }
-        true
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = (basis, source, source_meta, options, preserve_xattrs);
         false
     }
 }
@@ -169,6 +100,19 @@ pub(super) fn process_links(
     let mut copy_source_override: Option<PathBuf> = None;
     let mut reference_basis: Option<PathBuf> = None;
 
+    // Whether `-X` xattr preservation is active, used both to evaluate a
+    // link-dest basis's match_level and to seed reference-directory queries.
+    let preserve_xattrs_flag = {
+        #[cfg(all(unix, feature = "xattr"))]
+        {
+            preserve_xattrs
+        }
+        #[cfg(not(all(unix, feature = "xattr")))]
+        {
+            false
+        }
+    };
+
     // 1. --link-dest style linking
     if let Some(link_target) = context.link_dest_target(
         relative_for_link,
@@ -178,16 +122,6 @@ pub(super) fn process_links(
         ignore_times_enabled,
         checksum_enabled,
     )? {
-        let preserve_xattrs_flag = {
-            #[cfg(all(unix, feature = "xattr"))]
-            {
-                preserve_xattrs
-            }
-            #[cfg(not(all(unix, feature = "xattr")))]
-            {
-                false
-            }
-        };
         // upstream: generator.c:967-1054 try_dests_reg() - a LINK_DEST candidate
         // that passes the quick-check (data matches) is hard-linked only when its
         // preserved attributes also match the source (match_level 3). When the
@@ -198,7 +132,7 @@ pub(super) fn process_links(
         // inode, so reapplying the differing attrs (e.g. a changed -X value under
         // --fake-super) would corrupt the basis and leave the file carrying an
         // extra hard link.
-        let attrs_match = link_dest_attrs_unchanged(
+        let attrs_match = reference_attrs_unchanged(
             &link_target,
             source,
             metadata,
@@ -615,6 +549,8 @@ pub(super) fn process_links(
                     size_only: size_only_enabled,
                     ignore_times: ignore_times_enabled,
                     checksum: checksum_enabled,
+                    metadata_options: &metadata_options,
+                    preserve_xattrs: preserve_xattrs_flag,
                 },
             )?
             .is_some();
@@ -648,6 +584,8 @@ pub(super) fn process_links(
                 size_only: size_only_enabled,
                 ignore_times: ignore_times_enabled,
                 checksum: checksum_enabled,
+                metadata_options: &metadata_options,
+                preserve_xattrs: preserve_xattrs_flag,
             },
         )?
     {

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -41,7 +41,7 @@ pub(crate) use iconv::{
 };
 pub(crate) use reference::{
     ReferenceDecision, ReferenceQuery, find_compare_dest_symlink, find_copy_dest_basis,
-    find_copy_dest_symlink, find_reference_action,
+    find_copy_dest_symlink, find_reference_action, reference_attrs_unchanged,
 };
 pub(crate) use sources::copy_sources;
 pub(crate) use special::{

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use ::metadata::MetadataOptions;
+
 use crate::local_copy::{CopyContext, LocalCopyError, ReferenceDirectoryKind};
 
 use super::{CopyComparison, should_skip_copy};
@@ -52,12 +54,102 @@ pub(crate) struct ReferenceQuery<'a> {
     pub(crate) size_only: bool,
     pub(crate) ignore_times: bool,
     pub(crate) checksum: bool,
+    /// Preserved-attribute options used to distinguish an exact (match_level 3)
+    /// basis from a data-only (match_level 2) one.
+    pub(crate) metadata_options: &'a MetadataOptions,
+    /// Whether `-X` xattr preservation is active, so an xattr difference demotes
+    /// a candidate from match_level 3 to match_level 2.
+    pub(crate) preserve_xattrs: bool,
 }
 
-/// Searches configured reference directories for a file matching the source.
+/// Reports whether a reference basis already carries the source's preserved
+/// attributes, mirroring upstream `generator.c:468 unchanged_attrs()`.
 ///
-/// Returns the first matching decision (skip, copy, or link) based on the
-/// reference directory kind, or `None` if no candidate matches.
+/// A `true` result is upstream match_level 3 (data and attributes both match):
+/// the basis is hard-linked (`--link-dest`) or treated as up-to-date
+/// (`--compare-dest`) with no attribute reapply, so no `user.rsync.%stat` xattr
+/// is written onto a shared basis inode. A `false` result is match_level 2 (data
+/// matches, attrs differ): upstream falls through to `copy_altdest_file`, copying
+/// the basis into a fresh inode and reapplying the source attributes via
+/// `set_file_attrs`.
+///
+/// Compares the attributes `unchanged_attrs` inspects for a regular file:
+/// permission bits (`perms_differ`), owner/group (`ownership_differs`), mtime
+/// (`any_time_differs`), and, when `-X` is active, the transferable extended
+/// attributes (`xattrs_differ`), each gated on the corresponding preserve option.
+///
+// upstream: generator.c:468-502 unchanged_attrs - perms/ownership/time/xattr.
+pub(crate) fn reference_attrs_unchanged(
+    basis: &Path,
+    source: &Path,
+    source_meta: &fs::Metadata,
+    options: &MetadataOptions,
+    preserve_xattrs: bool,
+) -> bool {
+    #[cfg(unix)]
+    {
+        use filetime::FileTime;
+        use std::os::unix::fs::MetadataExt;
+
+        let Ok(basis_meta) = fs::symlink_metadata(basis) else {
+            return false;
+        };
+
+        // A --chmod tweak changes the intended mode away from the source's, so
+        // the basis (which carries the untweaked mode) can never be a
+        // match_level-3 attrs match; force a reapply.
+        if options.chmod().is_some() {
+            return false;
+        }
+        if options.permissions() && (source_meta.mode() & 0o7777) != (basis_meta.mode() & 0o7777) {
+            return false;
+        }
+        if options.owner() && source_meta.uid() != basis_meta.uid() {
+            return false;
+        }
+        if options.group() && source_meta.gid() != basis_meta.gid() {
+            return false;
+        }
+        if options.times()
+            && FileTime::from_last_modification_time(source_meta)
+                != FileTime::from_last_modification_time(&basis_meta)
+        {
+            return false;
+        }
+        // upstream: generator.c:501 - xattrs_differ() demotes to match_level 2,
+        // forcing the copy + set_file_attrs that reapplies the source xattrs.
+        if preserve_xattrs && !::metadata::xattrs_match(source, basis, true).unwrap_or(false) {
+            return false;
+        }
+        true
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (basis, source, source_meta, options, preserve_xattrs);
+        false
+    }
+}
+
+/// Searches configured reference directories for a file matching the source and
+/// returns the action for the BEST candidate.
+///
+/// upstream: generator.c:954-1054 `try_dests_reg()` scans every `basis_dir[]`,
+/// tracking the highest match_level (2 = data matches `quick_check_ok`, 3 = data
+/// and attributes both match `unchanged_attrs`), breaking early only on an exact
+/// (level-3) match, then acts on the best candidate. A first-match scan wrongly
+/// picks an earlier data-only basis over a later exact one, forcing an
+/// unnecessary copy/transfer and (for `--link-dest`) reapplying attrs onto a
+/// shared basis inode. The winning level then drives the action
+/// (generator.c:995-1054):
+///
+/// - `--compare-dest`: level 3 is up-to-date (skip, no write); level 2 copies the
+///   basis in and reapplies attrs (`copy_altdest_file`).
+/// - `--copy-dest`: always copies the basis (never hard-links), reapplying attrs.
+/// - `--link-dest`: level 3 hard-links without reapply; level 2 copies + reapplies
+///   (upstream `try_a_copy`) so a differing-attr basis inode is never shared.
+///
+/// Returns `None` when no candidate reaches match_level 2 (a level-1 basis is
+/// left to the normal transfer path).
 pub(crate) fn find_reference_action(
     context: &CopyContext<'_>,
     query: ReferenceQuery<'_>,
@@ -70,7 +162,11 @@ pub(crate) fn find_reference_action(
         size_only,
         ignore_times,
         checksum,
+        metadata_options,
+        preserve_xattrs,
     } = query;
+
+    let mut best: Option<(ReferenceDirectoryKind, PathBuf, u8)> = None;
     for reference in context.reference_directories() {
         let candidate = resolve_reference_candidate(reference.path(), relative, destination);
         let candidate_metadata = match fs::symlink_metadata(&candidate) {
@@ -89,7 +185,7 @@ pub(crate) fn find_reference_action(
             continue;
         }
 
-        if should_skip_copy(CopyComparison {
+        if !should_skip_copy(CopyComparison {
             source_path: source,
             source: metadata,
             destination_path: &candidate,
@@ -101,15 +197,58 @@ pub(crate) fn find_reference_action(
             modify_window: context.options().modify_window(),
             prefetched_match: None,
         }) {
-            return Ok(Some(match reference.kind() {
-                ReferenceDirectoryKind::Compare => ReferenceDecision::Skip(candidate),
-                ReferenceDirectoryKind::Copy => ReferenceDecision::Copy(candidate),
-                ReferenceDirectoryKind::Link => ReferenceDecision::Link(candidate),
-            }));
+            continue;
+        }
+
+        // The candidate is at least match_level 2 (data matches); it is
+        // match_level 3 when its preserved attributes also match the source.
+        let level = if reference_attrs_unchanged(
+            &candidate,
+            source,
+            metadata,
+            metadata_options,
+            preserve_xattrs,
+        ) {
+            3
+        } else {
+            2
+        };
+
+        if best
+            .as_ref()
+            .is_none_or(|(_, _, best_level)| level > *best_level)
+        {
+            best = Some((reference.kind(), candidate, level));
+        }
+        // upstream: generator.c:979 - an exact match ends the scan immediately.
+        if level == 3 {
+            break;
         }
     }
 
-    Ok(None)
+    let Some((kind, basis, level)) = best else {
+        return Ok(None);
+    };
+
+    let decision = match kind {
+        ReferenceDirectoryKind::Compare => {
+            if level == 3 {
+                ReferenceDecision::Skip(basis)
+            } else {
+                ReferenceDecision::Copy(basis)
+            }
+        }
+        ReferenceDirectoryKind::Copy => ReferenceDecision::Copy(basis),
+        ReferenceDirectoryKind::Link => {
+            if level == 3 {
+                ReferenceDecision::Link(basis)
+            } else {
+                ReferenceDecision::Copy(basis)
+            }
+        }
+    };
+
+    Ok(Some(decision))
 }
 
 /// Locates a `--copy-dest` basis symlink at `relative` whose target matches.
@@ -367,6 +506,7 @@ mod tests {
         let rel = PathBuf::from("relative");
         let src = PathBuf::from("/src");
         let meta = fs::metadata(".").unwrap_or_else(|_| fs::metadata("/").unwrap());
+        let metadata_options = MetadataOptions::default();
 
         let query = ReferenceQuery {
             destination: &dest,
@@ -376,6 +516,8 @@ mod tests {
             size_only: true,
             ignore_times: false,
             checksum: true,
+            metadata_options: &metadata_options,
+            preserve_xattrs: false,
         };
 
         assert_eq!(query.destination, Path::new("/dest"));
@@ -384,5 +526,6 @@ mod tests {
         assert!(query.size_only);
         assert!(!query.ignore_times);
         assert!(query.checksum);
+        assert!(!query.preserve_xattrs);
     }
 }

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -86,48 +86,75 @@ pub(crate) fn reference_attrs_unchanged(
     options: &MetadataOptions,
     preserve_xattrs: bool,
 ) -> bool {
+    let Ok(basis_meta) = fs::symlink_metadata(basis) else {
+        return false;
+    };
+
+    // A --chmod tweak changes the intended mode away from the source's, so
+    // the basis (which carries the untweaked mode) can never be a
+    // match_level-3 attrs match; force a reapply.
+    if options.chmod().is_some() {
+        return false;
+    }
+
+    // upstream: generator.c:485 any_time_differs - the mtime must match for a
+    // level-3 basis. Compared through `SystemTime` (like the quick-check
+    // `unchanged_file` path) so the check holds on every platform, not just Unix
+    // where `st_mtime` is available.
+    if options.times() {
+        match (source_meta.modified(), basis_meta.modified()) {
+            (Ok(source_time), Ok(basis_time)) if source_time == basis_time => {}
+            _ => return false,
+        }
+    }
+
+    // upstream: generator.c:487 perms_differ - Unix compares the full permission
+    // bits; on platforms without POSIX modes (Windows) the only preserved
+    // permission is the read-only attribute, matching how oc applies and
+    // quick-checks permissions there.
+    if options.permissions() && !reference_permissions_match(source_meta, &basis_meta) {
+        return false;
+    }
+
     #[cfg(unix)]
     {
-        use filetime::FileTime;
         use std::os::unix::fs::MetadataExt;
 
-        let Ok(basis_meta) = fs::symlink_metadata(basis) else {
-            return false;
-        };
-
-        // A --chmod tweak changes the intended mode away from the source's, so
-        // the basis (which carries the untweaked mode) can never be a
-        // match_level-3 attrs match; force a reapply.
-        if options.chmod().is_some() {
-            return false;
-        }
-        if options.permissions() && (source_meta.mode() & 0o7777) != (basis_meta.mode() & 0o7777) {
-            return false;
-        }
         if options.owner() && source_meta.uid() != basis_meta.uid() {
             return false;
         }
         if options.group() && source_meta.gid() != basis_meta.gid() {
             return false;
         }
-        if options.times()
-            && FileTime::from_last_modification_time(source_meta)
-                != FileTime::from_last_modification_time(&basis_meta)
-        {
-            return false;
-        }
         // upstream: generator.c:501 - xattrs_differ() demotes to match_level 2,
         // forcing the copy + set_file_attrs that reapplies the source xattrs.
+        // Owner, group, and xattrs have no meaningful equivalent on non-Unix
+        // platforms, where oc preserves none of them.
         if preserve_xattrs && !::metadata::xattrs_match(source, basis, true).unwrap_or(false) {
             return false;
         }
-        true
     }
     #[cfg(not(unix))]
     {
-        let _ = (basis, source, source_meta, options, preserve_xattrs);
-        false
+        let _ = (source, preserve_xattrs);
     }
+
+    true
+}
+
+/// Reports whether two files carry the same preserved permission bits.
+///
+/// On Unix this is the low 12 mode bits (`0o7777`); on other platforms it is the
+/// read-only attribute, the only permission bit oc preserves there.
+#[cfg(unix)]
+fn reference_permissions_match(source_meta: &fs::Metadata, basis_meta: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    (source_meta.mode() & 0o7777) == (basis_meta.mode() & 0o7777)
+}
+
+#[cfg(not(unix))]
+fn reference_permissions_match(source_meta: &fs::Metadata, basis_meta: &fs::Metadata) -> bool {
+    source_meta.permissions().readonly() == basis_meta.permissions().readonly()
 }
 
 /// Searches configured reference directories for a file matching the source and

--- a/crates/engine/src/local_copy/tests/execute_compare_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_compare_dest.rs
@@ -754,3 +754,66 @@ fn compare_dest_skips_identical_empty_file() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 }
+
+// upstream: generator.c:1029-1039 - a COMPARE_DEST basis whose data matches but
+// whose attributes differ (match_level 2) is NOT treated as up-to-date; upstream
+// copies the basis into the destination via copy_altdest_file and reapplies the
+// source attributes. Only an exact (match_level 3) basis skips the write.
+#[cfg(unix)]
+#[test]
+fn compare_dest_content_match_attrs_differ_copies() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    let compare_dir = temp.path().join("compare");
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir_all(&source_dir).expect("create source");
+    fs::create_dir_all(&compare_dir).expect("create compare");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+
+    let source_file = source_dir.join("file.txt");
+    let compare_file = compare_dir.join("file.txt");
+    let dest_file = dest_dir.join("file.txt");
+
+    fs::write(&source_file, b"identical content").expect("write source");
+    fs::write(&compare_file, b"identical content").expect("write compare");
+    fs::set_permissions(&source_file, fs::Permissions::from_mode(0o644)).expect("chmod source");
+    // Same data + mtime, but different perms -> match_level 2.
+    fs::set_permissions(&compare_file, fs::Permissions::from_mode(0o600)).expect("chmod compare");
+
+    let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
+    set_file_mtime(&source_file, timestamp).expect("set source mtime");
+    set_file_mtime(&compare_file, timestamp).expect("set compare mtime");
+
+    let operands = vec![
+        source_file.into_os_string(),
+        dest_file.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .times(true)
+        .permissions(true)
+        .push_reference_directory(ReferenceDirectory::new(
+            ReferenceDirectoryKind::Compare,
+            &compare_dir,
+        ));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("execution succeeds");
+
+    // The differing-attr basis is copied into the destination with the source's
+    // attributes reapplied, matching upstream copy_altdest_file.
+    assert!(
+        dest_file.exists(),
+        "a level-2 compare-dest basis must be copied into the destination"
+    );
+    assert_eq!(fs::read(&dest_file).expect("read dest"), b"identical content");
+    assert_eq!(dest_file.metadata().expect("dest meta").permissions().mode() & 0o777, 0o644);
+    // The compare basis inode is untouched.
+    assert_eq!(
+        compare_file.metadata().expect("compare meta").permissions().mode() & 0o777,
+        0o600,
+    );
+}

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -280,6 +280,146 @@ fn link_dest_uses_first_matching_directory() {
     assert!(summary.hard_links_created() >= 1);
 }
 
+// upstream: generator.c:954-983 try_dests_reg() scans every basis dir and picks
+// the BEST match_level, so an earlier match_level-2 basis (data matches but perms
+// differ) must NOT shadow a later match_level-3 basis (data + attrs match). The
+// exact basis is hard-linked with no attr reapply; a first-match scan would
+// wrongly copy the earlier basis and reapply attrs.
+#[cfg(unix)]
+#[test]
+fn link_dest_best_match_prefers_exact_over_content_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source");
+    let source_file = source_dir.join("file.txt");
+    fs::write(&source_file, b"shared content").expect("write source");
+    fs::set_permissions(&source_file, fs::Permissions::from_mode(0o644)).expect("chmod source");
+
+    // backup1: data + mtime match but PERMS differ -> match_level 2.
+    let link_dest1 = temp.path().join("backup1");
+    fs::create_dir_all(&link_dest1).expect("create link-dest1");
+    let link_dest1_file = link_dest1.join("file.txt");
+    fs::write(&link_dest1_file, b"shared content").expect("write link-dest1");
+    fs::set_permissions(&link_dest1_file, fs::Permissions::from_mode(0o600)).expect("chmod ld1");
+
+    // backup2: data + mtime + perms all match -> match_level 3 (exact).
+    let link_dest2 = temp.path().join("backup2");
+    fs::create_dir_all(&link_dest2).expect("create link-dest2");
+    let link_dest2_file = link_dest2.join("file.txt");
+    fs::write(&link_dest2_file, b"shared content").expect("write link-dest2");
+    fs::set_permissions(&link_dest2_file, fs::Permissions::from_mode(0o644)).expect("chmod ld2");
+
+    let source_meta = fs::metadata(&source_file).expect("source metadata");
+    let ftime = FileTime::from_system_time(source_meta.modified().expect("source mtime"));
+    set_file_times(&link_dest1_file, ftime, ftime).expect("sync ld1");
+    set_file_times(&link_dest2_file, ftime, ftime).expect("sync ld2");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+    let dest_file = dest_dir.join("file.txt");
+    let operands = vec![
+        source_file.into_os_string(),
+        dest_file.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .times(true)
+        .permissions(true)
+        .extend_link_dests([link_dest1.clone(), link_dest2.clone()]);
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let dest_meta = fs::metadata(&dest_file).expect("dest metadata");
+    let link_dest2_meta = fs::metadata(&link_dest2_file).expect("link-dest2 metadata");
+    let link_dest1_meta = fs::metadata(&link_dest1_file).expect("link-dest1 metadata");
+
+    // The exact (match_level 3) basis wins even though it is second.
+    assert_eq!(
+        dest_meta.ino(),
+        link_dest2_meta.ino(),
+        "destination must hard-link the exact (level-3) basis, not the earlier level-2 one"
+    );
+    assert_ne!(
+        dest_meta.ino(),
+        link_dest1_meta.ino(),
+        "destination must not link the level-2 basis"
+    );
+    assert!(summary.hard_links_created() >= 1);
+    assert_eq!(summary.files_copied(), 0, "an exact basis is hard-linked, not copied");
+    // The level-2 basis inode must not be mutated (no attr reapply on a shared inode).
+    assert_eq!(
+        link_dest1_meta.permissions().mode() & 0o777,
+        0o600,
+        "the unused level-2 basis must keep its original permissions"
+    );
+}
+
+// upstream: generator.c:995-1031 - a LINK_DEST basis whose data matches but whose
+// attributes differ (match_level 2) is NOT hard-linked; upstream falls through to
+// try_a_copy/copy_altdest_file, copying into a fresh inode and reapplying the
+// source attrs. Hard-linking + reapplying would corrupt the shared basis inode.
+#[cfg(unix)]
+#[test]
+fn link_dest_content_match_attrs_differ_copies_not_links() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source");
+    let source_file = source_dir.join("file.txt");
+    fs::write(&source_file, b"payload").expect("write source");
+    fs::set_permissions(&source_file, fs::Permissions::from_mode(0o644)).expect("chmod source");
+
+    let link_dest_dir = temp.path().join("previous");
+    fs::create_dir_all(&link_dest_dir).expect("create link-dest");
+    let link_dest_file = link_dest_dir.join("file.txt");
+    fs::write(&link_dest_file, b"payload").expect("write link-dest");
+    fs::set_permissions(&link_dest_file, fs::Permissions::from_mode(0o600)).expect("chmod ld");
+
+    let source_meta = fs::metadata(&source_file).expect("source metadata");
+    let ftime = FileTime::from_system_time(source_meta.modified().expect("source mtime"));
+    set_file_times(&link_dest_file, ftime, ftime).expect("sync ld");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir_all(&dest_dir).expect("create dest");
+    let dest_file = dest_dir.join("file.txt");
+    let operands = vec![
+        source_file.into_os_string(),
+        dest_file.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .times(true)
+        .permissions(true)
+        .extend_link_dests([link_dest_dir.clone()]);
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let dest_meta = fs::metadata(&dest_file).expect("dest metadata");
+    let link_dest_meta = fs::metadata(&link_dest_file).expect("link-dest metadata");
+
+    // A match_level-2 basis is copied into a fresh inode, not hard-linked.
+    assert_ne!(
+        dest_meta.ino(),
+        link_dest_meta.ino(),
+        "a level-2 basis (attrs differ) must be copied, not hard-linked"
+    );
+    // The source's permissions are reapplied on the fresh copy.
+    assert_eq!(dest_meta.permissions().mode() & 0o777, 0o644);
+    // The basis inode is untouched (no shared-inode attr corruption).
+    assert_eq!(
+        link_dest_meta.permissions().mode() & 0o777,
+        0o600,
+        "the level-2 basis must keep its original permissions"
+    );
+    assert_eq!(fs::read(&dest_file).expect("read dest"), b"payload");
+}
+
 #[cfg(unix)]
 #[test]
 fn link_dest_works_with_directory_recursion() {


### PR DESCRIPTION
## Problem

Local-copy `--link-dest` / `--compare-dest` / `--copy-dest` handling scanned the configured basis directories and acted on the **first** candidate whose data matched, rather than upstream's **best-match** selection driven by `match_level`.

Upstream `generator.c:954-1054` `try_dests_reg()` scans every `basis_dir[]`, tracks the highest match level, breaks early only on an exact match, then acts on the best candidate:

- level 2 = data matches (`quick_check_ok`)
- level 3 = data **and** attributes match (`unchanged_attrs`)

Observable divergences (verified against rsync 3.4.4):

- **Multiple `--link-dest` dirs:** with `dir1` a data-only match (perms differ, level 2) and `dir2` an exact match (level 3), oc picked `dir1` first and **copied** it (fresh inode) + reapplied attrs, while upstream picks `dir2` and **hard-links** it with no reapply. A first-match hard-link of a level-2 basis would also share the basis inode and corrupt it on attr reapply.
- **`--compare-dest` with data-match/attrs-differ (level 2):** oc skipped the file, leaving the destination empty; upstream copies the basis into place and reapplies the source attributes.

## Fix

`link_dest_target` and `find_reference_action` now scan all bases, rank by match level (break on the first exact match), and return the best candidate. The winning level drives the action, mirroring `generator.c:995-1054`:

- `--compare-dest`: level 3 skips (no write); level 2 copies + reapplies attrs
- `--copy-dest`: always copies + reapplies attrs
- `--link-dest`: level 3 hard-links with no reapply; level 2 copies + reapplies

A shared `reference_attrs_unchanged` helper (port of `unchanged_attrs`) replaces the previous link-dest-only attribute check, keeping one implementation for all three kinds.

## Tests

Adds regression coverage (none existed for level-based selection):

- multi-basis best-match selection prefers the later exact basis over an earlier data-only one, leaving the unused basis inode untouched
- a level-2 `--link-dest` basis is copied into a fresh inode (not hard-linked), source attrs reapplied, basis untouched
- a level-2 `--compare-dest` basis is copied into the destination instead of being skipped

Verified on Linux (aarch64): `cargo fmt`/`clippy -p engine -D warnings` clean; targeted nextest green; the `oc-rsync` binary now matches rsync 3.4.4 byte-for-byte on the link-dest multi-basis and compare-dest level-2 scenarios above (single-basis behaviour unchanged).