### PR TITLE
fix(engine): re-apply directory mtimes after delayed-update commit in local copy

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -370,6 +370,15 @@ pub(crate) struct DeferredOperationQueue {
     pub(crate) delay_staging_dirs: HashSet<PathBuf>,
     /// Newly created paths tracked for rollback on timeout errors.
     pub(crate) created_entries: Vec<CreatedEntry>,
+    /// Transferred directories and their source mtimes, recorded when
+    /// `apply_final_directory_metadata` runs. A single final pass
+    /// (`touch_up_dirs`) re-applies these after all late in-directory mutations
+    /// (delayed-update renames, deletions, backups) so directory timestamps
+    /// survive the wall-clock bump those operations cause.
+    ///
+    /// upstream: generator.c:2093 `touch_up_dirs()` / generator.c:2271
+    /// `need_retouch_dir_times`.
+    pub(crate) finalized_dirs: Vec<(PathBuf, filetime::FileTime)>,
 }
 
 /// A directory deletion deferred until after the transfer phase completes.

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -146,6 +146,59 @@ impl<'a> CopyContext<'a> {
         }
     }
 
+    /// Re-applies each transferred directory's source mtime after all late
+    /// in-directory mutations complete - the single final directory touch-up
+    /// pass, run once from the executor finalize after the delayed-update,
+    /// deletion, and sync flushes.
+    ///
+    /// The delayed-update rename sweep, deferred deletions, and backup file
+    /// creation each bump the mtime of the directory they act in, clobbering
+    /// the value `apply_final_directory_metadata` set during the traversal.
+    /// Rather than have every late operation carry its own capture/restore
+    /// guard, this consolidates the "directory mtime survives late in-dir
+    /// mutations" invariant into one pass, mirroring both upstream and the
+    /// receiver driver's `touch_up_dirs`.
+    ///
+    /// Directories are re-touched deepest-first so setting a child's mtime
+    /// cannot re-clobber a parent processed earlier (utimensat on a directory
+    /// does not disturb its own parent, but the ordering keeps the pass robust
+    /// and matches the receiver's reverse iteration).
+    ///
+    /// Gated identically to `apply_final_directory_metadata` and upstream's
+    /// `need_retouch_dir_times`: only when times are preserved and
+    /// `--omit-dir-times` is off. Skipped when `--backup` is active without a
+    /// backup directory, because backup file creation legitimately changes the
+    /// destination directory mtimes.
+    ///
+    /// upstream: generator.c:2449-2451 - touch_up_dirs(dir_flist, -1) runs
+    /// after the receiver's handle_delayed_updates(); generator.c:2093
+    /// touch_up_dirs(); generator.c:2271 need_retouch_dir_times =
+    /// preserve_mtimes && !omit_dir_times.
+    pub(super) fn touch_up_dirs(&mut self) {
+        let dirs = std::mem::take(&mut self.deferred_ops.finalized_dirs);
+        let preserve_times = self.metadata_options().times() && !self.omit_dir_times_enabled();
+        // upstream: generator.c - skip retouching when make_backups && !backup_dir,
+        // since in-place backup file creation changes directory mtimes on purpose.
+        let backup_without_dir =
+            self.options.backup_enabled() && self.options.backup_directory().is_none();
+        if !preserve_times || backup_without_dir {
+            return;
+        }
+        let mut dirs = dirs;
+        dirs.sort_by(|a, b| b.0.components().count().cmp(&a.0.components().count()));
+        for (dir, mtime) in dirs {
+            // upstream: generator.c:2130 - only re-set when mtime_differs(), so
+            // directories untouched by a late mutation are left alone.
+            let needs_update = match fs::metadata(&dir) {
+                Ok(meta) => filetime::FileTime::from_last_modification_time(&meta) != mtime,
+                Err(_) => false,
+            };
+            if needs_update {
+                let _ = filetime::set_file_mtime(&dir, mtime);
+            }
+        }
+    }
+
     /// Executes all queued deferred deletions, unless I/O errors suppress them.
     ///
     /// Deletions modify the parent directory's mtime. When `-t` is active the
@@ -153,6 +206,12 @@ impl<'a> CopyContext<'a> {
     /// Capture each directory's mtime before deletion and restore it afterwards
     /// to match upstream rsync's behaviour where the receiver sets directory
     /// times independently of the generator's delayed-deletion phase.
+    ///
+    /// This per-operation restore is now redundant with the final
+    /// [`touch_up_dirs`](Self::touch_up_dirs) pass (both re-apply the same
+    /// source mtime). It is intentionally retained here to keep this change
+    /// scoped to one concern; folding it into the final pass is a deferred DRY
+    /// cleanup. Both set the identical value, so the overlap is harmless.
     // upstream: generator.c:2419 do_delayed_deletions() runs after generate_files()
     pub(super) fn flush_deferred_deletions(&mut self) -> Result<(), LocalCopyError> {
         // Nothing queued means no delete pass ran, so there is no notice to

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -723,6 +723,24 @@ impl<'a> CopyContext<'a> {
         self.destination_metadata_cache.clear();
     }
 
+    /// Records a finalized directory and its source mtime for the final
+    /// [`touch_up_dirs`](Self::touch_up_dirs) pass.
+    ///
+    /// Called by `apply_final_directory_metadata` right after it applies the
+    /// source mtime during the traversal. Late in-directory mutations (the
+    /// delayed-update rename sweep, deferred deletions, backup file creation)
+    /// bump this mtime again, so the final pass re-applies the recorded value.
+    pub(super) fn record_finalized_directory(
+        &mut self,
+        destination: &Path,
+        metadata: &fs::Metadata,
+    ) {
+        let mtime = filetime::FileTime::from_last_modification_time(metadata);
+        self.deferred_ops
+            .finalized_dirs
+            .push((destination.to_path_buf(), mtime));
+    }
+
     /// Queues a deferred update for `--delay-updates` and records the hard-link
     /// source. The staging directory is tracked for cleanup after commit.
     pub(super) fn register_deferred_update(&mut self, update: DeferredUpdate) {

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -28,7 +28,7 @@ use ::metadata::apply_directory_metadata_with_options;
 /// component materialized by `--relative` so they do not carry wall-clock
 /// timestamps from `create_dir_all`.
 pub(super) fn apply_final_directory_metadata(
-    context: &CopyContext,
+    context: &mut CopyContext,
     source: &Path,
     destination: &Path,
     metadata: &fs::Metadata,
@@ -48,6 +48,16 @@ pub(super) fn apply_final_directory_metadata(
     };
     apply_directory_metadata_with_options(destination, metadata, metadata_options.clone())
         .map_err(map_metadata_error)?;
+
+    // Record the directory and its source mtime for the final touch-up pass.
+    // Late in-directory mutations (delayed-update renames, deletions, backups)
+    // bump this directory's mtime after we set it here, so a single final pass
+    // re-applies the recorded source mtime once everything else is done.
+    // upstream: generator.c:2093 touch_up_dirs() re-touches directory mtimes
+    // after the delayed-update phase completes.
+    if metadata_options.times() {
+        context.record_finalized_directory(destination, metadata);
+    }
 
     // upstream: generator.c:1410 - implied parent dirs are finalized via
     // set_file_attrs() when --implied-dirs is active (the default). With

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -573,6 +573,11 @@ fn flush_deferred_operations(context: &mut CopyContext) -> Result<(), LocalCopyE
     context.flush_deferred_updates()?;
     context.flush_deferred_deletions()?;
     context.flush_deferred_syncs()?;
+    // Final directory-mtime touch-up. Runs once, after every late in-directory
+    // mutation above (delayed-update renames, deletions, backups) has bumped
+    // the destination directory mtimes that apply_final_directory_metadata set.
+    // upstream: generator.c:2449-2451 touch_up_dirs after handle_delayed_updates.
+    context.touch_up_dirs();
     context.enforce_timeout()?;
     Ok(())
 }

--- a/crates/engine/src/local_copy/tests/execute_delay_updates.rs
+++ b/crates/engine/src/local_copy/tests/execute_delay_updates.rs
@@ -2186,3 +2186,96 @@ fn delay_updates_staging_dirs_cleaned_in_subdirectories() {
     }
     assert_no_staging_dirs(&dest_root);
 }
+
+/// Regression: `--delay-updates` must not leave a stale destination directory
+/// mtime. The deferred rename that moves each `.~tmp~/<file>` into place at the
+/// end of the transfer bumps the parent directory's mtime that
+/// `apply_final_directory_metadata` already set to the source value. Upstream
+/// re-applies directory mtimes only after the delayed-update phase completes
+/// (generator.c:2449-2451 `touch_up_dirs()` after `handle_delayed_updates()`),
+/// so without the final touch-up pass the destination directory would carry the
+/// deferred-commit wall-clock time instead of the source directory's mtime.
+#[test]
+fn delay_updates_restores_root_directory_mtime_after_rename() {
+    let temp = create_tempdir();
+    let source_root = temp.path().join("source");
+    let dest_root = temp.path().join("dest");
+    fs::create_dir_all(&source_root).expect("create source");
+    fs::create_dir_all(&dest_root).expect("create dest");
+
+    // Different sizes force a transfer: the file is staged to `.~tmp~` and
+    // renamed into the destination root at flush, bumping the root mtime.
+    fs::write(source_root.join("file.txt"), b"delayed new content").expect("write source");
+    fs::write(dest_root.join("file.txt"), b"old").expect("write dest");
+
+    // Backdate the SOURCE directory after populating it; the deferred rename
+    // runs at "now", so a correct implementation restores this mtime.
+    let past = FileTime::from_unix_time(1_600_000_000, 0);
+    set_file_mtime(&source_root, past).expect("set source dir mtime");
+
+    let mut source_operand = source_root.clone().into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().delay_updates(true).times(true),
+        )
+        .expect("copy succeeds");
+    assert_eq!(summary.files_copied(), 1);
+
+    let dest_dir_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_root).expect("dest dir metadata"));
+    assert_eq!(
+        dest_dir_mtime, past,
+        "the delayed-update rename bumps the dir mtime apply_final_directory_metadata \
+         set; the final touch_up_dirs pass must restore the source dir mtime"
+    );
+}
+
+/// Same regression, but for a nested subdirectory. A per-operation restore
+/// could miss subdirs, whereas the single final pass must cover them. A
+/// pre-seeded `.~tmp~` under the subdir mirrors upstream's staging area, so the
+/// rename plus staging-dir removal both bump the subdir mtime that
+/// `apply_final_directory_metadata` set.
+#[test]
+fn delay_updates_restores_nested_directory_mtime_after_rename() {
+    let temp = create_tempdir();
+    let source_root = temp.path().join("source");
+    let dest_root = temp.path().join("dest");
+    let source_sub = source_root.join("sub");
+    fs::create_dir_all(&source_sub).expect("create source sub");
+    fs::write(source_sub.join("foo.txt"), b"nested new content").expect("write source");
+
+    // Pre-existing dest tree with a stale file (forces re-transfer) plus a
+    // pre-seeded `.~tmp~` staging dir under the subdir.
+    let dest_sub = dest_root.join("sub");
+    fs::create_dir_all(dest_sub.join(".~tmp~")).expect("create dest staging");
+    fs::write(dest_sub.join("foo.txt"), b"old").expect("write dest file");
+    fs::write(dest_sub.join(".~tmp~").join("foo.txt"), b"stale").expect("write staging file");
+
+    let past = FileTime::from_unix_time(1_600_000_000, 0);
+    set_file_mtime(&source_root, past).expect("set source root mtime");
+    set_file_mtime(&source_sub, past).expect("set source sub mtime");
+
+    let mut source_operand = source_root.clone().into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
+    LocalCopyPlan::from_operands(&operands)
+        .expect("plan")
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().delay_updates(true).times(true),
+        )
+        .expect("copy succeeds");
+
+    let dest_sub_mtime =
+        FileTime::from_last_modification_time(&fs::metadata(&dest_sub).expect("dest sub metadata"));
+    assert_eq!(
+        dest_sub_mtime, past,
+        "the final touch_up_dirs pass must restore nested directory mtimes too, \
+         not just the transfer root"
+    );
+}


### PR DESCRIPTION
## Problem

With `-t`/`--times`, a `--delay-updates` **local** copy left the destination
directory carrying the deferred-commit wall-clock time instead of the source
directory's mtime. This is the real cause of the intermittent
upstream-testsuite `delay-updates` failure (a genuine bug, not a flake): rsync
preserves whole-second directory mtimes, so the set-time and the delayed rename
usually land in the same second and it only fails when they straddle a second
boundary.

Root cause: the local-copy executor applies each directory's source mtime
during the traversal (`apply_final_directory_metadata`), but the late
in-directory mutations that run at finalize - the `--delay-updates` rename
sweep (`flush_deferred_updates`) and its `.~tmp~` staging-dir removal - bump
the parent directory's mtime again, and nothing re-applied it.

## Upstream mechanism

Upstream runs a single directory touch-up pass **after** the delayed-update
phase completes:

- `generator.c:2449-2451` - `touch_up_dirs(dir_flist, -1)` runs after the
  receiver's `handle_delayed_updates()` (`receiver.c:695`/`1112`).
- `generator.c:2093` - `touch_up_dirs()` re-applies directory mtimes.
- `generator.c:2271` - `need_retouch_dir_times = preserve_mtimes && !omit_dir_times`.

## Fix

Add the equivalent single final pass to the local-copy executor:

- Record each finalized directory + its source mtime in
  `apply_final_directory_metadata` (only when dir times are preserved).
- After the delayed-update, deletion, and sync flushes, `touch_up_dirs()`
  re-applies them once, **deepest-first**, guarded by an `mtime_differs`-style
  check so untouched directories are left alone.
- Gated identically to `apply_final_directory_metadata` / upstream
  `need_retouch_dir_times`: only when times are preserved and
  `--omit-dir-times` is off, and skipped when `--backup` is active without a
  backup directory.

This consolidates the "directory mtime survives late in-dir mutations"
invariant into one pass (Single-Responsibility / Open-Closed: new late ops are
auto-covered), matching both upstream and the receiver driver's existing
`touch_up_dirs`. The deletion path's pre-existing per-op capture/restore is
intentionally left in place for now (it sets the identical source mtime, so the
overlap is harmless) to keep this change to one concern; a DRY cleanup is
deferred.

## Verification

Verified against a real rsync binary:

- Backdated source directory, `-a --delay-updates` (with a pre-seeded `.~tmp~`):
  destination directory mtime now equals the source (root **and** nested
  subdirs), matching upstream. Before the fix it was the rename wall-clock time.
- `--omit-dir-times`: destination directory mtime is left at the rename
  wall-clock time, byte-for-byte matching upstream.
- Non-delay transfers are unchanged.

Adds root and nested-directory regression tests encoding why the pass matters
(the rename bumps the mtime `apply_final_directory_metadata` set). `cargo
clippy -p engine -D warnings` and stable `rustfmt --check` are clean; targeted
engine tests (delay-updates, omit-dir-times, delete, backup, recursive) all
pass.