### PR TITLE
fix(cli): gate flist banner and created-dir on INFO category

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -10,6 +10,7 @@ use core::{
     },
     message::Message,
 };
+use logging::{InfoFlag, info_gte};
 use logging_sink::MessageSink;
 
 use crate::frontend::{
@@ -117,9 +118,12 @@ where
     // direction arrow (upstream: log.c:701-704 - `<` for sender, `>` otherwise).
     let is_sender = config.is_local_sender();
     // upstream: flist.c:2251 emits "sending incremental file list" only when
-    // inc_recurse is on, which compat.c:172 disables when `!recurse`. Mirror
-    // that gate so single-file (`-v`) transfers don't get a spurious banner.
-    let recursive = config.recursive();
+    // `inc_recurse && INFO_GTE(FLIST, 1) && !am_server`. compat.c:172 disables
+    // inc_recurse when `!recurse`, so mirror the recursion gate (single-file
+    // `-v` transfers get no banner); additionally require the FLIST info
+    // category so `--info=flist0` suppresses the banner even at `-v`, matching
+    // upstream's per-category gate rather than a raw verbose-level check.
+    let emit_flist_banner = config.recursive() && info_gte(InfoFlag::Flist, 1);
     // Capture the preserve-links state before `config` is consumed so the
     // `--list-only` renderer knows whether to append the ` -> <target>` arrow
     // to symlink rows (upstream: generator.c:1183 gates it on preserve_links).
@@ -172,7 +176,7 @@ where
                     name_overridden,
                     human_readable_mode,
                     suppress_updated_only_totals,
-                    recursive,
+                    emit_flist_banner,
                     show_copy_method,
                     show_atimes,
                     show_crtimes,

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -50,6 +50,7 @@ use super::format::{
 };
 use super::mode::{NameOutputLevel, ProgressMode};
 use crate::{OutFormat, OutFormatContext, emit_out_format};
+use logging::{InfoFlag, info_gte};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_transfer_summary(
@@ -137,9 +138,12 @@ pub(crate) fn emit_transfer_summary(
     // reports the directory it would create. Mirror the same gate plus
     // trailing-slash trim here so `-i` and `-v` invocations - including
     // `--dry-run` - emit the notice ahead of the per-entry itemize lines,
-    // matching the upstream `testsuite/itemize.test` golden.
+    // matching the upstream `testsuite/itemize.test` golden. Gate on the NAME
+    // info category (`INFO_GTE(NAME, 1)`) rather than a raw `verbosity > 0`
+    // check so `--info=name0` suppresses the notice, while `-i`/`--out-format`
+    // still forces it via `stdout_format_has_i` (mirrored by `out_format`).
     if summary.destination_root_created()
-        && (out_format.is_some() || verbosity > 0)
+        && (out_format.is_some() || info_gte(InfoFlag::Name, 1))
         && let Some(dest_root) = events.iter().map(ClientEvent::destination_root).next()
     {
         writer.write_all(b"created directory ")?;

--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -370,6 +370,92 @@ fn info_name0_suppresses_verbose_output() {
 }
 
 #[test]
+fn info_flist0_suppresses_incremental_banner_at_verbose() {
+    use tempfile::tempdir;
+
+    // upstream: flist.c:2251 gates "sending incremental file list" on
+    // `inc_recurse && INFO_GTE(FLIST, 1) && !am_server`. `-v` raises FLIST to 1
+    // (options.c info_verbosity[1]), so the banner normally prints; a following
+    // `--info=flist0` drops FLIST back to 0 and must suppress the banner even
+    // though `-v` is still in effect. The `created directory` notice and the
+    // name listing stay because they are gated on the NAME category, which `-v`
+    // leaves at 1 - proving the gate is per-category, not a raw verbose level.
+    let tmp = tempdir().expect("tempdir");
+    let src = tmp.path().join("src");
+    std::fs::create_dir_all(src.join("sub")).expect("mkdir");
+    std::fs::write(src.join("sub/f.txt"), b"hi").expect("write source");
+    let dst = tmp.path().join("dst");
+
+    let mut src_arg = src.into_os_string();
+    src_arg.push("/");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-a"),
+        OsString::from("-v"),
+        OsString::from("--info=flist0"),
+        src_arg,
+        dst.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    let rendered = String::from_utf8(stdout).expect("stdout utf8");
+    assert!(
+        !rendered.contains("sending incremental file list"),
+        "--info=flist0 must suppress the banner even at -v: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("created directory"),
+        "NAME (still 1 at -v) keeps the created-directory notice: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("sub/"),
+        "NAME listing stays under --info=flist0: {rendered:?}"
+    );
+}
+
+#[test]
+fn info_name0_suppresses_created_directory_notice_at_verbose() {
+    use tempfile::tempdir;
+
+    // upstream: main.c:807-808 gates `created directory %s` on
+    // `INFO_GTE(NAME, 1) || stdout_format_has_i`. `-v` raises NAME to 1, so the
+    // notice normally prints; `--info=name0` drops NAME to 0 and must suppress
+    // it even at `-v`. The incremental-file-list banner stays because it is
+    // gated on the FLIST category, which `-v` leaves at 1.
+    let tmp = tempdir().expect("tempdir");
+    let src = tmp.path().join("src");
+    std::fs::create_dir_all(src.join("sub")).expect("mkdir");
+    std::fs::write(src.join("sub/f.txt"), b"hi").expect("write source");
+    let dst = tmp.path().join("dst");
+
+    let mut src_arg = src.into_os_string();
+    src_arg.push("/");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-a"),
+        OsString::from("-v"),
+        OsString::from("--info=name0"),
+        src_arg,
+        dst.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    let rendered = String::from_utf8(stdout).expect("stdout utf8");
+    assert!(
+        !rendered.contains("created directory"),
+        "--info=name0 must suppress the created-directory notice at -v: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("sending incremental file list"),
+        "FLIST (still 1 at -v) keeps the incremental banner: {rendered:?}"
+    );
+}
+
+#[test]
 fn info_name2_reports_unchanged_entries() {
     use tempfile::tempdir;
 


### PR DESCRIPTION
## Summary

Output-fidelity fix: two verbose/info messages were gated on the raw verbose
level instead of the per-category INFO level, so `--info=flist0` / `--info=name0`
failed to suppress them at `-v` (upstream suppresses them). This aligns oc-rsync
with upstream's `INFO_GTE(category, level)` gating for these two messages.

## Items fixed

### 1. "sending incremental file list" banner - gate on INFO_FLIST
Upstream `flist.c:2251` gates the banner on `inc_recurse && INFO_GTE(FLIST, 1)
&& !am_server`. oc-rsync gated it on `recursive && verbosity > 0`, so
`--info=flist0` did not suppress it at `-v`.

Fix: fold `info_gte(InfoFlag::Flist, 1)` into `emit_flist_banner` in
`execution/drive/summary.rs`, where the resolved verbosity config is
authoritative (`logging::init(from_verbose_level)` + `apply_to_thread_local`
have both run on this thread).

Before / after (`-v --info=flist0`):
```
- sending incremental file list      <- wrongly printed
  created directory DEST
  ./
  a.txt
```

### 2. "created directory" notice - gate on INFO_NAME
Upstream `main.c:807-808` gates the notice on `INFO_GTE(NAME, 1) ||
stdout_format_has_i`. oc-rsync gated it on `out_format.is_some() ||
verbosity > 0`, so `--info=name0` did not suppress it at `-v`.

Fix: gate on `out_format.is_some() || info_gte(InfoFlag::Name, 1)` in
`progress/render.rs` (`out_format` mirrors `stdout_format_has_i`).

Before / after (`-v --info=name0`):
```
  sending incremental file list
- created directory DEST             <- wrongly printed
```

Default `-v`/`-vv`/`-vvv` output is unchanged: `-v` raises both FLIST and NAME
to level 1 (options.c `info_verbosity[1]`), so both messages still print.

## lxhost verification (rsync 3.4.4)

Byte-for-byte compared oc vs upstream `~/rsync-3.4.4/rsync` on a simple local
transfer (paths/rates normalised):

| Invocation | Result |
|---|---|
| `-v` | identical |
| `-v --info=flist0` | identical (banner suppressed, created-dir + listing kept) |
| `-v --info=name0` | matches except a pre-existing missing blank line before the trailer (see below) |
| `-v --info=flist2,name2` | identical |

## Tests

Added `info_flist0_suppresses_incremental_banner_at_verbose` and
`info_name0_suppresses_created_directory_notice_at_verbose` in
`tests/info_debug.rs`, each citing the upstream gate and asserting the
complementary category stays enabled. Full cli unit-test suite: 464 relevant
tests pass, 0 failures. rustfmt (edition 2024) and clippy
(`-p cli -D warnings`) clean.

## Follow-ups (out of scope here)

- Blank line before the `sent ...` trailer is coupled to a non-empty verbose
  listing; upstream emits it unconditionally at `INFO_GTE(STATS, 1)`
  (`main.c:461`). Pre-existing, lives in the delicate trailer-spacing logic.
- `-vv` `total: matches=...` line and the `-vvv` debug-trace corpus originate
  in the matching/sender/generator/receiver paths, not cli/core/logging.
- `delta-transmission` notice is emitted early but drained after the summary
  (buffered-event flush ordering).
- `--stats` "File list generation/transfer time" lines already match upstream
  for local copies (measured; sub-millisecond runs suppress them exactly as
  upstream's `if (flist_buildtime)` guard does).
