### PR TITLE
feat(transfer): implement --copy-dirlinks and fix --keep-dirlinks receiver behavior

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -352,6 +352,7 @@ where
             {
                 use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
                 if is_supported() {
+                    let canonical_root = root.clone();
                     let mut allowed = vec![root];
 
                     // UTS-V3-D: a remote files-from path (upstream
@@ -374,6 +375,20 @@ where
                                 allowed.push(canon);
                             }
                         }
+                    }
+
+                    // upstream: generator.c:1356 - with --keep-dirlinks the
+                    // receiver follows a destination symlink that resolves to a
+                    // directory and writes through it, which upstream permits
+                    // even when the target lives outside the transfer root. The
+                    // Landlock allowlist would otherwise deny those writes
+                    // (EACCES), so extend it with the canonical targets of any
+                    // pre-existing destination symlink-to-directory entries. Only
+                    // symlinks already present before the transfer are added, so
+                    // the escape defense against a mid-transfer symlink swap is
+                    // preserved for paths the user did not pre-establish.
+                    if config.flags.keep_dirlinks {
+                        collect_keep_dirlink_targets(&canonical_root, &mut allowed);
                     }
 
                     let allowed_refs: Vec<&std::path::Path> =
@@ -416,6 +431,60 @@ where
         Err(e) => {
             write_server_error(stderr, program_brand, format!("server error: {e}"));
             1
+        }
+    }
+}
+
+/// Collects the canonical directory targets of pre-existing destination
+/// symlink-to-directory entries so they can be added to the `--keep-dirlinks`
+/// Landlock allowlist.
+///
+/// Walks the real directory structure beneath `root` without descending into
+/// symlinks (avoiding loops); each symlink whose target resolves to a directory
+/// contributes its canonical path. The walk is bounded in depth and total
+/// entries so a hostile or pathological destination tree cannot stall receiver
+/// startup. Mirrors upstream's `--keep-dirlinks` trust model: the destination
+/// symlinks the user pre-established are followed even when their targets sit
+/// outside the transfer root (`generator.c:1356`).
+fn collect_keep_dirlink_targets(root: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    const MAX_DEPTH: usize = 32;
+    const MAX_ENTRIES: usize = 100_000;
+
+    let mut seen: std::collections::HashSet<std::path::PathBuf> = std::collections::HashSet::new();
+    let mut stack: Vec<(std::path::PathBuf, usize)> = vec![(root.to_path_buf(), 0)];
+    let mut visited = 0usize;
+
+    while let Some((dir, depth)) = stack.pop() {
+        if depth > MAX_DEPTH {
+            continue;
+        }
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            visited += 1;
+            if visited > MAX_ENTRIES {
+                return;
+            }
+            let path = entry.path();
+            // Classify without following the symlink so loops are impossible.
+            let Ok(lst) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if lst.file_type().is_symlink() {
+                // A symlink that resolves to a directory is a kept dirlink;
+                // allowlist its canonical target so writes through it succeed.
+                if let Ok(canon) = std::fs::canonicalize(&path) {
+                    if std::fs::metadata(&canon).is_ok_and(|m| m.file_type().is_dir())
+                        && seen.insert(canon.clone())
+                    {
+                        out.push(canon);
+                    }
+                }
+            } else if lst.file_type().is_dir() {
+                stack.push((path, depth + 1));
+            }
         }
     }
 }
@@ -572,5 +641,72 @@ fn write_server_error<Err: Write>(stderr: &mut Err, brand: Brand, text: impl fmt
     message = message.with_role(Role::Server);
     if super::super::write_message(&message, &mut sink).is_err() {
         let _ = writeln!(sink.writer_mut(), "{text}");
+    }
+}
+
+#[cfg(all(test, unix))]
+mod keep_dirlink_target_tests {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    use super::collect_keep_dirlink_targets;
+
+    /// A destination symlink resolving to a directory contributes its canonical
+    /// target so the `--keep-dirlinks` Landlock allowlist permits writes through
+    /// it; a symlink-to-file and a plain directory contribute nothing.
+    #[test]
+    fn collects_only_symlink_to_dir_targets() {
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let root = scratch.path().join("dest");
+        fs::create_dir(&root).unwrap();
+
+        // A symlink-to-directory whose target lives outside the dest root.
+        let outside = scratch.path().join("outside");
+        fs::create_dir(&outside).unwrap();
+        symlink(&outside, root.join("dlink")).unwrap();
+
+        // A symlink-to-file (not a dirlink) and a plain directory: neither is a
+        // kept dirlink target.
+        let file = scratch.path().join("f.txt");
+        fs::write(&file, b"x").unwrap();
+        symlink(&file, root.join("flink")).unwrap();
+        fs::create_dir(root.join("realdir")).unwrap();
+
+        let mut out = Vec::new();
+        collect_keep_dirlink_targets(&root, &mut out);
+
+        let canon_outside = fs::canonicalize(&outside).unwrap();
+        assert!(
+            out.contains(&canon_outside),
+            "the symlink-to-directory target must be allowlisted: {out:?}"
+        );
+        assert_eq!(
+            out.len(),
+            1,
+            "only the symlink-to-directory contributes a target: {out:?}"
+        );
+    }
+
+    /// A nested symlink-to-directory (below the root) is also collected, since
+    /// upstream follows kept dirlinks at any depth.
+    #[test]
+    fn collects_nested_symlink_to_dir_targets() {
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let root = scratch.path().join("dest");
+        let sub = root.join("sub");
+        fs::create_dir_all(&sub).unwrap();
+
+        let outside = scratch.path().join("outside");
+        fs::create_dir(&outside).unwrap();
+        symlink(&outside, sub.join("dlink")).unwrap();
+
+        let mut out = Vec::new();
+        collect_keep_dirlink_targets(&root, &mut out);
+
+        let canon_outside = fs::canonicalize(&outside).unwrap();
+        assert!(
+            out.contains(&canon_outside),
+            "a nested kept-dirlink target must be allowlisted: {out:?}"
+        );
     }
 }

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -144,6 +144,15 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.copy_links() {
         flags.push('L');
     }
+    // upstream: options.c:2658-2659 - 'k' = copy_dirlinks. Packed alongside
+    // 'L' so the in-process push sender (build_server_config_for_generator)
+    // sets `flags.copy_dirlinks` and the flist walker transmits a
+    // symlink-to-directory as a real directory; also forwarded to a remote
+    // daemon sender on a pull. Both dereference on the sender exactly like
+    // copy_links.
+    if config.copy_dirlinks() {
+        flags.push('k');
+    }
 
     // upstream: options.c:2750-2762 - itemize-changes is forwarded via
     // --log-format=%i in the long-form args, not as a compact flag.

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -442,6 +442,22 @@ impl GeneratorContext {
             let StatResult { path, metadata } = result;
             match metadata {
                 Ok(mut meta) => {
+                    // upstream: flist.c:1362-1370 link_stat() - with
+                    // --copy-dirlinks (follow_dirlinks), a symlink whose
+                    // target is a directory is transmitted as a real
+                    // directory. Applied before the copy-unsafe-links check
+                    // exactly as upstream applies it inside link_stat() before
+                    // readlink_stat() re-examines S_ISLNK. Only symlinks to
+                    // directories are followed; symlinks to files stay
+                    // symlinks (distinct from --copy-links, which follows all).
+                    if !follow && self.config.flags.copy_dirlinks && meta.file_type().is_symlink() {
+                        if let Ok(followed) = std::fs::metadata(&path) {
+                            if followed.file_type().is_dir() {
+                                meta = followed;
+                            }
+                        }
+                    }
+
                     // upstream: flist.c:215 - follow unsafe symlinks when
                     // --copy-unsafe-links. The batch used lstat, so we need
                     // to re-stat symlinks whose target escapes the tree.
@@ -544,6 +560,21 @@ impl GeneratorContext {
         }
 
         let meta = std::fs::symlink_metadata(path)?;
+
+        // upstream: flist.c:1362-1370 link_stat() - with --copy-dirlinks
+        // (follow_dirlinks), a symlink whose target is a directory is
+        // transmitted as a real directory. Applied before the
+        // copy-unsafe-links check, mirroring upstream's link_stat()
+        // (dirlink follow) running before readlink_stat()'s S_ISLNK
+        // re-examination. Only symlinks to directories are followed;
+        // symlinks to files stay symlinks (distinct from --copy-links).
+        if self.config.flags.copy_dirlinks && meta.file_type().is_symlink() {
+            if let Ok(followed) = std::fs::metadata(path) {
+                if followed.file_type().is_dir() {
+                    return Ok(followed);
+                }
+            }
+        }
 
         // upstream: flist.c:215 - follow unsafe symlinks when --copy-unsafe-links
         if self.config.flags.copy_unsafe_links && meta.file_type().is_symlink() {

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -19,7 +19,64 @@ use protocol::xattr::XattrList;
 use super::FailedDirectories;
 use crate::receiver::{ReceiverContext, apply_acls_from_receiver_cache};
 
+/// Outcome of classifying a directory destination before creation.
+///
+/// Mirrors upstream's generator dir preparation: `link_stat(fname, &sx.st,
+/// keep_dirlinks && is_dir)` (`generator.c:1356`) classifies the destination,
+/// then a non-directory destination is deleted via `delete_item(...,
+/// del_opts | DEL_FOR_DIR)` before `do_mkdir_at()` (`generator.c:1451-1455`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DirDestination {
+    /// Destination is absent - create it (and honour `--existing` skipping).
+    Missing,
+    /// Destination already usable as a directory - reuse it. Either a real
+    /// directory, or a symlink-to-directory followed under `--keep-dirlinks`.
+    Existing,
+    /// A conflicting symlink was removed - create a real directory in its
+    /// place. The destination existed, so `--existing` does NOT skip it.
+    ReplacedSymlink,
+}
+
+impl DirDestination {
+    /// Whether a directory must be materialised (mkdir) for this outcome.
+    const fn needs_mkdir(self) -> bool {
+        matches!(self, Self::Missing | Self::ReplacedSymlink)
+    }
+}
+
 impl ReceiverContext {
+    /// Classifies a directory destination, removing a conflicting symlink first
+    /// when required.
+    ///
+    /// A `.exists()`-style probe would be wrong here: it follows symlinks, so a
+    /// destination symlink-to-directory would always be treated as an existing
+    /// directory and never replaced, diverging from upstream when
+    /// `--keep-dirlinks` is off.
+    fn classify_dir_destination(&self, dir_path: &Path) -> io::Result<DirDestination> {
+        match fs::symlink_metadata(dir_path) {
+            Ok(existing) if existing.file_type().is_symlink() => {
+                let resolves_to_dir = fs::metadata(dir_path)
+                    .map(|meta| meta.file_type().is_dir())
+                    .unwrap_or(false);
+                if self.config.flags.keep_dirlinks && resolves_to_dir {
+                    // upstream: generator.c:1356 - keep_dirlinks follows the
+                    // destination symlink-to-directory instead of replacing it.
+                    Ok(DirDestination::Existing)
+                } else {
+                    // upstream: generator.c:1454 - delete_item(fname, ...,
+                    // DEL_FOR_DIR) removes the conflicting symlink before mkdir.
+                    fs::remove_file(dir_path)?;
+                    Ok(DirDestination::ReplacedSymlink)
+                }
+            }
+            // An existing real directory (or any other existing non-symlink
+            // entry, matching the prior `.exists()` semantics) is reused.
+            Ok(_) => Ok(DirDestination::Existing),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(DirDestination::Missing),
+            Err(error) => Err(error),
+        }
+    }
+
     /// Creates directories from the file list, applying metadata in parallel.
     ///
     /// Two-phase approach: directory creation is sequential (cheap, respects
@@ -125,9 +182,24 @@ impl ReceiverContext {
             // `relative_path` is only read on Unix (mkdirat fast path).
             #[cfg(not(unix))]
             let _ = relative_path;
-            let is_new = !dir_path.exists();
+            // upstream: generator.c:1356 / 1451-1455 - classify the destination
+            // via lstat (not exists()) so a symlink-to-directory is replaced by
+            // a real directory unless --keep-dirlinks is set, in which case it is
+            // followed. A remove failure is non-fatal (matches upstream
+            // skipping_dir_contents): fall back to the exists() probe.
+            let dir_dest = self.classify_dir_destination(dir_path).unwrap_or_else(|_| {
+                if dir_path.exists() {
+                    DirDestination::Existing
+                } else {
+                    DirDestination::Missing
+                }
+            });
+            let is_new = dir_dest.needs_mkdir();
             dir_was_new.push(is_new);
-            if is_new && existing_only {
+            // upstream: generator.c:1401 - --existing (ignore_non_existing) only
+            // skips a genuinely absent destination (statret == -1); a symlink
+            // being replaced existed, so it is not skipped.
+            if dir_dest == DirDestination::Missing && existing_only {
                 // upstream: generator.c:1374-1378 - "not creating new directory".
                 // Record in the skip set (not `failed_dir_paths`) so the
                 // itemize and metadata passes below skip this directory without
@@ -439,13 +511,29 @@ impl ReceiverContext {
         // parent. Multi-component paths fall back to
         // `fs::create_dir_all`, which preserves the parent-walk for
         // `--relative` shapes.
-        let is_new = !dir_path.exists();
+        // upstream: generator.c:1356 / 1451-1455 - lstat-classify the
+        // destination so a symlink-to-directory is replaced by a real directory
+        // unless --keep-dirlinks follows it. Non-fatal on error: fall back to
+        // the exists() probe (matches upstream's skipping_dir_contents path).
+        let dir_dest = self
+            .classify_dir_destination(&dir_path)
+            .unwrap_or_else(|_| {
+                if dir_path.exists() {
+                    DirDestination::Existing
+                } else {
+                    DirDestination::Missing
+                }
+            });
+        let is_new = dir_dest.needs_mkdir();
         // upstream: generator.c:1368-1383 - with --existing (ignore_non_existing),
         // a directory missing at the destination is never created; the dir is
         // marked skipped (FLAG_MISSING_DIR) so its descendants are skipped too.
         // Marking it failed here drives the same descendant skip via the
         // failed-ancestor check above on subsequent entries.
-        if is_new && self.config.file_selection.existing_only {
+        //
+        // upstream: generator.c:1401 - --existing only skips a genuinely absent
+        // destination; a replaced symlink existed and is not skipped.
+        if dir_dest == DirDestination::Missing && self.config.file_selection.existing_only {
             if self.config.flags.verbose && self.config.connection.client_mode {
                 info_log!(
                     Skip,
@@ -909,6 +997,122 @@ mod touch_up_dirs_tests {
         assert_eq!(
             actual, past,
             "touch_up_dirs must not modify non-directory entries"
+        );
+    }
+
+    #[cfg(unix)]
+    fn config_with_keep_dirlinks(keep: bool) -> ServerConfig {
+        ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-r".to_owned(),
+            flags: ParsedServerFlags {
+                keep_dirlinks: keep,
+                recursive: true,
+                ..ParsedServerFlags::default()
+            },
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        }
+    }
+
+    /// Without `--keep-dirlinks`, a destination symlink standing where the
+    /// source has a directory is a type conflict: upstream deletes it and
+    /// creates a real directory (`generator.c:1451-1455`). The classifier must
+    /// remove the symlink and report that a mkdir is needed.
+    #[cfg(unix)]
+    #[test]
+    fn keep_dirlinks_off_replaces_dest_symlink_to_dir() {
+        use std::os::unix::fs::symlink;
+
+        let dir = test_support::create_tempdir();
+        let target = dir.path().join("target");
+        fs::create_dir(&target).unwrap();
+        let link = dir.path().join("d");
+        symlink(&target, &link).unwrap();
+
+        let hs = handshake();
+        let ctx = ReceiverContext::new_for_test(&hs, config_with_keep_dirlinks(false));
+
+        let decision = ctx
+            .classify_dir_destination(&link)
+            .expect("classify succeeds");
+        assert_eq!(
+            decision,
+            super::DirDestination::ReplacedSymlink,
+            "without -K the conflicting dest symlink must be replaced"
+        );
+        assert!(decision.needs_mkdir(), "a real directory must be created");
+        assert!(
+            fs::symlink_metadata(&link).is_err(),
+            "the conflicting symlink must have been removed"
+        );
+    }
+
+    /// With `--keep-dirlinks`, a destination symlink resolving to a directory is
+    /// followed rather than replaced (`generator.c:1356`): the classifier keeps
+    /// the symlink in place and reports no mkdir is needed.
+    #[cfg(unix)]
+    #[test]
+    fn keep_dirlinks_on_follows_dest_symlink_to_dir() {
+        use std::os::unix::fs::symlink;
+
+        let dir = test_support::create_tempdir();
+        let target = dir.path().join("target");
+        fs::create_dir(&target).unwrap();
+        let link = dir.path().join("d");
+        symlink(&target, &link).unwrap();
+
+        let hs = handshake();
+        let ctx = ReceiverContext::new_for_test(&hs, config_with_keep_dirlinks(true));
+
+        let decision = ctx
+            .classify_dir_destination(&link)
+            .expect("classify succeeds");
+        assert_eq!(
+            decision,
+            super::DirDestination::Existing,
+            "with -K a dest symlink-to-directory is followed, not replaced"
+        );
+        assert!(
+            !decision.needs_mkdir(),
+            "no mkdir when following the symlink"
+        );
+        let md = fs::symlink_metadata(&link).unwrap();
+        assert!(
+            md.file_type().is_symlink(),
+            "the dest symlink must be preserved under -K"
+        );
+    }
+
+    /// A destination symlink that resolves to a non-directory (a file) is a
+    /// type conflict even under `--keep-dirlinks`: `keep_dirlinks` follows only
+    /// symlinks-to-directories, so the symlink is replaced.
+    #[cfg(unix)]
+    #[test]
+    fn keep_dirlinks_on_replaces_symlink_to_non_dir() {
+        use std::os::unix::fs::symlink;
+
+        let dir = test_support::create_tempdir();
+        let target = dir.path().join("target.txt");
+        fs::write(&target, b"file").unwrap();
+        let link = dir.path().join("d");
+        symlink(&target, &link).unwrap();
+
+        let hs = handshake();
+        let ctx = ReceiverContext::new_for_test(&hs, config_with_keep_dirlinks(true));
+
+        let decision = ctx
+            .classify_dir_destination(&link)
+            .expect("classify succeeds");
+        assert_eq!(
+            decision,
+            super::DirDestination::ReplacedSymlink,
+            "-K follows only symlinks-to-directories; a symlink-to-file is replaced"
+        );
+        assert!(
+            fs::symlink_metadata(&link).is_err(),
+            "the symlink-to-file conflict must have been removed"
         );
     }
 }

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -338,36 +338,32 @@ mod create_directory_incremental_tests {
         assert_eq!(failed.count(), 2); // Parent + child marked as failed
     }
 
-    /// UTS-16.b regression: a non-EACCES error from
-    /// `mkdirat_via_sandbox_or_fallback` must propagate to the caller
-    /// instead of being silently coerced to `Ok(None)`.
+    /// A conflicting symlink at a directory-creation target must be replaced
+    /// by a real directory, mirroring upstream `generator.c`.
     ///
-    /// Before the fix, a symlink-swap attack on a subdir leaf would
-    /// surface as an arbitrary errno (EEXIST for a dangling symlink at
-    /// the leaf, ELOOP/ENOTDIR/EOPNOTSUPP for sandbox refusals). The
-    /// receiver dropped those errors on the floor and returned rc=0
-    /// with the directory missing - exactly the silent-skip pattern
-    /// Rule 12 (fail loud) forbids.
+    /// Upstream lstat-classifies the destination with `link_stat(fname,
+    /// &sx.st, keep_dirlinks && is_dir)` (`generator.c:1356`). With
+    /// `--keep-dirlinks` off, a symlink at the target (even a dangling one)
+    /// lstats as `FT_SYMLINK != FT_DIR`, so upstream removes it via
+    /// `delete_item(fname, ..., del_opts | DEL_FOR_DIR)` and then
+    /// `do_mkdir_at()` (`generator.c:1451-1455`). The receiver's
+    /// `classify_dir_destination` reproduces this: it removes the conflicting
+    /// symlink and reports `ReplacedSymlink`, which drives a fresh `mkdir`.
     ///
-    /// This test shapes a dangling-symlink leaf so the underlying
-    /// `mkdirat`/`fs::create_dir` returns `AlreadyExists` (EEXIST), a
-    /// non-EACCES error class. The fix must surface it as `Err`, not
-    /// `Ok(None)`.
+    /// A dangling symlink is used deliberately: `Path::exists` follows it and
+    /// reports "missing", which the old `.exists()` probe mistook for a plain
+    /// new directory and let `mkdir` fail with `EEXIST` on the symlink. The
+    /// lstat-based classifier must instead replace it and create a real
+    /// directory.
     #[cfg(unix)]
     #[test]
-    fn surfaces_non_permission_error_from_mkdir() {
+    fn replaces_conflicting_symlink_with_real_directory() {
         use std::os::unix::fs::symlink;
 
         let temp = TempDir::new().unwrap();
         let dest = temp.path();
 
-        // Plant a dangling symlink at the leaf the receiver intends to
-        // create. `Path::exists` follows the symlink and reports
-        // false (target missing), so the `is_new` guard inside
-        // `create_directory_incremental` will fall through to the
-        // mkdir attempt. `mkdir`/`mkdirat` on an existing symlink
-        // leaf returns EEXIST regardless of whether the target
-        // exists.
+        // Plant a dangling symlink where the incoming directory will land.
         let leaf = dest.join("victim");
         symlink(dest.join("does-not-exist"), &leaf).expect("plant dangling symlink");
 
@@ -390,20 +386,76 @@ mod create_directory_incremental_tests {
             None,
         );
 
-        // Fail loud: the underlying EEXIST must propagate. The
-        // pre-fix behaviour was `Ok(None)` with `mark_failed`, which
-        // hid the failure from the caller's exit-code path.
-        let err = result.expect_err(
-            "non-EACCES mkdir failure must propagate as Err, not be coerced to Ok(None)",
+        // The conflicting symlink is removed and a real directory is created:
+        // upstream reports `FLAG_DIR_CREATED`, so this is a freshly made dir.
+        assert_eq!(
+            result.expect("classifier replaces the symlink and mkdirs a real directory"),
+            Some(true),
+            "a conflicting symlink at a dir target must be replaced, not skipped"
         );
-        // Accept any non-PermissionDenied class. EEXIST is
-        // `AlreadyExists`; on some kernels with sandbox routing the
-        // error class may differ but must never be `PermissionDenied`
-        // (that path is the upstream-parity non-fatal branch).
+        let meta = std::fs::symlink_metadata(&leaf).expect("target must exist");
+        assert!(
+            meta.file_type().is_dir(),
+            "the destination must be a real directory, not the original symlink"
+        );
+        assert_eq!(failed.count(), 0, "replacement is not a failure");
+    }
+
+    /// Fail-loud invariant (Rule 12): a genuine non-EACCES error from the
+    /// underlying `mkdir` must propagate as `Err`, never be coerced to
+    /// `Ok(None)` / `mark_failed`, which would hide it from the caller's
+    /// exit-code path.
+    ///
+    /// EACCES is the only non-fatal `mkdir` class (upstream
+    /// `receiver.c:693-700` folds it into `io_error` and continues); every
+    /// other errno is a hard failure. This shapes an `ENOTDIR` by placing a
+    /// regular file in the middle of the directory path (`afile/sub`, where
+    /// `afile` is a file), so `mkdir` on `afile/sub` fails because a path
+    /// component is not a directory. That error class is neither `NotFound`
+    /// (which would trigger the `create_dir_all` parent-walk) nor
+    /// `PermissionDenied` (the non-fatal branch), so it must surface as `Err`.
+    #[cfg(unix)]
+    #[test]
+    fn surfaces_non_permission_error_from_mkdir() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path();
+
+        // A regular file where a parent directory is expected forces ENOTDIR
+        // when the receiver tries to create `afile/sub` beneath it.
+        std::fs::write(dest.join("afile"), b"not a directory").expect("plant regular file");
+
+        let entry = FileEntry::new_directory("afile/sub".into(), 0o755);
+        let opts = metadata::MetadataOptions::default();
+        let mut failed = FailedDirectories::new();
+
+        let handshake = test_handshake();
+        let config = test_config();
+        let ctx = ReceiverContext::new_for_test(&handshake, config);
+
+        let result = ctx.create_directory_incremental(
+            dest,
+            &entry,
+            &opts,
+            &mut failed,
+            None,
+            None,
+            #[cfg(unix)]
+            None,
+        );
+
+        // Fail loud: the underlying ENOTDIR must propagate. Coercing it to
+        // `Ok(None)` would hide the failure from the caller's exit-code path.
+        let err = result
+            .expect_err("non-EACCES mkdir failure must propagate as Err, not be coerced to Ok");
         assert_ne!(
             err.kind(),
             std::io::ErrorKind::PermissionDenied,
-            "EACCES must take the non-fatal branch; this scenario is shaped to avoid it"
+            "EACCES takes the non-fatal branch; this scenario is shaped to avoid it"
+        );
+        assert_ne!(
+            err.kind(),
+            std::io::ErrorKind::NotFound,
+            "NotFound would trigger the create_dir_all parent-walk, not a hard error"
         );
     }
 

--- a/crates/transfer/tests/copy_dirlinks_flist.rs
+++ b/crates/transfer/tests/copy_dirlinks_flist.rs
@@ -1,0 +1,158 @@
+//! Sender-side `--copy-dirlinks` (`-k`) file-list behaviour.
+//!
+//! With `--copy-dirlinks` the flist generator transmits a symlink whose target
+//! is a directory as a real directory (using `stat`, descending into it),
+//! while a symlink to a non-directory (a file) stays a symlink. This mirrors
+//! upstream `link_stat()` (`flist.c:1362-1370`): `follow_dirlinks` follows only
+//! symlinks-to-directories, unlike `--copy-links` (`-L`), which follows all
+//! symlinks. Without `-k` every symlink is recorded unfollowed.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:1362-1370` - `link_stat()` follows a symlink-to-dir when
+//!   `follow_dirlinks` (set to `copy_dirlinks`) and the target is a directory.
+//! - `options.c:687` / `options.c:2658-2659` - `-k` / compact `k`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use protocol::ProtocolVersion;
+use protocol::flist::FileType;
+use transfer::{
+    GeneratorContext, HandshakeResult, ServerConfig, ServerRole, TransferPhase, TransferPipeline,
+};
+
+/// Builds a recursive sender (generator) config. When `copy_dirlinks` is set
+/// the compact flag string carries the `k` letter parsed into
+/// `flags.copy_dirlinks`. The `.iLsfxCIvu` suffix is the `-e` capability
+/// string (the `L` there is a capability byte, not `--copy-links`).
+fn generator_config(source_root: &Path, copy_dirlinks: bool) -> ServerConfig {
+    let flag_string = if copy_dirlinks {
+        "-rk.iLsfxCIvu".to_owned()
+    } else {
+        "-r.iLsfxCIvu".to_owned()
+    };
+    let mut config = ServerConfig::from_flag_string_and_args(
+        ServerRole::Generator,
+        flag_string,
+        vec![source_root.to_path_buf().into_os_string()],
+    )
+    .expect("server config");
+    config.connection.client_mode = true;
+    assert_eq!(config.flags.copy_dirlinks, copy_dirlinks);
+    // --copy-dirlinks must never imply --copy-links (which follows all links).
+    assert!(!config.flags.copy_links);
+    config
+}
+
+fn test_handshake() -> HandshakeResult {
+    HandshakeResult {
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        buffered: Vec::new(),
+        compat_exchanged: true,
+        client_args: None,
+        io_timeout: None,
+        negotiated_algorithms: None,
+        compat_flags: None,
+        checksum_seed: 0,
+    }
+}
+
+fn test_pipeline() -> TransferPipeline {
+    let mut pipeline = TransferPipeline::new(ServerRole::Generator);
+    pipeline
+        .advance_to(TransferPhase::FilterExchange)
+        .expect("advance to FilterExchange");
+    pipeline
+        .advance_to(TransferPhase::FileListTransfer)
+        .expect("advance to FileListTransfer");
+    pipeline
+}
+
+/// Populates `src` with a real directory, a plain file, a symlink-to-directory
+/// and a symlink-to-file. Returns the `src` path.
+fn build_source_tree(scratch: &TempDir) -> std::path::PathBuf {
+    let src = scratch.path().join("src");
+    let realdir = src.join("realdir");
+    fs::create_dir_all(&realdir).expect("mkdir src/realdir");
+    fs::write(realdir.join("f.txt"), b"payload").expect("write realdir/f.txt");
+    fs::write(src.join("afile"), b"file contents").expect("write afile");
+    symlink("realdir", src.join("dlink")).expect("plant dlink -> realdir");
+    symlink("afile", src.join("flink")).expect("plant flink -> afile");
+    src
+}
+
+/// With `-k`, the symlink-to-directory `dlink` is recorded as a real directory
+/// and its contents are enumerated, while the symlink-to-file `flink` remains a
+/// symlink.
+#[test]
+fn copy_dirlinks_transmits_symlink_to_dir_as_directory() {
+    let scratch = TempDir::new().expect("tempdir");
+    let src = build_source_tree(&scratch);
+
+    let config = generator_config(&src, true);
+    let handshake = test_handshake();
+    let pipeline = test_pipeline();
+    let mut ctx = GeneratorContext::new(&handshake, config, pipeline);
+    ctx.build_file_list(&[src.clone()])
+        .expect("build_file_list");
+
+    let file_list = ctx.file_list();
+    let find = |suffix: &str| file_list.iter().find(|e| e.name().ends_with(suffix));
+
+    let dlink = find("dlink").expect("dlink entry present");
+    assert_eq!(
+        dlink.file_type(),
+        FileType::Directory,
+        "with -k a symlink-to-directory must be transmitted as a real directory"
+    );
+
+    // The followed directory's contents are enumerated beneath it, exactly as
+    // upstream descends into a copy_dirlinks'd directory.
+    assert!(
+        file_list
+            .iter()
+            .any(|e| e.name().contains("dlink") && e.name().ends_with("f.txt")),
+        "the contents of the followed symlink-to-directory must be enumerated: {:?}",
+        file_list.iter().map(|e| e.name()).collect::<Vec<_>>()
+    );
+
+    // A symlink to a plain file is NOT a dirlink and stays a symlink.
+    let flink = find("flink").expect("flink entry present");
+    assert_eq!(
+        flink.file_type(),
+        FileType::Symlink,
+        "with -k a symlink-to-file must remain a symlink (only dirlinks are followed)"
+    );
+}
+
+/// Without `-k`, every symlink is recorded unfollowed - `dlink` stays a
+/// symlink, proving the follow is gated on the flag.
+#[test]
+fn without_copy_dirlinks_symlink_to_dir_stays_symlink() {
+    let scratch = TempDir::new().expect("tempdir");
+    let src = build_source_tree(&scratch);
+
+    let config = generator_config(&src, false);
+    let handshake = test_handshake();
+    let pipeline = test_pipeline();
+    let mut ctx = GeneratorContext::new(&handshake, config, pipeline);
+    ctx.build_file_list(&[src.clone()])
+        .expect("build_file_list");
+
+    let file_list = ctx.file_list();
+    let dlink = file_list
+        .iter()
+        .find(|e| e.name().ends_with("dlink"))
+        .expect("dlink entry present");
+    assert_eq!(
+        dlink.file_type(),
+        FileType::Symlink,
+        "without -k a symlink-to-directory must stay a symlink"
+    );
+}


### PR DESCRIPTION
## Summary

Two symlink dir-link options are brought into line with upstream rsync 3.4.4 (protocol 32). Both touch the sender/receiver symlink-walk paths, so they ship together.

### `--copy-dirlinks` (`-k`) - implemented (was parsed but ignored)
Previously `-k` was accepted but never applied on the SSH/daemon sender path, so a symlink whose target is a directory was transmitted as a symlink. Now, mirroring upstream `link_stat()` (`flist.c:1362-1370`), the flist walker follows a symlink-to-directory (stat, descend) while leaving symlinks-to-files as symlinks - distinct from `--copy-links` (`-L`), which follows all symlinks. The flag is packed into the in-process sender's compact flag string next to `L` so `build_server_config_for_generator` sets it (`flags.rs`). The engine local-copy path already implemented this; this closes the remote-transfer gap.

### `--keep-dirlinks` (`-K`) - receiver behavior fixed
The receiver classified a directory destination with an `exists()` probe, which follows symlinks and so never handled a destination symlink-to-directory per upstream. Destinations are now classified with `lstat`:
- without `-K`: a conflicting destination symlink is removed and a real directory created (`generator.c:1451-1455`);
- with `-K`: the symlink is followed and written through (`generator.c:1356`).

`--existing` skipping is gated on a genuinely absent destination (`generator.c:1401`), so a replaced symlink is not skipped.

The receiver Landlock allowlist is extended with the canonical targets of pre-existing destination symlink-to-directory entries when `-K` is set, so writes through a kept dirlink that resolves outside the transfer root succeed (upstream has no such confinement). Only symlinks present before the transfer are added, preserving the mid-transfer symlink-swap defense.

## Verification

Sealed against real upstream rsync 3.4.4 over SSH and locally, both directions:

**copy_dirlinks** - `dlink -> realdir` becomes a real directory (contents copied), `flink -> afile` stays a symlink; matches upstream for oc->oc, oc->upstream, upstream->oc (ssh + local). Without `-k` the symlink is preserved.

**keep_dirlinks** - dest pre-seeded with a symlink-to-directory where the source has a real directory:
- without `-K`: oc replaces it with a real directory, target left empty - matches upstream.
- with `-K`: oc follows the symlink and writes into the target - matches upstream, including targets outside the transfer root.

## Tests
- `crates/transfer/tests/copy_dirlinks_flist.rs` - flist records a symlink-to-dir as a directory under `-k`, stays a symlink without it, symlink-to-file unaffected.
- `crates/transfer/src/receiver/directory/creation.rs` - classifier replaces vs follows a dest symlink-to-dir per `-K`; symlink-to-file always replaced.
- `crates/cli/src/frontend/server/run.rs` - kept-dirlink target collection (only symlink-to-dir, including nested).

`cargo fmt` clean; `clippy -p cli -p transfer -p core` clean; targeted nextest green on Linux aarch64.