### PR TITLE
fix(transfer): clear content-dir flag on implied --files-from parents

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -38,6 +38,27 @@ use super::GeneratorContext;
 #[cfg(all(unix, test))]
 pub(super) use self::entry::rdev_to_major_minor;
 
+/// Marks a directory entry as an implied parent directory on the wire.
+///
+/// upstream: flist.c:1949 - `send_implied_dirs()` sets each implied parent's
+/// flags to `(flags | FLAG_IMPLIED_DIR) & ~(FLAG_TOP_DIR | FLAG_CONTENT_DIR)`,
+/// clearing CONTENT_DIR so the receiver does NOT scan the dir for `--delete`.
+/// upstream: flist.c:2419 - the `--files-from`/`--relative` transfer-root `.`
+/// is sent the same way (`& ~FLAG_CONTENT_DIR`). At encode time (flist.c:426)
+/// a dir with FLAG_IMPLIED_DIR and no FLAG_CONTENT_DIR serializes as
+/// `XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR`, which the receiver decodes back to
+/// FLAG_IMPLIED_DIR (flist.c:1117-1118) - never FLAG_CONTENT_DIR. In oc's flat
+/// encoding that wire pair is `top_dir = true` + `content_dir = false`
+/// (write/xflags.rs:93,284). A real content dir keeps `content_dir = true`.
+///
+/// Marking implied parents as content dirs (the old default) makes a real
+/// upstream receiver scan them for `--delete` and over-delete stale files
+/// upstream preserves (data loss).
+fn mark_implied_dir(entry: &mut FileEntry) {
+    entry.set_top_dir(true);
+    entry.set_content_dir(false);
+}
+
 impl GeneratorContext {
     /// Builds the file list from the specified paths.
     ///
@@ -202,8 +223,7 @@ impl GeneratorContext {
             if let Ok(meta) = std::fs::symlink_metadata(base_dir) {
                 if meta.is_dir() {
                     let mut dot_entry = self.create_entry(base_dir, PathBuf::from("."), &meta)?;
-                    dot_entry.set_top_dir(true);
-                    dot_entry.set_content_dir(false);
+                    mark_implied_dir(&mut dot_entry);
                     self.push_file_item(dot_entry, base_dir.to_path_buf());
                 }
             }
@@ -279,9 +299,13 @@ impl GeneratorContext {
                         let full = entry.base.join(&ancestor);
                         if let Ok(meta) = std::fs::symlink_metadata(&full) {
                             if meta.is_dir() {
-                                if let Ok(file_entry) =
+                                if let Ok(mut file_entry) =
                                     self.create_entry(&full, ancestor.clone(), &meta)
                                 {
+                                    // upstream: flist.c:1949 - implied parents clear
+                                    // FLAG_CONTENT_DIR so a real upstream receiver does
+                                    // not scan them for --delete (over-delete data loss).
+                                    mark_implied_dir(&mut file_entry);
                                     self.push_file_item(file_entry, full);
                                 }
                             }
@@ -418,7 +442,10 @@ impl GeneratorContext {
                 Ok(m) if m.is_dir() => m,
                 _ => continue,
             };
-            if let Ok(entry) = self.create_entry(&full, relative_ancestor, &meta) {
+            if let Ok(mut entry) = self.create_entry(&full, relative_ancestor, &meta) {
+                // upstream: flist.c:1949 - implied parents clear FLAG_CONTENT_DIR
+                // so a real upstream receiver does not scan them for --delete.
+                mark_implied_dir(&mut entry);
                 self.push_file_item(entry, full);
             }
         }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3386,6 +3386,54 @@ mod files_from {
     }
 
     #[test]
+    fn files_from_implied_parent_dir_clears_content_dir() {
+        // Task #299 (DATA-LOSS, sender wire): oc's --files-from implied-parent
+        // loop emitted purely implied parent dirs with the default
+        // content_dir=true. Upstream flist.c:1949 sets implied parents to
+        // `(flags | FLAG_IMPLIED_DIR) & ~(FLAG_TOP_DIR | FLAG_CONTENT_DIR)`,
+        // which serializes as XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR (flist.c:426)
+        // and a receiver decodes to FLAG_IMPLIED_DIR (flist.c:1117-1118) - so
+        // the receiver never scans them for --delete. With content_dir=true a
+        // real upstream receiver scans the implied parent and over-deletes
+        // stale files upstream preserves. In oc's flat encoding the correct
+        // wire pair is top_dir=true + content_dir=false.
+        //
+        // Entry `<src>/subdir/file` strips to rel `subdir/file`; `subdir` is a
+        // purely implied parent that must be sent with content_dir cleared.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        let subdir = src.join("subdir");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(subdir.join("file"), b"x").unwrap();
+
+        let handshake = test_handshake_with_protocol(32);
+        let mut config = test_config();
+        config.flags.relative = true;
+        config.args = vec![OsString::from(&src)];
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let file_paths = vec![subdir.join("file")];
+        ctx.build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
+            .unwrap();
+
+        let implied = ctx
+            .file_list()
+            .iter()
+            .find(|e| String::from_utf8_lossy(&e.name_bytes()) == "subdir")
+            .expect("implied parent `subdir` must be sent");
+        assert!(
+            !implied.content_dir(),
+            "implied parent dir must clear content_dir so an upstream receiver \
+             does not scan it for --delete (flist.c:1949)"
+        );
+        assert!(
+            implied.top_dir(),
+            "implied parent dir wire form is XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR \
+             (flist.c:426); oc encodes top_dir=true + content_dir=false"
+        );
+    }
+
+    #[test]
     fn files_from_no_relative_flattens_and_omits_implied_parents() {
         // Task #292: under --no-relative (relative_paths == 0) upstream splits
         // each --files-from entry on its LAST `/` (flist.c:2338-2349) so the


### PR DESCRIPTION
## Problem (data loss, sender wire)

The sender's `--files-from` / `--relative` implied-parent loops emitted purely implied parent directories with the default `content_dir = true`. When oc is the sender over SSH/daemon, a real upstream **receiver** then scans those implied directories during the `--delete` pass and **over-deletes stale files that upstream preserves** - silent data loss.

This is the sender-side companion to #6534, which fixed the receiver side (only scans content dirs). #6534's seal surfaced exactly one direction it could not fix on its own: oc client -> upstream server, where a stale file was still deleted. That is this bug.

## Upstream truth

- `flist.c:1949` - `send_implied_dirs()` sets each implied parent's flags to `(flags | FLAG_IMPLIED_DIR) & ~(FLAG_TOP_DIR | FLAG_CONTENT_DIR)` - implied parents clear `CONTENT_DIR`.
- `flist.c:2419` - the `--files-from` transfer-root `.` is sent via `send_file_name(".", ..., (flags | FLAG_IMPLIED_DIR) & ~FLAG_CONTENT_DIR, ...)`.
- `flist.c:423-427` - at encode time a dir with `FLAG_IMPLIED_DIR` and no `FLAG_CONTENT_DIR` serializes as `XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR`.
- `flist.c:1113-1118` - the receiver decodes that pair back to `FLAG_IMPLIED_DIR`, never `FLAG_CONTENT_DIR`, so the dir is not scanned in the delete pass.
- Contrast: a real content dir (explicit arg / recursion target) keeps `FLAG_CONTENT_DIR`.

## Fix

A single shared predicate `mark_implied_dir()` sets `top_dir = true` + `content_dir = false` (oc's flat encoding of the `XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR` wire pair, per `write/xflags.rs:93,284`). It is applied to:

- the `--files-from` implied-parent loop,
- the `--relative` positional implied-parent loop (`emit_implied_parents`),
- the `--files-from`/`--relative` transfer-root `.` entry (deduplicated with the existing inline logic).

Real content dirs (explicit args / recursion targets) are untouched and keep `content_dir = true`. The affected code paths are gated on `--relative` / `--files-from`, so a plain non-relative transfer's flist bytes are unchanged (wire-transparent).

## Test

`files_from_implied_parent_dir_clears_content_dir` builds a `--files-from` list with a nested `subdir/file` and asserts the implied `subdir` entry has `content_dir` cleared and `top_dir` set. Fails before, passes after.

## Empirical seal vs rsync 3.4.4

`--files-from subdir/file --delete` with a pre-existing stale file in the implied `subdir/` at the destination:

| Direction | Result |
|-----------|--------|
| upstream -> upstream (reference) | stale PRESERVED |
| **oc (sender) -> upstream (receiver), SSH** | **stale PRESERVED** (was DELETED before this fix) |
| oc -> oc, SSH | stale PRESERVED |
| `diff -r` oc->upstream vs upstream->upstream | identical, byte-for-byte |