### PR TITLE
fix(transfer): itemize hardlink followers on push (emit ndx+iflags in server mode)

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -290,6 +290,14 @@ pub struct ReceiverContext {
     /// redo re-itemizing an entry. `RefCell` suffices: every emit site runs on
     /// the main driver thread (rayon workers never touch this).
     pub(in crate::receiver) itemize_rows: RefCell<BTreeMap<usize, Vec<String>>>,
+    /// Count of server-mode hardlink-follower itemize records emitted this phase
+    /// that the peer's sender will echo back (upstream `sender.c:286-292` echoes
+    /// every non-transfer item). The pipeline response loop is request-count
+    /// driven and never reads these echoes, so they must be drained at the phase
+    /// boundary - after the receiver's NDX_DONE unblocks the sender to flush -
+    /// before [`Self::read_expected_ndx_done`] expects the sender's NDX_DONE.
+    /// `Cell` because the emit site runs behind a `&self` pipeline closure.
+    pub(in crate::receiver) hardlink_follower_echoes: std::cell::Cell<usize>,
     /// Extraneous-entry victims decided during the transfer walk for a
     /// `--delete-delay` run, awaiting execution after the transfer completes.
     ///
@@ -378,6 +386,7 @@ impl ReceiverContext {
             hardlink_lookahead_target: 500,
             defer_itemize: false,
             itemize_rows: RefCell::new(BTreeMap::new()),
+            hardlink_follower_echoes: std::cell::Cell::new(0),
             delayed_delete_victims: Vec::new(),
         }
     }

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -254,7 +254,7 @@ impl ReceiverContext {
             }
         }
 
-        let mut emitted = false;
+        let mut emitted = 0usize;
         for (flat_idx, entry) in self.file_list.iter().enumerate() {
             if !entry.hlinked() || entry.hlink_first() {
                 continue;
@@ -275,14 +275,20 @@ impl ReceiverContext {
             writer.write_all(&iflags.to_le_bytes())?;
             // upstream: generator.c:591 write_vstring(sock_f_out, xname, len)
             write_itemize_vstring(writer, leader_name.as_bytes())?;
-            emitted = true;
+            emitted += 1;
         }
 
-        // upstream: generator.c flushes each itemize via rwrite(); flush once so
-        // the peer's sender sees the follower rows without waiting on the
-        // create_hardlinks pass that follows.
-        if emitted {
+        if emitted > 0 {
+            // upstream: generator.c flushes each itemize via rwrite(); flush once
+            // so the peer's sender sees the follower rows without waiting on the
+            // create_hardlinks pass that follows.
             writer.flush()?;
+            // The peer's sender echoes every non-transfer item back
+            // (upstream sender.c:286-292). Record the count so the phase-done
+            // read drains those echoes before expecting NDX_DONE - the pipeline
+            // response loop is request-count driven and never reads them.
+            self.hardlink_follower_echoes
+                .set(self.hardlink_follower_echoes.get() + emitted);
         }
         Ok(())
     }

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -193,6 +193,100 @@ impl ReceiverContext {
         }
     }
 
+    /// Emits over-the-wire itemize records for every hardlink follower so a
+    /// pushing client's sender renders the `hf...` / `=> leader` row.
+    ///
+    /// A hardlink follower is never sent for transfer, so it produces no
+    /// `NDX + iflags` request in the per-file loop. Upstream instead itemizes
+    /// each follower from `finish_hard_link()` -> `maybe_hard_link()`, which
+    /// writes `NDX + write_shortint(iflags) + write_vstring(xname)` to
+    /// `sock_f_out`; the peer's sender reads those attrs and logs the row
+    /// (`sender.c:287` `maybe_log_item`). Without this a server-mode receiver
+    /// (the remote end of a push) drops every follower row, because
+    /// [`emit_itemize`](Self::emit_itemize) is a no-op off the client.
+    ///
+    /// This is the server-only counterpart of the client-mode follower rows that
+    /// `create_hardlinks` renders locally, so a pull is left untouched. The
+    /// `iflags` mirror `maybe_hard_link()`'s `ITEM_LOCAL_CHANGE |
+    /// ITEM_XNAME_FOLLOWS`, plus `ITEM_IS_NEW` for the new-follower case, and the
+    /// xname carries the leader's transfer-relative name the peer renders after
+    /// `=>`.
+    ///
+    /// Writes go through `ndx_codec`, which MUST be the same NDX diff-state used
+    /// for this phase's file requests so the delta encoding stays in sync with
+    /// the peer's read state.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:585-591` - `itemize()` writes `NDX`,
+    ///   `write_shortint(iflags)`, then `write_vstring(xname)`.
+    /// - `hlink.c:218-234` - `maybe_hard_link()` itemizes each follower with
+    ///   `ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS`, passing the leader realname.
+    pub(in crate::receiver) fn emit_server_hardlink_follower_itemize<W>(
+        &self,
+        writer: &mut W,
+        ndx_codec: &mut protocol::codec::NdxCodecEnum,
+    ) -> std::io::Result<()>
+    where
+        W: std::io::Write + ?Sized,
+    {
+        use protocol::codec::NdxCodec;
+
+        // Client-mode (pull) receivers render follower rows locally in
+        // create_hardlinks; only a server-mode (push) receiver forwards them over
+        // the wire. Pre-iflags protocols (< 29) carry no itemize attrs.
+        if self.config.connection.client_mode
+            || !self.config.flags.hard_links
+            || !self.protocol.supports_iflags()
+        {
+            return Ok(());
+        }
+
+        // Leader group index -> transfer-relative name, so each follower can name
+        // its leader in the xname the peer renders after "=>".
+        let mut leader_names: std::collections::HashMap<u32, &str> =
+            std::collections::HashMap::new();
+        for entry in &self.file_list {
+            if entry.hlink_first() {
+                if let Some(gnum) = entry.hardlink_idx() {
+                    leader_names.entry(gnum).or_insert_with(|| entry.name());
+                }
+            }
+        }
+
+        let mut emitted = false;
+        for (flat_idx, entry) in self.file_list.iter().enumerate() {
+            if !entry.hlinked() || entry.hlink_first() {
+                continue;
+            }
+            let Some(gnum) = entry.hardlink_idx() else {
+                continue;
+            };
+            let Some(leader_name) = leader_names.get(&gnum).copied() else {
+                continue;
+            };
+
+            let ndx = self.flat_to_wire_ndx(flat_idx);
+            ndx_codec.write_ndx(writer, ndx)?;
+            // upstream: generator.c:587 write_shortint(sock_f_out, iflags)
+            let iflags = (crate::generator::ItemFlags::ITEM_LOCAL_CHANGE
+                | crate::generator::ItemFlags::ITEM_XNAME_FOLLOWS
+                | crate::generator::ItemFlags::ITEM_IS_NEW) as u16;
+            writer.write_all(&iflags.to_le_bytes())?;
+            // upstream: generator.c:591 write_vstring(sock_f_out, xname, len)
+            write_itemize_vstring(writer, leader_name.as_bytes())?;
+            emitted = true;
+        }
+
+        // upstream: generator.c flushes each itemize via rwrite(); flush once so
+        // the peer's sender sees the follower rows without waiting on the
+        // create_hardlinks pass that follows.
+        if emitted {
+            writer.flush()?;
+        }
+        Ok(())
+    }
+
     /// Emits an itemize row immediately, or buffers it for the deferred
     /// flist-index-order flush when [`Self::defer_itemize`] is set.
     ///
@@ -265,4 +359,26 @@ impl ReceiverContext {
         }
         Ok(())
     }
+}
+
+/// Writes an itemize xname as an upstream `io.c:write_vstring()` length-prefixed
+/// string: a single length byte for `len <= 0x7F`, otherwise a two-byte prefix
+/// (`0x80 | len >> 8`, then `len & 0xFF`). Mirrors the reader in
+/// `generator::item_flags::ItemFlags::read_trailing` so a peer's sender decodes
+/// the exact bytes it emitted.
+fn write_itemize_vstring<W: std::io::Write + ?Sized>(
+    writer: &mut W,
+    bytes: &[u8],
+) -> std::io::Result<()> {
+    let len = bytes.len();
+    debug_assert!(len <= 0x7FFF, "itemize xname exceeds vstring capacity");
+    if len > 0x7F {
+        writer.write_all(&[((len >> 8) as u8) | 0x80, (len & 0xFF) as u8])?;
+    } else {
+        writer.write_all(&[len as u8])?;
+    }
+    if len > 0 {
+        writer.write_all(bytes)?;
+    }
+    Ok(())
 }

--- a/crates/transfer/src/receiver/tests/hard_links.rs
+++ b/crates/transfer/src/receiver/tests/hard_links.rs
@@ -4,6 +4,7 @@
 use std::ffi::OsString;
 
 use protocol::ProtocolVersion;
+use protocol::flist::FileEntry;
 
 use super::support::{
     TestDeletionWriter, make_hlink_follower, make_hlink_leader, receiver_with_hardlinks,
@@ -613,5 +614,178 @@ fn finalize_links_followers_after_delayed_leader_rename() {
     assert!(
         !staging.exists(),
         "the .~tmp~ staging dir must be removed after the delayed rename",
+    );
+}
+
+/// Builds a client-mode (pull) receiver over the same hardlink fixture so the
+/// scope guard in [`ReceiverContext::emit_server_hardlink_follower_itemize`] can
+/// be exercised. A pull renders follower rows locally in `create_hardlinks`, so
+/// nothing must cross the wire here.
+fn pull_receiver_with_hardlinks(entries: Vec<FileEntry>) -> ReceiverContext {
+    let handshake = test_handshake();
+    let config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        flag_string: "-logDtpHre.".to_owned(),
+        flags: ParsedServerFlags {
+            hard_links: true,
+            ..Default::default()
+        },
+        connection: crate::config::ConnectionConfig {
+            client_mode: true,
+            ..Default::default()
+        },
+        args: vec![OsString::from(".")],
+        ..Default::default()
+    };
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.file_list = entries;
+    ctx
+}
+
+/// A hardlink follower is never sent for transfer, so a server-mode push
+/// receiver must forward its itemize record (`NDX + iflags + xname`)
+/// explicitly; otherwise the pushing client's sender has nothing to render and
+/// the follower's `hf...` / `=> leader` row is silently dropped (issue #119).
+/// This pins the exact wire shape upstream emits (`generator.c:585-591`,
+/// `hlink.c:218-234`) and proves the peer's own sender decoder round-trips it.
+#[test]
+fn server_push_emits_follower_ndx_iflags_and_leader_xname() {
+    use crate::generator::ItemFlags;
+    use protocol::codec::{NdxCodec, create_ndx_codec};
+
+    let entries = vec![
+        make_hlink_leader("leader.txt", 14, 42),
+        make_hlink_follower("follower.txt", 14, 42),
+    ];
+    let ctx = receiver_with_hardlinks(entries);
+    let expected_ndx = ctx.flat_to_wire_ndx(1);
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut ndx_codec = create_ndx_codec(32);
+    ctx.emit_server_hardlink_follower_itemize(&mut buf, &mut ndx_codec)
+        .expect("server-mode follower itemize must serialize");
+    assert!(
+        !buf.is_empty(),
+        "a server-mode push must forward the follower itemize record",
+    );
+
+    // Decode with the peer sender's own reader path so the test fails if the
+    // emitted bytes ever diverge from what the sender consumes.
+    let mut cur = std::io::Cursor::new(buf);
+    let mut rd = create_ndx_codec(32);
+    let ndx = rd.read_ndx(&mut cur).expect("follower NDX must decode");
+    assert_eq!(
+        ndx, expected_ndx,
+        "the follower must be itemized under its own wire NDX",
+    );
+
+    let iflags = ItemFlags::read(&mut cur, 32).expect("follower iflags must decode");
+    assert!(
+        iflags.raw() & ItemFlags::ITEM_XNAME_FOLLOWS != 0,
+        "the follower carries ITEM_XNAME_FOLLOWS so the peer expects a leader name",
+    );
+    assert!(
+        iflags.raw() & ItemFlags::ITEM_LOCAL_CHANGE != 0,
+        "the follower is a local hardlink change (renders the `h` itemize char)",
+    );
+
+    let (fnamecmp_type, xname, _trailing) = iflags
+        .read_trailing(&mut cur)
+        .expect("the xname vstring must decode");
+    assert!(fnamecmp_type.is_none(), "a follower carries no basis type");
+    assert_eq!(
+        xname.as_deref(),
+        Some(b"leader.txt".as_ref()),
+        "the xname must name the leader so the peer renders `=> leader.txt`",
+    );
+    assert_eq!(
+        cur.position() as usize,
+        cur.get_ref().len(),
+        "exactly one follower record, fully consumed, must be on the wire",
+    );
+}
+
+/// Two followers sharing one leader must each get their own record, in flist
+/// order, so the peer renders a row per follower rather than a single collapsed
+/// line.
+#[test]
+fn server_push_emits_one_record_per_follower() {
+    use crate::generator::ItemFlags;
+    use protocol::codec::{NdxCodec, create_ndx_codec};
+
+    let entries = vec![
+        make_hlink_leader("a.txt", 11, 100),
+        make_hlink_follower("b.txt", 11, 100),
+        make_hlink_follower("c.txt", 11, 100),
+    ];
+    let ctx = receiver_with_hardlinks(entries);
+    let expected = [ctx.flat_to_wire_ndx(1), ctx.flat_to_wire_ndx(2)];
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut ndx_codec = create_ndx_codec(32);
+    ctx.emit_server_hardlink_follower_itemize(&mut buf, &mut ndx_codec)
+        .expect("server-mode follower itemize must serialize");
+
+    let mut cur = std::io::Cursor::new(buf);
+    let mut rd = create_ndx_codec(32);
+    for want_ndx in expected {
+        let ndx = rd.read_ndx(&mut cur).expect("follower NDX must decode");
+        assert_eq!(ndx, want_ndx, "followers must be itemized in flist order");
+        let iflags = ItemFlags::read(&mut cur, 32).expect("iflags must decode");
+        let (_ft, xname, _n) = iflags.read_trailing(&mut cur).expect("xname must decode");
+        assert_eq!(
+            xname.as_deref(),
+            Some(b"a.txt".as_ref()),
+            "every follower names the same shared leader",
+        );
+    }
+    assert_eq!(
+        cur.position() as usize,
+        cur.get_ref().len(),
+        "both follower records must be fully consumed",
+    );
+}
+
+/// A client-mode (pull) receiver renders follower rows locally via
+/// `create_hardlinks`; forwarding them over the wire too would double every
+/// follower against the pull's own row. The server-only emission must stay a
+/// no-op off a push.
+#[test]
+fn pull_receiver_emits_no_follower_wire_record() {
+    use protocol::codec::create_ndx_codec;
+
+    let entries = vec![
+        make_hlink_leader("leader.txt", 14, 42),
+        make_hlink_follower("follower.txt", 14, 42),
+    ];
+    let ctx = pull_receiver_with_hardlinks(entries);
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut ndx_codec = create_ndx_codec(32);
+    ctx.emit_server_hardlink_follower_itemize(&mut buf, &mut ndx_codec)
+        .expect("client-mode call must succeed as a no-op");
+    assert!(
+        buf.is_empty(),
+        "a pull renders follower rows locally; nothing crosses the wire",
+    );
+}
+
+/// With no hardlink followers in the file list, a server push must emit nothing
+/// - the emission is scoped strictly to the follower path.
+#[test]
+fn server_push_without_followers_emits_nothing() {
+    use protocol::codec::create_ndx_codec;
+
+    let entries = vec![make_hlink_leader("solo.txt", 9, 7)];
+    let ctx = receiver_with_hardlinks(entries);
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut ndx_codec = create_ndx_codec(32);
+    ctx.emit_server_hardlink_follower_itemize(&mut buf, &mut ndx_codec)
+        .expect("no-follower call must succeed");
+    assert!(
+        buf.is_empty(),
+        "a lone leader has no follower rows to forward",
     );
 }

--- a/crates/transfer/src/receiver/tests/hard_links.rs
+++ b/crates/transfer/src/receiver/tests/hard_links.rs
@@ -669,6 +669,12 @@ fn server_push_emits_follower_ndx_iflags_and_leader_xname() {
         !buf.is_empty(),
         "a server-mode push must forward the follower itemize record",
     );
+    assert_eq!(
+        ctx.hardlink_follower_echoes.get(),
+        1,
+        "the peer will echo the one non-transfer record; the phase-done read \
+         must drain exactly that many or it reads the echo as NDX_DONE (exit 10)",
+    );
 
     // Decode with the peer sender's own reader path so the test fails if the
     // emitted bytes ever diverge from what the sender consumes.
@@ -726,6 +732,11 @@ fn server_push_emits_one_record_per_follower() {
     let mut ndx_codec = create_ndx_codec(32);
     ctx.emit_server_hardlink_follower_itemize(&mut buf, &mut ndx_codec)
         .expect("server-mode follower itemize must serialize");
+    assert_eq!(
+        ctx.hardlink_follower_echoes.get(),
+        2,
+        "two followers produce two echoes to drain at the phase boundary",
+    );
 
     let mut cur = std::io::Cursor::new(buf);
     let mut rd = create_ndx_codec(32);
@@ -769,6 +780,11 @@ fn pull_receiver_emits_no_follower_wire_record() {
         buf.is_empty(),
         "a pull renders follower rows locally; nothing crosses the wire",
     );
+    assert_eq!(
+        ctx.hardlink_follower_echoes.get(),
+        0,
+        "a pull emits nothing, so there are no echoes to drain",
+    );
 }
 
 /// With no hardlink followers in the file list, a server push must emit nothing
@@ -787,5 +803,58 @@ fn server_push_without_followers_emits_nothing() {
     assert!(
         buf.is_empty(),
         "a lone leader has no follower rows to forward",
+    );
+    assert_eq!(ctx.hardlink_follower_echoes.get(), 0);
+}
+
+/// The peer's sender echoes every non-transfer item back (upstream
+/// `sender.c:286-292`), but the request-count-driven pipeline response loop
+/// never reads them. If they are not drained at the phase boundary, the first
+/// `read_expected_ndx_done` reads a follower echo's NDX instead of NDX_DONE and
+/// aborts with a protocol error (the exit-10 `hardlinks` testsuite failure).
+/// This crafts the sender's echo stream and asserts the phase-done read
+/// consumes every echo before matching NDX_DONE.
+#[test]
+fn phase_done_read_drains_pending_follower_echoes() {
+    use crate::generator::ItemFlags;
+    use protocol::codec::{NdxCodec, create_ndx_codec};
+
+    // Sender echo stream: two non-transfer follower records (NDX + iflags +
+    // xname vstring) then the phase NDX_DONE.
+    let mut wire: Vec<u8> = Vec::new();
+    let mut wc = create_ndx_codec(32);
+    let iflags = (ItemFlags::ITEM_LOCAL_CHANGE
+        | ItemFlags::ITEM_XNAME_FOLLOWS
+        | ItemFlags::ITEM_IS_NEW) as u16;
+    for ndx in [2i32, 3i32] {
+        wc.write_ndx(&mut wire, ndx).unwrap();
+        wire.extend_from_slice(&iflags.to_le_bytes());
+        let leader = b"a.txt";
+        wire.push(leader.len() as u8);
+        wire.extend_from_slice(leader);
+    }
+    wc.write_ndx_done(&mut wire).unwrap();
+    let total = wire.len();
+
+    let ctx = receiver_with_hardlinks(vec![
+        make_hlink_leader("a.txt", 6, 1),
+        make_hlink_follower("b.txt", 6, 1),
+        make_hlink_follower("c.txt", 6, 1),
+    ]);
+    ctx.hardlink_follower_echoes.set(2);
+
+    let mut cur = std::io::Cursor::new(wire);
+    let mut rc = create_ndx_codec(32);
+    ctx.read_expected_ndx_done(&mut rc, &mut cur, "test phase transition")
+        .expect("must drain the two follower echoes then match NDX_DONE");
+    assert_eq!(
+        ctx.hardlink_follower_echoes.get(),
+        0,
+        "the pending-echo count must reset so later NDX_DONE reads do not re-drain",
+    );
+    assert_eq!(
+        cur.position() as usize,
+        total,
+        "every echo plus the trailing NDX_DONE must be consumed from the stream",
     );
 }

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -110,6 +110,30 @@ impl ReceiverContext {
         Ok(())
     }
 
+    /// Drains the peer sender's echoes of this phase's hardlink-follower itemize
+    /// records before an NDX_DONE read.
+    ///
+    /// A server-mode push forwards `NDX + iflags + xname` for each hardlink
+    /// follower (see `emit_server_hardlink_follower_itemize`); the peer's sender
+    /// echoes every non-transfer item back (upstream `sender.c:286-292`), yet the
+    /// request-count-driven pipeline response loop never reads them. The sender
+    /// buffers those echoes until it reads the receiver's NDX_DONE, so this runs
+    /// on the first NDX_DONE read - once the sender has flushed - consuming each
+    /// echo and leaving the stream aligned on the sender's NDX_DONE. `read_ndx`
+    /// framing is delta-state independent, so consuming with the fresh phase
+    /// codec still advances by the exact wire bytes even though the discarded
+    /// index values are not needed.
+    fn drain_hardlink_follower_echoes<R: Read>(
+        &self,
+        ndx_read_codec: &mut NdxCodecEnum,
+        reader: &mut R,
+    ) -> io::Result<()> {
+        for _ in 0..self.hardlink_follower_echoes.take() {
+            crate::receiver::wire::SenderAttrs::read_with_codec(reader, ndx_read_codec)?;
+        }
+        Ok(())
+    }
+
     /// Reads an NDX and validates it is NDX_DONE (-1).
     pub(in crate::receiver) fn read_expected_ndx_done<R: Read>(
         &self,
@@ -117,6 +141,7 @@ impl ReceiverContext {
         reader: &mut R,
         context: &str,
     ) -> io::Result<()> {
+        self.drain_hardlink_follower_echoes(ndx_read_codec, reader)?;
         let ndx = ndx_read_codec.read_ndx(reader)?;
         if ndx != -1 {
             // upstream: io.c read_ndx / rsync.c:818 - a wire index that is not

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -439,6 +439,15 @@ impl ReceiverContext {
                 };
             }
 
+            // upstream: generator.c:2169 finish_hard_link() itemizes every
+            // follower once the leader completes, before the phase-1 NDX_DONE.
+            // Emit through the request-phase NDX diff-state (never the redo
+            // pass, which carries no new followers) so a pushing client's
+            // sender renders each `hf...` / `=> leader` row.
+            if !is_redo_pass {
+                self.emit_server_hardlink_follower_itemize(writer, ndx_write_codec.inner_mut())?;
+            }
+
             let redo_indices = pipelined_receiver.take_redo_indices();
             let delayed = pipelined_receiver.take_delayed_updates();
 

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -536,6 +536,12 @@ impl ReceiverContext {
             files_transferred += 1;
         }
 
+        // upstream: generator.c:2169 finish_hard_link() itemizes every follower
+        // before the phase's NDX_DONE. Emit through the request-phase NDX
+        // diff-state so a pushing client's sender renders each `hf...` /
+        // `=> leader` row (a no-op in client-mode pull).
+        self.emit_server_hardlink_follower_itemize(writer, ndx_write_codec.inner_mut())?;
+
         #[cfg(unix)]
         self.create_hardlinks(&dest_dir, sandbox.as_deref(), writer)?;
         #[cfg(not(unix))]


### PR DESCRIPTION
## Summary

On a daemon/ssh **push** where oc is the receiver-generator in **server** mode,
hardlink follower itemize records (the `hf...` / `=> leader` rows) were dropped:
a follower is never sent for transfer, so it produced no `NDX + iflags` request
in the per-file loop, and `emit_itemize` is a no-op off the client - so the
pushing client's sender had nothing to render (#119).

Upstream itemizes each follower from `finish_hard_link()` -> `maybe_hard_link()`,
which writes `NDX + write_shortint(iflags) + write_vstring(xname)` to
`sock_f_out` (`generator.c:585-591`, `hlink.c:218-234`) regardless of `-i` at
protocol >= 29 (`generator.c:2253` sets `itemizing = 1`; the record is written
whenever `xname` is non-empty). The peer's sender reads those attrs and logs the
row.

## Change

`ReceiverContext::emit_server_hardlink_follower_itemize` runs in the per-file
request phase (the shared pipelined `run_pipeline_loop_decoupled` and the sync
driver), before the delayed-update / `create_hardlinks` finalization:

- Server-mode (push) only; a client-mode pull still renders follower rows
  locally in `create_hardlinks`, so that path is untouched. Not made active for
  non-followers.
- For each follower, in flist order, it writes `NDX + iflags + xname` through the
  same request-phase NDX diff-state used for file requests. It reuses the exact
  wire fields the peer's sender already parses (`ItemFlags::read` /
  `read_trailing`); no new wire path, no change to the hardlink encode/decode.
- `iflags = ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS | ITEM_IS_NEW`; the xname is
  the leader's transfer-relative name (upstream `write_vstring` length-prefix
  form).

### Draining the sender's echoes (the exit-10 fix)

The peer's sender echoes every non-transfer item back to the receiver (upstream
`sender.c:286-292`; oc's own sender does the same in `transfer_loop.rs`). oc's
receiver pipeline is request-count driven and never reads those echoes, so
without draining them the first `read_expected_ndx_done` reads a follower echo's
NDX instead of NDX_DONE and aborts (`RERR_PROTOCOL` / broken pipe, exit 10 - the
`hardlinks` testsuite failure).

The sender buffers the echoes until it reads the receiver's phase-1 NDX_DONE (it
does not flush before blocking on read), so a synchronous drain right after
emission would deadlock. Instead the receiver records how many records it
emitted (`hardlink_follower_echoes`) and drains exactly that many at the start of
the phase-done read - after its NDX_DONE has unblocked the sender to flush.
`read_ndx` framing is delta-state independent, so the discarded echoes are
consumed by the exact wire bytes even with the fresh phase codec.

## Validation

Built `oc-rsync` and reproduced the failing scenario, then confirmed the fix
against real rsync 3.4.4 (protocol 32) over a remote-shell push:

- real rsync 3.4.4 --> oc receiver, `-aHivv`: exit 0, hardlinks correct, and the
  real-rsync client renders `hf+++++++++ b.txt => a.txt` / `c.txt => a.txt` from
  the emitted records.
- real rsync 3.4.4 --> oc receiver, plain `-aH` (no `-i`): exit 0, correct.
- oc --> real rsync 3.4.4 receiver, both `-aHivv` and `-aH`: exit 0, correct.
- oc <-> oc push (`-aHivv` and `-aH`), hardlink pull, and a second uptodate push:
  exit 0, no desync.

`checkit` compares exit status, `ls -lR` (nlink) and file contents, all of which
now match.

## Tests

Deterministic, in-process (no real-binary subprocess, cannot hang CI):

- `server_push_emits_follower_ndx_iflags_and_leader_xname` - decodes the emitted
  record with the peer sender's own reader and asserts NDX, iflags and leader
  xname, plus the recorded echo count.
- `server_push_emits_one_record_per_follower` - one record per follower, in flist
  order, naming the shared leader.
- `phase_done_read_drains_pending_follower_echoes` - crafts the sender's echo
  stream and asserts `read_expected_ndx_done` drains every echo before matching
  NDX_DONE and resets the count.
- `pull_receiver_emits_no_follower_wire_record` /
  `server_push_without_followers_emits_nothing` - the emission is scoped to
  server-mode followers only.

## Scope

Limited to the server-mode follower itemize emission and draining its echoes. No
change to the delayed-update ordering or the hardlink wire encode/decode. No
unsafe.
