### PR TITLE
fix(cli): match upstream symlink size, created-file counts, and stats footer

### DIFF
--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -188,6 +188,13 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
             return;
         }
 
+        // upstream: receiver.c:674-676 - the NDX_DONE end_progress(0) summary
+        // is emitted only under --info=progress2. Per-file progress mode has no
+        // terminal summary line, so drop the synthetic transfer-complete tick.
+        if update.is_transfer_complete() && matches!(self.mode, ProgressMode::PerFile) {
+            return;
+        }
+
         let total = update.total().max(update.index());
         // Use the transfer-relative remaining computed by the forwarder rather
         // than `total - index`: `total` counts every checked file-list entry

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -203,19 +203,15 @@ pub(crate) fn emit_transfer_summary(
         )?;
     }
 
-    let name_enabled = !matches!(name_level, NameOutputLevel::Disabled);
-    // upstream: main.c output_summary() emits the `sent/received/total size`
-    // trailer only for `verbose > 0 || INFO_GTE(STATS, 1)`; itemize alone
-    // (`-i` or `-ii`, no `-v`/`--stats`) never shows it. `suppress_updated_only_totals`
-    // captures that itemize-without-verbose-or-stats condition, so it applies to
-    // both itemize name levels (`UpdatedOnly` for `-i`, `UpdatedAndUnchanged` for `-ii`).
-    let suppress_name_totals = suppress_updated_only_totals
-        && matches!(
-            name_level,
-            NameOutputLevel::UpdatedOnly | NameOutputLevel::UpdatedAndUnchanged
-        );
-    let emit_trailer_totals =
-        !stats_on && (verbosity > 0 || (name_enabled && !suppress_name_totals));
+    // upstream: main.c:459-461 output_summary() emits the
+    // `sent/received/total size` trailer only when
+    // `verbose > 0 || INFO_GTE(STATS, 1)`. `stats_on` already captures the
+    // STATS>=1 arm (it routes to emit_stats below), so the name-only and
+    // itemize cases - `--info=name1`/`--info=name2`, `--progress`, `-i`/`-ii`
+    // (verbose 0, no stats level) - correctly print no trailer. A plain
+    // `-v` sets verbose>0 (upstream also raises STATS to 1) and does show it.
+    let _ = suppress_updated_only_totals;
+    let emit_trailer_totals = !stats_on && verbosity > 0;
 
     // upstream: main.c:461 - `output_summary()` emits a blank
     // `rprintf(FCLIENT, "\n")` before the INFO_GTE(STATS, 1) totals so the
@@ -376,25 +372,30 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
         .filter(|event| is_progress_event(event.kind()))
         .collect();
 
-    // Denominator counts every checked entry; the numerator counts down only the
-    // transfers, so to-chk reaches 0 on the last transferred file even when an
-    // up-to-date entry (e.g. an unchanged parent dir) trails it in the list.
+    // Denominator counts every checked flist entry (upstream num_files:
+    // directories and symlinks included); the numerator `total - checked`
+    // counts down over all of them, mirroring upstream's
+    // `num_files - current_file_index - 1`. Only regular-file transfers print a
+    // block and advance `xfr#` (upstream receiver.c:782), so a symlink or
+    // directory is counted but silent.
     let total = flist_entries.len();
     let transferred_total = flist_entries
         .iter()
-        .filter(|event| !is_uptodate_event(event))
+        .filter(|event| event.kind().is_transfer() && !is_uptodate_event(event))
         .count();
     if transferred_total == 0 {
         return Ok(false);
     }
 
     let mut xfr_index = 0usize;
+    let mut checked = 0usize;
     for event in flist_entries.into_iter() {
-        if is_uptodate_event(event) {
+        checked += 1;
+        if !event.kind().is_transfer() || is_uptodate_event(event) {
             continue;
         }
         xfr_index += 1;
-        let remaining = transferred_total - xfr_index;
+        let remaining = total.saturating_sub(checked);
 
         let name =
             normalize_progress_separators(escape_path(event.relative_path(), eight_bit_output));

--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -329,7 +329,11 @@ fn info_name_emits_filenames_without_verbose() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stdout utf8");
     assert!(rendered.contains("name.txt"));
-    assert!(rendered.contains("sent"));
+    // upstream: main.c:459-461 output_summary - the `sent ... total size`
+    // trailer prints only under `--stats` or `-v` (INFO_GTE(STATS, 1)).
+    // `--info=name` sets INFO_NAME alone, so the trailer is absent; verified
+    // against rsync 3.4.4 which emits just the filename line.
+    assert!(!rendered.contains("sent"));
     assert_eq!(
         std::fs::read(destination).expect("read destination"),
         b"name-info"

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -128,9 +128,9 @@ fn info_name_only_suppresses_stats_footer() {
     let mut rendered = Vec::new();
     emit_transfer_summary(
         &summary,
-        0,     // verbosity (name-only, no -v)
+        0, // verbosity (name-only, no -v)
         None,
-        0,     // stats_level (no --stats / --info=statsN)
+        0, // stats_level (no --stats / --info=statsN)
         false, // progress_already_rendered
         false, // list_only
         false, // dry_run

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -130,7 +130,7 @@ fn info_name_only_suppresses_stats_footer() {
         &summary,
         0, // verbosity (name-only, no -v)
         None,
-        0, // stats_level (no --stats / --info=statsN)
+        0,     // stats_level (no --stats / --info=statsN)
         false, // progress_already_rendered
         false, // list_only
         false, // dry_run

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -118,6 +118,58 @@ fn render_itemize(event: &ClientEvent) -> String {
 }
 
 #[test]
+fn info_name_only_suppresses_stats_footer() {
+    // upstream: main.c:459-461 output_summary() gates the
+    // `sent %s bytes  received %s bytes` / `total size is %s` trailer on
+    // `verbose > 0 || INFO_GTE(STATS, 1)`. `--info=name2` raises only the NAME
+    // level, so the trailer must NOT print - previously oc emitted it whenever
+    // any name output was enabled, diverging from upstream.
+    let (summary, _temp) = create_known_summary(&[("file.txt", b"hello world")]);
+    let mut rendered = Vec::new();
+    emit_transfer_summary(
+        &summary,
+        0,     // verbosity (name-only, no -v)
+        None,
+        0,     // stats_level (no --stats / --info=statsN)
+        false, // progress_already_rendered
+        false, // list_only
+        false, // dry_run
+        None,
+        &OutFormatContext::default(),
+        NameOutputLevel::UpdatedAndUnchanged, // --info=name2-style name output
+        false,
+        HumanReadableMode::Grouped,
+        false,
+        false, // emit_flist_banner
+        false, // show_copy_method
+        false, // show_atimes
+        false, // show_crtimes
+        false, // eight_bit_output
+        &mut rendered,
+    )
+    .expect("render");
+    let out = String::from_utf8(rendered).expect("utf8");
+    assert!(
+        !out.contains("sent ") && !out.contains("total size is"),
+        "name-only output (verbose 0, stats 0) must not print the summary \
+         trailer, matching upstream main.c:459-461:\n{out}"
+    );
+}
+
+#[test]
+fn verbose_still_emits_stats_footer() {
+    // upstream: the verbose level-1 word list raises INFO_STATS to 1
+    // (options.c:251), so plain `-v` still prints the trailer. Guards against
+    // over-suppressing the footer when tightening the name-only gate.
+    let (summary, _temp) = create_known_summary(&[("file.txt", b"hello world")]);
+    let out = render_verbose(&summary, 1);
+    assert!(
+        out.contains("total size is"),
+        "`-v` must still print the summary trailer:\n{out}"
+    );
+}
+
+#[test]
 fn parity_stats_output_contains_all_upstream_field_labels() {
     let (summary, _temp) = create_known_summary(&[("file.txt", b"hello world")]);
     let output = render_stats(&summary, HumanReadableMode::Grouped);

--- a/crates/cli/src/frontend/tests/progress.rs
+++ b/crates/cli/src/frontend/tests/progress.rs
@@ -222,9 +222,16 @@ fn progress_reports_unknown_totals_with_placeholder() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("progress output is UTF-8");
+    // upstream: receiver.c:731-782 - a lone special (fifo) is not ITEM_TRANSFER,
+    // so per-file `--progress` prints no per-file progress block for it. The
+    // terminal `end_progress(0)` summary at NDX_DONE fires only under
+    // `--info=progress2` (receiver.c:674-676), not plain `--progress`. The
+    // fifo's name still prints via the name-output path. Verified against rsync
+    // 3.4.4: `--progress --specials <fifo>` emits just `<fifo>\n` - no `??%`
+    // placeholder, no `to-chk` line.
     assert!(rendered.contains("fifo.in"));
-    assert!(rendered.contains("??%"));
-    assert!(rendered.contains("to-chk=0/1"));
+    assert!(!rendered.contains("??%"));
+    assert!(!rendered.contains("to-chk"));
 
     let metadata = std::fs::symlink_metadata(&destination).expect("stat destination");
     assert!(metadata.file_type().is_fifo());

--- a/crates/cli/src/frontend/tests/progress2_format_parity.rs
+++ b/crates/cli/src/frontend/tests/progress2_format_parity.rs
@@ -245,10 +245,14 @@ fn progress2_single_file_final_tick_matches_upstream_format() {
 
     validate_final_tick(final_line).unwrap_or_else(|e| panic!("{e}"));
 
-    // Final tick should show to-chk=0/1 (single file, all done)
+    // Final tick should show to-chk=0/2: the trailing-slash copy enumerates the
+    // source root directory plus the single file, so `num_files == 2` (reg: 1,
+    // dir: 1). upstream: flist.c:2561 counts directories into stats.num_files,
+    // so `rsync -r source/ dest` reports `to-chk=0/2` here. Verified against
+    // rsync 3.4.4: `Number of files: 2 (reg: 1, dir: 1)`.
     assert!(
-        final_line.contains("to-chk=0/1"),
-        "single file transfer should end with to-chk=0/1: {final_line:?}"
+        final_line.contains("to-chk=0/2"),
+        "single file + dir transfer should end with to-chk=0/2: {final_line:?}"
     );
 }
 

--- a/crates/cli/src/frontend/tests/progress_live.rs
+++ b/crates/cli/src/frontend/tests/progress_live.rs
@@ -113,9 +113,13 @@ fn live_progress_per_file_renders_xfr_and_to_chk() {
         output.contains("xfr#1"),
         "per-file output should contain xfr#1: {output:?}"
     );
+    // upstream: flist.c:2561 counts the source root directory into num_files, so
+    // a trailing-slash `source/` copy of one file enumerates dir + file = 2
+    // entries. Verified vs rsync 3.4.4: `--progress -r source/ dest` prints
+    // `to-chk=0/2`.
     assert!(
-        output.contains("to-chk=0/1"),
-        "per-file output should contain to-chk=0/1 for single file: {output:?}"
+        output.contains("to-chk=0/2"),
+        "per-file output should contain to-chk=0/2 for dir + single file: {output:?}"
     );
 }
 
@@ -263,8 +267,12 @@ fn live_progress_overall_renders_xfr_and_to_chk() {
         output.contains("xfr#1"),
         "overall mode should contain xfr#: {output:?}"
     );
+    // upstream: flist.c:2561 counts the source root directory into num_files, so
+    // a trailing-slash `source/` copy of one file enumerates dir + file = 2
+    // entries. Verified vs rsync 3.4.4: `--info=progress2 -r source/ dest`
+    // prints `to-chk=0/2`.
     assert!(
-        output.contains("to-chk=0/1"),
+        output.contains("to-chk=0/2"),
         "overall mode should show to-chk counters: {output:?}"
     );
 }
@@ -646,8 +654,11 @@ fn live_progress_output_matches_upstream_format_pattern() {
     );
 
     // 5. Contains tracking suffix
+    // upstream: flist.c:2561 - the trailing-slash `source/` copy enumerates the
+    // root dir plus the file (num_files == 2), so the final tick reads
+    // `to-chk=0/2`. Verified vs rsync 3.4.4.
     assert!(
-        xfr_line.contains("(xfr#1, to-chk=0/1)"),
+        xfr_line.contains("(xfr#1, to-chk=0/2)"),
         "should contain tracking suffix: {xfr_line:?}"
     );
 }

--- a/crates/core/src/client/progress.rs
+++ b/crates/core/src/client/progress.rs
@@ -210,10 +210,16 @@ pub(crate) struct ClientProgressForwarder<'a> {
     // even when up-to-date entries (e.g. an unchanged parent dir the local
     // executor visits last) trail it in processing order.
     transferred_total: usize,
-    // Running count of entries transferred. Drives `xfr#` and the remaining
-    // figure (transferred_total - transferred); only advances for real
-    // transfers, never for up-to-date matches.
+    // Running count of entries transferred. Drives `xfr#`; only advances for
+    // real regular-file transfers, never for directories, symlinks, devices,
+    // FIFOs, hard links or up-to-date matches.
     transferred: usize,
+    // Running count of file-list entries walked so far, in emission (flist)
+    // order. Mirrors upstream's `current_file_index` (progress.c:147): the
+    // `to-chk` numerator is `total - checked`, so it counts down over *every*
+    // entry the generator checks - directories and symlinks included - not just
+    // the transfers. upstream: progress.c:79-81.
+    checked: usize,
     overall_total_bytes: Option<u64>,
     overall_transferred: u64,
     overall_start: Instant,
@@ -242,12 +248,14 @@ impl<'a> ClientProgressForwarder<'a> {
             .map(|record| ClientEvent::from_record_owned(record, Arc::clone(&destination_root)))
             .filter(|event| event.kind().is_progress())
             .collect();
-        // Denominator counts every checked entry; the numerator base counts only
-        // those that will transfer, so to-chk reaches 0 on the last transfer.
+        // Denominator counts every checked flist entry (upstream num_files:
+        // directories and symlinks included); the numerator counts down over
+        // all of them via `checked`. `transferred_total` counts only the
+        // regular-file transfers that will print a block and advance `xfr#`.
         let total = progress_events.len();
         let transferred_total = progress_events
             .iter()
-            .filter(|event| !event.is_uptodate())
+            .filter(|event| event.kind().is_transfer() && !event.is_uptodate())
             .count();
 
         let total_bytes = summary.total_source_bytes();
@@ -257,6 +265,7 @@ impl<'a> ClientProgressForwarder<'a> {
             total,
             transferred_total,
             transferred: 0,
+            checked: 0,
             overall_total_bytes: (total_bytes > 0).then_some(total_bytes),
             overall_transferred: 0,
             overall_start: Instant::now(),
@@ -277,16 +286,23 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             return;
         }
 
-        // upstream: an up-to-date entry prints no per-file progress block and
-        // does not advance `xfr#` - it is silent under `--progress`/`-P` (it
-        // surfaces only with `-vv`/`-i`), so a no-change run emits nothing.
-        if event.is_uptodate() {
+        // upstream: progress.c:147 set_current_file_index - every checked flist
+        // entry advances the file index, so `to-chk` counts down over
+        // directories and symlinks too, even though they print nothing.
+        self.checked = self.checked.saturating_add(1);
+
+        // upstream: receiver.c:731-782 - only ITEM_TRANSFER (regular file data)
+        // entries print a per-file block and bump `xfr#`. Directories, symlinks,
+        // devices, FIFOs and hard links are walked (counted above) but return
+        // here. An up-to-date match is likewise silent under `--progress`/`-P`
+        // (it surfaces only with `-vv`/`-i`), so a no-change run emits nothing.
+        if !event.kind().is_transfer() || event.is_uptodate() {
             return;
         }
 
         self.transferred = self.transferred.saturating_add(1);
         let index = self.transferred;
-        let remaining = self.transferred_total.saturating_sub(self.transferred);
+        let remaining = self.total.saturating_sub(self.checked);
 
         let total_bytes = if matches!(event.kind(), ClientEventKind::DataCopied) {
             event.total_bytes()
@@ -324,10 +340,12 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             return;
         }
 
-        // The in-flight file is the next transfer (`xfr#`); to-chk counts the
-        // transfers still pending after it.
+        // The in-flight file is the next transfer (`xfr#`). Its own flist entry
+        // has not been counted into `checked` yet (that happens in `handle`
+        // when its final record arrives), so subtract one for it: to-chk mirrors
+        // upstream `num_files - current_file_index - 1` for the file now moving.
         let index = (self.transferred + 1).min(self.transferred_total);
-        let remaining = self.transferred_total.saturating_sub(self.transferred + 1);
+        let remaining = self.total.saturating_sub(self.checked + 1);
         let event = ClientEvent::from_progress(
             progress.relative_path(),
             progress.bytes_transferred(),

--- a/crates/core/src/client/progress.rs
+++ b/crates/core/src/client/progress.rs
@@ -55,6 +55,7 @@ pub struct ClientProgressUpdate {
     overall_total_bytes: Option<u64>,
     overall_elapsed: Duration,
     flist_eof: bool,
+    transfer_complete: bool,
 }
 
 impl ClientProgressUpdate {
@@ -122,6 +123,20 @@ impl ClientProgressUpdate {
     pub const fn flist_eof(&self) -> bool {
         self.flist_eof
     }
+
+    /// Reports whether this update is the synthetic progress2 end-of-transfer
+    /// summary rather than a per-file tick.
+    ///
+    /// Mirrors upstream's `end_progress(0)` call at `NDX_DONE`
+    /// (receiver.c:674-676), which prints one final
+    /// `(xfr#N, to-chk=0/total)` line under `--info=progress2` even when the
+    /// transfer moved no file data (a lone special/symlink, or a no-change
+    /// run). It fires only in overall/progress2 rendering; per-file progress
+    /// mode has no such terminal line and ignores it.
+    #[must_use]
+    pub const fn is_transfer_complete(&self) -> bool {
+        self.transfer_complete
+    }
 }
 
 /// Observer invoked for each progress update generated during client execution.
@@ -155,6 +170,7 @@ impl ClientProgressUpdate {
             overall_total_bytes: None,
             overall_elapsed,
             flist_eof,
+            transfer_complete: false,
         }
     }
 }
@@ -187,6 +203,7 @@ impl ClientProgressUpdate {
             overall_total_bytes,
             overall_elapsed,
             flist_eof,
+            transfer_complete: false,
         }
     }
 }
@@ -277,6 +294,52 @@ impl<'a> ClientProgressForwarder<'a> {
     pub(crate) fn as_handler_mut(&mut self) -> &mut dyn LocalCopyRecordHandler {
         self
     }
+
+    /// Emits the progress2 end-of-transfer summary line when no regular-file
+    /// transfer produced one.
+    ///
+    /// upstream: receiver.c:674-676 - at `NDX_DONE` the receiver calls
+    /// `end_progress(0)` under `--info=progress2`, printing one
+    /// `<bytes> <pct>% <rate> <time> (xfr#<n>, to-chk=0/<total>)` line even
+    /// when the transfer moved no file data (a lone special/symlink, or a
+    /// no-change run). The per-file transfer path already prints this line
+    /// whenever at least one regular file transfers, so synthesize it only
+    /// when none did (`transferred == 0`). The observer marks the update
+    /// `transfer_complete`; per-file progress rendering ignores it because
+    /// upstream has no terminal summary outside progress2.
+    pub(crate) fn finalize(&mut self) {
+        if self.total == 0 || self.transferred > 0 {
+            return;
+        }
+
+        // upstream: progress.c:128 - the final line's percent is
+        // `total_transferred_size / total_size`, so an empty flist (size 0,
+        // e.g. a lone fifo) renders 100% while a no-change run over sized
+        // files renders 0%. Pass `Some(flist_total)` (never `None`) so the
+        // renderer computes the ratio instead of `??%`.
+        let flist_total = self.overall_total_bytes.unwrap_or(0);
+        let elapsed = self.overall_start.elapsed();
+        let update = ClientProgressUpdate {
+            event: ClientEvent::from_progress(
+                Path::new(""),
+                self.overall_transferred,
+                Some(flist_total),
+                elapsed,
+                Arc::clone(&self.destination_root),
+            ),
+            total: self.total,
+            remaining: 0,
+            index: self.transferred,
+            total_bytes: Some(flist_total),
+            final_update: true,
+            overall_transferred: self.overall_transferred,
+            overall_total_bytes: Some(flist_total),
+            overall_elapsed: elapsed,
+            flist_eof: true,
+            transfer_complete: true,
+        };
+        self.observer.on_progress(&update);
+    }
 }
 
 impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
@@ -330,6 +393,7 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             // Local copies enumerate the file list eagerly before transferring,
             // so the list is always complete when progress is emitted.
             flist_eof: true,
+            transfer_complete: false,
         };
 
         self.observer.on_progress(&update);
@@ -377,6 +441,7 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             // Local copies do not use INC_RECURSE: the file list is enumerated
             // eagerly before any progress event is emitted.
             flist_eof: true,
+            transfer_complete: false,
         };
 
         self.observer.on_progress(&update);
@@ -412,6 +477,7 @@ mod tests {
             overall_total_bytes: Some(10000),
             overall_elapsed: Duration::from_secs(5),
             flist_eof: true,
+            transfer_complete: false,
         }
     }
 

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -392,6 +392,13 @@ fn run_client_internal(
 
     let summary = summary.map_err(map_local_copy_error)?;
 
+    // upstream: receiver.c:674-676 - emit the progress2 end-of-transfer summary
+    // line when the transfer moved no file data (a lone special/symlink or a
+    // no-change run), which the per-file path never produces.
+    if let Some(adapter) = handler_adapter.as_mut() {
+        adapter.finalize();
+    }
+
     if let Some(ref writer_arc) = batch_writer
         && let Some(batch_cfg) = config.batch_config()
     {

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -75,7 +75,25 @@ impl ClientEventKind {
                 | Self::SymlinkCopied
                 | Self::FifoCopied
                 | Self::DeviceCopied
+                | Self::DirectoryCreated
         )
+    }
+
+    /// Returns whether the event kind is an actual regular-file data transfer -
+    /// the narrower question of whether it prints a per-file `--progress` block
+    /// and advances `xfr#`.
+    ///
+    /// Upstream only counts `ITEM_TRANSFER` entries (regular file data) into
+    /// `stats.xferred_files` and only those emit a progress block
+    /// (receiver.c:782 `stats.xferred_files++` sits *after* the
+    /// `!(iflags & ITEM_TRANSFER)` early-continue that handles directories,
+    /// symlinks, devices and specials). So a symlink, device, FIFO, hard link
+    /// or directory is walked (counted in the `to-chk` denominator via
+    /// [`Self::is_progress`]) but never prints a progress line and never bumps
+    /// `xfr#`. Copy-dest / reference reconstructions write regular file data
+    /// locally, so they transfer.
+    pub const fn is_transfer(&self) -> bool {
+        matches!(self, Self::DataCopied | Self::ReferenceCopied)
     }
 }
 
@@ -476,6 +494,29 @@ mod tests {
     #[test]
     fn client_event_kind_is_progress_returns_true_for_device_copied() {
         assert!(ClientEventKind::DeviceCopied.is_progress());
+    }
+
+    #[test]
+    fn client_event_kind_is_progress_returns_true_for_directory_created() {
+        // upstream: stats.num_files counts directories (flist.c:2561), so they
+        // belong in the `to-chk` denominator even though they never transfer.
+        assert!(ClientEventKind::DirectoryCreated.is_progress());
+    }
+
+    #[test]
+    fn client_event_kind_is_transfer_only_for_regular_data() {
+        assert!(ClientEventKind::DataCopied.is_transfer());
+        assert!(ClientEventKind::ReferenceCopied.is_transfer());
+        // upstream: receiver.c:782 `stats.xferred_files++` sits after the
+        // `!(iflags & ITEM_TRANSFER)` continue, so symlinks, directories,
+        // devices, FIFOs and hard links are walked but never advance `xfr#`
+        // nor print a per-file progress block.
+        assert!(!ClientEventKind::SymlinkCopied.is_transfer());
+        assert!(!ClientEventKind::FifoCopied.is_transfer());
+        assert!(!ClientEventKind::DeviceCopied.is_transfer());
+        assert!(!ClientEventKind::HardLink.is_transfer());
+        assert!(!ClientEventKind::DirectoryCreated.is_transfer());
+        assert!(!ClientEventKind::MetadataReused.is_transfer());
     }
 
     #[test]

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -133,6 +133,13 @@ pub(crate) fn copy_symlink(
         .map(Path::to_path_buf)
         .or_else(|| destination.file_name().map(PathBuf::from));
     context.summary_mut().record_symlink_total();
+    // upstream: flist.c:691/1243 - `if (S_ISREG(mode) || S_ISLNK(mode))
+    // stats.total_size += F_LENGTH(file)`. A symlink's F_LENGTH is its lstat
+    // st_size, i.e. the byte length of its target, so count it into the flist
+    // total_size exactly once per preserved symlink. Without this the
+    // `--stats` "Total file size" line and the "total size is N" trailer are
+    // short by the target length (e.g. 50 vs upstream's 55 for a 5-byte link).
+    context.summary_mut().record_total_bytes(metadata.len());
 
     let raw_target = fs::read_link(source)
         .map_err(|error| LocalCopyError::io("read symbolic link", source, error))?;
@@ -313,7 +320,11 @@ pub(crate) fn copy_symlink(
             false,
             context.options().modify_window(),
         );
-        context.summary_mut().record_symlink();
+        // upstream: generator.c:1140 + receiver.c:734 - a `--compare-dest`
+        // match leaves the destination absent and itemizes `.L` with no
+        // ITEM_IS_NEW, so `stats.created_files`/`created_symlinks` do NOT count
+        // it. It is still tallied into num_symlinks via `record_symlink_total`
+        // above; only the created-count is suppressed here.
         let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, Some(target));
         context.record(
             LocalCopyRecord::new(
@@ -362,7 +373,12 @@ pub(crate) fn copy_symlink(
             apply_symlink_metadata_with_options(destination, metadata, &symlink_options)
                 .map_err(map_metadata_error)?;
         }
-        context.summary_mut().record_symlink();
+        // upstream: generator.c:1572-1585 + receiver.c:731-746 - an existing
+        // symlink already pointing at the same target quick-checks equal:
+        // `itemize(..., 0, ...)` sets no ITEM_IS_NEW, so `stats.created_files`
+        // does not count it. A no-change re-run therefore reports 0 created
+        // files. The symlink is still counted in num_symlinks via
+        // `record_symlink_total` above; only the created-count is suppressed.
         if let Some(path) = &record_path {
             let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, Some(target));
             let total_bytes = Some(metadata_snapshot.len());

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -441,6 +441,15 @@ impl LocalCopySummary {
     }
 
     pub(in crate::local_copy) const fn mark_destination_root_created(&mut self) {
+        // upstream: receiver.c:731-746 - the pre-flight mkdir of the
+        // destination root sets ITEM_IS_NEW on the synthesized "." entry, so
+        // `stats.created_files++` and `stats.created_dirs++` count it. Bump the
+        // created-directory tally exactly once (guarded by the flag, which both
+        // call sites also set) so `--stats` "Number of created files" includes
+        // the destination root - dir:2 for a fresh recursive copy, not dir:1.
+        if !self.destination_root_created {
+            self.directories_created = self.directories_created.saturating_add(1);
+        }
         self.destination_root_created = true;
     }
 

--- a/crates/engine/src/local_copy/tests/execute_symlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_symlinks.rs
@@ -1431,3 +1431,69 @@ fn copy_unsafe_links_dereferences_symlink_chain() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.symlinks_copied(), 0);
 }
+
+#[cfg(unix)]
+#[test]
+fn execute_symlink_tree_stats_match_upstream() {
+    use std::os::unix::fs::symlink;
+
+    // Tree: 3 regular files (10 + 20 + 20 = 50 bytes) + one symlink whose
+    // target `a.txt` is 5 bytes, under a `sub/` subdirectory.
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src");
+    fs::create_dir_all(src.join("sub")).expect("mkdir sub");
+    fs::write(src.join("a.txt"), [b'X'; 10]).expect("a");
+    fs::write(src.join("b.txt"), [b'Y'; 20]).expect("b");
+    fs::write(src.join("sub/c.txt"), [b'Z'; 20]).expect("c");
+    symlink("a.txt", src.join("link.txt")).expect("symlink");
+
+    // Copy CONTENTS of src into a not-yet-existing destination root.
+    let mut src_operand = src.into_os_string();
+    src_operand.push("/");
+    let dest = temp.path().join("dst");
+    let operands = vec![src_operand, dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default().recursive(true).links(true);
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options.clone())
+        .expect("copy succeeds");
+
+    // upstream flist.c:691/1243 - `stats.total_size` sums the F_LENGTH of
+    // regular files AND symlinks; a symlink's F_LENGTH is its lstat st_size,
+    // i.e. the target byte length (5). Without it the total is 50, not the
+    // upstream 55, and both `--stats` "Total file size" and "total size is N"
+    // come up short.
+    assert_eq!(
+        summary.total_source_bytes(),
+        55,
+        "3 regular files (50 bytes) + symlink target length (5 bytes)"
+    );
+
+    // upstream receiver.c:731-746 - a fresh recursive copy creates the
+    // destination root plus `sub`; both entries set ITEM_IS_NEW, so
+    // `Number of created files` reports dir:2, link:1.
+    assert_eq!(
+        summary.directories_created(),
+        2,
+        "the destination root and `sub` are both newly created"
+    );
+    assert_eq!(summary.symlinks_copied(), 1, "the symlink is newly created");
+
+    // Second pass over an unchanged destination: upstream reports 0 created
+    // files because nothing is ITEM_IS_NEW. In particular the unchanged
+    // symlink (quick-check match) must NOT be recounted as created every run.
+    let summary2 = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("re-copy succeeds");
+    assert_eq!(
+        summary2.directories_created(),
+        0,
+        "no directories are created on a no-change re-run"
+    );
+    assert_eq!(
+        summary2.symlinks_copied(),
+        0,
+        "an unchanged symlink must not be counted as created (upstream reports 0)"
+    );
+}


### PR DESCRIPTION
## Summary

Four output/stats fidelity fixes for local-copy transfers, each verified
byte-for-byte against upstream rsync 3.4.4 (a source tree with three regular
files totalling 50 bytes plus `link.txt -> a.txt`, a 5-byte target, under a
`sub/` subdirectory).

1. **Symlink size in `total_size`** - count a preserved symlink's target byte
   length (its lstat `st_size`) into the flist `total_size` so `--stats`
   "Total file size" and the "total size is N" trailer include it
   (upstream `flist.c:691/1243`, `S_ISREG || S_ISLNK`). It was short by the
   target length.

2. **Created-file counts** (`--stats` "Number of created files")
   - Count the pre-flight destination-root `mkdir` as a created directory
     (upstream `receiver.c:731-746` sets `ITEM_IS_NEW` on the synthesized
     `.` entry), so a fresh recursive copy reports `dir:2`.
   - Stop counting an unchanged/reused symlink (quick-check match or
     `--compare-dest`) as created, so a no-change re-run reports `0`
     (upstream only counts `ITEM_IS_NEW` entries).

3. **`--progress` accounting** - directories now count toward the `to-chk`
   denominator (upstream `num_files`), while only regular-file data transfers
   print a per-file block and advance `xfr#`. Symlinks, directories, devices,
   FIFOs and hard links are walked but stay silent (upstream `receiver.c:782`
   - `xfr#` counts only `ITEM_TRANSFER`). The `to-chk` numerator now counts
   down over every checked entry (`total - checked`), mirroring
   `num_files - current_file_index - 1`.

4. **Stats footer gating** - emit the `sent/received/total size` trailer only
   when `verbose > 0 || INFO_GTE(STATS, 1)` (upstream `main.c:459-461`), so
   `--info=name2` / `--progress` / `-i` no longer print a spurious footer.

## Before / after vs upstream 3.4.4

| Case | Field | Before (oc) | After (oc) | Upstream |
|------|-------|-------------|------------|----------|
| `-a` | `total size is` | 50 | **55** | 55 |
| `-a --stats` | `Total file size` | 50 bytes | **55 bytes** | 55 bytes |
| `-a --stats` (1st) | `Number of created files` | 5 (reg:3, dir:1, link:1) | **6 (reg:3, dir:2, link:1)** | 6 (reg:3, dir:2, link:1) |
| `-a --stats` (no-change) | `Number of created files` | 1 (link:1) | **0** | 0 |
| `--progress` | symlink | `link.txt` + bogus progress line | **no progress line** | no progress line |
| `--progress` | `xfr#` / `to-chk` | xfr#1..4, `to-chk=N/4` | **xfr#1..3, `to-chk=N/6`** | xfr#1..3, `to-chk=N/6` |
| `--info=name2` | trailer | `sent .. / total size is ..` printed | **suppressed** | suppressed |

## Testing

- fmt + clippy (`-D warnings`) clean on engine/core/cli.
- New regression tests: engine `execute_symlink_tree_stats_match_upstream`
  (total_size 55, dir:2 created, no-change symlink not recounted); cli
  `info_name_only_suppresses_stats_footer` + `verbose_still_emits_stats_footer`;
  core `is_transfer` / directory-in-`to-chk` classification.

## Scope

This is the DATA subset of the verbosity audit. Pre-existing, unrelated
divergences left for follow-up: local-copy `sent/received` byte totals and
`speedup` (the wire-overhead accounting), the leading blank line and
`File list generation/transfer time` lines in the `--stats` block, the
`skipping directory .` / `created directory` name-output lines under
`--info=name`, and the live `--progress` interim-tick line-splitting (`\r` vs
`\n`).
