### PR TITLE
fix(compress): allow negative zstd compression levels down to ZSTD_minCLevel

### DIFF
--- a/crates/compress/src/algorithm.rs
+++ b/crates/compress/src/algorithm.rs
@@ -38,6 +38,21 @@ pub const LZ4_DEFAULT_ACCELERATION: i32 = 1;
 /// `token.c:init_compression_level()`.
 pub const CLVL_NOT_SPECIFIED: i32 = i32::MIN;
 
+/// Minimum (fastest) zstd compression level, i.e. `ZSTD_minCLevel()`.
+///
+/// This is a large negative value whose exact magnitude depends on the linked
+/// libzstd version, so it is queried at runtime through the safe `zstd` crate
+/// API rather than hard-coded. That keeps oc's lower bound identical to the
+/// libzstd it is built against, matching upstream, which likewise calls
+/// `ZSTD_minCLevel()` at run time.
+///
+/// upstream: token.c:73 - `min_level = skip_compression_level = ZSTD_minCLevel()`.
+#[cfg(feature = "zstd")]
+#[must_use]
+pub fn zstd_min_level() -> i32 {
+    *::zstd::compression_level_range().start()
+}
+
 /// Compression algorithms recognised by the workspace.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum CompressionAlgorithm {
@@ -162,14 +177,17 @@ impl CompressionAlgorithm {
                     raw_level.clamp(1, 9)
                 }
             }
-            // upstream: token.c:72-79 - def ZSTD_CLEVEL_DEFAULT (3); a literal 0
-            // also maps to def; values saturate into [minCLevel, maxCLevel].
+            // upstream: token.c:72-79,101-104 - def ZSTD_CLEVEL_DEFAULT (3); a
+            // literal 0 also maps to def; other values saturate into
+            // [ZSTD_minCLevel(), ZSTD_maxCLevel()]. The lower bound is negative,
+            // so "fast" levels below 1 (e.g. --compress-level=-5) are preserved,
+            // not raised to 1.
             #[cfg(feature = "zstd")]
             CompressionAlgorithm::Zstd => {
                 if raw_level == CLVL_NOT_SPECIFIED || raw_level == 0 {
                     ZSTD_DEFAULT_LEVEL
                 } else {
-                    raw_level.clamp(1, ZSTD_MAX_LEVEL)
+                    raw_level.clamp(zstd_min_level(), ZSTD_MAX_LEVEL)
                 }
             }
             // upstream: token.c:81-87 - lz4 forces min/max/def to 0.
@@ -501,6 +519,70 @@ mod tests {
         );
         assert_eq!(CompressionAlgorithm::Zstd.resolve_debug_level(0), 3);
         assert_eq!(CompressionAlgorithm::Zstd.resolve_debug_level(19), 19);
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn zstd_min_level_is_negative() {
+        // upstream: token.c:73 - zstd's min_level is ZSTD_minCLevel(), which
+        // libzstd documents as "a very large negative number". If this were
+        // >= 1 the negative-level fix below would be silently meaningless.
+        assert!(
+            zstd_min_level() < 0,
+            "ZSTD_minCLevel() must be negative, got {}",
+            zstd_min_level()
+        );
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn resolve_debug_level_preserves_negative_zstd_levels() {
+        // upstream: token.c:73,101-104 - zstd's lower clamp bound is
+        // ZSTD_minCLevel() (negative), NOT 1. A "fast" level such as
+        // --compress-level=-5 is a valid zstd level that upstream passes
+        // straight to ZSTD_c_compressionLevel; it must be preserved, never
+        // raised to 1. Regression guard for the old `.clamp(1, ..)` bound that
+        // silently rewrote every negative level to 1.
+        assert_eq!(CompressionAlgorithm::Zstd.resolve_debug_level(-5), -5);
+        let min = zstd_min_level();
+        assert_eq!(
+            CompressionAlgorithm::Zstd.resolve_debug_level(min),
+            min,
+            "the exact ZSTD_minCLevel() boundary is preserved"
+        );
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn resolve_debug_level_clamps_below_min_to_zstd_min() {
+        // upstream: token.c:101-102 - a level below min_level saturates UP to
+        // min_level (ZSTD_minCLevel()); upstream never rejects it. Mirrors the
+        // zlib below-min behaviour but at zstd's negative floor.
+        let min = zstd_min_level();
+        assert_eq!(
+            CompressionAlgorithm::Zstd.resolve_debug_level(min - 1),
+            min,
+            "below-min saturates to ZSTD_minCLevel(), not rejected"
+        );
+        // The i32::MIN sentinel is CLVL_NOT_SPECIFIED, which resolves to the
+        // codec default (3) - it is not treated as a below-min level.
+        assert_eq!(
+            CompressionAlgorithm::Zstd.resolve_debug_level(CLVL_NOT_SPECIFIED),
+            ZSTD_DEFAULT_LEVEL
+        );
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn resolve_debug_level_positive_and_zero_zstd_unchanged() {
+        // No regression: positive levels, the default substitution for 0, and
+        // the upper clamp to ZSTD_maxCLevel (22) are all unchanged by the
+        // negative-level fix. upstream: token.c:74,77-78,103-104.
+        assert_eq!(CompressionAlgorithm::Zstd.resolve_debug_level(0), 3);
+        assert_eq!(CompressionAlgorithm::Zstd.resolve_debug_level(1), 1);
+        assert_eq!(CompressionAlgorithm::Zstd.resolve_debug_level(15), 15);
+        assert_eq!(CompressionAlgorithm::Zstd.resolve_debug_level(22), 22);
+        assert_eq!(CompressionAlgorithm::Zstd.resolve_debug_level(99), 22);
     }
 
     #[cfg(feature = "lz4")]

--- a/crates/compress/src/zstd.rs
+++ b/crates/compress/src/zstd.rs
@@ -344,6 +344,35 @@ mod tests {
     }
 
     #[test]
+    fn encoder_accepts_negative_zstd_levels() {
+        // WHY: upstream passes do_compression_level (which can be a negative
+        // "fast" level for zstd) straight to ZSTD_c_compressionLevel
+        // (token.c:748). The level the shared clamp resolves for a negative
+        // --compress-level is therefore a real, usable encoder input - proving
+        // it must NOT be raised to 1. This exercises the resolved level end to
+        // end through a live zstd encoder/decoder round trip.
+        use crate::algorithm::{CompressionAlgorithm, zstd_min_level};
+
+        let payload = b"the quick brown fox jumps over the lazy dog\n".repeat(64);
+        for raw in [-5, zstd_min_level()] {
+            let level = CompressionAlgorithm::Zstd.resolve_debug_level(raw);
+            assert!(level < 0, "resolver preserves the negative level {raw}");
+
+            let mut encoder =
+                ZstdEncoder::new(Vec::new(), level).expect("encoder accepts negative level");
+            encoder.write_all(&payload).expect("compress payload");
+            let compressed = encoder.finish().expect("finish stream");
+
+            let mut decoded = Vec::new();
+            ZstdDecoder::new(&compressed[..])
+                .expect("decoder")
+                .read_to_end(&mut decoded)
+                .expect("decompress");
+            assert_eq!(decoded, payload, "round trip at level {level}");
+        }
+    }
+
+    #[test]
     fn all_levels_produce_valid_output() {
         let input = b"The quick brown fox jumps over the lazy dog";
 


### PR DESCRIPTION
## Summary

zstd supports negative ("fast") compression levels, and upstream rsync accepts
them. Its `--compress-level` clamp for zstd runs from `ZSTD_minCLevel()` (a large
negative value) up to `ZSTD_maxCLevel()`, so `--compress-level=-5` stays `-5`.

oc's shared compression-level resolver clamped zstd to a minimum of `1`, silently
rewriting every negative level to `1`. That produced a different effective level
than upstream for the same flag.

This corrects the zstd branch of the shared level resolver to mirror upstream's
lower bound exactly, using the linked libzstd's own `ZSTD_minCLevel()` value.

## Upstream reference

`token.c:init_compression_level()` (rsync 3.4.4), zstd branch:

```c
case CPRES_ZSTD:
    min_level = skip_compression_level = ZSTD_minCLevel();   /* token.c:73 */
    max_level = ZSTD_maxCLevel();                            /* token.c:74 */
    def_level = ZSTD_CLEVEL_DEFAULT;                         /* token.c:75 */
    off_level = CLVL_NOT_SPECIFIED;
    if (do_compression_level == 0)                           /* token.c:77-78 */
        do_compression_level = def_level;
    break;
...
if (do_compression_level < min_level)                        /* token.c:101-102 */
    do_compression_level = min_level;
else if (do_compression_level > max_level)                   /* token.c:103-104 */
    do_compression_level = max_level;
```

The lower bound is `ZSTD_minCLevel()` (negative), not `1`. A level of `0` maps to
the default (`3`); values below the minimum saturate *up* to `ZSTD_minCLevel()`;
values are never rejected. The clamped level is what upstream hands to
`ZSTD_CCtx_setParameter(.., ZSTD_c_compressionLevel, ..)` (`token.c:748`).

## Change

`crates/compress/src/algorithm.rs`:

- Add `zstd_min_level()`, a safe accessor for `ZSTD_minCLevel()` via the `zstd`
  crate's `compression_level_range()` (no unsafe added to the compress crate).
  The value is queried at runtime so the lower bound tracks the linked libzstd,
  exactly as upstream does.
- `CompressionAlgorithm::resolve_debug_level` (the single source of truth for the
  `init_compression_level()` resolution, shared by the wire-negotiation and
  local-copy summary paths) now clamps the zstd branch to
  `[zstd_min_level(), ZSTD_MAX_LEVEL]` instead of `[1, ZSTD_MAX_LEVEL]`. The
  upper clamp (`ZSTD_MAX_LEVEL` = 22) and the `0`/`CLVL_NOT_SPECIFIED` default
  substitution are unchanged. zlib and lz4 handling are untouched.

## Scope note

The user-facing `--compress-level` value is currently carried through the CLI and
transfer layers as an unsigned type (`NonZeroU8` in `CompressLevelArg`,
`CompressionLevel::Precise`, `CompressionSetting`), so a negative level is
collapsed to a positive value at parse time before any downstream code sees it.
Threading a signed representation through those layers so a negative
`--compress-level` reaches the encoder end to end is a separate, broader change
(the signed-`CompressionLevel` refactor) and is intentionally out of scope here.
This PR fixes the shared clamp so it no longer raises negative zstd levels to `1`
and stops the resolver from being the place that discards them.

## Tests

- `zstd_min_level_is_negative` - guards that `ZSTD_minCLevel()` really is
  negative (otherwise the fix would be a no-op).
- `resolve_debug_level_preserves_negative_zstd_levels` - `-5` and the exact
  `ZSTD_minCLevel()` boundary are preserved, not raised to `1`.
- `resolve_debug_level_clamps_below_min_to_zstd_min` - a level below the minimum
  saturates to `ZSTD_minCLevel()` (matching upstream), and the `CLVL_NOT_SPECIFIED`
  sentinel still resolves to the default.
- `resolve_debug_level_positive_and_zero_zstd_unchanged` - positive levels, the
  `0`-to-default substitution, and the upper clamp to `22` are unchanged.
- `encoder_accepts_negative_zstd_levels` - drives the resolved negative level
  through a live zstd encoder/decoder round trip, proving it is a real, usable
  encoder input that must not be raised to `1`.
