### PR TITLE
fix(daemon): non-lethal seccomp default + allow restart_syscall

### DIFF
--- a/crates/daemon/src/async_listener.rs
+++ b/crates/daemon/src/async_listener.rs
@@ -27,7 +27,7 @@
 //! - A dedicated thread - rather than tokio's reused `spawn_blocking` pool -
 //!   is required because the worker arms a per-thread seccomp filter that must
 //!   die with the connection; a reused thread would leak the filter into the
-//!   next session and SIGSYS-kill its setup syscalls.
+//!   next session and fail its pre-seccomp setup syscalls with EPERM.
 //! - The worker is the caller-supplied sync closure; this module does not
 //!   embed any knowledge of the daemon session state machine.
 //!
@@ -178,11 +178,11 @@ async fn accept_loop(
             // Run the synchronous worker on a dedicated OS thread rather than
             // tokio's shared `spawn_blocking` pool. The worker installs a
             // per-thread seccomp filter (LSM-SECCOMP) that is a one-way latch:
-            // once armed, the thread traps every unlisted syscall for the rest
+            // once armed, the thread denies every unlisted syscall for the rest
             // of its life. tokio's blocking pool reuses threads across tasks,
-            // so a filter armed by one session would SIGSYS-kill the *next*
-            // session's pre-seccomp setup syscalls (capability drop `capget`,
-            // socket `FIONBIO` ioctl) - a flaky whole-process kill. A fresh
+            // so a filter armed by one session would fail the *next* session's
+            // pre-seccomp setup syscalls (capability drop `capget`, socket
+            // `FIONBIO` ioctl) with EPERM - a flaky broken session. A fresh
             // thread per connection keeps the design invariant documented in
             // `engage_seccomp_sandbox`: the filter dies with the disposable
             // worker thread and never leaks into another session.

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -375,9 +375,9 @@ fn process_approved_module(
     // privilege-drop, post-filter-load, pre-client-data. The seccomp
     // helper is a no-op on builds without the `daemon-seccomp` feature so
     // the call is unconditional. Stdio sessions are skipped because the
-    // process IS the worker (no parent to survive KillProcess). Failures
-    // do not abort the connection - Landlock + SEC-1 `*at` remain the
-    // primary defenses.
+    // process IS the worker, so a process-scoped filter would restrict its
+    // post-transfer cleanup. Failures do not abort the connection -
+    // Landlock + SEC-1 `*at` remain the primary defenses.
     engage_seccomp_sandbox(ctx)?;
 
     // #503: arm the background delta-drain thread only for a real transfer. An

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -357,8 +357,9 @@ fn engage_landlock_sandbox(
 ///
 /// Layers above the Landlock LSM defense engaged immediately prior:
 /// Landlock denies path-based syscalls with `EACCES`; seccomp denies
-/// out-of-scope syscalls with `SIGSYS` before the kernel ever consults
-/// the LSM stack.
+/// out-of-scope syscalls with `EPERM` (default action `SECCOMP_RET_ERRNO`)
+/// before the kernel ever consults the LSM stack. A non-lethal default
+/// keeps a rare, benign syscall from killing a legitimate transfer.
 ///
 /// On builds without the `daemon-seccomp` feature the helper is a no-op
 /// that returns `Unavailable`; the wire-in is unconditional so the call
@@ -368,10 +369,10 @@ fn engage_landlock_sandbox(
 ///
 /// **Stdio sessions are skipped.** When the daemon runs as `--server
 /// --daemon` over stdin/stdout (remote-shell daemon mode via `lsh.sh` /
-/// SSH), the process IS the worker - there is no parent accept loop to
-/// survive a `KillProcess`. The seccomp filter would also restrict
-/// post-transfer cleanup, process exit, and any syscalls the Python test
-/// harness or shell wrapper needs after the transfer completes. TCP
+/// SSH), the process IS the worker. A process-scoped filter would
+/// restrict post-transfer cleanup, process exit, and any syscalls the
+/// Python test harness or shell wrapper needs after the transfer
+/// completes (an `EPERM` there would fail cleanup just as surely). TCP
 /// daemon workers are disposable threads inside a long-lived process, so
 /// the filter dies with the thread and does not affect the daemon or any
 /// other connection.
@@ -397,7 +398,7 @@ fn engage_seccomp_sandbox(ctx: &mut ModuleRequestContext<'_>) -> io::Result<()> 
         SeccompOutcome::Installed => {
             if let Some(log) = ctx.log_sink {
                 let text = format!(
-                    "module '{}': seccomp BPF filter engaged (KillProcess on unlisted syscalls)",
+                    "module '{}': seccomp BPF filter engaged (EPERM on unlisted syscalls)",
                     ctx.request,
                 );
                 let message = rsync_info!(text).with_role(Role::Daemon);

--- a/crates/daemon/src/daemon/sections/seccomp.rs
+++ b/crates/daemon/src/daemon/sections/seccomp.rs
@@ -2,10 +2,24 @@
 //
 // Layers a kernel-enforced syscall allowlist above the SEC-1.p Landlock
 // LSM defense. Landlock denies path-based syscalls with EACCES; seccomp
-// denies out-of-scope syscalls with SIGSYS before the kernel ever
-// consults the LSM stack. Default action is `KillProcess` so a regression
-// surfaces as a crash with `si_syscall` populated, never as a silent
-// degradation.
+// denies out-of-scope syscalls before the kernel ever consults the LSM
+// stack.
+//
+// Default action is `Errno(EPERM)`, not `KillProcess`. Upstream rsync
+// ships no seccomp at all, so oc's hardening must never make a legitimate
+// transfer *more* fragile than upstream: a `KillProcess` default turns
+// any allowlist gap into a fatal SIGSYS that - because `KILL_PROCESS`
+// targets the whole thread group - tears down the entire daemon and RSTs
+// every concurrent connection, the exact residual observed under full-CI
+// concurrency (a rare, load-triggered `restart_syscall` from a signal-
+// interrupted blocking call killed the worker mid-transfer). `Errno`
+// preserves the hardening intent - a disallowed syscall still does NOT
+// execute, so an attacker who hijacks the worker still cannot `execve`/
+// `ptrace`/`mount`/etc. - while a benign, unanticipated syscall from a
+// valid transfer degrades to a syscall error surfaced through normal I/O
+// error handling instead of crashing the daemon. This matches the
+// industry-standard container seccomp posture (Docker, Podman, and
+// containerd all default to `SCMP_ACT_ERRNO(EPERM)`).
 //
 // See `docs/design/lsm-seccomp-allowlist.md` for the per-syscall
 // justification. Enabled by default when the `daemon-seccomp` feature
@@ -23,8 +37,8 @@
 /// Outcome of [`apply_worker_seccomp_filter`].
 #[derive(Debug)]
 pub enum SeccompOutcome {
-    /// Filter installed; the calling thread now traps unlisted syscalls
-    /// with `SIGSYS` (default action `KILL_PROCESS`).
+    /// Filter installed; the calling thread now fails unlisted syscalls
+    /// with `EPERM` (default action `SECCOMP_RET_ERRNO`).
     #[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
     Installed,
     /// Build target is not one of the supported architectures, or the
@@ -60,8 +74,9 @@ pub enum SeccompOutcome {
 pub fn apply_worker_seccomp_filter() -> SeccompOutcome {
     // Default ON when the daemon-seccomp feature is compiled in.
     // Operators can opt out with `OC_RSYNC_NO_SECCOMP=1` if a workload
-    // triggers a missing syscall (diagnosed via the SIGSYS crash with
-    // `si_syscall` populated in the kernel log).
+    // trips a missing syscall (which now surfaces as an `EPERM` I/O error
+    // in the transfer, not a crash - see the module header on the
+    // non-lethal default).
     if seccomp_runtime_disabled() {
         return SeccompOutcome::Unavailable;
     }
@@ -85,10 +100,14 @@ pub fn apply_worker_seccomp_filter() -> SeccompOutcome {
 
     let filter = match SeccompFilter::new(
         rules,
-        // Mismatched syscall: kill the process. SIGSYS surfaces with
-        // siginfo_t::si_syscall populated, so a regression produces a
-        // diagnosable crash, not a silent failure.
-        SeccompAction::KillProcess,
+        // Mismatched syscall: fail it with EPERM instead of killing the
+        // process. The syscall never executes (attack surface identical to
+        // a kill default), but a benign, unanticipated syscall from a valid
+        // transfer degrades to an errno the daemon can surface through its
+        // normal error path rather than a whole-daemon SIGSYS that RSTs
+        // every concurrent connection. See the module header for the
+        // upstream-fidelity rationale.
+        SeccompAction::Errno(libc::EPERM as u32),
         // Matched syscall: allow it through unconditionally. Argument-
         // level conditions are out of scope for the first cut; tightening
         // is deferred until the allowlist itself bakes.
@@ -258,6 +277,16 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
         libc::SYS_rt_sigaction,
         libc::SYS_rt_sigprocmask,
         libc::SYS_rt_sigreturn,
+        // The kernel injects `restart_syscall` (not the program) when a
+        // signal interrupts a restartable blocking call - `nanosleep`,
+        // `clock_nanosleep`, `futex` with a timeout, `ppoll`, all of which
+        // the transfer worker issues (bandwidth limiter, Condvar timeouts,
+        // I/O readiness waits). Under load, signal delivery to the worker
+        // makes this fire rarely; omitting it from a lethal-default filter
+        // is a latent whole-daemon kill mid-transfer. Not attacker-
+        // controllable (it carries no arguments and only resumes an
+        // already-permitted syscall), so allowing it costs no surface.
+        libc::SYS_restart_syscall,
         libc::SYS_brk,
         libc::SYS_mmap,
         libc::SYS_munmap,
@@ -424,6 +453,12 @@ mod seccomp_tests {
             // on aarch64 when fcntl was missing. Sender file open and
             // socket non-blocking toggling both require it.
             libc::SYS_fcntl,
+            // SYS_restart_syscall is kernel-injected when a signal
+            // interrupts a restartable blocking call the worker issues
+            // (nanosleep, clock_nanosleep, futex-with-timeout, ppoll).
+            // Its omission was the residual whole-daemon SIGSYS kill under
+            // full-CI concurrency; pin it so it can never regress out.
+            libc::SYS_restart_syscall,
         ] {
             assert!(
                 list.binary_search(&required).is_ok(),
@@ -452,7 +487,7 @@ mod seccomp_tests {
         }
         let filter = SeccompFilter::new(
             rules,
-            SeccompAction::KillProcess,
+            SeccompAction::Errno(libc::EPERM as u32),
             SeccompAction::Allow,
             arch,
         )

--- a/crates/daemon/tests/seccomp_production_allowlist.rs
+++ b/crates/daemon/tests/seccomp_production_allowlist.rs
@@ -7,15 +7,15 @@
 //! 1. Fork a child process so the test harness thread is unaffected.
 //! 2. Build the production allowlist via the daemon crate's
 //!    `worker_seccomp_allowlist()` accessor.
-//! 3. Install the filter with `KillProcess` default action - identical to
-//!    the production wire-in.
+//! 3. Install the filter with the production `Errno(EPERM)` default
+//!    action - identical to the production wire-in.
 //! 4. Exercise a representative slice of file / metadata / process
 //!    syscalls that a daemon transfer touches in steady state. Network
 //!    socket creation is intentionally NOT exercised here: in production
 //!    the worker inherits the accepted socket fd from the parent and
 //!    never calls `socket(2)` / `connect(2)`.
-//! 5. Exit cleanly. Any missing syscall traps SIGSYS and surfaces as a
-//!    failed assertion in the parent.
+//! 5. Exit cleanly. A missing allow-listed syscall would fail with EPERM
+//!    and surface as a non-zero exit code in the parent.
 //!
 //! Gated on `cfg(all(target_os = "linux", feature = "daemon-seccomp"))`.
 
@@ -128,6 +128,55 @@ fn production_allowlist_covers_a_clean_transfer_slice() {
     assert_eq!(
         code, 0,
         "clean-transfer slice failed with exit code {code} - check allowlist",
+    );
+}
+
+#[test]
+fn unlisted_syscall_fails_eperm_without_killing_the_process() {
+    // Intent: upstream rsync has no seccomp, so oc's hardening must never
+    // make a legitimate transfer more fragile than upstream. The default
+    // action is `Errno(EPERM)`, not `KillProcess`: an unanticipated
+    // syscall is denied (never executes) but the worker - and therefore
+    // the whole daemon and every concurrent connection - stays alive. A
+    // regression back to a lethal default would let one rare, benign
+    // syscall RST every in-flight transfer, which is the bug this guards.
+    let status = fork_run(|| {
+        match apply_worker_seccomp_filter() {
+            SeccompOutcome::Installed => {}
+            SeccompOutcome::Unavailable => return 77, // skip
+            SeccompOutcome::Error(_) => return 78,
+        }
+
+        // ptrace is intentionally absent from the production allowlist.
+        // Under an `Errno(EPERM)` default it returns -1/EPERM and execution
+        // continues; under a kill default the process would die here.
+        // SAFETY: raw ptrace syscall; expected to be denied by seccomp.
+        #[allow(unsafe_code)]
+        let rc = unsafe { libc::syscall(libc::SYS_ptrace, libc::PTRACE_TRACEME, 0, 0, 0) };
+        if rc != -1 {
+            return 20; // syscall unexpectedly succeeded - not denied
+        }
+        if std::io::Error::last_os_error().raw_os_error() != Some(libc::EPERM) {
+            return 21; // denied, but with the wrong errno
+        }
+        // Reaching here proves the process survived a denied syscall.
+        0
+    });
+
+    let extracted = std::process::ExitStatus::from_raw(status);
+    if let Some(sig) = extracted.signal() {
+        panic!(
+            "production filter killed the process (signal {sig}) on an unlisted syscall - default action must be non-lethal Errno(EPERM)",
+        );
+    }
+    let code = extracted.code().expect("child must exit");
+    if code == 77 {
+        eprintln!("seccomp filter unavailable in this build/kernel; skipping");
+        return;
+    }
+    assert_eq!(
+        code, 0,
+        "unlisted syscall must fail with EPERM and leave the process alive (exit code {code})",
     );
 }
 

--- a/docs/design/lsm-seccomp-allowlist.md
+++ b/docs/design/lsm-seccomp-allowlist.md
@@ -7,7 +7,7 @@ Companion to `sec-1-p-landlock-defense-in-depth-2026-05-22.md`. Landlock
 restricts what the daemon may *touch on the filesystem*; seccomp restricts
 which *syscalls* it may issue at all. The two layers compose: Landlock
 denies a path-based syscall with `EACCES`, seccomp denies an out-of-scope
-syscall with `SIGSYS` before the kernel ever consults the LSM stack.
+syscall with `EPERM` before the kernel ever consults the LSM stack.
 
 ## Goals
 
@@ -15,9 +15,15 @@ syscall with `SIGSYS` before the kernel ever consults the LSM stack.
   (`engage_landlock_sandbox`): after `chroot`, after privilege drop, after
   daemon-filter rules are loaded into memory, before any client-controlled
   data is parsed.
-- Default action `KILL_PROCESS` (delivers `SIGSYS`) so a regression that
-  reaches an out-of-allowlist syscall fails loudly instead of mis-behaving
-  silently. The worker dies; the parent `accept(2)` loop survives.
+- Default action `Errno(EPERM)`. An out-of-allowlist syscall is denied
+  (it never executes, so the attack surface is identical to a kill
+  default) but the daemon stays alive: a `KILL_PROCESS` default delivers
+  `SIGSYS` to the whole thread group and tears down the *entire* daemon,
+  RSTing every concurrent connection, so a single rare, benign syscall
+  from a legitimate transfer becomes a fatal outage. Upstream rsync has
+  no seccomp at all; the hardening must never make a valid transfer more
+  fragile than upstream. This matches the container-runtime posture
+  (Docker/Podman/containerd default to `SCMP_ACT_ERRNO(EPERM)`).
 - Per-architecture (`x86_64`, `aarch64`) syscall number resolution via
   `libc::SYS_*` and `seccompiler::TargetArch::native()`.
 - Enabled by default when `--features daemon-seccomp` is compiled in.
@@ -82,6 +88,7 @@ clean run.
 |---------|--------|-----------|
 | `futex` | `std::sync::Mutex`, `Condvar`, `crossbeam` | Rust synchronisation primitives |
 | `rseq` | glibc 2.35+ initialises per-thread restartable sequences | required by every threaded glibc program |
+| `restart_syscall` | kernel-injected when a signal interrupts a restartable blocking call (`nanosleep`, `clock_nanosleep`, `futex` timeout, `ppoll`) | the worker's bandwidth limiter, Condvar timeouts, and I/O readiness waits are all restartable; under load, signal delivery makes the kernel resume them via `restart_syscall`. Omitting it was the residual whole-daemon kill under full-CI concurrency. Not attacker-controllable (no arguments; only resumes an already-permitted call). |
 | `clock_gettime` / `clock_nanosleep` | progress reporting, bandwidth limiter sleeps | `Instant::now()`, throttle waits |
 | `nanosleep` | bandwidth limiter | sub-millisecond throttle |
 | `gettid` | `tracing` instrumentation, thread-local debugging | identifying worker threads |
@@ -117,8 +124,8 @@ accepting connections. The filter only constrains the per-connection
 worker thread.
 
 Stdio daemon sessions (`--server --daemon` via remote shell) are exempt
-from seccomp entirely because the process IS the worker - applying
-`KillProcess` would leave no supervisor to recover from a filter miss.
+from seccomp entirely because the process IS the worker - a process-
+scoped filter would restrict post-transfer cleanup and the exit path.
 
 For reference, the parent uses: `socket`, `bind`, `listen`, `accept4`,
 `setsockopt`, `setuid`, `setgid`, `setgroups`, `chroot`, `chdir`,
@@ -126,23 +133,34 @@ For reference, the parent uses: `socket`, `bind`, `listen`, `accept4`,
 
 ## Default action
 
-`SeccompAction::KillProcess` - the kernel delivers `SIGSYS` synchronously
-to the offending thread, which terminates the entire worker process. The
-core-dump captures the violating syscall number in
-`siginfo_t::si_syscall`, so a regression surfaces as a crash with a clear
-artifact. The daemon supervisor sees an abnormal exit and the next
-client gets a fresh worker.
+`SeccompAction::Errno(EPERM)` - a mismatched syscall returns `-EPERM`
+without executing. The kernel never runs the call, so an attacker who
+hijacks the worker still cannot `execve`/`ptrace`/`mount`/etc.; the
+attack surface is identical to a kill default. The difference is failure
+mode: a benign, unanticipated syscall from a *legitimate* transfer
+degrades to an errno the daemon surfaces through its normal I/O error
+path instead of dying.
+
+Why not `KillProcess` (the original choice): `SECCOMP_RET_KILL_PROCESS`
+delivers `SIGSYS` to the whole thread group and terminates the *entire*
+daemon, not just the offending worker thread - RSTing every concurrent
+connection. Under full-CI concurrency a rare, load-triggered
+`restart_syscall` (kernel-injected on a signal-interrupted blocking call)
+was absent from the allowlist and killed the daemon mid-transfer, so
+every in-flight client saw `Connection reset by peer` / exit 23. Upstream
+rsync has no seccomp; making a valid transfer more fragile than upstream
+is the wrong trade. The concrete gap (`restart_syscall`) is now in the
+allowlist, and the non-lethal default ensures any *future* gap degrades
+gracefully rather than taking the daemon down.
 
 Alternatives considered and rejected:
 
-- `Errno(EPERM)` - silently returning `-EPERM` would let the daemon
-  continue with the syscall having mysteriously failed. Defense-in-depth
-  is meaningless if it doesn't fail loud.
+- `KillProcess` / `KillThread` - lethal on the first miss; a single rare
+  benign syscall aborts live transfers (see above).
 - `Trap` - delivering `SIGSYS` but allowing a custom handler would let an
   attacker who controls the syscall stream catch and ignore violations.
-- `Log` - useful during bake; we expose it via an env var
-  (`OC_RSYNC_SECCOMP_LOG_ONLY=1`) for the 14-day bake window but the
-  default once flipped is kill-process.
+- `Log` - allows the syscall through, so it provides no enforcement; only
+  useful for a diagnostic bake, not as a steady-state default.
 
 ## Bake plan
 
@@ -152,16 +170,17 @@ Alternatives considered and rejected:
    Operators opt out with `OC_RSYNC_NO_SECCOMP=1` or
    `OC_RSYNC_DAEMON_SECCOMP=0`.
 4. Stdio daemon sessions (remote-shell mode via `lsh.sh` / SSH) are
-   excluded - the filter only applies to TCP worker threads where the
-   parent accept loop survives a `KillProcess`.
+   excluded - the filter only applies to TCP worker threads, never to a
+   whole stdio process where it would restrict post-transfer cleanup.
 5. The companion `landlock-feature-guidance.md` documents the layered
    defense story for distro packagers.
 
 ## Allowlist completeness criterion
 
 The filter is correct iff *every clean daemon transfer* completes without
-a `SIGSYS`. The integration test in Phase 4 runs a non-trivial transfer
-through the seccomp-filtered worker and asserts a zero exit code; any
-missing syscall fails that test. The negative test asserts that an
-intentionally-blocked syscall (e.g. `ptrace`) does deliver `SIGSYS`,
-proving the filter is actually installed and enforcing.
+a denied syscall. The integration test runs a transfer slice through the
+seccomp-filtered worker and asserts a zero exit code; a missing syscall
+would fail with `EPERM` and surface as a non-zero exit. The negative test
+asserts that an intentionally-blocked syscall (e.g. `ptrace`) returns
+`EPERM` *and leaves the process alive*, proving both that the filter is
+installed and enforcing and that the default action is non-lethal.


### PR DESCRIPTION
## Summary

The daemon worker's seccomp BPF filter (`daemon-seccomp` feature, on by
default in release builds) used a `KillProcess` default action and an
allowlist that omitted `restart_syscall(2)`. This pairing is a latent
whole-daemon kill: `SECCOMP_RET_KILL_PROCESS` delivers `SIGSYS` to the
entire thread group, so a single unlisted syscall on any worker thread
tears down the whole daemon and RSTs every concurrent connection - a
client sees `Connection reset by peer (os error 104)` / exit 23.

`restart_syscall` is exactly such a syscall: the kernel injects it (not
the program) when a signal interrupts a restartable blocking call the
transfer worker issues - `nanosleep`/`clock_nanosleep` (bandwidth
limiter), `futex` with a timeout (Condvar waits), `ppoll` (I/O
readiness). Under heavy concurrency, a signal landing on a worker blocked
in one of these makes the kernel resume via `restart_syscall`, which the
allowlist did not permit. This matches the ultra-rare, load-only residual
RST that survived the earlier port co-bind fix.

Upstream rsync ships no seccomp at all, so oc's hardening must never make
a legitimate transfer more fragile than upstream. This change makes two
robustness fixes:

1. **Add `restart_syscall` to the worker allowlist.** It is kernel-
   injected, carries no arguments, and only resumes an already-permitted
   syscall, so allowing it adds no attack surface.
2. **Change the default (mismatch) action from `KillProcess` to
   `Errno(EPERM)`.** A denied syscall still never executes - an attacker
   who hijacks the worker still cannot `execve`/`ptrace`/`mount`/etc., so
   the attack surface is identical - but a benign, unanticipated syscall
   from a valid transfer now degrades to a syscall error surfaced through
   the daemon's normal I/O error path instead of crashing the process.
   This is the industry-standard container posture (Docker, Podman, and
   containerd all default to `SCMP_ACT_ERRNO(EPERM)`).

Together: the known gap is closed, and any *future* gap degrades
gracefully rather than taking the daemon down mid-transfer.

Wire-transparent: only the seccomp filter's default action and allowlist
change; no protocol, socket, or transfer-path behaviour is touched.

## Evidence

A self-contained seccomp micro-reproduction on Linux 7.0.0 aarch64
isolates `restart_syscall` as the sole lethal rule (every other syscall
allowed), then forces the kernel to resume an interrupted
`nanosleep`/`clock_nanosleep` via `restart_syscall` using job-control
STOP/CONT:

- `strace` confirms the kernel emits `restart_syscall` on the interrupted
  sleep: `restart_syscall(<... resuming interrupted clock_nanosleep ...>)`
  (fired 59x in one run).
- With `restart_syscall` denied under a `KILL_PROCESS` default, the child
  is killed by `SIGSYS` (signal 31) on every run.
- With `restart_syscall` permitted, the child survives on every run.

This proves the syscall is reachable from the worker's blocking calls and
that a `KILL_PROCESS` default without it is a deterministic process kill.

## Connection-establishment (secondary)

Checked the daemon's own listener setup: it performs `bind()` then
`listen()` synchronously and returns the socket only after `listen(2)`
succeeds, so there is no bound-but-not-listening window on the daemon
side. The "Connection refused under load" seen previously is a test-
harness startup-readiness race in the free-port daemon-spawn helper, not
a daemon-code defect; it is out of scope for this production fix.

## Testing

- `cargo fmt -p daemon -- --check` clean.
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings` clean.
- New test `unlisted_syscall_fails_eperm_without_killing_the_process`
  installs the production filter, issues an unlisted `ptrace`, and asserts
  it returns `EPERM` and the process survives - encoding the non-lethal
  intent so a regression to a lethal default fails the suite.
- Existing `production_allowlist_covers_a_clean_transfer_slice` and the
  allowlist-essentials audit (now pinning `restart_syscall`) still pass.
