### PR TITLE
fix(compress): explicit-choice vstring desync and all-literal pipeline deadlock

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -400,6 +400,21 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // negotiator's checksum_override; without this the choice is silently
     // dropped at protocol >= 30 (binary negotiation).
     server_config.checksum_choice = config.checksum_protocol_override();
+    // upstream: compat.c:543-544 - `if (do_compression && !compress_choice)`
+    // gates the compression vstring list, so an explicit --compress-choice (also
+    // its --new-compress/--old-compress aliases) sets compress_choice and
+    // suppresses the list. Carry that explicit choice onto the local half here so
+    // the client-sender's TransferConfig has connection.compress_choice = Some(..)
+    // and transfer/src/lib.rs's send_compression gate stays false; without this
+    // the client sent an extra vstring the peer never expected and desynced the
+    // stream. Non-explicit `-z`/`-zz` leaves compress_choice None (vstring
+    // negotiation), matching the daemon-push path in daemon_transfer.
+    if config.explicit_compress_choice()
+        && let Ok(algo) =
+            protocol::CompressionAlgorithm::parse(config.compression_algorithm().name())
+    {
+        server_config.connection.compress_choice = Some(algo);
+    }
 }
 
 #[cfg(test)]
@@ -557,6 +572,38 @@ mod tests {
         let mut server_config = ServerConfig::default();
         apply_common_server_flags(&config, &mut server_config);
         assert_eq!(server_config.connection.compression_threads, None);
+    }
+
+    #[test]
+    fn apply_common_server_flags_wires_explicit_compress_choice() {
+        // upstream: compat.c:543-544 - an explicit --compress-choice sets
+        // compress_choice, which suppresses the compression vstring list. Carry
+        // it onto the local half so the client-sender's send_compression gate
+        // (transfer/src/lib.rs: do_compression && compress_choice.is_none())
+        // stays false and no stray vstring desyncs the stream.
+        let config = ClientConfig::builder()
+            .compress(true)
+            .compression_algorithm(compress::algorithm::CompressionAlgorithm::Zlib)
+            .build();
+        assert!(config.explicit_compress_choice());
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert_eq!(
+            server_config.connection.compress_choice,
+            Some(protocol::CompressionAlgorithm::Zlib),
+            "explicit --compress-choice must land on connection.compress_choice"
+        );
+    }
+
+    #[test]
+    fn apply_common_server_flags_default_compress_leaves_choice_none() {
+        // Plain `-z` (no explicit choice) must leave compress_choice None so the
+        // sender still negotiates via the vstring list, matching upstream.
+        let config = ClientConfig::builder().compress(true).build();
+        assert!(!config.explicit_compress_choice());
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert_eq!(server_config.connection.compress_choice, None);
     }
 
     #[test]

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -192,7 +192,7 @@ pub(in crate::disk_commit) fn process_file(
                 bytes_written += data.len() as u64;
                 // Return the buffer for reuse. Ignore errors - the network
                 // thread may have moved on (e.g. after an error).
-                let _ = buf_return_tx.send(data);
+                let _ = buf_return_tx.try_send(data);
             }
             FileMessage::Commit => {
                 // upstream: fileio.c:43 sparse_end() - flush the trailing hole
@@ -379,7 +379,7 @@ pub(in crate::disk_commit) fn process_whole_file(
         None
     };
 
-    let _ = buf_return_tx.send(data);
+    let _ = buf_return_tx.try_send(data);
 
     output.flush_and_sync(config.do_fsync, &begin.file_path)?;
     output.finish(config.do_fsync, &begin.file_path)?;
@@ -454,7 +454,7 @@ fn discard_file_on_open_failure(
         match file_rx.recv() {
             Ok(FileMessage::Chunk(data)) => {
                 // Recycle the buffer for the network thread; drop the bytes.
-                let _ = buf_return_tx.send(data);
+                let _ = buf_return_tx.try_send(data);
             }
             Ok(FileMessage::Commit) => {
                 return Err(open_err);

--- a/crates/transfer/src/pipeline/spsc.rs
+++ b/crates/transfer/src/pipeline/spsc.rs
@@ -86,6 +86,21 @@ impl<T> Sender<T> {
         }
     }
 
+    /// Attempts to send `item` without spin-waiting.
+    ///
+    /// Returns `Err(SendError(item))` immediately if the queue is full or the
+    /// receiver has been dropped, instead of spinning like [`send`](Self::send).
+    /// This is the non-blocking analog used for the buffer-return path, where
+    /// `item` is only a recycling spare (never live data): if the ring is full,
+    /// the returned buffer is simply dropped and the consumer allocates a fresh
+    /// one. Never use this for data-carrying channels.
+    pub fn try_send(&self, item: T) -> Result<(), SendError<T>> {
+        if !self.0.consumer_alive.load(Ordering::Relaxed) {
+            return Err(SendError(item));
+        }
+        self.0.queue.push(item).map_err(SendError)
+    }
+
     /// Returns `true` if the receiver has been dropped.
     #[cfg(test)]
     pub fn is_disconnected(&self) -> bool {
@@ -268,6 +283,31 @@ mod tests {
         tx.send(3).unwrap();
         let received = drain.join().unwrap();
         assert_eq!(received, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn try_send_full_ring_does_not_block() {
+        // A full ring must reject immediately (returning the item) rather than
+        // spin-wait. This is the property the disk thread's buffer-return path
+        // relies on to avoid deadlocking when the network thread never drains
+        // the return ring (compressed all-literal streams never recycle).
+        let (tx, rx) = channel::<i32>(2);
+        assert!(tx.try_send(1).is_ok());
+        assert!(tx.try_send(2).is_ok());
+        // Ring is full: try_send returns the rejected item instead of blocking.
+        let SendError(rejected) = tx.try_send(3).expect_err("full ring must reject");
+        assert_eq!(rejected, 3);
+        // Draining a slot lets the next try_send succeed.
+        assert_eq!(rx.recv().unwrap(), 1);
+        assert!(tx.try_send(3).is_ok());
+    }
+
+    #[test]
+    fn try_send_disconnected_returns_item() {
+        let (tx, rx) = channel::<i32>(4);
+        drop(rx);
+        let SendError(item) = tx.try_send(7).expect_err("disconnected must reject");
+        assert_eq!(item, 7);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes two root-caused, independently serious compression bugs, each diagnosed with lxhost wire evidence. One commit per bug.

### Bug 1 - client-sender desyncs with explicit `--compress-choice` (commit 1)

An oc client-sender launched with an explicit `--compress-choice` (zlib / zlibx / zstd - all affected), or the `--new-compress` / `--old-compress` aliases, sent an extra compression vstring list during negotiation that the peer never expected, desyncing the stream.

Upstream gates the vstring list on `if (do_compression && !compress_choice)` (`compat.c:544`): an explicit choice sends **no** list. oc has the equivalent gate in `transfer/src/lib.rs` (`send_compression = do_compression && compress_choice.is_none()`), but the client path never populated `connection.compress_choice`, so the gate evaluated to `true` and emitted the stray vstring.

Fix: carry the explicit choice onto the local `ServerConfig` in `apply_common_server_flags` (shared by SSH push/pull; idempotent with the daemon-push path that already sets it), right next to the existing `checksum_choice` wiring. Non-explicit `-z` / `-zz` still leaves `compress_choice` `None` so vstring negotiation proceeds unchanged. Matches `compat.c:543-544`.

lxhost evidence: oc-sender with explicit `--compress-choice` emitted an extra vstring, desyncing the stream against an upstream receiver.

### Bug 2 - receiver hangs on compressed all-literal streams (commit 2)

oc's network to disk lock-free SPSC pipeline deadlocked on compressed all-literal files past ~256 decompressed chunks.

The disk thread returned every written buffer via a **blocking** `buf_return_tx.send()`. The network thread only drains the return ring via `recycle_or_alloc`, which the compressed-literal path never calls: `literal_to_buf`'s `LiteralData::Ready(data)` arm returns the decoder-owned `Vec` directly (unlike the plain `Pending` and `BlockRef` arms that recycle). The return ring (cap 256) filled, the disk thread spun on `send()`, the network thread filled `file_tx` (cap 128) and spun too - a mutual spin-deadlock. The file never committed and the sender waited forever.

Fix: add a non-blocking `Sender::try_send` to the SPSC channel and use it at the three buffer-return sites in `disk_commit/process/file_ops.rs`. Buffer recycling is purely an allocation optimization (upstream `token.c:284` reuses one static buffer and never blocks returning it); dropping a returned spare when the ring is full is safe because `recycle_or_alloc` uses a non-blocking `try_recv` and falls back to a fresh allocation. Buffers are returned only after being written to disk, so the dropped item is never live data. The data-carrying channels (`file_tx`, etc.) are untouched.

lxhost evidence: an upstream sender pushing a >4 MB `-z` all-literal file to an oc receiver hung indefinitely; the file never committed.

## Tests

- `apply_common_server_flags_wires_explicit_compress_choice` - explicit choice lands on `connection.compress_choice` (so no stray vstring).
- `apply_common_server_flags_default_compress_leaves_choice_none` - plain `-z` keeps `None` for vstring negotiation.
- `try_send_full_ring_does_not_block` / `try_send_disconnected_returns_item` - a full/disconnected ring rejects immediately instead of spinning, the property the disk thread relies on.

The >4 MB `-z` transfer on lxhost (up-sender to oc-receiver, no hang; oc-sender `--compress-choice` to upstream, exit 0) is the end-to-end seal and runs separately before merge.

## Validation

- `cargo fmt -p transfer -p core -p cli` clean
- `cargo clippy -p transfer -p core -p cli --all-features --no-deps -- -D warnings` - no issues
