### PR TITLE
feat(compress): thread signed compression level so negative zstd levels reach the encoder

### DIFF
--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -12,7 +12,7 @@ use core::{
 
 pub(crate) enum CompressLevelArg {
     Disable,
-    Level(NonZeroU8),
+    Level(CompressionLevel),
 }
 
 enum CompressionLevelParseError {
@@ -207,9 +207,7 @@ pub(crate) fn parse_compress_level_argument(
 ) -> Result<CompressionSetting, Message> {
     match parse_raw_level(value).map(|raw| clamp_level(codec, raw)) {
         Ok(CompressLevelArg::Disable) => Ok(CompressionSetting::disabled()),
-        Ok(CompressLevelArg::Level(level)) => {
-            Ok(CompressionSetting::level(CompressionLevel::precise(level)))
-        }
+        Ok(CompressLevelArg::Level(level)) => Ok(CompressionSetting::level(level)),
         Err(error) => Err(error.into_argument_message()),
     }
 }

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -455,7 +455,7 @@ where
             CompressLevelArg::Level(level) => {
                 if !no_compress {
                     compress = true;
-                    compression_level_override = Some(CompressionLevel::precise(*level));
+                    compression_level_override = Some(*level);
                 }
             }
         }
@@ -488,9 +488,7 @@ where
 
     let compression_setting = match compress_level_setting {
         Some(CompressLevelArg::Disable) => CompressionSetting::disabled(),
-        Some(CompressLevelArg::Level(level)) => {
-            CompressionSetting::level(CompressionLevel::precise(level))
-        }
+        Some(CompressLevelArg::Level(level)) => CompressionSetting::level(level),
         None => CompressionSetting::default(),
     };
 

--- a/crates/cli/src/frontend/tests/compress_level_upstream.rs
+++ b/crates/cli/src/frontend/tests/compress_level_upstream.rs
@@ -399,6 +399,38 @@ fn parse_compress_level_argument_clamps_to_zstd_range() {
     expect("15", 15);
 }
 
+#[cfg(feature = "zstd")]
+#[test]
+fn parse_compress_level_argument_threads_negative_zstd_to_encoder() {
+    use compress::algorithm::{CompressionAlgorithm, zstd_min_level};
+
+    // WHY: --compress-level=-5 must survive the whole CLI pipeline
+    // (parse -> CompressionSetting -> CompressionLevel) and map to the raw
+    // signed level the zstd encoder feeds to ZSTD_c_compressionLevel. The
+    // historical unsigned NonZeroU8 clamp collapsed every negative to 1 here,
+    // long before the resolver saw it. upstream: token.c:73,748.
+    let resolved = |raw: &str| {
+        let setting = parse_compress_level_argument(OsStr::new(raw), CompressionAlgorithm::Zstd)
+            .unwrap_or_else(|_| panic!("zstd level {raw} should clamp, not error"));
+        compress::zstd::level_to_i32(setting.level_or_default())
+    };
+
+    assert_eq!(resolved("-5"), -5, "-5 reaches the encoder unchanged");
+    let min = zstd_min_level();
+    assert_eq!(
+        resolved(&min.to_string()),
+        min,
+        "the exact ZSTD_minCLevel() boundary is preserved end to end"
+    );
+    assert_eq!(
+        resolved(&(min - 1).to_string()),
+        min,
+        "below ZSTD_minCLevel() saturates UP to the min, never rejected"
+    );
+    // No regression: level 0 still selects the zstd default (3), never negative.
+    assert_eq!(resolved("0"), 3, "level 0 = zstd default, unchanged");
+}
+
 #[test]
 fn parse_compress_level_argument_rejects_empty() {
     use compress::algorithm::CompressionAlgorithm;

--- a/crates/compress/src/algorithm.rs
+++ b/crates/compress/src/algorithm.rs
@@ -8,6 +8,8 @@ use std::num::NonZeroU8;
 
 use thiserror::Error;
 
+use crate::zlib::CompressionLevel;
+
 /// Default zlib compression level matching upstream rsync.
 /// upstream: token.c - `Z_DEFAULT_COMPRESSION` resolves to 6.
 pub const ZLIB_DEFAULT_LEVEL: i32 = 6;
@@ -140,17 +142,24 @@ impl CompressionAlgorithm {
     /// the codec's `min_level`/`max_level` ("We don't bother with any errors or
     /// warnings -- just make sure that the values are valid."). Returns `None`
     /// when the level disables compression (zlib `off_level` of `0`); `Some`
-    /// with the clamped level otherwise.
+    /// with the clamped level otherwise. For zstd the returned level may be a
+    /// negative [`CompressionLevel::PreciseSigned`], since zstd's range extends
+    /// below zero down to `ZSTD_minCLevel()`.
     #[must_use]
-    pub fn clamp_level(self, level: i32) -> Option<NonZeroU8> {
+    pub fn clamp_level(self, level: i32) -> Option<CompressionLevel> {
         match self {
-            CompressionAlgorithm::Zlib => clamp_zlib_level(level),
+            CompressionAlgorithm::Zlib => clamp_zlib_level(level).map(CompressionLevel::Precise),
             #[cfg(feature = "lz4")]
             // upstream: token.c:81-87 - lz4 forces min/max/def to 0 and never
             // disables; oc represents this as the fastest expressible level.
-            CompressionAlgorithm::Lz4 => Some(clamped(1)),
+            CompressionAlgorithm::Lz4 => Some(CompressionLevel::Precise(clamped(1))),
+            // upstream: token.c:72-79,101-104 - reuse the shared resolver so the
+            // encoder and the debug-print paths clamp identically. A negative
+            // result is preserved as PreciseSigned instead of being raised to 1.
             #[cfg(feature = "zstd")]
-            CompressionAlgorithm::Zstd => Some(clamp_zstd_level(level)),
+            CompressionAlgorithm::Zstd => Some(CompressionLevel::from_signed(
+                self.resolve_debug_level(level),
+            )),
         }
     }
 
@@ -217,19 +226,6 @@ fn clamp_zlib_level(level: i32) -> Option<NonZeroU8> {
     Some(clamped(level.clamp(1, 9) as u8))
 }
 
-/// Clamps into the zstd range, mirroring `token.c:72-79`.
-///
-/// `0` selects `ZSTD_CLEVEL_DEFAULT` (3); zstd's `off_level` is
-/// `CLVL_NOT_SPECIFIED`, so `0` never disables. The representable range is
-/// `1..=ZSTD_MAX_LEVEL`.
-#[cfg(feature = "zstd")]
-fn clamp_zstd_level(level: i32) -> NonZeroU8 {
-    if level == 0 {
-        return clamped(ZSTD_DEFAULT_LEVEL as u8);
-    }
-    clamped(level.clamp(1, ZSTD_MAX_LEVEL) as u8)
-}
-
 impl Default for CompressionAlgorithm {
     fn default() -> Self {
         Self::default_algorithm()
@@ -267,8 +263,15 @@ mod tests {
         assert_eq!(available, &[CompressionAlgorithm::Zlib]);
     }
 
-    fn level(algorithm: CompressionAlgorithm, raw: i32) -> Option<u8> {
-        algorithm.clamp_level(raw).map(NonZeroU8::get)
+    fn level(algorithm: CompressionAlgorithm, raw: i32) -> Option<i32> {
+        algorithm.clamp_level(raw).map(|resolved| match resolved {
+            CompressionLevel::None => 0,
+            CompressionLevel::Fast => ZSTD_FAST_LEVEL,
+            CompressionLevel::Default => ZSTD_DEFAULT_LEVEL,
+            CompressionLevel::Best => ZSTD_BEST_LEVEL,
+            CompressionLevel::Precise(value) => i32::from(value.get()),
+            CompressionLevel::PreciseSigned(value) => value,
+        })
     }
 
     #[test]
@@ -300,7 +303,32 @@ mod tests {
         assert_eq!(level(CompressionAlgorithm::Zstd, 15), Some(15), "in range");
         assert_eq!(level(CompressionAlgorithm::Zstd, 22), Some(22), "max");
         assert_eq!(level(CompressionAlgorithm::Zstd, 99), Some(22), "above max");
-        assert_eq!(level(CompressionAlgorithm::Zstd, -5), Some(1), "below min");
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn zstd_clamp_preserves_negative_levels_to_the_encoder() {
+        // WHY: the encoder path (clamp_level) - not just the debug-print path -
+        // must carry a negative zstd "fast" level all the way to
+        // ZSTD_c_compressionLevel. Guards against the historical unsigned
+        // NonZeroU8 clamp that rewrote every negative to 1. upstream:
+        // token.c:73,101-102 - the lower bound is ZSTD_minCLevel(), not 1.
+        assert_eq!(
+            level(CompressionAlgorithm::Zstd, -5),
+            Some(-5),
+            "-5 survives clamp_level as a signed encoder level"
+        );
+        let min = zstd_min_level();
+        assert_eq!(
+            level(CompressionAlgorithm::Zstd, min),
+            Some(min),
+            "the exact ZSTD_minCLevel() boundary is preserved"
+        );
+        assert_eq!(
+            level(CompressionAlgorithm::Zstd, min - 1),
+            Some(min),
+            "below ZSTD_minCLevel() saturates UP to the min, never rejected"
+        );
     }
 
     #[test]

--- a/crates/compress/src/lz4/frame.rs
+++ b/crates/compress/src/lz4/frame.rs
@@ -206,6 +206,8 @@ fn frame_info_for_level(level: CompressionLevel) -> FrameInfo {
             7..=8 => BlockSize::Max1MB,
             _ => BlockSize::Max4MB,
         },
+        // lz4 never receives a signed (zstd-only) level; treat the fastest.
+        CompressionLevel::PreciseSigned(_) => BlockSize::Max64KB,
     };
 
     FrameInfo::new()

--- a/crates/compress/src/zlib/level.rs
+++ b/crates/compress/src/zlib/level.rs
@@ -20,6 +20,14 @@ pub enum CompressionLevel {
     Best,
     /// Use an explicit zlib compression level in the range `1..=9`.
     Precise(NonZeroU8),
+    /// Use an explicit signed codec level that a [`NonZeroU8`] cannot express.
+    ///
+    /// This exists for zstd, whose valid `--compress-level` range extends below
+    /// zero down to `ZSTD_minCLevel()`. Upstream passes those negative "fast"
+    /// levels straight to `ZSTD_c_compressionLevel` (token.c:73,748), so they
+    /// must survive end to end rather than being collapsed into the unsigned
+    /// [`Precise`](Self::Precise) range. Never produced for zlib.
+    PreciseSigned(i32),
 }
 
 impl CompressionLevel {
@@ -51,6 +59,21 @@ impl CompressionLevel {
     pub const fn precise(level: NonZeroU8) -> Self {
         Self::Precise(level)
     }
+
+    /// Builds a level from an already-range-checked signed codec level.
+    ///
+    /// Used by the zstd clamp path, whose valid range includes negative "fast"
+    /// levels down to `ZSTD_minCLevel()`. A positive level (`1..=255`) becomes
+    /// [`Precise`](Self::Precise); any value a [`NonZeroU8`] cannot hold (i.e. a
+    /// negative one) becomes [`PreciseSigned`](Self::PreciseSigned), preserving
+    /// the sign so it reaches `ZSTD_c_compressionLevel` unchanged.
+    #[must_use]
+    pub fn from_signed(level: i32) -> Self {
+        match u8::try_from(level).ok().and_then(NonZeroU8::new) {
+            Some(value) => Self::Precise(value),
+            None => Self::PreciseSigned(level),
+        }
+    }
 }
 
 impl From<CompressionLevel> for Compression {
@@ -61,6 +84,9 @@ impl From<CompressionLevel> for Compression {
             CompressionLevel::Default => Compression::default(),
             CompressionLevel::Best => Compression::best(),
             CompressionLevel::Precise(value) => Compression::new(u32::from(value.get())),
+            // zlib never yields a signed level; clamp defensively into zlib's
+            // valid 0..=9 range so this arm can never panic in flate2.
+            CompressionLevel::PreciseSigned(value) => Compression::new(value.clamp(0, 9) as u32),
         }
     }
 }

--- a/crates/compress/src/zstd.rs
+++ b/crates/compress/src/zstd.rs
@@ -300,6 +300,9 @@ pub fn level_to_i32(level: CompressionLevel) -> i32 {
         CompressionLevel::Default => ZSTD_DEFAULT_LEVEL,
         CompressionLevel::Best => ZSTD_BEST_LEVEL,
         CompressionLevel::Precise(value) => i32::from(value.get()),
+        // upstream: token.c:73,748 - negative "fast" levels pass straight to
+        // ZSTD_c_compressionLevel; forward the signed value unchanged.
+        CompressionLevel::PreciseSigned(value) => value,
     }
 }
 
@@ -347,16 +350,23 @@ mod tests {
     fn encoder_accepts_negative_zstd_levels() {
         // WHY: upstream passes do_compression_level (which can be a negative
         // "fast" level for zstd) straight to ZSTD_c_compressionLevel
-        // (token.c:748). The level the shared clamp resolves for a negative
-        // --compress-level is therefore a real, usable encoder input - proving
-        // it must NOT be raised to 1. This exercises the resolved level end to
-        // end through a live zstd encoder/decoder round trip.
+        // (token.c:748). This drives the level through the real encoder pipeline
+        // - clamp_level -> CompressionLevel -> level_to_i32 - proving the signed
+        // value survives representation AND is a usable encoder input, never
+        // raised to 1. A live encode/decode round trip confirms it.
         use crate::algorithm::{CompressionAlgorithm, zstd_min_level};
 
         let payload = b"the quick brown fox jumps over the lazy dog\n".repeat(64);
         for raw in [-5, zstd_min_level()] {
-            let level = CompressionAlgorithm::Zstd.resolve_debug_level(raw);
-            assert!(level < 0, "resolver preserves the negative level {raw}");
+            let resolved = CompressionAlgorithm::Zstd
+                .clamp_level(raw)
+                .expect("zstd never disables compression");
+            assert!(
+                matches!(resolved, CompressionLevel::PreciseSigned(_)),
+                "negative level {raw} is carried as a signed CompressionLevel"
+            );
+            let level = level_to_i32(resolved);
+            assert_eq!(level, raw, "clamp_level preserves the signed level {raw}");
 
             let mut encoder =
                 ZstdEncoder::new(Vec::new(), level).expect("encoder accepts negative level");

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -842,15 +842,19 @@ fn escape_with(prefix: &str, value: &str, escapes: &str, is_filename_arg: bool) 
     out
 }
 
-/// Converts a [`compress::zlib::CompressionLevel`] to its numeric zlib value.
-fn compression_level_numeric(level: compress::zlib::CompressionLevel) -> u32 {
+/// Converts a [`compress::zlib::CompressionLevel`] to its signed wire value.
+///
+/// upstream: options.c:2755-2756 - `--compress-level=%d` forwards the signed
+/// `do_compression_level`, so a negative zstd "fast" level is preserved.
+fn compression_level_numeric(level: compress::zlib::CompressionLevel) -> i32 {
     use compress::zlib::CompressionLevel;
     match level {
         CompressionLevel::None => 0,
         CompressionLevel::Fast => 1,
         CompressionLevel::Default => 6,
         CompressionLevel::Best => 9,
-        CompressionLevel::Precise(n) => u32::from(n.get()),
+        CompressionLevel::Precise(n) => i32::from(n.get()),
+        CompressionLevel::PreciseSigned(v) => v,
     }
 }
 

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -1006,15 +1006,18 @@ pub(super) fn shell_safe_filename_arg_with_tilde(arg: &str, escape_leading_tilde
 
 /// Converts a `CompressionLevel` into its numeric representation for the wire.
 ///
-/// Upstream rsync sends the compression level as an integer in the range 0-9.
-pub(super) fn compression_level_to_numeric(level: compress::zlib::CompressionLevel) -> u32 {
+/// upstream: options.c:2755-2756 - `--compress-level=%d` forwards the signed
+/// `do_compression_level`, so a negative zstd "fast" level reaches the server
+/// verbatim rather than being collapsed into an unsigned range.
+pub(super) fn compression_level_to_numeric(level: compress::zlib::CompressionLevel) -> i32 {
     use compress::zlib::CompressionLevel;
     match level {
         CompressionLevel::None => 0,
         CompressionLevel::Fast => 1,
         CompressionLevel::Default => 6,
         CompressionLevel::Best => 9,
-        CompressionLevel::Precise(n) => u32::from(n.get()),
+        CompressionLevel::Precise(n) => i32::from(n.get()),
+        CompressionLevel::PreciseSigned(v) => v,
     }
 }
 

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -573,6 +573,8 @@ fn compression_level_to_nstr(level: compress::zlib::CompressionLevel) -> i32 {
         CompressionLevel::Default => 6,
         CompressionLevel::Best => 9,
         CompressionLevel::Precise(n) => i32::from(n.get()),
+        // upstream: token.c:73 - preserve zstd's negative "fast" levels.
+        CompressionLevel::PreciseSigned(v) => v,
     }
 }
 

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -87,6 +87,8 @@ impl<'a> CopyContext<'a> {
                 CompressionLevel::Default => 6,
                 CompressionLevel::Best => 9,
                 CompressionLevel::Precise(v) => i32::from(v.get()),
+                // upstream: token.c:73 - preserve zstd's negative "fast" levels.
+                CompressionLevel::PreciseSigned(v) => v,
             };
             match options.compression_algorithm() {
                 CompressionAlgorithm::Zlib => Some(

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -59,6 +59,9 @@ impl ZlibTokenEncoder {
             CompressionLevel::Default => Compression::default(),
             CompressionLevel::Best => Compression::best(),
             CompressionLevel::Precise(n) => Compression::new(u32::from(n.get())),
+            // zlib tokens never carry a signed (zstd-only) level; clamp
+            // defensively into zlib's 0..=9 range so flate2 cannot panic.
+            CompressionLevel::PreciseSigned(v) => Compression::new(v.clamp(0, 9) as u32),
         };
         Self {
             literal_buf: Vec::new(),

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -263,6 +263,8 @@ fn compression_level_to_i32(level: compress::zlib::CompressionLevel) -> i32 {
         CompressionLevel::Default => 6,
         CompressionLevel::Best => 9,
         CompressionLevel::Precise(n) => i32::from(n.get()),
+        // upstream: token.c:73 - preserve zstd's negative "fast" levels.
+        CompressionLevel::PreciseSigned(v) => v,
     }
 }
 


### PR DESCRIPTION
## Summary

Threads a signed compression-level representation from CLI parse through
`CoreConfig` to the encoder so a negative zstd `--compress-level` survives
end to end and reaches `ZSTD_c_compressionLevel` unchanged.

This completes the negative-zstd-level work started in #6648 (#51). That PR
fixed the resolver clamp (`resolve_debug_level`) to accept negatives and added
the `zstd_min_level()` accessor, but the value was still destroyed earlier, at
the first CLI clamp: the whole pipeline (`clamp_zstd_level` -> `NonZeroU8` ->
`CompressLevelArg::Level(NonZeroU8)` -> `CompressionLevel::Precise(NonZeroU8)`)
was unsigned, so `--compress-level=-5` was collapsed to `1` at parse time and
never reached the encoder.

## Upstream reference

`token.c:73-102` `init_compression_level()`: for zstd,
`min_level = ZSTD_minCLevel()` (a large negative), `max_level = ZSTD_maxCLevel()`
(22), `def_level = ZSTD_CLEVEL_DEFAULT` (3), and `0` selects the default rather
than disabling. A value below `min_level` saturates UP to `min_level`; upstream
"doesn't bother with any errors or warnings". zlib remains `[0..9]` with no
negatives. `--compress-level` is parsed as a plain signed int
(`options.c:767` `POPT_ARG_INT`), and forwarded to the server verbatim with
`%d` (`options.c:2755-2756`), so negative levels are wire-legal.

## Change

A new `CompressionLevel::PreciseSigned(i32)` variant carries the signed zstd
level that a `NonZeroU8` cannot express. It is produced only on the zstd clamp
path (via the shared `resolve_debug_level` resolver, so the encoder and
debug-print paths now clamp identically) and threaded through unchanged.

Layers converted from unsigned/`NonZeroU8` to the signed representation:

- `CompressionAlgorithm::clamp_level` now returns `Option<CompressionLevel>`
  (was `Option<NonZeroU8>`); the zstd branch defers to `resolve_debug_level` and
  preserves a negative result. `clamp_zstd_level` (the old `1..=22` clamp) is
  removed.
- `CompressLevelArg::Level(NonZeroU8)` -> `Level(CompressionLevel)` (cli).
- `compression_level_to_numeric` / `compression_level_numeric` (ssh + daemon
  server-arg builders) now return `i32`, forwarding `--compress-level=-5`
  verbatim to match upstream's `%d`.
- The zstd encoder mapper (`zstd::level_to_i32`) and the NSTR/adaptive i32
  mappers in `core`, `transfer`, and `engine` pass the signed value through.
- The zlib `Compression` mappers (`zlib::level.rs`, `protocol` zlib token codec)
  and the lz4 block-size selector gain defensive arms; a signed level never
  reaches those codecs in practice.

zlib is unaffected (`[0..9]`, level 0 = disabled), and zstd level 0 still
resolves to the default (3).

## Wire compatibility

No wire-byte change versus upstream. For an in-range level (e.g. `-5`) the
forwarded server arg is `--compress-level=-5`, exactly what upstream sends via
`options.c:2756`; the token framing and compression negotiation are untouched.

## Tests

- `parse_compress_level_argument_threads_negative_zstd_to_encoder` (cli):
  `--compress-level=-5` survives parse and maps to `-5` through
  `level_to_i32`; the exact `ZSTD_minCLevel()` boundary is preserved;
  below-min saturates up to the min; level 0 still resolves to 3.
- `encoder_accepts_negative_zstd_levels` (compress): drives the level through
  `clamp_level -> CompressionLevel::PreciseSigned -> level_to_i32` and confirms
  a live zstd encode/decode round trip at `-5` and at `ZSTD_minCLevel()`.
- `zstd_clamp_preserves_negative_levels_to_the_encoder` (compress): `clamp_level`
  preserves `-5` and the min boundary, and saturates below-min up to the min.
- Existing zlib clamp and positive/zero zstd tests unchanged, guarding against
  regression.
