### PR TITLE
perf(daemon): honor max connections in async accept-loop worker cap

### DIFF
--- a/crates/daemon/src/async_listener.rs
+++ b/crates/daemon/src/async_listener.rs
@@ -54,7 +54,7 @@ use tokio::runtime::Builder;
 /// into a later session.
 pub type SyncWorker = Arc<dyn Fn(TcpStream, SocketAddr) -> io::Result<()> + Send + Sync + 'static>;
 
-/// Upper bound on concurrent per-connection worker threads.
+/// Default upper bound on concurrent per-connection worker threads.
 ///
 /// Each connection runs its sync worker on a dedicated OS thread (required for
 /// the seccomp-filter lifetime invariant). Unlike tokio's `spawn_blocking`
@@ -64,7 +64,13 @@ pub type SyncWorker = Arc<dyn Fn(TcpStream, SocketAddr) -> io::Result<()> + Send
 /// threads. This semaphore restores that backpressure: at the cap the accept
 /// task parks until an in-flight worker completes, matching tokio's historical
 /// blocking-pool default.
-const MAX_INFLIGHT_WORKERS: usize = 512;
+///
+/// This is only the flood-protection floor used when the operator does not
+/// configure a higher `max connections`. Callers derive the effective cap so
+/// it never binds below a configured connection limit (see
+/// [`run_hybrid_listener`]); otherwise a daemon with `max connections = 1000`
+/// would be silently throttled to 512 concurrent sessions.
+pub const DEFAULT_MAX_INFLIGHT_WORKERS: usize = 512;
 
 /// Builds and runs the hybrid async listener.
 ///
@@ -78,6 +84,11 @@ const MAX_INFLIGHT_WORKERS: usize = 512;
 /// worker count only governs the accept loop and per-connection async
 /// dispatcher; a small bounded value is sufficient.
 ///
+/// `max_inflight` bounds the number of concurrent per-connection worker
+/// threads. Callers pass a value derived from the operator's `max connections`
+/// so the accept loop never throttles below the configured limit; a value of
+/// `0` is clamped up to `1`. See [`DEFAULT_MAX_INFLIGHT_WORKERS`].
+///
 /// `shutdown` is polled between accepts. Setting it from another thread
 /// drains the loop and returns `Ok(())`. The listener does not install
 /// signal handlers; integration sites wire `SIGTERM`/`Ctrl-C` to this flag.
@@ -90,6 +101,7 @@ const MAX_INFLIGHT_WORKERS: usize = 512;
 pub fn run_hybrid_listener(
     bind_addr: SocketAddr,
     worker_threads: usize,
+    max_inflight: usize,
     shutdown: Arc<AtomicBool>,
     worker: SyncWorker,
 ) -> io::Result<()> {
@@ -101,9 +113,7 @@ pub fn run_hybrid_listener(
         .thread_name("oc-rsyncd-async")
         .build()?;
 
-    runtime.block_on(
-        async move { accept_loop(bind_addr, MAX_INFLIGHT_WORKERS, shutdown, worker).await },
-    )
+    runtime.block_on(async move { accept_loop(bind_addr, max_inflight, shutdown, worker).await })
 }
 
 async fn accept_loop(
@@ -152,8 +162,8 @@ async fn accept_loop(
                 return;
             }
 
-            // Bound the number of concurrent worker threads (see
-            // `MAX_INFLIGHT_WORKERS`). Acquiring here - after the cheap accept
+            // Bound the number of concurrent worker threads to `max_inflight`
+            // (see `DEFAULT_MAX_INFLIGHT_WORKERS`). Acquiring here - after the cheap accept
             // but before the expensive `thread::spawn` - parks this dispatch
             // task when at capacity so a connect flood cannot spawn unbounded
             // blocked-on-read threads. The permit is released when this task
@@ -261,7 +271,7 @@ mod tests {
             runtime.block_on(async move {
                 accept_loop(
                     local_addr,
-                    MAX_INFLIGHT_WORKERS,
+                    DEFAULT_MAX_INFLIGHT_WORKERS,
                     shutdown_for_loop,
                     worker_for_loop,
                 )
@@ -362,7 +372,13 @@ mod tests {
         let shutdown_for_thread = Arc::clone(&shutdown);
         let worker_for_thread = Arc::clone(&worker);
         let handle = thread::spawn(move || {
-            run_hybrid_listener(bind_addr, 1, shutdown_for_thread, worker_for_thread)
+            run_hybrid_listener(
+                bind_addr,
+                1,
+                DEFAULT_MAX_INFLIGHT_WORKERS,
+                shutdown_for_thread,
+                worker_for_thread,
+            )
         });
 
         thread::sleep(Duration::from_millis(150));

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -435,11 +435,12 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
 /// The configuration is parsed identically to [`run_daemon`], but the accept
 /// loop is hosted on a tokio multi-thread runtime via
 /// [`crate::async_listener::run_hybrid_listener`]. Each accepted connection is
-/// served by the existing synchronous session handler through
-/// `tokio::task::spawn_blocking` (see
-/// [`ConnectionContext::serve_one_connection`]), so the wire protocol, auth,
-/// and transfer pipeline stay byte-identical with the sync daemon; only the
-/// accept + task dispatch is asynchronous.
+/// served by the existing synchronous session handler on a dedicated OS thread
+/// (see [`ConnectionContext::serve_one_connection`]), so the wire protocol,
+/// auth, and transfer pipeline stay byte-identical with the sync daemon; only
+/// the accept + task dispatch is asynchronous. The number of concurrent worker
+/// threads is bounded so it never throttles below the configured
+/// `max connections` (see [`async_max_inflight`]).
 ///
 /// # Selection
 ///
@@ -621,18 +622,25 @@ pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
         context.serve_one_connection(stream, peer)
     });
 
-    crate::async_listener::run_hybrid_listener(bind_addr, worker_threads, shutdown, worker).map_err(
-        |error| {
-            DaemonError::new(
-                FEATURE_UNAVAILABLE_EXIT_CODE,
-                rsync_error!(
-                    FEATURE_UNAVAILABLE_EXIT_CODE,
-                    format!("async-daemon listener failed: {error}")
-                )
-                .with_role(Role::Daemon),
-            )
-        },
+    let max_inflight = async_max_inflight(max_connections);
+
+    crate::async_listener::run_hybrid_listener(
+        bind_addr,
+        worker_threads,
+        max_inflight,
+        shutdown,
+        worker,
     )
+    .map_err(|error| {
+        DaemonError::new(
+            FEATURE_UNAVAILABLE_EXIT_CODE,
+            rsync_error!(
+                FEATURE_UNAVAILABLE_EXIT_CODE,
+                format!("async-daemon listener failed: {error}")
+            )
+            .with_role(Role::Daemon),
+        )
+    })
 }
 
 /// Builds the fail-closed error returned when the async daemon is asked to
@@ -653,6 +661,28 @@ fn async_privileged_module_error() -> DaemonError {
         )
         .with_role(Role::Daemon),
     )
+}
+
+/// Derives the concurrent-worker-thread cap for the async accept loop.
+///
+/// The accept loop bounds in-flight per-connection worker threads with a
+/// semaphore for flood protection. That backstop must never be the binding
+/// constraint below the operator's configured `max connections`: a daemon set
+/// to `max connections = 1000` should serve up to 1000 concurrent sessions,
+/// not the 512-thread flood floor. So the cap is the larger of the configured
+/// limit and [`DEFAULT_MAX_INFLIGHT_WORKERS`]. When `max connections` is unset
+/// (unbounded, matching the sync default) the floor alone applies. Keeping the
+/// cap at or above the configured limit also preserves the per-session refusal
+/// semantics: the `max connections` admission semaphore inside the worker still
+/// fires first, emitting the upstream `@ERROR: max connections` reply rather
+/// than silently parking the excess connection.
+#[cfg(feature = "async-daemon")]
+pub(crate) fn async_max_inflight(max_connections: Option<usize>) -> usize {
+    use crate::async_listener::DEFAULT_MAX_INFLIGHT_WORKERS;
+    match max_connections {
+        Some(limit) => limit.max(DEFAULT_MAX_INFLIGHT_WORKERS),
+        None => DEFAULT_MAX_INFLIGHT_WORKERS,
+    }
 }
 
 /// Writes the upstream-compatible max-connections refusal to an accepted

--- a/crates/daemon/src/tests/chunks/daemon_async_push_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_async_push_pull.rs
@@ -176,3 +176,29 @@ fn daemon_async_rejects_privileged_module() {
         "expected privileged-module refusal, got: {rendered}"
     );
 }
+
+/// The async accept loop's worker-thread cap must never throttle below the
+/// operator's configured `max connections`, while still applying the
+/// flood-protection floor when the limit is unset or lower than the floor.
+#[cfg(feature = "async-daemon")]
+#[test]
+fn async_max_inflight_honors_configured_limit() {
+    use crate::async_listener::DEFAULT_MAX_INFLIGHT_WORKERS;
+    use crate::daemon::async_max_inflight;
+
+    // Unbounded (sync default): the flood floor alone applies.
+    assert_eq!(async_max_inflight(None), DEFAULT_MAX_INFLIGHT_WORKERS);
+
+    // A limit below the floor keeps the floor: the per-session admission
+    // semaphore refuses excess connections before the floor ever binds.
+    assert_eq!(async_max_inflight(Some(10)), DEFAULT_MAX_INFLIGHT_WORKERS);
+    assert_eq!(
+        async_max_inflight(Some(DEFAULT_MAX_INFLIGHT_WORKERS)),
+        DEFAULT_MAX_INFLIGHT_WORKERS
+    );
+
+    // A limit above the floor raises the cap so all configured sessions run
+    // concurrently instead of being silently capped at the floor.
+    assert_eq!(async_max_inflight(Some(1000)), 1000);
+    assert_eq!(async_max_inflight(Some(5000)), 5000);
+}


### PR DESCRIPTION
## Summary

The daemon's per-session dispatch has three code paths. The **production default** (`serve_connections`) is thread-per-connection with no fixed concurrency ceiling (bounded only by the configured `max connections`, default unlimited). The **opt-in `async-daemon`** path (feature-gated + `OC_RSYNC_ASYNC_DAEMON`) hosts a tokio accept loop that runs each session's synchronous worker on a dedicated OS thread (required by the per-thread seccomp filter lifetime invariant - it already does **not** use `spawn_blocking`).

### Measured ceiling

The async accept loop bounded concurrent worker threads with a hardcoded `MAX_INFLIGHT_WORKERS = 512` semaphore. This is the real ceiling for that path: a daemon configured with `max connections = 1000` was silently throttled to 512 concurrent sessions, because the accept-loop cap parks excess dispatch tasks below the operator's limit. The concurrency scaling harness (`crates/rsync_io/tests/concurrent_session_validation.rs`, up to 512 sessions) exercises this dispatch pattern.

### Change

Derive the accept-loop cap as `max(configured max connections, 512)`:
- `max connections` unset (unbounded, the sync default) -> the 512 flood floor alone applies.
- `max connections <= 512` -> floor stays 512; the per-session admission semaphore refuses excess first.
- `max connections > 512` -> cap rises to the configured limit so all configured sessions run concurrently.

Keeping the cap at or above the limit preserves the per-session refusal semantics: the admission semaphore inside the worker still emits the upstream `@ERROR: max connections (N) reached` reply rather than silently parking the excess connection. The concurrency policy is isolated in a single pure function (`async_max_inflight`), with `run_hybrid_listener` taking the cap as a parameter instead of hardcoding it.

This is the minimal safe increment. It does not restructure the daemon session lifecycle; per-session wire/auth/transfer behavior is byte-identical, only concurrency scales.

## Verification (lxhost, aarch64 Linux)

- `rustfmt --edition 2024 --check`: clean.
- `cargo clippy -p daemon -p rsync_io --features daemon/async-daemon -- -D warnings`: clean (note: the transport crate is `rsync_io`; all changes are in `daemon`).
- `cargo nextest -p daemon --features async-daemon` targeted: 6/6 pass, including the new `async_max_inflight_honors_configured_limit` unit test, the async listener cap tests, and the `daemon_async` byte-identity push/pull test proving per-session behavior is unchanged.