### PR TITLE
refactor(transfer): lazy on-demand flist-segment fetch in the receiver (no behavior change)

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -204,6 +204,32 @@ pub struct ReceiverContext {
     /// gate drops. `emit_itemize` reads this to decide whether to force the
     /// created-directory glyph for the root entry.
     pub(in crate::receiver) dest_root_created: bool,
+    /// Whether the sender has finished transmitting the file list.
+    ///
+    /// Set to `true` once `receive_file_list` completes on a non-INC_RECURSE
+    /// transfer (the whole list arrives in one shot), or once the terminating
+    /// `NDX_FLIST_EOF` marker is read during INC_RECURSE sub-list reception.
+    /// The lazy segment-fetch primitives in [`super::file_list`] consult this to
+    /// know when no further segments can arrive, so they never block on a wire
+    /// read past the end of the list.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:101` / `io.c:1750-1786` - `flist_eof` gates the generator's
+    ///   on-demand `recv_file_list()` fetch loop.
+    pub(in crate::receiver) flist_eof: bool,
+    /// Target `file_list` length for the INC_RECURSE hardlink look-ahead.
+    ///
+    /// Before applying hardlinks the receiver pre-reads sub-list segments until
+    /// the list holds at least this many entries (or `flist_eof` is reached), so
+    /// a follower whose leader arrives in a later segment is already resolved.
+    /// Defaults to `MIN_FILECNT_LOOKAHEAD / 2` (500).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:2300-2305` - `preserve_hard_links && inc_recurse` pre-reads
+    ///   until `file_total < MIN_FILECNT_LOOKAHEAD / 2`.
+    pub(in crate::receiver) hardlink_lookahead_target: usize,
 }
 
 impl ReceiverContext {
@@ -262,6 +288,9 @@ impl ReceiverContext {
             pending_del_stats: DeleteStats::new(),
             pipeline,
             dest_root_created: false,
+            flist_eof: false,
+            // upstream: generator.c:2304 - MIN_FILECNT_LOOKAHEAD / 2 (1000 / 2).
+            hardlink_lookahead_target: 500,
         }
     }
 

--- a/crates/transfer/src/receiver/file_list/mod.rs
+++ b/crates/transfer/src/receiver/file_list/mod.rs
@@ -7,7 +7,10 @@
 //! Split into focused submodules to keep each file within the 650-line cap:
 //!
 //! - `receive` - `receive_file_list`, `receive_extra_file_lists`,
-//!   `publish_segment_to_delete_pipeline`, and `incremental_file_list_receiver`.
+//!   `receive_one_extra_segment`, `publish_segment_to_delete_pipeline`, and
+//!   `incremental_file_list_receiver`.
+//! - `on_demand` - lazy INC_RECURSE segment fetch (`read_next_frame`,
+//!   `ensure_flat_idx`, `ensure_all_segments_loaded`, `prefetch_for_hardlinks`).
 //! - `id_lists` - UID/GID name-to-ID mapping reception.
 //! - `sanitize` - file-list sanity validation against directory traversal.
 //! - `hardlinks` - post-sort hardlink leader/follower assignment for
@@ -17,6 +20,7 @@
 mod hardlinks;
 mod id_lists;
 mod incremental;
+mod on_demand;
 mod prune;
 mod receive;
 #[cfg(feature = "tokio-transfer")]

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -1,0 +1,367 @@
+//! Lazy, on-demand INC_RECURSE flist-segment fetch for the receiver.
+//!
+//! Upstream's generator fetches sub-list segments on demand: it reads one frame
+//! at a time off the sender's stream (`io.c:read_ndx_and_attrs`), appending a
+//! new segment whenever a `NDX_FLIST_OFFSET` marker arrives and stopping at
+//! `NDX_FLIST_EOF`. The receiver never drains the whole list up front; it pulls
+//! the next segment only when it needs an index the current list does not yet
+//! cover. This module provides that primitive as methods on
+//! [`ReceiverContext`]:
+//!
+//! - [`ReceiverContext::read_next_frame`] classifies and dispatches one frame,
+//!   appending a segment via
+//!   [`receive_one_extra_segment`](ReceiverContext::receive_one_extra_segment)
+//!   and setting `flist_eof` at the terminator.
+//! - [`ReceiverContext::ensure_flat_idx`] pulls segments until a target flat
+//!   index is materialized (or the list ends), never indexing out of bounds.
+//! - [`ReceiverContext::ensure_all_segments_loaded`] drains every remaining
+//!   segment, reproducing the old up-front behaviour for the batched drivers.
+//! - [`ReceiverContext::prefetch_for_hardlinks`] pre-reads segments so a
+//!   follower's leader in a later segment is resolved before hardlinking.
+//!
+//! When INC_RECURSE is not negotiated, `flist_eof` is already set once
+//! `receive_file_list` returns, so every method here is an immediate no-op that
+//! performs no wire read - the transfer behaves exactly as before.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync.c:318-429` - `read_ndx_and_attrs()` frame dispatch
+//! - `io.c:1750-1786` - `wait_for_receiver()` one-frame fetch
+//! - `generator.c:2299-2368` - `generate_files()` on-demand fetch loop
+
+use std::io::{self, Read};
+
+use protocol::codec::{NDX_DONE, NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum};
+
+use super::super::ReceiverContext;
+
+/// Classification of one frame read off the sender's flist/transfer stream.
+///
+/// Mirrors the four outcomes of upstream `read_ndx_and_attrs()`
+/// (`rsync.c:318-429`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::receiver) enum FrameKind {
+    /// An INC_RECURSE sub-list segment for the content-directory wire NDX was
+    /// consumed and appended to `file_list`.
+    Segment(i32),
+    /// `NDX_FLIST_EOF`: no more segments follow. `flist_eof` is now set.
+    FlistEof,
+    /// `NDX_DONE`: the sender signalled phase completion.
+    Done,
+    /// A non-negative NDX - a per-file reply/echo.
+    Reply(i32),
+}
+
+impl ReceiverContext {
+    /// Reads and dispatches one frame off the sender's stream.
+    ///
+    /// A segment marker (`ndx <= NDX_FLIST_OFFSET`) is consumed in full via
+    /// [`receive_one_extra_segment`](Self::receive_one_extra_segment) and
+    /// reported as [`FrameKind::Segment`]. `NDX_FLIST_EOF` sets `flist_eof` and
+    /// reports [`FrameKind::FlistEof`]; `NDX_DONE` reports [`FrameKind::Done`];
+    /// any non-negative value reports [`FrameKind::Reply`].
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:330-381` - segment marker vs NDX_DONE vs positive-ndx dispatch
+    pub(in crate::receiver) fn read_next_frame<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        ndx_codec: &mut NdxCodecEnum,
+    ) -> io::Result<FrameKind> {
+        let ndx = ndx_codec.read_ndx(reader)?;
+
+        if ndx == NDX_FLIST_EOF {
+            self.flist_eof = true;
+            return Ok(FrameKind::FlistEof);
+        }
+        if ndx == NDX_DONE {
+            return Ok(FrameKind::Done);
+        }
+        if ndx <= NDX_FLIST_OFFSET {
+            self.receive_one_extra_segment(reader, ndx)?;
+            return Ok(FrameKind::Segment(NDX_FLIST_OFFSET - ndx));
+        }
+        Ok(FrameKind::Reply(ndx))
+    }
+
+    /// Ensures `file_list[flat_idx]` is materialized, pulling INC_RECURSE
+    /// segments as needed.
+    ///
+    /// Returns `true` when an entry exists at `flat_idx` (the caller may index
+    /// it), or `false` once the list is complete (`flist_eof`) and `flat_idx`
+    /// is past the end. Never indexes out of bounds and never reads the wire
+    /// when `flist_eof` is already set - so on a non-INC_RECURSE transfer this
+    /// simply reports `flat_idx < file_list.len()` without touching the reader.
+    ///
+    /// Encountering a per-file [`FrameKind::Reply`] while fetching a segment is
+    /// a protocol desync and surfaces as [`io::ErrorKind::InvalidData`].
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:2299-2368` - fetch the next segment when the cursor
+    ///   reaches the end of the current one and `!flist_eof`.
+    pub(in crate::receiver) fn ensure_flat_idx<R: Read + ?Sized>(
+        &mut self,
+        flat_idx: usize,
+        reader: &mut R,
+        ndx_codec: &mut NdxCodecEnum,
+    ) -> io::Result<bool> {
+        loop {
+            if flat_idx < self.file_list.len() {
+                return Ok(true);
+            }
+            if self.flist_eof {
+                return Ok(false);
+            }
+            match self.read_next_frame(reader, ndx_codec)? {
+                FrameKind::Segment(_) | FrameKind::FlistEof => {}
+                FrameKind::Done => {
+                    // The sender signalled completion before NDX_FLIST_EOF;
+                    // treat it as the end of the list.
+                    self.flist_eof = true;
+                    return Ok(false);
+                }
+                FrameKind::Reply(ndx) => return Err(unexpected_reply(ndx)),
+            }
+        }
+    }
+
+    /// Drains every remaining INC_RECURSE segment until `flist_eof`.
+    ///
+    /// Reproduces the pre-refactor behaviour where the whole list was
+    /// materialized up front, so the batched pipelined drivers see a complete
+    /// `file_list`. A no-op (no wire read) once `flist_eof` is set, which is
+    /// always the case on a non-INC_RECURSE transfer by the time a driver calls
+    /// this.
+    pub(in crate::receiver) fn ensure_all_segments_loaded<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        ndx_codec: &mut NdxCodecEnum,
+    ) -> io::Result<()> {
+        while !self.flist_eof {
+            match self.read_next_frame(reader, ndx_codec)? {
+                FrameKind::Segment(_) | FrameKind::FlistEof => {}
+                FrameKind::Done => self.flist_eof = true,
+                FrameKind::Reply(ndx) => return Err(unexpected_reply(ndx)),
+            }
+        }
+        Ok(())
+    }
+
+    /// Pre-reads segments until the list holds `hardlink_lookahead_target`
+    /// entries (or `flist_eof`), so a follower whose leader arrives in a later
+    /// segment is resolved before hardlinking.
+    ///
+    /// A no-op when `flist_eof` is already set (every non-INC_RECURSE transfer).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:2300-2305` - `preserve_hard_links && inc_recurse`
+    ///   pre-reads until `file_total < MIN_FILECNT_LOOKAHEAD / 2`.
+    pub(in crate::receiver) fn prefetch_for_hardlinks<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        ndx_codec: &mut NdxCodecEnum,
+    ) -> io::Result<()> {
+        while !self.flist_eof && self.file_list.len() < self.hardlink_lookahead_target {
+            match self.read_next_frame(reader, ndx_codec)? {
+                FrameKind::Segment(_) | FrameKind::FlistEof => {}
+                FrameKind::Done => self.flist_eof = true,
+                // A per-file reply here means the transfer phase has started;
+                // stop prefetching rather than treat it as a desync.
+                FrameKind::Reply(_) => break,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Builds the "unexpected per-file NDX while fetching a segment" error.
+fn unexpected_reply(ndx: i32) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "unexpected per-file NDX {ndx} while fetching file-list segment {}{}",
+            crate::role_trailer::error_location!(),
+            crate::role_trailer::receiver()
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    //! Lazy segment-fetch against a mock throttled sender.
+    //!
+    //! Builds a `Cursor<Vec<u8>>` wire the same way the receiver's own
+    //! wire-parity tests do (`FileListWriter` for the segment entries, the NDX
+    //! codec for the `NDX_FLIST_OFFSET` / `NDX_FLIST_EOF` framing), simulating a
+    //! sender that pushes several sub-list segments before the terminator. The
+    //! test proves `ensure_flat_idx` grows `file_list` one segment at a time and
+    //! reports `flist_eof` exactly at the marker - never over-reading and never
+    //! indexing out of bounds.
+
+    use std::ffi::OsString;
+    use std::io::Cursor;
+    use std::path::PathBuf;
+
+    use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, create_ndx_codec};
+    use protocol::flist::{FileEntry, FileListWriter};
+    use protocol::{CompatibilityFlags, ProtocolVersion};
+
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::receiver::ReceiverContext;
+    use crate::role::ServerRole;
+
+    const PROTOCOL: u8 = 32;
+
+    /// Protocol-32 receiver config with no flags set (mirrors the shared
+    /// `test_config` fixture, inlined because that helper is `pub(super)` to the
+    /// receiver test tree).
+    fn test_config() -> ServerConfig {
+        ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(PROTOCOL).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        }
+    }
+
+    /// Protocol-32 handshake with no compat flags.
+    fn test_handshake() -> HandshakeResult {
+        HandshakeResult {
+            protocol: ProtocolVersion::try_from(PROTOCOL).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        }
+    }
+
+    /// Encodes `segments.len()` INC_RECURSE sub-list segments (each with its own
+    /// `NDX_FLIST_OFFSET - dir_ndx` marker and entries) followed by
+    /// `NDX_FLIST_EOF`. Returns the wire bytes and the total entry count.
+    fn encode_segments(segments: &[Vec<(&str, u64)>]) -> (Vec<u8>, usize) {
+        let protocol = ProtocolVersion::try_from(PROTOCOL).unwrap();
+        let mut writer = FileListWriter::new(protocol);
+        let mut ndx_codec = create_ndx_codec(PROTOCOL);
+        let mut wire = Vec::new();
+        let mut total = 0;
+
+        for (dir_ndx, entries) in segments.iter().enumerate() {
+            ndx_codec
+                .write_ndx(&mut wire, NDX_FLIST_OFFSET - dir_ndx as i32)
+                .unwrap();
+            for (name, size) in entries {
+                let mut e = FileEntry::new_file(PathBuf::from(name), *size, 0o100644);
+                e.set_mtime(1_700_000_000, 0);
+                writer.write_entry(&mut wire, &e).unwrap();
+                total += 1;
+            }
+            writer.write_end(&mut wire, None).unwrap();
+        }
+        ndx_codec.write_ndx(&mut wire, NDX_FLIST_EOF).unwrap();
+        (wire, total)
+    }
+
+    fn inc_recurse_receiver() -> ReceiverContext {
+        let mut handshake = test_handshake();
+        handshake.compat_flags = Some(CompatibilityFlags::INC_RECURSE);
+        ReceiverContext::new_for_test(&handshake, test_config())
+    }
+
+    #[test]
+    fn ensure_flat_idx_pulls_segments_lazily_until_eof() {
+        // Three segments of 2, 3, and 1 entries: a sender that interleaves
+        // several pushes before throttling at the terminator.
+        let segments = vec![
+            vec![("dir0/a.txt", 10u64), ("dir0/b.txt", 20)],
+            vec![("dir1/c.txt", 30), ("dir1/d.txt", 40), ("dir1/e.txt", 50)],
+            vec![("dir2/f.txt", 60)],
+        ];
+        let (wire, total) = encode_segments(&segments);
+        assert_eq!(total, 6);
+
+        let mut ctx = inc_recurse_receiver();
+        // A fresh INC_RECURSE receiver has no entries yet and is not at EOF.
+        assert_eq!(ctx.file_list().len(), 0);
+        assert!(!ctx.flist_eof);
+
+        let mut reader = Cursor::new(wire);
+        let mut codec = create_ndx_codec(PROTOCOL);
+
+        // Index 0 pulls the first segment (2 entries), so the list grows to 2.
+        assert!(ctx.ensure_flat_idx(0, &mut reader, &mut codec).unwrap());
+        assert_eq!(ctx.file_list().len(), 2);
+        assert!(!ctx.flist_eof);
+
+        // Index 1 is already covered - no further read.
+        let pos_before = reader.position();
+        assert!(ctx.ensure_flat_idx(1, &mut reader, &mut codec).unwrap());
+        assert_eq!(ctx.file_list().len(), 2);
+        assert_eq!(
+            reader.position(),
+            pos_before,
+            "index within segment re-read the wire"
+        );
+
+        // Index 2 pulls the second segment (3 entries) -> 5.
+        assert!(ctx.ensure_flat_idx(2, &mut reader, &mut codec).unwrap());
+        assert_eq!(ctx.file_list().len(), 5);
+
+        // Walk to the last real entry, pulling the third segment (1 entry) -> 6.
+        assert!(ctx.ensure_flat_idx(5, &mut reader, &mut codec).unwrap());
+        assert_eq!(ctx.file_list().len(), total);
+
+        // One past the end reads the NDX_FLIST_EOF marker and reports no entry.
+        assert!(!ctx.ensure_flat_idx(6, &mut reader, &mut codec).unwrap());
+        assert!(
+            ctx.flist_eof,
+            "flist_eof must be set once the terminator is read"
+        );
+
+        // Idempotent past EOF: no more reads, still no entry.
+        let pos_eof = reader.position();
+        assert!(!ctx.ensure_flat_idx(6, &mut reader, &mut codec).unwrap());
+        assert!(!ctx.ensure_flat_idx(100, &mut reader, &mut codec).unwrap());
+        assert_eq!(reader.position(), pos_eof, "reads occurred past flist_eof");
+    }
+
+    #[test]
+    fn ensure_all_segments_loaded_drains_every_segment() {
+        let segments = vec![vec![("s0/a", 1u64)], vec![("s1/b", 2), ("s1/c", 3)]];
+        let (wire, total) = encode_segments(&segments);
+
+        let mut ctx = inc_recurse_receiver();
+        let mut reader = Cursor::new(wire);
+        let mut codec = create_ndx_codec(PROTOCOL);
+
+        ctx.ensure_all_segments_loaded(&mut reader, &mut codec)
+            .unwrap();
+        assert_eq!(ctx.file_list().len(), total);
+        assert!(ctx.flist_eof);
+    }
+
+    #[test]
+    fn ensure_flat_idx_is_noop_without_inc_recurse() {
+        // A non-INC_RECURSE receiver is already at flist_eof (set by
+        // receive_file_list); ensure_flat_idx must never touch the reader.
+        let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
+        ctx.flist_eof = true;
+        ctx.file_list
+            .push(FileEntry::new_file("only.txt".into(), 7, 0o100644));
+
+        // A reader that would error if read from, proving no wire access.
+        let mut reader = Cursor::new(Vec::<u8>::new());
+        let mut codec = create_ndx_codec(PROTOCOL);
+
+        assert!(ctx.ensure_flat_idx(0, &mut reader, &mut codec).unwrap());
+        assert!(!ctx.ensure_flat_idx(1, &mut reader, &mut codec).unwrap());
+        assert_eq!(reader.position(), 0);
+    }
+}

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -64,6 +64,14 @@ impl ReceiverContext {
         let inc_recurse = self
             .compat_flags
             .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
+
+        // Without INC_RECURSE the whole list arrives in this single call, so the
+        // file list is complete. With INC_RECURSE the sender streams per-directory
+        // sub-lists afterwards, terminated by NDX_FLIST_EOF, so leave `flist_eof`
+        // clear until that marker is read (in `receive_one_extra_segment`'s caller).
+        // upstream: io.c:1750-1786 - `flist_eof` gates the on-demand fetch loop.
+        self.flist_eof = !inc_recurse;
+
         if !inc_recurse {
             self.receive_id_lists(reader)?;
         }
@@ -154,6 +162,11 @@ impl ReceiverContext {
     ///
     /// - `flist.c:recv_file_list()` - reads entries for each sub-list
     /// - `io.c:read_ndx_and_attrs()` - detects NDX_FLIST_OFFSET framing
+    ///
+    /// Retained as the batched drain for the wire-parity tests and future
+    /// `--files-from` use; the drivers now fetch segments lazily via the
+    /// on-demand primitives, so the non-test lib build has no caller.
+    #[allow(dead_code)]
     pub(in crate::receiver) fn receive_extra_file_lists<R: Read + ?Sized>(
         &mut self,
         reader: &mut R,
@@ -166,12 +179,6 @@ impl ReceiverContext {
         }
 
         let mut ndx_codec = create_ndx_codec(self.protocol.as_u8());
-        // upstream: flist.c:recv_file_entry() - reuse cached reader to preserve
-        // compression state (prev_name, prev_mode, prev_uid, prev_gid).
-        let mut flist_reader = self
-            .flist_reader_cache
-            .take()
-            .unwrap_or_else(|| self.build_flist_reader());
         let mut total_extra = 0;
 
         loop {
@@ -179,90 +186,11 @@ impl ReceiverContext {
 
             if ndx == NDX_FLIST_EOF {
                 debug_log!(Flist, 2, "received NDX_FLIST_EOF, file list complete");
+                self.flist_eof = true;
                 break;
             }
 
-            if ndx > NDX_FLIST_OFFSET {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "expected NDX_FLIST_OFFSET or NDX_FLIST_EOF, got {ndx} {}{}",
-                        crate::role_trailer::error_location!(),
-                        crate::role_trailer::receiver()
-                    ),
-                ));
-            }
-
-            let dir_ndx = NDX_FLIST_OFFSET - ndx;
-            let flat_start = self.file_list.len();
-
-            // Compute seg_ndx_start BEFORE reading entries so the reader can
-            // distinguish abbreviated vs unabbreviated hardlink followers.
-            // upstream: flist.c:recv_file_entry() uses flist->ndx_start
-            let &(prev_flat_start, prev_ndx_start) =
-                self.ndx_segments.last().expect("initial segment exists");
-            let prev_used = (flat_start - prev_flat_start) as i32;
-            let seg_ndx_start = prev_ndx_start + prev_used + 1;
-            flist_reader.set_ndx_start(seg_ndx_start);
-
-            let mut segment_count = 0;
-
-            // Pass segment entries so abbreviated followers can resolve leaders.
-            while let Some(entry) =
-                flist_reader.read_entry_with_flist(reader, &self.file_list[flat_start..])?
-            {
-                self.file_list.push(entry);
-                segment_count += 1;
-            }
-
-            // upstream: flist.c:1646 - leader GNUM is readdir-order wire NDX,
-            // assigned before sorting.
-            if self.config.flags.hard_links {
-                for (i, entry) in self.file_list[flat_start..].iter_mut().enumerate() {
-                    if entry.hlink_first() {
-                        entry.set_hardlink_idx((seg_ndx_start + i as i32) as u32);
-                    }
-                }
-            }
-
-            // upstream: flist.c:2155,2736 - both sides call flist_sort_and_clean()
-            // independently. Unstable sort (true) is safe - entries have unique paths.
-            // INC_RECURSE requires protocol >= 30, so pre29 is always false here.
-            //
-            // Iconv suppresses the in-place reorder for the same reason as the
-            // initial flist: upstream's `need_unsorted_flist` keeps the
-            // NDX-addressed array in scan order so the receiver can resolve
-            // generator requests against the bytes the sender emitted.
-            if !self.iconv_reorder_suppressed() {
-                sort_file_list(&mut self.file_list[flat_start..], true, false);
-            }
-            match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);
-
-            // Normalize pre-30 hardlinks in this segment.
-            if self.protocol.as_u8() < 30 && self.config.flags.hard_links {
-                normalize_pre30_hardlinks(&mut self.file_list[flat_start..]);
-            }
-
-            // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
-            self.ndx_segments.push((flat_start, seg_ndx_start));
-
-            // DDP-B3 (#2257): if a parallel-deterministic-delete context
-            // is attached, publish a DeletePlan for this segment's
-            // content directory into the shared DeletePlanMap. Failures
-            // are logged + skipped; the legacy batched-sweep path
-            // remains the active delete driver until the emitter wiring
-            // lands (tasks DDP-E1-E5).
-            self.publish_segment_to_delete_pipeline(dir_ndx, flat_start);
-
-            debug_log!(
-                Flist,
-                2,
-                "received sub-list for dir_ndx={}, {} entries (ndx_start={})",
-                dir_ndx,
-                segment_count,
-                seg_ndx_start
-            );
-            total_extra += segment_count;
+            total_extra += self.receive_one_extra_segment(reader, ndx)?;
         }
 
         debug_log!(
@@ -272,6 +200,126 @@ impl ReceiverContext {
             total_extra
         );
         Ok(total_extra)
+    }
+
+    /// Receives one INC_RECURSE sub-list segment framed by a `NDX_FLIST_OFFSET`
+    /// marker whose raw wire value is `ndx`.
+    ///
+    /// This is the body of a single [`receive_extra_file_lists`] loop iteration,
+    /// minus the `read_ndx` and the `NDX_FLIST_EOF` termination check. It is the
+    /// shared segment-append primitive used both by the batched
+    /// [`receive_extra_file_lists`] wrapper (kept for `--files-from` and the
+    /// wire-parity tests) and by the lazy on-demand fetch in
+    /// [`super::super::ReceiverContext::read_next_frame`]. Returns the number of
+    /// entries appended for this segment.
+    ///
+    /// Validates the marker (`ndx <= NDX_FLIST_OFFSET`), decodes the segment
+    /// entries with the cached [`protocol::flist::FileListReader`] (preserving
+    /// compression state across sub-lists), assigns leader GNUM wire NDXes, sorts
+    /// and hardlink-matches the segment slice, pushes the `(flat_start,
+    /// ndx_start)` boundary, and publishes the segment to the delete pipeline.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:recv_file_list()` - per-sub-list entry decode
+    /// - `flist.c:2931` - `ndx_start = prev->ndx_start + prev->used + 1`
+    pub(in crate::receiver) fn receive_one_extra_segment<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        ndx: i32,
+    ) -> io::Result<usize> {
+        if ndx > NDX_FLIST_OFFSET {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "expected NDX_FLIST_OFFSET or NDX_FLIST_EOF, got {ndx} {}{}",
+                    crate::role_trailer::error_location!(),
+                    crate::role_trailer::receiver()
+                ),
+            ));
+        }
+
+        // upstream: flist.c:recv_file_entry() - reuse cached reader to preserve
+        // compression state (prev_name, prev_mode, prev_uid, prev_gid).
+        let mut flist_reader = self
+            .flist_reader_cache
+            .take()
+            .unwrap_or_else(|| self.build_flist_reader());
+
+        let dir_ndx = NDX_FLIST_OFFSET - ndx;
+        let flat_start = self.file_list.len();
+
+        // Compute seg_ndx_start BEFORE reading entries so the reader can
+        // distinguish abbreviated vs unabbreviated hardlink followers.
+        // upstream: flist.c:recv_file_entry() uses flist->ndx_start
+        let &(prev_flat_start, prev_ndx_start) =
+            self.ndx_segments.last().expect("initial segment exists");
+        let prev_used = (flat_start - prev_flat_start) as i32;
+        let seg_ndx_start = prev_ndx_start + prev_used + 1;
+        flist_reader.set_ndx_start(seg_ndx_start);
+
+        let mut segment_count = 0;
+
+        // Pass segment entries so abbreviated followers can resolve leaders.
+        while let Some(entry) =
+            flist_reader.read_entry_with_flist(reader, &self.file_list[flat_start..])?
+        {
+            self.file_list.push(entry);
+            segment_count += 1;
+        }
+
+        // upstream: flist.c:1646 - leader GNUM is readdir-order wire NDX,
+        // assigned before sorting.
+        if self.config.flags.hard_links {
+            for (i, entry) in self.file_list[flat_start..].iter_mut().enumerate() {
+                if entry.hlink_first() {
+                    entry.set_hardlink_idx((seg_ndx_start + i as i32) as u32);
+                }
+            }
+        }
+
+        // upstream: flist.c:2155,2736 - both sides call flist_sort_and_clean()
+        // independently. Unstable sort (true) is safe - entries have unique paths.
+        // INC_RECURSE requires protocol >= 30, so pre29 is always false here.
+        //
+        // Iconv suppresses the in-place reorder for the same reason as the
+        // initial flist: upstream's `need_unsorted_flist` keeps the
+        // NDX-addressed array in scan order so the receiver can resolve
+        // generator requests against the bytes the sender emitted.
+        if !self.iconv_reorder_suppressed() {
+            sort_file_list(&mut self.file_list[flat_start..], true, false);
+        }
+        match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);
+
+        // Normalize pre-30 hardlinks in this segment.
+        if self.protocol.as_u8() < 30 && self.config.flags.hard_links {
+            normalize_pre30_hardlinks(&mut self.file_list[flat_start..]);
+        }
+
+        // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
+        self.ndx_segments.push((flat_start, seg_ndx_start));
+
+        // Restore the cached reader so the next segment continues the same
+        // compression state (upstream's static recv_file_entry() variables).
+        self.flist_reader_cache = Some(flist_reader);
+
+        // DDP-B3 (#2257): if a parallel-deterministic-delete context
+        // is attached, publish a DeletePlan for this segment's
+        // content directory into the shared DeletePlanMap. Failures
+        // are logged + skipped; the legacy batched-sweep path
+        // remains the active delete driver until the emitter wiring
+        // lands (tasks DDP-E1-E5).
+        self.publish_segment_to_delete_pipeline(dir_ndx, flat_start);
+
+        debug_log!(
+            Flist,
+            2,
+            "received sub-list for dir_ndx={}, {} entries (ndx_start={})",
+            dir_ndx,
+            segment_count,
+            seg_ndx_start
+        );
+        Ok(segment_count)
     }
 
     /// Publishes one INC_RECURSE segment into the parallel-deterministic-

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -9,6 +9,7 @@ use std::io::{self, Read, Write};
 use std::path::PathBuf;
 
 use logging::{PhaseTimer, debug_log, info_log};
+use protocol::codec::create_ndx_codec;
 use protocol::flist::FileEntry;
 use protocol::stats::DeleteStats;
 
@@ -39,6 +40,13 @@ impl ReceiverContext {
         let _t = PhaseTimer::new("receiver-transfer-pipelined");
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
+
+        // Materialize any INC_RECURSE sub-list segments the setup no longer
+        // drains, so the batched candidate build below sees the complete list.
+        // No-op without INC_RECURSE (`flist_eof` is already set, so no wire read
+        // occurs). upstream: generator.c:2299-2368 fetches sub-lists on demand.
+        let mut flist_ndx_codec = create_ndx_codec(self.protocol.as_u8());
+        self.ensure_all_segments_loaded(reader, &mut flist_ndx_codec)?;
 
         // upstream: generator.c:1317-1326 - make_path() for relative_paths
         self.ensure_relative_parents(&setup.dest_dir);

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -9,6 +9,7 @@ use std::io::{self, Read, Write};
 use std::path::PathBuf;
 
 use logging::{PhaseTimer, debug_log};
+use protocol::codec::create_ndx_codec;
 use protocol::flist::FileEntry;
 use protocol::stats::DeleteStats;
 
@@ -37,6 +38,12 @@ impl ReceiverContext {
         let _t = PhaseTimer::new("receiver-transfer-incremental");
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
+
+        // Materialize any INC_RECURSE sub-list segments the setup no longer
+        // drains. No-op without INC_RECURSE (`flist_eof` already set).
+        // upstream: generator.c:2299-2368 fetches sub-lists on demand.
+        let mut flist_ndx_codec = create_ndx_codec(self.protocol.as_u8());
+        self.ensure_all_segments_loaded(reader, &mut flist_ndx_codec)?;
 
         let mut stats = TransferStats {
             files_listed: file_count,

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -32,9 +32,10 @@ use super::wire_filters::parse_wire_filters_for_receiver;
 impl ReceiverContext {
     /// Common setup for all transfer modes.
     ///
-    /// Activates input multiplex, reads filter list if needed, receives the file
-    /// list (including INC_RECURSE extra segments), sanitizes paths, and builds
-    /// the `PipelineSetup` with checksum and metadata configuration.
+    /// Activates input multiplex, reads filter list if needed, receives the
+    /// initial file list, sanitizes paths, and builds the `PipelineSetup` with
+    /// checksum and metadata configuration. INC_RECURSE sub-list segments are
+    /// pulled on demand by the drivers rather than drained here.
     ///
     /// # Upstream Reference
     ///
@@ -121,10 +122,13 @@ impl ReceiverContext {
             info_log!(Flist, 1, "receiving incremental file list");
         }
 
+        // INC_RECURSE sub-list segments are no longer drained here. The whole
+        // list arrives in `receive_file_list` for the non-INC_RECURSE case (it
+        // sets `flist_eof`); under INC_RECURSE the drivers pull segments lazily
+        // via the on-demand primitives (`ensure_flat_idx` /
+        // `ensure_all_segments_loaded`), mirroring upstream's generator which
+        // fetches sub-lists on demand rather than up front (generator.c:2299).
         let file_count = self.receive_file_list(&mut reader)?;
-
-        let extra_count = self.receive_extra_file_lists(&mut reader)?;
-        let file_count = file_count + extra_count;
 
         let (file_count, setup) = self.build_pipeline_setup(file_count)?;
         Ok((reader, file_count, setup))
@@ -493,9 +497,9 @@ impl ReceiverContext {
     /// Runs the identical receiver transfer-setup sequence with `.await` on the
     /// two wire reads: the filter-list read
     /// ([`read_filter_list_async`](protocol::filters::read_filter_list_async))
-    /// and the file-list reception
-    /// ([`receive_file_list_async`](Self::receive_file_list_async) plus
-    /// [`receive_extra_file_lists_async`](Self::receive_extra_file_lists_async)).
+    /// and the initial file-list reception
+    /// ([`receive_file_list_async`](Self::receive_file_list_async)). INC_RECURSE
+    /// sub-list segments are pulled lazily by the drivers, not drained here.
     /// Every other step - multiplex activation, filter-chain compilation
     /// ([`apply_received_filter_rules`](Self::apply_received_filter_rules) /
     /// [`build_client_deletion_filter_chain`](Self::build_client_deletion_filter_chain)),
@@ -612,11 +616,10 @@ impl ReceiverContext {
         // must not be dropped. `run_sync_async` prepends the returned `carry` to
         // the per-file read stream so no wire bytes are lost when the sender
         // packs the list and the first per-file response into one frame.
+        // INC_RECURSE sub-list segments are no longer drained here (see the sync
+        // `setup_transfer`); the async drivers materialize them lazily. `carry`
+        // is threaded straight through so no look-ahead wire bytes are lost.
         let (file_count, carry) = self.receive_file_list_async(&mut reader).await?;
-        let (extra_count, carry) = self
-            .receive_extra_file_lists_async(&mut reader, carry)
-            .await?;
-        let file_count = file_count + extra_count;
 
         let (file_count, setup) = self.build_pipeline_setup(file_count)?;
         Ok((reader, file_count, setup, carry))

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -113,7 +113,22 @@ impl ReceiverContext {
             Vec::new()
         };
 
-        for (file_idx, file_entry) in self.file_list.iter().enumerate() {
+        // upstream: generator.c:2300-2305 - pre-read INC_RECURSE sub-lists so a
+        // hardlink follower's leader (which may live in a later segment) is
+        // resolved before the per-file loop. No-op without INC_RECURSE.
+        let mut flist_ndx_codec = create_ndx_codec(self.protocol.as_u8());
+        if self.config.flags.hard_links {
+            self.prefetch_for_hardlinks(reader, &mut flist_ndx_codec)?;
+        }
+
+        // upstream: generator.c:2299-2368 - walk the flist by a flat cursor,
+        // pulling the next INC_RECURSE segment on demand. Without INC_RECURSE the
+        // list is already complete, so `ensure_flat_idx` never reads the wire and
+        // this is a plain 0..len walk.
+        let mut flat_idx = 0usize;
+        while self.ensure_flat_idx(flat_idx, reader, &mut flist_ndx_codec)? {
+            let file_idx = flat_idx;
+            flat_idx += 1;
             if self.config.flags.list_only {
                 break;
             }
@@ -123,6 +138,7 @@ impl ReceiverContext {
                 }
             }
 
+            let file_entry = &self.file_list[file_idx];
             let relative_path = file_entry.path();
             // upstream: receiver.c:708-709 DEBUG_GTE(RECV, 1)
             debug_log!(Recv, 1, "recv_files({})", relative_path.display());


### PR DESCRIPTION
## Summary

Behavior-preserving stage 1 of the receiver INC_RECURSE restructure. Replaces the up-front sub-list drain in transfer setup with a lazy, on-demand segment-fetch primitive that mirrors upstream `generate_files()` / `read_ndx_and_attrs()`. INC_RECURSE remains **disabled** on pull (advertise gates untouched), so real transfers send zero extra segments and the wire is byte-identical to master for the non-inc-recurse path.

## What changed

- **`ReceiverContext`**: new `flist_eof` flag (set immediately when INC_RECURSE is not negotiated - the whole list arrives in one shot) and `hardlink_lookahead_target` (500 = `MIN_FILECNT_LOOKAHEAD / 2`).
- **`receive.rs`**: extracted the per-segment loop body into a reusable `receive_one_extra_segment(reader, ndx)`; the batched `receive_extra_file_lists` wrapper is retained (used by the wire-parity tests and future `--files-from`). The delete-pipeline publish now lives in the per-segment primitive.
- **`file_list/on_demand.rs`** (new): `FrameKind` + `read_next_frame`, `ensure_flat_idx`, `ensure_all_segments_loaded`, `prefetch_for_hardlinks`. Unit-tested against a mock throttled sender built from a `Cursor<Vec<u8>>` fixture (segments interleaved before the terminator), asserting the list grows one segment at a time, `flist_eof` is reported exactly at the marker, no over-read, no OOB.
- **Drivers**: the drain is moved out of `setup_transfer` / `setup_transfer_async`. `run_sync` now walks the flist by a flat cursor via `ensure_flat_idx` (+ `prefetch_for_hardlinks` when `--hard-links`); the pipelined drivers call `ensure_all_segments_loaded` before building the candidate list. Every path is a strict no-op without INC_RECURSE (`flist_eof` already set -> no wire read).

## Not in this stage (deferred)

- The advertise gates (`builder.rs`, `lib.rs`) are **unchanged** - INC_RECURSE stays off on pull, keeping this stage inert on the wire.
- `exchange_phase_done` / goodbye framing is untouched, so goodbye NDX_DONE ordering and counts are byte-identical to master.
- A full per-segment restructure of the pipelined transfer loop and per-segment `ack_completed_segments` are left for the follow-up that flips the gate; here the pipelined drivers materialize the list up front (identical result), avoiding any change to the production hot path.

## Verification

- `cargo check` (transfer + core, all-features; transfer with `tokio-transfer`) clean.
- `cargo clippy` (all-targets, all-features and `tokio-transfer`, `-D warnings`) clean.
- `cargo nextest -p transfer --all-features`: **2223 passed, 3 skipped**, including all driver/setup/goodbye/carry sync-vs-async parity tests and the INC_RECURSE segment + reclaim + ndx-convert tests.
- `rustfmt --check` clean.
