### PR TITLE
fix(protocol): reject out-of-range ACL access bits

### DIFF
--- a/crates/protocol/src/acl/wire/encoding.rs
+++ b/crates/protocol/src/acl/wire/encoding.rs
@@ -3,9 +3,11 @@
 //! Access bits are shifted left by 2, with the lower 2 bits used as flags.
 //! This keeps high bits clear for efficient varint encoding.
 
+use std::io;
+
 use super::super::constants::{NAME_IS_USER, XFLAG_NAME_FOLLOWS, XFLAG_NAME_IS_USER};
 
-use crate::acl::constants::ACCESS_SHIFT;
+use crate::acl::constants::{ACCESS_SHIFT, ACL_VALID_NAME_BITS, ACL_VALID_OBJ_BITS};
 
 /// Encodes access permission bits for wire transmission.
 ///
@@ -34,30 +36,65 @@ pub(crate) fn encode_access(access: u32, include_name: bool) -> u32 {
     encoded
 }
 
-/// Decodes access permission bits from wire format.
+/// Decodes and validates access permission bits from wire format.
 ///
-/// Extracts the flags from lower 2 bits and shifts to get permission bits.
+/// For named entries the flags occupy the lower 2 bits and the permission
+/// bits are shifted down; for object entries the value is the raw permission
+/// mask. In both cases the permission bits are validated against the valid
+/// range before use, rejecting an out-of-range peer value.
 ///
 /// # Returns
 ///
 /// Tuple of (access_with_flags, name_follows) where access_with_flags
-/// has `NAME_IS_USER` set if the entry is for a user.
+/// has `NAME_IS_USER` set if the entry is for a user. `name_follows` is
+/// always `false` for object entries.
+///
+/// # Errors
+///
+/// Returns an `InvalidData` error - which the core exit-code mapper renders as
+/// `RERR_STREAMIO` (exit 12) - when the permission bits fall outside the valid
+/// range, mirroring upstream's `exit_cleanup(RERR_STREAMIO)`.
 ///
 /// # Upstream Reference
 ///
-/// Mirrors `recv_acl_access()` in `acls.c` lines 672-695.
-pub(crate) fn decode_access(encoded: u32, is_name_entry: bool) -> (u32, bool) {
+/// Mirrors `recv_acl_access()` in `acls.c` lines 672-695: named entries are
+/// checked against `SMB_ACL_VALID_NAME_BITS` and object entries against
+/// `SMB_ACL_VALID_OBJ_BITS`, both `(4|2|1)` for POSIX ACLs.
+pub(crate) fn decode_access(encoded: u32, is_name_entry: bool) -> io::Result<(u32, bool)> {
     if is_name_entry {
         let flags = encoded & 0x03;
         let mut access = encoded >> ACCESS_SHIFT;
+
+        // upstream: acls.c:679 rejects `access & ~SMB_ACL_VALID_NAME_BITS`
+        // after the shift, before folding in NAME_IS_USER.
+        if access & !ACL_VALID_NAME_BITS != 0 {
+            return Err(access_value_error(access));
+        }
 
         let name_follows = flags & XFLAG_NAME_FOLLOWS != 0;
         if flags & XFLAG_NAME_IS_USER != 0 {
             access |= NAME_IS_USER;
         }
 
-        (access, name_follows)
+        Ok((access, name_follows))
     } else {
-        (encoded, false)
+        // upstream: acls.c:687 rejects `access & ~SMB_ACL_VALID_OBJ_BITS`.
+        if encoded & !ACL_VALID_OBJ_BITS != 0 {
+            return Err(access_value_error(encoded));
+        }
+        Ok((encoded, false))
     }
+}
+
+/// Builds the out-of-range access-bit error.
+///
+/// upstream: acls.c:688-691 `recv_acl_access()` prints "value out of range"
+/// and calls `exit_cleanup(RERR_STREAMIO)`. A bare `InvalidData` io::Error maps
+/// to `RERR_STREAMIO` (exit 12) via the core exit-code mapper
+/// (`exit_code/codes.rs`), so no dedicated error variant is introduced.
+fn access_value_error(access: u32) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("recv_acl_access: value out of range: {access:x}"),
+    )
 }

--- a/crates/protocol/src/acl/wire/recv.rs
+++ b/crates/protocol/src/acl/wire/recv.rs
@@ -43,7 +43,7 @@ pub fn recv_ida_entries<R: Read + ?Sized>(reader: &mut R) -> io::Result<(IdaEntr
         let id = read_varint(reader)? as u32;
         let encoded = read_varint(reader)? as u32;
 
-        let (access, name_follows) = decode_access(encoded, true);
+        let (access, name_follows) = decode_access(encoded, true)?;
 
         // upstream: acls.c recv_ida_entries() reads name bytes after access
         let name = if name_follows {
@@ -62,6 +62,22 @@ pub fn recv_ida_entries<R: Read + ?Sized>(reader: &mut R) -> io::Result<(IdaEntr
     }
 
     Ok((entries, computed_mask & !NO_ENTRY))
+}
+
+/// Reads and validates a single object-entry access value from the wire.
+///
+/// Object entries (`user_obj`, `group_obj`, `mask_obj`, `other_obj`) carry a
+/// raw permission mask that must fall within the valid range; an out-of-range
+/// peer value surfaces `RERR_STREAMIO` (exit 12) rather than being silently
+/// truncated to `u8`.
+///
+/// # Upstream Reference
+///
+/// Mirrors the `recv_acl_access(f, NULL)` calls in `acls.c` lines 753-760.
+fn recv_obj_access<R: Read + ?Sized>(reader: &mut R) -> io::Result<u8> {
+    let encoded = read_varint(reader)? as u32;
+    let (access, _) = decode_access(encoded, false)?;
+    Ok(access as u8)
 }
 
 /// Receives an rsync ACL from the wire.
@@ -99,16 +115,16 @@ pub fn recv_rsync_acl<R: Read + ?Sized>(
     let mut acl = RsyncAcl::new();
 
     if flags & XMIT_USER_OBJ != 0 {
-        acl.user_obj = read_varint(reader)? as u8;
+        acl.user_obj = recv_obj_access(reader)?;
     }
     if flags & XMIT_GROUP_OBJ != 0 {
-        acl.group_obj = read_varint(reader)? as u8;
+        acl.group_obj = recv_obj_access(reader)?;
     }
     if flags & XMIT_MASK_OBJ != 0 {
-        acl.mask_obj = read_varint(reader)? as u8;
+        acl.mask_obj = recv_obj_access(reader)?;
     }
     if flags & XMIT_OTHER_OBJ != 0 {
-        acl.other_obj = read_varint(reader)? as u8;
+        acl.other_obj = recv_obj_access(reader)?;
     }
     if flags & XMIT_NAME_LIST != 0 {
         let (entries, computed_mask) = recv_ida_entries(reader)?;

--- a/crates/protocol/src/acl/wire/tests.rs
+++ b/crates/protocol/src/acl/wire/tests.rs
@@ -12,13 +12,14 @@ use crate::acl::constants::{
     XMIT_USER_OBJ,
 };
 use crate::acl::entry::{AclCache, IdAccess, IdaEntries, RsyncAcl};
+use crate::varint::write_varint;
 
 #[test]
 fn encode_decode_access_roundtrip() {
     // User entry with rwx
     let access = 0x07 | NAME_IS_USER;
     let encoded = encode_access(access, false);
-    let (decoded, name_follows) = decode_access(encoded, true);
+    let (decoded, name_follows) = decode_access(encoded, true).unwrap();
     assert_eq!(decoded & !NAME_IS_USER, access & !NAME_IS_USER);
     assert!(decoded & NAME_IS_USER != 0);
     assert!(!name_follows);
@@ -26,7 +27,7 @@ fn encode_decode_access_roundtrip() {
     // Group entry with rx
     let access = 0x05;
     let encoded = encode_access(access, true);
-    let (decoded, name_follows) = decode_access(encoded, true);
+    let (decoded, name_follows) = decode_access(encoded, true).unwrap();
     assert_eq!(decoded, access);
     assert!(name_follows);
 }
@@ -196,7 +197,7 @@ fn encode_access_all_permission_bits() {
     // Test all permission combinations
     for perms in 0..=7 {
         let encoded = encode_access(perms, false);
-        let (decoded, _) = decode_access(encoded, true);
+        let (decoded, _) = decode_access(encoded, true).unwrap();
         assert_eq!(
             decoded & !NAME_IS_USER,
             perms,
@@ -214,7 +215,7 @@ fn encode_access_name_is_user_flag() {
     assert!(encoded & XFLAG_NAME_FOLLOWS != 0);
     assert!(encoded & XFLAG_NAME_IS_USER != 0);
 
-    let (decoded, name_follows) = decode_access(encoded, true);
+    let (decoded, name_follows) = decode_access(encoded, true).unwrap();
     assert!(name_follows);
     assert!(decoded & NAME_IS_USER != 0);
     assert_eq!(decoded & !NAME_IS_USER, 0x05);
@@ -222,11 +223,52 @@ fn encode_access_name_is_user_flag() {
 
 #[test]
 fn decode_access_non_name_entry() {
-    // Non-name entries return the raw value without flag interpretation
-    let value = 0x1234;
-    let (decoded, name_follows) = decode_access(value, false);
+    // Object entries return the raw permission mask without flag interpretation.
+    let value = 0x05;
+    let (decoded, name_follows) = decode_access(value, false).unwrap();
     assert_eq!(decoded, value);
     assert!(!name_follows);
+}
+
+#[test]
+fn decode_access_named_out_of_range_is_stream_io() {
+    // upstream: acls.c:672-695 recv_acl_access() rejects a named entry whose
+    // shifted permission bits exceed SMB_ACL_VALID_NAME_BITS (rwx = 0x07) via
+    // rprintf(FERROR_XFER) + exit_cleanup(RERR_STREAMIO). A bare InvalidData
+    // io::Error maps to RERR_STREAMIO (exit 12) in the core exit-code mapper.
+    // WHY this matters: without the range check the extra bit is silently
+    // truncated by `as u8`, corrupting the applied ACL instead of aborting the
+    // transfer as upstream does.
+    let out_of_range_perms = 0x08; // bit 3 is outside rwx
+    let encoded = out_of_range_perms << ACCESS_SHIFT;
+
+    let err = decode_access(encoded, true).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn decode_access_object_out_of_range_is_stream_io() {
+    // upstream: acls.c:687-692 recv_acl_access() rejects an object entry whose
+    // bits exceed SMB_ACL_VALID_OBJ_BITS (0x07) with exit_cleanup(RERR_STREAMIO).
+    let err = decode_access(0x08, false).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn recv_ida_entries_out_of_range_access_is_stream_io() {
+    // upstream: acls.c:672-695 recv_acl_access() (called from recv_ida_entries,
+    // acls.c:708) aborts with RERR_STREAMIO on an out-of-range named-entry
+    // access value. Drive the full wire decode to prove the error surfaces from
+    // the receive path, not just the pure decoder. An out-of-range value must
+    // yield the InvalidData -> RERR_STREAMIO (exit 12) error, never a silent
+    // `as u8` truncation.
+    let mut wire = Vec::new();
+    write_varint(&mut wire, 1).unwrap(); // one named entry
+    write_varint(&mut wire, 1000).unwrap(); // id
+    write_varint(&mut wire, 0x08i32 << ACCESS_SHIFT).unwrap(); // out-of-range perms
+
+    let err = recv_ida_entries(&mut Cursor::new(wire)).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Harden the ACL receive path against out-of-range access bits. A received
named- or object-entry access value that carried bits outside the valid
permission range (`rwx` = `0x07`) was narrowed with `as u8` and silently
truncated, corrupting the applied ACL instead of aborting the transfer.

Upstream `recv_acl_access()` (`acls.c:672-695`) rejects such values:

```c
if (name_follows_ptr) {
    int flags = access & 3;
    access >>= 2;
    if (am_root >= 0 && access & ~SMB_ACL_VALID_NAME_BITS)
        goto value_error;
    ...
} else if (am_root >= 0 && access & ~SMB_ACL_VALID_OBJ_BITS) {
  value_error:
    rprintf(FERROR_XFER, "recv_acl_access: value out of range: %x\n", access);
    exit_cleanup(RERR_STREAMIO);
}
```

with `SMB_ACL_VALID_NAME_BITS` / `SMB_ACL_VALID_OBJ_BITS` both `(4|2|1)`
(`lib/sysacls.h:62-63`).

## Changes

- `decode_access()` now validates the decoded permission bits against
  `ACL_VALID_NAME_BITS` (named entries, after the shift) and
  `ACL_VALID_OBJ_BITS` (object entries), wiring in the two previously
  dead constants. It returns `io::Result`, and an out-of-range value
  yields an `InvalidData` error.
- Object entries (`user_obj`, `group_obj`, `mask_obj`, `other_obj`) are now
  read through a shared `recv_obj_access()` helper that applies the same
  validation, mirroring upstream's `recv_acl_access(f, NULL)` calls
  (`acls.c:753-760`).
- The `InvalidData` error maps to `RERR_STREAMIO` (exit 12) via the existing
  exit-code mapper (`ErrorKind::InvalidData => StreamIo`), matching upstream's
  `exit_cleanup(RERR_STREAMIO)`. No new error variant was introduced.

## Tests

New WHY tests assert that an out-of-range access value produces the
`InvalidData` -> `RERR_STREAMIO` (exit 12) error rather than a silent `as u8`
truncation, covering the pure decoder (named and object entries) and the full
`recv_ida_entries` wire path. These fail against the previous truncating code
and pass after the fix. All references cite `acls.c:672-695`.

## Verification

- `cargo fmt --all`
- `cargo clippy -p protocol --all-features --all-targets --no-deps -- -D warnings`
- `cargo nextest run -p protocol --all-features -E 'test(acl)'` (215 passed)
