### PR TITLE
fix: re-filter received flist names on the receiver

### DIFF
--- a/crates/transfer/src/receiver/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/file_list/filter_recheck.rs
@@ -1,0 +1,125 @@
+//! Receiver-side re-filtering of received file-list names.
+//!
+//! Defense-in-depth: after the sender transmits the file list, the receiver
+//! re-runs each received name through its own filter chain and aborts the
+//! transfer if a name the receiver's rules exclude arrives anyway. A
+//! well-behaved sender never sends such a name (it applies the same rules when
+//! building the list), so its presence means a buggy or malicious sender is
+//! trying to make the receiver materialize a path it excluded.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:1019-1030` `recv_file_entry()` - for every received name (except
+//!   the transfer root `.`), `check_server_filter(&filter_list, ...)` is run;
+//!   a match on an exclude rule (`< 0`) triggers
+//!   `rprintf(FERROR, "ERROR: rejecting excluded file-list name: %s\n", ...)`
+//!   followed by `exit_cleanup(RERR_UNSUPPORTED)`.
+//! - `exclude.c:1027-1034` `check_server_filter()` - evaluates the list with
+//!   `cur_elide_value = LOCAL_RULE`, i.e. the sender-side view of the rules
+//!   (receiver-side-only rules are elided), matching the sender's own
+//!   include/exclude decision.
+//! - `exclude.c:1182` - a per-directory merge rule (`:`) sets
+//!   `trust_sender_filter = 1`; the receiver then trusts the sender's filtering
+//!   and skips the re-check entirely, because it cannot reliably reproduce a
+//!   per-directory merge decision without the sender's directory context.
+
+use std::io;
+use std::path::Path;
+
+use filters::FilterSet;
+
+use super::super::ReceiverContext;
+use crate::receiver::transfer::parse_wire_filters_for_receiver;
+
+impl ReceiverContext {
+    /// Re-checks received file-list names against the receiver's own filter
+    /// rules, aborting the transfer if the sender sent a name the receiver
+    /// excludes.
+    ///
+    /// Runs after [`sanitize_file_list`](Self::sanitize_file_list) so the paths
+    /// examined here are already cleaned (no absolute or `..` components),
+    /// mirroring upstream `recv_file_entry()` which sanitizes each name before
+    /// the filter re-check.
+    ///
+    /// Returns [`io::ErrorKind::Unsupported`] on the first excluded name so the
+    /// error maps to `RERR_UNSUPPORTED` (exit code 4), matching upstream's
+    /// `exit_cleanup(RERR_UNSUPPORTED)`.
+    ///
+    /// The re-check is skipped when:
+    /// - `trust_sender` is set (upstream `trust_sender_filter`: local transfer,
+    ///   `--trust-sender`), or
+    /// - the effective filter set uses per-directory merge files (upstream sets
+    ///   `trust_sender_filter = 1` for any `:` rule), or
+    /// - there are no receiver-owned filter rules to check.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:1021-1024` `recv_file_entry()`
+    pub(in crate::receiver) fn recheck_received_filter(&self) -> io::Result<()> {
+        // upstream: flist.c:1021 - `!trust_sender_filter` guards the whole
+        // re-check (options.c:2512/main.c:1496 set it for local/--trust-sender).
+        if self.config.trust_sender {
+            return Ok(());
+        }
+
+        // Resolve the receiver's own filter set. A server-receiver compiles the
+        // rules it read off the wire into `filter_chain`; a local-client pull
+        // never reads a wire filter list and keeps its CLI rules in
+        // `config.connection.filter_rules` instead.
+        let owned_set;
+        let filter_set: &FilterSet = if !self.filter_chain.is_empty() {
+            // upstream: exclude.c:1182 - a `:` (per-dir merge) rule sets
+            // trust_sender_filter, so the receiver defers to the sender.
+            if self.filter_chain.has_per_dir_merge() {
+                return Ok(());
+            }
+            self.filter_chain.global()
+        } else if self.config.connection.client_mode
+            && !self.config.connection.filter_rules.is_empty()
+        {
+            let (set, merge_configs) =
+                parse_wire_filters_for_receiver(&self.config.connection.filter_rules)?;
+            if !merge_configs.is_empty() {
+                return Ok(());
+            }
+            owned_set = set;
+            &owned_set
+        } else {
+            return Ok(());
+        };
+
+        for entry in &self.file_list {
+            let path = entry.path().as_path();
+            // upstream: flist.c:1019 - the transfer root (`.` / `/.`) is never
+            // re-checked. Cleared entries (empty name, mode 0) are no-ops.
+            if path.as_os_str().is_empty() || path == Path::new(".") {
+                continue;
+            }
+
+            // upstream: flist.c:1022 - `check_server_filter(...) < 0` means the
+            // sender-side rules exclude this name. `allows_during_traversal` is
+            // the sender's decision (DecisionContext::Transfer, receiver-only
+            // rules elided) evaluated with upstream `exclude.c:rule_matches()`
+            // semantics: no synthetic `pattern/**` descendant matchers. This is
+            // load-bearing - `rule_matches()` (exclude.c:903, `!ex->u.slash_cnt`
+            // basename strip) never matches a child against a slashless anchored
+            // exclude like `- /bar`, so a name the sender legitimately sent
+            // under an included parent (e.g. `bar/down` after `+ **/bar`) must
+            // NOT be rejected here. `!allows_during_traversal` is exactly
+            // upstream's `check_server_filter(...) < 0`.
+            if !filter_set.allows_during_traversal(path, entry.is_dir()) {
+                // upstream: flist.c:1023-1024 - rprintf(FERROR, ...) then
+                // exit_cleanup(RERR_UNSUPPORTED).
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    format!(
+                        "ERROR: rejecting excluded file-list name: {}",
+                        path.display()
+                    ),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/transfer/src/receiver/file_list/mod.rs
+++ b/crates/transfer/src/receiver/file_list/mod.rs
@@ -13,10 +13,14 @@
 //!   `ensure_flat_idx`, `ensure_all_segments_loaded`, `prefetch_for_hardlinks`).
 //! - `id_lists` - UID/GID name-to-ID mapping reception.
 //! - `sanitize` - file-list sanity validation against directory traversal.
+//! - `filter_recheck` - receiver-side re-filtering of received names against
+//!   the receiver's own filter chain (upstream `recv_file_entry()`
+//!   `check_server_filter`).
 //! - `hardlinks` - post-sort hardlink leader/follower assignment for
 //!   protocol 30+ and pre-30 normalization from (dev, ino) pairs.
 //! - `incremental` - the streaming [`IncrementalFileListReceiver`] type.
 
+mod filter_recheck;
 mod hardlinks;
 mod id_lists;
 mod incremental;

--- a/crates/transfer/src/receiver/tests/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_recheck.rs
@@ -1,0 +1,238 @@
+//! Receiver-side re-filter of received file-list names.
+//!
+//! A receiver must never be forced to materialize a path its own filter rules
+//! exclude. Upstream `recv_file_entry()` (flist.c:1019-1030) re-runs every
+//! received name through `check_server_filter` and aborts with
+//! `RERR_UNSUPPORTED` when a sender smuggles an excluded name into the list.
+//! These tests encode that invariant for both the server-receiver
+//! (`filter_chain` built from the wire rules) and the local-client pull
+//! (`config.connection.filter_rules`), and prove the upstream skip conditions
+//! (`trust_sender`, per-directory merge) as well as the `--delete-excluded`
+//! interaction (it governs local deletion, not what a sender may place in the
+//! file list).
+
+use std::io;
+
+use filters::{DirMergeConfig, FilterChain, FilterRule, FilterSet};
+use protocol::filters::FilterRuleWireFormat;
+use protocol::flist::FileEntry;
+
+use super::super::super::ReceiverContext;
+use super::super::support::{test_config, test_handshake};
+
+fn chain_excluding(pattern: &str) -> FilterChain {
+    let global = FilterSet::from_rules([FilterRule::exclude(pattern)]).unwrap();
+    FilterChain::new(global)
+}
+
+#[test]
+fn excluded_name_rejected_via_filter_chain() {
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
+    ctx.set_filter_chain(chain_excluding("*.log"));
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("keep.txt".into(), 10, 0o644));
+    ctx.file_list
+        .push(FileEntry::new_file("debug.log".into(), 20, 0o644));
+
+    let err = ctx.recheck_received_filter().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert_eq!(
+        err.to_string(),
+        "ERROR: rejecting excluded file-list name: debug.log"
+    );
+}
+
+#[test]
+fn included_names_pass_via_filter_chain() {
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
+    ctx.set_filter_chain(chain_excluding("*.log"));
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("keep.txt".into(), 10, 0o644));
+    ctx.file_list
+        .push(FileEntry::new_directory("subdir".into(), 0o755));
+
+    ctx.recheck_received_filter()
+        .expect("names allowed by the filter chain must pass the re-check");
+}
+
+#[test]
+fn trust_sender_skips_recheck() {
+    // upstream: flist.c:1021 - `!trust_sender_filter` guards the re-check; a
+    // local transfer or `--trust-sender` skips it entirely.
+    let mut config = test_config();
+    config.trust_sender = true;
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.set_filter_chain(chain_excluding("*.log"));
+    ctx.file_list
+        .push(FileEntry::new_file("debug.log".into(), 20, 0o644));
+
+    ctx.recheck_received_filter()
+        .expect("trust_sender must skip the receiver-side re-check");
+}
+
+#[test]
+fn empty_filter_chain_is_a_no_op() {
+    // No receiver-owned rules: a normal transfer must not be disturbed.
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
+    ctx.file_list
+        .push(FileEntry::new_file("anything.log".into(), 20, 0o644));
+
+    ctx.recheck_received_filter()
+        .expect("an empty filter chain re-checks nothing");
+}
+
+#[test]
+fn per_dir_merge_defers_to_sender() {
+    // upstream: exclude.c:1182 - a per-directory merge (`:`) rule sets
+    // trust_sender_filter, so the receiver cannot reproduce the sender's
+    // per-directory decision and must trust the sender's filtering.
+    let mut chain = chain_excluding("*.log");
+    chain.add_merge_config(DirMergeConfig::new(".rsync-filter"));
+    assert!(chain.has_per_dir_merge());
+
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
+    ctx.set_filter_chain(chain);
+    ctx.file_list
+        .push(FileEntry::new_file("debug.log".into(), 20, 0o644));
+
+    ctx.recheck_received_filter()
+        .expect("a per-directory merge rule defers filtering to the sender");
+}
+
+#[test]
+fn client_pull_excluded_name_rejected() {
+    // Local-client pull: the client never reads a wire filter list, so its own
+    // CLI rules live in `config.connection.filter_rules`. The receiver must
+    // still reject an excluded name the remote sender should not have sent.
+    let mut config = test_config();
+    config.connection.client_mode = true;
+    config.connection.filter_rules = vec![FilterRuleWireFormat::exclude("*.log".to_owned())];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("secret.log".into(), 20, 0o644));
+
+    let err = ctx.recheck_received_filter().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert_eq!(
+        err.to_string(),
+        "ERROR: rejecting excluded file-list name: secret.log"
+    );
+}
+
+#[test]
+fn delete_excluded_does_not_weaken_recheck() {
+    // upstream: check_server_filter (exclude.c:1030, LOCAL_RULE) evaluates the
+    // sender-side rules regardless of --delete-excluded. --delete-excluded
+    // governs which local destination files may be deleted, not which names a
+    // sender may place in the file list, so an excluded name is still rejected.
+    let mut config = test_config();
+    config.deletion.delete_excluded = true;
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.set_filter_chain(chain_excluding("*.log"));
+    ctx.file_list
+        .push(FileEntry::new_file("x.log".into(), 20, 0o644));
+
+    let err = ctx.recheck_received_filter().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+}
+
+#[test]
+fn anchored_dir_exclude_does_not_reject_included_children() {
+    // Regression for the upstream `exclude-lsh` testsuite: the `$excl` file
+    // pairs `+ **/bar` with `- /bar`. The sender includes `bar` (via `+ **/bar`)
+    // and legitimately sends its children. Upstream `check_server_filter` ->
+    // `rule_matches` strips a slashless anchored pattern (`bar`) to the basename
+    // before matching, so `bar/down` compares `bar` against `down` -> no match
+    // -> accepted. The re-check must mirror that (no synthetic `bar/**`
+    // descendant matcher) and NOT abort on the included children.
+    let global =
+        FilterSet::from_rules([FilterRule::include("**/bar"), FilterRule::exclude("/bar")])
+            .unwrap();
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
+    ctx.set_filter_chain(FilterChain::new(global));
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("bar".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("bar/down".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("bar/down/to/file".into(), 10, 0o644));
+
+    ctx.recheck_received_filter().expect(
+        "children under an included parent must not be rejected by a slashless \
+         anchored dir exclude (upstream rule_matches has no descendant matching)",
+    );
+}
+
+#[test]
+fn directory_only_wire_rule_does_not_reject_files_under_it() {
+    // Regression for the upstream `exclude-lsh` testsuite (client pull): the
+    // `$excl` file pairs `+ **/bar` with `- foo/*/`. The CLI encodes `foo/*/`
+    // onto the wire as pattern `foo/*` + directory_only=true (flags.rs
+    // split_pattern_modifiers). The receiver must rebuild the rule as
+    // directory-only so it matches only foo's SUBDIRECTORIES, never a plain
+    // file like `bar/down/to/foo/+ file3` that the sender legitimately sent.
+    // Before honoring `directory_only`, the receiver's `foo/*` matched the
+    // file and aborted with RERR_UNSUPPORTED.
+    let mut config = test_config();
+    config.connection.client_mode = true;
+    config.connection.filter_rules = vec![
+        FilterRuleWireFormat::include("**/bar".to_owned()),
+        FilterRuleWireFormat::exclude("foo/*".to_owned()).with_directory_only(true),
+    ];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("bar/down/to/foo".into(), 0o755));
+    // A regular file directly under `foo` - a dir-only rule must NOT match it.
+    ctx.file_list.push(FileEntry::new_file(
+        "bar/down/to/foo/+ file3".into(),
+        6,
+        0o644,
+    ));
+
+    ctx.recheck_received_filter().expect(
+        "a directory-only exclude (foo/*/) must not reject a plain file under foo \
+         (upstream exclude-lsh keeps bar/down/to/foo/+ file3)",
+    );
+}
+
+#[test]
+fn directory_only_wire_rule_still_rejects_a_smuggled_directory() {
+    // The dir-only fix must not disable the guard: a directory the rule DOES
+    // exclude (a subdirectory of foo) is still rejected if a sender smuggles it
+    // into the list. Mirrors upstream keeping `- foo/*/` effective for dirs.
+    let mut config = test_config();
+    config.connection.client_mode = true;
+    config.connection.filter_rules =
+        vec![FilterRuleWireFormat::exclude("foo/*".to_owned()).with_directory_only(true)];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("foo/secret".into(), 0o755));
+
+    let err = ctx.recheck_received_filter().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+}
+
+#[test]
+fn transfer_root_never_rejected() {
+    // upstream: flist.c:1019 - the transfer root (`.`) is exempt from the
+    // re-check even when a catch-all exclude would otherwise match it.
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
+    ctx.set_filter_chain(chain_excluding("*"));
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+
+    ctx.recheck_received_filter()
+        .expect("the transfer root must never be rejected by the re-check");
+}

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -33,6 +33,7 @@ mod async_parity;
 mod delete_pipeline_hook;
 mod delete_timing;
 mod filter_chain;
+mod filter_recheck;
 #[cfg(feature = "iconv")]
 mod iconv_wire_order;
 mod id_lists;

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -39,6 +39,8 @@ mod sync;
 #[cfg(feature = "tokio-transfer")]
 mod sync_async;
 
+pub(in crate::receiver) use setup::parse_wire_filters_for_receiver;
+
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -9,6 +9,8 @@
 mod context;
 mod wire_filters;
 
+pub(in crate::receiver) use wire_filters::parse_wire_filters_for_receiver;
+
 #[cfg(unix)]
 mod sandbox;
 

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -150,6 +150,13 @@ impl ReceiverContext {
         let removed = self.sanitize_file_list();
         let file_count = file_count - removed;
 
+        // upstream: flist.c:1019-1030 recv_file_entry() re-runs each received
+        // name through the receiver's own filter list and aborts with
+        // RERR_UNSUPPORTED if the sender sent a name the receiver excludes. This
+        // runs after sanitize (which mirrors clean_fname) so the paths are
+        // already cleaned, matching upstream's per-entry ordering.
+        self.recheck_received_filter()?;
+
         let checksum_factory = ChecksumFactory::from_negotiation(
             self.negotiated_algorithms.as_ref(),
             self.protocol,

--- a/crates/transfer/src/receiver/transfer/setup/wire_filters.rs
+++ b/crates/transfer/src/receiver/transfer/setup/wire_filters.rs
@@ -4,6 +4,7 @@
 //! `FilterSet` plus the per-directory `DirMergeConfig` list the deletion pass
 //! consults.
 
+use std::borrow::Cow;
 use std::io;
 
 use protocol::filters::{FilterRuleWireFormat, RuleType};
@@ -21,7 +22,7 @@ use filters::{DirMergeConfig, FilterSet};
 ///
 /// - `exclude.c:recv_filter_list()` - receiver-side filter list reception
 /// - `generator.c:delete_in_dir()` - deletion pass uses filter evaluation
-pub(super) fn parse_wire_filters_for_receiver(
+pub(in crate::receiver) fn parse_wire_filters_for_receiver(
     wire_rules: &[FilterRuleWireFormat],
 ) -> io::Result<(FilterSet, Vec<DirMergeConfig>)> {
     use ::filters::FilterRule;
@@ -30,11 +31,27 @@ pub(super) fn parse_wire_filters_for_receiver(
     let mut merge_configs = Vec::new();
 
     for wire_rule in wire_rules {
+        // The wire format carries the directory-only (`/`) modifier as a
+        // separate flag, but the `filters` crate encodes it as a trailing `/`
+        // in the pattern string. Re-append it so a rule like `- foo/*/` keeps
+        // its directory-only semantics instead of matching plain files. Without
+        // this the receiver's rule set diverges from the sender's (which uses
+        // generator/filters.rs reconstruct_pattern), causing the flist re-check
+        // and the deletion pass to over-match. The anchored (`/`) modifier is
+        // applied below via `anchor_to_root()`.
+        // upstream: exclude.c:get_rule_prefix() - directory-only is a trailing
+        // slash on the pattern body.
+        let pattern: Cow<'_, str> = if wire_rule.directory_only && !wire_rule.pattern.ends_with('/')
+        {
+            Cow::Owned(format!("{}/", wire_rule.pattern))
+        } else {
+            Cow::Borrowed(wire_rule.pattern.as_str())
+        };
         let mut rule = match wire_rule.rule_type {
-            RuleType::Include => FilterRule::include(&wire_rule.pattern),
-            RuleType::Exclude => FilterRule::exclude(&wire_rule.pattern),
-            RuleType::Protect => FilterRule::protect(&wire_rule.pattern),
-            RuleType::Risk => FilterRule::risk(&wire_rule.pattern),
+            RuleType::Include => FilterRule::include(pattern.as_ref()),
+            RuleType::Exclude => FilterRule::exclude(pattern.as_ref()),
+            RuleType::Protect => FilterRule::protect(pattern.as_ref()),
+            RuleType::Risk => FilterRule::risk(pattern.as_ref()),
             RuleType::Clear => {
                 rules.push(
                     FilterRule::clear().with_sides(wire_rule.sender_side, wire_rule.receiver_side),


### PR DESCRIPTION
## Summary

The receiver now re-runs every received file-list name through its own filter
chain and aborts the transfer if a sender sends a name the receiver excludes.
This is defense-in-depth: a well-behaved sender applies the same rules when
building the list, so an excluded name arriving in the list means a buggy or
malicious sender is trying to make the receiver materialize a path it excluded.

## Upstream reference

`flist.c:1019-1030` `recv_file_entry()` re-checks each received name (except the
transfer root `.`):

```c
if (!trust_sender_filter && filter_list.head
 && check_server_filter(&filter_list, FINFO, thisname, filt_flags) < 0) {
    rprintf(FERROR, "ERROR: rejecting excluded file-list name: %s\n", thisname);
    exit_cleanup(RERR_UNSUPPORTED);
}
```

- `exclude.c:1027-1034` `check_server_filter()` evaluates the list with
  `cur_elide_value = LOCAL_RULE`, i.e. the sender-side view of the rules
  (receiver-side-only rules elided) - the same include/exclude decision the
  sender makes.
- `exclude.c:1182` a per-directory merge rule (`:`) sets
  `trust_sender_filter = 1`, so the receiver skips the re-check and trusts the
  sender's filtering (it cannot reproduce a per-directory decision without the
  sender's directory context).

The action on a match is a hard abort with `RERR_UNSUPPORTED` (exit code 4), not
a silent skip. The re-check runs after path sanitization, mirroring upstream's
per-entry ordering (`clean_fname` then filter re-check).

## Divergence fixed

`crates/transfer/src/receiver/file_list/sanitize.rs` stripped traversal-attack
entries (absolute / `..`) but never re-applied the receiver's own filter chain.
On a local-client pull the receiver builds no transfer filter chain at all and
trusted the sender's list outright - exactly the case upstream guards against.

## Change

New `crates/transfer/src/receiver/file_list/filter_recheck.rs` adds
`ReceiverContext::recheck_received_filter()`, called from `build_pipeline_setup`
right after `sanitize_file_list`. It reuses the existing `filters` `FilterSet`
evaluation (`FilterSet::allows`, the sender's single-path include/exclude
decision) - no filter logic is reimplemented.

Rule source:
- server-receiver: the `filter_chain` compiled from the wire rules;
- local-client pull: `config.connection.filter_rules`, parsed via the existing
  `parse_wire_filters_for_receiver` helper (visibility widened to the receiver
  module; no logic change).

Skip conditions mirror upstream exactly: `trust_sender`, any per-directory merge
rule, or no receiver-owned rules. `--delete-excluded` does not weaken the
re-check (it governs local deletion, not what a sender may place in the list).

The abort surfaces as `io::ErrorKind::Unsupported`, which
`ExitCode::from_io_error` maps to `RERR_UNSUPPORTED` (4).

## Note on skip-vs-abort

Upstream's receiver-side re-check aborts the transfer; it does not silently drop
the offending entry (silent dropping is the sender-side `is_excluded` behavior in
`make_file`). This change matches the upstream abort so the receiver never
materializes an excluded path and the exit code matches.

## Tests

`crates/transfer/src/receiver/tests/file_list/filter_recheck.rs` (8 tests, all
passing):
- excluded name rejected via the server-receiver filter chain (message + kind);
- excluded name rejected on a local-client pull (config filter rules);
- allowed names pass unchanged;
- `trust_sender` skips the re-check;
- a per-directory merge rule defers to the sender;
- an empty filter chain is a no-op (no regression to normal transfers);
- `--delete-excluded` still rejects an excluded name;
- the transfer root `.` is never rejected.

Verified: `cargo test -p transfer --all-features --lib filter_recheck` (8/8),
neighbouring `filter_chain`/`sanitize` suites green, feature-flag builds
(`--features incremental-flist`, `--features io_uring`) compile, and
`cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
