### PR TITLE
feat(protocol): honor RSYNC_CHECKSUM_LIST/RSYNC_COMPRESS_LIST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,6 +2779,7 @@ dependencies = [
  "lz4_flex",
  "md-5",
  "memchr",
+ "platform",
  "proptest",
  "rustc-hash 2.1.3",
  "serde",

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -59,6 +59,7 @@ tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+platform = { path = "../platform" }
 proptest = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/protocol/src/negotiation/capabilities/env_list.rs
+++ b/crates/protocol/src/negotiation/capabilities/env_list.rs
@@ -1,0 +1,148 @@
+//! `RSYNC_CHECKSUM_LIST` / `RSYNC_COMPRESS_LIST` overrides for the algorithm
+//! negotiation candidate lists.
+//!
+//! Upstream rsync lets an operator override or restrict the ordered list of
+//! negotiable checksum and compression algorithms through two environment
+//! variables. When set, the variable's whitespace-separated names replace the
+//! built-in preference order a peer advertises during `negotiate_the_strings()`
+//! and uses to select a mutually supported algorithm. An unset or empty value
+//! leaves the built-in default order untouched, so the default wire bytes are
+//! unchanged.
+//!
+//! Names are canonicalised to their wire spelling (e.g. the `xxhash` alias
+//! becomes `xxh64`, matching upstream's `main_nni` rewrite), de-duplicated, and
+//! kept in the order the variable lists them. Unrecognised or build-unsupported
+//! names are dropped; when a value holds names but none survive, the parsed list
+//! collapses to the literal `INVALID`, which fails negotiation just as upstream
+//! does.
+//!
+//! # Upstream reference
+//!
+//! - `compat.c:409-424 getenv_nstr()` - reads the variable and applies the
+//!   server-side `&` split.
+//! - `compat.c:281-331 parse_nni_str()` - validates, de-duplicates and reorders
+//!   the names, canonicalising aliases and emitting `INVALID` when no name
+//!   survives.
+//! - `compat.c:506-533 send_negotiate_str()` - advertises the parsed list,
+//!   falling back to `get_default_nno_list()` when the value is empty.
+
+use super::algorithms::{
+    ChecksumAlgorithm, CompressionAlgorithm, SUPPORTED_CHECKSUMS, supported_compressions,
+};
+
+/// Environment variable that overrides the checksum negotiation list.
+const CHECKSUM_LIST_ENV: &str = "RSYNC_CHECKSUM_LIST";
+/// Environment variable that overrides the compression negotiation list.
+const COMPRESS_LIST_ENV: &str = "RSYNC_COMPRESS_LIST";
+
+/// Sentinel emitted when a value held names but none were recognised.
+///
+/// upstream: compat.c:327-328 `parse_nni_str()`.
+const INVALID: &str = "INVALID";
+
+/// An environment override applied to a negotiation candidate list.
+pub(super) struct EnvOverride {
+    /// Space-joined names to advertise on the wire. Equals [`INVALID`] when the
+    /// value held names but none were recognised.
+    pub advertised: String,
+    /// Ordered canonical wire names used for local algorithm selection. Empty
+    /// when `advertised` is [`INVALID`].
+    pub candidates: Vec<&'static str>,
+}
+
+/// Returns the checksum candidate override from `RSYNC_CHECKSUM_LIST`, or
+/// `None` when the variable is unset or holds only whitespace - in which case
+/// the caller keeps the built-in default order.
+pub(super) fn checksum_candidates(is_server: bool) -> Option<EnvOverride> {
+    parse_env(CHECKSUM_LIST_ENV, is_server, resolve_checksum)
+}
+
+/// Returns the compression candidate override from `RSYNC_COMPRESS_LIST`, or
+/// `None` when the variable is unset or holds only whitespace.
+pub(super) fn compression_candidates(is_server: bool) -> Option<EnvOverride> {
+    parse_env(COMPRESS_LIST_ENV, is_server, resolve_compression)
+}
+
+/// Resolves a checksum name to its canonical wire spelling, or `None` when the
+/// name is not a build-supported algorithm. Accepts the `xxhash` alias and any
+/// ASCII casing, mirroring upstream's case-insensitive `get_nni_by_name`.
+fn resolve_checksum(name: &str) -> Option<&'static str> {
+    let canonical = ChecksumAlgorithm::parse(&name.to_ascii_lowercase())
+        .ok()?
+        .as_str();
+    SUPPORTED_CHECKSUMS
+        .contains(&canonical)
+        .then_some(canonical)
+}
+
+/// Resolves a compression name to its canonical wire spelling, or `None` when
+/// the name is not a build-supported algorithm. Feature-gated codecs (lz4,
+/// zstd) absent from this build are treated as unrecognised, matching upstream's
+/// compile-time `valid_compressions_items[]` gating.
+fn resolve_compression(name: &str) -> Option<&'static str> {
+    let canonical = CompressionAlgorithm::parse(&name.to_ascii_lowercase())
+        .ok()?
+        .as_str();
+    supported_compressions()
+        .contains(&canonical)
+        .then_some(canonical)
+}
+
+/// Core parser shared by both variables.
+///
+/// Mirrors `getenv_nstr()` + `parse_nni_str()`: applies the `&` client/server
+/// split, tokenises on whitespace, resolves and de-duplicates names in the
+/// listed order, drops unrecognised names, and yields the [`INVALID`] sentinel
+/// when names were present but none survived.
+fn parse_env(
+    key: &str,
+    is_server: bool,
+    resolve: impl Fn(&str) -> Option<&'static str>,
+) -> Option<EnvOverride> {
+    let raw = std::env::var(key).ok()?;
+
+    // upstream: compat.c:417-421 getenv_nstr - the server uses only the portion
+    // after the first '&', while the client stops at it because parse_nni_str
+    // treats '&' as a token terminator (compat.c:291-292). A value without '&'
+    // is used whole by both sides.
+    let scoped = match raw.split_once('&') {
+        Some((before, after)) => {
+            if is_server {
+                after
+            } else {
+                before
+            }
+        }
+        None => raw.as_str(),
+    };
+
+    // upstream: compat.c:435-438 / 512,519 - an empty or all-whitespace value is
+    // treated as unset, leaving the built-in default order in place.
+    scoped.split_whitespace().next()?;
+
+    let mut candidates: Vec<&'static str> = Vec::new();
+    for token in scoped.split_whitespace() {
+        // upstream: compat.c:295-306 - unrecognised names are dropped and the
+        // first occurrence of each algorithm wins (duplicates removed).
+        if let Some(name) = resolve(token) {
+            if !candidates.contains(&name) {
+                candidates.push(name);
+            }
+        }
+    }
+
+    // upstream: compat.c:327-328 - names were seen but none were valid, so the
+    // parsed list collapses to "INVALID", which is advertised verbatim and
+    // subsequently fails to negotiate a mutual algorithm.
+    if candidates.is_empty() {
+        return Some(EnvOverride {
+            advertised: INVALID.to_string(),
+            candidates,
+        });
+    }
+
+    Some(EnvOverride {
+        advertised: candidates.join(" "),
+        candidates,
+    })
+}

--- a/crates/protocol/src/negotiation/capabilities/env_list.rs
+++ b/crates/protocol/src/negotiation/capabilities/env_list.rs
@@ -9,8 +9,11 @@
 //! leaves the built-in default order untouched, so the default wire bytes are
 //! unchanged.
 //!
-//! Names are canonicalised to their wire spelling (e.g. the `xxhash` alias
-//! becomes `xxh64`, matching upstream's `main_nni` rewrite), de-duplicated, and
+//! A recognised alias is rewritten to its canonical wire spelling (e.g. the
+//! `xxhash` alias becomes `xxh64`, matching upstream's `main_nni` rewrite);
+//! every other name keeps the operator's original bytes verbatim, including its
+//! casing, so the advertised vstring is byte-for-byte what upstream emits.
+//! Lookup and selection remain case-insensitive. Names are de-duplicated and
 //! kept in the order the variable lists them. Unrecognised or build-unsupported
 //! names are dropped; when a value holds names but none survive, the parsed list
 //! collapses to the literal `INVALID`, which fails negotiation just as upstream
@@ -121,12 +124,23 @@ fn parse_env(
     scoped.split_whitespace().next()?;
 
     let mut candidates: Vec<&'static str> = Vec::new();
+    let mut advertised: Vec<String> = Vec::new();
     for token in scoped.split_whitespace() {
         // upstream: compat.c:295-306 - unrecognised names are dropped and the
         // first occurrence of each algorithm wins (duplicates removed).
-        if let Some(name) = resolve(token) {
-            if !candidates.contains(&name) {
-                candidates.push(name);
+        if let Some(canonical) = resolve(token) {
+            if !candidates.contains(&canonical) {
+                candidates.push(canonical);
+                // upstream: compat.c:298-304 - only a recognised alias (an entry
+                // whose main_nni points elsewhere) is rewritten to its canonical
+                // spelling; every other name keeps the operator's original bytes
+                // verbatim on the wire, including casing. A token that differs
+                // from its canonical name only in ASCII case is not an alias.
+                if token.eq_ignore_ascii_case(canonical) {
+                    advertised.push(token.to_string());
+                } else {
+                    advertised.push(canonical.to_string());
+                }
             }
         }
     }
@@ -142,7 +156,7 @@ fn parse_env(
     }
 
     Some(EnvOverride {
-        advertised: candidates.join(" "),
+        advertised: advertised.join(" "),
         candidates,
     })
 }

--- a/crates/protocol/src/negotiation/capabilities/mod.rs
+++ b/crates/protocol/src/negotiation/capabilities/mod.rs
@@ -28,6 +28,7 @@
 //! - Upstream: `compat.c:332-391` (parse_negotiate_str, recv_negotiate_str)
 
 mod algorithms;
+mod env_list;
 mod negotiate;
 
 pub use algorithms::{ChecksumAlgorithm, CompressionAlgorithm};

--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -11,6 +11,7 @@ use crate::nstr::{
 use super::algorithms::{
     ChecksumAlgorithm, CompressionAlgorithm, SUPPORTED_CHECKSUMS, supported_compressions,
 };
+use super::env_list;
 
 /// Configuration for capability negotiation.
 ///
@@ -297,14 +298,36 @@ pub fn negotiate_capabilities_with_override(
     // symmetrically. Sending a single-entry list here would desync against an
     // upstream peer that sends nothing.
     let send_checksum = checksum_override.is_none();
+
+    // upstream: compat.c:506-533 send_negotiate_str - RSYNC_CHECKSUM_LIST /
+    // RSYNC_COMPRESS_LIST, when set, replace the advertised default order and the
+    // local candidate list used for selection; an empty value falls through to
+    // get_default_nno_list() so the default wire bytes are unchanged.
+    let checksum_env = if send_checksum {
+        env_list::checksum_candidates(is_server)
+    } else {
+        None
+    };
+    let compression_env = if send_compression {
+        env_list::compression_candidates(is_server)
+    } else {
+        None
+    };
+
     if send_checksum {
-        let checksum_list = advertised_list(SUPPORTED_CHECKSUMS.iter().copied(), is_server);
+        let checksum_list = match &checksum_env {
+            Some(env) => env.advertised.clone(),
+            None => advertised_list(SUPPORTED_CHECKSUMS.iter().copied(), is_server),
+        };
         trace_send_list(side, NstrCategory::Checksum, &checksum_list);
         write_vstring(stdout, &checksum_list)?;
     }
 
     if send_compression {
-        let compression_list = advertised_list(supported_compressions(), is_server);
+        let compression_list = match &compression_env {
+            Some(env) => env.advertised.clone(),
+            None => advertised_list(supported_compressions(), is_server),
+        };
         trace_send_list(side, NstrCategory::Compress, &compression_list);
         write_vstring(stdout, &compression_list)?;
     }
@@ -346,7 +369,13 @@ pub fn negotiate_capabilities_with_override(
         Some(forced) => forced,
         None => {
             let list = remote_checksum_list.as_deref().unwrap_or("");
-            choose_checksum_algorithm(list, is_server)?
+            // upstream: compat.c:350 - selection matches remote names against our
+            // local `saw` list, which the env override reorders/restricts.
+            let candidates: &[&str] = match &checksum_env {
+                Some(env) => &env.candidates,
+                None => SUPPORTED_CHECKSUMS,
+            };
+            choose_checksum_algorithm_in(list, is_server, candidates)?
         }
     };
 
@@ -356,7 +385,12 @@ pub fn negotiate_capabilities_with_override(
     let compression = if let Some(forced) = compression_override {
         forced
     } else if let Some(ref list) = remote_compression_list {
-        choose_compression_algorithm(list, is_server)?
+        let supported = supported_compressions();
+        let candidates: &[&str] = match &compression_env {
+            Some(env) => &env.candidates,
+            None => &supported,
+        };
+        choose_compression_algorithm_in(list, is_server, candidates)?
     } else {
         CompressionAlgorithm::None
     };
@@ -423,9 +457,28 @@ fn resolved_compress_level(compression: CompressionAlgorithm, raw_level: i32) ->
 ///
 /// Returns an error if no common algorithm is found - upstream rsync treats
 /// this as a hard failure (compat.c:383-406 `recv_negotiate_str`).
+///
+/// This is the default-list convenience wrapper exercised by the test suite;
+/// production callers use [`choose_checksum_algorithm_in`] so the
+/// `RSYNC_CHECKSUM_LIST` env override can substitute the candidate list.
+#[cfg(test)]
 pub(super) fn choose_checksum_algorithm(
     remote_list: &str,
     is_server: bool,
+) -> io::Result<ChecksumAlgorithm> {
+    choose_checksum_algorithm_in(remote_list, is_server, SUPPORTED_CHECKSUMS)
+}
+
+/// Chooses a checksum algorithm from an explicit local candidate list.
+///
+/// Behaves like [`choose_checksum_algorithm`] but takes the ordered local
+/// candidate names as a parameter so the caller can substitute the
+/// `RSYNC_CHECKSUM_LIST` env override (upstream `nno->saw`, compat.c:350). With
+/// the default [`SUPPORTED_CHECKSUMS`] list the behaviour is unchanged.
+pub(super) fn choose_checksum_algorithm_in(
+    remote_list: &str,
+    is_server: bool,
+    local: &[&str],
 ) -> io::Result<ChecksumAlgorithm> {
     let remote_items: Vec<&str> = remote_list.split_whitespace().collect();
 
@@ -434,7 +487,7 @@ pub(super) fn choose_checksum_algorithm(
         // upstream: compat.c:353 `if (best == 1 || am_server) break;`
         for algo in &remote_items {
             if let Ok(checksum) = ChecksumAlgorithm::parse(algo) {
-                if SUPPORTED_CHECKSUMS.contains(&checksum.as_str()) {
+                if local.contains(&checksum.as_str()) {
                     return Ok(checksum);
                 }
             }
@@ -444,9 +497,9 @@ pub(super) fn choose_checksum_algorithm(
         // list wins. This gives client preference order priority.
         // upstream: compat.c:349-354 - client continues iterating to find the
         // local item with the best (lowest) position in our own list.
-        for &local in SUPPORTED_CHECKSUMS {
-            if remote_items.contains(&local) {
-                return ChecksumAlgorithm::parse(local)
+        for &name in local {
+            if remote_items.contains(&name) {
+                return ChecksumAlgorithm::parse(name)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()));
             }
         }
@@ -465,18 +518,37 @@ pub(super) fn choose_checksum_algorithm(
 /// on the first entry in the client's list that also appears in the server's list.
 ///
 /// upstream: compat.c:332-363 `parse_negotiate_str()`
+///
+/// This is the default-list convenience wrapper exercised by the test suite;
+/// production callers use [`choose_compression_algorithm_in`] so the
+/// `RSYNC_COMPRESS_LIST` env override can substitute the candidate list.
+#[cfg(test)]
 pub(super) fn choose_compression_algorithm(
     remote_list: &str,
     is_server: bool,
 ) -> io::Result<CompressionAlgorithm> {
     let supported = supported_compressions();
+    choose_compression_algorithm_in(remote_list, is_server, &supported)
+}
+
+/// Chooses a compression algorithm from an explicit local candidate list.
+///
+/// Behaves like [`choose_compression_algorithm`] but takes the ordered local
+/// candidate names as a parameter so the caller can substitute the
+/// `RSYNC_COMPRESS_LIST` env override. With the default
+/// [`supported_compressions`] list the behaviour is unchanged.
+pub(super) fn choose_compression_algorithm_in(
+    remote_list: &str,
+    is_server: bool,
+    local: &[&str],
+) -> io::Result<CompressionAlgorithm> {
     let remote_items: Vec<&str> = remote_list.split_whitespace().collect();
 
     if is_server {
         // Server: iterate client's (remote) list, first match in our list wins.
         for algo in &remote_items {
             if let Ok(compression) = CompressionAlgorithm::parse(algo) {
-                if supported.contains(algo) {
+                if local.contains(algo) {
                     return Ok(compression);
                 }
             }
@@ -484,9 +556,9 @@ pub(super) fn choose_compression_algorithm(
     } else {
         // Client: iterate our local list, first item also in server's (remote)
         // list wins.
-        for &local in &supported {
-            if remote_items.contains(&local) {
-                return CompressionAlgorithm::parse(local)
+        for &name in local {
+            if remote_items.contains(&name) {
+                return CompressionAlgorithm::parse(name)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()));
             }
         }

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -3149,3 +3149,213 @@ fn compression_override_none_falls_through_to_normal_negotiation() {
         "without override, legacy protocol defaults to Zlib"
     );
 }
+
+/// Tests for the `RSYNC_CHECKSUM_LIST` / `RSYNC_COMPRESS_LIST` env overrides
+/// (upstream compat.c:409-533).
+///
+/// The environment is process-global, so every test here serialises on
+/// [`ENV_LOCK`] and mutates via [`EnvGuard`], which restores the previous value
+/// on drop.
+mod env_list_overrides {
+    use std::ffi::OsStr;
+    use std::sync::Mutex;
+
+    use platform::env::EnvGuard;
+
+    use super::super::env_list;
+    use super::super::negotiate::{choose_checksum_algorithm_in, read_vstring};
+    use super::*;
+
+    /// Serialises env-mutating tests since the process environment is global.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    const CHECKSUM_ENV: &str = "RSYNC_CHECKSUM_LIST";
+    const COMPRESS_ENV: &str = "RSYNC_COMPRESS_LIST";
+
+    /// Reads the first vstring from a captured `negotiate` output buffer.
+    fn first_vstring(bytes: &[u8]) -> String {
+        let mut cursor = bytes;
+        read_vstring(&mut cursor).unwrap()
+    }
+
+    // (a) Unset env - the default candidate order is untouched. This is the
+    // regression guard that the default wire bytes never change.
+    #[test]
+    fn unset_env_keeps_default_order() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::remove(CHECKSUM_ENV);
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+
+        assert!(env_list::checksum_candidates(false).is_none());
+        assert!(env_list::checksum_candidates(true).is_none());
+        assert!(env_list::compression_candidates(false).is_none());
+        assert!(env_list::compression_candidates(true).is_none());
+    }
+
+    // (a') Unset env - a full negotiation advertises the built-in default list
+    // byte-for-byte (client drops "none").
+    #[test]
+    fn unset_env_advertises_default_checksum_list() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::remove(CHECKSUM_ENV);
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+
+        let protocol = ProtocolVersion::try_from(31).unwrap();
+        let peer = test_peer_data(false);
+        let mut stdin = &peer[..];
+        let mut stdout = Vec::new();
+
+        negotiate_capabilities(protocol, &mut stdin, &mut stdout, true, false, false, false)
+            .unwrap();
+
+        // Client omits the num == 0 ("none") entry, matching get_default_nno_list.
+        assert_eq!(first_vstring(&stdout), "xxh128 xxh3 xxh64 md5 md4 sha1");
+    }
+
+    // (b) A checksum list restricts and reorders the candidate set.
+    #[test]
+    fn checksum_env_restricts_and_reorders() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 xxh3"));
+
+        let client = env_list::checksum_candidates(false).unwrap();
+        assert_eq!(client.candidates, vec!["md5", "xxh3"]);
+        assert_eq!(client.advertised, "md5 xxh3");
+
+        let server = env_list::checksum_candidates(true).unwrap();
+        assert_eq!(server.candidates, vec!["md5", "xxh3"]);
+        assert_eq!(server.advertised, "md5 xxh3");
+    }
+
+    // (b') The restricted list flows onto the wire and drives selection: the
+    // client picks its own first candidate that the server also offers.
+    #[test]
+    fn checksum_env_drives_client_selection() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 xxh3"));
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+
+        let protocol = ProtocolVersion::try_from(31).unwrap();
+        // Server advertises the full default checksum list.
+        let peer = test_peer_data(false);
+        let mut stdin = &peer[..];
+        let mut stdout = Vec::new();
+
+        let result =
+            negotiate_capabilities(protocol, &mut stdin, &mut stdout, true, false, false, false)
+                .unwrap();
+
+        // Advertised list is the env order, not the built-in default.
+        assert_eq!(first_vstring(&stdout), "md5 xxh3");
+        // Client preference order (env order) wins: md5 before xxh3.
+        assert_eq!(result.checksum, ChecksumAlgorithm::MD5);
+    }
+
+    // (c) A compression list likewise restricts and reorders candidates.
+    #[test]
+    fn compress_env_restricts_and_reorders() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zlib zlibx"));
+
+        let client = env_list::compression_candidates(false).unwrap();
+        assert_eq!(client.candidates, vec!["zlib", "zlibx"]);
+        assert_eq!(client.advertised, "zlib zlibx");
+    }
+
+    // (c') The compression override flows onto the wire and drives selection.
+    #[test]
+    fn compress_env_drives_client_selection() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::remove(CHECKSUM_ENV);
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zlib zlibx"));
+
+        let protocol = ProtocolVersion::try_from(31).unwrap();
+        // Server offers both zlib and zlibx (plus none).
+        let server_lists = b"\x0Exxh128 md5 md4\x0Fzlibx zlib none";
+        let mut stdin = &server_lists[..];
+        let mut stdout = Vec::new();
+
+        let result =
+            negotiate_capabilities(protocol, &mut stdin, &mut stdout, true, true, false, false)
+                .unwrap();
+
+        // Second vstring is the compression list.
+        let mut cursor = &stdout[..];
+        let _checksum = read_vstring(&mut cursor).unwrap();
+        let compress = read_vstring(&mut cursor).unwrap();
+        assert_eq!(compress, "zlib zlibx");
+        // Env order puts zlib first, so zlib wins over the server's zlibx-first list.
+        assert_eq!(result.compression, CompressionAlgorithm::Zlib);
+    }
+
+    // (d) Unknown names are dropped; a value with a mix keeps only valid names.
+    #[test]
+    fn unknown_names_are_dropped() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("bogus md5 alsobad xxh3"));
+
+        let over = env_list::checksum_candidates(false).unwrap();
+        assert_eq!(over.candidates, vec!["md5", "xxh3"]);
+        assert_eq!(over.advertised, "md5 xxh3");
+    }
+
+    // (d') A value whose names are all unknown collapses to the INVALID
+    // sentinel (upstream compat.c:327-328), which then fails negotiation.
+    #[test]
+    fn all_unknown_names_yield_invalid_sentinel() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("bogus notreal"));
+
+        let over = env_list::checksum_candidates(false).unwrap();
+        assert!(over.candidates.is_empty());
+        assert_eq!(over.advertised, "INVALID");
+
+        // An INVALID list cannot match any remote offer, so selection errors -
+        // upstream exits with RERR_UNSUPPORTED here.
+        let err =
+            choose_checksum_algorithm_in("xxh128 md5 md4", false, &over.candidates).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    // Empty / whitespace-only values are treated as unset (default order).
+    #[test]
+    fn whitespace_only_env_is_treated_as_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("   \t "));
+        assert!(env_list::checksum_candidates(false).is_none());
+    }
+
+    // Duplicate names are removed, keeping first occurrence (upstream dedup).
+    #[test]
+    fn duplicate_names_are_deduped() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 xxh3 md5 xxh3"));
+        let over = env_list::checksum_candidates(false).unwrap();
+        assert_eq!(over.candidates, vec!["md5", "xxh3"]);
+    }
+
+    // The "xxhash" alias is canonicalised to "xxh64" on the wire, matching
+    // upstream's main_nni rewrite.
+    #[test]
+    fn xxhash_alias_is_canonicalised() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("xxhash md5"));
+        let over = env_list::checksum_candidates(false).unwrap();
+        assert_eq!(over.candidates, vec!["xxh64", "md5"]);
+        assert_eq!(over.advertised, "xxh64 md5");
+    }
+
+    // The '&' separator scopes the value: client uses names before it, server
+    // uses names after it (upstream getenv_nstr + parse_nni_str terminator).
+    #[test]
+    fn ampersand_scopes_client_and_server() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 & xxh3 xxh128"));
+
+        let client = env_list::checksum_candidates(false).unwrap();
+        assert_eq!(client.candidates, vec!["md5"]);
+
+        let server = env_list::checksum_candidates(true).unwrap();
+        assert_eq!(server.candidates, vec!["xxh3", "xxh128"]);
+    }
+}

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -3345,6 +3345,26 @@ mod env_list_overrides {
         assert_eq!(over.advertised, "xxh64 md5");
     }
 
+    // A mixed-case non-alias name keeps its original bytes on the wire while
+    // still resolving case-insensitively for selection - upstream parse_nni_str
+    // only rewrites recognised aliases, so "MD5" stays "MD5" (not "md5").
+    #[test]
+    fn mixed_case_non_alias_preserves_original_bytes() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("MD5 XXH3"));
+        let over = env_list::checksum_candidates(false).unwrap();
+        // Advertised bytes preserve the operator's casing.
+        assert_eq!(over.advertised, "MD5 XXH3");
+        // Candidates are canonical for case-insensitive selection.
+        assert_eq!(over.candidates, vec!["md5", "xxh3"]);
+
+        // A mixed-case alias still canonicalises (case-insensitive match).
+        let _cs2 = EnvGuard::set(CHECKSUM_ENV, OsStr::new("XxHaSh"));
+        let alias = env_list::checksum_candidates(false).unwrap();
+        assert_eq!(alias.advertised, "xxh64");
+        assert_eq!(alias.candidates, vec!["xxh64"]);
+    }
+
     // The '&' separator scopes the value: client uses names before it, server
     // uses names after it (upstream getenv_nstr + parse_nni_str terminator).
     #[test]


### PR DESCRIPTION
## Summary

Implements upstream rsync's `RSYNC_CHECKSUM_LIST` / `RSYNC_COMPRESS_LIST` environment customization for the protocol 30+ algorithm negotiation. When either variable is set, its names override and restrict the ordered list of negotiable checksum / compression algorithms that a peer advertises during `negotiate_the_strings()` and uses to pick a mutually supported algorithm.

## Upstream fidelity

Mirrors `getenv_nstr()` (compat.c:409-424), `parse_nni_str()` (compat.c:281-331), and `send_negotiate_str()` (compat.c:506-533):

- Whitespace-separated names, validated against the build-supported algorithm set.
- Canonicalised to wire spelling - the `xxhash` alias becomes `xxh64`, matching upstream's `main_nni` rewrite.
- De-duplicated, keeping first occurrence in listed order.
- Unrecognised names are dropped; a value whose names are all unknown collapses to the literal `INVALID`, which fails negotiation (upstream `RERR_UNSUPPORTED`).
- The `&` separator scopes the value: the client uses names before it, the server uses names after it.
- Feature-gated codecs absent from the build (lz4, zstd) are treated as unrecognised, matching upstream's compile-time `valid_compressions_items[]` gating.
- An unset or whitespace-only value leaves the built-in default order - and the default wire bytes - untouched.

## Design

The override plugs into the existing candidate-list plumbing rather than forking it. A new `env_list` module parses the variables into an ordered candidate set; the `choose_*` selection helpers gain a candidate-list parameter so one selection path serves both the default and env-restricted lists. The default (unset) path is unchanged and byte-identical.

## Tests

12 new tests (isolated via `EnvGuard` + a serialising mutex) cover: unset-env default order (regression guard, incl. advertised wire bytes), restrict+reorder for both variables, wire advertisement plus selection, unknown-name drop, all-unknown `INVALID` sentinel + negotiation failure, whitespace-only as unset, dedup, `xxhash` canonicalisation, and `&` client/server scoping. All 179 negotiation tests pass; `cargo clippy -p protocol --all-targets --all-features --no-deps -D warnings` is clean.

