### PR TITLE
fix(cli): match upstream short-option and --stderr argument parsing

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -16,7 +16,7 @@ use crate::frontend::arguments::short_options::{
 use crate::frontend::command_builder::clap_command;
 use crate::frontend::execution::{parse_checksum_seed_argument, parse_compress_level_argument};
 use crate::frontend::filter_rules::{FilterOrderToken, build_filter_order};
-use crate::frontend::progress::{NameOutputLevel, ProgressSetting};
+use crate::frontend::progress::{NameOutputLevel, ProgressSetting, StderrMode};
 use core::client::{
     AddressMode, DeleteMode, HumanReadableMode, StrongChecksumChoice, TcpFastOpenMode,
 };
@@ -447,6 +447,22 @@ where
     let implied_dirs = tri_state_flag_positive_first(&matches, "implied-dirs", "no-implied-dirs");
     let msgs_to_stderr = tri_state_flag_positive_first(&matches, "msgs2stderr", "no-msgs2stderr");
     let stderr_mode = matches.remove_one::<OsString>("stderr");
+    // upstream: options.c:1912 OPT_STDERR rejects any value that is not a
+    // non-empty prefix of "errors", "all", or "client" with this exact message.
+    if let Some(value) = stderr_mode.as_ref() {
+        let valid = value
+            .to_str()
+            .is_some_and(|text| StderrMode::from_str(text).is_some());
+        if !valid {
+            return Err(clap::Error::raw(
+                clap::error::ErrorKind::ValueValidation,
+                format!(
+                    "--stderr mode \"{}\" is not one of errors, all, or client\n",
+                    value.to_string_lossy()
+                ),
+            ));
+        }
+    }
     let outbuf = matches.remove_one::<OsString>("outbuf");
     let max_alloc = matches.remove_one::<OsString>("max-alloc");
     let stats = matches.get_flag("stats");

--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -7,7 +7,6 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 
 use clap::Command as ClapCommand;
-use clap::builder::ValueRange;
 
 /// Reorders arguments so that recognised options precede positional operands,
 /// mirroring upstream rsync's popt-based parsing which accepts options in any
@@ -246,17 +245,23 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
             continue;
         };
 
-        let num_args = argument.get_num_args().unwrap_or(ValueRange::EMPTY);
-        let min_values = num_args.min_values();
-
         // Arguments that require at least one value (for example `-M` or
         // `-f<rule>`) must only appear at the end of a cluster so the
         // following argument can be treated as their value. Optional
-        // arguments (such as `-h`, which accepts `-h` or `-h=2`) are
-        // treated as simple flags to preserve existing clap behaviour;
-        // packing a value onto an optional-value short flag is not
-        // supported by upstream rsync.
-        let requires_value = min_values > 0;
+        // arguments (such as `-h`, which is an `ArgAction::Count` flag) are
+        // treated as simple flags; packing a value onto an optional-value
+        // short flag is not supported by upstream rsync.
+        //
+        // Honour an explicit `num_args`; otherwise fall back to whether the
+        // action consumes a value, mirroring `classify_long_options`. A
+        // value-bearing short with a defaulted arity (for example `-T`, whose
+        // Arg sets a `value_parser` but no explicit `num_args`, so its action
+        // defaults to `Set`) would otherwise be misclassified as a flag and
+        // the packed/`=`-joined forms (`-T/tmp`, `-T=/tmp`) rejected.
+        let requires_value = argument
+            .get_num_args()
+            .map(|range| range.min_values() > 0)
+            .unwrap_or_else(|| argument.get_action().takes_values());
 
         if requires_value {
             value_options.extend(shorts);
@@ -549,6 +554,33 @@ mod tests {
                 OsString::from("-C"),
             ]
         );
+    }
+
+    #[test]
+    fn expand_short_options_value_short_without_explicit_num_args() {
+        // Regression: a value-bearing short whose Arg sets a value_parser but no
+        // explicit num_args (its action defaults to Set) must still be treated
+        // as value-taking, so `-T=/tmp` and `-T/tmp` expand instead of being
+        // rejected as unknown options. Mirrors the real `--temp-dir`/`-T` Arg.
+        let command = ClapCommand::new("rsync").arg(
+            clap::Arg::new("temp-dir")
+                .short('T')
+                .long("temp-dir")
+                .value_parser(clap::builder::OsStringValueParser::new()),
+        );
+        for (input, value) in [("-T=/tmp", "/tmp"), ("-T/tmp", "/tmp")] {
+            let args = vec![OsString::from("rsync"), OsString::from(input)];
+            let expanded = expand_short_options(&command, args);
+            assert_eq!(
+                expanded,
+                vec![
+                    OsString::from("rsync"),
+                    OsString::from("-T"),
+                    OsString::from(value),
+                ],
+                "{input}"
+            );
+        }
     }
 
     fn hoist_command() -> ClapCommand {

--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -294,7 +294,13 @@ fn expand_cluster(
             // `-` as additional short options.
             let next_offset = offset + short.len_utf8();
             if next_offset < cluster.len() {
-                fragments.push(cluster[next_offset..].to_owned());
+                let remainder = &cluster[next_offset..];
+                // popt (and clap for the un-expanded `-o=value` form) strip a
+                // single '=' that joins a short option to its packed value, so
+                // `-B=4096` -> `4096` and `-T=/tmp` -> `/tmp`. Mirror that here
+                // for every value-bearing short. upstream: popt short-arg parse.
+                let value = remainder.strip_prefix('=').unwrap_or(remainder);
+                fragments.push(value.to_owned());
             }
             return Some(fragments);
         } else if flag_options.contains(&short) {
@@ -435,6 +441,31 @@ mod tests {
         assert_eq!(
             result,
             Some(vec!["-z".to_owned(), "-v".to_owned(), "-a".to_owned()])
+        );
+    }
+
+    #[test]
+    fn expand_cluster_strips_equals_from_packed_value() {
+        // popt strips one '=' joining a short option to its packed value, so
+        // `-B=4096` -> `-B 4096` and `-T=/tmp` -> `-T /tmp`. Only one '=' goes.
+        let flags = HashSet::new();
+        let values = make_flags("BT");
+        assert_eq!(
+            expand_cluster("-B=4096", &flags, &values),
+            Some(vec!["-B".to_owned(), "4096".to_owned()])
+        );
+        assert_eq!(
+            expand_cluster("-T=/tmp", &flags, &values),
+            Some(vec!["-T".to_owned(), "/tmp".to_owned()])
+        );
+        assert_eq!(
+            expand_cluster("-T==foo", &flags, &values),
+            Some(vec!["-T".to_owned(), "=foo".to_owned()])
+        );
+        // The attached (no '=') form is untouched.
+        assert_eq!(
+            expand_cluster("-B4096", &flags, &values),
+            Some(vec!["-B".to_owned(), "4096".to_owned()])
         );
     }
 

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1287,6 +1287,40 @@ mod option_values {
     }
 
     #[test]
+    fn block_size_short_b_forms_match_long() {
+        // upstream: options.c:752 {"block-size", 'B', ...}. -B/-B<v>/-B=<v> and
+        // --block-size all yield the same value (popt/clap strip the '=').
+        let expected = Some(OsString::from("4096"));
+        for args in [
+            vec!["-B", "4096", "src/", "dst/"],
+            vec!["-B4096", "src/", "dst/"],
+            vec!["-B=4096", "src/", "dst/"],
+            vec!["--block-size", "4096", "src/", "dst/"],
+        ] {
+            let parsed =
+                parse_test_args(args.clone()).unwrap_or_else(|_| panic!("{args:?} should parse"));
+            assert_eq!(parsed.block_size, expected, "{args:?}");
+        }
+    }
+
+    #[test]
+    fn temp_dir_short_t_forms_match_long() {
+        // upstream: options.c:825 {"temp-dir", 'T', ...}. -T/-T<v>/-T=<v> and
+        // --temp-dir all yield the same DIR (the leading '=' is stripped).
+        let expected = Some(std::path::PathBuf::from("/tmp/rsync-temp"));
+        for args in [
+            vec!["-T", "/tmp/rsync-temp", "src/", "dst/"],
+            vec!["-T/tmp/rsync-temp", "src/", "dst/"],
+            vec!["-T=/tmp/rsync-temp", "src/", "dst/"],
+            vec!["--temp-dir=/tmp/rsync-temp", "src/", "dst/"],
+        ] {
+            let parsed =
+                parse_test_args(args.clone()).unwrap_or_else(|_| panic!("{args:?} should parse"));
+            assert_eq!(parsed.temp_dir, expected, "{args:?}");
+        }
+    }
+
+    #[test]
     fn io_uring_depth_accepts_power_of_two() {
         let parsed = parse_test_args(["--io-uring-depth=256", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.io_uring_depth, Some(256));
@@ -2659,6 +2693,38 @@ mod msgs_stderr_tests {
     fn stderr_mode_option() {
         let parsed = parse_test_args(["--stderr=errors", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.stderr_mode, Some(OsString::from("errors")));
+    }
+
+    #[test]
+    fn stderr_mode_accepts_upstream_prefixes() {
+        // upstream: options.c:1912 OPT_STDERR accepts any non-empty prefix of
+        // errors/all/client (strncmp), so e/err/al/cli all parse.
+        for value in [
+            "e", "err", "error", "errors", "a", "al", "all", "c", "cli", "client",
+        ] {
+            let arg = format!("--stderr={value}");
+            let parsed = parse_test_args([arg.as_str(), "src/", "dst/"])
+                .unwrap_or_else(|_| panic!("--stderr={value} should be accepted"));
+            assert_eq!(parsed.stderr_mode, Some(OsString::from(value)));
+        }
+    }
+
+    #[test]
+    fn stderr_mode_rejects_invalid_with_upstream_message() {
+        // upstream rejects non-prefixes and (case-sensitively) uppercase forms
+        // with: --stderr mode "X" is not one of errors, all, or client
+        for value in ["bogus", "errorsX", "ERRORS", "ALL", "ax", ""] {
+            let arg = format!("--stderr={value}");
+            let err = parse_test_args([arg.as_str(), "src/", "dst/"])
+                .expect_err(&format!("--stderr={value} should be rejected"));
+            let rendered = err.to_string();
+            assert!(
+                rendered.contains(&format!(
+                    "--stderr mode \"{value}\" is not one of errors, all, or client"
+                )),
+                "unexpected message for --stderr={value}: {rendered}"
+            );
+        }
     }
 }
 

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -432,6 +432,8 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("block-size")
                     .long("block-size")
+                    // upstream: options.c:752 {"block-size", 'B', ...} - short alias.
+                    .short('B')
                     .value_name("SIZE")
                     .help("Force the delta-transfer block size to SIZE bytes.")
                     .num_args(1)

--- a/crates/cli/src/frontend/progress/mode.rs
+++ b/crates/cli/src/frontend/progress/mode.rs
@@ -60,15 +60,25 @@ pub enum StderrMode {
 }
 
 impl StderrMode {
-    /// Parses a stderr mode string value.
+    /// Parses a `--stderr` mode value.
     ///
-    /// Returns `None` for unrecognized values.
+    /// Mirrors upstream rsync's `options.c:1912` `OPT_STDERR` handler, which
+    /// accepts any non-empty, case-sensitive prefix of `errors`, `all`, or
+    /// `client` (via `strncmp(word, arg, strlen(arg))`). So `e`/`er`/`err`/
+    /// `error`/`errors` all select `Errors`, but `ERRORS` and `errorsX` are
+    /// rejected. Returns `None` for anything that is not such a prefix.
     pub fn from_str(s: &str) -> Option<Self> {
-        match s.to_ascii_lowercase().as_str() {
-            "errors" | "e" => Some(Self::Errors),
-            "all" | "a" => Some(Self::All),
-            "client" | "c" => Some(Self::Client),
-            _ => None,
+        if s.is_empty() {
+            return None;
+        }
+        if "errors".starts_with(s) {
+            Some(Self::Errors)
+        } else if "all".starts_with(s) {
+            Some(Self::All)
+        } else if "client".starts_with(s) {
+            Some(Self::Client)
+        } else {
+            None
         }
     }
 }
@@ -123,33 +133,52 @@ mod tests {
 
     #[test]
     fn stderr_mode_from_str_errors() {
-        assert_eq!(StderrMode::from_str("errors"), Some(StderrMode::Errors));
-        assert_eq!(StderrMode::from_str("e"), Some(StderrMode::Errors));
-        assert_eq!(StderrMode::from_str("ERRORS"), Some(StderrMode::Errors));
-        assert_eq!(StderrMode::from_str("E"), Some(StderrMode::Errors));
+        // upstream accepts every non-empty prefix of "errors".
+        for value in ["e", "er", "err", "erro", "error", "errors"] {
+            assert_eq!(
+                StderrMode::from_str(value),
+                Some(StderrMode::Errors),
+                "{value}"
+            );
+        }
     }
 
     #[test]
     fn stderr_mode_from_str_all() {
-        assert_eq!(StderrMode::from_str("all"), Some(StderrMode::All));
-        assert_eq!(StderrMode::from_str("a"), Some(StderrMode::All));
-        assert_eq!(StderrMode::from_str("ALL"), Some(StderrMode::All));
-        assert_eq!(StderrMode::from_str("A"), Some(StderrMode::All));
+        for value in ["a", "al", "all"] {
+            assert_eq!(
+                StderrMode::from_str(value),
+                Some(StderrMode::All),
+                "{value}"
+            );
+        }
     }
 
     #[test]
     fn stderr_mode_from_str_client() {
-        assert_eq!(StderrMode::from_str("client"), Some(StderrMode::Client));
-        assert_eq!(StderrMode::from_str("c"), Some(StderrMode::Client));
-        assert_eq!(StderrMode::from_str("CLIENT"), Some(StderrMode::Client));
-        assert_eq!(StderrMode::from_str("C"), Some(StderrMode::Client));
+        for value in ["c", "cl", "cli", "clie", "clien", "client"] {
+            assert_eq!(
+                StderrMode::from_str(value),
+                Some(StderrMode::Client),
+                "{value}"
+            );
+        }
+    }
+
+    #[test]
+    fn stderr_mode_from_str_is_case_sensitive() {
+        // upstream uses strncmp (case-sensitive); uppercase variants are rejected.
+        for value in ["ERRORS", "E", "ALL", "A", "CLIENT", "C", "Errors", "All"] {
+            assert!(StderrMode::from_str(value).is_none(), "{value}");
+        }
     }
 
     #[test]
     fn stderr_mode_from_str_invalid() {
-        assert!(StderrMode::from_str("invalid").is_none());
-        assert!(StderrMode::from_str("").is_none());
-        assert!(StderrMode::from_str("xyz").is_none());
+        // Empty, non-prefixes, and over-long values (longer than the word) all fail.
+        for value in ["", "invalid", "xyz", "errorsX", "allX", "ax", "x"] {
+            assert!(StderrMode::from_str(value).is_none(), "{value}");
+        }
     }
 
     #[test]

--- a/crates/cli/tests/upstream_arg_fidelity.rs
+++ b/crates/cli/tests/upstream_arg_fidelity.rs
@@ -259,11 +259,7 @@ const UPSTREAM_OPTS: &[Opt] = &[
 
 /// Short forms upstream accepts but oc-rsync currently rejects outright.
 /// Keep in lockstep with the `#[ignore]`d trackers below.
-const KNOWN_SHORT_REJECTED: &[(char, &str)] = &[
-    // upstream options.c:752 `{"block-size", 'B', ...}` - oc declares
-    // `--block-size` long-only (no `.short('B')`).
-    ('B', "block-size short -B not wired"),
-];
+const KNOWN_SHORT_REJECTED: &[(char, &str)] = &[];
 
 /// Options that upstream (and oc) refuse without `-r`/`-d`: "--delete does not
 /// work without --recursive (-r) or --dirs (-d)." (upstream options.c). Probing
@@ -293,7 +289,7 @@ fn context_for(opt: &Opt) -> &'static [&'static str] {
 /// rejects for path-like values though upstream popt accepts them. oc's
 /// `expand_short_options` omits these from its value-short set, so a value that
 /// looks like an operand (`-T/tmp`, `-T=/tmp`) leaks into the operand list.
-const KNOWN_SHORT_VALUE_FORM_REJECTED: &[&str] = &["temp-dir", "modify-window"];
+const KNOWN_SHORT_VALUE_FORM_REJECTED: &[&str] = &[];
 
 /// Parses `tokens` with two trailing sentinel operands and confirms the option
 /// (and any value) was consumed by a real argument, leaving only the sentinels
@@ -657,7 +653,6 @@ fn modify_window_short_at_is_accepted() {
 
 /// upstream options.c:752 `{"block-size", 'B', POPT_ARG_STRING, ...}`.
 #[test]
-#[ignore = "oc divergence: -B (block-size short) not wired; --block-size is long-only"]
 fn block_size_short_b_is_accepted() {
     recognize(&["-B", "1024"]).expect("-B 1024 must be accepted as --block-size=1024");
 }
@@ -666,7 +661,6 @@ fn block_size_short_b_is_accepted() {
 /// path-like values (`-T/tmp`). oc's `expand_short_options` omits `T` from its
 /// value-short set, so the token leaks into the operand list.
 #[test]
-#[ignore = "oc divergence: -T/PATH attached short-value rejected for path-like values"]
 fn temp_dir_short_attached_value_is_accepted() {
     let parsed = recognize(&["-T/tmp"]).expect("-T/tmp must bind temp-dir");
     assert_eq!(
@@ -678,7 +672,6 @@ fn temp_dir_short_attached_value_is_accepted() {
 /// popt accepts `-S=value` equals form on value-taking short options. oc
 /// rejects `-T=/tmp` (only `-e=`, `-M=`, `-f=` are handled today).
 #[test]
-#[ignore = "oc divergence: -T=VALUE equals short-value form rejected"]
 fn temp_dir_short_equals_value_is_accepted() {
     recognize(&["-T=/tmp"]).expect("-T=/tmp must bind temp-dir");
 }


### PR DESCRIPTION
Closes four CLI-argument fidelity gaps against upstream rsync 3.4.4
(`options.c` is the source of truth). Each form was verified against the
real upstream 3.4.4 binary on Linux (aarch64); before/after tables below.

## Gap 1 - `-B` short alias for `--block-size`
`options.c:752` defines `{"block-size", 'B', ...}`; oc only declared the
long form, so `-B 4096` failed with "unknown option". Added `.short('B')`.

## Gap 2 - `-T` packed / `=`-joined short-value forms (a real gap, wider than reported)
Upstream popt accepts `-T /tmp` (space), `-T/tmp` (attached) and
`-T=/tmp` (equals) - the `=` is stripped. oc accepted only the space and
`--temp-dir=` long forms; both `-T/tmp` and `-T=/tmp` were rejected as
"unknown option".

Root cause was a class bug: the custom short-option classifier only
treated a short as value-taking when its `Arg` set an explicit `num_args`
with `min > 0`. `--temp-dir`/`-T` sets a `value_parser` but no `num_args`
(its action defaults to `Set`), so `-T` was misclassified as a flag.
Fixed by mirroring `classify_long_options`: fall back to the action's
`takes_values()` when `num_args` is absent. `expand_cluster` now also
strips one `=` joining a short option to its packed value, matching popt
(and clap's native `-o=value`). `ArgAction::Count` flags such as `-h` are
unaffected. `-B` already worked because its `Arg` carries `num_args(1)`.

## Gap 3 - `--max-size` / `--min-size` trailing `+1` / `-1`
Already correct: both route through `parse_size_limit_argument` ->
`bandwidth::parse_size_arg`, which implements the `+1`/`-1` adjustment.
No code change; verified `1K-1`, `1K+1`, `1.5m`, `1K`, `1MB`, `1MiB` all
match upstream's computed value. (Kept a focused unit test.)

## Gap 4 - `--stderr` mode validation
`options.c:1912` `OPT_STDERR` accepts only a non-empty, case-sensitive
prefix of `errors`/`all`/`client` (`strncmp`) and otherwise errors with
`--stderr mode "X" is not one of errors, all, or client`. oc accepted any
string and silently defaulted. Now `StderrMode::from_str` does the
case-sensitive prefix match and the parser rejects invalid values with
the upstream message. Uppercase (`ERRORS`, `ALL`) is correctly rejected.

## Verification vs real upstream 3.4.4 (exit codes)

| Form | upstream | oc before | oc after |
|------|----------|-----------|----------|
| `-B 4096` / `-B4096` / `-B=4096` | 0 | unknown-opt (`-B`) | 0 |
| `-T /tmp` | 0 | 0 | 0 |
| `-T/tmp` (attached) | 0 | unknown-opt | 0 |
| `-T=/tmp` (equals) | 0 | unknown-opt | 0 |
| `--max-size=1K-1` / `1K+1` | 0 | 0 | 0 |
| `--stderr=err` / `e` / `al` / `cli` | 0 | 0 | 0 |
| `--stderr=ERRORS` / `bogus` / `errorsX` / (empty) | 1 (msg) | 0 (silent) | 1 (upstream msg) |

Error text matches upstream byte-for-byte (modulo oc's brand/role
trailer): `--stderr mode "bogus" is not one of errors, all, or client`.

Note: a pre-existing, orthogonal divergence surfaced during verification -
oc does not pre-validate that `--temp-dir` exists (upstream `main.c:1041`
prints "The temp-dir does not exist" / exit 1; oc proceeds and exits 24).
It reproduces with the always-parsed space form too, so it is unrelated to
this parsing change and is left for a separate follow-up.

Tests: focused unit tests next to the parser code (short-option
classification and `=` stripping, `StderrMode` prefix contract, `-B`/`-T`
form parity, `--stderr` accept/reject with the upstream message).
`cargo fmt` and `cargo clippy -p cli -p bandwidth` clean.