### PR TITLE
feat(transfer): dedup INC_RECURSE sub-lists + validate sub-list path-belongs

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -8,6 +8,7 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroU8;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
@@ -103,6 +104,19 @@ pub struct ReceiverContext {
     ///   "refusing malicious duplicate flist for dir %d" ...
     ///   exit_cleanup(RERR_PROTOCOL)`.
     pub(in crate::receiver) served_dir_flists: HashSet<i32>,
+    /// Full relative path of each directory in wire `dir_ndx` order, mirroring
+    /// upstream's `dir_flist->files[]` array. Built from the sorted (and, under
+    /// non-iconv, deduped) file list of the initial flist and each INC_RECURSE
+    /// sub-list, in the exact order the sender assigns `dir_ndx`: initial-list
+    /// directories (including `.`) first, then each sub-list's directories in
+    /// depth-first reception order. Indexed by the wire `dir_ndx` so a received
+    /// sub-list entry can be validated against its declared parent directory.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2685` - `f_name(dir_flist->files[dir_ndx], NULL)` names the
+    ///   parent that every entry in the sub-list must live under.
+    pub(in crate::receiver) dir_flist_names: Vec<PathBuf>,
     /// Cached file list reader for compression state continuity across sub-lists.
     ///
     /// Upstream rsync uses `static` variables in `recv_file_entry()` that persist
@@ -344,6 +358,7 @@ impl ReceiverContext {
             first_segment_idx: 0,
             dir_flist_used: 0,
             served_dir_flists: HashSet::new(),
+            dir_flist_names: Vec::new(),
             flist_reader_cache: None,
             uid_list: IdList::new(),
             gid_list: IdList::new(),

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -597,11 +597,105 @@ mod tests {
         let wire = encode_segment_with_dir_ndx(0, &[("dir0/a.txt", 3u64), ("dir0/b.txt", 4)]);
         let mut ctx = inc_recurse_receiver();
         ctx.dir_flist_used = 1;
+        ctx.dir_flist_names = vec![PathBuf::from("dir0")];
         let n = ctx
             .receive_extra_file_lists(&mut Cursor::new(wire))
             .expect("in-range dir_ndx must be accepted");
         assert_eq!(n, 2);
         assert_eq!(ctx.file_list().len(), 2);
         assert!(ctx.flist_eof);
+    }
+
+    /// A sub-list that repeats a normalized name must collapse to a single entry.
+    ///
+    /// WHY: upstream runs `flist_sort_and_clean()` on EACH INC_RECURSE sub-list
+    /// (send `flist.c:2190`, recv `flist.c:2771`), whose clean pass
+    /// (`flist.c:3031`, active for the receiver) removes duplicate names. Before
+    /// this fix `receive_one_extra_segment` sorted the sub-list but skipped the
+    /// dedup, so a redundant or hostile duplicate survived and the generator
+    /// requested the same path twice - an NDX divergence driven by untrusted
+    /// bytes, exactly the class of bug the initial-list dedup (#6631) closed. The
+    /// legitimate sender ships deduped sub-lists (partitions of an already-cleaned
+    /// list), so this pass is a no-op there and only collapses a duplicate,
+    /// keeping both sides' NDX numbering identical.
+    #[test]
+    fn sublist_duplicate_name_is_deduped() {
+        let wire = encode_segment_with_dir_ndx(
+            0,
+            &[("x/dup.txt", 10u64), ("x/dup.txt", 10), ("x/z.txt", 20)],
+        );
+        let mut ctx = inc_recurse_receiver();
+        ctx.dir_flist_used = 1;
+        ctx.dir_flist_names = vec![PathBuf::from("x")];
+        let n = ctx
+            .receive_extra_file_lists(&mut Cursor::new(wire))
+            .expect("legitimate sub-list must be accepted");
+        // Three entries arrive on the wire; the duplicate "x/dup.txt" collapses.
+        assert_eq!(n, 3, "the wire carried three entries");
+        let names: Vec<String> = ctx
+            .file_list()
+            .iter()
+            .map(|e| e.name().to_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["x/dup.txt".to_owned(), "x/z.txt".to_owned()],
+            "the repeated name must be deduped, leaving two entries"
+        );
+    }
+
+    /// A sub-list entry whose dirname escapes its declared parent must be rejected.
+    ///
+    /// WHY: upstream `flist.c:2684-2695` compares every sub-list entry's dirname
+    /// against `f_name(dir_flist->files[dir_ndx])` and, on a mismatch, aborts with
+    /// `exit_cleanup(RERR_UNSUPPORTED)` ("ABORTING due to invalid path from
+    /// sender"). Without this check a hostile sender could frame a sub-list for a
+    /// legitimate parent (`dir_ndx` 0 = "x") but fill it with an entry that lands
+    /// outside that tree ("y/evil.txt"), escaping the intended directory. The
+    /// range/duplicate guards (#28) do not catch this because `dir_ndx` itself is
+    /// valid; only the path-belongs check does.
+    #[test]
+    fn sublist_entry_escaping_parent_is_rejected() {
+        let wire = encode_segment_with_dir_ndx(0, &[("y/evil.txt", 9u64)]);
+        let mut ctx = inc_recurse_receiver();
+        ctx.dir_flist_used = 1;
+        // dir_ndx 0 is the legitimate parent "x"; the entry claims "y".
+        ctx.dir_flist_names = vec![PathBuf::from("x")];
+        let err = ctx
+            .receive_extra_file_lists(&mut Cursor::new(wire))
+            .expect_err("an entry escaping its parent must be rejected");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::Unsupported,
+            "path-belongs rejection must map to RERR_UNSUPPORTED (4), got {err:?}"
+        );
+        assert!(
+            err.to_string()
+                .contains("ABORTING due to invalid path from sender"),
+            "unexpected message: {err}"
+        );
+        assert_eq!(
+            ctx.file_list().len(),
+            0,
+            "the escaping segment's entries must be dropped"
+        );
+    }
+
+    /// A legitimate entry that lives directly under its declared parent passes.
+    ///
+    /// WHY: the path-belongs guard must accept the normal case (entry dirname ==
+    /// parent) or it would break every deep INC_RECURSE transfer. Guards this
+    /// against a false-positive regression.
+    #[test]
+    fn sublist_entry_under_parent_is_accepted() {
+        let wire = encode_segment_with_dir_ndx(0, &[("x/a.txt", 1u64), ("x/b.txt", 2)]);
+        let mut ctx = inc_recurse_receiver();
+        ctx.dir_flist_used = 1;
+        ctx.dir_flist_names = vec![PathBuf::from("x")];
+        let n = ctx
+            .receive_extra_file_lists(&mut Cursor::new(wire))
+            .expect("entries under their parent must be accepted");
+        assert_eq!(n, 2);
+        assert_eq!(ctx.file_list().len(), 2);
     }
 }

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -6,13 +6,12 @@
 //! parallel-deterministic-delete pipeline.
 
 use std::io::{self, Read};
+use std::path::Path;
 
 use logging::debug_log;
 use protocol::CompatibilityFlags;
 use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, create_ndx_codec};
-use protocol::flist::{
-    FileEntry, IncrementalFileListBuilder, sort_and_clean_file_list, sort_file_list,
-};
+use protocol::flist::{FileEntry, IncrementalFileListBuilder, sort_and_clean_file_list};
 
 use super::super::ReceiverContext;
 use super::hardlinks::{match_hard_links, normalize_pre30_hardlinks};
@@ -156,6 +155,18 @@ impl ReceiverContext {
             let list = std::mem::take(&mut self.file_list);
             let (cleaned, _clean) = sort_and_clean_file_list(list, self.config.qsort, pre29);
             self.file_list = cleaned;
+        }
+
+        // upstream: flist.c:recv_file_list() appends every directory to
+        // `dir_flist` as it is read, so a later INC_RECURSE sub-list header's
+        // `dir_ndx` resolves to that directory's full path (flist.c:2685). Record
+        // the same mapping in wire `dir_ndx` order - sorted here (or sender scan
+        // order under iconv) and taken before the receiver-only prune pass, so it
+        // stays aligned with the sender's `dir_ndx` numbering over every shipped
+        // directory. `receive_one_extra_segment()` uses it to reject a sub-list
+        // entry that does not live under its declared parent.
+        if inc_recurse {
+            self.record_dir_flist_names(0);
         }
 
         // upstream: flist.c:3121-3184 - flist_sort_and_clean() runs the
@@ -309,6 +320,14 @@ impl ReceiverContext {
             segment_count += 1;
         }
 
+        // upstream: flist.c:2684-2695 - every entry in a sub-list must live under
+        // the directory named by its header `dir_ndx`; a mismatch is an attempt
+        // by a hostile sender to inject a path that escapes its declared parent,
+        // which upstream aborts with `exit_cleanup(RERR_UNSUPPORTED)`. Validate
+        // before any further processing and drop the offending entries so nothing
+        // escapes into the transfer.
+        self.validate_extra_segment_path_belongs(dir_ndx, flat_start)?;
+
         // upstream: flist.c:1646 - leader GNUM is readdir-order wire NDX,
         // assigned before sorting.
         if self.config.flags.hard_links {
@@ -319,16 +338,25 @@ impl ReceiverContext {
             }
         }
 
-        // upstream: flist.c:2155,2736 - both sides call flist_sort_and_clean()
-        // independently. Unstable sort (true) is safe - entries have unique paths.
-        // INC_RECURSE requires protocol >= 30, so pre29 is always false here.
+        // upstream: flist.c:2190,2771 - both sides call flist_sort_and_clean()
+        // on EACH sub-list independently (send_extra_file_list / recv_file_list).
+        // That runs sort THEN the duplicate-clean pass (flist.c:3031, active for
+        // the receiver because `!am_sender || inc_recurse`), so a sub-list that
+        // repeats a normalized name collapses to a single entry with the upstream
+        // tie-break (a directory over a same-named file, else the first). We reuse
+        // the shared sort+dedup primitive so this matches the receiver's initial
+        // pass and the sender's per-dir clean, keeping the NDX numbering of the
+        // next segment identical on both sides. INC_RECURSE requires protocol >=
+        // 30, so pre29 is always false here.
         //
-        // Iconv suppresses the in-place reorder for the same reason as the
-        // initial flist: upstream's `need_unsorted_flist` keeps the
-        // NDX-addressed array in scan order so the receiver can resolve
-        // generator requests against the bytes the sender emitted.
+        // Iconv suppresses the in-place reorder+dedup for the same reason as the
+        // initial flist: upstream's `need_unsorted_flist` keeps the NDX-addressed
+        // array in scan order so the receiver can resolve generator requests
+        // against the bytes the sender emitted.
         if !self.iconv_reorder_suppressed() {
-            sort_file_list(&mut self.file_list[flat_start..], true, false);
+            let tail = self.file_list.split_off(flat_start);
+            let (cleaned, _clean) = sort_and_clean_file_list(tail, true, false);
+            self.file_list.extend(cleaned);
         }
         match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);
 
@@ -339,8 +367,11 @@ impl ReceiverContext {
 
         // upstream: flist.c:2695-2701 - directories in this sub-list are appended
         // to dir_flist, so a later sub-list may legitimately reference them by
-        // dir_ndx. Fold them into the running count.
+        // dir_ndx. Fold them into the running count and record their full paths in
+        // the same wire dir_ndx order so a deeper sub-list's path-belongs check
+        // resolves this segment's directories.
         self.dir_flist_used += count_directories(&self.file_list[flat_start..]);
+        self.record_dir_flist_names(flat_start);
 
         // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
         self.ndx_segments.push((flat_start, seg_ndx_start));
@@ -410,6 +441,76 @@ impl ReceiverContext {
                 crate::role_trailer::error_location!(),
                 crate::role_trailer::receiver()
             )));
+        }
+        Ok(())
+    }
+
+    /// Records the full relative path of every directory in `file_list[from..]`
+    /// into [`dir_flist_names`](super::super::ReceiverContext::dir_flist_names),
+    /// in the order they appear. Called after each list/sub-list is sorted (and,
+    /// under non-iconv, deduped) so the vector index matches the wire `dir_ndx`
+    /// the sender assigns to that directory.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2704` - `dir_flist->files[dir_flist->used++] = file` appends
+    ///   each directory so `dir_flist->files[dir_ndx]` names it later.
+    pub(in crate::receiver) fn record_dir_flist_names(&mut self, from: usize) {
+        for entry in &self.file_list[from..] {
+            if entry.is_dir() {
+                self.dir_flist_names.push(entry.path().clone());
+            }
+        }
+    }
+
+    /// Validates that every entry in the just-read INC_RECURSE sub-list
+    /// (`file_list[flat_start..]`) lives directly under the directory named by
+    /// the header's `dir_ndx`. A hostile sender that frames a sub-list for a
+    /// legitimate parent but fills it with an entry whose dirname escapes that
+    /// parent (`../` or an unrelated tree) is rejected, mapping to
+    /// `RERR_UNSUPPORTED` (4) exactly like upstream's `exit_cleanup`. The
+    /// offending segment's entries are dropped so nothing escapes into the
+    /// transfer.
+    ///
+    /// The parent name is looked up in [`dir_flist_names`] built by
+    /// [`record_dir_flist_names`](Self::record_dir_flist_names). Leading slashes
+    /// (present only under `--relative`, where upstream defers stripping to
+    /// `flist_sort_and_clean(..., strip_root)`) are ignored on both sides so a
+    /// legitimate relative transfer is never falsely rejected.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2684-2695` - `strcmp(cur_dir, d) != 0` -> "ABORTING due to
+    ///   invalid path from sender" -> `exit_cleanup(RERR_UNSUPPORTED)`.
+    pub(in crate::receiver) fn validate_extra_segment_path_belongs(
+        &mut self,
+        dir_ndx: i32,
+        flat_start: usize,
+    ) -> io::Result<()> {
+        // The range check in validate_extra_segment_dir_ndx guarantees
+        // `dir_ndx < dir_flist_used`; the name vector is kept in lockstep with
+        // that count, so a present entry is expected. If it is somehow absent we
+        // cannot name the parent, so skip rather than falsely abort.
+        let Some(parent) = self.dir_flist_names.get(dir_ndx as usize) else {
+            return Ok(());
+        };
+        let parent = strip_leading_slashes(parent);
+        for i in flat_start..self.file_list.len() {
+            let child_dir = strip_leading_slashes(self.file_list[i].dirname());
+            if child_dir != parent {
+                let basename = self.file_list[i].name().to_owned();
+                let cur = self.file_list[i].dirname().display().to_string();
+                // Drop this segment's entries so nothing escapes the tree.
+                self.file_list.truncate(flat_start);
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    format!(
+                        "ABORTING due to invalid path from sender: {cur}/{basename} {}{}",
+                        crate::role_trailer::error_location!(),
+                        crate::role_trailer::receiver()
+                    ),
+                ));
+            }
         }
         Ok(())
     }
@@ -534,4 +635,22 @@ impl ReceiverContext {
 ///   dir_flist->used++] = file; }`.
 pub(super) fn count_directories(entries: &[FileEntry]) -> usize {
     entries.iter().filter(|e| e.is_dir()).count()
+}
+
+/// Strips leading path separators so a `--relative` dirname - which carries a
+/// leading `/` until upstream's `strip_root` pass runs - compares equal to the
+/// slash-free parent path recorded in `dir_flist_names`.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:2685-2686` - `if (relative_paths && *cur_dir == '/') cur_dir++;`
+fn strip_leading_slashes(p: &Path) -> &Path {
+    let mut s = p;
+    while let Ok(rest) = s.strip_prefix("/") {
+        if rest.as_os_str().is_empty() {
+            break;
+        }
+        s = rest;
+    }
+    s
 }

--- a/crates/transfer/src/receiver/file_list/receive_async.rs
+++ b/crates/transfer/src/receiver/file_list/receive_async.rs
@@ -31,7 +31,7 @@ use std::io;
 use logging::debug_log;
 use protocol::CompatibilityFlags;
 use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, create_ndx_codec};
-use protocol::flist::{read_entry_with_flist_async, sort_file_list};
+use protocol::flist::{read_entry_with_flist_async, sort_and_clean_file_list};
 use tokio::io::AsyncRead;
 
 use super::super::ReceiverContext;
@@ -100,10 +100,24 @@ impl ReceiverContext {
             }
         }
 
-        // upstream: flist.c:2736 - flist_sort_and_clean() after recv_id_list().
+        // upstream: flist.c:2736,3016 - flist_sort_and_clean() runs sort THEN the
+        // duplicate-clean pass on the receiver; mirror the sync path so both wire
+        // surfaces collapse a redundant name identically.
         let pre29 = self.protocol.as_u8() < 29;
         if !self.iconv_reorder_suppressed() {
-            sort_file_list(&mut self.file_list, self.config.qsort, pre29);
+            let list = std::mem::take(&mut self.file_list);
+            let (cleaned, _clean) = sort_and_clean_file_list(list, self.config.qsort, pre29);
+            self.file_list = cleaned;
+        }
+
+        // upstream: flist.c:2704 - record each directory's full path in wire
+        // dir_ndx order (pre-prune) so a later sub-list's path-belongs check
+        // resolves its parent, matching the sync path.
+        if self
+            .compat_flags
+            .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE))
+        {
+            self.record_dir_flist_names(seg_start);
         }
 
         // upstream: flist.c:3121-3184 - `--prune-empty-dirs` pass after sorting.
@@ -222,6 +236,10 @@ impl ReceiverContext {
                 segment_count += 1;
             }
 
+            // upstream: flist.c:2684-2695 - reject any entry that does not live
+            // under its header dir_ndx's directory, matching the sync path.
+            self.validate_extra_segment_path_belongs(dir_ndx, flat_start)?;
+
             // upstream: flist.c:1646 - leader GNUM is readdir-order wire NDX.
             if self.config.flags.hard_links {
                 for (i, entry) in self.file_list[flat_start..].iter_mut().enumerate() {
@@ -231,9 +249,13 @@ impl ReceiverContext {
                 }
             }
 
-            // upstream: flist.c:2155,2736 - both sides call flist_sort_and_clean().
+            // upstream: flist.c:2190,2771 - both sides call flist_sort_and_clean()
+            // per sub-list (sort THEN dedup); mirror the sync path so a repeated
+            // name collapses identically and the next segment's NDX stays in sync.
             if !self.iconv_reorder_suppressed() {
-                sort_file_list(&mut self.file_list[flat_start..], true, false);
+                let tail = self.file_list.split_off(flat_start);
+                let (cleaned, _clean) = sort_and_clean_file_list(tail, true, false);
+                self.file_list.extend(cleaned);
             }
             match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);
 
@@ -242,9 +264,10 @@ impl ReceiverContext {
             }
 
             // upstream: flist.c:2695-2701 - fold this sub-list's directories into
-            // the running dir_flist->used count so a later sub-list may reference
-            // them by dir_ndx.
+            // the running dir_flist->used count and record their paths so a later
+            // sub-list may reference them by dir_ndx.
             self.dir_flist_used += super::receive::count_directories(&self.file_list[flat_start..]);
+            self.record_dir_flist_names(flat_start);
 
             // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
             self.ndx_segments.push((flat_start, seg_ndx_start));

--- a/pr_body_t88.md
+++ b/pr_body_t88.md
@@ -1,0 +1,83 @@
+## Summary
+
+Extends the file-list dedup pass (#6631) to INC_RECURSE sub-lists and adds the
+per-entry path-belongs validation upstream runs on every received sub-list.
+Both were left open when #6631 wired `flist_sort_and_clean` into the initial
+list only.
+
+Two gaps closed in the receiver's sub-list receive path
+(`receive_one_extra_segment` / its async twin):
+
+### 1. Sub-list dedup
+
+Upstream runs `flist_sort_and_clean()` on **each** INC_RECURSE sub-list on both
+sides - the sender per directory (`flist.c:2190` `send_extra_file_list`) and the
+receiver per `recv_file_list(f, dir_ndx)` call (`flist.c:2771`). Its clean pass
+(`flist.c:3031`, active for the receiver because `!am_sender || inc_recurse`)
+removes duplicate names, keeping the upstream tie-break (a directory over a
+same-named file "because it might have contents in the list", else the first).
+
+Before this change the sub-list path sorted the segment but skipped the dedup, so
+a redundant or hostile duplicate survived and the generator requested the same
+path twice - an NDX divergence driven by untrusted bytes, the exact class #6631
+closed for the initial list. The fix reuses the shared `sort_and_clean_file_list`
+primitive on each segment slice.
+
+**Both sides stay NDX-identical.** The legitimate sender ships deduped sub-lists:
+its per-directory segments are partitions of a full file list that was already
+sorted+deduped (`dedup_with_parallel`) before partitioning, so no segment can
+carry a duplicate. The receiver's pass is therefore a no-op on any legitimate
+transfer and only collapses a hostile duplicate - it never changes the entry
+count or NDX numbering the sender expects. This is the same symmetry lesson as
+the initial-list fix: a receiver-only dedup of bytes the sender did *not* dedup
+would desync (RERR_PROTOCOL 16); here the sender's list is deduped-by-construction
+before it is split into sub-lists, so both sides converge to the same segment.
+
+### 2. Sub-list path-belongs validation
+
+Upstream rejects any sub-list entry whose dirname does not match the directory
+named by the header's `dir_ndx`, aborting with `exit_cleanup(RERR_UNSUPPORTED)`
+(`flist.c:2684-2695`, "ABORTING due to invalid path from sender"). This defends
+against a hostile sender that frames a sub-list for a legitimate parent but fills
+it with an entry that escapes that tree.
+
+The existing range + duplicate `dir_ndx` guards (from the merged dir_ndx
+validation work) do not catch this: `dir_ndx` itself is valid; only the
+per-entry dirname comparison does. To perform it the receiver now records the
+full path of every directory in wire `dir_ndx` order (`dir_flist_names`,
+mirroring upstream's `dir_flist->files[]`, `flist.c:2704`), built after each
+list/sub-list is sorted so the index matches the sender's `dir_ndx` assignment.
+A mismatched entry is rejected with `io::ErrorKind::Unsupported`, which the core
+exit-code mapper turns into `RERR_UNSUPPORTED` (4), matching upstream. Leading
+slashes (present only under `--relative`, where upstream defers stripping to
+`flist_sort_and_clean`'s `strip_root`) are ignored on both sides so a legitimate
+relative transfer is never falsely rejected.
+
+## Upstream references
+
+- `flist.c:2190` `send_extra_file_list()` - `flist_sort_and_clean(flist, 0)` per sub-list (sender).
+- `flist.c:2771` `recv_file_list()` - `flist_sort_and_clean(flist, relative_paths)` per sub-list (receiver).
+- `flist.c:3016-3082` `flist_sort_and_clean()` / clean pass - the dedup tie-break, active for the receiver (`!am_sender || inc_recurse`, line 3031).
+- `flist.c:2684-2695` - path-belongs check -> "ABORTING due to invalid path from sender" -> `exit_cleanup(RERR_UNSUPPORTED)`.
+- `flist.c:2704` - `dir_flist->files[dir_flist->used++] = file` appends each directory so `dir_flist->files[dir_ndx]` names it later.
+
+## Tests
+
+- `sublist_duplicate_name_is_deduped` - a repeated name in a sub-list collapses to one entry.
+- `sublist_entry_escaping_parent_is_rejected` - an entry whose dirname escapes its `dir_ndx` parent is rejected with `Unsupported` (exit 4) and its segment dropped.
+- `sublist_entry_under_parent_is_accepted` - the normal case still passes (no false rejection).
+- The existing real-upstream multi-segment sub-list frame test now exercises path-belongs against genuine upstream 3.4.4 bytes and passes, confirming the `dir_ndx` -> name ordering matches upstream.
+
+Both wire surfaces (sync and the default-off async twin) receive the identical
+change, keeping the async-parity contract.
+
+## End-to-end verification
+
+Built the binary and drove a deep recursive tree (8-level chain plus a wide
+subtree, 84 files) over a two-process local-shell transport, exercising real
+INC_RECURSE sub-lists across sender and receiver:
+
+- `push` and `pull` both exit 0 (RERR_PROTOCOL-free) and are byte-identical to a
+  local reference copy (`diff -r` clean).
+- `-vv` confirms "sending/receiving incremental file list" - inc-recurse engaged.
+- Idempotent re-sync transfers nothing and exits 0.


### PR DESCRIPTION
## Summary

Extends the file-list dedup pass (#6631) to INC_RECURSE sub-lists and adds the
per-entry path-belongs validation upstream runs on every received sub-list.
Both were left open when #6631 wired `flist_sort_and_clean` into the initial
list only.

Two gaps closed in the receiver's sub-list receive path
(`receive_one_extra_segment` / its async twin):

### 1. Sub-list dedup

Upstream runs `flist_sort_and_clean()` on **each** INC_RECURSE sub-list on both
sides - the sender per directory (`flist.c:2190` `send_extra_file_list`) and the
receiver per `recv_file_list(f, dir_ndx)` call (`flist.c:2771`). Its clean pass
(`flist.c:3031`, active for the receiver because `!am_sender || inc_recurse`)
removes duplicate names, keeping the upstream tie-break (a directory over a
same-named file "because it might have contents in the list", else the first).

Before this change the sub-list path sorted the segment but skipped the dedup, so
a redundant or hostile duplicate survived and the generator requested the same
path twice - an NDX divergence driven by untrusted bytes, the exact class #6631
closed for the initial list. The fix reuses the shared `sort_and_clean_file_list`
primitive on each segment slice.

**Both sides stay NDX-identical.** The legitimate sender ships deduped sub-lists:
its per-directory segments are partitions of a full file list that was already
sorted+deduped (`dedup_with_parallel`) before partitioning, so no segment can
carry a duplicate. The receiver's pass is therefore a no-op on any legitimate
transfer and only collapses a hostile duplicate - it never changes the entry
count or NDX numbering the sender expects. This is the same symmetry lesson as
the initial-list fix: a receiver-only dedup of bytes the sender did *not* dedup
would desync (RERR_PROTOCOL 16); here the sender's list is deduped-by-construction
before it is split into sub-lists, so both sides converge to the same segment.

### 2. Sub-list path-belongs validation

Upstream rejects any sub-list entry whose dirname does not match the directory
named by the header's `dir_ndx`, aborting with `exit_cleanup(RERR_UNSUPPORTED)`
(`flist.c:2684-2695`, "ABORTING due to invalid path from sender"). This defends
against a hostile sender that frames a sub-list for a legitimate parent but fills
it with an entry that escapes that tree.

The existing range + duplicate `dir_ndx` guards (from the merged dir_ndx
validation work) do not catch this: `dir_ndx` itself is valid; only the
per-entry dirname comparison does. To perform it the receiver now records the
full path of every directory in wire `dir_ndx` order (`dir_flist_names`,
mirroring upstream's `dir_flist->files[]`, `flist.c:2704`), built after each
list/sub-list is sorted so the index matches the sender's `dir_ndx` assignment.
A mismatched entry is rejected with `io::ErrorKind::Unsupported`, which the core
exit-code mapper turns into `RERR_UNSUPPORTED` (4), matching upstream. Leading
slashes (present only under `--relative`, where upstream defers stripping to
`flist_sort_and_clean`'s `strip_root`) are ignored on both sides so a legitimate
relative transfer is never falsely rejected.

## Upstream references

- `flist.c:2190` `send_extra_file_list()` - `flist_sort_and_clean(flist, 0)` per sub-list (sender).
- `flist.c:2771` `recv_file_list()` - `flist_sort_and_clean(flist, relative_paths)` per sub-list (receiver).
- `flist.c:3016-3082` `flist_sort_and_clean()` / clean pass - the dedup tie-break, active for the receiver (`!am_sender || inc_recurse`, line 3031).
- `flist.c:2684-2695` - path-belongs check -> "ABORTING due to invalid path from sender" -> `exit_cleanup(RERR_UNSUPPORTED)`.
- `flist.c:2704` - `dir_flist->files[dir_flist->used++] = file` appends each directory so `dir_flist->files[dir_ndx]` names it later.

## Tests

- `sublist_duplicate_name_is_deduped` - a repeated name in a sub-list collapses to one entry.
- `sublist_entry_escaping_parent_is_rejected` - an entry whose dirname escapes its `dir_ndx` parent is rejected with `Unsupported` (exit 4) and its segment dropped.
- `sublist_entry_under_parent_is_accepted` - the normal case still passes (no false rejection).
- The existing real-upstream multi-segment sub-list frame test now exercises path-belongs against genuine upstream 3.4.4 bytes and passes, confirming the `dir_ndx` -> name ordering matches upstream.

Both wire surfaces (sync and the default-off async twin) receive the identical
change, keeping the async-parity contract.

## End-to-end verification

Built the binary and drove a deep recursive tree (8-level chain plus a wide
subtree, 84 files) over a two-process local-shell transport, exercising real
INC_RECURSE sub-lists across sender and receiver:

- `push` and `pull` both exit 0 (RERR_PROTOCOL-free) and are byte-identical to a
  local reference copy (`diff -r` clean).
- `-vv` confirms "sending/receiving incremental file list" - inc-recurse engaged.
- Idempotent re-sync transfers nothing and exits 0.
