### PR TITLE
fix(transfer): implement --copy-devices in the protocol sender

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -106,6 +106,14 @@ pub(super) struct ServerLongFlags {
     /// `remove_source_files` to decide whether to unlink each file after
     /// the receiver acknowledges a successful transfer.
     pub(super) remove_source_files: bool,
+    /// Stream device contents as regular files (upstream: `--copy-devices`).
+    ///
+    /// upstream: options.c:2987 - `if (copy_devices && !am_sender) args[ac++] =
+    /// "--copy-devices"`. The flag is forwarded only when the remote peer is the
+    /// sender (a pull), so this server-side process is the sender and must
+    /// convert each block/char device into a regular file whose contents are
+    /// streamed (`flist.c:1419`).
+    pub(super) copy_devices: bool,
     /// Whether `--stats` was forwarded by the client.
     ///
     /// upstream: options.c:2838-2839 - `server_options()` emits `--stats` whenever
@@ -234,6 +242,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         numeric_ids: false,
         delete: false,
         remove_source_files: false,
+        copy_devices: false,
         stats: false,
         ignore_existing: false,
         existing_only: false,
@@ -288,6 +297,10 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             "--remove-source-files" | "--remove-sent-files" => {
                 flags.remove_source_files = true;
             }
+            // upstream: options.c:2987 - `--copy-devices` is forwarded to the
+            // remote sender (pull) so it streams device contents as a regular
+            // file (flist.c:1419). Long-form only.
+            "--copy-devices" => flags.copy_devices = true,
             // upstream: options.c:2838-2839 - --stats forwarded by server_options()
             // when do_stats was set. The server-side flag drives NDX_DEL_STATS
             // emission in the goodbye phase (generator.c:2377,2422).

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -206,6 +206,10 @@ where
     // consumed by the sender's `successful_send()` after each transferred
     // file is acknowledged.
     config.flags.remove_source_files = long_flags.remove_source_files;
+    // upstream: options.c:2987 / flist.c:1419 - `--copy-devices` is forwarded to
+    // the remote sender on a pull. As the server-side sender, this process must
+    // convert each block/char device into a regular file and stream its bytes.
+    config.flags.copy_devices = long_flags.copy_devices;
     // upstream: options.c:2996-2997 - `--mkpath` is forwarded long-form to the
     // server receiver on a push. The receiver gates dest-arg path creation on
     // this flag: without it, a missing ancestor chain is an error

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -370,6 +370,14 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // upstream: options.c:2881-2885 - copy_unsafe_links and safe_links are long-form only
     server_config.flags.copy_unsafe_links = config.copy_unsafe_links();
     server_config.flags.safe_links = config.safe_links();
+    // upstream: flist.c:1419 / options.c:2987 - `--copy-devices` converts device
+    // entries into regular files on the SENDER so their contents stream like a
+    // file. The flag is long-form only; on a push the local client IS the sender
+    // and never sends `--copy-devices` over the wire (`if (copy_devices &&
+    // !am_sender)`), so the in-process sender must carry it here. On a pull the
+    // local half is the receiver, where the flag is inert (the remote sender does
+    // the conversion), so setting it unconditionally is safe.
+    server_config.flags.copy_devices = config.copy_devices();
     // upstream: syscall.c do_open / do_open_nofollow propagate O_NOATIME when set.
     server_config.write.open_noatime = config.open_noatime();
     // upstream: options.c:2750-2762 - itemize_changes is forwarded to the remote

--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -79,6 +79,36 @@ impl<'a> CopyContext<'a> {
         self.options.copy_devices_as_files_enabled()
     }
 
+    /// Returns the readable byte length to use when `--copy-devices` should
+    /// stream `source` (a block/char device) as a regular file, or `None` when
+    /// `source` is not a copy-devices device and the caller should use the stat
+    /// length as usual.
+    ///
+    /// Mirrors upstream `flist.c:1419-1424 make_file()`, which opens the device
+    /// and records `get_device_size()` in place of the (zero) stat length. See
+    /// [`crate::local_copy::LocalCopyMetadata::virtualize_copy_device_as_file`]
+    /// for the matching reporting override.
+    pub(super) fn copy_device_as_file_size(
+        &self,
+        source: &std::path::Path,
+        metadata: &std::fs::Metadata,
+    ) -> Option<u64> {
+        if !self.copy_devices_as_files_enabled()
+            || !crate::local_copy::is_device(metadata.file_type())
+        {
+            return None;
+        }
+        #[cfg(unix)]
+        {
+            Some(::metadata::device_readable_size(source).unwrap_or(0))
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = source;
+            None
+        }
+    }
+
     pub(super) const fn specials_enabled(&self) -> bool {
         self.options.specials_enabled()
     }

--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -42,7 +42,11 @@ pub(super) fn handle_dry_run(
         existing_metadata,
     } = request;
     let destination_previously_existed = existing_metadata.is_some();
-    let file_size = metadata.len();
+    // upstream: flist.c:1419-1424 - a `--copy-devices` device is reported and
+    // sized as a regular file. `Some(size)` also signals the snapshot below to
+    // virtualize the kind/mode so `--list-only` shows `-rw-...` not `brw-...`.
+    let device_as_file_size = context.copy_device_as_file_size(source, metadata);
+    let file_size = device_as_file_size.unwrap_or(metadata.len());
     let file_type = metadata.file_type();
     if context.update_enabled()
         && let Some(existing) = existing_metadata
@@ -194,7 +198,10 @@ pub(super) fn handle_dry_run(
         context.checksum_enabled(),
         context.options().modify_window(),
     );
-    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+    let mut metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+    if let Some(size) = device_as_file_size {
+        metadata_snapshot = metadata_snapshot.virtualize_copy_device_as_file(size);
+    }
     let total_bytes = Some(metadata_snapshot.len());
     context.record(
         LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -56,7 +56,11 @@ pub(crate) fn copy_file(
                 .map(PathBuf::from)
                 .unwrap_or_default()
         });
-    let file_size = metadata.len();
+    // upstream: flist.c:1419-1424 - `--copy-devices` streams a device as a
+    // regular file, so its readable length (not the zero stat size) drives the
+    // size checks, stats, and the copy byte count.
+    let device_as_file_size = context.copy_device_as_file_size(source, metadata);
+    let file_size = device_as_file_size.unwrap_or(metadata.len());
     debug_log!(
         Send,
         3,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -104,7 +104,10 @@ pub(in crate::local_copy) fn execute_transfer(
         preserve_acls,
     } = flags;
 
-    let file_size = metadata.len();
+    // upstream: flist.c:1419-1424 - stream a `--copy-devices` device as a
+    // regular file of its readable byte length instead of the zero stat size.
+    let device_as_file_size = context.copy_device_as_file_size(source, metadata);
+    let file_size = device_as_file_size.unwrap_or(metadata.len());
 
     if let Some(existing) = existing_metadata {
         if try_skip_up_to_date(
@@ -196,7 +199,12 @@ pub(in crate::local_copy) fn execute_transfer(
         }
     }
 
-    if !file_type.is_file() {
+    // A non-regular source that is NOT a `--copy-devices` device (a FIFO,
+    // socket, or a device without `--copy-devices`) is materialised as an empty
+    // placeholder. A `--copy-devices` device (`device_as_file_size.is_some()`)
+    // instead falls through to the generic read/write loop below, which streams
+    // its `file_size` bytes just like a regular file (upstream sender.c:410-418).
+    if !file_type.is_file() && device_as_file_size.is_none() {
         return super::special::copy_special_as_regular_file(
             context,
             source,
@@ -213,27 +221,32 @@ pub(in crate::local_copy) fn execute_transfer(
         );
     }
 
-    // Fast path: macOS clonefile for new whole-file copies.
+    // Fast path: macOS clonefile for new whole-file copies. Skipped for
+    // `--copy-devices` devices, whose contents must be read/streamed (clonefile
+    // clones extents by stat length, which is 0 for a device).
     #[cfg(target_os = "macos")]
-    if clonefile::eligible(
-        context,
-        existing_metadata,
-        flags,
-        copy_source_override.is_some(),
-    ) && clonefile::try_clone(
-        context,
-        source,
-        destination,
-        metadata,
-        metadata_options.clone(),
-        record_path,
-        existing_metadata,
-        destination_previously_existed,
-        file_type,
-        relative,
-        mode,
-        flags,
-    )? {
+    if device_as_file_size.is_none()
+        && clonefile::eligible(
+            context,
+            existing_metadata,
+            flags,
+            copy_source_override.is_some(),
+        )
+        && clonefile::try_clone(
+            context,
+            source,
+            destination,
+            metadata,
+            metadata_options.clone(),
+            record_path,
+            existing_metadata,
+            destination_previously_existed,
+            file_type,
+            relative,
+            mode,
+            flags,
+        )?
+    {
         return Ok(());
     }
 
@@ -243,25 +256,28 @@ pub(in crate::local_copy) fn execute_transfer(
     // copy. The dispatcher hands large files COPY_FILE_NO_BUFFERING and
     // attempts FSCTL_DUPLICATE_EXTENTS_TO_FILE on ReFS volumes first.
     #[cfg(target_os = "windows")]
-    if wincopy::eligible(
-        context,
-        existing_metadata,
-        flags,
-        copy_source_override.is_some(),
-    ) && wincopy::try_copy(
-        context,
-        source,
-        destination,
-        metadata,
-        metadata_options.clone(),
-        record_path,
-        existing_metadata,
-        destination_previously_existed,
-        file_type,
-        relative,
-        mode,
-        flags,
-    )? {
+    if device_as_file_size.is_none()
+        && wincopy::eligible(
+            context,
+            existing_metadata,
+            flags,
+            copy_source_override.is_some(),
+        )
+        && wincopy::try_copy(
+            context,
+            source,
+            destination,
+            metadata,
+            metadata_options.clone(),
+            record_path,
+            existing_metadata,
+            destination_previously_existed,
+            file_type,
+            relative,
+            mode,
+            flags,
+        )?
+    {
         return Ok(());
     }
 
@@ -269,25 +285,28 @@ pub(in crate::local_copy) fn execute_transfer(
     // XFS (reflink enabled), and bcachefs. Cross-filesystem / unsupported-fs
     // failures degrade to the generic read/write loop transparently.
     #[cfg(target_os = "linux")]
-    if ficlone::eligible(
-        context,
-        existing_metadata,
-        flags,
-        copy_source_override.is_some(),
-    ) && ficlone::try_clone(
-        context,
-        source,
-        destination,
-        metadata,
-        metadata_options.clone(),
-        record_path,
-        existing_metadata,
-        destination_previously_existed,
-        file_type,
-        relative,
-        mode,
-        flags,
-    )? {
+    if device_as_file_size.is_none()
+        && ficlone::eligible(
+            context,
+            existing_metadata,
+            flags,
+            copy_source_override.is_some(),
+        )
+        && ficlone::try_clone(
+            context,
+            source,
+            destination,
+            metadata,
+            metadata_options.clone(),
+            record_path,
+            existing_metadata,
+            destination_previously_existed,
+            file_type,
+            relative,
+            mode,
+            flags,
+        )?
+    {
         return Ok(());
     }
 
@@ -669,8 +688,11 @@ pub(in crate::local_copy) fn execute_transfer(
         .record_copy_method(CopyMethodKind::Standard);
     context.summary_mut().record_elapsed(elapsed);
 
-    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
+    let mut metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
         .virtualize_fake_super(source, metadata_options.fake_super_enabled());
+    if let Some(size) = device_as_file_size {
+        metadata_snapshot = metadata_snapshot.virtualize_copy_device_as_file(size);
+    }
     let total_bytes = Some(metadata_snapshot.len());
     let wrote_data = outcome.literal_bytes() > 0 || append_offset > 0;
 

--- a/crates/engine/src/local_copy/plan/metadata.rs
+++ b/crates/engine/src/local_copy/plan/metadata.rs
@@ -190,6 +190,29 @@ impl LocalCopyMetadata {
         self
     }
 
+    /// Presents a `--copy-devices` block/char device as a regular file for
+    /// reporting, so `--list-only` and itemized output show `-rw-...` with the
+    /// device's readable byte length instead of `brw-...`/`crw-...` and `0`.
+    ///
+    /// Mirrors upstream `flist.c:1419-1428 make_file()`, which rewrites the
+    /// device stat to `S_IFREG | (mode & ACCESSPERMS)` with `get_device_size()`
+    /// before the entry is ever itemized. A no-op for non-device kinds.
+    #[must_use]
+    pub(in crate::local_copy) fn virtualize_copy_device_as_file(mut self, size: u64) -> Self {
+        if matches!(
+            self.kind,
+            LocalCopyFileKind::CharDevice | LocalCopyFileKind::BlockDevice
+        ) {
+            self.kind = LocalCopyFileKind::File;
+            self.len = size;
+            if let Some(mode) = self.mode {
+                // upstream: S_IFREG | (st.st_mode & ACCESSPERMS).
+                self.mode = Some(0o100_000 | (mode & 0o7777));
+            }
+        }
+        self
+    }
+
     /// Returns the entry kind associated with the metadata.
     #[must_use]
     pub const fn kind(&self) -> LocalCopyFileKind {
@@ -417,5 +440,53 @@ mod tests {
             LocalCopyMetadata::from_metadata(&meta, None).virtualize_fake_super(&path, true);
         assert_eq!(snapshot.kind(), LocalCopyFileKind::CharDevice);
         assert_eq!(snapshot.mode(), Some(0o020644));
+    }
+
+    // upstream: flist.c:1419-1428 - `--copy-devices` reports a device as a
+    // regular file. The virtualisation must flip the kind to `File`, adopt the
+    // supplied device size, and rewrite the mode's type bits to `S_IFREG` while
+    // preserving the permission bits, so `--list-only` renders `-rw-...` with
+    // the real byte length instead of `crw-.../brw-...` and `0`.
+    #[cfg(unix)]
+    #[test]
+    fn virtualize_copy_device_as_file_reports_regular_file() {
+        use std::fs;
+        use std::os::unix::fs::FileTypeExt;
+
+        let dev = Path::new("/dev/zero");
+        let Ok(meta) = fs::symlink_metadata(dev) else {
+            eprintln!("skipping: /dev/zero unavailable");
+            return;
+        };
+        if !meta.file_type().is_char_device() {
+            eprintln!("skipping: /dev/zero is not a char device here");
+            return;
+        }
+
+        let snapshot = LocalCopyMetadata::from_metadata(&meta, None);
+        assert_eq!(snapshot.kind(), LocalCopyFileKind::CharDevice);
+
+        let virtualized = snapshot.virtualize_copy_device_as_file(4096);
+        assert_eq!(virtualized.kind(), LocalCopyFileKind::File);
+        assert_eq!(virtualized.len(), 4096);
+        // Type bits are S_IFREG; permission bits are preserved from the device.
+        assert_eq!(virtualized.mode().map(|m| m & 0o170_000), Some(0o100_000));
+    }
+
+    // The virtualisation is a strict no-op for a regular file: kind, length,
+    // and mode are untouched so ordinary transfers are unaffected.
+    #[test]
+    fn virtualize_copy_device_as_file_noop_for_regular_file() {
+        use std::fs;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("regular");
+        fs::write(&path, b"payload").unwrap();
+        let meta = fs::symlink_metadata(&path).unwrap();
+
+        let snapshot = LocalCopyMetadata::from_metadata(&meta, None);
+        let len_before = snapshot.len();
+        let virtualized = snapshot.virtualize_copy_device_as_file(999);
+        assert_eq!(virtualized.kind(), LocalCopyFileKind::File);
+        assert_eq!(virtualized.len(), len_before);
     }
 }

--- a/crates/metadata/src/device_size.rs
+++ b/crates/metadata/src/device_size.rs
@@ -1,0 +1,104 @@
+//! Portable readable-size probing for `--copy-devices`.
+//!
+//! Mirrors upstream rsync's `flist.c:get_device_size()`, which is an
+//! `lseek(fd, 0, SEEK_END)`. That returns the block-device byte length on Linux
+//! but `0` on macOS/BSD, where raw block devices are not seekable. On Apple
+//! targets we fall back to the `DKIOCGETBLOCKSIZE`/`DKIOCGETBLOCKCOUNT` ioctls
+//! (`<sys/disk.h>`) to recover the real size, so `--copy-devices` streams the
+//! full device contents there too.
+//!
+//! Character devices (and any device that reports neither a seek length nor a
+//! block count) yield `0`, matching upstream: their length is unknown/infinite
+//! and rsync streams zero bytes rather than reading forever.
+
+#[cfg(unix)]
+use std::io;
+#[cfg(unix)]
+use std::path::Path;
+
+/// Returns the readable byte length of the block/char device at `path`.
+///
+/// Opens the device read-only and probes its size via `lseek(SEEK_END)`, then
+/// (on Apple targets, where that yields `0`) via the disk ioctls. Returns `0`
+/// when the size cannot be determined - the upstream behaviour for unseekable
+/// character devices.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:1419-1424` `make_file()` - opens the device and calls
+///   `get_device_size()` when a `--copy-devices` entry reports `st_size == 0`.
+/// - `flist.c:1550-1562` `get_device_size()` - `lseek(fd, 0, SEEK_END)`.
+#[cfg(unix)]
+pub fn device_readable_size(path: &Path) -> io::Result<u64> {
+    use std::io::{Seek, SeekFrom};
+
+    let mut file = std::fs::File::open(path)?;
+    // upstream: flist.c:1552 - lseek(fd, 0, SEEK_END). Authoritative on Linux.
+    let via_seek = file.seek(SeekFrom::End(0)).unwrap_or(0);
+    if via_seek > 0 {
+        return Ok(via_seek);
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    if let Some(size) = apple_block_device_size(&file) {
+        return Ok(size);
+    }
+
+    Ok(via_seek)
+}
+
+/// Recovers a block device's byte length on Apple targets via the disk ioctls.
+///
+/// macOS block devices return `0` from `lseek(SEEK_END)`, so the size must come
+/// from `DKIOCGETBLOCKSIZE` * `DKIOCGETBLOCKCOUNT`. Returns `None` when the fd
+/// is not a block device or the ioctls fail (e.g. a character device).
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[allow(unsafe_code)] // REASON: disk-size ioctls have no safe libc wrapper.
+fn apple_block_device_size(file: &std::fs::File) -> Option<u64> {
+    use std::os::unix::io::AsRawFd;
+
+    // <sys/disk.h>: _IOR('d', 24, uint32_t) and _IOR('d', 25, uint64_t).
+    const DKIOCGETBLOCKSIZE: libc::c_ulong = 0x4004_6418;
+    const DKIOCGETBLOCKCOUNT: libc::c_ulong = 0x4008_6419;
+
+    let fd = file.as_raw_fd();
+    let mut block_size: u32 = 0;
+    let mut block_count: u64 = 0;
+
+    // SAFETY: `fd` is a live descriptor owned by `file`. Each ioctl writes
+    // exactly the fixed-width integer its `_IOR` encoding declares (a `u32` and
+    // a `u64` respectively) into the provided stack slot; a non-zero return
+    // leaves the slot untouched and is treated as "unknown".
+    unsafe {
+        if libc::ioctl(fd, DKIOCGETBLOCKSIZE, &mut block_size) != 0 {
+            return None;
+        }
+        if libc::ioctl(fd, DKIOCGETBLOCKCOUNT, &mut block_count) != 0 {
+            return None;
+        }
+    }
+
+    Some(block_count.saturating_mul(u64::from(block_size)))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    /// A character device with no seekable length yields `0`, matching
+    /// upstream's `get_device_size()` for unseekable devices.
+    #[test]
+    fn char_device_reports_zero() {
+        let dev = Path::new("/dev/zero");
+        let Ok(meta) = std::fs::symlink_metadata(dev) else {
+            eprintln!("skipping: /dev/zero unavailable");
+            return;
+        };
+        use std::os::unix::fs::FileTypeExt;
+        if !meta.file_type().is_char_device() {
+            eprintln!("skipping: /dev/zero is not a char device here");
+            return;
+        }
+        assert_eq!(device_readable_size(dev).unwrap(), 0);
+    }
+}

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -131,6 +131,12 @@ use ownership_stub as ownership;
 pub mod stat_cache;
 
 mod special;
+
+/// Portable readable-size probing for `--copy-devices` device streaming.
+pub mod device_size;
+#[cfg(unix)]
+pub use device_size::device_readable_size;
+
 /// Symlink munging helpers for daemon-mode security.
 ///
 /// Provides `munge_symlink` and `unmunge_symlink` which prepend or strip the

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -249,6 +249,27 @@ pub struct ParsedServerFlags {
     /// - `options.c:765` - `remove_source_files` global definition
     pub remove_source_files: bool,
 
+    /// Treat device files as regular files and stream their contents
+    /// (long-form `--copy-devices`).
+    ///
+    /// Sender-side only. Not part of the compact flag string. When set and the
+    /// sender encounters a block/char device, the file-list entry is emitted as
+    /// a regular file (mode `S_IFREG | perms`, mtime "now", size = the device's
+    /// readable byte length) and the device is read as a byte stream, so the
+    /// receiver materialises a plain file holding the device contents rather
+    /// than a device node.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:1419-1428` `make_file()` - `copy_devices && am_sender &&
+    ///   IS_DEVICE(st.st_mode)` converts the entry to `S_IFREG | ACCESSPERMS`,
+    ///   sets `st_mtime = time(NULL)`, and records `get_device_size()`.
+    /// - `sender.c:410-418` - re-opens the device and streams its bytes.
+    /// - `options.c:2987` - `if (copy_devices && !am_sender)` forwards the flag
+    ///   to the remote peer only on a pull, so the local sender must carry it
+    ///   in-process on a push.
+    pub copy_devices: bool,
+
     /// Create missing destination path components (long-form `--mkpath`).
     ///
     /// Not part of the compact flag string; forwarded by the sending client

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -527,9 +527,15 @@ impl GeneratorContext {
 
         let use_noatime = self.config.write.open_noatime;
 
+        // upstream: sender.c streams a `--copy-devices` device through the plain
+        // read path. Block/char devices report `st_size == 0`, so the io_uring
+        // fast path (which sizes reads from the fd's stat length) yields EOF at 0
+        // bytes and short-reads the stream. Force buffered I/O for devices so the
+        // full `file_size` bytes reach the wire.
         if !use_noatime
             && file_size >= IO_URING_READ_THRESHOLD
             && self.config.write.io_uring_policy != fast_io::IoUringPolicy::Disabled
+            && !self.source_is_copy_device(path)
         {
             match fast_io::reader_from_path_with_depth(
                 path,
@@ -548,6 +554,29 @@ impl GeneratorContext {
             adaptive_buffer_size(file_size),
             f,
         )))
+    }
+
+    /// Returns whether `--copy-devices` is active and `path` is a block/char
+    /// device, i.e. a source that must be read through the plain buffered path
+    /// rather than the size-from-stat io_uring/mmap fast paths.
+    ///
+    /// The `symlink_metadata` probe runs only when `--copy-devices` is set, so
+    /// regular transfers pay no extra stat.
+    #[cfg(unix)]
+    pub(crate) fn source_is_copy_device(&self, path: &std::path::Path) -> bool {
+        use std::os::unix::fs::FileTypeExt;
+        self.config.flags.copy_devices
+            && std::fs::symlink_metadata(path).is_ok_and(|m| {
+                let ft = m.file_type();
+                ft.is_block_device() || ft.is_char_device()
+            })
+    }
+
+    /// Non-Unix stub: devices are not a distinct source kind, so nothing forces
+    /// the buffered path.
+    #[cfg(not(unix))]
+    pub(crate) fn source_is_copy_device(&self, _path: &std::path::Path) -> bool {
+        false
     }
 
     /// Opens a source file without intermediate buffering.
@@ -580,9 +609,13 @@ impl GeneratorContext {
 
         let use_noatime = self.config.write.open_noatime;
 
+        // upstream: `--copy-devices` streams through the plain read path; a
+        // device's stat size is 0, so the io_uring fast path would short-read.
+        // See `source_is_copy_device` / `open_source_reader`.
         if !use_noatime
             && file_size >= IO_URING_READ_THRESHOLD
             && self.config.write.io_uring_policy != fast_io::IoUringPolicy::Disabled
+            && !self.source_is_copy_device(path)
         {
             match fast_io::reader_from_path_with_depth(
                 path,

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -107,7 +107,14 @@ impl GeneratorContext {
                 && (file_type.is_block_device() || file_type.is_char_device())
             {
                 let mode = metadata.mode() & 0o7777;
-                let size = super::device::device_readable_size(full_path, metadata.len());
+                // upstream: flist.c:1421-1424 - open the device and size it when
+                // st_size is 0 (block devices report 0). `device_readable_size`
+                // mirrors get_device_size() with a macOS ioctl fallback.
+                let size = if metadata.len() != 0 {
+                    metadata.len()
+                } else {
+                    ::metadata::device_readable_size(full_path).unwrap_or(0)
+                };
                 Some((size, mode))
             } else {
                 None

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -94,7 +94,32 @@ impl GeneratorContext {
             None
         };
 
-        let mut entry = if file_type.is_file() && {
+        // upstream: flist.c:1419-1428 - `copy_devices && am_sender &&
+        // IS_DEVICE(st.st_mode)` rewrites a block/char device into a regular
+        // file: mode becomes `S_IFREG | ACCESSPERMS`, mtime is forced to "now",
+        // and the size is the device's readable byte length. The device's
+        // contents are then streamed like a plain file. This generator only ever
+        // builds the sender's file list, so `am_sender` is implicit here.
+        #[cfg(unix)]
+        let copy_device_override: Option<(u64, u32)> = {
+            use std::os::unix::fs::FileTypeExt;
+            if self.config.flags.copy_devices
+                && (file_type.is_block_device() || file_type.is_char_device())
+            {
+                let mode = metadata.mode() & 0o7777;
+                let size = super::device::device_readable_size(full_path, metadata.len());
+                Some((size, mode))
+            } else {
+                None
+            }
+        };
+        #[cfg(not(unix))]
+        let copy_device_override: Option<(u64, u32)> = None;
+
+        let mut entry = if let Some((dev_size, dev_mode)) = copy_device_override {
+            // upstream: flist.c:1425 - st.st_mode = S_IFREG | (mode & ACCESSPERMS)
+            FileEntry::new_file(relative_path, dev_size, dev_mode)
+        } else if file_type.is_file() && {
             #[cfg(windows)]
             {
                 !is_reparse_point
@@ -222,6 +247,16 @@ impl GeneratorContext {
                     entry.set_mtime(duration.as_secs() as i64, duration.subsec_nanos());
                 }
             }
+        }
+
+        // upstream: flist.c:1427 - the device mtime is not up-to-date, so a
+        // `--copy-devices` entry carries `time(NULL)` instead of the on-disk
+        // stat time. This is a no-op on non-device entries and on non-Unix.
+        if copy_device_override.is_some() {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_secs() as i64);
+            entry.set_mtime(now, 0);
         }
 
         // Set access time if preserving (upstream: flist.c:489-494)
@@ -527,6 +562,96 @@ mod fake_super_round_trip_tests {
         assert_eq!(entry.gid(), Some(6));
         assert_eq!(entry.rdev_major(), Some(8));
         assert_eq!(entry.rdev_minor(), Some(0));
+    }
+
+    /// Builds a sender generator with `--copy-devices` active.
+    fn make_copy_devices_generator() -> GeneratorContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let mut config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        config.flags.copy_devices = true;
+        config.flags.numeric_ids = crate::NumericIds::Explicit;
+        GeneratorContext::new_for_test(&handshake, config)
+    }
+
+    /// upstream: flist.c:1419-1428 - with `--copy-devices` the sender must emit a
+    /// character/block device as a regular file (its contents are streamed like a
+    /// plain file), not as a device node. Verified against `/dev/zero`, a char
+    /// device present on every supported Unix. Without the conversion the receiver
+    /// would create a device node and then block waiting for file data that never
+    /// arrives (issue #229 deadlock).
+    #[cfg(unix)]
+    #[test]
+    fn copy_devices_encodes_char_device_as_regular_file() {
+        use std::os::unix::fs::FileTypeExt;
+
+        let dev = std::path::Path::new("/dev/zero");
+        let Ok(meta) = std::fs::symlink_metadata(dev) else {
+            eprintln!("skipping: /dev/zero unavailable on this host");
+            return;
+        };
+        if !meta.file_type().is_char_device() {
+            eprintln!("skipping: /dev/zero is not a char device here");
+            return;
+        }
+
+        let ctx = make_copy_devices_generator();
+        let entry = ctx.create_entry(dev, PathBuf::from("zero"), &meta).unwrap();
+
+        // The device is presented as a regular file, not a device node.
+        assert_eq!(
+            entry.file_type(),
+            FileType::Regular,
+            "copy-devices must convert the device to a regular file"
+        );
+        assert_eq!(entry.rdev_major(), None, "regular file carries no rdev");
+        assert_eq!(entry.rdev_minor(), None, "regular file carries no rdev");
+        // upstream: st.st_mtime = time(NULL) - the entry carries a fresh mtime.
+        assert!(
+            entry.mtime() > 0,
+            "copy-devices entry must set mtime to now"
+        );
+    }
+
+    /// Without `--copy-devices`, `create_entry` classifies the same char device
+    /// as a device node - the conversion is strictly gated on the flag.
+    #[cfg(unix)]
+    #[test]
+    fn without_copy_devices_char_device_stays_device_node() {
+        use std::os::unix::fs::FileTypeExt;
+
+        let dev = std::path::Path::new("/dev/zero");
+        let Ok(meta) = std::fs::symlink_metadata(dev) else {
+            eprintln!("skipping: /dev/zero unavailable on this host");
+            return;
+        };
+        if !meta.file_type().is_char_device() {
+            eprintln!("skipping: /dev/zero is not a char device here");
+            return;
+        }
+
+        // make_generator has --devices (D) but not --copy-devices.
+        let ctx = make_generator(false, false, false);
+        let entry = ctx.create_entry(dev, PathBuf::from("zero"), &meta).unwrap();
+        assert_eq!(
+            entry.file_type(),
+            FileType::CharDevice,
+            "without copy-devices the device stays a device node"
+        );
     }
 
     #[test]

--- a/crates/transfer/src/generator/file_list/entry/device.rs
+++ b/crates/transfer/src/generator/file_list/entry/device.rs
@@ -3,36 +3,6 @@
 //! Splits a raw `rdev` value into major/minor components using the
 //! platform-specific bit layout (Linux split encoding vs BSD/macOS).
 
-#[cfg(unix)]
-use std::io::{Seek, SeekFrom};
-#[cfg(unix)]
-use std::path::Path;
-
-/// Returns the readable byte length of a device for `--copy-devices` streaming.
-///
-/// A block/char device usually reports `st_size == 0`, so upstream opens the
-/// device and seeks to the end to learn how many bytes the sender must stream.
-/// When the stat already carries a non-zero size we trust it and skip the open.
-/// A seek failure (typical for unseekable char devices) yields `0`, matching
-/// upstream's `get_device_size()` fallback.
-///
-/// # Upstream Reference
-///
-/// - `flist.c:1419-1424` - `if (st.st_size == 0) { fd = do_open_checklinks(fname);
-///   st.st_size = get_device_size(fd, fname); }`
-/// - `flist.c:1550-1562` `get_device_size()` - `lseek(fd, 0, SEEK_END)`, returning
-///   `0` on failure.
-#[cfg(unix)]
-pub(in crate::generator) fn device_readable_size(path: &Path, stat_size: u64) -> u64 {
-    if stat_size != 0 {
-        return stat_size;
-    }
-    match std::fs::File::open(path) {
-        Ok(mut f) => f.seek(SeekFrom::End(0)).unwrap_or(0),
-        Err(_) => 0,
-    }
-}
-
 /// Extracts major and minor device numbers from a raw `rdev` value.
 ///
 /// The layout differs by platform:

--- a/crates/transfer/src/generator/file_list/entry/device.rs
+++ b/crates/transfer/src/generator/file_list/entry/device.rs
@@ -3,6 +3,36 @@
 //! Splits a raw `rdev` value into major/minor components using the
 //! platform-specific bit layout (Linux split encoding vs BSD/macOS).
 
+#[cfg(unix)]
+use std::io::{Seek, SeekFrom};
+#[cfg(unix)]
+use std::path::Path;
+
+/// Returns the readable byte length of a device for `--copy-devices` streaming.
+///
+/// A block/char device usually reports `st_size == 0`, so upstream opens the
+/// device and seeks to the end to learn how many bytes the sender must stream.
+/// When the stat already carries a non-zero size we trust it and skip the open.
+/// A seek failure (typical for unseekable char devices) yields `0`, matching
+/// upstream's `get_device_size()` fallback.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:1419-1424` - `if (st.st_size == 0) { fd = do_open_checklinks(fname);
+///   st.st_size = get_device_size(fd, fname); }`
+/// - `flist.c:1550-1562` `get_device_size()` - `lseek(fd, 0, SEEK_END)`, returning
+///   `0` on failure.
+#[cfg(unix)]
+pub(in crate::generator) fn device_readable_size(path: &Path, stat_size: u64) -> u64 {
+    if stat_size != 0 {
+        return stat_size;
+    }
+    match std::fs::File::open(path) {
+        Ok(mut f) => f.seek(SeekFrom::End(0)).unwrap_or(0),
+        Err(_) => 0,
+    }
+}
+
 /// Extracts major and minor device numbers from a raw `rdev` value.
 ///
 /// The layout differs by platform:

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -225,7 +225,13 @@ impl GeneratorContext {
         {
             use std::os::unix::fs::FileTypeExt;
             let ft = metadata.file_type();
-            if (ft.is_block_device() || ft.is_char_device()) && !self.config.flags.devices {
+            // upstream: flist.c:1419 - `--copy-devices` makes make_file() emit a
+            // block/char device as a regular file, so it is included on the wire
+            // even without `--devices`. Only skip when neither flag is active.
+            if (ft.is_block_device() || ft.is_char_device())
+                && !self.config.flags.devices
+                && !self.config.flags.copy_devices
+            {
                 return Ok(());
             }
             if (ft.is_fifo() || ft.is_socket()) && !self.config.flags.specials {


### PR DESCRIPTION
## Problem

`oc-rsync --copy-devices` did not stream device contents on the wire. The
protocol sender emitted each block/char device as a device node (with `rdev`)
and never streamed its bytes, so a push to a remote receiver hung (exit 124) or
left an empty destination. `grep copy_devices crates/transfer` was empty - the
flag only reached the engine local-copy path, which itself produced an empty
placeholder file for devices.

## Fix

Implement `--copy-devices` end-to-end, mirroring upstream `make_file()`:

- **Flist entry (sender).** When `copy_devices` is set and the sender meets a
  block/char device, the file-list entry is emitted as a regular file
  (`S_IFREG | perms`), with the size set to the device's readable byte length
  and mtime forced to "now". The sender walk includes the device even without
  `--devices`.
- **Portable device size.** `metadata::device_readable_size` sizes the device
  via `lseek(SEEK_END)` (authoritative on Linux) and falls back to the
  `DKIOCGETBLOCKSIZE`/`DKIOCGETBLOCKCOUNT` ioctls on Apple targets, where raw
  block devices are not seekable and would otherwise report 0.
- **Sender read.** A device reports a 0 stat size, so the io_uring read fast
  path (gated on `file_size >= 1 MiB`) short-read the stream and desynced
  (`failed to fill whole buffer`). Copy-device sources are now forced through
  buffered I/O on both sender read paths.
- **Engine local copy / `--list-only`.** The engine routed devices to an empty
  placeholder and rendered them as device nodes with size 0. The device size is
  threaded through `copy_file`, copy-device sources stream through the generic
  read/write loop (skipping the clonefile/reflink fast paths, which clone by the
  0-length stat), and the reported metadata is virtualized to a regular file so
  `--list-only` shows `-rw-...` with the real length.
- **Config threading.** The long-form flag is carried onto the in-process sender
  `ServerConfig` for SSH, daemon, and remote-to-remote pushes, and parsed for
  the server-side sender (`--server --sender`) on a pull. On a push it is never
  sent over the wire (upstream gates forwarding on `!am_sender`).

## Verification (1 MiB loop-backed block device)

- `oc --copy-devices --list-only` renders `-rw-r----- 1048576` (regular file,
  real size); without the flag it stays `brw-r----- 0`.
- Remote-shell push reproduces the device contents byte-for-byte (sha match),
  exit 0, no hang.
- Local copy reproduces the device contents byte-for-byte (sha match).
- A char device (`/dev/null`, unseekable) yields a 0-length regular file,
  matching upstream.

## Tests

- `metadata`: `device_readable_size` returns 0 for an unseekable char device.
- `transfer`: a device flist entry is encoded as a regular file (not a device
  node) under `--copy-devices`, and stays a device node without it.
- `engine`: `virtualize_copy_device_as_file` flips a device snapshot to a
  regular file with the given size and `S_IFREG` mode, and is a no-op for
  regular files.

## Upstream reference

- `flist.c:1419-1428` `make_file()` - `copy_devices && am_sender &&
  IS_DEVICE(st.st_mode)` rewrites the entry to `S_IFREG | ACCESSPERMS`, sets
  `st_mtime = time(NULL)`, and records `get_device_size()`.
- `flist.c:1550-1562` `get_device_size()` - `lseek(fd, 0, SEEK_END)`.
- `sender.c:410-418` - re-opens the device and streams its bytes.
- `options.c:2987` - `if (copy_devices && !am_sender)` forwards the flag to the
  remote peer only on a pull.
