### PR TITLE
feat(core): honor negative --modify-window for nanosecond-exact mtime compare

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -210,22 +210,15 @@ where
     let modify_window = match matches.remove_one::<OsString>("modify-window") {
         Some(value) => {
             let s = value.to_string_lossy();
+            // upstream: options.c:660 parses `--modify-window`/`-@` as a signed
+            // int (`POPT_ARG_INT`); a negative value is valid and requests
+            // nanosecond-exact comparison (util1.c:1482), so accept any integer.
             match s.parse::<i32>() {
-                Ok(n) if n >= 0 => Some(value),
-                Ok(_) => {
-                    return Err(clap::Error::raw(
-                        clap::error::ErrorKind::ValueValidation,
-                        format!(
-                            "invalid --modify-window value '{s}': must be a non-negative integer\n"
-                        ),
-                    ));
-                }
+                Ok(_) => Some(value),
                 Err(_) => {
                     return Err(clap::Error::raw(
                         clap::error::ErrorKind::ValueValidation,
-                        format!(
-                            "invalid --modify-window value '{s}': must be a non-negative integer\n"
-                        ),
+                        format!("invalid --modify-window value '{s}': must be an integer\n"),
                     ));
                 }
             }

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs
@@ -183,9 +183,15 @@ pub(super) fn add_transfer_args(command: ClapCommand) -> ClapCommand {
         .arg(
             Arg::new("modify-window")
                 .long("modify-window")
+                // upstream: options.c:660 - `-@` is the short alias, parsed as a
+                // signed int. `allow_hyphen_values` lets a negative window
+                // (e.g. `--modify-window=-1` or `-@-1`) be taken as the value
+                // rather than mistaken for another option.
+                .short('@')
                 .value_name("SECS")
                 .help("Treat mtimes within SECS seconds as equal when comparing files.")
                 .num_args(1)
+                .allow_hyphen_values(true)
                 .action(ArgAction::Set)
                 .value_parser(OsStringValueParser::new()),
         )

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -73,7 +73,7 @@ pub(crate) struct ConfigInputs {
     pub(crate) times: bool,
     pub(crate) atimes: bool,
     pub(crate) crtimes: bool,
-    pub(crate) modify_window_setting: Option<u64>,
+    pub(crate) modify_window_setting: Option<i64>,
     pub(crate) omit_dir_times: bool,
     pub(crate) omit_link_times: bool,
     pub(crate) devices: bool,

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -69,7 +69,7 @@ pub(crate) struct DerivedSettings {
     pub(crate) max_size_limit: Option<u64>,
     pub(crate) block_size_override: Option<NonZeroU32>,
     pub(crate) max_alloc_limit: Option<u64>,
-    pub(crate) modify_window_setting: Option<u64>,
+    pub(crate) modify_window_setting: Option<i64>,
     pub(crate) compress: bool,
     pub(crate) compression_level_override: Option<CompressionLevel>,
     pub(crate) skip_compress_list: Option<SkipCompressList>,
@@ -264,7 +264,7 @@ struct SizeLimitsResult {
     max_size_limit: Option<u64>,
     block_size_override: Option<NonZeroU32>,
     max_alloc_limit: Option<u64>,
-    modify_window_setting: Option<u64>,
+    modify_window_setting: Option<i64>,
 }
 
 /// Input parameters for size/limit parsing, grouped to reduce argument count.

--- a/crates/cli/src/frontend/execution/options/mod.rs
+++ b/crates/cli/src/frontend/execution/options/mod.rs
@@ -161,7 +161,11 @@ mod tests {
 
     #[test]
     fn parse_modify_window_argument_negative() {
-        assert!(parse_modify_window_argument(&os("-1")).is_err());
+        // upstream: options.c parses `--modify-window` as a signed int; a
+        // negative value (`-1`) is valid and requests nanosecond-exact
+        // comparison (util1.c:1482), so it must NOT be rejected.
+        assert_eq!(parse_modify_window_argument(&os("-1")).unwrap(), -1);
+        assert_eq!(parse_modify_window_argument(&os("-2")).unwrap(), -2);
     }
 
     #[test]

--- a/crates/cli/src/frontend/execution/options/numeric.rs
+++ b/crates/cli/src/frontend/execution/options/numeric.rs
@@ -156,10 +156,13 @@ pub(crate) fn parse_checksum_seed_argument(value: &OsStr) -> Result<u32, Message
     })
 }
 
-/// Parses the `--modify-window` argument as a non-negative `u64` seconds value.
+/// Parses the `--modify-window` argument as a signed `i64` seconds value.
 ///
-/// A leading `+` prefix is permitted and ignored.
-pub(crate) fn parse_modify_window_argument(value: &OsStr) -> Result<u64, Message> {
+/// A leading `+` prefix is permitted and ignored. A negative value is accepted
+/// and requests upstream's nanosecond-exact mtime comparison
+/// (`modify_window < 0`, util1.c:1482); upstream parses this option as a signed
+/// `int` (options.c:660, `POPT_ARG_INT`).
+pub(crate) fn parse_modify_window_argument(value: &OsStr) -> Result<i64, Message> {
     let text = value.to_string_lossy();
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
     let display = if trimmed.is_empty() {
@@ -174,24 +177,13 @@ pub(crate) fn parse_modify_window_argument(value: &OsStr) -> Result<u64, Message
         );
     }
 
-    if trimmed.starts_with('-') {
-        return Err(rsync_error!(
-            1,
-            format!(
-                "invalid --modify-window '{}': window must be non-negative",
-                display
-            )
-        )
-        .with_role(Role::Client));
-    }
-
     let normalized = trimmed.strip_prefix('+').unwrap_or(trimmed);
 
-    match normalized.parse::<u64>() {
+    match normalized.parse::<i64>() {
         Ok(value) => Ok(value),
         Err(error) => {
             let detail = match error.kind() {
-                IntErrorKind::InvalidDigit => "window must be an unsigned integer",
+                IntErrorKind::InvalidDigit => "window must be an integer",
                 IntErrorKind::PosOverflow | IntErrorKind::NegOverflow => {
                     "window exceeds the supported range"
                 }

--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -412,12 +412,20 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
                     idx += 2;
                     continue;
                 }
+                // upstream: options.c:2874 - a negative modify_window is
+                // forwarded via the short `-@%d` spelling (e.g. `-@-1`), emitted
+                // as its own argv slot after the compact flag string. The value
+                // is the joined remainder; run.rs parses it via
+                // parse_modify_window_argument (signed).
+                if let Some(window) = s.strip_prefix("-@") {
+                    flags.modify_window = Some(window.to_owned());
+                }
                 // Accept the joined `--partial-dir=VALUE` form too, even
                 // though upstream's server_options() does not emit it - the
                 // CLI parser accepts both forms for client-side use, and a
                 // forwarder built on a non-upstream client might still send
                 // the joined form.
-                if let Some(value) = s.strip_prefix("--partial-dir=") {
+                else if let Some(value) = s.strip_prefix("--partial-dir=") {
                     flags.partial_dir = Some(OsString::from(value));
                 } else {
                     parse_value_bearing_flag(&s, &mut flags);
@@ -604,6 +612,10 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--copy-dest=")
         || arg.starts_with("--link-dest=")
         || arg.starts_with("--modify-window=")
+        // upstream: options.c:2874 - a negative modify_window arrives as the
+        // short `-@%d` token (e.g. `-@-1`) after the compact flag string, so it
+        // must be recognised here or it leaks into the positional path list.
+        || arg.starts_with("-@")
         || arg.starts_with("--min-size=")
         || arg.starts_with("--max-size=")
         || arg.starts_with("--max-alloc=")

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -555,7 +555,9 @@ fn apply_value_flags<Err: Write>(
         match super::super::execution::parse_modify_window_argument(std::ffi::OsStr::new(
             window_str,
         )) {
-            Ok(window) => config.file_selection.modify_window = window,
+            Ok(window) => {
+                config.file_selection.modify_window = ::metadata::ModifyWindow::from_secs(window)
+            }
             Err(msg) => {
                 write_server_error(stderr, brand, msg.text().to_owned());
                 return Err(1);

--- a/crates/cli/src/frontend/tests/parse_args_recognises_modify.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_modify.rs
@@ -26,22 +26,35 @@ fn parse_args_recognises_modify_window_zero() {
 }
 
 #[test]
-fn parse_args_rejects_negative_modify_window() {
-    let error = match parse_args([
+fn parse_args_accepts_negative_modify_window() {
+    // WHY: `--modify-window=-1` is upstream's request for nanosecond-exact
+    // comparison (options.c parses a signed int); it must parse successfully and
+    // retain the negative value verbatim rather than be rejected.
+    let parsed = parse_args([
         OsString::from(RSYNC),
         OsString::from("--modify-window=-1"),
         OsString::from("source"),
         OsString::from("dest"),
-    ]) {
-        Ok(_) => panic!("parse should fail"),
-        Err(error) => error,
-    };
-    assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
-    assert!(
-        error
-            .to_string()
-            .contains("invalid --modify-window value '-1'")
-    );
+    ])
+    .expect("negative modify-window should parse");
+    assert_eq!(parsed.modify_window, Some(OsString::from("-1")));
+}
+
+#[test]
+fn parse_args_accepts_short_at_alias_modify_window() {
+    // WHY: upstream options.c:660 defines `-@` as the short alias for
+    // `--modify-window`. `-@-1`, `-@2`, and `-@ 2` must all parse to the same
+    // value the long form yields.
+    for (arg, expected) in [("-@-1", "-1"), ("-@2", "2")] {
+        let parsed = parse_args([
+            OsString::from(RSYNC),
+            OsString::from(arg),
+            OsString::from("source"),
+            OsString::from("dest"),
+        ])
+        .unwrap_or_else(|e| panic!("{arg} should parse: {e}"));
+        assert_eq!(parsed.modify_window, Some(OsString::from(expected)));
+    }
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/parse_modify.rs
+++ b/crates/cli/src/frontend/tests/parse_modify.rs
@@ -8,13 +8,17 @@ fn parse_modify_window_argument_accepts_positive_values() {
 }
 
 #[test]
-fn parse_modify_window_argument_rejects_negative_values() {
-    let error = parse_modify_window_argument(OsStr::new("-1"))
-        .expect_err("negative modify-window should fail");
-    let rendered = error.to_string();
-    assert!(
-        rendered.contains("window must be non-negative"),
-        "diagnostic missing negativity detail: {rendered}"
+fn parse_modify_window_argument_accepts_negative_values() {
+    // WHY: upstream options.c parses `--modify-window` as a signed int; a
+    // negative value requests nanosecond-exact comparison (util1.c:1482), so it
+    // must be accepted rather than rejected.
+    assert_eq!(
+        parse_modify_window_argument(OsStr::new("-1")).expect("parse -1"),
+        -1
+    );
+    assert_eq!(
+        parse_modify_window_argument(OsStr::new(" -2 ")).expect("parse -2"),
+        -2
     );
 }
 
@@ -24,7 +28,7 @@ fn parse_modify_window_argument_rejects_invalid_values() {
         .expect_err("non-numeric modify-window should fail");
     let rendered = error.to_string();
     assert!(
-        rendered.contains("window must be an unsigned integer"),
+        rendered.contains("window must be an integer"),
         "diagnostic missing numeric detail: {rendered}"
     );
 }

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -148,7 +148,7 @@ pub struct ClientConfigBuilder {
     rayon_threads: Option<NonZeroUsize>,
     tokio_threads: Option<NonZeroUsize>,
     max_alloc: Option<u64>,
-    modify_window: Option<u64>,
+    modify_window: Option<i64>,
     remove_source_files: bool,
     bandwidth_limit: Option<BandwidthLimit>,
     preserve_owner: bool,

--- a/crates/core/src/client/config/builder/selection.rs
+++ b/crates/core/src/client/config/builder/selection.rs
@@ -7,7 +7,9 @@ impl ClientConfigBuilder {
         /// Sets the maximum file size to transfer.
         max_file_size: Option<u64>,
         /// Sets the modification time tolerance used when comparing files.
-        modify_window: Option<u64>,
+        ///
+        /// A negative value selects upstream's nanosecond-exact comparison.
+        modify_window: Option<i64>,
         /// Enables or disables removal of source files after a successful transfer.
         remove_source_files: bool,
         /// Enables or disables size-only change detection.

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -1,9 +1,9 @@
 use std::ffi::{OsStr, OsString};
 use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
-use ::metadata::{ChmodModifiers, GroupMapping, UserMapping};
+use ::metadata::{ChmodModifiers, GroupMapping, ModifyWindow, UserMapping};
 use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::CompressionLevel;
 use engine::SkipCompressList;
@@ -72,7 +72,7 @@ pub struct ClientConfig {
     pub(super) rayon_threads: Option<NonZeroUsize>,
     pub(super) tokio_threads: Option<NonZeroUsize>,
     pub(super) max_alloc: Option<u64>,
-    pub(super) modify_window: Option<u64>,
+    pub(super) modify_window: Option<i64>,
     pub(super) remove_source_files: bool,
     pub(super) bandwidth_limit: Option<BandwidthLimit>,
     pub(super) preserve_owner: bool,

--- a/crates/core/src/client/config/client/selection.rs
+++ b/crates/core/src/client/config/client/selection.rs
@@ -13,17 +13,23 @@ impl ClientConfig {
         self.max_file_size
     }
 
-    /// Returns the modification time tolerance, if configured.
+    /// Returns the modification time tolerance in whole seconds, if configured.
+    ///
+    /// A negative value requests upstream's nanosecond-exact comparison
+    /// (`modify_window < 0`, util1.c:1482).
     #[doc(alias = "--modify-window")]
-    pub const fn modify_window(&self) -> Option<u64> {
+    pub const fn modify_window(&self) -> Option<i64> {
         self.modify_window
     }
 
-    /// Returns the modification time tolerance as a [`Duration`].
+    /// Returns the modification time tolerance as a [`ModifyWindow`].
+    ///
+    /// Unset defaults to [`ModifyWindow::ZERO`], mirroring upstream's default
+    /// `modify_window = 0` (options.c:143).
     #[must_use]
-    pub fn modify_window_duration(&self) -> Duration {
+    pub fn modify_window_setting(&self) -> ModifyWindow {
         self.modify_window
-            .map_or(Duration::ZERO, Duration::from_secs)
+            .map_or(ModifyWindow::ZERO, ModifyWindow::from_secs)
     }
 
     /// Returns whether the sender should remove source files after transfer.
@@ -228,9 +234,9 @@ mod tests {
     }
 
     #[test]
-    fn modify_window_duration_default_is_zero() {
+    fn modify_window_setting_default_is_zero() {
         let config = default_config();
-        assert_eq!(config.modify_window_duration(), Duration::ZERO);
+        assert_eq!(config.modify_window_setting(), ModifyWindow::ZERO);
     }
 
     #[test]

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -349,7 +349,10 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // local client IS the receiver, so carry the window onto its config; the
     // server-side receiver (push) picks it up from the forwarded
     // `--modify-window=NUM` arg. `modify_window()` is None when unset (window 0).
-    server_config.file_selection.modify_window = config.modify_window().unwrap_or(0);
+    server_config.file_selection.modify_window = config.modify_window().map_or(
+        ::metadata::ModifyWindow::ZERO,
+        ::metadata::ModifyWindow::from_secs,
+    );
     // upstream: options.c:2046-2048 - do_stats sets INFO_STATS to level 2+
     server_config.do_stats = config.stats();
     // upstream: generator.c:124 - EARLY_DELETE_DONE_MSG = !(delete_during==2 || delete_after)

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -311,8 +311,20 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from(format!("--max-alloc={limit}")));
         }
 
-        if let Some(window) = self.config.modify_window() {
-            args.push(OsString::from(format!("--modify-window={window}")));
+        // upstream: options.c:2873-2875 - server_options() forwards the
+        // modify_window value only when it was explicitly set AND the local
+        // side is the sender (`modify_window_set && am_sender`): the remote
+        // receiver's generator is what performs the mtime quick-check. A
+        // negative window (nanosecond-exact) is sent via the short `-@%d`
+        // spelling (e.g. `-@-1`); a non-negative window uses `--modify-window=%d`.
+        if self.role == RemoteRole::Sender
+            && let Some(window) = self.config.modify_window()
+        {
+            if window < 0 {
+                args.push(OsString::from(format!("-@{window}")));
+            } else {
+                args.push(OsString::from(format!("--modify-window={window}")));
+            }
         }
 
         // upstream: options.c - compress_level sent to server when

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -1746,6 +1746,42 @@ fn includes_modify_window_long_arg() {
 }
 
 #[test]
+fn negative_modify_window_uses_short_at_spelling() {
+    // WHY: upstream options.c:2874 forwards a negative modify_window via the
+    // short `-@%d` spelling (`-@-1`), NOT `--modify-window=-1`, so a stock
+    // upstream `--server` receiver honours nanosecond-exact comparison. The
+    // long form would be rejected as an invalid unsigned value on the peer.
+    let config = ClientConfig::builder().modify_window(Some(-1)).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "-@-1"),
+        "expected -@-1 in sender args for a negative window: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a.starts_with("--modify-window=")),
+        "negative window must not use the long spelling: {args:?}"
+    );
+}
+
+#[test]
+fn modify_window_not_forwarded_on_pull() {
+    // WHY: upstream options.c:2873 gates the forwarded arg on `am_sender`. On a
+    // pull the local client is the receiver and runs the mtime quick-check
+    // itself, so nothing is sent to the remote sender. Forwarding it would
+    // diverge from upstream's argv byte-for-byte.
+    let config = ClientConfig::builder().modify_window(Some(2)).build();
+    let args = build_receiver_args(&config);
+    assert!(
+        !args.iter().any(|a| a.starts_with("--modify-window=")),
+        "pull must not forward --modify-window: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a.starts_with("-@")),
+        "pull must not forward -@ window: {args:?}"
+    );
+}
+
+#[test]
 fn includes_compress_level_long_arg() {
     let config = ClientConfig::builder()
         .compress(true)

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -821,7 +821,7 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             .ignore_missing_args(config.ignore_missing_args())
             .delete_missing_args(config.delete_missing_args())
             .update(config.update())
-            .with_modify_window(config.modify_window_duration())
+            .with_modify_window(config.modify_window_setting())
             .numeric_ids(config.numeric_ids())
             .preallocate(config.preallocate())
             .fsync(config.fsync())

--- a/crates/core/src/client/tests/builder_compress.rs
+++ b/crates/core/src/client/tests/builder_compress.rs
@@ -305,11 +305,26 @@ fn builder_records_modify_window() {
         .build();
 
     assert_eq!(config.modify_window(), Some(5));
-    assert_eq!(config.modify_window_duration(), Duration::from_secs(5));
+    assert_eq!(config.modify_window_setting(), ::metadata::ModifyWindow::from_secs(5));
     assert_eq!(
-        ClientConfig::default().modify_window_duration(),
-        Duration::ZERO
+        ClientConfig::default().modify_window_setting(),
+        ::metadata::ModifyWindow::ZERO
     );
+}
+
+#[test]
+fn builder_records_negative_modify_window() {
+    // WHY: `--modify-window=-1` is a valid upstream request for nanosecond-exact
+    // comparison (options.c uses a signed int); the builder must retain the
+    // negative value rather than clamp or reject it.
+    let config = ClientConfig::builder()
+        .transfer_args([OsString::from("src"), OsString::from("dst")])
+        .modify_window(Some(-1))
+        .build();
+
+    assert_eq!(config.modify_window(), Some(-1));
+    assert_eq!(config.modify_window_setting(), ::metadata::ModifyWindow::from_secs(-1));
+    assert!(config.modify_window_setting().is_nsec_exact());
 }
 
 #[test]
@@ -349,14 +364,14 @@ fn local_copy_options_apply_modify_window() {
         .build();
 
     let options = build_local_copy_options(&config, None);
-    assert_eq!(options.modify_window(), Duration::from_secs(3));
+    assert_eq!(options.modify_window(), ::metadata::ModifyWindow::from_secs(3));
 
     let default_config = ClientConfig::builder()
         .transfer_args([OsString::from("src"), OsString::from("dst")])
         .build();
     assert_eq!(
         build_local_copy_options(&default_config, None).modify_window(),
-        Duration::ZERO
+        ::metadata::ModifyWindow::ZERO
     );
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -258,8 +258,15 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                 // The daemon receiver's quick-check honours it via same_time() so
                 // files within the window are not needlessly re-transferred.
                 } else if let Some(val) = arg.strip_prefix("--modify-window=") {
-                    if let Ok(n) = val.trim_start_matches('+').parse::<u64>() {
-                        config.file_selection.modify_window = n;
+                    if let Ok(n) = val.trim_start_matches('+').parse::<i64>() {
+                        config.file_selection.modify_window = ::metadata::ModifyWindow::from_secs(n);
+                    }
+                // upstream: options.c:2874 - a negative modify_window is
+                // forwarded via the short `-@%d` spelling (e.g. `-@-1`) for
+                // nanosecond-exact comparison (util1.c:1482).
+                } else if let Some(val) = arg.strip_prefix("-@") {
+                    if let Ok(n) = val.parse::<i64>() {
+                        config.file_selection.modify_window = ::metadata::ModifyWindow::from_secs(n);
                     }
                 // Fallback: =value format for reference directories and backup options.
                 // Handles both upstream (two-arg) and legacy (=value) formats.

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -46,6 +46,10 @@ use crate::signature::SignatureBlock;
 use ::metadata::{
     MetadataOptions, apply_file_metadata_with_options, apply_symlink_metadata_with_options,
 };
+// Used only by the `#[cfg(unix)]` hardlink-candidate mtime compare in
+// context_impl/state.rs; on other platforms the name would be unused.
+#[cfg(unix)]
+use ::metadata::ModifyWindow;
 use bandwidth::{BandwidthLimitComponents, BandwidthLimiter};
 use checksums::RollingChecksum;
 use compress::algorithm::CompressionAlgorithm;

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -1263,21 +1263,22 @@ impl<'a> CopyContext<'a> {
 /// `--modify-window`.
 ///
 /// upstream: util1.c:1478 same_time() - a whole-second delta within
-/// `modify_window` counts as unchanged; with a zero window the sub-second
-/// component must also match.
+/// `modify_window` counts as unchanged. For a zero window (the default) or a
+/// negative window (`--modify-window < 0`, nsec-exact) a hardlink candidate
+/// must match on both the whole-second and nanosecond components.
 #[cfg(unix)]
 fn mtimes_within_window(
     source: &fs::Metadata,
     candidate: &fs::Metadata,
-    modify_window: Duration,
+    modify_window: ModifyWindow,
 ) -> bool {
     use std::os::unix::fs::MetadataExt;
 
     let delta = source.mtime().abs_diff(candidate.mtime());
     let window = modify_window.as_secs();
-    if window == 0 {
+    if window <= 0 {
         delta == 0 && source.mtime_nsec() == candidate.mtime_nsec()
     } else {
-        delta <= window
+        delta <= window as u64
     }
 }

--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -4,9 +4,10 @@ use std::fs;
 use std::io::{self, Read};
 use std::num::{NonZeroU8, NonZeroU32};
 use std::path::Path;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use checksums::strong::Xxh64;
+use metadata::ModifyWindow;
 
 use crate::delta::{DeltaSignatureIndex, SignatureLayoutParams, calculate_signature_layout};
 use crate::local_copy::{COPY_BUFFER_SIZE, LocalCopyError};
@@ -94,7 +95,7 @@ fn same_file_type(source: &fs::Metadata, destination: &fs::Metadata) -> bool {
 pub(crate) fn destination_is_newer(
     source: &fs::Metadata,
     destination: &fs::Metadata,
-    modify_window: Duration,
+    modify_window: ModifyWindow,
 ) -> bool {
     // upstream: generator.c:1721 - the `stype == ftype` guard means a
     // type-mismatched destination is never skipped by `--update`.
@@ -105,14 +106,15 @@ pub(crate) fn destination_is_newer(
         (Ok(src), Ok(dst)) => {
             // upstream: generator.c:1721
             //   file->modtime - sx.st.st_mtime < modify_window
-            // Both operands are whole-second `time_t` values and the
-            // subtraction is signed, so the destination counts as "newer"
-            // (and the copy is skipped) only when the source second is less
-            // than the destination second by more than `modify_window`. A
+            // Both operands are whole-second `time_t` values and the signed
+            // `int modify_window` is used directly, so the destination counts as
+            // "newer" (skip the copy) only when the source second is smaller
+            // than the destination second by more than the window. A negative
+            // window (nsec-exact mode) simply makes the threshold negative; a
             // sub-second-only difference collapses to zero and is never a skip.
             let src_sec = unix_seconds(src);
             let dst_sec = unix_seconds(dst);
-            let window_secs = modify_window.as_secs() as i64;
+            let window_secs = modify_window.as_secs();
             src_sec - dst_sec < window_secs
         }
         _ => false,
@@ -196,7 +198,7 @@ pub(crate) struct CopyComparison<'a> {
     pub(crate) ignore_times: bool,
     pub(crate) checksum: bool,
     pub(crate) checksum_algorithm: SignatureAlgorithm,
-    pub(crate) modify_window: Duration,
+    pub(crate) modify_window: ModifyWindow,
     /// Prefetched checksum match result from parallel computation.
     ///
     /// When `Some(true)`, checksums were pre-computed and match (skip copy).
@@ -292,16 +294,29 @@ pub(crate) fn should_skip_copy(params: CopyComparison<'_>) -> bool {
 /// second regardless of their fractional part, mirroring the `time_t`
 /// truncation upstream applies before comparing modification times.
 fn unix_seconds(time: SystemTime) -> i64 {
+    unix_sec_nsec(time).0
+}
+
+/// Returns the whole-second UNIX timestamp and its non-negative nanosecond
+/// remainder, both floored toward negative infinity.
+///
+/// The nanosecond component matches the POSIX `st_mtim.tv_nsec` convention
+/// (always in `[0, 1_000_000_000)` and measured up from the floored second),
+/// so a negative-window (`--modify-window < 0`) comparison sees the same
+/// nanosecond values upstream's `same_time()` compares.
+fn unix_sec_nsec(time: SystemTime) -> (i64, u32) {
     match time.duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(diff) => diff.as_secs() as i64,
+        Ok(diff) => (diff.as_secs() as i64, diff.subsec_nanos()),
         Err(error) => {
             let diff = error.duration();
-            // A non-zero sub-second remainder means the instant lands strictly
-            // before the flooring boundary, so subtract one to floor.
-            if diff.subsec_nanos() == 0 {
-                -(diff.as_secs() as i64)
+            let nsec = diff.subsec_nanos();
+            if nsec == 0 {
+                (-(diff.as_secs() as i64), 0)
             } else {
-                -(diff.as_secs() as i64) - 1
+                // A non-zero sub-second remainder means the instant lands
+                // strictly before the flooring boundary, so subtract one to
+                // floor and re-express the nanoseconds up from that second.
+                (-(diff.as_secs() as i64) - 1, 1_000_000_000 - nsec)
             }
         }
     }
@@ -320,21 +335,22 @@ fn unix_seconds(time: SystemTime) -> i64 {
 ///   `f2_sec > f1_sec ? f2_sec - f1_sec <= modify_window : f1_sec - f2_sec <=
 ///   modify_window` -- i.e. `|a_sec - b_sec| <= window_secs`. Nanoseconds do not
 ///   figure into the window check ("time windows don't care about that").
+/// - `window < 0`: a nanosecond-exact comparison applies - the seconds AND the
+///   nanoseconds must match (upstream `modify_window < 0`, util1.c:1482).
 ///
 /// upstream: util1.c:1478 same_time() (via generator.c unchanged_file()).
-pub(crate) fn system_time_within_window(a: SystemTime, b: SystemTime, window: Duration) -> bool {
-    // Truncate to whole seconds, exactly as upstream compares `time_t` values.
-    let a_sec = unix_seconds(a);
-    let b_sec = unix_seconds(b);
-
-    if window.is_zero() {
-        // upstream: same_time() returns `f1_sec == f2_sec` when modify_window == 0.
-        return a_sec == b_sec;
-    }
-
-    // upstream: same_time() applies a symmetric window on whole seconds --
-    // nanoseconds are deliberately ignored (util1.c:1484).
-    a_sec.abs_diff(b_sec) <= window.as_secs()
+pub(crate) fn system_time_within_window(
+    a: SystemTime,
+    b: SystemTime,
+    window: ModifyWindow,
+) -> bool {
+    // Extract whole seconds and the POSIX nanosecond remainder, exactly as
+    // upstream compares `st_mtim` (`time_t` seconds plus `tv_nsec`). The
+    // nanoseconds only matter for a negative window; same_time() ignores them
+    // for the zero/positive cases.
+    let (a_sec, a_nsec) = unix_sec_nsec(a);
+    let (b_sec, b_nsec) = unix_sec_nsec(b);
+    window.same_time(a_sec, a_nsec, b_sec, b_nsec)
 }
 
 enum LockstepCheck {
@@ -468,6 +484,7 @@ mod tests {
     use super::*;
     use std::io::Write;
     use std::path::PathBuf;
+    use std::time::Duration;
 
     use filetime::{FileTime, set_file_mtime};
     use tempfile::TempDir;
@@ -550,7 +567,7 @@ mod tests {
             ignore_times: false,
             checksum: true,
             checksum_algorithm: default_checksum_algorithm(),
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: None,
         };
 
@@ -571,7 +588,7 @@ mod tests {
             ignore_times: false,
             checksum: false,
             checksum_algorithm: default_checksum_algorithm(),
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: None,
         };
 
@@ -589,7 +606,11 @@ mod tests {
         // already-hardlinked alias under `-vvH`.
         let base = SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, 100_000_000);
         let same_second = SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, 900_000_000);
-        assert!(system_time_within_window(base, same_second, Duration::ZERO));
+        assert!(system_time_within_window(
+            base,
+            same_second,
+            ModifyWindow::ZERO
+        ));
     }
 
     #[test]
@@ -601,7 +622,7 @@ mod tests {
         assert!(!system_time_within_window(
             earlier,
             next_second,
-            Duration::ZERO
+            ModifyWindow::ZERO
         ));
     }
 
@@ -616,7 +637,7 @@ mod tests {
         // implementation compared full-resolution durations, so a source at .0s and
         // a destination at +2.9s (whole-second delta 2, within window) was wrongly
         // seen as 2.9s apart and re-transferred.
-        let window = Duration::from_secs(2);
+        let window = ModifyWindow::from_secs(2);
         let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let plus_two = base + Duration::from_secs(2);
         let minus_two = base - Duration::from_secs(2);
@@ -640,7 +661,7 @@ mod tests {
         // tolerance, so upstream same_time() returns 0 (different) and the file
         // must be re-transferred. Guards against an off-by-one that would swallow
         // a genuinely stale destination.
-        let window = Duration::from_secs(2);
+        let window = ModifyWindow::from_secs(2);
         let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let plus_three = base + Duration::from_secs(3);
 
@@ -656,8 +677,39 @@ mod tests {
         let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let plus_one = base + Duration::from_secs(1);
 
-        assert!(!system_time_within_window(base, plus_one, Duration::ZERO));
-        assert!(!system_time_within_window(plus_one, base, Duration::ZERO));
+        assert!(!system_time_within_window(
+            base,
+            plus_one,
+            ModifyWindow::ZERO
+        ));
+        assert!(!system_time_within_window(
+            plus_one,
+            base,
+            ModifyWindow::ZERO
+        ));
+    }
+
+    #[test]
+    fn system_time_negative_window_requires_nanosecond_exactness() {
+        // WHY: upstream util1.c:1482 - a negative `modify_window` compares the
+        // nanosecond component too (`f1_sec == f2_sec && f1_nsec == f2_nsec`).
+        // Two mtimes in the same second but a different fraction are therefore
+        // DIFFERENT and the local copy must proceed, whereas any non-negative
+        // window ignores the sub-second drift and treats them as equal.
+        let exact = ModifyWindow::from_secs(-1);
+        let base = SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, 100_000_000);
+        let same_second = SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, 900_000_000);
+
+        assert!(!system_time_within_window(base, same_second, exact));
+        assert!(!system_time_within_window(same_second, base, exact));
+        // Identical instants still match under the nsec-exact window.
+        assert!(system_time_within_window(base, base, exact));
+        // A zero window ignores the same sub-second drift and treats them equal.
+        assert!(system_time_within_window(
+            base,
+            same_second,
+            ModifyWindow::ZERO
+        ));
     }
 
     #[test]
@@ -676,7 +728,7 @@ mod tests {
             ignore_times: true,
             checksum: false,
             checksum_algorithm: default_checksum_algorithm(),
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: None,
         };
 
@@ -709,7 +761,11 @@ mod tests {
         assert!(dst_meta.file_type().is_symlink());
 
         // Even though the symlink is newer, the type mismatch forces an update.
-        assert!(!destination_is_newer(&src_meta, &dst_meta, Duration::ZERO));
+        assert!(!destination_is_newer(
+            &src_meta,
+            &dst_meta,
+            ModifyWindow::ZERO
+        ));
     }
 
     #[test]
@@ -730,7 +786,11 @@ mod tests {
         let dst_newer = FileTime::from_unix_time(1_700_000_000, 900_000_000);
         let (_temp, src_meta, dst_meta) = setup_timed_files(src, dst_newer);
 
-        assert!(!destination_is_newer(&src_meta, &dst_meta, Duration::ZERO));
+        assert!(!destination_is_newer(
+            &src_meta,
+            &dst_meta,
+            ModifyWindow::ZERO
+        ));
     }
 
     #[test]
@@ -739,7 +799,11 @@ mod tests {
         let newer = FileTime::from_unix_time(1_700_000_005, 0);
         let (_temp, src_meta, dst_meta) = setup_timed_files(older, newer);
 
-        assert!(destination_is_newer(&src_meta, &dst_meta, Duration::ZERO));
+        assert!(destination_is_newer(
+            &src_meta,
+            &dst_meta,
+            ModifyWindow::ZERO
+        ));
     }
 
     #[test]
@@ -748,7 +812,11 @@ mod tests {
         let newer = FileTime::from_unix_time(1_700_000_005, 0);
         let (_temp, src_meta, dst_meta) = setup_timed_files(newer, older);
 
-        assert!(!destination_is_newer(&src_meta, &dst_meta, Duration::ZERO));
+        assert!(!destination_is_newer(
+            &src_meta,
+            &dst_meta,
+            ModifyWindow::ZERO
+        ));
     }
 
     #[test]
@@ -756,7 +824,11 @@ mod tests {
         let same = FileTime::from_unix_time(1_700_000_000, 0);
         let (_temp, src_meta, dst_meta) = setup_timed_files(same, same);
 
-        assert!(!destination_is_newer(&src_meta, &dst_meta, Duration::ZERO));
+        assert!(!destination_is_newer(
+            &src_meta,
+            &dst_meta,
+            ModifyWindow::ZERO
+        ));
     }
 
     #[test]
@@ -770,7 +842,7 @@ mod tests {
         assert!(destination_is_newer(
             &src_meta,
             &dst_meta,
-            Duration::from_secs(1)
+            ModifyWindow::from_secs(1)
         ));
     }
 
@@ -784,7 +856,7 @@ mod tests {
         assert!(destination_is_newer(
             &src_meta,
             &dst_meta,
-            Duration::from_secs(1)
+            ModifyWindow::from_secs(1)
         ));
     }
 
@@ -798,7 +870,7 @@ mod tests {
         assert!(destination_is_newer(
             &src_meta,
             &dst_meta,
-            Duration::from_secs(2)
+            ModifyWindow::from_secs(2)
         ));
     }
 
@@ -811,7 +883,7 @@ mod tests {
         assert!(destination_is_newer(
             &src_meta,
             &dst_meta,
-            Duration::from_secs(2)
+            ModifyWindow::from_secs(2)
         ));
     }
 
@@ -825,7 +897,7 @@ mod tests {
         assert!(destination_is_newer(
             &src_meta,
             &dst_meta,
-            Duration::from_secs(2)
+            ModifyWindow::from_secs(2)
         ));
     }
 
@@ -839,7 +911,7 @@ mod tests {
         assert!(!destination_is_newer(
             &src_meta,
             &dst_meta,
-            Duration::from_secs(2)
+            ModifyWindow::from_secs(2)
         ));
     }
 
@@ -853,7 +925,7 @@ mod tests {
         assert!(!destination_is_newer(
             &src_meta,
             &dst_meta,
-            Duration::from_secs(2)
+            ModifyWindow::from_secs(2)
         ));
     }
 

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
-use ::metadata::{ChmodModifiers, CopyAsIds, GroupMapping, UserMapping};
+use ::metadata::{ChmodModifiers, CopyAsIds, GroupMapping, ModifyWindow, UserMapping};
 use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::CompressionLevel;
 use fast_io::{DefaultPlatformCopy, PlatformCopy};
@@ -110,7 +110,7 @@ pub struct LocalCopyOptionsBuilder {
     pub(super) existing_only: bool,
     pub(super) ignore_missing_args: bool,
     pub(super) update: bool,
-    pub(super) modify_window: Duration,
+    pub(super) modify_window: ModifyWindow,
 
     pub(super) partial: bool,
     pub(super) partial_dir: Option<PathBuf>,
@@ -242,7 +242,7 @@ impl LocalCopyOptionsBuilder {
             existing_only: false,
             ignore_missing_args: false,
             update: false,
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             partial: false,
             partial_dir: None,
             temp_dir: None,

--- a/crates/engine/src/local_copy/options/builder/setters_misc.rs
+++ b/crates/engine/src/local_copy/options/builder/setters_misc.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use fast_io::PlatformCopy;
+use metadata::ModifyWindow;
 
 use super::LocalCopyOptionsBuilder;
 use crate::batch::BatchWriter;
@@ -123,7 +124,7 @@ impl LocalCopyOptionsBuilder {
 
     /// Sets the modification time window.
     #[must_use]
-    pub fn modify_window(mut self, window: Duration) -> Self {
+    pub fn modify_window(mut self, window: ModifyWindow) -> Self {
         self.modify_window = window;
         self
     }

--- a/crates/engine/src/local_copy/options/builder/tests.rs
+++ b/crates/engine/src/local_copy/options/builder/tests.rs
@@ -1,6 +1,7 @@
 //! Unit tests for [`super::LocalCopyOptionsBuilder`] covering presets,
 //! per-concern setters, validation rules, and error display.
 
+use ::metadata::ModifyWindow;
 use std::num::NonZeroU64;
 use std::time::{Duration, SystemTime};
 
@@ -344,7 +345,7 @@ mod integrity_options {
 
     #[test]
     fn modify_window_sets_value() {
-        let window = Duration::from_secs(5);
+        let window = ModifyWindow::from_secs(5);
         let options = LocalCopyOptionsBuilder::new()
             .modify_window(window)
             .build()

--- a/crates/engine/src/local_copy/options/integrity.rs
+++ b/crates/engine/src/local_copy/options/integrity.rs
@@ -3,7 +3,8 @@
 //! existence filters, block-size override, and modify-window tolerance.
 
 use std::num::NonZeroU32;
-use std::time::Duration;
+
+use metadata::ModifyWindow;
 
 use crate::signature::SignatureAlgorithm;
 
@@ -131,7 +132,7 @@ impl LocalCopyOptions {
     /// Applies the modification time tolerance used when comparing files.
     #[must_use]
     #[doc(alias = "--modify-window")]
-    pub const fn with_modify_window(mut self, window: Duration) -> Self {
+    pub const fn with_modify_window(mut self, window: ModifyWindow) -> Self {
         self.modify_window = window;
         self
     }
@@ -217,7 +218,7 @@ impl LocalCopyOptions {
 
     /// Returns the modification time tolerance applied during comparisons.
     #[must_use]
-    pub const fn modify_window(&self) -> Duration {
+    pub const fn modify_window(&self) -> ModifyWindow {
         self.modify_window
     }
 }
@@ -360,7 +361,7 @@ mod tests {
 
     #[test]
     fn with_modify_window_sets_value() {
-        let window = Duration::from_secs(2);
+        let window = ModifyWindow::from_secs(2);
         let opts = LocalCopyOptions::new().with_modify_window(window);
         assert_eq!(opts.modify_window(), window);
     }
@@ -377,6 +378,6 @@ mod tests {
         assert!(!opts.delete_missing_args_enabled());
         assert!(!opts.update_enabled());
         assert!(opts.block_size_override().is_none());
-        assert_eq!(opts.modify_window(), Duration::ZERO);
+        assert_eq!(opts.modify_window(), ModifyWindow::ZERO);
     }
 }

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
-use ::metadata::{ChmodModifiers, CopyAsIds, GroupMapping, UserMapping};
+use ::metadata::{ChmodModifiers, CopyAsIds, GroupMapping, ModifyWindow, UserMapping};
 use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::CompressionLevel;
 use fast_io::{DefaultPlatformCopy, PlatformCopy};
@@ -190,7 +190,7 @@ pub struct LocalCopyOptions {
     pub(super) existing_only: bool,
     pub(super) ignore_missing_args: bool,
     pub(super) update: bool,
-    pub(super) modify_window: Duration,
+    pub(super) modify_window: ModifyWindow,
     pub(super) partial: bool,
     pub(super) partial_dir: Option<PathBuf>,
     pub(super) temp_dir: Option<PathBuf>,
@@ -334,7 +334,7 @@ impl LocalCopyOptions {
             existing_only: false,
             ignore_missing_args: false,
             update: false,
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             partial: false,
             partial_dir: None,
             temp_dir: None,

--- a/crates/engine/src/local_copy/plan/change_set/detection.rs
+++ b/crates/engine/src/local_copy/plan/change_set/detection.rs
@@ -1,7 +1,7 @@
 use std::fs;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
-use ::metadata::MetadataOptions;
+use ::metadata::{MetadataOptions, ModifyWindow};
 
 use crate::local_copy::executor::system_time_within_window;
 
@@ -25,7 +25,7 @@ impl LocalCopyChangeSet {
         wrote_data: bool,
         xattrs_enabled: bool,
         acls_enabled: bool,
-        modify_window: Duration,
+        modify_window: ModifyWindow,
     ) -> Self {
         Self::for_file_with_checksum(
             metadata,
@@ -58,7 +58,7 @@ impl LocalCopyChangeSet {
         xattrs_enabled: bool,
         acls_enabled: bool,
         checksum_enabled: bool,
-        modify_window: Duration,
+        modify_window: ModifyWindow,
     ) -> Self {
         let mut change_set = Self::new();
 
@@ -153,7 +153,7 @@ impl LocalCopyChangeSet {
         omit_dir_times: bool,
         xattrs_enabled: bool,
         acls_enabled: bool,
-        modify_window: Duration,
+        modify_window: ModifyWindow,
     ) -> Self {
         let mut change_set = Self::new();
 
@@ -264,7 +264,7 @@ impl LocalCopyChangeSet {
         source: &fs::Metadata,
         existing: &fs::Metadata,
         metadata_options: &MetadataOptions,
-        modify_window: Duration,
+        modify_window: ModifyWindow,
         content_differs: bool,
         xattrs_enabled: bool,
         acls_enabled: bool,
@@ -341,7 +341,7 @@ fn determine_time_change(
     existing: Option<&fs::Metadata>,
     destination_previously_existed: bool,
     wrote_data: bool,
-    modify_window: Duration,
+    modify_window: ModifyWindow,
 ) -> Option<TimeChange> {
     if metadata_options.times() {
         if !destination_previously_existed {

--- a/crates/engine/src/local_copy/plan/change_set/tests.rs
+++ b/crates/engine/src/local_copy/plan/change_set/tests.rs
@@ -1,5 +1,5 @@
+use ::metadata::ModifyWindow;
 use std::fs;
-use std::time::Duration;
 
 use ::metadata::MetadataOptions;
 
@@ -260,7 +260,7 @@ fn for_file_new_destination_sets_size_changed() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(change_set.size_changed());
@@ -283,7 +283,7 @@ fn for_file_wrote_data_sets_checksum_changed() {
         false,
         false,
         true, // checksum mode active (gates position-2 `c` glyph per upstream generator.c:1942)
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(change_set.checksum_changed());
@@ -305,7 +305,7 @@ fn for_file_xattrs_enabled_sets_xattr_changed() {
         false,
         true, // xattrs enabled
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(change_set.xattr_changed());
@@ -327,7 +327,7 @@ fn for_file_acls_enabled_sets_acl_changed() {
         false,
         false,
         true, // acls enabled
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(change_set.acl_changed());
@@ -349,7 +349,7 @@ fn for_file_no_changes_same_metadata() {
         false, // no data written
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(!change_set.checksum_changed());
@@ -375,7 +375,7 @@ fn for_file_size_difference_detected() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(change_set.size_changed());
@@ -397,7 +397,7 @@ fn for_file_times_preserved_new_destination() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert_eq!(change_set.time_change(), Some(TimeChange::Modified));
@@ -419,7 +419,7 @@ fn for_file_times_not_preserved_wrote_data() {
         true, // wrote data
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert_eq!(change_set.time_change(), Some(TimeChange::TransferTime));
@@ -441,7 +441,7 @@ fn for_file_times_not_preserved_new_destination() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert_eq!(change_set.time_change(), Some(TimeChange::TransferTime));
@@ -463,7 +463,7 @@ fn for_file_times_not_changed_existing_no_write() {
         false, // no write
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(change_set.time_change().is_none());
@@ -500,7 +500,7 @@ fn for_file_within_window_mtime_drift_reports_no_time_change() {
         false,
         false,
         false,
-        Duration::from_secs(2),
+        ModifyWindow::from_secs(2),
     );
     assert!(within.time_change().is_none());
     assert!(!within.has_any_change());
@@ -514,7 +514,7 @@ fn for_file_within_window_mtime_drift_reports_no_time_change() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
     assert_eq!(exact.time_change(), Some(TimeChange::Modified));
 }
@@ -544,7 +544,7 @@ fn change_set_detects_size_and_time_changes() {
         true,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(change_set.size_changed());
@@ -590,7 +590,7 @@ fn change_set_detects_permission_changes_for_existing_destination() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(change_set.permissions_changed());
@@ -626,7 +626,7 @@ fn change_set_detects_owner_override_mismatch() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(change_set.owner_changed());
@@ -660,7 +660,7 @@ fn change_set_detects_group_override_mismatch() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert!(change_set.group_changed());
@@ -691,7 +691,7 @@ fn for_existing_directory_flags_time_change_when_mtimes_differ() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert_eq!(change_set.time_change(), Some(TimeChange::Modified));
@@ -731,7 +731,7 @@ fn for_existing_directory_ignores_sub_second_mtime_drift() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert_eq!(change_set.time_change(), None);
@@ -764,7 +764,7 @@ fn for_existing_directory_no_change_when_mtimes_match() {
         false,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert_eq!(change_set.time_change(), None);
@@ -796,7 +796,7 @@ fn for_existing_directory_omit_dir_times_suppresses_time_flag() {
         true,
         false,
         false,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
     );
 
     assert_eq!(change_set.time_change(), None);
@@ -895,7 +895,7 @@ fn for_recreated_device_sets_checksum_and_time_when_content_differs() {
         &src_meta,
         &dst_meta,
         &options,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
         true,
         false,
         false,
@@ -929,7 +929,7 @@ fn for_recreated_device_reports_transfer_time_when_times_not_preserved() {
         &src_meta,
         &dst_meta,
         &options,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
         true,
         false,
         false,
@@ -965,7 +965,7 @@ fn for_recreated_device_no_change_when_content_and_time_match() {
         &src_meta,
         &dst_meta,
         &options,
-        Duration::ZERO,
+        ModifyWindow::ZERO,
         false,
         false,
         false,

--- a/crates/engine/src/local_copy/tests/execute_dry_run.rs
+++ b/crates/engine/src/local_copy/tests/execute_dry_run.rs
@@ -1176,7 +1176,7 @@ fn dry_run_existing_differing_dest_itemizes_size_and_time_change() {
 /// dry_run; util1.c:same_time() applies the `--modify-window` tolerance.
 #[test]
 fn dry_run_skips_up_to_date_and_window_absorbed_destinations() {
-    let record_for = |mtime_offset: i64, window_secs: u64| {
+    let record_for = |mtime_offset: i64, window_secs: i64| {
         let temp = tempdir().expect("tempdir");
         let source = temp.path().join("src");
         let destination = temp.path().join("dst");
@@ -1195,7 +1195,7 @@ fn dry_run_skips_up_to_date_and_window_absorbed_destinations() {
         let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
         let mut options = LocalCopyOptions::default().times(true).collect_events(true);
         if window_secs > 0 {
-            options = options.with_modify_window(Duration::from_secs(window_secs));
+            options = options.with_modify_window(ModifyWindow::from_secs(window_secs));
         }
         let report = plan
             .execute_with_report(LocalCopyExecution::DryRun, options)

--- a/crates/engine/src/local_copy/tests/execute_modify_window.rs
+++ b/crates/engine/src/local_copy/tests/execute_modify_window.rs
@@ -39,7 +39,7 @@ fn modify_window_skips_files_within_one_second_window() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(1)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -78,7 +78,7 @@ fn modify_window_copies_files_outside_one_second_window() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(1)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -118,7 +118,7 @@ fn modify_window_two_seconds_for_fat_filesystems() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(2)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(2)),
         )
         .expect("copy succeeds");
 
@@ -153,7 +153,7 @@ fn modify_window_sixty_seconds_for_large_tolerance() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(60)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(60)),
         )
         .expect("copy succeeds");
 
@@ -187,7 +187,7 @@ fn modify_window_sixty_seconds_copies_when_outside() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(60)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(60)),
         )
         .expect("copy succeeds");
 
@@ -285,7 +285,7 @@ fn modify_window_applies_symmetrically_source_older() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(1)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -318,7 +318,7 @@ fn modify_window_applies_symmetrically_source_newer() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(1)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -351,7 +351,7 @@ fn modify_window_symmetry_boundary_at_exact_limit() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(2)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(2)),
         )
         .expect("copy succeeds");
 
@@ -385,7 +385,7 @@ fn modify_window_with_update_skips_when_dest_newer_outside_window() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .update(true)
-                .with_modify_window(Duration::from_secs(1)),
+                .with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -428,7 +428,7 @@ fn modify_window_with_update_skips_when_dest_slightly_newer() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .update(true)
-                .with_modify_window(Duration::from_secs(1)),
+                .with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -467,7 +467,7 @@ fn modify_window_with_update_skips_when_dest_newer_within_window_despite_size_di
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .update(true)
-                .with_modify_window(Duration::from_secs(1)),
+                .with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -506,7 +506,7 @@ fn modify_window_with_update_copies_when_source_definitively_newer() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .update(true)
-                .with_modify_window(Duration::from_secs(1)),
+                .with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -549,7 +549,7 @@ fn modify_window_with_update_skips_when_source_slightly_newer_within_window() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .update(true)
-                .with_modify_window(Duration::from_secs(2)),
+                .with_modify_window(ModifyWindow::from_secs(2)),
         )
         .expect("copy succeeds");
 
@@ -591,7 +591,7 @@ fn modify_window_with_update_copies_when_source_at_exact_window_boundary() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .update(true)
-                .with_modify_window(Duration::from_secs(2)),
+                .with_modify_window(ModifyWindow::from_secs(2)),
         )
         .expect("copy succeeds");
 
@@ -641,7 +641,7 @@ fn modify_window_recursive_mixed_timestamps() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .recursive(true)
-                .with_modify_window(Duration::from_secs(1)),
+                .with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -695,7 +695,7 @@ fn modify_window_subsecond_same_second_skips() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(1)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -726,7 +726,7 @@ fn modify_window_with_different_file_sizes_always_copies() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(1)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -763,7 +763,7 @@ fn modify_window_with_ignore_times_always_copies() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .ignore_times(true)
-                .with_modify_window(Duration::from_secs(1)),
+                .with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -798,7 +798,7 @@ fn modify_window_with_size_only_ignores_timestamps() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .size_only(true)
-                .with_modify_window(Duration::from_secs(1)),
+                .with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -830,7 +830,7 @@ fn modify_window_dry_run_reports_correctly() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::DryRun,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(1)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("dry run succeeds");
 
@@ -878,7 +878,7 @@ fn modify_window_dry_run_absorbs_within_window_mtime_drift() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::DryRun,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(2)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(2)),
         )
         .expect("dry run succeeds");
 
@@ -980,7 +980,7 @@ fn modify_window_matches_upstream_rsync_semantics() {
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_secs(2)),
+            LocalCopyOptions::default().with_modify_window(ModifyWindow::from_secs(2)),
         )
         .expect("copy succeeds");
 

--- a/crates/engine/src/local_copy/tests/execute_skip.rs
+++ b/crates/engine/src/local_copy/tests/execute_skip.rs
@@ -1804,7 +1804,7 @@ fn execute_skips_within_modify_window() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .times(true)
-                .with_modify_window(Duration::from_secs(2)),
+                .with_modify_window(ModifyWindow::from_secs(2)),
         )
         .expect("copy succeeds");
 
@@ -1839,7 +1839,7 @@ fn execute_skip_transfers_outside_modify_window() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .times(true)
-                .with_modify_window(Duration::from_secs(2)),
+                .with_modify_window(ModifyWindow::from_secs(2)),
         )
         .expect("copy succeeds");
 
@@ -2233,7 +2233,7 @@ fn execute_skip_update_respects_modify_window() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .update(true)
-                .with_modify_window(Duration::from_secs(2)),
+                .with_modify_window(ModifyWindow::from_secs(2)),
         )
         .expect("copy succeeds");
 

--- a/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
+++ b/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
@@ -571,7 +571,7 @@ fn modify_window_tolerates_small_differences() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .times(true)
-                .with_modify_window(Duration::from_secs(1)),  // 1 second tolerance
+                .with_modify_window(ModifyWindow::from_secs(1)),  // 1 second tolerance
         )
         .expect("copy succeeds");
 

--- a/crates/engine/src/local_copy/tests/executor_file_comparison.rs
+++ b/crates/engine/src/local_copy/tests/executor_file_comparison.rs
@@ -25,7 +25,7 @@ mod file_comparison_tests {
             ignore_times: false,
             checksum: false,
             checksum_algorithm: SignatureAlgorithm::Md4,
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: None,
         };
 
@@ -58,7 +58,7 @@ mod file_comparison_tests {
             ignore_times: false,
             checksum: false,
             checksum_algorithm: SignatureAlgorithm::Md4,
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: None,
         };
 
@@ -87,7 +87,7 @@ mod file_comparison_tests {
             ignore_times: false,
             checksum: false,
             checksum_algorithm: SignatureAlgorithm::Md4,
-            modify_window: Duration::from_secs(3600), // 1 hour window
+            modify_window: ModifyWindow::from_secs(3600), // 1 hour window
             prefetched_match: None,
         };
 
@@ -117,7 +117,7 @@ mod file_comparison_tests {
             ignore_times: false,
             checksum: false,
             checksum_algorithm: SignatureAlgorithm::Md4,
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: None,
         };
 
@@ -147,7 +147,7 @@ mod file_comparison_tests {
             ignore_times: true,
             checksum: false,
             checksum_algorithm: SignatureAlgorithm::Md4,
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: None,
         };
 
@@ -175,7 +175,7 @@ mod file_comparison_tests {
             ignore_times: false,
             checksum: true,
             checksum_algorithm: SignatureAlgorithm::Md4,
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: None,
         };
 
@@ -204,7 +204,7 @@ mod file_comparison_tests {
             ignore_times: false,
             checksum: true,
             checksum_algorithm: SignatureAlgorithm::Md4,
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: None,
         };
 
@@ -232,7 +232,7 @@ mod file_comparison_tests {
             ignore_times: false,
             checksum: true,
             checksum_algorithm: SignatureAlgorithm::Md4,
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: Some(true), // Prefetched indicates match
         };
 
@@ -260,7 +260,7 @@ mod file_comparison_tests {
             ignore_times: false,
             checksum: true,
             checksum_algorithm: SignatureAlgorithm::Md4,
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: Some(false), // Prefetched indicates no match
         };
 
@@ -480,7 +480,7 @@ mod file_comparison_tests {
             checksum_algorithm: SignatureAlgorithm::Md5 {
                 seed_config: checksums::strong::Md5Seed::proper(42),
             },
-            modify_window: Duration::ZERO,
+            modify_window: ModifyWindow::ZERO,
             prefetched_match: None,
         };
 

--- a/crates/engine/src/local_copy/tests/mod.rs
+++ b/crates/engine/src/local_copy/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::signature::SignatureAlgorithm;
 use ::metadata::ChmodModifiers;
+use ::metadata::ModifyWindow;
 use ::test_support::create_tempdir;
 use bandwidth::BandwidthLimiter;
 use compress::algorithm::CompressionAlgorithm;

--- a/crates/engine/src/local_copy/tests/options.rs
+++ b/crates/engine/src/local_copy/tests/options.rs
@@ -29,10 +29,10 @@ fn local_copy_options_fsync_round_trip() {
 
 #[test]
 fn local_copy_options_modify_window_round_trip() {
-    let window = Duration::from_secs(5);
+    let window = ModifyWindow::from_secs(5);
     let options = LocalCopyOptions::default().with_modify_window(window);
     assert_eq!(options.modify_window(), window);
-    assert_eq!(LocalCopyOptions::default().modify_window(), Duration::ZERO);
+    assert_eq!(LocalCopyOptions::default().modify_window(), ModifyWindow::ZERO);
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn should_skip_copy_requires_exact_mtime_when_window_zero() {
         ignore_times: false,
         checksum: false,
         checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
-        modify_window: Duration::ZERO,
+        modify_window: ModifyWindow::ZERO,
         prefetched_match: None,
     }));
 }
@@ -97,7 +97,7 @@ fn should_skip_copy_allows_difference_within_window() {
         ignore_times: false,
         checksum: false,
         checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
-        modify_window: Duration::from_secs(5),
+        modify_window: ModifyWindow::from_secs(5),
         prefetched_match: None,
     }));
 
@@ -113,7 +113,7 @@ fn should_skip_copy_allows_difference_within_window() {
         ignore_times: false,
         checksum: false,
         checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
-        modify_window: Duration::from_secs(5),
+        modify_window: ModifyWindow::from_secs(5),
         prefetched_match: None,
     }));
 }
@@ -142,7 +142,7 @@ fn should_skip_copy_skips_when_size_and_mtime_match_unless_ignored() {
         ignore_times: false,
         checksum: false,
         checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
-        modify_window: Duration::ZERO,
+        modify_window: ModifyWindow::ZERO,
         prefetched_match: None,
     }));
 
@@ -155,7 +155,7 @@ fn should_skip_copy_skips_when_size_and_mtime_match_unless_ignored() {
         ignore_times: true,
         checksum: false,
         checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
-        modify_window: Duration::ZERO,
+        modify_window: ModifyWindow::ZERO,
         prefetched_match: None,
     }));
 }

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -107,6 +107,10 @@ mod chmod;
 pub mod copy_as;
 mod error;
 
+/// Signed `--modify-window` tolerance and the `same_time()` mtime comparison.
+pub mod modify_window;
+pub use modify_window::ModifyWindow;
+
 /// UID/GID lookup and mapping utilities.
 pub mod id_lookup;
 

--- a/crates/metadata/src/modify_window.rs
+++ b/crates/metadata/src/modify_window.rs
@@ -1,0 +1,106 @@
+//! Signed modification-time comparison tolerance (`--modify-window`).
+//!
+//! Mirrors upstream rsync's `int modify_window` (options.c:143), which the
+//! generator consults through `same_time()` when deciding whether a
+//! destination file is already up to date. The value is deliberately signed:
+//! a negative window requests nanosecond-exact comparison rather than the
+//! default whole-second tolerance.
+
+/// Signed whole-second tolerance for the mtime quick-check.
+///
+/// Semantics mirror upstream `util1.c:1478 same_time()`:
+/// - `0` (default): whole-second equality; any sub-second difference is ignored.
+/// - `> 0`: symmetric whole-second window; nanoseconds are ignored.
+/// - `< 0`: nanosecond-exact comparison - both the whole seconds and the
+///   nanoseconds must be equal.
+///
+/// upstream: options.c:143 `int modify_window` / util1.c:1478 `same_time()`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ModifyWindow(i64);
+
+impl ModifyWindow {
+    /// The default zero-second window (whole-second equality).
+    pub const ZERO: Self = Self(0);
+
+    /// Builds a window from a signed whole-second count.
+    ///
+    /// A negative `secs` selects nanosecond-exact comparison, matching
+    /// upstream's `modify_window < 0` branch (util1.c:1482).
+    #[must_use]
+    pub const fn from_secs(secs: i64) -> Self {
+        Self(secs)
+    }
+
+    /// Returns the signed whole-second window value (upstream's `int
+    /// modify_window`).
+    #[must_use]
+    pub const fn as_secs(self) -> i64 {
+        self.0
+    }
+
+    /// Reports whether the window requests nanosecond-exact comparison.
+    #[must_use]
+    pub const fn is_nsec_exact(self) -> bool {
+        self.0 < 0
+    }
+
+    /// Returns `true` when two mtimes are "the same" under this window.
+    ///
+    /// Direct port of upstream `util1.c:1478 same_time()`:
+    /// - `window == 0`: `f1_sec == f2_sec` (nanoseconds ignored).
+    /// - `window < 0`: `f1_sec == f2_sec && f1_nsec == f2_nsec` (nsec-exact).
+    /// - `window > 0`: `|f1_sec - f2_sec| <= window` (nanoseconds ignored -
+    ///   upstream note: "time windows don't care about that", util1.c:1484).
+    #[must_use]
+    pub fn same_time(self, f1_sec: i64, f1_nsec: u32, f2_sec: i64, f2_nsec: u32) -> bool {
+        // upstream: util1.c:1480
+        if self.0 == 0 {
+            return f1_sec == f2_sec;
+        }
+        // upstream: util1.c:1482 - a negative window compares nanoseconds too.
+        if self.0 < 0 {
+            return f1_sec == f2_sec && f1_nsec == f2_nsec;
+        }
+        // upstream: util1.c:1485-1487 - symmetric second window; the value is
+        // positive here, so the cast to u64 for `abs_diff` is lossless.
+        f1_sec.abs_diff(f2_sec) <= self.0 as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ModifyWindow;
+
+    #[test]
+    fn zero_window_compares_whole_seconds_only() {
+        // Why: upstream same_time() with modify_window == 0 returns
+        // `f1_sec == f2_sec`, so a purely sub-second difference must still be
+        // treated as equal (no needless re-transfer).
+        let w = ModifyWindow::ZERO;
+        assert!(w.same_time(100, 0, 100, 999_999_999));
+        assert!(!w.same_time(100, 0, 101, 0));
+    }
+
+    #[test]
+    fn positive_window_tolerates_second_drift_and_ignores_nsec() {
+        // Why: upstream applies a symmetric whole-second window and explicitly
+        // ignores nanoseconds ("time windows don't care about that").
+        let w = ModifyWindow::from_secs(2);
+        assert!(w.same_time(100, 0, 102, 0));
+        assert!(w.same_time(102, 0, 100, 0));
+        assert!(!w.same_time(100, 0, 103, 0));
+        assert!(w.same_time(100, 500, 102, 999)); // nsec ignored
+    }
+
+    #[test]
+    fn negative_window_requires_nanosecond_exactness() {
+        // Why: `--modify-window=-1` selects upstream's `modify_window < 0`
+        // branch, where two files differing only in the sub-second component
+        // are considered DIFFERENT and must be transferred.
+        let w = ModifyWindow::from_secs(-1);
+        assert!(w.is_nsec_exact());
+        assert!(w.same_time(100, 500, 100, 500));
+        assert!(!w.same_time(100, 500, 100, 501));
+        assert!(!w.same_time(100, 0, 101, 0));
+    }
+}

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -23,7 +23,7 @@ use std::time::SystemTime;
 
 use compress::zlib::CompressionLevel;
 use engine::SkipCompressList;
-use metadata::{ChmodModifiers, GroupMapping, UserMapping};
+use metadata::{ChmodModifiers, GroupMapping, ModifyWindow, UserMapping};
 use protocol::FilenameConverter;
 use protocol::ProtocolVersion;
 use protocol::filters::FilterRuleWireFormat;
@@ -440,8 +440,11 @@ impl ServerConfigBuilder {
     }
 
     /// Sets the `--modify-window` mtime comparison tolerance in whole seconds.
-    pub fn modify_window(&mut self, seconds: u64) -> &mut Self {
-        self.file_selection.modify_window = seconds;
+    ///
+    /// A negative `seconds` selects upstream's nanosecond-exact comparison
+    /// (`modify_window < 0`, util1.c:1482).
+    pub fn modify_window(&mut self, seconds: i64) -> &mut Self {
+        self.file_selection.modify_window = ModifyWindow::from_secs(seconds);
         self
     }
 

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 
 use compress::zlib::CompressionLevel;
 use engine::SkipCompressList;
-use metadata::{ChmodModifiers, GroupMapping, UserMapping};
+use metadata::{ChmodModifiers, GroupMapping, ModifyWindow, UserMapping};
 use protocol::FilenameConverter;
 use protocol::ProtocolVersion;
 use protocol::filters::FilterRuleWireFormat;
@@ -190,13 +190,15 @@ pub struct FileSelectionConfig {
     pub existing_only: bool,
     /// Compare only file sizes, ignoring modification times (`--size-only`).
     pub size_only: bool,
-    /// Modification-time comparison tolerance in whole seconds (`--modify-window`).
+    /// Modification-time comparison tolerance (`--modify-window`).
     ///
     /// When zero (the default) the quick-check requires exact whole-second
     /// mtime equality. When positive, two mtimes are treated as equal if their
-    /// whole-second delta does not exceed this value, matching upstream
-    /// `util1.c:same_time()` consulted via `generator.c:quick_check_ok()`.
-    pub modify_window: u64,
+    /// whole-second delta does not exceed this value. When negative, a
+    /// nanosecond-exact comparison is required, matching upstream
+    /// `util1.c:same_time()` (the signed `int modify_window`) consulted via
+    /// `generator.c:quick_check_ok()`.
+    pub modify_window: ModifyWindow,
     /// Path for `--files-from` when the server reads the file list directly.
     pub files_from_path: Option<String>,
     /// Use NUL bytes as delimiters for `--files-from` input (`--from0`).

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -14,7 +14,7 @@ use protocol::flist::FileEntry;
 use crate::config::{ReferenceDirectory, ReferenceDirectoryKind};
 use crate::delta_apply::ChecksumVerifier;
 
-use metadata::{AclIdMapper, MetadataOptions, apply_metadata_with_cached_stat};
+use metadata::{AclIdMapper, MetadataOptions, ModifyWindow, apply_metadata_with_cached_stat};
 use protocol::acl::AclCache;
 
 use super::apply_acls_from_receiver_cache;
@@ -31,26 +31,6 @@ use super::apply_acls_from_receiver_cache;
 /// - `hlink.c:284` - `hard_link_check()` called for non-first entries
 pub(super) fn is_hardlink_follower(entry: &FileEntry) -> bool {
     entry.hlinked() && !entry.hlink_first()
-}
-
-/// Returns `true` when two whole-second mtimes are the "same" under
-/// `--modify-window`, a direct port of upstream `util1.c:1478 same_time()`.
-///
-/// The receiver compares `time_t` seconds (`st_mtime` vs the file-list entry's
-/// `modtime`), so nanoseconds never enter this predicate - upstream likewise
-/// ignores them for the window check ("time windows don't care about that").
-///
-/// - `window == 0`: the seconds must be exactly equal (`f1_sec == f2_sec`).
-/// - `window > 0`: a SYMMETRIC whole-second tolerance applies, matching upstream
-///   `f2_sec > f1_sec ? f2_sec - f1_sec <= modify_window : f1_sec - f2_sec <=
-///   modify_window`, i.e. `|a_sec - b_sec| <= window`.
-///
-/// upstream: util1.c:1478 same_time() (via generator.c:quick_check_ok()).
-fn same_time(a_sec: i64, b_sec: i64, window: u64) -> bool {
-    if window == 0 {
-        return a_sec == b_sec;
-    }
-    a_sec.abs_diff(b_sec) <= window
 }
 
 /// Pure-function quick-check: compares destination stat against source entry.
@@ -70,7 +50,7 @@ pub(super) fn quick_check_matches(
     preserve_times: bool,
     size_only: bool,
     always_checksum: Option<protocol::ChecksumAlgorithm>,
-    modify_window: u64,
+    modify_window: ModifyWindow,
 ) -> bool {
     // upstream: generator.c:621 - size check first
     if dest_meta.len() != entry.size() {
@@ -95,11 +75,17 @@ pub(super) fn quick_check_matches(
         return false;
     }
     // upstream: generator.c:645 - `mtime_differs()` -> `same_time()` applies the
-    // `--modify-window` tolerance symmetrically on whole seconds.
+    // `--modify-window` tolerance. A negative window compares nanoseconds too
+    // (util1.c:1482), so pass the sub-second component from both sides.
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
-        same_time(dest_meta.mtime(), entry.mtime(), modify_window)
+        modify_window.same_time(
+            dest_meta.mtime(),
+            dest_meta.mtime_nsec() as u32,
+            entry.mtime(),
+            entry.mtime_nsec(),
+        )
     }
     #[cfg(not(unix))]
     {
@@ -108,7 +94,12 @@ pub(super) fn quick_check_matches(
             .ok()
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
             .map_or(false, |d| {
-                same_time(d.as_secs() as i64, entry.mtime(), modify_window)
+                modify_window.same_time(
+                    d.as_secs() as i64,
+                    d.subsec_nanos(),
+                    entry.mtime(),
+                    entry.mtime_nsec(),
+                )
             })
     }
 }
@@ -243,7 +234,7 @@ pub(super) fn try_reference_dest(
     preserve_times: bool,
     size_only: bool,
     always_checksum: Option<protocol::ChecksumAlgorithm>,
-    modify_window: u64,
+    modify_window: ModifyWindow,
     copy_links: bool,
     metadata_opts: &MetadataOptions,
     metadata_errors: &mut Vec<(PathBuf, String)>,
@@ -481,7 +472,7 @@ mod info_copy_emission_tests {
     use metadata::MetadataOptions;
     use protocol::flist::FileEntry;
 
-    use super::try_reference_dest;
+    use super::{ModifyWindow, try_reference_dest};
     use crate::config::{ReferenceDirectory, ReferenceDirectoryKind};
 
     fn copy_messages() -> Vec<String> {
@@ -543,7 +534,7 @@ mod info_copy_emission_tests {
             false,
             true,
             None,
-            0,
+            ModifyWindow::from_secs(0),
             false,
             &metadata_opts,
             &mut metadata_errors,
@@ -604,7 +595,7 @@ mod info_copy_emission_tests {
             false,
             true,
             None,
-            0,
+            ModifyWindow::from_secs(0),
             false,
             &metadata_opts,
             &mut metadata_errors,
@@ -647,7 +638,7 @@ mod symlink_basis_tests {
     use metadata::MetadataOptions;
     use protocol::flist::FileEntry;
 
-    use super::try_reference_dest;
+    use super::{ModifyWindow, try_reference_dest};
     use crate::config::{ReferenceDirectory, ReferenceDirectoryKind};
 
     fn setup_symlink_basis() -> (tempfile::TempDir, PathBuf, PathBuf) {
@@ -696,7 +687,7 @@ mod symlink_basis_tests {
             false,
             true,
             None,
-            0,
+            ModifyWindow::from_secs(0),
             copy_links,
             &metadata_opts,
             &mut metadata_errors,
@@ -900,17 +891,30 @@ mod modify_window_tests {
     use filetime::{FileTime, set_file_mtime};
     use protocol::flist::FileEntry;
 
-    use super::quick_check_matches;
+    use super::{ModifyWindow, quick_check_matches};
 
     /// Builds a dest file at `dest_secs` and a source entry claiming `src_secs`,
     /// both the same size, then runs the quick-check with `preserve_times=true`,
     /// `size_only=false`, no checksum, at the given `window`.
-    fn run_window(src_secs: i64, dest_secs: i64, window: u64) -> bool {
+    fn run_window(src_secs: i64, dest_secs: i64, window: ModifyWindow) -> bool {
+        run_window_nsec(src_secs, 0, dest_secs, 0, window)
+    }
+
+    /// Like [`run_window`] but with explicit nanosecond components, so the
+    /// negative-window (nanosecond-exact) path can be exercised.
+    fn run_window_nsec(
+        src_secs: i64,
+        src_nsec: u32,
+        dest_secs: i64,
+        dest_nsec: u32,
+        window: ModifyWindow,
+    ) -> bool {
         let dir = tempfile::tempdir().expect("tempdir");
         let dest_path = dir.path().join("payload.bin");
         let payload = b"identical content";
         fs::write(&dest_path, payload).expect("write dest");
-        set_file_mtime(&dest_path, FileTime::from_unix_time(dest_secs, 0)).expect("set dest mtime");
+        set_file_mtime(&dest_path, FileTime::from_unix_time(dest_secs, dest_nsec))
+            .expect("set dest mtime");
 
         // Read back the on-disk mtime so the assertion reflects what the
         // filesystem actually stored (the quick-check reads dest_meta.mtime()).
@@ -922,7 +926,7 @@ mod modify_window_tests {
         );
 
         let mut entry = FileEntry::new_file("payload.bin".into(), payload.len() as u64, 0o644);
-        entry.set_mtime(src_secs, 0);
+        entry.set_mtime(src_secs, src_nsec);
 
         quick_check_matches(&entry, &dest_path, &dest_meta, true, false, None, window)
     }
@@ -936,15 +940,15 @@ mod modify_window_tests {
         let base = 1_700_000_000;
         // Both directions of drift must skip (same_time is symmetric).
         assert!(
-            run_window(base, base + 2, 2),
+            run_window(base, base + 2, ModifyWindow::from_secs(2)),
             "dest +2s within window must skip"
         );
         assert!(
-            run_window(base, base - 2, 2),
+            run_window(base, base - 2, ModifyWindow::from_secs(2)),
             "dest -2s within window must skip"
         );
         assert!(
-            run_window(base, base + 1, 2),
+            run_window(base, base + 1, ModifyWindow::from_secs(2)),
             "dest +1s within window must skip"
         );
     }
@@ -955,11 +959,11 @@ mod modify_window_tests {
     fn beyond_window_two_is_transferred() {
         let base = 1_700_000_000;
         assert!(
-            !run_window(base, base + 3, 2),
+            !run_window(base, base + 3, ModifyWindow::from_secs(2)),
             "dest +3s beyond window must transfer"
         );
         assert!(
-            !run_window(base, base - 3, 2),
+            !run_window(base, base - 3, ModifyWindow::from_secs(2)),
             "dest -3s beyond window must transfer"
         );
     }
@@ -971,12 +975,38 @@ mod modify_window_tests {
     fn zero_window_requires_exact_seconds() {
         let base = 1_700_000_000;
         assert!(
-            run_window(base, base, 0),
+            run_window(base, base, ModifyWindow::from_secs(0)),
             "equal mtimes at window 0 must skip"
         );
         assert!(
-            !run_window(base, base + 1, 0),
+            !run_window(base, base + 1, ModifyWindow::from_secs(0)),
             "1s delta at window 0 must transfer"
+        );
+    }
+
+    /// With `--modify-window=-1` the quick-check requires nanosecond-exact
+    /// equality (upstream `modify_window < 0`, util1.c:1482): two files sharing
+    /// a whole second but differing in the sub-second component are DIFFERENT
+    /// and must be transferred, whereas any non-negative window skips them.
+    #[test]
+    fn negative_window_requires_nanosecond_exactness() {
+        let base = 1_700_000_000;
+        let exact = ModifyWindow::from_secs(-1);
+        // Same second, differing nanoseconds -> transfer under nsec-exact mode.
+        assert!(
+            !run_window_nsec(base, 500_000_000, base, 0, exact),
+            "sub-second mtime drift must transfer at window -1"
+        );
+        // Identical seconds and nanoseconds -> still skipped.
+        assert!(
+            run_window_nsec(base, 0, base, 0, exact),
+            "identical mtimes must skip even at window -1"
+        );
+        // A zero window ignores the same sub-second drift and skips, proving the
+        // negative window is what makes the difference observable.
+        assert!(
+            run_window_nsec(base, 500_000_000, base, 0, ModifyWindow::from_secs(0)),
+            "sub-second drift is ignored at window 0"
         );
     }
 }


### PR DESCRIPTION
## Summary

Upstream rsync parses `--modify-window` / `-@` as a **signed** `int` (options.c:660, `POPT_ARG_INT`) and a **negative** value requests nanosecond-exact mtime comparison in `same_time()` (util1.c:1482): both the whole seconds *and* the nanoseconds must be equal. oc-rsync previously typed the window as `u64`/`Duration` end to end and hard-rejected negative values, so it could not honor `--modify-window=-1` and diverged from upstream.

## Changes

- **New `metadata::ModifyWindow`** signed-second type with a single `same_time()` helper (a direct port of util1.c:1478), reused by **both** quick-check engines (transfer receiver `quick_check` and engine local-copy `comparison`) - no duplicated compare logic.
- **Parse:** accept negative values (removed the two hard rejects); added the `-@` short alias with `allow_hyphen_values`, so `-@-1`, `-@2`, and `-@ 2` all parse to the same value as `--modify-window`.
- **Compare:** `window < 0` performs a nanosecond-exact compare in both engines; `window >= 0` behaviour is unchanged. `--update` arithmetic uses signed `i64` (no underflow on a negative window).
- **Wire:** mirrors options.c:2873 - the window is forwarded to the remote only when the local side is the sender, using the short `-@%d` spelling for a negative window (e.g. `-@-1`) and `--modify-window=%d` otherwise. The `--server` and daemon argument parsers recognise the `-@` token.

## Verification (Linux, aarch64, vs upstream rsync 3.4.4)

Seal matrix - `window ∈ {-1,0,1,2}` × `delta ∈ {sub-second, whole-second}` × `{local, ssh}`, comparing skip/transfer decisions. oc == upstream in **all 16 cells**:

| window | sub-second | whole-second |
|--------|-----------|-------------|
| -1 (nsec-exact) | transfer | transfer |
| 0 | skip | transfer |
| 1 | skip | skip |
| 2 | skip | skip |

Server argv captured over SSH confirms oc emits `-@-1` for the negative window (byte-identical to upstream) and `--modify-window=N` for non-negative windows. `-@2` / `-@ 2` / `--modify-window=2` all parse identically to upstream.

Tests added encode the *why* (negative window = nsec-exact per upstream `cmp_time`) at the type, both quick-check engines, argument parsing (long + `-@` short), and the wire spelling/direction gating.

`cargo fmt`, `cargo clippy -D warnings`, and `cargo check --target x86_64-pc-windows-gnu` all clean on the touched crates.