### PR TITLE
fix(transfer): itemize existing-directory time change on remote pull

### DIFF
--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -331,12 +331,17 @@ impl ReceiverContext {
                     )
                 } else {
                     // upstream: generator.c:1482 - existing dir is itemize()'d
-                    // with statret == 0 and iflags == 0; emit_itemize's
-                    // standard gate then drops the row when nothing is
-                    // significant, while the root-dir compensation in
-                    // emit_itemize still fires `cd+++++++++ ./` when the
-                    // pre-flight mkdir created the destination root.
-                    crate::generator::ItemFlags::from_raw(0)
+                    // with statret == 0. itemize() (generator.c:511-572) still
+                    // compares the pre-apply dest stat against the sender entry
+                    // and sets ITEM_REPORT_{TIME,PERMS,OWNER,GROUP} for any
+                    // attribute that differs; the transfer root `.` therefore
+                    // reports `.d..t......` when its mtime differs. The stat is
+                    // read here, before the parallel metadata pass below applies
+                    // the source values, so it reflects the pre-transfer state.
+                    // emit_itemize's standard gate drops the row when nothing
+                    // differs, and the root-dir compensation still fires
+                    // `cd+++++++++ ./` when the pre-flight mkdir created the root.
+                    crate::generator::ItemFlags::from_raw(self.existing_dir_iflags(entry, dir_path))
                 };
                 let _ = self.emit_itemize(writer, &iflags, entry);
             }
@@ -506,14 +511,21 @@ impl ReceiverContext {
     /// Creates a single directory during incremental processing.
     ///
     /// Returns `Ok(None)` on failure or skip (marks dir as failed).
-    /// Returns `Ok(Some(true))` when a new directory was created.
-    /// Returns `Ok(Some(false))` when an existing directory had metadata applied.
-    /// Only returns `Err` for unrecoverable errors.
+    /// Returns `Ok(Some((true, iflags)))` when a new directory was created.
+    /// Returns `Ok(Some((false, iflags)))` when an existing directory had
+    /// metadata applied. In both cases `iflags` are the raw itemize flags the
+    /// caller should emit: for a new dir, `ITEM_LOCAL_CHANGE | ITEM_IS_NEW`;
+    /// for an existing dir, the attribute-diff flags computed against the
+    /// pre-apply destination stat (`ITEM_REPORT_{TIME,PERMS,OWNER,GROUP}`),
+    /// mirroring upstream's `itemize()` at `generator.c:1481` which runs before
+    /// `set_file_attrs` (`generator.c:1503`). Only returns `Err` for
+    /// unrecoverable errors.
     ///
     /// # Upstream Reference
     ///
     /// - `generator.c:1432` - `recv_generator()` creates directories
     /// - `generator.c:1472-1475` - retry `mkdir` after `make_path()`
+    /// - `generator.c:1480-1483` - `itemize()` before metadata application
     pub(in crate::receiver) fn create_directory_incremental(
         &self,
         dest_dir: &Path,
@@ -523,7 +535,7 @@ impl ReceiverContext {
         acl_cache: Option<&AclCache>,
         acl_id_map: Option<&AclIdMapper>,
         #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
-    ) -> io::Result<Option<bool>> {
+    ) -> io::Result<Option<(bool, u32)>> {
         let relative_path = entry.path();
         let dir_path = if relative_path.as_os_str() == "." {
             dest_dir.to_path_buf()
@@ -589,6 +601,19 @@ impl ReceiverContext {
             failed_dirs.mark_failed(entry.name());
             return Ok(None);
         }
+        // upstream: generator.c:1480-1483 - itemize() runs before set_file_attrs
+        // (generator.c:1503), so compute the itemize flags from the pre-apply
+        // destination stat here. A new dir reports ITEM_LOCAL_CHANGE|ITEM_IS_NEW
+        // (`cd+++++++++`); an existing dir reports the attribute-diff flags
+        // (ITEM_REPORT_{TIME,PERMS,OWNER,GROUP}) so a differing root `.` mtime
+        // emits `.d..t......`. For an existing dir the stat must be read now,
+        // before apply_metadata_with_cached_stat below overwrites the mtime.
+        let iflags: u32 = if is_new {
+            crate::generator::ItemFlags::ITEM_LOCAL_CHANGE
+                | crate::generator::ItemFlags::ITEM_IS_NEW
+        } else {
+            self.existing_dir_iflags(entry, &dir_path)
+        };
         if is_new {
             #[cfg(unix)]
             let create_result = fast_io::mkdirat_via_sandbox_or_fallback(
@@ -705,7 +730,7 @@ impl ReceiverContext {
             }
         }
 
-        Ok(Some(is_new))
+        Ok(Some((is_new, iflags)))
     }
 
     /// Restores directory permissions and mtimes after all file transfers

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -22,6 +22,34 @@ impl ReceiverContext {
         self.config.flags.info_flags.itemize
     }
 
+    /// Computes the itemize flags for an existing (already-present) directory
+    /// by comparing its current on-disk metadata against the sender's file-list
+    /// entry, mirroring upstream `generator.c:1480-1483` -> `itemize()` for the
+    /// `statret == 0` directory branch.
+    ///
+    /// Upstream's `itemize()` sets `ITEM_REPORT_TIME` for a directory whenever
+    /// `mtime_differs(&sxp->st, file)` (`generator.c:526-530`, `keep_time` true
+    /// for a dir under `--times`), independent of `--checksum`: the transfer
+    /// root `.` therefore emits `.d..t......` when the destination directory
+    /// mtime differs from the source. The previous receiver behaviour passed
+    /// `iflags == 0` for every existing directory, so this row was never
+    /// produced on a remote pull.
+    ///
+    /// Must be called BEFORE the directory's metadata is (re)applied so the
+    /// stat reflects the pre-transfer state upstream's `itemize()` compares
+    /// against. Returns raw flags (0 when nothing differs or the stat fails,
+    /// matching upstream's benign "no change" outcome).
+    pub(in crate::receiver) fn existing_dir_iflags(
+        &self,
+        entry: &protocol::flist::FileEntry,
+        dir_path: &std::path::Path,
+    ) -> u32 {
+        match std::fs::metadata(dir_path) {
+            Ok(meta) => self.itemize_existing_flags(entry, &meta, 0),
+            Err(_) => 0,
+        }
+    }
+
     /// Routes an already-formatted info line (itemize, skip notice) to the
     /// correct sink: a server receiver multiplexes it as `MSG_INFO`; a client
     /// receiver (pull) writes it directly to stdout.
@@ -96,11 +124,15 @@ impl ReceiverContext {
         if !is_created_root_dir && !show_unchanged && !iflags.has_significant_flags() {
             return None;
         }
-        let effective_iflags = if is_created_root_dir && !iflags.has_significant_flags() {
-            // upstream: generator.c:1468-1471 + generator.c:566-572 - itemize()
-            // with `statret < 0` ORs `ITEM_LOCAL_CHANGE | ITEM_IS_NEW`. Apply
-            // the same bits here so `format_itemize_line` emits the full
-            // `cd+++++++++` glyph instead of `.d ...`.
+        let effective_iflags = if is_created_root_dir {
+            // upstream: generator.c:1468-1471 + generator.c:566-572 - a root that
+            // the pre-flight mkdir created this run is itemize()'d with
+            // `statret < 0`, which takes the `else` branch and ORs
+            // `ITEM_LOCAL_CHANGE | ITEM_IS_NEW` WITHOUT computing any attribute
+            // diff. Force the same bits here so a created root always renders the
+            // full `cd+++++++++` glyph, even though `existing_dir_iflags` (which
+            // classifies the already-mkdir'd root as "existing") may have
+            // computed a spurious `ITEM_REPORT_TIME` against the fresh dir mtime.
             crate::generator::ItemFlags::from_raw(
                 crate::generator::ItemFlags::ITEM_LOCAL_CHANGE
                     | crate::generator::ItemFlags::ITEM_IS_NEW,

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -222,7 +222,8 @@ mod create_directory_incremental_tests {
         );
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), Some(true)); // Returns Some(true) for new dir
+        // Returns Some((true, _)) for a newly created dir.
+        assert_eq!(result.unwrap().map(|(is_new, _)| is_new), Some(true));
         assert!(dest.join("subdir").exists());
         assert_eq!(failed.count(), 0);
     }
@@ -301,10 +302,119 @@ mod create_directory_incremental_tests {
         );
 
         assert!(result.is_ok());
-        // Returns Some(false): existing dir, not newly created.
-        assert_eq!(result.unwrap(), Some(false));
+        // Returns Some((false, _)): existing dir, not newly created.
+        assert_eq!(result.unwrap().map(|(is_new, _)| is_new), Some(false));
         assert!(dest.join("present").exists());
         assert_eq!(failed.count(), 0);
+    }
+
+    /// An existing destination directory whose mtime differs from the sender
+    /// entry must report `ITEM_REPORT_TIME`, so the transfer root `.` (and any
+    /// existing directory) emits a `.d..t......` itemize row.
+    ///
+    /// WHY: upstream's `itemize()` (`generator.c:511-572`, reached from
+    /// `generator.c:1480-1483` with `statret == 0`) sets `ITEM_REPORT_TIME`
+    /// whenever `mtime_differs(&sxp->st, file)` for a directory under `--times`
+    /// (`keep_time` true). This is independent of `--checksum`: a quick-check
+    /// hunt surfaced it under `-c` because content-identical files are skipped
+    /// while the root directory's mtime still differs. The prior receiver
+    /// passed `iflags == 0` for every existing directory, so this row was never
+    /// produced on a remote pull, diverging from upstream. The flags are
+    /// computed against the pre-apply stat (before this call re-sets the
+    /// directory mtime), matching upstream's itemize-before-set_file_attrs order.
+    #[test]
+    fn existing_directory_with_differing_mtime_reports_time_change() {
+        use crate::generator::ItemFlags;
+
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path();
+        let present = dest.join("present");
+        std::fs::create_dir(&present).unwrap();
+
+        // Backdate the on-disk directory so its mtime differs from the entry.
+        let old = filetime::FileTime::from_unix_time(1_500_000_000, 0);
+        filetime::set_file_mtime(&present, old).unwrap();
+
+        // Sender entry carries a newer mtime (2021-01-01 vs the 2017 on disk).
+        let mut entry = FileEntry::new_directory("present".into(), 0o755);
+        entry.set_mtime(1_609_459_200, 0);
+
+        let opts = metadata::MetadataOptions::default();
+        let mut failed = FailedDirectories::new();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.flags.times = true;
+        let ctx = ReceiverContext::new_for_test(&handshake, config);
+
+        let result = ctx
+            .create_directory_incremental(
+                dest,
+                &entry,
+                &opts,
+                &mut failed,
+                None,
+                None,
+                #[cfg(unix)]
+                None,
+            )
+            .expect("create_directory_incremental succeeds");
+
+        let (is_new, iflags) = result.expect("existing dir returns Some");
+        assert!(!is_new, "the directory already existed");
+        assert_ne!(
+            iflags & ItemFlags::ITEM_REPORT_TIME,
+            0,
+            "a differing directory mtime must set ITEM_REPORT_TIME (upstream .d..t......)"
+        );
+    }
+
+    /// The mirror-image gate: an existing directory whose mtime already matches
+    /// the sender entry must NOT set `ITEM_REPORT_TIME`, so the significance
+    /// gate drops the row exactly as upstream does when nothing changed.
+    #[test]
+    fn existing_directory_with_matching_mtime_reports_no_time_change() {
+        use crate::generator::ItemFlags;
+
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path();
+        let present = dest.join("present");
+        std::fs::create_dir(&present).unwrap();
+
+        let when = filetime::FileTime::from_unix_time(1_609_459_200, 0);
+        filetime::set_file_mtime(&present, when).unwrap();
+
+        let mut entry = FileEntry::new_directory("present".into(), 0o755);
+        entry.set_mtime(1_609_459_200, 0);
+
+        let opts = metadata::MetadataOptions::default();
+        let mut failed = FailedDirectories::new();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.flags.times = true;
+        let ctx = ReceiverContext::new_for_test(&handshake, config);
+
+        let (is_new, iflags) = ctx
+            .create_directory_incremental(
+                dest,
+                &entry,
+                &opts,
+                &mut failed,
+                None,
+                None,
+                #[cfg(unix)]
+                None,
+            )
+            .expect("create_directory_incremental succeeds")
+            .expect("existing dir returns Some");
+
+        assert!(!is_new, "the directory already existed");
+        assert_eq!(
+            iflags & ItemFlags::ITEM_REPORT_TIME,
+            0,
+            "a matching directory mtime must not set ITEM_REPORT_TIME"
+        );
     }
 
     #[test]
@@ -389,7 +499,9 @@ mod create_directory_incremental_tests {
         // The conflicting symlink is removed and a real directory is created:
         // upstream reports `FLAG_DIR_CREATED`, so this is a freshly made dir.
         assert_eq!(
-            result.expect("classifier replaces the symlink and mkdirs a real directory"),
+            result
+                .expect("classifier replaces the symlink and mkdirs a real directory")
+                .map(|(is_new, _)| is_new),
             Some(true),
             "a conflicting symlink at a dir target must be replaced, not skipped"
         );
@@ -510,7 +622,7 @@ mod create_directory_incremental_tests {
         // Root (or a non-DAC-respecting filesystem) bypasses chmod so
         // mkdir succeeds. Only enforce the upstream-parity branch when
         // the kernel actually produced EACCES.
-        let succeeded_under_root = matches!(&result, Ok(Some(true)));
+        let succeeded_under_root = matches!(&result, Ok(Some((true, _))));
         if succeeded_under_root {
             return;
         }
@@ -602,7 +714,7 @@ mod incremental_mode_tests {
         );
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), Some(true));
+        assert_eq!(result.unwrap().map(|(is_new, _)| is_new), Some(true));
         assert!(dest.join("a/b/c").exists());
     }
 

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -362,9 +362,13 @@ impl ReceiverContext {
     /// up-to-date file (quick-check match). The returned raw flags OR `base`
     /// with `ITEM_REPORT_{SIZE,TIME,PERMS,OWNER,GROUP}` for every attribute that
     /// differs between `entry` (the sender's view) and `dest_meta` (the
-    /// pre-transfer destination stat). Only regular-file candidates reach this
-    /// path, so `keep_time` reduces to the `--times` preservation flag.
-    fn itemize_existing_flags(
+    /// pre-transfer destination stat). Both regular files (quick-check match)
+    /// and existing directories reach this path: the `ITEM_REPORT_SIZE` check
+    /// is gated on `entry.is_file()` so it never fires for a directory, and
+    /// `keep_time` reduces to the `--times` preservation flag in both cases
+    /// (`--omit-dir-times` is not modelled by the server flag set, matching
+    /// [`super::super::directory::creation`]'s `touch_up_dirs`).
+    pub(in crate::receiver) fn itemize_existing_flags(
         &self,
         entry: &FileEntry,
         dest_meta: &fs::Metadata,

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -74,18 +74,17 @@ impl ReceiverContext {
                     setup.sandbox.as_deref(),
                 )?;
                 match result {
-                    Some(true) => {
-                        stats.directories_created += 1;
-                        // upstream: generator.c:1432 - itemize new directory
-                        let iflags = crate::generator::ItemFlags::from_raw(
-                            crate::generator::ItemFlags::ITEM_LOCAL_CHANGE
-                                | crate::generator::ItemFlags::ITEM_IS_NEW,
-                        );
-                        let _ = self.emit_itemize(writer, &iflags, file_entry);
-                    }
-                    Some(false) => {
-                        // upstream: generator.c:2260 - existing dir, metadata only
-                        let iflags = crate::generator::ItemFlags::from_raw(0);
+                    Some((is_new, iflags_raw)) => {
+                        if is_new {
+                            stats.directories_created += 1;
+                        }
+                        // upstream: generator.c:1480-1483 - itemize each dir with
+                        // the flags computed against its pre-apply stat. A new dir
+                        // carries ITEM_LOCAL_CHANGE|ITEM_IS_NEW; an existing dir
+                        // carries the attribute-diff flags (so a differing root
+                        // `.` mtime emits `.d..t......`). emit_itemize's gate
+                        // drops the row when nothing is significant.
+                        let iflags = crate::generator::ItemFlags::from_raw(iflags_raw);
                         let _ = self.emit_itemize(writer, &iflags, file_entry);
                     }
                     None => {

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
@@ -93,18 +93,17 @@ impl ReceiverContext {
                     setup.sandbox.as_deref(),
                 )?;
                 match result {
-                    Some(true) => {
-                        stats.directories_created += 1;
-                        // upstream: generator.c:1432 - itemize new directory
-                        let iflags = crate::generator::ItemFlags::from_raw(
-                            crate::generator::ItemFlags::ITEM_LOCAL_CHANGE
-                                | crate::generator::ItemFlags::ITEM_IS_NEW,
-                        );
-                        let _ = self.emit_itemize(writer, &iflags, file_entry);
-                    }
-                    Some(false) => {
-                        // upstream: generator.c:2260 - existing dir, metadata only
-                        let iflags = crate::generator::ItemFlags::from_raw(0);
+                    Some((is_new, iflags_raw)) => {
+                        if is_new {
+                            stats.directories_created += 1;
+                        }
+                        // upstream: generator.c:1480-1483 - itemize each dir with
+                        // the flags computed against its pre-apply stat. A new dir
+                        // carries ITEM_LOCAL_CHANGE|ITEM_IS_NEW; an existing dir
+                        // carries the attribute-diff flags (so a differing root
+                        // `.` mtime emits `.d..t......`). emit_itemize's gate
+                        // drops the row when nothing is significant.
+                        let iflags = crate::generator::ItemFlags::from_raw(iflags_raw);
                         let _ = self.emit_itemize(writer, &iflags, file_entry);
                     }
                     None => {


### PR DESCRIPTION
The transfer receiver emitted `iflags == 0` for every existing destination
directory, so a directory whose mtime differs from the sender never produced
an itemize row on a remote pull.

Upstream `itemize()` (generator.c:511-572, reached from generator.c:1480-1483
with `statret == 0`) sets `ITEM_REPORT_TIME` whenever `mtime_differs()` for a
directory under `--times`, independent of `--checksum`. The transfer root `.`
therefore reports `.d..t......` when its mtime differs from the source. A
`--checksum` run surfaces this cleanly: content-identical files are skipped,
leaving only the directory time change to report.

## Fix

Compute the attribute-diff itemize flags for an existing directory against its
pre-apply stat (mirroring upstream itemize-before-`set_file_attrs` ordering) and
emit them from both the batch and incremental directory paths, reusing the
existing `itemize_existing_flags` comparison (size is gated on `is_file()` so it
never fires for a directory). The created-root override is made unconditional so
a freshly `mkdir`-ed root still renders `cd+++++++++`.

## Verification (vs upstream rsync 3.4.4, aarch64)

`-a -c -ii` stdout and `diff -r` of the destination tree, three trees:
(a) only the root dir mtime differs, (b) nothing differs, (c) a nested dir + file
differ.

- **Local copy**: byte-identical to upstream for all three cases, including
  `.d..t...... ./` for (a) and `.d..t...... sub/deep/` for (c). Dest trees identical.
- **SSH pull**: the directory time rows now match upstream (before this change the
  root reported `.d          ./` with no `t`).

The local-copy path was already correct (the engine change-set already computes
`for_existing_directory` time flags); this change brings the transfer/SSH-pull
receiver in line.

## Out of scope (pre-existing, confirmed unchanged vs the parent commit)

The SSH pull/push paths retain divergences that predate this change and are
independent of directory-time itemize: (1) `-c` re-transfers content-identical
files over SSH instead of skipping them, (2) the receiver emits all directory
rows before file rows rather than interleaving per file-list order, and (3) the
push path forwards no directory itemize rows from the server receiver to the
client sender. These are tracked separately.

## Tests

New regression tests cover the differing-mtime (time bit set) and matching-mtime
(no time bit) cases for an existing directory.