### PR TITLE
feat(transfer): wire MSG_DELETED for server-side --delete output

### DIFF
--- a/crates/protocol/tests/golden_msg_deleted_wire.rs
+++ b/crates/protocol/tests/golden_msg_deleted_wire.rs
@@ -1,0 +1,72 @@
+//! Golden byte tests for the `MSG_DELETED` (tag 101) multiplex frame.
+//!
+//! A server generator forwards each `--delete` victim to the client as a
+//! `MSG_DELETED` frame carrying the raw deletion-root-relative name; a directory
+//! carries a trailing NUL so the reader can tell it from a regular file. These
+//! tests pin the exact wire bytes (4-byte LE header + payload) so the encoding
+//! stays byte-compatible with upstream rsync.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync.h:300` - `MSG_DELETED = 101`.
+//! - `io.c:mplex_write()` - header = `(MPLEX_BASE + code) << 24 | len`, so the
+//!   tag byte is `7 + 101 = 108 = 0x6C`.
+//! - `log.c:866-869` - `send_msg(MSG_DELETED, fname, len, ...)`; a directory
+//!   bumps `len` to include its trailing NUL (`log.c:867-868`).
+//! - `io.c:1616` - the reader treats a trailing NUL as a directory marker.
+
+use std::io::Cursor;
+
+use protocol::{MessageCode, MessageFrame, MessageHeader, recv_msg_into, send_msg};
+
+#[test]
+fn golden_msg_deleted_header_tag_is_108() {
+    // Tag = MPLEX_BASE(7) + 101 = 108 = 0x6C. For payload length 3:
+    // header = (108 << 24) | 3 = 0x6C000003, LE bytes [0x03, 0x00, 0x00, 0x6C].
+    let header = MessageHeader::new(MessageCode::Deleted, 3).unwrap();
+    assert_eq!(header.encode(), [0x03, 0x00, 0x00, 0x6C]);
+
+    let decoded = MessageHeader::decode(&[0x03, 0x00, 0x00, 0x6C]).unwrap();
+    assert_eq!(decoded.code(), MessageCode::Deleted);
+    assert_eq!(decoded.payload_len(), 3);
+}
+
+#[test]
+fn golden_msg_deleted_file_frame_exact_bytes() {
+    // A deleted regular file "foo": payload is the raw name, no trailing NUL.
+    // len = 3, header 0x6C000003 (LE [0x03,0x00,0x00,0x6C]), then b"foo".
+    let frame = MessageFrame::new(MessageCode::Deleted, b"foo".to_vec()).unwrap();
+    let mut bytes = Vec::new();
+    frame.encode_into_vec(&mut bytes).unwrap();
+
+    assert_eq!(bytes, [0x03, 0x00, 0x00, 0x6C, b'f', b'o', b'o']);
+}
+
+#[test]
+fn golden_msg_deleted_dir_frame_has_trailing_nul() {
+    // A deleted directory "bar": upstream bumps len to include the trailing NUL
+    // (log.c:867-868), so the payload is b"bar\0" (len 4). header 0x6C000004,
+    // LE [0x04,0x00,0x00,0x6C], then b"bar\0".
+    let frame = MessageFrame::new(MessageCode::Deleted, b"bar\0".to_vec()).unwrap();
+    let mut bytes = Vec::new();
+    frame.encode_into_vec(&mut bytes).unwrap();
+
+    assert_eq!(bytes, [0x04, 0x00, 0x00, 0x6C, b'b', b'a', b'r', 0x00]);
+}
+
+#[test]
+fn golden_msg_deleted_send_recv_round_trip() {
+    // send_msg writes the same frame the receiver reads back verbatim, so the
+    // client's demux sees the exact payload (dir marker preserved).
+    let mut wire = Vec::new();
+    send_msg(&mut wire, MessageCode::Deleted, b"sub/dir\0").unwrap();
+    assert_eq!(wire[..4], [0x08, 0x00, 0x00, 0x6C]);
+
+    let mut reader = Cursor::new(wire);
+    let mut buf = Vec::new();
+    let code = recv_msg_into(&mut reader, &mut buf).unwrap();
+    assert_eq!(code, MessageCode::Deleted);
+    assert_eq!(buf, b"sub/dir\0");
+    // Trailing NUL is the directory marker the client strips before rendering.
+    assert_eq!(buf.last(), Some(&0u8));
+}

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -671,6 +671,21 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         }
     }
 
+    // upstream: log.c:870-874 - the client (a push client is the sender/generator
+    // role) renders each MSG_DELETED the remote receiver forwards, gating on its
+    // own info=del / itemize verbosity. Capture the gate now, on the setup
+    // thread where the verbosity thread-local is valid, so the read loop never
+    // depends on its own thread's state. `-v` sets INFO_GTE(DEL, 1)
+    // (options.c:251), so verbose_level covers the common case even if the
+    // read loop runs elsewhere; --info=del without -v is caught by info_gte.
+    if config.connection.client_mode && config.role == crate::role::ServerRole::Generator {
+        reader.enable_deleted_render(reader::DeletedRender {
+            itemize: config.flags.info_flags.itemize,
+            show_plain: config.flags.verbose_level >= 1
+                || logging::info_gte(logging::InfoFlag::Del, 1),
+        });
+    }
+
     // MultiplexWriter provides 64KB buffering (matching upstream iobuf_out).
     let mut writer = writer::ServerWriter::new_plain(stdout);
 

--- a/crates/transfer/src/reader/mod.rs
+++ b/crates/transfer/src/reader/mod.rs
@@ -16,8 +16,8 @@ mod compressed;
 mod tests;
 
 pub(crate) use counting::CountingReader;
-pub(crate) use multiplex::MultiplexReader;
 pub use multiplex::RemoteExitError;
+pub(crate) use multiplex::{DeletedRender, MultiplexReader};
 pub use server::ServerReader;
 
 #[cfg(feature = "tokio-transfer")]

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -53,6 +53,58 @@ impl MuxSink for RealSink {
     }
 }
 
+/// Client-side rendering state for received `MSG_DELETED` frames.
+///
+/// A server generator sends only the raw deleted name (a directory carries a
+/// trailing NUL); the client formats and gates the line itself, exactly as
+/// upstream `log_delete()` does on the non-`am_server` side. Present only on the
+/// client-sender reader (a push, where the remote receiver performs `--delete`);
+/// every other reader leaves it `None` so the `MSG_DELETED` arm is inert.
+///
+/// # Upstream Reference
+///
+/// - `log.c:870-874` - the client renders `stdout_format` (itemize) when set,
+///   else `"deleting %n"`, and skips output when neither `INFO_GTE(DEL, 1)` nor
+///   `stdout_format` is active.
+/// - `io.c:1616-1621` - a trailing NUL in the payload marks a directory.
+#[derive(Clone, Copy)]
+pub(crate) struct DeletedRender {
+    /// `--itemize-changes` is active: render the `*deleting` row form.
+    pub(crate) itemize: bool,
+    /// `INFO_GTE(DEL, 1)` (e.g. `-v` or `--info=del`): render the plain
+    /// `deleting <path>` line when itemize is off.
+    pub(crate) show_plain: bool,
+}
+
+impl DeletedRender {
+    /// Formats a received `MSG_DELETED` payload into the client-visible line, or
+    /// `None` when the current verbosity suppresses it.
+    ///
+    /// upstream: log.c:870-874 - `stdout_format` (itemize) wins over
+    /// `"deleting %n"`; both append a trailing slash for a directory (log.c:%n).
+    fn format(&self, payload: &[u8]) -> Option<String> {
+        if !self.itemize && !self.show_plain {
+            return None;
+        }
+        // upstream: io.c:1616 - a trailing NUL byte marks a deleted directory.
+        let (is_dir, name_bytes) = match payload.split_last() {
+            Some((0, rest)) => (true, rest),
+            _ => (false, payload),
+        };
+        let name = String::from_utf8_lossy(name_bytes);
+        let display = if is_dir {
+            format!("{name}/")
+        } else {
+            name.into_owned()
+        };
+        Some(if self.itemize {
+            format!("*deleting   {display}\n")
+        } else {
+            format!("deleting {display}\n")
+        })
+    }
+}
+
 /// Reader that automatically demultiplexes incoming messages.
 ///
 /// Reads multiplex frames from the wire and extracts MSG_DATA payloads.
@@ -116,6 +168,11 @@ pub(crate) struct MultiplexReader<R> {
     /// Set once a received `MSG_IO_TIMEOUT` violated the upstream `msg_bytes == 4`
     /// / role invariant (upstream `goto invalid_msg`, fatal `RERR_STREAMIO`).
     io_timeout_invalid: bool,
+    /// Client-sender rendering state for `MSG_DELETED` frames. `Some` only on
+    /// the client side of a push, where the remote receiver runs `--delete`;
+    /// every other reader leaves it `None` so the frame is dropped like upstream
+    /// drops it on `am_server`. upstream: log.c:870-874.
+    deleted_render: Option<DeletedRender>,
 }
 
 /// Exit code for partial transfer due to error.
@@ -194,7 +251,20 @@ impl<R> MultiplexReader<R> {
             io_timeout: None,
             io_timeout_reapply: None,
             io_timeout_invalid: false,
+            deleted_render: None,
         }
+    }
+
+    /// Enables client-side rendering of received `MSG_DELETED` frames.
+    ///
+    /// Called only on the client-sender reader (a push, where the remote
+    /// receiver performs `--delete`), so a server or client-receiver reader
+    /// leaves the state unset and silently drops any `MSG_DELETED` frame,
+    /// mirroring upstream's `am_server`/`am_generator` non-rendering path.
+    ///
+    /// upstream: log.c:870-874 `log_delete()` renders on the non-server side.
+    pub(super) fn set_deleted_render(&mut self, render: DeletedRender) {
+        self.deleted_render = Some(render);
     }
 
     /// Installs client-receiver I/O-timeout adoption state.
@@ -521,6 +591,18 @@ impl<R> MultiplexReader<R> {
                 // upstream: io.c:1551-1561
                 self.handle_io_timeout_msg(sink);
             }
+            protocol::MessageCode::Deleted => {
+                // upstream: io.c:1614-1621 + log.c:870-874 - the client formats
+                // the raw deleted name (a trailing NUL marks a directory) and
+                // gates on its own info=del / itemize verbosity. A server or
+                // client-receiver reader has no render state and drops the frame,
+                // matching upstream's non-rendering `am_server` path.
+                if let Some(render) = self.deleted_render {
+                    if let Some(line) = render.format(&self.buffer) {
+                        sink.info(&line);
+                    }
+                }
+            }
             _ => {}
         }
         false
@@ -780,6 +862,84 @@ mod remote_exit_error_tests {
         let mut reader = MultiplexReader::new(io::empty());
         reader.error_exit_code = Some(RERR_PARTIAL);
         assert!(reader.check_error_exit().is_ok());
+    }
+}
+
+/// Tests for the client-side `MSG_DELETED` render, encoding the upstream
+/// `log.c:870-874` + `io.c:1614-1621` contract: the client formats the raw
+/// deleted name (a trailing NUL marks a directory), itemize (`stdout_format`)
+/// wins over `"deleting %n"`, and a reader without render state drops the frame
+/// exactly as upstream drops it on `am_server`.
+#[cfg(test)]
+mod deleted_render_tests {
+    use super::*;
+
+    /// Minimal capturing sink so the render assertion is byte-exact.
+    struct CapturingSink(Vec<String>);
+
+    impl MuxSink for CapturingSink {
+        fn info(&mut self, msg: &str) {
+            self.0.push(msg.to_owned());
+        }
+        fn error(&mut self, _msg: &str) {
+            panic!("MSG_DELETED must render via info(), never error()");
+        }
+    }
+
+    fn render(payload: &[u8], render: DeletedRender) -> Vec<String> {
+        let mut reader = MultiplexReader::new(io::empty());
+        reader.set_deleted_render(render);
+        reader.buffer = payload.to_vec();
+        let mut sink = CapturingSink(Vec::new());
+        // A MSG_DELETED frame never breaks the read loop.
+        assert!(!reader.dispatch_message_with(protocol::MessageCode::Deleted, &mut sink));
+        sink.0
+    }
+
+    #[test]
+    fn plain_render_file_and_dir() {
+        // upstream: log.c:874 "deleting %n"; %n appends a trailing slash for a
+        // directory (the trailing-NUL payload marks it).
+        let cfg = DeletedRender {
+            itemize: false,
+            show_plain: true,
+        };
+        assert_eq!(render(b"foo", cfg), vec!["deleting foo\n".to_owned()]);
+        assert_eq!(render(b"bar\0", cfg), vec!["deleting bar/\n".to_owned()]);
+    }
+
+    #[test]
+    fn itemize_render_wins_over_plain() {
+        // upstream: log.c:873 - stdout_format (itemize) is used instead of the
+        // plain form when active, even at -v.
+        let cfg = DeletedRender {
+            itemize: true,
+            show_plain: true,
+        };
+        assert_eq!(render(b"foo", cfg), vec!["*deleting   foo\n".to_owned()]);
+        assert_eq!(render(b"bar\0", cfg), vec!["*deleting   bar/\n".to_owned()]);
+    }
+
+    #[test]
+    fn suppressed_when_neither_gate_active() {
+        // upstream: log.c:870 - `!INFO_GTE(DEL,1) && !stdout_format` prints
+        // nothing even though the frame arrived.
+        let cfg = DeletedRender {
+            itemize: false,
+            show_plain: false,
+        };
+        assert!(render(b"foo", cfg).is_empty());
+    }
+
+    #[test]
+    fn dropped_without_render_state() {
+        // A server or client-receiver reader never enables rendering, so a
+        // MSG_DELETED frame is silently dropped (upstream `am_server` path).
+        let mut reader = MultiplexReader::new(io::empty());
+        reader.buffer = b"foo".to_vec();
+        let mut sink = CapturingSink(Vec::new());
+        assert!(!reader.dispatch_message_with(protocol::MessageCode::Deleted, &mut sink));
+        assert!(sink.0.is_empty());
     }
 }
 

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -23,6 +23,10 @@ pub struct ServerReader<R: Read> {
     /// starts in Plain mode. `(current --timeout secs, live-socket re-apply)`.
     /// upstream: io.c:1551-1561 read_a_msg() case MSG_IO_TIMEOUT.
     pending_io_timeout_adoption: Option<(Option<u32>, crate::handshake::IoTimeoutReapply)>,
+    /// Client-sender `MSG_DELETED` render state, applied to the
+    /// `MultiplexReader` on multiplex activation. `Some` only on a push where
+    /// the remote receiver performs `--delete`. upstream: log.c:870-874.
+    pending_deleted_render: Option<super::DeletedRender>,
 }
 
 #[allow(private_interfaces)]
@@ -44,7 +48,19 @@ impl<R: Read> ServerReader<R> {
             inner: ServerReaderInner::Plain(reader),
             pending_batch_recorder: None,
             pending_io_timeout_adoption: None,
+            pending_deleted_render: None,
         }
+    }
+
+    /// Enables client-side rendering of received `MSG_DELETED` frames.
+    ///
+    /// Applied to the `MultiplexReader` on `activate_multiplex`. Called only on
+    /// the client-sender path of a push, where the remote receiver performs
+    /// `--delete`; every other reader leaves it unset and drops the frames.
+    ///
+    /// upstream: log.c:870-874 `log_delete()` renders on the non-server side.
+    pub(crate) fn enable_deleted_render(&mut self, render: super::DeletedRender) {
+        self.pending_deleted_render = Some(render);
     }
 
     /// Registers client-receiver I/O-timeout adoption state.
@@ -106,10 +122,14 @@ impl<R: Read> ServerReader<R> {
                 if let Some((current, reapply)) = self.pending_io_timeout_adoption {
                     mux.set_io_timeout_adoption(current, reapply);
                 }
+                if let Some(render) = self.pending_deleted_render {
+                    mux.set_deleted_render(render);
+                }
                 Ok(Self {
                     inner: ServerReaderInner::Multiplex(mux),
                     pending_batch_recorder: None,
                     pending_io_timeout_adoption: None,
+                    pending_deleted_render: None,
                 })
             }
             ServerReaderInner::Multiplex(_) => Err(io::Error::new(
@@ -148,6 +168,7 @@ impl<R: Read> ServerReader<R> {
                     inner: ServerReaderInner::Compressed(compressed),
                     pending_batch_recorder: None,
                     pending_io_timeout_adoption: None,
+                    pending_deleted_render: None,
                 })
             }
             ServerReaderInner::Plain(_) => Err(io::Error::new(

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -24,6 +24,75 @@ use protocol::stats::DeleteStats;
 use super::normalize_filename_for_compare;
 use crate::receiver::ReceiverContext;
 
+/// Upstream `MAXPATHLEN` (`rsync.h`): a deleted name is only sent as a
+/// `MSG_DELETED` frame when `len < MAXPATHLEN` (`log.c:866`); longer names fall
+/// back to the local render path.
+const MAXPATHLEN: usize = 4096;
+
+/// Routes one deletion notification the way upstream `log_delete()` does.
+///
+/// A server generator (`server_mode`, i.e. `am_server`) at protocol >= 29 sends
+/// the raw name to the client as a `MSG_DELETED` frame and prints nothing
+/// locally; the client formats and gates the `deleting`/`*deleting` line. Every
+/// other side (a local or client-side receiver) renders directly, exactly as
+/// before.
+///
+/// # Upstream Reference
+///
+/// - `log.c:845-875` - `log_delete()`: `am_server && protocol_version >= 29 &&
+///   len < MAXPATHLEN` emits `send_msg(MSG_DELETED, fname, len, ...)`, otherwise
+///   `log_formatted(FCLIENT, "deleting %n" | stdout_format, ...)`.
+/// - `log.c:867-868` - a directory bumps `len` to include its trailing NUL.
+fn emit_delete_notification<W: crate::writer::MsgInfoSender + ?Sized>(
+    writer: &mut W,
+    rel: &Path,
+    is_dir: bool,
+    server_mode: bool,
+    protocol: u8,
+    emit_itemize: bool,
+) {
+    if server_mode && protocol >= 29 {
+        let name = path_wire_bytes(rel);
+        if name.len() < MAXPATHLEN {
+            // upstream: log.c:867-868 - a directory carries a trailing NUL so
+            // the reader (io.c:1616) can distinguish it from a regular file.
+            let mut payload = name;
+            if is_dir {
+                payload.push(0);
+            }
+            let _ = writer.send_msg_deleted(&payload);
+            return;
+        }
+    }
+    // upstream: log.c:872-874 - a local/client receiver renders "deleting %n"
+    // directly; %n (log.c:633-641) appends a trailing slash for a directory.
+    if is_dir {
+        info_log!(Del, 1, "deleting {}/", rel.display());
+    } else {
+        info_log!(Del, 1, "deleting {}", rel.display());
+    }
+    if emit_itemize {
+        // upstream: log.c:log_delete() emits the "*deleting" itemize row when
+        // --itemize-changes is active.
+        let line = format!("*deleting   {}\n", rel.display());
+        let _ = writer.send_msg_info(line.as_bytes());
+    }
+}
+
+/// Returns the on-the-wire bytes of a deletion-root-relative name, matching the
+/// raw `fname` upstream passes to `send_msg(MSG_DELETED, ...)` (`log.c:869`).
+fn path_wire_bytes(rel: &Path) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        rel.as_os_str().as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        rel.to_string_lossy().into_owned().into_bytes()
+    }
+}
+
 /// A single deleted destination entry carried out of the parallel scan
 /// workers so its `deleting`/`*deleting` line can be emitted in upstream's
 /// deterministic per-directory sorted order rather than the hash-random
@@ -211,6 +280,8 @@ impl ReceiverContext {
         let mut stats = DeleteStats::new();
         let mut io_bits: i32 = 0;
         let emit_itemize = self.should_emit_itemize();
+        let server_mode = !self.config.connection.client_mode;
+        let protocol = self.protocol.as_u8();
         for entry in victims {
             let path = dest_dir.join(&entry.rel);
             let result = if entry.is_dir {
@@ -249,19 +320,19 @@ impl ReceiverContext {
                 Ok(()) => {
                     if entry.is_dir {
                         stats.dirs += 1;
-                        info_log!(Del, 1, "deleting {}/", entry.rel.display());
+                    } else if entry.is_symlink {
+                        stats.symlinks += 1;
                     } else {
-                        if entry.is_symlink {
-                            stats.symlinks += 1;
-                        } else {
-                            stats.files += 1;
-                        }
-                        info_log!(Del, 1, "deleting {}", entry.rel.display());
+                        stats.files += 1;
                     }
-                    if emit_itemize {
-                        let line = format!("*deleting   {}\n", entry.rel.display());
-                        let _ = writer.send_msg_info(line.as_bytes());
-                    }
+                    emit_delete_notification(
+                        writer,
+                        &entry.rel,
+                        entry.is_dir,
+                        server_mode,
+                        protocol,
+                        emit_itemize,
+                    );
                 }
                 Err(e) => {
                     debug_log!(Del, 1, "failed to delete {}: {}", path.display(), e);
@@ -915,21 +986,20 @@ impl ReceiverContext {
         // time. The ordered victim list is returned for that later execution.
         if !collect_only {
             let emit_itemize = self.should_emit_itemize();
+            let server_mode = !self.config.connection.client_mode;
+            let protocol = self.protocol.as_u8();
             for entry in &all_deleted {
-                // upstream: log.c:845 log_delete uses one "deleting %n" form; %n
-                // (log.c:633-641) appends a trailing slash for directories, so a
-                // dir prints "deleting sub/" - no word "directory".
-                if entry.is_dir {
-                    info_log!(Del, 1, "deleting {}/", entry.rel.display());
-                } else {
-                    info_log!(Del, 1, "deleting {}", entry.rel.display());
-                }
-                // upstream: log.c:log_delete() emits the "*deleting" itemize line
-                // for each deleted item when --itemize-changes is active.
-                if emit_itemize {
-                    let line = format!("*deleting   {}\n", entry.rel.display());
-                    let _ = writer.send_msg_info(line.as_bytes());
-                }
+                // upstream: log.c:845 log_delete() - a server generator forwards
+                // the raw name as MSG_DELETED; a local/client receiver renders
+                // "deleting %n" directly (%n appends a trailing slash for dirs).
+                emit_delete_notification(
+                    writer,
+                    &entry.rel,
+                    entry.is_dir,
+                    server_mode,
+                    protocol,
+                    emit_itemize,
+                );
             }
         }
 
@@ -987,6 +1057,8 @@ impl ReceiverContext {
             combined: DeleteStats::new(),
             io_err_bits: 0,
             emit_itemize: self.should_emit_itemize(),
+            server_mode: !self.config.connection.client_mode,
+            protocol: self.protocol.as_u8(),
             writer,
         };
 
@@ -1144,6 +1216,11 @@ struct CappedDeleteState<'w, W: ?Sized> {
     combined: DeleteStats,
     io_err_bits: i32,
     emit_itemize: bool,
+    /// `true` when this receiver is a server generator (`am_server`) and must
+    /// forward deletions to the client as `MSG_DELETED` rather than render them.
+    server_mode: bool,
+    /// Negotiated protocol version, gating the `>= 29` `MSG_DELETED` path.
+    protocol: u8,
     writer: &'w mut W,
 }
 
@@ -1300,16 +1377,17 @@ impl<W: crate::writer::MsgInfoSender + ?Sized> CappedDeleteState<'_, W> {
                 } else {
                     self.combined.files = self.combined.files.saturating_add(1);
                 }
-                // upstream: log.c:log_delete() emits one line per deleted item.
-                if is_dir {
-                    info_log!(Del, 1, "deleting {}/", rel.display());
-                } else {
-                    info_log!(Del, 1, "deleting {}", rel.display());
-                }
-                if self.emit_itemize {
-                    let line = format!("*deleting   {}\n", rel.display());
-                    let _ = self.writer.send_msg_info(line.as_bytes());
-                }
+                // upstream: log.c:log_delete() emits one line per deleted item -
+                // forwarded as MSG_DELETED on a server generator, rendered
+                // directly otherwise.
+                emit_delete_notification(
+                    self.writer,
+                    rel,
+                    is_dir,
+                    self.server_mode,
+                    self.protocol,
+                    self.emit_itemize,
+                );
                 Ok(true)
             }
             Err(e) => {
@@ -1419,6 +1497,103 @@ fn fail_loud_unlink_error(e: io::Error) -> Option<io::Error> {
 #[cfg(unix)]
 fn crosses_mount_boundary(boundary_dev: u64, entry_dev: u64) -> bool {
     entry_dev != boundary_dev
+}
+
+/// Tests for the server-vs-local routing of a deletion notification, encoding
+/// the upstream `log.c:866-874` gate: a server generator at protocol >= 29
+/// forwards the raw name (dir bytes + trailing NUL) as MSG_DELETED and prints
+/// nothing locally; every other side renders `deleting %n` directly.
+#[cfg(test)]
+mod emit_notification_tests {
+    use super::*;
+    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, init};
+
+    /// Records the frames a receiver would put on the wire.
+    #[derive(Default)]
+    struct RecordingWriter {
+        deleted: Vec<Vec<u8>>,
+        info: Vec<Vec<u8>>,
+    }
+
+    impl crate::writer::MsgInfoSender for RecordingWriter {
+        fn send_msg_deleted(&mut self, data: &[u8]) -> io::Result<()> {
+            self.deleted.push(data.to_vec());
+            Ok(())
+        }
+        fn send_msg_info(&mut self, data: &[u8]) -> io::Result<()> {
+            self.info.push(data.to_vec());
+            Ok(())
+        }
+    }
+
+    fn del_events() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|e| match e {
+                DiagnosticEvent::Info {
+                    flag: InfoFlag::Del,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn server_generator_forwards_msg_deleted_not_local_print() {
+        let mut cfg = VerbosityConfig::default();
+        cfg.info.del = 1;
+        init(cfg);
+        let _ = drain_events();
+
+        let mut w = RecordingWriter::default();
+        // server_mode=true, proto 32: file -> raw name, dir -> name + NUL.
+        emit_delete_notification(&mut w, Path::new("foo"), false, true, 32, false);
+        emit_delete_notification(&mut w, Path::new("sub/bar"), true, true, 32, false);
+
+        assert_eq!(w.deleted, vec![b"foo".to_vec(), b"sub/bar\0".to_vec()]);
+        // Server prints nothing locally: the client renders from the wire.
+        assert!(w.info.is_empty());
+        assert!(
+            del_events().is_empty(),
+            "server must not emit local Del lines"
+        );
+    }
+
+    #[test]
+    fn local_receiver_renders_directly_no_frame() {
+        let mut cfg = VerbosityConfig::default();
+        cfg.info.del = 1;
+        init(cfg);
+        let _ = drain_events();
+
+        let mut w = RecordingWriter::default();
+        // server_mode=false: local/client receiver renders "deleting %n".
+        emit_delete_notification(&mut w, Path::new("foo"), false, false, 32, false);
+        emit_delete_notification(&mut w, Path::new("bar"), true, false, 32, false);
+
+        assert!(w.deleted.is_empty(), "a local receiver sends no wire frame");
+        assert_eq!(
+            del_events(),
+            vec!["deleting foo".to_owned(), "deleting bar/".to_owned()]
+        );
+    }
+
+    #[test]
+    fn protocol_below_29_falls_back_to_local_render() {
+        let mut cfg = VerbosityConfig::default();
+        cfg.info.del = 1;
+        init(cfg);
+        let _ = drain_events();
+
+        let mut w = RecordingWriter::default();
+        // upstream: log.c:866 - the MSG_DELETED path requires protocol >= 29.
+        emit_delete_notification(&mut w, Path::new("foo"), false, true, 28, false);
+
+        assert!(w.deleted.is_empty(), "proto 28 must not send MSG_DELETED");
+        assert_eq!(del_events(), vec!["deleting foo".to_owned()]);
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/crates/transfer/src/receiver/tests/support.rs
+++ b/crates/transfer/src/receiver/tests/support.rs
@@ -179,8 +179,14 @@ impl crate::writer::MsgInfoSender for TestDeletionWriter {
     }
 }
 
-/// Writer that records every `MSG_INFO` frame so tests can assert the
-/// emitted `*deleting` itemize order.
+/// Writer that records every client-visible delete itemize row so tests can
+/// assert the emitted `*deleting` order.
+///
+/// A local/client receiver renders the row itself and forwards it as a
+/// `MSG_INFO` frame; a server generator instead forwards the raw deleted name
+/// as a `MSG_DELETED` frame that the client renders into the same
+/// `*deleting   <name>` row (upstream `log.c:869` vs `log.c:873`). Both channels
+/// are captured here so the order assertion holds regardless of role.
 #[cfg(unix)]
 #[derive(Default)]
 pub(super) struct CapturingDeletionWriter {
@@ -202,6 +208,24 @@ impl crate::writer::MsgInfoSender for CapturingDeletionWriter {
     fn send_msg_info(&mut self, data: &[u8]) -> io::Result<()> {
         self.lines
             .push(String::from_utf8_lossy(data).trim_end().to_owned());
+        Ok(())
+    }
+
+    fn send_msg_deleted(&mut self, data: &[u8]) -> io::Result<()> {
+        // Reproduce the client-side render (DeletedRender, itemize form): a
+        // trailing NUL marks a directory (upstream io.c:1616), which the client
+        // prints with a trailing slash.
+        let (is_dir, name_bytes) = match data.split_last() {
+            Some((0, rest)) => (true, rest),
+            _ => (false, data),
+        };
+        let name = String::from_utf8_lossy(name_bytes);
+        let display = if is_dir {
+            format!("{name}/")
+        } else {
+            name.into_owned()
+        };
+        self.lines.push(format!("*deleting   {display}"));
         Ok(())
     }
 }

--- a/crates/transfer/src/writer/msg_info.rs
+++ b/crates/transfer/src/writer/msg_info.rs
@@ -47,6 +47,23 @@ pub trait MsgInfoSender {
     fn send_msg_error_xfer(&mut self, _data: &[u8]) -> io::Result<()> {
         Ok(())
     }
+
+    /// Sends a `MSG_DELETED` frame carrying the raw name of a deleted entry.
+    ///
+    /// A server generator emits one frame per deletion so the client renders the
+    /// `deleting <path>` line itself (the client owns the verbosity and itemize
+    /// gating). Directories carry a trailing NUL in `data` so the peer can tell
+    /// a directory from a regular file (upstream `io.c:1616`).
+    ///
+    /// The default implementation is a no-op, matching [`Self::send_msg_info`].
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:866-869` - `am_server && protocol_version >= 29` sends
+    ///   `send_msg(MSG_DELETED, fname, len, am_generator)`.
+    fn send_msg_deleted(&mut self, _data: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 impl<W: Write> MsgInfoSender for ServerWriter<W> {
@@ -67,6 +84,16 @@ impl<W: Write> MsgInfoSender for ServerWriter<W> {
             Ok(())
         }
     }
+
+    fn send_msg_deleted(&mut self, data: &[u8]) -> io::Result<()> {
+        // upstream: log.c:866-869 - the MSG_DELETED path only exists on a
+        // multiplexed server stream; plain mode never reaches this branch.
+        if self.is_multiplexed() {
+            self.send_message(MessageCode::Deleted, data)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
@@ -77,6 +104,10 @@ impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
     fn send_msg_error_xfer(&mut self, data: &[u8]) -> io::Result<()> {
         (**self).send_msg_error_xfer(data)
     }
+
+    fn send_msg_deleted(&mut self, data: &[u8]) -> io::Result<()> {
+        (**self).send_msg_deleted(data)
+    }
 }
 
 impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
@@ -86,5 +117,9 @@ impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
 
     fn send_msg_error_xfer(&mut self, data: &[u8]) -> io::Result<()> {
         self.inner_ref_mut().send_msg_error_xfer(data)
+    }
+
+    fn send_msg_deleted(&mut self, data: &[u8]) -> io::Result<()> {
+        self.inner_ref_mut().send_msg_deleted(data)
     }
 }


### PR DESCRIPTION
## Summary

Wires the `MSG_DELETED` (multiplex tag 101) message end-to-end so a server
generator performing `--delete` forwards each deletion to the client over the
wire, exactly as upstream rsync does. Previously a server-side `--delete` pass
rendered its `deleting <path>` lines into a thread-local buffer that is never
drained on the remote side, so a `-v --delete` push produced no client-visible
deletion output, and the `-i` push routed the row through `MSG_INFO` rather than
the dedicated `MSG_DELETED` tag. A client receiving `MSG_DELETED` from an
upstream server silently dropped the frame.

## Upstream behaviour mirrored

- `rsync.h:300` - `MSG_DELETED = 101`.
- `log.c:866-869` `log_delete()` - `am_server && protocol_version >= 29 &&
  len < MAXPATHLEN` sends `send_msg(MSG_DELETED, fname, len, ...)`; a directory
  bumps `len` to include its trailing NUL (`log.c:867-868`). Otherwise the line
  is rendered locally (`log.c:872-874`, `"deleting %n"` or the itemize format).
- `io.c:1614-1621` - the reader treats a trailing NUL as a directory marker,
  then calls `log_delete()`, which on the non-server side formats and gates the
  line on `INFO_GTE(DEL, 1)` / `stdout_format`.
- `options.c:251` - verbose level 1 sets `DEL=1`, so `-v` enables the plain
  form.

## Changes

- `protocol`: `MessageCode::Deleted` (101) already existed and the multiplex
  frame layer is generic over the tag, so no production change was needed. Added
  a golden byte test pinning the exact wire bytes (header tag `0x6C` plus
  payload, with the directory trailing-NUL convention) and the send/recv round
  trip.
- `transfer` writer: added `MsgInfoSender::send_msg_deleted`, emitting a
  `MSG_DELETED` frame on a multiplexed server stream (no-op otherwise).
- `transfer` receiver delete pass: a single `emit_delete_notification` helper
  routes each deletion the way `log_delete()` does - a server generator at
  protocol >= 29 forwards the raw name (directory + trailing NUL) and prints
  nothing locally; every other side renders `deleting %n` directly as before.
  Applied to all three emit sites (immediate parallel pass, `--delete-delay`
  executor, and the `--max-delete` capped serial path).
- `transfer` reader: the client-sender demux now renders received `MSG_DELETED`
  frames, formatting `deleting <path>` / `*deleting   <path>` (directories get a
  trailing slash) and gating on the client's own info=del / itemize verbosity.
  The render state is captured on the setup thread and plumbed through
  `ServerReader`, so a server or client-receiver reader leaves it unset and
  drops the frame, matching upstream's non-rendering `am_server` path.

## Tests

- Golden byte test for the `MSG_DELETED` frame (file payload, directory
  trailing-NUL payload, header tag, send/recv round trip).
- Client render unit tests: plain and itemize forms for files and directories,
  itemize-wins-over-plain precedence, suppression when neither gate is active,
  and drop-without-render-state.
- Server-vs-local routing unit tests: a server generator forwards `MSG_DELETED`
  and prints nothing locally; a local/client receiver renders directly with no
  frame; protocol < 29 falls back to the local render path.

All new tests pass; the existing deletion, delete-timing, and filter-chain
suites remain green. `cargo fmt`, workspace `clippy -D warnings`, protocol and
transfer targeted tests all clean.
