### PR TITLE
fix(transfer): gate --files-from transfer-root '.' to relative + leading ./ anchor

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -148,14 +148,15 @@ impl GeneratorContext {
     /// Each entry's wire-side relative name is computed by stripping its own
     /// `base`, matching upstream rsync's `chdir(dir)` + transmit-`fn` split
     /// (`flist.c:2316-2330`). The `base_dir` argument is the source argument
-    /// shared by entries without a `/./` anchor and is used to emit the
-    /// transfer-root `.` entry.
+    /// shared by entries without a `/./` anchor and, in `--relative` mode with
+    /// a leading `./` anchor, roots the implied transfer-root `.` entry.
     ///
     /// # Upstream Reference
     ///
     /// - `flist.c:2240-2264` - `change_dir(argv[0])` then read relative filenames
     /// - `flist.c:2316-2330` - per-entry `/./` anchor split
-    /// - `flist.c:2287` - `send_file_name(".", ...)` for the transfer-root entry
+    /// - `flist.c:2368-2419` - `implied_dot_dir` gates the transfer-root `.`
+    ///   emission via `send_file_name(".", ..., FLAG_IMPLIED_DIR & ~FLAG_CONTENT_DIR, ...)`
     pub fn build_file_list_with_base(
         &mut self,
         base_dir: &Path,
@@ -170,19 +171,39 @@ impl GeneratorContext {
         self.file_list.reserve(FLIST_START);
         self.source_bases.reserve(FLIST_START);
 
-        // upstream: flist.c:2287 - emit "." with XMIT_TOP_DIR for the root
-        // transfer directory so --delete works correctly on the receiver side.
-        // Skip when any entry's effective walk will already emit a `.` (i.e.
-        // an entry whose `/./` anchor produced `path == base`). Otherwise a
-        // duplicate `.` would race the entry's `.` on the wire and could
-        // overwrite the transfer-root permissions with the per-entry root's
-        // permissions when the upstream receiver dedupes by name.
-        let entry_emits_root_dot = entries.iter().any(|e| e.path == e.base);
-        if !entry_emits_root_dot {
+        // upstream: flist.c:2368-2419 - the transfer-root `.` entry is emitted
+        // ONLY in `--relative` mode and ONLY when some `--files-from` entry has
+        // a leading `./` anchor (`implied_dot_dir`). Upstream emits it via
+        // `send_file_name(".", ..., (flags | FLAG_IMPLIED_DIR) & ~FLAG_CONTENT_DIR, ...)`
+        // (flist.c:2419): FLAG_IMPLIED_DIR set, FLAG_TOP_DIR NOT set,
+        // FLAG_CONTENT_DIR cleared. Such an entry does NOT scope `--delete` over
+        // the destination root. A plain list with no `./` anchor emits NO `.`
+        // entry at all.
+        //
+        // Emitting an unconditional `.` here (the old behaviour) produced a
+        // spurious `.d ./` itemize row on the receiver and, worse, with
+        // `--delete` its TOP_DIR + CONTENT_DIR flags scoped deletion over the
+        // destination root, deleting stale root-level files that upstream
+        // preserves (data loss).
+        //
+        // Wire encoding: FLAG_IMPLIED_DIR with FLAG_CONTENT_DIR cleared
+        // serializes as XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR (flist.c:426-427);
+        // the receiver decodes that pair back to FLAG_IMPLIED_DIR
+        // (flist.c:1117-1118), never FLAG_TOP_DIR/FLAG_CONTENT_DIR. In oc's flat
+        // encoding that is `set_top_dir(true)` + `set_content_dir(false)`
+        // (`calculate_basic_flags`/`calculate_directory_flags`).
+        //
+        // A leading-`./` entry never has `path == base` (a bare `.`/`./` DOTDIR
+        // does, but carries `implied_dot == false`), so the two never collide
+        // on a duplicate root `.`.
+        let emit_implied_root_dot =
+            self.config.flags.relative && entries.iter().any(|e| e.implied_dot);
+        if emit_implied_root_dot {
             if let Ok(meta) = std::fs::symlink_metadata(base_dir) {
                 if meta.is_dir() {
                     let mut dot_entry = self.create_entry(base_dir, PathBuf::from("."), &meta)?;
                     dot_entry.set_top_dir(true);
+                    dot_entry.set_content_dir(false);
                     self.push_file_item(dot_entry, base_dir.to_path_buf());
                 }
             }

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -58,6 +58,23 @@ pub struct FilesFromEntry {
     /// into the directory's children even when global `-r` is disabled
     /// (`options.c:2189` clears `recurse` whenever `--files-from` is active).
     pub recurse: bool,
+    /// True when the transmitted relative name (after any `/./` split) begins
+    /// with a leading `./` anchor followed by more path, mirroring upstream's
+    /// `implied_dot_dir` trigger (`flist.c:2368`:
+    /// `*fn == '.' && fn[1] == '/' && fn[2]`). In `--relative` mode this makes
+    /// the sender emit a single transfer-root `.` entry with `FLAG_IMPLIED_DIR`
+    /// (`flist.c:2417-2419`). Plain entries without a leading `./` leave it
+    /// unset so no root `.` is emitted.
+    pub implied_dot: bool,
+}
+
+/// Returns true when a transmitted relative name carries a leading `./`
+/// anchor with content after it, mirroring upstream's `implied_dot_dir`
+/// detection at `flist.c:2368` (`*fn == '.' && fn[1] == '/' && fn[2]`). The
+/// third-byte requirement excludes a bare `.` or `./`.
+fn has_leading_dot_anchor(name: &str) -> bool {
+    let b = name.as_bytes();
+    b.len() > 2 && b[0] == b'.' && b[1] == b'/'
 }
 
 /// Splits a sanitized `--files-from` entry on its first `/./` anchor.
@@ -105,10 +122,14 @@ pub(super) fn split_files_from_entry(
         // An empty suffix (e.g. `from/./`) is upstream's DOTDIR_NAME case,
         // which always recurses. Otherwise honour the raw trailing slash.
         let recurse = rest.is_empty() || raw_trailing_slash;
+        // upstream: flist.c:2359-2368 - after the `/./` split, `fn` is `rest`;
+        // a further leading `./` on it still trips `implied_dot_dir`.
+        let implied_dot = has_leading_dot_anchor(rest);
         return FilesFromEntry {
             base,
             path,
             recurse,
+            implied_dot,
         };
     }
 
@@ -122,6 +143,8 @@ pub(super) fn split_files_from_entry(
                 path: base,
                 // Upstream DOTDIR_NAME always recurses.
                 recurse: true,
+                // The transmitted name is a bare `.`, so no implied root dir.
+                implied_dot: false,
             };
         }
     }
@@ -130,6 +153,8 @@ pub(super) fn split_files_from_entry(
         base: base_dir.to_path_buf(),
         path: base_dir.join(sanitized),
         recurse: raw_trailing_slash,
+        // No `/./` split: the whole sanitized name is the transmitted `fn`.
+        implied_dot: has_leading_dot_anchor(sanitized),
     }
 }
 
@@ -802,5 +827,42 @@ mod tests {
             })
             .collect();
         assert_eq!(comps, vec!["sub".to_owned()]);
+    }
+
+    #[test]
+    fn split_files_from_entry_plain_name_is_not_implied_dot() {
+        // upstream: flist.c:2368 - `implied_dot_dir` only trips on a leading
+        // `./`; a plain relative name never emits the transfer-root `.`.
+        let base = PathBuf::from("/src");
+        let split = split_files_from_entry(&base, "dir/file.txt", false);
+        assert!(!split.implied_dot);
+    }
+
+    #[test]
+    fn split_files_from_entry_leading_dot_anchor_sets_implied_dot() {
+        // upstream: flist.c:2368 - `*fn == '.' && fn[1] == '/' && fn[2]`. A
+        // leading `./foo` files-from line (no embedded `/./`) marks the entry
+        // so `--relative` mode emits a single FLAG_IMPLIED_DIR root `.`.
+        let base = PathBuf::from("/src");
+        let split = split_files_from_entry(&base, "./foo/bar", false);
+        assert!(split.implied_dot);
+    }
+
+    #[test]
+    fn split_files_from_entry_bare_dot_forms_are_not_implied_dot() {
+        // A bare `.` or `./` (upstream `fn[2]` is NUL) never sets the flag.
+        let base = PathBuf::from("/src");
+        assert!(!split_files_from_entry(&base, ".", false).implied_dot);
+        assert!(!split_files_from_entry(&base, "./", true).implied_dot);
+    }
+
+    #[test]
+    fn split_files_from_entry_anchor_then_leading_dot_sets_implied_dot() {
+        // upstream: flist.c:2359-2368 - after the `/./` split, `fn` is the
+        // suffix; `dir/././sub` leaves `rest == "./sub"`, which still trips
+        // `implied_dot_dir`.
+        let base = PathBuf::from("/src");
+        let split = split_files_from_entry(&base, "dir/././sub", false);
+        assert!(split.implied_dot);
     }
 }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3464,11 +3464,18 @@ mod files_from {
             .build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
             .unwrap();
 
-        // Dot entry + exists.txt; missing.txt is skipped with io_error.
-        assert_eq!(count, 2, "dot + exists.txt");
+        // exists.txt only; missing.txt is skipped with io_error. No implied
+        // root "." for a non-anchored files-from list (upstream flist.c:2417
+        // emits the root dot only when a leading "./" anchor sets
+        // implied_dot_dir).
+        assert_eq!(count, 1, "exists.txt only");
         let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
         assert!(names.contains(&"exists.txt"));
         assert!(!names.contains(&"missing.txt"));
+        assert!(
+            !names.contains(&"."),
+            "no implied root . for a non-anchored list"
+        );
 
         // upstream: flist.c:1810 - ENOENT for a --files-from entry that never
         // existed should set IOERR_GENERAL (exit 23), not IOERR_VANISHED (exit 24).
@@ -3503,11 +3510,17 @@ mod files_from {
             .build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
             .unwrap();
 
-        // Dot entry + exists.txt; missing.txt silently skipped.
-        assert_eq!(count, 2, "dot + exists.txt");
+        // exists.txt only; missing.txt silently skipped. No implied root "."
+        // for a non-anchored files-from list (upstream flist.c:2417 emits the
+        // root dot only when a leading "./" anchor sets implied_dot_dir).
+        assert_eq!(count, 1, "exists.txt only");
         let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
         assert!(names.contains(&"exists.txt"));
         assert!(!names.contains(&"missing.txt"));
+        assert!(
+            !names.contains(&"."),
+            "no implied root . for a non-anchored list"
+        );
 
         // No io_error flags should be set - the missing entry is silently ignored.
         assert_eq!(

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3542,7 +3542,10 @@ mod files_from {
         assert_eq!(count, 2, "exists.txt + sentinel for missing.txt");
         let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
         assert!(names.contains(&"exists.txt"));
-        assert!(!names.contains(&"."), "no implied root . for a non-anchored list");
+        assert!(
+            !names.contains(&"."),
+            "no implied root . for a non-anchored list"
+        );
 
         // The sentinel entry should have mode == 0.
         let sentinel = ctx

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3536,10 +3536,13 @@ mod files_from {
             .build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
             .unwrap();
 
-        // Dot entry + exists.txt + mode-0 sentinel for missing.txt
-        assert_eq!(count, 3, "dot + exists.txt + sentinel for missing.txt");
+        // exists.txt + mode-0 sentinel for missing.txt. No implied root "."
+        // for a plain files-from list without a leading "./" anchor
+        // (upstream flist.c:2368 emits the root dot only for relative + ./ anchor).
+        assert_eq!(count, 2, "exists.txt + sentinel for missing.txt");
         let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
         assert!(names.contains(&"exists.txt"));
+        assert!(!names.contains(&"."), "no implied root . for a non-anchored list");
 
         // The sentinel entry should have mode == 0.
         let sentinel = ctx
@@ -3581,8 +3584,9 @@ mod files_from {
             .build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
             .unwrap();
 
-        // Dot entry + mode-0 sentinel (delete takes precedence over ignore).
-        assert_eq!(count, 2, "dot + sentinel for missing.txt");
+        // mode-0 sentinel only (delete takes precedence over ignore); no
+        // implied root "." for a non-anchored files-from list.
+        assert_eq!(count, 1, "sentinel for missing.txt");
         let sentinel = ctx
             .file_list()
             .iter()

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -173,6 +173,7 @@ fn files_from_entries(base: &Path, paths: Vec<PathBuf>) -> Vec<super::filters::F
             base: base.to_path_buf(),
             path,
             recurse: false,
+            implied_dot: false,
         })
         .collect()
 }
@@ -2888,7 +2889,7 @@ mod files_from {
             .build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
             .unwrap();
 
-        // Dot entry + 2 files + 1 parent dir "subdir"
+        // 2 files + 1 parent dir "subdir"
         assert!(count >= 3, "expected at least 3 entries, got {count}");
 
         // Verify that file entries have correct relative names (not empty).
@@ -2901,8 +2902,93 @@ mod files_from {
             names.iter().any(|n| n.contains("file.txt")),
             "expected file.txt in {names:?}"
         );
-        // The dot entry should be present.
-        assert!(names.contains(&"."), "expected dot entry in {names:?}");
+        // upstream: flist.c:2368-2419 - a plain --files-from list (no leading
+        // `./` anchor) in non-relative mode emits NO transfer-root `.` entry.
+        // The old code emitted one unconditionally, producing a spurious
+        // `.d ./` itemize row and, with --delete, scoping deletion over the
+        // destination root (data loss).
+        assert!(
+            !names.contains(&"."),
+            "plain files-from list must not emit a root `.` entry: {names:?}"
+        );
+    }
+
+    #[test]
+    fn build_file_list_with_base_leading_dot_anchor_emits_implied_root_dot() {
+        // upstream: flist.c:2417-2419 - in --relative mode a leading `./`
+        // anchor (`implied_dot_dir`) emits ONE transfer-root `.` via
+        // `send_file_name(".", ..., (flags | FLAG_IMPLIED_DIR) & ~FLAG_CONTENT_DIR, ...)`:
+        // FLAG_IMPLIED_DIR set, FLAG_TOP_DIR unset, FLAG_CONTENT_DIR cleared.
+        // On the wire that pair serializes as XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR
+        // (flist.c:426-427), which the receiver decodes back to FLAG_IMPLIED_DIR
+        // (flist.c:1117-1118) - it therefore does NOT scope --delete over the
+        // destination root. In oc's flat encoding that is top_dir=true +
+        // content_dir=false.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("foo"), b"x").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.args = vec![OsString::from(&src)];
+        config.flags.relative = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let entry = super::filters::FilesFromEntry {
+            base: src.clone(),
+            path: src.join("foo"),
+            recurse: false,
+            implied_dot: true,
+        };
+        ctx.build_file_list_with_base(&src, std::slice::from_ref(&entry))
+            .unwrap();
+
+        let dot = ctx
+            .file_list()
+            .iter()
+            .find(|e| e.name() == ".")
+            .expect("expected an implied transfer-root `.` entry");
+        assert!(
+            dot.top_dir(),
+            "implied `.` must set XMIT_TOP_DIR on the wire"
+        );
+        assert!(
+            !dot.content_dir(),
+            "implied `.` must clear FLAG_CONTENT_DIR (XMIT_NO_CONTENT_DIR) so it does not scope --delete"
+        );
+    }
+
+    #[test]
+    fn build_file_list_with_base_leading_dot_without_relative_emits_no_root_dot() {
+        // upstream: flist.c:2350 - the `implied_dot_dir` root `.` lives inside
+        // the `if (relative_paths)` branch. Without --relative, even a leading
+        // `./` files-from entry emits no transfer-root `.`.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("foo"), b"x").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.args = vec![OsString::from(&src)];
+        config.flags.relative = false;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let entry = super::filters::FilesFromEntry {
+            base: src.clone(),
+            path: src.join("foo"),
+            recurse: false,
+            implied_dot: true,
+        };
+        ctx.build_file_list_with_base(&src, std::slice::from_ref(&entry))
+            .unwrap();
+
+        let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+        assert!(
+            !names.contains(&"."),
+            "non-relative mode must not emit a root `.` entry: {names:?}"
+        );
     }
 
     #[test]
@@ -2997,6 +3083,7 @@ mod files_from {
             base: from_dir.clone(),
             path: from_dir.clone(),
             recurse: true,
+            implied_dot: false,
         };
         ctx.build_file_list_with_base(&src, std::slice::from_ref(&dotdir_entry))
             .unwrap();


### PR DESCRIPTION
## Problem

`build_file_list_with_base` (the remote/SSH/daemon `--files-from` sender path)
pushed a transfer-root `.` entry unconditionally for every plain `--files-from`
list and marked it `set_top_dir(true)` with the default `content_dir=true`. That
pair serializes as `XMIT_TOP_DIR` with content, which an upstream receiver
decodes as `FLAG_TOP_DIR | FLAG_CONTENT_DIR` and uses to scope `--delete` over
the destination root.

Verified against upstream 3.4.4 (oc-sender to upstream-receiver, no-change
second pass `-a -ii`):

1. the upstream receiver printed a spurious `.d ./` itemize row;
2. with `--delete` and a stale file in the destination root, oc caused it to be
   deleted, while a pure-upstream transfer preserves it (data loss).

## Upstream ground truth

`flist.c:2368-2419`: upstream emits the transfer-root `.` entry ONLY when
`relative_paths` AND some `--files-from` entry carries a leading `./` anchor
(`implied_dot_dir`, `*fn == '.' && fn[1] == '/' && fn[2]`). It is sent via
`send_file_name(".", ..., (flags | FLAG_IMPLIED_DIR) & ~FLAG_CONTENT_DIR, ...)`:
`FLAG_IMPLIED_DIR` set, `FLAG_TOP_DIR` unset, `FLAG_CONTENT_DIR` cleared, so it
does NOT scope root deletion. A plain list with no leading `./` emits no `.`
entry at all.

On the wire, `FLAG_IMPLIED_DIR` with `FLAG_CONTENT_DIR` cleared serializes as
`XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR` (`flist.c:426-427`), which the receiver
decodes back to `FLAG_IMPLIED_DIR` (`flist.c:1117-1118`).

## Fix

Emit the root `.` only when `relative_paths` (which `--files-from` implies,
`options.c:2205`) and at least one entry has a leading `./` anchor. When emitted,
mark it `top_dir=true` + `content_dir=false`; in oc's flat encoding that produces
exactly `XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR`. `implied_dot` is computed in
`split_files_from_entry` from the transmitted relative name's leading `./`,
mirroring upstream's per-line `implied_dot_dir` detection.

## Verification (Linux, aarch64, vs upstream rsync 3.4.4)

Every oc-sender to upstream-receiver cell matches a pure-upstream reference over
both SSH and daemon, both push and pull:

| cell | plain list | `./`-anchored list |
| --- | --- | --- |
| flist root `.` count (oc sender) | 0 | 1 |
| tree diff vs upstream ref | empty | empty |
| stale dest-root file | preserved | preserved |
| `-ii` `./` itemize row parity | match | match |

Regression tests added encode the upstream rationale (`flist.c:2368-2419`).
`cargo fmt`, `cargo clippy -D warnings`, and the touched crate's test build pass;
`cargo check --target x86_64-pc-windows-gnu` passes.
