### PR TITLE
fix(protocol): stream compressed-token inflate to match upstream

### DIFF
--- a/crates/protocol/src/wire/compressed_token/step.rs
+++ b/crates/protocol/src/wire/compressed_token/step.rs
@@ -41,33 +41,83 @@ pub(super) enum TokenStep {
 /// chunking, and the deflated-length header reads). It defers only the parts
 /// that differ per algorithm:
 ///
-/// - whether consecutive DEFLATED_DATA blocks are accumulated before
-///   decompression (zlib) or decompressed one block at a time (zstd, lz4);
-/// - how a completed compressed buffer is turned into decompressed output.
+/// - whether a consecutive DEFLATED_DATA run is one continuous stream fed block
+///   by block through a persistent inflate state (zlib) or a series of
+///   independently decompressible blocks (zstd, lz4);
+/// - how compressed input is turned into decompressed output.
 ///
-/// Implementors own the persistent decompression context and the accumulation
-/// buffer; the core owns the run index, saved flag, and output buffer.
+/// Two decode paths exist, selected by [`accumulates`](Self::accumulates):
+///
+/// - Non-streaming (zstd/lz4): each DEFLATED_DATA block is a complete unit. The
+///   core calls [`begin_block`](Self::begin_block) then
+///   [`decompress_into`](Self::decompress_into) once per block.
+/// - Streaming (zlib): a consecutive DEFLATED_DATA run is one deflate stream
+///   split across wire blocks. The core feeds each block via
+///   [`begin_block`](Self::begin_block) (first) or [`push_block`](Self::push_block)
+///   (follow-on), pulls bounded output with [`stream_step`](Self::stream_step)
+///   between and within blocks, and, when the run ends, restores the stripped
+///   `Z_SYNC_FLUSH` trailer via [`finish_run`](Self::finish_run). This mirrors
+///   upstream token.c:recv_deflated_token()'s r_inflating/r_inflated states:
+///   O(CHUNK_SIZE) memory for a multi-GB transfer, no accumulation, no cap.
+///
+/// Implementors own the persistent decompression context; the core owns the run
+/// index, saved flag, and output buffer.
 pub(super) trait DeflateSink {
-    /// Whether this algorithm accumulates consecutive DEFLATED_DATA blocks into
-    /// one compressed buffer before decompressing (zlib does; zstd/lz4 do not).
+    /// Whether a consecutive DEFLATED_DATA run is one continuous inflate stream
+    /// fed block by block (zlib) rather than a series of independent blocks
+    /// (zstd/lz4). Streaming sinks use [`stream_step`](Self::stream_step) and
+    /// [`finish_run`](Self::finish_run); non-streaming sinks use
+    /// [`decompress_into`](Self::decompress_into).
     fn accumulates(&self) -> bool;
 
-    /// Starts a new DEFLATED_DATA sequence with its first block payload.
+    /// Presents the first block of a DEFLATED_DATA run.
     ///
-    /// Resets the accumulation buffer and stores `payload`. The first block is
-    /// never subject to the accumulation cap (upstream applies the cap only to
-    /// the consecutive follow-on blocks).
+    /// Non-streaming sinks store `payload` for [`decompress_into`](Self::decompress_into);
+    /// streaming sinks feed it into the persistent inflate stream for
+    /// [`stream_step`](Self::stream_step).
     fn begin_block(&mut self, payload: &[u8]);
 
-    /// Appends one consecutive follow-on DEFLATED_DATA payload (zlib only).
+    /// Presents a consecutive follow-on block of the same DEFLATED_DATA run.
     ///
-    /// Returns an error if the accumulation cap would be exceeded.
+    /// Only called on streaming sinks; feeds `payload` into the persistent
+    /// inflate stream. Non-streaming sinks never receive follow-on blocks.
     fn push_block(&mut self, payload: &[u8]) -> io::Result<()>;
 
-    /// Decompresses the accumulated compressed input into `output`, which the
-    /// caller has already cleared. Returns the produced bytes appended to
-    /// `output`.
-    fn decompress_into(&mut self, output: &mut Vec<u8>) -> io::Result<()>;
+    /// Decompresses one complete block into `output` (non-streaming sinks).
+    ///
+    /// The caller has already cleared `output`. Streaming sinks leave this
+    /// defaulted and produce output through [`stream_step`](Self::stream_step)
+    /// instead.
+    fn decompress_into(&mut self, _output: &mut Vec<u8>) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Inflates the current block incrementally into `output`, appending at most
+    /// one CHUNK_SIZE worth (streaming sinks).
+    ///
+    /// Returns `true` once the current block's input is fully consumed with no
+    /// further pending output. When output is produced it returns `false`, so
+    /// the core emits that chunk and re-enters to drain the rest of the block.
+    /// The default (non-streaming sinks) reports the block already exhausted.
+    ///
+    /// upstream: token.c recv_deflated_token() r_inflating (Z_NO_FLUSH into a
+    /// fixed CHUNK_SIZE dbuf, emitting output incrementally).
+    fn stream_step(&mut self, _output: &mut Vec<u8>) -> io::Result<bool> {
+        Ok(true)
+    }
+
+    /// Ends a consecutive DEFLATED_DATA run (streaming sinks).
+    ///
+    /// Restores the `Z_SYNC_FLUSH` trailer (`00 00 FF FF`) the sender stripped,
+    /// feeds it through the persistent inflate stream, and drains any residual
+    /// output into `output` (which the caller has cleared). The default is a
+    /// no-op for non-streaming sinks.
+    ///
+    /// upstream: token.c recv_deflated_token() r_inflated (feeds the 4-byte sync
+    /// trailer with Z_SYNC_FLUSH).
+    fn finish_run(&mut self, _output: &mut Vec<u8>) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 /// Resumable, reader-free state of a common token decoder.
@@ -107,12 +157,17 @@ enum Phase {
     DeflatedLen { flag: u8 },
     /// Have the full deflated length; needs the `len`-byte payload.
     DeflatedPayload { len: usize },
-    /// (zlib accumulation) peeking the flag byte after a DEFLATED_DATA block.
+    /// (zlib streaming) inflating the current block into bounded output; needs
+    /// no wire bytes. Re-entered until the block's input is fully consumed.
+    Inflating,
+    /// (zlib streaming) peeking the flag byte after a DEFLATED_DATA block: a
+    /// follow-on DEFLATED_DATA continues the same inflate stream, anything else
+    /// ends the run and triggers the sync-trailer restore.
     AccumPeek,
-    /// (zlib accumulation) read a follow-on DEFLATED_DATA flag; needs its low
+    /// (zlib streaming) read a follow-on DEFLATED_DATA flag; needs its low
     /// length byte.
     AccumLen { flag: u8 },
-    /// (zlib accumulation) needs the follow-on `len`-byte payload.
+    /// (zlib streaming) needs the follow-on `len`-byte payload.
     AccumPayload { len: usize },
     /// Parsed a TOKEN_REL/TOKEN_LONG flag that carries a 2-byte run count.
     RunCount { token: i32 },
@@ -205,118 +260,146 @@ impl TokenDecodeCore {
             self.initialized = true;
         }
 
-        // Each arm returns; the phase encodes exactly which read is resuming, so
-        // there is no need to iterate within a single step.
-        match self.phase {
-            Phase::Idle => {
-                // Drain any buffered decompressed output first.
-                if let Some(tok) = self.emit_pending_output() {
-                    return Ok(TokenStep::Emit(tok));
-                }
-                // Emit pending run tokens.
-                if self.rx_run > 0 {
-                    return Ok(TokenStep::Emit(self.next_run_token()?));
-                }
-                // Read the next flag byte, unless one was saved.
-                let flag = if let Some(f) = self.saved_flag.take() {
-                    f
-                } else if input.is_empty() {
-                    return Ok(TokenStep::Need(1));
-                } else {
-                    input[0]
-                };
-                self.dispatch_flag(flag)
-            }
-            Phase::DeflatedLen { flag } => {
-                // input holds the 1 low length byte.
-                let high = (flag & 0x3F) as usize;
-                let len = (high << 8) | (input[0] as usize);
-                if len == 0 {
-                    // Zero-length payload: no wire read needed. Process an
-                    // empty first block directly, matching the original
-                    // read_exact(&mut buf[..0]) no-op.
-                    sink.begin_block(&[]);
-                    if sink.accumulates() {
-                        self.phase = Phase::AccumPeek;
+        // Most arms return; the phase encodes exactly which read is resuming. A
+        // few streaming transitions (feed a block, then inflate it) need no wire
+        // bytes, so they `continue` into `Phase::Inflating` within this call.
+        // The `input` slice is only ever consumed by the arm that requested it;
+        // the `continue` targets (`Inflating`) never read `input`.
+        loop {
+            match self.phase {
+                Phase::Idle => {
+                    // Drain any buffered decompressed output first.
+                    if let Some(tok) = self.emit_pending_output() {
+                        return Ok(TokenStep::Emit(tok));
+                    }
+                    // Emit pending run tokens.
+                    if self.rx_run > 0 {
+                        return Ok(TokenStep::Emit(self.next_run_token()?));
+                    }
+                    // Read the next flag byte, unless one was saved.
+                    let flag = if let Some(f) = self.saved_flag.take() {
+                        f
+                    } else if input.is_empty() {
                         return Ok(TokenStep::Need(1));
+                    } else {
+                        input[0]
+                    };
+                    return self.dispatch_flag(flag);
+                }
+                Phase::DeflatedLen { flag } => {
+                    // input holds the 1 low length byte.
+                    let high = (flag & 0x3F) as usize;
+                    let len = (high << 8) | (input[0] as usize);
+                    if len == 0 {
+                        // Zero-length payload: no wire read needed. Process an
+                        // empty first block directly, matching the original
+                        // read_exact(&mut buf[..0]) no-op.
+                        sink.begin_block(&[]);
+                        if sink.accumulates() {
+                            self.phase = Phase::Inflating;
+                            continue;
+                        }
+                        return self.finish_deflate(sink);
+                    }
+                    self.phase = Phase::DeflatedPayload { len };
+                    return Ok(TokenStep::Need(len));
+                }
+                Phase::DeflatedPayload { len } => {
+                    debug_assert_eq!(input.len(), len);
+                    sink.begin_block(input);
+                    if sink.accumulates() {
+                        self.phase = Phase::Inflating;
+                        continue;
                     }
                     return self.finish_deflate(sink);
                 }
-                self.phase = Phase::DeflatedPayload { len };
-                Ok(TokenStep::Need(len))
-            }
-            Phase::DeflatedPayload { len } => {
-                debug_assert_eq!(input.len(), len);
-                sink.begin_block(input);
-                if sink.accumulates() {
+                Phase::Inflating => {
+                    // Inflate the current block into a bounded (<= CHUNK_SIZE)
+                    // output chunk and emit it, or advance to peek the next flag
+                    // once the block's input is exhausted. This is upstream's
+                    // r_inflating loop: no accumulation, O(CHUNK_SIZE) memory.
+                    self.decompress_buf.clear();
+                    let exhausted = sink.stream_step(&mut self.decompress_buf)?;
+                    if let Some(tok) = self.take_first_output() {
+                        // Stay in Inflating to drain the rest of this block.
+                        return Ok(TokenStep::Emit(tok));
+                    }
+                    debug_assert!(exhausted);
                     self.phase = Phase::AccumPeek;
                     return Ok(TokenStep::Need(1));
                 }
-                self.finish_deflate(sink)
-            }
-            Phase::AccumPeek => {
-                let next_flag = input[0];
-                if (next_flag & 0xC0) == DEFLATED_DATA {
-                    self.phase = Phase::AccumLen { flag: next_flag };
-                    return Ok(TokenStep::Need(1));
-                }
-                self.saved_flag = Some(next_flag);
-                self.finish_deflate(sink)
-            }
-            Phase::AccumLen { flag } => {
-                let high = (flag & 0x3F) as usize;
-                let len = (high << 8) | (input[0] as usize);
-                if len == 0 {
-                    sink.push_block(&[])?;
-                    self.phase = Phase::AccumPeek;
-                    return Ok(TokenStep::Need(1));
-                }
-                self.phase = Phase::AccumPayload { len };
-                Ok(TokenStep::Need(len))
-            }
-            Phase::AccumPayload { len } => {
-                debug_assert_eq!(input.len(), len);
-                sink.push_block(input)?;
-                self.phase = Phase::AccumPeek;
-                Ok(TokenStep::Need(1))
-            }
-            Phase::RunCount { token } => {
-                self.rx_token = token;
-                self.rx_run = u16::from_le_bytes([input[0], input[1]]) as i32;
-                self.phase = Phase::Idle;
-                Ok(TokenStep::Emit(CompressedToken::BlockMatch(
-                    self.rx_token as u32,
-                )))
-            }
-            Phase::LongToken { has_run } => {
-                let token = i32::from_le_bytes([input[0], input[1], input[2], input[3]]);
-                if token < 0 {
+                Phase::AccumPeek => {
+                    let next_flag = input[0];
+                    if (next_flag & 0xC0) == DEFLATED_DATA {
+                        self.phase = Phase::AccumLen { flag: next_flag };
+                        return Ok(TokenStep::Need(1));
+                    }
+                    // Run ended: restore the sync trailer and drain, then
+                    // dispatch the flag that ended the run.
+                    self.saved_flag = Some(next_flag);
+                    self.decompress_buf.clear();
+                    sink.finish_run(&mut self.decompress_buf)?;
                     self.phase = Phase::Idle;
-                    // upstream: token.c:528 invalid_compressed_token() ->
-                    // exit_cleanup(RERR_PROTOCOL) (exit 2). Tag the error so the
-                    // core exit-code mapper yields RERR_PROTOCOL, not
-                    // RERR_STREAMIO(12).
-                    return Err(crate::protocol_violation::protocol_violation(
-                        "invalid token number in compressed stream",
-                    ));
+                    if let Some(tok) = self.take_first_output() {
+                        return Ok(TokenStep::Emit(tok));
+                    }
+                    return self.step_idle_after_zero_output();
                 }
-                if has_run {
-                    self.phase = Phase::LongRunCount { token };
-                    return Ok(TokenStep::Need(2));
+                Phase::AccumLen { flag } => {
+                    let high = (flag & 0x3F) as usize;
+                    let len = (high << 8) | (input[0] as usize);
+                    if len == 0 {
+                        // Empty follow-on block contributes nothing; peek again.
+                        self.phase = Phase::AccumPeek;
+                        return Ok(TokenStep::Need(1));
+                    }
+                    self.phase = Phase::AccumPayload { len };
+                    return Ok(TokenStep::Need(len));
                 }
-                self.rx_token = token;
-                self.phase = Phase::Idle;
-                Ok(TokenStep::Emit(CompressedToken::BlockMatch(
-                    self.rx_token as u32,
-                )))
-            }
-            Phase::LongRunCount { token } => {
-                self.rx_token = token;
-                self.rx_run = u16::from_le_bytes([input[0], input[1]]) as i32;
-                self.phase = Phase::Idle;
-                Ok(TokenStep::Emit(CompressedToken::BlockMatch(
-                    self.rx_token as u32,
-                )))
+                Phase::AccumPayload { len } => {
+                    debug_assert_eq!(input.len(), len);
+                    sink.push_block(input)?;
+                    self.phase = Phase::Inflating;
+                    continue;
+                }
+                Phase::RunCount { token } => {
+                    self.rx_token = token;
+                    self.rx_run = u16::from_le_bytes([input[0], input[1]]) as i32;
+                    self.phase = Phase::Idle;
+                    return Ok(TokenStep::Emit(CompressedToken::BlockMatch(
+                        self.rx_token as u32,
+                    )));
+                }
+                Phase::LongToken { has_run } => {
+                    let token = i32::from_le_bytes([input[0], input[1], input[2], input[3]]);
+                    if token < 0 {
+                        self.phase = Phase::Idle;
+                        // upstream: token.c:528 invalid_compressed_token() ->
+                        // exit_cleanup(RERR_PROTOCOL) (exit 2). Tag the error so
+                        // the core exit-code mapper yields RERR_PROTOCOL, not
+                        // RERR_STREAMIO(12).
+                        return Err(crate::protocol_violation::protocol_violation(
+                            "invalid token number in compressed stream",
+                        ));
+                    }
+                    if has_run {
+                        self.phase = Phase::LongRunCount { token };
+                        return Ok(TokenStep::Need(2));
+                    }
+                    self.rx_token = token;
+                    self.phase = Phase::Idle;
+                    return Ok(TokenStep::Emit(CompressedToken::BlockMatch(
+                        self.rx_token as u32,
+                    )));
+                }
+                Phase::LongRunCount { token } => {
+                    self.rx_token = token;
+                    self.rx_run = u16::from_le_bytes([input[0], input[1]]) as i32;
+                    self.phase = Phase::Idle;
+                    return Ok(TokenStep::Emit(CompressedToken::BlockMatch(
+                        self.rx_token as u32,
+                    )));
+                }
             }
         }
     }
@@ -365,14 +448,13 @@ impl TokenDecodeCore {
         }
     }
 
-    /// Runs decompression on the accumulated block(s) and sets up output.
+    /// Decompresses one complete block (non-streaming sinks) and sets up output.
     ///
     /// Returns the first output chunk, or resumes the idle state when the block
-    /// produced no output. This replaces the original zero-output recursive
+    /// produced no output. The zero-output case replaces the original recursive
     /// re-read (`self.recv_token`) with an in-place state-machine transition:
-    /// when a flag was already saved during accumulation it is dispatched
-    /// without asking the driver for bytes, otherwise a fresh `Need(1)` is
-    /// returned - exactly the reads the recursion would have performed.
+    /// a fresh `Need(1)` for the next flag - exactly the read the recursion
+    /// would have performed.
     fn finish_deflate<S: DeflateSink>(&mut self, sink: &mut S) -> io::Result<TokenStep> {
         self.decompress_buf.clear();
         sink.decompress_into(&mut self.decompress_buf)?;

--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -1666,122 +1666,64 @@ fn lz4_decoder_rejects_run_overflow() {
     assert_rejects_run_overflow(CompressedTokenDecoder::new_lz4());
 }
 
-/// Defence-in-depth: the zlib decoder must reject accumulated compressed
-/// data that exceeds `MAX_ACCUMULATED_COMPRESSED_BYTES` (64 MiB).
+/// A whole-file `-z` transfer whose compressed literal run exceeds the old
+/// 64 MiB accumulation cap must round-trip byte-for-byte.
 ///
-/// Rust's `usize` arithmetic prevents the integer-overflow CVE that
-/// affected upstream C (CVE-2026-43618), but an explicit cap prevents
-/// OOM from crafted input sending an unbounded chain of DEFLATED_DATA
-/// blocks.
+/// WHY: upstream token.c:recv_deflated_token() streams each DEFLATED_DATA block
+/// through a persistent inflate state into a fixed CHUNK_SIZE buffer, emitting
+/// output incrementally with NO size cap - O(CHUNK_SIZE) memory for a multi-GB
+/// transfer. oc previously accumulated the entire compressed literal run and
+/// inflated it once, guarded by a 64 MiB cap that upstream does not have, so any
+/// compressed literal over 64 MiB aborted a transfer upstream completes fine.
 ///
-/// upstream: token.c defence-in-depth - bound accumulated compressed data (3.4.3)
+/// This builds a single consecutive DEFLATED_DATA run larger than that cap
+/// (level-0 "stored" deflate keeps the compressed size ~= the input size) and
+/// asserts a byte-identical round-trip, decoding incrementally so the decoder's
+/// own working set stays bounded. It fails against the accumulate+cap design
+/// (recv_token returns an "accumulated compressed data exceeds" error) and
+/// passes once the decoder streams per block, as upstream does.
 #[test]
-fn zlib_decoder_rejects_oversized_accumulated_compressed_data() {
-    use super::zlib_codec::MAX_ACCUMULATED_COMPRESSED_BYTES;
+fn zlib_streams_large_literal_exceeding_old_64mib_cap() {
+    // 65 MiB of varied bytes: a level-0 (stored) deflate run of this literal
+    // exceeds the removed 64 MiB cap. A deterministic non-uniform pattern keeps
+    // the round-trip assertion meaningful.
+    let size = 65 * 1024 * 1024;
+    let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
 
-    // Build a synthetic wire stream: an initial DEFLATED_DATA block
-    // followed by enough consecutive DEFLATED_DATA blocks to breach
-    // the cap. Use a streaming reader to avoid allocating 64 MiB.
-    struct OverflowReader {
-        /// Pre-built header+payload for each DEFLATED_DATA block.
-        block: Vec<u8>,
-        /// Total bytes of compressed data emitted so far.
-        emitted: usize,
-        /// Position within the current copy of `block`.
-        pos: usize,
-        /// Whether the first flag byte (the one that enters the
-        /// DEFLATED_DATA branch in recv_token) has been emitted.
-        first_flag_emitted: bool,
-        cap: usize,
-    }
+    // Level 0 (stored) keeps compressed size ~= input size and is fast, so the
+    // single consecutive DEFLATED_DATA run clears the old 64 MiB cap.
+    let mut encoded = Vec::new();
+    let mut encoder = CompressedTokenEncoder::new(CompressionLevel::None, 31);
+    encoder.send_literal(&mut encoded, &data).unwrap();
+    encoder.finish(&mut encoded).unwrap();
 
-    impl io::Read for OverflowReader {
-        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-            if buf.is_empty() {
-                return Ok(0);
+    // Sanity: the compressed literal run really is larger than the removed cap,
+    // otherwise this would not exercise the regression.
+    assert!(
+        encoded.len() > 64 * 1024 * 1024,
+        "compressed run ({} bytes) must exceed the old 64 MiB cap",
+        encoded.len()
+    );
+
+    // Decode incrementally, comparing against the source as we go so the
+    // decoder streams rather than materialising the whole literal.
+    let mut cursor = Cursor::new(&encoded);
+    let mut decoder = CompressedTokenDecoder::new();
+    let mut offset = 0usize;
+    loop {
+        match decoder.recv_token(&mut cursor).unwrap() {
+            CompressedToken::Literal(chunk) => {
+                assert!(offset + chunk.len() <= data.len(), "decoder overran source");
+                assert_eq!(
+                    chunk.as_slice(),
+                    &data[offset..offset + chunk.len()],
+                    "mismatch at offset {offset}"
+                );
+                offset += chunk.len();
             }
-
-            // The very first byte the decoder reads is the flag byte
-            // that routes into the DEFLATED_DATA branch. Emit it once.
-            if !self.first_flag_emitted {
-                // DEFLATED_DATA with length = MAX_DATA_COUNT
-                let len = MAX_DATA_COUNT;
-                let flag = DEFLATED_DATA | ((len >> 8) as u8);
-                buf[0] = flag;
-                self.first_flag_emitted = true;
-                // The next read_exact(1) from the decoder will read
-                // the low-byte of the length from the block data.
-                // We set pos to 0 so the block data starts being read.
-                self.pos = 0;
-                // Prepend the low byte of the length to the block
-                // payload. We handle this by having `block` start
-                // with the low byte.
-                return Ok(1);
-            }
-
-            // Keep emitting blocks until we exceed the cap.
-            // Each "block" in self.block is: [len_low_byte, payload...]
-            // followed by the next DEFLATED_DATA header for the
-            // subsequent block (2 bytes).
-            let remaining_in_block = self.block.len() - self.pos;
-            if remaining_in_block == 0 {
-                // We just finished a block. Decide whether to emit
-                // another DEFLATED_DATA header or stop.
-                if self.emitted > self.cap {
-                    // We've exceeded the cap; the decoder should have
-                    // already errored. If we get here, something is
-                    // wrong - just return EOF to avoid infinite loops.
-                    return Ok(0);
-                }
-                self.pos = 0;
-            }
-
-            let n = buf.len().min(self.block.len() - self.pos);
-            buf[..n].copy_from_slice(&self.block[self.pos..self.pos + n]);
-            self.pos += n;
-
-            // Track emitted compressed data bytes (payload only, not
-            // headers).
-            if self.pos >= 1 {
-                // Approximate: most of what we emit is payload.
-                self.emitted += n;
-            }
-
-            Ok(n)
+            CompressedToken::End => break,
+            CompressedToken::BlockMatch(_) => panic!("unexpected block match"),
         }
     }
-
-    // Build a repeating block: low byte of length + MAX_DATA_COUNT
-    // bytes of payload + next DEFLATED_DATA header (2 bytes).
-    let payload_len = MAX_DATA_COUNT;
-    let mut block = Vec::with_capacity(1 + payload_len + 2);
-    // Low byte of the length for read_deflated_data_length
-    block.push((payload_len & 0xFF) as u8);
-    // Payload (content doesn't matter - the decoder will try to
-    // inflate it and may fail, but the cap check happens before
-    // decompression)
-    block.extend(std::iter::repeat_n(0xAA, payload_len));
-    // Next DEFLATED_DATA header (flag + low byte will be read by the
-    // next iteration of the accumulation loop)
-    let next_flag = DEFLATED_DATA | ((payload_len >> 8) as u8);
-    block.push(next_flag);
-
-    let mut reader = OverflowReader {
-        block,
-        emitted: 0,
-        pos: 0,
-        first_flag_emitted: false,
-        cap: MAX_ACCUMULATED_COMPRESSED_BYTES + MAX_DATA_COUNT,
-    };
-
-    let mut decoder = CompressedTokenDecoder::new();
-    let err = decoder
-        .recv_token(&mut reader)
-        .expect_err("decoder must reject oversized accumulated compressed data");
-    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-    assert!(
-        err.to_string()
-            .contains("accumulated compressed data exceeds"),
-        "unexpected error message: {err}"
-    );
+    assert_eq!(offset, data.len(), "decoded length must match the source");
 }

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -19,18 +19,6 @@ use super::{
     TOKENRUN_REL, write_deflated_data_pieces,
 };
 
-/// Maximum aggregate size of accumulated compressed data in a single
-/// DEFLATED_DATA sequence before decompression (64 MiB).
-///
-/// Defence-in-depth: bounds the memory a peer can force the decoder to
-/// allocate by sending an unbounded chain of consecutive DEFLATED_DATA
-/// blocks. Rust's `usize` arithmetic prevents the integer-overflow CVE
-/// that affected upstream C, but an explicit cap prevents OOM from
-/// crafted input.
-///
-/// upstream: token.c defence-in-depth - bound accumulated compressed data (3.4.3)
-pub(super) const MAX_ACCUMULATED_COMPRESSED_BYTES: usize = 64 * 1024 * 1024;
-
 /// Zlib encoder state for sending compressed tokens.
 ///
 /// Manages a persistent deflate stream for compressing literal data.
@@ -303,25 +291,39 @@ impl ZlibTokenEncoder {
 
 /// Zlib decompression sink: the algorithm-specific half of the sans-io decoder.
 ///
-/// Owns the persistent inflate stream, the reusable output scratch, and the
-/// consecutive-DEFLATED_DATA accumulation buffer. The shared
-/// [`TokenDecodeCore`] drives all wire framing and delegates only block
-/// accumulation and decompression here.
+/// Owns the persistent inflate stream and a fixed CHUNK_SIZE output scratch, and
+/// holds only the current DEFLATED_DATA block being inflated. Consecutive blocks
+/// of a run form one deflate stream, fed block by block and inflated
+/// incrementally: O(CHUNK_SIZE) memory for a multi-GB literal, matching upstream.
 ///
-/// Reference: upstream token.c:recv_deflated_token()
+/// Reference: upstream token.c:recv_deflated_token() r_inflating/r_inflated
 struct ZlibDeflate {
     decompressor: Decompress,
     output_buf: Vec<u8>,
-    compressed_input_buf: Vec<u8>,
+    /// The current block payload being inflated.
+    pending: Vec<u8>,
+    /// Read cursor into `pending`.
+    pending_pos: usize,
 }
 
 impl ZlibDeflate {
     fn new() -> Self {
         Self {
             decompressor: Decompress::new(false),
-            output_buf: vec![0u8; CHUNK_SIZE * 2],
-            compressed_input_buf: Vec::with_capacity(MAX_DATA_COUNT + 4),
+            output_buf: vec![0u8; CHUNK_SIZE],
+            pending: Vec::with_capacity(MAX_DATA_COUNT),
+            pending_pos: 0,
         }
+    }
+
+    /// Feeds one DEFLATED_DATA block into the persistent inflate stream.
+    ///
+    /// The bytes must persist across the multiple `stream_step` calls that drain
+    /// this block, so they are copied into `pending` (bounded by MAX_DATA_COUNT).
+    fn feed(&mut self, payload: &[u8]) {
+        self.pending.clear();
+        self.pending.extend_from_slice(payload);
+        self.pending_pos = 0;
     }
 }
 
@@ -331,32 +333,58 @@ impl DeflateSink for ZlibDeflate {
     }
 
     fn begin_block(&mut self, payload: &[u8]) {
-        self.compressed_input_buf.clear();
-        self.compressed_input_buf.extend_from_slice(payload);
+        self.feed(payload);
     }
 
     fn push_block(&mut self, payload: &[u8]) -> io::Result<()> {
-        // upstream: token.c defence-in-depth - bound accumulated compressed
-        // data (3.4.3). The cap guards the consecutive follow-on blocks; the
-        // first block (begin_block) is not capped, matching upstream.
-        if self.compressed_input_buf.len() + payload.len() > MAX_ACCUMULATED_COMPRESSED_BYTES {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "accumulated compressed data exceeds {MAX_ACCUMULATED_COMPRESSED_BYTES} byte cap",
-                ),
-            ));
-        }
-        self.compressed_input_buf.extend_from_slice(payload);
+        self.feed(payload);
         Ok(())
     }
 
-    fn decompress_into(&mut self, output: &mut Vec<u8>) -> io::Result<()> {
-        // Restore sync marker stripped by encoder.
-        self.compressed_input_buf
-            .extend_from_slice(&[0x00, 0x00, 0xFF, 0xFF]);
+    fn stream_step(&mut self, output: &mut Vec<u8>) -> io::Result<bool> {
+        // upstream: token.c recv_deflated_token() r_inflating - inflate the block
+        // with Z_NO_FLUSH into a fixed dbuf, emitting each CHUNK_SIZE increment.
+        loop {
+            let before_in = self.decompressor.total_in();
+            let before_out = self.decompressor.total_out();
 
-        let mut input = &self.compressed_input_buf[..];
+            self.decompressor
+                .decompress(
+                    &self.pending[self.pending_pos..],
+                    &mut self.output_buf,
+                    FlushDecompress::None,
+                )
+                .map_err(|e| io::Error::other(e.to_string()))?;
+
+            let consumed = (self.decompressor.total_in() - before_in) as usize;
+            let produced = (self.decompressor.total_out() - before_out) as usize;
+            self.pending_pos += consumed;
+
+            if produced > 0 {
+                // At most CHUNK_SIZE (output_buf length); the block may hold
+                // more, so report not-yet-exhausted and let the core re-enter.
+                output.extend_from_slice(&self.output_buf[..produced]);
+                return Ok(false);
+            }
+            if self.pending_pos >= self.pending.len() {
+                // Block fully consumed, decoder drained.
+                return Ok(true);
+            }
+            if consumed == 0 {
+                // No forward progress with input still pending: treat the block
+                // as done to avoid a spin. A valid deflate stream never hits
+                // this - the sender only splits at MAX_DATA_COUNT boundaries.
+                return Ok(true);
+            }
+        }
+    }
+
+    fn finish_run(&mut self, output: &mut Vec<u8>) -> io::Result<()> {
+        // upstream: token.c recv_deflated_token() r_inflated - restore the
+        // Z_SYNC_FLUSH trailer the sender stripped and feed it through the
+        // persistent inflate stream, draining any residual output.
+        let marker = [0x00u8, 0x00, 0xFF, 0xFF];
+        let mut input = &marker[..];
 
         loop {
             let before_in = self.decompressor.total_in();
@@ -369,15 +397,14 @@ impl DeflateSink for ZlibDeflate {
             let consumed = (self.decompressor.total_in() - before_in) as usize;
             let produced = (self.decompressor.total_out() - before_out) as usize;
 
+            if consumed > 0 {
+                input = &input[consumed..];
+            }
             if produced > 0 {
                 output.extend_from_slice(&self.output_buf[..produced]);
             }
 
-            if consumed > 0 {
-                input = &input[consumed..];
-            }
-
-            if input.is_empty() || (consumed == 0 && produced == 0) {
+            if input.is_empty() && produced == 0 {
                 break;
             }
         }
@@ -423,7 +450,8 @@ impl ZlibTokenDecoder {
         self.core.reset();
         self.core.initialized = false;
         self.deflate.decompressor.reset(false);
-        self.deflate.compressed_input_buf.clear();
+        self.deflate.pending.clear();
+        self.deflate.pending_pos = 0;
     }
 
     pub(super) fn recv_token<R: Read>(&mut self, reader: &mut R) -> io::Result<CompressedToken> {


### PR DESCRIPTION
## Summary

The zlib/zlibx compressed-token receiver accumulated the entire compressed
literal stream into a single buffer and inflated it once, guarded by a 64 MiB
cap (`MAX_ACCUMULATED_COMPRESSED_BYTES`). A whole-file `-z` transfer (a new file
or `--whole-file`) emits one unbroken run of `DEFLATED_DATA` blocks, so any
compressed literal larger than 64 MiB aborted a transfer that upstream rsync
completes fine. This affected both zlib and zlibx, in both directions
(oc-receiver against an upstream sender, and oc against oc).

## Upstream contract

`token.c:recv_deflated_token()` (rsync 3.4.4, protocol 32) drives a persistent
`rx_strm` inflate state machine (`r_init` / `r_idle` / `r_inflated` /
`r_inflating`). It reads ONE compressed block (at most `MAX_DATA_COUNT` = 16383
bytes) into a fixed `cbuf`, sets `avail_in = n`, and inflates it into a fixed
`AVAIL_OUT_SIZE(CHUNK_SIZE)` (~32 KiB) `dbuf`, emitting output incrementally.
Consecutive `DEFLATED_DATA` blocks form one continuous deflate stream; the
stripped `Z_SYNC_FLUSH` trailer (`00 00 FF FF`) is restored and fed exactly once,
when the run ends (`r_inflated` transitions to a non-`DEFLATED_DATA` flag). There
is no accumulation and no size cap: memory is O(CHUNK_SIZE) for a multi-GB
transfer. The comment attributing the 64 MiB cap to upstream "defence-in-depth"
was factually wrong; no such cap exists upstream.

## Fix

Rewrite the zlib/zlibx receive path to stream per block, mirroring
`recv_deflated_token`:

- The `DeflateSink` seam gains two streaming hooks, `stream_step` (incremental
  inflate of the current block into a bounded CHUNK_SIZE buffer, `Z_NO_FLUSH`)
  and `finish_run` (restore the `00 00 FF FF` trailer with `Z_SYNC_FLUSH` and
  drain), with defaults so the non-streaming zstd/lz4 sinks are untouched.
- The shared `TokenDecodeCore` state machine feeds each block into the
  persistent inflate stream and emits output between and within blocks
  (new `Inflating` phase), deferring the sync-trailer restore until the
  consecutive `DEFLATED_DATA` run ends.
- The accumulate-then-inflate design and the 64 MiB cap are removed entirely.
  The zlib sink now holds only the current block (bounded by `MAX_DATA_COUNT`)
  plus a fixed CHUNK_SIZE output scratch.

Preserved exactly: the `Z_SYNC_FLUSH` trailer strip-on-send / restore-on-recv,
the `see_token` dictionary sync (stored-block header, `hdr[0]=0`, len LE, `~len`
LE), the `protocol_version >= 31` data-duplication offset quirk, and all
`DEFLATED_DATA` header framing `[0x40 | (len >> 8), len & 0xFF]` split at
`MAX_DATA_COUNT`. zstd/lz4 already stream (they do not accumulate) and are not
touched.

## Test

Added `zlib_streams_large_literal_exceeding_old_64mib_cap`: a whole-file `-z`
round-trip whose single consecutive `DEFLATED_DATA` run exceeds the removed
64 MiB threshold (level-0 "stored" deflate keeps the compressed size close to
the input size). It decodes incrementally and asserts a byte-identical
round-trip. The test fails against the old accumulate+cap code (recv returns
"accumulated compressed data exceeds ... byte cap") and passes once the decoder
streams per block. The prior test that enshrined the cap
(`zlib_decoder_rejects_oversized_accumulated_compressed_data`) is removed.

## Verification

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p protocol --all-features --all-targets --no-deps -- -D warnings`:
  clean.
- `cargo nextest run -p protocol --all-features` (compressed_token module): 102
  tests pass, including all zlib/zstd/lz4 round-trips and parity tests.
- Failing-first confirmed: with the source reverted to master and only the new
  test present, the run fails on the cap error.
