### PR TITLE
fix(transfer): forward full itemize iflags on push so new files show +++

### DIFF
--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -269,6 +269,7 @@ impl ReceiverContext {
                                 basis_result.basis_path,
                                 basis_result.fnamecmp_type,
                                 file_entry.size(),
+                                base_iflags,
                                 &request_config,
                             )?;
 
@@ -292,6 +293,7 @@ impl ReceiverContext {
                                 None,
                                 protocol::FnameCmpType::Fname,
                                 file_entry.size(),
+                                base_iflags,
                                 &request_config,
                             )?;
 
@@ -486,15 +488,19 @@ impl ReceiverContext {
         // upstream: io.c perform_io() flushes output via select() while waiting
         // for input. We flush once before blocking on each response read, but
         // only when needed (the multiplex dirty-flag skips redundant syscalls).
-        for &(file_idx, file_entry, _, _) in files_to_transfer {
+        for &(file_idx, file_entry, _, base_iflags) in files_to_transfer {
             // upstream: generator.c:1925 - write_ndx(f_out, ndx)
             let wire_ndx = self.flat_to_wire_ndx(file_idx);
             ndx_write_codec.write_ndx(&mut *writer, wire_ndx)?;
 
-            // upstream: generator.c:1926 - iflags with ITEM_TRANSFER
+            // upstream: generator.c:1937-1947 - iflags carry the full itemize
+            // bits (ITEM_TRANSFER plus the pre-transfer attribute diff, incl.
+            // ITEM_IS_NEW for a new dest) so the sender prints the right glyph
+            // (e.g. `<f+++++++++` for a new file) even in a dry run.
             if write_iflags {
                 use crate::receiver::wire::SenderAttrs;
-                writer.write_all(&SenderAttrs::ITEM_TRANSFER.to_le_bytes())?;
+                let iflags = ((base_iflags & 0xFFFF) as u16) | SenderAttrs::ITEM_TRANSFER;
+                writer.write_all(&iflags.to_le_bytes())?;
             }
 
             // Flush before blocking on the sender's echo. The multiplex
@@ -593,7 +599,7 @@ impl ReceiverContext {
             append_verify: self.config.flags.append_verify,
         };
 
-        for &(file_idx, file_entry, ref file_path, _) in files_to_transfer {
+        for &(file_idx, file_entry, ref file_path, base_iflags) in files_to_transfer {
             // upstream: generator.c:1961-1969 - compute the basis signature and
             // send a real sum head so the sender can diff against the receiver's
             // basis (empty when no basis exists, driving a whole-file batch).
@@ -624,6 +630,7 @@ impl ReceiverContext {
                 basis.basis_path,
                 basis.fnamecmp_type,
                 file_entry.size(),
+                base_iflags,
                 &request_config,
             )?;
 

--- a/crates/transfer/src/receiver/transfer/pipeline_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline_async.rs
@@ -294,6 +294,7 @@ impl ReceiverContext {
                                 basis_result.basis_path,
                                 basis_result.fnamecmp_type,
                                 file_entry.size(),
+                                base_iflags,
                                 &request_config,
                             )?;
 
@@ -317,6 +318,7 @@ impl ReceiverContext {
                                 None,
                                 protocol::FnameCmpType::Fname,
                                 file_entry.size(),
+                                base_iflags,
                                 &request_config,
                             )?;
 

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -411,4 +411,97 @@ mod tests {
         let debug_str = format!("{config:?}");
         assert!(debug_str.contains("RequestConfig"));
     }
+
+    /// Builds a minimal protocol-31 `RequestConfig` with iflags enabled.
+    fn iflags_request_config() -> RequestConfig<'static> {
+        RequestConfig {
+            protocol: ProtocolVersion::from_supported(31).expect("31 is supported"),
+            write_iflags: true,
+            checksum_length: NonZeroU8::new(16).unwrap(),
+            checksum_algorithm: engine::signature::SignatureAlgorithm::Md4,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+            use_sparse: false,
+            do_fsync: false,
+            temp_dir: None,
+            write_devices: false,
+            inplace: false,
+            inplace_partial: false,
+            io_uring_policy: fast_io::IoUringPolicy::Auto,
+            io_uring_depth: None,
+            preserve_xattrs: false,
+            want_xattr_optim: false,
+            append: false,
+            append_verify: false,
+        }
+    }
+
+    fn request_bytes(base_iflags: u32) -> Vec<u8> {
+        use protocol::codec::MonotonicNdxWriter;
+        let config = iflags_request_config();
+        let mut ndx_codec = MonotonicNdxWriter::new(config.protocol.as_u8());
+        let mut buf: Vec<u8> = Vec::new();
+        send_file_request(
+            &mut buf,
+            &mut ndx_codec,
+            0,
+            std::path::PathBuf::from("data.txt"),
+            None,
+            None,
+            protocol::FnameCmpType::Fname,
+            0,
+            base_iflags,
+            &config,
+        )
+        .expect("request encodes");
+        buf
+    }
+
+    /// upstream: generator.c:1937-1947 - the generator writes the full itemize
+    /// iflags to the sender, so a new-file request carries ITEM_IS_NEW (0x2000)
+    /// alongside ITEM_TRANSFER (0x8000) → wire shortint 0xA000 (LE 00 A0). The
+    /// sender echoes these back and prints `<f+++++++++` (#301). A bare transfer
+    /// request (no diff bits) writes only 0x8000 (LE 00 80).
+    #[test]
+    fn new_file_request_forwards_item_is_new() {
+        let new_bytes = request_bytes(
+            u32::from(SenderAttrs::ITEM_TRANSFER) | crate::generator::ItemFlags::ITEM_IS_NEW,
+        );
+        assert!(
+            new_bytes.windows(2).any(|w| w == [0x00, 0xA0]),
+            "new-file request must carry ITEM_TRANSFER|ITEM_IS_NEW (0xA000): {new_bytes:02x?}"
+        );
+
+        let bare_bytes = request_bytes(u32::from(SenderAttrs::ITEM_TRANSFER));
+        assert!(
+            bare_bytes.windows(2).any(|w| w == [0x00, 0x80]),
+            "bare request carries ITEM_TRANSFER (0x8000): {bare_bytes:02x?}"
+        );
+        assert!(
+            !bare_bytes.windows(2).any(|w| w == [0x00, 0xA0]),
+            "bare request must NOT set ITEM_IS_NEW: {bare_bytes:02x?}"
+        );
+    }
+
+    /// The managed trailing-field bits (XATTR/BASIS/XNAME) must never leak from
+    /// `base_iflags` into the wire shortint, since they demand trailing bytes
+    /// this call site does not write for a plain FNAME request.
+    #[test]
+    fn base_iflags_managed_bits_are_masked_off() {
+        // Deliberately pollute base_iflags with the managed bits.
+        let polluted = u32::from(
+            SenderAttrs::ITEM_TRANSFER
+                | SenderAttrs::ITEM_REPORT_XATTR
+                | SenderAttrs::ITEM_BASIS_TYPE_FOLLOWS
+                | SenderAttrs::ITEM_XNAME_FOLLOWS,
+        );
+        let bytes = request_bytes(polluted);
+        // Only ITEM_TRANSFER (0x8000, LE 00 80) survives; none of the managed
+        // bits (which would each demand a trailing wire field) appear.
+        assert!(
+            bytes.windows(2).any(|w| w == [0x00, 0x80]),
+            "masked request keeps ITEM_TRANSFER only: {bytes:02x?}"
+        );
+    }
 }

--- a/crates/transfer/src/transfer_ops/request.rs
+++ b/crates/transfer/src/transfer_ops/request.rs
@@ -61,6 +61,7 @@ pub fn send_file_request<W: Write + ?Sized>(
     basis_path: Option<PathBuf>,
     fnamecmp_type: protocol::FnameCmpType,
     target_size: u64,
+    base_iflags: u32,
     config: &RequestConfig<'_>,
 ) -> io::Result<PendingTransfer> {
     send_file_request_xattr(
@@ -72,6 +73,7 @@ pub fn send_file_request<W: Write + ?Sized>(
         basis_path,
         fnamecmp_type,
         target_size,
+        base_iflags,
         config,
         None,
     )
@@ -97,6 +99,7 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
     basis_path: Option<PathBuf>,
     fnamecmp_type: protocol::FnameCmpType,
     target_size: u64,
+    base_iflags: u32,
     config: &RequestConfig<'_>,
     xattr_list: Option<&XattrList>,
 ) -> io::Result<PendingTransfer> {
@@ -110,7 +113,19 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
             list.iter()
                 .any(|e| e.state().needs_send() || e.state().needs_request())
         });
-        let mut iflags = SenderAttrs::ITEM_TRANSFER;
+        // upstream: generator.c:1937-1947 - the generator forwards the full
+        // itemize iflags (ITEM_TRANSFER plus the pre-transfer attribute-diff
+        // bits from itemize(), including ITEM_IS_NEW when the destination did
+        // not exist). The sender reads them, echoes them back, and prints the
+        // row via log_item(FCLIENT), so on a push a brand-new file shows
+        // `<f+++++++++` rather than `<f.........`. Keep only the low 16-bit
+        // report/new bits and drop the ones this function manages itself
+        // (XATTR/BASIS/XNAME require trailing wire fields written below);
+        // always force ITEM_TRANSFER so the sender still reads the sum head.
+        const MANAGED: u16 = SenderAttrs::ITEM_REPORT_XATTR
+            | SenderAttrs::ITEM_BASIS_TYPE_FOLLOWS
+            | SenderAttrs::ITEM_XNAME_FOLLOWS;
+        let mut iflags = ((base_iflags & 0xFFFF) as u16 & !MANAGED) | SenderAttrs::ITEM_TRANSFER;
         if has_xattr_request && config.preserve_xattrs {
             iflags |= SenderAttrs::ITEM_REPORT_XATTR;
         }


### PR DESCRIPTION
## Summary

Fixes #301: on a push to an oc server, a brand-new file now itemizes as `<f+++++++++` (matching upstream), instead of `<f.........`.

## Root cause

oc's receiver-generator wrote a **bare `ITEM_TRANSFER`** over the wire for every transfer request, discarding the `base_iflags` (with `ITEM_IS_NEW` and the `ITEM_REPORT_*` attribute-diff bits) that `candidates.rs` had already computed. The peer sender therefore printed `<f.........` for a new file and for an attribute change.

upstream: `generator.c:1937-1947` calls `itemize(...)` which at `:578` sets `ITEM_IS_NEW` when `statret < 0`, then `:587 write_shortint(iflags)` sends the **full** iflags to the sender, echoed back and printed via `log_item(FCLIENT)`; the `+` fill is `log.c:736-738`.

## Fix

Thread `base_iflags` into `send_file_request` and write `(base_iflags & 0xFFFF) & !MANAGED | ITEM_TRANSFER`, where `MANAGED = ITEM_REPORT_XATTR | ITEM_BASIS_TYPE_FOLLOWS | ITEM_XNAME_FOLLOWS` (those bits gate trailing wire fields and are managed separately). `ITEM_TRANSFER` is always forced so the sender still reads the sum head. 4 files (`transfer_ops/request.rs`, `receiver/transfer/pipeline.rs`, `pipeline_async.rs`, `transfer_ops/mod.rs` tests).

## Seal (lxhost, oc-rsync vs upstream rsync 3.4.4 over SSH, `-ai`)

New file, push to oc server (`rsync --rsync-path=oc-rsync`):
```
upstream: <f+++++++++ afile.txt   <f+++++++++ sub/child.txt
oc (FIX): <f+++++++++ afile.txt   <f+++++++++ sub/child.txt
```
Existing-file content change — **byte-identical** `<f.st......`. Before the fix both showed `<f.........`. Unit tests `3 passed`; `cargo clippy -p transfer --all-targets` clean on current master.

## Scoped, not in this PR (follow-ups)

- **#286(b)** (dir mtime-only itemize `.d..t`) is already correct on the oc-generator path — verified, no change.
- **#286(a)/(c)** (receiver emits all `.d` rows before `.f` rows; push forwards no iflags for non-transferred dir/unchanged entries) is a single architectural gap — the receiver processes all directories in a pre-pass, so fixing it means walking the flist in order and emitting `write_ndx + write_shortint(iflags)` (no sum head) for non-transferred entries. Left for a dedicated change.
- A separate pre-existing **oc-client-sender** itemize misprint (spurious `cf+++++++++` / `.f..t` instead of `.d..t` for dir rows read off the wire) was found on the sender print path; worth its own issue.
