### PR TITLE
fix(transfer): gate --files-from implied-dirs emission to protocol >= 30

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -223,28 +223,41 @@ impl GeneratorContext {
         // `try_walk_source_entry_dedup` to suppress the duplicate top-level
         // walk that would re-emit an implied parent.
         let mut emitted_dirs: HashSet<(PathBuf, PathBuf)> = explicit_dirs.clone();
-        for entry in entries {
-            if let Ok(rel) = entry.path.strip_prefix(&entry.base) {
-                // Walk each ancestor of the relative path and emit a
-                // directory entry when we haven't seen it yet.
-                let mut ancestor = PathBuf::new();
-                for component in rel.parent().into_iter().flat_map(Path::components) {
-                    ancestor.push(component);
-                    let key = (entry.base.clone(), ancestor.clone());
-                    if emitted_dirs.contains(&key) {
-                        continue;
-                    }
-                    let full = entry.base.join(&ancestor);
-                    if let Ok(meta) = std::fs::symlink_metadata(&full) {
-                        if meta.is_dir() {
-                            if let Ok(file_entry) =
-                                self.create_entry(&full, ancestor.clone(), &meta)
-                            {
-                                self.push_file_item(file_entry, full);
+        // upstream: flist.c:2257-2258 - `if (relative_paths && protocol_version
+        // >= 30) implied_dirs = 1;` forces flagged implied parent dirs at
+        // protocol >= 30 regardless of --no-implied-dirs; at protocol < 30 the
+        // flag is honoured (flist.c:2468 `else if (implied_dirs && ...)`), so
+        // --no-implied-dirs omits the implied parents from the --files-from
+        // flist and the receiver recreates them via make_path (generator.c:1317)
+        // without their source metadata. Mirror the same gate as the positional
+        // path (build_file_list): emit when implied dirs are on OR the protocol
+        // forces them. When suppressed, `emitted_dirs` stays equal to
+        // `explicit_dirs`, so `implied_only_dirs` below is empty and the
+        // explicit top-level walk is left untouched (dedup unchanged).
+        if !self.config.flags.no_implied_dirs || self.protocol.as_u8() >= 30 {
+            for entry in entries {
+                if let Ok(rel) = entry.path.strip_prefix(&entry.base) {
+                    // Walk each ancestor of the relative path and emit a
+                    // directory entry when we haven't seen it yet.
+                    let mut ancestor = PathBuf::new();
+                    for component in rel.parent().into_iter().flat_map(Path::components) {
+                        ancestor.push(component);
+                        let key = (entry.base.clone(), ancestor.clone());
+                        if emitted_dirs.contains(&key) {
+                            continue;
+                        }
+                        let full = entry.base.join(&ancestor);
+                        if let Ok(meta) = std::fs::symlink_metadata(&full) {
+                            if meta.is_dir() {
+                                if let Ok(file_entry) =
+                                    self.create_entry(&full, ancestor.clone(), &meta)
+                                {
+                                    self.push_file_item(file_entry, full);
+                                }
                             }
                         }
+                        emitted_dirs.insert(key);
                     }
-                    emitted_dirs.insert(key);
                 }
             }
         }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3225,10 +3225,15 @@ mod files_from {
             ctx.build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
                 .unwrap();
 
+            // Compare on the wire form (name_bytes, always '/'-separated via
+            // path_bytes_to_wire) rather than name() which returns the local
+            // PathBuf verbatim - on Windows that yields `usr\bin\ar`, so the
+            // multi-component assertions below would spuriously fail. The wire
+            // name is what the proto-gate actually governs.
             let names: Vec<String> = ctx
                 .file_list()
                 .iter()
-                .map(|e| e.name().to_string())
+                .map(|e| String::from_utf8_lossy(&e.name_bytes()).into_owned())
                 .collect();
             assert!(
                 names.iter().any(|n| n == "usr/bin/ar"),

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3195,6 +3195,88 @@ mod files_from {
     }
 
     #[test]
+    fn files_from_implied_dirs_gated_to_protocol_30() {
+        // Bug #268 (same class as #266): the --files-from implied-parent loop
+        // in `build_file_list_with_base` emitted purely implied parent dirs
+        // unconditionally, at every protocol. Upstream gates the send on
+        // `implied_dirs` (flist.c:2468), which --no-implied-dirs clears; the
+        // force-on at flist.c:2257-2258 only applies at protocol >= 30. So a
+        // proto-29 `--files-from --relative --no-implied-dirs` transfer must
+        // omit the purely implied parent, while proto >= 30 keeps it.
+        //
+        // Entry `<src>/usr/bin/ar` strips to rel `usr/bin/ar`; its purely
+        // implied parents are `usr` and `usr/bin`. The leaf file `usr/bin/ar`
+        // is always sent; only the implied parents are gated.
+        fn implied_parents_present(protocol: u8, no_implied_dirs: bool) -> (bool, bool) {
+            let temp_dir = TempDir::new().unwrap();
+            let src = temp_dir.path().join("src");
+            let leaf = src.join("usr").join("bin");
+            std::fs::create_dir_all(&leaf).unwrap();
+            std::fs::write(leaf.join("ar"), b"x").unwrap();
+
+            let handshake = test_handshake_with_protocol(protocol);
+            let mut config = test_config();
+            config.flags.relative = true;
+            config.flags.no_implied_dirs = no_implied_dirs;
+            config.args = vec![OsString::from(&src)];
+            let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+            let file_paths = vec![leaf.join("ar")];
+            ctx.build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
+                .unwrap();
+
+            let names: Vec<String> = ctx
+                .file_list()
+                .iter()
+                .map(|e| e.name().to_string())
+                .collect();
+            assert!(
+                names.iter().any(|n| n == "usr/bin/ar"),
+                "walked leaf must always be sent (proto={protocol}, \
+                 no_implied_dirs={no_implied_dirs}): {names:?}"
+            );
+            (
+                names.iter().any(|n| n == "usr"),
+                names.iter().any(|n| n == "usr/bin"),
+            )
+        }
+
+        // Default (implied dirs on): implied parents sent at every protocol.
+        assert_eq!(
+            implied_parents_present(29, false),
+            (true, true),
+            "proto 29 default must emit implied parents usr + usr/bin"
+        );
+        assert_eq!(
+            implied_parents_present(32, false),
+            (true, true),
+            "proto 32 default must emit implied parents usr + usr/bin"
+        );
+
+        // --no-implied-dirs: omitted at protocol < 30, forced on at protocol >= 30.
+        assert_eq!(
+            implied_parents_present(28, true),
+            (false, false),
+            "proto 28 --no-implied-dirs must omit implied parents"
+        );
+        assert_eq!(
+            implied_parents_present(29, true),
+            (false, false),
+            "proto 29 --no-implied-dirs must omit implied parents"
+        );
+        assert_eq!(
+            implied_parents_present(30, true),
+            (true, true),
+            "proto 30 forces implied parents on despite --no-implied-dirs"
+        );
+        assert_eq!(
+            implied_parents_present(32, true),
+            (true, true),
+            "proto 32 forces implied parents on despite --no-implied-dirs"
+        );
+    }
+
+    #[test]
     fn non_relative_mode_emits_source_basename() {
         // upstream: flist.c:2338-2349 - non-relative mode splits each
         // positional on its last `/`: `dir` becomes the chdir target,


### PR DESCRIPTION
Gates the `--files-from` implied-parent emission loop in `build_file_list_with_base` on `!no_implied_dirs || protocol >= 30`, mirroring the main sender gate (flist.c:2257-2258 / flist.c:2468). At protocol 28/29 with `--relative --no-implied-dirs`, oc previously over-sent purely-implied parent dir entries vs upstream.

Sealed on lxhost vs real rsync 2.6.9 (protocol 29): `--no-implied-dirs` omits the implied parents (dest-identical to upstream), default still emits them, proto 32 force-on preserved. Dedup preserved (`emitted_dirs == explicit_dirs` when suppressed). Unit test pins protocols 28/29/30/32 for both default and `--no-implied-dirs`.

Supersedes the auto-closed stacked PR (rebased onto master after the implied-dirs proto-gate landed).