### PR TITLE
fix(daemon): refuse device options by default per upstream

### DIFF
--- a/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
@@ -41,8 +41,20 @@ const VITAL_OPTIONS: &[&str] = &[
     "iconv",
     "no-iconv",
     "checksum-seed",
+    "copy-devices",
     "write-devices",
 ];
+
+/// Options refused by default in daemon mode, overridable only by an explicit
+/// negated exact match (e.g. `refuse options = !copy-devices`).
+///
+/// upstream: options.c:984-987 - when `am_daemon`, `parse_arguments` seeds the
+/// refuse list with `copy-devices` and `write-devices` before applying the
+/// module's `refuse options` rules, so a daemon rejects client device
+/// read/write unless the module explicitly allows it. Both are also vital
+/// (exact-match only, see `VITAL_OPTIONS`) so a `refuse options = *` wildcard
+/// cannot silently re-enable them.
+const DEFAULT_REFUSED_OPTIONS: &[&str] = &["copy-devices", "write-devices"];
 
 /// Checks whether a client-requested option is refused by the module's refuse list.
 ///
@@ -57,10 +69,9 @@ const VITAL_OPTIONS: &[&str] = &[
 ///
 /// upstream: clientserver.c - `check_refuse_options()` with fnmatch semantics.
 fn refused_option<'a>(module: &ModuleDefinition, options: &'a [String]) -> Option<&'a str> {
-    if module.refuse_options.is_empty() {
-        return None;
-    }
-
+    // No early-out on an empty refuse list: a daemon still refuses the default
+    // device options (`copy-devices`/`write-devices`) even with no `refuse
+    // options` line. upstream: options.c:984-987.
     options.iter().find_map(|candidate| {
         let canonical = canonical_option(candidate);
         let short = long_option_short_letter(&canonical);
@@ -209,9 +220,9 @@ fn long_option_short_letter(long_name: &str) -> Option<char> {
 /// post-OK arg list; popt treats each bundled short letter as a separate
 /// option and rejects any that the module's refuse list disabled.
 fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Option<String> {
-    if module.refuse_options.is_empty() {
-        return None;
-    }
+    // No early-out on an empty refuse list: a daemon still refuses the default
+    // device options (`copy-devices`/`write-devices`) even with no `refuse
+    // options` line. upstream: options.c:984-987.
 
     // upstream: options.c:2215-2241 - a `refuse options = delete` rule matches
     // the single `delete` popt entry, but the enforcement at options.c:2238 is
@@ -317,7 +328,10 @@ fn enables_delete_mode(arg: &str) -> bool {
 /// can refuse or un-refuse vital options when named explicitly.
 fn is_option_refused(refuse_list: &[String], long_name: &str, short_letter: Option<char>) -> bool {
     let vital = is_option_vital(long_name, short_letter);
-    let mut refused = false;
+    // upstream: options.c:984-987 - a daemon seeds `copy-devices`/`write-devices`
+    // as refused before applying the module's rules. Start from that default so
+    // the loop below can only un-refuse them via an explicit negated exact match.
+    let mut refused = DEFAULT_REFUSED_OPTIONS.contains(&long_name);
     let short_lower = short_letter.map(|c| c.to_ascii_lowercase().to_string());
 
     for rule in refuse_list {

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -453,6 +453,89 @@ fn refused_client_arg_pure_negation_allowlist_passes_av() {
 }
 
 #[test]
+fn refused_client_arg_copy_and_write_devices_refused_by_default() {
+    // A daemon refuses `--copy-devices` and `--write-devices` even when the
+    // module has no `refuse options` line at all: allowing a client to read or
+    // write device nodes is a security-relevant default-deny.
+    //
+    // upstream: options.c:984-987 - when `am_daemon`, `parse_arguments` seeds
+    // the refuse list with `parse_one_refuse_match(0, "copy-devices", ...)` and
+    // `parse_one_refuse_match(0, "write-devices", ...)` before applying any
+    // module rules.
+    let module = ModuleDefinition {
+        refuse_options: Vec::new(),
+        ..Default::default()
+    };
+    assert_eq!(
+        refused_client_arg(&module, &["--copy-devices".to_owned()]),
+        Some("--copy-devices".to_owned())
+    );
+    assert_eq!(
+        refused_client_arg(&module, &["--write-devices".to_owned()]),
+        Some("--write-devices".to_owned())
+    );
+}
+
+#[test]
+fn refused_client_arg_non_device_option_not_refused_by_default() {
+    // The default device refusal is scoped strictly to `copy-devices` and
+    // `write-devices`; an empty refuse list must not refuse anything else.
+    // upstream: options.c:984-987 - only those two options are seeded.
+    let module = ModuleDefinition {
+        refuse_options: Vec::new(),
+        ..Default::default()
+    };
+    assert_eq!(
+        refused_client_arg(&module, &["--compress".to_owned(), "-avzD".to_owned()]),
+        None
+    );
+}
+
+#[test]
+fn refused_option_copy_and_write_devices_vital_survive_wildcard() {
+    // `copy-devices`/`write-devices` are vital (exact-match only), so a blanket
+    // `refuse options = *` neither un-refuses them nor is even consulted for
+    // them - they remain refused by the daemon default.
+    //
+    // upstream: options.c:971-974 marks both as `descrip = "a="` (exact-match
+    // only, wild-match disabled) and options.c:984-987 refuses them by default.
+    let module = ModuleDefinition {
+        refuse_options: vec!["*".to_owned()],
+        ..Default::default()
+    };
+    assert_eq!(
+        refused_option(&module, &["--copy-devices".to_owned()]),
+        Some("--copy-devices")
+    );
+    assert_eq!(
+        refused_option(&module, &["--write-devices".to_owned()]),
+        Some("--write-devices")
+    );
+}
+
+#[test]
+fn refused_client_arg_device_options_allowed_by_explicit_negation() {
+    // The default device refusal is overridable, but only by an explicit
+    // negated exact match - never by a wildcard.
+    //
+    // upstream: options.c:984 - "Refused by default, but can be accepted via a
+    // negated exact match." A module that trusts its clients can set
+    // `refuse options = !copy-devices !write-devices`.
+    let module = ModuleDefinition {
+        refuse_options: vec!["!copy-devices".to_owned(), "!write-devices".to_owned()],
+        ..Default::default()
+    };
+    assert_eq!(
+        refused_client_arg(&module, &["--copy-devices".to_owned()]),
+        None
+    );
+    assert_eq!(
+        refused_client_arg(&module, &["--write-devices".to_owned()]),
+        None
+    );
+}
+
+#[test]
 fn refused_client_arg_delete_rule_refuses_timing_variant() {
     // Regression for the upstream `daemon-refuse` testsuite: a module with
     // `refuse options = delete` must reject a client `-a --delete` even though


### PR DESCRIPTION
## Problem

A daemon must not accept client device read/write unless a module explicitly allows it. Upstream rsync 3.4.4 (`options.c`, `am_daemon` branch of `parse_arguments`) enforces this two ways:

- Lines 971-974: `copy-devices` and `write-devices` are marked vital (`descrip = "a="`, exact-match only), so a `refuse options = *` wildcard cannot touch them.
- Lines 984-987: when `am_daemon`, the refuse list is seeded with `parse_one_refuse_match(0, "copy-devices", ...)` and `parse_one_refuse_match(0, "write-devices", ...)` before any module rule is applied, so both are refused by default.

oc-rsync had two gaps against this:

1. The vital set contained `write-devices` but was missing `copy-devices`, so a `refuse options = *` wildcard could interact with `copy-devices` inconsistently.
2. Neither option was refused by default. A plain module with no `refuse options` line accepted `--copy-devices` and `--write-devices`, so a daemon could be driven into reading or writing device nodes against upstream's security default.

## Fix

- Add `copy-devices` to the vital (exact-match-only) option set.
- Seed `copy-devices` and `write-devices` as refused-by-default in the refuse evaluator, overridable only by an explicit negated exact match (`refuse options = !copy-devices`), matching upstream's "accepted via a negated exact match" comment.
- Drop the empty-`refuse options` early-outs in the two enforcement points so the default refusal applies even when a module has no `refuse options` line.

Change is confined to the existing refuse-list mechanism (one constant, the evaluator seed, and the two early-outs); no new abstraction.

## Tests

- A plain module (empty refuse list) refuses `--copy-devices` and `--write-devices`.
- The default refusal is scoped strictly to those two options: an empty list still accepts other options (`--compress`, `-avzD`).
- Both survive `refuse options = *` (vital, wildcard cannot re-enable them).
- Both are accepted when explicitly negated (`refuse options = !copy-devices !write-devices`).

Each test cites the relevant upstream `options.c` lines. Verified against rsync 3.4.4; `cargo fmt` / `cargo clippy -p daemon --all-features -- -D warnings` clean; targeted `nextest -p daemon` refuse suite green (69 passed).