### PR TITLE
feat(bench): gated async-receiver daemon path over real socket for benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,17 @@ tokio-transfer = [
     "daemon/tokio-transfer",
 ]
 
+# BENCHMARK-ONLY (default-off): forwards the gated async-receiver daemon path to
+# the workspace binary so it can be enabled from the root package. Reachable only
+# with this feature AND the OC_RSYNC_ASYNC_BENCH=1 runtime env; production/default
+# builds are unaffected. Not wire-fidelity-guaranteed under arbitrary backpressure.
+async-bench = [
+    "tokio-transfer",
+    "core/async-bench",
+    "transfer/async-bench",
+    "daemon/async-bench",
+]
+
 # systemd sd-notify integration for daemon
 sd-notify = ["daemon/sd-notify"]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -51,6 +51,19 @@ parallel = ["engine/lazy-metadata", "checksums/parallel"]
 # concurrency benchmark.
 async-daemon = ["daemon/async-daemon"]
 
+# EXPERIMENTAL (default-off): route the per-connection daemon transfer through
+# the tokio driver. Forwards to both `core` and `daemon` so the callee signature
+# (`run_server_with_handshake`, re-exported from `core`) and the daemon call-site
+# cfg gates stay in lockstep - selecting `-p cli --all-features` must not enable
+# `core/tokio-transfer` (which changes the signature) without also enabling
+# `daemon/tokio-transfer` (which selects the matching call site).
+tokio-transfer = ["async-daemon", "core/tokio-transfer", "daemon/tokio-transfer"]
+
+# BENCHMARK-ONLY (default-off): the gated async-receiver daemon path. Forwards to
+# both `core` and `daemon` for the same lockstep reason as `tokio-transfer`.
+# Also requires OC_RSYNC_ASYNC_BENCH=1 at runtime; production builds unaffected.
+async-bench = ["tokio-transfer", "core/async-bench", "daemon/async-bench"]
+
 
 [dependencies]
 bandwidth = { path = "../bandwidth" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -100,6 +100,12 @@ async = ["dep:tokio", "engine/async", "transfer/async"]
 # `core` signature. See docs/design/asy-2-tokio-runtime-feature.md section 5.
 tokio-transfer = ["async", "dep:tokio", "transfer/tokio-transfer"]
 
+# BENCHMARK-ONLY (default-off): forwards `transfer/async-bench` so the daemon
+# receiver can run the async driver over a real socket for benchmarking. Also
+# gated at runtime by `OC_RSYNC_ASYNC_BENCH=1`. NOT production-safe. Implies
+# `tokio-transfer`.
+async-bench = ["tokio-transfer", "transfer/async-bench"]
+
 
 # DEPRECATED (ISI.h): sender INC_RECURSE is now default-on. Marker
 # retained for one release until ISI.i.2 retires the feature flag.

--- a/crates/core/src/client/remote/async_ssh_transport.rs
+++ b/crates/core/src/client/remote/async_ssh_transport.rs
@@ -577,6 +577,8 @@ fn run_blocking_server(
         None,
         batch_recording,
         None,
+        #[cfg(feature = "async-bench")]
+        None,
     );
 
     // Drop the writer to signal EOF so the remote process can exit

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -89,6 +89,8 @@ pub(crate) fn run_pull_transfer(
         progress,
         batch_recording,
         None,
+        #[cfg(feature = "async-bench")]
+        None,
     )
     .map_err(|e| invalid_argument_error(&format!("transfer failed: {e}"), 23))?;
     let elapsed = start.elapsed();
@@ -171,6 +173,8 @@ pub(crate) fn run_push_transfer(
         } else {
             None
         },
+        #[cfg(feature = "async-bench")]
+        None,
     );
 
     match result {

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -372,6 +372,8 @@ fn run_transfer_over_embedded_ssh(
         progress,
         batch_recording,
         None,
+        #[cfg(feature = "async-bench")]
+        None,
     );
 
     // Goodbye phase: drop the writer to signal EOF to the russh bridge

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -374,6 +374,8 @@ fn run_server_over_ssh_connection(
         } else {
             None
         },
+        #[cfg(feature = "async-bench")]
+        None,
     );
 
     // Close the writer to signal EOF so the remote process can exit.

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -31,6 +31,13 @@ async-daemon = ["dep:tokio"]
 # server body can run on the runtime. Default-off until the ASY-12 gate. See
 # docs/design/asy-2-tokio-runtime-feature.md section 5.
 tokio-transfer = ["async-daemon", "core/tokio-transfer"]
+# BENCHMARK-ONLY (default-off): activates the gated daemon-receiver async path
+# that runs the existing async receiver driver over a real socket on a
+# multi-thread runtime, for a fair async-vs-threaded receiver benchmark. Also
+# requires `OC_RSYNC_ASYNC_BENCH=1` at runtime; both gates must be present.
+# NOT production-safe and NOT wire-fidelity-guaranteed under backpressure.
+# Implies `tokio-transfer` and forwards `core/async-bench`.
+async-bench = ["tokio-transfer", "core/async-bench"]
 # Concurrent session tracking - enables efficient shared state for multi-session daemons
 concurrent-sessions = ["dep:dashmap"]
 # Extended attributes (xattr) preservation during transfers

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -60,6 +60,9 @@ use core::{
 // `docs/design/asy-2-tokio-runtime-feature.md` section 5.
 #[cfg(feature = "tokio-transfer")]
 use core::server::run_server_with_handshake_on;
+// BENCHMARK-ONLY (default-off): receiver handoff for the gated async-bench path.
+#[cfg(feature = "async-bench")]
+use core::server::AsyncBenchReceiver;
 use logging_sink::MessageSink;
 use protocol::{
     LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonMessage, MessageCode, MessageFrame, ProtocolVersion,

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -344,6 +344,16 @@ fn run_daemon_transfer(
     async_socket: Option<TcpStream>,
 ) -> ServerResult {
     match async_socket {
+        // BENCHMARK-ONLY (default-off): when the `async-bench` feature is
+        // compiled AND `OC_RSYNC_ASYNC_BENCH=1` is set, run the async receiver
+        // driver over the real socket on a multi-thread runtime instead of
+        // hosting the sync body. Both gates must be present; either missing keeps
+        // the byte-identical threaded path below. This is not production-safe and
+        // does not satisfy the live-wiring rung (the write leg still blocks).
+        #[cfg(feature = "async-bench")]
+        Some(socket) if async_bench_enabled() => {
+            run_async_bench_receiver(config, handshake, read_stream, write_stream, socket)
+        }
         // Socket-backed daemon module transfer: route through the tokio driver.
         // The driver hosts the sync server body via `host_sync_on`, so output is
         // byte-identical to the direct call. The socket clone is held for the
@@ -372,6 +382,8 @@ fn run_daemon_transfer(
             None,
             None,
             None,
+            #[cfg(feature = "async-bench")]
+            None,
         ),
     }
 }
@@ -396,6 +408,58 @@ fn with_daemon_transfer_runtime<R>(f: impl FnOnce(&tokio::runtime::Handle) -> R)
             f(runtime.handle())
         }
     }
+}
+
+/// BENCHMARK-ONLY runtime gate: is `OC_RSYNC_ASYNC_BENCH=1` set?
+///
+/// The `async-bench` cargo feature is the compile-time gate; this env var is the
+/// runtime gate. Both must be present for the async-bench receiver path to run,
+/// so a build that compiled the feature still uses the threaded path unless the
+/// operator opts in explicitly. Any value other than `"1"` (including unset)
+/// keeps the default path.
+#[cfg(feature = "async-bench")]
+fn async_bench_enabled() -> bool {
+    std::env::var("OC_RSYNC_ASYNC_BENCH").is_ok_and(|v| v == "1")
+}
+
+/// BENCHMARK-ONLY: runs the async receiver driver over the real socket.
+///
+/// Builds a multi-thread tokio runtime (`>= 2` worker threads) and hands the
+/// pre-split socket clone plus the runtime handle to
+/// [`run_server_with_handshake`]. The multi-thread runtime is load-bearing: the
+/// async receiver driver still writes the request half synchronously, so a
+/// blocking write parks one worker while another polls the `.await` read and the
+/// peer keeps draining. A current-thread runtime would starve the read and
+/// deadlock (asy-7 Blocker F). The synchronous protocol setup runs on
+/// `read_stream`/`write_stream` (blocking clones); the driver then takes over
+/// the wire-facing reads via `socket` (a third clone of the same kernel socket).
+#[cfg(feature = "async-bench")]
+fn run_async_bench_receiver(
+    config: ServerConfig,
+    handshake: HandshakeResult,
+    read_stream: &mut dyn Read,
+    write_stream: &mut dyn Write,
+    socket: TcpStream,
+) -> ServerResult {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .map_err(|e| io::Error::other(format!("failed to build async-bench runtime: {e}")))?;
+    let bench = AsyncBenchReceiver {
+        handle: runtime.handle(),
+        socket,
+    };
+    run_server_with_handshake(
+        config,
+        handshake,
+        read_stream,
+        write_stream,
+        None,
+        None,
+        None,
+        Some(bench),
+    )
 }
 
 /// Executes the server transfer and logs the result.

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -154,6 +154,16 @@ async = ["dep:tokio", "dep:tokio-util"]
 # docs/design/asy-3-async-boundary-spec.md.
 tokio-transfer = ["async", "protocol/tokio-transfer"]
 
+# BENCHMARK-ONLY (default-off): compiles the gated daemon-receiver path that
+# runs the existing async receiver driver over a real socket on a multi-thread
+# runtime, for a fair async-vs-threaded receiver benchmark. Also requires the
+# `OC_RSYNC_ASYNC_BENCH=1` env var at runtime; both gates must be present for
+# the path to activate. The synchronous write leg still blocks (no AsyncWrite
+# stack), so this is NOT production-safe and NOT wire-fidelity-guaranteed under
+# arbitrary backpressure - it does not satisfy the live-wiring rung. Implies
+# `tokio-transfer`.
+async-bench = ["tokio-transfer"]
+
 # ============================================================================
 # Debugging Features
 # ============================================================================

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -327,7 +327,42 @@ pub fn run_server_stdio(
     progress: Option<&mut dyn TransferProgressCallback>,
 ) -> ServerResult {
     let handshake = perform_handshake(stdin, stdout)?;
-    run_server_with_handshake(config, handshake, stdin, stdout, progress, None, None)
+    run_server_with_handshake(
+        config,
+        handshake,
+        stdin,
+        stdout,
+        progress,
+        None,
+        None,
+        #[cfg(feature = "async-bench")]
+        None,
+    )
+}
+
+/// BENCHMARK-ONLY receiver handoff for the gated `async-bench` daemon path.
+///
+/// Carries the multi-thread runtime handle the async receiver driver is driven
+/// on plus the pre-split socket clone adopted as the async read half. It is
+/// threaded into [`run_server_with_handshake`] only under the `async-bench`
+/// feature and is never constructed in a default build, so the production
+/// server path is unchanged. Activating the path additionally requires
+/// `OC_RSYNC_ASYNC_BENCH=1` at runtime (checked by the daemon before this is
+/// constructed). This does NOT satisfy the live-wiring rung: the synchronous
+/// write leg still blocks, so it is not production-safe.
+#[cfg(feature = "async-bench")]
+#[derive(Debug)]
+pub struct AsyncBenchReceiver<'a> {
+    /// Multi-thread runtime handle (`>= 2` workers) the driver is
+    /// `block_on`-driven on. A synchronous blocking write parks one worker while
+    /// another polls the `.await` read, so the peer keeps draining and the
+    /// driver does not self-deadlock the way a current-thread runtime would
+    /// (asy-7 Blocker F).
+    pub handle: &'a tokio::runtime::Handle,
+    /// The socket clone (a dup'd fd of the transfer socket) adopted as the async
+    /// read half. It is flipped non-blocking and handed to the tokio reactor
+    /// inside the driver; the blocking write leg uses a separate clone.
+    pub socket: std::net::TcpStream,
 }
 
 /// Executes the native server with a pre-negotiated protocol version.
@@ -358,6 +393,11 @@ pub fn run_server_with_handshake<W: Write>(
     progress: Option<&mut dyn TransferProgressCallback>,
     batch: Option<BatchRecording>,
     itemize: Option<&mut dyn ItemizeCallback>,
+    // BENCHMARK-ONLY (default-off): when `Some`, the receiver dispatch runs the
+    // async driver over `async_bench.socket` instead of the threaded path. The
+    // parameter only exists under the `async-bench` feature, so the default
+    // build's signature and every production call site are unchanged.
+    #[cfg(feature = "async-bench")] async_bench: Option<AsyncBenchReceiver<'_>>,
 ) -> ServerResult {
     // FSM: begin at Handshake (version exchange is already complete when this
     // function is called - either via run_server_stdio or daemon greeting).
@@ -663,6 +703,20 @@ pub fn run_server_with_handshake<W: Write>(
 
     match config.role {
         ServerRole::Receiver => {
+            // BENCHMARK-ONLY: the protocol setup above already ran synchronously
+            // on `stdin`/`writer`. Hand the wire-facing reads to the async
+            // receiver driver over the pre-split socket clone, keeping the
+            // request half on the blocking `writer` (a separate clone). Reachable
+            // only with the `async-bench` feature AND a `Some(async_bench)` from
+            // the daemon (which only supplies it when `OC_RSYNC_ASYNC_BENCH=1`).
+            #[cfg(feature = "async-bench")]
+            if let Some(bench) = async_bench {
+                let mut ctx = ReceiverContext::new(&handshake, config, pipeline);
+                let stats = bench
+                    .handle
+                    .block_on(ctx.run_receiver_async_bench(bench.socket, &mut writer))?;
+                return Ok(ServerStats::Receiver(stats));
+            }
             let mut ctx = ReceiverContext::new(&handshake, config, pipeline);
             // upstream: io.c:859 - stats.total_written tracking
             let mut counting_writer = writer::CountingWriter::new(&mut writer);

--- a/crates/transfer/src/pipeline/tokio_driver.rs
+++ b/crates/transfer/src/pipeline/tokio_driver.rs
@@ -67,7 +67,19 @@ pub fn run_server_with_handshake_on<W: Write>(
     // inline sync call with per-boundary `.await` sites; ASY-3 only establishes
     // the runtime-hosted scaffold.
     host_sync_on(handle, move || {
-        run_server_with_handshake(config, handshake, stdin, stdout, progress, batch, itemize)
+        run_server_with_handshake(
+            config,
+            handshake,
+            stdin,
+            stdout,
+            progress,
+            batch,
+            itemize,
+            // The tokio driver hosts the sync server body; the async-bench path
+            // is driven separately by the daemon, never through here.
+            #[cfg(feature = "async-bench")]
+            None,
+        )
     })
 }
 

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -79,6 +79,59 @@ impl ReceiverContext {
             self.run_pipelined(reader, writer, crate::pipeline::PipelineConfig::default())
         }
     }
+
+    /// BENCHMARK-ONLY async twin of [`run`](Self::run) over a real socket.
+    ///
+    /// Adopts `socket` (a dup'd clone of the transfer socket) as the async read
+    /// half: it is flipped non-blocking and handed to the tokio reactor, then
+    /// wrapped as a plain [`AsyncServerReader`](crate::reader::AsyncServerReader)
+    /// (multiplex activation happens inside the driver's `setup_transfer_async`,
+    /// exactly as the sync path activates it inside `setup_transfer`). The
+    /// wire-facing reads are driven through the matching async receiver driver;
+    /// the synchronous request half keeps writing through the caller's blocking
+    /// `writer`, which is a separate socket clone. Both fds point at the same
+    /// kernel socket, so the async reads continue from exactly where the
+    /// synchronous protocol setup left off - sound only because that setup reads
+    /// the compat exchange directly (no look-ahead buffer that could strand wire
+    /// bytes in a discarded reader).
+    ///
+    /// This exists purely to measure the async receiver driver against the
+    /// threaded one over a live socket. The synchronous write leg still blocks,
+    /// so it is not production-safe and not wire-fidelity-guaranteed under
+    /// arbitrary backpressure. Reachable only with the `async-bench` feature
+    /// compiled AND `OC_RSYNC_ASYNC_BENCH=1` set at runtime.
+    #[cfg(feature = "async-bench")]
+    pub(crate) async fn run_receiver_async_bench<W>(
+        &mut self,
+        socket: std::net::TcpStream,
+        writer: &mut W,
+    ) -> io::Result<TransferStats>
+    where
+        W: Write + crate::writer::MsgInfoSender + ?Sized,
+    {
+        socket.set_nonblocking(true)?;
+        let async_socket = tokio::net::TcpStream::from_std(socket)?;
+        let reader = crate::reader::AsyncServerReader::new_plain(async_socket);
+
+        // Mirror the sync `run` dispatch exactly so the benchmark compares
+        // like-for-like: incremental directory creation when `incremental-flist`
+        // is compiled, otherwise the decoupled pipeline.
+        #[cfg(feature = "incremental-flist")]
+        {
+            self.run_pipelined_incremental_async(
+                reader,
+                writer,
+                crate::pipeline::PipelineConfig::default(),
+                None,
+            )
+            .await
+        }
+        #[cfg(not(feature = "incremental-flist"))]
+        {
+            self.run_pipelined_async(reader, writer, crate::pipeline::PipelineConfig::default())
+                .await
+        }
+    }
 }
 
 /// Renames all delayed-update files from their `.~tmp~` staging paths to

--- a/crates/transfer/src/receiver/transfer/pipelined_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_async.rs
@@ -683,4 +683,136 @@ mod async_pipelined_driver_parity_tests {
         let total_literal: u64 = contents.iter().map(|c| c.len() as u64).sum();
         assert_eq!(async_stats.bytes_received, total_literal);
     }
+
+    /// BENCHMARK-ONLY correctness gate for the async-bench receiver wiring.
+    ///
+    /// Drives the same recorded multi-file protocol-32 wire through BOTH the
+    /// threaded receiver ([`ReceiverContext::run`], into one temp dest) and the
+    /// async-bench receiver ([`ReceiverContext::run_receiver_async_bench`], into
+    /// another) and asserts byte-identical destination trees, identical
+    /// [`TransferStats`], the same Ok outcome, and no hang. Unlike the driver
+    /// parity tests above (in-memory `ChunkedReader`), the async side runs over a
+    /// *real* loopback TCP socket on a multi-thread runtime - exactly the path
+    /// the daemon benchmark takes - so this exercises the socket split (async
+    /// read half via `tokio::net::TcpStream::from_std`, blocking write half via a
+    /// separate sink) and the multi-thread `block_on`. A benchmark of a
+    /// desyncing or deadlocking path would be worthless, so this must pass before
+    /// the bench wiring is trusted.
+    ///
+    /// The peer delivers the whole recorded wire then closes its write side; the
+    /// receiver's request half is absorbed by a separate `CaptureWriter` sink, so
+    /// the socket carries only server->receiver bytes and cannot write-write
+    /// deadlock. If the async read half stranded wire bytes or the runtime
+    /// starved the read, the tree/stats assertions would fail (or the test would
+    /// hang under the harness timeout).
+    #[cfg(feature = "async-bench")]
+    #[test]
+    fn async_bench_receiver_matches_threaded_over_real_socket() {
+        use std::io::Write as _;
+        use std::net::{Shutdown, TcpListener, TcpStream};
+
+        // Four regular files: f0/f1 fresh (no basis), f2/f3 unchanged (basis).
+        let contents: Vec<Vec<u8>> = vec![
+            {
+                let mut v = b"fresh f0 ".to_vec();
+                v.extend(std::iter::repeat_n(0x11u8, 250));
+                v.extend_from_slice(b" end f0");
+                v
+            },
+            {
+                let mut v = b"fresh f1 ".to_vec();
+                v.extend(std::iter::repeat_n(0x22u8, 300));
+                v.extend_from_slice(b" end f1");
+                v
+            },
+            b"unchanged f2 basis contents".to_vec(),
+            b"unchanged f3 basis contents - a bit longer than f2".to_vec(),
+        ];
+
+        let entries = flist_entries(&contents);
+        let flist_wire = encode_flist(&entries);
+
+        let probe_dir = tempdir().unwrap();
+        let ndx_map = probe_ndx(probe_dir.path(), &flist_wire);
+        assert_eq!(ndx_map.len(), 4, "expected four regular-file requests");
+
+        let requests: Vec<(i32, Vec<u8>)> = ndx_map
+            .iter()
+            .map(|&(idx, ndx)| {
+                let content = &contents[idx - 1];
+                (ndx, encode_literal_wire(content))
+            })
+            .collect();
+
+        // Two multiplex frames: the flist, then the per-file + finalize data.
+        let data_wire = build_data_wire(&requests);
+        let mut wire = muxed(&flist_wire);
+        wire.extend_from_slice(&muxed(&data_wire));
+
+        let basis: Vec<(usize, &[u8])> =
+            vec![(2usize, &contents[2][..]), (3usize, &contents[3][..])];
+
+        // --- threaded receiver (production sync dispatch) over the recorded wire ---
+        let sync_dest = tempdir().unwrap();
+        seed_basis(sync_dest.path(), &basis);
+        let sync_stats = {
+            let mut ctx = ReceiverContext::new_for_test(&handshake(), config(sync_dest.path()));
+            let reader = ServerReader::new_plain(Cursor::new(wire.clone()));
+            let mut writer = CaptureWriter(Vec::new());
+            ctx.run(reader, &mut writer, None)
+                .expect("threaded receiver must succeed")
+        };
+        let sync_tree = read_tree(sync_dest.path());
+
+        // --- async-bench receiver over a real loopback socket on a multi-thread rt ---
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut peer = TcpStream::connect(addr).unwrap();
+        let (recv_sock, _peer_addr) = listener.accept().unwrap();
+        // The recorded wire is a couple of KiB - well within the socket buffer -
+        // so writing it up front then closing the write side is deterministic:
+        // the bytes stay in the receiver's kernel buffer and the receiver reads
+        // them then observes EOF after the finalize handshake.
+        peer.write_all(&wire).unwrap();
+        peer.flush().unwrap();
+        peer.shutdown(Shutdown::Write).unwrap();
+
+        let async_dest = tempdir().unwrap();
+        seed_basis(async_dest.path(), &basis);
+        // Multi-thread runtime (>= 2 workers), matching the daemon bench path: a
+        // blocking write parks one worker while another polls the `.await` read.
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+        let async_stats = {
+            let mut ctx = ReceiverContext::new_for_test(&handshake(), config(async_dest.path()));
+            let mut writer = CaptureWriter(Vec::new());
+            runtime
+                .block_on(ctx.run_receiver_async_bench(recv_sock, &mut writer))
+                .expect("async-bench receiver must succeed over a real socket")
+        };
+        let async_tree = read_tree(async_dest.path());
+        drop(peer);
+
+        // (a) byte-identical destination trees
+        assert_eq!(
+            async_tree, sync_tree,
+            "async-bench receiver committed a different destination tree than the threaded receiver"
+        );
+        for (i, content) in contents.iter().enumerate() {
+            assert_eq!(
+                &std::fs::read(async_dest.path().join(format!("d/f{i}"))).unwrap(),
+                content,
+                "async-bench f{i} content mismatch"
+            );
+        }
+
+        // (b) identical TransferStats, (c) no hang (reaching here proves it)
+        assert_stats_eq(&async_stats, &sync_stats);
+        assert_eq!(async_stats.files_transferred, 4);
+        let total_literal: u64 = contents.iter().map(|c| c.len() as u64).sum();
+        assert_eq!(async_stats.bytes_received, total_literal);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a **benchmark-only** daemon-receiver path that runs the existing async receiver driver over a real socket, so the async receiver can be measured head-to-head against the threaded one over a live connection.

The path is **double-gated** and never active in a default or production build:

1. Compile-time: the new `async-bench` cargo feature (implies `tokio-transfer`).
2. Runtime: the `OC_RSYNC_ASYNC_BENCH=1` environment variable.

Both must be present. With either missing, the daemon takes the byte-identical threaded path. The default build's public signature of `run_server_with_handshake` is unchanged (the extra argument only exists under the feature), and every production call site is untouched.

## What it does

When both gates are on, the socket-backed daemon receiver:

- builds a multi-thread tokio runtime (`>= 2` worker threads);
- runs the synchronous protocol setup (compat exchange, capability negotiation) on the blocking socket clones, exactly as today;
- at the receiver dispatch, hands the wire-facing `.await` reads to the matching async driver — `run_pipelined_incremental_async` when `incremental-flist` is compiled, otherwise `run_pipelined_async`, mirroring the sync `run` dispatch exactly;
- adopts a third `try_clone()`d socket fd as the async read half via `set_nonblocking(true)` + `tokio::net::TcpStream::from_std`, wrapped as a plain `AsyncServerReader` (multiplex activation happens inside the driver's `setup_transfer_async`, just as the sync path activates it inside `setup_transfer`);
- keeps the request half writing synchronously through the same blocking `ServerWriter`.

The multi-thread runtime is load-bearing. The async drivers still write synchronously (no AsyncWrite stack), so on a current-thread runtime a blocking write would starve the `.await` read and deadlock. On a multi-thread runtime the blocking write parks one worker while another polls the read, so the peer keeps draining.

## This does NOT satisfy live production wiring

Because the write leg still blocks, this is **not** production-safe and **not** wire-fidelity-guaranteed under arbitrary backpressure. Production live-wiring still needs the async writer stack; that work is unchanged by this PR. This path exists purely to enable a fair async-vs-threaded receiver benchmark.

## Correctness gate

`async_bench_receiver_matches_threaded_over_real_socket` (feature-gated) drives one recorded multi-file protocol-32 wire (a directory plus four regular files — two fresh, two with a pre-existing basis) through **both** the threaded receiver (`ReceiverContext::run`) and the async-bench receiver (`ReceiverContext::run_receiver_async_bench`) — the latter over a **real loopback TCP socket on a multi-thread runtime** — and asserts byte-identical destination trees, identical `TransferStats`, the same Ok outcome, and no hang.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p daemon -p transfer -p core --all-targets --all-features --no-deps -- -D warnings` — clean
- `cargo check` default (macOS + `x86_64-pc-windows-gnu`) — clean
- `cargo check --features async-bench` (macOS + `x86_64-pc-windows-gnu`) — clean
- new correctness test passes (no deadlock over a real multi-file socket transfer); existing async driver parity tests still pass

## Running the benchmark on the Linux host

Build the daemon with the feature and set the env var, e.g.:

```sh
# build once with the bench feature
cargo build --release -p oc-rsync --features async-bench

# run the daemon receiver with the runtime gate on
OC_RSYNC_ASYNC_BENCH=1 ./target/release/oc-rsync --daemon --no-detach --config /path/to/oc-rsyncd.conf --port 8730

# from a client, push into a writable module (daemon is the receiver):
oc-rsync -a /data/src/ rsync://127.0.0.1:8730/bench-dst/
```

With `OC_RSYNC_ASYNC_BENCH` unset (or the feature not compiled) the same daemon runs the threaded receiver, so the two can be timed back to back.
