### PR TITLE
fix(filters): accept comma/tab/underscore rule separators

### DIFF
--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -430,6 +430,14 @@ fn try_parse_short_form(
         return Ok(None);
     };
 
+    // upstream: exclude.c:1176-1179 - in the default (single-character prefix)
+    // case, a comma immediately after the prefix is consumed as a separator
+    // (`if (s[1] == ',') s++;`) so the modifier loop begins after it. This lets
+    // `+,x pattern` be written as an equivalent of `+x pattern`. Only the comma
+    // directly after the prefix is a separator; a later comma remains an
+    // invalid modifier, exactly as upstream reports.
+    let rest = rest.strip_prefix(',').unwrap_or(rest);
+
     // upstream: exclude.c:1136 - `prefix_specifies_side` is set for the H/S
     // (sender) and P/R (receiver) prefixes, gating the `s`/`r` modifiers.
     let prefix_specifies_side = matches!(prefix_char, 'H' | 'S' | 'P' | 'R');
@@ -461,38 +469,94 @@ fn try_parse_short_form(
     }))
 }
 
+/// Returns true for the characters upstream `isspace()` treats as whitespace in
+/// the C locale (space, tab, newline, vertical tab, form feed, carriage return).
+///
+/// Rust's [`char::is_ascii_whitespace`] omits the vertical tab, so this mirrors
+/// the C set exactly for `rule_strcmp` separator detection.
+fn is_c_isspace(ch: char) -> bool {
+    matches!(ch, ' ' | '\t' | '\n' | '\x0b' | '\x0c' | '\r')
+}
+
 /// Tries to parse a long-form rule (keyword prefix like `include`, `exclude`).
 ///
-/// Returns `Some(rule)` if the line matches a long-form pattern, `None` otherwise.
+/// Returns `Ok(Some(rule))` if the line matches a long-form keyword, `Ok(None)`
+/// if no keyword matched, or `Err` if a keyword was followed by a comma and an
+/// invalid modifier.
 ///
-/// upstream: exclude.c:parse_filter_str() - long-form keyword handling
-fn try_parse_long_form(line: &str) -> Option<FilterRule> {
-    let lower = line.to_ascii_lowercase();
-
-    let keywords: &[(&str, usize, ShortFormAction)] = &[
-        ("include ", 8, ShortFormAction::Include),
-        ("exclude ", 8, ShortFormAction::Exclude),
-        ("protect ", 8, ShortFormAction::Protect),
-        ("risk ", 5, ShortFormAction::Risk),
-        ("merge ", 6, ShortFormAction::Merge),
-        ("dir-merge ", 10, ShortFormAction::DirMerge),
-        ("hide ", 5, ShortFormAction::Hide),
-        ("show ", 5, ShortFormAction::Show),
+/// upstream: exclude.c:1069-1078 rule_strcmp - a keyword matches only when it is
+/// followed by one of the accepted separators: whitespace, `_`, `,`, or the end
+/// of the string. Whitespace/`_`/end terminate the keyword and the remaining
+/// text is the pattern verbatim; a `,` instead introduces modifiers, which are
+/// parsed by the same modifier loop as short-form prefixes (exclude.c:1138-1289).
+fn try_parse_long_form(
+    line: &str,
+    source_path: &Path,
+    line_num: usize,
+) -> Result<Option<FilterRule>, MergeFileError> {
+    const KEYWORDS: &[(&str, ShortFormAction)] = &[
+        ("include", ShortFormAction::Include),
+        ("exclude", ShortFormAction::Exclude),
+        ("protect", ShortFormAction::Protect),
+        ("risk", ShortFormAction::Risk),
+        ("merge", ShortFormAction::Merge),
+        ("dir-merge", ShortFormAction::DirMerge),
+        ("hide", ShortFormAction::Hide),
+        ("show", ShortFormAction::Show),
     ];
 
-    for &(keyword, len, action) in keywords {
-        if lower.starts_with(keyword) {
-            // upstream: exclude.c:1290-1313 - RULE_STRCMP matches the keyword and
-            // its single trailing separator, then strlen takes the rest of the
-            // line verbatim. The keyword table already includes that one
-            // separator, so the remainder must not be trimmed: trailing (and
-            // any embedded) whitespace stays part of the pattern.
-            let pattern = &line[len..];
-            return Some(action.to_rule(pattern));
+    let bytes = line.as_bytes();
+    for &(keyword, action) in KEYWORDS {
+        let klen = keyword.len();
+        if bytes.len() < klen || !bytes[..klen].eq_ignore_ascii_case(keyword.as_bytes()) {
+            continue;
+        }
+        // The matched prefix is all ASCII, so `klen` is a valid char boundary.
+        let after = &line[klen..];
+        match after.chars().next() {
+            // upstream: rule_strcmp returns `str + rule_len` for `,`, so the
+            // modifier loop begins after the comma (e.g. `dir-merge,n .filt`).
+            Some(',') => {
+                let prefix_specifies_side = matches!(
+                    action,
+                    ShortFormAction::Hide
+                        | ShortFormAction::Show
+                        | ShortFormAction::Protect
+                        | ShortFormAction::Risk
+                );
+                let (mods, pattern) = parse_modifiers(
+                    &after[','.len_utf8()..],
+                    action.is_merge(),
+                    prefix_specifies_side,
+                    line,
+                    source_path,
+                    line_num,
+                )?;
+                let rule = action.to_rule(pattern);
+                return Ok(Some(if action.supports_mods() {
+                    mods.apply(rule)
+                } else {
+                    rule
+                }));
+            }
+            // upstream: rule_strcmp accepts isspace/`_` as terminating
+            // separators; exactly one is consumed and the remainder is the
+            // pattern verbatim (strlen, no trimming), so trailing and embedded
+            // whitespace stays part of the pattern.
+            Some(ch) if ch == '_' || is_c_isspace(ch) => {
+                let pattern = &after[ch.len_utf8()..];
+                return Ok(Some(action.to_rule(pattern)));
+            }
+            // upstream: rule_strcmp accepts end-of-string (`!str[rule_len]`); the
+            // keyword stands alone and the pattern is empty.
+            None => return Ok(Some(action.to_rule(""))),
+            // Any other trailing byte means this is not the keyword (e.g.
+            // `excludes`); fall through to the next candidate.
+            Some(_) => continue,
         }
     }
 
-    None
+    Ok(None)
 }
 
 /// Parses a single filter rule line.
@@ -513,7 +577,7 @@ fn parse_rule_line(
         return Ok(rule);
     }
 
-    if let Some(rule) = try_parse_long_form(line) {
+    if let Some(rule) = try_parse_long_form(line, source_path, line_num)? {
         return Ok(rule);
     }
 

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -1012,3 +1012,96 @@ fn parse_rules_no_prefixes_line_mode_keeps_whole_line() {
     assert_eq!(rules.len(), 1);
     assert_eq!(rules[0].pattern(), "*.log *.tmp *.bak");
 }
+
+// upstream: exclude.c:1069-1078 rule_strcmp accepts `_` as a keyword separator
+// exactly like a space, so `exclude_*.bak` must parse identically to
+// `exclude *.bak`. Long-form filter files written with `_` separators are a
+// documented rsync convenience and must interoperate.
+#[test]
+fn long_form_keyword_underscore_separator_matches_space_form() {
+    let under = parse_rules("exclude_*.bak", Path::new("test")).unwrap();
+    let space = parse_rules("exclude *.bak", Path::new("test")).unwrap();
+    assert_eq!(under.len(), 1);
+    assert_eq!(under[0].action(), FilterAction::Exclude);
+    assert_eq!(under[0].pattern(), space[0].pattern());
+    assert_eq!(under[0].pattern(), "*.bak");
+}
+
+// upstream: rule_strcmp uses isspace(), which accepts a tab as a separator, so
+// `include<TAB>*.txt` is the same rule as `include *.txt`.
+#[test]
+fn long_form_keyword_tab_separator() {
+    let rules = parse_rules("include\t*.txt", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::Include);
+    assert_eq!(rules[0].pattern(), "*.txt");
+}
+
+// upstream: rule_strcmp accepts end-of-string (`!str[rule_len]`), so a bare
+// keyword with no pattern is a valid rule whose pattern is empty.
+#[test]
+fn long_form_keyword_alone_is_empty_pattern() {
+    let rules = parse_rules("hide", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::Exclude);
+    assert!(rules[0].applies_to_sender());
+    assert!(!rules[0].applies_to_receiver());
+    assert_eq!(rules[0].pattern(), "");
+}
+
+// upstream: rule_strcmp returns `str + rule_len` for a comma, so the modifier
+// loop runs after it. `dir-merge,n .filt` must therefore carry the same
+// no-inherit modifier as the short-form `:n .filt`.
+#[test]
+fn long_form_comma_modifier_matches_short_form() {
+    let long = parse_rules("dir-merge,n .filt", Path::new("test")).unwrap();
+    let short = parse_rules(":n .filt", Path::new("test")).unwrap();
+    assert_eq!(long.len(), 1);
+    assert_eq!(long[0].action(), FilterAction::DirMerge);
+    assert_eq!(long[0].pattern(), ".filt");
+    assert!(long[0].is_no_inherit());
+    assert_eq!(long[0].pattern(), short[0].pattern());
+    assert_eq!(long[0].is_no_inherit(), short[0].is_no_inherit());
+}
+
+// upstream: a comma after a long-form keyword introduces side modifiers just as
+// on a short-form prefix, so `exclude,s foo` is a sender-only exclude of `foo`.
+#[test]
+fn long_form_comma_sender_side_exclude() {
+    let rules = parse_rules("exclude,s foo", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::Exclude);
+    assert_eq!(rules[0].pattern(), "foo");
+    assert!(rules[0].applies_to_sender());
+    assert!(!rules[0].applies_to_receiver());
+}
+
+// upstream: exclude.c:1176-1179 consumes a comma immediately after a
+// single-character prefix, so `+,p foo` is the same perishable include as the
+// directly-adjacent `+p foo`.
+#[test]
+fn short_form_prefix_comma_separator_matches_plain() {
+    let comma = parse_rules("+,p foo", Path::new("test")).unwrap();
+    let plain = parse_rules("+p foo", Path::new("test")).unwrap();
+    assert_eq!(comma.len(), 1);
+    assert_eq!(comma[0].action(), FilterAction::Include);
+    assert_eq!(comma[0].pattern(), "foo");
+    assert!(comma[0].is_perishable());
+    assert_eq!(comma[0].is_perishable(), plain[0].is_perishable());
+}
+
+// upstream: only the comma directly after the prefix is a separator; a comma
+// later in the modifier run is an invalid modifier and must be rejected, so the
+// `,` in `-p,x foo` is a syntax error just like in upstream rsync.
+#[test]
+fn short_form_comma_not_after_prefix_is_invalid() {
+    assert!(parse_rules("-p,x foo", Path::new("test")).is_err());
+}
+
+// upstream: a keyword followed by a non-separator byte is not that keyword, so
+// `excludes foo` is not an exclude rule and falls through to "Unknown filter
+// rule" rather than silently matching `exclude`.
+#[test]
+fn long_form_keyword_without_separator_is_unknown() {
+    assert!(parse_rules("excludes foo", Path::new("test")).is_err());
+}


### PR DESCRIPTION
## Summary

Filter-rule parsing accepted only a space between a long-form rule keyword and
its pattern, and rejected a comma directly after a short-form prefix. Upstream
`exclude.c:rule_strcmp` (lines 1069-1078) accepts a wider separator set, so
valid filter files written for upstream rsync failed to parse here.

This aligns the `filters` crate with upstream's separator handling.

## Upstream reference

`rule_strcmp()` (exclude.c:1069-1078) matches a keyword when the following
character is one of:

- `isspace()` (space, tab, newline, vertical tab, form feed, carriage return)
- `_` (underscore)
- `,` (comma) - returns the pointer at the comma so the modifier loop begins
  after it
- end-of-string

The single-character-prefix path (exclude.c:1176-1179) additionally consumes a
comma that immediately follows the prefix (`if (s[1] == ',') s++;`).

## Changes

- **Long-form keywords** (`include`, `exclude`, `protect`, `risk`, `merge`,
  `dir-merge`, `hide`, `show`): accept any `isspace` char, `_`, `,`, or
  end-of-string after the keyword. A `,` now routes the remainder through the
  shared modifier loop, so `dir-merge,n .filt` and `exclude,s foo` parse
  correctly. Whitespace/`_`/end terminate the keyword and the remainder is the
  pattern verbatim (one separator consumed, no trimming - matching upstream's
  `strlen`).
- **Short-form prefixes**: consume a comma immediately after the prefix, so
  `+,p foo` is equivalent to `+p foo`. A later comma remains an invalid
  modifier, exactly as upstream reports.

Separator set mirrored: space, tab, `\n`, `\v`, `\f`, `\r`, `_`, `,`, and
end-of-string. (`=` is not a `rule_strcmp` separator and is not accepted.)

## Tests

Added unit tests encoding upstream filter-file interoperability: underscore and
tab keyword separators, bare-keyword empty pattern, `dir-merge,n .filt` equals
`:n .filt`, `exclude,s foo` sender-side, `+,p foo` equals `+p foo`, and the
negative cases (`-p,x foo` invalid modifier, `excludes foo` unknown rule).

`cargo fmt --all -- --check` and
`cargo clippy -p filters --all-targets --all-features --no-deps -- -D warnings`
both pass.
