### PR TITLE
fix(daemon): match upstream listener sockopts (SO_REUSEADDR only by default) + --port 0

### DIFF
--- a/crates/daemon/src/daemon/runtime_options/parsing.rs
+++ b/crates/daemon/src/daemon/runtime_options/parsing.rs
@@ -41,7 +41,11 @@ impl RuntimeOptions {
         while let Some(argument) = iter.next() {
             if let Some(value) = take_option_value(argument, &mut iter, "--port")? {
                 options.port = parse_port(&value)?;
-                options.port_overridden = true;
+                // upstream: clientserver.c:1573 - `--port 0` is treated as
+                // "unspecified": it does not override a config `port` directive
+                // and falls through to the 873 default below. Only a non-zero
+                // CLI port suppresses the config value.
+                options.port_overridden = options.port != 0;
             } else if let Some(value) = take_option_value(argument, &mut iter, "--bind")? {
                 let addr = parse_bind_address(&value)?;
                 options.set_bind_address(addr)?;
@@ -123,6 +127,18 @@ impl RuntimeOptions {
             } else {
                 return Err(unsupported_option(argument.clone(), brand));
             }
+        }
+
+        // upstream: clientserver.c:1573-1574 -
+        //   `if (rsync_port == 0 && (rsync_port = lp_rsync_port()) == 0)
+        //        rsync_port = RSYNC_PORT;`
+        // After CLI and config resolution, a still-zero port coerces to the
+        // well-known rsync port 873 rather than binding a kernel-assigned
+        // ephemeral port. This is the same 0 -> 873 coercion the config
+        // accessor applies (`rsyncd_config::sections::port`), applied once here
+        // so both the sync and async daemon bind paths share it.
+        if options.port == 0 {
+            options.port = DEFAULT_PORT;
         }
 
         Ok(options)

--- a/crates/daemon/src/daemon/runtime_options/tests.rs
+++ b/crates/daemon/src/daemon/runtime_options/tests.rs
@@ -96,6 +96,21 @@ mod runtime_options_tests {
     }
 
     #[test]
+    fn parse_port_zero_coerces_to_well_known_rsync_port() {
+        // upstream: clientserver.c:1573-1574 -
+        //   `if (rsync_port == 0 && (rsync_port = lp_rsync_port()) == 0)
+        //        rsync_port = RSYNC_PORT;`
+        // A resolved port of 0 (from `--port 0`) falls back to the well-known
+        // rsync port 873 rather than binding a kernel-assigned ephemeral port.
+        let args = vec![OsString::from("--port"), OsString::from("0")];
+        let options = RuntimeOptions::parse(&args).expect("parse");
+        assert_eq!(
+            options.port, DEFAULT_PORT,
+            "--port 0 must coerce to the well-known rsync port 873, matching upstream"
+        );
+    }
+
+    #[test]
     fn parse_ipv4_option_sets_address_family() {
         let args = vec![OsString::from("--ipv4")];
         let options = RuntimeOptions::parse(&args).expect("parse");

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -167,6 +167,7 @@ fn bind_with_backlog(
     addr: SocketAddr,
     backlog: i32,
     tcp_fastopen: TcpFastOpenMode,
+    reuse_port: bool,
 ) -> io::Result<TcpListener> {
     let domain = if addr.is_ipv4() {
         socket2::Domain::IPV4
@@ -185,30 +186,40 @@ fn bind_with_backlog(
         })?;
 
     // Allow port reuse so the daemon can restart quickly without waiting for
-    // TIME_WAIT sockets to expire. Mirrors standard TcpListener::bind behaviour.
+    // TIME_WAIT sockets to expire.
+    // upstream: socket.c:447 - open_socket_in() sets SO_REUSEADDR (and only
+    // SO_REUSEADDR) on every listener.
     socket.set_reuse_address(true)?;
 
-    // Enable SO_REUSEPORT where supported (NACC) so multiple listener sockets
-    // can share the bind address and the kernel load-balances accepts across
-    // them. Best-effort: a failure downgrades to the single-listener path
-    // rather than aborting the bind. socket2's setter is Unix-only; Windows
-    // has no equivalent, so the call is skipped there.
+    // SO_REUSEPORT is set ONLY for the opt-in multi-acceptor daemon (more than
+    // one replica socket per address), where several listener sockets must
+    // share the bind address and the kernel load-balances accepts across them.
+    // The default single-listener daemon (`reuse_port == false`) must NOT set
+    // it: upstream (socket.c:447) sets only SO_REUSEADDR, so a second daemon
+    // attempting to bind the same port is refused with EADDRINUSE rather than
+    // silently co-binding. Best-effort when enabled: a failure downgrades to a
+    // debug log. socket2's setter is Unix-only; Windows has no equivalent, so
+    // the flag is consumed but unused there.
+    #[cfg(not(unix))]
+    let _ = reuse_port;
     #[cfg(unix)]
-    if fast_io::reuse_port_supported() {
-        match socket.set_reuse_port(true) {
-            Ok(()) => logging::debug_log!(Sockopt, 1, "SO_REUSEPORT set on listener {addr}"),
-            Err(_) => logging::debug_log!(
+    if reuse_port {
+        if fast_io::reuse_port_supported() {
+            match socket.set_reuse_port(true) {
+                Ok(()) => logging::debug_log!(Sockopt, 1, "SO_REUSEPORT set on listener {addr}"),
+                Err(_) => logging::debug_log!(
+                    Sockopt,
+                    1,
+                    "SO_REUSEPORT apply failed on listener {addr}: single-listener fallback"
+                ),
+            }
+        } else {
+            logging::debug_log!(
                 Sockopt,
                 1,
-                "SO_REUSEPORT apply failed on listener {addr}: single-listener fallback"
-            ),
+                "SO_REUSEPORT unsupported on this platform: skipped for listener {addr}"
+            );
         }
-    } else {
-        logging::debug_log!(
-            Sockopt,
-            1,
-            "SO_REUSEPORT unsupported on this platform: skipped for listener {addr}"
-        );
     }
 
     // For IPv6 sockets, set IPV6_V6ONLY to avoid conflicts with the separate
@@ -374,6 +385,11 @@ fn bind_listeners_per_family(
     log_sink: Option<&SharedLogSink>,
 ) -> Result<(Vec<TcpListener>, Vec<SocketAddr>), io::Error> {
     let replicas = acceptor_threads.max(1) as usize;
+    // SO_REUSEPORT is only needed when more than one replica socket must
+    // co-bind the same address (the opt-in multi-acceptor extension). The
+    // default single-listener daemon binds with SO_REUSEADDR only, matching
+    // upstream socket.c:447 so a duplicate bind is refused with EADDRINUSE.
+    let reuse_port = replicas > 1;
     let mut listeners = Vec::with_capacity(bind_addresses.len() * replicas);
     let mut bound_addresses = Vec::with_capacity(bind_addresses.len() * replicas);
     let dual_stack = bind_addresses.len() > 1;
@@ -389,7 +405,7 @@ fn bind_listeners_per_family(
         let mut family_bound = 0usize;
         let mut family_error: Option<io::Error> = None;
         for _ in 0..replicas {
-            match bind_with_backlog(requested_addr, backlog, tcp_fastopen) {
+            match bind_with_backlog(requested_addr, backlog, tcp_fastopen, reuse_port) {
                 Ok(listener) => {
                     let local_addr = listener.local_addr().unwrap_or(requested_addr);
                     bound_addresses.push(local_addr);

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1073,6 +1073,99 @@ fn default_acceptor_threads_is_one() {
     assert_eq!(RuntimeOptions::default().acceptor_threads(), 1);
 }
 
+// Unix-only: asserts POSIX SO_REUSEADDR semantics (a second bind on an active
+// listener is refused). Windows SO_REUSEADDR instead permits re-binding, so this
+// exact-refusal invariant is a Unix property.
+#[cfg(unix)]
+#[test]
+fn default_single_listener_refuses_a_second_bind_on_the_same_port() {
+    // upstream: socket.c:447 - open_socket_in() sets SO_REUSEADDR only. The
+    // default single-listener daemon (acceptor_threads == 1) must therefore NOT
+    // set SO_REUSEPORT, so a second bind on the same in-use port is refused with
+    // EADDRINUSE rather than co-binding. This is what makes concurrent daemon
+    // tests safe from cross-connection load-balancing.
+    let reachable = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+
+    // Bind the first default listener on an ephemeral port and learn it; the
+    // listener holds the port so there is no reserve/rebind window.
+    let (first, first_addrs) = bind_listeners_per_family(
+        &[reachable],
+        0,
+        DEFAULT_LISTEN_BACKLOG,
+        TcpFastOpenMode::Off,
+        1,
+        None,
+    )
+    .expect("first default bind must succeed");
+    assert_eq!(first.len(), 1);
+    let port = first_addrs[0].port();
+    assert!(port != 0);
+
+    // A second default (replicas == 1) bind on that same, in-use port must be
+    // refused - no SO_REUSEPORT co-bind.
+    let second = bind_listeners_per_family(
+        &[reachable],
+        port,
+        DEFAULT_LISTEN_BACKLOG,
+        TcpFastOpenMode::Off,
+        1,
+        None,
+    );
+    assert!(
+        second.is_err(),
+        "a second default-daemon bind on an in-use port must fail (SO_REUSEADDR only), got Ok"
+    );
+}
+
+// Unix-only: SO_REUSEPORT (the fixed-port co-bind mechanism) is a POSIX socket
+// option; socket2's setter is Unix-only and the daemon only sets it under
+// `#[cfg(unix)]`.
+#[cfg(unix)]
+#[test]
+fn multi_acceptor_replicas_co_bind_the_same_fixed_port() {
+    // The opt-in multi-acceptor daemon (acceptor_threads > 1) still sets
+    // SO_REUSEPORT on its replica sockets, so multiple listeners share ONE fixed
+    // port and the kernel load-balances accepts across them. Binding replicas on
+    // a fixed port (rather than port 0, which hands each replica a distinct
+    // ephemeral port) is what actually exercises the shared-port co-bind.
+    let reachable = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+
+    // Reserve a currently-free fixed port. A concurrent test could steal it in
+    // the window between reserve and bind, so retry until a clean attempt binds
+    // both replicas (or the budget is exhausted).
+    for _ in 0..32 {
+        let port = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .and_then(|l| l.local_addr())
+            .map(|a| a.port())
+            .expect("reserve free port");
+
+        match bind_listeners_per_family(
+            &[reachable],
+            port,
+            DEFAULT_LISTEN_BACKLOG,
+            TcpFastOpenMode::Off,
+            2,
+            None,
+        ) {
+            Ok((listeners, addrs)) if listeners.len() == 2 => {
+                assert!(
+                    addrs.iter().all(|a| a.port() == port),
+                    "both replicas must co-bind the same fixed port {port}, got {addrs:?}"
+                );
+                return;
+            }
+            // A regression that dropped SO_REUSEPORT would bind only the first
+            // replica (the second EADDRINUSEs), returning a single listener.
+            // Retry: this attempt lost the reserve race or the port was busy.
+            _ => continue,
+        }
+    }
+    panic!(
+        "acceptor_threads=2 must co-bind two replica listeners on one fixed port \
+         (SO_REUSEPORT); none of the attempts bound both replicas"
+    );
+}
+
 #[test]
 fn bind_listeners_per_family_fails_only_when_all_families_unreachable() {
     // Companion to the fallback test: confirm the helper surfaces an error

--- a/crates/test-support/src/daemon_port.rs
+++ b/crates/test-support/src/daemon_port.rs
@@ -1,0 +1,199 @@
+//! Race-free free-port allocation for daemon integration tests.
+//!
+//! # Why this exists
+//!
+//! Allocating an ephemeral port (bind port 0, read its number, drop the
+//! listener) and then starting a separate daemon process on that number has a
+//! time-of-check / time-of-use window: between the drop and the daemon's own
+//! `bind`, a concurrently-running test can be handed the same ephemeral port.
+//!
+//! The oc-rsync daemon binds its default single listener with `SO_REUSEADDR`
+//! only (matching upstream `socket.c:447`), so such a collision is a **clean
+//! `EADDRINUSE` daemon-startup failure** - never a silent co-bind. (Only the
+//! opt-in `acceptor threads > 1` multi-acceptor daemon sets `SO_REUSEPORT`, for
+//! its own replica sockets.) That means a losing daemon simply exits, and the
+//! winner owns the port exclusively - no two daemons ever share a port and no
+//! cross-connection load-balancing is possible.
+//!
+//! [`spawn_daemon_on_free_port`] turns that into a bounded retry: allocate a
+//! candidate port, spawn the daemon on it, and confirm the spawned process
+//! itself is listening on that port (matched by pid via [`daemon_listen_port`]).
+//! If the daemon lost the bind race it exits and we retry with a fresh port.
+//! Matching by pid - rather than merely connecting to the port - is what closes
+//! the window: it never mistakes a *different* winning daemon on the same port
+//! for our own.
+
+use std::io;
+use std::net::{Ipv4Addr, TcpListener};
+use std::process::Child;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// How long to wait for a freshly-spawned daemon to bind its listener before
+/// treating the attempt as failed and retrying with a new port.
+const READY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Upper bound on port-allocation retries, so a persistently failing daemon
+/// (bad config, unbindable address) surfaces an error instead of looping.
+const MAX_ATTEMPTS: u32 = 32;
+
+/// Allocates a currently-free loopback TCP port by binding ephemeral port 0 and
+/// dropping the listener. The port is free on return; callers must hand it to a
+/// daemon promptly and tolerate the (now clean-failing) collision window via
+/// the retry in [`spawn_daemon_on_free_port`].
+fn candidate_port() -> Option<u16> {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
+    let port = listener.local_addr().ok()?.port();
+    drop(listener);
+    Some(port)
+}
+
+/// Spawns a daemon on a race-free free port and returns the live child plus the
+/// port it owns.
+///
+/// `spawn_on_port(port)` must start the daemon process bound to `port` (e.g.
+/// `oc-rsync --daemon --port <port> ...`) and return its [`Child`]. The helper
+/// allocates candidate ports and retries until the spawned process is confirmed
+/// listening on its port, or the attempt budget is exhausted.
+///
+/// The caller owns the returned [`Child`] and is responsible for reaping it
+/// (typically via a guard whose `Drop` kills and waits).
+pub fn spawn_daemon_on_free_port<F>(mut spawn_on_port: F) -> io::Result<(Child, u16)>
+where
+    F: FnMut(u16) -> io::Result<Child>,
+{
+    let mut last_err: Option<io::Error> = None;
+    for _ in 0..MAX_ATTEMPTS {
+        let Some(port) = candidate_port() else {
+            continue;
+        };
+        let mut child = spawn_on_port(port)?;
+        let pid = child.id();
+        let deadline = Instant::now() + READY_TIMEOUT;
+        let mut acquired = false;
+        loop {
+            // Confirm *this* process is the one listening on `port`. On a lost
+            // bind race the daemon never reaches this state (it exits with
+            // EADDRINUSE), so a different winning daemon on the same port is
+            // never mistaken for ours.
+            if daemon_listen_port(pid) == Some(port) {
+                acquired = true;
+                break;
+            }
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    last_err = Some(io::Error::other(format!(
+                        "daemon exited before binding port {port} ({status})"
+                    )));
+                    break;
+                }
+                Ok(None) => {}
+                Err(e) => return Err(e),
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                last_err = Some(io::Error::other(format!(
+                    "daemon did not bind port {port} within {READY_TIMEOUT:?}"
+                )));
+                break;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+        if acquired {
+            return Ok((child, port));
+        }
+    }
+    Err(last_err.unwrap_or_else(|| io::Error::other("could not allocate a free daemon port")))
+}
+
+/// Returns the TCP port that process `pid` is listening on (loopback), or
+/// `None` if it has no `LISTEN` TCP socket yet.
+///
+/// Used by [`spawn_daemon_on_free_port`] to confirm a specific daemon process
+/// owns its port. Only the daemon's own socket table is consulted (matched by
+/// the socket inodes it owns on Linux, or scoped to the pid by `lsof` on
+/// macOS), so an unrelated process listening on loopback is never mistaken for
+/// the daemon.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn daemon_listen_port(pid: u32) -> Option<u16> {
+    use std::collections::HashSet;
+    use std::fs;
+
+    let mut inodes: HashSet<String> = HashSet::new();
+    for entry in fs::read_dir(format!("/proc/{pid}/fd")).ok()?.flatten() {
+        if let Ok(link) = fs::read_link(entry.path()) {
+            if let Some(inode) = link
+                .to_str()
+                .and_then(|s| s.strip_prefix("socket:["))
+                .and_then(|s| s.strip_suffix(']'))
+            {
+                inodes.insert(inode.to_owned());
+            }
+        }
+    }
+    if inodes.is_empty() {
+        return None;
+    }
+
+    // `/proc/<pid>/net/tcp{,6}` columns: sl local_address rem_address st ...
+    // inode. `st == 0A` is TCP_LISTEN; `local_address` is HEXIP:HEXPORT.
+    for family in ["tcp", "tcp6"] {
+        let Ok(table) = fs::read_to_string(format!("/proc/{pid}/net/{family}")) else {
+            continue;
+        };
+        for line in table.lines().skip(1) {
+            let cols: Vec<&str> = line.split_whitespace().collect();
+            if cols.len() < 10 || cols[3] != "0A" || !inodes.contains(cols[9]) {
+                continue;
+            }
+            if let Some((_, port_hex)) = cols[1].rsplit_once(':') {
+                if let Ok(port) = u16::from_str_radix(port_hex, 16) {
+                    if port != 0 {
+                        return Some(port);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// macOS variant backed by `lsof`, which is present by default.
+#[cfg(target_os = "macos")]
+#[must_use]
+pub fn daemon_listen_port(pid: u32) -> Option<u16> {
+    let output = std::process::Command::new("lsof")
+        .args([
+            "-nP",
+            "-a",
+            "-p",
+            &pid.to_string(),
+            "-iTCP",
+            "-sTCP:LISTEN",
+            "-Fn",
+        ])
+        .output()
+        .ok()?;
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        // e.g. "n127.0.0.1:52345" or "n[::1]:52345".
+        if let Some((_, port)) = line.strip_prefix('n').and_then(|a| a.rsplit_once(':')) {
+            if let Ok(p) = port.parse::<u16>() {
+                if p != 0 {
+                    return Some(p);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Fallback for platforms without a supported discovery mechanism. The daemon
+/// integration tests using this are `#![cfg(unix)]` and CI runs them only on
+/// Linux and macOS.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[must_use]
+pub fn daemon_listen_port(_pid: u32) -> Option<u16> {
+    None
+}

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -6,12 +6,14 @@
 //! duplicated retry logic and setup boilerplate across crates.
 
 pub mod cli;
+pub mod daemon_port;
 pub mod dir_diff;
 pub mod lsh;
 pub mod skip;
 pub mod upstream_compat;
 
 pub use cli::{CliOutput, OcRsyncCliRunner, RunnerError};
+pub use daemon_port::{daemon_listen_port, spawn_daemon_on_free_port};
 pub use dir_diff::{DirDiff, DirDiffEntry, DirDiffError, DirDiffMismatch, DirDiffOptions};
 pub use lsh::{LSH_STUB_BIN, LshError, LshRunnerStub};
 pub use skip::{

--- a/crates/transfer/tests/nxt_4_reverse_daemon_delta.rs
+++ b/crates/transfer/tests/nxt_4_reverse_daemon_delta.rs
@@ -58,7 +58,7 @@
 //!
 //! Self-skips (prints `skipping:` and returns) when the workspace `oc-rsync`
 //! binary cannot be located, a loopback port cannot be allocated, or the daemon
-//! does not accept connections within [`DAEMON_BOOT_TIMEOUT`]. Non-zero exit,
+//! does not start within the daemon boot timeout. Non-zero exit,
 //! a diverged destination, or zero `Matched data` are real regressions.
 
 #![cfg(unix)]
@@ -66,16 +66,10 @@
 use std::env;
 use std::fs;
 use std::io;
-use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
 
 use tempfile::{TempDir, tempdir};
-
-/// Maximum time the daemon has to start accepting connections.
-const DAEMON_BOOT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Size of the delta-bearing payload. Large enough to span many signature
 /// blocks so the preserved outer thirds yield multiple Copy tokens.
@@ -106,29 +100,6 @@ fn locate_oc_rsync() -> Option<PathBuf> {
         }
     }
     None
-}
-
-/// Allocate a free TCP port by binding to ephemeral port 0.
-fn allocate_test_port() -> Option<u16> {
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
-    let port = listener.local_addr().ok()?.port();
-    drop(listener);
-    Some(port)
-}
-
-/// Wait until the daemon accepts a TCP connection on `port`.
-fn wait_for_daemon(port: u16) -> bool {
-    let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-    let deadline = Instant::now() + DAEMON_BOOT_TIMEOUT;
-    let mut backoff = Duration::from_millis(20);
-    while Instant::now() < deadline {
-        if std::net::TcpStream::connect_timeout(&target, Duration::from_millis(200)).is_ok() {
-            return true;
-        }
-        thread::sleep(backoff);
-        backoff = (backoff * 2).min(Duration::from_millis(200));
-    }
-    false
 }
 
 /// Write an `rsyncd.conf` exposing one read-only module rooted at
@@ -173,27 +144,26 @@ impl Drop for DaemonGuard {
 }
 
 /// Spawn `oc-rsync --daemon` on `port` and wait until it accepts connections.
-fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path, port: u16) -> io::Result<DaemonGuard> {
-    let child = Command::new(oc_bin)
-        .arg("--daemon")
-        .arg("--no-detach")
-        .arg("--port")
-        .arg(port.to_string())
-        .arg("--config")
-        .arg(config_path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if !wait_for_daemon(port) {
-        let mut guard = DaemonGuard { child };
-        let _ = guard.child.kill();
-        return Err(io::Error::other(format!(
-            "oc-rsync --daemon did not accept connections on port {port} within {DAEMON_BOOT_TIMEOUT:?}",
-        )));
-    }
-    Ok(DaemonGuard { child })
+fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    // Acquire a race-free free port and start the daemon on it. Because the
+    // default daemon binds with SO_REUSEADDR only (upstream socket.c:447), a
+    // port collision is a clean EADDRINUSE daemon exit - never a silent
+    // SO_REUSEPORT co-bind - so the helper simply retries with a fresh port.
+    // See `test_support::daemon_port`.
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
 }
 
 /// Deterministic authoritative payload bytes.
@@ -315,7 +285,6 @@ struct DaemonScratch {
     config: PathBuf,
     log: PathBuf,
     pid: PathBuf,
-    port: u16,
 }
 
 impl DaemonScratch {
@@ -325,14 +294,12 @@ impl DaemonScratch {
         let config = root.join("rsyncd.conf");
         let log = root.join("rsyncd.log");
         let pid = root.join("rsyncd.pid");
-        let port = allocate_test_port()?;
         Some(Self {
             _tmp: tmp,
             root,
             config,
             log,
             pid,
-            port,
         })
     }
 }
@@ -366,7 +333,7 @@ fn reverse_daemon_delta_reconstructs_via_copy_tokens() {
     )
     .expect("write daemon config");
 
-    let _daemon = match spawn_oc_daemon(&oc_bin, &scratch.config, scratch.port) {
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &scratch.config) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("skipping: could not start oc-rsync --daemon: {e}");
@@ -374,7 +341,7 @@ fn reverse_daemon_delta_reconstructs_via_copy_tokens() {
         }
     };
 
-    let src_url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{}/data/", scratch.port));
+    let src_url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{port}/data/"));
     let mut dest_arg = dest_dir.clone().into_os_string();
     dest_arg.push("/");
 

--- a/crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs
+++ b/crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs
@@ -50,18 +50,11 @@
 use std::env;
 use std::fs;
 use std::io::{self, Write};
-use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
 
 use tempfile::{TempDir, tempdir};
 use test_support::{UpstreamVersion, require_upstream_rsync, upstream_compat_enabled};
-
-/// Daemon startup deadline. Mirrors the sibling
-/// `uts_nextest_daemon_gzip_zz.rs` so retry budgets stay aligned.
-const DAEMON_BOOT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Total payload size. Picked to clear the ~615 KB cutoff observed in
 /// the UTS-9 capture so the goodbye-flush invariant is exercised on the
@@ -98,30 +91,6 @@ fn locate_oc_rsync() -> Option<PathBuf> {
     None
 }
 
-/// Allocate a free TCP port by binding to ephemeral port 0.
-fn allocate_test_port() -> Option<u16> {
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
-    let port = listener.local_addr().ok()?.port();
-    drop(listener);
-    Some(port)
-}
-
-/// Poll until the daemon accepts a TCP connection on `port`, or the
-/// deadline elapses.
-fn wait_for_daemon(port: u16) -> bool {
-    let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-    let deadline = Instant::now() + DAEMON_BOOT_TIMEOUT;
-    let mut backoff = Duration::from_millis(20);
-    while Instant::now() < deadline {
-        if TcpStream::connect_timeout(&target, Duration::from_millis(200)).is_ok() {
-            return true;
-        }
-        thread::sleep(backoff);
-        backoff = (backoff * 2).min(Duration::from_millis(200));
-    }
-    false
-}
-
 /// RAII guard that kills the oc-rsync daemon on drop so a panicking
 /// assertion does not leave a dangling listener.
 struct DaemonGuard {
@@ -137,28 +106,25 @@ impl Drop for DaemonGuard {
 
 /// Spawn `oc-rsync --daemon` on `port` against `config_path` and wait
 /// for it to accept connections.
-fn spawn_oc_rsync_daemon(bin: &Path, config_path: &Path, port: u16) -> io::Result<DaemonGuard> {
-    let child = Command::new(bin)
-        .arg("--daemon")
-        .arg("--no-detach")
-        .arg("--port")
-        .arg(port.to_string())
-        .arg("--address=127.0.0.1")
-        .arg("--config")
-        .arg(config_path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if !wait_for_daemon(port) {
-        let mut guard = DaemonGuard { child };
-        let _ = guard.child.kill();
-        return Err(io::Error::other(format!(
-            "oc-rsync --daemon did not accept connections on port {port} within {DAEMON_BOOT_TIMEOUT:?}",
-        )));
-    }
-    Ok(DaemonGuard { child })
+fn spawn_oc_rsync_daemon(bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    // Race-free free port: the default daemon binds SO_REUSEADDR only (upstream
+    // socket.c:447), so a collision is a clean EADDRINUSE exit the helper
+    // retries. See `test_support::daemon_port`.
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--address=127.0.0.1")
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
 }
 
 /// Write an `rsyncd.conf` exposing a single read-write module rooted at
@@ -236,9 +202,7 @@ impl Fixture {
         let pid_path = workdir.path().join("rsyncd.pid");
         write_daemon_config(&config_path, &log_path, &pid_path, &module_root)?;
 
-        let port = allocate_test_port()
-            .ok_or_else(|| io::Error::other("could not allocate ephemeral port"))?;
-        let daemon = spawn_oc_rsync_daemon(oc_rsync_bin, &config_path, port)?;
+        let (daemon, port) = spawn_oc_rsync_daemon(oc_rsync_bin, &config_path)?;
 
         Ok(Self {
             _workdir: workdir,

--- a/crates/transfer/tests/uts_15_e_daemon_pull_write_batch.rs
+++ b/crates/transfer/tests/uts_15_e_daemon_pull_write_batch.rs
@@ -59,8 +59,8 @@
 //! - The workspace `oc-rsync` binary cannot be located (e.g., when this
 //!   file is built outside a `cargo nextest` invocation).
 //! - A loopback TCP port cannot be allocated.
-//! - The daemon fails to start accepting connections within
-//!   [`DAEMON_BOOT_TIMEOUT`].
+//! - The daemon fails to start accepting connections within the daemon boot
+//!   timeout.
 //!
 //! Hard failures (non-zero exit, missing destination files, empty batch
 //! file, failed replay) are real regressions.
@@ -81,20 +81,10 @@
 use std::env;
 use std::fs;
 use std::io;
-use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
 
 use tempfile::{TempDir, tempdir};
-
-/// Maximum time the daemon has to start accepting connections.
-///
-/// 10 seconds matches `uts_nextest_daemon_delete_stats.rs` and
-/// `v61d_2_daemon_push_increcurse_perf_regression.rs`. A healthy daemon
-/// binds well inside this budget; anything slower is a real failure.
-const DAEMON_BOOT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Locate the workspace `oc-rsync` binary the test runner built.
 ///
@@ -127,29 +117,6 @@ fn locate_oc_rsync() -> Option<PathBuf> {
         }
     }
     None
-}
-
-/// Allocate a free TCP port by binding to ephemeral port 0.
-fn allocate_test_port() -> Option<u16> {
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
-    let port = listener.local_addr().ok()?.port();
-    drop(listener);
-    Some(port)
-}
-
-/// Wait until the daemon accepts a TCP connection on `port`.
-fn wait_for_daemon(port: u16) -> bool {
-    let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-    let deadline = Instant::now() + DAEMON_BOOT_TIMEOUT;
-    let mut backoff = Duration::from_millis(20);
-    while Instant::now() < deadline {
-        if std::net::TcpStream::connect_timeout(&target, Duration::from_millis(200)).is_ok() {
-            return true;
-        }
-        thread::sleep(backoff);
-        backoff = (backoff * 2).min(Duration::from_millis(200));
-    }
-    false
 }
 
 /// Write an `rsyncd.conf` exposing one read-only module rooted at
@@ -197,27 +164,26 @@ impl Drop for DaemonGuard {
 
 /// Spawn `oc-rsync --daemon` on `port` against `config_path` and wait
 /// until it accepts connections.
-fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path, port: u16) -> io::Result<DaemonGuard> {
-    let child = Command::new(oc_bin)
-        .arg("--daemon")
-        .arg("--no-detach")
-        .arg("--port")
-        .arg(port.to_string())
-        .arg("--config")
-        .arg(config_path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if !wait_for_daemon(port) {
-        let mut guard = DaemonGuard { child };
-        let _ = guard.child.kill();
-        return Err(io::Error::other(format!(
-            "oc-rsync --daemon did not accept connections on port {port} within {DAEMON_BOOT_TIMEOUT:?}",
-        )));
-    }
-    Ok(DaemonGuard { child })
+fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    // Acquire a race-free free port and start the daemon on it. Because the
+    // default daemon binds with SO_REUSEADDR only (upstream socket.c:447), a
+    // port collision is a clean EADDRINUSE daemon exit - never a silent
+    // SO_REUSEPORT co-bind - so the helper simply retries with a fresh port.
+    // See `test_support::daemon_port`.
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
 }
 
 /// Build the daemon-side source tree: two top-level regular files, a
@@ -317,7 +283,6 @@ struct DaemonScratch {
     config: PathBuf,
     log: PathBuf,
     pid: PathBuf,
-    port: u16,
 }
 
 impl DaemonScratch {
@@ -327,14 +292,12 @@ impl DaemonScratch {
         let config = root.join("rsyncd.conf");
         let log = root.join("rsyncd.log");
         let pid = root.join("rsyncd.pid");
-        let port = allocate_test_port()?;
         Some(Self {
             _tmp: tmp,
             root,
             config,
             log,
             pid,
-            port,
         })
     }
 }
@@ -381,7 +344,7 @@ fn daemon_pull_write_batch_records_and_replays() {
     )
     .expect("write daemon config");
 
-    let _daemon = match spawn_oc_daemon(&oc_bin, &scratch.config, scratch.port) {
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &scratch.config) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("skipping: could not start oc-rsync --daemon: {e}");
@@ -389,7 +352,7 @@ fn daemon_pull_write_batch_records_and_replays() {
         }
     };
 
-    let src_url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{}/pullmod/", scratch.port));
+    let src_url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{port}/pullmod/"));
     let mut dest_arg = dest_dir.clone().into_os_string();
     dest_arg.push("/");
     let write_batch_arg = {

--- a/crates/transfer/tests/uts_nextest_daemon_delete_stats.rs
+++ b/crates/transfer/tests/uts_nextest_daemon_delete_stats.rs
@@ -88,23 +88,10 @@
 use std::env;
 use std::fs;
 use std::io;
-use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
 
 use tempfile::{TempDir, tempdir};
-
-/// Maximum time the daemon has to start accepting connections.
-///
-/// 10 seconds matches `v61d_2_daemon_push_increcurse_perf_regression.rs`,
-/// the closest sibling that spawns an `oc-rsync --daemon` process. A
-/// daemon that does not bind in this window is treated as a hard
-/// failure rather than a flake, because the readiness probe polls
-/// every 20-200ms so a healthy daemon always responds well inside the
-/// budget.
-const DAEMON_BOOT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Locate the workspace `oc-rsync` binary the test runner built.
 ///
@@ -138,39 +125,6 @@ fn locate_oc_rsync() -> Option<PathBuf> {
         }
     }
     None
-}
-
-/// Allocate a free TCP port by binding to ephemeral port 0.
-///
-/// The kernel does not immediately recycle ephemeral ports, so the
-/// residual race between drop and daemon bind is small enough that the
-/// test does not need nextest-level retries. Mirrors the helper in
-/// `v61d_2_daemon_push_increcurse_perf_regression.rs` and
-/// `crates/core/tests/common/mod.rs::allocate_test_port`.
-fn allocate_test_port() -> Option<u16> {
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
-    let port = listener.local_addr().ok()?.port();
-    drop(listener);
-    Some(port)
-}
-
-/// Wait until the daemon accepts a TCP connection on `port`.
-///
-/// Polls with a short backoff up to [`DAEMON_BOOT_TIMEOUT`]. Returns
-/// `true` once a connection succeeds, `false` if the timeout elapses
-/// without ever getting through.
-fn wait_for_daemon(port: u16) -> bool {
-    let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-    let deadline = Instant::now() + DAEMON_BOOT_TIMEOUT;
-    let mut backoff = Duration::from_millis(20);
-    while Instant::now() < deadline {
-        if std::net::TcpStream::connect_timeout(&target, Duration::from_millis(200)).is_ok() {
-            return true;
-        }
-        thread::sleep(backoff);
-        backoff = (backoff * 2).min(Duration::from_millis(200));
-    }
-    false
 }
 
 /// Write an `rsyncd.conf` exposing a single read-write module.
@@ -224,27 +178,26 @@ impl Drop for DaemonGuard {
 
 /// Spawn `oc-rsync --daemon` on `port` against `config_path` and wait
 /// until it accepts connections.
-fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path, port: u16) -> io::Result<DaemonGuard> {
-    let child = Command::new(oc_bin)
-        .arg("--daemon")
-        .arg("--no-detach")
-        .arg("--port")
-        .arg(port.to_string())
-        .arg("--config")
-        .arg(config_path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if !wait_for_daemon(port) {
-        let mut guard = DaemonGuard { child };
-        let _ = guard.child.kill();
-        return Err(io::Error::other(format!(
-            "oc-rsync --daemon did not accept connections on port {port} within {DAEMON_BOOT_TIMEOUT:?}",
-        )));
-    }
-    Ok(DaemonGuard { child })
+fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    // Acquire a race-free free port and start the daemon on it. Because the
+    // default daemon binds with SO_REUSEADDR only (upstream socket.c:447), a
+    // port collision is a clean EADDRINUSE daemon exit - never a silent
+    // SO_REUSEPORT co-bind - so the helper simply retries with a fresh port.
+    // See `test_support::daemon_port`.
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
 }
 
 /// Build the standard two-file source set + the extras the
@@ -344,7 +297,6 @@ struct DaemonScratch {
     config: PathBuf,
     log: PathBuf,
     pid: PathBuf,
-    port: u16,
 }
 
 impl DaemonScratch {
@@ -354,14 +306,12 @@ impl DaemonScratch {
         let config = root.join("rsyncd.conf");
         let log = root.join("rsyncd.log");
         let pid = root.join("rsyncd.pid");
-        let port = allocate_test_port()?;
         Some(Self {
             _tmp: tmp,
             root,
             config,
             log,
             pid,
-            port,
         })
     }
 }
@@ -403,7 +353,7 @@ fn daemon_push_emits_ndx_del_stats_and_reports_count() {
     )
     .expect("write daemon config");
 
-    let _daemon = match spawn_oc_daemon(&oc_bin, &scratch.config, scratch.port) {
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &scratch.config) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("skipping: could not start oc-rsync --daemon: {e}");
@@ -413,7 +363,7 @@ fn daemon_push_emits_ndx_del_stats_and_reports_count() {
 
     let mut source_arg = source_dir.clone().into_os_string();
     source_arg.push("/");
-    let dst_url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{}/pushmod/", scratch.port));
+    let dst_url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{port}/pushmod/"));
 
     let args: &[&std::ffi::OsStr] = &[
         std::ffi::OsStr::new("--delete"),
@@ -477,7 +427,7 @@ fn daemon_pull_emits_ndx_del_stats_and_reports_count() {
     )
     .expect("write daemon config");
 
-    let _daemon = match spawn_oc_daemon(&oc_bin, &scratch.config, scratch.port) {
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &scratch.config) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("skipping: could not start oc-rsync --daemon: {e}");
@@ -485,7 +435,7 @@ fn daemon_pull_emits_ndx_del_stats_and_reports_count() {
         }
     };
 
-    let src_url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{}/pullmod/", scratch.port));
+    let src_url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{port}/pullmod/"));
     let mut dest_arg = dest_dir.clone().into_os_string();
     dest_arg.push("/");
 

--- a/crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs
+++ b/crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs
@@ -75,7 +75,6 @@
 use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
-use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::thread;
@@ -92,9 +91,6 @@ use tempfile::{TempDir, tempdir};
 /// deterministic PRNG stream. Total source size is ~1 MB.
 const COMPRESSIBLE_BYTES: usize = 512 * 1024;
 const INCOMPRESSIBLE_BYTES: usize = 512 * 1024;
-
-/// Daemon startup deadline. Mirrors `v61d_2_daemon_push_increcurse_perf_regression.rs`.
-const DAEMON_BOOT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Locate the workspace `oc-rsync` binary the test runner built.
 ///
@@ -129,34 +125,6 @@ fn locate_oc_rsync() -> Option<PathBuf> {
     None
 }
 
-/// Allocate a free TCP port by binding to ephemeral port 0.
-///
-/// Drops the listener immediately so the daemon can rebind. The residual
-/// window between drop and daemon bind is acceptable for tests since each
-/// test gets a fresh ephemeral port from the OS.
-fn allocate_test_port() -> Option<u16> {
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
-    let port = listener.local_addr().ok()?.port();
-    drop(listener);
-    Some(port)
-}
-
-/// Poll until the daemon accepts a TCP connection on `port`, or the
-/// deadline elapses.
-fn wait_for_daemon(port: u16) -> bool {
-    let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-    let deadline = Instant::now() + DAEMON_BOOT_TIMEOUT;
-    let mut backoff = Duration::from_millis(20);
-    while Instant::now() < deadline {
-        if TcpStream::connect_timeout(&target, Duration::from_millis(200)).is_ok() {
-            return true;
-        }
-        thread::sleep(backoff);
-        backoff = (backoff * 2).min(Duration::from_millis(200));
-    }
-    false
-}
-
 /// Guard that kills the oc-rsync daemon on drop. Mirrors the pattern from
 /// `v61d_2_daemon_push_increcurse_perf_regression.rs` and keeps a
 /// panicking test from leaving a dangling TCP listener behind.
@@ -171,31 +139,41 @@ impl Drop for DaemonGuard {
     }
 }
 
-/// Spawn `oc-rsync --daemon` on `port` against `config_path` and wait for
-/// it to accept connections. Returns `Err` if the daemon never becomes
-/// ready within `DAEMON_BOOT_TIMEOUT`.
-fn spawn_oc_rsync_daemon(bin: &Path, config_path: &Path, port: u16) -> io::Result<DaemonGuard> {
-    let child = Command::new(bin)
-        .arg("--daemon")
-        .arg("--no-detach")
-        .arg("--port")
-        .arg(port.to_string())
-        .arg("--address=127.0.0.1")
-        .arg("--config")
-        .arg(config_path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if !wait_for_daemon(port) {
-        let mut guard = DaemonGuard { child };
-        let _ = guard.child.kill();
-        return Err(io::Error::other(format!(
-            "oc-rsync --daemon did not accept connections on port {port} within {DAEMON_BOOT_TIMEOUT:?}",
-        )));
+impl DaemonGuard {
+    /// PID of the running daemon process, for OS-level ownership checks.
+    fn pid(&self) -> u32 {
+        self.child.id()
     }
-    Ok(DaemonGuard { child })
+}
+
+/// Spawn `oc-rsync --daemon` on a race-free free port against `config_path` and
+/// return the guard plus the port it owns, or `Err` if no free port could be
+/// acquired.
+///
+/// Delegates port acquisition to [`test_support::spawn_daemon_on_free_port`]:
+/// it allocates a candidate port, starts the daemon on it, and - because the
+/// default daemon binds with `SO_REUSEADDR` only (upstream `socket.c:447`) - a
+/// port collision is a clean `EADDRINUSE` daemon exit rather than a silent
+/// `SO_REUSEPORT` co-bind, so a losing attempt simply retries with a fresh
+/// port. No two daemons ever share a port, eliminating the cross-talk that
+/// produced the intermittent `Connection reset by peer` / missing-file
+/// failures under concurrent load.
+fn spawn_oc_rsync_daemon(bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--address=127.0.0.1")
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
 }
 
 /// Write an `rsyncd.conf` exposing a single read-write module rooted at
@@ -311,9 +289,7 @@ impl GzipDaemonFixture {
         let pid_path = workdir.path().join("rsyncd.pid");
         write_daemon_config(&config_path, &log_path, &pid_path, &module_root)?;
 
-        let port = allocate_test_port()
-            .ok_or_else(|| io::Error::other("could not allocate ephemeral port"))?;
-        let daemon = spawn_oc_rsync_daemon(&bin, &config_path, port)?;
+        let (daemon, port) = spawn_oc_rsync_daemon(&bin, &config_path)?;
 
         Ok(Some(Self {
             _workdir: workdir,
@@ -334,6 +310,11 @@ impl GzipDaemonFixture {
     /// upstream invocations.
     fn url(&self) -> String {
         format!("rsync://127.0.0.1:{}/gzipmod", self.port)
+    }
+
+    /// PID of the fixture's daemon process, for OS-level port-ownership checks.
+    fn daemon_pid(&self) -> u32 {
+        self._daemon.pid()
     }
 }
 
@@ -613,4 +594,178 @@ fn daemon_gzip_z_vs_zz_negotiation() {
              {raw_len}); compression did not engage on the daemon pull\nstdout:\n{stdout}"
         );
     }
+}
+
+/// UTS-NEXTEST-EDGE.e.4 - the default daemon must refuse a second bind on an
+/// in-use port (upstream fidelity), which is what makes concurrent daemon tests
+/// safe from cross-talk.
+///
+/// # Why this matters
+///
+/// The intermittent `-zz` reset / missing-file flake under concurrent load was
+/// a shared-port cross-talk: two test daemons ended up on one port and the
+/// kernel load-balanced client connections between them, so a client reached
+/// the wrong daemon (upload landing in a different module root, or a reset when
+/// the sibling was torn down). That was only possible because oc set
+/// `SO_REUSEPORT` on the *default* listener, letting a second daemon co-bind.
+/// Upstream (`socket.c:447`) sets only `SO_REUSEADDR`, so a second daemon on an
+/// in-use port is refused with `EADDRINUSE`.
+///
+/// This test pins that behaviour deterministically: with the fixture daemon
+/// owning a port, a second `oc-rsync --daemon` told to bind the same port must
+/// exit (fail to bind) rather than co-bind, and the original daemon must still
+/// exclusively own the port.
+#[test]
+fn second_daemon_on_the_same_port_is_refused_no_co_bind() {
+    let Some(bin) = locate_oc_rsync() else {
+        eprintln!("skip: oc-rsync binary not located");
+        return;
+    };
+    let fixture = match GzipDaemonFixture::start() {
+        Ok(Some(f)) => f,
+        Ok(None) => {
+            eprintln!("skip: oc-rsync binary not located");
+            return;
+        }
+        Err(e) => {
+            eprintln!("skip: could not start oc-rsync daemon: {e}");
+            return;
+        }
+    };
+
+    // A second daemon (distinct module root) told to bind the SAME port the
+    // fixture already owns.
+    let workdir = tempdir().expect("second-daemon workdir");
+    let module_root = workdir.path().join("module");
+    fs::create_dir_all(&module_root).expect("second module root");
+    let config_path = workdir.path().join("rsyncd.conf");
+    write_daemon_config(
+        &config_path,
+        &workdir.path().join("rsyncd.log"),
+        &workdir.path().join("rsyncd.pid"),
+        &module_root,
+    )
+    .expect("second daemon config");
+
+    let mut second = Command::new(&bin)
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg("--port")
+        .arg(fixture.port.to_string())
+        .arg("--address=127.0.0.1")
+        .arg("--config")
+        .arg(&config_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn second daemon");
+
+    // Upstream single-listener semantics: the second bind is refused, so the
+    // process must exit (non-zero) within the window rather than co-bind and
+    // keep running.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let status = loop {
+        if let Some(status) = second.try_wait().expect("try_wait second daemon") {
+            break Some(status);
+        }
+        if Instant::now() >= deadline {
+            break None;
+        }
+        thread::sleep(Duration::from_millis(25));
+    };
+    if status.is_none() {
+        let _ = second.kill();
+        let _ = second.wait();
+    }
+    let status =
+        status.expect("a second oc-rsync --daemon on an in-use port must exit (EADDRINUSE)");
+    assert!(
+        !status.success(),
+        "the second daemon must fail to bind the in-use port (upstream SO_REUSEADDR-only, no co-bind)"
+    );
+
+    // The original daemon still exclusively owns the port.
+    assert_eq!(
+        test_support::daemon_listen_port(fixture.daemon_pid()),
+        Some(fixture.port),
+        "the fixture daemon must still own the port after the refused second bind"
+    );
+}
+
+/// UTS-NEXTEST-EDGE.e.5 - concurrent fixtures must never share a port and must
+/// never cross-talk.
+///
+/// Reproduces the triggering condition of the original flake - several daemon
+/// fixtures alive at once - and asserts the fix's guarantee end to end: every
+/// fixture gets a distinct port and every upload lands in its own module root
+/// with the correct bytes. With the old reuse-window allocation (plus the
+/// removed default `SO_REUSEPORT`) this would intermittently cross-talk (a file
+/// landing in the wrong root, or a reset); with the free-port retry helper it
+/// is deterministic.
+#[test]
+fn concurrent_fixtures_get_distinct_ports_and_do_not_cross_talk() {
+    if locate_oc_rsync().is_none() {
+        eprintln!("skip: oc-rsync binary not located");
+        return;
+    }
+
+    const FIXTURES: usize = 6;
+    let handles: Vec<_> = (0..FIXTURES)
+        .map(|idx| {
+            thread::spawn(move || {
+                let fixture = GzipDaemonFixture::start()
+                    .expect("start fixture")
+                    .expect("oc-rsync binary present");
+
+                // A payload unique to this fixture so a cross-talk landing is
+                // detectable by content, not just presence.
+                let src_dir = tempdir().expect("src tempdir");
+                let src_path = src_dir.path().join("payload.bin");
+                let marker = format!("fixture-{idx}-unique-payload ");
+                let mut content = marker.repeat(4096).into_bytes();
+                content.extend_from_slice(&build_incompressible(64 * 1024));
+                fs::write(&src_path, &content).expect("write source");
+
+                let url = format!("{}/", fixture.url());
+                let url_os = std::ffi::OsString::from(url);
+                let src_arg = src_path.as_os_str().to_owned();
+                let output = run_client(&[
+                    "-a".as_ref(),
+                    "-zz".as_ref(),
+                    "--timeout=30".as_ref(),
+                    src_arg.as_ref(),
+                    url_os.as_ref(),
+                ])
+                .expect("spawn client");
+                assert!(
+                    output.status.success(),
+                    "fixture {idx} upload must exit 0; status={:?}\nstderr:\n{}",
+                    output.status.code(),
+                    String::from_utf8_lossy(&output.stderr),
+                );
+
+                let landed = fixture.module_root().join("payload.bin");
+                let received = read_all(&landed);
+                assert_eq!(
+                    received, content,
+                    "fixture {idx} destination must hold its own payload (no cross-talk)"
+                );
+                fixture.port
+            })
+        })
+        .collect();
+
+    let mut ports: Vec<u16> = handles
+        .into_iter()
+        .map(|h| h.join().expect("join"))
+        .collect();
+    ports.sort_unstable();
+    let unique = ports.len();
+    ports.dedup();
+    assert_eq!(
+        ports.len(),
+        unique,
+        "every concurrent fixture must bind a distinct port (no reuse collision)"
+    );
 }

--- a/crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs
+++ b/crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs
@@ -58,10 +58,8 @@
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, Write};
-use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::thread;
 use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
@@ -83,11 +81,6 @@ const FILE_PAYLOAD_BYTES: usize = 1_024;
 /// regression's flist-construction cost grew with both file count and
 /// directory count.
 const FILES_PER_DIR: usize = 64;
-
-/// Receiver-side timeout for both daemon spawns. Upstream rsync exits on
-/// stdin EOF or when the connection drops; this is a defensive cap so a
-/// hung daemon does not stall the test runner indefinitely.
-const DAEMON_BOOT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Maximum slowdown factor over the upstream baseline before the test
 /// fails. The v0.6.1 symptom was 95-201x; 5x catches a regression of
@@ -173,38 +166,6 @@ fn build_fixture(root: &Path) -> io::Result<()> {
     Ok(())
 }
 
-/// Allocate a free TCP port by binding to ephemeral port 0.
-///
-/// Mirrors the pattern in `tests/integration_daemon_server.rs::allocate_test_port`.
-/// The kernel does not immediately recycle ephemeral ports, so the
-/// residual race between drop and daemon bind is small enough that the
-/// test does not need nextest-level retries.
-fn allocate_test_port() -> Option<u16> {
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
-    let port = listener.local_addr().ok()?.port();
-    drop(listener);
-    Some(port)
-}
-
-/// Wait until the daemon accepts a TCP connection on `port`.
-///
-/// Polls with a short backoff up to `DAEMON_BOOT_TIMEOUT`. Returns
-/// `true` once a connection succeeds, `false` if the timeout elapses
-/// without ever getting through.
-fn wait_for_daemon(port: u16) -> bool {
-    let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-    let deadline = Instant::now() + DAEMON_BOOT_TIMEOUT;
-    let mut backoff = Duration::from_millis(20);
-    while Instant::now() < deadline {
-        if std::net::TcpStream::connect_timeout(&target, Duration::from_millis(200)).is_ok() {
-            return true;
-        }
-        thread::sleep(backoff);
-        backoff = (backoff * 2).min(Duration::from_millis(200));
-    }
-    false
-}
-
 /// Write an `rsyncd.conf` exposing a single read-write module rooted at
 /// `module_root`. `use chroot = false` and `read only = false` are both
 /// required so the unprivileged test process can drive a push transfer
@@ -256,32 +217,25 @@ impl Drop for DaemonGuard {
 
 /// Spawn `rsync --daemon` on `port` against `config_path`. Waits for the
 /// port to accept connections before returning.
-fn spawn_upstream_daemon(
-    rsync_bin: &Path,
-    config_path: &Path,
-    port: u16,
-) -> io::Result<DaemonGuard> {
-    let child = Command::new(rsync_bin)
-        .arg("--daemon")
-        .arg("--no-detach")
-        .arg("--port")
-        .arg(port.to_string())
-        .arg("--address=127.0.0.1")
-        .arg("--config")
-        .arg(config_path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if !wait_for_daemon(port) {
-        let mut guard = DaemonGuard { child };
-        let _ = guard.child.kill();
-        return Err(io::Error::other(format!(
-            "upstream rsync --daemon did not accept connections on port {port} within {DAEMON_BOOT_TIMEOUT:?}",
-        )));
-    }
-    Ok(DaemonGuard { child })
+fn spawn_upstream_daemon(rsync_bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    // Race-free free port: upstream rsync binds SO_REUSEADDR only (socket.c:447),
+    // so a collision is a clean EADDRINUSE exit the helper retries. See
+    // `test_support::daemon_port`.
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(rsync_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--address=127.0.0.1")
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
 }
 
 /// Drive one push transfer against `rsync://127.0.0.1:<port>/push/` and
@@ -344,14 +298,6 @@ fn daemon_push_under_inc_recurse_stays_within_5x_of_upstream_sender_baseline() {
         }
     };
 
-    let port = match allocate_test_port() {
-        Some(p) => p,
-        None => {
-            eprintln!("skip: could not allocate test port");
-            return;
-        }
-    };
-
     let tmp = TempDir::new().expect("tempdir");
     let src = tmp.path().join("src");
     let module_root = tmp.path().join("module");
@@ -364,7 +310,7 @@ fn daemon_push_under_inc_recurse_stays_within_5x_of_upstream_sender_baseline() {
     write_daemon_config(&config_path, &log_path, &pid_path, &module_root)
         .expect("write daemon config");
 
-    let _daemon = match spawn_upstream_daemon(&up_bin, &config_path, port) {
+    let (_daemon, port) = match spawn_upstream_daemon(&up_bin, &config_path) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("skip: could not start upstream rsync daemon: {e}");


### PR DESCRIPTION
## Summary

`daemon_gzip_zz_upload_byte_identical` (and other daemon integration tests) failed intermittently under concurrent nextest load with `Connection reset by peer (os error 104)` / `Broken pipe` (exit 23) or a missing destination file.

The trigger was a **test-harness port-reuse race**, but the reason a collision was *destructive* (rather than a clean failure) is that the daemon diverged from upstream in two places. This PR fixes both divergences (production, wire-transparent) and reworks the daemon tests onto one shared, race-free helper.

## Upstream divergences fixed

**1. `SO_REUSEPORT` on the default listener.** oc set `SO_REUSEPORT` on every daemon listener, including the default single-listener daemon. Upstream sets only `SO_REUSEADDR` (`socket.c:447`). With `SO_REUSEPORT`, two daemon processes could **co-bind the same port** and the kernel load-balanced client connections across them, so a client reached the wrong daemon (upload landing in a different module root -> empty destination) or reset when a sibling daemon was torn down. Verified on Linux: two daemons on one port both bound, and 20 uploads split evenly across the two module roots.

Fix: set `SO_REUSEPORT` only for the opt-in multi-acceptor daemon (`acceptor threads > 1`), whose replica sockets genuinely need to share the bind address. The default daemon binds `SO_REUSEADDR` only, so a second daemon on an in-use port is refused with `EADDRINUSE` — a clean failure, never silent cross-talk.

**2. `--port 0`.** oc bound a kernel-assigned ephemeral port; upstream coerces a resolved port of 0 to the well-known rsync port 873 (`clientserver.c:1573-1574`). The config `port = 0` path already coerced, but the CLI `--port 0` path did not. Fix: treat `--port 0` as unspecified (so it does not override a config `port`) and coerce a still-zero resolved port to 873, once, in `RuntimeOptions` parsing so both the sync and async daemon bind paths share it.

Both changes are wire/protocol-transparent — no on-the-wire byte changes; only listener sockopts and port resolution.

## Empirical validation (Linux)

- Two default daemons on the same port: the second is refused with `Address already in use (os error 98)`; only one listener exists on the port.
- `--port 0`: the daemon attempts to bind `127.0.0.1:873` (Permission denied as non-root), proving 873 rather than an ephemeral port.
- `acceptor threads = 2`: two co-bound listener sockets on one port — the opt-in `SO_REUSEPORT` extension still works.

## Test rework (DRY, race-free)

All six daemon integration tests are converted onto one shared helper, `test_support::daemon_port::spawn_daemon_on_free_port`: it allocates a real candidate port, starts the daemon on it, and — because a collision is now a clean `EADDRINUSE` daemon exit — simply retries with a fresh port, confirming the spawned pid itself owns the port (matched via `/proc` on Linux / `lsof` on macOS, so a different winning daemon is never mistaken for ours).

Converted: `uts_nextest_daemon_gzip_zz`, `uts_nextest_daemon_delete_stats`, `nxt_4_reverse_daemon_delta`, `uts_15_e_daemon_pull_write_batch`, `upstream_compat_daemon_gzip_goodbye`, `v61d_2_daemon_push_increcurse_perf_regression`.

## Deterministic regression tests

- `runtime_options`: `--port 0` resolves to 873 (`parse_port_zero_coerces_to_well_known_rsync_port`).
- `server_runtime`: the default single listener refuses a second bind on the same port (`default_single_listener_refuses_a_second_bind_on_the_same_port`); `acceptor threads = 2` co-binds a fixed port via `SO_REUSEPORT` (`multi_acceptor_replicas_co_bind_the_same_fixed_port`).
- integration: a second `oc-rsync --daemon` on an in-use port is refused, no co-bind (`second_daemon_on_the_same_port_is_refused_no_co_bind`); concurrent fixtures get distinct ports with no cross-talk (`concurrent_fixtures_get_distinct_ports_and_do_not_cross_talk`).

## Seals

- All daemon unit fidelity tests pass; all six integration tests pass.
- Upload flake seal: **0 failures / 2400** runs at 8-way concurrency under CPU load (previously ~2/2400), and **0 / 250** full-binary runs at 10-way concurrency.
- `cargo fmt --all --check` and `cargo clippy -p daemon -p test-support -p transfer --all-targets --all-features --no-deps -D warnings` are clean.
