### PR TITLE
feat(daemon): support @netgroup tokens in hosts allow/deny

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -220,6 +220,7 @@ pub(crate) use self::module_state::{
 pub(crate) use self::module_state::{
     TEST_SECRETS_CANDIDATES, TEST_SECRETS_ENV, TestSecretsEnvOverride,
     clear_test_hostname_overrides, set_test_forward_override, set_test_hostname_override,
+    set_test_netgroup_members,
 };
 
 type SharedLogSink = Arc<Mutex<MessageSink<std::fs::File>>>;

--- a/crates/daemon/src/daemon/module_state/hostname.rs
+++ b/crates/daemon/src/daemon/module_state/hostname.rs
@@ -130,6 +130,34 @@ fn resolve_forward_key(key: &str) -> Vec<IpAddr> {
         .unwrap_or_default()
 }
 
+/// Tests whether the connecting client `host` belongs to the named `netgroup`.
+///
+/// This is the daemon-side seam for `@netgroup` tokens in `hosts allow`/`hosts
+/// deny`. Production builds delegate to [`metadata::host_in_netgroup`], which
+/// performs a real `innetgr` lookup on platforms with a netgroup database
+/// (glibc, macOS, the BSDs) and is a no-op returning `false` on musl/Windows.
+/// Tests inject deterministic membership via `TEST_NETGROUP_MEMBERS`, keeping
+/// access-control tests hermetic and free of a real netgroup database.
+///
+/// upstream: access.c:42 `innetgr(tok + 1, host, NULL, NULL)` - only the
+/// netgroup's host field is consulted (user and domain are NULL).
+#[cfg(not(test))]
+pub(in crate::daemon) fn netgroup_contains(netgroup: &str, host: &str) -> bool {
+    metadata::host_in_netgroup(netgroup, host)
+}
+
+/// Test-build netgroup resolver: consults the injected membership table and
+/// treats any unknown netgroup as empty, so a `@netgroup` token yields a
+/// deterministic non-match without a real netgroup database.
+#[cfg(test)]
+pub(in crate::daemon) fn netgroup_contains(netgroup: &str, host: &str) -> bool {
+    TEST_NETGROUP_MEMBERS.with(|map| {
+        map.borrow()
+            .get(netgroup)
+            .is_some_and(|hosts| hosts.iter().any(|member| member == host))
+    })
+}
+
 /// Normalizes a hostname by removing trailing dots and lowercasing.
 pub(super) fn normalize_hostname_owned(mut name: String) -> String {
     if name.ends_with('.') {
@@ -144,6 +172,8 @@ thread_local! {
     pub(in crate::daemon) static TEST_HOSTNAME_OVERRIDES: RefCell<HashMap<IpAddr, Option<String>>> =
         RefCell::new(HashMap::new());
     pub(in crate::daemon) static TEST_FORWARD_OVERRIDES: RefCell<HashMap<String, Vec<IpAddr>>> =
+        RefCell::new(HashMap::new());
+    pub(in crate::daemon) static TEST_NETGROUP_MEMBERS: RefCell<HashMap<String, Vec<String>>> =
         RefCell::new(HashMap::new());
 }
 
@@ -171,10 +201,27 @@ pub(crate) fn set_test_forward_override(name: &str, addrs: &[IpAddr]) {
     });
 }
 
-/// Clears all test hostname resolution overrides (reverse and forward).
+/// Declares that `hosts` are members of `netgroup` for the duration of a test.
+///
+/// The daemon's `@netgroup` matching consults this table via
+/// [`netgroup_contains`] in test builds, so access-control tests are hermetic
+/// and never touch a real netgroup database.
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn set_test_netgroup_members(netgroup: &str, hosts: &[&str]) {
+    TEST_NETGROUP_MEMBERS.with(|map| {
+        map.borrow_mut().insert(
+            netgroup.to_owned(),
+            hosts.iter().map(|host| (*host).to_owned()).collect(),
+        );
+    });
+}
+
+/// Clears all test hostname resolution overrides (reverse, forward, netgroup).
 #[cfg(test)]
 #[allow(dead_code)]
 pub(crate) fn clear_test_hostname_overrides() {
     TEST_HOSTNAME_OVERRIDES.with(|map| map.borrow_mut().clear());
     TEST_FORWARD_OVERRIDES.with(|map| map.borrow_mut().clear());
+    TEST_NETGROUP_MEMBERS.with(|map| map.borrow_mut().clear());
 }

--- a/crates/daemon/src/daemon/module_state/mod.rs
+++ b/crates/daemon/src/daemon/module_state/mod.rs
@@ -24,13 +24,14 @@ pub(crate) use auth::{AuthUser, SystemGroupMembership, UserAccessLevel, authoriz
 pub(crate) use connection_limiter::{ConnectionLimiter, ConnectionLockGuard};
 pub(crate) use definition::ModuleDefinition;
 pub(crate) use hostname::module_peer_hostname;
-pub(in crate::daemon) use hostname::{forward_resolve, resolve_peer_hostname};
+pub(in crate::daemon) use hostname::{forward_resolve, netgroup_contains, resolve_peer_hostname};
 pub(in crate::daemon) use runtime::build_module_runtimes;
 pub(crate) use runtime::{ModuleConnectionError, ModuleRuntime};
 
 #[cfg(test)]
 pub(crate) use hostname::{
     clear_test_hostname_overrides, set_test_forward_override, set_test_hostname_override,
+    set_test_netgroup_members,
 };
 #[cfg(test)]
 use runtime::ModuleConnectionGuard;

--- a/crates/daemon/src/daemon/sections/config_helpers/host_pattern.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/host_pattern.rs
@@ -11,6 +11,9 @@ pub(crate) enum HostPattern {
     Ipv6 { network: Ipv6Addr, prefix: u8 },
     /// Matches by hostname pattern (exact, suffix, or wildcard).
     Hostname(HostnamePattern),
+    /// Matches when the client's resolved hostname is a member of a netgroup
+    /// (`@name` token). Holds the netgroup name (the text after `@`).
+    Netgroup(String),
 }
 
 /// IP address family for filtering.
@@ -53,6 +56,19 @@ impl HostPattern {
 
         if token == "*" || token.eq_ignore_ascii_case("all") {
             return Ok(Self::Any);
+        }
+
+        // upstream: access.c:41-42 - a token of the form `@name` tests the
+        // client's resolved hostname for membership in the netgroup `name`
+        // (`innetgr(tok + 1, host, NULL, NULL)`). A bare `@` (no name) is not a
+        // netgroup (`tok[1]` is required, access.c:41) and falls through to be
+        // treated as an ordinary hostname token. The name is lowercased to
+        // match upstream's `strlower(list2)` over the whole host list
+        // (access.c:251).
+        if let Some(name) = token.strip_prefix('@') {
+            if !name.is_empty() {
+                return Ok(Self::Netgroup(name.to_ascii_lowercase()));
+            }
         }
 
         let (address_str, prefix_text) = if let Some((addr, mask)) = token.split_once('/') {
@@ -157,13 +173,27 @@ impl HostPattern {
             (Self::Hostname(pattern), _) => {
                 hostname.is_some_and(|name| pattern.matches(name))
             }
+            // upstream: access.c:41-42 `innetgr(tok + 1, host, NULL, NULL)` -
+            // the client's resolved hostname is tested for netgroup membership.
+            // Like the reverse-DNS name match, this needs a resolved hostname;
+            // without one (access.c:37-38 `if (!host || !*host) return 0`) it
+            // never matches. Resolution goes through the `module_state`
+            // netgroup seam, a no-op returning false on musl/Windows.
+            (Self::Netgroup(name), _) => {
+                hostname.is_some_and(|host| module_state::netgroup_contains(name, host))
+            }
             _ => false,
         }
     }
 
     /// Returns whether this pattern requires a resolved hostname.
+    ///
+    /// Both hostname-pattern and `@netgroup` tokens are evaluated against the
+    /// client's resolved hostname (upstream access.c:37-38, 46), so a deny rule
+    /// of either kind must fail closed when no hostname is available
+    /// (GHSA-rjfm-3w2m-jf4f).
     const fn requires_hostname(&self) -> bool {
-        matches!(self, Self::Hostname(_))
+        matches!(self, Self::Hostname(_) | Self::Netgroup(_))
     }
 
     /// Forward-resolves a config-specified hostname token and matches the

--- a/crates/daemon/src/daemon/sections/config_helpers/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/tests.rs
@@ -337,6 +337,25 @@ mod config_helpers_tests {
         assert!(result.is_err());
     }
 
+    // WHY: operators centrally manage trusted hosts via netgroups. A `@name`
+    // token must parse into the dedicated netgroup variant (upstream
+    // access.c:41-42) rather than a literal hostname, and the name must be
+    // lowercased to match upstream's `strlower(list2)` (access.c:251).
+    #[test]
+    fn host_pattern_parse_netgroup_token() {
+        let pattern = HostPattern::parse("@Trusted").unwrap();
+        assert_eq!(pattern, HostPattern::Netgroup("trusted".to_owned()));
+    }
+
+    // WHY: upstream requires `tok[1]` before treating `@` as a netgroup
+    // (access.c:41). A bare `@` is therefore not a netgroup; it falls through
+    // to an ordinary hostname token that can never match a real hostname.
+    #[test]
+    fn host_pattern_parse_bare_at_is_not_netgroup() {
+        let pattern = HostPattern::parse("@").unwrap();
+        assert!(matches!(pattern, HostPattern::Hostname(_)));
+    }
+
     #[test]
     fn host_pattern_parse_invalid_prefix() {
         let result = HostPattern::parse("192.168.1.1/abc");

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -67,6 +67,7 @@ use crate::daemon::{
     sanitize_module_identifier,
     set_test_forward_override,
     set_test_hostname_override,
+    set_test_netgroup_members,
 };
 
 use core::{
@@ -160,9 +161,13 @@ include!("tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs");
 include!("tests/chunks/module_hostname_allow_forward_resolve_failure_fails_closed.rs");
 include!("tests/chunks/module_hostname_allow_forward_resolve_non_matching_denies.rs");
 include!("tests/chunks/module_hostname_allow_forward_resolves_token_to_peer.rs");
+include!("tests/chunks/module_hostname_allow_netgroup_admits_member.rs");
 include!("tests/chunks/module_hostname_deny_fails_closed_when_dns_unresolved.rs");
 include!("tests/chunks/module_hostname_deny_forward_resolves_token_to_peer.rs");
 include!("tests/chunks/module_hostname_forward_lookup_off_skips_token_resolution.rs");
+include!("tests/chunks/module_hostname_netgroup_deny_blocks_member.rs");
+include!("tests/chunks/module_hostname_netgroup_deny_fails_closed_without_hostname.rs");
+include!("tests/chunks/module_hostname_netgroup_non_member_falls_through.rs");
 include!("tests/chunks/module_hostname_wildcard_token_not_forward_resolved.rs");
 include!("tests/chunks/module_ip_deny_unaffected_by_dns_failure.rs");
 include!("tests/chunks/module_peer_hostname_forward_confirm_rejects_spoofed_ptr.rs");

--- a/crates/daemon/src/tests/chunks/module_hostname_allow_netgroup_admits_member.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_allow_netgroup_admits_member.rs
@@ -1,0 +1,26 @@
+/// A `hosts allow = @trusted` rule admits a client whose resolved hostname is a
+/// member of the `trusted` netgroup. The `@name` token routes to the netgroup
+/// membership check rather than literal hostname matching.
+///
+/// WHY: operators use netgroups to centrally manage the set of trusted hosts
+/// (add a host to the netgroup once, and every module honoring `@trusted`
+/// admits it) instead of enumerating hostnames per module. Membership is
+/// injected via the `module_state` netgroup seam so the test is deterministic
+/// without a real netgroup database.
+///
+/// upstream: access.c:41-42 `match_hostname` - `innetgr(tok + 1, host, NULL,
+/// NULL)` tests the client hostname for membership in the `@`-prefixed group.
+#[test]
+fn module_hostname_allow_netgroup_admits_member() {
+    clear_test_hostname_overrides();
+    let module = module_with_host_patterns(&["@trusted"], &[]);
+    let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 20));
+    set_test_netgroup_members("trusted", &["client.example.com"]);
+
+    assert!(
+        module.permits(peer, Some("client.example.com")),
+        "a client whose hostname is a member of the @netgroup allow rule must be admitted"
+    );
+
+    clear_test_hostname_overrides();
+}

--- a/crates/daemon/src/tests/chunks/module_hostname_netgroup_deny_blocks_member.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_netgroup_deny_blocks_member.rs
@@ -1,0 +1,28 @@
+/// A `hosts deny = @blocked` rule blocks a client whose resolved hostname is a
+/// member of the `blocked` netgroup, while a non-member is admitted.
+///
+/// WHY: netgroups are equally useful for centrally maintained deny lists; a
+/// `@netgroup` deny token must route through the same membership check and
+/// block members. Verifying a non-member is still admitted proves the deny is
+/// membership-scoped, not a blanket refusal.
+///
+/// upstream: access.c:41-42 via `access_match` over the deny list - a matching
+/// `@netgroup` deny token returns 0 (access denied).
+#[test]
+fn module_hostname_netgroup_deny_blocks_member() {
+    clear_test_hostname_overrides();
+    let module = module_with_host_patterns(&[], &["@blocked"]);
+    let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 22));
+    set_test_netgroup_members("blocked", &["bad.example.com"]);
+
+    assert!(
+        !module.permits(peer, Some("bad.example.com")),
+        "a member of the @netgroup deny rule must be blocked"
+    );
+    assert!(
+        module.permits(peer, Some("good.example.com")),
+        "a non-member must not be caught by the @netgroup deny rule"
+    );
+
+    clear_test_hostname_overrides();
+}

--- a/crates/daemon/src/tests/chunks/module_hostname_netgroup_deny_fails_closed_without_hostname.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_netgroup_deny_fails_closed_without_hostname.rs
@@ -1,0 +1,26 @@
+/// A `hosts deny = @blocked` rule fails closed when the peer has no resolved
+/// hostname: the connection is denied because the netgroup membership needed to
+/// clear the deny rule cannot be evaluated.
+///
+/// WHY: like a hostname deny token, a `@netgroup` deny token is meaningless
+/// without a resolved client hostname. Admitting a peer whose name is unknown
+/// would let a client evade a deny rule simply by lacking a PTR record. The
+/// fail-closed guard (GHSA-rjfm-3w2m-jf4f) must therefore treat `@netgroup`
+/// deny rules as requiring a hostname, matching upstream's `if (!host || !*host)
+/// return 0` bail-out before the membership test (access.c:37-38).
+///
+/// upstream: access.c:37-38 - `match_hostname` returns no-match when the host
+/// is absent, before reaching the `innetgr` netgroup branch.
+#[test]
+fn module_hostname_netgroup_deny_fails_closed_without_hostname() {
+    clear_test_hostname_overrides();
+    let module = module_with_host_patterns(&[], &["@blocked"]);
+    let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 23));
+
+    assert!(
+        !module.permits(peer, None),
+        "an @netgroup deny rule must fail closed when the peer has no resolved hostname"
+    );
+
+    clear_test_hostname_overrides();
+}

--- a/crates/daemon/src/tests/chunks/module_hostname_netgroup_non_member_falls_through.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_netgroup_non_member_falls_through.rs
@@ -1,0 +1,28 @@
+/// A `hosts allow = @trusted` rule does not admit a client that is not a member
+/// of the netgroup, so with no other allow rule the connection falls through to
+/// deny-by-default. This same path covers the musl/Windows no-op, where
+/// `innetgr` is unavailable and a `@netgroup` token can never match.
+///
+/// WHY: an unresolvable or unsupported netgroup must yield a clean non-match,
+/// never an error or panic, exactly as an upstream build compiled without
+/// `HAVE_INNETGR`. Declaring no members reproduces both a genuine non-member and
+/// the no-op platform, pinning that `@netgroup` simply fails to match rather
+/// than crashing or spuriously admitting the peer.
+///
+/// upstream: access.c:40-43 - the `innetgr` branch is compiled only under
+/// `HAVE_INNETGR`; without it a `@name` token never matches.
+#[test]
+fn module_hostname_netgroup_non_member_falls_through() {
+    clear_test_hostname_overrides();
+    let module = module_with_host_patterns(&["@trusted"], &[]);
+    let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 21));
+    // No members declared: mirrors both a genuine non-member and the
+    // musl/Windows no-op resolver that always reports no membership.
+
+    assert!(
+        !module.permits(peer, Some("stranger.example.com")),
+        "a non-member (or the no-op netgroup platform) must not satisfy an @netgroup allow rule"
+    );
+
+    clear_test_hostname_overrides();
+}

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -173,6 +173,11 @@ pub use nfsv4_acl_stub as nfsv4_acl;
 /// Fake super-user mode for preserving privileged metadata without root.
 pub mod fake_super;
 
+/// Netgroup host-membership lookup for daemon `hosts allow`/`hosts deny`
+/// `@netgroup` tokens.
+pub mod netgroup;
+pub use netgroup::host_in_netgroup;
+
 /// Windows-specific NTFS metadata helpers (reparse-point classification,
 /// future native primitives). Empty on non-Windows targets.
 #[cfg(target_os = "windows")]

--- a/crates/metadata/src/netgroup.rs
+++ b/crates/metadata/src/netgroup.rs
@@ -1,0 +1,141 @@
+//! Netgroup host-membership lookup for the daemon's `hosts allow`/`hosts deny`
+//! `@netgroup` tokens.
+//!
+//! upstream: access.c `match_hostname` - when a `hosts allow`/`hosts deny`
+//! token begins with `@`, rsync tests the connecting client's resolved
+//! hostname for membership in the named netgroup:
+//! `innetgr(tok + 1, host, NULL, NULL)` (access.c:41-42). The netgroup name is
+//! `tok + 1` (the text after `@`); the second argument is the client host; the
+//! user and domain arguments are `NULL`. A non-zero return means the host is a
+//! member.
+//!
+//! The whole branch is compiled only under `HAVE_INNETGR` (access.c:40-43): on
+//! platforms whose C library ships no `innetgr`/netgroup database - notably
+//! musl - upstream simply omits netgroup support, so a `@netgroup` token can
+//! never match. This module mirrors that exactly: where `innetgr` is available
+//! (glibc, macOS, the BSDs, illumos/Solaris) it performs the real membership
+//! test; everywhere else (musl, Windows, other targets) it is a no-op that
+//! returns `false`. A `@netgroup` rule then never matches - graceful, not an
+//! error and never a panic.
+
+/// Targets whose C library provides `innetgr` and a netgroup database.
+///
+/// glibc Linux (`target_env = "gnu"`), macOS, and the BSDs / illumos / Solaris
+/// ship `innetgr`. musl (`target_env = "musl"`), Android's bionic, Windows, and
+/// bare targets do not, and fall through to the no-op stub below.
+#[cfg(all(
+    unix,
+    any(
+        all(target_os = "linux", target_env = "gnu"),
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly",
+        target_os = "solaris",
+        target_os = "illumos",
+    )
+))]
+mod imp {
+    use std::ffi::{CString, c_char, c_int};
+    use std::ptr;
+
+    // upstream: access.c innetgr @netgroup - libc does not expose `innetgr`,
+    // so we declare the symbol directly. Signature per POSIX/BSD:
+    // `int innetgr(const char *netgroup, const char *host,
+    //              const char *user, const char *domain)`.
+    #[allow(unsafe_code)]
+    unsafe extern "C" {
+        fn innetgr(
+            netgroup: *const c_char,
+            host: *const c_char,
+            user: *const c_char,
+            domain: *const c_char,
+        ) -> c_int;
+    }
+
+    /// Real `innetgr` membership test. Interior NUL bytes make a valid C string
+    /// impossible, so such input yields `false` (no match) rather than a panic.
+    #[allow(unsafe_code)]
+    pub(super) fn host_in_netgroup(netgroup: &str, host: &str) -> bool {
+        let (Ok(netgroup), Ok(host)) = (CString::new(netgroup), CString::new(host)) else {
+            return false;
+        };
+        // SAFETY: `netgroup` and `host` are valid NUL-terminated C strings that
+        // outlive the call; `user` and `domain` are NULL, matching upstream
+        // access.c:42 `innetgr(tok + 1, host, NULL, NULL)`. `innetgr` reads the
+        // pointers but retains no references past the call.
+        let member = unsafe { innetgr(netgroup.as_ptr(), host.as_ptr(), ptr::null(), ptr::null()) };
+        member != 0
+    }
+}
+
+/// Targets without `innetgr` (musl, Windows, Android, and others): a `@netgroup`
+/// token can never match, mirroring an upstream build with `HAVE_INNETGR`
+/// undefined.
+#[cfg(not(all(
+    unix,
+    any(
+        all(target_os = "linux", target_env = "gnu"),
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly",
+        target_os = "solaris",
+        target_os = "illumos",
+    )
+)))]
+mod imp {
+    /// No-op stub: no netgroup database, so membership is always `false`.
+    pub(super) fn host_in_netgroup(_netgroup: &str, _host: &str) -> bool {
+        false
+    }
+}
+
+/// Returns whether `host` is a member of the named `netgroup`.
+///
+/// Mirrors upstream `innetgr(netgroup, host, NULL, NULL)` (access.c:42): only
+/// the netgroup's host field is consulted; the user and domain fields are
+/// ignored. Used by the daemon to evaluate `hosts allow`/`hosts deny`
+/// `@netgroup` tokens against a connecting client's resolved hostname.
+///
+/// On platforms without a netgroup database (musl, Windows, and others) this is
+/// a no-op returning `false` - a `@netgroup` rule never matches there, exactly
+/// as an upstream build compiled without `HAVE_INNETGR`. This is a graceful
+/// non-match, not an error.
+#[must_use]
+pub fn host_in_netgroup(netgroup: &str, host: &str) -> bool {
+    if netgroup.is_empty() || host.is_empty() {
+        return false;
+    }
+    imp::host_in_netgroup(netgroup, host)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_in_netgroup;
+
+    // WHY: upstream access.c:37-38 bails out (`return 0`) before calling
+    // innetgr when the host is empty; and an empty netgroup name is never a
+    // real group. Guard both so callers get a deterministic non-match instead
+    // of forwarding degenerate input to the C library.
+    #[test]
+    fn empty_inputs_never_match() {
+        assert!(!host_in_netgroup("", "host.example.com"));
+        assert!(!host_in_netgroup("trusted", ""));
+        assert!(!host_in_netgroup("", ""));
+    }
+
+    // WHY: a netgroup that the platform cannot resolve (or, on musl/Windows,
+    // netgroups being entirely unsupported) must yield a non-match, never an
+    // error or panic. Using a name that cannot exist in a real netgroup db
+    // exercises the "not a member" path consistently across every target.
+    #[test]
+    fn unknown_netgroup_yields_no_match() {
+        assert!(!host_in_netgroup(
+            "oc-rsync-nonexistent-netgroup-zzz",
+            "host.invalid"
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for `@netgroup` tokens in the daemon's `hosts allow` / `hosts deny`
directives. Upstream rsyncd accepts a `@name` token in these lists: the
connecting client's resolved hostname is tested for membership in the named
netgroup via `innetgr()`. oc previously handled literal IPs, CIDRs, and
forward-resolved hostnames, but treated `@name` as an ordinary (never-matching)
hostname token.

## Upstream semantics

`access.c:match_hostname` (rsync 3.4.4, protocol 32):

```c
#ifdef HAVE_INNETGR
    if (*tok == '@' && tok[1])
        return innetgr(tok + 1, host, NULL, NULL);
#endif
```

- The netgroup name is `tok + 1` (the text after `@`); the second argument is
  the client's resolved hostname; the user and domain arguments are `NULL`, so
  only the netgroup's host field is consulted (`access.c:41-42`).
- The whole list is lowercased before tokenizing (`strlower(list2)`,
  `access.c:251`), so the netgroup name is matched case-insensitively.
- `match_hostname` returns no-match when the host is empty
  (`if (!host || !*host) return 0`, `access.c:37-38`), before reaching the
  netgroup branch - so a `@netgroup` rule requires a resolved client hostname.
- The branch is compiled only under `HAVE_INNETGR` (`access.c:40-43`). On
  platforms whose C library ships no `innetgr`/netgroup database, upstream omits
  netgroup support and a `@name` token can never match. This is not an error.

## Design

**FFI in `metadata`, safe API to `daemon`.** `innetgr()` is libc FFI, so it lives
in `crates/metadata` (which already holds POSIX FFI such as `getpwnam_r` under a
scoped `#[allow(unsafe_code)]`). It exposes a safe function:

```rust
pub fn host_in_netgroup(netgroup: &str, host: &str) -> bool
```

`crates/daemon` stays `#![deny(unsafe_code)]` and depends only on this safe
abstraction (dependency inversion) - it never sees libc.

**musl / cross-platform no-op.** `innetgr` exists on glibc, macOS, and the BSDs
but not on musl (no netgroup database), Windows, or Android. The implementation
is `#[cfg]`-split inside `metadata`:

- On glibc Linux, macOS, and the BSDs / illumos / Solaris: a real `innetgr`
  call (the symbol is declared directly, as `libc` does not expose it). The
  unsafe block carries a scoped `#[allow(unsafe_code)]` and a SAFETY comment.
- Everywhere else (musl, Windows, and others): a no-op returning `false`. A
  `@netgroup` rule simply never matches - graceful, exactly as an upstream build
  with `HAVE_INNETGR` undefined, and never an error or panic. This keeps musl CI
  green.

**Daemon wiring.** `HostPattern::parse` classifies a `@name` token (with a
non-empty name) into a new `HostPattern::Netgroup(name)` variant, lowercasing the
name to match upstream. During first-match-wins allow/deny evaluation, the
netgroup variant tests the client's resolved hostname through a `module_state`
seam that delegates to `metadata::host_in_netgroup` in production and to an
injected membership table in tests. A bare `@` (no name) is not a netgroup and
falls through to an ordinary hostname token, matching `tok[1]` in `access.c:41`.

Netgroup tokens also count as requiring a resolved hostname, so a `@netgroup`
deny rule fails closed when the peer has no resolved name (consistent with the
existing hostname fail-closed guard).

## Tests

- `metadata`: empty-input guard and unknown-netgroup non-match (deterministic on
  every target, including the no-op platforms).
- `daemon` parse: `@Trusted` routes to `Netgroup("trusted")`; bare `@` stays a
  hostname token.
- `daemon` allow/deny decisions (membership injected via a test seam, no real
  netgroup database): an `@netgroup` allow rule admits a member; a non-member
  (and the no-op platform) falls through to deny-by-default; an `@netgroup` deny
  rule blocks a member while admitting a non-member; a `@netgroup` deny rule
  fails closed when the peer has no resolved hostname.
- Existing literal/CIDR/hostname allow-deny tests continue to pass (no
  regression).
