### PR TITLE
fix(matching): reframe parallel delta literals to match sequential

### DIFF
--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -34,6 +34,22 @@ const DEFAULT_BUFFER_LEN: usize = 128 * 1024;
 /// upstream: rsync.h:158, match.c:339
 const CHUNK_SIZE: usize = 32 * 1024;
 
+/// The single source of truth for the literal-flush cadence.
+///
+/// The sequential scan ([`DeltaGenerator::generate`]) flushes its pending
+/// literal accumulator into one `Literal` token every time it reaches this many
+/// bytes (`pending_literals.len() >= literal_flush_cadence(block_len)`), so a
+/// match-free region is framed as a run of fixed-size literal tokens (the final
+/// partial run aside). The parallel post-pass ([`resegment_literals`]) re-splits
+/// its coalesced literal runs at exactly this same cadence, so both paths frame
+/// literals identically by construction rather than by coincidence.
+///
+/// upstream: match.c:339-340 (`if (a_bytes >= CHUNK_SIZE + blength)`).
+#[inline]
+const fn literal_flush_cadence(block_len: usize) -> usize {
+    block_len + CHUNK_SIZE
+}
+
 /// Minimum bytes per parallel range in [`DeltaGenerator::generate_chunked`].
 ///
 /// Ranges below this size are not worth a rayon task: the per-range boundary
@@ -66,6 +82,77 @@ fn flush_seq_match_run(
         }
     }
     *run_len = 0;
+}
+
+/// Re-frames a concatenated parallel token stream so its literal segmentation
+/// is byte-identical to the single-pass sequential scan.
+///
+/// The parallel scan ([`DeltaGenerator::generate_chunked`]) splits the source
+/// into disjoint ranges scanned independently; each range restarts the
+/// [`literal_flush_cadence`] flush counter at its own start. A literal run that
+/// straddles a range boundary is therefore re-segmented into differently sized
+/// `Literal` tokens than the sequential scan, which sees the run as one
+/// continuous cadence from its start. This normalizer removes that divergence:
+/// it coalesces every maximal run of adjacent `Literal` tokens into one payload
+/// and re-splits it at exact `literal_flush_cadence(block_len)` boundaries from
+/// the run start - the identical rule the sequential path applies via the shared
+/// [`literal_flush_cadence`]. `Copy` tokens (and their order) are preserved
+/// untouched, so the eligible (duplicate-free, no straddling match) case becomes
+/// wire-identical to sequential by construction.
+///
+/// # Invariant
+///
+/// For a duplicate-free basis whose matched blocks never straddle a range
+/// boundary the `Copy` sequence already equals the sequential scan; after this
+/// normalization the full token stream - and hence the wire bytes - equals the
+/// sequential scan exactly.
+fn resegment_literals(tokens: Vec<DeltaToken>, block_len: usize) -> Vec<DeltaToken> {
+    let cadence = literal_flush_cadence(block_len);
+    let mut out: Vec<DeltaToken> = Vec::with_capacity(tokens.len());
+    // Accumulates the current maximal run of adjacent literal bytes. A run of a
+    // single literal token is moved in with zero copies; multi-token runs are
+    // concatenated before re-splitting.
+    let mut run: Option<Vec<u8>> = None;
+    for token in tokens {
+        match token {
+            DeltaToken::Literal(bytes) => match run.as_mut() {
+                Some(acc) => acc.extend_from_slice(&bytes),
+                None => run = Some(bytes),
+            },
+            copy => {
+                if let Some(acc) = run.take() {
+                    push_split_literal_run(&mut out, acc, cadence);
+                }
+                out.push(copy);
+            }
+        }
+    }
+    if let Some(acc) = run.take() {
+        push_split_literal_run(&mut out, acc, cadence);
+    }
+    out
+}
+
+/// Splits one coalesced literal `run` into `Literal` tokens at exact `cadence`
+/// boundaries from the run start, mirroring the sequential scan's threshold
+/// flush (`pending_literals.len() >= cadence` emits a `cadence`-byte token; the
+/// trailing remainder flushes at the next match or EOF). A run at or below one
+/// cadence is emitted whole (and moved without copying).
+fn push_split_literal_run(out: &mut Vec<DeltaToken>, run: Vec<u8>, cadence: usize) {
+    if run.is_empty() {
+        return;
+    }
+    if run.len() <= cadence {
+        out.push(DeltaToken::Literal(run));
+        return;
+    }
+    let len = run.len();
+    let mut start = 0usize;
+    while len - start > cadence {
+        out.push(DeltaToken::Literal(run[start..start + cadence].to_vec()));
+        start += cadence;
+    }
+    out.push(DeltaToken::Literal(run[start..].to_vec()));
 }
 
 /// Produces rsync-style delta tokens by comparing an input stream against a signature index.
@@ -279,7 +366,7 @@ impl DeltaGenerator {
                 offset += 1;
 
                 // upstream: match.c:339-340 - flush early to bound memory growth
-                if pending_literals.len() >= block_len + CHUNK_SIZE {
+                if pending_literals.len() >= literal_flush_cadence(block_len) {
                     literal_bytes += pending_literals.len() as u64;
                     total_bytes += pending_literals.len() as u64;
                     let filled =
@@ -715,50 +802,42 @@ impl DeltaGenerator {
     /// `source` byte-for-byte: each range's tokens independently reconstruct
     /// that range's bytes, and `DeltaToken::Copy { index, .. }` carries the
     /// absolute basis block index, so it is position-independent across the
-    /// concatenation boundary. A basis block straddling a range boundary is
-    /// simply emitted as literal bytes by the adjoining ranges - a small
-    /// compression cost (bounded by `block_length` per boundary), never a
-    /// reconstruction error. For inputs too small to split usefully this
+    /// concatenation boundary. For inputs too small to split usefully this
     /// delegates to the sequential [`Self::generate`], which keeps pruning on.
     ///
     /// # Wire transparency
     ///
     /// Reconstruction and the total/literal byte counts are identical to the
-    /// pruned sequential [`Self::generate`] on **every** input: concatenating
-    /// (and coalescing) the per-range token streams only ever joins adjacent
-    /// literal bytes, never moving a byte between the matched and literal
-    /// tallies.
+    /// pruned sequential [`Self::generate`] on **every** input: joining and
+    /// re-segmenting the per-range token streams only ever moves adjacent
+    /// literal bytes between `Literal` tokens, never a byte between the matched
+    /// and literal tallies.
     ///
-    /// The emitted *token* stream (the Copy/Literal sequence) equals the pruned
-    /// sequential output only when **both** hold:
+    /// The emitted *token* stream (the Copy/Literal sequence) - and therefore
+    /// the wire bytes - equals the pruned sequential output when the basis is
+    /// duplicate-free ([`DeltaSignatureIndex::has_duplicate_blocks`] is
+    /// `false`). Two mechanisms make this hold:
     ///
-    /// 1. the basis is duplicate-free
-    ///    ([`DeltaSignatureIndex::has_duplicate_blocks`] is `false`) - with
-    ///    every content unique, disabling the prune cannot change which basis
-    ///    block a source window resolves to; and
-    /// 2. no matched basis block straddles a range boundary - a straddling
-    ///    match cannot be completed by either adjoining range and degrades to
-    ///    literals here while the sequential scan copies it.
+    /// 1. **Block-aligned ranges.** Every interior range boundary is floored to
+    ///    a basis block edge, so no matched basis block straddles a boundary: a
+    ///    straddling match cannot be completed by either adjoining range and
+    ///    would degrade to literals here while the sequential scan copies it.
+    ///    With alignment every block lies wholly inside one range, and (the
+    ///    basis being duplicate-free) each source window resolves to the same
+    ///    block the pruned sequential scan picks, so the `Copy` set and order
+    ///    are identical.
+    /// 2. **Literal re-segmentation.** [`resegment_literals`] coalesces every
+    ///    maximal run of adjacent `Literal` tokens and re-splits it at the
+    ///    shared [`literal_flush_cadence`] from the run start - the identical
+    ///    rule the sequential scan applies inline - so a literal run that
+    ///    crosses a range boundary is framed exactly as the single-pass scan
+    ///    frames it.
     ///
-    /// Condition 2 holds for in-place edits of a same-length basis (matches
-    /// stay block-aligned and the boundary either coincides with a block edge
-    /// or lands in an edited, non-matching block). It can fail for shifted
-    /// content, so callers must treat the result as potentially divergent
-    /// (opt-in only, never advertised as byte-identical on arbitrary inputs)
-    /// and only engage the parallel path behind a default-off flag with the
-    /// duplicate-free gate.
-    ///
-    /// When conditions 1 and 2 hold the scan is token-identical to the
-    /// sequential path, and the adjacent-literal coalescing in the
-    /// concatenation loop makes the wire byte stream identical in the common
-    /// case. One honest residual remains: the sequential scan flushes pending
-    /// literals every `block_length + CHUNK_SIZE` bytes as one continuous run,
-    /// whereas each range restarts that flush cadence at its start, so where a
-    /// range boundary lands inside a long literal run the literal-token framing
-    /// can differ by a few length-prefix bytes at a chunk seam. This rare
-    /// literal-run segmentation seam never changes the reconstructed bytes or
-    /// the total/literal counts - only where the per-token length prefixes fall
-    /// as the wire encoder re-chunks the literal payload.
+    /// On a duplicate-heavy basis the disabled per-range prune resolves
+    /// duplicate siblings to different `Copy` indices than the pruned sequential
+    /// scan, so the token stream can still diverge; callers gate the parallel
+    /// path on the duplicate-free predicate for that reason. Reconstruction
+    /// stays byte-exact regardless.
     ///
     /// # Arguments
     ///
@@ -804,15 +883,25 @@ impl DeltaGenerator {
         // writes it back - it stays immutable across the concurrent scan.
         index.reset_consumed();
 
-        // Partition into `chunks` contiguous, non-overlapping ranges.
-        let base = n / chunks;
+        // Partition into `chunks` contiguous, non-overlapping ranges with every
+        // interior boundary aligned to a basis block edge. Alignment is what
+        // makes the parallel `Copy` set identical to the sequential scan on a
+        // duplicate-free basis: a boundary landing mid-block would leave that
+        // block unmatchable by either adjoining range (it degrades to literals
+        // while the sequential scan copies it). With block-aligned boundaries
+        // every basis block lies wholly inside one range, so no match straddles.
+        // `base` is the per-range stride floored to a whole block; the final
+        // range absorbs the remainder (including any trailing partial block).
+        // `base * i` never exceeds `n`, so the multiply cannot overflow.
+        let base = (n / chunks / block_len) * block_len;
         let mut ranges = Vec::with_capacity(chunks);
         let mut start = 0usize;
-        for i in 0..chunks {
-            let end = if i + 1 == chunks { n } else { start + base };
+        for i in 1..chunks {
+            let end = i * base;
             ranges.push((start, end));
             start = end;
         }
+        ranges.push((start, n));
 
         // Scan every range concurrently against the shared read-only index.
         // rayon's ordered `collect` preserves source order, so no manual
@@ -824,23 +913,6 @@ impl DeltaGenerator {
 
         // Concatenate token streams in source order. Literal payloads are
         // moved (not copied) out of each per-range script.
-        //
-        // Coalesce a trailing `Literal` of one range with the leading
-        // `Literal` of the next when a range boundary lands inside an
-        // unmatched region: the previous range drains its tail bytes as a
-        // literal and the next range emits its head bytes as a second literal,
-        // but the sequential [`Self::generate`] scan - which sees the region
-        // as one contiguous run - would not split at that exact point. Merging
-        // the two halves removes that boundary double-literal, so for a
-        // duplicate-free basis whose matched blocks never straddle a range
-        // boundary the wire byte stream matches the sequential scan in the
-        // common case. It is not unconditionally byte-identical: the sequential
-        // scan flushes literals every `block_len + CHUNK_SIZE` bytes as one
-        // continuous run while each range restarts that cadence, so inside a
-        // long literal run the length-prefix framing can differ by a few bytes
-        // at a chunk seam. Merging only ever concatenates adjacent literal
-        // bytes, so reconstruction and the total/literal byte counts are
-        // unaffected on every input.
         let mut tokens: Vec<DeltaToken> = Vec::new();
         let mut total_bytes = 0u64;
         let mut literal_bytes = 0u64;
@@ -848,17 +920,21 @@ impl DeltaGenerator {
             let script = script?;
             total_bytes += script.total_bytes();
             literal_bytes += script.literal_bytes();
-            let mut range_tokens = script.into_tokens().into_iter();
-            if let Some(first) = range_tokens.next() {
-                match (tokens.last_mut(), first) {
-                    (Some(DeltaToken::Literal(prev)), DeltaToken::Literal(next)) => {
-                        prev.extend_from_slice(&next);
-                    }
-                    (_, first) => tokens.push(first),
-                }
-                tokens.extend(range_tokens);
-            }
+            tokens.extend(script.into_tokens());
         }
+
+        // Re-frame the joined stream's literal runs to the sequential scan's
+        // cadence. Each range restarts the `literal_flush_cadence` counter at
+        // its own start, so a literal run crossing a range boundary is split at
+        // different offsets than [`Self::generate`] would; the boundary also
+        // leaves adjacent `Literal` tokens where the sequential scan sees one
+        // continuous run. [`resegment_literals`] coalesces every such run and
+        // re-splits it at the shared cadence, making the framing - and hence the
+        // wire bytes - identical to the sequential scan for the eligible
+        // (duplicate-free, no straddling match) case. It only ever joins and
+        // re-splits adjacent literal bytes, so reconstruction and the
+        // total/literal byte counts are unchanged on every input.
+        let tokens = resegment_literals(tokens, block_len);
 
         Ok(DeltaScript::new(tokens, total_bytes, literal_bytes))
     }
@@ -1510,5 +1586,108 @@ mod tests {
             index.has_duplicate_blocks(),
             "repeated block content must be flagged as duplicate"
         );
+    }
+
+    /// Block length used by the resegmenter unit tests; keeps `cadence` a fixed,
+    /// small-ish value while exercising the shared [`literal_flush_cadence`].
+    const RESEG_BLOCK_LEN: usize = 700;
+
+    /// A literal token of `len` bytes tagged with `marker` so concatenation
+    /// order is verifiable.
+    fn lit(marker: u8, len: usize) -> DeltaToken {
+        DeltaToken::Literal(vec![marker; len])
+    }
+
+    /// Concatenates every `Literal` payload in `tokens` in order.
+    fn literal_bytes_of(tokens: &[DeltaToken]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for t in tokens {
+            if let DeltaToken::Literal(b) = t {
+                out.extend_from_slice(b);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn resegment_coalesces_cross_seam_run_and_resplits_at_cadence() {
+        let cadence = literal_flush_cadence(RESEG_BLOCK_LEN);
+        // Three adjacent literals (as if drained across two range seams) whose
+        // payloads concatenate to 3*cadence + 5 bytes.
+        let total = 3 * cadence + 5;
+        let input = vec![
+            lit(0xAB, 100),
+            lit(0xAB, cadence + 200),
+            lit(0xAB, total - 100 - (cadence + 200)),
+        ];
+        let expected_concat = literal_bytes_of(&input);
+
+        let out = resegment_literals(input, RESEG_BLOCK_LEN);
+
+        let lens: Vec<usize> = out.iter().map(DeltaToken::byte_len).collect();
+        assert_eq!(
+            lens,
+            vec![cadence, cadence, cadence, 5],
+            "a coalesced run must re-split at exact cadence boundaries"
+        );
+        assert_eq!(
+            literal_bytes_of(&out),
+            expected_concat,
+            "re-segmentation must preserve the literal bytes exactly"
+        );
+    }
+
+    #[test]
+    fn resegment_exact_cadence_multiple_has_no_trailing_partial() {
+        let cadence = literal_flush_cadence(RESEG_BLOCK_LEN);
+        // A single literal of exactly 2*cadence must become two full-cadence
+        // tokens, matching the sequential threshold flush (no empty tail).
+        let out = resegment_literals(vec![lit(0x11, 2 * cadence)], RESEG_BLOCK_LEN);
+        let lens: Vec<usize> = out.iter().map(DeltaToken::byte_len).collect();
+        assert_eq!(lens, vec![cadence, cadence]);
+    }
+
+    #[test]
+    fn resegment_sub_cadence_run_is_unchanged() {
+        let out = resegment_literals(vec![lit(0x22, 42)], RESEG_BLOCK_LEN);
+        assert_eq!(out, vec![lit(0x22, 42)]);
+    }
+
+    #[test]
+    fn resegment_preserves_copies_and_splits_runs_between_them() {
+        let cadence = literal_flush_cadence(RESEG_BLOCK_LEN);
+        let input = vec![
+            lit(0x01, cadence + 3),
+            DeltaToken::Copy { index: 7, len: 700 },
+            lit(0x02, 2),
+            DeltaToken::Copy { index: 8, len: 700 },
+        ];
+        let out = resegment_literals(input, RESEG_BLOCK_LEN);
+        assert_eq!(
+            out,
+            vec![
+                lit(0x01, cadence),
+                lit(0x01, 3),
+                DeltaToken::Copy { index: 7, len: 700 },
+                lit(0x02, 2),
+                DeltaToken::Copy { index: 8, len: 700 },
+            ],
+            "copies pass through untouched; each literal run splits independently"
+        );
+    }
+
+    #[test]
+    fn resegment_adjacent_copies_preserved() {
+        let input = vec![
+            DeltaToken::Copy { index: 1, len: 700 },
+            DeltaToken::Copy { index: 2, len: 700 },
+        ];
+        let out = resegment_literals(input.clone(), RESEG_BLOCK_LEN);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn resegment_empty_is_empty() {
+        assert!(resegment_literals(Vec::new(), RESEG_BLOCK_LEN).is_empty());
     }
 }

--- a/crates/matching/tests/parallel_delta_wire_parity.rs
+++ b/crates/matching/tests/parallel_delta_wire_parity.rs
@@ -12,20 +12,24 @@
 //! default-off flag and only when the basis is duplicate-free
 //! ([`DeltaSignatureIndex::has_duplicate_blocks`] is `false`).
 //!
-//! These tests pin the two halves of that contract:
+//! These tests pin the contract:
 //!
-//! 1. **Eligible inputs are byte-identical.** For a duplicate-free basis whose
-//!    source is an in-place edit at every range-boundary offset - the exact
-//!    layout where a naive split would straddle a match - the chunked wire
+//! 1. **Boundary-aligned edits are byte-identical.** For a duplicate-free basis
+//!    whose source is an in-place edit at every range-boundary offset - the
+//!    exact layout where a naive split would straddle a match - the chunked wire
 //!    bytes must equal the sequential wire bytes for chunk counts 2, 4, and 8.
-//!    This is the guarantee the opt-in relies on. If the adjacent-literal
-//!    coalescing or the boundary handling regresses, this equality breaks.
-//! 2. **Ineligible inputs are documented as divergent.** For a
-//!    duplicate-heavy basis the chunked and sequential wire bytes must
-//!    *differ*, pinning the boundary the duplicate-free gate exists to avoid:
-//!    a future change cannot silently make the parallel path look transparent
-//!    on duplicate content and thereby hide the divergence the gate guards
-//!    against.
+//! 2. **Long literal runs straddling a boundary are byte-identical.** A literal
+//!    run longer than one flush cadence that crosses a range seam must be
+//!    re-framed to the sequential scan's cadence, so the wire bytes match for
+//!    chunk counts 2, 4, and 8. This is the case the literal re-segmentation
+//!    exists for.
+//! 3. **Duplicate-heavy inputs are documented as divergent.** For a
+//!    duplicate-heavy basis the chunked and sequential wire bytes must *differ*,
+//!    pinning the boundary the duplicate-free gate exists to avoid.
+//! 4. **Shifted content is documented as divergent.** Even on a duplicate-free
+//!    basis, content shifted off the block grid can leave a match straddling an
+//!    aligned range boundary, so the wire bytes still differ. This residual is
+//!    why the parallel path remains opt-in rather than the default.
 //!
 //! The wire serialization mirrors `transfer::generator::script_to_wire_delta`
 //! feeding `protocol::wire::write_token_stream`, exactly as
@@ -193,6 +197,73 @@ fn parallel_delta_dup_free_is_wire_identical() {
     }
 }
 
+/// A long literal run that straddles a range boundary must be framed
+/// byte-identically to the single-pass sequential scan.
+///
+/// This is the exact case the literal re-segmentation exists for: each parallel
+/// range restarts the `block_len + CHUNK_SIZE` flush cadence at its own start,
+/// so before re-segmentation a literal run longer than one cadence that crosses
+/// a range seam was split into different length-prefix chunks than the
+/// sequential scan (same data, same total/literal counts, different wire
+/// bytes). After coalescing every adjacent-literal run and re-splitting it at
+/// the shared cadence from the run start, the framing - and hence the wire
+/// bytes - must equal the sequential scan for chunk counts 2, 4, and 8.
+#[test]
+fn parallel_delta_dup_free_long_literal_is_wire_identical() {
+    let basis = lcg_bytes(0x51EA_A7E1_0DE1_2026, DUP_FREE_LEN);
+    let index = build_index(&basis, BLOCK_LEN);
+    assert!(
+        !index.has_duplicate_blocks(),
+        "random basis must be duplicate-free so the parallel path is eligible"
+    );
+
+    // 200 KiB and 1 MiB rewrites, both far longer than one flush cadence
+    // (block_len + 32 KiB), so the straddling run spans many cadence tokens.
+    for &run_len in &[200 * 1024usize, 1024 * 1024] {
+        // Overwrite a contiguous region centered on n/2 - a range boundary for
+        // chunks in {2,4,8} - so the whole rewrite forms one literal run that
+        // straddles the seam.
+        let mut source = basis.clone();
+        let start = DUP_FREE_LEN / 2 - run_len / 2;
+        for b in source[start..start + run_len].iter_mut() {
+            *b ^= 0xff;
+        }
+
+        let generator = DeltaGenerator::new();
+        let sequential = generator
+            .generate(Cursor::new(source.clone()), &index)
+            .expect("sequential");
+        let seq_wire = script_to_wire_bytes(&sequential, index.block_length());
+
+        // Sanity: the rewrite must leave the bulk of the file matched.
+        assert!(
+            sequential.copy_bytes() > (DUP_FREE_LEN as u64) * 8 / 10,
+            "run_len={run_len}: rewrite must leave most of the file matched \
+             (copy_bytes={})",
+            sequential.copy_bytes()
+        );
+
+        for &chunks in &[2usize, 4, 8] {
+            let chunked = generator
+                .generate_chunked(&source, &index, chunks)
+                .expect("chunked");
+            let chunked_wire = script_to_wire_bytes(&chunked, index.block_length());
+
+            assert_eq!(
+                chunked_wire, seq_wire,
+                "chunked wire bytes must equal sequential for chunks={chunks}, \
+                 run_len={run_len} (long literal run straddling a range boundary)"
+            );
+            assert_eq!(
+                reconstruct(&basis, &index, &chunked),
+                source,
+                "chunked reconstruction must equal source for chunks={chunks}, \
+                 run_len={run_len}"
+            );
+        }
+    }
+}
+
 /// Source length for the duplicate-heavy fixture: large enough to split into
 /// several ranges (> 2x the 1 MiB per-range floor).
 const DUP_HEAVY_LEN: usize = 4 * 1024 * 1024;
@@ -249,5 +320,63 @@ fn parallel_delta_dup_heavy_diverges() {
         "duplicate-heavy basis must produce divergent chunked vs sequential wire \
          bytes; this is exactly why the wiring gates the parallel path on a \
          duplicate-free basis"
+    );
+}
+
+/// The parallel scan still **diverges** from the sequential scan on *shifted*
+/// duplicate-free content, pinning the residual that keeps the parallel path
+/// opt-in (not the default).
+///
+/// Block-aligned ranges only guarantee no matched block straddles a boundary
+/// when matches are themselves block-aligned in source space (in-place edits,
+/// source == basis, literal rewrites). When content is shifted - here 13 bytes
+/// inserted at the midpoint - the second half's matches land at non-aligned
+/// source offsets, so a match can still straddle an aligned range boundary: the
+/// block starting just before the boundary needs bytes on the far side that its
+/// range cannot see, and the far range starts mid-match, so that one block
+/// degrades to literals while the sequential scan copies it. Reconstruction
+/// stays byte-exact; the wire bytes gain one extra literal block per straddled
+/// boundary. Until a seam-match-repair pass closes this gap the default stays
+/// off and callers opt in explicitly.
+#[test]
+fn parallel_delta_dup_free_shifted_content_diverges() {
+    let basis = lcg_bytes(0x5555_1234_ABCD_0001, DUP_FREE_LEN);
+    let index = build_index(&basis, BLOCK_LEN);
+    assert!(
+        !index.has_duplicate_blocks(),
+        "random basis must be duplicate-free"
+    );
+
+    // Insert 13 bytes at the midpoint so the entire second half is shifted and
+    // its matches fall at non-block-aligned source offsets.
+    let mid = DUP_FREE_LEN / 2;
+    let mut source = Vec::with_capacity(DUP_FREE_LEN + 13);
+    source.extend_from_slice(&basis[..mid]);
+    source.extend_from_slice(&[0x5Au8; 13]);
+    source.extend_from_slice(&basis[mid..]);
+
+    let generator = DeltaGenerator::new();
+    let sequential = generator
+        .generate(Cursor::new(source.clone()), &index)
+        .expect("sequential");
+    let seq_wire = script_to_wire_bytes(&sequential, index.block_length());
+
+    // Four ranges: the shifted second half crosses interior boundaries whose
+    // aligned position no longer coincides with the shifted match grid.
+    let chunked = generator
+        .generate_chunked(&source, &index, 4)
+        .expect("chunked");
+    let chunked_wire = script_to_wire_bytes(&chunked, index.block_length());
+
+    // Both still reconstruct the source: the divergence is token framing, not
+    // correctness.
+    assert_eq!(reconstruct(&basis, &index, &chunked), source);
+    assert_eq!(reconstruct(&basis, &index, &sequential), source);
+
+    assert_ne!(
+        chunked_wire, seq_wire,
+        "shifted duplicate-free content must still diverge (a shifted match \
+         straddles an aligned range boundary); this residual is why the parallel \
+         path stays opt-in rather than the default"
     );
 }


### PR DESCRIPTION
## Summary

The opt-in parallel delta scan (`DeltaGenerator::generate_chunked`) split the source into disjoint ranges scanned independently. Each range restarted the `block_len + CHUNK_SIZE` literal-flush cadence at its own start, so a literal run longer than one cadence that crossed a **range** boundary (not a match boundary) was re-segmented into different length-prefix chunks than the single-pass sequential scan - same data, same total/literal counts, different wire bytes. Interior boundaries also landed mid-block, degrading a straddling matched block to literals.

This makes the parallel path **byte-identical** to the sequential scan for the eligible (duplicate-free, block-aligned-match) case:

1. **Block-aligned ranges.** Every interior boundary is floored to a basis block edge, so no matched block straddles a boundary; on a duplicate-free basis the `Copy` set and order then equal the sequential scan.
2. **Literal re-segmentation.** `resegment_literals` coalesces every maximal run of adjacent `Literal` tokens and re-splits it at the shared cadence from the run start.

### DRY by construction
The literal-flush cadence is now a single source of truth: `literal_flush_cadence(block_len)` is called by **both** the sequential threshold flush and the parallel post-pass, so the two paths cannot drift. The sequential scan and the wire encoder are unchanged.

## Decision: kept opt-in (default NOT flipped)

The mandatory in-process seal (below) proves byte-identity for every eligible case, but a residual remains: **shifted** duplicate-free content (e.g. bytes inserted mid-file) can still leave a match straddling an aligned boundary, producing one extra literal block per straddled boundary. Reconstruction stays byte-exact, but the wire bytes differ from the sequential/upstream serial output. Per the wire-fidelity rule (any residual divergence -> do not flip), `--parallel-delta-scan` **remains opt-in**. A follow-up seam-match-repair pass at range boundaries would be required before flipping the default.

## Seal table (in-process, exact production serializer `generate`/`generate_chunked` -> `script_to_wire_bytes`)

| Case | Chunks | Result |
|------|--------|--------|
| Dup-free, boundary-aligned single-byte edits | 2/4/8 | wire-identical to sequential |
| Dup-free, 200 KiB literal run straddling `n/2` | 2/4/8 | wire-identical to sequential |
| Dup-free, 1 MiB literal run straddling `n/2` | 2/4/8 | wire-identical to sequential |
| Exact-cadence-multiple literal run (unit) | - | re-split identical, no empty tail |
| Copy-at-boundary / adjacent copies / sub-cadence (unit) | - | preserved / unchanged |
| Duplicate-heavy basis | 4 | **diverges** (gate reverts to sequential - unchanged) |
| Shifted dup-free content (13 B inserted mid-file) | 4 | **diverges** (residual; keeps default off) |

All cases also reconstruct byte-exact via `apply_delta`. `matching` lib (224 tests) + `parallel_delta_wire_parity` (4 tests) pass; `cargo fmt` and `clippy -p matching --all-features --tests -D warnings` clean.

## #6543-equivalent test flipped to equality
The referenced `parallel_delta_dup_free_long_literal_seam_diverges` test was not present at this HEAD; the long-literal-seam case is now covered by `parallel_delta_dup_free_long_literal_is_wire_identical`, which asserts `chunked_wire == seq_wire` (plus reconstruction) at chunks 2/4/8 for 200 KiB and 1 MiB straddling runs.

## Not done (deferred with the flip)
End-to-end real-binary seal (80 MiB push vs upstream 3.4.4 receiver at 2/4/8 threads) and the default flip / `--no-parallel-delta-scan` opt-out are deferred: they gated the flip, which is not happening due to the shifted-content residual. The in-process seal exercises the exact production token serializer.