### PR TITLE
fix: report P_GLOBAL rsyncd.conf params inside modules

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -4,6 +4,35 @@
 // rsyncd.conf. Each recognized key is dispatched to the corresponding setter
 // on `ModuleDefinitionBuilder`.
 
+/// Public config keys of the daemon parameters upstream classifies `P_GLOBAL`.
+///
+/// These are only valid in the global section (before the first `[module]`
+/// header). The list mirrors the `Globals:` block of upstream
+/// `daemon-parm.txt`; each entry is the `parm_table` label (the parameter's
+/// public name with underscores rendered as spaces).
+///
+/// upstream: daemon-parm.txt `Globals:` - `parm_table[]` marks each of these
+/// `P_GLOBAL` (loadparm.c `parm_class`). Everything else is `P_LOCAL` and may
+/// be set per-module.
+const GLOBAL_ONLY_DIRECTIVES: &[&str] = &[
+    "address",
+    "daemon chroot",
+    "daemon gid",
+    "daemon uid",
+    "motd file",
+    "pid file",
+    "socket options",
+    "listen backlog",
+    "port",
+    "proxy protocol",
+];
+
+/// Returns `true` when `key` names an upstream `P_GLOBAL` parameter that is
+/// valid only in the global section (see [`GLOBAL_ONLY_DIRECTIVES`]).
+fn is_global_only_directive(key: &str) -> bool {
+    GLOBAL_ONLY_DIRECTIVES.contains(&key)
+}
+
 /// Applies a single per-module directive to the builder.
 ///
 /// Returns `Ok(true)` if the key was recognized (even if unknown and warned),
@@ -362,6 +391,13 @@ fn apply_module_directive(
             if !value.is_empty() {
                 builder.include.push(value.to_owned());
             }
+        }
+        _ if is_global_only_directive(key) => {
+            // upstream: loadparm.c:do_parameter - a known P_GLOBAL parameter
+            // that appears inside a module section is reported and ignored,
+            // never applied to the module (loadparm.c: "Global parameter %s
+            // found in module section!").
+            eprintln!("Global parameter {key} found in module section!");
         }
         _ => {
             eprintln!(

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -1353,8 +1353,9 @@ mod config_parsing_tests {
 
     #[test]
     fn global_only_directive_inside_module_is_unknown() {
-        // "pid file" is a global-only directive. Inside a module section,
-        // it becomes an unknown per-module directive (warned and ignored).
+        // "pid file" is a P_GLOBAL directive. Inside a module section, upstream
+        // reports it ("Global parameter ... found in module section!") and
+        // ignores it, so it never becomes a daemon-wide or per-module setting.
         let dir = TempDir::new().expect("create temp dir");
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
@@ -2707,6 +2708,87 @@ mod config_parsing_tests {
             result.modules[0].hosts_allow.len(),
             2,
             "'HOSTS  ALLOW' must resolve to the hosts allow parameter",
+        );
+    }
+
+    // upstream: daemon-parm.txt classifies each parameter P_GLOBAL or P_LOCAL.
+    // The `Globals:` block is valid only before the first module; everything in
+    // the `Locals:` block may be set per-module. This test pins that boundary so
+    // a parameter cannot silently drift across it: the daemon-wide params stay
+    // global-only, while representative P_LOCAL params - including the ones oc
+    // currently accepts only in the global section (reverse lookup, lock file,
+    // syslog tag, syslog facility) - are never treated as global-only.
+    #[test]
+    fn global_only_classification_matches_upstream_parm_table() {
+        for global in [
+            "address",
+            "daemon chroot",
+            "daemon gid",
+            "daemon uid",
+            "motd file",
+            "pid file",
+            "socket options",
+            "listen backlog",
+            "port",
+            "proxy protocol",
+        ] {
+            assert!(
+                is_global_only_directive(global),
+                "'{global}' is P_GLOBAL in upstream daemon-parm.txt and must be global-only",
+            );
+        }
+
+        for local in [
+            "path",
+            "read only",
+            "uid",
+            "gid",
+            "hosts allow",
+            "reverse lookup",
+            "lock file",
+            "syslog tag",
+            "syslog facility",
+        ] {
+            assert!(
+                !is_global_only_directive(local),
+                "'{local}' is P_LOCAL in upstream daemon-parm.txt and is valid per-module",
+            );
+        }
+    }
+
+    // upstream: loadparm.c:do_parameter - a P_LOCAL parameter set inside a module
+    // overrides the global default for that module only. This is the semantic the
+    // P_GLOBAL/P_LOCAL split protects: the value must reach the module, not be
+    // rejected as a global-only directive.
+    #[test]
+    fn local_param_in_module_overrides_global_default() {
+        let dir = TempDir::new().expect("create temp dir");
+        let inherited = dir.path().join("inherited");
+        let overridden = dir.path().join("overridden");
+        fs::create_dir(&inherited).expect("create inherited dir");
+        fs::create_dir(&overridden).expect("create overridden dir");
+
+        let config = format!(
+            "read only = yes\n\
+             [inherited]\n\
+             path = {}\n\
+             [overridden]\n\
+             path = {}\n\
+             read only = no\n",
+            inherited.display(),
+            overridden.display(),
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+
+        assert_eq!(result.modules.len(), 2);
+        assert!(
+            result.modules[0].read_only,
+            "module without an override inherits the global P_LOCAL default",
+        );
+        assert!(
+            !result.modules[1].read_only,
+            "module-level P_LOCAL directive overrides the global default",
         );
     }
 }


### PR DESCRIPTION
## Summary

Upstream `loadparm.c` classifies every rsyncd.conf parameter as `P_GLOBAL`
or `P_LOCAL` via `parm_table[]` (generated from `daemon-parm.txt`). When a
`P_GLOBAL` parameter appears inside a `[module]` section, `do_parameter`
reports it and ignores it:

```c
if (parm_table[parmnum].class == P_GLOBAL) {
    rprintf(FLOG, "Global parameter %s found in module section!\n", parmname);
    return True;
}
```
(`loadparm.c:do_parameter`, lines 398-401)

oc lumped this case in with genuinely unknown per-module keys, emitting a
generic `warning: unknown per-module directive ...` instead of upstream's
specific diagnostic. This change adds the `P_GLOBAL`/`P_LOCAL` classification
as data (mirroring the `Globals:` block of `daemon-parm.txt`) and emits
upstream's message for a global-only parameter placed in a module, while
still ignoring it (never applying it to the module) exactly as upstream does.

The classification table lists only the ten genuine `P_GLOBAL` keys
(`address`, `daemon chroot`, `daemon gid`, `daemon uid`, `motd file`,
`pid file`, `socket options`, `listen backlog`, `port`, `proxy protocol`).
Every `P_LOCAL` parameter continues to fall through to the existing
per-module handling, so the well-tested per-module override machinery is
unchanged.

## Changes

- `config_parsing/module_directives.rs`: add `GLOBAL_ONLY_DIRECTIVES` table
  and `is_global_only_directive()`; emit upstream's
  `Global parameter <name> found in module section!` diagnostic for a
  global-only parameter inside a module.
- Tests: pin the classification against the upstream `parm_table` boundary,
  and assert a `P_LOCAL` directive set in a module overrides the global
  default for that module only.

## Verification

- `cargo fmt --all`
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo test -p daemon --lib` config-parsing module: 184 passed, 0 failed
