### PR TITLE
feat(transfer): preallocate destination files on the receiver

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -94,6 +94,10 @@ pub(super) struct ServerLongFlags {
     /// existing length and the sender streams only the tail (sender.c:89-95,
     /// generator.c:786).
     pub(super) append: bool,
+    /// upstream: options.c:715 / 2990-2991 - `--preallocate` (preallocate_files)
+    /// is forwarded to a server receiver, which `fallocate()`s each destination
+    /// file to its eventual length before writing to reduce fragmentation.
+    pub(super) preallocate: bool,
     /// Re-verify the existing prefix under append (upstream: `--append-verify`,
     /// wire-encoded as a doubled `--append`, `append_mode == 2`).
     ///
@@ -392,6 +396,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         from0: false,
         inplace: false,
         append: false,
+        preallocate: false,
         append_verify: false,
         size_only: false,
         modify_window: None,
@@ -494,13 +499,12 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             "--super" => {}
             // upstream: options.c:2990-2991 - `if (preallocate_files && am_sender)
             // args[ac++] = "--preallocate"`, forwarded to a server receiver so
-            // it fallocate()s each destination file before writing. Preallocation
-            // affects only on-disk block allocation, never file content, so a
-            // receiver that skips it produces byte-identical results. oc
-            // implements preallocation in the local-copy executor only, not the
-            // network receiver, so this is recognized to prevent a positional
-            // leak; the transferred bytes match upstream.
-            "--preallocate" => {}
+            // it fallocate()s each destination file before writing (receiver.c:
+            // 320). Preallocation affects only on-disk block allocation, never
+            // file content, so a receiver that skips it produces byte-identical
+            // results; the flag is carried onto the receiver config to reserve
+            // extents up front.
+            "--preallocate" => flags.preallocate = true,
             // upstream: options.c:696 / 2976-2977 - `--no-implied-dirs` is
             // forwarded to the sender on a pull. The server-side sender must omit
             // implied parent dirs from the flist at protocol < 30.

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -208,6 +208,9 @@ where
     // (receiver.c:357, match.c:373). Mirrors the daemon long-form parser.
     config.flags.append = long_flags.append;
     config.flags.append_verify = long_flags.append_verify;
+    // upstream: receiver.c:320 - a server receiver that was passed --preallocate
+    // fallocate()s each destination file to its eventual length before writing.
+    config.flags.preallocate = long_flags.preallocate;
     config.file_selection.size_only = long_flags.size_only;
     // upstream: options.c:2993-2994 - `--open-noatime` forwarded to the sender so
     // it opens source files with O_NOATIME (do_open), leaving atime untouched.

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -2105,6 +2105,22 @@ fn force_super_preallocate_recognised_as_known_long_flags() {
     assert!(is_known_server_long_flag("--preallocate"));
 }
 
+/// upstream: options.c:2990-2991 / receiver.c:320 - a server receiver invoked
+/// with `--preallocate` must fallocate() each destination file. The flag has no
+/// compact letter, so it arrives only as the long-form arg; parsing must set
+/// `preallocate` so `run.rs` can carry it onto `config.flags.preallocate` and
+/// the receiver reserves extents. Regression guard: the flag was previously
+/// recognised-but-dropped (`"--preallocate" => {}`), silently no-op'ing.
+#[test]
+fn parse_server_long_flags_sets_preallocate() {
+    let without = parse_server_long_flags(&[OsString::from("--server")]);
+    assert!(!without.preallocate, "default must be false");
+
+    let with =
+        parse_server_long_flags(&[OsString::from("--server"), OsString::from("--preallocate")]);
+    assert!(with.preallocate, "--preallocate must set the flag");
+}
+
 /// Regression for the positional leak: with the compact flag string present,
 /// none of the seven newly recognised long flags may fall through into
 /// `positional_args`; only the real destination path (`dst/`) survives. Without

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -384,6 +384,14 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // they must be carried onto the in-process ServerConfig for SSH and daemon.
     server_config.flags.append = config.append();
     server_config.flags.append_verify = config.append_verify();
+    // upstream: receiver.c:320 - `--preallocate` (preallocate_files) is a
+    // long-form-only flag with no compact letter, so build_server_flag_string
+    // never packs it into the capability string this local ServerConfig is
+    // parsed from. On a remote-shell/daemon pull the LOCAL client is the
+    // receiver, so carry the flag directly onto its config; without this the
+    // receiver never fallocate()s its destination files. Inert on a push (the
+    // remote receiver picks it up from the forwarded --preallocate arg).
+    server_config.flags.preallocate = config.preallocate();
     server_config.has_partial_dir = config.partial_directory().is_some();
     server_config.partial_dir = config.partial_directory().map(std::path::Path::to_path_buf);
     server_config.file_selection.min_file_size = config.min_file_size();

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -162,6 +162,9 @@ pub mod platform_copy;
 /// Cross-platform abstraction seam for zero-copy file-to-socket transfer
 /// (`sendfile(2)` / `TransmitFile()`).
 pub mod platform_sendfile;
+/// Destination file preallocation via `fallocate(FALLOC_FL_KEEP_SIZE)`, reserving
+/// blocks for a file's eventual length before writing (upstream `--preallocate`).
+pub mod preallocate;
 /// Sparse-file hole punching via `fallocate(PUNCH_HOLE)` with a zero-write
 /// fallback, for reclaiming/zeroing basis blocks during in-place sparse writes.
 pub mod punch_hole;
@@ -333,6 +336,7 @@ pub use platform_sendfile::{
     LinuxSendFile, MacOsSendFile, PlatformSendFile, SocketHandle, UnsupportedSendFile,
     WindowsTransmitFile, platform_default,
 };
+pub use preallocate::preallocate;
 pub use punch_hole::punch_hole;
 pub use traits::{FileReader, FileWriter};
 

--- a/crates/fast_io/src/preallocate.rs
+++ b/crates/fast_io/src/preallocate.rs
@@ -11,10 +11,7 @@ use std::fs::File;
 use std::io;
 
 #[cfg(target_os = "linux")]
-use rustix::{
-    fs::{FallocateFlags, fallocate},
-    io::Errno,
-};
+use rustix::fs::{FallocateFlags, fallocate};
 
 /// Preallocates disk blocks for `file`'s eventual `length` bytes without
 /// changing the file's logical size.

--- a/crates/fast_io/src/preallocate.rs
+++ b/crates/fast_io/src/preallocate.rs
@@ -1,0 +1,119 @@
+//! Destination file preallocation via `fallocate(FALLOC_FL_KEEP_SIZE)`.
+//!
+//! On Linux, reserves disk blocks for a file's eventual length before writing
+//! begins, reducing fragmentation on extent-based filesystems (ext4, xfs, NTFS).
+//! Mirrors upstream rsync's `do_fallocate()` (`syscall.c`), which the receiver
+//! calls when `--preallocate` is set. On platforms without `fallocate` upstream
+//! compiles the preallocation path out (`SUPPORT_PREALLOCATION` undefined), so
+//! this is a no-op there.
+
+use std::fs::File;
+use std::io;
+
+#[cfg(target_os = "linux")]
+use rustix::{
+    fs::{FallocateFlags, fallocate},
+    io::Errno,
+};
+
+/// Preallocates disk blocks for `file`'s eventual `length` bytes without
+/// changing the file's logical size.
+///
+/// Returns the number of already-reserved bytes the caller should treat as
+/// `preallocated_len`: with `FALLOC_FL_KEEP_SIZE` the file size is unchanged so
+/// this is `0`, exactly as upstream `do_fallocate()` returns `0` for its
+/// `opts != 0` case. A zero `length` (or one that overflows the signed syscall
+/// argument) is a no-op returning `0`.
+///
+/// # Errors
+///
+/// Returns the underlying `fallocate` error. Callers must mirror upstream's
+/// `rsyserr(FWARNING, ...)` and continue: preallocation is an optimization, and
+/// its failure (an unsupported filesystem, `ENOSPC`, ...) must never abort the
+/// transfer.
+// upstream: syscall.c:1528 do_fallocate() / receiver.c:323
+#[cfg(target_os = "linux")]
+pub fn preallocate(file: &File, length: u64) -> io::Result<u64> {
+    // fallocate's offset/length args are signed; skip when length would
+    // overflow i64 (also covers the `length + 1` perturbation below).
+    if length == 0 || length >= i64::MAX as u64 {
+        return Ok(0);
+    }
+    // upstream: syscall.c:1534-1537 - perturb the length by one so it never
+    // exactly matches the file's eventual size (only observable on the
+    // KEEP_SIZE-unavailable fallback, but replicated for fidelity).
+    let length = if length & 1 == 1 {
+        length + 1
+    } else {
+        length - 1
+    };
+    // upstream: syscall.c:1530 - opts == FALLOC_FL_KEEP_SIZE when preallocating.
+    match fallocate(file, FallocateFlags::KEEP_SIZE, 0, length) {
+        // upstream: syscall.c:1555 - opts != 0 returns 0 (size unchanged).
+        Ok(()) => Ok(0),
+        Err(err) => Err(io::Error::from_raw_os_error(err.raw_os_error())),
+    }
+}
+
+/// Non-Linux platforms lack `fallocate`; upstream compiles the preallocation
+/// path out entirely (`SUPPORT_PREALLOCATION` undefined), so this is a no-op
+/// that reports no reserved extent.
+// upstream: syscall.c - SUPPORT_PREALLOCATION guards the whole feature.
+#[cfg(not(target_os = "linux"))]
+pub fn preallocate(_file: &File, _length: u64) -> io::Result<u64> {
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preallocate_zero_length_is_noop() {
+        let f = tempfile::tempfile().expect("tempfile");
+        assert_eq!(preallocate(&f, 0).expect("prealloc"), 0);
+    }
+
+    #[test]
+    fn preallocate_absurd_length_is_noop() {
+        let f = tempfile::tempfile().expect("tempfile");
+        assert_eq!(preallocate(&f, u64::MAX).expect("prealloc"), 0);
+    }
+
+    // Preallocation reserves blocks up front so the eventual write lands in one
+    // contiguous extent; verify st_blocks reflects the reservation before any
+    // bytes are written. Linux-only: fallocate is the only tier that reserves
+    // without changing the logical size. Degrades gracefully if the temp
+    // filesystem (e.g. tmpfs) does not support fallocate.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn preallocate_reserves_blocks_without_growing_size() {
+        use std::os::unix::fs::MetadataExt;
+
+        let f = tempfile::tempfile().expect("tempfile");
+        let one_mib: u64 = 1024 * 1024;
+        match preallocate(&f, one_mib) {
+            Ok(len) => {
+                // KEEP_SIZE reports 0 reserved-for-punching bytes.
+                assert_eq!(len, 0, "KEEP_SIZE preallocation reports 0");
+                let meta = f.metadata().expect("metadata");
+                // Logical size stays 0 (KEEP_SIZE); blocks are reserved.
+                assert_eq!(meta.len(), 0, "KEEP_SIZE must not grow logical size");
+                let reserved = meta.blocks() * 512;
+                assert!(
+                    reserved + 512 >= one_mib,
+                    "expected ~{one_mib} bytes reserved, got {reserved}"
+                );
+            }
+            // tmpfs and other filesystems reject fallocate; the transfer must
+            // still succeed, so a rejection here is an acceptable degrade.
+            Err(err) => {
+                let raw = err.raw_os_error();
+                assert!(
+                    matches!(raw, Some(libc::EOPNOTSUPP | libc::ENOSYS | libc::ENOSPC)),
+                    "unexpected preallocate error: {err}"
+                );
+            }
+        }
+    }
+}

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -81,6 +81,10 @@ pub struct DiskCommitConfig {
     pub do_fsync: bool,
     /// Whether to use sparse file writing.
     pub use_sparse: bool,
+    /// Whether to preallocate each destination file to its eventual length
+    /// before writing (`--preallocate`). Reserves blocks up front to reduce
+    /// fragmentation. upstream: receiver.c:320 do_fallocate(fd, 0, total_size).
+    pub preallocate: bool,
     /// Destination tree root used to anchor SEC-1.r/SEC-1.j cross-thread
     /// `*at` syscalls. `None` when the destination root could not be opened
     /// at receiver setup or when running on a platform without the carrier.
@@ -193,6 +197,7 @@ impl Default for DiskCommitConfig {
         Self {
             do_fsync: false,
             use_sparse: false,
+            preallocate: false,
             dest_dir: None,
             #[cfg(unix)]
             sandbox: None,

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -122,6 +122,11 @@ pub(in crate::disk_commit) fn process_file(
     } else {
         0
     };
+    // upstream: receiver.c:319-336 - when --preallocate is set, fallocate the
+    // destination to its eventual length before writing. do_fallocate()'s return
+    // becomes preallocated_len, overriding the inplace basis for sparse hole
+    // decisions; a failure warns and continues (never aborts).
+    let preallocated_len = maybe_preallocate(&file, config, &begin, basis_len);
 
     let mut output = make_writer(
         file,
@@ -136,7 +141,7 @@ pub(in crate::disk_commit) fn process_file(
 
     let mut sparse_state = if config.use_sparse {
         let mut state = SparseWriteState::default();
-        state.set_preallocated_len(basis_len);
+        state.set_preallocated_len(preallocated_len);
         Some(state)
     } else {
         None
@@ -369,6 +374,9 @@ pub(in crate::disk_commit) fn process_whole_file(
     } else {
         0
     };
+    // upstream: receiver.c:319-336 - preallocate the destination before writing
+    // when --preallocate is set (see process_file).
+    let preallocated_len = maybe_preallocate(&file, config, &begin, basis_len);
 
     let mut output = make_writer(
         file,
@@ -392,7 +400,7 @@ pub(in crate::disk_commit) fn process_whole_file(
 
     let sparse_final = if config.use_sparse {
         let mut sparse = SparseWriteState::default();
-        sparse.set_preallocated_len(basis_len);
+        sparse.set_preallocated_len(preallocated_len);
         sparse.write(output.buffered_for_sparse(), &data)?;
         let logical = sparse.finish(output.buffered_for_sparse())?;
         Some(SparseFinalize {
@@ -594,6 +602,51 @@ fn open_output_file(
         #[cfg(not(unix))]
         let (file, guard) = open_tmpfile(&begin.file_path, config.temp_dir.as_deref())?;
         Ok((file, guard, true))
+    }
+}
+
+/// Preallocates the destination file to its eventual length under
+/// `config.preallocate`, returning the `preallocated_len` the sparse writer
+/// must use (bytes reserved that a zero run should punch rather than seek).
+///
+/// Mirrors upstream `receiver.c:319-336`: the preallocation branch gates on
+/// `preallocate_files && total_size > 0 && (!inplace_sizing || total_size >
+/// size_r)`, and its `do_fallocate()` return value overrides the inplace basis
+/// length. A `do_fallocate()` failure warns and continues (`receiver.c:324`), so
+/// this never propagates an error - preallocation is a best-effort optimization
+/// and its failure must not abort the receive.
+// upstream: receiver.c:320 - preallocated_len = do_fallocate(fd, 0, total_size)
+fn maybe_preallocate(
+    file: &fs::File,
+    config: &DiskCommitConfig,
+    begin: &BeginMessage,
+    fallback_preallocated_len: u64,
+) -> u64 {
+    if !config.preallocate {
+        return fallback_preallocated_len;
+    }
+    // upstream: receiver.c:320 - size_r is the existing basis length; only an
+    // in-place write reuses it, otherwise the temp file starts empty.
+    let existing_len = if begin.is_inplace {
+        file.metadata().map(|m| m.len()).unwrap_or(0)
+    } else {
+        0
+    };
+    if begin.target_size == 0 || (begin.is_inplace && begin.target_size <= existing_len) {
+        return fallback_preallocated_len;
+    }
+    match fast_io::preallocate(file, begin.target_size) {
+        Ok(preallocated_len) => preallocated_len,
+        // upstream: receiver.c:324 - rsyserr(FWARNING, ...) then continue.
+        Err(err) => {
+            logging::debug_log!(
+                Io,
+                1,
+                "preallocate {}: {err}; continuing without preallocation",
+                begin.file_path.display()
+            );
+            fallback_preallocated_len
+        }
     }
 }
 

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -179,6 +179,10 @@ pub struct ParsedServerFlags {
     pub whole_file: bool,
     /// Sparse file handling (`S` flag, `--sparse`).
     pub sparse: bool,
+    /// Preallocate destination file extents before writing (`--preallocate`).
+    /// Long-form only (no compact letter); the receiver calls `fallocate()` on
+    /// each destination temp file. upstream: options.c:715 / receiver.c:320.
+    pub preallocate: bool,
     /// One file system level (`x` flag count, `--one-file-system`).
     /// 0 = off, 1 = single -x, 2 = double -xx.
     pub one_file_system: u8,

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -144,6 +144,7 @@ impl ReceiverContext {
         let disk_config = DiskCommitConfig {
             do_fsync: self.config.write.fsync,
             use_sparse: self.config.flags.sparse,
+            preallocate: self.config.flags.preallocate,
             dest_dir: Some(setup.dest_dir.clone()),
             #[cfg(unix)]
             sandbox: setup.sandbox.clone(),

--- a/crates/transfer/src/receiver/transfer/pipeline_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline_async.rs
@@ -165,6 +165,7 @@ impl ReceiverContext {
         let disk_config = DiskCommitConfig {
             do_fsync: self.config.write.fsync,
             use_sparse: self.config.flags.sparse,
+            preallocate: self.config.flags.preallocate,
             dest_dir: Some(setup.dest_dir.clone()),
             #[cfg(unix)]
             sandbox: setup.sandbox.clone(),


### PR DESCRIPTION
## Summary

Implements `--preallocate` on the network receiver, wiring the flag end to end so a receiver (SSH pull, daemon, or a server started with `--server --preallocate`) reserves each destination file's disk blocks before writing.

Previously the flag was parsed, forwarded in server args, and honoured by the local-copy executor, but the network receiver recognised-and-dropped it (`"--preallocate" => {}`), silently no-op'ing preallocation for every remote transfer.

## Upstream reference

- `receiver.c:320` - `if (preallocate_files && fd != -1 && total_size > 0 && (!inplace_sizing || total_size > size_r))` calls `preallocated_len = do_fallocate(fd, 0, total_size)` before writing; a negative return warns via `rsyserr(FWARNING, ...)` and continues.
- `syscall.c:1528` `do_fallocate()` - `opts = inplace || preallocate_files ? FALLOC_FL_KEEP_SIZE : 0`, perturbs the length by one, and returns `0` for the `opts != 0` (KEEP_SIZE) case.
- `options.c:715` defines `--preallocate`; `options.c:2990-2991` forwards it (`if (preallocate_files && am_sender) args[ac++] = "--preallocate"`).
- Sparse interaction: `do_fallocate()`'s return becomes `preallocated_len`, which `fileio.c:92` uses to decide punch-vs-seek; with `KEEP_SIZE` it is `0`, so the preallocation branch takes precedence over the inplace-sizing branch.

## Changes

- **`fast_io::preallocate(&File, len) -> io::Result<u64>`** (new `preallocate.rs`): Linux `fallocate(FALLOC_FL_KEEP_SIZE)` via the existing safe `rustix` wrapper (same pattern as the sibling `punch_hole.rs`, no `unsafe`); no-op returning `Ok(0)` on non-Linux, mirroring upstream's compiled-out `SUPPORT_PREALLOCATION` path. Replicates upstream's length-by-one perturbation and `0` return.
- **Flag plumbing**: `preallocate` added to `ParsedServerFlags`; the server long-flag parser (`--preallocate`) and `apply_common_server_flags` (client-receiver pull) both set it; `run.rs` carries it onto the receiver config.
- **Receiver wiring**: `DiskCommitConfig.preallocate` threaded from `flags.preallocate` at both pipelined construction sites; `maybe_preallocate()` in `file_ops.rs` fallocate()s the destination temp file before writing in both `process_file` and `process_whole_file`, folding the result into the sparse writer's `preallocated_len` and warning-and-continuing on failure.

## Tests

- `fast_io`: zero-length and absurd-length no-ops; Linux-gated block-reservation test (`st_blocks` reflects the full reservation while the logical size stays 0, degrading gracefully on filesystems that reject `fallocate`).
- `cli`: `parse_server_long_flags_sets_preallocate` regression guard (flag was previously dropped).
- Existing `preallocate_forwarded_on_push_only` covers server-arg forwarding.

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and targeted `fast_io` / `cli` / `transfer` (`disk_commit`, 104 tests) suites pass. The block-reservation test is Linux-only and runs on CI.
