### PR TITLE
fix(cli): match upstream local-copy skip-notice text, gating, and order

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -672,6 +672,21 @@ fn is_uptodate_event(event: &ClientEvent) -> bool {
     event.is_uptodate()
 }
 
+/// Returns `true` for the per-file skip notices that upstream's `recv_generator`
+/// emits during the generator phase (`"exists"`, `"not creating new"`, `"is
+/// newer"`), ahead of the receiver phase that prints transferred-file names.
+/// Bucketing these with the uptodate notices reproduces that interleaving.
+///
+/// upstream: generator.c:1379,1395,1723 (recv_generator)
+fn is_generator_phase_skip(event: &ClientEvent) -> bool {
+    matches!(
+        event.kind(),
+        ClientEventKind::SkippedExisting
+            | ClientEventKind::SkippedMissingDestination
+            | ClientEventKind::SkippedNewerDestination
+    )
+}
+
 /// Returns `true` for a HardLink event describing a hard-linked symlink (`hL`).
 /// Its metadata kind is `Symlink` and its `symlink_target` slot holds the link
 /// target, not a `=> leader` trailer.
@@ -752,7 +767,13 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
     // group preserves its original relative ordering.
     let mut ordered_events: Vec<&ClientEvent> = events.iter().collect();
     ordered_events.sort_by_key(|event| {
-        if is_uptodate_event(event) {
+        // upstream: recv_generator() emits the "is uptodate", "exists",
+        // "not creating new", and "is newer" notices synchronously in the
+        // generator phase, ahead of the receiver phase that prints the
+        // transferred-file names. Bucket those generator-phase notices first
+        // so the stable sort reproduces that interleaving.
+        // (generator.c:1379,1395,1723)
+        if is_uptodate_event(event) || is_generator_phase_skip(event) {
             0u8
         } else if is_deferred_hardlink_event(event) {
             // Hardlink aliases linked to a this-run leader are finished last.
@@ -817,36 +838,51 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
 
         match kind {
             ClientEventKind::SkippedExisting => {
-                // upstream: generator.c:1409 - `rprintf(FINFO, "%s exists\n",
+                // upstream: generator.c:1397-1409 - `rprintf(FINFO, "%s exists\n",
                 // fname)` for an --ignore-existing skip: the bare relative name
-                // followed by " exists", no descriptor and no quotes.
-                writeln_wrapped(
-                    stdout,
-                    "",
-                    event.relative_path(),
-                    eight_bit_output,
-                    " exists",
-                )?;
+                // followed by " exists", no descriptor and no quotes. Gated on
+                // INFO_GTE(SKIP, 1), which the info verbosity table raises only
+                // at -vv (options.c:252).
+                if info_gte(InfoFlag::Skip, 1) {
+                    writeln_wrapped(
+                        stdout,
+                        "",
+                        event.relative_path(),
+                        eight_bit_output,
+                        " exists",
+                    )?;
+                }
                 continue;
             }
             ClientEventKind::SkippedMissingDestination => {
-                writeln_wrapped(
-                    stdout,
-                    "skipping non-existent destination file \"",
-                    event.relative_path(),
-                    eight_bit_output,
-                    "\"",
-                )?;
+                // upstream: generator.c:1379-1382 - `rprintf(FINFO,
+                // "not creating new %s \"%s\"\n", "file", fname)` for an
+                // --existing / --ignore-non-existing skip, gated on
+                // INFO_GTE(SKIP, 1).
+                if info_gte(InfoFlag::Skip, 1) {
+                    writeln_wrapped(
+                        stdout,
+                        "not creating new file \"",
+                        event.relative_path(),
+                        eight_bit_output,
+                        "\"",
+                    )?;
+                }
                 continue;
             }
             ClientEventKind::SkippedNewerDestination => {
-                writeln_wrapped(
-                    stdout,
-                    "skipping newer destination file \"",
-                    event.relative_path(),
-                    eight_bit_output,
-                    "\"",
-                )?;
+                // upstream: generator.c:1723-1724 - `rprintf(FINFO, "%s is
+                // newer\n", fname)` for an --update skip: the bare relative name
+                // followed by " is newer", gated on INFO_GTE(SKIP, 1).
+                if info_gte(InfoFlag::Skip, 1) {
+                    writeln_wrapped(
+                        stdout,
+                        "",
+                        event.relative_path(),
+                        eight_bit_output,
+                        " is newer",
+                    )?;
+                }
                 continue;
             }
             ClientEventKind::SkippedNonRegular => {
@@ -1063,6 +1099,106 @@ mod tests {
         )
         .expect("emit_verbose writes to an in-memory buffer");
         String::from_utf8(out).expect("output is valid UTF-8")
+    }
+
+    fn render_verbose_scenario(events: Vec<ClientEvent>, verbose_level: u8) -> String {
+        // Mirror the CLI's per-thread verbosity setup so `info_gte(Skip, ..)`
+        // reflects the requested level. `from_verbose_level(2)` raises Skip to 1
+        // (upstream options.c:252), `(1)` leaves it at 0.
+        logging::init(logging::VerbosityConfig::from_verbose_level(verbose_level));
+        let mut out = Vec::new();
+        emit_verbose(
+            &events,
+            verbose_level,
+            NameOutputLevel::UpdatedAndUnchanged,
+            false,
+            HumanReadableMode::Grouped,
+            false,
+            &mut out,
+        )
+        .expect("emit_verbose writes to an in-memory buffer");
+        String::from_utf8(out).expect("output is valid UTF-8")
+    }
+
+    fn transferred_event(name: &str) -> ClientEvent {
+        ClientEvent::for_test(
+            PathBuf::from(name),
+            ClientEventKind::DataCopied,
+            true,
+            Some(ClientEntryMetadata::for_test(ClientEntryKind::File)),
+            LocalCopyChangeSet::new(),
+        )
+    }
+
+    fn skip_event(name: &str, kind: ClientEventKind) -> ClientEvent {
+        ClientEvent::for_test(
+            PathBuf::from(name),
+            kind,
+            false,
+            Some(ClientEntryMetadata::for_test(ClientEntryKind::File)),
+            LocalCopyChangeSet::new(),
+        )
+    }
+
+    #[test]
+    fn ignore_existing_skip_notices_cluster_before_transferred_at_vv() {
+        // WHY: a drop-in tool parses the local client stream in order. Upstream's
+        // recv_generator emits the `"%s exists"` --ignore-existing notice in the
+        // generator phase, ahead of the receiver phase that prints transferred
+        // names, and only at INFO_GTE(SKIP, 1) (i.e. -vv). Collection order here
+        // is the sorted flist (big, onlyexists, small, tiny); the two skip
+        // notices must surface first, in flist order, with upstream's exact
+        // bare-name-plus-" exists" text - never after the transferred names or
+        // after the stats block.
+        // upstream: generator.c:1395-1409
+        let events = vec![
+            transferred_event("big.txt"),
+            skip_event("onlyexists.txt", ClientEventKind::SkippedExisting),
+            skip_event("small.txt", ClientEventKind::SkippedExisting),
+            transferred_event("tiny.txt"),
+        ];
+        assert_eq!(
+            render_verbose_scenario(events, 2),
+            "onlyexists.txt exists\nsmall.txt exists\nbig.txt\ntiny.txt\n"
+        );
+    }
+
+    #[test]
+    fn skip_notices_suppressed_below_skip_verbosity() {
+        // WHY: upstream gates the exists/not-creating/is-newer notices on
+        // INFO_GTE(SKIP, 1), which the info verbosity table raises only at -vv
+        // (options.c:252). At plain -v they must be silent, leaving only the
+        // transferred-file names - otherwise a drop-in tool sees phantom lines
+        // that upstream never emits.
+        let events = vec![
+            transferred_event("big.txt"),
+            skip_event("onlyexists.txt", ClientEventKind::SkippedExisting),
+            skip_event("small.txt", ClientEventKind::SkippedExisting),
+            transferred_event("tiny.txt"),
+        ];
+        assert_eq!(render_verbose_scenario(events, 1), "big.txt\ntiny.txt\n");
+    }
+
+    #[test]
+    fn not_creating_and_is_newer_use_upstream_text_at_vv() {
+        // WHY: the local path previously emitted oc-invented wording ("skipping
+        // non-existent destination file", "skipping newer destination file").
+        // Upstream prints `not creating new file "%s"` (generator.c:1380) and
+        // `%s is newer` (generator.c:1724). Drop-in parsers key on the exact
+        // strings, so any deviation breaks compatibility.
+        let missing = vec![skip_event(
+            "big.txt",
+            ClientEventKind::SkippedMissingDestination,
+        )];
+        assert_eq!(
+            render_verbose_scenario(missing, 2),
+            "not creating new file \"big.txt\"\n"
+        );
+        let newer = vec![skip_event(
+            "big.txt",
+            ClientEventKind::SkippedNewerDestination,
+        )];
+        assert_eq!(render_verbose_scenario(newer, 2), "big.txt is newer\n");
     }
 
     #[test]

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -71,21 +71,6 @@ pub(crate) fn copy_file(
     context.summary_mut().record_regular_file_total();
     context.summary_mut().record_total_bytes(file_size);
 
-    // upstream: generator.c:recv_generator() - skip files outside size range
-    if let Some(min_limit) = context.min_file_size_limit()
-        && file_size < min_limit
-    {
-        info_log!(Skip, 1, "{} is under min-size", record_path.display());
-        return Ok(false);
-    }
-
-    if let Some(max_limit) = context.max_file_size_limit()
-        && file_size > max_limit
-    {
-        info_log!(Skip, 1, "{} is over max-size", record_path.display());
-        return Ok(false);
-    }
-
     // Reuse the destination lstat gathered by the checksum-mode prefetch when
     // present; otherwise lstat here. This keeps checksum mode at one generator
     // link_stat per destination instead of two. upstream: generator.c:recv_generator().
@@ -152,6 +137,24 @@ pub(crate) fn copy_file(
             Some(metadata_snapshot),
         ));
         return Ok(true);
+    }
+
+    // upstream: generator.c:1704-1719 recv_generator() - the max-size/min-size
+    // filter runs after the "not creating new" (--existing) check at
+    // generator.c:1368, so an out-of-range file absent from the destination
+    // reports "not creating new file" rather than a size skip.
+    if let Some(max_limit) = context.max_file_size_limit()
+        && file_size > max_limit
+    {
+        info_log!(Skip, 1, "{} is over max-size", record_path.display());
+        return Ok(false);
+    }
+
+    if let Some(min_limit) = context.min_file_size_limit()
+        && file_size < min_limit
+    {
+        info_log!(Skip, 1, "{} is under min-size", record_path.display());
+        return Ok(false);
     }
 
     // Dry-run check must precede parent directory preparation: in dry-run mode


### PR DESCRIPTION
## Summary

Aligns the local-copy (`oc-rsync src/ dst/`, no network) per-file skip notices
with upstream rsync 3.4.4's `recv_generator()` for text, verbosity gating, and
emission order. Verified byte-for-byte against the system `rsync 3.4.4`
(protocol 32).

Upstream emits the per-file skip notices from `recv_generator()` in the
generator phase, ahead of the receiver phase that prints transferred-file names,
and only at `INFO_GTE(SKIP, 1)` — which the info verbosity table raises solely at
`-vv` (`options.c:252`, `/*2*/ "...,SKIP"`). The local path diverged in three
ways, all observable in the client output stream that drop-in tooling parses.

## Divergences (oc before vs upstream 3.4.4)

All runs `-avv`, destination pre-seeded so `onlyexists.txt`/`small.txt` exist and
`big.txt`/`tiny.txt` are absent.

### 1. Wrong notice text

| condition | oc (before) | upstream 3.4.4 | upstream ref |
|-----------|-------------|----------------|--------------|
| `--existing`, dest absent | `skipping non-existent destination file "big.txt"` | `not creating new file "big.txt"` | generator.c:1380 |
| `--update`, dest newer | `skipping newer destination file "big.txt"` | `big.txt is newer` | generator.c:1724 |
| `--ignore-existing` | `onlyexists.txt exists` (correct) | `onlyexists.txt exists` | generator.c:1409 |

### 2. Wrong verbosity gating

The record-based skip notices printed at `-v` (verbosity 1). Upstream is silent
until `-vv`:

```
# oc before: oc-rsync -av --ignore-existing src/ dst/
onlyexists.txt exists      <- upstream emits nothing here
small.txt exists           <- upstream emits nothing here
```

### 3. Wrong order (`--existing`)

The engine ran the `--max-size`/`--min-size` filter before the "not creating
new" (`--existing`) check, so an out-of-range file that was absent from the
destination reported a size skip instead of the not-creating notice. Upstream
evaluates not-creating (`generator.c:1368`) before the size bounds
(`generator.c:1704-1719`):

```
# oc before: oc-rsync -avv --existing --max-size=1000 --min-size=3 src/ dst/
big.txt is over max-size    <- wrong; upstream: not creating new file "big.txt"
```

## Fix

- **crates/engine** (`local_copy/executor/file/copy/mod.rs`): move the
  max-size/min-size filter to after the `--existing` "not creating new" check,
  matching the upstream precedence (`generator.c:1368` before `1704`). This is
  the same relocation applied to the network receiver path.
- **crates/cli** (`frontend/progress/render.rs`):
  - Correct the `SkippedMissingDestination` text to `not creating new file "%s"`
    and `SkippedNewerDestination` to `%s is newer`, matching
    `generator.c:1380,1724`.
  - Gate the exists / not-creating / is-newer notices on
    `info_gte(InfoFlag::Skip, 1)` so they surface only at `-vv`, mirroring
    `INFO_GTE(SKIP, 1)` (`generator.c:1379,1397,1723`).
  - Bucket these generator-phase notices ahead of the receiver-phase
    transferred-file names in the stable partition sort, reproducing upstream's
    generator-then-receiver interleaving.

## Verification

Byte-compared against `rsync 3.4.4` for `--existing`, `--ignore-existing`, and
`--update` at both `-v` and `-vv`; the skip-notice text, gating, and relative
order now match. New unit tests in `render.rs` pin the interleaved sequence, the
exact upstream text, and the `-v` silence.

## Follow-ups (out of scope here)

- The pure `--max-size`/`--min-size` skip (no `--existing`) is still emitted via
  the buffered diagnostic path, which drains after the stats block. Interleaving
  it before stats requires a dedicated size-skip event kind in the shared client
  event enum (`crates/core`), outside this change's engine+cli surface.
- The local path does not print the transfer-root `./` listing line that
  upstream emits between the generator and receiver phases; this is a separate
  directory-listing gap unrelated to skip notices.
