### PR TITLE
fix(protocol): reject flist entries with invalid mode type bits

### DIFF
--- a/crates/protocol/src/flist/read/metadata.rs
+++ b/crates/protocol/src/flist/read/metadata.rs
@@ -107,6 +107,21 @@ impl FileListReader {
             self.state.update_mode(mode);
             mode
         };
+        // upstream: flist.c:876-892 recv_file_entry() - reject any mode whose
+        // S_IFMT type bits are not one of the standard file types, so a garbage
+        // or malicious mode cannot propagate into the downstream S_ISxxx checks.
+        // Upstream validates the FINAL resolved mode, whether freshly read or
+        // inherited via XMIT_SAME_MODE, so the check lives outside the branch.
+        // mode 0 is the sole exception, and only under --delete-missing-args
+        // (missing_args == 2), the mode-0 sentinel for a vanished arg (flist.c:2257).
+        if !(mode == 0 && self.delete_missing_args)
+            && crate::flist::FileType::from_mode(mode).is_none()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid file mode 0{mode:o}"),
+            ));
+        }
 
         // Determine if this is a directory (needed for atime and content_dir)
         let is_dir = (mode & 0o170000) == 0o040000;

--- a/crates/protocol/src/flist/read/mod.rs
+++ b/crates/protocol/src/flist/read/mod.rs
@@ -81,6 +81,12 @@ pub struct FileListReader {
     preserve_atimes: bool,
     /// Whether to preserve (and thus read) creation times from the wire.
     preserve_crtimes: bool,
+    /// Whether `--delete-missing-args` is active (upstream `missing_args == 2`).
+    ///
+    /// When true, a mode-0 sentinel entry is legitimate and bypasses the
+    /// file-mode type-bit validation performed while reading each entry.
+    /// upstream: flist.c:recv_file_entry() line 884 `missing_args != 2`.
+    delete_missing_args: bool,
     /// Whether sender is in checksum mode (--checksum / -c).
     always_checksum: bool,
     /// Whether to preserve (and thus read) ACLs from the wire.
@@ -163,6 +169,7 @@ impl FileListReader {
             preserve_hard_links: false,
             preserve_atimes: false,
             preserve_crtimes: false,
+            delete_missing_args: false,
             always_checksum: false,
             preserve_acls: false,
             preserve_xattrs: false,
@@ -198,6 +205,7 @@ impl FileListReader {
             preserve_hard_links: false,
             preserve_atimes: false,
             preserve_crtimes: false,
+            delete_missing_args: false,
             always_checksum: false,
             preserve_acls: false,
             preserve_xattrs: false,
@@ -278,6 +286,17 @@ impl FileListReader {
     #[must_use]
     pub const fn with_preserve_crtimes(mut self, preserve: bool) -> Self {
         self.preserve_crtimes = preserve;
+        self
+    }
+
+    /// Sets whether `--delete-missing-args` is active.
+    ///
+    /// When enabled, a mode-0 sentinel entry (upstream `missing_args == 2`) is
+    /// accepted instead of being rejected by the file-mode type-bit validation.
+    #[inline]
+    #[must_use]
+    pub const fn with_delete_missing_args(mut self, enabled: bool) -> Self {
+        self.delete_missing_args = enabled;
         self
     }
 

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -1097,17 +1097,24 @@ fn truncated_user_name_length() {
 #[test]
 fn truncated_user_name_data() {
     use crate::flist::flags::XMIT_USER_NAME_FOLLOWS;
-    use crate::varint::encode_varint_to_vec;
+    use crate::varint::{encode_varint_to_vec, write_varlong};
 
-    let flags_value = (0x01) | ((XMIT_USER_NAME_FOLLOWS as i32) << 8);
+    // The size and mtime fields are variable-length (varlong30 / varlong) on
+    // protocol >= 30, so they must be written with the real encoders for the
+    // rest of the entry to stay byte-aligned. A prior hand-rolled layout used
+    // single bytes for size/mtime, which left the mode field mis-aligned and
+    // read a garbage type - now caught by the entry mode-type validation. Here
+    // the mode is a valid regular file, so the decode reaches the truncated
+    // user-name blob and surfaces UnexpectedEof, the behaviour under test.
+    let flags_value = 0x01 | ((XMIT_USER_NAME_FOLLOWS as i32) << 8);
     let mut data = Vec::new();
     encode_varint_to_vec(flags_value, &mut data);
     data.push(4u8);
     data.extend_from_slice(b"file");
-    data.push(100u8);
-    data.push(0u8);
-    data.extend_from_slice(&0o100644u32.to_le_bytes());
-    data.push(100u8); // UID
+    write_varlong(&mut data, 100, 3).unwrap(); // size
+    write_varlong(&mut data, 0, 4).unwrap(); // mtime
+    data.extend_from_slice(&0o100644u32.to_le_bytes()); // mode: regular file
+    encode_varint_to_vec(100, &mut data); // UID (varint on protocol >= 30)
     data.push(10u8); // User name length: 10
     data.extend_from_slice(b"user"); // Only 4 of 10 bytes
 
@@ -1575,6 +1582,92 @@ fn read_write_end_of_list_nonvarint_round_trip_exact_bytes() {
         buf.len(),
         "must consume all written bytes"
     );
+}
+
+/// Serializes a single entry whose file type nibble has been forced to `mode`.
+///
+/// The entry is built as a regular file, then `set_mode` overrides the mode
+/// field so the writer emits an arbitrary (possibly bogus) type on the wire.
+/// This lets the reader-side type validation be exercised in isolation.
+fn entry_bytes_with_mode(protocol: ProtocolVersion, mode: u32) -> Vec<u8> {
+    use crate::flist::write::FileListWriter;
+
+    let mut data = Vec::new();
+    let mut writer = FileListWriter::new(protocol);
+    let mut entry = FileEntry::new_file("x".into(), 0, 0o100644);
+    entry.set_mtime(1700000000, 0);
+    entry.set_mode(mode);
+    writer.write_entry(&mut data, &entry).unwrap();
+    data
+}
+
+/// upstream: flist.c:876-892 recv_file_entry() rejects any file mode whose
+/// S_IFMT type bits are not a standard file type. Without this a malicious or
+/// buggy sender could smuggle a garbage mode past the downstream S_ISxxx
+/// checks; oc previously coerced unknown types to Regular. `0o070000` is an
+/// unused S_IFMT nibble, so the entry must be refused as protocol garbage.
+#[test]
+fn read_entry_rejects_invalid_mode_type() {
+    let protocol = test_protocol();
+    let data = entry_bytes_with_mode(protocol, 0o070644);
+
+    let mut cursor = Cursor::new(&data[..]);
+    let mut reader = FileListReader::new(protocol);
+    let err = reader.read_entry(&mut cursor).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+/// Every standard S_IFMT type (reg/dir/lnk/chr/blk/fifo/sock) stays acceptable,
+/// so the hardening in `read_entry_rejects_invalid_mode_type` never rejects a
+/// legitimate entry. upstream: flist.c:885-887 S_ISREG/DIR/LNK/CHR/BLK/FIFO/SOCK.
+#[test]
+fn read_entry_accepts_all_standard_mode_types() {
+    let protocol = test_protocol();
+    // S_IFREG, S_IFDIR, S_IFLNK, S_IFCHR, S_IFBLK, S_IFIFO, S_IFSOCK with perms.
+    let modes = [
+        0o100644, 0o040755, 0o120777, 0o020660, 0o060660, 0o010644, 0o140755,
+    ];
+    for mode in modes {
+        let data = entry_bytes_with_mode(protocol, mode);
+        let mut cursor = Cursor::new(&data[..]);
+        let mut reader = FileListReader::new(protocol);
+        let entry = reader
+            .read_entry(&mut cursor)
+            .unwrap_or_else(|e| panic!("mode {mode:o} must be accepted: {e}"))
+            .expect("entry present");
+        assert_eq!(entry.mode(), mode, "mode {mode:o} must round-trip");
+    }
+}
+
+/// upstream: flist.c:884 - the mode-0 sentinel (a vanished source arg) is only
+/// legitimate under `--delete-missing-args` (missing_args == 2). With the flag
+/// set, the sentinel is accepted rather than rejected as an invalid type.
+#[test]
+fn read_entry_accepts_mode_zero_sentinel_with_delete_missing_args() {
+    let protocol = test_protocol();
+    let data = entry_bytes_with_mode(protocol, 0);
+
+    let mut cursor = Cursor::new(&data[..]);
+    let mut reader = FileListReader::new(protocol).with_delete_missing_args(true);
+    let entry = reader
+        .read_entry(&mut cursor)
+        .expect("mode-0 sentinel accepted")
+        .expect("entry present");
+    assert_eq!(entry.mode(), 0);
+}
+
+/// Without `--delete-missing-args` a mode-0 entry is not a sentinel and its
+/// (empty) type bits are invalid, so upstream rejects it - as must oc.
+/// upstream: flist.c:884 `mode != 0 || missing_args != 2`.
+#[test]
+fn read_entry_rejects_mode_zero_without_delete_missing_args() {
+    let protocol = test_protocol();
+    let data = entry_bytes_with_mode(protocol, 0);
+
+    let mut cursor = Cursor::new(&data[..]);
+    let mut reader = FileListReader::new(protocol);
+    let err = reader.read_entry(&mut cursor).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
 }
 
 /// Tests for ACL integration in the flist read path.

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -511,6 +511,7 @@ impl ReceiverContext {
         .with_preserve_acls(self.config.flags.acls)
         .with_preserve_xattrs(self.config.flags.xattrs)
         .with_preserve_atimes(self.config.flags.atimes)
+        .with_delete_missing_args(self.config.file_selection.delete_missing_args)
         .with_relative_paths(self.config.flags.relative);
 
         // upstream: flist.c - always_checksum includes per-file checksums in the file list


### PR DESCRIPTION
## Summary

Harden the file-list receive path against garbage or malicious file modes.
Upstream `recv_file_entry()` (`flist.c:876-892`) rejects any entry whose
`S_IFMT` type bits are not one of the standard file types
(`S_ISREG`/`S_ISDIR`/`S_ISLNK`/`S_ISCHR`/`S_ISBLK`/`S_ISFIFO`/`S_ISSOCK`),
calling `exit_cleanup(RERR_PROTOCOL)` with `invalid file mode 0%o`. The only
exception is `mode == 0` when `missing_args == 2` (the `--delete-missing-args`
mode-0 sentinel, `flist.c:2257`).

oc-rsync previously read the mode via `from_wire_mode()` with no type-bit
validation and silently coerced unrecognized types to `Regular`
(`FileType::from_mode()` returns `None` -> `unwrap_or(Regular)`), letting a
buggy or hostile sender smuggle a garbage mode into the downstream file-type
checks.

## Change

- Add S_IFMT type-bit validation in the flist metadata read
  (`crates/protocol/src/flist/read/metadata.rs`): an unrecognized mode type is
  rejected as an `InvalidData` error, mirroring the crate's malformed-flist
  error path. Reuses `FileType::from_mode()` as the recognized-type predicate.
- Preserve the upstream exception: `mode == 0` is accepted only when
  `--delete-missing-args` is active. Threaded via a new
  `FileListReader::with_delete_missing_args()` builder, wired from the receiver
  context (`config.file_selection.delete_missing_args`).

No change to valid-entry encoding or decoding; this only adds rejection of
invalid mode types. Golden byte tests for valid flists are unaffected.

## Tests

- A mode with a bogus type nibble (`0o070000`) is rejected as `InvalidData`.
- Every standard type (reg/dir/lnk/chr/blk/fifo/sock) is still accepted and
  round-trips.
- The `mode == 0` sentinel is accepted with `--delete-missing-args` and
  rejected without it.

## Validation

- `cargo fmt --all` clean.
- `cargo clippy -p protocol --all-targets --all-features --no-deps -D warnings`
  clean; `cargo clippy -p transfer` clean.

Reference: `flist.c:recv_file_entry()` (lines 876-892), `flist.c:2257`.
