### PR TITLE
fix(filters): apply x-modifier rules to xattr-name matching

### DIFF
--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -10,6 +10,7 @@
 mod clear;
 mod pattern;
 mod rule;
+mod xattr;
 
 use std::collections::HashSet;
 
@@ -18,6 +19,7 @@ use crate::{FilterAction, FilterError, FilterRule};
 pub(crate) use clear::apply_clear_rule;
 use pattern::{compile_patterns, normalise_pattern};
 pub(crate) use rule::CompiledRule;
+pub(crate) use xattr::CompiledXattrRule;
 
 impl CompiledRule {
     /// Compiles a [`FilterRule`] into optimised glob matchers.

--- a/crates/filters/src/compiled/xattr.rs
+++ b/crates/filters/src/compiled/xattr.rs
@@ -1,0 +1,66 @@
+//! Compiled xattr-name filter rules (the `x` rule modifier).
+//!
+//! upstream: exclude.c:914 rule_matches() gates every rule on
+//! `!(name_flags & NAME_IS_XATTR) ^ !(ex->rflags & FILTRULE_XATTR)`: a rule
+//! carrying the `x` modifier (`FILTRULE_XATTR`) matches ONLY when the candidate
+//! is an xattr name (`NAME_IS_XATTR`), and a rule WITHOUT `x` never participates
+//! in xattr-name matching. These rules are therefore kept out of the ordinary
+//! path include/exclude chain and evaluated separately, first-match-wins,
+//! against xattr names alone (upstream: xattrs.c:250 rsync_xal_get() consults
+//! `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)`).
+
+use std::path::Path;
+
+use super::pattern::{CompiledPattern, compile_patterns};
+use crate::{FilterAction, FilterError, FilterRule};
+
+/// A compiled `x`-modifier filter rule matched against xattr names only.
+///
+/// Only include/exclude actions carry meaning for xattr-name filtering; the
+/// deletion (protect/risk) and meta (clear/merge) actions never reach this list
+/// because upstream's xattr filter dispatch is a plain include/exclude decision.
+#[derive(Debug)]
+pub(crate) struct CompiledXattrRule {
+    action: FilterAction,
+    matchers: Vec<CompiledPattern>,
+    negate: bool,
+}
+
+impl CompiledXattrRule {
+    /// Compiles an `x`-modifier [`FilterRule`] into an xattr-name matcher.
+    ///
+    /// The pattern is matched exactly as upstream matches an xattr name: the
+    /// name has no path separators, so no anchoring or descendant expansion is
+    /// applied - only the interior-`**` normalisation shared with ordinary
+    /// rules (via [`compile_patterns`]) is used so wildcard semantics stay in
+    /// lockstep with the path chain.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the pattern is not a valid glob.
+    pub(crate) fn new(rule: FilterRule) -> Result<Self, FilterError> {
+        debug_assert!(rule.xattr_only, "non-xattr rule compiled as xattr rule");
+        let mut patterns = std::collections::HashSet::with_capacity(1);
+        patterns.insert(rule.pattern.clone());
+        let matchers = compile_patterns(patterns, &rule.pattern, false)?;
+        Ok(Self {
+            action: rule.action,
+            matchers,
+            negate: rule.negate,
+        })
+    }
+
+    /// Returns the rule's action, used to resolve the first-match-wins decision.
+    pub(crate) const fn action(&self) -> FilterAction {
+        self.action
+    }
+
+    /// Tests whether `name` matches this rule, honouring the `!` negate modifier.
+    ///
+    /// upstream: exclude.c:906 - `ret_match = FILTRULE_NEGATE ? 0 : 1`.
+    pub(crate) fn matches(&self, name: &str) -> bool {
+        let candidate = Path::new(name);
+        let matched = self.matchers.iter().any(|m| m.is_match(candidate));
+        matched ^ self.negate
+    }
+}

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -2,17 +2,44 @@ use std::path::Path;
 
 use logging::debug_log;
 
-use crate::{FilterAction, compiled::CompiledRule};
+use crate::{
+    FilterAction,
+    compiled::{CompiledRule, CompiledXattrRule},
+};
 
 /// Internal rule storage shared by [`FilterSet`](crate::FilterSet) instances.
 ///
-/// Maintains two independent rule chains following the Chain of Responsibility
-/// pattern. Each chain is evaluated with first-match-wins semantics, mirroring
-/// upstream rsync's `check_filter()` in `exclude.c`.
+/// Maintains three independent rule chains following the Chain of
+/// Responsibility pattern. Each chain is evaluated with first-match-wins
+/// semantics, mirroring upstream rsync's `check_filter()` in `exclude.c`.
+///
+/// - `include_exclude` / `protect_risk` govern path (file) decisions.
+/// - `xattr` holds `x`-modifier rules that govern xattr-name decisions only,
+///   kept separate because upstream `exclude.c:914` never matches an
+///   `x`-modifier rule against a path nor an ordinary rule against an xattr
+///   name.
 #[derive(Debug, Default)]
 pub(crate) struct FilterSetInner {
     pub(crate) include_exclude: Vec<CompiledRule>,
     pub(crate) protect_risk: Vec<CompiledRule>,
+    pub(crate) xattr: Vec<CompiledXattrRule>,
+}
+
+impl FilterSetInner {
+    /// Resolves whether an xattr `name` is allowed by the `x`-modifier rules.
+    ///
+    /// Evaluates the xattr chain first-match-wins and returns the matching
+    /// rule's include/exclude verdict; with no match the name is included by
+    /// default. Mirrors upstream `exclude.c:name_is_excluded(name,
+    /// NAME_IS_XATTR, ALL_FILTERS)` consulted from `xattrs.c:250`.
+    pub(crate) fn xattr_name_allowed(&self, name: &str) -> bool {
+        for rule in &self.xattr {
+            if rule.matches(name) {
+                return matches!(rule.action(), FilterAction::Include);
+            }
+        }
+        true
+    }
 }
 
 impl FilterSetInner {

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use crate::{
     FilterAction, FilterError, FilterRule, MergeFileError,
     apple_double::default_patterns as apple_double_default_patterns,
-    compiled::{CompiledRule, apply_clear_rule},
+    compiled::{CompiledRule, CompiledXattrRule, apply_clear_rule},
     cvs::default_patterns as cvs_default_patterns,
     decision::{DecisionContext, FilterSetInner},
     merge::{read_rules_recursive, scope_local_clear},
@@ -87,9 +87,17 @@ impl FilterSet {
     {
         let mut include_exclude = Vec::new();
         let mut protect_risk = Vec::new();
+        let mut xattr = Vec::new();
 
         for rule in rules.into_iter() {
+            // upstream: exclude.c:914 rule_matches() - an `x`-modifier rule
+            // matches xattr names only, never a path. Route it into its own
+            // chain instead of dropping it so `--filter='-x user.foo'` can be
+            // honoured by xattr-name matching (upstream: xattrs.c:250).
             if rule.is_xattr_only() {
+                if matches!(rule.action, FilterAction::Include | FilterAction::Exclude) {
+                    xattr.push(CompiledXattrRule::new(rule)?);
+                }
                 continue;
             }
             match rule.action {
@@ -110,6 +118,9 @@ impl FilterSet {
                         rule.applies_to_sender,
                         rule.applies_to_receiver,
                     );
+                    // upstream: exclude.c:pop_filter_list() clears the whole
+                    // active section, including any xattr-name rules.
+                    xattr.clear();
                 }
                 FilterAction::Merge | FilterAction::DirMerge => {}
             }
@@ -119,6 +130,7 @@ impl FilterSet {
             inner: Arc::new(FilterSetInner {
                 include_exclude,
                 protect_risk,
+                xattr,
             }),
         })
     }
@@ -128,7 +140,32 @@ impl FilterSet {
     /// An empty filter set allows all paths and all deletions.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.inner.include_exclude.is_empty() && self.inner.protect_risk.is_empty()
+        self.inner.include_exclude.is_empty()
+            && self.inner.protect_risk.is_empty()
+            && self.inner.xattr.is_empty()
+    }
+
+    /// Returns `true` when the set carries any `x`-modifier (xattr-name) rules.
+    ///
+    /// Callers gate xattr-name filtering on this so a transfer without any `x`
+    /// rules keeps upstream's "no `saw_xattr_filter`" fast path (upstream:
+    /// xattrs.c:250 only calls `name_is_excluded` when `saw_xattr_filter`).
+    #[must_use]
+    pub fn has_xattr_rules(&self) -> bool {
+        !self.inner.xattr.is_empty()
+    }
+
+    /// Returns `true` when the extended-attribute `name` is allowed by the
+    /// `x`-modifier rules.
+    ///
+    /// Only rules carrying the `x` modifier participate; ordinary path rules
+    /// never affect the verdict. Evaluation is first-match-wins and a name that
+    /// matches no rule is allowed. Mirrors upstream rsync's
+    /// `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)` (exclude.c:914,
+    /// consulted from xattrs.c:250).
+    #[must_use]
+    pub fn xattr_name_allowed(&self, name: &str) -> bool {
+        self.inner.xattr_name_allowed(name)
     }
 
     /// Returns `true` if the path should be included in the transfer.
@@ -745,5 +782,63 @@ mod tests {
         assert!(!set.allows(Path::new("new/lose/this"), false));
         // A file named "new/lose" is still allowed (directory-only match).
         assert!(set.allows(Path::new("new/lose"), false));
+    }
+
+    /// upstream: exclude.c:914 - rule_matches() gates every rule on
+    /// `!(name_flags & NAME_IS_XATTR) ^ !(ex->rflags & FILTRULE_XATTR)`. An
+    /// `x`-modifier rule must match xattr NAMES (and only xattr names), so a
+    /// `-x user.foo` rule excludes the `user.foo` xattr during an `-X`
+    /// transfer. This regression-guards FLT-1, where `x`-modifier rules were
+    /// silently dropped from the compiled set and the xattr filter was a no-op.
+    #[test]
+    fn xattr_modifier_rule_excludes_matching_xattr_name() {
+        let set =
+            FilterSet::from_rules([FilterRule::exclude("user.foo").with_xattr_only(true)]).unwrap();
+
+        assert!(set.has_xattr_rules());
+        // The named xattr is excluded...
+        assert!(!set.xattr_name_allowed("user.foo"));
+        // ...while an unrelated xattr name is still allowed (default include).
+        assert!(set.xattr_name_allowed("user.bar"));
+        // ...and the rule must NOT leak into path matching: a *file* called
+        // "user.foo" is unaffected by the xattr-only rule.
+        assert!(set.allows(Path::new("user.foo"), false));
+    }
+
+    /// upstream: exclude.c:914 - the include (`+x`) variant makes an otherwise
+    /// excluded xattr name pass, first-match-wins.
+    #[test]
+    fn xattr_modifier_include_wins_over_later_exclude() {
+        let set = FilterSet::from_rules([
+            FilterRule::include("user.keep").with_xattr_only(true),
+            FilterRule::exclude("user.*").with_xattr_only(true),
+        ])
+        .unwrap();
+
+        assert!(set.xattr_name_allowed("user.keep"));
+        assert!(!set.xattr_name_allowed("user.drop"));
+    }
+
+    /// upstream: exclude.c:914 - a rule WITHOUT the `x` modifier never
+    /// participates in xattr-name matching. It governs paths only.
+    #[test]
+    fn plain_rule_does_not_affect_xattr_names() {
+        let set = FilterSet::from_rules([FilterRule::exclude("user.foo")]).unwrap();
+
+        assert!(!set.has_xattr_rules());
+        // The plain rule excludes the *file* path "user.foo"...
+        assert!(!set.allows(Path::new("user.foo"), false));
+        // ...but leaves the xattr NAME "user.foo" allowed - no `x` modifier.
+        assert!(set.xattr_name_allowed("user.foo"));
+    }
+
+    /// An empty set (or one with only path rules) allows every xattr name and
+    /// reports no xattr rules, so callers keep upstream's `saw_xattr_filter`
+    /// fast path.
+    #[test]
+    fn xattr_name_allowed_defaults_to_true() {
+        let set = FilterSet::default();
+        assert!(!set.has_xattr_rules());
+        assert!(set.xattr_name_allowed("user.anything"));
     }
 }

--- a/crates/filters/tests/edge_cases.rs
+++ b/crates/filters/tests/edge_cases.rs
@@ -480,17 +480,24 @@ fn many_rules() {
     assert!(set.allows(Path::new("file1001.txt"), false));
 }
 
-/// Verifies xattr_only rules are filtered out.
+/// Verifies xattr_only rules apply to xattr names, not file paths.
+///
+/// upstream: exclude.c:914 - an `x`-modifier rule matches xattr NAMES only
+/// (NAME_IS_XATTR), never a file path.
 #[test]
-fn xattr_only_rules_filtered() {
+fn xattr_only_rules_apply_to_names_not_paths() {
     let rule = FilterRule::exclude("*.xattr").with_xattr_only(true);
     let set = FilterSet::from_rules([rule]).unwrap();
 
-    // XAttr-only rules are filtered out during compilation
-    assert!(set.is_empty());
+    // The rule is retained as an xattr-name rule, so the set is not empty.
+    assert!(!set.is_empty());
+    assert!(set.has_xattr_rules());
 
-    // So the pattern doesn't affect file matching
+    // The xattr-only rule does not affect file (path) matching...
     assert!(set.allows(Path::new("file.xattr"), false));
+    // ...but it does exclude a matching xattr NAME.
+    assert!(!set.xattr_name_allowed("user.xattr"));
+    assert!(set.xattr_name_allowed("user.keep"));
 }
 
 /// Verifies Unicode patterns.


### PR DESCRIPTION
## Summary

Filter rules carrying the `x` modifier (xattr-name matching) were silently
dropped when compiling a `FilterSet`: `set.rs` skipped every `is_xattr_only()`
rule during compilation, so `--filter='-x user.foo'` (and its `+x` include
variant) had no effect on the wire transfer path. Upstream evaluates these
rules against xattr NAMES during an `-X` transfer and keeps ordinary path rules
out of that decision (`exclude.c:914` gates every rule on
`!(name_flags & NAME_IS_XATTR) ^ !(ex->rflags & FILTRULE_XATTR)`; consulted from
`xattrs.c:250` via `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)`).

This change stops dropping the rules and instead routes them into a dedicated
xattr-name chain, exposing a focused public API mirroring upstream's
`FILTRULE_XATTR` path.

## Changes

- `compiled/xattr.rs` (new): `CompiledXattrRule`, an `x`-modifier rule compiled
  into an xattr-name matcher. Reuses the crate's existing `compile_patterns`
  (wildmatch semantics) so wildcard behaviour stays in lockstep with the path
  chain. No path anchoring or descendant expansion - xattr names are flat.
- `decision.rs`: `FilterSetInner` gains an `xattr` chain plus a first-match-wins
  `xattr_name_allowed()` resolver.
- `set.rs`: `from_rules` retains `x`-modifier include/exclude rules instead of
  dropping them; a `!` clear rule also clears the xattr chain. New public
  `FilterSet::has_xattr_rules()` and `FilterSet::xattr_name_allowed()`.
- Tests: WHY-tests proving `-x user.foo` excludes the `user.foo` xattr name, the
  `+x` include variant wins first-match-wins, a rule WITHOUT `x` never affects
  xattr-name matching (and still governs paths), and an `x`-only rule never
  leaks into path matching. Updated the existing edge-case test that encoded the
  old drop behaviour.

## Behaviour parity

- `exclude.c:914` - `x`-modifier rules match xattr names only; plain rules never
  do.
- `xattrs.c:250` - `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)` is only
  consulted when xattr filters are present; `has_xattr_rules()` preserves that
  fast path for callers.

## Scope

The local-copy engine already evaluates `x`-modifier rules through its separate
`FilterProgram::allows_xattr` path, so this gap only affected the wire
(`FilterSet`) path. This change fixes the root cause (rules were dropped) and
provides the xattr-name matching entry point. Consuming the new API at the wire
sender/receiver xattr read/apply sites (`read_xattrs_for_wire` /
`apply_xattrs_from_list`) is a separate, larger follow-up: it requires signature
changes across those metadata functions and their transfer callers.

## Testing

- `cargo fmt --all`
- `cargo clippy -p filters --all-features --all-targets --no-deps -- -D warnings`
- `cargo nextest run -p filters --all-features` - 1417 passed
