### PR TITLE
fix(engine,transfer): guard sender-side --remove-source-files unlink

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -191,6 +191,14 @@ pub(crate) struct CopyContext<'a> {
     /// `RERR_PARTIAL` (exit 23) exit code, mirroring upstream's `FERROR_XFER`
     /// handling of a failed `do_symlink()`.
     unsupported_operation_skipped: bool,
+    /// Set when a `--remove-source-files` source was refused (it changed since
+    /// it was copied, or it is the very inode just written to the destination)
+    /// or its unlink failed. The entry is left in place and the run continues,
+    /// but this flag drives the final `RERR_PARTIAL` (exit 23) exit code,
+    /// mirroring upstream `successful_send()` where every such `FERROR_XFER`
+    /// sets `got_xfer_error` without aborting the transfer.
+    // upstream: sender.c:131-182 successful_send(); log.c:311 got_xfer_error
+    sender_remove_error: bool,
     /// `true` when the active plan carries more than one source operand.
     /// Used to switch `--delete-during` to a deferred sweep so the per-source
     /// keep lists can be merged before any extraneous unlink fires; upstream

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -138,6 +138,7 @@ impl<'a> CopyContext<'a> {
             io_error_delete_warning_emitted: false,
             iconv_conversion_error: false,
             unsupported_operation_skipped: false,
+            sender_remove_error: false,
             multi_source: false,
             verified_parents: HashMap::new(),
             batch_flist_writer,
@@ -395,7 +396,7 @@ impl<'a> CopyContext<'a> {
         store_effective_fake_super_if_requested(&metadata_options, source, destination, metadata)?;
 
         self.record_hard_link(metadata, destination);
-        remove_source_entry_if_requested(self, source, relative, file_type)?;
+        remove_source_entry_if_requested(self, source, destination, metadata, relative, file_type)?;
 
         // Register file for deferred sync (runtime-selected via fsync_enabled)
         self.deferred_sync
@@ -1208,6 +1209,25 @@ impl<'a> CopyContext<'a> {
     /// (`RERR_PARTIAL`) even though every other entry was copied.
     pub(super) const fn unsupported_operation_skipped(&self) -> bool {
         self.unsupported_operation_skipped
+    }
+
+    /// Records that a `--remove-source-files` source could not be removed - it
+    /// was refused by a safety guard (changed since it was copied, or it is the
+    /// same inode as the destination) or its unlink failed. The run continues
+    /// but finishes `RERR_PARTIAL` (exit 23).
+    ///
+    /// upstream: `sender.c:successful_send()` sets `got_xfer_error` via
+    /// `FERROR_XFER` and returns without aborting; `main.c:1630` then exits
+    /// `RERR_PARTIAL`.
+    pub(super) fn record_sender_remove_error(&mut self) {
+        self.sender_remove_error = true;
+    }
+
+    /// Reports whether any `--remove-source-files` removal was refused or
+    /// failed, so the transfer can finish with exit code 23 (`RERR_PARTIAL`)
+    /// even though every other entry was copied.
+    pub(super) const fn sender_remove_error_occurred(&self) -> bool {
+        self.sender_remove_error
     }
 
     /// Reports whether deletions should proceed despite I/O errors.

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -1021,13 +1021,36 @@ pub(crate) fn record_directory_subtree(
     Ok(())
 }
 
-/// Removes the source entry after a successful copy when `--remove-source-files` is active.
+/// Removes the source entry after a successful copy when `--remove-source-files`
+/// is active, applying upstream's `successful_send` safety guards first.
 ///
-/// Directories are never removed (upstream rsync only removes files).
-/// No-ops in dry-run mode.
+/// Mirrors upstream `successful_send()` (sender.c:131-182). Before unlinking the
+/// source the guards run in order:
+///
+/// 1. **Re-stat** the source (`do_lstat`). A vanished source (`ENOENT`) is the
+///    benign "already removed" no-op; any other stat failure is a soft
+///    `RERR_PARTIAL` (exit 23) error that leaves the source in place.
+/// 2. **Destination inode** (Unix): refuse to remove the source when it is the
+///    very inode just written to the destination (a local same-file transfer),
+///    which would otherwise delete the freshly written destination.
+/// 3. **Changed file**: refuse to remove a source whose size or modification
+///    time changed since it was copied (`recorded`), so a file the user
+///    modified mid-transfer is never removed.
+///
+/// Directories are never removed (upstream only removes files). A guard refusal
+/// or an unlink failure records a soft error so the run finishes `RERR_PARTIAL`
+/// (exit 23) without aborting, mirroring upstream's `FERROR_XFER` ->
+/// `got_xfer_error`. No-ops in dry-run mode.
+///
+/// # Upstream Reference
+///
+/// - `sender.c:131-182` `successful_send()`
+/// - `log.c:311` / `main.c:1630` `got_xfer_error` -> `RERR_PARTIAL`
 pub(crate) fn remove_source_entry_if_requested(
     context: &mut CopyContext,
     source: &Path,
+    destination: &Path,
+    recorded: &fs::Metadata,
     record_path: Option<&Path>,
     file_type: fs::FileType,
 ) -> Result<(), LocalCopyError> {
@@ -1035,15 +1058,61 @@ pub(crate) fn remove_source_entry_if_requested(
         return Ok(());
     }
 
-    let source_type = match fs::symlink_metadata(source) {
-        Ok(metadata) => metadata.file_type(),
-        Err(_) => file_type,
+    // upstream: sender.c:150 - re-stat the source before removing it.
+    let current = match fs::symlink_metadata(source) {
+        Ok(metadata) => metadata,
+        // upstream: sender.c:174-175 - ENOENT is the benign "already removed" case.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        // upstream: sender.c:151-153,176-177 - any other re-lstat failure is an
+        // FERROR_XFER: leave the source in place and finish RERR_PARTIAL (23).
+        Err(error) => {
+            eprintln!(
+                "rsync: [sender] sender failed to re-lstat \"{}\": {}",
+                source.display(),
+                crate::local_copy::upstream_io_error(&error),
+            );
+            context.record_sender_remove_error();
+            return Ok(());
+        }
     };
 
-    if source_type.is_dir() {
+    // upstream: sender.c:145 - directories are never removed. Prefer the
+    // freshly-stat'd type; fall back to the copy-time type only if it is a dir.
+    let _ = file_type;
+    if current.file_type().is_dir() {
         return Ok(());
     }
 
+    // upstream: sender.c:155-160 - refuse removal when the source is the very
+    // inode just written to the destination (local_server num_dev_ino_buf).
+    #[cfg(unix)]
+    {
+        if let Ok(destination_meta) = fs::symlink_metadata(destination) {
+            if is_destination_inode(&current, &destination_meta) {
+                eprintln!(
+                    "ERROR: Skipping sender remove of destination file: {}",
+                    source.display()
+                );
+                context.record_sender_remove_error();
+                return Ok(());
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = destination;
+
+    // upstream: sender.c:162-169 - refuse to remove a source that changed size
+    // or modification time since it was copied.
+    if source_identity_changed(recorded, &current) {
+        eprintln!(
+            "ERROR: Skipping sender remove for changed file: {}",
+            source.display()
+        );
+        context.record_sender_remove_error();
+        return Ok(());
+    }
+
+    // upstream: sender.c:171 - do_unlink(fname) once every guard passed.
     match fs::remove_file(source) {
         Ok(()) => {
             info_log!(Remove, 1, "removing source {}", source.display());
@@ -1061,12 +1130,136 @@ pub(crate) fn remove_source_entry_if_requested(
             context.register_progress();
             Ok(())
         }
+        // upstream: sender.c:174-175 - ENOENT after the guards is still benign.
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(LocalCopyError::io(
-            "remove source entry",
-            source.to_path_buf(),
-            error,
-        )),
+        // upstream: sender.c:172-173,176-177 - a failed unlink is an FERROR_XFER:
+        // record the soft error so the run finishes RERR_PARTIAL (23).
+        Err(error) => {
+            eprintln!(
+                "rsync: [sender] sender failed to remove \"{}\": {}",
+                source.display(),
+                crate::local_copy::upstream_io_error(&error),
+            );
+            context.record_sender_remove_error();
+            Ok(())
+        }
+    }
+}
+
+/// Returns true when a freshly re-stat'd source no longer matches the identity
+/// recorded when it was copied, mirroring the changed-file guard in upstream
+/// `successful_send`: size, whole-second mtime, and sub-second mtime compared
+/// only when the recorded timestamp carried nanoseconds (upstream gates the
+/// nsec compare on `NSEC_BUMP`, i.e. a transmitted `FLAG_MOD_NSEC`).
+///
+/// upstream: sender.c:162-169
+#[cfg(unix)]
+fn source_identity_changed(recorded: &fs::Metadata, current: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    recorded.len() != current.len()
+        || recorded.mtime() != current.mtime()
+        || (recorded.mtime_nsec() != 0 && recorded.mtime_nsec() != current.mtime_nsec())
+}
+
+/// Returns true when the re-stat'd source shares the destination's device and
+/// inode - i.e. the source *is* the file just written to the destination, so
+/// removing it would delete the destination.
+///
+/// upstream: sender.c:155-160 `(int64)st.st_dev == IVAL64(num_dev_ino_buf, 4)`
+#[cfg(unix)]
+fn is_destination_inode(source: &fs::Metadata, destination: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    source.dev() == destination.dev() && source.ino() == destination.ino()
+}
+
+/// Non-Unix changed-file guard: compares size and the full-precision
+/// modification time. `recorded` and `current` are both the untouched source at
+/// different instants, so an equality compare never spuriously fires.
+///
+/// upstream: sender.c:162-169
+#[cfg(not(unix))]
+fn source_identity_changed(recorded: &fs::Metadata, current: &fs::Metadata) -> bool {
+    if recorded.len() != current.len() {
+        return true;
+    }
+    match (recorded.modified(), current.modified()) {
+        (Ok(recorded_mtime), Ok(current_mtime)) => recorded_mtime != current_mtime,
+        _ => false,
+    }
+}
+
+#[cfg(all(test, unix))]
+mod sender_remove_guard_tests {
+    use super::{is_destination_inode, source_identity_changed};
+    use filetime::{FileTime, set_file_mtime};
+    use std::fs;
+
+    #[test]
+    fn unchanged_source_is_removable() {
+        // Data safety: a source that still matches its copy-time identity is the
+        // one we transferred, so upstream successful_send unlinks it.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("f");
+        fs::write(&path, b"data").expect("write");
+        let recorded = fs::symlink_metadata(&path).expect("stat");
+        let current = fs::symlink_metadata(&path).expect("stat");
+        assert!(!source_identity_changed(&recorded, &current));
+    }
+
+    #[test]
+    fn grown_source_is_not_removed() {
+        // Data safety: the file grew after it was copied; removing it now would
+        // destroy bytes we never sent (sender.c:162 st_size compare).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("f");
+        fs::write(&path, b"data").expect("write");
+        let recorded = fs::symlink_metadata(&path).expect("stat");
+        fs::write(&path, b"data-and-more").expect("grow");
+        let current = fs::symlink_metadata(&path).expect("stat");
+        assert!(source_identity_changed(&recorded, &current));
+    }
+
+    #[test]
+    fn retouched_source_is_not_removed() {
+        // Data safety: same size but a newer mtime means the file was rewritten
+        // in place; upstream refuses the remove (sender.c:162 st_mtime compare).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("f");
+        fs::write(&path, b"data").expect("write");
+        set_file_mtime(&path, FileTime::from_unix_time(1_600_000_000, 0)).expect("set mtime");
+        let recorded = fs::symlink_metadata(&path).expect("stat");
+        set_file_mtime(&path, FileTime::from_unix_time(1_700_000_000, 0)).expect("set mtime");
+        let current = fs::symlink_metadata(&path).expect("stat");
+        assert!(source_identity_changed(&recorded, &current));
+    }
+
+    #[test]
+    fn hardlinked_source_and_destination_share_inode() {
+        // Data safety: when the destination is a hard link to the source they
+        // share dev/ino, so upstream refuses the sender remove that would
+        // otherwise delete the destination (sender.c:155-160).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = dir.path().join("src");
+        let destination = dir.path().join("dst");
+        fs::write(&source, b"data").expect("write");
+        fs::hard_link(&source, &destination).expect("hardlink");
+        let source_meta = fs::symlink_metadata(&source).expect("stat src");
+        let dest_meta = fs::symlink_metadata(&destination).expect("stat dst");
+        assert!(is_destination_inode(&source_meta, &dest_meta));
+    }
+
+    #[test]
+    fn distinct_files_do_not_share_inode() {
+        // A normal transfer writes a separate destination inode, so the guard
+        // must not fire and the source removal proceeds.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = dir.path().join("src");
+        let destination = dir.path().join("dst");
+        fs::write(&source, b"data").expect("write src");
+        fs::write(&destination, b"data").expect("write dst");
+        let source_meta = fs::symlink_metadata(&source).expect("stat src");
+        let dest_meta = fs::symlink_metadata(&destination).expect("stat dst");
+        assert!(!is_destination_inode(&source_meta, &dest_meta));
     }
 }
 

--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -215,7 +215,14 @@ pub(super) fn handle_dry_run(
         .with_change_set(change_set)
         .with_creation(!destination_previously_existed),
     );
-    remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
+    remove_source_entry_if_requested(
+        context,
+        source,
+        destination,
+        metadata,
+        Some(record_path),
+        file_type,
+    )?;
     Ok(())
 }
 

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -239,7 +239,14 @@ pub(super) fn process_links(
             CreatedEntryKind::HardLink,
             destination_previously_existed,
         );
-        remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
+        remove_source_entry_if_requested(
+            context,
+            source,
+            destination,
+            metadata,
+            Some(record_path),
+            file_type,
+        )?;
         // upstream: generator.c:1006-1007 try_dests_reg() - at match_level 3 the
         // file is only hard-linked; set_file_attrs runs *only* under --atimes.
         // Rewriting metadata unconditionally would, under --fake-super, write a
@@ -373,7 +380,14 @@ pub(super) fn process_links(
                 // instead of the bare path.
                 .with_hardlink_uptodate(true),
             );
-            remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
+            remove_source_entry_if_requested(
+                context,
+                source,
+                destination,
+                metadata,
+                Some(record_path),
+                file_type,
+            )?;
             return Ok(LinkOutcome {
                 copy_source_override: None,
                 reference_basis: None,
@@ -563,7 +577,14 @@ pub(super) fn process_links(
             CreatedEntryKind::HardLink,
             destination_previously_existed,
         );
-        remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
+        remove_source_entry_if_requested(
+            context,
+            source,
+            destination,
+            metadata,
+            Some(record_path),
+            file_type,
+        )?;
         return Ok(LinkOutcome {
             copy_source_override: None,
             reference_basis: None,
@@ -652,7 +673,14 @@ pub(super) fn process_links(
                     .with_change_set(change_set),
                 );
                 context.register_progress();
-                remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
+                remove_source_entry_if_requested(
+                    context,
+                    source,
+                    destination,
+                    metadata,
+                    Some(record_path),
+                    file_type,
+                )?;
                 return Ok(LinkOutcome {
                     copy_source_override: None,
                     reference_basis: None,
@@ -761,6 +789,8 @@ pub(super) fn process_links(
                     remove_source_entry_if_requested(
                         context,
                         source,
+                        destination,
+                        metadata,
                         Some(record_path),
                         file_type,
                     )?;

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -251,6 +251,14 @@ pub(crate) fn copy_sources(
             if context.iconv_conversion_error_occurred() {
                 return Err(LocalCopyError::partial_transfer());
             }
+            // upstream: sender.c:successful_send() - a source refused by a
+            // --remove-source-files safety guard (changed file / destination
+            // inode) or a failed unlink sets got_xfer_error; main.c:1630 then
+            // exits RERR_PARTIAL (23). The per-entry diagnostic was already
+            // printed at the guard site, so surface only the summary error here.
+            if context.sender_remove_error_occurred() {
+                return Err(LocalCopyError::partial_transfer());
+            }
             Ok(())
         })()
     };

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -188,7 +188,14 @@ pub(crate) fn copy_device(
         }
 
         context.register_progress();
-        remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+        remove_source_entry_if_requested(
+            context,
+            source,
+            destination,
+            metadata,
+            record_path.as_deref(),
+            file_type,
+        )?;
         return Ok(());
     }
 
@@ -303,7 +310,14 @@ pub(crate) fn copy_device(
                 destination_previously_existed,
             );
             context.register_progress();
-            remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+            remove_source_entry_if_requested(
+                context,
+                source,
+                destination,
+                metadata,
+                record_path.as_deref(),
+                file_type,
+            )?;
             return Ok(());
         }
     }
@@ -414,7 +428,14 @@ pub(crate) fn copy_device(
         }
 
         context.register_progress();
-        remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+        remove_source_entry_if_requested(
+            context,
+            source,
+            destination,
+            metadata,
+            record_path.as_deref(),
+            file_type,
+        )?;
     }
     Ok(())
 }

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -198,7 +198,14 @@ pub(crate) fn copy_fifo(
         }
 
         context.register_progress();
-        remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+        remove_source_entry_if_requested(
+            context,
+            source,
+            destination,
+            metadata,
+            record_path.as_deref(),
+            file_type,
+        )?;
         return Ok(());
     }
 
@@ -315,7 +322,14 @@ pub(crate) fn copy_fifo(
                 destination_previously_existed,
             );
             context.register_progress();
-            remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+            remove_source_entry_if_requested(
+                context,
+                source,
+                destination,
+                metadata,
+                record_path.as_deref(),
+                file_type,
+            )?;
             return Ok(());
         }
     }
@@ -420,7 +434,14 @@ pub(crate) fn copy_fifo(
     }
 
     context.register_progress();
-    remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+    remove_source_entry_if_requested(
+        context,
+        source,
+        destination,
+        metadata,
+        record_path.as_deref(),
+        file_type,
+    )?;
     Ok(())
 }
 

--- a/crates/engine/src/local_copy/executor/special/mod.rs
+++ b/crates/engine/src/local_copy/executor/special/mod.rs
@@ -99,6 +99,13 @@ pub(super) fn link_special_from_link_dest(
         destination_previously_existed,
     );
     context.register_progress();
-    remove_source_entry_if_requested(context, source, record_path, file_type)?;
+    remove_source_entry_if_requested(
+        context,
+        source,
+        destination,
+        metadata,
+        record_path,
+        file_type,
+    )?;
     Ok(())
 }

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -338,7 +338,14 @@ pub(crate) fn copy_symlink(
             .with_change_set(change_set),
         );
         context.register_progress();
-        remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+        remove_source_entry_if_requested(
+            context,
+            source,
+            destination,
+            metadata,
+            record_path.as_deref(),
+            file_type,
+        )?;
         return Ok(());
     }
 
@@ -411,7 +418,14 @@ pub(crate) fn copy_symlink(
             );
         }
         context.register_progress();
-        remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+        remove_source_entry_if_requested(
+            context,
+            source,
+            destination,
+            metadata,
+            record_path.as_deref(),
+            file_type,
+        )?;
         return Ok(());
     }
 
@@ -500,7 +514,14 @@ pub(crate) fn copy_symlink(
                 destination_previously_existed,
             );
             context.register_progress();
-            remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+            remove_source_entry_if_requested(
+                context,
+                source,
+                destination,
+                metadata,
+                record_path.as_deref(),
+                file_type,
+            )?;
             return Ok(());
         }
     }
@@ -522,7 +543,14 @@ pub(crate) fn copy_symlink(
                 ));
             }
             context.register_progress();
-            remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+            remove_source_entry_if_requested(
+                context,
+                source,
+                destination,
+                metadata,
+                record_path.as_deref(),
+                file_type,
+            )?;
             return Ok(());
         }
 
@@ -581,7 +609,14 @@ pub(crate) fn copy_symlink(
             destination_previously_existed,
         );
         context.register_progress();
-        remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+        remove_source_entry_if_requested(
+            context,
+            source,
+            destination,
+            metadata,
+            record_path.as_deref(),
+            file_type,
+        )?;
         return Ok(());
     }
 
@@ -657,7 +692,14 @@ pub(crate) fn copy_symlink(
             }
         }
         context.register_progress();
-        remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+        remove_source_entry_if_requested(
+            context,
+            source,
+            destination,
+            metadata,
+            record_path.as_deref(),
+            file_type,
+        )?;
         return Ok(());
     }
 
@@ -788,7 +830,14 @@ pub(crate) fn copy_symlink(
         context.record(record);
     }
     context.register_progress();
-    remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+    remove_source_entry_if_requested(
+        context,
+        source,
+        destination,
+        metadata,
+        record_path.as_deref(),
+        file_type,
+    )?;
     Ok(())
 }
 

--- a/crates/engine/src/local_copy/tests/execute_remove_source.rs
+++ b/crates/engine/src/local_copy/tests/execute_remove_source.rs
@@ -554,6 +554,58 @@ fn remove_source_files_summary_tracks_count() {
     assert_eq!(summary.files_copied(), 3);
 }
 
+#[cfg(unix)]
+#[test]
+fn remove_source_files_unlink_failure_exits_partial() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Data safety: a source we cannot unlink must be left in place and the run
+    // must finish RERR_PARTIAL (23) without aborting, mirroring upstream
+    // successful_send() where a failed do_unlink() sets got_xfer_error.
+    if rustix::process::geteuid().as_raw() == 0 {
+        return; // root bypasses the directory write bit, so the unlink succeeds
+    }
+
+    let ctx = test_helpers::setup_copy_test();
+    let locked = ctx.source.join("locked");
+    fs::create_dir_all(&locked).expect("create locked dir");
+    let src_file = locked.join("file.txt");
+    fs::write(&src_file, b"content").expect("write source");
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+
+    let operands = vec![
+        src_file.clone().into_os_string(),
+        ctx.dest.join("file.txt").into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    // Deny write on the source's parent directory so its unlink fails (EACCES).
+    fs::set_permissions(&locked, PermissionsExt::from_mode(0o555)).expect("lock dir");
+
+    let result = plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().remove_source_files(true),
+    );
+
+    // Restore permissions so the tempdir can be cleaned up regardless of outcome.
+    let _ = fs::set_permissions(&locked, PermissionsExt::from_mode(0o755));
+
+    let error = result.expect_err("a failed source unlink must surface an error");
+    assert_eq!(
+        error.exit_code(),
+        23,
+        "a failed source unlink must exit RERR_PARTIAL (23)"
+    );
+    assert!(
+        src_file.exists(),
+        "the source must remain when its unlink failed"
+    );
+    assert!(
+        ctx.dest.join("file.txt").exists(),
+        "the destination copy must still be written"
+    );
+}
+
 #[test]
 fn remove_source_files_with_relative_paths() {
     let ctx = test_helpers::setup_copy_test();

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -726,13 +726,23 @@ impl GeneratorContext {
             }
             files_transferred += 1;
 
-            // upstream: sender.c:129-178 successful_send() - unlink the source
+            // upstream: sender.c:131-182 successful_send() - unlink the source
             // when --remove-source-files is active and the transfer succeeded.
             // Upstream defers the unlink to the MSG_SUCCESS handshake so the
             // receiver's commit is confirmed; we run inline here at the
             // file-transfer boundary because the generator does not exchange
-            // an MSG_SUCCESS round-trip with the receiver.
-            self.remove_source_file_if_requested(&source_path);
+            // an MSG_SUCCESS round-trip with the receiver. The re-stat and
+            // changed-file guards still run, so a source that vanished or was
+            // modified since it entered the file list is never removed, and a
+            // guard refusal or unlink failure sets io_error -> exit 23.
+            let recorded_identity = RecordedSourceIdentity {
+                size: file_entry.size(),
+                mtime: file_entry.mtime(),
+                mtime_nsec: file_entry.mtime_nsec(),
+            };
+            let remove_io_error =
+                self.remove_source_file_if_requested(&source_path, recorded_identity);
+            self.io_error |= remove_io_error;
 
             // upstream: sender.c:445-446
             // rprintf(FINFO, "sender finished %s%s%s\n", path,slash,fname)
@@ -847,37 +857,61 @@ impl GeneratorContext {
         })
     }
 
-    /// Unlinks the sender-side source file when `--remove-source-files` is active.
+    /// Unlinks the sender-side source file when `--remove-source-files` is
+    /// active, applying upstream's `successful_send` safety guards first and
+    /// returning the `io_error` bits the caller must OR into the transfer's
+    /// accumulated error state.
     ///
-    /// Mirrors upstream `successful_send()` in sender.c:129-178: dry-run and
-    /// directory entries are skipped, vanished sources are tolerated as a
-    /// successful no-op, and any other unlink failure is logged but does not
-    /// fail the transfer. Upstream emits `FERROR_XFER` for failed unlinks and
-    /// `FINFO` for the success notice; we mirror that by routing the success
-    /// notice through the `info_log!(Remove, ...)` channel (gated by
-    /// `--info=remove` / `-vv`) and the failure path through `debug_log!`.
+    /// Mirrors upstream `successful_send()` (sender.c:131-182): the source is
+    /// re-stat'd (`do_stat` under `--copy-links`, else `do_lstat`) and is only
+    /// unlinked when it still matches the size and modification time recorded in
+    /// the file list. A vanished source (`ENOENT`) is the benign "already
+    /// removed" notice (`FINFO`); a re-stat failure, a source that changed since
+    /// it entered the file list, or an unlink failure is an `FERROR_XFER`, which
+    /// upstream turns into `got_xfer_error` -> exit 23 (`RERR_PARTIAL`) without
+    /// aborting the run. We mirror the exit code by returning
+    /// [`IOERR_GENERAL`](super::super::io_error_flags::IOERR_GENERAL); the send
+    /// loop reports it via `MSG_IO_ERROR` after the final file.
+    ///
+    /// The dev/ino "destination file" guard (sender.c:155-160) is gated on
+    /// `local_server` upstream. The network generator is never `local_server`
+    /// (local transfers use the engine copy path), so that guard lives only on
+    /// the local-copy side.
     ///
     /// # Upstream Reference
     ///
-    /// - `sender.c:129-178` `successful_send()`
+    /// - `sender.c:131-182` `successful_send()`
     /// - `options.c:765` `remove_source_files` global
-    fn remove_source_file_if_requested(&self, source_path: &Path) {
-        // upstream: sender.c:137-138 - bail before any FS calls when the flag is off.
+    #[must_use]
+    fn remove_source_file_if_requested(
+        &self,
+        source_path: &Path,
+        recorded: RecordedSourceIdentity,
+    ) -> i32 {
+        use super::super::io_error_flags::IOERR_GENERAL;
+
+        // upstream: sender.c:139-140 - bail before any FS calls when the flag is off.
         if !self.config.flags.remove_source_files {
-            return;
+            return 0;
         }
         // upstream: sender.c:131-138 - successful_send() is a no-op when
         // do_xfers is false (dry-run). Mirror that early return so --dry-run
         // never touches the filesystem.
         if self.config.flags.dry_run {
-            return;
+            return 0;
         }
-        match std::fs::remove_file(source_path) {
-            Ok(()) => {
-                // upstream: sender.c:175-176 - rprintf(FINFO, "sender removed %s\n", fname)
-                info_log!(Remove, 1, "removing source {}", source_path.display());
-            }
-            // upstream: sender.c:170-171 - ENOENT is the "already removed" notice.
+
+        // upstream: sender.c:150 - re-stat the source (do_stat under
+        // --copy-links, else do_lstat) before removing it, so a source that
+        // vanished or changed since it entered the file list is never unlinked.
+        let restat = if self.config.flags.copy_links {
+            std::fs::metadata(source_path)
+        } else {
+            std::fs::symlink_metadata(source_path)
+        };
+        let current = match restat {
+            Ok(meta) => meta,
+            // upstream: sender.c:174-175 - ENOENT is the benign FINFO notice.
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
                 info_log!(
                     Remove,
@@ -885,21 +919,113 @@ impl GeneratorContext {
                     "sender file already removed: {}",
                     source_path.display()
                 );
+                return 0;
             }
+            // upstream: sender.c:151-153,176-177 - any other re-lstat failure is
+            // rsyserr(FERROR_XFER, ...), setting got_xfer_error -> exit 23.
             Err(error) => {
-                // upstream: sender.c:172-173 - rsyserr(FERROR_XFER, ...) on
-                // unlink failure. We route to the debug channel instead of
-                // failing the transfer so a single permission error does not
-                // abort the rest of the run.
-                debug_log!(
-                    Send,
-                    1,
-                    "sender failed to remove {}: {}",
+                eprintln!(
+                    "rsync: [sender] sender failed to re-lstat \"{}\": {}",
                     source_path.display(),
-                    error
+                    engine::local_copy::upstream_io_error(&error),
                 );
+                return IOERR_GENERAL;
+            }
+        };
+
+        // upstream: sender.c:162-169 - refuse to remove a source that changed
+        // size or modification time since it entered the file list.
+        let (size, mtime, mtime_nsec) = stat_identity(&current);
+        if source_changed_since_flist(recorded, size, mtime, mtime_nsec) {
+            eprintln!(
+                "ERROR: Skipping sender remove for changed file: {}",
+                source_path.display()
+            );
+            return IOERR_GENERAL;
+        }
+
+        // upstream: sender.c:171 - do_unlink(fname) once every guard passed.
+        match std::fs::remove_file(source_path) {
+            Ok(()) => {
+                // upstream: sender.c:179-180 - INFO_GTE(REMOVE,1) success notice.
+                info_log!(Remove, 1, "removing source {}", source_path.display());
+                0
+            }
+            // upstream: sender.c:174-175 - ENOENT after the guards is still benign.
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                info_log!(
+                    Remove,
+                    1,
+                    "sender file already removed: {}",
+                    source_path.display()
+                );
+                0
+            }
+            // upstream: sender.c:172-173,176-177 - rsyserr(FERROR_XFER, ...) on
+            // unlink failure sets got_xfer_error -> exit 23.
+            Err(error) => {
+                eprintln!(
+                    "rsync: [sender] sender failed to remove \"{}\": {}",
+                    source_path.display(),
+                    engine::local_copy::upstream_io_error(&error),
+                );
+                IOERR_GENERAL
             }
         }
+    }
+}
+
+/// Source-file identity recorded in the file list, compared against a fresh
+/// re-stat before `--remove-source-files` unlinks the source.
+///
+/// upstream: `sender.c:162` compares `st.st_size` / `st.st_mtime` /
+/// `ST_MTIME_NSEC` against the file-list `F_LENGTH` / `modtime` / `F_MOD_NSEC`.
+#[derive(Clone, Copy)]
+struct RecordedSourceIdentity {
+    size: u64,
+    mtime: i64,
+    mtime_nsec: u32,
+}
+
+/// Returns true when a freshly re-stat'd source no longer matches its recorded
+/// file-list identity, mirroring the changed-file guard in upstream
+/// `successful_send`: size, whole-second mtime, and sub-second mtime compared
+/// only when the recorded timestamp carried nanoseconds (upstream gates the
+/// nsec compare on `NSEC_BUMP`, i.e. a transmitted `FLAG_MOD_NSEC`).
+///
+/// upstream: sender.c:162-169
+const fn source_changed_since_flist(
+    recorded: RecordedSourceIdentity,
+    current_size: u64,
+    current_mtime: i64,
+    current_mtime_nsec: u32,
+) -> bool {
+    recorded.size != current_size
+        || recorded.mtime != current_mtime
+        || (recorded.mtime_nsec != 0 && recorded.mtime_nsec != current_mtime_nsec)
+}
+
+/// Extracts `(size, mtime_seconds, mtime_nanoseconds)` from a re-stat result in
+/// the same representation the file list records, so the changed-file guard can
+/// compare like-for-like across platforms.
+fn stat_identity(metadata: &std::fs::Metadata) -> (u64, i64, u32) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        (
+            metadata.len(),
+            metadata.mtime(),
+            metadata.mtime_nsec() as u32,
+        )
+    }
+    #[cfg(not(unix))]
+    {
+        let (secs, nsec) = metadata
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map_or((0, 0), |d| (d.as_secs() as i64, d.subsec_nanos()));
+        (metadata.len(), secs, nsec)
     }
 }
 
@@ -951,5 +1077,72 @@ mod parallel_delta_gate_tests {
     #[test]
     fn min_chunk_floor_is_one_mib() {
         assert_eq!(PARALLEL_DELTA_MIN_CHUNK_BYTES, 1024 * 1024);
+    }
+}
+
+#[cfg(test)]
+mod sender_remove_guard_tests {
+    use super::{RecordedSourceIdentity, source_changed_since_flist, stat_identity};
+
+    fn recorded(size: u64, mtime: i64, mtime_nsec: u32) -> RecordedSourceIdentity {
+        RecordedSourceIdentity {
+            size,
+            mtime,
+            mtime_nsec,
+        }
+    }
+
+    #[test]
+    fn unchanged_source_is_removable() {
+        // Data safety: a source that still matches its file-list identity is the
+        // one we transferred, so upstream successful_send unlinks it.
+        let r = recorded(1024, 1_700_000_000, 500);
+        assert!(!source_changed_since_flist(r, 1024, 1_700_000_000, 500));
+    }
+
+    #[test]
+    fn grown_source_is_not_removed() {
+        // Data safety: the user appended to the file after it entered the flist;
+        // removing it now would destroy data we never sent (sender.c:162).
+        let r = recorded(1024, 1_700_000_000, 0);
+        assert!(source_changed_since_flist(r, 2048, 1_700_000_000, 0));
+    }
+
+    #[test]
+    fn retouched_source_is_not_removed() {
+        // Data safety: same size but a newer mtime means the file was rewritten
+        // in place; upstream refuses the remove (sender.c:162 st_mtime compare).
+        let r = recorded(1024, 1_700_000_000, 0);
+        assert!(source_changed_since_flist(r, 1024, 1_700_000_500, 0));
+    }
+
+    #[test]
+    fn subsecond_change_is_detected_when_flist_carried_nsec() {
+        // Upstream compares nanoseconds only when the flist entry carried them
+        // (NSEC_BUMP); a nonzero recorded nsec makes the compare active.
+        let r = recorded(1024, 1_700_000_000, 500);
+        assert!(source_changed_since_flist(r, 1024, 1_700_000_000, 999));
+    }
+
+    #[test]
+    fn subsecond_change_is_ignored_when_flist_lacked_nsec() {
+        // With no recorded sub-second component the nsec compare must not fire,
+        // or every second-granularity source would be spuriously kept.
+        let r = recorded(1024, 1_700_000_000, 0);
+        assert!(!source_changed_since_flist(r, 1024, 1_700_000_000, 999));
+    }
+
+    #[test]
+    fn stat_identity_reads_size_and_mtime() {
+        // The guard must read back the very identity it wrote, so a freshly
+        // created file compares equal to its own recorded attributes.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("src.bin");
+        std::fs::write(&path, b"hello world").expect("write");
+        let meta = std::fs::symlink_metadata(&path).expect("stat");
+        let (size, mtime, mtime_nsec) = stat_identity(&meta);
+        assert_eq!(size, 11);
+        let r = recorded(size, mtime, mtime_nsec);
+        assert!(!source_changed_since_flist(r, size, mtime, mtime_nsec));
     }
 }


### PR DESCRIPTION
## Summary

Ports upstream's `sender.c:successful_send()` safety guards to oc-rsync's inline
`--remove-source-files` unlink, so a source is never removed when it vanished,
changed, or is the very inode just written to the destination. This is **Stage 1**
of a larger fix: it adds the safety guards only and keeps the existing **inline
unlink timing**. Deferring the unlink to a `MSG_SUCCESS` handshake (upstream's
timing) is intentionally out of scope - it needs a two-sided wire change and would
hang an oc<->oc transfer if done one-sided.

## Upstream reference

`sender.c:131-182` `successful_send()`. Before `do_unlink()`, upstream re-stats the
source and refuses removal on three conditions; a refusal or a failed unlink is an
`FERROR_XFER`, which sets `got_xfer_error` (`log.c:311`) and exits `RERR_PARTIAL`
(23) at `main.c:1630` without aborting the run.

## Guards ported (both the network sender and the local-copy path)

1. **Re-stat** the source (`do_stat` under `--copy-links`, else `do_lstat`). A
   vanished source (`ENOENT`) stays the benign "already removed" no-op; any other
   stat failure refuses the removal and drives exit 23.
2. **Destination inode** (Unix, `sender.c:155-160`): refuse removal when the source
   shares the destination's `dev`/`ino` - i.e. it *is* the file just written -
   which would otherwise delete the destination. On the network path this is
   `local_server`-only upstream, so it lives only on the local-copy side (the
   network generator is never `local_server`).
3. **Changed file** (`sender.c:162-169`): refuse removal when the source's size or
   modification time (plus sub-second time when the recorded timestamp carried
   nanoseconds) differs from what was recorded when it was scheduled for transfer.

## Exit-code wiring (23 / `RERR_PARTIAL`)

- **Network sender** (`generator/transfer/transfer_loop.rs`): the guard predicate
  returns `IOERR_GENERAL`, which the caller ORs into `self.io_error`. The send loop
  already emits that via `MSG_IO_ERROR` after the final file, so the client sees
  exit 23. This replaces the previous downgrade that logged a failed unlink to the
  debug channel and never surfaced any error.
- **Local copy** (`engine/local_copy/executor/cleanup.rs`): a guard refusal or a
  failed unlink records a soft `sender_remove_error` flag and continues, mirroring
  upstream's non-aborting `got_xfer_error`; the run finishes `RERR_PARTIAL` (23) via
  the existing summary path in `sources/orchestration.rs`.

## Tests

Guard predicates are dependency-inverted so they are testable without real
transfers:

- Network side: unchanged source removable; grown/retouched source refused;
  sub-second change detected only when the recorded timestamp carried nanoseconds.
- Local-copy side: same size/mtime cases; hard-linked source/destination share an
  inode (guard fires); distinct files do not; and an end-to-end test that a source
  whose unlink fails is left in place and the run exits 23.
