### PR TITLE
test(transfer): lock in phase-2 redo full-checksum delta

### DIFF
--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -972,6 +972,95 @@ mod tests {
         assert_eq!(result.fnamecmp_type, protocol::FnameCmpType::Fname);
     }
 
+    /// Phase-2 redo must still send a checksum-based delta against the basis,
+    /// not a whole-file literal resend. When a file fails its whole-file
+    /// verification in phase 1, upstream re-queues it and regenerates the block
+    /// signature with the FULL strong-checksum length rather than discarding the
+    /// basis: `check_for_finished_files()` sets `csum_length = SUM_LENGTH` (16)
+    /// around the redo `recv_generator()` call, and `sum_sizes_sqroot()` then
+    /// takes the `csum_length == SUM_LENGTH` branch to emit a full-strength
+    /// `s2length` instead of the phase-1 sqrt-reduced length.
+    /// upstream: generator.c:2178 (`csum_length = SUM_LENGTH`),
+    /// generator.c:739-740 (`s2length = max_s2length`), generator.c:2205
+    /// (restore `SHORT_SUM_LENGTH`).
+    ///
+    /// The invariant this locks in: for an existing basis, the redo checksum
+    /// length yields a non-EMPTY signature (a delta) whose strong sum is the
+    /// full 16 bytes - never an EMPTY (whole-file) result and never the
+    /// phase-1 short sum.
+    #[test]
+    fn phase2_redo_sends_full_checksum_delta_not_whole_file() {
+        use std::io::Write;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tmp.path();
+        // The basis is the file present at the destination when the redo pass
+        // runs (the receiver kept/committed it after phase 1). Size is chosen so
+        // the phase-1 sqrt heuristic would pick a strong sum shorter than 16,
+        // making the phase-2 upgrade to the full length observable.
+        let data: Vec<u8> = (0..8192u32).map(|i| (i % 251) as u8).collect();
+        {
+            let mut f = fs::File::create(dest_dir.join("file.bin")).expect("create dest");
+            f.write_all(&data).expect("write dest");
+            f.flush().expect("flush");
+        }
+
+        let dest_file = dest_dir.join("file.bin");
+        let make_config = |checksum_length: NonZeroU8| BasisFileConfig {
+            file_path: &dest_file,
+            dest_dir,
+            relative_path: std::path::Path::new("file.bin"),
+            target_size: data.len() as u64,
+            target_mtime: 0,
+            fuzzy_level: 0,
+            reference_directories: &[],
+            partial_dir: None,
+            protocol: ProtocolVersion::NEWEST,
+            checksum_length,
+            checksum_algorithm: SignatureAlgorithm::Md4,
+            // Not --whole-file: the redo path must still search for a basis.
+            whole_file: false,
+            compat_flags: None,
+        };
+
+        let strong_len = |result: &BasisFileResult| -> u8 {
+            result
+                .signature
+                .as_ref()
+                .expect("redo must produce a delta signature, not a whole-file resend")
+                .layout()
+                .strong_sum_length()
+                .get()
+        };
+
+        let phase1 =
+            find_basis_file_with_config(&make_config(crate::receiver::PHASE1_CHECKSUM_LENGTH));
+        let redo = find_basis_file_with_config(&make_config(crate::receiver::REDO_CHECKSUM_LENGTH));
+
+        // Redo yields a real block signature (delta), never EMPTY (whole file).
+        assert!(
+            redo.signature.is_some(),
+            "phase-2 redo must send a checksum-based delta, not a whole-file literal transfer"
+        );
+        assert_eq!(
+            redo.fnamecmp_type,
+            protocol::FnameCmpType::Fname,
+            "the redo basis is the ordinary destination file (no wire basis-type byte)"
+        );
+        // The redo strong sum is the full 16 bytes, and never shorter than the
+        // phase-1 sqrt-reduced length: this is the phase-2 collision-resistance
+        // upgrade that lets the corrected delta pass verification.
+        assert_eq!(
+            strong_len(&redo),
+            signature::block_size::MAX_SUM_LENGTH,
+            "phase-2 redo must use the full strong-checksum length"
+        );
+        assert!(
+            strong_len(&redo) >= strong_len(&phase1),
+            "redo strong sum must not be shorter than the phase-1 signature"
+        );
+    }
+
     #[test]
     fn consecutive_match_cap_halves_strong_sum_length() {
         use std::io::Write;


### PR DESCRIPTION
## Summary

Investigation of the phase-2 "redo" path (a file re-queued after failing its
whole-file checksum in phase 1) confirmed that the receiver already regenerates
a full-strength block signature against the existing basis, so the corrected
transfer is a checksum-based delta rather than a whole-file literal resend.
This adds a regression test that pins that behaviour.

## Upstream behaviour (source of truth)

- `generator.c:2178` - `check_for_finished_files()` sets `csum_length = SUM_LENGTH`
  (16) before invoking `recv_generator()` for the redo index, then restores
  `csum_length = SHORT_SUM_LENGTH` afterwards (`generator.c:2205`).
- `generator.c:739-740` - `sum_sizes_sqroot()` takes the `csum_length == SUM_LENGTH`
  branch and emits the full `s2length` (`max_s2length`) instead of the phase-1
  sqrt-reduced length.
- `generator.c:775-827` - `generate_and_send_sums()` still walks the basis file
  and writes real per-block `sum1`/`sum2`; the redo continues to send a delta.
- `receiver.c:1055-1096` - on phase-1 verification failure the temp is discarded
  and `MSG_REDO` is queued, leaving the basis intact for the phase-2 delta.

## Existing receiver behaviour

All three receiver redo paths already set the redo checksum length and re-run
the pipeline, which regenerates the basis signature:

- `receiver/transfer/pipelined.rs:174`
- `receiver/transfer/pipelined_async.rs:195`
- `receiver/transfer/pipelined_incremental_async.rs:206`

`REDO_CHECKSUM_LENGTH` is `MAX_SUM_LENGTH` (16) and `derive_strong_sum_length()`
(`signature/src/layout.rs:288`) short-circuits to the full length when
`checksum_length == SUM_LENGTH`, mirroring `sum_sizes_sqroot()`. The redo pass
searches for a basis with the user's `--whole-file` flag (not forced), so an
existing destination basis yields a real delta signature.

## Change

Adds `phase2_redo_sends_full_checksum_delta_not_whole_file` to
`crates/transfer/src/receiver/basis.rs`. For an existing basis it asserts the
redo checksum length produces a non-empty signature whose strong sum is the
full 16 bytes (never an empty whole-file result, never the phase-1 short sum),
and that the redo strong sum is never shorter than the phase-1 signature.

No production code changed: the behaviour was already correct; this locks it in
against a regression to a whole-file resend.

## Verification

- `cargo fmt --all`
- `cargo clippy -p transfer --all-targets --all-features --no-deps -- -D warnings` (clean)
- `cargo nextest run -p transfer --all-features -E 'test(phase2_redo_sends_full_checksum_delta_not_whole_file)'` -> 1 passed
