### PR TITLE
fix(daemon): accept all 12 upstream socket options

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
@@ -16,8 +16,37 @@ enum SocketOption {
     /// `IP_TOS=<value>` - set the IP Type of Service field.
     ///
     /// upstream: socket.c - `IP_TOS` sets the TOS byte in the IP header.
-    /// Common values: `0x10` (IPTOS_LOWDELAY), `0x08` (IPTOS_THROUGHPUT).
+    /// The `IPTOS_LOWDELAY` / `IPTOS_THROUGHPUT` symbolic option names are
+    /// upstream `OPT_ON` presets that resolve to this variant with values
+    /// `0x10` and `0x08` respectively.
     IpTos(u32),
+    /// `SO_BROADCAST` - allow sending broadcast datagrams.
+    ///
+    /// upstream: socket.c:socket_options[] `SO_BROADCAST` (OPT_BOOL).
+    SoBroadcast(bool),
+    /// `SO_SNDLOWAT=<n>` - send low-water mark.
+    ///
+    /// upstream: socket.c:socket_options[] `SO_SNDLOWAT` (OPT_INT). Guarded by
+    /// `#ifdef SO_SNDLOWAT`; unavailable on Linux, so gated to the platforms
+    /// whose `libc` defines it, mirroring the client-side applier.
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+    SoSndLoWat(i32),
+    /// `SO_RCVLOWAT=<n>` - receive low-water mark.
+    ///
+    /// upstream: socket.c:socket_options[] `SO_RCVLOWAT` (OPT_INT).
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+    SoRcvLoWat(i32),
+    /// `SO_SNDTIMEO=<n>` - send timeout, written as a plain `int` exactly as
+    /// upstream does (`setsockopt(..., &value, sizeof(int))`).
+    ///
+    /// upstream: socket.c:socket_options[] `SO_SNDTIMEO` (OPT_INT).
+    #[cfg(unix)]
+    SoSndTimeo(i32),
+    /// `SO_RCVTIMEO=<n>` - receive timeout, written as a plain `int`.
+    ///
+    /// upstream: socket.c:socket_options[] `SO_RCVTIMEO` (OPT_INT).
+    #[cfg(unix)]
+    SoRcvTimeo(i32),
 }
 
 /// Parses a comma-separated socket options string into typed option values.
@@ -67,6 +96,43 @@ fn parse_socket_options(options: &str) -> Result<Vec<SocketOption>, String> {
                 let tos = parse_tos_option_value(value)?;
                 result.push(SocketOption::IpTos(tos));
             }
+            // upstream: socket.c:socket_options[] - `IPTOS_LOWDELAY` and
+            // `IPTOS_THROUGHPUT` are OPT_ON presets that must not take a value
+            // and resolve to fixed IP_TOS bytes (0x10 / 0x08).
+            #[cfg(not(target_family = "windows"))]
+            "IPTOS_LOWDELAY" => {
+                reject_value_for_preset(value, "IPTOS_LOWDELAY")?;
+                result.push(SocketOption::IpTos(0x10));
+            }
+            #[cfg(not(target_family = "windows"))]
+            "IPTOS_THROUGHPUT" => {
+                reject_value_for_preset(value, "IPTOS_THROUGHPUT")?;
+                result.push(SocketOption::IpTos(0x08));
+            }
+            "SO_BROADCAST" => {
+                let enabled = parse_bool_option_value(value, "SO_BROADCAST")?;
+                result.push(SocketOption::SoBroadcast(enabled));
+            }
+            #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+            "SO_SNDLOWAT" => {
+                let n = parse_int_option_value(value, "SO_SNDLOWAT")?;
+                result.push(SocketOption::SoSndLoWat(n));
+            }
+            #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+            "SO_RCVLOWAT" => {
+                let n = parse_int_option_value(value, "SO_RCVLOWAT")?;
+                result.push(SocketOption::SoRcvLoWat(n));
+            }
+            #[cfg(unix)]
+            "SO_SNDTIMEO" => {
+                let n = parse_int_option_value(value, "SO_SNDTIMEO")?;
+                result.push(SocketOption::SoSndTimeo(n));
+            }
+            #[cfg(unix)]
+            "SO_RCVTIMEO" => {
+                let n = parse_int_option_value(value, "SO_RCVTIMEO")?;
+                result.push(SocketOption::SoRcvTimeo(n));
+            }
             _ => {
                 return Err(format!("unknown socket option '{name}'"));
             }
@@ -98,6 +164,33 @@ fn parse_size_option_value(value: Option<&str>, name: &str) -> Result<usize, Str
         Some(s) => s
             .parse::<usize>()
             .map_err(|_| format!("invalid numeric value '{s}' for {name}")),
+    }
+}
+
+/// Parses a required signed integer value for an `OPT_INT` socket option.
+///
+/// upstream: socket.c:set_socket_options() applies `atoi()` and passes the
+/// result as a plain `int`. `SO_SNDLOWAT`/`SO_RCVLOWAT` and the
+/// `SO_SNDTIMEO`/`SO_RCVTIMEO` quirk are written this way.
+#[cfg(unix)]
+fn parse_int_option_value(value: Option<&str>, name: &str) -> Result<i32, String> {
+    match value {
+        None => Err(format!("{name} requires a numeric value (e.g., {name}=1)")),
+        Some(s) => s
+            .parse::<i32>()
+            .map_err(|_| format!("invalid numeric value '{s}' for {name}")),
+    }
+}
+
+/// Rejects an `=value` suffix on an `OPT_ON` preset option.
+///
+/// upstream: socket.c:set_socket_options() prints "syntax error -- %s does not
+/// take a value" for `OPT_ON` entries such as `IPTOS_LOWDELAY`.
+#[cfg(not(target_family = "windows"))]
+fn reject_value_for_preset(value: Option<&str>, name: &str) -> Result<(), String> {
+    match value {
+        None => Ok(()),
+        Some(_) => Err(format!("{name} does not take a value")),
     }
 }
 
@@ -153,12 +246,48 @@ fn apply_socket_options_impl(
         match opt {
             SocketOption::TcpNoDelay(enabled) => sock.set_tcp_nodelay(*enabled)?,
             SocketOption::SoKeepAlive(enabled) => sock.set_keepalive(*enabled)?,
+            SocketOption::SoBroadcast(enabled) => sock.set_broadcast(*enabled)?,
             SocketOption::SoSndBuf(size) => sock.set_send_buffer_size(*size)?,
             SocketOption::SoRcvBuf(size) => sock.set_recv_buffer_size(*size)?,
             SocketOption::IpTos(tos) => apply_ip_tos(&sock, *tos)?,
+            #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+            SocketOption::SoSndLoWat(n) => {
+                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_SNDLOWAT, *n)?;
+            }
+            #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+            SocketOption::SoRcvLoWat(n) => {
+                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_RCVLOWAT, *n)?;
+            }
+            #[cfg(unix)]
+            SocketOption::SoSndTimeo(n) => {
+                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_SNDTIMEO, *n)?;
+            }
+            #[cfg(unix)]
+            SocketOption::SoRcvTimeo(n) => {
+                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_RCVTIMEO, *n)?;
+            }
         }
     }
     Ok(())
+}
+
+/// Applies an integer socket option that has no typed `socket2` setter.
+///
+/// `socket2::SockRef` unifies the listener and stream apply paths, so the raw
+/// `setsockopt(2)` call is routed through `fast_io` (the only crate permitted
+/// to hold the unsafe FFI) using the socket's borrowed file descriptor.
+///
+/// upstream: socket.c:set_socket_options() writes these OPT_INT entries via
+/// `setsockopt(fd, level, option, &value, sizeof(int))`.
+#[cfg(unix)]
+fn apply_raw_int(
+    sock: &socket2::SockRef<'_>,
+    level: libc::c_int,
+    option: libc::c_int,
+    value: i32,
+) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    fast_io::set_socket_int_option_raw(sock.as_raw_fd(), level, option, value)
 }
 
 /// Sets IP_TOS / IPV6_TCLASS depending on the socket's address family.

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -694,6 +694,94 @@ fn apply_stream_socket_options_empty_is_noop() {
     apply_socket_options_to_stream(&stream, &[]).expect("empty options should succeed");
 }
 
+/// A daemon `socket options =` config written for upstream rsync must parse
+/// every entry in upstream's `socket_options[]` table (socket.c) - silently
+/// dropping an option would make a config that is portable under upstream
+/// behave differently here. This locks in the five entries previously missing
+/// from the daemon table (`SO_BROADCAST`, `SO_SNDLOWAT`, `SO_RCVLOWAT`,
+/// `SO_SNDTIMEO`, `SO_RCVTIMEO`) plus the `IPTOS_*` `OPT_ON` symbolic presets,
+/// each resolving to the correct level/optname/value semantics.
+#[test]
+fn parse_socket_options_accepts_all_upstream_options() {
+    use SocketOption::{SoBroadcast, SoKeepAlive, SoRcvBuf, SoSndBuf, TcpNoDelay};
+
+    // Available across every daemon target platform.
+    assert_eq!(
+        parse_socket_options("SO_KEEPALIVE").expect("parse"),
+        vec![SoKeepAlive(true)]
+    );
+    assert_eq!(
+        parse_socket_options("TCP_NODELAY").expect("parse"),
+        vec![TcpNoDelay(true)]
+    );
+    assert_eq!(
+        parse_socket_options("SO_BROADCAST").expect("parse"),
+        vec![SoBroadcast(true)]
+    );
+    assert_eq!(
+        parse_socket_options("SO_SNDBUF=65536, SO_RCVBUF=32768").expect("parse"),
+        vec![SoSndBuf(65536), SoRcvBuf(32768)]
+    );
+
+    // upstream: IPTOS_LOWDELAY / IPTOS_THROUGHPUT are OPT_ON presets that map
+    // to a fixed IP_TOS byte and must reject an `=value` suffix.
+    #[cfg(not(target_family = "windows"))]
+    {
+        assert_eq!(
+            parse_socket_options("IPTOS_LOWDELAY").expect("parse"),
+            vec![SocketOption::IpTos(0x10)]
+        );
+        assert_eq!(
+            parse_socket_options("IPTOS_THROUGHPUT").expect("parse"),
+            vec![SocketOption::IpTos(0x08)]
+        );
+        let err =
+            parse_socket_options("IPTOS_LOWDELAY=5").expect_err("preset must reject a value");
+        assert!(err.contains("does not take a value"), "{err}");
+    }
+
+    // SO_SNDTIMEO / SO_RCVTIMEO are written as a plain int on all Unix targets.
+    #[cfg(unix)]
+    {
+        assert_eq!(
+            parse_socket_options("SO_SNDTIMEO=30").expect("parse"),
+            vec![SocketOption::SoSndTimeo(30)]
+        );
+        assert_eq!(
+            parse_socket_options("SO_RCVTIMEO=30").expect("parse"),
+            vec![SocketOption::SoRcvTimeo(30)]
+        );
+    }
+
+    // SO_SNDLOWAT / SO_RCVLOWAT exist only where libc defines them (not Linux).
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+    {
+        assert_eq!(
+            parse_socket_options("SO_SNDLOWAT=1").expect("parse"),
+            vec![SocketOption::SoSndLoWat(1)]
+        );
+        assert_eq!(
+            parse_socket_options("SO_RCVLOWAT=1").expect("parse"),
+            vec![SocketOption::SoRcvLoWat(1)]
+        );
+    }
+}
+
+/// `SO_BROADCAST` is the one newly-added option that applies cleanly to a real
+/// socket on every daemon platform, so it exercises the apply path end to end
+/// (the LOWAT/TIMEO entries mirror upstream's best-effort `setsockopt` and can
+/// be rejected by the kernel at runtime, so they are covered at the parse
+/// layer only).
+#[test]
+fn apply_socket_options_broadcast_sets_flag() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    apply_socket_options_to_listener(&listener, &[SocketOption::SoBroadcast(true)])
+        .expect("apply succeeds");
+
+    let sock = socket2::SockRef::from(&listener);
+    assert!(sock.broadcast().expect("query broadcast"));
+}
+
 /// Builds an [`AcceptLoopState`] suitable for unit tests that exercise
 /// admission control without spinning up a full daemon.
 ///

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -767,11 +767,13 @@ fn parse_socket_options_accepts_all_upstream_options() {
     }
 }
 
-/// `SO_BROADCAST` is the one newly-added option that applies cleanly to a real
-/// socket on every daemon platform, so it exercises the apply path end to end
-/// (the LOWAT/TIMEO entries mirror upstream's best-effort `setsockopt` and can
-/// be rejected by the kernel at runtime, so they are covered at the parse
-/// layer only).
+/// `SO_BROADCAST` exercises the apply path end to end on Unix, where the kernel
+/// accepts the option on any socket type at `setsockopt` time. Windows validates
+/// that `SO_BROADCAST` is only meaningful for datagram sockets and rejects it on
+/// a stream socket with `WSAENOPROTOOPT`, so on Windows it joins the LOWAT/TIMEO
+/// entries that mirror upstream's best-effort `setsockopt` (rejectable by the
+/// platform at runtime) and are covered at the parse layer only.
+#[cfg(unix)]
 #[test]
 fn apply_socket_options_broadcast_sets_flag() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -368,6 +368,8 @@ pub use secure_dir::secure_open_dir;
 // See WIN-S.LAND.1.a audit (#5552) confirming zero external callers.
 #[cfg(unix)]
 pub use sendfile::send_file_to_fd_with_policy;
+#[cfg(unix)]
+pub use socket_options::set_socket_int_option_raw;
 pub use socket_options::{
     DEFAULT_TCP_FASTOPEN_QLEN, DEFAULT_TCP_NOTSENT_LOWAT, MAX_SOCKET_BUFFER_SIZE,
     connectx_fastopen_raw, connectx_fastopen_supported, enable_tcp_fastopen_connect_raw,

--- a/crates/fast_io/src/socket_options.rs
+++ b/crates/fast_io/src/socket_options.rs
@@ -78,6 +78,27 @@ pub fn set_listener_int_option(
     set_listener_int_option_impl(listener, level, option, value)
 }
 
+/// Sets an integer-valued socket option on a borrowed raw file descriptor.
+///
+/// Same `setsockopt(fd, level, option, &value, sizeof(int))` semantics as
+/// [`set_socket_int_option`], but accepts a `RawFd` so a caller holding a
+/// `socket2::SockRef` (which unifies the listener and stream apply paths) can
+/// set the handful of options that have no typed `socket2` equivalent
+/// (`SO_SNDLOWAT`, `SO_RCVLOWAT`, and the `SO_SNDTIMEO`/`SO_RCVTIMEO` quirk).
+///
+/// # Errors
+///
+/// Returns the OS error reported by `setsockopt(2)` if the call fails.
+#[cfg(unix)]
+pub fn set_socket_int_option_raw(
+    fd: std::os::fd::RawFd,
+    level: i32,
+    option: i32,
+    value: i32,
+) -> io::Result<()> {
+    setsockopt_int_raw(fd, level, option, value)
+}
+
 /// Enables the server-side `TCP_FASTOPEN` option on a raw socket file
 /// descriptor or handle.
 ///


### PR DESCRIPTION
## Summary

The daemon `socket options =` directive only implemented 5 of upstream rsync's
12 `socket_options[]` entries (`socket.c`): `SO_KEEPALIVE`, `TCP_NODELAY`,
`SO_SNDBUF`, `SO_RCVBUF`, and `IP_TOS`. A `rsyncd.conf` written for upstream
that named any other option was rejected or silently unusable, so a config
portable under upstream behaved differently here.

This adds the five missing entries and the two `OPT_ON` symbolic presets so the
daemon accepts and applies every upstream option name:

- `SO_BROADCAST` (OPT_BOOL) - applied via the typed `socket2` setter.
- `SO_SNDLOWAT` / `SO_RCVLOWAT` (OPT_INT) - gated to the platforms whose `libc`
  defines them (upstream guards them with `#ifdef`; unavailable on Linux),
  mirroring the client-side applier's gating.
- `SO_SNDTIMEO` / `SO_RCVTIMEO` (OPT_INT) - written as a plain `int` exactly as
  upstream does.
- `IPTOS_LOWDELAY` / `IPTOS_THROUGHPUT` (OPT_ON) - symbolic presets resolving to
  the fixed IP_TOS bytes `0x10` / `0x08`, rejecting an `=value` suffix as
  upstream's "does not take a value" syntax error.

Options that have no typed `socket2` setter are applied through a new safe
`fast_io::set_socket_int_option_raw` wrapper, keeping the raw `setsockopt`
inside the crate permitted to hold FFI.

## Approach

Add-5 rather than a full client/daemon unify: the daemon table is a
self-contained module whose ~30 existing tests are bound to its `SocketOption`
enum and `socket2` typed setters, and the client applier lives in a different
crate with a different application mechanism. Unifying both onto one shared
table would be a large, cross-crate change touching working code - too invasive
to do surgically. The added entries mirror the existing client applier
(`crates/core/src/client/module_list/socket_options/`), which already
implements all 12, and upstream `socket.c` semantics.

## Testing

- `cargo fmt` clean; `cargo clippy -p daemon -p fast_io --all-targets --no-deps
  -D warnings` clean.
- New unit tests: `parse_socket_options_accepts_all_upstream_options` (parser
  accepts every upstream name with correct level/optname/value, including the
  IPTOS_* presets and their no-value rule) and
  `apply_socket_options_broadcast_sets_flag` (end-to-end apply).
- All 31 daemon `socket_option` tests pass on Linux/aarch64.

Wire-transparent: `setsockopt` only, no protocol change.
