### PR TITLE
fix(transport): thread --timeout into SSH stall watchdog end-to-end

### DIFF
--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -57,6 +57,22 @@ impl ClientConfig {
         self.timeout
     }
 
+    /// Resolves the `--timeout` value into the I/O stall timeout applied to the
+    /// SSH data channel.
+    ///
+    /// Returns `None` when `--timeout` is unset or `0`, matching upstream where
+    /// `io_timeout == 0` disables the check entirely; a positive value maps to
+    /// that many seconds. Upstream applies the same `io_timeout` uniformly to
+    /// every transport (the SSH pipe included) via `set_io_timeout(io_timeout)`.
+    ///
+    /// upstream: options.c:2369 `set_io_timeout(io_timeout)`, io.c:1148-1160.
+    #[must_use]
+    pub fn ssh_io_timeout(&self) -> Option<std::time::Duration> {
+        self.timeout
+            .as_seconds()
+            .map(|secs| std::time::Duration::from_secs(secs.get()))
+    }
+
     /// Returns the configured connection timeout.
     #[must_use]
     #[doc(alias = "--contimeout")]
@@ -241,6 +257,33 @@ mod tests {
     fn connect_timeout_default_is_default() {
         let config = default_config();
         assert_eq!(config.connect_timeout(), TransferTimeout::Default);
+    }
+
+    #[test]
+    fn ssh_io_timeout_maps_positive_timeout_to_seconds() {
+        // WHY: --timeout N must reach the SSH stall watchdog so a hung remote
+        // aborts after N seconds instead of hanging the client forever.
+        // upstream: options.c:815 --timeout sets io_timeout; options.c:2369
+        // set_io_timeout applies it to every transport, the SSH pipe included.
+        let mut config = default_config();
+        config.timeout = TransferTimeout::Seconds(std::num::NonZeroU64::new(45).unwrap());
+        assert_eq!(
+            config.ssh_io_timeout(),
+            Some(std::time::Duration::from_secs(45))
+        );
+    }
+
+    #[test]
+    fn ssh_io_timeout_absent_or_disabled_stays_off() {
+        // WHY: io_timeout == 0 (unset or --no-timeout) disables the check, so
+        // the SSH watchdog must remain in its default-off state and never abort
+        // an otherwise-healthy transfer. upstream: io.c:1153 `if (!io_timeout)`.
+        let default = default_config();
+        assert_eq!(default.ssh_io_timeout(), None);
+
+        let mut disabled = default_config();
+        disabled.timeout = TransferTimeout::Disabled;
+        assert_eq!(disabled.ssh_io_timeout(), None);
     }
 
     #[test]

--- a/crates/core/src/client/remote/async_ssh_transport.rs
+++ b/crates/core/src/client/remote/async_ssh_transport.rs
@@ -210,7 +210,12 @@ fn build_plan(
     };
 
     let connect_timeout = config.connect_timeout().effective(Duration::from_secs(30));
-    let connect_config = SshConnectConfig::new().with_connect_timeout(connect_timeout);
+    // upstream: options.c:2369 set_io_timeout(io_timeout) applies --timeout to
+    // every transport; on the SSH pipe it drives the stall watchdog. 0/unset
+    // leaves it disabled.
+    let connect_config = SshConnectConfig::new()
+        .with_connect_timeout(connect_timeout)
+        .with_io_timeout(config.ssh_io_timeout());
 
     Ok(AsyncSpawnPlan {
         remote,
@@ -662,6 +667,38 @@ mod tests {
         let mut writer = SyncWriter::new(tx);
         let err = writer.write_all(b"x").unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    }
+
+    #[test]
+    fn build_plan_threads_timeout_into_ssh_transport_config() {
+        // WHY: before this wiring the async SSH transport always constructed the
+        // connect config with io_timeout: None, so a stalled remote could hang
+        // the client forever despite an explicit --timeout. The parsed value
+        // must reach the SshConnectConfig the stall watchdog reads.
+        // upstream: options.c:2369 set_io_timeout(io_timeout) on the SSH pipe.
+        let config = crate::client::config::ClientConfigBuilder::default()
+            .timeout(crate::client::config::TransferTimeout::Seconds(
+                std::num::NonZeroU64::new(37).unwrap(),
+            ))
+            .build();
+        let plan = build_plan(&config, RemoteRole::Sender, "host:/data", None)
+            .expect("build_plan should succeed for a simple remote dest");
+        assert_eq!(
+            plan.config.io_timeout,
+            Some(std::time::Duration::from_secs(37)),
+            "parsed --timeout must reach the SSH transport's io_timeout"
+        );
+    }
+
+    #[test]
+    fn build_plan_leaves_io_timeout_disabled_when_unset() {
+        // WHY: --timeout unset means io_timeout == 0 (off); the SSH transport
+        // must preserve the watchdog's default-off behavior, matching the
+        // pre-wiring contract for transfers that never opt into a timeout.
+        let config = crate::client::config::ClientConfigBuilder::default().build();
+        let plan = build_plan(&config, RemoteRole::Sender, "host:/data", None)
+            .expect("build_plan should succeed for a simple remote dest");
+        assert_eq!(plan.config.io_timeout, None);
     }
 
     #[test]

--- a/crates/core/src/client/remote/remote_to_remote.rs
+++ b/crates/core/src/client/remote/remote_to_remote.rs
@@ -208,6 +208,11 @@ fn spawn_ssh_connection(
         .effective(std::time::Duration::from_secs(30));
     ssh.set_connect_timeout(connect_timeout);
 
+    // upstream: options.c:2369 set_io_timeout(io_timeout) applies --timeout to
+    // every transport; on the SSH pipe it drives the stall watchdog. 0/unset
+    // leaves it disabled.
+    ssh.set_io_timeout(config.ssh_io_timeout());
+
     ssh.set_remote_command(invocation_args);
 
     ssh.spawn().map_err(|e| {

--- a/crates/core/src/client/remote/ssh_transfer/connection.rs
+++ b/crates/core/src/client/remote/ssh_transfer/connection.rs
@@ -58,6 +58,11 @@ pub(super) fn build_ssh_connection(
     let connect_timeout = config.connect_timeout().effective(Duration::from_secs(30));
     ssh.set_connect_timeout(connect_timeout);
 
+    // upstream: options.c:2369 set_io_timeout(io_timeout) applies --timeout
+    // uniformly to every transport; on the SSH pipe it drives the stall
+    // watchdog. 0/unset leaves it disabled.
+    ssh.set_io_timeout(config.ssh_io_timeout());
+
     ssh.set_remote_command(invocation_args);
 
     warn_double_compression_once(config.compress(), ssh.has_ssh_compression());


### PR DESCRIPTION
## Summary

Completes the SSH `--timeout` work started in #6636. That PR added the
`IoStallWatchdog` for the SSH transport, but the user-supplied `--timeout N`
value was never threaded end-to-end into the transport: every core SSH
call site constructed the connection with `io_timeout: None`, so the watchdog
ran with stall detection disabled regardless of what the user passed. A hung
remote could still hang the client indefinitely despite an explicit
`--timeout`.

This PR threads the parsed `--timeout` (seconds) from `ClientConfig` into the
SSH transport's `io_timeout` at all three SSH spawn sites, so the #6636
watchdog now arms with the user's value. `--timeout 0` / unset continues to
map to `None`, preserving the existing default-off behavior exactly.

## Upstream reference

Upstream applies one `io_timeout` uniformly across every transport - the SSH
pipe included. `--timeout` sets the global `io_timeout` (`options.c:815`),
and `set_io_timeout(io_timeout)` is called once after option parsing
(`options.c:2369`), which the `select`/`poll` loop then enforces on all fds
(`io.c:254,341,758`). `io_timeout == 0` disables the check
(`io.c:1153 if (!io_timeout) ... select_timeout = SELECT_TIMEOUT`), matching
the `Option::None` off state. This change makes the SSH transport honor the
same semantics.

## Changes

A single shared resolver, `ClientConfig::ssh_io_timeout()`, maps the parsed
`--timeout` into `Option<Duration>` (positive seconds -> `Some`, unset /
disabled / zero -> `None`). It is consumed at every SSH spawn site, replacing
the previous hardcoded `None`:

- `client/remote/ssh_transfer/connection.rs` `build_ssh_connection` -
  `ssh.set_io_timeout(config.ssh_io_timeout())` (main sync SSH path).
- `client/remote/remote_to_remote.rs` `spawn_ssh_connection` -
  `ssh.set_io_timeout(config.ssh_io_timeout())` (remote-to-remote relay).
- `client/remote/async_ssh_transport.rs` `build_plan` -
  `SshConnectConfig::new().with_connect_timeout(..).with_io_timeout(config.ssh_io_timeout())`
  (async SSH transport).

The watchdog logic itself is unchanged; only the input value is now wired
through.

## Tests

- `ssh_io_timeout_maps_positive_timeout_to_seconds` - `--timeout N` resolves to
  `Some(N seconds)`.
- `ssh_io_timeout_absent_or_disabled_stays_off` - unset and disabled both
  resolve to `None`, preserving the default-off watchdog behavior.
- `build_plan_threads_timeout_into_ssh_transport_config` - a parsed `--timeout`
  reaches `SshConnectConfig.io_timeout` (the struct the watchdog reads),
  proving the value is no longer `None`.
- `build_plan_leaves_io_timeout_disabled_when_unset` - no `--timeout` leaves the
  transport's `io_timeout` disabled.
