### PR TITLE
fix(cli): accept --append/--append-verify in ssh server-arg parser

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -85,6 +85,23 @@ pub(super) struct ServerLongFlags {
     pub(super) files_from: Option<String>,
     pub(super) from0: bool,
     pub(super) inplace: bool,
+    /// Append data onto shorter destination files (upstream: `--append`).
+    ///
+    /// upstream: options.c:1722-1726 - `OPT_APPEND` increments `append_mode`
+    /// on the server side, so a single `--append` sets `append_mode == 1`.
+    /// server_options() (options.c:2951-2954) always emits the bare `--append`
+    /// long flag (never `--append-verify`); the receiver seeks past the
+    /// existing length and the sender streams only the tail (sender.c:89-95,
+    /// generator.c:786).
+    pub(super) append: bool,
+    /// Re-verify the existing prefix under append (upstream: `--append-verify`,
+    /// wire-encoded as a doubled `--append`, `append_mode == 2`).
+    ///
+    /// upstream: options.c:1724 - a second `--append` on the server bumps
+    /// `append_mode` to 2, folding the on-disk prefix into the whole-file
+    /// checksum (match.c:373, receiver.c:357) so a corrupted prefix fails
+    /// verification and triggers a full re-transmit.
+    pub(super) append_verify: bool,
     pub(super) size_only: bool,
     /// Modification-time window in whole seconds (upstream: `--modify-window=NUM`).
     ///
@@ -237,6 +254,8 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         files_from: None,
         from0: false,
         inplace: false,
+        append: false,
+        append_verify: false,
         size_only: false,
         modify_window: None,
         numeric_ids: false,
@@ -285,6 +304,19 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             "--qsort" => flags.qsort = true,
             "--from0" => flags.from0 = true,
             "--inplace" => flags.inplace = true,
+            // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode
+            // on the server side. server_options() (options.c:2951-2954) emits a
+            // single bare `--append` for append_mode == 1 and a doubled
+            // `--append --append` for append_mode == 2 (`--append-verify`); the
+            // client never forwards the long-form `--append-verify`. So the
+            // first `--append` sets append and a second sets append_verify,
+            // mirroring the daemon long-form parser.
+            "--append" => {
+                if flags.append {
+                    flags.append_verify = true;
+                }
+                flags.append = true;
+            }
             "--size-only" => flags.size_only = true,
             // upstream: --numeric-ids is long-form only (options.c:2887-2888)
             "--numeric-ids" => flags.numeric_ids = true,
@@ -521,6 +553,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--qsort"
             | "--from0"
             | "--inplace"
+            | "--append"
             | "--size-only"
             | "--numeric-ids"
             | "--delete"

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -185,6 +185,13 @@ where
     config.file_selection.files_from_path = long_flags.files_from;
     config.file_selection.from0 = long_flags.from0;
     config.write.inplace = long_flags.inplace;
+    // upstream: options.c:2400-2412 - append mode implies inplace; the transfer
+    // layer derives that internally (transfer_ops.rs `use_inplace = inplace ||
+    // append`), so only the append flags need forwarding. append_verify
+    // (append_mode == 2) folds the on-disk prefix into the whole-file checksum
+    // (receiver.c:357, match.c:373). Mirrors the daemon long-form parser.
+    config.flags.append = long_flags.append;
+    config.flags.append_verify = long_flags.append_verify;
     config.file_selection.size_only = long_flags.size_only;
     // upstream: options.c:2893 - bare --partial (no compact 'P' letter) tells the
     // receiver to keep interrupted temp files. OR with the compact value so a

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -381,6 +381,64 @@ fn parse_server_args_skips_joined_partial_dir_flag() {
     assert_eq!(pos_args, vec![OsString::from("dest")]);
 }
 
+/// Regression for network `--append` over SSH: upstream `server_options()`
+/// (options.c:2951-2954) emits a single bare `--append` for `append_mode == 1`.
+/// Without a match arm the flag fell through to `positional_args[0]`
+/// (parse.rs), so the receiver tried to `mkdir` a destination root literally
+/// named `--append` and exited 12 ("failed to create destination root
+/// --append"). The flag string and real positional path must survive intact.
+#[test]
+fn parse_server_args_skips_append_flag() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpre.iLsfxCIvu"),
+        OsString::from("--append"),
+        OsString::from("."),
+        OsString::from("dst/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpre.iLsfxCIvu");
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("dst/")],
+        "--append must not leak into positional args: {pos_args:?}",
+    );
+}
+
+/// `parse_server_long_flags` records a single `--append` as `append_mode == 1`
+/// (plain append, prefix trusted) and never sets `append_verify`.
+#[test]
+fn long_flags_captures_single_append() {
+    let args = vec![OsString::from("--server"), OsString::from("--append")];
+    let flags = parse_server_long_flags(&args);
+    assert!(flags.append);
+    assert!(!flags.append_verify);
+}
+
+/// Upstream wire-encodes `--append-verify` (`append_mode == 2`) as a doubled
+/// bare `--append` (options.c:2952-2954); the client never sends the long-form
+/// `--append-verify`. The second occurrence must set `append_verify`,
+/// mirroring the daemon long-form parser and upstream's `am_server`
+/// `append_mode++` (options.c:1722-1726).
+#[test]
+fn long_flags_captures_doubled_append_as_verify() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--append"),
+        OsString::from("--append"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert!(flags.append);
+    assert!(flags.append_verify);
+}
+
+/// `--append` must be a known server long flag so the compact-flag-string
+/// scanner skips it rather than mistaking it for the flag string or a path.
+#[test]
+fn append_is_known_server_long_flag() {
+    assert!(is_known_server_long_flag("--append"));
+}
+
 /// `parse_server_long_flags` must capture both split and joined
 /// `--partial-dir` forms into `ServerLongFlags::partial_dir`.
 #[test]


### PR DESCRIPTION
## Problem

Network `--append` / `--append-verify` over SSH to an oc server-receiver failed. Upstream `server_options()` (options.c:2951-2954) sends the append option as a bare `--append` long flag alongside the compact flag string:

```
--server -logDtpre.iLsfxCIvu --append . dst/
```

The ssh server-arg parser (`crates/cli/src/frontend/server/flags.rs`) did not recognise `--append`, so it fell through to `positional_args[0]` in `parse.rs`. The receiver then tried to create a file literally named `--append`, failing with a permission error and aborting the transfer.

## Scope of the earlier fix (#6447)

#6447 ("make network --append/--append-verify work over ssh and daemon") wired append through the transfer engine (sender tail-streaming, receiver prefix folding), the client emission (doubled bare `--append` for verify), the CLI argument parser, and the **daemon** long-form parser. It did not add `--append` to the **ssh server-arg** flag table (`server/flags.rs`), so the ssh server-receiver leg still mis-parsed the flag. The daemon path worked; the ssh path did not. This is the remaining gap.

## Fix

- Recognise `--append` in `is_known_server_long_flag` and the long-flag match arm, mirroring the daemon parser: the first `--append` sets `append`, a second (the wire encoding of `--append-verify`, `append_mode == 2`) sets `append_verify` (upstream options.c:1722-1726, `am_server` does `append_mode++`).
- Forward `config.flags.append` / `config.flags.append_verify`. The transfer layer already derives append-implies-inplace internally (`transfer_ops.rs`: `use_inplace = inplace || append`), matching upstream options.c:2400-2412, so no separate inplace wiring is needed.
- Add parser unit tests: `--append` is not shoved into positional args, a single `--append` is plain append, and a doubled `--append` records `append_verify`.

## Verification (upstream rsync 3.4.4, aarch64)

| Scenario | Before | After |
|---|---|---|
| upstream client PUSH `--append` -> oc server-receiver | exit 23, `mkstemp "./--append" failed: Permission denied` | exit 0, sha matches, `diff -r` empty |
| upstream client PUSH `--append-verify` -> oc server-receiver | (same failure) | exit 0, sha matches, `diff -r` empty |
| oc -> oc ssh `--append` | - | exit 0, sha matches, `diff -r` empty |
| normal ssh push (no `--append`), regression | - | exit 0, sha matches, `diff -r` empty |

Cross-check: the oc-after appended file is **byte-identical** (`cmp`) to the result of an upstream<->upstream `--append` transfer.
