### PR TITLE
fix(receiver): seek past in-place matched blocks at same offset

### DIFF
--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -130,6 +130,7 @@ pub(in crate::disk_commit) fn process_file(
         iocp_batch,
         config.use_sparse,
         begin.append_offset,
+        begin.is_inplace,
         begin.target_size,
     )?;
 
@@ -192,6 +193,29 @@ pub(in crate::disk_commit) fn process_file(
                 bytes_written += data.len() as u64;
                 // Return the buffer for reuse. Ignore errors - the network
                 // thread may have moved on (e.g. after an error).
+                let _ = buf_return_tx.try_send(data);
+            }
+            FileMessage::SkipMatched(data) => {
+                // In-place matched block already at its destination offset.
+                // upstream: receiver.c:461-465 hashes the matched bytes via
+                // sum_update BEFORE skip_matched(), so fold them into the
+                // per-file checksum here regardless of whether we write them.
+                if let Some(ref mut verifier) = checksum_verifier {
+                    verifier.update(&data);
+                }
+                if let Some(ref mut sparse) = sparse_state {
+                    // upstream: fileio.c:196-200 skip_matched() sparse branch
+                    // hands the bytes to the sparse processor (with the seek
+                    // flag). Writing them through SparseWriteState is
+                    // byte-identical for an in-place basis==dest update.
+                    sparse.write(output.buffered_for_sparse(), &data)?;
+                } else {
+                    // upstream: fileio.c:202-209 skip_matched() - flush then
+                    // lseek past the already-in-place bytes instead of
+                    // rewriting identical data.
+                    output.skip_matched(data.len() as u64)?;
+                }
+                bytes_written += data.len() as u64;
                 let _ = buf_return_tx.try_send(data);
             }
             FileMessage::Commit => {
@@ -353,6 +377,7 @@ pub(in crate::disk_commit) fn process_whole_file(
         iocp_batch,
         config.use_sparse,
         begin.append_offset,
+        begin.is_inplace,
         begin.target_size,
     )?;
     let bytes_written = data.len() as u64;
@@ -452,7 +477,7 @@ fn discard_file_on_open_failure(
 ) -> io::Result<CommitResult> {
     loop {
         match file_rx.recv() {
-            Ok(FileMessage::Chunk(data)) => {
+            Ok(FileMessage::Chunk(data) | FileMessage::SkipMatched(data)) => {
                 // Recycle the buffer for the network thread; drop the bytes.
                 let _ = buf_return_tx.try_send(data);
             }
@@ -603,11 +628,18 @@ pub(super) fn make_writer<'a>(
     iocp_batch: Option<&'a mut fast_io::IocpDiskBatch>,
     use_sparse: bool,
     append_offset: u64,
+    is_inplace: bool,
     size_hint: u64,
 ) -> io::Result<Writer<'a>> {
+    // In-place updates must use the buffered writer: they seek past matched
+    // basis bytes already in the destination (upstream skip_matched, fileio.c:
+    // 202-209), and the batched backends submit at their own internally
+    // tracked offset and cannot honor an intervening seek. This mirrors
+    // upstream, which always drives in-place writes through buffered
+    // write_file + lseek rather than any async submission path.
     #[cfg(all(target_os = "linux", feature = "io_uring"))]
     {
-        if !use_sparse && append_offset == 0 {
+        if !use_sparse && append_offset == 0 && !is_inplace {
             if let Some(batch) = disk_batch {
                 batch.begin_file(file)?;
                 return Ok(Writer::IoUring { batch });
@@ -616,7 +648,7 @@ pub(super) fn make_writer<'a>(
     }
     #[cfg(all(target_os = "windows", feature = "iocp"))]
     {
-        if !use_sparse && append_offset == 0 {
+        if !use_sparse && append_offset == 0 && !is_inplace {
             if let Some(batch) = iocp_batch {
                 batch.begin_file(file)?;
                 return Ok(Writer::Iocp { batch });
@@ -629,13 +661,13 @@ pub(super) fn make_writer<'a>(
     // they fall back to the buffered writer below.
     #[cfg(all(target_os = "macos", feature = "macos-gcd"))]
     {
-        if !use_sparse && append_offset == 0 {
+        if !use_sparse && append_offset == 0 && !is_inplace {
             return Ok(Writer::MacosGcd(fast_io::GcdWriter::from_file(file)?));
         }
     }
     #[cfg(target_os = "macos")]
     {
-        if !use_sparse && append_offset == 0 {
+        if !use_sparse && append_offset == 0 && !is_inplace {
             return Ok(Writer::Macos(fast_io::MacosWriter::from_file(
                 file, size_hint,
             )));
@@ -651,7 +683,7 @@ pub(super) fn make_writer<'a>(
     // Buffered.
     #[cfg(all(target_os = "linux", feature = "dontcache"))]
     {
-        if !use_sparse && append_offset == 0 && fast_io::dontcache_supported() {
+        if !use_sparse && append_offset == 0 && !is_inplace && fast_io::dontcache_supported() {
             return Ok(Writer::Dontcache(fast_io::DontcacheFileWriter::new(file)?));
         }
     }
@@ -661,7 +693,7 @@ pub(super) fn make_writer<'a>(
     // shape B. Sparse and append require Seek, so they keep using Buffered.
     #[cfg(all(target_os = "linux", feature = "vmsplice"))]
     {
-        if !use_sparse && append_offset == 0 {
+        if !use_sparse && append_offset == 0 && !is_inplace {
             return Ok(Writer::Vmsplice(fast_io::VmspliceFileWriter::new(file)?));
         }
     }

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -89,6 +89,7 @@ fn make_writer_selects_macos_for_non_sparse_zero_offset() {
         None,
         /* use_sparse */ false,
         /* append_offset */ 0,
+        /* is_inplace */ false,
         /* size_hint */ 0,
     )
     .unwrap();
@@ -117,6 +118,7 @@ fn make_writer_falls_back_to_buffered_when_seek_required() {
         None,
         /* use_sparse */ true,
         /* append_offset */ 0,
+        /* is_inplace */ false,
         /* size_hint */ 0,
     )
     .unwrap();
@@ -136,6 +138,7 @@ fn make_writer_falls_back_to_buffered_when_seek_required() {
         None,
         /* use_sparse */ false,
         /* append_offset */ 4096,
+        /* is_inplace */ false,
         /* size_hint */ 0,
     )
     .unwrap();
@@ -163,6 +166,7 @@ fn make_writer_selects_macos_gcd_when_feature_enabled() {
         None,
         /* use_sparse */ false,
         /* append_offset */ 0,
+        /* is_inplace */ false,
         /* size_hint */ 0,
     )
     .unwrap();
@@ -191,6 +195,7 @@ fn make_writer_macos_gcd_falls_back_to_buffered_for_seek() {
         None,
         /* use_sparse */ true,
         /* append_offset */ 0,
+        /* is_inplace */ false,
         /* size_hint */ 0,
     )
     .unwrap();
@@ -209,6 +214,7 @@ fn make_writer_macos_gcd_falls_back_to_buffered_for_seek() {
         None,
         /* use_sparse */ false,
         /* append_offset */ 4096,
+        /* is_inplace */ false,
         /* size_hint */ 0,
     )
     .unwrap();
@@ -257,6 +263,7 @@ fn macos_gcd_writer_matches_buffered_byte_for_byte() {
         None,
         /* use_sparse */ true,
         /* append_offset */ 0,
+        /* is_inplace */ false,
         /* size_hint */ 0,
     )
     .unwrap();

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -241,6 +241,67 @@ fn write_and_commit_file() {
     h.join_handle.join().unwrap();
 }
 
+/// A `SkipMatched` message in an in-place update must SEEK past the matched
+/// bytes, not rewrite them. This is upstream's `skip_matched()` optimization
+/// (receiver.c:468-474 -> fileio.c:202-209): a block that already sits at its
+/// destination offset is left untouched on disk while the write position still
+/// advances so the following data lands at the correct offset.
+///
+/// WHY this matters: rewriting bytes that are already correct dirties clean
+/// pages and issues a needless write, diverging from upstream's I/O profile.
+/// The final file content must stay byte-identical to a full rewrite.
+///
+/// To observe "not rewritten" directly, the `SkipMatched` payload here
+/// deliberately differs from the on-disk bytes: if the disk thread wrote the
+/// payload (a bug) the first block would change; because it seeks, the original
+/// on-disk bytes survive. The trailing `Chunk` proves the write cursor advanced
+/// past the skipped block (it lands at offset 8, not 0).
+#[test]
+fn inplace_skip_matched_seeks_without_rewriting() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("inplace_skip.dat");
+
+    // Pre-existing destination: block0 already correct, block1 to be replaced.
+    fs::write(&file_path, b"AAAAAAAABBBBBBBB").unwrap();
+
+    let h = spawn_disk_thread(DiskCommitConfig::default()).unwrap();
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 16,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: true,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    // block0 matches at offset 0: seek past it. The probe payload differs from
+    // the on-disk bytes so a stray write would be observable.
+    h.file_tx
+        .send(FileMessage::SkipMatched(b"XXXXXXXX".to_vec()))
+        .unwrap();
+    // block1 is new literal data written at the advanced offset (8).
+    h.file_tx
+        .send(FileMessage::Chunk(b"CCCCCCCC".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Commit).unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    // Both the skipped and the written block count toward the final size so the
+    // in-place ftruncate (commit.rs) clips to the right length.
+    assert_eq!(result.bytes_written, 16);
+    // block0 preserved (seek, not rewrite); block1 overwritten at offset 8.
+    assert_eq!(fs::read(&file_path).unwrap(), b"AAAAAAAACCCCCCCC");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
 #[test]
 fn abort_cleans_up_temp_file() {
     let _registry_lock = test_support::cleanup_registry_test_guard();

--- a/crates/transfer/src/disk_commit/thread.rs
+++ b/crates/transfer/src/disk_commit/thread.rs
@@ -256,7 +256,10 @@ fn disk_thread_main(
                     break;
                 }
             }
-            FileMessage::Chunk(_) | FileMessage::Commit | FileMessage::Abort { .. } => {
+            FileMessage::Chunk(_)
+            | FileMessage::SkipMatched(_)
+            | FileMessage::Commit
+            | FileMessage::Abort { .. } => {
                 let err = io::Error::new(
                     io::ErrorKind::InvalidData,
                     "disk thread received message without preceding Begin",

--- a/crates/transfer/src/disk_commit/writer.rs
+++ b/crates/transfer/src/disk_commit/writer.rs
@@ -221,6 +221,56 @@ impl<'a> Writer<'a> {
         }
     }
 
+    /// Seeks past `len` bytes that are already correct in the destination,
+    /// instead of rewriting them (the `--inplace` matched-at-same-offset case).
+    ///
+    /// Mirrors upstream `skip_matched()` (`fileio.c:202-209`): flush any pending
+    /// buffered bytes, then advance the file position by `len` via
+    /// `lseek(SEEK_CUR)`. The buffered writer's [`Seek`] impl performs exactly
+    /// that flush-then-seek. Only the buffered writer is used for in-place
+    /// updates (`make_writer` forces it whenever `is_inplace` is set), because
+    /// the batched backends submit at their own internally tracked offset and
+    /// cannot honor an intervening seek; the other variants are therefore
+    /// unreachable here.
+    pub(super) fn skip_matched(&mut self, len: u64) -> io::Result<()> {
+        match self {
+            Writer::Buffered(w) => {
+                w.seek(io::SeekFrom::Current(len as i64))?;
+                Ok(())
+            }
+            #[cfg(all(target_os = "linux", feature = "io_uring"))]
+            Writer::IoUring { .. } => {
+                debug_assert!(false, "in-place skip must select buffered writer");
+                unreachable!("in-place skip must select buffered writer")
+            }
+            #[cfg(all(target_os = "windows", feature = "iocp"))]
+            Writer::Iocp { .. } => {
+                debug_assert!(false, "in-place skip must select buffered writer");
+                unreachable!("in-place skip must select buffered writer")
+            }
+            #[cfg(target_os = "macos")]
+            Writer::Macos(_) => {
+                debug_assert!(false, "in-place skip must select buffered writer");
+                unreachable!("in-place skip must select buffered writer")
+            }
+            #[cfg(all(target_os = "macos", feature = "macos-gcd"))]
+            Writer::MacosGcd(_) => {
+                debug_assert!(false, "in-place skip must select buffered writer");
+                unreachable!("in-place skip must select buffered writer")
+            }
+            #[cfg(all(target_os = "linux", feature = "vmsplice"))]
+            Writer::Vmsplice(_) => {
+                debug_assert!(false, "in-place skip must select buffered writer");
+                unreachable!("in-place skip must select buffered writer")
+            }
+            #[cfg(all(target_os = "linux", feature = "dontcache"))]
+            Writer::Dontcache(_) => {
+                debug_assert!(false, "in-place skip must select buffered writer");
+                unreachable!("in-place skip must select buffered writer")
+            }
+        }
+    }
+
     /// Writes the entire chunk, dispatching to the active variant.
     pub(super) fn write_chunk(&mut self, data: &[u8]) -> io::Result<()> {
         match self {

--- a/crates/transfer/src/pipeline/messages.rs
+++ b/crates/transfer/src/pipeline/messages.rs
@@ -23,6 +23,25 @@ pub enum FileMessage {
     Begin(Box<BeginMessage>),
     /// A chunk of file data to write.
     Chunk(Vec<u8>),
+    /// Matched basis bytes for an in-place update that already sit at the same
+    /// offset in the destination as where they would be written.
+    ///
+    /// The disk thread folds these bytes into the per-file checksum (upstream
+    /// hashes matched blocks via `sum_update` regardless) but seeks past them
+    /// instead of rewriting identical data, avoiding a needless write and
+    /// leaving the pages clean.
+    ///
+    /// Only produced when the basis file IS the destination being updated
+    /// (`--inplace` with `fnamecmp == fname`) and the matched block's basis
+    /// offset equals the current output position.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:468-474` - `updating_basis_or_equiv && offset == offset2`
+    ///   dispatches to `skip_matched()` instead of `write_file()`.
+    /// - `fileio.c:192-211` - `skip_matched()` flushes then `lseek`s past the
+    ///   in-place bytes (or feeds the sparse processor with the seek flag).
+    SkipMatched(Vec<u8>),
     /// Finalize the current file (flush, fsync, rename).
     Commit,
     /// Coalesced message for single-chunk files: combines Begin + one Chunk +

--- a/crates/transfer/src/transfer_ops/streaming.rs
+++ b/crates/transfer/src/transfer_ops/streaming.rs
@@ -86,6 +86,14 @@ pub fn process_file_response_streaming<R: Read>(
 ) -> io::Result<StreamingResult> {
     let header = read_response_header(reader, ndx_codec, pending, ctx)?;
 
+    // upstream: receiver.c:911-912 - updating_basis_or_equiv is set when the
+    // basis file IS the destination being updated in place (fnamecmp == fname).
+    // We take the provably-safe subset: --inplace with the basis path equal to
+    // the output path. Matched blocks whose basis offset equals the output
+    // position are then seeked past rather than rewritten.
+    let updating_basis =
+        header.use_inplace && header.basis_path.as_deref() == Some(header.file_path.as_path());
+
     // upstream: xattrs.c:744-755 - apply abbreviated values from sender to xattr list
     let xattr_list = if !header.xattr_values.is_empty() {
         let mut list = xattr_list.unwrap_or_default();
@@ -195,6 +203,7 @@ pub fn process_file_response_streaming<R: Read>(
                 Some(next_delta),
                 token_reader,
                 total_bytes, // initial literal bytes from first chunk
+                updating_basis,
             )
         }
         first_delta => {
@@ -214,6 +223,7 @@ pub fn process_file_response_streaming<R: Read>(
                 Some(first_delta),
                 token_reader,
                 0,
+                updating_basis,
             )
         }
     }

--- a/crates/transfer/src/transfer_ops/streaming_async.rs
+++ b/crates/transfer/src/transfer_ops/streaming_async.rs
@@ -104,6 +104,14 @@ where
 {
     let header = read_response_header_async(reader, ndx_codec, pending, ctx).await?;
 
+    // upstream: receiver.c:911-912 - updating_basis_or_equiv is set when the
+    // basis file IS the destination being updated in place (fnamecmp == fname).
+    // We take the provably-safe subset: --inplace with the basis path equal to
+    // the output path. Matched blocks whose basis offset equals the output
+    // position are then seeked past rather than rewritten.
+    let updating_basis =
+        header.use_inplace && header.basis_path.as_deref() == Some(header.file_path.as_path());
+
     // upstream: xattrs.c:744-755 - apply abbreviated values from sender to xattr list
     let xattr_list = if !header.xattr_values.is_empty() {
         let mut list = xattr_list.unwrap_or_default();
@@ -215,6 +223,7 @@ where
                 Some(next_delta),
                 token_reader,
                 total_bytes, // initial literal bytes from first chunk
+                updating_basis,
             )
             .await
         }
@@ -235,6 +244,7 @@ where
                 Some(first_delta),
                 token_reader,
                 0,
+                updating_basis,
             )
             .await
         }
@@ -260,6 +270,7 @@ async fn process_remaining_tokens_async<R>(
     pending_delta: Option<DeltaToken>,
     token_reader: &mut TokenReader,
     initial_literal_bytes: u64,
+    updating_basis: bool,
 ) -> io::Result<StreamingResult>
 where
     R: tokio::io::AsyncRead + Unpin + ?Sized,
@@ -365,7 +376,16 @@ where
 
                     let mut buf = recycle_or_alloc(buf_return_rx, bytes_to_copy);
                     buf.extend_from_slice(block_data);
-                    file_tx.send(FileMessage::Chunk(buf)).map_err(|_| {
+                    // upstream: receiver.c:468-474 - seek past matched blocks
+                    // already at their destination offset in an in-place update
+                    // instead of rewriting identical bytes. See the sync twin in
+                    // token_loop.rs for the full rationale.
+                    let msg = if updating_basis && offset == total_bytes {
+                        FileMessage::SkipMatched(buf)
+                    } else {
+                        FileMessage::Chunk(buf)
+                    };
+                    file_tx.send(msg).map_err(|_| {
                         io::Error::new(
                             io::ErrorKind::BrokenPipe,
                             "disk commit thread disconnected during block send",

--- a/crates/transfer/src/transfer_ops/token_loop.rs
+++ b/crates/transfer/src/transfer_ops/token_loop.rs
@@ -85,6 +85,7 @@ pub(super) fn process_remaining_tokens<R: Read>(
     pending_delta: Option<DeltaToken>,
     token_reader: &mut TokenReader,
     initial_literal_bytes: u64,
+    updating_basis: bool,
 ) -> io::Result<StreamingResult> {
     let send_abort = |tx: &spsc::Sender<FileMessage>, reason: String| {
         let _ = tx.send(FileMessage::Abort { reason });
@@ -184,7 +185,21 @@ pub(super) fn process_remaining_tokens<R: Read>(
 
                     let mut buf = recycle_or_alloc(buf_return_rx, bytes_to_copy);
                     buf.extend_from_slice(block_data);
-                    file_tx.send(FileMessage::Chunk(buf)).map_err(|_| {
+
+                    // upstream: receiver.c:468-474 - when updating the basis in
+                    // place (fnamecmp == fname) and this matched block's basis
+                    // offset equals the current output position, the bytes are
+                    // already correct in the destination. Seek past them via
+                    // skip_matched() instead of rewriting identical data. The
+                    // bytes are still hashed on the disk thread (upstream's
+                    // sum_update runs regardless), so the file checksum and
+                    // final size stay byte-identical to a full rewrite.
+                    let msg = if updating_basis && offset == total_bytes {
+                        FileMessage::SkipMatched(buf)
+                    } else {
+                        FileMessage::Chunk(buf)
+                    };
+                    file_tx.send(msg).map_err(|_| {
                         io::Error::new(
                             io::ErrorKind::BrokenPipe,
                             "disk commit thread disconnected during block send",


### PR DESCRIPTION
## Summary

With `--inplace`, the pipelined receiver rewrote every matched block, even
when the block already sat at the exact destination offset it would be
written to. Upstream avoids that redundant write: a matched block already in
place is seeked past, not rewritten, so clean pages stay clean and the disk
sees no needless write.

This ports upstream's `skip_matched` optimization to the receiver's streaming
delta path. Output bytes are unchanged in every case; only the redundant write
is elided, exactly where upstream elides it.

## Upstream reference

- `receiver.c:468-474` - when `updating_basis_or_equiv && offset == offset2`
  the receiver dispatches to `skip_matched()` instead of `write_file()`.
- `receiver.c:461-465` - the matched basis bytes are still folded into the
  whole-file checksum via `sum_update` *before* the skip decision, so the
  digest is identical whether the block is written or skipped.
- `fileio.c:192-211` - `skip_matched()` flushes the write buffer then
  `lseek(SEEK_CUR)` past the in-place bytes (sparse mode feeds the bytes to
  the sparse processor with the seek flag).
- `receiver.c:911-912` - `updating_basis_or_equiv` requires the basis file to
  be the destination itself (`fnamecmp == fname`).

## What changed

- New internal `FileMessage::SkipMatched(Vec<u8>)` carrying the matched bytes.
  The disk thread folds them into the per-file checksum (matching upstream's
  unconditional `sum_update`) but seeks past them instead of writing.
- The streaming token loop (sync and async) sends `SkipMatched` instead of
  `Chunk` only when the basis IS the output (`--inplace`, basis path == output
  path) and the matched block's basis offset equals the current output
  position - the exact `offset == offset2` gate. All other matched blocks keep
  the existing read-basis + write behavior.
- In-place writes now select the buffered writer (which supports `Seek`),
  matching upstream's buffered write + `lseek` I/O model. The batched backends
  (io_uring / IOCP / macOS / vmsplice / dontcache) submit at their own
  internally-tracked offset and cannot honor an intervening seek, so they are
  not used for in-place updates.

## Correctness

The skip only fires when the basis file is provably the destination being
updated and the matched region has not yet been passed by the write cursor, so
the on-disk bytes are guaranteed already correct - identical to what a rewrite
would produce. The gate is a strict subset of upstream's condition: in the rare
cases upstream also treats as "equivalent" (backup / partial-dir basis) this
change simply falls back to the existing rewrite, which is still byte-correct.
The matched-block-at-a-different-offset path is untouched.

## Tests

- `inplace_skip_matched_seeks_without_rewriting` drives the disk thread with an
  in-place `SkipMatched` whose payload deliberately differs from the on-disk
  bytes: because the block is seeked past (not written), the original bytes
  survive, and the following `Chunk` proves the write cursor advanced to the
  correct offset. Final file content and byte count are asserted byte-identical
  to a full rewrite.
- `cargo clippy -p transfer --all-features --no-deps -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- Full `disk_commit` module (106 tests) and all `inplace` tests (12) pass.
