### PR TITLE
fix(filters): auto-exclude --partial-dir from transfer and deletion

### DIFF
--- a/crates/core/src/client/config/builder/filters.rs
+++ b/crates/core/src/client/config/builder/filters.rs
@@ -29,4 +29,41 @@ impl ClientConfigBuilder {
         self.filter_rules.extend(rules);
         self
     }
+
+    /// Appends the implicit exclude rule that upstream rsync injects for a
+    /// relative `--partial-dir`.
+    ///
+    /// upstream: compat.c:791-797 (`setup_protocol`). When `partial_dir` is
+    /// set and relative (`*partial_dir != '/'`), rsync appends a
+    /// directory-only exclude rule for the partial directory to the tail of
+    /// the filter list. Being appended after every CLI rule, it carries the
+    /// lowest precedence, so a user rule matching the same path still wins
+    /// under first-match evaluation. The rule keeps the partial directory out
+    /// of the sender's file list (it is neither listed nor transferred) and
+    /// protects it from `--delete` on the receiver. It is marked perishable
+    /// so an otherwise-empty parent directory can still be reaped
+    /// (upstream sets `FILTRULE_PERISHABLE` at protocol >= 30, which is the
+    /// negotiated default).
+    ///
+    /// An absolute partial directory is left untouched, matching upstream's
+    /// `*partial_dir != '/'` guard.
+    pub(super) fn push_implicit_partial_dir_filter(&mut self) {
+        let Some(dir) = self.partial_dir.as_ref() else {
+            return;
+        };
+        if !dir.is_relative() {
+            return;
+        }
+        let mut pattern = dir.to_string_lossy().into_owned();
+        if pattern.is_empty() {
+            return;
+        }
+        // Trailing slash restricts the rule to directories, mirroring
+        // upstream's FILTRULE_DIRECTORY flag.
+        if !pattern.ends_with('/') {
+            pattern.push('/');
+        }
+        self.filter_rules
+            .push(FilterRuleSpec::exclude(pattern).with_perishable(true));
+    }
 }

--- a/crates/core/src/client/config/builder/filters.rs
+++ b/crates/core/src/client/config/builder/filters.rs
@@ -51,11 +51,16 @@ impl ClientConfigBuilder {
         let Some(dir) = self.partial_dir.as_ref() else {
             return;
         };
-        if !dir.is_relative() {
-            return;
-        }
         let mut pattern = dir.to_string_lossy().into_owned();
         if pattern.is_empty() {
+            return;
+        }
+        // upstream: compat.c:791 guard `*partial_dir != '/'` - an absolute
+        // (leading-slash) partial dir injects no implicit rule. Test the
+        // leading slash directly rather than `Path::is_relative()`, which is
+        // platform-dependent: on Windows a leading-slash path has no drive
+        // prefix and is classified as relative, wrongly injecting the rule.
+        if pattern.starts_with('/') {
             return;
         }
         // Trailing slash restricts the rule to directories, mirroring

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -368,6 +368,9 @@ impl ClientConfigBuilder {
         if self.checksum_choice.transfer_is_none() {
             self.whole_file = Some(true);
         }
+        // upstream: compat.c:791-797 - append the implicit `--partial-dir`
+        // exclude at the tail of the filter list, after every CLI rule.
+        self.push_implicit_partial_dir_filter();
         ClientConfig {
             transfer_args: self.transfer_args,
             dry_run: self.dry_run,

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -946,6 +946,59 @@ fn partial_directory_none_clears_path() {
     assert!(config.partial_directory().is_none());
 }
 
+/// upstream: compat.c:791-797 - a relative `--partial-dir` appends a
+/// directory-only, perishable exclude rule so the partial directory is kept
+/// out of the sender's file list and protected from `--delete` on the
+/// receiver. Encoded here to guard against a regression that would leak the
+/// partial directory into the transfer or delete a pre-existing one.
+#[test]
+fn implicit_partial_dir_filter_excludes_and_protects() {
+    let config = builder().partial_directory(Some(".rsync-partial")).build();
+    let rules = config.filter_rules();
+    let rule = rules
+        .last()
+        .expect("relative partial-dir must inject an implicit rule");
+    assert_eq!(rule.kind(), FilterRuleKind::Exclude);
+    // Trailing slash restricts the match to directories (FILTRULE_DIRECTORY).
+    assert_eq!(rule.pattern(), ".rsync-partial/");
+    assert!(rule.is_perishable());
+    // Applies to the sender (drop from flist) and the receiver (protect from
+    // deletion), matching upstream's rule with no FILTRULES_SIDES bit set.
+    assert!(rule.applies_to_sender());
+    assert!(rule.applies_to_receiver());
+}
+
+/// upstream: compat.c:791 guard `*partial_dir != '/'` - an absolute partial
+/// directory must not inject any implicit rule.
+#[test]
+fn implicit_partial_dir_filter_skips_absolute_dir() {
+    let config = builder().partial_directory(Some("/tmp/partial")).build();
+    assert!(config.filter_rules().is_empty());
+}
+
+/// The implicit rule is appended after every user rule (upstream adds it in
+/// `setup_protocol`, after argument parsing), so it carries the lowest
+/// precedence under first-match evaluation.
+#[test]
+fn implicit_partial_dir_filter_follows_user_rules() {
+    let config = builder()
+        .extend_filter_rules([FilterRuleSpec::include(".rsync-partial/")])
+        .partial_directory(Some(".rsync-partial"))
+        .build();
+    let rules = config.filter_rules();
+    assert_eq!(rules.len(), 2);
+    assert_eq!(rules[0].kind(), FilterRuleKind::Include);
+    assert_eq!(rules[1].kind(), FilterRuleKind::Exclude);
+    assert_eq!(rules[1].pattern(), ".rsync-partial/");
+}
+
+/// Without `--partial-dir` no implicit rule is added.
+#[test]
+fn implicit_partial_dir_filter_absent_without_partial_dir() {
+    let config = builder().build();
+    assert!(config.filter_rules().is_empty());
+}
+
 #[test]
 fn temp_directory_sets_path() {
     let config = builder().temp_directory(Some("/tmp/staging")).build();


### PR DESCRIPTION
## Problem

Upstream rsync (`compat.c:791-797`, `setup_protocol`) injects an implicit
filter rule when a relative `--partial-dir` is configured: a directory-only,
perishable **exclude** for the partial directory, appended to the tail of the
filter list. This keeps the partial directory out of the sender's file list
and protects a pre-existing one from `--delete` on the receiver.

oc-rsync only had a hardcoded protection in the *local-copy* deletion path and
never injected the filter rule, so the partial directory leaked into every
sender-side flist and was deleted on remote receivers.

## Verified divergences (oc vs upstream 3.4.4, aarch64)

With a source/dest tree containing a `.rsync-partial` directory:

| Scenario | Before | Upstream |
|---|---|---|
| `--list-only` | lists `.rsync-partial/…` | omits it |
| local `-a` transfer | copies `.rsync-partial/…` | omits it |
| remote (ssh) `-a` transfer | copies `.rsync-partial/…` | omits it |
| remote (ssh) `-a --delete` with pre-existing partial dir on receiver | **deletes it (data loss)** | protects it |
| local `-a --delete` | protects it | protects it |

## Fix

Append the implicit exclude rule in `ClientConfigBuilder::build()`, after all
CLI rules, when `partial_dir` is set and relative. Because
`config.filter_rules()` is the single source feeding the local filter program,
the wire-format rules sent to a remote server, and batch mode, this one
injection fixes local, SSH, and daemon transfers uniformly. An absolute
partial directory is left untouched, mirroring upstream's `*partial_dir != '/'`
guard. The rule is directory-only (trailing slash) and perishable (protocol
>= 30 default).

## Verification

All five scenarios now byte-match upstream 3.4.4 (list-only, local transfer,
remote transfer, remote `--delete`, local `--delete`). Regression checks:
`--exclude` + `--delete` without `--partial-dir` is unchanged, and an explicit
`+ .rsync-partial/` user rule still overrides the implicit exclude (precedence
preserved). New unit tests cover the exclude+protect rule, the absolute-dir
skip, tail precedence after user rules, and absence without `--partial-dir`.
`cargo fmt`/`cargo clippy -p core` clean.
