### PR TITLE
fix(daemon): warn and continue on per-option setsockopt failure

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -249,17 +249,11 @@ fn serve_connections(
                 .with_role(Role::Daemon),
             )
         })?;
+        // upstream: socket.c:730-733 - a failed setsockopt warns and continues;
+        // it never aborts binding. apply_socket_options_to_listener applies each
+        // option independently and logs any per-option failure.
         for listener in &listeners {
-            apply_socket_options_to_listener(listener, &parsed).map_err(|error| {
-                DaemonError::new(
-                    FEATURE_UNAVAILABLE_EXIT_CODE,
-                    rsync_error!(
-                        FEATURE_UNAVAILABLE_EXIT_CODE,
-                        format!("failed to set socket options: {error}")
-                    )
-                    .with_role(Role::Daemon),
-                )
-            })?;
+            apply_socket_options_to_listener(listener, &parsed, log_sink.as_ref());
         }
         Arc::new(parsed)
     } else {

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -224,21 +224,13 @@ fn apply_client_options(
     // upstream: clientserver.c - set_socket_options() is called
     // on the accepted client fd before the session handler runs.
     // Skipped for stdio streams which have no underlying TCP socket.
+    // upstream: socket.c:730-733 - each option that fails to apply warns and
+    // the loop continues; a single failure never rejects the connection.
     if !client_socket_options.is_empty() {
         let Some(tcp) = stream.tcp_stream() else {
             return;
         };
-        if let Err(error) =
-            apply_socket_options_to_stream(tcp, client_socket_options)
-        {
-            if let Some(log) = log_sink {
-                let text = format!(
-                    "failed to apply socket options to client connection: {error}"
-                );
-                let message = rsync_warning!(text).with_role(Role::Daemon);
-                log_message(log, &message);
-            }
-        }
+        apply_socket_options_to_stream(tcp, client_socket_options, log_sink);
     }
 }
 

--- a/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
@@ -49,6 +49,32 @@ enum SocketOption {
     SoRcvTimeo(i32),
 }
 
+impl SocketOption {
+    /// Returns the upstream option name used in warning messages.
+    ///
+    /// upstream: socket.c:730-733 - `set_socket_options()` reports a failed
+    /// `setsockopt(2)` as "failed to set socket option %s" using the option's
+    /// `socket_options[].name`.
+    fn name(&self) -> &'static str {
+        match self {
+            SocketOption::TcpNoDelay(_) => "TCP_NODELAY",
+            SocketOption::SoKeepAlive(_) => "SO_KEEPALIVE",
+            SocketOption::SoSndBuf(_) => "SO_SNDBUF",
+            SocketOption::SoRcvBuf(_) => "SO_RCVBUF",
+            SocketOption::IpTos(_) => "IP_TOS",
+            SocketOption::SoBroadcast(_) => "SO_BROADCAST",
+            #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+            SocketOption::SoSndLoWat(_) => "SO_SNDLOWAT",
+            #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+            SocketOption::SoRcvLoWat(_) => "SO_RCVLOWAT",
+            #[cfg(unix)]
+            SocketOption::SoSndTimeo(_) => "SO_SNDTIMEO",
+            #[cfg(unix)]
+            SocketOption::SoRcvTimeo(_) => "SO_RCVTIMEO",
+        }
+    }
+}
+
 /// Parses a comma-separated socket options string into typed option values.
 ///
 /// Accepts the upstream `rsyncd.conf` format: comma-separated option names with
@@ -222,8 +248,9 @@ fn parse_tos_option_value(value: Option<&str>) -> Result<u32, String> {
 fn apply_socket_options_to_listener(
     listener: &TcpListener,
     options: &[SocketOption],
-) -> io::Result<()> {
-    apply_socket_options_impl(socket2::SockRef::from(listener), options)
+    log_sink: Option<&SharedLogSink>,
+) {
+    apply_socket_options_impl(socket2::SockRef::from(listener), options, log_sink);
 }
 
 /// Applies parsed socket options to an accepted client `TcpStream` via `socket2`.
@@ -233,42 +260,58 @@ fn apply_socket_options_to_listener(
 fn apply_socket_options_to_stream(
     stream: &TcpStream,
     options: &[SocketOption],
-) -> io::Result<()> {
-    apply_socket_options_impl(socket2::SockRef::from(stream), options)
+    log_sink: Option<&SharedLogSink>,
+) {
+    apply_socket_options_impl(socket2::SockRef::from(stream), options, log_sink);
 }
 
 /// Shared implementation for applying socket options to any socket reference.
+///
+/// upstream: socket.c:730-733 - `set_socket_options()` applies each option
+/// independently; on a failed `setsockopt(2)` it emits a warning
+/// (`rsyserr(FERROR, errno, "failed to set socket option %s", tok)`) and
+/// `continue`s to the next option. A single failed option never aborts the
+/// connection, so we warn-and-continue rather than propagate an error.
 fn apply_socket_options_impl(
     sock: socket2::SockRef<'_>,
     options: &[SocketOption],
-) -> io::Result<()> {
+    log_sink: Option<&SharedLogSink>,
+) {
     for opt in options {
-        match opt {
-            SocketOption::TcpNoDelay(enabled) => sock.set_tcp_nodelay(*enabled)?,
-            SocketOption::SoKeepAlive(enabled) => sock.set_keepalive(*enabled)?,
-            SocketOption::SoBroadcast(enabled) => sock.set_broadcast(*enabled)?,
-            SocketOption::SoSndBuf(size) => sock.set_send_buffer_size(*size)?,
-            SocketOption::SoRcvBuf(size) => sock.set_recv_buffer_size(*size)?,
-            SocketOption::IpTos(tos) => apply_ip_tos(&sock, *tos)?,
+        let result: io::Result<()> = match opt {
+            SocketOption::TcpNoDelay(enabled) => sock.set_tcp_nodelay(*enabled),
+            SocketOption::SoKeepAlive(enabled) => sock.set_keepalive(*enabled),
+            SocketOption::SoBroadcast(enabled) => sock.set_broadcast(*enabled),
+            SocketOption::SoSndBuf(size) => sock.set_send_buffer_size(*size),
+            SocketOption::SoRcvBuf(size) => sock.set_recv_buffer_size(*size),
+            SocketOption::IpTos(tos) => apply_ip_tos(&sock, *tos),
             #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
             SocketOption::SoSndLoWat(n) => {
-                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_SNDLOWAT, *n)?;
+                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_SNDLOWAT, *n)
             }
             #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
             SocketOption::SoRcvLoWat(n) => {
-                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_RCVLOWAT, *n)?;
+                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_RCVLOWAT, *n)
             }
             #[cfg(unix)]
             SocketOption::SoSndTimeo(n) => {
-                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_SNDTIMEO, *n)?;
+                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_SNDTIMEO, *n)
             }
             #[cfg(unix)]
             SocketOption::SoRcvTimeo(n) => {
-                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_RCVTIMEO, *n)?;
+                apply_raw_int(&sock, libc::SOL_SOCKET, libc::SO_RCVTIMEO, *n)
+            }
+        };
+
+        if let Err(error) = result {
+            // upstream: socket.c:730-733 - warn and keep applying the rest.
+            if let Some(log) = log_sink {
+                let text = format!("failed to set socket option {}: {error}", opt.name());
+                let message = rsync_warning!(text).with_role(Role::Daemon);
+                log_message(log, &message);
             }
         }
     }
-    Ok(())
 }
 
 /// Applies an integer socket option that has no typed `socket2` setter.

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -609,7 +609,7 @@ fn apply_listener_socket_options_nodelay_keepalive() {
         SocketOption::TcpNoDelay(true),
         SocketOption::SoKeepAlive(true),
     ];
-    apply_socket_options_to_listener(&listener, &opts).expect("apply succeeds");
+    apply_socket_options_to_listener(&listener, &opts, None);
 
     let sock = socket2::SockRef::from(&listener);
     assert!(sock.tcp_nodelay().expect("query nodelay"));
@@ -620,7 +620,7 @@ fn apply_listener_socket_options_nodelay_keepalive() {
 fn apply_listener_socket_options_buffer_sizes() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let opts = vec![SocketOption::SoSndBuf(32768), SocketOption::SoRcvBuf(32768)];
-    apply_socket_options_to_listener(&listener, &opts).expect("apply succeeds");
+    apply_socket_options_to_listener(&listener, &opts, None);
 
     let sock = socket2::SockRef::from(&listener);
     assert!(sock.send_buffer_size().expect("query sndbuf") >= 32768);
@@ -636,7 +636,7 @@ fn apply_stream_socket_options_nodelay_keepalive() {
         SocketOption::TcpNoDelay(true),
         SocketOption::SoKeepAlive(true),
     ];
-    apply_socket_options_to_stream(&stream, &opts).expect("apply succeeds");
+    apply_socket_options_to_stream(&stream, &opts, None);
 
     let sock = socket2::SockRef::from(&stream);
     assert!(sock.tcp_nodelay().expect("query nodelay"));
@@ -649,7 +649,7 @@ fn apply_stream_socket_options_buffer_sizes() {
     let addr = listener.local_addr().expect("local addr");
     let stream = TcpStream::connect(addr).expect("connect");
     let opts = vec![SocketOption::SoSndBuf(32768), SocketOption::SoRcvBuf(32768)];
-    apply_socket_options_to_stream(&stream, &opts).expect("apply succeeds");
+    apply_socket_options_to_stream(&stream, &opts, None);
 
     let sock = socket2::SockRef::from(&stream);
     assert!(sock.send_buffer_size().expect("query sndbuf") >= 32768);
@@ -691,7 +691,55 @@ fn apply_stream_socket_options_empty_is_noop() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr");
     let stream = TcpStream::connect(addr).expect("connect");
-    apply_socket_options_to_stream(&stream, &[]).expect("empty options should succeed");
+    apply_socket_options_to_stream(&stream, &[], None);
+}
+
+/// upstream: socket.c:730-733 - `set_socket_options()` responds to a failed
+/// `setsockopt(2)` with `rsyserr(FERROR, errno, "failed to set socket option
+/// %s")` and then `continue`s the loop; one failed option must never abort the
+/// connection or skip the remaining options. Applying `IP_TOS` to an AF_UNIX
+/// socket has no IP address family and is guaranteed to fail, so it stands in
+/// for any unsettable option. We feed it ahead of a settable `SO_RCVBUF` and
+/// assert: (1) exactly one per-option warning is logged, naming the failed
+/// `IP_TOS`; (2) the later `SO_RCVBUF` produced no warning, proving the loop
+/// continued and applied it; and (3) apply returns normally (no abort).
+#[cfg(unix)]
+#[test]
+fn apply_socket_options_warns_and_continues_on_per_option_failure() {
+    use std::os::unix::net::UnixStream;
+
+    let (sock_a, _sock_b) = UnixStream::pair().expect("unix socketpair");
+
+    let log_dir = tempfile::tempdir().expect("log dir");
+    let log_path = log_dir.path().join("daemon.log");
+    let log_sink: Option<SharedLogSink> =
+        Some(open_log_sink(&log_path, Brand::Oc).expect("open log"));
+
+    // IP_TOS fails on AF_UNIX; SO_RCVBUF that follows must still be applied.
+    let opts = vec![SocketOption::IpTos(0x10), SocketOption::SoRcvBuf(8192)];
+    apply_socket_options_impl(socket2::SockRef::from(&sock_a), &opts, log_sink.as_ref());
+
+    drop(log_sink);
+    let contents = std::fs::read_to_string(&log_path).expect("read log");
+    assert!(
+        contents.starts_with("oc-rsync warning:"),
+        "expected warning level, got: {contents}"
+    );
+    assert!(
+        contents.contains("failed to set socket option IP_TOS"),
+        "missing per-option failure warning for IP_TOS: {contents}"
+    );
+    // SO_RCVBUF was reached and succeeded, so it emits no warning: the loop
+    // continued past the failed option instead of aborting.
+    assert!(
+        !contents.contains("failed to set socket option SO_RCVBUF"),
+        "SO_RCVBUF should have applied without a warning: {contents}"
+    );
+    assert_eq!(
+        contents.matches("failed to set socket option").count(),
+        1,
+        "expected exactly one per-option failure warning: {contents}"
+    );
 }
 
 /// A daemon `socket options =` config written for upstream rsync must parse
@@ -777,8 +825,7 @@ fn parse_socket_options_accepts_all_upstream_options() {
 #[test]
 fn apply_socket_options_broadcast_sets_flag() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
-    apply_socket_options_to_listener(&listener, &[SocketOption::SoBroadcast(true)])
-        .expect("apply succeeds");
+    apply_socket_options_to_listener(&listener, &[SocketOption::SoBroadcast(true)], None);
 
     let sock = socket2::SockRef::from(&listener);
     assert!(sock.broadcast().expect("query broadcast"));


### PR DESCRIPTION
## Problem

The daemon's socket-option apply path hard-errored on any `setsockopt(2)`
failure. `apply_socket_options_impl` used `?` on every option, and the
listener-setup path wrapped that in a fatal `DaemonError`, so a single failed
socket option aborted binding (and, on the client path, silently skipped every
option after the first failure).

This diverges from upstream rsync. In `set_socket_options()`, upstream applies
each configured option independently and, on a failed `setsockopt(2)`, emits a
warning and `continue`s to the next option. A single failed option never
rejects the connection.

## Upstream reference

`socket.c:730-733` (`set_socket_options()`):

```c
if (ret != 0) {
    rsyserr(FERROR, errno,
        "failed to set socket option %s", tok);
}
```

The `if (ret != 0)` warning sits inside the per-token `for` loop, so control
falls through to the next token; there is no early return or abort.

## Fix

- `apply_socket_options_impl` now applies every option independently. On a
  per-option error it logs a `failed to set socket option NAME: <err>` daemon
  warning (`rsync_warning!(...).with_role(Role::Daemon)`, the existing warning
  pattern in this crate) and continues, rather than returning `Err`.
- The applier takes the existing `SharedLogSink` from the listener-setup and
  accept paths (dependency-injected, no globals); the wrapper functions no
  longer return `io::Result` since a per-option failure is not fatal.
- The listener path drops its fatal error wrapping; the client path drops its
  whole-function error handling (superseded by per-option warnings).
- This also makes options a platform rejects at runtime (e.g. `SO_BROADCAST`
  returning `WSAENOPROTOOPT` on Windows) degrade gracefully.

## Test

Adds `apply_socket_options_warns_and_continues_on_per_option_failure`: applies
`IP_TOS` (guaranteed to fail on an AF_UNIX socket, which has no IP address
family) followed by a settable `SO_RCVBUF`, then asserts exactly one per-option
warning is logged naming `IP_TOS` while `SO_RCVBUF` produces none, proving the
loop continued and applied the later option without aborting.

Validated with `cargo fmt`, `cargo check --all-features --tests`, `cargo clippy
--all-features --all-targets -- -D warnings`, and the scoped `daemon`
`socket_options` test set (32 passed).
