### PR TITLE
fix(daemon): rsyncd.conf backslash continuation and include scoping

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -57,10 +57,10 @@ fn apply_global_directive(
             // upstream: params.c:parse_directives - `&include` and `&merge` both
             // pull configuration from another file. The historical `include =`
             // form is retained as a synonym so existing oc-rsync configs keep
-            // working. `&merge` differs from `&include` in upstream only in
-            // global-defaults handling for directory inclusion; we apply file
-            // contents uniformly because oc-rsync does not yet track Vars push/
-            // pop semantics for directory globbing.
+            // working. `&include` runs under a private global scope (`]push`/
+            // `]pop`) so the included file's globals do not leak back, and a
+            // directory target globs `*.conf`; `&merge` shares the current scope
+            // and globs `*.inc`. `apply_include_directive` implements both.
             apply_include_directive(state, key, value, path, line_number, canonical, stack)?;
         }
         "motd file" => {

--- a/crates/daemon/src/daemon/sections/config_parsing/include_merge.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/include_merge.rs
@@ -28,25 +28,109 @@ fn apply_include_directive(
     }
 
     let include_path = resolve_config_relative_path(canonical, trimmed);
-    // upstream: loadparm.c::lp_load() &include handling - pass the parent
-    // state's globals into the recursive parse so modules declared in the
-    // included file inherit the parent's P_LOCAL defaults (use chroot,
-    // hosts allow, secrets file, etc.), matching upstream's shared `Vars`
-    // semantics across the `]push`/`]pop` boundary.
-    let included =
-        parse_config_modules_inner(&include_path, stack, Some(state)).map_err(|error| {
-            // Wrap inner failures so the user sees both the directive site that
-            // triggered the include and the underlying parse error from the
-            // included file. Missing-file and recursive-include errors already
-            // name the offending path; this wrap adds the parent line context.
-            let display = include_path.display();
-            config_parse_error(
+
+    // upstream: params.c:parse_directives - `&include` maps to
+    // include_config(val, 1) (a private global scope, `]push`/`]pop`) while
+    // `&merge` maps to include_config(val, 0) (the current scope is shared).
+    // The legacy `include =` synonym follows `&include`.
+    let manage_globals = directive != "&merge";
+
+    // upstream: params.c:include_config - when the target is a directory, every
+    // matching entry is pulled in: "*.conf" for `&include`, "*.inc" for
+    // `&merge`, processed in sorted (strcmp) order.
+    if fs::metadata(&include_path)
+        .map(|meta| meta.is_dir())
+        .unwrap_or(false)
+    {
+        let suffix = if manage_globals { ".conf" } else { ".inc" };
+        let mut entries = Vec::new();
+        let dir = fs::read_dir(&include_path)
+            .map_err(|error| config_io_error("read", &include_path, error))?;
+        for entry in dir {
+            let entry = entry.map_err(|error| config_io_error("read", &include_path, error))?;
+            if entry.file_name().to_string_lossy().ends_with(suffix) {
+                entries.push(entry.path());
+            }
+        }
+        entries.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+        for entry in entries {
+            include_config_file(
+                state,
+                directive,
+                &entry,
                 path,
                 line_number,
-                format!("failed to process '{directive} {display}': {error}"),
-            )
-        })?;
+                stack,
+                manage_globals,
+            )?;
+        }
+        return Ok(());
+    }
 
+    include_config_file(
+        state,
+        directive,
+        &include_path,
+        path,
+        line_number,
+        stack,
+        manage_globals,
+    )
+}
+
+/// Parses a single included config file and folds its results into `state`.
+///
+/// `manage_globals` selects the upstream scope semantics: `&include`
+/// (`manage_globals = true`) runs under `]push`/`]pop`, so only the included
+/// modules survive and the file's global directives are discarded; `&merge`
+/// shares the scope and merges the included globals into the current state.
+fn include_config_file(
+    state: &mut GlobalParseState,
+    directive: &str,
+    include_path: &Path,
+    path: &Path,
+    line_number: usize,
+    stack: &mut Vec<PathBuf>,
+    manage_globals: bool,
+) -> Result<(), DaemonError> {
+    // upstream: params.c:include_config - the recursive parse continues against
+    // the parent's globals so modules declared in the included file inherit the
+    // parent's P_LOCAL defaults (use chroot, hosts allow, secrets file, ...),
+    // matching the shared `Vars` that `]push` copies (not resets).
+    let included = parse_config_modules_inner(include_path, stack, Some(state)).map_err(|error| {
+        // Wrap inner failures so the user sees both the directive site that
+        // triggered the include and the underlying parse error from the
+        // included file. Missing-file and recursive-include errors already
+        // name the offending path; this wrap adds the parent line context.
+        let display = include_path.display();
+        config_parse_error(
+            path,
+            line_number,
+            format!("failed to process '{directive} {display}': {error}"),
+        )
+    })?;
+
+    if manage_globals {
+        // `&include`: `]pop` restores the parent's globals afterwards, so the
+        // included file's global directives do not leak back into the caller.
+        // Only the modules (upstream's section list) survive.
+        state.modules.extend(included.modules);
+        return Ok(());
+    }
+
+    // `&merge`: the scope is shared, so the included file's globals merge into
+    // the current state (later duplicate detection matches the shared `Vars`).
+    merge_included_globals(state, included)
+}
+
+/// Merges an included file's modules and global directives into `state`.
+///
+/// Used for `&merge` (and directory entries pulled in via `&merge`), where the
+/// included file shares the current scope.
+fn merge_included_globals(
+    state: &mut GlobalParseState,
+    included: ParsedConfigModules,
+) -> Result<(), DaemonError> {
     if !included.modules.is_empty() {
         state.modules.extend(included.modules);
     }

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -43,9 +43,8 @@ fn parse_config_modules_inner(
     let mut current: Option<ModuleDefinitionBuilder> = None;
 
     let result = (|| -> Result<ParsedConfigModules, DaemonError> {
-        for (index, raw_line) in contents.lines().enumerate() {
-            let line_number = index + 1;
-            let line = raw_line.trim();
+        for (line_number, logical_line) in logical_config_lines(&contents) {
+            let line = logical_line.trim();
 
             if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
                 continue;
@@ -192,6 +191,60 @@ fn finish_module_builder(
         default_use_chroot,
         &state.module_defaults,
     )
+}
+
+/// Splits `contents` into logical config lines, joining backslash-continued
+/// physical lines into one.
+///
+/// upstream: params.c:Continuation() - a physical line whose last
+/// non-whitespace character is a backslash continues onto the following line;
+/// the backslash and the newline are removed and the two lines are joined into
+/// a single logical line. Comment (`#`/`;`) and blank lines are emitted
+/// verbatim because upstream consumes them with EatComment/EatWhitespace,
+/// neither of which scans for the continuation character. Each logical line is
+/// paired with the 1-based number of its first physical line so diagnostics
+/// keep pointing at the directive's start.
+fn logical_config_lines(contents: &str) -> Vec<(usize, String)> {
+    let physical: Vec<&str> = contents.lines().collect();
+    let mut logical = Vec::with_capacity(physical.len());
+    let mut index = 0;
+
+    while index < physical.len() {
+        let start_line = index + 1;
+        let first = physical[index];
+        index += 1;
+
+        let leading = first.trim_start();
+        if leading.is_empty() || leading.starts_with('#') || leading.starts_with(';') {
+            logical.push((start_line, first.to_owned()));
+            continue;
+        }
+
+        let mut joined = first.to_owned();
+        while let Some(offset) = continuation_offset(&joined) {
+            // Drop the trailing backslash (and any whitespace after it),
+            // matching upstream which resumes writing over the '\\' position.
+            joined.truncate(offset);
+            if index >= physical.len() {
+                break;
+            }
+            joined.push_str(physical[index]);
+            index += 1;
+        }
+        logical.push((start_line, joined));
+    }
+
+    logical
+}
+
+/// Returns the byte offset of a trailing line-continuation backslash when the
+/// last non-whitespace character of `line` is a `\\`.
+///
+/// upstream: params.c:Continuation() - scans backwards past trailing
+/// whitespace and reports the offset of the `\\` (or -1 when it is absent).
+fn continuation_offset(line: &str) -> Option<usize> {
+    let trimmed = line.trim_end();
+    trimmed.ends_with('\\').then(|| trimmed.len() - 1)
 }
 
 fn resolve_config_relative_path(config_path: &Path, value: &str) -> PathBuf {

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -499,6 +499,130 @@ mod config_parsing_tests {
     }
 
     #[test]
+    fn backslash_continuation_joins_directive_value() {
+        // upstream: params.c:Continuation() - a line ending in a backslash is
+        // joined with the next physical line into one logical directive. Split
+        // across two lines, the `World` fragment on its own is not a valid
+        // `key = value` line, so a config that failed to join would error;
+        // proving the join is what makes this parse succeed as one directive.
+        let file = write_config("motd = Hello \\\nWorld\n");
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.motd_lines, vec!["Hello World"]);
+    }
+
+    #[test]
+    fn backslash_continuation_not_applied_to_comment_line() {
+        // upstream: params.c:Parse() - comment lines are consumed by
+        // EatComment(), which never scans for the continuation character, so a
+        // trailing backslash on a comment must not swallow the following
+        // directive. Were it wrongly continued, the `motd` line would be eaten
+        // and `motd_lines` would be empty.
+        let file = write_config("# a trailing backslash comment \\\nmotd = Real\n");
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.motd_lines, vec!["Real"]);
+    }
+
+    #[test]
+    fn amp_include_directory_globs_conf_files_sorted() {
+        // upstream: params.c:include_config() - an `&include` of a directory
+        // pulls in every `*.conf` entry (never `*.inc`), processed in sorted
+        // order.
+        let dir = TempDir::new().expect("create temp dir");
+        let data = dir.path().join("data");
+        fs::create_dir(&data).expect("create data dir");
+
+        let conf_dir = dir.path().join("conf.d");
+        fs::create_dir(&conf_dir).expect("create conf dir");
+        fs::write(
+            conf_dir.join("b.conf"),
+            format!("[mod_b]\npath = {}\n", data.display()),
+        )
+        .expect("write b.conf");
+        fs::write(
+            conf_dir.join("a.conf"),
+            format!("[mod_a]\npath = {}\n", data.display()),
+        )
+        .expect("write a.conf");
+        // A `*.inc` file and an unrelated file must both be ignored by
+        // `&include`.
+        fs::write(
+            conf_dir.join("z.inc"),
+            format!("[mod_z]\npath = {}\n", data.display()),
+        )
+        .expect("write z.inc");
+        fs::write(conf_dir.join("notes.txt"), "ignored\n").expect("write notes.txt");
+
+        let main_config = format!("&include {}\n", conf_dir.display());
+        let main_file = write_config(&main_config);
+
+        let result = parse_config_modules(main_file.path()).expect("parse succeeds");
+        let names: Vec<&str> = result.modules.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(names, vec!["mod_a", "mod_b"]);
+    }
+
+    #[test]
+    fn amp_merge_directory_globs_inc_files() {
+        // upstream: params.c:include_config() - an `&merge` of a directory
+        // pulls in every `*.inc` entry (never `*.conf`).
+        let dir = TempDir::new().expect("create temp dir");
+        let data = dir.path().join("data");
+        fs::create_dir(&data).expect("create data dir");
+
+        let inc_dir = dir.path().join("inc.d");
+        fs::create_dir(&inc_dir).expect("create inc dir");
+        fs::write(
+            inc_dir.join("first.inc"),
+            format!("[mod_inc]\npath = {}\n", data.display()),
+        )
+        .expect("write first.inc");
+        fs::write(
+            inc_dir.join("other.conf"),
+            format!("[mod_conf]\npath = {}\n", data.display()),
+        )
+        .expect("write other.conf");
+
+        let main_config = format!("&merge {}\n", inc_dir.display());
+        let main_file = write_config(&main_config);
+
+        let result = parse_config_modules(main_file.path()).expect("parse succeeds");
+        let names: Vec<&str> = result.modules.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(names, vec!["mod_inc"]);
+    }
+
+    #[test]
+    fn amp_include_global_directives_do_not_leak_to_parent() {
+        // upstream: params.c:include_config() - `&include` wraps the parse in
+        // `]push`/`]pop`, restoring the parent's global `Vars` afterwards, so a
+        // global directive set only inside the included file must not surface in
+        // the parent configuration.
+        let included = write_config("bwlimit = 2000\n");
+        let main_config = format!("&include {}\n", included.path().display());
+        let main_file = write_config(&main_config);
+
+        let result = parse_config_modules(main_file.path()).expect("parse succeeds");
+        assert!(
+            result.global_bandwidth_limit.is_none(),
+            "&include must not leak the included file's globals into the parent",
+        );
+    }
+
+    #[test]
+    fn amp_merge_global_directives_leak_to_parent() {
+        // upstream: params.c:include_config() - `&merge` shares the current
+        // scope (no `]push`/`]pop`), so a global directive set inside the merged
+        // file does take effect in the parent configuration.
+        let included = write_config("bwlimit = 2000\n");
+        let main_config = format!("&merge {}\n", included.path().display());
+        let main_file = write_config(&main_config);
+
+        let result = parse_config_modules(main_file.path()).expect("parse succeeds");
+        assert!(
+            result.global_bandwidth_limit.is_some(),
+            "&merge must merge the included file's globals into the parent",
+        );
+    }
+
+    #[test]
     fn parse_recursive_include_detected() {
         let dir = TempDir::new().expect("create temp dir");
         let config_path = dir.path().join("config.conf");


### PR DESCRIPTION
## Summary

Aligns `rsyncd.conf` parsing in the `daemon` crate with upstream rsync 3.4.4 `params.c`, closing three include/continuation divergences.

## Changes

### 1. Backslash line continuation (`params.c:Continuation`, line 154)
A physical line whose last non-whitespace character is a backslash now continues onto the following line: the backslash and newline are removed and the two lines are joined into one logical directive before dispatch. Comment (`#`/`;`) and blank lines are never continued, matching upstream where `EatComment`/`EatWhitespace` consume them without scanning for the continuation character. Logical lines keep the 1-based number of their first physical line for diagnostics.

### 2. Directory targets for `&include` / `&merge` (`params.c:include_config`, lines 413-477)
When the include target is a directory, every matching entry is now pulled in, in sorted (`strcmp`) order:
- `&include <dir>` globs `*.conf`
- `&merge <dir>` globs `*.inc`

A regular-file target keeps the previous single-file behaviour, and missing-path errors still name the directive and path.

### 3. `&include` vs `&merge` global scoping (`params.c:parse_directives` 479-487, `include_config` 425-429)
`&include` now runs under a private global scope (upstream's `]push`/`]pop`): the included file inherits the parent's current globals as defaults, but its own global directives do **not** leak back into the parent - only its modules survive. `&merge` continues to share the current scope and merge the included file's globals into it. The legacy `include =` synonym follows `&include`.

## Tests

Six unit tests added, each encoding the upstream-fidelity intent:
- a backslash-continued directive parses as one logical line;
- a trailing backslash on a comment line does not swallow the next directive;
- `&include` of a directory pulls in its `*.conf` files sorted (ignoring `*.inc`/others);
- `&merge` of a directory pulls in its `*.inc` files;
- `&include` global directives do not leak to the parent;
- `&merge` global directives do leak to the parent.

## Validation
- `cargo fmt --all` clean
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo test -p daemon --lib config_parsing_tests`: 177 passed
