### PR TITLE
fix(core): flatten --no-relative --files-from on client-sender push

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -35,10 +35,19 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     }
 
     // upstream: options.c:2169-2173 - --files-from disables recursion and
-    // enables xfer_dirs. options.c:2188 - --files-from implies --relative.
+    // enables xfer_dirs. options.c:2205-2206 - --files-from defaults
+    // relative_paths=1.
     let files_from_active = config.files_from().is_active();
     let effective_recursive = config.recursive() && !files_from_active;
-    let effective_relative = config.relative_paths() || files_from_active;
+    // upstream: options.c:2713-2714 - `if (relative_paths) argstr[x++] = 'R';`
+    // packs the compact `R` for the RESOLVED relative_paths. `relative_paths()`
+    // already folds in the --files-from default (options.c:2205-2206: relative
+    // defaults to 1 under --files-from) at the CLI layer, so it must NOT be
+    // re-forced with `|| files_from_active` - that wrongly packs `R` even when
+    // the user passed --no-relative, telling the remote peer relative is on and
+    // making the client-sender flatten (flist.c:2338-2349) diverge from the
+    // wire signal (`sub/file` implied dir instead of the flattened `file`).
+    let effective_relative = config.relative_paths();
 
     if config.links() {
         flags.push('l');
@@ -1038,13 +1047,16 @@ mod tests {
 
     #[test]
     fn server_flag_string_files_from_suppresses_r_adds_d_and_r_upper() {
-        // upstream: options.c:2169-2188 - --files-from sets recurse=0,
-        // xfer_dirs=1, relative_paths=1.
+        // upstream: options.c:2169-2173, 2205-2206 - --files-from sets
+        // recurse=0, xfer_dirs=1, and defaults relative_paths=1. The CLI layer
+        // (workflow/run.rs) folds that default into the resolved relative_paths
+        // passed here, so relative is explicit at this stage.
         use crate::client::config::FilesFromSource;
 
         let config = ClientConfig::builder()
             .recursive(true)
             .times(true)
+            .relative_paths(true)
             .files_from(FilesFromSource::LocalFile("/tmp/list.txt".into()))
             .build();
         let flags = build_server_flag_string(&config);
@@ -1059,6 +1071,43 @@ mod tests {
         assert!(
             flags.contains('R'),
             "should add 'R' (relative) with --files-from: {flags}"
+        );
+    }
+
+    #[test]
+    fn server_flag_string_files_from_no_relative_omits_r_keeps_d() {
+        // upstream: options.c:2713-2714 - `if (relative_paths) argstr[x++] =
+        // 'R';` packs the compact `R` only for the RESOLVED relative_paths.
+        // Under --no-relative --files-from the CLI resolves relative_paths=0
+        // (options.c:368-369, 693), so no `R` is packed even though files-from
+        // is active. This is the PUSH client-sender wire signal: without `R`
+        // the peer knows relative is off and no implied `sub` parent dir is
+        // expected, matching the client-sender flatten (flist.c:2338-2349) that
+        // splits each entry on its last `/` down to the basename.
+        use crate::client::config::FilesFromSource;
+
+        let config = ClientConfig::builder()
+            .recursive(true)
+            .times(true)
+            .relative_paths(false)
+            .files_from(FilesFromSource::LocalFile("/tmp/list.txt".into()))
+            .build();
+        assert!(
+            !config.relative_paths(),
+            "--no-relative must resolve relative_paths=false"
+        );
+        let flags = build_server_flag_string(&config);
+        assert!(
+            !flags.contains('R'),
+            "should omit 'R' under --no-relative --files-from: {flags}"
+        );
+        assert!(
+            flags.contains('d'),
+            "should still add 'd' (xfer_dirs) with --files-from: {flags}"
+        );
+        assert!(
+            !flags.contains('r'),
+            "should still suppress 'r' with --files-from: {flags}"
         );
     }
 


### PR DESCRIPTION
## Problem

As a client-sender pushing over SSH/daemon with `--no-relative --files-from`, oc-rsync did not flatten files-from entries to their basenames on the wire. PR #6530 landed the sender-side flatten (`split_files_from_entry` with a `relative_paths` param) and fixed the PULL/server-sender arg path in `invocation/builder.rs`, but the PUSH path stayed broken.

Root cause: the daemon/embedded-ssh compact-flag builder in `crates/core/src/client/remote/flags.rs` carried a duplicated `relative_paths() || files_from_active` term. Under `--no-relative`, `relative_paths()` already resolves to `false` (the CLI folds in the `--files-from` default), but `|| files_from_active` re-forced it `true`, so the compact `R` letter was still packed on the wire. That told the peer relative was on, diverging the wire signal from the flattened flist the client-sender actually builds - the same wrong `|| files_from_active` term #6530 dropped in `invocation/builder.rs`.

## Fix

Drop the `|| files_from_active` term so the single resolved `relative_paths()` drives the compact `R` letter (DRY with the #6530 `builder.rs` fix). No behavioral change to the non-`--no-relative` path.

## Upstream references

- `options.c:2205-2206` - `--files-from` defaults `relative_paths=1`; the CLI layer resolves this before it reaches the flag builder.
- `options.c:2207-2208` - non-relative forces `implied_dirs=0` (no implied parents).
- `options.c:2713-2714` - `if (relative_paths) argstr[x++] = 'R';` packs `R` only for the RESOLVED relative_paths.
- `options.c:368-369,693` - `--no-relative` clears `relative_paths`.
- `flist.c:2338-2349` - when `relative_paths==0`, each files-from entry is split on its last `/` and only the basename is sent.

## Verification

Empirical seal on aarch64 Linux: oc client PUSH over SSH to a real upstream `rsync 3.4.4` receiver, files-from list containing `sub/file`.

| Scenario | oc dest | upstream dest | rc | dest diff |
|----------|---------|---------------|----|-----------|
| `--no-relative --files-from` | `./file` (flattened) | `./file` | 0 | identical |
| default `--files-from` (relative) | `./sub/file` (implied dir) | `./sub/file` | 0 | identical |

Both directions byte-identical to upstream-client -> upstream-receiver for the same command. The default path is unchanged.

Unit tests (`cargo nextest -p core`): updated `server_flag_string_files_from_suppresses_r_adds_d_and_r_upper` to set the resolved `relative_paths(true)` (the CLI layer's job, no longer forced by the flag builder), and added `server_flag_string_files_from_no_relative_omits_r_keeps_d` asserting `--no-relative --files-from` omits `R`, keeps `d`, suppresses `r`. Both pass. rustfmt (edition 2024) and `clippy -p core -- -D warnings` clean.
