### PR TITLE
fix(cli): parse forwarded --debug= server arg, not as a path

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -183,6 +183,18 @@ pub(super) struct ServerLongFlags {
     /// `make_output_option(info_words, info_levels, ...)`, so the server
     /// receives `--info=...` whenever the client has non-default info levels.
     pub(super) info: Vec<OsString>,
+    /// Raw `--debug=FLAGS` values forwarded by the client.
+    ///
+    /// The client forwards explicitly-set debug levels via
+    /// `make_output_option(debug_words, ...)` so an oc peer raises its debug
+    /// output to match (`client/remote/output_option.rs`). The receiving side
+    /// parses `--debug=...` the same way upstream parses a user `--debug` arg
+    /// (options.c:1777 `parse_output_words(debug_words, ...)`), silently
+    /// ignoring unknown tokens because `am_server` (options.c:475). Without
+    /// capturing it here the token falls through to
+    /// `parse_server_flag_string_and_args` and is mistaken for a positional
+    /// destination path (`failed to create destination root --debug=hlink4`).
+    pub(super) debug: Vec<OsString>,
     /// Explicit compression algorithm forwarded by the client.
     ///
     /// upstream: options.c:2800-2805 - `server_options()` emits long-form
@@ -397,6 +409,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         timeout: None,
         reference_directories: Vec::new(),
         info: Vec::new(),
+        debug: Vec::new(),
         compress_choice: None,
         compression_level: None,
         log_format: None,
@@ -769,6 +782,11 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
     // parse_info_flags_server (mirroring `am_server` in parse_output_words).
     } else if let Some(value) = s.strip_prefix("--info=") {
         flags.info.push(OsString::from(value));
+    // The client forwards explicitly-set debug levels the same way it forwards
+    // --info; capture the raw value so run_server_mode applies it tolerantly
+    // (unknown tokens ignored, mirroring `am_server` in parse_output_words).
+    } else if let Some(value) = s.strip_prefix("--debug=") {
+        flags.debug.push(OsString::from(value));
     // upstream: options.c:2915-2923 - reference directory args
     } else if let Some(value) = s.strip_prefix("--compare-dest=") {
         flags.reference_directories.push(ReferenceDirectory::new(
@@ -906,6 +924,11 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--io-uring-depth=")
         || arg.starts_with("--log-format=")
         || arg.starts_with("--info=")
+        // upstream: options.c:1777 - `--debug=FLAGS` parsed via
+        // parse_output_words(debug_words, ...). The client forwards it like
+        // --info; recognise it so the value is consumed, not mistaken for a
+        // positional destination path.
+        || arg.starts_with("--debug=")
         || arg.starts_with("--partial-dir=")
         // upstream: options.c:2850-2851 - `--only-write-batch=X` reaches a
         // server receiver on a push. Recognise it so the placeholder token is

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -173,6 +173,22 @@ where
         }
     }
 
+    // upstream: options.c:1777 / 475 - the client forwards explicitly-set debug
+    // levels (`--debug=hlink4`) the same way it forwards `--info`. Apply each
+    // forwarded token to the thread-local debug config so debug_log! callsites on
+    // the server side honour the client's request. Unknown tokens are silently
+    // ignored because `am_server` (options.c:475), so a newer client can forward
+    // categories this build has not learned yet without aborting the transfer.
+    for value in &long_flags.debug {
+        let text = value.to_string_lossy();
+        for token in text.split(',') {
+            let token = token.trim();
+            if !token.is_empty() {
+                let _ = logging::apply_debug_flag(token);
+            }
+        }
+    }
+
     // Boolean and move-only flags applied after value parsing releases its borrow.
     config.deletion.ignore_errors = long_flags.ignore_errors;
     config.write.fsync = long_flags.fsync;

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -528,6 +528,64 @@ fn parse_server_args_skips_only_write_batch_flag() {
     assert!(is_known_server_long_flag("--only-write-batch=X"));
 }
 
+/// Regression for the forwarded `--debug=FLAGS` server arg. The client forwards
+/// explicitly-set debug levels (`--debug=hlink4`, level baked into the token)
+/// to the peer via `make_output_option`. Before recognition the token fell
+/// through to the positional list and the receiver tried to create a
+/// destination root literally named `--debug=hlink4` (exit 12,
+/// `failed to create destination root --debug=hlink4`). It must be captured as
+/// a flag so the real paths `.` and `to/` remain the sole positionals.
+#[test]
+fn parse_server_args_skips_debug_flag() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--sender"),
+        OsString::from("-vvlHogDtpre.iLsfxCIvu"),
+        OsString::from("--debug=hlink4"),
+        OsString::from("--log-format=%i%I"),
+        OsString::from("."),
+        OsString::from("to/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-vvlHogDtpre.iLsfxCIvu");
+    // The `.` flags/paths separator is dropped (parse.rs:68), so the sole
+    // positional is the real destination root; `--debug=hlink4` must not appear.
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("to/")],
+        "--debug=hlink4 must not leak into the positional path list",
+    );
+    assert!(is_known_server_long_flag("--debug=hlink4"));
+
+    let long = parse_server_long_flags(&args);
+    assert_eq!(long.debug, vec![OsString::from("hlink4")]);
+}
+
+/// The forwarded `--info=FLAGS` arg (already recognised) must likewise be
+/// captured rather than leaking into the positional path list, including the
+/// concatenated `name{level}` spelling the client emits.
+#[test]
+fn parse_server_args_skips_info_flag() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpre.iLsfxCIvu"),
+        OsString::from("--info=name2"),
+        OsString::from("."),
+        OsString::from("to/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpre.iLsfxCIvu");
+    assert_eq!(
+        pos_args,
+        vec![OsString::from("to/")],
+        "--info=name2 must not leak into the positional path list",
+    );
+    assert!(is_known_server_long_flag("--info=name2"));
+
+    let long = parse_server_long_flags(&args);
+    assert_eq!(long.info, vec![OsString::from("name2")]);
+}
+
 /// `parse_server_long_flags` records `--only-write-batch=X` as
 /// `only_write_batch == true`.
 #[test]


### PR DESCRIPTION
## Problem

The `upstream-testsuite` `hardlinks` test fails (exit 12), blocking all PRs. The remote-shell leg spawns the server as:

```
oc-rsync --server -vvlHogDtpre.iLsfxCIvu --debug=hlink4 --log-format=%i%I . to/
```

and the server dies with:

```
server error: failed to create destination root --debug=hlink4: Permission denied (os error 13) [receiver]
```

## Root cause

The client forwards explicitly-set `--debug=`/`--info=` levels to the peer as server args. The server has a dedicated flag parser (`crates/cli/src/frontend/server/flags.rs`) separate from the client clap parser. That parser recognised `--info=` but had no `--debug=` case:

- `is_known_server_long_flag()` did not return true for `--debug=...`, so `parse_server_flag_string_and_args` treated the token as a positional operand.
- With the `.` flags/paths separator dropped, `--debug=hlink4` became the destination root, and the receiver tried to `mkdir` it (exit 12).

`--info=` was already handled, so only `--debug=` regressed.

## Fix

Surgical, server-side only (forwarding is unchanged and correct):

- Add a `debug: Vec<OsString>` field to `ServerLongFlags`.
- Capture `--debug=VALUE` in `parse_value_bearing_flag` (mirrors the existing `--info=` handling).
- Recognise `--debug=` in `is_known_server_long_flag` so the token is consumed, not treated as a path.
- Apply the forwarded debug tokens to the server's thread-local debug config via `logging::apply_debug_flag`, silently ignoring unknown tokens. This mirrors upstream `parse_output_words` (`options.c:1777`), whose unknown-item error is gated on `!am_server` (`options.c:475`). The value parser already handles the concatenated `name{level}` form and the oc-specific categories (`iouring`/`clone`/`sockopt`/`iocp`).

## Tests

Added parser-level regression guards in `crates/cli/src/frontend/server/tests.rs`:

- `parse_server_args_skips_debug_flag` - parses the exact failing server argv and asserts `--debug=hlink4` is captured (not leaked) and the sole positional is `to/`. Fails on the base (`left: ["--debug=hlink4", "to/"]`), passes after.
- `parse_server_args_skips_info_flag` - companion guard for `--info=name2`.

The oc-specific `name{level}` categories (`clone2`, etc.) are already covered by `logging::config` unit tests, which is the exact parser this path calls.

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy -p cli -p core --all-targets --all-features --no-deps -- -D warnings` - clean
- `cargo test -p cli --lib parse_server_args_skips` - 12 passed
- RED confirmed on the base commit before the fix.
