### PR TITLE
feat(transfer): copy to backup under --inplace to preserve dest inode

### DIFF
--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -1008,6 +1008,92 @@ impl<'a> CopyContext<'a> {
         Ok(())
     }
 
+    /// Backs up an existing regular destination file by COPYING it aside,
+    /// leaving the destination inode in place for an `--inplace` rewrite.
+    ///
+    /// Unlike [`backup_existing_entry`](Self::backup_existing_entry), which
+    /// renames the destination (moving its inode to the backup name), this
+    /// duplicates the pre-transfer contents so the original inode stays put and
+    /// is updated in place - the whole point of `--inplace`. Only used for
+    /// regular-file inplace updates; other entries keep the rename path.
+    ///
+    /// upstream: backup.c make_backup() inplace copy path - the generator makes
+    /// the backup a COPY (`generator.c:1862` `copy_file(fname, backupptr, ...)`,
+    /// with the delta twin building the same copy at `generator.c:1898`) BEFORE
+    /// the receiver rewrites the destination in place. The inplace copy bypasses
+    /// `make_backup()`, so it emits no `DEBUG_GTE(BACKUP, 1)` trace, but it still
+    /// emits the `INFO_GTE(BACKUP, 1)` "backed up X to Y" line
+    /// (`generator.c:1990-1992`).
+    pub(super) fn backup_existing_entry_copy(
+        &mut self,
+        destination: &Path,
+    ) -> Result<(), LocalCopyError> {
+        let backup_path = compute_backup_path(
+            self.destination_root(),
+            destination,
+            None,
+            self.options.backup_directory(),
+            self.options.backup_suffix(),
+        );
+
+        if let Some(parent) = backup_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent)
+                .map_err(|error| LocalCopyError::io("create backup directory", parent, error))?;
+        }
+
+        // upstream: generator.c:1866 copy_file() - duplicate the pre-image; the
+        // destination inode is left in place to be rewritten by the inplace
+        // writer. A pre-existing backup is overwritten (upstream robust_unlinks
+        // it at generator.c:1901); fs::copy truncates to the same end state.
+        match fs::copy(destination, &backup_path) {
+            Ok(_) => {}
+            // A vanished destination has nothing to back up, mirroring the
+            // NotFound arm of the rename path (backup.c:make_backup returns 3).
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(LocalCopyError::io("create backup", backup_path, error));
+            }
+        }
+
+        // upstream: generator.c:1988 set_file_attrs(backupptr, back_file, ...) -
+        // the backup carries the source node's mode/owner/times. fs::copy
+        // preserves only permissions, so reapply full metadata like the
+        // cross-device COPY fallback in backup_existing_entry.
+        if let Ok(source_meta) = fs::symlink_metadata(destination) {
+            let metadata_options = self.metadata_options();
+            apply_file_metadata_with_options(&backup_path, &source_meta, &metadata_options)
+                .map_err(map_metadata_error)?;
+            // upstream: generator.c:1985 copy_xattrs() under --fake-super
+            // re-records the source stat in `user.rsync.%stat`; no-op otherwise.
+            #[cfg(all(unix, feature = "xattr"))]
+            store_effective_fake_super_if_requested(
+                &metadata_options,
+                destination,
+                &backup_path,
+                &source_meta,
+            )?;
+        }
+
+        // upstream: generator.c:1990-1992 - INFO_GTE(BACKUP, 1) "backed up X to
+        // Y". No DEBUG_GTE(BACKUP) trace: the inplace copy bypasses make_backup().
+        let dest_root = self.destination_root();
+        let destination_rel = destination.strip_prefix(dest_root).unwrap_or(destination);
+        let backup_rel = backup_path
+            .strip_prefix(dest_root)
+            .unwrap_or(backup_path.as_path());
+        info_log!(
+            Backup,
+            1,
+            "backed up {} to {}",
+            destination_rel.display(),
+            backup_rel.display()
+        );
+
+        Ok(())
+    }
+
     /// Forcibly removes a type-conflicting destination entry (backing it up
     /// first if needed) to make room for an incoming item of a different type.
     ///

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -180,22 +180,37 @@ pub(in crate::local_copy) fn execute_transfer(
     let mut delta_basis_override: Option<PathBuf> =
         fuzzy_basis.as_ref().map(|(path, _)| path.clone());
     if let Some(existing) = existing_metadata {
-        context.backup_existing_entry(destination, relative, existing.file_type())?;
-        // When backup renamed the basis file and delta transfer will need it,
-        // record the backup path so copy_file_contents reads from the right
-        // location. The delta signature is only built for regular files, so
-        // this condition is sufficient.
-        if delta_signature.is_some()
+        // upstream: generator.c:1862,1898 - under --inplace, --backup COPIES the
+        // pre-image aside (preserving the destination inode for the in-place
+        // rewrite) rather than renaming the destination away. Only a regular-file
+        // inplace update qualifies; every other entry keeps the rename path.
+        let inplace_regular_backup = inplace_enabled
+            && existing.is_file()
             && context.options().backup_enabled()
-            && !context.mode().is_dry_run()
-        {
-            delta_basis_override = Some(compute_backup_path(
-                context.destination_root(),
-                destination,
-                None,
-                context.options().backup_directory(),
-                context.options().backup_suffix(),
-            ));
+            && !context.mode().is_dry_run();
+        if inplace_regular_backup {
+            context.backup_existing_entry_copy(destination)?;
+            // The destination stays in place as the true in-place basis, so no
+            // basis override: copy_file_contents rewrites the existing inode via
+            // the proven inplace path (which truncates to the final length).
+        } else {
+            context.backup_existing_entry(destination, relative, existing.file_type())?;
+            // When a rename moved the basis file, delta transfer must read
+            // matched blocks from the backup location. The delta signature is
+            // only built for regular files, so this condition is sufficient.
+            // upstream: receiver.c:872-876 (FNAMECMP_BACKUP).
+            if delta_signature.is_some()
+                && context.options().backup_enabled()
+                && !context.mode().is_dry_run()
+            {
+                delta_basis_override = Some(compute_backup_path(
+                    context.destination_root(),
+                    destination,
+                    None,
+                    context.options().backup_directory(),
+                    context.options().backup_suffix(),
+                ));
+            }
         }
     }
 
@@ -565,16 +580,18 @@ pub(in crate::local_copy) fn execute_transfer(
         }
     );
 
-    // When backup moved the basis file, point the delta transfer at its new
-    // location so it can read matched blocks from the backup copy.
+    // When a backup RENAME moved the basis file (non-inplace --backup) or a
+    // fuzzy basis is used, point the delta transfer at that separate location so
+    // it reads matched blocks from there while the writer builds a fresh
+    // destination. Under `--inplace --backup` the destination is instead copied
+    // aside (inode preserved) and rewritten in place, so `delta_basis_override`
+    // stays unset and the writer IS the basis.
     let delta_basis = delta_basis_override.as_deref().unwrap_or(destination);
-    // upstream: receiver.c:872-876 - when --inplace + --backup runs, upstream
-    // sets `fnamecmp = get_backup_name(fname)` (FNAMECMP_BACKUP) so matched
-    // blocks read from the backup path while the writer overwrites the
-    // (now-empty) destination. If we kept the inplace optimization in this
-    // case, matched-block bytes would never reach the writer (the writer's
-    // file is fresh after the backup rename), and the destination would end
-    // up with only literal bytes plus sparse holes.
+    // The inplace skip-optimization is unsafe whenever the writer's file is
+    // separate from the basis: a freshly created destination contains nothing to
+    // skip over, so every matched block must be copied through. Forcing
+    // non-inplace here keeps matched-block bytes flowing to the writer instead of
+    // being skipped against an empty file.
     let basis_separate_from_writer = delta_basis_override.is_some();
     let copy_result = context.copy_file_contents(
         &mut reader,

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -1323,6 +1323,67 @@ fn backup_with_inplace_mode() {
     assert_eq!(fs::read(dest_root.join("file.txt")).expect("read dest"), b"inplace new");
 }
 
+// The inode-preservation contract for `--inplace --backup`. Under --inplace the
+// destination must be rewritten in place (same inode); the backup is a COPY of
+// the pre-image, NOT a rename of the destination. Renaming the destination away
+// (the pre-fix behavior) gave the updated file a fresh inode, defeating
+// --inplace for hardlinked / mmapped / reflinked consumers. The old content is
+// LONGER than the new content so this also pins the final truncation: after an
+// in-place delta rewrite the destination must not retain trailing stale bytes.
+//
+// upstream: generator.c:1862 - copy_file(fname, backupptr, ...) copies the
+// pre-image aside while the original inode stays put for the inplace rewrite.
+#[cfg(unix)]
+#[test]
+fn backup_with_inplace_preserves_dest_inode_and_truncates() {
+    use std::os::unix::fs::MetadataExt;
+
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+
+    let source_file = ctx.source.join("file.txt");
+    fs::write(&source_file, b"short-new").expect("write source");
+
+    let dest_root = ctx.dest.join("source");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+    let existing = dest_root.join("file.txt");
+    fs::write(&existing, b"much-longer-original-content").expect("write dest");
+    let inode_before = fs::metadata(&existing).expect("stat dest").ino();
+
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .inplace(true)
+        .whole_file(false);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    // Backup holds the ORIGINAL pre-transfer bytes (copy, not the rewrite).
+    let backup = dest_root.join("file.txt~");
+    assert_eq!(
+        fs::read(&backup).expect("read backup"),
+        b"much-longer-original-content",
+        "backup must hold the original pre-image, not the rewritten content"
+    );
+    // Destination holds exactly the new content - fully truncated, no stale tail.
+    assert_eq!(
+        fs::read(&existing).expect("read dest"),
+        b"short-new",
+        "inplace rewrite must truncate the shorter new content, leaving no stale bytes"
+    );
+    // The destination inode is unchanged - the whole point of --inplace.
+    assert_eq!(
+        fs::metadata(&existing).expect("stat dest").ino(),
+        inode_before,
+        "--inplace --backup must preserve the destination inode (copy-backup, not rename)"
+    );
+}
+
 // Regression: --inplace + --no-whole-file + --backup-dir on a delta transfer
 // must copy matched blocks from the renamed-away basis. Before the fix, the
 // inplace optimization (skip reading matched blocks because writer is the

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -88,9 +88,16 @@ pub(super) fn commit_file(
         }
     }
 
-    // upstream: backup.c:make_backup() - rename existing file before overwrite
+    // upstream: backup.c:make_backup() - rename existing file before overwrite.
     // With delay_updates, backup happens during the sweep, not here.
-    let backup_notice = if !config.delay_updates {
+    //
+    // The inplace case is deliberately excluded: under --inplace the destination
+    // inode is rewritten in place, so a rename-to-backup here would move the very
+    // file we already overwrote (its pre-transfer contents are gone by commit).
+    // Upstream instead COPIES the pre-image aside BEFORE the inplace rewrite
+    // (generator.c:1862,1898); oc mirrors that in `process_file` /
+    // `process_whole_file` via `make_backup_copy` prior to the first write.
+    let backup_notice = if !config.delay_updates && !begin.is_inplace {
         if let Some(ref backup_config) = config.backup {
             make_backup(&begin.file_path, backup_config, config)?
         } else {
@@ -523,6 +530,72 @@ pub(super) fn make_backup(
     // root to match upstream test assertions (testsuite/backup.test). The
     // actual `info_log!` emission happens on the main thread; see
     // `crate::pipeline::receiver::emit_backup_notice`.
+    let file_rel = file_path
+        .strip_prefix(&backup_config.dest_dir)
+        .unwrap_or(file_path)
+        .to_path_buf();
+    let backup_rel = backup_path
+        .strip_prefix(&backup_config.dest_dir)
+        .unwrap_or(&backup_path)
+        .to_path_buf();
+    Ok(Some(BackupNotice {
+        original: file_rel,
+        backup: backup_rel,
+    }))
+}
+
+/// Copies the destination's pre-transfer contents aside to the backup path,
+/// used for the `--inplace --backup` case where the destination inode is
+/// rewritten in place rather than replaced by a temp+rename.
+///
+/// upstream: backup.c make_backup() inplace copy path - the generator makes the
+/// backup a COPY (`generator.c:1862` `copy_file(fname, backupptr, ...)`, and the
+/// delta twin at `generator.c:1898`) BEFORE the receiver rewrites the
+/// destination in place, keeping `fnamecmp_type == FNAMECMP_FNAME`. A plain
+/// rename-to-backup would move the very inode we are about to update, so the
+/// pre-image must be duplicated first. Unlike the rename path this does NOT emit
+/// the `make_backup: RENAME` debug line (upstream's inplace copy bypasses
+/// `make_backup()` and so emits no `DEBUG_GTE(BACKUP, 1)` trace), but it still
+/// returns a [`BackupNotice`] so the main thread emits the same
+/// `INFO_GTE(BACKUP, 1)` "backed up X to Y" line (`generator.c:1990-1992`).
+///
+/// Called before the first inplace write; the caller has already confirmed
+/// `begin.is_inplace`. Returns `Ok(None)` when the destination does not yet
+/// exist (nothing to back up), matching upstream's `x_lstat` guard.
+pub(super) fn make_backup_copy(
+    file_path: &Path,
+    backup_config: &BackupConfig,
+    config: &DiskCommitConfig,
+) -> io::Result<Option<BackupNotice>> {
+    if !file_path.exists() {
+        return Ok(None);
+    }
+
+    let backup_path = compute_backup_path(
+        &backup_config.dest_dir,
+        file_path,
+        None,
+        backup_config.backup_dir.as_deref(),
+        &backup_config.suffix,
+    );
+
+    if let Some(parent) = backup_path.parent() {
+        if !parent.exists() {
+            create_dir_all_sandboxed(config, parent)?;
+        }
+    }
+
+    // upstream: generator.c:1866 copy_file() - duplicate the pre-transfer bytes
+    // into the backup, leaving the original inode in place to be updated. A
+    // pre-existing backup at this path is overwritten (upstream robust_unlinks
+    // it at generator.c:1901); `fs::copy` truncates, reaching the same end
+    // state. `fs::copy` is portable across Linux/macOS/Windows.
+    fs::copy(file_path, &backup_path)?;
+
+    // upstream: generator.c:1990-1992 - INFO_GTE(BACKUP, 1) "backed up X to Y".
+    // Paths are relative to the destination root to match test assertions; the
+    // `info_log!` emission happens on the main thread (see
+    // `crate::pipeline::receiver::emit_backup_notice`).
     let file_rel = file_path
         .strip_prefix(&backup_config.dest_dir)
         .unwrap_or(file_path)

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -22,7 +22,7 @@ use crate::temp_guard::open_tmpfile_sandboxed;
 
 use super::super::config::DiskCommitConfig;
 use super::super::writer::{ReusableBufWriter, Writer};
-use super::commit::{SparseFinalize, commit_file, retain_partial_file};
+use super::commit::{SparseFinalize, commit_file, make_backup_copy, retain_partial_file};
 use super::metadata::{apply_file_metadata, finalize_checksum};
 
 /// Folds the existing on-disk prefix into the whole-file checksum for
@@ -158,6 +158,13 @@ pub(in crate::disk_commit) fn process_file(
     // permission failure to a per-file partial (IOERR_GENERAL -> RERR_PARTIAL,
     // exit 23) with the upstream sender warning, exactly like the synchronous
     // receiver (receiver/transfer/sync.rs via delta_apply::discard_delta_stream).
+    // upstream: generator.c:1862,1898 make_backup() inplace copy path - under
+    // --inplace --backup the destination inode is rewritten in place, so the
+    // backup must be a COPY of the pre-transfer contents taken BEFORE the first
+    // write (a rename would move the very inode we are about to update). The
+    // temp+rename path instead backs up at commit time (see commit_file).
+    let inplace_backup_notice = make_inplace_backup(&begin, config)?;
+
     let (file, mut cleanup_guard, needs_rename) = match open_output_file(&begin, config) {
         Ok(triple) => triple,
         Err(open_err) => {
@@ -370,7 +377,9 @@ pub(in crate::disk_commit) fn process_file(
                     metadata_error,
                     computed_checksum,
                     delayed_path: outcome.delayed_path,
-                    backup_notice: outcome.backup_notice,
+                    // Inplace copy-backup (taken before the write) or the
+                    // temp+rename backup (taken at commit); never both.
+                    backup_notice: outcome.backup_notice.or(inplace_backup_notice),
                 });
             }
             FileMessage::Abort { reason } => {
@@ -441,6 +450,10 @@ pub(in crate::disk_commit) fn process_whole_file(
     // there are no queued channel messages to drain (unlike process_file); the
     // open error surfaces directly and drain_all_results maps a permission
     // failure to RERR_PARTIAL (exit 23).
+    // upstream: generator.c:1862,1898 - copy the pre-transfer contents aside
+    // before rewriting the destination in place (see process_file).
+    let inplace_backup_notice = make_inplace_backup(&begin, config)?;
+
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
     if needs_rename {
         CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
@@ -547,7 +560,9 @@ pub(in crate::disk_commit) fn process_whole_file(
         metadata_error,
         computed_checksum,
         delayed_path: outcome.delayed_path,
-        backup_notice: outcome.backup_notice,
+        // Inplace copy-backup (before the write) or temp+rename backup (at
+        // commit); never both.
+        backup_notice: outcome.backup_notice.or(inplace_backup_notice),
     })
 }
 
@@ -607,6 +622,33 @@ fn discard_file_on_open_failure(
             }
         }
     }
+}
+
+/// Makes the `--inplace --backup` pre-image copy when required.
+///
+/// Under `--inplace` the destination is rewritten in place (same inode), so the
+/// backup cannot be a rename of the destination - it must be a COPY of the
+/// pre-transfer contents taken before the first write. Upstream does this in the
+/// generator (`generator.c:1862,1898` `copy_file(fname, backupptr, ...)`) while
+/// keeping `fnamecmp_type == FNAMECMP_FNAME`. Because oc refuses
+/// `--inplace --partial-dir` (config validation), an inplace basis is always the
+/// destination itself, so `begin.is_inplace` here matches upstream's
+/// `inplace && fnamecmp_type == FNAMECMP_FNAME` condition exactly.
+///
+/// Returns `Ok(None)` (no backup) unless the target is inplace, backup is
+/// configured, and `--delay-updates` is off (which stages its own backup during
+/// the sweep). `make_backup_copy` further no-ops when the destination is absent.
+fn make_inplace_backup(
+    begin: &BeginMessage,
+    config: &DiskCommitConfig,
+) -> io::Result<Option<crate::pipeline::messages::BackupNotice>> {
+    if !begin.is_inplace || config.delay_updates {
+        return Ok(None);
+    }
+    let Some(ref backup_config) = config.backup else {
+        return Ok(None);
+    };
+    make_backup_copy(&begin.file_path, backup_config, config)
 }
 
 /// Opens the output file using device write, inplace, or temp+rename strategy.

--- a/crates/transfer/src/disk_commit/process/mod.rs
+++ b/crates/transfer/src/disk_commit/process/mod.rs
@@ -31,7 +31,9 @@ pub(super) use self::file_ops::{process_file, process_whole_file};
 #[cfg(all(test, unix))]
 use self::commit::rename_config_sandboxed;
 #[cfg(test)]
-use self::commit::{is_cross_device, make_backup, partial_dir_path, rename_with_io_uring_fallback};
+use self::commit::{
+    is_cross_device, make_backup, make_backup_copy, partial_dir_path, rename_with_io_uring_fallback,
+};
 #[cfg(all(test, target_os = "macos"))]
 use self::file_ops::make_writer;
 #[cfg(test)]

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -375,6 +375,76 @@ fn make_backup_missing_file_is_noop() {
     assert!(notice.is_none(), "no notice when nothing was backed up");
 }
 
+/// Verifies `make_backup_copy` (the `--inplace --backup` path) DUPLICATES the
+/// original to the backup and LEAVES the original in place, unlike `make_backup`
+/// which renames it away. Preserving the original is the whole point: under
+/// `--inplace` that file is the destination inode about to be rewritten in
+/// place, so it must survive the backup step.
+///
+/// upstream: generator.c:1862 - `copy_file(fname, backupptr, ...)` copies the
+/// pre-image aside while the destination stays put for the inplace rewrite.
+#[test]
+fn make_backup_copy_duplicates_and_keeps_original() {
+    use std::ffi::OsString;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("payload.bin");
+    fs::write(&file_path, b"original bytes").unwrap();
+
+    let config = BackupConfig {
+        dest_dir: dir.path().to_path_buf(),
+        backup_dir: None,
+        suffix: OsString::from("~"),
+    };
+    let notice = make_backup_copy(&file_path, &config, &DiskCommitConfig::default())
+        .expect("make_backup_copy succeeds")
+        .expect("notice produced when an existing file is copied");
+
+    let backup_path = file_path.with_extension("bin~");
+    assert!(backup_path.exists(), "backup copy must exist");
+    assert!(
+        file_path.exists(),
+        "original must REMAIN in place for the inplace rewrite (copy, not rename)"
+    );
+    assert_eq!(
+        fs::read(&backup_path).unwrap(),
+        b"original bytes",
+        "backup must hold the original pre-transfer bytes"
+    );
+    assert_eq!(
+        fs::read(&file_path).unwrap(),
+        b"original bytes",
+        "original content is untouched by the copy step"
+    );
+
+    assert_eq!(notice.original, PathBuf::from("payload.bin"));
+    assert_eq!(notice.backup, PathBuf::from("payload.bin~"));
+}
+
+/// Verifies `make_backup_copy` no-ops (returns `None`, writes nothing) when the
+/// destination does not yet exist, mirroring upstream's `x_lstat` guard: a
+/// first-time inplace create has no pre-image to preserve.
+#[test]
+fn make_backup_copy_missing_file_is_noop() {
+    use std::ffi::OsString;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("absent.bin");
+
+    let config = BackupConfig {
+        dest_dir: dir.path().to_path_buf(),
+        backup_dir: None,
+        suffix: OsString::from("~"),
+    };
+    let notice = make_backup_copy(&file_path, &config, &DiskCommitConfig::default())
+        .expect("make_backup_copy succeeds");
+    assert!(notice.is_none(), "no notice when nothing was backed up");
+    assert!(
+        !file_path.with_extension("bin~").exists(),
+        "no backup file created when the destination is absent"
+    );
+}
+
 /// #507 (TOCTOU regression): the dirfd anchor on the commit rename refuses to
 /// land the final file through a destination parent that was swapped for a
 /// symlink pointing outside the tree.

--- a/crates/transfer/tests/uts_inplace_backup.rs
+++ b/crates/transfer/tests/uts_inplace_backup.rs
@@ -1,0 +1,281 @@
+//! `--inplace --backup` must COPY the original aside, not rename it.
+//!
+//! # Background
+//!
+//! Normally `--backup` renames the existing destination to its backup name and
+//! a fresh temp file becomes the new destination (a new inode). Under
+//! `--inplace` the destination is rewritten in place - same inode, no
+//! temp+rename - so a plain rename-to-backup would move the very file rsync is
+//! about to overwrite. Upstream instead makes the backup a COPY of the
+//! pre-transfer contents BEFORE the inplace rewrite, leaving the original inode
+//! in place to be updated.
+//!
+//! Upstream condition (both from `generator.c`):
+//!   `inplace && make_backups > 0 && fnamecmp_type == FNAMECMP_FNAME`
+//! -> `copy_file(fname, backupptr, ...)` (`generator.c:1862` for the
+//! whole-file/read-batch case, `generator.c:1898` for the delta case), then the
+//! `INFO_GTE(BACKUP, 1)` "backed up X to Y" line at `generator.c:1990-1992`.
+//!
+//! # Why this matters
+//!
+//! Two invariants ride on this and both silently corrupt data if broken:
+//!   1. The backup must hold the ORIGINAL pre-transfer bytes, not the rewritten
+//!      ones. If oc renamed the already-overwritten dest, the "backup" would be
+//!      a copy of the NEW content - the prior version is lost.
+//!   2. The destination inode must be PRESERVED. `--inplace` exists precisely to
+//!      update the same inode (hardlinks, mmaps, reflinks stay valid). A backup
+//!      that renames the dest away would give the updated file a new inode,
+//!      defeating `--inplace`.
+//!
+//! The control test asserts the opposite for plain `--backup` (no `--inplace`):
+//! there the dest inode SHOULD change, because temp+rename is the correct
+//! mechanism and the rename-to-backup path is what must stay in force.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+use filetime::{FileTime, set_file_mtime};
+use tempfile::TempDir;
+use test_support::{OcRsyncCliRunner, require_binary};
+
+/// Backdate `path` well before the freshly written source so rsync's
+/// quick-check (matching size + mtime) never short-circuits the transfer.
+fn backdate(path: &Path) {
+    set_file_mtime(path, FileTime::from_unix_time(946_684_800, 0)).expect("backdate mtime");
+}
+
+/// Seed `dest` with `old` content and backdate it, forcing an overwrite (and
+/// thus a backup) on the next transfer.
+fn seed_dest(dest: &Path, old: &str) {
+    fs::write(dest, old).expect("seed dest");
+    backdate(dest);
+}
+
+/// `st_ino` of `path`, for the preserve-inode assertions.
+fn inode(path: &Path) -> u64 {
+    fs::metadata(path).expect("stat").ino()
+}
+
+/// Trailing-slash form so rsync copies a directory's contents.
+fn slash(path: &Path) -> std::ffi::OsString {
+    let mut s = path.as_os_str().to_os_string();
+    s.push("/");
+    s
+}
+
+/// Delta path (`--no-whole-file`): `--inplace --backup` copies the original to
+/// `name~`, writes the new content into the SAME inode, and emits the upstream
+/// backup line.
+#[test]
+fn inplace_backup_copies_original_and_preserves_dest_inode() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root: TempDir = tempfile::tempdir().expect("tempdir");
+    let base = root.path();
+    let from = base.join("from");
+    let to = base.join("to");
+    fs::create_dir_all(&from).expect("mkdir from");
+    fs::create_dir_all(&to).expect("mkdir to");
+
+    // Different sizes so the quick-check cannot skip even if mtimes collided.
+    fs::write(from.join("name1"), "brand-new-inplace-content\n").expect("write source");
+    let dest = to.join("name1");
+    seed_dest(&dest, "old\n");
+    let ino_before = inode(&dest);
+
+    let out = OcRsyncCliRunner::new()
+        .args([
+            "-ai",
+            "--info=backup",
+            "--no-whole-file",
+            "--inplace",
+            "--backup",
+        ])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    // (a) backup holds the ORIGINAL pre-transfer bytes.
+    assert_eq!(
+        fs::read_to_string(to.join("name1~")).unwrap(),
+        "old\n",
+        "backup must contain the original pre-transfer content, not the rewrite"
+    );
+    // (b) dest holds the NEW content.
+    assert_eq!(
+        fs::read_to_string(&dest).unwrap(),
+        "brand-new-inplace-content\n",
+        "destination must hold the new content"
+    );
+    // (c) dest inode is UNCHANGED - the whole point of --inplace.
+    assert_eq!(
+        inode(&dest),
+        ino_before,
+        "--inplace must preserve the destination inode (copy-backup, not rename)"
+    );
+    assert!(
+        out.stdout_contains("backed up name1 to name1~"),
+        "missing upstream inplace-backup message; stdout was:\n{}",
+        out.stdout_str()
+    );
+}
+
+/// Whole-file path (`--whole-file`): the copy-before-write branch in
+/// `process_whole_file` must equally preserve the inode and back up the
+/// original.
+#[test]
+fn inplace_whole_file_backup_preserves_dest_inode() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root: TempDir = tempfile::tempdir().expect("tempdir");
+    let base = root.path();
+    let from = base.join("from");
+    let to = base.join("to");
+    fs::create_dir_all(&from).expect("mkdir from");
+    fs::create_dir_all(&to).expect("mkdir to");
+
+    fs::write(from.join("name1"), "whole-file-new\n").expect("write source");
+    let dest = to.join("name1");
+    seed_dest(&dest, "whole-file-old-longer\n");
+    let ino_before = inode(&dest);
+
+    let out = OcRsyncCliRunner::new()
+        .args([
+            "-ai",
+            "--info=backup",
+            "--whole-file",
+            "--inplace",
+            "--backup",
+        ])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    assert_eq!(
+        fs::read_to_string(to.join("name1~")).unwrap(),
+        "whole-file-old-longer\n",
+        "whole-file inplace backup must hold the original content"
+    );
+    assert_eq!(
+        fs::read_to_string(&dest).unwrap(),
+        "whole-file-new\n",
+        "destination must hold the new content"
+    );
+    assert_eq!(
+        inode(&dest),
+        ino_before,
+        "--inplace --whole-file must preserve the destination inode"
+    );
+    assert!(
+        out.stdout_contains("backed up name1 to name1~"),
+        "missing inplace whole-file backup message; stdout was:\n{}",
+        out.stdout_str()
+    );
+}
+
+/// `--inplace --backup --backup-dir=DIR`: the pre-image copy lands under the
+/// backup dir at the same relative path (no `~`), and the dest inode is still
+/// preserved.
+#[test]
+fn inplace_backup_dir_relocates_copy_and_preserves_inode() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root: TempDir = tempfile::tempdir().expect("tempdir");
+    let base = root.path();
+    let from = base.join("from");
+    let to = base.join("to");
+    let bak = base.join("bak");
+    fs::create_dir_all(&from).expect("mkdir from");
+    fs::create_dir_all(&to).expect("mkdir to");
+
+    fs::write(from.join("name1"), "dir-new-content\n").expect("write source");
+    let dest = to.join("name1");
+    seed_dest(&dest, "dir-old\n");
+    let ino_before = inode(&dest);
+
+    let mut backup_dir_arg = std::ffi::OsString::from("--backup-dir=");
+    backup_dir_arg.push(&bak);
+    let out = OcRsyncCliRunner::new()
+        .args([
+            std::ffi::OsString::from("-ai"),
+            std::ffi::OsString::from("--info=backup"),
+            std::ffi::OsString::from("--no-whole-file"),
+            std::ffi::OsString::from("--inplace"),
+            std::ffi::OsString::from("--backup"),
+            backup_dir_arg,
+        ])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    assert_eq!(
+        fs::read_to_string(bak.join("name1")).unwrap(),
+        "dir-old\n",
+        "backup-dir copy must hold the original content at the relative path"
+    );
+    assert!(
+        !to.join("name1~").exists(),
+        "backup-dir mode must not also create an in-place ~ backup"
+    );
+    assert_eq!(fs::read_to_string(&dest).unwrap(), "dir-new-content\n");
+    assert_eq!(
+        inode(&dest),
+        ino_before,
+        "--inplace --backup-dir must preserve the destination inode"
+    );
+}
+
+/// Control: plain `--backup` WITHOUT `--inplace` still renames via temp+rename,
+/// so the destination gets a NEW inode. This pins the contrast - the copy-aside
+/// behaviour is specific to `--inplace` and must not leak into the default path.
+#[test]
+fn backup_without_inplace_changes_dest_inode() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root: TempDir = tempfile::tempdir().expect("tempdir");
+    let base = root.path();
+    let from = base.join("from");
+    let to = base.join("to");
+    fs::create_dir_all(&from).expect("mkdir from");
+    fs::create_dir_all(&to).expect("mkdir to");
+
+    fs::write(from.join("name1"), "replaced-content\n").expect("write source");
+    let dest = to.join("name1");
+    seed_dest(&dest, "original\n");
+    let ino_before = inode(&dest);
+
+    let out = OcRsyncCliRunner::new()
+        .args(["-ai", "--info=backup", "--no-whole-file", "--backup"])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    // Backup holds the original, dest holds the new content - same end state.
+    assert_eq!(
+        fs::read_to_string(to.join("name1~")).unwrap(),
+        "original\n",
+        "non-inplace backup must still hold the original content"
+    );
+    assert_eq!(fs::read_to_string(&dest).unwrap(), "replaced-content\n");
+    // But the inode changes: temp+rename installs a fresh inode over the dest.
+    assert_ne!(
+        inode(&dest),
+        ino_before,
+        "non-inplace --backup uses temp+rename, so the dest inode must change"
+    );
+}


### PR DESCRIPTION
# Copy to backup under `--inplace` to preserve the destination inode

## Problem

With `--backup` alone, rsync renames the existing destination to its backup name and installs a fresh file at the destination (a new inode). Under `--inplace`, however, the destination is rewritten in place - same inode, no temp+rename - so hardlinked, mmapped, and reflinked consumers keep seeing the updated file. Combining the two, the backup step was renaming the destination away, which:

1. gave the "in-place" update a brand-new inode, silently defeating `--inplace`; and
2. on a shrinking update, could leave stale trailing bytes because the truncation path only runs for a genuine in-place rewrite.

Backup content was correct, so the regression was invisible to content-only checks, but the inode contract was broken on both the local-copy path and the wire (daemon/SSH) receive path.

## Upstream behavior (source of truth)

Upstream never renames the destination when `--inplace` is active. It makes the backup a **copy** of the pre-transfer contents *before* the in-place rewrite, leaving the original inode in place to be updated:

- `generator.c:1862` (whole-file / read-batch case) and `generator.c:1898` (delta case): the gate is
  `inplace && make_backups > 0 && fnamecmp_type == FNAMECMP_FNAME`, under which the code calls
  `copy_file(fname, backupptr, ...)` rather than `make_backup()`.
- The rename path (`make_backup(fname, prefer_rename)`, `backup.c:226` -> `link_or_rename`) is used only when `--inplace` is off.
- Because the inplace copy bypasses `make_backup()`, it emits no `DEBUG_GTE(BACKUP, 1)` trace, but it still emits the `INFO_GTE(BACKUP, 1)` line `backed up %s to %s` (`generator.c:1990-1992`), identical to the rename path's `backup.c:353`.

**Exact copy-vs-rename condition:** copy (not rename) precisely when `inplace` is enabled and the basis is the destination file itself (`fnamecmp_type == FNAMECMP_FNAME`). Since both endpoints refuse `--inplace` together with `--partial-dir`, an in-place basis is always the destination, so the condition reduces to "inplace update of an existing regular file".

## Fix

Mirror the upstream copy-vs-rename split on both receive paths.

### Local-copy executor (`crates/engine`)

- New `CopyContext::backup_existing_entry_copy` duplicates the pre-image with `fs::copy` (reapplying the source node's mode/owner/times, and the fake-super `%stat` xattr), emits the `backed up X to Y` info line, and emits no backup debug trace - matching the generator's inplace copy path.
- `execute_transfer` now calls the copy variant for an inplace regular-file update and, crucially, does **not** redirect the delta basis to the backup in that case. The destination stays put as the true in-place basis, so the existing (proven) in-place writer rewrites the same inode and truncates to the final length. The rename path and its `FNAMECMP_BACKUP` basis redirect are unchanged for non-inplace `--backup`.

### Wire receive path (`crates/transfer`)

- New `make_backup_copy` in the disk-commit thread copies the pre-image to the backup path before the first in-place write (parent-dir creation is sandbox-anchored exactly like the rename path), returning the same `BackupNotice` so the main thread emits the `backed up` line.
- `process_file` / `process_whole_file` take that copy before opening the destination for the in-place write; `commit_file` now skips the rename-to-backup whenever the target is in-place (it would otherwise move the very inode being updated). Temp+rename backups are untouched.

Portable throughout (`std::fs::copy`); no unsafe added to `transfer`.

## Verification

Validated end-to-end against the built binary, both paths, including a shrinking update (new content shorter than old) to exercise truncation:

- Local `--inplace --backup` (delta, whole-file, and `--backup-dir`): destination holds the new content, the backup holds the original, and the destination inode is unchanged.
- Daemon `rsync://` push `--inplace --backup` (shrinking file): destination new, backup original, inode preserved.
- Control `--backup` without `--inplace`: inode changes (temp+rename), behavior unchanged.

Tests added:

- `crates/transfer/tests/uts_inplace_backup.rs` - four end-to-end cases (delta, whole-file, backup-dir, and the non-inplace control) asserting backup=original, dest=new, and `#[cfg(unix)]` inode identity (preserved for inplace, changed for the control).
- `crates/transfer` unit tests: `make_backup_copy` duplicates and keeps the original; no-op when the destination is absent.
- `crates/engine` unit test: `--inplace --backup` preserves the destination inode and truncates a shrinking rewrite.

Existing `backup_with_inplace_mode`, the `--inplace --backup-dir` matched-blocks regression test, the inode tests, and the backup debug-emission tests all still pass. `cargo fmt --all`, full-workspace `cargo clippy --all-targets --all-features --no-deps -D warnings` clean.
