### PR TITLE
feat(protocol): default-off negotiated consecutive-match gating (oc-peer only)

### DIFF
--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -72,6 +72,17 @@ fn flush_seq_match_run(
 #[derive(Clone, Debug)]
 pub struct DeltaGenerator {
     buffer_len: usize,
+    /// Consecutive-match gating threshold (zsync `seq_matches`).
+    ///
+    /// `1` (default) reproduces upstream's accept-on-first-match behaviour and
+    /// leaves the scan byte-for-byte unchanged. `2` engages the oc-only
+    /// consecutive-match extension: a block match is only trusted (emitted as a
+    /// Copy) when it belongs to a run of at least two consecutive matching
+    /// blocks; a lone match is demoted to a Literal of its own source bytes.
+    /// The threshold is set to `2` only when the mutually negotiated
+    /// `CAP_CONSECUTIVE_MATCH` bit is present, which is also the sole condition
+    /// under which the receiver halves the per-block strong-sum length.
+    consecutive_match_needed: u8,
     /// Test-only knob disabling the matched-block pruning bitmap so the
     /// property tests can compare prune-on against prune-off output. The
     /// production path always prunes; see `docs/design/zsync-prune.md`.
@@ -85,6 +96,7 @@ impl DeltaGenerator {
     pub const fn new() -> Self {
         Self {
             buffer_len: DEFAULT_BUFFER_LEN,
+            consecutive_match_needed: 1,
             #[cfg(any(test, feature = "bench-internal"))]
             prune_matched: true,
         }
@@ -94,6 +106,17 @@ impl DeltaGenerator {
     #[must_use]
     pub fn with_buffer_len(mut self, buffer_len: usize) -> Self {
         self.buffer_len = buffer_len.max(1);
+        self
+    }
+
+    /// Sets the consecutive-match gating threshold (zsync `seq_matches`).
+    ///
+    /// Values are clamped to `>= 1`. Only `1` (default, upstream-identical) and
+    /// `2` (oc consecutive-match extension) are meaningful; any value `>= 2`
+    /// engages the gated scan.
+    #[must_use]
+    pub fn with_consecutive_match_needed(mut self, needed: u8) -> Self {
+        self.consecutive_match_needed = needed.max(1);
         self
     }
 
@@ -152,6 +175,9 @@ impl DeltaGenerator {
         reader: R,
         index: &DeltaSignatureIndex,
     ) -> io::Result<DeltaScript> {
+        if self.consecutive_match_needed >= 2 {
+            return self.generate_gated(reader, index);
+        }
         #[cfg(any(test, feature = "bench-internal"))]
         let prune_matched = self.prune_matched;
         #[cfg(not(any(test, feature = "bench-internal")))]
@@ -497,6 +523,176 @@ impl DeltaGenerator {
         Ok(DeltaScript::new(tokens, total_bytes, literal_bytes))
     }
 
+    /// Consecutive-match (zsync `seq_matches=2`) gated delta scan.
+    ///
+    /// This path is engaged only when the mutually negotiated
+    /// `CAP_CONSECUTIVE_MATCH` capability is present (both peers are oc and both
+    /// opted in), which is the same condition under which the receiver halves
+    /// the per-block strong-sum length. Halving the strong sum roughly doubles
+    /// the per-block false-alarm probability; requiring a matching neighbour
+    /// before trusting a block restores the effective collision resistance,
+    /// mirroring zsync's `seq_matches` heuristic (`librcksum/rsum.c`).
+    ///
+    /// A run of consecutive matching source blocks is buffered together with
+    /// each block's source bytes. When the run ends:
+    /// - length >= 2: every block is emitted as a `Copy` (trusted).
+    /// - length == 1: the lone block is demoted to a `Literal` of its own
+    ///   source bytes.
+    ///
+    /// Demoting a lone match to a literal is byte-exact regardless of whether
+    /// the match was a genuine block or a halved-checksum false alarm, so
+    /// reconstruction is always correct. As with upstream's short phase-1
+    /// checksums, the receiver's whole-file checksum and phase-2 full-checksum
+    /// redo remain the ultimate backstop against any residual collision.
+    fn generate_gated<R: Read>(
+        &self,
+        mut reader: R,
+        index: &DeltaSignatureIndex,
+    ) -> io::Result<DeltaScript> {
+        let block_len = index.block_length();
+        let mut window = RingBuffer::with_capacity(block_len);
+        let mut pending_literals = Vec::with_capacity(block_len);
+        let mut rolling = RollingChecksum::new();
+        let mut tokens: Vec<DeltaToken> = Vec::new();
+        let mut total_bytes = 0u64;
+        let mut literal_bytes = 0u64;
+
+        let mut matched_blocks = MatchedBlocks::with_block_count(index.block_count());
+        index.reset_consumed();
+
+        let mut buffer = vec![0u8; self.buffer_len.max(block_len)];
+        let mut buffer_pos = 0usize;
+        let mut buffer_len = 0usize;
+
+        // Flushes accumulated literal bytes as a single token, keeping the
+        // total/literal accounting in step. Returns nothing; mutates in place.
+        macro_rules! flush_pending {
+            () => {
+                if !pending_literals.is_empty() {
+                    literal_bytes += pending_literals.len() as u64;
+                    total_bytes += pending_literals.len() as u64;
+                    let filled =
+                        std::mem::replace(&mut pending_literals, Vec::with_capacity(block_len));
+                    tokens.push(DeltaToken::Literal(filled));
+                }
+            };
+        }
+
+        loop {
+            if buffer_pos == buffer_len {
+                buffer_len = reader.read(&mut buffer)?;
+                buffer_pos = 0;
+                if buffer_len == 0 {
+                    break;
+                }
+            }
+
+            let byte = buffer[buffer_pos];
+            buffer_pos += 1;
+
+            let evicted = window.push_back(byte);
+            if let Some(outgoing_byte) = evicted {
+                rolling
+                    .roll(outgoing_byte, byte)
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+                pending_literals.push(outgoing_byte);
+            } else {
+                rolling.update_byte(byte);
+            }
+
+            if !window.is_full() {
+                continue;
+            }
+
+            let digest = rolling.digest();
+            let (first, second) = window.as_slices();
+            let matched =
+                index.find_match_slices_filtered(digest, first, second, Some(&matched_blocks));
+
+            let Some(mut match_idx) = matched else {
+                continue;
+            };
+
+            // A run begins: flush any literals accumulated before it.
+            flush_pending!();
+
+            // Buffer the run of consecutive matching blocks with their source
+            // bytes so a lone match can be demoted to a literal.
+            let mut run: Vec<(u64, Vec<u8>)> = Vec::new();
+
+            loop {
+                let basis_idx = index.block(match_idx).index();
+                let (s1, s2) = window.as_slices();
+                let mut src = Vec::with_capacity(block_len);
+                src.extend_from_slice(s1);
+                src.extend_from_slice(s2);
+                run.push((basis_idx, src));
+
+                matched_blocks.mark_matched(match_idx);
+                index.mark_consumed(match_idx as u32);
+
+                window.clear();
+                rolling.reset();
+
+                let mut filled = 0usize;
+                while filled < block_len {
+                    if buffer_pos == buffer_len {
+                        buffer_len = reader.read(&mut buffer)?;
+                        buffer_pos = 0;
+                        if buffer_len == 0 {
+                            break;
+                        }
+                    }
+                    let take = (buffer_len - buffer_pos).min(block_len - filled);
+                    window.extend_from_slice(&buffer[buffer_pos..buffer_pos + take]);
+                    filled += take;
+                    buffer_pos += take;
+                }
+
+                if filled < block_len {
+                    // EOF before a full next block: the remaining window bytes
+                    // (if any) drain as literals after the run flush.
+                    break;
+                }
+
+                let (f, s) = window.as_slices();
+                rolling.update(f);
+                if !s.is_empty() {
+                    rolling.update(s);
+                }
+                let adj_digest = rolling.digest();
+                match index.find_match_slices_filtered(adj_digest, f, s, Some(&matched_blocks)) {
+                    Some(next_idx) => match_idx = next_idx,
+                    None => break,
+                }
+            }
+
+            // Flush the run: trusted runs (>= 2) become Copy tokens; a lone
+            // match is demoted to a Literal of its own source bytes.
+            if run.len() >= 2 {
+                for (idx, bytes) in run {
+                    total_bytes += bytes.len() as u64;
+                    tokens.push(DeltaToken::Copy {
+                        index: idx,
+                        len: bytes.len(),
+                    });
+                }
+            } else if let Some((_, bytes)) = run.into_iter().next() {
+                literal_bytes += bytes.len() as u64;
+                total_bytes += bytes.len() as u64;
+                tokens.push(DeltaToken::Literal(bytes));
+            }
+        }
+
+        // Drain any residual window bytes as literals.
+        while let Some(byte) = window.pop_front() {
+            pending_literals.push(byte);
+        }
+        flush_pending!();
+
+        Ok(DeltaScript::new(tokens, total_bytes, literal_bytes))
+    }
+
     /// Generates a [`DeltaScript`] by scanning `source` in parallel across up
     /// to `max_chunks` contiguous, non-overlapping ranges.
     ///
@@ -561,6 +757,15 @@ impl DeltaGenerator {
         index: &DeltaSignatureIndex,
         max_chunks: usize,
     ) -> io::Result<DeltaScript> {
+        // The consecutive-match extension needs a single sequential pass to
+        // reason about cross-range block adjacency, so route it through the
+        // gated scan rather than the parallel range split. This path is only
+        // ever taken on the wire sender (never local copy), which already uses
+        // the sequential `generate`, so no parallelism is lost in practice.
+        if self.consecutive_match_needed >= 2 {
+            return self.generate_gated(Cursor::new(source), index);
+        }
+
         let block_len = index.block_length();
         let n = source.len();
 
@@ -1012,6 +1217,116 @@ mod tests {
         assert_eq!(sequential.tokens().len(), single.tokens().len());
         assert_eq!(sequential.total_bytes(), single.total_bytes());
         assert_eq!(sequential.literal_bytes(), single.literal_bytes());
+    }
+
+    #[test]
+    fn gated_two_consecutive_blocks_are_both_copied() {
+        // seq_matches=2: a run of two consecutive matching blocks is trusted,
+        // so both are emitted as Copy tokens.
+        let basis: Vec<u8> = (0..10_000).map(|b| (b % 251) as u8).collect();
+        let index = build_index(&basis);
+        let block_len = index.block_length();
+        let input = basis[..2 * block_len].to_vec();
+
+        let generator = DeltaGenerator::new().with_consecutive_match_needed(2);
+        let script = generator.generate(&input[..], &index).expect("script");
+
+        let copies = script
+            .tokens()
+            .iter()
+            .filter(|t| matches!(t, DeltaToken::Copy { .. }))
+            .count();
+        assert_eq!(copies, 2, "both consecutive blocks must be copied");
+        assert_eq!(reconstruct(&basis, &index, &script), input);
+    }
+
+    #[test]
+    fn gated_lone_match_is_demoted_to_literal() {
+        // seq_matches=2: a single matching block flanked by non-matching data
+        // has no matching neighbour, so it must NOT be emitted as a Copy - it is
+        // demoted to a Literal and reconstruction stays byte-exact.
+        let basis: Vec<u8> = (0..10_000).map(|b| (b % 251) as u8).collect();
+        let index = build_index(&basis);
+        let block_len = index.block_length();
+
+        // 0xAA never appears in the basis (values are b % 251, and 0xAA=170<251
+        // does appear... use a byte guaranteed absent). basis holds 0..=250, so
+        // 251..=255 are absent; use 0xFF.
+        let filler = vec![0xFFu8; block_len];
+        let mut input = Vec::new();
+        input.extend_from_slice(&filler);
+        input.extend_from_slice(&basis[..block_len]); // exactly one basis block
+        input.extend_from_slice(&filler);
+
+        let generator = DeltaGenerator::new().with_consecutive_match_needed(2);
+        let script = generator.generate(&input[..], &index).expect("script");
+
+        let copies = script
+            .tokens()
+            .iter()
+            .filter(|t| matches!(t, DeltaToken::Copy { .. }))
+            .count();
+        assert_eq!(copies, 0, "a lone match must be demoted to a literal");
+        assert_eq!(reconstruct(&basis, &index, &script), input);
+    }
+
+    #[test]
+    fn gated_default_needed_one_matches_ungated_output() {
+        // Threshold 1 (default) must be byte-for-byte identical to the ungated
+        // generate: the gated path is never entered.
+        let basis: Vec<u8> = (0..10_000).map(|b| (b % 251) as u8).collect();
+        let index = build_index(&basis);
+        let block_len = index.block_length();
+        let mut input = basis[..3 * block_len].to_vec();
+        input.extend_from_slice(b"tail");
+
+        let ungated = DeltaGenerator::new().generate(&input[..], &index).unwrap();
+        let needed_one = DeltaGenerator::new()
+            .with_consecutive_match_needed(1)
+            .generate(&input[..], &index)
+            .unwrap();
+
+        assert_eq!(ungated.tokens().len(), needed_one.tokens().len());
+        assert_eq!(ungated.total_bytes(), needed_one.total_bytes());
+        assert_eq!(ungated.literal_bytes(), needed_one.literal_bytes());
+    }
+
+    #[test]
+    fn gated_reconstructs_modified_source_byte_exact() {
+        // Broad byte-exactness check for the gated scan over a mix of copies,
+        // lone matches and literal regions.
+        let basis = pseudo_random(512 * 1024, 0x00c0_ffee);
+        let index = build_index(&basis);
+        let block_len = index.block_length();
+
+        let mut source = basis.clone();
+        for off in [37usize, 5000, 100_000, source.len() - 40] {
+            source[off] ^= 0xff;
+        }
+        // Splice a lone unmatched region and an isolated single basis block.
+        let mut full = vec![0xFFu8; block_len + 13];
+        full.extend_from_slice(&source);
+        full.extend_from_slice(&basis[block_len..2 * block_len]);
+        full.extend_from_slice(&vec![0xFEu8; block_len + 7]);
+
+        let generator = DeltaGenerator::new().with_consecutive_match_needed(2);
+        let script = generator.generate(&full[..], &index).expect("script");
+        assert_eq!(reconstruct(&basis, &index, &script), full);
+        assert_eq!(script.total_bytes(), full.len() as u64);
+    }
+
+    #[test]
+    fn gated_empty_and_short_inputs() {
+        let basis = vec![0u8; 4096];
+        let index = build_index(&basis);
+        let generator = DeltaGenerator::new().with_consecutive_match_needed(2);
+
+        let empty = generator.generate(&[][..], &index).expect("empty");
+        assert!(empty.tokens().is_empty());
+        assert_eq!(empty.total_bytes(), 0);
+
+        let short = generator.generate(&b"hi"[..], &index).expect("short");
+        assert_eq!(reconstruct(&basis, &index, &short), b"hi");
     }
 
     #[test]

--- a/crates/protocol/src/compatibility/flags.rs
+++ b/crates/protocol/src/compatibility/flags.rs
@@ -49,6 +49,24 @@ impl CompatibilityFlags {
     /// File-list entries support id0 names (`CF_ID0_NAMES`).
     pub const ID0_NAMES: Self = Self::new(1 << 8);
 
+    /// Private oc-only extension: consecutive-match gating with a halved
+    /// per-block strong checksum (`CAP_CONSECUTIVE_MATCH`).
+    ///
+    /// This is NOT an upstream rsync flag. It occupies a high private bit
+    /// (`0x0200_0000`) deliberately kept out of [`Self::KNOWN_MASK`], the
+    /// default-advertised set, and [`Self::ALL_KNOWN`]. compat_flags is a
+    /// varint on the wire (upstream `compat.c:741` `read_varint`), and upstream
+    /// tolerates unknown bits by ignoring them, so this private bit transmits
+    /// harmlessly to a stock peer and is masked away by the negotiation AND
+    /// unless BOTH peers are oc AND both opted in.
+    ///
+    /// Data-integrity invariant: this bit is the sole gate for shrinking the
+    /// per-file strong-sum length (see [`effective_s2length`]). When it is
+    /// absent from the mutually negotiated flags the strong sum stays at full
+    /// length, byte-identical to upstream. It must never be added to
+    /// `KNOWN_MASK` or advertised unconditionally.
+    pub const CONSECUTIVE_MATCH: Self = Self::new(0x0200_0000);
+
     /// Bitfield containing every compatibility flag recognised by this crate.
     pub const ALL_KNOWN: Self = Self::new(Self::KNOWN_MASK);
 
@@ -217,6 +235,36 @@ impl CompatibilityFlags {
             }
             Err(err) => Err(err),
         }
+    }
+}
+
+/// Returns the strong-sum length to use for a file signature given the
+/// mutually negotiated compatibility flags.
+///
+/// This is the single data-integrity choke-point for the consecutive-match
+/// extension (`CAP_CONSECUTIVE_MATCH`). It returns `base_len` unchanged unless
+/// `negotiated` contains [`CompatibilityFlags::CONSECUTIVE_MATCH`], in which
+/// case it returns the halved length (floored at 1). Halving the per-block
+/// strong sum is only safe when the sender simultaneously applies
+/// seq_matches=2 gating, and both behaviours are bound to this exact same
+/// mutual bit.
+///
+/// # Iron invariant
+///
+/// `negotiated` is the result of the negotiation AND (`my_advertised &
+/// peer_advertised`). The private [`CompatibilityFlags::CONSECUTIVE_MATCH`] bit
+/// is only ever set by an oc peer that opted in, so the AND can only retain it
+/// when BOTH peers are oc AND both opted in. Against any upstream rsync (which
+/// never advertises the bit) or any oc peer without the opt-in, the AND clears
+/// the bit and this function returns `base_len` verbatim - byte-identical to
+/// upstream. There is deliberately no other code path that shrinks the
+/// strong-sum length.
+#[must_use]
+pub fn effective_s2length(negotiated: CompatibilityFlags, base_len: u8) -> u8 {
+    if negotiated.contains(CompatibilityFlags::CONSECUTIVE_MATCH) {
+        (base_len / 2).max(1)
+    } else {
+        base_len
     }
 }
 
@@ -695,5 +743,64 @@ mod tests {
         let flags = CompatibilityFlags::INC_RECURSE;
         let cloned = flags;
         assert_eq!(flags, cloned);
+    }
+
+    #[test]
+    fn consecutive_match_is_high_private_bit() {
+        assert_eq!(CompatibilityFlags::CONSECUTIVE_MATCH.bits(), 0x0200_0000);
+    }
+
+    #[test]
+    fn consecutive_match_not_in_known_mask_or_all_known() {
+        // The private extension must never be advertised as a standard flag.
+        assert_eq!(CompatibilityFlags::KNOWN_MASK & 0x0200_0000, 0);
+        assert!(!CompatibilityFlags::ALL_KNOWN.contains(CompatibilityFlags::CONSECUTIVE_MATCH));
+        // Being outside KNOWN_MASK, it reads as an "unknown" (future) bit,
+        // which is exactly how upstream tolerates it.
+        assert!(CompatibilityFlags::CONSECUTIVE_MATCH.has_unknown_bits());
+    }
+
+    #[test]
+    fn consecutive_match_survives_varint_roundtrip() {
+        // A high private bit must round-trip through the varint codec so the
+        // negotiated value the sender reads still carries the capability.
+        let flags = CompatibilityFlags::INC_RECURSE | CompatibilityFlags::CONSECUTIVE_MATCH;
+        let mut encoded = Vec::new();
+        flags.write_to(&mut encoded).unwrap();
+        let decoded = CompatibilityFlags::read_from(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded, flags);
+        assert!(decoded.contains(CompatibilityFlags::CONSECUTIVE_MATCH));
+    }
+
+    #[test]
+    fn mutual_and_only_retains_cap_when_both_advertise() {
+        let cap = CompatibilityFlags::CONSECUTIVE_MATCH;
+        // Both advertise -> retained.
+        assert!((cap & cap).contains(cap));
+        // Only one side (peer is upstream, advertises nothing) -> cleared.
+        let peer_upstream = CompatibilityFlags::INC_RECURSE;
+        assert!(!(cap & peer_upstream).contains(cap));
+        assert!(!(peer_upstream & cap).contains(cap));
+    }
+
+    #[test]
+    fn effective_s2length_full_without_cap() {
+        // Iron invariant: no CAP bit -> full length verbatim, for every base.
+        let no_cap = CompatibilityFlags::INC_RECURSE | CompatibilityFlags::SAFE_FILE_LIST;
+        for base in 1u8..=20 {
+            assert_eq!(effective_s2length(no_cap, base), base);
+        }
+        assert_eq!(effective_s2length(CompatibilityFlags::EMPTY, 16), 16);
+    }
+
+    #[test]
+    fn effective_s2length_halved_with_cap() {
+        let with_cap = CompatibilityFlags::INC_RECURSE | CompatibilityFlags::CONSECUTIVE_MATCH;
+        assert_eq!(effective_s2length(with_cap, 16), 8);
+        assert_eq!(effective_s2length(with_cap, 4), 2);
+        assert_eq!(effective_s2length(with_cap, 3), 1);
+        // Never drops below 1 (NonZeroU8 downstream).
+        assert_eq!(effective_s2length(with_cap, 1), 1);
+        assert_eq!(effective_s2length(with_cap, 2), 1);
     }
 }

--- a/crates/protocol/src/compatibility/mod.rs
+++ b/crates/protocol/src/compatibility/mod.rs
@@ -30,7 +30,7 @@ mod flags;
 mod iter;
 mod known;
 
-pub use self::flags::CompatibilityFlags;
+pub use self::flags::{CompatibilityFlags, effective_s2length};
 pub use self::iter::KnownCompatibilityFlagsIter;
 pub use self::known::{KnownCompatibilityFlag, ParseKnownCompatibilityFlagError};
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -154,7 +154,7 @@ pub mod xattr;
 
 pub use compatibility::{
     CompatibilityFlags, KnownCompatibilityFlag, KnownCompatibilityFlagsIter,
-    ParseKnownCompatibilityFlagError,
+    ParseKnownCompatibilityFlagError, effective_s2length,
 };
 pub use envelope::{
     EnvelopeError, HEADER_LEN as MESSAGE_HEADER_LEN, LogCode, LogCodeConversionError,

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -137,9 +137,10 @@ pub fn generate_delta_from_signature<R: Read>(
     source: R,
     config: DeltaGeneratorConfig<'_>,
 ) -> io::Result<DeltaScript> {
+    let needed = consecutive_match_needed(&config);
     let index = build_signature_index(config)?;
 
-    let generator = DeltaGenerator::new();
+    let generator = DeltaGenerator::new().with_consecutive_match_needed(needed);
     generator.generate(source, &index).map_err(|e| {
         io::Error::other(format!(
             "delta generation failed: {e} {}{}",
@@ -183,9 +184,15 @@ pub fn generate_delta_from_signature_chunked(
     config: DeltaGeneratorConfig<'_>,
     max_chunks: usize,
 ) -> io::Result<DeltaScript> {
+    // Carry the negotiated consecutive-match threshold onto the parallel path:
+    // when the mutual CAP_CONSECUTIVE_MATCH bit is set the receiver has halved
+    // the strong-sum length, so the sender must apply seq_matches=2 gating here
+    // too. `generate_chunked` routes needed >= 2 through the sequential gated
+    // scan, so the parallel opt-in stays wire-transparent under the bit.
+    let needed = consecutive_match_needed(&config);
     let index = build_signature_index(config)?;
 
-    let generator = DeltaGenerator::new();
+    let generator = DeltaGenerator::new().with_consecutive_match_needed(needed);
     let result = if index.has_duplicate_blocks() {
         // Duplicate-content basis: the prune-off parallel scan would diverge
         // from the pruned sequential wire bytes, so keep the sequential path.
@@ -289,6 +296,26 @@ fn build_signature_index(config: DeltaGeneratorConfig<'_>) -> io::Result<DeltaSi
             ),
         )
     })
+}
+
+/// Derives the zsync consecutive-match gating threshold (`seq_matches`) from the
+/// mutually negotiated compat flags.
+///
+/// Returns `2` only when the private `CAP_CONSECUTIVE_MATCH` bit is present -
+/// the exact same condition under which the receiver halved the per-block
+/// strong-sum length carried in `config.strong_sum_length`. The gating
+/// compensates for the shorter, weaker checksum; the two are bound to one
+/// negotiated bit so they can never diverge. Absent the bit (any upstream peer,
+/// or no opt-in) the threshold stays at `1` and the scan is upstream-identical.
+fn consecutive_match_needed(config: &DeltaGeneratorConfig<'_>) -> u8 {
+    if config
+        .compat_flags
+        .is_some_and(|f| f.contains(protocol::CompatibilityFlags::CONSECUTIVE_MATCH))
+    {
+        2
+    } else {
+        1
+    }
 }
 
 /// Streams a whole file to the wire in a single pass: read -> hash -> write.

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -81,6 +81,12 @@ pub struct BasisFileConfig<'a> {
     pub checksum_algorithm: engine::signature::SignatureAlgorithm,
     /// When true, skip basis file search entirely (upstream `--whole-file`).
     pub whole_file: bool,
+    /// Mutually negotiated compatibility flags. Only the private
+    /// [`protocol::CompatibilityFlags::CONSECUTIVE_MATCH`] bit is consulted
+    /// here, to decide whether the per-block strong-sum length is halved (see
+    /// [`protocol::effective_s2length`]). `None` (local copy / no negotiation)
+    /// leaves the strong sum at full length, byte-identical to upstream.
+    pub compat_flags: Option<protocol::CompatibilityFlags>,
 }
 
 /// Configuration for generating a signature from a basis file.
@@ -96,6 +102,8 @@ struct SignatureGenerationConfig {
     checksum_length: NonZeroU8,
     /// Algorithm for strong checksums.
     checksum_algorithm: engine::signature::SignatureAlgorithm,
+    /// Mutually negotiated compatibility flags (see [`BasisFileConfig::compat_flags`]).
+    compat_flags: Option<protocol::CompatibilityFlags>,
 }
 
 impl SignatureGenerationConfig {
@@ -105,6 +113,7 @@ impl SignatureGenerationConfig {
             protocol: config.protocol,
             checksum_length: config.checksum_length,
             checksum_algorithm: config.checksum_algorithm,
+            compat_flags: config.compat_flags,
         }
     }
 }
@@ -227,6 +236,33 @@ fn generate_basis_signature(
     let layout = match calculate_signature_layout(params) {
         Ok(layout) => layout,
         Err(_) => return BasisFileResult::EMPTY,
+    };
+
+    // Iron invariant choke-point: the per-block strong-sum length is shrunk
+    // here, and ONLY here, and ONLY when the mutually negotiated compat flags
+    // carry the private CAP_CONSECUTIVE_MATCH bit. That bit can only survive the
+    // negotiation AND when both peers are oc and both opted in, in which case
+    // the sender applies seq_matches=2 gating to compensate for the shorter
+    // checksum. Against any upstream peer, or without the opt-in, the mutual bit
+    // is absent and `effective_s2length` returns the full length verbatim,
+    // yielding a SumHead byte-identical to upstream.
+    let layout = {
+        let base_len = layout.strong_sum_length().get();
+        let negotiated = config
+            .compat_flags
+            .unwrap_or(protocol::CompatibilityFlags::EMPTY);
+        let eff_len = protocol::effective_s2length(negotiated, base_len);
+        if eff_len == base_len {
+            layout
+        } else {
+            let eff_nz = NonZeroU8::new(eff_len).expect("effective_s2length floors at 1");
+            SignatureLayout::from_raw_parts(
+                layout.block_length(),
+                layout.remainder(),
+                layout.block_count(),
+                eff_nz,
+            )
+        }
     };
 
     let parallel = parallel_checksum_enabled();
@@ -736,6 +772,7 @@ mod tests {
             protocol: ProtocolVersion::NEWEST,
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
+            compat_flags: None,
         };
 
         // Production path (mmap default engaged because size >= threshold).
@@ -769,5 +806,70 @@ mod tests {
             "generate_basis_signature mmap-default diverged from raw-file signature",
         );
         assert_eq!(via_default.basis_path.as_deref(), Some(path.as_path()));
+    }
+
+    #[test]
+    fn consecutive_match_cap_halves_strong_sum_length() {
+        use std::io::Write;
+
+        let data: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("basis.bin");
+        {
+            let mut f = fs::File::create(&path).expect("create");
+            f.write_all(&data).expect("write");
+            f.flush().expect("flush");
+        }
+
+        let strong_len = |cfg: SignatureGenerationConfig| -> u8 {
+            generate_basis_signature(
+                fast_io::open_basis_nofollow(&path).expect("open"),
+                data.len() as u64,
+                path.clone(),
+                cfg,
+            )
+            .signature
+            .as_ref()
+            .expect("signature")
+            .layout()
+            .strong_sum_length()
+            .get()
+        };
+
+        let base = SignatureGenerationConfig {
+            protocol: ProtocolVersion::NEWEST,
+            checksum_length: NonZeroU8::new(16).unwrap(),
+            checksum_algorithm: SignatureAlgorithm::Md4,
+            compat_flags: None,
+        };
+
+        // No flags -> full length (byte-identical to upstream).
+        assert_eq!(strong_len(base), 16);
+
+        // Iron invariant: flags WITHOUT the private CAP bit never shrink it,
+        // even a rich set of standard flags.
+        let no_cap = protocol::CompatibilityFlags::INC_RECURSE
+            | protocol::CompatibilityFlags::SAFE_FILE_LIST
+            | protocol::CompatibilityFlags::CHECKSUM_SEED_FIX;
+        assert_eq!(
+            strong_len(SignatureGenerationConfig {
+                compat_flags: Some(no_cap),
+                ..base
+            }),
+            16
+        );
+
+        // CAP present in the mutual flags -> halved. This is the ONLY input
+        // that shrinks the strong-sum length.
+        let with_cap = protocol::CompatibilityFlags::INC_RECURSE
+            | protocol::CompatibilityFlags::CONSECUTIVE_MATCH;
+        assert_eq!(
+            strong_len(SignatureGenerationConfig {
+                compat_flags: Some(with_cap),
+                ..base
+            }),
+            8,
+            "CAP_CONSECUTIVE_MATCH must halve the strong-sum length"
+        );
     }
 }

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -449,6 +449,7 @@ impl ReceiverContext {
             checksum_length,
             checksum_algorithm,
             whole_file: self.config.flags.whole_file,
+            compat_flags: self.compat_flags,
         }
     }
 

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -197,6 +197,7 @@ impl ReceiverContext {
                         let fuzzy_level = self.config.flags.fuzzy_level;
                         let ref_dirs = &self.config.reference_directories;
                         let protocol = self.protocol;
+                        let compat_flags = self.compat_flags;
                         let whole_file = self.config.flags.whole_file;
                         let dest_dir = &setup.dest_dir;
                         let checksum_length = setup.checksum_length;
@@ -224,6 +225,7 @@ impl ReceiverContext {
                                         checksum_length,
                                         checksum_algorithm,
                                         whole_file,
+                                        compat_flags,
                                     };
                                     find_basis_file_with_config(&basis_config)
                                 })
@@ -244,6 +246,7 @@ impl ReceiverContext {
                                         checksum_length,
                                         checksum_algorithm,
                                         whole_file,
+                                        compat_flags,
                                     };
                                     find_basis_file_with_config(&basis_config)
                                 })

--- a/crates/transfer/src/receiver/transfer/pipeline_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline_async.rs
@@ -222,6 +222,7 @@ impl ReceiverContext {
                         let fuzzy_level = self.config.flags.fuzzy_level;
                         let ref_dirs = &self.config.reference_directories;
                         let protocol = self.protocol;
+                        let compat_flags = self.compat_flags;
                         let whole_file = self.config.flags.whole_file;
                         let dest_dir = &setup.dest_dir;
                         let checksum_length = setup.checksum_length;
@@ -249,6 +250,7 @@ impl ReceiverContext {
                                         checksum_length,
                                         checksum_algorithm,
                                         whole_file,
+                                        compat_flags,
                                     };
                                     find_basis_file_with_config(&basis_config)
                                 })
@@ -269,6 +271,7 @@ impl ReceiverContext {
                                         checksum_length,
                                         checksum_algorithm,
                                         whole_file,
+                                        compat_flags,
                                     };
                                     find_basis_file_with_config(&basis_config)
                                 })

--- a/crates/transfer/src/setup/capability.rs
+++ b/crates/transfer/src/setup/capability.rs
@@ -117,6 +117,31 @@ pub(crate) const CAPABILITY_MAPPINGS: &[CapabilityMapping] = &[
     },
 ];
 
+/// Private oc-to-oc capability letter advertised in the `-e.<...>` string when
+/// the consecutive-match extension is opted in.
+///
+/// This letter is NOT an upstream rsync capability. Upstream ignores unknown
+/// capability letters in `client_info` (it only `strchr`s for its own known
+/// set, compat.c:712-732), so advertising it to a stock peer is inert. It is
+/// the wire channel that carries "this oc client opted in": the private
+/// [`CompatibilityFlags::CONSECUTIVE_MATCH`] bit is only ever set when the oc
+/// server sees this letter AND is itself opted in.
+const CONSECUTIVE_MATCH_CHAR: char = 'Z';
+
+/// Returns whether this process opted in to the consecutive-match extension.
+///
+/// The opt-in is a default-off internal switch driven by the
+/// `OC_CONSECUTIVE_MATCH=1` environment variable. It is deliberately NOT a
+/// default-advertised capability: both peers must set it (and both must be oc)
+/// for the negotiation AND to retain
+/// [`CompatibilityFlags::CONSECUTIVE_MATCH`]. Against any upstream rsync, or any
+/// oc peer without the opt-in, the extension stays fully inert and the wire is
+/// byte-identical to upstream.
+#[must_use]
+fn consecutive_match_opt_in() -> bool {
+    std::env::var_os("OC_CONSECUTIVE_MATCH").is_some_and(|value| value == "1" || value == "true")
+}
+
 /// Returns whether the iconv capability ('s' / CF_SYMLINK_ICONV) is
 /// compiled into this build.
 ///
@@ -172,6 +197,13 @@ fn append_capability_chars(buf: &mut String, allow_inc_recurse: bool) {
             continue;
         }
         buf.push(mapping.char);
+    }
+
+    // Private oc extension: advertise the consecutive-match capability letter
+    // only when this process opted in. Upstream peers ignore the unknown
+    // letter, so this is inert against stock rsync.
+    if consecutive_match_opt_in() {
+        buf.push(CONSECUTIVE_MATCH_CHAR);
     }
 }
 
@@ -267,6 +299,16 @@ pub(crate) fn build_compat_flags_from_client_info(
         if client_info.contains(mapping.char) {
             flags |= mapping.flag;
         }
+    }
+
+    // Private oc extension (CAP_CONSECUTIVE_MATCH): set the bit only when BOTH
+    // sides opted in - the client advertised the letter AND this server process
+    // is itself opted in. This is the negotiation AND that guards the halved
+    // strong-sum length. A stock upstream client never sends the letter, and an
+    // un-opted-in oc server never sets the bit, so the extension is inert unless
+    // both peers are oc and both opted in.
+    if consecutive_match_opt_in() && client_info.contains(CONSECUTIVE_MATCH_CHAR) {
+        flags |= CompatibilityFlags::CONSECUTIVE_MATCH;
     }
 
     flags

--- a/crates/transfer/tests/fuzzy_level2_basis_search.rs
+++ b/crates/transfer/tests/fuzzy_level2_basis_search.rs
@@ -74,6 +74,7 @@ fn fuzzy_level2_finds_basis_in_reference_directory() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
+        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -132,6 +133,7 @@ fn fuzzy_level1_does_not_search_reference_directories() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
+        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -193,6 +195,7 @@ fn fuzzy_level2_selects_best_match_across_reference_dirs() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
+        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -247,6 +250,7 @@ fn fuzzy_level2_generates_valid_signature_from_basis() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
+        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -304,6 +308,7 @@ fn fuzzy_level0_skips_search() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
+        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -351,6 +356,7 @@ fn whole_file_bypasses_fuzzy_search() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: true,
+        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -400,6 +406,7 @@ fn fuzzy_basis_selection_emits_debug_fuzzy_line() {
         checksum_length: NonZeroU8::new(16).unwrap(),
         checksum_algorithm: signature::SignatureAlgorithm::Md4,
         whole_file: false,
+        compat_flags: None,
     };
 
     let result = find_basis_file_with_config(&config);


### PR DESCRIPTION
## Summary

A **default-off**, negotiated, wire-safe delta optimization active **only between two opted-in oc peers**: requiring a block match to be preceded by a matching neighbour (zsync `seq_matches=2`) halves the per-block false-alarm probability, which lets the per-file strong-sum length be halved, saving signature bytes on the receiver-to-sender channel. It is completely inert against stock rsync and against any oc peer without the opt-in.

**Default is not flipped. Do not merge without the benchmark-before-default decision.**

## The iron invariant (data-integrity)

The per-file strong-sum length (`s2length` in the `SumHead`) is shrunk at **exactly one choke-point** - `protocol::effective_s2length()` - which returns the full length unless the *mutually negotiated* compat flags carry the private `CAP_CONSECUTIVE_MATCH` bit (`0x0200_0000`):

```
s2length halved  <=>  CAP in mutual compat_flags  <=>  both peers oc AND both opted in  <=>  sender applies seq_matches=2 gating
```

- The bit is not in `KNOWN_MASK`, not in `ALL_KNOWN`, and is never advertised by default. It rides the varint `compat_flags` that upstream tolerates and ignores (`compat.c:741` `read_varint`).
- Negotiation is server-authoritative: the oc server sets the bit only when the client advertised the private capability letter (`Z` in `-e.<...>`) **and** the server itself opted in. Both require an oc peer with the opt-in, so the AND can never retain it against upstream.
- The sender's `seq_matches=2` gating is bound to the same bit and lives in a separate scan path; the default scan (needed=1) is byte-for-byte untouched. A lone match is demoted to a Literal of its own source bytes, so reconstruction is always byte-exact regardless of a halved-checksum false alarm; the receiver's whole-file checksum and phase-2 full-checksum redo remain the same backstop upstream already relies on for its short phase-1 sums.

## Opt-in

Internal, default-off switch via `OC_CONSECUTIVE_MATCH=1` (both peers must set it). Kept as an env-backed internal bool rather than threaded CLI plumbing to keep this data-integrity-critical change surgical; a user-facing flag is a trivial follow-up.

## Inert-ness seal (lxhost aarch64, upstream rsync 3.4.4, 8 MB delta, `--stats` signature bytes)

SSH transport, pull direction (client is receiver and sends the signature; a smaller signature means a halved `s2length`):

| case | proto | signature bytes | sha vs source |
|------|-------|-----------------|---------------|
| oc<->oc  OFF | 32 | 17022 | identical |
| oc<->oc  ON  | 32 | **14189** (halved, engaged) | identical |
| oc<->upstream OFF | 32 | 17022 | identical |
| oc<->upstream ON  | 32 | **17022** (INERT - full length) | identical |
| oc<->oc ON | 30 / 29 / 28 | 14189 (engaged) | identical |
| oc<->upstream ON | 30 / 29 / 28 | **17022** (INERT - full length) | identical |

Push direction, oc-sender -> upstream-receiver: signature identical ON vs OFF (17016), sha identical - the oc sender reads the full `s2length` upstream declares and never gates.

Every oc<->upstream case (both directions, proto 28-32) leaves `s2length` at full length and produces byte-identical output with exit 0 and no hang - the corruption-inertness guarantee, confirmed empirically. oc<->oc engages the halving at every protocol and reconstructs byte-identically.

Two unrelated, **pre-existing** issues were found during validation and confirmed to reproduce identically on the master binary (so neither is caused by or affects this change): oc<->oc ssh-push to a pre-existing dest hits `mkstemp: Permission denied` on the server-receiver; the local oc-daemon harness desyncs with "unknown multiplexed message code 108". The daemon negotiation path uses the same gated `build_compat_flags_from_client_info` and the same receiver choke-point as SSH, so the invariant holds there by construction; CI's daemon-interop harness exercises that transport.

## Tests (384 pass; check + clippy `-D warnings` + fmt clean)

- protocol: CAP round-trips through varint compat_flags; not in `KNOWN_MASK`; mutual = AND; `effective_s2length` returns full length without CAP and halved (floored at 1) with it.
- matching: `seq_matches=2` demotes a lone match to a Literal and keeps two consecutive matches as Copies; needed=1 is identical to the ungated scan; broad byte-exact reconstruction.
- transfer/receiver: the halving choke-point shrinks the strong-sum length only with the CAP bit, never with any combination of standard flags.
