### PR TITLE
fix(transfer): flatten --files-from entries under --no-relative over the wire

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -267,13 +267,17 @@ pub(super) struct ServerLongFlags {
     /// `whole_file` (options.c:746 `{"no-W", ..., &whole_file, 0}`).
     pub(super) no_whole_file: bool,
 
-    /// Whether the client forwarded `--no-relative` (upstream `relative_paths = 0`).
+    /// Whether the client forwarded `--relative` / `--no-relative`.
     ///
-    /// upstream: options.c:2962-2973 - when `files_from` is active and
-    /// `!relative_paths`, the client emits `--no-relative`. The server-side
-    /// popt table clears `relative_paths` (options.c:693 `{"no-relative", ...,
-    /// &relative_paths, 0}`).
-    pub(super) no_relative: bool,
+    /// upstream: options.c:109-110 - `if (relative_paths) argstr[x++] = 'R';`
+    /// packs the compact `R` letter for relative mode, and options.c:368-369
+    /// emits the long `--no-relative` when relative paths are off (including the
+    /// `--files-from` default, which is otherwise relative). The long form must
+    /// be recognised and consumed here; otherwise it falls through to the
+    /// positional-path branch and the sender treats `--no-relative` as the
+    /// transfer root (`link_stat "--no-relative/..."`). `None` leaves the value
+    /// implied by the compact `R` letter untouched.
+    pub(super) relative: Option<bool>,
 
     /// Whether the client forwarded `--open-noatime` (upstream `open_noatime`).
     ///
@@ -356,7 +360,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         no_implied_dirs: false,
         no_recurse: false,
         no_whole_file: false,
-        no_relative: false,
+        relative: None,
         open_noatime: false,
         delete_missing_args: false,
         ignore_missing_args: false,
@@ -442,9 +446,16 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // upstream: options.c:746 / 2955-2959 - `--no-W` clears `whole_file`
             // so `--inplace --sparse` streams a delta instead of the whole file.
             "--no-W" => flags.no_whole_file = true,
-            // upstream: options.c:693 / 2962-2973 - `--no-relative` clears
-            // `relative_paths` when the client used `--files-from` without `-R`.
-            "--no-relative" => flags.no_relative = true,
+            // upstream: options.c:368-369 / 692-694 - the sender packs the
+            // compact `R` letter for relative mode; when relative paths are off
+            // (including the `--files-from` default being explicitly disabled),
+            // server_options() emits the long `--no-relative` instead. Recognise
+            // and record both so the flag is consumed rather than mistaken for a
+            // positional path, and so the server-side sender flattens each
+            // --files-from entry to its basename (flist.c:2338-2349) with no
+            // implied parent directories (options.c:2207-2208).
+            "--no-relative" | "--no-R" => flags.relative = Some(false),
+            "--relative" => flags.relative = Some(true),
             "--from0" => flags.from0 = true,
             "--inplace" => flags.inplace = true,
             // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode
@@ -743,6 +754,8 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--no-r"
             | "--no-W"
             | "--no-relative"
+            | "--no-R"
+            | "--relative"
             | "--from0"
             | "--inplace"
             | "--append"

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -232,11 +232,13 @@ where
     if long_flags.no_whole_file {
         config.flags.whole_file = false;
     }
-    // upstream: options.c:693 / 2962-2973 - `--no-relative` clears
-    // `relative_paths` when the client used `--files-from` without `-R`.
-    // Overrides the compact `R` letter.
-    if long_flags.no_relative {
-        config.flags.relative = false;
+    // upstream: options.c:109-110 / 368-369 - relative mode arrives as the
+    // compact `R` letter (already parsed into config.flags.relative) or as the
+    // long `--no-relative`. Apply the long form when present so an explicit
+    // `--no-relative` (which the peer sends without the `R` letter) forces
+    // non-relative mode and the sender flattens --files-from entries.
+    if let Some(relative) = long_flags.relative {
+        config.flags.relative = relative;
     }
     config.flags.numeric_ids = core::server::NumericIds::from_client(long_flags.numeric_ids);
     config.flags.delete = long_flags.delete;

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -439,6 +439,38 @@ fn append_is_known_server_long_flag() {
     assert!(is_known_server_long_flag("--append"));
 }
 
+/// Task #292: upstream server_options() emits the long `--no-relative` when
+/// relative paths are off (options.c:368-369), and it must be recognised so it
+/// is consumed as a flag - not treated as the transfer-root positional path.
+/// This reproduces the exact argv an upstream client sends for a
+/// `--files-from --no-relative` pull.
+#[test]
+fn no_relative_is_recognised_and_not_a_positional() {
+    assert!(is_known_server_long_flag("--no-relative"));
+    assert!(is_known_server_long_flag("--no-R"));
+    assert!(is_known_server_long_flag("--relative"));
+
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--sender"),
+        OsString::from("-logDtpe.LsfxCIvu"),
+        OsString::from("--files-from=-"),
+        OsString::from("--from0"),
+        OsString::from("--no-relative"),
+        OsString::from("."),
+        OsString::from("/src/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpe.LsfxCIvu");
+    // The real source path must be the sole positional; `--no-relative` must
+    // NOT leak in as the transfer root (which caused `link_stat
+    // "--no-relative/..."` on the sender).
+    assert_eq!(pos_args, vec![OsString::from("/src/")]);
+
+    let long = parse_server_long_flags(&args);
+    assert_eq!(long.relative, Some(false));
+}
+
 /// `parse_server_long_flags` must capture both split and joined
 /// `--partial-dir` forms into `ServerLongFlags::partial_dir`.
 #[test]
@@ -859,10 +891,10 @@ fn long_flags_no_w_recognized_and_parsed() {
 fn long_flags_no_relative_recognized_and_parsed() {
     let flags =
         parse_server_long_flags(&[OsString::from("--server"), OsString::from("--no-relative")]);
-    assert!(flags.no_relative);
+    assert_eq!(flags.relative, Some(false));
 
     let flags = parse_server_long_flags(&[OsString::from("--server")]);
-    assert!(!flags.no_relative);
+    assert_eq!(flags.relative, None);
 
     assert!(is_known_server_long_flag("--no-relative"));
 }

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -645,6 +645,15 @@ impl<'a> RemoteInvocationBuilder<'a> {
             if plan.remote_from0 {
                 args.push(OsString::from("--from0"));
             }
+            // upstream: options.c:368-369 - a peer that reads the --files-from
+            // list defaults relative_paths=1 (options.c:2205-2206). When the
+            // client resolved relative paths off (explicit --no-relative), emit
+            // --no-relative so the remote sender overrides that default and
+            // flattens each entry to its basename (flist.c:2338-2349) with no
+            // implied parent dirs.
+            if !self.config.relative_paths() {
+                args.push(OsString::from("--no-relative"));
+            }
         }
 
         // upstream: options.c:2894-2898 - --usermap / --groupmap are
@@ -699,7 +708,15 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // 'R' to match this behaviour.
         let files_from_active = self.config.files_from().is_active();
         let effective_recursive = self.config.recursive() && !files_from_active;
-        let effective_relative = self.config.relative_paths() || files_from_active;
+        // upstream: options.c:109-110 - server_options() packs the compact `R`
+        // letter for the RESOLVED relative_paths. `relative_paths()` already
+        // folds in the --files-from default (options.c:2205-2206: relative
+        // defaults to 1 under --files-from) at the CLI layer, so it must NOT be
+        // re-forced with `|| files_from_active` - that wrongly packs `R` even
+        // when the user passed --no-relative, defeating the --no-relative arg
+        // emitted below and making the remote sender keep the leading path
+        // components (`sub/file` instead of `file`).
+        let effective_relative = self.config.relative_paths();
         let effective_dirs = self.config.dirs() || files_from_active;
         // upstream: options.c:2641 / :2655 - several compact letters live in a
         // direction-specific branch. `am_sender` is true when the local process

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -3627,6 +3627,60 @@ fn pull_with_local_files_from_sends_files_from_stdin_to_remote() {
     );
 }
 
+/// upstream: options.c:368-369 - a PULL with `--files-from --no-relative`
+/// (relative_paths resolved off) must forward `--no-relative` to the remote
+/// sender AND must NOT pack the compact `R` letter. Without this the remote
+/// defaults relative_paths=1 (options.c:2205-2206) and keeps the leading path
+/// components (`sub/file` instead of the flattened `file`).
+#[test]
+fn pull_with_files_from_no_relative_forwards_no_relative_and_omits_r() {
+    use crate::client::config::FilesFromSource;
+    use std::path::PathBuf;
+
+    let config = ClientConfig::builder()
+        .files_from(FilesFromSource::LocalFile(PathBuf::from("/tmp/list.txt")))
+        .relative_paths(false)
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/remote/source");
+
+    assert!(
+        args.iter().any(|a| a == "--no-relative"),
+        "files-from + non-relative must forward --no-relative: {args:?}"
+    );
+    let flags = receiver_flag_string(&config);
+    assert!(
+        !flags.contains('R'),
+        "files-from + non-relative must NOT pack compact 'R': {flags}"
+    );
+}
+
+/// upstream: options.c:109-110 - a PULL with `--files-from` defaulting to
+/// relative (relative_paths resolved on) packs the compact `R` letter and does
+/// NOT forward `--no-relative`.
+#[test]
+fn pull_with_files_from_relative_packs_r_and_omits_no_relative() {
+    use crate::client::config::FilesFromSource;
+    use std::path::PathBuf;
+
+    let config = ClientConfig::builder()
+        .files_from(FilesFromSource::LocalFile(PathBuf::from("/tmp/list.txt")))
+        .relative_paths(true)
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/remote/source");
+
+    assert!(
+        !args.iter().any(|a| a == "--no-relative"),
+        "relative files-from must NOT forward --no-relative: {args:?}"
+    );
+    let flags = receiver_flag_string(&config);
+    assert!(
+        flags.contains('R'),
+        "relative files-from must pack compact 'R': {flags}"
+    );
+}
+
 /// SSH pull with a remote-hosted `--files-from` forwards the absolute path
 /// (matching upstream `options.c:2964 safe_arg("", files_from)`).
 #[test]

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -244,6 +244,12 @@ impl GeneratorContext {
         // `try_walk_source_entry_dedup` to suppress the duplicate top-level
         // walk that would re-emit an implied parent.
         let mut emitted_dirs: HashSet<(PathBuf, PathBuf)> = explicit_dirs.clone();
+        // upstream: options.c:2207-2208 - `if (!relative_paths) implied_dirs = 0;`.
+        // Under --no-relative (relative_paths == 0) the sender FLATTENS every
+        // --files-from entry to its transmitted name and emits NO implied parent
+        // directories (flist.c:2468 gates the send on `implied_dirs`, which is
+        // forced off). Without this gate oc emits an intermediate `sub` dir that
+        // an upstream receiver rejects as an unrequested file-list name (exit 4).
         // upstream: flist.c:2257-2258 - `if (relative_paths && protocol_version
         // >= 30) implied_dirs = 1;` forces flagged implied parent dirs at
         // protocol >= 30 regardless of --no-implied-dirs; at protocol < 30 the
@@ -251,11 +257,14 @@ impl GeneratorContext {
         // --no-implied-dirs omits the implied parents from the --files-from
         // flist and the receiver recreates them via make_path (generator.c:1317)
         // without their source metadata. Mirror the same gate as the positional
-        // path (build_file_list): emit when implied dirs are on OR the protocol
-        // forces them. When suppressed, `emitted_dirs` stays equal to
-        // `explicit_dirs`, so `implied_only_dirs` below is empty and the
-        // explicit top-level walk is left untouched (dedup unchanged).
-        if !self.config.flags.no_implied_dirs || self.protocol.as_u8() >= 30 {
+        // path (build_file_list): emit only in relative mode, and then when
+        // implied dirs are on OR the protocol forces them. When suppressed,
+        // `emitted_dirs` stays equal to `explicit_dirs`, so `implied_only_dirs`
+        // below is empty and the explicit top-level walk is left untouched
+        // (dedup unchanged).
+        if self.config.flags.relative
+            && (!self.config.flags.no_implied_dirs || self.protocol.as_u8() >= 30)
+        {
             for entry in entries {
                 if let Ok(rel) = entry.path.strip_prefix(&entry.base) {
                     // Walk each ancestor of the relative path and emit a

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -97,11 +97,70 @@ fn has_leading_dot_anchor(name: &str) -> bool {
 /// (`from/./` → `from/.`). Without this, `from/./` would never match the
 /// `/./` substring search and would emit a stray `from/` directory entry
 /// instead of promoting `from` to the per-entry walk base.
+///
+/// `relative_paths` selects the upstream split branch. In relative mode
+/// (`flist.c:2350-2365`) the entry is split on its first `/./` anchor as
+/// above. Under `--no-relative` (`relative_paths == 0`, `flist.c:2338-2349`)
+/// upstream instead splits on the entry's LAST `/`: the parent becomes the
+/// chdir target (walk base) and only the basename is transmitted, so nested
+/// entries FLATTEN (`sub/file` transmits as `file`, no implied `sub` dir).
+/// The `/./` anchor is relative-only and is not honoured under `--no-relative`.
 pub(super) fn split_files_from_entry(
     base_dir: &Path,
     sanitized: &str,
     raw_trailing_slash: bool,
+    relative_paths: bool,
 ) -> FilesFromEntry {
+    // upstream: flist.c:2338-2349 - `if (!relative_paths) { p = strrchr(fbuf,
+    // '/'); ... dir = fbuf; fn = p + 1; }`. Non-relative mode drops every
+    // leading path component: the walk base absorbs the parent directory and
+    // the transmitted name is the trailing basename. No implied parent dirs.
+    if !relative_paths {
+        let trimmed = sanitized.trim_end_matches('/');
+        if raw_trailing_slash {
+            // upstream: flist.c:2312-2322 - a trailing `/` turns `X/` into the
+            // DOTDIR `X/.`; the strrchr split then makes the WHOLE directory the
+            // chdir target (`dir = X`, `fn = "."`) and recurses, so the entry's
+            // contents flatten into the transfer root (`sub/` sends `file`,
+            // `deep`, `deep/x` - not `sub/...`). Recursion is forced regardless
+            // of the global `-r` flag (SLASH_ENDING_NAME / DOTDIR_NAME).
+            let base = if trimmed.is_empty() {
+                base_dir.to_path_buf()
+            } else {
+                base_dir.join(trimmed)
+            };
+            return FilesFromEntry {
+                base: base.clone(),
+                path: base,
+                recurse: true,
+                // upstream: flist.c:2367 - `implied_dot_dir` is set only in the
+                // relative-mode branch; non-relative entries never trip it.
+                implied_dot: false,
+            };
+        }
+        let (head, fname) = match trimmed.rsplit_once('/') {
+            Some((head, fname)) => (head, fname),
+            None => ("", trimmed),
+        };
+        let base = if head.is_empty() {
+            base_dir.to_path_buf()
+        } else {
+            base_dir.join(head)
+        };
+        let path = if fname.is_empty() {
+            base.clone()
+        } else {
+            base.join(fname)
+        };
+        return FilesFromEntry {
+            base,
+            path,
+            recurse: false,
+            // upstream: flist.c:2367 - `implied_dot_dir` is relative-mode only.
+            implied_dot: false,
+        };
+    }
+
     // Anchored form: prefix `/./` suffix.
     if let Some(anchor) = sanitized.find("/./") {
         let (head, tail) = sanitized.split_at(anchor);
@@ -305,6 +364,7 @@ impl GeneratorContext {
                 &base_dir,
                 &sanitized,
                 raw_trailing_slash,
+                self.config.flags.relative,
             ));
         }
 
@@ -745,10 +805,66 @@ mod tests {
     #[test]
     fn split_files_from_entry_without_anchor_inherits_base() {
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "dir/file.txt", false);
+        let split = split_files_from_entry(&base, "dir/file.txt", false, true);
         assert_eq!(split.base, PathBuf::from("/src"));
         assert_eq!(split.path, PathBuf::from("/src/dir/file.txt"));
         assert!(!split.recurse);
+    }
+
+    #[test]
+    fn split_files_from_entry_no_relative_flattens_to_basename() {
+        // Task #292: upstream flist.c:2338-2349 - under --no-relative the entry
+        // splits on its LAST `/`, so the walk base absorbs every parent
+        // component and only the basename is transmitted. `sub/file` must
+        // resolve to base `/src/sub`, path `/src/sub/file`, wire name `file` -
+        // no implied `sub` directory. An upstream receiver rejects an
+        // unrequested intermediate `sub` with exit 4.
+        let base = PathBuf::from("/src");
+        let split = split_files_from_entry(&base, "sub/file", false, false);
+        assert_eq!(split.base, PathBuf::from("/src/sub"));
+        assert_eq!(split.path, PathBuf::from("/src/sub/file"));
+        assert_eq!(
+            split.path.strip_prefix(&split.base).unwrap(),
+            Path::new("file")
+        );
+        assert!(!split.recurse);
+
+        // Deeper nesting still flattens to the trailing basename (last `/`).
+        let deep = split_files_from_entry(&base, "a/b/c/file", false, false);
+        assert_eq!(deep.base, PathBuf::from("/src/a/b/c"));
+        assert_eq!(
+            deep.path.strip_prefix(&deep.base).unwrap(),
+            Path::new("file")
+        );
+
+        // A top-level entry keeps the source argument as its base.
+        let top = split_files_from_entry(&base, "file", false, false);
+        assert_eq!(top.base, PathBuf::from("/src"));
+        assert_eq!(top.path, PathBuf::from("/src/file"));
+
+        // The `/./` anchor is relative-only; under --no-relative it is a
+        // literal component and the split still takes the last `/`.
+        let anchored = split_files_from_entry(&base, "from/./dir/file", false, false);
+        assert_eq!(anchored.base, PathBuf::from("/src/from/./dir"));
+        assert_eq!(
+            anchored.path.strip_prefix(&anchored.base).unwrap(),
+            Path::new("file")
+        );
+
+        // A trailing slash names a directory whose contents flatten into the
+        // transfer root: base is the whole dir, path == base (transmit `.`),
+        // and recursion is forced (upstream DOTDIR / SLASH_ENDING_NAME).
+        let dir = split_files_from_entry(&base, "sub", true, false);
+        assert_eq!(dir.base, PathBuf::from("/src/sub"));
+        assert_eq!(dir.path, PathBuf::from("/src/sub"));
+        assert!(dir.recurse);
+
+        // A plain directory entry (no trailing slash) keeps the parent as base,
+        // transmits the basename, and is NOT recursed (files-from clears `-r`).
+        let plain_dir = split_files_from_entry(&base, "sub", false, false);
+        assert_eq!(plain_dir.base, PathBuf::from("/src"));
+        assert_eq!(plain_dir.path, PathBuf::from("/src/sub"));
+        assert!(!plain_dir.recurse);
     }
 
     #[test]
@@ -758,7 +874,7 @@ mod tests {
         // `dir/subdir`. Otherwise upstream's `implied_filter_list` check
         // (flist.c:998) rejects `from/dir/subdir` as "unrequested".
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "from/./dir/subdir", false);
+        let split = split_files_from_entry(&base, "from/./dir/subdir", false, true);
         assert_eq!(split.base, PathBuf::from("/src/from"));
         assert_eq!(split.path, PathBuf::from("/src/from/dir/subdir"));
         assert!(!split.recurse);
@@ -772,7 +888,7 @@ mod tests {
         // anchor directory itself, with the relative name collapsing to `.`,
         // and is always recursed into.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "from/./", true);
+        let split = split_files_from_entry(&base, "from/./", true, true);
         assert_eq!(split.base, PathBuf::from("/src/from"));
         assert_eq!(split.path, PathBuf::from("/src/from"));
         assert!(split.recurse);
@@ -788,7 +904,7 @@ mod tests {
         let sanitized = crate::sanitize_path::sanitize_path_keep_dot_dirs("from/./");
         assert_eq!(sanitized, "from/.");
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, &sanitized, true);
+        let split = split_files_from_entry(&base, &sanitized, true, true);
         assert_eq!(split.base, PathBuf::from("/src/from"));
         assert_eq!(split.path, PathBuf::from("/src/from"));
         assert!(split.recurse);
@@ -801,7 +917,7 @@ mod tests {
         // the named directory even though `--files-from` clears the global
         // `-r` flag.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "from/./dir/subdir/subsubdir2", true);
+        let split = split_files_from_entry(&base, "from/./dir/subdir/subsubdir2", true, true);
         assert_eq!(split.base, PathBuf::from("/src/from"));
         assert_eq!(split.path, PathBuf::from("/src/from/dir/subdir/subsubdir2"));
         assert!(split.recurse);
@@ -811,7 +927,7 @@ mod tests {
     fn split_files_from_entry_collapses_redundant_separator_slashes() {
         // `dir/././sub` should behave like `dir/./sub`: head is `dir`, rest is `sub`.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "dir/././sub", false);
+        let split = split_files_from_entry(&base, "dir/././sub", false, true);
         assert_eq!(split.base, PathBuf::from("/src/dir"));
         // The second `./` is part of `rest` and joins as `./sub`; PathBuf
         // join keeps it as a no-op fs component.
@@ -834,7 +950,7 @@ mod tests {
         // upstream: flist.c:2368 - `implied_dot_dir` only trips on a leading
         // `./`; a plain relative name never emits the transfer-root `.`.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "dir/file.txt", false);
+        let split = split_files_from_entry(&base, "dir/file.txt", false, true);
         assert!(!split.implied_dot);
     }
 
@@ -844,7 +960,7 @@ mod tests {
         // leading `./foo` files-from line (no embedded `/./`) marks the entry
         // so `--relative` mode emits a single FLAG_IMPLIED_DIR root `.`.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "./foo/bar", false);
+        let split = split_files_from_entry(&base, "./foo/bar", false, true);
         assert!(split.implied_dot);
     }
 
@@ -852,8 +968,8 @@ mod tests {
     fn split_files_from_entry_bare_dot_forms_are_not_implied_dot() {
         // A bare `.` or `./` (upstream `fn[2]` is NUL) never sets the flag.
         let base = PathBuf::from("/src");
-        assert!(!split_files_from_entry(&base, ".", false).implied_dot);
-        assert!(!split_files_from_entry(&base, "./", true).implied_dot);
+        assert!(!split_files_from_entry(&base, ".", false, true).implied_dot);
+        assert!(!split_files_from_entry(&base, "./", true, true).implied_dot);
     }
 
     #[test]
@@ -862,7 +978,7 @@ mod tests {
         // suffix; `dir/././sub` leaves `rest == "./sub"`, which still trips
         // `implied_dot_dir`.
         let base = PathBuf::from("/src");
-        let split = split_files_from_entry(&base, "dir/././sub", false);
+        let split = split_files_from_entry(&base, "dir/././sub", false, true);
         assert!(split.implied_dot);
     }
 }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2764,10 +2764,20 @@ mod files_from {
 
         let result = ctx.resolve_files_from_paths(&paths, &mut reader).unwrap();
         assert_eq!(result.len(), 2);
+        // A top-level entry keeps the source argument as its walk base.
         assert_eq!(result[0].path, PathBuf::from("/src/file1.txt"));
         assert_eq!(result[0].base, PathBuf::from("/src"));
+        // upstream: flist.c:2338-2349 - the default `--files-from` mode is
+        // non-relative (relative_paths == 0), so a nested entry splits on its
+        // LAST `/`: the parent directory becomes the walk base and only the
+        // basename is transmitted (`subdir/file2.txt` -> base `/src/subdir`,
+        // wire name `file2.txt`, no implied `subdir` entry).
         assert_eq!(result[1].path, PathBuf::from("/src/subdir/file2.txt"));
-        assert_eq!(result[1].base, PathBuf::from("/src"));
+        assert_eq!(result[1].base, PathBuf::from("/src/subdir"));
+        assert_eq!(
+            result[1].path.strip_prefix(&result[1].base).unwrap(),
+            Path::new("file2.txt")
+        );
     }
 
     #[test]
@@ -2882,6 +2892,13 @@ mod files_from {
         let handshake = test_handshake();
         let mut config = test_config();
         config.args = vec![OsString::from(&src)];
+        // A nested wire-relative name (`subdir/file.txt`) only implies its
+        // parent directory in relative mode. upstream: options.c:2207-2208 -
+        // `if (!relative_paths) implied_dirs = 0;`, so non-relative --files-from
+        // flattens each entry to its basename (flist.c:2338-2349) and emits no
+        // implied parents. This test exercises the implied-parent path, so it
+        // must run in relative mode.
+        config.flags.relative = true;
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
         let file_paths = vec![src.join("hello.txt"), src.join("subdir/file.txt")];
@@ -3366,6 +3383,60 @@ mod files_from {
             (true, true),
             "proto 32 forces implied parents on despite --no-implied-dirs"
         );
+    }
+
+    #[test]
+    fn files_from_no_relative_flattens_and_omits_implied_parents() {
+        // Task #292: under --no-relative (relative_paths == 0) upstream splits
+        // each --files-from entry on its LAST `/` (flist.c:2338-2349) so the
+        // transmitted name is the basename, and forces `implied_dirs = 0`
+        // (options.c:2207-2208) so NO implied parent directories are sent. For
+        // entry `sub/file` the sender emits only `file`, never `sub` or
+        // `sub/file`. oc previously emitted the intermediate `sub` dir (and the
+        // un-flattened `sub/file`), which an upstream receiver rejects as an
+        // unrequested file-list name (exit 4). This must hold at every protocol,
+        // including proto >= 30 where the flist.c:2257-2258 force-on is itself
+        // gated on relative_paths.
+        fn wire_names(protocol: u8) -> Vec<String> {
+            let temp_dir = TempDir::new().unwrap();
+            let src = temp_dir.path().join("src");
+            let leaf = src.join("sub");
+            std::fs::create_dir_all(&leaf).unwrap();
+            std::fs::write(leaf.join("file"), b"x").unwrap();
+
+            let handshake = test_handshake_with_protocol(protocol);
+            let mut config = test_config();
+            config.flags.relative = false;
+            config.flags.no_implied_dirs = false;
+            config.args = vec![OsString::from(&src)];
+            let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+            // Build the entry through the real non-relative split so the walk
+            // base absorbs `sub` and the wire name flattens to `file`.
+            let entry = super::filters::split_files_from_entry(&src, "sub/file", false, false);
+            ctx.build_file_list_with_base(&src, &[entry]).unwrap();
+
+            ctx.file_list()
+                .iter()
+                .map(|e| String::from_utf8_lossy(&e.name_bytes()).into_owned())
+                .collect()
+        }
+
+        for protocol in [28u8, 29, 30, 32] {
+            let names = wire_names(protocol);
+            assert!(
+                names.iter().any(|n| n == "file"),
+                "proto {protocol}: --no-relative must send flattened basename `file`: {names:?}"
+            );
+            assert!(
+                !names.iter().any(|n| n == "sub"),
+                "proto {protocol}: --no-relative must NOT emit implied parent `sub`: {names:?}"
+            );
+            assert!(
+                !names.iter().any(|n| n == "sub/file"),
+                "proto {protocol}: --no-relative must FLATTEN, not send `sub/file`: {names:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/transfer/tests/uts_files_from_ssh_push_relative.rs
+++ b/crates/transfer/tests/uts_files_from_ssh_push_relative.rs
@@ -156,7 +156,16 @@ fn ssh_push_files_from_emits_relative_wire_names() {
     let mut saw_foobar = false;
 
     for entry in file_list {
-        let name = entry.name();
+        // Compare against the wire-format name, not the `name()` accessor: the
+        // latter returns the raw `PathBuf` string, which carries the native `\`
+        // separator on Windows (the implied-parent loop builds names via
+        // `PathBuf::push`). The wire bytes are always `/`-separated
+        // (`FileEntry::name_bytes()` -> `wire_path::path_bytes_to_wire`,
+        // upstream flist.c:534-570 emits `/` verbatim), so the assertions must
+        // use that platform-independent representation.
+        let name_bytes = entry.name_bytes();
+        let name = String::from_utf8_lossy(&name_bytes);
+        let name: &str = &name;
         assert!(
             !name.starts_with('/'),
             "wire-side name must be relative, got absolute path: {name:?}"


### PR DESCRIPTION
## Problem

A `--files-from --no-relative` pull over the wire failed against a real upstream rsync. With oc-rsync acting as the SSH server-sender, an upstream 3.4.4 client aborted the transfer (exit != 0, hang) instead of receiving the flattened file.

Root cause was three stacked divergences from upstream 3.4.4, all specific to `--no-relative` + `--files-from`:

1. **Server arg parser dropped `--no-relative`.** `server_options()` sends the long `--no-relative` (no compact `R`) when relative paths are off (options.c:368-369). The oc server long-option parser had no case for it, so `--no-relative` fell through to the positional list and the sender used it as the transfer root — `link_stat "--no-relative/sub/file" failed`.

2. **Sender did not flatten.** Upstream splits each `--files-from` entry on its LAST `/` when `relative_paths == 0` (flist.c:2338-2349), transmitting only the basename and emitting no implied parent directories (`implied_dirs` is forced to 0, options.c:2207-2208). oc kept the source argument as the walk base (`sub/file`) and emitted the intermediate `sub` directory, which an upstream receiver rejects as an unrequested file-list name.

3. **Client forced `-R`.** The remote-invocation builder packed the compact `R` letter whenever `--files-from` was active (`relative_paths() || files_from_active`), so an explicit `--no-relative` pull still advertised relative mode. `relative_paths()` already folds in the `--files-from` default at the CLI layer, so the `|| files_from_active` term was both redundant (default case) and wrong (`--no-relative` case). Now `-R` follows the resolved value and `--no-relative` is forwarded when the peer reads the list.

## Changes

- `transfer/generator/file_list/mod.rs` — gate the `--files-from` implied-parent loop on relative mode, mirroring the positional path and options.c:2207-2208.
- `transfer/generator/filters.rs` — `split_files_from_entry` takes `relative_paths`; under `--no-relative` it splits on the last `/` (flist.c:2338-2349), flattening entries to their basename. Trailing-slash directory entries flatten their contents into the transfer root (flist.c:2312-2322 DOTDIR split).
- `cli/frontend/server/flags.rs` + `parse.rs` — recognise `--no-relative` / `--no-R` / `--relative` in both the long-flag scanner and the positional extractor; apply to `flags.relative`.
- `core/client/remote/invocation/builder.rs` — gate `-R` on the resolved `relative_paths()` and emit `--no-relative` when the remote reads the `--files-from` list and relative paths are off.

Regression tests added in all four areas, each citing the upstream source.

## Verification

Sealed on Linux (aarch64) against upstream rsync 3.4.4 over SSH, pulling a `sub/file` entry with `-a --no-relative --files-from`, `diff -r` vs an upstream-to-upstream reference:

| Case | Direction | Result | dst |
|------|-----------|--------|-----|
| Reference | upstream client to upstream server | exit 0 | `file` |
| A | upstream client to oc server (the bug) | exit 0, identical | `file` |
| B | oc client to upstream server | exit 0, identical | `file` |
| C | oc client to oc server | exit 0, identical | `file` |
| D (regression) | default (no `--no-relative`), upstream client to oc server | exit 0, identical | `sub/file` |
| E (regression) | default, oc client to oc server | exit 0, identical | `sub/file` |

`cargo fmt --all --check`, `cargo clippy -p transfer -p cli -p core --all-features -- -D warnings`, and `cargo check --target x86_64-pc-windows-gnu -p transfer -p cli -p core` all pass.

## Known pre-existing limitation (out of scope, not a regression)

A `--files-from --no-relative` PUSH (oc as client-sender over SSH) does not flatten (`sub/file` reaches the receiver). This reproduces identically on master, is a separate mechanism (the client-side sender file-list resolution over SSH, plus a duplicated `relative_paths() || files_from_active` in `core/client/remote/flags.rs`), and is left for a dedicated follow-up. The PULL server-sender path targeted here is fully fixed.
