### PR TITLE
fix: list all daemon modules regardless of host access

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/listing.rs
+++ b/crates/daemon/src/daemon/sections/module_access/listing.rs
@@ -20,38 +20,30 @@ fn format_module_listing_line(name: &str, comment: &str) -> String {
 /// Sends the list of available modules to a client.
 ///
 /// This responds to a module listing request by sending the names and comments
-/// of modules the peer is allowed to access. Only modules marked as listable and
-/// that permit the peer's IP address are included in the response. The MOTD is
-/// emitted earlier, right after the greeting, matching upstream's
-/// `exchange_protocols()` (clientserver.c:158-170).
+/// of every listable module. A module appears iff `list = yes` (the default);
+/// host access (`hosts allow`/`hosts deny`) is NOT applied here - it is enforced
+/// only when the client tries to open a module. A host denied access still sees
+/// the module in the listing, matching upstream. The MOTD is emitted earlier,
+/// right after the greeting, matching upstream's `exchange_protocols()`
+/// (clientserver.c:158-170).
 fn respond_with_module_list(
     stream: &mut DaemonStream,
     limiter: &mut Option<BandwidthLimiter>,
     modules: &[ModuleRuntime],
-    peer_ip: IpAddr,
-    reverse_lookup: bool,
     messages: &LegacyMessageCache,
 ) -> io::Result<()> {
-    // upstream: clientserver.c:1266-1272 send_listing() - the listing goes
-    // straight to the module names followed by @RSYNCD: EXIT. It does NOT send
-    // @RSYNCD: OK first, and the MOTD was already emitted after the greeting.
-
-    let mut hostname_cache: Option<Option<String>> = None;
+    // upstream: clientserver.c:1261-1272 send_listing() - the listing loops over
+    // every module and prints it iff `lp_list(i)`. No `allow_access()`/hosts
+    // check is applied; host filtering happens only in rsync_module() on the
+    // module-open path (clientserver.c:728). The listing goes straight to the
+    // module names followed by @RSYNCD: EXIT - it does NOT send @RSYNCD: OK
+    // first, and the MOTD was already emitted after the greeting.
     for module in modules {
         if !module.listable {
             continue;
         }
 
-        // upstream: clientserver.c:723 `lp_reverse_lookup(i)` - effective
-        // per-module value is the global default OR the module override.
-        let module_reverse_lookup = reverse_lookup || module.reverse_lookup;
-        let peer_host =
-            module_peer_hostname(module, &mut hostname_cache, peer_ip, module_reverse_lookup);
-        if !module.permits(peer_ip, peer_host) {
-            continue;
-        }
-
-        // upstream: clientserver.c:1254 - io_printf(fd, "%-15s\t%s\n", lp_name(i), lp_comment(i));
+        // upstream: clientserver.c:1267 - io_printf(fd, "%-15s\t%s\n", lp_name(i), lp_comment(i));
         let comment = module.comment.as_deref().unwrap_or("");
         let line = format_module_listing_line(&module.name, comment);
         write_limited(stream, limiter, line.as_bytes())?;

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -341,14 +341,7 @@ fn handle_legacy_session(
         if let Some(log) = log_sink.as_ref() {
             log_list_request(log, peer_host.as_deref(), peer_addr);
         }
-        respond_with_module_list(
-            reader.get_mut(),
-            &mut limiter,
-            modules,
-            peer_addr.ip(),
-            reverse_lookup,
-            messages,
-        )?;
+        respond_with_module_list(reader.get_mut(), &mut limiter, modules, messages)?;
         // FSM: -> Closing after sending the module list and EXIT.
         _ = conn_state
             .transition(ConnectionState::Closing)

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -196,7 +196,7 @@ include!("tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs");
 include!("tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs");
 include!("tests/chunks/run_daemon_enforces_module_connection_limit.rs");
 include!("tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs");
-include!("tests/chunks/run_daemon_filters_modules_during_list_request.rs");
+include!("tests/chunks/run_daemon_lists_host_denied_module.rs");
 include!("tests/chunks/run_daemon_handles_binary_negotiation.rs");
 include!("tests/chunks/run_daemon_handles_parallel_sessions.rs");
 include!("tests/chunks/run_daemon_honours_max_sessions.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_host_denied_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_host_denied_module.rs
@@ -1,5 +1,5 @@
 #[test]
-fn run_daemon_filters_modules_during_list_request() {
+fn run_daemon_lists_host_denied_module() {
     let _lock = ENV_LOCK.lock().expect("env lock");
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
@@ -10,6 +10,9 @@ fn run_daemon_filters_modules_during_list_request() {
     // so the daemon module-arg parser doesn't swallow escapes (see PR #4560).
     let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
     let mut file = NamedTempFile::new().expect("config file");
+    // `private` restricts access to 10.0.0.0/8, so the loopback client is
+    // denied on connect. It is still `list = yes` (the default), so it MUST
+    // appear in the listing. Visibility and access are separate concerns.
     writeln!(
         file,
         "[public]\npath = {module_path}\n\n[private]\npath = {module_path}\nhosts allow = 10.0.0.0/8\n",
@@ -38,18 +41,25 @@ fn run_daemon_filters_modules_during_list_request() {
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush list request");
 
+    // upstream: clientserver.c:1261-1272 send_listing() lists every module with
+    // `list = yes` and applies NO hosts allow/deny filtering. The host-denied
+    // `private` module therefore appears alongside `public`; the deny only
+    // takes effect on the module-open path (clientserver.c:728 allow_access).
     line.clear();
     reader.read_line(&mut line).expect("public module");
     assert_eq!(line, "public         \t\n");
 
     line.clear();
+    reader.read_line(&mut line).expect("host-denied private module");
+    assert_eq!(line, "private        \t\n");
+
+    line.clear();
     reader
         .read_line(&mut line)
-        .expect("exit line after accessible modules");
+        .expect("exit line after all listable modules");
     assert_eq!(line, "@RSYNCD: EXIT\n");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
     assert!(result.is_ok());
 }
-


### PR DESCRIPTION
## Summary

The daemon module listing must show every listable module regardless of the
connecting client's host access, matching upstream rsync 3.4.4.

Upstream `send_listing()` (`clientserver.c:1261-1272`) loops over all modules
and prints each one iff `lp_list(i)` is true (`list = yes`, the default). It
applies **no** `hosts allow`/`hosts deny` filtering to the listing. Host access
is enforced only when a client tries to **open** a module, in `rsync_module()`
via `allow_access()` (`clientserver.c:728`). Consequently a host denied access
to a module still sees it in the listing (unless `list = no`), and a `list = no`
module is hidden from the listing but remains connectable.

oc's `respond_with_module_list` incorrectly filtered the listing by the peer's
`hosts allow`/`hosts deny`, hiding modules the client could not access.

## Change

- Remove host-access filtering (`permits`/`module_peer_hostname`) from
  `respond_with_module_list`; the listing now depends on `list` only.
- Drop the now-unused `peer_ip` and `reverse_lookup` parameters from the
  listing function and its single caller.
- The connect-time access check (`request.rs` `module.permits`, mirroring
  `allow_access`) is untouched and remains fail-closed. No change to
  connect-time security.

## Tests

- Repurposed the former host-filter listing test into
  `run_daemon_lists_host_denied_module`: a `hosts allow = 10.0.0.0/8` module
  (which denies the loopback client) now **appears** in the listing alongside an
  unrestricted module, proving the listing is not host-filtered.
- `run_daemon_denies_module_when_host_not_allowed` and
  `daemon_negotiation_error_host_allow_blocks_unlisted` remain unchanged and
  guard that connecting to a host-denied module still returns
  `@ERROR: access denied` (security regression guard).
- `run_daemon_omits_unlisted_modules_from_listing` remains unchanged and guards
  that `list = no` modules stay hidden from the listing.

Visibility and access are separate concerns: a host-denied module is visible in
the listing but refused on connect.
