### PR TITLE
feat(transfer): support --only-write-batch on server receiver

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -240,6 +240,16 @@ pub(super) struct ServerLongFlags {
     /// is a listing. The receiver renders the flist without writing to the
     /// destination.
     pub(super) list_only: bool,
+    /// Whether the client forwarded `--only-write-batch=X` (upstream
+    /// `write_batch = -1`). Emitted only in the `am_sender` block, so it
+    /// reaches this process only when it is the server receiver on a push.
+    ///
+    /// upstream: options.c:2850-2851 - `if (write_batch < 0) args[ac++] =
+    /// "--only-write-batch=X"`. On the receiver, main.c:1839 forces
+    /// `dry_run = 1` (no destination writes) while `do_xfers` stays 1 so the
+    /// generator still sends real block checksums; the push sender records the
+    /// batch locally (sender.c:217) and streams no delta data over the wire.
+    pub(super) only_write_batch: bool,
 
     /// Whether the client forwarded `--no-implied-dirs` (upstream
     /// `implied_dirs == 0`).
@@ -353,6 +363,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         delay_updates: false,
         mkpath: false,
         list_only: false,
+        only_write_batch: false,
         no_implied_dirs: false,
         no_recurse: false,
         no_whole_file: false,
@@ -668,6 +679,14 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.compression_level = Some(value.to_owned());
     // upstream: options.c:2750-2762 - client forwards --log-format=%i (or %o,
     // %i%I, X) so the server knows whether to generate itemize data.
+    } else if s.strip_prefix("--only-write-batch=").is_some() {
+        // upstream: options.c:2850-2851 - server_options() always emits the
+        // literal `--only-write-batch=X` placeholder (the real batch path
+        // lives on the client). The value carries no server-side meaning; we
+        // only latch the flag so run_server_mode forces the receiver into
+        // dry-run-with-real-checksums mode instead of leaking the token into
+        // the positional destination list.
+        flags.only_write_batch = true;
     } else if let Some(value) = s.strip_prefix("--log-format=") {
         flags.log_format = Some(value.to_owned());
     // upstream: options.c:2928-2931 - server_options() forwards info levels.
@@ -798,6 +817,10 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--log-format=")
         || arg.starts_with("--info=")
         || arg.starts_with("--partial-dir=")
+        // upstream: options.c:2850-2851 - `--only-write-batch=X` reaches a
+        // server receiver on a push. Recognise it so the placeholder token is
+        // not mistaken for a positional destination path.
+        || arg.starts_with("--only-write-batch=")
 }
 
 /// Returns `true` when the argument is a bare server-mode long flag whose

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -267,6 +267,19 @@ where
     // by the client tells the server to render the flist without writing to the
     // destination (`TransferFlags::skip_dest_writes`).
     config.flags.list_only = long_flags.list_only;
+    // upstream: options.c:2850-2851 / main.c:1839 - a push sender forwards
+    // `--only-write-batch=X`; on the receiver, `write_batch < 0` forces
+    // `dry_run = 1` (no destination writes) while `do_xfers` stays 1 so the
+    // generator still sends real block checksums. The client records the batch
+    // locally and streams no delta data over the wire (sender.c:217), so the
+    // receiver runs the dedicated only-write-batch loop: send sum heads, read
+    // the bare NDX+attrs echo, write nothing to the destination. Only the
+    // receiver role ever sees this flag - server_options() emits it inside the
+    // am_sender block, so a pull sender-server never receives it.
+    if long_flags.only_write_batch && role == ServerRole::Receiver {
+        config.flags.only_write_batch = true;
+        config.flags.dry_run = true;
+    }
     // upstream: options.c:2046-2048 - do_stats sets info_levels[INFO_STATS] >= 2.
     // The server-side flag must be set so the generator emits NDX_DEL_STATS
     // during the goodbye phase (generator.c:2377,2422).

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -471,6 +471,43 @@ fn long_flags_captures_joined_partial_dir() {
     assert!(!flags.delay_updates);
 }
 
+/// Regression for the `--only-write-batch=X` server arg (task #296). Upstream
+/// `server_options()` (options.c:2850-2851) emits the literal placeholder
+/// `--only-write-batch=X` to a push receiver. Before recognition it leaked into
+/// the positional list and the receiver tried to create a destination root
+/// literally named `--only-write-batch=X` (exit 12). It must be captured as a
+/// flag instead.
+#[test]
+fn parse_server_args_skips_only_write_batch_flag() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpre.iLsfxCIvu"),
+        OsString::from("--only-write-batch=X"),
+        OsString::from("."),
+        OsString::from("dest/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpre.iLsfxCIvu");
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("dest/")],
+        "--only-write-batch=X must not leak into the positional path list",
+    );
+    assert!(is_known_server_long_flag("--only-write-batch=X"));
+}
+
+/// `parse_server_long_flags` records `--only-write-batch=X` as
+/// `only_write_batch == true`.
+#[test]
+fn long_flags_captures_only_write_batch() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--only-write-batch=X"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert!(flags.only_write_batch);
+}
+
 #[test]
 fn long_flags_defaults() {
     let args: Vec<OsString> = vec![OsString::from("--server")];
@@ -482,6 +519,7 @@ fn long_flags_defaults() {
     assert!(!flags.write_devices);
     assert!(!flags.trust_sender);
     assert!(!flags.qsort);
+    assert!(!flags.only_write_batch);
     assert!(flags.checksum_seed.is_none());
     assert!(flags.checksum_choice.is_none());
     assert!(flags.min_size.is_none());

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -152,6 +152,27 @@ pub struct ParsedServerFlags {
     /// - `options.c:2194` - `list_only` global / implied-list-only derivation
     /// - `generator.c:1249` - `list_file_entry()` render gate
     pub list_only: bool,
+    /// Only-write-batch mode on a server receiver (`--only-write-batch=X`).
+    ///
+    /// The push client records the batch locally and writes each file's delta
+    /// to its own batch fd, not the wire (upstream sender.c:217 `f_xfer =
+    /// write_batch < 0 ? batch_fd : f_out`), so the server receiver reads no
+    /// delta data off the wire. It must still send REAL block checksums,
+    /// because upstream forces `dry_run = 1` only AFTER `do_xfers` is computed
+    /// (main.c:1839), leaving `do_xfers = 1` so the generator emits sum heads
+    /// the sender needs to build a correct batch. Implies [`dry_run`] (no
+    /// destination writes) but diverges from it by sending sum heads instead
+    /// of the bare NDX echo.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:1673` - `OPT_ONLY_WRITE_BATCH` sets `write_batch = -1`
+    /// - `main.c:1839` - `if (write_batch < 0) dry_run = 1`
+    /// - `receiver.c:811-817` - `write_batch < 0` path logs the item, sends
+    ///   `send_msg_success` under inc_recurse, and writes nothing to the dest
+    ///
+    /// [`dry_run`]: Self::dry_run
+    pub only_write_batch: bool,
     /// Transfer directories without recursion (`d` flag, `--dirs`).
     pub dirs: bool,
     /// Whole file transfer, no delta (`W` flag, `--whole-file`).

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -525,4 +525,126 @@ impl ReceiverContext {
         writer.flush()?;
         Ok(())
     }
+
+    /// Server-receiver loop for `--only-write-batch=X` (upstream `write_batch
+    /// < 0`).
+    ///
+    /// Unlike [`run_dry_run_loop`](Self::run_dry_run_loop), the generator sends
+    /// REAL block checksums (a full sum head + signature per file), because
+    /// upstream forces `dry_run = 1` only after `do_xfers` is computed
+    /// (main.c:1839), so `do_xfers` stays 1 and the sender needs the checksums
+    /// to build its batch. The push sender writes each delta to its own batch
+    /// fd rather than the wire (sender.c:217 `f_xfer = write_batch < 0 ?
+    /// batch_fd : f_out`), so this loop reads only the bare NDX+attrs echo the
+    /// sender emits via `write_ndx_and_attrs(f_out, ...)` (sender.c:442) and
+    /// writes nothing to the destination.
+    ///
+    /// Requests are sent one file at a time, flushing before each echo read, so
+    /// there is no risk of a buffer-fill deadlock against a large signature.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:1839` - `if (write_batch < 0) dry_run = 1` (do_xfers stays 1)
+    /// - `sender.c:442-443` - `write_ndx_and_attrs(f_out); write_sum_head(f_xfer)`
+    /// - `receiver.c:811-817` - `write_batch < 0` path: log, no dest write
+    pub(in crate::receiver) fn run_only_write_batch_loop<
+        R: Read,
+        W: Write + crate::writer::MsgInfoSender + ?Sized,
+    >(
+        &self,
+        reader: &mut crate::reader::ServerReader<R>,
+        writer: &mut W,
+        files_to_transfer: &[(usize, &FileEntry, PathBuf, u32)],
+        setup: &PipelineSetup,
+    ) -> io::Result<()> {
+        if files_to_transfer.is_empty() {
+            writer.flush()?;
+            return Ok(());
+        }
+
+        let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
+        let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
+
+        let preserve_xattrs = self.config.flags.xattrs;
+        let want_xattr_optim = self.protocol.as_u8() >= 31
+            && self.compat_flags.is_some_and(|f| {
+                !f.contains(protocol::CompatibilityFlags::AVOID_XATTR_OPTIMIZATION)
+            });
+
+        let request_config = RequestConfig {
+            protocol: self.protocol,
+            write_iflags: self.protocol.supports_iflags(),
+            checksum_length: setup.checksum_length,
+            checksum_algorithm: setup.checksum_algorithm,
+            negotiated_algorithms: self.negotiated_algorithms.as_ref(),
+            compat_flags: self.compat_flags.as_ref(),
+            checksum_seed: self.checksum_seed,
+            use_sparse: self.config.flags.sparse,
+            do_fsync: self.config.write.fsync,
+            temp_dir: self.config.temp_dir.as_deref(),
+            write_devices: self.config.write.write_devices,
+            inplace: self.config.write.inplace,
+            inplace_partial: self.config.write.inplace_partial,
+            io_uring_policy: self.config.write.io_uring_policy,
+            io_uring_depth: self.config.write.io_uring_depth,
+            preserve_xattrs,
+            want_xattr_optim,
+            append: self.config.flags.append,
+            append_verify: self.config.flags.append_verify,
+        };
+
+        for &(file_idx, file_entry, ref file_path, _) in files_to_transfer {
+            // upstream: generator.c:1961-1969 - compute the basis signature and
+            // send a real sum head so the sender can diff against the receiver's
+            // basis (empty when no basis exists, driving a whole-file batch).
+            let basis_config = BasisFileConfig {
+                file_path,
+                dest_dir: &setup.dest_dir,
+                relative_path: file_entry.path(),
+                target_size: file_entry.size(),
+                target_mtime: file_entry.mtime(),
+                fuzzy_level: self.config.flags.fuzzy_level,
+                reference_directories: &self.config.reference_directories,
+                partial_dir: self.config.partial_dir.as_deref(),
+                protocol: self.protocol,
+                checksum_length: setup.checksum_length,
+                checksum_algorithm: setup.checksum_algorithm,
+                whole_file: self.config.flags.whole_file,
+                compat_flags: self.compat_flags,
+            };
+            let basis = find_basis_file_with_config(&basis_config);
+
+            // upstream: generator.c:1939 write_ndx + write_sum_head(f_out, s).
+            let _pending = send_file_request(
+                writer,
+                &mut ndx_write_codec,
+                self.flat_to_wire_ndx(file_idx),
+                file_path.clone(),
+                basis.signature,
+                basis.basis_path,
+                basis.fnamecmp_type,
+                file_entry.size(),
+                &request_config,
+            )?;
+
+            // Flush before blocking on the echo so the sender has the full
+            // request. It reads the sum head, writes the delta into its own
+            // batch fd, and echoes only NDX+attrs back to us.
+            writer.flush()?;
+
+            // upstream: sender.c:442 - write_ndx_and_attrs(f_out, ...) echo.
+            // No delta follows (it went to the batch fd), so we stop here and
+            // write nothing to the destination.
+            let (_echoed_ndx, _sender_attrs) =
+                crate::receiver::wire::SenderAttrs::read_with_codec_xattr(
+                    reader,
+                    &mut ndx_read_codec,
+                    preserve_xattrs,
+                    want_xattr_optim,
+                )?;
+        }
+
+        writer.flush()?;
+        Ok(())
+    }
 }

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -127,6 +127,14 @@ impl ReceiverContext {
         if self.config.flags.list_only {
             stats.list_only_entries = self.collect_list_only_entries();
             writer.flush()?;
+        } else if self.config.flags.only_write_batch {
+            // upstream: main.c:1839 `write_batch < 0` forces dry_run but leaves
+            // do_xfers = 1, so unlike a plain `-n` the generator still sends
+            // real block checksums while the receiver writes nothing to the
+            // destination and reads no delta data (the push sender records it
+            // into its own batch fd, sender.c:217). Checked before `dry_run`
+            // because only-write-batch sets both flags.
+            self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
         } else if self.config.flags.dry_run {
             self.run_dry_run_loop(reader, writer, &files_to_transfer)?;
         } else {


### PR DESCRIPTION
## Summary

Adds server-receiver support for `--only-write-batch=X` (task #296). Previously the server left the flag unrecognised, so it leaked into the positional argument list and the receiver tried to create a destination root literally named `--only-write-batch=X`, failing with exit 12.

## Upstream behaviour (rsync 3.4.4)

- `options.c:1673` — `OPT_ONLY_WRITE_BATCH` sets `write_batch = -1`.
- `options.c:2850-2851` — `server_options()` emits `--only-write-batch=X` **only inside its `am_sender` block**, so the flag reaches a server process only when that process is the **receiver** on a push. A pull sender-server never receives it (verified empirically by capturing the forwarded argv).
- `main.c:1839` — `if (write_batch < 0) dry_run = 1`, executed **after** `do_xfers` is computed in `parse_arguments`, so `do_xfers` stays `1`. The generator therefore still sends real block checksums even though the destination is never written.
- `sender.c:217` — `int f_xfer = write_batch < 0 ? batch_fd : f_out`: the push sender writes each file's sum head and delta into its own batch fd, not the wire. `sender.c:442` still sends `write_ndx_and_attrs(f_out, ...)`, so the receiver sees a bare NDX+attrs echo and **no delta data**.
- `receiver.c:811-817` — the `write_batch < 0` path logs the item, writes nothing to the destination, and (under inc_recurse) acknowledges it.

## Design

The receiver runs a dedicated loop (`run_only_write_batch_loop`) selected before the plain `dry_run` branch, since only-write-batch sets both flags:

- **Generator side**: reuses the normal `send_file_request` path (basis signature + real sum head), matching upstream's `do_xfers = 1`. A plain `-n` receiver would send only the bare NDX echo, which would hang the upstream sender waiting on `receive_sums()` — the reason a naive "force dry_run" attempt was deferred.
- **Receiver side**: reads only the sender's NDX+attrs echo and commits nothing to disk, because the delta went to the client's batch fd.

The behaviour is strictly gated on the new `only_write_batch` flag; every normal transfer path is byte-unchanged.

## Empirical seal (lxhost, vs upstream rsync 3.4.4)

Real upstream client pushing `--only-write-batch` to the oc server:

| Check | Before | After |
|-------|--------|-------|
| exit code | 12 (dest-root error) | **0** |
| server destination | — | **empty** (matches upstream) |
| batch file | none | produced; `--read-batch` replays to reproduce the source exactly |
| plain `-n` push | rc 0 | rc 0 (unchanged) |
| normal push / pull upstream↔oc | matches | matches (no regression) |

Batch **content** is faithful (replays byte-for-byte to the source). Batch **bytes** are not identical to an upstream-server-mediated batch: the difference is entirely a pre-existing generator itemize divergence — a plain `-ai` push (no batch) to the oc server already emits `<f.........` where upstream emits `<f+++++++++` for a new file, i.e. the generator omits `ITEM_IS_NEW`/attribute-change iflags. Those iflags get teed into the batch, so byte-exact batch parity is blocked on that separate itemize fix, not on this change. Filed as a follow-up.

## Tests

- `parse_server_args_skips_only_write_batch_flag` — the flag no longer leaks into the positional list (the exact baseline bug).
- `long_flags_captures_only_write_batch` / `long_flags_defaults` — flag recognition and default.
- `cargo clippy -p cli -p transfer -p batch -- -D warnings`: clean. rustfmt (edition 2024): clean.
