### PR TITLE
fix(protocol): use legacy longint for proto<30 end-of-transfer stats

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -295,10 +295,10 @@ jobs:
       # build it inline via the RP28.b.1 helper to keep the cell
       # self-sufficient. The harness exits 77 when either binary is
       # missing so the cell becomes a no-op rather than a false failure.
-      # Non-blocking via `continue-on-error: true` until RP28.k promotes
-      # pre-30 parity to a required check.
+      # Blocking: the pre-30 daemon-sender end-of-transfer stats deadlock is
+      # fixed (proto < 30 now emits fixed 4-byte longint stats, matching
+      # `write_varlong30`), so the full D1-D10 matrix passes against 2.6.9.
       - name: Run rsync 2.6.9 daemon-mode client interop (RP28.e.2)
-        continue-on-error: true
         run: |
           set -euo pipefail
           RSYNC_269="target/interop/upstream-install/2.6.9/bin/rsync"
@@ -317,12 +317,9 @@ jobs:
             exit 1
           fi
 
-          # Outer wall-clock guard. oc-rsync as a daemon *sender* stalls in the
-          # end-of-transfer phase against a protocol-29 client (the pull legs of
-          # this matrix), so per-fixture 60s timeouts would otherwise accumulate
-          # and consume the whole job budget. The harness traps SIGTERM to stop
-          # its daemon. This cell is continue-on-error, so a timeout here fails
-          # fast without cancelling the job.
+          # Outer wall-clock guard: bound total runtime so an unexpected stall in
+          # any fixture cannot consume the whole job budget. The harness traps
+          # SIGTERM to stop its daemon; a timeout here surfaces as a hard failure.
           timeout --signal=TERM --kill-after=30 360 \
             bash scripts/rp28_e_1_run.sh \
             --oc-rsync "$OC_RSYNC" \
@@ -348,11 +345,10 @@ jobs:
       # `target/interop/upstream-install/2.6.9/bin/rsync`; falls back to
       # the RP28.b.1 build helper if the cache is cold. The harness
       # exits 77 when either binary is missing so the cell becomes a
-      # no-op rather than a false failure. Non-blocking via
-      # `continue-on-error: true` until RP28.k promotes pre-30 parity
-      # to a required check.
+      # no-op rather than a false failure. Blocking: the pre-30 stats
+      # deadlock that stalled the proto-29 legs is fixed, so the full
+      # F1-F12 matrix passes with 2.6.9 as the daemon.
       - name: Run rsync 2.6.9 client-mode daemon interop (RP28.f.2)
-        continue-on-error: true
         run: |
           set -euo pipefail
           RSYNC_269="target/interop/upstream-install/2.6.9/bin/rsync"
@@ -371,10 +367,9 @@ jobs:
             exit 1
           fi
 
-          # Outer wall-clock guard (see RP28.e.2 cell): bound total runtime so a
-          # stalled legacy proto-29 fixture cannot consume the job budget. The
-          # harness traps SIGTERM to stop its daemon; continue-on-error means a
-          # timeout fails fast without cancelling the job.
+          # Outer wall-clock guard (see RP28.e.2 cell): bound total runtime so an
+          # unexpected stall in any fixture cannot consume the job budget. The
+          # harness traps SIGTERM to stop its daemon; a timeout is a hard failure.
           timeout --signal=TERM --kill-after=30 360 \
             bash scripts/rp28_f_1_run.sh \
             --oc-rsync "$OC_RSYNC" \

--- a/crates/protocol/src/stats/tests.rs
+++ b/crates/protocol/src/stats/tests.rs
@@ -51,6 +51,73 @@ fn test_transfer_stats_roundtrip_proto28() {
     assert_eq!(decoded.flist_xfertime, 0);
 }
 
+/// Protocol 29 must encode each stats value as a fixed 4-byte `write_longint`,
+/// not a varlong. A proto-29 peer (rsync 2.6.9) reads the five-value stats block
+/// with `read_longint`; emitting varlong truncates the block and deadlocks the
+/// end-of-transfer goodbye (both peers block reading). This asserts the exact
+/// wire bytes so a regression to varlong encoding fails here rather than only
+/// against a live 2.6.9 peer.
+#[test]
+fn test_transfer_stats_proto29_uses_fixed_longint() {
+    let stats = TransferStats {
+        total_read: 1024,
+        total_written: 2048,
+        total_size: 10000,
+        flist_buildtime: 5,
+        flist_xfertime: 7,
+        ..Default::default()
+    };
+
+    let mut buf = Vec::new();
+    stats.write_to(&mut buf, ProtocolVersion::V29).unwrap();
+
+    // Five little-endian 4-byte longints: 5 * 4 = 20 bytes.
+    let expected: Vec<u8> = [1024u32, 2048, 10000, 5, 7]
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+    assert_eq!(
+        buf, expected,
+        "proto-29 stats must be fixed 4-byte longints"
+    );
+    assert_eq!(buf.len(), 20);
+}
+
+/// Protocol 29 (legacy longint) and protocol 30 (varlong) must produce distinct
+/// encodings for the same values, and each must round-trip under its own version.
+/// Small values compress under varlong, so the byte lengths diverge.
+#[test]
+fn test_transfer_stats_proto29_differs_from_proto30() {
+    let stats = TransferStats {
+        total_read: 1024,
+        total_written: 2048,
+        total_size: 10000,
+        flist_buildtime: 5,
+        flist_xfertime: 7,
+        ..Default::default()
+    };
+
+    let mut buf29 = Vec::new();
+    stats.write_to(&mut buf29, ProtocolVersion::V29).unwrap();
+    let mut buf30 = Vec::new();
+    stats.write_to(&mut buf30, ProtocolVersion::V30).unwrap();
+
+    assert_ne!(
+        buf29, buf30,
+        "proto-29 longint and proto-30 varlong encodings must differ"
+    );
+
+    let d29 = TransferStats::read_from(&mut Cursor::new(&buf29), ProtocolVersion::V29).unwrap();
+    let d30 = TransferStats::read_from(&mut Cursor::new(&buf30), ProtocolVersion::V30).unwrap();
+    for d in [d29, d30] {
+        assert_eq!(d.total_read, 1024);
+        assert_eq!(d.total_written, 2048);
+        assert_eq!(d.total_size, 10000);
+        assert_eq!(d.flist_buildtime, 5);
+        assert_eq!(d.flist_xfertime, 7);
+    }
+}
+
 #[test]
 fn test_transfer_stats_swap_perspective() {
     let stats = TransferStats {

--- a/crates/protocol/src/stats/transfer.rs
+++ b/crates/protocol/src/stats/transfer.rs
@@ -3,19 +3,47 @@
 //! Stats are exchanged at the end of a transfer in this order:
 //!
 //! ```text
-//! total_read      : varlong30 (bytes read by sender, written by receiver)
-//! total_written   : varlong30 (bytes written by sender, read by receiver)
-//! total_size      : varlong30 (total file size)
-//! flist_buildtime : varlong30 (protocol >= 29, microseconds)
-//! flist_xfertime  : varlong30 (protocol >= 29, microseconds)
+//! total_read      : longint(<30) / varlong(>=30) (bytes read by sender)
+//! total_written   : longint(<30) / varlong(>=30) (bytes written by sender)
+//! total_size      : longint(<30) / varlong(>=30) (total file size)
+//! flist_buildtime : longint(<30) / varlong(>=30) (protocol >= 29, microseconds)
+//! flist_xfertime  : longint(<30) / varlong(>=30) (protocol >= 29, microseconds)
 //! ```
 //!
+//! Each value is encoded with upstream's `write_varlong30` semantics: fixed
+//! 4-byte `write_longint` for protocol < 30, `write_varlong(_, 3)` for >= 30.
 //! The meaning of read/write swaps between sender and receiver perspectives.
 
 use std::io::{self, Read, Write};
 
-use crate::varint::{read_varlong30, write_varlong30};
+use crate::varint::{read_longint, read_varlong, write_longint, write_varlong};
 use crate::version::ProtocolVersion;
+
+/// Writes one stats value using the protocol-appropriate integer encoding.
+///
+/// Mirrors upstream's `write_varlong30(f, x, 3)` inline helper (io.h): protocol
+/// < 30 uses the fixed 4-byte `write_longint`, protocol >= 30 uses `write_varlong`
+/// with `min_bytes = 3`. A proto-29 peer (e.g. rsync 2.6.9) reads these via
+/// `read_longint`, so emitting varlong here truncates the 5-value stats block and
+/// deadlocks the end-of-transfer goodbye.
+fn write_stat<W: Write>(writer: &mut W, value: i64, varint: bool) -> io::Result<()> {
+    if varint {
+        write_varlong(writer, value, 3)
+    } else {
+        write_longint(writer, value)
+    }
+}
+
+/// Reads one stats value using the protocol-appropriate integer encoding.
+///
+/// Inverse of [`write_stat`]; mirrors upstream's `read_varlong30(f, 3)`.
+fn read_stat<R: Read>(reader: &mut R, varint: bool) -> io::Result<i64> {
+    if varint {
+        read_varlong(reader, 3)
+    } else {
+        read_longint(reader)
+    }
+}
 
 /// Transfer statistics exchanged between rsync processes.
 ///
@@ -197,13 +225,14 @@ impl TransferStats {
     ///
     /// Returns an error if writing to the stream fails.
     pub fn write_to<W: Write>(&self, writer: &mut W, protocol: ProtocolVersion) -> io::Result<()> {
-        write_varlong30(writer, self.total_read as i64, 3)?;
-        write_varlong30(writer, self.total_written as i64, 3)?;
-        write_varlong30(writer, self.total_size as i64, 3)?;
+        let varint = protocol.uses_varint_encoding();
+        write_stat(writer, self.total_read as i64, varint)?;
+        write_stat(writer, self.total_written as i64, varint)?;
+        write_stat(writer, self.total_size as i64, varint)?;
 
         if protocol.supports_flist_times() {
-            write_varlong30(writer, self.flist_buildtime as i64, 3)?;
-            write_varlong30(writer, self.flist_xfertime as i64, 3)?;
+            write_stat(writer, self.flist_buildtime as i64, varint)?;
+            write_stat(writer, self.flist_xfertime as i64, varint)?;
         }
 
         Ok(())
@@ -217,13 +246,14 @@ impl TransferStats {
     ///
     /// Returns an error if reading from the stream fails.
     pub fn read_from<R: Read>(reader: &mut R, protocol: ProtocolVersion) -> io::Result<Self> {
-        let total_read = read_varlong30(reader, 3)? as u64;
-        let total_written = read_varlong30(reader, 3)? as u64;
-        let total_size = read_varlong30(reader, 3)? as u64;
+        let varint = protocol.uses_varint_encoding();
+        let total_read = read_stat(reader, varint)? as u64;
+        let total_written = read_stat(reader, varint)? as u64;
+        let total_size = read_stat(reader, varint)? as u64;
 
         let (flist_buildtime, flist_xfertime) = if protocol.supports_flist_times() {
-            let buildtime = read_varlong30(reader, 3)? as u64;
-            let xfertime = read_varlong30(reader, 3)? as u64;
+            let buildtime = read_stat(reader, varint)? as u64;
+            let xfertime = read_stat(reader, varint)? as u64;
             (buildtime, xfertime)
         } else {
             (0, 0)


### PR DESCRIPTION
## Problem (#204, #205)

Every proto-29 transfer that reached the end-of-transfer stats exchange
deadlocked. Symptoms tracked as #204 (`-z` zlib) and #205 (1 MiB delta),
but the root cause is shared and affects **all** proto-29 file transfers,
not just those two options.

## Root cause

The sender's end-of-transfer sequence is
`send_files -> handle_stats -> read_final_goodbye`. At protocol >= 29,
`handle_stats` exchanges **five** longint values (total_read,
total_written, total_size, flist_buildtime, flist_xfertime). Upstream
encodes each with `write_varlong30`, which is protocol-gated (io.h):

```c
static inline void write_varlong30(int f, int64 x, uchar min_bytes) {
    if (protocol_version < 30) write_longint(f, x);      // fixed 4 bytes
    else                       write_varlong(f, x, min_bytes);
}
```

`TransferStats::write_to`/`read_from` called our `write_varlong30`
unconditionally, and that helper never restored the `protocol_version < 30`
branch. So at proto 29 the five stats were emitted as compact varlong
(15 bytes) instead of fixed 4-byte longint (20 bytes). A 2.6.9 peer reads
them with `read_longint`, consumed the first three plus 3 stray bytes,
then blocked mid-read of `flist_buildtime`. Its final `-1` goodbye was
never sent, so the sender's `read_final_goodbye` blocked too - a
deadlock, seen as "connection unexpectedly closed" under the CI timeout.

Captured on the wire (oc daemon-sender, 100-byte file): proto-29 emitted a
15-byte stats frame then blocked on `recvfrom`; proto-30 emitted its
varlong stats and completed. Confirmed against rsync 2.6.9.

## Fix

`TransferStats::write_to`/`read_from` now branch on
`ProtocolVersion::uses_varint_encoding()` (>= 30) and use `write_longint`/
`read_longint` for proto < 30, exactly mirroring upstream `write_varlong30`
/`read_varlong30`. Protocol >= 30 uses `write_varlong(_, 3)` as before, so
the proto 30/31/32 wire is byte-for-byte unchanged.

## Verification (rsync 2.6.9, aarch64)

- proto-29 `-avz` pull and 1 MiB delta pull: rc=0, trees byte-identical
  (previously hung).
- proto 30/31/32 `-z` and delta pull (oc<->oc): no regression, rc=0,
  byte-identical.
- Full `rp28_e_1_run.sh` (oc daemon, 2.6.9 client): **15/15 pass**.
- Full `rp28_f_1_run.sh` (oc client, 2.6.9 daemon): **18/18 pass**.
- `cargo nextest -p protocol -E 'test(transfer_stats)'`: 21/21 pass,
  including new golden-byte tests asserting the proto-29 4-byte layout.
- fmt + clippy (`-p protocol`) clean.

Both interop cells that documented this exact stall (RP28.e.2, RP28.f.2)
are promoted from `continue-on-error` to blocking.
