### PR TITLE
fix(daemon): keep uid/gid name-list on wire for daemon-forced numeric-ids

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -199,7 +199,7 @@ where
     }
     config.file_selection.ignore_existing = long_flags.ignore_existing;
     config.file_selection.existing_only = long_flags.existing_only;
-    config.flags.numeric_ids = long_flags.numeric_ids;
+    config.flags.numeric_ids = core::server::NumericIds::from_client(long_flags.numeric_ids);
     config.flags.delete = long_flags.delete;
     // upstream: options.c:2964-2965 - `--remove-source-files` is forwarded
     // long-form when the client requested sender-side removal. The flag is

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -93,7 +93,7 @@ fn apply_common_daemon_config(
     server_config.flags.verbose = config.verbosity() > 0;
 
     // upstream: numeric_ids and delete are --numeric-ids / --delete-* long-form args only.
-    server_config.flags.numeric_ids = config.numeric_ids();
+    server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -489,7 +489,7 @@ fn build_server_config_for_receiver(
         ServerConfig::from_flag_string_and_args(ServerRole::Receiver, flag_string, args)
             .map_err(|e| invalid_argument_error(&format!("invalid server config: {e}"), 1))?;
 
-    server_config.flags.numeric_ids = config.numeric_ids();
+    server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,
@@ -530,7 +530,7 @@ fn build_server_config_for_generator(
         ServerConfig::from_flag_string_and_args(ServerRole::Generator, flag_string, args)
             .map_err(|e| invalid_argument_error(&format!("invalid server config: {e}"), 1))?;
 
-    server_config.flags.numeric_ids = config.numeric_ids();
+    server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -26,7 +26,7 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
 
     // Propagate long-form-only flags that aren't part of the compact flag string.
     // upstream: numeric_ids and delete are --numeric-ids / --delete-* long-form args only.
-    server_config.flags.numeric_ids = config.numeric_ids();
+    server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,
@@ -78,7 +78,7 @@ pub(in crate::client::remote) fn build_server_config_for_generator(
 
     // Propagate long-form-only flags that aren't part of the compact flag string.
     // upstream: numeric_ids and delete are --numeric-ids / --delete-* long-form args only.
-    server_config.flags.numeric_ids = config.numeric_ids();
+    server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -72,9 +72,10 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
             "--safe-links" => {
                 config.flags.safe_links = true;
             }
-            // upstream: options.c:2887-2888
+            // upstream: options.c:2887-2888 - an explicit client --numeric-ids
+            // sets `numeric_ids = 1` (drops the wire name-list entirely).
             "--numeric-ids" => {
-                config.flags.numeric_ids = true;
+                config.flags.numeric_ids = core::server::NumericIds::Explicit;
             }
             // upstream: options.c:2890-2891
             "--use-qsort" => {

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -59,28 +59,33 @@ fn clamped_verbose_level(flag_string: &str) -> u8 {
 /// - `ignore errors = yes` forces error-tolerant deletion regardless of the
 ///   client's flags. upstream: clientserver.c:1111-1112 -
 ///   `if (lp_ignore_errors(module_id)) ignore_errors = 1;`.
-/// - `numeric ids = yes` forces `--numeric-ids` for the session. upstream:
+/// - `numeric ids = yes` forces `numeric_ids = -1` for the session. upstream:
 ///   clientserver.c:1201-1204 -
 ///   `if (!numeric_ids && (use_chroot ? lp_numeric_ids(module_id) != False &&
 ///   !*lp_name_converter(module_id) : lp_numeric_ids(module_id) == True))
 ///   numeric_ids = -1;`. The option is forced on only when the client did not
 ///   already request it and, under chroot, only when no `name converter` is
-///   configured (the converter maps names inside the chroot). oc stores
-///   `numeric ids` as a plain bool with no tri-state True/False/Unset, so the
-///   unset and explicit-off cases both read as `false` and never force the
-///   option on; only an explicit `numeric ids = yes` does.
+///   configured (the converter maps names inside the chroot). Upstream sets the
+///   sentinel `-1` (not `1`) so the uid/gid name-list stays on the wire; oc
+///   mirrors that with `NumericIds::DaemonForced`, distinct from the client's
+///   explicit `NumericIds::Explicit` which also drops the wire list.
 fn apply_module_transfer_directives(module: &ModuleDefinition, cfg: &mut ServerConfig) {
     // upstream: clientserver.c:1111-1112
     if module.ignore_errors {
         cfg.deletion.ignore_errors = true;
     }
 
-    // upstream: clientserver.c:1201-1204
-    if !cfg.flags.numeric_ids
+    // upstream: clientserver.c:1201-1204 - force `numeric_ids = -1` (daemon-
+    // forced) when the client did not already pass --numeric-ids and, under
+    // chroot, only when no `name converter` maps names inside the chroot. The
+    // `-1` state suppresses local name resolution but keeps the uid/gid name-
+    // list on the wire (`numeric_ids <= 0`), so a real upstream client whose
+    // own `numeric_ids` is `0` still has its transmitted list consumed.
+    if cfg.flags.numeric_ids.is_off()
         && module.numeric_ids
         && !(module.use_chroot && module.name_converter.is_some())
     {
-        cfg.flags.numeric_ids = true;
+        cfg.flags.numeric_ids = core::server::NumericIds::DaemonForced;
     }
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -3008,19 +3008,52 @@ mod module_access_tests {
     }
 
     // upstream: clientserver.c:1201-1204 - `numeric ids = yes` forces
-    // `--numeric-ids` for the session, except under chroot when a `name
-    // converter` is configured (the converter maps names inside the chroot).
+    // `numeric_ids = -1` for the session (NOT `1`), except under chroot when a
+    // `name converter` is configured (the converter maps names inside the
+    // chroot). The `-1` sentinel is load-bearing: it suppresses local name
+    // resolution but keeps the uid/gid name-list on the wire, so a real
+    // upstream client (whose own `numeric_ids` is `0`) still transmits the
+    // list and the receiver must read it. Collapsing this into the explicit
+    // `1` state (which drops the list) desyncs the receiver: it skips the
+    // name-list read and misreads those bytes as the next NDX. This test pins
+    // the daemon-forced state to `DaemonForced` so a future refactor cannot
+    // silently reintroduce the wire desync.
     #[test]
-    fn module_numeric_ids_forces_config_flag() {
+    fn module_numeric_ids_forces_daemon_forced_state() {
         let module = ModuleDefinition {
             numeric_ids: true,
             use_chroot: false,
             ..Default::default()
         };
         let mut cfg = ServerConfig::default();
-        assert!(!cfg.flags.numeric_ids);
+        assert!(cfg.flags.numeric_ids.is_off());
         apply_module_transfer_directives(&module, &mut cfg);
-        assert!(cfg.flags.numeric_ids);
+        // Daemon-forced, not client-explicit: keeps the wire name-list.
+        assert_eq!(
+            cfg.flags.numeric_ids,
+            core::server::NumericIds::DaemonForced
+        );
+        // Local name resolution is suppressed (numeric owner preserved) ...
+        assert!(cfg.flags.numeric_ids.maps_numeric());
+        // ... but the wire name-list is NOT dropped (upstream `numeric_ids <= 0`).
+        assert!(!cfg.flags.numeric_ids.is_explicit());
+    }
+
+    // A client that explicitly passed --numeric-ids is already in the Explicit
+    // state; the daemon directive must not downgrade it and the wire list stays
+    // dropped (upstream `!numeric_ids` at clientserver.c:1201 is false for `1`).
+    #[test]
+    fn client_explicit_numeric_ids_not_downgraded_by_module() {
+        let module = ModuleDefinition {
+            numeric_ids: true,
+            use_chroot: false,
+            ..Default::default()
+        };
+        let mut cfg = ServerConfig::default();
+        cfg.flags.numeric_ids = core::server::NumericIds::Explicit;
+        apply_module_transfer_directives(&module, &mut cfg);
+        assert_eq!(cfg.flags.numeric_ids, core::server::NumericIds::Explicit);
+        assert!(cfg.flags.numeric_ids.is_explicit());
     }
 
     #[test]
@@ -3035,7 +3068,7 @@ mod module_access_tests {
         };
         let mut cfg = ServerConfig::default();
         apply_module_transfer_directives(&module, &mut cfg);
-        assert!(!cfg.flags.numeric_ids);
+        assert!(cfg.flags.numeric_ids.is_off());
     }
 
     #[test]
@@ -3048,7 +3081,10 @@ mod module_access_tests {
         };
         let mut cfg = ServerConfig::default();
         apply_module_transfer_directives(&module, &mut cfg);
-        assert!(cfg.flags.numeric_ids);
+        assert_eq!(
+            cfg.flags.numeric_ids,
+            core::server::NumericIds::DaemonForced
+        );
     }
 
     #[test]
@@ -3059,7 +3095,7 @@ mod module_access_tests {
         };
         let mut cfg = ServerConfig::default();
         apply_module_transfer_directives(&module, &mut cfg);
-        assert!(!cfg.flags.numeric_ids);
+        assert!(cfg.flags.numeric_ids.is_off());
     }
 }
 

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -7,6 +7,75 @@
 
 use thiserror::Error;
 
+/// Tri-state numeric-ids mode, mirroring upstream's `int numeric_ids`
+/// (`options.c:97`) which carries three values: `0`, `-1`, and `1`.
+///
+/// Upstream folds two independent concerns onto that single integer:
+///
+/// - Wire: the uid/gid name-list is sent and received whenever
+///   `numeric_ids <= 0` (`flist.c:2548` send gate, `uidlist.c:465,473` recv
+///   gate). Only an explicit client `--numeric-ids` (`> 0`) drops the list
+///   from the wire.
+/// - Local: name-based id resolution is suppressed whenever
+///   `numeric_ids != 0` (`flist.c:478` gates `add_uid()` on `!numeric_ids`),
+///   so both the daemon-forced and the explicit states preserve numeric
+///   owner/group without a name lookup.
+///
+/// Collapsing these into one bool (as before) made a daemon module's
+/// `numeric ids = yes` skip the name-list wire read, desyncing against a real
+/// upstream client whose own `numeric_ids` is `0` and therefore still sends the
+/// list. `DaemonForced` restores upstream's `-1` semantics: suppress local
+/// mapping, keep the wire list.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub enum NumericIds {
+    /// `numeric_ids == 0`: names are resolved locally and the uid/gid name-list
+    /// stays on the wire.
+    #[default]
+    Off,
+    /// `numeric_ids == -1`: a daemon module `numeric ids = yes` forced the
+    /// option after the client argv was parsed (`clientserver.c:1201-1204`).
+    /// Local name resolution is suppressed, but the wire name-list is preserved
+    /// so the protocol is not broken for a peer whose own `numeric_ids` is `0`.
+    DaemonForced,
+    /// `numeric_ids > 0`: the client explicitly requested `--numeric-ids`. Both
+    /// local resolution and the wire name-list are dropped.
+    Explicit,
+}
+
+impl NumericIds {
+    /// True when the uid/gid name-list must be dropped from the wire, i.e.
+    /// upstream `numeric_ids > 0`. [`Off`](Self::Off) and
+    /// [`DaemonForced`](Self::DaemonForced) keep the list (`numeric_ids <= 0`).
+    #[must_use]
+    pub const fn is_explicit(self) -> bool {
+        matches!(self, Self::Explicit)
+    }
+
+    /// True when local name resolution is suppressed, i.e. upstream
+    /// `numeric_ids != 0` (both [`DaemonForced`](Self::DaemonForced) and
+    /// [`Explicit`](Self::Explicit)).
+    #[must_use]
+    pub const fn maps_numeric(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
+    /// True when upstream `!numeric_ids` (`numeric_ids == 0`): names are
+    /// resolved and per-entry names are emitted on the wire.
+    #[must_use]
+    pub const fn is_off(self) -> bool {
+        matches!(self, Self::Off)
+    }
+
+    /// Builds the client-side state from a parsed `--numeric-ids` flag: an
+    /// explicit request maps to [`Explicit`](Self::Explicit), its absence to
+    /// [`Off`](Self::Off). Clients never produce [`DaemonForced`](Self::DaemonForced),
+    /// which is set only by the daemon after argv parsing.
+    #[must_use]
+    pub const fn from_client(explicit: bool) -> Self {
+        if explicit { Self::Explicit } else { Self::Off }
+    }
+}
+
 /// Parsed server options decoded from the compact flag string.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct ParsedServerFlags {
@@ -52,11 +121,13 @@ pub struct ParsedServerFlags {
     pub acls: bool,
     /// Preserve extended attributes (`X` flag, `--xattrs`).
     pub xattrs: bool,
-    /// Numeric IDs only (long-form `--numeric-ids`).
+    /// Numeric IDs mode (long-form `--numeric-ids`, or daemon `numeric ids`).
     ///
-    /// Not part of the compact flag string; set via long-form args or explicit
-    /// propagation. In upstream, `'n'` means dry-run, not numeric-ids.
-    pub numeric_ids: bool,
+    /// Not part of the compact flag string; set via long-form args, client
+    /// propagation, or a daemon module directive. In upstream, `'n'` means
+    /// dry-run, not numeric-ids. See [`NumericIds`] for the tri-state that
+    /// separates the wire and local-mapping concerns.
+    pub numeric_ids: NumericIds,
     /// Delete extraneous files (long-form `--delete-*` variants).
     ///
     /// Not part of the compact flag string; set via long-form args or explicit

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -283,7 +283,9 @@ impl GeneratorContext {
         let inc_recurse = self
             .compat_flags
             .is_some_and(|f| f.contains(protocol::CompatibilityFlags::INC_RECURSE));
-        let acl_send_names = inc_recurse && !self.config.flags.numeric_ids;
+        // upstream: acls.c:716 - `if (inc_recurse && !numeric_ids)`; per-entry
+        // ACL names travel only when names are active (`numeric_ids == 0`).
+        let acl_send_names = inc_recurse && self.config.flags.numeric_ids.is_off();
 
         let mut writer = if let Some(flags) = self.compat_flags {
             protocol::flist::FileListWriter::with_compat_flags(self.protocol, flags)

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -260,7 +260,7 @@ impl GeneratorContext {
             // upstream: flist.c:466-470 - add_uid() looks up name for inline
             // sending via XMIT_USER_NAME_FOLLOWS when INC_RECURSE is active.
             // Without names, the receiver can't map uid->name on the remote.
-            if !self.config.flags.numeric_ids {
+            if self.config.flags.numeric_ids.is_off() {
                 if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_user_name_cached(uid) {
                     if let Ok(name) = String::from_utf8(name_bytes) {
                         entry.set_user_name(name);
@@ -276,7 +276,7 @@ impl GeneratorContext {
             entry.set_gid(gid);
             // upstream: flist.c:476-480 - add_gid() looks up name for inline
             // sending via XMIT_GROUP_NAME_FOLLOWS when INC_RECURSE is active.
-            if !self.config.flags.numeric_ids {
+            if self.config.flags.numeric_ids.is_off() {
                 if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_group_name_cached(gid) {
                     if let Ok(name) = String::from_utf8(name_bytes) {
                         entry.set_group_name(name);
@@ -444,7 +444,7 @@ mod fake_super_round_trip_tests {
         };
         config.flags.owner = owner;
         config.flags.group = group;
-        config.flags.numeric_ids = true; // skip uid/gid name lookups in tests
+        config.flags.numeric_ids = crate::NumericIds::Explicit; // skip uid/gid name lookups in tests
         GeneratorContext::new_for_test(&handshake, config)
     }
 
@@ -597,7 +597,7 @@ mod daemon_outgoing_chmod_tests {
             daemon_outgoing_chmod: outgoing_chmod,
             ..Default::default()
         };
-        config.flags.numeric_ids = true;
+        config.flags.numeric_ids = crate::NumericIds::Explicit;
         GeneratorContext::new_for_test(&handshake, config)
     }
 
@@ -941,7 +941,7 @@ mod entry_length_tests {
             args: vec![OsString::from(".")],
             ..Default::default()
         };
-        config.flags.numeric_ids = true;
+        config.flags.numeric_ids = crate::NumericIds::Explicit;
         GeneratorContext::new_for_test(&handshake, config)
     }
 

--- a/crates/transfer/src/generator/file_list/hardlinks.rs
+++ b/crates/transfer/src/generator/file_list/hardlinks.rs
@@ -85,8 +85,10 @@ impl GeneratorContext {
     pub fn collect_id_mappings(&mut self) {
         use metadata::id_lookup::{lookup_group_name_cached, lookup_user_name_cached};
 
-        // Skip if numeric_ids is set - no name mapping needed
-        if self.config.flags.numeric_ids {
+        // upstream: flist.c:478 gates add_uid()/add_gid() on `!numeric_ids`, so
+        // the id-list is populated only when names are active (`numeric_ids ==
+        // 0`). Both daemon-forced and explicit numeric-ids leave it empty.
+        if self.config.flags.numeric_ids.maps_numeric() {
             return;
         }
 

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -64,8 +64,12 @@ impl GeneratorContext {
             .compat_flags
             .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
 
-        // upstream: flist.c:2513-2514
-        if inc_recurse || self.config.flags.numeric_ids {
+        // upstream: flist.c:2548 - `if (numeric_ids <= 0 && !inc_recurse)
+        // send_id_lists(f);`. The list stays on the wire for `numeric_ids <= 0`
+        // (Off and daemon-forced -1); only an explicit client --numeric-ids
+        // (`> 0`) drops it. Under daemon-forced numeric-ids the list is sent but
+        // empty, since add_uid()/add_gid() are gated on `!numeric_ids`.
+        if inc_recurse || self.config.flags.numeric_ids.is_explicit() {
             return Ok(());
         }
 
@@ -101,7 +105,11 @@ impl GeneratorContext {
     pub(crate) fn collect_acl_id_mappings(&mut self) {
         use metadata::id_lookup::{lookup_group_name_cached, lookup_user_name_cached};
 
-        if self.config.flags.numeric_ids || !self.config.flags.acls {
+        // upstream: acls.c:593,595 - `name = numeric_ids ? NULL : add_uid(...)`;
+        // the named-entry id is added (and later mapped) only when names are in
+        // play, i.e. `numeric_ids == 0`. Both daemon-forced and explicit
+        // numeric-ids suppress it (`numeric_ids != 0`).
+        if self.config.flags.numeric_ids.maps_numeric() || !self.config.flags.acls {
             return;
         }
 

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -1,6 +1,6 @@
 //! Tests for the generator module.
 
-use super::super::flags::ParsedServerFlags;
+use super::super::flags::{NumericIds, ParsedServerFlags};
 use super::super::role::ServerRole;
 use super::delta::{
     LARGE_FILE_WARNING_THRESHOLD, script_to_wire_delta, stream_whole_file_transfer,
@@ -1708,7 +1708,7 @@ fn apply_permutation_in_place_single() {
 }
 
 /// Creates test config with specific flags for ID list tests.
-fn config_with_flags(owner: bool, group: bool, numeric_ids: bool) -> ServerConfig {
+fn config_with_flags(owner: bool, group: bool, numeric_ids: NumericIds) -> ServerConfig {
     config_with_role_and_flags(ServerRole::Generator, owner, group, numeric_ids)
 }
 
@@ -1717,7 +1717,7 @@ fn config_with_role_and_flags(
     role: ServerRole,
     owner: bool,
     group: bool,
-    numeric_ids: bool,
+    numeric_ids: NumericIds,
 ) -> ServerConfig {
     ServerConfig {
         role,
@@ -1737,7 +1737,7 @@ fn config_with_role_and_flags(
 #[test]
 fn send_id_lists_skips_when_numeric_ids_true() {
     let handshake = test_handshake();
-    let config = config_with_flags(true, true, true);
+    let config = config_with_flags(true, true, NumericIds::Explicit);
     let ctx = GeneratorContext::new_for_test(&handshake, config);
 
     let mut output = Vec::new();
@@ -1751,7 +1751,7 @@ fn send_id_lists_skips_when_numeric_ids_true() {
 #[test]
 fn send_id_lists_sends_uid_list_when_owner_set() {
     let handshake = test_handshake();
-    let config = config_with_flags(true, false, false);
+    let config = config_with_flags(true, false, NumericIds::Off);
     let ctx = GeneratorContext::new_for_test(&handshake, config);
 
     let mut output = Vec::new();
@@ -1765,7 +1765,7 @@ fn send_id_lists_sends_uid_list_when_owner_set() {
 #[test]
 fn send_id_lists_sends_gid_list_when_group_set() {
     let handshake = test_handshake();
-    let config = config_with_flags(false, true, false);
+    let config = config_with_flags(false, true, NumericIds::Off);
     let ctx = GeneratorContext::new_for_test(&handshake, config);
 
     let mut output = Vec::new();
@@ -1779,7 +1779,7 @@ fn send_id_lists_sends_gid_list_when_group_set() {
 #[test]
 fn send_id_lists_sends_both_when_owner_and_group_set() {
     let handshake = test_handshake();
-    let config = config_with_flags(true, true, false);
+    let config = config_with_flags(true, true, NumericIds::Off);
     let ctx = GeneratorContext::new_for_test(&handshake, config);
 
     let mut output = Vec::new();
@@ -1793,7 +1793,7 @@ fn send_id_lists_sends_both_when_owner_and_group_set() {
 #[test]
 fn send_id_lists_skips_both_when_neither_flag_set() {
     let handshake = test_handshake();
-    let config = config_with_flags(false, false, false);
+    let config = config_with_flags(false, false, NumericIds::Off);
     let ctx = GeneratorContext::new_for_test(&handshake, config);
 
     let mut output = Vec::new();
@@ -1810,7 +1810,7 @@ fn id_lists_round_trip_with_numeric_ids_false() {
     let handshake = test_handshake();
 
     // Generator sends ID lists (numeric_ids=false, owner/group=true)
-    let gen_config = config_with_flags(true, true, false);
+    let gen_config = config_with_flags(true, true, NumericIds::Off);
     let generator = GeneratorContext::new_for_test(&handshake, gen_config);
 
     let mut wire_data = Vec::new();
@@ -1820,7 +1820,7 @@ fn id_lists_round_trip_with_numeric_ids_false() {
     assert_eq!(wire_data, vec![0, 0]);
 
     // Receiver reads ID lists with matching flags
-    let recv_config = config_with_role_and_flags(ServerRole::Receiver, true, true, false);
+    let recv_config = config_with_role_and_flags(ServerRole::Receiver, true, true, NumericIds::Off);
     let mut receiver = ReceiverContext::new_for_test(&handshake, recv_config);
 
     let mut cursor = Cursor::new(&wire_data[..]);
@@ -1837,7 +1837,7 @@ fn id_lists_round_trip_with_numeric_ids_true() {
     let handshake = test_handshake();
 
     // Generator skips ID lists (numeric_ids=true)
-    let gen_config = config_with_flags(true, true, true);
+    let gen_config = config_with_flags(true, true, NumericIds::Explicit);
     let generator = GeneratorContext::new_for_test(&handshake, gen_config);
 
     let mut wire_data = Vec::new();
@@ -1847,7 +1847,8 @@ fn id_lists_round_trip_with_numeric_ids_true() {
     assert!(wire_data.is_empty());
 
     // Receiver also skips reading with matching flags
-    let recv_config = config_with_role_and_flags(ServerRole::Receiver, true, true, true);
+    let recv_config =
+        config_with_role_and_flags(ServerRole::Receiver, true, true, NumericIds::Explicit);
     let mut receiver = ReceiverContext::new_for_test(&handshake, recv_config);
 
     let mut cursor = Cursor::new(&wire_data[..]);
@@ -1855,6 +1856,45 @@ fn id_lists_round_trip_with_numeric_ids_true() {
 
     assert!(result.is_ok());
     assert_eq!(cursor.position(), 0);
+}
+
+/// Daemon-forced numeric-ids (upstream `-1`) keeps the uid/gid name-list on
+/// the wire: the generator still writes the (empty) list terminators and the
+/// receiver still consumes them. This is the sender/receiver mirror of the
+/// `numeric ids = yes` module directive and the exact round-trip that a bool
+/// collapse broke - the sender would send the list while the receiver skipped
+/// it (or vice versa), desyncing the stream.
+///
+/// upstream: flist.c:2548 (send, `numeric_ids <= 0`) and uidlist.c:465,473
+/// (recv, `numeric_ids <= 0`).
+#[test]
+fn id_lists_round_trip_with_daemon_forced_numeric_ids() {
+    use crate::receiver::ReceiverContext;
+
+    let handshake = test_handshake();
+
+    let gen_config = config_with_flags(true, true, NumericIds::DaemonForced);
+    let generator = GeneratorContext::new_for_test(&handshake, gen_config);
+
+    let mut wire_data = Vec::new();
+    generator.send_id_lists(&mut wire_data).unwrap();
+
+    // Daemon-forced still sends both (empty) lists: two varint 0 terminators.
+    assert_eq!(
+        wire_data,
+        vec![0, 0],
+        "daemon-forced numeric-ids must keep the id-list on the wire"
+    );
+
+    let recv_config =
+        config_with_role_and_flags(ServerRole::Receiver, true, true, NumericIds::DaemonForced);
+    let mut receiver = ReceiverContext::new_for_test(&handshake, recv_config);
+
+    let mut cursor = Cursor::new(&wire_data[..]);
+    let result = receiver.receive_id_lists(&mut cursor);
+
+    assert!(result.is_ok());
+    assert_eq!(cursor.position() as usize, wire_data.len());
 }
 
 #[test]

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -169,7 +169,7 @@ pub use self::config::{
     ServerConfigBuilder,
 };
 pub use self::delta_config::DeltaGeneratorConfig;
-pub use self::flags::{InfoFlags, ParseFlagError, ParsedServerFlags};
+pub use self::flags::{InfoFlags, NumericIds, ParseFlagError, ParsedServerFlags};
 pub use self::generator::{
     GeneratorContext, GeneratorStats, generate_delta_from_signature, io_error_flags,
 };

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -100,7 +100,7 @@ impl ReceiverContext {
                         .preserve_group(self.config.flags.group)
                         .preserve_times(self.config.flags.times)
                         .preserve_atimes(self.config.flags.atimes)
-                        .numeric_ids(self.config.flags.numeric_ids)
+                        .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
                         .fake_super(self.config.fake_super);
                     if let Err(error) =
                         apply_symlink_metadata_from_entry(&link_path, entry, &symlink_options)
@@ -215,7 +215,7 @@ impl ReceiverContext {
                 .preserve_group(self.config.flags.group)
                 .preserve_times(self.config.flags.times)
                 .preserve_atimes(self.config.flags.atimes)
-                .numeric_ids(self.config.flags.numeric_ids)
+                .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
                 .fake_super(self.config.fake_super);
             if let Err(error) =
                 apply_symlink_metadata_from_entry(&link_path, entry, &symlink_options)

--- a/crates/transfer/src/receiver/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/file_list/id_lists.rs
@@ -33,8 +33,12 @@ impl ReceiverContext {
     /// - Condition: `(preserve_uid || preserve_acls) && numeric_ids <= 0`
     #[cfg(unix)]
     pub(crate) fn receive_id_lists<R: Read + ?Sized>(&mut self, reader: &mut R) -> io::Result<()> {
-        // upstream: uidlist.c:460 - skip when numeric_ids is set
-        if self.config.flags.numeric_ids {
+        // upstream: uidlist.c:465,473 - the name-list is read for `numeric_ids
+        // <= 0`. Only an explicit client --numeric-ids (`> 0`) skips the read;
+        // daemon-forced numeric-ids (-1) still consumes the list from the wire
+        // (the sender's own numeric_ids may be 0), so guarding on the bare bool
+        // here would misread the list bytes as the next NDX and desync.
+        if self.config.flags.numeric_ids.is_explicit() {
             return Ok(());
         }
 
@@ -89,7 +93,9 @@ impl ReceiverContext {
     /// - Condition: `(preserve_uid || preserve_acls) && numeric_ids <= 0`
     #[cfg(not(unix))]
     pub(crate) fn receive_id_lists<R: Read + ?Sized>(&mut self, reader: &mut R) -> io::Result<()> {
-        if self.config.flags.numeric_ids {
+        // upstream: uidlist.c:465,473 - read for `numeric_ids <= 0`; only an
+        // explicit client --numeric-ids (`> 0`) skips the wire read.
+        if self.config.flags.numeric_ids.is_explicit() {
             return Ok(());
         }
 

--- a/crates/transfer/src/receiver/tests/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/tests/file_list/id_lists.rs
@@ -1,19 +1,26 @@
 //! `ReceiverContext::receive_id_lists` gating: ensures uid/gid lists are
-//! consumed only when the matching server flag is set, and that
-//! `numeric_ids` short-circuits both lists.
+//! consumed only when the matching server flag is set, that an explicit
+//! client `--numeric-ids` short-circuits both lists, and - critically - that
+//! a daemon-forced numeric-ids state still reads the list off the wire.
+//!
+//! upstream: uidlist.c:465,473 - `recv_id_list` runs for `numeric_ids <= 0`
+//! (both Off and the daemon-forced `-1`); only an explicit client
+//! `--numeric-ids` (`> 0`) skips the read.
 
 use std::io::Cursor;
 
 use super::super::super::ReceiverContext;
 use super::super::support::{config_with_flags, test_handshake};
+use crate::flags::NumericIds;
 
 #[test]
-fn receive_id_lists_skips_when_numeric_ids_true() {
+fn receive_id_lists_skips_when_numeric_ids_explicit() {
     let handshake = test_handshake();
-    let config = config_with_flags(true, true, true);
+    let config = config_with_flags(true, true, NumericIds::Explicit);
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    // With numeric_ids=true, no data should be read even with owner/group set
+    // With an explicit client --numeric-ids (upstream `> 0`), no data is read
+    // even with owner/group set: the sender dropped the list from the wire.
     let data: &[u8] = &[];
     let mut cursor = Cursor::new(data);
     let result = ctx.receive_id_lists(&mut cursor);
@@ -23,10 +30,39 @@ fn receive_id_lists_skips_when_numeric_ids_true() {
     assert_eq!(cursor.position(), 0);
 }
 
+/// Regression pin for the daemon numeric-ids wire desync: a daemon module's
+/// `numeric ids = yes` maps to [`NumericIds::DaemonForced`] (upstream `-1`),
+/// which suppresses local name resolution but keeps the uid/gid name-list on
+/// the wire (`numeric_ids <= 0`). The receiver MUST still consume the list; a
+/// prior bool collapse skipped the read and misread the list bytes as the next
+/// NDX, hanging every transfer from a real upstream client (whose own
+/// `numeric_ids` is `0` and therefore sends a populated list).
+///
+/// upstream: uidlist.c:465,473 - `(preserve_uid || preserve_acls) && numeric_ids <= 0`.
+#[test]
+fn receive_id_lists_reads_when_daemon_forced() {
+    let handshake = test_handshake();
+    let config = config_with_flags(true, true, NumericIds::DaemonForced);
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    // Two empty lists (uid + gid): two varint 0 terminators. Under the old bool
+    // behaviour these bytes would be left unread and desync the stream.
+    let data: &[u8] = &[0, 0];
+    let mut cursor = Cursor::new(data);
+    let result = ctx.receive_id_lists(&mut cursor);
+
+    assert!(result.is_ok());
+    assert_eq!(
+        cursor.position(),
+        2,
+        "daemon-forced numeric-ids must still consume both id lists"
+    );
+}
+
 #[test]
 fn receive_id_lists_reads_uid_list_when_owner_set() {
     let handshake = test_handshake();
-    let config = config_with_flags(true, false, false);
+    let config = config_with_flags(true, false, NumericIds::Off);
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
     // Empty UID list: varint 0 terminator only
@@ -41,7 +77,7 @@ fn receive_id_lists_reads_uid_list_when_owner_set() {
 #[test]
 fn receive_id_lists_reads_gid_list_when_group_set() {
     let handshake = test_handshake();
-    let config = config_with_flags(false, true, false);
+    let config = config_with_flags(false, true, NumericIds::Off);
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
     // Empty GID list: varint 0 terminator only
@@ -56,7 +92,7 @@ fn receive_id_lists_reads_gid_list_when_group_set() {
 #[test]
 fn receive_id_lists_reads_both_when_owner_and_group_set() {
     let handshake = test_handshake();
-    let config = config_with_flags(true, true, false);
+    let config = config_with_flags(true, true, NumericIds::Off);
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
     // Both lists: two varint 0 terminators
@@ -71,7 +107,7 @@ fn receive_id_lists_reads_both_when_owner_and_group_set() {
 #[test]
 fn receive_id_lists_skips_both_when_neither_flag_set() {
     let handshake = test_handshake();
-    let config = config_with_flags(false, false, false);
+    let config = config_with_flags(false, false, NumericIds::Off);
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
     let data: &[u8] = &[];

--- a/crates/transfer/src/receiver/tests/file_list/proto_io_error.rs
+++ b/crates/transfer/src/receiver/tests/file_list/proto_io_error.rs
@@ -12,7 +12,7 @@ use protocol::ProtocolVersion;
 use super::super::super::ReceiverContext;
 use super::super::support::test_handshake_with_protocol;
 use crate::config::ServerConfig;
-use crate::flags::ParsedServerFlags;
+use crate::flags::{NumericIds, ParsedServerFlags};
 use crate::role::ServerRole;
 
 /// Verifies that `receive_file_list` reads the 4-byte LE io_error flag
@@ -25,7 +25,7 @@ fn receive_file_list_reads_io_error_for_proto28() {
         protocol: ProtocolVersion::try_from(28u8).unwrap(),
         flag_string: "-logDtpre.".to_owned(),
         flags: ParsedServerFlags {
-            numeric_ids: true,
+            numeric_ids: NumericIds::Explicit,
             ..Default::default()
         },
         args: vec![OsString::from(".")],
@@ -56,7 +56,7 @@ fn receive_file_list_reads_io_error_for_proto29() {
         protocol: ProtocolVersion::try_from(29u8).unwrap(),
         flag_string: "-logDtpre.".to_owned(),
         flags: ParsedServerFlags {
-            numeric_ids: true,
+            numeric_ids: NumericIds::Explicit,
             ..Default::default()
         },
         args: vec![OsString::from(".")],
@@ -84,7 +84,7 @@ fn receive_file_list_skips_io_error_for_proto30() {
         protocol: ProtocolVersion::try_from(30u8).unwrap(),
         flag_string: "-logDtpre.".to_owned(),
         flags: ParsedServerFlags {
-            numeric_ids: true,
+            numeric_ids: NumericIds::Explicit,
             ..Default::default()
         },
         args: vec![OsString::from(".")],
@@ -110,7 +110,7 @@ fn receive_file_list_ignore_errors_suppresses_io_error() {
         protocol: ProtocolVersion::try_from(28u8).unwrap(),
         flag_string: "-logDtpre.".to_owned(),
         flags: ParsedServerFlags {
-            numeric_ids: true,
+            numeric_ids: NumericIds::Explicit,
             ..Default::default()
         },
         deletion: crate::config::DeletionConfig {

--- a/crates/transfer/src/receiver/tests/support.rs
+++ b/crates/transfer/src/receiver/tests/support.rs
@@ -12,7 +12,7 @@ use protocol::flist::FileEntry;
 use protocol::wire::DeltaOp;
 
 use crate::config::ServerConfig;
-use crate::flags::ParsedServerFlags;
+use crate::flags::{NumericIds, ParsedServerFlags};
 use crate::handshake::HandshakeResult;
 use crate::role::ServerRole;
 
@@ -52,7 +52,7 @@ pub(super) fn test_handshake_with_protocol(protocol_version: u8) -> HandshakeRes
 }
 
 /// Builds an id-list test config with the requested owner/group/numeric-ids flags.
-pub(super) fn config_with_flags(owner: bool, group: bool, numeric_ids: bool) -> ServerConfig {
+pub(super) fn config_with_flags(owner: bool, group: bool, numeric_ids: NumericIds) -> ServerConfig {
     ServerConfig {
         role: ServerRole::Receiver,
         protocol: ProtocolVersion::try_from(32u8).unwrap(),

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -162,7 +162,7 @@ impl ReceiverContext {
             .preserve_crtimes(self.config.flags.crtimes)
             .preserve_owner(self.config.flags.owner)
             .preserve_group(self.config.flags.group)
-            .numeric_ids(self.config.flags.numeric_ids)
+            .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
             // upstream: generator.c:1344 - `link_stat(fname, &sx.st,
             // keep_dirlinks && is_dir)` follows a destination symlink-to-dir
             // at stat time instead of rejecting it. The
@@ -728,7 +728,7 @@ impl ReceiverContext {
             self.gid_list.resolved_map(),
             self.config.user_mapping.clone(),
             self.config.group_mapping.clone(),
-            self.config.flags.numeric_ids,
+            self.config.flags.numeric_ids.maps_numeric(),
         )
     }
 
@@ -738,7 +738,7 @@ impl ReceiverContext {
         metadata::AclIdMapper::new(
             self.uid_list.resolved_map(),
             self.gid_list.resolved_map(),
-            self.config.flags.numeric_ids,
+            self.config.flags.numeric_ids.maps_numeric(),
         )
     }
 


### PR DESCRIPTION
## Regression fix: daemon numeric-ids wire desync (interop hang)

A daemon module configured with `numeric ids = yes` receiving from a **real upstream rsync client** desynced and hung the transfer (all `up:*` interop legs, exit 124/12). This regressed daemon-receive whenever the module forces numeric ids.

### Problem

`apply_module_transfer_directives` honored the module directive by setting a plain bool `numeric_ids = true`. oc's receiver skips **reading the uid/gid name-list off the wire** when that bool is set (`receiver/file_list/id_lists.rs`), and the generator skips **sending** it (`generator/protocol_io.rs`).

But upstream's daemon does not set `numeric_ids = 1`. It forces the sentinel `numeric_ids = -1` (clientserver.c:1201-1204), and its send/recv guards are `numeric_ids <= 0` (flist.c:2548 send, uidlist.c:465,473 recv). At `-1` the name-list **stays on the wire** - only local id->name resolution is suppressed. Only an explicit client `--numeric-ids` (`> 0`) removes the list.

oc's bool collapsed upstream's `-1` and `1` into a single value. A real upstream sender (its own `numeric_ids == 0`) therefore still transmitted the name-list, while the oc daemon receiver (bool = true) skipped reading it, misread those bytes as the next NDX, and desynced ("NDX N but expected 1") into a hang.

### Fix

Replace the bool with a tri-state `NumericIds { Off, DaemonForced, Explicit }` mirroring upstream's int `0 / -1 / 1`, and route the two concerns onto distinct predicates:

- **Wire name-list send/recv** guards on `is_explicit()` (upstream `> 0`): only a client `--numeric-ids` drops the list. `Off` and `DaemonForced` keep it on the wire.
- **Local name resolution** and per-entry name/ACL suppression keep upstream's `!= 0` (`maps_numeric()`) and `== 0` (`is_off()`) semantics, so daemon-forced numeric-ids still preserves numeric owner/group without a name lookup.

The daemon directive sets `DaemonForced`; CLI/client `--numeric-ids` sets `Explicit`. The chroot/name-converter conditional from upstream clientserver.c:1201-1204 is preserved.

### Verification (Linux, aarch64, real upstream rsync 3.4.4 client -> oc daemon)

Real upstream `rsync -av` push into an oc daemon module (`use chroot = no`, `read only = no`). Same script and port, buggy master vs this branch:

| Case | Before (master, buggy) | After (this branch) |
|------|------------------------|---------------------|
| `numeric ids = yes` (bare `-av`) | exit 12, "connection unexpectedly closed", dest MISMATCH | exit 0, dest == src |
| `numeric ids = yes` + `--checksum` | (same desync) | exit 0, dest == src |
| `numeric ids = yes` + `--compress` | (same desync) | exit 0, dest == src |
| `numeric ids = yes` + `--whole-file` | (same desync) | exit 0, dest == src |
| `numeric ids = no` | exit 0 | exit 0, dest == src |
| `numeric ids = yes` + client `--numeric-ids` | exit 0 | exit 0, dest == src |

The buggy master build emits the exact protocol desync: `rsync error: error in rsync protocol data stream (code 12) at io.c(232) [sender=3.4.4]` after the file list. This branch completes the transfer.

`numeric ids = yes` feature intact: dest files receive the numeric owner/group (uid:gid `1000:1000` preserved as numbers, not name-mapped).

### Tests

- `receiver` unit test: `DaemonForced` still consumes both id lists off the wire; `Explicit` skips them.
- `generator`+`receiver` round-trip: `DaemonForced` writes and reads the (empty) id-list terminators; `Explicit` writes/reads nothing.
- `daemon` directive tests pin the module directive to `DaemonForced` (not `Explicit`), so a future refactor cannot silently reintroduce the wire skip. Upstream references cited in each test.
