### PR TITLE
fix(transfer): async flist read returns leftover carry (tokio-transfer)

### DIFF
--- a/crates/transfer/src/receiver/file_list/receive_async.rs
+++ b/crates/transfer/src/receiver/file_list/receive_async.rs
@@ -46,11 +46,21 @@ impl ReceiverContext {
     /// Decodes entries via the shared async leaf until the end-of-list marker,
     /// then applies the identical post-processing (leader GNUM assignment,
     /// sort, prune, hardlink matching, pre-30 normalization, reader-cache
-    /// preservation). Returns the number of entries received.
+    /// preservation). Returns the number of entries received plus any wire bytes
+    /// the async leaf read past the end-of-list marker.
+    ///
+    /// The async leaf fills an ~8 KiB look-ahead `carry` from each demux read, so
+    /// when the sender packs the file list and the first per-file response into
+    /// one multiplex frame (rather than flushing the list separately) the surplus
+    /// bytes land in `carry` after the end-of-list marker is decoded. The sync
+    /// path never over-reads (it `read_exact`s exactly what each field needs), so
+    /// to keep the async byte discipline identical those surplus bytes must not
+    /// be dropped: they are returned as the second tuple element for the caller to
+    /// feed into the following wire phase.
     ///
     /// Unlike the sync path, this does not read the trailing UID/GID id-lists or
     /// the protocol < 30 io-error integer (see the module scope note).
-    pub async fn receive_file_list_async<R>(&mut self, src: &mut R) -> io::Result<usize>
+    pub async fn receive_file_list_async<R>(&mut self, src: &mut R) -> io::Result<(usize, Vec<u8>)>
     where
         R: AsyncRead + Unpin + ?Sized,
     {
@@ -111,7 +121,12 @@ impl ReceiverContext {
         // recv_file_list() calls - cache the reader to preserve that state.
         self.flist_reader_cache = Some(flist_reader);
 
-        Ok(count)
+        // Return the look-ahead bytes read past the end-of-list marker so the
+        // caller can hand them to the next wire phase (the INC_RECURSE segment
+        // framing, or the per-file stream when there are no sub-lists). Dropping
+        // `carry` here would desync a transfer whose sender packed the list and
+        // the first per-file response into a single multiplex frame.
+        Ok((count, carry))
     }
 
     /// Async twin of
@@ -123,7 +138,15 @@ impl ReceiverContext {
     /// entries are decoded via the shared async leaf. Post-processing per segment
     /// (leader GNUM, sort, hardlink matching, pre-30 normalization, delete-pipeline
     /// publish) is identical to the sync path. Returns the total number of entries
-    /// received across all sub-lists.
+    /// received across all sub-lists plus any wire bytes read past the terminating
+    /// `NDX_FLIST_EOF`.
+    ///
+    /// `carry` is the look-ahead the initial file-list read
+    /// ([`receive_file_list_async`](Self::receive_file_list_async)) read past its
+    /// end-of-list marker; those bytes are the start of the first segment's NDX
+    /// framing, so they seed the shared carry-over buffer here. When INC_RECURSE
+    /// is not negotiated this is a no-op that returns the `carry` unchanged so no
+    /// wire bytes are lost.
     ///
     // Unwired by design: the atomic receiver fork (ASY-7 redo) is the consuming
     // rung. Exercised only by the `async_parity` tests, so the non-test lib
@@ -132,7 +155,8 @@ impl ReceiverContext {
     pub(in crate::receiver) async fn receive_extra_file_lists_async<R>(
         &mut self,
         src: &mut R,
-    ) -> io::Result<usize>
+        mut carry: Vec<u8>,
+    ) -> io::Result<(usize, Vec<u8>)>
     where
         R: AsyncRead + Unpin + ?Sized,
     {
@@ -140,7 +164,7 @@ impl ReceiverContext {
             .compat_flags
             .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
         if !inc_recurse {
-            return Ok(0);
+            return Ok((0, carry));
         }
 
         let mut ndx_codec = create_ndx_codec(self.protocol.as_u8());
@@ -149,7 +173,6 @@ impl ReceiverContext {
             .take()
             .unwrap_or_else(|| self.build_flist_reader());
         let mut total_extra = 0;
-        let mut carry: Vec<u8> = Vec::new();
 
         loop {
             let ndx = ndx_codec.read_ndx_from_carry_async(src, &mut carry).await?;
@@ -235,6 +258,8 @@ impl ReceiverContext {
             "received {} extra entries across all sub-lists",
             total_extra
         );
-        Ok(total_extra)
+        // Any bytes read past NDX_FLIST_EOF belong to the following per-file wire
+        // phase; hand them back so the driver can prepend them and lose nothing.
+        Ok((total_extra, carry))
     }
 }

--- a/crates/transfer/src/receiver/tests/file_list/async_parity.rs
+++ b/crates/transfer/src/receiver/tests/file_list/async_parity.rs
@@ -100,7 +100,7 @@ async fn receive_file_list_async_matches_sync() {
     for chunk in [1usize, 2, 3, 7, 13, data.len()] {
         let mut async_ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
         let mut src = ChunkedReader::new(data.clone(), chunk);
-        let async_count = async_ctx.receive_file_list_async(&mut src).await.unwrap();
+        let (async_count, _leftover) = async_ctx.receive_file_list_async(&mut src).await.unwrap();
 
         assert_eq!(
             async_count, sync_count,
@@ -153,8 +153,8 @@ async fn receive_extra_file_lists_async_matches_sync() {
     for chunk in [1usize, 2, 3, 8, extra.len()] {
         let mut async_ctx = ReceiverContext::new_for_test(&handshake, test_config());
         let mut src = ChunkedReader::new(extra.clone(), chunk);
-        let async_total = async_ctx
-            .receive_extra_file_lists_async(&mut src)
+        let (async_total, _leftover) = async_ctx
+            .receive_extra_file_lists_async(&mut src, Vec::new())
             .await
             .unwrap();
 

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -506,6 +506,13 @@ impl ReceiverContext {
     /// post-sanitize `file_count`, independent of how the bytes are chunked
     /// across `.await` points.
     ///
+    /// The fourth tuple element is the file-list look-ahead carry: bytes the
+    /// async flist reader pulled past the end of the list (and past
+    /// `NDX_FLIST_EOF`) that belong to the following per-file wire phase. The
+    /// sync path never over-reads, so the driver must prepend these to the
+    /// per-file read stream to preserve the identical byte discipline; see
+    /// [`run_sync_async`](Self::run_sync_async).
+    ///
     /// Additive and unwired: the coupled async receiver driver (the deferred
     /// atomic ASY receiver fork) is the consuming rung. Exercised only by the
     /// `setup_transfer_async_matches_sync` parity test, so the non-test lib build
@@ -521,7 +528,12 @@ impl ReceiverContext {
         &mut self,
         reader: crate::reader::AsyncServerReader<R>,
         writer: &mut W,
-    ) -> io::Result<(crate::reader::AsyncServerReader<R>, usize, PipelineSetup)>
+    ) -> io::Result<(
+        crate::reader::AsyncServerReader<R>,
+        usize,
+        PipelineSetup,
+        Vec<u8>,
+    )>
     where
         R: tokio::io::AsyncRead + Unpin + Send + 'static,
         W: io::Write + ?Sized,
@@ -593,12 +605,21 @@ impl ReceiverContext {
             info_log!(Flist, 1, "receiving incremental file list");
         }
 
-        let file_count = self.receive_file_list_async(&mut reader).await?;
-        let extra_count = self.receive_extra_file_lists_async(&mut reader).await?;
+        // Thread the file-list read's look-ahead carry through the extra-lists
+        // read and back out to the driver: the async flist leaf fills an ~8 KiB
+        // buffer per demux read, so bytes read past the end-of-list marker (and
+        // past NDX_FLIST_EOF) belong to the following per-file wire phase and
+        // must not be dropped. `run_sync_async` prepends the returned `carry` to
+        // the per-file read stream so no wire bytes are lost when the sender
+        // packs the list and the first per-file response into one frame.
+        let (file_count, carry) = self.receive_file_list_async(&mut reader).await?;
+        let (extra_count, carry) = self
+            .receive_extra_file_lists_async(&mut reader, carry)
+            .await?;
         let file_count = file_count + extra_count;
 
         let (file_count, setup) = self.build_pipeline_setup(file_count)?;
-        Ok((reader, file_count, setup))
+        Ok((reader, file_count, setup, carry))
     }
 
     /// Applies upstream's `get_local_name()` single-file rename semantics.

--- a/crates/transfer/src/receiver/transfer/setup/tests.rs
+++ b/crates/transfer/src/receiver/transfer/setup/tests.rs
@@ -617,7 +617,8 @@ mod setup_transfer_async_parity {
         let mut ctx = ReceiverContext::new_for_test(&parity_handshake(), parity_config(dest));
         let reader = AsyncServerReader::new_plain(ChunkedReader::new(muxed_wire.to_vec(), chunk));
         let mut sink = std::io::sink();
-        let (_reader, count, setup) = ctx.setup_transfer_async(reader, &mut sink).await.unwrap();
+        let (_reader, count, setup, _leftover) =
+            ctx.setup_transfer_async(reader, &mut sink).await.unwrap();
         (
             count,
             project_file_list(&ctx),

--- a/crates/transfer/src/receiver/transfer/sync_async.rs
+++ b/crates/transfer/src/receiver/transfer/sync_async.rs
@@ -73,7 +73,17 @@ impl ReceiverContext {
         W: io::Write + crate::writer::MsgInfoSender + ?Sized,
     {
         let _t = PhaseTimer::new("receiver-transfer-async");
-        let (mut reader, file_count, setup) = self.setup_transfer_async(reader, writer).await?;
+        let (reader, file_count, setup, carry) = self.setup_transfer_async(reader, writer).await?;
+
+        // Prepend the file-list look-ahead carry (demuxed bytes the async flist
+        // reader pulled past the end of the list) ahead of the reader so the
+        // per-file legs consume them first. These are already-demuxed output of
+        // the same reader, so they are chained at the demux-output level (never
+        // re-demultiplexed). When the sender flushes the list separately - the
+        // common case - `carry` is empty and the chain is a zero-copy passthrough.
+        // Without this the async driver would desync on a sender that packs the
+        // list and the first per-file response into one multiplex frame.
+        let mut reader = tokio::io::AsyncReadExt::chain(std::io::Cursor::new(carry), reader);
         let reader = &mut reader;
 
         let PipelineSetup {
@@ -460,12 +470,15 @@ mod async_driver_parity_tests {
     /// `ITEM_TRANSFER` iflags + an empty echoed sum-head + the literal delta,
     /// then the finalize handshake (3 phase NDX_DONE + 1 goodbye-echo NDX_DONE).
     ///
-    /// This is carried in a MSG_DATA frame *separate* from the flist frame, which
-    /// is how upstream frames the two phases (the sender flushes the file list
-    /// before streaming per-file data). Keeping them in distinct frames is also
-    /// required for the async receiver: `read_entry_with_flist_async` fills an
-    /// 8 KiB look-ahead `carry` from a single demux read, so a data byte packed
-    /// into the flist's own frame would be swallowed into that discarded carry.
+    /// `async_receiver_driver_matches_sync_output` carries this in a MSG_DATA
+    /// frame *separate* from the flist frame, which is how upstream frames the two
+    /// phases (the sender flushes the file list before streaming per-file data).
+    /// The async receiver no longer depends on that separation:
+    /// `read_entry_with_flist_async` fills an ~8 KiB look-ahead `carry` from each
+    /// demux read, and the surplus bytes past the end-of-list marker are now
+    /// returned by `receive_file_list_async` and prepended to the per-file read
+    /// stream by `run_sync_async`. `async_flist_carry_no_byte_loss_shared_frame`
+    /// packs the flist and this data into one frame to prove that.
     fn build_data_wire(requests: &[(i32, Vec<u8>)]) -> Vec<u8> {
         let mut data = Vec::new();
 
@@ -620,6 +633,97 @@ mod async_driver_parity_tests {
         assert_eq!(std::fs::read(sync_dest.path().join("d/f2")).unwrap(), f2);
 
         // (b) identical TransferStats
+        assert_stats_eq(&async_stats, &sync_stats);
+        assert_eq!(async_stats.files_transferred, 2);
+        assert_eq!(async_stats.bytes_received, (f1.len() + f2.len()) as u64);
+    }
+
+    /// The async driver loses no wire bytes when the sender packs the file list
+    /// AND the first per-file response into a single multiplex frame (no flush
+    /// between the two phases).
+    ///
+    /// The async flist reader fills an ~8 KiB look-ahead `carry` from each demux
+    /// read, so when the per-file bytes ride in the flist's own frame they land
+    /// in `carry` after the end-of-list marker is decoded. The sync path never
+    /// over-reads. If those surplus bytes were dropped the async per-file read
+    /// would start mid-stream and desync; the carry-return path
+    /// (`receive_file_list_async` -> `setup_transfer_async` -> `run_sync_async`
+    /// prepend) preserves them.
+    ///
+    /// The same recorded wire - here a *single* MSG_DATA frame holding the flist,
+    /// the two per-file echo/delta streams, and the finalize handshake - is fed to
+    /// both [`ReceiverContext::run_sync`] and
+    /// [`ReceiverContext::run_sync_async`] (one byte per poll), and the committed
+    /// trees, [`TransferStats`], and Ok/Err outcome are asserted identical. This
+    /// test fails without the carry-return fix (the async driver desyncs) and
+    /// passes with it.
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_flist_carry_no_byte_loss_shared_frame() {
+        let f1: Vec<u8> = {
+            let mut v = b"hello f1 ".to_vec();
+            v.extend(std::iter::repeat_n(0x5Au8, 200));
+            v.extend_from_slice(b" end f1");
+            v
+        };
+        let f2: Vec<u8> = b"original f2 basis contents - unchanged".to_vec();
+
+        let entries = flist_entries(&f1, &f2);
+        let flist_wire = encode_flist(&entries);
+
+        let probe_dir = tempdir().unwrap();
+        let ndx_map = probe_ndx(probe_dir.path(), &flist_wire);
+        assert_eq!(ndx_map.len(), 2, "expected two regular-file requests");
+
+        let requests: Vec<(i32, Vec<u8>)> = ndx_map
+            .iter()
+            .map(|&(idx, ndx)| {
+                let content = if idx == 1 { &f1 } else { &f2 };
+                (ndx, encode_literal_wire(content))
+            })
+            .collect();
+
+        let data_wire = build_data_wire(&requests);
+
+        // The whole point: flist AND the per-file + finalize data share ONE
+        // multiplex frame - no separator flush between the list and the first
+        // per-file response.
+        let mut inner = flist_wire.clone();
+        inner.extend_from_slice(&data_wire);
+        let wire = muxed(&inner);
+
+        // --- sync driver ---
+        let sync_dest = tempdir().unwrap();
+        seed_basis(sync_dest.path(), &f2);
+        let sync_stats = {
+            let mut ctx = ReceiverContext::new_for_test(&handshake(), config(sync_dest.path()));
+            let reader = ServerReader::new_plain(Cursor::new(wire.clone()));
+            let mut writer = CaptureWriter(Vec::new());
+            ctx.run_sync(reader, &mut writer)
+                .expect("sync driver must succeed")
+        };
+        let sync_tree = read_tree(sync_dest.path());
+
+        // --- async driver, one byte per poll ---
+        let async_dest = tempdir().unwrap();
+        seed_basis(async_dest.path(), &f2);
+        let async_stats = {
+            let mut ctx = ReceiverContext::new_for_test(&handshake(), config(async_dest.path()));
+            let reader = AsyncServerReader::new_plain(ChunkedReader::new(wire.clone(), 1));
+            let mut writer = CaptureWriter(Vec::new());
+            ctx.run_sync_async(reader, &mut writer)
+                .await
+                .expect("async driver must succeed on a shared flist+data frame")
+        };
+        let async_tree = read_tree(async_dest.path());
+
+        assert_eq!(
+            async_tree, sync_tree,
+            "async driver committed a different destination tree than sync \
+             when the flist and first per-file response shared one frame"
+        );
+        assert_eq!(std::fs::read(sync_dest.path().join("d/f1")).unwrap(), f1);
+        assert_eq!(std::fs::read(sync_dest.path().join("d/f2")).unwrap(), f2);
+
         assert_stats_eq(&async_stats, &sync_stats);
         assert_eq!(async_stats.files_transferred, 2);
         assert_eq!(async_stats.bytes_received, (f1.len() + f2.len()) as u64);


### PR DESCRIPTION
## Problem

The opt-in async receiver (`tokio-transfer`, default-off) desyncs when the sender packs the file list and the first per-file response into a single multiplex frame instead of flushing the list separately.

`read_entry_with_flist_async` fills an ~8 KiB look-ahead `carry` from each demux read, then decodes entries until the end-of-list marker. Any bytes read past that marker (the start of the per-file stream) stayed in a `carry` that `receive_file_list_async` owned locally and dropped on return. Upstream normally flushes the list before per-file data, so the existing parity tests never exercised the shared-frame case, but a robust async driver must not depend on that flush.

The sync path never over-reads (it `read_exact`s exactly each field's bytes), so async must match that byte discipline.

## Fix

Thread the look-ahead carry back to the driver instead of discarding it. The protocol leaf is unchanged (its caller-owned `carry` already retains leftovers); only the receiver-side consumers changed:

- `receive_file_list_async` returns `(count, leftover: Vec<u8>)`.
- `receive_extra_file_lists_async` takes the incoming carry (seeding the shared INC_RECURSE NDX buffer) and returns its own leftover; the non-inc-recurse early return passes the carry through unchanged.
- `setup_transfer_async` threads the carry through both reads and returns it as a fourth tuple element.
- `run_sync_async` prepends the carry ahead of the reader via a `Chain<Cursor<Vec<u8>>, AsyncServerReader>` at the demux-output level (the carry is already-demuxed output, never re-demultiplexed). When the list is flushed separately the carry is empty and the chain is a passthrough.

Sync path untouched; the entire change is behind `#[cfg(feature = "tokio-transfer")]`.

## Test

New `async_flist_carry_no_byte_loss_shared_frame`: the file list, both per-file echo/delta streams, and the finalize handshake are packed into one MSG_DATA frame (no separator flush) and fed to both `run_sync` and `run_sync_async` (one byte per poll). Asserts byte-identical destination tree, identical `TransferStats`, and identical Ok/Err outcome. Verified it fails without the fix (`UnexpectedEof` desync) and passes with it.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p transfer -p protocol --all-targets --all-features -- -D warnings`
- `cargo check -p transfer -p protocol` (default and `--features tokio-transfer`)
- `cargo check --target x86_64-pc-windows-gnu -p transfer -p protocol` (default and feature)
- `cargo nextest run -p transfer --all-features -E 'test(async...)'` (48 async tests pass)
