### PR TITLE
feat(transfer): pipelined async receiver driver (tokio-transfer)

### DIFF
--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -8,20 +8,32 @@
 //! - `sync_async` - `.await` twin of `sync` used by `run_sync_async`
 //!   (`tokio-transfer` only).
 //! - `pipelined` - decoupled two-phase pipeline used by `run_pipelined`.
+//! - `pipelined_async` - `.await` twin of `pipelined` used by
+//!   `run_pipelined_async` (`tokio-transfer` only).
 //! - `pipelined_incremental` - same as `pipelined` plus incremental directory
 //!   creation and failed-dir tracking.
+//! - `pipelined_incremental_async` - `.await` twin of `pipelined_incremental`
+//!   used by `run_pipelined_incremental_async` (`tokio-transfer` only).
 //! - `setup` - common multiplex/filter/file-list setup.
 //! - `phases` - protocol phase exchange and goodbye handshake.
 //! - `candidates` - candidate-file selection for the pipelined paths.
 //! - `pipeline` - the inner `run_pipeline_loop_decoupled` plus dry-run loop.
+//! - `pipeline_async` - `.await` twin of `pipeline` used by the async pipelined
+//!   drivers (`tokio-transfer` only).
 
 mod candidates;
 #[cfg(feature = "tokio-transfer")]
 mod file_async;
 mod phases;
 mod pipeline;
+#[cfg(feature = "tokio-transfer")]
+mod pipeline_async;
 mod pipelined;
+#[cfg(feature = "tokio-transfer")]
+mod pipelined_async;
 mod pipelined_incremental;
+#[cfg(feature = "tokio-transfer")]
+mod pipelined_incremental_async;
 mod setup;
 mod sync;
 #[cfg(feature = "tokio-transfer")]

--- a/crates/transfer/src/receiver/transfer/pipeline_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline_async.rs
@@ -1,0 +1,544 @@
+//! Async (tokio-transfer) twin of the decoupled pipelined transfer loop.
+//!
+//! [`ReceiverContext::run_pipeline_loop_decoupled_async`] is the `.await` twin of
+//! the network-read side of
+//! [`run_pipeline_loop_decoupled`](super::pipeline). It reproduces the sync
+//! pipeline's control flow - fill a sliding request window, compute signatures
+//! (in parallel via rayon when the batch is large enough), send requests
+//! sequentially, and process responses - but drives the per-file delta read off
+//! an [`AsyncRead`](tokio::io::AsyncRead) transport via
+//! [`process_file_response_streaming_async`].
+//!
+//! The producer/consumer split is preserved exactly: the network-read side (this
+//! loop) awaits the wire and hands each reconstructed chunk to the **same**
+//! synchronous SPSC channel feeding the dedicated background disk-commit thread
+//! ([`PipelinedReceiver`]). That disk thread stays a `std::thread` - it never
+//! cooperates with the async runtime, so there is no runtime-cooperation
+//! deadlock. Only the wire reads become `.await`; the request-half writes,
+//! signature computation, buffer recycling, disk-result draining, itemize
+//! emission, and stats accumulation run through the identical synchronous logic
+//! the sync loop uses.
+//!
+//! Gated on `tokio-transfer` (default off); additive and not wired into
+//! [`run`](ReceiverContext::run) yet.
+//!
+//! # Upstream Reference
+//!
+//! - `receiver.c:720` - `recv_files()` main reception loop
+//! - `generator.c:2157-2163` - phase 1 vs phase 2 checksum length selection
+//! - `io.c:perform_io()` - upstream bidirectional I/O batching via `select()`
+
+#![allow(dead_code)]
+
+use std::collections::VecDeque;
+use std::io;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use logging::{debug_log, info_log};
+use protocol::codec::{MonotonicNdxWriter, NdxCodec, create_ndx_codec};
+use protocol::flist::FileEntry;
+
+use crate::delta_apply::ChecksumVerifier;
+use crate::pipeline::{PipelineConfig, PipelineState};
+use crate::receiver::basis::{BasisFileConfig, find_basis_file_with_config};
+use crate::receiver::{PipelineSetup, ReceiverContext};
+use crate::transfer_ops::{
+    RequestConfig, ResponseContext, process_file_response_streaming_async, send_file_request,
+};
+
+/// Result type for the pipelined transfer closure:
+/// `(files_transferred, bytes, literal, matched, redo_indices, delayed_updates)`.
+type PipelineResult = (usize, u64, u64, u64, Vec<usize>, Vec<(PathBuf, PathBuf)>);
+
+impl ReceiverContext {
+    /// Async twin of [`run_pipeline_loop_decoupled`](Self::run_pipeline_loop_decoupled).
+    ///
+    /// Fills a sliding window of file requests, computes signatures (in parallel
+    /// when the batch exceeds the configured signature threshold), then processes
+    /// responses off the async transport with the same background disk-commit
+    /// thread. Returns
+    /// `(files_transferred, bytes, literal, matched, redo_indices, delayed_updates)`.
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::receiver) async fn run_pipeline_loop_decoupled_async<Rd, W>(
+        &self,
+        reader: &mut Rd,
+        writer: &mut W,
+        pipeline_config: PipelineConfig,
+        setup: &PipelineSetup,
+        files_to_transfer: Vec<(usize, &FileEntry, PathBuf, u32)>,
+        metadata_errors: &mut Vec<(PathBuf, String)>,
+        is_redo_pass: bool,
+        total_files: usize,
+        progress: &mut Option<&mut dyn crate::TransferProgressCallback>,
+    ) -> io::Result<PipelineResult>
+    where
+        Rd: tokio::io::AsyncRead + Unpin + ?Sized,
+        W: io::Write + crate::writer::MsgInfoSender + ?Sized,
+    {
+        use crate::disk_commit::{BackupConfig, DiskCommitConfig, PartialMode};
+        use crate::pipeline::receiver::PipelinedReceiver;
+        use crate::shared::TransferDeadline;
+
+        // Early return when there is nothing to transfer - avoids spawning the
+        // disk-commit thread, creating codecs, and pipeline state. Flush buffered
+        // itemize messages from build_files_to_transfer() so the generator sees
+        // them before the NDX_DONE handshake.
+        // upstream: generator.c sends itemize immediately per-file via rwrite()
+        if files_to_transfer.is_empty() {
+            writer.flush()?;
+            return Ok((0, 0, 0, 0, Vec::new(), Vec::new()));
+        }
+
+        let deadline = TransferDeadline::from_system_time(self.config.stop_at);
+
+        let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
+        let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
+
+        let request_config = RequestConfig {
+            protocol: self.protocol,
+            write_iflags: self.protocol.supports_iflags(),
+            checksum_length: setup.checksum_length,
+            checksum_algorithm: setup.checksum_algorithm,
+            negotiated_algorithms: self.negotiated_algorithms.as_ref(),
+            compat_flags: self.compat_flags.as_ref(),
+            checksum_seed: self.checksum_seed,
+            use_sparse: self.config.flags.sparse,
+            do_fsync: self.config.write.fsync,
+            temp_dir: self.config.temp_dir.as_deref(),
+            write_devices: self.config.write.write_devices,
+            inplace: self.config.write.inplace,
+            inplace_partial: self.config.write.inplace_partial,
+            io_uring_policy: self.config.write.io_uring_policy,
+            io_uring_depth: self.config.write.io_uring_depth,
+            preserve_xattrs: self.config.flags.xattrs,
+            want_xattr_optim: self.protocol.as_u8() >= 31
+                && self.compat_flags.is_some_and(|f| {
+                    !f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
+                }),
+            // upstream: receiver.c:761-773 - a phase-2 redo negates append_mode
+            // (`append_mode = -append_mode`), so the re-request is a full
+            // transfer that overwrites the file rather than appending to a
+            // prefix the verify pass already rejected.
+            append: self.config.flags.append && !is_redo_pass,
+            append_verify: self.config.flags.append_verify && !is_redo_pass,
+        };
+
+        // upstream: token.c uses a single compression context across all files.
+        // For zstd the DCtx must persist across file boundaries (continuous
+        // stream), so the reader is built once and reused for the session.
+        let mut token_reader = request_config.create_token_reader()?;
+
+        let mut pipeline = PipelineState::new(pipeline_config);
+        let mut file_iter = files_to_transfer.into_iter();
+        let mut pending_files_info: VecDeque<(usize, PathBuf, &FileEntry, u32)> =
+            VecDeque::with_capacity(pipeline.window_size());
+        let mut files_transferred = 0usize;
+        let mut bytes_received = 0u64;
+        let mut total_literal_bytes = 0u64;
+        let mut total_matched_bytes = 0u64;
+
+        let mut checksum_verifier = ChecksumVerifier::new(
+            self.negotiated_algorithms.as_ref(),
+            self.protocol,
+            self.checksum_seed,
+            self.compat_flags.as_ref(),
+        );
+        let backup = if self.config.flags.backup {
+            Some(BackupConfig {
+                dest_dir: setup.dest_dir.clone(),
+                backup_dir: self.config.backup_dir.as_ref().map(PathBuf::from),
+                suffix: self.config.effective_backup_suffix().into(),
+            })
+        } else {
+            None
+        };
+        let file_list_arc = Arc::new(self.file_list.clone());
+        // upstream: cleanup.c - compute partial mode from --partial / --partial-dir flags
+        let partial_mode = if let Some(ref dir) = self.config.partial_dir {
+            PartialMode::PartialDir(dir.clone())
+        } else if self.config.flags.partial {
+            PartialMode::Partial
+        } else {
+            PartialMode::None
+        };
+        let disk_config = DiskCommitConfig {
+            do_fsync: self.config.write.fsync,
+            use_sparse: self.config.flags.sparse,
+            dest_dir: Some(setup.dest_dir.clone()),
+            #[cfg(unix)]
+            sandbox: setup.sandbox.clone(),
+            temp_dir: self.config.temp_dir.as_ref().map(PathBuf::from),
+            file_list: Some(file_list_arc),
+            metadata_opts: Some(setup.metadata_opts.clone()),
+            backup,
+            acl_cache: setup.acl_cache.clone(),
+            acl_id_map: setup.acl_id_map.clone(),
+            io_uring_policy: self.config.write.io_uring_policy,
+            io_uring_depth: self.config.write.io_uring_depth,
+            partial_mode,
+            delay_updates: self.config.write.delay_updates,
+            append_verify: self.config.flags.append_verify && !is_redo_pass,
+            ..DiskCommitConfig::default()
+        };
+        let mut pipelined_receiver = PipelinedReceiver::new(disk_config)?;
+        if is_redo_pass {
+            let _ = pipelined_receiver.take_redo_indices();
+        }
+
+        // Async equivalent of the sync loop's inner closure: run the loop and
+        // capture its result, then run the graceful shutdown regardless of
+        // outcome. A regular async block replaces the sync `(|| { .. })()`
+        // immediately-invoked closure so `.await` is usable inside.
+        let result: io::Result<PipelineResult> = async {
+            // Track how many requests the sender has received (flushed) but not
+            // yet responded to. We only flush the write buffer when this drops to
+            // zero - otherwise the sender already has queued requests.
+            //
+            // upstream: io.c perform_io() uses select() for bidirectional I/O,
+            // naturally batching writes until the output buffer is full.
+            let mut flushed_pending: usize = 0;
+
+            loop {
+                if let Some(ref dl) = deadline {
+                    if dl.is_reached() {
+                        break;
+                    }
+                }
+
+                // Collect a batch of files, compute signatures (potentially in
+                // parallel for incremental sync), then send requests sequentially.
+                {
+                    use rayon::prelude::*;
+
+                    let batch: Vec<_> = file_iter
+                        .by_ref()
+                        .take(pipeline.available_slots())
+                        .collect();
+
+                    if !batch.is_empty() && !is_redo_pass {
+                        // Extract basis config fields for the closure to avoid
+                        // capturing &self across rayon worker boundaries.
+                        let fuzzy_level = self.config.flags.fuzzy_level;
+                        let ref_dirs = &self.config.reference_directories;
+                        let protocol = self.protocol;
+                        let whole_file = self.config.flags.whole_file;
+                        let dest_dir = &setup.dest_dir;
+                        let checksum_length = setup.checksum_length;
+                        let checksum_algorithm = setup.checksum_algorithm;
+                        let sig_threshold = self
+                            .parallel_thresholds
+                            .for_op(crate::parallel_io::ParallelOp::Signature);
+
+                        // Ordering: wire protocol requires file requests in file-list index order.
+                        // Preserved by par_iter().map().collect() + sequential zip/send loop below.
+                        // Violation sends signatures for wrong files, corrupting delta transfer.
+                        let sig_results: Vec<_> = if batch.len() >= sig_threshold {
+                            batch
+                                .par_iter()
+                                .map(|(_, file_entry, file_path, _)| {
+                                    let basis_config = BasisFileConfig {
+                                        file_path,
+                                        dest_dir,
+                                        relative_path: file_entry.path(),
+                                        target_size: file_entry.size(),
+                                        target_mtime: file_entry.mtime(),
+                                        fuzzy_level,
+                                        reference_directories: ref_dirs,
+                                        protocol,
+                                        checksum_length,
+                                        checksum_algorithm,
+                                        whole_file,
+                                    };
+                                    find_basis_file_with_config(&basis_config)
+                                })
+                                .collect()
+                        } else {
+                            batch
+                                .iter()
+                                .map(|(_, file_entry, file_path, _)| {
+                                    let basis_config = BasisFileConfig {
+                                        file_path,
+                                        dest_dir,
+                                        relative_path: file_entry.path(),
+                                        target_size: file_entry.size(),
+                                        target_mtime: file_entry.mtime(),
+                                        fuzzy_level,
+                                        reference_directories: ref_dirs,
+                                        protocol,
+                                        checksum_length,
+                                        checksum_algorithm,
+                                        whole_file,
+                                    };
+                                    find_basis_file_with_config(&basis_config)
+                                })
+                                .collect()
+                        };
+
+                        // Send requests sequentially (wire order matters).
+                        for ((file_idx, file_entry, file_path, base_iflags), basis_result) in
+                            batch.into_iter().zip(sig_results)
+                        {
+                            let pending = send_file_request(
+                                writer,
+                                &mut ndx_write_codec,
+                                self.flat_to_wire_ndx(file_idx),
+                                file_path.clone(),
+                                basis_result.signature,
+                                basis_result.basis_path,
+                                file_entry.size(),
+                                &request_config,
+                            )?;
+
+                            pipeline.push(pending);
+                            pending_files_info.push_back((
+                                file_idx,
+                                file_path,
+                                file_entry,
+                                base_iflags,
+                            ));
+                        }
+                    } else {
+                        // Redo pass or empty batch: no basis files, skip signatures.
+                        for (file_idx, file_entry, file_path, base_iflags) in batch {
+                            let pending = send_file_request(
+                                writer,
+                                &mut ndx_write_codec,
+                                self.flat_to_wire_ndx(file_idx),
+                                file_path.clone(),
+                                None,
+                                None,
+                                file_entry.size(),
+                                &request_config,
+                            )?;
+
+                            pipeline.push(pending);
+                            pending_files_info.push_back((
+                                file_idx,
+                                file_path,
+                                file_entry,
+                                base_iflags,
+                            ));
+                        }
+                    }
+                }
+
+                if pipeline.is_empty() {
+                    break;
+                }
+
+                // Flush only when the sender has no queued requests left.
+                if flushed_pending == 0 {
+                    writer.flush()?;
+                    flushed_pending = pipeline.outstanding();
+                }
+
+                // Process one response from a previously flushed request.
+                let pending = pipeline.pop().expect("pipeline not empty");
+                flushed_pending = flushed_pending.saturating_sub(1);
+                let (file_idx, file_path, file_entry, base_iflags) =
+                    pending_files_info.pop_front().expect("pipeline not empty");
+
+                // upstream: receiver.c:708-709 DEBUG_GTE(RECV, 1)
+                debug_log!(Recv, 1, "recv_files({})", file_entry.path().display());
+
+                let response_ctx = ResponseContext {
+                    config: &request_config,
+                    #[cfg(unix)]
+                    sandbox: setup.sandbox.as_ref(),
+                    #[cfg(unix)]
+                    dest_dir: Some(setup.dest_dir.as_path()),
+                };
+
+                let xattr_list = self.resolve_xattr_list(file_entry);
+                let is_device_target = self.config.write.write_devices && file_entry.is_device();
+                let result = process_file_response_streaming_async(
+                    reader,
+                    &mut ndx_read_codec,
+                    pending,
+                    &response_ctx,
+                    &mut checksum_verifier,
+                    pipelined_receiver.file_sender(),
+                    pipelined_receiver.buf_return_rx(),
+                    file_idx,
+                    is_device_target,
+                    xattr_list,
+                    &mut token_reader,
+                )
+                .await?;
+
+                pipelined_receiver.note_commit_sent(
+                    result.expected_checksum,
+                    result.checksum_len,
+                    file_path,
+                    file_idx,
+                );
+
+                // Non-blocking: collect any ready disk results.
+                let (_disk_bytes, disk_meta_errors) = pipelined_receiver.drain_ready_results()?;
+                metadata_errors.extend(disk_meta_errors);
+
+                // Route accumulated warnings through the multiplexed writer
+                // instead of eprintln (which deadlocks in daemon handler threads).
+                // Fatal transfer errors ride MSG_ERROR_XFER so the peer sets
+                // got_xfer_error (exit 23); everything else is MSG_INFO.
+                for (code, warning) in pipelined_receiver.drain_warnings() {
+                    let _ = if code == protocol::MessageCode::ErrorXfer {
+                        writer.send_msg_error_xfer(warning.as_bytes())
+                    } else {
+                        writer.send_msg_info(warning.as_bytes())
+                    };
+                }
+
+                // upstream: io.c:820 stats.total_read only counts bytes read off
+                // the wire. Matched-from-basis bytes never traverse the read fd,
+                // so exclude them from bytes_received.
+                bytes_received += result.literal_bytes;
+                total_literal_bytes += result.literal_bytes;
+                total_matched_bytes += result.matched_bytes;
+                files_transferred += 1;
+
+                // upstream: receiver.c:950 - log_item() after successful file transfer
+                {
+                    if self.config.flags.verbose && self.config.connection.client_mode {
+                        info_log!(Name, 1, "{}", file_entry.path().display());
+                    }
+                    // upstream: generator.c:1925-1937 - the transfer itemize is
+                    // emitted right after the file request. With
+                    // log_before_transfer == 0 (`am_server`) the row is logged
+                    // after the transfer, so a server-mode receiver emits it
+                    // here. Client-mode receivers (log_before_transfer == 1)
+                    // already emitted it in the linear candidate pass to keep the
+                    // stdout interleaving with skip/unchanged rows.
+                    if !self.config.connection.client_mode {
+                        use crate::generator::ItemFlags;
+                        let iflags = ItemFlags::from_raw(base_iflags);
+                        let _ = self.emit_itemize(writer, &iflags, file_entry);
+                    }
+                }
+
+                if let Some(cb) = progress.as_mut() {
+                    let event = crate::TransferProgressEvent {
+                        path: file_entry.path(),
+                        file_bytes: result.total_bytes,
+                        total_file_bytes: Some(file_entry.size()),
+                        files_done: files_transferred,
+                        total_files,
+                        // Receiver-side INC_RECURSE collects every sub-list via
+                        // `receive_extra_file_lists` before the pipeline begins,
+                        // so the file list is always complete when progress is
+                        // emitted. upstream: progress.c:79-82 rprint_progress.
+                        flist_eof: true,
+                    };
+                    cb.on_file_transferred(&event);
+                }
+            }
+
+            // Drain all remaining disk results
+            let (_disk_bytes, disk_meta_errors) = pipelined_receiver.drain_all_results()?;
+            metadata_errors.extend(disk_meta_errors);
+
+            // Route accumulated warnings through the multiplexed writer.
+            // Fatal transfer errors ride MSG_ERROR_XFER so the peer sets
+            // got_xfer_error (exit 23); everything else is MSG_INFO.
+            for (code, warning) in pipelined_receiver.drain_warnings() {
+                let _ = if code == protocol::MessageCode::ErrorXfer {
+                    writer.send_msg_error_xfer(warning.as_bytes())
+                } else {
+                    writer.send_msg_info(warning.as_bytes())
+                };
+            }
+
+            let redo_indices = pipelined_receiver.take_redo_indices();
+            let delayed = pipelined_receiver.take_delayed_updates();
+
+            Ok((
+                files_transferred,
+                bytes_received,
+                total_literal_bytes,
+                total_matched_bytes,
+                redo_indices,
+                delayed,
+            ))
+        }
+        .await;
+
+        // Graceful shutdown regardless of success or failure.
+        let _ = pipelined_receiver.shutdown();
+
+        result
+    }
+
+    /// Async twin of [`run_dry_run_loop`](Self::run_dry_run_loop).
+    ///
+    /// Sends NDX + iflags per candidate (synchronous `Write`, as in the sync
+    /// leaf) and reads the sender's echoed NDX + attrs off the async transport.
+    /// No sum-head or file data is exchanged. Mirrors upstream generator.c
+    /// behavior during `!do_xfers`.
+    ///
+    /// upstream: generator.c:1845-1946 - `!do_xfers` path sends write_ndx() then
+    /// goto cleanup, skipping write_sum_head(). sender.c:394-399 - `!do_xfers`
+    /// logs the item and echoes write_ndx_and_attrs() without receive_sums().
+    pub(in crate::receiver) async fn run_dry_run_loop_async<Rd, W>(
+        &self,
+        reader: &mut Rd,
+        writer: &mut W,
+        files_to_transfer: &[(usize, &FileEntry, PathBuf, u32)],
+    ) -> io::Result<()>
+    where
+        Rd: tokio::io::AsyncRead + Unpin + ?Sized,
+        W: io::Write + crate::writer::MsgInfoSender + ?Sized,
+    {
+        if files_to_transfer.is_empty() {
+            writer.flush()?;
+            return Ok(());
+        }
+
+        let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
+        let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
+        let write_iflags = self.protocol.supports_iflags();
+        let preserve_xattrs = self.config.flags.xattrs;
+        let want_xattr_optim = self.protocol.as_u8() >= 31
+            && self.compat_flags.is_some_and(|f| {
+                !f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
+            });
+
+        // upstream: io.c perform_io() flushes output via select() while waiting
+        // for input. We flush once before blocking on each response read.
+        for &(file_idx, file_entry, _, _) in files_to_transfer {
+            // upstream: generator.c:1925 - write_ndx(f_out, ndx)
+            let wire_ndx = self.flat_to_wire_ndx(file_idx);
+            ndx_write_codec.write_ndx(&mut *writer, wire_ndx)?;
+
+            // upstream: generator.c:1926 - iflags with ITEM_TRANSFER
+            if write_iflags {
+                use crate::receiver::wire::SenderAttrs;
+                writer.write_all(&SenderAttrs::ITEM_TRANSFER.to_le_bytes())?;
+            }
+
+            // Flush before blocking on the sender's echo.
+            writer.flush()?;
+
+            // upstream: sender.c:394-399 - sender echoes write_ndx_and_attrs back
+            let (_echoed_ndx, _sender_attrs) =
+                crate::receiver::wire::SenderAttrs::read_with_codec_xattr_async(
+                    reader,
+                    &mut ndx_read_codec,
+                    preserve_xattrs,
+                    want_xattr_optim,
+                )
+                .await?;
+
+            // upstream: rsync.c:672-676 set_file_attrs emits the bare-name notice
+            // AFTER the transfer decision is known. In dry-run the sender's echo
+            // confirms the file would have been transferred, so emit the
+            // "updated" line at the post-decision point to match upstream order.
+            if self.config.flags.verbose && self.config.connection.client_mode {
+                info_log!(Name, 1, "{}", file_entry.path().display());
+            }
+        }
+
+        writer.flush()?;
+        Ok(())
+    }
+}

--- a/crates/transfer/src/receiver/transfer/pipelined_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_async.rs
@@ -1,0 +1,686 @@
+//! Async (tokio-transfer) twin of the pipelined receiver driver loop.
+//!
+//! [`ReceiverContext::run_pipelined_async`] is the `.await` twin of
+//! [`run_pipelined`](super::pipelined). It reproduces the pipelined driver's
+//! control flow - setup, directory/symlink/missing-args creation, the optional
+//! delete pass, the two-phase (phase-1 + redo) pipeline loop, verbose dir
+//! listing, hardlink creation, delayed-updates, `touch_up_dirs`, and
+//! finalization - but drives the three wire-facing legs through their async
+//! leaves:
+//!
+//! - setup: [`setup_transfer_async`](ReceiverContext::setup_transfer_async)
+//!   (returns the flist look-ahead carry, consumed exactly as `run_sync_async`
+//!   does);
+//! - per-file pipeline: [`run_pipeline_loop_decoupled_async`](ReceiverContext::run_pipeline_loop_decoupled_async),
+//!   the `.await` twin of the network-read side of the sync pipeline loop, which
+//!   still hands each reconstructed chunk to the same synchronous SPSC->disk
+//!   thread;
+//! - finalize: [`finalize_transfer_async`](ReceiverContext::finalize_transfer_async).
+//!
+//! Every non-IO step - `ensure_relative_parents`, `create_directories`,
+//! `create_symlinks`, `process_missing_args_sentinels`, the delete pass,
+//! `build_files_to_transfer`, `create_hardlinks`, `handle_delayed_updates`, and
+//! `touch_up_dirs` - is the identical synchronous helper the sync driver calls,
+//! and the `TransferStats` are accumulated field-for-field the same way. Only the
+//! three wire legs above differ, so for the same wire bytes this produces a
+//! byte-identical destination tree and identical `TransferStats`, independent of
+//! how the bytes are chunked across `.await` points.
+//!
+//! Gated on `tokio-transfer` (default off); additive and not wired into
+//! [`run`](ReceiverContext::run) yet (that gating is the receiver-routing rung).
+//!
+//! # Upstream Reference
+//!
+//! - `receiver.c:720` - `recv_files()` main loop
+//! - `generator.c:2157-2163` - phase 1 vs phase 2 checksum length
+
+use std::io;
+use std::path::PathBuf;
+
+use logging::{PhaseTimer, debug_log, info_log};
+use protocol::flist::FileEntry;
+use protocol::stats::DeleteStats;
+
+use crate::pipeline::PipelineConfig;
+use crate::receiver::stats::TransferStats;
+use crate::receiver::{REDO_CHECKSUM_LENGTH, ReceiverContext};
+
+impl ReceiverContext {
+    /// Async twin of [`run_pipelined`](Self::run_pipelined).
+    ///
+    /// Runs the two-phase pipelined receiver with `.await` on the wire-read legs.
+    /// The request half of each per-file exchange stays a plain synchronous
+    /// `Write`; only the sender's echoed NDX/attrs, echoed sum-head, delta
+    /// tokens, trailing checksums, and the finalization phase/goodbye frames are
+    /// read via `.await`. The SPSC channel and the dedicated background
+    /// disk-commit thread are unchanged from the sync path, so this produces the
+    /// same committed tree and `TransferStats`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:720` - `recv_files()` main loop
+    #[cfg(feature = "tokio-transfer")]
+    #[allow(dead_code)]
+    pub(in crate::receiver) async fn run_pipelined_async<R, W>(
+        &mut self,
+        reader: crate::reader::AsyncServerReader<R>,
+        writer: &mut W,
+        pipeline_config: PipelineConfig,
+    ) -> io::Result<TransferStats>
+    where
+        R: tokio::io::AsyncRead + Unpin + Send + 'static,
+        W: io::Write + crate::writer::MsgInfoSender + ?Sized,
+    {
+        let _t = PhaseTimer::new("receiver-transfer-pipelined-async");
+        let (reader, file_count, mut setup, carry) =
+            self.setup_transfer_async(reader, writer).await?;
+
+        // Prepend the file-list look-ahead carry (demuxed bytes the async flist
+        // reader pulled past the end of the list) ahead of the reader so the
+        // per-file legs consume them first. Identical to `run_sync_async`.
+        let mut reader = tokio::io::AsyncReadExt::chain(std::io::Cursor::new(carry), reader);
+        let reader = &mut reader;
+
+        // upstream: generator.c:1317-1326 - make_path() for relative_paths
+        self.ensure_relative_parents(&setup.dest_dir);
+        let mut metadata_errors = self.create_directories(
+            &setup.dest_dir,
+            &setup.metadata_opts,
+            setup.acl_cache.as_deref(),
+            setup.acl_id_map.as_deref(),
+            writer,
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
+        )?;
+        #[cfg(unix)]
+        self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        #[cfg(not(unix))]
+        self.create_symlinks(&setup.dest_dir, writer)?;
+
+        // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
+        // deletes the destination path and skips any creation for the sentinel.
+        self.process_missing_args_sentinels(
+            &setup.dest_dir,
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
+        )?;
+
+        // upstream: receiver.c:653-654 DEBUG_GTE(RECV, 1)
+        debug_log!(Recv, 1, "recv_files({}) starting", file_count);
+
+        let mut delete_stats = DeleteStats::new();
+        let mut delete_limit_exceeded = false;
+        let mut delete_io_error: i32 = 0;
+        if self.config.flags.delete {
+            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
+                &setup.dest_dir,
+                #[cfg(unix)]
+                setup.sandbox.as_ref(),
+                writer,
+            )?;
+            delete_stats = ds;
+            delete_limit_exceeded = exceeded;
+            delete_io_error = io_bits;
+            // Carry the per-type counters into the receiver context so the
+            // goodbye handshake can emit NDX_DEL_STATS to the peer sender.
+            // upstream: generator.c:2393-2398 - early write_del_stats() emission.
+            self.pending_del_stats = delete_stats;
+        }
+
+        let mut stats = TransferStats {
+            files_listed: file_count,
+            entries_received: file_count as u64,
+            io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
+                | self.flist_io_error
+                | delete_io_error,
+            ..Default::default()
+        };
+        let files_to_transfer = self.build_files_to_transfer(
+            writer,
+            &setup.dest_dir,
+            &setup.metadata_opts,
+            None,
+            &mut metadata_errors,
+            &mut stats,
+            setup.acl_cache.as_deref(),
+            setup.acl_id_map.as_deref(),
+        );
+
+        let mut files_transferred: usize = 0;
+        let mut bytes_received: u64 = 0;
+        let mut literal_data: u64 = 0;
+        let mut matched_data: u64 = 0;
+        let mut redo_count: usize = 0;
+        let mut all_delayed_updates: Vec<(PathBuf, PathBuf)> = Vec::new();
+
+        // upstream: generator.c:1249 - list-only renders every flist entry via
+        // list_file_entry() and sends NO per-file NDX request. This branch must
+        // precede the dry_run check: list-only is not dry-run.
+        if self.config.flags.list_only {
+            stats.list_only_entries = self.collect_list_only_entries();
+            writer.flush()?;
+        } else if self.config.flags.dry_run {
+            self.run_dry_run_loop_async(reader, writer, &files_to_transfer)
+                .await?;
+        } else {
+            let total_files = files_to_transfer.len();
+            let redo_config = pipeline_config.clone();
+            let mut no_progress: Option<&mut dyn crate::TransferProgressCallback> = None;
+            let redo_indices;
+            let delayed;
+            (
+                files_transferred,
+                bytes_received,
+                literal_data,
+                matched_data,
+                redo_indices,
+                delayed,
+            ) = self
+                .run_pipeline_loop_decoupled_async(
+                    reader,
+                    writer,
+                    pipeline_config,
+                    &setup,
+                    files_to_transfer,
+                    &mut metadata_errors,
+                    false,
+                    total_files,
+                    &mut no_progress,
+                )
+                .await?;
+            all_delayed_updates.extend(delayed);
+
+            // Phase 2: redo pass for files that failed checksum verification.
+            redo_count = redo_indices.len();
+            if !redo_indices.is_empty() {
+                setup.checksum_length = REDO_CHECKSUM_LENGTH;
+
+                // upstream: generator.c:1926 - the phase-2 redo re-itemizes with
+                // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
+                let redo_files: Vec<(usize, &FileEntry, PathBuf, u32)> = redo_indices
+                    .iter()
+                    .filter_map(|&idx| {
+                        self.file_list.get(idx).map(|entry| {
+                            let p = entry.path();
+                            let file_path = if p.as_os_str() == "." {
+                                setup.dest_dir.clone()
+                            } else {
+                                setup.dest_dir.join(p)
+                            };
+                            (
+                                idx,
+                                entry,
+                                file_path,
+                                crate::generator::ItemFlags::ITEM_TRANSFER,
+                            )
+                        })
+                    })
+                    .collect();
+
+                let (redo_transferred, redo_bytes, redo_literal, redo_matched, _, redo_delayed) =
+                    self.run_pipeline_loop_decoupled_async(
+                        reader,
+                        writer,
+                        redo_config,
+                        &setup,
+                        redo_files,
+                        &mut metadata_errors,
+                        true,
+                        total_files,
+                        &mut no_progress,
+                    )
+                    .await?;
+
+                files_transferred += redo_transferred;
+                bytes_received += redo_bytes;
+                literal_data += redo_literal;
+                matched_data += redo_matched;
+                all_delayed_updates.extend(redo_delayed);
+            }
+        }
+
+        if self.config.flags.verbose && self.config.connection.client_mode {
+            for file_entry in &self.file_list {
+                if file_entry.is_dir() {
+                    let relative_path = file_entry.path();
+                    if relative_path.as_os_str() == "." {
+                        info_log!(Name, 1, "./");
+                    } else {
+                        info_log!(Name, 1, "{}/", relative_path.display());
+                    }
+                }
+            }
+        }
+
+        #[cfg(unix)]
+        self.create_hardlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        #[cfg(not(unix))]
+        self.create_hardlinks(&setup.dest_dir, writer)?;
+
+        // upstream: receiver.c:584-585 - handle_delayed_updates() at phase 2
+        if !all_delayed_updates.is_empty() {
+            let backup_cfg = if self.config.flags.backup {
+                Some(crate::disk_commit::BackupConfig {
+                    dest_dir: setup.dest_dir.clone(),
+                    backup_dir: self.config.backup_dir.as_ref().map(PathBuf::from),
+                    suffix: self.config.effective_backup_suffix().into(),
+                })
+            } else {
+                None
+            };
+            super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
+        }
+
+        // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
+        // directory mtimes after file writes clobber them.
+        self.touch_up_dirs(&setup.dest_dir);
+
+        self.finalize_transfer_async(reader, writer).await?;
+
+        let total_source_bytes: u64 = self.file_list.iter().map(|e| e.size()).sum();
+
+        stats.files_transferred = files_transferred;
+        stats.bytes_received = bytes_received;
+        stats.literal_data = literal_data;
+        stats.matched_data = matched_data;
+        stats.total_source_bytes = total_source_bytes;
+        if !metadata_errors.is_empty() {
+            stats.io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
+        }
+        stats.metadata_errors = metadata_errors;
+        stats.delete_stats = delete_stats;
+        stats.delete_limit_exceeded = delete_limit_exceeded;
+        stats.redo_count = redo_count;
+
+        Ok(stats)
+    }
+}
+
+#[cfg(all(test, feature = "tokio-transfer"))]
+mod async_pipelined_driver_parity_tests {
+    //! Whole-driver sync-vs-async parity for the *pipelined* receiver.
+    //!
+    //! Records one server->receiver wire (protocol 32, server mode): the file
+    //! list, then a per-file echo/delta stream for each transferred regular file
+    //! (enough files to fill the pipeline window so the loop actually pipelines),
+    //! then the finalization phase-done + goodbye handshake, all wrapped in
+    //! MSG_DATA multiplex frames. The identical recorded wire is fed to both
+    //! [`ReceiverContext::run_pipelined`] (sync, into one temp dest) and
+    //! [`ReceiverContext::run_pipelined_async`] (into another, via a
+    //! one-byte-per-poll [`ChunkedReader`] to prove poll-correctness), and the two
+    //! committed destination trees, the returned [`TransferStats`], and the
+    //! Ok/Err outcome are asserted identical.
+    //!
+    //! Coverage: a directory entry (created by `create_directories`) plus four
+    //! regular files - two fresh (whole-file literal delta, no basis) and two with
+    //! pre-existing destination bases (so the driver computes and sends a real
+    //! signature) reconstructed from literal deltas whose bytes equal the basis.
+    //! Four files force the pipeline window to hold multiple outstanding requests
+    //! at once, so the async loop is exercised in its genuinely pipelined regime
+    //! (not a single-file degenerate case). The finalize leg exercises
+    //! `finalize_transfer_async`; the SPSC->disk-thread hand-off is exercised
+    //! end to end for every file.
+
+    use std::ffi::OsString;
+    use std::io::{Cursor, Read, Write};
+    use std::path::{Path, PathBuf};
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use protocol::ChecksumAlgorithm;
+    use protocol::codec::{MonotonicNdxWriter, NdxCodec, create_ndx_codec};
+    use protocol::flist::{FileEntry, FileListWriter};
+    use protocol::{MessageCode, ProtocolVersion, send_msg};
+    use tempfile::tempdir;
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    use crate::config::ServerConfig;
+    use crate::delta_apply::ChecksumVerifier;
+    use crate::handshake::HandshakeResult;
+    use crate::pipeline::PipelineConfig;
+    use crate::reader::{AsyncServerReader, ServerReader};
+    use crate::receiver::ReceiverContext;
+    use crate::receiver::stats::TransferStats;
+    use crate::receiver::wire::{SenderAttrs, SumHead};
+    use crate::role::ServerRole;
+
+    const PROTOCOL: u8 = 32;
+    const ALGO: ChecksumAlgorithm = ChecksumAlgorithm::MD5;
+    const SEED: i32 = 0;
+
+    /// Delivers at most `chunk` bytes per `poll_read`, forcing async wire reads
+    /// to cross `.await` boundaries mid-token when `chunk == 1`.
+    struct ChunkedReader {
+        data: Vec<u8>,
+        pos: usize,
+        chunk: usize,
+    }
+
+    impl ChunkedReader {
+        fn new(data: Vec<u8>, chunk: usize) -> Self {
+            Self {
+                data,
+                pos: 0,
+                chunk: chunk.max(1),
+            }
+        }
+    }
+
+    impl AsyncRead for ChunkedReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            let remaining = self.data.len() - self.pos;
+            if remaining == 0 {
+                return Poll::Ready(Ok(()));
+            }
+            let take = remaining.min(self.chunk).min(buf.remaining());
+            let start = self.pos;
+            let end = start + take;
+            buf.put_slice(&self.data[start..end]);
+            self.pos = end;
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    /// A capturing writer with a no-op `MsgInfoSender` so the receiver's
+    /// request-half bytes are absorbed (the sender side is pre-recorded).
+    struct CaptureWriter(Vec<u8>);
+    impl Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl crate::writer::MsgInfoSender for CaptureWriter {
+        fn send_msg_info(&mut self, _data: &[u8]) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn handshake() -> HandshakeResult {
+        HandshakeResult {
+            protocol: ProtocolVersion::try_from(PROTOCOL).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        }
+    }
+
+    /// Server-mode protocol-32 receiver rooted at `dest`. `--delete` is off, so
+    /// setup reads no wire filter list and finalize emits no `NDX_DEL_STATS`;
+    /// server mode (not client) means finalize reads no sender stats.
+    fn config(dest: &Path) -> ServerConfig {
+        ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(PROTOCOL).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(dest)],
+            ..Default::default()
+        }
+    }
+
+    /// The flist entries: one directory and four regular files under it. Sizes
+    /// match the literal content each file is reconstructed from.
+    fn flist_entries(contents: &[Vec<u8>]) -> Vec<FileEntry> {
+        let mut dir = FileEntry::new_directory(PathBuf::from("d"), 0o40755);
+        dir.set_mtime(1_700_000_000, 0);
+        let mut entries = vec![dir];
+        for (i, c) in contents.iter().enumerate() {
+            let mut e =
+                FileEntry::new_file(PathBuf::from(format!("d/f{i}")), c.len() as u64, 0o100644);
+            e.set_mtime(1_700_000_000, 0);
+            entries.push(e);
+        }
+        entries
+    }
+
+    fn encode_flist(entries: &[FileEntry]) -> Vec<u8> {
+        let protocol = ProtocolVersion::try_from(PROTOCOL).unwrap();
+        let mut wire = Vec::new();
+        let mut writer = FileListWriter::new(protocol);
+        for e in entries {
+            writer.write_entry(&mut wire, e).unwrap();
+        }
+        writer.write_end(&mut wire, None).unwrap();
+        wire
+    }
+
+    /// Encodes a literal-only whole-file delta: each literal as a positive i32-LE
+    /// length prefix + bytes, a zero-length terminator, then the trailing
+    /// whole-file checksum. Mirrors the sender's `token.c` literal emission.
+    fn encode_literal_wire(content: &[u8]) -> Vec<u8> {
+        let mut wire = Vec::new();
+        let len = i32::try_from(content.len()).unwrap();
+        wire.extend_from_slice(&len.to_le_bytes());
+        wire.extend_from_slice(content);
+        wire.extend_from_slice(&0_i32.to_le_bytes());
+        let mut verifier = ChecksumVerifier::for_algorithm_seeded(ALGO, SEED);
+        verifier.update(content);
+        let mut digest = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+        let n = verifier.finalize_into(&mut digest);
+        wire.extend_from_slice(&digest[..n]);
+        wire
+    }
+
+    /// Runs `setup_transfer` on a throwaway receiver to learn the exact
+    /// post-sanitize file-list order and the wire NDX each regular file will be
+    /// requested with, so the recorded echo stream matches what the driver sends.
+    fn probe_ndx(dest: &Path, flist_wire: &[u8]) -> Vec<(usize, i32)> {
+        let mut ctx = ReceiverContext::new_for_test(&handshake(), config(dest));
+        let reader = ServerReader::new_plain(Cursor::new(muxed(flist_wire)));
+        let mut sink = std::io::sink();
+        let (_r, _count, _setup) = ctx.setup_transfer(reader, &mut sink).unwrap();
+        ctx.file_list()
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e.is_file())
+            .map(|(idx, _)| (idx, ctx.flat_to_wire_ndx(idx)))
+            .collect()
+    }
+
+    /// Wraps `inner` in a single MSG_DATA multiplex frame.
+    fn muxed(inner: &[u8]) -> Vec<u8> {
+        let mut wire = Vec::new();
+        send_msg(&mut wire, MessageCode::Data, inner).unwrap();
+        wire
+    }
+
+    /// Builds the demuxed per-file + finalize payload (everything after the
+    /// flist): for each requested file (in driver order) the echoed NDX +
+    /// `ITEM_TRANSFER` iflags + an empty echoed sum-head + the literal delta,
+    /// then the finalize handshake (3 phase NDX_DONE + 1 goodbye-echo NDX_DONE).
+    fn build_data_wire(requests: &[(i32, Vec<u8>)]) -> Vec<u8> {
+        let mut data = Vec::new();
+
+        // Per-file echoes share one monotonic NDX writer across files, matching
+        // the receiver's single per-loop `ndx_read_codec`.
+        let mut echo_ndx = MonotonicNdxWriter::new(PROTOCOL);
+        for (ndx, delta) in requests {
+            echo_ndx.write_ndx(&mut data, *ndx).unwrap();
+            data.extend_from_slice(&SenderAttrs::ITEM_TRANSFER.to_le_bytes());
+            SumHead::empty().write(&mut data).unwrap();
+            data.extend_from_slice(delta);
+        }
+
+        // Finalize reads 4 NDX_DONE via a fresh codec (finalize_transfer builds
+        // its own): 3 for the phase exchange (non-inc-recurse proto 32) + 1 for
+        // the extended-goodbye echo.
+        let mut fin = create_ndx_codec(PROTOCOL);
+        for _ in 0..4 {
+            fin.write_ndx_done(&mut data).unwrap();
+        }
+        data
+    }
+
+    /// Reads a destination tree into a sorted `(relative_path, bytes)` vector for
+    /// byte-exact comparison across the two drivers.
+    fn read_tree(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+        fn walk(dir: &Path, root: &Path, out: &mut Vec<(PathBuf, Vec<u8>)>) {
+            let mut entries: Vec<_> = std::fs::read_dir(dir)
+                .unwrap()
+                .map(|e| e.unwrap())
+                .collect();
+            entries.sort_by_key(std::fs::DirEntry::path);
+            for entry in entries {
+                let path = entry.path();
+                let ty = entry.file_type().unwrap();
+                let rel = path.strip_prefix(root).unwrap().to_path_buf();
+                if ty.is_dir() {
+                    out.push((rel, Vec::new()));
+                    walk(&path, root, out);
+                } else {
+                    let mut bytes = Vec::new();
+                    std::fs::File::open(&path)
+                        .unwrap()
+                        .read_to_end(&mut bytes)
+                        .unwrap();
+                    out.push((rel, bytes));
+                }
+            }
+        }
+        let mut out = Vec::new();
+        walk(root, root, &mut out);
+        out
+    }
+
+    /// Pre-creates destination bases for the "unchanged file" legs so the driver
+    /// finds them, computes a real signature, and takes the basis branch.
+    fn seed_basis(dest: &Path, files: &[(usize, &[u8])]) {
+        std::fs::create_dir_all(dest.join("d")).unwrap();
+        for (i, content) in files {
+            std::fs::write(dest.join(format!("d/f{i}")), content).unwrap();
+        }
+    }
+
+    fn assert_stats_eq(a: &TransferStats, b: &TransferStats) {
+        assert_eq!(a.files_listed, b.files_listed, "files_listed");
+        assert_eq!(
+            a.files_transferred, b.files_transferred,
+            "files_transferred"
+        );
+        assert_eq!(a.bytes_received, b.bytes_received, "bytes_received");
+        assert_eq!(
+            a.total_source_bytes, b.total_source_bytes,
+            "total_source_bytes"
+        );
+        assert_eq!(a.literal_data, b.literal_data, "literal_data");
+        assert_eq!(a.matched_data, b.matched_data, "matched_data");
+        assert_eq!(a.io_error, b.io_error, "io_error");
+        assert_eq!(a.error_count, b.error_count, "error_count");
+        assert_eq!(a.redo_count, b.redo_count, "redo_count");
+        assert_eq!(a.entries_received, b.entries_received, "entries_received");
+        assert_eq!(
+            a.delete_stats.total(),
+            b.delete_stats.total(),
+            "delete_stats"
+        );
+        assert_eq!(a.metadata_errors, b.metadata_errors, "metadata_errors");
+    }
+
+    /// The pipelined async driver commits a byte-identical destination tree and
+    /// returns identical `TransferStats` to the sync pipelined driver over the
+    /// same recorded wire, with multiple files in flight (genuine pipelining) and
+    /// the wire delivered one byte per poll.
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_pipelined_driver_matches_sync_output() {
+        // Four regular files: f0/f1 fresh (no basis), f2/f3 unchanged (basis).
+        let contents: Vec<Vec<u8>> = vec![
+            {
+                let mut v = b"fresh f0 ".to_vec();
+                v.extend(std::iter::repeat_n(0x11u8, 250));
+                v.extend_from_slice(b" end f0");
+                v
+            },
+            {
+                let mut v = b"fresh f1 ".to_vec();
+                v.extend(std::iter::repeat_n(0x22u8, 300));
+                v.extend_from_slice(b" end f1");
+                v
+            },
+            b"unchanged f2 basis contents".to_vec(),
+            b"unchanged f3 basis contents - a bit longer than f2".to_vec(),
+        ];
+
+        let entries = flist_entries(&contents);
+        let flist_wire = encode_flist(&entries);
+
+        // Probe the NDX request order on a throwaway receiver (same config shape).
+        let probe_dir = tempdir().unwrap();
+        let ndx_map = probe_ndx(probe_dir.path(), &flist_wire);
+        assert_eq!(ndx_map.len(), 4, "expected four regular-file requests");
+
+        // Map each requested file index to its literal delta. Flist index i+1 maps
+        // to contents[i] (index 0 is the directory `d`).
+        let requests: Vec<(i32, Vec<u8>)> = ndx_map
+            .iter()
+            .map(|&(idx, ndx)| {
+                let content = &contents[idx - 1];
+                (ndx, encode_literal_wire(content))
+            })
+            .collect();
+
+        // Two multiplex frames: the flist, then the per-file + finalize data.
+        let data_wire = build_data_wire(&requests);
+        let mut wire = muxed(&flist_wire);
+        wire.extend_from_slice(&muxed(&data_wire));
+
+        // The basis files to pre-seed on both dests: f2 and f3.
+        let basis: Vec<(usize, &[u8])> =
+            vec![(2usize, &contents[2][..]), (3usize, &contents[3][..])];
+
+        // --- sync pipelined driver ---
+        let sync_dest = tempdir().unwrap();
+        seed_basis(sync_dest.path(), &basis);
+        let sync_stats = {
+            let mut ctx = ReceiverContext::new_for_test(&handshake(), config(sync_dest.path()));
+            let reader = ServerReader::new_plain(Cursor::new(wire.clone()));
+            let mut writer = CaptureWriter(Vec::new());
+            ctx.run_pipelined(reader, &mut writer, PipelineConfig::default())
+                .expect("sync pipelined driver must succeed")
+        };
+        let sync_tree = read_tree(sync_dest.path());
+
+        // --- async pipelined driver, one byte per poll ---
+        let async_dest = tempdir().unwrap();
+        seed_basis(async_dest.path(), &basis);
+        let async_stats = {
+            let mut ctx = ReceiverContext::new_for_test(&handshake(), config(async_dest.path()));
+            let reader = AsyncServerReader::new_plain(ChunkedReader::new(wire.clone(), 1));
+            let mut writer = CaptureWriter(Vec::new());
+            ctx.run_pipelined_async(reader, &mut writer, PipelineConfig::default())
+                .await
+                .expect("async pipelined driver must succeed")
+        };
+        let async_tree = read_tree(async_dest.path());
+
+        // (a) byte-identical destination trees
+        assert_eq!(
+            async_tree, sync_tree,
+            "async pipelined driver committed a different destination tree than sync"
+        );
+        // Sanity: every file landed with the expected content.
+        for (i, content) in contents.iter().enumerate() {
+            assert_eq!(
+                &std::fs::read(sync_dest.path().join(format!("d/f{i}"))).unwrap(),
+                content,
+                "sync f{i} content mismatch"
+            );
+        }
+
+        // (b) identical TransferStats
+        assert_stats_eq(&async_stats, &sync_stats);
+        assert_eq!(async_stats.files_transferred, 4);
+        let total_literal: u64 = contents.iter().map(|c| c.len() as u64).sum();
+        assert_eq!(async_stats.bytes_received, total_literal);
+    }
+}

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
@@ -1,0 +1,294 @@
+//! Async (tokio-transfer) twin of the incremental pipelined receiver driver.
+//!
+//! [`ReceiverContext::run_pipelined_incremental_async`] is the `.await` twin of
+//! [`run_pipelined_incremental`](super::pipelined_incremental). Like that driver
+//! it interleaves directory creation with the file-list walk, tracks
+//! per-directory failures, and emits per-directory itemize output; but it drives
+//! the three wire-facing legs (setup, per-file pipeline, finalize) through their
+//! async leaves, exactly as [`run_pipelined_async`](ReceiverContext::run_pipelined_async)
+//! does. The incremental directory pass, delete pass, candidate build, hardlink
+//! creation, delayed-updates, and `touch_up_dirs` are the identical synchronous
+//! helpers, and `TransferStats` are accumulated field-for-field the same way.
+//! The SPSC->disk-commit-thread hand-off is unchanged from the sync path.
+//!
+//! Gated on `tokio-transfer` (default off); additive and not wired into
+//! [`run`](ReceiverContext::run) yet.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:1432` - itemize new directory
+//! - `generator.c:2260` - itemize existing directory (metadata only)
+
+use std::io;
+use std::path::PathBuf;
+
+use logging::{PhaseTimer, debug_log};
+use protocol::flist::FileEntry;
+use protocol::stats::DeleteStats;
+
+use crate::pipeline::PipelineConfig;
+use crate::receiver::stats::TransferStats;
+use crate::receiver::{REDO_CHECKSUM_LENGTH, ReceiverContext};
+
+impl ReceiverContext {
+    /// Async twin of [`run_pipelined_incremental`](Self::run_pipelined_incremental).
+    ///
+    /// Runs the incremental pipelined receiver with `.await` on the wire-read
+    /// legs; every non-IO step runs through the identical synchronous helpers the
+    /// sync driver calls, so it produces the same committed tree and
+    /// `TransferStats`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1432` - itemize new directory
+    /// - `generator.c:2260` - itemize existing directory (metadata only)
+    #[cfg(feature = "tokio-transfer")]
+    #[allow(dead_code)]
+    pub(in crate::receiver) async fn run_pipelined_incremental_async<R, W>(
+        &mut self,
+        reader: crate::reader::AsyncServerReader<R>,
+        writer: &mut W,
+        pipeline_config: PipelineConfig,
+        mut progress: Option<&mut dyn crate::TransferProgressCallback>,
+    ) -> io::Result<TransferStats>
+    where
+        R: tokio::io::AsyncRead + Unpin + Send + 'static,
+        W: io::Write + crate::writer::MsgInfoSender + ?Sized,
+    {
+        let _t = PhaseTimer::new("receiver-transfer-incremental-async");
+        let (reader, file_count, mut setup, carry) =
+            self.setup_transfer_async(reader, writer).await?;
+
+        // Prepend the file-list look-ahead carry ahead of the reader so the
+        // per-file legs consume them first. Identical to `run_sync_async`.
+        let mut reader = tokio::io::AsyncReadExt::chain(std::io::Cursor::new(carry), reader);
+        let reader = &mut reader;
+
+        let mut stats = TransferStats {
+            files_listed: file_count,
+            entries_received: file_count as u64,
+            io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
+                | self.flist_io_error,
+            ..Default::default()
+        };
+        // upstream: receiver.c:653-654 DEBUG_GTE(RECV, 1)
+        debug_log!(Recv, 1, "recv_files({}) starting", file_count);
+
+        let mut failed_dirs = crate::receiver::directory::FailedDirectories::new();
+        let mut metadata_errors: Vec<(PathBuf, String)> = Vec::new();
+
+        // upstream: generator.c:1317-1326 - make_path() for relative_paths
+        self.ensure_relative_parents(&setup.dest_dir);
+
+        for file_entry in &self.file_list {
+            if file_entry.is_dir() {
+                let result = self.create_directory_incremental(
+                    &setup.dest_dir,
+                    file_entry,
+                    &setup.metadata_opts,
+                    &mut failed_dirs,
+                    setup.acl_cache.as_deref(),
+                    setup.acl_id_map.as_deref(),
+                    #[cfg(unix)]
+                    setup.sandbox.as_deref(),
+                )?;
+                match result {
+                    Some(true) => {
+                        stats.directories_created += 1;
+                        // upstream: generator.c:1432 - itemize new directory
+                        let iflags = crate::generator::ItemFlags::from_raw(
+                            crate::generator::ItemFlags::ITEM_LOCAL_CHANGE
+                                | crate::generator::ItemFlags::ITEM_IS_NEW,
+                        );
+                        let _ = self.emit_itemize(writer, &iflags, file_entry);
+                    }
+                    Some(false) => {
+                        // upstream: generator.c:2260 - existing dir, metadata only
+                        let iflags = crate::generator::ItemFlags::from_raw(0);
+                        let _ = self.emit_itemize(writer, &iflags, file_entry);
+                    }
+                    None => {
+                        stats.directories_failed += 1;
+                    }
+                }
+            }
+        }
+
+        #[cfg(unix)]
+        self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        #[cfg(not(unix))]
+        self.create_symlinks(&setup.dest_dir, writer)?;
+
+        // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
+        // deletes the destination path and skips any creation for the sentinel.
+        self.process_missing_args_sentinels(
+            &setup.dest_dir,
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
+        )?;
+
+        // Mirror `run_pipelined`: when `--delete` is in effect, sweep the
+        // destination for extraneous entries and capture per-type counters.
+        // upstream: generator.c:do_delete_pass()
+        let mut delete_stats = DeleteStats::new();
+        let mut delete_limit_exceeded = false;
+        if self.config.flags.delete {
+            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
+                &setup.dest_dir,
+                #[cfg(unix)]
+                setup.sandbox.as_ref(),
+                writer,
+            )?;
+            delete_stats = ds;
+            delete_limit_exceeded = exceeded;
+            stats.io_error |= io_bits;
+            // Carry the counters into the receiver context so the goodbye
+            // handshake can emit NDX_DEL_STATS to the peer sender.
+            // upstream: generator.c:2393-2398 - early write_del_stats() emission.
+            self.pending_del_stats = delete_stats;
+        }
+
+        let files_to_transfer = self.build_files_to_transfer(
+            writer,
+            &setup.dest_dir,
+            &setup.metadata_opts,
+            Some(&failed_dirs),
+            &mut metadata_errors,
+            &mut stats,
+            setup.acl_cache.as_deref(),
+            setup.acl_id_map.as_deref(),
+        );
+
+        let mut files_transferred: usize = 0;
+        let mut bytes_received: u64 = 0;
+        let mut literal_data: u64 = 0;
+        let mut matched_data: u64 = 0;
+        let mut redo_count: usize = 0;
+        let mut all_delayed_updates: Vec<(PathBuf, PathBuf)> = Vec::new();
+
+        // upstream: generator.c:1249 - list-only renders every flist entry via
+        // list_file_entry() and sends NO per-file NDX request. This branch must
+        // precede the dry_run check: list-only is not dry-run.
+        if self.config.flags.list_only {
+            stats.list_only_entries = self.collect_list_only_entries();
+            writer.flush()?;
+        } else if self.config.flags.dry_run {
+            self.run_dry_run_loop_async(reader, writer, &files_to_transfer)
+                .await?;
+        } else {
+            let total_files = files_to_transfer.len();
+            let redo_config = pipeline_config.clone();
+            let redo_indices;
+            let delayed;
+            (
+                files_transferred,
+                bytes_received,
+                literal_data,
+                matched_data,
+                redo_indices,
+                delayed,
+            ) = self
+                .run_pipeline_loop_decoupled_async(
+                    reader,
+                    writer,
+                    pipeline_config,
+                    &setup,
+                    files_to_transfer,
+                    &mut metadata_errors,
+                    false,
+                    total_files,
+                    &mut progress,
+                )
+                .await?;
+            all_delayed_updates.extend(delayed);
+
+            // Phase 2: redo pass for files that failed checksum verification.
+            redo_count = redo_indices.len();
+            if !redo_indices.is_empty() {
+                setup.checksum_length = REDO_CHECKSUM_LENGTH;
+
+                // upstream: generator.c:1926 - the phase-2 redo re-itemizes with
+                // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
+                let redo_files: Vec<(usize, &FileEntry, PathBuf, u32)> = redo_indices
+                    .iter()
+                    .filter_map(|&idx| {
+                        self.file_list.get(idx).map(|entry| {
+                            let p = entry.path();
+                            let file_path = if p.as_os_str() == "." {
+                                setup.dest_dir.clone()
+                            } else {
+                                setup.dest_dir.join(p)
+                            };
+                            (
+                                idx,
+                                entry,
+                                file_path,
+                                crate::generator::ItemFlags::ITEM_TRANSFER,
+                            )
+                        })
+                    })
+                    .collect();
+
+                let (redo_transferred, redo_bytes, redo_literal, redo_matched, _, redo_delayed) =
+                    self.run_pipeline_loop_decoupled_async(
+                        reader,
+                        writer,
+                        redo_config,
+                        &setup,
+                        redo_files,
+                        &mut metadata_errors,
+                        true,
+                        total_files,
+                        &mut progress,
+                    )
+                    .await?;
+
+                files_transferred += redo_transferred;
+                bytes_received += redo_bytes;
+                literal_data += redo_literal;
+                matched_data += redo_matched;
+                all_delayed_updates.extend(redo_delayed);
+            }
+        }
+
+        #[cfg(unix)]
+        self.create_hardlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        #[cfg(not(unix))]
+        self.create_hardlinks(&setup.dest_dir, writer)?;
+
+        // upstream: receiver.c:584-585 - handle_delayed_updates() at phase 2
+        if !all_delayed_updates.is_empty() {
+            let backup_cfg = if self.config.flags.backup {
+                Some(crate::disk_commit::BackupConfig {
+                    dest_dir: setup.dest_dir.clone(),
+                    backup_dir: self.config.backup_dir.as_ref().map(PathBuf::from),
+                    suffix: self.config.effective_backup_suffix().into(),
+                })
+            } else {
+                None
+            };
+            super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
+        }
+
+        // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
+        // directory mtimes after file writes clobber them.
+        self.touch_up_dirs(&setup.dest_dir);
+
+        stats.files_transferred = files_transferred;
+        stats.bytes_received = bytes_received;
+        stats.literal_data = literal_data;
+        stats.matched_data = matched_data;
+        stats.total_source_bytes = self.file_list.iter().map(|e| e.size()).sum();
+        if !metadata_errors.is_empty() || stats.directories_failed > 0 || stats.files_skipped > 0 {
+            stats.io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
+        }
+        stats.metadata_errors = metadata_errors;
+        stats.delete_stats = delete_stats;
+        stats.delete_limit_exceeded = delete_limit_exceeded;
+        stats.redo_count = redo_count;
+
+        self.finalize_transfer_async(reader, writer).await?;
+
+        Ok(stats)
+    }
+}

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -39,6 +39,8 @@
 mod request;
 mod response;
 mod streaming;
+#[cfg(feature = "tokio-transfer")]
+mod streaming_async;
 mod token_loop;
 
 use std::io::{self, Read};
@@ -53,6 +55,8 @@ use crate::receiver::{SenderAttrs, SumHead};
 pub use self::request::{send_file_request, send_file_request_xattr};
 pub use self::response::process_file_response;
 pub use self::streaming::{StreamingResult, process_file_response_streaming};
+#[cfg(feature = "tokio-transfer")]
+pub use self::streaming_async::process_file_response_streaming_async;
 pub use crate::token_reader::TokenReader;
 
 /// Configuration for sending file transfer requests and processing responses.
@@ -249,6 +253,76 @@ fn read_response_header<R: Read>(
 
     // The echoed sum_head carries the existing file length used for the append mode offset.
     let echoed_sum_head = SumHead::read(reader)?;
+
+    let (file_path, basis_path, signature, target_size) = pending.into_parts();
+
+    // upstream: receiver.c:797 - one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR
+    // upstream: receiver.c:855 - append mode implies inplace (write directly to destination,
+    // preserving existing content; sender only sends data beyond the existing length)
+    let use_inplace = ctx.config.inplace
+        || ctx.config.append
+        || (ctx.config.inplace_partial
+            && sender_attrs.fnamecmp_type == Some(protocol::FnameCmpType::PartialDir));
+
+    // upstream: receiver.c:287-307 - in append mode, seek output fd to existing file length
+    // (derived from echoed sum_head) before writing new data
+    let append_offset = if ctx.config.append {
+        echoed_sum_head.flength()
+    } else {
+        0
+    };
+
+    Ok(ResponseHeader {
+        file_path,
+        basis_path,
+        signature,
+        target_size,
+        use_inplace,
+        append_offset,
+        xattr_values: sender_attrs.xattr_values,
+    })
+}
+
+/// Async twin of [`read_response_header`].
+///
+/// Reads the echoed NDX + attrs ([`SenderAttrs::read_with_codec_xattr_async`])
+/// and echoed sum-head ([`SumHead::read_async`]) off an
+/// [`AsyncRead`](tokio::io::AsyncRead) transport, then applies the identical
+/// NDX-match validation and inplace/append-offset derivation the sync leaf runs.
+/// For the same wire bytes it yields the same [`ResponseHeader`] and consumes the
+/// same bytes as the sync path. Gated on `tokio-transfer`.
+#[cfg(feature = "tokio-transfer")]
+async fn read_response_header_async<R>(
+    reader: &mut R,
+    ndx_codec: &mut protocol::codec::NdxCodecEnum,
+    pending: crate::pipeline::PendingTransfer,
+    ctx: &ResponseContext<'_>,
+) -> io::Result<ResponseHeader>
+where
+    R: tokio::io::AsyncRead + Unpin + ?Sized,
+{
+    let expected_ndx = pending.ndx();
+
+    let (echoed_ndx, sender_attrs) = SenderAttrs::read_with_codec_xattr_async(
+        reader,
+        ndx_codec,
+        ctx.config.preserve_xattrs,
+        ctx.config.want_xattr_optim,
+    )
+    .await?;
+
+    // upstream: sender.c emits responses in NDX order; out-of-order is a protocol violation.
+    if echoed_ndx != expected_ndx {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "sender echoed NDX {echoed_ndx} but expected {expected_ndx} - protocol violation"
+            ),
+        ));
+    }
+
+    // The echoed sum_head carries the existing file length used for the append mode offset.
+    let echoed_sum_head = SumHead::read_async(reader).await?;
 
     let (file_path, basis_path, signature, target_size) = pending.into_parts();
 

--- a/crates/transfer/src/transfer_ops/streaming_async.rs
+++ b/crates/transfer/src/transfer_ops/streaming_async.rs
@@ -1,0 +1,385 @@
+//! Async (tokio-transfer) twin of the streaming file-response processor.
+//!
+//! [`process_file_response_streaming_async`] is the `.await` twin of the
+//! network-read side of [`process_file_response_streaming`](super::process_file_response_streaming).
+//! It reads the sender's echoed header, delta tokens, literal bytes, and trailing
+//! whole-file checksum off an [`AsyncRead`](tokio::io::AsyncRead) transport, and
+//! streams the reconstructed chunks to the **same** synchronous SPSC channel the
+//! sync path uses (`file_tx` / `buf_return_rx`). The background disk-commit thread
+//! that drains those channels stays a dedicated `std::thread`: it is a legitimate
+//! permanent boundary (it never cooperates with the async runtime, so there is no
+//! runtime-cooperation deadlock), so only the wire reads become `.await`.
+//!
+//! Every non-IO step - the single-chunk coalescing decision, the `see_token`
+//! dictionary feed, the basis-block copy via [`MapFile`], the buffer recycling,
+//! and the `FileMessage` hand-off - runs through the identical synchronous logic
+//! the sync path uses. For the same wire bytes it therefore produces the same
+//! sequence of `FileMessage`s and the same [`StreamingResult`] as the sync leaf,
+//! independent of how the bytes are chunked across `.await` points.
+//!
+//! # Upstream Reference
+//!
+//! - `receiver.c:recv_files()` reads deltas (the sync twin mirrors this)
+//! - `receiver.c:receive_data()` applies delta tokens
+//! - `token.c:284` - `simple_recv_token()` single-buffer literal pattern
+
+use std::io;
+
+use protocol::codec::NdxCodecEnum;
+use tokio::io::AsyncReadExt;
+
+use crate::delta_apply::ChecksumVerifier;
+use crate::map_file::MapFile;
+use crate::pipeline::PendingTransfer;
+use crate::pipeline::messages::{BeginMessage, FileMessage};
+use crate::pipeline::spsc;
+use crate::token_reader::{DeltaToken, LiteralData, TokenReader};
+
+use super::streaming::StreamingResult;
+use super::token_loop::recycle_or_alloc;
+use super::{ResponseContext, read_response_header_async};
+
+/// Async twin of [`literal_to_buf`](super::token_loop::literal_to_buf).
+///
+/// For `Ready` data (compressed mode) wraps the decompressed bytes directly.
+/// For `Pending` data (plain mode) reads exactly `len` bytes off the async
+/// transport into a recycled buffer. Unlike the sync leaf there is no
+/// zero-copy `try_borrow_exact` fast path (the async transport is a plain
+/// [`AsyncRead`], not a buffered `ServerReader`), but the produced bytes are
+/// identical.
+async fn literal_to_buf_async<R>(
+    literal: LiteralData,
+    reader: &mut R,
+    buf_return_rx: &spsc::Receiver<Vec<u8>>,
+) -> io::Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin + ?Sized,
+{
+    match literal {
+        LiteralData::Ready(data) => Ok(data),
+        LiteralData::Pending(len) => {
+            let mut buf = recycle_or_alloc(buf_return_rx, len);
+            let start = buf.len();
+            buf.resize(start + len, 0);
+            reader.read_exact(&mut buf[start..]).await?;
+            Ok(buf)
+        }
+    }
+}
+
+/// Async twin of [`process_file_response_streaming`](super::process_file_response_streaming).
+///
+/// Reads the echoed header, delta tokens, and trailing checksum off `reader`
+/// via `.await` and streams the reconstructed chunks to the synchronous disk
+/// thread through `file_tx`. Deferred-checksum verification, single-chunk
+/// coalescing, buffer recycling, and the basis-block copy all match the sync
+/// leaf exactly.
+///
+/// # Arguments
+///
+/// See [`process_file_response_streaming`](super::process_file_response_streaming);
+/// the only difference is `reader` is an [`AsyncRead`](tokio::io::AsyncRead)
+/// transport and `ndx_codec` is a concrete [`NdxCodecEnum`] (the type the async
+/// NDX reader needs).
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:recv_files()` reads deltas
+#[allow(clippy::too_many_arguments)]
+pub async fn process_file_response_streaming_async<R>(
+    reader: &mut R,
+    ndx_codec: &mut NdxCodecEnum,
+    pending: PendingTransfer,
+    ctx: &ResponseContext<'_>,
+    checksum_verifier: &mut ChecksumVerifier,
+    file_tx: &spsc::Sender<FileMessage>,
+    buf_return_rx: &spsc::Receiver<Vec<u8>>,
+    file_entry_index: usize,
+    is_device_target: bool,
+    xattr_list: Option<protocol::xattr::XattrList>,
+    token_reader: &mut TokenReader,
+) -> io::Result<StreamingResult>
+where
+    R: tokio::io::AsyncRead + Unpin + ?Sized,
+{
+    let header = read_response_header_async(reader, ndx_codec, pending, ctx).await?;
+
+    // upstream: xattrs.c:744-755 - apply abbreviated values from sender to xattr list
+    let xattr_list = if !header.xattr_values.is_empty() {
+        let mut list = xattr_list.unwrap_or_default();
+        crate::receiver::apply_xattr_abbreviation_values(&mut list, &header.xattr_values);
+        Some(list)
+    } else {
+        xattr_list
+    };
+
+    // Move the checksum verifier to the disk thread so hashing overlaps with
+    // I/O and the network task can focus solely on reading the wire.
+    let algo = checksum_verifier.algorithm();
+    // upstream: checksum.c:sum_init() prepends seed for legacy MD4 (proto < 30).
+    // The replacement verifier must also be seeded for the next file.
+    let disk_verifier = std::mem::replace(
+        checksum_verifier,
+        ChecksumVerifier::for_algorithm_seeded(algo, ctx.config.checksum_seed),
+    );
+
+    // Defer sending Begin - allows coalescing single-chunk files into a single
+    // WholeFile message (3 channel sends -> 1, reducing futex overhead).
+    let begin_msg = Box::new(BeginMessage {
+        file_path: header.file_path,
+        target_size: header.target_size,
+        file_entry_index,
+        checksum_verifier: Some(disk_verifier),
+        is_device_target,
+        // upstream: receiver.c:797 - one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR
+        is_inplace: header.use_inplace,
+        append_offset: header.append_offset,
+        xattr_list,
+    });
+
+    let mut basis_map = if let Some(ref path) = header.basis_path {
+        Some(MapFile::open(path).map_err(|e| {
+            io::Error::new(e.kind(), format!("failed to open basis file {path:?}: {e}"))
+        })?)
+    } else {
+        None
+    };
+
+    let mut total_bytes: u64 = 0;
+
+    // upstream: token.c:807-810 - reset per-file token state. For zstd the
+    // decompression context is preserved (single continuous stream across all
+    // files); for zlib it reinitializes the inflate context (per-file streams).
+    token_reader.reset();
+
+    // Read the first token to determine if this is a single-chunk file.
+    let first_delta = token_reader.read_token_async(reader).await?;
+
+    // Try single-chunk coalescing: if the first token is a literal and the next
+    // token is end-of-file, send one WholeFile message instead of
+    // Begin + Chunk + Commit (3 sends -> 1).
+    match first_delta {
+        DeltaToken::Literal(literal_data) if basis_map.is_none() => {
+            let buf = literal_to_buf_async(literal_data, reader, buf_return_rx).await?;
+            let len = buf.len();
+
+            let next_delta = token_reader.read_token_async(reader).await?;
+
+            if matches!(next_delta, DeltaToken::End) {
+                total_bytes = len as u64;
+                let checksum_len = checksum_verifier.digest_len();
+                let mut expected_checksum = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+                reader
+                    .read_exact(&mut expected_checksum[..checksum_len])
+                    .await?;
+
+                file_tx
+                    .send(FileMessage::WholeFile {
+                        begin: begin_msg,
+                        data: buf,
+                    })
+                    .map_err(|_| {
+                        io::Error::new(io::ErrorKind::BrokenPipe, "disk commit thread disconnected")
+                    })?;
+
+                return Ok(StreamingResult {
+                    total_bytes,
+                    literal_bytes: total_bytes,
+                    matched_bytes: 0,
+                    expected_checksum,
+                    checksum_len,
+                });
+            }
+
+            // Not a single-chunk file - send Begin + first Chunk, then continue
+            // the regular loop starting with the peeked token.
+            file_tx.send(FileMessage::Begin(begin_msg)).map_err(|_| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "disk commit thread disconnected")
+            })?;
+            file_tx.send(FileMessage::Chunk(buf)).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "disk commit thread disconnected during chunk send",
+                )
+            })?;
+            total_bytes = len as u64;
+
+            process_remaining_tokens_async(
+                reader,
+                file_tx,
+                buf_return_rx,
+                checksum_verifier,
+                &header.signature,
+                &mut basis_map,
+                total_bytes,
+                Some(next_delta),
+                token_reader,
+                total_bytes, // initial literal bytes from first chunk
+            )
+            .await
+        }
+        first_delta => {
+            // First token was not a simple literal - send Begin and process normally.
+            file_tx.send(FileMessage::Begin(begin_msg)).map_err(|_| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "disk commit thread disconnected")
+            })?;
+
+            process_remaining_tokens_async(
+                reader,
+                file_tx,
+                buf_return_rx,
+                checksum_verifier,
+                &header.signature,
+                &mut basis_map,
+                total_bytes,
+                Some(first_delta),
+                token_reader,
+                0,
+            )
+            .await
+        }
+    }
+}
+
+/// Async twin of [`process_remaining_tokens`](super::token_loop::process_remaining_tokens).
+///
+/// Reads the remaining delta tokens off the async transport (`.await`) and
+/// forwards them as `FileMessage`s to the synchronous disk thread. The
+/// basis-block copy (via [`MapFile::map_ptr`]), the `see_token` dictionary feed,
+/// buffer recycling, and the abort-on-error hand-off are the identical
+/// synchronous logic the sync leaf runs.
+#[allow(clippy::too_many_arguments)]
+async fn process_remaining_tokens_async<R>(
+    reader: &mut R,
+    file_tx: &spsc::Sender<FileMessage>,
+    buf_return_rx: &spsc::Receiver<Vec<u8>>,
+    checksum_verifier: &mut ChecksumVerifier,
+    signature: &Option<engine::signature::FileSignature>,
+    basis_map: &mut Option<MapFile>,
+    mut total_bytes: u64,
+    pending_delta: Option<DeltaToken>,
+    token_reader: &mut TokenReader,
+    initial_literal_bytes: u64,
+) -> io::Result<StreamingResult>
+where
+    R: tokio::io::AsyncRead + Unpin + ?Sized,
+{
+    let send_abort = |tx: &spsc::Sender<FileMessage>, reason: String| {
+        let _ = tx.send(FileMessage::Abort { reason });
+    };
+
+    let mut literal_bytes: u64 = initial_literal_bytes;
+    let mut matched_bytes: u64 = 0;
+    let mut next_delta = pending_delta;
+
+    loop {
+        let delta = match next_delta.take() {
+            Some(d) => d,
+            None => match token_reader.read_token_async(reader).await {
+                Ok(d) => d,
+                Err(e) => {
+                    send_abort(file_tx, format!("network read error: {e}"));
+                    return Err(e);
+                }
+            },
+        };
+
+        match delta {
+            DeltaToken::End => {
+                let checksum_len = checksum_verifier.digest_len();
+                let mut expected_checksum = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+                if let Err(e) = reader
+                    .read_exact(&mut expected_checksum[..checksum_len])
+                    .await
+                {
+                    send_abort(file_tx, format!("failed to read checksum: {e}"));
+                    return Err(e);
+                }
+
+                file_tx.send(FileMessage::Commit).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "disk commit thread disconnected during commit",
+                    )
+                })?;
+
+                return Ok(StreamingResult {
+                    total_bytes,
+                    literal_bytes,
+                    matched_bytes,
+                    expected_checksum,
+                    checksum_len,
+                });
+            }
+            DeltaToken::Literal(literal_data) => {
+                let buf = match literal_to_buf_async(literal_data, reader, buf_return_rx).await {
+                    Ok(b) => b,
+                    Err(e) => {
+                        send_abort(file_tx, format!("network read error: {e}"));
+                        return Err(e);
+                    }
+                };
+                let len = buf.len() as u64;
+
+                file_tx.send(FileMessage::Chunk(buf)).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "disk commit thread disconnected during chunk send",
+                    )
+                })?;
+                total_bytes += len;
+                literal_bytes += len;
+            }
+            DeltaToken::BlockRef(block_idx) => {
+                if let (Some(sig), Some(basis_map)) = (signature, basis_map.as_mut()) {
+                    let layout = sig.layout();
+                    let block_count = layout.block_count() as usize;
+
+                    if block_idx >= block_count {
+                        let msg = format!(
+                            "block index {block_idx} out of bounds (file has {block_count} blocks)"
+                        );
+                        send_abort(file_tx, msg.clone());
+                        return Err(io::Error::new(io::ErrorKind::InvalidData, msg));
+                    }
+
+                    let block_len = layout.block_length().get() as u64;
+                    let offset = block_idx as u64 * block_len;
+
+                    let bytes_to_copy = if block_idx == block_count.saturating_sub(1) {
+                        let remainder = layout.remainder();
+                        if remainder > 0 {
+                            remainder as usize
+                        } else {
+                            block_len as usize
+                        }
+                    } else {
+                        block_len as usize
+                    };
+
+                    let block_data = basis_map.map_ptr(offset, bytes_to_copy)?;
+
+                    // upstream: token.c:631 - see_deflate_token() keeps the
+                    // decompressor dictionary in sync after block matches.
+                    token_reader.see_token(block_data)?;
+
+                    let mut buf = recycle_or_alloc(buf_return_rx, bytes_to_copy);
+                    buf.extend_from_slice(block_data);
+                    file_tx.send(FileMessage::Chunk(buf)).map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::BrokenPipe,
+                            "disk commit thread disconnected during block send",
+                        )
+                    })?;
+                    let copy_len = bytes_to_copy as u64;
+                    total_bytes += copy_len;
+                    matched_bytes += copy_len;
+                } else {
+                    let msg = format!("block reference {block_idx} without basis file");
+                    send_abort(file_tx, msg.clone());
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, msg));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Builds the async twins of the **pipelined** receiver drivers (the common/default receiver mode) behind the default-off `tokio-transfer` feature, so the pipelined path can run natively on tokio. Additive only: the default (threaded) build is unchanged, the sync pipelined path is untouched, and nothing is wired into `run()` yet (that routing is a later rung).

Follows the established pattern from the sequential async twin (`run_sync_async`): only the network-read side becomes `.await`; the request-half writes stay synchronous `Write`, and the SPSC channel feeding the dedicated background disk-commit `std::thread` is preserved exactly. The disk consumer stays a sync thread on purpose - it never cooperates with the async runtime, so there is no runtime-cooperation deadlock.

## What was added

Driver twins (gated on `tokio-transfer`):
- `run_pipelined_async` - `.await` twin of `run_pipelined`.
- `run_pipelined_incremental_async` - `.await` twin of `run_pipelined_incremental`.

Network-read async legs they drive:
- `run_pipeline_loop_decoupled_async` - the window-fill / signature-compute / send-request loop, with the per-file response read awaited. Signature computation (rayon), request writes, pipeline management, `PipelinedReceiver`/SPSC/disk thread, and stats accumulation are the identical synchronous logic.
- `run_dry_run_loop_async` - `.await` twin of the dry-run NDX/echo loop.
- `process_file_response_streaming_async` (+ `read_response_header_async`) - the core: reads the echoed header, delta tokens, literal bytes, and trailing whole-file checksum off the async transport and streams reconstructed chunks to the **same** sync `file_tx`/`buf_return_rx`. Single-chunk coalescing, `see_token` dictionary feed, basis-block copy, and buffer recycling all match the sync leaf.

The flist look-ahead carry from `setup_transfer_async` is consumed exactly as `run_sync_async` does (chained ahead of the per-file reader).

All async wire-read primitives already existed (`TokenReader::read_token_async`, `SenderAttrs::read_with_codec_xattr_async`, `SumHead::read_async`), so no new leaf was required.

## Parity test

`async_pipelined_driver_matches_sync_output` records one protocol-32 server->receiver wire (flist with a directory + 4 regular files, per-file echo/delta streams that fill the pipeline window, then the finalize phase-done + goodbye handshake) and feeds the identical wire to both `run_pipelined` (sync) and `run_pipelined_async` (via a one-byte-per-poll reader). It asserts byte-identical destination trees, identical `TransferStats`, and identical outcome. Four files (2 fresh, 2 with a pre-existing basis) ensure the loop actually pipelines rather than degenerating to a single file.

## Verification

- `cargo check -p transfer` (default) and `--features tokio-transfer`: clean.
- `cargo check --target x86_64-pc-windows-gnu -p transfer` (default) and `--features tokio-transfer`: clean.
- `cargo clippy -p transfer --all-targets --all-features -- -D warnings`: clean.
- `rustfmt --edition 2024 --check` on all touched files: clean.
- `cargo nextest run -p transfer --all-features -E 'test(async_pipelined_driver)'`: 1 passed. Related async driver/carry/file tests re-verified green.