### PR TITLE
feat(transport): honor --timeout with SSH stall detection

### DIFF
--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -50,6 +50,7 @@ pub struct SshCommand {
     keepalive: bool,
     options: Vec<OsString>,
     connect_timeout: Option<Duration>,
+    io_timeout: Option<Duration>,
     remote_command: Vec<OsString>,
     envs: Vec<(OsString, OsString)>,
     target_override: Option<OsString>,
@@ -70,6 +71,7 @@ impl SshCommand {
             bind_address: None,
             keepalive: true,
             connect_timeout: Some(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS)),
+            io_timeout: None,
             options: Vec::new(),
             remote_command: Vec::new(),
             envs: Vec::new(),
@@ -147,6 +149,26 @@ impl SshCommand {
     /// The default is `Some(Duration::from_secs(30))`.
     pub const fn set_connect_timeout(&mut self, timeout: Option<Duration>) -> &mut Self {
         self.connect_timeout = timeout;
+        self
+    }
+
+    /// Sets the data-channel I/O timeout (the negotiated `--timeout`).
+    ///
+    /// When `Some(non-zero)`, the spawned [`SshConnection`] arms a stall
+    /// watchdog that aborts the transfer with a timeout error if no read or
+    /// write makes progress for that long, mirroring upstream rsync's uniform
+    /// `io_timeout` enforcement across transports. Keepalive writes emitted by
+    /// the transfer layer reset the progress clock, so a legitimate lull does
+    /// not trip the timeout. `None` or `Some(0)` disables stall detection,
+    /// matching upstream's `io_timeout == 0` off state.
+    ///
+    /// Unlike [`set_connect_timeout`](Self::set_connect_timeout), this is not
+    /// rendered as an `ssh` command-line option: it governs the parent-side
+    /// stall detector over the child's stdio pipes.
+    ///
+    /// upstream: io.c `set_io_timeout` / `check_timeout`; errcode.h `RERR_TIMEOUT`.
+    pub const fn set_io_timeout(&mut self, timeout: Option<Duration>) -> &mut Self {
+        self.io_timeout = timeout;
         self
     }
 
@@ -397,6 +419,7 @@ impl SshCommand {
             stdout,
             stderr_channel,
             self.connect_timeout,
+            self.io_timeout,
         ))
     }
 
@@ -623,6 +646,14 @@ impl SshCommand {
     #[cfg(test)]
     pub(crate) fn command_parts_for_testing(&self) -> (OsString, Vec<OsString>) {
         self.command_parts()
+    }
+
+    /// Returns the configured data-channel I/O timeout. Test-only accessor used
+    /// to assert the negotiated `--timeout` is threaded into the transport (it
+    /// governs the parent-side stall detector, not the rendered argv).
+    #[cfg(test)]
+    pub(crate) fn io_timeout_for_testing(&self) -> Option<Duration> {
+        self.io_timeout
     }
 }
 

--- a/crates/rsync_io/src/ssh/connect.rs
+++ b/crates/rsync_io/src/ssh/connect.rs
@@ -107,6 +107,12 @@ pub struct SshConnectConfig {
     /// Connection establishment timeout. `None` disables the
     /// `-o ConnectTimeout` injection and the in-process watchdog.
     pub connect_timeout: Option<Duration>,
+    /// Data-channel I/O timeout (the negotiated `--timeout`). When
+    /// `Some(non-zero)`, the spawned connection arms a stall watchdog that
+    /// aborts the transfer with a timeout error after that much idle time,
+    /// mirroring upstream's uniform `io_timeout` enforcement. `None` or
+    /// `Some(0)` disables stall detection.
+    pub io_timeout: Option<Duration>,
     /// Keepalive parameters. `None` disables `-o ServerAliveInterval` and
     /// `-o ServerAliveCountMax` injection.
     pub keepalive: Option<KeepAliveConfig>,
@@ -118,6 +124,7 @@ impl Default for SshConnectConfig {
     fn default() -> Self {
         Self {
             connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),
+            io_timeout: None,
             keepalive: Some(KeepAliveConfig::default()),
             remote_command: Vec::new(),
         }
@@ -137,6 +144,17 @@ impl SshConnectConfig {
     #[must_use]
     pub const fn with_connect_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.connect_timeout = timeout;
+        self
+    }
+
+    /// Builder-style setter for [`SshConnectConfig::io_timeout`].
+    ///
+    /// Threads the negotiated `--timeout` into the SSH transport so a stalled
+    /// data channel aborts instead of hanging indefinitely. `None` or
+    /// `Some(0)` leaves stall detection disabled.
+    #[must_use]
+    pub const fn with_io_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.io_timeout = timeout;
         self
     }
 
@@ -200,6 +218,7 @@ pub(super) fn build_ssh_command(remote: &str, config: &SshConnectConfig) -> SshC
     }
 
     command.set_connect_timeout(config.connect_timeout);
+    command.set_io_timeout(config.io_timeout);
 
     if let Some(keepalive) = config.keepalive {
         let interval_secs = duration_to_secs_ceil(keepalive.interval);
@@ -260,10 +279,44 @@ mod tests {
     fn default_config_matches_builder_defaults() {
         let config = SshConnectConfig::new();
         assert_eq!(config.connect_timeout, Some(DEFAULT_CONNECT_TIMEOUT));
+        // Stall detection is off by default; the negotiated `--timeout` must be
+        // supplied explicitly via `with_io_timeout`.
+        assert_eq!(config.io_timeout, None);
         let keepalive = config.keepalive.expect("default keepalive present");
         assert_eq!(keepalive.interval, DEFAULT_KEEPALIVE_INTERVAL);
         assert_eq!(keepalive.max_failures, DEFAULT_KEEPALIVE_MAX_FAILURES);
         assert!(config.remote_command.is_empty());
+    }
+
+    #[test]
+    fn io_timeout_is_threaded_into_the_ssh_command() {
+        // Regression guard: SSH transfers previously dropped `--timeout`
+        // entirely. The negotiated value must reach the spawned command so the
+        // stall watchdog is armed with the effective deadline.
+        let timeout = Duration::from_secs(45);
+        let config = SshConnectConfig::new().with_io_timeout(Some(timeout));
+        assert_eq!(config.io_timeout, Some(timeout));
+
+        let command = build_ssh_command("user@example.com", &config);
+        assert_eq!(command.io_timeout_for_testing(), Some(timeout));
+
+        // The I/O timeout is a parent-side detector, not an `ssh` option, so it
+        // must not leak into the rendered argv.
+        let (_, args) = command.command_parts_for_testing();
+        let rendered = args_to_strings(&args);
+        assert!(
+            !rendered
+                .iter()
+                .any(|a| a.to_ascii_lowercase().contains("timeout=45")),
+            "io_timeout must not render as an ssh option: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn io_timeout_defaults_to_disabled_in_command() {
+        let config = SshConnectConfig::new();
+        let command = build_ssh_command("example.com", &config);
+        assert_eq!(command.io_timeout_for_testing(), None);
     }
 
     #[test]

--- a/crates/rsync_io/src/ssh/connection.rs
+++ b/crates/rsync_io/src/ssh/connection.rs
@@ -16,6 +16,56 @@ use std::time::Duration;
 use logging::debug_log;
 
 use super::aux_channel::BoxedStderrChannel;
+use super::stall::{IoStallWatchdog, StallHandle, effective_io_timeout};
+
+/// Applies stall detection to a completed read/write on a stall-tracked half.
+///
+/// Translates the watchdog's latched timeout into an [`io::ErrorKind::TimedOut`]
+/// error (mapped by `core` to `ExitCode::Timeout`, upstream `RERR_TIMEOUT`) and
+/// records forward progress on success so the shared clock is reset. When no
+/// timeout is configured the result passes through untouched.
+fn guard_io_result(stall: Option<&StallHandle>, res: io::Result<usize>) -> io::Result<usize> {
+    let Some(handle) = stall else {
+        return res;
+    };
+    // Checking after the (possibly blocking) call catches a watchdog that fired
+    // mid-read: the child was killed to unblock the pipe, so the raw result is
+    // an EOF or broken-pipe error that must surface as a timeout.
+    if handle.timed_out() {
+        return Err(handle.timeout_error());
+    }
+    if let Ok(n) = &res {
+        handle.record(*n);
+    }
+    res
+}
+
+/// Arms the data-phase stall watchdog for a shared child handle.
+///
+/// Returns `(None, None)` when `io_timeout` is disabled. Otherwise arms a
+/// watchdog whose abort action kills the child - closing its pipe endpoints and
+/// unblocking any pending read/write - so the stalled I/O returns promptly and
+/// the read/write half can surface a timeout error.
+fn arm_io_stall(
+    io_timeout: Option<Duration>,
+    shared_child: &Arc<Mutex<Option<Child>>>,
+) -> (Option<IoStallWatchdog>, Option<StallHandle>) {
+    match effective_io_timeout(io_timeout) {
+        Some(timeout) => {
+            let kill_child = Arc::clone(shared_child);
+            let abort = Box::new(move || {
+                if let Ok(mut guard) = kill_child.lock() {
+                    if let Some(child) = guard.as_mut() {
+                        let _ = child.kill();
+                    }
+                }
+            });
+            let (watchdog, handle) = IoStallWatchdog::arm(timeout, abort);
+            (Some(watchdog), Some(handle))
+        }
+        None => (None, None),
+    }
+}
 
 /// Owns an active SSH subprocess and exposes its stdio handles.
 ///
@@ -36,6 +86,12 @@ pub struct SshConnection {
     stdout: Option<ChildStdout>,
     stderr_drain: Option<BoxedStderrChannel>,
     connect_watchdog: Option<ConnectWatchdog>,
+    /// Data-phase stall watchdog enforcing the negotiated `--timeout`. `None`
+    /// when the timeout is disabled (`0`/absent), matching upstream's off state.
+    io_stall_watchdog: Option<IoStallWatchdog>,
+    /// Progress/timeout handle consulted by the read and write paths. Shares
+    /// its clock and latch with [`Self::io_stall_watchdog`].
+    stall: Option<StallHandle>,
 }
 
 impl SshConnection {
@@ -49,22 +105,32 @@ impl SshConnection {
     /// given duration. Call
     /// [`cancel_connect_watchdog`](Self::cancel_connect_watchdog) after
     /// the remote rsync version greeting is received to disarm it.
+    ///
+    /// `io_timeout` is the negotiated `--timeout` applied to the data channel.
+    /// When `Some(non-zero)`, a stall watchdog is armed that aborts the transfer
+    /// with a timeout error if no read/write makes progress for that long. `0`
+    /// or `None` disables stall detection, matching upstream's `io_timeout == 0`
+    /// off state. upstream: io.c `set_io_timeout` / `check_timeout`.
     pub(super) fn new(
         child: Child,
         stdin: Option<ChildStdin>,
         stdout: ChildStdout,
         stderr_channel: Option<BoxedStderrChannel>,
         connect_timeout: Option<Duration>,
+        io_timeout: Option<Duration>,
     ) -> Self {
         let shared_child = Arc::new(Mutex::new(Some(child)));
         let connect_watchdog =
             connect_timeout.map(|timeout| ConnectWatchdog::arm(timeout, Arc::clone(&shared_child)));
+        let (io_stall_watchdog, stall) = arm_io_stall(io_timeout, &shared_child);
         Self {
             child: shared_child,
             stdin,
             stdout: Some(stdout),
             stderr_drain: stderr_channel,
             connect_watchdog,
+            io_stall_watchdog,
+            stall,
         }
     }
 
@@ -193,25 +259,37 @@ impl SshConnection {
             io::Error::new(io::ErrorKind::BrokenPipe, "stdout has already been taken")
         })?;
 
-        let child = self
-            .child
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .take()
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "child process already taken")
-            })?;
+        {
+            let guard = self.child.lock().unwrap_or_else(|e| e.into_inner());
+            if guard.is_none() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "child process already taken",
+                ));
+            }
+        }
+        // Move the whole shared handle to the child owner so the stall watchdog
+        // (which holds a clone of this same `Arc`) can still reach the child to
+        // kill it on a timeout. Leaving an empty `Arc` behind keeps
+        // `SshConnection::Drop` from reaping the child we just handed off.
+        let child = std::mem::replace(&mut self.child, Arc::new(Mutex::new(None)));
 
         let stderr_drain = self.stderr_drain.take();
         let connect_watchdog = self.connect_watchdog.take();
+        let io_stall_watchdog = self.io_stall_watchdog.take();
+        let stall = self.stall.take();
 
         Ok((
-            SshReader { stdout },
-            SshWriter { stdin },
+            SshReader {
+                stdout,
+                stall: stall.clone(),
+            },
+            SshWriter { stdin, stall },
             SshChildHandle {
                 child,
                 stderr_drain,
                 connect_watchdog,
+                io_stall_watchdog,
             },
         ))
     }
@@ -221,11 +299,14 @@ impl SshConnection {
 #[derive(Debug)]
 pub struct SshReader {
     stdout: ChildStdout,
+    /// Shared stall handle; `None` when `--timeout` is disabled.
+    stall: Option<StallHandle>,
 }
 
 impl Read for SshReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.stdout.read(buf)
+        let res = self.stdout.read(buf);
+        guard_io_result(self.stall.as_ref(), res)
     }
 }
 
@@ -233,11 +314,14 @@ impl Read for SshReader {
 #[derive(Debug)]
 pub struct SshWriter {
     stdin: ChildStdin,
+    /// Shared stall handle; `None` when `--timeout` is disabled.
+    stall: Option<StallHandle>,
 }
 
 impl Write for SshWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.stdin.write(buf)
+        let res = self.stdin.write(buf);
+        guard_io_result(self.stall.as_ref(), res)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -394,9 +478,14 @@ impl Drop for ConnectWatchdog {
 /// to process stderr. Collected output is retrievable via
 /// [`stderr_output`](Self::stderr_output).
 pub struct SshChildHandle {
-    child: Child,
+    /// Shared with the stall watchdog so both can reach the child; the watchdog
+    /// kills it on an I/O timeout, while `wait`/`Drop` reap it normally.
+    child: Arc<Mutex<Option<Child>>>,
     stderr_drain: Option<BoxedStderrChannel>,
     connect_watchdog: Option<ConnectWatchdog>,
+    /// Data-phase stall watchdog transferred here on `split`. Dropped/cancelled
+    /// before the child is reaped so it cannot fire during teardown.
+    io_stall_watchdog: Option<IoStallWatchdog>,
 }
 
 impl std::fmt::Debug for SshChildHandle {
@@ -416,6 +505,13 @@ impl std::fmt::Debug for SshChildHandle {
                     .connect_watchdog
                     .as_ref()
                     .map(|_| "ConnectWatchdog(armed)"),
+            )
+            .field(
+                "io_stall_watchdog",
+                &self
+                    .io_stall_watchdog
+                    .as_ref()
+                    .map(|_| "IoStallWatchdog(armed)"),
             )
             .finish()
     }
@@ -450,12 +546,32 @@ impl SshChildHandle {
             .map_or_else(Vec::new, |drain| drain.collected())
     }
 
+    /// Reaps the shared child handle, waiting for it to exit.
+    ///
+    /// Returns an error if the child was already taken by a prior wait/drop.
+    fn take_and_wait_child(&mut self) -> io::Result<ExitStatus> {
+        let mut guard = self.child.lock().unwrap_or_else(|e| e.into_inner());
+        match guard.take() {
+            Some(mut child) => {
+                drop(guard);
+                child.wait()
+            }
+            None => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "child process already taken",
+            )),
+        }
+    }
+
     /// Waits for the subprocess to exit.
     ///
     /// Joins the stderr drain thread after the child exits to ensure all
     /// error output has been forwarded.
     pub fn wait(mut self) -> io::Result<ExitStatus> {
-        let status = self.child.wait();
+        // Cancel stall detection before reaping so it cannot kill the child
+        // during a legitimate final lull.
+        drop(self.io_stall_watchdog.take());
+        let status = self.take_and_wait_child();
         if let Some(ref drain) = self.stderr_drain {
             drain.shutdown_read();
         }
@@ -471,7 +587,8 @@ impl SshChildHandle {
     /// into a single call, ensuring all stderr is captured before the handle
     /// is consumed.
     pub fn wait_with_stderr(mut self) -> io::Result<(ExitStatus, Vec<u8>)> {
-        let status = self.child.wait();
+        drop(self.io_stall_watchdog.take());
+        let status = self.take_and_wait_child();
         // Wake the drain thread now that the child is reaped; a re-execed
         // ssh helper may still hold the write end open so EOF cannot be
         // relied on by itself.
@@ -491,24 +608,29 @@ impl SshChildHandle {
 
 impl Drop for SshChildHandle {
     fn drop(&mut self) {
-        // Drop the watchdog first so its background thread exits before we
+        // Drop the watchdogs first so their background threads exit before we
         // touch the child handle.
         drop(self.connect_watchdog.take());
+        drop(self.io_stall_watchdog.take());
 
         // Reap the child to prevent zombies. Unlike SshConnection::Drop,
         // stdin is not owned here (it lives in SshWriter) so we skip the
         // close_stdin step.
-        if let Ok(None) = self.child.try_wait() {
-            let _ = self.child.kill();
-        }
-        let status = self.child.wait();
+        let mut guard = self.child.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(mut child) = guard.take() {
+            drop(guard);
+            if let Ok(None) = child.try_wait() {
+                let _ = child.kill();
+            }
+            let status = child.wait();
 
-        // Surface collected stderr when the child exited with an error,
-        // ensuring SSH diagnostics are visible even on abnormal control
-        // flow (panic, early return) where the caller never calls
-        // wait_with_stderr().
-        if let Some(ref mut drain) = self.stderr_drain {
-            drain.join_and_surface_on_error(&status);
+            // Surface collected stderr when the child exited with an error,
+            // ensuring SSH diagnostics are visible even on abnormal control
+            // flow (panic, early return) where the caller never calls
+            // wait_with_stderr().
+            if let Some(ref mut drain) = self.stderr_drain {
+                drain.join_and_surface_on_error(&status);
+            }
         }
     }
 }
@@ -530,25 +652,27 @@ impl Read for SshConnection {
                 ));
             }
         }
-        match self.stdout.as_mut() {
+        let res = match self.stdout.as_mut() {
             Some(stdout) => stdout.read(buf),
             None => Err(io::Error::new(
                 io::ErrorKind::BrokenPipe,
                 "stdout has already been taken",
             )),
-        }
+        };
+        guard_io_result(self.stall.as_ref(), res)
     }
 }
 
 impl Write for SshConnection {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match self.stdin.as_mut() {
+        let res = match self.stdin.as_mut() {
             Some(stdin) => stdin.write(buf),
             None => Err(io::Error::new(
                 io::ErrorKind::BrokenPipe,
                 "stdin has already been closed",
             )),
-        }
+        };
+        guard_io_result(self.stall.as_ref(), res)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -561,9 +685,10 @@ impl Write for SshConnection {
 
 impl Drop for SshConnection {
     fn drop(&mut self) {
-        // Drop the watchdog first so its background thread exits before we
+        // Drop the watchdogs first so their background threads exit before we
         // touch the child handle.
         drop(self.connect_watchdog.take());
+        drop(self.io_stall_watchdog.take());
 
         let _ = self.close_stdin();
 

--- a/crates/rsync_io/src/ssh/mod.rs
+++ b/crates/rsync_io/src/ssh/mod.rs
@@ -101,6 +101,7 @@ mod parse;
 /// Cross-platform stderr aux-channel between the parent process and a spawned `ssh` child.
 #[cfg(feature = "ssh-socketpair-stderr")]
 pub mod socketpair_stderr;
+mod stall;
 
 #[cfg(all(feature = "async-ssh", feature = "ssh-socketpair-stderr"))]
 pub use async_stderr_drain::{ASYNC_STDERR_BUFFER_CAP, AsyncStderrDrain, RingBuffer};

--- a/crates/rsync_io/src/ssh/stall.rs
+++ b/crates/rsync_io/src/ssh/stall.rs
@@ -1,0 +1,357 @@
+//! I/O stall detection for the SSH transport.
+//!
+//! Upstream rsync enforces the negotiated `--timeout` (`io_timeout`) uniformly
+//! across every transport: the `select`/`poll` loop in `io.c` aborts with
+//! [`RERR_TIMEOUT`] (exit code 30) when no I/O has made progress for
+//! `io_timeout` seconds, and keepalive writes reset the progress clock so a
+//! legitimate computation lull does not trip the timeout.
+//!
+//! The SSH data channel here is the spawned `ssh` child's inherited stdio - a
+//! pair of anonymous pipes - which cannot carry a `SO_RCVTIMEO`/`SO_SNDTIMEO`
+//! deadline the way a socket can. This module reproduces the upstream stall
+//! semantics with a background watchdog that mirrors the existing
+//! [`ConnectWatchdog`](super::connection): a shared progress clock is bumped on
+//! every successful read/write, and a watchdog thread wakes every
+//! `allowed_lull` to compare the idle interval against `io_timeout`. On expiry
+//! it invokes an abort action (killing the child, which unblocks the pending
+//! pipe read) and latches a `fired` flag so the read/write half can translate
+//! the resulting EOF/error into an [`io::ErrorKind::TimedOut`] - the kind that
+//! `core` maps to `ExitCode::Timeout` (30).
+//!
+//! upstream: io.c `check_timeout` / `set_io_timeout` / `RERR_TIMEOUT`
+//! (errcode.h:47).
+
+use std::io;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+/// Lower bound on the watchdog poll interval.
+///
+/// For sub-second timeouts (used by tests) a naive `io_timeout / 2` would busy
+/// loop, so the poll cadence is floored here. It stays well below any realistic
+/// `io_timeout` so detection latency is dominated by `io_timeout` itself.
+const MIN_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Upper bound on the watchdog poll interval.
+///
+/// upstream: io.c:35 `SELECT_TIMEOUT` caps `select_timeout` at 60 seconds even
+/// when `allowed_lull` would be larger.
+const MAX_POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Normalises a configured `--timeout` value into an effective I/O timeout.
+///
+/// Returns `None` when the timeout is absent or zero, matching upstream's
+/// "`io_timeout == 0` means off" convention (`options.c` leaves `io_timeout`
+/// at `0` and `set_io_timeout(0)` disables the check). Any positive duration is
+/// returned unchanged. This is the single point that decides whether stall
+/// detection is armed at all.
+///
+/// upstream: io.c:179 `if (!io_timeout) return;`
+#[must_use]
+pub(crate) fn effective_io_timeout(timeout: Option<Duration>) -> Option<Duration> {
+    timeout.filter(|d| !d.is_zero())
+}
+
+/// Computes the watchdog poll interval for a given `io_timeout`.
+///
+/// Mirrors upstream's `allowed_lull = (io_timeout + 1) / 2` (io.c:1151),
+/// clamped to `[MIN_POLL_INTERVAL, MAX_POLL_INTERVAL]`. Polling at half the
+/// timeout guarantees the stall is detected within `~1.5 * io_timeout`.
+#[must_use]
+pub(crate) fn stall_poll_interval(io_timeout: Duration) -> Duration {
+    (io_timeout / 2).clamp(MIN_POLL_INTERVAL, MAX_POLL_INTERVAL)
+}
+
+/// Shared progress clock recording the instant of the most recent successful
+/// I/O on the SSH channel.
+///
+/// Both the read and write halves bump the same clock, so a keepalive write
+/// (emitted by the transfer layer's `maybe_send_keepalive`) resets it exactly
+/// like an inbound read - matching upstream's `MAX(last_io_out, last_io_in)`
+/// (io.c:195).
+#[derive(Debug)]
+pub(crate) struct StallProgress {
+    /// Monotonic base captured at construction. All offsets are measured from
+    /// here so the clock is immune to wall-clock adjustments.
+    base: Instant,
+    /// Milliseconds elapsed from `base` at the last recorded progress.
+    last_millis: AtomicU64,
+}
+
+impl StallProgress {
+    /// Creates a progress clock seeded with "progress just happened".
+    fn new() -> Self {
+        Self {
+            base: Instant::now(),
+            last_millis: AtomicU64::new(0),
+        }
+    }
+
+    /// Records that I/O just made progress.
+    fn record(&self) {
+        let elapsed = self.base.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+        self.last_millis.store(elapsed, Ordering::Release);
+    }
+
+    /// Returns how long the channel has been idle since the last progress.
+    fn idle(&self) -> Duration {
+        let now = self.base.elapsed();
+        let last = Duration::from_millis(self.last_millis.load(Ordering::Acquire));
+        now.saturating_sub(last)
+    }
+}
+
+/// Read/write-half handle that enforces the stall deadline.
+///
+/// Cloned into both the [`SshReader`](super::connection::SshReader) and
+/// [`SshWriter`](super::connection::SshWriter) so each I/O direction bumps the
+/// shared progress clock and observes the latched timeout.
+#[derive(Clone, Debug)]
+pub(crate) struct StallHandle {
+    progress: Arc<StallProgress>,
+    fired: Arc<AtomicBool>,
+    io_timeout: Duration,
+}
+
+impl StallHandle {
+    /// Records successful progress of `n` bytes; a zero-length transfer (EOF)
+    /// is not progress and never resets the clock.
+    pub(crate) fn record(&self, n: usize) {
+        if n > 0 {
+            self.progress.record();
+        }
+    }
+
+    /// Returns `true` once the watchdog has latched a timeout.
+    pub(crate) fn timed_out(&self) -> bool {
+        self.fired.load(Ordering::Acquire)
+    }
+
+    /// Builds the [`io::ErrorKind::TimedOut`] error surfaced to callers, which
+    /// `core` maps to `ExitCode::Timeout` (upstream `RERR_TIMEOUT`, 30).
+    pub(crate) fn timeout_error(&self) -> io::Error {
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!(
+                "io timeout after {} seconds -- no data received",
+                self.io_timeout.as_secs()
+            ),
+        )
+    }
+}
+
+/// Background watchdog that aborts the SSH channel when I/O stalls beyond
+/// `io_timeout`.
+///
+/// Mirrors [`ConnectWatchdog`](super::connection): a condvar-driven thread
+/// avoids busy polling and lets [`cancel`](Self::cancel) / drop wake it
+/// immediately. On expiry it latches `fired` and runs the injected abort action
+/// (which kills the child to unblock a pending pipe read). The abort action is
+/// injected rather than hard-coded so the watchdog can be unit-tested against a
+/// loopback socket without spawning a subprocess.
+pub(crate) struct IoStallWatchdog {
+    cancelled: Arc<AtomicBool>,
+    condvar_pair: Arc<(Mutex<bool>, Condvar)>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl IoStallWatchdog {
+    /// Arms a stall watchdog and returns it together with the [`StallHandle`]
+    /// the read/write halves must consult.
+    ///
+    /// The watchdog thread polls every `stall_poll_interval(io_timeout)` and,
+    /// when the channel has been idle for at least `io_timeout`, latches the
+    /// timeout and calls `abort` exactly once. `abort` is responsible for
+    /// unblocking any in-flight read (for the SSH path, by killing the child).
+    pub(crate) fn arm(
+        io_timeout: Duration,
+        abort: Box<dyn FnOnce() + Send + 'static>,
+    ) -> (Self, StallHandle) {
+        let progress = Arc::new(StallProgress::new());
+        let fired = Arc::new(AtomicBool::new(false));
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let condvar_pair = Arc::new((Mutex::new(false), Condvar::new()));
+        let poll = stall_poll_interval(io_timeout);
+
+        let thread_progress = Arc::clone(&progress);
+        let thread_fired = Arc::clone(&fired);
+        let thread_cancelled = Arc::clone(&cancelled);
+        let thread_pair = Arc::clone(&condvar_pair);
+
+        let handle = thread::Builder::new()
+            .name("ssh-io-stall-watchdog".into())
+            .spawn(move || {
+                let mut abort = Some(abort);
+                let (lock, cvar) = &*thread_pair;
+                loop {
+                    let guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+                    let (_guard, _res) = cvar
+                        .wait_timeout_while(guard, poll, |notified| !*notified)
+                        .unwrap_or_else(|e| e.into_inner());
+
+                    if thread_cancelled.load(Ordering::Acquire) {
+                        return;
+                    }
+
+                    // upstream: io.c:196 `if (t - chk >= io_timeout)` aborts.
+                    if thread_progress.idle() >= io_timeout {
+                        thread_fired.store(true, Ordering::Release);
+                        if let Some(action) = abort.take() {
+                            action();
+                        }
+                        return;
+                    }
+                }
+            })
+            .expect("failed to spawn ssh io stall watchdog thread");
+
+        (
+            Self {
+                cancelled,
+                condvar_pair,
+                handle: Some(handle),
+            },
+            StallHandle {
+                progress,
+                fired,
+                io_timeout,
+            },
+        )
+    }
+
+    /// Cancels the watchdog and joins its thread.
+    ///
+    /// Call this once the transfer has completed normally so the thread does
+    /// not fire during connection teardown.
+    fn cancel(&mut self) {
+        self.cancelled.store(true, Ordering::Release);
+        let (lock, cvar) = &*self.condvar_pair;
+        if let Ok(mut notified) = lock.lock() {
+            *notified = true;
+            cvar.notify_one();
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for IoStallWatchdog {
+    fn drop(&mut self) {
+        self.cancel();
+    }
+}
+
+impl std::fmt::Debug for IoStallWatchdog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IoStallWatchdog")
+            .field("cancelled", &self.cancelled.load(Ordering::Acquire))
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_io_timeout_treats_zero_and_absent_as_off() {
+        // upstream: io_timeout == 0 disables the check entirely.
+        assert_eq!(effective_io_timeout(None), None);
+        assert_eq!(effective_io_timeout(Some(Duration::ZERO)), None);
+        assert_eq!(
+            effective_io_timeout(Some(Duration::from_secs(30))),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn poll_interval_is_half_the_timeout_within_bounds() {
+        // 30s -> 15s (upstream allowed_lull), within [50ms, 60s].
+        assert_eq!(
+            stall_poll_interval(Duration::from_secs(30)),
+            Duration::from_secs(15)
+        );
+        // Tiny timeouts floor at MIN_POLL_INTERVAL instead of busy looping.
+        assert_eq!(
+            stall_poll_interval(Duration::from_millis(20)),
+            MIN_POLL_INTERVAL
+        );
+        // Huge timeouts cap at SELECT_TIMEOUT (60s).
+        assert_eq!(
+            stall_poll_interval(Duration::from_secs(600)),
+            MAX_POLL_INTERVAL
+        );
+    }
+
+    #[test]
+    fn progress_clock_resets_idle_on_record() {
+        let progress = StallProgress::new();
+        std::thread::sleep(Duration::from_millis(30));
+        let before = progress.idle();
+        assert!(
+            before >= Duration::from_millis(20),
+            "idle should accrue: {before:?}"
+        );
+        progress.record();
+        assert!(progress.idle() < before, "record must reset the idle clock");
+    }
+
+    #[test]
+    fn watchdog_fires_and_aborts_when_idle_exceeds_timeout() {
+        let aborted = Arc::new(AtomicBool::new(false));
+        let aborted_thread = Arc::clone(&aborted);
+        let (_watchdog, handle) = IoStallWatchdog::arm(
+            Duration::from_millis(150),
+            Box::new(move || aborted_thread.store(true, Ordering::Release)),
+        );
+
+        // Never record progress: the watchdog must latch a timeout and run the
+        // abort action within a generous window (fires at ~150-225ms; 10s
+        // tolerates a heavily loaded/slow runner without a false pass).
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !handle.timed_out() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            handle.timed_out(),
+            "watchdog should latch a timeout on a stall"
+        );
+        assert!(
+            aborted.load(Ordering::Acquire),
+            "abort action should run on expiry"
+        );
+
+        let err = handle.timeout_error();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    }
+
+    #[test]
+    fn watchdog_does_not_fire_while_progress_continues() {
+        // Chosen so the record cadence is a large fraction below the timeout:
+        // recording every ~5ms against an 800ms timeout tolerates a ~160x
+        // scheduling overshoot before the idle clock could reach the timeout,
+        // so the test cannot false-trip on a heavily loaded/slow runner.
+        let timeout = Duration::from_millis(800);
+        let (_watchdog, handle) = IoStallWatchdog::arm(
+            timeout,
+            Box::new(|| panic!("abort must not run while progress continues")),
+        );
+
+        // Span longer than the timeout (plus a poll cycle) so the watchdog
+        // genuinely had the opportunity to fire; continuous progress (as
+        // keepalive writes provide) must keep it quiet the whole time.
+        let start = Instant::now();
+        while start.elapsed() < timeout + stall_poll_interval(timeout) {
+            handle.record(1);
+            assert!(
+                !handle.timed_out(),
+                "keepalive progress must prevent a false timeout"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(!handle.timed_out(), "progress must prevent any timeout");
+    }
+}

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -411,6 +411,110 @@ fn spawned_connection_forwards_io() {
     assert!(status.success());
 }
 
+/// A stalled SSH read must abort with a timeout error rather than hang the
+/// client forever. WHY: a hung remote (no data for `io_timeout`) must not block
+/// the client indefinitely; upstream aborts with `RERR_TIMEOUT` (exit 30), and
+/// `core` maps `io::ErrorKind::TimedOut` to that same exit code.
+#[cfg(unix)]
+#[test]
+fn stalled_read_aborts_with_timeout_error() {
+    // Spawn `cat` directly (not via `sh -c cat`) so the spawned child IS the
+    // blocking process. A shell wrapper is unreliable here: on some platforms
+    // `sh -c cat` forks `cat` rather than exec'ing it, so killing the child
+    // (the shell) would orphan `cat` and never close the stdout pipe, hanging
+    // the read forever. In production the SSH child is the `ssh` binary spawned
+    // directly, so the watchdog's `Child::kill()` reaches the right process.
+    let mut command = SshCommand::new("ignored");
+    command.set_program("cat");
+    command.set_batch_mode(false);
+    command.set_target_override(Some(OsString::new()));
+    command.set_io_timeout(Some(std::time::Duration::from_millis(300)));
+
+    let connection = command.spawn().expect("spawn stalling child");
+    // `_writer` keeps stdin open so `cat` stays blocked; `handle` keeps the
+    // stall watchdog alive for the duration of the read.
+    let (mut reader, _writer, handle) = connection.split().expect("split");
+
+    // Run the blocking read on a worker thread and bound the wait. `cat` blocks
+    // until the watchdog kills it; if the watchdog ever regresses, this fails
+    // fast with a diagnostic instead of hanging until the CI harness cap.
+    let (tx, rx) = std::sync::mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        let start = std::time::Instant::now();
+        let mut buf = [0u8; 16];
+        let outcome = reader.read(&mut buf).map_err(|e| e.kind());
+        let _ = tx.send((start.elapsed(), outcome));
+    });
+
+    // io_timeout is 300ms, so the watchdog fires at ~300-450ms; 8s tolerates a
+    // heavily loaded runner yet is far below any test-harness hang cap.
+    match rx.recv_timeout(std::time::Duration::from_secs(8)) {
+        Ok((elapsed, outcome)) => {
+            worker.join().expect("reader thread panicked");
+            assert_eq!(
+                outcome,
+                Err(std::io::ErrorKind::TimedOut),
+                "stalled read must map to a timeout after {elapsed:?}"
+            );
+        }
+        Err(_) => {
+            // Watchdog never fired: kill the child so the worker unblocks and
+            // the process can exit, then fail loudly.
+            drop(handle);
+            let _ = worker.join();
+            panic!("stalled read did not time out within 8s: watchdog never fired");
+        }
+    }
+}
+
+/// Continued progress (as keepalive writes provide) must prevent a false
+/// timeout even when the total transfer outlasts `io_timeout`. WHY: upstream
+/// resets its idle clock on every successful read/write, so a busy channel never
+/// trips the timeout no matter how long the transfer runs.
+#[cfg(unix)]
+#[test]
+fn progress_prevents_false_timeout() {
+    // A 1s timeout with round-trips spaced only ~5ms apart leaves a ~200x margin
+    // between the record cadence and the timeout, so scheduling drift on a slow
+    // runner cannot push the idle clock to the timeout and false-trip.
+    let timeout = std::time::Duration::from_secs(1);
+    let mut command = SshCommand::new("ignored");
+    // Spawn `cat` directly so it echoes stdin verbatim (child == the process we
+    // read/write), avoiding any shell-wrapper fork ambiguity.
+    command.set_program("cat");
+    command.set_batch_mode(false);
+    command.set_target_override(Some(OsString::new()));
+    command.set_io_timeout(Some(timeout));
+
+    let connection = command.spawn().expect("spawn echo child");
+    let (mut reader, mut writer, child_handle) = connection.split().expect("split");
+
+    // Drive continuous echo round-trips for longer than the timeout (plus a poll
+    // cycle). Each successful write and read resets the idle clock, so the
+    // watchdog must never fire despite the transfer outlasting `io_timeout`.
+    let payload = b"ping-pkt";
+    let mut got = [0u8; 8];
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout + std::time::Duration::from_millis(600) {
+        writer.write_all(payload).expect("write payload");
+        writer.flush().expect("flush payload");
+        reader
+            .read_exact(&mut got)
+            .expect("echo must arrive, not time out");
+        assert_eq!(&got, payload);
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    assert!(
+        start.elapsed() >= timeout,
+        "test must outlast the timeout to be meaningful"
+    );
+
+    // Closing stdin lets `cat` exit cleanly; the watchdog is cancelled on wait.
+    writer.close().expect("close writer");
+    let status = child_handle.wait().expect("wait for cat");
+    assert!(status.success());
+}
+
 #[cfg(unix)]
 #[test]
 fn stderr_output_collected_via_child_handle() {
@@ -1819,18 +1923,20 @@ fn connect_timeout_zero_duration() {
 fn connect_watchdog_fires_on_timeout() {
     use std::time::Duration;
 
-    // Spawn a process that sleeps for a long time - simulating an SSH process
-    // that hangs during connection establishment.
+    // Spawn a long-running process directly (not via `sh -c`) so the spawned
+    // child IS the sleeper: the final `connection.read()` below relies on the
+    // watchdog's `Child::kill()` closing the stdout pipe, and on some shells
+    // `sh -c 'sleep 60'` forks `sleep`, so killing the child (the shell) would
+    // orphan `sleep` and never close the pipe - hanging the read.
     let mut command = SshCommand::new("ignored");
-    command.set_program("sh");
+    command.set_program("sleep");
     command.set_batch_mode(false);
-    command.push_option("-c");
-    command.push_option("sleep 60");
+    command.push_option("60");
     command.set_target_override(Some(OsString::new()));
     // Set a very short connect timeout to trigger the watchdog quickly.
     command.set_connect_timeout(Some(Duration::from_millis(200)));
 
-    let mut connection = command.spawn().expect("spawn shell");
+    let mut connection = command.spawn().expect("spawn sleeper");
 
     // Wait for the watchdog to fire before attempting any read. This avoids
     // relying on Child::kill() to unblock a blocking pipe read, which is


### PR DESCRIPTION
## Summary

SSH transfers dropped the user's `--timeout` (the negotiated `io_timeout`)
entirely: the SSH data channel is the spawned `ssh` child's inherited stdio
(a pair of anonymous pipes), which carries no read/write deadline, so a hung
remote could block the client forever. Upstream rsync applies `io_timeout`
uniformly across every transport - the `io.c` select/poll loop aborts with
`RERR_TIMEOUT` (exit code 30) when no I/O has made progress for `io_timeout`
seconds, and keepalive writes reset the progress clock so a legitimate lull
does not trip the timeout.

This threads the negotiated I/O timeout into the SSH transport and adds a
parent-side stall detector that reproduces upstream's semantics over the
child's stdio pipes.

## The gap (before)

- The SSH transport had no data-channel deadline. The only time bounds were the
  hardcoded connection-establishment timeout `DEFAULT_CONNECT_TIMEOUT_SECS = 30`
  (`crates/rsync_io/src/ssh/builder.rs`) and the hardcoded SSH keepalive
  `ServerAliveInterval = 20` - both connection-level, neither derived from the
  user's `--timeout`.
- `SshConnectConfig` had no I/O-timeout field, and `SshConnection::new` accepted
  only a connect timeout, so the negotiated value had no path into the transport.

## The fix

- New `crates/rsync_io/src/ssh/stall.rs`: a single well-named
  `effective_io_timeout(Option<Duration>) -> Option<Duration>` decides whether
  stall detection is armed (`0`/`None` = off, matching upstream's
  `io_timeout == 0` means off). An `IoStallWatchdog` mirrors the existing
  `ConnectWatchdog`: a shared progress clock is bumped on every successful
  read/write, and a condvar-driven thread wakes every `allowed_lull`
  (`(io_timeout)/2`, clamped to `[50ms, 60s]` per upstream `SELECT_TIMEOUT`) to
  compare the idle interval against `io_timeout`. On expiry it latches a `fired`
  flag and runs an injected abort action.
- The abort action kills the `ssh` child, closing its pipe endpoints and
  unblocking any pending read/write; the read/write half then translates the
  resulting EOF/error into `io::ErrorKind::TimedOut`, which `core` maps to
  `ExitCode::Timeout` (upstream `RERR_TIMEOUT`, 30).
- `SshConnectConfig::with_io_timeout` / `SshCommand::set_io_timeout` thread the
  value through `build_ssh_command` into `SshConnection::new`. The timeout is a
  parent-side detector, not an `ssh` option, so it is not rendered into the argv.

## Keepalive interaction

Both the read and write halves bump the same progress clock, so a keepalive
write emitted by the transfer layer (`maybe_send_keepalive`, driven by the
`set_allowed_lull` value derived from the negotiated `io_timeout`) resets the
stall clock exactly like an inbound read - matching upstream's
`MAX(last_io_out, last_io_in)`. This reuses the existing keepalive machinery
rather than duplicating it; the transport only observes progress.

## Upstream references

- `io.c` `check_timeout` (`if (t - MAX(last_io_out, last_io_in) >= io_timeout)`
  aborts), `set_io_timeout` (`allowed_lull = (io_timeout + 1) / 2`,
  `select_timeout` capped at `SELECT_TIMEOUT = 60`), `maybe_send_keepalive`.
- `errcode.h`: `RERR_TIMEOUT = 30`.
- `options.c`: `--timeout` sets `io_timeout`; `0` leaves the check disabled.

## Tests (encode why)

- `effective_io_timeout` treats `0`/absent as off; poll interval is half the
  timeout within `[50ms, 60s]`; the progress clock resets idle on record.
- The watchdog fires and runs its abort action on a stall, and stays quiet while
  progress continues (keepalive analogue).
- A stalled SSH read (`sh -c 'sleep 30'`) aborts with `ErrorKind::TimedOut`
  within a bounded window - WHY: a hung remote must not hang the client forever.
- Continued round-trips spanning longer than the timeout never trip it - WHY:
  upstream resets its idle clock on every successful read/write.
- The negotiated timeout is plumbed into the spawned command (regression guard),
  and is not leaked as an `ssh` command-line option.

## Scope note

This delivers the transport-layer mechanism (config, watchdog, read/write
enforcement, exit-code mapping) end to end within the transport crate. Wiring
the user's `--timeout` into `SshConnectConfig::with_io_timeout` at the SSH
transfer call sites, and populating the SSH-mode negotiated `io_timeout`, live
in higher layers and are a follow-up.
