### PR TITLE
fix(cli): consume exactly one filter-rule separator, keep rest verbatim

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
@@ -1,9 +1,20 @@
-pub(super) fn trim_short_rule_remainder(remainder: &str) -> &str {
-    let remainder = remainder.trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
-    if let Some(rest) = remainder.strip_prefix(',') {
-        return rest.trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
+/// Consumes exactly one rule separator (a single space, `_`, or `,`) that
+/// terminates the rule character and its modifiers, returning the rest of the
+/// line verbatim.
+///
+/// upstream: exclude.c:1290-1291 - after the modifier loop stops at the first
+/// ` `/`_` separator, `if (*s) s++` consumes exactly ONE separator character.
+/// The pattern length is then `strlen` (exclude.c:1313), so any further leading
+/// whitespace or `_` stays part of the pattern verbatim and is never trimmed.
+/// The `,` case mirrors the optional comma that may follow a rule character or
+/// keyword (exclude.c:1075-1077, 1176-1177). A non-separator leading character
+/// is returned unchanged.
+pub(super) fn consume_rule_separator(remainder: &str) -> &str {
+    let mut chars = remainder.chars();
+    match chars.next() {
+        Some(ch) if ch == '_' || ch == ',' || ch.is_ascii_whitespace() => chars.as_str(),
+        _ => remainder,
     }
-    remainder
 }
 
 pub(super) fn split_short_rule_modifiers(text: &str) -> (&str, &str) {
@@ -20,13 +31,13 @@ pub(super) fn split_short_rule_modifiers(text: &str) -> (&str, &str) {
     }
 
     if matches!(text.chars().next(), Some(ch) if ch.is_ascii_whitespace() || ch == '_') {
-        return ("", trim_short_rule_remainder(text));
+        return ("", consume_rule_separator(text));
     }
 
     for (idx, ch) in text.char_indices() {
         if ch == ',' || ch == '_' || ch.is_ascii_whitespace() {
             let modifiers = &text[..idx];
-            let remainder = trim_short_rule_remainder(&text[idx..]);
+            let remainder = consume_rule_separator(&text[idx..]);
             return (modifiers, remainder);
         }
     }
@@ -48,14 +59,14 @@ pub(super) fn split_short_merge_modifiers(text: &str, allow_extended: bool) -> (
     }
 
     if matches!(text.chars().next(), Some(ch) if ch.is_ascii_whitespace() || ch == '_') {
-        return ("", trim_short_rule_remainder(text));
+        return ("", consume_rule_separator(text));
     }
 
     let mut end = 0usize;
     for (idx, ch) in text.char_indices() {
         if ch == ',' || ch == '_' || ch.is_ascii_whitespace() {
             let modifiers = &text[..end];
-            let remainder = trim_short_rule_remainder(&text[idx..]);
+            let remainder = consume_rule_separator(&text[idx..]);
             return (modifiers, remainder);
         }
 
@@ -69,7 +80,7 @@ pub(super) fn split_short_merge_modifiers(text: &str, allow_extended: bool) -> (
         }
 
         let modifiers = &text[..end];
-        let remainder = trim_short_rule_remainder(&text[idx..]);
+        let remainder = consume_rule_separator(&text[idx..]);
         return (modifiers, remainder);
     }
 
@@ -89,27 +100,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn trim_short_rule_remainder_basic() {
-        assert_eq!(trim_short_rule_remainder("pattern"), "pattern");
+    fn consume_rule_separator_basic() {
+        // A non-separator leading character is returned unchanged.
+        assert_eq!(consume_rule_separator("pattern"), "pattern");
     }
 
     #[test]
-    fn trim_short_rule_remainder_leading_whitespace() {
-        assert_eq!(trim_short_rule_remainder("  pattern"), "pattern");
-        assert_eq!(trim_short_rule_remainder("\t\tpattern"), "pattern");
+    fn consume_rule_separator_leading_whitespace() {
+        // Exactly one separator is consumed; any further whitespace stays in the
+        // pattern verbatim (upstream exclude.c:1290-1291 `if (*s) s++`).
+        assert_eq!(consume_rule_separator("  pattern"), " pattern");
+        assert_eq!(consume_rule_separator("\t\tpattern"), "\tpattern");
+        assert_eq!(consume_rule_separator(" pattern"), "pattern");
     }
 
     #[test]
-    fn trim_short_rule_remainder_leading_underscore() {
-        assert_eq!(trim_short_rule_remainder("__pattern"), "pattern");
-        assert_eq!(trim_short_rule_remainder("_ pattern"), "pattern");
+    fn consume_rule_separator_leading_underscore() {
+        assert_eq!(consume_rule_separator("__pattern"), "_pattern");
+        assert_eq!(consume_rule_separator("_ pattern"), " pattern");
+        assert_eq!(consume_rule_separator("_pattern"), "pattern");
     }
 
     #[test]
-    fn trim_short_rule_remainder_comma_prefix() {
-        assert_eq!(trim_short_rule_remainder(",pattern"), "pattern");
-        assert_eq!(trim_short_rule_remainder(", pattern"), "pattern");
-        assert_eq!(trim_short_rule_remainder(",_pattern"), "pattern");
+    fn consume_rule_separator_comma_prefix() {
+        assert_eq!(consume_rule_separator(",pattern"), "pattern");
+        assert_eq!(consume_rule_separator(", pattern"), " pattern");
+        assert_eq!(consume_rule_separator(",_pattern"), "_pattern");
     }
 
     #[test]

--- a/crates/cli/src/frontend/filter_rules/parsing/rules.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/rules.rs
@@ -77,7 +77,10 @@ pub(super) fn parse_short_include_rule(
         Ok(state) => state,
         Err(error) => return Some(Err(error)),
     };
-    let pattern = remainder.trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
+    // `split_short_rule_modifiers` already consumed the single separator that
+    // terminates the modifiers (upstream exclude.c:1290-1291), so the remainder
+    // is the pattern verbatim. Do not trim further leading whitespace/`_`.
+    let pattern = remainder;
     if pattern.is_empty() {
         let text = format!("filter rule '{trimmed}' is missing a pattern after '{prefix}'");
         let message = rsync_error!(1, text).with_role(Role::Client);
@@ -97,7 +100,10 @@ pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Messa
     let keyword = parts.next().expect("split always yields at least one part");
     let remainder = parts.next().unwrap_or("");
     let (keyword, keyword_modifiers) = split_keyword_modifiers(keyword);
-    let pattern = remainder.trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
+    // `splitn` on the first whitespace already consumed the single separator
+    // between the keyword and the pattern (upstream exclude.c:1290-1291), so the
+    // remainder is the pattern verbatim. Do not trim further leading separators.
+    let pattern = remainder;
 
     let build_rule = |builder: fn(String) -> FilterRuleSpec,
                       allow_perishable: bool,

--- a/crates/cli/src/frontend/filter_rules/parsing/shorthand.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/shorthand.rs
@@ -3,7 +3,7 @@ use core::message::{Message, Role};
 use core::rsync_error;
 
 use super::super::directive::FilterDirective;
-use super::helpers::trim_short_rule_remainder;
+use super::helpers::consume_rule_separator;
 
 pub(super) fn parse_filter_shorthand(
     trimmed: &str,
@@ -32,7 +32,7 @@ pub(super) fn parse_filter_shorthand(
         return None;
     }
 
-    let pattern = trim_short_rule_remainder(remainder);
+    let pattern = consume_rule_separator(remainder);
     if pattern.is_empty() {
         let text = format!("filter rule '{trimmed}' is missing a pattern after '{label}'");
         let message = rsync_error!(1, text).with_role(Role::Client);

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -462,8 +462,79 @@ fn trailing_whitespace_is_kept_in_pattern() {
 
 #[test]
 fn multiple_spaces_in_pattern() {
-    let result = parse_filter_directive(OsStr::new("+   *.txt"));
-    assert!(result.is_ok());
+    // upstream: exclude.c:1290-1291,1313 - exactly one separator is consumed
+    // after the rule char, so `+   *.txt` (three spaces) keeps the two extra
+    // leading spaces in the pattern.
+    match parse_filter_directive(OsStr::new("+   *.txt")).unwrap() {
+        FilterDirective::Rule(spec) => {
+            assert_eq!(spec.kind(), FilterRuleKind::Include);
+            assert_eq!(spec.pattern(), "  *.txt");
+        }
+        other => panic!("expected Rule directive, got {other:?}"),
+    }
+}
+
+#[test]
+fn single_space_separator_consumed_short_rule() {
+    // `-  x` (two spaces) keeps one leading space; verified against rsync 3.4.4
+    // which excludes only a file literally named " x".
+    match parse_filter_directive(OsStr::new("-  x")).unwrap() {
+        FilterDirective::Rule(spec) => {
+            assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+            assert_eq!(spec.pattern(), " x");
+        }
+        other => panic!("expected Rule directive, got {other:?}"),
+    }
+}
+
+#[test]
+fn one_space_separator_leaves_no_leading_space() {
+    // `- x` (one space) consumes the single separator; pattern is `x`.
+    match parse_filter_directive(OsStr::new("- x")).unwrap() {
+        FilterDirective::Rule(spec) => {
+            assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+            assert_eq!(spec.pattern(), "x");
+        }
+        other => panic!("expected Rule directive, got {other:?}"),
+    }
+}
+
+#[test]
+fn underscore_separator_leaves_following_space() {
+    // `-_ x` uses `_` as the single separator, leaving the following space in
+    // the pattern (` x`), matching rsync 3.4.4.
+    match parse_filter_directive(OsStr::new("-_ x")).unwrap() {
+        FilterDirective::Rule(spec) => {
+            assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+            assert_eq!(spec.pattern(), " x");
+        }
+        other => panic!("expected Rule directive, got {other:?}"),
+    }
+}
+
+#[test]
+fn keyword_rule_keeps_extra_separator_in_pattern() {
+    // The keyword and its pattern are split on the first whitespace only, so
+    // `exclude   x` (three spaces) keeps the two extra leading spaces verbatim.
+    match parse_keyword_rule("exclude   x").unwrap() {
+        FilterDirective::Rule(spec) => {
+            assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+            assert_eq!(spec.pattern(), "  x");
+        }
+        other => panic!("expected Rule directive, got {other:?}"),
+    }
+}
+
+#[test]
+fn shorthand_rule_keeps_extra_separator_in_pattern() {
+    // `P  x` (two spaces) consumes one separator, keeping one leading space.
+    match parse_shorthand_rules("P  x").unwrap().unwrap() {
+        FilterDirective::Rule(spec) => {
+            assert_eq!(spec.kind(), FilterRuleKind::Protect);
+            assert_eq!(spec.pattern(), " x");
+        }
+        other => panic!("expected Rule directive, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/parse_filter.rs
+++ b/crates/cli/src/frontend/tests/parse_filter.rs
@@ -159,15 +159,28 @@ fn parse_filter_directive_rejects_clear_with_trailing_characters() {
 
 #[test]
 fn parse_filter_directive_rejects_missing_pattern() {
-    let error =
-        parse_filter_directive(OsStr::new("+   ")).expect_err("missing pattern should error");
+    // upstream: exclude.c:1290-1291,1326 - exactly one separator is consumed
+    // after the rule char, so an empty remainder (`+ ` / `P `) is a missing
+    // pattern ("unexpected end of filter rule"). A whitespace-only remainder is
+    // NOT empty: `+   ` keeps the two extra spaces as the pattern "  " and is
+    // accepted (verified against rsync 3.4.4), so only the single-separator
+    // forms error here.
+    let error = parse_filter_directive(OsStr::new("+ ")).expect_err("missing pattern should error");
     let rendered = error.to_string();
     assert!(rendered.contains("missing a pattern"));
 
     let shorthand_error =
-        parse_filter_directive(OsStr::new("P   ")).expect_err("shorthand protect requires pattern");
+        parse_filter_directive(OsStr::new("P ")).expect_err("shorthand protect requires pattern");
     let rendered = shorthand_error.to_string();
     assert!(rendered.contains("missing a pattern"));
+
+    // A whitespace-only remainder is a valid (if unusual) pattern, not an error.
+    let accepted =
+        parse_filter_directive(OsStr::new("+   ")).expect("whitespace pattern is accepted");
+    assert_eq!(
+        accepted,
+        FilterDirective::Rule(FilterRuleSpec::include("  ".to_owned()))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

The command-line filter parser (`--filter`/`--exclude`/`--include`) collapsed *every* leading separator after the rule character and its modifiers, whereas upstream rsync consumes exactly one. So `--filter='-  x'` (two spaces) produced the pattern `x` instead of ` x`, silently over-excluding files.

## Upstream contract (rsync 3.4.4)

`exclude.c:1290-1291` consumes a single ` `/`_` separator via `if (*s) s++`, then takes the pattern as the remainder verbatim (`strlen`, `exclude.c:1313`). Any further leading whitespace/`_` stays part of the pattern. Verified against a real rsync 3.4.4 binary:

- `--filter='- x'`  -> pattern `x`
- `--filter='-  x'` -> pattern ` x` (one leading space kept)
- `--filter='-_ x'` -> pattern ` x` (`_` is the single separator)
- `--filter='+   '`  -> pattern `  ` (whitespace-only pattern is **accepted**)
- `--filter='+ '`    -> error "unexpected end of filter rule" (truly empty)

This mirrors the same single-separator contract already honored by the merge-file parser.

## Fix

- Introduce one shared `consume_rule_separator` helper (renamed from `trim_short_rule_remainder`) that consumes exactly one leading separator (` `, `_`, or `,`) and returns the rest verbatim.
- Use it from the short (`+`/`-`), keyword, and shorthand (P/H/S/R) forms; drop the redundant re-trim in the short and keyword parsers (the separator was already consumed by the split / `splitn`).
- A whitespace-only remainder is now a valid pattern; only a truly empty remainder is a missing-pattern error.

The merge-file parser and the word-split path are untouched. The trailing-whitespace and error contracts are preserved and asserted.

## Tests

Added differential unit tests (`- x`, `-  x`, `-_ x`, keyword and shorthand multi-space) and updated the helper and missing-pattern tests to the single-separator contract. Full `cli` crate suite passes (3547 tests, TZ=UTC).

## Gates

`cargo fmt --all --check`, `cargo clippy -p cli -p filters --all-targets --all-features -- -D warnings`, `cargo check -p cli`, `cargo check --target x86_64-pc-windows-gnu -p cli`, and targeted `cargo nextest run -p cli -E 'test(filter)'` all pass.