### PR TITLE
fix(transfer): defer --delete-after so per-directory filters protect at delete time

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -114,6 +114,16 @@ pub(super) struct ServerLongFlags {
     pub(super) numeric_ids: bool,
     /// Delete extraneous files (upstream: `--delete-*` variants, long-form only).
     pub(super) delete: bool,
+    /// Defer the delete pass until after the transfer (upstream: `--delete-after`
+    /// / `--delete-delay`, i.e. `delete_after` or `delete_during == 2`).
+    ///
+    /// When set, the server-side receiver runs its delete sweep only after every
+    /// file (including each destination `.rsync-filter` merge file) has landed,
+    /// so per-directory merge protect rules are honoured at delete time.
+    ///
+    /// upstream: generator.c:124 - `EARLY_DELETE_DONE_MSG = !(delete_during == 2
+    /// || delete_after)`; generator.c:2425-2428 late delete pass.
+    pub(super) late_delete: bool,
     /// Remove source files after a successful transfer.
     ///
     /// upstream: options.c:2964-2965 - `server_options()` emits
@@ -269,6 +279,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         modify_window: None,
         numeric_ids: false,
         delete: false,
+        late_delete: false,
         remove_source_files: false,
         copy_devices: false,
         stats: false,
@@ -335,8 +346,17 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // upstream: --numeric-ids is long-form only (options.c:2887-2888)
             "--numeric-ids" => flags.numeric_ids = true,
             // upstream: --delete variants are long-form only (options.c:2818-2827)
-            "--delete" | "--delete-before" | "--delete-during" | "--delete-after"
-            | "--delete-delay" | "--delete-excluded" => flags.delete = true,
+            "--delete" | "--delete-before" | "--delete-during" | "--delete-excluded" => {
+                flags.delete = true;
+            }
+            // upstream: generator.c:124 EARLY_DELETE_DONE_MSG = !(delete_during==2
+            // || delete_after). --delete-after / --delete-delay defer the delete
+            // sweep to after the transfer so the destination `.rsync-filter`
+            // merge files transferred by this run are consulted at delete time.
+            "--delete-after" | "--delete-delay" => {
+                flags.delete = true;
+                flags.late_delete = true;
+            }
             // upstream: options.c:2964-2965 - --remove-source-files is long-form
             // only. --remove-sent-files is the deprecated alias that still names
             // the same option in `parse_arguments()`.

--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -124,6 +124,13 @@ pub(super) struct ServerLongFlags {
     /// upstream: generator.c:124 - `EARLY_DELETE_DONE_MSG = !(delete_during == 2
     /// || delete_after)`; generator.c:2425-2428 late delete pass.
     pub(super) late_delete: bool,
+    /// Defer the delete *decision* until after the transfer (upstream:
+    /// `--delete-after` / `delete_after` only). Set apart from [`late_delete`]
+    /// because `--delete-delay` decides during the walk (generator.c:2315) and
+    /// defers only the unlink, so its delete pass runs early like `--delete-during`.
+    ///
+    /// [`late_delete`]: Self::late_delete
+    pub(super) delete_after: bool,
     /// Remove source files after a successful transfer.
     ///
     /// upstream: options.c:2964-2965 - `server_options()` emits
@@ -280,6 +287,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         numeric_ids: false,
         delete: false,
         late_delete: false,
+        delete_after: false,
         remove_source_files: false,
         copy_devices: false,
         stats: false,
@@ -350,12 +358,21 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
                 flags.delete = true;
             }
             // upstream: generator.c:124 EARLY_DELETE_DONE_MSG = !(delete_during==2
-            // || delete_after). --delete-after / --delete-delay defer the delete
-            // sweep to after the transfer so the destination `.rsync-filter`
-            // merge files transferred by this run are consulted at delete time.
-            "--delete-after" | "--delete-delay" => {
+            // || delete_after). --delete-delay defers only the goodbye del-stats
+            // and the physical unlink; its delete *decision* still runs during the
+            // walk (generator.c:2315), so the delete pass stays early.
+            "--delete-delay" => {
                 flags.delete = true;
                 flags.late_delete = true;
+            }
+            // upstream: generator.c:2427-2428 - only --delete-after defers the
+            // delete *decision* to after the transfer, so a destination
+            // `.rsync-filter` merge file transferred by this run protects matching
+            // entries at delete time.
+            "--delete-after" => {
+                flags.delete = true;
+                flags.late_delete = true;
+                flags.delete_after = true;
             }
             // upstream: options.c:2964-2965 - --remove-source-files is long-form
             // only. --remove-sent-files is the deprecated alias that still names

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -213,11 +213,14 @@ where
     config.flags.no_implied_dirs = long_flags.no_implied_dirs;
     config.flags.numeric_ids = core::server::NumericIds::from_client(long_flags.numeric_ids);
     config.flags.delete = long_flags.delete;
-    // upstream: generator.c:124 / 2425-2428 - --delete-after / --delete-delay
-    // defer the server receiver's delete sweep until after the transfer so the
-    // per-directory `.rsync-filter` merge files it just received protect matching
-    // destination entries at delete time.
+    // upstream: generator.c:124 - --delete-after / --delete-delay both defer the
+    // goodbye del-stats emission.
     config.deletion.late_delete = long_flags.late_delete;
+    // upstream: generator.c:2427-2428 - only --delete-after defers the delete
+    // *decision* to after the transfer, so the per-directory `.rsync-filter`
+    // merge files it just received protect matching destination entries at delete
+    // time. --delete-delay decides during the walk and only defers the unlink.
+    config.deletion.delete_after = long_flags.delete_after;
     // upstream: options.c:2964-2965 - `--remove-source-files` is forwarded
     // long-form when the client requested sender-side removal. The flag is
     // consumed by the sender's `successful_send()` after each transferred

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -213,6 +213,11 @@ where
     config.flags.no_implied_dirs = long_flags.no_implied_dirs;
     config.flags.numeric_ids = core::server::NumericIds::from_client(long_flags.numeric_ids);
     config.flags.delete = long_flags.delete;
+    // upstream: generator.c:124 / 2425-2428 - --delete-after / --delete-delay
+    // defer the server receiver's delete sweep until after the transfer so the
+    // per-directory `.rsync-filter` merge files it just received protect matching
+    // destination entries at delete time.
+    config.deletion.late_delete = long_flags.late_delete;
     // upstream: options.c:2964-2965 - `--remove-source-files` is forwarded
     // long-form when the client requested sender-side removal. The flag is
     // consumed by the sender's `successful_send()` after each transferred

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -355,6 +355,11 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // upstream: generator.c:124 - EARLY_DELETE_DONE_MSG = !(delete_during==2 || delete_after)
     server_config.deletion.late_delete =
         matches!(config.delete_mode(), DeleteMode::Delay | DeleteMode::After);
+    // upstream: generator.c:2427-2428 - only --delete-after defers the delete
+    // *decision* to after the transfer (so a per-dir `.rsync-filter` protects at
+    // delete time). --delete-delay decides during the walk (generator.c:2315),
+    // deferring only the unlink, so it is NOT flagged here.
+    server_config.deletion.delete_after = matches!(config.delete_mode(), DeleteMode::After);
     // upstream: options.c `delete_excluded` - the receiver's delete pass must
     // treat filter-excluded (non-protected) entries as deletable. For a
     // remote-shell pull the receiver builds its deletion chain from the local

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -42,9 +42,17 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
             "--delete" | "--delete-before" | "--delete-during" => {
                 config.flags.delete = true;
             }
-            "--delete-after" | "--delete-delay" => {
+            "--delete-delay" => {
                 config.flags.delete = true;
                 config.deletion.late_delete = true;
+            }
+            // upstream: generator.c:2427-2428 - only --delete-after defers the
+            // delete *decision* to after the transfer; --delete-delay decides
+            // during the walk (generator.c:2315) and defers only the unlink.
+            "--delete-after" => {
+                config.flags.delete = true;
+                config.deletion.late_delete = true;
+                config.deletion.delete_after = true;
             }
             "--delete-excluded" => {
                 config.flags.delete = true;

--- a/crates/transfer/src/config/builder_tests.rs
+++ b/crates/transfer/src/config/builder_tests.rs
@@ -407,6 +407,7 @@ mod composite_setters {
             max_delete: Some(50),
             ignore_errors: true,
             late_delete: true,
+            delete_after: false,
             delete_excluded: false,
         };
         let config = ServerConfigBuilder::new()

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -115,6 +115,28 @@ pub struct DeletionConfig {
     ///
     /// - `generator.c:124`: `#define EARLY_DELETE_DONE_MSG() (!(delete_during == 2 || delete_after))`
     pub late_delete: bool,
+    /// Whether the delete *pass* (the extraneous-entry decision) is deferred
+    /// until after the per-file transfer completes.
+    ///
+    /// True ONLY for `--delete-after` (`delete_after` in upstream), which runs
+    /// `do_delete_pass()` at the very end (generator.c:2427-2428) once every
+    /// file - including each destination `.rsync-filter` merge file - has landed,
+    /// so per-directory merge protect rules apply at delete time.
+    ///
+    /// NOT set for `--delete-delay` (`delete_during == 2`): upstream makes the
+    /// delete *decision* during the walk (delete_in_dir via remember_delete,
+    /// generator.c:2315-2327) - before that directory's `.rsync-filter` has been
+    /// received - and defers only the physical unlink. Its observable file
+    /// outcome therefore matches `--delete-during` / `--delete-before`, so oc
+    /// runs the delete pass early for delay just like those modes. This is
+    /// distinct from [`late_delete`] (delay || after), which governs only the
+    /// goodbye NDX_DEL_STATS timing.
+    ///
+    /// Verified empirically vs upstream 3.4.4: over SSH (inc-recurse), delay
+    /// DELETES a per-dir-merge-protected entry while after PROTECTS it.
+    ///
+    /// [`late_delete`]: Self::late_delete
+    pub delete_after: bool,
     /// Also delete filter-excluded entries from the destination
     /// (`--delete-excluded`). When set, the receiver's delete pass treats an
     /// excluded (non-protected) entry as deletable rather than protected.

--- a/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
+++ b/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
@@ -25,49 +25,52 @@ use super::super::super::ReceiverContext;
 use super::super::support::{TestDeletionWriter, test_config, test_handshake};
 
 /// The early/late routing predicates must partition the four delete modes the
-/// way upstream's `EARLY_DELETE_DONE_MSG()` does: `--delete-before` /
-/// `--delete-during` sweep early, `--delete-after` / `--delete-delay` sweep
-/// late, and the sweep runs exactly once (never both, never neither when
-/// `--delete` is set). A regression that mis-routes after/delay to the early
-/// site would silently reintroduce the #280 data loss, so this test guards the
-/// routing decision directly rather than only the on-disk effect.
+/// way upstream does: only `--delete-after` (`delete_after`) defers the delete
+/// *decision* to after the transfer (generator.c:2427-2428); `--delete-before`,
+/// `--delete-during`, AND `--delete-delay` all decide early. `--delete-delay`
+/// belongs with the early group because upstream makes its decision during the
+/// walk (generator.c:2315) and defers only the unlink - verified vs upstream
+/// 3.4.4 over SSH, where delay DELETES a per-dir-merge-protected entry exactly
+/// as during/before do, while after PROTECTS it. A regression that deferred
+/// delay would over-protect (keep files upstream deletes); one that failed to
+/// defer after would reintroduce the #280 data loss. The sweep runs exactly
+/// once when `--delete` is set (never both, never neither).
 #[test]
 fn delete_pass_timing_predicates_partition_the_four_modes() {
     let handshake = test_handshake();
 
-    // --delete-before / --delete-during: delete on, late_delete off.
-    let mut early = test_config();
-    early.flags.delete = true;
-    early.deletion.late_delete = false;
-    let ctx = ReceiverContext::new_for_test(&handshake, early);
-    assert!(ctx.delete_pass_is_early(), "before/during must sweep early");
-    assert!(
-        !ctx.delete_pass_is_late(),
-        "before/during must not sweep late"
-    );
+    // --delete-before / --delete-during / --delete-delay: delete on, but the
+    // decision is NOT deferred (`delete_after` off). late_delete may be set for
+    // delay (it governs only goodbye del-stats), which must not affect routing.
+    for (label, late_delete) in [("before/during", false), ("delay", true)] {
+        let mut early = test_config();
+        early.flags.delete = true;
+        early.deletion.delete_after = false;
+        early.deletion.late_delete = late_delete;
+        let ctx = ReceiverContext::new_for_test(&handshake, early);
+        assert!(ctx.delete_pass_is_early(), "{label} must sweep early");
+        assert!(!ctx.delete_pass_is_late(), "{label} must not sweep late");
+    }
 
-    // --delete-after / --delete-delay: delete on, late_delete on.
+    // --delete-after: delete on, decision deferred.
     let mut late = test_config();
     late.flags.delete = true;
     late.deletion.late_delete = true;
+    late.deletion.delete_after = true;
     let ctx = ReceiverContext::new_for_test(&handshake, late);
-    assert!(
-        !ctx.delete_pass_is_early(),
-        "after/delay must not sweep early"
-    );
-    assert!(ctx.delete_pass_is_late(), "after/delay must sweep late");
+    assert!(!ctx.delete_pass_is_early(), "after must not sweep early");
+    assert!(ctx.delete_pass_is_late(), "after must sweep late");
 
-    // No --delete: neither site fires, regardless of the late_delete bit (which
-    // a stale config could still carry). The sweep must never run without
-    // deletion requested.
-    for late_delete in [false, true] {
+    // No --delete: neither site fires, regardless of the deferral bits (which a
+    // stale config could still carry). The sweep must never run unrequested.
+    for delete_after in [false, true] {
         let mut off = test_config();
         off.flags.delete = false;
-        off.deletion.late_delete = late_delete;
+        off.deletion.delete_after = delete_after;
         let ctx = ReceiverContext::new_for_test(&handshake, off);
         assert!(
             !ctx.delete_pass_is_early() && !ctx.delete_pass_is_late(),
-            "no --delete => no sweep (late_delete={late_delete})"
+            "no --delete => no sweep (delete_after={delete_after})"
         );
     }
 }
@@ -89,7 +92,10 @@ fn build_receiver_with_perdir_merge(dest: &std::path::Path) -> ReceiverContext {
     let handshake = test_handshake();
     let mut config = test_config();
     config.flags.delete = true;
+    // Represents --delete-after: the deferred delete pass runs after the
+    // transfer, when the destination `.rsync-filter` is present.
     config.deletion.late_delete = true;
+    config.deletion.delete_after = true;
     config.args = vec![OsString::from(dest.to_str().unwrap())];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 

--- a/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
+++ b/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
@@ -1,0 +1,187 @@
+//! Late (`--delete-after` / `--delete-delay`) vs early (`--delete-before` /
+//! `--delete-during`) delete-pass scheduling on the receiver.
+//!
+//! WHY this matters (the #280 data-loss bug): upstream defers the delete sweep
+//! for `--delete-after` / `--delete-delay` until after every file has been
+//! transferred (generator.c:2425-2428), because the sweep reloads each
+//! destination directory's per-directory `.rsync-filter` merge file at delete
+//! time (exclude.c:875 `change_local_filter_dir`). A merge-file protect rule
+//! (e.g. `- *.bak`) can only shield a matching destination entry once that
+//! `.rsync-filter` is present in the destination - which it is not until the
+//! transfer has run. Running the sweep before the transfer (as oc did for all
+//! four modes) therefore deleted files upstream protects.
+//!
+//! These tests pin the two halves of the fix:
+//!   1. the timing predicates that route the sweep early vs late, and
+//!   2. the load-bearing invariant that protection depends on the destination
+//!      `.rsync-filter` being present at delete time (proving deferral is not
+//!      cosmetic).
+
+use std::ffi::OsString;
+
+use protocol::flist::FileEntry;
+
+use super::super::super::ReceiverContext;
+use super::super::support::{TestDeletionWriter, test_config, test_handshake};
+
+/// The early/late routing predicates must partition the four delete modes the
+/// way upstream's `EARLY_DELETE_DONE_MSG()` does: `--delete-before` /
+/// `--delete-during` sweep early, `--delete-after` / `--delete-delay` sweep
+/// late, and the sweep runs exactly once (never both, never neither when
+/// `--delete` is set). A regression that mis-routes after/delay to the early
+/// site would silently reintroduce the #280 data loss, so this test guards the
+/// routing decision directly rather than only the on-disk effect.
+#[test]
+fn delete_pass_timing_predicates_partition_the_four_modes() {
+    let handshake = test_handshake();
+
+    // --delete-before / --delete-during: delete on, late_delete off.
+    let mut early = test_config();
+    early.flags.delete = true;
+    early.deletion.late_delete = false;
+    let ctx = ReceiverContext::new_for_test(&handshake, early);
+    assert!(ctx.delete_pass_is_early(), "before/during must sweep early");
+    assert!(
+        !ctx.delete_pass_is_late(),
+        "before/during must not sweep late"
+    );
+
+    // --delete-after / --delete-delay: delete on, late_delete on.
+    let mut late = test_config();
+    late.flags.delete = true;
+    late.deletion.late_delete = true;
+    let ctx = ReceiverContext::new_for_test(&handshake, late);
+    assert!(
+        !ctx.delete_pass_is_early(),
+        "after/delay must not sweep early"
+    );
+    assert!(ctx.delete_pass_is_late(), "after/delay must sweep late");
+
+    // No --delete: neither site fires, regardless of the late_delete bit (which
+    // a stale config could still carry). The sweep must never run without
+    // deletion requested.
+    for late_delete in [false, true] {
+        let mut off = test_config();
+        off.flags.delete = false;
+        off.deletion.late_delete = late_delete;
+        let ctx = ReceiverContext::new_for_test(&handshake, off);
+        assert!(
+            !ctx.delete_pass_is_early() && !ctx.delete_pass_is_late(),
+            "no --delete => no sweep (late_delete={late_delete})"
+        );
+    }
+}
+
+/// Builds the destination tree and receiver used by both invariant tests: a
+/// nested `sub/` directory, an extraneous `normal.bak` at the root and an
+/// extraneous `sub/x.bak`, plus a `source.txt` that is present in the file
+/// list. The file list carries `.`, `sub`, `source.txt`, and `.rsync-filter`
+/// (the merge file itself is transferred, so it is a kept entry), but NOT the
+/// `.bak` files, which are therefore extraneous deletion candidates. The
+/// receiver's deletion chain has a `.rsync-filter` per-directory merge config
+/// registered, exactly as `-F` / `--filter=': /.rsync-filter'` would install.
+fn build_receiver_with_perdir_merge(dest: &std::path::Path) -> ReceiverContext {
+    std::fs::create_dir(dest.join("sub")).unwrap();
+    std::fs::write(dest.join("normal.bak"), b"extraneous root bak").unwrap();
+    std::fs::write(dest.join("sub").join("x.bak"), b"extraneous nested bak").unwrap();
+    std::fs::write(dest.join("source.txt"), b"from sender").unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = true;
+    config.deletion.late_delete = true;
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("sub".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("source.txt".into(), 11, 0o644));
+    ctx.file_list
+        .push(FileEntry::new_file(".rsync-filter".into(), 8, 0o644));
+
+    // Register the dest-side per-directory `.rsync-filter` merge config on the
+    // dedicated deletion chain (upstream: the receiver's isolated delete filter
+    // list, exclude.c:759 `push_local_filters`). The chain is otherwise empty,
+    // so protection can only come from a `.rsync-filter` read off the disk.
+    let mut chain = ::filters::FilterChain::empty();
+    chain.add_merge_config(::filters::DirMergeConfig::new(".rsync-filter"));
+    ctx.set_deletion_filter_chain(chain);
+    ctx
+}
+
+/// LATE case: when the destination `.rsync-filter` (`- *.bak`) is already on
+/// disk at delete time - the state after the transfer has landed it - the
+/// deferred sweep reloads it per directory and the protect rule shields both
+/// the root `normal.bak` and the inherited nested `sub/x.bak`. This is the
+/// behaviour upstream produces for `--delete-after` / `--delete-delay`, and the
+/// on-disk survival is exactly what oc failed to preserve before #280.
+#[test]
+fn late_delete_pass_with_dest_rsync_filter_protects_bak() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let dest = temp_dir.path();
+    let ctx = build_receiver_with_perdir_merge(dest);
+
+    // The `.rsync-filter` has landed (transferred). `- *.bak` excludes, and an
+    // excluded entry is absent from the delete candidate list, hence protected.
+    std::fs::write(dest.join(".rsync-filter"), b"- *.bak\n").unwrap();
+
+    let mut writer = TestDeletionWriter;
+    let (_stats, _, _) = ctx
+        .delete_extraneous_files(
+            dest,
+            #[cfg(unix)]
+            None,
+            &mut writer,
+        )
+        .unwrap();
+
+    assert!(
+        dest.join("normal.bak").exists(),
+        "root normal.bak must be protected by the dest .rsync-filter '- *.bak'"
+    );
+    assert!(
+        dest.join("sub").join("x.bak").exists(),
+        "nested sub/x.bak must be protected by the inherited '- *.bak' rule"
+    );
+    assert!(dest.join("source.txt").exists(), "listed file must survive");
+}
+
+/// TIMING CONTRAST: the very same sweep, run while the destination
+/// `.rsync-filter` is NOT yet present (the state at an early, pre-transfer
+/// sweep), deletes the `.bak` files - there is no on-disk merge file to load,
+/// so nothing protects them. This is why the fix defers the sweep for
+/// after/delay: protection is a function of the `.rsync-filter` being on disk,
+/// which only holds once the transfer has run. If deferral regressed to an
+/// early sweep, the after/delay data loss would return - this test would then
+/// pass for the wrong reason, so it is paired with the LATE test above.
+#[test]
+fn delete_pass_without_dest_rsync_filter_deletes_bak() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let dest = temp_dir.path();
+    let ctx = build_receiver_with_perdir_merge(dest);
+
+    // No `.rsync-filter` written: mirror an early sweep before the merge file
+    // has been transferred into the destination.
+    let mut writer = TestDeletionWriter;
+    let (_stats, _, _) = ctx
+        .delete_extraneous_files(
+            dest,
+            #[cfg(unix)]
+            None,
+            &mut writer,
+        )
+        .unwrap();
+
+    assert!(
+        !dest.join("normal.bak").exists(),
+        "without a dest .rsync-filter nothing protects normal.bak"
+    );
+    assert!(
+        !dest.join("sub").join("x.bak").exists(),
+        "without a dest .rsync-filter nothing protects sub/x.bak"
+    );
+    assert!(dest.join("source.txt").exists(), "listed file must survive");
+}

--- a/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
+++ b/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
@@ -109,12 +109,16 @@ fn build_receiver_with_perdir_merge(dest: &std::path::Path) -> ReceiverContext {
         .push(FileEntry::new_file(".rsync-filter".into(), 8, 0o644));
 
     // Register the dest-side per-directory `.rsync-filter` merge config on the
-    // dedicated deletion chain (upstream: the receiver's isolated delete filter
-    // list, exclude.c:759 `push_local_filters`). The chain is otherwise empty,
-    // so protection can only come from a `.rsync-filter` read off the disk.
+    // receiver's wire-populated `filter_chain`, exactly as a server receiver does
+    // after parsing a `-F` (`dir-merge /.rsync-filter`) rule off the wire
+    // (setup/wire_filters.rs -> parse_wire_filters_for_receiver). The delete pass
+    // (deletion.rs) consults this chain and reloads each destination directory's
+    // `.rsync-filter` at delete time (upstream exclude.c:759 push_local_filters).
+    // The chain carries no global rules, so protection can only come from a
+    // `.rsync-filter` read off the disk - which is the whole point of deferral.
     let mut chain = ::filters::FilterChain::empty();
     chain.add_merge_config(::filters::DirMergeConfig::new(".rsync-filter"));
-    ctx.set_deletion_filter_chain(chain);
+    ctx.set_filter_chain(chain);
     ctx
 }
 

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -21,6 +21,9 @@
 //!   and round-trip coverage.
 //! - [`delete_pipeline_hook`] - DDP-B3 hook that publishes one delete
 //!   plan per INC_RECURSE segment.
+//! - [`delete_timing`] - early vs late (`--delete-after` / `--delete-delay`)
+//!   delete-pass scheduling and the dest-side `.rsync-filter` protection
+//!   invariant that makes deferral load-bearing.
 //! - [`iconv_wire_order`] - regression coverage for the receiver-side
 //!   `--iconv` ordering invariant (file_list stays in sender wire-emit
 //!   order, never re-sorted on local-charset bytes).
@@ -28,6 +31,7 @@
 #[cfg(feature = "tokio-transfer")]
 mod async_parity;
 mod delete_pipeline_hook;
+mod delete_timing;
 mod filter_chain;
 #[cfg(feature = "iconv")]
 mod iconv_wire_order;

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -135,28 +135,35 @@ impl ReceiverContext {
 
     /// True when the delete pass runs EARLY, before the per-file transfer loop.
     ///
-    /// Covers `--delete-before` and `--delete-during`. Mirrors upstream
-    /// generator.c:2280-2281 (`delete_before` runs `do_delete_pass()` up front)
-    /// and generator.c:2315-2327 (`delete_during` deletes as each directory is
-    /// entered during the loop). oc collapses both into one pre-loop sweep,
-    /// which is byte-equivalent because the destination `.rsync-filter` merge
-    /// files that gate protection are the same at either point for these modes.
+    /// Covers `--delete-before`, `--delete-during`, AND `--delete-delay`. Mirrors
+    /// upstream generator.c:2280-2281 (`delete_before` runs `do_delete_pass()` up
+    /// front) and generator.c:2315-2327 (`delete_during` / `delete_during == 2`
+    /// decide as each directory is entered during the loop). oc collapses these
+    /// into one pre-loop sweep; the observable file outcome matches because none
+    /// of these modes has the destination `.rsync-filter` merge files present
+    /// when the deletion decision is made. `--delete-delay` defers only the
+    /// physical unlink upstream, not the decision, so its kept/deleted set equals
+    /// `--delete-during` - verified vs upstream 3.4.4 over SSH (delay DELETES a
+    /// per-dir-merge-protected entry, exactly as during/before do).
     pub(in crate::receiver) fn delete_pass_is_early(&self) -> bool {
-        self.config.flags.delete && !self.config.deletion.late_delete
+        self.config.flags.delete && !self.config.deletion.delete_after
     }
 
     /// True when the delete pass is DEFERRED to after the per-file transfer loop.
     ///
-    /// Covers `--delete-after` and `--delete-delay`. Mirrors upstream
-    /// generator.c:2425-2428 which runs `do_delayed_deletions()` (delay) or
-    /// `do_delete_pass()` (after) only once every file - including each
-    /// destination `.rsync-filter` merge file - has been transferred. Deferring
-    /// is load-bearing: the delete pass reloads each destination directory's
-    /// per-directory `.rsync-filter` at delete time, so a merge-file protect
-    /// rule (e.g. `- *.bak`) only survives the sweep once that filter file is
-    /// present in the destination, which it is not until the transfer has run.
+    /// Covers `--delete-after` ONLY. Mirrors upstream generator.c:2425-2428 which
+    /// runs `do_delete_pass()` after every file - including each destination
+    /// `.rsync-filter` merge file - has been transferred. Deferring is
+    /// load-bearing: the delete pass reloads each destination directory's
+    /// per-directory `.rsync-filter` at delete time, so a merge-file protect rule
+    /// (e.g. `- *.bak`) only survives the sweep once that filter file is present
+    /// in the destination, which it is not until the transfer has run.
+    ///
+    /// `--delete-delay` is deliberately NOT here: upstream makes its deletion
+    /// decision during the walk (deferring only the unlink), so it deletes such
+    /// an entry - see [`delete_pass_is_early`](Self::delete_pass_is_early).
     pub(in crate::receiver) fn delete_pass_is_late(&self) -> bool {
-        self.config.flags.delete && self.config.deletion.late_delete
+        self.config.flags.delete && self.config.deletion.delete_after
     }
 
     /// Runs the destination delete pass and folds its results into `stats`.

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -40,7 +40,7 @@ mod sync;
 mod sync_async;
 
 use std::io::{self, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use logging::{debug_log, info_log};
 
@@ -131,6 +131,77 @@ impl ReceiverContext {
             self.run_pipelined_async(reader, writer, crate::pipeline::PipelineConfig::default())
                 .await
         }
+    }
+
+    /// True when the delete pass runs EARLY, before the per-file transfer loop.
+    ///
+    /// Covers `--delete-before` and `--delete-during`. Mirrors upstream
+    /// generator.c:2280-2281 (`delete_before` runs `do_delete_pass()` up front)
+    /// and generator.c:2315-2327 (`delete_during` deletes as each directory is
+    /// entered during the loop). oc collapses both into one pre-loop sweep,
+    /// which is byte-equivalent because the destination `.rsync-filter` merge
+    /// files that gate protection are the same at either point for these modes.
+    pub(in crate::receiver) fn delete_pass_is_early(&self) -> bool {
+        self.config.flags.delete && !self.config.deletion.late_delete
+    }
+
+    /// True when the delete pass is DEFERRED to after the per-file transfer loop.
+    ///
+    /// Covers `--delete-after` and `--delete-delay`. Mirrors upstream
+    /// generator.c:2425-2428 which runs `do_delayed_deletions()` (delay) or
+    /// `do_delete_pass()` (after) only once every file - including each
+    /// destination `.rsync-filter` merge file - has been transferred. Deferring
+    /// is load-bearing: the delete pass reloads each destination directory's
+    /// per-directory `.rsync-filter` at delete time, so a merge-file protect
+    /// rule (e.g. `- *.bak`) only survives the sweep once that filter file is
+    /// present in the destination, which it is not until the transfer has run.
+    pub(in crate::receiver) fn delete_pass_is_late(&self) -> bool {
+        self.config.flags.delete && self.config.deletion.late_delete
+    }
+
+    /// Runs the destination delete pass and folds its results into `stats`.
+    ///
+    /// Sweeps the destination for entries absent from the sender's file list,
+    /// reloading each directory's per-directory `.rsync-filter` merge files so
+    /// their protect rules apply at delete time. Shared by all four receiver
+    /// pipeline drivers so the defer-and-filter logic lives in exactly one place.
+    ///
+    /// The caller positions the call via [`delete_pass_is_early`] (before the
+    /// per-file loop) or [`delete_pass_is_late`] (after it, before finalize).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:358` - `do_delete_pass()` tree sweep
+    /// - `generator.c:279` - `delete_in_dir()` per-directory candidate check
+    /// - `exclude.c:875` - `change_local_filter_dir()` reloads dest `.rsync-filter`
+    /// - `generator.c:2393-2398` / `2437-2440` - `write_del_stats()` emission
+    ///
+    /// [`delete_pass_is_early`]: Self::delete_pass_is_early
+    /// [`delete_pass_is_late`]: Self::delete_pass_is_late
+    pub(in crate::receiver) fn run_receiver_delete_pass<W>(
+        &mut self,
+        dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&std::sync::Arc<fast_io::DirSandbox>>,
+        writer: &mut W,
+        stats: &mut TransferStats,
+    ) -> io::Result<()>
+    where
+        W: Write + crate::writer::MsgInfoSender + ?Sized,
+    {
+        let (delete_stats, limit_exceeded, io_bits) = self.delete_extraneous_files(
+            dest_dir,
+            #[cfg(unix)]
+            sandbox,
+            writer,
+        )?;
+        stats.io_error |= io_bits;
+        stats.delete_stats = delete_stats;
+        stats.delete_limit_exceeded = limit_exceeded;
+        // Carry the per-type counters into the receiver context so the goodbye
+        // handshake can emit NDX_DEL_STATS to the peer sender.
+        // upstream: generator.c:2393-2398 - write_del_stats() emission.
+        self.pending_del_stats = delete_stats;
+        Ok(())
     }
 }
 

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -11,7 +11,6 @@ use std::path::PathBuf;
 use logging::{PhaseTimer, debug_log, info_log};
 use protocol::codec::create_ndx_codec;
 use protocol::flist::FileEntry;
-use protocol::stats::DeleteStats;
 
 use crate::pipeline::PipelineConfig;
 use crate::receiver::stats::TransferStats;
@@ -79,33 +78,29 @@ impl ReceiverContext {
         // upstream: receiver.c:653-654 DEBUG_GTE(RECV, 1)
         debug_log!(Recv, 1, "recv_files({}) starting", file_count);
 
-        let mut delete_stats = DeleteStats::new();
-        let mut delete_limit_exceeded = false;
-        let mut delete_io_error: i32 = 0;
-        if self.config.flags.delete {
-            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
-                &setup.dest_dir,
-                #[cfg(unix)]
-                setup.sandbox.as_ref(),
-                writer,
-            )?;
-            delete_stats = ds;
-            delete_limit_exceeded = exceeded;
-            delete_io_error = io_bits;
-            // Carry the per-type counters into the receiver context so the
-            // goodbye handshake can emit NDX_DEL_STATS to the peer sender.
-            // upstream: generator.c:2393-2398 - early write_del_stats() emission.
-            self.pending_del_stats = delete_stats;
-        }
-
         let mut stats = TransferStats {
             files_listed: file_count,
             entries_received: file_count as u64,
             io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
-                | self.flist_io_error
-                | delete_io_error,
+                | self.flist_io_error,
             ..Default::default()
         };
+
+        // upstream: generator.c:2280-2281 - --delete-before / --delete-during
+        // sweep before the per-file loop. --delete-after / --delete-delay defer
+        // the sweep until after the transfer (see the late call below) so the
+        // destination `.rsync-filter` merge files transferred by this run are
+        // present and consulted at delete time.
+        if self.delete_pass_is_early() {
+            self.run_receiver_delete_pass(
+                &setup.dest_dir,
+                #[cfg(unix)]
+                setup.sandbox.as_ref(),
+                writer,
+                &mut stats,
+            )?;
+        }
+
         let files_to_transfer = self.build_files_to_transfer(
             writer,
             &setup.dest_dir,
@@ -240,6 +235,23 @@ impl ReceiverContext {
             super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
         }
 
+        // upstream: generator.c:2425-2428 - --delete-after / --delete-delay run
+        // the sweep only after every file (including each destination
+        // `.rsync-filter` and any --delay-updates staged file committed just
+        // above) has landed, so per-directory merge protect rules are honoured
+        // at delete time. Runs before touch_up_dirs so deletion-induced parent
+        // mtime changes are re-tidied (upstream touch_up_dirs at generator.c:2449
+        // follows the late delete pass).
+        if self.delete_pass_is_late() {
+            self.run_receiver_delete_pass(
+                &setup.dest_dir,
+                #[cfg(unix)]
+                setup.sandbox.as_ref(),
+                writer,
+                &mut stats,
+            )?;
+        }
+
         // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
         // directory mtimes after file writes clobber them.
         self.touch_up_dirs(&setup.dest_dir);
@@ -257,8 +269,6 @@ impl ReceiverContext {
             stats.io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
         }
         stats.metadata_errors = metadata_errors;
-        stats.delete_stats = delete_stats;
-        stats.delete_limit_exceeded = delete_limit_exceeded;
         stats.redo_count = redo_count;
 
         Ok(stats)

--- a/crates/transfer/src/receiver/transfer/pipelined_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_async.rs
@@ -39,7 +39,6 @@ use std::path::PathBuf;
 
 use logging::{PhaseTimer, debug_log, info_log};
 use protocol::flist::FileEntry;
-use protocol::stats::DeleteStats;
 
 use crate::pipeline::PipelineConfig;
 use crate::receiver::stats::TransferStats;
@@ -112,33 +111,29 @@ impl ReceiverContext {
         // upstream: receiver.c:653-654 DEBUG_GTE(RECV, 1)
         debug_log!(Recv, 1, "recv_files({}) starting", file_count);
 
-        let mut delete_stats = DeleteStats::new();
-        let mut delete_limit_exceeded = false;
-        let mut delete_io_error: i32 = 0;
-        if self.config.flags.delete {
-            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
-                &setup.dest_dir,
-                #[cfg(unix)]
-                setup.sandbox.as_ref(),
-                writer,
-            )?;
-            delete_stats = ds;
-            delete_limit_exceeded = exceeded;
-            delete_io_error = io_bits;
-            // Carry the per-type counters into the receiver context so the
-            // goodbye handshake can emit NDX_DEL_STATS to the peer sender.
-            // upstream: generator.c:2393-2398 - early write_del_stats() emission.
-            self.pending_del_stats = delete_stats;
-        }
-
         let mut stats = TransferStats {
             files_listed: file_count,
             entries_received: file_count as u64,
             io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
-                | self.flist_io_error
-                | delete_io_error,
+                | self.flist_io_error,
             ..Default::default()
         };
+
+        // upstream: generator.c:2280-2281 - --delete-before / --delete-during
+        // sweep before the per-file loop. --delete-after / --delete-delay defer
+        // the sweep until after the transfer (see the late call below) so the
+        // destination `.rsync-filter` merge files transferred by this run are
+        // present and consulted at delete time.
+        if self.delete_pass_is_early() {
+            self.run_receiver_delete_pass(
+                &setup.dest_dir,
+                #[cfg(unix)]
+                setup.sandbox.as_ref(),
+                writer,
+                &mut stats,
+            )?;
+        }
+
         let files_to_transfer = self.build_files_to_transfer(
             writer,
             &setup.dest_dir,
@@ -275,6 +270,23 @@ impl ReceiverContext {
             super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
         }
 
+        // upstream: generator.c:2425-2428 - --delete-after / --delete-delay run
+        // the sweep only after every file (including each destination
+        // `.rsync-filter` and any --delay-updates staged file committed just
+        // above) has landed, so per-directory merge protect rules are honoured
+        // at delete time. Runs before touch_up_dirs so deletion-induced parent
+        // mtime changes are re-tidied (upstream touch_up_dirs at generator.c:2449
+        // follows the late delete pass).
+        if self.delete_pass_is_late() {
+            self.run_receiver_delete_pass(
+                &setup.dest_dir,
+                #[cfg(unix)]
+                setup.sandbox.as_ref(),
+                writer,
+                &mut stats,
+            )?;
+        }
+
         // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
         // directory mtimes after file writes clobber them.
         self.touch_up_dirs(&setup.dest_dir);
@@ -292,8 +304,6 @@ impl ReceiverContext {
             stats.io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
         }
         stats.metadata_errors = metadata_errors;
-        stats.delete_stats = delete_stats;
-        stats.delete_limit_exceeded = delete_limit_exceeded;
         stats.redo_count = redo_count;
 
         Ok(stats)

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -11,7 +11,6 @@ use std::path::PathBuf;
 use logging::{PhaseTimer, debug_log};
 use protocol::codec::create_ndx_codec;
 use protocol::flist::FileEntry;
-use protocol::stats::DeleteStats;
 
 use crate::pipeline::PipelineConfig;
 use crate::receiver::stats::TransferStats;
@@ -114,28 +113,19 @@ impl ReceiverContext {
 
         // Mirror `run_pipelined`: when `--delete` is in effect, sweep the
         // destination for extraneous entries and capture per-type counters.
-        // Upstream accumulates these globally across all delete paths so they
-        // can be reported via stats and emitted as NDX_DEL_STATS.
-        // upstream: generator.c:do_delete_pass()
-        let mut delete_stats = DeleteStats::new();
-        let mut delete_limit_exceeded = false;
-        if self.config.flags.delete {
-            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
+        // upstream: generator.c:2280-2281 - --delete-before / --delete-during
+        // sweep before the per-file loop. --delete-after / --delete-delay defer
+        // the sweep until after the transfer (see the late call below) so the
+        // destination `.rsync-filter` merge files transferred by this run are
+        // present and consulted at delete time.
+        if self.delete_pass_is_early() {
+            self.run_receiver_delete_pass(
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
                 writer,
+                &mut stats,
             )?;
-            delete_stats = ds;
-            delete_limit_exceeded = exceeded;
-            stats.io_error |= io_bits;
-            // Carry the counters into the receiver context so the goodbye
-            // handshake can emit NDX_DEL_STATS to the peer sender. URV-6.b
-            // landed the on-disk deletion but the counters were never
-            // propagated to the wire, so client `--stats` reported
-            // "Number of deleted files: 0" on every daemon upload.
-            // upstream: generator.c:2393-2398 - early write_del_stats() emission.
-            self.pending_del_stats = delete_stats;
         }
 
         let files_to_transfer = self.build_files_to_transfer(
@@ -256,6 +246,23 @@ impl ReceiverContext {
             super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
         }
 
+        // upstream: generator.c:2425-2428 - --delete-after / --delete-delay run
+        // the sweep only after every file (including each destination
+        // `.rsync-filter` and any --delay-updates staged file committed just
+        // above) has landed, so per-directory merge protect rules are honoured
+        // at delete time. Runs before touch_up_dirs so deletion-induced parent
+        // mtime changes are re-tidied (upstream touch_up_dirs at generator.c:2449
+        // follows the late delete pass).
+        if self.delete_pass_is_late() {
+            self.run_receiver_delete_pass(
+                &setup.dest_dir,
+                #[cfg(unix)]
+                setup.sandbox.as_ref(),
+                writer,
+                &mut stats,
+            )?;
+        }
+
         // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
         // directory mtimes after file writes clobber them.
         self.touch_up_dirs(&setup.dest_dir);
@@ -269,8 +276,6 @@ impl ReceiverContext {
             stats.io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
         }
         stats.metadata_errors = metadata_errors;
-        stats.delete_stats = delete_stats;
-        stats.delete_limit_exceeded = delete_limit_exceeded;
         stats.redo_count = redo_count;
 
         self.finalize_transfer(reader, writer)?;

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
@@ -24,7 +24,6 @@ use std::path::PathBuf;
 
 use logging::{PhaseTimer, debug_log};
 use protocol::flist::FileEntry;
-use protocol::stats::DeleteStats;
 
 use crate::pipeline::PipelineConfig;
 use crate::receiver::stats::TransferStats;
@@ -133,23 +132,19 @@ impl ReceiverContext {
 
         // Mirror `run_pipelined`: when `--delete` is in effect, sweep the
         // destination for extraneous entries and capture per-type counters.
-        // upstream: generator.c:do_delete_pass()
-        let mut delete_stats = DeleteStats::new();
-        let mut delete_limit_exceeded = false;
-        if self.config.flags.delete {
-            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
+        // upstream: generator.c:2280-2281 - --delete-before / --delete-during
+        // sweep before the per-file loop. --delete-after / --delete-delay defer
+        // the sweep until after the transfer (see the late call below) so the
+        // destination `.rsync-filter` merge files transferred by this run are
+        // present and consulted at delete time.
+        if self.delete_pass_is_early() {
+            self.run_receiver_delete_pass(
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
                 writer,
+                &mut stats,
             )?;
-            delete_stats = ds;
-            delete_limit_exceeded = exceeded;
-            stats.io_error |= io_bits;
-            // Carry the counters into the receiver context so the goodbye
-            // handshake can emit NDX_DEL_STATS to the peer sender.
-            // upstream: generator.c:2393-2398 - early write_del_stats() emission.
-            self.pending_del_stats = delete_stats;
         }
 
         let files_to_transfer = self.build_files_to_transfer(
@@ -274,6 +269,23 @@ impl ReceiverContext {
             super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
         }
 
+        // upstream: generator.c:2425-2428 - --delete-after / --delete-delay run
+        // the sweep only after every file (including each destination
+        // `.rsync-filter` and any --delay-updates staged file committed just
+        // above) has landed, so per-directory merge protect rules are honoured
+        // at delete time. Runs before touch_up_dirs so deletion-induced parent
+        // mtime changes are re-tidied (upstream touch_up_dirs at generator.c:2449
+        // follows the late delete pass).
+        if self.delete_pass_is_late() {
+            self.run_receiver_delete_pass(
+                &setup.dest_dir,
+                #[cfg(unix)]
+                setup.sandbox.as_ref(),
+                writer,
+                &mut stats,
+            )?;
+        }
+
         // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
         // directory mtimes after file writes clobber them.
         self.touch_up_dirs(&setup.dest_dir);
@@ -287,8 +299,6 @@ impl ReceiverContext {
             stats.io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
         }
         stats.metadata_errors = metadata_errors;
-        stats.delete_stats = delete_stats;
-        stats.delete_limit_exceeded = delete_limit_exceeded;
         stats.redo_count = redo_count;
 
         self.finalize_transfer_async(reader, writer).await?;


### PR DESCRIPTION
## Problem

Under `--delete-after`, the remote (SSH + daemon) receiver deleted destination
files that upstream protects via a per-directory `.rsync-filter` merge rule
(e.g. `- *.bak`). The receiver ran its delete pass **before** the per-file
transfer in all four pipeline drivers (`pipelined*.rs`), so the deferred modes
were never actually deferred: at that point the destination `.rsync-filter`
merge files had not yet been received, so the protect rules could not apply and
protected files were unlinked. Confirmed against a real upstream 3.4.4 binary,
both directions and both transports.

## Upstream behaviour (the goal)

Read from `target/interop/upstream-src/rsync-3.4.4/`:

- `generator.c:2280-2281` - `--delete-before` runs `do_delete_pass()` up front.
- `generator.c:2315-2327` - `--delete-during` (and `--delete-delay`,
  `delete_during == 2`) make the deletion **decision** during the directory
  walk, via `delete_in_dir()` / `remember_delete()`.
- `generator.c:2425-2428` - only `--delete-after` (`do_delete_pass()`) and the
  `--delete-delay` **unlink flush** (`do_delayed_deletions()`) run after the
  transfer. Crucially, `--delete-delay` defers only the physical unlink, not the
  decision.
- `exclude.c:875 change_local_filter_dir` / `759 push_local_filters` - the
  delete pass reloads each destination directory's `.rsync-filter` at delete
  time, which is why timing matters: a protect rule only applies once its filter
  file is present on disk.

Empirically (verified on the Linux host vs upstream 3.4.4), the protected files
survive **only** under `--delete-after`, and only once the transfer has landed
the `.rsync-filter`. `--delete-delay` deletes them (its decision happens during
the walk), matching `--delete-during`/`--delete-before`. The outcome is also
transport-dependent (SSH deletes for before/during/delay; the daemon path
protects for all), and this implementation already tracks that difference.

## Fix

- Restructure the four receiver pipeline drivers so the delete pass is routed by
  new `delete_pass_is_early()` / `delete_pass_is_late()` predicates. Only
  `--delete-after` defers the pass to after the transfer and delayed-updates
  (before `touch_up_dirs` and finalize); `--delete-before`, `--delete-during`
  and `--delete-delay` run it early. The shared defer-and-filter logic lives in
  one helper (`run_receiver_delete_pass`) - no copy-paste across the sync/async
  and incremental variants.
- Add a `delete_after` config signal (set only for `--delete-after`) distinct
  from the existing `late_delete` (delay || after, which continues to govern
  only the goodbye `NDX_DEL_STATS` timing). Threaded through the client-pull,
  daemon, and SSH server-mode argument paths. The SSH server path previously
  dropped the delete-timing entirely (it set only `flags.delete`), so a
  server-side receiver on a push never deferred - now fixed.

## Verification (host, oc vs upstream 3.4.4)

Deterministic ground-truth matrix - for each mode x transport, does the
oc-receiver keep the same per-directory-filter-protected set (`normal.bak`,
`sub/x.bak`, `sub/sub2/z.bak`, `sub/y.log`) as an upstream receiver? "protect" =
kept, "delete" = removed. `up->oc` = upstream client pushing to an oc receiver.

| transport | mode | upstream | oc->oc | up->oc |
|-----------|------|----------|--------|--------|
| ssh | before  | delete  | delete  | delete  |
| ssh | during  | delete  | delete  | delete  |
| ssh | delay   | delete  | delete  | delete  |
| ssh | after   | protect | protect | delete* |
| daemon | before | protect | protect | protect |
| daemon | during | protect | protect | protect |
| daemon | delay  | protect | protect | protect |
| daemon | after  | protect | protect | protect |

`oc->oc` matches upstream for every cell; `up->oc` matches every cell except
ssh `--delete-after` (`*`, see below). Confirmed deterministic across 6x reruns
of the after/delay cells, plus a full mode x scenario (root/nested/deep
`.rsync-filter`, plain `--delete`, global `--exclude`) x client x transport
sweep whose destination trees `diff -r` clean against the upstream ground truth.

`*` The single remaining `up->oc` ssh `--delete-after` diff is a **separate,
pre-existing** filter-wire issue, orthogonal to delete timing: an upstream
client's `-F` (dir-merge) directive is not registered into the oc receiver's
delete filter chain, so the reload finds no protect rule (flat `--exclude`
interops correctly; oc-to-oc protects; both `.rsync-filter` files are present on
the destination). It deletes identically before this change. Tracked for a
follow-up.

## Tests

Regression coverage in `crates/transfer` for the early/late routing predicates
across all four modes, plus the load-bearing invariant that protection depends
on the destination `.rsync-filter` being present at delete time (paired
present/absent cases). All pass. Compile + `cargo fmt` + `cargo clippy -p transfer`
clean.
