### PR TITLE
fix: forward --super/--stats on daemon push (SSH parity)

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -400,6 +400,12 @@ pub(super) fn build_full_daemon_args(
         if let Some(max) = config.max_file_size() {
             args.push(format!("--max-size={max}"));
         }
+
+        // upstream: options.c:2852-2857 - sender-only `--super` (am_root > 1)
+        // and `--stats` (do_stats). Shared with the SSH push builder via
+        // flags::sender_super_stats_args so both transports forward the same
+        // trailer on a push.
+        args.extend(flags::sender_super_stats_args(config).map(str::to_owned));
     }
 
     // upstream: options.c:2863-2864 - `if (max_alloc_arg && max_alloc !=

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -399,6 +399,89 @@ mod protect_args_daemon_tests {
         );
     }
 
+    // upstream: options.c:2852-2853 - `if (am_root > 1) --super`, inside the
+    // am_sender block. On a daemon push the client is the sender, so --super is
+    // forwarded to the remote receiver which performs the privileged operations.
+    // Shared with the SSH builder via flags::sender_super_stats_args.
+    #[test]
+    fn build_full_args_forwards_super_on_push_only() {
+        let config = ClientConfig::builder().super_user(true).build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+
+        // Push (is_sender=false => daemon is receiver, local side is sender).
+        let push = build_full_daemon_args(&config, &request, protocol, false);
+        assert!(
+            push.iter().any(|a| a == "--super"),
+            "daemon push must forward --super: {push:?}"
+        );
+
+        // Pull (is_sender=true => daemon is sender): --super is receiver-side and
+        // must not be forwarded to the remote sender.
+        let pull = build_full_daemon_args(&config, &request, protocol, true);
+        assert!(
+            !pull.iter().any(|a| a == "--super"),
+            "daemon pull must not forward --super: {pull:?}"
+        );
+
+        // Not requested: never forwarded.
+        let off = ClientConfig::default();
+        let args = build_full_daemon_args(&off, &request, protocol, false);
+        assert!(!args.iter().any(|a| a == "--super"));
+    }
+
+    // upstream: options.c:2856-2857 - `if (do_stats) --stats`, inside the
+    // am_sender block. Forwarded only on a daemon push, where the remote
+    // receiver/generator computes the transfer statistics.
+    #[test]
+    fn build_full_args_forwards_stats_on_push_only() {
+        let config = ClientConfig::builder().stats(true).build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+
+        let push = build_full_daemon_args(&config, &request, protocol, false);
+        assert!(
+            push.iter().any(|a| a == "--stats"),
+            "daemon push must forward --stats: {push:?}"
+        );
+
+        let pull = build_full_daemon_args(&config, &request, protocol, true);
+        assert!(
+            !pull.iter().any(|a| a == "--stats"),
+            "daemon pull must not forward --stats: {pull:?}"
+        );
+
+        let off = ClientConfig::default();
+        let args = build_full_daemon_args(&off, &request, protocol, false);
+        assert!(!args.iter().any(|a| a == "--stats"));
+    }
+
+    // WHY: the daemon push builder must emit the sender-only --super/--stats
+    // trailer with the same spelling and adjacency as the SSH push builder,
+    // since both consume flags::sender_super_stats_args. This encodes the
+    // SSH<->daemon parity that task #48 established for the SSH path.
+    #[test]
+    fn build_full_args_super_stats_match_ssh_push_order() {
+        let config = ClientConfig::builder().super_user(true).stats(true).build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, false);
+
+        let super_pos = args
+            .iter()
+            .position(|a| a == "--super")
+            .expect("--super must be present");
+        let stats_pos = args
+            .iter()
+            .position(|a| a == "--stats")
+            .expect("--stats must be present");
+        assert_eq!(
+            stats_pos,
+            super_pos + 1,
+            "--super must immediately precede --stats: {args:?}"
+        );
+    }
+
     #[test]
     fn build_full_args_omits_missing_args_by_default() {
         let config = ClientConfig::default();

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -177,6 +177,25 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     flags
 }
 
+/// Sender-only `--super`/`--stats` server args, shared by the SSH and
+/// daemon-push argument builders.
+///
+/// upstream: options.c:2852-2857 server_options() - inside the `if (am_sender)`
+/// block, `--super` is appended when `am_root > 1` (an explicit `--super`, never
+/// mere root) and `--stats` when `do_stats`. Both are forwarded only on a push,
+/// where the remote receiver/generator performs the privileged operations and
+/// computes the transfer statistics. Callers invoke this only from their sender
+/// branch so both transports emit the same trailer in the same order.
+/// `--fake-super` (am_root == -1) is receiver-local and is never forwarded.
+pub(crate) fn sender_super_stats_args(config: &ClientConfig) -> impl Iterator<Item = &'static str> {
+    [
+        config.super_user().then_some("--super"),
+        config.stats().then_some("--stats"),
+    ]
+    .into_iter()
+    .flatten()
+}
+
 /// Converts client filter rules to wire format.
 ///
 /// Maps [`FilterRuleSpec`] (client-side representation) to [`FilterRuleWireFormat`]

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -16,6 +16,7 @@ use super::super::super::config::{
     ClientConfig, DeleteMode, IconvSetting, ReferenceDirectoryKind, StrongChecksumAlgorithm,
     TransferTimeout,
 };
+use super::super::flags;
 use super::super::output_option::{OutputWordKind, make_output_option};
 use super::{RemoteRole, SecludedInvocation};
 use transfer::setup::build_capability_string_suffix;
@@ -546,12 +547,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // made the remote stat source paths under fake-super semantics, which
         // upstream never does.
         if self.role == RemoteRole::Sender {
-            if self.config.super_user() {
-                args.push(OsString::from("--super"));
-            }
-            if self.config.stats() {
-                args.push(OsString::from("--stats"));
-            }
+            args.extend(flags::sender_super_stats_args(self.config).map(OsString::from));
         }
 
         // upstream: options.c:2646-2649 - --omit-dir-times ('O') and


### PR DESCRIPTION
## Summary

Forward `--super` and `--stats` to the peer on a **daemon push**, matching the
behaviour already implemented for the SSH path. Both flags are sender-only
server args in upstream `server_options()`; the daemon-push argument builder was
the only push path that omitted them.

## Upstream reference

`options.c:2852-2857` `server_options()`, inside the `if (am_sender)` block:

```c
if (am_root > 1)
    args[ac++] = "--super";
if (size_only)
    args[ac++] = "--size-only";
if (do_stats)
    args[ac++] = "--stats";
```

- `--super` is appended when `am_root > 1` (an explicit `--super`, never mere
  root).
- `--stats` is appended when `do_stats`.
- Both live inside the `am_sender` block, so they are emitted only on a push,
  where the remote receiver/generator performs the privileged operations and
  computes the transfer statistics.
- `--fake-super` (`am_root == -1`) is receiver-local and is never forwarded.

Upstream shares a single `server_options()` for the SSH and daemon-push argv, so
the two paths must emit these identically.

## The divergence

oc has two server-arg builders in `crates/core`:

- SSH: `client/remote/invocation/builder.rs` — already forwarded `--super`/
  `--stats` (they were added for the SSH path).
- daemon push: `client/remote/daemon_transfer/orchestration/arguments.rs`
  (`build_full_daemon_args`) — its `am_sender` block stopped at
  `--min-size`/`--max-size` and never emitted `--super` or `--stats`.

So a daemon push dropped both flags, diverging from both upstream and the SSH
path.

## Fix (one shared mechanism)

Rather than duplicate the gating a third time, the sender-only `--super`/
`--stats` trailer is extracted into a single shared helper,
`flags::sender_super_stats_args(config)`, in the module already documented as
"shared flag builder functions ... shared between SSH and daemon transfer
orchestration". Both builders now consume it:

- SSH builder: `args.extend(sender_super_stats_args(self.config).map(OsString::from))`
- daemon builder: `args.extend(sender_super_stats_args(config).map(str::to_owned))`

This keeps the spelling, gating, and `--super`-before-`--stats` order in one
place, so the two transports can no longer drift.

## Tests

- `build_full_args_forwards_super_on_push_only` — daemon push emits `--super`;
  pull does not; absent when not requested.
- `build_full_args_forwards_stats_on_push_only` — same for `--stats`.
- `build_full_args_super_stats_match_ssh_push_order` — asserts `--super`
  immediately precedes `--stats`, encoding SSH/daemon parity.
- Existing SSH `ssh_forwards_super_on_push_only` / `ssh_forwards_stats_on_push_only`
  still pass after the refactor.

All targeted `-p core` tests pass; `cargo fmt --all` and
`cargo clippy -p core --all-targets --all-features --no-deps -D warnings` clean.
