### PR TITLE
fix(transfer): match upstream sparse_end for network sparse writes

### DIFF
--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -160,6 +160,9 @@ pub mod platform_copy;
 /// Cross-platform abstraction seam for zero-copy file-to-socket transfer
 /// (`sendfile(2)` / `TransmitFile()`).
 pub mod platform_sendfile;
+/// Sparse-file hole punching via `fallocate(PUNCH_HOLE)` with a zero-write
+/// fallback, for reclaiming/zeroing basis blocks during in-place sparse writes.
+pub mod punch_hole;
 /// ReFS filesystem detection for Windows reflink support.
 pub mod refs_detect;
 /// Zero-copy file-to-socket transfer using `sendfile` with automatic fallback.
@@ -326,6 +329,7 @@ pub use platform_sendfile::{
     LinuxSendFile, MacOsSendFile, PlatformSendFile, SocketHandle, UnsupportedSendFile,
     WindowsTransmitFile, platform_default,
 };
+pub use punch_hole::punch_hole;
 pub use traits::{FileReader, FileWriter};
 
 #[cfg(all(target_os = "macos", feature = "macos-gcd"))]

--- a/crates/fast_io/src/punch_hole.rs
+++ b/crates/fast_io/src/punch_hole.rs
@@ -1,0 +1,126 @@
+//! Filesystem hole punching via `fallocate(PUNCH_HOLE)`.
+//!
+//! On Linux, uses `fallocate(2)` with `FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE`
+//! to deallocate blocks for a zero-filled region while preserving the file's
+//! logical length, then `FALLOC_FL_ZERO_RANGE` as a second tier. Both leave the
+//! region reading back as zeros. On platforms without hole-punch support (and
+//! when both `fallocate` tiers are rejected) it falls back to writing explicit
+//! zeros, matching upstream rsync's `do_punch_hole()` fallback in `syscall.c`.
+
+use std::fs::File;
+use std::io::{self, Seek, SeekFrom, Write};
+
+#[cfg(target_os = "linux")]
+use rustix::{
+    fs::{FallocateFlags, fallocate},
+    io::Errno,
+};
+
+/// Buffer size for the zero-write fallback. Matches upstream rsync's
+/// `do_punch_hole()` zero buffer sizing (`syscall.c`).
+const ZERO_WRITE_BUFFER_SIZE: usize = 32 * 1024;
+
+/// Punches a hole of `len` bytes at absolute offset `pos` in `file`, leaving the
+/// region reading back as zeros without allocating disk blocks where possible.
+///
+/// The file's logical length is left unchanged (`FALLOC_FL_KEEP_SIZE`); callers
+/// establish the final length with a separate `set_len`. On the zero-write
+/// fallback the file position ends at `pos + len`; on the `fallocate` fast paths
+/// the position is not moved (the caller does not depend on it).
+///
+/// Mirrors upstream rsync's `do_punch_hole()` (`syscall.c`).
+///
+/// # Errors
+///
+/// Returns an error if the zero-write fallback fails to seek or write.
+#[cfg(target_os = "linux")]
+pub fn punch_hole(file: &mut File, pos: u64, len: u64) -> io::Result<()> {
+    if len == 0 {
+        return Ok(());
+    }
+
+    // fallocate's offset/length args are signed; fall back when either would
+    // overflow i64.
+    if pos <= i64::MAX as u64 && len <= i64::MAX as u64 {
+        // upstream: syscall.c do_punch_hole() - PUNCH_HOLE | KEEP_SIZE first.
+        let punch_flags = FallocateFlags::PUNCH_HOLE | FallocateFlags::KEEP_SIZE;
+        match fallocate(&*file, punch_flags, pos, len) {
+            Ok(()) => return Ok(()),
+            Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => {}
+            Err(_) => {}
+        }
+        // ZERO_RANGE zeroes without allocation on filesystems that support it.
+        match fallocate(&*file, FallocateFlags::ZERO_RANGE, pos, len) {
+            Ok(()) => return Ok(()),
+            Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => {}
+            Err(_) => {}
+        }
+    }
+
+    write_zeros_fallback(file, pos, len)
+}
+
+/// Non-Linux platforms lack `fallocate(PUNCH_HOLE)`; overwrite the region with
+/// explicit zeros so stale basis data does not survive an in-place update.
+///
+/// # Errors
+///
+/// Returns an error if seeking or writing the zeros fails.
+#[cfg(not(target_os = "linux"))]
+pub fn punch_hole(file: &mut File, pos: u64, len: u64) -> io::Result<()> {
+    if len == 0 {
+        return Ok(());
+    }
+    write_zeros_fallback(file, pos, len)
+}
+
+/// Writes `len` zero bytes starting at absolute offset `pos`.
+///
+/// Final, universal fallback: unlike hole punching this allocates disk space,
+/// but it guarantees the region reads back as zeros (correctness over space).
+fn write_zeros_fallback(file: &mut File, pos: u64, mut len: u64) -> io::Result<()> {
+    file.seek(SeekFrom::Start(pos))?;
+    let zeros = [0u8; ZERO_WRITE_BUFFER_SIZE];
+    while len > 0 {
+        let chunk = len.min(ZERO_WRITE_BUFFER_SIZE as u64) as usize;
+        file.write_all(&zeros[..chunk])?;
+        len -= chunk as u64;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn punch_hole_zero_len_is_noop() {
+        let mut f = tempfile::tempfile().expect("tempfile");
+        f.write_all(&[1u8; 4096]).expect("write");
+        punch_hole(&mut f, 0, 0).expect("punch");
+        f.seek(SeekFrom::Start(0)).expect("seek");
+        let mut buf = [0u8; 4096];
+        f.read_exact(&mut buf).expect("read");
+        assert!(
+            buf.iter().all(|&b| b == 1),
+            "zero-len punch must not alter data"
+        );
+    }
+
+    #[test]
+    fn punch_hole_reads_back_zeros() {
+        let mut f = tempfile::tempfile().expect("tempfile");
+        f.write_all(&[0xABu8; 8192]).expect("write");
+        punch_hole(&mut f, 2048, 4096).expect("punch");
+        f.seek(SeekFrom::Start(0)).expect("seek");
+        let mut buf = [0u8; 8192];
+        f.read_exact(&mut buf).expect("read");
+        assert!(buf[..2048].iter().all(|&b| b == 0xAB), "prefix intact");
+        assert!(
+            buf[2048..6144].iter().all(|&b| b == 0),
+            "punched region reads zero"
+        );
+        assert!(buf[6144..].iter().all(|&b| b == 0xAB), "suffix intact");
+    }
+}

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -778,6 +778,13 @@ impl<'a> DeltaApplicator<'a> {
     ) -> io::Result<(File, DeltaApplyResult)> {
         if let Some(ref mut sparse) = self.sparse_state {
             let final_pos = sparse.finish(&mut self.output)?;
+            // upstream: fileio.c:43 sparse_end() - ftruncate to the logical
+            // length (leaving the trailing region a hole) and punch any
+            // in-basis zero runs, instead of materializing a trailing byte.
+            self.output.set_len(final_pos)?;
+            for (pos, len) in sparse.take_holes() {
+                fast_io::punch_hole(&mut self.output, pos, len)?;
+            }
             self.stats.final_pos = Some(final_pos);
             if let Some(expected) = expected_size {
                 if final_pos != expected {
@@ -931,6 +938,13 @@ impl<'a> DeltaApplicator<'a> {
 
         if let Some(ref mut sparse) = self.sparse_state {
             let final_pos = sparse.finish(&mut self.output)?;
+            // upstream: fileio.c:43 sparse_end() - ftruncate to the logical
+            // length (leaving the trailing region a hole) and punch any
+            // in-basis zero runs, instead of materializing a trailing byte.
+            self.output.set_len(final_pos)?;
+            for (pos, len) in sparse.take_holes() {
+                fast_io::punch_hole(&mut self.output, pos, len)?;
+            }
             self.stats.final_pos = Some(final_pos);
             if let Some(expected) = expected_size {
                 if final_pos != expected {

--- a/crates/transfer/src/delta_apply/sparse.rs
+++ b/crates/transfer/src/delta_apply/sparse.rs
@@ -261,17 +261,20 @@ mod tests {
 
     #[test]
     fn in_basis_zero_run_is_recorded_as_hole() {
-        // With a preallocated (basis) extent, a zero run starting inside it is
-        // recorded for punching; a run past the extent is only seeked.
+        // A zero run that is seeked over (accumulated as pending, then flushed
+        // by a following data write) starting inside the preallocated basis
+        // extent is recorded for punching, so an --inplace update deallocates
+        // stale basis blocks instead of leaving them on disk. The run is fed as
+        // a distinct write, mirroring receive_data streaming CHUNK_SIZE pieces;
+        // interior zeros within one write are written literally (as upstream)
+        // and correctly overwrite the basis, so only seeked runs are punched.
+        // upstream: fileio.c:90-99 write_sparse().
         let mut state = SparseWriteState::new();
         state.set_preallocated_len(1000);
         let mut cursor = Cursor::new(vec![0xAAu8; 2000]);
-        // Write 100 data bytes, then a 300-byte zero run starting at offset 100
-        // (inside the 1000-byte basis), then trailing data to force the flush.
-        let mut buf = vec![1u8; 100];
-        buf.extend(std::iter::repeat_n(0u8, 300));
-        buf.extend(std::iter::repeat_n(9u8, 10));
-        state.write(&mut cursor, &buf).unwrap();
+        state.write(&mut cursor, &[1u8; 100]).unwrap(); // data -> offset 100
+        state.write(&mut cursor, &[0u8; 300]).unwrap(); // zero run -> pending
+        state.write(&mut cursor, &[9u8; 10]).unwrap(); // data forces the flush
         let holes = state.take_holes();
         assert_eq!(holes, vec![(100, 300)], "in-basis run recorded for punch");
     }
@@ -281,10 +284,9 @@ mod tests {
         let mut state = SparseWriteState::new();
         state.set_preallocated_len(50);
         let mut cursor = Cursor::new(vec![0u8; 2000]);
-        let mut buf = vec![1u8; 100]; // data ends at offset 100 (> basis 50)
-        buf.extend(std::iter::repeat_n(0u8, 300)); // zero run starts at 100
-        buf.extend(std::iter::repeat_n(9u8, 10));
-        state.write(&mut cursor, &buf).unwrap();
+        state.write(&mut cursor, &[1u8; 100]).unwrap(); // data ends at 100 (> basis 50)
+        state.write(&mut cursor, &[0u8; 300]).unwrap(); // zero run starts at 100
+        state.write(&mut cursor, &[9u8; 10]).unwrap(); // data forces the flush
         assert!(
             state.take_holes().is_empty(),
             "run past basis extent needs no punch"

--- a/crates/transfer/src/delta_apply/sparse.rs
+++ b/crates/transfer/src/delta_apply/sparse.rs
@@ -1,6 +1,6 @@
 //! Sparse file write state tracker for hole optimization during delta apply.
 //!
-//! upstream: `fileio.c` `write_sparse()`.
+//! upstream: `fileio.c` `write_sparse()` and `sparse_end()`.
 
 use std::io::{self, Seek, SeekFrom, Write};
 
@@ -9,17 +9,47 @@ use crate::constants::{CHUNK_SIZE, leading_zero_count, trailing_zero_count};
 /// Tracks pending runs of zeros so they become holes in the output file rather
 /// than being written as data.
 ///
-/// Mirrors upstream rsync's `write_sparse()` behaviour in `fileio.c`.
+/// Mirrors upstream rsync's `write_sparse()` / `sparse_end()` in `fileio.c`.
+/// A zero run is always seeked over (advancing the writer to leave a natural
+/// hole); when the run starts inside the destination's pre-existing extent
+/// (`start < preallocated_len`, the `--inplace` basis case) its byte range is
+/// additionally recorded so the caller can punch it, deallocating the stale
+/// basis blocks and reading them back as zeros. Runs starting at or beyond
+/// `preallocated_len` (fresh temp file, or bytes past the old EOF) need no
+/// punch because a seek over never-written space already reads as zeros.
+///
+/// upstream: `fileio.c:92` `if (sparse_past_write >= preallocated_len)`.
 #[derive(Debug, Default)]
 pub struct SparseWriteState {
+    /// Accumulated pending zero bytes (upstream `sparse_seek`).
     pending_zeros: u64,
+    /// Length of the destination's pre-existing extent (upstream
+    /// `preallocated_len`). Zero runs starting below this offset carry stale
+    /// basis data and are recorded for hole-punching.
+    preallocated_len: u64,
+    /// Absolute `(start, len)` ranges to punch after the write pass, in file
+    /// order. Only populated for in-place updates over an existing basis.
+    holes: Vec<(u64, u64)>,
 }
 
 impl SparseWriteState {
     /// Creates a new sparse write state.
     #[must_use]
     pub const fn new() -> Self {
-        Self { pending_zeros: 0 }
+        Self {
+            pending_zeros: 0,
+            preallocated_len: 0,
+            holes: Vec::new(),
+        }
+    }
+
+    /// Records the destination's pre-existing length so zero runs that overlap
+    /// stale basis data are punched rather than merely seeked over (which would
+    /// leave the old bytes on disk in an `--inplace` update).
+    ///
+    /// upstream: `fileio.c:92` seek-vs-punch decision keyed on `preallocated_len`.
+    pub const fn set_preallocated_len(&mut self, len: u64) {
+        self.preallocated_len = len;
     }
 
     /// Adds zero bytes to the pending run.
@@ -34,11 +64,28 @@ impl SparseWriteState {
         self.pending_zeros
     }
 
-    /// Flushes pending zeros by seeking forward, creating a hole.
+    /// Takes the recorded hole ranges to punch, leaving the state empty.
+    ///
+    /// The caller punches each `(start, len)` on the raw destination file after
+    /// establishing the final length with `set_len`.
+    #[must_use]
+    pub fn take_holes(&mut self) -> Vec<(u64, u64)> {
+        std::mem::take(&mut self.holes)
+    }
+
+    /// Flushes the pending zero run: seeks forward to leave a hole and records
+    /// the range for punching when it overlaps the pre-existing basis extent.
+    ///
+    /// upstream: `fileio.c:90-99` `write_sparse()`.
     #[inline]
     pub fn flush<W: Write + Seek>(&mut self, writer: &mut W) -> io::Result<()> {
         if self.pending_zeros == 0 {
             return Ok(());
+        }
+
+        let start = writer.stream_position()?;
+        if start < self.preallocated_len {
+            self.holes.push((start, self.pending_zeros));
         }
 
         let mut remaining = self.pending_zeros;
@@ -93,22 +140,19 @@ impl SparseWriteState {
         Ok(data.len())
     }
 
-    /// Finalizes sparse writing and returns final position.
+    /// Finalizes sparse writing and returns the file's logical end offset.
+    ///
+    /// Any trailing zero run becomes a hole (seeked over, and recorded for
+    /// punching when it overlaps the basis). Unlike a plain writer this does
+    /// NOT materialize the final byte; the caller establishes the logical size
+    /// with `set_len(returned_len)`, leaving the trailing region a true hole.
+    ///
+    /// upstream: `fileio.c:43` `sparse_end()` -> `do_ftruncate(f, size)`.
     pub fn finish<W: Write + Seek>(&mut self, writer: &mut W) -> io::Result<u64> {
-        if self.pending_zeros > 0 {
-            let skip = self.pending_zeros.saturating_sub(1);
-            if skip > 0 {
-                let mut remaining = skip;
-                while remaining > 0 {
-                    let step = remaining.min(i64::MAX as u64);
-                    writer.seek(SeekFrom::Current(step as i64))?;
-                    remaining -= step;
-                }
-            }
-            writer.write_all(&[0])?;
-            self.pending_zeros = 0;
-        }
-        writer.stream_position()
+        let position = writer.stream_position()?;
+        let logical_end = position.saturating_add(self.pending_zeros);
+        self.flush(writer)?;
+        Ok(logical_end)
     }
 }
 
@@ -167,11 +211,17 @@ mod tests {
     }
 
     #[test]
-    fn sparse_state_finish() {
+    fn sparse_state_finish_returns_logical_end_without_writing_byte() {
+        // A file that is data followed by a trailing zero run: finish must
+        // report the logical size (incl. the hole). upstream sparse_end()
+        // ftruncate leaves the tail unallocated; the caller feeds the returned
+        // length to set_len.
         let mut state = SparseWriteState::new();
-        state.accumulate(10);
-        let mut cursor = Cursor::new(vec![0u8; 100]);
-        assert_eq!(state.finish(&mut cursor).unwrap(), 10);
+        let mut cursor = Cursor::new(Vec::new());
+        state.write(&mut cursor, b"abc").unwrap();
+        state.accumulate(97);
+        let logical = state.finish(&mut cursor).unwrap();
+        assert_eq!(logical, 100, "logical size includes trailing hole");
     }
 
     #[test]
@@ -187,7 +237,6 @@ mod tests {
     fn sparse_state_write_mixed_data() {
         let mut state = SparseWriteState::new();
         let mut cursor = Cursor::new(vec![0u8; 200]);
-        // Write data with leading zeros, non-zero content, trailing zeros
         let data = [0, 0, 0, 1, 2, 3, 0, 0];
         let result = state.write(&mut cursor, &data);
         assert!(result.is_ok());
@@ -197,10 +246,8 @@ mod tests {
     #[test]
     fn sparse_state_accumulate_overflow_protection() {
         let mut state = SparseWriteState::new();
-        // accumulate uses saturating_add to prevent overflow
         state.accumulate(usize::MAX);
         state.accumulate(1);
-        // Should not overflow
         assert!(state.pending() > 0);
     }
 
@@ -209,16 +256,38 @@ mod tests {
         let mut state = SparseWriteState::new();
         let mut cursor = Cursor::new(vec![0u8; 100]);
         let pos = state.finish(&mut cursor).unwrap();
-        assert_eq!(pos, 0); // No movement when no pending zeros
+        assert_eq!(pos, 0);
     }
 
     #[test]
-    fn sparse_state_large_pending_zeros() {
+    fn in_basis_zero_run_is_recorded_as_hole() {
+        // With a preallocated (basis) extent, a zero run starting inside it is
+        // recorded for punching; a run past the extent is only seeked.
         let mut state = SparseWriteState::new();
-        state.accumulate(1000);
+        state.set_preallocated_len(1000);
+        let mut cursor = Cursor::new(vec![0xAAu8; 2000]);
+        // Write 100 data bytes, then a 300-byte zero run starting at offset 100
+        // (inside the 1000-byte basis), then trailing data to force the flush.
+        let mut buf = vec![1u8; 100];
+        buf.extend(std::iter::repeat_n(0u8, 300));
+        buf.extend(std::iter::repeat_n(9u8, 10));
+        state.write(&mut cursor, &buf).unwrap();
+        let holes = state.take_holes();
+        assert_eq!(holes, vec![(100, 300)], "in-basis run recorded for punch");
+    }
+
+    #[test]
+    fn zero_run_beyond_basis_is_not_recorded() {
+        let mut state = SparseWriteState::new();
+        state.set_preallocated_len(50);
         let mut cursor = Cursor::new(vec![0u8; 2000]);
-        // finish should seek to position 999, write one byte
-        let pos = state.finish(&mut cursor).unwrap();
-        assert_eq!(pos, 1000);
+        let mut buf = vec![1u8; 100]; // data ends at offset 100 (> basis 50)
+        buf.extend(std::iter::repeat_n(0u8, 300)); // zero run starts at 100
+        buf.extend(std::iter::repeat_n(9u8, 10));
+        state.write(&mut cursor, &buf).unwrap();
+        assert!(
+            state.take_holes().is_empty(),
+            "run past basis extent needs no punch"
+        );
     }
 }

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -17,6 +17,29 @@ use crate::temp_guard::TempFileGuard;
 
 use super::super::config::{BackupConfig, DiskCommitConfig, PartialMode};
 
+/// Sparse finalization carried from the write pass.
+///
+/// upstream: `fileio.c:43` `sparse_end()` - truncate the file to its logical
+/// length (leaving the trailing region a hole) and punch the in-basis zero
+/// runs so an `--inplace` update does not retain stale bytes.
+pub(super) struct SparseFinalize {
+    /// Logical end offset for `set_len` (`ftruncate`).
+    pub(super) logical_len: u64,
+    /// Absolute `(start, len)` ranges to punch out of the destination.
+    pub(super) holes: Vec<(u64, u64)>,
+}
+
+/// Truncates `target` to the sparse logical length and punches its in-basis
+/// zero runs. Runs before the file is put into place.
+fn finalize_sparse(target: &Path, sparse: &SparseFinalize) -> io::Result<()> {
+    let mut file = fs::OpenOptions::new().write(true).open(target)?;
+    file.set_len(sparse.logical_len)?;
+    for &(pos, len) in &sparse.holes {
+        fast_io::punch_hole(&mut file, pos, len)?;
+    }
+    Ok(())
+}
+
 /// Commit result indicating whether a cross-device copy occurred and
 /// whether the file was staged to the partial dir for delayed updates.
 pub(super) struct CommitOutcome {
@@ -54,7 +77,17 @@ pub(super) fn commit_file(
     cleanup_guard: &mut TempFileGuard,
     needs_rename: bool,
     bytes_written: u64,
+    sparse_final: Option<SparseFinalize>,
 ) -> io::Result<CommitOutcome> {
+    // upstream: fileio.c:43 sparse_end() - for the temp+rename path, truncate
+    // and punch the temp file before it is renamed into place. The inplace
+    // path finalizes in its dedicated branch below (after any backup).
+    if needs_rename {
+        if let Some(ref sparse) = sparse_final {
+            finalize_sparse(cleanup_guard.path(), sparse)?;
+        }
+    }
+
     // upstream: backup.c:make_backup() - rename existing file before overwrite
     // With delay_updates, backup happens during the sweep, not here.
     let backup_notice = if !config.delay_updates {
@@ -88,16 +121,22 @@ pub(super) fn commit_file(
         CleanupManager::global().unregister_temp_file(cleanup_guard.path());
         result
     } else if begin.is_inplace {
-        // upstream: receiver.c:340 - set_file_length(fd, F_LENGTH(file))
-        // In append mode, bytes_written only counts newly received data -
-        // the full file size includes the existing content we seeked past.
-        let final_size = if begin.append_offset > 0 {
-            begin.target_size
+        if let Some(ref sparse) = sparse_final {
+            // upstream: fileio.c:47-52 sparse_end() - punch stale basis blocks
+            // then ftruncate to the logical length for the in-place update.
+            finalize_sparse(&begin.file_path, sparse)?;
         } else {
-            bytes_written
-        };
-        let file = fs::OpenOptions::new().write(true).open(&begin.file_path)?;
-        file.set_len(final_size)?;
+            // upstream: receiver.c:340 - set_file_length(fd, F_LENGTH(file))
+            // In append mode, bytes_written only counts newly received data -
+            // the full file size includes the existing content we seeked past.
+            let final_size = if begin.append_offset > 0 {
+                begin.target_size
+            } else {
+                bytes_written
+            };
+            let file = fs::OpenOptions::new().write(true).open(&begin.file_path)?;
+            file.set_len(final_size)?;
+        }
         false
     } else {
         false

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -20,7 +20,7 @@ use crate::temp_guard::open_tmpfile_sandboxed;
 
 use super::super::config::DiskCommitConfig;
 use super::super::writer::{ReusableBufWriter, Writer};
-use super::commit::{commit_file, retain_partial_file};
+use super::commit::{SparseFinalize, commit_file, retain_partial_file};
 use super::metadata::{apply_file_metadata, finalize_checksum};
 
 /// Processes a single file: open, write chunks, commit or abort.
@@ -74,6 +74,15 @@ pub(in crate::disk_commit) fn process_file(
         cleanup_guard.mark_registered();
     }
 
+    // Pre-existing basis length for sparse hole-punching: only in-place writes
+    // reuse existing bytes, so a zero run there must be punched rather than
+    // merely seeked over. upstream: receiver.c:318-338 preallocated_len.
+    let basis_len = if config.use_sparse && begin.is_inplace {
+        file.metadata().map(|m| m.len()).unwrap_or(0)
+    } else {
+        0
+    };
+
     let mut output = make_writer(
         file,
         write_buf,
@@ -85,7 +94,9 @@ pub(in crate::disk_commit) fn process_file(
     )?;
 
     let mut sparse_state = if config.use_sparse {
-        Some(SparseWriteState::default())
+        let mut state = SparseWriteState::default();
+        state.set_preallocated_len(basis_len);
+        Some(state)
     } else {
         None
     };
@@ -140,9 +151,18 @@ pub(in crate::disk_commit) fn process_file(
                 let _ = buf_return_tx.send(data);
             }
             FileMessage::Commit => {
-                if let Some(ref mut sparse) = sparse_state {
-                    let _final_pos = sparse.finish(output.buffered_for_sparse())?;
-                }
+                // upstream: fileio.c:43 sparse_end() - flush the trailing hole
+                // and hand the logical length + in-basis hole ranges to the
+                // commit step for ftruncate + punch (no materialized byte).
+                let sparse_final = if let Some(ref mut sparse) = sparse_state {
+                    let logical = sparse.finish(output.buffered_for_sparse())?;
+                    Some(SparseFinalize {
+                        logical_len: logical,
+                        holes: sparse.take_holes(),
+                    })
+                } else {
+                    None
+                };
 
                 output.flush_and_sync(config.do_fsync, &begin.file_path)?;
                 output.finish(config.do_fsync, &begin.file_path)?;
@@ -164,6 +184,7 @@ pub(in crate::disk_commit) fn process_file(
                     &mut cleanup_guard,
                     needs_rename,
                     bytes_written,
+                    sparse_final,
                 )?;
 
                 // Temp file has been renamed to its final destination (or
@@ -274,6 +295,13 @@ pub(in crate::disk_commit) fn process_whole_file(
         cleanup_guard.mark_registered();
     }
 
+    // Pre-existing basis length for sparse hole-punching (see process_file).
+    let basis_len = if config.use_sparse && begin.is_inplace {
+        file.metadata().map(|m| m.len()).unwrap_or(0)
+    } else {
+        0
+    };
+
     let mut output = make_writer(
         file,
         write_buf,
@@ -290,13 +318,19 @@ pub(in crate::disk_commit) fn process_whole_file(
         verifier.update(&data);
     }
 
-    if config.use_sparse {
+    let sparse_final = if config.use_sparse {
         let mut sparse = SparseWriteState::default();
+        sparse.set_preallocated_len(basis_len);
         sparse.write(output.buffered_for_sparse(), &data)?;
-        let _final_pos = sparse.finish(output.buffered_for_sparse())?;
+        let logical = sparse.finish(output.buffered_for_sparse())?;
+        Some(SparseFinalize {
+            logical_len: logical,
+            holes: sparse.take_holes(),
+        })
     } else {
         output.write_chunk(&data)?;
-    }
+        None
+    };
 
     let _ = buf_return_tx.send(data);
 
@@ -317,6 +351,7 @@ pub(in crate::disk_commit) fn process_whole_file(
         &mut cleanup_guard,
         needs_rename,
         bytes_written,
+        sparse_final,
     )?;
 
     if needs_rename && outcome.delayed_path.is_none() {

--- a/crates/transfer/src/receiver/tests/delta_apply.rs
+++ b/crates/transfer/src/receiver/tests/delta_apply.rs
@@ -367,7 +367,11 @@ fn sparse_write_state_handles_trailing_zeros() {
     let zeros = [0u8; 1024];
     sparse.write(&mut output, data).unwrap();
     sparse.write(&mut output, &zeros).unwrap();
-    sparse.finish(&mut output).unwrap();
+    // finish() returns the logical length and seeks over the trailing hole; the
+    // caller establishes the size via set_len (ftruncate) rather than writing a
+    // terminal byte. Emulate that here with resize. upstream: fileio.c:43.
+    let logical = sparse.finish(&mut output).unwrap();
+    output.get_mut().resize(logical as usize, 0);
 
     let result = output.into_inner();
     assert_eq!(result.len(), 4 + 1024);
@@ -444,7 +448,12 @@ fn sparse_write_state_finish_handles_only_zeros() {
     let mut sparse = SparseWriteState::default();
 
     sparse.accumulate(4096);
-    sparse.finish(&mut output).unwrap();
+    // finish() returns the logical length; the caller truncates to it (leaving
+    // the region a hole that reads back as zeros) instead of materializing a
+    // trailing byte. Emulate set_len with resize. upstream: fileio.c:43.
+    let logical = sparse.finish(&mut output).unwrap();
+    assert_eq!(logical, 4096);
+    output.get_mut().resize(logical as usize, 0);
 
     let result = output.into_inner();
     assert_eq!(result.len(), 4096);

--- a/crates/transfer/src/transfer_ops/response.rs
+++ b/crates/transfer/src/transfer_ops/response.rs
@@ -117,6 +117,16 @@ pub fn process_file_response<R: Read>(
         file.seek(io::SeekFrom::Start(append_offset))?;
     }
 
+    // Length of the pre-existing basis extent for sparse hole-punching. Only
+    // in-place writes reuse existing bytes; a temp file is fresh, so its runs
+    // are seeked (natural holes) and need no punch.
+    // upstream: receiver.c:318-338 sets preallocated_len from the basis size.
+    let basis_len = if use_inplace {
+        file.metadata().map(|m| m.len()).unwrap_or(0)
+    } else {
+        0
+    };
+
     // Use io_uring when available (Linux 5.6+), falling back to BufWriter.
     // Buffer capacity is adaptive based on file size:
     // - Small files (< 64KB): 4KB buffer to avoid wasted memory
@@ -132,7 +142,9 @@ pub fn process_file_response<R: Read>(
     let mut total_bytes: u64 = 0;
 
     let mut sparse_state = if ctx.config.use_sparse {
-        Some(SparseWriteState::default())
+        let mut state = SparseWriteState::default();
+        state.set_preallocated_len(basis_len);
+        Some(state)
     } else {
         None
     };
@@ -276,9 +288,16 @@ pub fn process_file_response<R: Read>(
         }
     }
 
-    if let Some(ref mut sparse) = sparse_state {
-        let _final_pos = sparse.finish(&mut output)?;
-    }
+    // upstream: fileio.c:43 sparse_end() - flush the trailing hole and hand the
+    // caller the logical length (and any in-basis hole ranges) so the file is
+    // truncated to size and stale basis blocks are punched, instead of
+    // materializing a trailing byte.
+    let sparse_final = if let Some(ref mut sparse) = sparse_state {
+        let logical = sparse.finish(&mut output)?;
+        Some((logical, sparse.take_holes()))
+    } else {
+        None
+    };
 
     // Uses io_uring fsync op when available.
     if ctx.config.do_fsync {
@@ -293,6 +312,25 @@ pub fn process_file_response<R: Read>(
         })?;
     }
     drop(output);
+
+    // upstream: fileio.c:43-71 sparse_end() - establish the logical size via
+    // ftruncate (leaving the trailing region a hole) and punch any in-basis
+    // zero runs so an --inplace update does not retain stale bytes. Runs on the
+    // temp file before rename for the atomic path, on the final file for
+    // in-place.
+    if let Some((logical, holes)) = sparse_final {
+        let target = if needs_rename {
+            cleanup_guard.path().to_path_buf()
+        } else {
+            file_path.clone()
+        };
+        let mut sfile = fs::OpenOptions::new().write(true).open(&target)?;
+        sfile.set_len(logical)?;
+        for (pos, len) in holes {
+            fast_io::punch_hole(&mut sfile, pos, len)?;
+        }
+        drop(sfile);
+    }
 
     if needs_rename {
         // Atomic rename: temp file to final destination.
@@ -348,11 +386,12 @@ pub fn process_file_response<R: Read>(
             }
         }
         CleanupManager::global().unregister_temp_file(cleanup_guard.path());
-    } else if ctx.config.inplace {
+    } else if ctx.config.inplace && sparse_state.is_none() {
         // Inplace: truncate to final size.
         // upstream: receiver.c:340 - set_file_length(fd, F_LENGTH(file))
         // In append mode, total_bytes only counts newly received data -
         // the full file size includes the existing content we seeked past.
+        // The sparse path already truncated to its logical length above.
         let final_size = if append_offset > 0 {
             target_size
         } else {

--- a/crates/transfer/tests/delta_applicator_equivalence.rs
+++ b/crates/transfer/tests/delta_applicator_equivalence.rs
@@ -269,8 +269,17 @@ fn reference_apply<R: Read>(
         }
     }
 
-    out.into_inner()
+    let file = out
+        .into_inner()
         .map_err(|e| std::io::Error::other(e.to_string()))?;
+    // upstream: fileio.c:43 sparse_end() -> do_ftruncate(f, size). finish() only
+    // seeks over the trailing hole; the caller establishes the logical length via
+    // set_len, mirroring DeltaApplicator. Punching in-basis holes is a block
+    // deallocation that reads back as zeros identically to the truncated tail, so
+    // set_len alone reproduces the applicator's byte-for-byte output here.
+    if let Some(pos) = final_pos {
+        file.set_len(pos)?;
+    }
     Ok(ReferenceResult {
         literal_bytes,
         final_pos,

--- a/crates/transfer/tests/empty_file_handling.rs
+++ b/crates/transfer/tests/empty_file_handling.rs
@@ -253,18 +253,23 @@ fn sparse_state_finish_without_any_operations() {
 #[test]
 fn sparse_state_accumulate_then_finish_creates_hole() {
     let mut state = SparseWriteState::new();
-    let mut cursor = Cursor::new(vec![1u8; 100]); // Fill with ones
+    let mut cursor = Cursor::new(Vec::new());
 
-    // Accumulate some zeros
+    // Accumulate a pure zero run.
     state.accumulate(50);
 
-    // Finish should create a hole
+    // finish() returns the logical length and seeks over the hole without
+    // materializing a byte; the caller establishes the size via set_len
+    // (ftruncate), leaving the region a true hole that reads back as zeros.
+    // upstream: fileio.c:43 sparse_end() -> do_ftruncate(f, size).
     let pos = state.finish(&mut cursor).expect("finish");
     assert_eq!(pos, 50);
 
-    // Check that a single zero was written at position 49
-    let buffer = cursor.into_inner();
-    assert_eq!(buffer[49], 0, "position 49 should be zero");
+    // Emulate the caller's set_len(pos); the hole reads back as zeros.
+    let mut buffer = cursor.into_inner();
+    buffer.resize(pos as usize, 0);
+    assert_eq!(buffer.len(), 50);
+    assert!(buffer.iter().all(|&b| b == 0), "hole reads back as zeros");
 }
 
 #[test]

--- a/crates/transfer/tests/sparse_write_state.rs
+++ b/crates/transfer/tests/sparse_write_state.rs
@@ -171,22 +171,27 @@ fn sparse_state_finish_with_pending_zeros() {
     state.accumulate(100);
     let mut cursor = Cursor::new(vec![0u8; 200]);
     let pos = state.finish(&mut cursor).expect("finish with pending");
-    // finish() should write a single zero at the end after seeking
+    // finish() returns the logical length (seeking over the hole); the caller
+    // truncates to it. upstream: fileio.c:43 sparse_end() -> do_ftruncate.
     assert_eq!(pos, 100);
 }
 
 #[test]
-fn sparse_state_finish_writes_single_trailing_zero() {
+fn sparse_state_finish_returns_logical_length_without_writing() {
     let mut state = SparseWriteState::new();
     state.accumulate(10);
-    let buffer = vec![1u8; 20]; // Fill with ones
-    let mut cursor = Cursor::new(buffer);
+    let mut cursor = Cursor::new(Vec::new()); // fresh (empty) destination
+    // finish() seeks over the trailing hole and returns the logical length; it
+    // does NOT materialize a terminal byte (the caller establishes the size via
+    // set_len). upstream: fileio.c:43 sparse_end() -> do_ftruncate(f, size).
     let pos = state.finish(&mut cursor).expect("finish");
     assert_eq!(pos, 10);
 
-    // Check that a single zero was written at position 9
-    let buffer = cursor.into_inner();
-    assert_eq!(buffer[9], 0);
+    // Emulate the caller's set_len(pos); the hole reads back as zeros.
+    let mut buffer = cursor.into_inner();
+    buffer.resize(pos as usize, 0);
+    assert_eq!(buffer.len(), 10);
+    assert!(buffer.iter().all(|&b| b == 0), "hole reads back as zeros");
 }
 
 const CHUNK_SIZE: usize = 32 * 1024;


### PR DESCRIPTION
## Summary

Fixes a data-correctness divergence in the **network receiver's sparse-file
writer** (`--sparse`, `--inplace --sparse`) versus upstream rsync's
`fileio.c` `write_sparse()` / `sparse_end()`. Verified byte-for-byte against
rsync 3.4.3 over ssh on Linux.

Two distinct bugs, both in the shared `transfer::delta_apply::SparseWriteState`
used by every network receiver path:

1. **Trailing hole over-allocation.** `finish()` materialized the trailing
   hole by seeking to `size-1` and writing a zero byte, which allocates the
   final filesystem block. Upstream `sparse_end()` calls `ftruncate(size)`,
   leaving the tail a real hole. `finish()` now returns the logical length and
   the callers `set_len()` to it (no byte write).

2. **`--inplace --sparse` stale-data corruption.** Mid-file and trailing zero
   runs over an existing basis were only seeked over, so the destination kept
   the old bytes and never reclaimed the blocks — the result **differed from
   the source**. Upstream `write_sparse()` punches (`do_punch_hole`) any run
   starting inside the pre-existing extent. `SparseWriteState` now tracks the
   basis length, records in-basis runs, and the callers punch them via a new
   `fast_io::punch_hole` (`fallocate` `PUNCH_HOLE`/`ZERO_RANGE`, with a
   zero-write fallback on non-Linux) before establishing the final size.

The fix is applied at the three network receiver paths that share
`SparseWriteState`: `transfer_ops::response` (non-pipelined),
`disk_commit::process` (pipelined), and `DeltaApplicator` (sync + async).

## Before / after (Linux, ssh pull, oc vs rsync 3.4.3)

| Case | oc before | oc after | upstream |
|------|-----------|----------|----------|
| trailing hole, `--inplace --sparse` | blocks=2048, **content DIFFERS** | blocks=128, content OK | blocks=128, content OK |
| trailing hole, `--sparse` (temp+rename) | blocks=136 (+1 block) | blocks=128, content OK | blocks=128, content OK |
| middle hole, `--inplace --sparse` | blocks=2048, **content DIFFERS** | blocks=256, content OK | blocks=256, content OK |

Logical size (`stat %s`) was already correct in all cases and stays correct.
Local (`--sparse`, engine executor) transfers were already correct and are
unchanged.

## Tests

- New unit tests in `fast_io::punch_hole` (zero-len no-op; region reads back
  as zeros with intact surroundings).
- New unit tests in `SparseWriteState`: `finish()` returns the logical end
  without materializing a byte; in-basis runs are recorded for punching while
  runs past the basis extent are not.
- `cargo fmt` clean; `cargo clippy -p fast_io -p transfer --all-features
  --no-deps -D warnings` clean.

## Out of scope (reported separately)

Investigating `--append-verify` over the network surfaced an unrelated,
more fundamental breakage that is **not** addressed here: the remote
server-sender does not parse `--append` (it is treated as a path, failing with
`link_stat "--append" failed`, exit 23), and for `--append-verify` the client
sends a single `--append` where upstream sends `--append --append`. Network
append therefore fails loudly rather than silently corrupting. Local
`--append-verify` correctly detects a corrupted prefix (byte-compare in the
engine executor). This warrants its own issue covering the server arg parser,
the client arg doubling, and the receiver's whole-file checksum over the
existing prefix in append-verify mode.
