### PR TITLE
fix(delete): order local delete plan by upstream traversal, not byte sort

### DIFF
--- a/crates/engine/src/delete/plan.rs
+++ b/crates/engine/src/delete/plan.rs
@@ -11,8 +11,8 @@
 //! `delete_in_dir`'s loop (`generator.c:320`), which iterates the sorted
 //! destination directory list in reverse. Callers obtain that ordering by
 //! sorting with [`super::super::delete::DeletePlan::sort_by_name`], which
-//! uses upstream's `f_name_cmp` ascending and then reverses the slice in
-//! place.
+//! uses upstream's protocol-29 `f_name_cmp` (files before directories)
+//! ascending and then reverses the slice in place.
 //!
 //! # Hardlink Cohort
 //!
@@ -29,7 +29,7 @@ use std::cmp::Ordering;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use protocol::flist::{FileEntry, FileType, f_name_cmp};
+use protocol::flist::{FileEntry, FileType, compare_file_entries};
 
 /// Identifier shared by all destination-side entries that belong to the
 /// same hardlink group (same `(dev, ino)` pair).
@@ -206,15 +206,23 @@ impl DeletePlan {
 
     /// Sorts the entries into upstream `delete_in_dir` emission order.
     ///
-    /// Order is `f_name_cmp` ascending applied to a temporary
-    /// [`FileEntry`] per entry (using the plan's `directory` as the
-    /// parent), then reversed in place. The sort is unstable to match
-    /// upstream's `qsort` choice (upstream:
+    /// Order is upstream's protocol-29 `f_name_cmp` ascending applied to a
+    /// temporary [`FileEntry`] per entry (using the plan's `directory` as
+    /// the parent), then reversed in place. The comparator is
+    /// [`compare_file_entries`], which honours the `t_PATH`/`t_ITEM`
+    /// distinction (upstream: `flist.c:3223`): within a directory,
+    /// non-directories sort before directories, so `get_dirlist`'s sorted
+    /// order places files first and directories last. A plain byte sort
+    /// would instead order dirs and files by name alone, so an
+    /// upper-case directory name like `D` would wrongly sort ahead of a
+    /// file `a` - diverging from upstream's traversal and, under
+    /// `--max-delete`, changing which entries survive when the cap trips.
+    /// The sort is unstable to match upstream's `qsort` choice (upstream:
     /// `flist.c:3217-3343`, `generator.c:320`).
     pub fn sort_by_name(&mut self) {
         let dir = &self.directory;
         self.extras.sort_unstable_by(|a, b| {
-            f_name_cmp(&entry_as_file_entry(dir, a), &entry_as_file_entry(dir, b))
+            compare_file_entries(&entry_as_file_entry(dir, a), &entry_as_file_entry(dir, b))
         });
         // Upstream's `delete_in_dir` iterates the sorted dirlist in
         // reverse (`for (i = dirlist->used; i--; )`), so the emission
@@ -226,20 +234,20 @@ impl DeletePlan {
     /// Convenience: returns the comparator that orders two [`DeleteEntry`]
     /// values in upstream ascending order under the plan's directory.
     /// Useful for callers that want to merge externally sorted candidate
-    /// lists without rebuilding [`FileEntry`] values.
+    /// lists without rebuilding [`FileEntry`] values. Uses the same
+    /// dir-aware [`compare_file_entries`] key as [`Self::sort_by_name`].
     #[must_use]
     pub fn ascending_order(&self, a: &DeleteEntry, b: &DeleteEntry) -> Ordering {
         let dir = &self.directory;
-        f_name_cmp(&entry_as_file_entry(dir, a), &entry_as_file_entry(dir, b))
+        compare_file_entries(&entry_as_file_entry(dir, a), &entry_as_file_entry(dir, b))
     }
 }
 
 /// Builds a transient [`FileEntry`] for one [`DeleteEntry`] so that
-/// [`f_name_cmp`] can score it against another entry in the same
-/// directory. The entry's mode is set from its `kind` so a directory
-/// vs file disambiguation could be layered on later by `sort.rs`'s
-/// protocol-29-aware comparator; the foundational `f_name_cmp` itself
-/// ignores the mode.
+/// [`compare_file_entries`] can score it against another entry in the
+/// same directory. The entry's mode is set from its `kind` so the
+/// protocol-29 comparator applies its directory-vs-file disambiguation
+/// (`is_dir()` is honoured for the `t_PATH`/`t_ITEM` ordering).
 fn entry_as_file_entry(dir: &std::path::Path, e: &DeleteEntry) -> FileEntry {
     let full = dir.join(&e.name);
     match e.kind {
@@ -367,9 +375,13 @@ mod tests {
     }
 
     #[test]
-    fn sort_orders_mixed_kinds_byte_wise() {
-        // f_name_cmp is byte-wise; the kind does not influence the sort
-        // key. Names alone decide.
+    fn sort_orders_files_before_dirs_like_upstream() {
+        // Upstream's protocol-29 f_name_cmp sorts non-directories before
+        // directories within a directory (t_ITEM before t_PATH), then by
+        // name. Ascending: [a(symlink), c(special), b(dir)]; the reverse
+        // that `sort_by_name` applies yields [b, c, a]. A plain byte sort
+        // would instead give [c, b, a] because it ignores the kind - the
+        // bug this ordering fix corrects.
         let mut plan = DeletePlan::new(PathBuf::from("d"));
         plan.push(DeleteEntry::new(OsString::from("b"), DeleteEntryKind::Dir));
         plan.push(DeleteEntry::new(
@@ -386,7 +398,35 @@ mod tests {
             .iter()
             .map(|e| e.name.to_str().unwrap())
             .collect();
-        assert_eq!(names, vec!["c", "b", "a"]);
+        assert_eq!(names, vec!["b", "c", "a"]);
+    }
+
+    #[test]
+    fn sort_emits_dirs_before_files_when_dir_name_sorts_first() {
+        // Regression for the --max-delete survivor divergence: an
+        // upper-case directory name `D` byte-sorts ahead of files `a1`,
+        // `a2`, so a plain byte sort would emit [D, a2, a1] reversed ->
+        // [a2, a1, D], deleting the files first. Upstream's dir-after-file
+        // ordering makes the ascending order [a1, a2, D], reversed to
+        // [D, a2, a1], so the directory is processed first and the cap
+        // trips inside it - matching upstream's traversal.
+        let mut plan = DeletePlan::new(PathBuf::from("dest"));
+        plan.push(DeleteEntry::new(OsString::from("D"), DeleteEntryKind::Dir));
+        plan.push(DeleteEntry::new(
+            OsString::from("a1"),
+            DeleteEntryKind::File,
+        ));
+        plan.push(DeleteEntry::new(
+            OsString::from("a2"),
+            DeleteEntryKind::File,
+        ));
+        plan.sort_by_name();
+        let names: Vec<&str> = plan
+            .extras
+            .iter()
+            .map(|e| e.name.to_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["D", "a2", "a1"]);
     }
 
     #[test]

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -217,6 +217,18 @@ fn delete_extraneous_entries_capped<S: AsRef<OsStr>>(
     Ok(())
 }
 
+/// Orders two directory children the way upstream `get_dirlist` sorts them
+/// for a delete pass: protocol-29 `f_name_cmp` places non-directories before
+/// directories (t_ITEM before t_PATH, upstream: flist.c:3223), then by name.
+/// Callers `reverse()` the sorted slice to reproduce upstream's reverse
+/// dirlist iteration (`for (i = dirlist->used; i--; )`, delete.c:85 /
+/// generator.c:326), so directories are visited first, then files - the
+/// order that decides which entries survive a `--max-delete` cap and the
+/// order deletion log lines are emitted.
+fn cmp_child_delete_order(a: (&OsStr, bool), b: (&OsStr, bool)) -> std::cmp::Ordering {
+    a.1.cmp(&b.1).then_with(|| a.0.cmp(b.0))
+}
+
 /// Recursively removes one extraneous entry under the `--max-delete` cap,
 /// returning `true` when the entry was fully removed and `false` when it (or
 /// part of its subtree) was left in place because the cap was reached.
@@ -251,14 +263,19 @@ fn remove_entry_capped(
     if file_type.is_dir() {
         // Peel the directory's contents depth-first in upstream reverse-sorted
         // order before considering the directory itself.
-        let mut children: Vec<OsString> = Vec::new();
+        let mut children: Vec<(OsString, bool)> = Vec::new();
         match fs::read_dir(path) {
             Ok(iter) => {
                 for child in iter {
                     let child = child.map_err(|error| {
                         LocalCopyError::io("read extraneous directory entry", path, error)
                     })?;
-                    children.push(child.file_name());
+                    // `file_type()` uses readdir's d_type (falling back to
+                    // lstat) and does not follow symlinks, so a symlink to a
+                    // directory is classified as a non-directory - matching
+                    // upstream's S_ISDIR test on the lstat mode.
+                    let is_dir = child.file_type().map(|t| t.is_dir()).unwrap_or(false);
+                    children.push((child.file_name(), is_dir));
                 }
             }
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(true),
@@ -270,12 +287,13 @@ fn remove_entry_capped(
                 ));
             }
         }
-        // upstream: delete.c:85 iterates the sorted dirlist in reverse.
-        children.sort_unstable();
+        // Peel contents in upstream's reverse-sorted delete order so the
+        // prefix that survives when `--max-delete` trips matches upstream.
+        children.sort_unstable_by(|a, b| cmp_child_delete_order((&a.0, a.1), (&b.0, b.1)));
         children.reverse();
 
         let mut all_children_removed = true;
-        for child_name in children {
+        for (child_name, _) in children {
             let child_path = path.join(&child_name);
             let child_relative = entry_relative.join(&child_name);
             if !remove_entry_capped(context, &child_path, &child_relative, skipped)? {
@@ -676,21 +694,32 @@ pub(crate) fn record_directory_subtree(
             ));
         }
     };
+    // Collect the children with their type, then order them the way upstream
+    // `delete_in_dir` walks a directory (reverse of `get_dirlist`'s sorted
+    // order), so the emitted `*deleting` lines match upstream byte-for-byte.
+    let mut children: Vec<(OsString, fs::FileType)> = Vec::new();
     for entry in read_dir {
         context.enforce_timeout()?;
         let entry = entry.map_err(|error| {
             LocalCopyError::io("read extraneous directory entry", path_buf.as_path(), error)
         })?;
-        let name = entry.file_name();
-        path_buf.push(&name);
-        relative_buf.push(&name);
         let file_type = entry.file_type().map_err(|error| {
             LocalCopyError::io(
                 "inspect extraneous directory entry",
-                path_buf.clone(),
+                path_buf.join(entry.file_name()),
                 error,
             )
         })?;
+        children.push((entry.file_name(), file_type));
+    }
+    children.sort_unstable_by(|a, b| {
+        cmp_child_delete_order((&a.0, a.1.is_dir()), (&b.0, b.1.is_dir()))
+    });
+    children.reverse();
+
+    for (name, file_type) in children {
+        path_buf.push(&name);
+        relative_buf.push(&name);
         let is_dir = file_type.is_dir();
         if is_dir {
             record_directory_subtree(context, path_buf, relative_buf)?;

--- a/crates/engine/src/local_copy/tests/execute_max_delete.rs
+++ b/crates/engine/src/local_copy/tests/execute_max_delete.rs
@@ -724,6 +724,76 @@ fn max_delete_without_delete_flag_has_no_effect() {
 
 
 #[test]
+fn max_delete_survivor_set_matches_upstream_traversal() {
+    // Regression for the which-entries divergence (#207): with a mix of an
+    // extraneous directory whose name byte-sorts BEFORE the extraneous
+    // sibling files, oc must delete the same entries upstream rsync does
+    // when `--max-delete` caps the pass.
+    //
+    // Layout under the target: `D/{f1..f5}` (directory), plus files `a1`,
+    // `a2`. Upstream sorts each directory with protocol-29 f_name_cmp -
+    // files before directories - and deletes the resulting list in reverse,
+    // so it visits `D` first (recursing into it) and only reaches `a1`/`a2`
+    // afterwards. With `--max-delete=3` it removes `D/f5`, `D/f4`, `D/f3`
+    // (reverse name order inside `D`), hits the cap, and keeps `D/f1`,
+    // `D/f2`, `a1`, `a2`.
+    //
+    // A plain byte sort would order `D` (0x44) ahead of `a1`/`a2` (0x61) and,
+    // reversed, delete `a2` and `a1` first, then a single file inside `D` -
+    // surviving set `D/f1..f4`, which diverges from upstream. This test
+    // fails if the dir-aware ordering regresses to a byte sort.
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+
+    fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
+
+    let target_root = ctx.dest.join("source");
+    fs::create_dir_all(target_root.join("D")).expect("create D");
+    fs::write(target_root.join("keep.txt"), b"old").expect("write old");
+    for i in 1..=5 {
+        fs::write(target_root.join("D").join(format!("f{i}")), b"x").expect("write f");
+    }
+    fs::write(target_root.join("a1"), b"x").expect("write a1");
+    fs::write(target_root.join("a2"), b"x").expect("write a2");
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .delete(true)
+        .max_deletions(Some(3));
+
+    let error = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect_err("should fail when max-delete exceeded");
+
+    assert_eq!(error.exit_code(), MAX_DELETE_EXIT_CODE);
+    match error.kind() {
+        LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
+            assert_eq!(*skipped, 4, "f2, f1, a2, a1 remain unskipped");
+        }
+        other => panic!("unexpected error kind: {other:?}"),
+    }
+
+    // Upstream-correct survivors.
+    for survivor in ["a1", "a2", "D/f1", "D/f2"] {
+        assert!(
+            target_root.join(survivor).exists(),
+            "{survivor} must survive (upstream keeps it)"
+        );
+    }
+    // Upstream-correct deletions.
+    for deleted in ["D/f3", "D/f4", "D/f5"] {
+        assert!(
+            !target_root.join(deleted).exists(),
+            "{deleted} must be deleted (upstream removes it)"
+        );
+    }
+}
+
+#[test]
 fn max_delete_exit_code_is_25() {
     // Verify the exit code constant matches upstream rsync's RERR_DEL_LIMIT
     assert_eq!(MAX_DELETE_EXIT_CODE, 25);


### PR DESCRIPTION
## Problem

On a LOCAL `--delete --max-delete=N` transfer with a mix of extraneous files and subdirectories, oc-rsync and upstream rsync both delete exactly `N` entries and stop (data-safety cap holds), but *which* entries survive could differ.

Example: destination directory holds `D/{f1..f5}` (a subdirectory) plus files `a1`, `a2`; source is empty; `--max-delete=3`.

- Upstream keeps `a1`, `a2`, `D/f1`, `D/f2` (deletes `D/f3`, `D/f4`, `D/f5`).
- oc-rsync kept `D/f1..f4` (deleted `a1`, `a2`, `D/f5`).

## Root cause

The local-copy delete path sorted each directory's extraneous entries with the foundational byte-wise `f_name_cmp`, which deliberately omits the directory-vs-file distinction. Upstream `get_dirlist` sorts each directory with the protocol-29 comparator that orders non-directories before directories (`t_ITEM` before `t_PATH`, `flist.c:3223`), and `delete_in_dir` / `delete_dir_contents` iterate that sorted list in reverse (`generator.c:326`, `delete.c:85`). A byte sort makes an upper-case directory name like `D` (0x44) sort ahead of files `a1`/`a2` (0x61); reversed, that deletes the files first and reaches the cap after removing only one entry inside `D`.

## Fix

- `DeletePlan::sort_by_name` (and the sibling `ascending_order` helper) now use the dir-aware `compare_file_entries` instead of byte-wise `f_name_cmp`.
- The capped executor's recursive directory peel and the deletion-log walk apply the same files-before-dirs ordering, so nested directories and the `*deleting` output also follow upstream's traversal.
- The `--max-delete` cap accounting (guard-before-delete, count-on-success) is unchanged; only the visitation order is.

## Verification (local, vs rsync 3.4.4)

- Surviving set now byte-for-byte identical (`diff -r`) across mixed file+directory layouts and every cap value `N`.
- Uncapped `--delete -i` deletion-line order matches upstream exactly.
- Exit code 25 and the `(N skipped)` message preserved.
- `cargo fmt --all --check` clean; `cargo clippy -p engine -D warnings` clean; `cargo check -p engine --target x86_64-pc-windows-gnu` clean.
- Targeted engine tests pass (349 delete-related tests, plus new regression `max_delete_survivor_set_matches_upstream_traversal`).

## Note

A separate, pre-existing accounting divergence remains for the `(N skipped)` count when the cap saturates above a *non-empty nested subdirectory*: upstream's `delete_item` (called with `DEL_DIR_IS_EMPTY`) counts such a subdirectory as one skipped delete before discovering it is non-empty, whereas oc does not. Surviving files are identical; only the reported skipped number differs by the number of such subdirectories. This is cap-accounting logic, orthogonal to this ordering change, and is left for a follow-up.