### PR TITLE
perf(engine): small-transfer fast path for the delete pass (DML-4)

### DIFF
--- a/crates/engine/src/delete/context/core.rs
+++ b/crates/engine/src/delete/context/core.rs
@@ -23,6 +23,35 @@ use super::super::traversal::DirTraversalCursor;
 use super::outcome::DrainOutcome;
 use super::timing::EmitterTiming;
 
+/// DML-4: extras count below which the parallel-delete drain skips the
+/// pipeline and runs the sequential [`DeleteEmitter`](super::super::emitter::DeleteEmitter)
+/// directly.
+///
+/// Standing up the parallel consumer (`CohortBatcher` + `ReorderBuffer` +
+/// a Condvar-driven consumer thread + a rayon dispatch) is a fixed cost
+/// that dominates when only a few entries are being unlinked. Upstream has
+/// no such pipeline: `generator.c::delete_in_dir` deletes inline, one
+/// `delete_item` call per non-matched entry, per directory - which is
+/// optimal at small scale. The fast path restores that inline behaviour
+/// below this threshold while keeping the delete events byte-identical to
+/// the parallel path (both dispatch through the same sequential emitter).
+#[cfg(feature = "parallel-delete-consumer")]
+pub(super) const SMALL_DIR_FAST_PATH_THRESHOLD: usize = 64;
+
+/// Returns `true` when the drain should take the DML-4 sequential fast
+/// path instead of the parallel consumer.
+///
+/// The pipeline only pays off when there is real work to spread across
+/// more than one worker: a total extras count at or above
+/// [`SMALL_DIR_FAST_PATH_THRESHOLD`] and at least two rayon threads to
+/// dispatch onto. Either condition failing routes to the sequential
+/// emitter. Kept as a pure function of the two inputs so the routing
+/// boundary is unit-testable without spinning up a real transfer.
+#[cfg(feature = "parallel-delete-consumer")]
+pub(super) fn should_use_fast_path(total_extras: usize, rayon_threads: usize) -> bool {
+    total_extras < SMALL_DIR_FAST_PATH_THRESHOLD || rayon_threads < 2
+}
+
 /// One cursor observation enqueued by a worker thread for the emitter to
 /// fold into its [`DirTraversalCursor`] at drain time.
 ///
@@ -388,13 +417,34 @@ impl DeleteContext {
     /// [`super::super::parallel_consumer::ParallelDeleteEmitter::run`],
     /// which spawns a dedicated consumer thread and shares the dispatcher
     /// across the rayon pool via [`Arc`].
+    ///
+    /// # DML-4 small-transfer fast path
+    ///
+    /// Standing up the parallel consumer (a `CohortBatcher`, a
+    /// `ReorderBuffer`, a Condvar-driven consumer thread, and a rayon
+    /// dispatch) costs a fixed overhead that dominates when only a handful
+    /// of entries are being deleted. When the whole transfer plans fewer
+    /// than [`SMALL_DIR_FAST_PATH_THRESHOLD`] extras, or the process has no
+    /// spare rayon worker to parallelise onto, the drain runs the
+    /// sequential [`DeleteEmitter`] directly. That emitter is the exact
+    /// code the parallel path dispatches through per cohort, so the delete
+    /// events, stats, and exit code are byte-identical either way; only the
+    /// scheduling wrapper is skipped.
     // DEL-2.d: feature-gated dispatch, parallel-delete-consumer opt-in
     #[cfg(feature = "parallel-delete-consumer")]
     pub fn emit_one<F: DeleteFs + Sync + Send + 'static>(
         self,
         fs: F,
     ) -> io::Result<DrainOutcome<F>> {
-        self.emit_via_parallel_consumer(fs)
+        let parts = self.into_drain_parts().map_err(io::Error::from)?;
+        if should_use_fast_path(
+            parts.plans.total_extras_count(),
+            rayon::current_num_threads(),
+        ) {
+            Self::emit_sequential_from_parts(parts, fs)
+        } else {
+            Self::emit_parallel_from_parts(parts, fs)
+        }
     }
 
     /// Drains every published plan through a freshly-built emitter. Used
@@ -427,15 +477,19 @@ impl DeleteContext {
     /// parallel consumer to completion. Returns a [`DrainOutcome`] with
     /// the same shape the sequential emitter produces so callers stay
     /// unchanged across the feature toggle.
+    ///
+    /// Takes the owned [`DrainParts`] already extracted by [`Self::emit_one`]
+    /// so the DML-4 fast-path routing (which needs
+    /// [`DeletePlanMap::total_extras_count`] before choosing a path) and the
+    /// sequential path share one `into_drain_parts` call.
     #[cfg(feature = "parallel-delete-consumer")]
-    fn emit_via_parallel_consumer<F: DeleteFs + Sync + Send + 'static>(
-        self,
+    pub(super) fn emit_parallel_from_parts<F: DeleteFs + Sync + Send + 'static>(
+        parts: DrainParts,
         fs: F,
     ) -> io::Result<DrainOutcome<F>> {
         use super::super::parallel_consumer::ParallelDeleteEmitter;
         use super::super::reorder_buffer::{DeleteCohortKey, DeleteOperation};
 
-        let parts = self.into_drain_parts().map_err(io::Error::from)?;
         let plans = parts.plans;
         let mut cursor = parts.cursor;
         let emitter = ParallelDeleteEmitter::with_policy(fs, parts.policy);
@@ -470,6 +524,38 @@ impl DeleteContext {
             stats: outcome.stats,
             io_error: outcome.io_error,
             exit_code: outcome.exit_code,
+        })
+    }
+
+    /// DML-4 fast path: drains the owned [`DrainParts`] through the
+    /// sequential [`DeleteEmitter`], bypassing the parallel consumer's
+    /// batching and scheduling machinery.
+    ///
+    /// This is the exact emitter the parallel consumer dispatches through
+    /// per cohort, so the recorded delete events, [`protocol::DeleteStats`],
+    /// `io_error` bitmask, and exit code are identical to
+    /// [`Self::emit_parallel_from_parts`] for the same input. Only the
+    /// pipeline overhead is skipped, which is the point at small scale.
+    #[cfg(feature = "parallel-delete-consumer")]
+    pub(super) fn emit_sequential_from_parts<F: DeleteFs>(
+        parts: DrainParts,
+        fs: F,
+    ) -> io::Result<DrainOutcome<F>> {
+        use super::super::emitter::DeleteEmitter;
+
+        let emitter = DeleteEmitter::with_policy(fs, parts.plans, parts.cursor, parts.policy);
+        #[cfg(unix)]
+        let emitter = match parts.sandbox {
+            Some(sandbox) => emitter.with_sandbox_rooted(sandbox, parts.sandbox_root),
+            None => emitter,
+        };
+        let mut emitter = emitter;
+        emitter.emit_all()?;
+        Ok(DrainOutcome {
+            stats: emitter.stats(),
+            io_error: emitter.io_error(),
+            exit_code: emitter.exit_code(),
+            fs: emitter.into_fs(),
         })
     }
 
@@ -516,7 +602,7 @@ impl DeleteContext {
     /// path under the `parallel-delete-consumer` feature. The
     /// channel-shutdown semantics and `Arc::try_unwrap` invariant are
     /// preserved exactly because both paths consume `self` by value.
-    fn into_drain_parts(self) -> Result<DrainParts, DeleteError> {
+    pub(super) fn into_drain_parts(self) -> Result<DrainParts, DeleteError> {
         let plans = Arc::try_unwrap(self.plans).map_err(|still_shared| {
             DeleteError::PlanMapStillShared {
                 strong_count: Arc::strong_count(&still_shared),
@@ -577,7 +663,7 @@ impl DeleteContext {
 /// [`fast_io::DirSandbox`] anchor (and the absolute root it was opened at)
 /// that lets the production emitter dispatch through the dirfd-anchored
 /// `*_at` syscalls.
-struct DrainParts {
+pub(super) struct DrainParts {
     plans: DeletePlanMap,
     cursor: DirTraversalCursor,
     policy: EmitterErrorPolicy,

--- a/crates/engine/src/delete/context/tests.rs
+++ b/crates/engine/src/delete/context/tests.rs
@@ -477,6 +477,184 @@ fn channel_drain_completes_when_worker_panics_mid_send() {
     );
 }
 
+/// DML-4 fixture: builds a delete context over `root` with `n` sibling
+/// subdirectories, each holding exactly one uniquely named extra file
+/// (`trashNNN`) that the drain must remove. The root keeps every
+/// subdirectory (they appear in its segment), so it plans zero extras and
+/// the total extras count equals `n`. Every cohort carries a single op, so
+/// the parallel consumer's intra-cohort `par_iter` cannot reorder and the
+/// cross-cohort order is the deterministic cursor traversal - making a
+/// leaf-for-leaf comparison of the two drain paths reproducible rather than
+/// racy. `n` is kept below the reorder buffer's 64-cohort cap by callers.
+#[cfg(feature = "parallel-delete-consumer")]
+fn build_multidir_ctx(root: &Path, n: usize) -> DeleteContext {
+    let ctx = DeleteContext::new(root.to_path_buf(), EmitterTiming::Before);
+
+    let mut root_children = Vec::with_capacity(n);
+    let mut root_segment = Vec::with_capacity(n);
+    for i in 0..n {
+        let name = format!("sub{i:03}");
+        let sub = root.join(&name);
+        fs::create_dir(&sub).unwrap();
+        touch(&sub, &format!("trash{i:03}"));
+        root_children.push(dir_child(root.to_str().unwrap(), &name));
+        root_segment.push(flist_dir(&name));
+    }
+
+    ctx.observe_directory(root.to_path_buf(), &root_children);
+    ctx.begin_directory(root_segment);
+    ctx.publish_plan_for(root).expect("publish root plan");
+
+    for i in 0..n {
+        let sub = root.join(format!("sub{i:03}"));
+        ctx.begin_directory(make_segment(&[]));
+        ctx.publish_plan_for(&sub).expect("publish sub plan");
+    }
+
+    ctx
+}
+
+/// Collects a drain outcome's recorded events as `(leaf, kind)` pairs in
+/// emission order. Normalises the dirfd-anchor leaf and the path-based
+/// fallback to the same leaf so the comparison is mechanism-agnostic.
+#[cfg(feature = "parallel-delete-consumer")]
+fn event_sequence(
+    outcome: &super::DrainOutcome<RecordingDeleteFs>,
+) -> Vec<(OsString, DeleteEntryKind)> {
+    outcome
+        .fs
+        .events()
+        .iter()
+        .map(|e| (recorded_leaf(&e.path).to_os_string(), e.kind))
+        .collect()
+}
+
+/// DML-4 (a) parity: the sequential fast path and the parallel consumer
+/// must produce byte-identical delete events, stats, and exit code for the
+/// same input - the correctness contract that lets the drain skip the
+/// pipeline below the threshold. Drives BOTH paths directly on two
+/// identical fixtures so the comparison never depends on the host's rayon
+/// thread count. Each cohort holds a single, uniquely named op, so the
+/// cross-cohort cursor order fully determines the event sequence and the
+/// leaf-for-leaf equality is reproducible.
+#[cfg(feature = "parallel-delete-consumer")]
+#[test]
+fn fast_and_parallel_paths_emit_identical_events() {
+    // 50 single-extra dirs (51 cohorts incl. root) stays under the reorder
+    // buffer's 64-cohort cap while still exercising cross-cohort ordering.
+    const N: usize = 50;
+
+    let tmp_seq = tempfile::tempdir().expect("tempdir");
+    let tmp_par = tempfile::tempdir().expect("tempdir");
+    let ctx_seq = build_multidir_ctx(tmp_seq.path(), N);
+    let ctx_par = build_multidir_ctx(tmp_par.path(), N);
+    assert_eq!(ctx_seq.plans.total_extras_count(), N);
+
+    let parts_seq = ctx_seq.into_drain_parts().expect("seq drain parts");
+    let out_seq = DeleteContext::emit_sequential_from_parts(parts_seq, RecordingDeleteFs::new())
+        .expect("fast-path drain");
+
+    let parts_par = ctx_par.into_drain_parts().expect("par drain parts");
+    let out_par = DeleteContext::emit_parallel_from_parts(parts_par, RecordingDeleteFs::new())
+        .expect("parallel drain");
+
+    assert_eq!(out_seq.stats, out_par.stats, "stats must be identical");
+    assert_eq!(out_seq.stats.files as usize, N, "every extra is deleted");
+    assert_eq!(out_seq.exit_code, out_par.exit_code, "exit code identical");
+    assert_eq!(
+        event_sequence(&out_seq),
+        event_sequence(&out_par),
+        "fast path and parallel path must emit an identical event order",
+    );
+    assert_eq!(out_seq.fs.events().len(), N);
+}
+
+/// DML-4 (a) routing: `emit_one` sends a sub-threshold workload down the
+/// sequential fast path and an at-or-above-threshold workload down the
+/// parallel consumer, and either way deletes exactly the right entries.
+/// Uses a single directory (one cohort, many ops) so the >= 64 case clears
+/// the reorder-buffer cohort cap; intra-cohort `par_iter` may reorder the
+/// parallel run, so the deletion SET is compared, while the routing
+/// decision itself is pinned on the pure predicate.
+#[cfg(feature = "parallel-delete-consumer")]
+#[test]
+fn emit_one_routes_small_and_large_transfers() {
+    use super::core::should_use_fast_path;
+
+    fn drain_single_dir(file_count: usize) -> super::DrainOutcome<RecordingDeleteFs> {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().to_path_buf();
+        for i in 0..file_count {
+            touch(&dir, &format!("f{i:03}"));
+        }
+        let ctx = DeleteContext::new(dir.clone(), EmitterTiming::During);
+        ctx.observe_directory(dir.clone(), &[]);
+        ctx.begin_directory(make_segment(&[]));
+        ctx.publish_plan_for(&dir).expect("publish plan");
+        assert_eq!(ctx.plans.total_extras_count(), file_count);
+        ctx.emit_one(RecordingDeleteFs::new()).expect("drain")
+    }
+
+    // Small transfer: below the threshold -> fast path.
+    assert!(should_use_fast_path(10, 2));
+    let small = drain_single_dir(10);
+    assert_eq!(small.stats.files, 10);
+    assert_eq!(small.exit_code, 0);
+    let mut small_leaves: Vec<OsString> = small
+        .fs
+        .events()
+        .iter()
+        .map(|e| recorded_leaf(&e.path).to_os_string())
+        .collect();
+    small_leaves.sort();
+    let small_expected: Vec<OsString> = (0..10)
+        .map(|i| OsString::from(format!("f{i:03}")))
+        .collect();
+    assert_eq!(small_leaves, small_expected);
+
+    // Large transfer: at the threshold -> parallel consumer.
+    assert!(!should_use_fast_path(64, 2));
+    let large = drain_single_dir(64);
+    assert_eq!(large.stats.files, 64);
+    assert_eq!(large.exit_code, 0);
+    let mut large_leaves: Vec<OsString> = large
+        .fs
+        .events()
+        .iter()
+        .map(|e| recorded_leaf(&e.path).to_os_string())
+        .collect();
+    large_leaves.sort();
+    let large_expected: Vec<OsString> = (0..64)
+        .map(|i| OsString::from(format!("f{i:03}")))
+        .collect();
+    assert_eq!(large_leaves, large_expected);
+}
+
+/// DML-4 (b): boundary parity at the threshold. 63 extras stay on the fast
+/// path, 65 cross to the parallel path, and 64 (the threshold itself) is
+/// the first parallel value. Thread starvation (`< 2` rayon workers) forces
+/// the fast path regardless of size, matching the "no spare worker to
+/// parallelise onto" clause.
+#[cfg(feature = "parallel-delete-consumer")]
+#[test]
+fn should_use_fast_path_at_threshold_boundary() {
+    use super::core::{SMALL_DIR_FAST_PATH_THRESHOLD, should_use_fast_path};
+
+    assert_eq!(SMALL_DIR_FAST_PATH_THRESHOLD, 64);
+    assert!(should_use_fast_path(63, 2), "63 < 64 -> fast path");
+    assert!(!should_use_fast_path(65, 2), "65 >= 64 -> parallel path");
+    assert!(
+        !should_use_fast_path(64, 2),
+        "64 == threshold -> parallel path"
+    );
+    // Single-threaded runtime cannot parallelise: fast path at any size.
+    assert!(should_use_fast_path(65, 1), "one thread -> fast path");
+    assert!(
+        should_use_fast_path(1_000_000, 1),
+        "one thread -> fast path"
+    );
+}
+
 /// #506 (production wiring): the drain built by `DeleteContext` now attaches
 /// a `DirSandbox` opened at the delete root, so the emitter dispatches every
 /// unlink through the SEC-1.q dirfd-anchored `*_at` syscalls rather than the

--- a/crates/engine/src/delete/plan_map.rs
+++ b/crates/engine/src/delete/plan_map.rs
@@ -133,6 +133,28 @@ impl DeletePlanMap {
             .len()
     }
 
+    /// Returns the total number of extras summed across every published
+    /// plan.
+    ///
+    /// Used by the drain to size the delete workload before choosing
+    /// between the sequential fast path and the parallel consumer. The
+    /// lock is held only for the summation, mirroring the other accessors
+    /// in this module.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned. See [`Self::insert`]
+    /// for why this map treats poisoning as fatal.
+    #[must_use]
+    pub fn total_extras_count(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("DeletePlanMap mutex poisoned")
+            .values()
+            .map(|plan| plan.extras.len())
+            .sum()
+    }
+
     /// Returns `true` when a plan for `dir` is currently published.
     ///
     /// Useful for tests and for the emitter to distinguish "not yet
@@ -211,6 +233,29 @@ mod tests {
         assert!(displaced.is_some(), "duplicate insert displaces previous");
         let current = map.take(Path::new("dup")).expect("plan present");
         assert_eq!(current.extras.len(), 2);
+    }
+
+    #[test]
+    fn total_extras_count_sums_across_plans() {
+        let map = DeletePlanMap::new();
+        assert_eq!(map.total_extras_count(), 0);
+        // `make_plan` publishes one extra per directory.
+        map.insert(make_plan("a"));
+        map.insert(make_plan("b"));
+        assert_eq!(map.total_extras_count(), 2);
+        // A plan with three extras lifts the sum to 5.
+        let mut wide = DeletePlan::new(PathBuf::from("wide"));
+        for name in ["one", "two", "three"] {
+            wide.push(DeleteEntry::new(
+                std::ffi::OsString::from(name),
+                DeleteEntryKind::File,
+            ));
+        }
+        map.insert(wide);
+        assert_eq!(map.total_extras_count(), 5);
+        // Draining a directory removes its extras from the sum.
+        map.take(Path::new("wide"));
+        assert_eq!(map.total_extras_count(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds the DML-4 small-transfer fast path to the delete pass. When the `parallel-delete-consumer` feature is enabled, a `--delete` transfer with fewer than 64 total extras (or when no spare rayon worker exists) now bypasses the `ParallelDeleteEmitter` / `CohortBatcher` / `ReorderBuffer` / Condvar pipeline and runs the existing sequential `DeleteEmitter` directly.

## Why

The parallel pipeline's ~50-60 us fixed setup (CohortBatcher alloc, ReorderBuffer BTreeMap, Condvar + slot creation, rayon dispatch) dominates a small delete set — a handful of unlinks costs ~30 us — giving a 1.5-2.5x latency overhead at small scale. Upstream `generator.c::delete_in_dir` deletes inline per directory with no pipeline, which is optimal there.

## Correctness

The fast path **is** the same sequential `DeleteEmitter` the parallel path already dispatches through per cohort, so delete events, stats, and exit code are **byte-identical**. `fast_and_parallel_paths_emit_identical_events` drives both paths on identical fixtures and asserts identical event order, stats, and exit code. The default (feature-off) path is completely untouched; no wire-output change.

## Changes

- `plan_map.rs`: `total_extras_count()` (sums `extras.len()` across plans, same lock pattern as siblings).
- `context/core.rs`: `SMALL_DIR_FAST_PATH_THRESHOLD = 64` (doc cites upstream `delete_in_dir`); pure routing predicate `should_use_fast_path(total_extras, rayon_threads)`; refactor the pipeline body into `emit_parallel_from_parts(parts, fs)` and add `emit_sequential_from_parts(parts, fs)` (builds `DeleteEmitter::with_policy`, same SEC-1.q sandbox anchor, matching `DrainOutcome`); `emit_one` extracts parts once and routes.
- `context/tests.rs`: identical-events parity test, `emit_one` routing test (10-file fast, 64-file parallel), and a 63/64/65 boundary + thread-starvation test.

## Verification

- `cargo clippy -p engine --all-targets --features parallel-delete-consumer` clean; default-feature clippy clean; `cargo fmt` clean.
- `cargo test -p engine --lib --features parallel-delete-consumer delete::context::tests` — 21 passed (incl. the 3 new). No unsafe, no wire changes.
