### PR TITLE
fix: honor daemon dont-compress '*' whole-stream store

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -244,7 +244,12 @@ fn build_server_config(
             // upstream: loadparm.c - `dont compress` parameter specifies suffixes
             // that should skip per-file compression during transfer.
             if let Some(dont_compress) = module.dont_compress.as_deref() {
-                if let Some(list) = parse_daemon_dont_compress(dont_compress) {
+                if dont_compress_is_match_all(dont_compress) {
+                    // upstream: token.c:206-211 - a bare `*` collapses the match
+                    // list to a whole-stream store (zlib level 0) and clears the
+                    // per-file suffix tree, so no `skip_compress` list is built.
+                    cfg.connection.dont_compress_match_all = true;
+                } else if let Some(list) = parse_daemon_dont_compress(dont_compress) {
                     cfg.skip_compress = Some(list);
                 }
             }

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -174,6 +174,22 @@ pub(crate) fn format_bandwidth_rate(value: NonZeroU64) -> String {
     }
 }
 
+/// Reports whether a daemon `dont compress` value collapses to the whole-stream
+/// "match all" special case.
+///
+/// Upstream treats a bare `*` token in the sender's dont-compress match list as
+/// a signal to store the entire zlib stream (level 0) rather than compress per
+/// block. Any other suffix present alongside the `*` is discarded.
+///
+/// # Upstream Reference
+///
+/// - `token.c:206-211`: `init_set_compression()` optimises a `*` match-string,
+///   setting `per_file_default_level = skip_compression_level` and clearing the
+///   per-file suffix tree.
+fn dont_compress_is_match_all(value: &str) -> bool {
+    value.split_whitespace().any(|token| token == "*")
+}
+
 /// Parses the daemon `dont compress` parameter into a `SkipCompressList`.
 ///
 /// The daemon format uses space-separated glob-style suffixes (e.g., `"*.gz *.zip *.jpg"`).

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1342,6 +1342,19 @@ mod module_access_tests {
         assert!(list.matches_path(Path::new("archive.bz2")));
     }
 
+    // WHY: upstream token.c:206-211 treats a bare `*` in the dont-compress match
+    // list as the whole-stream store signal (not a per-file suffix). A normal
+    // suffix list must not be mistaken for it, or ordinary transfers would lose
+    // compression.
+    #[test]
+    fn dont_compress_bare_star_is_match_all() {
+        assert!(dont_compress_is_match_all("*"));
+        assert!(dont_compress_is_match_all("*.gz *"));
+        assert!(!dont_compress_is_match_all("*.gz *.zip"));
+        assert!(!dont_compress_is_match_all("gz"));
+        assert!(!dont_compress_is_match_all(""));
+    }
+
 
     fn test_module_with_defaults() -> ModuleRuntime {
         ModuleRuntime::from(ModuleDefinition::default())

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -181,6 +181,24 @@ pub struct ConnectionConfig {
     /// - `options.c:89`: `do_compression_threads` global
     /// - `token.c:701`: `ZSTD_CCtx_setParameter(.., ZSTD_c_nbWorkers, ..)`
     pub compression_threads: Option<std::num::NonZeroU8>,
+    /// Whole-stream compression store triggered by a daemon module's
+    /// `dont compress = *` (upstream's match-all special case).
+    ///
+    /// When true and the negotiated codec is zlib/zlibx, the sender initialises
+    /// the deflate stream at level 0 (store) for the entire transfer rather than
+    /// compressing per block. Mirrors upstream `init_set_compression()`, where a
+    /// bare `*` in the sender's dont-compress match list sets
+    /// `per_file_default_level = skip_compression_level`. Has no effect on
+    /// zstd/lz4, which use `do_compression_level`. A client's `--skip-compress`
+    /// never sets this: upstream discards it (`f = ""`).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `token.c:206-211`: `init_set_compression()` `*` match-string optimization
+    /// - `token.c:378`: `deflateInit2(.., per_file_default_level, ..)` (zlib store)
+    /// - `token.c:748`: zstd uses `do_compression_level`, ignoring the match-all case
+    /// - `token.c:182`: non-daemon `--skip-compress` sets `f = ""`
+    pub dont_compress_match_all: bool,
     /// Pre-read `--files-from` data for forwarding to a remote daemon.
     ///
     /// When the client has `--files-from` pointing to stdin or a local file,

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -78,6 +78,37 @@ pub(super) fn create_token_encoder(
     }
 }
 
+/// Selects the whole-stream compression level, applying upstream's
+/// skip-compress "match all" special case.
+///
+/// When `match_all` is set (a daemon module's `dont compress = *`) and the
+/// negotiated codec is zlib/zlibx, the entire deflate stream is initialised at
+/// level 0 (store) instead of compressing per block. All other cases keep the
+/// `configured` level.
+///
+/// upstream: token.c:206-211 `init_set_compression()` - a bare `*` in the
+/// sender's dont-compress match list sets `per_file_default_level =
+/// skip_compression_level` (`Z_NO_COMPRESSION` for zlib), which token.c:378
+/// feeds into `deflateInit2()` to store the whole stream. zstd/lz4 keep
+/// `do_compression_level` (token.c:748), so the match-all case never lowers
+/// their level.
+pub(super) fn whole_stream_compression_level(
+    match_all: bool,
+    codec: CompressionAlgorithm,
+    configured: CompressionLevel,
+) -> CompressionLevel {
+    if match_all
+        && matches!(
+            codec,
+            CompressionAlgorithm::Zlib | CompressionAlgorithm::ZlibX
+        )
+    {
+        CompressionLevel::None
+    } else {
+        configured
+    }
+}
+
 /// Protocol version historically used to initialise the zlib token encoder.
 ///
 /// Matches the previous `CompressedTokenEncoder::default()` behaviour so this
@@ -806,6 +837,59 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // WHY: a daemon module's `dont compress = *` must store the whole zlib
+    // stream (level 0), because upstream token.c:206-211 sets
+    // per_file_default_level = skip_compression_level for a `*` match list and
+    // token.c:378 feeds it into deflateInit2(). Compressing per block instead
+    // would diverge from upstream's observable "no compression savings" output.
+    #[test]
+    fn whole_stream_store_forces_level_none_for_zlib() {
+        assert_eq!(
+            whole_stream_compression_level(
+                true,
+                CompressionAlgorithm::Zlib,
+                CompressionLevel::Best
+            ),
+            CompressionLevel::None,
+        );
+        assert_eq!(
+            whole_stream_compression_level(
+                true,
+                CompressionAlgorithm::ZlibX,
+                CompressionLevel::Best,
+            ),
+            CompressionLevel::None,
+        );
+    }
+
+    // WHY: upstream feeds per_file_default_level only into deflateInit2() (zlib).
+    // zstd/lz4 use do_compression_level unconditionally (token.c:748), so the
+    // match-all case must NOT lower their level.
+    #[test]
+    fn whole_stream_store_leaves_non_zlib_codecs_unchanged() {
+        for codec in [CompressionAlgorithm::Zstd, CompressionAlgorithm::LZ4] {
+            assert_eq!(
+                whole_stream_compression_level(true, codec, CompressionLevel::Best),
+                CompressionLevel::Best,
+            );
+        }
+    }
+
+    // WHY: without the match-all trigger (normal skip list or none) the
+    // configured level must pass through untouched so ordinary transfers stay
+    // wire-identical to upstream.
+    #[test]
+    fn without_match_all_configured_level_passes_through() {
+        assert_eq!(
+            whole_stream_compression_level(
+                false,
+                CompressionAlgorithm::Zlib,
+                CompressionLevel::Best,
+            ),
+            CompressionLevel::Best,
+        );
+    }
 
     #[cfg(feature = "zstd")]
     #[test]

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -19,7 +19,7 @@ use protocol::stats::DeleteStats;
 
 use super::super::delta::{
     create_token_encoder, script_to_wire_delta, stream_append_transfer, stream_whole_file_transfer,
-    write_delta_with_inline_checksum,
+    whole_stream_compression_level, write_delta_with_inline_checksum,
 };
 use super::super::item_flags::ItemFlags;
 use super::super::protocol_io::NdxAttrs;
@@ -134,13 +134,20 @@ impl GeneratorContext {
         // upstream: token.c inits the compressor with do_compression_level (the
         // negotiated --compress-level). Absent an explicit level, each codec
         // substitutes its own default via CompressionLevel::Default.
-        let compression_level = self
+        let configured_level = self
             .config
             .connection
             .compression_level
             .unwrap_or(compress::zlib::CompressionLevel::Default);
+        // upstream: token.c:206-211 - a daemon module's `dont compress = *`
+        // stores the whole zlib stream (level 0); zstd/lz4 are unaffected.
+        let dont_compress_match_all = self.config.connection.dont_compress_match_all;
         let mut token_encoder = negotiated_compression
-            .map(|algo| create_token_encoder(algo, compression_level, compression_threads))
+            .map(|algo| {
+                let level =
+                    whole_stream_compression_level(dont_compress_match_all, algo, configured_level);
+                create_token_encoder(algo, level, compression_threads)
+            })
             .transpose()?
             .flatten();
 


### PR DESCRIPTION
## Summary

Honor upstream rsync's whole-stream compression "match all" special case: when a
daemon module is configured with `dont compress = *`, the sender must initialise
the zlib stream at level 0 (store) for the entire transfer instead of compressing
per block.

## Upstream mechanism

`token.c:init_set_compression()` builds the sender's dont-compress match list from
`lp_dont_compress(module_id)`. When a bare `*` token appears in that list, upstream
collapses it to a whole-stream store (`token.c:206-211`):

```c
if (t - start == 1+1 && *start == '*') {
    *match_list = '\0';
    suftree = NULL;
    per_file_default_level = skip_compression_level;   /* Z_NO_COMPRESSION for zlib */
    break;
}
```

`per_file_default_level` is fed into `deflateInit2()` (`token.c:378`), so the whole
zlib stream is stored. This is zlib-only: zstd uses `do_compression_level`
unconditionally (`token.c:748`) and is unaffected. The per-file suffix matching
(`set_compression()`) is compiled out (`#if 0`) in 3.4.4, so no per-file level
change happens. A non-daemon client's `--skip-compress` sets `f = ""`
(`token.c:182`) and never triggers the store.

Verified against rsync 3.4.4 (zlib, 2 MB compressible file, daemon sender):

| Scenario | Bytes on wire |
|---|---|
| `dont compress = *` (daemon) | ~2,000,918 (stored) |
| normal module `-z` | ~2,036 (compressed) |
| client `--skip-compress='*'` | ~2,036 (compressed, discarded) |
| zstd + `dont compress = *` | ~190 (compressed, ignored) |

## Divergence

oc parsed a bare `*` as a literal suffix pattern that matches nothing, so
`dont compress = *` compressed the whole stream at level 6 instead of storing it.

## Fix

- Detect the bare-`*` match-all case when building the daemon server config and
  set a new `ConnectionConfig::dont_compress_match_all` flag (instead of an inert
  literal-`*` skip list). Scoped to the daemon path, so client `--skip-compress`
  is untouched, matching upstream's `f = ""`.
- In the generator transfer loop, when the flag is set and the negotiated codec is
  zlib/zlibx, select `CompressionLevel::None` (level 0 store) for the whole-stream
  encoder. zstd/lz4 keep the configured level, mirroring upstream.

No changes to the compression-level representation. The default skip-compress path
and all other codecs remain wire-identical.

## Verification

- New unit tests: `whole_stream_compression_level` (zlib match-all -> None; zstd/lz4
  and non-match-all pass through) and `dont_compress_is_match_all` detection.
- End-to-end against rsync 3.4.4 as client pulling from an oc-rsync daemon: zlib
  `dont compress = *` -> 2,000,696 bytes (stored, matches upstream); normal module
  and zstd unchanged; transferred content byte-identical.
- `cargo fmt`, `cargo clippy -p transfer -p daemon --all-features --no-deps -D warnings`
  clean.
