### PR TITLE
style(daemon): pre-empt clippy::manual_ok_err in charset parser

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/module_directives.rs
@@ -56,18 +56,16 @@ fn resolve_module_charset_converter(charset: Option<&str>) -> Option<FilenameCon
         return Some(FilenameConverter::identity());
     }
 
-    match FilenameConverter::new(local_part, "UTF-8") {
-        Ok(converter) => Some(converter),
-        Err(_error) => {
+    FilenameConverter::new(local_part, "UTF-8")
+        .inspect_err(|_error| {
             #[cfg(feature = "tracing")]
             tracing::warn!(
                 charset = %local_part,
                 error = %_error,
                 "module 'charset' directive: unsupported encoding; daemon will not transcode filenames",
             );
-            None
-        }
-    }
+        })
+        .ok()
 }
 
 /// Parses the module's `incoming chmod` / `outgoing chmod` directives into the


### PR DESCRIPTION
The daemon module 'charset' directive parser maps `FilenameConverter::new` via a hand-written `match { Ok(v) => Some(v), Err(_) => { warn; None } }`. The Err arm's only effect is a `#[cfg(feature = "tracing")]`-gated `warn!`; in the default (tracing-off) build the arm collapses to bare `None`, which a newer clippy flags as `manual_ok_err` under `-D warnings`.

Pinned 1.88.0 clippy does not flag it, so master fmt+clippy stays green today, but this is a latent CI trip-wire on a toolchain bump (verified: stable 1.94 fires `manual_ok_err` at module_directives.rs:59).

Rewrite as `inspect_err(...).ok()`, preserving the tracing warn and the exact Result to Option mapping. Behavior is byte-identical in both feature configs. Verified with clippy on 1.88.0 (clean) and 1.94.0 (lint gone) for `--all-features` and `--no-default-features`.