### PR TITLE
fix(receiver): create fifo/device specials on protocol receive

### DIFF
--- a/crates/metadata/src/apply/timestamps.rs
+++ b/crates/metadata/src/apply/timestamps.rs
@@ -284,10 +284,46 @@ pub(super) fn apply_timestamps_from_entry(
     };
 
     if needs_utime {
-        set_file_times(destination, atime, mtime)
-            .map_err(|error| MetadataError::new("preserve timestamps", destination, error))?;
+        set_entry_times(destination, entry, atime, mtime, "preserve timestamps")?;
     }
 
+    Ok(())
+}
+
+/// Applies mtime/atime to a node materialised from a wire `FileEntry`, choosing
+/// an open-free `utimensat` for special files.
+///
+/// filetime's follow variant (`set_file_times`) opens the target with
+/// `File::open` before calling `File::set_times`, which blocks forever on a
+/// FIFO that has no reader/writer peer - exactly the node the protocol receiver
+/// materialises via `create_specials`. Device, FIFO, and socket nodes are never
+/// symlinks, so the `AT_SYMLINK_NOFOLLOW` variant (`set_symlink_file_times`)
+/// sets their times without opening them, matching upstream `set_file_attrs()`
+/// which applies times through `utimensat` on the path and never opens the
+/// target. Tolerable special-file errnos are swallowed as best-effort, mirroring
+/// [`set_timestamp_like`].
+// upstream: rsync.c:set_file_attrs() - utimensat on the path, never opens the node
+fn set_entry_times(
+    destination: &Path,
+    entry: &protocol::flist::FileEntry,
+    atime: FileTime,
+    mtime: FileTime,
+    context: &'static str,
+) -> Result<(), MetadataError> {
+    let is_special = entry.is_device() || entry.is_special();
+    let result = if is_special {
+        set_symlink_file_times(destination, atime, mtime)
+    } else {
+        set_file_times(destination, atime, mtime)
+    };
+
+    if let Err(error) = result {
+        #[cfg(unix)]
+        if is_special && is_tolerable_special_time_error(&error) {
+            return Ok(());
+        }
+        return Err(MetadataError::new(context, destination, error));
+    }
     Ok(())
 }
 
@@ -377,8 +413,7 @@ pub(super) fn apply_atime_only_from_entry(
                 FileTime::from_last_modification_time(&meta)
             }
         };
-        set_file_times(destination, atime, mtime)
-            .map_err(|error| MetadataError::new("preserve access time", destination, error))?;
+        set_entry_times(destination, entry, atime, mtime, "preserve access time")?;
     }
 
     Ok(())
@@ -585,6 +620,51 @@ fn set_crtime(path: &Path, secs: i64) -> Result<(), MetadataError> {
 #[cfg(not(any(target_os = "macos", windows)))]
 fn set_crtime(_path: &Path, _secs: i64) -> Result<(), MetadataError> {
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod fifo_hang_regression {
+    use crate::{MetadataOptions, apply_metadata_from_file_entry, create_fifo_node_from_parts};
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::MetadataExt;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    /// Issue #223: the protocol receiver materialises a FIFO via `create_specials`
+    /// and then applies metadata from the wire `FileEntry`. Timestamp application
+    /// must NOT open the node - `File::open` on a FIFO with no peer blocks
+    /// forever, deadlocking the wire receiver against the sender. The fix routes
+    /// special files through the open-free `utimensat(AT_SYMLINK_NOFOLLOW)`. This
+    /// test runs the apply on a worker thread and fails via timeout if it blocks,
+    /// so a regression surfaces as a fast failure rather than a hung CI job.
+    #[test]
+    fn applying_times_to_fifo_does_not_block_open() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fifo = tmp.path().join("f");
+        create_fifo_node_from_parts(&fifo, 0o644, false, false).expect("create fifo");
+
+        let mut entry = FileEntry::new_fifo("f".into(), 0o644);
+        entry.set_mtime(1_000_000_000, 0);
+        let options = MetadataOptions::new().preserve_times(true);
+
+        let path = fifo.clone();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(apply_metadata_from_file_entry(&path, &entry, &options));
+        });
+
+        let result = rx.recv_timeout(Duration::from_secs(10)).expect(
+            "apply_metadata_from_file_entry must not block opening a FIFO (issue #223 receiver hang)",
+        );
+        result.expect("metadata application should succeed on a fifo");
+
+        let meta = std::fs::symlink_metadata(&fifo).expect("stat fifo");
+        assert_eq!(
+            meta.mtime(),
+            1_000_000_000,
+            "the open-free utimensat path must still set the FIFO's mtime",
+        );
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -249,9 +249,11 @@ pub use mapping_win::{GroupMapping, MappingKind, MappingParseError, NameMapping,
 
 pub use options::{AttrsFlags, MetadataOptions};
 
+#[cfg(unix)]
+pub use special::device_word;
 pub use special::{
-    create_device_node, create_device_node_with_fake_super, create_fifo,
-    create_fifo_with_fake_super,
+    create_device_node, create_device_node_from_parts, create_device_node_with_fake_super,
+    create_fifo, create_fifo_node_from_parts, create_fifo_with_fake_super,
 };
 
 #[cfg(all(feature = "xattr", any(unix, windows)))]

--- a/crates/metadata/src/special.rs
+++ b/crates/metadata/src/special.rs
@@ -82,6 +82,71 @@ pub fn create_device_node_with_fake_super(
     }
 }
 
+/// Creates a FIFO or socket node from wire-protocol components, honouring
+/// `--fake-super`.
+///
+/// The protocol receiver holds only a `FileEntry` from the file list, not an
+/// on-disk [`fs::Metadata`], so it cannot use [`create_fifo_with_fake_super`].
+/// This entry point takes the raw permission bits and a socket/FIFO
+/// discriminator directly, mirroring upstream `generator.c:recv_generator`'s
+/// `FT_SPECIAL` branch, which materialises the node from the flist entry's
+/// mode via `do_mknod()` before any data transfer.
+///
+/// `mode_bits` carries the source permission bits (only the low `0o777` are
+/// honoured). `is_socket` selects a Unix-domain socket node over a FIFO.
+///
+/// # Errors
+///
+/// Returns [`MetadataError`] if the node cannot be created.
+// upstream: generator.c recv_generator FT_SPECIAL -> syscall.c:do_mknod()
+pub fn create_fifo_node_from_parts(
+    destination: &Path,
+    mode_bits: u32,
+    is_socket: bool,
+    fake_super: bool,
+) -> Result<(), MetadataError> {
+    if fake_super {
+        let context = if is_socket {
+            "create socket"
+        } else {
+            "create fifo"
+        };
+        create_fake_super_placeholder(destination, context)
+    } else {
+        create_fifo_parts_inner(destination, mode_bits, is_socket)
+    }
+}
+
+/// Creates a character or block device node from wire-protocol components,
+/// honouring `--fake-super`.
+///
+/// The protocol receiver holds only a `FileEntry` from the file list, so it
+/// supplies the device major/minor pair separately rather than a combined
+/// `dev_t`. Mirrors upstream `generator.c:recv_generator`'s `FT_DEVICE`
+/// branch, which calls `do_mknod()` with the flist entry's mode and rdev.
+///
+/// `is_block` selects a block device over a character device. `mode_bits`
+/// carries the source permission bits (only the low `0o777` are honoured).
+///
+/// # Errors
+///
+/// Returns [`MetadataError`] if the node cannot be created.
+// upstream: generator.c recv_generator FT_DEVICE -> syscall.c:do_mknod()
+pub fn create_device_node_from_parts(
+    destination: &Path,
+    mode_bits: u32,
+    is_block: bool,
+    rdev_major: u32,
+    rdev_minor: u32,
+    fake_super: bool,
+) -> Result<(), MetadataError> {
+    if fake_super {
+        create_fake_super_placeholder(destination, "create device")
+    } else {
+        create_device_parts_inner(destination, mode_bits, is_block, rdev_major, rdev_minor)
+    }
+}
+
 /// Creates an empty 0600 regular file used as a fake-super placeholder.
 ///
 /// Upstream `do_mknod()` performs the equivalent substitution by routing the
@@ -131,10 +196,32 @@ fn apply_placeholder_mode(_open_options: &mut fs::OpenOptions) {
     ))
 ))]
 fn create_fifo_inner(destination: &Path, metadata: &fs::Metadata) -> Result<(), MetadataError> {
-    use nix::sys::stat::{Mode, SFlag, makedev, mknod};
     use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 
     let is_socket = metadata.file_type().is_socket();
+    create_fifo_parts_inner(
+        destination,
+        metadata.permissions().mode() & 0o777,
+        is_socket,
+    )
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos"
+    ))
+))]
+fn create_fifo_parts_inner(
+    destination: &Path,
+    mode_bits: u32,
+    is_socket: bool,
+) -> Result<(), MetadataError> {
+    use nix::sys::stat::{Mode, SFlag, makedev, mknod};
+
     let (kind, context) = if is_socket {
         // Linux defines MKNOD_CREATES_SOCKETS, so upstream materialises socket
         // nodes with mknod(S_IFSOCK) here (the Apple path binds instead).
@@ -143,7 +230,7 @@ fn create_fifo_inner(destination: &Path, metadata: &fs::Metadata) -> Result<(), 
         (SFlag::S_IFIFO, "create fifo")
     };
 
-    let mode_bits = permissions_mode(context, destination, metadata.permissions().mode() & 0o777)?;
+    let mode_bits = permissions_mode(context, destination, mode_bits & 0o777)?;
     let perm = Mode::from_bits_truncate(mode_bits.into());
 
     // `nix::sys::stat::mknod` wraps the libc `mknod` symbol, so an LD_PRELOAD
@@ -165,14 +252,13 @@ fn create_device_node_inner(
     destination: &Path,
     metadata: &fs::Metadata,
 ) -> Result<(), MetadataError> {
-    use nix::sys::stat::{Mode, SFlag, mknod};
     use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 
     let file_type = metadata.file_type();
-    let kind = if file_type.is_char_device() {
-        SFlag::S_IFCHR
+    let is_block = if file_type.is_char_device() {
+        false
     } else if file_type.is_block_device() {
-        SFlag::S_IFBLK
+        true
     } else {
         return Err(MetadataError::new(
             "create device",
@@ -183,13 +269,6 @@ fn create_device_node_inner(
             ),
         ));
     };
-
-    let mode_bits = permissions_mode(
-        "create device",
-        destination,
-        metadata.permissions().mode() & 0o777,
-    )?;
-    let perm = Mode::from_bits_truncate(mode_bits.into());
 
     // The source rdev already encodes major/minor for this platform, so it can
     // be handed straight to mknod (matching upstream do_mknod, which forwards
@@ -203,6 +282,42 @@ fn create_device_node_inner(
         .try_into()
         .map_err(|_| invalid_device_error(destination))?;
 
+    mknod_device_raw(
+        destination,
+        metadata.permissions().mode() & 0o777,
+        is_block,
+        device,
+    )
+}
+
+/// Issues the `mknod(2)` for a character/block device node from a combined
+/// `dev_t`. Shared by the `fs::Metadata` path (source rdev forwarded verbatim)
+/// and the wire-protocol path (major/minor recombined via `makedev`).
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos"
+    ))
+))]
+fn mknod_device_raw(
+    destination: &Path,
+    mode_bits: u32,
+    is_block: bool,
+    device: libc::dev_t,
+) -> Result<(), MetadataError> {
+    use nix::sys::stat::{Mode, SFlag, mknod};
+
+    let kind = if is_block {
+        SFlag::S_IFBLK
+    } else {
+        SFlag::S_IFCHR
+    };
+    let mode_bits = permissions_mode("create device", destination, mode_bits & 0o777)?;
+    let perm = Mode::from_bits_truncate(mode_bits.into());
+
     // `nix::sys::stat::mknod` calls the libc `mknod` symbol rather than issuing
     // the raw `mknod`/`mknodat` syscall that rustix emits. This matters under
     // `fakeroot`/`fakeroot-ng`, which fake privileged operations by
@@ -214,6 +329,76 @@ fn create_device_node_inner(
     // upstream: syscall.c:do_mknod() - libc mknod(), interceptable by fakeroot
     mknod(destination, kind, perm, device)
         .map_err(|error| MetadataError::new("create device", destination, io::Error::from(error)))
+}
+
+/// Materialises a device node from a wire-protocol major/minor pair by
+/// recombining them with `makedev` and delegating to [`mknod_device_raw`].
+///
+/// `makedev(major(x), minor(x)) == x` under the platform's standard `dev_t`
+/// encoding, so this recovers the same device word the sender's `fs::Metadata`
+/// path forwards verbatim.
+#[cfg(unix)]
+fn create_device_parts_inner(
+    destination: &Path,
+    mode_bits: u32,
+    is_block: bool,
+    rdev_major: u32,
+    rdev_minor: u32,
+) -> Result<(), MetadataError> {
+    mknod_device_raw(
+        destination,
+        mode_bits,
+        is_block,
+        combine_dev(rdev_major, rdev_minor),
+    )
+}
+
+/// Recombines a device major/minor pair into the platform `dev_t` word.
+///
+/// `nix::sys::stat::makedev` is Linux-only, so this goes through the
+/// cross-platform `libc::makedev` (a safe `const fn` on every unix target),
+/// keeping `#![deny(unsafe_code)]` intact while supporting Apple/BSD.
+// upstream: syscall.c:do_mknod() forwards `makedev(major, minor)` verbatim.
+#[cfg(all(
+    unix,
+    any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos"
+    )
+))]
+#[must_use]
+fn combine_dev(rdev_major: u32, rdev_minor: u32) -> libc::dev_t {
+    libc::makedev(rdev_major as i32, rdev_minor as i32)
+}
+
+/// Recombines a device major/minor pair into the platform `dev_t` word.
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos"
+    ))
+))]
+#[must_use]
+fn combine_dev(rdev_major: u32, rdev_minor: u32) -> libc::dev_t {
+    libc::makedev(rdev_major as libc::c_uint, rdev_minor as libc::c_uint)
+}
+
+/// Recombines a device major/minor pair into the platform `dev_t` word,
+/// widened to `u64` for direct comparison against
+/// `std::os::unix::fs::MetadataExt::rdev`.
+///
+/// Lets a caller quick-check whether an existing on-disk device node already
+/// carries the wire entry's rdev without depending on `nix`/`libc` itself,
+/// keeping `#![deny(unsafe_code)]` crates free of raw device-number math.
+#[cfg(unix)]
+#[must_use]
+pub fn device_word(rdev_major: u32, rdev_minor: u32) -> u64 {
+    combine_dev(rdev_major, rdev_minor) as u64
 }
 
 #[cfg(all(
@@ -229,13 +414,34 @@ fn create_fifo_inner(destination: &Path, metadata: &fs::Metadata) -> Result<(), 
     use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 
     let is_socket = metadata.file_type().is_socket();
+    create_fifo_parts_inner(
+        destination,
+        metadata.permissions().mode() & 0o777,
+        is_socket,
+    )
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos"
+    )
+))]
+fn create_fifo_parts_inner(
+    destination: &Path,
+    mode_bits: u32,
+    is_socket: bool,
+) -> Result<(), MetadataError> {
     let context = if is_socket {
         "create socket"
     } else {
         "create fifo"
     };
 
-    let mode_bits = permissions_mode(context, destination, metadata.permissions().mode() & 0o777)?;
+    let mode_bits = permissions_mode(context, destination, mode_bits & 0o777)?;
 
     if is_socket {
         create_socket_via_bind(context, destination, mode_bits)
@@ -340,10 +546,10 @@ fn create_device_node_inner(
     use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 
     let file_type = metadata.file_type();
-    let type_bits: libc::mode_t = if file_type.is_char_device() {
-        libc::S_IFCHR
+    let is_block = if file_type.is_char_device() {
+        false
     } else if file_type.is_block_device() {
-        libc::S_IFBLK
+        true
     } else {
         return Err(MetadataError::new(
             "create device",
@@ -355,14 +561,6 @@ fn create_device_node_inner(
         ));
     };
 
-    let perm_bits = permissions_mode(
-        "create device",
-        destination,
-        metadata.permissions().mode() & 0o777,
-    )?;
-    // As above, `libc::mode_t` is a `u16` alias on Apple targets,
-    // so this is an infallible cast and cannot overflow.
-    let permissions: libc::mode_t = perm_bits as libc::mode_t;
     // try_into guards narrow-dev_t targets; on Linux dev_t is u64 so the
     // conversion is a no-op there, which clippy would otherwise flag.
     #[allow(clippy::useless_conversion)]
@@ -370,6 +568,43 @@ fn create_device_node_inner(
         .rdev()
         .try_into()
         .map_err(|_| invalid_device_error(destination))?;
+
+    mknod_device_raw(
+        destination,
+        metadata.permissions().mode() & 0o777,
+        is_block,
+        device,
+    )
+}
+
+/// Issues the Apple `mknod(2)` for a character/block device node from a
+/// combined `dev_t`. Shared by the `fs::Metadata` path (source rdev forwarded
+/// verbatim) and the wire-protocol path (major/minor recombined via `makedev`).
+#[cfg(all(
+    unix,
+    any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos"
+    )
+))]
+fn mknod_device_raw(
+    destination: &Path,
+    mode_bits: u32,
+    is_block: bool,
+    device: libc::dev_t,
+) -> Result<(), MetadataError> {
+    let type_bits: libc::mode_t = if is_block {
+        libc::S_IFBLK
+    } else {
+        libc::S_IFCHR
+    };
+
+    let perm_bits = permissions_mode("create device", destination, mode_bits & 0o777)?;
+    // As above, `libc::mode_t` is a `u16` alias on Apple targets,
+    // so this is an infallible cast and cannot overflow.
+    let permissions: libc::mode_t = perm_bits as libc::mode_t;
     let mode = type_bits | permissions;
 
     apple_fs::mknod(destination, mode, device)
@@ -403,6 +638,28 @@ pub(crate) fn format_skip_special_message(destination: &Path, kind_label: &'stat
 #[cfg(not(unix))]
 fn create_fifo_inner(destination: &Path, _metadata: &fs::Metadata) -> Result<(), MetadataError> {
     warn_skip_special(destination, "fifo entry");
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_fifo_parts_inner(
+    destination: &Path,
+    _mode_bits: u32,
+    _is_socket: bool,
+) -> Result<(), MetadataError> {
+    warn_skip_special(destination, "fifo entry");
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_device_parts_inner(
+    destination: &Path,
+    _mode_bits: u32,
+    _is_block: bool,
+    _rdev_major: u32,
+    _rdev_minor: u32,
+) -> Result<(), MetadataError> {
+    warn_skip_special(destination, "device entry");
     Ok(())
 }
 

--- a/crates/transfer/src/receiver/directory/mod.rs
+++ b/crates/transfer/src/receiver/directory/mod.rs
@@ -1,13 +1,16 @@
-//! Directory, symlink, and hardlink creation; extraneous file deletion.
+//! Directory, symlink, special-file, and hardlink creation; extraneous file
+//! deletion.
 //!
 //! Handles filesystem mutations driven by the received file list, including
-//! directory creation (batch and incremental), symlink creation, hardlink
-//! creation for both protocol 30+ and pre-30 modes, and `--delete` scanning.
+//! directory creation (batch and incremental), symlink creation, special-file
+//! creation (FIFOs, sockets, and device nodes), hardlink creation for both
+//! protocol 30+ and pre-30 modes, and `--delete` scanning.
 
 mod creation;
 mod deletion;
 mod links;
 mod missing_args;
+mod special;
 
 /// Normalizes a filename for cross-platform comparison.
 ///

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -1,0 +1,234 @@
+//! Special-file (FIFO, socket, device node) creation from the received file list.
+//!
+//! The protocol receiver materialises FIFOs, Unix-domain sockets, and
+//! character/block device nodes named in the file list, gated on the
+//! transfer's `--specials` / `--devices` flags. Without this pass the receiver
+//! silently drops every special entry: the flist carries them, but only
+//! regular files, directories, and symlinks reach disk, so a
+//! `rsync -a remote:src/ dst/` pull (or a push to an oc-rsync daemon) loses
+//! fifos and devices with no error and a zero exit.
+//!
+//! Runs as a first pass alongside `create_symlinks`, before the per-file data
+//! loop, mirroring upstream's generator which materialises the node from the
+//! flist entry rather than transferring any payload.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:1627-1692` recv_generator - `FT_DEVICE` (when
+//!   `preserve_devices`) and `FT_SPECIAL` (when `preserve_specials`) call
+//!   `atomic_create` -> `do_mknod_at` to create the node from the flist entry.
+//! - `syscall.c:do_mknod()` - the underlying `mknod(2)` (or fake-super
+//!   placeholder) that materialises the node.
+
+#[cfg(unix)]
+use std::fs;
+use std::path::Path;
+
+#[cfg(unix)]
+use logging::{debug_log, info_log};
+#[cfg(unix)]
+use metadata::{
+    MetadataOptions, apply_metadata_from_file_entry, create_device_node_from_parts,
+    create_fifo_node_from_parts,
+};
+#[cfg(unix)]
+use protocol::flist::{FileEntry, FileType};
+
+#[cfg(unix)]
+use crate::generator::ItemFlags;
+use crate::receiver::ReceiverContext;
+
+impl ReceiverContext {
+    /// Creates FIFO, socket, and device nodes from the file list entries.
+    ///
+    /// Devices are gated on `--devices`, FIFOs and sockets on `--specials`
+    /// (matching upstream's `preserve_devices` / `preserve_specials`). An
+    /// existing node of the same type - and, for devices, the same rdev - is
+    /// left in place and only refreshed; any other obstacle is removed so the
+    /// fresh node can be created. Fake-super substitutes a `0600` placeholder
+    /// for the node, mirroring `syscall.c:do_mknod()`'s `am_root < 0` branch.
+    ///
+    /// A per-entry creation failure is logged and skipped rather than aborting
+    /// the transfer, mirroring upstream's `do_mknod` failure path which records
+    /// an I/O error and continues with the next entry.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1627` - `if (preserve_devices && IS_DEVICE(file->mode))`
+    /// - `generator.c:1663` - `atomic_create(file, fname, NULL, ...)`
+    #[cfg(unix)]
+    pub(in crate::receiver) fn create_specials<W: crate::writer::MsgInfoSender + ?Sized>(
+        &self,
+        dest_dir: &Path,
+        sandbox: Option<&fast_io::DirSandbox>,
+        writer: &mut W,
+    ) -> std::io::Result<()> {
+        if self.config.flags.skip_dest_writes()
+            || (!self.config.flags.devices && !self.config.flags.specials)
+        {
+            return Ok(());
+        }
+
+        for entry in &self.file_list {
+            let is_device = entry.is_device();
+            let is_special = entry.is_special();
+            if is_device {
+                if !self.config.flags.devices {
+                    continue;
+                }
+            } else if is_special {
+                if !self.config.flags.specials {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+
+            let relative_path = entry.path();
+            let node_path = dest_dir.join(relative_path);
+
+            // Ensure parent directory exists for --relative paths.
+            // upstream: generator.c:1317-1326 make_path() for relative_paths
+            if let Some(parent) = node_path.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+
+            // upstream: generator.c:1651-1670 - an existing node of the same
+            // type (and, for devices, the same rdev) is treated as up-to-date;
+            // only its metadata is refreshed.
+            let up_to_date = existing_special_matches(&node_path, entry, is_device);
+
+            if !up_to_date {
+                // SEC-1.g: route the obstacle unlink through the sandbox dirfd
+                // when the destination parent is the sandbox root so a TOCTOU
+                // swap between the stat above and this unlink cannot redirect
+                // the syscall. Falls back to path-based removal otherwise. The
+                // result is intentionally ignored: the receiver may attempt but
+                // is not required to succeed at obstacle removal (a dangling
+                // obstacle simply surfaces as a create failure below).
+                let _ = fast_io::unlink_via_sandbox_or_fallback(
+                    sandbox,
+                    dest_dir,
+                    relative_path,
+                    &node_path,
+                    fast_io::UnlinkFlags::File,
+                );
+
+                // upstream: generator.c:1663 atomic_create -> do_mknod_at
+                let create_result = if is_device {
+                    create_device_node_from_parts(
+                        &node_path,
+                        entry.mode() & 0o7777,
+                        entry.is_block_device(),
+                        entry.rdev_major().unwrap_or(0),
+                        entry.rdev_minor().unwrap_or(0),
+                        self.config.fake_super,
+                    )
+                } else {
+                    create_fifo_node_from_parts(
+                        &node_path,
+                        entry.mode() & 0o7777,
+                        entry.file_type() == FileType::Socket,
+                        self.config.fake_super,
+                    )
+                };
+                if let Err(error) = create_result {
+                    // upstream: generator.c do_mknod failure - rsyserr() then
+                    // io_error |= IOERR_GENERAL and continue with the next
+                    // entry rather than aborting the whole transfer.
+                    debug_log!(
+                        Recv,
+                        1,
+                        "failed to create special file {}: {}",
+                        node_path.display(),
+                        error
+                    );
+                    continue;
+                }
+            }
+
+            // upstream: generator.c:1672 set_file_attrs(fname, file, ...) runs
+            // for both the freshly-created and up-to-date branches so the node
+            // carries the sender-supplied perms/owner/times.
+            let options = MetadataOptions::new()
+                .preserve_permissions(self.config.flags.perms)
+                .preserve_owner(self.config.flags.owner)
+                .preserve_group(self.config.flags.group)
+                .preserve_times(self.config.flags.times)
+                .preserve_atimes(self.config.flags.atimes)
+                .preserve_crtimes(self.config.flags.crtimes)
+                .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
+                .fake_super(self.config.fake_super);
+            if let Err(error) = apply_metadata_from_file_entry(&node_path, entry, &options) {
+                debug_log!(
+                    Recv,
+                    1,
+                    "failed to apply metadata for special file {}: {}",
+                    node_path.display(),
+                    error
+                );
+            }
+
+            if up_to_date {
+                // upstream: generator.c:1133 - "%s is uptodate" at INFO_GTE(NAME, 2)
+                let iflags = ItemFlags::from_raw(0);
+                let _ = self.emit_itemize(writer, &iflags, entry);
+                info_log!(Name, 2, "{} is uptodate", relative_path.display());
+            } else {
+                // upstream: generator.c:1462 itemize() sets ITEM_IS_NEW when the
+                // receiver newly materialises the node via do_mknod().
+                let iflags =
+                    ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+                let _ = self.emit_itemize(writer, &iflags, entry);
+            }
+        }
+        Ok(())
+    }
+
+    /// No-op on non-Unix platforms where FIFOs, sockets, and device nodes are
+    /// not supported. Mirrors the WIND-2 skip-with-warn contract used elsewhere
+    /// for special files the Windows receiver cannot materialise.
+    #[cfg(not(unix))]
+    pub(in crate::receiver) fn create_specials<W: crate::writer::MsgInfoSender + ?Sized>(
+        &self,
+        _dest_dir: &Path,
+        _writer: &mut W,
+    ) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Returns `true` when an on-disk node at `path` already matches the wire
+/// entry: same node type, and for devices the same rdev. Any read failure
+/// (including a missing path) reports `false` so the caller (re)creates it.
+///
+/// upstream: generator.c:1651-1670 - the receiver's quick-check leaves a
+/// matching special/device node in place instead of recreating it.
+#[cfg(unix)]
+fn existing_special_matches(path: &Path, entry: &FileEntry, is_device: bool) -> bool {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    let meta = match fs::symlink_metadata(path) {
+        Ok(meta) => meta,
+        Err(_) => return false,
+    };
+    let file_type = meta.file_type();
+
+    if is_device {
+        let type_ok = if entry.is_block_device() {
+            file_type.is_block_device()
+        } else {
+            file_type.is_char_device()
+        };
+        type_ok
+            && meta.rdev()
+                == metadata::device_word(
+                    entry.rdev_major().unwrap_or(0),
+                    entry.rdev_minor().unwrap_or(0),
+                )
+    } else if entry.file_type() == FileType::Socket {
+        file_type.is_socket()
+    } else {
+        file_type.is_fifo()
+    }
+}

--- a/crates/transfer/src/receiver/tests/create_specials.rs
+++ b/crates/transfer/src/receiver/tests/create_specials.rs
@@ -1,0 +1,159 @@
+//! Regression tests for `ReceiverContext::create_specials`.
+//!
+//! Issue #223: the protocol wire receiver silently dropped FIFO and device
+//! entries. The flist carried them (the daemon logged "built file list with N
+//! entries"), but the receiver only materialised regular files, directories,
+//! and symlinks, so a `rsync -a remote:src/ dst/` pull - or a push to an
+//! oc-rsync daemon - lost every special with exit 0 and no error. These tests
+//! pin the fix: a FIFO and a device entry in the file list must be created on
+//! disk, gated on `--specials` / `--devices`, matching upstream
+//! `generator.c:recv_generator`'s `FT_SPECIAL` / `FT_DEVICE` branches.
+
+use std::io::{self, Write};
+
+use protocol::ProtocolVersion;
+use protocol::flist::FileEntry;
+
+use super::super::ReceiverContext;
+use super::support::test_handshake;
+use crate::config::ServerConfig;
+use crate::flags::ParsedServerFlags;
+use crate::role::ServerRole;
+use crate::writer::MsgInfoSender;
+
+/// Sink that captures emitted MSG_INFO frames without touching the daemon
+/// multiplex layer.
+struct CapturingMsgInfoWriter;
+
+impl Write for CapturingMsgInfoWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl MsgInfoSender for CapturingMsgInfoWriter {
+    fn send_msg_info(&mut self, _data: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Builds a receiver config that mirrors what an SSH/daemon receiver sees for
+/// `rsync -aD`: `-D` implies both `--devices` and `--specials`, plus the
+/// archive metadata flags. Individual flags are overridden per-test.
+fn special_receiver_config() -> ServerConfig {
+    ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        flags: ParsedServerFlags {
+            devices: true,
+            specials: true,
+            perms: true,
+            ..Default::default()
+        },
+        args: vec![std::ffi::OsString::from(".")],
+        ..Default::default()
+    }
+}
+
+/// upstream: generator.c:1663 - `FT_SPECIAL` entries are materialised via
+/// `atomic_create -> do_mknod_at`. Without `create_specials` the receiver
+/// dropped the FIFO entirely; this test fails (dest is empty) on the pre-fix
+/// receiver and passes once the node is created.
+#[test]
+fn receiver_creates_fifo_from_flist_entry() {
+    use std::os::unix::fs::FileTypeExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, special_receiver_config());
+    ctx.file_list = vec![FileEntry::new_fifo("pipe".into(), 0o640)];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_specials(dest, None, &mut writer)
+        .expect("create_specials must succeed on a writable tempdir");
+
+    let meta = std::fs::symlink_metadata(dest.join("pipe"))
+        .expect("the FIFO entry must be materialised, not silently dropped (#223)");
+    assert!(
+        meta.file_type().is_fifo(),
+        "the receiver must create a FIFO node for an FT_SPECIAL flist entry",
+    );
+}
+
+/// A character-device entry must be recreated with its wire rdev. Devices are
+/// gated on `--devices`; upstream also requires super-user, which the metadata
+/// layer's fake-super path handles when unprivileged. This test only runs when
+/// the process can actually create a device node (root), degrading gracefully
+/// otherwise so CI on unprivileged runners stays green.
+///
+/// upstream: generator.c:1627 - `FT_DEVICE` entries are created via do_mknod().
+#[test]
+fn receiver_creates_char_device_from_flist_entry() {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    // Pre-check privilege: attempt a throwaway mknod via the same helper the
+    // receiver uses. If it fails (unprivileged, common on CI), skip the
+    // assertion rather than falsely fail - the FIFO test already covers the
+    // dispatch wiring on every runner.
+    let probe = dest.join(".probe");
+    let can_mknod =
+        metadata::create_device_node_from_parts(&probe, 0o600, false, 1, 3, false).is_ok();
+    let _ = std::fs::remove_file(&probe);
+    if !can_mknod {
+        return;
+    }
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, special_receiver_config());
+    ctx.file_list = vec![FileEntry::new_char_device("nulllike".into(), 0o600, 1, 3)];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_specials(dest, None, &mut writer)
+        .expect("create_specials must succeed");
+
+    let meta = std::fs::symlink_metadata(dest.join("nulllike"))
+        .expect("the device entry must be materialised, not silently dropped (#223)");
+    assert!(
+        meta.file_type().is_char_device(),
+        "the receiver must create a character device for an FT_DEVICE flist entry",
+    );
+    assert_eq!(
+        meta.rdev(),
+        metadata::device_word(1, 3),
+        "the created device must carry the wire entry's rdev (major=1, minor=3)",
+    );
+}
+
+/// Without `--specials` the receiver must not create a FIFO - the entry is left
+/// absent, matching upstream where `preserve_specials` gates FT_SPECIAL
+/// creation. This guards against the fix over-creating specials.
+#[test]
+fn receiver_skips_fifo_without_specials_flag() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    let mut config = special_receiver_config();
+    config.flags.specials = false;
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.file_list = vec![FileEntry::new_fifo("pipe".into(), 0o640)];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_specials(dest, None, &mut writer)
+        .expect("create_specials must succeed");
+
+    assert!(
+        std::fs::symlink_metadata(dest.join("pipe")).is_err(),
+        "without --specials the receiver must not materialise the FIFO",
+    );
+}

--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -15,6 +15,8 @@
 //!   propagation, legacy goodbye handling, input-multiplex activation,
 //!   daemon filter set, and path-traversal rejection.
 
+#[cfg(unix)]
+mod create_specials;
 mod delta_apply;
 mod errors_and_timeouts;
 mod file_list;

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -55,6 +55,10 @@ impl ReceiverContext {
         self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
         #[cfg(not(unix))]
         self.create_symlinks(&setup.dest_dir, writer)?;
+        #[cfg(unix)]
+        self.create_specials(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        #[cfg(not(unix))]
+        self.create_specials(&setup.dest_dir, writer)?;
 
         // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
         // deletes the destination path and skips any creation for the sentinel.

--- a/crates/transfer/src/receiver/transfer/pipelined_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_async.rs
@@ -96,6 +96,10 @@ impl ReceiverContext {
         self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
         #[cfg(not(unix))]
         self.create_symlinks(&setup.dest_dir, writer)?;
+        #[cfg(unix)]
+        self.create_specials(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        #[cfg(not(unix))]
+        self.create_specials(&setup.dest_dir, writer)?;
 
         // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
         // deletes the destination path and skips any creation for the sentinel.

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -92,6 +92,10 @@ impl ReceiverContext {
         self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
         #[cfg(not(unix))]
         self.create_symlinks(&setup.dest_dir, writer)?;
+        #[cfg(unix)]
+        self.create_specials(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        #[cfg(not(unix))]
+        self.create_specials(&setup.dest_dir, writer)?;
 
         // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
         // deletes the destination path and skips any creation for the sentinel.

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
@@ -118,6 +118,10 @@ impl ReceiverContext {
         self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
         #[cfg(not(unix))]
         self.create_symlinks(&setup.dest_dir, writer)?;
+        #[cfg(unix)]
+        self.create_specials(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        #[cfg(not(unix))]
+        self.create_specials(&setup.dest_dir, writer)?;
 
         // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
         // deletes the destination path and skips any creation for the sentinel.

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -80,6 +80,10 @@ impl ReceiverContext {
         self.create_symlinks(&dest_dir, sandbox.as_deref(), writer)?;
         #[cfg(not(unix))]
         self.create_symlinks(&dest_dir, writer)?;
+        #[cfg(unix)]
+        self.create_specials(&dest_dir, sandbox.as_deref(), writer)?;
+        #[cfg(not(unix))]
+        self.create_specials(&dest_dir, writer)?;
 
         // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
         // deletes the destination path and skips any creation for the sentinel.

--- a/crates/transfer/src/receiver/transfer/sync_async.rs
+++ b/crates/transfer/src/receiver/transfer/sync_async.rs
@@ -119,6 +119,10 @@ impl ReceiverContext {
         self.create_symlinks(&dest_dir, sandbox.as_deref(), writer)?;
         #[cfg(not(unix))]
         self.create_symlinks(&dest_dir, writer)?;
+        #[cfg(unix)]
+        self.create_specials(&dest_dir, sandbox.as_deref(), writer)?;
+        #[cfg(not(unix))]
+        self.create_specials(&dest_dir, writer)?;
 
         // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
         // deletes the destination path and skips any creation for the sentinel.


### PR DESCRIPTION
## Problem (HIGH - silent data loss / hang)

The protocol **wire receiver** did not materialise FIFO, socket, or device entries from a remote sender. The file list carried them, but only regular files, directories, and symlinks reached disk, so a pull from a remote (`rsync -a remote:src/ dst/`) - or a push to an oc-rsync daemon - lost every special file. oc-as-sender and oc local-copy created specials correctly; only the protocol receiver diverged.

## Fix (two parts)

**1. Wire special-file creation into the receiver.** Added a `create_specials` first pass alongside `create_symlinks`, mirroring upstream `generator.c` `recv_generator`: `FT_SPECIAL` (fifo/socket) nodes are created when `--specials` is set and `FT_DEVICE` (char/block) nodes when `--devices` is set, via `do_mknod` before any data transfer. The metadata mknod logic is centralised behind two part-based entry points (`create_fifo_node_from_parts` / `create_device_node_from_parts`) the receiver calls from a wire `FileEntry`; `--fake-super` is honoured. Existing matching nodes are left in place; other obstacles are removed first.

**2. Apply special-file timestamps without opening the node.** The receiver applies metadata from the wire `FileEntry` after creating the node. `apply_timestamps_from_entry` used filetime's follow variant (`set_file_times`), which opens the target with `File::open` before setting times. **Opening a FIFO with no reader/writer peer blocks forever**, deadlocking the wire receiver against the sender - the node was created on disk but the transfer hung. Fixed by routing device/fifo/socket entries through the open-free `utimensat(AT_SYMLINK_NOFOLLOW)` variant, mirroring `set_timestamp_like` (the `fs::Metadata` path already guarded for local-copy) and upstream `set_file_attrs`, which applies times on the path and never opens the node.

## Evidence (per systematic debugging)

Reproduced on Linux: upstream `rsync 3.4.4 -av` via `lsh` -> oc server-receiver. Round-trip unit test proved the wire **decode** preserves type + rdev (fifo -> `is_special`, cdev/bdev -> device with rdev). Instrumenting `create_specials` showed the entry was correctly typed (`myfifo mode=010664 is_special=true`) and the pass ran with `devices=true specials=true` - the node **was** created. `strace` then pinpointed the real defect: after `mknod`/`chown`/`chmod`, oc issued `openat("...fifo", O_RDONLY)` which blocked (ERESTARTSYS), while the sender waited on `ppoll` - a deadlock. That open was the timestamp follow-path; part 2 removes it.

## Re-verification (Linux, as root)

Upstream `rsync -av` of a tree containing a FIFO, char device (1,3), block device (7,0), a symlink, and a regular file:

- **SSH (lsh) -> oc receiver:** exit 0, dst has `p myfifo`, `c 1,3 cdev`, `b 7,0 bdev`, symlink, regular - matches the up->up control exactly.
- **upstream push -> oc daemon** (use chroot=no): exit 0, module has all specials (symlink carries the expected `/rsyncd-munged/` prefix from the non-chroot daemon default).

Both previously hung / dropped; both now recreate every special end-to-end.

## Tests

Receiver `create_specials` tests (fifo created; char device recreated with wire rdev; not created without `--specials`) plus a watchdog-timed metadata regression that applying times to a real FIFO does not block on open. `cargo fmt` / `clippy --all-features -D warnings` clean on transfer, engine, metadata.
