### PR TITLE
fix: reject daemon greeting missing subprotocol or digest list

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -65,9 +65,9 @@ use core::server::run_server_with_handshake_on;
 use core::server::AsyncBenchReceiver;
 use logging_sink::MessageSink;
 use protocol::{
-    LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonMessage, MessageCode, MessageFrame, ProtocolVersion,
-    filters::FilterRuleWireFormat, format_legacy_daemon_message, iconv::FilenameConverter,
-    parse_legacy_daemon_message,
+    LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonMessage, MessageCode, MessageFrame,
+    ProtocolVersion, filters::FilterRuleWireFormat, format_legacy_daemon_message,
+    iconv::FilenameConverter, parse_legacy_daemon_message,
 };
 
 use crate::{

--- a/crates/daemon/src/daemon/sections/greeting.rs
+++ b/crates/daemon/src/daemon/sections/greeting.rs
@@ -59,6 +59,65 @@ pub(crate) fn cached_legacy_daemon_greeting() -> &'static [u8] {
     GREETING.get_or_init(|| legacy_daemon_greeting().into_bytes().into_boxed_slice())
 }
 
+/// Validates a client's `@RSYNCD:` version greeting the way an rsync daemon
+/// does, returning the fatal `@ERROR:` line to emit when it is malformed.
+///
+/// Returns `Some(payload)` (including the `@ERROR:` prefix) when the greeting
+/// announces a protocol version but omits a token the protocol requires: the
+/// `.subprotocol` suffix for protocol >= 30, or the digest-name list for
+/// protocol > 31. The caller must write the payload, close the connection, and
+/// stop. Returns `None` when the line is a well-formed greeting or is not a
+/// version banner at all, in which case normal parsing proceeds.
+///
+/// upstream: clientserver.c:180-211 `exchange_protocols()` with `am_client == 0`.
+/// The daemon reads the protocol number with `sscanf(buf, "@RSYNCD: %d.%d", ...)`;
+/// a missing `.subprotocol` leaves `remote_sub < 0` and, for `remote_protocol >= 30`,
+/// yields `@ERROR: your client omitted the subprotocol value: %s`. A missing digest
+/// list (`strchr(buf + 9, ' ')` is NULL) yields, for `remote_protocol > 31`,
+/// `@ERROR: your client omitted the digest name list: %s`. The `%s` echoes the raw
+/// greeting line.
+pub(crate) fn reject_malformed_client_greeting(line: &str) -> Option<String> {
+    let after_prefix = line.strip_prefix(LEGACY_DAEMON_PREFIX)?;
+
+    // upstream: sscanf `%d` skips leading whitespace before the protocol number.
+    let rest = after_prefix.trim_start();
+    let digits = rest
+        .as_bytes()
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digits == 0 {
+        // sscanf(...) < 1: not a version banner - leave it to the other handlers.
+        return None;
+    }
+    let remote_protocol: u32 = rest[..digits].parse().unwrap_or(u32::MAX);
+
+    // upstream: `remote_sub` stays < 0 unless a ".NNN" suffix follows the number.
+    let has_subprotocol = rest[digits..]
+        .strip_prefix('.')
+        .and_then(|fractional| fractional.as_bytes().first())
+        .is_some_and(u8::is_ascii_digit);
+    if !has_subprotocol && remote_protocol >= 30 {
+        return Some(format!(
+            "@ERROR: your client omitted the subprotocol value: {line}"
+        ));
+    }
+
+    // upstream: `daemon_auth_choices = strchr(buf + 9, ' ')` - any space past
+    // "@RSYNCD: " marks the start of the digest-name list.
+    let has_digest_list = line
+        .as_bytes()
+        .get(LEGACY_DAEMON_PREFIX_LEN + 1..)
+        .is_some_and(|tail| tail.contains(&b' '));
+    if !has_digest_list && remote_protocol > 31 {
+        return Some(format!(
+            "@ERROR: your client omitted the digest name list: {line}"
+        ));
+    }
+
+    None
+}
+
 /// Reads one line from `reader`, stripping trailing `\r` and `\n`.
 ///
 /// Returns `Ok(None)` on EOF, or `Ok(Some(line))` with the stripped content.
@@ -99,4 +158,71 @@ pub(crate) fn advertised_capability_lines(modules: &[ModuleRuntime]) -> Vec<Stri
     }
 
     vec![features.join(" ")]
+}
+
+#[cfg(test)]
+mod greeting_validation_tests {
+    use super::reject_malformed_client_greeting;
+
+    // upstream: clientserver.c:188-197 - a protocol >= 30 greeting without a
+    // ".subprotocol" suffix leaves remote_sub < 0 and is fatal. The @ERROR line
+    // must echo the raw greeting so the client can report what it sent.
+    #[test]
+    fn rejects_greeting_missing_subprotocol() {
+        assert_eq!(
+            reject_malformed_client_greeting("@RSYNCD: 32").as_deref(),
+            Some("@ERROR: your client omitted the subprotocol value: @RSYNCD: 32"),
+        );
+        assert_eq!(
+            reject_malformed_client_greeting("@RSYNCD: 30").as_deref(),
+            Some("@ERROR: your client omitted the subprotocol value: @RSYNCD: 30"),
+        );
+    }
+
+    // upstream: clientserver.c:199-211 - protocol > 31 must carry a digest name
+    // list; its absence is fatal even when the subprotocol value is present.
+    #[test]
+    fn rejects_greeting_missing_digest_list() {
+        assert_eq!(
+            reject_malformed_client_greeting("@RSYNCD: 32.0").as_deref(),
+            Some("@ERROR: your client omitted the digest name list: @RSYNCD: 32.0"),
+        );
+    }
+
+    // upstream: clientserver.c:205 - the digest gate is `remote_protocol > 31`, so
+    // protocol 31 needs the subprotocol but not a digest list.
+    #[test]
+    fn protocol_31_requires_subprotocol_not_digest() {
+        assert_eq!(
+            reject_malformed_client_greeting("@RSYNCD: 31").as_deref(),
+            Some("@ERROR: your client omitted the subprotocol value: @RSYNCD: 31"),
+        );
+        assert_eq!(reject_malformed_client_greeting("@RSYNCD: 31.0"), None);
+    }
+
+    // upstream: clientserver.c:196 - protocol < 30 defaults remote_sub to 0 and
+    // needs no digest list, so a bare legacy version is accepted.
+    #[test]
+    fn accepts_legacy_greeting_without_subprotocol_or_digest() {
+        assert_eq!(reject_malformed_client_greeting("@RSYNCD: 29"), None);
+    }
+
+    // A fully-formed modern greeting (subprotocol suffix + digest list), exactly
+    // what upstream and oc-rsync clients send, is accepted unchanged.
+    #[test]
+    fn accepts_well_formed_modern_greeting() {
+        assert_eq!(
+            reject_malformed_client_greeting("@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4"),
+            None,
+        );
+    }
+
+    // Non-version lines (module names, control keywords) are not greetings and
+    // pass through so the normal message parser handles them.
+    #[test]
+    fn ignores_non_version_lines() {
+        assert_eq!(reject_malformed_client_greeting("module"), None);
+        assert_eq!(reject_malformed_client_greeting("@RSYNCD: OK"), None);
+        assert_eq!(reject_malformed_client_greeting("#list"), None);
+    }
 }

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -204,7 +204,7 @@ fn write_limited(
 ///
 /// upstream: clientserver.c - the daemon greeting/response sequence is:
 /// 1. Server sends `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n`
-/// 2. Client responds with `@RSYNCD: 32.0\n`
+/// 2. Client responds with `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n`
 /// 3. Client sends module name (or `#list`)
 #[cfg_attr(feature = "tracing", instrument(skip(stream, params), fields(peer = %peer_addr), name = "legacy_session"))]
 fn handle_legacy_session(
@@ -264,6 +264,21 @@ fn handle_legacy_session(
     fast_io::rearm_tcp_quickack(reader.get_ref().tcp_stream());
     while let Some(line) = read_trimmed_line(&mut reader)? {
         fast_io::rearm_tcp_quickack(reader.get_ref().tcp_stream());
+        // upstream: clientserver.c:180-211 exchange_protocols() (am_client == 0) -
+        // before proceeding the daemon validates the client's version greeting,
+        // refusing one that omits the subprotocol value (protocol >= 30) or the
+        // digest name list (protocol > 31). The refusal is a fatal pre-OK
+        // @ERROR line, after which the client returns and the socket closes.
+        if negotiated_protocol.is_none() {
+            if let Some(payload) = reject_malformed_client_greeting(&line) {
+                write_limited(reader.get_mut(), &mut limiter, payload.as_bytes())?;
+                write_limited(reader.get_mut(), &mut limiter, b"\n")?;
+                reader.get_mut().flush()?;
+                // FSM: -> Closing after the fatal @ERROR refusal.
+                let _ = conn_state.transition(ConnectionState::Closing);
+                return Ok(());
+            }
+        }
         match parse_legacy_daemon_message(&line) {
             Ok(LegacyDaemonMessage::Version(version)) => {
                 // Record the negotiated protocol version but do NOT send @RSYNCD: OK here.

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -151,7 +151,7 @@
 //! let mut line = String::new();
 //! reader.read_line(&mut line)?;
 //! assert_eq!(line, "@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n");
-//! stream.write_all(b"@RSYNCD: 32.0\n")?;
+//! stream.write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")?;
 //! stream.flush()?;
 //! // Send a non-existent module name
 //! stream.write_all(b"module\n")?;

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
@@ -75,7 +75,7 @@ fn daemon_negotiation_auth_challenge_is_unique_per_session() {
 
         // Send version response
         stream
-            .write_all(b"@RSYNCD: 32.0\n")
+            .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
             .expect("send version");
         stream.flush().expect("flush");
 
@@ -166,7 +166,7 @@ fn daemon_negotiation_auth_denies_wrong_password() {
 
     // Send version response
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 
@@ -261,7 +261,7 @@ fn daemon_negotiation_auth_denies_unknown_user() {
 
     // Send version response
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 
@@ -347,7 +347,7 @@ fn daemon_negotiation_auth_skipped_for_unprotected_module() {
 
     // Send version response
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 
@@ -424,7 +424,7 @@ fn daemon_negotiation_auth_denies_empty_credentials() {
 
     // Send version response
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 
@@ -514,7 +514,7 @@ fn daemon_negotiation_auth_successful_sends_ok() {
 
     // Send version response
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_handling.rs
@@ -30,7 +30,7 @@ fn daemon_negotiation_error_unknown_module() {
 
     // Send version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 
@@ -87,7 +87,7 @@ fn daemon_negotiation_error_empty_module_request() {
 
     // Send version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 
@@ -151,7 +151,7 @@ fn daemon_negotiation_error_host_denied() {
 
     // Send version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 
@@ -218,7 +218,7 @@ fn daemon_negotiation_error_refused_options() {
 
     // Send version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 
@@ -304,7 +304,7 @@ fn daemon_negotiation_error_max_connections_exceeded() {
     reader1.read_line(&mut line).expect("greeting1");
 
     stream1
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version1");
     stream1.flush().expect("flush1");
 
@@ -328,7 +328,7 @@ fn daemon_negotiation_error_max_connections_exceeded() {
     reader2.read_line(&mut line).expect("greeting2");
 
     stream2
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version2");
     stream2.flush().expect("flush2");
 
@@ -379,7 +379,7 @@ fn daemon_negotiation_error_sanitizes_module_name_in_response() {
 
     // Send version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 
@@ -436,7 +436,7 @@ fn daemon_negotiation_error_no_exit_after_error() {
 
     // Send version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
@@ -42,7 +42,7 @@ fn daemon_negotiation_error_host_allow_blocks_unlisted() {
 
     // Send version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send version");
     stream.flush().expect("flush");
 

--- a/crates/daemon/src/tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs
+++ b/crates/daemon/src/tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs
@@ -42,7 +42,7 @@ fn daemon_pre_xfer_exec_rejects_on_nonzero_exit() {
 
     // Send client version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_accepts_valid_credentials.rs
@@ -50,7 +50,7 @@ fn run_daemon_accepts_valid_credentials() {
     assert_eq!(line, expected_greeting);
 
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
@@ -51,7 +51,7 @@ fn run_daemon_auth_failure_rejects_wrong_credentials() {
 
     // Send client version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
@@ -39,7 +39,7 @@ fn run_daemon_denies_module_when_host_not_allowed() {
     assert_eq!(line, expected_greeting);
 
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
@@ -49,7 +49,7 @@ fn run_daemon_enforces_module_connection_limit() {
     assert_eq!(line, expected_greeting);
 
     first_stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake");
     first_stream.flush().expect("flush handshake");
 
@@ -74,7 +74,7 @@ fn run_daemon_enforces_module_connection_limit() {
     assert_eq!(line, expected_greeting);
 
     second_stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send second handshake");
     second_stream.flush().expect("flush second handshake");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_handles_parallel_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_handles_parallel_sessions.rs
@@ -34,7 +34,7 @@ fn run_daemon_handles_parallel_sessions() {
             assert_eq!(line, legacy_daemon_greeting());
 
             stream
-                .write_all(b"@RSYNCD: 32.0\n")
+                .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
                 .expect("send handshake response");
             stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_honours_max_sessions.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_honours_max_sessions.rs
@@ -29,7 +29,7 @@ fn run_daemon_honours_max_sessions() {
         assert_eq!(line, expected_greeting);
 
         stream
-            .write_all(b"@RSYNCD: 32.0\n")
+            .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
             .expect("send handshake response");
         stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs
@@ -82,7 +82,7 @@ fn run_daemon_panic_isolation_keeps_daemon_alive() {
 
         // Complete the session so the daemon counts it toward max-sessions
         // and can exit cleanly.
-        good.write_all(b"@RSYNCD: 32.0\n")
+        good.write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
             .expect("send version");
         good.flush().expect("flush version");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs
@@ -68,7 +68,7 @@ fn run_daemon_per_module_cap_overrides_global_max_connections() {
     assert_eq!(line, expected_greeting);
 
     first_stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake");
     first_stream.flush().expect("flush handshake");
 
@@ -94,7 +94,7 @@ fn run_daemon_per_module_cap_overrides_global_max_connections() {
     assert_eq!(line, expected_greeting);
 
     second_stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send second handshake");
     second_stream.flush().expect("flush second handshake");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
@@ -54,7 +54,7 @@ fn run_daemon_post_ok_refused_option_uses_multiplexed_error() {
     assert!(line.starts_with("@RSYNCD:"), "greeting mismatch: {line:?}");
 
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_records_log_file_entries.rs
@@ -36,7 +36,7 @@ fn run_daemon_records_log_file_entries() {
     assert_eq!(line, expected_greeting);
 
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refuses_disallowed_module_options.rs
@@ -34,7 +34,7 @@ fn run_daemon_refuses_disallowed_module_options() {
     assert_eq!(line, expected_greeting);
 
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
@@ -42,7 +42,7 @@ fn run_daemon_rejects_push_to_default_read_only_module() {
 
     // Send client version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
@@ -41,7 +41,7 @@ fn run_daemon_rejects_push_to_read_only_module() {
 
     // Send client version
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_hash_command.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_unknown_hash_command.rs
@@ -33,7 +33,7 @@ fn run_daemon_rejects_unknown_hash_command() {
     assert_eq!(line, expected_greeting);
 
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_requests_authentication_for_protected_module.rs
@@ -50,7 +50,7 @@ fn run_daemon_requests_authentication_for_protected_module() {
     assert_eq!(line, expected_greeting);
 
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
@@ -66,7 +66,7 @@ fn run_daemon_runs_post_xfer_exec_on_read_only_refuse() {
     assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
 
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs
@@ -35,7 +35,7 @@ fn run_daemon_sends_motd_before_unknown_module_error() {
     assert_eq!(line, expected_greeting);
 
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_serves_single_legacy_connection.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_serves_single_legacy_connection.rs
@@ -24,7 +24,7 @@ fn run_daemon_serves_single_legacy_connection() {
     assert_eq!(line, expected_greeting);
 
     stream
-        .write_all(b"@RSYNCD: 32.0\n")
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
         .expect("send handshake response");
     stream.flush().expect("flush handshake response");
 

--- a/crates/daemon/tests/connection_lifecycle_fsm.rs
+++ b/crates/daemon/tests/connection_lifecycle_fsm.rs
@@ -103,7 +103,9 @@ fn read_greeting(reader: &mut BufReader<TcpStream>) -> String {
 }
 
 fn send_version(stream: &mut TcpStream) {
-    stream.write_all(b"@RSYNCD: 32.0\n").expect("send version");
+    stream
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
+        .expect("send version");
     stream.flush().expect("flush version");
 }
 

--- a/crates/daemon/tests/connection_scaling_stress.rs
+++ b/crates/daemon/tests/connection_scaling_stress.rs
@@ -13,7 +13,8 @@
 //! 2. Launches `N` client threads (in batches of `CLIENT_BATCH_SIZE` for
 //!    higher connection counts to avoid client-side thread exhaustion).
 //!    Each client opens a TCP connection, reads the `@RSYNCD: <ver>`
-//!    greeting, sends `@RSYNCD: 32.0\n`, then closes the socket. This
+//!    greeting, sends `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n`, then
+//!    closes the socket. This
 //!    exercises the accept loop, thread spawn, handshake write, and worker
 //!    join paths without doing any file transfer work.
 //! 3. Records wall time, peak RSS (via `getrusage(RUSAGE_SELF).ru_maxrss`),
@@ -290,7 +291,10 @@ fn run_one_client(target: SocketAddr) -> (ConnectionOutcome, Option<u64>) {
     let latency_us = t0.elapsed().as_micros() as u64;
 
     let mut writer = stream;
-    if writer.write_all(b"@RSYNCD: 32.0\n").is_err() {
+    if writer
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
+        .is_err()
+    {
         // The handshake reached the daemon thread; a broken pipe at this
         // point still counts as a successful accept.
         return (ConnectionOutcome::Ok, Some(latency_us));


### PR DESCRIPTION
## Summary

An rsync daemon validates the client's `@RSYNCD:` version greeting in
`exchange_protocols()` (server side, `am_client == 0`) before proceeding.
Upstream refuses a greeting that:

- omits the `.subprotocol` suffix when `remote_protocol >= 30`
  (`@ERROR: your client omitted the subprotocol value: <line>`), or
- omits the digest name list when `remote_protocol > 31`
  (`@ERROR: your client omitted the digest name list: <line>`).

The daemon previously accepted these malformed greetings.

## Upstream reference

`clientserver.c:180-211` (`exchange_protocols`, `rsync-3.4.4`, protocol 32):

- The protocol version is read with `sscanf(buf, "@RSYNCD: %d.%d", ...)`.
- A missing `.subprotocol` leaves `remote_sub < 0`; for `remote_protocol >= 30`
  the server emits the subprotocol `@ERROR` and returns `-1`. For `< 30`,
  `remote_sub` defaults to `0` and the greeting is accepted.
- The digest list is `strchr(buf + 9, ' ')`; when absent and `remote_protocol > 31`
  the server emits the digest `@ERROR` and returns `-1`. Protocol `31` and below
  need no digest list.

Both the modern upstream client and the oc-rsync client always send the
subprotocol suffix and digest list (`compat.c:833 output_daemon_greeting`,
which writes `@RSYNCD: %d.%d %s\n` for both roles), so a well-formed handshake
is unaffected.

## Changes

- Add `reject_malformed_client_greeting()` in the daemon greeting section,
  mirroring the upstream gating exactly and returning the byte-for-byte
  `@ERROR:` payload to emit.
- Refuse a malformed greeting in the legacy session handler with the pre-OK
  `@ERROR` framing (raw line + newline, no `@RSYNCD: EXIT`), then close, exactly
  as the daemon does for other pre-OK refusals.
- Update the daemon test greetings from `@RSYNCD: 32.0` to
  `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4`, matching what a real protocol-32
  client sends. The daemon ignores the greeting's trailing digest list, so this
  is behaviour-neutral apart from passing the new validation.

## Tests

New unit tests cover the rejection triggers and the accepted cases, each
citing the upstream lines they encode:

- protocol >= 30 without subprotocol -> subprotocol `@ERROR` (byte-exact)
- protocol > 31 without digest list -> digest `@ERROR` (byte-exact)
- protocol 31 needs subprotocol but not a digest list
- protocol < 30 bare version accepted
- well-formed modern greeting accepted
- non-version lines pass through untouched
