### PR TITLE
fix(transfer): resolve sent uid/gid names to local ids for file ownership

### DIFF
--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::path::Path;
 
 #[cfg(unix)]
-use crate::id_lookup::{map_gid, map_uid};
+use crate::id_lookup::{lookup_group_by_name, lookup_user_by_name, map_gid, map_uid};
 #[cfg(unix)]
 use crate::ownership;
 #[cfg(unix)]
@@ -167,6 +167,82 @@ pub(super) fn gate_preserved_group(group: Option<unix_fs::Gid>) -> Option<unix_f
     // See `gate_preserved_owner`: nix (libc `geteuid`) so fakeroot's faked root
     // euid is honoured, matching upstream's `am_root` gate.
     group.filter(|gid| nix::unistd::geteuid().is_root() || process_in_group(*gid))
+}
+
+/// Resolves the preserved owner of `entry` to a local uid.
+///
+/// `--usermap` is consulted first on the raw sender id (its rules match numeric
+/// ids and names alike, mirroring upstream `recv_add_id`'s uidmap scan). When no
+/// rule matches and `--numeric-ids` is off, the sender-transmitted user name
+/// (INC_RECURSE `XMIT_USER_NAME_FOLLOWS`) is resolved against the receiver's user
+/// database so ownership follows the *name* across hosts with differing id
+/// namespaces, rather than re-deriving the name from the receiver's
+/// `getpwuid(raw)` - which is wrong when the raw sender id is absent or bound to
+/// a different name locally. Without an inline name (local copy) the raw id is
+/// round-tripped through the receiver's database exactly as before.
+// upstream: flist.c:914 recv_user_name / uidlist.c:307 match_uid
+#[cfg(unix)]
+fn resolve_owner_uid(
+    entry: &protocol::flist::FileEntry,
+    options: &MetadataOptions,
+) -> Option<unix_fs::Uid> {
+    entry.uid().and_then(|uid| {
+        let numeric = options.numeric_ids_enabled();
+        let mut base = uid as RawUid;
+        let mut mapped = false;
+        if let Some(mapping) = options.user_mapping()
+            && let Ok(Some(target)) = mapping.map_uid(base, numeric)
+        {
+            base = target;
+            mapped = true;
+        }
+        if !mapped
+            && !numeric
+            && let Some(name) = entry.user_name()
+        {
+            let local = lookup_user_by_name(name.as_bytes())
+                .ok()
+                .flatten()
+                .unwrap_or(base);
+            return Some(ownership::uid_from_raw(local));
+        }
+        map_uid(base, numeric)
+    })
+}
+
+/// Resolves the preserved group of `entry` to a local gid.
+///
+/// The group counterpart of [`resolve_owner_uid`]: `--groupmap` first, then the
+/// sender-transmitted group name (INC_RECURSE `XMIT_GROUP_NAME_FOLLOWS`) resolved
+/// against the receiver's group database.
+// upstream: flist.c:926 recv_group_name / uidlist.c:317 match_gid
+#[cfg(unix)]
+fn resolve_group_gid(
+    entry: &protocol::flist::FileEntry,
+    options: &MetadataOptions,
+) -> Option<unix_fs::Gid> {
+    entry.gid().and_then(|gid| {
+        let numeric = options.numeric_ids_enabled();
+        let mut base = gid as RawGid;
+        let mut mapped = false;
+        if let Some(mapping) = options.group_mapping()
+            && let Ok(Some(target)) = mapping.map_gid(base, numeric)
+        {
+            base = target;
+            mapped = true;
+        }
+        if !mapped
+            && !numeric
+            && let Some(name) = entry.group_name()
+        {
+            let local = lookup_group_by_name(name.as_bytes())
+                .ok()
+                .flatten()
+                .unwrap_or(base);
+            return Some(ownership::gid_from_raw(local));
+        }
+        map_gid(base, numeric)
+    })
 }
 
 /// Resolves the target UID and GID after applying overrides, mappings, and
@@ -401,15 +477,7 @@ pub(super) fn apply_ownership_from_entry(
     let owner = if let Some(uid_override) = options.owner_override() {
         Some(ownership::uid_from_raw(uid_override as RawUid))
     } else if options.owner() {
-        gate_preserved_owner(entry.uid().and_then(|uid| {
-            let mut mapped_uid = uid as RawUid;
-            if let Some(mapping) = options.user_mapping()
-                && let Ok(Some(mapped)) = mapping.map_uid(mapped_uid, options.numeric_ids_enabled())
-            {
-                mapped_uid = mapped;
-            }
-            map_uid(mapped_uid, options.numeric_ids_enabled())
-        }))
+        gate_preserved_owner(resolve_owner_uid(entry, options))
     } else {
         None
     };
@@ -417,15 +485,7 @@ pub(super) fn apply_ownership_from_entry(
     let group = if let Some(gid_override) = options.group_override() {
         Some(ownership::gid_from_raw(gid_override as RawGid))
     } else if options.group() {
-        gate_preserved_group(entry.gid().and_then(|gid| {
-            let mut mapped_gid = gid as RawGid;
-            if let Some(mapping) = options.group_mapping()
-                && let Ok(Some(mapped)) = mapping.map_gid(mapped_gid, options.numeric_ids_enabled())
-            {
-                mapped_gid = mapped;
-            }
-            map_gid(mapped_gid, options.numeric_ids_enabled())
-        }))
+        gate_preserved_group(resolve_group_gid(entry, options))
     } else {
         None
     };
@@ -486,15 +546,7 @@ pub(super) fn apply_symlink_ownership_from_entry(
     let owner = if let Some(uid_override) = options.owner_override() {
         Some(ownership::uid_from_raw(uid_override as RawUid))
     } else if options.owner() {
-        gate_preserved_owner(entry.uid().and_then(|uid| {
-            let mut mapped_uid = uid as RawUid;
-            if let Some(mapping) = options.user_mapping()
-                && let Ok(Some(mapped)) = mapping.map_uid(mapped_uid, options.numeric_ids_enabled())
-            {
-                mapped_uid = mapped;
-            }
-            map_uid(mapped_uid, options.numeric_ids_enabled())
-        }))
+        gate_preserved_owner(resolve_owner_uid(entry, options))
     } else {
         None
     };
@@ -502,15 +554,7 @@ pub(super) fn apply_symlink_ownership_from_entry(
     let group = if let Some(gid_override) = options.group_override() {
         Some(ownership::gid_from_raw(gid_override as RawGid))
     } else if options.group() {
-        gate_preserved_group(entry.gid().and_then(|gid| {
-            let mut mapped_gid = gid as RawGid;
-            if let Some(mapping) = options.group_mapping()
-                && let Ok(Some(mapped)) = mapping.map_gid(mapped_gid, options.numeric_ids_enabled())
-            {
-                mapped_gid = mapped;
-            }
-            map_gid(mapped_gid, options.numeric_ids_enabled())
-        }))
+        gate_preserved_group(resolve_group_gid(entry, options))
     } else {
         None
     };
@@ -771,6 +815,39 @@ mod own_debug_tests {
         assert!(
             own_messages().is_empty(),
             "level-0 must suppress all OWN traces"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolves_inline_owner_name_to_local_id() {
+        // upstream: flist.c:914 recv_user_name - the receiver resolves the
+        // SENDER-transmitted user name to a LOCAL id so ownership follows the
+        // NAME across hosts with differing id namespaces. A raw sender id that
+        // does not exist locally must not leak through as the file owner.
+        use protocol::flist::FileEntry;
+
+        let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
+        entry.set_uid(4_000_123); // no such uid on the receiver
+        entry.set_user_name("root".to_string());
+
+        let opts = MetadataOptions::new()
+            .preserve_owner(true)
+            .numeric_ids(false);
+        assert_eq!(
+            resolve_owner_uid(&entry, &opts).map(|u| u.as_raw()),
+            Some(0),
+            "sent name 'root' must resolve to local uid 0, not the raw sender id"
+        );
+
+        // --numeric-ids keeps the raw sender id (no name resolution).
+        let opts_num = MetadataOptions::new()
+            .preserve_owner(true)
+            .numeric_ids(true);
+        assert_eq!(
+            resolve_owner_uid(&entry, &opts_num).map(|u| u.as_raw()),
+            Some(4_000_123),
+            "--numeric-ids must keep the raw sender id"
         );
     }
 }

--- a/crates/transfer/src/receiver/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/file_list/id_lists.rs
@@ -129,4 +129,57 @@ impl ReceiverContext {
 
         Ok(())
     }
+
+    /// Remaps every file-list entry's uid/gid from the sender's raw ids to the
+    /// local ids resolved from the transmitted name lists.
+    ///
+    /// Mirrors upstream `recv_id_list()`, which rewrites `F_OWNER`/`F_GROUP` for
+    /// every flist entry via `match_uid`/`match_gid` after the name lists are
+    /// read. Without this the receiver would chown files to the raw sender id,
+    /// which is wrong when that id is absent locally or bound to a different
+    /// name than on the sender - the very purpose of the non-numeric name list
+    /// is that ownership follows the *name* across hosts with different id
+    /// namespaces. Ids not present in the sent list keep their raw value,
+    /// matching `match_uid`'s `recv_add_id(..., NULL)` fallback (`--usermap`,
+    /// which upstream folds into `match_uid`, is applied later in
+    /// `metadata::apply`).
+    ///
+    /// Only applied for `numeric_ids == 0` (upstream's `!numeric_ids` gate): an
+    /// explicit or daemon-forced numeric transfer keeps the raw ids. Non-root
+    /// uid remaps are harmless because the chown is gated away in
+    /// `metadata::apply`, matching upstream where a non-root receiver cannot
+    /// chown a file to another owner.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `uidlist.c:483-494` - `recv_id_list()` remap loop
+    pub(crate) fn remap_flist_ownership_from_id_lists(&mut self) {
+        if !self.config.flags.numeric_ids.is_off() {
+            return;
+        }
+        if self.config.flags.owner {
+            let uid_map = self.uid_list.resolved_map();
+            if !uid_map.is_empty() {
+                for entry in self.file_list.iter_mut() {
+                    if let Some(uid) = entry.uid()
+                        && let Some(&local) = uid_map.get(&uid)
+                    {
+                        entry.set_uid(local);
+                    }
+                }
+            }
+        }
+        if self.config.flags.group {
+            let gid_map = self.gid_list.resolved_map();
+            if !gid_map.is_empty() {
+                for entry in self.file_list.iter_mut() {
+                    if let Some(gid) = entry.gid()
+                        && let Some(&local) = gid_map.get(&gid)
+                    {
+                        entry.set_gid(local);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -74,6 +74,9 @@ impl ReceiverContext {
 
         if !inc_recurse {
             self.receive_id_lists(reader)?;
+            // upstream: uidlist.c:483-494 recv_id_list() remaps the whole flist
+            // from sender ids to local ids right after reading the name lists.
+            self.remap_flist_ownership_from_id_lists();
         }
 
         // upstream: flist.c:2738-2742 - read io_error flag for protocol < 30.

--- a/crates/transfer/src/receiver/tests/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/tests/file_list/id_lists.rs
@@ -117,3 +117,72 @@ fn receive_id_lists_skips_both_when_neither_flag_set() {
     assert!(result.is_ok());
     assert_eq!(cursor.position(), 0);
 }
+
+/// Pins the upstream `recv_id_list()` remap: after reading the name list the
+/// receiver rewrites every flist entry's uid from the sender's raw id to the
+/// LOCAL id resolved from the transmitted name. A sender id that does not exist
+/// on the receiver (but whose name does) must end up owned by the local id, not
+/// the raw sender id - the whole point of the non-numeric name list.
+///
+/// upstream: uidlist.c:483-494 `recv_id_list` remap loop via `match_uid`.
+#[test]
+#[cfg(unix)]
+fn remap_rewrites_flist_uid_from_sent_name() {
+    use protocol::flist::FileEntry;
+    use protocol::idlist::IdList;
+
+    let handshake = test_handshake();
+    // owner only (uid list), non-numeric so the name list is read + applied.
+    let config = config_with_flags(true, false, NumericIds::Off);
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    let proto = ctx.protocol().as_u8();
+
+    // Sender-built uid list: a raw sender uid that does not exist locally,
+    // carrying the well-known name "root" (which resolves to 0 everywhere).
+    let mut sender = IdList::new();
+    sender.add_id(4_000_123, Some(b"root".to_vec()));
+    let mut wire = Vec::new();
+    sender
+        .write(&mut wire, false, proto)
+        .expect("write uid list");
+
+    let mut cursor = Cursor::new(wire);
+    ctx.receive_id_lists(&mut cursor).expect("read uid list");
+
+    // A file owned by the nonexistent sender uid.
+    let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
+    entry.set_uid(4_000_123);
+    ctx.file_list.push(entry);
+
+    ctx.remap_flist_ownership_from_id_lists();
+
+    assert_eq!(
+        ctx.file_list[0].uid(),
+        Some(0),
+        "receiver must resolve sent name 'root' to local uid 0, not keep the raw sender id"
+    );
+}
+
+/// `--numeric-ids` (explicit) must leave file ownership as the raw sender id:
+/// no name list is read and the remap is a no-op.
+#[test]
+#[cfg(unix)]
+fn remap_keeps_raw_uid_under_numeric_ids() {
+    use protocol::flist::FileEntry;
+
+    let handshake = test_handshake();
+    let config = config_with_flags(true, false, NumericIds::Explicit);
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
+    entry.set_uid(4_000_123);
+    ctx.file_list.push(entry);
+
+    ctx.remap_flist_ownership_from_id_lists();
+
+    assert_eq!(
+        ctx.file_list[0].uid(),
+        Some(4_000_123),
+        "--numeric-ids must keep the raw sender id"
+    );
+}


### PR DESCRIPTION
## Problem

With default (non-numeric) ownership preservation, the sender transmits a uid/gid name list so the receiver can resolve each **name** against its own user database. This is what lets ownership follow the name across two machines whose user databases assign different numeric ids to the same account (upstream `recv_id_list`, `uidlist.c`).

The receiver did not do this for file ownership. The received name list was applied only to ACL entries; the file-ownership path re-derived the name from the receiver's `getpwuid(raw_sender_id)` instead of using the name the sender transmitted. When the raw sender id was absent on the receiver, or bound to a different name there, files were chowned to the **raw sender id** rather than the local id for the transmitted name.

## Reproduction

Two mount namespaces give sender and receiver different `/etc/passwd` views (`xfer` = uid 6001 on the sender, uid 6002 on the receiver; 6001 has no name on the receiver). A file owned by 6001 is transferred; the sender transmits name `xfer`.

| receiver | dest owner | correct? |
|----------|-----------|----------|
| upstream rsync 3.4.4 | 6002 (name-resolved) | yes |
| before this change | 6001 (raw sender id) | no |
| after this change | 6002 (name-resolved) | yes |

Verified for both incremental-recursion (inline per-entry names) and non-incremental (batch name list) transfers. `--numeric-ids` keeps the raw id (6001) on both, and same-database transfers are unchanged.

## Fix

Mirror upstream by remapping every file-list entry's uid/gid to the local id resolved from the transmitted name:

- **Receiver batch path**: after reading the uid/gid name lists, rewrite the flist uid/gid via the resolved remote to local map, gated on `numeric_ids == 0` (`uidlist.c:483-494 recv_id_list`).
- **Metadata apply path**: when an inline per-entry name is present (`XMIT_USER_NAME_FOLLOWS`, incremental recursion), resolve that name to the local id instead of `getpwuid(raw)` (`flist.c:914 recv_user_name`).

`--numeric-ids` still sends/uses raw ids; `--usermap`/`--groupmap` behavior is unchanged (applied on top, as before); a non-root receiver cannot chown so the remap is a no-op there, matching upstream.

## Tests

- `metadata`: pins that an inline sender name resolves to the local id (and that `--numeric-ids` keeps the raw id).
- `transfer`: pins that the batch name-list remap rewrites the flist uid to the local id, and that `--numeric-ids` leaves it raw.
- Existing ownership/id-list tests unchanged and passing.
