### PR TITLE
test(cli): track -@ short-value attached/equals as known-rejected

### DIFF
--- a/crates/cli/tests/upstream_arg_fidelity.rs
+++ b/crates/cli/tests/upstream_arg_fidelity.rs
@@ -293,7 +293,7 @@ fn context_for(opt: &Opt) -> &'static [&'static str] {
 /// rejects for path-like values though upstream popt accepts them. oc's
 /// `expand_short_options` omits these from its value-short set, so a value that
 /// looks like an operand (`-T/tmp`, `-T=/tmp`) leaks into the operand list.
-const KNOWN_SHORT_VALUE_FORM_REJECTED: &[&str] = &["temp-dir"];
+const KNOWN_SHORT_VALUE_FORM_REJECTED: &[&str] = &["temp-dir", "modify-window"];
 
 /// Parses `tokens` with two trailing sentinel operands and confirms the option
 /// (and any value) was consumed by a real argument, leaving only the sentinels


### PR DESCRIPTION
Completes the #6522 fix. #6522 removed `-@` from `KNOWN_SHORT_REJECTED` (its space form works via #6517) but that un-skipped `-@` in `short_value_options_accept_attached_and_equals_forms`, which then demands `-@2`/`-@=2` — the attached/equals short-value forms that only land with #6518's `-T`/`-B` class fix. Add `modify-window` to `KNOWN_SHORT_VALUE_FORM_REJECTED` to match current behaviour and un-red master; the suite self-heals when #6518 merges (remove `-@`/`-B`/`-T` together, un-ignore trackers).