### PR TITLE
fix(transfer): sender emits MSG_IO_ERROR after send loop

### DIFF
--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -101,6 +101,12 @@ impl GeneratorContext {
         // upstream: sender.c:217-218 - rprintf(FINFO, "send_files starting\n")
         debug_log!(Send, 1, "send_files starting");
 
+        // upstream: sender.c:218 - int save_io_error = io_error;
+        // Baseline io_error already conveyed with the file list. Any bits set
+        // beyond this during the send loop (vanished/unreadable source files)
+        // must be reported to the receiver so its exit code reflects them.
+        let save_io_error = self.io_error;
+
         // Phase handling: upstream sender.c line 210: max_phase = protocol_version >= 29 ? 2 : 1
         let mut phase: i32 = 0;
         let max_phase: i32 = if self.protocol.supports_iflags() {
@@ -795,6 +801,20 @@ impl GeneratorContext {
         // upstream: sender.c:457-458
         // rprintf(FINFO, "send files finished\n")
         debug_log!(Send, 1, "send files finished");
+
+        // upstream: sender.c:485-486 - if (io_error != save_io_error &&
+        // protocol_version >= 30) send_msg_int(MSG_IO_ERROR, io_error);
+        // Emitted immediately before NDX_DONE so a remote receiver learns of
+        // vanished/unreadable source files and reports exit 24/23. MSG_NO_SEND
+        // only skips the file; it does not carry the exit-code bits.
+        if self.io_error != save_io_error && self.protocol.supports_generator_messages() {
+            let io_error = self.io_error;
+            if let Err(e) = writer.send_io_error(io_error) {
+                if !(tolerant && is_early_close_error(&e)) {
+                    return Err(e);
+                }
+            }
+        }
 
         // upstream: sender.c:454-462 - after the transfer loop exits, the sender
         // sends io_error (if changed) and a final NDX_DONE. This NDX_DONE is the

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -244,6 +244,37 @@ fn server_reader_take_io_error_plain_returns_zero() {
     assert_eq!(reader.take_io_error(), 0);
 }
 
+/// The receiver folds a sender's MSG_IO_ERROR into its exit-code io_error so a
+/// remote pull that loses a source file mid-transfer reports the right code:
+/// IOERR_VANISHED -> 24, IOERR_GENERAL -> 23. This is the value the receiver
+/// transfer path ORs via `stats.io_error |= reader.take_io_error()`.
+/// upstream: io.c:1547 `io_error |= val`; log.c `log_exit` maps to RERR_*.
+#[test]
+fn server_reader_io_error_drives_receiver_exit_code() {
+    use crate::generator::io_error_flags::{IOERR_GENERAL, IOERR_VANISHED, to_exit_code};
+
+    for (bits, expected) in [(IOERR_VANISHED, 24), (IOERR_GENERAL, 23)] {
+        let mut stream = Vec::new();
+        protocol::send_msg(
+            &mut stream,
+            protocol::MessageCode::IoError,
+            &bits.to_le_bytes(),
+        )
+        .unwrap();
+        protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"x").unwrap();
+
+        let mut reader = ServerReader::new_plain(Cursor::new(stream))
+            .activate_multiplex()
+            .unwrap();
+        let mut buf = [0u8; 1];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(&buf, b"x");
+
+        assert_eq!(to_exit_code(reader.take_io_error()), expected);
+    }
+}
+
 #[test]
 fn server_reader_take_io_error_multiplex_accumulates() {
     let mut stream = Vec::new();

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -275,6 +275,13 @@ impl ReceiverContext {
 
         self.finalize_transfer(reader, writer)?;
 
+        // upstream: io.c:1547 - io_error |= val on MSG_IO_ERROR from the sender.
+        // The sender emits MSG_IO_ERROR (sender.c:485-486) for source files that
+        // vanished or could not be opened during its send loop. Fold those bits
+        // into the exit-code io_error so the receiver reports 24/23; MSG_NO_SEND
+        // alone only skips the file and carries no exit-code bits.
+        stats.io_error |= reader.take_io_error();
+
         let total_source_bytes: u64 = self.file_list.iter().map(|e| e.size()).sum();
 
         stats.files_transferred = files_transferred;

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -292,6 +292,13 @@ impl ReceiverContext {
 
         self.finalize_transfer(reader, writer)?;
 
+        // upstream: io.c:1547 - io_error |= val on MSG_IO_ERROR from the sender.
+        // The sender emits MSG_IO_ERROR (sender.c:485-486) for source files that
+        // vanished or could not be opened during its send loop. Fold those bits
+        // into the exit-code io_error so the receiver reports 24/23; MSG_NO_SEND
+        // alone only skips the file and carries no exit-code bits.
+        stats.io_error |= reader.take_io_error();
+
         Ok(stats)
     }
 }

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -548,6 +548,13 @@ impl ReceiverContext {
 
         self.finalize_transfer(reader, writer)?;
 
+        // upstream: io.c:1547 - io_error |= val on MSG_IO_ERROR from the sender.
+        // The sender emits MSG_IO_ERROR (sender.c:485-486) for source files that
+        // vanished or could not be opened during its send loop. Fold those bits
+        // into the exit-code io_error so the receiver reports 24/23; MSG_NO_SEND
+        // alone only skips the file and carries no exit-code bits.
+        let sender_io_error = reader.take_io_error();
+
         let total_source_bytes: u64 = self.file_list.iter().map(|e| e.size()).sum();
 
         Ok(TransferStats {
@@ -558,7 +565,8 @@ impl ReceiverContext {
             total_source_bytes,
             metadata_errors,
             io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
-                | self.flist_io_error,
+                | self.flist_io_error
+                | sender_io_error,
             error_count: 0,
             entries_received: 0,
             directories_created: 0,

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -219,6 +219,29 @@ impl<W: Write> ServerWriter<W> {
         self.send_message(MessageCode::Redo, &ndx.to_le_bytes())
     }
 
+    /// Sends a `MSG_IO_ERROR` message carrying the accumulated io_error bits.
+    ///
+    /// After the transfer loop, the sender reports any io_error accumulated
+    /// beyond the baseline already conveyed with the file list (vanished or
+    /// unreadable source files discovered mid-transfer). The receiver ORs this
+    /// value into its own io_error, which drives the final exit code (24 for
+    /// `IOERR_VANISHED`, 23 for `IOERR_GENERAL`). `MSG_NO_SEND` alone only tells
+    /// the receiver to skip the file; it does not carry the exit-code bits.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:485-486`: `if (io_error != save_io_error && protocol_version >= 30)
+    ///   send_msg_int(MSG_IO_ERROR, io_error);` immediately before `write_ndx(NDX_DONE)`.
+    /// - `io.c:1542-1549`: receiver handler ORs the value into `io_error`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the writer is not in multiplex mode or the underlying
+    /// I/O operation fails.
+    pub fn send_io_error(&mut self, io_error: i32) -> io::Result<()> {
+        self.send_message(MessageCode::IoError, &io_error.to_le_bytes())
+    }
+
     /// Attaches a batch recorder for capturing compressed protocol data.
     ///
     /// The recorder is always attached to the `MultiplexWriter` so it captures

--- a/crates/transfer/src/writer/tests.rs
+++ b/crates/transfer/src/writer/tests.rs
@@ -479,6 +479,41 @@ fn server_writer_send_redo_plain_mode_fails() {
     assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidInput);
 }
 
+/// A remote receiver only learns of vanished/unreadable source files - and thus
+/// reports exit 24/23 - if the sender emits `MSG_IO_ERROR` with the io_error
+/// bits as a 4-byte LE payload (upstream sender.c:485-486, io.c:1542-1549).
+/// `MSG_NO_SEND` alone carries no exit-code bits. This pins the wire encoding a
+/// real upstream receiver folds via `io_error |= val`.
+#[test]
+fn server_writer_send_io_error_frame_encoding() {
+    let mut buf = Vec::new();
+    {
+        let mut writer = ServerWriter::new_plain(&mut buf)
+            .activate_multiplex()
+            .unwrap();
+        // IOERR_VANISHED (1) | IOERR_GENERAL (2) = 3.
+        writer.send_io_error(3).unwrap();
+    }
+    assert_eq!(buf.len(), 8, "one 4-byte header + 4-byte payload frame");
+    let header = protocol::MessageHeader::decode(&buf[0..4]).unwrap();
+    assert_eq!(
+        header.code(),
+        MessageCode::IoError,
+        "frame tag must be MSG_IO_ERROR"
+    );
+    assert_eq!(header.payload_len(), 4);
+    assert_eq!(&buf[4..8], &3_i32.to_le_bytes(), "io_error as 4-byte LE");
+}
+
+#[test]
+fn server_writer_send_io_error_plain_mode_fails() {
+    let mut buf = Vec::new();
+    let mut writer = ServerWriter::new_plain(&mut buf);
+    let result = writer.send_io_error(3);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidInput);
+}
+
 #[test]
 fn msg_info_sender_plain_mode_noop() {
     let mut buf = Vec::new();


### PR DESCRIPTION
## Problem

A server-sender accumulates `io_error` during its send loop when source files
vanish or cannot be opened (per-file open/fstat failures on files that existed
at flist-build time - `record_open_failure` OR's `IOERR_VANISHED`/`IOERR_GENERAL`).
It sends per-file `MSG_NO_SEND`, but it never emitted `MSG_IO_ERROR` after the
loop. A remote receiver pulling from an oc server that lost a source file
mid-transfer therefore reported exit 0 instead of 24 (vanished) / 23 (partial).

`MSG_NO_SEND` only tells the receiver to skip the file; it does not carry the
`io_error` bits that drive the exit code.

## Fix

Mirror upstream `sender.c:485-486`:

```c
if (io_error != save_io_error && protocol_version >= 30)
    send_msg_int(MSG_IO_ERROR, io_error);
```

- Capture the flist baseline `save_io_error = io_error` at `send_files` entry
  (`run_transfer_loop`).
- After the transfer loop, if `io_error` changed and `protocol_version >= 30`,
  emit exactly one `MSG_IO_ERROR` frame carrying `io_error` as a 4-byte LE
  payload over the multiplex channel, immediately before `NDX_DONE`. Framing is
  byte-exact with upstream (tag `MSG_IO_ERROR` = 22, 4-byte LE), so a real
  upstream receiver folds it via `io_error |= val` (`io.c:1547`).

This is the primary interop win: oc-sender -> real-upstream-receiver now
reports the correct exit code.

## Receiver round-trip (oc<->oc)

The multiplex reader already accumulated `MSG_IO_ERROR` into its `io_error`
(`take_io_error`), but no non-test caller ever drained it. The three sync
receiver transfer paths now fold `reader.take_io_error()` into the exit-code
`io_error`, so an oc receiver also reports 24/23. The async receiver drivers
(`tokio-transfer` / `async-bench`, `#[allow(dead_code)]`) are experimental
benchmark paths and are unchanged; the production receiver is the sync path.

## Constraints honored

- Protocol >= 30 only (gated on `supports_generator_messages()`); `< 30`
  keeps existing behavior.
- Full `io_error` value sent (matches upstream); receiver OR is idempotent
  against the flist baseline, so no double-count.
- `MSG_NO_SEND` behavior and `NDX_DONE` ordering unchanged - the emit is
  inserted immediately before `NDX_DONE`.

## Tests

- Writer frame encoding: `send_io_error` produces one frame with tag
  `MSG_IO_ERROR` and a 4-byte LE payload; plain (non-multiplex) mode errors.
- Receiver exit-code fold: a received `MSG_IO_ERROR` carrying `IOERR_VANISHED`
  maps to exit 24 and `IOERR_GENERAL` to 23 through `take_io_error` +
  `to_exit_code`, encoding why a remote receiver must learn of vanished/failed
  source files.

## Validation

- `cargo build --release --bin oc-rsync` - success
- `cargo fmt --all` - clean
- `cargo clippy -p transfer --all-features --no-deps -- -D warnings` - clean

Upstream references: `sender.c:send_files` (MSG_IO_ERROR emit before NDX_DONE),
`io.c:1542-1549` (receiver fold).
