### PR TITLE
fix(transfer): honor negotiated CF_INC_RECURSE on receiver (drop non-upstream strip)

### DIFF
--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -347,6 +347,124 @@ mod tests {
         assert!(ctx.flist_eof);
     }
 
+    /// Protocol-32 INC_RECURSE receiver configured for a `-a` pull: the compat
+    /// flags mirror what an upstream daemon negotiates (all known bits, so
+    /// varint entry flags and inline id names are in force) and owner/group
+    /// preservation is on so the uid/gid + name fields decode.
+    fn archive_inc_recurse_receiver() -> ReceiverContext {
+        use crate::flags::ParsedServerFlags;
+        let mut handshake = test_handshake();
+        handshake.compat_flags = Some(CompatibilityFlags::ALL_KNOWN);
+        let config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(PROTOCOL).unwrap(),
+            flag_string: "-logDtpre.iLsfxCIvu".to_owned(),
+            flags: ParsedServerFlags {
+                owner: true,
+                group: true,
+                links: true,
+                times: true,
+                perms: true,
+                recursive: true,
+                archive: true,
+                ..ParsedServerFlags::default()
+            },
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        ReceiverContext::new_for_test(&handshake, config)
+    }
+
+    /// A real multi-segment INC_RECURSE sub-list stream captured verbatim from
+    /// an upstream rsync 3.4.4 daemon answering an `i`-advertised `-a` pull of a
+    /// 3-directory / 6-file tree (`{a,b,c}/{f1,f2}.txt`). The daemon packs the
+    /// whole stream into one `MSG_DATA` frame:
+    ///
+    /// - the initial level-1 flist (`.`, `b`, `a`, `c` in readdir order),
+    /// - the end-of-flist marker (varint `0` flag + varint `0` io_error),
+    /// - three per-directory sub-lists, each introduced by
+    ///   `write_ndx(NDX_FLIST_OFFSET - dir_ndx)` (a `0xFF`-led negative NDX),
+    /// - `write_ndx(NDX_FLIST_EOF)` (`0xFF 0xFE 0x80 0x02 …`).
+    ///
+    /// This exercises the ACTUAL carry/framing boundary an upstream peer
+    /// produces. An oc<->oc round-trip hides the bug because both ends share the
+    /// encoder; only genuine upstream bytes catch a receiver that reads the
+    /// `0xFF` `NDX_FLIST_OFFSET` marker as a varint entry-flags byte (which trips
+    /// `overflow in read_varint`, since `int_byte_extra[0xFF >> 2] = 5 > 4`).
+    ///
+    /// upstream: flist.c:2152 `write_ndx(NDX_FLIST_OFFSET - dir_ndx)`,
+    /// io.c:2243 `write_ndx()`, flist.c:2112 `write_end_of_flist()`.
+    #[rustfmt::skip]
+    const UPSTREAM_INC_RECURSE_FRAME: &[u8] = &[
+        0xac, 0x01, 0x01, 0x2e, 0x00, 0x00, 0x10, 0x6a, 0x66, 0x1f, 0x52, 0xf0,
+        0x6f, 0x84, 0x1b, 0x1d, 0xfd, 0x41, 0x00, 0x00, 0x83, 0xe8, 0x04, 0x6f,
+        0x66, 0x65, 0x72, 0x83, 0xe8, 0x04, 0x6f, 0x66, 0x65, 0x72, 0xa0, 0x9a,
+        0x01, 0x62, 0x00, 0x00, 0x10, 0xf0, 0x3d, 0x65, 0xd9, 0x1c, 0xa0, 0x9a,
+        0x01, 0x61, 0x00, 0x00, 0x10, 0xf0, 0xd3, 0x92, 0x93, 0x1c, 0xa0, 0x9a,
+        0x01, 0x63, 0x00, 0x00, 0x10, 0xf0, 0x6f, 0x84, 0x1b, 0x1d, 0x00, 0x00,
+        0xff, 0x65, 0xa0, 0x98, 0x08, 0x61, 0x2f, 0x66, 0x31, 0x2e, 0x74, 0x78,
+        0x74, 0x00, 0x0a, 0x00, 0xf0, 0xd3, 0x92, 0x93, 0x1c, 0xb4, 0x81, 0x00,
+        0x00, 0xa0, 0xba, 0x03, 0x05, 0x32, 0x2e, 0x74, 0x78, 0x74, 0x00, 0x07,
+        0x00, 0xf0, 0xd3, 0x92, 0x93, 0x1c, 0x00, 0x00, 0xff, 0x01, 0xa0, 0x9a,
+        0x08, 0x62, 0x2f, 0x66, 0x31, 0x2e, 0x74, 0x78, 0x74, 0x00, 0x0a, 0x00,
+        0xf0, 0x3d, 0x65, 0xd9, 0x1c, 0xa0, 0xba, 0x03, 0x05, 0x32, 0x2e, 0x74,
+        0x78, 0x74, 0x00, 0x07, 0x00, 0xf0, 0x3d, 0x65, 0xd9, 0x1c, 0x00, 0x00,
+        0xff, 0x01, 0xa0, 0x9a, 0x08, 0x63, 0x2f, 0x66, 0x31, 0x2e, 0x74, 0x78,
+        0x74, 0x00, 0x0a, 0x00, 0xf0, 0x6f, 0x84, 0x1b, 0x1d, 0xa0, 0xba, 0x03,
+        0x05, 0x32, 0x2e, 0x74, 0x78, 0x74, 0x00, 0x07, 0x00, 0xf0, 0x6f, 0x84,
+        0x1b, 0x1d, 0x00, 0x00, 0xff, 0xfe, 0x80, 0x02, 0x00, 0x00,
+    ];
+
+    #[test]
+    fn real_upstream_multisegment_sublist_decodes_as_segments() {
+        let mut ctx = archive_inc_recurse_receiver();
+        let mut reader = Cursor::new(UPSTREAM_INC_RECURSE_FRAME.to_vec());
+
+        // Initial flist: the four level-1 entries decode, the end-of-list marker
+        // is consumed, but INC_RECURSE leaves `flist_eof` clear until the
+        // terminating NDX_FLIST_EOF is seen in the sub-list stream.
+        let initial = ctx
+            .receive_file_list(&mut reader)
+            .expect("initial level-1 flist decodes cleanly");
+        assert_eq!(initial, 4, "level-1 flist has `.` plus dirs a, b, c");
+        assert!(
+            !ctx.flist_eof,
+            "INC_RECURSE keeps flist_eof clear until NDX_FLIST_EOF"
+        );
+
+        // Drain the sub-lists. The regression: the `0xFF`-led NDX_FLIST_OFFSET
+        // markers must be decoded as segment markers by `read_ndx`, NOT read as
+        // varint entry flags. A fresh codec here matches the sender's fresh NDX
+        // state at the first sub-list marker.
+        let mut codec = create_ndx_codec(PROTOCOL);
+        ctx.ensure_all_segments_loaded(&mut reader, &mut codec)
+            .expect("NDX_FLIST_OFFSET sub-list markers decode as segments, not varint flags");
+
+        assert!(
+            ctx.flist_eof,
+            "NDX_FLIST_EOF terminates the sub-list stream"
+        );
+        assert_eq!(
+            ctx.file_list().len(),
+            10,
+            "4 level-1 dirs + 6 files across 3 per-directory sub-lists"
+        );
+
+        let names: std::collections::BTreeSet<String> = ctx
+            .file_list()
+            .iter()
+            .map(|e| e.path().to_string_lossy().into_owned())
+            .collect();
+        for expected in [
+            "a/f1.txt", "a/f2.txt", "b/f1.txt", "b/f2.txt", "c/f1.txt", "c/f2.txt",
+        ] {
+            assert!(
+                names.contains(expected),
+                "sub-list entry {expected} missing from decoded list: {names:?}"
+            );
+        }
+    }
+
     #[test]
     fn ensure_flat_idx_is_noop_without_inc_recurse() {
         // A non-INC_RECURSE receiver is already at flist_eof (set by

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -116,12 +116,21 @@ pub fn setup_protocol_with<'a>(
                 stdout.flush()?;
                 final_flags
             } else {
-                let mut flags = negotiator.read_compat_flags(stdin)?;
-                // upstream: compat.c:720 - client clears INC_RECURSE when not allowed.
-                if !config.allow_inc_recurse {
-                    flags &= !CompatibilityFlags::INC_RECURSE;
-                }
-                flags
+                // The compat-flags exchange is unidirectional: the server writes
+                // the negotiated set and the client honours it verbatim.
+                // upstream: compat.c:745-746 recv side -
+                //   `inc_recurse = compat_flags & CF_INC_RECURSE ? 1 : 0;`
+                // The server only sets CF_INC_RECURSE when the client advertised
+                // the 'i' capability (compat.c:713, gated by
+                // set_allow_inc_recurse), so a received CF_INC_RECURSE means this
+                // side opted in and must drain the per-directory sub-lists framed
+                // by NDX_FLIST_OFFSET. Masking the flag here (the old
+                // `!allow_inc_recurse` strip) left the receiver reading that
+                // segment framing as file entries, tripping
+                // `overflow in read_varint`. When 'i' is not advertised the server
+                // never sets the bit, so honouring it is inert for every transfer
+                // that does not opt in.
+                negotiator.read_compat_flags(stdin)?
             };
 
             // Determine whether capability negotiation should happen.

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -161,6 +161,61 @@ fn ssh_server_no_flag_string_uses_defaults() {
 }
 
 #[test]
+fn client_honors_negotiated_inc_recurse_regardless_of_local_allow() {
+    // Regression for the INC_RECURSE-on-pull framing desync: on a daemon/SSH
+    // pull the client (is_server=false) reads the server's negotiated compat
+    // flags. The server only sets CF_INC_RECURSE when the client advertised the
+    // `i` capability (upstream compat.c:713, gated by set_allow_inc_recurse), so
+    // a received CF_INC_RECURSE means this side opted in and MUST drain the
+    // per-directory sub-lists framed by NDX_FLIST_OFFSET.
+    //
+    // The old client path silently cleared INC_RECURSE whenever
+    // `allow_inc_recurse` was false, so the receiver skipped the sub-list stream
+    // and later read the `0xFF` NDX_FLIST_OFFSET marker as a varint entry-flags
+    // byte, tripping `overflow in read_varint`. Upstream never masks the bit:
+    // compat.c:745-746 sets `inc_recurse = compat_flags & CF_INC_RECURSE`
+    // unconditionally on the read side. This test pins that the client honours a
+    // negotiated CF_INC_RECURSE even when the local `allow_inc_recurse` gate is
+    // false.
+    let protocol = ProtocolVersion::try_from(31).unwrap();
+    let mut stdin = &b""[..];
+    let mut stdout = Vec::new();
+
+    let config = ProtocolSetupConfig {
+        protocol,
+        skip_compat_exchange: false,
+        client_args: None,
+        flag_string: None,
+        is_server: false,
+        is_daemon_mode: true,
+        do_compression: false,
+        compress_choice: None,
+        checksum_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
+        checksum_seed: Some(42),
+        allow_inc_recurse: false,
+    };
+
+    // The server hands back CF_INC_RECURSE among its negotiated flags.
+    let mock = MockNegotiator {
+        flags_to_read: CompatibilityFlags::INC_RECURSE
+            | CompatibilityFlags::CHECKSUM_SEED_FIX
+            | CompatibilityFlags::VARINT_FLIST_FLAGS,
+        ..MockNegotiator::new()
+    };
+
+    let result = setup_protocol_with(&mut stdout, &mut stdin, &config, &mock)
+        .expect("client compat-flags read should succeed");
+    let flags = result
+        .compat_flags
+        .expect("protocol 31 performs the compat-flags exchange");
+    assert!(
+        flags.contains(CompatibilityFlags::INC_RECURSE),
+        "client must honour the server's negotiated CF_INC_RECURSE (no silent strip)"
+    );
+}
+
+#[test]
 #[cfg(unix)]
 fn build_compat_flags_enables_symlink_times_when_client_advertises_l() {
     let flags = build_compat_flags_from_client_info("LfxCIvu", true);


### PR DESCRIPTION
## Summary

On a daemon or SSH **pull**, the client reads the server's negotiated compatibility flags. The server sets `CF_INC_RECURSE` only when the client advertised the `i` capability, so a received `CF_INC_RECURSE` means this side opted in and must drain the per-directory sub-lists framed by `NDX_FLIST_OFFSET`.

The client's read path previously cleared `INC_RECURSE` whenever `allow_inc_recurse` was false:

```rust
let mut flags = negotiator.read_compat_flags(stdin)?;
if !config.allow_inc_recurse {
    flags &= !CompatibilityFlags::INC_RECURSE;   // non-upstream silent strip
}
```

This diverges from upstream `compat.c:745-746`, which sets `inc_recurse = compat_flags & CF_INC_RECURSE` unconditionally on the read side (it never silently masks the bit). With the flag masked, the receiver set `flist_eof` early, skipped the INC_RECURSE sub-list stream entirely, and then read the leading `0xFF` `NDX_FLIST_OFFSET` segment marker as a varint entry-flags byte - tripping `overflow in read_varint` (exit 23) on the first sub-list frame.

The fix honors the negotiated flag verbatim. Because the server only sets `CF_INC_RECURSE` toward a client that advertised `i`, this is **inert for every transfer that does not opt in** - no default and no advertise gate changes.

## Root cause (byte-level)

Captured from a real upstream rsync 3.4.4 daemon answering an `i`-advertised `-a` pull of a 3-dir / 6-file tree. The daemon packs the whole stream into one `MSG_DATA` frame: the initial level-1 flist (`.`, `b`, `a`, `c`) + end-of-flist varints, then three per-directory sub-lists each framed by `write_ndx(NDX_FLIST_OFFSET - dir_ndx)` (`0xFF`-led), then `write_ndx(NDX_FLIST_EOF)`. A drain trace showed the receiver consuming the initial flist correctly (to frame offset 72) and then reading the segment marker byte `0xFF` via `read_varint` (`int_byte_extra[0xFF >> 2] = 5 > 4` -> overflow) instead of `read_ndx`, because `inc_recurse` had been forced false. An oc<->oc round-trip hid the divergence (both ends share the encoder); only genuine upstream bytes expose it.

## Validation (against real upstream daemons)

| Seal | Setup | Before | After |
|------|-------|--------|-------|
| A - i-OFF regression | `--no-inc-recursive` pull, upstream 3.4.4, 6-file tree | n/a | exit 0, `diff -r` empty (inert) |
| B - i-ON | 3.5.0dev daemon, 6-file tree | overflow | exit 0, 6 files, `diff -r` empty |
| C - i-ON at scale | upstream 3.4.4, 1680-file tree | `overflow in read_varint`, exit 23 | overflow **gone**; now blocks at the separate `MIN_FILECNT_LOOKAHEAD` deadlock |

The 1680-file deadlock is a distinct, pre-existing gap in the up-front sub-list drain (it materializes all segments eagerly while the sender only sends them on demand). It is **out of scope** here and tracked separately; this change only fixes the parsing desync.

## Tests

- `real_upstream_multisegment_sublist_decodes_as_segments` (receiver): replays the real captured multi-segment upstream byte stream and asserts the `NDX_FLIST_OFFSET` markers decode as segment markers (not varint flags), yielding the full 10-entry list.
- `client_honors_negotiated_inc_recurse_regardless_of_local_allow` (setup): pins that the client retains a negotiated `CF_INC_RECURSE` even when `allow_inc_recurse` is false. Verified to FAIL on the old strip and PASS with the fix.

`cargo clippy -p transfer -p protocol --all-features --all-targets -D warnings` clean; `cargo fmt` stable; both new tests pass.

## Scope

Parsing only. No advertise gate is flipped and INC_RECURSE-on-pull stays OFF by default; enabling the pull default and resolving the `MIN_FILECNT_LOOKAHEAD` deadlock are follow-up work.
