### PR TITLE
fix(metadata): apply upstream dir-permission fixup to transfer-root chmod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3962,6 +3962,7 @@ dependencies = [
  "protocol",
  "rand 0.10.2",
  "rayon",
+ "rustix",
  "signature 0.6.3",
  "socket2",
  "tempfile",

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -6,6 +6,8 @@
 // upstream: receiver.c - directory metadata finalization after recv_files()
 
 use std::fs;
+#[cfg(unix)]
+use std::io;
 use std::path::{Path, PathBuf};
 
 #[cfg(any(
@@ -85,6 +87,84 @@ pub(super) fn apply_final_directory_metadata(
     let _ = source;
 
     Ok(())
+}
+
+/// Reproduces upstream's transfer-root self-lock when a `--chmod` strips the
+/// root directory's owner-execute bit.
+///
+/// upstream: generator.c:1503-1520 - the generator chmods a directory to its
+/// tweaked mode and then re-adds owner-`rwx` (`do_chmod_at(fname, mode | S_IRWXU)`)
+/// so it can write the directory's contents. The transfer root is addressed as
+/// `dst/.`, so that re-add chmod must resolve `.` *inside* `dst`; a tweak that
+/// removed owner-execute makes it fail with `EACCES` (generator.c:1514 "failed
+/// to modify permissions on %s") and the generator can no longer stat or create
+/// the root's contents. Nothing under it transfers and rsync exits 23.
+/// Non-root directories are addressed by name and never take this path, so the
+/// caller scopes the check to the transfer root (`relative == None`).
+///
+/// Returns `Ok(Some(error))` when the root self-locks - after leaving it at the
+/// strict tweaked mode and recording an I/O error (exit 23) - so the caller
+/// skips the root's contents and its metadata finalization. Returns `Ok(None)`
+/// when no `--chmod` is active, the tweak keeps owner execute, or the root has
+/// not been materialised yet.
+#[cfg(unix)]
+pub(super) fn enforce_transfer_root_self_lock(
+    context: &mut CopyContext,
+    destination: &Path,
+    metadata: &fs::Metadata,
+) -> Result<Option<LocalCopyError>, LocalCopyError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let existing = fs::symlink_metadata(destination).ok();
+    let Some(existing_meta) = existing.as_ref().filter(|meta| meta.is_dir()) else {
+        return Ok(None);
+    };
+
+    let options = context.metadata_options();
+    let Some((tweaked, self_locks)) = ::metadata::transfer_root_chmod_self_lock(
+        destination,
+        metadata,
+        &options,
+        Some(existing_meta),
+    )
+    .map_err(map_metadata_error)?
+    else {
+        return Ok(None);
+    };
+    if !self_locks {
+        return Ok(None);
+    }
+
+    // Apply the strict tweaked mode to the root, self-locking it exactly as
+    // upstream's set_file_attrs() does before it fails to re-add owner-rwx.
+    fs::set_permissions(destination, fs::Permissions::from_mode(tweaked))
+        .map_err(|error| LocalCopyError::io("modify permissions on", destination, error))?;
+
+    // upstream: generator.c:1514 do_chmod_at("dst/.", mode | S_IRWXU) - fails
+    // with EACCES because `.` can no longer be resolved inside the now
+    // owner-non-executable root. Trigger the identical OS error to report it.
+    let dot = destination.join(".");
+    let io_error = match fs::set_permissions(&dot, fs::Permissions::from_mode(tweaked | 0o700)) {
+        Err(error) => error,
+        Ok(()) => io::Error::new(io::ErrorKind::PermissionDenied, "Permission denied"),
+    };
+    context.record_io_error();
+    Ok(Some(LocalCopyError::io(
+        "modify permissions on",
+        dot,
+        io_error,
+    )))
+}
+
+/// Non-Unix stub: permission-driven self-lock does not apply without POSIX
+/// directory-execute traversal semantics.
+#[cfg(not(unix))]
+pub(super) fn enforce_transfer_root_self_lock(
+    _context: &mut CopyContext,
+    _destination: &Path,
+    _metadata: &fs::Metadata,
+) -> Result<Option<LocalCopyError>, LocalCopyError> {
+    Ok(None)
 }
 
 /// Records directory completion statistics and pending records.

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -31,7 +31,9 @@ use deletion::{
     apply_during_transfer_deletions, handle_empty_directory_pruning, handle_post_transfer_deletions,
 };
 use destination::{check_destination_state, record_skipped_missing_destination};
-use dir_metadata::{apply_final_directory_metadata, record_directory_completion};
+use dir_metadata::{
+    apply_final_directory_metadata, enforce_transfer_root_self_lock, record_directory_completion,
+};
 use entry::process_planned_entry;
 
 use super::planner::{
@@ -466,6 +468,20 @@ fn copy_directory_recursive_inner(
 
     if !directory_ready.get() && !prune_enabled {
         ensure_directory(context)?;
+    }
+
+    // upstream: generator.c:1503-1520 - the generator applies a directory's
+    // tweaked mode and re-adds owner-rwx BEFORE writing its contents. For the
+    // transfer root ("dst/.") a --chmod that strips owner-execute makes that
+    // re-add chmod fail (EACCES) and the root can no longer be entered, so none
+    // of its contents transfer and rsync exits 23. Reproduce that self-lock
+    // here, before planning or touching the root's contents; other directories
+    // are addressed by name and never take this path.
+    if relative.is_none()
+        && !context.mode().is_dry_run()
+        && let Some(error) = enforce_transfer_root_self_lock(context, destination, metadata)?
+    {
+        return Err(error);
     }
 
     let mut plan = plan_directory_entries(context, &entries, relative, root_device)?;

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -110,6 +110,33 @@ pub fn apply_dest_mode_pre_transfer(
     )
 }
 
+/// Reports whether a transfer-root directory self-locks under the configured
+/// `--chmod` modifiers, returning the tweaked permission bits alongside the
+/// verdict, or `None` when no `--chmod` is configured.
+///
+/// `am_root` is sampled through the same libc `geteuid` the chmod apply path
+/// uses, so the self-lock decision and the on-disk fixup agree under
+/// `fakeroot`. See [`crate::transfer_root_self_locks`] for the mechanism.
+// upstream: rsync.c:set_file_attrs() new_mode + generator.c:1512 fixup.
+#[cfg(unix)]
+pub fn transfer_root_chmod_self_lock(
+    destination: &Path,
+    metadata: &fs::Metadata,
+    options: &MetadataOptions,
+    existing: Option<&fs::Metadata>,
+) -> Result<Option<(u32, bool)>, MetadataError> {
+    let Some(tweaked) =
+        permissions::chmod_directory_target_mode(destination, metadata, options, existing)?
+    else {
+        return Ok(None);
+    };
+    let running_as_root = nix::unistd::geteuid().is_root();
+    Ok(Some((
+        tweaked,
+        crate::transfer_root_self_locks(tweaked, running_as_root),
+    )))
+}
+
 /// Applies file metadata using an open file descriptor for efficiency.
 ///
 /// When an fd is available (e.g. after writing a file), this avoids redundant

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -14,6 +14,24 @@ use std::io;
 #[cfg(unix)]
 use std::os::fd::BorrowedFd;
 
+/// Reproduces upstream's during-transfer owner-`rwx` fixup for directories.
+///
+/// Directories written by a non-root transfer are raised to owner-`rwx` while
+/// their contents land, then restored to the strict tweaked mode only when the
+/// owner would otherwise lack write. Files pass through unchanged. Reuses the
+/// shared [`crate::directory_transfer_mode`] so the local-copy, receiver, and
+/// daemon chmod paths all compute one identical result (DRY). `am_root` is
+/// sampled through the same libc `geteuid` the ownership gate uses so
+/// `fakeroot`'s faked identity is honoured.
+// upstream: generator.c:1512-1520 fixup + generator.c:2107-2145 touch_up_dirs.
+#[cfg(unix)]
+fn tweak_directory_transfer_mode(mode: u32, file_type: fs::FileType) -> u32 {
+    if !file_type.is_dir() {
+        return mode;
+    }
+    (mode & !0o7777) | crate::directory_transfer_mode(mode, nix::unistd::geteuid().is_root())
+}
+
 /// Applies an fd-based `fchmod` through the `nix` crate (libc `fchmod(2)`).
 ///
 /// Like ownership's chown helper, the mode change must go through the libc
@@ -436,6 +454,7 @@ pub(super) fn apply_permissions_with_chmod(
         if let Some(modifiers) = options.chmod() {
             let mut mode = base_mode_for_permissions(destination, metadata, options, existing)?;
             mode = modifiers.apply(mode, metadata.file_type());
+            mode = tweak_directory_transfer_mode(mode, metadata.file_type());
 
             if let Some(existing) = existing {
                 if permissions_match(mode, existing) {
@@ -512,6 +531,7 @@ pub(super) fn apply_permissions_with_chmod_fd(
     if let Some(modifiers) = options.chmod() {
         let mut mode = base_mode_for_permissions(destination, metadata, options, existing)?;
         mode = modifiers.apply(mode, metadata.file_type());
+        mode = tweak_directory_transfer_mode(mode, metadata.file_type());
 
         if let Some(existing) = existing {
             if permissions_match(mode, existing) {
@@ -649,6 +669,28 @@ fn intended_fake_super_mode(
         None => base,
     };
     Ok(mode)
+}
+
+/// Computes the `--chmod`-tweaked permission bits (`0o7777`) a directory would
+/// receive, BEFORE upstream's during-transfer owner-`rwx` fixup.
+///
+/// Returns `None` when no `--chmod` modifiers are configured. The local-copy
+/// executor uses this to detect a transfer-root directory whose tweaked mode
+/// strips owner execute and therefore self-locks (see
+/// [`crate::transfer_root_self_locks`]).
+// upstream: rsync.c:set_file_attrs() new_mode, pre generator.c:1512 fixup.
+#[cfg(unix)]
+pub(super) fn chmod_directory_target_mode(
+    destination: &Path,
+    metadata: &fs::Metadata,
+    options: &MetadataOptions,
+    existing: Option<&fs::Metadata>,
+) -> Result<Option<u32>, MetadataError> {
+    let Some(modifiers) = options.chmod() else {
+        return Ok(None);
+    };
+    let base = base_mode_for_permissions(destination, metadata, options, existing)?;
+    Ok(Some(modifiers.apply(base, metadata.file_type()) & 0o7777))
 }
 
 /// Determines the base mode before chmod modifiers are applied.

--- a/crates/metadata/src/chmod/mod.rs
+++ b/crates/metadata/src/chmod/mod.rs
@@ -82,5 +82,62 @@ impl ChmodModifiers {
     }
 }
 
+/// Owner `rwx` bits (`S_IRWXU`).
+const S_IRWXU: u32 = 0o700;
+/// Owner execute bit (`S_IXUSR`).
+const S_IXUSR: u32 = 0o100;
+/// Owner write bit (`S_IWUSR`).
+const S_IWUSR: u32 = 0o200;
+
+/// Final on-disk permission bits a directory carries after upstream rsync's
+/// during-transfer permission dance, given the `--chmod`-tweaked `mode`.
+///
+/// upstream: generator.c:1512-1520 raises every directory to owner-`rwx` while
+/// its contents are written (`do_chmod_at(fname, file->mode | S_IRWXU)`), then
+/// generator.c:2107-2145 `touch_up_dirs()` restores the tweaked mode ONLY when
+/// the owner would otherwise lack write
+/// (`fix_dir_perms = !am_root && !(file->mode & S_IWUSR)`). The net effect a
+/// synchronous local copy must reproduce: a tweak that leaves an owner-writable
+/// but not fully owner-`rwx` directory keeps the transient owner bits (e.g.
+/// `--chmod=ug=rw` 0o665 -> 0o765), while an owner-non-writable one is left at
+/// the strict tweaked mode (e.g. `--chmod=u=r` 0o455 -> 0o455).
+///
+/// `running_as_root` mirrors `am_root`: a privileged transfer skips the dance
+/// entirely because root traverses any directory regardless of its mode.
+#[must_use]
+pub fn directory_transfer_mode(mode: u32, running_as_root: bool) -> u32 {
+    let perm = mode & 0o7777;
+    // upstream gates the fixup on `!am_root && dir_tweaking`; root needs no
+    // temporary owner bits to write into a directory.
+    if running_as_root {
+        return perm;
+    }
+    // The fixup only fires when the owner is not already `rwx`.
+    if perm & S_IRWXU == S_IRWXU {
+        return perm;
+    }
+    // touch_up_dirs restores the strict tweaked mode when the owner lacks
+    // write; otherwise the transient owner-`rwx` bits persist on disk.
+    if perm & S_IWUSR == 0 {
+        perm
+    } else {
+        perm | S_IRWXU
+    }
+}
+
+/// Whether a *transfer-root* directory self-locks under the tweaked `mode`.
+///
+/// The transfer root is addressed as `dst/.`, so upstream's during-transfer
+/// fixup `do_chmod_at("dst/.", mode | S_IRWXU)` must resolve `.` *inside* `dst`,
+/// which needs owner-execute on `dst`. When the tweaked mode strips owner
+/// execute the chmod fails with `EACCES` (generator.c:1514 "failed to modify
+/// permissions on %s") and the generator can no longer stat or create the
+/// directory's contents, so nothing under it transfers and rsync exits 23.
+/// Non-root directories are addressed by name and never take this path.
+#[must_use]
+pub fn transfer_root_self_locks(mode: u32, running_as_root: bool) -> bool {
+    !running_as_root && (mode & S_IXUSR == 0)
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/metadata/src/chmod/tests.rs
+++ b/crates/metadata/src/chmod/tests.rs
@@ -1,4 +1,53 @@
 use super::ChmodModifiers;
+use super::{directory_transfer_mode, transfer_root_self_locks};
+
+// The following encode upstream's generator dir-permission-during-transfer +
+// write-gated restore (generator.c:1512-1520 / 2107-2145). They pin the exact
+// final mode a directory carries after the dance, verified against upstream
+// rsync 3.4.4: `ug=rw` on a dir yields 0o765 (owner-write kept the transient
+// owner-rwx), `u=rx` yields 0o555 (owner lacked write, strict mode restored),
+// and an owner-non-executable transfer root self-locks.
+
+#[test]
+fn directory_transfer_mode_keeps_owner_rwx_when_owner_writable() {
+    // ug=rw -> 0o665: owner writable but not executable; upstream leaves 0o765.
+    assert_eq!(directory_transfer_mode(0o665, false), 0o765);
+    // Setgid bit survives: 2665 -> 2765.
+    assert_eq!(directory_transfer_mode(0o2665, false), 0o2765);
+}
+
+#[test]
+fn directory_transfer_mode_restores_strict_when_owner_not_writable() {
+    // u=rx -> 0o555: owner not writable; touch_up_dirs restores 0o555.
+    assert_eq!(directory_transfer_mode(0o555, false), 0o555);
+    // u=r -> 0o455: neither write nor execute; strict mode kept.
+    assert_eq!(directory_transfer_mode(0o455, false), 0o455);
+}
+
+#[test]
+fn directory_transfer_mode_noop_when_owner_already_rwx() {
+    assert_eq!(directory_transfer_mode(0o775, false), 0o775);
+    assert_eq!(directory_transfer_mode(0o755, false), 0o755);
+}
+
+#[test]
+fn directory_transfer_mode_root_skips_dance() {
+    // am_root: no fixup, no restore - the strict tweaked mode passes through.
+    assert_eq!(directory_transfer_mode(0o665, true), 0o665);
+    assert_eq!(directory_transfer_mode(0o555, true), 0o555);
+}
+
+#[test]
+fn transfer_root_self_locks_only_without_owner_execute() {
+    assert!(transfer_root_self_locks(0o665, false));
+    assert!(transfer_root_self_locks(0o424, false));
+    assert!(transfer_root_self_locks(0o455, false));
+    // Owner keeps execute -> the "." fixup resolves, no self-lock.
+    assert!(!transfer_root_self_locks(0o555, false));
+    assert!(!transfer_root_self_locks(0o775, false));
+    // Root traverses regardless of mode.
+    assert!(!transfer_root_self_locks(0o665, true));
+}
 
 #[test]
 fn parse_symbolic_and_numeric_specifications() {

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -234,10 +234,9 @@ pub use acl_windows::{
 pub use acl_noop::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
 
 #[cfg(unix)]
-pub use apply::transfer_root_chmod_self_lock;
 pub use apply::{
     apply_dest_mode_pre_transfer, apply_file_metadata_with_fd,
-    apply_file_metadata_with_fd_if_changed,
+    apply_file_metadata_with_fd_if_changed, transfer_root_chmod_self_lock,
 };
 pub use apply::{
     apply_directory_metadata, apply_directory_metadata_with_options, apply_file_metadata,

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -234,7 +234,6 @@ pub use acl_windows::{
 pub use acl_noop::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
 
 #[cfg(unix)]
-#[cfg(unix)]
 pub use apply::transfer_root_chmod_self_lock;
 pub use apply::{
     apply_dest_mode_pre_transfer, apply_file_metadata_with_fd,

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -234,6 +234,8 @@ pub use acl_windows::{
 pub use acl_noop::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
 
 #[cfg(unix)]
+#[cfg(unix)]
+pub use apply::transfer_root_chmod_self_lock;
 pub use apply::{
     apply_dest_mode_pre_transfer, apply_file_metadata_with_fd,
     apply_file_metadata_with_fd_if_changed,
@@ -247,7 +249,7 @@ pub use apply::{
     apply_symlink_metadata_from_entry, apply_symlink_metadata_with_options, metadata_unchanged,
 };
 
-pub use chmod::{ChmodError, ChmodModifiers};
+pub use chmod::{ChmodError, ChmodModifiers, directory_transfer_mode, transfer_root_self_locks};
 
 pub use error::MetadataError;
 

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -176,6 +176,7 @@ tracing = ["dep:tracing"]
 tempfile = { workspace = true }
 filetime = { workspace = true }
 test-support = { path = "../test-support" }
+rustix = { workspace = true, features = ["process"] }
 platform = { path = "../platform" }
 criterion = { workspace = true }
 proptest = { workspace = true }

--- a/crates/transfer/tests/uts_chmod_option.rs
+++ b/crates/transfer/tests/uts_chmod_option.rs
@@ -63,6 +63,13 @@ fn slash(p: &Path) -> std::ffi::OsString {
     s
 }
 
+/// The self-lock and write-gated-restore legs only manifest for a non-root
+/// transfer: root traverses any directory regardless of its mode, so upstream's
+/// `!am_root` fixup gate is skipped and no self-lock occurs.
+fn running_as_root() -> bool {
+    rustix::process::geteuid().is_root()
+}
+
 /// Leg 1: `--chmod ug-s,a+rX,D+w`.
 ///
 /// Source modes: `name1` = 04700 (setuid, rwx------), `name2` = 0644,
@@ -165,4 +172,121 @@ fn chmod_file_only_clears_world_execute() {
         0o755,
         "foo: directory left untouched by the F-only chmod (0755)",
     );
+}
+
+/// Deliverable #1: a `--chmod` that strips the transfer-root directory's own
+/// owner-execute bit self-locks it.
+///
+/// upstream: generator.c:1503-1520 - the generator chmods the transfer root
+/// ("dst/.") to its tweaked mode and then tries to re-add owner-`rwx` so it can
+/// write the root's contents. Resolving `.` inside the now owner-non-executable
+/// root fails with `EACCES` ("failed to modify permissions on dst/."), the
+/// generator can no longer stat or create the contents, so nothing transfers
+/// and rsync exits 23 with the root left at the strict tweaked mode.
+///
+/// Verified against upstream rsync 3.4.4: `--chmod=ug=rw` leaves `dst` at 0o665,
+/// `--chmod=a=r,g=w` at 0o424, `--chmod=u=r` at 0o455 - each exit 23 with an
+/// empty destination. This encodes WHY the exit code matters: the spec makes the
+/// destination root unreadable to its own owner, a partial-transfer failure a
+/// script must observe, not silently succeed.
+#[test]
+fn chmod_transfer_root_self_locks_without_owner_execute() {
+    if !require_binary("oc-rsync") || running_as_root() {
+        return;
+    }
+    for (spec, expected_mode) in [("ug=rw", 0o665u32), ("a=r,g=w", 0o424), ("u=r", 0o455)] {
+        let root = tempfile::tempdir().expect("tempdir");
+        let from = root.path().join("from");
+        let to = root.path().join("to");
+        fs::create_dir_all(&from).expect("mkdir from");
+        fs::write(from.join("f"), b"hello\n").expect("write f");
+        fs::set_permissions(&from, fs::Permissions::from_mode(0o755)).expect("chmod from");
+        fs::set_permissions(from.join("f"), fs::Permissions::from_mode(0o644)).expect("chmod f");
+
+        let out = OcRsyncCliRunner::new()
+            .args(["-a", "--chmod"])
+            .arg(spec)
+            .arg(slash(&from))
+            .arg(slash(&to))
+            .run()
+            .expect("run oc-rsync");
+
+        out.assert_exit(23);
+        assert!(
+            out.stderr_contains("modify permissions"),
+            "spec {spec}: expected a self-lock permission error, got:\n{}",
+            out.stderr_str(),
+        );
+        assert_eq!(
+            mode_bits(&to),
+            expected_mode,
+            "spec {spec}: transfer root must be left at the strict tweaked mode",
+        );
+
+        // Restore owner-execute so TempDir can traverse and clean up.
+        fs::set_permissions(&to, fs::Permissions::from_mode(0o755)).expect("restore to");
+        let contents: Vec<_> = fs::read_dir(&to)
+            .expect("read to")
+            .map(|e| e.expect("dirent").file_name())
+            .collect();
+        assert!(
+            contents.is_empty(),
+            "spec {spec}: a self-locked root transfers no contents, found {contents:?}",
+        );
+    }
+}
+
+/// Deliverable #2: a subdirectory made owner-non-executable but owner-writable
+/// by `--chmod` regains owner-execute; owner-non-writable ones keep the strict
+/// mode.
+///
+/// upstream: generator.c:1512-1520 raises a directory to owner-`rwx` while its
+/// contents are written, and generator.c:2107-2145 `touch_up_dirs()` restores
+/// the tweaked mode ONLY when the owner would otherwise lack write. A subdir is
+/// addressed by name (not "./"), so the re-add chmod always succeeds; the net
+/// on-disk mode therefore keeps the transient owner bits when the owner is
+/// writable.
+///
+/// Verified against upstream rsync 3.4.4 for `src -> dst/src`: `--chmod=ug=rw`
+/// leaves `dst/src` at 0o765 (owner-write kept 0o700), while `--chmod=u=r`
+/// leaves it at 0o455 (owner not writable, strict mode restored).
+#[test]
+fn chmod_subdir_owner_writable_regains_execute() {
+    if !require_binary("oc-rsync") || running_as_root() {
+        return;
+    }
+    for (spec, expected_mode) in [("ug=rw", 0o765u32), ("u=r", 0o455)] {
+        let root = tempfile::tempdir().expect("tempdir");
+        let src = root.path().join("src");
+        let dst = root.path().join("dst");
+        fs::create_dir_all(&src).expect("mkdir src");
+        fs::write(src.join("f"), b"hello\n").expect("write f");
+        fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).expect("chmod src");
+        fs::set_permissions(src.join("f"), fs::Permissions::from_mode(0o644)).expect("chmod f");
+        fs::create_dir(&dst).expect("mkdir dst");
+
+        // No trailing slash on src: the transfer root is dst/src, a named
+        // subdirectory that never self-locks.
+        let out = OcRsyncCliRunner::new()
+            .args(["-a", "--chmod"])
+            .arg(spec)
+            .arg(&src)
+            .arg(slash(&dst))
+            .run()
+            .expect("run oc-rsync");
+
+        out.assert_success();
+        assert_eq!(
+            mode_bits(&dst.join("src")),
+            expected_mode,
+            "spec {spec}: dst/src final mode must match upstream's during-transfer dance",
+        );
+        // Restore owner-execute before probing contents: a 0o455 result is not
+        // traversable by its owner, so `exists()` would spuriously fail.
+        fs::set_permissions(dst.join("src"), fs::Permissions::from_mode(0o755)).expect("restore");
+        assert!(
+            dst.join("src/f").exists(),
+            "spec {spec}: subdir contents must transfer (the dir was owner-rwx while writing)",
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Reproduces upstream rsync 3.4.4's during-transfer directory-permission handling for `--chmod` in the local-copy executor, so a spec that strips a directory's own permission bits matches upstream byte-for-byte (exit code, resulting mode, and resulting contents).

Upstream applies a directory's `--chmod`-tweaked mode *before* writing its contents (`set_file_attrs`), temporarily raises it to owner-`rwx` while files land, and restores the strict mode afterward only when the owner would otherwise lack write. The local-copy executor previously applied the tweaked mode once at finalization (after contents), which produced two observable divergences from upstream:

1. **Transfer-root self-lock.** A trailing-slash transfer (`src/ dst/`) whose `--chmod` strips the destination root's own owner-execute bit leaves the root addressed as `dst/.`. Upstream cannot re-add owner-`rwx` through that path (`EACCES`), can no longer enter the root, transfers nothing, and exits 23. oc-rsync silently transferred the contents and exited 0.
2. **Directory mode after the dance.** A directory left owner-writable but not fully owner-`rwx` keeps the transient owner bits upstream adds during transfer (e.g. `--chmod=ug=rw` on a subdirectory: `0665` → `0765`), while an owner-non-writable one is restored to the strict tweaked mode (`--chmod=u=r` → `0455`). oc-rsync applied the strict mode unconditionally.

## Changes

- New shared helper `metadata::directory_transfer_mode` encodes upstream's write-gated net directory mode, and `metadata::transfer_root_self_locks` its self-lock predicate. Both are pure and unit-tested.
- The shared metadata chmod-apply site (`apply_permissions_with_chmod` / `_fd`) now routes directory modes through the helper, so the local-copy, receiver, and daemon chmod paths reuse one implementation. `am_root` is sampled through the same libc `geteuid` the ownership gate uses, so `fakeroot` is honoured.
- The local-copy executor detects a self-locking transfer root before touching its contents, leaves the root at the strict tweaked mode, and reports the permission failure (exit 23), matching upstream.

The receiver path (SSH/daemon) already implements this mechanism via `dir_needs_writable_transfer_mode` + `touch_up_dirs`, so it was already correct; this change brings the local-copy path in line.

Upstream references: `generator.c:1503-1520` (tweaked mode + during-transfer owner-`rwx` fixup) and `generator.c:2107-2145` (`touch_up_dirs` write-gated restore, `fix_dir_perms = !am_root && !(mode & S_IWUSR)`).

## Verification

Differential seal against upstream rsync 3.4.4 with fresh destinations per spec — byte-identical exit code, resulting mode, and contents across all cases:

| spec | case | upstream | oc-rsync |
|------|------|----------|----------|
| `ug=rw` | root (`src/ dst/`) | exit 23, mode 0665, empty | exit 23, mode 0665, empty |
| `a=r,g=w` | root | exit 23, mode 0424, empty | exit 23, mode 0424, empty |
| `u=r` | root | exit 23, mode 0455, empty | exit 23, mode 0455, empty |
| `F644` | root | exit 0, mode 0755 | exit 0, mode 0755 |
| `D755` | root | exit 0, mode 0755 | exit 0, mode 0755 |
| `g+w` | root | exit 0, mode 0775 | exit 0, mode 0775 |
| `o-x` | root | exit 0, mode 0754 | exit 0, mode 0754 |
| `u=rx` | root | exit 0, mode 0555 | exit 0, mode 0555 |
| `ug=rw` | subdir (`src dst/`) | exit 0, mode 0765 | exit 0, mode 0765 |
| `u=r` | subdir | exit 0, mode 0455 | exit 0, mode 0455 |
| `u=rx` | subdir | exit 0, mode 0555 | exit 0, mode 0555 |

New tests encode the intent (`crates/transfer/tests/uts_chmod_option.rs`): the transfer-root self-lock (exit 23, strict mode, empty destination) and the subdir write-gated mode (`ug=rw` → 0765, `u=r` → 0455), plus pure-function unit tests in `crates/metadata/src/chmod/tests.rs`.

Regression suites (zero regressions): metadata 535/535, engine dir/chmod/permission/executability 487/487, transfer chmod/touch_up/permission 61/61. `cargo fmt --check` and `cargo clippy -p metadata -p engine -p transfer --all-features --all-targets -- -D warnings` clean.

## Scope note

The local-copy executor is synchronous (contents written before dir metadata is finalized), whereas upstream's generator/receiver pipeline applies nested-directory perms before their contents are written. One out-of-scope consequence: a `--chmod` that makes a *nested* subdirectory owner-non-writable (e.g. `--chmod=Du=r` on a two-level tree) makes upstream's receiver fail an `mkstemp` inside that subdirectory (exit 23, contents skipped), while the local-copy path writes the contents first and exits 0. The resulting directory mode still matches upstream in that case; only the exit code differs. Reproducing it would require reordering the local-copy executor to apply every directory's mode before its contents, which risks perturbing normal transfers, so it is intentionally left unchanged.
