### PR TITLE
fix(transfer): resolve INC_RECURSE dir gap NDX to parent on itemize

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -220,13 +220,18 @@ impl GeneratorContext {
     /// on the trailing file of the previous segment, so a directory row would
     /// print with a file type char and the wrong path. Upstream recovers the
     /// directory via `file = dir_flist->files[cur_flist->parent_ndx]`
-    /// (sender.c:269-272); we mirror that by mapping the gap to its sub-list's
-    /// recorded parent directory NDX.
+    /// (sender.c:269-272); oc mirrors that by mapping the gap to its sub-list's
+    /// recorded owning-directory flat index. Each sub-list resolves to its own
+    /// owning directory - the initial list's gap to the `.` root, a
+    /// subdirectory's gap to that subdirectory - so every directory is itemized
+    /// once, exactly as upstream emits one row per directory.
     ///
     /// # Upstream Reference
     ///
     /// - `sender.c:267-272` - gap NDX (`ndx < cur_flist->ndx_start`) resolves to
-    ///   the parent directory entry in `dir_flist`.
+    ///   the owning directory entry in `dir_flist`.
+    /// - `generator.c:2306-2313` - each sub-list (including the initial list
+    ///   whose `parent_ndx >= 0`) itemizes its owning directory at `ndx_start - 1`.
     pub(crate) fn resolve_itemize_ndx(&self, wire_ndx: i32) -> usize {
         let segments = &self.incremental.ndx_segments;
         // A gap NDX `g` satisfies `g + 1 == ndx_start` for exactly one sub-list;
@@ -236,9 +241,9 @@ impl GeneratorContext {
         if let Ok(seg_idx) =
             segments.binary_search_by(|&(_, ndx_start)| ndx_start.cmp(&(wire_ndx + 1)))
         {
-            let parent = self.incremental.segment_parent_ndx[seg_idx];
-            if parent >= 0 {
-                return self.wire_to_flat_ndx(parent);
+            let parent_flat = self.incremental.segment_parent_flat[seg_idx];
+            if parent_flat >= 0 {
+                return parent_flat as usize;
             }
         }
         self.wire_to_flat_ndx(wire_ndx)

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -209,6 +209,41 @@ impl GeneratorContext {
         flat_start + (wire_ndx - ndx_start) as usize
     }
 
+    /// Resolves a wire NDX read back from the receiver to the flat `file_list`
+    /// index whose entry drives itemize formatting and xattr responses.
+    ///
+    /// This is [`Self::wire_to_flat_ndx`] for every regular entry. Under
+    /// INC_RECURSE, however, the remote generator itemizes a directory by
+    /// sending the "gap NDX" `ndx_start - 1` of that directory's sub-list
+    /// (generator.c:2313 `ndx = cur_flist->ndx_start - 1`) instead of the
+    /// directory's own NDX. Feeding that gap through the plain segment map lands
+    /// on the trailing file of the previous segment, so a directory row would
+    /// print with a file type char and the wrong path. Upstream recovers the
+    /// directory via `file = dir_flist->files[cur_flist->parent_ndx]`
+    /// (sender.c:269-272); we mirror that by mapping the gap to its sub-list's
+    /// recorded parent directory NDX.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:267-272` - gap NDX (`ndx < cur_flist->ndx_start`) resolves to
+    ///   the parent directory entry in `dir_flist`.
+    pub(crate) fn resolve_itemize_ndx(&self, wire_ndx: i32) -> usize {
+        let segments = &self.incremental.ndx_segments;
+        // A gap NDX `g` satisfies `g + 1 == ndx_start` for exactly one sub-list;
+        // no regular entry's NDX can equal a sub-list start minus one (the +1
+        // gap is reserved, flist.c:2931). Binary search is valid because
+        // `ndx_start` values are strictly increasing.
+        if let Ok(seg_idx) =
+            segments.binary_search_by(|&(_, ndx_start)| ndx_start.cmp(&(wire_ndx + 1)))
+        {
+            let parent = self.incremental.segment_parent_ndx[seg_idx];
+            if parent >= 0 {
+                return self.wire_to_flat_ndx(parent);
+            }
+        }
+        self.wire_to_flat_ndx(wire_ndx)
+    }
+
     /// Converts a flat file list array index to a wire NDX value.
     ///
     /// Updates the `NDX_CONVERT_CALLS` / `NDX_CONVERT_CMPS` counters used

--- a/crates/transfer/src/generator/file_list/inc_recurse.rs
+++ b/crates/transfer/src/generator/file_list/inc_recurse.rs
@@ -176,12 +176,17 @@ impl GeneratorContext {
         // Phase 1: Assign wire dir_ndx to initial list directories.
         // Dense Vec indexed by node_id - O(1) lookup.
         let mut node_to_wire: Vec<i32> = vec![-1; num_dirs];
+        // Flat file_list index of each directory node, so a sub-list's gap NDX
+        // itemize resolves to its owning directory's own path/type char.
+        // upstream: sender.c:269-272 - `dir_flist->files[cur_flist->parent_ndx]`.
+        let mut node_to_flat: Vec<usize> = vec![usize::MAX; num_dirs];
         let mut wire_dir_ndx: i32 = 0;
 
         for (i, tagged) in initial_entries.iter().enumerate() {
             if self.file_list[i].is_dir() {
                 if let Some(nid) = tagged.node_id {
                     node_to_wire[nid] = wire_dir_ndx;
+                    node_to_flat[nid] = i;
                 }
                 // Count ALL dirs including "." for correct dir_flist alignment.
                 wire_dir_ndx += 1;
@@ -208,6 +213,7 @@ impl GeneratorContext {
             let flist_start = self.file_list.len();
 
             for child in &seg.children {
+                let child_flat = self.file_list.len();
                 self.file_list
                     .push(file_entries[child.file_idx].take().unwrap());
                 self.source_bases
@@ -215,6 +221,7 @@ impl GeneratorContext {
 
                 if let Some(child_nid) = child.node_id {
                     node_to_wire[child_nid] = wire_dir_ndx;
+                    node_to_flat[child_nid] = child_flat;
                     wire_dir_ndx += 1;
                 }
             }
@@ -222,12 +229,26 @@ impl GeneratorContext {
             let parent_wire_ndx = node_to_wire[node_id];
             pending.push(PendingSegment {
                 parent_dir_ndx: parent_wire_ndx,
+                parent_flat_idx: node_to_flat[node_id],
                 flist_start,
                 count: seg.children.len(),
             });
         }
 
         self.incremental.pending_segments = pending;
+
+        // The initial list itemizes the transfer root `.` via its own gap NDX
+        // (`ndx_start - 1`) when the first entry is `.`. upstream flist.c:2572
+        // keeps `flist->parent_ndx` (pointing at dir_flist[0] == `.`) unless the
+        // first sorted entry's basename differs from ".", in which case the root
+        // has no directory row. `.` is always the first initial entry (flat 0)
+        // when present, so resolve its slot to flat 0; otherwise leave it -1.
+        self.incremental.segment_parent_flat[0] =
+            if self.file_list.get(0).is_some_and(|e| e.name() == ".") {
+                0
+            } else {
+                -1
+            };
     }
 }
 

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -615,6 +615,13 @@ impl GeneratorContext {
         self.incremental
             .ndx_segments
             .push((segment.flist_start, seg_ndx_start));
+        // Record the parent directory's wire NDX so a directory itemize read
+        // back at the gap NDX `seg_ndx_start - 1` resolves to the directory
+        // entry rather than to the trailing file of the previous segment.
+        // upstream: sender.c:269-272 - `dir_flist->files[cur_flist->parent_ndx]`.
+        self.incremental
+            .segment_parent_ndx
+            .push(segment.parent_dir_ndx);
 
         // Signal new sub-list to receiver.
         // upstream: flist.c:2117 - write_ndx(f, NDX_FLIST_OFFSET - dir_ndx)

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -615,13 +615,13 @@ impl GeneratorContext {
         self.incremental
             .ndx_segments
             .push((segment.flist_start, seg_ndx_start));
-        // Record the parent directory's wire NDX so a directory itemize read
+        // Record the owning directory's flat index so a directory itemize read
         // back at the gap NDX `seg_ndx_start - 1` resolves to the directory
         // entry rather than to the trailing file of the previous segment.
         // upstream: sender.c:269-272 - `dir_flist->files[cur_flist->parent_ndx]`.
         self.incremental
-            .segment_parent_ndx
-            .push(segment.parent_dir_ndx);
+            .segment_parent_flat
+            .push(segment.parent_flat_idx as i32);
 
         // Signal new sub-list to receiver.
         // upstream: flist.c:2117 - write_ndx(f, NDX_FLIST_OFFSET - dir_ndx)

--- a/crates/transfer/src/generator/segments.rs
+++ b/crates/transfer/src/generator/segments.rs
@@ -33,8 +33,19 @@ pub const MIN_FILECNT_LOOKAHEAD: usize = 1000;
 /// - `flist.c:2931` - `ndx_start = prev->ndx_start + prev->used + 1`
 #[derive(Debug)]
 pub(crate) struct PendingSegment {
-    /// Global NDX of the parent directory.
+    /// Wire `dir_ndx` of the owning directory in the receiver's `dir_flist`.
+    ///
+    /// Written to the wire as `NDX_FLIST_OFFSET - parent_dir_ndx`
+    /// (flist.c:2117) to identify which directory this sub-list belongs to.
     pub(crate) parent_dir_ndx: i32,
+    /// Flat `GeneratorContext::file_list` index of the owning directory entry.
+    ///
+    /// Distinct from `parent_dir_ndx`: the wire `dir_ndx` counts only
+    /// directories in `dir_flist` growth order, whereas this indexes the flat
+    /// entry list that drives itemize formatting. A directory itemized via its
+    /// sub-list's gap NDX (`ndx_start - 1`) resolves to this flat index so the
+    /// printed row carries the directory's own path and type char.
+    pub(crate) parent_flat_idx: usize,
     /// Start index into `GeneratorContext::file_list`.
     pub(crate) flist_start: usize,
     /// Number of entries in this segment.
@@ -162,17 +173,25 @@ pub(crate) struct IncrementalState {
     ///
     /// Without INC_RECURSE, this contains a single entry `(0, 0)`.
     pub(crate) ndx_segments: Vec<(usize, i32)>,
-    /// Wire NDX of each segment's parent directory, aligned 1:1 with
-    /// `ndx_segments`. The initial segment has no parent and stores `-1`.
+    /// Flat `file_list` index of each sub-list's owning directory, aligned 1:1
+    /// with `ndx_segments`. Stores `-1` when a sub-list has no owning directory
+    /// entry to itemize (the initial list whose first entry is not `.`).
     ///
     /// Under INC_RECURSE the remote generator itemizes a directory by sending
     /// the "gap NDX" `ndx_start - 1` of that directory's sub-list
     /// (generator.c:2313 `ndx = cur_flist->ndx_start - 1`). The sender must map
-    /// that gap back to the parent directory entry rather than to a regular
+    /// that gap back to the owning directory entry rather than to a regular
     /// file, mirroring `dir_flist->files[cur_flist->parent_ndx]`
-    /// (sender.c:269-272). This table records the parent wire NDX for each
-    /// sub-list so `resolve_itemize_ndx` can perform that lookup.
-    pub(crate) segment_parent_ndx: Vec<i32>,
+    /// (sender.c:269-272). oc keeps a single flat entry list rather than a
+    /// separate `dir_flist`, so this table records the flat index of each
+    /// sub-list's owning directory directly, letting `resolve_itemize_ndx`
+    /// return it without a second wire-NDX translation.
+    ///
+    /// The initial list's slot is the flat index of the `.` root when the
+    /// transfer root is `.` (upstream flist.c:2572 keeps `parent_ndx` when the
+    /// first sorted entry is `.`), so the root directory row is itemized rather
+    /// than dropped; otherwise it is `-1`.
+    pub(crate) segment_parent_flat: Vec<i32>,
     /// Index into `ndx_segments` of the oldest unreclaimed segment.
     ///
     /// Advances by one each time a completed segment is reclaimed via
@@ -196,7 +215,7 @@ impl IncrementalState {
             flist_writer_cache: None,
             initial_segment_count: None,
             ndx_segments: vec![(0, initial_ndx_start)],
-            segment_parent_ndx: vec![-1],
+            segment_parent_flat: vec![-1],
             first_segment_idx: 0,
         }
     }

--- a/crates/transfer/src/generator/segments.rs
+++ b/crates/transfer/src/generator/segments.rs
@@ -162,6 +162,17 @@ pub(crate) struct IncrementalState {
     ///
     /// Without INC_RECURSE, this contains a single entry `(0, 0)`.
     pub(crate) ndx_segments: Vec<(usize, i32)>,
+    /// Wire NDX of each segment's parent directory, aligned 1:1 with
+    /// `ndx_segments`. The initial segment has no parent and stores `-1`.
+    ///
+    /// Under INC_RECURSE the remote generator itemizes a directory by sending
+    /// the "gap NDX" `ndx_start - 1` of that directory's sub-list
+    /// (generator.c:2313 `ndx = cur_flist->ndx_start - 1`). The sender must map
+    /// that gap back to the parent directory entry rather than to a regular
+    /// file, mirroring `dir_flist->files[cur_flist->parent_ndx]`
+    /// (sender.c:269-272). This table records the parent wire NDX for each
+    /// sub-list so `resolve_itemize_ndx` can perform that lookup.
+    pub(crate) segment_parent_ndx: Vec<i32>,
     /// Index into `ndx_segments` of the oldest unreclaimed segment.
     ///
     /// Advances by one each time a completed segment is reclaimed via
@@ -185,6 +196,7 @@ impl IncrementalState {
             flist_writer_cache: None,
             initial_segment_count: None,
             ndx_segments: vec![(0, initial_ndx_start)],
+            segment_parent_ndx: vec![-1],
             first_segment_idx: 0,
         }
     }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -377,64 +377,115 @@ fn inc_recurse_gap_ndx_round_trip_preserves_original() {
 
 #[test]
 fn inc_recurse_gap_ndx_itemizes_parent_directory() {
-    // upstream: generator.c:2313 - under INC_RECURSE a directory is itemized by
-    // sending the "gap NDX" `ndx_start - 1` of that directory's sub-list, not
-    // the directory's own NDX. On the client-sender print path the gap must
-    // resolve to the parent directory entry (sender.c:269-272,
-    // `dir_flist->files[cur_flist->parent_ndx]`). Feeding the gap through the
-    // plain segment map instead lands on the trailing child of the previous
-    // segment, so a directory row prints with a file type char and the child's
-    // path (`.f..t...... sub/child.txt` instead of `.d..t...... sub/`) and a
-    // new-dir push emits a spurious child row. This is display-only: the wire
-    // NDX echoed back to the receiver is unchanged.
+    // upstream: generator.c:2306-2313 - under INC_RECURSE every directory is
+    // itemized exactly once, via the "gap NDX" `ndx_start - 1` of ITS OWN
+    // sub-list, not its own NDX. A push of `src/` containing `sub/child.txt`
+    // has TWO sub-lists: the initial list (contents of the transfer root `.`)
+    // and sub/'s sub-list (contents of `sub`). Each gap resolves to the OWNING
+    // directory (sender.c:269-272, `dir_flist->files[cur_flist->parent_ndx]`),
+    // so upstream prints one row per directory:
+    //     .d          ./
+    //     cd+++++++++ sub/
+    //     <f+++++++++ sub/child.txt
+    //
+    // The WHY this pins: the itemize type char and path both come from the
+    // resolved entry, so each gap MUST map to its own owning directory's flat
+    // entry. Mapping sub/'s gap through the wire `dir_ndx` (a `dir_flist` index,
+    // not a flist NDX) resolves it to `./` (flat 0), and the initial list's gap
+    // has no owning-directory record so the root row is dropped - the exact two
+    // defects this test guards. Display-only: the echoed wire NDX and all
+    // transferred data are unchanged.
     use super::item_flags::ItemFlags;
+    use protocol::CompatibilityFlags;
     use protocol::flist::FileEntry;
 
-    let (_handshake, mut ctx) = test_generator();
+    let mut handshake = test_handshake_with_protocol(32);
+    handshake.compat_flags = Some(CompatibilityFlags::INC_RECURSE);
+    let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());
+    assert!(ctx.inc_recurse());
 
-    // Model a push of `sub/child.txt`: flat index 0 is the directory `sub`,
-    // flat index 1 is its child. The child travels in a sub-list whose
-    // ndx_start is 2, so the directory's itemize arrives at gap NDX 1.
-    ctx.file_list
-        .push(FileEntry::new_directory("sub".into(), 0o755));
-    ctx.file_list
-        .push(FileEntry::new_file("sub/child.txt".into(), 10, 0o644));
-    ctx.incremental.ndx_segments = vec![(0, 0), (1, 2)];
-    ctx.incremental.segment_parent_ndx = vec![-1, 0];
+    // Flat, sorted flist for `rsync -r src/ dst`: `.` root (flat 0), the `sub`
+    // dir (flat 1), then its child (flat 2). source_bases stays 1:1 with
+    // file_list so the real partitioner can move entries into sub-lists.
+    let empty_base: std::sync::Arc<Path> = std::sync::Arc::from(Path::new(""));
+    for entry in [
+        FileEntry::new_directory(".".into(), 0o755),
+        FileEntry::new_directory("sub".into(), 0o755),
+        FileEntry::new_file("sub/child.txt".into(), 10, 0o644),
+    ] {
+        ctx.file_list.push(entry);
+        ctx.source_bases.push(std::sync::Arc::clone(&empty_base));
+    }
 
-    // Gap NDX (2 - 1 = 1) resolves to the directory at flat index 0, never the
-    // child file at flat index 1.
-    assert_eq!(ctx.resolve_itemize_ndx(1), 0);
-    // The child's own NDX (2) still resolves to its flat index (1).
-    assert_eq!(ctx.resolve_itemize_ndx(2), 1);
-    // A directory itemized at its real NDX (0, the non-INC_RECURSE path) also
-    // resolves to itself.
-    assert_eq!(ctx.resolve_itemize_ndx(0), 0);
+    // Build the sub-lists exactly as a real INC_RECURSE push does.
+    ctx.partition_file_list_for_inc_recurse();
 
-    // A --times push implies preserve_mtimes, so the time position renders
-    // lowercase `t`; the type char and path are what this test pins.
+    // The builder records each sub-list's owning-directory FLAT index. The
+    // initial list owns `.` at flat 0 (flist.c:2572 keeps parent_ndx when the
+    // first entry is "."); sub/'s pending sub-list owns `sub` at flat 1. These
+    // are flat file_list indices, NOT wire dir_ndx values (`sub` has wire
+    // dir_ndx 1 but that alone would misresolve to flat 0 == `.`).
+    assert_eq!(ctx.incremental.segment_parent_flat, vec![0]);
+    assert_eq!(ctx.incremental.pending_segments.len(), 1);
+    assert_eq!(ctx.incremental.pending_segments[0].parent_flat_idx, 1);
+    assert_eq!(ctx.incremental.pending_segments[0].flist_start, 2);
+
+    // Dispatching sub/'s sub-list appends its (flat_start, ndx_start) and
+    // owning-flat rows, exactly as encode_and_send_segment does in the transfer
+    // loop. upstream flist.c:2931: ndx_start = prev(1) + prev_used(2) + 1 = 4,
+    // so sub/'s gap NDX is 3. The initial list keeps ndx_start 1, gap NDX 0.
+    ctx.incremental.ndx_segments = vec![(0, 1), (2, 4)];
+    ctx.incremental.segment_parent_flat = vec![0, 1];
+
+    // Each gap resolves to its OWN owning directory; the child resolves to
+    // itself. The `!= 0` anti-regression: sub/'s gap 3 must be flat 1 (`sub`),
+    // never flat 0 (`./`), and the root gap 0 must map to the live flat 0 so the
+    // root row is emitted rather than guarded out as an out-of-range index.
+    assert_eq!(ctx.resolve_itemize_ndx(0), 0, "root gap -> `.`");
+    assert_eq!(ctx.resolve_itemize_ndx(3), 1, "sub/ gap -> `sub`, not `./`");
+    assert_eq!(ctx.resolve_itemize_ndx(4), 2, "child -> itself");
+
     let itemize_ctx = itemize::ItemizeContext::default();
 
-    // A dir-mtime-only push carries ITEM_REPORT_TIME at the gap NDX. The
-    // resolved entry must render a directory row for `sub/`, not a file row for
-    // the child. This is the WHY: the type char and path come from the entry,
-    // so mapping the gap to the wrong entry corrupts both.
-    let dir_mtime = ItemFlags::from_raw(ItemFlags::ITEM_REPORT_TIME);
-    let flat = ctx.resolve_itemize_ndx(1);
-    let line = itemize::format_itemize_line(&dir_mtime, &ctx.file_list[flat], true, &itemize_ctx);
-    assert_eq!(line, ".d..t...... sub/\n");
-
-    // A new-dir push carries ITEM_LOCAL_CHANGE|ITEM_IS_NEW at the gap NDX; the
-    // resolved entry yields `cd+++++++++ sub/`, so no spurious child row is
-    // emitted for the directory.
-    let new_dir = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
-    let new_line = itemize::format_itemize_line(
-        &new_dir,
-        &ctx.file_list[ctx.resolve_itemize_ndx(1)],
-        true,
-        &itemize_ctx,
+    // New-dir push: the root `.` already exists (`.d`, unchanged -> dots
+    // collapse to spaces), sub/ is created (`cd+++`), the child is transferred
+    // (`<f+++`). All three rows must appear with their own path and type char.
+    let unchanged = ItemFlags::from_raw(0);
+    let new_local = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+    let new_xfer = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
+    let root = &ctx.file_list[ctx.resolve_itemize_ndx(0)];
+    let sub = &ctx.file_list[ctx.resolve_itemize_ndx(3)];
+    let child = &ctx.file_list[ctx.resolve_itemize_ndx(4)];
+    assert_eq!(
+        itemize::format_itemize_line(&unchanged, root, true, &itemize_ctx),
+        ".d          ./\n"
     );
-    assert_eq!(new_line, "cd+++++++++ sub/\n");
+    assert_eq!(
+        itemize::format_itemize_line(&new_local, sub, true, &itemize_ctx),
+        "cd+++++++++ sub/\n"
+    );
+    assert_eq!(
+        itemize::format_itemize_line(&new_xfer, child, true, &itemize_ctx),
+        "<f+++++++++ sub/child.txt\n"
+    );
+
+    // Dir-mtime push (dest exists, both dir mtimes stale): every directory row
+    // carries ITEM_REPORT_TIME at its gap NDX and must render against its own
+    // path, never the previous segment's trailing child.
+    let dir_mtime = ItemFlags::from_raw(ItemFlags::ITEM_REPORT_TIME);
+    let file_mtime = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_REPORT_TIME);
+    assert_eq!(
+        itemize::format_itemize_line(&dir_mtime, root, true, &itemize_ctx),
+        ".d..t...... ./\n"
+    );
+    assert_eq!(
+        itemize::format_itemize_line(&dir_mtime, sub, true, &itemize_ctx),
+        ".d..t...... sub/\n"
+    );
+    assert_eq!(
+        itemize::format_itemize_line(&file_mtime, child, true, &itemize_ctx),
+        "<f..t...... sub/child.txt\n"
+    );
 }
 
 #[test]
@@ -4253,6 +4304,7 @@ fn segment_scheduler_dispatches_when_remaining_below_threshold() {
 
     let seg = PendingSegment {
         parent_dir_ndx: 0,
+        parent_flat_idx: 0,
         flist_start: 10,
         count: 500,
     };
@@ -4277,6 +4329,7 @@ fn segment_scheduler_blocks_when_remaining_at_threshold() {
 
     let seg = PendingSegment {
         parent_dir_ndx: 0,
+        parent_flat_idx: 0,
         flist_start: 10,
         count: 500,
     };
@@ -4296,6 +4349,7 @@ fn segment_scheduler_blocks_when_remaining_above_threshold() {
 
     let seg = PendingSegment {
         parent_dir_ndx: 0,
+        parent_flat_idx: 0,
         flist_start: 10,
         count: 500,
     };
@@ -4315,6 +4369,7 @@ fn segment_scheduler_boundary_dispatches_at_999() {
 
     let seg = PendingSegment {
         parent_dir_ndx: 0,
+        parent_flat_idx: 0,
         flist_start: 10,
         count: 500,
     };
@@ -4338,6 +4393,7 @@ fn segment_scheduler_many_files_deadlock_scenario() {
 
     let seg = PendingSegment {
         parent_dir_ndx: 1,
+        parent_flat_idx: 0,
         flist_start: 13,
         count: 1000,
     };
@@ -4356,6 +4412,7 @@ fn segment_scheduler_many_files_deadlock_scenario() {
     // Reset scheduler for the corrected test.
     let seg = PendingSegment {
         parent_dir_ndx: 1,
+        parent_flat_idx: 0,
         flist_start: 13,
         count: 1000,
     };
@@ -4390,6 +4447,7 @@ fn empty_segment_sends_wire_bytes() {
 
     let seg = super::PendingSegment {
         parent_dir_ndx: 0,
+        parent_flat_idx: 0,
         flist_start: 1, // past the single entry, so count=0 segment is empty
         count: 0,
     };
@@ -4427,6 +4485,7 @@ fn nonempty_segment_also_sends_wire_bytes() {
 
     let seg = super::PendingSegment {
         parent_dir_ndx: 0,
+        parent_flat_idx: 0,
         flist_start: 0,
         count: 1,
     };

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -376,6 +376,68 @@ fn inc_recurse_gap_ndx_round_trip_preserves_original() {
 }
 
 #[test]
+fn inc_recurse_gap_ndx_itemizes_parent_directory() {
+    // upstream: generator.c:2313 - under INC_RECURSE a directory is itemized by
+    // sending the "gap NDX" `ndx_start - 1` of that directory's sub-list, not
+    // the directory's own NDX. On the client-sender print path the gap must
+    // resolve to the parent directory entry (sender.c:269-272,
+    // `dir_flist->files[cur_flist->parent_ndx]`). Feeding the gap through the
+    // plain segment map instead lands on the trailing child of the previous
+    // segment, so a directory row prints with a file type char and the child's
+    // path (`.f..t...... sub/child.txt` instead of `.d..t...... sub/`) and a
+    // new-dir push emits a spurious child row. This is display-only: the wire
+    // NDX echoed back to the receiver is unchanged.
+    use super::item_flags::ItemFlags;
+    use protocol::flist::FileEntry;
+
+    let (_handshake, mut ctx) = test_generator();
+
+    // Model a push of `sub/child.txt`: flat index 0 is the directory `sub`,
+    // flat index 1 is its child. The child travels in a sub-list whose
+    // ndx_start is 2, so the directory's itemize arrives at gap NDX 1.
+    ctx.file_list
+        .push(FileEntry::new_directory("sub".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("sub/child.txt".into(), 10, 0o644));
+    ctx.incremental.ndx_segments = vec![(0, 0), (1, 2)];
+    ctx.incremental.segment_parent_ndx = vec![-1, 0];
+
+    // Gap NDX (2 - 1 = 1) resolves to the directory at flat index 0, never the
+    // child file at flat index 1.
+    assert_eq!(ctx.resolve_itemize_ndx(1), 0);
+    // The child's own NDX (2) still resolves to its flat index (1).
+    assert_eq!(ctx.resolve_itemize_ndx(2), 1);
+    // A directory itemized at its real NDX (0, the non-INC_RECURSE path) also
+    // resolves to itself.
+    assert_eq!(ctx.resolve_itemize_ndx(0), 0);
+
+    // A --times push implies preserve_mtimes, so the time position renders
+    // lowercase `t`; the type char and path are what this test pins.
+    let itemize_ctx = itemize::ItemizeContext::default();
+
+    // A dir-mtime-only push carries ITEM_REPORT_TIME at the gap NDX. The
+    // resolved entry must render a directory row for `sub/`, not a file row for
+    // the child. This is the WHY: the type char and path come from the entry,
+    // so mapping the gap to the wrong entry corrupts both.
+    let dir_mtime = ItemFlags::from_raw(ItemFlags::ITEM_REPORT_TIME);
+    let flat = ctx.resolve_itemize_ndx(1);
+    let line = itemize::format_itemize_line(&dir_mtime, &ctx.file_list[flat], true, &itemize_ctx);
+    assert_eq!(line, ".d..t...... sub/\n");
+
+    // A new-dir push carries ITEM_LOCAL_CHANGE|ITEM_IS_NEW at the gap NDX; the
+    // resolved entry yields `cd+++++++++ sub/`, so no spurious child row is
+    // emitted for the directory.
+    let new_dir = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+    let new_line = itemize::format_itemize_line(
+        &new_dir,
+        &ctx.file_list[ctx.resolve_itemize_ndx(1)],
+        true,
+        &itemize_ctx,
+    );
+    assert_eq!(new_line, "cd+++++++++ sub/\n");
+}
+
+#[test]
 fn flush_with_count_increments_global_counter() {
     // INC_RECURSE diagnostic I3 (#2198): every flush on the generator
     // transfer hot path must bump the global FLUSH_CALLS counter. The

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -328,8 +328,12 @@ impl GeneratorContext {
             // converting through wire_to_flat_ndx and back via flat_to_wire_ndx
             // corrupts these gap values (the subtraction wraps to usize::MAX).
             let wire_ndx = ndx;
-            // upstream: rsync.c:424 - i = ndx - cur_flist->ndx_start
-            let ndx = self.wire_to_flat_ndx(wire_ndx);
+            // upstream: rsync.c:424 - i = ndx - cur_flist->ndx_start.
+            // resolve_itemize_ndx also handles the INC_RECURSE directory gap
+            // NDX (`ndx_start - 1`), mapping it to the parent directory entry so
+            // a dir itemize prints `.d.. sub/` rather than a file row for the
+            // trailing child of the previous segment (sender.c:267-272).
+            let ndx = self.resolve_itemize_ndx(wire_ndx);
 
             // upstream: rsync.c:227 - read_ndx_and_attrs() reads iflags
             let iflags = ItemFlags::read(&mut *reader, self.protocol.as_u8())?;


### PR DESCRIPTION
## Summary

Fixes the client-sender itemize print path for INC_RECURSE directory rows (task #308).

**This is display-only.** The transferred data and every wire byte (including the NDX echoed back to the receiver) stay byte-identical to upstream. Only the `-i`/`-ii` itemize rows printed locally were wrong.

## Symptoms

When pushing to a remote receiver (oc client-sender), directory itemize rows read back from the remote generator were mis-rendered:

1. New-dir push emitted a spurious `cf+++++++++ sub/child.txt` row (plus a duplicate) instead of the correct directory row.
2. Dir-mtime-only push printed `.f..t...... sub/child.txt` (a file row for the child) where upstream prints `.d..t...... sub/` (a directory row for the dir).

In short, the sender lost the directory-ness of the entry: it printed a file type char and the child's path.

## Root cause

Under INC_RECURSE the remote generator itemizes a directory by sending the "gap NDX" `ndx_start - 1` of that directory's sub-list (upstream `generator.c:2307-2314`, `ndx = cur_flist->ndx_start - 1`), not the directory's own NDX. Upstream's sender maps that gap to the parent directory entry via `dir_flist->files[cur_flist->parent_ndx]` (`sender.c:267-272`). oc instead fed the gap through its plain segment map (`wire_to_flat_ndx`), which lands on the trailing child of the previous segment - so the directory's iflags were formatted against the child file entry.

## Fix

Each sub-list now records its parent directory's wire NDX alongside `ndx_segments` (`segment_parent_ndx`, populated in `encode_and_send_segment`). A new `resolve_itemize_ndx` detects a gap NDX (`g + 1 == ndx_start` of a sub-list, an NDX no regular entry can hold because the +1 gap is reserved, `flist.c:2931`) and maps it back to the parent directory's flat index before itemize formatting and xattr-response lookup. Every non-gap NDX resolves exactly as before.

## Upstream citations

- `generator.c:2307-2314` `generate_files()` - directory itemized at `ndx = cur_flist->ndx_start - 1`.
- `generator.c:1242-1244` `recv_generator()` - `is_dir` is only fully processed when `ndx == cur_flist->ndx_start - 1`.
- `generator.c:511-586` `itemize()` - writes `write_ndx(sock_f_out, ndx)` + iflags back to the sender.
- `sender.c:267-272` `send_files()` - gap NDX (`ndx < cur_flist->ndx_start`) resolves to `dir_flist->files[cur_flist->parent_ndx]`.
- `log.c` `itemize()`/`log_item` - type char (`f`/`d`/`L`/`D`) and field formatting come from the resolved file entry.

## Files changed

- `crates/transfer/src/generator/segments.rs` - add `segment_parent_ndx` parallel table.
- `crates/transfer/src/generator/protocol_io.rs` - record parent NDX when a sub-list is sent.
- `crates/transfer/src/generator/context.rs` - add `resolve_itemize_ndx`.
- `crates/transfer/src/generator/transfer/transfer_loop.rs` - use `resolve_itemize_ndx` for the flat index driving itemize.
- `crates/transfer/src/generator/tests.rs` - `inc_recurse_gap_ndx_itemizes_parent_directory` pins the corrected directory row and the absence of a spurious child row.

## Validation

- `cargo fmt --all` clean.
- `cargo clippy -p transfer --all-targets --all-features --no-deps -- -D warnings` clean.
- Unit test added. Full test suite runs in CI.

A validation-host seal against a real upstream rsync binary (both directions, daemon + ssh) is still required before merge to confirm the corrected rows byte-match upstream end to end.
