### PR TITLE
fix(cli): recognize --no-r/--no-W/--no-relative server negation flags

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -249,6 +249,31 @@ pub(super) struct ServerLongFlags {
     /// the flist at protocol < 30 (flist.c:2468); protocol >= 30 always sends
     /// them (flist.c:2257-2258).
     pub(super) no_implied_dirs: bool,
+
+    /// Whether the client forwarded `--no-r` (upstream `recurse = 0`).
+    ///
+    /// upstream: options.c:2750-2753 - `if (xfer_dirs && !recurse &&
+    /// delete_mode && am_sender) args[ac++] = "--no-r"`. A client running
+    /// `-d --delete` (e.g. `--files-from --delete`) forwards `--no-r` so the
+    /// remote receiver can delete with `-d` sans `-r`; the server-side popt
+    /// table clears `recurse` (options.c:623 `{"no-r", ..., &recurse, 0}`).
+    pub(super) no_recurse: bool,
+
+    /// Whether the client forwarded `--no-W` (upstream `whole_file = 0`).
+    ///
+    /// upstream: options.c:2955-2959 - under `--inplace`, `if (sparse_files &&
+    /// !whole_file && am_sender) args[ac++] = "--no-W"` works around an older
+    /// remote bug for `--inplace --sparse`. The server-side popt table clears
+    /// `whole_file` (options.c:746 `{"no-W", ..., &whole_file, 0}`).
+    pub(super) no_whole_file: bool,
+
+    /// Whether the client forwarded `--no-relative` (upstream `relative_paths = 0`).
+    ///
+    /// upstream: options.c:2962-2973 - when `files_from` is active and
+    /// `!relative_paths`, the client emits `--no-relative`. The server-side
+    /// popt table clears `relative_paths` (options.c:693 `{"no-relative", ...,
+    /// &relative_paths, 0}`).
+    pub(super) no_relative: bool,
 }
 
 /// Parses all long-form flags from the server argument list.
@@ -306,6 +331,9 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         mkpath: false,
         list_only: false,
         no_implied_dirs: false,
+        no_recurse: false,
+        no_whole_file: false,
+        no_relative: false,
     };
 
     let mut idx = 0;
@@ -335,6 +363,16 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // forwarded to the sender on a pull. The server-side sender must omit
             // implied parent dirs from the flist at protocol < 30.
             "--no-implied-dirs" => flags.no_implied_dirs = true,
+            // upstream: options.c:623 / 2750-2753 - `--no-r` clears `recurse`
+            // on the server-side popt table. A client running `-d --delete`
+            // forwards it so the remote can delete with `-d` sans `-r`.
+            "--no-r" => flags.no_recurse = true,
+            // upstream: options.c:746 / 2955-2959 - `--no-W` clears `whole_file`
+            // so `--inplace --sparse` streams a delta instead of the whole file.
+            "--no-W" => flags.no_whole_file = true,
+            // upstream: options.c:693 / 2962-2973 - `--no-relative` clears
+            // `relative_paths` when the client used `--files-from` without `-R`.
+            "--no-relative" => flags.no_relative = true,
             "--from0" => flags.from0 = true,
             "--inplace" => flags.inplace = true,
             // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode
@@ -611,6 +649,13 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--no-msgs2stderr"
             | "--qsort"
             | "--no-implied-dirs"
+            // upstream: options.c:2753/2959/2973 - server_options() emits these
+            // negations; the server-side popt table clears recurse/whole_file/
+            // relative_paths (options.c:623/746/693). Recognise them so they are
+            // not mistaken for positional destination paths.
+            | "--no-r"
+            | "--no-W"
+            | "--no-relative"
             | "--from0"
             | "--inplace"
             | "--append"

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -211,6 +211,24 @@ where
     // must omit the implied parent dirs from the flist at protocol < 30; at
     // protocol >= 30 they are always sent (flist.c:2257-2258).
     config.flags.no_implied_dirs = long_flags.no_implied_dirs;
+    // upstream: options.c:623 / 2750-2753 - `--no-r` clears `recurse` via the
+    // server popt table. The client emits it under `-d --delete` so the remote
+    // can delete with `-d` sans `-r`. It overrides the compact `r` letter that
+    // `ParsedServerFlags::parse` set, so apply it only when forwarded.
+    if long_flags.no_recurse {
+        config.flags.recursive = false;
+    }
+    // upstream: options.c:746 / 2955-2959 - `--no-W` clears `whole_file` so
+    // `--inplace --sparse` streams a delta. Overrides the compact `W` letter.
+    if long_flags.no_whole_file {
+        config.flags.whole_file = false;
+    }
+    // upstream: options.c:693 / 2962-2973 - `--no-relative` clears
+    // `relative_paths` when the client used `--files-from` without `-R`.
+    // Overrides the compact `R` letter.
+    if long_flags.no_relative {
+        config.flags.relative = false;
+    }
     config.flags.numeric_ids = core::server::NumericIds::from_client(long_flags.numeric_ids);
     config.flags.delete = long_flags.delete;
     // upstream: generator.c:124 - --delete-after / --delete-delay both defer the

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -821,6 +821,73 @@ fn long_flags_specials_and_no_specials() {
     assert!(is_known_server_long_flag("--no-specials"));
 }
 
+// upstream: options.c:2750-2753 - `if (xfer_dirs && !recurse && delete_mode &&
+// am_sender) args[ac++] = "--no-r"`. A real upstream client running
+// `--files-from --delete` forwards `--no-r`; the server-side popt table clears
+// `recurse` (options.c:623). Without recognition the token leaks into the
+// positional path list and the receiver tries to create a destination root
+// literally named `--no-r`, failing with "Permission denied" (exit 1).
+#[test]
+fn long_flags_no_r_recognized_and_parsed() {
+    let flags = parse_server_long_flags(&[OsString::from("--server"), OsString::from("--no-r")]);
+    assert!(flags.no_recurse);
+
+    let flags = parse_server_long_flags(&[OsString::from("--server")]);
+    assert!(!flags.no_recurse);
+
+    assert!(is_known_server_long_flag("--no-r"));
+}
+
+// upstream: options.c:2955-2959 - under `--inplace`, `if (sparse_files &&
+// !whole_file && am_sender) args[ac++] = "--no-W"`. Clears `whole_file`
+// server-side (options.c:746) so `--inplace --sparse` streams a delta.
+#[test]
+fn long_flags_no_w_recognized_and_parsed() {
+    let flags = parse_server_long_flags(&[OsString::from("--server"), OsString::from("--no-W")]);
+    assert!(flags.no_whole_file);
+
+    let flags = parse_server_long_flags(&[OsString::from("--server")]);
+    assert!(!flags.no_whole_file);
+
+    assert!(is_known_server_long_flag("--no-W"));
+}
+
+// upstream: options.c:2962-2973 - `--no-relative` is emitted with
+// `--files-from` when `!relative_paths`. Clears `relative_paths` server-side
+// (options.c:693).
+#[test]
+fn long_flags_no_relative_recognized_and_parsed() {
+    let flags =
+        parse_server_long_flags(&[OsString::from("--server"), OsString::from("--no-relative")]);
+    assert!(flags.no_relative);
+
+    let flags = parse_server_long_flags(&[OsString::from("--server")]);
+    assert!(!flags.no_relative);
+
+    assert!(is_known_server_long_flag("--no-relative"));
+}
+
+// Regression: the four `--no-*` negations upstream emits must be split off the
+// compact flag string and never surface as positional destination paths. This
+// reproduces the `--files-from --delete` push where the client sends `--no-r`.
+// upstream: options.c:2753/2959/2973/2977.
+#[test]
+fn no_negations_do_not_leak_as_positional_paths() {
+    let args = [
+        OsString::from("--server"),
+        OsString::from("--no-r"),
+        OsString::from("--no-W"),
+        OsString::from("--no-relative"),
+        OsString::from("--no-implied-dirs"),
+        OsString::from("-logDtpr"),
+        OsString::from("."),
+        OsString::from("dst/"),
+    ];
+    let (flag_string, positional) = parse_server_flag_string_and_args(&args[1..]);
+    assert_eq!(flag_string, "-logDtpr");
+    assert_eq!(positional, vec![OsString::from("dst/")]);
+}
+
 #[test]
 fn long_flags_checksum_seed() {
     let args = vec![


### PR DESCRIPTION
## Problem

Upstream `server_options()` emits four `--no-*` negations that a real rsync
client forwards over SSH/daemon, but oc's server-mode long-flag parser
`is_known_server_long_flag()` recognized only `--no-implied-dirs`. The other
three fell through to `parse_server_flag_string_and_args()` and were treated as
positional **destination paths**, breaking the transfer.

The most common trigger is a client running `--files-from --delete`, which
emits `--no-r` (options.c:2750-2753). Against an oc SSH server this failed with:

```
failed to create destination root --no-r: Permission denied   (exit 1)
```

## Upstream reference

`server_options()` in `options.c` emits, and the server-side popt table applies:

| Emit | Gate (options.c) | popt clears (options.c) |
|------|------------------|--------------------------|
| `--no-r`            | 2750-2753 `xfer_dirs && !recurse && delete_mode && am_sender` | 623 `recurse = 0` |
| `--no-W`            | 2955-2959 `inplace && sparse_files && !whole_file && am_sender` | 746 `whole_file = 0` |
| `--no-relative`     | 2962-2973 `files_from && !relative_paths` | 693 `relative_paths = 0` |
| `--no-implied-dirs` | 2976-2977 (already handled) | 696 `implied_dirs = 0` |

## Fix

- Recognize `--no-r`, `--no-W`, `--no-relative` in `is_known_server_long_flag()`
  so they are split off the compact flag string instead of leaking into the
  positional path list.
- Parse them into `ServerLongFlags` and apply each to the server config,
  overriding the compact short-letter value exactly as upstream's popt table
  clears the global:
  - `--no-r` -> `recursive = false`
  - `--no-W` -> `whole_file = false`
  - `--no-relative` -> `relative = false`

Single recognition path; regression tests cover parsing, recognition, and the
positional-leak path for all four negations.

## Validation

Real upstream 3.4.4 client -> oc SSH server; reference = same upstream client ->
upstream SSH server over ssh.

| Leg | Flag | Client command | oc receives flag | oc exit | Result |
|-----|------|----------------|:---------------:|:-------:|--------|
| A | `--no-r` | push `-d --delete --files-from` | yes | 0 | intended files transfer correctly; no positional-path error (was exit 1 before) |
| B | `--no-W` | push `-a --inplace --sparse --no-whole-file` | yes | 0 | `diff -r` IDENTICAL |
| C | `--no-relative` | pull `-d --files-from --no-relative` | yes | 4 | flag applied; surfaces a separate pre-existing sender bug (below) |
| D | `--no-implied-dirs` | push `-aR --no-implied-dirs` | yes | 0 | `diff -r` IDENTICAL |
| E | oc -> oc | oc client + oc server, leg A | - | 0 | works (no regression) |

No previously-working path is affected: before this change all four negations
leaked as positional paths and every transfer failed.

## Two pre-existing, orthogonal bugs unmasked (follow-ups, not caused by this change)

Both reproduce only when oc is the SSH server; oc's local-copy path matches
upstream exactly in both cases.

1. Server-receiver over-deletes with `--delete` + `--files-from`. In leg A, oc
   deletes a destination file that upstream keeps. This reproduces with a plain
   `-r --delete --files-from` client (no `--no-r` on the wire) and disappears
   entirely without `--delete`, so it is a delete-scope bug in the server
   receiver, independent of the flag-recognition fix. Local
   `--delete --files-from` is byte-identical to upstream.

2. Server-sender with `--no-relative` + files-from-over-wire fails to flatten.
   On a pull, oc's sender emits the implied `sub` directory instead of the
   flattened basenames, and the upstream receiver rejects it ("rejecting
   unrequested file-list name: sub", exit 4). Every files-from pull without
   `--no-relative` is byte-identical, and the local `--files-from --no-relative`
   copy flattens correctly, so the gap is specific to the server-sender
   no-relative + wire-sourced files-from path.

## Also found while re-deriving `server_options()` (follow-ups)

These long flags are emitted by upstream `server_options()` but not yet
recognized by oc's server parser, so they would also leak as positional paths:
`--force` (2849), `--only-write-batch=X` (2851), `--super` (2853),
`--delete-missing-args` (2869), `--ignore-missing-args` (2871),
`--use-qsort` (2909, note: oc currently recognizes `--qsort`, not the emitted
`--use-qsort`), `--preallocate` (2991), `--open-noatime` (2994). Left for a
dedicated change since several require new config plumbing and their own
validation; recognizing without correctly applying would silently change
behavior.
