### PR TITLE
perf(engine): gate spill zstd on compressibility to cut round-trip CPU

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
@@ -11,6 +11,19 @@ use super::super::{SpillCodec, SpillCompression, SpillError, SpillGranularity, r
 use super::SPILL_TAG_ZSTD;
 use super::{HOT_ZONE, SPILL_TAG_RAW, SpillableReorderBuffer};
 
+/// Minimum encoded-payload size (in bytes) below which the zstd spill codec is
+/// skipped and the record is stored raw.
+///
+/// zstd frames carry a fixed floor of overhead (4-byte magic plus frame and
+/// block headers, roughly 13 bytes) before any payload byte is emitted, so a
+/// record smaller than this can never come out smaller than its raw form. The
+/// reorder buffer's dominant payload is a fixed 37-byte `DeltaResult` success
+/// record, so gating at 64 bytes keeps the common case raw (no wasted
+/// compress+decompress round-trip) while still compressing the rare, genuinely
+/// compressible large records (multi-hundred-byte redo/error reason strings).
+#[cfg(feature = "spill-compression")]
+const SPILL_MIN_COMPRESS_BYTES: usize = 64;
+
 /// Emits the one-shot spill-activation warning the first time the reorder
 /// buffer spills to disk. Subsequent calls with `already_warned = true` are
 /// no-ops so the operator sees the diagnostic exactly once per transfer.
@@ -344,15 +357,32 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
     /// Applies the configured compression codec to the freshly encoded payload.
     ///
     /// Returns `(tag, bytes_to_write)`. [`SpillCompression::None`] is a
-    /// pass-through that emits [`SPILL_TAG_RAW`]; [`SpillCompression::Zstd`]
-    /// emits [`SPILL_TAG_ZSTD`] and the zstd-encoded bytes.
+    /// pass-through that emits [`SPILL_TAG_RAW`].
+    ///
+    /// [`SpillCompression::Zstd`] is compressibility-gated: the reorder buffer
+    /// spills small fixed-size result records (a `DeltaResult` success record
+    /// is 37 bytes), and the zstd frame overhead alone (magic + frame/block
+    /// headers, ~13 bytes) means such records never shrink - the
+    /// compress+decompress round-trip would cost CPU for zero or negative I/O
+    /// saving. So records below [`SPILL_MIN_COMPRESS_BYTES`] skip the codec
+    /// entirely, and any record whose compressed form is not strictly smaller
+    /// than the raw encoding is stored raw. Every record still carries its own
+    /// tag ([`SPILL_TAG_RAW`] / [`SPILL_TAG_ZSTD`]) so the reader restores it
+    /// byte-identically regardless of which branch a given record took.
     fn compress_payload(&self, encoded: Vec<u8>) -> io::Result<(u8, Vec<u8>)> {
         match self.compression {
             SpillCompression::None => Ok((SPILL_TAG_RAW, encoded)),
             #[cfg(feature = "spill-compression")]
             SpillCompression::Zstd { level } => {
+                if encoded.len() < SPILL_MIN_COMPRESS_BYTES {
+                    return Ok((SPILL_TAG_RAW, encoded));
+                }
                 let compressed = zstd::stream::encode_all(encoded.as_slice(), level)?;
-                Ok((SPILL_TAG_ZSTD, compressed))
+                if compressed.len() < encoded.len() {
+                    Ok((SPILL_TAG_ZSTD, compressed))
+                } else {
+                    Ok((SPILL_TAG_RAW, encoded))
+                }
             }
         }
     }

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/compression.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/compression.rs
@@ -26,6 +26,33 @@ fn read_first_header<T: SpillCodec>(buf: &mut SpillableReorderBuffer<T>) -> (u8,
     (header[0], len)
 }
 
+/// Walks every `[tag][u32 len][payload]` record in a PerItem spill file up to
+/// the current write cursor and returns each record's `(tag, on_disk_len)`.
+///
+/// Order-independent so a test can assert *which* codecs the compressibility
+/// gate selected across a whole workload without pinning a specific record to
+/// a specific offset.
+#[cfg(feature = "spill-compression")]
+fn collect_records<T: SpillCodec>(buf: &mut SpillableReorderBuffer<T>) -> Vec<(u8, u32)> {
+    let end = buf.spill_write_pos;
+    let backend = buf
+        .spill_file
+        .as_mut()
+        .expect("spill file should be initialized");
+    let file = backend.file();
+    let mut out = Vec::new();
+    let mut pos = 0u64;
+    while pos < end {
+        file.seek(SeekFrom::Start(pos)).expect("seek to record");
+        let mut header = [0u8; 5];
+        file.read_exact(&mut header).expect("read record header");
+        let len = u32::from_le_bytes(header[1..5].try_into().unwrap());
+        out.push((header[0], len));
+        pos += 5 + len as u64;
+    }
+    out
+}
+
 #[test]
 fn compression_none_writes_uncompressed_tag() {
     // Default policy: every spill record must start with SPILL_TAG_RAW
@@ -58,10 +85,12 @@ fn compression_none_writes_uncompressed_tag() {
 
 #[cfg(feature = "spill-compression")]
 #[test]
-fn compression_zstd_writes_compressed_tag() {
-    // With the spill-compression feature on, every record must start
-    // with SPILL_TAG_ZSTD (0x01) and the round-trip must still recover
-    // the original values.
+fn compression_zstd_small_record_stays_raw_under_gate() {
+    // An 8-byte u64 payload is below the compressibility gate
+    // (SPILL_MIN_COMPRESS_BYTES = 64), so even under the Zstd policy the
+    // record is stored with SPILL_TAG_RAW (0x00) - zstd's frame overhead
+    // could never make an 8-byte record smaller, so paying the codec would
+    // be pure waste. The round-trip must still recover the original values.
     let scratch = ::tempfile::tempdir().expect("create scratch root");
     let mut buf: SpillableReorderBuffer<u64> =
         SpillableReorderBuffer::with_spill_dir(32, 16, scratch.path().join("spill"))
@@ -74,12 +103,16 @@ fn compression_zstd_writes_compressed_tag() {
     }
     assert!(buf.spill_stats().spill_events > 0, "expected spilling");
 
-    let (tag, _len) = read_first_header(&mut buf);
-    assert_eq!(tag, SPILL_TAG_ZSTD, "first record must carry the zstd tag");
+    let (tag, len) = read_first_header(&mut buf);
+    assert_eq!(
+        tag, SPILL_TAG_RAW,
+        "a sub-gate record must stay raw even under the Zstd policy"
+    );
+    assert_eq!(len, 8, "raw u64 payload is 8 bytes");
 
     let items = drain_all(&mut buf);
     let expected: Vec<u64> = (0..6).map(|i| i * 17).collect();
-    assert_eq!(items, expected, "zstd round-trip must preserve values");
+    assert_eq!(items, expected, "round-trip must preserve values");
 }
 
 #[cfg(not(feature = "spill-compression"))]
@@ -138,4 +171,216 @@ fn compression_zstd_tag_without_feature_returns_unsupported() {
         SpillError::UnsupportedCompression(tag) => assert_eq!(tag, SPILL_TAG_ZSTD),
         other => panic!("expected UnsupportedCompression, got {other:?}"),
     }
+}
+
+/// Encodes a [`DeltaResult`] to bytes for byte-identical round-trip assertions.
+fn encode_result(item: &crate::concurrent_delta::DeltaResult) -> Vec<u8> {
+    let mut buf = Vec::new();
+    item.encode(&mut buf).expect("encode into Vec cannot fail");
+    buf
+}
+
+/// Builds a workload of `DeltaResult` items sized so the highest sequences
+/// spill first, and drives it through a PerItem spill buffer with the given
+/// compression policy. Returns the buffer (spill file still populated) and the
+/// original items keyed by sequence for byte-identical comparison after drain.
+fn drive_peritem(
+    dir: &std::path::Path,
+    compression: SpillCompression,
+    items: Vec<crate::concurrent_delta::DeltaResult>,
+) -> (
+    SpillableReorderBuffer<crate::concurrent_delta::DeltaResult>,
+    Vec<Vec<u8>>,
+) {
+    let expected: Vec<Vec<u8>> = items.iter().map(encode_result).collect();
+    let mut buf: SpillableReorderBuffer<crate::concurrent_delta::DeltaResult> =
+        SpillableReorderBuffer::with_spill_dir(64, 128, dir)
+            .expect("setup spill directory")
+            .with_compression(compression)
+            .with_granularity(SpillGranularity::PerItem);
+    // Insert highest-sequence first so the furthest-from-delivery items are
+    // the ones evicted to disk.
+    for (seq, item) in items.into_iter().enumerate().rev() {
+        buf.insert(seq as u64, item).expect("insert must not fail");
+    }
+    (buf, expected)
+}
+
+/// A small `Success` record (37 bytes encoded) is below the compressibility
+/// gate, so even under the Zstd policy it is stored raw - no wasted
+/// compress+decompress round-trip - and still round-trips byte-identically.
+#[cfg(feature = "spill-compression")]
+#[test]
+fn zstd_gate_small_records_stay_raw() {
+    use crate::concurrent_delta::DeltaResult;
+
+    let scratch = ::tempfile::tempdir().expect("create scratch root");
+    let items: Vec<DeltaResult> = (0..40u32)
+        .map(|i| DeltaResult::success(i, u64::from(i) * 10, 5, 5).with_sequence(u64::from(i)))
+        .collect();
+    let (mut buf, expected) = drive_peritem(
+        &scratch.path().join("spill"),
+        SpillCompression::Zstd { level: 3 },
+        items,
+    );
+
+    assert!(buf.spill_stats().spill_events > 0, "expected spilling");
+    let records = collect_records(&mut buf);
+    assert!(!records.is_empty(), "expected at least one spilled record");
+    assert!(
+        records.iter().all(|(tag, _)| *tag == SPILL_TAG_RAW),
+        "small records must stay raw under the compressibility gate: {records:?}"
+    );
+
+    let drained: Vec<Vec<u8>> = drain_all(&mut buf).iter().map(encode_result).collect();
+    assert_eq!(drained, expected, "round-trip must be byte-identical");
+}
+
+/// A large, highly compressible record (a redo/error reason of repeated bytes)
+/// is above the gate and compresses smaller, so it is stored zstd, shrinks on
+/// disk, and still round-trips byte-identically.
+#[cfg(feature = "spill-compression")]
+#[test]
+fn zstd_gate_compresses_large_compressible_records() {
+    use crate::concurrent_delta::DeltaResult;
+
+    let scratch = ::tempfile::tempdir().expect("create scratch root");
+    let items: Vec<DeltaResult> = (0..40u32)
+        .map(|i| DeltaResult::failed(i, "y".repeat(400)).with_sequence(u64::from(i)))
+        .collect();
+    let raw_total: u32 = items.iter().map(|d| encode_result(d).len() as u32).sum();
+    let (mut buf, expected) = drive_peritem(
+        &scratch.path().join("spill"),
+        SpillCompression::Zstd { level: 3 },
+        items,
+    );
+
+    assert!(buf.spill_stats().spill_events > 0, "expected spilling");
+    let records = collect_records(&mut buf);
+    assert!(
+        records.iter().any(|(tag, _)| *tag == SPILL_TAG_ZSTD),
+        "compressible records must be stored zstd: {records:?}"
+    );
+    let on_disk: u32 = records.iter().map(|(_, len)| *len).sum();
+    let raw_spilled: u32 = raw_total * records.len() as u32 / 40;
+    assert!(
+        on_disk < raw_spilled,
+        "compressed payload bytes ({on_disk}) must be smaller than raw ({raw_spilled})"
+    );
+
+    let drained: Vec<Vec<u8>> = drain_all(&mut buf).iter().map(encode_result).collect();
+    assert_eq!(drained, expected, "zstd round-trip must be byte-identical");
+}
+
+/// Length-prefixed opaque byte record used to feed the gate genuinely
+/// incompressible binary payloads (full 0..=255 byte range), which a
+/// UTF-8-constrained reason string cannot express.
+#[cfg(feature = "spill-compression")]
+#[derive(Clone, PartialEq, Debug)]
+struct Blob(Vec<u8>);
+
+#[cfg(feature = "spill-compression")]
+impl SpillCodec for Blob {
+    fn encode(&self, w: &mut dyn std::io::Write) -> std::io::Result<()> {
+        w.write_all(&(self.0.len() as u32).to_le_bytes())?;
+        w.write_all(&self.0)
+    }
+
+    fn decode(r: &mut dyn std::io::Read) -> std::io::Result<Self> {
+        let mut len_buf = [0u8; 4];
+        r.read_exact(&mut len_buf)?;
+        let len = u32::from_le_bytes(len_buf) as usize;
+        let mut bytes = vec![0u8; len];
+        r.read_exact(&mut bytes)?;
+        Ok(Blob(bytes))
+    }
+
+    fn estimated_size(&self) -> usize {
+        self.0.len() + 4
+    }
+}
+
+/// A large but incompressible record (high-entropy binary bytes) is above the
+/// size gate yet the zstd output is not strictly smaller, so the codec result
+/// is discarded and the record is stored raw. Proves the "not strictly
+/// smaller => raw" fallback never inflates a spill record, and that a record
+/// stored raw under the Zstd policy still round-trips byte-identically.
+#[cfg(feature = "spill-compression")]
+#[test]
+fn zstd_gate_incompressible_large_records_stay_raw() {
+    // splitmix64 yields high-quality pseudorandom bytes across the full 0..=255
+    // range, so entropy coding cannot recover the ~13-byte zstd frame overhead
+    // - the compressed form is always larger than the 128-byte raw payload.
+    let blob = |seed: u64| -> Blob {
+        let mut state = seed;
+        let mut next = || {
+            state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        };
+        let bytes: Vec<u8> = (0..16).flat_map(|_| next().to_le_bytes()).collect();
+        Blob(bytes)
+    };
+
+    let scratch = ::tempfile::tempdir().expect("create scratch root");
+    let dir = scratch.path().join("spill");
+    let items: Vec<Blob> = (0..40u64).map(|i| blob(0xDEAD_0000 ^ i)).collect();
+    let expected = items.clone();
+
+    let mut buf: SpillableReorderBuffer<Blob> =
+        SpillableReorderBuffer::with_spill_dir(64, 128, &dir)
+            .expect("setup spill directory")
+            .with_compression(SpillCompression::Zstd { level: 3 })
+            .with_granularity(SpillGranularity::PerItem);
+    for (seq, item) in items.into_iter().enumerate().rev() {
+        buf.insert(seq as u64, item).expect("insert must not fail");
+    }
+
+    assert!(buf.spill_stats().spill_events > 0, "expected spilling");
+    let records = collect_records(&mut buf);
+    assert!(!records.is_empty(), "expected at least one spilled record");
+    assert!(
+        records.iter().all(|(tag, _)| *tag == SPILL_TAG_RAW),
+        "incompressible records must fall back to raw, never inflate: {records:?}"
+    );
+
+    let drained = drain_all(&mut buf);
+    assert_eq!(
+        drained, expected,
+        "raw-fallback round-trip must be byte-identical"
+    );
+}
+
+/// A mixed workload of small and large records drains byte-identically. Runs
+/// in both default (None -> all raw) and `spill-compression` (mixed raw/zstd
+/// records interleaved in one spill file) builds, guarding the non-negotiable
+/// round-trip contract across every branch of the compressibility gate.
+#[test]
+fn mixed_sizes_roundtrip_byte_identical() {
+    use crate::concurrent_delta::DeltaResult;
+
+    let scratch = ::tempfile::tempdir().expect("create scratch root");
+    let items: Vec<DeltaResult> = (0..48u32)
+        .map(|i| match i % 3 {
+            0 => DeltaResult::success(i, u64::from(i), 1, 1).with_sequence(u64::from(i)),
+            1 => DeltaResult::needs_redo(i, "z".repeat(200)).with_sequence(u64::from(i)),
+            _ => DeltaResult::failed(i, "q".repeat(500)).with_sequence(u64::from(i)),
+        })
+        .collect();
+
+    #[cfg(feature = "spill-compression")]
+    let compression = SpillCompression::Zstd { level: 5 };
+    #[cfg(not(feature = "spill-compression"))]
+    let compression = SpillCompression::None;
+
+    let (mut buf, expected) = drive_peritem(&scratch.path().join("spill"), compression, items);
+    assert!(buf.spill_stats().spill_events > 0, "expected spilling");
+
+    let drained: Vec<Vec<u8>> = drain_all(&mut buf).iter().map(encode_result).collect();
+    assert_eq!(
+        drained, expected,
+        "mixed-size round-trip must be byte-identical regardless of per-record codec"
+    );
 }


### PR DESCRIPTION
## Summary

The reorder buffer's spill layer compresses spilled payloads when the opt-in
`SpillCompression::Zstd` policy is selected. But the items it spills are
`DeltaResult` **statistics** records - a fixed 37 bytes for the common
`Success` case (ndx + sequence + three `u64` counters + a status byte) - not
file content. Running zstd on records that small pays the full
compress+decompress round-trip while the ~13-byte zstd frame overhead
guarantees they never shrink. The round-trip costs CPU for zero or negative
I/O saving on the dominant workload.

This gates the codec behind compressibility: records below 64 bytes skip zstd
entirely, and any record whose compressed form is not strictly smaller than
its raw encoding is stored raw. Every record already carries its own on-disk
tag (`0x00` raw / `0x01` zstd) and the reader dispatches per record, so this
is a strict, per-record Pareto improvement to the Zstd path - never larger on
disk, never a wasted round-trip - with no new configuration surface.

Default builds are unaffected: `SpillCompression::None` is the default and the
gate only touches the feature-gated Zstd branch.

## Measurement (lxhost, aarch64)

Existing `spill_policy_perf` bench (in-memory `Cursor`, 1000-item mixed
workload) shows the per-record round-trip cost the gate targets:

| cell | wall (median) | bytes on disk |
|------|--------------|---------------|
| none / whole_batch | 71.6 us | 141,509 |
| none / per_item | 95.6 us | 141,501 |
| zstd3 / whole_batch | 311.8 us | 12,525 |
| zstd3 / per_item | **13,965 us** | 38,524 |

Per-item zstd is ~146x the CPU of raw per-item, on a workload already 30%
large compressible strings; on the Success-dominated real workload it is worse
and inflates the file.

Real `SpillableReorderBuffer` PerItem+Zstd (level 3), best of 7 runs,
in-memory backend, before (no gate) vs after (gate):

| workload | metric | no gate | gate | delta |
|----------|--------|---------|------|-------|
| success (incompressible, 20k x 37B) | insert | 2,100,639 us | 1,636,613 us | **-22%** |
| success | drain | 9,880 us | 2,034 us | **-4.9x** |
| failed (compressible, 2k x 441B) | insert | 33,593 us | 34,522 us | ~equal (noise) |
| failed | drain | 1,319 us | 1,419 us | ~equal (noise) |

The gate reclaims the wasted round-trip on incompressible records and leaves
the compressible path untouched.

## Decision

Threshold + strictly-smaller gate on the existing per-record tag mechanism
(the Raw-vs-Zstd tag byte is the strategy dispatch; no new trait needed).
Compression is kept for the genuinely compressible large records rather than
ripped out. Default behaviour (`None`) is unchanged.

## Correctness

Byte-identical spill -> restore is non-negotiable and preserved: raw fallback
stores exactly the encoded bytes, and each record's tag drives the reader. New
adversarial round-trip tests:

- `zstd_gate_small_records_stay_raw` - 37B success records stay raw, round-trip.
- `zstd_gate_compresses_large_compressible_records` - large repeated-byte
  reasons compress (zstd tag), shrink on disk, round-trip byte-identical.
- `zstd_gate_incompressible_large_records_stay_raw` - high-entropy binary
  payloads (full 0..=255 range) fall back to raw, never inflate, round-trip.
- `mixed_sizes_roundtrip_byte_identical` - mixed small/large payloads
  round-trip byte-identical in both default and feature builds.
- Pre-existing `compression_zstd_small_record_stays_raw_under_gate` updated to
  document the gate for the u64 codec.

Full spill suite: 141/141 pass with `spill-compression`, 137/137 without.

`rustfmt --edition 2024 --check`: clean.
`cargo clippy -p engine --all-targets --all-features --no-deps -- -D warnings`: clean.
