### PR TITLE
perf(matching): drop discarded per-block copies in gated delta scan

### DIFF
--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -839,17 +839,27 @@ impl DeltaGenerator {
             // A run begins: flush any literals accumulated before it.
             flush_pending!();
 
-            // Buffer the run of consecutive matching blocks with their source
-            // bytes so a lone match can be demoted to a literal.
-            let mut run: Vec<(u64, Vec<u8>)> = Vec::new();
+            // Buffer the run of consecutive matching blocks by basis index.
+            // Every block the loop extends spans exactly `block_len` source
+            // bytes (the run only grows on a full next block), so a trusted run
+            // (>= 2) reconstructs from the index alone and never needs a
+            // per-block byte copy. Only a lone match is demoted to a Literal,
+            // and that needs the source bytes - but the window is cleared before
+            // the next block, so the first block's bytes are captured once,
+            // up front. This drops the discarded per-block `Vec` allocation the
+            // trusted path used to make (one copy per matched block).
+            let mut run: Vec<u64> = Vec::new();
+            let mut lone_src: Vec<u8> = Vec::new();
 
             loop {
                 let basis_idx = index.block(match_idx).index();
-                let (s1, s2) = window.as_slices();
-                let mut src = Vec::with_capacity(block_len);
-                src.extend_from_slice(s1);
-                src.extend_from_slice(s2);
-                run.push((basis_idx, src));
+                if run.is_empty() {
+                    let (s1, s2) = window.as_slices();
+                    lone_src.reserve_exact(block_len);
+                    lone_src.extend_from_slice(s1);
+                    lone_src.extend_from_slice(s2);
+                }
+                run.push(basis_idx);
 
                 matched_blocks.mark_matched(match_idx);
                 index.mark_consumed(match_idx as u32);
@@ -899,17 +909,17 @@ impl DeltaGenerator {
             // Flush the run: trusted runs (>= 2) become Copy tokens; a lone
             // match is demoted to a Literal of its own source bytes.
             if run.len() >= 2 {
-                for (idx, bytes) in run {
-                    total_bytes += bytes.len() as u64;
+                for idx in run {
+                    total_bytes += block_len as u64;
                     tokens.push(DeltaToken::Copy {
                         index: idx,
-                        len: bytes.len(),
+                        len: block_len,
                     });
                 }
-            } else if let Some((_, bytes)) = run.into_iter().next() {
-                literal_bytes += bytes.len() as u64;
-                total_bytes += bytes.len() as u64;
-                tokens.push(DeltaToken::Literal(bytes));
+            } else if !run.is_empty() {
+                literal_bytes += lone_src.len() as u64;
+                total_bytes += lone_src.len() as u64;
+                tokens.push(DeltaToken::Literal(lone_src));
             }
         }
 
@@ -1494,6 +1504,44 @@ mod tests {
             .filter(|t| matches!(t, DeltaToken::Copy { .. }))
             .count();
         assert_eq!(copies, 2, "both consecutive blocks must be copied");
+        assert_eq!(reconstruct(&basis, &index, &script), input);
+    }
+
+    #[test]
+    fn gated_trusted_run_emits_exact_block_len_copy_tokens() {
+        // Pins the exact Copy token stream for a trusted (>= 2) consecutive run.
+        // The gated flush tracks basis indices and reconstructs each Copy length
+        // from `block_len` instead of materializing (then discarding) every
+        // block's source bytes; this golden locks that the emitted tokens - one
+        // `block_len` Copy per basis block, in order - stay byte-identical to the
+        // materialized baseline, so the wire output cannot silently drift.
+        const BLOCK_LEN: u32 = 512;
+        let basis = pseudo_random(4 * BLOCK_LEN as usize, 0x7eed_1234);
+        let index = build_index_fixed(&basis, BLOCK_LEN);
+        assert!(
+            !index.has_duplicate_blocks(),
+            "run indices are only deterministic on a duplicate-free basis"
+        );
+        let bl = index.block_length();
+        let input = basis[..3 * bl].to_vec();
+
+        let script = DeltaGenerator::new()
+            .with_consecutive_match_needed(2)
+            .generate(&input[..], &index)
+            .expect("script");
+
+        let expected = [
+            DeltaToken::Copy { index: 0, len: bl },
+            DeltaToken::Copy { index: 1, len: bl },
+            DeltaToken::Copy { index: 2, len: bl },
+        ];
+        assert_eq!(
+            script.tokens(),
+            expected.as_slice(),
+            "trusted run must emit one block_len Copy per basis block, in order"
+        );
+        assert_eq!(script.literal_bytes(), 0);
+        assert_eq!(script.total_bytes(), input.len() as u64);
         assert_eq!(reconstruct(&basis, &index, &script), input);
     }
 


### PR DESCRIPTION
## Summary

Removes a discarded per-block heap allocation from the consecutive-match
(`seq_matches = 2`) delta scan in `crates/matching/src/generator.rs`. The scan
buffered every matched block of a run together with a freshly allocated,
`memcpy`-filled copy of that block's source bytes, then threw those bytes away
whenever the run turned out to be trusted (length >= 2) and emitted `Copy`
tokens that only need the block length. A run of N consecutive matches paid N
block-sized allocations plus N block-sized copies to keep bytes that only a
lone (length-1) match ever consumes.

The run is now buffered as `Vec<u64>` of basis indices. The source bytes of the
**first** block are captured once, up front, solely for the lone-match
demotion path (the sliding window is cleared before the next block, so those
bytes cannot be recovered later). This drops the per-run allocation count from
N to 1 and eliminates N `block_len`-byte copies per trusted run, with no change
to the emitted token stream.

This mirrors upstream `match.c` intent: `matched()` never allocates per token,
it reasons about a matched block by its index/length and streams literal bytes
through a single persistent output buffer.

## Wire output is provably byte-identical

Pure allocation optimization - no semantic change:

- Every block the run loop extends spans exactly `block_len` source bytes (the
  loop only grows the run on a *full* next block; a short trailing block breaks
  out before it is pushed). So the previous `Copy { len: bytes.len() }` and the
  new `Copy { len: block_len }` are the same value by construction, and the
  `total_bytes` accounting is unchanged.
- The lone-match branch still emits `Literal(first_block_bytes)` with identical
  `literal_bytes`/`total_bytes` bookkeeping; the retained first-block bytes are
  exactly the bytes the old code kept.
- `Copy` token ordering and basis indices are untouched.

Existing gated-path coverage passes unchanged (`gated_two_consecutive_blocks_
are_both_copied`, `gated_lone_match_is_demoted_to_literal`, `gated_reconstructs_
modified_source_byte_exact`, `gated_empty_and_short_inputs`, `updating_basis_
file_guard_holds_in_gated_scan`). A new golden,
`gated_trusted_run_emits_exact_block_len_copy_tokens`, pins the exact `Copy`
token sequence (one `block_len` copy per basis block, in order) so any future
drift in the flush is caught loudly.

## Scope note

The default (`seq_matches = 1`) scan's literal flushes were also reviewed. They
already move the pending-literal accumulator into the owned `DeltaToken::Literal`
via `std::mem::replace` (zero-copy), so they allocate exactly one buffer per
emitted literal token - the irreducible minimum while a token owns its bytes and
all tokens in a `DeltaScript` are live until the script is returned. Further
reduction there would require changing `DeltaToken` to hold a pooled/borrowed
buffer, a cross-crate change touching the wire serialization lifetime, so that
path is intentionally left unchanged.

## Benchmarks

No existing criterion bench exercises the gated (`seq_matches = 2`) scan, so
there is no harness delta to report; the win is a static reduction in
allocation and `memcpy` count (N -> 1 allocations per trusted run) on the
consecutive-match path.

## Verification

- `cargo fmt --all`
- `cargo clippy -p matching --all-features --all-targets --no-deps -- -D warnings` (clean)
- `cargo nextest run -p matching --all-features` targeted at `gated`, `seq_match`,
  and `updating_basis_file`: 29 tests passed.
