### PR TITLE
fix(core): match upstream server_options arg forwarding on SSH path

### DIFF
--- a/crates/core/src/client/config/bandwidth.rs
+++ b/crates/core/src/client/config/bandwidth.rs
@@ -165,6 +165,21 @@ impl BandwidthLimit {
     pub fn fallback_unlimited_argument() -> OsString {
         OsString::from("0")
     }
+
+    /// Returns the whole-KiB value that `server_options()` forwards as
+    /// `--bwlimit=N` to a remote peer.
+    ///
+    /// upstream: options.c:1718 - `bwlimit = (size + 512) / 1024` converts the
+    /// parsed byte-per-second rate into whole KiB, and options.c:2799 forwards
+    /// that integer as `--bwlimit=%d`. The remote side re-parses the value with
+    /// a default `K` suffix (options.c:1714 `parse_size_arg(bwlimit_arg, 'K',
+    /// ...)`, mirrored here by `size_arg::parse_size_arg(.., b'K')`), so the
+    /// wire value MUST be KiB. Forwarding the raw byte count would be scaled up
+    /// 1024x by the peer, effectively removing the throttle.
+    #[must_use]
+    pub fn server_option_kib(&self) -> u64 {
+        (self.bytes_per_second.get() + 512) / 1024
+    }
 }
 
 impl From<BandwidthLimit> for bandwidth::BandwidthLimitComponents {

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -345,13 +345,12 @@ pub(super) fn build_full_daemon_args(
         args.push(format!("--timeout={}", secs.get()));
     }
 
-    // upstream: options.c:2799-2803 - --bwlimit=BYTES so the remote peer
-    // throttles to the same rate the client requested.
+    // upstream: options.c:2799 - `--bwlimit=%d` forwards the rate in whole KiB
+    // (options.c:1718), NOT bytes: the remote peer re-parses the value with a
+    // default `K` suffix, so a byte count would be scaled up 1024x and the
+    // throttle would effectively vanish.
     if let Some(bwlimit) = config.bandwidth_limit() {
-        args.push(format!(
-            "--bwlimit={}",
-            bwlimit.fallback_argument().to_string_lossy()
-        ));
+        args.push(format!("--bwlimit={}", bwlimit.server_option_kib()));
     }
 
     // upstream: options.c:2807-2839 - sender-specific args.
@@ -1444,17 +1443,28 @@ mod server_option_fidelity_tests {
         assert!(args(&config, false).iter().any(|a| a == "--timeout=60"));
     }
 
-    // upstream: options.c:2799-2803 - --bwlimit in bytes/sec so the remote
-    // throttles identically.
+    // WHY: upstream options.c:2799 forwards `--bwlimit=%d` in whole KiB
+    // (options.c:1718 `bwlimit = (size + 512) / 1024`), NOT bytes/sec. The
+    // remote peer re-parses the value with a default `K` suffix (options.c:1714
+    // `parse_size_arg(bwlimit_arg, 'K', ...)`), so a byte count of 1048576 would
+    // be read as 1048576 KiB and the throttle would balloon 1024x. A rate of
+    // 1 MiB/s (1048576 B/s) must therefore travel as `--bwlimit=1024`.
     #[test]
-    fn bwlimit_forwarded() {
+    fn bwlimit_forwarded_in_kib_not_bytes() {
         let limit = crate::client::config::BandwidthLimit::from_bytes_per_second(
-            std::num::NonZeroU64::new(1024).unwrap(),
+            std::num::NonZeroU64::new(1_048_576).unwrap(),
         );
         let config = ClientConfig::builder().bandwidth_limit(Some(limit)).build();
         assert!(
             args(&config, false).iter().any(|a| a == "--bwlimit=1024"),
-            "bwlimit must forward as bytes/sec: {:?}",
+            "bwlimit must forward as whole KiB: {:?}",
+            args(&config, false)
+        );
+        assert!(
+            !args(&config, false)
+                .iter()
+                .any(|a| a == "--bwlimit=1048576"),
+            "bwlimit must NOT forward the raw byte count: {:?}",
             args(&config, false)
         );
     }

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -173,7 +173,12 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--ignore-errors"));
         }
 
-        if self.config.fsync() {
+        // upstream: options.c:2930-2931 - `if (do_fsync) --fsync` lives inside
+        // the `if (am_sender)` block, so it is forwarded only on a PUSH
+        // (RemoteRole::Sender): the remote receiver fsyncs the files it writes.
+        // On a PULL the local receiver fsyncs its own writes and the remote
+        // sender, which never writes destination files, must not receive it.
+        if self.config.fsync() && self.role == RemoteRole::Sender {
             args.push(OsString::from("--fsync"));
         }
 
@@ -251,6 +256,16 @@ impl<'a> RemoteInvocationBuilder<'a> {
     /// `--key=value` tokens rather than single-character flags. The order mirrors
     /// upstream for predictable interop testing.
     fn append_long_form_args(&self, args: &mut Vec<OsString>) {
+        // upstream: options.c server_options() - `am_sender` is true when the
+        // local process is the sender (a PUSH). RemoteRole::Sender == am_sender.
+        // A large block of options (options.c:2825-2857, 2911-2943, 2990) is
+        // emitted only inside `if (am_sender)` because they steer the remote
+        // RECEIVER; forwarding them on a PULL makes the remote sender link_stat()
+        // the flag as a source path or mutate its own send behaviour (the
+        // --delete-excluded leak is the worst: it rewrites the remote sender's
+        // send_rules so excluded files vanish from the file list).
+        let am_sender = self.role == RemoteRole::Sender;
+
         // upstream: options.c:2747-2748 - `if (list_only > 1) "--list-only"`.
         // Only the EXPLICIT `--list-only` (list_only == 2) is forwarded; the
         // implicit single-source listing (list_only == 1) is not. The compact
@@ -269,40 +284,62 @@ impl<'a> RemoteInvocationBuilder<'a> {
             None => {}
         }
 
-        // upstream: options.c:2818-2829 - delete timing variants. Explicit
-        // --delete-before/during/after/delay are always sent. Bare --delete
-        // (DuringDefault) is suppressed when --delete-excluded is active,
-        // matching upstream: `else if (delete_mode && !delete_excluded)`.
-        match self.config.delete_mode() {
-            DeleteMode::Disabled => {}
-            DeleteMode::Before => args.push(OsString::from("--delete-before")),
-            DeleteMode::During => args.push(OsString::from("--delete-during")),
-            DeleteMode::DuringDefault => {
-                if !self.config.delete_excluded() {
-                    args.push(OsString::from("--delete"));
+        // upstream: options.c:2825-2857 - the delete timing/limit and size
+        // filters all sit inside the `if (am_sender)` block, so they are
+        // forwarded only on a PUSH; the remote receiver is what performs the
+        // deletion and size-based skip decisions.
+        if am_sender {
+            // upstream: options.c:2826-2831 - `if (max_delete > 0)
+            // --max-delete=N; else if (max_delete == 0) --max-delete=-1`. A
+            // ceiling of 0 MUST be remapped to -1: the remote receiver reads
+            // `--max-delete=0` as UNLIMITED (max_delete <= 0 disables the cap at
+            // options.c:2182-2184), so forwarding `--max-delete=0` with --delete
+            // would delete every extraneous file instead of none. Placed first
+            // to match upstream's emission order within the am_sender block.
+            if let Some(max) = self.config.max_delete() {
+                if max > 0 {
+                    args.push(OsString::from(format!("--max-delete={max}")));
+                } else {
+                    args.push(OsString::from("--max-delete=-1"));
                 }
             }
-            DeleteMode::After => args.push(OsString::from("--delete-after")),
-            DeleteMode::Delay => args.push(OsString::from("--delete-delay")),
-        }
 
-        if self.config.delete_excluded() {
-            args.push(OsString::from("--delete-excluded"));
-        }
+            // upstream: options.c:2832-2835 - --min-size / --max-size.
+            if let Some(min) = self.config.min_file_size() {
+                args.push(OsString::from(format!("--min-size={min}")));
+            }
+            if let Some(max) = self.config.max_file_size() {
+                args.push(OsString::from(format!("--max-size={max}")));
+            }
 
-        if self.config.force_replacements() {
-            args.push(OsString::from("--force"));
-        }
+            // upstream: options.c:2836-2845 - delete timing variants. Explicit
+            // --delete-before/during/after/delay are always sent. Bare --delete
+            // (DuringDefault) is suppressed when --delete-excluded is active,
+            // matching upstream: `else if (delete_mode && !delete_excluded)`.
+            match self.config.delete_mode() {
+                DeleteMode::Disabled => {}
+                DeleteMode::Before => args.push(OsString::from("--delete-before")),
+                DeleteMode::During => args.push(OsString::from("--delete-during")),
+                DeleteMode::DuringDefault => {
+                    if !self.config.delete_excluded() {
+                        args.push(OsString::from("--delete"));
+                    }
+                }
+                DeleteMode::After => args.push(OsString::from("--delete-after")),
+                DeleteMode::Delay => args.push(OsString::from("--delete-delay")),
+            }
 
-        if let Some(max) = self.config.max_delete() {
-            args.push(OsString::from(format!("--max-delete={max}")));
-        }
+            // upstream: options.c:2846-2847 - --delete-excluded. On a PULL this
+            // must NOT be forwarded: it rewrites the remote sender's send_rules
+            // so excluded files disappear from the file list entirely.
+            if self.config.delete_excluded() {
+                args.push(OsString::from("--delete-excluded"));
+            }
 
-        if let Some(max) = self.config.max_file_size() {
-            args.push(OsString::from(format!("--max-size={max}")));
-        }
-        if let Some(min) = self.config.min_file_size() {
-            args.push(OsString::from(format!("--min-size={min}")));
+            // upstream: options.c:2848-2849 - --force.
+            if self.config.force_replacements() {
+                args.push(OsString::from("--force"));
+            }
         }
 
         // upstream: options.c:2845-2846 - `--max-alloc=arg` is forwarded to
@@ -385,11 +422,14 @@ impl<'a> RemoteInvocationBuilder<'a> {
             }
         }
 
-        // upstream: options.c - bwlimit forwarded as bytes-per-second.
+        // upstream: options.c:2799 - `--bwlimit=%d` forwards the rate in whole
+        // KiB (options.c:1718), NOT bytes: the remote peer re-parses the value
+        // with a default `K` suffix, so a byte count would be scaled up 1024x.
         if let Some(bwlimit) = self.config.bandwidth_limit() {
-            let mut arg = OsString::from("--bwlimit=");
-            arg.push(bwlimit.fallback_argument());
-            args.push(arg);
+            args.push(OsString::from(format!(
+                "--bwlimit={}",
+                bwlimit.server_option_kib()
+            )));
         }
 
         if let Some(dir) = self.config.partial_directory() {
@@ -410,7 +450,11 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--partial"));
         }
 
-        if let Some(dir) = self.config.temp_directory() {
+        // upstream: options.c:2925-2928 - `if (tmpdir) { --temp-dir; ... }`
+        // inside the `if (am_sender)` block. Forwarded only on a PUSH so the
+        // remote receiver writes temp files under the requested directory; a
+        // remote sender never writes temp files and must not receive it.
+        if am_sender && let Some(dir) = self.config.temp_directory() {
             let mut arg = OsString::from("--temp-dir=");
             arg.push(dir.as_os_str());
             args.push(arg);
@@ -479,16 +523,25 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from(format!("--checksum-seed={seed}")));
         }
 
-        if self.config.size_only() {
+        // upstream: options.c:2854-2855 - `if (size_only) --size-only` inside
+        // the `if (am_sender)` block (a PUSH), so the remote receiver's
+        // generator applies the size-only quick-check the client requested.
+        if am_sender && self.config.size_only() {
             args.push(OsString::from("--size-only"));
         }
+        // upstream: options.c:2918-2923 - --ignore-existing and --existing
+        // (sent as --existing for ignore_non_existing) both sit inside the
+        // `if (am_sender)` block: they steer the remote receiver's generator,
+        // so they are forwarded only on a PUSH.
         // upstream: options.c:2711-2712 - --ignore-times is emitted as the
         // compact `I` letter in build_flag_string(), not as a long-form arg.
-        if self.config.ignore_existing() {
-            args.push(OsString::from("--ignore-existing"));
-        }
-        if self.config.existing_only() {
-            args.push(OsString::from("--existing"));
+        if am_sender {
+            if self.config.ignore_existing() {
+                args.push(OsString::from("--ignore-existing"));
+            }
+            if self.config.existing_only() {
+                args.push(OsString::from("--existing"));
+            }
         }
 
         // upstream: options.c:817-818 - missing_args forwarded as long-form.
@@ -613,7 +666,6 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // forwards the explicitly-set --info / --debug levels to the peer so
         // its diagnostic output matches. `am_sender` (a push) selects the
         // receiving half of the role `where` filter.
-        let am_sender = self.role == RemoteRole::Sender;
         if let Some(arg) =
             make_output_option(OutputWordKind::Info, self.config.info_flags(), am_sender)
         {
@@ -629,7 +681,11 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--open-noatime"));
         }
 
-        if self.config.preallocate() {
+        // upstream: options.c:2990-2991 - `if (preallocate_files && am_sender)
+        // --preallocate`. Forwarded only on a PUSH so the remote receiver
+        // preallocates the destination file extents; a remote sender allocates
+        // nothing and must not receive it.
+        if am_sender && self.config.preallocate() {
             args.push(OsString::from("--preallocate"));
         }
 
@@ -696,11 +752,19 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // We rely on `protect_args` being the default for SSH transports
         // (matching upstream's `old_style_args = -1` default at options.c:325),
         // so the verbatim form is correct and the wildcard `*` survives.
-        if let Some(mapping) = self.config.user_mapping() {
-            args.push(OsString::from(format!("--usermap={}", mapping.spec())));
-        }
-        if let Some(mapping) = self.config.group_mapping() {
-            args.push(OsString::from(format!("--groupmap={}", mapping.spec())));
+        //
+        // upstream: options.c:2911-2917 - both --usermap and --groupmap sit
+        // inside the `if (am_sender)` block, so they are forwarded only on a
+        // PUSH: the remote receiver applies the id remapping when it writes
+        // ownership. On a PULL the local receiver owns the mapping and the
+        // remote sender must not receive it.
+        if am_sender {
+            if let Some(mapping) = self.config.user_mapping() {
+                args.push(OsString::from(format!("--usermap={}", mapping.spec())));
+            }
+            if let Some(mapping) = self.config.group_mapping() {
+                args.push(OsString::from(format!("--groupmap={}", mapping.spec())));
+            }
         }
 
         // upstream: options.c:2716-2723 - --iconv forwarding. When iconv_opt

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -428,22 +428,32 @@ fn omits_ignore_errors_flag_when_not_set() {
     );
 }
 
+// WHY: upstream options.c:2930-2931 emits `--fsync` inside the `if (am_sender)`
+// block, so it rides only on a PUSH (RemoteRole::Sender) where the remote
+// receiver fsyncs the files it writes. On a PULL the remote sender writes no
+// destination files, so forwarding --fsync would be meaningless (and upstream
+// never does), while the local receiver still fsyncs its own writes.
 #[test]
-fn includes_fsync_flag_when_set() {
+fn fsync_forwarded_on_push_only() {
     let config = ClientConfig::builder().fsync(true).build();
-    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
-    let args = builder.build("/path");
 
+    let push = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
     assert!(
-        args.iter().any(|a| a == "--fsync"),
-        "expected --fsync in args: {args:?}"
+        push.iter().any(|a| a == "--fsync"),
+        "push must forward --fsync: {push:?}"
+    );
+
+    let pull = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
+    assert!(
+        !pull.iter().any(|a| a == "--fsync"),
+        "pull must not forward --fsync to the remote sender: {pull:?}"
     );
 }
 
 #[test]
 fn omits_fsync_flag_when_not_set() {
     let config = ClientConfig::builder().build();
-    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/path");
 
     assert!(
@@ -3792,5 +3802,175 @@ fn ssh_forwards_info_and_debug_when_set() {
             .any(|a| a.to_string_lossy().starts_with("--info=")
                 || a.to_string_lossy().starts_with("--debug=")),
         "no info/debug flags must yield no --info/--debug arg: {args:?}"
+    );
+}
+
+// WHY (OPT-GAP-01, HIGH DATA-LOSS): upstream options.c:2826-2831 remaps a
+// max-delete ceiling of 0 to `--max-delete=-1` before forwarding. The remote
+// receiver treats `--max-delete=0` as UNLIMITED (options.c:2182-2184 disables
+// the cap for max_delete <= 0), so a client that ran `--max-delete=0 --delete`
+// - meaning "delete NOTHING" - would instead delete EVERY extraneous file if we
+// forwarded `--max-delete=0` verbatim. The inversion (0 -> -1) is what makes the
+// remote enforce the "delete nothing" ceiling the user asked for.
+#[test]
+fn max_delete_zero_forwards_minus_one_not_zero_on_push() {
+    let config = ClientConfig::builder().max_delete(Some(0)).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--max-delete=-1"),
+        "max-delete=0 must forward as --max-delete=-1 (unlimited-cap inversion): {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--max-delete=0"),
+        "max-delete=0 must NEVER reach the remote verbatim (deletes everything): {args:?}"
+    );
+}
+
+// WHY (OPT-GAP-01): a positive ceiling is forwarded unchanged, matching
+// upstream's `if (max_delete > 0) --max-delete=N` branch.
+#[test]
+fn max_delete_positive_forwarded_verbatim_on_push() {
+    let config = ClientConfig::builder().max_delete(Some(7)).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--max-delete=7"),
+        "positive max-delete must forward verbatim: {args:?}"
+    );
+}
+
+// WHY (OPT-GAP-01 + OPT-GAP-05): every option in upstream's `if (am_sender)`
+// block (options.c:2825-2857) is receiver-steering, so on a PULL (the local
+// process is the receiver, RemoteRole::Receiver) NONE of them may be forwarded
+// to the remote sender. In particular --max-delete=0 must not leak even in its
+// remapped form, because the remote sender performs no deletion at all.
+#[test]
+fn sender_only_delete_and_size_options_not_forwarded_on_pull() {
+    let config = ClientConfig::builder()
+        .max_delete(Some(0))
+        .max_file_size(Some(1_048_576))
+        .min_file_size(Some(1024))
+        .delete_before(true)
+        .force_replacements(true)
+        .size_only(true)
+        .build();
+    let pull = build_receiver_args(&config);
+    for needle in [
+        "--max-delete=-1",
+        "--max-delete=0",
+        "--max-size=1048576",
+        "--min-size=1024",
+        "--delete-before",
+        "--force",
+        "--size-only",
+    ] {
+        assert!(
+            !pull.iter().any(|a| a == needle),
+            "PULL must not forward am_sender-only {needle} to the remote sender: {pull:?}"
+        );
+    }
+
+    // Same config on a PUSH forwards them (the remote receiver needs them).
+    let push = build_sender_args(&config);
+    assert!(
+        push.iter().any(|a| a == "--delete-before") && push.iter().any(|a| a == "--size-only"),
+        "PUSH must still forward the am_sender-only options: {push:?}"
+    );
+}
+
+// WHY (OPT-GAP-05, most-important leak): upstream options.c:2846-2847 emits
+// --delete-excluded only inside `if (am_sender)`. On a PULL, forwarding it
+// rewrites the remote sender's send_rules so excluded files vanish from the
+// file list, corrupting what the receiver sees. It must ride only on a PUSH.
+#[test]
+fn delete_excluded_forwarded_on_push_only() {
+    let config = ClientConfig::builder()
+        .delete_excluded(true)
+        .delete_before(true)
+        .build();
+
+    let push = build_sender_args(&config);
+    assert!(
+        push.iter().any(|a| a == "--delete-excluded"),
+        "PUSH must forward --delete-excluded: {push:?}"
+    );
+
+    let pull = build_receiver_args(&config);
+    assert!(
+        !pull.iter().any(|a| a == "--delete-excluded"),
+        "PULL must NOT forward --delete-excluded (it rewrites the remote sender's send_rules): {pull:?}"
+    );
+}
+
+// WHY (OPT-GAP-05): --usermap / --groupmap, --ignore-existing / --existing,
+// --temp-dir and --preallocate all live in upstream's `if (am_sender)` block
+// (options.c:2911-2943, 2990). They steer the remote receiver, so a PULL must
+// not forward them to the remote sender.
+#[cfg(unix)]
+#[test]
+fn sender_only_mapping_and_dest_options_not_forwarded_on_pull() {
+    let user = ::metadata::UserMapping::parse("*:5678").expect("parse");
+    let group = ::metadata::GroupMapping::parse("*:1234").expect("parse");
+    let config = ClientConfig::builder()
+        .user_mapping(Some(user))
+        .group_mapping(Some(group))
+        .ignore_existing(true)
+        .existing_only(true)
+        .temp_directory(Some("/tmp/staging"))
+        .preallocate(true)
+        .build();
+
+    let pull = build_receiver_args(&config);
+    for needle in [
+        "--usermap=*:5678",
+        "--groupmap=*:1234",
+        "--ignore-existing",
+        "--existing",
+        "--temp-dir=/tmp/staging",
+        "--preallocate",
+    ] {
+        assert!(
+            !pull.iter().any(|a| a == needle),
+            "PULL must not forward am_sender-only {needle}: {pull:?}"
+        );
+    }
+
+    let push = build_sender_args(&config);
+    for needle in [
+        "--usermap=*:5678",
+        "--groupmap=*:1234",
+        "--ignore-existing",
+        "--existing",
+        "--temp-dir=/tmp/staging",
+        "--preallocate",
+    ] {
+        assert!(
+            push.iter().any(|a| a == needle),
+            "PUSH must forward am_sender-only {needle}: {push:?}"
+        );
+    }
+}
+
+// WHY (OPT-GAP-02): upstream options.c:2799 forwards `--bwlimit=%d` in whole KiB
+// (options.c:1718 `bwlimit = (size + 512) / 1024`), NOT bytes/sec. The remote
+// peer re-parses the value with a default `K` suffix (options.c:1714), so a raw
+// byte count is scaled up 1024x and the throttle effectively vanishes. A rate of
+// 1 MiB/s (1048576 B/s) must travel as `--bwlimit=1024`.
+#[test]
+fn bwlimit_forwarded_in_kib_not_bytes() {
+    use crate::client::config::BandwidthLimit;
+    use std::num::NonZeroU64;
+    let config = ClientConfig::builder()
+        .bandwidth_limit(Some(BandwidthLimit::from_bytes_per_second(
+            NonZeroU64::new(1_048_576).unwrap(),
+        )))
+        .build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--bwlimit=1024"),
+        "bwlimit must forward as whole KiB: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--bwlimit=1048576"),
+        "bwlimit must NOT forward the raw byte count: {args:?}"
     );
 }


### PR DESCRIPTION
## Summary

The SSH remote-invocation server-arg builder
(`crates/core/src/client/remote/invocation/builder.rs`) diverged from upstream
`options.c:server_options()` (rsync 3.4.4, protocol 32). This aligns it with the
upstream source and the already-role-gated daemon builder.

### HIGH severity data-loss inversion (lead)

`--max-delete` was forwarded verbatim and role-agnostically. Upstream
(`options.c:2826-2831`) remaps a ceiling of **0 to `--max-delete=-1`** and emits
it only inside `if (am_sender)`. The remote receiver treats `--max-delete=0` as
**UNLIMITED** (the cap is disabled for `max_delete <= 0` at
`options.c:2182-2184`), so a client running `--max-delete=0 --delete` - meaning
"delete NOTHING" - would instead have the remote delete **every** extraneous
file. We now map `0 -> -1` and gate on the sender role, matching upstream and the
daemon builder.

## Gaps fixed

| Gap | Upstream | Fix |
|-----|----------|-----|
| OPT-GAP-01 (HIGH) | `options.c:2826-2831` | `--max-delete=0` -> `--max-delete=-1`; gated on `am_sender` |
| OPT-GAP-05 (MED) | `options.c:2825-2857, 2911-2943, 2990` | `am_sender`-gate `--max-delete`, `--min-size`, `--max-size`, delete variants, `--delete-excluded`, `--force`, `--size-only`, `--usermap`/`--groupmap`, `--ignore-existing`, `--existing`, `--temp-dir`, `--fsync`, `--preallocate` |
| OPT-GAP-02 (MED) | `options.c:1718, 2799` | `--bwlimit` now forwarded in whole KiB, not bytes/sec |

`--delete-excluded` was the most important OPT-GAP-05 leak: on a PULL it rewrites
the remote sender's `send_rules` so excluded files vanish from the file list.

For OPT-GAP-02, the remote peer re-parses `--bwlimit` with a default `K` suffix
(`options.c:1714` / oc `size_arg::parse_size_arg(.., b'K')`), so a raw byte count
was scaled up 1024x, effectively removing the throttle. Conversion mirrors
`options.c:1718` (`(size + 512) / 1024`) via a new shared
`BandwidthLimit::server_option_kib()`.

### Scope note: daemon builder shared bug

The daemon builder (`daemon_transfer/orchestration/arguments.rs`) forwarded
`--bwlimit` in bytes through the same code path (the "already faithful" reference
was actually wrong here). Since this is the identical, proven 1024x bug, it was
fixed via the same shared helper (one line + test), consistent with the
one-shared-mechanism principle. Its `bwlimit_forwarded` test asserted the buggy
byte value and was rewritten to assert KiB.

## Gaps deferred (require model changes beyond builder.rs)

- **OPT-GAP-03 (`-C`/--cvs-exclude): NOT DONE.** The `cvs_exclude` state is
  discarded at `cli/.../drive/workflow/run.rs:135` (`cvs_exclude: _`) and never
  reaches `ClientConfig`. oc conveys CVS mode via a filter **wire rule**
  (`flags.rs:325 wire_rule.cvs_exclude = options.is_cvs_mode()`), a different
  mechanism than upstream's `-C` compact letter. Forwarding `-C` needs
  cross-crate plumbing (a `cvs_exclude` bool through ClientConfig + builder +
  run.rs) plus verification that it does not double-apply against the existing
  filter-rule path. Needs dedicated investigation vs a real binary.
- **OPT-GAP-04 (--skip-compress): NOT DONE.** `SkipCompressList` parses the spec
  into tokens with no way to render the original string back, and
  `ClientConfig.skip_compress` is a non-`Option` field defaulting to the built-in
  suffix list - so the builder cannot tell "user set it" from the default nor
  reconstruct the value. Faithful forwarding requires retaining the raw spec and
  tracking explicit-set (cross-crate model change).
- **OPT-GAP-06 (`-XX`/`-UU` level 2): NOT DONE.** `preserve_xattrs` /
  `preserve_atimes` are `bool` (CLI `ArgAction::SetTrue`, config bool). Level-2
  doubling is unrepresentable without changing the CLI to `ArgAction::Count`, the
  config to a `u8` level, and every consumer across crates. The minimal
  representable state (single `X`/`U`) is already emitted for level 1.

## Tests (WHY-encoded, failing-first)

New tests in `invocation/tests.rs` (each cites `options.c`):

- `max_delete_zero_forwards_minus_one_not_zero_on_push` - the data-loss inversion.
- `max_delete_positive_forwarded_verbatim_on_push`.
- `sender_only_delete_and_size_options_not_forwarded_on_pull`.
- `sender_only_mapping_and_dest_options_not_forwarded_on_pull`.
- `delete_excluded_forwarded_on_push_only` - the send_rules leak.
- `bwlimit_forwarded_in_kib_not_bytes`.
- `fsync_forwarded_on_push_only` (replaces a test that asserted the pre-fix
  role-agnostic behaviour).

Daemon: `bwlimit_forwarded_in_kib_not_bytes` (rewritten).

## Verification

- `cargo fmt --all`
- `cargo clippy -p core --all-features --all-targets --no-deps -- -D warnings` -
  clean.
- `cargo nextest run -p core` targeted + full `invocation` / daemon
  `orchestration` / `config::bandwidth` modules: 411 passed, 0 failed. Full
  workspace suite deferred to CI.
