### PR TITLE
fix(core): validate --temp-dir exists before transferring

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -360,6 +360,51 @@ pub(crate) fn destination_access_error(path: &Path, error: io::Error) -> ClientE
     ClientError::with_code(code, message)
 }
 
+/// Validates a `--temp-dir` argument before transferring, mirroring upstream's
+/// receiver-side check.
+///
+/// upstream: main.c:1031-1046 `do_recv()` stats `tmpdir` and, on failure,
+/// `exit_cleanup()`s before any file is transferred:
+/// - stat succeeds but the path is not a directory -> `The temp-dir is not a
+///   directory: <path>` with `RERR_SYNTAX` (1).
+/// - stat fails with `ENOENT` -> `The temp-dir does not exist: <path>` with
+///   `RERR_SYNTAX` (1).
+/// - any other stat failure -> `Failed to stat temp-dir <path>: <errno>` with
+///   `RERR_FILEIO` (11).
+///
+/// `tmpdir` is a receiver-only option (options.c:2925 forwards `--temp-dir` to
+/// the remote only when `am_sender`), so callers invoke this only when the
+/// local process receives - a local copy or a pull, never a push. The receiver
+/// role tags the diagnostic to match upstream's `who_am_i()` in `do_recv()`.
+#[cold]
+pub(crate) fn validate_temp_dir(temp_dir: &Path) -> Result<(), ClientError> {
+    match std::fs::metadata(temp_dir) {
+        Ok(metadata) if metadata.is_dir() => Ok(()),
+        Ok(_) => Err(temp_dir_error(
+            format!("The temp-dir is not a directory: {}", temp_dir.display()),
+            ExitCode::Syntax,
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Err(temp_dir_error(
+            format!("The temp-dir does not exist: {}", temp_dir.display()),
+            ExitCode::Syntax,
+        )),
+        Err(error) => Err(temp_dir_error(
+            format!(
+                "Failed to stat temp-dir {}: {}",
+                temp_dir.display(),
+                upstream_io_error(&error)
+            ),
+            ExitCode::FileIo,
+        )),
+    }
+}
+
+#[cold]
+fn temp_dir_error(text: String, code: ExitCode) -> ClientError {
+    let message = rsync_error!(code.as_i32(), text).with_role(Role::Receiver);
+    ClientError::with_code(code, message)
+}
+
 #[cold]
 pub(crate) fn socket_error(
     action: &str,
@@ -641,6 +686,46 @@ mod tests {
             let error = invalid_argument_error_typed("typed error", ExitCode::FileSelect);
             assert_eq!(error.code(), ExitCode::FileSelect);
             assert!(error.to_string().contains("typed error"));
+        }
+
+        /// upstream: main.c:1039-1041 do_recv() - a missing --temp-dir prints
+        /// "The temp-dir does not exist: <path>" and exit_cleanup(RERR_SYNTAX=1).
+        #[test]
+        fn validate_temp_dir_missing_is_syntax_error() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let missing = dir.path().join("does-not-exist");
+            let error = validate_temp_dir(&missing).expect_err("missing temp-dir must error");
+            assert_eq!(error.exit_code(), 1);
+            assert_eq!(error.code(), ExitCode::Syntax);
+            let msg = error.to_string();
+            assert!(msg.contains("The temp-dir does not exist:"), "{msg}");
+            assert!(msg.contains(&missing.display().to_string()), "{msg}");
+        }
+
+        /// upstream: main.c:1036-1037 do_recv() - an existing non-directory
+        /// prints "The temp-dir is not a directory: <path>" and RERR_SYNTAX.
+        #[test]
+        fn validate_temp_dir_non_directory_is_syntax_error() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let file = dir.path().join("a-file");
+            std::fs::write(&file, b"x").expect("write");
+            let error = validate_temp_dir(&file).expect_err("file temp-dir must error");
+            assert_eq!(error.exit_code(), 1);
+            assert_eq!(error.code(), ExitCode::Syntax);
+            assert!(
+                error
+                    .to_string()
+                    .contains("The temp-dir is not a directory:"),
+                "{error}"
+            );
+        }
+
+        /// upstream: main.c:1031-1034 do_recv() - an existing directory passes
+        /// the check without error.
+        #[test]
+        fn validate_temp_dir_existing_directory_is_ok() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            assert!(validate_temp_dir(dir.path()).is_ok());
         }
 
         #[test]

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -67,7 +67,7 @@ use engine::local_copy::{
 };
 
 use super::config::{BandwidthLimit, ClientConfig, DeleteMode};
-use super::error::{ClientError, map_local_copy_error, missing_operands_error};
+use super::error::{ClientError, map_local_copy_error, missing_operands_error, validate_temp_dir};
 use super::progress::{ClientProgressForwarder, ClientProgressObserver};
 use super::remote;
 use super::summary::ClientSummary;
@@ -186,6 +186,21 @@ fn run_client_internal(
     }
 
     apply_max_alloc(&config);
+
+    // upstream: main.c:1031-1046 do_recv() - the receiver validates --temp-dir
+    // exists and is a directory before transferring. tmpdir is a receiver-only
+    // option (options.c:2925 forwards it only when am_sender), so the check
+    // fires only when the local process receives: a local copy or a pull (local
+    // destination), never a push (remote destination).
+    if let Some(temp_dir) = config.temp_directory() {
+        let dest_is_local = config
+            .transfer_args()
+            .last()
+            .is_none_or(|dest| !remote::operand_is_remote(dest));
+        if dest_is_local {
+            validate_temp_dir(temp_dir)?;
+        }
+    }
 
     let batch_writer = if let Some(batch_cfg) = config.batch_config() {
         if let Some(result) = batch::handle_batch_read(batch_cfg, &config) {


### PR DESCRIPTION
## Summary

Upstream rsync's receiver validates the `--temp-dir`/`-T` path in `do_recv()` before any file is transferred, exiting `RERR_SYNTAX` (1) if the directory does not exist or is not a directory (main.c:1031-1046). oc-rsync skipped this pre-check and instead proceeded into the transfer, failing later with exit 24.

This adds the equivalent startup check.

## Upstream reference

```c
/* main.c:1031-1046 do_recv() */
if (tmpdir) {
    STRUCT_STAT st;
    int ret = do_stat(tmpdir, &st);
    if (ret < 0 || !S_ISDIR(st.st_mode)) {
        if (ret == 0) {
            rprintf(FERROR, "The temp-dir is not a directory: %s\n", tmpdir);
            exit_cleanup(RERR_SYNTAX);
        }
        if (errno == ENOENT) {
            rprintf(FERROR, "The temp-dir does not exist: %s\n", tmpdir);
            exit_cleanup(RERR_SYNTAX);
        }
        rprintf(FERROR, "Failed to stat temp-dir %s: %s\n", tmpdir, strerror(errno));
        exit_cleanup(RERR_FILEIO);
    }
}
```

`tmpdir` is a receiver-only option (options.c:2925 forwards `--temp-dir` to the remote only when `am_sender`), so the check fires only when the local process receives - a local copy or a pull (local destination), never a push (remote destination). The diagnostic is tagged with the receiver role to match `who_am_i()` in `do_recv()`.

## Behaviour

- Missing directory: `The temp-dir does not exist: <path>` -> exit 1 (`RERR_SYNTAX`)
- Existing non-directory: `The temp-dir is not a directory: <path>` -> exit 1 (`RERR_SYNTAX`)
- Any other stat error: `Failed to stat temp-dir <path>: <errno>` -> exit 11 (`RERR_FILEIO`)

## Validation

Verified against upstream rsync 3.4.4 on Linux (aarch64):

| Case | Upstream | oc-rsync |
|------|----------|----------|
| `--temp-dir=/nonexistent` | `The temp-dir does not exist: /nonexistent`, exit 1 | same message, exit 1 |
| `--temp-dir=<a file>` | `The temp-dir is not a directory: <path>`, exit 1 | same message, exit 1 |
| valid `--temp-dir` | transfers, exit 0 | transfers, exit 0 (no regression) |
| no `--temp-dir` | transfers, exit 0 | transfers, exit 0 (no regression) |

## Tests

Adds unit tests for the missing, non-directory, and existing-directory cases, each citing `main.c`.
