### PR TITLE
fix(daemon): run post-xfer exec on refused transfers to match upstream

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -1,5 +1,59 @@
 // Top-level approved-module request driver: connection acquisition,
 // auth, exec hooks, config build, transfer execution, and TCP drain.
+
+/// Runs the module's `post-xfer exec` hook, if one is configured and exec
+/// hooks are enabled, with the given transfer `exit_status`.
+///
+/// upstream: clientserver.c:906-931 - the daemon forks a child that runs the
+/// whole module session while the parent waits for the child's exit status and
+/// then runs `post-xfer exec` with it. Because the parent waits for *any* child
+/// outcome, the hook fires regardless of transfer success - including a refused
+/// request (a read-only push or write-only pull exits `RERR_SYNTAX`, so the
+/// hook sees `RSYNC_EXIT_STATUS=1`). This finalizer lets the early-return refuse
+/// paths mirror that "post-xfer always runs" flow, matching the inline
+/// post-xfer dispatch on the success path.
+fn run_post_xfer_finalizer(
+    ctx: &ModuleRequestContext<'_>,
+    module: &ModuleRuntime,
+    host_name: Option<&str>,
+    user_name: Option<&str>,
+    client_args: &[String],
+    exit_status: i32,
+) {
+    let Some(command) = module
+        .post_xfer_exec
+        .as_deref()
+        .filter(|_| xfer_exec_enabled())
+    else {
+        return;
+    };
+
+    let addr_str = ctx.peer_ip.to_string();
+    let path_str = module.path.display().to_string();
+    // Mirror the success-path `exec_path_ctx`: %-expansion of the command
+    // string uses an empty username, while RSYNC_USER_NAME carries the
+    // authenticated user via the `XferExecContext` below.
+    let path_ctx = PathExpansionContext {
+        module_path: &path_str,
+        module_name: &module.name,
+        username: "",
+        remote_addr: &addr_str,
+        hostname: host_name.unwrap_or(""),
+        pid: std::process::id(),
+    };
+    let expanded_command = expand_exec_command(command, &path_ctx);
+    let xfer_ctx = XferExecContext {
+        module_name: &module.name,
+        module_path: &module.path,
+        host_addr: ctx.peer_ip,
+        host_name,
+        user_name,
+        request: ctx.request,
+        client_args,
+    };
+    run_post_xfer_exec(&expanded_command, &xfer_ctx, exit_status, ctx.log_sink);
+}
+
 /// Processes an approved module request.
 ///
 /// Handles the full transfer flow: connection acquisition, authentication,
@@ -162,21 +216,47 @@ fn process_approved_module(
     // check is unaffected: upstream's auth override only touches `read_only`.
     let role = determine_server_role(&client_args);
     let effective_read_only = access_effective_read_only(module.read_only, auth_access_level);
+    // upstream: clientserver.c:906-931 - the post-xfer parent waits for the
+    // module child and runs `post-xfer exec` regardless of outcome. A refused
+    // read-only push / write-only pull exits `RERR_SYNTAX` (1) in the child, so
+    // the hook still fires with `RSYNC_EXIT_STATUS=1`. Emit the framed
+    // rejection first (the child's `rprintf(FERROR, ...)` + `exit_cleanup`),
+    // then run the post-xfer finalizer, matching that ordering.
     if effective_read_only && matches!(role, ServerRole::Receiver) {
-        return handle_access_denied_post_handshake(
+        let host_owned = ctx.effective_host().map(str::to_owned);
+        let result = handle_access_denied_post_handshake(
             ctx,
             MODULE_READ_ONLY_PAYLOAD,
             negotiated_protocol,
             &client_args,
         );
+        run_post_xfer_finalizer(
+            ctx,
+            module,
+            host_owned.as_deref(),
+            auth_user.as_deref(),
+            &client_args,
+            RERR_SYNTAX_EXIT_CODE,
+        );
+        return result;
     }
     if module.write_only && matches!(role, ServerRole::Generator) {
-        return handle_access_denied_post_handshake(
+        let host_owned = ctx.effective_host().map(str::to_owned);
+        let result = handle_access_denied_post_handshake(
             ctx,
             MODULE_WRITE_ONLY_PAYLOAD,
             negotiated_protocol,
             &client_args,
         );
+        run_post_xfer_finalizer(
+            ctx,
+            module,
+            host_owned.as_deref(),
+            auth_user.as_deref(),
+            &client_args,
+            RERR_SYNTAX_EXIT_CODE,
+        );
+        return result;
     }
 
     if !validate_module_path(ctx, module)? {

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -210,6 +210,7 @@ include!("tests/chunks/run_daemon_rejects_invalid_max_sessions.rs");
 include!("tests/chunks/run_daemon_rejects_invalid_port.rs");
 include!("tests/chunks/run_daemon_rejects_unknown_argument.rs");
 include!("tests/chunks/run_daemon_rejects_push_to_read_only_module.rs");
+include!("tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs");
 include!("tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs");
 include!("tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs");
 include!("tests/chunks/run_daemon_requests_authentication_for_protected_module.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
@@ -1,0 +1,113 @@
+/// A push to a `read only = yes` module is refused, but the module's
+/// `post-xfer exec` hook must still run - upstream's post-xfer parent waits for
+/// the module child and runs the hook regardless of outcome, so a refused push
+/// (child exits `RERR_SYNTAX`) fires the hook with `RSYNC_EXIT_STATUS=1`.
+///
+/// upstream: clientserver.c:906-931 - post-xfer exec runs after the child exits
+/// for any reason; main.c:1166-1169 - the read-only push child exits
+/// `RERR_SYNTAX` (1). Regression guard for the daemon skipping the hook on the
+/// refuse early-return path.
+#[cfg(unix)]
+#[test]
+fn run_daemon_runs_post_xfer_exec_on_read_only_refuse() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let dir = tempdir().expect("config dir");
+    let module_dir = dir.path().join("module");
+    fs::create_dir_all(&module_dir).expect("module dir");
+
+    // post-xfer exec hook records $RSYNC_EXIT_STATUS to a marker file so the
+    // test can assert the hook ran and saw the refused-transfer exit code.
+    let marker = dir.path().join("post.out");
+    let hook = dir.path().join("post.sh");
+    fs::write(
+        &hook,
+        format!(
+            "#!/bin/sh\necho \"$RSYNC_EXIT_STATUS\" > {}\nexit 0\n",
+            marker.display()
+        ),
+    )
+    .expect("write hook script");
+    fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).expect("chmod hook");
+
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(
+        &config_path,
+        format!(
+            "[readonly]\npath = {}\nread only = true\nuse chroot = false\npost-xfer exec = {}\n",
+            module_dir.display(),
+            hook.display()
+        ),
+    )
+    .expect("write config");
+
+    let (port, held_listener) = allocate_test_port();
+
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--once"),
+            OsString::from("--config"),
+            config_path.as_os_str().to_os_string(),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+
+    stream
+        .write_all(b"@RSYNCD: 32.0\n")
+        .expect("send handshake response");
+    stream.flush().expect("flush handshake response");
+
+    stream
+        .write_all(b"readonly\n")
+        .expect("send module request");
+    stream.flush().expect("flush module request");
+
+    line.clear();
+    reader.read_line(&mut line).expect("ok message");
+    assert_eq!(line, "@RSYNCD: OK\n");
+
+    // A push (no --sender): the read-only module must refuse it.
+    stream
+        .write_all(b"--server\0-logDtpr\0.\0readonly/\0\0")
+        .expect("send client args");
+    stream.flush().expect("flush client args");
+
+    // The refusal still arrives framed, exactly as the plain refuse test.
+    assert_read_only_multiplexed_rejection(&mut reader);
+
+    drop(reader);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok());
+
+    // The post-xfer hook must have run despite the refusal, recording the
+    // RERR_SYNTAX exit status the child conveyed to the post-xfer parent.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut contents = String::new();
+    while Instant::now() < deadline {
+        if let Ok(text) = fs::read_to_string(&marker) {
+            if !text.trim().is_empty() {
+                contents = text;
+                break;
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(
+        contents.trim(),
+        RERR_SYNTAX_EXIT_CODE.to_string(),
+        "post-xfer exec must run on a refused read-only push with RSYNC_EXIT_STATUS=1",
+    );
+}


### PR DESCRIPTION
## Problem

When a push to a `read only = yes` module is refused, the daemon returned early without running the module's `post-xfer exec` hook. Upstream runs it.

Upstream reference: the daemon forks a child that runs the whole module session while the parent waits for the child's exit status and then runs `post-xfer exec` (`clientserver.c:906-931`). Because the parent waits for **any** child outcome, the hook fires even when the request is refused: a read-only push (or write-only pull) exits `RERR_SYNTAX` in the child (`main.c:1166-1169`), so `post-xfer exec` still runs with `RSYNC_EXIT_STATUS=1`.

## Fix

Route the read-only and write-only refuse branches through a new `run_post_xfer_finalizer` that emits the framed rejection first (mirroring the child's `rprintf(FERROR, ...)` + `exit_cleanup`), then runs `post-xfer exec` with the `RERR_SYNTAX` (1) exit status. The success path is unchanged, so the hook never runs twice.

An integration test asserts the hook runs on a refused read-only push and records `RSYNC_EXIT_STATUS=1`.

## Verification

Env-captured against a real upstream 3.4.4 daemon on aarch64 Linux:
- Before: master/oc did **not** run the hook on a refused read-only push (marker absent).
- After: oc runs it with `RSYNC_EXIT_STATUS=1`, matching upstream (upstream: `RSYNC_EXIT_STATUS=1`, `RSYNC_RAW_STATUS=256`).
- `RSYNC_RAW_STATUS=256` is produced by the separate raw-status change (`exit_status << 8`); with both in place the refused-push post-xfer marker is `RSYNC_EXIT_STATUS=1` + `RSYNC_RAW_STATUS=256`, byte-matching upstream.
- `fmt` / `clippy -p daemon -D warnings` / `check -p daemon` / `check -p daemon --target x86_64-pc-windows-gnu` all clean.
- Upstream `daemon-exec` testsuite: PASS.
