### PR TITLE
fix(protocol): reject out-of-range hardlink reference index with RERR_PROTOCOL

### DIFF
--- a/crates/protocol/src/flist/read/mod.rs
+++ b/crates/protocol/src/flist/read/mod.rs
@@ -570,80 +570,65 @@ impl FileListReader {
                 };
                 let leader_local_idx = (idx as i32 - self.ndx_start) as usize;
 
-                if let Some(leader) = segment_entries.get(leader_local_idx) {
-                    // upstream: flist.c:795-810 - copy fields from leader
-                    let leader_mode = leader.mode();
-                    let leader_mtime = leader.mtime();
-                    let leader_uid = leader.uid();
-                    let leader_gid = leader.gid();
-                    let leader_atime = leader.atime();
+                // upstream: flist.c:794-799 - a follower whose reference index
+                // is beyond the entries received so far (>= ndx_start + used)
+                // is a protocol violation. Upstream logs "hard-link reference
+                // out of range" and aborts with exit_cleanup(RERR_PROTOCOL).
+                // Mirror that abort instead of silently substituting zero
+                // metadata, which would desync the remaining decode.
+                let Some(leader) = segment_entries.get(leader_local_idx) else {
+                    return Err(crate::protocol_violation::protocol_violation(format!(
+                        "hard-link reference out of range: {idx} ({})",
+                        self.ndx_start as i64 + segment_entries.len() as i64
+                    )));
+                };
 
-                    // Update compression state to match sender's statics
-                    // upstream: sender updates mode/modtime/uid/gid/atime at
-                    // flist.c:430-493 BEFORE goto the_end
-                    self.state.update_mode(leader_mode);
-                    self.state.update_mtime(leader_mtime);
-                    if let Some(uid) = leader_uid {
-                        self.state.update_uid(uid);
-                    }
-                    if let Some(gid) = leader_gid {
-                        self.state.update_gid(gid);
-                    }
-                    if (leader_mode & 0o170000) != 0o040000 {
-                        self.state.update_atime(leader_atime);
-                    }
+                // upstream: flist.c:795-810 - copy fields from leader
+                let leader_mode = leader.mode();
+                let leader_mtime = leader.mtime();
+                let leader_uid = leader.uid();
+                let leader_gid = leader.gid();
+                let leader_atime = leader.atime();
 
-                    (
-                        leader.size(),
-                        MetadataResult {
-                            mtime: leader_mtime,
-                            nsec: leader.mtime_nsec(),
-                            mode: leader_mode,
-                            uid: leader_uid,
-                            gid: leader_gid,
-                            user_name: None,
-                            group_name: None,
-                            atime: if leader_atime != 0 {
-                                Some(leader_atime)
-                            } else {
-                                None
-                            },
-                            atime_nsec: leader.atime_nsec(),
-                            crtime: None,
-                            content_dir: (leader_mode & 0o170000) == 0o040000,
-                        },
-                        leader.link_target().cloned(),
-                        leader.rdev_major().zip(leader.rdev_minor()),
-                        None,
-                        leader.checksum().map(|s| s.to_vec()),
-                    )
-                } else {
-                    // Leader not available (segment_entries not provided or
-                    // index out of range) - fall back to zero metadata.
-                    // Compression state is NOT updated, which may cause
-                    // subsequent decode errors if the caller didn't pass
-                    // segment_entries.
-                    (
-                        0u64,
-                        MetadataResult {
-                            mtime: 0,
-                            nsec: 0,
-                            mode: 0,
-                            uid: None,
-                            gid: None,
-                            user_name: None,
-                            group_name: None,
-                            atime: None,
-                            atime_nsec: 0,
-                            crtime: None,
-                            content_dir: true,
-                        },
-                        None,
-                        None,
-                        None,
-                        None,
-                    )
+                // Update compression state to match sender's statics
+                // upstream: sender updates mode/modtime/uid/gid/atime at
+                // flist.c:430-493 BEFORE goto the_end
+                self.state.update_mode(leader_mode);
+                self.state.update_mtime(leader_mtime);
+                if let Some(uid) = leader_uid {
+                    self.state.update_uid(uid);
                 }
+                if let Some(gid) = leader_gid {
+                    self.state.update_gid(gid);
+                }
+                if (leader_mode & 0o170000) != 0o040000 {
+                    self.state.update_atime(leader_atime);
+                }
+
+                (
+                    leader.size(),
+                    MetadataResult {
+                        mtime: leader_mtime,
+                        nsec: leader.mtime_nsec(),
+                        mode: leader_mode,
+                        uid: leader_uid,
+                        gid: leader_gid,
+                        user_name: None,
+                        group_name: None,
+                        atime: if leader_atime != 0 {
+                            Some(leader_atime)
+                        } else {
+                            None
+                        },
+                        atime_nsec: leader.atime_nsec(),
+                        crtime: None,
+                        content_dir: (leader_mode & 0o170000) == 0o040000,
+                    },
+                    leader.link_target().cloned(),
+                    leader.rdev_major().zip(leader.rdev_minor()),
+                    None,
+                    leader.checksum().map(|s| s.to_vec()),
+                )
             } else {
                 let size = self.read_size(reader)?;
                 let metadata = self.read_metadata(reader, flags)?;

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -1677,6 +1677,105 @@ fn read_entry_rejects_mode_zero_without_delete_missing_args() {
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
 }
 
+/// upstream: flist.c:794-799 recv_file_entry() validates the abbreviated
+/// hard-link follower's reference index against the entries received so far
+/// (`first_hlink_ndx < 0 || first_hlink_ndx >= flist->ndx_start + flist->used`)
+/// and aborts with exit_cleanup(RERR_PROTOCOL) when it is out of range. A
+/// hostile sender that points a follower past the leaders it has actually sent
+/// must be refused with a protocol error - not decoded on with zero-filled
+/// metadata, which would silently desync every subsequent entry in the stream.
+#[test]
+fn abbreviated_hardlink_follower_out_of_range_is_protocol_violation() {
+    use crate::flist::write::FileListWriter;
+
+    let protocol = test_protocol();
+    let mut data = Vec::new();
+    let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
+
+    // NDX 0: a valid leader. NDX 1: a follower whose index (99) points far
+    // beyond the single leader received so far, so it is out of range.
+    let mut leader = FileEntry::new_file("leader".into(), 100, 0o100644);
+    leader.set_mtime(1700000000, 0);
+    leader.set_hardlink_idx(u32::MAX);
+    let mut follower = FileEntry::new_file("bogus".into(), 100, 0o100644);
+    follower.set_hardlink_idx(99);
+
+    writer.write_entry(&mut data, &leader).unwrap();
+    writer.write_entry(&mut data, &follower).unwrap();
+
+    let mut cursor = Cursor::new(&data[..]);
+    let mut reader = FileListReader::new(protocol).with_preserve_hard_links(true);
+
+    // Decode the leader; it is the only entry received so far.
+    let mut segment: Vec<FileEntry> = Vec::new();
+    let leader_entry = reader
+        .read_entry_with_flist(&mut cursor, &segment)
+        .expect("leader decodes")
+        .expect("leader present");
+    segment.push(leader_entry);
+
+    // The out-of-range follower must abort with RERR_PROTOCOL, not zero-fill.
+    let err = reader
+        .read_entry_with_flist(&mut cursor, &segment)
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::ProtocolViolation>()),
+        "out-of-range hard-link reference must be tagged RERR_PROTOCOL (exit 2)",
+    );
+    assert!(
+        err.to_string().contains("hard-link reference out of range"),
+        "error message must mirror upstream flist.c:795, got: {err}",
+    );
+}
+
+/// A follower whose reference index is in range (its leader precedes it in the
+/// same segment) still decodes cleanly and inherits the leader's metadata,
+/// proving the bounds check in
+/// `abbreviated_hardlink_follower_out_of_range_is_protocol_violation` never
+/// rejects a legitimate follower. upstream: flist.c:795-810.
+#[test]
+fn abbreviated_hardlink_follower_in_range_decodes() {
+    use crate::flist::write::FileListWriter;
+
+    let protocol = test_protocol();
+    let mut data = Vec::new();
+    let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
+
+    let mut leader = FileEntry::new_file("leader".into(), 500, 0o100644);
+    leader.set_mtime(1700000000, 0);
+    leader.set_hardlink_idx(u32::MAX);
+    let mut follower = FileEntry::new_file("link".into(), 500, 0o100644);
+    follower.set_hardlink_idx(0); // points to the leader at NDX 0
+
+    writer.write_entry(&mut data, &leader).unwrap();
+    writer.write_entry(&mut data, &follower).unwrap();
+    writer.write_end(&mut data, None).unwrap();
+
+    let mut cursor = Cursor::new(&data[..]);
+    let mut reader = FileListReader::new(protocol).with_preserve_hard_links(true);
+
+    // Thread the accumulating segment, exactly as the real receiver does.
+    let mut segment: Vec<FileEntry> = Vec::new();
+    loop {
+        let next = reader
+            .read_entry_with_flist(&mut cursor, &segment)
+            .expect("entry decodes");
+        match next {
+            Some(entry) => segment.push(entry),
+            None => break,
+        }
+    }
+
+    assert_eq!(segment.len(), 2);
+    assert_eq!(segment[1].name(), "link");
+    assert_eq!(segment[1].hardlink_idx(), Some(0));
+    // Follower metadata is skipped on the wire and copied from the leader.
+    assert_eq!(segment[1].size(), 500);
+    assert_eq!(segment[1].mtime(), 1700000000);
+}
+
 /// Tests for ACL integration in the flist read path.
 mod acl_integration {
     use super::*;

--- a/crates/protocol/src/flist/write/tests/extended_flags.rs
+++ b/crates/protocol/src/flist/write/tests/extended_flags.rs
@@ -134,22 +134,36 @@ fn extended_flags_hardlink_flag_combinations() {
         );
     }
 
-    // Test: XMIT_HLINKED only (hardlink follower)
+    // Test: XMIT_HLINKED only (hardlink follower). A follower must reference an
+    // already-seen leader (upstream flist.c:794), so write the leader at NDX 0
+    // and the follower at NDX 1 pointing back to it.
     {
         let mut buf = Vec::new();
         let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
-        let mut entry = FileEntry::new_file("follower.txt".into(), 100, 0o644);
-        entry.set_hardlink_idx(42);
-        writer.write_entry(&mut buf, &entry).unwrap();
+        let mut leader = FileEntry::new_file("leader.txt".into(), 100, 0o644);
+        leader.set_hardlink_idx(u32::MAX);
+        let mut follower = FileEntry::new_file("follower.txt".into(), 100, 0o644);
+        follower.set_hardlink_idx(0);
+        writer.write_entry(&mut buf, &leader).unwrap();
+        writer.write_entry(&mut buf, &follower).unwrap();
         writer.write_end(&mut buf, None).unwrap();
 
         let mut cursor = Cursor::new(&buf[..]);
         let mut reader = FileListReader::new(protocol).with_preserve_hard_links(true);
-        let read = reader.read_entry(&mut cursor).unwrap().unwrap();
+        let mut segment: Vec<FileEntry> = Vec::new();
+        let leader_read = reader
+            .read_entry_with_flist(&mut cursor, &segment)
+            .unwrap()
+            .unwrap();
+        segment.push(leader_read);
+        let follower_read = reader
+            .read_entry_with_flist(&mut cursor, &segment)
+            .unwrap()
+            .unwrap();
         assert_eq!(
-            read.hardlink_idx(),
-            Some(42),
-            "follower should have index 42"
+            follower_read.hardlink_idx(),
+            Some(0),
+            "follower should reference the leader at NDX 0"
         );
     }
 }

--- a/crates/protocol/src/flist/write/tests/hardlink.rs
+++ b/crates/protocol/src/flist/write/tests/hardlink.rs
@@ -1,10 +1,26 @@
+use std::io::Cursor;
+
+use super::super::super::read::FileListReader;
 use super::*;
+
+/// Decodes every entry from `buf`, threading the accumulating segment so
+/// abbreviated hardlink followers resolve their leader - exactly as the real
+/// receiver does (it passes `file_list[seg_start..]` to
+/// [`FileListReader::read_entry_with_flist`]). Panics on decode error.
+fn read_all(reader: &mut FileListReader, buf: &[u8]) -> Vec<FileEntry> {
+    let mut cursor = Cursor::new(buf);
+    let mut out: Vec<FileEntry> = Vec::new();
+    while let Some(entry) = reader
+        .read_entry_with_flist(&mut cursor, &out.clone())
+        .expect("decode entry")
+    {
+        out.push(entry);
+    }
+    out
+}
 
 #[test]
 fn write_hardlink_first_round_trip_protocol_30() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = ProtocolVersion::try_from(30u8).unwrap();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
@@ -25,32 +41,31 @@ fn write_hardlink_first_round_trip_protocol_30() {
 
 #[test]
 fn write_hardlink_follower_round_trip_protocol_30() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = ProtocolVersion::try_from(30u8).unwrap();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
 
-    let mut entry = FileEntry::new_file("file2.txt".into(), 100, 0o644);
-    entry.set_hardlink_idx(5);
+    // A follower must reference an already-seen leader (upstream flist.c:794).
+    // Write the leader at NDX 0 and the follower at NDX 1 pointing back to it.
+    let mut leader = FileEntry::new_file("file1.txt".into(), 100, 0o644);
+    leader.set_hardlink_idx(u32::MAX);
+    let mut follower = FileEntry::new_file("file2.txt".into(), 100, 0o644);
+    follower.set_hardlink_idx(0);
 
-    writer.write_entry(&mut buf, &entry).unwrap();
+    writer.write_entry(&mut buf, &leader).unwrap();
+    writer.write_entry(&mut buf, &follower).unwrap();
     writer.write_end(&mut buf, None).unwrap();
 
-    let mut cursor = Cursor::new(&buf[..]);
     let mut reader = FileListReader::new(protocol).with_preserve_hard_links(true);
+    let entries = read_all(&mut reader, &buf);
 
-    let read_entry = reader.read_entry(&mut cursor).unwrap().unwrap();
-    assert_eq!(read_entry.name(), "file2.txt");
-    assert_eq!(read_entry.hardlink_idx(), Some(5));
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[1].name(), "file2.txt");
+    assert_eq!(entries[1].hardlink_idx(), Some(0));
 }
 
 #[test]
 fn write_hardlink_without_preserve_hard_links_omits_idx() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = test_protocol();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol);
@@ -71,9 +86,6 @@ fn write_hardlink_without_preserve_hard_links_omits_idx() {
 
 #[test]
 fn write_hardlink_group_round_trip_protocol_32() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = ProtocolVersion::try_from(32u8).unwrap();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
@@ -92,28 +104,22 @@ fn write_hardlink_group_round_trip_protocol_32() {
     writer.write_entry(&mut buf, &entry3).unwrap();
     writer.write_end(&mut buf, None).unwrap();
 
-    let mut cursor = Cursor::new(&buf[..]);
     let mut reader = FileListReader::new(protocol).with_preserve_hard_links(true);
+    let entries = read_all(&mut reader, &buf);
 
-    let read1 = reader.read_entry(&mut cursor).unwrap().unwrap();
-    let read2 = reader.read_entry(&mut cursor).unwrap().unwrap();
-    let read3 = reader.read_entry(&mut cursor).unwrap().unwrap();
+    assert_eq!(entries.len(), 3);
+    assert_eq!(entries[0].name(), "original.txt");
+    assert_eq!(entries[0].hardlink_idx(), Some(u32::MAX));
 
-    assert_eq!(read1.name(), "original.txt");
-    assert_eq!(read1.hardlink_idx(), Some(u32::MAX));
+    assert_eq!(entries[1].name(), "link1.txt");
+    assert_eq!(entries[1].hardlink_idx(), Some(0));
 
-    assert_eq!(read2.name(), "link1.txt");
-    assert_eq!(read2.hardlink_idx(), Some(0));
-
-    assert_eq!(read3.name(), "link2.txt");
-    assert_eq!(read3.hardlink_idx(), Some(0));
+    assert_eq!(entries[2].name(), "link2.txt");
+    assert_eq!(entries[2].hardlink_idx(), Some(0));
 }
 
 #[test]
 fn write_hardlink_follower_skips_metadata() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = ProtocolVersion::try_from(30u8).unwrap();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
@@ -137,30 +143,25 @@ fn write_hardlink_follower_skips_metadata() {
         "follower entry should be much smaller: {second_len} vs {first_len}"
     );
 
-    let mut cursor = Cursor::new(&buf[..]);
     let mut reader = FileListReader::new(protocol).with_preserve_hard_links(true);
+    let entries = read_all(&mut reader, &buf);
 
-    let read1 = reader.read_entry(&mut cursor).unwrap().unwrap();
-    let read2 = reader.read_entry(&mut cursor).unwrap().unwrap();
+    assert_eq!(entries[0].name(), "original.txt");
+    assert_eq!(entries[0].size(), 500);
+    assert_eq!(entries[0].mtime(), 1700000000);
+    assert_eq!(entries[0].hardlink_idx(), Some(u32::MAX));
 
-    assert_eq!(read1.name(), "original.txt");
-    assert_eq!(read1.size(), 500);
-    assert_eq!(read1.mtime(), 1700000000);
-    assert_eq!(read1.hardlink_idx(), Some(u32::MAX));
-
-    // Follower metadata is intentionally skipped on the wire; the caller copies
-    // it from the leader (upstream flist.c:recv_file_entry lines 793-822).
-    assert_eq!(read2.name(), "link.txt");
-    assert_eq!(read2.size(), 0);
-    assert_eq!(read2.mtime(), 0);
-    assert_eq!(read2.hardlink_idx(), Some(0));
+    // Follower metadata is skipped on the wire; the receiver copies it from the
+    // leader in the same segment (upstream flist.c:recv_file_entry lines
+    // 793-822), so size and mtime match the leader rather than being blank.
+    assert_eq!(entries[1].name(), "link.txt");
+    assert_eq!(entries[1].size(), 500);
+    assert_eq!(entries[1].mtime(), 1700000000);
+    assert_eq!(entries[1].hardlink_idx(), Some(0));
 }
 
 #[test]
 fn write_hardlink_follower_with_uid_gid_skips_all() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = ProtocolVersion::try_from(32u8).unwrap();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol)
@@ -194,31 +195,29 @@ fn write_hardlink_follower_with_uid_gid_skips_all() {
         "follower should skip metadata: {second_len} vs {first_len}"
     );
 
-    let mut cursor = Cursor::new(&buf[..]);
     let mut reader = FileListReader::new(protocol)
         .with_preserve_hard_links(true)
         .with_preserve_uid(true)
         .with_preserve_gid(true);
+    let entries = read_all(&mut reader, &buf);
 
-    let read1 = reader.read_entry(&mut cursor).unwrap().unwrap();
-    let read2 = reader.read_entry(&mut cursor).unwrap().unwrap();
+    assert_eq!(entries[0].user_name(), Some("testuser"));
+    assert_eq!(entries[0].group_name(), Some("testgroup"));
 
-    assert_eq!(read1.user_name(), Some("testuser"));
-    assert_eq!(read1.group_name(), Some("testgroup"));
-
-    assert_eq!(read2.size(), 0);
-    assert_eq!(read2.mtime(), 0);
-    assert_eq!(read2.mode(), 0);
-    assert_eq!(read2.user_name(), None);
-    assert_eq!(read2.group_name(), None);
-    assert_eq!(read2.hardlink_idx(), Some(0));
+    // The follower inherits size/mtime/mode/uid/gid from the leader in the same
+    // segment; the id->name strings are not part of the copied metadata.
+    assert_eq!(entries[1].size(), 1000);
+    assert_eq!(entries[1].mtime(), 1700000000);
+    assert_eq!(entries[1].mode(), entries[0].mode());
+    assert_eq!(entries[1].uid(), entries[0].uid());
+    assert_eq!(entries[1].gid(), entries[0].gid());
+    assert_eq!(entries[1].user_name(), None);
+    assert_eq!(entries[1].group_name(), None);
+    assert_eq!(entries[1].hardlink_idx(), Some(0));
 }
 
 #[test]
 fn write_hardlink_leader_has_full_metadata() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = ProtocolVersion::try_from(30u8).unwrap();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
@@ -286,9 +285,6 @@ fn abbreviated_vs_unabbreviated_hardlink_follower() {
 
 #[test]
 fn hardlink_dev_ino_round_trip_protocol_29() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = ProtocolVersion::try_from(29u8).unwrap();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
@@ -312,9 +308,6 @@ fn hardlink_dev_ino_round_trip_protocol_29() {
 
 #[test]
 fn hardlink_dev_compression_protocol_29() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = ProtocolVersion::try_from(29u8).unwrap();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
@@ -362,9 +355,6 @@ fn hardlink_dev_compression_protocol_29() {
 /// that occupy wire positions but are not hardlinked themselves.
 #[test]
 fn hardlink_round_trip_with_interspersed_directories() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = ProtocolVersion::try_from(32u8).unwrap();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
@@ -394,25 +384,20 @@ fn hardlink_round_trip_with_interspersed_directories() {
     writer.write_entry(&mut buf, &follower).unwrap();
     writer.write_end(&mut buf, None).unwrap();
 
-    let mut cursor = Cursor::new(&buf[..]);
     let mut reader = FileListReader::new(protocol).with_preserve_hard_links(true);
-
-    let read_dir_a = reader.read_entry(&mut cursor).unwrap().unwrap();
-    let read_leader = reader.read_entry(&mut cursor).unwrap().unwrap();
-    let read_dir_b = reader.read_entry(&mut cursor).unwrap().unwrap();
-    let read_follower = reader.read_entry(&mut cursor).unwrap().unwrap();
+    let entries = read_all(&mut reader, &buf);
 
     // Directory entries have no hardlink index
-    assert_eq!(read_dir_a.hardlink_idx(), None);
-    assert_eq!(read_dir_b.hardlink_idx(), None);
+    assert_eq!(entries[0].hardlink_idx(), None);
+    assert_eq!(entries[2].hardlink_idx(), None);
 
     // Leader round-trips with u32::MAX
-    assert_eq!(read_leader.name(), "a/orig.txt");
-    assert_eq!(read_leader.hardlink_idx(), Some(u32::MAX));
+    assert_eq!(entries[1].name(), "a/orig.txt");
+    assert_eq!(entries[1].hardlink_idx(), Some(u32::MAX));
 
     // Follower round-trips with the correct wire NDX pointing to the leader
-    assert_eq!(read_follower.name(), "b/link.txt");
-    assert_eq!(read_follower.hardlink_idx(), Some(1));
+    assert_eq!(entries[3].name(), "b/link.txt");
+    assert_eq!(entries[3].hardlink_idx(), Some(1));
 }
 
 /// Verifies that multiple hardlink groups with directories interspersed all
@@ -420,9 +405,6 @@ fn hardlink_round_trip_with_interspersed_directories() {
 /// between them must maintain independent leader/follower relationships.
 #[test]
 fn hardlink_multiple_groups_with_directories() {
-    use super::super::super::read::FileListReader;
-    use std::io::Cursor;
-
     let protocol = ProtocolVersion::try_from(32u8).unwrap();
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_hard_links(true);
@@ -464,18 +446,12 @@ fn hardlink_multiple_groups_with_directories() {
     writer.write_entry(&mut buf, &follower_b).unwrap();
     writer.write_end(&mut buf, None).unwrap();
 
-    let mut cursor = Cursor::new(&buf[..]);
     let mut reader = FileListReader::new(protocol).with_preserve_hard_links(true);
+    let entries = read_all(&mut reader, &buf);
 
-    let _ = reader.read_entry(&mut cursor).unwrap().unwrap(); // dir d
-    let read_la = reader.read_entry(&mut cursor).unwrap().unwrap();
-    let read_fa = reader.read_entry(&mut cursor).unwrap().unwrap();
-    let _ = reader.read_entry(&mut cursor).unwrap().unwrap(); // dir e
-    let read_lb = reader.read_entry(&mut cursor).unwrap().unwrap();
-    let read_fb = reader.read_entry(&mut cursor).unwrap().unwrap();
-
-    assert_eq!(read_la.hardlink_idx(), Some(u32::MAX));
-    assert_eq!(read_fa.hardlink_idx(), Some(1));
-    assert_eq!(read_lb.hardlink_idx(), Some(u32::MAX));
-    assert_eq!(read_fb.hardlink_idx(), Some(4));
+    // NDX 1/4 are the group leaders; NDX 2/5 the followers referencing them.
+    assert_eq!(entries[1].hardlink_idx(), Some(u32::MAX));
+    assert_eq!(entries[2].hardlink_idx(), Some(1));
+    assert_eq!(entries[4].hardlink_idx(), Some(u32::MAX));
+    assert_eq!(entries[5].hardlink_idx(), Some(4));
 }

--- a/crates/protocol/src/wire/file_entry_decode/hardlink.rs
+++ b/crates/protocol/src/wire/file_entry_decode/hardlink.rs
@@ -26,6 +26,12 @@ pub fn decode_hardlink_idx<R: Read>(reader: &mut R, flags: u32) -> io::Result<Op
         } else {
             // Cast i32 bits to u32 to preserve the full index space;
             // upstream C uses unsigned int for hlink_flist indices.
+            //
+            // The value is range-checked by the caller against the entries
+            // received so far (upstream: flist.c:794-799, `first_hlink_ndx < 0
+            // || first_hlink_ndx >= flist->ndx_start + flist->used`) - see
+            // `FileListReader::read_entry_with_flist`. Decoding here stays
+            // context-free because `ndx_start`/`used` live in the reader state.
             Ok(Some(read_varint(reader)? as u32))
         }
     } else {

--- a/crates/protocol/tests/proptest_file_entry_roundtrip.rs
+++ b/crates/protocol/tests/proptest_file_entry_roundtrip.rs
@@ -166,8 +166,13 @@ fn roundtrip_sequence(
     writer.write_end(&mut buf, None).unwrap();
 
     let mut cursor = Cursor::new(&buf[..]);
-    let mut decoded = Vec::new();
-    while let Some(entry) = reader.read_entry(&mut cursor).unwrap() {
+    let mut decoded: Vec<FileEntry> = Vec::new();
+    // Thread the accumulating segment so abbreviated hardlink followers can
+    // resolve their leader, exactly as the real receiver does.
+    while let Some(entry) = reader
+        .read_entry_with_flist(&mut cursor, &decoded.clone())
+        .unwrap()
+    {
         decoded.push(entry);
     }
     decoded
@@ -951,33 +956,45 @@ proptest! {
         assert_eq!(decoded.hardlink_idx(), Some(u32::MAX), "leader should have u32::MAX idx");
     }
 
-    /// Hardlink followers reference a leader by index.
+    /// Hardlink followers reference an already-seen leader by index.
     ///
-    /// A follower has hardlink_idx < u32::MAX. The writer sets XMIT_HLINKED
-    /// but NOT XMIT_HLINK_FIRST, and skips all metadata after the index.
-    /// The decoded entry will have zeroed metadata fields.
+    /// A follower has hardlink_idx < u32::MAX. The writer sets XMIT_HLINKED but
+    /// NOT XMIT_HLINK_FIRST, and skips all metadata after the index; the
+    /// receiver copies that metadata from the leader. The reference must point
+    /// at an entry received so far (upstream flist.c:794): here the follower
+    /// references the leader at NDX 0, so it is always in range.
     #[test]
     fn hardlink_follower_roundtrip(
         proto in modern_protocol_version_strategy(),
         name in basename_strategy(),
-        idx in 0u32..1000,
+        leaders in 1usize..8,
     ) {
         let protocol = ProtocolVersion::try_from(proto).unwrap();
-        let mut entry = FileEntry::new_file(name, 500, 0o644);
-        entry.set_mtime(1000, 0);
-        entry.set_hardlink_idx(idx);
+
+        // Build `leaders` leaders at NDX 0.., then a follower referencing NDX 0.
+        let mut entries = Vec::new();
+        for i in 0..leaders {
+            let mut leader = FileEntry::new_file(format!("leader{i}").into(), 500, 0o644);
+            leader.set_mtime(1000, 0);
+            leader.set_hardlink_idx(u32::MAX);
+            entries.push(leader);
+        }
+        let mut follower = FileEntry::new_file(name.clone(), 500, 0o644);
+        follower.set_mtime(1000, 0);
+        follower.set_hardlink_idx(0);
+        entries.push(follower);
 
         let mut writer = FileListWriter::new(protocol)
             .with_preserve_hard_links(true);
         let mut reader = FileListReader::new(protocol)
             .with_preserve_hard_links(true);
 
-        let decoded = roundtrip(&mut writer, &mut reader, &entry);
-        assert_eq!(decoded.name(), entry.name(), "name mismatch");
-        assert_eq!(decoded.hardlink_idx(), Some(idx), "follower idx mismatch");
-        // Followers have zeroed metadata on the wire
-        assert_eq!(decoded.size(), 0, "follower size should be 0");
-        assert_eq!(decoded.mode(), 0, "follower mode should be 0");
+        let decoded = roundtrip_sequence(&mut writer, &mut reader, &entries);
+        let follower_decoded = decoded.last().expect("follower decoded");
+        assert_eq!(follower_decoded.name(), &*name.to_string_lossy(), "name mismatch");
+        assert_eq!(follower_decoded.hardlink_idx(), Some(0), "follower idx mismatch");
+        // Follower metadata is skipped on the wire and copied from the leader.
+        assert_eq!(follower_decoded.size(), 500, "follower inherits leader size");
     }
 }
 


### PR DESCRIPTION
## Summary

An abbreviated hard-link follower carries a reference index (`first_hlink_ndx`)
that must point at a leader the receiver has already seen. Upstream rsync
validates this bound in `recv_file_entry` and aborts cleanly on a bad value:

```c
/* flist.c:794-799 */
first_hlink_ndx = read_varint(f);
if (first_hlink_ndx < 0 || first_hlink_ndx >= flist->ndx_start + flist->used) {
    rprintf(FERROR,
        "hard-link reference out of range: %d (%d)\n",
        first_hlink_ndx, flist->ndx_start + flist->used);
    exit_cleanup(RERR_PROTOCOL);
}
```

The decoder read the index as a `u32` with no range check. For an out-of-range
follower it silently substituted zero metadata, left the name/compression state
un-updated, and kept decoding - turning a malformed or hostile file list into a
desynced parse instead of the clean protocol abort upstream performs.

## Fix

Bound-check the follower's reference index against the entries received so far
in the current segment (`ndx_start + used`, where `used` is the accumulated
segment length passed to the reader, exactly as upstream tracks `flist->used`).
On an out-of-range reference the decoder now returns a protocol-violation error
that the exit-code mapper reports as `RERR_PROTOCOL` (exit 2), reusing the
existing `protocol_violation` marker used by the modtime_nsec, invalid-mode and
other wire-hardening sites - no new error path. The zero-metadata fallback is
removed.

## Tests

- `abbreviated_hardlink_follower_out_of_range_is_protocol_violation` - a
  follower whose index points past the entries received so far is rejected with
  an `InvalidData` error tagged `ProtocolViolation` (exit 2) and the upstream
  "hard-link reference out of range" message, rather than a zero-metadata entry.
- `abbreviated_hardlink_follower_in_range_decodes` - a valid in-range follower
  still decodes and inherits the leader's metadata (no regression).

Existing hard-link decode tests and the `hardlink_follower_roundtrip` property
test were updated to thread the accumulating segment (mirroring the real
receiver, which passes `file_list[seg_start..]`) so followers resolve their
leader; several now assert the correctly copied leader metadata.

Full `protocol` and `transfer` targeted suites pass; `cargo fmt` and
`clippy -p protocol --all-targets --all-features -- -D warnings` are clean.
