### PR TITLE
fix(daemon): match upstream rsyncd.conf bool/int parsing

### DIFF
--- a/crates/daemon/src/daemon/sections/config_helpers/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/tests.rs
@@ -107,8 +107,6 @@ mod config_helpers_tests {
         assert_eq!(parse_boolean_directive("TRUE"), Some(true));
         assert_eq!(parse_boolean_directive("yes"), Some(true));
         assert_eq!(parse_boolean_directive("YES"), Some(true));
-        assert_eq!(parse_boolean_directive("on"), Some(true));
-        assert_eq!(parse_boolean_directive("ON"), Some(true));
     }
 
     #[test]
@@ -118,8 +116,17 @@ mod config_helpers_tests {
         assert_eq!(parse_boolean_directive("FALSE"), Some(false));
         assert_eq!(parse_boolean_directive("no"), Some(false));
         assert_eq!(parse_boolean_directive("NO"), Some(false));
-        assert_eq!(parse_boolean_directive("off"), Some(false));
-        assert_eq!(parse_boolean_directive("OFF"), Some(false));
+    }
+
+    #[test]
+    fn parse_boolean_directive_rejects_on_off() {
+        // upstream: loadparm.c:365-370 set_boolean() accepts only
+        // yes/true/1 and no/false/0 - it never recognizes on/off. Accepting
+        // them would let a config parse a value upstream rsync rejects.
+        assert_eq!(parse_boolean_directive("on"), None);
+        assert_eq!(parse_boolean_directive("ON"), None);
+        assert_eq!(parse_boolean_directive("off"), None);
+        assert_eq!(parse_boolean_directive("OFF"), None);
     }
 
     #[test]
@@ -127,6 +134,65 @@ mod config_helpers_tests {
         assert_eq!(parse_boolean_directive("maybe"), None);
         assert_eq!(parse_boolean_directive("2"), None);
         assert_eq!(parse_boolean_directive(""), None);
+    }
+
+    #[test]
+    fn classify_boolean_directive_bool3_unset_is_valid() {
+        // upstream: loadparm.c:369 - a P_BOOL3 directive (use chroot, numeric
+        // ids, munge symlinks, open noatime) treats `unset`/`-1` as a valid
+        // tri-state, distinct from a badly formed value.
+        assert!(matches!(
+            classify_boolean_directive("unset", true),
+            BooleanDirective::Unset
+        ));
+        assert!(matches!(
+            classify_boolean_directive("-1", true),
+            BooleanDirective::Unset
+        ));
+        // A plain P_BOOL directive does not accept the tri-state.
+        assert!(matches!(
+            classify_boolean_directive("unset", false),
+            BooleanDirective::Malformed
+        ));
+        // Concrete values are unaffected by allow_unset.
+        assert!(matches!(
+            classify_boolean_directive("yes", true),
+            BooleanDirective::Value(true)
+        ));
+    }
+
+    #[test]
+    fn apply_boolean_directive_malformed_keeps_default() {
+        // upstream: loadparm.c:418-423 do_parameter() ignores set_boolean()'s
+        // failure, so a badly formed boolean warns and retains the default
+        // rather than aborting. Here that surfaces as `None` (no value to set).
+        let path = std::path::Path::new("rsyncd.conf");
+        assert_eq!(
+            apply_boolean_directive("maybe", false, "read only", path, 1),
+            None
+        );
+        // A BOOL3 `unset` also yields None (leave the setting at its default).
+        assert_eq!(
+            apply_boolean_directive("unset", true, "use chroot", path, 1),
+            None
+        );
+        // Concrete values are returned for the caller to apply.
+        assert_eq!(
+            apply_boolean_directive("yes", false, "read only", path, 1),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn parse_atoi_matches_c_leniency() {
+        // upstream: loadparm.c:431-433 stores atoi(parmvalue) for P_INTEGER
+        // directives, so a trailing non-digit suffix is tolerated.
+        assert_eq!(parse_atoi("5x"), 5);
+        assert_eq!(parse_atoi("30 seconds"), 30);
+        assert_eq!(parse_atoi("  42"), 42);
+        assert_eq!(parse_atoi("-7"), -7);
+        assert_eq!(parse_atoi("abc"), 0);
+        assert_eq!(parse_atoi(""), 0);
     }
 
     #[test]
@@ -172,13 +238,16 @@ mod config_helpers_tests {
     }
 
     #[test]
-    fn parse_timeout_seconds_empty() {
-        assert_eq!(parse_timeout_seconds(""), None);
+    fn parse_timeout_seconds_empty_disables() {
+        // upstream: `timeout` is P_INTEGER, so atoi("") == 0 disables it.
+        assert_eq!(parse_timeout_seconds(""), Some(None));
     }
 
     #[test]
-    fn parse_timeout_seconds_invalid() {
-        assert_eq!(parse_timeout_seconds("abc"), None);
+    fn parse_timeout_seconds_atoi_leniency() {
+        // upstream: atoi("abc") == 0 (disabled); atoi("30x") == 30.
+        assert_eq!(parse_timeout_seconds("abc"), Some(None));
+        assert_eq!(parse_timeout_seconds("30x").unwrap().unwrap().get(), 30);
     }
 
     #[test]
@@ -194,13 +263,19 @@ mod config_helpers_tests {
     }
 
     #[test]
-    fn parse_max_connections_directive_empty() {
-        assert_eq!(parse_max_connections_directive(""), None);
+    fn parse_max_connections_directive_empty_is_unlimited() {
+        // upstream: `max connections` is P_INTEGER, so atoi("") == 0 (unlimited).
+        assert_eq!(parse_max_connections_directive(""), Some(None));
     }
 
     #[test]
-    fn parse_max_connections_directive_invalid() {
-        assert_eq!(parse_max_connections_directive("abc"), None);
+    fn parse_max_connections_directive_atoi_leniency() {
+        // upstream: atoi("abc") == 0 (unlimited); atoi("10x") == 10.
+        assert_eq!(parse_max_connections_directive("abc"), Some(None));
+        assert_eq!(
+            parse_max_connections_directive("10x").unwrap().unwrap().get(),
+            10
+        );
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
@@ -142,17 +142,114 @@ pub(crate) fn parse_refuse_option_list(value: &str) -> Result<Vec<String>, Strin
     )
 }
 
-/// Parses a boolean value from a config directive.
+/// Classification of a boolean directive value, mirroring the branches of
+/// upstream `loadparm.c:set_boolean()`.
+enum BooleanDirective {
+    /// A concrete `true`/`false` value.
+    Value(bool),
+    /// The P_BOOL3 `unset`/`-1` tri-state (only recognized when unset is
+    /// allowed).
+    Unset,
+    /// A value that `set_boolean()` rejects as badly formed.
+    Malformed,
+}
+
+/// Classifies a boolean directive value the way upstream `set_boolean()` does.
 ///
-/// Accepts common boolean representations: 1/0, true/false, yes/no, on/off.
-/// Returns `None` for unrecognized values.
-pub(crate) fn parse_boolean_directive(value: &str) -> Option<bool> {
-    let normalized = value.trim().to_ascii_lowercase();
-    match normalized.as_str() {
-        "1" | "true" | "yes" | "on" => Some(true),
-        "0" | "false" | "no" | "off" => Some(false),
-        _ => None,
+/// upstream: loadparm.c:363-376. Accepts only `yes`/`true`/`1` and
+/// `no`/`false`/`0` (case-insensitive); when `allow_unset` is set (P_BOOL3
+/// params) also accepts `unset`/`-1` as a tri-state. Upstream does NOT accept
+/// `on`/`off`.
+fn classify_boolean_directive(value: &str, allow_unset: bool) -> BooleanDirective {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "yes" | "true" | "1" => BooleanDirective::Value(true),
+        "no" | "false" | "0" => BooleanDirective::Value(false),
+        "unset" | "-1" if allow_unset => BooleanDirective::Unset,
+        _ => BooleanDirective::Malformed,
     }
+}
+
+/// Parses a strict (non-tri-state) boolean directive value.
+///
+/// Mirrors the P_BOOL branch of upstream `loadparm.c:set_boolean()`: accepts
+/// `yes`/`true`/`1` and `no`/`false`/`0` (case-insensitive) and nothing else.
+/// Notably upstream does NOT accept `on`/`off`, so neither do we. Returns
+/// `None` for any unrecognized value.
+pub(crate) fn parse_boolean_directive(value: &str) -> Option<bool> {
+    match classify_boolean_directive(value, false) {
+        BooleanDirective::Value(flag) => Some(flag),
+        BooleanDirective::Unset | BooleanDirective::Malformed => None,
+    }
+}
+
+/// Applies upstream `set_boolean()`/`do_parameter()` semantics to a boolean
+/// directive, reporting malformed values without aborting the config load.
+///
+/// `allow_unset` selects the P_BOOL3 tri-state (`unset`/`-1`). Returns
+/// `Some(flag)` for a concrete value. Returns `None` when the value is the
+/// BOOL3 `unset` tri-state (leave the setting unconfigured) or is malformed.
+///
+/// upstream: loadparm.c:418-423 - `do_parameter()` calls `set_boolean()` and
+/// ignores its failure return, so a badly formed boolean only warns
+/// (loadparm.c:372) and the directive's previous default is retained rather
+/// than aborting the load.
+pub(crate) fn apply_boolean_directive(
+    value: &str,
+    allow_unset: bool,
+    directive: &str,
+    path: &Path,
+    line_number: usize,
+) -> Option<bool> {
+    match classify_boolean_directive(value, allow_unset) {
+        BooleanDirective::Value(flag) => Some(flag),
+        BooleanDirective::Unset => None,
+        BooleanDirective::Malformed => {
+            eprintln!(
+                "warning: badly formed boolean in configuration file: '{value}' for '{directive}' in '{}' line {} [daemon={}]",
+                path.display(),
+                line_number,
+                env!("CARGO_PKG_VERSION"),
+            );
+            None
+        }
+    }
+}
+
+/// Parses the leading integer of a config value the way C `atoi()` does.
+///
+/// upstream: loadparm.c:431-433 stores `atoi(parmvalue)` for P_INTEGER
+/// directives. `atoi` skips leading whitespace, reads an optional sign followed
+/// by the leading run of decimal digits, and stops at the first non-digit (so
+/// `"5x"` yields `5`). It yields `0` when no digits are present. Overflow
+/// saturates to the `i32` range rather than invoking C's undefined behaviour.
+pub(crate) fn parse_atoi(value: &str) -> i32 {
+    let bytes = value.trim_start().as_bytes();
+    let mut index = 0;
+    let negative = match bytes.first() {
+        Some(b'+') => {
+            index = 1;
+            false
+        }
+        Some(b'-') => {
+            index = 1;
+            true
+        }
+        _ => false,
+    };
+
+    let mut magnitude: i64 = 0;
+    while let Some(&byte) = bytes.get(index) {
+        if !byte.is_ascii_digit() {
+            break;
+        }
+        magnitude = magnitude
+            .saturating_mul(10)
+            .saturating_add(i64::from(byte - b'0'));
+        index += 1;
+    }
+
+    let signed = if negative { -magnitude } else { magnitude };
+    signed.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
 }
 
 /// Parses a numeric identifier (uid/gid) from a config value.
@@ -165,17 +262,16 @@ pub(crate) fn parse_numeric_identifier(value: &str) -> Option<u32> {
     trimmed.parse().ok()
 }
 
-/// Parses a timeout value in seconds.
+/// Parses a timeout directive value in seconds.
 ///
-/// Returns `Some(None)` for "0" (disabled), `Some(Some(n))` for valid timeouts,
-/// or `None` for empty or invalid input.
+/// upstream: `timeout` is a P_INTEGER directive (daemon-parm.h:294), so the
+/// value is read with `atoi()` leniency: a leading integer is parsed and
+/// trailing non-digits are tolerated. A non-positive result (including an
+/// empty or non-numeric value, which `atoi` maps to `0`) disables the timeout,
+/// yielding `Some(None)`; a positive value yields `Some(Some(n))`. Never
+/// returns `None`.
 pub(crate) fn parse_timeout_seconds(value: &str) -> Option<Option<NonZeroU64>> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    let seconds: u64 = trimmed.parse().ok()?;
+    let seconds = parse_atoi(value).max(0) as u64;
     if seconds == 0 {
         Some(None)
     } else {
@@ -185,17 +281,12 @@ pub(crate) fn parse_timeout_seconds(value: &str) -> Option<Option<NonZeroU64>> {
 
 /// Parses a max-connections directive value.
 ///
-/// Returns `Some(None)` for "0" (unlimited), `Some(Some(n))` for a limit,
-/// or `None` for empty or invalid input.
+/// upstream: `max connections` is a P_INTEGER directive (daemon-parm.h:292),
+/// so the value is read with `atoi()` leniency: a leading integer is parsed and
+/// trailing non-digits are tolerated. A non-positive result (including an empty
+/// or non-numeric value, which `atoi` maps to `0`) means unlimited, yielding
+/// `Some(None)`; a positive value yields `Some(Some(n))`. Never returns `None`.
 pub(crate) fn parse_max_connections_directive(value: &str) -> Option<Option<NonZeroU32>> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    if trimmed == "0" {
-        return Some(None);
-    }
-
-    trimmed.parse::<NonZeroU32>().ok().map(Some)
+    let limit = parse_atoi(value).max(0) as u32;
+    Some(NonZeroU32::new(limit))
 }

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -123,13 +123,11 @@ fn apply_global_directive(
             }
         }
         "reverse lookup" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'reverse lookup'"),
-                )
-            })?;
+            let Some(parsed) =
+                apply_boolean_directive(value, false, "reverse lookup", path, line_number)
+            else {
+                return Ok(());
+            };
 
             let origin = ConfigDirectiveOrigin {
                 path: canonical.to_path_buf(),
@@ -309,13 +307,11 @@ fn apply_global_directive(
         // upstream: loadparm.c - use chroot is valid in the global section as a
         // default that applies to all modules which do not override it explicitly.
         "use chroot" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'use chroot'"),
-                )
-            })?;
+            let Some(parsed) =
+                apply_boolean_directive(value, true, "use chroot", path, line_number)
+            else {
+                return Ok(());
+            };
 
             let origin = ConfigDirectiveOrigin {
                 path: canonical.to_path_buf(),
@@ -511,13 +507,7 @@ fn apply_global_directive(
         // upstream: daemon-parm.txt - listen_backlog INTEGER, default 5.
         // Controls the backlog argument passed to listen(2).
         "listen backlog" => {
-            let parsed: u32 = value.parse().map_err(|_| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid integer value '{value}' for 'listen backlog'"),
-                )
-            })?;
+            let parsed = parse_atoi(value).max(0) as u32;
 
             let origin = ConfigDirectiveOrigin {
                 path: canonical.to_path_buf(),
@@ -581,13 +571,7 @@ fn apply_global_directive(
         // upstream: daemon-parm.txt - port INTEGER, P_GLOBAL, default 0.
         // Controls the TCP port the daemon listens on.
         "port" | "rsync port" => {
-            let parsed: u16 = value.parse().map_err(|_| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid port number '{value}' for 'port'"),
-                )
-            })?;
+            let parsed = parse_atoi(value).clamp(0, i32::from(u16::MAX)) as u16;
 
             let origin = ConfigDirectiveOrigin {
                 path: canonical.to_path_buf(),
@@ -642,13 +626,11 @@ fn apply_global_directive(
             }
         }
         "proxy protocol" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'proxy protocol'"),
-                )
-            })?;
+            let Some(parsed) =
+                apply_boolean_directive(value, false, "proxy protocol", path, line_number)
+            else {
+                return Ok(());
+            };
 
             let origin = ConfigDirectiveOrigin {
                 path: canonical.to_path_buf(),
@@ -719,24 +701,14 @@ fn apply_global_directive(
             }
         }
         "max verbosity" => {
-            let parsed: i32 = value.parse().map_err(|_| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid integer value '{value}' for 'max verbosity'"),
-                )
-            })?;
-            state.module_defaults.max_verbosity = Some(parsed);
+            state.module_defaults.max_verbosity = Some(parse_atoi(value));
         }
         "transfer logging" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'transfer logging'"),
-                )
-            })?;
-            state.module_defaults.transfer_logging = Some(parsed);
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "transfer logging", path, line_number)
+            {
+                state.module_defaults.transfer_logging = Some(parsed);
+            }
         }
         "log format" => {
             if !value.is_empty() {
@@ -773,64 +745,44 @@ fn apply_global_directive(
             }
         }
         "read only" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'read only'"),
-                )
-            })?;
-            state.module_defaults.read_only = Some(parsed);
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "read only", path, line_number)
+            {
+                state.module_defaults.read_only = Some(parsed);
+            }
         }
         "write only" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'write only'"),
-                )
-            })?;
-            state.module_defaults.write_only = Some(parsed);
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "write only", path, line_number)
+            {
+                state.module_defaults.write_only = Some(parsed);
+            }
         }
         "list" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'list'"),
-                )
-            })?;
-            state.module_defaults.listable = Some(parsed);
+            if let Some(parsed) = apply_boolean_directive(value, false, "list", path, line_number) {
+                state.module_defaults.listable = Some(parsed);
+            }
         }
         "munge symlinks" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'munge symlinks'"),
-                )
-            })?;
-            state.module_defaults.munge_symlinks = Some(Some(parsed));
+            if let Some(parsed) =
+                apply_boolean_directive(value, true, "munge symlinks", path, line_number)
+            {
+                state.module_defaults.munge_symlinks = Some(Some(parsed));
+            }
         }
         "numeric ids" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'numeric ids'"),
-                )
-            })?;
-            state.module_defaults.numeric_ids = Some(parsed);
+            if let Some(parsed) =
+                apply_boolean_directive(value, true, "numeric ids", path, line_number)
+            {
+                state.module_defaults.numeric_ids = Some(parsed);
+            }
         }
         "fake super" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'fake super'"),
-                )
-            })?;
-            state.module_defaults.fake_super = Some(parsed);
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "fake super", path, line_number)
+            {
+                state.module_defaults.fake_super = Some(parsed);
+            }
         }
         "max connections" => {
             let max = parse_max_connections_directive(value).ok_or_else(|| {
@@ -843,56 +795,41 @@ fn apply_global_directive(
             state.module_defaults.max_connections = Some(max);
         }
         "ignore errors" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'ignore errors'"),
-                )
-            })?;
-            state.module_defaults.ignore_errors = Some(parsed);
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "ignore errors", path, line_number)
+            {
+                state.module_defaults.ignore_errors = Some(parsed);
+            }
         }
         "ignore nonreadable" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'ignore nonreadable'"),
-                )
-            })?;
-            state.module_defaults.ignore_nonreadable = Some(parsed);
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "ignore nonreadable", path, line_number)
+            {
+                state.module_defaults.ignore_nonreadable = Some(parsed);
+            }
         }
         "strict modes" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'strict modes'"),
-                )
-            })?;
-            state.module_defaults.strict_modes = Some(parsed);
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "strict modes", path, line_number)
+            {
+                state.module_defaults.strict_modes = Some(parsed);
+            }
         }
         "forward lookup" => {
             // forward lookup is both P_LOCAL and has a global handler above
             // for reverse_lookup. This arm handles the module-default case.
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'forward lookup'"),
-                )
-            })?;
-            state.module_defaults.forward_lookup = Some(parsed);
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "forward lookup", path, line_number)
+            {
+                state.module_defaults.forward_lookup = Some(parsed);
+            }
         }
         "open noatime" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'open noatime'"),
-                )
-            })?;
-            state.module_defaults.open_noatime = Some(parsed);
+            if let Some(parsed) =
+                apply_boolean_directive(value, true, "open noatime", path, line_number)
+            {
+                state.module_defaults.open_noatime = Some(parsed);
+            }
         }
         "exclude from" => {
             if !value.is_empty() {

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -91,74 +91,51 @@ fn apply_module_directive(
             builder.set_refuse_options(options, path, line_number)?;
         }
         "read only" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'read only'"),
-                )
-            })?;
-            builder.set_read_only(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "read only", path, line_number)
+            {
+                builder.set_read_only(parsed, path, line_number)?;
+            }
         }
         "write only" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'write only'"),
-                )
-            })?;
-            builder.set_write_only(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "write only", path, line_number)
+            {
+                builder.set_write_only(parsed, path, line_number)?;
+            }
         }
         "use chroot" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'use chroot'"),
-                )
-            })?;
-            builder.set_use_chroot(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, true, "use chroot", path, line_number)
+            {
+                builder.set_use_chroot(parsed, path, line_number)?;
+            }
         }
         "numeric ids" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'numeric ids'"),
-                )
-            })?;
-            builder.set_numeric_ids(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, true, "numeric ids", path, line_number)
+            {
+                builder.set_numeric_ids(parsed, path, line_number)?;
+            }
         }
         "list" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'list'"),
-                )
-            })?;
-            builder.set_listable(parsed, path, line_number)?;
+            if let Some(parsed) = apply_boolean_directive(value, false, "list", path, line_number) {
+                builder.set_listable(parsed, path, line_number)?;
+            }
         }
         "fake super" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'fake super'"),
-                )
-            })?;
-            builder.set_fake_super(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "fake super", path, line_number)
+            {
+                builder.set_fake_super(parsed, path, line_number)?;
+            }
         }
         "munge symlinks" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'munge symlinks'"),
-                )
-            })?;
-            builder.set_munge_symlinks(Some(parsed), path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, true, "munge symlinks", path, line_number)
+            {
+                builder.set_munge_symlinks(Some(parsed), path, line_number)?;
+            }
         }
         "uid" => {
             let uid = parse_numeric_identifier(value).ok_or_else(|| {
@@ -221,44 +198,29 @@ fn apply_module_directive(
             )?;
         }
         "max verbosity" => {
-            let parsed: i32 = value.parse().map_err(|_| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid integer value '{value}' for 'max verbosity'"),
-                )
-            })?;
+            let parsed = parse_atoi(value);
             builder.set_max_verbosity(parsed, path, line_number)?;
         }
         "ignore errors" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'ignore errors'"),
-                )
-            })?;
-            builder.set_ignore_errors(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "ignore errors", path, line_number)
+            {
+                builder.set_ignore_errors(parsed, path, line_number)?;
+            }
         }
         "ignore nonreadable" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'ignore nonreadable'"),
-                )
-            })?;
-            builder.set_ignore_nonreadable(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "ignore nonreadable", path, line_number)
+            {
+                builder.set_ignore_nonreadable(parsed, path, line_number)?;
+            }
         }
         "transfer logging" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'transfer logging'"),
-                )
-            })?;
-            builder.set_transfer_logging(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "transfer logging", path, line_number)
+            {
+                builder.set_transfer_logging(parsed, path, line_number)?;
+            }
         }
         "log format" => {
             let format = if value.is_empty() {
@@ -336,34 +298,25 @@ fn apply_module_directive(
             builder.set_charset(cs, path, line_number)?;
         }
         "forward lookup" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'forward lookup'"),
-                )
-            })?;
-            builder.set_forward_lookup(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "forward lookup", path, line_number)
+            {
+                builder.set_forward_lookup(parsed, path, line_number)?;
+            }
         }
         "strict modes" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'strict modes'"),
-                )
-            })?;
-            builder.set_strict_modes(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, false, "strict modes", path, line_number)
+            {
+                builder.set_strict_modes(parsed, path, line_number)?;
+            }
         }
         "open noatime" => {
-            let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                config_parse_error(
-                    path,
-                    line_number,
-                    format!("invalid boolean value '{value}' for 'open noatime'"),
-                )
-            })?;
-            builder.set_open_noatime(parsed, path, line_number)?;
+            if let Some(parsed) =
+                apply_boolean_directive(value, true, "open noatime", path, line_number)
+            {
+                builder.set_open_noatime(parsed, path, line_number)?;
+            }
         }
         // upstream: daemon-parm.txt - `exclude_from` STRING, default NULL.
         // Loaded via parse_filter_file() in clientserver.c.

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -557,10 +557,13 @@ mod config_parsing_tests {
 
 
     #[test]
-    fn parse_invalid_boolean_errors() {
+    fn parse_invalid_boolean_keeps_default() {
+        // upstream: loadparm.c:418-423 - a badly formed boolean warns and
+        // retains the directive's default rather than aborting the load, so
+        // `read only = maybe` leaves read_only at its default (true).
         let file = write_config("[mod]\npath = /tmp\nread only = maybe\n");
-        let err = parse_config_modules(file.path()).expect_err("should fail");
-        assert!(err.to_string().contains("invalid boolean"));
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(result.modules[0].read_only);
     }
 
 
@@ -615,10 +618,21 @@ mod config_parsing_tests {
     }
 
     #[test]
-    fn parse_module_munge_symlinks_invalid_boolean() {
+    fn parse_module_munge_symlinks_invalid_boolean_keeps_default() {
+        // upstream: loadparm.c:418-423 - a badly formed boolean warns and keeps
+        // the default; munge symlinks is unset (None) unless explicitly set.
         let file = write_config("[mod]\npath = /tmp\nmunge symlinks = maybe\n");
-        let err = parse_config_modules(file.path()).expect_err("should fail");
-        assert!(err.to_string().contains("invalid boolean"));
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(result.modules[0].munge_symlinks.is_none());
+    }
+
+    #[test]
+    fn parse_module_munge_symlinks_unset_tristate() {
+        // upstream: loadparm.c:369 - munge symlinks is a P_BOOL3 param, so the
+        // `unset` tri-state is accepted and leaves the setting at its default.
+        let file = write_config("[mod]\npath = /tmp\nmunge symlinks = unset\n");
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(result.modules[0].munge_symlinks.is_none());
     }
 
     #[test]
@@ -656,10 +670,16 @@ mod config_parsing_tests {
     }
 
     #[test]
-    fn parse_module_max_verbosity_invalid() {
+    fn parse_module_max_verbosity_atoi_leniency() {
+        // upstream: loadparm.c:431-433 - P_INTEGER uses atoi(), so "abc" yields
+        // 0 and a trailing suffix like "5x" yields 5, never an error.
         let file = write_config("[mod]\npath = /tmp\nmax verbosity = abc\n");
-        let err = parse_config_modules(file.path()).expect_err("should fail");
-        assert!(err.to_string().contains("invalid integer"));
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].max_verbosity, 0);
+
+        let file = write_config("[mod]\npath = /tmp\nmax verbosity = 5x\n");
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].max_verbosity, 5);
     }
 
     #[test]
@@ -925,10 +945,13 @@ mod config_parsing_tests {
     }
 
     #[test]
-    fn parse_module_strict_modes_invalid_boolean() {
+    fn parse_module_strict_modes_invalid_boolean_keeps_default() {
+        // upstream: loadparm.c:418-423 - a badly formed boolean warns and keeps
+        // the default. `strict modes` defaults to True (daemon-parm.h:203), so
+        // the malformed value must leave it enabled, not clear it.
         let file = write_config("[mod]\npath = /tmp\nstrict modes = maybe\n");
-        let err = parse_config_modules(file.path()).expect_err("should fail");
-        assert!(err.to_string().contains("invalid boolean"));
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(result.modules[0].strict_modes);
     }
 
     #[test]
@@ -984,10 +1007,12 @@ mod config_parsing_tests {
     }
 
     #[test]
-    fn parse_module_open_noatime_invalid_boolean() {
+    fn parse_module_open_noatime_invalid_boolean_keeps_default() {
+        // upstream: loadparm.c:418-423 - a badly formed boolean warns and keeps
+        // the default (open noatime defaults to false).
         let file = write_config("[mod]\npath = /tmp\nopen noatime = maybe\n");
-        let err = parse_config_modules(file.path()).expect_err("should fail");
-        assert!(err.to_string().contains("invalid boolean"));
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(!result.modules[0].open_noatime);
     }
 
     #[test]
@@ -2152,15 +2177,17 @@ mod config_parsing_tests {
     }
 
     #[test]
-    fn parse_global_rsync_port_invalid() {
+    fn parse_global_rsync_port_atoi_leniency() {
+        // upstream: loadparm.c:431-433 - `port` is P_INTEGER, parsed with
+        // atoi(), so "abc" yields 0 (the default port) rather than an error.
         let dir = TempDir::new().expect("create temp dir");
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
 
         let config = format!("port = abc\n[mod]\npath = {}\n", path.display());
         let file = write_config(&config);
-        let result = parse_config_modules(file.path());
-        assert!(result.is_err());
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.rsync_port.map(|(port, _)| port), Some(0));
     }
 
     #[test]

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_boolean_and_id_directives_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_boolean_and_id_directives_from_config.rs
@@ -4,7 +4,7 @@ fn runtime_options_loads_boolean_and_id_directives_from_config() {
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(
         file,
-        "[docs]\npath = /srv/docs\nread only = yes\nwrite only = yes\nnumeric ids = on\nuid = 1234\ngid = 4321\nlist = no\n",
+        "[docs]\npath = /srv/docs\nread only = yes\nwrite only = yes\nnumeric ids = yes\nuid = 1234\ngid = 4321\nlist = no\n",
     )
     .expect("write config");
 

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_boolean_directive.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_boolean_directive.rs
@@ -1,19 +1,16 @@
 #[test]
-fn runtime_options_rejects_invalid_boolean_directive() {
+fn runtime_options_invalid_boolean_keeps_default() {
+    // upstream: loadparm.c:418-423 - do_parameter() ignores set_boolean()'s
+    // failure, so a badly formed boolean warns and retains the directive's
+    // default rather than aborting the load. `read only` defaults to true.
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(file, "[docs]\npath = /srv/docs\nread only = maybe\n").expect("write config");
 
-    let error = RuntimeOptions::parse(&[
+    let options = RuntimeOptions::parse(&[
         OsString::from("--config"),
         file.path().as_os_str().to_os_string(),
     ])
-    .expect_err("invalid boolean should fail");
+    .expect("badly formed boolean must not abort the load");
 
-    assert!(
-        error
-            .message()
-            .to_string()
-            .contains("invalid boolean value 'maybe'")
-    );
+    assert!(options.modules()[0].read_only());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_list_directive.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_list_directive.rs
@@ -1,19 +1,15 @@
 #[test]
-fn runtime_options_rejects_invalid_list_directive() {
+fn runtime_options_invalid_list_boolean_keeps_default() {
+    // upstream: loadparm.c:418-423 - a badly formed boolean warns and retains
+    // the directive's default rather than aborting. `list` defaults to true.
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(file, "[docs]\npath = /srv/docs\nlist = maybe\n").expect("write config");
 
-    let error = RuntimeOptions::parse(&[
+    let options = RuntimeOptions::parse(&[
         OsString::from("--config"),
         file.path().as_os_str().to_os_string(),
     ])
-    .expect_err("invalid list boolean should fail");
+    .expect("badly formed boolean must not abort the load");
 
-    assert!(
-        error
-            .message()
-            .to_string()
-            .contains("invalid boolean value 'maybe' for 'list'")
-    );
+    assert!(options.modules()[0].listable());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_max_connections.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_max_connections.rs
@@ -1,19 +1,15 @@
 #[test]
-fn runtime_options_rejects_invalid_max_connections() {
+fn runtime_options_max_connections_atoi_leniency() {
+    // upstream: loadparm.c:431-433 - `max connections` is P_INTEGER, parsed
+    // with atoi(), so a non-numeric value yields 0 (unlimited), not an error.
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(file, "[docs]\npath = /srv/docs\nmax connections = nope\n").expect("write config");
 
-    let error = RuntimeOptions::parse(&[
+    let options = RuntimeOptions::parse(&[
         OsString::from("--config"),
         file.path().as_os_str().to_os_string(),
     ])
-    .expect_err("invalid max connections should fail");
+    .expect("atoi-lenient max connections must not abort the load");
 
-    assert!(
-        error
-            .message()
-            .to_string()
-            .contains("invalid max connections value")
-    );
+    assert!(options.modules()[0].max_connections().is_none());
 }
-

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_timeout.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_invalid_timeout.rs
@@ -1,14 +1,15 @@
 #[test]
-fn runtime_options_rejects_invalid_timeout() {
+fn runtime_options_timeout_atoi_leniency() {
+    // upstream: loadparm.c:431-433 - `timeout` is P_INTEGER, parsed with
+    // atoi(), so a non-numeric value yields 0 (disabled) rather than an error.
     let mut file = NamedTempFile::new().expect("config file");
     writeln!(file, "[docs]\npath = /srv/docs\ntimeout = never\n").expect("write config");
 
-    let error = RuntimeOptions::parse(&[
+    let options = RuntimeOptions::parse(&[
         OsString::from("--config"),
         file.path().as_os_str().to_os_string(),
     ])
-    .expect_err("invalid timeout should fail");
+    .expect("atoi-lenient timeout must not abort the load");
 
-    assert!(error.message().to_string().contains("invalid timeout"));
+    assert!(options.modules()[0].timeout().is_none());
 }
-


### PR DESCRIPTION
## Summary

Aligns the daemon's `rsyncd.conf` boolean and integer directive parsing with
upstream rsync 3.4.4 (`loadparm.c`). All four fixes live in the shared config
value-parsing layer (`config_helpers/value_parsing.rs`) and are wired through
the live config parser (`config_parsing/module_directives.rs` and
`config_parsing/global_directives/dispatch.rs`).

## Upstream reference

`loadparm.c`:
- `set_boolean()` (363-376): accepts only `yes`/`true`/`1` and `no`/`false`/`0`
  (case-insensitive), plus `unset`/`-1` when `allow_unset` is set (P_BOOL3).
- `do_parameter()` P_BOOL (418-420) and P_BOOL3 (422-423): calls `set_boolean()`
  and ignores its failure return, so a malformed boolean only warns (372) and
  the previous default is retained.
- `do_parameter()` P_INTEGER (431-433): stores `atoi(parmvalue)`.

P_BOOL3 params (`daemon-parm.h`): `use chroot`, `numeric ids`,
`munge symlinks`, `open noatime`. P_INTEGER params: `port`, `listen backlog`,
`max connections`, `max verbosity`, `timeout`.

## Changes

1. BOOL3 `unset` tri-state - the four P_BOOL3 directives now accept `unset`/`-1`
   and leave the setting at its default, mirroring the `allow_unset` branch of
   `set_boolean()`.
2. Malformed boolean is non-fatal - a badly formed boolean value now warns and
   retains the directive's default instead of aborting the load, matching
   `do_parameter()` ignoring `set_boolean()`'s failure return.
3. `on`/`off` rejected - upstream `set_boolean()` recognizes neither, so the
   parser no longer accepts them.
4. Integer atoi leniency - integer directives now parse the leading integer and
   tolerate a trailing non-digit suffix (`5x` -> `5`, `abc` -> `0`), mirroring
   `atoi()`.

A single `atoi()`-faithful `parse_atoi` helper and a single
`apply_boolean_directive` helper keep the bool and integer handling DRY across
both the per-module and global directive paths.

## Tests

New unit tests encode the upstream fidelity intent per gap (BOOL3 `unset` is
valid, malformed boolean keeps the default, `on`/`off` rejected, atoi parses
`5x` -> `5`), plus integration tests through the config loader. Existing tests
that asserted the previous (divergent) abort behavior were updated to assert the
upstream-faithful behavior.

## Validation

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`:
  clean.

## Scope note

The separate command-line inline module-spec path (`module_parsing/`) inherits
the tightened boolean tokens and atoi leniency through the shared helpers; its
error handling for the CLI surface is unchanged.
