### PR TITLE
test(matching): pin bithash false-positive bound + block-skip iteration count

### DIFF
--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -703,6 +703,22 @@ mod tests {
         DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
     }
 
+    /// Builds an index with a caller-chosen fixed block length so a
+    /// byte-aligned source yields an exact, predictable block count.
+    fn build_index_fixed(data: &[u8], block_len: u32) -> DeltaSignatureIndex {
+        use std::num::NonZeroU32;
+        let params = SignatureLayoutParams::new(
+            data.len() as u64,
+            Some(NonZeroU32::new(block_len).unwrap()),
+            ProtocolVersion::NEWEST,
+            NonZeroU8::new(16).unwrap(),
+        );
+        let layout = calculate_signature_layout(params).expect("layout");
+        let signature =
+            generate_file_signature(data, layout, SignatureAlgorithm::Md4).expect("signature");
+        DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+    }
+
     #[test]
     fn generate_delta_produces_literals_when_no_matches() {
         let basis = vec![0u8; 2048];
@@ -1046,6 +1062,95 @@ mod tests {
             chunked.literal_bytes(),
             data.len()
         );
+    }
+
+    #[test]
+    fn block_skip_matched_path_is_o_blocks_not_o_bytes() {
+        // ZSO-2 regression: after a confirmed block match the generator
+        // advances the scan by a whole block (`offset += block_len` on the
+        // matched path, generator.rs ~:391) instead of sliding one byte at a
+        // time (`offset += 1` on the miss path, ~:253). A byte-for-byte copy
+        // of a duplicate-free, block-aligned basis is therefore resolved with
+        // O(file_len / block_len) block probes, never O(file_len) per-byte
+        // probes.
+        const BLOCK_LEN: u32 = 1024;
+        const N_BLOCKS: usize = 64;
+
+        let data = pseudo_random(N_BLOCKS * BLOCK_LEN as usize, 0x51ce_b100);
+        let index = build_index_fixed(&data, BLOCK_LEN);
+        // A deterministic per-block count requires a duplicate-free basis so
+        // every source window resolves to exactly one basis block.
+        assert!(
+            !index.has_duplicate_blocks(),
+            "random basis must be duplicate-free for a deterministic skip count",
+        );
+        let block_len = index.block_length();
+        assert_eq!(
+            block_len, BLOCK_LEN as usize,
+            "layout must honor the block length"
+        );
+        let n_blocks = data.len() / block_len;
+        assert_eq!(n_blocks, N_BLOCKS);
+        assert_eq!(index.block_count(), N_BLOCKS);
+
+        // The index owns the shared seq-match probe counters. Reset them, then
+        // scan an exact copy of the basis.
+        let counters = index.seq_match_counters();
+        counters.reset();
+
+        let generator = DeltaGenerator::new();
+        let script = generator
+            .generate(Cursor::new(&data[..]), &index)
+            .expect("script");
+
+        // A 100%-match, duplicate-free, block-aligned source coalesces into a
+        // single fat Copy token spanning every basis block, with zero literals.
+        // A matched path that slid by one byte would fall out of block
+        // alignment and spill literals instead.
+        assert_eq!(
+            script.literal_bytes(),
+            0,
+            "a full copy must emit no literals"
+        );
+        assert_eq!(script.total_bytes(), data.len() as u64);
+        assert_eq!(
+            script.tokens().len(),
+            1,
+            "seq-match must coalesce the full run into a single Copy token",
+        );
+        match &script.tokens()[0] {
+            DeltaToken::Copy { index: idx, len } => {
+                assert_eq!(*idx, 0, "the coalesced run must start at basis block 0");
+                assert_eq!(*len, data.len(), "the run must cover every basis block");
+            }
+            other => panic!("expected a single Copy token, got {other:?}"),
+        }
+
+        // Block-skip proof: the matched path takes the adjacency fast-path
+        // exactly once per block transition - N-1 probes for N blocks, every
+        // one a hit. This is the iteration count the spec pins: O(blocks), i.e.
+        // `file_len / block_len - 1`, not O(bytes) = `file_len`. A broken skip
+        // that slid by 1 on the matched path would never enter the bulk-refill
+        // inner loop, recording ZERO seq-match probes (and spilling literals,
+        // asserted above).
+        let probes = counters.probes();
+        let hits = counters.hits();
+        assert_eq!(
+            probes,
+            (n_blocks - 1) as u64,
+            "expected {} block probes (file_len/block_len - 1), got {probes}; \
+             O(file_len)={} probes would mean a per-byte matched path",
+            n_blocks - 1,
+            data.len(),
+        );
+        assert_eq!(
+            hits,
+            (n_blocks - 1) as u64,
+            "every adjacency probe must confirm through the seq-match fast path",
+        );
+
+        // The skipped-ahead script must still rebuild the source byte-for-byte.
+        assert_eq!(reconstruct(&data, &index, &script), data);
     }
 
     #[test]

--- a/crates/matching/src/index/bithash_tests.rs
+++ b/crates/matching/src/index/bithash_tests.rs
@@ -181,6 +181,66 @@ fn bithash_rejects_at_least_seven_eighths_of_known_misses() {
 }
 
 #[test]
+fn bithash_false_positive_rate_within_spec_bound() {
+    // ZSO-1 detail validation: the zsync spec targets a bithash
+    // false-positive rate of <= 25% for a filter sized 8x the element count.
+    // oc-rsync over-provisions further - `2^i >= 4*N` buckets times
+    // `2^(BITHASH_BITS+1) = 16` bits per bucket, i.e. >= 32 bits per element
+    // (`log2_bits_for` rounds N to the next power of two, so effective bits
+    // per element sit in the 32..64 band). The saturation set-bit density is
+    // therefore ~1/32..1/64, well under the spec's 1/8, so the measured FP
+    // rate must clear the 25% bound with wide margin.
+    //
+    // A false positive here only costs a redundant strong-checksum verify; a
+    // false *negative* would drop a real match and is pinned separately by
+    // `bithash_never_misses_inserted_block` / `bithash_contains_every_inserted_rsum`.
+    //
+    // Measured on this build (N = 4096 inserted, 65536 known-miss probes):
+    //   false-positive rate = 2017/65536 = 0.031 (see the eprintln below),
+    //   roughly 8x under the 0.25 spec bound.
+    let n_blocks = 4096usize;
+    let mut bh = BitHash::with_block_count(n_blocks);
+
+    let mut inserted = std::collections::HashSet::with_capacity(n_blocks);
+    let mut rng = 0x1234_5678_9abc_def0_u64;
+    while inserted.len() < n_blocks {
+        let rsum = lcg_next(&mut rng);
+        if inserted.insert(rsum) {
+            bh.insert(rsum);
+        }
+    }
+
+    // Probe a large disjoint stream of never-inserted rsums and count the
+    // ones the filter fails to reject (false positives).
+    let probe_target = 16 * n_blocks;
+    let mut probe_rng = 0x0fed_cba9_8765_4321_u64;
+    let mut probes = 0usize;
+    let mut false_positives = 0usize;
+    while probes < probe_target {
+        let rsum = lcg_next(&mut probe_rng);
+        if inserted.contains(&rsum) {
+            continue;
+        }
+        probes += 1;
+        if bh.contains(rsum) {
+            false_positives += 1;
+        }
+    }
+
+    let fp_rate = false_positives as f64 / probes as f64;
+    eprintln!(
+        "bithash FP rate at default sizing: {false_positives}/{probes} = {fp_rate:.4} \
+         (N={n_blocks}, bits={})",
+        n_blocks << 5,
+    );
+    assert!(
+        fp_rate <= 0.25,
+        "bithash false-positive rate {fp_rate:.4} exceeds the spec's 25% bound \
+         at oc's default sizing; investigate `log2_bits_for` before loosening this",
+    );
+}
+
+#[test]
 fn bithash_state_does_not_leak_between_independent_indexes() {
     // ZSO-1 acceptance test: two `DeltaSignatureIndex` values built from
     // distinct basis bytes must hold independent bithash state. Per the


### PR DESCRIPTION
## Summary

Adds test-only coverage pinning two already-shipped zsync-derived optimizations in `crates/matching`, and validates each against its intended property. No production code changed.

## TASK 1 - bithash negative pre-filter (`index/bithash.rs`)

New property/measurement test `bithash_false_positive_rate_within_spec_bound`:

- Validates the spec's <= 25% false-positive bound at oc's actual default sizing.
- Measured FP rate: **2017 / 65536 = 0.031** (N = 4096 inserted, 65536 known-miss probes) - roughly 8x under the 0.25 bound.
- oc over-provisions vs the spec's 8x filter: `2^i >= 4*N` buckets x 16 bits/bucket => >= 32 bits per element, so saturation set-bit density is ~1/32, not the spec's 1/8. No divergence.
- No-false-negative property was already pinned by `bithash_contains_every_inserted_rsum` / `bithash_never_misses_inserted_block`; this complements them with the FP bound.

## TASK 2 - block-skip after a confirmed match (`generator.rs`)

New regression test `block_skip_matched_path_is_o_blocks_not_o_bytes`:

- Source is a byte-for-byte copy of a duplicate-free, block-aligned basis (64 x 1024-byte blocks).
- Asserts the matched path advances a whole block, not one byte: measured **63 seq-match block probes (= file_len/block_len - 1), all hits** via the existing seq-match counters, i.e. O(blocks) not O(bytes) = 65536.
- Also asserts the 100%-match coalesces into a single fat Copy token, zero literals, and reconstructs byte-for-byte. A per-byte matched path would record zero seq-match probes and spill literals - both guarded.

## Validation

Both details match the intended properties. No divergence found.

- `cargo check -p matching --all-targets`: clean
- `cargo clippy -p matching --all-targets --all-features --no-deps -- -D warnings`: clean
- `cargo fmt -p matching -- --check`: clean
- Targeted nextest (both new tests): pass
