### PR TITLE
fix(transfer): exit RERR_PROTOCOL on out-of-range peer protocol version

### DIFF
--- a/crates/core/src/client/module_list/errors.rs
+++ b/crates/core/src/client/module_list/errors.rs
@@ -5,7 +5,8 @@ use crate::client::module_list::parsing::strip_prefix_ignore_ascii_case;
 use protocol::{NegotiationError, parse_legacy_error_message};
 
 use super::super::{
-    ClientError, PARTIAL_TRANSFER_EXIT_CODE, daemon_error, daemon_protocol_error, socket_error,
+    ClientError, PARTIAL_TRANSFER_EXIT_CODE, PROTOCOL_INCOMPATIBLE_EXIT_CODE, daemon_error,
+    daemon_protocol_error, socket_error,
 };
 use super::DaemonAddress;
 
@@ -89,6 +90,21 @@ fn handshake_error_to_client_error(error: &io::Error) -> Option<ClientError> {
         }
 
         return Some(daemon_protocol_error(input));
+    }
+
+    // upstream: compat.c:619-623 setup_protocol - a daemon that advertises a
+    // protocol version outside [MIN_PROTOCOL_VERSION, MAX_PROTOCOL_VERSION]
+    // makes the client exit_cleanup(RERR_PROTOCOL) (exit 2). Both the
+    // out-of-range (UnsupportedVersion) and no-mutual-version cases carry that
+    // negotiation failure, so map them to RERR_PROTOCOL rather than falling
+    // through to the RERR_SOCKETIO (10) socket-error path.
+    if negotiation_error.unsupported_version().is_some()
+        || negotiation_error.peer_versions().is_some()
+    {
+        return Some(daemon_error(
+            negotiation_error.to_string(),
+            PROTOCOL_INCOMPATIBLE_EXIT_CODE,
+        ));
     }
 
     None
@@ -315,5 +331,42 @@ mod tests {
         let mut reader = ErrorReader::new(io::ErrorKind::BrokenPipe);
         let result = read_trimmed_line(&mut reader).expect("broken pipe as eof");
         assert!(result.is_none());
+    }
+
+    // WHY: upstream compat.c:619-623 setup_protocol exits RERR_PROTOCOL (2) when
+    // the daemon advertises a protocol version outside
+    // [MIN_PROTOCOL_VERSION, MAX_PROTOCOL_VERSION]. oc rejects the out-of-range
+    // greeting during negotiation, so the daemon handshake mapper must report
+    // exit 2 - not the RERR_SOCKETIO (10) socket-error fallback - so a drop-in
+    // tool distinguishes a protocol mismatch from a transport failure.
+    #[test]
+    fn out_of_range_daemon_version_maps_to_rerr_protocol() {
+        let error: io::Error = NegotiationError::UnsupportedVersion(999).into();
+        let mapped =
+            handshake_error_to_client_error(&error).expect("out-of-range version is classified");
+        assert_eq!(mapped.exit_code(), PROTOCOL_INCOMPATIBLE_EXIT_CODE);
+        assert_eq!(mapped.exit_code(), 2);
+    }
+
+    // WHY: a daemon whose advertised versions do not overlap our supported set
+    // is the same protocol-incompatibility class and must also exit 2.
+    #[test]
+    fn no_mutual_daemon_version_maps_to_rerr_protocol() {
+        let error: io::Error = NegotiationError::NoMutualProtocol {
+            peer_versions: vec![20, 21],
+        }
+        .into();
+        let mapped =
+            handshake_error_to_client_error(&error).expect("no-mutual version is classified");
+        assert_eq!(mapped.exit_code(), PROTOCOL_INCOMPATIBLE_EXIT_CODE);
+    }
+
+    // Regression guard: a genuine transport failure (not a NegotiationError)
+    // must NOT be reclassified as a protocol error; it stays on the socket-error
+    // path (RERR_SOCKETIO, 10) handled by the caller.
+    #[test]
+    fn non_negotiation_error_is_not_classified_as_protocol() {
+        let error = io::Error::new(io::ErrorKind::ConnectionReset, "reset");
+        assert!(handshake_error_to_client_error(&error).is_none());
     }
 }

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -331,13 +331,16 @@ fn run_server_over_ssh_connection(
             };
 
             // upstream: io.c:232 whine_about_eof() maps an unexpected EOF
-            // during setup to RERR_STREAMIO (12); other handshake failures keep
-            // the client/server-startup code (5). exit_cleanup() then takes the
-            // worst of that base and the child's raw exit status
-            // (cleanup.c:150), so an arbitrary remote exit code propagates
-            // verbatim.
+            // during setup to RERR_STREAMIO (12); an out-of-range peer protocol
+            // version is RERR_PROTOCOL (2) per compat.c:619-623 setup_protocol;
+            // other handshake failures keep the client/server-startup code (5).
+            // exit_cleanup() then takes the worst of that base and the child's
+            // raw exit status (cleanup.c:150), so an arbitrary remote exit code
+            // propagates verbatim.
             let base = if e.kind() == std::io::ErrorKind::UnexpectedEof {
                 ExitCode::StreamIo
+            } else if ExitCode::from_io_error(&e) == ExitCode::Protocol {
+                ExitCode::Protocol
             } else {
                 ExitCode::StartClient
             };

--- a/crates/transfer/src/handshake.rs
+++ b/crates/transfer/src/handshake.rs
@@ -172,14 +172,15 @@ pub fn perform_handshake_with_max(
 
     let remote_version = read_client_version(stdin)?;
 
+    // upstream: compat.c:619-623 setup_protocol - a remote protocol version
+    // outside [MIN_PROTOCOL_VERSION, MAX_PROTOCOL_VERSION] calls
+    // exit_cleanup(RERR_PROTOCOL) (exit 2), not RERR_STREAMIO (12). Tag the
+    // negotiation failure so the exit-code mapper reports RERR_PROTOCOL.
     let negotiated = select_highest_mutual([remote_version]).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "remote protocol version {} is not supported: {e}",
-                remote_version.as_u8()
-            ),
-        )
+        protocol::protocol_violation(format!(
+            "remote protocol version {} is not supported: {e}",
+            remote_version.as_u8()
+        ))
     })?;
     // upstream: compat.c:606-607 - protocol_version = MIN(protocol_version,
     // remote_protocol). Clamp the mutually-supported version to our advertised
@@ -204,19 +205,19 @@ fn read_client_version(stdin: &mut dyn Read) -> io::Result<ProtocolVersion> {
     stdin.read_exact(&mut buf)?;
 
     let version_byte = buf[0];
+    // upstream: compat.c:619-623 setup_protocol - an out-of-range remote
+    // protocol version is a protocol incompatibility (RERR_PROTOCOL, exit 2),
+    // distinct from a truncated stream (RERR_STREAMIO, exit 12). The
+    // read_exact above keeps its stream-error mapping; only the version-value
+    // checks are tagged as protocol violations.
     if version_byte == 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
+        return Err(protocol::protocol_violation(
             "received invalid protocol version 0",
         ));
     }
 
-    ProtocolVersion::try_from(version_byte).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("invalid protocol version: {e}"),
-        )
-    })
+    ProtocolVersion::try_from(version_byte)
+        .map_err(|e| protocol::protocol_violation(format!("invalid protocol version: {e}")))
 }
 
 /// Writes the server's protocol version advertisement.
@@ -277,18 +278,15 @@ pub fn perform_legacy_handshake(
             )
         })?;
 
-    let client_version = ProtocolVersion::try_from(version_number).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("unsupported protocol version: {e}"),
-        )
-    })?;
+    // upstream: compat.c:619-623 setup_protocol - an out-of-range peer protocol
+    // version is RERR_PROTOCOL (exit 2), not RERR_STREAMIO (12).
+    let client_version = ProtocolVersion::try_from(version_number)
+        .map_err(|e| protocol::protocol_violation(format!("unsupported protocol version: {e}")))?;
 
     let negotiated = select_highest_mutual([client_version]).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("protocol version {version_number} is not supported: {e}"),
-        )
+        protocol::protocol_violation(format!(
+            "protocol version {version_number} is not supported: {e}"
+        ))
     })?;
 
     let response = format!("@RSYNCD: {}.0\n", negotiated.as_u8());
@@ -508,5 +506,73 @@ mod tests {
 
         let response = String::from_utf8_lossy(&stdout);
         assert!(response.starts_with("@RSYNCD: 32"));
+    }
+
+    /// Asserts that `error` is an `InvalidData` error tagged as a
+    /// [`protocol::ProtocolViolation`], which the core exit-code mapper turns
+    /// into `RERR_PROTOCOL` (exit 2) rather than `RERR_STREAMIO` (exit 12).
+    fn assert_maps_to_rerr_protocol(error: &io::Error) {
+        assert_eq!(
+            error.kind(),
+            io::ErrorKind::InvalidData,
+            "kind must stay InvalidData for backward compatibility"
+        );
+        assert!(
+            error
+                .get_ref()
+                .is_some_and(|inner| inner.is::<protocol::ProtocolViolation>()),
+            "out-of-range protocol version must map to RERR_PROTOCOL (2), not RERR_STREAMIO (12)"
+        );
+    }
+
+    // WHY: upstream compat.c:619-623 exits RERR_PROTOCOL (2) for a peer protocol
+    // version outside [MIN_PROTOCOL_VERSION, MAX_PROTOCOL_VERSION]. A drop-in
+    // tool or wrapper script keys on that exit code to distinguish a protocol
+    // mismatch (2) from a corrupt/truncated data stream (12), so the binary
+    // handshake must tag the out-of-range version as a protocol violation.
+    #[test]
+    fn binary_handshake_out_of_range_version_maps_to_rerr_protocol() {
+        let mut stdin = Cursor::new(vec![99, 0, 0, 0]);
+        let mut stdout = Vec::new();
+
+        let error = perform_handshake(&mut stdin, &mut stdout)
+            .expect_err("version 99 is outside the supported range");
+        assert_maps_to_rerr_protocol(&error);
+    }
+
+    // WHY: a zero version byte is an invalid protocol version, not a stream
+    // error; upstream treats an out-of-range remote_protocol as RERR_PROTOCOL.
+    #[test]
+    fn binary_handshake_version_zero_maps_to_rerr_protocol() {
+        let mut stdin = Cursor::new(vec![0, 0, 0, 0]);
+        let mut stdout = Vec::new();
+
+        let error = perform_handshake(&mut stdin, &mut stdout).expect_err("version 0 is invalid");
+        assert_maps_to_rerr_protocol(&error);
+    }
+
+    // WHY: the legacy `@RSYNCD:` handshake path must classify an out-of-range
+    // version identically to the binary path - protocol version 27 is below the
+    // supported floor and must exit RERR_PROTOCOL (2), not RERR_STREAMIO (12).
+    #[test]
+    fn legacy_handshake_out_of_range_version_maps_to_rerr_protocol() {
+        let mut stdin = Cursor::new(b"@RSYNCD: 27.0\n".to_vec());
+        let mut stdout = Vec::new();
+
+        let error = perform_legacy_handshake(&mut stdin, &mut stdout)
+            .expect_err("protocol 27 is below the supported floor");
+        assert_maps_to_rerr_protocol(&error);
+    }
+
+    // Regression guard: a legitimate in-range version must still negotiate
+    // successfully and must NOT be misclassified as a protocol violation.
+    #[test]
+    fn binary_handshake_in_range_version_still_succeeds() {
+        let mut stdin = Cursor::new(vec![30, 0, 0, 0]);
+        let mut stdout = Vec::new();
+
+        let result =
+            perform_handshake(&mut stdin, &mut stdout).expect("in-range handshake succeeds");
+        assert_eq!(result.protocol, ProtocolVersion::V30);
     }
 }


### PR DESCRIPTION
## Summary

An out-of-range peer protocol version during handshake exited with the wrong
code on two paths. Upstream rsync exits `RERR_PROTOCOL` (2) when the negotiated
remote protocol version falls outside `[MIN_PROTOCOL_VERSION, MAX_PROTOCOL_VERSION]`;
oc exited `RERR_STREAMIO` (12) on the SSH path and `RERR_SOCKETIO` (10) on the
daemon module-list path. Both are now `RERR_PROTOCOL` (2).

This is an observable-fidelity fix: a drop-in tool or wrapper script keys on the
exit code to distinguish a protocol-version mismatch (2) from a corrupt/truncated
data stream (12) or a transport failure (10).

## Upstream reference

`compat.c:619-623` `setup_protocol()`:

```c
if (remote_protocol < MIN_PROTOCOL_VERSION
 || remote_protocol > MAX_PROTOCOL_VERSION) {
	rprintf(FERROR,"protocol version mismatch -- is your shell clean?\n");
	rprintf(FERROR,"(see the rsync manpage for an explanation)\n");
	exit_cleanup(RERR_PROTOCOL);
}
```

`errcode.h:26` `#define RERR_PROTOCOL 2`. `rsync.h`: `MIN_PROTOCOL_VERSION 20`,
`MAX_PROTOCOL_VERSION 40`. For a daemon connection `remote_protocol` is set from
the `@RSYNCD:` greeting, so `setup_protocol()`'s `remote_protocol == 0` re-read
is skipped and the same `MIN`/`MAX` guard fires when the greeting version is out
of range.

## Divergences fixed

- **SSH path (12 -> 2):** `crates/transfer/src/handshake.rs`. The binary and
  legacy handshakes now tag out-of-range-version errors via
  `protocol::protocol_violation(...)`, which the core exit-code mapper
  (`ExitCode::from_io_error`) already turns into `RERR_PROTOCOL` (2). The message
  text and `io::ErrorKind::InvalidData` are unchanged, so the wire behaviour and
  diagnostics are byte-identical; only the exit code changes. Both the version
  ceiling check (`ProtocolVersion::try_from`, the effective binary trigger since
  the supported range is `[28,32]`), the zero-version guard, and the defensive
  `select_highest_mutual` sites are tagged. A truncated stream (`read_exact`
  short read) keeps its `RERR_STREAMIO` mapping.
- **SSH driver consumer:** `crates/core/src/client/remote/ssh_transfer/drive.rs`
  computes its handshake-failure base code manually (EOF -> 12, else -> 5). It now
  also recognises the tagged protocol violation and reports `RERR_PROTOCOL` (2).
  The other two SSH transports (`async_ssh_transport`, `embedded_ssh_transfer`)
  already route through `ExitCode::from_io_error` and needed no change.
- **Daemon module-list path (10 -> 2):** `crates/core/src/client/module_list/errors.rs`.
  `handshake_error_to_client_error` previously only special-cased malformed
  greetings; an out-of-range or no-mutual `NegotiationError` fell through to the
  `socket_error` fallback (`RERR_SOCKETIO`, 10). It now maps
  `NegotiationError::UnsupportedVersion` and `NegotiationError::NoMutualProtocol`
  to `RERR_PROTOCOL` (2), matching upstream. Genuine transport failures (non-
  `NegotiationError`) still fall through to the socket-error path unchanged.

## Message fidelity note

For the `UnsupportedVersion` case the daemon error text is
`NegotiationError`'s Display, which is byte-identical to upstream's
`compat.c:621-622` two-line message. The `NoMutualProtocol` case carries oc's
existing diagnostic (peer offered / we support); only its exit code is corrected
to 2. No daemon sub-case required a code other than 2: the greeting version-range
condition maps to the same `setup_protocol()` `RERR_PROTOCOL` guard upstream.
Malformed-greeting and `@ERROR` payload sub-cases keep their existing codes.

## Tests

- SSH: binary out-of-range (99), zero version, and legacy (`@RSYNCD: 27.0`)
  handshakes now assert the error is tagged as a `ProtocolViolation` (maps to
  exit 2, not 12), plus a regression guard that an in-range version (30) still
  negotiates.
- Daemon: `UnsupportedVersion` and `NoMutualProtocol` map to exit 2; a
  `ConnectionReset` transport error is not reclassified as a protocol error.
