### PR TITLE
fix(daemon): reject unknown #command distinct from module

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -146,6 +146,15 @@ pub(crate) const AUTH_FAILED_PAYLOAD: &str = "@ERROR: auth failed on module {mod
 ///
 /// upstream: clientserver.c:730 - `@ERROR: Unknown module '%s'\n`
 pub(crate) const UNKNOWN_MODULE_PAYLOAD: &str = "@ERROR: Unknown module '{module}'";
+/// Error payload returned when a `#`-prefixed request is not a recognized command.
+///
+/// A `#`-prefixed line (e.g. `#bogus`) that is neither `#list` nor the
+/// already-consumed `#early_input=` command is a command the daemon does not
+/// understand. Upstream rejects it with a message distinct from the
+/// unknown-module response, keeping the raw line (leading `#` included).
+///
+/// upstream: clientserver.c:1429 - `@ERROR: Unknown command '%s'\n`
+pub(crate) const UNKNOWN_COMMAND_PAYLOAD: &str = "@ERROR: Unknown command '{command}'";
 /// Error payload returned when a module reaches its connection cap.
 ///
 /// upstream: clientserver.c:752 - `@ERROR: max connections (%d) reached -- try again later\n`

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -338,6 +338,22 @@ fn handle_legacy_session(
         _ = conn_state
             .transition(ConnectionState::Closing)
             .map_err(transition_error)?;
+    } else if request.starts_with('#') {
+        // upstream: clientserver.c:1427-1431 - `if (*line == '#') { io_printf(
+        // f_out, "@ERROR: Unknown command '%s'\n", line); return -1; }`. A
+        // `#`-prefixed request that is neither `#list` (handled above) nor the
+        // already-consumed `#early_input=` command is a command the daemon does
+        // not recognize. It is rejected with the unknown-command error - keeping
+        // the raw line including the leading `#` - which is distinct from the
+        // unknown-module response reserved for a bad module name. The client
+        // treats `@ERROR` as fatal and closes without reading further.
+        let command_display = sanitize_module_identifier(&request);
+        let payload = UNKNOWN_COMMAND_PAYLOAD.replace("{command}", command_display.as_ref());
+        send_error(reader.get_mut(), &mut limiter, &payload)?;
+        // FSM: -> Closing after rejecting the unknown command.
+        _ = conn_state
+            .transition(ConnectionState::Closing)
+            .map_err(transition_error)?;
     } else {
         respond_with_module_request(
             &mut reader,

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -222,6 +222,7 @@ include!("tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs");
 include!("tests/chunks/run_daemon_requests_authentication_for_protected_module.rs");
 include!("tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs");
 include!("tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs");
+include!("tests/chunks/run_daemon_rejects_unknown_hash_command.rs");
 include!("tests/chunks/run_daemon_serves_single_legacy_connection.rs");
 include!("tests/chunks/run_daemon_writes_and_removes_pid_file.rs");
 include!("tests/chunks/run_daemon_pid_file_contains_correct_pid.rs");

--- a/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
+++ b/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
@@ -15,6 +15,12 @@ fn daemon_error_payloads_match_upstream_wording() {
         "@ERROR: Unknown module '{module}'",
     );
 
+    // upstream: clientserver.c:1429 - `@ERROR: Unknown command '%s'\n`
+    assert_eq!(
+        crate::daemon::UNKNOWN_COMMAND_PAYLOAD,
+        "@ERROR: Unknown command '{command}'",
+    );
+
     // upstream: clientserver.c:733-734 - `@ERROR: access denied to %s from %s (%s)\n`
     assert_eq!(
         crate::daemon::ACCESS_DENIED_PAYLOAD,

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_hash_command.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_hash_command.rs
@@ -1,0 +1,61 @@
+#[test]
+fn run_daemon_rejects_unknown_hash_command() {
+    // upstream: clientserver.c:1427-1431 - a `#`-prefixed request that is not
+    // `#list` is a command the daemon does not understand, rejected with
+    // "@ERROR: Unknown command '%s'\n" (the raw line, leading `#` included).
+    // This is distinct from the unknown-module response reserved for a bad
+    // module name: it proves the daemon classifies `#bogus` as a command, not
+    // as a module named "#bogus".
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (port, held_listener) = allocate_test_port();
+
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--module"),
+            OsString::from(format!("docs={module_path}")),
+            OsString::from("--once"),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let expected_greeting = legacy_daemon_greeting();
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert_eq!(line, expected_greeting);
+
+    stream
+        .write_all(b"@RSYNCD: 32.0\n")
+        .expect("send handshake response");
+    stream.flush().expect("flush handshake response");
+
+    stream
+        .write_all(b"#bogus\n")
+        .expect("send unknown command");
+    stream.flush().expect("flush unknown command");
+
+    // upstream: clientserver.c:1429 - "@ERROR: Unknown command '%s'\n" keeps
+    // the leading `#`; it is NOT the "Unknown module" response.
+    line.clear();
+    reader.read_line(&mut line).expect("error message");
+    assert_eq!(line, "@ERROR: Unknown command '#bogus'\n");
+
+    // upstream: the client treats @ERROR as fatal; the daemon closes the
+    // socket without emitting @RSYNCD: EXIT, so the stream reaches EOF next.
+    line.clear();
+    let read = reader.read_line(&mut line).expect("eof after error");
+    assert_eq!(read, 0);
+    assert!(line.is_empty());
+
+    drop(reader);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary

After the `@RSYNCD:` greeting, a daemon client sends either a module name or a
`#`-prefixed command (e.g. `#list`). A recognized command such as `#list` is
handled; an unrecognized `#`-prefixed command must be rejected with a distinct
"Unknown command" error rather than the "Unknown module" error reserved for a
bad module name.

Previously an unrecognized `#command` fell through to the module-lookup path
and was reported as `@ERROR: Unknown module '#bogus'`. This adds the missing
dispatch branch so it is reported as `@ERROR: Unknown command '#bogus'`,
matching upstream rsync exactly.

## Upstream reference

`clientserver.c` `start_daemon()` dispatches the request line in order:

```c
if (!*line || strcmp(line, "#list") == 0) { send_listing(f_out); return -1; }
if (*line == '#') {
    /* it's some sort of command that I don't understand */
    io_printf(f_out, "@ERROR: Unknown command '%s'\n", line);
    return -1;
}
if ((i = lp_number(line)) < 0) {
    io_printf(f_out, "@ERROR: Unknown module '%s'\n", line);
    return -1;
}
```

The `#`-prefix check sits between the `#list`/empty listing case and the
unknown-module case, and prints the raw line (leading `#` included).

## Changes

- `crates/daemon/src/daemon.rs` - add `UNKNOWN_COMMAND_PAYLOAD` constant
  (`@ERROR: Unknown command '{command}'`) with upstream citation.
- `crates/daemon/src/daemon/sections/session_runtime.rs` - add the
  `request.starts_with('#')` dispatch branch between the listing and
  module-request branches, emitting the unknown-command error and driving the
  connection FSM to `Closing`. The already-consumed `#early_input=` command is
  handled earlier in the request loop, so any remaining `#`-prefixed line here
  is genuinely unrecognized.

## Tests

- `run_daemon_rejects_unknown_hash_command` - drives the daemon over TCP: an
  unrecognized `#bogus` request yields the exact
  `@ERROR: Unknown command '#bogus'\n` line, then EOF (no `@RSYNCD: EXIT`).
- `daemon_error_payloads_match_upstream_wording` - pins the new payload
  constant to its byte-exact upstream wording.
- Existing `#list` listing and unknown-module tests continue to cover those
  paths unchanged.

## Verification

- `cargo fmt --all`
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`
  (clean, no warnings)
