### PR TITLE
fix(transfer): link hardlink followers after delayed-updates rename leaders

### DIFF
--- a/crates/transfer/src/receiver/tests/hard_links.rs
+++ b/crates/transfer/src/receiver/tests/hard_links.rs
@@ -523,3 +523,95 @@ fn create_hardlinks_surfaces_non_eacces_error() {
          incremental segments preserve their leader-path state",
     );
 }
+
+/// Pins the `--delay-updates` + `--hard-links` phase ordering (Rule 9).
+///
+/// A `--delay-updates` leader is committed under the `.~tmp~` partial-dir and is
+/// renamed to its final path only in phase 2 by `handle_delayed_updates`. A
+/// follower may be hard-linked to it only *after* that rename - upstream
+/// `receiver.c:694-695` (the phase-2 rename) then `:551-552`
+/// (`send_msg_success` -> `finish_hard_link`). `create_hardlinks` links the
+/// follower against the leader's FINAL path (`dest_dir.join(rel)`), so if it ran
+/// before the delayed rename the follower's `linkat` would target a leader still
+/// staged under `.~tmp~`: `ENOENT` (a fatal transfer error) or a stale
+/// pre-existing inode.
+///
+/// `finalize_delayed_updates_and_hardlinks` is the single ordering site the four
+/// pipelined drivers share. This test stages a leader under `.~tmp~` (its final
+/// path absent, exactly as a delayed commit leaves it) and drives the finalize
+/// step: the follower must end up hard-linked to the leader at its final path
+/// with the committed content. Reversing the two calls inside the helper makes
+/// `create_hardlinks` run first and fail with `ENOENT`, failing this test.
+#[cfg(unix)]
+#[test]
+fn finalize_links_followers_after_delayed_leader_rename() {
+    use std::os::unix::fs::MetadataExt;
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    // Leader staged under `.~tmp~`, as a `--delay-updates` commit leaves it: its
+    // final path `dest/leader.txt` does NOT exist yet.
+    let staging = dest.join(".~tmp~");
+    std::fs::create_dir_all(&staging).unwrap();
+    let payload = b"shared delayed payload\n";
+    std::fs::write(staging.join("leader.txt"), payload).unwrap();
+
+    let entries = vec![
+        make_hlink_leader("leader.txt", payload.len() as u64, 42),
+        make_hlink_follower("follower.txt", payload.len() as u64, 42),
+    ];
+    let mut ctx = receiver_with_hardlinks(entries);
+    let mut writer = TestDeletionWriter;
+
+    // The delayed-updates list the driver hands to the finalize step: rename the
+    // staged leader to its final path.
+    let delayed = vec![(staging.join("leader.txt"), dest.join("leader.txt"))];
+
+    ctx.finalize_delayed_updates_and_hardlinks(dest, None, &delayed, &mut writer)
+        .expect(
+            "finalize must succeed: handle_delayed_updates renames the staged \
+             leader to its final path before the follower is linked to it",
+        );
+
+    let leader = dest.join("leader.txt");
+    let follower = dest.join("follower.txt");
+    assert!(
+        leader.exists(),
+        "the delayed leader must be renamed to its final path",
+    );
+    assert!(
+        follower.exists(),
+        "the follower must be hard-linked to the final leader path",
+    );
+    assert_eq!(
+        std::fs::read(&leader).unwrap(),
+        payload,
+        "leader must hold the committed content",
+    );
+    assert_eq!(
+        std::fs::read(&follower).unwrap(),
+        payload,
+        "follower must carry the leader's content via the shared inode, not a \
+         stale or empty file",
+    );
+
+    let leader_meta = std::fs::metadata(&leader).unwrap();
+    let follower_meta = std::fs::metadata(&follower).unwrap();
+    assert_eq!(
+        leader_meta.ino(),
+        follower_meta.ino(),
+        "follower must share the leader's inode at its FINAL path; a follower \
+         linked before the delayed rename would target the still-staged leader \
+         (ENOENT) or a stale inode",
+    );
+    assert!(
+        leader_meta.nlink() >= 2,
+        "leader nlink must be >= 2 for a hard-link pair, got {}",
+        leader_meta.nlink(),
+    );
+    assert!(
+        !staging.exists(),
+        "the .~tmp~ staging dir must be removed after the delayed rename",
+    );
+}

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -82,6 +82,57 @@ impl ReceiverContext {
         }
     }
 
+    /// Finalizes a completed transfer's delayed updates and hardlink followers,
+    /// in the order upstream mandates.
+    ///
+    /// `handle_delayed_updates` runs first, renaming every `--delay-updates`
+    /// leader out of the `.~tmp~` partial-dir to its final path; only then does
+    /// `create_hardlinks` link followers to those leaders. Running the hardlink
+    /// pass first would target a leader still staged under `.~tmp~` - `ENOENT`
+    /// (a fatal transfer error) or a stale pre-existing inode with the wrong
+    /// content.
+    ///
+    /// This is the single ordering site shared by all four pipelined drivers
+    /// (`run_pipelined`, `run_pipelined_async`, `run_pipelined_incremental`,
+    /// `run_pipelined_incremental_async`) so they cannot drift apart.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:694-695` - `handle_delayed_updates()` at `phase == 2`.
+    /// - `receiver.c:551-552` - only after the delayed rename does
+    ///   `send_msg_success()` drive `finish_hard_link()` (`hlink.c:475`,
+    ///   `generator.c:2169`) to link the leader's followers.
+    pub(in crate::receiver) fn finalize_delayed_updates_and_hardlinks<W>(
+        &mut self,
+        dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
+        all_delayed_updates: &[(PathBuf, PathBuf)],
+        writer: &mut W,
+    ) -> io::Result<()>
+    where
+        W: Write + crate::writer::MsgInfoSender + ?Sized,
+    {
+        if !all_delayed_updates.is_empty() {
+            let backup_cfg = if self.config.flags.backup {
+                Some(crate::disk_commit::BackupConfig {
+                    dest_dir: dest_dir.to_path_buf(),
+                    backup_dir: self.config.backup_dir.as_ref().map(PathBuf::from),
+                    suffix: self.config.effective_backup_suffix().into(),
+                })
+            } else {
+                None
+            };
+            handle_delayed_updates(all_delayed_updates, backup_cfg);
+        }
+
+        #[cfg(unix)]
+        self.create_hardlinks(dest_dir, sandbox, writer)?;
+        #[cfg(not(unix))]
+        self.create_hardlinks(dest_dir, writer)?;
+
+        Ok(())
+    }
+
     /// BENCHMARK-ONLY async twin of [`run`](Self::run) over a real socket.
     ///
     /// Adopts `socket` (a dup'd clone of the transfer socket) as the async read

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -230,24 +230,19 @@ impl ReceiverContext {
             }
         }
 
+        // upstream: receiver.c:694-695 then :551-552 - handle_delayed_updates()
+        // renames each delay-updates leader to its final path in phase 2, and
+        // only then are followers hard-linked to it. See
+        // finalize_delayed_updates_and_hardlinks for the ordering rationale.
         #[cfg(unix)]
-        self.create_hardlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        self.finalize_delayed_updates_and_hardlinks(
+            &setup.dest_dir,
+            setup.sandbox.as_deref(),
+            &all_delayed_updates,
+            writer,
+        )?;
         #[cfg(not(unix))]
-        self.create_hardlinks(&setup.dest_dir, writer)?;
-
-        // upstream: receiver.c:584-585 - handle_delayed_updates() at phase 2
-        if !all_delayed_updates.is_empty() {
-            let backup_cfg = if self.config.flags.backup {
-                Some(crate::disk_commit::BackupConfig {
-                    dest_dir: setup.dest_dir.clone(),
-                    backup_dir: self.config.backup_dir.as_ref().map(PathBuf::from),
-                    suffix: self.config.effective_backup_suffix().into(),
-                })
-            } else {
-                None
-            };
-            super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
-        }
+        self.finalize_delayed_updates_and_hardlinks(&setup.dest_dir, &all_delayed_updates, writer)?;
 
         // upstream: generator.c:2425-2428 - --delete-after / --delete-delay run
         // the sweep only after every file (including each destination

--- a/crates/transfer/src/receiver/transfer/pipelined_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_async.rs
@@ -252,24 +252,19 @@ impl ReceiverContext {
             }
         }
 
+        // upstream: receiver.c:694-695 then :551-552 - handle_delayed_updates()
+        // renames each delay-updates leader to its final path in phase 2, and
+        // only then are followers hard-linked to it. See
+        // finalize_delayed_updates_and_hardlinks for the ordering rationale.
         #[cfg(unix)]
-        self.create_hardlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        self.finalize_delayed_updates_and_hardlinks(
+            &setup.dest_dir,
+            setup.sandbox.as_deref(),
+            &all_delayed_updates,
+            writer,
+        )?;
         #[cfg(not(unix))]
-        self.create_hardlinks(&setup.dest_dir, writer)?;
-
-        // upstream: receiver.c:584-585 - handle_delayed_updates() at phase 2
-        if !all_delayed_updates.is_empty() {
-            let backup_cfg = if self.config.flags.backup {
-                Some(crate::disk_commit::BackupConfig {
-                    dest_dir: setup.dest_dir.clone(),
-                    backup_dir: self.config.backup_dir.as_ref().map(PathBuf::from),
-                    suffix: self.config.effective_backup_suffix().into(),
-                })
-            } else {
-                None
-            };
-            super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
-        }
+        self.finalize_delayed_updates_and_hardlinks(&setup.dest_dir, &all_delayed_updates, writer)?;
 
         // upstream: generator.c:2425-2428 - --delete-after / --delete-delay run
         // the sweep only after every file (including each destination

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -236,24 +236,19 @@ impl ReceiverContext {
             }
         }
 
+        // upstream: receiver.c:694-695 then :551-552 - handle_delayed_updates()
+        // renames each delay-updates leader to its final path in phase 2, and
+        // only then are followers hard-linked to it. See
+        // finalize_delayed_updates_and_hardlinks for the ordering rationale.
         #[cfg(unix)]
-        self.create_hardlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        self.finalize_delayed_updates_and_hardlinks(
+            &setup.dest_dir,
+            setup.sandbox.as_deref(),
+            &all_delayed_updates,
+            writer,
+        )?;
         #[cfg(not(unix))]
-        self.create_hardlinks(&setup.dest_dir, writer)?;
-
-        // upstream: receiver.c:584-585 - handle_delayed_updates() at phase 2
-        if !all_delayed_updates.is_empty() {
-            let backup_cfg = if self.config.flags.backup {
-                Some(crate::disk_commit::BackupConfig {
-                    dest_dir: setup.dest_dir.clone(),
-                    backup_dir: self.config.backup_dir.as_ref().map(PathBuf::from),
-                    suffix: self.config.effective_backup_suffix().into(),
-                })
-            } else {
-                None
-            };
-            super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
-        }
+        self.finalize_delayed_updates_and_hardlinks(&setup.dest_dir, &all_delayed_updates, writer)?;
 
         // upstream: generator.c:2425-2428 - --delete-after / --delete-delay run
         // the sweep only after every file (including each destination

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental_async.rs
@@ -250,24 +250,19 @@ impl ReceiverContext {
             }
         }
 
+        // upstream: receiver.c:694-695 then :551-552 - handle_delayed_updates()
+        // renames each delay-updates leader to its final path in phase 2, and
+        // only then are followers hard-linked to it. See
+        // finalize_delayed_updates_and_hardlinks for the ordering rationale.
         #[cfg(unix)]
-        self.create_hardlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer)?;
+        self.finalize_delayed_updates_and_hardlinks(
+            &setup.dest_dir,
+            setup.sandbox.as_deref(),
+            &all_delayed_updates,
+            writer,
+        )?;
         #[cfg(not(unix))]
-        self.create_hardlinks(&setup.dest_dir, writer)?;
-
-        // upstream: receiver.c:584-585 - handle_delayed_updates() at phase 2
-        if !all_delayed_updates.is_empty() {
-            let backup_cfg = if self.config.flags.backup {
-                Some(crate::disk_commit::BackupConfig {
-                    dest_dir: setup.dest_dir.clone(),
-                    backup_dir: self.config.backup_dir.as_ref().map(PathBuf::from),
-                    suffix: self.config.effective_backup_suffix().into(),
-                })
-            } else {
-                None
-            };
-            super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
-        }
+        self.finalize_delayed_updates_and_hardlinks(&setup.dest_dir, &all_delayed_updates, writer)?;
 
         // upstream: generator.c:2425-2428 - --delete-after / --delete-delay run
         // the sweep only after every file (including each destination


### PR DESCRIPTION
## Problem

With `--delay-updates` combined with `--hard-links`, the pipelined receiver
linked hardlink followers to their leader **before** the delayed leaders were
renamed out of the `.~tmp~` partial-dir into their final destination path.

The follower is linked against the leader's recorded final path
(`dest_dir.join(rel)`), which does not exist yet while the leader is staged
under `.~tmp~`, so the follower's `linkat()` either:

- hits `ENOENT` and fails the transfer (fatal, non-`PermissionDenied` errors are
  propagated), or
- links to a stale pre-existing inode with the wrong content.

## Upstream behaviour (source of truth)

Upstream links a follower to its leader only **after** the leader reaches its
final path:

- `receiver.c:694-695` - `handle_delayed_updates()` runs at `phase == 2`,
  renaming each staged leader out of the partial-dir to its final path.
- `receiver.c:551-552` - only after that rename does `send_msg_success()` drive
  `finish_hard_link()` for the leader's followers.
- `hlink.c:475` (`finish_hard_link`) / `generator.c:2169`
  (`check_for_finished_files`) - the follower link is created against the
  now-final leader path.

Under `--delay-updates` the leader's final-path rename is deferred to phase 2, so
follower linking is deferred with it. The non-delay path is unchanged: when
`handle_delayed_updates` has nothing to do, leaders are already at their final
path, so running the hardlink pass immediately after is equivalent.

## Fix

Run `handle_delayed_updates` **before** `create_hardlinks` in all four pipelined
receiver drivers so a delayed leader is present at its final path before any
follower `linkat()` targets it.

The two calls were identical across the four drivers, so they are consolidated
into a single shared method, `ReceiverContext::finalize_delayed_updates_and_hardlinks`,
which owns the ordering. The four drivers (`run_pipelined`,
`run_pipelined_async`, `run_pipelined_incremental`,
`run_pipelined_incremental_async`) now call it, so they cannot drift apart. The
follower-link logic in `directory/links.rs` already records and links against the
final destination path and is unchanged.

## Test

`crates/transfer/src/receiver/tests/hard_links.rs::finalize_links_followers_after_delayed_leader_rename`
stages a leader under `.~tmp~` with its final path absent - exactly as a
`--delay-updates` commit leaves it - and drives the shared finalize step with a
delayed-updates entry that renames the staged leader to its final path plus a
follower entry. It asserts the follower ends up hard-linked to the leader at its
final path with the committed content (shared inode, `nlink >= 2`, correct
bytes) and that the `.~tmp~` staging dir is cleaned up.

The test is deterministic and in-process (no networked daemon), so it is not
subject to daemon-transfer environment flakiness or CI timeouts. Reversing the
two calls inside `finalize_delayed_updates_and_hardlinks` makes `create_hardlinks`
run first and fail with `ENOENT`, which fails this test - so the ordering is
genuinely guarded.

`cargo fmt --all` and `cargo clippy -p transfer --all-targets --all-features
--no-deps -D warnings` are clean; the transfer hardlink/delayed-updates lib tests
pass.
