### PR TITLE
fix(client): propagate daemon rejection exit code instead of 23

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -13,12 +13,14 @@ use protocol::ProtocolVersion;
 use super::server_config::{build_server_config_for_generator, build_server_config_for_receiver};
 use super::stats::convert_server_stats_to_summary;
 use crate::client::config::ClientConfig;
-use crate::client::error::{ClientError, invalid_argument_error};
+use crate::client::error::{ClientError, invalid_argument_error, remote_exit_error};
 use crate::client::module_list::{DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter};
 use crate::client::progress::ClientProgressObserver;
 use crate::client::remote::batch_support::{BatchContext, build_batch_recording};
 use crate::client::remote::flags;
 use crate::client::summary::ClientSummary;
+use crate::exit_code::ExitCode;
+use crate::message::Role;
 use crate::server::handshake::HandshakeResult;
 use crate::server::{TransferProgressCallback, TransferProgressEvent};
 
@@ -92,7 +94,7 @@ pub(crate) fn run_pull_transfer(
         #[cfg(feature = "async-bench")]
         None,
     )
-    .map_err(|e| invalid_argument_error(&format!("transfer failed: {e}"), 23))?;
+    .map_err(|e| map_server_transfer_error(e, Role::Receiver))?;
     let elapsed = start.elapsed();
 
     let mut summary = convert_server_stats_to_summary(server_stats, elapsed);
@@ -189,8 +191,48 @@ pub(crate) fn run_push_transfer(
             // its socket early after receiving the file list.
             Ok(ClientSummary::default())
         }
-        Err(e) => Err(invalid_argument_error(&format!("transfer failed: {e}"), 23)),
+        Err(e) => Err(map_server_transfer_error(e, Role::Sender)),
     }
+}
+
+/// Maps a `run_server_with_handshake` failure to a [`ClientError`], honouring a
+/// remote peer's explicit `MSG_ERROR_EXIT` code when one is present.
+///
+/// When the remote daemon rejects the transfer (for example a read-only module
+/// on a push), it emits its error text via `MSG_ERROR_XFER` - already printed to
+/// stderr by the multiplex reader - followed by `MSG_ERROR_EXIT` carrying the
+/// exit code. The reader surfaces that code as a [`transfer::RemoteExitError`]
+/// nested inside the returned `io::Error`. Recovering it here lets the client
+/// exit with the daemon's own code (e.g. `RERR_SYNTAX = 1`) instead of forcing a
+/// generic partial-transfer (23). The role-tagged `rsync error:` trailer mirrors
+/// upstream `log_exit()`; the daemon's message is not reprinted because the
+/// reader already delivered it to stderr in wire order.
+///
+/// Failures with no embedded remote code (local I/O, protocol desync) keep the
+/// prior generic `transfer failed: ...` (23) diagnostic.
+///
+/// upstream: io.c:1663-1701 - `MSG_ERROR_EXIT` drives the NORETURN
+/// `_exit_cleanup(val)`, so the client's final exit code is the peer's code.
+fn map_server_transfer_error(error: std::io::Error, role: Role) -> ClientError {
+    if let Some(code) = remote_exit_code(&error) {
+        let exit = ExitCode::from_i32(code).unwrap_or(ExitCode::PartialTransfer);
+        return remote_exit_error(exit, role, "");
+    }
+    invalid_argument_error(&format!("transfer failed: {error}"), 23)
+}
+
+/// Walks the source chain of an `io::Error` looking for a
+/// [`transfer::RemoteExitError`], returning the peer-supplied exit code when the
+/// failure originated from a remote `MSG_ERROR_EXIT` frame.
+fn remote_exit_code(error: &std::io::Error) -> Option<i32> {
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(error.get_ref()?);
+    while let Some(err) = source {
+        if let Some(remote) = err.downcast_ref::<crate::server::RemoteExitError>() {
+            return Some(remote.code);
+        }
+        source = err.source();
+    }
+    None
 }
 
 /// Builds a `HandshakeResult` for daemon transfers where the protocol version
@@ -293,3 +335,83 @@ impl TransferProgressCallback for DaemonProgressAdapter<'_> {
 /// - `main.c:1354-1356` - `start_filesfrom_forwarding(filesfrom_fd)`
 #[cfg(test)]
 pub(super) use crate::client::remote::files_from_forwarding::read_local_files_from_for_forwarding as read_files_from_for_forwarding;
+
+#[cfg(test)]
+mod map_server_transfer_error_tests {
+    use super::*;
+    use crate::server::RemoteExitError;
+
+    fn remote_exit_io(code: i32) -> std::io::Error {
+        std::io::Error::new(
+            std::io::ErrorKind::ConnectionAborted,
+            RemoteExitError { code },
+        )
+    }
+
+    /// The production path wraps `RemoteExitError` directly as the inner error,
+    /// so it must be recovered from `get_ref()`.
+    #[test]
+    fn extracts_code_from_direct_inner_error() {
+        assert_eq!(remote_exit_code(&remote_exit_io(1)), Some(1));
+    }
+
+    /// A `RemoteExitError` reached only via a `source()` link must still be
+    /// found, so an intermediate wrapper cannot hide the peer's code.
+    #[test]
+    fn extracts_code_from_nested_source_chain() {
+        #[derive(Debug)]
+        struct Wrap(RemoteExitError);
+        impl std::fmt::Display for Wrap {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "wrapped: {}", self.0)
+            }
+        }
+        impl std::error::Error for Wrap {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+        let nested = std::io::Error::other(Wrap(RemoteExitError { code: 7 }));
+        assert_eq!(remote_exit_code(&nested), Some(7));
+    }
+
+    #[test]
+    fn no_code_for_plain_io_error() {
+        let plain = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe");
+        assert_eq!(remote_exit_code(&plain), None);
+    }
+
+    /// A daemon rejection (e.g. read-only module, RERR_SYNTAX = 1) must exit
+    /// with the daemon's code, tagged with the local role, and must NOT prepend
+    /// the generic `transfer failed:` prefix - the reader already printed the
+    /// daemon's message to stderr in wire order.
+    #[test]
+    fn maps_remote_reject_to_daemon_code_without_transfer_failed_prefix() {
+        let err = map_server_transfer_error(remote_exit_io(1), Role::Sender);
+        assert_eq!(err.exit_code(), 1);
+        assert_eq!(err.code(), ExitCode::Syntax);
+        let rendered = err.to_string();
+        assert!(!rendered.contains("transfer failed"), "{rendered}");
+        assert!(rendered.contains("[sender="), "{rendered}");
+    }
+
+    /// A pull tags the diagnostic with the receiver role.
+    #[test]
+    fn maps_remote_reject_pull_uses_receiver_role() {
+        let err = map_server_transfer_error(remote_exit_io(1), Role::Receiver);
+        assert_eq!(err.exit_code(), 1);
+        assert!(err.to_string().contains("[receiver="), "{err}");
+    }
+
+    /// Failures with no embedded remote code keep the prior generic
+    /// `transfer failed: ...` (23) behaviour.
+    #[test]
+    fn maps_plain_failure_to_generic_partial_transfer() {
+        let err = map_server_transfer_error(
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe"),
+            Role::Receiver,
+        );
+        assert_eq!(err.exit_code(), 23);
+        assert!(err.to_string().contains("transfer failed"), "{err}");
+    }
+}

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -174,6 +174,7 @@ pub use self::generator::{
     GeneratorContext, GeneratorStats, generate_delta_from_signature, io_error_flags,
 };
 pub use self::handshake::{HandshakeResult, perform_handshake, perform_legacy_handshake};
+pub use self::reader::RemoteExitError;
 pub use self::receiver::{ListOnlyEntry, ReceiverContext, SumHead, TransferStats};
 pub use self::role::ServerRole;
 pub use self::shared::{ChecksumFactory, TransferDeadline};

--- a/crates/transfer/src/reader/mod.rs
+++ b/crates/transfer/src/reader/mod.rs
@@ -17,6 +17,7 @@ mod tests;
 
 pub(crate) use counting::CountingReader;
 pub(crate) use multiplex::MultiplexReader;
+pub use multiplex::RemoteExitError;
 pub use server::ServerReader;
 
 #[cfg(feature = "tokio-transfer")]

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -110,6 +110,36 @@ pub(crate) struct MultiplexReader<R> {
 /// `got_xfer_error` is set (cleanup.c:217-218, main.c:1608-1609).
 pub(super) const RERR_PARTIAL: i32 = 23;
 
+/// Typed error carrying the exit code a remote peer requested via
+/// `MSG_ERROR_EXIT`.
+///
+/// [`MultiplexReader::check_error_exit`] wraps this in an [`io::Error`] as its
+/// inner error so the code survives `?` propagation up the read stack. Callers
+/// that terminate a transfer can `downcast_ref` the inner error to recover the
+/// peer's exact exit code (e.g. `RERR_SYNTAX = 1` for a read-only module
+/// rejection) instead of collapsing every failure to a generic partial-transfer
+/// (23) code.
+///
+/// The [`Display`](std::fmt::Display) output is byte-identical to the previous
+/// inline string form (`"remote error exit (code N)"`), so any diagnostic that
+/// rendered the wrapping `io::Error` verbatim is unchanged.
+///
+/// upstream: io.c:1663-1701 - on `MSG_ERROR_EXIT` the client calls the NORETURN
+/// `_exit_cleanup(val)`, exiting with the peer-supplied code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemoteExitError {
+    /// Exit code the remote peer requested via `MSG_ERROR_EXIT`.
+    pub code: i32,
+}
+
+impl std::fmt::Display for RemoteExitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "remote error exit (code {})", self.code)
+    }
+}
+
+impl std::error::Error for RemoteExitError {}
+
 /// Default buffer capacity for `MultiplexReader`.
 ///
 /// 64KB matches the `MultiplexWriter` buffer size and upstream rsync's
@@ -217,7 +247,7 @@ impl<R> MultiplexReader<R> {
             }
             Err(io::Error::new(
                 io::ErrorKind::ConnectionAborted,
-                format!("remote error exit (code {code})"),
+                RemoteExitError { code },
             ))
         } else {
             Ok(())
@@ -576,5 +606,46 @@ impl<R: tokio::io::AsyncRead + Unpin> MultiplexReader<R> {
             }
             self.check_error_exit()?;
         }
+    }
+}
+
+#[cfg(test)]
+mod remote_exit_error_tests {
+    use super::*;
+
+    /// The typed error must render byte-identically to the previous inline
+    /// string form so any diagnostic that displayed the wrapping `io::Error`
+    /// verbatim is unchanged.
+    #[test]
+    fn display_matches_legacy_string_form() {
+        for code in [0, 1, 23, 255, -1] {
+            let err = RemoteExitError { code };
+            assert_eq!(err.to_string(), format!("remote error exit (code {code})"));
+        }
+    }
+
+    /// `check_error_exit` must wrap the code as the inner error of a
+    /// `ConnectionAborted` `io::Error` so callers can `downcast_ref` it and
+    /// honour the peer's exit code instead of forcing 23.
+    #[test]
+    fn check_error_exit_wraps_typed_inner_error() {
+        let mut reader = MultiplexReader::new(io::empty());
+        reader.error_exit_code = Some(1);
+        let err = reader.check_error_exit().expect_err("code 1 must abort");
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
+        let inner = err
+            .get_ref()
+            .and_then(|e| e.downcast_ref::<RemoteExitError>())
+            .expect("inner RemoteExitError must survive");
+        assert_eq!(inner.code, 1);
+    }
+
+    /// RERR_PARTIAL (23) suppression must remain: the msg2sndr race means a
+    /// bare exit-23 is non-fatal and must not abort the read loop.
+    #[test]
+    fn check_error_exit_suppresses_rerr_partial() {
+        let mut reader = MultiplexReader::new(io::empty());
+        reader.error_exit_code = Some(RERR_PARTIAL);
+        assert!(reader.check_error_exit().is_ok());
     }
 }


### PR DESCRIPTION
## Problem

When a daemon rejects a transfer post-handshake (e.g. a read-only module on a push), it sends its error text via `MSG_ERROR_XFER` followed by `MSG_ERROR_EXIT` carrying the exit code (`RERR_SYNTAX = 1` for a read-only module). The multiplex reader already printed the daemon's text to stderr and captured the code, but `check_error_exit` discarded the code into a plain-string `io::Error`, and the daemon transfer orchestration then flattened every failure to `invalid_argument_error("transfer failed: ...", 23)`.

Result: the client exited **23** with `transfer failed: remote error exit (code 1) (code 23) ... [client=...]` instead of upstream's **1** with the daemon's message. Note the daemon had already reported code 1 - the client threw it away.

Upstream (`io.c:1663-1701`) instead runs `_exit_cleanup(val)`, exiting with the daemon-supplied code after printing the daemon's message.

## Fix

- New typed `RemoteExitError { code }` (exported from the transfer crate) carried as the inner error of the `ConnectionAborted` `io::Error` produced by `check_error_exit`. Its `Display` is byte-identical to the previous string form (`remote error exit (code N)`), so any diagnostic that rendered the wrapping error verbatim is unchanged.
- The daemon push/pull orchestration walks the `io::Error` source chain, recovers the peer's code, and renders the role-tagged `rsync error:` trailer via the existing `remote_exit_error` machinery - without reprinting the daemon message (the reader already delivered it in wire order) or prepending `transfer failed:`. Push tags `[sender]`, pull tags `[receiver]`, matching `who_am_i()`.
- Failures with no embedded remote code keep the prior generic `transfer failed: ...` (23) diagnostic. The `RERR_PARTIAL (23)` msg2sndr suppression branch is unchanged.

No string parsing - the code is recovered by downcasting the typed inner error.

## Verification (real upstream rsync 3.4.4, aarch64 Linux)

Read-only module, PUSH:

| Scenario | exit | stderr (final line) |
|----------|------|---------------------|
| current master, oc-client -> oc daemon | 23 | `... error: transfer failed: remote error exit (code 1) (code 23) ... [client=...]` |
| **fixed**, oc-client -> oc daemon | **1** | `ERROR: module is read only` + `... error: syntax or usage error (code 1) ... [sender=...]` |
| upstream 3.4.4 client -> oc daemon | 1 | `ERROR: module is read only` (+ write-error whine); exit **1** |
| fixed oc-client -> upstream 3.4.4 daemon | **1** | daemon message + `... syntax or usage error (code 1) ...`; exit **1** |
| upstream client -> upstream daemon | 1 | daemon message; exit **1** |

The fixed client decodes both oc's and real upstream's `MSG_ERROR_EXIT` frames and exits with the daemon's code (1), matching upstream, instead of forcing 23.

## Tests

- `RemoteExitError` `Display` byte-parity with the legacy string form; `check_error_exit` wraps the typed inner error and still suppresses `RERR_PARTIAL (23)`.
- Orchestration helper extracts the code from a direct and a nested (`source()`-chained) `io::Error`, maps a daemon reject to the daemon's code with the correct role and no `transfer failed:` prefix, and keeps the generic 23 fallback for plain failures.
