### PR TITLE
fix(transfer): match upstream cross-file skip-notice ordering

### DIFF
--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -128,16 +128,6 @@ impl ReceiverContext {
             .filter(|(_, e)| e.is_file())
             .filter(|(_, e)| !is_hardlink_follower(e))
             .filter(|(_, e)| {
-                if !has_size_bounds {
-                    return true;
-                }
-                // upstream: generator.c:1704-1718 - a file whose sender-side
-                // length exceeds max-size or falls below min-size is skipped
-                // with a SKIP-gated notice on FINFO. The bound uses the flist
-                // length, so no destination stat is needed here.
-                !self.emit_size_bound_skip(writer, e, min_size, max_size)
-            })
-            .filter(|(_, e)| {
                 // upstream: receiver.c:599-604 - check_filter(&daemon_filter_list, ...)
                 // rejects daemon-excluded files before accepting transfer data.
                 if has_daemon_filters {
@@ -179,6 +169,14 @@ impl ReceiverContext {
             // attrs over the wire and does not consume this precomputed value.
             return candidates
                 .into_iter()
+                .filter(|(_, entry)| {
+                    // upstream: generator.c:1704-1718 - the max/min-size skip
+                    // (`goto cleanup`) fires before the `do_xfers` gate, so a
+                    // dry run still excludes out-of-range files and emits the
+                    // SKIP-gated notice in flist order.
+                    !has_size_bounds
+                        || !self.emit_size_bound_skip(writer, entry, min_size, max_size)
+                })
                 .map(|(idx, entry)| {
                     (
                         idx,
@@ -267,6 +265,14 @@ impl ReceiverContext {
                     }
                     continue;
                 }
+                // upstream: generator.c:1704-1718 - the max/min-size skip is
+                // tested per file after the `--ignore-existing` "exists" notice
+                // (1395) and before the `--update` "is newer" notice (1721), so
+                // the size notices interleave with the other skip notices in
+                // strict flist order rather than as a separate batch.
+                if has_size_bounds && self.emit_size_bound_skip(writer, entry, min_size, max_size) {
+                    continue;
+                }
                 if update_only
                     && dest_type_matches_source(&file_path, entry)
                     && dest_mtime_newer(meta, entry)
@@ -330,6 +336,13 @@ impl ReceiverContext {
                         let _ = self
                             .emit_info_line(writer, &format!("not creating new file \"{name}\"\n"));
                     }
+                    continue;
+                }
+                // upstream: generator.c:1704-1718 - a not-yet-existing file
+                // still hits the max/min-size skip (after the not-creating
+                // check at 1368), so the size notice for an absent file appears
+                // in flist order alongside the other per-file notices.
+                if has_size_bounds && self.emit_size_bound_skip(writer, entry, min_size, max_size) {
                     continue;
                 }
                 if has_reference_dirs
@@ -953,6 +966,51 @@ mod skip_notice_tests {
         );
 
         assert!(run(cfg(), 0, files(), dest).is_empty());
+    }
+
+    /// #81 - upstream: generator.c:1368-1719. `recv_generator` tests every
+    /// per-file skip in one strictly sequential pass, so the max/min-size skip
+    /// (1704-1718) is evaluated right after the `--existing` not-creating check
+    /// (1368) for the *same* file. The notices therefore interleave in flist
+    /// order; a size notice must never batch ahead of a not-creating notice for
+    /// an earlier file. This matters because drop-in tools parse rsync's output
+    /// stream line-by-line in order: a reordered notice block changes the
+    /// observable transcript even though every individual line is correct.
+    #[test]
+    fn skip_notices_interleave_in_flist_order() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        // `b_big` / `d_small` must exist at the destination so `--existing`
+        // routes them to the size check (Some branch) rather than emitting a
+        // not-creating notice; `a_new` / `e_new` stay absent.
+        std::fs::write(dest.join("b_big"), b"x").expect("seed dest b_big");
+        std::fs::write(dest.join("d_small"), b"x").expect("seed dest d_small");
+        let files = || {
+            vec![
+                FileEntry::new_file("a_new".into(), 50, 0o644),
+                FileEntry::new_file("b_big".into(), 200, 0o644),
+                FileEntry::new_file("d_small".into(), 5, 0o644),
+                FileEntry::new_file("e_new".into(), 50, 0o644),
+            ]
+        };
+        let cfg = || {
+            let mut c = server_config();
+            c.file_selection.existing_only = true;
+            c.file_selection.max_file_size = Some(100);
+            c.file_selection.min_file_size = Some(10);
+            c
+        };
+
+        let lines = run(cfg(), 1, files(), dest);
+        assert_eq!(
+            lines,
+            vec![
+                "not creating new file \"a_new\"\n".to_owned(),
+                "b_big is over max-size\n".to_owned(),
+                "d_small is under min-size\n".to_owned(),
+                "not creating new file \"e_new\"\n".to_owned(),
+            ]
+        );
     }
 
     /// #45 - upstream: generator.c:1395-1410. With `--ignore-existing`, a file


### PR DESCRIPTION
## Summary

The receiver's generator phase (`crates/transfer` `build_files_to_transfer`) emitted the `--max-size` / `--min-size` skip notices as a separate up-front batch, ahead of every `--existing` "not creating new file" and `--ignore-existing` "exists" notice. Upstream `recv_generator()` evaluates all per-file skips in one strictly sequential pass, so the notices interleave in flist order. Drop-in tools parse rsync's output stream line-by-line, so the cross-file ordering is observable and must match.

## The divergence (repro)

Multi-file pull from a daemon with `--existing --max-size=1000 --min-size=3` where the size-skipped files (`b_big.bin`, `d_small.txt`) exist at the destination and two new files (`a_new.txt`, `e_new2.txt`) do not:

Upstream rsync 3.4.4 (`-vv`):
```
not creating new file "a_new.txt"
b_big.bin is over max-size
d_small.txt is under min-size
not creating new file "e_new2.txt"
```

oc-rsync before this change (size notices batched first):
```
b_big.bin is over max-size
d_small.txt is under min-size
not creating new file "a_new.txt"
not creating new file "e_new2.txt"
```

## Root cause

`build_files_to_transfer` ran the size-bound check inside the Phase A candidate `.filter()` closure, which scans the whole flist before the Phase C per-file loop that emits the not-creating / exists / is-newer notices. All size notices therefore flushed before any of the other skip notices.

## Fix

Relocate `emit_size_bound_skip` out of the Phase A filter and into the Phase C per-file loop, at the upstream precedence position:

- After the `--ignore-existing` "exists" notice and before the `--update` "is newer" notice for an existing destination (upstream `generator.c:1395` then `1704-1718` then `1721`).
- After the `--existing` "not creating new file" notice for an absent destination (upstream `generator.c:1368` then `1704-1718`).

The dry-run / list-only early-return path keeps its size exclusion (upstream applies the `goto cleanup` at `generator.c:1710/1718` before the `do_xfers` gate), now expressed as a flist-order `.filter()` so out-of-range files are still dropped and their notice emitted.

Notice text and itemize format are unchanged; this is purely an emit-order change.

## Upstream reference

`generator.c` `recv_generator()`:
- `1368-1383` not creating new file (`ignore_non_existing`)
- `1395-1415` `%s exists%s` (`ignore_existing`)
- `1704-1711` `%s is over max-size`
- `1712-1719` `%s is under min-size`
- `1721-1730` `%s is newer` (`update_only`)

All share a single top-to-bottom pass per file, so the notices emit in strict flist order.

## Tests

Added `skip_notices_interleave_in_flist_order` pinning the interleaved cross-file sequence for a mixed `--existing` + size-bound scan. Verified end-to-end against real rsync 3.4.4 over a daemon pull; `-vv`, `-vvi`, plain `--max-size`/`--min-size`, and `--dry-run --max-size` all match upstream notice ordering and exclusion.
