### PR TITLE
feat(fast_io): dispatch Windows file reads through IOCP with std fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,16 +277,17 @@ jobs:
           # Full test suite runs on Linux; Windows validates platform-specific paths
           cargo nextest run --locked -p core -p engine -p cli --all-features
 
-      # Pin the Windows crtime (NTFS creation-time via SetFileTime) and NTFS
-      # sparse (FSCTL_SET_SPARSE) tests on the required Windows cell. These
-      # live in `metadata` (crtime) and `fast_io` (sparse) - crates the main
-      # Test step above does not run - so without this step the Windows
-      # regression signal for those two paths sits only in the separate
-      # windows-acl-xattr / windows-iocp jobs. The filter matches the crtime
-      # conversion and skip-flag tests plus the mark_file_sparse probe.
-      - name: Test crtime + sparse (metadata, fast_io)
+      # Pin the Windows crtime (NTFS creation-time via SetFileTime), NTFS
+      # sparse (FSCTL_SET_SPARSE) and IOCP read-parity tests on the required
+      # Windows cell. These live in `metadata` (crtime) and `fast_io` (sparse,
+      # IOCP) - crates the main Test step above does not run - so without this
+      # step the Windows regression signal for those paths sits only in the
+      # separate windows-acl-xattr / windows-iocp jobs. The filter matches the
+      # crtime conversion and skip-flag tests, the mark_file_sparse probe, and
+      # the IOCP-vs-std read-path parity tests.
+      - name: Test crtime + sparse + iocp read parity (metadata, fast_io)
         shell: bash
-        run: cargo nextest run --locked -p metadata -p fast_io -E 'test(crtime) | test(sparse)'
+        run: cargo nextest run --locked -p metadata -p fast_io -E 'test(crtime) | test(sparse) | test(iocp_read_parity)'
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/crates/fast_io/src/iocp/file_reader.rs
+++ b/crates/fast_io/src/iocp/file_reader.rs
@@ -410,4 +410,84 @@ mod tests {
         let result = reader.read_all().unwrap();
         assert_eq!(result, data);
     }
+
+    /// Reads `path` through the standard buffered [`StdFileReader`] - the exact
+    /// fallback the IOCP dispatch degrades to - so parity assertions compare
+    /// against the very bytes a non-IOCP build would produce.
+    fn read_all_via_std(path: &std::path::Path) -> Vec<u8> {
+        use crate::traits::{FileReader, StdFileReader};
+        StdFileReader::open(path).unwrap().read_all().unwrap()
+    }
+
+    /// Reads `path` through [`IocpReader`] using the streaming `Read` impl so
+    /// the sequential `read_at` overlapped path is exercised (not just the
+    /// batched `read_all`).
+    fn read_streaming_via_iocp(path: &std::path::Path) -> Vec<u8> {
+        let config = IocpConfig::default();
+        let mut reader = IocpReader::open(path, &config).unwrap();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        out
+    }
+
+    /// The IOCP reader and the std buffered reader must yield byte-identical
+    /// output across the whole size spectrum. This is the wire-fidelity
+    /// guarantee behind the Windows read-path dispatch: swapping the reader
+    /// implementation must never change the bytes handed to the delta/checksum
+    /// pipeline. A multi-block file crosses several `buffer_size` overlapped
+    /// segments; the short and empty cases pin the boundary conditions.
+    #[test]
+    fn iocp_read_parity_multiblock() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("parity_multiblock.bin");
+        // > IocpConfig::default().buffer_size and > concurrent_ops * buffer_size
+        // so multiple overlapped batches are submitted and drained.
+        let data: Vec<u8> = (0..(1024 * 1024 + 4096))
+            .map(|i| ((i * 31 + 7) % 251) as u8)
+            .collect();
+        std::fs::write(&path, &data).unwrap();
+
+        let config = IocpConfig::default();
+        let mut reader = IocpReader::open(&path, &config).unwrap();
+        let batched = reader.read_all().unwrap();
+
+        assert_eq!(batched, data, "IOCP batched read must match source bytes");
+        assert_eq!(
+            batched,
+            read_all_via_std(&path),
+            "IOCP batched read must be byte-identical to the std fallback"
+        );
+        assert_eq!(
+            read_streaming_via_iocp(&path),
+            data,
+            "IOCP sequential read must match source bytes"
+        );
+    }
+
+    #[test]
+    fn iocp_read_parity_short_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("parity_short.bin");
+        let data = b"short-file bytes for iocp parity".to_vec();
+        std::fs::write(&path, &data).unwrap();
+
+        let config = IocpConfig::default();
+        let mut reader = IocpReader::open(&path, &config).unwrap();
+        assert_eq!(reader.read_all().unwrap(), data);
+        assert_eq!(read_all_via_std(&path), data);
+        assert_eq!(read_streaming_via_iocp(&path), data);
+    }
+
+    #[test]
+    fn iocp_read_parity_empty_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("parity_empty.bin");
+        std::fs::write(&path, b"").unwrap();
+
+        let config = IocpConfig::default();
+        let mut reader = IocpReader::open(&path, &config).unwrap();
+        assert!(reader.read_all().unwrap().is_empty());
+        assert!(read_all_via_std(&path).is_empty());
+        assert!(read_streaming_via_iocp(&path).is_empty());
+    }
 }

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -503,8 +503,9 @@ impl GeneratorContext {
     ///
     /// Files at or above the io_uring read threshold (1 MB) use `reader_from_path`,
     /// which creates an io_uring-backed reader on Linux 5.6+ (respecting the
-    /// `--no-io-uring` flag). Smaller files use a standard `BufReader` to avoid
-    /// the overhead of creating an io_uring ring per file.
+    /// `--no-io-uring` flag) or an IOCP overlapped reader on Windows, each with
+    /// transparent std fallback. Smaller files use a standard `BufReader` to
+    /// avoid the overhead of creating a ring/completion port per file.
     ///
     /// When `--open-noatime` is in effect the io_uring fast path is bypassed
     /// because `IoUringReader::open` does not accept custom open flags;
@@ -537,14 +538,29 @@ impl GeneratorContext {
             && self.config.write.io_uring_policy != fast_io::IoUringPolicy::Disabled
             && !self.source_is_copy_device(path)
         {
-            match fast_io::reader_from_path_with_depth(
-                path,
-                self.config.write.io_uring_policy,
-                self.config.write.io_uring_depth,
-            ) {
-                Ok(r) => return Ok(Box::new(r)),
-                Err(_) => {
-                    // Fall through to standard BufReader on io_uring failure
+            // Windows gets IOCP where Linux gets io_uring, std elsewhere. The
+            // IOCP reader mirrors the disk-commit writer's dispatch: runtime
+            // `is_iocp_available()` detection with transparent std buffered
+            // fallback (see fast_io iocp::file_factory::reader_from_path and
+            // disk_commit/config.rs iocp_policy).
+            #[cfg(target_os = "windows")]
+            {
+                if let Ok(r) = fast_io::iocp_reader_from_path(path, fast_io::IocpPolicy::Auto) {
+                    return Ok(Box::new(r));
+                }
+                // Fall through to standard BufReader on IOCP failure.
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                match fast_io::reader_from_path_with_depth(
+                    path,
+                    self.config.write.io_uring_policy,
+                    self.config.write.io_uring_depth,
+                ) {
+                    Ok(r) => return Ok(Box::new(r)),
+                    Err(_) => {
+                        // Fall through to standard BufReader on io_uring failure
+                    }
                 }
             }
         }
@@ -617,14 +633,29 @@ impl GeneratorContext {
             && self.config.write.io_uring_policy != fast_io::IoUringPolicy::Disabled
             && !self.source_is_copy_device(path)
         {
-            match fast_io::reader_from_path_with_depth(
-                path,
-                self.config.write.io_uring_policy,
-                self.config.write.io_uring_depth,
-            ) {
-                Ok(r) => return Ok((Box::new(r), None)),
-                Err(_) => {
-                    // Fall through to raw File on io_uring failure
+            // Windows gets IOCP where Linux gets io_uring, std elsewhere. The
+            // IOCP reader mirrors the disk-commit writer's dispatch: runtime
+            // `is_iocp_available()` detection with transparent std buffered
+            // fallback (see fast_io iocp::file_factory::reader_from_path and
+            // disk_commit/config.rs iocp_policy).
+            #[cfg(target_os = "windows")]
+            {
+                if let Ok(r) = fast_io::iocp_reader_from_path(path, fast_io::IocpPolicy::Auto) {
+                    return Ok((Box::new(r), None));
+                }
+                // Fall through to raw File on IOCP failure.
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                match fast_io::reader_from_path_with_depth(
+                    path,
+                    self.config.write.io_uring_policy,
+                    self.config.write.io_uring_depth,
+                ) {
+                    Ok(r) => return Ok((Box::new(r), None)),
+                    Err(_) => {
+                        // Fall through to raw File on io_uring failure
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Windows source-file reads at or above the 1 MB fast-path threshold now route
through the IOCP overlapped reader, mirroring how Linux reads route through
io_uring. The IOCP reader (`IocpReader` / `IocpOrStdReader`) was already fully
implemented but unwired: file reads on Windows fell to the standard buffered
stub, so the async completion-port read path never ran.

## What changed

- `crates/transfer/src/generator/context.rs` - the two large-read sites
  (`open_source_reader`, `open_source_unbuffered`) now `#[cfg(target_os = "windows")]`
  dispatch through `fast_io::iocp_reader_from_path(path, IocpPolicy::Auto)`.
  Linux / macOS keep the existing `reader_from_path_with_depth` (io_uring / std)
  path unchanged. Both branches depend only on the `FileReader` trait, so the
  call sites are agnostic to the concrete reader.
- The dispatch mirrors the disk-commit writer exactly: runtime
  `is_iocp_available()` detection with a transparent std buffered fallback, and
  the same feature/cfg gating (`iocp` is a default fast_io feature, real impl on
  Windows and a std-backed stub elsewhere). Builds without IOCP or systems
  without completion-port support are byte-for-byte unchanged. The change is
  gated by the pre-existing `io_uring_policy != Disabled` guard, so `--no-io-uring`
  disables the fast read path on Windows too.

## Tests

- Windows-gated parity tests in `crates/fast_io/src/iocp/file_reader.rs` assert
  the IOCP reader yields byte-identical output to the std reader across
  multi-block (> 1 MB, multiple overlapped batches), short, and empty files,
  exercising both the batched `read_all` and the sequential `read_at` paths.
- The required `windows-test` CI cell's `fast_io` step filter is extended to run
  the new tests (`test(iocp_read_parity)`) alongside the existing crtime/sparse
  tests. The `windows-iocp` job additionally runs the full `fast_io` suite.

## Cross-compile verification (from macOS)

- `cargo check -p fast_io -p transfer -p engine` (host) - clean
- `cargo check ... --target x86_64-pc-windows-gnu` - clean
- `cargo check --tests -p fast_io --target x86_64-pc-windows-gnu` - clean
- `cargo clippy -p fast_io -p transfer -p engine --all-features -- -D warnings` - clean
- `x86_64-pc-windows-msvc` does not resolve in this environment: the C `zstd`
  build dependency needs MSVC C headers when cross-compiling from macOS
  (unrelated to this change).
