### PR TITLE
fix(transfer): apply negotiated compress-level to token encoder

### DIFF
--- a/crates/compress/src/zstd.rs
+++ b/crates/compress/src/zstd.rs
@@ -100,7 +100,8 @@ where
         workers: Option<NonZeroU8>,
     ) -> io::Result<Self> {
         let writer = CountingWriter::new(sink);
-        let mut encoder = ZstdEncoder::new(writer, zstd_level(level)).map_err(io::Error::other)?;
+        let mut encoder =
+            ZstdEncoder::new(writer, level_to_i32(level)).map_err(io::Error::other)?;
         configure_workers(&mut encoder, workers)?;
         Ok(Self { inner: encoder })
     }
@@ -228,7 +229,8 @@ where
 
 /// Compresses `input` into a new [`Vec`].
 pub fn compress_to_vec(input: &[u8], level: CompressionLevel) -> io::Result<Vec<u8>> {
-    let mut encoder = ZstdEncoder::new(Vec::new(), zstd_level(level)).map_err(io::Error::other)?;
+    let mut encoder =
+        ZstdEncoder::new(Vec::new(), level_to_i32(level)).map_err(io::Error::other)?;
     encoder.write_all(input)?;
     encoder.finish().map_err(io::Error::other)
 }
@@ -277,9 +279,20 @@ fn configure_workers<W: Write>(
     }
 }
 
-// upstream: token.c:init_compression_level() - ZSTD_CLEVEL_DEFAULT is 3,
-// ZSTD_minCLevel() is the minimum, ZSTD_maxCLevel() is the maximum.
-fn zstd_level(level: CompressionLevel) -> i32 {
+/// Maps a [`CompressionLevel`] to the raw signed level zstd's C API expects
+/// (`ZSTD_c_compressionLevel`).
+///
+/// This is the single source of truth for the zstd level mapping, shared by the
+/// streaming encoders in this module and by the wire token encoder in the
+/// `transfer` crate so the negotiated `--compress-level` reaches every zstd
+/// compression context. `Default` resolves to `ZSTD_CLEVEL_DEFAULT` (3), not the
+/// zlib default (6): each codec substitutes its own default level.
+///
+/// upstream: token.c:send_zstd_token() passes `do_compression_level` to
+/// `ZSTD_CCtx_setParameter(.., ZSTD_c_compressionLevel, ..)`; token.c:75
+/// `def_level = ZSTD_CLEVEL_DEFAULT`.
+#[must_use]
+pub fn level_to_i32(level: CompressionLevel) -> i32 {
     use crate::algorithm::{ZSTD_BEST_LEVEL, ZSTD_DEFAULT_LEVEL, ZSTD_FAST_LEVEL};
     match level {
         CompressionLevel::None => 0,

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -14,6 +14,7 @@
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
+use compress::zlib::CompressionLevel;
 use logging::debug_log;
 #[cfg(test)]
 use protocol::wire::write_token_stream;
@@ -44,29 +45,44 @@ use crate::role_trailer::error_location;
 /// upstream: token.c:701 - `ZSTD_CCtx_setParameter(.., ZSTD_c_nbWorkers, ..)`
 pub(super) fn create_token_encoder(
     algo: CompressionAlgorithm,
+    level: CompressionLevel,
     workers: Option<std::num::NonZeroU8>,
 ) -> io::Result<Option<CompressedTokenEncoder>> {
     match algo {
         CompressionAlgorithm::Zlib | CompressionAlgorithm::ZlibX => {
-            let mut enc = CompressedTokenEncoder::default();
+            // upstream: token.c:378 - deflateInit2() uses per_file_default_level
+            // (= the negotiated do_compression_level). Protocol version 31 mirrors
+            // the historical default; only the level varies per --compress-level.
+            let mut enc = CompressedTokenEncoder::new(level, ZLIB_TOKEN_PROTOCOL_VERSION);
             if algo == CompressionAlgorithm::ZlibX {
                 enc.set_zlibx(true);
             }
             Ok(Some(enc))
         }
         #[cfg(feature = "zstd")]
-        CompressionAlgorithm::Zstd => Ok(Some(CompressedTokenEncoder::new_zstd(3, workers)?)),
+        // upstream: token.c:748 - ZSTD_CCtx_setParameter(.., ZSTD_c_compressionLevel,
+        // do_compression_level). Negative "fast" levels pass through unchanged.
+        CompressionAlgorithm::Zstd => Ok(Some(CompressedTokenEncoder::new_zstd(
+            compress::zstd::level_to_i32(level),
+            workers,
+        )?)),
         #[cfg(feature = "lz4")]
         CompressionAlgorithm::LZ4 => {
-            let _ = workers;
+            let _ = (workers, level);
             Ok(Some(CompressedTokenEncoder::new_lz4()))
         }
         _ => {
-            let _ = workers;
+            let _ = (workers, level);
             Ok(None)
         }
     }
 }
+
+/// Protocol version historically used to initialise the zlib token encoder.
+///
+/// Matches the previous `CompressedTokenEncoder::default()` behaviour so this
+/// change alters only the compression level, never the zlib token framing.
+const ZLIB_TOKEN_PROTOCOL_VERSION: u32 = 31;
 
 /// Soft warning threshold for whole-file transfers (8 GB).
 ///
@@ -794,8 +810,9 @@ mod tests {
     #[cfg(feature = "zstd")]
     #[test]
     fn create_token_encoder_zstd_no_workers() {
-        let encoder = create_token_encoder(CompressionAlgorithm::Zstd, None)
-            .expect("zstd encoder creation should succeed");
+        let encoder =
+            create_token_encoder(CompressionAlgorithm::Zstd, CompressionLevel::Default, None)
+                .expect("zstd encoder creation should succeed");
         assert!(encoder.is_some(), "zstd should produce an encoder");
     }
 
@@ -803,24 +820,36 @@ mod tests {
     #[test]
     fn create_token_encoder_zstd_with_workers() {
         let workers = std::num::NonZeroU8::new(1);
-        let encoder = create_token_encoder(CompressionAlgorithm::Zstd, workers)
-            .expect("zstd encoder with workers=1 should succeed");
+        let encoder = create_token_encoder(
+            CompressionAlgorithm::Zstd,
+            CompressionLevel::Default,
+            workers,
+        )
+        .expect("zstd encoder with workers=1 should succeed");
         assert!(encoder.is_some(), "zstd should produce an encoder");
     }
 
     #[test]
     fn create_token_encoder_zlib_ignores_workers() {
         let workers = std::num::NonZeroU8::new(4);
-        let encoder = create_token_encoder(CompressionAlgorithm::Zlib, workers)
-            .expect("zlib encoder should succeed even with workers");
+        let encoder = create_token_encoder(
+            CompressionAlgorithm::Zlib,
+            CompressionLevel::Default,
+            workers,
+        )
+        .expect("zlib encoder should succeed even with workers");
         assert!(encoder.is_some(), "zlib should produce an encoder");
     }
 
     #[test]
     fn create_token_encoder_zlibx_ignores_workers() {
         let workers = std::num::NonZeroU8::new(4);
-        let encoder = create_token_encoder(CompressionAlgorithm::ZlibX, workers)
-            .expect("zlibx encoder should succeed even with workers");
+        let encoder = create_token_encoder(
+            CompressionAlgorithm::ZlibX,
+            CompressionLevel::Default,
+            workers,
+        )
+        .expect("zlibx encoder should succeed even with workers");
         assert!(encoder.is_some(), "zlibx should produce an encoder");
     }
 
@@ -828,9 +857,44 @@ mod tests {
     #[test]
     fn create_token_encoder_lz4_ignores_workers() {
         let workers = std::num::NonZeroU8::new(4);
-        let encoder = create_token_encoder(CompressionAlgorithm::LZ4, workers)
-            .expect("lz4 encoder should succeed even with workers");
+        let encoder = create_token_encoder(
+            CompressionAlgorithm::LZ4,
+            CompressionLevel::Default,
+            workers,
+        )
+        .expect("lz4 encoder should succeed even with workers");
         assert!(encoder.is_some(), "lz4 should produce an encoder");
+    }
+
+    /// The negotiated `--compress-level` must reach the wire token encoder:
+    /// upstream `token.c` inits both the zlib (`deflateInit2`) and zstd
+    /// (`ZSTD_c_compressionLevel`) contexts with `do_compression_level`, so a
+    /// higher level must produce a materially smaller compressed token stream
+    /// for the same compressible literal. A regression that hardcodes the
+    /// default level would make these two streams identical.
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn create_token_encoder_zstd_honors_negotiated_level() {
+        use std::num::NonZeroU8;
+
+        fn emit(level: CompressionLevel) -> Vec<u8> {
+            let mut enc = create_token_encoder(CompressionAlgorithm::Zstd, level, None)
+                .expect("zstd encoder")
+                .expect("zstd produces an encoder");
+            // A repetitive-but-structured payload so a higher zstd level wins.
+            let payload: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+            let mut out = Vec::new();
+            enc.send_literal(&mut out, &payload).expect("send literal");
+            enc.finish(&mut out).expect("finish");
+            out
+        }
+
+        let fast = emit(CompressionLevel::Precise(NonZeroU8::new(1).unwrap()));
+        let best = emit(CompressionLevel::Precise(NonZeroU8::new(19).unwrap()));
+        assert_ne!(
+            fast, best,
+            "distinct zstd levels must yield distinct compressed token streams"
+        );
     }
 
     /// Reverse-daemon-delta regression: with a delta script that interleaves

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -125,8 +125,16 @@ impl GeneratorContext {
         // (one continuous stream). Create once here, reuse across all files.
         let negotiated_compression = self.negotiated_algorithms.map(|n| n.compression);
         let compression_threads = self.config.connection.compression_threads;
+        // upstream: token.c inits the compressor with do_compression_level (the
+        // negotiated --compress-level). Absent an explicit level, each codec
+        // substitutes its own default via CompressionLevel::Default.
+        let compression_level = self
+            .config
+            .connection
+            .compression_level
+            .unwrap_or(compress::zlib::CompressionLevel::Default);
         let mut token_encoder = negotiated_compression
-            .map(|algo| create_token_encoder(algo, compression_threads))
+            .map(|algo| create_token_encoder(algo, compression_level, compression_threads))
             .transpose()?
             .flatten();
 


### PR DESCRIPTION
## Summary

The generator's wire token encoder was built with hardcoded default compression
levels, so `--compress-level` had no effect on the sender's compressed token
stream. `create_token_encoder` used `CompressedTokenEncoder::default()` for zlib
(level 6) and `new_zstd(3, ..)` for zstd, ignoring the negotiated level entirely.

This threads the negotiated compression level from the connection config into the
token encoder for both codecs, mirroring upstream `token.c`:

- **zlib** (`token.c:378`): `deflateInit2()` is initialised with
  `per_file_default_level`, which equals the negotiated `do_compression_level`.
- **zstd** (`token.c:748`): `do_compression_level` is passed to
  `ZSTD_CCtx_setParameter(.., ZSTD_c_compressionLevel, ..)`.

Absent an explicit `--compress-level`, each codec substitutes its own default via
`CompressionLevel::Default`, so the no-flag path is byte-identical to before
(zlib 6, zstd 3, matching `token.c:66`/`token.c:75`). The wire framing is
unchanged; only the compressor's ratio is affected, and any resulting stream
remains a valid zlib/zstd stream the peer decompresses transparently.

Also adds `compress::zstd::level_to_i32` as the single source of truth for the
zstd `CompressionLevel` -> raw level mapping, now shared by the streaming
encoders and the wire token encoder.

## Testing

- `cargo fmt --all --check`
- `cargo clippy -p compress -p transfer --all-targets --all-features --no-deps -- -D warnings`
- New unit test asserts distinct `--compress-level` values yield distinct
  compressed token streams (a hardcoded-default regression would make them equal).
