### PR TITLE
fix(metadata): mirror upstream usermap numeric-range parsing

### DIFF
--- a/crates/metadata/src/mapping/parse.rs
+++ b/crates/metadata/src/mapping/parse.rs
@@ -6,8 +6,6 @@
 //! including numeric IDs, numeric ranges, exact names, and wildcard patterns.
 //! Mirrors upstream rsync's `uidlist.c` parsing.
 
-use std::cmp::Ordering;
-
 use super::types::{MappingKind, MappingMatcher, MappingParseError, MappingTarget};
 
 /// Parses the source (left-hand) side of a mapping entry.
@@ -25,16 +23,25 @@ use super::types::{MappingKind, MappingMatcher, MappingParseError, MappingTarget
 /// `noiu.name = ""`, matching the nameless id (recv_add_id normalizes a missing
 /// name to "" before the strcmp).
 pub(crate) fn parse_matcher(
-    _kind: MappingKind,
+    kind: MappingKind,
     source: &str,
-    _entry: &str,
+    entry: &str,
 ) -> Result<MappingMatcher, MappingParseError> {
     if source == "*" {
         return Ok(MappingMatcher::Any);
     }
 
-    if let Some((start, end)) = parse_numeric_range(source) {
-        return Ok(MappingMatcher::IdRange { start, end });
+    // upstream: uidlist.c:parse_name_map - isDigit(cp) tests only the first
+    // character. Once a source begins with a digit it must be a valid number or
+    // numeric range; any other content is a fatal syntax error, never a name.
+    if source.starts_with(|ch: char| ch.is_ascii_digit()) {
+        return match parse_numeric_range(source) {
+            Some((start, end)) => Ok(MappingMatcher::IdRange { start, end }),
+            None => Err(MappingParseError::new(
+                kind,
+                format!("Invalid number in {}: {}", kind.flag(), entry),
+            )),
+        };
     }
 
     if source.chars().any(|ch| matches!(ch, '*' | '?' | '[')) {
@@ -47,8 +54,12 @@ pub(crate) fn parse_matcher(
 /// Parses a numeric value or range from a source string.
 ///
 /// Returns `Some((start, end))` for single values (where `start == end`) and
-/// `start-end` ranges. Reversed ranges (`end-start`) are normalized so
-/// `start <= end`. Returns `None` for any non-numeric or malformed input.
+/// `start-end` ranges. Returns `None` for any non-numeric or malformed input.
+///
+/// A reversed range (`end-start`) is preserved verbatim as `(start, end)` with
+/// `start > end`, so it matches no identifier. upstream: uidlist.c:parse_name_map
+/// stores `id1`/`max_id` unswapped, and the match test (`id < node->id || id >
+/// node->u.max_id`) then rejects every id when `from > to`.
 pub(super) fn parse_numeric_range(source: &str) -> Option<(u32, u32)> {
     let mut parts = source.split('-');
     let start = parts.next()?;
@@ -63,11 +74,7 @@ pub(super) fn parse_numeric_range(source: &str) -> Option<(u32, u32)> {
         }
         let start_value = start.parse::<u32>().ok()?;
         let end_value = rest.parse::<u32>().ok()?;
-        let (start, end) = match start_value.cmp(&end_value) {
-            Ordering::Greater => (end_value, start_value),
-            _ => (start_value, end_value),
-        };
-        Some((start, end))
+        Some((start_value, end_value))
     } else {
         start.parse::<u32>().ok().map(|value| (value, value))
     }

--- a/crates/metadata/src/mapping/tests.rs
+++ b/crates/metadata/src/mapping/tests.rs
@@ -244,8 +244,41 @@ fn numeric_range_two_values() {
 }
 
 #[test]
-fn numeric_range_reversed_values() {
-    assert_eq!(parse_numeric_range("200-100"), Some((100, 200)));
+fn numeric_range_reversed_values_preserved() {
+    // upstream: uidlist.c:parse_name_map stores id1/max_id unswapped, so a
+    // reversed range keeps start > end and consequently matches no id.
+    assert_eq!(parse_numeric_range("200-100"), Some((200, 100)));
+}
+
+#[test]
+fn reversed_range_matches_nothing() {
+    // A reversed numeric range (`from > to`) must match no identifier, mirroring
+    // upstream's `id < node->id || id > node->u.max_id` test which rejects every
+    // id when from > to. Without this, silently swapping would over-map ids.
+    let matcher = parse_matcher(MappingKind::User, "500-400", "500-400:0").unwrap();
+    assert_eq!(
+        matcher,
+        MappingMatcher::IdRange {
+            start: 500,
+            end: 400
+        }
+    );
+    for id in [399, 400, 450, 500, 501] {
+        assert!(!matcher.matches(id, || Ok(None)).unwrap());
+    }
+}
+
+#[test]
+fn malformed_numeric_source_is_fatal() {
+    // upstream: uidlist.c:parse_name_map - once a source begins with a digit it
+    // must be a valid number/range; junk digits are a fatal syntax error, not a
+    // name to be looked up. `12x` and `1*` must both fail to parse.
+    for source in ["12x", "1*", "100-abc", "100-", "1-2-3"] {
+        let entry = format!("{source}:0");
+        let error = parse_matcher(MappingKind::User, source, &entry)
+            .expect_err("malformed numeric source must be a hard error");
+        assert!(error.to_string().contains("Invalid number"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix two `--usermap`/`--groupmap` numeric-range parsing divergences from upstream rsync 3.4.4 (`uidlist.c:parse_name_map`).

## Divergences fixed

### 1. Reversed numeric range must match nothing

Upstream stores `id1` (start) and `max_id` (end) unswapped (`uidlist.c:529-535`). The runtime match test (`uidlist.c:262-264`) is `id < node->id || id > node->u.max_id`, which rejects every id when `from > to`. A reversed range such as `500-400:GID` therefore matches no identifier.

oc previously normalized reversed ranges by swapping endpoints, so `500-400` matched `400..=500`. The parser now preserves the range verbatim (`start > end`), and `MappingMatcher::IdRange` (`start..=end`) then matches nothing, mirroring upstream.

### 2. Malformed numeric source is a fatal syntax error, not a name

Upstream gates on `isDigit(cp)`, which tests only the first character (`uidlist.c:521`). Once a source begins with a digit it must be a valid number or `start-end` range; otherwise `uidlist.c:523-527` raises `Invalid number` and exits with `RERR_SYNTAX`. `id_parse` (`uidlist.c:76-94`) likewise rejects non-digit content.

oc previously treated a malformed digit-leading source (e.g. `12x`, `1*`) as a name or wildcard pattern. Digit-leading sources are now routed through the numeric parser, and invalid content produces an `Invalid number` parse error instead of silently falling through to a name.

## Tests

- `numeric_range_reversed_values_preserved` - reversed range is kept unswapped.
- `reversed_range_matches_nothing` - a reversed range matches no id across a spread of values.
- `malformed_numeric_source_is_fatal` - `12x`, `1*`, `100-abc`, `100-`, `1-2-3` all fail with `Invalid number`.

## Validation

- `cargo fmt --all -- --check` clean.
- `cargo clippy -p metadata --all-targets --all-features --no-deps -- -D warnings` clean.
