### PR TITLE
fix(protocol): correct RERR exit codes for xattr/acl/nsec/multiplex overruns

### DIFF
--- a/crates/protocol/src/acl/wire/recv.rs
+++ b/crates/protocol/src/acl/wire/recv.rs
@@ -25,12 +25,16 @@ use super::types::{AclType, RecvAclResult};
 ///
 /// Mirrors `recv_ida_entries()` in `acls.c` lines 697-729.
 pub fn recv_ida_entries<R: Read + ?Sized>(reader: &mut R) -> io::Result<(IdaEntries, u8)> {
+    // upstream: acls.c:700 recv_ida_entries() reads the count via
+    // read_varint_bounded(f, 0, MAX_WIRE_ACL_COUNT, "ACL count") (io.c:1904-1913),
+    // which aborts with exit_cleanup(RERR_PROTOCOL) (exit 2) on an over-range
+    // value. Tag it so the core exit-code mapper yields RERR_PROTOCOL, not the
+    // RERR_STREAMIO (12) that a bare InvalidData maps to.
     let count = read_varint(reader)? as usize;
     if count > MAX_WIRE_ACL_ENTRIES {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("ACL entry count {count} exceeds maximum {MAX_WIRE_ACL_ENTRIES}"),
-        ));
+        return Err(crate::protocol_violation::protocol_violation(format!(
+            "ACL entry count {count} exceeds maximum {MAX_WIRE_ACL_ENTRIES}"
+        )));
     }
     let mut entries = IdaEntries::with_capacity(count);
     let mut computed_mask: u8 = 0;

--- a/crates/protocol/src/acl/wire/tests.rs
+++ b/crates/protocol/src/acl/wire/tests.rs
@@ -249,6 +249,31 @@ fn recv_ida_entries_eof_reading_count() {
 }
 
 #[test]
+fn recv_ida_entries_exceeds_max_count_is_protocol_violation() {
+    use crate::acl::constants::MAX_WIRE_ACL_ENTRIES;
+    use crate::varint::write_varint;
+
+    // A hostile ACL entry count above the cap. upstream: acls.c:700
+    // recv_ida_entries() reads it via read_varint_bounded(f, 0,
+    // MAX_WIRE_ACL_COUNT, "ACL count") (io.c:1904-1913), which
+    // exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun. WHY it matters: a drop-in
+    // tool must exit 2 (protocol incompatibility) here, not RERR_STREAMIO (12);
+    // the ProtocolViolation tag is what makes the core mapper reproduce exit 2.
+    let mut buf = Vec::new();
+    write_varint(&mut buf, (MAX_WIRE_ACL_ENTRIES as i32) + 1).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let err = recv_ida_entries(&mut cursor).expect_err("oversized ACL count must be rejected");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized ACL count must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
+}
+
+#[test]
 fn recv_ida_entries_eof_reading_id() {
     // Count says 1 entry but no id follows
     let data = vec![0x01]; // count = 1

--- a/crates/protocol/src/flist/read/metadata.rs
+++ b/crates/protocol/src/flist/read/metadata.rs
@@ -17,6 +17,14 @@ use crate::varint::read_varint;
 
 use super::FileListReader;
 
+/// Maximum wire-encoded nanosecond value accepted for `modtime_nsec`.
+///
+/// upstream: rsync.h `#define MAX_WIRE_NSEC 999999999` - the inclusive upper
+/// bound `recv_file_entry()` passes to `read_varint_bounded()` (flist.c:855/857)
+/// when decoding the sub-second modification time. A wire value outside
+/// `[0, MAX_WIRE_NSEC]` is a protocol violation (`RERR_PROTOCOL`, exit 2).
+const MAX_WIRE_NSEC: i32 = 999_999_999;
+
 /// Decoded metadata fields for a single file entry.
 ///
 /// Fields are `Option` when conditionally present based on protocol options
@@ -79,8 +87,19 @@ impl FileListReader {
         };
 
         // 2. Read nanoseconds if flag set (protocol 31+)
+        // upstream: flist.c:855/857 recv_file_entry() reads modtime_nsec via
+        // read_varint_bounded(f, 0, MAX_WIRE_NSEC, "modtime_nsec")
+        // (io.c:1904-1913), which aborts with exit_cleanup(RERR_PROTOCOL)
+        // (exit 2) on a value outside [0, MAX_WIRE_NSEC]. Mirror that bound so a
+        // hostile nsec yields RERR_PROTOCOL rather than being accepted unchecked.
         let nsec = if flags.mod_nsec() {
-            crate::read_varint(reader)? as u32
+            let raw = read_varint(reader)?;
+            if !(0..=MAX_WIRE_NSEC).contains(&raw) {
+                return Err(crate::protocol_violation::protocol_violation(format!(
+                    "modtime_nsec {raw} out of range: not in [0,{MAX_WIRE_NSEC}]"
+                )));
+            }
+            raw as u32
         } else {
             0
         };
@@ -273,4 +292,69 @@ fn read_owner_id<R: Read + ?Sized>(
     };
 
     Ok((id, name))
+}
+
+#[cfg(test)]
+mod nsec_tests {
+    use std::io::Cursor;
+
+    use crate::ProtocolVersion;
+    use crate::flist::flags::{FileFlags, XMIT_MOD_NSEC, XMIT_SAME_TIME};
+    use crate::varint::write_varint;
+
+    use super::{FileListReader, MAX_WIRE_NSEC};
+
+    fn reader() -> FileListReader {
+        FileListReader::new(ProtocolVersion::try_from(31u8).unwrap())
+    }
+
+    // SAME_TIME reuses the previous second (no mtime field on the wire) and
+    // MOD_NSEC signals the sub-second varint is present - the minimal flag set
+    // that drives read_metadata straight to the nsec read.
+    fn nsec_flags() -> FileFlags {
+        FileFlags::new(XMIT_SAME_TIME, XMIT_MOD_NSEC)
+    }
+
+    #[test]
+    fn modtime_nsec_in_range_still_parses() {
+        // WHY: the new bound must not over-reject legitimate sub-second mtimes.
+        // A value at exactly MAX_WIRE_NSEC is the largest upstream accepts
+        // (flist.c:855/857 read_varint_bounded(f, 0, MAX_WIRE_NSEC, ...)).
+        let mut buf = Vec::new();
+        write_varint(&mut buf, MAX_WIRE_NSEC).unwrap();
+        // read_metadata continues to the 4-byte mode after nsec; supply a
+        // regular-file mode so the entry decodes cleanly.
+        buf.extend_from_slice(&0o100644i32.to_le_bytes());
+
+        let mut cursor = Cursor::new(buf);
+        let meta = reader()
+            .read_metadata(&mut cursor, nsec_flags())
+            .expect("in-range nsec must parse");
+        assert_eq!(meta.nsec, MAX_WIRE_NSEC as u32);
+    }
+
+    #[test]
+    fn modtime_nsec_out_of_range_is_protocol_violation() {
+        // WHY: upstream flist.c:855/857 bounds modtime_nsec to [0, MAX_WIRE_NSEC]
+        // via read_varint_bounded (io.c:1904-1913), which
+        // exit_cleanup(RERR_PROTOCOL) (exit 2) on an out-of-range value. A
+        // drop-in tool must exit 2 (protocol incompatibility) on a hostile nsec,
+        // never accept it unchecked nor exit RERR_STREAMIO (12); the
+        // ProtocolViolation tag is what makes the core mapper reproduce exit 2.
+        for raw in [MAX_WIRE_NSEC + 1, -1] {
+            let mut buf = Vec::new();
+            write_varint(&mut buf, raw).unwrap();
+            let mut cursor = Cursor::new(buf);
+            // MetadataResult is not Debug, so avoid expect_err/unwrap_err.
+            let Err(err) = reader().read_metadata(&mut cursor, nsec_flags()) else {
+                panic!("out-of-range nsec must be rejected");
+            };
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+            assert!(
+                err.get_ref()
+                    .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+                "out-of-range modtime_nsec must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+            );
+        }
+    }
 }

--- a/crates/protocol/src/multiplex/codec.rs
+++ b/crates/protocol/src/multiplex/codec.rs
@@ -294,7 +294,19 @@ mod tests {
         let result = codec.decode(&mut buf);
         assert!(result.is_err());
         let err = result.unwrap_err();
+        // upstream: io.c:1667 - an incoming multiplexed message whose byte count
+        // exceeds the receive buffer prints "multiplexing overflow" and calls
+        // exit_cleanup(RERR_STREAMIO) (exit 12), a stream error, NOT a protocol
+        // violation (2). WHY it matters: a drop-in tool must classify an
+        // oversized wire frame as RERR_STREAMIO. InvalidData maps to RERR_STREAMIO
+        // in the core mapper, so the error must NOT carry the ProtocolViolation
+        // tag (which would wrongly downgrade the exit code to RERR_PROTOCOL=2).
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.get_ref()
+                .is_none_or(|e| !e.is::<crate::protocol_violation::ProtocolViolation>()),
+            "oversized multiplex frame must map to RERR_STREAMIO (12), not ProtocolViolation (2)"
+        );
     }
 
     #[test]

--- a/crates/protocol/src/xattr/wire/decode.rs
+++ b/crates/protocol/src/xattr/wire/decode.rs
@@ -53,52 +53,56 @@ use super::types::{RecvXattrResult, XattrDefinition, XattrSet};
 /// See `xattrs.c:receive_xattr()` lines 790-860 - the entry-reading loop
 /// after `ndx == 0` and before `rsync_xal_store()`.
 pub fn read_xattr_definitions<R: Read>(reader: &mut R) -> io::Result<XattrSet> {
+    // upstream: xattrs.c:793 receive_xattr() reads the count via
+    // read_varint_bounded(f, 0, MAX_WIRE_XATTR_COUNT, ...) (io.c:1904-1913),
+    // which aborts with exit_cleanup(RERR_PROTOCOL) (exit 2) on a negative or
+    // over-range value. Tag both rejections so the core exit-code mapper yields
+    // RERR_PROTOCOL, not the RERR_STREAMIO (12) that a bare InvalidData maps to.
     let count = read_varint(reader)?;
     if count < 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("negative xattr count: {count}"),
-        ));
+        return Err(crate::protocol_violation::protocol_violation(format!(
+            "negative xattr count: {count}"
+        )));
     }
     let count = count as usize;
     if count > MAX_WIRE_XATTR_COUNT {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("xattr count {count} exceeds maximum {MAX_WIRE_XATTR_COUNT}"),
-        ));
+        return Err(crate::protocol_violation::protocol_violation(format!(
+            "xattr count {count} exceeds maximum {MAX_WIRE_XATTR_COUNT}"
+        )));
     }
 
     let mut entries = Vec::with_capacity(count);
 
     for _ in 0..count {
-        // upstream: name_len = read_varint(f); datum_len = read_varint(f)
+        // upstream: name_len = read_varint_size(f, MAX_WIRE_XATTR_NAMELEN, ...);
+        // datum_len = read_varint_size(f, MAX_WIRE_XATTR_DATALEN, ...) at
+        // xattrs.c:802-803. read_varint_size (io.c:1917-1926) aborts with
+        // exit_cleanup(RERR_PROTOCOL) (exit 2) on a negative or over-max value,
+        // so tag these to reproduce exit 2 rather than RERR_STREAMIO (12).
         let name_len = read_varint(reader)? as usize;
         let datum_len = read_varint(reader)? as usize;
 
         if name_len > MAX_WIRE_XATTR_NAME_LEN {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("xattr name length {name_len} exceeds maximum {MAX_WIRE_XATTR_NAME_LEN}"),
-            ));
+            return Err(crate::protocol_violation::protocol_violation(format!(
+                "xattr name length {name_len} exceeds maximum {MAX_WIRE_XATTR_NAME_LEN}"
+            )));
         }
         if datum_len > MAX_WIRE_XATTR_VALUE_LEN {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "xattr value length {datum_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
-                ),
-            ));
+            return Err(crate::protocol_violation::protocol_violation(format!(
+                "xattr value length {datum_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
+            )));
         }
 
         let mut name = vec![0u8; name_len];
         reader.read_exact(&mut name)?;
 
-        // upstream: name_len < 1 || name[name_len-1] != '\0' -> out_of_memory("receive_xattr")
+        // upstream: xattrs.c:811-814 receive_xattr() - `name_len < 1 ||
+        // name[name_len-1] != '\0'` prints "Invalid xattr name received" and
+        // calls exit_cleanup(RERR_FILEIO) (exit 11), a file-IO error, not a
+        // protocol (2) or stream (12) error. io::Error::other maps to
+        // RERR_FILEIO via the core exit-code mapper's catch-all arm.
         if name.is_empty() || name[name_len - 1] != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "invalid xattr name: missing trailing NUL",
-            ));
+            return Err(io::Error::other("invalid xattr name: missing trailing NUL"));
         }
 
         // Strip the NUL terminator for internal storage
@@ -154,32 +158,32 @@ pub fn recv_xattr<R: Read>(reader: &mut R) -> io::Result<RecvXattrResult> {
         return Ok(RecvXattrResult::CacheHit(ndx as u32));
     }
 
+    // upstream: xattrs.c:793 read_varint_bounded(f, 0, MAX_WIRE_XATTR_COUNT,
+    // ...) aborts with exit_cleanup(RERR_PROTOCOL) (exit 2) on an over-range
+    // count; tag it so the mapper yields RERR_PROTOCOL, not RERR_STREAMIO (12).
     let count = read_varint(reader)? as usize;
     if count > MAX_WIRE_XATTR_COUNT {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("xattr count {count} exceeds maximum {MAX_WIRE_XATTR_COUNT}"),
-        ));
+        return Err(crate::protocol_violation::protocol_violation(format!(
+            "xattr count {count} exceeds maximum {MAX_WIRE_XATTR_COUNT}"
+        )));
     }
     let mut list = XattrList::new();
 
     for _ in 0..count {
+        // upstream: name_len/datum_len via read_varint_size (xattrs.c:802-803,
+        // io.c:1917-1926) -> exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun.
         let name_len = read_varint(reader)? as usize;
         let datum_len = read_varint(reader)? as usize;
 
         if name_len > MAX_WIRE_XATTR_NAME_LEN {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("xattr name length {name_len} exceeds maximum {MAX_WIRE_XATTR_NAME_LEN}"),
-            ));
+            return Err(crate::protocol_violation::protocol_violation(format!(
+                "xattr name length {name_len} exceeds maximum {MAX_WIRE_XATTR_NAME_LEN}"
+            )));
         }
         if datum_len > MAX_WIRE_XATTR_VALUE_LEN {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "xattr value length {datum_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
-                ),
-            ));
+            return Err(crate::protocol_violation::protocol_violation(format!(
+                "xattr value length {datum_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
+            )));
         }
 
         // upstream: name_len includes a trailing NUL terminator on the wire
@@ -260,12 +264,14 @@ pub fn recv_xattr_request<R: Read>(reader: &mut R, list: &mut XattrList) -> io::
 pub fn recv_xattr_values<R: Read>(reader: &mut R, list: &mut XattrList) -> io::Result<()> {
     for entry in list.entries_mut() {
         if entry.state().needs_request() {
+            // upstream: xattrs.c:752 recv_xattr_request() reads the resolved
+            // datum_len via read_varint_size(f_in, MAX_WIRE_XATTR_DATALEN, ...)
+            // (io.c:1917-1926) -> exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun.
             let len = read_varint(reader)? as usize;
             if len > MAX_WIRE_XATTR_VALUE_LEN {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("xattr value length {len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"),
-                ));
+                return Err(crate::protocol_violation::protocol_violation(format!(
+                    "xattr value length {len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
+                )));
             }
             let mut value = vec![0u8; len];
             reader.read_exact(&mut value)?;

--- a/crates/protocol/src/xattr/wire/tests.rs
+++ b/crates/protocol/src/xattr/wire/tests.rs
@@ -1004,6 +1004,17 @@ fn read_definitions_exceeds_max_count() {
     let err = result.unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("exceeds maximum"));
+    // WHY: upstream reads these counts/lengths via read_varint_bounded /
+    // read_varint_size (xattrs.c:793,802-803; io.c:1904-1926), which
+    // exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun. The ProtocolViolation
+    // tag must survive so the core exit-code mapper reproduces exit 2, not the
+    // RERR_STREAMIO (12) a bare InvalidData maps to - a drop-in tool must
+    // distinguish a hostile wire value from a genuinely broken stream.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized xattr wire value must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
 }
 
 #[test]
@@ -1021,6 +1032,17 @@ fn read_definitions_exceeds_max_name_len() {
     let err = result.unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("exceeds maximum"));
+    // WHY: upstream reads these counts/lengths via read_varint_bounded /
+    // read_varint_size (xattrs.c:793,802-803; io.c:1904-1926), which
+    // exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun. The ProtocolViolation
+    // tag must survive so the core exit-code mapper reproduces exit 2, not the
+    // RERR_STREAMIO (12) a bare InvalidData maps to - a drop-in tool must
+    // distinguish a hostile wire value from a genuinely broken stream.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized xattr wire value must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
 }
 
 #[test]
@@ -1038,6 +1060,17 @@ fn read_definitions_exceeds_max_value_len() {
     let err = result.unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("exceeds maximum"));
+    // WHY: upstream reads these counts/lengths via read_varint_bounded /
+    // read_varint_size (xattrs.c:793,802-803; io.c:1904-1926), which
+    // exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun. The ProtocolViolation
+    // tag must survive so the core exit-code mapper reproduces exit 2, not the
+    // RERR_STREAMIO (12) a bare InvalidData maps to - a drop-in tool must
+    // distinguish a hostile wire value from a genuinely broken stream.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized xattr wire value must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
 }
 
 #[test]
@@ -1055,6 +1088,17 @@ fn recv_xattr_exceeds_max_count() {
     let err = result.unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("exceeds maximum"));
+    // WHY: upstream reads these counts/lengths via read_varint_bounded /
+    // read_varint_size (xattrs.c:793,802-803; io.c:1904-1926), which
+    // exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun. The ProtocolViolation
+    // tag must survive so the core exit-code mapper reproduces exit 2, not the
+    // RERR_STREAMIO (12) a bare InvalidData maps to - a drop-in tool must
+    // distinguish a hostile wire value from a genuinely broken stream.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized xattr wire value must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
 }
 
 #[test]
@@ -1073,6 +1117,17 @@ fn recv_xattr_exceeds_max_name_len() {
     let err = result.unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("exceeds maximum"));
+    // WHY: upstream reads these counts/lengths via read_varint_bounded /
+    // read_varint_size (xattrs.c:793,802-803; io.c:1904-1926), which
+    // exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun. The ProtocolViolation
+    // tag must survive so the core exit-code mapper reproduces exit 2, not the
+    // RERR_STREAMIO (12) a bare InvalidData maps to - a drop-in tool must
+    // distinguish a hostile wire value from a genuinely broken stream.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized xattr wire value must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
 }
 
 #[test]
@@ -1091,6 +1146,17 @@ fn recv_xattr_exceeds_max_value_len() {
     let err = result.unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("exceeds maximum"));
+    // WHY: upstream reads these counts/lengths via read_varint_bounded /
+    // read_varint_size (xattrs.c:793,802-803; io.c:1904-1926), which
+    // exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun. The ProtocolViolation
+    // tag must survive so the core exit-code mapper reproduces exit 2, not the
+    // RERR_STREAMIO (12) a bare InvalidData maps to - a drop-in tool must
+    // distinguish a hostile wire value from a genuinely broken stream.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized xattr wire value must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
 }
 
 #[test]
@@ -1113,6 +1179,42 @@ fn recv_xattr_values_exceeds_max_value_len() {
     let err = result.unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(err.to_string().contains("exceeds maximum"));
+    // WHY: upstream reads these counts/lengths via read_varint_bounded /
+    // read_varint_size (xattrs.c:793,802-803; io.c:1904-1926), which
+    // exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun. The ProtocolViolation
+    // tag must survive so the core exit-code mapper reproduces exit 2, not the
+    // RERR_STREAMIO (12) a bare InvalidData maps to - a drop-in tool must
+    // distinguish a hostile wire value from a genuinely broken stream.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized xattr wire value must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
+}
+
+#[test]
+fn read_definitions_missing_nul_maps_to_fileio() {
+    // A literal xattr name whose declared bytes lack the trailing NUL. upstream:
+    // xattrs.c:811-814 receive_xattr() rejects this with
+    // exit_cleanup(RERR_FILEIO) (exit 11) - a file-IO error, NOT a protocol (2)
+    // or stream (12) error. WHY it matters: a drop-in tool must reproduce
+    // upstream's exact exit classification. io::Error::other maps to RERR_FILEIO
+    // via the core mapper's catch-all, and the error must NOT carry the
+    // ProtocolViolation tag (which would wrongly downgrade the exit code to 2).
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 1).unwrap(); // count
+    write_varint(&mut buf, 3).unwrap(); // name_len (the 3 bytes hold no NUL)
+    write_varint(&mut buf, 0).unwrap(); // datum_len
+    buf.extend_from_slice(b"abc");
+
+    let mut cursor = Cursor::new(buf);
+    let err = read_xattr_definitions(&mut cursor).expect_err("missing NUL must be rejected");
+    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    assert!(
+        err.get_ref()
+            .is_none_or(|e| !e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "missing-NUL must map to RERR_FILEIO (11), never ProtocolViolation (2)"
+    );
 }
 
 /// Pins the literal-xattr wire layout to exact bytes and asserts it is


### PR DESCRIPTION
## Summary

Correct the RERR_* exit codes emitted by six wire-decode reject sites in the
`protocol` crate so a hostile or malformed peer produces the same exit code the
upstream C receiver would (`errcode.h`: `RERR_PROTOCOL=2`, `RERR_FILEIO=11`,
`RERR_STREAMIO=12`). Previously these sites returned a bare
`io::ErrorKind::InvalidData` (mapped to `RERR_STREAMIO`/12) or left a field
unbounded; upstream reaches `exit_cleanup(RERR_PROTOCOL)` at each overrun.

This continues the "bounded wire-read overrun -> RERR_PROTOCOL" pattern already
established for the varint helpers and delete-stats reader, reusing the same
`protocol_violation()` marker so the core exit-code mapper reproduces exit 2.
No new mechanism is introduced.

## Sites fixed

| # | Site | Condition | Old code | New code | Upstream |
|---|------|-----------|----------|----------|----------|
| 96 | `xattr/wire/decode.rs` `read_xattr_definitions` / `recv_xattr` | xattr count negative or > cap | StreamIo (12) | Protocol (2) | `xattrs.c:793` `read_varint_bounded` -> `io.c:1904-1913` |
| 97 | `xattr/wire/decode.rs` (both fns) | xattr name_len > cap | StreamIo (12) | Protocol (2) | `xattrs.c:802` `read_varint_size` -> `io.c:1917-1926` |
| 98 | `xattr/wire/decode.rs` (both fns + `recv_xattr_values`) | xattr datum_len > cap | StreamIo (12) | Protocol (2) | `xattrs.c:803,752` `read_varint_size` -> `io.c:1917-1926` |
| 98b | `xattr/wire/decode.rs` `read_xattr_definitions` | xattr name missing trailing NUL | StreamIo (12) | FileIo (11) | `xattrs.c:811-814` `exit_cleanup(RERR_FILEIO)` |
| 99 | `acl/wire/recv.rs` `recv_ida_entries` | ACL entry count > cap | StreamIo (12) | Protocol (2) | `acls.c:700` `read_varint_bounded` -> `io.c:1904-1913` |
| 100 | `flist/read/metadata.rs` `read_metadata` | modtime_nsec out of `[0, MAX_WIRE_NSEC]` | (unchecked) | Protocol (2) | `flist.c:855/857` `read_varint_bounded(f, 0, MAX_WIRE_NSEC, ...)` |
| 95 | `multiplex/codec.rs` `Decoder::decode` | received frame payload > cap | StreamIo (12) | StreamIo (12) — already correct | `io.c:1667` `exit_cleanup(RERR_STREAMIO)` |

## Notes on two divergences from the original request

- **#98 missing-NUL is RERR_FILEIO (11), not RERR_MALLOC (22).** The upstream
  3.4.4 receiver (`xattrs.c:811-814`) prints "Invalid xattr name received
  (missing trailing \0)" and calls `exit_cleanup(RERR_FILEIO)`. The
  `RERR_MALLOC` path in `receive_xattr` is the `overflow_exit()` /
  allocation-failure guard (`xattrs.c:806-808`), which is unreachable here
  because the wire caps bound `name_len + datum_len` far below `SIZE_MAX`.
  We mirror upstream exactly: missing-NUL -> `RERR_FILEIO` (11) via
  `io::Error::other`, overrun -> `RERR_PROTOCOL` (2).

- **#95 was already correct.** The reachable wire-receive oversized check
  (`MultiplexCodec::decode`) already returns `InvalidData` -> `RERR_STREAMIO`
  (12), matching `io.c:1667`. The remaining `InvalidInput` oversized sites are
  send/construct-side guards, which do not correspond to the upstream receive
  overflow. No code change; a regression assertion was added to pin the
  StreamIo classification (must not be tagged as a protocol violation).

## Caps unchanged

Only the exit code emitted when a cap is exceeded changes. The numeric
`MAX_WIRE_*` cap values are untouched; aligning them with upstream is a separate
functional decision tracked independently.

## Tests

Each site has a test asserting the corrected exit-code class, with a comment
stating why the specific code matters for drop-in fidelity:

- xattr count/name_len/datum_len overruns (both decode functions and the
  value-resolution path): tagged `ProtocolViolation` (exit 2).
- xattr missing-NUL: `ErrorKind::Other` and explicitly *not* tagged
  `ProtocolViolation` (exit 11).
- ACL entry-count overrun: tagged `ProtocolViolation` (exit 2).
- modtime_nsec: an in-range value at exactly `MAX_WIRE_NSEC` still parses (no
  over-rejection); out-of-range and negative values are tagged
  `ProtocolViolation` (exit 2).
- multiplex oversized received frame: `InvalidData`, not tagged
  `ProtocolViolation` (exit 12).

Verified: `cargo nextest run -p protocol --all-features` (targeted), plus
`cargo fmt` and `cargo clippy -p protocol --all-targets --all-features --no-deps
-- -D warnings` clean.
