### PR TITLE
fix: wire check_sub_protocol into live server handshake

### DIFF
--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -66,7 +66,10 @@ pub fn run_server_stdio(
     // The handshake is intrinsically part of the server body; perform it inside
     // the same driver invocation so the tokio path is a drop-in for the
     // threaded `transfer::run_server_stdio` (which does handshake + transfer).
-    let handshake = transfer::perform_handshake(stdin, stdout)?;
+    // upstream: compat.c:600-602 - reconcile a pre-release peer's subprotocol
+    // (carried in its `-e` capability string) before advertising our version.
+    // Wire-identical to a plain handshake for any stock release peer.
+    let handshake = transfer::perform_server_handshake(stdin, stdout, &config.flag_string)?;
     with_transfer_runtime(|handle| {
         transfer::run_server_with_handshake_on(
             handle, config, handshake, stdin, stdout, progress, None, None,

--- a/crates/transfer/src/handshake.rs
+++ b/crates/transfer/src/handshake.rs
@@ -16,7 +16,10 @@
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::sync::Arc;
 
-use protocol::{CompatibilityFlags, NegotiationResult, ProtocolVersion, select_highest_mutual};
+use protocol::{
+    CompatibilityFlags, NegotiationResult, ProtocolVersion, check_sub_protocol,
+    get_subprotocol_version, select_highest_mutual,
+};
 
 /// Re-applies an adopted daemon `MSG_IO_TIMEOUT` to the live client socket.
 ///
@@ -94,6 +97,57 @@ pub fn perform_handshake(
     stdout: &mut dyn Write,
 ) -> io::Result<HandshakeResult> {
     perform_handshake_with_max(stdin, stdout, ProtocolVersion::NEWEST)
+}
+
+/// Performs the server-side version handshake, reconciling a pre-release peer's
+/// subprotocol before advertising our protocol version.
+///
+/// upstream: compat.c:600-602 `setup_protocol()` - on the server side of a
+/// non-local (remote-shell) transfer the server runs `check_sub_protocol()`
+/// (compat.c:133-160) against the client's advertised `VER.SUB` BEFORE it writes
+/// its own protocol version. The client's `VER.SUB` rides its `-e` capability
+/// string (`client_info = shell_cmd`, compat.c:163-164), which oc receives in the
+/// compact server flag string. When both sides are final releases (subprotocol
+/// 0) this is a no-op and the exchange is byte-identical to [`perform_handshake`];
+/// only a pre-release peer triggers the one-step downgrade.
+///
+/// `client_flags` is the compact server flag string the client sent (oc's
+/// equivalent of upstream `shell_cmd`). A release peer that advertised no
+/// pre-release `VER.SUB` yields no downgrade and the uncapped newest-version
+/// handshake stands.
+pub fn perform_server_handshake(
+    stdin: &mut dyn Read,
+    stdout: &mut dyn Write,
+    client_flags: &str,
+) -> io::Result<HandshakeResult> {
+    let effective = reconcile_subprotocol(ProtocolVersion::NEWEST, client_flags);
+    perform_handshake_with_max(stdin, stdout, effective)
+}
+
+/// Applies upstream `check_sub_protocol()` (compat.c:133-160) to derive the
+/// protocol version the server advertises after reconciling the peer's
+/// pre-release `VER.SUB`.
+///
+/// upstream: compat.c:602 - the reconciliation runs against `protocol_version`
+/// (here `max_version`, the newest version the server would otherwise advertise)
+/// and lowers it by one step when the peer is a pre-release whose subprotocol is
+/// incompatible with ours. A stock release peer parses to `(0, 0)` and leaves the
+/// version unchanged, so the write remains wire-identical to [`perform_handshake`].
+fn reconcile_subprotocol(max_version: ProtocolVersion, client_flags: &str) -> ProtocolVersion {
+    let (their_protocol, their_sub) = crate::setup::parse_peer_subprotocol(client_flags);
+    // upstream: compat.c:137 `get_subprotocol_version()` - a release oc build
+    // (SUBPROTOCOL_VERSION == 0) always advertises subprotocol 0.
+    let our_sub = get_subprotocol_version(max_version.as_u8());
+    let reconciled = check_sub_protocol(max_version.as_u8(), our_sub, their_protocol, their_sub);
+    if reconciled == max_version.as_u8() {
+        return max_version;
+    }
+    // check_sub_protocol never raises the version. Clamp the (unreachable for a
+    // release peer) sub-OLDEST result to the floor so the downgrade direction is
+    // preserved, mirroring upstream which advertises the lowered value and lets
+    // the later MIN_PROTOCOL_VERSION guard reject anything too old.
+    let floor = ProtocolVersion::OLDEST.as_u8();
+    ProtocolVersion::try_from(reconciled.max(floor)).unwrap_or(max_version)
 }
 
 /// Performs the version handshake while advertising at most `max_version`.
@@ -339,6 +393,109 @@ mod tests {
 
         let result = perform_handshake(&mut stdin, &mut stdout);
         assert!(result.is_err());
+    }
+
+    // upstream: compat.c:600-602 + compat.c:156-159 - the non-local server runs
+    // check_sub_protocol() before writing its version. A pre-release peer of the
+    // SAME protocol whose subprotocol differs from ours forces the one-step
+    // downgrade so both sides drop to the last mutually compatible protocol.
+    // This is the WHY: without it, an oc server would advertise 32 to a
+    // pre-release-32 peer and the two would disagree on wire semantics.
+    #[test]
+    fn server_handshake_downgrades_against_equal_prerelease_peer() {
+        // Peer advertises numeric protocol 32 and, via its `-e` capability
+        // string, subprotocol 7 of protocol 32 (a pre-release).
+        let mut stdin = Cursor::new(vec![32, 0, 0, 0]);
+        let mut stdout = Vec::new();
+
+        let result = perform_server_handshake(&mut stdin, &mut stdout, "-logDtpre32.7LsfxCIvu")
+            .expect("handshake succeeds");
+
+        assert_eq!(result.protocol, ProtocolVersion::V31);
+        assert_eq!(
+            stdout[0], 31,
+            "server must advertise the downgraded version"
+        );
+    }
+
+    // upstream: compat.c:150-154 - a pre-release of an OLDER protocol pins the
+    // negotiated version to the last release of that older protocol.
+    #[test]
+    fn server_handshake_downgrades_against_older_prerelease_peer() {
+        // Peer is a pre-release of protocol 30 (subprotocol 5).
+        let mut stdin = Cursor::new(vec![30, 0, 0, 0]);
+        let mut stdout = Vec::new();
+
+        let result = perform_server_handshake(&mut stdin, &mut stdout, "-logDtpre30.5LsfxCIvu")
+            .expect("handshake succeeds");
+
+        assert_eq!(result.protocol, ProtocolVersion::V29);
+        assert_eq!(stdout[0], 29, "pins to their_protocol - 1");
+    }
+
+    // upstream: compat.c:139-148 - a stock release peer advertises `-e.<caps>`
+    // whose leading '.' makes `atoi` return 0, so check_sub_protocol is a no-op.
+    // This is the wire-transparency guarantee: current behaviour is unchanged for
+    // every real release peer.
+    #[test]
+    fn server_handshake_noop_against_release_peer() {
+        let mut stdin = Cursor::new(vec![32, 0, 0, 0]);
+        let mut stdout = Vec::new();
+
+        let result = perform_server_handshake(&mut stdin, &mut stdout, "-logDtpre.LsfxCIvu")
+            .expect("handshake succeeds");
+
+        assert_eq!(result.protocol, ProtocolVersion::NEWEST);
+        assert_eq!(stdout[0], ProtocolVersion::NEWEST.as_u8());
+    }
+
+    // A flag string with no `-e` capability payload carries no VER.SUB, so there
+    // is nothing to reconcile and the newest version stands.
+    #[test]
+    fn server_handshake_noop_without_capability_string() {
+        let mut stdin = Cursor::new(vec![32, 0, 0, 0]);
+        let mut stdout = Vec::new();
+
+        let result = perform_server_handshake(&mut stdin, &mut stdout, "-logDtpr")
+            .expect("handshake succeeds");
+
+        assert_eq!(result.protocol, ProtocolVersion::NEWEST);
+        assert_eq!(stdout[0], ProtocolVersion::NEWEST.as_u8());
+    }
+
+    // upstream: compat.c:600-601 - check_sub_protocol runs ONLY on the server
+    // (am_server && !local_server). The client-side handshake has no client_info
+    // channel, so a plain `perform_handshake` never reconciles: even when the
+    // peer would be a pre-release, the client leaves the version untouched.
+    #[test]
+    fn client_handshake_never_reconciles() {
+        let mut stdin = Cursor::new(vec![32, 0, 0, 0]);
+        let mut stdout = Vec::new();
+
+        let result = perform_handshake(&mut stdin, &mut stdout).expect("handshake succeeds");
+
+        assert_eq!(result.protocol, ProtocolVersion::NEWEST);
+        assert_eq!(stdout[0], ProtocolVersion::NEWEST.as_u8());
+    }
+
+    // Pins the reconciliation mapping directly, independent of the I/O exchange.
+    // upstream: compat.c:133-160 check_sub_protocol() driven from a release side.
+    #[test]
+    fn reconcile_subprotocol_matches_check_sub_protocol() {
+        let newest = ProtocolVersion::NEWEST;
+        // Release peer / no VER.SUB -> unchanged.
+        assert_eq!(reconcile_subprotocol(newest, "-e.LsfxCIvu"), newest);
+        assert_eq!(reconcile_subprotocol(newest, ""), newest);
+        // Equal-protocol pre-release peer -> newest - 1.
+        assert_eq!(
+            reconcile_subprotocol(newest, "-e32.4LsfxCIvu"),
+            ProtocolVersion::V31,
+        );
+        // Older-protocol pre-release peer -> their_protocol - 1.
+        assert_eq!(
+            reconcile_subprotocol(newest, "-e31.2LsfxCIvu"),
+            ProtocolVersion::V30,
+        );
     }
 
     #[test]

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -175,7 +175,7 @@ pub use self::generator::{
 };
 pub use self::handshake::{
     HandshakeResult, IoTimeoutReapply, perform_handshake, perform_handshake_with_max,
-    perform_legacy_handshake,
+    perform_legacy_handshake, perform_server_handshake,
 };
 pub use self::reader::RemoteExitError;
 pub use self::receiver::{ListOnlyEntry, ReceiverContext, SumHead, TransferStats};
@@ -330,7 +330,11 @@ pub fn run_server_stdio(
     stdout: &mut dyn Write,
     progress: Option<&mut dyn TransferProgressCallback>,
 ) -> ServerResult {
-    let handshake = perform_handshake(stdin, stdout)?;
+    // upstream: compat.c:600-602 - the non-local server reconciles the client's
+    // pre-release subprotocol (carried in its `-e` capability string) before it
+    // writes its protocol version. For a stock release peer this is a no-op and
+    // the version exchange is byte-identical to a plain `perform_handshake`.
+    let handshake = perform_server_handshake(stdin, stdout, &config.flag_string)?;
     run_server_with_handshake(
         config,
         handshake,

--- a/crates/transfer/src/setup/capability.rs
+++ b/crates/transfer/src/setup/capability.rs
@@ -262,6 +262,78 @@ pub(crate) fn parse_client_info(client_args: &[String]) -> Cow<'_, str> {
     Cow::Borrowed("")
 }
 
+/// Extracts a peer's advertised `(protocol, subprotocol)` from the `-e`
+/// capability payload embedded in a compact server flag string, mirroring
+/// upstream `check_sub_protocol`'s parse of `client_info` (compat.c:139-148).
+///
+/// Upstream's `client_info` is the raw value of the client's `-e` option
+/// (`client_info = shell_cmd`, compat.c:163-164). A pre-release client
+/// negotiating the newest protocol emits `-e<proto>.<sub><caps>`
+/// (options.c:3031-3036), e.g. `-e32.7LsfxCIvu`; a release client emits
+/// `-e.<caps>`, e.g. `-e.LsfxCIvu`. `check_sub_protocol()` then computes
+/// `their_protocol = atoi(client_info)` and, when a `.` follows,
+/// `their_sub = atoi(dot+1)`. The leading `.` of a release payload makes the
+/// first `atoi` return `0`, folding into the "no pre-release info" branch.
+///
+/// Returns `(0, 0)` when there is no usable VER.SUB - a release peer, no `-e`
+/// payload, or a value whose protocol or subprotocol parses as zero - so the
+/// caller's `check_sub_protocol` is a no-op against every stock release peer.
+pub(crate) fn parse_peer_subprotocol(flag_string: &str) -> (u8, u8) {
+    let Some(info) = e_capability_payload(flag_string) else {
+        return (0, 0);
+    };
+    // upstream: compat.c:140 `atoi(client_info)` - a leading '.' (release peer)
+    // or any non-digit start yields 0.
+    let their_protocol = leading_atoi(info);
+    if their_protocol == 0 {
+        return (0, 0);
+    }
+    // upstream: compat.c:141 `strchr(client_info, '.')` then `atoi(dot+1)`.
+    let Some(dot) = info.find('.') else {
+        return (0, 0);
+    };
+    let their_sub = leading_atoi(&info[dot + 1..]);
+    if their_sub == 0 {
+        return (0, 0);
+    }
+    (their_protocol, their_sub)
+}
+
+/// Returns the raw capability payload following the `-e` option letter in a
+/// compact flag string (everything after the first `e` in a `-`-prefixed,
+/// non-`--` token), WITHOUT stripping the leading VER.SUB placeholder.
+///
+/// This is upstream's `client_info` string. Unlike [`parse_client_info`], the
+/// leading `.`/`<proto>.<sub>` prefix is preserved so the subprotocol can be
+/// read by [`parse_peer_subprotocol`].
+fn e_capability_payload(flag_string: &str) -> Option<&str> {
+    for token in flag_string.split_whitespace() {
+        if token.starts_with('-')
+            && !token.starts_with("--")
+            && let Some(e_pos) = token.find('e')
+            && e_pos + 1 < token.len()
+        {
+            return Some(&token[e_pos + 1..]);
+        }
+    }
+    None
+}
+
+/// Mirrors C `atoi` for the leading run of ASCII digits, saturating at
+/// `u8::MAX`. A non-digit prefix (e.g. the release `.` placeholder) yields 0.
+fn leading_atoi(s: &str) -> u8 {
+    let mut value: u32 = 0;
+    for byte in s.bytes() {
+        if !byte.is_ascii_digit() {
+            break;
+        }
+        value = value
+            .saturating_mul(10)
+            .saturating_add(u32::from(byte - b'0'));
+    }
+    value.min(u32::from(u8::MAX)) as u8
+}
+
 /// Builds compatibility flags based on client capabilities.
 ///
 /// Uses table-driven approach for maintainability. This mirrors upstream

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -25,6 +25,7 @@ mod negotiator;
 mod restrictions;
 mod types;
 
+pub(crate) use capability::parse_peer_subprotocol;
 pub use capability::{build_capability_string, build_capability_string_suffix};
 pub use compat::exchange_compat_flags_direct;
 pub use negotiator::{

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -2026,3 +2026,29 @@ fn no_crtimes_never_aborts_even_without_varint_flist_flags() {
     let peer_flags = CompatibilityFlags::from_bits(0);
     assert!(require_crtimes_capability(false, peer_flags).is_ok());
 }
+
+// upstream: compat.c:139-148 - parse a peer's advertised (protocol, subprotocol)
+// from its `-e` capability payload exactly as check_sub_protocol() does.
+#[test]
+fn parse_peer_subprotocol_reads_prerelease_ver_sub() {
+    // Pre-release peer at the newest protocol: "-e32.7<caps>".
+    assert_eq!(parse_peer_subprotocol("-logDtpre32.7LsfxCIvu"), (32, 7));
+    // Pre-release peer of an older protocol.
+    assert_eq!(parse_peer_subprotocol("-logDtpre30.5LsfxCIvu"), (30, 5));
+    // `-e` supplied as its own token.
+    assert_eq!(parse_peer_subprotocol("-e31.2LsfxCIvu"), (31, 2));
+}
+
+// upstream: compat.c:140 - a release peer's leading '.' makes atoi return 0,
+// which folds into the "no pre-release info" branch (returns (0, 0) here).
+#[test]
+fn parse_peer_subprotocol_release_peer_yields_zero() {
+    assert_eq!(parse_peer_subprotocol("-logDtpre.LsfxCIvu"), (0, 0));
+    // A protocol with an explicit `.0` subprotocol is still a final release.
+    assert_eq!(parse_peer_subprotocol("-e32.0LsfxCIvu"), (0, 0));
+    // No `-e` payload at all.
+    assert_eq!(parse_peer_subprotocol("-logDtpr"), (0, 0));
+    assert_eq!(parse_peer_subprotocol(""), (0, 0));
+    // A `<proto>` with no trailing '.' has no subprotocol.
+    assert_eq!(parse_peer_subprotocol("-e32LsfxCIvu"), (0, 0));
+}


### PR DESCRIPTION
## Summary

Wires the previously-dormant `check_sub_protocol()` helper into the live server-side version handshake so it actually takes effect, matching upstream `compat.c:600-602 setup_protocol()`.

Upstream, on the server side of a non-local (remote-shell) transfer, the server runs `check_sub_protocol()` (`compat.c:133-160`) against the client's advertised `VER.SUB` *before* it writes its own protocol version. The client's `VER.SUB` rides its `-e` capability string (`client_info = shell_cmd`, `compat.c:163-164`; the `-e<proto>.<sub>` form is emitted by `maybe_add_e_option()` at `options.c:3031-3036`). The helper (`SUBPROTOCOL_VERSION` / `get_subprotocol_version()` / `check_sub_protocol()`) already existed and was unit-tested, but was never invoked from a real handshake, so oc never performed the pre-release reconciliation.

## Changes

- `crates/transfer/src/setup/capability.rs`: add `parse_peer_subprotocol()` mirroring upstream's `atoi(client_info)` / `strchr('.')` / `atoi(dot+1)` parse (`compat.c:139-148`), extracting `(their_protocol, their_sub)` from the `-e` payload of the compact server flag string. A release peer's leading `.` parses to `(0, 0)`.
- `crates/transfer/src/handshake.rs`: add `perform_server_handshake()` (parallel to `perform_handshake`, hardcoding the newest version) plus `reconcile_subprotocol()`, which calls the existing `protocol::get_subprotocol_version()` + `protocol::check_sub_protocol()` and applies the reconciled version as the effective advertisement cap before the numeric exchange.
- `crates/transfer/src/lib.rs` and `crates/core/src/session.rs`: the two genuine `--server` stdio entry points (`run_server_stdio`, threaded and tokio) now call `perform_server_handshake(&config.flag_string)` instead of the plain `perform_handshake`.

The reconciliation reuses the existing protocol-crate helper verbatim; no new wire fields are introduced. The client-side handshake paths are untouched, mirroring upstream where `check_sub_protocol` runs only on the server (`am_server && !local_server`). The daemon path is unaffected: it sets `remote_protocol` from the `@RSYNCD:` greeting, so upstream's `if (remote_protocol == 0)` guard skips `check_sub_protocol` there (the daemon has its own inline greeting reconciliation at `clientserver.c:213-227`).

## Wire transparency

For any stock release peer (subprotocol 0, the universal case), `check_sub_protocol` is provably a no-op and the version exchange is byte-identical to before. Only a pre-release peer of the same or an older protocol triggers the one-step downgrade.

## Tests

- Handshake seam (`handshake.rs`): a pre-release peer of the same protocol (`-e32.7...`) downgrades to 31; a pre-release of an older protocol (`-e30.5...`) pins to 29; a release peer (`-e.LsfxCIvu`) and a peer with no `-e` payload leave the newest version unchanged; the client-side `perform_handshake` never reconciles; plus a direct `reconcile_subprotocol` mapping check.
- Parser (`setup/tests.rs`): `parse_peer_subprotocol` reads pre-release `VER.SUB` and returns `(0, 0)` for release peers, `.0` subprotocols, and missing/incomplete payloads.

`cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings`, and the targeted `transfer` lib tests (default and `incremental-flist` features) all pass locally.
