### PR TITLE
fix(engine): preserve owner/mode/mtime on cross-device file and symlink backups

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -486,6 +486,9 @@ pub(crate) enum BackupStrategy {
     Rename,
     Copy,
     Symlink,
+    // Constructed only by the `#[cfg(unix)]` device/FIFO/socket mknod backup
+    // path; on non-Unix targets it is matched but never built.
+    #[cfg_attr(not(unix), allow(dead_code))]
     Device,
 }
 

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -43,7 +43,9 @@ use super::{
 };
 use crate::delta::DeltaSignatureIndex;
 use crate::signature::SignatureBlock;
-use ::metadata::{MetadataOptions, apply_file_metadata_with_options};
+use ::metadata::{
+    MetadataOptions, apply_file_metadata_with_options, apply_symlink_metadata_with_options,
+};
 use bandwidth::{BandwidthLimitComponents, BandwidthLimiter};
 use checksums::RollingChecksum;
 use compress::algorithm::CompressionAlgorithm;
@@ -53,6 +55,7 @@ use filters::FilterRule;
 use logging::info_log;
 use protocol::flist::FileListWriter;
 
+use super::overrides::backup_rename;
 #[cfg(target_os = "linux")]
 use super::overrides::{cached_parent_device, same_filesystem};
 

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -852,7 +852,7 @@ impl<'a> CopyContext<'a> {
         // Track which backup strategy succeeded so we can emit the matching
         // upstream `--debug=BACKUP` trace (RENAME, COPY, or SYMLINK).
         // upstream: backup.c:link_or_rename and the fall-through copy_file path.
-        let strategy = match fs::rename(destination, &backup_path) {
+        let strategy = match backup_rename(destination, &backup_path) {
             Ok(()) => BackupStrategy::Rename,
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
             // upstream: backup.c:247-256 - link_or_rename failing with EEXIST or
@@ -954,16 +954,27 @@ impl<'a> CopyContext<'a> {
         // upstream: backup.c:338-341 - set_file_attrs(buf, file, NULL, fname,
         // ATTRS_ACCURATE_TIME) copies the source node's mode/owner/times onto
         // the freshly-created backup node (with preserve_xattrs temporarily
-        // cleared), overriding the umask that mknod applied. Only the
-        // cross-device device/special copy fallback needs this: rename carries
-        // the inode's attributes verbatim, and the regular-file copy path
-        // mirrors upstream's own COPY handling.
-        if strategy == BackupStrategy::Device
-            && let Ok(source_meta) = fs::symlink_metadata(destination)
+        // cleared), overriding the umask/copy defaults. Every cross-device copy
+        // fallback needs this - regular file (COPY), symlink (SYMLINK), and
+        // device/special (DEVICE) - because fs::copy/create_symlink/mknod leave
+        // the backup owned by the caller (root), whereas upstream reapplies the
+        // source uid/gid/mode/mtime. The same-fs rename path carries the inode's
+        // attributes verbatim and is skipped here.
+        if matches!(
+            strategy,
+            BackupStrategy::Copy | BackupStrategy::Symlink | BackupStrategy::Device
+        ) && let Ok(source_meta) = fs::symlink_metadata(destination)
         {
             let metadata_options = self.metadata_options();
-            apply_file_metadata_with_options(&backup_path, &source_meta, &metadata_options)
-                .map_err(map_metadata_error)?;
+            // upstream: rsync.c:set_file_attrs() skips chmod for symlinks and
+            // applies ownership/times with AT_SYMLINK_NOFOLLOW.
+            if strategy == BackupStrategy::Symlink {
+                apply_symlink_metadata_with_options(&backup_path, &source_meta, &metadata_options)
+                    .map_err(map_metadata_error)?;
+            } else {
+                apply_file_metadata_with_options(&backup_path, &source_meta, &metadata_options)
+                    .map_err(map_metadata_error)?;
+            }
             // upstream: xattrs.c:set_stat_xattr() re-records the source stat in
             // `user.rsync.%stat` under --fake-super so the virtualised node's
             // mode/owner/rdev survive; no-op when fake-super is off.

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -266,6 +266,14 @@ where
 }
 
 #[cfg(test)]
+pub(crate) fn with_backup_rename_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
+where
+    F: Fn(&std::path::Path, &std::path::Path) -> Option<std::io::Result<()>> + 'static,
+{
+    overrides::with_backup_rename_override(override_fn, action)
+}
+
+#[cfg(test)]
 mod tests;
 
 #[cfg(test)]

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -266,6 +266,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(not(unix), allow(dead_code))]
 pub(crate) fn with_backup_rename_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
 where
     F: Fn(&std::path::Path, &std::path::Path) -> Option<std::io::Result<()>> + 'static,

--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -17,6 +17,9 @@ type HardLinkOverrideFn = dyn Fn(&Path, &Path) -> io::Result<()> + 'static;
 type DeviceIdOverrideFn = dyn Fn(&Path, &fs::Metadata) -> Option<u64> + 'static;
 
 #[cfg(test)]
+type BackupRenameOverrideFn = dyn Fn(&Path, &Path) -> Option<io::Result<()>> + 'static;
+
+#[cfg(test)]
 thread_local! {
     static HARD_LINK_OVERRIDE: RefCell<Option<Box<HardLinkOverrideFn>>> =
         const { RefCell::new(None) };
@@ -93,6 +96,54 @@ where
     let result = action();
     drop(guard);
     result
+}
+
+#[cfg(test)]
+thread_local! {
+    static BACKUP_RENAME_OVERRIDE: RefCell<Option<Box<BackupRenameOverrideFn>>> =
+        const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn with_backup_rename_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
+where
+    F: Fn(&Path, &Path) -> Option<io::Result<()>> + 'static,
+{
+    struct ResetGuard;
+
+    impl Drop for ResetGuard {
+        fn drop(&mut self) {
+            BACKUP_RENAME_OVERRIDE.with(|cell| {
+                cell.replace(None);
+            });
+        }
+    }
+
+    BACKUP_RENAME_OVERRIDE.with(|cell| {
+        cell.replace(Some(Box::new(override_fn)));
+    });
+    let guard = ResetGuard;
+    let result = action();
+    drop(guard);
+    result
+}
+
+/// Renames a destination entry to its backup location.
+///
+/// In tests a thread-local override can force a specific outcome (e.g. an
+/// `EXDEV` cross-device error) to exercise the copy-tree fallback without a
+/// real second filesystem; production always calls `std::fs::rename`.
+pub(super) fn backup_rename(from: &Path, to: &Path) -> io::Result<()> {
+    #[cfg(test)]
+    if let Some(result) = BACKUP_RENAME_OVERRIDE.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .and_then(|override_fn| override_fn(from, to))
+    }) {
+        return result;
+    }
+
+    fs::rename(from, to)
 }
 
 pub(super) fn device_identifier(path: &Path, metadata: &fs::Metadata) -> Option<u64> {

--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -105,6 +105,9 @@ thread_local! {
 }
 
 #[cfg(test)]
+// Only the `#[cfg(unix)]` cross-device backup tests install this override; on
+// non-Unix targets it is unreferenced.
+#[cfg_attr(not(unix), allow(dead_code))]
 pub(crate) fn with_backup_rename_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
 where
     F: Fn(&Path, &Path) -> Option<io::Result<()>> + 'static,

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -574,6 +574,134 @@ fn backup_preserves_symlinks_in_directory() {
     );
 }
 
+// upstream: backup.c:338-341 - after copying a regular file to the backup tree,
+// make_backup runs set_file_attrs(buf, file, ...) so the backup carries the
+// source node's mode/owner/mtime rather than the copy defaults. When the
+// backup-dir is on a different filesystem the rename fails with EXDEV and
+// oc-rsync falls back to fs::copy, which leaves the caller's umask/current
+// mtime; the metadata reapply must restore the original attributes. Ownership
+// cannot be exercised without root, so this asserts mode + mtime, both of which
+// fs::copy alone would not preserve (current mtime, no explicit chmod).
+#[cfg(unix)]
+#[test]
+fn cross_device_file_backup_preserves_mode_and_mtime() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+
+    let source_file = ctx.source.join("file.txt");
+    fs::write(&source_file, b"updated").expect("write source");
+
+    let dest_root = ctx.dest.join("source");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+    let existing = dest_root.join("file.txt");
+    fs::write(&existing, b"original").expect("write dest");
+    fs::set_permissions(&existing, PermissionsExt::from_mode(0o604)).expect("chmod dest");
+    let backup_mtime = FileTime::from_unix_time(1_600_000_000, 0);
+    set_file_mtime(&existing, backup_mtime).expect("set dest mtime");
+
+    let backup_dir = ctx.dest.join("backups");
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .times(true)
+        .permissions(true)
+        .owner(true)
+        .group(true)
+        .with_backup_directory(Some(backup_dir.clone()));
+
+    with_backup_rename_override(
+        |_, _| Some(Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE))),
+        || {
+            plan.execute_with_options(LocalCopyExecution::Apply, options)
+                .expect("copy succeeds")
+        },
+    );
+
+    let backup = backup_dir.join("source/file.txt~");
+    let meta = fs::symlink_metadata(&backup).expect("backup metadata");
+    assert_eq!(fs::read(&backup).expect("read backup"), b"original");
+    assert_eq!(
+        meta.permissions().mode() & 0o777,
+        0o604,
+        "cross-device file backup did not preserve mode"
+    );
+    assert_eq!(
+        FileTime::from_last_modification_time(&meta),
+        backup_mtime,
+        "cross-device file backup did not preserve mtime"
+    );
+}
+
+// upstream: backup.c:338-341 / rsync.c:set_file_attrs() - the same reapply runs
+// for the SYMLINK branch, but chmod is skipped and ownership/times are applied
+// with AT_SYMLINK_NOFOLLOW. Across a filesystem boundary the symlink backup is
+// recreated with do_symlink and must then carry the original link's mtime.
+#[cfg(unix)]
+#[test]
+fn cross_device_symlink_backup_preserves_target_and_mtime() {
+    use std::os::unix::fs::symlink;
+
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+
+    let source_link = ctx.source.join("link");
+    symlink("new_target", &source_link).expect("create source symlink");
+
+    let dest_root = ctx.dest.join("source");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+    let existing_link = dest_root.join("link");
+    symlink("old_target", &existing_link).expect("create dest symlink");
+    let backup_mtime = FileTime::from_unix_time(1_600_000_000, 0);
+    filetime::set_symlink_file_times(&existing_link, backup_mtime, backup_mtime)
+        .expect("set dest symlink mtime");
+
+    let backup_dir = ctx.dest.join("backups");
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .links(true)
+        .times(true)
+        .owner(true)
+        .group(true)
+        .with_backup_directory(Some(backup_dir.clone()));
+
+    with_backup_rename_override(
+        |_, _| Some(Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE))),
+        || {
+            plan.execute_with_options(LocalCopyExecution::Apply, options)
+                .expect("copy succeeds")
+        },
+    );
+
+    let backup = backup_dir.join("source/link~");
+    let meta = fs::symlink_metadata(&backup).expect("backup symlink metadata");
+    assert!(
+        meta.file_type().is_symlink(),
+        "backup is not a symlink at {}",
+        backup.display()
+    );
+    assert_eq!(
+        fs::read_link(&backup).expect("read backup link"),
+        PathBuf::from("old_target")
+    );
+    assert_eq!(
+        FileTime::from_last_modification_time(&meta),
+        backup_mtime,
+        "cross-device symlink backup did not preserve mtime"
+    );
+}
+
 #[test]
 fn backup_with_special_characters_in_filename() {
     let ctx = test_helpers::setup_copy_test();


### PR DESCRIPTION
## Problem

When `--backup-dir` is on a different filesystem from the destination, the rename into the backup tree fails with `EXDEV` and oc-rsync falls back to a copy-tree: `fs::copy` for regular files, a fresh symlink for links. Neither preserves the source node's ownership or modification time, so the backup ended up owned by the caller (root) with the current mtime.

Reproduced as root with `--backup-dir` on tmpfs while the destination is on ext4:

| entry | oc (before) | upstream 3.4.4 |
|-------|-------------|----------------|
| file backup | owner `0:0`, mtime `2026-...` (current) | owner `1000:1000`, mtime `2000-01-01` |
| symlink backup | owner `0:0`, mtime current | owner `1000:1000`, mtime `2000-01-01` |

## Fix

Upstream `make_backup` runs `set_file_attrs(buf, file, NULL, fname, ATTRS_ACCURATE_TIME)` after every copy-tree branch (COPY, SYMLINK, DEVICE), reapplying the source uid/gid/mode/mtime (backup.c:338-341). The device/special branch already reapplied these; this extends the reapply to the regular-file and symlink branches:

- regular files use `apply_file_metadata_with_options`
- symlinks use `apply_symlink_metadata_with_options` (chmod skipped, ownership/times applied with `AT_SYMLINK_NOFOLLOW`, mirroring `rsync.c:set_file_attrs()`)

Ownership is gated exactly as upstream: a non-root caller cannot chown and matches upstream there. `--fake-super` records the owner in the `%stat` xattr as before. The same-filesystem rename path is untouched - the inode carries its attributes verbatim.

## Verification (root, aarch64 Linux, cross-device destination vs tmpfs backup-dir)

Compared against upstream rsync 3.4.4 byte-for-byte (`stat -c '%u:%g %a', mtime, symlink target`):

- Cross-device file backup: owner `1000:1000`, mode `604`, mtime `2000` - matches upstream
- Cross-device symlink backup: owner `1000:1000`, mtime `2000`, target `old_target` - matches upstream
- Same-filesystem backup (rename path): unchanged, matches upstream
- Non-root cross-device: exit 0, owner/mode/mtime preserved - matches upstream
- Device/special backup: char device owner `1000:1000`, mode `660`, rdev `1,5`, mtime `2000` - unchanged, matches upstream

Added two unix-gated regression tests that force the cross-device fallback through a test-only rename override and assert the file and symlink backups keep their mode and mtime. Both pass.
