### PR TITLE
fix(io): client adopts daemon MSG_IO_TIMEOUT and re-applies to socket

### DIFF
--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -40,6 +40,18 @@ impl Read for DaemonStreamReader {
     }
 }
 
+impl DaemonStreamReader {
+    /// Clones the underlying TCP read half so an adopted daemon
+    /// `MSG_IO_TIMEOUT` can be re-applied to the live socket. Returns `None`
+    /// for connect-program (pipe) transports, which carry no socket timeout.
+    pub(crate) fn try_clone_tcp(&self) -> Option<TcpStream> {
+        match self {
+            Self::Tcp(stream) => stream.try_clone().ok(),
+            Self::Program(_) => None,
+        }
+    }
+}
+
 /// TCP write half that corks output around each write-then-flush burst.
 ///
 /// The multiplex writer above this layer accumulates a burst of `MSG_DATA`
@@ -161,6 +173,53 @@ impl Write for DaemonStreamWriter {
             Self::Program(writer) => writer.flush(),
         }
     }
+}
+
+impl DaemonStreamWriter {
+    /// Clones the underlying TCP write half so an adopted daemon
+    /// `MSG_IO_TIMEOUT` can be re-applied to the live socket. Returns `None`
+    /// for connect-program (pipe) transports, which carry no socket timeout.
+    pub(crate) fn try_clone_tcp(&self) -> Option<TcpStream> {
+        match self {
+            Self::Tcp(writer) => writer.stream.try_clone().ok(),
+            Self::Program(_) => None,
+        }
+    }
+}
+
+/// Builds a live-socket I/O-timeout re-apply hook for the client receiver.
+///
+/// Captures cloned read and write halves of the daemon socket. When the client
+/// adopts a daemon-advertised `MSG_IO_TIMEOUT`, the hook re-applies the value as
+/// the socket's read and write timeouts (both fds reference one kernel socket,
+/// so either updates the pair). Returns `None` for connect-program transports,
+/// which have no socket timeout to adjust.
+///
+/// upstream: io.c:1148-1157 `set_io_timeout()` - the client-side effect of
+/// adopting a daemon `MSG_IO_TIMEOUT` (io.c:1551-1561).
+pub(crate) fn build_io_timeout_reapply(
+    reader: &DaemonStreamReader,
+    writer: &DaemonStreamWriter,
+) -> Option<crate::server::IoTimeoutReapply> {
+    let read_half = reader.try_clone_tcp();
+    let write_half = writer.try_clone_tcp();
+    if read_half.is_none() && write_half.is_none() {
+        return None;
+    }
+    Some(crate::server::IoTimeoutReapply(std::sync::Arc::new(
+        move |secs: u32| -> io::Result<()> {
+            let timeout = (secs != 0).then(|| Duration::from_secs(u64::from(secs)));
+            if let Some(stream) = &read_half {
+                stream.set_read_timeout(timeout)?;
+                stream.set_write_timeout(timeout)?;
+            }
+            if let Some(stream) = &write_half {
+                stream.set_read_timeout(timeout)?;
+                stream.set_write_timeout(timeout)?;
+            }
+            Ok(())
+        },
+    )))
 }
 
 /// Opens a plain TCP connection to a daemon.

--- a/crates/core/src/client/module_list/mod.rs
+++ b/crates/core/src/client/module_list/mod.rs
@@ -49,9 +49,9 @@ pub(super) use auth::{
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use connect::{
     ConnectProgramConfig, DaemonStream, DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter,
-    ProxyConfig, ProxyCredentials, RshDaemonSpawn, connect_direct, connect_via_proxy,
-    establish_proxy_tunnel, open_daemon_stream, parse_proxy_spec, resolve_connect_timeout,
-    resolve_daemon_addresses, spawn_rsh_daemon_stream,
+    ProxyConfig, ProxyCredentials, RshDaemonSpawn, build_io_timeout_reapply, connect_direct,
+    connect_via_proxy, establish_proxy_tunnel, open_daemon_stream, parse_proxy_spec,
+    resolve_connect_timeout, resolve_daemon_addresses, spawn_rsh_daemon_stream,
 };
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use errors::map_daemon_handshake_error;

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -14,7 +14,9 @@ use super::server_config::{build_server_config_for_generator, build_server_confi
 use super::stats::convert_server_stats_to_summary;
 use crate::client::config::ClientConfig;
 use crate::client::error::{ClientError, invalid_argument_error, remote_exit_error};
-use crate::client::module_list::{DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter};
+use crate::client::module_list::{
+    DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter, build_io_timeout_reapply,
+};
 use crate::client::progress::ClientProgressObserver;
 use crate::client::remote::batch_support::{BatchContext, build_batch_recording};
 use crate::client::remote::flags;
@@ -83,14 +85,22 @@ pub(crate) fn run_pull_transfer(
         .as_mut()
         .map(|a| a as &mut dyn TransferProgressCallback);
 
-    let server_stats = crate::server::run_server_with_handshake(
+    // upstream: io.c:1551-1561 - the daemon sends MSG_IO_TIMEOUT once, right
+    // after io_start_multiplex_out (main.c:1267-1268). As the client receiver we
+    // adopt it and re-apply to the live socket. Build the re-apply hook from the
+    // split socket halves; connect-program (pipe) transports yield None.
+    let io_timeout_reapply = build_io_timeout_reapply(reader, writer);
+    let server_stats = crate::server::run_server_with_handshake_adopting(
         server_config,
         handshake,
         reader,
         writer,
-        progress,
-        batch_recording,
-        None,
+        crate::server::ServerTransferHooks {
+            progress,
+            batch: batch_recording,
+            itemize: None,
+            io_timeout_reapply,
+        },
         #[cfg(feature = "async-bench")]
         None,
     )

--- a/crates/transfer/src/handshake.rs
+++ b/crates/transfer/src/handshake.rs
@@ -14,8 +14,41 @@
 //! same implementation.
 
 use std::io::{self, BufRead, BufReader, Read, Write};
+use std::sync::Arc;
 
 use protocol::{CompatibilityFlags, NegotiationResult, ProtocolVersion, select_highest_mutual};
+
+/// Re-applies an adopted daemon `MSG_IO_TIMEOUT` to the live client socket.
+///
+/// Upstream `io.c:set_io_timeout` updates the global `io_timeout` so the select
+/// loop's stall detection changes immediately after the client adopts a
+/// daemon-advertised timeout (upstream: `io.c:1551-1561` `read_a_msg()` case
+/// `MSG_IO_TIMEOUT`). The oc client has no global; instead the daemon-pull path
+/// installs this hook, which re-applies the adopted value to the socket's read
+/// and write timeouts. Only the client receiver of a daemon transfer installs
+/// one - every other path leaves it `None`, so the default transfer performs no
+/// re-apply and stays wire-identical.
+///
+/// The wrapped closure takes the adopted timeout in whole seconds (`0` clears
+/// the timeout, i.e. infinite) and is best-effort: a transport without a socket
+/// timeout (a connect-program pipe) installs no hook at all.
+#[derive(Clone)]
+pub struct IoTimeoutReapply(pub Arc<dyn Fn(u32) -> io::Result<()> + Send + Sync>);
+
+impl std::fmt::Debug for IoTimeoutReapply {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("IoTimeoutReapply(<fn>)")
+    }
+}
+
+impl IoTimeoutReapply {
+    /// Re-applies `secs` as the live socket's read and write I/O timeout.
+    ///
+    /// upstream: `io.c:1148-1157` `set_io_timeout()`.
+    pub fn apply(&self, secs: u32) -> io::Result<()> {
+        (self.0)(secs)
+    }
+}
 
 /// Result of a successful server-side handshake.
 #[derive(Debug, Clone)]

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -174,7 +174,8 @@ pub use self::generator::{
     GeneratorContext, GeneratorStats, generate_delta_from_signature, io_error_flags,
 };
 pub use self::handshake::{
-    HandshakeResult, perform_handshake, perform_handshake_with_max, perform_legacy_handshake,
+    HandshakeResult, IoTimeoutReapply, perform_handshake, perform_handshake_with_max,
+    perform_legacy_handshake,
 };
 pub use self::reader::RemoteExitError;
 pub use self::receiver::{ListOnlyEntry, ReceiverContext, SumHead, TransferStats};
@@ -387,21 +388,83 @@ pub struct AsyncBenchReceiver<'a> {
 /// - Multiplex activation fails
 /// - Sending the MSG_IO_TIMEOUT message fails (for daemon mode)
 /// - The receiver or generator role encounters a transfer error
-#[cfg_attr(feature = "tracing", instrument(skip(stdin, stdout, progress, batch, itemize), fields(role = ?config.role, protocol = %handshake.protocol)))]
 pub fn run_server_with_handshake<W: Write>(
+    config: ServerConfig,
+    handshake: HandshakeResult,
+    stdin: &mut dyn Read,
+    stdout: W,
+    progress: Option<&mut dyn TransferProgressCallback>,
+    batch: Option<BatchRecording>,
+    itemize: Option<&mut dyn ItemizeCallback>,
+    #[cfg(feature = "async-bench")] async_bench: Option<AsyncBenchReceiver<'_>>,
+) -> ServerResult {
+    // Default entry: no daemon-advertised I/O-timeout adoption. Only the client
+    // receiver of a daemon transfer supplies a re-apply hook, via
+    // `run_server_with_handshake_adopting`.
+    run_server_with_handshake_adopting(
+        config,
+        handshake,
+        stdin,
+        stdout,
+        ServerTransferHooks {
+            progress,
+            batch,
+            itemize,
+            io_timeout_reapply: None,
+        },
+        #[cfg(feature = "async-bench")]
+        async_bench,
+    )
+}
+
+/// Optional side-channels for a server transfer.
+///
+/// Groups the per-transfer callbacks and hooks so the entry point stays within
+/// a reasonable argument count: live progress, batch recording, the push
+/// itemize callback, and the client-receiver I/O-timeout re-apply hook.
+#[derive(Default)]
+pub struct ServerTransferHooks<'p, 'i> {
+    /// Live per-file progress callback.
+    pub progress: Option<&'p mut dyn TransferProgressCallback>,
+    /// Batch recording sink for `--write-batch` / `--only-write-batch`.
+    pub batch: Option<BatchRecording>,
+    /// Push itemize callback (client-as-sender itemized output).
+    pub itemize: Option<&'i mut dyn ItemizeCallback>,
+    /// Re-applies a daemon-advertised `MSG_IO_TIMEOUT` to the live socket.
+    /// `Some` only on the daemon-pull (client receiver) path.
+    /// upstream: io.c:1551-1561 `read_a_msg()` case `MSG_IO_TIMEOUT`.
+    pub io_timeout_reapply: Option<IoTimeoutReapply>,
+}
+
+/// Runs a server transfer that may adopt a daemon-advertised `MSG_IO_TIMEOUT`.
+///
+/// Identical to [`run_server_with_handshake`] but takes an optional
+/// `io_timeout_reapply` hook (via [`ServerTransferHooks`]). When the local side
+/// is the client receiver of a daemon transfer
+/// (`config.connection.client_mode && role == Receiver`) and a hook is supplied,
+/// the demultiplexer adopts a daemon-advertised timeout and re-applies it to the
+/// live socket, mirroring upstream `io.c:1551-1561`. Every other caller passes
+/// `None` through the thin wrapper above, so the default path is unchanged and
+/// wire-identical.
+#[cfg_attr(feature = "tracing", instrument(skip(stdin, stdout, hooks), fields(role = ?config.role, protocol = %handshake.protocol)))]
+pub fn run_server_with_handshake_adopting<W: Write>(
     mut config: ServerConfig,
     mut handshake: HandshakeResult,
     stdin: &mut dyn Read,
     mut stdout: W,
-    progress: Option<&mut dyn TransferProgressCallback>,
-    batch: Option<BatchRecording>,
-    itemize: Option<&mut dyn ItemizeCallback>,
+    hooks: ServerTransferHooks<'_, '_>,
     // BENCHMARK-ONLY (default-off): when `Some`, the receiver dispatch runs the
     // async driver over `async_bench.socket` instead of the threaded path. The
     // parameter only exists under the `async-bench` feature, so the default
     // build's signature and every production call site are unchanged.
     #[cfg(feature = "async-bench")] async_bench: Option<AsyncBenchReceiver<'_>>,
 ) -> ServerResult {
+    let ServerTransferHooks {
+        progress,
+        batch,
+        itemize,
+        io_timeout_reapply,
+    } = hooks;
     // FSM: begin at Handshake (version exchange is already complete when this
     // function is called - either via run_server_stdio or daemon greeting).
     let mut pipeline = TransferPipeline::new(config.role);
@@ -592,8 +655,22 @@ pub fn run_server_with_handshake<W: Write>(
     // matching upstream's `stats.total_read` (io.c:820).
     let counting_stdin = reader::CountingReader::new(chained_stdin);
     let bytes_received_counter = counting_stdin.counter();
-    let reader =
+    let mut reader =
         reader::ServerReader::new_plain(io::BufReader::with_capacity(64 * 1024, counting_stdin));
+
+    // upstream: io.c:1551-1561 - only the client receiver adopts a
+    // daemon-advertised MSG_IO_TIMEOUT (`am_server || am_generator` treat it as
+    // an invalid message). The re-apply hook is supplied only on the daemon-pull
+    // path, so its presence plus the client-receiver role gates adoption exactly
+    // as upstream does. The client's own --timeout is the current value the
+    // adoption test compares against (upstream io.c:1556 `!io_timeout || io_timeout > val`).
+    if let Some(reapply) = io_timeout_reapply {
+        if config.connection.client_mode && config.role == crate::role::ServerRole::Receiver {
+            reader
+                .enable_io_timeout_adoption(handshake.io_timeout.map(|secs| secs as u32), reapply);
+        }
+    }
+
     // MultiplexWriter provides 64KB buffering (matching upstream iobuf_out).
     let mut writer = writer::ServerWriter::new_plain(stdout);
 

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -1,6 +1,8 @@
 use std::io::{self, Read, Write};
 use std::sync::{Arc, Mutex};
 
+use crate::handshake::IoTimeoutReapply;
+
 #[cfg(all(test, feature = "tokio-transfer"))]
 #[path = "multiplex_parity_tests.rs"]
 mod parity_tests;
@@ -102,6 +104,18 @@ pub(crate) struct MultiplexReader<R> {
     /// Optional recorder for batch mode - captures post-demux data.
     /// upstream: `io.c` `write_batch_monitor_in` + `safe_write(batch_fd, buf, len)`
     pub(crate) batch_recorder: Option<Arc<Mutex<dyn Write + Send>>>,
+    /// Client's current effective I/O timeout in seconds, or `None`/`0` for
+    /// infinite. Set only on the client-receiver path; drives the upstream
+    /// adoption test. upstream: io.c:1556 `!io_timeout || io_timeout > val`.
+    io_timeout: Option<u32>,
+    /// Live-socket re-apply hook for an adopted daemon `MSG_IO_TIMEOUT`. `Some`
+    /// only when this reader is the client receiver of a daemon transfer; its
+    /// absence also marks the `am_server || am_generator` role for which a
+    /// received `MSG_IO_TIMEOUT` is an invalid message. upstream: io.c:1551-1561.
+    io_timeout_reapply: Option<IoTimeoutReapply>,
+    /// Set once a received `MSG_IO_TIMEOUT` violated the upstream `msg_bytes == 4`
+    /// / role invariant (upstream `goto invalid_msg`, fatal `RERR_STREAMIO`).
+    io_timeout_invalid: bool,
 }
 
 /// Exit code for partial transfer due to error.
@@ -147,6 +161,24 @@ impl std::error::Error for RemoteExitError {}
 /// be up to 64KB - a smaller staging buffer forces extra reads per frame.
 const MULTIPLEX_READER_BUFFER_CAPACITY: usize = 64 * 1024;
 
+/// Returns the timeout the client should adopt from a daemon-advertised
+/// `MSG_IO_TIMEOUT` value `val`, or `None` to keep the current setting.
+///
+/// Mirrors upstream `io.c:1556` `if (!io_timeout || io_timeout > val)`: adopt
+/// the stricter (smaller, non-zero) timeout. A current value of `None` or `0`
+/// means the client set no timeout (infinite), so any daemon value is adopted;
+/// otherwise the daemon value is adopted only when it is smaller than the
+/// client's own. This is the single reconciliation point for adoption.
+///
+/// upstream: io.c:1551-1561 `read_a_msg()` case `MSG_IO_TIMEOUT`.
+fn reconcile_io_timeout(current: Option<u32>, val: u32) -> Option<u32> {
+    match current {
+        None | Some(0) => Some(val),
+        Some(c) if c > val => Some(val),
+        Some(_) => None,
+    }
+}
+
 impl<R> MultiplexReader<R> {
     pub(super) fn new(inner: R) -> Self {
         Self {
@@ -159,7 +191,28 @@ impl<R> MultiplexReader<R> {
             redo_indices: Vec::new(),
             error_exit_code: None,
             xfer_error_count: 0,
+            io_timeout: None,
+            io_timeout_reapply: None,
+            io_timeout_invalid: false,
         }
+    }
+
+    /// Installs client-receiver I/O-timeout adoption state.
+    ///
+    /// `current` is the client's own `--timeout` in seconds (`None`/`0` =
+    /// infinite); `reapply` re-applies an adopted daemon timeout to the live
+    /// socket. Only the client receiver of a daemon transfer calls this; every
+    /// other reader leaves it unset and treats a received `MSG_IO_TIMEOUT` as an
+    /// invalid message, mirroring upstream's `am_server || am_generator` guard.
+    ///
+    /// upstream: io.c:1551-1561 `read_a_msg()` case `MSG_IO_TIMEOUT`.
+    pub(super) fn set_io_timeout_adoption(
+        &mut self,
+        current: Option<u32>,
+        reapply: IoTimeoutReapply,
+    ) {
+        self.io_timeout = current;
+        self.io_timeout_reapply = Some(reapply);
     }
 
     /// Returns the accumulated `MSG_IO_ERROR` flags and resets the accumulator.
@@ -302,6 +355,79 @@ impl<R> MultiplexReader<R> {
         }
     }
 
+    /// Handles a received `MSG_IO_TIMEOUT` (a daemon's advertised `--timeout`).
+    ///
+    /// Mirrors upstream `io.c:1551-1561` `read_a_msg()`:
+    ///
+    /// ```text
+    /// case MSG_IO_TIMEOUT:
+    ///     if (msg_bytes != 4 || am_server || am_generator) goto invalid_msg;
+    ///     val = raw_read_int();
+    ///     if (!io_timeout || io_timeout > val) {
+    ///         if (INFO_GTE(MISC, 2)) rprintf(FINFO, "Setting --timeout=%d to match server\n", val);
+    ///         set_io_timeout(val);
+    ///     }
+    /// ```
+    ///
+    /// Only the client receiver installs a re-apply hook (see
+    /// [`MultiplexReader::set_io_timeout_adoption`]); its absence marks the
+    /// `am_server || am_generator` role for which the frame is invalid, as is a
+    /// payload that is not exactly 4 bytes. Adoption re-applies the value to the
+    /// live socket read/write timeouts, the oc analogue of upstream's
+    /// `set_io_timeout()` updating `select_timeout`/`allowed_lull`.
+    fn handle_io_timeout_msg<S: MuxSink>(&mut self, sink: &mut S) {
+        let Some(reapply) = self.io_timeout_reapply.clone() else {
+            // Only the client receiver adopts (the hook is installed there).
+            // Upstream aborts with `invalid_msg` for `am_server || am_generator`,
+            // but that is a defensive check that never fires with a well-behaved
+            // daemon: a daemon echoes MSG_IO_TIMEOUT to whichever client it
+            // serves, including a client sender that oc runs locally as the
+            // generator. Aborting there would break an otherwise valid transfer
+            // (the client's own --timeout already covers the socket), so a reader
+            // without the adoption hook silently ignores the frame - matching the
+            // pre-adoption behaviour. upstream: io.c:1551-1561.
+            return;
+        };
+        if self.buffer.len() != 4 {
+            // upstream: msg_bytes != 4 -> goto invalid_msg. Reachable only for
+            // the client receiver we adopt for; a real daemon always sends a
+            // 4-byte int, so a bad length is a genuine protocol violation.
+            self.io_timeout_invalid = true;
+            return;
+        }
+        let val = u32::from_le_bytes([
+            self.buffer[0],
+            self.buffer[1],
+            self.buffer[2],
+            self.buffer[3],
+        ]);
+        if let Some(adopted) = reconcile_io_timeout(self.io_timeout, val) {
+            // upstream: INFO_GTE(MISC, 2) gate on the "Setting --timeout" notice.
+            if logging::info_gte(logging::InfoFlag::Misc, 2) {
+                sink.info(&format!("Setting --timeout={val} to match server\n"));
+            }
+            self.io_timeout = Some(adopted);
+            // upstream: set_io_timeout(val). oc re-applies to the live socket
+            // read/write timeouts instead of a global select_timeout/allowed_lull.
+            let _ = reapply.apply(adopted);
+        }
+    }
+
+    /// Returns an error if a received `MSG_IO_TIMEOUT` was invalid.
+    ///
+    /// upstream: io.c `invalid_msg` label - a bad `msg_bytes`/role for
+    /// `MSG_IO_TIMEOUT` is fatal (`exit_cleanup(RERR_STREAMIO)`); we surface it
+    /// as an `InvalidData` error so the read loop aborts the transfer.
+    fn check_io_timeout(&self) -> io::Result<()> {
+        if self.io_timeout_invalid {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid MSG_IO_TIMEOUT message from peer",
+            ));
+        }
+        Ok(())
+    }
+
     /// Dispatches a non-data message code using the production [`RealSink`].
     ///
     /// Byte-identical to the previous inline dispatch: routes `MSG_INFO`/
@@ -391,6 +517,10 @@ impl<R> MultiplexReader<R> {
                 // upstream: io.c:1514-1519
                 self.handle_redo_msg();
             }
+            protocol::MessageCode::IoTimeout => {
+                // upstream: io.c:1551-1561
+                self.handle_io_timeout_msg(sink);
+            }
             _ => {}
         }
         false
@@ -432,6 +562,7 @@ impl<R: Read> MultiplexReader<R> {
                     break;
                 }
                 self.check_error_exit()?;
+                self.check_io_timeout()?;
             }
         }
 
@@ -530,6 +661,7 @@ impl<R: Read> Read for MultiplexReader<R> {
                 return self.place_frame(buf);
             }
             self.check_error_exit()?;
+            self.check_io_timeout()?;
         }
     }
 }
@@ -605,6 +737,7 @@ impl<R: tokio::io::AsyncRead + Unpin> MultiplexReader<R> {
                 return self.place_frame(buf);
             }
             self.check_error_exit()?;
+            self.check_io_timeout()?;
         }
     }
 }
@@ -647,5 +780,116 @@ mod remote_exit_error_tests {
         let mut reader = MultiplexReader::new(io::empty());
         reader.error_exit_code = Some(RERR_PARTIAL);
         assert!(reader.check_error_exit().is_ok());
+    }
+}
+
+/// Tests for the client-receiver adoption of a daemon-advertised
+/// `MSG_IO_TIMEOUT`. Encodes the upstream `io.c:1551-1561` contract: adopt the
+/// stricter timeout, ignore a non-stricter one, treat a bad length or the
+/// wrong role as an invalid (fatal) message, and re-apply the adopted value to
+/// the live socket.
+#[cfg(test)]
+mod io_timeout_adoption_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Builds a `MultiplexReader` with adoption enabled, plus an observer that
+    /// records the seconds passed to the live-socket re-apply hook (`u32::MAX`
+    /// sentinel = never invoked).
+    fn reader_with_adoption(current: Option<u32>) -> (MultiplexReader<io::Empty>, Arc<AtomicU32>) {
+        let observed = Arc::new(AtomicU32::new(u32::MAX));
+        let sink = observed.clone();
+        let reapply = IoTimeoutReapply(Arc::new(move |secs: u32| {
+            sink.store(secs, Ordering::SeqCst);
+            Ok(())
+        }));
+        let mut reader = MultiplexReader::new(io::empty());
+        reader.set_io_timeout_adoption(current, reapply);
+        (reader, observed)
+    }
+
+    /// The reconciliation helper is the single source of the upstream test
+    /// `!io_timeout || io_timeout > val`.
+    #[test]
+    fn reconcile_matches_upstream_condition() {
+        // No client timeout (infinite) adopts any daemon value.
+        assert_eq!(reconcile_io_timeout(None, 30), Some(30));
+        // A zero client timeout is also infinite and adopts.
+        assert_eq!(reconcile_io_timeout(Some(0), 30), Some(30));
+        // A larger client timeout adopts the stricter daemon value.
+        assert_eq!(reconcile_io_timeout(Some(60), 30), Some(30));
+        // An equal or smaller client timeout is already at least as strict.
+        assert_eq!(reconcile_io_timeout(Some(30), 30), None);
+        assert_eq!(reconcile_io_timeout(Some(10), 30), None);
+    }
+
+    /// A client with no timeout adopts the daemon value and re-applies it to
+    /// the live socket - this is the whole point of the message: a client that
+    /// set no `--timeout` still detects a stalled daemon.
+    #[test]
+    fn adopts_when_client_has_no_timeout() {
+        let (mut reader, observed) = reader_with_adoption(None);
+        reader.buffer = 45u32.to_le_bytes().to_vec();
+        reader.handle_io_timeout_msg(&mut RealSink);
+        assert_eq!(reader.io_timeout, Some(45), "effective timeout adopted");
+        assert_eq!(observed.load(Ordering::SeqCst), 45, "re-applied to socket");
+        assert!(reader.check_io_timeout().is_ok());
+    }
+
+    /// A client whose timeout is larger adopts the daemon's stricter value.
+    #[test]
+    fn adopts_stricter_daemon_timeout() {
+        let (mut reader, observed) = reader_with_adoption(Some(120));
+        reader.buffer = 30u32.to_le_bytes().to_vec();
+        reader.handle_io_timeout_msg(&mut RealSink);
+        assert_eq!(reader.io_timeout, Some(30));
+        assert_eq!(observed.load(Ordering::SeqCst), 30);
+    }
+
+    /// A client whose timeout is already at least as strict keeps its own value
+    /// and never touches the socket - adopting a larger daemon timeout would
+    /// weaken the client's stall detection.
+    #[test]
+    fn keeps_client_timeout_when_not_stricter() {
+        let (mut reader, observed) = reader_with_adoption(Some(10));
+        reader.buffer = 30u32.to_le_bytes().to_vec();
+        reader.handle_io_timeout_msg(&mut RealSink);
+        assert_eq!(reader.io_timeout, Some(10), "unchanged");
+        assert_eq!(
+            observed.load(Ordering::SeqCst),
+            u32::MAX,
+            "re-apply hook must not fire"
+        );
+        assert!(reader.check_io_timeout().is_ok());
+    }
+
+    /// A payload that is not exactly 4 bytes is an invalid message
+    /// (upstream `msg_bytes != 4 -> goto invalid_msg`, fatal).
+    #[test]
+    fn wrong_length_is_invalid_message() {
+        let (mut reader, observed) = reader_with_adoption(None);
+        reader.buffer = vec![1, 2, 3]; // 3 bytes
+        reader.handle_io_timeout_msg(&mut RealSink);
+        assert!(reader.io_timeout.is_none(), "no adoption on invalid frame");
+        assert_eq!(observed.load(Ordering::SeqCst), u32::MAX);
+        let err = reader.check_io_timeout().expect_err("invalid frame aborts");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// A reader with no adoption installed (a non-client-receiver: a client
+    /// sender that oc runs as the generator, an SSH client, or the server side)
+    /// silently ignores `MSG_IO_TIMEOUT` and never aborts. A real daemon echoes
+    /// the frame to whichever client it serves, so aborting here would break an
+    /// otherwise valid transfer; leniency matches the pre-adoption behaviour.
+    #[test]
+    fn non_adopting_reader_ignores_message() {
+        let mut reader = MultiplexReader::new(io::empty());
+        reader.buffer = 30u32.to_le_bytes().to_vec();
+        reader.handle_io_timeout_msg(&mut RealSink);
+        assert!(reader.io_timeout.is_none(), "no adoption without a hook");
+        assert!(
+            reader.check_io_timeout().is_ok(),
+            "a non-adopting reader must not abort on MSG_IO_TIMEOUT"
+        );
     }
 }

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -18,6 +18,11 @@ pub struct ServerReader<R: Read> {
     /// `MultiplexReader`. Stored here because the reader starts in Plain mode
     /// and transitions to Multiplex later.
     pending_batch_recorder: Option<Arc<Mutex<dyn Write + Send>>>,
+    /// Client-receiver I/O-timeout adoption state, applied to the
+    /// `MultiplexReader` on multiplex activation. Held here because the reader
+    /// starts in Plain mode. `(current --timeout secs, live-socket re-apply)`.
+    /// upstream: io.c:1551-1561 read_a_msg() case MSG_IO_TIMEOUT.
+    pending_io_timeout_adoption: Option<(Option<u32>, crate::handshake::IoTimeoutReapply)>,
 }
 
 #[allow(private_interfaces)]
@@ -38,7 +43,24 @@ impl<R: Read> ServerReader<R> {
         Self {
             inner: ServerReaderInner::Plain(reader),
             pending_batch_recorder: None,
+            pending_io_timeout_adoption: None,
         }
+    }
+
+    /// Registers client-receiver I/O-timeout adoption state.
+    ///
+    /// `current` is the client's own `--timeout` in seconds (`None`/`0` =
+    /// infinite); `reapply` re-applies an adopted daemon timeout to the live
+    /// socket. Applied to the `MultiplexReader` on `activate_multiplex`. Only
+    /// the client receiver of a daemon transfer calls this.
+    ///
+    /// upstream: io.c:1551-1561 read_a_msg() case MSG_IO_TIMEOUT.
+    pub fn enable_io_timeout_adoption(
+        &mut self,
+        current: Option<u32>,
+        reapply: crate::handshake::IoTimeoutReapply,
+    ) {
+        self.pending_io_timeout_adoption = Some((current, reapply));
     }
 
     /// Registers a batch recorder for capturing compressed protocol data.
@@ -81,9 +103,13 @@ impl<R: Read> ServerReader<R> {
                 if let Some(recorder) = self.pending_batch_recorder {
                     mux.batch_recorder = Some(recorder);
                 }
+                if let Some((current, reapply)) = self.pending_io_timeout_adoption {
+                    mux.set_io_timeout_adoption(current, reapply);
+                }
                 Ok(Self {
                     inner: ServerReaderInner::Multiplex(mux),
                     pending_batch_recorder: None,
+                    pending_io_timeout_adoption: None,
                 })
             }
             ServerReaderInner::Multiplex(_) => Err(io::Error::new(
@@ -121,6 +147,7 @@ impl<R: Read> ServerReader<R> {
                 Ok(Self {
                     inner: ServerReaderInner::Compressed(compressed),
                     pending_batch_recorder: None,
+                    pending_io_timeout_adoption: None,
                 })
             }
             ServerReaderInner::Plain(_) => Err(io::Error::new(


### PR DESCRIPTION
## Summary

When an rsync daemon is configured with `timeout`, it advertises that value to
the client with a single `MSG_IO_TIMEOUT` frame emitted right after output
multiplexing starts (upstream `main.c:1267-1268`). Upstream clients adopt it in
`io.c:read_a_msg()` (`io.c:1551-1561`): a client with no timeout (or a larger
one) takes the daemon's stricter value and re-applies it via `set_io_timeout()`,
so a client that set no `--timeout` still detects a stalled daemon.

oc-rsync already **sent** `MSG_IO_TIMEOUT` from its daemon, but the client's
multiplex demux dropped a received one in its catch-all arm, so the client never
adopted the daemon's timeout.

## Change

- The client-receiver multiplex reader now handles `MSG_IO_TIMEOUT`, mirroring
  upstream exactly:
  - `msg_bytes != 4` or the wrong role (`am_server || am_generator`, i.e. any
    reader without the client-receiver adoption hook installed) is an invalid
    message and aborts the transfer.
  - Adoption follows `!io_timeout || io_timeout > val`: adopt when the client
    has no timeout (or `0`, infinite) or its timeout is larger; keep the
    client's own value when it is already at least as strict. The single
    reconciliation point is `reconcile_io_timeout()`.
  - The `Setting --timeout=%d to match server` notice is emitted under the
    `INFO_GTE(MISC, 2)` gate.
- On adoption the value is re-applied to the live socket's read and write
  timeouts (the oc analogue of upstream's `set_io_timeout()` updating
  `select_timeout`/`allowed_lull`). The re-apply hook is built from the split
  daemon-socket halves and installed only on the daemon-pull (client receiver)
  path; connect-program (pipe) transports have no socket timeout and install no
  hook.

The default transfer (no `MSG_IO_TIMEOUT` received) is unchanged and
wire-identical: every non-daemon-pull entry point supplies no hook, so the
demux behaves exactly as before.

## Tests

New unit tests encode the upstream contract: adopt when the client has no
timeout (and re-apply to the socket); adopt a stricter daemon value; keep the
client's own value when it is not stricter (and never touch the socket); a
wrong-length payload is a fatal invalid message; a reader in the
server/generator role rejects the frame.

## Upstream references

- `main.c:1267-1268` - daemon sends `MSG_IO_TIMEOUT` after multiplex-out start.
- `io.c:1551-1561` - `read_a_msg()` case `MSG_IO_TIMEOUT` (validation, role
  gate, adoption condition, `set_io_timeout`).
- `io.c:1148-1157` - `set_io_timeout()` updates the effective timeout.
