### PR TITLE
fix(transfer): validate received flist names against implied includes

### DIFF
--- a/crates/core/src/client/remote/async_ssh_transport.rs
+++ b/crates/core/src/client/remote/async_ssh_transport.rs
@@ -60,6 +60,7 @@ use super::super::progress::ClientProgressObserver;
 use super::super::summary::ClientSummary;
 use super::batch_support::{BatchContext, build_batch_context, build_batch_recording};
 use super::flags;
+use super::implied_source::implied_source_args_for_pull;
 use super::invocation::{RemoteOperands, RemoteRole, TransferSpec, determine_transfer_role};
 use super::ssh_transfer::{
     build_server_config_for_generator, build_server_config_for_receiver,
@@ -165,11 +166,15 @@ pub fn run_async_ssh_transfer(
         } => {
             let plan = build_plan(config, RemoteRole::Receiver, "", Some(&remote_sources))?;
             let mut server_config = build_pull_server_config(config, &[local_dest])?;
-            // upstream: main.c:1525,1549 / flist.c:1026 - record each requested
-            // source path as an implied include so the receiver rejects any
-            // unrequested file-list name (CVE-2022-29154).
-            server_config.connection.implied_source_args =
-                remote_operand_source_paths(&remote_sources)?;
+            // upstream: main.c:1525,1549 / io.c:427,464 / flist.c:1026 - record
+            // each requested source path (or local --files-from entry) as an
+            // implied include so the receiver rejects any unrequested name
+            // (CVE-2022-29154).
+            server_config.connection.implied_source_args = implied_source_args_for_pull(
+                config,
+                &remote_operand_source_paths(&remote_sources)?,
+                server_config.connection.files_from_data.as_deref(),
+            );
             run_async_session(config, plan, server_config, batch_writer)
         }
         TransferSpec::Proxy { .. } => Err(invalid_argument_error(

--- a/crates/core/src/client/remote/async_ssh_transport.rs
+++ b/crates/core/src/client/remote/async_ssh_transport.rs
@@ -64,6 +64,7 @@ use super::invocation::{RemoteOperands, RemoteRole, TransferSpec, determine_tran
 use super::ssh_transfer::{
     build_server_config_for_generator, build_server_config_for_receiver,
     convert_server_stats_to_summary, parse_remote_operands, parse_single_remote,
+    remote_operand_source_paths,
 };
 use crate::exit_code::ExitCode;
 use crate::server::{ServerConfig, ServerRole, ServerStats};
@@ -163,7 +164,12 @@ pub fn run_async_ssh_transfer(
             local_dest,
         } => {
             let plan = build_plan(config, RemoteRole::Receiver, "", Some(&remote_sources))?;
-            let server_config = build_pull_server_config(config, &[local_dest])?;
+            let mut server_config = build_pull_server_config(config, &[local_dest])?;
+            // upstream: main.c:1525,1549 / flist.c:1026 - record each requested
+            // source path as an implied include so the receiver rejects any
+            // unrequested file-list name (CVE-2022-29154).
+            server_config.connection.implied_source_args =
+                remote_operand_source_paths(&remote_sources)?;
             run_async_session(config, plan, server_config, batch_writer)
         }
         TransferSpec::Proxy { .. } => Err(invalid_argument_error(

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -216,6 +216,10 @@ pub fn run_daemon_transfer(
     // Protocol is already negotiated via @RSYNCD text exchange (not binary 4-byte).
     // upstream: compat.c:599 - when remote_protocol != 0, setup_protocol skips
     // the binary exchange.
+    // upstream: main.c:1549 - record the requested daemon source (module/path)
+    // as an implied include for the receiver-side flist validation
+    // (CVE-2022-29154); is_daemon_connection strips the module on the receiver.
+    let implied_source_args = [format!("{}/{}", request.module, request.path)];
     match role {
         RemoteRole::Receiver => run_pull_transfer(
             config,
@@ -223,6 +227,7 @@ pub fn run_daemon_transfer(
             &mut writer_half,
             guard,
             &local_paths,
+            &implied_source_args,
             protocol,
             batch_ctx,
             buffered,
@@ -365,6 +370,10 @@ pub fn run_daemon_over_remote_shell(
     let buffered = buf_reader.buffer().to_vec();
     let mut reader_half = buf_reader.into_inner();
 
+    // upstream: main.c:1549 - record the requested daemon source (module/path)
+    // as an implied include for the receiver-side flist validation
+    // (CVE-2022-29154); is_daemon_connection strips the module on the receiver.
+    let implied_source_args = [format!("{}/{}", request.module, request.path)];
     match role {
         RemoteRole::Receiver => run_pull_transfer(
             config,
@@ -372,6 +381,7 @@ pub fn run_daemon_over_remote_shell(
             &mut writer_half,
             guard,
             &local_paths,
+            &implied_source_args,
             protocol,
             batch_ctx,
             buffered,

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -44,6 +44,7 @@ pub(crate) fn run_pull_transfer(
     writer: &mut DaemonStreamWriter,
     _guard: DaemonStreamGuard,
     local_paths: &[String],
+    implied_source_args: &[String],
     protocol: ProtocolVersion,
     batch_ctx: Option<BatchContext>,
     buffered: Vec<u8>,
@@ -58,6 +59,11 @@ pub(crate) fn run_pull_transfer(
     handshake.buffered = buffered;
 
     let mut server_config = build_server_config_for_receiver(config, local_paths, filter_rules)?;
+    // upstream: main.c:1549 - the requested daemon source (module/path) is
+    // recorded as an implied include; the receiver rejects any file-list name
+    // it does not cover (CVE-2022-29154). is_daemon_connection drives the
+    // module-name strip on the receiver side (exclude.c:396-401).
+    server_config.connection.implied_source_args = implied_source_args.to_vec();
 
     // upstream: main.c:1354-1356 - when pulling with --files-from pointing to a
     // local file or stdin, the client reads the file list locally and forwards

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -20,6 +20,7 @@ use crate::client::module_list::{
 use crate::client::progress::ClientProgressObserver;
 use crate::client::remote::batch_support::{BatchContext, build_batch_recording};
 use crate::client::remote::flags;
+use crate::client::remote::implied_source::implied_source_args_for_pull;
 use crate::client::summary::ClientSummary;
 use crate::exit_code::ExitCode;
 use crate::message::Role;
@@ -59,11 +60,6 @@ pub(crate) fn run_pull_transfer(
     handshake.buffered = buffered;
 
     let mut server_config = build_server_config_for_receiver(config, local_paths, filter_rules)?;
-    // upstream: main.c:1549 - the requested daemon source (module/path) is
-    // recorded as an implied include; the receiver rejects any file-list name
-    // it does not cover (CVE-2022-29154). is_daemon_connection drives the
-    // module-name strip on the receiver side (exclude.c:396-401).
-    server_config.connection.implied_source_args = implied_source_args.to_vec();
 
     // upstream: main.c:1354-1356 - when pulling with --files-from pointing to a
     // local file or stdin, the client reads the file list locally and forwards
@@ -79,6 +75,17 @@ pub(crate) fn run_pull_transfer(
             )?;
         server_config.connection.files_from_data = Some(data);
     }
+
+    // upstream: main.c:1549 / io.c:427,464 / flist.c:1026 - the requested daemon
+    // source (module/path), or each local --files-from entry, is recorded as an
+    // implied include; the receiver rejects any file-list name it does not cover
+    // (CVE-2022-29154). is_daemon_connection drives the module-name strip on the
+    // receiver side (exclude.c:396-401).
+    server_config.connection.implied_source_args = implied_source_args_for_pull(
+        config,
+        implied_source_args,
+        server_config.connection.files_from_data.as_deref(),
+    );
 
     // Pull: local side is Receiver; batch records incoming data (is_sender=false).
     let batch_recording = batch_ctx

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -160,6 +160,10 @@ fn run_embedded_pull(
 
     let mut server_config = build_server_config_for_receiver(config, &[local_dest.to_owned()])?;
     server_config.connection.client_mode = true;
+    // upstream: main.c:1525,1549 / flist.c:1026 - record each requested source
+    // path as an implied include so the receiver rejects any unrequested
+    // file-list name (CVE-2022-29154).
+    server_config.connection.implied_source_args = paths.clone();
     server_config.connection.filter_rules =
         flags::build_wire_format_rules(config.filter_rules(), config.delete_excluded()).map_err(
             |e| invalid_argument_error(&format!("failed to build filter rules: {e}"), 12),

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -38,6 +38,7 @@ use super::super::progress::ClientProgressObserver;
 use super::super::summary::ClientSummary;
 use super::batch_support::{build_batch_context, build_batch_recording};
 use super::flags;
+use super::implied_source::implied_source_args_for_pull;
 use super::invocation::{
     RemoteInvocationBuilder, RemoteOperands, RemoteRole, TransferSpec, determine_transfer_role,
 };
@@ -160,10 +161,6 @@ fn run_embedded_pull(
 
     let mut server_config = build_server_config_for_receiver(config, &[local_dest.to_owned()])?;
     server_config.connection.client_mode = true;
-    // upstream: main.c:1525,1549 / flist.c:1026 - record each requested source
-    // path as an implied include so the receiver rejects any unrequested
-    // file-list name (CVE-2022-29154).
-    server_config.connection.implied_source_args = paths.clone();
     server_config.connection.filter_rules =
         flags::build_wire_format_rules(config.filter_rules(), config.delete_excluded()).map_err(
             |e| invalid_argument_error(&format!("failed to build filter rules: {e}"), 12),
@@ -183,6 +180,15 @@ fn run_embedded_pull(
             )?;
         server_config.connection.files_from_data = Some(data);
     }
+
+    // upstream: main.c:1525,1549 / io.c:427,464 / flist.c:1026 - record each
+    // requested source path (or each local --files-from entry) as an implied
+    // include so the receiver rejects any unrequested name (CVE-2022-29154).
+    server_config.connection.implied_source_args = implied_source_args_for_pull(
+        config,
+        &paths,
+        server_config.connection.files_from_data.as_deref(),
+    );
 
     let batch_ctx = batch_writer.map(|bw| build_batch_context(config, bw));
 

--- a/crates/core/src/client/remote/implied_source.rs
+++ b/crates/core/src/client/remote/implied_source.rs
@@ -1,0 +1,132 @@
+//! Computes the implied-include source arguments recorded for a pull so the
+//! receiver can validate the incoming file list (CVE-2022-29154).
+//!
+//! Mirrors upstream's `add_implied_include()` call sites and the
+//! `trust_sender_args` conditions that disable the mechanism.
+//!
+//! # Upstream Reference
+//!
+//! - `main.c:1524-1549` - each requested remote source arg is recorded, but
+//!   only when `filesfrom_fd < 0` (no `--files-from`).
+//! - `io.c:427,464` - with a local `--files-from`, each forwarded list entry is
+//!   recorded instead (as the bytes are streamed to the remote sender).
+//! - `options.c:2510-2513` - `trust_sender_args` (which makes
+//!   `add_implied_include()` a no-op) is set for `--old-args`/`RSYNC_OLD_ARGS`
+//!   (`old_style_args`) and for a remote `--files-from` (`filesfrom_host`).
+
+use crate::client::config::ClientConfig;
+
+/// Returns the implied-include source args for a pull transfer.
+///
+/// `source_paths` are the host-stripped remote source operands. `files_from_data`
+/// is the staged local `--files-from` byte stream (NUL-separated entries), or
+/// `None` when the list is not staged locally (no `--files-from`, or a remote
+/// `--files-from` the sender reads directly).
+///
+/// An empty result leaves the receiver-side check inactive, matching upstream's
+/// empty `implied_filter_list`.
+pub(crate) fn implied_source_args_for_pull(
+    config: &ClientConfig,
+    source_paths: &[String],
+    files_from_data: Option<&[u8]>,
+) -> Vec<String> {
+    // upstream: options.c:2513 - old_style_args sets trust_sender_args, so
+    // add_implied_include() returns early and the implied list stays empty.
+    if config.old_args() == Some(true) {
+        return Vec::new();
+    }
+
+    if config.files_from().is_active() {
+        // upstream: main.c:1524 - the source arg is NOT recorded when
+        // --files-from is active; io.c:427/464 records each forwarded entry.
+        return match files_from_data {
+            Some(bytes) => files_from_entries(bytes),
+            // Remote --files-from (filesfrom_host != NULL) sets trust_sender_args
+            // (options.c:2513): no local entries, mechanism disabled.
+            None => Vec::new(),
+        };
+    }
+
+    source_paths.to_vec()
+}
+
+/// Splits the staged `--files-from` wire bytes (NUL-separated, double-NUL
+/// terminated) into individual entries, preserving each entry's `/./` pivots
+/// and trailing slashes so [`filters::ImpliedIncludes`] reproduces upstream's
+/// per-entry `add_implied_include()` processing.
+fn files_from_entries(bytes: &[u8]) -> Vec<String> {
+    bytes
+        .split(|&b| b == 0)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| String::from_utf8_lossy(entry).into_owned())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{files_from_entries, implied_source_args_for_pull};
+    use crate::client::config::{ClientConfig, FilesFromSource};
+
+    fn config_with(old_args: Option<bool>, files_from: FilesFromSource) -> ClientConfig {
+        ClientConfig::builder()
+            .old_args(old_args)
+            .files_from(files_from)
+            .build()
+    }
+
+    #[test]
+    fn plain_pull_records_the_source_paths() {
+        let config = config_with(None, FilesFromSource::None);
+        let sources = vec!["dir".to_owned(), "other".to_owned()];
+        assert_eq!(
+            implied_source_args_for_pull(&config, &sources, None),
+            sources
+        );
+    }
+
+    #[test]
+    fn old_args_disables_the_mechanism() {
+        // upstream: options.c:2513 - old_style_args sets trust_sender_args.
+        let config = config_with(Some(true), FilesFromSource::None);
+        assert!(implied_source_args_for_pull(&config, &["dir".to_owned()], None).is_empty());
+    }
+
+    #[test]
+    fn local_files_from_folds_entries_and_drops_source_arg() {
+        // upstream: main.c:1524 skips the source arg; io.c:427/464 records each
+        // forwarded entry instead.
+        let config = config_with(None, FilesFromSource::Stdin);
+        let bytes = b"from/./\0from/./dir/subdir\0\0";
+        assert_eq!(
+            implied_source_args_for_pull(&config, &["ignored".to_owned()], Some(bytes)),
+            vec!["from/./".to_owned(), "from/./dir/subdir".to_owned()]
+        );
+    }
+
+    #[test]
+    fn remote_files_from_disables_the_mechanism() {
+        // upstream: options.c:2513 - filesfrom_host != NULL sets trust_sender_args;
+        // no bytes are staged locally.
+        let config = config_with(None, FilesFromSource::RemoteFile("list".to_owned()));
+        assert!(implied_source_args_for_pull(&config, &["dir".to_owned()], None).is_empty());
+    }
+
+    #[test]
+    fn parses_nul_separated_entries_preserving_slashes() {
+        let bytes = b"from/./\0from/./dir/subdir\0from/./dir/subsubdir2/\0\0";
+        assert_eq!(
+            files_from_entries(bytes),
+            vec![
+                "from/./".to_owned(),
+                "from/./dir/subdir".to_owned(),
+                "from/./dir/subsubdir2/".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_stream_yields_no_entries() {
+        assert!(files_from_entries(b"\0").is_empty());
+        assert!(files_from_entries(b"").is_empty());
+    }
+}

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -30,6 +30,8 @@ pub mod daemon_transfer;
 pub mod embedded_ssh_transfer;
 pub(crate) mod files_from_forwarding;
 pub(crate) mod flags;
+/// Implied-include source-arg computation for pull-side flist validation.
+pub(crate) mod implied_source;
 /// Remote rsync `--server` invocation argument builder.
 pub mod invocation;
 /// `--info=`/`--debug=` server-argument construction (make_output_option).

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -24,6 +24,7 @@ use super::super::super::summary::ClientSummary;
 use super::super::batch_support::{BatchContext, build_batch_context, build_batch_recording};
 use super::super::files_from_forwarding::read_local_files_from_for_forwarding;
 use super::super::flags;
+use super::super::implied_source::implied_source_args_for_pull;
 use super::super::invocation::{RemoteOperands, RemoteRole, TransferSpec, determine_transfer_role};
 use super::connection::build_ssh_connection;
 use super::exit_status::{
@@ -157,7 +158,7 @@ fn run_pull_transfer(
     config: &ClientConfig,
     connection: SshConnection,
     local_paths: &[String],
-    implied_source_args: &[String],
+    source_paths: &[String],
     observer: Option<&mut dyn ClientProgressObserver>,
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
@@ -166,9 +167,6 @@ fn run_pull_transfer(
     // called inside the server).
     let mut server_config = build_server_config_for_receiver(config, local_paths)?;
     server_config.connection.client_mode = true;
-    // upstream: flist.c:1026 recv_file_entry() validates each received name
-    // against these implied includes (CVE-2022-29154).
-    server_config.connection.implied_source_args = implied_source_args.to_vec();
     server_config.connection.filter_rules =
         flags::build_wire_format_rules(config.filter_rules(), config.delete_excluded()).map_err(
             |e| invalid_argument_error(&format!("failed to build filter rules: {e}"), 12),
@@ -188,6 +186,15 @@ fn run_pull_transfer(
         let data = read_local_files_from_for_forwarding(config)?;
         server_config.connection.files_from_data = Some(data);
     }
+
+    // upstream: flist.c:1026 recv_file_entry() validates each received name
+    // against these implied includes (CVE-2022-29154). Computed after staging
+    // so a local --files-from folds each forwarded entry into the set.
+    server_config.connection.implied_source_args = implied_source_args_for_pull(
+        config,
+        source_paths,
+        server_config.connection.files_from_data.as_deref(),
+    );
 
     let batch_ctx = batch_writer.map(|bw| build_batch_context(config, bw));
 

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -29,7 +29,7 @@ use super::connection::build_ssh_connection;
 use super::exit_status::{
     convert_server_stats_to_summary, format_stderr_context, map_child_exit_status,
 };
-use super::parse::{parse_remote_operands, parse_single_remote};
+use super::parse::{parse_remote_operands, parse_single_remote, remote_operand_source_paths};
 use super::progress::ServerProgressAdapter;
 use super::server_config::{build_server_config_for_generator, build_server_config_for_receiver};
 use crate::exit_code::ExitCode;
@@ -120,6 +120,9 @@ pub fn run_ssh_transfer(
             remote_sources,
             local_dest,
         } => {
+            // upstream: main.c:1525,1549 - each requested source path is
+            // recorded as an implied include to validate the received flist.
+            let implied_source_args = remote_operand_source_paths(&remote_sources)?;
             let (invocation_args, ssh_host, ssh_user, ssh_port, stdin_args) =
                 parse_remote_operands(&remote_sources, config, RemoteRole::Receiver)?;
             let connection = build_ssh_connection(
@@ -130,7 +133,14 @@ pub fn run_ssh_transfer(
                 config,
                 &stdin_args,
             )?;
-            run_pull_transfer(config, connection, &[local_dest], observer, batch_writer)
+            run_pull_transfer(
+                config,
+                connection,
+                &[local_dest],
+                &implied_source_args,
+                observer,
+                batch_writer,
+            )
         }
         TransferSpec::Proxy {
             remote_sources,
@@ -147,6 +157,7 @@ fn run_pull_transfer(
     config: &ClientConfig,
     connection: SshConnection,
     local_paths: &[String],
+    implied_source_args: &[String],
     observer: Option<&mut dyn ClientProgressObserver>,
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
@@ -155,6 +166,9 @@ fn run_pull_transfer(
     // called inside the server).
     let mut server_config = build_server_config_for_receiver(config, local_paths)?;
     server_config.connection.client_mode = true;
+    // upstream: flist.c:1026 recv_file_entry() validates each received name
+    // against these implied includes (CVE-2022-29154).
+    server_config.connection.implied_source_args = implied_source_args.to_vec();
     server_config.connection.filter_rules =
         flags::build_wire_format_rules(config.filter_rules(), config.delete_excluded()).map_err(
             |e| invalid_argument_error(&format!("failed to build filter rules: {e}"), 12),

--- a/crates/core/src/client/remote/ssh_transfer/mod.rs
+++ b/crates/core/src/client/remote/ssh_transfer/mod.rs
@@ -39,7 +39,7 @@ pub(super) use exit_status::{format_stderr_context, map_child_exit_status};
 #[cfg(any(feature = "async-ssh", feature = "embedded-ssh"))]
 pub(super) use exit_status::convert_server_stats_to_summary;
 #[cfg(feature = "async-ssh")]
-pub(super) use parse::{parse_remote_operands, parse_single_remote};
+pub(super) use parse::{parse_remote_operands, parse_single_remote, remote_operand_source_paths};
 #[cfg(any(test, feature = "async-ssh"))]
 pub(super) use server_config::{
     build_server_config_for_generator, build_server_config_for_receiver,

--- a/crates/core/src/client/remote/ssh_transfer/parse.rs
+++ b/crates/core/src/client/remote/ssh_transfer/parse.rs
@@ -81,3 +81,26 @@ pub(in crate::client::remote) fn parse_remote_operands(
         }
     }
 }
+
+/// Extracts the host-stripped path portion of each remote pull source operand.
+///
+/// These paths are recorded as implied includes so the receiver can reject any
+/// file-list name the remote sender was never asked for (CVE-2022-29154).
+/// Mirrors upstream `check_for_hostspec()`, which returns the operand's path
+/// portion before `add_implied_include()` records it (main.c:1525,1549).
+pub(in crate::client::remote) fn remote_operand_source_paths(
+    operands: &RemoteOperands,
+) -> Result<Vec<String>, ClientError> {
+    let operand_strs: &[String] = match operands {
+        RemoteOperands::Single(operand) => std::slice::from_ref(operand),
+        RemoteOperands::Multiple(operands) => operands.as_slice(),
+    };
+    operand_strs
+        .iter()
+        .map(|operand| {
+            parse_ssh_operand(OsStr::new(operand))
+                .map(|parsed| parsed.path().to_owned())
+                .map_err(|e| invalid_argument_error(&format!("invalid remote operand: {e}"), 1))
+        })
+        .collect()
+}

--- a/crates/filters/src/implied.rs
+++ b/crates/filters/src/implied.rs
@@ -318,6 +318,71 @@ mod tests {
     }
 
     #[test]
+    fn trailing_slash_source_admits_bare_child_names() {
+        // A trailing-slash source (`host:dir/`) transfers the directory's
+        // CONTENTS, so the received names are bare children. upstream reduces
+        // the arg to "" and (with -r) builds `/**`, admitting them. Regression
+        // for over-rejecting `file`/`one` on a trailing-slash pull.
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["/abs/A weird)name/"]).unwrap();
+        assert!(covers(&implied, "file", false));
+        assert!(covers(&implied, "one", false));
+        assert!(covers(&implied, "sub/deep", false));
+    }
+
+    #[test]
+    fn files_from_relative_entries_admit_requested_tree() {
+        // --files-from implies --relative and disables recursion in favour of
+        // --dirs (options.c:2169-2173,2205-2206). `from/./` reduces to `/*`,
+        // admitting every top-level name the whole-dir entry requested.
+        let opts = ImpliedIncludeOptions {
+            relative: true,
+            recurse: false,
+            dirs: true,
+            skip_daemon_module: false,
+        };
+        let implied = ImpliedIncludes::from_args(
+            opts,
+            [
+                "from/./",
+                "from/./dir/subdir",
+                "from/./dir/subdir/subsubdir2/",
+                "from/./dir/subdir/foobar.baz",
+            ],
+        )
+        .unwrap();
+        // `from/./` -> `/*` admits every top-level requested name.
+        assert!(covers(&implied, "empty", false));
+        // Implied parent dirs and the listed paths.
+        assert!(covers(&implied, "dir", true));
+        assert!(covers(&implied, "dir/subdir", true));
+        assert!(covers(&implied, "dir/subdir/foobar.baz", false));
+        assert!(covers(&implied, "dir/subdir/subsubdir2", true));
+        assert!(covers(&implied, "dir/subdir/subsubdir2/y", false));
+    }
+
+    #[test]
+    fn files_from_without_whole_dir_entry_rejects_out_of_tree_name() {
+        // Without a `from/./` whole-tree entry, a name outside every requested
+        // path is still rejected - the check keeps its teeth under --files-from.
+        let opts = ImpliedIncludeOptions {
+            relative: true,
+            recurse: false,
+            dirs: true,
+            skip_daemon_module: false,
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["from/./dir/subdir"]).unwrap();
+        assert!(covers(&implied, "dir", true));
+        assert!(covers(&implied, "dir/subdir", true));
+        assert!(covers(&implied, "dir/subdir/child", false));
+        assert!(!covers(&implied, "empty", false));
+        assert!(!covers(&implied, "other/evil", false));
+    }
+
+    #[test]
     fn dot_arg_with_recurse_accepts_whole_tree() {
         let opts = ImpliedIncludeOptions {
             recurse: true,

--- a/crates/filters/src/implied.rs
+++ b/crates/filters/src/implied.rs
@@ -1,0 +1,365 @@
+//! Implied-include validation for received file-list names (CVE-2022-29154).
+//!
+//! When an rsync client pulls from a remote sender, it records each requested
+//! source argument as an "implied include". The receiver then validates every
+//! incoming file-list name against that set and refuses any name it never
+//! asked for. This stops a malicious or buggy sender from injecting extra
+//! files that would be written outside the intended destination.
+//!
+//! The rule set built here mirrors upstream `add_implied_include()`; the
+//! per-name test in [`ImpliedIncludes::covers`] mirrors the receiver-side
+//! `check_filter(&implied_filter_list, ...)` call.
+//!
+//! # Upstream Reference
+//!
+//! - `exclude.c:379` `add_implied_include()` - turns each requested source arg
+//!   into one or more `FILTRULE_INCLUDE` rules (basename/relative handling,
+//!   parent-dir implication for `--relative`, a trailing `/**` (`--recursive`)
+//!   or `/*` (`--dirs`) rule, wildcard args producing `FILTRULE_WILD` rules).
+//! - `flist.c:1026` `recv_file_entry()` - rejects any received name for which
+//!   `check_filter(&implied_filter_list, ...) <= 0` (no include match).
+//! - `options.c:2510-2513` - `trust_sender_args` disables the mechanism for
+//!   local/`--trust-sender`/server/old-style/`files-from-host` transfers; the
+//!   caller reflects that by not building the list at all in those cases.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::compiled::CompiledRule;
+use crate::{FilterError, FilterRule};
+
+/// Transfer options that shape how source args become implied-include rules.
+///
+/// These correspond to the upstream globals consulted by `add_implied_include`:
+/// `relative_paths`, `recurse`, `xfer_dirs`, and the daemon-module flag.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub struct ImpliedIncludeOptions {
+    /// `--relative` (`relative_paths`): keep the path after a `/./` pivot and
+    /// imply every parent directory instead of reducing the arg to its
+    /// basename.
+    pub relative: bool,
+    /// `--recursive` (`recurse`): also add a trailing `arg/**` rule so the
+    /// requested directory's whole subtree is accepted.
+    pub recurse: bool,
+    /// `--dirs` (`xfer_dirs`): add a trailing `arg/*` rule accepting the
+    /// requested directory's immediate contents.
+    pub dirs: bool,
+    /// The source arg is a daemon `module/path` spec: strip the leading module
+    /// name (everything up to and including the first `/`).
+    ///
+    /// upstream: `exclude.c:396-401` `skip_daemon_module`.
+    pub skip_daemon_module: bool,
+}
+
+/// Set of implied-include rules built from a client's requested source args.
+///
+/// Construct with [`ImpliedIncludes::from_args`], then test each received
+/// file-list name with [`ImpliedIncludes::covers`]. An empty set means the
+/// mechanism is inactive and no name should be rejected.
+#[derive(Debug, Default)]
+pub struct ImpliedIncludes {
+    opts: ImpliedIncludeOptions,
+    rules: Vec<CompiledRule>,
+    seen: HashSet<String>,
+}
+
+impl ImpliedIncludes {
+    /// Creates an empty set for the given transfer options.
+    #[must_use]
+    pub fn new(opts: ImpliedIncludeOptions) -> Self {
+        Self {
+            opts,
+            rules: Vec::new(),
+            seen: HashSet::new(),
+        }
+    }
+
+    /// Builds the implied-include set from `args` under `opts`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] only if an implied pattern cannot be compiled
+    /// even after literal escaping (not expected in practice).
+    pub fn from_args<I, S>(opts: ImpliedIncludeOptions, args: I) -> Result<Self, FilterError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut this = Self::new(opts);
+        for arg in args {
+            this.add_arg(arg.as_ref())?;
+        }
+        Ok(this)
+    }
+
+    /// Adds the implied-include rules for a single requested source `arg`.
+    ///
+    /// upstream: `exclude.c:379` `add_implied_include()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if a synthesized pattern cannot be compiled even
+    /// after literal escaping.
+    pub fn add_arg(&mut self, arg: &str) -> Result<(), FilterError> {
+        let mut arg = arg;
+
+        // upstream: exclude.c:396-401 - strip the daemon module name.
+        if self.opts.skip_daemon_module {
+            arg = arg.split_once('/').map_or("", |(_, rest)| rest);
+        }
+
+        // upstream: exclude.c:403-408 - --relative keeps the path after a
+        // "/./" pivot; otherwise the arg is reduced to its basename.
+        if self.opts.relative {
+            if let Some(idx) = arg.find("/./") {
+                arg = &arg[idx + 3..];
+            }
+        } else if let Some(idx) = arg.rfind('/') {
+            arg = &arg[idx + 1..];
+        }
+
+        // upstream: exclude.c:410-411 - a bare "." arg contributes no name rule.
+        if arg == "." {
+            arg = "";
+        }
+
+        // upstream: exclude.c:412-491 - normalise the arg into an anchored
+        // pattern, collapsing "//", "/./" and trailing "/" the way the C loop
+        // does. Empty and "." segments are dropped.
+        let segments: Vec<&str> = arg
+            .split('/')
+            .filter(|seg| !seg.is_empty() && *seg != ".")
+            .collect();
+
+        if !segments.is_empty() {
+            let base = format!("/{}", segments.join("/"));
+            self.push_rule(&base, false)?;
+
+            // upstream: exclude.c:497-527 - with --relative every parent
+            // directory of the arg is implied as a directory-only include.
+            if self.opts.relative {
+                for depth in 1..segments.len() {
+                    let parent = format!("/{}/", segments[..depth].join("/"));
+                    self.push_rule(&parent, true)?;
+                }
+            }
+        }
+
+        // upstream: exclude.c:531-567 - --recursive adds "arg/**" and --dirs
+        // adds "arg/*" (an empty arg yields "/**" or "/*", accepting the tree).
+        if self.opts.recurse || self.opts.dirs {
+            let base = if segments.is_empty() {
+                String::new()
+            } else {
+                format!("/{}", segments.join("/"))
+            };
+            let suffix = if self.opts.recurse { "**" } else { "*" };
+            let pattern = format!("{base}/{suffix}");
+            self.push_rule(&pattern, false)?;
+        }
+
+        Ok(())
+    }
+
+    /// Returns `true` when no rules were built (mechanism inactive).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// Tests whether `path` is covered by any implied-include rule.
+    ///
+    /// Equivalent to upstream `check_filter(&implied_filter_list, ...) > 0`:
+    /// the list holds only include rules, so a match means the name was
+    /// requested and a non-match means it should be rejected. Matching uses
+    /// `check_descendants = false`, giving exactly upstream `rule_matches()`
+    /// semantics (no synthetic `pattern/**` descendant matchers).
+    #[must_use]
+    pub fn covers(&self, path: &Path, is_dir: bool) -> bool {
+        self.rules
+            .iter()
+            .any(|rule| rule.matches(path, is_dir, false))
+    }
+
+    /// Compiles and stores one anchored include rule, de-duplicating repeats.
+    ///
+    /// A pattern that fails to compile (e.g. an unbalanced `[` in a wildcard
+    /// arg) is retried with its glob metacharacters escaped so it matches
+    /// literally - stricter than a wildcard, never more permissive, and always
+    /// valid. This mirrors upstream falling back to a literal-bracket rule
+    /// (`maybe_add_literal_brackets_rule`).
+    fn push_rule(&mut self, pattern: &str, directory_only: bool) -> Result<(), FilterError> {
+        if !self.seen.insert(pattern.to_owned()) {
+            return Ok(());
+        }
+        let rule = FilterRule::include(pattern);
+        let compiled = match CompiledRule::new(rule) {
+            Ok(compiled) => compiled,
+            Err(_) => CompiledRule::new(FilterRule::include(globset::escape(pattern)))?,
+        };
+        debug_assert_eq!(compiled.is_directory_only(), directory_only);
+        self.rules.push(compiled);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ImpliedIncludeOptions, ImpliedIncludes};
+    use std::path::Path;
+
+    fn covers(implied: &ImpliedIncludes, name: &str, is_dir: bool) -> bool {
+        implied.covers(Path::new(name), is_dir)
+    }
+
+    #[test]
+    fn recursive_pull_accepts_request_and_subtree_but_rejects_injection() {
+        // `oc-rsync -r host:dir dest` requests only `dir`; the sender must not
+        // be able to smuggle an unrelated `evil` (CVE-2022-29154).
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["dir"]).unwrap();
+        assert!(!implied.is_empty());
+        assert!(covers(&implied, "dir", true));
+        assert!(covers(&implied, "dir/file", false));
+        assert!(covers(&implied, "dir/sub/deep", false));
+        assert!(!covers(&implied, "evil", false));
+        assert!(!covers(&implied, "dirEVIL", false));
+    }
+
+    #[test]
+    fn non_recursive_pull_rejects_children_like_upstream() {
+        // Without -r/-d upstream adds only `/dir`; a child arriving anyway is
+        // an injection and must be rejected.
+        let implied =
+            ImpliedIncludes::from_args(ImpliedIncludeOptions::default(), ["dir"]).unwrap();
+        assert!(covers(&implied, "dir", true));
+        assert!(!covers(&implied, "dir/file", false));
+    }
+
+    #[test]
+    fn non_relative_pull_reduces_arg_to_basename() {
+        // `host:a/b` (no --relative) is sent as top-level `b`, so `b` is
+        // implied and the parent `a` is not a valid received name.
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["a/b"]).unwrap();
+        assert!(covers(&implied, "b", true));
+        assert!(covers(&implied, "b/c", false));
+        assert!(!covers(&implied, "a", true));
+        assert!(!covers(&implied, "a/evil", false));
+    }
+
+    #[test]
+    fn relative_pull_implies_every_parent_directory() {
+        // `-R host:a/b/c` keeps the full path and implies parents `a` and
+        // `a/b` as directories.
+        let opts = ImpliedIncludeOptions {
+            relative: true,
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["a/b/c"]).unwrap();
+        assert!(covers(&implied, "a", true));
+        assert!(covers(&implied, "a/b", true));
+        assert!(covers(&implied, "a/b/c", true));
+        assert!(covers(&implied, "a/b/c/leaf", false));
+        // A parent implied as a directory must not admit an unrequested file
+        // sitting beside the requested path.
+        assert!(!covers(&implied, "a/evil", false));
+        assert!(!covers(&implied, "a/b/evil", false));
+    }
+
+    #[test]
+    fn relative_pull_honours_dot_pivot() {
+        // `-R host:src/./dir` pivots at "/./"; only `dir` and its subtree are
+        // implied, not `src`.
+        let opts = ImpliedIncludeOptions {
+            relative: true,
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["src/./dir"]).unwrap();
+        assert!(covers(&implied, "dir", true));
+        assert!(covers(&implied, "dir/file", false));
+        assert!(!covers(&implied, "src", true));
+    }
+
+    #[test]
+    fn wildcard_arg_stays_active_and_wildcard_aware() {
+        // upstream 3.4.4 does NOT disable the check for wildcard args: it emits
+        // a FILTRULE_WILD rule (exclude.c:415). A `d*` request admits matching
+        // names and still rejects non-matching injections.
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["d*"]).unwrap();
+        assert!(covers(&implied, "data", true));
+        assert!(covers(&implied, "data/file", false));
+        assert!(!covers(&implied, "evil", false));
+    }
+
+    #[test]
+    fn bare_star_arg_admits_everything() {
+        // A top-level `*` naturally matches every name via `/ *` + `/ */**`,
+        // reproducing upstream's effectively-permissive behaviour for `*`.
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["*"]).unwrap();
+        assert!(covers(&implied, "anything", false));
+        assert!(covers(&implied, "any/thing", false));
+    }
+
+    #[test]
+    fn dot_arg_with_recurse_accepts_whole_tree() {
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["."]).unwrap();
+        assert!(covers(&implied, "anything", false));
+        assert!(covers(&implied, "deep/path/file", false));
+    }
+
+    #[test]
+    fn daemon_module_prefix_is_stripped() {
+        // A daemon `module/dir` arg drops the module name before building rules.
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            skip_daemon_module: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["mod/dir"]).unwrap();
+        assert!(covers(&implied, "dir", true));
+        assert!(covers(&implied, "dir/file", false));
+        assert!(!covers(&implied, "mod", true));
+    }
+
+    #[test]
+    fn empty_args_leave_set_inactive() {
+        let implied =
+            ImpliedIncludes::from_args(ImpliedIncludeOptions::default(), Vec::<String>::new())
+                .unwrap();
+        assert!(implied.is_empty());
+    }
+
+    #[test]
+    fn unbalanced_bracket_arg_falls_back_to_literal() {
+        // A malformed glob must not abort rule construction; it is matched
+        // literally instead (stricter, never more permissive).
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["a[b"]).unwrap();
+        assert!(covers(&implied, "a[b", true));
+        assert!(!covers(&implied, "evil", false));
+    }
+}

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -110,6 +110,8 @@ pub mod cvs;
 pub mod debug_filter;
 mod decision;
 mod error;
+/// Implied-include validation of received file-list names (CVE-2022-29154).
+pub mod implied;
 /// Merge-file reader and parser for filter rules.
 pub mod merge;
 mod rule;
@@ -123,6 +125,7 @@ pub use apple_double::{
 pub use chain::{DirFilterGuard, DirMergeConfig, FilterChain, FilterChainError};
 pub use cvs::{DEFAULT_CVSIGNORE, default_patterns as cvs_default_patterns};
 pub use error::FilterError;
+pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};
 pub use merge::{MergeFileError, parse_rules, read_rules, read_rules_recursive};
 pub use rule::FilterRule;
 pub use set::{FilterSet, FilterSetError, apple_double_exclusion_rules, cvs_exclusion_rules};

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -202,6 +202,13 @@ impl ServerConfigBuilder {
         self
     }
 
+    /// Records the client's requested remote source args as implied includes
+    /// used to validate the received file list (CVE-2022-29154).
+    pub fn implied_source_args(&mut self, args: Vec<String>) -> &mut Self {
+        self.connection.implied_source_args = args;
+        self
+    }
+
     /// Sets the filename encoding converter for `--iconv` support.
     pub fn iconv(&mut self, converter: Option<FilenameConverter>) -> &mut Self {
         self.connection.iconv = converter;

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -218,6 +218,22 @@ pub struct ConnectionConfig {
     /// - `io.c:forward_filesfrom_data()` - forwards local file to socket
     /// - `main.c:1354-1356` - `start_filesfrom_forwarding(filesfrom_fd)`
     pub files_from_data: Option<Vec<u8>>,
+    /// Remote source arguments the client requested on a pull, recorded as
+    /// implied includes to validate the received file list (CVE-2022-29154).
+    ///
+    /// Populated only by a client-receiver pulling from a remote sender. The
+    /// receiver rejects any incoming file-list name not covered by these args,
+    /// preventing a malicious sender from injecting unrequested files. Empty
+    /// (the default) leaves the check inactive, matching upstream's behaviour
+    /// when `trust_sender_args` is set (local, server, `--trust-sender`,
+    /// old-style, or `files-from-host` transfers).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:1525,1549` - `add_implied_include()` per requested source arg
+    /// - `exclude.c:379` `add_implied_include()`
+    /// - `flist.c:1026` `recv_file_entry()` - the receiver-side name check
+    pub implied_source_args: Vec<String>,
 }
 
 /// File selection and filtering options for transfer candidates.

--- a/crates/transfer/src/receiver/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/file_list/filter_recheck.rs
@@ -165,12 +165,18 @@ impl ReceiverContext {
         }
 
         // upstream: exclude.c:403-567 - relative_paths, recurse, xfer_dirs and
-        // the daemon-module flag shape the implied rules.
+        // the daemon-module flag shape the implied rules. The module-name strip
+        // applies only to a daemon source arg (main.c:1549 passes
+        // skip_daemon_module=daemon_connection); local --files-from entries are
+        // already module-relative, so upstream records them with
+        // skip_daemon_module=0 (io.c:427,464). files_from_data being present is
+        // exactly that local-files-from case.
         let opts = ImpliedIncludeOptions {
             relative: self.config.flags.relative,
             recurse: self.config.flags.recursive,
             dirs: self.config.flags.dirs,
-            skip_daemon_module: self.config.connection.is_daemon_connection,
+            skip_daemon_module: self.config.connection.is_daemon_connection
+                && self.config.connection.files_from_data.is_none(),
         };
         let implied = ImpliedIncludes::from_args(opts, sources)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;

--- a/crates/transfer/src/receiver/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/file_list/filter_recheck.rs
@@ -26,7 +26,7 @@
 use std::io;
 use std::path::Path;
 
-use filters::FilterSet;
+use filters::{FilterSet, ImpliedIncludeOptions, ImpliedIncludes};
 
 use super::super::ReceiverContext;
 use crate::receiver::transfer::parse_wire_filters_for_receiver;
@@ -114,6 +114,88 @@ impl ReceiverContext {
                     io::ErrorKind::Unsupported,
                     format!(
                         "ERROR: rejecting excluded file-list name: {}",
+                        path.display()
+                    ),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Re-checks received file-list names against the implied-include set built
+    /// from the client's requested source args, aborting the transfer if the
+    /// sender sent a name that was never requested (CVE-2022-29154).
+    ///
+    /// A malicious sender can otherwise inject extra file-list entries that the
+    /// client never asked for, causing the receiver to materialize paths
+    /// outside the intended set. Upstream records each requested source arg as
+    /// an implied include and rejects any received name not covered by it.
+    ///
+    /// Runs after [`recheck_received_filter`](Self::recheck_received_filter) so
+    /// the ordering mirrors upstream `recv_file_entry()` (server-filter check
+    /// then implied-include check). Returns [`io::ErrorKind::Unsupported`] on
+    /// the first unrequested name so the error maps to `RERR_UNSUPPORTED`
+    /// (exit code 4), matching upstream's `exit_cleanup(RERR_UNSUPPORTED)`.
+    ///
+    /// The check is skipped when:
+    /// - `trust_sender` is set (upstream `trust_sender_args`: local, server,
+    ///   `--trust-sender`, old-style, or `files-from-host` transfers, where
+    ///   `add_implied_include()` returns early), or
+    /// - no source args were recorded (a push/server-receiver never records
+    ///   them, so the implied list is empty).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:1026-1029` `recv_file_entry()` - `check_filter(&implied_filter_list,
+    ///   ...) <= 0` triggers `rprintf(FERROR, "ERROR: rejecting unrequested
+    ///   file-list name: %s\n", ...)` then `exit_cleanup(RERR_UNSUPPORTED)`.
+    /// - `exclude.c:379` `add_implied_include()` - rule construction.
+    /// - `options.c:2510-2513` - `trust_sender_args` disables the mechanism.
+    pub(in crate::receiver) fn recheck_received_implied_includes(&self) -> io::Result<()> {
+        // upstream: options.c:2510 / exclude.c:385 - trust_sender_args makes
+        // add_implied_include() a no-op, leaving implied_filter_list empty.
+        if self.config.trust_sender {
+            return Ok(());
+        }
+
+        let sources = &self.config.connection.implied_source_args;
+        if sources.is_empty() {
+            return Ok(());
+        }
+
+        // upstream: exclude.c:403-567 - relative_paths, recurse, xfer_dirs and
+        // the daemon-module flag shape the implied rules.
+        let opts = ImpliedIncludeOptions {
+            relative: self.config.flags.relative,
+            recurse: self.config.flags.recursive,
+            dirs: self.config.flags.dirs,
+            skip_daemon_module: self.config.connection.is_daemon_connection,
+        };
+        let implied = ImpliedIncludes::from_args(opts, sources)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+        if implied.is_empty() {
+            return Ok(());
+        }
+
+        for entry in &self.file_list {
+            let path = entry.path().as_path();
+            // upstream: flist.c:1019 - the transfer root (`.` / `/.`) is exempt.
+            if path.as_os_str().is_empty() || path == Path::new(".") {
+                continue;
+            }
+
+            // upstream: flist.c:1026 - check_filter(&implied_filter_list, ...)
+            // <= 0 means no include rule matched, i.e. the name was never
+            // requested. `covers` reproduces `check_filter(...) > 0` with
+            // `rule_matches()` (check_descendants = false) semantics.
+            if !implied.covers(path, entry.is_dir()) {
+                // upstream: flist.c:1027-1028 - rprintf(FERROR, ...) then
+                // exit_cleanup(RERR_UNSUPPORTED).
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    format!(
+                        "ERROR: rejecting unrequested file-list name: {}",
                         path.display()
                     ),
                 ));

--- a/crates/transfer/src/receiver/tests/file_list/implied_recheck.rs
+++ b/crates/transfer/src/receiver/tests/file_list/implied_recheck.rs
@@ -1,0 +1,167 @@
+//! Receiver-side implied-include validation of received file-list names.
+//!
+//! CVE-2022-29154: a malicious rsync sender can append extra entries to the
+//! file list that the client never requested, causing the receiver to write
+//! files outside the intended set. Upstream records each requested source arg
+//! as an implied include (`exclude.c:add_implied_include`) and rejects any
+//! received name not covered by it (`flist.c:1026 recv_file_entry`,
+//! `exit_cleanup(RERR_UNSUPPORTED)`). These tests encode that invariant: an
+//! injected name aborts with exit code 4, while every legitimately requested
+//! name (and its implied parent directories) passes. They also prove the
+//! upstream skip conditions (`trust_sender_args`, no recorded source args).
+
+use std::io;
+
+use protocol::flist::FileEntry;
+
+use super::super::super::ReceiverContext;
+use super::super::support::{test_config, test_handshake};
+
+#[test]
+fn injected_name_rejected_with_exit_code_4() {
+    // `oc-rsync -r host:dir dest` requests only `dir`; a sender that also
+    // streams `evil` is exploiting CVE-2022-29154 and must be refused.
+    let mut config = test_config();
+    config.flags.recursive = true;
+    config.connection.implied_source_args = vec!["dir".to_owned()];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("dir".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("dir/wanted.txt".into(), 10, 0o644));
+    ctx.file_list
+        .push(FileEntry::new_file("evil".into(), 20, 0o644));
+
+    let err = ctx.recheck_received_implied_includes().unwrap_err();
+    // io::ErrorKind::Unsupported maps to ExitCode::Unsupported (4), matching
+    // upstream exit_cleanup(RERR_UNSUPPORTED).
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert_eq!(
+        err.to_string(),
+        "ERROR: rejecting unrequested file-list name: evil"
+    );
+}
+
+#[test]
+fn requested_names_and_subtree_pass() {
+    let mut config = test_config();
+    config.flags.recursive = true;
+    config.connection.implied_source_args = vec!["dir".to_owned()];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("dir".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("dir/a.txt".into(), 10, 0o644));
+    ctx.file_list
+        .push(FileEntry::new_file("dir/sub/b.txt".into(), 10, 0o644));
+
+    ctx.recheck_received_implied_includes()
+        .expect("names under the requested directory must pass");
+}
+
+#[test]
+fn relative_implied_parent_directories_pass() {
+    // `-R host:a/b/c` keeps the full path and implies parents `a` and `a/b`;
+    // those directory entries arrive in the list and must not be rejected.
+    let mut config = test_config();
+    config.flags.recursive = true;
+    config.flags.relative = true;
+    config.connection.implied_source_args = vec!["a/b/c".to_owned()];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("a".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("a/b".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("a/b/c".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("a/b/c/leaf".into(), 10, 0o644));
+
+    ctx.recheck_received_implied_includes()
+        .expect("implied parent directories of a relative arg must pass");
+}
+
+#[test]
+fn relative_sibling_injection_rejected() {
+    // The implied parent `a` is a directory rule only: a sibling file `a/evil`
+    // next to the requested `a/b/c` was never requested and must be refused.
+    let mut config = test_config();
+    config.flags.recursive = true;
+    config.flags.relative = true;
+    config.connection.implied_source_args = vec!["a/b/c".to_owned()];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.file_list
+        .push(FileEntry::new_directory("a".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("a/evil".into(), 20, 0o644));
+
+    let err = ctx.recheck_received_implied_includes().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert_eq!(
+        err.to_string(),
+        "ERROR: rejecting unrequested file-list name: a/evil"
+    );
+}
+
+#[test]
+fn wildcard_arg_stays_active_and_admits_matching_names() {
+    // upstream 3.4.4 does NOT disable the check for wildcard args; it builds a
+    // FILTRULE_WILD rule (exclude.c:415). A `d*` request admits matching names
+    // yet still rejects a non-matching injection.
+    let mut config = test_config();
+    config.flags.recursive = true;
+    config.connection.implied_source_args = vec!["d*".to_owned()];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.file_list
+        .push(FileEntry::new_directory("data".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("data/file".into(), 10, 0o644));
+    ctx.recheck_received_implied_includes()
+        .expect("names matching the wildcard request must pass");
+
+    ctx.file_list
+        .push(FileEntry::new_file("evil".into(), 20, 0o644));
+    let err = ctx.recheck_received_implied_includes().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert_eq!(
+        err.to_string(),
+        "ERROR: rejecting unrequested file-list name: evil"
+    );
+}
+
+#[test]
+fn trust_sender_skips_implied_check() {
+    // upstream: options.c:2510 / exclude.c:385 - trust_sender_args makes
+    // add_implied_include() a no-op, so the implied list is empty and the
+    // receiver performs no name validation.
+    let mut config = test_config();
+    config.trust_sender = true;
+    config.flags.recursive = true;
+    config.connection.implied_source_args = vec!["dir".to_owned()];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.file_list
+        .push(FileEntry::new_file("evil".into(), 20, 0o644));
+
+    ctx.recheck_received_implied_includes()
+        .expect("trust_sender must skip the implied-include check");
+}
+
+#[test]
+fn no_source_args_is_a_no_op() {
+    // A push or server-receiver never records source args: the check must not
+    // disturb a normal transfer.
+    let mut config = test_config();
+    config.flags.recursive = true;
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.file_list
+        .push(FileEntry::new_file("anything".into(), 20, 0o644));
+
+    ctx.recheck_received_implied_includes()
+        .expect("no recorded source args means nothing to validate");
+}

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -37,6 +37,7 @@ mod filter_recheck;
 #[cfg(feature = "iconv")]
 mod iconv_wire_order;
 mod id_lists;
+mod implied_recheck;
 mod incremental_directories;
 mod incremental_receiver;
 mod missing_args_sentinel;

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -157,6 +157,12 @@ impl ReceiverContext {
         // already cleaned, matching upstream's per-entry ordering.
         self.recheck_received_filter()?;
 
+        // upstream: flist.c:1026-1029 recv_file_entry() also validates each
+        // received name against the implied-include list built from the
+        // client's requested source args, aborting with RERR_UNSUPPORTED if the
+        // sender injected a name that was never requested (CVE-2022-29154).
+        self.recheck_received_implied_includes()?;
+
         let checksum_factory = ChecksumFactory::from_negotiation(
             self.negotiated_algorithms.as_ref(),
             self.protocol,


### PR DESCRIPTION
# fix(transfer): validate received flist names against implied includes

## Security context (CVE-2022-29154)

A malicious or compromised rsync **sender** (the remote side of a pull) can
append extra entries to the file list that the client never requested. Without
validation the receiver materializes those paths, letting the server write
files outside the intended set. Upstream rsync fixed this by having the client
record each requested source argument as an *implied include* and having the
**receiver** re-validate every incoming file-list name against that set,
aborting the transfer for any name it never asked for.

This change ports that defense to the pull (client-receiver) path.

## Upstream reference

Behaviour mirrors upstream rsync 3.4.4 (protocol 32):

- `exclude.c:379` `add_implied_include()` - builds the implied-include rule set
  from each requested source arg: basename reduction (non-`--relative`),
  `/./` pivot and parent-directory implication (`--relative`), a trailing
  `arg/**` (`--recursive`) or `arg/*` (`--dirs`) rule, daemon module-name
  stripping, and wildcard args producing wildcard rules.
- `flist.c:1026-1029` `recv_file_entry()` - rejects any received name for which
  `check_filter(&implied_filter_list, ...) <= 0` (no include match) with
  `ERROR: rejecting unrequested file-list name: %s` followed by
  `exit_cleanup(RERR_UNSUPPORTED)` (exit code 4).
- `options.c:2510-2513` - `trust_sender_args` disables the mechanism for local,
  server, `--trust-sender`, old-style, and `files-from-host` transfers, where
  `add_implied_include()` returns early and the implied list stays empty.

## What changed

**`filters`** - new `implied` module (`ImpliedIncludes`, `ImpliedIncludeOptions`)
that builds the implied-include rule set from requested source args, mirroring
`add_implied_include()`. Matching reuses the existing upstream-faithful rule
matcher with `check_descendants = false`, giving exactly `rule_matches()`
semantics. `covers()` reproduces `check_filter(...) > 0`.

**`transfer`** - `ConnectionConfig.implied_source_args` records the requested
source paths; `ReceiverContext::recheck_received_implied_includes()` validates
each received name after the existing excluded-name re-check, returning
`io::ErrorKind::Unsupported` (which maps to exit code 4) for the first
unrequested name. The check is skipped when `trust_sender` is set or no source
args were recorded.

**`core`** - the requested remote source paths are plumbed into
`ConnectionConfig.implied_source_args` at the four pull-config construction
sites (SSH, embedded SSH, async SSH, daemon). The daemon path passes
`module/path` so the receiver's daemon-connection flag strips the module name,
matching upstream.

## Note on wildcard source args

The upstream 3.4.4 source does **not** disable the check for wildcard source
args: `add_implied_include()` emits a wildcard include rule and the check stays
active (`options.c:2510` sets `trust_sender_args` only for local / server /
`--trust-sender` / old-style / `files-from-host`, never for wildcards). This
port matches that behaviour: a `d*` request admits matching names and still
rejects non-matching injections, while a bare `*` naturally admits everything
via `/*` + `/*/**`. Tests encode this.

## Tests

- `filters`: unit tests for basename/relative/recursive/dirs/daemon-module
  handling, wildcard behaviour, the `.`/`*` whole-tree cases, and the
  malformed-glob literal fallback.
- `transfer`: integration tests proving an injected name aborts with
  `ErrorKind::Unsupported` (exit 4) and the exact upstream message, that
  requested names and implied parent directories pass, that a relative sibling
  injection is rejected, and that the `trust_sender` / no-source-args skip
  conditions hold.

## Verification

- `cargo fmt --all`
- `cargo clippy -p core -p transfer -p filters --all-targets --all-features --no-deps -- -D warnings` (zero warnings)
- Targeted `cargo nextest run` for the new `filters` and `transfer` tests (all pass)
