### PR TITLE
fix(transfer): render "=> leader" suffix for hardlink-follower itemize lines

### DIFF
--- a/crates/transfer/src/generator/itemize.rs
+++ b/crates/transfer/src/generator/itemize.rs
@@ -206,8 +206,14 @@ pub(crate) fn format_iflags(
 
 /// Formats a complete itemize output line for MSG_INFO emission.
 ///
-/// Produces `"{iflags_str} {filename}\n"` matching upstream's default
+/// Produces `"{iflags_str} {filename}{L-suffix}\n"` matching upstream's default
 /// `stdout_format = "%i %n%L"` when `--itemize-changes` is active.
+///
+/// `xname` is the alternate-basis name read off the wire when the item carries
+/// `ITEM_XNAME_FOLLOWS` (the hard-link leader from `hlink.c:232-234`), or `None`
+/// otherwise. When present and non-empty it renders the `%L` ` => <xname>`
+/// suffix; upstream's `%L` gates purely on `hlink && *hlink` and takes priority
+/// over the symlink ` -> target` form (`log.c:643-655`).
 ///
 /// Uses a single `String` buffer to avoid intermediate allocations from
 /// `format_iflags`, path display, and symlink target formatting.
@@ -216,12 +222,16 @@ pub(crate) fn format_iflags(
 ///
 /// - `options.c:2336-2338` - `stdout_format = "%i %n%L"` for `-i`
 /// - `log.c:627-636` - `%n` expansion (filename with trailing `/` for dirs)
-/// - `log.c:637-653` - `%L` expansion (` -> target` for symlinks)
+/// - `log.c:643-655` - `%L` expansion: ` => hlink` when the xname is non-empty,
+///   else ` -> target` for symlinks
+/// - `hlink.c:232-234` - hard-link follower emits `ITEM_XNAME_FOLLOWS` with the
+///   leader name as the xname
 pub(crate) fn format_itemize_line(
     iflags: &ItemFlags,
     entry: &FileEntry,
     is_sender: bool,
     ctx: &ItemizeContext,
+    xname: Option<&[u8]>,
 ) -> String {
     use std::fmt::Write;
 
@@ -239,8 +249,16 @@ pub(crate) fn format_itemize_line(
         buf.push('/');
     }
 
-    // upstream: log.c:637-653 - append " -> target" for symlinks
-    if entry.is_symlink() {
+    // upstream: log.c:643-655 - %L expansion. The ` => <xname>` form wins
+    // whenever the item carries a non-empty alternate-basis name (the hard-link
+    // leader), mirroring the `if (hlink && *hlink)` branch that precedes the
+    // symlink case. Only when no xname trails does `%L` fall through to the
+    // symlink ` -> target` form.
+    let hlink =
+        xname.filter(|name| iflags.raw() & ItemFlags::ITEM_XNAME_FOLLOWS != 0 && !name.is_empty());
+    if let Some(name) = hlink {
+        let _ = write!(buf, " => {}", String::from_utf8_lossy(name));
+    } else if entry.is_symlink() {
         if let Some(target) = entry.link_target() {
             let _ = write!(buf, " -> {}", target.display());
         }
@@ -540,7 +558,7 @@ mod tests {
     fn format_itemize_line_file() {
         let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
         let entry = make_file_entry("docs/readme.txt");
-        let line = format_itemize_line(&iflags, &entry, true, &default_ctx());
+        let line = format_itemize_line(&iflags, &entry, true, &default_ctx(), None);
         assert_eq!(line, "<f+++++++++ docs/readme.txt\n");
     }
 
@@ -548,7 +566,7 @@ mod tests {
     fn format_itemize_line_directory() {
         let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
         let entry = make_dir_entry("subdir");
-        let line = format_itemize_line(&iflags, &entry, true, &default_ctx());
+        let line = format_itemize_line(&iflags, &entry, true, &default_ctx(), None);
         assert_eq!(line, "cd+++++++++ subdir/\n");
     }
 
@@ -569,8 +587,38 @@ mod tests {
     fn format_itemize_line_symlink() {
         let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
         let entry = make_symlink_entry("mylink");
-        let line = format_itemize_line(&iflags, &entry, true, &default_ctx());
+        let line = format_itemize_line(&iflags, &entry, true, &default_ctx(), None);
         assert_eq!(line, "cL+++++++++ mylink -> target\n");
+    }
+
+    /// A hard-link follower carries `ITEM_XNAME_FOLLOWS` with the leader name as
+    /// the wire xname (upstream `hlink.c:232-234`). The push sender renderer must
+    /// append the `%L` ` => <leader>` suffix so oc's own client renders
+    /// `hf+++++++++ follower => leader`, not a bare `hf+++++++++ follower`.
+    ///
+    /// upstream: log.c:643-646 - `%L` renders ` => hlink` for a non-empty xname.
+    #[test]
+    fn format_itemize_line_hardlink_follower_appends_leader() {
+        let iflags = ItemFlags::from_raw(
+            ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_XNAME_FOLLOWS | ItemFlags::ITEM_IS_NEW,
+        );
+        let entry = make_file_entry("follower");
+        let line = format_itemize_line(&iflags, &entry, true, &default_ctx(), Some(b"leader"));
+        assert_eq!(line, "hf+++++++++ follower => leader\n");
+    }
+
+    /// The `%L` ` => ` suffix must not appear when the xname is empty - upstream's
+    /// alt-dest hard-link/copy-dest paths (e.g. `hlink.c:219-221`,
+    /// `generator.c:1011-1013`) set `ITEM_XNAME_FOLLOWS` with an empty string, and
+    /// `%L` gates on `hlink && *hlink` (log.c:644).
+    #[test]
+    fn format_itemize_line_empty_xname_renders_no_suffix() {
+        let iflags = ItemFlags::from_raw(
+            ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_XNAME_FOLLOWS | ItemFlags::ITEM_IS_NEW,
+        );
+        let entry = make_file_entry("follower");
+        let line = format_itemize_line(&iflags, &entry, true, &default_ctx(), Some(b""));
+        assert_eq!(line, "hf+++++++++ follower\n");
     }
 
     /// upstream: log.c:716-717 - non-symlink with preserve_mtimes shows lowercase 't'

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -430,6 +430,7 @@ impl GeneratorContext {
         writer: &mut super::super::writer::ServerWriter<W>,
         iflags: &super::item_flags::ItemFlags,
         ndx: usize,
+        xname: Option<&[u8]>,
         itemize_cb: &mut Option<&mut dyn super::super::ItemizeCallback>,
     ) -> io::Result<()> {
         if !self.config.flags.info_flags.itemize {
@@ -456,8 +457,11 @@ impl GeneratorContext {
 
         let entry = &self.file_list[ndx];
         let ctx = self.itemize_context();
-        // Generator role is always the sender side
-        let line = super::itemize::format_itemize_line(iflags, entry, true, &ctx);
+        // Generator role is always the sender side. The wire xname carries the
+        // hard-link leader for an ITEM_XNAME_FOLLOWS follower so `%L` can append
+        // the ` => leader` suffix (upstream sender.c:293 maybe_log_item passes
+        // the xname buffer as the hlink arg to log_item -> log.c:643-646).
+        let line = super::itemize::format_itemize_line(iflags, entry, true, &ctx, xname);
 
         if self.config.connection.client_mode {
             // upstream: log.c:822-823 - when !am_server, rwrite() sends FCLIENT

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -460,15 +460,15 @@ fn inc_recurse_gap_ndx_itemizes_parent_directory() {
     let sub = &ctx.file_list[ctx.resolve_itemize_ndx(3)];
     let child = &ctx.file_list[ctx.resolve_itemize_ndx(4)];
     assert_eq!(
-        itemize::format_itemize_line(&unchanged, root, true, &itemize_ctx),
+        itemize::format_itemize_line(&unchanged, root, true, &itemize_ctx, None),
         ".d          ./\n"
     );
     assert_eq!(
-        itemize::format_itemize_line(&new_local, sub, true, &itemize_ctx),
+        itemize::format_itemize_line(&new_local, sub, true, &itemize_ctx, None),
         "cd+++++++++ sub/\n"
     );
     assert_eq!(
-        itemize::format_itemize_line(&new_xfer, child, true, &itemize_ctx),
+        itemize::format_itemize_line(&new_xfer, child, true, &itemize_ctx, None),
         "<f+++++++++ sub/child.txt\n"
     );
 
@@ -478,15 +478,15 @@ fn inc_recurse_gap_ndx_itemizes_parent_directory() {
     let dir_mtime = ItemFlags::from_raw(ItemFlags::ITEM_REPORT_TIME);
     let file_mtime = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_REPORT_TIME);
     assert_eq!(
-        itemize::format_itemize_line(&dir_mtime, root, true, &itemize_ctx),
+        itemize::format_itemize_line(&dir_mtime, root, true, &itemize_ctx, None),
         ".d..t...... ./\n"
     );
     assert_eq!(
-        itemize::format_itemize_line(&dir_mtime, sub, true, &itemize_ctx),
+        itemize::format_itemize_line(&dir_mtime, sub, true, &itemize_ctx, None),
         ".d..t...... sub/\n"
     );
     assert_eq!(
-        itemize::format_itemize_line(&file_mtime, child, true, &itemize_ctx),
+        itemize::format_itemize_line(&file_mtime, child, true, &itemize_ctx, None),
         "<f..t...... sub/child.txt\n"
     );
 }
@@ -5037,7 +5037,7 @@ mod itemize_emit_gate {
 
         let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
         let iflags = ItemFlags::from_raw(iflags_raw);
-        ctx.maybe_emit_itemize(&mut writer, &iflags, 0, &mut callback)
+        ctx.maybe_emit_itemize(&mut writer, &iflags, 0, None, &mut callback)
             .expect("maybe_emit_itemize must not error in client mode");
 
         // Reset the verbosity config so siblings see a clean default.
@@ -5082,6 +5082,55 @@ mod itemize_emit_gate {
             lines.len(),
             1,
             "ITEM_XNAME_FOLLOWS must force an itemize line under upstream gate; got: {lines:?}"
+        );
+    }
+
+    /// A `--hard-links -i` push where oc is BOTH the sender renderer and the
+    /// receiver: the remote generator forwards `ITEM_XNAME_FOLLOWS` plus the
+    /// leader vstring (upstream `hlink.c:232-234`), and the client-side sender
+    /// owns the visible itemize (`sender.c:293 maybe_log_item`). The follower row
+    /// must render `hf+++++++++ follower => leader`, not a bare
+    /// `hf+++++++++ follower`, matching upstream `%L` (`log.c:643-646`).
+    #[test]
+    fn hardlink_follower_renders_leader_suffix_through_emit_path() {
+        init({
+            let mut cfg = VerbosityConfig::default();
+            cfg.info.name = 0;
+            cfg
+        });
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.connection.client_mode = true;
+        config.flags.info_flags.itemize = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+        ctx.file_list.push(protocol::flist::FileEntry::new_file(
+            "follower".into(),
+            0,
+            0o644,
+        ));
+
+        let captured: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let lines = Rc::clone(&captured);
+        let mut sink = move |line: &str| {
+            lines.borrow_mut().push(line.to_owned());
+        };
+        let mut callback: Option<&mut dyn crate::ItemizeCallback> = Some(&mut sink);
+
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+        let iflags = ItemFlags::from_raw(
+            ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_XNAME_FOLLOWS | ItemFlags::ITEM_IS_NEW,
+        );
+        ctx.maybe_emit_itemize(&mut writer, &iflags, 0, Some(b"leader"), &mut callback)
+            .expect("maybe_emit_itemize must not error in client mode");
+
+        init(VerbosityConfig::default());
+
+        let rows = captured.borrow();
+        assert_eq!(rows.len(), 1, "expected one follower row; got: {rows:?}");
+        assert_eq!(
+            rows[0], "hf+++++++++ follower => leader\n",
+            "hard-link follower must carry the `%L` ` => leader` suffix",
         );
     }
 }

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -405,7 +405,7 @@ impl GeneratorContext {
                 // so the receiver can pair the response with its outstanding
                 // request and apply xattr-only updates. Without this echo the
                 // wire stream stalls when ITEM_REPORT_XATTR is the only delta.
-                self.maybe_emit_itemize(writer, &iflags, ndx, itemize)?;
+                self.maybe_emit_itemize(writer, &iflags, ndx, xname.as_deref(), itemize)?;
                 self.write_ndx_iflags_and_xattr_response(
                     &mut *writer,
                     &mut ndx_write_codec,
@@ -812,8 +812,8 @@ impl GeneratorContext {
             // rprintf(FINFO, "sender finished %s%s%s\n", path,slash,fname)
             debug_log!(Send, 1, "sender finished {}", file_entry.path().display());
 
-            // upstream: sender.c:430 - log_item(log_code, file, iflags, NULL)
-            self.maybe_emit_itemize(writer, &iflags, ndx, itemize)?;
+            // upstream: sender.c:430 - log_item(log_code, file, iflags, xname)
+            self.maybe_emit_itemize(writer, &iflags, ndx, xname.as_deref(), itemize)?;
 
             if let Some(cb) = progress.as_mut() {
                 // upstream: progress.c:80 - "to" once the final sub-list has been

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -149,11 +149,16 @@ impl ReceiverContext {
         // end of a push (the client is the sender), so it renders `<`; a
         // client-mode receiver is a local pull and renders `>`.
         let is_sender = !self.config.connection.client_mode;
+        // The receiver-side generator computes iflags locally rather than reading
+        // them off the wire, so no alternate-basis xname is available here; the
+        // hard-link ` => leader` suffix is owned by the push sender renderer
+        // (generator/transfer/transfer_loop.rs::maybe_emit_itemize).
         Some(crate::generator::itemize::format_itemize_line(
             &effective_iflags,
             entry,
             is_sender,
             &ctx,
+            None,
         ))
     }
 


### PR DESCRIPTION
## Summary

The pushing-sender's itemize renderer dropped the ` => leader` suffix on
hard-link follower rows. Against oc's own client a follower rendered as
`hf+++++++++ follower` instead of the upstream `hf+++++++++ follower => leader`.

Upstream's default itemize format is `%i %n%L` (`options.c:2336-2338`). The `%L`
expansion in `log.c:643-655` renders ` => <hlink>` whenever the item carries a
non-empty alternate-basis name and takes priority over the symlink ` -> target`
form:

```c
case 'L':
        if (hlink && *hlink) {
                n = hlink;
                strlcpy(buf2, " => ", sizeof buf2);
        } else if (S_ISLNK(file->mode) && !fname) {
                n = F_SYMLINK(file);
                strlcpy(buf2, " -> ", sizeof buf2);
        }
```

A hard-link follower is emitted by `hlink.c:232-234` with
`ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS` and the leader name (`realname`) as the
xname vstring. On the sender-render path that name is read off the wire by
`rsync.c:407-418 read_ndx_and_attrs` and passed through as the `hlink` argument
to `log_item` via `sender.c:293 maybe_log_item`.

The xname was already on the wire (read by the generator transfer loop), but the
renderer never appended it. This restores the `%L` suffix.

## Change

- `format_itemize_line` now takes the wire `xname` and, mirroring `%L`, appends
  ` => <xname>` when the item carries `ITEM_XNAME_FOLLOWS` with a non-empty name,
  ahead of the symlink ` -> target` fallback.
- `maybe_emit_itemize` threads the xname read from the wire (the same buffer the
  ndx/iflags echo already forwards) into the renderer.
- Render-only. No wire bytes change. The empty-xname alt-dest hard-link and
  copy-dest cases (`hlink.c:219-221`, `generator.c:1011-1013`) still render no
  suffix, matching `%L`'s `hlink && *hlink` gate.

## Tests

- `format_itemize_line_hardlink_follower_appends_leader` - a follower with the
  leader xname renders `hf+++++++++ follower => leader`.
- `format_itemize_line_empty_xname_renders_no_suffix` - an empty xname renders no
  suffix (the alt-dest/copy-dest cases).
- `hardlink_follower_renders_leader_suffix_through_emit_path` - drives the full
  `maybe_emit_itemize` sender-render path with oc as both sender renderer and
  receiver and asserts the `=> leader` suffix reaches the client sink.
