### PR TITLE
fix(engine): back up device/fifo/socket special files via mknod (--backup)

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -38,7 +38,8 @@ use super::{
     filter_program_local_error, follow_symlink_metadata, load_dir_merge_rules_recursive,
     map_metadata_error, record_directory_subtree, remove_source_entry_if_requested,
     resolve_dir_merge_path, should_skip_copy, symlink_target_is_safe, trace_make_backup_copy,
-    trace_make_backup_rename, trace_make_backup_symlink, write_sparse_chunk,
+    trace_make_backup_device, trace_make_backup_rename, trace_make_backup_symlink,
+    write_sparse_chunk,
 };
 use crate::delta::DeltaSignatureIndex;
 use crate::signature::SignatureBlock;
@@ -473,14 +474,16 @@ pub(crate) enum CreatedEntryKind {
 /// Strategy used to place an existing destination into the backup
 /// location. Mirrors upstream rsync's `make_backup` success branches
 /// (RENAME / COPY / SYMLINK / DEVICE / HLINK) for `--debug=BACKUP`
-/// reporting; oc-rsync's local-copy executor exercises only RENAME,
-/// COPY (cross-device fallback for regular files), and SYMLINK
-/// (cross-device fallback for symlinks).
+/// reporting; oc-rsync's local-copy executor exercises RENAME, COPY
+/// (cross-device fallback for regular files), SYMLINK (cross-device
+/// fallback for symlinks), and DEVICE (cross-device fallback for
+/// device/FIFO/socket nodes, recreated via mknod).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum BackupStrategy {
     Rename,
     Copy,
     Symlink,
+    Device,
 }
 
 include!("context_impl/state.rs");

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -925,17 +925,51 @@ impl<'a> CopyContext<'a> {
                         return Ok(());
                     }
                 }
-                copy_entry_to_backup(destination, &backup_path, file_type)?;
-                if file_type.is_symlink() {
-                    BackupStrategy::Symlink
-                } else {
-                    BackupStrategy::Copy
+                match copy_entry_to_backup(
+                    destination,
+                    &backup_path,
+                    file_type,
+                    self.options.devices_enabled(),
+                    self.options.specials_enabled(),
+                    self.options.fake_super_enabled(),
+                )? {
+                    Some(strategy) => strategy,
+                    // upstream: backup.c:306-317 - a non-regular file that is
+                    // neither backed up as a device/special (gates off) nor a
+                    // symlink is skipped; make_backup returns 3 and leaves no
+                    // backup, so emit no trace and no "backed up" notice.
+                    None => return Ok(()),
                 }
             }
             Err(error) => {
                 return Err(LocalCopyError::io("create backup", backup_path, error));
             }
         };
+
+        // upstream: backup.c:338-341 - set_file_attrs(buf, file, NULL, fname,
+        // ATTRS_ACCURATE_TIME) copies the source node's mode/owner/times onto
+        // the freshly-created backup node (with preserve_xattrs temporarily
+        // cleared), overriding the umask that mknod applied. Only the
+        // cross-device device/special copy fallback needs this: rename carries
+        // the inode's attributes verbatim, and the regular-file copy path
+        // mirrors upstream's own COPY handling.
+        if strategy == BackupStrategy::Device
+            && let Ok(source_meta) = fs::symlink_metadata(destination)
+        {
+            let metadata_options = self.metadata_options();
+            apply_file_metadata_with_options(&backup_path, &source_meta, &metadata_options)
+                .map_err(map_metadata_error)?;
+            // upstream: xattrs.c:set_stat_xattr() re-records the source stat in
+            // `user.rsync.%stat` under --fake-super so the virtualised node's
+            // mode/owner/rdev survive; no-op when fake-super is off.
+            #[cfg(all(unix, feature = "xattr"))]
+            store_effective_fake_super_if_requested(
+                &metadata_options,
+                destination,
+                &backup_path,
+                &source_meta,
+            )?;
+        }
 
         // upstream: backup.c:201-202,216-217,299-300,333-334 - DEBUG_GTE(BACKUP, 1)
         // emits one of HLINK/RENAME/SYMLINK/COPY per success path. oc-rsync's
@@ -946,6 +980,7 @@ impl<'a> CopyContext<'a> {
             BackupStrategy::Rename => trace_make_backup_rename(&destination_display),
             BackupStrategy::Copy => trace_make_backup_copy(&destination_display),
             BackupStrategy::Symlink => trace_make_backup_symlink(&destination_display),
+            BackupStrategy::Device => trace_make_backup_device(&destination_display),
         }
 
         // upstream: backup.c:353 - rprintf(FINFO, "backed up %s to %s\n", fname, buf)

--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -10,7 +10,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::local_copy::LocalCopyError;
+use crate::local_copy::context::BackupStrategy;
 use crate::local_copy::create_symlink;
+#[cfg(unix)]
+use crate::local_copy::map_metadata_error;
 
 /// Computes the backup file path for a destination file.
 ///
@@ -74,23 +77,109 @@ pub fn compute_backup_path(
     base
 }
 
-/// Copies a file or recreates a symlink at the backup path.
-// upstream: backup.c:make_backup() - backup creation
+/// Copies a regular file, recreates a symlink, or re-materialises a
+/// device/FIFO/socket node at the backup path.
+///
+/// Returns the [`BackupStrategy`] that placed the backup, or `None` when the
+/// entry is a non-regular file that upstream declines to back up (mirrors
+/// `backup.c:306-317`, where `make_backup` returns 3 and leaves no backup:
+/// a device without `am_root && --devices`, or a special without
+/// `--specials`).
+// upstream: backup.c:make_backup() - copy-tree fallback (COPY / SYMLINK /
+// DEVICE branches). Device and special nodes are recreated via do_mknod_at
+// (backup.c:278-285), gated on am_root+preserve_devices / preserve_specials.
 pub(crate) fn copy_entry_to_backup(
     source: &Path,
     backup_path: &Path,
     file_type: fs::FileType,
-) -> Result<(), LocalCopyError> {
+    devices_enabled: bool,
+    specials_enabled: bool,
+    fake_super: bool,
+) -> Result<Option<BackupStrategy>, LocalCopyError> {
     if file_type.is_file() {
         fs::copy(source, backup_path)
             .map_err(|error| LocalCopyError::io("create backup", backup_path, error))?;
-    } else if file_type.is_symlink() {
+        return Ok(Some(BackupStrategy::Copy));
+    }
+    if file_type.is_symlink() {
         let target = fs::read_link(source)
             .map_err(|error| LocalCopyError::io("read symbolic link", source, error))?;
         create_symlink(&target, source, backup_path)
             .map_err(|error| LocalCopyError::io("create symbolic link", backup_path, error))?;
+        return Ok(Some(BackupStrategy::Symlink));
     }
-    Ok(())
+    #[cfg(unix)]
+    {
+        copy_special_to_backup(
+            source,
+            backup_path,
+            devices_enabled,
+            specials_enabled,
+            fake_super,
+        )
+    }
+    #[cfg(not(unix))]
+    {
+        // Native Windows has no device/FIFO/socket nodes to back up; upstream's
+        // do_mknod path is Unix-only, so there is nothing to recreate here.
+        let _ = (
+            source,
+            backup_path,
+            devices_enabled,
+            specials_enabled,
+            fake_super,
+        );
+        Ok(None)
+    }
+}
+
+/// Re-materialises a device, FIFO, or socket node at `backup_path` from the
+/// existing destination node at `source`, mirroring upstream
+/// `backup.c:278-285`.
+///
+/// Returns `Some(BackupStrategy::Device)` once the node is recreated (upstream
+/// emits `make_backup: DEVICE` for both devices and specials), or `None` when
+/// the preserve gates decline it (upstream `make_backup` returns 3 without
+/// placing a backup). Under `--fake-super` the node is virtualised as a `0600`
+/// placeholder carrying the `%stat` xattr, matching `syscall.c:do_mknod()`'s
+/// `am_root < 0` branch.
+// upstream: backup.c:278 - `(am_root && preserve_devices && IS_DEVICE(mode))
+// || (preserve_specials && IS_SPECIAL(mode))` gates `do_mknod_at`. am_root is
+// non-zero for real root, --super, and --fake-super (options.c:90).
+#[cfg(unix)]
+fn copy_special_to_backup(
+    source: &Path,
+    backup_path: &Path,
+    devices_enabled: bool,
+    specials_enabled: bool,
+    fake_super: bool,
+) -> Result<Option<BackupStrategy>, LocalCopyError> {
+    use std::os::unix::fs::FileTypeExt;
+
+    let source_meta = fs::symlink_metadata(source)
+        .map_err(|error| LocalCopyError::io("stat backup source", source, error))?;
+    let source_type = source_meta.file_type();
+    let is_device = source_type.is_char_device() || source_type.is_block_device();
+
+    let should_backup = if is_device {
+        (::metadata::am_root() || fake_super) && devices_enabled
+    } else if source_type.is_fifo() || source_type.is_socket() {
+        specials_enabled
+    } else {
+        false
+    };
+    if !should_backup {
+        return Ok(None);
+    }
+
+    if is_device {
+        ::metadata::create_device_node_with_fake_super(backup_path, &source_meta, fake_super)
+            .map_err(map_metadata_error)?;
+    } else {
+        ::metadata::create_fifo_with_fake_super(backup_path, &source_meta, fake_super)
+            .map_err(map_metadata_error)?;
+    }
+    Ok(Some(BackupStrategy::Device))
 }
 
 #[cfg(test)]

--- a/crates/engine/src/local_copy/tests/executor_file_operations.rs
+++ b/crates/engine/src/local_copy/tests/executor_file_operations.rs
@@ -103,7 +103,7 @@ mod file_operations_tests {
         fs::write(&source, b"original content").expect("write");
 
         let metadata = fs::metadata(&source).expect("metadata");
-        let result = copy_entry_to_backup(&source, &backup, metadata.file_type());
+        let result = copy_entry_to_backup(&source, &backup, metadata.file_type(), true, true, false);
 
         assert!(result.is_ok());
         assert!(backup.exists());
@@ -128,7 +128,7 @@ mod file_operations_tests {
         std::os::windows::fs::symlink_file(&target, &symlink).expect("symlink");
 
         let metadata = fs::symlink_metadata(&symlink).expect("metadata");
-        let result = copy_entry_to_backup(&symlink, &backup, metadata.file_type());
+        let result = copy_entry_to_backup(&symlink, &backup, metadata.file_type(), true, true, false);
 
         assert!(result.is_ok());
         assert!(backup.exists());
@@ -148,10 +148,58 @@ mod file_operations_tests {
         fs::write(source_dir.join("file.txt"), b"content").expect("write");
 
         let metadata = fs::metadata(&source_dir).expect("metadata");
-        let result = copy_entry_to_backup(&source_dir, &backup, metadata.file_type());
+        let result =
+            copy_entry_to_backup(&source_dir, &backup, metadata.file_type(), true, true, false);
 
         // Should succeed but not copy directory
         assert!(result.is_ok());
+        assert!(!backup.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_entry_to_backup_fifo_recreates_node() {
+        use crate::local_copy::context::BackupStrategy;
+        use std::os::unix::fs::FileTypeExt;
+
+        let temp = tempdir().expect("tempdir");
+        let fifo = temp.path().join("pipe");
+        let backup = temp.path().join("pipe.bak");
+        mkfifo_for_tests(&fifo, 0o644).expect("mkfifo");
+
+        let metadata = fs::symlink_metadata(&fifo).expect("metadata");
+        assert!(metadata.file_type().is_fifo());
+
+        // --specials must recreate the node at the backup location rather than
+        // silently dropping it (the cross-device copy fallback previously did
+        // nothing for non-regular files). upstream: backup.c:279-285 do_mknod_at.
+        let result = copy_entry_to_backup(&fifo, &backup, metadata.file_type(), false, true, false)
+            .expect("backup");
+        assert_eq!(result, Some(BackupStrategy::Device));
+
+        let backup_meta = fs::symlink_metadata(&backup).expect("backup metadata");
+        assert!(backup_meta.file_type().is_fifo());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_entry_to_backup_special_skipped_without_specials() {
+        use std::os::unix::fs::FileTypeExt;
+
+        let temp = tempdir().expect("tempdir");
+        let fifo = temp.path().join("pipe");
+        let backup = temp.path().join("pipe.bak");
+        mkfifo_for_tests(&fifo, 0o644).expect("mkfifo");
+
+        let metadata = fs::symlink_metadata(&fifo).expect("metadata");
+        assert!(metadata.file_type().is_fifo());
+
+        // Without --specials upstream make_backup returns 3 and places no
+        // backup (backup.c:306-317); copy_entry_to_backup reports None so the
+        // caller emits neither a trace nor a "backed up" notice.
+        let result = copy_entry_to_backup(&fifo, &backup, metadata.file_type(), true, false, false)
+            .expect("backup");
+        assert_eq!(result, None);
         assert!(!backup.exists());
     }
 
@@ -192,7 +240,7 @@ mod file_operations_tests {
         fs::write(&dummy_file, b"dummy").expect("write");
         let metadata = fs::metadata(&dummy_file).expect("metadata");
 
-        let result = copy_entry_to_backup(&source, &backup, metadata.file_type());
+        let result = copy_entry_to_backup(&source, &backup, metadata.file_type(), true, true, false);
 
         // Should fail because source doesn't exist
         assert!(result.is_err());
@@ -208,7 +256,7 @@ mod file_operations_tests {
         let backup = Path::new("/nonexistent/impossible/backup.txt");
 
         let metadata = fs::metadata(&source).expect("metadata");
-        let result = copy_entry_to_backup(&source, backup, metadata.file_type());
+        let result = copy_entry_to_backup(&source, backup, metadata.file_type(), true, true, false);
 
         // Should fail because backup location is invalid
         assert!(result.is_err());
@@ -296,7 +344,7 @@ mod file_operations_tests {
         fs::write(&backup, b"old backup").expect("write old backup");
 
         let metadata = fs::metadata(&source).expect("metadata");
-        let result = copy_entry_to_backup(&source, &backup, metadata.file_type());
+        let result = copy_entry_to_backup(&source, &backup, metadata.file_type(), true, true, false);
 
         assert!(result.is_ok());
         assert_eq!(
@@ -319,7 +367,7 @@ mod file_operations_tests {
         std::os::windows::fs::symlink_file(&target, &symlink).expect("symlink");
 
         let metadata = fs::symlink_metadata(&symlink).expect("metadata");
-        let result = copy_entry_to_backup(&symlink, &backup, metadata.file_type());
+        let result = copy_entry_to_backup(&symlink, &backup, metadata.file_type(), true, true, false);
 
         assert!(result.is_ok());
 


### PR DESCRIPTION
## Problem

The local-copy `--backup` path silently loses device, FIFO, and socket
nodes when the backup falls back to a cross-filesystem copy.

`make_backup` first tries to rename the existing destination to the backup
location. When the backup target is on a different filesystem (for example
`--backup-dir` pointing at another mount), the rename fails with `EXDEV` and
the code falls back to `copy_entry_to_backup()`. That fallback handled only
regular files (`fs::copy`) and symlinks; a device, FIFO, or socket node hit
neither branch and was dropped without a `mknod`. Worse, the transfer still
reported the backup as placed and exited `0`, so the special file's backup
was lost with no diagnostic.

Verified against upstream rsync 3.4.4: replacing (or deleting under
`--delete`) a char/block device in the destination with `--backup
--backup-dir` on a separate filesystem recreates the device in the
backup-dir upstream, whereas the previous behaviour left the backup-dir
empty.

## Fix

`copy_entry_to_backup()` now re-materialises device/FIFO/socket nodes at the
backup location, mirroring upstream `backup.c:278-285`
(`do_mknod_at` for `IS_DEVICE`/`IS_SPECIAL`):

- Device nodes are recreated when `am_root` (real root, `--super`, or
  `--fake-super`) and `--devices` are in effect.
- FIFO/socket nodes are recreated when `--specials` is in effect.
- The source node's mode/owner/times are then applied to the backup so the
  `mknod` umask is overridden, matching upstream's `set_file_attrs(...,
  ATTRS_ACCURATE_TIME)` (xattrs excluded, `--fake-super` `%stat` recorded).
- When the preserve gates decline the node, no backup is placed and no
  "backed up" notice is emitted (upstream `make_backup` returns 3).

The device wire encoding was already correct; this is purely the local
backup copy path. Same-filesystem backups are unaffected (the rename path
already moves the inode verbatim), and the regular-file and symlink backup
paths are unchanged. `mknod` is gated under `#[cfg(unix)]`; native Windows,
which has no device nodes, is a graceful no-op.

## Validation (Linux, aarch64, upstream rsync 3.4.4)

Cross-filesystem `--backup-dir` (dest on ext4, backup-dir on tmpfs), run as
root; backup-dir contents compared byte-for-byte with upstream:

| Case | upstream backup-dir | oc-rsync backup-dir |
|------|---------------------|---------------------|
| char device replace | `crw-r--r-- 1,3 mode=644 root:root` | identical |
| char device `--delete` | `crw-r--r-- 1,3 mode=644 root:root` | identical |
| block device replace | `brw-r--r-- 7,0 mode=644 root:root` | identical |
| FIFO replace (`--specials`) | `prw-rw-r-- mode=664 1000:1000` | identical |

Before the fix, every special-file backup-dir above was empty.

- `cargo fmt --all -- --check` clean
- `cargo clippy -p engine --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo check -p engine --all-features --target x86_64-pc-windows-gnu` clean (cfg gating)
- New unix-gated tests: `copy_entry_to_backup_fifo_recreates_node`,
  `copy_entry_to_backup_special_skipped_without_specials` (9/9 backup tests pass)
