### PR TITLE
fix(daemon): drain to peer EOF after half-close to avoid abortive RST

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -18,6 +18,8 @@ include!("transfer/sandbox.rs");
 
 include!("transfer/draining_reader.rs");
 
+include!("transfer/graceful_close.rs");
+
 include!("transfer/streams.rs");
 
 include!("transfer/orchestration.rs");

--- a/crates/daemon/src/daemon/sections/module_access/transfer/graceful_close.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/graceful_close.rs
@@ -1,0 +1,186 @@
+// Graceful lingering-close drain for the daemon connection teardown.
+//
+// After the transfer engine has completed the full goodbye handshake (both
+// directions of the NDX_DONE exchange) and every user-space byte has been
+// flushed, the connection thread must close the socket. On Unix a `close()`
+// that still has unread bytes queued in the kernel receive buffer is an
+// *abortive* close: the kernel discards the data and sends a TCP RST instead of
+// a clean FIN. The peer then surfaces that RST as
+// "Connection reset by peer (os error 104)" on its next socket read, which the
+// client maps to a partial-transfer failure (exit 23) even though the transfer
+// itself completed correctly.
+//
+// Upstream rsync never hits this because the daemon-receiver child keeps reading
+// the socket (`io.c:943 noop_io_until_death()` loops on `read_buf()` until the
+// peer dies) right up to process exit, so the kernel receive buffer is empty by
+// the time `cleanup.c:265 close_all()` runs. The threaded daemon collapses that
+// pattern into an explicit drain-to-EOF here: read the socket until the peer
+// sends FIN (`Ok(0)`), so the final `close()` finds an empty receive buffer and
+// emits a clean FIN rather than a RST.
+//
+// The drain is bounded by a read timeout so a wedged or silent peer can never
+// pin the connection thread: an idle socket returns `TimedOut`/`WouldBlock` and
+// the loop exits. This mirrors upstream's `set_io_timeout(60)` guard around
+// `noop_io_until_death()`.
+//
+// This file is `include!`d into the `crate::daemon` scope (see
+// `module_access.rs`), so it reuses the enclosing module's imports (`io`,
+// `Read`, `Duration`, `TcpStream`).
+
+/// Read timeout that bounds each blocking drain `read()` during the teardown
+/// drain-to-EOF loop.
+///
+/// A silent peer returns `TimedOut` after this window so the loop exits instead
+/// of parking the connection thread. Five seconds is generous for any
+/// reasonable goodbye round-trip while keeping a wedged peer from pinning the
+/// thread; it also matches the companion `SO_LINGER` window applied to the
+/// kernel send buffer.
+const GOODBYE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A readable connection whose blocking `read` can be bounded by a read timeout
+/// so a drain-to-EOF loop can never hang on a wedged peer.
+///
+/// Implemented by [`DaemonStream`] (production) and `TcpStream` (tests). The
+/// timeout setter mirrors `set_read_timeout`; `None` clears it.
+trait PeerDrainStream: Read {
+    /// Sets (or clears, with `None`) the read timeout on the underlying socket.
+    fn set_drain_timeout(&self, timeout: Option<Duration>) -> io::Result<()>;
+}
+
+impl PeerDrainStream for DaemonStream {
+    fn set_drain_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+        self.set_read_timeout(timeout)
+    }
+}
+
+#[cfg(test)]
+impl PeerDrainStream for TcpStream {
+    fn set_drain_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+        self.set_read_timeout(timeout)
+    }
+}
+
+/// Drains the connection's read side until the peer sends FIN (a clean `Ok(0)`
+/// EOF), bounded by `timeout`, so the socket's receive buffer is empty when the
+/// connection is finally closed.
+///
+/// This is the invariant that keeps the daemon from ever performing an abortive
+/// `close()`: with the receive buffer drained to EOF, the final close emits a
+/// clean FIN, so the peer reads a clean EOF rather than a RST. A `close()` with
+/// unread bytes still queued would make the kernel send a RST that the peer
+/// reports as "Connection reset by peer".
+///
+/// The loop tolerates every terminal condition equally - EOF, an elapsed read
+/// timeout, or a peer-close error (`ConnectionReset`/`BrokenPipe`) - because all
+/// three mean there is nothing left to drain. Errors are swallowed: this runs on
+/// the teardown path after the transfer result has already been decided, so a
+/// drain hiccup must never change the transfer's outcome.
+///
+/// upstream: `io.c:943-963 noop_io_until_death()` keeps reading until the peer
+/// dies; `set_io_timeout(60)` bounds it so a wedged peer cannot hang forever.
+fn drain_until_peer_eof<S: PeerDrainStream + ?Sized>(stream: &mut S, timeout: Duration) {
+    let _ = stream.set_drain_timeout(Some(timeout));
+    let mut sink = [0u8; 4096];
+    loop {
+        match stream.read(&mut sink) {
+            // Peer FINed: the receive buffer is empty, the close will be clean.
+            Ok(0) => break,
+            // More trailing bytes (peer goodbye / codec trailer); keep draining.
+            Ok(_) => continue,
+            // Idle-socket timeout, interrupted syscall, or any peer-close error:
+            // nothing left to drain, stop so the close can proceed.
+            Err(_) => break,
+        }
+    }
+    let _ = stream.set_drain_timeout(None);
+}
+
+#[cfg(test)]
+mod graceful_close_tests {
+    //! Drain-to-EOF invariant tests for [`drain_until_peer_eof`].
+    //!
+    //! The daemon must fully drain the peer's trailing bytes and wait for the
+    //! peer's FIN before closing, so the kernel receive buffer is empty and the
+    //! final `close()` emits a clean FIN instead of an abortive RST. These tests
+    //! pin that invariant without depending on timing luck.
+
+    use super::drain_until_peer_eof;
+    use std::io::Write;
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::mpsc::channel;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    /// A peer that writes a trailing goodbye burst then closes must be drained
+    /// to EOF: every trailing byte is consumed and the loop returns only once
+    /// the FIN arrives. This is the exact shape of the teardown race - trailing
+    /// goodbye/codec bytes still in flight when the daemon starts to close.
+    #[test]
+    fn drains_all_trailing_bytes_then_returns_on_fin() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let peer = thread::spawn(move || {
+            let (mut server, _) = listener.accept().expect("accept");
+            // Trailing bytes larger than one drain chunk, then FIN via drop.
+            server.write_all(&vec![0x5Au8; 20_000]).expect("write trailing");
+            server.flush().expect("flush trailing");
+            // Drop -> FIN -> EOF on the drain side.
+        });
+
+        let mut client = TcpStream::connect(addr).expect("connect loopback");
+        drain_until_peer_eof(&mut client, Duration::from_secs(5));
+        // Reaching here means the loop observed EOF (Ok(0)); if it had returned
+        // early on the first non-empty read, the peer's FIN would be unobserved
+        // and a real close would risk an abortive RST.
+        peer.join().expect("peer join");
+    }
+
+    /// A silent peer that never sends and never FINs must not pin the thread:
+    /// the bounded read timeout makes the drain return promptly. This is the
+    /// anti-hang guard - the drain can never block indefinitely on a wedged
+    /// peer (upstream's `set_io_timeout` around `noop_io_until_death`).
+    #[test]
+    fn returns_promptly_when_peer_is_silent() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let (drop_tx, drop_rx) = channel::<()>();
+        let peer = thread::spawn(move || {
+            let (server, _) = listener.accept().expect("accept");
+            // Hold the connection open, silent, until the test says to drop it.
+            let _ = drop_rx.recv();
+            drop(server);
+        });
+
+        let mut client = TcpStream::connect(addr).expect("connect loopback");
+        let start = Instant::now();
+        drain_until_peer_eof(&mut client, Duration::from_millis(200));
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "drain must return within the read-timeout window on a silent peer"
+        );
+        drop_tx.send(()).expect("signal peer");
+        peer.join().expect("peer join");
+    }
+
+    /// A peer that FINs immediately with no data drains instantly: the first
+    /// read is EOF and the loop returns without blocking. This is the common
+    /// case (peer already closed by the time the daemon reaches teardown).
+    #[test]
+    fn returns_immediately_on_prompt_eof() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let peer = thread::spawn(move || {
+            let (server, _) = listener.accept().expect("accept");
+            drop(server); // immediate FIN
+        });
+
+        let mut client = TcpStream::connect(addr).expect("connect loopback");
+        let start = Instant::now();
+        drain_until_peer_eof(&mut client, Duration::from_secs(5));
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "a prompt peer FIN must drain immediately, not wait out the timeout"
+        );
+        peer.join().expect("peer join");
+    }
+}

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -572,9 +572,27 @@ fn process_approved_module(
     //   2. Drain read until EOF - waits for the peer to finish its own
     //      goodbye and FIN. We do NOT call `shutdown(Write)` first;
     //      sending FIN early would tell the peer "I'm done" before the
-    //      peer has written its trailing goodbye, which is the race.
-    //   3. close() - the linger window guarantees in-flight TX bytes are
+    //      peer has written its trailing goodbye (the oc<->upstream
+    //      download case where the receiver still sends MSG_STATS + a
+    //      final NDX_DONE after our engine's handle_goodbye returns).
+    //   3. shutdown(SHUT_WR) - half-close the write side now the protocol
+    //      is complete, so the peer observes our FIN and stops reading.
+    //   4. Drain read until EOF AGAIN - once we have FINed, wait for the
+    //      peer to observe it and close, draining any last bytes so the
+    //      final close() finds an EMPTY receive buffer. A close() with
+    //      unread bytes queued is an abortive close: the kernel discards
+    //      the data and sends a RST instead of a FIN, which the peer
+    //      reports as "Connection reset by peer (os error 104)" (exit 23)
+    //      even though the transfer completed. Steps 2 and 4 bracket the
+    //      half-close so neither an early FIN (step 2 first) nor a slow
+    //      peer that has not yet FINed by step 2's timeout (step 4 catches
+    //      it after the half-close prompts its close) can leave unread
+    //      bytes at the final close.
+    //   5. close() - the linger window guarantees in-flight TX bytes are
     //      delivered before the close completes.
+    //
+    // Every drain is bounded by a read timeout so a wedged peer can never
+    // pin the connection thread (never an unbounded blocking read).
     //
     // upstream: io.c:943-963 noop_io_until_death() loops on read() until
     // the peer sends FIN; cleanup.c:265 then calls close_all(). Our
@@ -598,35 +616,15 @@ fn process_approved_module(
             let _ = sock.set_linger(Some(Duration::from_secs(5)));
         }
 
-        // Drain the read side until the peer sends FIN (EOF). We do NOT
-        // shutdown(Write) first: that would tell the peer "I'm done"
-        // before it has written its trailing MSG_STATS / NDX_DONE, which
-        // the peer abandons on receipt of FIN. Mirrors upstream's
-        // `noop_io_until_death()` for the sender side: read until peer
-        // FINs (which it does on its own `exit_cleanup`), then close.
-        //
-        // Cap at 5s so a wedged peer cannot pin the daemon thread; the
-        // window is generous enough for any reasonable goodbye exchange.
-        let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
-        let mut sink = [0u8; 4096];
-        loop {
-            match stream.read(&mut sink) {
-                Ok(0) => break,
-                Ok(_) => continue,
-                Err(err)
-                    if matches!(
-                        err.kind(),
-                        io::ErrorKind::TimedOut
-                            | io::ErrorKind::WouldBlock
-                            | io::ErrorKind::Interrupted
-                    ) =>
-                {
-                    break;
-                }
-                Err(_) => break,
-            }
-        }
-        let _ = stream.set_read_timeout(None);
+        // Pre-shutdown drain: read the peer's trailing bytes until FIN (EOF).
+        // We do NOT shutdown(Write) first: that would tell the peer "I'm done"
+        // before it has written its trailing MSG_STATS / NDX_DONE, which the
+        // peer (an upstream receiver in the oc<->upstream download case)
+        // abandons on receipt of FIN. Mirrors upstream's
+        // `noop_io_until_death()`: read until the peer FINs on its own
+        // `exit_cleanup`. Bounded by a read timeout so a wedged peer cannot pin
+        // the daemon thread; the window is generous for any goodbye exchange.
+        drain_until_peer_eof(stream, GOODBYE_DRAIN_TIMEOUT);
 
         // UTS-V3.A explicit drain barrier (kernel-level half-close).
         // Once the peer has FINed (read-drain returned EOF/timeout) and
@@ -653,6 +651,16 @@ fn process_approved_module(
                 }
             }
         }
+
+        // Post-shutdown drain: now that our FIN is on the wire, wait for the
+        // peer to observe it and close, consuming any last bytes so the final
+        // close() below finds an EMPTY receive buffer and emits a clean FIN
+        // rather than an abortive RST. This catches the slow-peer case where
+        // the pre-shutdown drain timed out before the peer had FINed: the
+        // half-close prompts the peer to finish reading and close, and this
+        // drain reaps its FIN. Bounded by the same read timeout so it can never
+        // hang. See `graceful_close.rs` for the abortive-close rationale.
+        drain_until_peer_eof(stream, GOODBYE_DRAIN_TIMEOUT);
     }
 
     // Drop transfer-engine stream clones after the drain completes.


### PR DESCRIPTION
## Problem

The daemon `-zz` upload integration test (`daemon_gzip_zz_upload_byte_identical`,
`crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs`) intermittently failed the
`nextest` cells with:

```
transfer failed: Connection reset by peer (os error 104) (code 23)
```

It is pre-existing and master-wide (it surfaced on four unrelated PRs at once - a
real regression would only touch one). The transfer itself completes correctly;
the failure is a teardown race where the daemon closes the socket in a way that
makes the client see a TCP RST instead of a clean EOF.

## Root cause

On Unix, `close()` on a socket that still has unread bytes queued in the kernel
receive buffer is an *abortive* close: the kernel discards the queued data and
sends a TCP **RST** instead of a FIN. The peer then reports
`Connection reset by peer (os error 104)` on its next socket read, which the
client maps to a partial-transfer failure (exit 23) even though every byte was
transferred.

Upstream rsync never hits this: the daemon-receiver child keeps reading the
socket right up to process exit (`io.c:943 noop_io_until_death()` loops on
`read_buf()` until the peer dies), so the kernel receive buffer is empty by the
time `cleanup.c:265 close_all()` runs.

The threaded oc-rsync daemon collapses upstream's fork model into an explicit
teardown in
`crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs`. It
did: `SO_LINGER(5s)` -> drain-read-until-EOF -> `shutdown(SHUT_WR)` -> `close`.
The single drain runs *before* the half-close. If that drain returns on its
bounded timeout (a peer descheduled under heavy full-suite load has not yet read
the final `NDX_DONE` and FINed), the daemon then half-closes and closes while the
peer's FIN/last bytes are still in flight - an abortive close - and the client
reads a RST. The drain in isolation is clean (0 RST over 4000 loopback
iterations under CPU load on Linux); the window only opens under the scheduling
pressure of the full `nextest` run.

## Upstream citations

- `io.c:943-963 noop_io_until_death()` - loops on `read_buf()` until the peer
  FINs; `set_io_timeout(60)` bounds it so a wedged peer cannot hang forever.
- `main.c:1052-1105 do_recv()` - the daemon-receiver child sends its goodbye
  (`write_int(f_out, NDX_DONE)` + `send_msg(MSG_STATS, ...)`) then keeps reading
  (`read_final_goodbye()` / `msleep` loop) until the generator kills it.
- `main.c:1310-1357 client_run()` (`am_sender`) - the client-sender's exit
  sequence: `read_final_goodbye()`, `output_summary()`, `exit_cleanup()`.
- `cleanup.c:265 close_all()` - the process-exit close that emits the FIN once
  the receive buffer has been drained.

## Fix

`crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs`
teardown, plus a new
`crates/daemon/src/daemon/sections/module_access/transfer/graceful_close.rs`
helper. The change is purely teardown ORDERING - not one transferred or wire byte
changes. The daemon now brackets the half-close with a drain on each side:

1. `SO_LINGER(5s)` (unchanged) - bounds the kernel TX drain.
2. Pre-shutdown drain to EOF (unchanged behaviour, factored into
   `drain_until_peer_eof`) - reads the peer's trailing goodbye before we FIN.
   This preserves the oc<->upstream download-cluster invariant (the upstream
   receiver still sends `MSG_STATS` + a final `NDX_DONE` after our engine's
   `handle_goodbye` returns; FINing first would make it abandon those writes).
3. `shutdown(SHUT_WR)` (unchanged) - half-close now the protocol is complete.
4. **New:** post-shutdown drain to EOF - now that our FIN is on the wire, wait
   for the peer to observe it, finish, and close, consuming any last bytes so
   the final `close()` finds an **empty** receive buffer and emits a clean FIN
   rather than an abortive RST. This catches the slow-peer case where the
   pre-shutdown drain timed out before the peer had FINed: the half-close
   prompts the peer to close, and this drain reaps its FIN.

Both drains go through the same `drain_until_peer_eof` helper, which sets a
bounded read timeout (`SO_RCVTIMEO`) before the loop and clears it after, so it
can never perform an unbounded blocking read - a silent/wedged peer returns
`TimedOut` and the loop exits (mirroring upstream's `set_io_timeout` guard). The
`SO_LINGER(5s)` from `shutdown_send_side` remains the catastrophic-failure
fallback. Worst-case teardown against a peer that never FINs is bounded by the
two 5s windows and is well within the test's `--timeout=30`.

## Why it can't hang

Every drain arms a read timeout before looping and clears it after; `read()`
returns `TimedOut`/`WouldBlock` on an idle socket and the loop breaks. No path
performs an unbounded blocking read. The pre-shutdown drain is the same bounded
loop as before; the added post-shutdown drain uses the identical helper.

## Regression protection

New deterministic unit tests in `graceful_close.rs` (`graceful_close_tests`) pin
the drain-to-EOF invariant without depending on timing luck:

- `drains_all_trailing_bytes_then_returns_on_fin` - a peer that writes a trailing
  burst larger than one drain chunk then closes must be fully drained and the
  loop must return only on the FIN (EOF). Encodes WHY: the receive buffer must be
  empty at close so the close is a clean FIN, never an abortive RST.
- `returns_promptly_when_peer_is_silent` - a silent peer that never FINs must not
  pin the thread; the bounded read timeout makes the drain return promptly
  (anti-hang guard).
- `returns_immediately_on_prompt_eof` - the common case: a peer that FINs at once
  drains instantly without waiting out the timeout.

## Related teardown flakes

The `daemon_filter_push` and exclude-lsh sender teardown flakes are the same
family ("daemon closes before the peer finishes reading"). This fix targets the
shared daemon teardown path they all traverse (`process_approved_module`), so it
should cover them; if either turns out distinct it will need a separate,
precisely scoped change.

## Validation

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p daemon -p transfer --all-targets --all-features --no-deps
  -- -D warnings`: clean.
- Because the race only opens under full-suite scheduling pressure, the required
  pre-merge validation is (1) the CI `nextest` cells run under load (stress), and
  (2) an lxhost real-upstream-daemon push/pull seal in both directions
  (oc client <-> upstream daemon and upstream client <-> oc daemon), to confirm
  the download-cluster invariant (step 2) and the abortive-close fix (step 4)
  both hold end-to-end.
