### PR TITLE
fix(cli): strip clap's stock error: header from usage diagnostics

### DIFF
--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -345,11 +345,12 @@ where
         }
         Err(error) => {
             let code = clap_parse_error_exit_code(&error);
-            let mut message = strings::exit_code_message_with_detail(code, error.to_string())
-                .unwrap_or_else(|| rsync_error!(code, "{}", error));
+            let detail = clap_error_detail(&error);
+            let mut message = strings::exit_code_message_with_detail(code, detail.as_str())
+                .unwrap_or_else(|| rsync_error!(code, "{}", detail));
             message = message.with_role(Role::Client);
             if write_message(&message, &mut stderr_sink).is_err() {
-                let _ = writeln!(stderr_sink.writer_mut(), "{error}");
+                let _ = writeln!(stderr_sink.writer_mut(), "{detail}");
             }
             code
         }
@@ -378,6 +379,25 @@ where
 /// validated inside the `clap` value flow (unlike `--compress-choice`, which is
 /// validated later in the pipeline where the message code survives), so its
 /// intended exit code is reconstructed here from the diagnostic text we emit.
+/// Renders a `clap` parse failure into the detail text used to compose an
+/// rsync-style diagnostic, stripping clap's own leading `error: ` header.
+///
+/// `clap::Error`'s `Display` prepends a stock `error: ` prefix to every
+/// message. oc then wraps the detail with the canonical `rerr_names` category
+/// (e.g. `syntax or usage error: `), so leaving clap's prefix in place doubles
+/// the wording into `syntax or usage error: error: ...`. Upstream rsync emits
+/// the category exactly once, so the redundant clap header is removed here at
+/// the single rendering site. The match is intentionally exact and
+/// case-sensitive: clap is built without the `color` feature, so the header is
+/// always the literal `error: ` with no ANSI styling.
+fn clap_error_detail(error: &clap::Error) -> String {
+    let rendered = error.to_string();
+    match rendered.strip_prefix("error: ") {
+        Some(stripped) => stripped.to_owned(),
+        None => rendered,
+    }
+}
+
 fn clap_parse_error_exit_code(error: &clap::Error) -> i32 {
     if error.kind() == clap::error::ErrorKind::ValueValidation
         && error.to_string().contains("--checksum-choice")

--- a/crates/cli/src/frontend/tests/run.rs
+++ b/crates/cli/src/frontend/tests/run.rs
@@ -41,6 +41,40 @@ fn clap_error_uses_canonical_exit_code_text() {
 }
 
 #[test]
+fn clap_value_error_does_not_double_error_prefix() {
+    // A clap value-validation failure (here `--block-size`) surfaces through
+    // `clap::Error::to_string()`, which prepends a stock `error: ` header. oc
+    // wraps the detail with the canonical `syntax or usage error: ` category
+    // (upstream `rerr_names`), so an unstripped clap header would render the
+    // wording twice as `syntax or usage error: error: ...`. Upstream rsync
+    // prints the category exactly once; this guards that parity.
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(OC_RSYNC),
+        OsString::from("--block-size=abc"),
+        OsString::from("src"),
+        OsString::from("dst"),
+    ]);
+
+    // RERR_SYNTAX (1) must be preserved; only the wording changes.
+    assert_eq!(code, 1);
+
+    let rendered = String::from_utf8(stderr).expect("diagnostic utf8");
+    assert!(
+        rendered.contains("syntax or usage error"),
+        "diagnostic should keep the canonical rerr_names category"
+    );
+    assert!(
+        rendered.contains("invalid --block-size value 'abc'"),
+        "diagnostic should include the clap-provided detail"
+    );
+    assert!(
+        !rendered.contains("syntax or usage error: error:"),
+        "clap's stock `error: ` header must not double the category prefix"
+    );
+    assert_contains_client_trailer(&rendered);
+}
+
+#[test]
 fn run_without_operands_emits_usage_for_oc_rsync() {
     let (code, stdout, stderr) = run_with_args([OsString::from(OC_RSYNC)]);
 


### PR DESCRIPTION
## Problem

When the CLI surfaces a clap parse failure, the rendered line doubled the `error:` wording, e.g.:

```
oc-rsync error: syntax or usage error: error: invalid --block-size value 'abc': must be a positive integer
oc-rsync error: requested action not supported: error: invalid --checksum-choice value 'bogus': unsupported checksum
```

## Root cause

`clap::Error`'s `Display` prepends a stock `error: ` header to every message. The CLI then wraps that detail with the canonical `rerr_names` category (`syntax or usage error: ` / `requested action not supported: `), stacking clap's header on top and rendering the wording twice. Upstream rsync emits the category exactly once.

## Fix

Strip the leading `error: ` at the single clap-error rendering chokepoint (`crates/cli/src/frontend/mod.rs`) before composing the diagnostic, via a small `clap_error_detail` helper alongside `clap_parse_error_exit_code`. clap is built without the `color` feature, so the header is always the literal `error: ` with no ANSI styling, making the exact case-sensitive match safe.

Before / after:

```
- oc-rsync error: syntax or usage error: error: invalid --block-size value 'abc': must be a positive integer
+ oc-rsync error: syntax or usage error: invalid --block-size value 'abc': must be a positive integer
```

Exit codes are untouched: the helper only rewrites the detail string, not the `clap::Error` passed to the exit-code mapper. `--block-size` stays `RERR_SYNTAX` (1); `--checksum-choice` stays `RERR_UNSUPPORTED` (4). Unknown options already bypass clap via `extract_operands` and were unaffected.

## Tests

Added `clap_value_error_does_not_double_error_prefix` asserting the rendered line keeps the category once, includes the clap detail, never contains `syntax or usage error: error:`, and preserves the RERR_SYNTAX exit code.

rustfmt (`--edition 2024 --check`) and `clippy -p cli --all-targets --all-features -- -D warnings` both clean.