### PR TITLE
feat(protocol): refuse env-excluded --checksum/--compress-choice

### DIFF
--- a/crates/protocol/src/negotiation/capabilities/env_list.rs
+++ b/crates/protocol/src/negotiation/capabilities/env_list.rs
@@ -29,6 +29,8 @@
 //! - `compat.c:506-533 send_negotiate_str()` - advertises the parsed list,
 //!   falling back to `get_default_nno_list()` when the value is empty.
 
+use std::io;
+
 use super::algorithms::{
     ChecksumAlgorithm, CompressionAlgorithm, SUPPORTED_CHECKSUMS, supported_compressions,
 };
@@ -64,6 +66,89 @@ pub(super) fn checksum_candidates(is_server: bool) -> Option<EnvOverride> {
 /// `None` when the variable is unset or holds only whitespace.
 pub(super) fn compression_candidates(is_server: bool) -> Option<EnvOverride> {
     parse_env(COMPRESS_LIST_ENV, is_server, resolve_compression)
+}
+
+/// Refuses a client-forced `--checksum-choice` whose algorithm is absent from
+/// the server's `RSYNC_CHECKSUM_LIST`.
+///
+/// Only the server validates, and only when the client explicitly forced the
+/// choice - the caller gates on `is_server` and `checksum_override.is_some()`,
+/// mirroring `checksum.c:185-186 parse_checksum_choice`
+/// (`if (am_server && checksum_choice) validate_choice_vs_env(...)`). When the
+/// variable is unset or holds only whitespace this is a no-op and any choice is
+/// accepted, so the default (unset-env) path is unchanged.
+///
+/// # MD4 family
+///
+/// Upstream keeps four distinct MD4 name-num slots (`CSUM_MD4`,
+/// `CSUM_MD4_OLD`, `CSUM_MD4_BUSTED`, `CSUM_MD4_ARCHAIC`) and, when `md4` is in
+/// the env list, marks all four as seen (`compat.c:443-444`). oc-rsync collapses
+/// the whole MD4 family into a single [`ChecksumAlgorithm::MD4`] whose wire name
+/// is `md4`, so a forced MD4 choice matches iff `md4` is a candidate - the
+/// special case is subsumed by the collapsed representation.
+///
+/// # Upstream reference
+///
+/// - `compat.c:426-449 validate_choice_vs_env()` - the refusal check itself.
+/// - `checksum.c:185-186` - the server-only call site.
+pub(super) fn validate_checksum_choice(choice: &str) -> io::Result<()> {
+    validate_choice(CHECKSUM_LIST_ENV, "checksum", choice, resolve_checksum)
+}
+
+/// Refuses a client-forced `--compress-choice` whose algorithm is absent from
+/// the server's `RSYNC_COMPRESS_LIST`.
+///
+/// The compression counterpart of [`validate_checksum_choice`], mirroring
+/// `compat.c:193-194 parse_compress_choice`
+/// (`if (am_server) validate_choice_vs_env(NSTR_COMPRESS, do_compression, -1)`).
+///
+/// # Upstream reference
+///
+/// - `compat.c:426-449 validate_choice_vs_env()`.
+/// - `compat.c:193-194` - the server-only call site.
+pub(super) fn validate_compress_choice(choice: &str) -> io::Result<()> {
+    validate_choice(COMPRESS_LIST_ENV, "compress", choice, resolve_compression)
+}
+
+/// Shared refusal check for both choice kinds.
+///
+/// Reuses [`parse_env`] with `is_server = true` (only the server validates) so
+/// the env list is parsed exactly once, with the same `&` split, tokenising,
+/// alias canonicalisation and de-duplication used to build the advertised list -
+/// no separate parse. When the variable is unset or empty, [`parse_env`] returns
+/// `None` and the choice is accepted. Otherwise the forced canonical name must
+/// appear in the parsed candidate set (an empty set - the `INVALID` sentinel -
+/// never contains it, so a value whose names were all unrecognised refuses every
+/// choice, matching upstream).
+///
+/// On refusal, emits the byte-exact upstream message and fails with an
+/// [`io::ErrorKind::Unsupported`] error, which the core exit-code mapper turns
+/// into `RERR_UNSUPPORTED` (exit 4) - the code `validate_choice_vs_env` passes to
+/// `exit_cleanup` (`compat.c:449`).
+fn validate_choice(
+    key: &str,
+    kind: &str,
+    choice: &str,
+    resolve: impl Fn(&str) -> Option<&'static str>,
+) -> io::Result<()> {
+    // upstream: compat.c:432-433 - an unset or all-whitespace list_str returns
+    // early, leaving the choice unvalidated (accepted).
+    let Some(env) = parse_env(key, true, resolve) else {
+        return Ok(());
+    };
+
+    // upstream: compat.c:445 - saw[num] must be set for the forced choice(s).
+    if env.candidates.contains(&choice) {
+        return Ok(());
+    }
+
+    // upstream: compat.c:446-448 rprintf(FERROR, "Your --%s-choice value (%s)
+    // was refused by the server.\n", ...). The trailing newline is added by the
+    // diagnostic layer, not embedded in the message, matching oc convention.
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        format!("Your --{kind}-choice value ({choice}) was refused by the server."),
+    ))
 }
 
 /// Resolves a checksum name to its canonical wire spelling, or `None` when the

--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -187,6 +187,10 @@ pub fn negotiate_capabilities_with_override(
     } = *config;
     // Protocol < 30 doesn't support negotiation, use defaults
     if protocol.uses_fixed_encoding() {
+        // upstream: setup_protocol calls parse_*_choice regardless of protocol
+        // version, so the server still validates a forced choice against the env
+        // list. No vstring exchange runs here, so ordering is irrelevant.
+        validate_forced_choices(is_server, checksum_override, compression_override)?;
         // When user forced a checksum on a legacy protocol, honour it directly
         // since there is no wire negotiation to perform.
         let checksum = checksum_override.unwrap_or(ChecksumAlgorithm::MD4);
@@ -216,6 +220,10 @@ pub fn negotiate_capabilities_with_override(
     // negotiate_the_strings is ONLY CALLED when do_negotiated_strings is TRUE.
     // When FALSE, upstream uses pre-filled defaults without any wire protocol exchange.
     if !do_negotiation {
+        // upstream: setup_protocol still calls parse_*_choice when
+        // do_negotiated_strings == 0, so the server validates a forced choice
+        // against the env list. No vstring exchange runs, so ordering is moot.
+        validate_forced_choices(is_server, checksum_override, compression_override)?;
         // Use protocol 30+ defaults without sending or reading anything.
         // upstream: compat.c:194 - when -z is active but no vstring negotiation,
         // parse_compress_choice() defaults to CPRES_ZLIB.
@@ -354,6 +362,14 @@ pub fn negotiate_capabilities_with_override(
         None
     };
 
+    // upstream: setup_protocol runs parse_checksum_choice/parse_compress_choice
+    // AFTER negotiate_the_strings completes, so the server validates a forced
+    // choice against the env list only once the full vstring exchange (any
+    // non-forced category) has been sent and received. Validating here - after
+    // the recv above - preserves that wire ordering: a refusal does not truncate
+    // the exchange the peer expects.
+    validate_forced_choices(is_server, checksum_override, compression_override)?;
+
     // upstream: compat.c:528-529 - "Each side sends their list of valid names
     // to the other side and then both sides pick the first name in the client's
     // list that is also in the server's list."
@@ -426,6 +442,33 @@ pub fn negotiate_capabilities_with_override(
         checksum,
         compression,
     })
+}
+
+/// Refuses client-forced `--checksum-choice`/`--compress-choice` values that
+/// the server's `RSYNC_CHECKSUM_LIST`/`RSYNC_COMPRESS_LIST` excludes.
+///
+/// upstream: `checksum.c:185-186` and `compat.c:193-194` - `parse_*_choice`
+/// call `validate_choice_vs_env()` (`compat.c:426-449`) only on the server and
+/// only for an explicitly forced choice. When neither env variable is set this
+/// is a no-op, so the default path is unchanged. Called at every point where a
+/// forced choice is finalised (legacy, no-negotiation and the main negotiated
+/// path) so the check is version- and path-independent, exactly as upstream
+/// validates inside `setup_protocol` regardless of `do_negotiated_strings`.
+fn validate_forced_choices(
+    is_server: bool,
+    checksum_override: Option<ChecksumAlgorithm>,
+    compression_override: Option<CompressionAlgorithm>,
+) -> io::Result<()> {
+    if !is_server {
+        return Ok(());
+    }
+    if let Some(forced) = checksum_override {
+        env_list::validate_checksum_choice(forced.as_str())?;
+    }
+    if let Some(forced) = compression_override {
+        env_list::validate_compress_choice(forced.as_str())?;
+    }
+    Ok(())
 }
 
 /// Resolves the compression level upstream renders in the NSTR compress

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -3378,4 +3378,191 @@ mod env_list_overrides {
         let server = env_list::checksum_candidates(true).unwrap();
         assert_eq!(server.candidates, vec!["xxh3", "xxh128"]);
     }
+
+    // -- validate_choice_vs_env (upstream compat.c:426-449) --
+    //
+    // The server refuses a client-forced --checksum-choice/--compress-choice
+    // whose algorithm is absent from RSYNC_CHECKSUM_LIST/RSYNC_COMPRESS_LIST.
+
+    // (a) Unset env - any forced choice is accepted. Regression guard that the
+    // default path performs no validation. upstream: compat.c:432-433 returns
+    // early when list_str is NULL.
+    #[test]
+    fn validate_checksum_choice_accepts_when_env_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::remove(CHECKSUM_ENV);
+        env_list::validate_checksum_choice("md5").expect("unset env accepts any choice");
+        env_list::validate_checksum_choice("xxh128").expect("unset env accepts any choice");
+    }
+
+    // Whitespace-only env is treated as unset (upstream compat.c:435-436).
+    #[test]
+    fn validate_checksum_choice_accepts_when_env_blank() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("   "));
+        env_list::validate_checksum_choice("md5").expect("blank env accepts any choice");
+    }
+
+    // (b) Env list set and the forced choice is a member - accepted.
+    #[test]
+    fn validate_checksum_choice_accepts_when_in_list() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 xxh3"));
+        env_list::validate_checksum_choice("md5").expect("md5 is in the list");
+        env_list::validate_checksum_choice("xxh3").expect("xxh3 is in the list");
+    }
+
+    // (c) Env list set and the forced choice is NOT a member - refused with the
+    // byte-exact upstream message and ErrorKind::Unsupported. The core exit-code
+    // mapper turns Unsupported into RERR_UNSUPPORTED (exit 4), matching upstream
+    // exit_cleanup(RERR_UNSUPPORTED) at compat.c:449. WHY exact text: it is
+    // observable stderr forwarded to the client, so a drop-in must match it.
+    #[test]
+    fn validate_checksum_choice_refuses_when_not_in_list() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("xxh3 xxh128"));
+        let err = env_list::validate_checksum_choice("md5").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        assert_eq!(
+            err.to_string(),
+            "Your --checksum-choice value (md5) was refused by the server."
+        );
+    }
+
+    // A value whose names are all unrecognised collapses to the INVALID
+    // sentinel (empty candidate set), so every choice is refused - upstream
+    // parse_nni_str yields "INVALID" and saw[num] is never set.
+    #[test]
+    fn validate_checksum_choice_refuses_when_list_all_invalid() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("bogus nope"));
+        let err = env_list::validate_checksum_choice("md5").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+    }
+
+    // (d) The compress counterpart: refusal message says "compress".
+    #[test]
+    fn validate_compress_choice_refuses_when_not_in_list() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zstd"));
+        let err = env_list::validate_compress_choice("zlib").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        assert_eq!(
+            err.to_string(),
+            "Your --compress-choice value (zlib) was refused by the server."
+        );
+    }
+
+    #[test]
+    fn validate_compress_choice_accepts_when_in_list() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zlib zlibx"));
+        env_list::validate_compress_choice("zlib").expect("zlib is in the list");
+        env_list::validate_compress_choice("zlibx").expect("zlibx is in the list");
+    }
+
+    // (e) MD4 special case. upstream compat.c:443-444 marks the archaic/busted/
+    // old MD4 slots as seen when "md4" is in the list; oc-rsync collapses the
+    // whole MD4 family into a single "md4", so a forced md4 choice is accepted
+    // iff "md4" is present and refused otherwise.
+    #[test]
+    fn validate_checksum_choice_md4_in_list_accepts_md4() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md4 md5"));
+        env_list::validate_checksum_choice("md4").expect("md4 is in the list");
+    }
+
+    #[test]
+    fn validate_checksum_choice_md4_absent_refuses_md4() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 xxh3"));
+        let err = env_list::validate_checksum_choice("md4").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        assert_eq!(
+            err.to_string(),
+            "Your --checksum-choice value (md4) was refused by the server."
+        );
+    }
+
+    // The '&' split applies during validation too: the server checks against the
+    // portion after '&' (upstream getenv_nstr, compat.c:417-421). Here the
+    // client half ("md5") would accept md5, but the server half ("xxh3") refuses.
+    #[test]
+    fn validate_uses_server_half_of_ampersand_scope() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 & xxh3"));
+        env_list::validate_checksum_choice("xxh3").expect("server half contains xxh3");
+        let err = env_list::validate_checksum_choice("md5").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+    }
+
+    // End-to-end: a server negotiating a client-forced --checksum-choice that
+    // its RSYNC_CHECKSUM_LIST excludes aborts negotiation with the exact
+    // refusal and ErrorKind::Unsupported (exit 4 in core).
+    #[test]
+    fn server_negotiation_refuses_forced_checksum_not_in_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("xxh3"));
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+
+        let protocol = ProtocolVersion::try_from(32).unwrap();
+        // Forced checksum skips the checksum vstring; compression off means
+        // nothing is exchanged, so stdin is empty.
+        let mut stdin = &b""[..];
+        let mut stdout = Vec::new();
+
+        let err = negotiate_capabilities_with_override(
+            protocol,
+            &mut stdin,
+            &mut stdout,
+            &NegotiationConfig {
+                do_negotiation: true,
+                send_compression: false,
+                is_daemon_mode: false,
+                is_server: true,
+                checksum_override: Some(ChecksumAlgorithm::MD5),
+                compression_override: None,
+                compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        assert_eq!(
+            err.to_string(),
+            "Your --checksum-choice value (md5) was refused by the server."
+        );
+    }
+
+    // The client never validates - only the server refuses (upstream am_server
+    // guard). A client with the env set and a forced choice not in the list
+    // still completes negotiation with the forced algorithm.
+    #[test]
+    fn client_does_not_validate_forced_checksum() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("xxh3"));
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+
+        let protocol = ProtocolVersion::try_from(32).unwrap();
+        let mut stdin = &b""[..];
+        let mut stdout = Vec::new();
+
+        let result = negotiate_capabilities_with_override(
+            protocol,
+            &mut stdin,
+            &mut stdout,
+            &NegotiationConfig {
+                do_negotiation: true,
+                send_compression: false,
+                is_daemon_mode: false,
+                is_server: false,
+                checksum_override: Some(ChecksumAlgorithm::MD5),
+                compression_override: None,
+                compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+            },
+        )
+        .expect("client does not validate the choice against the env list");
+
+        assert_eq!(result.checksum, ChecksumAlgorithm::MD5);
+    }
 }


### PR DESCRIPTION
## Summary

Server-side validation counterpart to the `RSYNC_CHECKSUM_LIST` / `RSYNC_COMPRESS_LIST` negotiation env customization. When the server has one of these variables set and the client explicitly forced `--checksum-choice` / `--compress-choice`, the server now refuses the transfer if the chosen algorithm is not in the env list.

Mirrors upstream `validate_choice_vs_env()` (`compat.c:426-449`), called from `parse_checksum_choice()` (`checksum.c:185-186`, `if (am_server && checksum_choice)`) and `parse_compress_choice()` (`compat.c:193-194`, `if (am_server)`).

## Behaviour

- Only the **server** validates, and only for an **explicitly forced** choice.
- Unset or whitespace-only env: no-op. The default path is unchanged (no behaviour change, no wire change).
- Choice in the list: accepted. Choice absent: refused with the byte-exact message `Your --<kind>-choice value (<choice>) was refused by the server.`
- A value whose names are all unrecognised collapses to the `INVALID` sentinel (empty candidate set), refusing every choice, as upstream does.
- The `&` client/server scope split applies during validation (server checks the portion after `&`).

## MD4 family

Upstream keeps four MD4 name-num slots and marks all as seen when `md4` is in the list (`compat.c:443-444`). oc-rsync collapses the MD4 family into a single `md4`, so the special case is naturally subsumed: a forced `md4` matches iff `md4` is a candidate.

## Exit code

Upstream `validate_choice_vs_env` calls `exit_cleanup(RERR_UNSUPPORTED)` (`compat.c:449`), i.e. exit code **4**, not `RERR_PROTOCOL` (2). The refusal is raised as an `io::ErrorKind::Unsupported` error, which the core exit-code mapper already maps to `ExitCode::Unsupported` (4), matching upstream exactly.

## Implementation

- Reuses the existing env-list parser (`parse_env`) so the list is read once with the same `&` scoping, alias canonicalisation and de-duplication as the advertised list. No re-parse.
- Validation is invoked at every point a forced choice is finalized (legacy, no-negotiation, and the main negotiated path). In the negotiated path it runs after the vstring exchange completes, preserving upstream's `negotiate_the_strings` -> `parse_*_choice` ordering so a refusal never truncates the exchange the peer expects.
- `protocol` stays `#![deny(unsafe_code)]`; no unsafe, no placeholders.

## Tests

EnvGuard-isolated (serialised on the existing env lock):

- unset / blank env accepts any choice (regression guard)
- choice in list accepted (checksum + compress)
- choice not in list refused with the exact message + `ErrorKind::Unsupported` (checksum + compress)
- all-invalid list refuses every choice
- `md4` in list accepts a forced md4; md4 absent refuses it
- `&` scope: server half drives the decision
- end-to-end server negotiation aborts with the exact refusal
- client never validates (server-only guard)

`cargo fmt --all`, `cargo clippy -p protocol --all-targets --all-features --no-deps -D warnings` clean; targeted `cargo test -p protocol --lib validate` -> 21 passed.
