### PR TITLE
fix(transfer): gate device server-args on am_sender direction

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -467,6 +467,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--zero-copy"
             | "--no-zero-copy"
             | "--write-devices"
+            | "--copy-devices"
             | "--trust-sender"
             | "--partial"
             | "--specials"

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -633,6 +633,26 @@ fn long_flags_write_devices() {
     assert!(flags.write_devices);
 }
 
+// upstream: options.c:2987 - a PULL client (upstream or oc) forwards
+// `--copy-devices` to the server sender. The flag-string scanner must treat it
+// as a known long flag; otherwise it leaks into the positional list and becomes
+// a stray source/destination path.
+#[test]
+fn copy_devices_is_known_and_not_positional() {
+    assert!(is_known_server_long_flag("--copy-devices"));
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--sender"),
+        OsString::from("--copy-devices"),
+        OsString::from("-logDtpr"),
+        OsString::from("."),
+        OsString::from("src/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpr");
+    assert_eq!(pos_args, vec![OsString::from("src/")]);
+}
+
 #[test]
 fn long_flags_trust_sender() {
     let args = vec![OsString::from("--server"), OsString::from("--trust-sender")];

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -419,6 +419,23 @@ pub(super) fn build_full_daemon_args(
         args.push("--remove-source-files".to_owned());
     }
 
+    // upstream: options.c:2979 - `if (write_devices && am_sender) args[ac++] =
+    // "--write-devices"`. Forwarded only when the local side is the sender
+    // (`we_are_sender`, a push), so the remote receiver writes into existing
+    // device destinations instead of recreating them with mknod.
+    if config.write_devices() && we_are_sender {
+        args.push("--write-devices".to_owned());
+    }
+
+    // upstream: options.c:2987 - `if (copy_devices && !am_sender) args[ac++] =
+    // "--copy-devices"`. Forwarded only when the local side is the receiver
+    // (a pull, where the daemon is the sender: `is_sender`), so the remote
+    // sender reads device contents as regular file data. `is_sender == !am_sender`
+    // here (see the module note above).
+    if config.copy_devices() && is_sender {
+        args.push("--copy-devices".to_owned());
+    }
+
     // upstream: options.c:2996-2997 - `if (mkpath_dest_arg && am_sender)`.
     // The dest-arg path creation is receiver-side, so forward `--mkpath` only
     // on a push (local client is the sender). `!is_sender` mirrors upstream's
@@ -946,6 +963,40 @@ mod server_option_fidelity_tests {
             "expected --specials: {a:?}"
         );
         assert!(!a.iter().any(|x| x == "--no-specials"));
+    }
+
+    // upstream: options.c:2979 - `if (write_devices && am_sender)`. am_sender is
+    // a PUSH (daemon receiver, is_sender=false); never forwarded on a PULL.
+    #[test]
+    fn write_devices_on_push_only() {
+        let config = ClientConfig::builder().write_devices(true).build();
+        let push = args(&config, false);
+        assert!(
+            push.iter().any(|a| a == "--write-devices"),
+            "push must forward --write-devices: {push:?}"
+        );
+        let pull = args(&config, true);
+        assert!(
+            !pull.iter().any(|a| a == "--write-devices"),
+            "pull must not forward --write-devices: {pull:?}"
+        );
+    }
+
+    // upstream: options.c:2987 - `if (copy_devices && !am_sender)`. !am_sender is
+    // a PULL (daemon sender, is_sender=true); never forwarded on a PUSH.
+    #[test]
+    fn copy_devices_on_pull_only() {
+        let config = ClientConfig::builder().copy_devices(true).build();
+        let pull = args(&config, true);
+        assert!(
+            pull.iter().any(|a| a == "--copy-devices"),
+            "pull must forward --copy-devices: {pull:?}"
+        );
+        let push = args(&config, false);
+        assert!(
+            !push.iter().any(|a| a == "--copy-devices"),
+            "push must not forward --copy-devices: {push:?}"
+        );
     }
 }
 

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -479,6 +479,23 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--no-implied-dirs"));
         }
 
+        // upstream: options.c:2979 - `if (write_devices && am_sender) args[ac++]
+        // = "--write-devices"`. Forwarded only on a PUSH (local process is the
+        // sender), so the remote receiver writes file data into matching device
+        // destinations instead of recreating them with mknod. `RemoteRole::Sender`
+        // is am_sender (see `am_sender` above).
+        if self.config.write_devices() && self.role == RemoteRole::Sender {
+            args.push(OsString::from("--write-devices"));
+        }
+
+        // upstream: options.c:2987 - `if (copy_devices && !am_sender) args[ac++]
+        // = "--copy-devices"`. Forwarded only on a PULL (local process is the
+        // receiver), so the remote sender reads device contents as regular file
+        // data. `RemoteRole::Receiver` is !am_sender (a pull).
+        if self.config.copy_devices() && self.role == RemoteRole::Receiver {
+            args.push(OsString::from("--copy-devices"));
+        }
+
         // upstream: options.c:2825,2852-2853 server_options() - the super flag
         // is forwarded only inside the `if (am_sender)` block (so to a remote
         // receiver), never to a remote sender. `RemoteRole::Receiver` means the
@@ -547,13 +564,6 @@ impl<'a> RemoteInvocationBuilder<'a> {
                 arg.push(ref_dir.path().as_os_str());
                 args.push(arg);
             }
-        }
-
-        if self.config.copy_devices() {
-            args.push(OsString::from("--copy-devices"));
-        }
-        if self.config.write_devices() {
-            args.push(OsString::from("--write-devices"));
         }
 
         if self.config.open_noatime() {

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -875,6 +875,46 @@ fn forwards_fake_super_to_remote_receiver_only() {
 }
 
 #[test]
+fn forwards_write_devices_to_remote_receiver_only() {
+    // upstream: options.c:2979 - `if (write_devices && am_sender) args[ac++] =
+    // "--write-devices"`. am_sender is a PUSH, so the flag reaches the remote
+    // receiver (RemoteRole::Sender) but never a remote sender (a PULL).
+    let config = ClientConfig::builder().write_devices(true).build();
+
+    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    assert!(
+        push.iter().any(|a| a == "--write-devices"),
+        "expected --write-devices forwarded on a push: {push:?}"
+    );
+
+    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
+    assert!(
+        !pull.iter().any(|a| a == "--write-devices"),
+        "did not expect --write-devices forwarded on a pull: {pull:?}"
+    );
+}
+
+#[test]
+fn forwards_copy_devices_to_remote_sender_only() {
+    // upstream: options.c:2987 - `if (copy_devices && !am_sender) args[ac++] =
+    // "--copy-devices"`. !am_sender is a PULL, so the flag reaches the remote
+    // sender (RemoteRole::Receiver) but never a remote receiver (a PUSH).
+    let config = ClientConfig::builder().copy_devices(true).build();
+
+    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
+    assert!(
+        pull.iter().any(|a| a == "--copy-devices"),
+        "expected --copy-devices forwarded on a pull: {pull:?}"
+    );
+
+    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    assert!(
+        !push.iter().any(|a| a == "--copy-devices"),
+        "did not expect --copy-devices forwarded on a push: {push:?}"
+    );
+}
+
+#[test]
 fn includes_delay_updates_long_arg() {
     let config = ClientConfig::builder().delay_updates(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
@@ -1899,16 +1939,6 @@ fn includes_copy_dest_long_arg() {
 }
 
 #[test]
-fn includes_copy_devices_long_arg() {
-    let config = ClientConfig::builder().copy_devices(true).build();
-    let args = build_sender_args(&config);
-    assert!(
-        args.iter().any(|a| a == "--copy-devices"),
-        "expected --copy-devices in args: {args:?}"
-    );
-}
-
-#[test]
 fn includes_write_devices_long_arg() {
     let config = ClientConfig::builder().write_devices(true).build();
     let args = build_sender_args(&config);
@@ -2493,7 +2523,6 @@ fn all_flags_enabled_produces_valid_invocation() {
         "--remove-source-files",
         "--no-implied-dirs",
         "--delay-updates",
-        "--copy-devices",
         "--write-devices",
         "--open-noatime",
         "--preallocate",
@@ -2512,6 +2541,14 @@ fn all_flags_enabled_produces_valid_invocation() {
     assert!(
         !args.iter().any(|a| a == "--fake-super"),
         "all-flags test: --fake-super must not be forwarded to a remote sender: {args:?}"
+    );
+
+    // upstream: options.c:2987 - `if (copy_devices && !am_sender)`. This is a
+    // push (client is the sender), so --copy-devices is a pull-only flag and
+    // must not appear even with copy_devices(true).
+    assert!(
+        !args.iter().any(|a| a == "--copy-devices"),
+        "all-flags test: --copy-devices must not be forwarded on a push: {args:?}"
     );
 
     // upstream: options.c:2802 - explicit zlib is sent as --old-compress


### PR DESCRIPTION
## Problem

`server_options()` in upstream rsync forwards the device options conditionally on transfer direction:

- `options.c:2979` - `if (write_devices && am_sender) args[ac++] = "--write-devices";` (forwarded only when the client is the sender, i.e. a push)
- `options.c:2987` - `if (copy_devices && !am_sender) args[ac++] = "--copy-devices";` (forwarded only when the client is the receiver, i.e. a pull)

The oc client diverged on both remote paths:

- The SSH invocation builder emitted `--copy-devices` and `--write-devices` unconditionally, regardless of direction. On a pull it leaked `--write-devices` to the remote sender; on a push it leaked `--copy-devices` to the remote receiver.
- The daemon argument builder omitted both flags entirely, so device options silently no-oped for an oc<->oc daemon transfer instead of being handled like a real rsync pair.

Additionally, the server-mode flag-string scanner did not list `--copy-devices` as a known long flag. Once the client forwards it, an unrecognised `--copy-devices` would fall through and land in the positional argument list as a stray source/destination path.

## Fix

- Gate `--write-devices` on the sender direction and `--copy-devices` on the receiver direction, matching upstream's `am_sender` conditions, on both the SSH invocation builder and the daemon argument builder.
- Add `--copy-devices` to the server-mode known-long-flag set so a forwarded flag is consumed rather than leaking into positional args. `--write-devices` was already recognised.

Found during a device-option refuse spot-check.

## Tests

- SSH builder: `--write-devices` forwards on a push and not a pull; `--copy-devices` forwards on a pull and not a push.
- Daemon args: same directional assertions.
- Server parser: `--copy-devices` is a known long flag and does not surface as a positional path.
- Updated the existing all-flags push test to assert `--copy-devices` is absent (pull-only), and removed a stale test that asserted the old unconditional behaviour.

Final empirical argv verification against a real upstream binary is planned separately before merge.