### PR TITLE
fix(transfer): fail-closed INC_RECURSE sub-list dir_ndx validation

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -6,7 +6,7 @@
 //! [`super::itemize`] module.
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroU8;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -76,6 +76,33 @@ pub struct ReceiverContext {
     /// - `flist.c:101` - `first_flist` pointer
     /// - `receiver.c:573` - `flist_free(first_flist)` advances `first_flist`
     pub(in crate::receiver) first_segment_idx: usize,
+    /// Count of directory entries received so far across the initial file list
+    /// and every INC_RECURSE sub-list, mirroring upstream's `dir_flist->used`.
+    ///
+    /// The sender frames each sub-list header as `NDX_FLIST_OFFSET - dir_ndx`,
+    /// where `dir_ndx` indexes the directories in reception (growth) order. A
+    /// header referencing a directory that has not been received yet
+    /// (`dir_ndx >= dir_flist_used`) is malformed or malicious and is rejected
+    /// fail-closed. The count is taken pre-prune (the `--prune-empty-dirs` pass
+    /// is receiver-only; the sender numbers `dir_ndx` over every directory it
+    /// ships), so a valid transfer never trips the bound.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2622-2626` - `if (dir_ndx >= dir_flist->used) ... "refusing
+    ///   invalid dir_ndx %u >= %u" ... exit_cleanup(RERR_PROTOCOL)`.
+    pub(in crate::receiver) dir_flist_used: usize,
+    /// Set of `dir_ndx` values that have already been served a sub-list,
+    /// mirroring upstream's per-directory `FLAG_GOT_DIR_FLIST`. A second
+    /// sub-list for the same directory is a malicious duplicate and is rejected
+    /// fail-closed with `RERR_PROTOCOL`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2627-2632` - `if (file->flags & FLAG_GOT_DIR_FLIST) ...
+    ///   "refusing malicious duplicate flist for dir %d" ...
+    ///   exit_cleanup(RERR_PROTOCOL)`.
+    pub(in crate::receiver) served_dir_flists: HashSet<i32>,
     /// Cached file list reader for compression state continuity across sub-lists.
     ///
     /// Upstream rsync uses `static` variables in `recv_file_entry()` that persist
@@ -315,6 +342,8 @@ impl ReceiverContext {
             checksum_seed: handshake.checksum_seed,
             ndx_segments: vec![(0, initial_ndx_start)],
             first_segment_idx: 0,
+            dir_flist_used: 0,
+            served_dir_flists: HashSet::new(),
             flist_reader_cache: None,
             uid_list: IdList::new(),
             gid_list: IdList::new(),

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -288,6 +288,10 @@ mod tests {
         assert_eq!(total, 6);
 
         let mut ctx = inc_recurse_receiver();
+        // Stand in for an initial flist that already carried the three parent
+        // directories (dir0..dir2), so each sub-list's dir_ndx (0..2) passes the
+        // fail-closed `dir_ndx >= dir_flist_used` range check.
+        ctx.dir_flist_used = segments.len();
         // A fresh INC_RECURSE receiver has no entries yet and is not at EOF.
         assert_eq!(ctx.file_list().len(), 0);
         assert!(!ctx.flist_eof);
@@ -338,6 +342,9 @@ mod tests {
         let (wire, total) = encode_segments(&segments);
 
         let mut ctx = inc_recurse_receiver();
+        // Two parent dirs (s0, s1) were in the initial flist; seed the count so
+        // dir_ndx 0 and 1 pass the fail-closed range check.
+        ctx.dir_flist_used = segments.len();
         let mut reader = Cursor::new(wire);
         let mut codec = create_ndx_codec(PROTOCOL);
 
@@ -481,5 +488,120 @@ mod tests {
         assert!(ctx.ensure_flat_idx(0, &mut reader, &mut codec).unwrap());
         assert!(!ctx.ensure_flat_idx(1, &mut reader, &mut codec).unwrap());
         assert_eq!(reader.position(), 0);
+    }
+
+    /// Encodes a single INC_RECURSE sub-list header framed for `dir_ndx`, its
+    /// entries, and the `NDX_FLIST_EOF` terminator. Unlike `encode_segments`,
+    /// the `dir_ndx` is caller-chosen so a malformed/out-of-range index can be
+    /// forced onto the wire.
+    fn encode_segment_with_dir_ndx(dir_ndx: i32, entries: &[(&str, u64)]) -> Vec<u8> {
+        let protocol = ProtocolVersion::try_from(PROTOCOL).unwrap();
+        let mut writer = FileListWriter::new(protocol);
+        let mut ndx_codec = create_ndx_codec(PROTOCOL);
+        let mut wire = Vec::new();
+        ndx_codec
+            .write_ndx(&mut wire, NDX_FLIST_OFFSET - dir_ndx)
+            .unwrap();
+        for (name, size) in entries {
+            let mut e = FileEntry::new_file(PathBuf::from(name), *size, 0o100644);
+            e.set_mtime(1_700_000_000, 0);
+            writer.write_entry(&mut wire, &e).unwrap();
+        }
+        writer.write_end(&mut wire, None).unwrap();
+        ndx_codec.write_ndx(&mut wire, NDX_FLIST_EOF).unwrap();
+        wire
+    }
+
+    /// A `dir_ndx` equal to, past, or absurdly beyond `dir_flist_used` is
+    /// untrusted wire data that references a directory the receiver never saw.
+    ///
+    /// WHY: upstream `flist.c:2622-2626` aborts with `exit_cleanup(RERR_PROTOCOL)`
+    /// on `dir_ndx >= dir_flist->used`. oc must fail closed - reject with a
+    /// `ProtocolViolation` (RERR_PROTOCOL) and append nothing - rather than trust
+    /// the sender's index or (for a huge value) panic on the framing arithmetic.
+    #[test]
+    fn out_of_range_sublist_dir_ndx_is_rejected_fail_closed() {
+        for bad in [1i32, 5, 2_000_000_000] {
+            let wire = encode_segment_with_dir_ndx(bad, &[("x/a.txt", 1)]);
+            let mut ctx = inc_recurse_receiver();
+            // Only dir_ndx 0 would be in range.
+            ctx.dir_flist_used = 1;
+            let err = ctx
+                .receive_extra_file_lists(&mut Cursor::new(wire))
+                .expect_err("out-of-range dir_ndx must be rejected, not appended");
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+            assert!(
+                err.get_ref()
+                    .and_then(|e| e.downcast_ref::<protocol::ProtocolViolation>())
+                    .is_some(),
+                "range rejection must map to RERR_PROTOCOL, got {err:?}"
+            );
+            assert!(
+                err.to_string().contains("refusing invalid dir_ndx"),
+                "unexpected message: {err}"
+            );
+            assert_eq!(
+                ctx.file_list().len(),
+                0,
+                "no entries may be appended when the header is rejected"
+            );
+        }
+    }
+
+    /// A second sub-list for a directory already served is a malicious duplicate.
+    ///
+    /// WHY: upstream `flist.c:2627-2632` sets `FLAG_GOT_DIR_FLIST` and aborts with
+    /// `RERR_PROTOCOL` on the second sub-list; without the guard a sender could
+    /// replay sub-lists to grow `file_list` without bound. The first sub-list for
+    /// dir_ndx 0 is accepted, the second is refused.
+    #[test]
+    fn duplicate_sublist_for_same_dir_is_rejected() {
+        let protocol = ProtocolVersion::try_from(PROTOCOL).unwrap();
+        let mut writer = FileListWriter::new(protocol);
+        let mut ndx_codec = create_ndx_codec(PROTOCOL);
+        let mut wire = Vec::new();
+        for entries in [&[("dir0/a.txt", 1u64)][..], &[("dir0/b.txt", 2u64)][..]] {
+            // Both headers target dir_ndx 0.
+            ndx_codec.write_ndx(&mut wire, NDX_FLIST_OFFSET).unwrap();
+            for (name, size) in entries {
+                let mut e = FileEntry::new_file(PathBuf::from(name), *size, 0o100644);
+                e.set_mtime(1_700_000_000, 0);
+                writer.write_entry(&mut wire, &e).unwrap();
+            }
+            writer.write_end(&mut wire, None).unwrap();
+        }
+        ndx_codec.write_ndx(&mut wire, NDX_FLIST_EOF).unwrap();
+
+        let mut ctx = inc_recurse_receiver();
+        ctx.dir_flist_used = 1;
+        let err = ctx
+            .receive_extra_file_lists(&mut Cursor::new(wire))
+            .expect_err("duplicate sub-list for dir 0 must be rejected");
+        assert!(
+            err.get_ref()
+                .and_then(|e| e.downcast_ref::<protocol::ProtocolViolation>())
+                .is_some(),
+            "duplicate rejection must map to RERR_PROTOCOL, got {err:?}"
+        );
+        assert!(
+            err.to_string()
+                .contains("refusing malicious duplicate flist for dir 0"),
+            "unexpected message: {err}"
+        );
+    }
+
+    /// An in-range, non-duplicate `dir_ndx` sub-list is accepted normally - the
+    /// guards must not reject legitimate wire data.
+    #[test]
+    fn in_range_sublist_dir_ndx_is_accepted() {
+        let wire = encode_segment_with_dir_ndx(0, &[("dir0/a.txt", 3u64), ("dir0/b.txt", 4)]);
+        let mut ctx = inc_recurse_receiver();
+        ctx.dir_flist_used = 1;
+        let n = ctx
+            .receive_extra_file_lists(&mut Cursor::new(wire))
+            .expect("in-range dir_ndx must be accepted");
+        assert_eq!(n, 2);
+        assert_eq!(ctx.file_list().len(), 2);
+        assert!(ctx.flist_eof);
     }
 }

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -10,7 +10,7 @@ use std::io::{self, Read};
 use logging::debug_log;
 use protocol::CompatibilityFlags;
 use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, create_ndx_codec};
-use protocol::flist::{IncrementalFileListBuilder, sort_file_list};
+use protocol::flist::{FileEntry, IncrementalFileListBuilder, sort_file_list};
 
 use super::super::ReceiverContext;
 use super::hardlinks::{match_hard_links, normalize_pre30_hardlinks};
@@ -64,6 +64,15 @@ impl ReceiverContext {
         let inc_recurse = self
             .compat_flags
             .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
+
+        // upstream: flist.c:2695-2701 - every received directory is appended to
+        // dir_flist as the read loop runs, so dir_flist->used counts all dirs in
+        // this list. We track the equivalent count only under INC_RECURSE (the
+        // sole mode that frames sub-list headers by dir_ndx) and take it before
+        // the receiver-only prune pass so it matches the sender's numbering.
+        if inc_recurse {
+            self.dir_flist_used += count_directories(&self.file_list[seg_start..]);
+        }
 
         // Without INC_RECURSE the whole list arrives in this single call, so the
         // file list is complete. With INC_RECURSE the sender streams per-directory
@@ -242,6 +251,11 @@ impl ReceiverContext {
             ));
         }
 
+        // `ndx <= NDX_FLIST_OFFSET` (checked above), so `dir_ndx = NDX_FLIST_OFFSET
+        // - ndx` is always in `0..=2147483547` and cannot overflow or go negative.
+        let dir_ndx = NDX_FLIST_OFFSET - ndx;
+        self.validate_extra_segment_dir_ndx(dir_ndx)?;
+
         // upstream: flist.c:recv_file_entry() - reuse cached reader to preserve
         // compression state (prev_name, prev_mode, prev_uid, prev_gid).
         let mut flist_reader = self
@@ -249,7 +263,6 @@ impl ReceiverContext {
             .take()
             .unwrap_or_else(|| self.build_flist_reader());
 
-        let dir_ndx = NDX_FLIST_OFFSET - ndx;
         let flat_start = self.file_list.len();
 
         // Compute seg_ndx_start BEFORE reading entries so the reader can
@@ -299,6 +312,11 @@ impl ReceiverContext {
             normalize_pre30_hardlinks(&mut self.file_list[flat_start..]);
         }
 
+        // upstream: flist.c:2695-2701 - directories in this sub-list are appended
+        // to dir_flist, so a later sub-list may legitimately reference them by
+        // dir_ndx. Fold them into the running count.
+        self.dir_flist_used += count_directories(&self.file_list[flat_start..]);
+
         // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
         self.ndx_segments.push((flat_start, seg_ndx_start));
 
@@ -323,6 +341,52 @@ impl ReceiverContext {
             seg_ndx_start
         );
         Ok(segment_count)
+    }
+
+    /// Validates an INC_RECURSE sub-list header's `dir_ndx` against untrusted
+    /// wire data, failing closed exactly like upstream, and claims the directory
+    /// so a duplicate sub-list is rejected.
+    ///
+    /// Two guards, both mapped to `RERR_PROTOCOL` (2) via
+    /// [`protocol::protocol_violation`]:
+    ///
+    /// 1. **Range** - a `dir_ndx` that references a directory not yet received
+    ///    (`dir_ndx >= dir_flist_used`) cannot belong to any real sender tree and
+    ///    is rejected. `dir_ndx` is always `>= 0` (see the caller), so the single
+    ///    `>=` test also covers the negative case upstream checks separately.
+    /// 2. **Duplicate** - a second sub-list for a directory already served is a
+    ///    malicious duplicate that would otherwise grow `file_list` unbounded.
+    ///
+    /// Shared by the synchronous [`Self::receive_one_extra_segment`] and the
+    /// asynchronous `receive_extra_file_lists_async` so both wire paths reject
+    /// identical bytes with identical exit codes.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2622-2626` - `if (dir_ndx >= dir_flist->used) ... "refusing
+    ///   invalid dir_ndx %u >= %u" ... exit_cleanup(RERR_PROTOCOL)`.
+    /// - `flist.c:2627-2632` - `FLAG_GOT_DIR_FLIST` duplicate guard, "refusing
+    ///   malicious duplicate flist for dir %d", `exit_cleanup(RERR_PROTOCOL)`.
+    pub(in crate::receiver) fn validate_extra_segment_dir_ndx(
+        &mut self,
+        dir_ndx: i32,
+    ) -> io::Result<()> {
+        if dir_ndx < 0 || dir_ndx as usize >= self.dir_flist_used {
+            return Err(protocol::protocol_violation(format!(
+                "refusing invalid dir_ndx {dir_ndx} >= {} {}{}",
+                self.dir_flist_used,
+                crate::role_trailer::error_location!(),
+                crate::role_trailer::receiver()
+            )));
+        }
+        if !self.served_dir_flists.insert(dir_ndx) {
+            return Err(protocol::protocol_violation(format!(
+                "refusing malicious duplicate flist for dir {dir_ndx} {}{}",
+                crate::role_trailer::error_location!(),
+                crate::role_trailer::receiver()
+            )));
+        }
+        Ok(())
     }
 
     /// Publishes one INC_RECURSE segment into the parallel-deterministic-
@@ -431,4 +495,18 @@ impl ReceiverContext {
             iconv_reorder_suppressed: self.iconv_reorder_suppressed(),
         }
     }
+}
+
+/// Counts the directory entries in a received file-list slice.
+///
+/// Mirrors upstream's `dir_flist` accounting: every `S_ISDIR` entry read in a
+/// list is appended to `dir_flist`, so this count is what `dir_flist->used`
+/// grows by for that list.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:2695-2701` - `if (S_ISDIR(file->mode)) { ... dir_flist->files[
+///   dir_flist->used++] = file; }`.
+pub(super) fn count_directories(entries: &[FileEntry]) -> usize {
+    entries.iter().filter(|e| e.is_dir()).count()
 }

--- a/crates/transfer/src/receiver/file_list/receive_async.rs
+++ b/crates/transfer/src/receiver/file_list/receive_async.rs
@@ -193,7 +193,12 @@ impl ReceiverContext {
                 ));
             }
 
+            // `ndx <= NDX_FLIST_OFFSET`, so `dir_ndx` is always in
+            // `0..=2147483547` and cannot overflow or go negative. Reject an
+            // out-of-range or duplicate dir_ndx fail-closed, exactly like the
+            // synchronous receive path.
             let dir_ndx = NDX_FLIST_OFFSET - ndx;
+            self.validate_extra_segment_dir_ndx(dir_ndx)?;
             let flat_start = self.file_list.len();
 
             let &(prev_flat_start, prev_ndx_start) =
@@ -235,6 +240,11 @@ impl ReceiverContext {
             if self.protocol.as_u8() < 30 && self.config.flags.hard_links {
                 normalize_pre30_hardlinks(&mut self.file_list[flat_start..]);
             }
+
+            // upstream: flist.c:2695-2701 - fold this sub-list's directories into
+            // the running dir_flist->used count so a later sub-list may reference
+            // them by dir_ndx.
+            self.dir_flist_used += super::receive::count_directories(&self.file_list[flat_start..]);
 
             // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
             self.ndx_segments.push((flat_start, seg_ndx_start));

--- a/crates/transfer/src/receiver/tests/file_list/async_parity.rs
+++ b/crates/transfer/src/receiver/tests/file_list/async_parity.rs
@@ -144,7 +144,11 @@ async fn receive_extra_file_lists_async_matches_sync() {
     };
 
     // Sync baseline: seed an initial (empty) segment so ndx_segments has a base.
+    // The lone sub-list is for dir_ndx 0 (the top-level content dir), so pretend
+    // the initial flist carried one directory to satisfy the fail-closed range
+    // check; both the sync and async paths get the identical seed.
     let mut sync_ctx = ReceiverContext::new_for_test(&handshake, test_config());
+    sync_ctx.dir_flist_used = 1;
     let sync_total = sync_ctx
         .receive_extra_file_lists(&mut Cursor::new(&extra[..]))
         .unwrap();
@@ -152,6 +156,7 @@ async fn receive_extra_file_lists_async_matches_sync() {
 
     for chunk in [1usize, 2, 3, 8, extra.len()] {
         let mut async_ctx = ReceiverContext::new_for_test(&handshake, test_config());
+        async_ctx.dir_flist_used = 1;
         let mut src = ChunkedReader::new(extra.clone(), chunk);
         let (async_total, _leftover) = async_ctx
             .receive_extra_file_lists_async(&mut src, Vec::new())


### PR DESCRIPTION
## Summary

Harden the receiver's INC_RECURSE sub-list reception against malformed or
malicious wire data. Each per-directory sub-list is framed by
`NDX_FLIST_OFFSET - dir_ndx`, where `dir_ndx` is an untrusted index the sender
chooses. Previously the receiver decoded and appended a sub-list for **any**
`dir_ndx` without validating it, diverging from upstream, which fails closed.

Two fail-closed guards are added, both mapped to `RERR_PROTOCOL` (exit 2), on
the single point every wire path funnels through
(`receive_one_extra_segment` and its `tokio-transfer` async twin):

1. **Range check** - a `dir_ndx` that references a directory the receiver has
   not seen (`dir_ndx >= dir_flist_used`) is rejected instead of silently
   appended. The receiver now tracks `dir_flist_used`, the count of directory
   entries received across the initial file list and every sub-list, mirroring
   upstream's `dir_flist->used`. The count is taken pre-prune because the
   `--prune-empty-dirs` pass is receiver-only while the sender numbers
   `dir_ndx` over every directory it ships, so a valid transfer never trips the
   bound. The `NDX_FLIST_OFFSET - ndx` framing arithmetic is also proven to
   stay in range (the caller already rejects `ndx > NDX_FLIST_OFFSET`, so the
   result is always in `0..=2147483547`), so a huge-magnitude index is rejected
   by the bound rather than mis-indexing.

2. **Duplicate-flist guard** - a second sub-list for a directory already served
   is refused. Without it a sender could replay sub-lists to grow the
   receiver's file list without bound.

## Upstream reference (rsync 3.4.4, `flist.c`)

- `recv_file_list()` 2622-2626: `if (dir_ndx >= dir_flist->used) { rprintf(...,
  "refusing invalid dir_ndx %u >= %u\n", ...); exit_cleanup(RERR_PROTOCOL); }`
- `recv_file_list()` 2627-2632: `FLAG_GOT_DIR_FLIST` duplicate guard ->
  `"refusing malicious duplicate flist for dir %d"`, `exit_cleanup(RERR_PROTOCOL)`
- `recv_file_list()` 2695-2701: every `S_ISDIR` entry is appended to
  `dir_flist`, which is what `dir_flist->used` counts.

Error messages follow the receiver's existing diagnostic convention (message +
`at <file>(<line>) [receiver=<version>]`) and are tagged as protocol
violations so the exit-code mapper returns `RERR_PROTOCOL` (2) rather than
`RERR_STREAMIO` (12).

## Tests

- `out_of_range_sublist_dir_ndx_is_rejected_fail_closed` - `dir_ndx` equal to,
  past, and absurdly beyond `dir_flist_used` each yield a `ProtocolViolation`
  with no entries appended and no panic.
- `duplicate_sublist_for_same_dir_is_rejected` - a replayed sub-list for the
  same directory is refused with the duplicate-flist message.
- `in_range_sublist_dir_ndx_is_accepted` - a legitimate in-range sub-list still
  decodes normally.
- The synchronous/asynchronous parity and lazy-fetch fixtures are seeded with a
  realistic received-directory count so they continue to exercise the accept
  path.

Verified locally: `cargo fmt --all`; `cargo clippy --workspace --all-targets
--all-features -- -D warnings` (clean); the transfer `file_list` lib tests (212
passing), async parity, and the `uts_nextest_hardlinks_inc_recurse`,
`uts_nextest_daemon_gzip_zz` end-to-end INC_RECURSE integration targets
(including deep-subdir multi-segment round-trips) all pass, confirming the
`dir_flist_used` count matches the generator's `dir_ndx` numbering on real
transfers.
