### PR TITLE
fix(transfer): gate --files-from implied-dirs emission to protocol >= 30

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -223,28 +223,41 @@ impl GeneratorContext {
         // `try_walk_source_entry_dedup` to suppress the duplicate top-level
         // walk that would re-emit an implied parent.
         let mut emitted_dirs: HashSet<(PathBuf, PathBuf)> = explicit_dirs.clone();
-        for entry in entries {
-            if let Ok(rel) = entry.path.strip_prefix(&entry.base) {
-                // Walk each ancestor of the relative path and emit a
-                // directory entry when we haven't seen it yet.
-                let mut ancestor = PathBuf::new();
-                for component in rel.parent().into_iter().flat_map(Path::components) {
-                    ancestor.push(component);
-                    let key = (entry.base.clone(), ancestor.clone());
-                    if emitted_dirs.contains(&key) {
-                        continue;
-                    }
-                    let full = entry.base.join(&ancestor);
-                    if let Ok(meta) = std::fs::symlink_metadata(&full) {
-                        if meta.is_dir() {
-                            if let Ok(file_entry) =
-                                self.create_entry(&full, ancestor.clone(), &meta)
-                            {
-                                self.push_file_item(file_entry, full);
+        // upstream: flist.c:2257-2258 - `if (relative_paths && protocol_version
+        // >= 30) implied_dirs = 1;` forces flagged implied parent dirs at
+        // protocol >= 30 regardless of --no-implied-dirs; at protocol < 30 the
+        // flag is honoured (flist.c:2468 `else if (implied_dirs && ...)`), so
+        // --no-implied-dirs omits the implied parents from the --files-from
+        // flist and the receiver recreates them via make_path (generator.c:1317)
+        // without their source metadata. Mirror the same gate as the positional
+        // path (build_file_list): emit when implied dirs are on OR the protocol
+        // forces them. When suppressed, `emitted_dirs` stays equal to
+        // `explicit_dirs`, so `implied_only_dirs` below is empty and the
+        // explicit top-level walk is left untouched (dedup unchanged).
+        if !self.config.flags.no_implied_dirs || self.protocol.as_u8() >= 30 {
+            for entry in entries {
+                if let Ok(rel) = entry.path.strip_prefix(&entry.base) {
+                    // Walk each ancestor of the relative path and emit a
+                    // directory entry when we haven't seen it yet.
+                    let mut ancestor = PathBuf::new();
+                    for component in rel.parent().into_iter().flat_map(Path::components) {
+                        ancestor.push(component);
+                        let key = (entry.base.clone(), ancestor.clone());
+                        if emitted_dirs.contains(&key) {
+                            continue;
+                        }
+                        let full = entry.base.join(&ancestor);
+                        if let Ok(meta) = std::fs::symlink_metadata(&full) {
+                            if meta.is_dir() {
+                                if let Ok(file_entry) =
+                                    self.create_entry(&full, ancestor.clone(), &meta)
+                                {
+                                    self.push_file_item(file_entry, full);
+                                }
                             }
                         }
+                        emitted_dirs.insert(key);
                     }
-                    emitted_dirs.insert(key);
                 }
             }
         }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3195,6 +3195,88 @@ mod files_from {
     }
 
     #[test]
+    fn files_from_implied_dirs_gated_to_protocol_30() {
+        // Bug #268 (same class as #266): the --files-from implied-parent loop
+        // in `build_file_list_with_base` emitted purely implied parent dirs
+        // unconditionally, at every protocol. Upstream gates the send on
+        // `implied_dirs` (flist.c:2468), which --no-implied-dirs clears; the
+        // force-on at flist.c:2257-2258 only applies at protocol >= 30. So a
+        // proto-29 `--files-from --relative --no-implied-dirs` transfer must
+        // omit the purely implied parent, while proto >= 30 keeps it.
+        //
+        // Entry `<src>/usr/bin/ar` strips to rel `usr/bin/ar`; its purely
+        // implied parents are `usr` and `usr/bin`. The leaf file `usr/bin/ar`
+        // is always sent; only the implied parents are gated.
+        fn implied_parents_present(protocol: u8, no_implied_dirs: bool) -> (bool, bool) {
+            let temp_dir = TempDir::new().unwrap();
+            let src = temp_dir.path().join("src");
+            let leaf = src.join("usr").join("bin");
+            std::fs::create_dir_all(&leaf).unwrap();
+            std::fs::write(leaf.join("ar"), b"x").unwrap();
+
+            let handshake = test_handshake_with_protocol(protocol);
+            let mut config = test_config();
+            config.flags.relative = true;
+            config.flags.no_implied_dirs = no_implied_dirs;
+            config.args = vec![OsString::from(&src)];
+            let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+            let file_paths = vec![leaf.join("ar")];
+            ctx.build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
+                .unwrap();
+
+            let names: Vec<String> = ctx
+                .file_list()
+                .iter()
+                .map(|e| e.name().to_string())
+                .collect();
+            assert!(
+                names.iter().any(|n| n == "usr/bin/ar"),
+                "walked leaf must always be sent (proto={protocol}, \
+                 no_implied_dirs={no_implied_dirs}): {names:?}"
+            );
+            (
+                names.iter().any(|n| n == "usr"),
+                names.iter().any(|n| n == "usr/bin"),
+            )
+        }
+
+        // Default (implied dirs on): implied parents sent at every protocol.
+        assert_eq!(
+            implied_parents_present(29, false),
+            (true, true),
+            "proto 29 default must emit implied parents usr + usr/bin"
+        );
+        assert_eq!(
+            implied_parents_present(32, false),
+            (true, true),
+            "proto 32 default must emit implied parents usr + usr/bin"
+        );
+
+        // --no-implied-dirs: omitted at protocol < 30, forced on at protocol >= 30.
+        assert_eq!(
+            implied_parents_present(28, true),
+            (false, false),
+            "proto 28 --no-implied-dirs must omit implied parents"
+        );
+        assert_eq!(
+            implied_parents_present(29, true),
+            (false, false),
+            "proto 29 --no-implied-dirs must omit implied parents"
+        );
+        assert_eq!(
+            implied_parents_present(30, true),
+            (true, true),
+            "proto 30 forces implied parents on despite --no-implied-dirs"
+        );
+        assert_eq!(
+            implied_parents_present(32, true),
+            (true, true),
+            "proto 32 forces implied parents on despite --no-implied-dirs"
+        );
+    }
+
+    #[test]
     fn non_relative_mode_emits_source_basename() {
         // upstream: flist.c:2338-2349 - non-relative mode splits each
         // positional on its last `/`: `dir` becomes the chdir target,


### PR DESCRIPTION
## Summary

The `--files-from` implied-parent loop in `build_file_list_with_base` emitted
purely implied parent directory entries unconditionally, at every protocol,
whenever a listed path contained subdirectories. This is the same class of
wire-fidelity gap fixed for the positional `--relative` path in
`build_file_list`, but on a distinct code path (flagged out of scope there due
to its dedup coupling).

Upstream gates the implied-dir send on `implied_dirs` (flist.c:2468
`else if (implied_dirs && ...)`), which `--no-implied-dirs` clears. The force-on
at flist.c:2257-2258 (`if (relative_paths && protocol_version >= 30) implied_dirs = 1`)
only applies at protocol >= 30. So a protocol 28/29
`--files-from --relative --no-implied-dirs` transfer must omit the purely implied
parent dirs from the file list; oc emitted them, sending a larger file set than
upstream to a proto-29 peer.

## Change

Gate the implied-parent emission loop on `!no_implied_dirs || protocol >= 30`,
mirroring the positional-path gate. When suppressed, `emitted_dirs` stays equal
to `explicit_dirs`, so `implied_only_dirs` is empty and the explicit top-level
walk is left untouched - the dedup logic is unchanged. Protocol >= 30 behaviour
is byte-identical to before.

## Verification (real upstream, proto 29)

Verified with oc-rsync as sender over SSH to a real rsync 2.6.9 receiver
(protocol 29), compared against upstream rsync 3.4.4 as sender:

- `-ai --relative --no-implied-dirs --files-from` (proto 29): oc omits the
  implied parents `usr/` and `usr/bin/` from the file list, matching upstream's
  flist; destination trees identical.
- `-ai --relative --files-from` (proto 29, implied dirs on by default): oc emits
  `usr/`, `usr/bin/` matching upstream; destination trees identical.
- Protocol 32: implied dirs emitted regardless of `--no-implied-dirs` (upstream
  force-on preserved).

A unit test pins the gate across protocols 28/29/30/32 for both the default and
`--no-implied-dirs` cases.

## Note on base branch

This change reads `config.flags.no_implied_dirs`, introduced by the open PR that
gated the positional path. This PR is stacked on that branch and should be
retargeted to master once it merges (the diff then reduces to this single commit).
