### PR TITLE
fix(cli): recognize server_options() flags to stop positional-dest leak

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -311,6 +311,43 @@ pub(super) struct ServerLongFlags {
     /// args[ac++] = "--ignore-missing-args"`. A vanished top-level source arg is
     /// silently dropped from the file list rather than raising an error.
     pub(super) ignore_missing_args: bool,
+
+    /// Backup suffix forwarded by the client (upstream: `--suffix=SUFFIX`).
+    ///
+    /// upstream: options.c:2812-2813 - `server_options()` emits
+    /// `safe_arg("--suffix", backup_suffix)` (joined `--suffix=VALUE`) whenever
+    /// the suffix differs from the default. The server receiver's backup path
+    /// honours it; without recognising the flag the value leaked into the
+    /// positional list and became a stray destination path.
+    pub(super) backup_suffix: Option<String>,
+
+    /// User id/name map spec forwarded by the client (upstream: `--usermap=SPEC`).
+    ///
+    /// upstream: options.c:2912-2913 - `safe_arg("--usermap", usermap)` (joined
+    /// `--usermap=VALUE`) is emitted inside the `am_sender` block so a server
+    /// receiver maps ownership on the destination.
+    pub(super) usermap: Option<String>,
+
+    /// Group id/name map spec forwarded by the client (upstream: `--groupmap=SPEC`).
+    ///
+    /// upstream: options.c:2915-2916 - `safe_arg("--groupmap", groupmap)` (joined
+    /// `--groupmap=VALUE`), emitted alongside `--usermap` in the `am_sender` block.
+    pub(super) groupmap: Option<String>,
+
+    /// Skip-compress suffix list forwarded by the client (upstream:
+    /// `--skip-compress=LIST`).
+    ///
+    /// upstream: options.c:2859-2860 - `safe_arg("--skip-compress", skip_compress)`
+    /// (joined `--skip-compress=VALUE`), emitted in the `else` (client-receiver)
+    /// branch so a server sender skips compression for the listed suffixes.
+    pub(super) skip_compress: Option<String>,
+
+    /// Block size forwarded by the client (upstream: `-B%u`).
+    ///
+    /// upstream: options.c:2787-2790 - `asprintf(&arg, "-B%u", block_size)`
+    /// emits a standalone `-B<digits>` token after the compact flag string.
+    /// Recognised here so it is not mistaken for a positional destination path.
+    pub(super) block_size: Option<String>,
 }
 
 /// Parses all long-form flags from the server argument list.
@@ -375,6 +412,11 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         open_noatime: false,
         delete_missing_args: false,
         ignore_missing_args: false,
+        backup_suffix: None,
+        usermap: None,
+        groupmap: None,
+        skip_compress: None,
+        block_size: None,
     };
 
     let mut idx = 0;
@@ -589,6 +631,16 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
                 if let Some(window) = s.strip_prefix("-@") {
                     flags.modify_window = Some(window.to_owned());
                 }
+                // upstream: options.c:2787-2790 - block_size arrives as a
+                // standalone `-B%u` token (e.g. `-B131072`) after the compact
+                // flag string. Guard on trailing digits so only the block-size
+                // spelling is consumed here, never some other `-B...` token.
+                else if let Some(size) = s
+                    .strip_prefix("-B")
+                    .filter(|r| !r.is_empty() && r.bytes().all(|b| b.is_ascii_digit()))
+                {
+                    flags.block_size = Some(size.to_owned());
+                }
                 // Accept the joined `--partial-dir=VALUE` form too, even
                 // though upstream's server_options() does not emit it - the
                 // CLI parser accepts both forms for client-side use, and a
@@ -669,6 +721,18 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.files_from = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--max-delete=") {
         flags.max_delete = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--suffix=") {
+        // upstream: options.c:2812-2813 - safe_arg("--suffix", backup_suffix).
+        flags.backup_suffix = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--usermap=") {
+        // upstream: options.c:2912-2913 - safe_arg("--usermap", usermap).
+        flags.usermap = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--groupmap=") {
+        // upstream: options.c:2915-2916 - safe_arg("--groupmap", groupmap).
+        flags.groupmap = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--skip-compress=") {
+        // upstream: options.c:2859-2860 - safe_arg("--skip-compress", skip_compress).
+        flags.skip_compress = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--iconv=") {
         // upstream: options.c:2716-2723 - server-side iconv forwarded by client
         flags.iconv = Some(value.to_owned());
@@ -824,6 +888,19 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--stop-after=")
         || arg.starts_with("--files-from=")
         || arg.starts_with("--max-delete=")
+        // upstream: options.c:2812-2813 / 2912-2913 / 2915-2916 / 2859-2860 -
+        // server_options() emits these as joined `--flag=value` via safe_arg().
+        // Recognise them so they are not mistaken for positional destination
+        // paths (same positional-dest leak class as --partial-dir / alt-dest).
+        || arg.starts_with("--suffix=")
+        || arg.starts_with("--usermap=")
+        || arg.starts_with("--groupmap=")
+        || arg.starts_with("--skip-compress=")
+        // upstream: options.c:2787-2790 - block_size arrives as a standalone
+        // `-B%u` token. Guard on trailing digits so only that spelling matches.
+        || (arg.starts_with("-B")
+            && arg.len() > 2
+            && arg.as_bytes()[2..].iter().all(u8::is_ascii_digit))
         || arg.starts_with("--iconv=")
         || arg.starts_with("--timeout=")
         || arg.starts_with("--io-uring-depth=")

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -287,6 +287,35 @@ where
     // during the goodbye phase (generator.c:2377,2422).
     config.do_stats = long_flags.stats;
     config.reference_directories = long_flags.reference_directories;
+    // upstream: options.c:2812-2813 - server_options() emits `--suffix=SUFFIX`
+    // (safe_arg) when the backup suffix differs from the default. The server's
+    // backup path honours it via effective_backup_suffix().
+    if let Some(suffix) = &long_flags.backup_suffix {
+        config.backup_suffix = Some(suffix.clone());
+    }
+    // upstream: options.c:2912-2913 / 2915-2916 - `--usermap=SPEC` / `--groupmap=SPEC`
+    // are emitted in the am_sender block so the server receiver maps ownership.
+    // A malformed spec leaves the field unset (mirroring the daemon path,
+    // module_access/client_args/long_form_args.rs, and upstream's fall-through
+    // to default id-mapping) rather than aborting the session.
+    if let Some(spec) = &long_flags.usermap
+        && let Ok(mapping) = ::metadata::UserMapping::parse(spec)
+    {
+        config.user_mapping = Some(mapping);
+    }
+    if let Some(spec) = &long_flags.groupmap
+        && let Ok(mapping) = ::metadata::GroupMapping::parse(spec)
+    {
+        config.group_mapping = Some(mapping);
+    }
+    // upstream: options.c:2859-2860 - `--skip-compress=LIST` is emitted when the
+    // client is the receiver (this process is the server sender); the sender
+    // skips compression for matching suffixes.
+    if let Some(spec) = &long_flags.skip_compress
+        && let Ok(list) = engine::SkipCompressList::parse(spec)
+    {
+        config.skip_compress = Some(list);
+    }
     // upstream: options.c:2886-2890 - `--partial-dir DIR` forwarded by the
     // sender. The server-side receiver moves interrupted temp files into this
     // directory and looks for resume basis files there. Without applying this

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -812,6 +812,185 @@ fn long_flags_capture_compress_level() {
     assert_eq!(flags.compression_level.as_deref(), Some("6"));
 }
 
+// upstream: options.c:2812-2813 - `server_options()` emits
+// `safe_arg("--suffix", backup_suffix)` (joined `--suffix=VALUE`). Without a
+// match arm the token leaked into the positional list and the receiver failed
+// with `failed to create destination root --suffix=.bak` (exit 12).
+#[test]
+fn suffix_is_known_and_not_positional() {
+    assert!(is_known_server_long_flag("--suffix=.bak"));
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("--suffix=.bak"),
+        OsString::from("."),
+        OsString::from("dst/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpr");
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("dst/")],
+        "--suffix=VALUE must not leak into positional args: {pos_args:?}",
+    );
+}
+
+// upstream: options.c:2812-2813 - the forwarded suffix is captured so the
+// server's backup path uses the same suffix the client requested.
+#[test]
+fn long_flags_capture_suffix() {
+    let args = vec![OsString::from("--server"), OsString::from("--suffix=.bak")];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.backup_suffix.as_deref(), Some(".bak"));
+}
+
+// upstream: options.c:2912-2913 - `server_options()` emits
+// `safe_arg("--usermap", usermap)` (joined `--usermap=VALUE`) in the am_sender
+// block. It must be recognised so a server receiver maps ownership rather than
+// treating the token as a positional destination path.
+#[test]
+fn usermap_is_known_and_not_positional() {
+    assert!(is_known_server_long_flag("--usermap=0:1000"));
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("--usermap=0:1000"),
+        OsString::from("."),
+        OsString::from("dst/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpr");
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("dst/")],
+        "--usermap=VALUE must not leak into positional args: {pos_args:?}",
+    );
+}
+
+// upstream: options.c:2912-2913 - the forwarded usermap spec is captured so the
+// server receiver can parse it into a UserMapping and remap ownership.
+#[test]
+fn long_flags_capture_usermap() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--usermap=0:1000"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.usermap.as_deref(), Some("0:1000"));
+}
+
+// upstream: options.c:2915-2916 - `server_options()` emits
+// `safe_arg("--groupmap", groupmap)` (joined `--groupmap=VALUE`) alongside
+// `--usermap`. Wildcard specs (`*:GID`) must survive intact into the flag list.
+#[test]
+fn groupmap_is_known_and_not_positional() {
+    assert!(is_known_server_long_flag("--groupmap=*:5678"));
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("--groupmap=*:5678"),
+        OsString::from("."),
+        OsString::from("dst/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpr");
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("dst/")],
+        "--groupmap=VALUE must not leak into positional args: {pos_args:?}",
+    );
+}
+
+// upstream: options.c:2915-2916 - the forwarded groupmap spec is captured
+// verbatim (wildcard intact) for GroupMapping::parse.
+#[test]
+fn long_flags_capture_groupmap() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--groupmap=*:5678"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.groupmap.as_deref(), Some("*:5678"));
+}
+
+// upstream: options.c:2859-2860 - `server_options()` emits
+// `safe_arg("--skip-compress", skip_compress)` (joined `--skip-compress=VALUE`)
+// in the client-receiver branch so a server sender skips compression for the
+// listed suffixes. It must not leak into the positional path list.
+#[test]
+fn skip_compress_is_known_and_not_positional() {
+    assert!(is_known_server_long_flag("--skip-compress=gz/zip/jpg"));
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--sender"),
+        OsString::from("-logDtprz"),
+        OsString::from("--skip-compress=gz/zip/jpg"),
+        OsString::from("."),
+        OsString::from("src/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtprz");
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("src/")],
+        "--skip-compress=VALUE must not leak into positional args: {pos_args:?}",
+    );
+}
+
+// upstream: options.c:2859-2860 - the forwarded skip-compress list is captured
+// so the server sender can build a SkipCompressList.
+#[test]
+fn long_flags_capture_skip_compress() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--skip-compress=gz/zip/jpg"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.skip_compress.as_deref(), Some("gz/zip/jpg"));
+}
+
+// upstream: options.c:2787-2790 - block_size is forwarded as a standalone
+// `-B%u` token (e.g. `-B131072`) after the compact flag string. Without
+// recognition the token leaked into the positional list and the receiver
+// failed with `failed to create destination root -B131072` (exit 12).
+#[test]
+fn block_size_is_known_and_not_positional() {
+    assert!(is_known_server_long_flag("-B131072"));
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("-B131072"),
+        OsString::from("."),
+        OsString::from("dst/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpr");
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("dst/")],
+        "-B<digits> must not leak into positional args: {pos_args:?}",
+    );
+}
+
+// upstream: options.c:2787-2790 - the forwarded block-size digits are captured.
+#[test]
+fn long_flags_capture_block_size() {
+    let args = vec![OsString::from("--server"), OsString::from("-B131072")];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.block_size.as_deref(), Some("131072"));
+}
+
+// The `-B` guard is digit-anchored: a non-block-size `-B...` token (no such
+// token is emitted by upstream, but the guard must not over-match) is neither
+// recognised nor captured as a block size.
+#[test]
+fn block_size_guard_rejects_non_digit_suffix() {
+    assert!(!is_known_server_long_flag("-Bxyz"));
+    assert!(!is_known_server_long_flag("-B"));
+    let flags = parse_server_long_flags(&[OsString::from("--server"), OsString::from("-Bxyz")]);
+    assert_eq!(flags.block_size, None);
+}
+
 // upstream: options.c:2747-2748 - the server recognises the forwarded
 // `--list-only` and records it so the transfer lists without writing.
 #[test]


### PR DESCRIPTION
## Problem

Upstream `server_options()` (options.c) emits several options to the remote
server that oc's server-argument recognizer did not know about. Each
unrecognized token fell through to the positional-argument branch in
`parse_server_flag_string_and_args`, so the receiver treated it as a
destination path and failed with `failed to create destination root <token>`
(exit 12) - corrupting real-upstream-client to oc-server transfers. This is
the same positional-dest leak class fixed for `--partial-dir` and the
alt-dest flags previously.

## Flags fixed

All confirmed against `options.c` `server_options()` in rsync 3.4.4:

| Flag | Wire form | Upstream site |
|------|-----------|---------------|
| `--suffix=VALUE` | joined (`safe_arg`) | options.c:2812-2813 |
| `--usermap=VALUE` | joined (`safe_arg`) | options.c:2912-2913 |
| `--groupmap=VALUE` | joined (`safe_arg`) | options.c:2915-2916 |
| `--skip-compress=VALUE` | joined (`safe_arg`) | options.c:2859-2860 |
| `-B<SIZE>` | standalone short token `-B%u` | options.c:2787-2790 |

`safe_arg(opt, val)` (options.c:2539) appends `=` to a non-empty `opt`, so the
four long forms are always the joined `--flag=value` spelling.

## Change

- `flags.rs`: added `--suffix=` / `--usermap=` / `--groupmap=` /
  `--skip-compress=` to the `is_known_server_long_flag` split-form chain and to
  `parse_value_bearing_flag`; added a digit-guarded `-B<digits>` recognizer to
  both `is_known_server_long_flag` and the standalone-short-token parser (mirrors
  the existing `-@` handling). The `-B` guard only matches `-B` followed by one
  or more ASCII digits, so no other `-B...` token is over-consumed.
- `run.rs`: threaded the recognized values into `ServerConfig`, which already
  carries `backup_suffix`, `user_mapping`, `group_mapping`, and `skip_compress`
  fields. This mirrors the daemon path
  (`module_access/client_args/long_form_args.rs`), which already parses the same
  specs. A malformed `--usermap` / `--groupmap` / `--skip-compress` spec leaves
  the field unset rather than aborting the session, matching upstream's
  fall-through to default id-mapping.

## Values applied vs recognition-only

- `--suffix`, `--usermap`, `--groupmap`, `--skip-compress`: **values applied**
  (config fields and parsers already existed; wiring mirrors the daemon).
- `-B` / block-size: **recognition-only**. `ServerConfig` has no `block_size`
  field, and threading one into the signature/delta layer would be substantial
  new plumbing. Preventing the positional-dest leak is the required correctness
  win here; applying the block size on the server is a follow-up.

## Tests

Extended the data-driven server-arg parity suite in
`crates/cli/src/frontend/server/tests.rs` with, per flag, a recognition test
(`is_known_server_long_flag`), a positional-leak reproduction of the exact
interop argv (asserting the token never lands in the positional/destination
list), and a capture test asserting the value reaches the `ServerLongFlags`
field. A negative test proves the `-B` guard rejects non-digit `-B...` tokens
and bare `-B`.

## Validation

`cargo fmt -p cli -- --check`, `cargo check -p cli --all-features --tests`, and
`cargo clippy -p cli --all-features --all-targets --no-deps -- -D warnings` all
pass clean.
