### PR TITLE
fix(cli): recognize 7 more server_options() long flags over SSH

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -274,6 +274,29 @@ pub(super) struct ServerLongFlags {
     /// popt table clears `relative_paths` (options.c:693 `{"no-relative", ...,
     /// &relative_paths, 0}`).
     pub(super) no_relative: bool,
+
+    /// Whether the client forwarded `--open-noatime` (upstream `open_noatime`).
+    ///
+    /// upstream: options.c:2993-2994 - `if (open_noatime && preserve_atimes <= 1)
+    /// args[ac++] = "--open-noatime"`. Forwarded to the sender so it opens each
+    /// source file with `O_NOATIME`, avoiding an atime update on read.
+    pub(super) open_noatime: bool,
+
+    /// Whether the client forwarded `--delete-missing-args` (upstream
+    /// `missing_args == 2`).
+    ///
+    /// upstream: options.c:2868-2869 - `if (missing_args == 2) args[ac++] =
+    /// "--delete-missing-args"`. Needs both sides: a vanished top-level source
+    /// arg becomes a mode-0 sentinel the receiver deletes at the destination.
+    pub(super) delete_missing_args: bool,
+
+    /// Whether the client forwarded `--ignore-missing-args` (upstream
+    /// `missing_args == 1`).
+    ///
+    /// upstream: options.c:2870-2871 - `else if (missing_args == 1 && !am_sender)
+    /// args[ac++] = "--ignore-missing-args"`. A vanished top-level source arg is
+    /// silently dropped from the file list rather than raising an error.
+    pub(super) ignore_missing_args: bool,
 }
 
 /// Parses all long-form flags from the server argument list.
@@ -334,6 +357,9 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         no_recurse: false,
         no_whole_file: false,
         no_relative: false,
+        open_noatime: false,
+        delete_missing_args: false,
+        ignore_missing_args: false,
     };
 
     let mut idx = 0;
@@ -359,6 +385,52 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             "--specials" => flags.specials = Some(true),
             "--no-specials" => flags.specials = Some(false),
             "--qsort" => flags.qsort = true,
+            // upstream: options.c:2908-2909 - `if (use_qsort) args[ac++] =
+            // "--use-qsort"`. This is the spelling server_options() actually
+            // emits; it selects the C-library qsort over the stable merge sort
+            // (flist.c:2991). Map it onto the same `qsort` sink as oc's own
+            // `--qsort` so both forms drive identical flist-ordering behavior.
+            "--use-qsort" => flags.qsort = true,
+            // upstream: options.c:2993-2994 - `--open-noatime` forwarded to the
+            // sender so it opens source files with O_NOATIME (do_open).
+            "--open-noatime" => flags.open_noatime = true,
+            // upstream: options.c:2868-2869 - `--delete-missing-args`
+            // (missing_args == 2): a vanished top-level source arg becomes a
+            // mode-0 sentinel the receiver deletes at the destination.
+            "--delete-missing-args" => flags.delete_missing_args = true,
+            // upstream: options.c:2870-2871 - `--ignore-missing-args`
+            // (missing_args == 1): a vanished top-level source arg is silently
+            // dropped from the file list rather than raising an error.
+            "--ignore-missing-args" => flags.ignore_missing_args = true,
+            // upstream: options.c:2848-2849 - `if (force_delete) args[ac++] =
+            // "--force"`, emitted in the am_sender block so it reaches a server
+            // acting as the receiver. force_delete only changes behavior when a
+            // non-empty directory must be replaced by a non-directory while
+            // deletions are inactive (delete.c). Under an active --delete pass -
+            // the trigger server_options() ships it alongside - oc already
+            // removes extraneous non-empty directories recursively
+            // (receiver/directory/deletion.rs), matching upstream 2.6.7+
+            // (`--delete` no longer needs `--force`). Recognized here so the arg
+            // does not leak into the positional path list.
+            "--force" => {}
+            // upstream: options.c:2852-2853 - `if (am_root > 1) args[ac++] =
+            // "--super"`, forcing super-user metadata semantics (chown/mknod)
+            // even when the receiver is not literally uid 0. oc gates those
+            // operations on the runtime `metadata::am_root()` check; when the
+            // server runs as root (the condition under which --super has any
+            // effect) that check already reports true, so recognizing the flag
+            // matches upstream. A non-root receiver would only differ by
+            // attempting privileged ops that fail with EPERM, which oc omits.
+            "--super" => {}
+            // upstream: options.c:2990-2991 - `if (preallocate_files && am_sender)
+            // args[ac++] = "--preallocate"`, forwarded to a server receiver so
+            // it fallocate()s each destination file before writing. Preallocation
+            // affects only on-disk block allocation, never file content, so a
+            // receiver that skips it produces byte-identical results. oc
+            // implements preallocation in the local-copy executor only, not the
+            // network receiver, so this is recognized to prevent a positional
+            // leak; the transferred bytes match upstream.
+            "--preallocate" => {}
             // upstream: options.c:696 / 2976-2977 - `--no-implied-dirs` is
             // forwarded to the sender on a pull. The server-side sender must omit
             // implied parent dirs from the flist at protocol < 30.
@@ -648,6 +720,21 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--msgs2stderr"
             | "--no-msgs2stderr"
             | "--qsort"
+            // upstream: options.c:2908-2909 - the spelling server_options()
+            // actually emits for use_qsort (oc's own forwarder uses --qsort).
+            | "--use-qsort"
+            // upstream: options.c:2993-2994 - `--open-noatime` (sender O_NOATIME).
+            | "--open-noatime"
+            // upstream: options.c:2848-2849 - `--force` (force_delete), am_sender
+            // block so it reaches a server receiver.
+            | "--force"
+            // upstream: options.c:2852-2853 - `--super` (am_root > 1).
+            | "--super"
+            // upstream: options.c:2990-2991 - `--preallocate` (preallocate_files).
+            | "--preallocate"
+            // upstream: options.c:2868-2871 - missing-args cooperation flags.
+            | "--delete-missing-args"
+            | "--ignore-missing-args"
             | "--no-implied-dirs"
             // upstream: options.c:2753/2959/2973 - server_options() emits these
             // negations; the server-side popt table clears recurse/whole_file/

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -193,6 +193,15 @@ where
     config.flags.append = long_flags.append;
     config.flags.append_verify = long_flags.append_verify;
     config.file_selection.size_only = long_flags.size_only;
+    // upstream: options.c:2993-2994 - `--open-noatime` forwarded to the sender so
+    // it opens source files with O_NOATIME (do_open), leaving atime untouched.
+    config.write.open_noatime = long_flags.open_noatime;
+    // upstream: options.c:2868-2871 - `--delete-missing-args` (missing_args == 2)
+    // and `--ignore-missing-args` (missing_args == 1) govern how a vanished
+    // top-level source arg is handled when building the file list. Mirrors the
+    // daemon long-form parser (long_form_args.rs).
+    config.file_selection.delete_missing_args = long_flags.delete_missing_args;
+    config.file_selection.ignore_missing_args = long_flags.ignore_missing_args;
     // upstream: options.c:2893 - bare --partial (no compact 'P' letter) tells the
     // receiver to keep interrupted temp files. OR with the compact value so a
     // legacy client that still packs 'P' is not clobbered.

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -1734,3 +1734,95 @@ fn long_flags_captures_split_files_from_value() {
     let flags = parse_server_long_flags(&args);
     assert_eq!(flags.files_from.as_deref(), Some("/tmp/list"));
 }
+
+// -- Task #291: server_options() long-form flags that previously leaked into
+// -- the positional-path list, breaking the transfer. Each flag below is one
+// -- that upstream `server_options()` (options.c) emits but oc did not
+// -- recognise in `is_known_server_long_flag`.
+
+/// upstream: options.c:2908-2909 - `if (use_qsort) args[ac++] = "--use-qsort"`.
+/// This is the exact spelling server_options() emits (oc's own forwarder uses
+/// `--qsort`). It must be recognised so it does not leak, and it maps onto the
+/// same `qsort` sink so flist ordering matches upstream (flist.c:2991).
+#[test]
+fn long_flags_use_qsort_maps_to_qsort() {
+    let args = vec![OsString::from("--server"), OsString::from("--use-qsort")];
+    let flags = parse_server_long_flags(&args);
+    assert!(flags.qsort, "--use-qsort must drive the qsort sink");
+    assert!(is_known_server_long_flag("--use-qsort"));
+}
+
+/// upstream: options.c:2993-2994 - `if (open_noatime && preserve_atimes <= 1)
+/// args[ac++] = "--open-noatime"`, forwarded to the sender.
+#[test]
+fn long_flags_open_noatime() {
+    let args = vec![OsString::from("--server"), OsString::from("--open-noatime")];
+    let flags = parse_server_long_flags(&args);
+    assert!(flags.open_noatime);
+    assert!(is_known_server_long_flag("--open-noatime"));
+}
+
+/// upstream: options.c:2868-2871 - `--delete-missing-args` (missing_args == 2)
+/// and `--ignore-missing-args` (missing_args == 1). Mirrors the daemon
+/// long-form parser (long_form_args.rs).
+#[test]
+fn long_flags_missing_args_variants() {
+    let del = parse_server_long_flags(&[
+        OsString::from("--server"),
+        OsString::from("--delete-missing-args"),
+    ]);
+    assert!(del.delete_missing_args);
+    assert!(!del.ignore_missing_args);
+
+    let ign = parse_server_long_flags(&[
+        OsString::from("--server"),
+        OsString::from("--ignore-missing-args"),
+    ]);
+    assert!(ign.ignore_missing_args);
+    assert!(!ign.delete_missing_args);
+
+    assert!(is_known_server_long_flag("--delete-missing-args"));
+    assert!(is_known_server_long_flag("--ignore-missing-args"));
+}
+
+/// upstream: options.c:2848-2853 / 2990-2991 - `--force` (force_delete),
+/// `--super` (am_root > 1), and `--preallocate` (preallocate_files) are emitted
+/// in the am_sender block and reach a server acting as the receiver. oc has no
+/// content-affecting server sink for these (recursive delete already happens,
+/// root is already privileged, preallocation is content-invisible), but they
+/// MUST be recognised so they never surface as a positional destination path.
+#[test]
+fn force_super_preallocate_recognised_as_known_long_flags() {
+    assert!(is_known_server_long_flag("--force"));
+    assert!(is_known_server_long_flag("--super"));
+    assert!(is_known_server_long_flag("--preallocate"));
+}
+
+/// Regression for the positional leak: with the compact flag string present,
+/// none of the seven newly recognised long flags may fall through into
+/// `positional_args`; only the real destination path (`dst/`) survives. Without
+/// recognition the receiver tried to `mkdir` a root literally named after the
+/// first unrecognised flag and exited 12.
+#[test]
+fn parse_server_args_skips_task291_long_flags() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpre.iLsfxCIvu"),
+        OsString::from("--force"),
+        OsString::from("--super"),
+        OsString::from("--preallocate"),
+        OsString::from("--open-noatime"),
+        OsString::from("--use-qsort"),
+        OsString::from("--delete-missing-args"),
+        OsString::from("--ignore-missing-args"),
+        OsString::from("."),
+        OsString::from("dst/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpre.iLsfxCIvu");
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("dst/")],
+        "task #291 long flags must not leak into positional args: {pos_args:?}",
+    );
+}


### PR DESCRIPTION
## Problem

Upstream `server_options()` (`options.c`) emits a number of long flags after
the compact flag string. The SSH server-mode parser
(`is_known_server_long_flag`) did not recognize several of them, so they fell
through into the positional-path list. The receiver then tried to `mkdir` a
destination root literally named after the flag (e.g. `--force`) and exited 12
("failed to create destination root ..."), breaking any transfer that used one
of these options.

## Fix

Recognize the flags so they no longer leak, and apply each to the server
config where oc models the behavior, mirroring the daemon long-form parser
(`long_form_args.rs`).

Recognized and applied:

| Flag | upstream | applied to |
|------|----------|-----------|
| `--open-noatime` | options.c:2993 | `write.open_noatime` |
| `--use-qsort` | options.c:2908 | `qsort` (upstream's emitted spelling; oc's own forwarder uses `--qsort`) |
| `--delete-missing-args` | options.c:2868 | `file_selection.delete_missing_args` |
| `--ignore-missing-args` | options.c:2870 | `file_selection.ignore_missing_args` |

Recognized to prevent the positional leak (no content-affecting server sink;
each is emitted in the `am_sender` block and reaches a server acting as the
receiver, where oc's default result already matches upstream in the forwarded
direction):

| Flag | upstream | why recognize-only is content-correct |
|------|----------|--------------------------------------|
| `--force` | options.c:2848 | an active `--delete` pass already removes extraneous non-empty dirs recursively (upstream 2.6.7+ no longer needs `--force` for that) |
| `--super` | options.c:2852 | `am_root > 1`; a root receiver is already privileged and the runtime `am_root()` check already reports true |
| `--preallocate` | options.c:2990 | allocation-only, never changes file content |

## Not included: `--only-write-batch=X`

On the server this maps to `write_batch = -1` -> `dry_run = 1` (`main.c:1839`),
but the peer still streams file data to record the batch
(`generator.c:1932` keeps the transfer alive under `write_batch < 0`). oc's
dry-run receiver does not consume that wire data, so forcing `dry_run` hangs
the transfer (verified: the oc server times out while plain `-n` push
completes). Correctly supporting it needs a batch "consume-but-don't-write"
mode oc lacks; tracked as a follow-up rather than shipping a wire hang.

## Verification

Sealed on Linux (aarch64) with a real upstream rsync 3.4.4 client driving the
oc SSH server (`--rsync-path=oc-rsync`), comparing against upstream->upstream
and capturing the forwarded server argv:

| Flag | forwarded | positional leak | result |
|------|-----------|-----------------|--------|
| `--open-noatime` | yes | no | tree byte-identical to upstream |
| `--use-qsort` | yes | no | oc output == source (upstream server itself rejects `--use-qsort` as unknown option -- an upstream 3.4.4 bug: it emits `--use-qsort` but only defines the `qsort` popt name) |
| `--force` (via `--delete`) | yes | no | tree byte-identical |
| `--preallocate` | yes | no | tree byte-identical |
| `--delete-missing-args` (via `--files-from`) | yes | no | tree byte-identical |
| `--ignore-missing-args` (via `--files-from`, pull) | yes | no | tree byte-identical |
| oc->oc regression (`--delete --force --open-noatime --qsort`) | - | no | tree byte-identical |

Also: `cargo fmt`, `cargo clippy -p cli` clean, and a Windows cross-check
(`cargo check --target x86_64-pc-windows-gnu -p cli`) pass.