### PR TITLE
fix(batch): gate batch-file stats encoding on protocol version

### DIFF
--- a/crates/batch/src/format/stats.rs
+++ b/crates/batch/src/format/stats.rs
@@ -5,12 +5,50 @@
 
 use std::io::{self, Read, Write};
 
+/// Writes one stats field using upstream's `write_varlong30` macro semantics.
+///
+/// upstream: main.c:374 writes the batch stats via `write_varlong30(batch_fd,
+/// x, 3)`, and io.h:46 `write_varlong30()` gates on the protocol version.
+/// Protocol below 30 falls back to `write_longint()` (fixed 4-byte
+/// little-endian, widening to 12 bytes for values that exceed a signed 32-bit
+/// int); protocol 30 and above uses the variable-length `write_varlong()` with
+/// `min_bytes`. A pre-30 `--read-batch` peer decodes these with
+/// `read_longint()`, so emitting the varlong form for such a batch file
+/// corrupts the trailing stats section. Mirrors
+/// `protocol::stats::transfer::write_stat`.
+fn write_stat<W: Write>(
+    writer: &mut W,
+    value: i64,
+    min_bytes: u8,
+    protocol_version: i32,
+) -> io::Result<()> {
+    if protocol_version < 30 {
+        protocol::write_longint(writer, value)
+    } else {
+        protocol::write_varlong(writer, value, min_bytes)
+    }
+}
+
+/// Reads one stats field using upstream's `read_varlong30` macro semantics.
+///
+/// upstream: io.h:29 `read_varlong30()` - the read-side counterpart to
+/// [`write_stat`]; protocol < 30 uses `read_longint()`, protocol >= 30 uses
+/// `read_varlong()` with `min_bytes`.
+fn read_stat<R: Read>(reader: &mut R, min_bytes: u8, protocol_version: i32) -> io::Result<i64> {
+    if protocol_version < 30 {
+        protocol::read_longint(reader)
+    } else {
+        protocol::read_varlong(reader, min_bytes)
+    }
+}
+
 /// Transfer statistics recorded at the end of a batch file.
 ///
 /// # Upstream Reference
 ///
 /// - `main.c:374-383`: `write_varlong30(batch_fd, total_read, 3)` etc.
-/// - Stats are written using `varlong30` encoding with 3 minimum bytes.
+/// - Stats use `varlong30` encoding: fixed 4-byte longint for protocol below
+///   30, variable-length varlong (`min_bytes=3`) for protocol 30 and above.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct BatchStats {
     /// Total bytes read from the source during transfer.
@@ -28,30 +66,41 @@ pub struct BatchStats {
 impl BatchStats {
     /// Write the statistics to a writer.
     ///
-    /// Uses `write_varlong30` with `min_bytes=3` to match upstream rsync's
-    /// `main.c` stats serialization.
+    /// Encodes each field with `varlong30` semantics gated on
+    /// `protocol_version` (fixed longint for < 30, varlong `min_bytes=3` for
+    /// >= 30) to match upstream rsync's `main.c` stats serialization.
     pub fn write_to<W: Write>(&self, writer: &mut W, protocol_version: i32) -> io::Result<()> {
-        protocol::write_varlong30(writer, self.total_read, 3)?;
-        protocol::write_varlong30(writer, self.total_written, 3)?;
-        protocol::write_varlong30(writer, self.total_size, 3)?;
+        write_stat(writer, self.total_read, 3, protocol_version)?;
+        write_stat(writer, self.total_written, 3, protocol_version)?;
+        write_stat(writer, self.total_size, 3, protocol_version)?;
         if protocol_version >= 29 {
-            protocol::write_varlong30(writer, self.flist_buildtime.unwrap_or(0), 3)?;
-            protocol::write_varlong30(writer, self.flist_xfertime.unwrap_or(0), 3)?;
+            write_stat(
+                writer,
+                self.flist_buildtime.unwrap_or(0),
+                3,
+                protocol_version,
+            )?;
+            write_stat(
+                writer,
+                self.flist_xfertime.unwrap_or(0),
+                3,
+                protocol_version,
+            )?;
         }
         Ok(())
     }
 
     /// Read the statistics from a reader.
     ///
-    /// Uses `read_varlong30` with `min_bytes=3` to match upstream rsync's
-    /// stats deserialization.
+    /// Decodes each field with `varlong30` semantics gated on
+    /// `protocol_version` to match upstream rsync's stats deserialization.
     pub fn read_from<R: Read>(reader: &mut R, protocol_version: i32) -> io::Result<Self> {
-        let total_read = protocol::read_varlong30(reader, 3)?;
-        let total_written = protocol::read_varlong30(reader, 3)?;
-        let total_size = protocol::read_varlong30(reader, 3)?;
+        let total_read = read_stat(reader, 3, protocol_version)?;
+        let total_written = read_stat(reader, 3, protocol_version)?;
+        let total_size = read_stat(reader, 3, protocol_version)?;
         let (flist_buildtime, flist_xfertime) = if protocol_version >= 29 {
-            let bt = protocol::read_varlong30(reader, 3)?;
-            let xt = protocol::read_varlong30(reader, 3)?;
+            let bt = read_stat(reader, 3, protocol_version)?;
+            let xt = read_stat(reader, 3, protocol_version)?;
             (Some(bt), Some(xt))
         } else {
             (None, None)

--- a/crates/batch/src/format/tests.rs
+++ b/crates/batch/src/format/tests.rs
@@ -410,6 +410,104 @@ fn test_batch_stats_zero_values() {
     assert_eq!(stats, restored);
 }
 
+/// Golden byte layout: a protocol 28 batch stats section is three fixed 4-byte
+/// little-endian longints (no flist times), NOT varlong.
+///
+/// upstream: main.c:374 `write_varlong30(batch_fd, x, 3)` -> io.h:46 falls back
+/// to `write_longint()` for protocol < 30. A proto-28 `--read-batch` peer reads
+/// these with `read_longint()`, so the varlong form would desync it.
+#[test]
+fn test_batch_stats_upstream_byte_layout_protocol_28() {
+    let stats = BatchStats {
+        total_read: 1024,
+        total_written: 2048,
+        total_size: 5000,
+        flist_buildtime: None,
+        flist_xfertime: None,
+    };
+
+    let mut buf = Vec::new();
+    stats.write_to(&mut buf, 28).unwrap();
+
+    // Three fields x 4-byte little-endian longint = 12 bytes, no flist times.
+    assert_eq!(
+        buf,
+        vec![
+            0x00, 0x04, 0x00, 0x00, // total_read   = 1024
+            0x00, 0x08, 0x00, 0x00, // total_written = 2048
+            0x88, 0x13, 0x00, 0x00, // total_size    = 5000
+        ]
+    );
+}
+
+/// Golden byte layout: a protocol 29 batch stats section is five fixed 4-byte
+/// little-endian longints (flist times included), NOT varlong.
+///
+/// upstream: main.c:378-382 adds `flist_buildtime`/`flist_xfertime` for
+/// protocol >= 29; each still encodes via `write_longint()` when protocol < 30.
+#[test]
+fn test_batch_stats_upstream_byte_layout_protocol_29() {
+    let stats = BatchStats {
+        total_read: 1024,
+        total_written: 2048,
+        total_size: 5000,
+        flist_buildtime: Some(42),
+        flist_xfertime: Some(100),
+    };
+
+    let mut buf = Vec::new();
+    stats.write_to(&mut buf, 29).unwrap();
+
+    // Five fields x 4-byte little-endian longint = 20 bytes.
+    assert_eq!(
+        buf,
+        vec![
+            0x00, 0x04, 0x00, 0x00, // total_read      = 1024
+            0x00, 0x08, 0x00, 0x00, // total_written    = 2048
+            0x88, 0x13, 0x00, 0x00, // total_size       = 5000
+            0x2A, 0x00, 0x00, 0x00, // flist_buildtime  = 42
+            0x64, 0x00, 0x00, 0x00, // flist_xfertime   = 100
+        ]
+    );
+}
+
+/// Golden byte layout: protocol >= 30 stats remain the varlong encoding, so
+/// proto 30/31/32 batch files are byte-identical before and after the
+/// version-gating fix (unchanged by construction).
+///
+/// Each field must equal `protocol::write_varlong(value, 3)`; the proto-28
+/// longint form must differ, proving the gate actually switches encodings.
+#[test]
+fn test_batch_stats_protocol_30_stays_varlong() {
+    let stats = BatchStats {
+        total_read: 1024,
+        total_written: 2048,
+        total_size: 5000,
+        flist_buildtime: Some(42),
+        flist_xfertime: Some(100),
+    };
+
+    let mut buf = Vec::new();
+    stats.write_to(&mut buf, 30).unwrap();
+
+    let mut expected = Vec::new();
+    for value in [1024_i64, 2048, 5000, 42, 100] {
+        protocol::write_varlong(&mut expected, value, 3).unwrap();
+    }
+    assert_eq!(buf, expected);
+
+    // Sanity: the varlong bytes must differ from the proto-28 longint layout.
+    let mut longint_form = Vec::new();
+    BatchStats {
+        flist_buildtime: None,
+        flist_xfertime: None,
+        ..stats
+    }
+    .write_to(&mut longint_form, 28)
+    .unwrap();
+    assert_ne!(buf, longint_form);
+}
+
 /// Verify the exact byte layout of a batch header matches upstream rsync.
 ///
 /// upstream: batch.c:write_stream_flags() writes the flags bitmap (i32 LE),


### PR DESCRIPTION
## Summary

Batch-file trailing transfer statistics were always encoded with the `varlong30`
variable-length form, ignoring the negotiated protocol version passed into
`BatchStats::write_to`/`read_from`. This diverges from upstream rsync for any
batch file written for a protocol < 30 peer.

Upstream `main.c:374-383` writes the batch stats via `write_varlong30(batch_fd, x, 3)`,
and `io.h:46` gates that macro on the protocol version:

- protocol < 30 -> `write_longint()` / `read_longint()` (fixed 4-byte little-endian,
  widening to 12 bytes for values exceeding a signed 32-bit int)
- protocol >= 30 -> `write_varlong()` / `read_varlong()` with `min_bytes`

A pre-30 `--read-batch` process decodes the trailing stats with `read_longint()`,
so emitting the varlong form corrupts the stats section for those batch files.

## Fix

Gate `BatchStats::write_to`/`read_from` on `protocol_version` via private
`write_stat`/`read_stat` helpers, mirroring the identical goodbye-stats fix in
`protocol::stats::transfer`:

- protocol < 30 -> `protocol::write_longint` / `protocol::read_longint`
- protocol >= 30 -> `protocol::write_varlong(_, 3)` / `protocol::read_varlong(_, 3)`

Protocol 30/31/32 batch files are byte-identical to before by construction (the
`>= 30` branch is the pre-existing varlong path).

## Tests

Golden-byte regression tests:

- `test_batch_stats_upstream_byte_layout_protocol_28` - exact 12-byte fixed-longint layout
- `test_batch_stats_upstream_byte_layout_protocol_29` - exact 20-byte fixed-longint layout (with flist times)
- `test_batch_stats_protocol_30_stays_varlong` - proto 30 equals `write_varlong(_, 3)` and differs from the longint form

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p batch -p protocol --all-targets --all-features --no-deps -- -D warnings`: clean
- `cargo nextest run -p batch --all-features -E 'test(stats)'`: 9 passed
- `cargo check --target x86_64-pc-windows-gnu -p batch`: clean
