### PR TITLE
fix(transfer): interleave itemize in flist order (sync incremental)

### DIFF
--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -35,6 +35,12 @@ impl ReceiverContext {
         mut progress: Option<&mut dyn crate::TransferProgressCallback>,
     ) -> io::Result<TransferStats> {
         let _t = PhaseTimer::new("receiver-transfer-incremental");
+        // Buffer itemize rows and flush them once in flist-index order before
+        // finalization, so a directory row immediately precedes its children
+        // (upstream's single flist-index-order walk, generator.c:2329-2344)
+        // rather than oc's two-phase "all dirs, then all files" emission.
+        // Mirrors run_pipelined; the async incremental path is out of scope.
+        self.defer_itemize = true;
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
 
@@ -60,7 +66,7 @@ impl ReceiverContext {
         // upstream: generator.c:1317-1326 - make_path() for relative_paths
         self.ensure_relative_parents(&setup.dest_dir);
 
-        for file_entry in &self.file_list {
+        for (flist_idx, file_entry) in self.file_list.iter().enumerate() {
             if file_entry.is_dir() {
                 let result = self.create_directory_incremental(
                     &setup.dest_dir,
@@ -84,7 +90,10 @@ impl ReceiverContext {
                         // `.` mtime emits `.d..t......`). emit_itemize's gate
                         // drops the row when nothing is significant.
                         let iflags = crate::generator::ItemFlags::from_raw(iflags_raw);
-                        let _ = self.emit_itemize(writer, &iflags, file_entry);
+                        // Deferred (defer_itemize) so the dir row lands in
+                        // flist-index order immediately before its children at
+                        // flush time, matching run_pipelined and upstream.
+                        let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, file_entry);
                     }
                     None => {
                         stats.directories_failed += 1;
@@ -277,8 +286,173 @@ impl ReceiverContext {
         stats.metadata_errors = metadata_errors;
         stats.redo_count = redo_count;
 
+        // Drain the deferred itemize rows in flist-index order before the
+        // goodbye handshake, matching upstream's single-pass emission ordering.
+        self.flush_itemize_rows(writer)?;
+
         self.finalize_transfer(reader, writer)?;
 
         Ok(stats)
+    }
+}
+
+#[cfg(test)]
+mod itemize_order_tests {
+    use std::ffi::OsString;
+
+    use protocol::ProtocolVersion;
+    use protocol::flist::FileEntry;
+
+    use crate::config::ServerConfig;
+    use crate::flags::{InfoFlags, ParsedServerFlags};
+    use crate::handshake::HandshakeResult;
+    use crate::receiver::ReceiverContext;
+    use crate::receiver::directory::FailedDirectories;
+    use crate::receiver::stats::TransferStats;
+    use crate::role::ServerRole;
+
+    fn handshake() -> HandshakeResult {
+        HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        }
+    }
+
+    /// A client-mode pull receiver with `-i` (itemize) requested.
+    fn itemize_client_config() -> ServerConfig {
+        let mut config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-ri".to_owned(),
+            flags: ParsedServerFlags {
+                recursive: true,
+                info_flags: InfoFlags {
+                    itemize: true,
+                    ..InfoFlags::default()
+                },
+                ..ParsedServerFlags::default()
+            },
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        config.connection.client_mode = true;
+        config
+    }
+
+    /// The incremental driver's deferred flush must interleave directory and
+    /// file itemize rows in flist-index order (a dir row immediately precedes
+    /// its children), not batch every directory ahead of every file.
+    ///
+    /// Upstream itemizes in a single flist-index-order walk: `generate_files`
+    /// (generator.c:2329-2344) calls `recv_generator` per `cur_flist->sorted[i]`
+    /// in index order, and `recv_generator` (generator.c:1480-1483) itemizes
+    /// each directory at its own flist position. For the flist `a/ a/f1 b/ b/f2`
+    /// upstream prints `.d a/`, `>f a/f1`, `.d b/`, `>f b/f2`.
+    ///
+    /// `run_pipelined` was wired to defer itemize in #6560; this asserts the sync
+    /// incremental driver's own record sites - the per-directory
+    /// `create_directory_incremental` loop plus `build_files_to_transfer` - do the
+    /// same. It fails if the batch emission returns: reverting the dir loop to an
+    /// immediate `emit_itemize` leaves indices 0 and 2 unbuffered, and recording
+    /// without the per-index key would order both directory rows ahead of the
+    /// files.
+    #[test]
+    fn incremental_deferred_itemize_rows_interleave_in_flist_index_order() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+
+        let hs = handshake();
+        let mut ctx = ReceiverContext::new_for_test(&hs, itemize_client_config());
+        ctx.defer_itemize = true;
+        ctx.file_list = vec![
+            FileEntry::new_directory("a".into(), 0o755),  // idx 0
+            FileEntry::new_file("a/f1".into(), 5, 0o644), // idx 1
+            FileEntry::new_directory("b".into(), 0o755),  // idx 2
+            FileEntry::new_file("b/f2".into(), 5, 0o644), // idx 3
+        ];
+
+        let opts = metadata::MetadataOptions::default();
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+
+        // Directory-creation pass: mirror the incremental driver's inline loop,
+        // recording the `.d` rows (flist indices 0 and 2) as it creates each dir.
+        let mut failed_dirs = FailedDirectories::new();
+        for (flist_idx, file_entry) in ctx.file_list.clone().iter().enumerate() {
+            if !file_entry.is_dir() {
+                continue;
+            }
+            let result = ctx
+                .create_directory_incremental(
+                    dest,
+                    file_entry,
+                    &opts,
+                    &mut failed_dirs,
+                    None,
+                    None,
+                    #[cfg(unix)]
+                    None,
+                )
+                .expect("create_directory_incremental succeeds");
+            if let Some((_, iflags_raw)) = result {
+                let iflags = crate::generator::ItemFlags::from_raw(iflags_raw);
+                let _ = ctx.emit_or_record_itemize(&mut writer, flist_idx, &iflags, file_entry);
+            }
+        }
+
+        // Candidate pass records the new-file transfer rows (indices 1 and 3).
+        let mut metadata_errors = Vec::new();
+        let mut stats = TransferStats::default();
+        let _ = ctx.build_files_to_transfer(
+            &mut writer,
+            dest,
+            &opts,
+            Some(&failed_dirs),
+            &mut metadata_errors,
+            &mut stats,
+            None,
+            None,
+        );
+
+        let rows: Vec<(usize, String)> = ctx
+            .itemize_rows
+            .borrow()
+            .iter()
+            .map(|(idx, lines)| (*idx, lines[0].clone()))
+            .collect();
+
+        let keys: Vec<usize> = rows.iter().map(|(idx, _)| *idx).collect();
+        assert_eq!(
+            keys,
+            vec![0, 1, 2, 3],
+            "itemize rows must be keyed by flist index and drain in index order"
+        );
+
+        // Interleaved dir/file/dir/file, not batched dir/dir/file/file.
+        assert!(
+            rows[0].1.starts_with("cd") && rows[0].1.contains('a'),
+            "row 0 must be the created directory a/: {:?}",
+            rows[0].1
+        );
+        assert!(
+            rows[1].1.starts_with(">f") && rows[1].1.contains("a/f1"),
+            "row 1 must be the new file a/f1 (before b/), not the b/ directory: {:?}",
+            rows[1].1
+        );
+        assert!(
+            rows[2].1.starts_with("cd") && rows[2].1.contains('b'),
+            "row 2 must be the created directory b/ AFTER a/f1: {:?}",
+            rows[2].1
+        );
+        assert!(
+            rows[3].1.starts_with(">f") && rows[3].1.contains("b/f2"),
+            "row 3 must be the new file b/f2: {:?}",
+            rows[3].1
+        );
     }
 }


### PR DESCRIPTION
## Problem

The receiver emits itemize (`-i`) rows in the wrong order versus upstream rsync 3.4.4. Upstream itemizes in a single flist-index-order walk (`generate_files`, `generator.c:2329-2344` -> `recv_generator` -> `itemize`, `generator.c:1480-1483`), so a directory row lands immediately before its children's rows. For the flist `a/ a/f1 b/ b/f2` upstream prints:

```
.d a/
>f a/f1
.d b/
>f b/f2
```

oc's two-phase receiver instead emitted every directory (`.d`) row first, then every file (`>f`) row:

```
.d a/
.d b/
>f a/f1
>f b/f2
```

## Prior fix

PR #6560 fixed this for the `run_pipelined` receiver driver by adding a deferral mechanism: `defer_itemize` (a context flag), `emit_or_record_itemize` (buffers a row keyed by its flist index instead of writing it immediately), and `flush_itemize_rows` (drains the `BTreeMap` in ascending index order just before finalization). The candidate-selection and pipeline record sites already route through `emit_or_record_itemize`.

However, the sync incremental-flist driver `run_pipelined_incremental` was not wired to it: its inline per-directory creation loop still called `emit_itemize` directly and it never flushed, so it kept emitting dir-block-then-file-block.

## This change

Extends the exact same #6560 mechanism to the sync incremental driver:

- Sets `self.defer_itemize = true` at driver start (mirrors `run_pipelined`).
- Routes the inline directory-creation loop's itemize through `emit_or_record_itemize`, keyed by the entry's flist index (obtained via `.enumerate()`), instead of `emit_itemize`.
- Calls `flush_itemize_rows` before `finalize_transfer` to drain in flist-index order.

No new interleave logic is introduced - it reuses the shared helper (DRY). The driver's responsibility is unchanged; only itemize emission is routed through the shared deferral path.

## Scope

- Only the sync incremental path (`run_pipelined_incremental`) is touched.
- The async variants (`run_pipelined_incremental_async`, `run_sync_async`, any `*_async`) are intentionally out of scope: those receiver paths are default-off and gated.

## Test

Adds `incremental_deferred_itemize_rows_interleave_in_flist_index_order`, mirroring #6560's `run_pipelined` test but driving the incremental driver's own record sites (the `create_directory_incremental` loop plus `build_files_to_transfer`). It asserts the buffered rows are keyed by flist index and drain interleaved (`.d a/`, `>f a/f1`, `.d b/`, `>f b/f2`), not batched. It fails if the batch emission returns.

## Validation

- `cargo fmt -p transfer -- --check` - clean
- `cargo check -p transfer --all-features --tests` - clean
- `cargo clippy -p transfer --all-features --all-targets --no-deps -- -D warnings` - clean
- new test passes
