### PR TITLE
docs(transfer): fix unresolved FnameCmpType intra-doc links (Pages rustdoc)

### DIFF
--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -33,8 +33,8 @@ pub struct BasisFileResult {
     /// Which basis the generator selected, sent to the sender as the
     /// `fnamecmp_type` byte behind `ITEM_BASIS_TYPE_FOLLOWS`.
     ///
-    /// [`FnameCmpType::Fname`] for the ordinary destination basis (no wire byte)
-    /// and [`FnameCmpType::PartialDir`] (`0x81`) when the basis was recovered
+    /// [`protocol::FnameCmpType::Fname`] for the ordinary destination basis (no wire byte)
+    /// and [`protocol::FnameCmpType::PartialDir`] (`0x81`) when the basis was recovered
     /// from `--partial-dir` on a resume. upstream: generator.c:1759-1765,1853.
     pub fnamecmp_type: protocol::FnameCmpType,
 }


### PR DESCRIPTION
The rustdoc build (Pages workflow) has been red on master because `crates/transfer/src/receiver/basis.rs` has two intra-doc links to `FnameCmpType` that omit the `protocol::` prefix. The type is not imported into that module, so rustdoc's `broken_intra_doc_links` (deny) fails with 'no item named FnameCmpType in scope' and aborts with 'could not document transfer'.

Fix: qualify both as `protocol::FnameCmpType::Fname` / `protocol::FnameCmpType::PartialDir`, matching the file's existing convention (`protocol::CompatibilityFlags::*`, `protocol::effective_s2length` on lines 85/87, which resolve fine).

Non-required Pages workflow only; no code or behavior change. Verified the two error paths are the sole rustdoc errors in the failing log.