### PR TITLE
feat(transfer): materialize symlinks on the Windows network receiver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,11 +283,14 @@ jobs:
       # IOCP) - crates the main Test step above does not run - so without this
       # step the Windows regression signal for those paths sits only in the
       # separate windows-acl-xattr / windows-iocp jobs. The filter matches the
-      # crtime conversion and skip-flag tests, the mark_file_sparse probe, and
-      # the IOCP-vs-std read-path parity tests.
-      - name: Test crtime + sparse + iocp read parity + symlink junction (metadata, fast_io)
+      # crtime conversion and skip-flag tests, the mark_file_sparse probe, the
+      # IOCP-vs-std read-path parity tests, and the network receiver's Windows
+      # symlink materialization (directory link -> junction fallback, file link
+      # -> skip-with-soft-error), which lives in `transfer` - another crate the
+      # main Test step does not run.
+      - name: Test crtime + sparse + iocp read parity + symlink junction (metadata, fast_io, transfer)
         shell: bash
-        run: cargo nextest run --locked -p metadata -p fast_io -E 'test(crtime) | test(sparse) | test(iocp_read_parity) | test(junction) | test(file_symlink_reports)'
+        run: cargo nextest run --locked -p metadata -p fast_io -p transfer -E 'test(crtime) | test(sparse) | test(iocp_read_parity) | test(junction) | test(file_symlink_reports) | test(windows_receiver_symlink)'
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::path::Path;
 
 use logging::{debug_log, info_log};
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use metadata::{MetadataOptions, apply_symlink_metadata_from_entry};
 use protocol::flist::{trace_leader_is, trace_looking_for_leader, trace_virtual_first};
 
@@ -235,8 +235,185 @@ impl ReceiverContext {
         Ok(())
     }
 
-    /// No-op on non-Unix platforms where symlinks are not supported.
-    #[cfg(not(unix))]
+    /// Materializes symbolic links from the file list on the Windows receiver.
+    ///
+    /// Mirrors the Unix path but routes creation through the safe
+    /// `fast_io::win_symlink` helpers: a link whose target resolves to a
+    /// directory is created as a real directory symbolic link, falling back to
+    /// a junction when the process lacks the create-symlink privilege; a file
+    /// link has no privilege-free equivalent, so a privilege refusal skips the
+    /// entry with a warning and sets the soft-error flag so the transfer still
+    /// finishes but exits `RERR_PARTIAL` (23). This matches the local-copy
+    /// executor's `create_symlink` behaviour so a remote transfer to a Windows
+    /// receiver no longer silently drops symlinks from the flist.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1544` - `if (preserve_links && ftype == FT_SYMLINK)`
+    /// - `generator.c:1591` - `atomic_create(file, fname, sl, ...)`
+    #[cfg(windows)]
+    pub(in crate::receiver) fn create_symlinks<W: crate::writer::MsgInfoSender + ?Sized>(
+        &mut self,
+        dest_dir: &Path,
+        writer: &mut W,
+    ) -> std::io::Result<()> {
+        if !self.config.flags.links || self.config.flags.skip_dest_writes() {
+            return Ok(());
+        }
+
+        // A file-symlink privilege refusal is skipped per-entry; record it here
+        // and fold it into `flist_io_error` after the loop so the immutable
+        // borrow of `self.file_list` never overlaps the mutable field write.
+        let mut unsupported_skip = false;
+
+        for entry in &self.file_list {
+            if !entry.is_symlink() {
+                continue;
+            }
+
+            let wire_target = match entry.link_target() {
+                Some(t) => t,
+                None => continue,
+            };
+
+            let relative_path = entry.path();
+
+            // upstream: generator.c:1547 - skip unsafe symlinks when --safe-links.
+            if self.config.flags.safe_links
+                && crate::symlink_safety::is_unsafe_symlink(wire_target.as_os_str(), relative_path)
+            {
+                // upstream: generator.c:1554 - log skipped unsafe symlinks
+                info_log!(
+                    Name,
+                    1,
+                    "skipping unsafe symlink \"{}\" -> \"{}\"",
+                    relative_path.display(),
+                    wire_target.display()
+                );
+                continue;
+            }
+
+            // upstream: flist.c:1122-1126 - prepend the `/rsyncd-munged/` prefix
+            // when the daemon enabled `munge symlinks` so the on-disk link
+            // cannot resolve outside the module root when followed.
+            let munged: std::path::PathBuf;
+            let target: &std::path::Path = if self.config.munge_symlinks {
+                munged = std::path::PathBuf::from(::metadata::munge_symlink(
+                    &wire_target.to_string_lossy(),
+                ));
+                munged.as_path()
+            } else {
+                wire_target.as_path()
+            };
+
+            let link_path = dest_dir.join(relative_path);
+
+            // upstream: generator.c:1561 - quick_check_ok(FT_SYMLINK, ...)
+            if let Ok(existing_target) = std::fs::read_link(&link_path) {
+                if existing_target == *target {
+                    // upstream: generator.c:1563 - refresh metadata even when the
+                    // link is already up-to-date so a stale mtime is corrected.
+                    let symlink_options = MetadataOptions::new()
+                        .preserve_owner(self.config.flags.owner)
+                        .preserve_group(self.config.flags.group)
+                        .preserve_times(self.config.flags.times)
+                        .preserve_atimes(self.config.flags.atimes)
+                        .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
+                        .fake_super(self.config.fake_super);
+                    if let Err(error) =
+                        apply_symlink_metadata_from_entry(&link_path, entry, &symlink_options)
+                    {
+                        debug_log!(
+                            Recv,
+                            1,
+                            "failed to refresh symlink metadata for {}: {}",
+                            link_path.display(),
+                            error
+                        );
+                    }
+                    // upstream: generator.c:1565 - symlink up-to-date, metadata only
+                    let iflags = ItemFlags::from_raw(0);
+                    let _ = self.emit_itemize(writer, &iflags, entry);
+                    // upstream: generator.c:1133 - "%s is uptodate" at INFO_GTE(NAME, 2)
+                    info_log!(Name, 2, "{} is uptodate", relative_path.display());
+                    continue;
+                }
+                let _ = fs::remove_file(&link_path);
+            } else if fs::symlink_metadata(&link_path).is_ok() {
+                let _ = fs::remove_file(&link_path);
+            }
+
+            // Ensure parent directory exists for --relative paths.
+            // upstream: generator.c:1317-1326 - make_path() for relative_paths
+            if let Some(parent) = link_path.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+
+            // upstream: generator.c:1591 - atomic_create() -> do_symlink().
+            if let Err(e) = create_windows_symlink(target, &link_path) {
+                // A Windows file symbolic link cannot be created without
+                // privilege and has no junction fallback (directory links do
+                // fall back inside the helper). Skip it with a warning and a
+                // soft error so the transfer still finishes but exits
+                // RERR_PARTIAL (23), matching upstream's FERROR_XFER handling.
+                if fast_io::is_unprivileged_symlink_error(&e) {
+                    info_log!(
+                        Nonreg,
+                        1,
+                        "skipping symlink \"{}\" -> \"{}\" (symlink creation requires Administrator or Developer Mode)",
+                        relative_path.display(),
+                        target.display()
+                    );
+                    unsupported_skip = true;
+                    continue;
+                }
+                debug_log!(
+                    Recv,
+                    1,
+                    "failed to create symlink {} -> {}: {}",
+                    link_path.display(),
+                    target.display(),
+                    e
+                );
+                return Err(e);
+            }
+
+            // upstream: generator.c:1592 - set_file_attrs() runs immediately
+            // after atomic_create -> do_symlink so the new link's mtime matches
+            // the sender-supplied value.
+            let symlink_options = MetadataOptions::new()
+                .preserve_owner(self.config.flags.owner)
+                .preserve_group(self.config.flags.group)
+                .preserve_times(self.config.flags.times)
+                .preserve_atimes(self.config.flags.atimes)
+                .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
+                .fake_super(self.config.fake_super);
+            if let Err(error) =
+                apply_symlink_metadata_from_entry(&link_path, entry, &symlink_options)
+            {
+                debug_log!(
+                    Recv,
+                    1,
+                    "failed to apply symlink metadata for {}: {}",
+                    link_path.display(),
+                    error
+                );
+            }
+            // upstream: generator.c:1594 - itemize new symlink after creation
+            let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+            let _ = self.emit_itemize(writer, &iflags, entry);
+        }
+
+        if unsupported_skip {
+            // upstream: main.c - a skipped do_symlink sets io_error, which maps
+            // to _exit(RERR_PARTIAL).
+            self.flist_io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
+        }
+        Ok(())
+    }
+
+    /// No-op on platforms that are neither Unix nor Windows.
+    #[cfg(not(any(unix, windows)))]
     pub(in crate::receiver) fn create_symlinks<W: crate::writer::MsgInfoSender + ?Sized>(
         &self,
         _dest_dir: &Path,
@@ -531,6 +708,32 @@ pub(in crate::receiver) fn apply_symlink_munge_prefix(target: &Path) -> std::pat
     let mut bytes = ::metadata::SYMLINK_MUNGE_PREFIX.as_bytes().to_vec();
     bytes.extend_from_slice(target.as_os_str().as_bytes());
     std::path::PathBuf::from(OsString::from_vec(bytes))
+}
+
+/// Creates a symbolic link at `link_path` pointing to `target` on Windows.
+///
+/// Resolves `target` against the link's parent directory to decide whether the
+/// link refers to a directory: a directory link goes through
+/// [`fast_io::create_directory_symlink_or_junction`] (real symlink, falling
+/// back to a junction on a privilege refusal), while a file link uses
+/// [`fast_io::create_file_symlink`], which surfaces `ERROR_PRIVILEGE_NOT_HELD`
+/// so the caller can skip the entry. A target that does not resolve to an
+/// existing directory (including a dangling link) is treated as a file link.
+///
+/// Mirrors the local-copy executor's `create_symlink`, which distinguishes
+/// directory from file links via the source's metadata.
+#[cfg(windows)]
+fn create_windows_symlink(target: &Path, link_path: &Path) -> std::io::Result<()> {
+    let resolved = match link_path.parent() {
+        Some(parent) => parent.join(target),
+        None => target.to_path_buf(),
+    };
+    let is_dir = matches!(fs::metadata(&resolved), Ok(meta) if meta.file_type().is_dir());
+    if is_dir {
+        fast_io::create_directory_symlink_or_junction(target, link_path).map(|_| ())
+    } else {
+        fast_io::create_file_symlink(target, link_path)
+    }
 }
 
 #[cfg(test)]

--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -29,4 +29,6 @@ mod post_decision_name_emission;
 mod support;
 mod symlinks_and_devices;
 #[cfg(windows)]
+mod windows_receiver_symlinks;
+#[cfg(windows)]
 mod windows_special_skip;

--- a/crates/transfer/src/receiver/tests/windows_receiver_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/windows_receiver_symlinks.rs
@@ -1,0 +1,144 @@
+//! Windows regression tests for `ReceiverContext::create_symlinks`.
+//!
+//! A remote transfer to a Windows receiver must materialize symbolic links
+//! from the file list instead of silently dropping them. Directory links are
+//! created as a real directory symlink, falling back to a junction when the
+//! process lacks the create-symlink privilege; file links have no privilege-
+//! free equivalent, so a privilege refusal skips the entry with a warning and a
+//! soft error (exit `RERR_PARTIAL`, 23) rather than aborting or panicking. This
+//! mirrors the local-copy executor's `create_symlink` behaviour and pins it so
+//! a future change cannot regress the Windows receiver back to the old no-op.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:1544` - `if (preserve_links && ftype == FT_SYMLINK)`
+//! - `generator.c:1591` - `atomic_create(file, fname, sl, ...)`
+
+#![cfg(windows)]
+
+use std::io::{self, Write};
+
+use protocol::ProtocolVersion;
+use protocol::flist::FileEntry;
+
+use super::super::ReceiverContext;
+use super::support::test_handshake;
+use crate::config::ServerConfig;
+use crate::flags::ParsedServerFlags;
+use crate::role::ServerRole;
+use crate::writer::MsgInfoSender;
+
+/// Sink that captures emitted MSG_INFO frames without touching the daemon
+/// multiplex layer.
+struct CapturingMsgInfoWriter;
+
+impl Write for CapturingMsgInfoWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl MsgInfoSender for CapturingMsgInfoWriter {
+    fn send_msg_info(&mut self, _data: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Mirrors a receiver invoked as `rsync -a`: `--links` is set so symlink
+/// entries in the file list are materialized.
+fn links_receiver_config() -> ServerConfig {
+    ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        flags: ParsedServerFlags {
+            links: true,
+            ..Default::default()
+        },
+        args: vec![std::ffi::OsString::from(".")],
+        ..Default::default()
+    }
+}
+
+/// A directory-symlink entry resolves to its target's contents on Windows.
+///
+/// The receiver creates a real directory symbolic link when privileged
+/// (Administrator or Developer Mode) and a junction otherwise; either way the
+/// on-disk reparse point resolves to the target directory. An absolute target
+/// is used so the junction fallback's `canonicalize` resolves correctly on a
+/// stock unprivileged CI runner (matching `fast_io::win_symlink`'s own test).
+#[test]
+fn windows_receiver_symlink_materializes_directory() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    // Real target directory with a file inside so we can read through the link.
+    let target_dir = dest.join("realdir");
+    std::fs::create_dir(&target_dir).expect("create target dir");
+    std::fs::write(target_dir.join("inside.txt"), b"hello").expect("write inside");
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, links_receiver_config());
+    ctx.file_list = vec![FileEntry::new_symlink("link".into(), target_dir.clone())];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_symlinks(dest, &mut writer)
+        .expect("create_symlinks must materialize a directory link on Windows");
+
+    let link = dest.join("link");
+    let meta = std::fs::symlink_metadata(&link).expect("symlink_metadata on the created link");
+    assert!(
+        meta.file_type().is_symlink(),
+        "a directory link must be a reparse point (symlink or junction), got {:?}",
+        meta.file_type(),
+    );
+
+    let through = std::fs::read_to_string(link.join("inside.txt"))
+        .expect("read target file through the link");
+    assert_eq!(
+        through, "hello",
+        "the receiver-created directory link must resolve to the target's contents",
+    );
+}
+
+/// A file-symlink entry never panics: it is created when the process holds the
+/// symlink privilege, or skipped with a warning and a soft error when it does
+/// not. Either outcome returns `Ok(())` so the transfer still finishes; the
+/// soft error drives the `RERR_PARTIAL` (23) exit upstream produces for a
+/// failed `do_symlink()`.
+#[test]
+fn windows_receiver_symlink_skips_file_on_privilege_refusal() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    // Real target file so the link is classified as a file link (not a dir).
+    let target_file = dest.join("payload.txt");
+    std::fs::write(&target_file, b"payload").expect("write target file");
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, links_receiver_config());
+    ctx.file_list = vec![FileEntry::new_symlink("flink".into(), target_file.clone())];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_symlinks(dest, &mut writer)
+        .expect("a file-symlink privilege refusal must skip gracefully, not error or panic");
+
+    let link = dest.join("flink");
+    if let Ok(meta) = std::fs::symlink_metadata(&link) {
+        // Privileged / Developer-Mode runner: the link was created.
+        assert!(
+            meta.file_type().is_symlink(),
+            "when created, a file link must be a symbolic link, got {:?}",
+            meta.file_type(),
+        );
+    } else {
+        // Unprivileged runner: the entry was skipped, leaving nothing behind.
+        assert!(
+            !link.exists(),
+            "a refused file link must leave no partial entry on disk",
+        );
+    }
+}


### PR DESCRIPTION
## Problem

The network receiver's symlink materialization (`crates/transfer/src/receiver/directory/links.rs::create_symlinks`) was a `#[cfg(not(unix))]` no-op. A remote transfer (SSH or daemon) to a Windows receiver therefore silently dropped every symlink present in the file list. Upstream rsync materializes symlinks on the receiver; oc must too. The local-copy path was already fixed (junction fallback); this brings the network receiver to parity.

## Fix

Replace the no-op with a Windows implementation that delegates to the `fast_io::win_symlink` primitives, mirroring the local-copy executor's `create_symlink` exactly:

- **Directory link** -> `fast_io::create_directory_symlink_or_junction`: a real directory symbolic link when the process holds the create-symlink privilege (Administrator or Developer Mode), falling back to a junction (mount-point reparse point) on an `ERROR_PRIVILEGE_NOT_HELD` refusal.
- **File link** -> `fast_io::create_file_symlink`: no junction equivalent exists, so a privilege refusal skips the entry with a warning and sets the `io_error` soft-error flag (`IOERR_GENERAL`). The transfer still finishes but exits `RERR_PARTIAL` (23), matching upstream's `FERROR_XFER` handling of a failed `do_symlink()`.

The link's directory-vs-file classification resolves the target against the link's parent directory - the receiver-side analog of the local-copy path's `source.metadata()`.

The Unix path is unchanged. All `unsafe` stays in `fast_io`; `transfer` remains unsafe-free. A stub keeps the no-op on platforms that are neither Unix nor Windows. Munge-symlink and safe-links handling, the quick-check, parent creation, metadata refresh, and itemize emission all mirror the Unix path.

## Tests

New Windows-gated module `crates/transfer/src/receiver/tests/windows_receiver_symlinks.rs`:

- `windows_receiver_symlink_materializes_directory` - a directory-symlink flist entry resolves to its target's contents through the created reparse point (symlink or junction).
- `windows_receiver_symlink_skips_file_on_privilege_refusal` - a file-symlink entry either creates the link (privileged runner) or skips it with no partial entry left behind (unprivileged runner); never panics, always returns `Ok`.

The required `Windows (stable)` cell runs only `-p core -p engine -p cli`, so the pinned nextest filter step is extended to `-p transfer` with `test(windows_receiver_symlink)` (same mechanism the local-copy fix used to pin its `junction` / `file_symlink_reports` tests). The tests also run under the `windows-iocp` job's `-p transfer --all-features`.

## Verification (macOS host)

- `cargo check -p transfer` (host) and `--target x86_64-pc-windows-gnu`: clean.
- `cargo check -p transfer --tests --all-features --target x86_64-pc-windows-gnu`: clean (new test typechecks for Windows).
- `cargo clippy -p transfer --all-features -- -D warnings` (host): clean.
- `cargo fmt --all --check`: clean.

The real `windows-latest` runner executing the new tests green is the seal.
