### PR TITLE
fix(cli): honor --protocol=NUM over ssh/remote-shell (upstream setup_protocol cap)

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -20,6 +20,9 @@ use crate::platform::{gid_t, uid_t};
 /// All inputs required to assemble the base [`ClientConfig`] before filters are applied.
 pub(crate) struct ConfigInputs {
     pub(crate) transfer_operands: Vec<OsString>,
+    /// Optional `--protocol=N` ceiling that caps the negotiated protocol version
+    /// for remote (SSH and daemon) transfers. `None` uses the default ceiling.
+    pub(crate) desired_protocol: Option<protocol::ProtocolVersion>,
     pub(crate) address_mode: AddressMode,
     pub(crate) connect_program: Option<OsString>,
     pub(crate) bind_address: Option<core::client::BindAddress>,
@@ -196,6 +199,7 @@ pub(crate) struct ConfigInputs {
 pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder {
     let mut builder = ClientConfig::builder()
         .transfer_args(std::mem::take(&mut inputs.transfer_operands))
+        .protocol_version(inputs.desired_protocol)
         .address_mode(inputs.address_mode)
         .connect_program(inputs.connect_program.clone())
         .bind_address(inputs.bind_address.clone())

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -821,6 +821,7 @@ where
 
     let config_inputs = config::ConfigInputs {
         transfer_operands,
+        desired_protocol,
         address_mode,
         connect_program: connect_program.clone(),
         bind_address,

--- a/crates/core/src/client/remote/async_ssh_transport.rs
+++ b/crates/core/src/client/remote/async_ssh_transport.rs
@@ -565,8 +565,9 @@ fn run_blocking_server(
         build_batch_recording(ctx, is_sender)
     });
 
-    let handshake = crate::server::perform_handshake(&mut reader, &mut writer)
-        .map_err(|e| invalid_argument_error(&format!("async SSH handshake failed: {e}"), 5))?;
+    let handshake =
+        crate::server::perform_handshake_with_max(&mut reader, &mut writer, config.protocol)
+            .map_err(|e| invalid_argument_error(&format!("async SSH handshake failed: {e}"), 5))?;
     let negotiated_protocol = handshake.protocol.as_u8();
 
     let transfer_result = crate::server::run_server_with_handshake(

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -355,8 +355,9 @@ fn run_transfer_over_embedded_ssh(
         build_batch_recording(ctx, is_sender)
     });
 
-    let handshake = crate::server::perform_handshake(&mut reader, &mut writer)
-        .map_err(|e| invalid_argument_error(&format!("handshake failed: {e}"), 5))?;
+    let handshake =
+        crate::server::perform_handshake_with_max(&mut reader, &mut writer, server_config.protocol)
+            .map_err(|e| invalid_argument_error(&format!("handshake failed: {e}"), 5))?;
     let negotiated_protocol = handshake.protocol.as_u8();
 
     let mut adapter = observer.map(|obs| ServerProgressAdapter::new(obs, start));

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -331,6 +331,14 @@ fn split_pattern_modifiers(raw: &str) -> (String, bool, bool) {
 /// for both receiver and generator roles: `trust_sender`, `qsort`, `inplace`,
 /// `min_file_size`, `max_file_size`, `do_stats`, `late_delete`, and `itemize`.
 pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &mut ServerConfig) {
+    // upstream: options.c:846 / compat.c:604-607 - `--protocol=N` lowers the
+    // advertised `protocol_version`, capping the negotiated version. Carry the
+    // requested ceiling onto the in-process ServerConfig so the SSH handshake
+    // clamps to it (the daemon path reads config.protocol_version() directly).
+    // Defaults to NEWEST when unset, reproducing the uncapped negotiation.
+    server_config.protocol = config
+        .protocol_version()
+        .unwrap_or(protocol::ProtocolVersion::NEWEST);
     server_config.trust_sender = config.trust_sender();
     server_config.qsort = config.qsort();
     server_config.write.inplace = config.inplace();

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -288,7 +288,11 @@ fn run_server_over_ssh_connection(
         build_batch_recording(ctx, is_sender)
     });
 
-    let handshake = match crate::server::perform_handshake(&mut reader, &mut writer) {
+    let handshake = match crate::server::perform_handshake_with_max(
+        &mut reader,
+        &mut writer,
+        config.protocol,
+    ) {
         Ok(h) => h,
         Err(e) => {
             // Close our writer so the remote can finish exiting, then reap the

--- a/crates/transfer/src/handshake.rs
+++ b/crates/transfer/src/handshake.rs
@@ -60,10 +60,27 @@ pub fn perform_handshake(
     stdin: &mut dyn Read,
     stdout: &mut dyn Write,
 ) -> io::Result<HandshakeResult> {
+    perform_handshake_with_max(stdin, stdout, ProtocolVersion::NEWEST)
+}
+
+/// Performs the version handshake while advertising at most `max_version`.
+///
+/// `max_version` caps both the version we advertise and the version we accept
+/// as negotiated, mirroring the upstream `--protocol=N` flag. Upstream stores
+/// the requested value in `protocol_version` (options.c:846) - already lowered
+/// from the `PROTOCOL_VERSION` default - and `setup_protocol()` writes it, reads
+/// the peer's version, then clamps with `protocol_version = MIN(protocol_version,
+/// remote_protocol)` (compat.c:604-607). Passing `ProtocolVersion::NEWEST` (the
+/// default) reproduces the uncapped behaviour.
+pub fn perform_handshake_with_max(
+    stdin: &mut dyn Read,
+    stdout: &mut dyn Write,
+    max_version: ProtocolVersion,
+) -> io::Result<HandshakeResult> {
     // upstream: compat.c:602-604 - write our max version first, then read.
     // Both sides do this simultaneously; reversing the order deadlocks when
     // both ends are oc-rsync (each waits for the other to write first).
-    write_server_version(stdout, ProtocolVersion::NEWEST)?;
+    write_server_version(stdout, max_version)?;
     stdout.flush()?;
 
     let remote_version = read_client_version(stdin)?;
@@ -77,6 +94,10 @@ pub fn perform_handshake(
             ),
         )
     })?;
+    // upstream: compat.c:606-607 - protocol_version = MIN(protocol_version,
+    // remote_protocol). Clamp the mutually-supported version to our advertised
+    // ceiling so `--protocol=N` caps the negotiated version.
+    let negotiated = negotiated.min(max_version);
 
     Ok(HandshakeResult {
         protocol: negotiated,
@@ -216,6 +237,55 @@ mod tests {
         // Server should respond with 4-byte version
         assert_eq!(stdout.len(), 4);
         assert_eq!(stdout[0], 32);
+    }
+
+    #[test]
+    fn max_version_caps_negotiated_below_remote() {
+        // Remote advertises 32; we cap to 29 via --protocol=29. The negotiated
+        // version must clamp to 29 and we must advertise 29 on the wire so the
+        // peer's own MIN(remote, ours) converges to 29 too.
+        // upstream: compat.c:604-607
+        let mut stdin = Cursor::new(vec![32, 0, 0, 0]);
+        let mut stdout = Vec::new();
+
+        let result = perform_handshake_with_max(&mut stdin, &mut stdout, ProtocolVersion::V29)
+            .expect("handshake succeeds");
+        assert_eq!(result.protocol, ProtocolVersion::V29);
+        assert_eq!(stdout[0], 29, "must advertise the capped version");
+    }
+
+    #[test]
+    fn max_version_does_not_raise_below_remote() {
+        // We cap to 32 (default) but the remote only offers 30: negotiate 30.
+        let mut stdin = Cursor::new(vec![30, 0, 0, 0]);
+        let mut stdout = Vec::new();
+
+        let result = perform_handshake_with_max(&mut stdin, &mut stdout, ProtocolVersion::V32)
+            .expect("handshake succeeds");
+        assert_eq!(result.protocol, ProtocolVersion::V30);
+        assert_eq!(stdout[0], 32);
+    }
+
+    #[test]
+    fn max_version_30_and_31_are_honored() {
+        for (cap, expected) in [(ProtocolVersion::V30, 30u8), (ProtocolVersion::V31, 31u8)] {
+            let mut stdin = Cursor::new(vec![32, 0, 0, 0]);
+            let mut stdout = Vec::new();
+            let result = perform_handshake_with_max(&mut stdin, &mut stdout, cap)
+                .expect("handshake succeeds");
+            assert_eq!(result.protocol.as_u8(), expected);
+            assert_eq!(stdout[0], expected);
+        }
+    }
+
+    #[test]
+    fn default_handshake_advertises_newest() {
+        // The no-cap path is byte-identical to advertising NEWEST.
+        let mut stdin = Cursor::new(vec![32, 0, 0, 0]);
+        let mut stdout = Vec::new();
+        let result = perform_handshake(&mut stdin, &mut stdout).expect("handshake succeeds");
+        assert_eq!(result.protocol, ProtocolVersion::NEWEST);
+        assert_eq!(stdout[0], ProtocolVersion::NEWEST.as_u8());
     }
 
     #[test]

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -173,7 +173,9 @@ pub use self::flags::{InfoFlags, NumericIds, ParseFlagError, ParsedServerFlags};
 pub use self::generator::{
     GeneratorContext, GeneratorStats, generate_delta_from_signature, io_error_flags,
 };
-pub use self::handshake::{HandshakeResult, perform_handshake, perform_legacy_handshake};
+pub use self::handshake::{
+    HandshakeResult, perform_handshake, perform_handshake_with_max, perform_legacy_handshake,
+};
 pub use self::reader::RemoteExitError;
 pub use self::receiver::{ListOnlyEntry, ReceiverContext, SumHead, TransferStats};
 pub use self::role::ServerRole;


### PR DESCRIPTION
## Summary

`--protocol=NUM` was accepted but **silently ignored** over ssh/remote-shell: the sender always advertised the newest protocol, so a forced `--protocol=29 -e ssh` still negotiated protocol 32. Upstream honors `--protocol` on every transport by lowering the advertised `protocol_version` and clamping the negotiated value with `protocol_version = MIN(protocol_version, remote_protocol)` in `setup_protocol` (compat.c:604-607). The value was never threaded into the transfer negotiation.

## Fix

Route the requested ceiling through the existing version-negotiation path (single source), without touching the wire format:

- CLI `--protocol` now flows into `ClientConfig.protocol_version` (`ConfigInputs.desired_protocol` -> `build_base_config`).
- `apply_common_server_flags` carries it onto the in-process `ServerConfig.protocol` (already documented as "Requested protocol version; capped during handshake"). Defaults to `NEWEST` when unset.
- New `perform_handshake_with_max(stdin, stdout, max_version)` advertises `max_version` and clamps the negotiated version to it, mirroring upstream's `MIN(protocol_version, remote_protocol)`. `perform_handshake` is now a thin wrapper passing `NEWEST`, so uncapped negotiation is byte-identical to before.
- The three ssh client handshake sites (system ssh, embedded ssh, async ssh) pass `config.protocol`. The real `--server` path keeps advertising `NEWEST` (upstream never forwards `--protocol` to the server).

Out-of-range values are already rejected at parse time against oc's supported 28-32 range (exit code 2, protocol incompatibility).

## Verification (vs upstream rsync 3.4.4, aarch64)

Advertised wire byte captured via a `tee` `--rsync-path` wrapper (byte 0 of the client->server stream is the advertised protocol version):

| command | advertised | transfer |
|---|---|---|
| `oc -a --protocol=29 -e ssh` | 29 | diff -r empty |
| `oc -a --protocol=30 -e ssh` | 30 | diff -r empty |
| `oc -a --protocol=31 -e ssh` | 31 | diff -r empty |
| `oc -a --protocol=32 -e ssh` | 32 | diff -r empty |
| `oc -a -e ssh` (no flag) | 32 | diff -r empty |

Cross-check: upstream `rsync --protocol=29/30/32 -e ssh` advertises the identical bytes (29/30/32) and transfers identically. oc<->oc over ssh honors 29/30/32 too. Before this change the sender stayed at 32 regardless of `--protocol`.

Out-of-range: `oc --protocol=99` errors with exit 2 (`protocol version 99 is outside the supported range 28-32`), matching upstream's rejection of 99. oc's implemented floor is 28 (upstream negotiates down to 20), so oc also rejects 20-27 with the same clear error rather than advertising an untested protocol.

## Tests

Added handshake unit tests pinning the cap: `--protocol=29` clamps a remote-32 peer to 29 and advertises 29 on the wire; 30/31 honored; the uncapped path stays byte-identical to advertising `NEWEST`; a below-remote cap does not raise the negotiated version. `cargo fmt`, `cargo clippy -D warnings` (cli/core/transfer/protocol) clean.
