### PR TITLE
fix(daemon): match rsyncd.conf param names whitespace-insensitively

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -18,7 +18,7 @@ fn apply_global_directive(
     stack: &mut Vec<PathBuf>,
 ) -> Result<(), DaemonError> {
     match key {
-        "refuse options" => {
+        "refuseoptions" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,
@@ -63,7 +63,7 @@ fn apply_global_directive(
             // and globs `*.inc`. `apply_include_directive` implements both.
             apply_include_directive(state, key, value, path, line_number, canonical, stack)?;
         }
-        "motd file" => {
+        "motdfile" => {
             let trimmed = value.trim();
             if trimmed.is_empty() {
                 return Err(config_parse_error(
@@ -90,7 +90,7 @@ fn apply_global_directive(
         "motd" => {
             state.motd_lines.push(value.trim_end_matches(['\r', '\n']).to_owned());
         }
-        "pid file" => {
+        "pidfile" => {
             let trimmed = value.trim();
             if trimmed.is_empty() {
                 return Err(config_parse_error(
@@ -122,7 +122,7 @@ fn apply_global_directive(
                 ));
             }
         }
-        "reverse lookup" => {
+        "reverselookup" => {
             let Some(parsed) =
                 apply_boolean_directive(value, false, "reverse lookup", path, line_number)
             else {
@@ -179,7 +179,7 @@ fn apply_global_directive(
                 state.global_bwlimit = Some((components, origin));
             }
         }
-        "secrets file" => {
+        "secretsfile" => {
             let trimmed = value.trim();
             if trimmed.is_empty() {
                 return Err(config_parse_error(
@@ -211,7 +211,7 @@ fn apply_global_directive(
                 state.global_secrets_file = Some((validated, origin));
             }
         }
-        "incoming chmod" | "incoming-chmod" => {
+        "incomingchmod" | "incoming-chmod" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,
@@ -242,7 +242,7 @@ fn apply_global_directive(
                 state.global_incoming_chmod = Some((owned, origin));
             }
         }
-        "outgoing chmod" | "outgoing-chmod" => {
+        "outgoingchmod" | "outgoing-chmod" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,
@@ -273,7 +273,7 @@ fn apply_global_directive(
                 state.global_outgoing_chmod = Some((owned, origin));
             }
         }
-        "lock file" => {
+        "lockfile" => {
             let trimmed = value.trim();
             if trimmed.is_empty() {
                 return Err(config_parse_error(
@@ -306,7 +306,7 @@ fn apply_global_directive(
         }
         // upstream: loadparm.c - use chroot is valid in the global section as a
         // default that applies to all modules which do not override it explicitly.
-        "use chroot" => {
+        "usechroot" => {
             let Some(parsed) =
                 apply_boolean_directive(value, true, "use chroot", path, line_number)
             else {
@@ -335,7 +335,7 @@ fn apply_global_directive(
         }
         // upstream: loadparm.c - syslog facility sets the syslog facility
         // for daemon log messages (e.g., "daemon", "local0"-"local7").
-        "syslog facility" => {
+        "syslogfacility" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,
@@ -367,7 +367,7 @@ fn apply_global_directive(
             }
         }
         // upstream: loadparm.c - syslog tag sets the syslog ident prefix.
-        "syslog tag" => {
+        "syslogtag" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,
@@ -506,7 +506,7 @@ fn apply_global_directive(
         }
         // upstream: daemon-parm.txt - listen_backlog INTEGER, default 5.
         // Controls the backlog argument passed to listen(2).
-        "listen backlog" => {
+        "listenbacklog" => {
             let parsed = parse_atoi(value).max(0) as u32;
 
             let origin = ConfigDirectiveOrigin {
@@ -532,7 +532,7 @@ fn apply_global_directive(
         // oc-rsync extension - number of SO_REUSEPORT listener replicas to bind
         // per address family (default 1). Has no upstream equivalent; changes
         // only kernel socket behaviour, never the wire.
-        "acceptor threads" => {
+        "acceptorthreads" => {
             let parsed: u32 = value.parse().map_err(|_| {
                 config_parse_error(
                     path,
@@ -570,7 +570,7 @@ fn apply_global_directive(
         }
         // upstream: daemon-parm.txt - port INTEGER, P_GLOBAL, default 0.
         // Controls the TCP port the daemon listens on.
-        "port" | "rsync port" => {
+        "port" | "rsyncport" => {
             let parsed = parse_atoi(value).clamp(0, i32::from(u16::MAX)) as u16;
 
             let origin = ConfigDirectiveOrigin {
@@ -595,7 +595,7 @@ fn apply_global_directive(
         }
         // upstream: daemon-parm.txt - socket options STRING.
         // Comma-separated TCP/IP socket options for the listener.
-        "socket options" => {
+        "socketoptions" => {
             let trimmed = value.trim();
             if trimmed.is_empty() {
                 return Err(config_parse_error(
@@ -625,7 +625,7 @@ fn apply_global_directive(
                 state.socket_options = Some((trimmed.to_string(), origin));
             }
         }
-        "proxy protocol" => {
+        "proxyprotocol" => {
             let Some(parsed) =
                 apply_boolean_directive(value, false, "proxy protocol", path, line_number)
             else {
@@ -652,7 +652,7 @@ fn apply_global_directive(
                 state.proxy_protocol = Some((parsed, origin));
             }
         }
-        "daemon chroot" => {
+        "daemonchroot" => {
             let trimmed = value.trim();
             if trimmed.is_empty() {
                 return Err(config_parse_error(
@@ -700,32 +700,32 @@ fn apply_global_directive(
                 state.module_defaults.filter.push(value.to_owned());
             }
         }
-        "max verbosity" => {
+        "maxverbosity" => {
             state.module_defaults.max_verbosity = Some(parse_atoi(value));
         }
-        "transfer logging" => {
+        "transferlogging" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "transfer logging", path, line_number)
             {
                 state.module_defaults.transfer_logging = Some(parsed);
             }
         }
-        "log format" => {
+        "logformat" => {
             if !value.is_empty() {
                 state.module_defaults.log_format = Some(value.to_owned());
             }
         }
-        "log file" => {
+        "logfile" => {
             if !value.is_empty() {
                 let resolved = resolve_config_relative_path(canonical, value);
                 state.module_defaults.log_file = Some(resolved);
             }
         }
-        "hosts allow" => {
+        "hostsallow" => {
             let patterns = parse_host_list(value, path, line_number, "hosts allow")?;
             state.module_defaults.hosts_allow = Some(patterns);
         }
-        "hosts deny" => {
+        "hostsdeny" => {
             let patterns = parse_host_list(value, path, line_number, "hosts deny")?;
             state.module_defaults.hosts_deny = Some(patterns);
         }
@@ -739,19 +739,19 @@ fn apply_global_directive(
             })?;
             state.module_defaults.timeout = Some(timeout);
         }
-        "dont compress" => {
+        "dontcompress" => {
             if !value.is_empty() {
                 state.module_defaults.dont_compress = Some(value.to_owned());
             }
         }
-        "read only" => {
+        "readonly" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "read only", path, line_number)
             {
                 state.module_defaults.read_only = Some(parsed);
             }
         }
-        "write only" => {
+        "writeonly" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "write only", path, line_number)
             {
@@ -763,28 +763,28 @@ fn apply_global_directive(
                 state.module_defaults.listable = Some(parsed);
             }
         }
-        "munge symlinks" => {
+        "mungesymlinks" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, true, "munge symlinks", path, line_number)
             {
                 state.module_defaults.munge_symlinks = Some(Some(parsed));
             }
         }
-        "numeric ids" => {
+        "numericids" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, true, "numeric ids", path, line_number)
             {
                 state.module_defaults.numeric_ids = Some(parsed);
             }
         }
-        "fake super" => {
+        "fakesuper" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "fake super", path, line_number)
             {
                 state.module_defaults.fake_super = Some(parsed);
             }
         }
-        "max connections" => {
+        "maxconnections" => {
             let max = parse_max_connections_directive(value).ok_or_else(|| {
                 config_parse_error(
                     path,
@@ -794,28 +794,28 @@ fn apply_global_directive(
             })?;
             state.module_defaults.max_connections = Some(max);
         }
-        "ignore errors" => {
+        "ignoreerrors" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "ignore errors", path, line_number)
             {
                 state.module_defaults.ignore_errors = Some(parsed);
             }
         }
-        "ignore nonreadable" => {
+        "ignorenonreadable" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "ignore nonreadable", path, line_number)
             {
                 state.module_defaults.ignore_nonreadable = Some(parsed);
             }
         }
-        "strict modes" => {
+        "strictmodes" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "strict modes", path, line_number)
             {
                 state.module_defaults.strict_modes = Some(parsed);
             }
         }
-        "forward lookup" => {
+        "forwardlookup" => {
             // forward lookup is both P_LOCAL and has a global handler above
             // for reverse_lookup. This arm handles the module-default case.
             if let Some(parsed) =
@@ -824,20 +824,20 @@ fn apply_global_directive(
                 state.module_defaults.forward_lookup = Some(parsed);
             }
         }
-        "open noatime" => {
+        "opennoatime" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, true, "open noatime", path, line_number)
             {
                 state.module_defaults.open_noatime = Some(parsed);
             }
         }
-        "exclude from" => {
+        "excludefrom" => {
             if !value.is_empty() {
                 let resolved = resolve_config_relative_path(canonical, value);
                 state.module_defaults.exclude_from = Some(resolved);
             }
         }
-        "include from" => {
+        "includefrom" => {
             if !value.is_empty() {
                 let resolved = resolve_config_relative_path(canonical, value);
                 state.module_defaults.include_from = Some(resolved);
@@ -848,22 +848,22 @@ fn apply_global_directive(
                 state.module_defaults.comment = Some(value.to_owned());
             }
         }
-        "early exec" => {
+        "earlyexec" => {
             if !value.is_empty() {
                 state.module_defaults.early_exec = Some(value.to_owned());
             }
         }
-        "pre-xfer exec" => {
+        "pre-xferexec" => {
             if !value.is_empty() {
                 state.module_defaults.pre_xfer_exec = Some(value.to_owned());
             }
         }
-        "post-xfer exec" => {
+        "post-xferexec" => {
             if !value.is_empty() {
                 state.module_defaults.post_xfer_exec = Some(value.to_owned());
             }
         }
-        "name converter" => {
+        "nameconverter" => {
             if !value.is_empty() {
                 state.module_defaults.name_converter = Some(value.to_owned());
             }
@@ -875,7 +875,7 @@ fn apply_global_directive(
         }
         // P_LOCAL directives that only make sense per-module - silently accepted
         // but not stored as inheritable defaults.
-        "path" | "auth users" => {}
+        "path" | "authusers" => {}
         _ => {
             eprintln!(
                 "warning: unknown global directive '{}' in '{}' line {} [daemon={}]",

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -35,15 +35,15 @@ fn apply_module_directive(
             };
             builder.set_comment(comment, path, line_number)?;
         }
-        "hosts allow" => {
+        "hostsallow" => {
             let patterns = parse_host_list(value, path, line_number, "hosts allow")?;
             builder.set_hosts_allow(patterns, path, line_number)?;
         }
-        "hosts deny" => {
+        "hostsdeny" => {
             let patterns = parse_host_list(value, path, line_number, "hosts deny")?;
             builder.set_hosts_deny(patterns, path, line_number)?;
         }
-        "auth users" => {
+        "authusers" => {
             let users = parse_auth_user_list(value).map_err(|error| {
                 config_parse_error(
                     path,
@@ -53,7 +53,7 @@ fn apply_module_directive(
             })?;
             builder.set_auth_users(users, path, line_number)?;
         }
-        "secrets file" => {
+        "secretsfile" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,
@@ -80,7 +80,7 @@ fn apply_module_directive(
                 line_number,
             )?;
         }
-        "refuse options" => {
+        "refuseoptions" => {
             let options = parse_refuse_option_list(value).map_err(|error| {
                 config_parse_error(
                     path,
@@ -90,28 +90,28 @@ fn apply_module_directive(
             })?;
             builder.set_refuse_options(options, path, line_number)?;
         }
-        "read only" => {
+        "readonly" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "read only", path, line_number)
             {
                 builder.set_read_only(parsed, path, line_number)?;
             }
         }
-        "write only" => {
+        "writeonly" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "write only", path, line_number)
             {
                 builder.set_write_only(parsed, path, line_number)?;
             }
         }
-        "use chroot" => {
+        "usechroot" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, true, "use chroot", path, line_number)
             {
                 builder.set_use_chroot(parsed, path, line_number)?;
             }
         }
-        "numeric ids" => {
+        "numericids" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, true, "numeric ids", path, line_number)
             {
@@ -123,14 +123,14 @@ fn apply_module_directive(
                 builder.set_listable(parsed, path, line_number)?;
             }
         }
-        "fake super" => {
+        "fakesuper" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "fake super", path, line_number)
             {
                 builder.set_fake_super(parsed, path, line_number)?;
             }
         }
-        "munge symlinks" => {
+        "mungesymlinks" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, true, "munge symlinks", path, line_number)
             {
@@ -159,7 +159,7 @@ fn apply_module_directive(
             })?;
             builder.set_timeout(timeout, path, line_number)?;
         }
-        "max connections" => {
+        "maxconnections" => {
             let max = parse_max_connections_directive(value).ok_or_else(|| {
                 config_parse_error(
                     path,
@@ -169,7 +169,7 @@ fn apply_module_directive(
             })?;
             builder.set_max_connections(max, path, line_number)?;
         }
-        "incoming chmod" | "incoming-chmod" => {
+        "incomingchmod" | "incoming-chmod" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,
@@ -183,7 +183,7 @@ fn apply_module_directive(
                 line_number,
             )?;
         }
-        "outgoing chmod" | "outgoing-chmod" => {
+        "outgoingchmod" | "outgoing-chmod" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,
@@ -197,32 +197,32 @@ fn apply_module_directive(
                 line_number,
             )?;
         }
-        "max verbosity" => {
+        "maxverbosity" => {
             let parsed = parse_atoi(value);
             builder.set_max_verbosity(parsed, path, line_number)?;
         }
-        "ignore errors" => {
+        "ignoreerrors" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "ignore errors", path, line_number)
             {
                 builder.set_ignore_errors(parsed, path, line_number)?;
             }
         }
-        "ignore nonreadable" => {
+        "ignorenonreadable" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "ignore nonreadable", path, line_number)
             {
                 builder.set_ignore_nonreadable(parsed, path, line_number)?;
             }
         }
-        "transfer logging" => {
+        "transferlogging" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "transfer logging", path, line_number)
             {
                 builder.set_transfer_logging(parsed, path, line_number)?;
             }
         }
-        "log format" => {
+        "logformat" => {
             let format = if value.is_empty() {
                 None
             } else {
@@ -230,7 +230,7 @@ fn apply_module_directive(
             };
             builder.set_log_format(format, path, line_number)?;
         }
-        "log file" => {
+        "logfile" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,
@@ -241,7 +241,7 @@ fn apply_module_directive(
             let resolved = resolve_config_relative_path(canonical, value);
             builder.set_log_file(resolved, path, line_number)?;
         }
-        "dont compress" => {
+        "dontcompress" => {
             let patterns = if value.is_empty() {
                 None
             } else {
@@ -249,7 +249,7 @@ fn apply_module_directive(
             };
             builder.set_dont_compress(patterns, path, line_number)?;
         }
-        "early exec" => {
+        "earlyexec" => {
             let cmd = if value.is_empty() {
                 None
             } else {
@@ -257,7 +257,7 @@ fn apply_module_directive(
             };
             builder.set_early_exec(cmd, path, line_number)?;
         }
-        "pre-xfer exec" => {
+        "pre-xferexec" => {
             let cmd = if value.is_empty() {
                 None
             } else {
@@ -265,7 +265,7 @@ fn apply_module_directive(
             };
             builder.set_pre_xfer_exec(cmd, path, line_number)?;
         }
-        "post-xfer exec" => {
+        "post-xferexec" => {
             let cmd = if value.is_empty() {
                 None
             } else {
@@ -273,7 +273,7 @@ fn apply_module_directive(
             };
             builder.set_post_xfer_exec(cmd, path, line_number)?;
         }
-        "name converter" => {
+        "nameconverter" => {
             let cmd = if value.is_empty() {
                 None
             } else {
@@ -281,7 +281,7 @@ fn apply_module_directive(
             };
             builder.set_name_converter(cmd, path, line_number)?;
         }
-        "temp dir" => {
+        "tempdir" => {
             let dir = if value.is_empty() {
                 None
             } else {
@@ -297,21 +297,21 @@ fn apply_module_directive(
             };
             builder.set_charset(cs, path, line_number)?;
         }
-        "forward lookup" => {
+        "forwardlookup" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "forward lookup", path, line_number)
             {
                 builder.set_forward_lookup(parsed, path, line_number)?;
             }
         }
-        "strict modes" => {
+        "strictmodes" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "strict modes", path, line_number)
             {
                 builder.set_strict_modes(parsed, path, line_number)?;
             }
         }
-        "open noatime" => {
+        "opennoatime" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, true, "open noatime", path, line_number)
             {
@@ -320,7 +320,7 @@ fn apply_module_directive(
         }
         // upstream: daemon-parm.txt - `exclude_from` STRING, default NULL.
         // Loaded via parse_filter_file() in clientserver.c.
-        "exclude from" => {
+        "excludefrom" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,
@@ -333,7 +333,7 @@ fn apply_module_directive(
         }
         // upstream: daemon-parm.txt - `include_from` STRING, default NULL.
         // Loaded via parse_filter_file() in clientserver.c.
-        "include from" => {
+        "includefrom" => {
             if value.is_empty() {
                 return Err(config_parse_error(
                     path,

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -4,6 +4,33 @@
 // line-by-line dispatch to module or global directive handlers, and
 // final assembly of the parsed result.
 
+/// Folds a directive name into the canonical form used to match it against a
+/// known parameter, mirroring upstream's whitespace- and case-insensitive
+/// comparison.
+///
+/// Upstream compares a configuration parameter name against the `parm_table`
+/// labels with `strwiEQ` (loadparm.c:282), which walks both strings skipping
+/// every `isSpace()` character (itypes.h:37) and comparing the remaining
+/// characters case-insensitively via `toUpper()` (itypes.h:67). Two names are
+/// therefore equal exactly when they are equal after removing all whitespace
+/// and lowercasing, so `read only`, `readonly`, `Read Only`, and `read<TAB>only`
+/// all resolve to the same parameter (loadparm.c:344 map_parameter).
+///
+/// Note that the labels themselves are generated with underscores rewritten to
+/// spaces (daemon-parm.awk `gsub(/_/, " ", pubname)`), while `strwiEQ` skips
+/// only whitespace - never underscores. An underscore is thus significant:
+/// `read_only` does NOT match the `read only` parameter upstream, and this
+/// helper preserves that by folding only whitespace.
+fn normalize_param_name(name: &str) -> String {
+    // upstream: itypes.h:37 isSpace() == C isspace(), which also matches the
+    // vertical tab that Rust's char::is_ascii_whitespace omits. toUpper()
+    // (itypes.h:67) is ASCII-only, so fold case with to_ascii_lowercase.
+    name.chars()
+        .filter(|c| !matches!(c, ' ' | '\t' | '\n' | '\x0B' | '\x0C' | '\r'))
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
 /// Parses the `rsyncd.conf` at `path` into module definitions and global settings.
 pub(crate) fn parse_config_modules(path: &Path) -> Result<ParsedConfigModules, DaemonError> {
     let mut stack = Vec::new();
@@ -105,14 +132,14 @@ fn parse_config_modules_inner(
                     .strip_prefix('=')
                     .unwrap_or(raw_value);
                 (
-                    format!("&{}", name.trim().to_ascii_lowercase()),
+                    format!("&{}", normalize_param_name(name)),
                     trimmed_value.trim(),
                 )
             } else {
                 let (raw_key, raw_value) = line.split_once('=').ok_or_else(|| {
                     config_parse_error(path, line_number, "expected 'key = value' directive")
                 })?;
-                (raw_key.trim().to_ascii_lowercase(), raw_value.trim())
+                (normalize_param_name(raw_key), raw_value.trim())
             };
 
             // upstream: params.c:Parse() - the `&include`/`&merge` directives

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -2621,4 +2621,92 @@ mod config_parsing_tests {
             "error must name the &include directive: {message}"
         );
     }
+
+    /// Parameter-name matching must fold whitespace and case exactly like
+    /// upstream `strwiEQ` (loadparm.c:282), so every spacing/case variant of a
+    /// label collapses to the same canonical form. This is why `read only`,
+    /// `readonly`, and `Read Only` all address the same parameter.
+    #[test]
+    fn normalize_param_name_folds_whitespace_and_case() {
+        assert_eq!(normalize_param_name("read only"), "readonly");
+        assert_eq!(normalize_param_name("readonly"), "readonly");
+        assert_eq!(normalize_param_name("Read Only"), "readonly");
+        assert_eq!(normalize_param_name("READONLY"), "readonly");
+        assert_eq!(normalize_param_name("  read   only  "), "readonly");
+        assert_eq!(normalize_param_name("read\tonly"), "readonly");
+        // upstream isSpace()==C isspace() also folds the vertical tab.
+        assert_eq!(normalize_param_name("read\u{0B}only"), "readonly");
+    }
+
+    /// `strwiEQ` skips only whitespace - never underscores or hyphens - and the
+    /// generated labels already have underscores rewritten to spaces
+    /// (daemon-parm.awk). An underscore is therefore significant: `read_only`
+    /// stays distinct from the `read only` parameter and must NOT be folded away.
+    #[test]
+    fn normalize_param_name_preserves_underscore_and_hyphen() {
+        assert_eq!(normalize_param_name("read_only"), "read_only");
+        assert_eq!(normalize_param_name("Read_Only"), "read_only");
+        assert_eq!(normalize_param_name("post-xfer exec"), "post-xferexec");
+    }
+
+    /// Whitespace- and case-variant spellings of a parameter name resolve to
+    /// the same directive, matching upstream 3.4.4 which accepts `readonly`,
+    /// `Read   Only`, and `read<TAB>only` as synonyms for `read only`.
+    #[test]
+    fn parse_module_read_only_whitespace_insensitive() {
+        for spelling in ["readonly", "Read   Only", "read\tonly", "READ ONLY"] {
+            let dir = TempDir::new().expect("create temp dir");
+            let path = dir.path().join("data");
+            fs::create_dir(&path).expect("create dir");
+
+            let config = format!("[mod]\npath = {}\n{spelling} = no\n", path.display());
+            let file = write_config(&config);
+            let result = parse_config_modules(file.path()).expect("parse succeeds");
+            assert!(
+                !result.modules[0].read_only,
+                "'{spelling}' must resolve to the read only parameter",
+            );
+        }
+    }
+
+    /// An underscore in a parameter name is significant. Upstream 3.4.4 logs
+    /// `Unknown Parameter encountered: "read_only"` and ignores the line
+    /// (loadparm.c:356), so `read_only` must NOT set the read only parameter,
+    /// which retains its default of true.
+    #[test]
+    fn parse_module_read_only_underscore_is_not_a_synonym() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!("[mod]\npath = {}\nread_only = no\n", path.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert!(
+            result.modules[0].read_only,
+            "underscore name must be ignored, leaving read only at its default",
+        );
+    }
+
+    /// The whitespace-insensitive match is shared by every parameter, not just
+    /// booleans: a multi-word string directive spelled without its space still
+    /// resolves. `hostsallow` must populate the same list as `hosts allow`.
+    #[test]
+    fn parse_module_hosts_allow_whitespace_insensitive() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\nHOSTS  ALLOW = 10.0.0.0/8 192.168.0.0/16\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(
+            result.modules[0].hosts_allow.len(),
+            2,
+            "'HOSTS  ALLOW' must resolve to the hosts allow parameter",
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`rsyncd.conf` parameter-name matching is now whitespace- and case-insensitive, mirroring upstream rsync 3.4.4.

Upstream compares a configuration parameter name against the `parm_table` labels with `strwiEQ` (`loadparm.c:282`), which walks both strings skipping every `isSpace()` character (`itypes.h:37`) and compares the remaining characters case-insensitively via `toUpper()` (`itypes.h:67`). Two names are equal exactly when they are equal after removing all whitespace and lowercasing, so `read only`, `readonly`, `Read Only`, and `read<TAB>only` all address the same parameter (`map_parameter`, `loadparm.c:344`).

Previously oc-rsync only lowercased the directive name, so any spacing variant other than the exact single-space label - a concatenated `readonly`, extra spaces, or a tab - fell through to the unknown-directive warning and was silently dropped.

## Change

- Add a small `normalize_param_name` helper that folds a directive name to its canonical whitespace-free lowercase form, applied at the single point where the parser derives the directive key (per-module and global directives share it).
- Match the directive dispatch arms against that canonical form.
- Underscores stay significant, exactly as `strwiEQ` treats them: the labels are generated with underscores rewritten to spaces (`daemon-parm.awk`), while `strwiEQ` skips only whitespace. `read_only` therefore remains an unknown name, matching upstream 3.4.4 which logs `Unknown Parameter encountered: "read_only"` and ignores the line.

## Verification

Behavior verified against a real upstream `rsync 3.4.4` daemon: `readonly`, `Read   Only`, and `read only` all resolve to the `read only` parameter, while `read_only` is reported as an unknown parameter and ignored.

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`: no issues
- Targeted unit + parser tests pass (182 `config_parsing` tests, plus new helper and behavioral tests). New tests pin the fold rules and the underscore-is-significant semantics with upstream citations.
