### PR TITLE
fix(metadata): preserve transmitted ACL mask on receiver (no narrowing to named entry)

### DIFF
--- a/crates/metadata/src/acl_exacl/tests.rs
+++ b/crates/metadata/src/acl_exacl/tests.rs
@@ -2,7 +2,7 @@ use super::apply::apply_acls_from_cache;
 use super::default_perms::default_perms_for_dir;
 use super::error::is_unsupported_error;
 use super::perms::rsync_perms_to_exacl;
-use super::reconstruct::rsync_acl_to_entries;
+use super::reconstruct::{reconstruct_acl, rsync_acl_to_entries};
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use super::reset::clear_default_acl;
 use super::reset::reset_acl_from_mode;
@@ -188,6 +188,63 @@ fn rsync_acl_to_entries_named_user_and_group() {
     assert_eq!(named[1].kind, AclEntryKind::Group);
     assert_eq!(named[1].name, "100");
     assert_eq!(named[1].perms, Perm::READ | Perm::EXECUTE);
+}
+
+#[test]
+fn reconstruct_access_acl_preserves_full_mask_over_narrower_named_entry() {
+    // Bug #251: the receiver narrowed the ACL mask to a named entry's perms
+    // instead of the transmitted (mode-derived) mask, silently downgrading
+    // group access (exit 0, no error).
+    //
+    // Fixture (mirrors the interop repro): source mode 0o664 with
+    // `user:root:r--`, `group::rw-`, `mask::rw-`. The sender strips the mask and
+    // group_obj because both equal the mode's group bits (rw-), so the received
+    // wire ACL carries only the named user (r--) with mask/base entries unset.
+    // reconstruct_acl() must restore the mask from the mode group bits
+    // ((0o664 >> 3) & 7 = 0o6 = rw-), NOT collapse it to the named user's r--.
+    // upstream: acls.c:770-773 recv_rsync_acl(type=ACCESS).
+    use protocol::acl::{IdAccess, NO_ENTRY};
+
+    let mut wire = RsyncAcl::new();
+    // Named user root with r-- only. Its access bits (0x04) are what the buggy
+    // decode collapsed the mask onto.
+    wire.names.push(IdAccess::user(0, 0x04));
+    // Everything else arrives stripped (inferred from the mode).
+    assert_eq!(wire.mask_obj, NO_ENTRY);
+
+    let reconstructed = reconstruct_acl(&wire, Some(0o664));
+
+    // The mask must equal the transmitted union mask rw- (0x06), pinned by
+    // value - proving it is not narrowed to the named user's r-- (0x04).
+    assert_eq!(
+        reconstructed.mask_obj, 0x06,
+        "mask must be restored from mode group bits (rw-), not the named entry (r--)"
+    );
+    assert_eq!(
+        reconstructed.group_obj, 0x06,
+        "group_obj rw- reconstructed from mode"
+    );
+    assert_eq!(reconstructed.user_obj, 0x06);
+    assert_eq!(reconstructed.other_obj, 0x04);
+}
+
+#[test]
+fn reconstruct_access_acl_keeps_explicit_transmitted_mask_verbatim() {
+    // When the mask is not strippable (it differs from the mode group bits) the
+    // sender transmits it explicitly and reconstruct_acl() must leave it
+    // untouched rather than recomputing from the mode. Mask r-x (0x05), mode
+    // group bits rw- (0x06): the two differ, so a recompute would corrupt it.
+    use protocol::acl::IdAccess;
+
+    let mut wire = RsyncAcl::new();
+    wire.names.push(IdAccess::user(0, 0x04));
+    wire.mask_obj = 0x05; // explicit r-x on the wire
+
+    let reconstructed = reconstruct_acl(&wire, Some(0o664));
+    assert_eq!(
+        reconstructed.mask_obj, 0x05,
+        "an explicitly transmitted mask is preserved verbatim"
+    );
 }
 
 #[test]

--- a/crates/protocol/src/acl/tests.rs
+++ b/crates/protocol/src/acl/tests.rs
@@ -300,7 +300,7 @@ mod wire_roundtrip_tests {
         send_rsync_acl(&mut buf, &acl, AclType::Access, &mut cache, false).unwrap();
 
         let mut cursor = Cursor::new(buf);
-        let result = recv_rsync_acl(&mut cursor).unwrap();
+        let result = recv_rsync_acl(&mut cursor, AclType::Access).unwrap();
 
         match result {
             RecvAclResult::Literal(received) => {
@@ -325,7 +325,9 @@ mod wire_roundtrip_tests {
             send_rsync_acl(&mut buf, &acl, AclType::Access, &mut cache, false).unwrap();
 
             let mut cursor = Cursor::new(buf);
-            if let RecvAclResult::Literal(received) = recv_rsync_acl(&mut cursor).unwrap() {
+            if let RecvAclResult::Literal(received) =
+                recv_rsync_acl(&mut cursor, AclType::Access).unwrap()
+            {
                 assert_eq!(received.user_obj, perm, "Permission {perm} not preserved");
             }
         }
@@ -417,7 +419,7 @@ mod wire_roundtrip_tests {
             send_rsync_acl(&mut buf, &acl, AclType::Access, &mut cache, false).unwrap();
 
             let mut cursor = Cursor::new(&buf);
-            match recv_rsync_acl(&mut cursor).unwrap() {
+            match recv_rsync_acl(&mut cursor, AclType::Access).unwrap() {
                 RecvAclResult::CacheHit(idx) => assert_eq!(idx, expected_idx),
                 RecvAclResult::Literal(_) => panic!("Expected cache hit"),
             }
@@ -448,14 +450,16 @@ mod wire_roundtrip_tests {
         buf.clear();
         send_rsync_acl(&mut buf, &acl1, AclType::Access, &mut cache, false).unwrap();
         let mut cursor = Cursor::new(&buf);
-        if let RecvAclResult::CacheHit(idx) = recv_rsync_acl(&mut cursor).unwrap() {
+        if let RecvAclResult::CacheHit(idx) = recv_rsync_acl(&mut cursor, AclType::Access).unwrap()
+        {
             assert_eq!(idx, 0);
         }
 
         buf.clear();
         send_rsync_acl(&mut buf, &acl2, AclType::Access, &mut cache, false).unwrap();
         let mut cursor = Cursor::new(&buf);
-        if let RecvAclResult::CacheHit(idx) = recv_rsync_acl(&mut cursor).unwrap() {
+        if let RecvAclResult::CacheHit(idx) = recv_rsync_acl(&mut cursor, AclType::Access).unwrap()
+        {
             assert_eq!(idx, 1);
         }
     }
@@ -528,7 +532,9 @@ mod edge_cases {
         send_rsync_acl(&mut buf, &acl, AclType::Access, &mut cache, false).unwrap();
 
         let mut cursor = Cursor::new(buf);
-        if let RecvAclResult::Literal(received) = recv_rsync_acl(&mut cursor).unwrap() {
+        if let RecvAclResult::Literal(received) =
+            recv_rsync_acl(&mut cursor, AclType::Access).unwrap()
+        {
             assert_eq!(received.mask_obj, 0x07);
             assert_eq!(received.user_obj, NO_ENTRY);
             assert_eq!(received.group_obj, NO_ENTRY);
@@ -549,7 +555,9 @@ mod edge_cases {
         send_rsync_acl(&mut buf, &acl, AclType::Access, &mut cache, false).unwrap();
 
         let mut cursor = Cursor::new(buf);
-        if let RecvAclResult::Literal(received) = recv_rsync_acl(&mut cursor).unwrap() {
+        if let RecvAclResult::Literal(received) =
+            recv_rsync_acl(&mut cursor, AclType::Access).unwrap()
+        {
             assert_eq!(received.user_obj, 0x07);
             assert_eq!(received.group_obj, 0x07);
             assert_eq!(received.mask_obj, 0x07);
@@ -745,7 +753,9 @@ mod wire_format_compatibility {
 
         // Verify round-trip
         let mut cursor = Cursor::new(buf);
-        if let RecvAclResult::Literal(received) = recv_rsync_acl(&mut cursor).unwrap() {
+        if let RecvAclResult::Literal(received) =
+            recv_rsync_acl(&mut cursor, AclType::Access).unwrap()
+        {
             assert_eq!(received.user_obj, 0x07);
             assert_eq!(received.names.len(), 1);
         } else {
@@ -845,9 +855,16 @@ mod computed_mask_and_names {
     use super::*;
 
     #[test]
-    fn recv_rsync_acl_sets_computed_mask_when_no_explicit_mask() {
-        // ACL with named entries but no explicit mask_obj.
-        // upstream: recv_rsync_acl sets mask_obj from computed_mask.
+    fn recv_access_acl_leaves_mask_unset_for_mode_reconstruction() {
+        // ACCESS ACL with named entries but no explicit mask on the wire.
+        //
+        // upstream: recv_rsync_acl(type=ACCESS) sets mask_obj = (mode>>3)&7,
+        // the authoritative source, because rsync_acl_strip_perms() only drops
+        // the mask when it equals those mode bits (acls.c:150-151, 770-773).
+        // oc defers that mode-based fill to reconstruct_acl() at apply time, so
+        // the wire decode must leave the mask as NO_ENTRY rather than folding in
+        // the OR of the named-entry access bits (which would narrow the mask to
+        // the named user's perms whenever the true mask exceeds them - bug #251).
         let mut acl = RsyncAcl::new();
         acl.user_obj = 0x07;
         acl.names.push(IdAccess::user(1000, 0x05)); // r-x
@@ -859,8 +876,42 @@ mod computed_mask_and_names {
         send_rsync_acl(&mut buf, &acl, AclType::Access, &mut cache, false).unwrap();
 
         let mut cursor = Cursor::new(buf);
-        if let RecvAclResult::Literal(received) = recv_rsync_acl(&mut cursor).unwrap() {
-            // computed_mask = 0x05 | 0x03 = 0x07
+        if let RecvAclResult::Literal(received) =
+            recv_rsync_acl(&mut cursor, AclType::Access).unwrap()
+        {
+            // The OR of the named entries would be 0x05 | 0x03 = 0x07. The old
+            // (buggy) decode stored that here, pre-empting the correct
+            // mode-based mask. The fixed decode leaves it unset for
+            // reconstruct_acl() to fill from the file mode.
+            assert_eq!(received.mask_obj, NO_ENTRY);
+        } else {
+            panic!("Expected literal ACL");
+        }
+    }
+
+    #[test]
+    fn recv_default_acl_computes_mask_from_named_entries_and_group() {
+        // DEFAULT ACL with named entries but no explicit mask. No file mode is
+        // available (upstream passes mode 0), so upstream folds the group object
+        // into the OR of the named-entry access bits:
+        //   computed_mask_bits |= group_obj & ~NO_ENTRY   (acls.c:774-777)
+        let mut acl = RsyncAcl::new();
+        acl.user_obj = 0x07;
+        acl.group_obj = 0x04; // r--
+        acl.other_obj = 0x00;
+        acl.names.push(IdAccess::user(1000, 0x05)); // r-x
+        acl.names.push(IdAccess::group(200, 0x03)); // -wx
+        // mask_obj stays NO_ENTRY (not set)
+
+        let mut cache = AclCache::new();
+        let mut buf = Vec::new();
+        send_rsync_acl(&mut buf, &acl, AclType::Default, &mut cache, false).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        if let RecvAclResult::Literal(received) =
+            recv_rsync_acl(&mut cursor, AclType::Default).unwrap()
+        {
+            // 0x05 | 0x03 (named OR) | 0x04 (group_obj) = 0x07
             assert_eq!(received.mask_obj, 0x07);
         } else {
             panic!("Expected literal ACL");
@@ -881,7 +932,9 @@ mod computed_mask_and_names {
         send_rsync_acl(&mut buf, &acl, AclType::Access, &mut cache, false).unwrap();
 
         let mut cursor = Cursor::new(buf);
-        if let RecvAclResult::Literal(received) = recv_rsync_acl(&mut cursor).unwrap() {
+        if let RecvAclResult::Literal(received) =
+            recv_rsync_acl(&mut cursor, AclType::Access).unwrap()
+        {
             assert_eq!(received.mask_obj, 0x04);
         } else {
             panic!("Expected literal ACL");
@@ -1741,7 +1794,7 @@ mod strip_perms_for_send_tests {
         send_rsync_acl(&mut buf, &acl, wire::AclType::Access, &mut cache, false).unwrap();
 
         let mut reader = Cursor::new(&buf);
-        let result = recv_rsync_acl(&mut reader).unwrap();
+        let result = recv_rsync_acl(&mut reader, wire::AclType::Access).unwrap();
 
         match result {
             RecvAclResult::Literal(received) => {
@@ -1774,7 +1827,7 @@ mod strip_perms_for_send_tests {
         send_rsync_acl(&mut buf, &acl, wire::AclType::Access, &mut cache, false).unwrap();
 
         let mut reader = Cursor::new(&buf);
-        let result = recv_rsync_acl(&mut reader).unwrap();
+        let result = recv_rsync_acl(&mut reader, wire::AclType::Access).unwrap();
 
         match result {
             RecvAclResult::Literal(received) => {

--- a/crates/protocol/src/acl/wire/recv.rs
+++ b/crates/protocol/src/acl/wire/recv.rs
@@ -70,7 +70,10 @@ pub fn recv_ida_entries<R: Read + ?Sized>(reader: &mut R) -> io::Result<(IdaEntr
 /// # Upstream Reference
 ///
 /// Mirrors `recv_rsync_acl()` in `acls.c` lines 731-800.
-pub fn recv_rsync_acl<R: Read + ?Sized>(reader: &mut R) -> io::Result<RecvAclResult> {
+pub fn recv_rsync_acl<R: Read + ?Sized>(
+    reader: &mut R,
+    acl_type: AclType,
+) -> io::Result<RecvAclResult> {
     let ndx_plus_one = read_varint(reader)?;
     // upstream: acls.c:736-740 reads `int ndx = read_varint(f)` and rejects
     // out-of-range indices with an error. The wire value is an index + 1, so a
@@ -107,10 +110,24 @@ pub fn recv_rsync_acl<R: Read + ?Sized>(reader: &mut R) -> io::Result<RecvAclRes
         let (entries, computed_mask) = recv_ida_entries(reader)?;
         acl.names = entries;
 
-        // upstream: acls.c recv_rsync_acl() sets mask_obj from computed_mask
-        // when named entries are present but no explicit mask was transmitted
-        if !acl.names.is_empty() && acl.mask_obj == NO_ENTRY {
-            acl.mask_obj = computed_mask;
+        // upstream: acls.c:770-779 recv_rsync_acl(). When named entries are
+        // present but no explicit mask was transmitted, the mask must be
+        // reconstructed - a POSIX ACL with named entries requires one.
+        //
+        // For an ACCESS ACL upstream derives the mask from the file mode group
+        // bits, `(mode >> 3) & 7`: the sender's rsync_acl_strip_perms()
+        // (acls.c:150) drops the mask *only* when it equals those bits, so the
+        // mode is the authoritative source. That reconstruction is deferred to
+        // reconstruct_acl() at apply time, which has the mode, so the ACCESS
+        // mask is left as NO_ENTRY here. Folding the OR of the named-entry
+        // access bits in instead (the previous behaviour) silently narrowed the
+        // mask to the named user's perms whenever the true mask exceeded them.
+        //
+        // For a DEFAULT ACL no mode is available (upstream passes mode 0), so
+        // upstream folds the group object into the OR of the named-entry access
+        // bits: `computed_mask_bits |= group_obj & ~NO_ENTRY`.
+        if acl_type == AclType::Default && !acl.names.is_empty() && acl.mask_obj == NO_ENTRY {
+            acl.mask_obj = computed_mask | (acl.group_obj & !NO_ENTRY);
         }
     }
 
@@ -132,10 +149,10 @@ pub fn recv_acl<R: Read + ?Sized>(
     reader: &mut R,
     is_directory: bool,
 ) -> io::Result<(RecvAclResult, Option<RecvAclResult>)> {
-    let access_result = recv_rsync_acl(reader)?;
+    let access_result = recv_rsync_acl(reader, AclType::Access)?;
 
     let default_result = if is_directory {
-        Some(recv_rsync_acl(reader)?)
+        Some(recv_rsync_acl(reader, AclType::Default)?)
     } else {
         None
     };
@@ -163,7 +180,7 @@ fn recv_rsync_acl_cached<R: Read + ?Sized>(
     acl_type: AclType,
     cache: &mut AclCache,
 ) -> io::Result<u32> {
-    let result = recv_rsync_acl(reader)?;
+    let result = recv_rsync_acl(reader, acl_type)?;
 
     match result {
         RecvAclResult::CacheHit(ndx) => {
@@ -238,6 +255,7 @@ pub fn receive_acl_cached<R: Read + ?Sized>(
 
 #[cfg(test)]
 mod edg_panic_tests {
+    use super::AclType;
     use super::recv_rsync_acl;
     use std::io;
 
@@ -250,7 +268,7 @@ mod edg_panic_tests {
     fn recv_rsync_acl_rejects_underflowing_cache_index() {
         // Varint of i32::MIN: leading tag 0xF0 (4 extra bytes) + LE 0x8000_0000.
         let wire = [0xF0u8, 0x00, 0x00, 0x00, 0x80];
-        let err = recv_rsync_acl(&mut &wire[..]).unwrap_err();
+        let err = recv_rsync_acl(&mut &wire[..], AclType::Access).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 }

--- a/crates/protocol/src/acl/wire/tests.rs
+++ b/crates/protocol/src/acl/wire/tests.rs
@@ -40,7 +40,7 @@ fn send_recv_empty_acl() {
     send_rsync_acl(&mut buf, &acl, AclType::Access, &mut cache, false).unwrap();
 
     let mut cursor = Cursor::new(buf);
-    let result = recv_rsync_acl(&mut cursor).unwrap();
+    let result = recv_rsync_acl(&mut cursor, AclType::Access).unwrap();
 
     match result {
         RecvAclResult::Literal(received) => {
@@ -63,7 +63,7 @@ fn send_recv_acl_with_entries() {
     send_rsync_acl(&mut buf, &acl, AclType::Access, &mut cache, false).unwrap();
 
     let mut cursor = Cursor::new(buf);
-    let result = recv_rsync_acl(&mut cursor).unwrap();
+    let result = recv_rsync_acl(&mut cursor, AclType::Access).unwrap();
 
     match result {
         RecvAclResult::Literal(received) => {
@@ -95,7 +95,7 @@ fn cache_hit_on_second_send() {
     assert!(buf.len() < first_len, "Cache hit should be shorter");
 
     let mut cursor = Cursor::new(buf);
-    let result = recv_rsync_acl(&mut cursor).unwrap();
+    let result = recv_rsync_acl(&mut cursor, AclType::Access).unwrap();
 
     match result {
         RecvAclResult::CacheHit(idx) => {
@@ -269,7 +269,7 @@ fn recv_ida_entries_eof_reading_access() {
 #[test]
 fn recv_rsync_acl_eof_reading_ndx() {
     let mut cursor = Cursor::new(Vec::<u8>::new());
-    let result = recv_rsync_acl(&mut cursor);
+    let result = recv_rsync_acl(&mut cursor, AclType::Access);
     assert!(result.is_err());
 }
 
@@ -278,7 +278,7 @@ fn recv_rsync_acl_eof_reading_flags() {
     // ndx = 0 (literal) but no flags byte
     let data = vec![0x00]; // ndx + 1 = 0, so ndx = -1
     let mut cursor = Cursor::new(data);
-    let result = recv_rsync_acl(&mut cursor);
+    let result = recv_rsync_acl(&mut cursor, AclType::Access);
     assert!(result.is_err());
 }
 
@@ -287,7 +287,7 @@ fn recv_rsync_acl_eof_reading_user_obj() {
     // ndx = 0 (literal), flags indicate user_obj, but no data
     let data = vec![0x00, XMIT_USER_OBJ]; // ndx = -1, flags = XMIT_USER_OBJ
     let mut cursor = Cursor::new(data);
-    let result = recv_rsync_acl(&mut cursor);
+    let result = recv_rsync_acl(&mut cursor, AclType::Access);
     assert!(result.is_err());
 }
 
@@ -296,7 +296,7 @@ fn recv_rsync_acl_eof_reading_group_obj() {
     // flags indicate group_obj, but no data after user_obj
     let data = vec![0x00, XMIT_USER_OBJ | XMIT_GROUP_OBJ, 0x07]; // user_obj = 7
     let mut cursor = Cursor::new(data);
-    let result = recv_rsync_acl(&mut cursor);
+    let result = recv_rsync_acl(&mut cursor, AclType::Access);
     assert!(result.is_err());
 }
 
@@ -410,11 +410,11 @@ fn separate_caches_for_access_and_default() {
 
     // Both should be full literals (not cache hits)
     let mut cursor1 = Cursor::new(buf1);
-    let result1 = recv_rsync_acl(&mut cursor1).unwrap();
+    let result1 = recv_rsync_acl(&mut cursor1, AclType::Access).unwrap();
     assert!(matches!(result1, RecvAclResult::Literal(_)));
 
     let mut cursor2 = Cursor::new(buf2);
-    let result2 = recv_rsync_acl(&mut cursor2).unwrap();
+    let result2 = recv_rsync_acl(&mut cursor2, AclType::Default).unwrap();
     assert!(matches!(result2, RecvAclResult::Literal(_)));
 }
 
@@ -485,7 +485,7 @@ fn send_recv_acl_with_mask_obj() {
     send_rsync_acl(&mut buf, &acl, AclType::Access, &mut cache, false).unwrap();
 
     let mut cursor = Cursor::new(buf);
-    let result = recv_rsync_acl(&mut cursor).unwrap();
+    let result = recv_rsync_acl(&mut cursor, AclType::Access).unwrap();
 
     match result {
         RecvAclResult::Literal(received) => {


### PR DESCRIPTION
When applying an incoming access ACL (`-A`), the receiver reconstructed the POSIX ACL mask from the OR of the named-entry access bits instead of the transmitted mask. Whenever the true mask exceeded a named entry's permissions, this silently narrowed the mask, downgrading group access with exit 0 and no error.

Example fixture: source file mode `664`, ACL `user:root:r--`, `group::rw-`, `mask::rw-`.

- upstream 3.4.4 receiver: `mode 664, mask::rw-` (exact preservation)
- receiver before this change: `mode 644, mask::r--, group::rw-#effective:r--` (corrupted)

## Root cause

Upstream recovers the access-ACL mask from the file mode group bits, `(mode >> 3) & 7`. The sender's `rsync_acl_strip_perms()` drops the mask on the wire only when it equals those mode bits (`acls.c:150`), so the mode is the authoritative source. The OR of the named-entry access bits is used only for default ACLs, and there only folded together with the group object (`acls.c:770-779`).

The wire decode was folding that named-entry OR into the mask for every ACL, pre-empting the correct mode-based reconstruction (which is deferred to apply time, where the file mode is available). Because the mask was then no longer unset, the mode-based fill was skipped.

## Fix

`recv_rsync_acl` now takes the ACL type and mirrors upstream:

- Access ACL: leave the mask unset so the apply-time reconstruction fills it from the file mode.
- Default ACL: compute `named_or | group_obj` (no mode available), matching upstream.

The sender path is unchanged (it was already correct - an upstream receiver accepts our output verbatim).

## Tests

- New unit tests pin the reconstructed mask **value** (mask `rw-` restored over a `r--` named entry; an explicitly transmitted mask preserved verbatim). The previous tests only checked entry presence, which is why this slipped through.
- Split the wire-decode test into access (mask left unset) and default (mask computed from OR + group object) cases.

## Validation (aarch64, upstream 3.4.4)

Receiver-side `-A` transfers, comparing `getfacl` + mode byte-for-byte against an upstream-3.4.4 receiver:

| path | before | after | upstream baseline |
|------|--------|-------|-------------------|
| ssh (upstream sender -> oc receiver) | `mode 644, mask::r--` | `mode 664, mask::rw-` | `mode 664, mask::rw-` |
| daemon-pull (upstream daemon -> oc client) | `mode 644, mask::r--` | `mode 664, mask::rw-` | `mode 664, mask::rw-` |

After the fix the receiver output is identical to the upstream receiver in both directions. Matched-mask fixtures and `-aHAX` remain correct (no regression).