### PR TITLE
feat(metadata): audit-trail unmappable SIDs on Windows DACL apply

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -337,6 +337,28 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
     Ok(())
 }
 
+/// Rewrites Windows native backslash separators to POSIX forward slashes.
+///
+/// upstream: flist.c f_name() emits forward-slash separators regardless of
+/// host OS. The escaped relative path carries native backslashes only on
+/// Windows; other platforms already use forward slashes, so the binding is
+/// returned unchanged.
+#[cfg(windows)]
+fn normalize_progress_separators(mut name: Vec<u8>) -> Vec<u8> {
+    for byte in name.iter_mut() {
+        if *byte == b'\\' {
+            *byte = b'/';
+        }
+    }
+    name
+}
+
+/// Non-Windows paths already use forward-slash separators; returned as-is.
+#[cfg(not(windows))]
+fn normalize_progress_separators(name: Vec<u8>) -> Vec<u8> {
+    name
+}
+
 /// Renders progress lines for the provided transfer events.
 pub(crate) fn emit_progress<W: Write + ?Sized>(
     events: &[ClientEvent],
@@ -374,16 +396,8 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
         xfr_index += 1;
         let remaining = transferred_total - xfr_index;
 
-        // upstream: flist.c f_name() emits POSIX forward-slash separators
-        // regardless of host OS. Normalize Windows native backslashes here.
-        #[cfg_attr(not(windows), allow(unused_mut))]
-        let mut name = escape_path(event.relative_path(), eight_bit_output);
-        #[cfg(windows)]
-        for byte in name.iter_mut() {
-            if *byte == b'\\' {
-                *byte = b'/';
-            }
-        }
+        let name =
+            normalize_progress_separators(escape_path(event.relative_path(), eight_bit_output));
         stdout.write_all(&name)?;
         stdout.write_all(b"\n")?;
 

--- a/crates/metadata/src/acl_windows/common.rs
+++ b/crates/metadata/src/acl_windows/common.rs
@@ -38,6 +38,28 @@ pub(super) fn warn_partial_apply() {
     });
 }
 
+/// Emits a per-file audit record naming the ACL entries whose principal
+/// could not be resolved to a Windows SID during apply.
+///
+/// Unlike [`warn_partial_apply`], this diagnostic is not rate-limited and
+/// names each dropped principal: cross-domain transfers can lose different
+/// entries on different files, and operators need a complete per-file trail
+/// of exactly which entries were discarded rather than a single opaque
+/// warning. Mirrors the spirit of upstream `acls.c`, which warns when an id
+/// cannot be mapped to a destination account.
+pub(super) fn warn_dropped_aces(path: &Path, dropped: &[String]) {
+    if dropped.is_empty() {
+        return;
+    }
+    eprintln!(
+        "warning: {}: ACL entries could not be mapped to Windows SIDs and were dropped \
+         ({} total): {}",
+        path.display(),
+        dropped.len(),
+        dropped.join(", "),
+    );
+}
+
 /// Converts a Rust [`Path`] to a NUL-terminated UTF-16 buffer suitable for
 /// [`windows::core::PCWSTR`] arguments.
 ///

--- a/crates/metadata/src/acl_windows/dacl.rs
+++ b/crates/metadata/src/acl_windows/dacl.rs
@@ -24,7 +24,7 @@ use windows::core::{PCWSTR, PWSTR};
 
 use super::common::{
     OwnedSecurityDescriptor, access_mask_to_rsync_perms, is_unsupported,
-    rsync_perms_to_access_mask, to_wide, warn_partial_apply, win32_error,
+    rsync_perms_to_access_mask, to_wide, warn_dropped_aces, win32_error,
 };
 use crate::AclIdMapper;
 use crate::MetadataError;
@@ -328,32 +328,60 @@ pub(super) fn reconstruct_acl(acl: &RsyncAcl, mode: Option<u32>) -> RsyncAcl {
     result
 }
 
-/// Applies the ACEs in `acl.names` to `path` by building a new DACL with
-/// one access-allowed ACE per resolvable named entry.
+/// A per-file audit record of ACL entries whose principal could not be
+/// resolved to a Windows SID during apply.
 ///
-/// Unmappable ACEs are silently dropped; when no entry survives the
-/// mapping, no DACL is written so the destination retains its inherited
-/// permissions, matching upstream's lossy semantics.
-pub(super) fn apply_rsync_acl_to_path(path: &Path, acl: &RsyncAcl) -> Result<(), MetadataError> {
-    if acl.names.is_empty() {
-        return Ok(());
+/// Cross-domain transfers routinely carry principals with no counterpart on
+/// the destination host. Rather than discarding those entries behind a single
+/// rate-limited warning, each dropped entry is captured with enough identity
+/// (account name plus synthetic uid/gid) to give operators a complete
+/// per-file trail of exactly what was lost.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(super) struct DroppedAces {
+    /// Human-readable identifiers of the dropped entries, in ACL order.
+    pub(super) descriptions: Vec<String>,
+}
+
+impl DroppedAces {
+    /// Returns `true` when no entry was dropped.
+    pub(super) fn is_empty(&self) -> bool {
+        self.descriptions.is_empty()
     }
 
+    /// Records a dropped entry, capturing enough identity to audit the loss.
+    fn record(&mut self, entry: &IdAccess) {
+        let kind = if entry.is_user() { "uid" } else { "gid" };
+        let desc = match entry.name.as_ref() {
+            Some(name) => format!("{} ({kind} {})", String::from_utf8_lossy(name), entry.id),
+            None => format!("{kind} {}", entry.id),
+        };
+        self.descriptions.push(desc);
+    }
+}
+
+/// Resolves each named ACE in `acl` to a Windows SID and access mask.
+///
+/// Entries whose principal cannot be resolved (missing name, non-UTF-8 name,
+/// or an account-name lookup that fails on this host) are not silently
+/// discarded: they are recorded in the returned [`DroppedAces`] so the caller
+/// can emit a per-file audit trail. Zero-permission entries are skipped
+/// without being reported as dropped, mirroring the read-side perms filter.
+pub(super) fn resolve_acl_aces(acl: &RsyncAcl) -> (Vec<Vec<u8>>, Vec<u32>, DroppedAces) {
     let mut sids: Vec<Vec<u8>> = Vec::with_capacity(acl.names.len());
     let mut masks: Vec<u32> = Vec::with_capacity(acl.names.len());
-    let mut dropped = false;
+    let mut dropped = DroppedAces::default();
 
     for entry in acl.names.iter() {
         let Some(name) = entry.name.as_ref() else {
-            dropped = true;
+            dropped.record(entry);
             continue;
         };
         let Ok(name_str) = std::str::from_utf8(name) else {
-            dropped = true;
+            dropped.record(entry);
             continue;
         };
         let Some(sid_buf) = lookup_sid(name_str) else {
-            dropped = true;
+            dropped.record(entry);
             continue;
         };
         let mask = rsync_perms_to_access_mask(entry.permissions() as u8);
@@ -364,8 +392,25 @@ pub(super) fn apply_rsync_acl_to_path(path: &Path, acl: &RsyncAcl) -> Result<(),
         masks.push(mask);
     }
 
-    if dropped {
-        warn_partial_apply();
+    (sids, masks, dropped)
+}
+
+/// Applies the ACEs in `acl.names` to `path` by building a new DACL with
+/// one access-allowed ACE per resolvable named entry.
+///
+/// Unmappable ACEs are dropped and surfaced through a per-file audit
+/// diagnostic naming each lost principal (see [`resolve_acl_aces`]); when no
+/// entry survives the mapping, no DACL is written so the destination retains
+/// its inherited permissions, matching upstream's lossy semantics.
+pub(super) fn apply_rsync_acl_to_path(path: &Path, acl: &RsyncAcl) -> Result<(), MetadataError> {
+    if acl.names.is_empty() {
+        return Ok(());
+    }
+
+    let (sids, masks, dropped) = resolve_acl_aces(acl);
+
+    if !dropped.is_empty() {
+        warn_dropped_aces(path, &dropped.descriptions);
     }
 
     if sids.is_empty() {

--- a/crates/metadata/src/acl_windows/tests/dacl.rs
+++ b/crates/metadata/src/acl_windows/tests/dacl.rs
@@ -95,6 +95,59 @@ fn entries_have_names_helper() {
 
 #[cfg(windows)]
 #[test]
+fn resolve_acl_aces_records_unmappable_sids() {
+    use crate::acl_windows::dacl::resolve_acl_aces;
+
+    // Two drop reasons, both reachable on any Windows host without a live
+    // domain: a named principal that resolves to no local account (standing in
+    // for a foreign-domain SID on a cross-domain transfer, where
+    // LookupAccountNameW fails), and an entry that arrived without a name.
+    let bogus = "oc-rsync-nonexistent-principal-\u{2713}-42"
+        .as_bytes()
+        .to_vec();
+    let mut acl = RsyncAcl::default();
+    acl.names.push(IdAccess::user(7000, 0o4));
+    acl.names.push(IdAccess::group_with_name(4242, 0o5, bogus));
+
+    let (sids, masks, dropped) = resolve_acl_aces(&acl);
+
+    // Nothing mappable survived, so no DACL would be written.
+    assert!(sids.is_empty(), "unmappable entries must not yield SIDs");
+    assert!(masks.is_empty());
+
+    // The dropped entries must be surfaced as a structured audit record rather
+    // than silently swallowed, and must identify each lost principal.
+    assert!(
+        !dropped.is_empty(),
+        "dropped SIDs must be recorded, not silently discarded"
+    );
+    assert_eq!(dropped.descriptions.len(), 2, "both entries recorded");
+    assert!(
+        dropped.descriptions.iter().any(|d| d.contains("uid 7000")),
+        "unnamed entry must be identified: {:?}",
+        dropped.descriptions
+    );
+    assert!(
+        dropped.descriptions.iter().any(|d| d.contains("gid 4242")),
+        "unmappable named entry must be identified: {:?}",
+        dropped.descriptions
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn resolve_acl_aces_no_drops_for_empty_acl() {
+    use crate::acl_windows::dacl::resolve_acl_aces;
+
+    let acl = RsyncAcl::default();
+    let (sids, masks, dropped) = resolve_acl_aces(&acl);
+    assert!(sids.is_empty());
+    assert!(masks.is_empty());
+    assert!(dropped.is_empty(), "no entries means no dropped record");
+}
+
+#[cfg(windows)]
+#[test]
 fn read_dacl_on_temp_file_returns_dacl() {
     use crate::acl_windows::dacl::read_dacl;
 


### PR DESCRIPTION
## Problem

Two Windows-parity issues in the metadata and CLI crates:

1. **DACL apply silently drops unmappable SIDs.** When receiving ACLs on
   Windows, `apply_rsync_acl_to_path` builds a new DACL from the wire ACL's
   named entries. Any entry whose principal cannot be resolved to a Windows
   SID (a foreign-domain account on a cross-domain transfer, a non-UTF-8
   name, or an entry that arrived without a name) was discarded behind at
   most a single rate-limited, generic warning. Operators had no per-file
   record of *which* entries were lost, making cross-domain ACL loss
   effectively invisible.

2. **`cfg` unused-mut cruft.** The progress renderer normalized Windows
   backslash separators to forward slashes using a
   `#[cfg_attr(not(windows), allow(unused_mut))]` attribute on a binding that
   is only mutated on Windows.

## Fix

1. Collect each dropped entry into a structured `DroppedAces` record that
   captures the account name plus synthetic uid/gid, and surface a per-file
   audit diagnostic naming every lost principal. The resolution loop is
   factored into `resolve_acl_aces`, which returns the resolved SIDs/masks
   alongside the dropped-entry record. This mirrors upstream `acls.c`, which
   warns when an id cannot be mapped to a destination account. No wire or
   apply behavior changes: unresolvable entries are still dropped and the
   destination retains its inherited permissions when nothing maps; the loss
   is now recorded instead of swallowed.

2. Replace the `cfg_attr` with a cfg-split `normalize_progress_separators`
   helper so the `mut` binding exists only on the Windows path where it is
   actually used. Behavior is identical on both platforms.

## Validation

- `cargo fmt` and `cargo clippy -p metadata -p cli --all-features -D warnings`
  clean for the changed files on non-Windows. The Windows-only ACL code and
  its new unit tests are exercised by the `windows-acl-xattr` CI job.
- New Windows unit tests assert that both an unmappable named entry and an
  unnamed entry are recorded in the audit trail (not silently discarded) and
  that each lost principal is identified. The tests use a synthetic
  never-resolving account name, so no live domain is required.
