### PR TITLE
fix(daemon): frame read-only/write-only rejection to avoid desync

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -101,6 +101,12 @@ use self::help::help_text;
 
 /// Exit code used when daemon functionality is unavailable.
 pub(crate) const FEATURE_UNAVAILABLE_EXIT_CODE: i32 = 1;
+/// Exit code for a usage/syntax error, mirroring upstream `RERR_SYNTAX`.
+///
+/// upstream: errcode.h:25 - `#define RERR_SYNTAX 1`. The daemon's read-only
+/// push and write-only pull rejections call `exit_cleanup(RERR_SYNTAX)`
+/// (main.c:934, main.c:1167).
+pub(crate) const RERR_SYNTAX_EXIT_CODE: i32 = 1;
 /// Exit code returned when socket I/O fails.
 const SOCKET_IO_EXIT_CODE: i32 = 10;
 
@@ -181,12 +187,17 @@ pub(crate) const INVALID_UID_PAYLOAD: &str = "@ERROR: invalid uid {uid}";
 pub(crate) const INVALID_GID_PAYLOAD: &str = "@ERROR: invalid gid {gid}";
 /// Error payload returned when a module is read-only and the client pushes.
 ///
-/// upstream: clientserver.c (implied by lp_read_only check)
-pub(crate) const MODULE_READ_ONLY_PAYLOAD: &str = "@ERROR: module is read only";
+/// upstream: main.c:1167 `do_server_recv()` - `rprintf(FERROR, "ERROR:
+/// module is read only\n")`. This fires after `setup_protocol()` and
+/// `io_start_multiplex_out()`, so the text is a plain `FERROR` message (no
+/// `@ERROR:` greeting prefix) delivered inside a `MSG_ERROR_XFER` frame.
+pub(crate) const MODULE_READ_ONLY_PAYLOAD: &str = "ERROR: module is read only";
 /// Error payload returned when a module is write-only and the client pulls.
 ///
-/// upstream: clientserver.c (implied by lp_write_only check)
-pub(crate) const MODULE_WRITE_ONLY_PAYLOAD: &str = "@ERROR: module is write only";
+/// upstream: main.c:935 `do_server_sender()` - `rprintf(FERROR, "ERROR:
+/// module is write only\n")`, delivered post-multiplex like the read-only
+/// rejection above.
+pub(crate) const MODULE_WRITE_ONLY_PAYLOAD: &str = "ERROR: module is write only";
 mod module_state;
 #[cfg(test)]
 use self::module_state::TEST_CONFIG_CANDIDATES;

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -241,6 +241,35 @@ fn handle_refused_option_post_handshake(
     Ok(())
 }
 
+/// Rejects a post-`@RSYNCD: OK` access-mode violation - a push to a
+/// `read only` module or a pull from a `write only` module - through the
+/// multiplexed error path.
+///
+/// upstream: main.c:1166-1169 `do_server_recv()` rejects a read-only push
+/// with `rprintf(FERROR, "ERROR: module is read only\n")` then
+/// `exit_cleanup(RERR_SYNTAX)`; main.c:934-936 `do_server_sender()` rejects a
+/// write-only pull the same way. Both fire after `setup_protocol()` and
+/// `io_start_multiplex_out()`, so the message travels as a `MSG_ERROR_XFER`
+/// frame followed by `MSG_ERROR_EXIT`. Emitting the raw text with
+/// [`send_error`] instead desynchronises the client's multiplex decoder
+/// (issue #227): the client reads the plaintext line as a 4-byte frame
+/// header and aborts with `invalid multi-message 102 (code 12)` rather than
+/// the clean `ERROR: module is read only` + exit 1 upstream produces.
+fn handle_access_denied_post_handshake(
+    ctx: &mut ModuleRequestContext<'_>,
+    payload: &str,
+    protocol_version: Option<ProtocolVersion>,
+    client_args: &[String],
+) -> io::Result<()> {
+    finalize_post_ok_protocol_for_error(ctx, protocol_version, client_args)?;
+    send_multiplexed_error_and_exit(
+        ctx.reader.get_mut(),
+        ctx.limiter,
+        payload,
+        RERR_SYNTAX_EXIT_CODE,
+    )
+}
+
 /// Mirrors the prefix of upstream's `setup_protocol(f_out, f_in)` that the
 /// daemon writes before turning on `io_start_multiplex_out()` for an error
 /// it needs to deliver after `@RSYNCD: OK`.

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -137,10 +137,22 @@ fn process_approved_module(
     }
 
     // Enforce read-only / write-only access restrictions.
-    // upstream: clientserver.c:rsync_module() - after reading args, check
-    // am_sender against lp_read_only(i) and lp_write_only(i).
-    // When --sender is absent the client is pushing (server = Receiver).
-    // A read-only module must reject pushes; a write-only module must reject pulls.
+    // upstream: main.c:1166-1169 `do_server_recv()` rejects a read-only push
+    // and main.c:934-936 `do_server_sender()` rejects a write-only pull, both
+    // via `rprintf(FERROR, "ERROR: module is ...\n")` + `exit_cleanup(
+    // RERR_SYNTAX)`. When --sender is absent the client is pushing (server =
+    // Receiver); a read-only module must reject pushes and a write-only module
+    // must reject pulls.
+    //
+    // Both upstream checks fire after `setup_protocol()` and
+    // `io_start_multiplex_out()`, so the error must be framed as
+    // `MSG_ERROR_XFER` + `MSG_ERROR_EXIT` rather than written as a raw line.
+    // The `@RSYNCD: OK` acknowledgement already flipped the client to
+    // multiplexed input; a raw `ERROR: ...\n` line would be decoded as a
+    // 4-byte frame header and desync the stream (issue #227:
+    // `invalid multi-message 102 (code 12)`).
+    // `handle_access_denied_post_handshake` finishes the post-OK protocol
+    // setup, then emits the framed error and exit code.
     //
     // upstream: clientserver.c:760 seeds `read_only = lp_read_only(module_id)`;
     // auth_server() (authenticate.c:340-343) then overrides it from the
@@ -151,20 +163,20 @@ fn process_approved_module(
     let role = determine_server_role(&client_args);
     let effective_read_only = access_effective_read_only(module.read_only, auth_access_level);
     if effective_read_only && matches!(role, ServerRole::Receiver) {
-        send_error(
-            ctx.reader.get_mut(),
-            ctx.limiter,
+        return handle_access_denied_post_handshake(
+            ctx,
             MODULE_READ_ONLY_PAYLOAD,
-        )?;
-        return Ok(());
+            negotiated_protocol,
+            &client_args,
+        );
     }
     if module.write_only && matches!(role, ServerRole::Generator) {
-        send_error(
-            ctx.reader.get_mut(),
-            ctx.limiter,
+        return handle_access_denied_post_handshake(
+            ctx,
             MODULE_WRITE_ONLY_PAYLOAD,
-        )?;
-        return Ok(());
+            negotiated_protocol,
+            &client_args,
+        );
     }
 
     if !validate_module_path(ctx, module)? {

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -28,6 +28,7 @@ use crate::daemon::{
     ModuleRuntime,
     // From sections/cli_args.rs
     ProgramName,
+    RERR_SYNTAX_EXIT_CODE,
     // From runtime_options.rs
     RuntimeOptions,
     TestSecretsEnvOverride,

--- a/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
+++ b/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
@@ -81,14 +81,17 @@ fn daemon_error_payloads_match_upstream_wording() {
         "@ERROR: invalid gid {gid}",
     );
 
-    // upstream: clientserver.c - module access mode restrictions
+    // upstream: main.c:1167 / main.c:935 - the read-only push and write-only
+    // pull rejections fire post-multiplex via `rprintf(FERROR, "ERROR: module
+    // is ...\n")`, so the payload carries a plain `ERROR:` prefix (no
+    // `@ERROR:` greeting form) and travels inside a `MSG_ERROR_XFER` frame.
     assert_eq!(
         crate::daemon::MODULE_READ_ONLY_PAYLOAD,
-        "@ERROR: module is read only",
+        "ERROR: module is read only",
     );
     assert_eq!(
         crate::daemon::MODULE_WRITE_ONLY_PAYLOAD,
-        "@ERROR: module is write only",
+        "ERROR: module is write only",
     );
 }
 

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
@@ -66,18 +66,11 @@ fn run_daemon_rejects_push_to_default_read_only_module() {
         .expect("send client args");
     stream.flush().expect("flush client args");
 
-    // upstream: clientserver.c - daemon rejects with
-    // "@ERROR: module is read only"
-    line.clear();
-    reader.read_line(&mut line).expect("error message");
-    assert_eq!(line.trim_end(), "@ERROR: module is read only");
-
-    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
-    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
-    // the refusal; the socket just closes (next read is EOF).
-    line.clear();
-    let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    // #227: the default `read only = true` push rejection is post-`@RSYNCD:
+    // OK`, so it must be framed as MSG_ERROR_XFER + MSG_ERROR_EXIT rather than
+    // written as a raw line. Shared decoder mirrors upstream
+    // `do_server_recv()` (main.c:1166-1169).
+    assert_read_only_multiplexed_rejection(&mut reader);
 
     drop(reader);
     let result = handle.join().expect("daemon thread");

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
@@ -65,20 +65,85 @@ fn run_daemon_rejects_push_to_read_only_module() {
         .expect("send client args");
     stream.flush().expect("flush client args");
 
-    // upstream: clientserver.c - daemon rejects with
-    // "@ERROR: module is read only"
-    line.clear();
-    reader.read_line(&mut line).expect("error message");
-    assert_eq!(line.trim_end(), "@ERROR: module is read only");
-
-    // upstream: clientserver.c:381-385 - the client treats @ERROR as fatal and
-    // returns before reading further, so the daemon sends no @RSYNCD: EXIT after
-    // the refusal; the socket just closes (next read is EOF).
-    line.clear();
-    let read = reader.read_line(&mut line).expect("eof after error");
-    assert_eq!(read, 0, "no trailing @RSYNCD: EXIT after @ERROR, got: {line:?}");
+    // #227: the read-only push rejection fires after `@RSYNCD: OK`, so the
+    // client has already switched to multiplexed input. The daemon must first
+    // finish the post-OK protocol setup (compat-flags varint + 4-byte checksum
+    // seed) and then deliver the error inside a `MSG_ERROR_XFER` frame, exactly
+    // like upstream `do_server_recv()` (main.c:1166-1169) does after
+    // `io_start_multiplex_out()`. A raw `@ERROR: ...\n` line here would be
+    // decoded as a 4-byte frame header and desync the stream (the regression
+    // upstream reports as `invalid multi-message 102 (code 12)`).
+    assert_read_only_multiplexed_rejection(&mut reader);
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
+}
+
+/// Decodes the post-`@RSYNCD: OK` protocol prefix and asserts the read-only
+/// rejection arrives as a framed `MSG_ERROR_XFER` (text `ERROR: module is read
+/// only`) followed by `MSG_ERROR_EXIT` carrying `RERR_SYNTAX` (exit 1).
+///
+/// upstream: main.c:1166-1169 - `rprintf(FERROR, "ERROR: module is read
+/// only\n")` + `exit_cleanup(RERR_SYNTAX)`; io.c encodes the FERROR message as
+/// a `MSG_ERROR_XFER` frame and the exit as `MSG_ERROR_EXIT`.
+fn assert_read_only_multiplexed_rejection(reader: &mut BufReader<TcpStream>) {
+    // Post-OK `setup_protocol()` prefix: compat-flags varint + 4-byte seed.
+    let compat_flags =
+        protocol::read_varint(reader).expect("read compat-flags varint after @RSYNCD: OK");
+    assert!(
+        compat_flags > 0,
+        "daemon must advertise at least one compat flag, got {compat_flags}",
+    );
+    let mut seed_buf = [0u8; 4];
+    reader.read_exact(&mut seed_buf).expect("read checksum seed");
+
+    // MSG_ERROR_XFER frame with the plain `ERROR:` text (no `@ERROR:` prefix).
+    let mut err_header = [0u8; 4];
+    reader
+        .read_exact(&mut err_header)
+        .expect("read MSG_ERROR_XFER header");
+    let err_raw = u32::from_le_bytes(err_header);
+    let err_tag = (err_raw >> 24) as u8;
+    let err_len = (err_raw & 0x00FF_FFFF) as usize;
+    assert_eq!(
+        err_tag,
+        protocol::MPLEX_BASE + protocol::MessageCode::ErrorXfer.as_u8(),
+        "read-only rejection must use MSG_ERROR_XFER (tag = MPLEX_BASE + 1 = 8); \
+         a raw line would surface as `invalid multi-message`/`unexpected tag`",
+    );
+    let mut err_body = vec![0u8; err_len];
+    reader
+        .read_exact(&mut err_body)
+        .expect("read MSG_ERROR_XFER payload");
+    let err_text = String::from_utf8(err_body).expect("UTF-8 error payload");
+    assert_eq!(
+        err_text.trim_end(),
+        "ERROR: module is read only",
+        "read-only rejection text must mirror upstream FERROR wording",
+    );
+
+    // MSG_ERROR_EXIT frame carrying the 4-byte RERR_SYNTAX exit code.
+    let mut exit_header = [0u8; 4];
+    reader
+        .read_exact(&mut exit_header)
+        .expect("read MSG_ERROR_EXIT header");
+    let exit_raw = u32::from_le_bytes(exit_header);
+    let exit_tag = (exit_raw >> 24) as u8;
+    let exit_len = (exit_raw & 0x00FF_FFFF) as usize;
+    assert_eq!(
+        exit_tag,
+        protocol::MPLEX_BASE + protocol::MessageCode::ErrorExit.as_u8(),
+        "read-only exit must use MSG_ERROR_EXIT (tag = MPLEX_BASE + 86 = 93)",
+    );
+    assert_eq!(exit_len, 4, "MSG_ERROR_EXIT payload must carry an i32");
+    let mut exit_buf = [0u8; 4];
+    reader
+        .read_exact(&mut exit_buf)
+        .expect("read MSG_ERROR_EXIT payload");
+    assert_eq!(
+        i32::from_le_bytes(exit_buf),
+        RERR_SYNTAX_EXIT_CODE,
+        "read-only rejection exit code must be RERR_SYNTAX (1)",
+    );
 }


### PR DESCRIPTION
## Problem (#227)

When a client pushes to a `read only` daemon module (or pulls from a `write only` module), the rejection fires *after* `@RSYNCD: OK` has been sent - by which point the client has already switched its input to the multiplexed stream. The daemon wrote the refusal as a raw plaintext line:

```
@ERROR: module is read only
```

The client decoded those ASCII bytes as a 4-byte multiplex frame header, desyncing the stream. The oc-rsync client aborts with `Broken pipe (code 23)`; a real upstream client aborts with `invalid multi-message 102 (code 12)`. Neither is the clean rejection upstream produces.

Upstream `do_server_recv()` (main.c:1166-1169) rejects a read-only push with `rprintf(FERROR, "ERROR: module is read only\n")` then `exit_cleanup(RERR_SYNTAX)` (exit 1), and `do_server_sender()` (main.c:934-936) rejects a write-only pull identically. Both fire after `setup_protocol()` and `io_start_multiplex_out()`, so the message travels as a framed `MSG_ERROR_XFER` + `MSG_ERROR_EXIT`, not a raw line.

## Fix

Route both access-mode denials through the existing post-handshake multiplexed-error path that the refused-options rejection already uses (`finalize_post_ok_protocol_for_error` + `send_multiplexed_error_and_exit`):

- Finishes the post-OK protocol setup the client expects (compat-flags varint + 4-byte checksum seed).
- Emits the error inside a `MSG_ERROR_XFER` frame followed by `MSG_ERROR_EXIT` carrying `RERR_SYNTAX` (exit 1).
- Message text drops the greeting-phase `@ERROR:` prefix to match the plain `FERROR` wording upstream emits post-multiplex (`ERROR: module is read only` / `ERROR: module is write only`).

No new framing code - the existing helper is reused.

## Tests

The two read-only rejection tests previously pinned the buggy raw-line wire shape; they now decode the framed response and assert `MSG_ERROR_XFER` (text `ERROR: module is read only`) + `MSG_ERROR_EXIT` (exit 1), i.e. no desync. The wording-constant test is updated to the post-multiplex `ERROR:` form.

## Validation

- `cargo-fmt -p daemon` + stable `cargo-fmt --all -- --check`: clean.
- `cargo clippy -p daemon --all-targets --all-features -- -D warnings`: clean.
- Full-transfer re-seal against a real upstream client (upstream write to an oc read-only module -> clean `ERROR: module is read only` + exit 1, no desync/broken-pipe) runs on the Linux host before merge: pending.

upstream: main.c:1166 (read-only), main.c:934 (write-only), errcode.h:25 (`RERR_SYNTAX = 1`).