### PR TITLE
feat(compress): advertise lz4 codec after wire-format validation

### DIFF
--- a/crates/compress/src/strategy/negotiator/default.rs
+++ b/crates/compress/src/strategy/negotiator/default.rs
@@ -451,10 +451,11 @@ mod tests {
     fn negotiation_supported_list_size() {
         let negotiator = DefaultCompressionNegotiator::new();
         let supported = negotiator.supported_algorithms();
-        #[cfg(feature = "zstd")]
-        assert_eq!(supported.len(), 4);
-        #[cfg(not(feature = "zstd"))]
-        assert_eq!(supported.len(), 3);
+        // Base list is zlibx, zlib, none; zstd and lz4 each add one entry when
+        // their feature is enabled (lz4 was added once its wire format was
+        // validated against upstream).
+        let expected = 3 + cfg!(feature = "zstd") as usize + cfg!(feature = "lz4") as usize;
+        assert_eq!(supported.len(), expected);
     }
 
     #[test]

--- a/crates/compress/src/strategy/negotiator/default.rs
+++ b/crates/compress/src/strategy/negotiator/default.rs
@@ -266,16 +266,37 @@ mod tests {
         assert!(!supported.contains(&"zstd"));
     }
 
+    #[cfg(feature = "lz4")]
+    #[test]
+    fn negotiation_lz4_in_auto_negotiation() {
+        let negotiator = DefaultCompressionNegotiator::new();
+        let supported = negotiator.supported_algorithms();
+        assert!(
+            supported.contains(&"lz4"),
+            "lz4 must appear in auto-negotiation list once its wire format is validated"
+        );
+    }
+
+    #[cfg(not(feature = "lz4"))]
     #[test]
     fn negotiation_lz4_not_in_auto_negotiation() {
         let negotiator = DefaultCompressionNegotiator::new();
         let supported = negotiator.supported_algorithms();
         assert!(
             !supported.contains(&"lz4"),
-            "lz4 must not appear in auto-negotiation list"
+            "lz4 must not appear in auto-negotiation list when the lz4 feature is off"
         );
     }
 
+    #[cfg(feature = "lz4")]
+    #[test]
+    fn negotiation_remote_only_lz4_returns_lz4() {
+        let negotiator = DefaultCompressionNegotiator::new();
+        let selected = negotiator.select_algorithm(&["lz4"], false);
+        assert_eq!(selected, "lz4");
+    }
+
+    #[cfg(not(feature = "lz4"))]
     #[test]
     fn negotiation_remote_only_lz4_returns_none() {
         let negotiator = DefaultCompressionNegotiator::new();
@@ -283,6 +304,15 @@ mod tests {
         assert_eq!(selected, "none");
     }
 
+    #[cfg(feature = "lz4")]
+    #[test]
+    fn negotiation_remote_only_lz4_server_returns_lz4() {
+        let negotiator = DefaultCompressionNegotiator::new();
+        let selected = negotiator.select_algorithm(&["lz4"], true);
+        assert_eq!(selected, "lz4");
+    }
+
+    #[cfg(not(feature = "lz4"))]
     #[test]
     fn negotiation_remote_only_lz4_server_returns_none() {
         let negotiator = DefaultCompressionNegotiator::new();

--- a/crates/compress/src/strategy/negotiator/protocol_aware.rs
+++ b/crates/compress/src/strategy/negotiator/protocol_aware.rs
@@ -363,13 +363,33 @@ mod tests {
         assert_eq!(neg30.select_algorithm(&["none"], false), "none");
     }
 
+    #[cfg(feature = "lz4")]
     #[test]
-    fn protocol_aware_proto_30_lz4_not_auto_negotiated() {
+    fn protocol_aware_proto_30_lz4_auto_negotiated() {
+        // upstream: compat.c:100-112 valid_compressions_items[] is NOT gated by
+        // protocol version - lz4 is advertised at every negotiated protocol
+        // (30, 31, 32) whenever SUPPORT_LZ4 is compiled in. Wire safety against
+        // genuine proto-30 peers (e.g. rsync 3.0.9) comes from the `v`
+        // capability / CF_VARINT_FLIST_FLAGS handshake (do_negotiated_strings),
+        // not from pruning the list by version: a peer that lacks `v` never
+        // receives this list at all. lz4's wire framing is validated
+        // byte-for-byte against upstream 3.4.4.
+        let neg = ProtocolAwareCompressionNegotiator::new(30);
+        let supported = neg.supported_algorithms();
+        assert!(
+            supported.contains(&"lz4"),
+            "lz4 must appear in the version-independent advertisement list"
+        );
+    }
+
+    #[cfg(not(feature = "lz4"))]
+    #[test]
+    fn protocol_aware_proto_30_lz4_absent_without_feature() {
         let neg = ProtocolAwareCompressionNegotiator::new(30);
         let supported = neg.supported_algorithms();
         assert!(
             !supported.contains(&"lz4"),
-            "lz4 must not appear in auto-negotiation list"
+            "lz4 must not appear when the lz4 feature is disabled"
         );
     }
 

--- a/crates/compress/src/strategy/profile.rs
+++ b/crates/compress/src/strategy/profile.rs
@@ -140,9 +140,12 @@ impl ProtocolCompressionProfile {
         #[cfg(feature = "zstd")]
         list.push("zstd");
 
-        // NOTE: lz4 is intentionally omitted from auto-negotiation. Its
-        // per-token wire framing is not yet interop-validated with upstream.
-        // Explicit --compress-choice=lz4 still works (bypasses this list).
+        // upstream: compat.c:105-107 - lz4 follows zstd when SUPPORT_LZ4 is
+        // defined. Its per-token wire framing is validated byte-for-byte against
+        // upstream rsync 3.4.4 (DEFLATED_DATA header + raw LZ4 block); explicit
+        // --compress-choice=lz4 also works, bypassing this list.
+        #[cfg(feature = "lz4")]
+        list.push("lz4");
 
         list.extend_from_slice(&["zlibx", "zlib", "none"]);
         list
@@ -230,8 +233,35 @@ mod tests {
         assert!(!advertised.contains(&"zstd"));
     }
 
+    #[cfg(feature = "lz4")]
     #[test]
-    fn modern_never_advertises_lz4() {
+    fn modern_advertises_lz4_after_zstd_before_zlibx() {
+        // lz4 wire framing is validated byte-for-byte against upstream 3.4.4, so
+        // it is advertised in upstream's preference slot: after zstd, before
+        // zlibx (upstream compat.c:101-108 valid_compressions_items[]).
+        let advertised = ProtocolCompressionProfile::MODERN.advertised_algorithms();
+        let lz4 = advertised
+            .iter()
+            .position(|&n| n == "lz4")
+            .expect("lz4 advertised");
+        let zlibx = advertised
+            .iter()
+            .position(|&n| n == "zlibx")
+            .expect("zlibx present");
+        assert!(lz4 < zlibx, "lz4 must precede zlibx: {advertised:?}");
+        #[cfg(feature = "zstd")]
+        {
+            let zstd = advertised
+                .iter()
+                .position(|&n| n == "zstd")
+                .expect("zstd present");
+            assert!(zstd < lz4, "zstd must precede lz4: {advertised:?}");
+        }
+    }
+
+    #[cfg(not(feature = "lz4"))]
+    #[test]
+    fn modern_omits_lz4_without_feature() {
         let advertised = ProtocolCompressionProfile::MODERN.advertised_algorithms();
         assert!(!advertised.contains(&"lz4"));
     }

--- a/crates/protocol/src/negotiation/capabilities/algorithms.rs
+++ b/crates/protocol/src/negotiation/capabilities/algorithms.rs
@@ -14,11 +14,18 @@ pub(super) const SUPPORTED_CHECKSUMS: &[&str] =
 /// negotiation (upstream compat.c:541-544). The order matches upstream's
 /// `valid_compressions_items[]` preference: zstd > lz4 > zlibx > zlib > none.
 ///
-/// Zstd is included when the `zstd` feature is enabled - its per-token wire
-/// framing has been validated against upstream rsync (PR #3081). Lz4 is still
-/// excluded from auto-negotiation until its wire format is interop-validated
-/// (task #1380). Explicit `--compress-choice=lz4` still works (bypasses this
-/// list per upstream compat.c:543).
+/// Both zstd and lz4 are included when their respective features are enabled -
+/// their per-token wire framing has been validated byte-for-byte against
+/// upstream rsync 3.4.4 in both directions (SSH and daemon, sender and
+/// receiver). The lz4 codec emits the same `DEFLATED_DATA` token framing and
+/// raw LZ4 block format that upstream's `send_compressed_token()` produces;
+/// upstream and oc decode each other's streams to identical file content.
+///
+/// The exchange itself only happens when `CF_VARINT_FLIST_FLAGS` (the `v`
+/// capability) is negotiated, which restricts lz4/zstd selection to peers new
+/// enough to send that flag (upstream 3.2.0+, protocol 31), mirroring upstream.
+/// Explicit `--compress-choice=lz4` still works independently of this list
+/// (upstream compat.c:543).
 ///
 /// # Upstream reference
 ///
@@ -31,9 +38,9 @@ pub(super) fn supported_compressions() -> Vec<&'static str> {
     #[cfg(feature = "zstd")]
     list.push("zstd");
 
-    // NOTE: lz4 is intentionally omitted from auto-negotiation.
-    // Its per-token wire framing is not yet interop-validated with upstream.
-    // Explicit --compress-choice=lz4 still works (bypasses this list).
+    // upstream: compat.c:105-107 - lz4 follows zstd when SUPPORT_LZ4 is defined
+    #[cfg(feature = "lz4")]
+    list.push("lz4");
 
     list.extend_from_slice(&["zlibx", "zlib", "none"]);
     list

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -2474,22 +2474,30 @@ fn capability_fallback_graceful_checksum_degradation() {
 
 /// Tests compression negotiation with modern and legacy peers.
 ///
-/// When the zstd feature is enabled, zstd is preferred over zlibx/zlib.
-/// Lz4 is still excluded from auto-negotiation (wire format unvalidated).
+/// Preference order follows upstream `valid_compressions_items[]`
+/// (compat.c:100-112): zstd > lz4 > zlibx > zlib > none, with each codec
+/// present only when its feature is compiled in. Both zstd and lz4 wire
+/// formats are validated byte-for-byte against upstream 3.4.4.
 #[test]
 fn capability_compression_negotiation_preference() {
-    // Remote offers full modern list - we pick zstd when feature is enabled
-    // (wire format validated in PR #3081), otherwise zlibx.
+    // Remote offers full modern list - server picks the first entry it also
+    // supports, in upstream preference order zstd > lz4 > zlibx.
     let modern_list = "zstd lz4 zlibx zlib none";
     let result = choose_compression_algorithm(modern_list, true).unwrap();
     #[cfg(feature = "zstd")]
     assert_eq!(result, CompressionAlgorithm::Zstd);
-    #[cfg(not(feature = "zstd"))]
+    #[cfg(all(not(feature = "zstd"), feature = "lz4"))]
+    assert_eq!(result, CompressionAlgorithm::LZ4);
+    #[cfg(all(not(feature = "zstd"), not(feature = "lz4")))]
     assert_eq!(result, CompressionAlgorithm::ZlibX);
 
-    // Remote offers lz4 first without zstd - picks zlibx (lz4 not validated).
+    // Remote offers lz4 first without zstd - picks lz4 when compiled in,
+    // otherwise falls through to zlibx.
     let no_zstd_list = "lz4 zlibx zlib none";
     let result = choose_compression_algorithm(no_zstd_list, true).unwrap();
+    #[cfg(feature = "lz4")]
+    assert_eq!(result, CompressionAlgorithm::LZ4);
+    #[cfg(not(feature = "lz4"))]
     assert_eq!(result, CompressionAlgorithm::ZlibX);
 
     // Server with only zlib variants
@@ -2854,17 +2862,20 @@ fn capability_fallback_all_protocol_versions() {
 
 #[test]
 fn supported_compressions_includes_validated_algorithms() {
-    // Zstd wire framing was validated against upstream (PR #3081).
-    // Lz4 wire framing is not yet validated - must remain excluded.
+    // Both zstd and lz4 wire framings are validated byte-for-byte against
+    // upstream 3.4.4, so each is advertised when its feature is compiled in.
     let list = supported_compressions();
     #[cfg(feature = "zstd")]
     assert!(
         list.contains(&"zstd"),
-        "zstd must be advertised - wire format validated (PR #3081)"
+        "zstd must be advertised when enabled"
     );
+    #[cfg(feature = "lz4")]
+    assert!(list.contains(&"lz4"), "lz4 must be advertised when enabled");
+    #[cfg(not(feature = "lz4"))]
     assert!(
         !list.contains(&"lz4"),
-        "lz4 must not be advertised until wire format is validated"
+        "lz4 must be absent when its feature is disabled"
     );
     assert!(list.contains(&"zlibx"));
     assert!(list.contains(&"zlib"));
@@ -2873,17 +2884,25 @@ fn supported_compressions_includes_validated_algorithms() {
 
 #[test]
 fn supported_compressions_order_matches_upstream() {
-    // upstream: compat.c:100-112 - preference order is zstd > zlibx > zlib > none
-    // (lz4 will be re-added after wire format validation)
+    // upstream: compat.c:100-112 - preference order is
+    // zstd > lz4 > zlibx > zlib > none, each present only when compiled in.
     let list = supported_compressions();
     let zlibx_pos = list.iter().position(|&s| s == "zlibx").unwrap();
     let zlib_pos = list.iter().position(|&s| s == "zlib").unwrap();
     let none_pos = list.iter().position(|&s| s == "none").unwrap();
-    // upstream: compat.c:101-102 - zstd precedes zlibx when available
+    // upstream: compat.c:101-108 - zstd, then lz4, precede zlibx when available.
+    #[cfg(feature = "lz4")]
+    let lz4_pos = {
+        let lz4_pos = list.iter().position(|&s| s == "lz4").unwrap();
+        assert!(lz4_pos < zlibx_pos);
+        lz4_pos
+    };
     #[cfg(feature = "zstd")]
     {
         let zstd_pos = list.iter().position(|&s| s == "zstd").unwrap();
         assert!(zstd_pos < zlibx_pos);
+        #[cfg(feature = "lz4")]
+        assert!(zstd_pos < lz4_pos);
     }
     assert!(zlibx_pos < zlib_pos);
     assert!(zlib_pos < none_pos);

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -2910,13 +2910,16 @@ fn supported_compressions_order_matches_upstream() {
 
 #[test]
 fn negotiate_picks_best_validated_algorithm() {
-    // Remote offers full modern list. When zstd feature is enabled, we pick zstd
-    // as the best validated algorithm (PR #3081). Lz4 is still excluded.
+    // Remote offers full modern list; server picks the first entry it also
+    // supports in upstream preference order zstd > lz4 > zlibx. Both zstd and
+    // lz4 wire formats are validated byte-for-byte against upstream 3.4.4.
     let list = "zstd lz4 zlibx zlib none";
     let result = choose_compression_algorithm(list, true).unwrap();
     #[cfg(feature = "zstd")]
     assert_eq!(result, CompressionAlgorithm::Zstd);
-    #[cfg(not(feature = "zstd"))]
+    #[cfg(all(not(feature = "zstd"), feature = "lz4"))]
+    assert_eq!(result, CompressionAlgorithm::LZ4);
+    #[cfg(all(not(feature = "zstd"), not(feature = "lz4")))]
     assert_eq!(result, CompressionAlgorithm::ZlibX);
 }
 

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -862,28 +862,58 @@ fn test_choose_checksum_empty_list() {
 
 #[test]
 fn test_choose_compression_first_match_wins_zstd_or_zlib() {
-    // Remote offers zstd and lz4 first, then zlib.
-    // When zstd feature is enabled, zstd is in our supported list (validated
-    // in PR #3081) and wins. Lz4 is still excluded.
+    // Remote offers zstd and lz4 first, then zlib. Both zstd and lz4 are now in
+    // our supported list (wire-format validated against upstream 3.4.4), so the
+    // first mutually supported entry wins in preference order zstd > lz4 > zlib.
     let client_list = "zstd lz4 zlib none";
     let result = choose_compression_algorithm(client_list, true).unwrap();
     #[cfg(feature = "zstd")]
     assert_eq!(result, CompressionAlgorithm::Zstd);
-    #[cfg(not(feature = "zstd"))]
+    #[cfg(all(not(feature = "zstd"), feature = "lz4"))]
+    assert_eq!(result, CompressionAlgorithm::LZ4);
+    #[cfg(all(not(feature = "zstd"), not(feature = "lz4")))]
     assert_eq!(result, CompressionAlgorithm::Zlib);
 }
 
 #[test]
 fn test_choose_compression_first_match_wins_zstd_or_zlibx() {
-    // Remote offers zstd, lz4, then zlibx.
-    // When zstd feature is enabled, zstd is in our supported list and wins.
-    // Lz4 is still excluded from auto-negotiation.
+    // Remote offers zstd, lz4, then zlibx. zstd wins when enabled, otherwise lz4
+    // (also validated), otherwise zlibx - preference zstd > lz4 > zlibx.
     let client_list = "zstd lz4 zlibx zlib none";
     let result = choose_compression_algorithm(client_list, true).unwrap();
     #[cfg(feature = "zstd")]
     assert_eq!(result, CompressionAlgorithm::Zstd);
-    #[cfg(not(feature = "zstd"))]
+    #[cfg(all(not(feature = "zstd"), feature = "lz4"))]
+    assert_eq!(result, CompressionAlgorithm::LZ4);
+    #[cfg(all(not(feature = "zstd"), not(feature = "lz4")))]
     assert_eq!(result, CompressionAlgorithm::ZlibX);
+}
+
+#[test]
+#[cfg(feature = "lz4")]
+fn test_lz4_is_advertised_in_preference_order() {
+    // lz4 must appear in the advertised list (wire-format validated vs upstream
+    // 3.4.4) positioned per upstream valid_compressions_items[]: after zstd,
+    // before zlibx/zlib/none. The list is only sent when CF_VARINT_FLIST_FLAGS
+    // (the `v` capability) is negotiated, matching upstream's proto-31+ gating.
+    let list = supported_compressions();
+    let lz4 = list
+        .iter()
+        .position(|&n| n == "lz4")
+        .expect("lz4 advertised");
+    let zlibx = list
+        .iter()
+        .position(|&n| n == "zlibx")
+        .expect("zlibx present");
+    assert!(lz4 < zlibx, "lz4 must precede zlibx: {list:?}");
+    #[cfg(feature = "zstd")]
+    {
+        let zstd = list
+            .iter()
+            .position(|&n| n == "zstd")
+            .expect("zstd present");
+        assert!(zstd < lz4, "zstd must precede lz4: {list:?}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The lz4 per-token wire codec (`DEFLATED_DATA` header + raw LZ4 block, mirroring
upstream `token.c:send_compressed_token()` / `recv_compressed_token()` for
`CPRES_LZ4`) was already implemented and reachable via explicit
`--compress-choice=lz4`, but lz4 was deliberately withheld from the advertised
negotiation list pending interop validation. This change validates the lz4 wire
format byte-for-byte against upstream rsync 3.4.4 and adds lz4 to the advertised
compression list so oc and upstream auto-negotiate lz4 when both prefer it -
exactly as two upstream peers would.

## What changed

- `supported_compressions()` and the parallel `ProtocolCompressionProfile::advertised_algorithms()`
  now include `lz4` in upstream preference order (`zstd > lz4 > zlibx > zlib > none`),
  guarded by the `lz4` feature. Mirrors upstream `compat.c:101-108`
  `valid_compressions_items[]`.
- The list is only emitted when `CF_VARINT_FLIST_FLAGS` (the `v` capability) is
  negotiated, which restricts lz4/zstd selection to protocol-31+ peers, matching
  upstream (`compat.c:556-563`). No separate version gate is needed - lz4 inherits
  zstd's existing gating.
- Tests that pinned lz4's absence are replaced with assertions that pin its
  presence and preference position; a new test enforces `zstd < lz4 < zlibx`.

## Validation

Built the release binary on an aarch64 Linux host and transferred against
upstream rsync 3.4.4 (`Compress list: zstd lz4 zlibx zlib none`).

**Wire-format correctness (`--compress-choice=lz4 -z`, forces lz4 both sides):**

| Transport | oc sender -> upstream receiver | upstream sender -> oc receiver |
|-----------|-------------------------------|-------------------------------|
| SSH       | exit 0, diff -r clean, sha match | exit 0, diff -r clean, sha match |
| daemon (`rsync://`) | exit 0, diff -r clean | exit 0, diff -r clean |

Both client roles covered (oc as client and upstream as client). Sizes from 33 B
to 10.6 MB, compressible and incompressible. A forced delta transfer (modified
basis, matched + literal token mix) reconstructs byte-perfect under lz4,
identical to zstd and no-compression.

**On-wire token framing (tcpdump, loopback daemon):** both oc and upstream emit
the identical grammar - `DEFLATED_DATA` header (`0x40 | len>>8`, `len & 0xff`),
raw LZ4 block (literal-run token + literals + 2-byte offset + `0xff` match-length
RLE extension), terminated by `END_FLAG` (`0x00`). Only the compressed payload
bytes differ (lz4_flex vs liblz4 emit different-but-valid LZ4 encodings, e.g.
83 vs 79 bytes for the same input) - allowed, since each peer decodes the other's
stream to identical content.

**Auto-negotiation (the gap this closes, `-z`, no `--compress-choice`):** with the
upstream side preferring lz4 (`RSYNC_COMPRESS_LIST="lz4 zlib none"`), oc push and
pull both report `Client negotiated compress: lz4 (level 6)` and reconstruct
clean. Against a peer that offers no lz4 (`zlib none`), oc falls back to
`zlib (level 6)` with no hang. oc advertises `zstd lz4 zlibx zlib`, confirming
the preference order.

## Notes

- Explicit `--compress-choice=lz4` behaviour is unchanged (it bypasses the list).
- zstd remains first preference, so oc<->upstream default `-z` still selects zstd;
  lz4 is selected only when it is the mutually-preferred codec.
