### PR TITLE
fix(transfer): scope receiver root delete to content-dir and register client dir-merge for deletion

### DIFF
--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -642,10 +642,21 @@ impl FilterChain {
         self.current_depth = self.current_depth.saturating_sub(1);
     }
 
-    /// Returns `true` if the chain has no rules at all (global or per-directory).
+    /// Returns `true` if the chain has no rules at all (global, per-directory
+    /// scopes, or per-directory merge configs).
+    ///
+    /// A chain that carries only a dir-merge directive (e.g. a client's `-F`
+    /// `.rsync-filter` transmitted to a server-side receiver) has an empty
+    /// `global` rule set and no active `scopes` until a directory is entered,
+    /// but it is emphatically not empty: the merge config governs which
+    /// destination entries the `--delete` pass may remove. Omitting
+    /// `merge_configs` here made such a chain read as empty, so the receiver's
+    /// deletion path fell back to the wrong chain and deleted dir-merge-protected
+    /// entries. Account for `merge_configs` so a merge-only chain is recognised
+    /// as populated.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.global.is_empty() && self.scopes.is_empty()
+        self.global.is_empty() && self.scopes.is_empty() && self.merge_configs.is_empty()
     }
 
     /// Number of active per-directory filter scopes on the stack.

--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -288,6 +288,26 @@ fn filter_chain_nested_directories_with_merge_files() {
 }
 
 #[test]
+fn is_empty_accounts_for_merge_configs() {
+    // A chain carrying only a dir-merge directive (the shape a client's `-F`
+    // `.rsync-filter` takes when it reaches a server-side receiver: an empty
+    // global rule set and no active scopes until a directory is entered) is not
+    // empty - the merge config governs which entries the --delete pass may
+    // remove. The receiver's deletion path selects the deletion chain via
+    // `is_empty()`; if a merge-only chain reads as empty it falls back to the
+    // wrong chain and deletes dir-merge-protected entries. Encode that
+    // merge_configs make the chain non-empty.
+    let mut chain = FilterChain::empty();
+    assert!(chain.is_empty(), "a chain with no rules at all is empty");
+    chain.add_merge_config(DirMergeConfig::new(".rsync-filter"));
+    assert!(
+        !chain.is_empty(),
+        "a merge-only chain must not read as empty: its dir-merge protect \
+         rules decide deletion candidates",
+    );
+}
+
+#[test]
 fn filter_chain_multiple_merge_configs() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join(".rsync-filter"), "- *.log\n").unwrap();

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -203,9 +203,23 @@ impl ReceiverContext {
         // match NFC names from the sender's file list.
         let mut dir_children: HashMap<PathBuf, HashSet<std::ffi::OsString>> = HashMap::new();
 
+        // upstream: generator.c:do_delete_pass() (and the delete-during loop at
+        // generator.c:2317) call delete_in_dir() for a flist directory ONLY when
+        // it carries FLAG_CONTENT_DIR - a directory the sender actually recursed
+        // into. The transfer root "." is a content dir for a recursive transfer
+        // but not for --files-from, where the root is sent as an implied dir
+        // (XMIT_NO_CONTENT_DIR, so the received entry's content_dir() is false).
+        // Register "." as a scan target only when the received root is a content
+        // dir; scanning it unconditionally deletes top-level destination entries
+        // that upstream preserves under --files-from.
+        let mut root_is_content_dir = false;
+
         for entry in &self.file_list {
             let relative = entry.path();
             if relative.as_os_str() == "." {
+                if entry.is_dir() && entry.content_dir() {
+                    root_is_content_dir = true;
+                }
                 continue;
             }
             let parent = relative.parent().map_or_else(
@@ -244,13 +258,17 @@ impl ReceiverContext {
             }
         }
 
-        // upstream: generator.c:delete_in_dir() always runs for the transfer
-        // root. When every source entry is filter-excluded (e.g. `--exclude='*'
-        // --delete-excluded`) the file list contains only "." and the loop
-        // above registers no directories, so the root would never be scanned
-        // and top-level extraneous entries would survive. Register "." with a
-        // (possibly empty) keep-set so the root is always a scan target.
-        dir_children.entry(PathBuf::from(".")).or_default();
+        // upstream: generator.c:do_delete_pass() runs delete_in_dir(".") only
+        // when the received root carries FLAG_CONTENT_DIR. For a recursive
+        // transfer the root is a content dir even when every source entry is
+        // filter-excluded (e.g. `--exclude='*' --delete-excluded`, whose file
+        // list contains only "."), so top-level extraneous entries are still
+        // removed. For --files-from the root is an implied (non-content) dir, so
+        // its stale top-level destination entries are preserved. Register "."
+        // with a (possibly empty) keep-set only in the content-dir case.
+        if root_is_content_dir {
+            dir_children.entry(PathBuf::from(".")).or_default();
+        }
 
         // Sort the scan set so directory processing is deterministic across
         // process runs. `HashMap::keys()` yields hash-randomized order, which

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -442,6 +442,25 @@ impl ReceiverContext {
                 chain.add_merge_config(config);
             }
             self.filter_chain = chain;
+
+            // upstream: exclude.c:recv_filter_list() parses every received rule
+            // into the same `filter_list` the generator's delete_in_dir()
+            // consults via change_local_filter_dir()/push_local_filters(). A
+            // server-side receiver must therefore register the client's
+            // transmitted dir-merge directive (a `-F` `.rsync-filter`, sent as a
+            // per-directory merge rule by exclude.c:send_rules()) on the
+            // dedicated deletion chain, not only on `filter_chain`. Without it a
+            // merge file's own protect rule is absent when the --delete pass
+            // decides candidates, so up-client -> oc-receiver + dir-merge deletes
+            // entries upstream -> upstream preserves. Mirror the local-pull
+            // build_client_deletion_filter_chain(): same combined rules, with
+            // --delete-excluded applied. Cloned from `filter_chain` so the global
+            // rules and merge configs stay identical; the delete-pass consults
+            // this chain (deletion.rs) whenever it is non-empty.
+            self.deletion_filter_chain = self
+                .filter_chain
+                .clone()
+                .with_delete_excluded(self.config.deletion.delete_excluded);
         }
         Ok(())
     }

--- a/crates/transfer/src/receiver/transfer/setup/wire_filters.rs
+++ b/crates/transfer/src/receiver/transfer/setup/wire_filters.rs
@@ -42,7 +42,27 @@ pub(super) fn parse_wire_filters_for_receiver(
                 continue;
             }
             RuleType::DirMerge => {
-                let mut config = DirMergeConfig::new(&wire_rule.pattern);
+                // upstream: exclude.c:setup_merge_file() derives the
+                // per-directory merge FILENAME from the basename after the last
+                // '/' in the rule pattern (`ex->pattern = strdup(y+1)` where
+                // `y = strrchr(x, '/')`). A client's `-F` reaches the receiver as
+                // `: /.rsync-filter` (exclude.c:1608), so the wire pattern is
+                // `/.rsync-filter`. Using it verbatim as the merge filename makes
+                // `directory.join("/.rsync-filter")` resolve to the filesystem
+                // root (Rust's `Path::join` discards the base on an absolute
+                // component), so the per-directory merge file is never found and
+                // its protect rules are absent when the --delete pass decides
+                // candidates - deleting dir-merge-protected destination entries.
+                // Split off the basename to mirror setup_merge_file(); oc's own
+                // encoder emits the anchor as a `/` modifier with a bare pattern,
+                // so this is a no-op for the oc<->oc wire and only normalises the
+                // `/`-in-body form a real upstream client sends.
+                let filename = wire_rule
+                    .pattern
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or(wire_rule.pattern.as_str());
+                let mut config = DirMergeConfig::new(filename);
                 if wire_rule.no_inherit {
                     config = config.with_inherit(false);
                 }
@@ -87,4 +107,59 @@ pub(super) fn parse_wire_filters_for_receiver(
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("filter error: {e}")))?;
 
     Ok((filter_set, merge_configs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A real upstream client transmits `-F` as the rule `: /.rsync-filter`
+    /// (exclude.c:1608), so the receiver decodes a `DirMerge` wire rule whose
+    /// pattern is `/.rsync-filter`. Upstream's `setup_merge_file()` splits at the
+    /// last '/' to recover the per-directory filename `.rsync-filter`; keeping the
+    /// leading slash makes `directory.join("/.rsync-filter")` escape to the
+    /// filesystem root, so the merge file is never found and its protect rules
+    /// are absent when the --delete pass runs - deleting entries the client's
+    /// dir-merge protects. Encode that the decoded config filename is the
+    /// basename, matching upstream.
+    #[test]
+    fn dir_merge_wire_pattern_yields_basename_filename() {
+        let wire = vec![FilterRuleWireFormat {
+            rule_type: RuleType::DirMerge,
+            pattern: "/.rsync-filter".to_string(),
+            ..FilterRuleWireFormat::default()
+        }];
+
+        let (_set, merge_configs) =
+            parse_wire_filters_for_receiver(&wire).expect("dir-merge rule parses");
+
+        assert_eq!(merge_configs.len(), 1, "one dir-merge config expected");
+        assert_eq!(
+            merge_configs[0].filename(),
+            ".rsync-filter",
+            "the leading slash from the wire pattern must be stripped so the \
+             per-directory merge file is looked up as `dir/.rsync-filter`, not \
+             at the filesystem root",
+        );
+    }
+
+    /// oc's own encoder emits the anchor as a `/` modifier with a bare pattern,
+    /// so an oc<->oc dir-merge arrives with pattern `.rsync-filter` (no slash).
+    /// The basename split must leave that untouched so the oc<->oc wire path is
+    /// unchanged.
+    #[test]
+    fn dir_merge_bare_pattern_is_unchanged() {
+        let wire = vec![FilterRuleWireFormat {
+            rule_type: RuleType::DirMerge,
+            pattern: ".rsync-filter".to_string(),
+            anchored: true,
+            ..FilterRuleWireFormat::default()
+        }];
+
+        let (_set, merge_configs) =
+            parse_wire_filters_for_receiver(&wire).expect("dir-merge rule parses");
+
+        assert_eq!(merge_configs.len(), 1);
+        assert_eq!(merge_configs[0].filename(), ".rsync-filter");
+    }
 }

--- a/crates/transfer/tests/delete_files_from_root_scope.rs
+++ b/crates/transfer/tests/delete_files_from_root_scope.rs
@@ -1,0 +1,129 @@
+//! Regression: `--delete --files-from` must not delete-scan the transfer root.
+//!
+//! Upstream `generator.c:do_delete_pass()` calls `delete_in_dir()` for a flist
+//! directory only when it carries `FLAG_CONTENT_DIR` - a directory the sender
+//! actually recursed into. Under `--files-from` the transfer root is an implied
+//! (non-content) directory, so upstream never scans the destination root for
+//! extraneous entries. Our receiver used to register the root `.` as a
+//! delete-scan target unconditionally, deleting a stale top-level destination
+//! file that upstream preserves. This exercises the end-to-end oc-rsync binary
+//! to pin the content-dir gate.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:358-390 do_delete_pass()` - `if (!(file->flags &
+//!   FLAG_CONTENT_DIR)) continue;` before `delete_in_dir()`.
+//! - `flist.c:2239` - `int flags = recurse ? FLAG_CONTENT_DIR : 0;` (the root is
+//!   a content dir only for a recursive transfer).
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+/// Locates the workspace `oc-rsync` binary the test runner built.
+fn locate_oc_rsync() -> Option<PathBuf> {
+    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    let exe = env::current_exe().ok()?;
+    let mut dir = exe.parent()?;
+    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
+    while !dir.ends_with("target") {
+        let candidate = dir.join(&name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    for sub in ["debug", "release"] {
+        let candidate = dir.join(sub).join(&name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// `--delete --files-from`: a stale destination-root file that is absent from
+/// the file list must survive, because the `--files-from` root is not a content
+/// directory and upstream never delete-scans it.
+#[test]
+fn files_from_delete_preserves_stale_dest_root_file() {
+    let Some(oc) = locate_oc_rsync() else {
+        eprintln!("oc-rsync binary not found; skipping");
+        return;
+    };
+
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let src = root.join("src");
+    let dst = root.join("dst");
+    fs::create_dir_all(src.join("subdir")).unwrap();
+    fs::create_dir_all(dst.join("subdir")).unwrap();
+    fs::write(src.join("subdir/keep.txt"), b"keep").unwrap();
+    fs::write(root.join("list.txt"), b"subdir/keep.txt\n").unwrap();
+    // Extraneous file at the destination ROOT, absent from the file list.
+    fs::write(dst.join("root_stale.txt"), b"stale").unwrap();
+
+    let status = Command::new(&oc)
+        .arg("-a")
+        .arg("--delete")
+        .arg(format!("--files-from={}", root.join("list.txt").display()))
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dst.display()))
+        .status()
+        .expect("run oc-rsync");
+    assert!(status.success(), "transfer should succeed");
+
+    assert!(
+        dst.join("root_stale.txt").is_file(),
+        "the --files-from root is a non-content dir; upstream never \
+         delete-scans it, so the stale destination-root file must survive",
+    );
+    assert!(
+        dst.join("subdir/keep.txt").is_file(),
+        "the listed file must be present",
+    );
+}
+
+/// Control: a plain recursive `--delete` (no `--files-from`) still deletes a
+/// stale destination-root file, because the recursive transfer root IS a
+/// content directory. Guards against the content-dir gate over-suppressing the
+/// normal delete pass.
+#[test]
+fn recursive_delete_still_removes_stale_dest_root_file() {
+    let Some(oc) = locate_oc_rsync() else {
+        eprintln!("oc-rsync binary not found; skipping");
+        return;
+    };
+
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let src = root.join("src");
+    let dst = root.join("dst");
+    fs::create_dir_all(src.join("subdir")).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("subdir/keep.txt"), b"keep").unwrap();
+    fs::write(dst.join("root_stale.txt"), b"stale").unwrap();
+
+    let status = Command::new(&oc)
+        .arg("-a")
+        .arg("--delete")
+        .arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dst.display()))
+        .status()
+        .expect("run oc-rsync");
+    assert!(status.success(), "transfer should succeed");
+
+    assert!(
+        !dst.join("root_stale.txt").exists(),
+        "a recursive --delete root is a content dir; the stale file must be \
+         removed (no over-suppression from the content-dir gate)",
+    );
+}


### PR DESCRIPTION
Two receiver-side `--delete` data-loss fixes, both in the delete path (they share the deletion scan/filter machinery, so they land together).

## Bug 1 - native pull deletes a stale destination-root file under `--files-from`

`delete_extraneous_files` registered the transfer root `.` as a delete-scan target unconditionally. Upstream `generator.c:do_delete_pass()` calls `delete_in_dir()` for a flist directory only when it carries `FLAG_CONTENT_DIR` (a directory the sender actually recursed into), and `flist.c:2239` sets `flags = recurse ? FLAG_CONTENT_DIR : 0`, so the `--files-from` root is an implied (non-content) directory that upstream never delete-scans. Scanning it unconditionally removed top-level destination entries upstream preserves.

Fix: gate the `.` scan-target registration on the received root's `content_dir()` flag, mirroring the `FLAG_CONTENT_DIR` gate. A recursive `--delete` root is still a content dir (including `--exclude='*' --delete-excluded`), so normal deletion is unaffected.

## Bug 2 - real upstream client pushing a dir-merge to an oc receiver deletes protected entries

An upstream client sending `-F` transmits the dir-merge directive as the rule `: /.rsync-filter` (`exclude.c:1608`, `send_rules`). Two gaps caused the receiver to ignore it:

1. The server-side receiver parsed the wire filter list into `filter_chain` only; `deletion_filter_chain` stayed empty, so the delete pass consulted the wrong chain. Now `deletion_filter_chain` is built from the same combined wire rules, mirroring the local-pull `build_client_deletion_filter_chain`.
2. The received merge pattern `/.rsync-filter` was used verbatim as the per-directory merge filename, and `directory.join("/.rsync-filter")` resolves to the filesystem root (Rust `Path::join` drops the base on an absolute component), so the merge file was never found at delete time. Upstream `setup_merge_file()` splits the pattern at the last `/` to recover the basename `.rsync-filter`; the decoder now does the same. oc's own encoder emits the anchor as a `/` modifier with a bare pattern, so this is a no-op for the oc-to-oc wire.

Also `FilterChain::is_empty()` ignored `merge_configs`, so a merge-only chain read as empty and the deletion path fell back to the wrong chain; it now accounts for `merge_configs`.

## Empirical seal (aarch64 Linux, vs upstream rsync 3.4.4)

`diff -r dst_oc dst_upstream` empty in every comparison.

| Scenario | Expected | Result |
|---|---|---|
| Bug1: oc->oc `-a --delete --files-from` stale dest-root file | preserved (== upstream) | PASS |
| Bug1 control: oc->oc plain recursive `-a --delete` stale root | deleted (== upstream) | PASS |
| Bug2: upstream-client -> oc-server `-aF --delete-after`, `- *.bak` | `.bak` preserved, stale deleted (== upstream) | PASS |
| oc->oc flat `--exclude='*.bak' --delete-after` | `.bak` protected, stale deleted | PASS |
| oc->oc `-aF --delete-after` (local) | `.bak` protected, stale deleted | PASS |
| oc->oc `-aF --delete-after` over ssh (server wire path) | `.bak` protected, stale deleted | PASS |

## Tests

- `filters`: `is_empty_accounts_for_merge_configs` - a merge-only chain is not empty.
- `transfer` (`wire_filters`): `dir_merge_wire_pattern_yields_basename_filename`, `dir_merge_bare_pattern_is_unchanged`.
- `transfer` (integration): `delete_files_from_root_scope` - files-from root preserved, recursive root still deleted.

`cargo fmt --check`, `clippy -D warnings` (filters, transfer), and `cargo check --target x86_64-pc-windows-gnu` (filters, transfer) all clean.