### PR TITLE
fix(daemon): match upstream secrets-file group matching and symlink-munge defaults

### DIFF
--- a/crates/daemon/src/daemon/module_state/definition.rs
+++ b/crates/daemon/src/daemon/module_state/definition.rs
@@ -333,12 +333,33 @@ impl ModuleDefinition {
 
     /// Returns whether symlink munging is effective for this module.
     ///
-    /// When `munge_symlinks` is `None` (auto), defaults to `!use_chroot`.
-    /// Upstream: `clientserver.c` sets `munge_symlinks = !use_chroot` before reading
-    /// the per-module override.
+    /// An explicit `munge symlinks` directive always wins. When unset (auto),
+    /// upstream defaults munging on whenever the module is not fully chrooted -
+    /// either because `use chroot` is off, or because a partial-chroot module
+    /// path splits at a `/./` marker (`module_dirlen > 0`), which still exposes
+    /// a sanitized inner path.
+    ///
+    /// upstream: clientserver.c:997-998 -
+    /// `munge_symlinks = !use_chroot || module_dirlen`.
     #[allow(dead_code)] // Wired during file list send/receive in daemon mode
     pub(crate) fn effective_munge_symlinks(&self) -> bool {
-        self.munge_symlinks.unwrap_or(!self.use_chroot)
+        self.munge_symlinks
+            .unwrap_or(!self.use_chroot || self.has_inside_chroot_split())
+    }
+
+    /// Returns whether the module path carries an inside-chroot split marker
+    /// (`/./`) with a non-empty inner path, mirroring upstream's
+    /// `module_dirlen > 0`.
+    ///
+    /// upstream: clientserver.c:845-872 - when `use chroot` is set and the
+    /// module path contains a `/./` marker, the normalized inner path length
+    /// (`module_dirlen`) is non-zero. A `/./` at the very end (empty inner
+    /// path) normalizes to `/` and resets `module_dirlen` back to 0.
+    fn has_inside_chroot_split(&self) -> bool {
+        self.path
+            .to_str()
+            .and_then(|path| path.split_once("/./"))
+            .is_some_and(|(_, inner)| inner.split('/').any(|part| !part.is_empty() && part != "."))
     }
 
     /// Returns the per-module log file path, if configured.

--- a/crates/daemon/src/daemon/sections/module_access/authentication.rs
+++ b/crates/daemon/src/daemon/sections/module_access/authentication.rs
@@ -107,7 +107,21 @@ fn perform_module_authentication(
         }
     };
 
-    if !verify_secret_response(module, username, &challenge, digest, protocol_version)? {
+    // upstream: authenticate.c:318 - check_secret() receives the group name only
+    // when the client was authorized via a matching `@group` token in
+    // `auth users` (`group_match >= 0 ? auth_uid_groups[group_match] : NULL`).
+    // A plain-username authorization passes NULL, so `@group:` secret lines
+    // never match. The matched entry's verbatim token carries that group.
+    let auth_group = auth_user.username.strip_prefix('@');
+
+    if !verify_secret_response(
+        module,
+        username,
+        auth_group,
+        &challenge,
+        digest,
+        protocol_version,
+    )? {
         send_auth_failed(reader.get_mut(), module, limiter)?;
         return Ok(AuthenticationStatus::Denied);
     }
@@ -173,25 +187,35 @@ fn generate_auth_challenge(
 
 /// Verifies a client's authentication response against the secrets file.
 ///
-/// Reads the module's secrets file line by line, looking for a matching
-/// username entry. For matching usernames, computes the expected digest
-/// using the stored secret and challenge, then compares with the client's
-/// response.
+/// Reads the module's secrets file line by line, mirroring upstream
+/// `check_secret()`. A line whose key starts with `@` is matched against the
+/// group `auth users` used to authorize the client (`group`, `None` when the
+/// client was authorized by a plain-username token); every other line is
+/// matched against `username`. This lets a shared `@group:secret` entry
+/// authenticate any member of that group, as upstream does.
+///
+/// First-name-match wins: on the first line whose key matches but whose digest
+/// mismatches, that key is retired so later duplicate entries for the same key
+/// cannot override the denial. User and group keys are retired independently,
+/// exactly as upstream nulls the individual `user`/`group` pointer.
 ///
 /// When the module has `strict_modes` enabled (the default), the secrets file
 /// permissions are validated before reading: the file must not be accessible by
 /// "other" users.
 ///
-/// upstream: authenticate.c - `check_secret()` enforces `lp_strict_modes(module)`
-/// by rejecting files with `(st.st_mode & 06) != 0`.
+/// upstream: authenticate.c:100-169 - `check_secret()` matches `@group`/user
+/// keys, enforces `lp_strict_modes(module)` by rejecting files with
+/// `(st.st_mode & 06) != 0`, and on a password mismatch sets `*ptr = NULL`
+/// ("Don't look for name again").
 ///
 /// The `protocol_version` is forwarded to `verify_daemon_auth_response` to
 /// select the correct digest for ambiguous MD4/MD5 responses.
 ///
-/// Returns `true` if the username exists and the digest matches, `false` otherwise.
+/// Returns `true` if a matching key's digest matches, `false` otherwise.
 fn verify_secret_response(
     module: &ModuleDefinition,
     username: &str,
+    group: Option<&str>,
     challenge: &str,
     response: &str,
     protocol_version: Option<ProtocolVersion>,
@@ -219,23 +243,52 @@ fn verify_secret_response(
         Err(_) => return Ok(false),
     };
 
+    // upstream: authenticate.c:141 `while ((user || group) && ...)` - each key
+    // is retired once it mismatches, so scanning stops when neither a user nor
+    // a group line can still match.
+    let mut user_active = true;
+    let mut group_active = group.is_some();
+
     for raw_line in contents.lines() {
+        if !user_active && !group_active {
+            break;
+        }
+
         let line = raw_line.trim_end_matches('\r');
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
 
-        if let Some((user, secret)) = line.split_once(':')
-            && user == username
-            && verify_daemon_auth_response(
-                secret.as_bytes(),
-                challenge,
-                response,
-                protocol_version.map(|v| v.as_u8()),
-            )
-        {
+        // upstream: authenticate.c:145-152 - an `@`-prefixed key selects the
+        // group pointer (skipping the `@`); every other key selects the user.
+        let (active, expected, entry) = match line.strip_prefix('@') {
+            Some(rest) => (&mut group_active, group, rest),
+            None => (&mut user_active, Some(username), line),
+        };
+
+        if !*active {
+            continue;
+        }
+
+        let Some((key, secret)) = entry.split_once(':') else {
+            continue;
+        };
+        if Some(key) != expected {
+            continue;
+        }
+
+        // upstream: authenticate.c:158-163 - the first key-matching line decides
+        // the outcome; a digest match authenticates, a mismatch retires the key
+        // (`*ptr = NULL`) so later duplicates cannot flip the denial.
+        if verify_daemon_auth_response(
+            secret.as_bytes(),
+            challenge,
+            response,
+            protocol_version.map(|v| v.as_u8()),
+        ) {
             return Ok(true);
         }
+        *active = false;
     }
 
     Ok(false)

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -779,7 +779,7 @@ mod module_access_tests {
         // violation is an auth denial, not a fatal error: verify returns
         // Ok(false) so the daemon emits `@ERROR: auth failed on module X`
         // rather than dropping the socket mid-handshake.
-        let result = verify_secret_response(&module, "alice", "challenge", "response", None)
+        let result = verify_secret_response(&module, "alice", None, "challenge", "response", None)
             .expect("strict-modes violation must be a denial, not an io error");
         assert!(
             !result,
@@ -804,7 +804,7 @@ mod module_access_tests {
 
         // With strict_modes disabled, the file is read even though it's world-readable.
         // Authentication will fail (wrong response), but no permission error is returned.
-        let result = verify_secret_response(&module, "alice", "challenge", "response", None)
+        let result = verify_secret_response(&module, "alice", None, "challenge", "response", None)
             .expect("should not error on permissions");
         assert!(
             !result,
@@ -829,11 +829,105 @@ mod module_access_tests {
 
         // Permissions are fine, so the file is read. Auth will fail (wrong response)
         // but no permission error is returned.
-        let result = verify_secret_response(&module, "alice", "challenge", "response", None)
+        let result = verify_secret_response(&module, "alice", None, "challenge", "response", None)
             .expect("should not error on permissions");
         assert!(!result, "auth should fail due to wrong response");
     }
 
+    /// Computes the client digest a member of the authorizing group (or the
+    /// user) would send for `secret`, so the shared-secret tests below assert
+    /// real authentication rather than a hard-coded string.
+    fn client_digest(secret: &str, challenge: &str) -> String {
+        core::auth::compute_daemon_auth_response(
+            secret.as_bytes(),
+            challenge,
+            core::auth::DaemonAuthDigest::Md5,
+        )
+    }
+
+    /// A shared `@group:secret` line authenticates a member authorized through
+    /// that same group token. Upstream matches such a line against the group
+    /// name that `auth users` resolved, so the shared entry is the credential
+    /// for every member - without this, a `auth users = @grp` + `@grp:pass`
+    /// config would authorize the user then wrongly deny at the secret lookup.
+    ///
+    /// upstream: authenticate.c:145-156 - an `@`-prefixed secrets key is matched
+    /// against the authorizing group rather than the username.
+    #[test]
+    fn verify_secret_matches_group_line_for_group_member() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let secrets = dir.path().join("secrets");
+        fs::write(&secrets, "@devs:groupsecret\n").expect("write");
+
+        let module = ModuleDefinition {
+            secrets_file: Some(secrets),
+            strict_modes: false,
+            ..Default::default()
+        };
+
+        let challenge = "challenge";
+        let response = client_digest("groupsecret", challenge);
+
+        // Authorized via the `@devs` token: the group line is the credential.
+        let granted =
+            verify_secret_response(&module, "alice", Some("devs"), challenge, &response, None)
+                .expect("no io error");
+        assert!(granted, "group member must authenticate via @devs shared secret");
+
+        // upstream: authenticate.c:318 - a plain-username authorization passes a
+        // NULL group, so `@group:` lines are never consulted. Denied here.
+        let denied = verify_secret_response(&module, "alice", None, challenge, &response, None)
+            .expect("no io error");
+        assert!(
+            !denied,
+            "a @group secret must not match when the user was not authorized via that group"
+        );
+    }
+
+    /// Duplicate username entries: the first key-matching line decides the
+    /// outcome. An earlier wrong-password line retires the username, so a later
+    /// correct-password line for the same user cannot flip the denial. This
+    /// mirrors upstream setting the name pointer to NULL on mismatch.
+    ///
+    /// upstream: authenticate.c:158-162 - on password mismatch `err =
+    /// "password mismatch"; *ptr = NULL;` ends the search for that name.
+    #[test]
+    fn verify_secret_first_username_match_wins() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let secrets = dir.path().join("secrets");
+        fs::write(&secrets, "alice:wrongpass\nalice:rightpass\n").expect("write");
+
+        let module = ModuleDefinition {
+            secrets_file: Some(secrets),
+            strict_modes: false,
+            ..Default::default()
+        };
+
+        let challenge = "challenge";
+        let response = client_digest("rightpass", challenge);
+
+        // The first `alice:` line mismatches, retiring the username; the later
+        // `alice:rightpass` duplicate must NOT authenticate.
+        let denied = verify_secret_response(&module, "alice", None, challenge, &response, None)
+            .expect("no io error");
+        assert!(
+            !denied,
+            "an earlier wrong-password line must retire the username and deny"
+        );
+
+        // Control: when the first line is the correct one, auth succeeds.
+        let secrets_ok = dir.path().join("secrets_ok");
+        fs::write(&secrets_ok, "alice:rightpass\nalice:wrongpass\n").expect("write");
+        let module_ok = ModuleDefinition {
+            secrets_file: Some(secrets_ok),
+            strict_modes: false,
+            ..Default::default()
+        };
+        let granted =
+            verify_secret_response(&module_ok, "alice", None, challenge, &response, None)
+                .expect("no io error");
+        assert!(granted, "a correct first line must authenticate");
+    }
 
     #[test]
     fn read_client_arguments_normal_protocol30() {

--- a/crates/daemon/src/daemon/sections/symlink_munge.rs
+++ b/crates/daemon/src/daemon/sections/symlink_munge.rs
@@ -174,4 +174,47 @@ mod symlink_munge_tests {
         };
         assert!(!def.effective_munge_symlinks());
     }
+
+    /// A chrooted module whose path splits at a `/./` marker is only partially
+    /// confined (`module_dirlen > 0`), so munging must still default ON to keep
+    /// symlinks from escaping the sanitized inner path. A bare `use chroot=yes`
+    /// with a non-split path stays OFF (covered by `effective_munge_auto_chroot_on`).
+    ///
+    /// upstream: clientserver.c:997-998 - `munge_symlinks = !use_chroot || module_dirlen`.
+    #[test]
+    fn effective_munge_auto_chroot_partial_split_on() {
+        let def = ModuleDefinition {
+            use_chroot: true,
+            munge_symlinks: None,
+            path: "/srv/./data".into(),
+            ..Default::default()
+        };
+        assert!(def.effective_munge_symlinks());
+    }
+
+    /// An explicit `munge symlinks = no` still wins over the partial-chroot
+    /// default, matching upstream's `lp_munge_symlinks(i) >= 0` short-circuit.
+    #[test]
+    fn effective_munge_explicit_false_overrides_partial_split() {
+        let def = ModuleDefinition {
+            use_chroot: true,
+            munge_symlinks: Some(false),
+            path: "/srv/./data".into(),
+            ..Default::default()
+        };
+        assert!(!def.effective_munge_symlinks());
+    }
+
+    /// A `/./` at the very end has an empty inner path, so upstream normalizes
+    /// it to `/` and resets `module_dirlen` to 0 - munging stays OFF.
+    #[test]
+    fn effective_munge_auto_chroot_trailing_split_off() {
+        let def = ModuleDefinition {
+            use_chroot: true,
+            munge_symlinks: None,
+            path: "/srv/./".into(),
+            ..Default::default()
+        };
+        assert!(!def.effective_munge_symlinks());
+    }
 }


### PR DESCRIPTION
## Summary

Three daemon-side authentication and symlink-munging behaviours diverged from
upstream rsync 3.4.4 (protocol 32). This change brings the secrets-file matcher
and the symlink-munge default in line with the upstream C source.

## Changes

### 1. `@group:secret` secrets-file lines now authenticate group members

Upstream's `check_secret()` matches a secrets line whose key begins with `@`
against the group name that authorized the client via `auth users`, so a shared
`@group:secret` line is the credential for every member of that group. oc only
compared the key against the username, so a module configured with
`auth users = @grp` plus a single shared `@grp:pass` entry authorized the user
during the `auth users` check and then wrongly denied at the secret lookup.

The matcher now threads the authorizing group (the `@group` token that matched
in `auth users`) into the secrets scan and matches `@`-prefixed keys against it.
A plain-username authorization passes no group, so `@group:` lines are never
consulted - exactly as upstream passes a NULL group in that case.

upstream: `authenticate.c:145-156` (group/user key selection) and
`authenticate.c:318` (`group_match >= 0 ? auth_uid_groups[group_match] : NULL`).

### 2. First-name-match-wins for duplicate secrets entries

Upstream retires a key on the first line whose name matches but whose password
mismatches (`*ptr = NULL; /* Don't look for name again. */`), so later duplicate
entries for the same name cannot flip the denial. oc scanned every line and
accepted if any line with the matching name carried the correct password,
granting access where upstream denies (earlier wrong password, later right
password). The scan now retires the user and group keys independently and stops
once neither can still match.

upstream: `authenticate.c:158-162`.

### 3. Symlink-munge default honours partial-chroot (`module_dirlen`)

Upstream defaults munging on with `munge_symlinks = !use_chroot || module_dirlen`.
When `use chroot = yes` but the module path splits at a `/./` marker
(`module_dirlen > 0`, a partially-confined module), munging still defaults ON.
oc defaulted OFF whenever `use_chroot` was set, ignoring the split-path case.

`effective_munge_symlinks()` now defaults to
`!use_chroot || has_inside_chroot_split()`, where the split test mirrors
upstream's `module_dirlen > 0`: a `/./` marker with a non-empty inner path.
A trailing `/./` (empty inner path) normalizes to `/` and keeps munging OFF, and
an explicit `munge symlinks = ...` directive still wins.

upstream: `clientserver.c:997-998` (`munge_symlinks = !use_chroot || module_dirlen`)
and `clientserver.c:845-872` (how `module_dirlen` is derived from the `/./` split).

## Tests

- `verify_secret_matches_group_line_for_group_member` - a `@devs:secret` line
  authenticates a member authorized via `@devs`, and is not consulted when the
  client was authorized by a plain username.
- `verify_secret_first_username_match_wins` - duplicate `alice:` entries with an
  earlier wrong password and a later right password are denied; the correct-first
  ordering still authenticates.
- `effective_munge_auto_chroot_partial_split_on` - `use chroot = yes` with path
  `/srv/./data` defaults munging ON.
- `effective_munge_explicit_false_overrides_partial_split` - an explicit
  `munge symlinks = no` still wins over the partial-chroot default.
- `effective_munge_auto_chroot_trailing_split_off` - a trailing `/srv/./` keeps
  munging OFF (empty inner path).
