### PR TITLE
fix(filters): case-sensitive long-form rule keyword match

### DIFF
--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -508,7 +508,9 @@ fn try_parse_long_form(
     let bytes = line.as_bytes();
     for &(keyword, action) in KEYWORDS {
         let klen = keyword.len();
-        if bytes.len() < klen || !bytes[..klen].eq_ignore_ascii_case(keyword.as_bytes()) {
+        // upstream: rule_strcmp uses strncmp, a case-sensitive byte compare, so
+        // only the exact lowercase keyword matches (`EXCLUDE`/`Merge` do not).
+        if bytes.len() < klen || &bytes[..klen] != keyword.as_bytes() {
             continue;
         }
         // The matched prefix is all ASCII, so `klen` is a valid char boundary.
@@ -569,7 +571,9 @@ fn parse_rule_line(
     source_path: &Path,
     line_num: usize,
 ) -> Result<FilterRule, MergeFileError> {
-    if line == "!" || line.eq_ignore_ascii_case("clear") {
+    // upstream: exclude.c:1139 RULE_STRCMP(s, "clear") is a case-sensitive
+    // strncmp, so `CLEAR`/`Clear` are not the clear directive.
+    if line == "!" || line == "clear" {
         return Ok(FilterRule::clear());
     }
 

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -107,6 +107,32 @@ fn parse_clear_long() {
 }
 
 #[test]
+fn long_form_keywords_are_case_sensitive() {
+    // WHY: upstream filter-file compatibility. exclude.c:1069 rule_strcmp uses a
+    // case-sensitive strncmp, so only the exact lowercase keyword is a directive.
+    // A rsync filter file that relies on uppercase keywords must fail identically
+    // under oc, otherwise the two implementations disagree on which rules apply.
+    let excl = parse_rules("exclude foo", Path::new("test")).unwrap();
+    assert_eq!(excl[0].action(), FilterAction::Exclude);
+    assert_eq!(excl[0].pattern(), "foo");
+    let dm = parse_rules("dir-merge .f", Path::new("test")).unwrap();
+    assert_eq!(dm[0].action(), FilterAction::DirMerge);
+    let clr = parse_rules("clear", Path::new("test")).unwrap();
+    assert_eq!(clr[0].action(), FilterAction::Clear);
+
+    // Uppercase / mixed-case keywords are not directives. `EXCLUDE`/`Dir-Merge`/
+    // `CLEAR` start with a non-prefix byte, so upstream reports "Unknown filter
+    // rule" and exits RERR_SYNTAX (exclude.c:1210).
+    for line in ["EXCLUDE foo", "Dir-Merge .f", "CLEAR", "Clear"] {
+        let err = parse_rules(line, Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("Unknown filter rule"),
+            "expected `{line}` to be rejected, got: {err}"
+        );
+    }
+}
+
+#[test]
 fn parse_comments_and_empty_lines() {
     let content = "# Comment\n\n; Another comment\n+ *.txt\n";
     let rules = parse_rules(content, Path::new("test")).unwrap();

--- a/crates/filters/tests/dir_merge_parsing_comprehensive.rs
+++ b/crates/filters/tests/dir_merge_parsing_comprehensive.rs
@@ -246,29 +246,29 @@ fn dir_merge_with_trailing_whitespace_kept() {
 }
 
 #[test]
-fn dir_merge_mixed_case_long_form() {
+fn dir_merge_mixed_case_long_form_rejected() {
     let dir = TempDir::new().unwrap();
     let rules_path = dir.path().join("rules.txt");
 
-    // Mixed case in long form (should be case-insensitive)
+    // upstream: exclude.c:1069 rule_strcmp is a case-sensitive strncmp, so
+    // `Dir-Merge` never matches the `dir-merge` keyword. The leading `D` is not
+    // a valid short-form prefix either, so upstream errors with RERR_SYNTAX
+    // (exclude.c:1210 "Unknown filter rule"). oc must reject it the same way.
     fs::write(&rules_path, "Dir-Merge .rsync-filter\n").unwrap();
 
-    let rules = filters::merge::read_rules(&rules_path).unwrap();
-    assert_eq!(rules.len(), 1);
-    assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    assert!(filters::merge::read_rules(&rules_path).is_err());
 }
 
 #[test]
-fn dir_merge_upper_case_long_form() {
+fn dir_merge_upper_case_long_form_rejected() {
     let dir = TempDir::new().unwrap();
     let rules_path = dir.path().join("rules.txt");
 
-    // All uppercase long form
+    // upstream rejects `DIR-MERGE` for the same reason as the mixed-case form:
+    // a case-sensitive keyword compare plus an invalid short-form prefix `D`.
     fs::write(&rules_path, "DIR-MERGE .rsync-filter\n").unwrap();
 
-    let rules = filters::merge::read_rules(&rules_path).unwrap();
-    assert_eq!(rules.len(), 1);
-    assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    assert!(filters::merge::read_rules(&rules_path).is_err());
 }
 
 #[test]

--- a/crates/filters/tests/filter_rule_syntax.rs
+++ b/crates/filters/tests/filter_rule_syntax.rs
@@ -49,10 +49,16 @@ mod include_rules {
     }
 
     #[test]
-    fn long_form_include_case_insensitive() {
-        let rules = parse_rules("INCLUDE *.txt", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].action(), FilterAction::Include);
+    fn long_form_include_uppercase_errors() {
+        // upstream: exclude.c:1069 rule_strcmp uses a case-sensitive strncmp, so
+        // `INCLUDE` never matches the `include` keyword. The leading `I` is not a
+        // short-form prefix either, so upstream reports "Unknown filter rule" and
+        // exits RERR_SYNTAX (exclude.c:1210).
+        let err = parse_rules("INCLUDE *.txt", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("Unknown filter rule"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -192,10 +198,15 @@ mod exclude_rules {
     }
 
     #[test]
-    fn long_form_exclude_case_insensitive() {
-        let rules = parse_rules("EXCLUDE *.bak", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].action(), FilterAction::Exclude);
+    fn long_form_exclude_uppercase_errors() {
+        // upstream: rule_strcmp is case-sensitive, so `EXCLUDE` is not the
+        // `exclude` keyword, and `E` is not a short-form prefix. rsync 3.4.4
+        // reports "Unknown filter rule" and exits RERR_SYNTAX.
+        let err = parse_rules("EXCLUDE *.bak", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("Unknown filter rule"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -337,10 +348,16 @@ mod clear_rules {
     }
 
     #[test]
-    fn long_form_clear_case_insensitive() {
-        let rules = parse_rules("CLEAR", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].action(), FilterAction::Clear);
+    fn long_form_clear_uppercase_errors() {
+        // upstream: exclude.c:1139 RULE_STRCMP(s, "clear") is a case-sensitive
+        // strncmp, so `CLEAR` is not the clear directive. `C` is not a short-form
+        // prefix either, so rsync 3.4.4 reports "Unknown filter rule" and exits
+        // RERR_SYNTAX.
+        let err = parse_rules("CLEAR", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("Unknown filter rule"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -453,10 +470,15 @@ mod dir_merge_rules {
     }
 
     #[test]
-    fn long_form_dir_merge_case_insensitive() {
-        let rules = parse_rules("DIR-MERGE .rsync-filter", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    fn long_form_dir_merge_uppercase_errors() {
+        // upstream: rule_strcmp is case-sensitive, so `DIR-MERGE` is not the
+        // `dir-merge` keyword, and `D` is not a short-form prefix. rsync 3.4.4
+        // reports "Unknown filter rule" and exits RERR_SYNTAX.
+        let err = parse_rules("DIR-MERGE .rsync-filter", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("Unknown filter rule"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Long-form filter-rule keyword matching in `filters` was case-insensitive, so
oc accepted directives like `EXCLUDE foo`, `Dir-Merge .f`, and `CLEAR` that
upstream rsync rejects. This makes the keyword compare case-sensitive to match
upstream exactly.

Upstream `exclude.c` compares keywords with `rule_strcmp`, a case-sensitive
`strncmp`:

```c
static const uchar *rule_strcmp(const uchar *str, const char *rule, int rule_len)
{
	if (strncmp((char*)str, rule, rule_len) != 0)
		return NULL;
	...
}
```

Every long-form keyword (`clear`, `dir-merge`, `exclude`, `hide`, `include`,
`merge`, `protect`, `risk`, `show`) is dispatched through `RULE_STRCMP` in
`parse_rule_tok` (exclude.c:1139-1171), so only the exact lowercase keyword is a
directive. A mixed/upper-case token whose leading byte is not a short-form
prefix falls through to `default:` and rsync reports `Unknown filter rule` and
exits `RERR_SYNTAX` (exclude.c:1210).

## Changes

- `crates/filters/src/merge/parse.rs`: replace the `eq_ignore_ascii_case`
  keyword-prefix compare in `try_parse_long_form` with an exact lowercase byte
  compare; make the `clear` check `line == "clear"` (was
  `eq_ignore_ascii_case("clear")`). Separator handling (whitespace / `_` / `,` /
  end-of-string) is untouched.

## Tests

- New lib unit test `long_form_keywords_are_case_sensitive` encoding the
  upstream-compat rationale: lowercase `exclude foo` / `dir-merge .f` / `clear`
  parse as directives; `EXCLUDE foo` / `Dir-Merge .f` / `CLEAR` / `Clear` are
  rejected with `Unknown filter rule`.
- Flipped four integration tests that previously asserted case-insensitive
  acceptance to assert upstream rejection, with upstream citations
  (`long_form_{include,exclude,dir_merge,clear}_*` and the two
  `dir_merge_*_case_long_form` tests). The existing `HIDE`/`SHOW`/`PROTECT`/
  `RISK` uppercase tests already asserted rejection and are unchanged.

Full `filters` suite: 1421 passed. `cargo fmt --all` and
`cargo clippy -p filters --all-targets --all-features --no-deps -D warnings`
clean.

## Note (out of scope)

The CLI crate has a separate command-line filter-directive parser
(`crates/cli/.../parsing/`, `parse_keyword_rule` / `parse_dir_merge_alias`)
that is still case-insensitive. That is a distinct divergence from this
merge-file/`filters` fix and is left for a follow-up.
