### PR TITLE
fix(filters): keep filter-rule whitespace verbatim per upstream

### DIFF
--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -152,18 +152,19 @@ fn parse_merge_contents(
     }
 
     for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
+        // upstream: exclude.c:1514 parse_filter_file - a line is skipped only
+        // when it is empty or (line parsing) begins with `;`/`#`. Whitespace is
+        // never stripped, so leading whitespace and whitespace-only lines fall
+        // through to the rule parser and error, while trailing whitespace stays
+        // part of the pattern verbatim (exclude.c:1313, strlen length).
+        if line.is_empty() {
             continue;
         }
-        if options.allows_comments() && trimmed.starts_with('#') {
-            continue;
-        }
-        if trimmed.starts_with(';') && options.allows_comments() {
+        if options.allows_comments() && (line.starts_with('#') || line.starts_with(';')) {
             continue;
         }
 
-        if trimmed == "!" {
+        if line == "!" {
             if options.list_clear_allowed() {
                 destination.clear();
                 continue;
@@ -177,16 +178,18 @@ fn parse_merge_contents(
         }
 
         if let Some(kind) = options.enforced_kind() {
+            // upstream: FILTRULE_NO_PREFIXES takes the whole line as the pattern
+            // verbatim (exclude.c:1122-1124,1313), so no whitespace is trimmed.
             let mut rule = match kind {
-                DirMergeEnforcedKind::Include => FilterRuleSpec::include(trimmed.to_owned()),
-                DirMergeEnforcedKind::Exclude => FilterRuleSpec::exclude(trimmed.to_owned()),
+                DirMergeEnforcedKind::Include => FilterRuleSpec::include(line.to_owned()),
+                DirMergeEnforcedKind::Exclude => FilterRuleSpec::exclude(line.to_owned()),
             };
             rule.apply_dir_merge_overrides(options);
             destination.push(rule);
             continue;
         }
 
-        process_merge_directive(trimmed, options, base_dir, display, destination, visited)?;
+        process_merge_directive(line, options, base_dir, display, destination, visited)?;
     }
 
     Ok(())

--- a/crates/cli/src/frontend/filter_rules/parsing/entry.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/entry.rs
@@ -19,17 +19,21 @@ use super::rules::{
 
 pub(crate) fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective, Message> {
     let text = argument.to_string_lossy();
-    let trimmed_leading = text.trim_start();
+    // upstream: exclude.c:1100-1213 parse_rule_tok - leading whitespace is only
+    // skipped under FILTRULE_WORD_SPLIT, which a top-level `--filter` rule never
+    // carries. A leading space therefore reaches the prefix `switch` default and
+    // raises "Unknown filter rule" (RERR_SYNTAX). Do not trim the leading edge.
+    let rule: &str = &text;
 
-    if let Some(result) = parse_short_merge_directive(trimmed_leading) {
+    if let Some(result) = parse_short_merge_directive(rule) {
         return result;
     }
 
-    if let Some(result) = parse_long_merge_directive(trimmed_leading) {
+    if let Some(result) = parse_long_merge_directive(rule) {
         return result;
     }
 
-    parse_rule_directive(trimmed_leading)
+    parse_rule_directive(rule)
 }
 
 /// Parses a line under upstream rsync's `XFLG_OLD_PREFIXES` compatibility mode
@@ -93,7 +97,11 @@ pub(crate) fn parse_old_prefix_rule(
 }
 
 pub(super) fn parse_rule_directive(text: &str) -> Result<FilterDirective, Message> {
-    let trimmed = text.trim_end();
+    // upstream: exclude.c:1313 parse_rule_tok - the pattern length is strlen, so
+    // trailing whitespace is part of the pattern and is never stripped. A rule
+    // like `- *.o ` keeps the trailing space in its pattern, so `x.o` is not
+    // matched by `*.o ` and stays included.
+    let trimmed = text;
 
     if trimmed.is_empty() {
         let message = rsync_error!(

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -437,12 +437,24 @@ fn shorthand_non_matching() {
 }
 
 #[test]
-fn leading_whitespace_trimmed() {
+fn leading_whitespace_is_rejected() {
+    // upstream: exclude.c:1100-1213 parse_rule_tok - a top-level rule never
+    // carries FILTRULE_WORD_SPLIT, so leading whitespace is not skipped; it
+    // reaches the prefix `switch` default and errors. It must not be trimmed.
     let result = parse_filter_directive(OsStr::new("   + *.txt"));
-    assert!(result.is_ok());
+    assert!(result.is_err());
+}
+
+#[test]
+fn trailing_whitespace_is_kept_in_pattern() {
+    // upstream: exclude.c:1313 - trailing whitespace is part of the pattern
+    // (strlen length), so `- *.o ` keeps its trailing space and `x.o` stays
+    // included.
+    let result = parse_filter_directive(OsStr::new("- *.o "));
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
-            assert_eq!(spec.kind(), FilterRuleKind::Include);
+            assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+            assert_eq!(spec.pattern(), "*.o ");
         }
         _ => panic!("expected Rule directive"),
     }

--- a/crates/cli/src/frontend/tests/parse_filter.rs
+++ b/crates/cli/src/frontend/tests/parse_filter.rs
@@ -123,9 +123,11 @@ fn parse_filter_directive_accepts_clear_directive() {
     let clear = parse_filter_directive(OsStr::new("!")).expect("clear directive parses");
     assert_eq!(clear, FilterDirective::Clear);
 
-    let clear_with_whitespace =
-        parse_filter_directive(OsStr::new("  !   ")).expect("clear with whitespace parses");
-    assert_eq!(clear_with_whitespace, FilterDirective::Clear);
+    // upstream: exclude.c:1211-1213 - leading whitespace is not skipped for a
+    // top-level rule, so `  !   ` reaches the prefix `switch` default and errors
+    // ("Unknown filter rule") rather than being treated as a clear.
+    let _ =
+        parse_filter_directive(OsStr::new("  !   ")).expect_err("leading whitespace should error");
 }
 
 #[test]
@@ -133,8 +135,14 @@ fn parse_filter_directive_accepts_clear_keyword() {
     let keyword = parse_filter_directive(OsStr::new("clear")).expect("keyword parses");
     assert_eq!(keyword, FilterDirective::Clear);
 
-    let uppercase = parse_filter_directive(OsStr::new("  CLEAR  ")).expect("uppercase parses");
+    let uppercase = parse_filter_directive(OsStr::new("CLEAR")).expect("uppercase parses");
     assert_eq!(uppercase, FilterDirective::Clear);
+
+    // upstream: exclude.c:1211-1213,1318-1320 - a leading space errors before the
+    // keyword is recognised, and trailing text on a clear rule is rejected with
+    // "'!' rule has trailing characters"; neither is trimmed away.
+    let _ = parse_filter_directive(OsStr::new("  CLEAR  "))
+        .expect_err("surrounding whitespace should error");
 }
 
 #[test]

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -40,8 +40,12 @@ pub fn parse_rules(content: &str, source_path: &Path) -> Result<Vec<FilterRule>,
 
     for (line_num, line) in content.lines().enumerate() {
         let line_num = line_num + 1; // 1-indexed for error messages
-        let line = line.trim();
 
+        // upstream: exclude.c:1514 parse_filter_file - a line is skipped only
+        // when it is empty or (line parsing) begins with `;`/`#`. Whitespace is
+        // never stripped, so a whitespace-only line and a leading-whitespace
+        // rule both fall through to parse_rule_tok and raise "Unknown filter
+        // rule" (RERR_SYNTAX). Trailing whitespace stays part of the pattern.
         if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
             continue;
         }
@@ -100,11 +104,14 @@ pub(crate) fn parse_rules_no_prefixes(
         }
     } else {
         for line in content.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+            // upstream: exclude.c:1514 parse_filter_file - skip only empty and
+            // (line parsing) `;`/`#` comment lines; the surviving line becomes a
+            // literal pattern verbatim (FILTRULE_NO_PREFIXES takes strlen with no
+            // trimming, exclude.c:1313), so leading/trailing whitespace is kept.
+            if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
                 continue;
             }
-            push_token(trimmed);
+            push_token(line);
         }
     }
 
@@ -306,8 +313,13 @@ pub(crate) fn parse_modifiers<'a>(
                 mods.no_prefixes_include = true;
             }
             ' ' | '_' => {
+                // upstream: exclude.c:1290-1291 - after the modifier loop stops
+                // at the first separator, exactly one separator is consumed
+                // (`if (*s) s++`). The pattern length is then strlen (line 1313),
+                // so any further leading/trailing whitespace stays in the
+                // pattern verbatim. Do not trim the remainder.
                 let remainder = &s[idx + ch.len_utf8()..];
-                return Ok((mods, remainder.trim_start()));
+                return Ok((mods, remainder));
             }
             _ => {
                 return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
@@ -470,7 +482,12 @@ fn try_parse_long_form(line: &str) -> Option<FilterRule> {
 
     for &(keyword, len, action) in keywords {
         if lower.starts_with(keyword) {
-            let pattern = line[len..].trim();
+            // upstream: exclude.c:1290-1313 - RULE_STRCMP matches the keyword and
+            // its single trailing separator, then strlen takes the rest of the
+            // line verbatim. The keyword table already includes that one
+            // separator, so the remainder must not be trimmed: trailing (and
+            // any embedded) whitespace stays part of the pattern.
+            let pattern = &line[len..];
             return Some(action.to_rule(pattern));
         }
     }

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -214,9 +214,43 @@ fn parse_preserves_pattern_case() {
 }
 
 #[test]
-fn parse_trims_whitespace() {
-    let rules = parse_rules("  + *.txt  ", Path::new("test")).unwrap();
-    assert_eq!(rules[0].pattern(), "*.txt");
+fn parse_leading_whitespace_is_rejected() {
+    // upstream: exclude.c:1211-1213 parse_rule_tok - a leading space is not a
+    // valid rule prefix, so it reaches the `switch` default and raises
+    // "Unknown filter rule" (RERR_SYNTAX). It must not be silently trimmed.
+    let result = parse_rules("  + *.txt", Path::new("test"));
+    assert!(result.is_err());
+    assert!(result.unwrap_err().message.contains("Unknown filter rule"));
+}
+
+#[test]
+fn parse_trailing_whitespace_is_kept_in_pattern() {
+    // upstream: exclude.c:1313 - the pattern length is strlen, so a trailing
+    // space stays part of the pattern verbatim. `x.o` therefore does not match
+    // `*.o ` and stays included (differential-fuzz silent-data regression).
+    let rules = parse_rules("- *.o ", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].pattern(), "*.o ");
+}
+
+#[test]
+fn parse_whitespace_only_line_is_rejected() {
+    // upstream: exclude.c:1514 parse_filter_file - a whitespace-only line is
+    // neither empty nor a comment, so it falls through to parse_rule_tok and
+    // errors rather than being skipped as blank.
+    let result = parse_rules("   \n- *.bak\n", Path::new("test"));
+    assert!(result.is_err());
+    assert!(result.unwrap_err().message.contains("Unknown filter rule"));
+}
+
+#[test]
+fn parse_no_prefixes_keeps_literal_whitespace() {
+    // upstream: exclude.c:1122-1124,1313 - under FILTRULE_NO_PREFIXES the whole
+    // line is taken verbatim as the pattern (no prefix scan, strlen length), so
+    // leading and trailing whitespace are preserved literally.
+    let rules = parse_rules_no_prefixes("  *.o \n", Path::new("test"), false, false, false);
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].pattern(), "  *.o ");
 }
 
 #[test]
@@ -304,8 +338,11 @@ fn parse_multiple_modifiers_order_independent() {
 
 #[test]
 fn parse_underscore_separator() {
+    // upstream: exclude.c:1290-1291,1313 - exactly one separator (here the `_`)
+    // is consumed after the rule char and modifiers; the remaining ` *.txt` is
+    // taken verbatim by strlen, so the leading space stays part of the pattern.
     let rules = parse_rules("-!_ *.txt", Path::new("test")).unwrap();
-    assert_eq!(rules[0].pattern(), "*.txt");
+    assert_eq!(rules[0].pattern(), " *.txt");
     assert!(rules[0].is_negated());
 }
 

--- a/crates/filters/tests/dir_merge_parsing_comprehensive.rs
+++ b/crates/filters/tests/dir_merge_parsing_comprehensive.rs
@@ -219,30 +219,30 @@ fn dir_merge_only_modifiers_no_pattern() {
 }
 
 #[test]
-fn dir_merge_with_leading_whitespace() {
+fn dir_merge_with_leading_whitespace_is_rejected() {
     let dir = TempDir::new().unwrap();
     let rules_path = dir.path().join("rules.txt");
 
-    // Leading whitespace before dir-merge
+    // upstream: exclude.c:1211-1213 - leading whitespace is not a valid rule
+    // prefix and errors; it is never trimmed away.
     fs::write(&rules_path, "   : .rsync-filter\n").unwrap();
 
-    let rules = filters::merge::read_rules(&rules_path).unwrap();
-    assert_eq!(rules.len(), 1);
-    assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    let err = filters::merge::read_rules(&rules_path).expect_err("leading whitespace errors");
+    assert!(err.message.contains("Unknown filter rule"));
 }
 
 #[test]
-fn dir_merge_with_trailing_whitespace() {
+fn dir_merge_with_trailing_whitespace_kept() {
     let dir = TempDir::new().unwrap();
     let rules_path = dir.path().join("rules.txt");
 
-    // Trailing whitespace after pattern
+    // upstream: exclude.c:1313 - the pattern (merge-file name) length is strlen,
+    // so trailing whitespace stays part of the pattern verbatim.
     fs::write(&rules_path, ": .rsync-filter   \n").unwrap();
 
     let rules = filters::merge::read_rules(&rules_path).unwrap();
     assert_eq!(rules.len(), 1);
-    // Trailing whitespace should be trimmed from pattern
-    assert_eq!(rules[0].pattern(), ".rsync-filter");
+    assert_eq!(rules[0].pattern(), ".rsync-filter   ");
 }
 
 #[test]

--- a/crates/filters/tests/exclude_from_file_parsing.rs
+++ b/crates/filters/tests/exclude_from_file_parsing.rs
@@ -202,16 +202,18 @@ mod comment_handling {
         assert_eq!(rules.len(), 2);
     }
 
-    /// Test: Comment with leading whitespace is still a comment.
+    /// Test: A `#` comment is only recognised at the very start of the line.
+    /// upstream: exclude.c:1514 parse_filter_file - leading whitespace is not
+    /// stripped, so `  # ...` is not a comment; it reaches parse_rule_tok and
+    /// errors with "Unknown filter rule".
     #[test]
-    fn comment_with_leading_whitespace() {
+    fn comment_with_leading_whitespace_is_rejected() {
         let dir = create_tempdir();
         let path = dir.path().join("excludes.txt");
         fs::write(&path, "  # Comment with leading spaces\n- *.tmp\n").expect("write");
 
-        let rules = read_rules(&path).expect("read rules");
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].pattern(), "*.tmp");
+        let err = read_rules(&path).expect_err("leading whitespace before # errors");
+        assert!(err.message.contains("Unknown filter rule"));
     }
 
     /// Test: File with only comments returns no rules.
@@ -286,26 +288,28 @@ mod blank_line_handling {
         assert_eq!(rules[2].pattern(), "*.log");
     }
 
-    /// Test: Whitespace-only lines are skipped.
+    /// Test: A whitespace-only line is not blank and is not skipped.
+    /// upstream: exclude.c:1514 - only truly-empty lines are skipped; a line of
+    /// spaces reaches parse_rule_tok and errors ("Unknown filter rule").
     #[test]
-    fn skips_whitespace_only_lines() {
+    fn whitespace_only_line_is_rejected() {
         let dir = create_tempdir();
         let path = dir.path().join("excludes.txt");
-        fs::write(&path, "- *.tmp\n   \n- *.bak\n\t\t\n- *.log\n").expect("write");
+        fs::write(&path, "- *.tmp\n   \n- *.bak\n").expect("write");
 
-        let rules = read_rules(&path).expect("read rules");
-        assert_eq!(rules.len(), 3);
+        let err = read_rules(&path).expect_err("whitespace-only line errors");
+        assert!(err.message.contains("Unknown filter rule"));
     }
 
-    /// Test: Lines with only tabs are skipped.
+    /// Test: A tab-only line is likewise not skipped and errors.
     #[test]
-    fn skips_tab_only_lines() {
+    fn tab_only_line_is_rejected() {
         let dir = create_tempdir();
         let path = dir.path().join("excludes.txt");
         fs::write(&path, "- *.tmp\n\t\n- *.bak\n").expect("write");
 
-        let rules = read_rules(&path).expect("read rules");
-        assert_eq!(rules.len(), 2);
+        let err = read_rules(&path).expect_err("tab-only line errors");
+        assert!(err.message.contains("Unknown filter rule"));
     }
 
     /// Test: File with blank lines at start.
@@ -330,23 +334,25 @@ mod blank_line_handling {
         assert_eq!(rules.len(), 2);
     }
 
-    /// Test: File with only blank lines.
+    /// Test: File with only (truly empty) blank lines produces no rules.
+    /// upstream: exclude.c:1514 - empty lines are skipped; whitespace-only lines
+    /// would instead error, so this fixture uses only newlines.
     #[test]
     fn only_blank_lines() {
         let dir = create_tempdir();
         let path = dir.path().join("excludes.txt");
-        fs::write(&path, "\n\n   \n\t\n").expect("write");
+        fs::write(&path, "\n\n\n\n").expect("write");
 
         let rules = read_rules(&path).expect("read rules");
         assert!(rules.is_empty());
     }
 
-    /// Test: Mixed blank lines and comments.
+    /// Test: Mixed empty lines and comments around a rule.
     #[test]
     fn mixed_blank_lines_and_comments() {
         let dir = create_tempdir();
         let path = dir.path().join("excludes.txt");
-        fs::write(&path, "\n# Comment\n\n; Another comment\n   \n- *.tmp\n\n").expect("write");
+        fs::write(&path, "\n# Comment\n\n; Another comment\n- *.tmp\n\n").expect("write");
 
         let rules = read_rules(&path).expect("read rules");
         assert_eq!(rules.len(), 1);
@@ -638,33 +644,33 @@ mod line_ending_handling {
 mod pattern_preservation {
     use super::*;
 
-    /// Test: Leading whitespace in pattern is trimmed.
-    /// Note: Unlike rsync's raw --exclude-from, filter rules parse patterns
-    /// and leading whitespace between the action and pattern is consumed.
+    /// Test: Only one separator is consumed after the action; further leading
+    /// whitespace stays in the pattern. upstream: exclude.c:1290-1291,1313 -
+    /// exactly one space/underscore is consumed, then the rest is taken verbatim
+    /// via strlen. `-   spaced_file.txt` keeps two leading spaces.
     #[test]
-    fn leading_whitespace_trimmed() {
+    fn only_one_separator_consumed_leading_whitespace_kept() {
         let dir = create_tempdir();
         let path = dir.path().join("excludes.txt");
-        // Pattern with leading space (after the action)
         fs::write(&path, "-   spaced_file.txt\n").expect("write");
 
         let rules = read_rules(&path).expect("read rules");
         assert_eq!(rules.len(), 1);
-        // Leading whitespace is trimmed by the parser
-        assert_eq!(rules[0].pattern(), "spaced_file.txt");
+        assert_eq!(rules[0].pattern(), "  spaced_file.txt");
     }
 
-    /// Test: Trailing whitespace in pattern is trimmed.
+    /// Test: Trailing whitespace in the pattern is kept verbatim.
+    /// upstream: exclude.c:1313 - pattern length is strlen, so trailing spaces
+    /// remain part of the pattern.
     #[test]
-    fn trailing_whitespace_trimmed() {
+    fn trailing_whitespace_kept() {
         let dir = create_tempdir();
         let path = dir.path().join("excludes.txt");
         fs::write(&path, "- pattern_with_trailing   \n").expect("write");
 
         let rules = read_rules(&path).expect("read rules");
         assert_eq!(rules.len(), 1);
-        // Trailing whitespace is trimmed
-        assert_eq!(rules[0].pattern(), "pattern_with_trailing");
+        assert_eq!(rules[0].pattern(), "pattern_with_trailing   ");
     }
 
     /// Test: Pattern case is preserved.

--- a/crates/filters/tests/filter_rule_syntax.rs
+++ b/crates/filters/tests/filter_rule_syntax.rs
@@ -308,9 +308,12 @@ mod exclude_rules {
 
     #[test]
     fn exclude_underscore_separator() {
-        // Underscore can separate modifiers from pattern
+        // Underscore separates modifiers from the pattern. upstream:
+        // exclude.c:1290-1291,1313 consumes exactly one separator (the `_`) and
+        // then takes the rest verbatim (strlen), so the following space stays
+        // part of the pattern.
         let rules = parse_rules("-!_ *.txt", Path::new("test")).unwrap();
-        assert_eq!(rules[0].pattern(), "*.txt");
+        assert_eq!(rules[0].pattern(), " *.txt");
         assert!(rules[0].is_negated());
     }
 }
@@ -1175,9 +1178,21 @@ mod comments_and_whitespace {
     }
 
     #[test]
-    fn whitespace_trimmed() {
-        let rules = parse_rules("  + *.txt  ", Path::new("test")).unwrap();
-        assert_eq!(rules[0].pattern(), "*.txt");
+    fn leading_whitespace_rejected() {
+        // upstream: exclude.c:1211-1213 parse_rule_tok - a leading space is not a
+        // valid rule prefix and raises "Unknown filter rule"; it is never
+        // trimmed away.
+        let result = parse_rules("  + *.txt", Path::new("test"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("Unknown filter rule"));
+    }
+
+    #[test]
+    fn trailing_whitespace_kept_in_pattern() {
+        // upstream: exclude.c:1313 - the pattern length is strlen, so trailing
+        // whitespace stays part of the pattern verbatim.
+        let rules = parse_rules("+ *.txt ", Path::new("test")).unwrap();
+        assert_eq!(rules[0].pattern(), "*.txt ");
     }
 
     #[test]

--- a/crates/filters/tests/proptest_fuzz.rs
+++ b/crates/filters/tests/proptest_fuzz.rs
@@ -174,12 +174,21 @@ proptest! {
         prop_assert!(result.is_ok());
     }
 
-    /// Empty and whitespace-only inputs produce no rules.
+    /// Blank inputs (empty or newline-only) produce no rules. upstream:
+    /// exclude.c:1514 parse_filter_file skips only truly empty lines.
     #[test]
-    fn parse_rules_whitespace_only(input in "[ \t\n\r]*") {
+    fn parse_rules_blank_lines_produce_no_rules(input in "\n*") {
         let result = parse_rules(&input, Path::new("<fuzz>"));
         prop_assert!(result.is_ok());
         prop_assert!(result.unwrap().is_empty());
+    }
+
+    /// A line that contains whitespace is not blank: upstream does not strip it,
+    /// so it reaches parse_rule_tok and errors ("Unknown filter rule").
+    #[test]
+    fn parse_rules_whitespace_line_is_rejected(ws in "[ \t]{1,8}") {
+        let result = parse_rules(&ws, Path::new("<fuzz>"));
+        prop_assert!(result.is_err());
     }
 
     /// Comment-only inputs produce no rules.
@@ -726,9 +735,21 @@ fn parse_rules_windows_line_endings() {
 
 #[test]
 fn parse_rules_trailing_whitespace() {
-    let content = "  - *.bak   \n  + *.txt   \n";
-    let result = parse_rules(content, Path::new("<test>"));
-    assert!(result.is_ok());
+    // upstream: exclude.c:1313 - trailing whitespace is part of the pattern
+    // (strlen length), so the rules parse and keep the trailing spaces verbatim.
+    let content = "- *.bak   \n+ *.txt   \n";
+    let rules = parse_rules(content, Path::new("<test>")).unwrap();
+    assert_eq!(rules.len(), 2);
+    assert_eq!(rules[0].pattern(), "*.bak   ");
+    assert_eq!(rules[1].pattern(), "*.txt   ");
+}
+
+#[test]
+fn parse_rules_leading_whitespace_is_rejected() {
+    // upstream: exclude.c:1211-1213 - leading whitespace is not a valid rule
+    // prefix and errors; it must not be trimmed away.
+    let result = parse_rules("  - *.bak\n", Path::new("<test>"));
+    assert!(result.is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Filter-rule parsing trimmed whitespace where upstream rsync 3.4.4 treats it as significant. Differential fuzzing surfaced two divergences:

1. **Silent data loss (primary):** a rule `- *.o ` (trailing space). Upstream keeps the space in the pattern (`strlen`, verbatim), so `x.o` does **not** match `*.o ` and stays included. The old code trimmed the pattern to `*.o` and silently **excluded** a file upstream keeps.
2. **Exit-code strictness:** a leading-whitespace rule (`  - *.o`) and a whitespace-only line. Upstream errors with `Unknown filter rule` (exit 1); the old code trimmed-and-applied or skipped as blank.

## Fix

Both parsers now mirror upstream `exclude.c` exactly:

- **Trailing whitespace stays in the pattern** (`parse_rule_tok` pattern length is `strlen`, exclude.c:1313).
- **Exactly one separator** (space or `_`) is consumed after the rule char + modifiers (exclude.c:1290-1291); further leading whitespace remains part of the pattern.
- **Leading whitespace and whitespace-only lines error** (exclude.c:1211-1213 prefix `switch` default; exclude.c:1514 `parse_filter_file` only skips empty and `;`/`#` comment lines), **except** under word-split where leading whitespace is skipped (exclude.c:1100-1106).
- Comment (`;`/`#`) and empty-line skipping is preserved exactly, on the raw (untrimmed) line.

Applied to the merge-file parser, the command-line rule parser, the merge-directive reader, and the no-prefixes literal path.

## Verification

Verified byte-for-byte against rsync 3.4.4 with `-rin --list-only`:

| Case | upstream | before | after |
|------|----------|--------|-------|
| `- *.o ` (trailing) | includes `x.o` | excluded `x.o` | includes `x.o` |
| `  - *.o` (leading) | error, exit 1 | applied, exit 0 | error, exit 1 |
| whitespace-only merge line | error, exit 1 | skipped, exit 0 | error, exit 1 |
| `--exclude='*.o '` (old-prefix) | includes `x.o` | includes `x.o` | includes `x.o` |
| `:w-` word-split leading ws | skipped | skipped | skipped |

`cargo fmt --all --check`, `clippy -p filters -p cli -D warnings`, and `cargo check --target x86_64-pc-windows-gnu` are clean; filters and cli test suites pass. Tests that encoded the old trimming behavior are corrected to the upstream-accurate result, and regression tests are added for each case.
