### PR TITLE
fix: back up existing specials/symlinks before receiver replace

### DIFF
--- a/crates/transfer/src/receiver/directory/backup.rs
+++ b/crates/transfer/src/receiver/directory/backup.rs
@@ -1,0 +1,325 @@
+//! Backup of an existing non-regular destination entry before it is replaced.
+//!
+//! When `--backup` is set and the receiver is about to replace an existing
+//! symlink, FIFO, socket, or device node with a fresh one from the file list,
+//! upstream's generator preserves the old entry to the backup location before
+//! creating the replacement. Without this pass oc-rsync would unlink the old
+//! entry outright, silently losing the user's prior data.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:2005-2026` `atomic_create()` - for a symlink/device/special
+//!   replacing an existing item (`del_for_flag`), calls `make_backup(fname, ...)`
+//!   before creating the new node; only when `--backup` is off does it fall
+//!   through to `delete_item()`.
+//! - `backup.c:187-221` `link_or_rename()` - hard-links the existing item into
+//!   the backup area (the `DEBUG_GTE(BACKUP, 1)` "HLINK" success line), falling
+//!   back to `rename(2)` ("RENAME") when the link cannot be made (cross-device
+//!   or a filesystem/type that cannot be hard-linked). Upstream's default
+//!   `atomic_create` (no `--temp-dir`) passes `prefer_rename = 0`, so the
+//!   hard-link path is tried first for symlinks and specials on platforms that
+//!   define `CAN_HARDLINK_SYMLINK` / `CAN_HARDLINK_SPECIAL`.
+//! - `backup.c:352-353` - `INFO_GTE(BACKUP, 1)` "backed up %s to %s".
+
+#[cfg(any(unix, windows))]
+use std::fs;
+#[cfg(any(unix, windows))]
+use std::io;
+#[cfg(any(unix, windows))]
+use std::path::Path;
+
+#[cfg(any(unix, windows))]
+use crate::receiver::ReceiverContext;
+
+/// Which mechanism moved the existing entry into the backup area.
+#[cfg(any(unix, windows))]
+enum BackupPlacement {
+    /// Hard-linked (upstream `link_or_rename` "HLINK" branch). The original
+    /// still exists as a second link and must be unlinked by the caller path
+    /// (done inside the method) before the replacement node is created.
+    Hardlinked,
+    /// Renamed (upstream "RENAME" fallback). The original path is now free.
+    Renamed,
+}
+
+/// Places `existing` into `backup_path`, mirroring upstream `link_or_rename`
+/// with `prefer_rename = 0`: hard-link first, rename on fallback.
+///
+/// upstream: `backup.c:200-219` - `do_link_at` then `do_rename_at`. A
+/// pre-existing backup (`EEXIST`) is removed and the link retried
+/// (`backup.c:247-256`).
+#[cfg(any(unix, windows))]
+fn place_existing_backup(existing: &Path, backup_path: &Path) -> io::Result<BackupPlacement> {
+    if let Some(parent) = backup_path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    match fast_io::hard_link(existing, backup_path) {
+        Ok(()) => Ok(BackupPlacement::Hardlinked),
+        // upstream: backup.c:247-256 - delete a stale backup and retry the link.
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+            let _ = fs::remove_file(backup_path);
+            match fast_io::hard_link(existing, backup_path) {
+                Ok(()) => Ok(BackupPlacement::Hardlinked),
+                Err(_) => {
+                    fs::rename(existing, backup_path)?;
+                    Ok(BackupPlacement::Renamed)
+                }
+            }
+        }
+        // upstream: backup.c:210 - rename fallback when the item cannot be
+        // hard-linked (cross-device, or a type/fs without CAN_HARDLINK_*).
+        Err(_) => {
+            fs::rename(existing, backup_path)?;
+            Ok(BackupPlacement::Renamed)
+        }
+    }
+}
+
+/// Emits the `--debug=BACKUP` mechanism trace and the `--info=BACKUP` notice
+/// for a completed backup of `existing` to `backup_path`, both relative to
+/// `dest_dir` so the wording matches upstream `testsuite/backup.test`.
+#[cfg(any(unix, windows))]
+fn report_backup(
+    placement: &BackupPlacement,
+    existing: &Path,
+    backup_path: &Path,
+    dest_dir: &Path,
+) {
+    let existing_display = existing.display().to_string();
+    match placement {
+        // upstream: backup.c:201-202 - DEBUG_GTE(BACKUP, 1) HLINK success.
+        BackupPlacement::Hardlinked => engine::trace_make_backup_hlink(&existing_display),
+        // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1) RENAME success.
+        BackupPlacement::Renamed => engine::trace_make_backup_rename(&existing_display),
+    }
+    // upstream: backup.c:352-353 - INFO_GTE(BACKUP, 1) "backed up %s to %s".
+    let file_rel = existing.strip_prefix(dest_dir).unwrap_or(existing);
+    let backup_rel = backup_path.strip_prefix(dest_dir).unwrap_or(backup_path);
+    logging::info_log!(
+        Backup,
+        1,
+        "backed up {} to {}",
+        file_rel.display(),
+        backup_rel.display()
+    );
+}
+
+impl ReceiverContext {
+    /// Backs up an existing destination entry before it is replaced by a fresh
+    /// symlink, FIFO, socket, or device node.
+    ///
+    /// Returns `Ok(true)` when a backup was made (the original was hard-linked
+    /// or renamed into the backup area and its original path is now clear for
+    /// the replacement). Returns `Ok(false)` when no backup applies - either
+    /// `--backup` is off or nothing exists at `existing` to preserve - in which
+    /// case the caller removes any obstacle itself. `Err` signals that the
+    /// backup mechanism failed; the caller skips creating the replacement,
+    /// mirroring upstream `atomic_create` returning 0 when `make_backup` fails.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:2018-2020` - `if (make_backups > 0 ...) if (!make_backup(fname, ...)) return 0;`
+    #[cfg(unix)]
+    pub(in crate::receiver) fn backup_existing_before_replace(
+        &self,
+        existing: &Path,
+        relative_path: &Path,
+        dest_dir: &Path,
+        sandbox: Option<&fast_io::DirSandbox>,
+    ) -> io::Result<bool> {
+        if !self.config.flags.backup {
+            return Ok(false);
+        }
+        // upstream: backup.c:236 - x_lstat returns 3 (nothing to keep) when the
+        // path is absent; a fresh create needs no backup.
+        if fs::symlink_metadata(existing).is_err() {
+            return Ok(false);
+        }
+
+        let backup_path = engine::compute_backup_path(
+            dest_dir,
+            existing,
+            None,
+            self.config.backup_dir.as_deref().map(Path::new),
+            std::ffi::OsStr::new(self.config.effective_backup_suffix()),
+        );
+
+        let placement = place_existing_backup(existing, &backup_path)?;
+        report_backup(&placement, existing, &backup_path, dest_dir);
+
+        if matches!(placement, BackupPlacement::Hardlinked) {
+            // The original still exists as a second link; remove it so the new
+            // node can take its place. upstream: atomic_create's rename over
+            // `fname` does this implicitly.
+            //
+            // SEC-1.g: route the removal through the sandbox dirfd when the
+            // destination parent is the sandbox root so a TOCTOU swap on the
+            // original path cannot redirect the unlink.
+            let _ = fast_io::unlink_via_sandbox_or_fallback(
+                sandbox,
+                dest_dir,
+                relative_path,
+                existing,
+                fast_io::UnlinkFlags::File,
+            );
+        }
+        Ok(true)
+    }
+
+    /// Windows variant: no dirfd sandbox, so the post-hard-link removal uses a
+    /// path-based `remove_file`, matching the Windows symlink-create path.
+    #[cfg(windows)]
+    pub(in crate::receiver) fn backup_existing_before_replace(
+        &self,
+        existing: &Path,
+        _relative_path: &Path,
+        dest_dir: &Path,
+    ) -> io::Result<bool> {
+        if !self.config.flags.backup {
+            return Ok(false);
+        }
+        if fs::symlink_metadata(existing).is_err() {
+            return Ok(false);
+        }
+
+        let backup_path = engine::compute_backup_path(
+            dest_dir,
+            existing,
+            None,
+            self.config.backup_dir.as_deref().map(Path::new),
+            std::ffi::OsStr::new(self.config.effective_backup_suffix()),
+        );
+
+        let placement = place_existing_backup(existing, &backup_path)?;
+        report_backup(&placement, existing, &backup_path, dest_dir);
+
+        if matches!(placement, BackupPlacement::Hardlinked) {
+            let _ = fs::remove_file(existing);
+        }
+        Ok(true)
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    //! Mechanism-level pins for the non-regular backup: an existing symlink or
+    //! FIFO is preserved in the backup area, and the `--debug=BACKUP` trace is
+    //! emitted (HLINK where hard-linking the type is supported) and suppressed
+    //! below level 1.
+
+    use super::{BackupPlacement, place_existing_backup, report_backup};
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+    use std::fs;
+    use std::os::unix::fs::FileTypeExt;
+
+    fn backup_debug_messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Backup,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// An existing symlink must survive in the backup location with its target
+    /// intact. On Linux hard-linking a symlink is supported, so the mechanism
+    /// takes the HLINK branch and emits the upstream `make_backup: HLINK` line.
+    #[test]
+    fn existing_symlink_preserved_in_backup_with_target() {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.backup = 1;
+        init(cfg);
+        let _ = drain_events();
+
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("link");
+        let backup = dir.path().join("link~");
+        std::os::unix::fs::symlink("original/target", &link).unwrap();
+
+        let placement = place_existing_backup(&link, &backup).unwrap();
+
+        // On Linux `link(2)` does not dereference a symlink source, so the
+        // backup is taken via hard-link and the HLINK trace is guaranteed.
+        // upstream: configure.ac:1067 defines CAN_HARDLINK_SYMLINK on Linux.
+        #[cfg(target_os = "linux")]
+        assert!(
+            matches!(placement, BackupPlacement::Hardlinked),
+            "Linux must hard-link the symlink backup (HLINK branch)"
+        );
+
+        // Backup carries the original target, byte-for-byte.
+        assert_eq!(
+            fs::read_link(&backup).unwrap(),
+            std::path::Path::new("original/target"),
+            "backup must preserve the original symlink target"
+        );
+
+        // place_existing_backup itself must not emit any trace.
+        assert!(
+            backup_debug_messages().is_empty(),
+            "place_existing_backup must not trace"
+        );
+
+        // upstream: backup.c:201-202 / :216-217 - report_backup emits exactly
+        // one mechanism trace, HLINK when the symlink was hard-linked.
+        report_backup(&placement, &link, &backup, dir.path());
+        let expected = match placement {
+            BackupPlacement::Hardlinked => {
+                format!("make_backup: HLINK {} successful.", link.display())
+            }
+            BackupPlacement::Renamed => {
+                format!("make_backup: RENAME {} successful.", link.display())
+            }
+        };
+        assert!(
+            backup_debug_messages().contains(&expected),
+            "missing mechanism trace {expected:?}"
+        );
+    }
+
+    /// An existing FIFO must survive in the backup location as a FIFO.
+    #[test]
+    fn existing_fifo_preserved_in_backup() {
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("pipe");
+        let backup = dir.path().join("pipe~");
+        // mkfifo via metadata's safe wrapper needs no privilege.
+        metadata::create_fifo_node_from_parts(&fifo, 0o644, false, false).unwrap();
+
+        place_existing_backup(&fifo, &backup).unwrap();
+
+        assert!(
+            fs::symlink_metadata(&backup).unwrap().file_type().is_fifo(),
+            "backup of a FIFO must itself be a FIFO"
+        );
+    }
+
+    /// Level 0 must suppress the mechanism trace entirely.
+    #[test]
+    fn debug_backup_level_zero_suppresses_trace() {
+        let cfg = VerbosityConfig::default();
+        init(cfg);
+        let _ = drain_events();
+
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("l");
+        let backup = dir.path().join("l~");
+        std::os::unix::fs::symlink("t", &link).unwrap();
+
+        let placement = place_existing_backup(&link, &backup).unwrap();
+        report_backup(&placement, &link, &backup, dir.path());
+
+        assert!(
+            backup_debug_messages().is_empty(),
+            "debug=BACKUP level 0 must suppress the mechanism trace"
+        );
+    }
+}

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -121,19 +121,42 @@ impl ReceiverContext {
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
                 }
-                // SEC-1.g: route the obstacle unlink through the sandbox
-                // dirfd when the destination parent is the sandbox root,
-                // so a TOCTOU swap on `link_path` between the readlink
-                // above and this unlink cannot redirect the syscall to
-                // an attacker-chosen parent. Falls back to path-based
-                // `remove_file` otherwise.
-                let _ = fast_io::unlink_via_sandbox_or_fallback(
-                    sandbox,
-                    dest_dir,
-                    relative_path,
+                // upstream: generator.c:2018-2020 atomic_create - back the old
+                // symlink up before it is removed when --backup is set; on
+                // backup-mechanism failure upstream skips the entry.
+                match self.backup_existing_before_replace(
                     &link_path,
-                    fast_io::UnlinkFlags::File,
-                );
+                    relative_path,
+                    dest_dir,
+                    sandbox,
+                ) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        // SEC-1.g: route the obstacle unlink through the sandbox
+                        // dirfd when the destination parent is the sandbox root,
+                        // so a TOCTOU swap on `link_path` between the readlink
+                        // above and this unlink cannot redirect the syscall to
+                        // an attacker-chosen parent. Falls back to path-based
+                        // `remove_file` otherwise.
+                        let _ = fast_io::unlink_via_sandbox_or_fallback(
+                            sandbox,
+                            dest_dir,
+                            relative_path,
+                            &link_path,
+                            fast_io::UnlinkFlags::File,
+                        );
+                    }
+                    Err(error) => {
+                        debug_log!(
+                            Recv,
+                            1,
+                            "failed to back up existing symlink {}: {}",
+                            link_path.display(),
+                            error
+                        );
+                        continue;
+                    }
+                }
             } else if fast_io::lstat_via_sandbox_or_fallback(
                 sandbox,
                 dest_dir,
@@ -148,16 +171,38 @@ impl ReceiverContext {
                 // `link_path` cannot redirect the probe to a different
                 // inode. Falls back to `symlink_metadata` otherwise.
                 //
-                // SEC-1.g: matching unlink also goes through the sandbox
-                // dirfd via `unlinkat` so the obstacle-remove syscall is
-                // anchored on the same parent the stat just observed.
-                let _ = fast_io::unlink_via_sandbox_or_fallback(
-                    sandbox,
-                    dest_dir,
-                    relative_path,
+                // upstream: generator.c:2018-2020 atomic_create - back the old
+                // obstacle up before removal when --backup is set.
+                match self.backup_existing_before_replace(
                     &link_path,
-                    fast_io::UnlinkFlags::File,
-                );
+                    relative_path,
+                    dest_dir,
+                    sandbox,
+                ) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        // SEC-1.g: matching unlink also goes through the sandbox
+                        // dirfd via `unlinkat` so the obstacle-remove syscall is
+                        // anchored on the same parent the stat just observed.
+                        let _ = fast_io::unlink_via_sandbox_or_fallback(
+                            sandbox,
+                            dest_dir,
+                            relative_path,
+                            &link_path,
+                            fast_io::UnlinkFlags::File,
+                        );
+                    }
+                    Err(error) => {
+                        debug_log!(
+                            Recv,
+                            1,
+                            "failed to back up existing obstacle {}: {}",
+                            link_path.display(),
+                            error
+                        );
+                        continue;
+                    }
+                }
             }
 
             // Ensure parent directory exists for --relative paths.
@@ -338,9 +383,43 @@ impl ReceiverContext {
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
                 }
-                let _ = fs::remove_file(&link_path);
+                // upstream: generator.c:2018-2020 atomic_create - back the old
+                // symlink up before removal when --backup is set.
+                match self.backup_existing_before_replace(&link_path, relative_path, dest_dir) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        let _ = fs::remove_file(&link_path);
+                    }
+                    Err(error) => {
+                        debug_log!(
+                            Recv,
+                            1,
+                            "failed to back up existing symlink {}: {}",
+                            link_path.display(),
+                            error
+                        );
+                        continue;
+                    }
+                }
             } else if fs::symlink_metadata(&link_path).is_ok() {
-                let _ = fs::remove_file(&link_path);
+                // upstream: generator.c:2018-2020 atomic_create - back the old
+                // obstacle up before removal when --backup is set.
+                match self.backup_existing_before_replace(&link_path, relative_path, dest_dir) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        let _ = fs::remove_file(&link_path);
+                    }
+                    Err(error) => {
+                        debug_log!(
+                            Recv,
+                            1,
+                            "failed to back up existing obstacle {}: {}",
+                            link_path.display(),
+                            error
+                        );
+                        continue;
+                    }
+                }
             }
 
             // Ensure parent directory exists for --relative paths.

--- a/crates/transfer/src/receiver/directory/mod.rs
+++ b/crates/transfer/src/receiver/directory/mod.rs
@@ -6,6 +6,7 @@
 //! creation (FIFOs, sockets, and device nodes), hardlink creation for both
 //! protocol 30+ and pre-30 modes, and `--delete` scanning.
 
+mod backup;
 mod creation;
 mod deletion;
 mod links;

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -99,20 +99,45 @@ impl ReceiverContext {
             let up_to_date = existing_special_matches(&node_path, entry, is_device);
 
             if !up_to_date {
-                // SEC-1.g: route the obstacle unlink through the sandbox dirfd
-                // when the destination parent is the sandbox root so a TOCTOU
-                // swap between the stat above and this unlink cannot redirect
-                // the syscall. Falls back to path-based removal otherwise. The
-                // result is intentionally ignored: the receiver may attempt but
-                // is not required to succeed at obstacle removal (a dangling
-                // obstacle simply surfaces as a create failure below).
-                let _ = fast_io::unlink_via_sandbox_or_fallback(
-                    sandbox,
-                    dest_dir,
-                    relative_path,
+                // upstream: generator.c:2018-2020 atomic_create - when --backup
+                // is set and an existing item is being replaced, preserve it to
+                // the backup location before it is removed. On backup-mechanism
+                // failure upstream returns 0 from atomic_create (skips the
+                // entry); mirror that by logging and continuing.
+                match self.backup_existing_before_replace(
                     &node_path,
-                    fast_io::UnlinkFlags::File,
-                );
+                    relative_path,
+                    dest_dir,
+                    sandbox,
+                ) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        // SEC-1.g: route the obstacle unlink through the sandbox
+                        // dirfd when the destination parent is the sandbox root
+                        // so a TOCTOU swap between the stat above and this
+                        // unlink cannot redirect the syscall. Falls back to
+                        // path-based removal otherwise. The result is
+                        // intentionally ignored: a dangling obstacle simply
+                        // surfaces as a create failure below.
+                        let _ = fast_io::unlink_via_sandbox_or_fallback(
+                            sandbox,
+                            dest_dir,
+                            relative_path,
+                            &node_path,
+                            fast_io::UnlinkFlags::File,
+                        );
+                    }
+                    Err(error) => {
+                        debug_log!(
+                            Recv,
+                            1,
+                            "failed to back up existing special file {}: {}",
+                            node_path.display(),
+                            error
+                        );
+                        continue;
+                    }
+                }
 
                 // upstream: generator.c:1663 atomic_create -> do_mknod_at
                 let create_result = if is_device {

--- a/crates/transfer/src/receiver/tests/create_specials.rs
+++ b/crates/transfer/src/receiver/tests/create_specials.rs
@@ -133,6 +133,50 @@ fn receiver_creates_char_device_from_flist_entry() {
     );
 }
 
+/// With `--backup`, an existing destination entry must be preserved to the
+/// backup location before the receiver replaces it with a fresh special node.
+/// Here a regular file sits where a FIFO is about to be created: upstream's
+/// `atomic_create` (generator.c:2018-2020) calls `make_backup` before removing
+/// it, so the old content must survive at `pipe~` and the new FIFO must land at
+/// `pipe`. Without the backup wiring the receiver would unlink the old file and
+/// lose it silently.
+#[test]
+fn receiver_backs_up_existing_entry_before_creating_special() {
+    use std::os::unix::fs::FileTypeExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    // An existing regular file occupies the path the FIFO will replace.
+    std::fs::write(dest.join("pipe"), b"old-payload").expect("seed existing dest entry");
+
+    let mut config = special_receiver_config();
+    config.flags.backup = true;
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.file_list = vec![FileEntry::new_fifo("pipe".into(), 0o640)];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_specials(dest, None, &mut writer)
+        .expect("create_specials must succeed");
+
+    // The prior content is preserved under the default `~` suffix.
+    assert_eq!(
+        std::fs::read(dest.join("pipe~")).expect("backup must be created before replacement"),
+        b"old-payload",
+        "the pre-existing file must be preserved in the ~ backup, not silently unlinked",
+    );
+    // The fresh FIFO replaced the old entry.
+    assert!(
+        std::fs::symlink_metadata(dest.join("pipe"))
+            .expect("the FIFO must be materialised")
+            .file_type()
+            .is_fifo(),
+        "the receiver must create the FIFO node in place of the backed-up file",
+    );
+}
+
 /// Without `--specials` the receiver must not create a FIFO - the entry is left
 /// absent, matching upstream where `preserve_specials` gates FT_SPECIAL
 /// creation. This guards against the fix over-creating specials.

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -276,3 +276,44 @@ fn msg_info_sender_default_noop() {
     // Default impl should succeed silently
     w.send_msg_info(b"test data").unwrap();
 }
+
+/// With `--backup`, replacing an existing destination symlink must preserve the
+/// old link (its target intact) at the backup path before the new one is
+/// created. upstream: generator.c:2018-2020 - `atomic_create` calls
+/// `make_backup` before removing the obstacle; without this the receiver would
+/// unlink the old symlink and lose the user's prior target silently.
+#[test]
+#[cfg(unix)]
+fn receiver_backs_up_existing_symlink_before_replacing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    // An existing symlink with the OLD target occupies the destination path.
+    std::os::unix::fs::symlink("old-target", dest.join("mylink")).expect("seed old symlink");
+
+    let mut config = test_config();
+    config.flags.links = true;
+    config.flags.backup = true;
+    config.connection.client_mode = false;
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.file_list = vec![FileEntry::new_symlink("mylink".into(), "new-target".into())];
+
+    let mut writer = MockMsgInfoWriter::new();
+    ctx.create_symlinks(dest, None, &mut writer)
+        .expect("create_symlinks must succeed");
+
+    // The new target replaced the old link.
+    assert_eq!(
+        std::fs::read_link(dest.join("mylink")).expect("new symlink must exist"),
+        std::path::Path::new("new-target"),
+        "the receiver must install the new symlink target",
+    );
+    // The old link survives at the ~ backup with its original target.
+    assert_eq!(
+        std::fs::read_link(dest.join("mylink~")).expect("backup symlink must exist"),
+        std::path::Path::new("old-target"),
+        "the prior symlink target must be preserved in the ~ backup",
+    );
+}


### PR DESCRIPTION
## Summary

Two related `--backup` gaps in the network receiver's non-regular creation
paths, matched to upstream rsync 3.4.4 (`backup.c` / `generator.c:atomic_create`).

### Back up existing symlinks / FIFOs / sockets / devices before replacement

Upstream `generator.c:2005-2026` `atomic_create()` calls `make_backup(fname, ...)`
before replacing an existing item (`del_for_flag`) when `--backup` is set; only
with backup off does it fall through to `delete_item()`. oc-rsync's receiver
paths (`create_specials`, `create_symlinks`) unconditionally unlinked the
existing entry, silently losing it under `--backup`.

Now, when an existing destination entry is about to be replaced by a fresh
symlink, FIFO, socket, or device node and `--backup` is set, the old entry is
preserved to the backup location (`file~` or `<backup-dir>/...`) first. The
mechanism mirrors `backup.c:187-221` `link_or_rename()` with `prefer_rename = 0`
(upstream's default `atomic_create` with no `--temp-dir`): hard-link into the
backup area first, falling back to `rename(2)` when the type/filesystem cannot be
hard-linked (cross-device, or a platform without `CAN_HARDLINK_SYMLINK` /
`CAN_HARDLINK_SPECIAL`). The `backed up %s to %s` notice
(`backup.c:352-353`, `INFO_GTE(BACKUP, 1)`) is emitted as before.

### `make_backup: HLINK` debug trace

Upstream `backup.c:200-204` emits `"make_backup: HLINK %s successful.\n"` under
`DEBUG_GTE(BACKUP, 1)` on the `do_link` success branch of `link_or_rename`. The
trace helper already existed (`engine::trace_make_backup_hlink`) but had no call
site, so oc-rsync never emitted it. The new non-regular backup path now emits it
on the hard-link branch (byte-exact string, gated at `--debug=BACKUP` level 1),
alongside the existing `RENAME` trace on the fallback branch. On Linux, backing
up an existing symlink or special takes the hard-link branch, so HLINK fires;
this matches upstream's default `atomic_create` output.

## Tests

- `receiver::directory::backup` unit tests: an existing symlink and FIFO are
  preserved in the backup area (target/type intact); the `--debug=BACKUP`
  mechanism trace is emitted at level 1 (HLINK on Linux) and suppressed at
  level 0.
- `receiver::tests::create_specials::receiver_backs_up_existing_entry_before_creating_special`
  and `receiver::tests::symlinks_and_devices::receiver_backs_up_existing_symlink_before_replacing`:
  end-to-end wiring through `create_specials` / `create_symlinks` with `--backup`.
- Existing regular-file backup coverage (`uts_backup_suffix_and_dir`) is
  unchanged (no regression).

Device-node coverage degrades gracefully on unprivileged runners
(the existing `create_specials` device test already gates on a `mknod` probe).

## Notes

Scope is the receiver's non-regular creation paths. The regular-file network
backup (`disk_commit`) continues to use `rename` (`RENAME` trace); converting it
to hard-link-first is unsafe for the in-place path and is out of scope here.
