### PR TITLE
fix(protocol): gate XMIT_*_NAME_FOLLOWS on inc_recurse (id-name wire encoding)

### DIFF
--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -83,6 +83,11 @@ impl<'a> CopyContext<'a> {
                 .with_preserve_hard_links(options.hard_links_enabled())
                 .with_preserve_atimes(options.preserve_atimes())
                 .with_preserve_crtimes(options.preserve_crtimes())
+                // The batch id-list trailer (write_batch_id_lists) emits bare
+                // terminators without names, so owner names must ride inline in
+                // every entry regardless of inc_recurse. Keep XMIT_*_NAME_FOLLOWS
+                // always enabled for the batch flist writer.
+                .with_name_follows(true)
         });
 
         let adaptive_level = if options.compress_enabled() && options.adaptive_compress_enabled() {

--- a/crates/protocol/src/flist/write/mod.rs
+++ b/crates/protocol/src/flist/write/mod.rs
@@ -119,6 +119,16 @@ pub struct FileListWriter {
     /// Upstream writes ACL names only when `inc_recurse && !numeric_ids`
     /// (`acls.c:597`); otherwise the receiver remaps ids through the id-list.
     acl_send_names: bool,
+    /// Whether to emit inline `XMIT_USER_NAME_FOLLOWS`/`XMIT_GROUP_NAME_FOLLOWS`
+    /// owner names in each file entry.
+    ///
+    /// Upstream sets these flags only under incremental recursion
+    /// (`flist.c:481-482,491-492`: `if (inc_recurse && user_name)`). Without
+    /// `inc_recurse` the names ride exclusively in the trailing id-list
+    /// (`send_id_lists`/`recv_id_list`, uidlist.c), so emitting them inline as
+    /// well diverges from upstream's wire encoding. Defaults to `false`; the
+    /// generator sets it to the negotiated `inc_recurse` value.
+    name_follows: bool,
     /// Xattr cache for sender-side deduplication across entries.
     /// upstream: xattrs.c - `find_matching_xattr()` + `rsync_xal_store()`
     xattr_cache: XattrCache,
@@ -146,6 +156,7 @@ impl FileListWriter {
             acl_cache: AclCache::new(),
             pending_acl: None,
             acl_send_names: false,
+            name_follows: false,
             xattr_cache: XattrCache::new(),
             checksum_seed: 0,
         }
@@ -170,6 +181,7 @@ impl FileListWriter {
             acl_cache: AclCache::new(),
             pending_acl: None,
             acl_send_names: false,
+            name_follows: false,
             xattr_cache: XattrCache::new(),
             checksum_seed: 0,
         }
@@ -262,6 +274,21 @@ impl FileListWriter {
     #[must_use]
     pub const fn with_acl_send_names(mut self, send_names: bool) -> Self {
         self.acl_send_names = send_names;
+        self
+    }
+
+    /// Sets whether inline owner names (`XMIT_USER_NAME_FOLLOWS`/
+    /// `XMIT_GROUP_NAME_FOLLOWS`) are emitted per file entry.
+    ///
+    /// Upstream sets these flags only under incremental recursion
+    /// (`flist.c:481-482,491-492`: `if (inc_recurse && user_name)`). Callers
+    /// pass the negotiated `inc_recurse` value. When `false`, owner names are
+    /// carried solely by the trailing id-list (`send_id_lists`), matching
+    /// upstream's non-incremental encoding.
+    #[inline]
+    #[must_use]
+    pub const fn with_name_follows(mut self, name_follows: bool) -> Self {
+        self.name_follows = name_follows;
         self
     }
 

--- a/crates/protocol/src/flist/write/tests/extended_flags.rs
+++ b/crates/protocol/src/flist/write/tests/extended_flags.rs
@@ -229,7 +229,8 @@ fn extended_flags_owner_name_flags() {
         let mut buf = Vec::new();
         let mut writer = FileListWriter::new(protocol)
             .with_preserve_uid(true)
-            .with_preserve_gid(true);
+            .with_preserve_gid(true)
+            .with_name_follows(true);
 
         let mut entry = FileEntry::new_file("owned.txt".into(), 100, 0o644);
         entry.set_uid(1000);
@@ -284,6 +285,83 @@ fn extended_flags_owner_name_flags() {
             "protocol 29 should not have group name"
         );
     }
+}
+
+#[test]
+fn name_follows_gated_on_inc_recurse() {
+    // upstream: flist.c:481-482,491-492 - `if (inc_recurse && user_name)` gates
+    // the inline XMIT_*_NAME_FOLLOWS flags. Without inc_recurse the sender must
+    // NOT emit inline owner names (they ride only in the trailing id-list), so
+    // `with_name_follows(false)` (the default) must produce a strictly shorter
+    // entry and a receiver that sees no inline name. With `with_name_follows`
+    // enabled the names appear inline, matching the incremental-recursion wire.
+    use super::super::super::read::FileListReader;
+    use std::io::Cursor;
+
+    let protocol = ProtocolVersion::try_from(30u8).unwrap();
+
+    let make_entry = || {
+        let mut entry = FileEntry::new_file("owned.txt".into(), 100, 0o644);
+        entry.set_uid(1000);
+        entry.set_gid(1000);
+        entry.set_user_name("alice".to_string());
+        entry.set_group_name("developers".to_string());
+        entry
+    };
+
+    // Default (name_follows = false): no inline names on the wire.
+    let mut off_buf = Vec::new();
+    let mut off_writer = FileListWriter::new(protocol)
+        .with_preserve_uid(true)
+        .with_preserve_gid(true);
+    off_writer.write_entry(&mut off_buf, &make_entry()).unwrap();
+    off_writer.write_end(&mut off_buf, None).unwrap();
+
+    // name_follows = true: inline names emitted (incremental-recursion path).
+    let mut on_buf = Vec::new();
+    let mut on_writer = FileListWriter::new(protocol)
+        .with_preserve_uid(true)
+        .with_preserve_gid(true)
+        .with_name_follows(true);
+    on_writer.write_entry(&mut on_buf, &make_entry()).unwrap();
+    on_writer.write_end(&mut on_buf, None).unwrap();
+
+    // The inline name strings appear only when name_follows is enabled; with it
+    // off they are absent from the entry (and, with no other extended-flag bits
+    // set, the XMIT_EXTENDED_FLAGS byte drops as well), so the gated-off stream
+    // is strictly shorter.
+    let contains = |hay: &[u8], needle: &[u8]| hay.windows(needle.len()).any(|w| w == needle);
+    assert!(contains(&on_buf, b"alice") && contains(&on_buf, b"developers"));
+    assert!(
+        !contains(&off_buf, b"alice") && !contains(&off_buf, b"developers"),
+        "inline owner names must be absent when name_follows is off"
+    );
+    assert!(off_buf.len() < on_buf.len());
+
+    // A receiver decoding the gated-off stream sees no inline names but keeps
+    // the numeric uid/gid (names would arrive via the id-list trailer).
+    let mut off_reader = FileListReader::new(protocol)
+        .with_preserve_uid(true)
+        .with_preserve_gid(true);
+    let off_read = off_reader
+        .read_entry(&mut Cursor::new(&off_buf[..]))
+        .unwrap()
+        .unwrap();
+    assert_eq!(off_read.user_name(), None);
+    assert_eq!(off_read.group_name(), None);
+    assert_eq!(off_read.uid(), Some(1000));
+    assert_eq!(off_read.gid(), Some(1000));
+
+    // The name_follows stream round-trips the inline names.
+    let mut on_reader = FileListReader::new(protocol)
+        .with_preserve_uid(true)
+        .with_preserve_gid(true);
+    let on_read = on_reader
+        .read_entry(&mut Cursor::new(&on_buf[..]))
+        .unwrap()
+        .unwrap();
+    assert_eq!(on_read.user_name(), Some("alice"));
+    assert_eq!(on_read.group_name(), Some("developers"));
 }
 
 #[test]

--- a/crates/protocol/src/flist/write/tests/hardlink.rs
+++ b/crates/protocol/src/flist/write/tests/hardlink.rs
@@ -166,7 +166,8 @@ fn write_hardlink_follower_with_uid_gid_skips_all() {
     let mut writer = FileListWriter::new(protocol)
         .with_preserve_hard_links(true)
         .with_preserve_uid(true)
-        .with_preserve_gid(true);
+        .with_preserve_gid(true)
+        .with_name_follows(true);
 
     let mut entry1 = FileEntry::new_file("leader.txt".into(), 1000, 0o755);
     entry1.set_mtime(1700000000, 0);

--- a/crates/protocol/src/flist/write/tests/names.rs
+++ b/crates/protocol/src/flist/write/tests/names.rs
@@ -9,7 +9,8 @@ fn write_user_name_round_trip_protocol_30() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol)
         .with_preserve_uid(true)
-        .with_preserve_gid(true);
+        .with_preserve_gid(true)
+        .with_name_follows(true);
 
     let mut entry = FileEntry::new_file("file.txt".into(), 100, 0o644);
     entry.set_uid(1000);
@@ -37,7 +38,8 @@ fn write_group_name_round_trip_protocol_30() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol)
         .with_preserve_uid(true)
-        .with_preserve_gid(true);
+        .with_preserve_gid(true)
+        .with_name_follows(true);
 
     let mut entry = FileEntry::new_file("file.txt".into(), 100, 0o644);
     entry.set_gid(1000);
@@ -65,7 +67,8 @@ fn write_user_and_group_names_round_trip_protocol_32() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol)
         .with_preserve_uid(true)
-        .with_preserve_gid(true);
+        .with_preserve_gid(true)
+        .with_name_follows(true);
 
     let mut entry = FileEntry::new_file("owned.txt".into(), 500, 0o644);
     entry.set_uid(1001);
@@ -96,7 +99,8 @@ fn write_user_name_omitted_when_same_uid() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol)
         .with_preserve_uid(true)
-        .with_preserve_gid(true);
+        .with_preserve_gid(true)
+        .with_name_follows(true);
 
     let mut entry1 = FileEntry::new_file("file1.txt".into(), 100, 0o644);
     entry1.set_uid(1000);
@@ -141,7 +145,8 @@ fn write_names_omitted_for_protocol_29() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol)
         .with_preserve_uid(true)
-        .with_preserve_gid(true);
+        .with_preserve_gid(true)
+        .with_name_follows(true);
 
     let mut entry = FileEntry::new_file("file.txt".into(), 100, 0o644);
     entry.set_uid(1000);

--- a/crates/protocol/src/flist/write/tests/protocol_boundaries.rs
+++ b/crates/protocol/src/flist/write/tests/protocol_boundaries.rs
@@ -48,7 +48,8 @@ fn protocol_boundary_29_30_user_names() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol30)
         .with_preserve_uid(true)
-        .with_preserve_gid(true);
+        .with_preserve_gid(true)
+        .with_name_follows(true);
 
     let mut entry = FileEntry::new_file("test.txt".into(), 1024, 0o644);
     entry.set_uid(1000);

--- a/crates/protocol/src/flist/write/xflags.rs
+++ b/crates/protocol/src/flist/write/xflags.rs
@@ -210,11 +210,20 @@ impl FileListWriter {
     ///
     /// Handles XMIT_USER_NAME_FOLLOWS and XMIT_GROUP_NAME_FOLLOWS.
     /// These require the corresponding SAME_UID/SAME_GID flags to NOT be set.
+    ///
+    /// # Upstream Reference
+    ///
+    /// `flist.c:481-482,491-492` gates the inline name flags on `inc_recurse`:
+    /// `if (inc_recurse && user_name) xflags |= XMIT_USER_NAME_FOLLOWS`. Without
+    /// incremental recursion there is no per-file inline name; the names travel
+    /// only in the trailing id-list (`send_id_lists`, uidlist.c). Setting the
+    /// flag when `!inc_recurse` would emit names both inline and in the trailer,
+    /// diverging from upstream's wire encoding.
     #[inline]
     fn calculate_owner_name_flags(&self, entry: &FileEntry, current_flags: u32) -> u32 {
         let mut xflags: u32 = 0;
 
-        if self.protocol.as_u8() < 30 {
+        if self.protocol.as_u8() < 30 || !self.name_follows {
             return xflags;
         }
 

--- a/crates/protocol/tests/flist_wire_flags_rp28g.rs
+++ b/crates/protocol/tests/flist_wire_flags_rp28g.rs
@@ -108,7 +108,8 @@ use protocol::flist::{FileEntry, FileListWriter};
 fn encode_fixture(protocol: ProtocolVersion) -> (Vec<u8>, [usize; 3]) {
     let mut writer = FileListWriter::new(protocol)
         .with_preserve_uid(true)
-        .with_preserve_links(true);
+        .with_preserve_links(true)
+        .with_name_follows(true);
     let mut buf = Vec::new();
     let mut offsets = [0usize; 3];
 

--- a/crates/protocol/tests/proptest_file_entry_roundtrip.rs
+++ b/crates/protocol/tests/proptest_file_entry_roundtrip.rs
@@ -870,7 +870,8 @@ proptest! {
 
         let mut writer = FileListWriter::new(protocol)
             .with_preserve_uid(true)
-            .with_preserve_gid(true);
+            .with_preserve_gid(true)
+            .with_name_follows(true);
         let mut reader = FileListReader::new(protocol)
             .with_preserve_uid(true)
             .with_preserve_gid(true);
@@ -1245,6 +1246,7 @@ proptest! {
         let mut writer = FileListWriter::new(protocol)
             .with_preserve_uid(true)
             .with_preserve_gid(true)
+            .with_name_follows(true)
             .with_preserve_atimes(true)
             .with_preserve_crtimes(true)
             .with_always_checksum(csum_len);

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -302,6 +302,12 @@ impl GeneratorContext {
         .with_preserve_crtimes(self.config.flags.crtimes)
         .with_preserve_acls(self.config.flags.acls)
         .with_acl_send_names(acl_send_names)
+        // upstream: flist.c:481-482,491-492 - inline XMIT_*_NAME_FOLLOWS owner
+        // names are emitted only under incremental recursion. Without it the
+        // names travel solely in the trailing id-list (send_id_lists), so
+        // gating inline emission on inc_recurse keeps the flist bytes identical
+        // to upstream for non-incremental transfers.
+        .with_name_follows(inc_recurse)
         .with_preserve_xattrs(self.config.flags.xattrs)
         .with_checksum_seed(self.checksum_seed);
 


### PR DESCRIPTION
## Summary

At `!inc_recurse`, the file-list writer emitted owner names both inline in every entry (`XMIT_USER_NAME_FOLLOWS` / `XMIT_GROUP_NAME_FOLLOWS`) **and** in the trailing id-list, diverging from upstream's wire encoding.

Upstream `flist.c:481-482,491-492` sets those inline flags only under incremental recursion:

```c
user_name = add_uid(uid);
if (inc_recurse && user_name)
    xflags |= XMIT_USER_NAME_FOLLOWS;
```

Without `inc_recurse`, upstream sends owner names solely in the trailing id-list (`send_id_lists` / `recv_id_list`, `uidlist.c`). The writer's `calculate_owner_name_flags` set the flags whenever a name was present, with no `inc_recurse` gate, so a plain `-a --no-inc-recursive` sender put the names in both places.

## Fix

- Add a `name_follows` flag to `FileListWriter` (default off) and gate the inline owner-name flags on it (mirrors upstream's `inc_recurse` condition; the inline name write is already flag-gated).
- The generator (`build_flist_writer`) sets it to the negotiated `inc_recurse` value.
- The batch flist writer keeps it enabled: its id-list trailer emits bare terminators (`write_batch_id_lists`) and carries owner names inline only.

## Verification (upstream rsync 3.4.4, aarch64)

Wire capture (`strace -e write -x`) of a `-a --no-inc-recursive` push of a file owned by `games`, sender flist entry payload:

| | flist entry bytes | inline name copies |
|---|---|---|
| upstream 3.4.4 | `... 00 00 05 3c a0 98 05 "afile" ...` | 0 (names in trailer only) |
| oc before | `... 00 00 05 05 "games" 3c 05 "games" ...` | 2 inline + 2 trailer |
| oc after | `... 00 00 05 3c a0 98 05 "afile" ...` | 0 (names in trailer only) |

After the fix the flist entry is byte-identical to upstream (uid `05`, gid `3c` back-to-back, no inline names).

Transfers (all exit 0, `diff -r` empty):
- oc -> upstream, `--no-inc-recursive`, root receiver: destination correctly owned by `games`.
- upstream -> oc and oc <-> oc, `--no-inc-recursive`: content match.
- oc -> upstream, default incremental recursion: unchanged, correct ownership (regression check).

Adds a protocol test pinning that the inline owner names are absent when `name_follows` is off and present when on. `cargo fmt` / `clippy -p protocol -p transfer --all-features -D warnings` clean; affected protocol/batch/transfer tests pass.
