### PR TITLE
fix(engine): match upstream --max-delete skipped count for nested cap-saturated dirs

### DIFF
--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -198,7 +198,10 @@ fn delete_extraneous_entries_capped<S: AsRef<OsStr>>(
             Some(base) => base.join(&name_path),
             None => name_path.clone(),
         };
-        remove_entry_capped(context, &path, &entry_relative, &mut skipped)?;
+        // `nested = false`: these are the top-level extraneous entries, reached
+        // by upstream's `delete_item` WITHOUT `DEL_DIR_IS_EMPTY`, so a survived
+        // top-level directory is not counted against the skipped total.
+        remove_entry_capped(context, &path, &entry_relative, &mut skipped, false)?;
     }
 
     if skipped > 0 {
@@ -238,11 +241,18 @@ fn cmp_child_delete_order(a: (&OsStr, bool), b: (&OsStr, bool)) -> std::cmp::Ord
 /// now-empty directory is itself subject to the same guard before its own
 /// removal. `skipped` accumulates the count reported to the user, matching
 /// upstream's `skipped_deletes` (`delete.c:157`).
+///
+/// `nested` distinguishes a directory reached during the recursion (upstream's
+/// `delete_item(..., DEL_DIR_IS_EMPTY)` call at `delete.c:107`) from a
+/// top-level extraneous entry (upstream's initial `delete_item` without
+/// `DEL_DIR_IS_EMPTY`). Only the former counts a cap-saturated non-empty
+/// directory toward `skipped` - see the `!all_children_removed` branch below.
 fn remove_entry_capped(
     context: &mut CopyContext,
     path: &Path,
     entry_relative: &Path,
     skipped: &mut u64,
+    nested: bool,
 ) -> Result<bool, LocalCopyError> {
     context.enforce_timeout()?;
 
@@ -296,22 +306,36 @@ fn remove_entry_capped(
         for (child_name, _) in children {
             let child_path = path.join(&child_name);
             let child_relative = entry_relative.join(&child_name);
-            if !remove_entry_capped(context, &child_path, &child_relative, skipped)? {
+            // Children are reached via the recursion, mirroring upstream's
+            // `delete_item(..., DEL_DIR_IS_EMPTY)` at delete.c:107; mark them
+            // `nested` so a cap-saturated non-empty subdir is counted.
+            if !remove_entry_capped(context, &child_path, &child_relative, skipped, true)? {
                 all_children_removed = false;
             }
         }
 
         if !all_children_removed {
-            // Contents survived (cap reached or filter-protected), so the
-            // directory cannot be removed. upstream: delete.c:117 prints this
-            // once per non-empty directory without counting it or flagging an
-            // I/O error.
+            // Contents survived because the cap was reached, so the directory
+            // cannot be removed. upstream: delete.c:117 prints this once per
+            // non-empty directory without flagging an I/O error.
             info_log!(
                 Nonreg,
                 1,
                 "cannot delete non-empty directory: {}",
                 path.display().to_string().replace('\\', "/")
             );
+            // A NESTED non-empty directory is still reached by upstream's
+            // `delete_item(..., DEL_DIR_IS_EMPTY)` (delete.c:107): with
+            // DEL_DIR_IS_EMPTY set, delete.c:144 is skipped and control falls
+            // straight to the max_delete guard (delete.c:156), which does
+            // `skipped_deletes++` because the cap is saturated. The TOP-LEVEL
+            // directory instead enters `delete_item` WITHOUT DEL_DIR_IS_EMPTY,
+            // so its survived contents take the `goto check_ret` path
+            // (delete.c:151-152) and it is never counted. Count the nested case
+            // to match upstream's skipped total exactly (issue #212).
+            if nested {
+                *skipped = skipped.saturating_add(1);
+            }
             return Ok(false);
         }
 

--- a/crates/engine/src/local_copy/tests/execute_max_delete.rs
+++ b/crates/engine/src/local_copy/tests/execute_max_delete.rs
@@ -904,6 +904,90 @@ fn max_delete_counts_leaves_inside_nonempty_directory() {
     );
 }
 
+/// COUNT-FIDELITY REGRESSION (#212): a cap-saturated non-empty NESTED
+/// directory must be counted toward the reported skipped total, exactly one
+/// per such directory, matching upstream.
+///
+/// upstream `delete.c` reaches a nested subdir via
+/// `delete_item(..., DEL_DIR_IS_EMPTY)` (delete.c:107). With `DEL_DIR_IS_EMPTY`
+/// set, delete.c:144 is skipped and control falls straight to the max_delete
+/// guard (delete.c:156), which does `skipped_deletes++` because the cap is
+/// saturated - even though the subdir is actually non-empty. The TOP-LEVEL
+/// directory instead enters `delete_item` WITHOUT `DEL_DIR_IS_EMPTY`, so its
+/// survived contents take the `goto check_ret` path (delete.c:151-152) and it
+/// is never counted.
+///
+/// Layout `a/{f4, b/{f3, c/{f1, f2}}}` plus loose `top`, all extraneous, with
+/// `--max-delete=1`: upstream deletes only `f2`, then reports 6 skipped -
+/// five leaves (`f1`, `f3`, `f4`, `top`, and the doomed-but-uncounted `f2` is
+/// the one deletion) plus the two non-empty NESTED subdirs `b` and `c`; the
+/// top-level `a` is NOT counted. Verified byte-for-byte against rsync 3.4.4
+/// (`Deletions stopped due to --max-delete limit (6 skipped)`, exit 25).
+///
+/// Guards #6446/#6440: the survivor set and exit code must stay unchanged;
+/// only the reported count moves from oc's old 4 to upstream's 6.
+#[test]
+fn max_delete_counts_nested_nonempty_directories_toward_skipped() {
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+    fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
+
+    let target_root = ctx.dest.join("source");
+    fs::create_dir_all(&target_root).expect("create target root");
+    fs::write(target_root.join("keep.txt"), b"old").expect("write old");
+
+    // Deep extraneous nest: a/{f4, b/{f3, c/{f1, f2}}} plus a loose `top`.
+    let c_dir = target_root.join("a").join("b").join("c");
+    fs::create_dir_all(&c_dir).expect("create a/b/c");
+    fs::write(c_dir.join("f1"), b"x").expect("write f1");
+    fs::write(c_dir.join("f2"), b"x").expect("write f2");
+    fs::write(target_root.join("a").join("b").join("f3"), b"x").expect("write f3");
+    fs::write(target_root.join("a").join("f4"), b"x").expect("write f4");
+    fs::write(target_root.join("top"), b"x").expect("write top");
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .delete(true)
+        .max_deletions(Some(1));
+
+    let error = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect_err("must stop at the cap and report RERR_DEL_LIMIT");
+
+    // Exit code unchanged (#6446/#6440): RERR_DEL_LIMIT (25).
+    assert_eq!(error.exit_code(), MAX_DELETE_EXIT_CODE);
+    match error.kind() {
+        LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
+            assert_eq!(
+                *skipped, 6,
+                "upstream counts 5 leaves + 2 nested non-empty dirs (b, c), \
+                 not the top-level a"
+            );
+        }
+        other => panic!("unexpected error kind: {other:?}"),
+    }
+
+    // Survivor set unchanged (#6446/#6440): only `f2` is removed; every other
+    // doomed entry (including both nested directories) must remain.
+    assert!(
+        !c_dir.join("f2").exists(),
+        "f2 is the single deletion the cap allows"
+    );
+    for survivor in ["a", "a/b", "a/b/c", "a/b/c/f1", "a/b/f3", "a/f4", "top"] {
+        assert!(
+            target_root.join(survivor).exists(),
+            "{survivor} must survive (upstream keeps it)"
+        );
+    }
+    // Exactly one of the eight doomed entries may be removed.
+    let survivors = count_entries_under(&target_root, Some("keep.txt"));
+    assert_eq!(survivors, 7, "only f2 may be deleted under --max-delete=1");
+}
+
 /// The same leaf-counting cap must hold under `--delete-delay` (collect then
 /// apply): a small `--max-delete` must not be defeated by the deferred pass.
 #[test]


### PR DESCRIPTION
## Summary

Fixes issue #212: the `(N skipped)` count reported when `--max-delete` is hit was off by one per cap-saturated non-empty NESTED subdirectory. The survivor set, exit code (25), and deletion order were already byte-identical to upstream rsync 3.4.4; only the reported number diverged.

## Root cause

Upstream `delete.c` reaches a nested subdir via `delete_item(..., DEL_DIR_IS_EMPTY)` (delete.c:107). With `DEL_DIR_IS_EMPTY` set, the emptiness re-check at delete.c:144 is skipped and control falls straight to the `max_delete` guard at delete.c:156, which does `skipped_deletes++` because the cap is saturated - even though the subdir is actually non-empty. A top-level directory instead enters `delete_item` WITHOUT `DEL_DIR_IS_EMPTY`, so its survived contents take the `goto check_ret` path (delete.c:151-152) and it is never counted.

`remove_entry_capped` returned early for a non-empty directory without counting it, so oc undercounted by one per cap-saturated non-empty nested subdir.

## Fix

`remove_entry_capped` now carries a `nested` flag. A cap-saturated non-empty directory is counted toward the skipped total only when it is nested (mirroring the `DEL_DIR_IS_EMPTY` call site), leaving the top-level case uncounted - matching upstream's total exactly. Only the counting timing changes: the survivor set, exit code, and deletion order are untouched.

## Verification

Reproduced against real rsync 3.4.4 with a deep-nest tree (`a/{f4, b/{f3, c/{f1, f2}}}` plus a loose `top`) and `--max-delete=1`:

- upstream: `Deletions stopped due to --max-delete limit (6 skipped)`, exit 25
- oc before: 4 skipped
- oc after: 6 skipped, identical survivors, exit 25

New regression test `max_delete_counts_nested_nonempty_directories_toward_skipped` pins the upstream count (6), asserts the survivor set and exit 25 are unchanged (guards the ordering work in prior deletion PRs), and the full `max_delete` suite (31 tests) passes.

Gates: rustfmt (real module clean), `clippy -p engine -D warnings`, `check -p engine`, `check --target x86_64-pc-windows-gnu -p engine`, targeted nextest - all green.