### PR TITLE
fix(transfer): match upstream sparse hole granularity and punch order

### DIFF
--- a/crates/engine/src/local_copy/executor/file/sparse/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/mod.rs
@@ -149,15 +149,17 @@ impl SparseRegion {
     }
 }
 
-/// Threshold for detecting sparse (all-zeros) regions during file writes.
+/// Scan window for sparse zero-run detection during file writes.
 ///
-/// A run of zeros at least this size will be converted to a sparse hole
-/// using fallocate(PUNCH_HOLE) or seek past on supported systems.
+/// Upstream `write_file()` hands `write_sparse()` at most this many bytes per
+/// call (`fileio.c:156`, `int len1 = MIN(len, SPARSE_WRITE_SIZE)`), so only the
+/// leading and trailing zeros of each 1 KB window become holes. Matching the
+/// window is required for allocated-block parity with upstream: a larger window
+/// writes sub-window interior zero runs as literal data, leaving them allocated
+/// where upstream deallocates them.
 ///
-/// Matches upstream rsync's CHUNK_SIZE (32KB) for consistent behavior.
-/// Using a larger threshold reduces syscall overhead for small zero runs
-/// while still efficiently handling large sparse regions.
-const SPARSE_WRITE_SIZE: usize = 32 * 1024;
+/// Matches upstream rsync's `SPARSE_WRITE_SIZE` (1024) in `rsync.h`.
+const SPARSE_WRITE_SIZE: usize = 1024;
 
 /// Buffer size for writing zeros when fallocate is not supported.
 /// Matches upstream rsync's do_punch_hole fallback buffer size.

--- a/crates/engine/src/local_copy/executor/file/sparse/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/tests.rs
@@ -2914,3 +2914,37 @@ fn sparse_writer_inner_access() {
 fn zero_scan_strategy_default_is_simd() {
     assert_eq!(ZeroScanStrategy::default(), ZeroScanStrategy::Simd);
 }
+
+#[test]
+fn sparse_write_size_matches_upstream_1k_window() {
+    // Upstream feeds write_sparse() in SPARSE_WRITE_SIZE (1024) pieces
+    // (fileio.c:156). The scan window must match so interior zero runs are
+    // punched at the same granularity as upstream. upstream: rsync.h SPARSE_WRITE_SIZE.
+    assert_eq!(super::SPARSE_WRITE_SIZE, 1024);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn sub_window_interior_zero_run_is_punched() {
+    // A 4 KB..8 KB..4 KB layout has an 8 KB interior zero run smaller than the
+    // former 32 KB scan window. With the upstream 1 KB window the interior run
+    // is seeked over and left unallocated; the old 32 KB window wrote it as
+    // literal data, allocating the blocks upstream deallocates (issue #257).
+    use std::os::unix::fs::MetadataExt;
+    let tmp = NamedTempFile::new().expect("tempfile");
+    let mut file = tmp.reopen().expect("reopen");
+    let mut state = SparseWriteState::default();
+    let mut data = vec![0xAAu8; 4096];
+    data.extend(std::iter::repeat_n(0u8, 8192));
+    data.extend(std::iter::repeat_n(0xBBu8, 4096));
+    write_sparse_chunk(&mut file, &mut state, &data, tmp.path()).expect("write");
+    let end = state.finish(&mut file, tmp.path()).expect("finish");
+    file.set_len(end).expect("set_len");
+    let meta = fs::metadata(tmp.path()).expect("metadata");
+    assert_eq!(meta.len(), 16384, "apparent size unchanged");
+    assert!(
+        meta.blocks() * 512 < 16384,
+        "interior 8 KB hole must be unallocated, got {} bytes",
+        meta.blocks() * 512
+    );
+}

--- a/crates/engine/src/local_copy/executor/file/sparse/writer.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/writer.rs
@@ -88,13 +88,14 @@ pub struct SparseWriter<W> {
     stats: SparseWriteStats,
 }
 
-/// Default chunk size for sparse scanning, matching upstream rsync's CHUNK_SIZE.
+/// Default scan window for sparse detection, matching upstream rsync's
+/// `SPARSE_WRITE_SIZE` (1 KB) so interior zero runs are punched as upstream does.
 const DEFAULT_CHUNK_SIZE: usize = super::SPARSE_WRITE_SIZE;
 
 impl<W: Write + Seek> SparseWriter<W> {
     /// Creates a new sparse writer wrapping the given writer.
     ///
-    /// Uses SIMD-accelerated zero detection and the default chunk size (32 KB).
+    /// Uses SIMD-accelerated zero detection and the default scan window (1 KB).
     #[must_use]
     pub fn new(inner: W) -> Self {
         Self {

--- a/crates/transfer/src/constants.rs
+++ b/crates/transfer/src/constants.rs
@@ -17,6 +17,18 @@
 /// Matches upstream `CHUNK_SIZE` (32 * 1024).
 pub const CHUNK_SIZE: usize = 32 * 1024;
 
+/// Scan window for sparse zero-run detection during file writes.
+///
+/// Upstream `write_file()` feeds `write_sparse()` in pieces of at most this
+/// size (`fileio.c:156`, `int len1 = MIN(len, SPARSE_WRITE_SIZE)`), so only
+/// leading/trailing zeros of each 1 KB window are turned into holes. Matching
+/// this window is required for oc's punched holes to line up with upstream:
+/// a larger window writes sub-window interior zero runs as literal data,
+/// leaving them allocated where upstream would deallocate them.
+///
+/// Matches upstream `SPARSE_WRITE_SIZE` (1024) in `rsync.h`.
+pub const SPARSE_WRITE_SIZE: usize = 1024;
+
 /// Maximum size of the memory-mapped file window.
 ///
 /// When reading basis files for delta application, data is cached in a
@@ -155,6 +167,7 @@ mod tests {
     #[test]
     fn constants_match_upstream() {
         assert_eq!(CHUNK_SIZE, 32 * 1024);
+        assert_eq!(SPARSE_WRITE_SIZE, 1024);
         assert_eq!(MAX_MAP_SIZE, 256 * 1024);
         assert_eq!(IO_BUFFER_SIZE, 32 * 1024);
         assert_eq!(ALIGN_BOUNDARY, 1024);

--- a/crates/transfer/src/delta_apply/sparse.rs
+++ b/crates/transfer/src/delta_apply/sparse.rs
@@ -4,7 +4,7 @@
 
 use std::io::{self, Seek, SeekFrom, Write};
 
-use crate::constants::{CHUNK_SIZE, leading_zero_count, trailing_zero_count};
+use crate::constants::{SPARSE_WRITE_SIZE, leading_zero_count, trailing_zero_count};
 
 /// Tracks pending runs of zeros so they become holes in the output file rather
 /// than being written as data.
@@ -102,7 +102,9 @@ impl SparseWriteState {
     /// Writes data with sparse optimization.
     ///
     /// Zero runs are tracked and become holes; non-zero data is written normally.
-    /// Uses 32KB chunks matching upstream rsync's CHUNK_SIZE for efficient processing.
+    /// Scans in `SPARSE_WRITE_SIZE` (1 KB) windows matching upstream rsync's
+    /// `write_file()` piece size so interior zero runs are punched exactly as
+    /// upstream does, not written as literal data.
     #[inline]
     pub fn write<W: Write + Seek>(&mut self, writer: &mut W, data: &[u8]) -> io::Result<usize> {
         if data.is_empty() {
@@ -112,7 +114,7 @@ impl SparseWriteState {
         let mut offset = 0;
 
         while offset < data.len() {
-            let end = (offset + CHUNK_SIZE).min(data.len());
+            let end = (offset + SPARSE_WRITE_SIZE).min(data.len());
             let chunk = &data[offset..end];
 
             let leading_zeros = leading_zero_count(chunk);
@@ -158,7 +160,7 @@ impl SparseWriteState {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
+    use std::io::{self, Cursor, Seek, SeekFrom, Write};
 
     use super::*;
 
@@ -265,7 +267,7 @@ mod tests {
         // by a following data write) starting inside the preallocated basis
         // extent is recorded for punching, so an --inplace update deallocates
         // stale basis blocks instead of leaving them on disk. The run is fed as
-        // a distinct write, mirroring receive_data streaming CHUNK_SIZE pieces;
+        // a distinct write, mirroring receive_data streaming SPARSE_WRITE_SIZE pieces;
         // interior zeros within one write are written literally (as upstream)
         // and correctly overwrite the basis, so only seeked runs are punched.
         // upstream: fileio.c:90-99 write_sparse().
@@ -277,6 +279,61 @@ mod tests {
         state.write(&mut cursor, &[9u8; 10]).unwrap(); // data forces the flush
         let holes = state.take_holes();
         assert_eq!(holes, vec![(100, 300)], "in-basis run recorded for punch");
+    }
+
+    /// A writer that records how many bytes are written versus seeked over, so a
+    /// test can prove interior zero runs became holes instead of literal data.
+    struct CountingWriter {
+        inner: Cursor<Vec<u8>>,
+        written: u64,
+        seeked: u64,
+    }
+
+    impl Write for CountingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.written += buf.len() as u64;
+            self.inner.write(buf)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            self.inner.flush()
+        }
+    }
+
+    impl Seek for CountingWriter {
+        fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+            if let SeekFrom::Current(delta) = pos {
+                self.seeked += delta.unsigned_abs();
+            }
+            self.inner.seek(pos)
+        }
+    }
+
+    #[test]
+    fn sub_window_interior_zero_run_becomes_hole_not_literal() {
+        // A 4 KB..8 KB..4 KB layout has an 8 KB interior zero run that is smaller
+        // than the old 32 KB scan window. Upstream `write_file()` scans in
+        // SPARSE_WRITE_SIZE (1 KB) pieces, so the interior run is seeked over
+        // (punched) rather than written as literal data. With a 32 KB window the
+        // whole 16 KB fell in one window and the interior zeros were written
+        // literally, leaving them allocated on disk (issue #257). The write pass
+        // must therefore write only the 8 KB of real data and seek the 8 KB hole.
+        // upstream: fileio.c:149 write_file() -> MIN(len, SPARSE_WRITE_SIZE).
+        let mut state = SparseWriteState::new();
+        let mut w = CountingWriter {
+            inner: Cursor::new(Vec::new()),
+            written: 0,
+            seeked: 0,
+        };
+        let mut data = vec![0xAAu8; 4096];
+        data.extend(std::iter::repeat_n(0u8, 8192));
+        data.extend(std::iter::repeat_n(0xBBu8, 4096));
+        state.write(&mut w, &data).unwrap();
+        state.finish(&mut w).unwrap();
+        assert_eq!(w.written, 8192, "only the two 4 KB data blocks are written");
+        assert_eq!(
+            w.seeked, 8192,
+            "the 8 KB interior zero run is seeked (hole)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Upstream `write_file()` hands `write_sparse()` at most `SPARSE_WRITE_SIZE`
(1024) bytes per call (`fileio.c:156`, `int len1 = MIN(len, SPARSE_WRITE_SIZE)`),
so only the leading and trailing zeros of each 1 KB window become holes. Our
sparse writers scanned in 32 KB windows and wrote interior zero runs smaller
than the window as literal data, leaving them allocated on disk where upstream
punches them out. Content and logical size were always correct; only the
allocated block count diverged.

This aligns the scan window to upstream's 1 KB in both write paths: the
receiver delta-apply writer (`transfer`) and the local-copy executor (`engine`).

## Verification (rsync 3.4.4 as receiver, aarch64/ext4, `du` allocated bytes)

Before -> after, versus upstream, same sha256 and apparent size throughout:

| fixture | path | oc before | oc after | upstream |
|---|---|---|---|---|
| 4 KB + 20 KB hole + 4 KB | local | 28672 | 8192 | 8192 |
| 4 KB + 20 KB hole + 4 KB | ssh | 28672 | 8192 | 8192 |
| 16x (8 KB data + 8 KB hole) | local | 196608 | 131072 | 131072 |
| 16x (8 KB data + 8 KB hole) | ssh | 196608 | 131072 | 131072 |
| 256 KB + 1 MB trailing hole | both | 262144 | 262144 | 262144 |
| `--inplace` over preallocated basis | local | 65536 | 65536 | 65536 |
| non-sparse (regression) | local | 28672 | 28672 | 28672 |

Trailing holes, `--inplace` over a preallocated basis, and non-sparse
transfers were already correct and are unchanged. After the fix oc matches
upstream block-for-block on every fixture.

## Tests

- `transfer`: `sub_window_interior_zero_run_becomes_hole_not_literal` proves an
  8 KB interior run is seeked (hole), not written, and pins the 1 KB window.
- `engine`: `sub_window_interior_zero_run_is_punched` (Linux) asserts the
  interior hole is unallocated; `sparse_write_size_matches_upstream_1k_window`
  pins the constant.
- `cargo clippy -p transfer -p engine --all-features -D warnings` clean; fmt clean.
