### PR TITLE
fix(transfer): make network --append/--append-verify work over ssh and daemon

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -569,8 +569,14 @@ where
     let remove_source_files =
         matches.get_flag("remove-source-files") || matches.get_flag("remove-sent-files");
     let inplace = tri_state_flag_positive_first(&matches, "inplace", "no-inplace");
-    let append_verify_flag = matches.get_flag("append-verify");
-    let append = if append_verify_flag || matches.get_flag("append") {
+    // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode only on
+    // the server (`am_server`); a non-server invocation caps it at 1. A second
+    // `--append` on the server wire is the encoding of `--append-verify`
+    // (append_mode == 2). `--append-verify` sets it directly (options.c:719).
+    let append_count = matches.get_count("append");
+    let append_verify_flag =
+        matches.get_flag("append-verify") || (server_mode && append_count >= 2);
+    let append = if append_verify_flag || append_count >= 1 {
         Some(true)
     } else if matches.get_flag("no-append") {
         Some(false)

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -580,8 +580,8 @@ mod long_options {
         // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode on
         // am_server, so two --append flags select append-verify (append_mode == 2).
         // The client encodes --append-verify this way; the server must recover it.
-        let parsed =
-            parse_test_args(["--server", "--sender", "--append", "--append", ".", "src"]).expect("parse");
+        let parsed = parse_test_args(["--server", "--sender", "--append", "--append", ".", "src"])
+            .expect("parse");
         assert_eq!(parsed.append, Some(true));
         assert!(
             parsed.append_verify,

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -576,6 +576,32 @@ mod long_options {
     }
 
     #[test]
+    fn doubled_append_in_server_mode_is_append_verify() {
+        // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode on
+        // am_server, so two --append flags select append-verify (append_mode == 2).
+        // The client encodes --append-verify this way; the server must recover it.
+        let parsed =
+            parse_test_args(["--server", "--sender", "--append", "--append", ".", "src"]).expect("parse");
+        assert_eq!(parsed.append, Some(true));
+        assert!(
+            parsed.append_verify,
+            "doubled --append on the server must set append_verify"
+        );
+    }
+
+    #[test]
+    fn doubled_append_client_mode_is_not_verify() {
+        // upstream: options.c:1726 - a non-server invocation caps append_mode at 1,
+        // so repeated --append on the client stays plain append (trust prefix).
+        let parsed = parse_test_args(["--append", "--append", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.append, Some(true));
+        assert!(
+            !parsed.append_verify,
+            "doubled --append off-server must not imply verify"
+        );
+    }
+
+    #[test]
     fn dirs_long_flag() {
         let parsed = parse_test_args(["--dirs", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.dirs, Some(true));

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -110,14 +110,18 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .overrides_with("remove-source-files"),
             )
             .arg(
+                // upstream: options.c:1722-1726 - OPT_APPEND increments
+                // append_mode on the server side; two `--append` flags mean
+                // append_mode == 2 (verify). Count occurrences so the server
+                // parser can recover that from the wire, where a repeated
+                // `--append` (never `--append-verify`) carries the verify bit.
                 Arg::new("append")
                     .long("append")
                     .help(
                         "Append data to existing destination files without rewriting preserved bytes.",
                     )
-                    .action(ArgAction::SetTrue)
-                    .overrides_with("no-append")
-                    .overrides_with("append-verify"),
+                    .action(ArgAction::Count)
+                    .overrides_with("no-append"),
             )
             .arg(
                 Arg::new("no-append")

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -313,6 +313,12 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     server_config.trust_sender = config.trust_sender();
     server_config.qsort = config.qsort();
     server_config.write.inplace = config.inplace();
+    // upstream: receiver.c:855 - append mode implies inplace; the sum_head
+    // block-skip (generator.c:786) and flength derivation (sender.c:89) on both
+    // the local sender (push) and receiver (pull) roles gate on these flags, so
+    // they must be carried onto the in-process ServerConfig for SSH and daemon.
+    server_config.flags.append = config.append();
+    server_config.flags.append_verify = config.append_verify();
     server_config.has_partial_dir = config.partial_directory().is_some();
     server_config.partial_dir = config.partial_directory().map(std::path::Path::to_path_buf);
     server_config.file_selection.min_file_size = config.min_file_size();

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -376,10 +376,15 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--inplace"));
         }
 
+        // upstream: options.c:2951-2954 server_options() - append_mode is sent
+        // as one or two bare `--append` flags, never `--append-verify`. A
+        // second `--append` is what tells the server-side receiver to run in
+        // verify mode (append_mode == 2, OPT_APPEND increments it on am_server).
         if self.config.append() {
             args.push(OsString::from("--append"));
-        } else if self.config.append_verify() {
-            args.push(OsString::from("--append-verify"));
+            if self.config.append_verify() {
+                args.push(OsString::from("--append"));
+            }
         }
 
         if self.config.copy_unsafe_links() {

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -1606,7 +1606,10 @@ fn includes_append_long_arg() {
     let config = ClientConfig::builder().append(true).build();
     let args = build_sender_args(&config);
     let count = args.iter().filter(|a| *a == "--append").count();
-    assert_eq!(count, 1, "plain --append should emit one --append: {args:?}");
+    assert_eq!(
+        count, 1,
+        "plain --append should emit one --append: {args:?}"
+    );
     assert!(
         !args.iter().any(|a| a == "--append-verify"),
         "must not forward --append-verify to the server: {args:?}"

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -1601,38 +1601,34 @@ fn includes_temp_dir_long_arg() {
 
 #[test]
 fn includes_append_long_arg() {
+    // Plain --append (append_mode == 1) emits exactly one --append and never
+    // --append-verify. upstream: options.c:2951-2954 server_options().
     let config = ClientConfig::builder().append(true).build();
     let args = build_sender_args(&config);
+    let count = args.iter().filter(|a| *a == "--append").count();
+    assert_eq!(count, 1, "plain --append should emit one --append: {args:?}");
     assert!(
-        args.iter().any(|a| a == "--append"),
-        "expected --append in args: {args:?}"
+        !args.iter().any(|a| a == "--append-verify"),
+        "must not forward --append-verify to the server: {args:?}"
     );
 }
 
 #[test]
-fn append_verify_via_builder_emits_append() {
-    // The builder's append_verify(true) sets append=true internally,
-    // so the invocation emits --append (the append() check comes first).
-    // This mirrors upstream behavior where --append-verify implies --append.
+fn append_verify_emits_doubled_append() {
+    // --append-verify (append_mode == 2) is encoded on the wire as two bare
+    // --append flags, never --append-verify. The server's OPT_APPEND increments
+    // append_mode on am_server, so the second flag is what selects verify mode.
+    // upstream: options.c:2951-2954 server_options() + options.c:1722-1726.
     let config = ClientConfig::builder().append_verify(true).build();
     let args = build_sender_args(&config);
-    assert!(
-        args.iter().any(|a| a == "--append"),
-        "append_verify via builder should produce --append: {args:?}"
+    let count = args.iter().filter(|a| *a == "--append").count();
+    assert_eq!(
+        count, 2,
+        "append_verify should emit two --append flags: {args:?}"
     );
-}
-
-#[test]
-fn append_verify_emits_append_because_builder_sets_both() {
-    // The builder's append_verify(true) sets both append=true and
-    // append_verify=true. The invocation code checks append() first,
-    // so --append is emitted. To get --append-verify alone, one would
-    // need to set append_verify without append (not possible via builder).
-    let config = ClientConfig::builder().append_verify(true).build();
-    let args = build_sender_args(&config);
     assert!(
-        args.iter().any(|a| a == "--append"),
-        "append_verify via builder should emit --append: {args:?}"
+        !args.iter().any(|a| a == "--append-verify"),
+        "must not forward --append-verify to the server: {args:?}"
     );
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -99,7 +99,14 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
             "--inplace" => {
                 config.write.inplace = true;
             }
+            // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode
+            // on the server side. A second `--append` (append_mode == 2) is the
+            // wire encoding of `--append-verify`; the client never sends the
+            // long-form `--append-verify` to a server.
             "--append" => {
+                if config.flags.append {
+                    config.flags.append_verify = true;
+                }
                 config.flags.append = true;
             }
             // upstream: options.c:2934-2935

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -174,6 +174,18 @@ pub struct DiskCommitConfig {
     /// - `receiver.c:906-929`: staging to partial dir when `delay_updates`
     /// - `receiver.c:584-585`: `handle_delayed_updates()` at phase 2
     pub delay_updates: bool,
+    /// Whether `--append-verify` (append_mode == 2) is active for the session.
+    ///
+    /// When true and a file is transferred with a non-zero append offset, the
+    /// disk thread reads the existing prefix `[0, append_offset)` and folds it
+    /// into the whole-file checksum before hashing the appended tokens, so a
+    /// corrupted prefix fails verification and triggers a re-transmit. Plain
+    /// `--append` leaves this false and trusts the prefix.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:357-373` - `if (append_mode == 2 && mapbuf)` prefix `sum_update`
+    pub append_verify: bool,
 }
 
 impl Default for DiskCommitConfig {
@@ -196,6 +208,7 @@ impl Default for DiskCommitConfig {
             iocp_policy: fast_io::IocpPolicy::Auto,
             partial_mode: PartialMode::None,
             delay_updates: false,
+            append_verify: false,
         }
     }
 }

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -9,7 +9,7 @@ use std::io;
 
 use engine::CleanupManager;
 
-use crate::delta_apply::SparseWriteState;
+use crate::delta_apply::{ChecksumVerifier, SparseWriteState};
 use crate::pipeline::messages::{BeginMessage, CommitResult, FileMessage};
 use crate::pipeline::spsc;
 use crate::temp_guard::TempFileGuard;
@@ -22,6 +22,46 @@ use super::super::config::DiskCommitConfig;
 use super::super::writer::{ReusableBufWriter, Writer};
 use super::commit::{commit_file, retain_partial_file};
 use super::metadata::{apply_file_metadata, finalize_checksum};
+
+/// Folds the existing on-disk prefix into the whole-file checksum for
+/// `--append-verify` (append_mode == 2).
+///
+/// Reads `[0, append_offset)` from the destination and feeds it to `verifier`
+/// before the appended tokens are hashed, so a corrupted prefix fails
+/// verification and triggers a re-transmit. A no-op unless append-verify is
+/// active with a non-zero offset and a live verifier.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:357-373` - `if (append_mode == 2 && mapbuf)` sum_update loop
+///   over `sum.flength` bytes in `CHUNK_SIZE` steps.
+fn sum_append_prefix(
+    config: &DiskCommitConfig,
+    begin: &BeginMessage,
+    verifier: &mut Option<ChecksumVerifier>,
+) -> io::Result<()> {
+    use std::io::Read;
+
+    if !config.append_verify || begin.append_offset == 0 {
+        return Ok(());
+    }
+    let Some(verifier) = verifier.as_mut() else {
+        return Ok(());
+    };
+
+    // Append implies inplace (receiver.c:855), so the prefix lives at the final
+    // destination and is untouched until the appended tail is written.
+    let mut file = fs::File::open(&begin.file_path)?;
+    let mut remaining = begin.append_offset;
+    let mut buf = vec![0u8; 256 * 1024];
+    while remaining > 0 {
+        let to_read = buf.len().min(remaining as usize);
+        file.read_exact(&mut buf[..to_read])?;
+        verifier.update(&buf[..to_read]);
+        remaining -= to_read as u64;
+    }
+    Ok(())
+}
 
 /// Processes a single file: open, write chunks, commit or abort.
 ///
@@ -94,6 +134,10 @@ pub(in crate::disk_commit) fn process_file(
     // Computing the checksum here overlaps hashing with disk I/O and
     // removes ~42% of instructions from the network-critical path.
     let mut checksum_verifier = begin.checksum_verifier.take();
+
+    // upstream: receiver.c:357-373 - fold the existing prefix into the
+    // whole-file checksum under --append-verify before hashing the tail.
+    sum_append_prefix(config, &begin, &mut checksum_verifier)?;
 
     let mut bytes_written: u64 = 0;
 
@@ -286,6 +330,9 @@ pub(in crate::disk_commit) fn process_whole_file(
     let bytes_written = data.len() as u64;
 
     let mut checksum_verifier = begin.checksum_verifier.take();
+    // upstream: receiver.c:357-373 - fold the existing prefix into the
+    // whole-file checksum under --append-verify before hashing the tail.
+    sum_append_prefix(config, &begin, &mut checksum_verifier)?;
     if let Some(ref mut verifier) = checksum_verifier {
         verifier.update(&data);
     }

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -133,6 +133,17 @@ pub struct ParsedServerFlags {
     ///
     /// Not part of the compact flag string; set via long-form args.
     pub append: bool,
+    /// Re-verify the existing prefix by folding it into the whole-file
+    /// checksum (`--append-verify`, upstream `append_mode == 2`).
+    ///
+    /// Implies [`append`](Self::append). When set, both sender and receiver
+    /// `sum_update()` the bytes already present on disk so a corrupted prefix
+    /// fails the whole-file checksum and triggers a full re-transmit. Plain
+    /// `--append` (`append_mode == 1`) trusts the prefix and never sums it.
+    ///
+    /// Upstream: `options.c:719` (`append_mode = 2`), `match.c:373` and
+    /// `receiver.c:357` (`if (append_mode == 2)` prefix `sum_update`).
+    pub append_verify: bool,
     /// Make backups before overwriting (`b` flag, `--backup`).
     ///
     /// Upstream: `options.c:2613` - `argstr[x++] = 'b'`.

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -330,6 +330,93 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
     })
 }
 
+/// Streams the appended tail of a file to the wire in append mode.
+///
+/// In append mode the receiver already holds the first `flength` bytes, so the
+/// sender transmits only `[flength, file_size)` as literal tokens - never any
+/// block-match tokens (the sum_head carried no block checksums). The whole-file
+/// checksum folds in the existing prefix only when `append_verify` is set
+/// (upstream `append_mode == 2`); plain append trusts the prefix and sums just
+/// the new tail so both sides agree.
+///
+/// # Upstream Reference
+///
+/// - `match.c:371-390 match_sums()` - prefix `sum_update` gated on `append_mode == 2`,
+///   `s->count = 0`, `last_match = s->flength`.
+/// - `sender.c:89-95 receive_sums()` - append mode derives `flength` and reads no blocks.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn stream_append_transfer<R: Read, W: Write>(
+    writer: &mut W,
+    mut source: R,
+    file_size: u64,
+    flength: u64,
+    append_verify: bool,
+    checksum_algorithm: ChecksumAlgorithm,
+    checksum_seed: i32,
+    encoder: Option<&mut CompressedTokenEncoder>,
+    buf: &mut Vec<u8>,
+) -> io::Result<StreamResult> {
+    let mut verifier = ChecksumVerifier::for_algorithm_seeded(checksum_algorithm, checksum_seed);
+
+    const MAX_READ_SIZE: usize = 256 * 1024;
+
+    // upstream: match.c:372-390 - consume the existing prefix. append_mode == 2
+    // folds it into the whole-file checksum (verify); append_mode == 1 skips the
+    // sum (trust). Either way the prefix bytes are never sent as tokens.
+    let mut prefix_remaining = flength.min(file_size);
+    if prefix_remaining > 0 {
+        buf.resize((prefix_remaining as usize).clamp(1, MAX_READ_SIZE), 0);
+        while prefix_remaining > 0 {
+            let to_read = buf.len().min(prefix_remaining as usize);
+            source.read_exact(&mut buf[..to_read])?;
+            if append_verify {
+                verifier.update(&buf[..to_read]);
+            }
+            prefix_remaining -= to_read as u64;
+        }
+    }
+
+    // Stream [flength, file_size) as literal tokens, folding into the checksum.
+    let mut remaining = file_size.saturating_sub(flength);
+    let read_size = (remaining as usize).clamp(1, MAX_READ_SIZE);
+
+    if let Some(encoder) = encoder {
+        buf.resize(read_size, 0);
+        while remaining > 0 {
+            let to_read = buf.len().min(remaining as usize);
+            source.read_exact(&mut buf[..to_read])?;
+            verifier.update(&buf[..to_read]);
+            encoder.send_literal(writer, &buf[..to_read])?;
+            remaining -= to_read as u64;
+        }
+        encoder.finish(writer)?;
+    } else {
+        buf.resize(4 + read_size, 0);
+        while remaining > 0 {
+            let to_read = (buf.len() - 4).min(remaining as usize);
+            source.read_exact(&mut buf[4..4 + to_read])?;
+            verifier.update(&buf[4..4 + to_read]);
+            let mut wire_off = 0;
+            while wire_off < to_read {
+                let chunk = (to_read - wire_off).min(CHUNK_SIZE);
+                buf[wire_off..wire_off + 4].copy_from_slice(&(chunk as i32).to_le_bytes());
+                writer.write_all(&buf[wire_off..wire_off + 4 + chunk])?;
+                wire_off += chunk;
+            }
+            remaining -= to_read as u64;
+        }
+        write_token_end(writer)?;
+    }
+
+    let mut checksum_buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+    let checksum_len = verifier.finalize_into(&mut checksum_buf);
+
+    Ok(StreamResult {
+        checksum_buf,
+        checksum_len,
+    })
+}
+
 /// Converts engine delta script to wire protocol delta operations.
 ///
 /// Takes ownership of the script to avoid cloning literal data. Multi-block
@@ -725,6 +812,82 @@ mod tests {
             &result.checksum_buf[..result.checksum_len],
             &expected_buf[..expected_len],
             "inline checksum must equal checksum of source bytes covered by the script",
+        );
+    }
+
+    /// The append streamer must transmit only the tail past `flength` and fold
+    /// the existing prefix into the whole-file checksum only under append-verify
+    /// (append_mode == 2). Mirrors upstream match.c:371-390.
+    #[test]
+    fn stream_append_transfer_tail_and_prefix_checksum() {
+        let file: Vec<u8> = (0..100u32).map(|i| (i % 256) as u8).collect();
+        let flength: u64 = 40;
+        let tail_len = file.len() as u64 - flength;
+
+        // Trust mode (append_mode == 1): checksum covers only [flength, len).
+        let mut wire_trust = Vec::new();
+        let mut buf = Vec::new();
+        let res_trust = stream_append_transfer(
+            &mut wire_trust,
+            std::io::Cursor::new(file.clone()),
+            file.len() as u64,
+            flength,
+            false,
+            ChecksumAlgorithm::MD5,
+            0,
+            None,
+            &mut buf,
+        )
+        .expect("append stream (trust)");
+
+        let mut exp_tail = ChecksumVerifier::for_algorithm(ChecksumAlgorithm::MD5);
+        exp_tail.update(&file[flength as usize..]);
+        let mut exp_tail_buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+        let exp_tail_len = exp_tail.finalize_into(&mut exp_tail_buf);
+        assert_eq!(
+            &res_trust.checksum_buf[..res_trust.checksum_len],
+            &exp_tail_buf[..exp_tail_len],
+            "append (trust) checksum must cover only the appended tail",
+        );
+
+        // Verify mode (append_mode == 2): checksum covers the whole file.
+        let mut wire_verify = Vec::new();
+        buf.clear();
+        let res_verify = stream_append_transfer(
+            &mut wire_verify,
+            std::io::Cursor::new(file.clone()),
+            file.len() as u64,
+            flength,
+            true,
+            ChecksumAlgorithm::MD5,
+            0,
+            None,
+            &mut buf,
+        )
+        .expect("append stream (verify)");
+
+        let mut exp_whole = ChecksumVerifier::for_algorithm(ChecksumAlgorithm::MD5);
+        exp_whole.update(&file);
+        let mut exp_whole_buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+        let exp_whole_len = exp_whole.finalize_into(&mut exp_whole_buf);
+        assert_eq!(
+            &res_verify.checksum_buf[..res_verify.checksum_len],
+            &exp_whole_buf[..exp_whole_len],
+            "append-verify checksum must cover the existing prefix plus the tail",
+        );
+
+        // The prefix is never sent as tokens, so both modes emit the same wire:
+        // one literal chunk carrying exactly the tail, then the end token.
+        assert_eq!(wire_trust, wire_verify, "verify must not change the wire");
+        assert_eq!(
+            &wire_trust[0..4],
+            &(tail_len as i32).to_le_bytes(),
+            "first wire chunk length must equal the appended tail length",
+        );
+        assert_eq!(
+            wire_trust.len() as u64,
+            4 + tail_len + 4,
+            "wire is [len][tail][end], no prefix bytes",
         );
     }
 }

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -18,7 +18,7 @@ use protocol::codec::{
 use protocol::stats::DeleteStats;
 
 use super::super::delta::{
-    create_token_encoder, script_to_wire_delta, stream_whole_file_transfer,
+    create_token_encoder, script_to_wire_delta, stream_append_transfer, stream_whole_file_transfer,
     write_delta_with_inline_checksum,
 };
 use super::super::item_flags::ItemFlags;
@@ -382,9 +382,20 @@ impl GeneratorContext {
             let source_path = self.reconstruct_source_path(ndx);
             let source_path_display = source_path.display().to_string();
 
-            let sig_blocks = read_signature_blocks(&mut *reader, &sum_head)?;
-            let bytes_per_block = 4 + sum_head.s2length as u64;
-            self.timing.total_bytes_read += sum_head.count as u64 * bytes_per_block;
+            // upstream: sender.c:89-95 receive_sums() - in append mode the
+            // receiver's generator writes only the sum_head, not the block
+            // checksums (generator.c:786 `if (append_mode > 0 && f_copy < 0)
+            // return 0`). Reading blocks here would block forever, so derive
+            // flength from the header and take the append literal path.
+            let is_append = self.config.flags.append;
+            let sig_blocks = if is_append {
+                Vec::new()
+            } else {
+                let blocks = read_signature_blocks(&mut *reader, &sum_head)?;
+                let bytes_per_block = 4 + sum_head.s2length as u64;
+                self.timing.total_bytes_read += sum_head.count as u64 * bytes_per_block;
+                blocks
+            };
 
             let block_length = sum_head.blength;
             let strong_sum_length = sum_head.s2length as u8;
@@ -396,7 +407,60 @@ impl GeneratorContext {
 
             let file_size = file_entry.size();
 
-            if has_basis {
+            if is_append && has_basis {
+                // upstream: match.c:371-390 - append mode streams only the tail
+                // past the existing prefix; the sum_head's count/blength encode
+                // that flength. No block matching, no signature blocks.
+                let (source, _src_fd): (Box<dyn Read>, Option<_>) = match self
+                    .open_source_unbuffered(&source_path, file_size)
+                {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        self.record_open_failure(&mut *writer, wire_ndx, &e, &source_path_display)?;
+                        continue;
+                    }
+                };
+
+                self.write_ndx_and_attrs(
+                    &mut *writer,
+                    &mut ndx_write_codec,
+                    &NdxAttrs {
+                        ndx: wire_ndx,
+                        iflags: &iflags,
+                        fnamecmp_type,
+                        xname: xname.as_deref(),
+                    },
+                    &sum_head,
+                    pending_xattr_response.as_mut(),
+                )?;
+
+                let checksum_algorithm = self.get_checksum_algorithm();
+                let use_compression = self.file_compression(&source_path).is_some();
+                let flength = sum_head.flength().min(file_size);
+                let append_verify = self.config.flags.append_verify;
+                let wire_bytes = {
+                    let mut cw = crate::writer::CountingWriter::new(&mut *writer);
+                    let result = stream_append_transfer(
+                        &mut cw,
+                        source,
+                        file_size,
+                        flength,
+                        append_verify,
+                        checksum_algorithm,
+                        self.checksum_seed,
+                        if use_compression {
+                            token_encoder.as_mut()
+                        } else {
+                            None
+                        },
+                        &mut stream_buf,
+                    )?;
+                    cw.write_all(&result.checksum_buf[..result.checksum_len])?;
+                    cw.bytes_written()
+                };
+                bytes_sent += wire_bytes;
+                literal_data += file_size.saturating_sub(flength);
+            } else if has_basis {
                 let source: Box<dyn Read> = match self.open_source_reader(&source_path, file_size) {
                     Ok(r) => r,
                     Err(e) => {

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -95,7 +95,12 @@ impl ReceiverContext {
                 && self.compat_flags.is_some_and(|f| {
                     !f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
                 }),
-            append: self.config.flags.append,
+            // upstream: receiver.c:761-773 - a phase-2 redo negates append_mode
+            // (`append_mode = -append_mode`), so the re-request is a full
+            // transfer that overwrites the file rather than appending to a
+            // prefix the verify pass already rejected.
+            append: self.config.flags.append && !is_redo_pass,
+            append_verify: self.config.flags.append_verify && !is_redo_pass,
         };
 
         // upstream: token.c uses a single compression context across all files.
@@ -152,6 +157,7 @@ impl ReceiverContext {
             io_uring_depth: self.config.write.io_uring_depth,
             partial_mode,
             delay_updates: self.config.write.delay_updates,
+            append_verify: self.config.flags.append_verify && !is_redo_pass,
             ..DiskCommitConfig::default()
         };
         let mut pipelined_receiver = PipelinedReceiver::new(disk_config)?;

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -144,6 +144,16 @@ pub struct RequestConfig<'a> {
     /// - `generator.c:775-776` - generator skips writing signature blocks in append mode
     /// - `sender.c:87-92` - `receive_sums()` returns early without reading blocks
     pub append: bool,
+    /// Whether append-verify mode is active (`--append-verify`, append_mode == 2).
+    ///
+    /// When true the receiver folds the existing on-disk prefix into the
+    /// whole-file checksum so a corrupted prefix fails verification and triggers
+    /// a re-transmit. Plain `--append` trusts the prefix and never sums it.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:357-373` - `if (append_mode == 2)` prefix `sum_update`
+    pub append_verify: bool,
 }
 
 impl RequestConfig<'_> {
@@ -322,6 +332,7 @@ mod tests {
             preserve_xattrs: false,
             want_xattr_optim: false,
             append: false,
+            append_verify: false,
         };
         let debug_str = format!("{config:?}");
         assert!(debug_str.contains("RequestConfig"));


### PR DESCRIPTION
## Summary

Network `--append` and `--append-verify` were non-functional over both SSH and daemon transports: a pull exited 23 with a protocol desync (`File-list index N not in -1 - 0`) and a push hung. Local append worked only because the local-copy path never uses the wire `sum_head` protocol.

### Root cause

In append mode upstream transmits **only** the `sum_head` (whose `count`/`blength`/`remainder` encode the existing file length) and **no** block checksums, on both sides:
- generator writes the header then returns without sending blocks (`generator.c:786`)
- sender reads the header, derives `flength`, and reads no blocks (`sender.c:89-95`)

oc's sender read block checksums that were never sent (the push hang), and the receiver never advertised append onto its own in-process `ServerConfig`, so it sent block checksums that the append-mode peer ignored, leaving them in the stream (the pull desync).

### Changes

- Propagate `--append`/`--append-verify` onto the in-process receiver and sender `ServerConfig` for both SSH and daemon paths (`apply_common_server_flags`).
- **Sender**: skip reading signature blocks in append mode and stream only the tail past `flength` via a new `stream_append_transfer`, folding the existing prefix into the whole-file checksum only under `--append-verify` (`match.c:371-390`).
- **Receiver**: fold the on-disk prefix into the whole-file checksum on the disk-commit thread under `--append-verify` (`receiver.c:357-373`), so a corrupted prefix fails verification instead of being trusted.
- **Client wire encoding**: emit the doubled bare `--append` for `--append-verify` rather than `--append-verify`, matching `server_options()` (`options.c:2951-2954`); the daemon path already did this.
- **Server arg parsing**: count repeated `--append` as `append_mode == 2` on `am_server` (`options.c:1722-1726`) in both the CLI parser and the daemon long-form parser.
- **Phase-2 redo**: negate append mode so a rejected verify prefix is redone as a full transfer (`receiver.c:761-773`).

### Verification (oc client vs upstream rsync 3.4.4 daemon)

| Scenario | Result |
|---|---|
| PULL `--append`, good prefix | rc=0, byte-identical |
| PUSH `--append`, good prefix | rc=0, byte-identical |
| PULL `--append-verify`, good prefix | rc=0, byte-identical (prefix verified) |
| PUSH `--append-verify`, good prefix | rc=0, byte-identical (prefix verified) |
| PULL `--append`, corrupted prefix | rc=0, prefix trusted (matches upstream) |
| PULL `--append-verify`, corrupted prefix | verification correctly fails |
| Plain `-a` pull/push/delta/no-change | rc=0, byte-identical (no regression) |

### Known limitation

On a **corrupted** `--append-verify` prefix, verification correctly detects the mismatch but the automatic phase-2 re-transmit desyncs against an upstream peer (exits 23, fails loud, no silent corruption). Upstream recovers here; oc's phase-2 redo handshake with an upstream peer is a separate pre-existing gap (this fix is what first makes that path reachable). Tracked for follow-up.

### Tests

- fmt + clippy clean on touched crates; `x86_64-pc-windows-gnu` cross-compile clean.
- Unit tests added: doubled-flag wire encoding, server-side append counting (server vs client mode), and the append tail streamer (tail-only wire + prefix checksum under verify).
