### PR TITLE
fix(transfer): defer --delete-delay unlink to after transfer

### DIFF
--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -126,11 +126,14 @@ pub struct DeletionConfig {
     /// NOT set for `--delete-delay` (`delete_during == 2`): upstream makes the
     /// delete *decision* during the walk (delete_in_dir via remember_delete,
     /// generator.c:2315-2327) - before that directory's `.rsync-filter` has been
-    /// received - and defers only the physical unlink. Its observable file
-    /// outcome therefore matches `--delete-during` / `--delete-before`, so oc
-    /// runs the delete pass early for delay just like those modes. This is
-    /// distinct from [`late_delete`] (delay || after), which governs only the
-    /// goodbye NDX_DEL_STATS timing.
+    /// received - so its victim set matches `--delete-during` / `--delete-before`,
+    /// but it defers the physical unlink to `do_delayed_deletions()` after the
+    /// whole transfer (generator.c:2419). The receiver therefore *collects* the
+    /// delay victims at the early site and *executes* them at the late site (a
+    /// mid-transfer abort leaves them in place), rather than deferring the
+    /// decision the way `--delete-after` does. This is distinct from
+    /// [`late_delete`] (delay || after), which additionally governs the goodbye
+    /// NDX_DEL_STATS timing and gates the late delete site.
     ///
     /// Verified empirically vs upstream 3.4.4: over SSH (inc-recurse), delay
     /// DELETES a per-dir-merge-protected entry while after PROTECTS it.

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -249,6 +249,23 @@ pub struct ReceiverContext {
     /// redo re-itemizing an entry. `RefCell` suffices: every emit site runs on
     /// the main driver thread (rayon workers never touch this).
     pub(in crate::receiver) itemize_rows: RefCell<BTreeMap<usize, Vec<String>>>,
+    /// Extraneous-entry victims decided during the transfer walk for a
+    /// `--delete-delay` run, awaiting execution after the transfer completes.
+    ///
+    /// Populated by [`collect_delayed_deletions`] at the early (pre-loop) delete
+    /// site and drained by [`execute_delayed_deletions`] at the late site, so the
+    /// deletion *decision* uses the DURING-time destination state while the
+    /// physical unlink is postponed to the end of the run. Empty for every other
+    /// delete mode.
+    ///
+    /// upstream: generator.c:157 `remember_delete()` fills the delete-delay buffer
+    /// during the walk; generator.c:2419 `do_delayed_deletions()` flushes it after
+    /// `generate_files()` finishes.
+    ///
+    /// [`collect_delayed_deletions`]: Self::collect_delayed_deletions
+    /// [`execute_delayed_deletions`]: Self::execute_delayed_deletions
+    pub(in crate::receiver) delayed_delete_victims:
+        Vec<crate::receiver::directory::deletion::DeletedEntry>,
 }
 
 impl ReceiverContext {
@@ -317,6 +334,7 @@ impl ReceiverContext {
             hardlink_lookahead_target: 500,
             defer_itemize: false,
             itemize_rows: RefCell::new(BTreeMap::new()),
+            delayed_delete_victims: Vec::new(),
         }
     }
 

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -28,13 +28,18 @@ use crate::receiver::ReceiverContext;
 /// workers so its `deleting`/`*deleting` line can be emitted in upstream's
 /// deterministic per-directory sorted order rather than the hash-random
 /// order the `HashMap`-keyed scan set would otherwise produce.
-struct DeletedEntry {
+#[derive(Debug)]
+pub(in crate::receiver) struct DeletedEntry {
     /// Path relative to the deletion root, as printed by upstream
     /// `log_delete()` (top-level entries are bare names, not `./name`).
     rel: PathBuf,
     /// Whether the entry is a directory. Directories sort after files at a
     /// given level (upstream `t_PATH`) and print with a trailing slash.
     is_dir: bool,
+    /// Whether the entry is a symlink. Carried so the deferred `--delete-delay`
+    /// executor can classify the removal into `DeleteStats.symlinks`, matching
+    /// the inline per-type counting the immediate pass performs from `read_dir`.
+    is_symlink: bool,
 }
 
 /// Orders deleted entries to match upstream's observable delete stream.
@@ -132,7 +137,164 @@ fn make_entry(path: &Path, is_dir: bool) -> FileEntry {
 }
 
 impl ReceiverContext {
-    /// Deletes extraneous files at the destination that are not in the received file list.
+    /// Deletes extraneous destination entries immediately: scan, unlink, and emit
+    /// the `deleting`/`*deleting` lines in one pass. Used by `--delete-before`,
+    /// `--delete-during`, and `--delete-after` (and a capped/`--one-file-system`
+    /// `--delete-delay`, which cannot defer through the serial executor).
+    ///
+    /// Returns `(stats, limit_exceeded, io_error_bits)`.
+    pub(in crate::receiver) fn delete_extraneous_files<W: crate::writer::MsgInfoSender + ?Sized>(
+        &self,
+        dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&std::sync::Arc<fast_io::DirSandbox>>,
+        writer: &mut W,
+    ) -> io::Result<(DeleteStats, bool, i32)> {
+        let (stats, limit_exceeded, io_bits, _victims) = self.run_delete_scan(
+            dest_dir,
+            #[cfg(unix)]
+            sandbox,
+            writer,
+            false,
+        )?;
+        Ok((stats, limit_exceeded, io_bits))
+    }
+
+    /// Decides the `--delete-delay` victim set during the transfer walk WITHOUT
+    /// unlinking or emitting anything, returning the entries in upstream's
+    /// deterministic emission order for a later [`execute_delayed_deletions`].
+    ///
+    /// upstream: generator.c:157 `remember_delete()` records each doomed entry
+    /// into the delete-delay buffer from inside `delete_in_dir()` while the
+    /// destination `.rsync-filter` merge files are in their DURING-time state;
+    /// only the physical unlink is postponed to `do_delayed_deletions()`
+    /// (generator.c:2419). Deciding here - not at flush time - keeps the victim
+    /// set identical to `--delete-during` even though the unlink runs late.
+    ///
+    /// [`execute_delayed_deletions`]: Self::execute_delayed_deletions
+    pub(in crate::receiver) fn collect_delayed_deletions<
+        W: crate::writer::MsgInfoSender + ?Sized,
+    >(
+        &self,
+        dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&std::sync::Arc<fast_io::DirSandbox>>,
+        writer: &mut W,
+    ) -> io::Result<(Vec<DeletedEntry>, i32)> {
+        let (_stats, _limit, io_bits, victims) = self.run_delete_scan(
+            dest_dir,
+            #[cfg(unix)]
+            sandbox,
+            writer,
+            true,
+        )?;
+        Ok((victims, io_bits))
+    }
+
+    /// Executes a previously [collected](Self::collect_delayed_deletions)
+    /// `--delete-delay` victim set: unlinks each entry and emits its
+    /// `deleting`/`*deleting` line, in the order the collector fixed.
+    ///
+    /// upstream: generator.c:2419 `do_delayed_deletions()` runs after the whole
+    /// transfer completes and calls `delete_item()` (which logs and unlinks) for
+    /// each remembered victim. Counting happens here, at unlink time, matching
+    /// upstream's `stats.deleted_*` increments inside `delete_item`.
+    pub(in crate::receiver) fn execute_delayed_deletions<
+        W: crate::writer::MsgInfoSender + ?Sized,
+    >(
+        &self,
+        dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&std::sync::Arc<fast_io::DirSandbox>>,
+        victims: &[DeletedEntry],
+        writer: &mut W,
+    ) -> io::Result<(DeleteStats, i32)> {
+        #[cfg(unix)]
+        let sandbox_ref = sandbox.map(|arc| arc.as_ref());
+        let mut stats = DeleteStats::new();
+        let mut io_bits: i32 = 0;
+        let emit_itemize = self.should_emit_itemize();
+        for entry in victims {
+            let path = dest_dir.join(&entry.rel);
+            let result = if entry.is_dir {
+                // upstream: delete.c:delete_item() -> delete_dir_contents() for a
+                // directory victim; recursive removal mirrors the immediate pass.
+                #[cfg(unix)]
+                {
+                    fast_io::recursive_unlinkat_via_sandbox_or_fallback(
+                        sandbox_ref,
+                        dest_dir,
+                        &entry.rel,
+                        &path,
+                    )
+                }
+                #[cfg(not(unix))]
+                {
+                    std::fs::remove_dir_all(&path)
+                }
+            } else {
+                #[cfg(unix)]
+                {
+                    fast_io::unlink_via_sandbox_or_fallback(
+                        sandbox_ref,
+                        dest_dir,
+                        &entry.rel,
+                        &path,
+                        fast_io::UnlinkFlags::File,
+                    )
+                }
+                #[cfg(not(unix))]
+                {
+                    std::fs::remove_file(&path)
+                }
+            };
+            match result {
+                Ok(()) => {
+                    if entry.is_dir {
+                        stats.dirs += 1;
+                        info_log!(Del, 1, "deleting {}/", entry.rel.display());
+                    } else {
+                        if entry.is_symlink {
+                            stats.symlinks += 1;
+                        } else {
+                            stats.files += 1;
+                        }
+                        info_log!(Del, 1, "deleting {}", entry.rel.display());
+                    }
+                    if emit_itemize {
+                        let line = format!("*deleting   {}\n", entry.rel.display());
+                        let _ = writer.send_msg_info(line.as_bytes());
+                    }
+                }
+                Err(e) => {
+                    debug_log!(Del, 1, "failed to delete {}: {}", path.display(), e);
+                    if fail_loud_unlink_error(e).is_some() {
+                        io_bits |= crate::generator::io_error_flags::IOERR_GENERAL;
+                    }
+                }
+            }
+        }
+        Ok((stats, io_bits))
+    }
+
+    /// Reports whether the delete pass routes through the serial, leaf-granular
+    /// executor (`--max-delete` cap or `--one-file-system` boundary) rather than
+    /// the parallel fast path.
+    ///
+    /// `--delete-delay` can only collect-then-execute on the parallel path; a
+    /// capped or one-file-system delay run enforces its cap/boundary inline, so
+    /// it stays on the immediate early pass. Mirrors the engine crate's
+    /// `delay_decides_during` gate, which likewise excludes `--max-delete`.
+    pub(in crate::receiver) fn delete_pass_uses_serial_executor(&self) -> bool {
+        #[cfg(unix)]
+        {
+            self.config.deletion.max_delete.is_some() || self.config.flags.one_file_system >= 1
+        }
+        #[cfg(not(unix))]
+        {
+            self.config.deletion.max_delete.is_some()
+        }
+    }
+
+    /// Scans the destination for extraneous entries and, unless `collect_only`,
+    /// unlinks them and emits their `deleting`/`*deleting` lines.
     ///
     /// Groups file list entries by parent directory, then for each destination directory,
     /// scans for entries not present in the source list and removes them. Directories
@@ -150,8 +312,11 @@ impl ReceiverContext {
     /// every site falls back to the path-based `std::fs` syscalls and is
     /// byte-identical to the pre-SEC-1.q2 behaviour.
     ///
-    /// Returns `(stats, limit_exceeded)` where `limit_exceeded` is true when deletions
-    /// were stopped due to `--max-delete`.
+    /// When `collect_only` is true the pass records each victim but performs no
+    /// unlink and no emission, returning the ordered victim list for a deferred
+    /// `--delete-delay` execution (upstream `remember_delete()`).
+    ///
+    /// Returns `(stats, limit_exceeded, io_error_bits, ordered_victims)`.
     ///
     /// # Upstream Reference
     ///
@@ -159,12 +324,13 @@ impl ReceiverContext {
     /// - `generator.c:do_delete_pass()` - full tree walk deletion sweep
     /// - `main.c:1367` - `deletion_count >= max_delete` check
     /// - `exclude.c:check_filter()` - is_excluded() before deletion
-    pub(in crate::receiver) fn delete_extraneous_files<W: crate::writer::MsgInfoSender + ?Sized>(
+    fn run_delete_scan<W: crate::writer::MsgInfoSender + ?Sized>(
         &self,
         dest_dir: &Path,
         #[cfg(unix)] sandbox: Option<&std::sync::Arc<fast_io::DirSandbox>>,
         writer: &mut W,
-    ) -> io::Result<(DeleteStats, bool, i32)> {
+        collect_only: bool,
+    ) -> io::Result<(DeleteStats, bool, i32, Vec<DeletedEntry>)> {
         use std::collections::{HashMap, HashSet};
         use std::path::PathBuf;
         use std::sync::Arc;
@@ -358,7 +524,15 @@ impl ReceiverContext {
             // unreachable u64::MAX sentinel keeps the executor's guard-before-
             // delete logic intact without ever tripping the limit warning.
             let limit = max_delete.unwrap_or(u64::MAX);
-            return self.delete_extraneous_files_capped(
+            // The serial executor unlinks inline, so a `--delete-delay` run that
+            // reaches it cannot defer; the caller keeps such a run on the
+            // immediate early pass (see `delete_pass_uses_serial_executor`), and
+            // `collect_only` is never set here.
+            debug_assert!(
+                !collect_only,
+                "delayed collection never uses the serial executor"
+            );
+            let (stats, limit_exceeded, io_bits) = self.delete_extraneous_files_capped(
                 dest_dir,
                 &dir_children,
                 &dirs_to_scan,
@@ -370,7 +544,8 @@ impl ReceiverContext {
                 limit,
                 #[cfg(unix)]
                 boundary_dev,
-            );
+            )?;
+            return Ok((stats, limit_exceeded, io_bits, Vec::new()));
         }
 
         // Atomic counter for max_delete enforcement across parallel workers.
@@ -613,7 +788,13 @@ impl ReceiverContext {
                             type_bits
                         );
 
-                        let result = if is_dir {
+                        // upstream: generator.c:345 `delete_during == 2` records
+                        // the victim via remember_delete() and defers the unlink;
+                        // in collect_only mode the worker only records the entry so
+                        // the physical removal runs later in do_delayed_deletions().
+                        let result = if collect_only {
+                            Ok(())
+                        } else if is_dir {
                             // SEC-1.q2 audit row #6
                             #[cfg(unix)]
                             {
@@ -671,7 +852,11 @@ impl ReceiverContext {
                                 // `order_deletions_upstream`); workers only
                                 // record what was deleted so the unlinks stay
                                 // parallel.
-                                deleted_paths.push(DeletedEntry { rel, is_dir });
+                                deleted_paths.push(DeletedEntry {
+                                    rel,
+                                    is_dir,
+                                    is_symlink,
+                                });
                             }
                             Err(e) => {
                                 debug_log!(Del, 1, "failed to delete {}: {}", path.display(), e);
@@ -722,21 +907,29 @@ impl ReceiverContext {
         // identical to upstream without serializing the unlinks.
         // upstream: log.c:log_delete() emits one line per deleted item.
         let all_deleted = order_deletions_upstream(all_deleted);
-        let emit_itemize = self.should_emit_itemize();
-        for entry in &all_deleted {
-            // upstream: log.c:845 log_delete uses one "deleting %n" form; %n
-            // (log.c:633-641) appends a trailing slash for directories, so a
-            // dir prints "deleting sub/" - no word "directory".
-            if entry.is_dir {
-                info_log!(Del, 1, "deleting {}/", entry.rel.display());
-            } else {
-                info_log!(Del, 1, "deleting {}", entry.rel.display());
-            }
-            // upstream: log.c:log_delete() emits the "*deleting" itemize line
-            // for each deleted item when --itemize-changes is active.
-            if emit_itemize {
-                let line = format!("*deleting   {}\n", entry.rel.display());
-                let _ = writer.send_msg_info(line.as_bytes());
+        // In collect_only mode nothing has been unlinked yet: skip emission so
+        // the `deleting`/`*deleting` lines appear only when the deferred
+        // `--delete-delay` executor actually removes each victim, matching
+        // upstream where log_delete() fires from delete_item() inside
+        // do_delayed_deletions() (generator.c:2419), not at remember_delete()
+        // time. The ordered victim list is returned for that later execution.
+        if !collect_only {
+            let emit_itemize = self.should_emit_itemize();
+            for entry in &all_deleted {
+                // upstream: log.c:845 log_delete uses one "deleting %n" form; %n
+                // (log.c:633-641) appends a trailing slash for directories, so a
+                // dir prints "deleting sub/" - no word "directory".
+                if entry.is_dir {
+                    info_log!(Del, 1, "deleting {}/", entry.rel.display());
+                } else {
+                    info_log!(Del, 1, "deleting {}", entry.rel.display());
+                }
+                // upstream: log.c:log_delete() emits the "*deleting" itemize line
+                // for each deleted item when --itemize-changes is active.
+                if emit_itemize {
+                    let line = format!("*deleting   {}\n", entry.rel.display());
+                    let _ = writer.send_msg_info(line.as_bytes());
+                }
             }
         }
 
@@ -748,7 +941,7 @@ impl ReceiverContext {
             + u64::from(combined.specials);
         let limit_exceeded = max_delete.is_some_and(|limit| total_deletions >= limit);
 
-        Ok((combined, limit_exceeded, io_err_bits))
+        Ok((combined, limit_exceeded, io_err_bits, all_deleted))
     }
 
     /// Serial, leaf-granular deletion path used when `--max-delete` is set.
@@ -1351,6 +1544,7 @@ mod tests {
         DeletedEntry {
             rel: PathBuf::from(rel),
             is_dir,
+            is_symlink: false,
         }
     }
 

--- a/crates/transfer/src/receiver/directory/mod.rs
+++ b/crates/transfer/src/receiver/directory/mod.rs
@@ -8,7 +8,9 @@
 
 mod backup;
 mod creation;
-mod deletion;
+// `pub(in crate::receiver)` so the receiver context can name `DeletedEntry`
+// for its deferred `--delete-delay` victim queue.
+pub(in crate::receiver) mod deletion;
 mod links;
 mod missing_args;
 mod special;

--- a/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
+++ b/crates/transfer/src/receiver/tests/file_list/delete_timing.rs
@@ -25,41 +25,58 @@ use super::super::super::ReceiverContext;
 use super::super::support::{TestDeletionWriter, test_config, test_handshake};
 
 /// The early/late routing predicates must partition the four delete modes the
-/// way upstream does: only `--delete-after` (`delete_after`) defers the delete
-/// *decision* to after the transfer (generator.c:2427-2428); `--delete-before`,
-/// `--delete-during`, AND `--delete-delay` all decide early. `--delete-delay`
-/// belongs with the early group because upstream makes its decision during the
-/// walk (generator.c:2315) and defers only the unlink - verified vs upstream
-/// 3.4.4 over SSH, where delay DELETES a per-dir-merge-protected entry exactly
-/// as during/before do, while after PROTECTS it. A regression that deferred
-/// delay would over-protect (keep files upstream deletes); one that failed to
-/// defer after would reintroduce the #280 data loss. The sweep runs exactly
-/// once when `--delete` is set (never both, never neither).
+/// way upstream does:
+///
+/// - `--delete-before` / `--delete-during`: EARLY only (immediate pre-loop
+///   sweep, generator.c:2280 / 2315).
+/// - `--delete-after`: LATE only (`do_delete_pass()` after the transfer,
+///   generator.c:2427).
+/// - `--delete-delay`: BOTH sites. Upstream decides the victim set during the
+///   walk (generator.c:2315 `remember_delete`) but unlinks them only in
+///   `do_delayed_deletions()` after the whole transfer (generator.c:2419), so
+///   oc collects at the early site and executes at the late site. Verified vs
+///   upstream 3.4.4 over SSH: delay DELETES a per-dir-merge-protected entry
+///   (its decision matches during/before), yet the unlink is deferred to the
+///   end (a mid-transfer abort leaves the stale file in place).
+///
+/// A regression that dropped delay from the early site would decide too late
+/// (over-protecting merge-shielded entries like `--delete-after`); one that
+/// dropped it from the late site would unlink during the transfer (losing the
+/// crash-safety upstream guarantees). The sweep never runs when `--delete` is
+/// off, regardless of stale deferral bits.
 #[test]
 fn delete_pass_timing_predicates_partition_the_four_modes() {
     let handshake = test_handshake();
 
-    // --delete-before / --delete-during / --delete-delay: delete on, but the
-    // decision is NOT deferred (`delete_after` off). late_delete may be set for
-    // delay (it governs only goodbye del-stats), which must not affect routing.
-    for (label, late_delete) in [("before/during", false), ("delay", true)] {
-        let mut early = test_config();
-        early.flags.delete = true;
-        early.deletion.delete_after = false;
-        early.deletion.late_delete = late_delete;
-        let ctx = ReceiverContext::new_for_test(&handshake, early);
-        assert!(ctx.delete_pass_is_early(), "{label} must sweep early");
-        assert!(!ctx.delete_pass_is_late(), "{label} must not sweep late");
-    }
+    // --delete-before / --delete-during: EARLY only.
+    let mut early = test_config();
+    early.flags.delete = true;
+    early.deletion.delete_after = false;
+    early.deletion.late_delete = false;
+    let ctx = ReceiverContext::new_for_test(&handshake, early);
+    assert!(ctx.delete_pass_is_early(), "before/during must run early");
+    assert!(
+        !ctx.delete_pass_is_late(),
+        "before/during must not run late"
+    );
 
-    // --delete-after: delete on, decision deferred.
+    // --delete-delay: BOTH sites (collect early, execute late).
+    let mut delay = test_config();
+    delay.flags.delete = true;
+    delay.deletion.delete_after = false;
+    delay.deletion.late_delete = true;
+    let ctx = ReceiverContext::new_for_test(&handshake, delay);
+    assert!(ctx.delete_pass_is_early(), "delay must collect early");
+    assert!(ctx.delete_pass_is_late(), "delay must execute late");
+
+    // --delete-after: LATE only (decision deferred).
     let mut late = test_config();
     late.flags.delete = true;
     late.deletion.late_delete = true;
     late.deletion.delete_after = true;
     let ctx = ReceiverContext::new_for_test(&handshake, late);
-    assert!(!ctx.delete_pass_is_early(), "after must not sweep early");
-    assert!(ctx.delete_pass_is_late(), "after must sweep late");
+    assert!(!ctx.delete_pass_is_early(), "after must not run early");
+    assert!(ctx.delete_pass_is_late(), "after must run late");
 
     // No --delete: neither site fires, regardless of the deferral bits (which a
     // stale config could still carry). The sweep must never run unrequested.
@@ -67,12 +84,116 @@ fn delete_pass_timing_predicates_partition_the_four_modes() {
         let mut off = test_config();
         off.flags.delete = false;
         off.deletion.delete_after = delete_after;
+        off.deletion.late_delete = delete_after;
         let ctx = ReceiverContext::new_for_test(&handshake, off);
         assert!(
             !ctx.delete_pass_is_early() && !ctx.delete_pass_is_late(),
             "no --delete => no sweep (delete_after={delete_after})"
         );
     }
+}
+
+/// The load-bearing `--delete-during` vs `--delete-delay` timing distinction:
+/// during unlinks an extraneous file as its directory is processed, while delay
+/// only *records* the victim during the walk and unlinks it after the whole
+/// transfer completes. This is upstream's crash-safety guarantee for delay
+/// (generator.c:345 `remember_delete` vs generator.c:2419
+/// `do_delayed_deletions`): if the transfer aborts mid-way, a delay run has not
+/// deleted anything yet, whereas a during run already has.
+///
+/// The test proves the distinction directly: `collect_delayed_deletions`
+/// (delay's early phase) must leave the stale file ON DISK - standing in for the
+/// mid-transfer state - while returning it as a pending victim; only
+/// `execute_delayed_deletions` (delay's late phase) removes it. An immediate
+/// sweep (during/before) removes the very same file in a single call. Both modes
+/// converge on the identical final set: stale gone, listed file kept.
+#[test]
+fn delete_delay_defers_unlink_until_execute_phase() {
+    let handshake = test_handshake();
+
+    // Shared destination layout builder: one extraneous file plus one listed
+    // file that must always survive. Returns a receiver whose file list carries
+    // only the survivor, making `stale.txt` an extraneous deletion candidate.
+    let build = |dest: &std::path::Path| {
+        std::fs::write(dest.join("stale.txt"), b"extraneous").unwrap();
+        std::fs::write(dest.join("keep.txt"), b"listed").unwrap();
+        let mut config = test_config();
+        config.flags.delete = true;
+        config.deletion.delete_after = false;
+        config.deletion.late_delete = true; // --delete-delay
+        config.args = vec![OsString::from(dest.to_str().unwrap())];
+        let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+        ctx.file_list
+            .push(FileEntry::new_directory(".".into(), 0o755));
+        ctx.file_list
+            .push(FileEntry::new_file("keep.txt".into(), 6, 0o644));
+        ctx
+    };
+
+    // --delete-delay: collect must NOT unlink (mid-transfer crash-safety).
+    let delay_dir = tempfile::TempDir::new().unwrap();
+    let dest = delay_dir.path();
+    let ctx = build(dest);
+    let mut writer = TestDeletionWriter;
+    let (victims, _io) = ctx
+        .collect_delayed_deletions(
+            dest,
+            #[cfg(unix)]
+            None,
+            &mut writer,
+        )
+        .unwrap();
+    assert!(
+        dest.join("stale.txt").exists(),
+        "delay must NOT unlink during collection - the file survives a mid-transfer abort",
+    );
+    assert!(!victims.is_empty(), "delay must record the pending victim");
+
+    // The late phase executes the recorded victims: now the file is gone.
+    let (stats, _io) = ctx
+        .execute_delayed_deletions(
+            dest,
+            #[cfg(unix)]
+            None,
+            &victims,
+            &mut writer,
+        )
+        .unwrap();
+    assert!(
+        !dest.join("stale.txt").exists(),
+        "delay must unlink the recorded victim at the execute (late) phase",
+    );
+    assert_eq!(stats.files, 1, "exactly one extraneous file deleted");
+    assert!(
+        dest.join("keep.txt").exists(),
+        "listed file must survive delay"
+    );
+
+    // --delete-during / --delete-before: an immediate sweep removes the same
+    // stale file in one call, and the surviving set is identical.
+    let during_dir = tempfile::TempDir::new().unwrap();
+    let dest2 = during_dir.path();
+    let ctx2 = build(dest2);
+    let (during_stats, _, _) = ctx2
+        .delete_extraneous_files(
+            dest2,
+            #[cfg(unix)]
+            None,
+            &mut writer,
+        )
+        .unwrap();
+    assert!(
+        !dest2.join("stale.txt").exists(),
+        "during/before unlinks the stale file immediately",
+    );
+    assert_eq!(
+        during_stats.files, stats.files,
+        "during and delay must delete the identical final set",
+    );
+    assert!(
+        dest2.join("keep.txt").exists(),
+        "listed file must survive during"
+    );
 }
 
 /// Builds the destination tree and receiver used by both invariant tests: a

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -133,59 +133,144 @@ impl ReceiverContext {
         }
     }
 
-    /// True when the delete pass runs EARLY, before the per-file transfer loop.
+    /// True when the delete pass has work to do at the EARLY site, before the
+    /// per-file transfer loop.
     ///
-    /// Covers `--delete-before`, `--delete-during`, AND `--delete-delay`. Mirrors
-    /// upstream generator.c:2280-2281 (`delete_before` runs `do_delete_pass()` up
-    /// front) and generator.c:2315-2327 (`delete_during` / `delete_during == 2`
-    /// decide as each directory is entered during the loop). oc collapses these
-    /// into one pre-loop sweep; the observable file outcome matches because none
-    /// of these modes has the destination `.rsync-filter` merge files present
-    /// when the deletion decision is made. `--delete-delay` defers only the
-    /// physical unlink upstream, not the decision, so its kept/deleted set equals
-    /// `--delete-during` - verified vs upstream 3.4.4 over SSH (delay DELETES a
-    /// per-dir-merge-protected entry, exactly as during/before do).
+    /// Covers `--delete-before` and `--delete-during` (each an immediate sweep
+    /// here) and `--delete-delay` (which *decides* its victim set here, deferring
+    /// the unlink to the late site - upstream generator.c:2315-2327 calls
+    /// `delete_in_dir()` during the walk, and `delete_during == 2` records the
+    /// victim via `remember_delete()` rather than unlinking). `--delete-after`
+    /// alone does nothing early. The phase dispatch in
+    /// [`run_receiver_delete_pass`](Self::run_receiver_delete_pass) picks
+    /// immediate-vs-collect per mode.
+    ///
+    /// upstream: generator.c:2280-2281 (`delete_before` -> `do_delete_pass()` up
+    /// front), generator.c:2315-2327 (`delete_during` / `delete_during == 2`
+    /// decide as each directory is entered during the loop).
     pub(in crate::receiver) fn delete_pass_is_early(&self) -> bool {
         self.config.flags.delete && !self.config.deletion.delete_after
     }
 
-    /// True when the delete pass is DEFERRED to after the per-file transfer loop.
+    /// True when the delete pass has work to do at the LATE site, after the
+    /// per-file transfer loop.
     ///
-    /// Covers `--delete-after` ONLY. Mirrors upstream generator.c:2425-2428 which
-    /// runs `do_delete_pass()` after every file - including each destination
-    /// `.rsync-filter` merge file - has been transferred. Deferring is
-    /// load-bearing: the delete pass reloads each destination directory's
-    /// per-directory `.rsync-filter` at delete time, so a merge-file protect rule
-    /// (e.g. `- *.bak`) only survives the sweep once that filter file is present
-    /// in the destination, which it is not until the transfer has run.
+    /// Covers `--delete-after` (an immediate sweep here, once every destination
+    /// `.rsync-filter` merge file has landed so its protect rules apply) AND
+    /// `--delete-delay` (which *executes* the victims it decided early). Both are
+    /// the upstream `late_delete` modes (`delete_during == 2 || delete_after`).
     ///
-    /// `--delete-delay` is deliberately NOT here: upstream makes its deletion
-    /// decision during the walk (deferring only the unlink), so it deletes such
-    /// an entry - see [`delete_pass_is_early`](Self::delete_pass_is_early).
+    /// `--delete-delay`'s split is load-bearing: upstream decides during the walk
+    /// (deferring only the unlink) so it DELETES a per-dir-merge-protected entry
+    /// exactly as `--delete-during` does (verified vs upstream 3.4.4 over SSH),
+    /// yet the unlink and `*deleting` output happen after the whole transfer -
+    /// so a mid-transfer abort leaves the stale file in place.
+    ///
+    /// upstream: generator.c:2425-2428 - `do_delayed_deletions()` (delay) and
+    /// `do_delete_pass()` (after) both run after `generate_files()` finishes.
     pub(in crate::receiver) fn delete_pass_is_late(&self) -> bool {
-        self.config.flags.delete && self.config.deletion.delete_after
+        self.config.flags.delete && self.config.deletion.late_delete
     }
 
-    /// Runs the destination delete pass and folds its results into `stats`.
+    /// Runs the destination delete pass for `phase` and folds its results into
+    /// `stats`. Called once at the early site (before the per-file loop) and once
+    /// at the late site (after it, before finalize); the mode decides what each
+    /// phase actually does:
     ///
-    /// Sweeps the destination for entries absent from the sender's file list,
-    /// reloading each directory's per-directory `.rsync-filter` merge files so
-    /// their protect rules apply at delete time. Shared by all four receiver
-    /// pipeline drivers so the defer-and-filter logic lives in exactly one place.
+    /// | mode | early | late |
+    /// |------|-------|------|
+    /// | `--delete-before` / `--delete-during` | immediate sweep | - |
+    /// | `--delete-after` | - | immediate sweep |
+    /// | `--delete-delay` (parallel path) | collect victims | execute victims |
+    /// | `--delete-delay` (+`--max-delete`/`-x`) | immediate sweep | - |
     ///
-    /// The caller positions the call via [`delete_pass_is_early`] (before the
-    /// per-file loop) or [`delete_pass_is_late`] (after it, before finalize).
+    /// A `--delete-delay` run that would route through the serial, leaf-granular
+    /// executor (`--max-delete` cap or `--one-file-system` boundary) cannot defer
+    /// through the collect/execute split, so it stays on the immediate early pass,
+    /// mirroring the engine crate's `delay_decides_during` gate.
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:358` - `do_delete_pass()` tree sweep
+    /// - `generator.c:358` - `do_delete_pass()` tree sweep (before/after)
     /// - `generator.c:279` - `delete_in_dir()` per-directory candidate check
+    /// - `generator.c:157` - `remember_delete()` records a delay victim
+    /// - `generator.c:2419` - `do_delayed_deletions()` unlinks delay victims
     /// - `exclude.c:875` - `change_local_filter_dir()` reloads dest `.rsync-filter`
-    /// - `generator.c:2393-2398` / `2437-2440` - `write_del_stats()` emission
-    ///
-    /// [`delete_pass_is_early`]: Self::delete_pass_is_early
-    /// [`delete_pass_is_late`]: Self::delete_pass_is_late
     pub(in crate::receiver) fn run_receiver_delete_pass<W>(
+        &mut self,
+        phase: DeletePassPhase,
+        dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&std::sync::Arc<fast_io::DirSandbox>>,
+        writer: &mut W,
+        stats: &mut TransferStats,
+    ) -> io::Result<()>
+    where
+        W: Write + crate::writer::MsgInfoSender + ?Sized,
+    {
+        // `--delete-delay` (`delete_during == 2`): late_delete without the
+        // `delete_after` decision-deferral. Deferrable only on the parallel path.
+        let delay = self.config.deletion.late_delete && !self.config.deletion.delete_after;
+        let deferrable_delay = delay && !self.delete_pass_uses_serial_executor();
+
+        match phase {
+            DeletePassPhase::Early => {
+                if deferrable_delay {
+                    // upstream: generator.c:345 remember_delete() records each
+                    // victim during the walk; the unlink is deferred.
+                    let (victims, io_bits) = self.collect_delayed_deletions(
+                        dest_dir,
+                        #[cfg(unix)]
+                        sandbox,
+                        writer,
+                    )?;
+                    stats.io_error |= io_bits;
+                    self.delayed_delete_victims = victims;
+                } else {
+                    self.run_immediate_delete_pass(
+                        dest_dir,
+                        #[cfg(unix)]
+                        sandbox,
+                        writer,
+                        stats,
+                    )?;
+                }
+            }
+            DeletePassPhase::Late => {
+                if self.config.deletion.delete_after {
+                    self.run_immediate_delete_pass(
+                        dest_dir,
+                        #[cfg(unix)]
+                        sandbox,
+                        writer,
+                        stats,
+                    )?;
+                } else if deferrable_delay {
+                    // upstream: generator.c:2419 do_delayed_deletions() unlinks the
+                    // remembered victims after the whole transfer has completed.
+                    let victims = std::mem::take(&mut self.delayed_delete_victims);
+                    let (delete_stats, io_bits) = self.execute_delayed_deletions(
+                        dest_dir,
+                        #[cfg(unix)]
+                        sandbox,
+                        &victims,
+                        writer,
+                    )?;
+                    stats.io_error |= io_bits;
+                    stats.delete_stats = delete_stats;
+                    // Carry the per-type counters into the receiver context so the
+                    // goodbye handshake can emit NDX_DEL_STATS to the peer sender.
+                    // upstream: generator.c:2437-2440 - late write_del_stats().
+                    self.pending_del_stats = delete_stats;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Immediate delete sweep: scan, unlink, emit, and fold the stats into
+    /// `stats`. Used by `--delete-before` / `--delete-during` / `--delete-after`
+    /// and a capped/`--one-file-system` `--delete-delay`.
+    fn run_immediate_delete_pass<W>(
         &mut self,
         dest_dir: &Path,
         #[cfg(unix)] sandbox: Option<&std::sync::Arc<fast_io::DirSandbox>>,
@@ -210,6 +295,19 @@ impl ReceiverContext {
         self.pending_del_stats = delete_stats;
         Ok(())
     }
+}
+
+/// Which side of the per-file transfer loop a
+/// [`run_receiver_delete_pass`](ReceiverContext::run_receiver_delete_pass) call
+/// sits on. The mode decides what work each phase performs (see that method).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::receiver) enum DeletePassPhase {
+    /// Before the per-file transfer loop (upstream `do_delete_pass()` /
+    /// `delete_in_dir()` during the walk).
+    Early,
+    /// After the per-file transfer loop (upstream `do_delayed_deletions()` /
+    /// late `do_delete_pass()`).
+    Late,
 }
 
 /// Renames all delayed-update files from their `.~tmp~` staging paths to

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -98,6 +98,7 @@ impl ReceiverContext {
         // present and consulted at delete time.
         if self.delete_pass_is_early() {
             self.run_receiver_delete_pass(
+                super::DeletePassPhase::Early,
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
@@ -257,6 +258,7 @@ impl ReceiverContext {
         // follows the late delete pass).
         if self.delete_pass_is_late() {
             self.run_receiver_delete_pass(
+                super::DeletePassPhase::Late,
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),

--- a/crates/transfer/src/receiver/transfer/pipelined_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_async.rs
@@ -126,6 +126,7 @@ impl ReceiverContext {
         // present and consulted at delete time.
         if self.delete_pass_is_early() {
             self.run_receiver_delete_pass(
+                super::DeletePassPhase::Early,
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
@@ -279,6 +280,7 @@ impl ReceiverContext {
         // follows the late delete pass).
         if self.delete_pass_is_late() {
             self.run_receiver_delete_pass(
+                super::DeletePassPhase::Late,
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -128,6 +128,7 @@ impl ReceiverContext {
         // present and consulted at delete time.
         if self.delete_pass_is_early() {
             self.run_receiver_delete_pass(
+                super::DeletePassPhase::Early,
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
@@ -263,6 +264,7 @@ impl ReceiverContext {
         // follows the late delete pass).
         if self.delete_pass_is_late() {
             self.run_receiver_delete_pass(
+                super::DeletePassPhase::Late,
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
@@ -138,6 +138,7 @@ impl ReceiverContext {
         // present and consulted at delete time.
         if self.delete_pass_is_early() {
             self.run_receiver_delete_pass(
+                super::DeletePassPhase::Early,
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
@@ -277,6 +278,7 @@ impl ReceiverContext {
         // follows the late delete pass).
         if self.delete_pass_is_late() {
             self.run_receiver_delete_pass(
+                super::DeletePassPhase::Late,
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),


### PR DESCRIPTION
## Summary

Separate the receiver's `--delete-during` and `--delete-delay` timing so each
matches upstream rsync 3.4.4 exactly. Previously the receiver collapsed
`--delete-before`, `--delete-during`, and `--delete-delay` into a single
immediate pre-loop sweep, unlinking delay victims *before* the transfer even
started. Upstream instead **decides** the delay victim set during the walk but
**defers the unlink** until the whole transfer completes.

## Upstream behaviour (generator.c / delete.c, proto 32)

- `--delete-before` (`delete_before`): `do_delete_pass()` runs up front
  (generator.c:2280).
- `--delete-during` (`delete_during == 1`): `delete_in_dir()` unlinks
  incrementally per directory during the transfer loop; `delete_item()` runs
  inline (generator.c:2315, 345 else-branch).
- `--delete-delay` (`delete_during == 2`): `delete_in_dir()` still runs during
  the walk, but calls `remember_delete()` (generator.c:345) to record the victim
  into the delete-delay buffer instead of unlinking. The actual unlink happens in
  `do_delayed_deletions()` (generator.c:2425), after the entire transfer and redo
  phase. A mid-transfer abort therefore leaves the stale files in place.
- `--delete-after` (`delete_after`): `do_delete_pass()` runs at the very end
  (generator.c:2427), deciding *and* unlinking after every file (including dest
  `.rsync-filter` merge files) has landed.

The distinction between delay and after is load-bearing: delay decides while the
destination merge files are in their during-time state (so it deletes a
per-dir-merge-protected entry, verified vs upstream 3.4.4 over SSH), whereas
after decides once those merge files are present (so it protects the entry).

## The divergence

The receiver's `delete_pass_is_early()` routed delay into the same immediate
pre-loop sweep as before/during, so delay unlinked *before* the transfer. This
lost upstream's crash-safety guarantee and emitted `*deleting` output at the
wrong time. Meanwhile the goodbye handshake already treated delay as a late
del-stats mode, leaving decision and stats timing inconsistent. (The local-copy
engine path was already correct via `decide_and_defer_delayed_deletions`; only
the network receiver diverged.)

## Fix

Split delay into a decide-early / execute-late pair, mirroring upstream's
`remember_delete` + `do_delayed_deletions`:

- `run_delete_scan(collect_only)` records victims in upstream emission order
  without unlinking or emitting when `collect_only` is set.
- `collect_delayed_deletions` (early site) captures the victim set using the
  DURING-time destination state and stores it on the receiver context; the
  decision is byte-identical to the old early sweep, so pre-existing and
  transferred `.rsync-filter` merge-file protection are both preserved.
- `execute_delayed_deletions` (late site) unlinks each recorded victim, emits its
  `deleting`/`*deleting` line, and counts del-stats - matching
  `do_delayed_deletions()` timing.
- Delay routing is gated by `delete_pass_uses_serial_executor()`: a
  `--max-delete` or `--one-file-system` delay run stays on the immediate early
  pass (the serial, leaf-granular executor unlinks inline and cannot defer),
  mirroring the engine crate's `delay_decides_during` gate.

Phase dispatch lives in `run_receiver_delete_pass(DeletePassPhase)`, called once
at each of the four drivers' early and late sites. before/during -> immediate
early; after -> immediate late; delay -> collect early, execute late.

## Design pattern

A small **Strategy over phase** split: one `DeletePassPhase` dispatcher selects
immediate / collect / execute per mode, keeping the DECIDE (filter) serial and
unchanged while only the physical unlink moves late - respecting the delete-pass
concurrency discipline (no filter decision moved into a parallel phase).

## Tests

- `delete_delay_defers_unlink_until_execute_phase`: proves the timing contract -
  `collect_delayed_deletions` leaves the stale file ON DISK (mid-transfer
  crash-safety) while returning it as a pending victim; only
  `execute_delayed_deletions` removes it. An immediate during/before sweep
  removes the same file in one call, and both modes converge on the identical
  final set (stale gone, listed file kept).
- `delete_pass_timing_predicates_partition_the_four_modes`: rewritten to assert
  before/during = early only, after = late only, delay = both sites.
- Existing merge-protection tests (`late_delete_pass_with_dest_rsync_filter_
  protects_bak`, `delete_pass_without_dest_rsync_filter_deletes_bak`) unchanged
  and still green, confirming the decision semantics are preserved.

All `transfer` delete tests pass; `cargo fmt` and
`cargo clippy -p transfer --all-targets --all-features --no-deps -D warnings`
are clean.
