### PR TITLE
fix(core): map protocol violations to RERR_PROTOCOL exit 2

### DIFF
--- a/crates/core/src/exit_code/codes.rs
+++ b/crates/core/src/exit_code/codes.rs
@@ -324,13 +324,31 @@ impl ExitCode {
     /// - `ConnectionRefused`, `ConnectionReset`, `ConnectionAborted`,
     ///   `BrokenPipe`, `AddrInUse`, `AddrNotAvailable`, `NotConnected` - `SocketIo`
     /// - `TimedOut` - `Timeout`
-    /// - `UnexpectedEof`, `InvalidData` - `StreamIo`
+    /// - `InvalidData` tagged [`protocol::ProtocolViolation`] - `Protocol`
+    /// - `UnexpectedEof`, other `InvalidData` - `StreamIo`
     /// - `Unsupported` - `Unsupported`
     /// - `Interrupted` by signal - `Signal`
     /// - All other I/O errors - `FileIo`
+    ///
+    /// A wire-protocol violation that upstream rsync exits with
+    /// `RERR_PROTOCOL` (2) is encoded as an `InvalidData` error whose inner
+    /// error is a [`protocol::ProtocolViolation`] (see
+    /// [`protocol::protocol_violation`]). Such errors map to
+    /// [`ExitCode::Protocol`]; every other `InvalidData`/`UnexpectedEof`
+    /// (truncated stream, corrupt frame, unexpected EOF) stays
+    /// [`ExitCode::StreamIo`] (12), matching upstream's `RERR_STREAMIO`.
     #[must_use]
     pub fn from_io_error(error: &std::io::Error) -> Self {
         use std::io::ErrorKind;
+
+        // upstream: errcode.h RERR_PROTOCOL=2 - a tagged protocol violation
+        // outranks the generic InvalidData=>StreamIo(12) mapping below.
+        if error
+            .get_ref()
+            .is_some_and(|inner| inner.is::<protocol::ProtocolViolation>())
+        {
+            return Self::Protocol;
+        }
 
         match error.kind() {
             ErrorKind::NotFound | ErrorKind::PermissionDenied | ErrorKind::AlreadyExists => {

--- a/crates/core/src/exit_code/tests.rs
+++ b/crates/core/src/exit_code/tests.rs
@@ -249,6 +249,29 @@ fn from_io_error_maps_stream_errors() {
 
     let err = Error::from(ErrorKind::InvalidData);
     assert_eq!(ExitCode::from_io_error(&err), ExitCode::StreamIo);
+
+    // An InvalidData error carrying an unrelated inner error stays StreamIo:
+    // only the ProtocolViolation marker opts into RERR_PROTOCOL.
+    let err = Error::new(ErrorKind::InvalidData, "corrupt multiplex frame");
+    assert_eq!(ExitCode::from_io_error(&err), ExitCode::StreamIo);
+}
+
+#[test]
+fn from_io_error_maps_tagged_protocol_violation_to_protocol() {
+    // WHY: upstream distinguishes RERR_PROTOCOL(2) from RERR_STREAMIO(12) at
+    // the call site (errcode.h). A ProtocolViolation-tagged InvalidData error
+    // is oc's carrier for the RERR_PROTOCOL sites (e.g. sender.c:316 phase-2
+    // transfer request, io.c:2032-2065 malformed sum_head); it must map to
+    // ExitCode::Protocol, while a plain InvalidData/UnexpectedEof stays
+    // StreamIo. Regressing this collapses exit 2 back into exit 12.
+    let err = protocol::protocol_violation("got transfer request in phase 2 [sender]");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert_eq!(ExitCode::from_io_error(&err), ExitCode::Protocol);
+    assert_eq!(ExitCode::from_io_error(&err).as_i32(), 2);
+
+    // The text is unchanged relative to a plain InvalidData error, so wrapping
+    // is observationally transparent apart from the exit-code mapping.
+    assert_eq!(err.to_string(), "got transfer request in phase 2 [sender]");
 }
 
 #[test]

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -510,8 +510,10 @@ fn parse_wire_rule_modern(
 /// `exclude.c:1623-1627` - sender exits with RERR_PROTOCOL when prefix is NULL
 fn serialize_rule(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -> io::Result<Vec<u8>> {
     let prefix = super::prefix::build_rule_prefix(rule, protocol).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
+        // upstream: exclude.c:1627 exit_cleanup(RERR_PROTOCOL) (exit 2). Tag the
+        // error so the core exit-code mapper yields RERR_PROTOCOL, not
+        // RERR_STREAMIO(12).
+        crate::protocol_violation::protocol_violation(
             "filter rules are too modern for remote rsync",
         )
     })?;

--- a/crates/protocol/src/flist/read/metadata.rs
+++ b/crates/protocol/src/flist/read/metadata.rs
@@ -117,10 +117,12 @@ impl FileListReader {
         if !(mode == 0 && self.delete_missing_args)
             && crate::flist::FileType::from_mode(mode).is_none()
         {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid file mode 0{mode:o}"),
-            ));
+            // upstream: flist.c:890 exit_cleanup(RERR_PROTOCOL) (exit 2). Tag the
+            // error so the core exit-code mapper yields RERR_PROTOCOL, not
+            // RERR_STREAMIO(12).
+            return Err(crate::protocol_violation::protocol_violation(format!(
+                "invalid file mode 0{mode:o}"
+            )));
         }
 
         // Determine if this is a directory (needed for atime and content_dir)

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -1615,6 +1615,13 @@ fn read_entry_rejects_invalid_mode_type() {
     let mut reader = FileListReader::new(protocol);
     let err = reader.read_entry(&mut cursor).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    // upstream flist.c:890 exit_cleanup(RERR_PROTOCOL) (exit 2), not
+    // RERR_STREAMIO(12); the error must carry the ProtocolViolation marker.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::ProtocolViolation>()),
+        "invalid file mode must be tagged RERR_PROTOCOL",
+    );
 }
 
 /// Every standard S_IFMT type (reg/dir/lnk/chr/blk/fifo/sock) stays acceptable,

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -136,6 +136,8 @@ mod multiplex;
 mod negotiation;
 /// `--debug=NSTR` producer emissions for algorithm-negotiation strings.
 pub mod nstr;
+/// Marker error type for genuine protocol violations (RERR_PROTOCOL).
+pub mod protocol_violation;
 /// Secluded-args (protect-args) stdin argument transmission protocol.
 ///
 /// When `--protect-args` is active, arguments are sent over stdin as
@@ -200,6 +202,7 @@ pub use negotiation::{
     read_and_parse_legacy_daemon_greeting, read_and_parse_legacy_daemon_greeting_details,
     read_legacy_daemon_line,
 };
+pub use protocol_violation::{ProtocolViolation, protocol_violation};
 pub use stats::{DeleteStats, TransferStats};
 pub use varint::{
     decode_varint, encode_varint_to_vec, read_int, read_longint, read_varint, read_varint_bounded,

--- a/crates/protocol/src/protocol_violation.rs
+++ b/crates/protocol/src/protocol_violation.rs
@@ -1,0 +1,89 @@
+//! Marker error for genuine rsync protocol violations (RERR_PROTOCOL).
+//!
+//! Rust's [`std::io::ErrorKind`] has no protocol-violation variant, so oc has
+//! historically encoded wire-protocol violations as
+//! [`io::ErrorKind::InvalidData`]. That kind is shared with truncated-stream
+//! and corrupt-frame conditions, which upstream rsync exits with
+//! `RERR_STREAMIO` (12). A subset of `InvalidData` sites correspond instead to
+//! upstream call sites that invoke `exit_cleanup(RERR_PROTOCOL)` (exit code 2)
+//! - for example an out-of-range wire index, a malformed `sum_head`, or a
+//! transfer request arriving in phase 2.
+//!
+//! [`ProtocolViolation`] tags exactly those sites. It is attached as the inner
+//! error of an `InvalidData` [`io::Error`] via [`protocol_violation`], so the
+//! error's [`kind`](io::Error::kind) and [`Display`](std::fmt::Display) text are
+//! unchanged (fully backward compatible), while the exit-code mapper can
+//! downcast the inner error and return `RERR_PROTOCOL` (2) rather than
+//! `RERR_STREAMIO` (12).
+//!
+//! # Upstream Reference
+//!
+//! `errcode.h` - `RERR_PROTOCOL = 2` (protocol incompatibility) versus
+//! `RERR_STREAMIO = 12` (error in rsync protocol data stream). Upstream
+//! distinguishes them at the call site; oc distinguishes them via this marker.
+
+use std::error::Error;
+use std::fmt;
+use std::io;
+
+/// Inner marker error identifying an [`io::Error`] as a genuine protocol
+/// violation that upstream rsync would exit with `RERR_PROTOCOL` (2).
+///
+/// Constructed via [`protocol_violation`] and detected by the core exit-code
+/// mapper. Its [`Display`](fmt::Display) renders exactly the wrapped message,
+/// so wrapping an existing diagnostic changes neither the error text nor its
+/// [`io::ErrorKind`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtocolViolation(pub String);
+
+impl fmt::Display for ProtocolViolation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Error for ProtocolViolation {}
+
+/// Builds an [`io::Error`] of kind [`InvalidData`](io::ErrorKind::InvalidData)
+/// tagged as a [`ProtocolViolation`].
+///
+/// Use this at wire-protocol sites that mirror an upstream
+/// `exit_cleanup(RERR_PROTOCOL)` call. The resulting error displays as `msg`
+/// and reports [`io::ErrorKind::InvalidData`], exactly like a plain
+/// `io::Error::new(InvalidData, msg)`, but the core exit-code mapper maps it to
+/// `RERR_PROTOCOL` (2) instead of `RERR_STREAMIO` (12).
+///
+/// # Upstream Reference
+///
+/// `errcode.h` - `RERR_PROTOCOL = 2`.
+pub fn protocol_violation(msg: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, ProtocolViolation(msg.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_kind_and_display() {
+        // WHY: wrapping must be observationally identical to a plain
+        // InvalidData error so existing callers that read `.kind()` or format
+        // the message keep their exact behaviour; only the exit-code mapping
+        // may change.
+        let err = protocol_violation("got transfer request in phase 2 [sender]");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(err.to_string(), "got transfer request in phase 2 [sender]");
+    }
+
+    #[test]
+    fn inner_downcasts_to_marker() {
+        // WHY: the core exit-code mapper identifies the RERR_PROTOCOL class by
+        // downcasting the inner error to ProtocolViolation. If this stops
+        // working the violation silently reverts to RERR_STREAMIO (12).
+        let err = protocol_violation("malformed sum_head");
+        let inner = err
+            .get_ref()
+            .and_then(|e| e.downcast_ref::<ProtocolViolation>());
+        assert_eq!(inner, Some(&ProtocolViolation("malformed sum_head".into())));
+    }
+}

--- a/crates/protocol/src/wire/compressed_token/step.rs
+++ b/crates/protocol/src/wire/compressed_token/step.rs
@@ -292,8 +292,11 @@ impl TokenDecodeCore {
                 let token = i32::from_le_bytes([input[0], input[1], input[2], input[3]]);
                 if token < 0 {
                     self.phase = Phase::Idle;
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
+                    // upstream: token.c:528 invalid_compressed_token() ->
+                    // exit_cleanup(RERR_PROTOCOL) (exit 2). Tag the error so the
+                    // core exit-code mapper yields RERR_PROTOCOL, not
+                    // RERR_STREAMIO(12).
+                    return Err(crate::protocol_violation::protocol_violation(
                         "invalid token number in compressed stream",
                     ));
                 }

--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -1513,6 +1513,13 @@ fn assert_rejects_negative_token(mut decoder: CompressedTokenDecoder) {
         .recv_token(&mut cursor)
         .expect_err("decoder must reject negative token");
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    // upstream token.c:528 invalid_compressed_token() exits RERR_PROTOCOL (2),
+    // not RERR_STREAMIO(12); the error must carry the ProtocolViolation marker.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::ProtocolViolation>()),
+        "negative token must be tagged RERR_PROTOCOL",
+    );
     assert_eq!(err.to_string(), "invalid token number in compressed stream");
 }
 

--- a/crates/protocol/tests/filter_legal_len_parity.rs
+++ b/crates/protocol/tests/filter_legal_len_parity.rs
@@ -64,6 +64,11 @@ fn serialize_rule_errors_with_too_modern_for_dir_merge_at_protocol_28() {
 
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<protocol::ProtocolViolation>()),
+        "too-modern filter must be tagged RERR_PROTOCOL (exclude.c:1627, exit 2)",
+    );
+    assert!(
         err.to_string()
             .contains("filter rules are too modern for remote rsync"),
         "error message must match upstream send_rules:1623-1627 wording; got {err}",

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -742,18 +742,20 @@ impl GeneratorContext {
     }
 
     /// Validates that a file index is within bounds of the file list.
+    ///
+    /// upstream: sender.c:144 `flist_for_ndx()` / rsync.c:352 - an out-of-range
+    /// wire file index aborts with `exit_cleanup(RERR_PROTOCOL)` (exit 2). The
+    /// error is tagged so the core exit-code mapper yields RERR_PROTOCOL(2)
+    /// rather than RERR_STREAMIO(12).
     pub(crate) fn validate_file_index(&self, ndx: usize) -> std::io::Result<()> {
         if ndx >= self.file_list.len() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "invalid file index {}, file list has {} entries {}{}",
-                    ndx,
-                    self.file_list.len(),
-                    error_location!(),
-                    crate::role_trailer::sender()
-                ),
-            ));
+            return Err(protocol::protocol_violation(format!(
+                "invalid file index {}, file list has {} entries {}{}",
+                ndx,
+                self.file_list.len(),
+                error_location!(),
+                crate::role_trailer::sender()
+            )));
         }
         Ok(())
     }

--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -110,14 +110,13 @@ impl GeneratorContext {
             Err(e) => return Err(e),
         };
         if ndx != NDX_DONE {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "expected goodbye NDX_DONE (-1) from receiver, got {ndx} {}{}",
-                    error_location!(),
-                    crate::role_trailer::sender()
-                ),
-            ));
+            // upstream: main.c:1097 exit_cleanup(RERR_PROTOCOL) (exit 2). Tag the
+            // error so the core exit-code mapper yields 2, not RERR_STREAMIO(12).
+            return Err(protocol::protocol_violation(format!(
+                "expected goodbye NDX_DONE (-1) from receiver, got {ndx} {}{}",
+                error_location!(),
+                crate::role_trailer::sender()
+            )));
         }
 
         // For protocol 31+: conditionally send del_stats, echo NDX_DONE, read final NDX_DONE.
@@ -176,14 +175,13 @@ impl GeneratorContext {
             match self.read_ndx_skipping_del_stats(reader, ndx_read_codec) {
                 Ok(final_ndx) => {
                     if final_ndx != NDX_DONE {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!(
-                                "expected final goodbye NDX_DONE (-1) from receiver, got {final_ndx} {}{}",
-                                error_location!(),
-                                crate::role_trailer::sender()
-                            ),
-                        ));
+                        // upstream: main.c:1097 exit_cleanup(RERR_PROTOCOL)
+                        // (exit 2); tagged so the mapper yields 2 not streamio.
+                        return Err(protocol::protocol_violation(format!(
+                            "expected final goodbye NDX_DONE (-1) from receiver, got {final_ndx} {}{}",
+                            error_location!(),
+                            crate::role_trailer::sender()
+                        )));
                     }
                 }
                 Err(e) if is_early_close_error(&e) => {

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -410,19 +410,16 @@ impl GeneratorContext {
             // phase where the sender has already emitted its own "phase done" and
             // is only draining the receiver's end-of-phase NDX_DONE acknowledgements.
             // Upstream prints `got transfer request in phase 2 [who_am_i]` to FERROR
-            // and aborts with exit_cleanup(RERR_PROTOCOL). oc mirrors that abort by
-            // returning the RERR_PROTOCOL-class `InvalidData` error (the same wire
-            // representation used by the receiver's goodbye NDX_DONE guard), so the
-            // loop fails loud instead of hanging or silently servicing the request.
+            // and aborts with exit_cleanup(RERR_PROTOCOL) (exit 2). oc mirrors that
+            // abort by returning a `ProtocolViolation`-tagged `InvalidData` error so
+            // the loop fails loud with the same exit code instead of hanging or
+            // silently servicing the request. The wire text is unchanged.
             if phase == 2 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "got transfer request in phase 2 [sender] {}{}",
-                        crate::role_trailer::error_location!(),
-                        crate::role_trailer::sender()
-                    ),
-                ));
+                return Err(protocol::protocol_violation(format!(
+                    "got transfer request in phase 2 [sender] {}{}",
+                    crate::role_trailer::error_location!(),
+                    crate::role_trailer::sender()
+                )));
             }
 
             // upstream: sender.c:341-344 - dry_run (!do_xfers) logs the item and
@@ -1338,9 +1335,16 @@ mod phase2_guard_tests {
         wire.extend_from_slice(&ITEM_TRANSFER_LE);
 
         let err = drive(&mut ctx, wire).expect_err("phase-2 request must abort");
-        // upstream RERR_PROTOCOL maps to InvalidData in this crate (mirrors the
-        // receiver's goodbye NDX_DONE guard, receiver/transfer/phases.rs).
+        // upstream sender.c:316 exit_cleanup(RERR_PROTOCOL) (exit 2). oc tags the
+        // InvalidData error as a ProtocolViolation so the core exit-code mapper
+        // yields RERR_PROTOCOL(2), not RERR_STREAMIO(12). The wire kind and text
+        // stay identical to the receiver's goodbye NDX_DONE guard.
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.get_ref()
+                .is_some_and(|e| e.is::<protocol::ProtocolViolation>()),
+            "phase-2 abort must be tagged RERR_PROTOCOL"
+        );
         assert!(
             err.to_string().contains("got transfer request in phase 2"),
             "unexpected message: {err}"

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/goodbye_partial_cutoff.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/goodbye_partial_cutoff.rs
@@ -187,6 +187,13 @@ fn handle_goodbye_proto32_rejects_garbage_in_place_of_ndx_done() {
         io::ErrorKind::InvalidData,
         "non-NDX_DONE garbage must surface InvalidData, got {err:?}",
     );
+    // upstream main.c:922 exit_cleanup(RERR_PROTOCOL) (exit 2): the error must
+    // carry the ProtocolViolation marker so the mapper yields 2 not streamio(12).
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<protocol::ProtocolViolation>()),
+        "goodbye garbage must be tagged RERR_PROTOCOL",
+    );
     // The error message must be informative and reference the role
     // trailer so upstream-style log scraping keeps working.
     let msg = err.to_string();
@@ -215,6 +222,12 @@ fn read_expected_ndx_done_proto29_rejects_garbage() {
         err.kind(),
         io::ErrorKind::InvalidData,
         "non-NDX_DONE garbage on legacy path must surface InvalidData, got {err:?}",
+    );
+    // upstream: RERR_PROTOCOL (exit 2) - the guard must tag the marker.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<protocol::ProtocolViolation>()),
+        "read_expected_ndx_done garbage must be tagged RERR_PROTOCOL",
     );
     let msg = err.to_string();
     assert!(

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -119,14 +119,15 @@ impl ReceiverContext {
     ) -> io::Result<()> {
         let ndx = ndx_read_codec.read_ndx(reader)?;
         if ndx != -1 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "expected NDX_DONE (-1) from sender during {context}, got {ndx} {}{}",
-                    crate::role_trailer::error_location!(),
-                    crate::role_trailer::receiver()
-                ),
-            ));
+            // upstream: io.c read_ndx / rsync.c:818 - a wire index that is not
+            // the expected NDX_DONE (-1) is "File-list index N not in ..." and
+            // aborts with exit_cleanup(RERR_PROTOCOL) (exit 2). Tag the error so
+            // the core exit-code mapper yields RERR_PROTOCOL, not RERR_STREAMIO.
+            return Err(protocol::protocol_violation(format!(
+                "expected NDX_DONE (-1) from sender during {context}, got {ndx} {}{}",
+                crate::role_trailer::error_location!(),
+                crate::role_trailer::receiver()
+            )));
         }
         Ok(())
     }
@@ -150,14 +151,13 @@ impl ReceiverContext {
     {
         let ndx = ndx_read_codec.read_ndx_async(reader).await?;
         if ndx != -1 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "expected NDX_DONE (-1) from sender during {context}, got {ndx} {}{}",
-                    crate::role_trailer::error_location!(),
-                    crate::role_trailer::receiver()
-                ),
-            ));
+            // upstream: io.c read_ndx / rsync.c:818 exit_cleanup(RERR_PROTOCOL)
+            // (exit 2); see the sync twin `read_expected_ndx_done`.
+            return Err(protocol::protocol_violation(format!(
+                "expected NDX_DONE (-1) from sender during {context}, got {ndx} {}{}",
+                crate::role_trailer::error_location!(),
+                crate::role_trailer::receiver()
+            )));
         }
         Ok(())
     }
@@ -315,14 +315,14 @@ impl ReceiverContext {
                     let _stats = protocol::stats::DeleteStats::read_from(reader)?;
                     continue;
                 }
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "expected goodbye NDX_DONE echo (-1) from sender, got {ndx} {}{}",
-                        crate::role_trailer::error_location!(),
-                        crate::role_trailer::receiver()
-                    ),
-                ));
+                // upstream: main.c:922 exit_cleanup(RERR_PROTOCOL) (exit 2) - a
+                // non-NDX_DONE goodbye echo is a protocol violation, tagged so
+                // the core exit-code mapper yields 2 rather than RERR_STREAMIO(12).
+                return Err(protocol::protocol_violation(format!(
+                    "expected goodbye NDX_DONE echo (-1) from sender, got {ndx} {}{}",
+                    crate::role_trailer::error_location!(),
+                    crate::role_trailer::receiver()
+                )));
             }
 
             ndx_write_codec.write_ndx_done(&mut *writer)?;
@@ -382,14 +382,14 @@ impl ReceiverContext {
                     let _stats = protocol::stats::DeleteStats::read_from_async(reader).await?;
                     continue;
                 }
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "expected goodbye NDX_DONE echo (-1) from sender, got {ndx} {}{}",
-                        crate::role_trailer::error_location!(),
-                        crate::role_trailer::receiver()
-                    ),
-                ));
+                // upstream: main.c:922 exit_cleanup(RERR_PROTOCOL) (exit 2) - a
+                // non-NDX_DONE goodbye echo is a protocol violation, tagged so
+                // the core exit-code mapper yields 2 rather than RERR_STREAMIO(12).
+                return Err(protocol::protocol_violation(format!(
+                    "expected goodbye NDX_DONE echo (-1) from sender, got {ndx} {}{}",
+                    crate::role_trailer::error_location!(),
+                    crate::role_trailer::receiver()
+                )));
             }
 
             ndx_write_codec.write_ndx_done(&mut *writer)?;

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -265,15 +265,17 @@ impl SumHead {
     const MAX_STRONG_SUM_LEN: usize = 20;
 
     /// Builds a `RERR_PROTOCOL`-mapped error for a malformed sum_head field.
+    ///
+    /// upstream: io.c:2032-2065 `read_sum_head()` validates every field and
+    /// calls `exit_cleanup(RERR_PROTOCOL)` (exit 2) on any out-of-range value.
+    /// The error is tagged so the core exit-code mapper yields RERR_PROTOCOL(2)
+    /// rather than RERR_STREAMIO(12).
     fn malformed(detail: String) -> io::Error {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "malformed sum_head: {detail} {}{}",
-                crate::role_trailer::error_location!(),
-                crate::role_trailer::receiver()
-            ),
-        )
+        protocol::protocol_violation(format!(
+            "malformed sum_head: {detail} {}{}",
+            crate::role_trailer::error_location!(),
+            crate::role_trailer::receiver()
+        ))
     }
 
     /// Reads a sum_head from the wire in rsync format.
@@ -896,6 +898,26 @@ mod xattr_abbrev_guard_tests {
         let err = read_xattr_abbreviation_data(&mut reader).expect_err("must error");
         assert_eq!(err.kind(), ErrorKind::InvalidData);
         assert!(err.to_string().contains("accumulation overflow"));
+    }
+
+    #[test]
+    fn malformed_sum_head_is_tagged_protocol_violation() {
+        // WHY: upstream io.c:2032 read_sum_head() aborts a negative checksum
+        // count with exit_cleanup(RERR_PROTOCOL) (exit 2), not RERR_STREAMIO.
+        // The InvalidData error must carry the ProtocolViolation marker so the
+        // core exit-code mapper yields 2; otherwise a hostile sum_head collapses
+        // into the streamio(12) bucket.
+        let mut buf = [0u8; 16];
+        buf[0..4].copy_from_slice(&(-1i32).to_le_bytes());
+        let mut reader = Cursor::new(buf.to_vec());
+        let err = super::SumHead::read(&mut reader).expect_err("negative count must abort");
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+        assert!(
+            err.get_ref()
+                .is_some_and(|e| e.is::<protocol::ProtocolViolation>()),
+            "malformed sum_head must be tagged RERR_PROTOCOL"
+        );
+        assert!(err.to_string().contains("malformed sum_head"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

oc collapsed genuine rsync protocol violations into the streamio exit-code
bucket. `ExitCode::from_io_error` mapped both `io::ErrorKind::UnexpectedEof`
and `io::ErrorKind::InvalidData` to `RERR_STREAMIO` (12). Rust's
`io::ErrorKind` has no protocol-violation variant, so wire-protocol violations
that upstream rsync exits with `RERR_PROTOCOL` (2) via
`exit_cleanup(RERR_PROTOCOL)` were indistinguishable from truncated-stream and
corrupt-frame conditions (which upstream *also* exits 12).

Exit codes are observable, so this is a drop-in fidelity fix. The change is
surgical: the default `InvalidData => StreamIo` mapping is unchanged; only
call sites that mirror an upstream `exit_cleanup(RERR_PROTOCOL)` opt into the
new mapping.

## Mechanism (one shared, DRY mechanism)

- New `protocol::ProtocolViolation` marker error plus a
  `protocol::protocol_violation(msg) -> io::Error` constructor. It builds an
  `InvalidData` error whose inner error is the marker, so the error's
  `kind()` and `Display` text are byte-for-byte unchanged - fully backward
  compatible.
- `ExitCode::from_io_error` gains one guard, before the existing
  `InvalidData | UnexpectedEof => StreamIo` arm: if the inner error downcasts
  to `ProtocolViolation`, return `ExitCode::Protocol` (2). Everything else is
  untouched.

Because the marker preserves the error kind and message, retagging a site can
only refine its exit code from 12 to 2; it can never change the wire text or
regress a genuine streamio error.

## Retagged sites (upstream RERR_PROTOCOL -> oc site)

| upstream | oc site | before -> after |
|----------|---------|-----------------|
| sender.c:316 got transfer request in phase 2 | transfer/generator/transfer/transfer_loop.rs | 12 -> 2 |
| io.c read_ndx / rsync.c:818 invalid file index | transfer/receiver/transfer/phases.rs `read_expected_ndx_done` (+ async twin) | 12 -> 2 |
| main.c:922 non-NDX_DONE goodbye echo | transfer/receiver/transfer/phases.rs goodbye guards (sync+async) | 12 -> 2 |
| main.c:1097 non-NDX_DONE goodbye / final | transfer/generator/transfer/goodbye.rs (2 guards) | 12 -> 2 |
| io.c:2032-2065 malformed sum_head | transfer/receiver/wire.rs `SumHead::malformed` | 12 -> 2 |
| sender.c:144 / rsync.c:352 flist_for_ndx | transfer/generator/context.rs `validate_file_index` | 12 -> 2 |
| exclude.c:1627 filter rules too modern | protocol/filters/wire.rs `serialize_rule` | 12 -> 2 |
| token.c:528 invalid compressed token | protocol/wire/compressed_token/step.rs | 12 -> 2 |
| flist.c:890 invalid file mode | protocol/flist/read/metadata.rs | 12 -> 2 |

Left as-is (genuine streamio / uncertain, not retagged): all `UnexpectedEof`
truncation paths; internal buffer/`impossible?` cases (io.c:429/447/584/599/
617/734/742/2436); handshake version/feature checks (compat.c) which oc maps
through separate option-validation paths; read_int/varint bounded-range reads
(io.c:1898-1923), hard-link ref (flist.c:798), inc-recurse dir_ndx / duplicate
flist (flist.c:2625-2814) - no confirmed 1:1 oc `InvalidData` equivalent.

## Tests

- Core: `from_io_error` maps a `ProtocolViolation`-tagged `InvalidData` to
  `Protocol` (2); plain `InvalidData`/`UnexpectedEof` and untagged inner
  errors still map to `StreamIo` (12).
- Per retagged site: assert the error is tagged (downcasts to
  `ProtocolViolation`) and the message text is unchanged; EOF/truncation
  siblings still surface `UnexpectedEof` -> streamio.
