### PR TITLE
fix: reject daemon greeting client-side via shared greeting gate

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -8,6 +8,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 
 use protocol::ProtocolVersion;
+use protocol::missing_greeting_token;
 use protocol::nstr::{trace_daemon_auth_negotiated, trace_daemon_greeting_auth_list};
 
 use crate::auth::{
@@ -223,6 +224,24 @@ pub(crate) fn perform_daemon_handshake<R: std::io::Read, W: Write>(
 
     // upstream: exchange_protocols line 178 - sscanf(buf, "@RSYNCD: %d.%d", ...)
     let remote_protocol = parse_protocol_from_greeting(&greeting)?;
+
+    // upstream: clientserver.c:188-210 (exchange_protocols, am_client == 1) - a
+    // server greeting that omits the subprotocol value (protocol >= 30) or the
+    // digest name list (protocol > 31) is fatal. Upstream prints
+    // `rsync: the server omitted the <token>: <buf>` to stderr and aborts with
+    // RERR_STARTCLIENT. The shared gate mirrors the daemon's `am_client == 0`
+    // check so both roles enforce identical thresholds.
+    if let Some(missing) = missing_greeting_token(&greeting) {
+        return Err(daemon_error(
+            format!(
+                "the server omitted the {}: {}",
+                missing.description(),
+                greeting.trim_end_matches(['\r', '\n'])
+            ),
+            CLIENT_SERVER_PROTOCOL_EXIT_CODE,
+        ));
+    }
+
     let advertised_digests = parse_digest_list_from_greeting(&greeting);
 
     // upstream: compat.c:843-844 - `am_client && DEBUG_GTE(NSTR, 2)` emits

--- a/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
@@ -521,9 +521,12 @@ mod handle_at_error_tests {
             username: None,
         };
 
-        // Valid greeting, then EOF: the daemon accepted the greeting but closed
+        // Valid greeting (subprotocol + digest list, as a real protocol-32
+        // daemon sends), then EOF: the daemon accepted the greeting but closed
         // the control socket before replying to the module request.
-        let mut reader = BufReader::new(Cursor::new(b"@RSYNCD: 32.0\n".to_vec()));
+        let mut reader = BufReader::new(Cursor::new(
+            b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n".to_vec(),
+        ));
         let mut writer: Vec<u8> = Vec::new();
 
         let result = perform_daemon_handshake(
@@ -542,6 +545,80 @@ mod handle_at_error_tests {
             err.exit_code(),
             CLIENT_SERVER_PROTOCOL_EXIT_CODE,
             "daemon EOF must map to the client-server protocol exit code"
+        );
+    }
+
+    fn handshake_over_greeting(greeting: &[u8]) -> Result<ProtocolVersion, ClientError> {
+        use std::io::{BufReader, Cursor};
+
+        let request = DaemonTransferRequest {
+            address: DaemonAddress::new("127.0.0.1".to_owned(), 873).unwrap(),
+            module: "mod".to_owned(),
+            path: String::new(),
+            username: None,
+        };
+        let mut reader = BufReader::new(Cursor::new(greeting.to_vec()));
+        let mut writer: Vec<u8> = Vec::new();
+        perform_daemon_handshake(
+            &mut reader,
+            &mut writer,
+            &request,
+            true,
+            &[],
+            None,
+            None,
+            None,
+        )
+    }
+
+    // upstream: clientserver.c:189-194 (am_client == 1) - a server greeting at
+    // protocol >= 30 that omits the ".subprotocol" suffix is fatal:
+    // `rsync: the server omitted the subprotocol value: <buf>` + RERR_STARTCLIENT.
+    // The gate fires at protocol 30, one below the shared parser's own leniency
+    // boundary, so this is exactly the divergence the client must now reject.
+    #[test]
+    fn client_rejects_server_greeting_missing_subprotocol() {
+        let err = handshake_over_greeting(b"@RSYNCD: 30\n")
+            .expect_err("missing subprotocol at protocol >= 30 must abort");
+        assert_eq!(err.exit_code(), CLIENT_SERVER_PROTOCOL_EXIT_CODE);
+        assert!(
+            err.message()
+                .to_string()
+                .contains("the server omitted the subprotocol value: @RSYNCD: 30"),
+            "unexpected message: {}",
+            err.message()
+        );
+    }
+
+    // upstream: clientserver.c:205-210 (am_client == 1) - a protocol > 31 greeting
+    // that omits the digest name list is fatal:
+    // `rsync: the server omitted the digest name list: <buf>` + RERR_STARTCLIENT.
+    #[test]
+    fn client_rejects_server_greeting_missing_digest_list() {
+        let err = handshake_over_greeting(b"@RSYNCD: 32.0\n")
+            .expect_err("missing digest list at protocol > 31 must abort");
+        assert_eq!(err.exit_code(), CLIENT_SERVER_PROTOCOL_EXIT_CODE);
+        assert!(
+            err.message()
+                .to_string()
+                .contains("the server omitted the digest name list: @RSYNCD: 32.0"),
+            "unexpected message: {}",
+            err.message()
+        );
+    }
+
+    // upstream: clientserver.c:196 - protocol < 30 defaults remote_sub to 0 and
+    // needs no digest list, so the greeting is accepted and the handshake
+    // proceeds (here it reaches the module-response phase and hits EOF). The
+    // failure must NOT be the greeting-omission refusal.
+    #[test]
+    fn client_accepts_legacy_server_greeting_without_tokens() {
+        let err = handshake_over_greeting(b"@RSYNCD: 29\n")
+            .expect_err("EOF after a valid legacy greeting still errors");
+        assert!(
+            !err.message().to_string().contains("the server omitted"),
+            "legacy greeting must not be refused for omitted tokens: {}",
+            err.message()
         );
     }
 

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -65,9 +65,9 @@ use core::server::run_server_with_handshake_on;
 use core::server::AsyncBenchReceiver;
 use logging_sink::MessageSink;
 use protocol::{
-    LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonMessage, MessageCode, MessageFrame,
-    ProtocolVersion, filters::FilterRuleWireFormat, format_legacy_daemon_message,
-    iconv::FilenameConverter, parse_legacy_daemon_message,
+    LEGACY_DAEMON_PREFIX_LEN, LegacyDaemonMessage, MessageCode, MessageFrame, ProtocolVersion,
+    filters::FilterRuleWireFormat, format_legacy_daemon_message, iconv::FilenameConverter,
+    missing_greeting_token, parse_legacy_daemon_message,
 };
 
 use crate::{

--- a/crates/daemon/src/daemon/sections/greeting.rs
+++ b/crates/daemon/src/daemon/sections/greeting.rs
@@ -76,46 +76,16 @@ pub(crate) fn cached_legacy_daemon_greeting() -> &'static [u8] {
 /// list (`strchr(buf + 9, ' ')` is NULL) yields, for `remote_protocol > 31`,
 /// `@ERROR: your client omitted the digest name list: %s`. The `%s` echoes the raw
 /// greeting line.
+///
+/// The presence gates themselves live in [`missing_greeting_token`] so the
+/// daemon (`am_client == 0`) and the client (`am_client == 1`) enforce the exact
+/// same upstream thresholds; only the diagnostic wording differs by role.
 pub(crate) fn reject_malformed_client_greeting(line: &str) -> Option<String> {
-    let after_prefix = line.strip_prefix(LEGACY_DAEMON_PREFIX)?;
-
-    // upstream: sscanf `%d` skips leading whitespace before the protocol number.
-    let rest = after_prefix.trim_start();
-    let digits = rest
-        .as_bytes()
-        .iter()
-        .take_while(|byte| byte.is_ascii_digit())
-        .count();
-    if digits == 0 {
-        // sscanf(...) < 1: not a version banner - leave it to the other handlers.
-        return None;
-    }
-    let remote_protocol: u32 = rest[..digits].parse().unwrap_or(u32::MAX);
-
-    // upstream: `remote_sub` stays < 0 unless a ".NNN" suffix follows the number.
-    let has_subprotocol = rest[digits..]
-        .strip_prefix('.')
-        .and_then(|fractional| fractional.as_bytes().first())
-        .is_some_and(u8::is_ascii_digit);
-    if !has_subprotocol && remote_protocol >= 30 {
-        return Some(format!(
-            "@ERROR: your client omitted the subprotocol value: {line}"
-        ));
-    }
-
-    // upstream: `daemon_auth_choices = strchr(buf + 9, ' ')` - any space past
-    // "@RSYNCD: " marks the start of the digest-name list.
-    let has_digest_list = line
-        .as_bytes()
-        .get(LEGACY_DAEMON_PREFIX_LEN + 1..)
-        .is_some_and(|tail| tail.contains(&b' '));
-    if !has_digest_list && remote_protocol > 31 {
-        return Some(format!(
-            "@ERROR: your client omitted the digest name list: {line}"
-        ));
-    }
-
-    None
+    let token = missing_greeting_token(line)?;
+    Some(format!(
+        "@ERROR: your client omitted the {}: {line}",
+        token.description()
+    ))
 }
 
 /// Reads one line from `reader`, stripping trailing `\r` and `\n`.
@@ -224,5 +194,27 @@ mod greeting_validation_tests {
         assert_eq!(reject_malformed_client_greeting("module"), None);
         assert_eq!(reject_malformed_client_greeting("@RSYNCD: OK"), None);
         assert_eq!(reject_malformed_client_greeting("#list"), None);
+    }
+
+    // Regression for #6604: the daemon refusal now delegates to the shared
+    // `missing_greeting_token` gate, but the @ERROR wording and the exact set of
+    // refused greetings must stay byte-identical. A greeting the gate accepts
+    // must return `None` here so `parse_legacy_daemon_message` handles it next -
+    // the daemon must never double-reject a greeting the shared gate cleared.
+    #[test]
+    fn daemon_refusal_agrees_with_shared_gate() {
+        for line in [
+            "@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4",
+            "@RSYNCD: 31.0",
+            "@RSYNCD: 29",
+            "@RSYNCD: OK",
+            "module",
+        ] {
+            assert_eq!(
+                protocol::missing_greeting_token(line).is_none(),
+                reject_malformed_client_greeting(line).is_none(),
+                "daemon refusal must track the shared gate for {line:?}",
+            );
+        }
     }
 }

--- a/crates/protocol/src/legacy/greeting/mod.rs
+++ b/crates/protocol/src/legacy/greeting/mod.rs
@@ -9,6 +9,7 @@ mod format;
 mod parse;
 mod tokens;
 mod types;
+mod validate;
 
 pub use format::{format_legacy_daemon_greeting, write_legacy_daemon_greeting};
 pub use parse::{
@@ -17,6 +18,7 @@ pub use parse::{
 };
 pub use tokens::DigestListTokens;
 pub use types::{LegacyDaemonGreeting, LegacyDaemonGreetingOwned};
+pub use validate::{MissingGreetingToken, missing_greeting_token};
 
 #[cfg(test)]
 mod tests;

--- a/crates/protocol/src/legacy/greeting/validate.rs
+++ b/crates/protocol/src/legacy/greeting/validate.rs
@@ -1,0 +1,174 @@
+//! Presence gates for the `@RSYNCD:` daemon greeting.
+//!
+//! The structural greeting parser in [`super::parse`] is intentionally lenient:
+//! it accepts a bare version banner so callers can inspect whatever a peer sent.
+//! Upstream rsync applies the *policy* gates - which tokens a greeting must
+//! carry for a given protocol - separately, inside `clientserver.c`'s
+//! `exchange_protocols()`. This module exposes that same decision as a single
+//! shared helper so every enforcement site (the daemon validating an incoming
+//! client greeting, the client validating the daemon's greeting) agrees on the
+//! exact gates without duplicating the logic.
+
+use super::super::{LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_LEN};
+
+/// A required `@RSYNCD:` greeting token that the peer omitted.
+///
+/// upstream: clientserver.c:188-210 `exchange_protocols()` - the subprotocol
+/// suffix and the digest name list are each mandatory past a protocol
+/// threshold, and their absence is fatal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MissingGreetingToken {
+    /// The `.subprotocol` suffix, required when `protocol >= 30`.
+    Subprotocol,
+    /// The digest name list, required when `protocol > 31`.
+    DigestList,
+}
+
+impl MissingGreetingToken {
+    /// Returns the noun upstream uses to name the token in its diagnostics.
+    ///
+    /// Both the daemon's `@ERROR: your client omitted the <desc>: <line>` and
+    /// the client's `rsync: the server omitted the <desc>: <line>` messages
+    /// interpolate this text, matching upstream `clientserver.c:191/193` and
+    /// `clientserver.c:207/209`.
+    #[must_use]
+    pub const fn description(self) -> &'static str {
+        match self {
+            Self::Subprotocol => "subprotocol value",
+            Self::DigestList => "digest name list",
+        }
+    }
+}
+
+/// Applies upstream `exchange_protocols()`'s presence gates to a raw `@RSYNCD:`
+/// greeting line, returning the token the peer omitted, if any.
+///
+/// Returns `None` when the line is a well-formed greeting, is not an `@RSYNCD:`
+/// version banner at all, or is a legacy (`protocol < 30`) greeting that needs
+/// neither token. The detection is byte-faithful to upstream
+/// `clientserver.c:180-211`:
+///
+/// - the subprotocol is parsed with the equivalent of
+///   `sscanf(buf, "@RSYNCD: %d.%d", ...)`; a missing `.subprotocol` leaves the
+///   value unset and is fatal for `remote_protocol >= 30`
+///   (upstream: clientserver.c:188-197),
+/// - the digest list is detected with the equivalent of
+///   `strchr(buf + 9, ' ')` - any space past the `"@RSYNCD: "` prefix - and its
+///   absence is fatal for `remote_protocol > 31`
+///   (upstream: clientserver.c:199-211).
+///
+/// Trailing `\r`/`\n` are stripped first so the gate matches upstream, which
+/// operates on the newline-stripped `read_line_old()` buffer.
+#[doc(alias = "@RSYNCD")]
+#[must_use]
+pub fn missing_greeting_token(line: &str) -> Option<MissingGreetingToken> {
+    let trimmed = line.trim_end_matches(['\r', '\n']);
+
+    let after_prefix = trimmed.strip_prefix(LEGACY_DAEMON_PREFIX)?;
+
+    // upstream: sscanf `%d` skips leading whitespace before the protocol number.
+    let rest = after_prefix.trim_start();
+    let digits = rest
+        .as_bytes()
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digits == 0 {
+        // sscanf(...) < 1: not a version banner - the caller keeps parsing.
+        return None;
+    }
+    let remote_protocol: u32 = rest[..digits].parse().unwrap_or(u32::MAX);
+
+    // upstream: `remote_sub` stays < 0 unless a ".NNN" suffix follows the number.
+    let has_subprotocol = rest[digits..]
+        .strip_prefix('.')
+        .and_then(|fractional| fractional.as_bytes().first())
+        .is_some_and(u8::is_ascii_digit);
+    if !has_subprotocol && remote_protocol >= 30 {
+        return Some(MissingGreetingToken::Subprotocol);
+    }
+
+    // upstream: `daemon_auth_choices = strchr(buf + 9, ' ')` - any space past
+    // "@RSYNCD: " marks the start of the digest-name list.
+    let has_digest_list = trimmed
+        .as_bytes()
+        .get(LEGACY_DAEMON_PREFIX_LEN + 1..)
+        .is_some_and(|tail| tail.contains(&b' '));
+    if !has_digest_list && remote_protocol > 31 {
+        return Some(MissingGreetingToken::DigestList);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MissingGreetingToken, missing_greeting_token};
+
+    // upstream: clientserver.c:188-197 - the subprotocol suffix is mandatory the
+    // moment protocol reaches 30, not 31; both 30 and 32 without ".NNN" are fatal.
+    #[test]
+    fn subprotocol_required_from_protocol_30() {
+        assert_eq!(
+            missing_greeting_token("@RSYNCD: 30"),
+            Some(MissingGreetingToken::Subprotocol),
+        );
+        assert_eq!(
+            missing_greeting_token("@RSYNCD: 31"),
+            Some(MissingGreetingToken::Subprotocol),
+        );
+        assert_eq!(
+            missing_greeting_token("@RSYNCD: 32"),
+            Some(MissingGreetingToken::Subprotocol),
+        );
+    }
+
+    // upstream: clientserver.c:199-211 - protocol > 31 must carry a digest name
+    // list even when the subprotocol suffix is present.
+    #[test]
+    fn digest_list_required_past_protocol_31() {
+        assert_eq!(
+            missing_greeting_token("@RSYNCD: 32.0"),
+            Some(MissingGreetingToken::DigestList),
+        );
+        // protocol 31 needs the subprotocol but not a digest list.
+        assert_eq!(missing_greeting_token("@RSYNCD: 31.0"), None);
+    }
+
+    // upstream: clientserver.c:196 - protocol < 30 defaults remote_sub to 0 and
+    // needs no digest list, so a bare legacy version is accepted.
+    #[test]
+    fn legacy_versions_need_neither_token() {
+        assert_eq!(missing_greeting_token("@RSYNCD: 29"), None);
+        assert_eq!(missing_greeting_token("@RSYNCD: 28.0"), None);
+    }
+
+    // A fully-formed modern greeting carries both tokens and passes cleanly.
+    #[test]
+    fn well_formed_modern_greeting_passes() {
+        assert_eq!(
+            missing_greeting_token("@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n"),
+            None,
+        );
+    }
+
+    // Non-version lines are not greetings; the gate defers to normal parsing.
+    #[test]
+    fn non_version_lines_defer() {
+        assert_eq!(missing_greeting_token("@RSYNCD: OK"), None);
+        assert_eq!(missing_greeting_token("module"), None);
+        assert_eq!(missing_greeting_token("@RSYNCD:"), None);
+    }
+
+    #[test]
+    fn description_matches_upstream_nouns() {
+        assert_eq!(
+            MissingGreetingToken::Subprotocol.description(),
+            "subprotocol value"
+        );
+        assert_eq!(
+            MissingGreetingToken::DigestList.description(),
+            "digest name list"
+        );
+    }
+}

--- a/crates/protocol/src/legacy/mod.rs
+++ b/crates/protocol/src/legacy/mod.rs
@@ -47,8 +47,8 @@ pub use bytes::{
 pub use greeting::write_legacy_daemon_greeting;
 #[allow(unused_imports)] // REASON: convenience re-export; not all items used in every consumer
 pub use greeting::{
-    DigestListTokens, LegacyDaemonGreeting, LegacyDaemonGreetingOwned,
-    format_legacy_daemon_greeting, parse_legacy_daemon_greeting,
+    DigestListTokens, LegacyDaemonGreeting, LegacyDaemonGreetingOwned, MissingGreetingToken,
+    format_legacy_daemon_greeting, missing_greeting_token, parse_legacy_daemon_greeting,
     parse_legacy_daemon_greeting_details, parse_legacy_daemon_greeting_owned,
 };
 #[allow(unused_imports)] // REASON: convenience re-export; not all items used in every consumer

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -175,12 +175,12 @@ pub use iconv::{
 };
 pub use legacy::{
     DigestListTokens, LEGACY_DAEMON_PREFIX, LEGACY_DAEMON_PREFIX_BYTES, LEGACY_DAEMON_PREFIX_LEN,
-    LegacyDaemonGreeting, LegacyDaemonGreetingOwned, LegacyDaemonMessage,
-    format_legacy_daemon_greeting, format_legacy_daemon_message, parse_legacy_daemon_greeting,
-    parse_legacy_daemon_greeting_bytes, parse_legacy_daemon_greeting_bytes_details,
-    parse_legacy_daemon_greeting_bytes_owned, parse_legacy_daemon_greeting_details,
-    parse_legacy_daemon_greeting_owned, parse_legacy_daemon_message,
-    parse_legacy_daemon_message_bytes, parse_legacy_error_message,
+    LegacyDaemonGreeting, LegacyDaemonGreetingOwned, LegacyDaemonMessage, MissingGreetingToken,
+    format_legacy_daemon_greeting, format_legacy_daemon_message, missing_greeting_token,
+    parse_legacy_daemon_greeting, parse_legacy_daemon_greeting_bytes,
+    parse_legacy_daemon_greeting_bytes_details, parse_legacy_daemon_greeting_bytes_owned,
+    parse_legacy_daemon_greeting_details, parse_legacy_daemon_greeting_owned,
+    parse_legacy_daemon_message, parse_legacy_daemon_message_bytes, parse_legacy_error_message,
     parse_legacy_error_message_bytes, parse_legacy_warning_message,
     parse_legacy_warning_message_bytes, write_legacy_daemon_greeting, write_legacy_daemon_message,
 };


### PR DESCRIPTION
## Summary

Follow-up to the daemon-side greeting refusal: the **client** now rejects a
malformed `@RSYNCD:` daemon greeting exactly the way upstream rsync does, and
both roles share a single greeting-gate helper.

Upstream `clientserver.c:exchange_protocols()` applies the same presence gates
regardless of role, branching only on the diagnostic wording:

- missing `.subprotocol` suffix is fatal for `remote_protocol >= 30`
  (`clientserver.c:188-197`),
- missing digest name list is fatal for `remote_protocol > 31`
  (`clientserver.c:199-211`),
- the client (`am_client == 1`) prints `rsync: the server omitted the <token>: <buf>`
  and aborts with `RERR_STARTCLIENT` (`main.c:1872-1874`, exit code 5).

Before this change the client daemon handshake never enforced those gates, so a
server greeting that omitted the subprotocol value (protocol >= 30) or the
digest list (protocol > 31) was silently accepted.

## Changes

- **protocol**: new shared `missing_greeting_token()` returning
  `MissingGreetingToken` - the single source of truth for the upstream gates,
  byte-faithful to `sscanf("@RSYNCD: %d.%d")` + `strchr(buf + 9, ' ')`.
- **daemon**: `reject_malformed_client_greeting()` now delegates to the shared
  gate. Its `@ERROR: your client omitted the <token>: <line>` output and the
  exact set of refused greetings stay byte-identical; a regression test asserts
  the daemon refusal tracks the shared gate (no double-reject).
- **client transfer handshake** (`perform_daemon_handshake`): applies the shared
  gate to the server greeting before proceeding, emitting
  `the server omitted the <token>: <greeting>` with `RERR_STARTCLIENT`.

The structural greeting parser stays intentionally lenient (its adversarial
corpus deliberately accepts a bare `@RSYNCD: 32.0`); the policy gate lives at the
handshake layer, matching upstream's separation of parsing from enforcement.

## Tests

- protocol: gate unit tests (subprotocol required from proto 30, digest required
  past 31, legacy versions need neither, well-formed accepted, non-greetings
  defer).
- daemon: existing byte-exact `@ERROR` tests unchanged; new
  `daemon_refusal_agrees_with_shared_gate`.
- client: rejects greeting missing subprotocol (proto 30) and missing digest
  (proto 32) with exact message + exit code; a legacy (proto 29) greeting is
  accepted and the handshake proceeds.

`cargo fmt` + `cargo clippy --all-targets --all-features -D warnings` clean on
protocol/daemon/core; targeted tests pass.

## Follow-up

The module-list negotiation helper (`negotiate_legacy_daemon_session_from_stream`)
is the other client consumer of the lenient parser. Gating it there would break
several low-level protocol-clamping tests that feed digest-less proto-32/40
greetings to exercise version capping; the correct home for the policy gate is
the application handshake layer (fixed here). The shared gate is ready to wire
into the module-list listing path in a dedicated change.
