### PR TITLE
docs(engine): fix broken DeleteEmitter intra-doc links (rustdoc/Pages)

### DIFF
--- a/crates/engine/src/delete/context/core.rs
+++ b/crates/engine/src/delete/context/core.rs
@@ -426,7 +426,8 @@ impl DeleteContext {
     /// of entries are being deleted. When the whole transfer plans fewer
     /// than [`SMALL_DIR_FAST_PATH_THRESHOLD`] extras, or the process has no
     /// spare rayon worker to parallelise onto, the drain runs the
-    /// sequential [`DeleteEmitter`] directly. That emitter is the exact
+    /// sequential [`DeleteEmitter`](super::super::emitter::DeleteEmitter)
+    /// directly. That emitter is the exact
     /// code the parallel path dispatches through per cohort, so the delete
     /// events, stats, and exit code are byte-identical either way; only the
     /// scheduling wrapper is skipped.
@@ -528,7 +529,8 @@ impl DeleteContext {
     }
 
     /// DML-4 fast path: drains the owned [`DrainParts`] through the
-    /// sequential [`DeleteEmitter`], bypassing the parallel consumer's
+    /// sequential [`DeleteEmitter`](super::super::emitter::DeleteEmitter),
+    /// bypassing the parallel consumer's
     /// batching and scheduling machinery.
     ///
     /// This is the exact emitter the parallel consumer dispatches through


### PR DESCRIPTION
## Summary

The workspace rustdoc build (`Pages` workflow, `-D rustdoc::broken_intra_doc_links`) fails on master with:

```
error: unresolved link to `DeleteEmitter`
error: could not document `engine`
```

blocking the GitHub Pages deploy.

## Cause

`crates/engine/src/delete/context/core.rs` has two **bare** `[`DeleteEmitter`]` intra-doc links (lines ~429 and ~531). `DeleteEmitter` (defined in `delete/emitter/mod.rs`) is not imported in that module, so the bare links are unresolved. An earlier reference in the same file (line 27) already uses the qualified path and resolves fine.

## Fix

Qualify both links with the same `super::super::emitter::DeleteEmitter` path used at line 27. Docs-only — no code, behavior, or wire change.
