### PR TITLE
fix(transfer): scan only content dirs in --delete pass

### DIFF
--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -203,16 +203,26 @@ impl ReceiverContext {
         // match NFC names from the sender's file list.
         let mut dir_children: HashMap<PathBuf, HashSet<std::ffi::OsString>> = HashMap::new();
 
-        // upstream: generator.c:do_delete_pass() (and the delete-during loop at
-        // generator.c:2317) call delete_in_dir() for a flist directory ONLY when
-        // it carries FLAG_CONTENT_DIR - a directory the sender actually recursed
-        // into. The transfer root "." is a content dir for a recursive transfer
-        // but not for --files-from, where the root is sent as an implied dir
-        // (XMIT_NO_CONTENT_DIR, so the received entry's content_dir() is false).
-        // Register "." as a scan target only when the received root is a content
-        // dir; scanning it unconditionally deletes top-level destination entries
-        // that upstream preserves under --files-from.
+        // upstream: generator.c:do_delete_pass() (376), recv_generator (1534),
+        // and the inc-recurse delete-during loop (2317) all call delete_in_dir()
+        // for a flist directory ONLY when it carries FLAG_CONTENT_DIR - a
+        // directory the sender actually recursed into. A non-content dir gets
+        // change_local_filter_dir() instead and is never scanned for deletion.
+        // The transfer root "." is a content dir for a recursive transfer but
+        // not for --files-from, where the root is sent as an implied dir
+        // (flist.c:2419 send_file_name(".", ... & ~FLAG_CONTENT_DIR), decoded as
+        // content_dir() == false). Likewise every implied parent dir created
+        // under --files-from / --relative clears FLAG_CONTENT_DIR
+        // (flist.c:1949). Only content dirs are scan targets; scanning an
+        // implied dir would delete a stale destination file inside it that
+        // upstream preserves (DATA-LOSS).
+        //
+        // `content_dirs` records exactly which file-list directories carry the
+        // flag, so `dirs_to_scan` can be filtered to them below. The keep-set
+        // map (`dir_children`) is still built for every parent - it only decides
+        // which children survive a scan, not whether the parent is scanned.
         let mut root_is_content_dir = false;
+        let mut content_dirs: HashSet<PathBuf> = HashSet::new();
 
         for entry in &self.file_list {
             let relative = entry.path();
@@ -241,20 +251,24 @@ impl ReceiverContext {
 
             // upstream: generator.c:delete_in_dir() runs for EVERY content
             // directory in the file list, regardless of whether any of that
-            // directory's source children are visible in the flist. A
+            // directory's source children are visible in the flist. A content
             // directory whose source children are all filter-hidden (e.g.
             // `--filter='hide,! */'`) must still be scanned so its extraneous
             // destination entries are removed; keying the scan set solely off
             // parents-with-a-visible-child leaves those entries undeleted.
-            // Register every directory in the file list as its own scan target
-            // with a (possibly empty) keep-set. Protection of entries that must
-            // survive is the responsibility of the per-candidate
+            // Register every content directory as its own scan target with a
+            // (possibly empty) keep-set. An implied (non-content) directory is
+            // NOT a scan target - upstream skips its delete_in_dir() entirely -
+            // so it is deliberately excluded here and filtered out of
+            // `dirs_to_scan` below. Protection of entries that must survive a
+            // scanned dir is the responsibility of the per-candidate
             // `allows_deletion` check below - which consults the per-directory
             // merge chain when one is reloaded for the directory, and otherwise
             // the flat global chain (complete when no per-dir merges exist) -
             // not of pruning the scan set.
-            if entry.is_dir() {
+            if entry.is_dir() && entry.content_dir() {
                 dir_children.entry(relative.to_path_buf()).or_default();
+                content_dirs.insert(relative.to_path_buf());
             }
         }
 
@@ -268,6 +282,7 @@ impl ReceiverContext {
         // with a (possibly empty) keep-set only in the content-dir case.
         if root_is_content_dir {
             dir_children.entry(PathBuf::from(".")).or_default();
+            content_dirs.insert(PathBuf::from("."));
         }
 
         // Sort the scan set so directory processing is deterministic across
@@ -276,7 +291,19 @@ impl ReceiverContext {
         // The final emission order is re-derived from the deleted set in
         // `order_deletions_upstream`; sorting here keeps the scan/unlink work
         // itself reproducible without serializing it.
-        let mut dirs_to_scan: Vec<PathBuf> = dir_children.keys().cloned().collect();
+        // Restrict the scan set to content directories. The keep-set map keys
+        // also include implied parent directories inferred from a visible
+        // child (e.g. `subdir` for a `--files-from` entry `subdir/file`), which
+        // upstream never scans for deletion (FLAG_CONTENT_DIR is clear). Scanning
+        // one would delete a stale destination file inside the implied dir that
+        // upstream preserves (DATA-LOSS). Filtering by `content_dirs` keeps the
+        // scan targets exactly the directories whose received entry carries
+        // FLAG_CONTENT_DIR, matching the generator.c:376/1534/2317 gate.
+        let mut dirs_to_scan: Vec<PathBuf> = dir_children
+            .keys()
+            .filter(|dir| content_dirs.contains(*dir))
+            .cloned()
+            .collect();
         dirs_to_scan.sort_unstable();
         logging::debug_log!(
             Del,

--- a/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
@@ -164,6 +164,83 @@ fn single_char_wildcard_exclude_does_not_block_top_level_deletion() {
     assert_eq!(stats.files, 1);
 }
 
+/// #295 DATA-LOSS regression: an implied (non-content) subdirectory under
+/// `--files-from` / `--relative` must NOT be scanned for deletion, so a stale
+/// destination file inside it survives - exactly as upstream preserves it.
+///
+/// Upstream only calls `generator.c:delete_in_dir()` for a file-list directory
+/// that carries `FLAG_CONTENT_DIR` (generator.c:376, 1534, 2317). An implied
+/// parent dir created to hold a `--files-from` entry has that flag cleared
+/// (`flist.c:1949 flags & ~FLAG_CONTENT_DIR`), so it is never a delete-scan
+/// target and its extraneous contents are left in place. Registering every
+/// file-list directory as a scan target (keying it off the parent-of-a-visible
+/// child) deleted `subdir/stale.txt` here, which upstream keeps - a silent
+/// data loss. The content-dir gate on `dirs_to_scan` restores parity.
+///
+/// The sibling content-dir case (`FileEntry::new_directory` defaults
+/// `content_dir() == true`) is covered by
+/// `delete_ordinary_subdir_succeeds_with_no_io_error`, which still deletes the
+/// extraneous child - proving the gate does not over-suppress real recursion
+/// targets.
+#[test]
+fn implied_non_content_subdir_is_not_scanned_for_deletion() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    // The `--files-from` entry `subdir/file` was transferred; `stale.txt` is a
+    // pre-existing destination file inside the implied subdir.
+    let subdir = dest.join("subdir");
+    std::fs::create_dir(&subdir).unwrap();
+    std::fs::write(subdir.join("file"), b"from sender").unwrap();
+    std::fs::write(subdir.join("stale.txt"), b"pre-existing").unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = true;
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    // Mirror the wire flist for `--files-from subdir/file`: the root `.` and
+    // the parent `subdir` are implied dirs (FLAG_CONTENT_DIR clear); only
+    // `subdir/file` is an actual transferred entry.
+    let mut root = FileEntry::new_directory(".".into(), 0o755);
+    root.set_content_dir(false);
+    ctx.file_list.push(root);
+    let mut implied = FileEntry::new_directory("subdir".into(), 0o755);
+    implied.set_content_dir(false);
+    ctx.file_list.push(implied);
+    ctx.file_list
+        .push(FileEntry::new_file("subdir/file".into(), 11, 0o644));
+
+    let mut writer = TestDeletionWriter;
+    let (stats, _, _) = ctx
+        .delete_extraneous_files(
+            dest,
+            #[cfg(unix)]
+            None,
+            &mut writer,
+        )
+        .unwrap();
+
+    // The stale file in the implied subdir must survive - upstream never scans
+    // a non-content dir for deletion.
+    assert!(
+        subdir.join("stale.txt").exists(),
+        "stale.txt in an implied (non-content) subdir must be preserved"
+    );
+    assert!(
+        subdir.join("file").exists(),
+        "the transferred file must survive"
+    );
+    assert_eq!(
+        stats.total(),
+        0,
+        "no deletions should occur when the only dirs are implied (non-content)"
+    );
+}
+
 #[test]
 fn receiver_set_and_get_filter_chain() {
     let handshake = test_handshake();


### PR DESCRIPTION
## Problem (DATA-LOSS)

The receiver `--delete` pass registered **every** file-list directory as a delete-scan target, keyed off any directory that had a visible child in the flist. Upstream only scans a directory for deletion when its received entry carries `FLAG_CONTENT_DIR` — a directory the sender actually recursed into:

- `generator.c:376` (`do_delete_pass`)
- `generator.c:1534` (`recv_generator`, non-inc)
- `generator.c:2317` (inc-recurse delete-during loop)

An implied parent directory created to hold a `--files-from` / `--relative` entry has that flag **cleared** (`flist.c:1949`: `flags & ~FLAG_CONTENT_DIR`) and receives `change_local_filter_dir()` instead of `delete_in_dir()`.

Because oc's scan set was derived from the parents-of-visible-children map, an implied non-root subdir (e.g. `subdir` for a `--files-from` entry `subdir/file`) was scanned, and a pre-existing **stale destination file** inside it was **deleted** — where upstream preserves it. This is the subdir sibling of the root `.` gating already applied to the transfer root.

## Fix

Record which file-list directories carry `FLAG_CONTENT_DIR` (via `content_dir()`) alongside the existing root gate, and restrict `dirs_to_scan` to those. The keep-set map is still built for every parent so a scanned content dir knows which children to preserve; only the scan-target set is gated. This reuses the same `content_dir()` predicate the root gate uses — one source of truth for "is this a delete-scan target." Receiver-only change.

## Empirical seal (Linux aarch64 vs rsync 3.4.4)

Scenario: `--files-from` listing `subdir/file` + `--delete`, with a pre-existing stale `subdir/stale.txt` at the destination. The stale file must survive.

| Direction | Who deletes | stale.txt |
|---|---|---|
| upstream local (reference) | upstream | preserved |
| oc local | oc receiver | preserved |
| upstream client → oc server (SSH) | oc receiver | preserved |
| oc client ← upstream server (SSH pull) | oc receiver (upstream flist) | preserved |

Every direction where the sender's flist correctly clears `FLAG_CONTENT_DIR` now preserves the stale file on an oc receiver, byte-matching the upstream-local reference.

### Known follow-up (out of scope, owned by the sender file_list PR)

`oc client → upstream server` (upstream is the receiver) still deletes the stale file, because oc's **wire sender** emits `FLAG_CONTENT_DIR` on the implied `subdir`. This is the sender-side counterpart in `crates/transfer/src/generator/` file_list, not touched here. Confirmed by isolation: oc→oc **local** preserves (correct local flist), while oc→oc **over SSH** deletes (wire flist marks the implied dir as content). Tracked separately.

## Tests

New regression test `implied_non_content_subdir_is_not_scanned_for_deletion` (fails before, passes after). The sibling content-dir case (`delete_ordinary_subdir_succeeds_with_no_io_error`) still deletes the extraneous child, proving the gate does not over-suppress real recursion targets.

rustfmt (`--edition 2024`) clean; clippy `-p transfer --all-features -D warnings` clean; targeted nextest 4/4 pass.