### PR TITLE
docs(matching): correct parallel-delta RSS + literal-framing wording

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -487,11 +487,11 @@ pub struct ParsedArgs {
 
     /// `--parallel-delta-scan` - opt-in, default-off local sender-side
     /// optimization that scans a large basis file's delta across multiple
-    /// cores. Local-only: it never changes the wire protocol and is never
-    /// forwarded to a remote peer. Only engages for large, duplicate-free
-    /// basis files; token boundaries and matched/literal stats may differ
-    /// for basis files with duplicate-content blocks. Reconstruction is
-    /// unaffected.
+    /// cores. Local-only: it is never forwarded to a remote peer. Only engages
+    /// for large, duplicate-free basis files (duplicate-content basis files
+    /// fall back to the sequential scan). Reconstruction and matched/literal
+    /// stats are unaffected; the literal-token wire framing may differ by a few
+    /// bytes at a range boundary.
     pub parallel_delta_scan: bool,
 
     /// `--cow` / `--no-cow` / `--reflink=<MODE>` - copy-on-write reflink

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -310,11 +310,13 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .help(
                         "Opt-in: scan a large file's delta across multiple \
                          cores (sender side). Only engages for large, \
-                         duplicate-free basis files; token boundaries and \
-                         matched/literal stats may differ for basis files \
-                         with duplicate-content blocks. Reconstruction is \
-                         unaffected. Local-only optimization, never forwarded \
-                         to a remote peer. Default off.",
+                         duplicate-free basis files (duplicate-content basis \
+                         files fall back to the sequential scan). \
+                         Reconstruction and matched/literal stats are \
+                         unaffected; the literal-token wire framing may differ \
+                         by a few bytes at a range boundary. Local-only \
+                         optimization, never forwarded to a remote peer. \
+                         Default off.",
                     )
                     .action(ArgAction::SetTrue),
             )

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -159,7 +159,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --reflink=MODE Copy-on-write reflink policy (auto, always, never).\n",
             "      --zero-copy  Allow I/O-level zero-copy (sendfile, splice, copy_file_range; io_uring SEND_ZC only when built with the iouring-send-zc cargo feature, otherwise downgrades to plain io_uring SEND) when supported by the kernel. This is the default (policy=auto/enabled).\n",
             "      --no-zero-copy  Disable I/O-level zero-copy; route through portable userspace read/write loops. Does not affect filesystem-level reflink/CoW cloning.\n",
-            "      --parallel-delta-scan  Opt-in: scan a large file's delta across multiple cores (sender side). Only engages for large, duplicate-free basis files; token boundaries and matched/literal stats may differ for basis files with duplicate-content blocks. Reconstruction is unaffected. Default off.\n",
+            "      --parallel-delta-scan  Opt-in: scan a large file's delta across multiple cores (sender side). Only engages for large, duplicate-free basis files (duplicate-content basis files fall back to the sequential scan). Reconstruction and matched/literal stats are unaffected; the literal-token wire framing may differ by a few bytes at a range boundary. Local-only, never forwarded to a remote peer. Default off.\n",
             "      --inplace    Write updated data directly to destination files.\n",
             "      --no-inplace Use temporary files when updating regular files.\n",
             "  -h, --human-readable  Output numbers in a human-readable format.\n",

--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -527,10 +527,14 @@ impl DeltaGenerator {
     ///
     /// # Wire transparency
     ///
-    /// The scan runs with the consumed-bitset prune disabled, so the emitted
-    /// token stream (and therefore the wire bytes and the matched/literal
-    /// split) equals the pruned sequential [`Self::generate`] output only when
-    /// **both** hold:
+    /// Reconstruction and the total/literal byte counts are identical to the
+    /// pruned sequential [`Self::generate`] on **every** input: concatenating
+    /// (and coalescing) the per-range token streams only ever joins adjacent
+    /// literal bytes, never moving a byte between the matched and literal
+    /// tallies.
+    ///
+    /// The emitted *token* stream (the Copy/Literal sequence) equals the pruned
+    /// sequential output only when **both** hold:
     ///
     /// 1. the basis is duplicate-free
     ///    ([`DeltaSignatureIndex::has_duplicate_blocks`] is `false`) - with
@@ -544,11 +548,21 @@ impl DeltaGenerator {
     /// stay block-aligned and the boundary either coincides with a block edge
     /// or lands in an edited, non-matching block). It can fail for shifted
     /// content, so callers must treat the result as potentially divergent
-    /// (opt-in only, never advertised as byte-identical) and only engage the
-    /// parallel path behind a default-off flag with the duplicate-free gate.
-    /// The adjacent-literal coalescing in the concatenation loop keeps the
-    /// literal-token framing identical to the sequential scan whenever
-    /// conditions 1 and 2 hold.
+    /// (opt-in only, never advertised as byte-identical on arbitrary inputs)
+    /// and only engage the parallel path behind a default-off flag with the
+    /// duplicate-free gate.
+    ///
+    /// When conditions 1 and 2 hold the scan is token-identical to the
+    /// sequential path, and the adjacent-literal coalescing in the
+    /// concatenation loop makes the wire byte stream identical in the common
+    /// case. One honest residual remains: the sequential scan flushes pending
+    /// literals every `block_length + CHUNK_SIZE` bytes as one continuous run,
+    /// whereas each range restarts that flush cadence at its start, so where a
+    /// range boundary lands inside a long literal run the literal-token framing
+    /// can differ by a few length-prefix bytes at a chunk seam. This rare
+    /// literal-run segmentation seam never changes the reconstructed bytes or
+    /// the total/literal counts - only where the per-token length prefixes fall
+    /// as the wire encoder re-chunks the literal payload.
     ///
     /// # Arguments
     ///
@@ -611,13 +625,17 @@ impl DeltaGenerator {
         // unmatched region: the previous range drains its tail bytes as a
         // literal and the next range emits its head bytes as a second literal,
         // but the sequential [`Self::generate`] scan - which sees the region
-        // as one contiguous run - emits a single literal token there. Merging
-        // the two halves restores that framing, so the wire byte stream
-        // (`write_token_literal` frames each literal token independently)
-        // stays identical to the sequential scan for a duplicate-free basis
-        // whose matched blocks never straddle a range boundary. Merging only
-        // ever concatenates adjacent literal bytes, so reconstruction and the
-        // total/literal byte counts are unaffected on every input.
+        // as one contiguous run - would not split at that exact point. Merging
+        // the two halves removes that boundary double-literal, so for a
+        // duplicate-free basis whose matched blocks never straddle a range
+        // boundary the wire byte stream matches the sequential scan in the
+        // common case. It is not unconditionally byte-identical: the sequential
+        // scan flushes literals every `block_len + CHUNK_SIZE` bytes as one
+        // continuous run while each range restarts that cadence, so inside a
+        // long literal run the length-prefix framing can differ by a few bytes
+        // at a chunk seam. Merging only ever concatenates adjacent literal
+        // bytes, so reconstruction and the total/literal byte counts are
+        // unaffected on every input.
         let mut tokens: Vec<DeltaToken> = Vec::new();
         let mut total_bytes = 0u64;
         let mut literal_bytes = 0u64;

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -290,9 +290,11 @@ pub struct ParsedServerFlags {
     /// across multiple cores (see
     /// [`crate::generator::generate_delta_from_signature_chunked`]). Defaults
     /// to off; the gate additionally requires a duplicate-free basis so the
-    /// emitted token stream stays byte-identical to the sequential scan for the
-    /// eligible inputs. Never advertised as producing byte-identical output on
-    /// arbitrary inputs.
+    /// emitted token stream stays identical to the sequential scan for the
+    /// eligible inputs (matched/literal counts and reconstruction are identical
+    /// on every input; the literal-token wire framing can differ by a few bytes
+    /// at a rare range-boundary seam). Never advertised as producing
+    /// byte-identical output on arbitrary inputs.
     pub parallel_delta_scan: bool,
 
     /// Info flags after the first `.` separator.

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -154,7 +154,10 @@ pub fn generate_delta_from_signature<R: Read>(
 ///
 /// The caller (`generator::transfer::transfer_loop`) opens the source as a
 /// memory-mapped slice and passes it here only after the size/core gate in
-/// `should_parallel_delta` has fired. This
+/// `should_parallel_delta` has fired. Because the mapping spans the whole
+/// source file (pages fault in lazily during the scan), peak RSS for the
+/// chunked scan is proportional to the file size, not bounded to a fixed
+/// window; the win is CPU parallelism, not a memory reduction. This
 /// function then reconstructs the signature index (sharing
 /// [`build_signature_index`] with the sequential
 /// [`generate_delta_from_signature`], so there is a single reconstruction
@@ -162,9 +165,13 @@ pub fn generate_delta_from_signature<R: Read>(
 ///
 /// - **Duplicate-free basis** ([`DeltaSignatureIndex::has_duplicate_blocks`]
 ///   is `false`): run [`DeltaGenerator::generate_chunked`], which scans the
-///   ranges across rayon workers. For the eligible inputs (matches never
-///   straddle a range boundary) the emitted token stream - and therefore the
-///   wire bytes and matched/literal split - equals the sequential scan.
+///   ranges across rayon workers. Reconstruction and the total/literal byte
+///   counts match the sequential scan on every input. For the eligible inputs
+///   (matches never straddle a range boundary) the emitted token stream also
+///   matches, and the wire bytes match in the common case; a rare literal-run
+///   segmentation seam at a range boundary can still shift the literal-token
+///   length framing by a few bytes (never the counts or the reconstructed
+///   data). See [`DeltaGenerator::generate_chunked`] for the exact contract.
 /// - **Duplicate-content basis**: fall back to the pruned sequential
 ///   [`DeltaGenerator::generate`] over the same slice, because the prune-off
 ///   parallel scan would resolve duplicate siblings differently and diverge

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -511,10 +511,13 @@ impl GeneratorContext {
             } else if has_basis {
                 // Opt-in parallel sender-side delta scan: only when the flag is
                 // set and the file is large enough to split usefully across
-                // cores. The source is memory-mapped so a 50 GB basis is never
-                // materialised into a Vec; the mapping is lazy-paged. On any
-                // mmap failure (NFS, FUSE, procfs) fall back to the streaming
-                // sequential reader so the wire output is unchanged. The
+                // cores. The source is memory-mapped rather than read into a
+                // Vec, but the mapping spans the whole file and every page is
+                // touched during the scan, so peak RSS is proportional to the
+                // file size (lazily paged in), not bounded - the gain is CPU
+                // parallelism, not memory. On any mmap failure (NFS, FUSE,
+                // procfs) fall back to the streaming sequential reader so the
+                // wire output is unchanged. The
                 // duplicate-free eligibility check lives inside
                 // generate_delta_from_signature_chunked, which reverts to the
                 // pruned sequential scan for a duplicate-content basis.

--- a/docs/audits/delta-sender-parallel-rolling-hash.md
+++ b/docs/audits/delta-sender-parallel-rolling-hash.md
@@ -414,8 +414,11 @@ Per in-flight file the worker holds:
   (4 + strong_sum_length)` bytes).
 - The `DeltaSignatureIndex` hash table.
 - The source-file mmap (`map_file`, currently from
-  `generator/delta.rs` callers). Size: file size, but RSS-cheap on
-  Linux because pages fault in on demand.
+  `generator/delta.rs` callers). The mapping spans the whole file, and
+  a full delta scan touches every page, so peak RSS is proportional to
+  the file size (pages fault in lazily rather than up front, but they
+  do fault in). The mmap avoids a second heap copy versus reading into
+  a `Vec`; it does not bound resident memory.
 - The accumulated `DeltaScript` token vector, which can hold up to
   `block_len + CHUNK_SIZE` bytes of pending literals before flushing
   (`match/src/generator.rs:148`). Worst case for a no-match file is


### PR DESCRIPTION
The opt-in parallel sender-delta scan (`--parallel-delta-scan`) feeds the generator an mmap of the whole source file, so peak RSS for the chunked scan is proportional to the file size (pages fault in lazily, but the mapping spans the file). Comments/rustdoc that implied bounded or "RSS-cheap" memory are corrected.

The wire-transparency wording is also tightened:

- Reconstruction and the total/literal byte counts are identical to the sequential scan on **every** input.
- For a duplicate-free basis with no range-boundary-straddling match, the scan is token-identical, and after the adjacent-literal coalescing the wire bytes match in the common case.
- Honest residual: the sequential scan flushes literals every `block_length + CHUNK_SIZE` bytes as one continuous run, while each range restarts that cadence, so where a range boundary lands inside a long literal run the literal-token length framing can differ by a few bytes at a chunk seam (never the counts or the reconstructed data).
- The docs no longer claim byte-identical output unconditionally.

The CLI help text had the duplicate-content condition backwards; duplicate-content basis files fall back to the sequential scan. Fixed in `help.rs`, the clap arg help, and the `ParsedArgs`/`DerivedSettings` field docs.

Comments/docs/help-text only; no behavior change. `cargo check -p matching -p transfer -p cli` and stable `cargo fmt --all --check` pass.