### PR TITLE
fix(protocol): gate xattr name-abbreviation wire encoding on protocol version (proto 30 compat)

### DIFF
--- a/crates/protocol/src/xattr/wire/tests.rs
+++ b/crates/protocol/src/xattr/wire/tests.rs
@@ -1114,3 +1114,45 @@ fn recv_xattr_values_exceeds_max_value_len() {
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("exceeds maximum"));
 }
+
+/// Pins the literal-xattr wire layout to exact bytes and asserts it is
+/// protocol-version independent.
+///
+/// Upstream `xattrs.c:send_xattr()` has NO `protocol_version` branch: the
+/// literal encoding (ndx+1, count, per-entry name_len/datum_len/name+NUL/value)
+/// is byte-identical for protocol 30, 31, and 32. The `CF_AVOID_XATTR_OPTIM`
+/// capability and `want_xattr_optim` gate (compat.c:747, only active at
+/// protocol >= 31) affect the transfer-phase hardlink optimisation, not this
+/// flist wire format. This test guards against ever re-introducing a
+/// version-conditioned xattr wire encoding, which desynced proto-30 peers with
+/// an "xa index out of range" error.
+#[test]
+fn send_xattr_literal_wire_is_protocol_independent_golden() {
+    let mut list = XattrList::new();
+    list.push(XattrEntry::new(b"user.foo".to_vec(), b"bar1".to_vec()));
+    list.push(XattrEntry::new(b"user.baz".to_vec(), b"qux2".to_vec()));
+
+    let mut buf = Vec::new();
+    send_xattr(&mut buf, &list, None, 0).unwrap();
+
+    // ndx+1=0 (literal), count=2, then per entry: name_len (incl NUL),
+    // datum_len, name bytes, NUL, value bytes. All varints here are < 0x80 so
+    // encode as a single byte, matching upstream write_varint.
+    let expected: Vec<u8> = [
+        &[0x00u8, 0x02][..], // ndx+1 = 0, count = 2
+        &[0x09, 0x04][..],   // name_len = 9, datum_len = 4
+        b"user.foo",
+        &[0x00][..],
+        b"bar1",
+        &[0x09, 0x04][..], // name_len = 9, datum_len = 4
+        b"user.baz",
+        &[0x00][..],
+        b"qux2",
+    ]
+    .concat();
+
+    assert_eq!(
+        buf, expected,
+        "literal xattr wire bytes drifted from golden"
+    );
+}

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -202,13 +202,16 @@ impl GeneratorContext {
             return Ok(None);
         }
         // upstream: sender.c:281 also gates on the want_xattr_optim hardlink
-        // optimisation. We mirror want_xattr_optim via the negotiated
-        // CF_AVOID_XATTR_OPTIM capability flag - when the flag is NOT set,
-        // upstream's want_xattr_optim is active and the optimisation skips
-        // xattr exchange for local-change hardlinks.
-        let want_xattr_optim = self
-            .compat_flags
-            .is_none_or(|f| !f.contains(CompatibilityFlags::AVOID_XATTR_OPTIMIZATION));
+        // optimisation. upstream: compat.c:747 -
+        // `want_xattr_optim = protocol_version >= 31 && !(compat_flags & CF_AVOID_XATTR_OPTIM)`.
+        // The optimisation only exists at protocol 31+, so it must stay off for
+        // proto-30 peers (rsync 3.0.x) where CF_AVOID_XATTR_OPTIM is undefined -
+        // otherwise the generator skips a request the sender still expects and
+        // desyncs the stream.
+        let want_xattr_optim = self.protocol.as_u8() >= 31
+            && self
+                .compat_flags
+                .is_none_or(|f| !f.contains(CompatibilityFlags::AVOID_XATTR_OPTIMIZATION));
         if want_xattr_optim
             && (iflags.raw() & ItemFlags::ITEM_XNAME_FOLLOWS != 0)
             && (iflags.raw() & ItemFlags::ITEM_LOCAL_CHANGE != 0)

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -549,27 +549,15 @@ pub fn run_server_with_handshake<W: Write>(
             config.write.inplace_partial = true;
         }
 
-        // upstream: compat.c:780-785 - when acting as client, detect that the
-        // remote daemon lacks xattr support (no CF_AVOID_XATTR_OPTIM in its compat
-        // flags means it was built without SUPPORT_XATTRS). Gracefully disable
-        // xattr preservation and warn the user instead of failing mid-transfer.
-        if config.connection.client_mode
-            && config.flags.xattrs
-            && !flags.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
-        {
-            eprintln!(
-                "WARNING: remote daemon does not support extended attributes - disabling xattr preservation {}{}",
-                role_trailer::error_location!(),
-                role_trailer::receiver()
-            );
-            config.flags.xattrs = false;
-        }
-
-        // Same pattern for ACLs: upstream sets CF_AVOID_XATTR_OPTIM only when
-        // SUPPORT_XATTRS is compiled in. A daemon without ACL support won't
-        // advertise the corresponding compat flag. Since upstream rsync has no
-        // dedicated ACL compat flag, ACL rejection is handled via the daemon's
-        // "refuse options" mechanism instead of compat-flag detection.
+        // upstream: compat.c:722-723,747 - CF_AVOID_XATTR_OPTIM only signals
+        // "avoid the xattr hardlink optimization" (want_xattr_optim) and is
+        // gated on protocol_version >= 31. Its absence does NOT mean the peer
+        // lacks xattr support: proto-30 peers (rsync 3.0.x) never define the
+        // flag yet fully preserve xattrs, and the 'x' capability that drives it
+        // is emitted unconditionally (options.c:3048). A remote genuinely built
+        // without SUPPORT_XATTRS rejects -X at option-parse time instead. So we
+        // must NOT disable xattr preservation here - doing so half-disabled the
+        // sender and desynced the proto-30 flist ("xa index out of range").
     }
 
     // upstream: options.c:1842-1868 - when compiled without SUPPORT_ACLS or


### PR DESCRIPTION
## Problem

`-X`/`-aX`/`-aHAX` transfers between oc-rsync and any protocol-30 peer (rsync 3.0.x) failed in both directions:

- push (oc -> 3.0.9): `receive_xattr: xa index NNNN out of range ... xattrs.c(668) [Receiver=3.0.9]`
- pull (3.0.9 -> oc): sender aborted

Baselines that worked (and still work): upstream 3.4.4 <-> 3.0.9 xattr, and oc <-> 3.4.4/3.5.0dev (protocol 32).

## Root cause

Two client-side misreadings of the `CF_AVOID_XATTR_OPTIM` capability flag:

1. **`transfer/src/lib.rs`** disabled xattr preservation whenever the peer's compat flags lacked `CF_AVOID_XATTR_OPTIM`, on the false premise that its absence means "remote built without xattr support". Upstream `compat.c:722-723,747` shows the flag only drives `want_xattr_optim` (a transfer-phase hardlink optimisation, gated on `protocol_version >= 31`); its absence is normal for proto-30 peers, which never define the flag yet fully preserve xattrs. The `x` capability that sets it is emitted unconditionally by any client (`options.c:3048`), and a peer genuinely lacking `SUPPORT_XATTRS` rejects `-X` at option-parse time instead. The wrong disable half-disabled the sender and desynced the flist, so 3.0.9 read a later byte as the xattr index (the garbage "xa index out of range").

2. **`transfer/src/generator/protocol_io.rs`** computed `want_xattr_optim` without the `protocol_version >= 31` gate that upstream (`compat.c:747`) and oc's own receiver pipeline already apply, so at proto 30 the generator could skip an xattr request the sender still expected.

The xattr wire format itself (`xattrs.c:send_xattr()`) has no `protocol_version` branch and is byte-identical across protocol 30/31/32, so it was never the problem.

## Fix

- Remove the baseless xattr-disable block; let xattr preservation proceed for proto-30 peers, matching upstream.
- Add the `protocol >= 31` gate to the generator's `want_xattr_optim`.
- Add a golden test pinning the protocol-independent literal xattr wire bytes.

## Verification (aarch64, rsync 3.0.9 proto-30 peer, upstream 3.4.4 baseline)

All getfattr output byte-for-byte identical to the upstream 3.4.4 -> 3.0.9 baseline:

| Scenario | Before | After |
|---|---|---|
| oc -> 3.0.9 push `-aX` | `xa index out of range`, exit 2/12 | exit 0, xattrs match |
| 3.0.9 -> oc pull `-aX` | sender abort | exit 0, xattrs match |
| oc <-> 3.0.9 `-aHAX` both dirs | fail | exit 0; hardlink inode + ACL + xattr preserved |
| oc <-> 3.4.4 `-aX` (proto 32) | ok | ok (no regression) |

`cargo clippy -p protocol -p transfer --all-features --no-deps -- -D warnings` clean; new golden test passes; fmt clean.
