### PR TITLE
fix(cli): case-sensitive long-form filter directive keywords

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/directives.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/directives.rs
@@ -61,7 +61,13 @@ pub(super) fn parse_dir_merge_alias(trimmed: &str) -> Option<Result<FilterDirect
 
     let mut matched_prefix = None;
     for alias in DIR_MERGE_ALIASES {
-        if trimmed.len() >= alias.len() && trimmed[..alias.len()].eq_ignore_ascii_case(alias) {
+        // upstream: exclude.c:1143 RULE_STRCMP(s, "dir-merge") is a case-sensitive
+        // strncmp reached via `case 'd'`, so `DIR-MERGE`/`Dir-Merge` never match
+        // the keyword. Compare bytes exactly (the `per-dir` alias is an oc-rsync
+        // extension held to the same case-sensitivity for consistency). Every
+        // alias is ASCII, so an equal prefix guarantees `alias.len()` is a char
+        // boundary, keeping the slices below panic-safe.
+        if trimmed.as_bytes().starts_with(alias.as_bytes()) {
             matched_prefix = Some((&trimmed[..alias.len()], &trimmed[alias.len()..]));
             break;
         }

--- a/crates/cli/src/frontend/filter_rules/parsing/entry.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/entry.rs
@@ -123,7 +123,12 @@ pub(super) fn parse_rule_directive(text: &str) -> Result<FilterDirective, Messag
         return Err(message);
     }
 
-    if trimmed.eq_ignore_ascii_case("clear") {
+    // upstream: exclude.c:1139 RULE_STRCMP(s, "clear") is a case-sensitive
+    // strncmp reached only via `case 'c'`, so `CLEAR`/`Clear` are not the clear
+    // directive - they fall through to the inner switch default and raise
+    // "Unknown filter rule". Match the exact lowercase keyword, matching the
+    // merge-file path (merge/parse.rs parse_rule_line).
+    if trimmed == "clear" {
         return Ok(FilterDirective::Clear);
     }
 

--- a/crates/cli/src/frontend/filter_rules/parsing/rules.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/rules.rs
@@ -122,27 +122,33 @@ pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Messa
         Ok(FilterDirective::Rule(rule))
     };
 
-    if keyword.eq_ignore_ascii_case("include") {
+    // upstream: exclude.c:1069-1078 rule_strcmp - the long-form keywords are
+    // matched with a case-sensitive strncmp dispatched from a switch on the
+    // lowercase first byte (exclude.c:1137-1173). A mixed-case keyword such as
+    // `EXCLUDE`/`Include` therefore never matches; it reaches the inner switch
+    // default and raises "Unknown filter rule" (RERR_SYNTAX). Compare exactly so
+    // this parser mirrors that behaviour rather than silently coercing the case.
+    if keyword == "include" {
         return build_rule(FilterRuleSpec::include, true, true);
     }
 
-    if keyword.eq_ignore_ascii_case("exclude") {
+    if keyword == "exclude" {
         return build_rule(FilterRuleSpec::exclude, true, true);
     }
 
-    if keyword.eq_ignore_ascii_case("show") {
+    if keyword == "show" {
         return build_rule(FilterRuleSpec::show, false, false);
     }
 
-    if keyword.eq_ignore_ascii_case("hide") {
+    if keyword == "hide" {
         return build_rule(FilterRuleSpec::hide, false, false);
     }
 
-    if keyword.eq_ignore_ascii_case("protect") {
+    if keyword == "protect" {
         return build_rule(FilterRuleSpec::protect, false, false);
     }
 
-    if keyword.eq_ignore_ascii_case("risk") {
+    if keyword == "risk" {
         return build_rule(FilterRuleSpec::risk, false, false);
     }
 

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -41,10 +41,19 @@ fn parse_clear_keyword() {
 }
 
 #[test]
-fn parse_clear_keyword_uppercase() {
+fn parse_clear_keyword_uppercase_is_error() {
+    // upstream: exclude.c:1139 RULE_STRCMP(s, "clear") is a case-sensitive
+    // strncmp reached only via `case 'c'`. `CLEAR` misses it, reaches the inner
+    // switch default, and raises "Unknown filter rule" (RERR_SYNTAX). A drop-in
+    // must reject it, not silently coerce the case into a clear directive.
     let result = parse_filter_directive(OsStr::new("CLEAR"));
-    assert!(result.is_ok());
-    assert!(matches!(result.unwrap(), FilterDirective::Clear));
+    assert!(result.is_err());
+}
+
+#[test]
+fn parse_clear_keyword_mixed_case_is_error() {
+    let result = parse_filter_directive(OsStr::new("Clear"));
+    assert!(result.is_err());
 }
 
 #[test]
@@ -267,10 +276,17 @@ fn dir_merge_per_dir_alias() {
 }
 
 #[test]
-fn dir_merge_case_insensitive() {
-    let result = parse_dir_merge_alias("DIR-MERGE .filter");
-    assert!(result.is_some());
-    assert!(result.unwrap().is_ok());
+fn dir_merge_uppercase_is_not_keyword() {
+    // upstream: exclude.c:1143 RULE_STRCMP(s, "dir-merge") is a case-sensitive
+    // strncmp reached via `case 'd'`. `DIR-MERGE` never matches, so this parser
+    // must decline it (returns None) and let the caller error, rather than
+    // treating a mixed-case spelling as the dir-merge directive.
+    assert!(parse_dir_merge_alias("DIR-MERGE .filter").is_none());
+    assert!(parse_dir_merge_alias("Dir-Merge .filter").is_none());
+    // The lowercase keyword still parses as the dir-merge directive.
+    let ok = parse_dir_merge_alias("dir-merge .filter");
+    assert!(ok.is_some());
+    assert!(ok.unwrap().is_ok());
 }
 
 #[test]
@@ -366,9 +382,19 @@ fn keyword_risk() {
 }
 
 #[test]
-fn keyword_case_insensitive() {
-    let result = parse_keyword_rule("INCLUDE *.rs");
-    assert!(result.is_ok());
+fn keyword_mixed_case_is_error() {
+    // upstream: exclude.c:1069-1078 rule_strcmp - long-form keywords are matched
+    // with a case-sensitive strncmp dispatched from a switch on the lowercase
+    // first byte (exclude.c:1147/1155). `INCLUDE`/`Exclude` never match; they
+    // reach the inner switch default and raise "Unknown filter rule". A drop-in
+    // must error rather than coerce the case into the include/exclude rule.
+    assert!(parse_keyword_rule("INCLUDE *.rs").is_err());
+    assert!(parse_keyword_rule("Include *.rs").is_err());
+    assert!(parse_keyword_rule("EXCLUDE *.bak").is_err());
+    assert!(parse_keyword_rule("Merge foo").is_err());
+    // Lowercase keywords still parse as their rule.
+    assert!(parse_keyword_rule("include *.rs").is_ok());
+    assert!(parse_keyword_rule("exclude *.bak").is_ok());
 }
 
 #[test]
@@ -402,6 +428,39 @@ fn long_merge_missing_path() {
 fn long_merge_non_matching() {
     let result = parse_long_merge_directive("include pattern");
     assert!(result.is_none());
+}
+
+#[test]
+fn long_merge_mixed_case_is_not_keyword() {
+    // upstream: exclude.c:1159 RULE_STRCMP(s, "merge") is a case-sensitive
+    // strncmp reached via `case 'm'`. `Merge`/`MERGE` never match the merge
+    // directive, so this parser declines them (returns None); the lowercase
+    // keyword still parses as a merge directive.
+    assert!(parse_long_merge_directive("Merge filter.rules").is_none());
+    assert!(parse_long_merge_directive("MERGE filter.rules").is_none());
+    assert!(parse_long_merge_directive("merge filter.rules").is_some());
+}
+
+#[test]
+fn filter_directive_mixed_case_keywords_are_errors() {
+    // End-to-end through the top-level dispatcher: mixed-case long-form keywords
+    // must be rejected exactly as upstream rsync rejects them (RERR_SYNTAX),
+    // while the lowercase spelling parses. upstream: exclude.c:1137-1173.
+    for rule in [
+        "Merge foo",
+        "INCLUDE bar",
+        "Exclude baz",
+        "Dir-Merge .f",
+        "CLEAR",
+    ] {
+        assert!(
+            parse_filter_directive(OsStr::new(rule)).is_err(),
+            "mixed-case keyword `{rule}` must be rejected"
+        );
+    }
+    assert!(parse_filter_directive(OsStr::new("merge foo")).is_ok());
+    assert!(parse_filter_directive(OsStr::new("include bar")).is_ok());
+    assert!(parse_filter_directive(OsStr::new("clear")).is_ok());
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/parse_filter.rs
+++ b/crates/cli/src/frontend/tests/parse_filter.rs
@@ -135,12 +135,15 @@ fn parse_filter_directive_accepts_clear_keyword() {
     let keyword = parse_filter_directive(OsStr::new("clear")).expect("keyword parses");
     assert_eq!(keyword, FilterDirective::Clear);
 
-    let uppercase = parse_filter_directive(OsStr::new("CLEAR")).expect("uppercase parses");
-    assert_eq!(uppercase, FilterDirective::Clear);
+    // upstream: exclude.c:1139 RULE_STRCMP(s, "clear") is a case-sensitive
+    // strncmp reached only via `case 'c'`, so `CLEAR` misses it, reaches the
+    // inner switch default, and errors with "Unknown filter rule". It is not a
+    // clear directive.
+    let _ = parse_filter_directive(OsStr::new("CLEAR")).expect_err("uppercase should error");
 
-    // upstream: exclude.c:1211-1213,1318-1320 - a leading space errors before the
-    // keyword is recognised, and trailing text on a clear rule is rejected with
-    // "'!' rule has trailing characters"; neither is trimmed away.
+    // upstream: exclude.c:1211-1213 - a leading space errors before any keyword
+    // is recognised, and the keyword is case-sensitive besides; neither the
+    // whitespace nor the case is normalised away.
     let _ = parse_filter_directive(OsStr::new("  CLEAR  "))
         .expect_err("surrounding whitespace should error");
 }


### PR DESCRIPTION
## Summary

Makes the command-line `--filter`/`--include`/`--exclude` directive parser
match the long-form rule keywords case-sensitively, matching upstream rsync.
This extends the same upstream fidelity previously applied to the
`.rsync-filter`/merge-file rule parser to the distinct command-line code path.

The cmdline parser (`crates/cli/src/frontend/filter_rules/parsing/`) matched
the long-form keywords with `eq_ignore_ascii_case`, so a mixed-case spelling
was silently accepted as the rule keyword:

- `--filter='INCLUDE bar'` / `--filter='Exclude baz'` -> treated as include/exclude
- `--filter='Dir-Merge .f'` -> treated as dir-merge
- `--filter='CLEAR'` -> treated as clear

## Upstream behaviour

Upstream matches these keywords with a case-sensitive `strncmp`
(`exclude.c:1069-1078` `rule_strcmp`) dispatched from a `switch` on the
lowercase first byte (`exclude.c:1137-1173`). A mixed-case keyword misses
every case, reaches the inner `switch` default, and raises
"Unknown filter rule" (`RERR_SYNTAX`). Only the single-char short forms and
modifiers are matched as-specified. `merge` already used a case-sensitive
`strip_prefix`; this brings `include`, `exclude`, `show`, `hide`, `protect`,
`risk`, `dir-merge`, and `clear` in line.

## Changes

- `parsing/rules.rs` `parse_keyword_rule`: exact match for include/exclude/show/hide/protect/risk.
- `parsing/entry.rs`: exact match for `clear`.
- `parsing/directives.rs` `parse_dir_merge_alias`: byte-exact prefix match for `dir-merge` (the non-upstream `per-dir` alias is held to the same case-sensitivity for consistency).

## Tests

Flipped three tests that encoded the old case-insensitive behaviour and added
end-to-end coverage through `parse_filter_directive`. Each test cites the
upstream rule and asserts mixed-case keywords error while the lowercase
spelling still parses. Verified RED without the fix (5 tests fail) and GREEN
with it.

`cargo fmt --all`, `cargo clippy -p filters -p cli --all-targets --all-features --no-deps -- -D warnings` (clean), and targeted `cargo test -p cli --lib` all pass.
