### PR TITLE
fix: keepalive during sender signature read on proto<31

### DIFF
--- a/crates/transfer/src/compressed_writer.rs
+++ b/crates/transfer/src/compressed_writer.rs
@@ -223,6 +223,14 @@ impl<W: Write> CompressedWriter<W> {
     pub const fn inner_mut(&mut self) -> &mut W {
         &mut self.inner
     }
+
+    /// Provides shared access to the underlying writer.
+    ///
+    /// Used to read pass-through state (e.g. the keep-alive lull interval) that
+    /// lives on the multiplex writer without mutating it.
+    pub const fn inner_ref(&self) -> &W {
+        &self.inner
+    }
 }
 
 impl<W: Write> Write for CompressedWriter<W> {

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -100,7 +100,10 @@ pub use self::diagnostics::{
     flush_rate_totals, ndx_convert_totals, prepare_acl_totals, segment_dispatch_totals,
 };
 pub use self::item_flags::ItemFlags;
-pub use self::protocol_io::{calculate_duration_ms, read_signature_blocks};
+pub use self::protocol_io::{
+    calculate_duration_ms, read_signature_blocks, read_signature_blocks_keepalive,
+    signature_read_lull_mod,
+};
 pub use self::stats::GeneratorStats;
 
 // Re-exports for sibling submodules accessing diagnostics, segments, and stats

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 
 use logging::{InfoFlag, PhaseTimer, debug_log, info_gte, info_log};
 use protocol::CompatibilityFlags;
+use protocol::ProtocolVersion;
 use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum};
 use protocol::wire::SignatureBlock;
 
@@ -770,6 +771,10 @@ impl GeneratorContext {
 /// After reading sum_head, this reads the rolling and strong checksums for each block.
 /// When sum_head.count is 0, returns an empty Vec (whole-file transfer).
 ///
+/// This is the keepalive-free path used for whole-file transfers and unit tests.
+/// The live sender loop uses [`read_signature_blocks_keepalive`] so a slow read on
+/// an older protocol does not trip the peer's `--timeout`.
+///
 /// # Upstream Reference
 ///
 /// - `sender.c:120` - `receive_sums()` reads signature blocks
@@ -778,6 +783,34 @@ pub fn read_signature_blocks<R: Read>(
     reader: &mut R,
     sum_head: &SumHead,
 ) -> io::Result<Vec<SignatureBlock>> {
+    read_signature_blocks_keepalive(reader, sum_head, 0, || Ok(()))
+}
+
+/// Reads signature blocks from the receiver, poking a keepalive every `lull_mod`
+/// blocks so a large/slow checksum read does not exceed the peer's I/O timeout.
+///
+/// `on_lull` is invoked once every `lull_mod` blocks (starting at block 0), or
+/// never when `lull_mod` is 0. It maps to upstream's `maybe_send_keepalive()`,
+/// which itself only emits an empty `MSG_DATA` frame once a full `allowed_lull`
+/// has elapsed with no output - so passing a keepalive closure is wire-neutral
+/// until the lull actually fires.
+///
+/// # Upstream Reference
+///
+/// - `sender.c:73` - `receive_sums()`; `lull_mod = protocol_version >= 31 ? 0 : allowed_lull * 5`
+/// - `sender.c:115-116` - `if (lull_mod && !(i % lull_mod)) maybe_send_keepalive(time(NULL), True)`
+/// - `io.c:1453` - `maybe_send_keepalive()` gates the actual emission on `allowed_lull`
+/// - `match.c:395` - Block format: rolling_sum (4 bytes) + strong_sum (s2length bytes)
+pub fn read_signature_blocks_keepalive<R, F>(
+    reader: &mut R,
+    sum_head: &SumHead,
+    lull_mod: u32,
+    mut on_lull: F,
+) -> io::Result<Vec<SignatureBlock>>
+where
+    R: Read,
+    F: FnMut() -> io::Result<()>,
+{
     if sum_head.is_empty() {
         // No basis file (count=0), whole-file transfer - no blocks to read
         return Ok(Vec::new());
@@ -800,9 +833,40 @@ pub fn read_signature_blocks<R: Read>(
             rolling_sum,
             strong_sum,
         });
+
+        // upstream: sender.c:115-116 - if (lull_mod && !(i % lull_mod))
+        //     maybe_send_keepalive(time(NULL), True);
+        // Poke a keepalive at the same cadence so a long checksum read on an
+        // older protocol keeps the write side alive.
+        if lull_mod != 0 && i % lull_mod == 0 {
+            on_lull()?;
+        }
     }
 
     Ok(blocks)
+}
+
+/// Derives upstream's signature-read keepalive cadence for a sender.
+///
+/// Returns the number of blocks between keepalive pokes, or 0 to disable them.
+/// Keepalives are only needed on protocols below 31; newer protocols multiplex
+/// the checksum stream so the sender's read no longer starves the write side.
+///
+/// # Upstream Reference
+///
+/// - `sender.c:76` - `int lull_mod = protocol_version >= 31 ? 0 : allowed_lull * 5;`
+///   (`allowed_lull` is in seconds, derived from `--timeout` at io.c:1151).
+#[must_use]
+pub fn signature_read_lull_mod(protocol: ProtocolVersion, allowed_lull: Option<Duration>) -> u32 {
+    if protocol.as_u8() >= 31 {
+        return 0;
+    }
+    match allowed_lull {
+        Some(lull) => u32::try_from(lull.as_secs())
+            .unwrap_or(u32::MAX)
+            .saturating_mul(5),
+        None => 0,
+    }
 }
 
 /// Calculates duration in milliseconds between two optional timestamps.

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -7,7 +7,10 @@ use super::delta::{
     write_delta_with_compression,
 };
 use super::file_list::apply_permutation_in_place;
-use super::protocol_io::{calculate_duration_ms, read_signature_blocks};
+use super::protocol_io::{
+    calculate_duration_ms, read_signature_blocks, read_signature_blocks_keepalive,
+    signature_read_lull_mod,
+};
 use super::*;
 use crate::delta_apply::ChecksumVerifier;
 use crate::handshake::HandshakeResult;
@@ -20,7 +23,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Cursor, Write};
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 use crate::config::ServerConfig;
@@ -1504,6 +1507,113 @@ fn read_signature_blocks_truncated_data() {
     let result = read_signature_blocks(&mut cursor, &sum_head);
 
     assert!(result.is_err());
+}
+
+/// Builds a wire buffer of `count` signature blocks with 16-byte strong sums.
+fn signature_wire(count: u32) -> Vec<u8> {
+    let mut data = Vec::new();
+    for i in 0..count {
+        data.extend_from_slice(&i.to_le_bytes());
+        data.extend_from_slice(&[0x5A; 16]);
+    }
+    data
+}
+
+/// On an older protocol with a slow/large checksum read, the sender must poke a
+/// keepalive every `lull_mod` blocks so the peer's --timeout does not fire while
+/// the write side is starved. upstream: sender.c:115-116.
+#[test]
+fn read_signature_blocks_keepalive_fires_on_cadence() {
+    let data = signature_wire(5);
+    let mut cursor = Cursor::new(&data[..]);
+    let sum_head = SumHead::new(5, 1024, 16, 0);
+
+    // lull_mod = 2 -> poke at blocks 0, 2, 4 (upstream `!(i % lull_mod)`).
+    let mut pokes = 0u32;
+    let blocks = read_signature_blocks_keepalive(&mut cursor, &sum_head, 2, || {
+        pokes += 1;
+        Ok(())
+    })
+    .unwrap();
+
+    assert_eq!(blocks.len(), 5);
+    assert_eq!(pokes, 3, "keepalive must fire at blocks 0, 2, and 4");
+}
+
+/// A `lull_mod` of 0 (modern protocol, or `--timeout` unset) must never poke a
+/// keepalive, keeping the default transfer path wire-identical. upstream:
+/// sender.c:76 sets `lull_mod = 0` for protocol_version >= 31.
+#[test]
+fn read_signature_blocks_keepalive_disabled_never_fires() {
+    let data = signature_wire(4);
+    let mut cursor = Cursor::new(&data[..]);
+    let sum_head = SumHead::new(4, 1024, 16, 0);
+
+    let mut pokes = 0u32;
+    let blocks = read_signature_blocks_keepalive(&mut cursor, &sum_head, 0, || {
+        pokes += 1;
+        Ok(())
+    })
+    .unwrap();
+
+    assert_eq!(blocks.len(), 4);
+    assert_eq!(pokes, 0, "lull_mod=0 must suppress all keepalives");
+}
+
+/// A whole-file transfer (count=0) reads no blocks and therefore never pokes a
+/// keepalive, regardless of `lull_mod`.
+#[test]
+fn read_signature_blocks_keepalive_empty_never_fires() {
+    let data: [u8; 0] = [];
+    let mut cursor = Cursor::new(&data[..]);
+    let sum_head = SumHead::empty();
+
+    let mut pokes = 0u32;
+    let blocks = read_signature_blocks_keepalive(&mut cursor, &sum_head, 5, || {
+        pokes += 1;
+        Ok(())
+    })
+    .unwrap();
+
+    assert!(blocks.is_empty());
+    assert_eq!(pokes, 0);
+}
+
+/// upstream: sender.c:76 - `lull_mod = protocol_version >= 31 ? 0 : allowed_lull * 5`.
+/// Protocol 31 and newer multiplex the checksum stream, so the sender never pokes
+/// keepalives during the signature read.
+#[test]
+fn signature_read_lull_mod_disabled_on_modern_protocol() {
+    assert_eq!(
+        signature_read_lull_mod(ProtocolVersion::V31, Some(Duration::from_secs(15))),
+        0
+    );
+    assert_eq!(
+        signature_read_lull_mod(ProtocolVersion::V32, Some(Duration::from_secs(15))),
+        0
+    );
+}
+
+/// On protocols below 31, the cadence is `allowed_lull * 5` blocks (seconds).
+/// upstream: sender.c:76.
+#[test]
+fn signature_read_lull_mod_scales_with_lull_on_old_protocol() {
+    assert_eq!(
+        signature_read_lull_mod(ProtocolVersion::V30, Some(Duration::from_secs(15))),
+        75
+    );
+    assert_eq!(
+        signature_read_lull_mod(ProtocolVersion::V28, Some(Duration::from_secs(1))),
+        5
+    );
+}
+
+/// Without `--timeout` there is no lull, so no keepalives even on an old
+/// protocol; the default path stays wire-identical. upstream: `allowed_lull`
+/// is 0 when no timeout is set (io.c:1151), making `lull_mod` 0.
+#[test]
+fn signature_read_lull_mod_zero_without_timeout() {
+    assert_eq!(signature_read_lull_mod(ProtocolVersion::V30, None), 0);
 }
 
 #[test]

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -96,7 +96,7 @@ impl GeneratorContext {
         use super::super::delta::{
             generate_delta_from_signature, generate_delta_from_signature_chunked,
         };
-        use super::super::protocol_io::read_signature_blocks;
+        use super::super::protocol_io::{read_signature_blocks_keepalive, signature_read_lull_mod};
 
         // upstream: sender.c:217-218 - rprintf(FINFO, "send_files starting\n")
         debug_log!(Send, 1, "send_files starting");
@@ -488,7 +488,15 @@ impl GeneratorContext {
             let sig_blocks = if is_append {
                 Vec::new()
             } else {
-                let blocks = read_signature_blocks(&mut *reader, &sum_head)?;
+                // upstream: sender.c:76 receive_sums() - on protocols below 31 the
+                // sender pokes a keepalive every `allowed_lull * 5` blocks so a
+                // large/slow checksum read does not trip the peer's --timeout.
+                // Newer protocols multiplex the stream and set lull_mod = 0.
+                let lull_mod = signature_read_lull_mod(self.protocol, writer.allowed_lull());
+                let blocks =
+                    read_signature_blocks_keepalive(&mut *reader, &sum_head, lull_mod, || {
+                        writer.maybe_send_keepalive().map(|_| ())
+                    })?;
                 let bytes_per_block = 4 + sum_head.s2length as u64;
                 self.timing.total_bytes_read += sum_head.count as u64 * bytes_per_block;
                 blocks

--- a/crates/transfer/src/writer/multiplex.rs
+++ b/crates/transfer/src/writer/multiplex.rs
@@ -83,6 +83,15 @@ impl<W: Write> MultiplexWriter<W> {
         self.last_io_out = Instant::now();
     }
 
+    /// Returns the configured keep-alive lull interval, or `None` when
+    /// `--timeout` is not set.
+    ///
+    /// Callers use this to derive upstream's `lull_mod = allowed_lull * 5`
+    /// cadence (sender.c:76) when poking keepalives inside a long read loop.
+    pub(crate) fn allowed_lull(&self) -> Option<Duration> {
+        self.allowed_lull
+    }
+
     /// Emits a lull keepalive if the configured `allowed_lull` has elapsed with
     /// no output since the last write.
     ///

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -212,6 +212,19 @@ impl<W: Write> ServerWriter<W> {
         }
     }
 
+    /// Returns the configured keep-alive lull interval, or `None` when no
+    /// `--timeout` is set or the stream is not multiplexed.
+    ///
+    /// Callers use this to derive upstream's `lull_mod = allowed_lull * 5`
+    /// cadence (sender.c:76) when poking keepalives inside a long read loop.
+    pub fn allowed_lull(&self) -> Option<Duration> {
+        match self {
+            Self::Multiplex(mux) => mux.allowed_lull(),
+            Self::Compressed(compressed) => compressed.inner_ref().allowed_lull(),
+            Self::Plain(_) | Self::Taken => None,
+        }
+    }
+
     /// Sends a `MSG_NO_SEND` message for the given file index.
     ///
     /// Indicates that the sender could not open the requested file and will


### PR DESCRIPTION
## Summary

On protocols below 31, the sender pokes an I/O keepalive while reading the
receiver's block-checksum (signature) set. A large or slow signature read can
block the sender for a long time with no output, and without keepalives the peer
trips its `--timeout`. This mirrors upstream's dedicated keepalive site in
`receive_sums()`.

## Upstream reference

- `sender.c:76` `receive_sums()` -
  `int lull_mod = protocol_version >= 31 ? 0 : allowed_lull * 5;`
- `sender.c:115-116` - inside the per-block read loop:
  `if (lull_mod && !(i % lull_mod)) maybe_send_keepalive(time(NULL), True);`
- `io.c:1453 maybe_send_keepalive()` - only emits an empty `MSG_DATA` frame once
  a full `allowed_lull` has elapsed with no output.
- `io.c:1151 set_io_timeout()` - `allowed_lull = (io_timeout + 1) / 2` (seconds).

Newer protocols (>= 31) multiplex the checksum stream, so the sender's read no
longer starves the write side and upstream sets `lull_mod = 0` (no keepalive).

## Divergence

The existing send-loop keepalive covers the per-file NDX loop, but the
signature block read (`read_signature_blocks`) had no keepalive, so a slow read
on an older protocol could exceed the peer's timeout. On modern protocols oc
already matched upstream (no keepalive during this read).

## Change

- `read_signature_blocks_keepalive()` reads the block sums and pokes a keepalive
  every `lull_mod` blocks (upstream's `!(i % lull_mod)` cadence). The existing
  `read_signature_blocks()` now delegates with `lull_mod = 0`, so the whole-file
  and test paths are unchanged.
- `signature_read_lull_mod()` derives the cadence exactly as upstream
  (`protocol < 31 ? allowed_lull_secs * 5 : 0`).
- The sender loop calls the keepalive-aware reader, deriving `allowed_lull` from
  the multiplex writer and reusing its `maybe_send_keepalive()` primitive (empty
  `MSG_DATA`, same cadence/gating).
- Added `allowed_lull()` accessors on `MultiplexWriter` / `ServerWriter` and an
  `inner_ref()` on `CompressedWriter`.

The emitted frame is an empty `MSG_DATA`, wire-identical to what an upstream peer
on the old protocol expects. The default path (modern protocol, or no `--timeout`,
or a signature set that never exceeds the lull) is unchanged and wire-identical:
`maybe_send_keepalive()` only writes once the lull actually elapses.

## Tests

- `read_signature_blocks_keepalive_fires_on_cadence` - 5 blocks, `lull_mod = 2`
  pokes at blocks 0/2/4.
- `read_signature_blocks_keepalive_disabled_never_fires` - `lull_mod = 0` never
  pokes (modern protocol / no timeout).
- `read_signature_blocks_keepalive_empty_never_fires` - whole-file transfer never
  pokes.
- `signature_read_lull_mod_*` - proto >= 31 disables; proto < 31 scales as
  `allowed_lull_secs * 5`; no timeout yields 0.

fmt + clippy (`-D warnings`) clean; targeted `transfer` lib tests pass.
