### PR TITLE
test(matching): pin dup-free long-literal chunk-boundary wire seam

### DIFF
--- a/crates/matching/tests/parallel_delta_wire_parity.rs
+++ b/crates/matching/tests/parallel_delta_wire_parity.rs
@@ -193,6 +193,70 @@ fn parallel_delta_dup_free_is_wire_identical() {
     }
 }
 
+/// A LONG literal run - far exceeding the sequential flush cadence of
+/// `block_len + 32 KiB` - straddling a chunk boundary makes the parallel scan
+/// diverge from the sequential scan on the wire even for a DUPLICATE-FREE
+/// basis. This is the residual literal-run segmentation seam the design
+/// blueprint warns about and the reason the parallel scan must stay opt-in:
+/// reconstruction and the matched/literal byte counts are unaffected, but the
+/// literal-token length-prefix framing shifts at each range join, so the wire
+/// bytes are not byte-identical to the single continuous sequential run.
+///
+/// The single-byte-edit case in `parallel_delta_dup_free_is_wire_identical`
+/// only ever leaves a SHORT literal (one straddling block) at each boundary,
+/// which the seam-join coalescing fully restores; it therefore cannot detect
+/// this divergence. This test pins the long-literal case explicitly. If a
+/// future overlapping-range / literal-coalesce fix removes the seam, this test
+/// flips to equality - the signal that a default-on flip could be reconsidered.
+#[test]
+fn parallel_delta_dup_free_long_literal_seam_diverges() {
+    let basis = lcg_bytes(0x9A7A_11E1_0DE1_2025, DUP_FREE_LEN);
+    let index = build_index(&basis, BLOCK_LEN);
+    assert!(
+        !index.has_duplicate_blocks(),
+        "random basis must be duplicate-free so the parallel path is eligible"
+    );
+
+    // Rewrite a 200 KiB region centred on the n/2 chunk boundary (which is
+    // shared by chunk counts 2, 4, and 8 because DUP_FREE_LEN is divisible by
+    // 8) with fresh, duplicate-free bytes, so it becomes one long literal run
+    // that every one of those splits bisects.
+    const LIT: usize = 200 * 1024;
+    let mid = DUP_FREE_LEN / 2;
+    let start = mid - LIT / 2;
+    let fresh = lcg_bytes(0xF00D_BEEF_1234_5678, LIT);
+    let mut source = basis.clone();
+    source[start..start + LIT].copy_from_slice(&fresh);
+
+    let generator = DeltaGenerator::new();
+    let sequential = generator
+        .generate(Cursor::new(source.clone()), &index)
+        .expect("sequential");
+    let seq_wire = script_to_wire_bytes(&sequential, index.block_length());
+
+    let mut any_diverge = false;
+    for &chunks in &[2usize, 4, 8] {
+        let chunked = generator
+            .generate_chunked(&source, &index, chunks)
+            .expect("chunked");
+        let chunked_wire = script_to_wire_bytes(&chunked, index.block_length());
+        assert_eq!(
+            reconstruct(&basis, &index, &chunked),
+            source,
+            "chunked reconstruction must stay correct for chunks={chunks} despite the seam"
+        );
+        if chunked_wire != seq_wire {
+            any_diverge = true;
+        }
+    }
+    assert!(
+        any_diverge,
+        "a long literal run straddling a chunk boundary must diverge on the wire for at \
+         least one chunk count; equality here would mean the seam is fixed and the \
+         duplicate-free opt-in gate could be revisited"
+    );
+}
+
 /// Source length for the duplicate-heavy fixture: large enough to split into
 /// several ranges (> 2x the 1 MiB per-range floor).
 const DUP_HEAVY_LEN: usize = 4 * 1024 * 1024;


### PR DESCRIPTION
## Summary

The opt-in `--parallel-delta-scan` (`DeltaGenerator::generate_chunked`) is only wire-transparent when matched blocks never straddle a range boundary and any literal at a boundary is short. This adds the regression test for the one case the existing suite missed: a **long literal run straddling a chunk boundary on a duplicate-free basis**, which re-segments the literal-token framing at the range join and makes the parallel wire bytes diverge from the sequential scan.

This test-only change documents and pins **why the parallel scan must remain opt-in (default-off)** and guards against a premature default-on flip.

## Why the existing coverage was insufficient

`parallel_delta_wire_parity.rs` had two tests:
- `parallel_delta_dup_free_is_wire_identical` - single-byte edits at every boundary. These leave only a **short** literal (one straddling block), which the seam-join coalescing fully restores, so the wire stays byte-identical. It cannot detect the long-literal seam.
- `parallel_delta_dup_heavy_diverges` - duplicate-content divergence, a different gate.

Neither covers a long literal run (larger than the sequential `block_len + 32 KiB` flush cadence) landing on a chunk boundary - exactly the residual seam noted in the design docs and the code comments on `generate_chunked`.

## Evidence

Verified against real upstream rsync 3.4.4 on a Linux aarch64 host with an 80 MiB duplicate-free basis and a 512 KiB region rewritten across the 40 MiB chunk boundary, pushing oc-rsync sender -> daemon and capturing the client->server (sender) byte stream:

| RAYON threads | sequential c2s bytes | parallel c2s bytes | delta |
|---|---|---|---|
| 2 | 575630 | 575630 | equal length, different bytes |
| 4 | 575630 | 593934 | +18304 |
| 8 | 575630 | 630546 | +54912 |

In all cases the reconstructed file was byte-identical to the source, and a real upstream rsync 3.4.4 daemon receiving the parallel push reconstructed the file byte-identically - the divergence is pure literal-token framing, never data. The equivalent in-process comparison (this test) shows the chunked wire bytes differ from sequential at chunk counts 2/4/8 while `parallel_delta_dup_free_is_wire_identical` (short literals) stays identical.

Because oc's sequential path matches upstream's serial framing byte-for-byte and the parallel path does not, flipping the scan to default-on would change what oc emits on the wire for every eligible >= 64 MiB duplicate-free transfer. The scan therefore stays opt-in until an overlapping-range / literal-coalesce fix removes the seam; when that lands, this test flips to equality and signals the gate can be revisited.

## Scope

- One test added to `crates/matching/tests/parallel_delta_wire_parity.rs`, reusing the file's existing helpers.
- No production code, defaults, or flags changed.
- `rustfmt --edition 2024` clean; the full `parallel_delta` test set passes.