### PR TITLE
fix(protocol): honor negotiated symlink-target iconv gating and strict-failure semantics

### DIFF
--- a/crates/protocol/src/flist/read/extras.rs
+++ b/crates/protocol/src/flist/read/extras.rs
@@ -22,10 +22,15 @@ impl FileListReader {
     /// Wire format: varint30(len) + raw bytes
     ///
     /// upstream: flist.c:recv_file_entry() lines 920-935
+    ///
+    /// `name` is the entry's already-read wire filename, used only to render the
+    /// `cannot convert symlink data for` diagnostic on a strict conversion
+    /// failure (mirroring upstream's `full_fname(thisname)`).
     pub(super) fn read_symlink_target<R: Read + ?Sized>(
-        &self,
+        &mut self,
         reader: &mut R,
         mode: u32,
+        name: &[u8],
     ) -> io::Result<Option<PathBuf>> {
         let is_symlink = mode & 0o170000 == 0o120000;
 
@@ -53,28 +58,32 @@ impl FileListReader {
         let mut target_bytes = vec![0u8; len];
         reader.read_exact(&mut target_bytes)?;
 
-        // upstream: flist.c:1127-1150 - when sender_symlink_iconv is set (peer
-        // advertised CF_SYMLINK_ICONV) and ic_recv is configured, run the
-        // target through iconvbufs(ic_recv, ...) so the receiver sees the
-        // local-charset bytes rather than the wire-charset (UTF-8) bytes.
-        // On conversion failure, upstream warns and empties the target
-        // (flist.c:1141-1148). We use lossy conversion instead, replacing
-        // unconvertible bytes with '?' and warning.
-        let target_bytes: std::borrow::Cow<'_, [u8]> = match self.iconv.as_ref() {
-            Some(converter) => {
-                let outcome = converter.remote_to_local_lossy(&target_bytes);
-                if outcome.had_replacements {
-                    // upstream: flist.c:1142-1145 - warn about unconvertible symlink
-                    crate::iconv::trace_conversion_warning(
-                        crate::iconv::IconvRole::Client,
-                        &String::from_utf8_lossy(&target_bytes),
-                        converter.remote_encoding_name(),
-                        converter.local_encoding_name(),
-                    );
-                }
-                outcome.output
+        // upstream: flist.c:1156 - the target is transcoded through ic_recv ONLY
+        // when `sender_symlink_iconv` (iconv active AND CF_SYMLINK_ICONV
+        // negotiated). Against a peer that lacks the capability the raw local
+        // bytes are read verbatim (flist.c:1181 `read_sbuf` else branch), so a
+        // proto-30 / pre-3.1 peer must NOT be transcoded here.
+        let target_bytes: std::borrow::Cow<'_, [u8]> = if self.symlink_iconv {
+            match self.iconv.as_ref() {
+                Some(converter) => match converter.remote_to_local(&target_bytes) {
+                    Ok(converted) => converted,
+                    Err(_) => {
+                        // upstream: flist.c:1169-1177 - strict `ic_recv` failure
+                        // warns via FERROR_XFER, sets io_error |= IOERR_GENERAL,
+                        // and empties the target (bp[0]='\0', outbuf.len=0). The
+                        // entry stays a symlink with an empty target.
+                        eprintln!(
+                            "{}",
+                            crate::iconv::cannot_convert_symlink_message("receiver", name)
+                        );
+                        self.io_error |= 1;
+                        return Ok(Some(PathBuf::new()));
+                    }
+                },
+                None => std::borrow::Cow::Borrowed(target_bytes.as_slice()),
             }
-            None => std::borrow::Cow::Borrowed(target_bytes.as_slice()),
+        } else {
+            std::borrow::Cow::Borrowed(target_bytes.as_slice())
         };
 
         #[cfg(unix)]

--- a/crates/protocol/src/flist/read/mod.rs
+++ b/crates/protocol/src/flist/read/mod.rs
@@ -108,6 +108,16 @@ pub struct FileListReader {
     flist_csum_len: usize,
     /// Optional filename encoding converter (for --iconv support).
     iconv: Option<FilenameConverter>,
+    /// Whether the negotiated session converts symlink TARGETS through iconv.
+    ///
+    /// Mirrors the sender's `sender_symlink_iconv`: the receiver only runs a
+    /// received symlink target through `ic_recv` when `--iconv` is active AND
+    /// `CF_SYMLINK_ICONV` was negotiated. Against a proto-30 / pre-3.1 peer the
+    /// target arrives as raw local bytes and must NOT be transcoded.
+    ///
+    /// upstream: flist.c:1156 gates the recv-side conversion on
+    /// `sender_symlink_iconv` (compat.c:765-767).
+    symlink_iconv: bool,
     /// Whether `--relative` (`-R`) paths are active.
     ///
     /// Controls pathname validation: when false, absolute paths (leading `/`)
@@ -177,6 +187,7 @@ impl FileListReader {
             am_root: false,
             flist_csum_len: 0,
             iconv: None,
+            symlink_iconv: false,
             relative_paths: false,
             ndx_start: 0,
             dirname_interner: PathInterner::new(),
@@ -213,6 +224,7 @@ impl FileListReader {
             am_root: false,
             flist_csum_len: 0,
             iconv: None,
+            symlink_iconv: false,
             relative_paths: false,
             ndx_start: 0,
             dirname_interner: PathInterner::new(),
@@ -364,6 +376,21 @@ impl FileListReader {
     #[must_use]
     pub const fn with_iconv(mut self, converter: FilenameConverter) -> Self {
         self.iconv = Some(converter);
+        self
+    }
+
+    /// Sets whether received symlink TARGETS are transcoded through iconv.
+    ///
+    /// Must reflect the negotiated `CF_SYMLINK_ICONV` capability AND an active
+    /// `--iconv`. When `false`, symlink targets are decoded as raw local bytes
+    /// even if a filename converter is attached.
+    ///
+    /// upstream: flist.c:1156 gates the recv-side conversion on
+    /// `sender_symlink_iconv` (compat.c:765-767).
+    #[inline]
+    #[must_use]
+    pub const fn with_symlink_iconv(mut self, symlink_iconv: bool) -> Self {
+        self.symlink_iconv = symlink_iconv;
         self
     }
 
@@ -648,7 +675,7 @@ impl FileListReader {
                 let size = self.read_size(reader)?;
                 let metadata = self.read_metadata(reader, flags)?;
                 let rdev = self.read_rdev(reader, metadata.mode, flags)?;
-                let link_target = self.read_symlink_target(reader, metadata.mode)?;
+                let link_target = self.read_symlink_target(reader, metadata.mode, &name)?;
                 let hardlink_dev_ino = self.read_hardlink_dev_ino(reader, flags, metadata.mode)?;
                 let checksum = self.read_checksum(reader, metadata.mode)?;
 

--- a/crates/protocol/src/flist/read/name.rs
+++ b/crates/protocol/src/flist/read/name.rs
@@ -132,19 +132,18 @@ impl FileListReader {
     ///
     /// When `--iconv` is used, filenames are converted from the remote encoding
     /// to the local encoding using the strict converter. A name that cannot be
-    /// represented in the local charset is reported unconditionally, records
-    /// `IOERR_GENERAL` (exit 23), and is kept with a lossy-degraded name rather
-    /// than dropped - the entry must remain so the receiver's ndx stays aligned
-    /// with the sender's.
+    /// represented in the local charset is reported, records `IOERR_GENERAL`
+    /// (exit 23), and is emptied - exactly mirroring upstream. The entry itself
+    /// remains in the file list (only its name becomes empty) so the receiver's
+    /// ndx stays aligned with the sender's.
     ///
     /// # Upstream Reference
     ///
-    /// `flist.c:749-763` `recv_file_entry()` runs the freshly-read filename
+    /// `flist.c:757-764` `recv_file_entry()` runs the freshly-read filename
     /// through `iconvbufs(ic_recv, ..., ICB_INIT)` (strict). On failure upstream
     /// sets `io_error |= IOERR_GENERAL`, prints `[%s] cannot convert filename:
-    /// %s (%s)` via `FERROR_UTF8`, and zeroes the output length. We surface the
-    /// same message and error but degrade the name lossily to preserve ndx
-    /// alignment.
+    /// %s (%s)` via `FERROR_UTF8`, and sets `outbuf.len = 0` so the name becomes
+    /// empty (`thisname[0] = '\0'`). We reproduce that byte-for-byte.
     ///
     /// The prefix-compression buffer (`lastname` / `state.prev_name()`)
     /// intentionally retains the wire bytes so subsequent entries can share
@@ -154,31 +153,21 @@ impl FileListReader {
             return Ok(name);
         }
 
-        let (result, failed) = {
-            // Safe: `self.iconv` was just checked to be `Some`.
-            let converter = self.iconv.as_ref().expect("iconv present");
-            match converter.remote_to_local(&name) {
-                Ok(converted) => (converted.into_owned(), false),
-                Err(_) => {
-                    // upstream: flist.c:757 - unconditional FERROR_UTF8 message.
-                    eprintln!(
-                        "{}",
-                        crate::iconv::cannot_convert_filename_message("receiver", &name)
-                    );
-                    (
-                        converter.remote_to_local_lossy(&name).output.into_owned(),
-                        true,
-                    )
-                }
+        // Safe: `self.iconv` was just checked to be `Some`.
+        let converter = self.iconv.as_ref().expect("iconv present");
+        match converter.remote_to_local(&name) {
+            Ok(converted) => Ok(converted.into_owned()),
+            Err(_) => {
+                // upstream: flist.c:759-762 - FERROR_UTF8 message, io_error, and
+                // `outbuf.len = 0` empties the name.
+                eprintln!(
+                    "{}",
+                    crate::iconv::cannot_convert_filename_message("receiver", &name)
+                );
+                self.io_error |= 1;
+                Ok(Vec::new())
             }
-        };
-
-        if failed {
-            // upstream: flist.c:759 - io_error |= IOERR_GENERAL (rsync.h: 1).
-            self.io_error |= 1;
         }
-
-        Ok(result)
     }
 
     /// Cleans and validates a filename received from the sender.

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -2612,11 +2612,12 @@ mod iconv_integration {
         data
     }
 
-    /// Symlink targets are decoded by `ic_recv` when `--iconv=LOCAL,REMOTE`
-    /// is in effect and CF_SYMLINK_ICONV has been negotiated, mirroring the
-    /// upstream `sender_symlink_iconv` path.
+    /// Symlink targets are decoded by `ic_recv` ONLY when `--iconv=LOCAL,REMOTE`
+    /// is in effect AND CF_SYMLINK_ICONV has been negotiated
+    /// (`with_symlink_iconv(true)`), mirroring the upstream `sender_symlink_iconv`
+    /// path.
     ///
-    /// upstream: flist.c:1127-1150 recv_file_entry() - sender_symlink_iconv
+    /// upstream: flist.c:1156 recv_file_entry() - sender_symlink_iconv gate.
     #[cfg(unix)]
     #[test]
     fn read_symlink_target_converts_latin1_wire_bytes_to_utf8() {
@@ -2633,13 +2634,49 @@ mod iconv_integration {
         let protocol = test_protocol();
         let mut reader = FileListReader::new(protocol)
             .with_preserve_links(true)
-            .with_iconv(converter);
+            .with_iconv(converter)
+            .with_symlink_iconv(true);
 
         let mut cursor = io::Cursor::new(&data[..]);
         let entry = reader.read_entry(&mut cursor).unwrap().unwrap();
 
         let target = entry.link_target().expect("symlink target present");
         assert_eq!(target.as_os_str().as_bytes(), utf8_local);
+    }
+
+    /// A converter WITHOUT negotiated CF_SYMLINK_ICONV (proto-30 / rsync 3.0.x
+    /// peer) must leave the received symlink target as RAW wire bytes, even
+    /// while filenames would be transcoded. This is the `read_sbuf` else branch
+    /// at upstream flist.c:1181 where `sender_symlink_iconv` is 0.
+    ///
+    /// upstream: compat.c:765-767 gate; flist.c:1156/1181 branch.
+    #[cfg(unix)]
+    #[test]
+    fn read_symlink_target_without_negotiated_flag_preserves_wire_bytes() {
+        use std::os::unix::ffi::OsStrExt;
+
+        // "café" target on the wire in ISO-8859-1; must survive verbatim.
+        let latin1_wire: &[u8] = &[0x63, 0x61, 0x66, 0xe9];
+
+        let data = write_symlink_with_raw_target(latin1_wire);
+
+        // Converter attached (would transcode) but symlink_iconv defaults false.
+        let converter = FilenameConverter::new("UTF-8", "ISO-8859-1").unwrap();
+        let protocol = test_protocol();
+        let mut reader = FileListReader::new(protocol)
+            .with_preserve_links(true)
+            .with_iconv(converter);
+
+        let mut cursor = io::Cursor::new(&data[..]);
+        let entry = reader.read_entry(&mut cursor).unwrap().unwrap();
+
+        let target = entry.link_target().expect("symlink target present");
+        assert_eq!(
+            target.as_os_str().as_bytes(),
+            latin1_wire,
+            "target must stay raw wire bytes without CF_SYMLINK_ICONV",
+        );
+        assert_eq!(reader.io_error(), 0, "raw pass-through sets no io_error");
     }
 
     /// Without a converter, the symlink target wire bytes pass through
@@ -2659,6 +2696,78 @@ mod iconv_integration {
 
         let target = entry.link_target().expect("symlink target present");
         assert_eq!(target.as_os_str().as_bytes(), wire);
+    }
+
+    /// A received symlink target that cannot be strictly transcoded to the local
+    /// charset (CF_SYMLINK_ICONV negotiated) must be EMPTIED and record
+    /// `io_error` (exit 23), not kept as a `?`-mangled target.
+    ///
+    /// upstream: flist.c:1169-1177 recv_file_entry() - `io_error |=
+    /// IOERR_GENERAL`, warn, `bp[0]='\0'`, `outbuf.len = 0`.
+    #[cfg(unix)]
+    #[test]
+    fn read_symlink_target_strict_failure_empties_target_and_sets_io_error() {
+        use std::os::unix::ffi::OsStrExt;
+
+        // "あ" (U+3042) in UTF-8 has no ISO-8859-1 / windows-1252 representation,
+        // so a strict remote(UTF-8) -> local(ISO-8859-1) conversion fails.
+        let hiragana_utf8_wire: &[u8] = &[0xe3, 0x81, 0x82];
+        let data = write_symlink_with_raw_target(hiragana_utf8_wire);
+
+        let converter = FilenameConverter::new("ISO-8859-1", "UTF-8").unwrap();
+        let protocol = test_protocol();
+        let mut reader = FileListReader::new(protocol)
+            .with_preserve_links(true)
+            .with_iconv(converter)
+            .with_symlink_iconv(true);
+
+        let mut cursor = io::Cursor::new(&data[..]);
+        let entry = reader.read_entry(&mut cursor).unwrap().unwrap();
+
+        let target = entry.link_target().expect("symlink entry retained");
+        assert_eq!(
+            target.as_os_str().as_bytes(),
+            b"",
+            "unconvertible target must be emptied, matching upstream",
+        );
+        assert_ne!(
+            reader.io_error(),
+            0,
+            "strict symlink-target failure must record io_error (exit 23)",
+        );
+    }
+
+    /// A received FILENAME that cannot be strictly transcoded to the local
+    /// charset must be EMPTIED and record `io_error` (exit 23) - upstream's
+    /// `outbuf.len = 0` semantics, NOT a lossy `?`-mangled name.
+    ///
+    /// upstream: flist.c:757-764 recv_file_entry() - `io_error |= IOERR_GENERAL`,
+    /// FERROR_UTF8, `outbuf.len = 0`.
+    #[cfg(unix)]
+    #[test]
+    fn read_entry_strict_filename_failure_empties_name_and_sets_io_error() {
+        // "あ" (U+3042) UTF-8 wire name has no ISO-8859-1 / windows-1252
+        // representation, forcing a strict conversion failure.
+        let hiragana_utf8_wire: &[u8] = &[0xe3, 0x81, 0x82];
+        let data = write_entry_with_raw_name(hiragana_utf8_wire);
+
+        let converter = FilenameConverter::new("ISO-8859-1", "UTF-8").unwrap();
+        let protocol = test_protocol();
+        let mut reader = FileListReader::new(protocol).with_iconv(converter);
+
+        let mut cursor = io::Cursor::new(&data[..]);
+        let entry = reader.read_entry(&mut cursor).unwrap().unwrap();
+
+        assert_eq!(
+            entry.name_bytes().as_ref(),
+            b"",
+            "unconvertible filename must be emptied, matching upstream",
+        );
+        assert_ne!(
+            reader.io_error(),
+            0,
+            "strict filename failure must record io_error (exit 23)",
+        );
     }
 }
 

--- a/crates/protocol/src/flist/write/encoding.rs
+++ b/crates/protocol/src/flist/write/encoding.rs
@@ -115,14 +115,21 @@ impl FileListWriter {
             // any platform-native backslash separators are translated to forward
             // slashes before transmission.
             // upstream: flist.c:send_file_entry() lines 660-670 and util1.c:955-961
-            let target_bytes = path_bytes_to_wire(target.as_path());
-            // upstream: flist.c:1606-1621 - when sender_symlink_iconv (CF_SYMLINK_ICONV
-            // negotiated) and a converter is configured, transcode the target through
-            // ic_send (local -> wire / UTF-8) before writing.
-            let target_bytes = self.apply_encoding_conversion(&target_bytes)?;
+            let wire_bytes = path_bytes_to_wire(target.as_path());
+            // upstream: flist.c:1642 - the target is transcoded through ic_send
+            // ONLY when `sender_symlink_iconv` (iconv active AND CF_SYMLINK_ICONV
+            // negotiated). Against a peer without the capability the raw local
+            // bytes are sent verbatim, mirroring the `else` branch at flist.c:1659.
+            let converted;
+            let target_bytes: &[u8] = if self.symlink_iconv {
+                converted = self.apply_encoding_conversion(&wire_bytes)?;
+                &converted
+            } else {
+                &wire_bytes
+            };
             let len = target_bytes.len();
             write_varint30_int(writer, len as i32, self.protocol.as_u8())?;
-            writer.write_all(&target_bytes)?;
+            writer.write_all(target_bytes)?;
         }
 
         Ok(())

--- a/crates/protocol/src/flist/write/mod.rs
+++ b/crates/protocol/src/flist/write/mod.rs
@@ -92,6 +92,17 @@ pub struct FileListWriter {
     flist_csum_len: usize,
     /// Optional filename encoding converter (for --iconv support).
     iconv: Option<FilenameConverter>,
+    /// Whether the negotiated session converts symlink TARGETS through iconv.
+    ///
+    /// Filename iconv (`iconv`) and symlink-target iconv are gated separately by
+    /// upstream. The sender only transcodes a symlink target when `--iconv` is
+    /// active AND the peer negotiated `CF_SYMLINK_ICONV` (the `'s'` capability).
+    /// Against a proto-30 / pre-3.1 peer that lacks the capability, targets are
+    /// sent as raw local bytes even while filenames are transcoded.
+    ///
+    /// upstream: compat.c:765-767 `sender_symlink_iconv = iconv_opt && (...)`,
+    /// applied at flist.c:1642.
+    symlink_iconv: bool,
     /// Cached: whether varint flag encoding is enabled (computed once at construction).
     use_varint_flags: bool,
     /// Cached: whether safe file list mode is enabled (computed once at construction).
@@ -150,6 +161,7 @@ impl FileListWriter {
             always_checksum: false,
             flist_csum_len: 0,
             iconv: None,
+            symlink_iconv: false,
             use_varint_flags: false,
             use_safe_file_list: protocol.safe_file_list_always_enabled(),
             first_ndx: 0,
@@ -174,6 +186,7 @@ impl FileListWriter {
             always_checksum: false,
             flist_csum_len: 0,
             iconv: None,
+            symlink_iconv: false,
             use_varint_flags: compat_flags.contains(CompatibilityFlags::VARINT_FLIST_FLAGS),
             use_safe_file_list: compat_flags.contains(CompatibilityFlags::SAFE_FILE_LIST)
                 || protocol.safe_file_list_always_enabled(),
@@ -359,6 +372,20 @@ impl FileListWriter {
     #[must_use]
     pub const fn with_iconv(mut self, converter: FilenameConverter) -> Self {
         self.iconv = Some(converter);
+        self
+    }
+
+    /// Sets whether symlink TARGETS are transcoded through iconv.
+    ///
+    /// Must reflect the negotiated `CF_SYMLINK_ICONV` capability AND an active
+    /// `--iconv`. When `false`, symlink targets are written as raw local bytes
+    /// even if a filename converter is attached.
+    ///
+    /// upstream: compat.c:765-767 `sender_symlink_iconv`, applied at flist.c:1642.
+    #[inline]
+    #[must_use]
+    pub const fn with_symlink_iconv(mut self, symlink_iconv: bool) -> Self {
+        self.symlink_iconv = symlink_iconv;
         self
     }
 

--- a/crates/protocol/src/flist/write/tests/symlink.rs
+++ b/crates/protocol/src/flist/write/tests/symlink.rs
@@ -139,12 +139,12 @@ fn wire_encoded_symlink_target_never_contains_backslash_byte() {
 }
 
 /// Symlink targets are transcoded by the same `ic_send` converter as
-/// filenames when `--iconv=LOCAL,REMOTE` is in effect and CF_SYMLINK_ICONV
-/// has been negotiated. A UTF-8 local target must appear on the wire as
-/// ISO-8859-1 bytes when the converter is configured `(local=UTF-8,
-/// remote=ISO-8859-1)`.
+/// filenames ONLY when `--iconv=LOCAL,REMOTE` is in effect AND CF_SYMLINK_ICONV
+/// has been negotiated (`with_symlink_iconv(true)`). A UTF-8 local target must
+/// appear on the wire as ISO-8859-1 bytes when the converter is configured
+/// `(local=UTF-8, remote=ISO-8859-1)`.
 ///
-/// upstream: flist.c:1606-1621 send_file_entry() - sender_symlink_iconv path
+/// upstream: flist.c:1642 send_file1() - `sender_symlink_iconv` path.
 #[cfg(feature = "iconv")]
 #[test]
 fn write_symlink_target_transcodes_with_iconv_to_remote_charset() {
@@ -156,7 +156,8 @@ fn write_symlink_target_transcodes_with_iconv_to_remote_charset() {
     let converter = FilenameConverter::new("UTF-8", "ISO-8859-1").unwrap();
     let mut writer = FileListWriter::new(test_protocol())
         .with_preserve_links(true)
-        .with_iconv(converter);
+        .with_iconv(converter)
+        .with_symlink_iconv(true);
 
     let mut entry = FileEntry::new_symlink("link".into(), utf8_target.into());
     entry.set_mtime(1_700_000_000, 0);
@@ -172,6 +173,44 @@ fn write_symlink_target_transcodes_with_iconv_to_remote_charset() {
         !buf.windows(utf8_target_bytes.len())
             .any(|w| w == utf8_target_bytes),
         "wire bytes must not contain UTF-8 form of the symlink target, got: {buf:?}",
+    );
+}
+
+/// A converter WITHOUT negotiated CF_SYMLINK_ICONV (e.g. a proto-30 / rsync
+/// 3.0.x peer) must leave symlink targets as raw local bytes even while
+/// filenames are transcoded. This is the `else` branch at upstream flist.c:1659
+/// where `sender_symlink_iconv` is 0.
+///
+/// upstream: compat.c:765-767 - `sender_symlink_iconv = iconv_opt &&
+/// (... CF_SYMLINK_ICONV)`; flist.c:1642 gate.
+#[cfg(feature = "iconv")]
+#[test]
+fn write_symlink_target_without_negotiated_flag_passes_raw_local_bytes() {
+    use crate::iconv::FilenameConverter;
+
+    let utf8_target = "café";
+    let utf8_bytes = utf8_target.as_bytes();
+    let latin1_bytes: &[u8] = &[0x63, 0x61, 0x66, 0xe9];
+
+    // Converter is attached (filenames would transcode) but symlink_iconv is
+    // left at its default `false`, modelling a peer that did not advertise 's'.
+    let converter = FilenameConverter::new("UTF-8", "ISO-8859-1").unwrap();
+    let mut writer = FileListWriter::new(test_protocol())
+        .with_preserve_links(true)
+        .with_iconv(converter);
+
+    let mut entry = FileEntry::new_symlink("link".into(), utf8_target.into());
+    entry.set_mtime(1_700_000_000, 0);
+    let mut buf = Vec::new();
+    writer.write_entry(&mut buf, &entry).unwrap();
+
+    assert!(
+        buf.windows(utf8_bytes.len()).any(|w| w == utf8_bytes),
+        "target must stay raw UTF-8 local bytes without CF_SYMLINK_ICONV, got: {buf:?}",
+    );
+    assert!(
+        !buf.windows(latin1_bytes.len()).any(|w| w == latin1_bytes),
+        "target must NOT be transcoded to ISO-8859-1 without CF_SYMLINK_ICONV, got: {buf:?}",
     );
 }
 

--- a/crates/protocol/src/iconv/mod.rs
+++ b/crates/protocol/src/iconv/mod.rs
@@ -39,7 +39,7 @@ pub use converter::{
 };
 pub use error::{ConversionError, EncodingError};
 pub use pair::EncodingPair;
-pub use skip::{cannot_convert_filename_message, escape_filename};
+pub use skip::{cannot_convert_filename_message, cannot_convert_symlink_message, escape_filename};
 pub use trace::{
     IconvRole, trace_conversion_warning, trace_msg_checking_charset,
     trace_msg_checking_via_isprint, trace_peer_charset,

--- a/crates/protocol/src/iconv/skip.rs
+++ b/crates/protocol/src/iconv/skip.rs
@@ -32,6 +32,31 @@ pub fn cannot_convert_filename_message(role: &str, name_bytes: &[u8]) -> String 
     )
 }
 
+/// Formats the upstream `cannot convert symlink data for` diagnostic.
+///
+/// Emitted when a symlink TARGET cannot be strictly transcoded under `--iconv`
+/// while `CF_SYMLINK_ICONV` is negotiated. Unlike the filename diagnostic,
+/// upstream renders the referenced pathname through `full_fname()`, which wraps
+/// it in double quotes, so `name_bytes` (the symlink's own path) is quoted here
+/// to match.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:1648-1650` `send_file1()` - sender: `rprintf(FERROR_XFER, "[%s]
+///   cannot convert symlink data for: %s (%s)\n", who_am_i(),
+///   full_fname(fbuf), strerror(errno))`.
+/// - `flist.c:1171-1173` `recv_file_entry()` - receiver: same message via
+///   `full_fname(thisname)`.
+#[must_use]
+pub fn cannot_convert_symlink_message(role: &str, name_bytes: &[u8]) -> String {
+    format!(
+        "[{}] cannot convert symlink data for: \"{}\" ({})",
+        role,
+        escape_filename(name_bytes),
+        eilseq_strerror()
+    )
+}
+
 /// Escapes non-printable bytes in a filename for terminal output, matching
 /// upstream rsync's `filtered_fwrite()` octal escape (`log.c:239` `"\#%03o"`).
 ///
@@ -99,6 +124,18 @@ mod tests {
         let msg = cannot_convert_filename_message("sender", b"caf\xe9.txt");
         assert!(
             msg.starts_with("[sender] cannot convert filename: caf\\#351.txt ("),
+            "{msg}"
+        );
+        assert!(msg.ends_with(')'), "{msg}");
+    }
+
+    #[test]
+    fn symlink_message_shape_matches_upstream() {
+        // upstream renders the referenced pathname via `full_fname()`, which
+        // wraps it in double quotes; the wording is "symlink data for".
+        let msg = cannot_convert_symlink_message("receiver", b"link");
+        assert!(
+            msg.starts_with("[receiver] cannot convert symlink data for: \"link\" ("),
             "{msg}"
         );
         assert!(msg.ends_with(')'), "{msg}");

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -368,7 +368,17 @@ impl GeneratorContext {
         }
 
         if let Some(ref converter) = self.config.connection.iconv {
-            writer = writer.with_iconv(converter.clone());
+            // upstream: compat.c:765-767 `sender_symlink_iconv = iconv_opt &&
+            // (... CF_SYMLINK_ICONV)`. Symlink-target iconv is gated separately
+            // from filename iconv: only transcode targets when the peer
+            // negotiated CF_SYMLINK_ICONV. A proto-30 / pre-3.1 peer receives
+            // raw local target bytes.
+            let symlink_iconv = self
+                .compat_flags
+                .is_some_and(|f| f.contains(CompatibilityFlags::SYMLINK_ICONV));
+            writer = writer
+                .with_iconv(converter.clone())
+                .with_symlink_iconv(symlink_iconv);
         }
         writer
     }

--- a/crates/transfer/src/generator/file_list/iconv.rs
+++ b/crates/transfer/src/generator/file_list/iconv.rs
@@ -14,15 +14,18 @@
 //! - `flist.c:1614-1638` `send_file1()` - strict `ic_send` conversion + skip.
 //! - `flist.c:757` `recv_file_entry()` - the receiver mirrors this.
 
+use protocol::CompatibilityFlags;
 use protocol::flist::DualFileList;
+use protocol::flist::FileEntry;
 
 use super::super::GeneratorContext;
 use super::super::io_error_flags;
 
 impl GeneratorContext {
-    /// Drops file-list entries whose names cannot be strictly transcoded to
-    /// the remote charset under `--iconv`, emitting the upstream diagnostic and
-    /// recording `IOERR_GENERAL` (exit 23) for each.
+    /// Drops file-list entries whose name - or, when `CF_SYMLINK_ICONV` was
+    /// negotiated, symlink TARGET - cannot be strictly transcoded to the remote
+    /// charset under `--iconv`, emitting the upstream diagnostic and recording
+    /// `IOERR_GENERAL` (exit 23) for each.
     ///
     /// Runs after the filesystem walk populates `file_list`/`source_bases` and
     /// before the sort, so dropped entries never receive an ndx. A directory
@@ -32,8 +35,11 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:1631` `send_file1()` - `rprintf(FERROR_XFER, "[%s] cannot
-    ///   convert filename: %s (%s)\n", ...)` then `return NULL`.
+    /// - `flist.c:1631` `send_file1()` - name failure: `rprintf(FERROR_XFER,
+    ///   "[%s] cannot convert filename: %s (%s)\n", ...)` then `return NULL`.
+    /// - `flist.c:1642-1651` `send_file1()` - symlink-target failure (guarded by
+    ///   `symlink_len && sender_symlink_iconv`): `rprintf(FERROR_XFER, "[%s]
+    ///   cannot convert symlink data for: %s (%s)\n", ...)` then `return NULL`.
     pub(super) fn drop_unconvertible_entries(&mut self) {
         let Some(converter) = self.config.connection.iconv.clone() else {
             return;
@@ -41,6 +47,14 @@ impl GeneratorContext {
         if converter.is_identity() {
             return;
         }
+
+        // upstream: compat.c:765-767 - the symlink TARGET is only strict-checked
+        // (and thus only a drop condition) when `sender_symlink_iconv` is set,
+        // i.e. the peer negotiated CF_SYMLINK_ICONV. Otherwise targets ship as
+        // raw local bytes and never gate list membership.
+        let symlink_iconv = self
+            .compat_flags
+            .is_some_and(|f| f.contains(CompatibilityFlags::SYMLINK_ICONV));
 
         let entries = std::mem::take(&mut self.file_list).into_vec();
         let bases = std::mem::take(&mut self.source_bases);
@@ -52,19 +66,7 @@ impl GeneratorContext {
         // interned source base; going through `push_file_item` would re-derive a
         // base by treating the stored base as a full path, which is wrong.
         for (entry, base) in entries.into_iter().zip(bases) {
-            let convertible = {
-                let name = entry.name_bytes();
-                let ok = converter.local_to_remote(&name).is_ok();
-                if !ok {
-                    // upstream: flist.c:1631 - unconditional FERROR_XFER message.
-                    eprintln!(
-                        "{}",
-                        protocol::iconv::cannot_convert_filename_message("sender", &name)
-                    );
-                }
-                ok
-            };
-            if convertible {
+            if Self::entry_is_convertible(&converter, symlink_iconv, &entry) {
                 self.file_list.push(entry);
                 self.source_bases.push(base);
             } else {
@@ -76,5 +78,120 @@ impl GeneratorContext {
             // upstream: flist.c:1633 - io_error |= IOERR_GENERAL -> exit 23.
             self.add_io_error(io_error_flags::IOERR_GENERAL);
         }
+    }
+
+    /// Returns whether `entry` survives strict `--iconv` transcoding, emitting
+    /// the matching upstream `FERROR_XFER` diagnostic when it does not.
+    ///
+    /// The name is checked first (upstream `send_file1` returns before ever
+    /// reaching the symlink block on a name failure), so at most one message is
+    /// printed per entry, matching upstream.
+    fn entry_is_convertible(
+        converter: &protocol::iconv::FilenameConverter,
+        symlink_iconv: bool,
+        entry: &FileEntry,
+    ) -> bool {
+        let name = entry.name_bytes();
+        if converter.local_to_remote(&name).is_err() {
+            // upstream: flist.c:1631 - FERROR_XFER "cannot convert filename".
+            eprintln!(
+                "{}",
+                protocol::iconv::cannot_convert_filename_message("sender", &name)
+            );
+            return false;
+        }
+
+        // upstream: flist.c:1642 - `if (symlink_len && sender_symlink_iconv)`.
+        if symlink_iconv
+            && entry.is_symlink()
+            && let Some(target) = entry.link_target()
+        {
+            let target_bytes = symlink_target_bytes(target);
+            if converter.local_to_remote(&target_bytes).is_err() {
+                // upstream: flist.c:1648 - FERROR_XFER "cannot convert symlink
+                // data for", keyed by the symlink's own path.
+                eprintln!(
+                    "{}",
+                    protocol::iconv::cannot_convert_symlink_message("sender", &name)
+                );
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+/// Returns the local-charset bytes of a symlink target for strict-convertibility
+/// testing. Mirrors the bytes the flist writer feeds to `ic_send`: the
+/// wire-form separator normalisation (`\` -> `/`) applied by the writer is
+/// separator-only and cannot change strict convertibility, so the raw local
+/// bytes are tested directly.
+#[cfg(unix)]
+fn symlink_target_bytes(target: &std::path::Path) -> std::borrow::Cow<'_, [u8]> {
+    use std::os::unix::ffi::OsStrExt;
+    std::borrow::Cow::Borrowed(target.as_os_str().as_bytes())
+}
+
+/// Non-Unix variant: `OsStr` bytes are WTF-8; the flist writer emits the same
+/// bytes (after `\` -> `/` normalisation, which is convertibility-neutral).
+#[cfg(not(unix))]
+fn symlink_target_bytes(target: &std::path::Path) -> std::borrow::Cow<'_, [u8]> {
+    std::borrow::Cow::Borrowed(target.as_os_str().as_encoded_bytes())
+}
+
+#[cfg(all(test, feature = "iconv", unix))]
+mod drop_decision_tests {
+    use super::*;
+    use protocol::flist::FileEntry;
+    use protocol::iconv::FilenameConverter;
+
+    /// local=UTF-8, remote=ISO-8859-1: a `あ` (U+3042) byte sequence has no
+    /// Latin-1 / windows-1252 representation, so `local_to_remote` fails
+    /// strictly. (`€` is avoided because encoding_rs maps the ISO-8859-1 label
+    /// to windows-1252, which DOES contain `€` at 0x80.)
+    fn latin1_converter() -> FilenameConverter {
+        FilenameConverter::new("UTF-8", "ISO-8859-1").expect("converter builds")
+    }
+
+    /// upstream: flist.c:1642-1651 - with `sender_symlink_iconv` (CF_SYMLINK_ICONV
+    /// negotiated) an unconvertible symlink TARGET makes `send_file1` `return
+    /// NULL`, dropping the entry. The name here converts fine, so the target is
+    /// the sole drop cause.
+    #[test]
+    fn symlink_with_unconvertible_target_dropped_when_negotiated() {
+        let conv = latin1_converter();
+        let entry = FileEntry::new_symlink("link".into(), "あ".into());
+        assert!(!GeneratorContext::entry_is_convertible(&conv, true, &entry));
+    }
+
+    /// Without CF_SYMLINK_ICONV the target ships as raw local bytes and never
+    /// gates list membership - the entry survives even with a non-Latin-1 target.
+    ///
+    /// upstream: flist.c:1642 gate `sender_symlink_iconv` is 0.
+    #[test]
+    fn symlink_with_unconvertible_target_kept_when_not_negotiated() {
+        let conv = latin1_converter();
+        let entry = FileEntry::new_symlink("link".into(), "あ".into());
+        assert!(GeneratorContext::entry_is_convertible(&conv, false, &entry));
+    }
+
+    /// An unconvertible NAME is always a drop cause, independent of the symlink
+    /// gate. upstream: flist.c:1631 `return NULL`.
+    #[test]
+    fn unconvertible_name_always_dropped() {
+        let conv = latin1_converter();
+        let entry = FileEntry::new_file("あ".into(), 0, 0o100_644);
+        assert!(!GeneratorContext::entry_is_convertible(
+            &conv, false, &entry
+        ));
+    }
+
+    /// A fully convertible symlink survives even with the gate on.
+    #[test]
+    fn convertible_symlink_survives_with_gate_on() {
+        let conv = latin1_converter();
+        let entry = FileEntry::new_symlink("link".into(), "sub/target".into());
+        assert!(GeneratorContext::entry_is_convertible(&conv, true, &entry));
     }
 }

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -588,7 +588,16 @@ impl ReceiverContext {
         }
 
         if let Some(ref converter) = self.config.connection.iconv {
-            reader = reader.with_iconv(converter.clone());
+            // upstream: flist.c:1156 gates recv-side symlink-target conversion on
+            // `sender_symlink_iconv` (compat.c:765-767). Only transcode targets
+            // when the peer negotiated CF_SYMLINK_ICONV; otherwise the target
+            // arrives as raw local bytes and must pass through untouched.
+            let symlink_iconv = self
+                .compat_flags
+                .is_some_and(|f| f.contains(protocol::CompatibilityFlags::SYMLINK_ICONV));
+            reader = reader
+                .with_iconv(converter.clone())
+                .with_symlink_iconv(symlink_iconv);
         }
 
         reader


### PR DESCRIPTION
## Summary

The `--iconv` filename/symlink-target path diverged from upstream rsync 3.4.4
(protocol 32) in four ways. Symlink-target transcoding was not gated on the
negotiated `CF_SYMLINK_ICONV` capability, and three strict-failure paths kept
lossy `?`/U+FFFD-mangled data instead of upstream's drop-or-empty + `io_error`
semantics. Against a peer that lacks the capability (e.g. proto-30 / rsync
3.0.x) this silently transcoded symlink targets that upstream sends raw, and on
unconvertible input it produced different bytes and a different exit code than
upstream. All four are fixed to match the upstream C byte-for-byte.

## Divergences fixed

1. **Symlink-target iconv must honor negotiated `CF_SYMLINK_ICONV`.**
   Upstream computes `sender_symlink_iconv = iconv_opt && (am_server ?
   strchr(client_info,'s') : (compat_flags & CF_SYMLINK_ICONV))`
   (`compat.c:765-767`) and gates the symlink-target conversion separately from
   the filename conversion on both send (`flist.c:1642`) and receive
   (`flist.c:1156`). oc attached the converter to the symlink-target
   writer/reader whenever `--iconv` was set, with no capability check. A single
   threaded `symlink_iconv` boolean (derived from the negotiated compat flags)
   now gates the encode/decode; without the capability, targets pass through as
   raw local bytes (`flist.c:1181` `read_sbuf` else branch / `flist.c:1659`).

2. **Sender drops a symlink entry whose target is unconvertible under strict
   iconv.** Upstream `send_file1` sets `io_error |= IOERR_GENERAL` and
   `return NULL` on the symlink target's `ic_send` failure
   (`flist.c:1642-1651`). oc used a lossy `?`-mangled target and kept the entry.
   The build-time drop pass now also strict-tests the symlink target (only when
   `symlink_iconv` gating says the target is being converted) and records
   `IOERR_GENERAL` (exit 23), keeping sender/receiver ndx aligned.

3. **Receiver empties an unconvertible received symlink target + sets
   `io_error`.** Upstream `recv_file_entry` warns, sets `io_error |=
   IOERR_GENERAL`, and empties the target (`bp[0]='\0'`, `outbuf.len = 0`) on
   `ic_recv` failure (`flist.c:1169-1177`). oc kept a `?`/U+FFFD target and only
   emitted a trace. It now empties the target and records `io_error`.

4. **Receiver empties an unconvertible received filename + sets `io_error`.**
   Upstream prints `FERROR_UTF8`, sets `io_error |= IOERR_GENERAL`, and sets
   `outbuf.len = 0` so the name becomes empty (`flist.c:757-764`). oc kept a
   lossy `?`/U+FFFD non-empty name. It now empties the name to match upstream;
   the entry stays in the list so ndx alignment is preserved.

## Upstream references verified (rsync-3.4.4)

- `compat.c:765-767` - `sender_symlink_iconv` negotiation gate.
- `flist.c:1642-1651` - `send_file1()` strict symlink-target failure -> drop.
- `flist.c:1156,1169-1178` - `recv_file_entry()` symlink-target gate + empty.
- `flist.c:757-764` - `recv_file_entry()` filename strict failure -> empty.

## Tests added

Protocol (`crates/protocol`):
- `read_symlink_target_without_negotiated_flag_preserves_wire_bytes` - no
  `CF_SYMLINK_ICONV` -> received target stays raw wire bytes, no `io_error`.
- `write_symlink_target_without_negotiated_flag_passes_raw_local_bytes` - no
  `CF_SYMLINK_ICONV` -> sent target stays raw local bytes.
- `read_symlink_target_strict_failure_empties_target_and_sets_io_error`.
- `read_entry_strict_filename_failure_empties_name_and_sets_io_error`.
- `symlink_message_shape_matches_upstream` - diagnostic wording.
- Existing transcode tests updated to require the negotiated flag
  (`with_symlink_iconv(true)`), pinning the corrected gating.

Transfer (`crates/transfer`), sender drop-decision unit tests:
- `symlink_with_unconvertible_target_dropped_when_negotiated`.
- `symlink_with_unconvertible_target_kept_when_not_negotiated`.
- `unconvertible_name_always_dropped`.
- `convertible_symlink_survives_with_gate_on`.

`cargo fmt --all --check` and `cargo clippy --all-targets --all-features
--no-deps -D warnings` are clean for the touched crates.
