### PR TITLE
feat(transfer): dedup received file list (flist_sort_and_clean pass)

### DIFF
--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -146,6 +146,72 @@ impl DualFileList {
         super::sort::apply_permutation_in_place(&mut self.legacy, parallel, indices);
     }
 
+    /// Removes duplicate-name entries in-place after sorting, keeping the
+    /// upstream survivor, and applies the same removals to `parallel` in
+    /// lockstep so a caller-owned array (the generator's `source_bases`) stays
+    /// aligned with the cleaned list.
+    ///
+    /// This is the sender-side half of upstream's `flist_sort_and_clean`: the
+    /// sender dedups before transmitting so the receiver's identical pass is
+    /// idempotent and both sides keep matching NDX numbering. The list MUST
+    /// already be sorted (call [`sort_with_parallel`](Self::sort_with_parallel)
+    /// first) - dedup only collapses adjacent equal names. On a list with no
+    /// duplicates this changes neither order nor length.
+    ///
+    /// Reuses [`resolve_duplicate`](super::sort::resolve_duplicate) so the
+    /// keep/drop tie-break is identical to the receiver's [`flist_clean`]. oc
+    /// converges both sides to the same sorted+cleaned list, so it drops
+    /// duplicates symmetrically rather than following upstream's `am_sender`
+    /// branch (mark a dup dir `FLAG_DUPLICATE` and keep it for the in-place
+    /// `dir_flist` tree at `flist.c:3067`); oc has no such tree, and keeping the
+    /// dup only on the sender would desync the NDX count.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds when `parallel.len() != self.len()`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2544` - `flist_sort_and_clean(flist, 0)` runs in
+    ///   `send_file_list()`; the sender passes `strip_root = 0`.
+    /// - `flist.c:3046-3082` - the duplicate-removal tie-break this mirrors.
+    pub fn dedup_with_parallel<P>(&mut self, parallel: &mut Vec<P>) -> super::sort::CleanResult {
+        let len = self.legacy.len();
+        let mut stats = super::sort::CleanResult::default();
+        if len == 0 {
+            return stats;
+        }
+        debug_assert_eq!(parallel.len(), len);
+
+        // Write cursor `w` marks the last kept entry; read cursor `r` scans
+        // ahead. Adjacent equal names collapse; the survivor's parallel base
+        // travels with it.
+        let mut w: usize = 0;
+        let mut r: usize = 1;
+        while r < len {
+            if self.legacy[w].name() != self.legacy[r].name() {
+                w += 1;
+                if w != r {
+                    self.legacy.swap(w, r);
+                    parallel.swap(w, r);
+                }
+                r += 1;
+                continue;
+            }
+
+            let (left, right) = self.legacy.split_at_mut(r);
+            if super::sort::resolve_duplicate(&mut left[w], &right[0], &mut stats) {
+                self.legacy.swap(w, r);
+                parallel.swap(w, r);
+            }
+            r += 1;
+        }
+
+        self.legacy.truncate(w + 1);
+        parallel.truncate(w + 1);
+        stats
+    }
+
     /// Reclaims heap data from entries in the range `[start..end)`.
     ///
     /// Calls [`FileEntry::reclaim_heap_data`] on each entry in the range,
@@ -379,6 +445,74 @@ mod tests {
 
         // List length is unchanged (entries stay in place).
         assert_eq!(list.len(), 5);
+    }
+
+    #[test]
+    fn dedup_with_parallel_noop_on_distinct_names() {
+        // WHY: the sender dedup must not shift order or count for a normal
+        // (duplicate-free) list, or sender/receiver NDX numbering desyncs.
+        let mut list = DualFileList::new();
+        for n in ["a.txt", "b.txt", "c.txt"] {
+            list.push(FileEntry::new_file(n.into(), 0, 0o644));
+        }
+        let mut bases = vec!["ba", "bb", "bc"];
+        let stats = list.dedup_with_parallel(&mut bases);
+        assert_eq!(stats.duplicates_removed, 0);
+        let names: Vec<&str> = list.iter().map(|e| e.name()).collect();
+        assert_eq!(names, ["a.txt", "b.txt", "c.txt"]);
+        assert_eq!(bases, ["ba", "bb", "bc"]);
+    }
+
+    #[test]
+    fn dedup_with_parallel_removes_dup_and_keeps_base_aligned() {
+        // WHY: when a duplicate is dropped, the survivor's parallel source_base
+        // must travel with it so file_list[i] still maps to source_bases[i].
+        let mut list = DualFileList::new();
+        list.push(FileEntry::new_file("dup".into(), 0, 0o644));
+        list.push(FileEntry::new_file("dup".into(), 0, 0o644));
+        list.push(FileEntry::new_file("z".into(), 0, 0o644));
+        let mut bases = vec!["first", "second", "zbase"];
+        let stats = list.dedup_with_parallel(&mut bases);
+        assert_eq!(stats.duplicates_removed, 1);
+        let names: Vec<&str> = list.iter().map(|e| e.name()).collect();
+        assert_eq!(names, ["dup", "z"]);
+        // The first "dup" survives (keep-first), so its base leads; z stays put.
+        assert_eq!(bases, ["first", "zbase"]);
+    }
+
+    #[test]
+    fn dedup_with_parallel_keeps_directory_over_file() {
+        // WHY: a dir must win over a same-named file "because it might have
+        // contents in the list" (flist.c:3060); its base must travel with it.
+        let mut list = DualFileList::new();
+        list.push(FileEntry::new_file("item".into(), 0, 0o644));
+        list.push(FileEntry::new_directory("item".into(), 0o755));
+        let mut bases = vec!["file_base", "dir_base"];
+        let stats = list.dedup_with_parallel(&mut bases);
+        assert_eq!(stats.duplicates_removed, 1);
+        assert_eq!(list.len(), 1);
+        assert!(list[0].is_dir());
+        assert_eq!(bases, ["dir_base"]);
+    }
+
+    #[test]
+    fn sender_dedup_makes_receiver_pass_idempotent() {
+        // WHY: the whole point of the sender-side dedup is that the receiver's
+        // identical flist_clean then removes NOTHING, so both sides keep the
+        // same entry count and NDX numbering (no RERR_PROTOCOL desync).
+        let mut list = DualFileList::new();
+        list.push(FileEntry::new_file("a".into(), 0, 0o644));
+        list.push(FileEntry::new_file("dup".into(), 0, 0o644));
+        list.push(FileEntry::new_file("dup".into(), 0, 0o644));
+        let mut bases = vec!["a", "d1", "d2"];
+        list.dedup_with_parallel(&mut bases);
+        let transmitted = list.into_vec();
+        // Receiver runs the same clean over the (already-deduped) transmitted list.
+        let (_receiver_list, stats) = crate::flist::sort::flist_clean(transmitted.clone());
+        assert_eq!(
+            stats.duplicates_removed, 0,
+            "receiver must remove nothing from a sender-deduped list"
+        );
     }
 
     #[test]

--- a/crates/protocol/src/flist/sort.rs
+++ b/crates/protocol/src/flist/sort.rs
@@ -287,6 +287,45 @@ pub struct CleanResult {
     pub flags_merged: usize,
 }
 
+/// Resolves a duplicate-name pair during a file-list clean, single-sourcing the
+/// upstream tie-break for both the receiver's [`flist_clean`] and the sender's
+/// [`super::dual::DualFileList::dedup_with_parallel`].
+///
+/// `write` is the currently-kept entry, `read` the later duplicate. Returns
+/// `true` when the caller must replace `write` with `read` (take the read
+/// entry), `false` to keep `write`. Updates `stats` for the removed duplicate
+/// and any merged directory flag.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:3050-3082` - "If one is a dir and the other is not, we want to
+///   keep the dir because it might have contents in the list. Otherwise keep
+///   the first one." When both are dirs, upstream merges the vital flags into
+///   the survivor (`fp->flags |= file->flags & (FLAG_TOP_DIR|FLAG_CONTENT_DIR)`).
+pub(super) fn resolve_duplicate(
+    write: &mut FileEntry,
+    read: &FileEntry,
+    stats: &mut CleanResult,
+) -> bool {
+    stats.duplicates_removed += 1;
+    match (write.is_dir(), read.is_dir()) {
+        // Keep the directory (read) over the plain file (write).
+        (false, true) => true,
+        // Keep the directory (write) over the plain file (read).
+        (true, false) => false,
+        // Both directories - keep the first, merge the content-dir flag.
+        (true, true) => {
+            if read.content_dir() {
+                write.set_content_dir(true);
+            }
+            stats.flags_merged += 1;
+            false
+        }
+        // Both plain entries - keep the first.
+        (false, false) => false,
+    }
+}
+
 /// Cleans a sorted file list in-place by removing duplicates and merging directory flags.
 ///
 /// This mirrors upstream's `clean_flist()` which operates in-place with zero allocation,
@@ -337,33 +376,12 @@ pub fn flist_clean(mut file_list: Vec<FileEntry>) -> (Vec<FileEntry>, CleanResul
             continue;
         }
 
-        // Duplicate found - decide which to keep at position `w`
-        let w_is_dir = file_list[w].is_dir();
-        let r_is_dir = file_list[r].is_dir();
-
-        match (w_is_dir, r_is_dir) {
-            (false, true) => {
-                // Keep the directory (at r), replace current write position
-                file_list.swap(w, r);
-                stats.duplicates_removed += 1;
-            }
-            (true, false) => {
-                // Keep current (directory at w), drop r
-                stats.duplicates_removed += 1;
-            }
-            (true, true) => {
-                // Both directories - merge flags into w
-                // upstream: flist.c merges FLAG_TOP_DIR, FLAG_CONTENT_DIR
-                if file_list[r].content_dir() {
-                    file_list[w].set_content_dir(true);
-                }
-                stats.duplicates_removed += 1;
-                stats.flags_merged += 1;
-            }
-            (false, false) => {
-                // Both files - keep first (at w)
-                stats.duplicates_removed += 1;
-            }
+        // Duplicate found - decide which entry survives at position `w`.
+        // Split the borrow so the write entry is `&mut` and the read entry
+        // `&` simultaneously; a `true` verdict means take the read entry.
+        let (left, right) = file_list.split_at_mut(r);
+        if resolve_duplicate(&mut left[w], &right[0], &mut stats) {
+            file_list.swap(w, r);
         }
 
         r += 1;

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -140,6 +140,22 @@ impl GeneratorContext {
                 .sort_with_parallel(&mut self.source_bases, self.config.qsort);
         }
 
+        // upstream: flist.c:2544 flist_sort_and_clean(flist, 0) in send_file_list
+        // - the sender sorts+cleans its built list so its post-clean NDX matches
+        // the receiver's flist.c:2771 pass. We dedup the transmitted list here so
+        // the receiver's identical pass is idempotent and both sides keep the
+        // same NDX numbering. A list with no duplicate names is unchanged
+        // (neither order nor length), so this is a no-op for normal transfers.
+        //
+        // oc converges BOTH sides to the same sorted+cleaned list (wire order =
+        // sorted order), so it drops duplicates symmetrically. Upstream's
+        // am_sender branch instead marks a duplicate dir FLAG_DUPLICATE and keeps
+        // it for its in-place dir_flist tree (flist.c:3067); oc has no such tree,
+        // and keeping the dup only on the sender would desync the NDX count, so a
+        // symmetric drop is the correct mirror for oc's model. INC_RECURSE
+        // (recursive + --relative overlap) stays dest-correct under this pass.
+        self.file_list.dedup_with_parallel(&mut self.source_bases);
+
         // upstream: hlink.c:match_hard_links() - must be called after sort
         #[cfg(unix)]
         if self.config.flags.hard_links {
@@ -369,6 +385,15 @@ impl GeneratorContext {
             self.file_list
                 .sort_with_parallel(&mut self.source_bases, self.config.qsort);
         }
+
+        // upstream: flist.c:2544 flist_sort_and_clean(flist, 0) in send_file_list
+        // - dedup the built list before transmit so the receiver's pass is
+        // idempotent and NDX numbering stays in sync. This is the --files-from
+        // build path where a redundant list entry can produce a duplicate name;
+        // deduping here (keep-first, matching the receiver for the non-dir case)
+        // is what fixed the remote files-from RERR_PROTOCOL. No-op when there are
+        // no duplicate names.
+        self.file_list.dedup_with_parallel(&mut self.source_bases);
 
         // upstream: hlink.c:match_hard_links() - must be called after sort
         #[cfg(unix)]

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -10,7 +10,9 @@ use std::io::{self, Read};
 use logging::debug_log;
 use protocol::CompatibilityFlags;
 use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, create_ndx_codec};
-use protocol::flist::{FileEntry, IncrementalFileListBuilder, sort_file_list};
+use protocol::flist::{
+    FileEntry, IncrementalFileListBuilder, sort_and_clean_file_list, sort_file_list,
+};
 
 use super::super::ReceiverContext;
 use super::hardlinks::{match_hard_links, normalize_pre30_hardlinks};
@@ -128,13 +130,36 @@ impl ReceiverContext {
         // upstream: flist.c:2496-2498 - "both sides keep an unsorted
         // file-list array because the names will differ on the sending and
         // receiving sides".
+        // upstream: flist.c:3016 flist_sort_and_clean() runs sort THEN the
+        // duplicate-clean pass (flist.c:3046-3082) on the receiver (am_sender
+        // is false). A sender that emits the same normalized name twice
+        // (redundant or hostile) must collapse to a single entry, keeping the
+        // upstream survivor: a directory over a plain file of the same name
+        // "because it might have contents in the list" (flist.c:3060), else the
+        // first entry. We reuse the shared sort+dedup primitive so both sides
+        // clean identically. `_clean` stats mirror the DEBUG_GTE(DUP) trace and
+        // are not surfaced elsewhere.
+        //
+        // When `--iconv` is in effect, upstream sets `need_unsorted_flist = 1`
+        // (options.c:2056) so the receiver's NDX-addressed `flist->files[]`
+        // array stays in sender scan order; only a separate `flist->sorted[]`
+        // pointer array is reordered and dedup-cleared. We do not maintain a
+        // parallel pointer array, so we mirror upstream by skipping the in-place
+        // reorder+dedup when an active (non-identity) iconv converter is
+        // configured. This keeps `self.file_list` in wire (NDX) order so
+        // subsequent generator requests resolve to the entry the sender meant.
+        // upstream: flist.c:2496-2498 - "both sides keep an unsorted file-list
+        // array because the names will differ on the sending and receiving
+        // sides".
         let pre29 = self.protocol.as_u8() < 29;
         if !self.iconv_reorder_suppressed() {
-            sort_file_list(&mut self.file_list, self.config.qsort, pre29);
+            let list = std::mem::take(&mut self.file_list);
+            let (cleaned, _clean) = sort_and_clean_file_list(list, self.config.qsort, pre29);
+            self.file_list = cleaned;
         }
 
         // upstream: flist.c:3121-3184 - flist_sort_and_clean() runs the
-        // `--prune-empty-dirs` pass after sorting and before the caller's
+        // `--prune-empty-dirs` pass after sorting and dedup, before the caller's
         // match_hard_links() in recv_file_list(). Only the receiver runs this
         // pass (am_sender is false); the sender ships every directory.
         if self.config.flags.prune_empty_dirs {

--- a/crates/transfer/src/receiver/tests/file_list/dedup.rs
+++ b/crates/transfer/src/receiver/tests/file_list/dedup.rs
@@ -1,0 +1,109 @@
+//! Receiver-side duplicate-clean pass coverage.
+//!
+//! Upstream `flist.c:flist_sort_and_clean()` runs three steps after the
+//! receiver decodes the file list: sort, remove duplicate names (keeping the
+//! upstream-correct survivor), then prune empty dirs. These tests pin the
+//! second step - a sender that emits the same normalized name twice (redundant
+//! or hostile) must not leave a duplicate in `self.file_list`.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:3016 flist_sort_and_clean()` - the combined sort+dedup+prune pass
+//!   run by `recv_file_list()` at `flist.c:2771`.
+
+use std::io::Cursor;
+
+use protocol::flist::{FileEntry, FileListWriter};
+
+use super::super::super::ReceiverContext;
+use super::super::support::{test_config, test_handshake};
+
+/// Encode a list of entries into a wire buffer terminated by the end marker.
+fn encode(protocol: protocol::ProtocolVersion, entries: &[FileEntry]) -> Vec<u8> {
+    let mut data = Vec::new();
+    let mut writer = FileListWriter::new(protocol);
+    for entry in entries {
+        writer.write_entry(&mut data, entry).unwrap();
+    }
+    writer.write_end(&mut data, None).unwrap();
+    data
+}
+
+/// A file name emitted twice by the sender must collapse to a single entry.
+///
+/// WHY: upstream removes the duplicate (`clear_file` on the dropped index)
+/// inside `flist_sort_and_clean` before the transfer runs. Leaving both would
+/// make the generator request the same path twice - a wire/NDX divergence and
+/// wasted work driven by untrusted sender bytes.
+#[test]
+fn receiver_removes_duplicate_file_name() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let entries = [
+        FileEntry::new_file("dup.txt".into(), 100, 0o644),
+        FileEntry::new_file("dup.txt".into(), 100, 0o644),
+        FileEntry::new_file("b.txt".into(), 50, 0o644),
+    ];
+    let data = encode(handshake.protocol, &entries);
+
+    let mut cursor = Cursor::new(&data[..]);
+    ctx.receive_file_list(&mut cursor).unwrap();
+
+    let names: Vec<_> = ctx.file_list().iter().map(|e| e.name()).collect();
+    assert_eq!(names, vec!["b.txt", "dup.txt"]);
+}
+
+/// Legitimately distinct names must all survive - no over-dedup.
+///
+/// WHY: the dedup key is the full normalized name; distinct paths that merely
+/// share a prefix (or a basename in different dirs) are not duplicates and must
+/// all reach the generator.
+#[test]
+fn receiver_keeps_distinct_names() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let entries = [
+        FileEntry::new_directory("d".into(), 0o755),
+        FileEntry::new_file("d/x.txt".into(), 1, 0o644),
+        FileEntry::new_file("dx.txt".into(), 1, 0o644),
+        FileEntry::new_file("a.txt".into(), 1, 0o644),
+    ];
+    let data = encode(handshake.protocol, &entries);
+
+    let mut cursor = Cursor::new(&data[..]);
+    ctx.receive_file_list(&mut cursor).unwrap();
+
+    let names: Vec<_> = ctx.file_list().iter().map(|e| e.name()).collect();
+    assert_eq!(names, vec!["a.txt", "dx.txt", "d", "d/x.txt"]);
+}
+
+/// When a file and a directory share a name, upstream keeps the directory.
+///
+/// WHY: `flist_sort_and_clean` keeps the dir "because it might have contents in
+/// the list" (`flist.c:3060`). Dropping the dir in favour of the plain file
+/// would orphan its children.
+#[test]
+fn receiver_keeps_directory_over_file_duplicate() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let entries = [
+        FileEntry::new_file("item".into(), 10, 0o644),
+        FileEntry::new_directory("item".into(), 0o755),
+    ];
+    let data = encode(handshake.protocol, &entries);
+
+    let mut cursor = Cursor::new(&data[..]);
+    ctx.receive_file_list(&mut cursor).unwrap();
+
+    assert_eq!(ctx.file_list().len(), 1);
+    assert!(
+        ctx.file_list()[0].is_dir(),
+        "duplicate collision must keep the directory, not the plain file"
+    );
+}

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -19,6 +19,8 @@
 //!   the file-list end marker.
 //! - [`ndx_convert`] - `flat_to_wire_ndx` / `wire_to_flat_ndx` counters
 //!   and round-trip coverage.
+//! - [`dedup`] - receiver duplicate-clean pass (`flist_sort_and_clean` step 2)
+//!   that removes duplicate received names, keeping the upstream survivor.
 //! - [`delete_pipeline_hook`] - DDP-B3 hook that publishes one delete
 //!   plan per INC_RECURSE segment.
 //! - [`delete_timing`] - early vs late (`--delete-after` / `--delete-delay`)
@@ -30,6 +32,7 @@
 
 #[cfg(feature = "tokio-transfer")]
 mod async_parity;
+mod dedup;
 mod delete_pipeline_hook;
 mod delete_timing;
 mod filter_chain;

--- a/pr_body_t29.md
+++ b/pr_body_t29.md
@@ -55,6 +55,37 @@ sort-suppression rationale).
 All three drive the real `receive_file_list` decode path with crafted wire
 buffers via the existing receiver flist harness.
 
+### Sender-side dedup (NDX-sync fix)
+
+A receiver-only dedup desyncs the wire NDX: oc's sender never ran
+`flist_sort_and_clean`, so with `--files-from` a redundant list entry produced
+a duplicate name in the transmitted list that the new receiver pass then
+removed - the receiver's entry count no longer matched the sender's NDX
+numbering, and the remote leg died with `RERR_PROTOCOL` (code 16). The local
+leg was unaffected because sender and receiver share one in-memory list.
+
+Upstream runs the pass on BOTH sides (`send_file_list` at `flist.c:2544`,
+`recv_file_list` at `flist.c:2771`); the sender dedups first so the receiver's
+identical pass is idempotent. This PR mirrors that: a parallel-aware
+`DualFileList::dedup_with_parallel` runs on the sender right after the sort,
+removing duplicates while keeping the generator's `source_bases` array aligned.
+Both sides now share one tie-break helper (`resolve_duplicate`), so the sender
+and receiver converge to the same sorted+cleaned list.
+
+`am_sender` asymmetry and `strip_root`: upstream's sender marks a duplicate
+directory `FLAG_DUPLICATE` and keeps it for its in-place `dir_flist` tree
+(`flist.c:3067`); oc has no such tree and converges both sides to the same list,
+so keeping a dup dir only on the sender would itself desync the NDX count.
+oc therefore drops symmetrically - verified dest-correct for INC_RECURSE
+(recursive push/pull and `--relative` overlapping paths) over `lsh`. The dedup
+primitive does not implement `strip_root` (no leading-slash strip), so neither
+side's `strip_root` semantics change.
+
+Verified locally over `support/lsh.sh`: all four `files-from` host combinations
+(both `filehost` x `srchost`) exit 0 with `todir == chkdir`; plain and recursive
+remote push/pull match a local copy byte-for-byte (no NDX shift on
+duplicate-free lists).
+
 ### Overlap with the INC_RECURSE sub-list dedup work
 
 This closes the duplicate-clean portion of `flist_sort_and_clean` for the

--- a/pr_body_t29.md
+++ b/pr_body_t29.md
@@ -1,0 +1,67 @@
+## Receiver must run the duplicate-clean pass of `flist_sort_and_clean`
+
+Upstream `flist.c:flist_sort_and_clean()` (rsync-3.4.4, `flist.c:3016`) runs
+three steps after the receiver decodes the file list, called from
+`recv_file_list()` at `flist.c:2771`:
+
+1. **sort** (`fsort` on the sorted array),
+2. **remove duplicate names** (`flist.c:3046-3082`) - runs on the receiver
+   (`!am_sender`), and
+3. **prune empty dirs** (`flist.c:3121-3184`, only under `--prune-empty-dirs`).
+
+### The gap
+
+The receiver (`crates/transfer/src/receiver/file_list/receive.rs`) ran step 1
+(sort) and step 3 (`prune_empty_dirs_pass`) but **never ran step 2**. A sender
+that emits the same normalized name twice - redundant, or a hostile peer -
+left both entries in `self.file_list`. The generator would then request the
+same path twice: wasted work and an NDX divergence driven by untrusted bytes.
+
+A full sort+dedup primitive already existed
+(`crates/protocol/src/flist/sort.rs`: `sort_and_clean_file_list` /
+`flist_clean`, "mirrors upstream's clean_flist()"), but it was only exercised
+by unit tests - no receiver path called it.
+
+### The fix
+
+Wire the shared `sort_and_clean_file_list` primitive into the receiver in
+place of the sort-only call, preserving upstream ordering (sort -> dedup ->
+prune) and the existing `--prune-empty-dirs` and iconv-suppression behaviour.
+Both sides now clean via one primitive (DRY - upstream has one
+`flist_sort_and_clean`).
+
+### Tie-break mirrored (`flist.c:3050-3082`)
+
+- file vs file, same name: keep the **first**.
+- directory vs plain file, same name: keep the **directory** "because it might
+  have contents in the list" (`flist.c:3060`).
+- directory vs directory, same name: keep the first, merge content-dir flag.
+
+Dedup is gated on the same non-iconv condition as the sort: under `--iconv`,
+upstream keeps `flist->files[]` in scan order and only reorders/clears a
+parallel `flist->sorted[]` pointer array, which oc does not maintain, so we
+skip the in-place reorder+dedup to preserve NDX order (matching the existing
+sort-suppression rationale).
+
+### Tests (encode WHY)
+
+- `receiver_removes_duplicate_file_name` - a name emitted twice collapses to
+  one entry (RED before this change).
+- `receiver_keeps_distinct_names` - distinct names sharing a prefix/basename
+  all survive (no over-dedup).
+- `receiver_keeps_directory_over_file_duplicate` - pins the dir-over-file
+  survivor.
+
+All three drive the real `receive_file_list` decode path with crafted wire
+buffers via the existing receiver flist harness.
+
+### Overlap with the INC_RECURSE sub-list dedup work
+
+This closes the duplicate-clean portion of `flist_sort_and_clean` for the
+**initial received file list** only. The INC_RECURSE per-sub-list decode path
+(`receive_one_extra_segment`) still sorts each segment without a dedup pass;
+that, plus the sub-list path-belongs check, remains a separate concern and is
+not touched here.
+
+Upstream reference: `flist.c:3016-3082` (`flist_sort_and_clean`), receiver call
+site `flist.c:2771`.


### PR DESCRIPTION
## Receiver must run the duplicate-clean pass of `flist_sort_and_clean`

Upstream `flist.c:flist_sort_and_clean()` (rsync-3.4.4, `flist.c:3016`) runs
three steps after the receiver decodes the file list, called from
`recv_file_list()` at `flist.c:2771`:

1. **sort** (`fsort` on the sorted array),
2. **remove duplicate names** (`flist.c:3046-3082`) - runs on the receiver
   (`!am_sender`), and
3. **prune empty dirs** (`flist.c:3121-3184`, only under `--prune-empty-dirs`).

### The gap

The receiver (`crates/transfer/src/receiver/file_list/receive.rs`) ran step 1
(sort) and step 3 (`prune_empty_dirs_pass`) but **never ran step 2**. A sender
that emits the same normalized name twice - redundant, or a hostile peer -
left both entries in `self.file_list`. The generator would then request the
same path twice: wasted work and an NDX divergence driven by untrusted bytes.

A full sort+dedup primitive already existed
(`crates/protocol/src/flist/sort.rs`: `sort_and_clean_file_list` /
`flist_clean`, "mirrors upstream's clean_flist()"), but it was only exercised
by unit tests - no receiver path called it.

### The fix

Wire the shared `sort_and_clean_file_list` primitive into the receiver in
place of the sort-only call, preserving upstream ordering (sort -> dedup ->
prune) and the existing `--prune-empty-dirs` and iconv-suppression behaviour.
Both sides now clean via one primitive (DRY - upstream has one
`flist_sort_and_clean`).

### Tie-break mirrored (`flist.c:3050-3082`)

- file vs file, same name: keep the **first**.
- directory vs plain file, same name: keep the **directory** "because it might
  have contents in the list" (`flist.c:3060`).
- directory vs directory, same name: keep the first, merge content-dir flag.

Dedup is gated on the same non-iconv condition as the sort: under `--iconv`,
upstream keeps `flist->files[]` in scan order and only reorders/clears a
parallel `flist->sorted[]` pointer array, which oc does not maintain, so we
skip the in-place reorder+dedup to preserve NDX order (matching the existing
sort-suppression rationale).

### Tests (encode WHY)

- `receiver_removes_duplicate_file_name` - a name emitted twice collapses to
  one entry (RED before this change).
- `receiver_keeps_distinct_names` - distinct names sharing a prefix/basename
  all survive (no over-dedup).
- `receiver_keeps_directory_over_file_duplicate` - pins the dir-over-file
  survivor.

All three drive the real `receive_file_list` decode path with crafted wire
buffers via the existing receiver flist harness.

### Overlap with the INC_RECURSE sub-list dedup work

This closes the duplicate-clean portion of `flist_sort_and_clean` for the
**initial received file list** only. The INC_RECURSE per-sub-list decode path
(`receive_one_extra_segment`) still sorts each segment without a dedup pass;
that, plus the sub-list path-belongs check, remains a separate concern and is
not touched here.

Upstream reference: `flist.c:3016-3082` (`flist_sort_and_clean`), receiver call
site `flist.c:2771`.
