### PR TITLE
fix(transfer): gate implied-dirs force-on to protocol >= 30

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -223,6 +223,15 @@ pub(super) struct ServerLongFlags {
     /// is a listing. The receiver renders the flist without writing to the
     /// destination.
     pub(super) list_only: bool,
+
+    /// Whether the client forwarded `--no-implied-dirs` (upstream
+    /// `implied_dirs == 0`).
+    ///
+    /// upstream: options.c:2976-2977 - forwarded to the sender on a pull. As the
+    /// server-side sender, this process must omit the implied parent dirs from
+    /// the flist at protocol < 30 (flist.c:2468); protocol >= 30 always sends
+    /// them (flist.c:2257-2258).
+    pub(super) no_implied_dirs: bool,
 }
 
 /// Parses all long-form flags from the server argument list.
@@ -277,6 +286,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         delay_updates: false,
         mkpath: false,
         list_only: false,
+        no_implied_dirs: false,
     };
 
     let mut idx = 0;
@@ -302,6 +312,10 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             "--specials" => flags.specials = Some(true),
             "--no-specials" => flags.specials = Some(false),
             "--qsort" => flags.qsort = true,
+            // upstream: options.c:696 / 2976-2977 - `--no-implied-dirs` is
+            // forwarded to the sender on a pull. The server-side sender must omit
+            // implied parent dirs from the flist at protocol < 30.
+            "--no-implied-dirs" => flags.no_implied_dirs = true,
             "--from0" => flags.from0 = true,
             "--inplace" => flags.inplace = true,
             // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode
@@ -551,6 +565,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--msgs2stderr"
             | "--no-msgs2stderr"
             | "--qsort"
+            | "--no-implied-dirs"
             | "--from0"
             | "--inplace"
             | "--append"

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -206,6 +206,11 @@ where
     }
     config.file_selection.ignore_existing = long_flags.ignore_existing;
     config.file_selection.existing_only = long_flags.existing_only;
+    // upstream: options.c:2976-2977 / flist.c:2468 - `--no-implied-dirs` is
+    // forwarded to the sender on a pull. As the server-side sender this process
+    // must omit the implied parent dirs from the flist at protocol < 30; at
+    // protocol >= 30 they are always sent (flist.c:2257-2258).
+    config.flags.no_implied_dirs = long_flags.no_implied_dirs;
     config.flags.numeric_ids = core::server::NumericIds::from_client(long_flags.numeric_ids);
     config.flags.delete = long_flags.delete;
     // upstream: options.c:2964-2965 - `--remove-source-files` is forwarded

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -376,6 +376,13 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
         config.delete_mode(),
         config.max_delete()
     );
+    // upstream: flist.c:2257-2258 / options.c:2976 - `--no-implied-dirs` is
+    // forwarded to the remote peer, but the in-process sender half (SSH/daemon
+    // push) builds the wire flist locally and must honour the flag too. Its
+    // generator emits implied parent dirs only when implied_dirs is on OR the
+    // protocol >= 30 forces them. `implied_dirs()` defaults true, so this stays
+    // false (implied dirs on) unless the client passed --no-implied-dirs.
+    server_config.flags.no_implied_dirs = !config.implied_dirs();
     // upstream: options.c:2881-2885 - copy_unsafe_links and safe_links are long-form only
     server_config.flags.copy_unsafe_links = config.copy_unsafe_links();
     server_config.flags.safe_links = config.safe_links();

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -77,6 +77,13 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
             "--numeric-ids" => {
                 config.flags.numeric_ids = core::server::NumericIds::Explicit;
             }
+            // upstream: options.c:2976-2977 - `--no-implied-dirs` forwarded to
+            // the sender on a pull. The daemon-sender must omit implied parent
+            // dirs from the flist at protocol < 30 (flist.c:2468); protocol >= 30
+            // always sends them (flist.c:2257-2258).
+            "--no-implied-dirs" => {
+                config.flags.no_implied_dirs = true;
+            }
             // upstream: options.c:2890-2891
             "--use-qsort" => {
                 config.qsort = true;

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -163,6 +163,28 @@ pub struct ParsedServerFlags {
     pub one_file_system: u8,
     /// Relative paths (`R` flag, `--relative`).
     pub relative: bool,
+    /// Suppress implied parent directories in `--relative` mode
+    /// (long-form `--no-implied-dirs`, upstream `implied_dirs == 0`).
+    ///
+    /// Stored negated so the `Default` derive leaves it `false` (implied dirs
+    /// on, matching upstream's `int implied_dirs = 1` default, options.c:95).
+    /// Not part of the compact flag string; set via long-form propagation.
+    ///
+    /// The sender's file-list builder emits the implied parent directories of a
+    /// `--relative` source only when this is `false` OR the protocol forces them
+    /// on. Upstream forces `implied_dirs = 1` whenever
+    /// `relative_paths && protocol_version >= 30` (flist.c:2257-2258), so at
+    /// protocol < 30 the flag is honoured and `--no-implied-dirs` omits the
+    /// implied parents from the flist (flist.c:2468 gates the non-incremental
+    /// send on `implied_dirs`). At protocol >= 30 the implied dirs are always
+    /// sent (flagged), regardless of this field.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:696` - `{"no-implied-dirs", 0, POPT_ARG_VAL, &implied_dirs, 0, ...}`
+    /// - `flist.c:2257-2258` - protocol >= 30 force-on
+    /// - `flist.c:2468` - `else if (implied_dirs && ...)` send gate
+    pub no_implied_dirs: bool,
     /// Keep partially transferred files (`P` flag, `--partial`).
     pub partial: bool,
     /// Update only newer files (`u` flag, `--update`).

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -91,7 +91,17 @@ impl GeneratorContext {
             if !self.try_walk_source_entry(&base, &path)? {
                 continue;
             }
-            if relative_paths {
+            // upstream: flist.c:2257-2258 - `if (relative_paths &&
+            // protocol_version >= 30) implied_dirs = 1;` forces the sender to
+            // emit flagged implied parent dirs at protocol >= 30 regardless of
+            // --no-implied-dirs. At protocol < 30 the flag is honoured
+            // (flist.c:2468 `else if (implied_dirs && ...)`), so
+            // --no-implied-dirs omits the implied parents from the flist and the
+            // receiver recreates them via make_path (generator.c:1317) without
+            // their source metadata. Mirror both: emit when implied dirs are on
+            // OR the protocol forces them.
+            if relative_paths && (!self.config.flags.no_implied_dirs || self.protocol.as_u8() >= 30)
+            {
                 self.emit_implied_parents(&base, &path, &mut implied_ancestors)?;
             }
         }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3142,10 +3142,16 @@ mod files_from {
             let mut ctx = GeneratorContext::new_for_test(&handshake, config);
             ctx.build_file_list(&[src_with_anchor]).unwrap();
 
+            // Compare the wire-form name (name_bytes normalises the
+            // platform-native separator to '/') rather than the internal
+            // PathBuf: on Windows a leaf name retains the '\' inserted by
+            // readdir's join (e.g. "usr/bin\\ar"), while the wire is always
+            // '/'-separated (flist.c:send_file_entry). This is what a POSIX
+            // peer receives and keeps the assertions portable.
             let names: Vec<String> = ctx
                 .file_list()
                 .iter()
-                .map(|e| e.path().to_string_lossy().into_owned())
+                .map(|e| String::from_utf8_lossy(&e.name_bytes()).into_owned())
                 .collect();
             assert!(
                 names.iter().any(|n| n == "usr/bin/ar"),

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3113,6 +3113,82 @@ mod files_from {
     }
 
     #[test]
+    fn implied_dirs_force_on_gated_to_protocol_30() {
+        // upstream: flist.c:2257-2258 - `if (relative_paths && protocol_version
+        // >= 30) implied_dirs = 1;` forces the sender to emit flagged implied
+        // parent dirs at protocol >= 30 regardless of --no-implied-dirs. At
+        // protocol < 30 the flag is honoured (flist.c:2468 `else if
+        // (implied_dirs && ...)`), so --no-implied-dirs omits the purely implied
+        // parents from the flist. Bug #266: oc emitted them unconditionally at
+        // every protocol, sending a larger file set than upstream to a proto-29
+        // peer under `--relative --no-implied-dirs`.
+        //
+        // Source `<tmp>/root/./usr/bin` walks `usr/bin` + `usr/bin/ar` (always
+        // present); only the purely implied parent `usr` is gated.
+        fn implied_parent_present(protocol: u8, no_implied_dirs: bool) -> bool {
+            let temp_dir = TempDir::new().unwrap();
+            let anchored = temp_dir.path().join("root");
+            let leaf = anchored.join("usr").join("bin");
+            std::fs::create_dir_all(&leaf).unwrap();
+            std::fs::write(leaf.join("ar"), b"x").unwrap();
+            let src_with_anchor =
+                PathBuf::from(format!("{}/./usr/bin", anchored.to_string_lossy()));
+
+            let handshake = test_handshake_with_protocol(protocol);
+            let mut config = test_config();
+            config.flags.relative = true;
+            config.flags.recursive = true;
+            config.flags.no_implied_dirs = no_implied_dirs;
+            let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+            ctx.build_file_list(&[src_with_anchor]).unwrap();
+
+            let names: Vec<String> = ctx
+                .file_list()
+                .iter()
+                .map(|e| e.path().to_string_lossy().into_owned())
+                .collect();
+            assert!(
+                names.iter().any(|n| n == "usr/bin/ar"),
+                "walked leaf must always be sent (proto={protocol}, \
+                 no_implied_dirs={no_implied_dirs}): {names:?}"
+            );
+            names.iter().any(|n| n == "usr")
+        }
+
+        // Default (implied dirs on): implied parents sent at every protocol.
+        assert!(
+            implied_parent_present(29, false),
+            "proto 29 default must emit implied parent 'usr'"
+        );
+        assert!(
+            implied_parent_present(30, false),
+            "proto 30 default must emit implied parent 'usr'"
+        );
+        assert!(
+            implied_parent_present(32, false),
+            "proto 32 default must emit implied parent 'usr'"
+        );
+
+        // --no-implied-dirs: omitted at protocol < 30, forced on at protocol >= 30.
+        assert!(
+            !implied_parent_present(28, true),
+            "proto 28 --no-implied-dirs must omit implied parent 'usr'"
+        );
+        assert!(
+            !implied_parent_present(29, true),
+            "proto 29 --no-implied-dirs must omit implied parent 'usr'"
+        );
+        assert!(
+            implied_parent_present(30, true),
+            "proto 30 forces implied parent 'usr' on despite --no-implied-dirs"
+        );
+        assert!(
+            implied_parent_present(32, true),
+            "proto 32 forces implied parent 'usr' on despite --no-implied-dirs"
+        );
+    }
+
+    #[test]
     fn non_relative_mode_emits_source_basename() {
         // upstream: flist.c:2338-2349 - non-relative mode splits each
         // positional on its last `/`: `dir` becomes the chdir target,


### PR DESCRIPTION
## Summary

Upstream `flist.c:2257-2258` forces implied dirs on **only** when
`relative_paths && protocol_version >= 30` ("we send flagged implied dirs").
At protocol < 30 the `--no-implied-dirs` flag is honoured, so the implied
parent directories are omitted from the file list (`flist.c:2468` gates the
non-incremental send on `implied_dirs`).

The sender generator emitted implied parents unconditionally whenever
`--relative` was active, at **every** protocol. So a protocol 28/29 transfer
with `--no-implied-dirs` put extra directory entries on the wire, sending a
larger file set than upstream to an old peer.

## Changes

- Thread the no-implied-dirs flag onto the sender's `ServerConfig`:
  SSH/daemon **push** via `apply_common_server_flags`; SSH/daemon **pull** via
  the server (`server/run.rs`) and daemon (`long_form_args.rs`) long-form arg
  parsers.
- Gate `emit_implied_parents` on `(!no_implied_dirs || protocol >= 30)`,
  mirroring upstream. Protocol >= 30 behaviour is byte-identical to before.
- Recognise `--no-implied-dirs` in the server-mode known-long-flag allowlist
  (`is_known_server_long_flag`) so the SSH server no longer mistakes it for a
  positional destination path. Previously **any** `--no-implied-dirs` transfer
  to an oc receiver failed with exit 12 (`failed to fill whole buffer`); the
  server tried to create a destination root literally named
  `--no-implied-dirs`.

## Empirical seal (aarch64 Linux, push over ssh)

Source `<abs>/src/a/b/file` transferred with `-a --relative`; the absolute
source has 6 implied parent dirs. `Number of files` is the sender flist size.

**Protocol 29 -> real rsync 2.6.9 receiver**

| sender / flags        | Number of files | verdict |
|-----------------------|-----------------|---------|
| upstream 3.4.4, default        | 7 (reg 1, dir 6) | reference |
| upstream 3.4.4, `--no-implied-dirs` | **1 (reg 1)** | reference: implied dirs omitted |
| oc before, default             | 7 | ok |
| oc before, `--no-implied-dirs` | **7** | BUG: implied dirs still sent |
| oc after,  default             | 7 | unchanged |
| oc after,  `--no-implied-dirs` | **1 (reg 1)** | FIXED: matches upstream |

**Protocol 32 (regression + desync check)**

| sender / flags        | Number of files | verdict |
|-----------------------|-----------------|---------|
| upstream, `--no-implied-dirs`  | 7 | proto >= 30 forces implied on |
| oc before, `--no-implied-dirs` | exit 12 desync | pre-existing receiver bug |
| oc after,  default             | 7 | unchanged |
| oc after,  `--no-implied-dirs` | 7 | forced on (upstream parity) + desync fixed |

Cross-version protocol 32 `--no-implied-dirs` (oc->oc, oc->upstream,
upstream->oc): all `EXIT=0` after the fix (was exit 12 to an oc receiver).

## Tests

- New `implied_dirs_force_on_gated_to_protocol_30` in
  `crates/transfer/src/generator/tests.rs` pins the gate across protocol
  28/29/30/32 for both default and `--no-implied-dirs`.
- `cargo fmt --all --check`, `cargo clippy -p transfer -p cli -p core -p daemon
  --all-targets --all-features -D warnings`: clean.

## Follow-ups (out of scope, pre-existing)

- The `--stats` reg/dir breakdown categorises implied dirs as `reg` on oc
  (`reg: 7`) vs upstream `reg: 1, dir: 6`; total count matches and the dest
  tree is correct. Separate stats-categorisation quirk.
- The `--files-from` implied-parent loop (`build_file_list_with_base`) has the
  same latent proto<30 gap but distinct dedup coupling; left untouched.
