### PR TITLE
fix(remote): align server_options generation with upstream 3.4.4

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -54,6 +54,20 @@ pub(super) struct ServerLongFlags {
     pub(super) zero_copy_policy: fast_io::ZeroCopyPolicy,
     pub(super) write_devices: bool,
     pub(super) trust_sender: bool,
+    /// Keep partially transferred files (upstream: `--partial`, long-form only).
+    ///
+    /// upstream: options.c:2893 - `server_options()` emits bare `--partial`
+    /// (never a compact `P` letter) when the client is the sender and no
+    /// `--partial-dir` is configured. The receiver consults `keep_partial`
+    /// (receiver.c) to leave interrupted temp files in place.
+    pub(super) partial: bool,
+    /// Explicit specials override (upstream: `--specials` / `--no-specials`).
+    ///
+    /// upstream: options.c:2760-2765 - the compact `D` letter carries
+    /// preserve_devices only, so specials arrive separately: `--specials`
+    /// (`Some(true)`) or `--no-specials` (`Some(false)`). `None` leaves the
+    /// value implied by the compact `D` letter untouched.
+    pub(super) specials: Option<bool>,
     pub(super) qsort: bool,
     pub(super) checksum_seed: Option<String>,
     pub(super) checksum_choice: Option<String>,
@@ -187,6 +201,8 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         zero_copy_policy: fast_io::ZeroCopyPolicy::Auto,
         write_devices: false,
         trust_sender: false,
+        partial: false,
+        specials: None,
         qsort: false,
         checksum_seed: None,
         checksum_choice: None,
@@ -234,6 +250,12 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             "--no-zero-copy" => flags.zero_copy_policy = fast_io::ZeroCopyPolicy::Disabled,
             "--write-devices" => flags.write_devices = true,
             "--trust-sender" => flags.trust_sender = true,
+            // upstream: options.c:2893 - bare --partial (no compact 'P').
+            "--partial" => flags.partial = true,
+            // upstream: options.c:2760-2765 - --specials / --no-specials convey
+            // preserve_specials separately from the compact 'D' (devices) letter.
+            "--specials" => flags.specials = Some(true),
+            "--no-specials" => flags.specials = Some(false),
             "--qsort" => flags.qsort = true,
             "--from0" => flags.from0 = true,
             "--inplace" => flags.inplace = true,
@@ -446,6 +468,9 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--no-zero-copy"
             | "--write-devices"
             | "--trust-sender"
+            | "--partial"
+            | "--specials"
+            | "--no-specials"
             | "--qsort"
             | "--from0"
             | "--inplace"

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -186,6 +186,17 @@ where
     config.file_selection.from0 = long_flags.from0;
     config.write.inplace = long_flags.inplace;
     config.file_selection.size_only = long_flags.size_only;
+    // upstream: options.c:2893 - bare --partial (no compact 'P' letter) tells the
+    // receiver to keep interrupted temp files. OR with the compact value so a
+    // legacy client that still packs 'P' is not clobbered.
+    if long_flags.partial {
+        config.flags.partial = true;
+    }
+    // upstream: options.c:2760-2765 - --specials / --no-specials override the
+    // specials bit that the compact 'D' letter set to preserve_devices's value.
+    if let Some(specials) = long_flags.specials {
+        config.flags.specials = specials;
+    }
     config.file_selection.ignore_existing = long_flags.ignore_existing;
     config.file_selection.existing_only = long_flags.existing_only;
     config.flags.numeric_ids = long_flags.numeric_ids;

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -647,6 +647,43 @@ fn long_flags_qsort() {
     assert!(flags.qsort);
 }
 
+// upstream: options.c:2893 - bare --partial (no compact 'P') tells the receiver
+// to keep interrupted temp files. The server must parse it, or an oc/upstream
+// client's PUSH loses keep_partial on the oc receiver.
+#[test]
+fn long_flags_partial() {
+    let args = vec![OsString::from("--server"), OsString::from("--partial")];
+    let flags = parse_server_long_flags(&args);
+    assert!(flags.partial);
+    assert!(is_known_server_long_flag("--partial"));
+}
+
+#[test]
+fn long_flags_partial_default_none() {
+    let args = vec![OsString::from("--server")];
+    let flags = parse_server_long_flags(&args);
+    assert!(!flags.partial);
+}
+
+// upstream: options.c:2760-2765 - --specials / --no-specials convey
+// preserve_specials separately from the compact 'D' (devices) letter.
+#[test]
+fn long_flags_specials_and_no_specials() {
+    let flags =
+        parse_server_long_flags(&[OsString::from("--server"), OsString::from("--specials")]);
+    assert_eq!(flags.specials, Some(true));
+
+    let flags =
+        parse_server_long_flags(&[OsString::from("--server"), OsString::from("--no-specials")]);
+    assert_eq!(flags.specials, Some(false));
+
+    let flags = parse_server_long_flags(&[OsString::from("--server")]);
+    assert_eq!(flags.specials, None);
+
+    assert!(is_known_server_long_flag("--specials"));
+    assert!(is_known_server_long_flag("--no-specials"));
+}
+
 #[test]
 fn long_flags_checksum_seed() {
     let args = vec![

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -321,6 +321,19 @@ pub(super) fn build_full_daemon_args(
         args.push("--safe-links".to_owned());
     }
 
+    // upstream: options.c:2760-2765 - the compact 'D' letter now tracks
+    // preserve_devices only (build_server_flag_string). specials ride separately:
+    // `if (preserve_devices) { if (!preserve_specials) --no-specials } else if
+    // (preserve_specials) --specials`. --no-specials (not --devices) keeps
+    // backward compatibility since -D already carries devices.
+    if config.preserve_devices() {
+        if !config.preserve_specials() {
+            args.push("--no-specials".to_owned());
+        }
+    } else if config.preserve_specials() {
+        args.push("--specials".to_owned());
+    }
+
     // upstream: options.c:2887-2888
     if config.numeric_ids() {
         args.push("--numeric-ids".to_owned());
@@ -378,6 +391,14 @@ pub(super) fn build_full_daemon_args(
         }
     } else if config.inplace() {
         args.push("--inplace".to_owned());
+    }
+
+    // upstream: options.c:2884-2893 - `if (partial_dir && am_sender) {
+    // --partial-dir ... } else if (keep_partial && am_sender) --partial`. There
+    // is no compact 'P'. Bare --partial only when the client is the sender
+    // (`we_are_sender`, a push) and no --partial-dir is configured.
+    if we_are_sender && config.partial() && config.partial_directory().is_none() {
+        args.push("--partial".to_owned());
     }
 
     // upstream: options.c:2630-2631 - `make_backups` rides in the compact
@@ -857,6 +878,74 @@ pub(super) mod tests {
         ];
         strip_client_only_batch_flags(&mut args);
         assert_eq!(args, vec!["--server", "--sender", "."]);
+    }
+}
+
+#[cfg(test)]
+mod server_option_fidelity_tests {
+    use super::build_full_daemon_args;
+    use crate::client::ClientConfig;
+    use crate::client::remote::daemon_transfer::connection::DaemonTransferRequest;
+    use protocol::ProtocolVersion;
+
+    fn request() -> DaemonTransferRequest {
+        DaemonTransferRequest::parse_rsync_url("rsync://host/mod/path").expect("valid rsync url")
+    }
+
+    fn args(config: &ClientConfig, is_sender: bool) -> Vec<String> {
+        build_full_daemon_args(config, &request(), ProtocolVersion::V31, is_sender)
+    }
+
+    // upstream: options.c has no compact 'P'; keep_partial rides long-form.
+    #[test]
+    fn never_packs_compact_p() {
+        let config = ClientConfig::builder().partial(true).build();
+        let flag = args(&config, false)
+            .into_iter()
+            .find(|a| a.starts_with('-') && !a.starts_with("--"))
+            .unwrap_or_default();
+        assert!(!flag.contains('P'), "daemon flag string packed 'P': {flag}");
+    }
+
+    // upstream: options.c:2884-2893 - bare --partial on a PUSH (daemon receiver,
+    // is_sender=false) without --partial-dir; never on a PULL.
+    #[test]
+    fn partial_long_form_on_push_only() {
+        let config = ClientConfig::builder().partial(true).build();
+        let push = args(&config, false);
+        assert!(
+            push.iter().any(|a| a == "--partial"),
+            "push must forward --partial: {push:?}"
+        );
+        let pull = args(&config, true);
+        assert!(
+            !pull.iter().any(|a| a == "--partial"),
+            "pull must not forward --partial: {pull:?}"
+        );
+    }
+
+    // upstream: options.c:2760-2765 - devices-without-specials sends --no-specials.
+    #[test]
+    fn devices_without_specials_emits_no_specials() {
+        let config = ClientConfig::builder().devices(true).build();
+        let a = args(&config, false);
+        assert!(
+            a.iter().any(|x| x == "--no-specials"),
+            "expected --no-specials: {a:?}"
+        );
+        assert!(!a.iter().any(|x| x == "--specials"));
+    }
+
+    // upstream: options.c:2760-2765 - specials-only sends --specials.
+    #[test]
+    fn specials_only_emits_specials() {
+        let config = ClientConfig::builder().specials(true).build();
+        let a = args(&config, false);
+        assert!(
+            a.iter().any(|x| x == "--specials"),
+            "expected --specials: {a:?}"
+        );
+        assert!(!a.iter().any(|x| x == "--no-specials"));
     }
 }
 

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -96,6 +96,13 @@ fn apply_common_daemon_config(
     server_config.flags.numeric_ids = config.numeric_ids();
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
+    // upstream: build_server_flag_string no longer packs the compact 'P' letter,
+    // and 'D' now tracks devices only, so carry keep_partial and specials onto
+    // the local half here (mirrors --partial / --specials|--no-specials which the
+    // wire generator emits long-form).
+    server_config.flags.partial = config.partial();
+    server_config.flags.devices = config.preserve_devices();
+    server_config.flags.specials = config.preserve_specials();
 
     server_config.write.fsync = config.fsync();
     server_config.write.io_uring_policy = config.io_uring_policy();

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -492,6 +492,13 @@ fn build_server_config_for_receiver(
     server_config.flags.numeric_ids = config.numeric_ids();
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
+    // upstream: build_server_flag_string no longer packs the compact 'P' letter,
+    // and 'D' now tracks devices only, so carry keep_partial and specials onto
+    // the local half here (mirrors --partial / --specials|--no-specials which the
+    // wire generator emits long-form).
+    server_config.flags.partial = config.partial();
+    server_config.flags.devices = config.preserve_devices();
+    server_config.flags.specials = config.preserve_specials();
     // upstream flist.c:flist_sort_and_clean prunes empty dirs on the receiver
     // (prune_empty_dirs && !am_sender); on a pull the local client IS the receiver,
     // and -m is never sent over the wire (options.c gates it on am_sender), so the
@@ -526,6 +533,13 @@ fn build_server_config_for_generator(
     server_config.flags.numeric_ids = config.numeric_ids();
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
+    // upstream: build_server_flag_string no longer packs the compact 'P' letter,
+    // and 'D' now tracks devices only, so carry keep_partial and specials onto
+    // the local half here (mirrors --partial / --specials|--no-specials which the
+    // wire generator emits long-form).
+    server_config.flags.partial = config.partial();
+    server_config.flags.devices = config.preserve_devices();
+    server_config.flags.specials = config.preserve_specials();
 
     // upstream: options.c:2476-2501 / main.c:1322-1328 - the local sender
     // resolves a single files-from fd: a local file (Stdin/LocalFile, or a

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -40,7 +40,10 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.preserve_group() {
         flags.push('g');
     }
-    if config.preserve_devices() || config.preserve_specials() {
+    // upstream: options.c:2677-2678 - `if (preserve_devices) argstr[x++] = 'D';
+    // /* ignore preserve_specials here */`. The compact 'D' tracks devices only;
+    // specials ride as long-form --specials/--no-specials on the wire.
+    if config.preserve_devices() {
         flags.push('D');
     }
     if config.preserve_times() {
@@ -112,9 +115,9 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if effective_relative {
         flags.push('R');
     }
-    if config.partial() {
-        flags.push('P');
-    }
+    // upstream: options.c has NO compact 'P' letter. keep_partial rides as the
+    // long-form --partial (daemon: build_full_daemon_args; local ServerConfig:
+    // propagated via server_config.flags.partial in the *_server_config sites).
     // upstream: options.c:2630-2631 - `make_backups` rides in the compact
     // flag string as `b`. Emitting `--backup` as a separate long arg lands
     // as a positional path on upstream server arg parsers that do not
@@ -403,6 +406,35 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
 mod tests {
     use super::*;
     use protocol::filters::RuleType;
+
+    // upstream: options.c has NO compact 'P' letter; keep_partial is conveyed
+    // long-form (--partial) or via propagated ServerConfig.flags.partial.
+    // build_server_flag_string must never pack 'P'.
+    #[test]
+    fn server_flag_string_never_packs_partial_p() {
+        let config = ClientConfig::builder().partial(true).build();
+        let flags = build_server_flag_string(&config);
+        assert!(!flags.contains('P'), "must not pack compact 'P': {flags}");
+    }
+
+    // upstream: options.c:2677-2678 - the compact 'D' tracks preserve_devices
+    // only. specials-only must NOT pack 'D' (it rides as --specials long-form).
+    #[test]
+    fn server_flag_string_specials_only_omits_d() {
+        let config = ClientConfig::builder().specials(true).build();
+        let flags = build_server_flag_string(&config);
+        assert!(
+            !flags.contains('D'),
+            "specials-only must not pack 'D': {flags}"
+        );
+    }
+
+    #[test]
+    fn server_flag_string_devices_packs_d() {
+        let config = ClientConfig::builder().devices(true).build();
+        let flags = build_server_flag_string(&config);
+        assert!(flags.contains('D'), "devices must pack 'D': {flags}");
+    }
 
     #[test]
     fn server_flag_string_includes_recursive() {

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -366,6 +366,18 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(arg);
         }
 
+        // upstream: options.c:2884-2893 - `if (partial_dir && am_sender) {
+        // --partial-dir ... } else if (keep_partial && am_sender) --partial`.
+        // Bare --partial is emitted only when the client is the sender (PUSH)
+        // and no --partial-dir is configured; the partial-dir branch above
+        // already conveys keep_partial otherwise. There is no compact 'P'.
+        if self.role == RemoteRole::Sender
+            && self.config.partial()
+            && self.config.partial_directory().is_none()
+        {
+            args.push(OsString::from("--partial"));
+        }
+
         if let Some(dir) = self.config.temp_directory() {
             let mut arg = OsString::from("--temp-dir=");
             arg.push(dir.as_os_str());
@@ -387,6 +399,20 @@ impl<'a> RemoteInvocationBuilder<'a> {
             }
         }
 
+        // upstream: options.c:2760-2765 - the compact 'D' letter tracks
+        // preserve_devices only (see build_flag_string). specials are conveyed
+        // separately: `if (preserve_devices) { if (!preserve_specials)
+        // --no-specials } else if (preserve_specials) --specials`. Note
+        // --no-specials (not --devices) because sending --devices would not be
+        // backward-compatible; -D already carries devices.
+        if self.config.preserve_devices() {
+            if !self.config.preserve_specials() {
+                args.push(OsString::from("--no-specials"));
+            }
+        } else if self.config.preserve_specials() {
+            args.push(OsString::from("--specials"));
+        }
+
         if self.config.copy_unsafe_links() {
             args.push(OsString::from("--copy-unsafe-links"));
         }
@@ -402,10 +428,11 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--numeric-ids"));
         }
 
-        // upstream: options.c:2889-2890 - --trust-sender forwarded as long-form.
-        if self.config.trust_sender() {
-            args.push(OsString::from("--trust-sender"));
-        }
+        // upstream: options.c:2511 - server_options() NEVER forwards
+        // --trust-sender. `parse_arguments()` only sets the internal
+        // `trust_sender_args`/`trust_sender` locals; the server side always
+        // trusts the client (am_server implies trust), so the flag is not a
+        // wire option. Forwarding it diverged from upstream.
 
         // upstream: options.c:2892-2894 - --checksum-seed=N forwarded so the
         // server uses the same seed for rolling and strong checksum generation.
@@ -502,15 +529,24 @@ impl<'a> RemoteInvocationBuilder<'a> {
             }
         }
 
-        for ref_dir in self.config.reference_directories() {
-            let flag = match ref_dir.kind() {
-                ReferenceDirectoryKind::Compare => "--compare-dest=",
-                ReferenceDirectoryKind::Copy => "--copy-dest=",
-                ReferenceDirectoryKind::Link => "--link-dest=",
-            };
-            let mut arg = OsString::from(flag);
-            arg.push(ref_dir.path().as_os_str());
-            args.push(arg);
+        // upstream: options.c:2911-2934 - the basis-dir args (--compare-dest,
+        // --copy-dest, --link-dest via alt_dest_opt) live entirely inside the
+        // `if (am_sender)` block: "the server only needs this option if it is
+        // not the sender". On a PUSH (local is sender, RemoteRole::Sender) the
+        // remote server is the receiver and needs the basis dirs. On a PULL the
+        // local receiver applies them locally and must NOT forward them, or the
+        // remote sender would link_stat() the flag as a source path.
+        if self.role == RemoteRole::Sender {
+            for ref_dir in self.config.reference_directories() {
+                let flag = match ref_dir.kind() {
+                    ReferenceDirectoryKind::Compare => "--compare-dest=",
+                    ReferenceDirectoryKind::Copy => "--copy-dest=",
+                    ReferenceDirectoryKind::Link => "--link-dest=",
+                };
+                let mut arg = OsString::from(flag);
+                arg.push(ref_dir.path().as_os_str());
+                args.push(arg);
+            }
         }
 
         if self.config.copy_devices() {
@@ -721,9 +757,11 @@ impl<'a> RemoteInvocationBuilder<'a> {
         if self.config.preserve_group() {
             flags.push('g');
         }
-        // upstream: options.c:2677-2678 - preserve_devices (specials handled
-        // via long-form --specials/--no-specials).
-        if self.config.preserve_devices() || self.config.preserve_specials() {
+        // upstream: options.c:2677-2678 - `if (preserve_devices) argstr[x++] =
+        // 'D'; /* ignore preserve_specials here */`. The compact 'D' letter
+        // tracks preserve_devices ONLY; specials ride separately as the
+        // long-form --specials/--no-specials (emitted in append_long_form_args).
+        if self.config.preserve_devices() {
             flags.push('D');
         }
         // upstream: options.c:2679-2680 - preserve_mtimes.
@@ -788,9 +826,10 @@ impl<'a> RemoteInvocationBuilder<'a> {
         if self.config.compress() {
             flags.push('z');
         }
-        if self.config.partial() {
-            flags.push('P');
-        }
+        // upstream: options.c has NO compact 'P' letter for --partial. keep_partial
+        // rides as the long-form --partial (append_long_form_args), gated on
+        // am_sender && !partial_dir (options.c:2884-2893). Packing 'P' here
+        // diverged from every upstream server invocation.
 
         flags
     }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -487,8 +487,10 @@ const UPSTREAM_SERVER_LONG_ARGS: &[&str] = &[
     "--safe-links",
     "--munge-links",
     "--numeric-ids",
-    "--trust-sender",
     "--checksum-seed",
+    "--partial",
+    "--specials",
+    "--no-specials",
     "--size-only",
     "--ignore-existing",
     "--existing",
@@ -823,6 +825,32 @@ fn includes_link_dest_via_reference_directories() {
         args.iter()
             .any(|a| a.to_string_lossy() == "--link-dest=/prev"),
         "expected --link-dest=/prev in args: {args:?}"
+    );
+}
+
+// upstream: options.c:2911-2934 - basis-dir args (--link-dest/--copy-dest/
+// --compare-dest) live inside the `if (am_sender)` block, so they are forwarded
+// only on a PUSH. On a PULL (RemoteRole::Receiver) the local receiver applies
+// them locally and must NOT forward them, or the remote sender would link_stat()
+// the flag as a source path. oc previously forwarded them unconditionally.
+#[test]
+fn reference_directories_not_forwarded_on_pull() {
+    let config = ClientConfig::builder()
+        .link_destination("/prev")
+        .copy_destination("/cpd")
+        .compare_destination("/cmp")
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/path");
+
+    assert!(
+        !args.iter().any(|a| {
+            let s = a.to_string_lossy();
+            s.starts_with("--link-dest")
+                || s.starts_with("--copy-dest")
+                || s.starts_with("--compare-dest")
+        }),
+        "pull must not forward basis-dir args: {args:?}"
     );
 }
 
@@ -1196,13 +1224,35 @@ fn includes_devices_flag() {
     assert!(flags.contains('D'), "expected 'D' in flags: {flags}");
 }
 
+// upstream: options.c:2677-2678 - the compact 'D' letter tracks preserve_devices
+// ONLY. specials-only sends NO 'D'; specials ride as the long-form --specials
+// (options.c:2760-2765). oc previously packed 'D' for specials, diverging.
 #[test]
-fn includes_specials_flag() {
+fn specials_only_emits_long_form_specials_not_compact_d() {
     let config = ClientConfig::builder().specials(true).build();
     let flags = sender_flag_string(&config);
     assert!(
-        flags.contains('D'),
-        "expected 'D' for specials in flags: {flags}"
+        !flags.contains('D'),
+        "specials-only must not pack compact 'D': {flags}"
+    );
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--specials"),
+        "specials-only must emit long-form --specials: {args:?}"
+    );
+}
+
+// upstream: options.c:2677-2678,2760-2765 - devices sets 'D'; when devices are
+// preserved but specials are not, --no-specials is sent (never --devices).
+#[test]
+fn devices_without_specials_emits_d_and_no_specials() {
+    let config = ClientConfig::builder().devices(true).build();
+    let flags = sender_flag_string(&config);
+    assert!(flags.contains('D'), "devices must pack 'D': {flags}");
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--no-specials"),
+        "devices-without-specials must emit --no-specials: {args:?}"
     );
 }
 
@@ -1214,6 +1264,15 @@ fn devices_and_specials_produce_single_d_flag() {
     assert_eq!(
         d_count, 1,
         "devices+specials should produce single 'D', got {d_count} in {flags}"
+    );
+    let args = build_sender_args(&config);
+    // Both preserved: -D carries devices, specials is implied, so neither
+    // --specials nor --no-specials is sent (upstream sends nothing here).
+    assert!(
+        !args
+            .iter()
+            .any(|a| a == "--specials" || a == "--no-specials"),
+        "devices+specials must not emit any specials long-form: {args:?}"
     );
 }
 
@@ -1248,13 +1307,17 @@ fn numeric_ids_is_long_form_not_in_flag_string() {
     );
 }
 
+// upstream: options.c:2511 - server_options() NEVER forwards --trust-sender. It
+// only sets internal trust_sender/trust_sender_args locals; the server always
+// trusts the client (am_server implies trust). oc previously forwarded it,
+// diverging from every upstream server invocation.
 #[test]
-fn includes_trust_sender_long_arg() {
+fn never_forwards_trust_sender_even_when_set() {
     let config = ClientConfig::builder().trust_sender(true).build();
     let args = build_sender_args(&config);
     assert!(
-        args.iter().any(|a| a == "--trust-sender"),
-        "expected --trust-sender in args: {args:?}"
+        !args.iter().any(|a| a == "--trust-sender"),
+        "--trust-sender must never be forwarded to the server: {args:?}"
     );
 }
 
@@ -1318,11 +1381,37 @@ fn includes_relative_paths_flag() {
     assert!(flags.contains('R'), "expected 'R' in flags: {flags}");
 }
 
+// upstream: options.c has NO compact 'P' letter. keep_partial rides as the
+// long-form --partial, emitted only on a PUSH (am_sender) without --partial-dir
+// (options.c:2884-2893). oc previously packed 'P', diverging from upstream.
 #[test]
-fn includes_partial_flag() {
+fn partial_emits_long_form_not_compact_p_on_push() {
     let config = ClientConfig::builder().partial(true).build();
     let flags = sender_flag_string(&config);
-    assert!(flags.contains('P'), "expected 'P' in flags: {flags}");
+    assert!(
+        !flags.contains('P'),
+        "compact 'P' must never be packed: {flags}"
+    );
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--partial"),
+        "push with --partial (no partial-dir) must emit long-form --partial: {args:?}"
+    );
+}
+
+// upstream: options.c:2884-2893 - the whole partial block is gated on am_sender,
+// so a PULL (local is receiver, RemoteRole::Receiver) forwards neither 'P' nor
+// --partial; the local receiver keeps partials itself.
+#[test]
+fn partial_not_forwarded_on_pull() {
+    let config = ClientConfig::builder().partial(true).build();
+    let flags = receiver_flag_string(&config);
+    assert!(!flags.contains('P'), "pull must not pack 'P': {flags}");
+    let args = build_receiver_args(&config);
+    assert!(
+        !args.iter().any(|a| a == "--partial"),
+        "pull must not forward --partial: {args:?}"
+    );
 }
 
 #[test]
@@ -1330,6 +1419,29 @@ fn includes_update_flag() {
     let config = ClientConfig::builder().update(true).build();
     let flags = sender_flag_string(&config);
     assert!(flags.contains('u'), "expected 'u' in flags: {flags}");
+}
+
+// upstream: options.c:2634-2635 - the compact 'n' letter tracks `!do_xfers`,
+// which is set by dry_run ONLY (options.c:2366-2367), never by list_only
+// (the "Note: NOT dry_run!" comment). list_only == 1 packs neither 'n' nor
+// --list-only. Guards against regressing 'n' back onto the list-only path.
+#[test]
+fn list_only_does_not_pack_dry_run_n() {
+    let config = ClientConfig::builder().list_only(true).build();
+    let flags = sender_flag_string(&config);
+    assert!(
+        !flags.contains('n'),
+        "list_only must not pack the dry-run 'n' letter: {flags}"
+    );
+}
+
+// upstream: options.c:2366-2367 - dry_run (and only dry_run) sets do_xfers=0,
+// which packs 'n'. The real dry-run path must be preserved.
+#[test]
+fn dry_run_still_packs_n() {
+    let config = ClientConfig::builder().dry_run(true).build();
+    let flags = sender_flag_string(&config);
+    assert!(flags.contains('n'), "dry_run must pack 'n': {flags}");
 }
 
 #[test]
@@ -1998,16 +2110,28 @@ fn compress_with_level_emits_both_flag_and_level() {
     );
 }
 
+// upstream: options.c:2884-2893 - `if (partial_dir && am_sender) { --partial-dir
+// ... } else if (keep_partial && am_sender) --partial`. With --partial-dir set,
+// the else-if is not taken: --partial-dir is emitted and bare --partial is NOT,
+// and there is never a compact 'P'.
 #[test]
-fn partial_dir_also_emits_partial_flag_string() {
+fn partial_dir_emits_partial_dir_not_compact_p_nor_bare_partial() {
     let config = ClientConfig::builder()
         .partial_directory(Some(".rsync-partial"))
         .build();
     let flags = sender_flag_string(&config);
-    // partial_directory sets partial=true, which should emit 'P' flag
     assert!(
-        flags.contains('P'),
-        "partial_directory should also set 'P' flag: {flags}"
+        !flags.contains('P'),
+        "partial-dir must not pack compact 'P': {flags}"
+    );
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--partial-dir=.rsync-partial"),
+        "expected --partial-dir=.rsync-partial: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--partial"),
+        "bare --partial must not be emitted when --partial-dir is set: {args:?}"
     );
 }
 
@@ -2322,7 +2446,8 @@ fn all_flags_enabled_produces_valid_invocation() {
         ('S', "sparse"),
         ('y', "fuzzy"),
         ('R', "relative_paths"),
-        ('P', "partial"),
+        // upstream: options.c has no compact 'P' letter; --partial rides
+        // long-form (and here --partial-dir is set, so neither is emitted).
         ('b', "backup"),
         ('u', "update"),
         ('N', "crtimes"),
@@ -2350,7 +2475,6 @@ fn all_flags_enabled_produces_valid_invocation() {
         "--delete-excluded",
         "--force",
         "--numeric-ids",
-        "--trust-sender",
         "--checksum-seed=42",
         "--max-delete=50",
         "--max-size=1000000",

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -29,6 +29,13 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
     server_config.flags.numeric_ids = config.numeric_ids();
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
+    // upstream: build_server_flag_string no longer packs the compact 'P' letter,
+    // and 'D' now tracks devices only, so carry keep_partial and specials onto
+    // the local half here (mirrors --partial / --specials|--no-specials which the
+    // wire generator emits long-form).
+    server_config.flags.partial = config.partial();
+    server_config.flags.devices = config.preserve_devices();
+    server_config.flags.specials = config.preserve_specials();
     // upstream flist.c:flist_sort_and_clean prunes empty dirs on the receiver
     // (prune_empty_dirs && !am_sender); on a pull the local client IS the receiver,
     // and -m is never sent over the wire (options.c gates it on am_sender), so the
@@ -74,6 +81,13 @@ pub(in crate::client::remote) fn build_server_config_for_generator(
     server_config.flags.numeric_ids = config.numeric_ids();
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
+    // upstream: build_server_flag_string no longer packs the compact 'P' letter,
+    // and 'D' now tracks devices only, so carry keep_partial and specials onto
+    // the local half here (mirrors --partial / --specials|--no-specials which the
+    // wire generator emits long-form).
+    server_config.flags.partial = config.partial();
+    server_config.flags.devices = config.preserve_devices();
+    server_config.flags.specials = config.preserve_specials();
 
     apply_files_from_for_sender(config, &mut server_config);
 


### PR DESCRIPTION
## Problem

oc-rsync's client-side server-argument generation diverged from upstream rsync's `server_options()` (`options.c`) on several options. The generated `rsync --server ...` argv (SSH) and daemon arg stream therefore differed from real rsync 3.4.4 on every remote transfer using the affected options. Divergences were confirmed empirically by capturing oc's argv and diffing against upstream 3.4.4.

## Fixes (each matched to upstream `options.c:server_options()`)

1. **`--partial`** - upstream has no compact `P` letter; `keep_partial` is emitted as long-form `--partial`, and only on a push (`am_sender`) when no `--partial-dir` is set (`options.c:2884-2893`). oc packed `P`. Now `P` is never packed and `--partial` is emitted under the exact upstream condition, on both the SSH and daemon generators.

2. **`--no-specials` / `--specials`** - the compact `D` letter tracks `preserve_devices` only (`options.c:2677-2678`). Specials ride separately: `--no-specials` when devices-but-not-specials, `--specials` when specials-only (`options.c:2760-2765`). oc packed `D` for specials too and never emitted the long-forms.

3. **`--trust-sender`** - `server_options()` never forwards it (`options.c:2511` only sets internal state; the server always trusts the client). oc forwarded it; now removed.

4. **`--link-dest` / `--copy-dest` / `--compare-dest`** - these live inside the `if (am_sender)` block (`options.c:2911-2934`), so they are forwarded only on a push. On a pull the local receiver applies them locally. oc forwarded them unconditionally, leaking them to the remote sender on pulls. Now gated on push.

5. **`--list-only` / `n`** - the compact `n` letter already tracks dry-run only (never `list_only`); this was already correct on master. Added regression coverage. (The `list_only > 1` long-form `--list-only` emission is not added: oc's config conflates explicit `--list-only` with the implicit single-remote-source listing case, so emitting it on the conflated boolean would introduce a *new* divergence for the implicit case. Left as-is rather than regress.)

6. **`--msgs2stderr` / `q`** - oc does not model `msgs2stderr` or a quiet-to-stderr tri-state at all, so there is nothing to forward. With the default (upstream `msgs2stderr == 2`) upstream also emits neither the flag nor `q`, so oc's current output already matches for the modeled cases. No change.

## Not regressing oc<->oc

Removing the compact `P` letter and making `D` devices-only would drop the signal for (a) the in-process `ServerConfig` and (b) an oc server peer. So `keep_partial` and `specials` are now propagated onto the local `ServerConfig` at the SSH/daemon config sites, and the server-side long-flag parser learns `--partial` / `--specials` / `--no-specials`. This also fixes a latent case where an oc server receiving `--partial` / `--no-specials` from an upstream client previously ignored them.

## Tests

Existing assertions that encoded the old (divergent) behavior were updated to the upstream-correct values (e.g. no compact `P`, no `--trust-sender`, `D` devices-only), and focused tests were added per fix: no `P`/`n` for partial/list-only, `--partial` long-form on push only, no `--trust-sender`, `--no-specials`/`--specials` per condition, basis-dir args absent on a pull, and server-parser round-trips for the new long-forms. Validated with `cargo fmt`, `cargo clippy --all-targets -D warnings` (core + cli), and targeted `nextest`.
