### PR TITLE
fix(cli): align choice/protocol/empty-filter exit codes with upstream

### DIFF
--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -89,8 +89,10 @@ pub(crate) fn parse_compress_choice(
     let trimmed = original.trim();
 
     if trimmed.is_empty() {
+        // upstream: compat.c:190 - an unparsable compress name returns
+        // RERR_UNSUPPORTED (errcode.h:28), not RERR_SYNTAX.
         return Err(
-            rsync_error!(1, "--compress-choice={} is invalid", original).with_role(Role::Client)
+            rsync_error!(4, "--compress-choice={} is invalid", original).with_role(Role::Client)
         );
     }
 
@@ -124,7 +126,9 @@ fn render_compress_choice_error(err: CompressionAlgorithmParseError, trimmed: &s
     let rendered = format!(
         "invalid compression algorithm '{display}': supported values include {supported_list}"
     );
-    rsync_error!(1, rendered).with_role(Role::Client)
+    // upstream: compat.c:190 - an unknown compress name returns
+    // RERR_UNSUPPORTED (errcode.h:28), not RERR_SYNTAX.
+    rsync_error!(4, rendered).with_role(Role::Client)
 }
 
 pub(crate) fn parse_bandwidth_limit(argument: &OsStr) -> Result<Option<BandwidthLimit>, Message> {

--- a/crates/cli/src/frontend/execution/drive/filters.rs
+++ b/crates/cli/src/frontend/execution/drive/filters.rs
@@ -102,6 +102,8 @@ fn push_filter_directive(
         }
         FilterDirective::Clear => filter_rules.clear(),
         FilterDirective::CvsDefaults => filter_rules.extend(cvs_default_exclude_rules()?),
+        // A blank rule contributes nothing (upstream parse_rule_tok returns NULL).
+        FilterDirective::Noop => {}
     }
     Ok(())
 }
@@ -122,8 +124,10 @@ fn push_old_prefix_rule(
     match parse_old_prefix_rule(&text, default_kind)? {
         FilterDirective::Rule(rule) => destination.push(rule),
         FilterDirective::Clear => destination.push(FilterRuleSpec::clear()),
+        // A blank `--exclude`/`--include` value contributes nothing.
+        FilterDirective::Noop => {}
         FilterDirective::Merge(_) | FilterDirective::CvsDefaults => {
-            unreachable!("parse_old_prefix_rule only emits Rule or Clear")
+            unreachable!("parse_old_prefix_rule only emits Rule, Clear, or Noop")
         }
     }
     Ok(())

--- a/crates/cli/src/frontend/execution/drive/validation.rs
+++ b/crates/cli/src/frontend/execution/drive/validation.rs
@@ -3,16 +3,12 @@ use std::io::Write;
 
 use core::{message::Role, rsync_error};
 use logging_sink::MessageSink;
-use protocol::ProtocolVersion;
 
 use super::messages::fail_with_message;
 
 /// Error message when `--remote-option` is used without a remote connection.
 pub(crate) const REMOTE_OPTION_REMOTE_ONLY_MESSAGE: &str =
     "the --remote-option option may only be used with remote connections";
-/// Error message when `--protocol` is used without a daemon connection.
-pub(crate) const PROTOCOL_DAEMON_ONLY_MESSAGE: &str =
-    "the --protocol option may only be used when accessing an rsync daemon";
 /// Error message when a password option is used without a daemon connection.
 pub(crate) const PASSWORD_DAEMON_ONLY_MESSAGE: &str = "the --password-file and --password-command options may only be used when accessing an rsync daemon";
 /// Error message when `--connect-program` is used without a daemon connection.
@@ -28,7 +24,6 @@ pub(crate) const CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE: &str =
 /// uses it when spawning a remote shell). The upstream testsuite relies on
 /// this behavior (e.g., the exclude test passes `--rsync-path` on local runs).
 pub(super) fn validate_local_only_options<Err>(
-    desired_protocol: Option<ProtocolVersion>,
     has_password_override: bool,
     has_password_option: bool,
     connect_program: Option<&OsString>,
@@ -46,12 +41,10 @@ where
         ));
     }
 
-    if desired_protocol.is_some() {
-        return Some(reject_local_only_option(
-            stderr,
-            PROTOCOL_DAEMON_ONLY_MESSAGE,
-        ));
-    }
+    // upstream imposes no daemon-only restriction on `--protocol`: setup_protocol
+    // (compat.c) runs for local copies too, so `--protocol=N` (20..=32) is
+    // accepted locally and simply ignored (this build never negotiates a
+    // protocol for a local copy). See resolve_desired_protocol.
 
     if has_password_override || has_password_option {
         return Some(reject_local_only_option(

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -54,7 +54,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use super::super::super::{
-    parse_bind_address_argument, parse_protocol_version_arg, parse_timeout_argument,
+    ProtocolArg, legacy_remote_rejection, parse_bind_address_argument, parse_protocol_version_arg,
+    parse_timeout_argument,
 };
 #[cfg(any(
     not(all(any(unix, windows), feature = "acl")),
@@ -90,20 +91,39 @@ where
     }
 }
 
-/// Parses the `--protocol` argument into a [`ProtocolVersion`].
+/// Parses and resolves the `--protocol` argument into a [`ProtocolVersion`].
+///
+/// upstream: `setup_protocol` (compat.c:629-637) runs for local copies too, so
+/// upstream accepts `--protocol` on a local transfer (protocol `20..=32` all
+/// exit 0; local output is identical regardless). This build never negotiates a
+/// protocol for a local copy, so any accepted value is simply ignored there
+/// (`Ok(None)`). Only a remote transfer carries a concrete version, and it must
+/// fall within this build's wire range (`28..=32`); a legacy value (`20..=27`)
+/// that upstream would negotiate is refused because this build cannot speak it.
 pub(crate) fn resolve_desired_protocol<Err>(
     protocol: Option<&OsString>,
+    has_remote_operand: bool,
     stderr: &mut MessageSink<Err>,
 ) -> Result<Option<ProtocolVersion>, i32>
 where
     Err: Write,
 {
-    match protocol {
-        Some(value) => match parse_protocol_version_arg(value.as_os_str()) {
-            Ok(version) => Ok(Some(version)),
-            Err(message) => Err(fail_with_message(message, stderr)),
-        },
-        None => Ok(None),
+    let Some(value) = protocol else {
+        return Ok(None);
+    };
+    match parse_protocol_version_arg(value.as_os_str()) {
+        Ok(ProtocolArg::Supported(version)) => {
+            // Local copies ignore the protocol entirely (no wire negotiation).
+            Ok(has_remote_operand.then_some(version))
+        }
+        Ok(ProtocolArg::LegacyLocalOnly(raw)) => {
+            if has_remote_operand {
+                Err(fail_with_message(legacy_remote_rejection(raw), stderr))
+            } else {
+                Ok(None)
+            }
+        }
+        Err(message) => Err(fail_with_message(message, stderr)),
     }
 }
 

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -326,11 +326,6 @@ where
         Err(message) => return fail_with_message(message, stderr),
     };
 
-    let desired_protocol = match resolve_desired_protocol(protocol.as_ref(), stderr) {
-        Ok(protocol) => protocol,
-        Err(code) => return code,
-    };
-
     let timeout_setting = match resolve_timeout(timeout.as_ref(), stderr) {
         Ok(setting) => setting,
         Err(code) => return code,
@@ -380,6 +375,17 @@ where
         Ok(operands) => operands,
         Err(unsupported) => return fail_with_message(unsupported.to_message(), stderr),
     };
+
+    // `--protocol` is resolved once operands are known: upstream accepts it on a
+    // local copy (setup_protocol runs there too) but this build only speaks the
+    // wire for a remote transfer, so the value is ignored locally and validated
+    // against the wire range only when an operand is remote.
+    let has_remote_operand = remainder.iter().any(|op| operand_is_remote(op));
+    let desired_protocol =
+        match resolve_desired_protocol(protocol.as_ref(), has_remote_operand, stderr) {
+            Ok(protocol) => protocol,
+            Err(code) => return code,
+        };
 
     // upstream: options.c:2055 `if (do_stats) parse_output_words("stats2", ...)`
     // (or "stats3" with `-vv`). The legacy `--stats` flag maps to level 2; with
@@ -656,7 +662,7 @@ where
 
     // Build transfer operands early so we can check if this is a daemon transfer.
     // upstream: main.c:780-790 - source dir is chdir target, not a transfer source
-    let has_remote_operand = remainder.iter().any(|op| operand_is_remote(op));
+    // `has_remote_operand` was computed above (protocol resolution needs it).
     let mut transfer_operands = Vec::with_capacity(file_list_operands.len() + remainder.len());
     if files_from_active && !file_list_operands.is_empty() {
         if has_remote_operand {
@@ -688,7 +694,6 @@ where
     let is_daemon_transfer = transfer_operands.iter().any(|op| operand_is_remote(op));
     if !is_daemon_transfer {
         if let Some(exit_code) = validation::validate_local_only_options(
-            desired_protocol,
             password_override.is_some(),
             password_file.is_some() || password_command.is_some(),
             connect_program.as_ref(),

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -31,9 +31,10 @@ pub(crate) use flags::{
 pub(crate) use module_list::render_module_list;
 pub(crate) use operands::{extract_operands, parse_bind_address_argument};
 pub(crate) use options::{
-    parse_block_size_argument, parse_checksum_seed_argument, parse_max_alloc_argument,
-    parse_max_delete_argument, parse_modify_window_argument, parse_protocol_version_arg,
-    parse_size_limit_argument, parse_timeout_argument, resolve_iconv_setting,
+    ProtocolArg, legacy_remote_rejection, parse_block_size_argument, parse_checksum_seed_argument,
+    parse_max_alloc_argument, parse_max_delete_argument, parse_modify_window_argument,
+    parse_protocol_version_arg, parse_size_limit_argument, parse_timeout_argument,
+    resolve_iconv_setting,
 };
 pub(crate) use stop::{parse_stop_after_argument, parse_stop_at_argument};
 

--- a/crates/cli/src/frontend/execution/options/mod.rs
+++ b/crates/cli/src/frontend/execution/options/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use numeric::{
     parse_checksum_seed_argument, parse_max_delete_argument, parse_modify_window_argument,
     parse_timeout_argument,
 };
-pub(crate) use protocol::parse_protocol_version_arg;
+pub(crate) use protocol::{ProtocolArg, legacy_remote_rejection, parse_protocol_version_arg};
 pub(crate) use size::{
     parse_block_size_argument, parse_max_alloc_argument, parse_size_limit_argument,
 };

--- a/crates/cli/src/frontend/execution/options/protocol.rs
+++ b/crates/cli/src/frontend/execution/options/protocol.rs
@@ -10,12 +10,42 @@ use core::{
 use protocol::{ParseProtocolVersionErrorKind, ProtocolVersion};
 use std::str::FromStr;
 
-/// Parses the `--protocol` command-line argument into a validated `ProtocolVersion`.
+/// Lowest protocol version upstream rsync accepts on the command line.
+///
+/// upstream: rsync.h:147 `MIN_PROTOCOL_VERSION 20`. `setup_protocol`
+/// (compat.c:629) rejects anything below this with `RERR_PROTOCOL`.
+const UPSTREAM_MIN_PROTOCOL: u8 = 20;
+/// Highest protocol version upstream rsync accepts on the command line.
+///
+/// upstream: rsync.h:114 `PROTOCOL_VERSION 32`. `setup_protocol`
+/// (compat.c:634) rejects anything above this with `RERR_PROTOCOL`.
+const UPSTREAM_MAX_PROTOCOL: u8 = 32;
+
+/// Classification of a validated `--protocol` argument.
+///
+/// Upstream accepts protocol `20..=32` on the command line, but this build only
+/// speaks `28..=32` over the wire. Values in `20..=27` are valid per upstream
+/// and are meaningful only for a local copy, where no protocol is ever
+/// negotiated (the local-copy executor never touches the wire).
+#[derive(Debug)]
+pub(crate) enum ProtocolArg {
+    /// A wire-capable protocol version in `28..=32`.
+    Supported(ProtocolVersion),
+    /// An upstream-valid version in `20..=27`, below this build's wire floor.
+    LegacyLocalOnly(u8),
+}
+
+/// Parses and classifies the `--protocol` command-line argument.
+///
+/// Mirrors upstream rsync's command-line bounds (`setup_protocol`,
+/// compat.c:629-637): values outside `20..=32` are protocol errors (exit 4 in
+/// this build is reserved for unsupported actions; a bad protocol number is
+/// `RERR_PROTOCOL` = 2). Non-numeric input is a syntax error (exit 1).
 ///
 /// Returns user-friendly errors matching upstream rsync diagnostics:
-/// - Exit code 1 for syntax errors (non-numeric input)
-/// - Exit code 2 for protocol incompatibility (valid number, unsupported range)
-pub(crate) fn parse_protocol_version_arg(value: &OsStr) -> Result<ProtocolVersion, Message> {
+/// - Exit code 1 for syntax errors (non-numeric input).
+/// - Exit code 2 for a numeric value outside upstream's `20..=32` range.
+pub(crate) fn parse_protocol_version_arg(value: &OsStr) -> Result<ProtocolArg, Message> {
     let text = value.to_string_lossy();
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
     let display = if trimmed.is_empty() {
@@ -25,54 +55,89 @@ pub(crate) fn parse_protocol_version_arg(value: &OsStr) -> Result<ProtocolVersio
     };
 
     match ProtocolVersion::from_str(text.as_ref()) {
-        Ok(version) => Ok(version),
-        Err(error) => {
-            let supported = supported_protocols_list();
-            // Mirror upstream: syntax errors (non-numeric) use exit code 1,
-            // protocol incompatibility (numeric but out of range) uses exit code 2
-            let (exit_code, detail) = match error.kind() {
-                ParseProtocolVersionErrorKind::Empty => (
-                    FEATURE_UNAVAILABLE_EXIT_CODE,
-                    "protocol value must not be empty".to_owned(),
-                ),
-                ParseProtocolVersionErrorKind::InvalidDigit => (
-                    FEATURE_UNAVAILABLE_EXIT_CODE,
-                    "protocol version must be an unsigned integer".to_owned(),
-                ),
-                ParseProtocolVersionErrorKind::Negative => (
-                    FEATURE_UNAVAILABLE_EXIT_CODE,
-                    "protocol version cannot be negative".to_owned(),
-                ),
-                ParseProtocolVersionErrorKind::Overflow => (
-                    FEATURE_UNAVAILABLE_EXIT_CODE,
-                    "protocol version value exceeds 255".to_owned(),
-                ),
-                ParseProtocolVersionErrorKind::UnsupportedRange(value) => {
-                    let (oldest, newest) = ProtocolVersion::supported_range_bounds();
-                    (
-                        PROTOCOL_INCOMPATIBLE_EXIT_CODE,
-                        format!(
-                            "protocol version {value} is outside the supported range {oldest}-{newest}"
-                        ),
-                    )
+        // `from_str` only succeeds for this build's supported range (28..=32).
+        Ok(version) => Ok(ProtocolArg::Supported(version)),
+        Err(error) => match error.kind() {
+            // Non-numeric input is a usage error: exit 1 (RERR_SYNTAX).
+            ParseProtocolVersionErrorKind::Empty => Err(syntax_error(
+                display,
+                "protocol value must not be empty".to_owned(),
+            )),
+            ParseProtocolVersionErrorKind::InvalidDigit => Err(syntax_error(
+                display,
+                "protocol version must be an unsigned integer".to_owned(),
+            )),
+            ParseProtocolVersionErrorKind::Negative => Err(syntax_error(
+                display,
+                "protocol version cannot be negative".to_owned(),
+            )),
+            // A value larger than u8 is necessarily above the upstream ceiling.
+            ParseProtocolVersionErrorKind::Overflow => Err(ceiling_error(display)),
+            ParseProtocolVersionErrorKind::UnsupportedRange(raw) => {
+                if raw < UPSTREAM_MIN_PROTOCOL {
+                    Err(floor_error(display))
+                } else if raw > UPSTREAM_MAX_PROTOCOL {
+                    Err(ceiling_error(display))
+                } else {
+                    // 20..=27: valid upstream, below this build's wire floor.
+                    Ok(ProtocolArg::LegacyLocalOnly(raw))
                 }
-            };
-            use std::fmt::Write;
-
-            let mut full_detail = detail;
-            if !full_detail.is_empty() {
-                full_detail.push_str("; ");
             }
-            // write! to String is infallible
-            let _ = write!(full_detail, "supported protocols are {supported}");
-
-            Err(rsync_error!(
-                exit_code,
-                format!("invalid protocol version '{display}': {full_detail}")
-            )
-            .with_role(Role::Client))
-        }
+        },
     }
+}
+
+/// Builds a syntax (exit 1) diagnostic for a non-numeric `--protocol` value.
+fn syntax_error(display: &str, detail: String) -> Message {
+    let supported = supported_protocols_list();
+    rsync_error!(
+        FEATURE_UNAVAILABLE_EXIT_CODE,
+        format!(
+            "invalid protocol version '{display}': {detail}; supported protocols are {supported}"
+        )
+    )
+    .with_role(Role::Client)
+}
+
+/// Builds the exit-2 diagnostic for a value below upstream's minimum (20).
+///
+/// upstream: compat.c:630 "--protocol must be at least 20 on the %s."
+fn floor_error(display: &str) -> Message {
+    rsync_error!(
+        PROTOCOL_INCOMPATIBLE_EXIT_CODE,
+        format!(
+            "invalid protocol version '{display}': --protocol must be at least {UPSTREAM_MIN_PROTOCOL} on the client"
+        )
+    )
+    .with_role(Role::Client)
+}
+
+/// Builds the exit-2 diagnostic for a value above upstream's maximum (32).
+///
+/// upstream: compat.c:635 "--protocol must be no more than 32 on the %s."
+fn ceiling_error(display: &str) -> Message {
+    rsync_error!(
+        PROTOCOL_INCOMPATIBLE_EXIT_CODE,
+        format!(
+            "invalid protocol version '{display}': --protocol must be no more than {UPSTREAM_MAX_PROTOCOL} on the client"
+        )
+    )
+    .with_role(Role::Client)
+}
+
+/// Builds the exit-2 diagnostic for a legacy protocol requested over the wire.
+///
+/// upstream accepts 20..=27 and would negotiate it, but this build speaks only
+/// 28..=32 over the wire, so a remote transfer at a legacy version is refused.
+pub(crate) fn legacy_remote_rejection(raw: u8) -> Message {
+    let supported = supported_protocols_list();
+    rsync_error!(
+        PROTOCOL_INCOMPATIBLE_EXIT_CODE,
+        format!(
+            "protocol version {raw} is not supported over the wire by this build (supported protocols are {supported}); it is accepted only for a local copy"
+        )
+    )
+    .with_role(Role::Client)
 }
 
 const fn supported_protocols_list() -> &'static str {

--- a/crates/cli/src/frontend/filter_rules/directive.rs
+++ b/crates/cli/src/frontend/filter_rules/directive.rs
@@ -11,6 +11,13 @@ pub(crate) enum FilterDirective {
     Merge(MergeDirective),
     /// Clears all existing filter rules.
     Clear,
+    /// An empty rule string that contributes no rule.
+    ///
+    /// upstream: exclude.c:1107 parse_rule_tok returns NULL for an empty rule
+    /// (`if (!*s) return NULL`), so parse_filter_str adds nothing and exits 0.
+    /// A blank `--filter`/`--exclude`/`--include` value is therefore a no-op,
+    /// not a syntax error.
+    Noop,
     /// The `-C` cvs-convenience rule: expands to the global CVS default
     /// excludes (built-in list + `$HOME/.cvsignore` + `$CVSIGNORE`).
     ///

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -221,6 +221,8 @@ pub(crate) fn process_merge_directive(
             })?;
         }
         Ok(FilterDirective::Clear) => destination.clear(),
+        // A blank line inside a merge file contributes no rule.
+        Ok(FilterDirective::Noop) => {}
         // upstream: exclude.c:1441-1443 a non-merge FILTRULE_CVS_IGNORE rule
         // (`-C`) inside a merge file expands to the global CVS defaults at this
         // position in the chain.

--- a/crates/cli/src/frontend/filter_rules/parsing/entry.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/entry.rs
@@ -59,8 +59,9 @@ pub(crate) fn parse_old_prefix_rule(
     );
 
     if line.is_empty() {
-        let message = rsync_error!(1, "filter rule is empty").with_role(Role::Client);
-        return Err(message);
+        // upstream: exclude.c:1107 parse_rule_tok returns NULL for an empty
+        // rule, so a blank `--exclude`/`--include` value adds nothing (exit 0).
+        return Ok(FilterDirective::Noop);
     }
 
     let bytes = line.as_bytes();
@@ -104,12 +105,12 @@ pub(super) fn parse_rule_directive(text: &str) -> Result<FilterDirective, Messag
     let trimmed = text;
 
     if trimmed.is_empty() {
-        let message = rsync_error!(
-            1,
-            "filter rule is empty: supply '+', '-', '!', or 'merge FILE'"
-        )
-        .with_role(Role::Client);
-        return Err(message);
+        // upstream: exclude.c:1107 parse_rule_tok returns NULL for an empty rule
+        // string (`if (!*s) return NULL`), so a blank `--filter` value adds
+        // nothing and exits 0. A `--filter=" "` (whitespace) value is NOT empty
+        // here - a top-level `--filter` never carries FILTRULE_WORD_SPLIT, so the
+        // space reaches the prefix switch and still raises "Unknown filter rule".
+        return Ok(FilterDirective::Noop);
     }
 
     if let Some(remainder) = trimmed.strip_prefix('!') {

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -72,9 +72,11 @@ fn parse_exclude_keyword() {
 }
 
 #[test]
-fn parse_empty_returns_error() {
+fn parse_empty_is_noop() {
+    // upstream: exclude.c:1107 parse_rule_tok returns NULL for an empty rule
+    // string, so a blank `--filter` value adds nothing and exits 0.
     let result = parse_filter_directive(OsStr::new(""));
-    assert!(result.is_err());
+    assert!(matches!(result, Ok(FilterDirective::Noop)));
 }
 
 #[test]
@@ -656,8 +658,13 @@ fn old_prefix_minus_without_space_is_raw_pattern() {
 }
 
 #[test]
-fn old_prefix_empty_is_error() {
-    assert!(parse_old_prefix_rule("", FilterRuleKind::Exclude).is_err());
+fn old_prefix_empty_is_noop() {
+    // upstream: exclude.c:1107 - a blank `--exclude`/`--include` value adds
+    // nothing (exit 0), so an empty old-prefix rule is a no-op, not an error.
+    assert!(matches!(
+        parse_old_prefix_rule("", FilterRuleKind::Exclude),
+        Ok(FilterDirective::Noop)
+    ));
 }
 
 #[test]

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -44,6 +44,8 @@ pub(crate) fn append_filter_rules_from_files(
                 match parse_old_prefix_rule(&pattern, kind)? {
                     FilterDirective::Rule(rule) => local.push(rule),
                     FilterDirective::Clear => local.clear(),
+                    // A blank line in an exclude-from/include-from file is skipped.
+                    FilterDirective::Noop => {}
                     FilterDirective::Merge(_) | FilterDirective::CvsDefaults => {
                         unreachable!(
                             "parse_old_prefix_rule never emits FilterDirective::Merge or CvsDefaults"

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -344,13 +344,14 @@ where
             }
         }
         Err(error) => {
-            let mut message = strings::exit_code_message_with_detail(1, error.to_string())
-                .unwrap_or_else(|| rsync_error!(1, "{}", error));
+            let code = clap_parse_error_exit_code(&error);
+            let mut message = strings::exit_code_message_with_detail(code, error.to_string())
+                .unwrap_or_else(|| rsync_error!(code, "{}", error));
             message = message.with_role(Role::Client);
             if write_message(&message, &mut stderr_sink).is_err() {
                 let _ = writeln!(stderr_sink.writer_mut(), "{error}");
             }
-            1
+            code
         }
     };
 
@@ -366,6 +367,24 @@ where
             | core::signal::ShutdownReason::HangUp),
         ) => i32::from(reason.exit_code()),
         _ => exit_code,
+    }
+}
+
+/// Maps a `clap` argument-parse failure to an rsync exit code.
+///
+/// Most usage errors map to `RERR_SYNTAX` (1). An unusable `--checksum-choice`
+/// name is the exception: upstream `checksum.c:139 parse_checksum_choice()`
+/// exits with `RERR_UNSUPPORTED` (4, errcode.h:28). `--checksum-choice` is
+/// validated inside the `clap` value flow (unlike `--compress-choice`, which is
+/// validated later in the pipeline where the message code survives), so its
+/// intended exit code is reconstructed here from the diagnostic text we emit.
+fn clap_parse_error_exit_code(error: &clap::Error) -> i32 {
+    if error.kind() == clap::error::ErrorKind::ValueValidation
+        && error.to_string().contains("--checksum-choice")
+    {
+        4
+    } else {
+        1
     }
 }
 

--- a/crates/cli/src/frontend/tests/exit_code_fidelity_tests.rs
+++ b/crates/cli/src/frontend/tests/exit_code_fidelity_tests.rs
@@ -1,0 +1,106 @@
+//! Exit-code fidelity with upstream rsync 3.4.4 for argument-validation
+//! failures. Each case is verified against the real upstream binary.
+
+use super::common::*;
+use super::*;
+use tempfile::tempdir;
+
+/// upstream: compat.c:190 `unknown compress name` -> RERR_UNSUPPORTED
+/// (errcode.h:28 `RERR_UNSUPPORTED 4`), not RERR_SYNTAX.
+#[test]
+fn invalid_compress_choice_returns_unsupported() {
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--compress-choice=invalid"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ]);
+    assert_eq!(code, 4);
+}
+
+/// An empty `--compress-choice=` is likewise an unusable name (exit 4).
+#[test]
+fn empty_compress_choice_returns_unsupported() {
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--compress-choice="),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ]);
+    assert_eq!(code, 4);
+}
+
+/// upstream: checksum.c:139 `unknown checksum name` -> RERR_UNSUPPORTED (4).
+#[test]
+fn invalid_checksum_choice_returns_unsupported() {
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--checksum-choice=invalid"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ]);
+    assert_eq!(code, 4);
+}
+
+/// An empty `--checksum-choice=` is likewise an unusable name (exit 4).
+#[test]
+fn empty_checksum_choice_returns_unsupported() {
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--checksum-choice="),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ]);
+    assert_eq!(code, 4);
+}
+
+/// upstream: exclude.c:1107 parse_rule_tok returns NULL for an empty rule, so a
+/// blank `--filter` value is a no-op and the transfer succeeds (exit 0).
+#[test]
+fn empty_filter_is_accepted_as_noop() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    std::fs::write(&source, b"data").expect("write source");
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--filter="),
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(destination.exists());
+}
+
+/// A blank `--exclude=`/`--include=` value is also a no-op (exit 0).
+#[test]
+fn empty_exclude_and_include_are_accepted_as_noop() {
+    for flag in ["--exclude=", "--include="] {
+        let temp = tempdir().expect("tempdir");
+        let source = temp.path().join("source.txt");
+        let destination = temp.path().join("dest.txt");
+        std::fs::write(&source, b"data").expect("write source");
+        let (code, _stdout, _stderr) = run_with_args([
+            OsString::from(RSYNC),
+            OsString::from(flag),
+            source.into_os_string(),
+            destination.clone().into_os_string(),
+        ]);
+        assert_eq!(code, 0, "{flag} should be accepted as a no-op");
+        assert!(destination.exists(), "{flag} transfer should complete");
+    }
+}
+
+/// A whitespace-only `--filter=" "` is NOT empty: a top-level `--filter` never
+/// carries FILTRULE_WORD_SPLIT, so the space reaches the prefix switch and
+/// upstream (exclude.c:1213) raises "Unknown filter rule" (RERR_SYNTAX = 1).
+#[test]
+fn whitespace_only_filter_is_still_rejected() {
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--filter= "),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ]);
+    assert_ne!(code, 0);
+}

--- a/crates/cli/src/frontend/tests/invalid.rs
+++ b/crates/cli/src/frontend/tests/invalid.rs
@@ -2,10 +2,14 @@ use super::common::*;
 use super::*;
 
 #[test]
-fn invalid_protocol_value_reports_error() {
+fn out_of_range_protocol_value_reports_error() {
+    // upstream: compat.c:635 rejects a value above PROTOCOL_VERSION (32) with
+    // RERR_PROTOCOL (errcode.h:26 -> exit 2). Protocol 27 is NOT rejected: it is
+    // within upstream's 20..=32 command-line range and is accepted for a local
+    // copy (exit 0). Use an out-of-range value to exercise the reject path.
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        OsString::from("--protocol=27"),
+        OsString::from("--protocol=33"),
         OsString::from("source"),
         OsString::from("dest"),
     ]);
@@ -13,6 +17,6 @@ fn invalid_protocol_value_reports_error() {
     assert_eq!(code, 2); // Mirror upstream: protocol incompatibility returns exit code 2
     assert!(stdout.is_empty());
     let rendered = String::from_utf8(stderr).expect("diagnostic is UTF-8");
-    assert!(rendered.contains("invalid protocol version '27'"));
-    assert!(rendered.contains("outside the supported range"));
+    assert!(rendered.contains("invalid protocol version '33'"));
+    assert!(rendered.contains("no more than 32"));
 }

--- a/crates/cli/src/frontend/tests/mod.rs
+++ b/crates/cli/src/frontend/tests/mod.rs
@@ -68,6 +68,7 @@ mod error_recovery_integration_tests;
 mod error_recovery_tests;
 #[path = "exclude_lsh_matrix.rs"]
 mod exclude_lsh_matrix_tests;
+mod exit_code_fidelity_tests;
 #[path = "files_from.rs"]
 mod files_from_tests;
 #[path = "filter_behavior_comprehensive.rs"]

--- a/crates/cli/src/frontend/tests/protocol.rs
+++ b/crates/cli/src/frontend/tests/protocol.rs
@@ -2,31 +2,62 @@ use super::common::*;
 use super::*;
 
 #[test]
-fn protocol_option_requires_daemon_operands() {
+fn protocol_option_accepted_on_local_copy() {
+    // upstream: setup_protocol (compat.c:629-637) runs for local copies too, so
+    // `--protocol=N` (20..=32) is accepted on a local transfer (exit 0) and the
+    // copy proceeds. This build ignores the value for a local copy.
     use tempfile::tempdir;
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
     std::fs::write(&source, b"data").expect("write source");
-    let (code, stdout, stderr) = run_with_args([
+    let (code, _stdout, _stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--protocol=30"),
         source.into_os_string(),
         destination.clone().into_os_string(),
     ]);
-    assert_eq!(code, 1);
-    assert!(stdout.is_empty());
-    let rendered = String::from_utf8(stderr).expect("diagnostic is UTF-8");
-    assert!(rendered.contains("--protocol"));
-    assert!(rendered.contains("rsync daemon"));
-    assert!(!destination.exists());
+    assert_eq!(code, 0);
+    assert!(destination.exists());
 }
 
 #[test]
 fn protocol_value_with_whitespace_and_plus_is_accepted() {
-    let version = parse_protocol_version_arg(OsStr::new(" +31 \n"))
-        .expect("whitespace-wrapped value should parse");
-    assert_eq!(version.as_u8(), 31);
+    match parse_protocol_version_arg(OsStr::new(" +31 \n"))
+        .expect("whitespace-wrapped value should parse")
+    {
+        ProtocolArg::Supported(version) => assert_eq!(version.as_u8(), 31),
+        ProtocolArg::LegacyLocalOnly(raw) => panic!("31 is wire-supported, got legacy {raw}"),
+    }
+}
+
+#[test]
+fn protocol_below_upstream_floor_is_protocol_error() {
+    // upstream: compat.c:630 rejects `< MIN_PROTOCOL_VERSION` (20) with
+    // RERR_PROTOCOL (errcode.h:26). errcode.h:26 defines RERR_PROTOCOL = 2.
+    let message = parse_protocol_version_arg(OsStr::new("19"))
+        .expect_err("protocol 19 is below the upstream floor");
+    assert_eq!(message.code(), Some(2));
+    assert!(message.to_string().contains("at least 20"));
+}
+
+#[test]
+fn protocol_above_upstream_ceiling_is_protocol_error() {
+    // upstream: compat.c:635 rejects `> PROTOCOL_VERSION` (32) with RERR_PROTOCOL.
+    let message = parse_protocol_version_arg(OsStr::new("33"))
+        .expect_err("protocol 33 is above the upstream ceiling");
+    assert_eq!(message.code(), Some(2));
+    assert!(message.to_string().contains("no more than 32"));
+}
+
+#[test]
+fn protocol_legacy_value_is_local_only() {
+    // upstream accepts 20..=27; this build classifies them as local-only
+    // (below the 28..=32 wire floor).
+    match parse_protocol_version_arg(OsStr::new("26")).expect("protocol 26 is valid upstream") {
+        ProtocolArg::LegacyLocalOnly(raw) => assert_eq!(raw, 26),
+        ProtocolArg::Supported(v) => panic!("26 is below the wire floor, got supported {v}"),
+    }
 }
 
 #[test]

--- a/crates/core/src/client/config/enums/checksum.rs
+++ b/crates/core/src/client/config/enums/checksum.rs
@@ -110,8 +110,10 @@ impl StrongChecksumChoice {
     pub fn parse(text: &str) -> Result<Self, Message> {
         let trimmed = text.trim();
         if trimmed.is_empty() {
+            // upstream: checksum.c:139 parse_checksum_choice returns
+            // RERR_UNSUPPORTED (errcode.h:28) for an unusable name, not RERR_SYNTAX.
             return Err(rsync_error!(
-                1,
+                4,
                 "invalid --checksum-choice value '': value must name a checksum algorithm"
             )
             .with_role(Role::Client));
@@ -143,8 +145,10 @@ impl StrongChecksumChoice {
             "xxh64" | "xxhash" => Ok(StrongChecksumAlgorithm::Xxh64),
             "xxh3" | "xxh3-64" => Ok(StrongChecksumAlgorithm::Xxh3),
             "xxh128" | "xxh3-128" => Ok(StrongChecksumAlgorithm::Xxh128),
+            // upstream: checksum.c:139 parse_checksum_choice returns
+            // RERR_UNSUPPORTED (errcode.h:28) for an unknown name, not RERR_SYNTAX.
             _ => Err(rsync_error!(
-                1,
+                4,
                 format!("invalid --checksum-choice value '{normalized}': unsupported checksum")
             )
             .with_role(Role::Client)),


### PR DESCRIPTION
## Summary

Aligns four argument-validation exit codes with upstream rsync 3.4.4, each verified against the real upstream binary (`rsync 3.4.4`, protocol 32) before and after the fix.

| Case | upstream 3.4.4 | oc before | oc after | source |
|------|:---:|:---:|:---:|--------|
| `--compress-choice=invalid` (and empty) | 4 | 1 | 4 | compat.c:190 -> `RERR_UNSUPPORTED` (errcode.h:28) |
| `--checksum-choice=invalid` (and empty) | 4 | 1 | 4 | checksum.c:139 -> `RERR_UNSUPPORTED` |
| `--protocol=26 src/ dst/` (local) | 0 | 2 | 0 | setup_protocol runs for local copies (compat.c) |
| `--filter=''` (empty) | 0 | 1 | 0 | parse_rule_tok returns NULL for empty (exclude.c:1107) |

All four candidates were genuine divergences. Sealed on aarch64 Linux against the upstream 3.4.4 binary (13/13 exit codes match):

```
--compress-choice=invalid     up=4 oc=4 OK
--compress-choice= (empty)     up=4 oc=4 OK
--checksum-choice=invalid      up=4 oc=4 OK
--checksum-choice= (empty)     up=4 oc=4 OK
--protocol=26 (local)          up=0 oc=0 OK
--protocol=20 (local)          up=0 oc=0 OK
--protocol=32 (local)          up=0 oc=0 OK
--protocol=19 (floor)          up=2 oc=2 OK
--protocol=33 (ceiling)        up=2 oc=2 OK
--filter= (empty)              up=0 oc=0 OK
--exclude= (empty)             up=0 oc=0 OK
--include= (empty)             up=0 oc=0 OK
--filter=' ' (whitespace)      up=1 oc=1 OK
```

## Details

**`--compress-choice` / `--checksum-choice`** — an unknown or empty algorithm name is a "requested action not supported" condition (`RERR_UNSUPPORTED` = 4), not a syntax error. `--compress-choice` is validated in the transfer pipeline (its message code now flows through), while `--checksum-choice` is validated inside the clap value flow (which discards the message code), so its exit code is reconstructed in the top-level clap-error handler.

**`--protocol` on a local copy** — upstream's `setup_protocol` runs for local copies too, so upstream accepts any command-line value in `20..=32` (all exit 0; local output is identical regardless) and rejects `<20`/`>32` with `RERR_PROTOCOL` (2). This build previously (a) rejected `20..=27` as out-of-range (exit 2) and (b) rejected `28..=32` on local transfers with an invented "`--protocol` only for daemons" message (exit 1). Both are removed. `--protocol` is now resolved once operands are known: it is ignored for a local copy (the local-copy executor never touches the wire) and only carried for a remote transfer, where it must fall in this build's wire range `28..=32`. A legacy value (`20..=27`) over the wire is still refused, since this build does not speak protocols below 28. No wire behavior changes for remote transfers.

**Empty `--filter` / `--exclude` / `--include`** — upstream `parse_rule_tok` returns NULL for an empty rule string, so a blank value contributes no rule (exit 0). A whitespace-only `--filter=' '` stays an error, matching upstream (a top-level `--filter` never carries `FILTRULE_WORD_SPLIT`, so the space reaches the prefix switch -> "Unknown filter rule").

## Tests

New regression tests cite the upstream sources and `errcode.h` values, covering all four exit codes plus the whitespace-filter boundary. `cargo clippy -p cli -p core --all-targets --all-features -- -D warnings` is clean; `cargo check --target x86_64-pc-windows-gnu` passes for the touched crates.
