### PR TITLE
ci: pin nightly toolchain around rustc_ast ICE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, beta, nightly]
+        # Nightly pinned to 2026-06-15 to dodge a rustc_ast attribute-parsing
+        # ICE in current nightly (compiler/rustc_ast/src/attr/mod.rs:307).
+        # Remove the date to track floating nightly once the regression lands.
+        toolchain: [stable, beta, nightly-2026-06-15]
 
     steps:
       - name: Free disk space
@@ -240,7 +243,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, beta, nightly]
+        # Nightly pinned to 2026-06-15 to dodge a rustc_ast attribute-parsing
+        # ICE in current nightly (compiler/rustc_ast/src/attr/mod.rs:307).
+        # Remove the date to track floating nightly once the regression lands.
+        toolchain: [stable, beta, nightly-2026-06-15]
 
     steps:
       - name: Checkout
@@ -553,7 +559,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, beta, nightly]
+        # Nightly pinned to 2026-06-15 to dodge a rustc_ast attribute-parsing
+        # ICE in current nightly (compiler/rustc_ast/src/attr/mod.rs:307).
+        # Remove the date to track floating nightly once the regression lands.
+        toolchain: [stable, beta, nightly-2026-06-15]
 
     steps:
       - name: Checkout
@@ -612,7 +621,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, beta, nightly]
+        # Nightly pinned to 2026-06-15 to dodge a rustc_ast attribute-parsing
+        # ICE in current nightly (compiler/rustc_ast/src/attr/mod.rs:307).
+        # Remove the date to track floating nightly once the regression lands.
+        toolchain: [stable, beta, nightly-2026-06-15]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

The informational nightly toolchain cells (`nextest (nightly)`, `Windows (nightly)`, `macOS (nightly)`, `Linux musl (nightly)`) fail repo-wide with a rustc internal compiler error while compiling `core`/`engine`/`cli`/`metadata`/`apple-fs`:

```
thread 'rustc' panicked at compiler/rustc_ast/src/attr/mod.rs:307:36
error: the compiler unexpectedly panicked. this is a bug.
```

This is a regression in the current floating nightly rustc (attribute parsing in `rustc_ast`), not in our code. It is red on master today and, because these cells are `continue-on-error`, it does not block merges but leaves the nightly matrix permanently red and hides any real nightly-only regression behind the ICE.

## Change

Pin the nightly matrix entry to `nightly-2026-06-15`, a dated nightly that predates the ICE, across all four toolchain-matrix cells in `ci.yml`:

- `nextest (${{ matrix.toolchain }})`
- `Windows (${{ matrix.toolchain }})`
- `macOS (${{ matrix.toolchain }})`
- `Linux musl (${{ matrix.toolchain }})`

`dtolnay/rust-toolchain` accepts the dated `nightly-YYYY-MM-DD` form, so this is a one-token change per matrix. Stable and beta are untouched; all `continue-on-error` / `if:` gates key only off `stable`, so required check names and gating are unchanged.

A short comment above each matrix notes the reason, the pinned date, and the removal path once the upstream regression lands.

## Follow-up

Drop the date (revert to floating `nightly`) once the `rustc_ast` attribute-parsing ICE is fixed upstream and a clean nightly is available.
