### PR TITLE
fix: role-gate L/k and emit v in server flag string

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -207,15 +207,15 @@ pub(super) fn build_full_daemon_args(
     // like `-logDtpre.iLsfxCIvu`. We follow the same format for interop.
     let mut flag_string = flags::build_server_flag_string(config);
 
-    // upstream: options.c:2641-2654 - the `am_sender` branch of server_options()
-    // packs several sender-only compact letters. `build_server_flag_string` is
+    // upstream: options.c:2641-2660 - server_options() packs a direction-
+    // specific branch of compact letters. `build_server_flag_string` is
     // role-agnostic and also feeds the local in-process ServerConfig parser
-    // (server_config.rs), where the L/k letters must stay unconditional for the
-    // local push sender's copy_links/copy_dirlinks (flags.rs:152-164). So the
-    // sender-only letters are appended here, on the daemon wire path only. On a
-    // daemon PUSH the local client is the sender (`we_are_sender`), so these ride
-    // to the remote receiver; on a PULL they are omitted (the local receiver
-    // applies omit-dir/link-times, prune-empty-dirs, and fuzzy matching itself).
+    // (server_config.rs), so the role-gated letters are applied here, on the
+    // daemon wire path only. On a daemon PUSH the local client is the sender
+    // (`we_are_sender`), so the `am_sender` letters (K/m/O/J/y/E) ride to the
+    // remote receiver; on a PULL the remote is the sender, so the `else`-branch
+    // letters (L/k) ride to it instead and the local receiver applies
+    // omit-dir/link-times, prune-empty-dirs, and fuzzy matching itself.
     if we_are_sender {
         // upstream: options.c:2642-2643 - keep_dirlinks 'K'.
         if config.keep_dirlinks() {
@@ -246,6 +246,19 @@ pub(super) fn build_full_daemon_args(
         // receiver's generator to keep the executable bit.
         if !config.preserve_permissions() && config.preserve_executability() {
             flag_string.push('E');
+        }
+    } else {
+        // upstream: options.c:2655-2660 - the `!am_sender` (else) branch packs
+        // copy_links 'L' and copy_dirlinks 'k'. On a daemon PULL the remote is
+        // the sender, so these ride to it to dereference symlinks and
+        // dir-symlinks; on a PUSH they are omitted (the local sender
+        // dereferences itself). `build_server_flag_string` no longer packs L/k,
+        // so the pull wire gets them here.
+        if config.copy_links() {
+            flag_string.push('L');
+        }
+        if config.copy_dirlinks() {
+            flag_string.push('k');
         }
     }
 

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -195,6 +195,82 @@ mod protect_args_daemon_tests {
         );
     }
 
+    // upstream: options.c:2655-2660 - `if (am_sender) { ... } else { if
+    // (copy_links) 'L'; if (copy_dirlinks) 'k'; }`. On a PULL the daemon is the
+    // sender (is_sender=true, we_are_sender=false), so L/k ride the wire to it -
+    // copy_links/copy_dirlinks dereference symlinks on the SENDER. A builder that
+    // sent them on a push (to the remote receiver) diverged from upstream.
+    #[test]
+    fn build_full_args_pull_packs_copy_links_and_dirlinks() {
+        let config = ClientConfig::builder()
+            .copy_links(true)
+            .copy_dirlinks(true)
+            .build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, true);
+
+        let flags = find_flag_string(&args);
+        // Isolate the transfer letters from the `e.` capability suffix, which
+        // itself carries an 'L' (log_format) that would false-positive.
+        let transfer = flags.split("e.").next().expect("transfer letters");
+        assert!(
+            transfer.contains('L'),
+            "pull (daemon-is-sender) must pack 'L' (copy-links): {flags}"
+        );
+        assert!(
+            transfer.contains('k'),
+            "pull (daemon-is-sender) must pack 'k' (copy-dirlinks): {flags}"
+        );
+    }
+
+    // upstream: options.c:2641-2654 - on a PUSH the local client is the sender
+    // (is_sender=false, we_are_sender=true), so server_options() takes the
+    // `am_sender` branch and never packs L/k. The local sender dereferences
+    // symlinks itself; the remote receiver must not receive copy-links.
+    #[test]
+    fn build_full_args_push_omits_copy_links_and_dirlinks() {
+        let config = ClientConfig::builder()
+            .copy_links(true)
+            .copy_dirlinks(true)
+            .build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, false);
+
+        let flags = find_flag_string(&args);
+        let transfer = flags.split("e.").next().expect("transfer letters");
+        assert!(
+            !transfer.contains('L'),
+            "push must omit 'L' (copy-links rides only to a remote sender): {flags}"
+        );
+        assert!(
+            !transfer.contains('k'),
+            "push must omit 'k' (copy-dirlinks rides only to a remote sender): {flags}"
+        );
+    }
+
+    // upstream: options.c:2625-2626 - `for (i = 0; i < verbose; i++)
+    // argstr[x++] = 'v';`. The daemon wire must carry one 'v' per verbosity
+    // level so the remote half emits matching verbose diagnostics. The `e.`
+    // capability suffix also contains a 'v', so the count is checked against
+    // the transfer-letter portion only.
+    #[test]
+    fn build_full_args_packs_verbose_v_per_level() {
+        let config = ClientConfig::builder().verbosity(2).build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, false);
+
+        let flags = find_flag_string(&args);
+        let transfer = flags.split("e.").next().expect("transfer letters");
+        assert_eq!(
+            transfer.matches('v').count(),
+            2,
+            "verbosity 2 must pack exactly two 'v' in the transfer letters: {flags}"
+        );
+    }
+
     #[test]
     fn build_full_args_includes_compare_dest() {
         let config = ClientConfig::builder()

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -25,6 +25,17 @@ use crate::server::ServerConfig;
 pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     let mut flags = String::from("-");
 
+    // upstream: options.c:2625-2626 - `for (i = 0; i < verbose; i++)
+    // argstr[x++] = 'v';` packs one 'v' per verbosity level, first after the
+    // leading '-'. server_options() sends the count to the remote so its
+    // generator/receiver emits matching verbose diagnostics; the daemon wire
+    // path (build_full_daemon_args) carries this string verbatim. The
+    // in-process half re-parses the same string (from_flag_string_and_args)
+    // and honours the 'v' count too, redundantly with apply_common_server_flags.
+    for _ in 0..config.verbosity() {
+        flags.push('v');
+    }
+
     // upstream: options.c:2628-2629 - `if (quiet && msgs2stderr) 'q'`. The
     // default `msgs2stderr` is 2 (nonzero), so plain `-q` packs 'q';
     // `--no-msgs2stderr` (msgs2stderr == 0) suppresses it. The local-half
@@ -149,19 +160,16 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.preserve_crtimes() {
         flags.push('N');
     }
-    // upstream: options.c:764 - 'L' = copy_links (resolve symlinks).
-    if config.copy_links() {
-        flags.push('L');
-    }
-    // upstream: options.c:2658-2659 - 'k' = copy_dirlinks. Packed alongside
-    // 'L' so the in-process push sender (build_server_config_for_generator)
-    // sets `flags.copy_dirlinks` and the flist walker transmits a
-    // symlink-to-directory as a real directory; also forwarded to a remote
-    // daemon sender on a pull. Both dereference on the sender exactly like
-    // copy_links.
-    if config.copy_dirlinks() {
-        flags.push('k');
-    }
+    // upstream: options.c:2655-2660 - `if (am_sender) { ... } else { if
+    // (copy_links) 'L'; if (copy_dirlinks) 'k'; }`. The compact L/k letters are
+    // role-specific: server_options() emits them ONLY when the local side is
+    // NOT the sender (a pull), because copy_links/copy_dirlinks dereference
+    // symlinks on the SENDER, so they matter to the remote only when the remote
+    // is the sender. This role-agnostic builder therefore does NOT pack L/k -
+    // the daemon wire path (build_full_daemon_args) re-adds them gated on the
+    // pull direction, and the in-process half sets `flags.copy_links` /
+    // `flags.copy_dirlinks` directly in apply_common_server_flags so a push
+    // generator still dereferences.
 
     // upstream: options.c:2750-2762 - itemize-changes is forwarded via
     // --log-format=%i in the long-form args, not as a compact flag.
@@ -408,6 +416,16 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // protocol >= 30 forces them. `implied_dirs()` defaults true, so this stays
     // false (implied dirs on) unless the client passed --no-implied-dirs.
     server_config.flags.no_implied_dirs = !config.implied_dirs();
+    // upstream: options.c:2655-2660 - `if (!am_sender) { if (copy_links) 'L';
+    // if (copy_dirlinks) 'k'; }`. The compact L/k letters are wire-role-gated
+    // (see build_server_flag_string, which no longer packs them). The in-process
+    // half still needs the flags set directly: on a push the LOCAL generator IS
+    // the sender and must dereference symlinks (copy_links) and dir-symlinks
+    // (copy_dirlinks) while building its flist. Setting them unconditionally is
+    // inert on a pull, where the local half is the receiver and the remote
+    // sender does the dereferencing.
+    server_config.flags.copy_links = config.copy_links();
+    server_config.flags.copy_dirlinks = config.copy_dirlinks();
     // upstream: options.c:2881-2885 - copy_unsafe_links and safe_links are long-form only
     server_config.flags.copy_unsafe_links = config.copy_unsafe_links();
     server_config.flags.safe_links = config.safe_links();
@@ -558,6 +576,85 @@ mod tests {
             .build();
         let flags = build_server_flag_string(&config);
         assert!(!flags.contains('z'), "should not send 'z' for lz4: {flags}");
+    }
+
+    // upstream: options.c:2625-2626 - `for (i = 0; i < verbose; i++)
+    // argstr[x++] = 'v';` packs one 'v' per verbosity level, and none at all
+    // when verbose == 0. server_options() sends the count to the remote so its
+    // half emits matching verbose diagnostics; a builder that dropped 'v'
+    // silenced the remote generator's output relative to upstream.
+    #[test]
+    fn server_flag_string_emits_one_v_per_verbosity_level() {
+        let config = ClientConfig::builder().verbosity(3).build();
+        let flags = build_server_flag_string(&config);
+        // 'v' is the ONLY letter that can repeat here; the leading '-' plus
+        // exactly three 'v's must lead the string in upstream source order.
+        assert!(
+            flags.starts_with("-vvv"),
+            "verbosity 3 must pack 'vvv' first: {flags}"
+        );
+        assert_eq!(
+            flags.matches('v').count(),
+            3,
+            "exactly one 'v' per level: {flags}"
+        );
+    }
+
+    #[test]
+    fn server_flag_string_omits_v_at_zero_verbosity() {
+        let config = ClientConfig::builder().build();
+        let flags = build_server_flag_string(&config);
+        assert!(
+            !flags.contains('v'),
+            "default (verbose 0) must pack no 'v': {flags}"
+        );
+    }
+
+    // upstream: options.c:2655-2660 - L/k live in the `!am_sender` (else) branch
+    // of server_options(), so they are role-specific and must NOT be packed by
+    // this role-agnostic builder. Packing them unconditionally sent 'L'/'k' to a
+    // remote RECEIVER on a push, diverging from upstream which only sends them to
+    // a remote SENDER (pull). The daemon wire path re-adds them role-gated.
+    #[test]
+    fn server_flag_string_never_packs_copy_links_or_dirlinks() {
+        let config = ClientConfig::builder()
+            .copy_links(true)
+            .copy_dirlinks(true)
+            .build();
+        let flags = build_server_flag_string(&config);
+        assert!(
+            !flags.contains('L'),
+            "role-agnostic builder must not pack 'L' (copy-links): {flags}"
+        );
+        assert!(
+            !flags.contains('k'),
+            "role-agnostic builder must not pack 'k' (copy-dirlinks): {flags}"
+        );
+    }
+
+    // upstream: options.c:2655-2660 - the in-process half no longer learns
+    // copy_links/copy_dirlinks from the compact string (build_server_flag_string
+    // dropped L/k), so apply_common_server_flags must carry them directly. On a
+    // push the local generator IS the sender and must dereference symlinks.
+    #[test]
+    fn apply_common_server_flags_sets_copy_links_and_dirlinks() {
+        let config = ClientConfig::builder()
+            .copy_links(true)
+            .copy_dirlinks(true)
+            .build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(server_config.flags.copy_links);
+        assert!(server_config.flags.copy_dirlinks);
+    }
+
+    #[test]
+    fn apply_common_server_flags_copy_links_default_false() {
+        let config = ClientConfig::default();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(!server_config.flags.copy_links);
+        assert!(!server_config.flags.copy_dirlinks);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The shared, role-agnostic `build_server_flag_string` diverged from upstream `server_options()` (`options.c:2625-2660`) in two wire-visible ways:

- It packed the compact `L` (`--copy-links`) and `k` (`--copy-dirlinks`) letters **unconditionally**, whereas upstream packs them **only in the `!am_sender` (else) branch** (`options.c:2655-2660`). Those flags dereference symlinks on the **sender**, so they are meaningful to the remote only when the remote is the sender (a pull). On a daemon **push**, oc wrongly shipped `L`/`k` to the remote **receiver**.
- It never emitted the verbose `v` letter, whereas upstream packs one `v` per verbosity level, first (`options.c:2625-2626`). The daemon wire therefore never told the remote half to be verbose.

The SSH invocation builder (`invocation/builder.rs::build_flag_string`) already handles this correctly via its own role-aware builder (it emits `v` and gates `L`/`k` on `am_sender`). Only the daemon path and the shared role-agnostic builder needed the fix.

## Upstream references

- `options.c:2625-2626` — `for (i = 0; i < verbose; i++) argstr[x++] = 'v';` (verbose count, first).
- `options.c:2641-2654` — `if (am_sender) { K m O J y ... }` (sender-only letters).
- `options.c:2655-2660` — `else { if (copy_links) 'L'; if (copy_dirlinks) 'k'; }` (receiver-side / pull only).

## Changes

- `remote/flags.rs::build_server_flag_string`: emit `v` per verbosity level (first, after `-`); stop packing `L`/`k` (they are wire-role-specific).
- `remote/flags.rs::apply_common_server_flags`: set `flags.copy_links` / `flags.copy_dirlinks` directly so the in-process **push** generator still dereferences symlinks. This mirrors the existing direct-set pattern for `partial`/`devices`/`specials`. Setting them unconditionally is inert on a pull (the local half is the receiver).
- `daemon_transfer/orchestration/arguments.rs::build_full_daemon_args`: add the `!we_are_sender` (pull) `else` branch that packs `L`/`k`, mirroring `options.c:2655-2660`, symmetric to the existing `am_sender` branch (K/m/O/J/y/E).

`build_server_flag_string` also seeds the in-process `ServerConfig` (via `from_flag_string_and_args`); the daemon makes a **separate** call for the wire, so the two uses were decoupled without changing local-config behaviour (`copy_links` is now carried by `apply_common_server_flags` instead of a parsed letter — identical final value).

## Proving byte-exact parity

New tests (all green):

- `build_server_flag_string`: emits `-vvv` for verbosity 3 and no `v` at 0; never packs `L`/`k`.
- `apply_common_server_flags`: sets `copy_links`/`copy_dirlinks` from config; false by default.
- `build_full_daemon_args`: pull (daemon-is-sender) packs `L`/`k`; push omits them; verbose count packed on the wire. Tests split the flag string at the `e.` capability marker so the suffix's own `L`/`v` do not false-positive.

Verified locally: `cargo fmt --all --check` clean, `cargo clippy -p core --all-targets --all-features --no-deps -D warnings` clean, `cargo test -p core --lib` for `flags` / `daemon_transfer::orchestration` / `invocation` = 434 passed, 0 failed.
