### PR TITLE
fix(cli): enforce upstream MAX_BASIS_DIRS limit on alt-dest args

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -27,6 +27,55 @@ use super::flags::{tri_state_flag_negative_first, tri_state_flag_positive_first}
 use super::values::join_os_values;
 use super::{BandwidthArgument, ParsedArgs, detect_program_name, env_protect_args_default};
 
+/// Maximum number of alt-dest directories rsync accepts across `--compare-dest`,
+/// `--copy-dest`, and `--link-dest` combined.
+///
+/// The three options share a single `basis_dir[]` array, so the cap is on their
+/// combined total. A separate conflict rule (upstream: options.c:1741-1745,
+/// mirrored by `conflicts_with_all` on the args) forbids mixing the types, so in
+/// practice the array only ever holds one type. upstream: rsync.h:196
+/// `#define MAX_BASIS_DIRS 20`.
+const MAX_BASIS_DIRS: usize = 20;
+
+/// Enforces upstream's [`MAX_BASIS_DIRS`] cap on alt-dest directories.
+///
+/// upstream: options.c:1749-1754 rejects the arg that would push the shared
+/// `basis_dir[]` array past `MAX_BASIS_DIRS`, reporting the alt-dest option in
+/// effect and exiting `RERR_SYNTAX` (1). The reported option is the first
+/// alt-dest option on the command line, mirroring upstream's `alt_dest_opt(0)`,
+/// which returns the type fixed by the first alt-dest arg parsed.
+fn check_basis_dir_limit(matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+    const ALT_DEST: [(&str, &str); 3] = [
+        ("compare-dest", "--compare-dest"),
+        ("copy-dest", "--copy-dest"),
+        ("link-dest", "--link-dest"),
+    ];
+
+    let total: usize = ALT_DEST
+        .iter()
+        .filter_map(|(id, _)| matches.get_many::<OsString>(id).map(Iterator::count))
+        .sum();
+    if total <= MAX_BASIS_DIRS {
+        return Ok(());
+    }
+
+    let option = ALT_DEST
+        .iter()
+        .filter_map(|(id, label)| {
+            matches
+                .indices_of(id)
+                .and_then(Iterator::min)
+                .map(|index| (index, *label))
+        })
+        .min_by_key(|(index, _)| *index)
+        .map_or("--link-dest", |(_, label)| label);
+
+    Err(clap::Error::raw(
+        clap::error::ErrorKind::TooManyValues,
+        format!("ERROR: at most {MAX_BASIS_DIRS} {option} args may be specified\n"),
+    ))
+}
+
 /// Parses command-line arguments into a structured [`ParsedArgs`] representation.
 ///
 /// This function accepts an iterator of arguments (typically from `std::env::args_os()`)
@@ -51,6 +100,8 @@ where
     let args = hoist_options_before_operands(&command, args);
     let args = expand_short_options(&command, args);
     let mut matches = command.try_get_matches_from(args.clone())?;
+
+    check_basis_dir_limit(&matches)?;
 
     let show_help = matches.get_flag("help");
     let show_version = matches.get_count("version");

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -953,3 +953,77 @@ fn checksum_threads_rejects_invalid_and_out_of_range() {
         assert!(result.is_err(), "value {arg:?} must be rejected");
     }
 }
+
+/// Builds `count` repetitions of a single alt-dest option plus operands.
+fn alt_dest_args(flag: &str, count: usize) -> Vec<String> {
+    let mut args: Vec<String> = (0..count)
+        .map(|index| format!("{flag}=dir{index}"))
+        .collect();
+    args.push("src/".to_string());
+    args.push("dst/".to_string());
+    args
+}
+
+/// upstream: options.c:1749-1754 accepts up to `MAX_BASIS_DIRS` (rsync.h:196)
+/// alt-dest args; the boundary itself must not be rejected.
+#[test]
+fn alt_dest_limit_accepts_twenty() {
+    let result = parse_test_args(alt_dest_args("--link-dest", 20));
+    assert!(result.is_ok(), "20 alt-dest dirs must be accepted");
+}
+
+/// upstream: options.c:1752-1753 rejects the 21st alt-dest arg with the verbatim
+/// `ERROR: at most 20 <opt> args may be specified` message and RERR_SYNTAX. The
+/// exact wording matters because it is observable output a drop-in must mirror.
+#[test]
+fn alt_dest_limit_rejects_twenty_one() {
+    let result = parse_test_args(alt_dest_args("--link-dest", 21));
+    let err = result.expect_err("21 alt-dest dirs must be rejected");
+    assert_eq!(err.kind(), clap::error::ErrorKind::TooManyValues);
+    assert!(
+        err.to_string()
+            .contains("ERROR: at most 20 --link-dest args may be specified"),
+        "unexpected message: {err}"
+    );
+}
+
+/// The cap counts the shared `basis_dir[]` array, so it fires for whichever of
+/// the three alt-dest option types is in use and names that option verbatim
+/// (upstream: `alt_dest_opt(0)`). Every type must be capped identically.
+#[test]
+fn alt_dest_limit_enforced_for_each_type() {
+    for flag in ["--compare-dest", "--copy-dest", "--link-dest"] {
+        assert!(
+            parse_test_args(alt_dest_args(flag, 20)).is_ok(),
+            "20 {flag} dirs must be accepted"
+        );
+        let err = parse_test_args(alt_dest_args(flag, 21))
+            .expect_err(&format!("21 {flag} dirs must be rejected"));
+        assert!(
+            err.to_string()
+                .contains(&format!("ERROR: at most 20 {flag} args may be specified")),
+            "unexpected message for {flag}: {err}"
+        );
+    }
+}
+
+/// The `basis_dir[]` array is shared, but upstream forbids mixing the three
+/// alt-dest types (options.c:1741-1745), a rule oc mirrors with
+/// `conflicts_with_all`. So a "combined" total spanning types (here 10
+/// `--compare-dest` + 11 `--link-dest`) can never reach the count check - it is
+/// rejected first by the conflict rule. This proves only one type ever populates
+/// the shared array, which is why the cap is enforced per type in effect.
+#[test]
+fn alt_dest_types_cannot_be_mixed() {
+    let mut args: Vec<String> = (0..10).map(|i| format!("--compare-dest=c{i}")).collect();
+    args.extend((0..11).map(|i| format!("--link-dest=l{i}")));
+    args.push("src/".to_string());
+    args.push("dst/".to_string());
+
+    let err = parse_test_args(args).expect_err("mixed alt-dest types must be rejected");
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    assert!(
+        err.to_string().contains("cannot be used with"),
+        "expected a conflict diagnostic, got: {err}"
+    );
+}

--- a/crates/cli/src/frontend/tests/run.rs
+++ b/crates/cli/src/frontend/tests/run.rs
@@ -51,6 +51,30 @@ fn clap_error_uses_canonical_exit_code_text() {
     );
 }
 
+// upstream: options.c:1749-1754 - the 21st alt-dest arg overflows the shared
+// `basis_dir[]` array (rsync.h:196 MAX_BASIS_DIRS) and exits RERR_SYNTAX (1)
+// with a verbatim `ERROR: at most 20 <opt> args may be specified` message. We
+// assert both the exit code and the message end-to-end.
+#[test]
+fn run_rejects_excess_alt_dest_dirs() {
+    let mut args = vec![OsString::from(OC_RSYNC)];
+    for index in 0..21 {
+        args.push(OsString::from(format!("--link-dest=dir{index}")));
+    }
+    args.push(OsString::from("src"));
+    args.push(OsString::from("dst"));
+
+    let (code, stdout, stderr) = run_with_args(args);
+
+    assert_eq!(code, 1, "21 alt-dest dirs must exit RERR_SYNTAX");
+    assert!(stdout.is_empty());
+    let rendered = String::from_utf8(stderr).expect("diagnostic utf8");
+    assert!(
+        rendered.contains("ERROR: at most 20 --link-dest args may be specified"),
+        "diagnostic was: {rendered}"
+    );
+}
+
 #[test]
 fn clap_value_error_does_not_double_error_prefix() {
     // A clap value-validation failure (here `--block-size`) surfaces through


### PR DESCRIPTION
## Summary

Enforce upstream rsync's `MAX_BASIS_DIRS` limit on alt-dest arguments
(`--compare-dest`, `--copy-dest`, `--link-dest`). Previously these directories
were accumulated without bound; upstream errors out on the arg that would push
the shared `basis_dir[]` array past 20 entries.

## Upstream reference

`rsync.h:196` defines the cap:

```c
#define MAX_BASIS_DIRS 20
```

`options.c:1749-1754` enforces it as each alt-dest arg is parsed:

```c
if (basis_dir_cnt >= MAX_BASIS_DIRS) {
    snprintf(err_buf, sizeof err_buf,
        "ERROR: at most %d %s args may be specified\n",
        MAX_BASIS_DIRS, alt_dest_opt(0));
    goto cleanup;
}
basis_dir[basis_dir_cnt++] = (char *)poptGetOptArg(pc);
```

On failure upstream exits `RERR_SYNTAX` (1, `errcode.h:25`). The three options
share the single `basis_dir[]` array, so the cap is on their combined total.
A separate conflict check (`options.c:1741-1745`) forbids mixing the three
types, which this crate already mirrors via clap `conflicts_with_all`; that rule
fires first, so the shared array only ever holds one type in practice.

## Change

- Added a named `MAX_BASIS_DIRS = 20` constant mirroring `rsync.h`, not a magic
  literal.
- A single `check_basis_dir_limit` guard runs right after argument matching. It
  sums the combined alt-dest count and, if it exceeds the cap, returns the
  verbatim upstream message via the existing clap error path (which maps to
  exit code 1). The reported option name mirrors upstream's `alt_dest_opt(0)`
  (the alt-dest type in effect).
- No change to alt-dest resolution or semantics; the fix is confined to the
  argument-count guard in the CLI crate.

## Tests

- `alt_dest_limit_accepts_twenty` - exactly 20 alt-dest dirs are accepted.
- `alt_dest_limit_rejects_twenty_one` - the 21st is rejected with the exact
  upstream message and error kind.
- `alt_dest_limit_enforced_for_each_type` - each of the three option types is
  capped identically and names itself in the diagnostic.
- `alt_dest_types_cannot_be_mixed` - a cross-type total is rejected first by the
  conflict rule, proving only one type populates the shared array.
- `run_rejects_excess_alt_dest_dirs` - end-to-end run exits `RERR_SYNTAX` (1)
  with the upstream message on stderr.
