### PR TITLE
fix(daemon): apply three unhandled module directives (auth access-level, ignore errors, numeric ids)

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/authentication.rs
+++ b/crates/daemon/src/daemon/sections/module_access/authentication.rs
@@ -11,10 +11,40 @@
 /// Result of a module authentication attempt.
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum AuthenticationStatus {
-    /// Authentication was successful, carrying the authenticated username.
-    Granted(String),
+    /// Authentication was successful, carrying the authenticated username and
+    /// the per-user access-level override parsed from the `auth users` entry
+    /// (`name:ro` / `name:rw`; `Default` when the entry has no such suffix).
+    Granted {
+        /// The authenticated username.
+        username: String,
+        /// Per-user access-level override applied to the session's `read only`.
+        access_level: UserAccessLevel,
+    },
     /// Authentication was denied (bad credentials or missing response).
     Denied,
+}
+
+/// Resolves the session's effective `read only` flag after authentication.
+///
+/// A user listed in `auth users` may carry an access-level suffix that
+/// overrides the module's `read only` setting for that session:
+///
+/// - `name:ro` forces read-only (client pushes are refused).
+/// - `name:rw` forces writable (pushes are allowed even on a `read only` module).
+/// - no suffix leaves the module's own `read only` in force.
+///
+/// `name:deny` is handled earlier by refusing authentication outright, so it
+/// never reaches this function.
+///
+/// upstream: authenticate.c:340-343 - `if (opt_ch=='r') read_only=1; else if
+/// (opt_ch=='w') read_only=0;`, applied to the `read_only` global that
+/// `rsync_module()` seeds from `lp_read_only(module_id)` (clientserver.c:760).
+fn access_effective_read_only(module_read_only: bool, access: UserAccessLevel) -> bool {
+    match access {
+        UserAccessLevel::ReadOnly => true,
+        UserAccessLevel::ReadWrite => false,
+        UserAccessLevel::Default | UserAccessLevel::Deny => module_read_only,
+    }
 }
 
 /// Performs challenge-response authentication for a protected module.
@@ -82,13 +112,20 @@ fn perform_module_authentication(
         return Ok(AuthenticationStatus::Denied);
     }
 
-    // Check for explicit deny access level
+    // upstream: authenticate.c:334-335 - `opt_ch == 'd'` ("deny") reports
+    // "denied by rule" and auth_server() returns NULL (auth failure).
     if auth_user.access_level == UserAccessLevel::Deny {
         send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied);
     }
 
-    Ok(AuthenticationStatus::Granted(username.to_owned()))
+    // upstream: authenticate.c:340-343 - the `:ro` / `:rw` suffix travels back
+    // to rsync_module() via the `read_only` global; carry the parsed access
+    // level so the caller can apply it to the session's effective `read only`.
+    Ok(AuthenticationStatus::Granted {
+        username: username.to_owned(),
+        access_level: auth_user.access_level,
+    })
 }
 
 /// Generates a unique authentication challenge string.

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -52,6 +52,38 @@ fn clamped_verbose_level(flag_string: &str) -> u8 {
     let count = flag_string.chars().filter(|&ch| ch == 'v').count();
     u8::try_from(count).unwrap_or(u8::MAX)
 }
+/// Applies module directives that force transfer-time behavior onto the
+/// per-session [`ServerConfig`], mirroring the daemon-only overrides upstream
+/// applies in `rsync_module()` after the client argv is parsed.
+///
+/// - `ignore errors = yes` forces error-tolerant deletion regardless of the
+///   client's flags. upstream: clientserver.c:1111-1112 -
+///   `if (lp_ignore_errors(module_id)) ignore_errors = 1;`.
+/// - `numeric ids = yes` forces `--numeric-ids` for the session. upstream:
+///   clientserver.c:1201-1204 -
+///   `if (!numeric_ids && (use_chroot ? lp_numeric_ids(module_id) != False &&
+///   !*lp_name_converter(module_id) : lp_numeric_ids(module_id) == True))
+///   numeric_ids = -1;`. The option is forced on only when the client did not
+///   already request it and, under chroot, only when no `name converter` is
+///   configured (the converter maps names inside the chroot). oc stores
+///   `numeric ids` as a plain bool with no tri-state True/False/Unset, so the
+///   unset and explicit-off cases both read as `false` and never force the
+///   option on; only an explicit `numeric ids = yes` does.
+fn apply_module_transfer_directives(module: &ModuleDefinition, cfg: &mut ServerConfig) {
+    // upstream: clientserver.c:1111-1112
+    if module.ignore_errors {
+        cfg.deletion.ignore_errors = true;
+    }
+
+    // upstream: clientserver.c:1201-1204
+    if !cfg.flags.numeric_ids
+        && module.numeric_ids
+        && !(module.use_chroot && module.name_converter.is_some())
+    {
+        cfg.flags.numeric_ids = true;
+    }
+}
+
 /// Builds the server configuration from client arguments.
 ///
 /// Returns the configuration on success, or sends an error and returns `None`.
@@ -263,6 +295,11 @@ fn build_server_config(
             // through the transfer layer so the sender strips `/rsyncd-munged/`
             // on `readlink()` and the receiver prepends it on `symlink()` writes.
             cfg.munge_symlinks = module.effective_munge_symlinks();
+
+            // upstream: clientserver.c:1111-1112 (`ignore errors`) and
+            // clientserver.c:1201-1204 (`numeric ids`) - module directives that
+            // force transfer behavior for the session once client args are known.
+            apply_module_transfer_directives(module, &mut cfg);
 
             Ok(Some(cfg))
         }

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -380,8 +380,9 @@ fn build_default_post_ok_compat_flags(client_info: &str) -> protocol::Compatibil
 
 /// Handles module authentication flow with FSM transition enforcement.
 ///
-/// Returns `Some(username)` if authentication succeeded, where the username is
-/// the authenticated user (or `None` inside `Some` when auth was not required).
+/// On success returns `Some((username, access_level))` where `username` is the
+/// authenticated user (or `None` when auth was not required) and `access_level`
+/// is the per-user `auth users` override applied to the session's `read only`.
 /// Returns `Ok(None)` if authentication failed or was denied.
 ///
 /// FSM transitions:
@@ -392,10 +393,12 @@ fn handle_authentication(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleDefinition,
     protocol_version: Option<ProtocolVersion>,
-) -> io::Result<Option<Option<String>>> {
+) -> io::Result<Option<(Option<String>, UserAccessLevel)>> {
     if !module.requires_authentication() {
         send_daemon_ok(ctx.reader.get_mut(), ctx.limiter, ctx.messages)?;
-        return Ok(Some(None));
+        // upstream: authenticate.c:238-239 - an empty/absent `auth users` list
+        // lets anyone in with no access-level override, so `read only` stays.
+        return Ok(Some((None, UserAccessLevel::Default)));
     }
 
     // FSM: ModuleSelect -> Authenticating - module requires auth, challenge sent.
@@ -423,12 +426,15 @@ fn handle_authentication(
                 .map_err(transition_error)?;
             Ok(None)
         }
-        AuthenticationStatus::Granted(username) => {
+        AuthenticationStatus::Granted {
+            username,
+            access_level,
+        } => {
             if let Some(log) = ctx.log_sink {
                 log_module_auth_success(log, ctx.effective_host(), ctx.peer_ip, ctx.request);
             }
             send_daemon_ok(ctx.reader.get_mut(), ctx.limiter, ctx.messages)?;
-            Ok(Some(Some(username)))
+            Ok(Some((Some(username), access_level)))
         }
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2942,6 +2942,125 @@ mod module_access_tests {
             );
         }
     }
+
+    // upstream: authenticate.c:340-343 - an authenticated user's `:ro` suffix
+    // forces read_only=1, `:rw` forces read_only=0. The per-user override must
+    // win over the module's own `read only` for the session; otherwise a
+    // `name:rw` user could never push to a `read only = yes` module and, worse,
+    // a `name:ro` user could write to a `read only = no` module (a privilege
+    // escalation). These tests pin that the override is honoured in both
+    // directions and that an unsuffixed user leaves the module default intact.
+    #[test]
+    fn auth_ro_suffix_forces_read_only_for_session() {
+        // `read only = no` module, but the user is pinned to `:ro`.
+        assert!(access_effective_read_only(
+            false,
+            UserAccessLevel::ReadOnly
+        ));
+    }
+
+    #[test]
+    fn auth_rw_suffix_forces_writable_for_session() {
+        // `read only = yes` module, but the user is pinned to `:rw`.
+        assert!(!access_effective_read_only(
+            true,
+            UserAccessLevel::ReadWrite
+        ));
+    }
+
+    #[test]
+    fn auth_default_access_preserves_module_read_only() {
+        // No suffix: the module's own `read only` setting stands unchanged.
+        assert!(access_effective_read_only(true, UserAccessLevel::Default));
+        assert!(!access_effective_read_only(
+            false,
+            UserAccessLevel::Default
+        ));
+    }
+
+    #[test]
+    fn auth_deny_access_preserves_module_read_only() {
+        // `:deny` is refused before reaching read-only resolution, so it never
+        // relaxes the module default: a denied user must not gain write access.
+        assert!(access_effective_read_only(true, UserAccessLevel::Deny));
+    }
+
+    // upstream: clientserver.c:1111-1112 - `if (lp_ignore_errors(module_id))
+    // ignore_errors = 1;` forces error-tolerant deletion for the session.
+    #[test]
+    fn module_ignore_errors_forces_config_flag() {
+        let module = ModuleDefinition {
+            ignore_errors: true,
+            ..Default::default()
+        };
+        let mut cfg = ServerConfig::default();
+        assert!(!cfg.deletion.ignore_errors);
+        apply_module_transfer_directives(&module, &mut cfg);
+        assert!(cfg.deletion.ignore_errors);
+    }
+
+    #[test]
+    fn module_without_ignore_errors_leaves_config_untouched() {
+        let module = ModuleDefinition::default();
+        let mut cfg = ServerConfig::default();
+        apply_module_transfer_directives(&module, &mut cfg);
+        assert!(!cfg.deletion.ignore_errors);
+    }
+
+    // upstream: clientserver.c:1201-1204 - `numeric ids = yes` forces
+    // `--numeric-ids` for the session, except under chroot when a `name
+    // converter` is configured (the converter maps names inside the chroot).
+    #[test]
+    fn module_numeric_ids_forces_config_flag() {
+        let module = ModuleDefinition {
+            numeric_ids: true,
+            use_chroot: false,
+            ..Default::default()
+        };
+        let mut cfg = ServerConfig::default();
+        assert!(!cfg.flags.numeric_ids);
+        apply_module_transfer_directives(&module, &mut cfg);
+        assert!(cfg.flags.numeric_ids);
+    }
+
+    #[test]
+    fn module_numeric_ids_suppressed_by_chroot_name_converter() {
+        // upstream: under chroot, a configured name converter means names can
+        // still be mapped, so numeric ids is NOT forced on.
+        let module = ModuleDefinition {
+            numeric_ids: true,
+            use_chroot: true,
+            name_converter: Some("/usr/bin/nc".to_owned()),
+            ..Default::default()
+        };
+        let mut cfg = ServerConfig::default();
+        apply_module_transfer_directives(&module, &mut cfg);
+        assert!(!cfg.flags.numeric_ids);
+    }
+
+    #[test]
+    fn module_numeric_ids_forced_under_chroot_without_name_converter() {
+        let module = ModuleDefinition {
+            numeric_ids: true,
+            use_chroot: true,
+            name_converter: None,
+            ..Default::default()
+        };
+        let mut cfg = ServerConfig::default();
+        apply_module_transfer_directives(&module, &mut cfg);
+        assert!(cfg.flags.numeric_ids);
+    }
+
+    #[test]
+    fn module_without_numeric_ids_leaves_config_untouched() {
+        let module = ModuleDefinition {
+            numeric_ids: false,
+            ..Default::default()
+        };
+        let mut cfg = ServerConfig::default();
+        apply_module_transfer_directives(&module, &mut cfg);
+        assert!(!cfg.flags.numeric_ids);
+    }
 }
 
 // ASY sub-rung 2: the tokio-driver routing shim for the socket-backed daemon

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -55,10 +55,11 @@ fn process_approved_module(
 
     apply_module_timeout(ctx.reader.get_mut(), module)?;
 
-    let auth_user = match handle_authentication(ctx, module, negotiated_protocol)? {
-        Some(user) => user,
-        None => return Ok(()),
-    };
+    let (auth_user, auth_access_level) =
+        match handle_authentication(ctx, module, negotiated_protocol)? {
+            Some(outcome) => outcome,
+            None => return Ok(()),
+        };
 
     // Run early exec after authentication so the authenticated username
     // is available in the RSYNC_USER_NAME environment variable.
@@ -140,8 +141,16 @@ fn process_approved_module(
     // am_sender against lp_read_only(i) and lp_write_only(i).
     // When --sender is absent the client is pushing (server = Receiver).
     // A read-only module must reject pushes; a write-only module must reject pulls.
+    //
+    // upstream: clientserver.c:760 seeds `read_only = lp_read_only(module_id)`;
+    // auth_server() (authenticate.c:340-343) then overrides it from the
+    // authenticated user's `:ro` / `:rw` suffix. Apply that override here so a
+    // `name:rw` user may push to a `read only = yes` module and a `name:ro`
+    // user is refused writes to a `read only = no` module. The `write only`
+    // check is unaffected: upstream's auth override only touches `read_only`.
     let role = determine_server_role(&client_args);
-    if module.read_only && matches!(role, ServerRole::Receiver) {
+    let effective_read_only = access_effective_read_only(module.read_only, auth_access_level);
+    if effective_read_only && matches!(role, ServerRole::Receiver) {
         send_error(
             ctx.reader.get_mut(),
             ctx.limiter,


### PR DESCRIPTION
## Problem

The rsync daemon parses several `rsyncd.conf` module directives into the module
definition but never applies three of them to the per-session server config, so
they were silent no-ops. Verified empirically against upstream rsync 3.4.4.

1. **auth user access-level (`auth users = name:ro` / `name:rw`) - security.**
   A user in `auth users` may carry a `:ro`, `:rw`, or `:deny` suffix. The
   daemon acted only on `:deny`; `:ro` and `:rw` were ignored. This let a
   `name:rw` user be blocked from pushing to a `read only = yes` module, and -
   the security-relevant case - allowed a `name:ro` user to **write to a
   `read only = no` module**, escalating past the per-user restriction.

2. **`ignore errors = yes`** was parsed but never forced the deletion
   error-tolerance flag.

3. **`numeric ids = yes`** was parsed but never forced `--numeric-ids` for the
   session.

## Fix

Apply all three when building the session config, matching upstream:

- Access-level override threaded out of authentication and applied to the
  effective `read only` before the push/pull gate
  (authenticate.c:340-343, seeded from lp_read_only at clientserver.c:760).
  The `write only` check is unchanged, mirroring upstream (the override only
  touches `read_only`).
- `ignore errors` forces error-tolerant deletion (clientserver.c:1111-1112).
- `numeric ids` forces `--numeric-ids` only when the client did not already
  request it and, under chroot, only when no `name converter` is configured
  (clientserver.c:1201-1204).

## Notes

Item 1 is a security fix (unauthorized writes to a read-only module).

Scoping limitation: `numeric ids` is stored as a plain bool, not the upstream
tri-state (True/False/Unset). The unset and explicit-off cases both read as
`false` and never force the option on; only an explicit `numeric ids = yes`
does. This matches upstream observable behavior for the configured cases.

## Tests

Unit tests cover access-level resolution (including the `:ro` escalation
guard), `ignore errors` application, and `numeric ids` application (including
the chroot + name-converter suppression case). Each test cites the upstream
line it pins.

`cargo fmt` and `cargo clippy -p daemon --all-features -- -D warnings` are
clean; the new targeted tests pass.