### PR TITLE
fix: verify whole-file checksum before committing on the receiver

### DIFF
--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -10,7 +10,9 @@ use std::io;
 use engine::CleanupManager;
 
 use crate::delta_apply::{ChecksumVerifier, SparseWriteState};
-use crate::pipeline::messages::{BeginMessage, CommitResult, FileMessage};
+use crate::pipeline::messages::{
+    BeginMessage, CommitResult, ComputedChecksum, ExpectedChecksum, FileMessage,
+};
 use crate::pipeline::spsc;
 use crate::temp_guard::TempFileGuard;
 #[cfg(not(unix))]
@@ -61,6 +63,65 @@ fn sum_append_prefix(
         remaining -= to_read as u64;
     }
     Ok(())
+}
+
+/// Finalizes the per-file checksum and compares it against the sender's
+/// trailing whole-file sum.
+///
+/// Returns the computed digest (so the receiver's redo bookkeeping still runs)
+/// and whether verification passed. A missing verifier or a zero-length
+/// expected sum means no checksum was supplied, so it always passes.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:505` - `sum_end(file_sum1)` computes the whole-file digest.
+/// - `receiver.c:515-519` - `read_buf(f_in, sender_file_sum, ...)` then
+///   `if (fd != -1 && memcmp(file_sum1, sender_file_sum, xfer_sum_len) != 0)
+///   return 0;` - a mismatch yields `recv_ok = 0` and the file is not put into
+///   place.
+fn verify_whole_file_checksum(
+    verifier: Option<ChecksumVerifier>,
+    expected: &ExpectedChecksum,
+) -> (Option<ComputedChecksum>, bool) {
+    let computed = finalize_checksum(verifier);
+    let verify_ok = match computed {
+        Some(ref c) if expected.len > 0 => {
+            c.len == expected.len && c.bytes[..c.len] == expected.bytes[..expected.len]
+        }
+        _ => true,
+    };
+    (computed, verify_ok)
+}
+
+/// Handles a whole-file checksum verification failure for a temp+rename file.
+///
+/// The temp file is retained in the partial dir (when `--partial`/`--partial-dir`
+/// is active) or discarded via the guard's `Drop`; it is never renamed over the
+/// destination. The computed digest is still reported so the receiver queues a
+/// redo (phase 1) or logs the error (phase 2).
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:1039-1056` - on `recv_ok == 0` the temp goes to the partial dir
+///   (`handle_partial_dir(PDIR_CREATE)`) or is unlinked (`do_unlink_at`);
+///   `finish_transfer()` - the destination rename - is skipped.
+fn withhold_failed_commit(
+    config: &DiskCommitConfig,
+    mut cleanup_guard: TempFileGuard,
+    begin: &BeginMessage,
+    bytes_written: u64,
+    computed_checksum: Option<ComputedChecksum>,
+) -> CommitResult {
+    retain_partial_file(config, &mut cleanup_guard, &begin.file_path);
+    drop(cleanup_guard);
+    CommitResult {
+        bytes_written,
+        file_entry_index: begin.file_entry_index,
+        metadata_error: None,
+        computed_checksum,
+        delayed_path: None,
+        backup_notice: None,
+    }
 }
 
 /// Processes a single file: open, write chunks, commit or abort.
@@ -223,7 +284,7 @@ pub(in crate::disk_commit) fn process_file(
                 bytes_written += data.len() as u64;
                 let _ = buf_return_tx.try_send(data);
             }
-            FileMessage::Commit => {
+            FileMessage::Commit { expected_checksum } => {
                 // upstream: fileio.c:43 sparse_end() - flush the trailing hole
                 // and hand the logical length + in-basis hole ranges to the
                 // commit step for ftruncate + punch (no materialized byte).
@@ -239,6 +300,25 @@ pub(in crate::disk_commit) fn process_file(
 
                 output.flush_and_sync(config.do_fsync, &begin.file_path)?;
                 output.finish(config.do_fsync, &begin.file_path)?;
+
+                // upstream: receiver.c:505-519 - compute the whole-file checksum
+                // and compare it against the sender's trailing sum BEFORE the
+                // file is put into place. On a temp+rename mismatch (recv_ok == 0)
+                // the temp is retained/discarded, never renamed over the
+                // destination. Inplace/device targets cannot be withheld (the
+                // bytes already landed), matching upstream's `|| inplace` branch
+                // at receiver.c:1029; the receiver still queues the redo.
+                let (computed_checksum, verify_ok) =
+                    verify_whole_file_checksum(checksum_verifier.take(), &expected_checksum);
+                if !verify_ok && needs_rename {
+                    return Ok(withhold_failed_commit(
+                        config,
+                        cleanup_guard,
+                        &begin,
+                        bytes_written,
+                        computed_checksum,
+                    ));
+                }
 
                 // upstream: rsync.c:748 finish_transfer() - "Change
                 // permissions before putting the file into place."
@@ -283,8 +363,6 @@ pub(in crate::disk_commit) fn process_file(
                 } else {
                     apply_file_metadata(&begin.file_path, &begin, config)
                 };
-
-                let computed_checksum = finalize_checksum(checksum_verifier);
 
                 return Ok(CommitResult {
                     bytes_written,
@@ -353,6 +431,7 @@ pub(in crate::disk_commit) fn process_whole_file(
     config: &DiskCommitConfig,
     mut begin: BeginMessage,
     data: Vec<u8>,
+    expected_checksum: ExpectedChecksum,
     write_buf: &mut Vec<u8>,
     disk_batch: Option<&mut fast_io::IoUringDiskBatch>,
     iocp_batch: Option<&mut fast_io::IocpDiskBatch>,
@@ -417,6 +496,21 @@ pub(in crate::disk_commit) fn process_whole_file(
     output.flush_and_sync(config.do_fsync, &begin.file_path)?;
     output.finish(config.do_fsync, &begin.file_path)?;
 
+    // upstream: receiver.c:505-519 - verify the whole-file checksum before the
+    // file is put into place (see process_file for the full rationale). A
+    // temp+rename mismatch is retained/discarded, never renamed over dest.
+    let (computed_checksum, verify_ok) =
+        verify_whole_file_checksum(checksum_verifier.take(), &expected_checksum);
+    if !verify_ok && needs_rename {
+        return Ok(withhold_failed_commit(
+            config,
+            cleanup_guard,
+            &begin,
+            bytes_written,
+            computed_checksum,
+        ));
+    }
+
     // upstream: rsync.c:748 finish_transfer() - apply metadata to the
     // temp file before rename (see process_file for full rationale).
     let pre_meta_error = if needs_rename {
@@ -446,8 +540,6 @@ pub(in crate::disk_commit) fn process_whole_file(
     } else {
         apply_file_metadata(&begin.file_path, &begin, config)
     };
-
-    let computed_checksum = finalize_checksum(checksum_verifier);
 
     Ok(CommitResult {
         bytes_written,
@@ -489,7 +581,7 @@ fn discard_file_on_open_failure(
                 // Recycle the buffer for the network thread; drop the bytes.
                 let _ = buf_return_tx.try_send(data);
             }
-            Ok(FileMessage::Commit) => {
+            Ok(FileMessage::Commit { .. }) => {
                 return Err(open_err);
             }
             Ok(FileMessage::Abort { reason }) => {

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -123,7 +123,11 @@ fn write_file_with_io_uring_auto_policy() {
     h.file_tx
         .send(FileMessage::Chunk(b"uring".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 5);
@@ -228,7 +232,11 @@ fn write_and_commit_file() {
     h.file_tx
         .send(FileMessage::Chunk(b"hello world".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 11);
@@ -289,7 +297,11 @@ fn inplace_skip_matched_seeks_without_rewriting() {
     h.file_tx
         .send(FileMessage::Chunk(b"CCCCCCCC".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     // Both the skipped and the written block count toward the final size so the
@@ -367,7 +379,11 @@ fn multiple_files_sequential() {
         h.file_tx
             .send(FileMessage::Chunk(data.into_bytes()))
             .unwrap();
-        h.file_tx.send(FileMessage::Commit).unwrap();
+        h.file_tx
+            .send(FileMessage::Commit {
+                expected_checksum: Default::default(),
+            })
+            .unwrap();
 
         let result = h.result_rx.recv().unwrap().unwrap();
         assert_eq!(result.file_entry_index, i);
@@ -416,7 +432,11 @@ fn multi_chunk_file() {
     h.file_tx.send(FileMessage::Chunk(b"aaa".to_vec())).unwrap();
     h.file_tx.send(FileMessage::Chunk(b"bbb".to_vec())).unwrap();
     h.file_tx.send(FileMessage::Chunk(b"ccc".to_vec())).unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 9);
@@ -453,7 +473,11 @@ fn buffer_recycling() {
     h.file_tx
         .send(FileMessage::Chunk(b" world".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 11);
@@ -489,6 +513,7 @@ fn whole_file_coalesced() {
                 xattr_list: None,
             }),
             data: b"whole dat".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -538,7 +563,11 @@ fn commit_file_rename_via_io_uring_or_fallback() {
     h.file_tx
         .send(FileMessage::Chunk(b"rename content".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 14);
@@ -581,7 +610,11 @@ fn commit_file_rename_replaces_existing_via_io_uring_or_fallback() {
     h.file_tx
         .send(FileMessage::Chunk(b"new content".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 11);
@@ -624,7 +657,11 @@ fn delay_updates_stages_to_partial_dir() {
     h.file_tx
         .send(FileMessage::Chunk(b"delayed write".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 13);
@@ -685,6 +722,7 @@ fn delay_updates_whole_file_stages_to_partial_dir() {
                 xattr_list: None,
             }),
             data: b"whole delayed!".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -730,6 +768,7 @@ fn whole_file_commit_via_io_uring_or_fallback() {
                 xattr_list: None,
             }),
             data: b"whole iouring".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -1192,7 +1231,11 @@ fn cleanup_manager_unregisters_on_successful_commit() {
     h.file_tx
         .send(FileMessage::Chunk(b"committed dat".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 13);
@@ -1248,7 +1291,11 @@ fn cleanup_manager_mixed_committed_and_orphaned_files() {
     h.file_tx
         .send(FileMessage::Chunk(b"good".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 4);
 
@@ -1359,6 +1406,7 @@ fn cleanup_manager_whole_file_unregisters_on_commit() {
                 xattr_list: None,
             }),
             data: b"whole file".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -1411,7 +1459,11 @@ fn cleanup_manager_inplace_skips_registration() {
     h.file_tx
         .send(FileMessage::Chunk(b"inplace".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 7);
@@ -1851,6 +1903,7 @@ fn partial_dir_whole_file_success_no_leftover_in_partial_dir() {
                 xattr_list: None,
             }),
             data: b"complete-dat".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -2097,7 +2150,11 @@ fn delay_updates_disk_thread_e2e_single_file() {
     h.file_tx
         .send(FileMessage::Chunk(b"e2e content!".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 12);
@@ -2172,7 +2229,11 @@ fn delay_updates_disk_thread_e2e_multiple_files() {
         h.file_tx
             .send(FileMessage::Chunk(content.into_bytes()))
             .unwrap();
-        h.file_tx.send(FileMessage::Commit).unwrap();
+        h.file_tx
+            .send(FileMessage::Commit {
+                expected_checksum: Default::default(),
+            })
+            .unwrap();
 
         let result = h.result_rx.recv().unwrap().unwrap();
         assert_eq!(result.file_entry_index, i);
@@ -2249,6 +2310,7 @@ fn delay_updates_disk_thread_e2e_whole_file() {
                 xattr_list: None,
             }),
             data: b"whole file sweep!".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -2306,7 +2368,11 @@ fn delay_updates_disk_thread_e2e_nested_dirs() {
     h.file_tx
         .send(FileMessage::Chunk(b"root data".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
     let _ = h.result_rx.recv().unwrap().unwrap();
 
     // File at sub level staging.
@@ -2327,7 +2393,11 @@ fn delay_updates_disk_thread_e2e_nested_dirs() {
     h.file_tx
         .send(FileMessage::Chunk(b"nested data".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
     let _ = h.result_rx.recv().unwrap().unwrap();
 
     h.file_tx.send(FileMessage::Shutdown).unwrap();
@@ -2683,6 +2753,7 @@ fn delay_updates_interrupt_leaves_committed_files_in_staging() {
                 xattr_list: None,
             }),
             data: b"file1 staged".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -2705,6 +2776,7 @@ fn delay_updates_interrupt_leaves_committed_files_in_staging() {
                 xattr_list: None,
             }),
             data: b"file2 staged".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -2775,6 +2847,7 @@ fn delay_updates_interrupt_mid_file_retains_prior_staged_files() {
                 xattr_list: None,
             }),
             data: b"committed".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -2855,6 +2928,7 @@ fn delay_updates_manual_sweep_after_commit_moves_to_final() {
                 xattr_list: None,
             }),
             data: b"sweep1".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -2874,6 +2948,7 @@ fn delay_updates_manual_sweep_after_commit_moves_to_final() {
                 xattr_list: None,
             }),
             data: b"sweep2".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -2934,6 +3009,7 @@ fn delay_updates_channel_disconnect_preserves_staged_files() {
                 xattr_list: None,
             }),
             data: b"disconnect data".to_vec(),
+            expected_checksum: Default::default(),
         })
         .unwrap();
 
@@ -3006,7 +3082,11 @@ fn pipelined_backup_default_suffix_returns_destination_relative_notice() {
     h.file_tx
         .send(FileMessage::Chunk(b"fresh".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     let notice = result
@@ -3072,7 +3152,11 @@ fn pipelined_backup_with_backup_dir_reports_destination_relative_paths() {
     h.file_tx
         .send(FileMessage::Chunk(b"updated".to_vec()))
         .unwrap();
-    h.file_tx.send(FileMessage::Commit).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
 
     let result = h.result_rx.recv().unwrap().unwrap();
     let notice = result
@@ -3093,6 +3177,194 @@ fn pipelined_backup_with_backup_dir_reports_destination_relative_paths() {
     assert_eq!(fs::read(&backup_path).unwrap(), b"pre-existing content");
     // Destination now holds the new content.
     assert_eq!(fs::read(&file_path).unwrap(), b"updated");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// Builds the expected whole-file checksum the disk thread verifies against,
+/// using the same MD5 algorithm as [`md5_verifier`].
+fn expected_md5(data: &[u8]) -> crate::pipeline::messages::ExpectedChecksum {
+    use crate::delta_apply::ChecksumVerifier;
+    let mut v = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::MD5);
+    v.update(data);
+    let mut bytes = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+    let len = v.finalize_into(&mut bytes);
+    crate::pipeline::messages::ExpectedChecksum { bytes, len }
+}
+
+/// A live MD5 verifier for the disk thread to hash received bytes into.
+fn md5_verifier() -> crate::delta_apply::ChecksumVerifier {
+    crate::delta_apply::ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::MD5)
+}
+
+/// WHY: a file whose whole-file checksum fails verification must NOT be renamed
+/// over the destination. Upstream `receive_data()` returns `recv_ok = 0` on a
+/// `memcmp` mismatch (receiver.c:518) and `recv_files()` then skips
+/// `finish_transfer()` (receiver.c:1029), so a corrupted transfer never lands
+/// at the destination. This pins the coalesced whole-file path.
+#[test]
+fn whole_file_checksum_mismatch_is_not_committed_to_dest() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("corrupt.dat");
+
+    let h = spawn_disk_thread(DiskCommitConfig::default()).unwrap();
+
+    let data = b"corrupt payload";
+    h.file_tx
+        .send(FileMessage::WholeFile {
+            begin: Box::new(BeginMessage {
+                file_path: file_path.clone(),
+                target_size: data.len() as u64,
+                file_entry_index: 0,
+                checksum_verifier: Some(md5_verifier()),
+                is_device_target: false,
+                is_inplace: false,
+                append_offset: 0,
+                xattr_list: None,
+            }),
+            data: data.to_vec(),
+            // Sender's sum for entirely different bytes: forces a mismatch.
+            expected_checksum: expected_md5(b"the good bytes"),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert_eq!(result.bytes_written, data.len() as u64);
+    assert!(
+        result.computed_checksum.is_some(),
+        "disk thread must still report the computed digest for redo bookkeeping"
+    );
+    assert!(
+        result.delayed_path.is_none(),
+        "a verification failure is never staged for the delay-updates sweep"
+    );
+    assert!(
+        !file_path.exists(),
+        "checksum-failed file must NOT be committed to the destination"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// The happy-path counterpart: a matching whole-file checksum commits normally.
+#[test]
+fn whole_file_checksum_match_commits_to_dest() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("verified.dat");
+
+    let h = spawn_disk_thread(DiskCommitConfig::default()).unwrap();
+
+    let data = b"verified payload";
+    h.file_tx
+        .send(FileMessage::WholeFile {
+            begin: Box::new(BeginMessage {
+                file_path: file_path.clone(),
+                target_size: data.len() as u64,
+                file_entry_index: 0,
+                checksum_verifier: Some(md5_verifier()),
+                is_device_target: false,
+                is_inplace: false,
+                append_offset: 0,
+                xattr_list: None,
+            }),
+            data: data.to_vec(),
+            expected_checksum: expected_md5(data),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert_eq!(result.bytes_written, data.len() as u64);
+    assert!(result.metadata_error.is_none());
+    assert_eq!(
+        fs::read(&file_path).unwrap(),
+        data,
+        "a verified file must be committed to the destination"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// Same invariant for the multi-message chunked path (Begin + Chunk + Commit).
+#[test]
+fn chunked_checksum_mismatch_is_not_committed_to_dest() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("chunked_corrupt.dat");
+
+    let h = spawn_disk_thread(DiskCommitConfig::default()).unwrap();
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 6,
+            file_entry_index: 0,
+            checksum_verifier: Some(md5_verifier()),
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+    h.file_tx.send(FileMessage::Chunk(b"aaa".to_vec())).unwrap();
+    h.file_tx.send(FileMessage::Chunk(b"bbb".to_vec())).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: expected_md5(b"not aaabbb"),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert_eq!(result.bytes_written, 6);
+    assert!(
+        !file_path.exists(),
+        "checksum-failed chunked file must NOT be committed to the destination"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// The strongest form of the invariant: a corrupted update must leave a good
+/// pre-existing destination file untouched. With temp+rename the failed temp
+/// is discarded and the original never sees the rename.
+#[test]
+fn checksum_mismatch_leaves_preexisting_dest_untouched() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("existing.dat");
+    fs::write(&file_path, b"original good data").unwrap();
+
+    let h = spawn_disk_thread(DiskCommitConfig::default()).unwrap();
+
+    let data = b"corrupt replacement";
+    h.file_tx
+        .send(FileMessage::WholeFile {
+            begin: Box::new(BeginMessage {
+                file_path: file_path.clone(),
+                target_size: data.len() as u64,
+                file_entry_index: 0,
+                checksum_verifier: Some(md5_verifier()),
+                is_device_target: false,
+                is_inplace: false,
+                append_offset: 0,
+                xattr_list: None,
+            }),
+            data: data.to_vec(),
+            expected_checksum: expected_md5(b"a different payload"),
+        })
+        .unwrap();
+
+    let _ = h.result_rx.recv().unwrap().unwrap();
+    assert_eq!(
+        fs::read(&file_path).unwrap(),
+        b"original good data",
+        "a checksum-failed update must not clobber the existing destination file"
+    );
 
     h.file_tx.send(FileMessage::Shutdown).unwrap();
     h.join_handle.join().unwrap();

--- a/crates/transfer/src/disk_commit/thread.rs
+++ b/crates/transfer/src/disk_commit/thread.rs
@@ -242,12 +242,17 @@ fn disk_thread_main(
                     break;
                 }
             }
-            FileMessage::WholeFile { begin, data } => {
+            FileMessage::WholeFile {
+                begin,
+                data,
+                expected_checksum,
+            } => {
                 let result = process_whole_file(
                     &buf_return_tx,
                     &config,
                     *begin,
                     data,
+                    expected_checksum,
                     &mut write_buf,
                     disk_batch.as_mut(),
                     iocp_batch.as_mut(),
@@ -258,7 +263,7 @@ fn disk_thread_main(
             }
             FileMessage::Chunk(_)
             | FileMessage::SkipMatched(_)
-            | FileMessage::Commit
+            | FileMessage::Commit { .. }
             | FileMessage::Abort { .. } => {
                 let err = io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/crates/transfer/src/pipeline/messages.rs
+++ b/crates/transfer/src/pipeline/messages.rs
@@ -42,8 +42,18 @@ pub enum FileMessage {
     /// - `fileio.c:192-211` - `skip_matched()` flushes then `lseek`s past the
     ///   in-place bytes (or feeds the sparse processor with the seek flag).
     SkipMatched(Vec<u8>),
-    /// Finalize the current file (flush, fsync, rename).
-    Commit,
+    /// Finalize the current file: compute the whole-file checksum, verify it
+    /// against the sender's trailing sum, and only then flush, fsync, and
+    /// rename into place.
+    ///
+    /// The expected checksum travels with this message so the disk thread can
+    /// verify BEFORE committing, mirroring upstream `receiver.c:505-519` where
+    /// `receive_data()` compares `sum_end()` against the sender's sum before
+    /// `recv_files()` calls `finish_transfer()`.
+    Commit {
+        /// Sender's trailing whole-file checksum for pre-commit verification.
+        expected_checksum: ExpectedChecksum,
+    },
     /// Coalesced message for single-chunk files: combines Begin + one Chunk +
     /// Commit into a single channel send, reducing futex overhead from 3+
     /// sends to 1. Used when the sender transmits the entire file as a single
@@ -53,6 +63,8 @@ pub enum FileMessage {
         begin: Box<BeginMessage>,
         /// Complete file data.
         data: Vec<u8>,
+        /// Sender's trailing whole-file checksum for pre-commit verification.
+        expected_checksum: ExpectedChecksum,
     },
     /// Abort the current file due to an error.
     Abort {
@@ -115,6 +127,21 @@ pub struct BeginMessage {
     /// Mirrors `xattrs.c:set_xattr()` called from `set_file_attrs()` in
     /// `receiver.c` after file transfer completes.
     pub xattr_list: Option<XattrList>,
+}
+
+/// Sender's trailing whole-file checksum, carried to the disk thread for
+/// pre-commit verification.
+///
+/// A `len` of 0 means the caller supplied no checksum, so verification is
+/// skipped and the file always commits. This mirrors the `fd == -1`
+/// short-circuit at upstream `receiver.c:518` where the memcmp is not
+/// performed.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExpectedChecksum {
+    /// Digest bytes (only `len` bytes are valid).
+    pub bytes: [u8; ChecksumVerifier::MAX_DIGEST_LEN],
+    /// Number of valid bytes in `bytes`. Zero disables verification.
+    pub len: usize,
 }
 
 /// Computed checksum digest returned by the disk thread.

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -517,7 +517,11 @@ mod tests {
             .send(FileMessage::Chunk(b"test data".to_vec()))
             .unwrap();
 
-        pr.file_sender().send(FileMessage::Commit).unwrap();
+        pr.file_sender()
+            .send(FileMessage::Commit {
+                expected_checksum: Default::default(),
+            })
+            .unwrap();
         pr.note_commit_sent(
             [0u8; ChecksumVerifier::MAX_DIGEST_LEN],
             0,
@@ -727,6 +731,7 @@ mod tests {
                     xattr_list: None,
                 }),
                 data: b"test data".to_vec(),
+                expected_checksum: Default::default(),
             })
             .unwrap();
 
@@ -807,7 +812,11 @@ mod tests {
         pr.file_sender()
             .send(FileMessage::Chunk(b"ccc".to_vec()))
             .unwrap();
-        pr.file_sender().send(FileMessage::Commit).unwrap();
+        pr.file_sender()
+            .send(FileMessage::Commit {
+                expected_checksum: Default::default(),
+            })
+            .unwrap();
 
         pr.note_commit_sent([0u8; ChecksumVerifier::MAX_DIGEST_LEN], 0, file_path, 0);
 
@@ -848,6 +857,7 @@ mod tests {
                     xattr_list: None,
                 }),
                 data: b"next".to_vec(),
+                expected_checksum: Default::default(),
             })
             .unwrap();
         pr.note_commit_sent(
@@ -909,6 +919,7 @@ mod tests {
                     xattr_list: None,
                 }),
                 data: b"test data".to_vec(),
+                expected_checksum: Default::default(),
             })
             .unwrap();
         pr.note_commit_sent([0u8; ChecksumVerifier::MAX_DIGEST_LEN], 0, file_path, 0);
@@ -1035,6 +1046,7 @@ mod tests {
                     xattr_list: None,
                 }),
                 data: b"drop staged".to_vec(),
+                expected_checksum: Default::default(),
             })
             .unwrap();
 
@@ -1097,6 +1109,7 @@ mod tests {
                     xattr_list: None,
                 }),
                 data: b"shutdown stage".to_vec(),
+                expected_checksum: Default::default(),
             })
             .unwrap();
 
@@ -1149,6 +1162,7 @@ mod tests {
                     xattr_list: None,
                 }),
                 data: b"e2e staged".to_vec(),
+                expected_checksum: Default::default(),
             })
             .unwrap();
 

--- a/crates/transfer/src/transfer_ops/streaming.rs
+++ b/crates/transfer/src/transfer_ops/streaming.rs
@@ -165,6 +165,10 @@ pub fn process_file_response_streaming<R: Read>(
                     .send(FileMessage::WholeFile {
                         begin: begin_msg,
                         data: buf,
+                        expected_checksum: crate::pipeline::messages::ExpectedChecksum {
+                            bytes: expected_checksum,
+                            len: checksum_len,
+                        },
                     })
                     .map_err(|_| {
                         io::Error::new(io::ErrorKind::BrokenPipe, "disk commit thread disconnected")

--- a/crates/transfer/src/transfer_ops/streaming_async.rs
+++ b/crates/transfer/src/transfer_ops/streaming_async.rs
@@ -185,6 +185,10 @@ where
                     .send(FileMessage::WholeFile {
                         begin: begin_msg,
                         data: buf,
+                        expected_checksum: crate::pipeline::messages::ExpectedChecksum {
+                            bytes: expected_checksum,
+                            len: checksum_len,
+                        },
                     })
                     .map_err(|_| {
                         io::Error::new(io::ErrorKind::BrokenPipe, "disk commit thread disconnected")
@@ -307,12 +311,19 @@ where
                     return Err(e);
                 }
 
-                file_tx.send(FileMessage::Commit).map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::BrokenPipe,
-                        "disk commit thread disconnected during commit",
-                    )
-                })?;
+                file_tx
+                    .send(FileMessage::Commit {
+                        expected_checksum: crate::pipeline::messages::ExpectedChecksum {
+                            bytes: expected_checksum,
+                            len: checksum_len,
+                        },
+                    })
+                    .map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::BrokenPipe,
+                            "disk commit thread disconnected during commit",
+                        )
+                    })?;
 
                 return Ok(StreamingResult {
                     total_bytes,

--- a/crates/transfer/src/transfer_ops/token_loop.rs
+++ b/crates/transfer/src/transfer_ops/token_loop.rs
@@ -116,12 +116,19 @@ pub(super) fn process_remaining_tokens<R: Read>(
                     return Err(e);
                 }
 
-                file_tx.send(FileMessage::Commit).map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::BrokenPipe,
-                        "disk commit thread disconnected during commit",
-                    )
-                })?;
+                file_tx
+                    .send(FileMessage::Commit {
+                        expected_checksum: crate::pipeline::messages::ExpectedChecksum {
+                            bytes: expected_checksum,
+                            len: checksum_len,
+                        },
+                    })
+                    .map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::BrokenPipe,
+                            "disk commit thread disconnected during commit",
+                        )
+                    })?;
 
                 return Ok(StreamingResult {
                     total_bytes,


### PR DESCRIPTION
## Summary

The receiver's decoupled network to disk pipeline renamed the temp file over
the destination **before** the whole-file checksum was verified. A corrupted or
mid-transfer-changed file could therefore land at the destination (clobbering a
good pre-existing file), after which the mismatch was only detected and a redo
queued. Upstream never lets a checksum-failing file reach the destination.

Upstream `receive_data()` computes the running whole-file digest with
`sum_end(file_sum1)` (receiver.c:505), reads the sender's trailing sum
(receiver.c:515), and `if (fd != -1 && memcmp(file_sum1, sender_file_sum,
xfer_sum_len) != 0) return 0;` (receiver.c:518-519) - a mismatch yields
`recv_ok = 0` *before* any rename. `recv_files()` then only calls
`finish_transfer()` (the temp to dest rename) when `recv_ok` is true
(receiver.c:1029-1032); on a mismatch the temp is retained in the partial dir or
discarded and `MSG_REDO` is requested, so the destination is never touched.

## Fix

The whole-file checksum is now verified inside the disk-commit thread, at the
same point upstream verifies it, so the commit is gated on the result while the
network to disk pipeline concurrency is preserved (the reorder is within the
disk thread, not a serialization of the pipeline):

- The sender's trailing checksum now travels to the disk thread on the `Commit`
  and coalesced `WholeFile` messages.
- On `Commit`, the disk thread finalizes the digest and compares it to the
  sender's sum *before* applying metadata or renaming. On a temp+rename mismatch
  the temp is retained (`--partial`/`--partial-dir`) or discarded via the guard
  and is **never** renamed over the destination (upstream receiver.c:1039-1056).
  Inplace/device targets cannot be withheld (the bytes already landed), matching
  upstream's `|| inplace` branch at receiver.c:1029; the receiver still queues
  the redo.
- The computed digest is still reported, so the existing redo/error bookkeeping
  (phase 1 `MSG_REDO`, phase 2 error) is unchanged.

## Tests

New `disk_commit` integration tests encode the invariant that a
verification-failing file must not reach the destination:

- `whole_file_checksum_mismatch_is_not_committed_to_dest` - coalesced path, dest
  absent after a mismatch.
- `chunked_checksum_mismatch_is_not_committed_to_dest` - Begin+Chunk+Commit path.
- `checksum_mismatch_leaves_preexisting_dest_untouched` - a corrupt update does
  not clobber a good existing destination file.
- `whole_file_checksum_match_commits_to_dest` - happy path still commits.

Verified: `cargo clippy -p transfer --all-targets --all-features` clean; the new
tests plus all `disk_commit::`, `pipeline::receiver::`, and checksum lib tests
pass; the `incremental-flist`, `io_uring`, and `tokio-transfer` feature cells
compile.
