### PR TITLE
test(daemon): align chunk tests with upstream boolean/atoi parsing

### DIFF
--- a/crates/daemon/src/tests/chunks/parse_boolean_directive_interprets_common_forms.rs
+++ b/crates/daemon/src/tests/chunks/parse_boolean_directive_interprets_common_forms.rs
@@ -1,13 +1,17 @@
 #[test]
 fn parse_boolean_directive_interprets_common_forms() {
-    for value in ["1", "true", "YES", " On "] {
+    for value in ["1", "true", "YES"] {
         assert_eq!(parse_boolean_directive(value), Some(true));
     }
 
-    for value in ["0", "false", "No", " off "] {
+    for value in ["0", "false", "No"] {
         assert_eq!(parse_boolean_directive(value), Some(false));
     }
 
-    assert_eq!(parse_boolean_directive("maybe"), None);
+    // upstream: loadparm.c:363-376 set_boolean() accepts only yes/true/1 and
+    // no/false/0 - on/off are never recognized, so they are malformed (None),
+    // like any other unrecognized value.
+    for value in [" On ", " off ", "maybe"] {
+        assert_eq!(parse_boolean_directive(value), None);
+    }
 }
-

--- a/crates/daemon/src/tests/chunks/parse_max_connections_directive_handles_zero_and_positive.rs
+++ b/crates/daemon/src/tests/chunks/parse_max_connections_directive_handles_zero_and_positive.rs
@@ -1,13 +1,14 @@
 #[test]
 fn parse_max_connections_directive_handles_zero_and_positive() {
-    assert_eq!(parse_max_connections_directive(""), None);
-    assert_eq!(parse_max_connections_directive("  "), None);
+    // upstream: `max connections` is a P_INTEGER directive read via atoi()
+    // (loadparm.c:431-433). atoi maps an empty, whitespace-only, non-numeric,
+    // or non-positive value to <= 0, which means unlimited -> Some(None).
+    assert_eq!(parse_max_connections_directive(""), Some(None));
+    assert_eq!(parse_max_connections_directive("  "), Some(None));
     assert_eq!(parse_max_connections_directive("0"), Some(None));
+    assert_eq!(parse_max_connections_directive("-1"), Some(None));
+    assert_eq!(parse_max_connections_directive("invalid"), Some(None));
 
     let expected = NonZeroU32::new(25).expect("non-zero");
     assert_eq!(parse_max_connections_directive("25"), Some(Some(expected)));
-
-    assert_eq!(parse_max_connections_directive("-1"), None);
-    assert_eq!(parse_max_connections_directive("invalid"), None);
 }
-

--- a/crates/daemon/src/tests/chunks/parse_timeout_seconds_supports_zero_and_non_zero_values.rs
+++ b/crates/daemon/src/tests/chunks/parse_timeout_seconds_supports_zero_and_non_zero_values.rs
@@ -1,11 +1,13 @@
 #[test]
 fn parse_timeout_seconds_supports_zero_and_non_zero_values() {
-    assert_eq!(parse_timeout_seconds(""), None);
-    assert_eq!(parse_timeout_seconds("  "), None);
+    // upstream: `timeout` is a P_INTEGER directive read via atoi()
+    // (loadparm.c:431-433). atoi maps an empty, whitespace-only, non-numeric,
+    // or non-positive value to <= 0, which disables the timeout -> Some(None).
+    assert_eq!(parse_timeout_seconds(""), Some(None));
+    assert_eq!(parse_timeout_seconds("  "), Some(None));
     assert_eq!(parse_timeout_seconds("0"), Some(None));
+    assert_eq!(parse_timeout_seconds("invalid"), Some(None));
 
     let expected = NonZeroU64::new(30).expect("non-zero timeout");
     assert_eq!(parse_timeout_seconds("30"), Some(Some(expected)));
-    assert_eq!(parse_timeout_seconds("invalid"), None);
 }
-


### PR DESCRIPTION
## Summary

Three `crates/daemon/src/tests/chunks/*` tests still asserted the pre-unification
behavior of the shared config value-parser and broke on master once the parser
was made upstream-faithful. This aligns all three with upstream rsync 3.4.4; the
parser code is correct and unchanged.

## Upstream reference

- `loadparm.c:363-376` `set_boolean()` accepts only `yes`/`true`/`1` and
  `no`/`false`/`0` (case-insensitive), plus `unset`/`-1` for the tri-state
  P_BOOL3. `on`/`off` are never recognized and are treated as malformed.
- `loadparm.c:431-433` reads P_INTEGER directives (`timeout`, `max connections`)
  with `atoi()`. `atoi` maps empty, whitespace-only, non-numeric, or
  non-positive input to `<= 0`, which means the directive's zero default
  (timeout disabled, connections unlimited).

## Tests updated

- `parse_boolean_directive_interprets_common_forms`: `on`/`off` now expect
  `None` (malformed), grouped with `maybe`.
- `parse_max_connections_directive_handles_zero_and_positive`: empty,
  whitespace, `-1`, and `invalid` now expect `Some(None)` (unlimited), matching
  atoi leniency; `25` still yields `Some(Some(25))`.
- `parse_timeout_seconds_supports_zero_and_non_zero_values`: empty, whitespace,
  and `invalid` now expect `Some(None)` (disabled), matching atoi leniency; `30`
  still yields `Some(Some(30))`.

These assertions now mirror the already-correct canonical tests in
`config_helpers/tests.rs`. The other config-parser directives read via `atoi`
(max verbosity, port, listen backlog) have no chunk tests asserting the old
strict behavior, so no further test changes are needed.

## CI impact

Fixes the master-red cells caused by the stale assertions: `Linux musl
(stable)`, `nextest (beta)`, `Windows daemon`, and every `Feature flag
combinations` job (`tracing`/`iconv`/`async`/`concurrent-sessions` on
windows-latest and macos-latest).

## Validation

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`:
  clean
- daemon lib tests for the parse and runtime-options families: 198 passed,
  0 failed (all three fixed chunk tests included).
