### PR TITLE
fix(batch): enforce iconv batch-flag match and honor from0 in .sh

### DIFF
--- a/crates/batch/src/error.rs
+++ b/crates/batch/src/error.rs
@@ -23,6 +23,13 @@ pub enum BatchError {
     /// Operation not supported.
     #[error("Unsupported operation: {0}")]
     Unsupported(String),
+    /// A data-stream-affecting flag in the batch file cannot be reconciled
+    /// with the active options and upstream treats the mismatch as fatal.
+    ///
+    /// upstream: batch.c:137-142 - an `--iconv` mismatch aborts with
+    /// `RERR_SYNTAX`.
+    #[error("{0}")]
+    FlagMismatch(String),
 }
 
 #[cfg(test)]

--- a/crates/batch/src/format/flags.rs
+++ b/crates/batch/src/format/flags.rs
@@ -7,6 +7,118 @@
 use std::io::{self, Read, Write};
 
 use super::wire::{read_i32, write_i32};
+use crate::error::{BatchError, BatchResult};
+
+/// Human-readable option names in stream-flag bit order.
+///
+/// Mirrors upstream `batch.c:78-95 flag_name[]` exactly. Index N names the
+/// option carried by bit N of the stream-flags bitmap and is embedded verbatim
+/// in the reconcile notices emitted by [`check_batch_flags`].
+const FLAG_NAMES: [&str; 15] = [
+    "--recurse (-r)",
+    "--owner (-o)",
+    "--group (-g)",
+    "--links (-l)",
+    "--devices (-D)",
+    "--hard-links (-H)",
+    "--checksum (-c)",
+    "--dirs (-d)",
+    "--compress (-z)",
+    "--iconv",
+    "--acls (-A)",
+    "--xattrs (-X)",
+    "--inplace",
+    "--append",
+    "--append-verify",
+];
+
+/// Bit index of the `--iconv` flag - a mismatch here is fatal upstream.
+const ICONV_BIT: usize = 9;
+
+/// Project a [`BatchFlags`] onto the 15-entry bit vector used by
+/// [`check_batch_flags`], in the same order as upstream `batch.c:59-76
+/// flag_ptr[]`.
+fn flag_bits(flags: &BatchFlags) -> [bool; 15] {
+    [
+        flags.recurse,
+        flags.preserve_uid,
+        flags.preserve_gid,
+        flags.preserve_links,
+        flags.preserve_devices,
+        flags.preserve_hard_links,
+        flags.always_checksum,
+        flags.xfer_dirs,
+        flags.do_compression,
+        flags.iconv,
+        flags.preserve_acls,
+        flags.preserve_xattrs,
+        flags.inplace,
+        flags.append,
+        flags.append_verify,
+    ]
+}
+
+/// Reconcile the currently-active options against a batch file's recorded
+/// stream flags.
+///
+/// `recorded` is the stream-flags bitmap read from the batch header; `active`
+/// is the flag state derived from the current `--read-batch` invocation. For
+/// every data-stream-affecting flag that differs, upstream forces the active
+/// option to match the batch and mentions the change at `--info=misc` level.
+/// The returned vector holds those notices in bit order, each formatted exactly
+/// as upstream's `rprintf(FINFO, ...)`; the caller decides whether to print
+/// them based on verbosity. An `--iconv` mismatch is instead fatal and returns
+/// [`BatchError::FlagMismatch`].
+///
+/// Protocol version gates which flags participate, matching how upstream
+/// truncates `flag_ptr[]`: bits 7-8 require protocol >= 29 and bits 9-14
+/// require protocol >= 30.
+///
+/// # Upstream Reference
+///
+/// - `batch.c:120-161`: `check_batch_flags()`.
+pub fn check_batch_flags(
+    recorded: BatchFlags,
+    active: BatchFlags,
+    protocol_version: i32,
+) -> BatchResult<Vec<String>> {
+    // upstream: batch.c:124-127 - flag_ptr[] is truncated by protocol version
+    // (flag_ptr[7]=NULL below 29, flag_ptr[9]=NULL below 30), so the reconcile
+    // loop only visits the bits the peer actually negotiated.
+    let bit_count = if protocol_version < 29 {
+        7
+    } else if protocol_version < 30 {
+        9
+    } else {
+        15
+    };
+
+    let recorded_bits = flag_bits(&recorded);
+    let active_bits = flag_bits(&active);
+    let mut messages = Vec::new();
+
+    for i in 0..bit_count {
+        let set = recorded_bits[i];
+        if active_bits[i] == set {
+            continue;
+        }
+        if i == ICONV_BIT {
+            // upstream: batch.c:137-142 - an --iconv mismatch is fatal.
+            return Err(BatchError::FlagMismatch(format!(
+                "{} specify the --iconv option to use this batch file.",
+                if set { "Please" } else { "Do not" }
+            )));
+        }
+        // upstream: batch.c:143-148 - INFO(MISC) reconcile notice.
+        messages.push(format!(
+            "{}ing the {} option to match the batchfile.",
+            if set { "Sett" } else { "Clear" },
+            FLAG_NAMES[i]
+        ));
+    }
+
+    Ok(messages)
+}
 
 /// Stream flags bitmap that affects data stream format.
 ///
@@ -162,5 +274,142 @@ impl BatchFlags {
     /// correct protocol version (read from the header after the bitmap).
     pub fn read_raw<R: Read>(reader: &mut R) -> io::Result<i32> {
         read_i32(reader)
+    }
+}
+
+#[cfg(test)]
+mod check_flags_tests {
+    use super::{BatchFlags, check_batch_flags};
+    use crate::error::BatchError;
+
+    #[test]
+    fn matching_flags_produce_no_notices() {
+        // WHY: when the invocation already matches the batchfile there is
+        // nothing to reconcile, so upstream stays silent (batch.c:135 skips
+        // the body when *flag_ptr[i] == set).
+        let flags = BatchFlags {
+            recurse: true,
+            preserve_uid: true,
+            ..BatchFlags::default()
+        };
+        assert_eq!(
+            check_batch_flags(flags, flags, 31).unwrap(),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn missing_active_flag_emits_setting_notice() {
+        // WHY: the batch enabled -r but the caller did not; upstream forces
+        // the option on and says so (batch.c:143-148, set=1 -> "Sett").
+        let recorded = BatchFlags {
+            recurse: true,
+            ..BatchFlags::default()
+        };
+        let active = BatchFlags::default();
+        assert_eq!(
+            check_batch_flags(recorded, active, 31).unwrap(),
+            vec!["Setting the --recurse (-r) option to match the batchfile.".to_owned()]
+        );
+    }
+
+    #[test]
+    fn extra_active_flag_emits_clearing_notice() {
+        // WHY: the caller passed -c but the batch was made without it; upstream
+        // clears the option to match (batch.c:143-148, set=0 -> "Clear").
+        let recorded = BatchFlags::default();
+        let active = BatchFlags {
+            always_checksum: true,
+            ..BatchFlags::default()
+        };
+        assert_eq!(
+            check_batch_flags(recorded, active, 31).unwrap(),
+            vec!["Clearing the --checksum (-c) option to match the batchfile.".to_owned()]
+        );
+    }
+
+    #[test]
+    fn iconv_required_by_batch_is_fatal() {
+        // WHY: batch.c:137-142 makes an --iconv mismatch fatal, not a notice;
+        // a batch recorded with --iconv cannot be replayed without it.
+        let recorded = BatchFlags {
+            iconv: true,
+            ..BatchFlags::default()
+        };
+        let active = BatchFlags::default();
+        let err = check_batch_flags(recorded, active, 31).unwrap_err();
+        assert!(matches!(err, BatchError::FlagMismatch(_)));
+        assert_eq!(
+            err.to_string(),
+            "Please specify the --iconv option to use this batch file."
+        );
+    }
+
+    #[test]
+    fn iconv_forbidden_by_batch_is_fatal() {
+        // WHY: the reverse mismatch - caller passed --iconv, batch has none -
+        // is equally fatal with the "Do not" wording (batch.c:139-140).
+        let recorded = BatchFlags::default();
+        let active = BatchFlags {
+            iconv: true,
+            ..BatchFlags::default()
+        };
+        let err = check_batch_flags(recorded, active, 31).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Do not specify the --iconv option to use this batch file."
+        );
+    }
+
+    #[test]
+    fn iconv_bit_is_ignored_below_protocol_30() {
+        // WHY: batch.c:126-127 nulls flag_ptr[9] below protocol 30, so the
+        // iconv bit must not be checked and must never abort a proto-29 replay.
+        let recorded = BatchFlags {
+            iconv: true,
+            ..BatchFlags::default()
+        };
+        let active = BatchFlags::default();
+        assert_eq!(
+            check_batch_flags(recorded, active, 29).unwrap(),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn proto28_ignores_dirs_and_compress_bits() {
+        // WHY: batch.c:124-125 nulls flag_ptr[7] below protocol 29, so -d/-z
+        // (bits 7-8) and every later bit are outside the reconcile loop.
+        let recorded = BatchFlags {
+            xfer_dirs: true,
+            do_compression: true,
+            ..BatchFlags::default()
+        };
+        let active = BatchFlags::default();
+        assert_eq!(
+            check_batch_flags(recorded, active, 28).unwrap(),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn notices_are_ordered_by_bit_index() {
+        // WHY: upstream walks flag_ptr[] in order, so notices arrive lowest
+        // bit first; downstream output fidelity depends on that ordering.
+        let recorded = BatchFlags {
+            preserve_links: true,
+            ..BatchFlags::default()
+        };
+        let active = BatchFlags {
+            preserve_uid: true,
+            ..BatchFlags::default()
+        };
+        assert_eq!(
+            check_batch_flags(recorded, active, 31).unwrap(),
+            vec![
+                "Clearing the --owner (-o) option to match the batchfile.".to_owned(),
+                "Setting the --links (-l) option to match the batchfile.".to_owned(),
+            ]
+        );
     }
 }

--- a/crates/batch/src/format/mod.rs
+++ b/crates/batch/src/format/mod.rs
@@ -21,6 +21,6 @@ pub(crate) mod wire;
 mod tests;
 
 pub use file_entry::FileEntry;
-pub use flags::BatchFlags;
+pub use flags::{BatchFlags, check_batch_flags};
 pub use header::BatchHeader;
 pub use stats::BatchStats;

--- a/crates/batch/src/lib.rs
+++ b/crates/batch/src/lib.rs
@@ -206,6 +206,12 @@ pub use error::BatchResult;
 /// when replaying the batch.
 pub use format::BatchFlags;
 
+/// Reconcile active options against a batch file's recorded stream flags.
+///
+/// Emits upstream's `--info=misc` reconcile notices and treats an `--iconv`
+/// mismatch as fatal, mirroring `batch.c:check_batch_flags()`.
+pub use format::check_batch_flags;
+
 /// Binary header structure at the start of every batch file.
 ///
 /// Contains protocol version, compatibility flags, checksum seed, and
@@ -409,6 +415,22 @@ pub struct BatchConfig {
     /// (`batch.c:269-275`). The destination is re-supplied through the
     /// `${1:-<dest>}` placeholder instead.
     pub operands: Vec<String>,
+
+    /// Data-stream-affecting options active during the current `--read-batch`
+    /// invocation.
+    ///
+    /// Reconciled against the batch header's recorded stream flags by
+    /// [`check_batch_flags`] when replaying, mirroring upstream
+    /// `batch.c:check_batch_flags()`. Only consulted in read mode.
+    pub active_flags: BatchFlags,
+
+    /// Whether filter-rule terminators use NUL bytes instead of newlines.
+    ///
+    /// Set from `--from0` / `-0`. Controls how the `.sh` replay wrapper writes
+    /// the filter heredoc: NUL-separated rules followed by a trailing `;\n`
+    /// when true, matching upstream `batch.c:write_filter_rules()` under
+    /// `eol_nulls`.
+    pub eol_nulls: bool,
 }
 
 impl BatchConfig {
@@ -461,6 +483,8 @@ impl BatchConfig {
             invoker: String::from("oc-rsync"),
             replay_args: Vec::new(),
             operands: Vec::new(),
+            active_flags: BatchFlags::default(),
+            eol_nulls: false,
         }
     }
 
@@ -584,6 +608,52 @@ impl BatchConfig {
         S: Into<String>,
     {
         self.operands = operands.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set the data-stream-affecting options active during `--read-batch`.
+    ///
+    /// These are reconciled against the batch header's recorded stream flags
+    /// by [`check_batch_flags`] during replay. Mirrors upstream
+    /// `batch.c:check_batch_flags()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use batch::{BatchConfig, BatchFlags, BatchMode};
+    ///
+    /// let flags = BatchFlags {
+    ///     recurse: true,
+    ///     ..BatchFlags::default()
+    /// };
+    /// let config = BatchConfig::new(BatchMode::Read, "/tmp/batch".to_string(), 31)
+    ///     .with_active_flags(flags);
+    ///
+    /// assert!(config.active_flags.recurse);
+    /// ```
+    pub const fn with_active_flags(mut self, flags: BatchFlags) -> Self {
+        self.active_flags = flags;
+        self
+    }
+
+    /// Set whether filter-rule terminators use NUL bytes (`--from0` / `-0`).
+    ///
+    /// When `true`, the `.sh` replay wrapper writes NUL-separated filter rules
+    /// followed by a trailing `;\n`, matching upstream
+    /// `batch.c:write_filter_rules()` under `eol_nulls`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use batch::{BatchConfig, BatchMode};
+    ///
+    /// let config = BatchConfig::new(BatchMode::Write, "/tmp/batch".to_string(), 31)
+    ///     .with_eol_nulls(true);
+    ///
+    /// assert!(config.eol_nulls);
+    /// ```
+    pub const fn with_eol_nulls(mut self, eol_nulls: bool) -> Self {
+        self.eol_nulls = eol_nulls;
         self
     }
 

--- a/crates/batch/src/replay/mod.rs
+++ b/crates/batch/src/replay/mod.rs
@@ -117,6 +117,20 @@ pub fn replay(
 
     let flags = reader.read_header()?;
 
+    // upstream: batch.c:120 check_batch_flags() - reconcile the active options
+    // against the batch's recorded stream flags. Non-iconv mismatches are
+    // forced to match the batch and mentioned at --info=misc (verbose >= 1);
+    // an --iconv mismatch is fatal.
+    for message in crate::format::check_batch_flags(
+        flags,
+        batch_cfg.active_flags,
+        reader.config().protocol_version,
+    )? {
+        if verbosity >= 1 {
+            println!("{message}");
+        }
+    }
+
     let mut entries = reader.read_protocol_flist()?;
 
     // upstream: flist.c:2736 - flist_sort_and_clean() after recv_file_list().

--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -100,14 +100,7 @@ pub fn generate_script_with_filters(
 
     // upstream: batch.c:305-306 - append filter rules as heredoc
     if let Some(rules) = filter_rules {
-        // upstream: batch.c:209 write_sbuf(fd, " <<'#E#'\n")
-        writeln!(file, " <<'#E#'")?;
-        write!(file, "{rules}")?;
-        if !rules.ends_with('\n') {
-            writeln!(file)?;
-        }
-        // upstream: batch.c:221 write_sbuf(fd, "#E#")
-        write!(file, "#E#")?;
+        write_filter_heredoc(&mut file, rules, config.eol_nulls)?;
     }
 
     writeln!(file)?;
@@ -117,6 +110,42 @@ pub fn generate_script_with_filters(
     // upstream: batch_sh_fd opened with S_IRUSR | S_IWUSR | S_IXUSR (0o700)
     set_script_permissions(&script_path)?;
 
+    Ok(())
+}
+
+/// Write the trailing filter-rule heredoc into the replay script.
+///
+/// Mirrors upstream `batch.c:205-222 write_filter_rules()`. Rules arrive
+/// newline-terminated; when `eol_nulls` is set (`--from0` / `-0`) each rule is
+/// instead terminated by a NUL byte and the whole block is followed by a
+/// trailing `;\n`, matching upstream's `eol_nulls` branch byte-for-byte so the
+/// replayed `--read-batch` parses the rules the same way the original run did.
+///
+/// # Upstream Reference
+///
+/// - `batch.c:209`: `write_sbuf(fd, " <<'#E#'\n")`.
+/// - `batch.c:212-217`: per-rule terminator (`0` when `eol_nulls`, else `\n`).
+/// - `batch.c:219-220`: trailing `";\n"` after NUL-terminated rules.
+/// - `batch.c:221`: closing `#E#` delimiter.
+fn write_filter_heredoc(file: &mut File, rules: &str, eol_nulls: bool) -> io::Result<()> {
+    // upstream: batch.c:209 write_sbuf(fd, " <<'#E#'\n")
+    writeln!(file, " <<'#E#'")?;
+    if eol_nulls {
+        // upstream: batch.c:212-217 - NUL terminates each rule under eol_nulls.
+        for rule in rules.strip_suffix('\n').unwrap_or(rules).split('\n') {
+            file.write_all(rule.as_bytes())?;
+            file.write_all(&[0])?;
+        }
+        // upstream: batch.c:219-220 write_sbuf(fd, ";\n")
+        file.write_all(b";\n")?;
+    } else {
+        write!(file, "{rules}")?;
+        if !rules.ends_with('\n') {
+            writeln!(file)?;
+        }
+    }
+    // upstream: batch.c:221 write_sbuf(fd, "#E#")
+    write!(file, "#E#")?;
     Ok(())
 }
 
@@ -210,14 +239,7 @@ pub fn generate_script_with_args(
 
     // upstream: batch.c:305-306 write_filter_rules() uses heredoc with #E# delimiter
     if let Some(rules) = filter_rules {
-        // upstream: batch.c:209 write_sbuf(fd, " <<'#E#'\n")
-        writeln!(file, " <<'#E#'")?;
-        write!(file, "{rules}")?;
-        if !rules.ends_with('\n') {
-            writeln!(file)?;
-        }
-        // upstream: batch.c:221 write_sbuf(fd, "#E#")
-        write!(file, "#E#")?;
+        write_filter_heredoc(&mut file, rules, config.eol_nulls)?;
     }
 
     writeln!(file)?;
@@ -976,6 +998,77 @@ mod tests {
             permissions.mode() & 0o777,
             0o700,
             "Script permissions should be exactly 0o700"
+        );
+    }
+
+    /// Verify the filter heredoc NUL-terminates each rule and appends a
+    /// trailing `;\n` when `eol_nulls` (`--from0`) is set.
+    ///
+    /// WHY: upstream `batch.c:212-220` swaps the per-rule `\n` terminator for a
+    /// NUL and writes `";\n"` after the last rule under `eol_nulls`. The
+    /// replayed `--read-batch` reads its rules with the same NUL separator, so
+    /// a newline-terminated heredoc would mis-parse a `--from0` batch.
+    #[test]
+    fn test_filter_heredoc_honors_eol_nulls() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            31,
+        )
+        .with_eol_nulls(true);
+
+        let filter_rules = "- *.tmp\n+ *.txt\n";
+        generate_script_with_filters(&config, Some(filter_rules), None).unwrap();
+
+        let content = fs::read(config.script_file_path()).unwrap();
+
+        // Each rule is NUL-terminated, then a trailing ";\n", then "#E#".
+        let expected = b"- *.tmp\0+ *.txt\0;\n#E#";
+        let window = content.windows(expected.len()).any(|w| w == expected);
+        assert!(
+            window,
+            "heredoc must NUL-terminate rules and append ;\\n: {:?}",
+            String::from_utf8_lossy(&content)
+        );
+        // The newline-terminated form must not appear when eol_nulls is set.
+        assert!(
+            !content.windows(b"*.tmp\n".len()).any(|w| w == b"*.tmp\n"),
+            "eol_nulls must not leave newline terminators: {:?}",
+            String::from_utf8_lossy(&content)
+        );
+    }
+
+    /// Verify that without `eol_nulls` the heredoc keeps newline terminators
+    /// and never emits the `;\n` terminator or NUL bytes.
+    ///
+    /// WHY: the `;\n` trailer and NUL separators are exclusive to upstream's
+    /// `eol_nulls` branch (`batch.c:219`); a default (`--from0`-less) batch
+    /// must reproduce the newline-terminated form exactly.
+    #[test]
+    fn test_filter_heredoc_default_uses_newlines() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            31,
+        );
+
+        let filter_rules = "- *.tmp\n+ *.txt\n";
+        generate_script_with_filters(&config, Some(filter_rules), None).unwrap();
+
+        let content = fs::read(config.script_file_path()).unwrap();
+        assert!(!content.contains(&0u8), "no NUL bytes without eol_nulls");
+
+        let text = String::from_utf8(content).unwrap();
+        assert!(text.contains("- *.tmp\n+ *.txt\n#E#"));
+        assert!(
+            !text.contains(";\n#E#"),
+            "no trailing ;\\n without eol_nulls: {text}"
         );
     }
 }

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -70,11 +70,13 @@ pub(crate) fn create_batch_writer(
     }
 }
 
-/// Writes the batch header containing stream flags before the transfer begins.
-pub(crate) fn write_batch_header(
-    writer: &Arc<Mutex<BatchWriter>>,
-    config: &ClientConfig,
-) -> Result<(), ClientError> {
+/// Builds the data-stream-affecting [`engine::batch::BatchFlags`] from the
+/// active config.
+///
+/// The same flag set is recorded on `--write-batch` and reconciled on
+/// `--read-batch`, so both paths derive it identically from the current
+/// options. Mirrors upstream `batch.c:97-113 write_stream_flags()`.
+fn config_batch_flags(config: &ClientConfig) -> engine::batch::BatchFlags {
     #[cfg(all(unix, feature = "xattr"))]
     let preserve_xattrs = config.preserve_xattrs();
     #[cfg(not(all(unix, feature = "xattr")))]
@@ -85,7 +87,7 @@ pub(crate) fn write_batch_header(
     #[cfg(not(all(any(unix, windows), feature = "acl")))]
     let preserve_acls = false;
 
-    let batch_flags = engine::batch::BatchFlags {
+    engine::batch::BatchFlags {
         recurse: config.recursive(),
         preserve_uid: config.preserve_owner(),
         preserve_gid: config.preserve_group(),
@@ -105,13 +107,24 @@ pub(crate) fn write_batch_header(
         // oc-rsync and upstream rsync replay the file without trying to
         // decompress already-uncompressed tokens.
         do_compression: false,
+        // upstream: batch.c:69,101-103 - bit 9 records tweaked_iconv
+        // (iconv_opt != NULL). --no-iconv and an unset --iconv both leave
+        // iconv_opt NULL, so only an explicit charset request sets the bit.
+        iconv: !config.iconv().is_unspecified() && !config.iconv().is_disabled(),
         preserve_acls,
         preserve_xattrs,
         inplace: config.inplace(),
         append: config.append(),
         append_verify: config.append_verify(),
-        ..Default::default()
-    };
+    }
+}
+
+/// Writes the batch header containing stream flags before the transfer begins.
+pub(crate) fn write_batch_header(
+    writer: &Arc<Mutex<BatchWriter>>,
+    config: &ClientConfig,
+) -> Result<(), ClientError> {
+    let batch_flags = config_batch_flags(config);
 
     let mut w = writer.lock().map_err(|_| {
         ClientError::new(
@@ -220,8 +233,11 @@ pub(crate) fn finalize_batch(
         .last()
         .map(|s| s.to_string_lossy().into_owned());
 
+    // upstream: batch.c:217,219-220 - the filter heredoc honors eol_nulls
+    // (--from0), NUL-terminating rules and appending ";\n".
+    let script_cfg = batch_cfg.clone().with_eol_nulls(config.from0());
     if let Err(e) = engine::batch::script::generate_script_with_filters(
-        batch_cfg,
+        &script_cfg,
         filter_opt,
         dest_operand.as_deref(),
     ) {
@@ -327,10 +343,24 @@ fn replay_batch(
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."));
 
-    let result = engine::batch::replay::replay(batch_cfg, &dest_root, config.verbosity().into())
-        .map_err(|e| {
-            let msg = format!("batch replay failed: {e}");
-            ClientError::new(1, rsync_error!(1, "{}", msg).with_role(Role::Client))
+    // upstream: batch.c:120 check_batch_flags() reconciles the active options
+    // against the batch header during replay, so carry the current flag state
+    // into the reader.
+    let replay_cfg = batch_cfg
+        .clone()
+        .with_active_flags(config_batch_flags(config));
+
+    let result = engine::batch::replay::replay(&replay_cfg, &dest_root, config.verbosity().into())
+        .map_err(|e| match e {
+            // upstream: batch.c:137-142 - an --iconv mismatch aborts with
+            // RERR_SYNTAX (exit 1) printing the bare reconcile message.
+            engine::batch::BatchError::FlagMismatch(msg) => {
+                ClientError::new(1, rsync_error!(1, "{}", msg).with_role(Role::Client))
+            }
+            other => {
+                let msg = format!("batch replay failed: {other}");
+                ClientError::new(1, rsync_error!(1, "{}", msg).with_role(Role::Client))
+            }
         })?;
 
     #[cfg(feature = "tracing")]


### PR DESCRIPTION
## Summary

Aligns batch mode with upstream `batch.c` on three flag/filter divergences.

### 1. `--read-batch` enforces the `--iconv` batch-flag match

`batch.c:check_batch_flags()` (batch.c:120-161) reconciles the active
`--read-batch` options against the stream flags recorded in the batch header.
An `--iconv` mismatch (bit 9, protocol >= 30) is fatal: upstream prints
`Please specify the --iconv option to use this batch file.` (or `Do not
specify ...` for the reverse) and aborts with `RERR_SYNTAX` (exit 1). The
reconcile now runs during replay and returns a fatal error on an iconv
mismatch, where oc-rsync previously replayed regardless.

### 2. Flag-reconcile `--info=misc` notices

For every other data-stream-affecting flag that differs, upstream forces the
option to match the batch and mentions it at `--info=misc` (verbose >= 1):
`Setting the <opt> option to match the batchfile.` /
`Clearing the <opt> option to match the batchfile.` (batch.c:134-149). These
notices are now emitted in bit order using the exact `flag_name[]` strings.

Protocol gating mirrors upstream's `flag_ptr[]` truncation: bits 7-8 require
protocol >= 29, bits 9-14 require protocol >= 30.

The `--write-batch` header now also records the iconv bit
(batch.c:69, batch.c:101-103), so oc-written batches reconcile symmetrically
instead of tripping the new check on their own round-trips.

### 3. `.sh` filter heredoc honors `--from0` / `eol_nulls`

`batch.c:write_filter_rules()` (batch.c:205-222) terminates each embedded
filter rule with a NUL byte instead of a newline when `eol_nulls` is set, and
appends a trailing `;\n` after the last rule (batch.c:217, 219-220). The `.sh`
replay wrapper now reproduces this byte-for-byte so a `--from0` batch replays
its rules with the same terminator the original run used.

## Tests

Unit tests encode intent:

- iconv mismatch is fatal in both directions with the exact upstream text; the
  iconv bit is ignored below protocol 30.
- reconcile notices emit the exact `Setting/Clearing ... to match the
  batchfile.` text, in bit order; matching flags stay silent.
- the `.sh` filter heredoc NUL-terminates rules and appends `;\n` under
  `--from0`, and keeps newline terminators (no `;\n`, no NUL) otherwise.

## Validation

- `cargo fmt --all -- --check` clean.
- `cargo clippy -p batch --all-targets --all-features --no-deps -- -D warnings` clean.
- `cargo clippy -p core --all-targets --all-features --no-deps -- -D warnings` clean.
