### PR TITLE
fix(protocol): map bounded wire-read overruns to RERR_PROTOCOL

### DIFF
--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -161,12 +161,14 @@ impl DeleteStats {
 /// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
 fn read_capped_del_stat(raw: i32, field: &str) -> io::Result<u32> {
     if !(0..=MAX_WIRE_DEL_STAT).contains(&raw) {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "delete stat '{field}' value {raw} exceeds MAX_WIRE_DEL_STAT ({MAX_WIRE_DEL_STAT})"
-            ),
-        ));
+        // upstream: main.c:read_del_stats() reads each field via
+        // read_varint_bounded(f, 0, MAX_WIRE_DEL_STAT, ...), which aborts with
+        // exit_cleanup(RERR_PROTOCOL) (exit 2) on an out-of-range value. Tag the
+        // error so the core exit-code mapper yields RERR_PROTOCOL, not the
+        // generic RERR_STREAMIO (12) that a bare InvalidData maps to.
+        return Err(crate::protocol_violation::protocol_violation(format!(
+            "delete stat '{field}' value {raw} exceeds MAX_WIRE_DEL_STAT ({MAX_WIRE_DEL_STAT})"
+        )));
     }
     Ok(raw as u32)
 }

--- a/crates/protocol/src/stats/tests.rs
+++ b/crates/protocol/src/stats/tests.rs
@@ -561,6 +561,14 @@ fn delete_stats_rejects_oversized_wire_value() {
         err.to_string().contains("MAX_WIRE_DEL_STAT"),
         "error should mention MAX_WIRE_DEL_STAT, got: {err}"
     );
+    // WHY: upstream main.c reads these via read_varint_bounded, exiting
+    // RERR_PROTOCOL (2) on an out-of-range value; the tag must survive so the
+    // core exit-code mapper reproduces exit 2, not RERR_STREAMIO (12).
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized delete-stat must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
 }
 
 /// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
@@ -580,6 +588,11 @@ fn delete_stats_rejects_negative_wire_value() {
     assert!(
         err.to_string().contains("MAX_WIRE_DEL_STAT"),
         "negative value should be rejected, got: {err}"
+    );
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "negative delete-stat must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
     );
 }
 

--- a/crates/protocol/src/varint/decode.rs
+++ b/crates/protocol/src/varint/decode.rs
@@ -100,7 +100,11 @@ pub fn read_varint_bounded<R: Read + ?Sized>(
 ) -> io::Result<i32> {
     let v = read_varint(reader)?;
     if v < lo || v > hi {
-        return Err(invalid_data(&format!(
+        // upstream: io.c:read_varint_bounded() aborts with
+        // exit_cleanup(RERR_PROTOCOL) (exit 2) on an out-of-range wire value.
+        // Tag the error so the core exit-code mapper yields RERR_PROTOCOL, not
+        // the generic RERR_STREAMIO (12) that a bare InvalidData maps to.
+        return Err(crate::protocol_violation::protocol_violation(format!(
             "wire value {what} out of range: {v} not in [{lo},{hi}]"
         )));
     }
@@ -114,7 +118,9 @@ pub fn read_varint_bounded<R: Read + ?Sized>(
 /// so a negative wire value cannot wrap to `~SIZE_MAX`. Callers reading a
 /// length or count from the wire should use this instead of casting the result
 /// of [`read_varint`] directly. Upstream aborts with `RERR_PROTOCOL` on a bad
-/// value; the Rust equivalent is a typed [`io::ErrorKind::InvalidData`].
+/// value; the Rust equivalent is an [`io::ErrorKind::InvalidData`] tagged as a
+/// [`ProtocolViolation`](crate::protocol_violation::ProtocolViolation) so the
+/// core exit-code mapper reproduces upstream's exit 2.
 ///
 /// # Errors
 ///
@@ -128,7 +134,11 @@ pub fn read_varint_size<R: Read + ?Sized>(
 ) -> io::Result<usize> {
     let v = read_varint(reader)?;
     if v < 0 || (v as usize) > max {
-        return Err(invalid_data(&format!(
+        // upstream: io.c:read_varint_size() aborts with
+        // exit_cleanup(RERR_PROTOCOL) (exit 2) on a negative or over-max wire
+        // value. Tag the error so the core exit-code mapper yields
+        // RERR_PROTOCOL, not the generic RERR_STREAMIO (12).
+        return Err(crate::protocol_violation::protocol_violation(format!(
             "wire size {what} out of range: {v} > {max}"
         )));
     }

--- a/crates/protocol/src/varint/tests.rs
+++ b/crates/protocol/src/varint/tests.rs
@@ -2010,12 +2010,20 @@ fn read_varint_bounded_accepts_in_range() {
 fn read_varint_bounded_rejects_below_and_above() {
     // A value one past either boundary is a protocol error (InvalidData). This
     // is the parity guarantee vs upstream io.c:read_varint_bounded, which aborts
-    // with RERR_PROTOCOL; callers must not receive an out-of-range value.
+    // with exit_cleanup(RERR_PROTOCOL); callers must not receive an out-of-range
+    // value. WHY the tag matters: a bare InvalidData maps to RERR_STREAMIO (12),
+    // but upstream exits 2 here - a drop-in tool that distinguishes "hostile
+    // wire value" (2) from "stream broke" (12) would misbehave on the wrong code.
     for (value, lo, hi) in [(-1, 0, 10), (11, 0, 10)] {
         let mut cursor = Cursor::new(encoded(value));
         let err = read_varint_bounded(&mut cursor, lo, hi, "flag")
             .expect_err("out-of-range value must be rejected");
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.get_ref()
+                .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+            "out-of-range wire value must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+        );
     }
 }
 
@@ -2036,6 +2044,11 @@ fn read_varint_size_rejects_negative() {
     let err =
         read_varint_size(&mut cursor, 1024, "xattr").expect_err("negative size must be rejected");
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "negative wire size must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
 }
 
 #[test]
@@ -2044,6 +2057,11 @@ fn read_varint_size_rejects_above_max() {
     let err = read_varint_size(&mut cursor, 1024, "xattr")
         .expect_err("size exceeding max must be rejected");
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "over-max wire size must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Bounded wire-value reads that overrun their declared range must exit with
`RERR_PROTOCOL` (2), matching upstream rsync 3.4.4. Three sites were producing a
bare `InvalidData` error, which the core exit-code mapper turns into
`RERR_STREAMIO` (12):

- `read_varint_bounded` (out-of-range varint)
- `read_varint_size` (negative or over-max size varint)
- `read_capped_del_stat` (per-category delete-stat over `MAX_WIRE_DEL_STAT`)

Each now tags the error as a `ProtocolViolation`, so the mapper reproduces
upstream's exit 2. This completes the exit-code family begun with the
invalid-file-mode fix (which already tags `ProtocolViolation`); these sibling
bounded-read sites were left untagged.

## Upstream reference

The bounded-read helpers are the direct analogues of upstream's hardened
readers, which `exit_cleanup(RERR_PROTOCOL)` on an out-of-range wire value:

- `io.c:read_int_bounded()` -> `exit_cleanup(RERR_PROTOCOL)` (io.c:1898)
- `io.c:read_varint_bounded()` -> `exit_cleanup(RERR_PROTOCOL)` (io.c:1910)
- `io.c:read_varint_size()` -> `exit_cleanup(RERR_PROTOCOL)` (io.c:1923)
- `main.c:read_del_stats()` reads each category via
  `read_varint_bounded(f, 0, MAX_WIRE_DEL_STAT, ...)`

`errcode.h`: `RERR_PROTOCOL = 2` (protocol incompatibility) versus
`RERR_STREAMIO = 12` (error in the protocol data stream).

The structural varint-overflow path (`io.c:read_varint()` "Overflow in
read_varint" -> `RERR_STREAMIO`, io.c:1832) is intentionally left untagged, so a
malformed encoding still exits 12. Truncated/EOF reads likewise stay
`UnexpectedEof` -> `RERR_STREAMIO`.

## Why it matters

The exit code is observable. A wrapper script or CI harness that distinguishes
"peer sent a hostile/out-of-range value" (exit 2) from "the stream broke"
(exit 12) behaves differently on each. Returning 12 where upstream returns 2 is
a drop-in fidelity divergence under adversarial or corrupt input, exactly the
conditions these caps exist to defend against.

## Tests

Strengthened the existing rejection tests to assert the `ProtocolViolation`
tag survives (they previously checked only `ErrorKind::InvalidData`, which is why
the exit-12-vs-2 gap went unnoticed):

- `read_varint_bounded_rejects_below_and_above`
- `read_varint_size_rejects_negative`, `read_varint_size_rejects_above_max`
- `delete_stats_rejects_oversized_wire_value`,
  `delete_stats_rejects_negative_wire_value`

The truncated-read test (`read_varint_size_propagates_truncated_read`) confirms
EOF stays `UnexpectedEof` (exit 12). The core mapper's
`ProtocolViolation` -> `Protocol` arm is already covered by
`from_io_error_maps_tagged_protocol_violation_to_protocol`.

`cargo fmt` and `cargo clippy` clean; 540 protocol + core exit-code tests pass.
