### PR TITLE
fix(cli): forward -C, --skip-compress, -XX/-UU server args

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -294,7 +294,10 @@ pub struct ParsedArgs {
     pub omit_link_times: Option<bool>,
 
     /// `--atimes`, `-U` / `--no-atimes` - preserve access times.
-    pub atimes: Option<bool>,
+    ///
+    /// Level: `Some(1)` for `-U`, `Some(2)` for `-UU`, `Some(0)` for
+    /// `--no-atimes`, `None` when unset.
+    pub atimes: Option<u8>,
 
     /// `--crtimes`, `-N` / `--no-crtimes` - preserve creation times (macOS/Windows).
     pub crtimes: Option<bool>,
@@ -303,7 +306,10 @@ pub struct ParsedArgs {
     pub acls: Option<bool>,
 
     /// `--xattrs`, `-X` / `--no-xattrs` - preserve extended attributes.
-    pub xattrs: Option<bool>,
+    ///
+    /// Level: `Some(1)` for `-X`, `Some(2)` for `-XX`, `Some(0)` for
+    /// `--no-xattrs`, `None` when unset.
+    pub xattrs: Option<u8>,
 
     /// `--numeric-ids` / `--no-numeric-ids` - use numeric uid/gid instead of names.
     pub numeric_ids: Option<bool>,

--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -23,7 +23,9 @@ use core::client::{
 
 use super::coerce::{parse_checksum_threads, parse_spill_threshold_bytes, parse_thread_count};
 use super::cow::{last_occurrence, parse_reflink_mode, resolve_cow_policy};
-use super::flags::{tri_state_flag_negative_first, tri_state_flag_positive_first};
+use super::flags::{
+    leveled_flag_pair, tri_state_flag_negative_first, tri_state_flag_positive_first,
+};
 use super::values::join_os_values;
 use super::{BandwidthArgument, ParsedArgs, detect_program_name, env_protect_args_default};
 
@@ -133,7 +135,7 @@ where
         tri_state_flag_negative_first(&matches, "prune-empty-dirs", "no-prune-empty-dirs");
     let omit_link_times =
         tri_state_flag_negative_first(&matches, "omit-link-times", "no-omit-link-times");
-    let atimes = tri_state_flag_negative_first(&matches, "atimes", "no-atimes");
+    let atimes = leveled_flag_pair(&matches, "atimes", "no-atimes");
     let crtimes = tri_state_flag_negative_first(&matches, "crtimes", "no-crtimes");
     // upstream: options.c:2366-2367 - only `dry_run` sets `do_xfers = 0` (and
     // thus the compact `n` letter); `list_only` does NOT (options.c:2634 "Note:
@@ -413,7 +415,7 @@ where
     let omit_dir_times =
         tri_state_flag_positive_first(&matches, "omit-dir-times", "no-omit-dir-times");
     let acls = tri_state_flag_positive_first(&matches, "acls", "no-acls");
-    let xattrs = tri_state_flag_positive_first(&matches, "xattrs", "no-xattrs");
+    let xattrs = leveled_flag_pair(&matches, "xattrs", "no-xattrs");
     let numeric_ids = tri_state_flag_positive_first(&matches, "numeric-ids", "no-numeric-ids");
     let hard_links = tri_state_flag_positive_first(&matches, "hard-links", "no-hard-links");
     let links = tri_state_flag_positive_first(&matches, "links", "no-links");

--- a/crates/cli/src/frontend/arguments/parser/flags.rs
+++ b/crates/cli/src/frontend/arguments/parser/flags.rs
@@ -74,3 +74,32 @@ fn tri_state_flag_with_order(
 fn last_occurrence(matches: &clap::ArgMatches, id: &str) -> Option<usize> {
     matches.indices_of(id).and_then(Iterator::max)
 }
+
+/// Resolves a repeatable positive flag paired with a `--no-` negative into a
+/// preservation level (0, 1, or 2).
+///
+/// The positive flag must use `ArgAction::Count` and mutually `overrides_with`
+/// the negative so clap's left-to-right resolution already reflects the winner:
+/// a later `--no-foo` clears the count, and a later `-ff` clears the negation.
+/// This mirrors upstream rsync's popt processing where `--foo` does `level++`
+/// and `--no-foo` resets `level = 0` (e.g. options.c:1585 `++preserve_atimes`,
+/// options.c:1877 `preserve_xattrs++`). The level is capped at 2 because that is
+/// the highest doubled letter upstream `server_options()` emits.
+///
+/// Returns `None` when neither flag is present, so callers can distinguish
+/// "unset" from an explicit `--no-foo` (`Some(0)`).
+pub(crate) fn leveled_flag_pair(
+    matches: &clap::ArgMatches,
+    positive: &str,
+    negative: &str,
+) -> Option<u8> {
+    let count = matches.get_count(positive);
+    let negated = matches.get_flag(negative);
+    if count > 0 {
+        Some(count.min(2))
+    } else if negated {
+        Some(0)
+    } else {
+        None
+    }
+}

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -244,7 +244,24 @@ mod short_options {
     #[test]
     fn atimes_short_flag() {
         let parsed = parse_test_args(["-U", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.atimes, Some(true));
+        assert_eq!(parsed.atimes, Some(1));
+    }
+
+    // upstream: options.c:1585 `if (++preserve_atimes > 1)` - a doubled `-UU`
+    // raises the level to 2, which server_options() forwards as `-UU`. Modelled
+    // as a count so the emitted server args match a real `rsync -UU`.
+    #[test]
+    fn atimes_double_short_flag_is_level_two() {
+        let parsed = parse_test_args(["-UU", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.atimes, Some(2));
+    }
+
+    // upstream: options.c:1877 `preserve_xattrs++` - a doubled `-XX` raises the
+    // level to 2, forwarded as `-XX`.
+    #[test]
+    fn xattrs_double_short_flag_is_level_two() {
+        let parsed = parse_test_args(["-XX", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.xattrs, Some(2));
     }
 
     #[test]
@@ -262,7 +279,7 @@ mod short_options {
     #[test]
     fn xattrs_short_flag() {
         let parsed = parse_test_args(["-X", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.xattrs, Some(true));
+        assert_eq!(parsed.xattrs, Some(1));
     }
 
     #[test]
@@ -2766,7 +2783,7 @@ mod time_option_tests {
     #[test]
     fn no_atimes_flag() {
         let parsed = parse_test_args(["--no-atimes", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.atimes, Some(false));
+        assert_eq!(parsed.atimes, Some(0));
     }
 
     #[test]
@@ -2938,7 +2955,7 @@ mod acls_xattrs_tests {
     #[test]
     fn no_xattrs_flag() {
         let parsed = parse_test_args(["--no-xattrs", "src/", "dst/"]).expect("parse");
-        assert_eq!(parsed.xattrs, Some(false));
+        assert_eq!(parsed.xattrs, Some(0));
     }
 }
 

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -843,8 +843,8 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                 Arg::new("atimes")
                     .long("atimes")
                     .short('U')
-                    .help("Preserve access times.")
-                    .action(ArgAction::SetTrue)
+                    .help("Preserve access times. Specify twice (-UU) to also preserve directory access times.")
+                    .action(ArgAction::Count)
                     .overrides_with("no-atimes"),
             )
             .arg(
@@ -891,8 +891,8 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                 Arg::new("xattrs")
                     .long("xattrs")
                     .short('X')
-                    .help("Preserve extended attributes when supported.")
-                    .action(ArgAction::SetTrue)
+                    .help("Preserve extended attributes when supported. Specify twice (-XX) to also transfer xattrs in a fake-super store.")
+                    .action(ArgAction::Count)
                     .overrides_with("no-xattrs"),
             )
             .arg(

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -76,7 +76,8 @@ pub(crate) struct ConfigInputs {
     /// Explicit `--super` request (upstream `am_root > 1`), forwarded on push.
     pub(crate) super_user: bool,
     pub(crate) times: bool,
-    pub(crate) atimes: bool,
+    /// Access-time preservation level (0 = off, 1 = `-U`, 2 = `-UU`).
+    pub(crate) atimes: u8,
     pub(crate) crtimes: bool,
     pub(crate) modify_window_setting: Option<i64>,
     pub(crate) omit_dir_times: bool,
@@ -155,9 +156,15 @@ pub(crate) struct ConfigInputs {
     pub(crate) link_destinations: Vec<OsString>,
     #[cfg(all(any(unix, windows), feature = "acl"))]
     pub(crate) preserve_acls: bool,
+    /// Extended-attribute preservation level (0 = off, 1 = `-X`, 2 = `-XX`).
     #[cfg(all(any(unix, windows), feature = "xattr"))]
-    pub(crate) xattrs: bool,
+    pub(crate) xattrs: u8,
     pub(crate) skip_compress_list: Option<SkipCompressList>,
+    /// Raw `--skip-compress` spec forwarded to the remote sender; `Some` only
+    /// when explicitly set.
+    pub(crate) skip_compress_spec: Option<String>,
+    /// `-C` / `--cvs-exclude` request, forwarded to the peer as the `C` letter.
+    pub(crate) cvs_exclude: bool,
     pub(crate) itemize_changes: bool,
     pub(crate) out_format_template: Option<crate::frontend::out_format::OutFormat>,
     pub(crate) log_file_template: Option<crate::frontend::out_format::OutFormat>,
@@ -396,6 +403,12 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
     if let Some(list) = inputs.skip_compress_list.take() {
         builder = builder.skip_compress(list);
     }
+
+    if let Some(spec) = inputs.skip_compress_spec.take() {
+        builder = builder.skip_compress_spec(Some(spec));
+    }
+
+    builder = builder.cvs_exclude(inputs.cvs_exclude);
 
     builder = match inputs.delete_mode {
         DeleteMode::Before => builder.delete_before(true),

--- a/crates/cli/src/frontend/execution/drive/metadata/compute.rs
+++ b/crates/cli/src/frontend/execution/drive/metadata/compute.rs
@@ -93,7 +93,7 @@ pub(crate) fn compute_metadata_settings(
     };
 
     let preserve_times = times.unwrap_or(archive);
-    let preserve_atimes = atimes.unwrap_or(false);
+    let preserve_atimes = atimes.unwrap_or(0) >= 1;
     let preserve_crtimes = crtimes.unwrap_or(false);
     let omit_dir_times_setting = omit_dir_times.unwrap_or(false);
     let omit_link_times_setting = omit_link_times.unwrap_or(false);

--- a/crates/cli/src/frontend/execution/drive/metadata/tests.rs
+++ b/crates/cli/src/frontend/execution/drive/metadata/tests.rs
@@ -186,7 +186,7 @@ fn atimes_defaults_to_false() {
 #[test]
 fn atimes_explicit_true() {
     let mut inputs = default_inputs();
-    inputs.atimes = Some(true);
+    inputs.atimes = Some(1);
     assert!(compute_metadata_settings(inputs).unwrap().preserve_atimes);
 }
 

--- a/crates/cli/src/frontend/execution/drive/metadata/types.rs
+++ b/crates/cli/src/frontend/execution/drive/metadata/types.rs
@@ -45,7 +45,8 @@ pub(crate) struct MetadataInputs<'a> {
     pub(crate) perms: Option<bool>,
     pub(crate) super_mode: Option<bool>,
     pub(crate) times: Option<bool>,
-    pub(crate) atimes: Option<bool>,
+    /// Access-time preservation level (0/1/2); `None` when unset.
+    pub(crate) atimes: Option<u8>,
     pub(crate) crtimes: Option<bool>,
     pub(crate) omit_dir_times: Option<bool>,
     pub(crate) omit_link_times: Option<bool>,

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -76,6 +76,9 @@ pub(crate) struct DerivedSettings {
     pub(crate) compress: bool,
     pub(crate) compression_level_override: Option<CompressionLevel>,
     pub(crate) skip_compress_list: Option<SkipCompressList>,
+    /// Raw `--skip-compress` spec forwarded to the remote sender; `Some` only
+    /// when explicitly set (CLI or `RSYNC_SKIP_COMPRESS`).
+    pub(crate) skip_compress_spec: Option<String>,
     pub(crate) compression_setting: CompressionSetting,
     pub(crate) compression_algorithm: Option<CompressionAlgorithm>,
     /// Raw `--compress-choice` name preserved for the `--debug=NSTR` summary
@@ -376,6 +379,7 @@ struct CompressionResult {
     compress: bool,
     compression_level_override: Option<CompressionLevel>,
     skip_compress_list: Option<SkipCompressList>,
+    skip_compress_spec: Option<String>,
     compression_setting: CompressionSetting,
     compression_algorithm: Option<CompressionAlgorithm>,
     /// Raw `--compress-choice` name (trimmed, lowercased) preserved for the
@@ -474,9 +478,18 @@ where
         compress_choice_name = None;
     }
 
+    // upstream: options.c:150 - the `skip_compress` global is NULL unless the
+    // `--skip-compress` option is given, and only that explicit value is
+    // forwarded to the remote sender (options.c:2858-2860). The
+    // `RSYNC_SKIP_COMPRESS` environment fallback is an oc extension that still
+    // applies locally, but - like upstream - it is not forwarded on the wire.
+    let mut skip_compress_spec = None;
     let skip_compress_list = if let Some(value) = skip_compress.as_ref() {
         match parse_skip_compress_list(value.as_os_str()) {
-            Ok(list) => Some(list),
+            Ok(list) => {
+                skip_compress_spec = Some(value.to_string_lossy().into_owned());
+                Some(list)
+            }
             Err(message) => return Err(fail_with_message(message, stderr)),
         }
     } else {
@@ -496,6 +509,7 @@ where
         compress,
         compression_level_override,
         skip_compress_list,
+        skip_compress_spec,
         compression_setting,
         compression_algorithm,
         compress_choice_name,
@@ -655,6 +669,7 @@ where
         compress: compression.compress,
         compression_level_override: compression.compression_level_override,
         skip_compress_list: compression.skip_compress_list,
+        skip_compress_spec: compression.skip_compress_spec,
         compression_setting: compression.compression_setting,
         compression_algorithm: compression.compression_algorithm,
         compress_choice_name: compression.compress_choice_name,

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -224,7 +224,7 @@ where
 /// Validates that requested ACL/xattr features are available on this platform.
 pub(crate) fn validate_feature_support<Err>(
     preserve_acls: bool,
-    xattrs: Option<bool>,
+    xattrs: Option<u8>,
     stderr: &mut MessageSink<Err>,
 ) -> Result<(), i32>
 where
@@ -242,7 +242,7 @@ where
     let _ = preserve_acls;
 
     #[cfg(not(all(any(unix, windows), feature = "xattr")))]
-    if xattrs.unwrap_or(false) {
+    if xattrs.unwrap_or(0) >= 1 {
         let message = rsync_error!(1, "extended attributes are not supported on this client")
             .with_role(Role::Client);
         let fallback = "extended attributes are not supported on this client".to_string();
@@ -281,7 +281,7 @@ mod tests {
     const ACL_REJECTION: &str = "POSIX ACLs are not supported on this client";
     const XATTR_REJECTION: &str = "extended attributes are not supported on this client";
 
-    fn assert_accepted(preserve_acls: bool, xattrs: Option<bool>, context: &str) {
+    fn assert_accepted(preserve_acls: bool, xattrs: Option<u8>, context: &str) {
         let mut sink = MessageSink::new(Vec::<u8>::new());
         let result = validate_feature_support(preserve_acls, xattrs, &mut sink);
         assert!(
@@ -298,7 +298,7 @@ mod tests {
     #[allow(dead_code)]
     fn assert_rejected_with(
         preserve_acls: bool,
-        xattrs: Option<bool>,
+        xattrs: Option<u8>,
         expected: &str,
         context: &str,
     ) {
@@ -321,7 +321,7 @@ mod tests {
     #[cfg(all(target_os = "linux", feature = "xattr"))]
     #[test]
     fn xattrs_accepted_on_linux_with_feature() {
-        assert_accepted(false, Some(true), "Linux + xattr feature");
+        assert_accepted(false, Some(1), "Linux + xattr feature");
     }
 
     /// Linux + `acl` feature: `--acls` accepted, no rejection emitted.
@@ -335,7 +335,7 @@ mod tests {
     #[cfg(all(target_os = "macos", feature = "xattr"))]
     #[test]
     fn xattrs_accepted_on_macos_with_feature() {
-        assert_accepted(false, Some(true), "macOS + xattr feature");
+        assert_accepted(false, Some(1), "macOS + xattr feature");
     }
 
     /// macOS + `acl` feature: `--acls` accepted, no rejection emitted.
@@ -351,7 +351,7 @@ mod tests {
     #[cfg(all(target_os = "windows", feature = "xattr"))]
     #[test]
     fn xattrs_accepted_on_windows_with_feature() {
-        assert_accepted(false, Some(true), "Windows + xattr feature");
+        assert_accepted(false, Some(1), "Windows + xattr feature");
     }
 
     /// Windows + `acl` feature: `--acls` accepted, no rejection emitted.
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn neither_flag_set_always_accepted() {
         assert_accepted(false, None, "neither flag set");
-        assert_accepted(false, Some(false), "xattrs=Some(false)");
+        assert_accepted(false, Some(0), "xattrs=Some(0)");
     }
 
     // --- Negative cases: feature absent, gate must reject ---
@@ -398,9 +398,9 @@ mod tests {
     fn xattrs_rejected_without_feature() {
         assert_rejected_with(
             false,
-            Some(true),
+            Some(1),
             XATTR_REJECTION,
-            "xattrs=Some(true) without xattr feature",
+            "xattrs=Some(1) without xattr feature",
         );
     }
 }

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -132,7 +132,7 @@ where
         include_from: _,
         filters: _,
         filter_order,
-        cvs_exclude: _,
+        cvs_exclude,
         apple_double_skip: _,
         rsync_filter_shortcuts: _,
         files_from,
@@ -442,6 +442,7 @@ where
         compress,
         compression_level_override,
         skip_compress_list,
+        skip_compress_spec,
         compression_setting,
         compression_algorithm,
         compress_choice_name,
@@ -878,7 +879,10 @@ where
         // --super (not by running as root). Forwarded on a push (options.c:2852).
         super_user: super_mode == Some(true),
         times: preserve_times,
-        atimes: preserve_atimes,
+        // The u8 level (0/1/2) drives the doubled `-UU` compact letter; the
+        // boolean `preserve_atimes` derived from it still governs local metadata
+        // application.
+        atimes: atimes.unwrap_or(0),
         crtimes: preserve_crtimes,
         modify_window_setting,
         omit_dir_times: omit_dir_times_setting,
@@ -950,8 +954,10 @@ where
         #[cfg(all(any(unix, windows), feature = "acl"))]
         preserve_acls,
         #[cfg(all(any(unix, windows), feature = "xattr"))]
-        xattrs: xattrs.unwrap_or(false),
+        xattrs: xattrs.unwrap_or(0),
         skip_compress_list,
+        skip_compress_spec,
+        cvs_exclude,
         itemize_changes,
         out_format_template: out_format_template.clone(),
         log_file_template,

--- a/crates/cli/src/frontend/tests/parse_args_recognises_no.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_no.rs
@@ -185,7 +185,7 @@ fn parse_args_negative_aliases_disable_flags() {
     assert_eq!(parsed.dirs, Some(false));
     assert_eq!(parsed.perms, Some(false));
     assert_eq!(parsed.acls, Some(false));
-    assert_eq!(parsed.xattrs, Some(false));
+    assert_eq!(parsed.xattrs, Some(0));
     assert_eq!(parsed.times, Some(false));
     assert_eq!(parsed.omit_dir_times, Some(false));
     assert_eq!(parsed.omit_link_times, Some(false));

--- a/crates/cli/tests/archive_flag_completeness.rs
+++ b/crates/cli/tests/archive_flag_completeness.rs
@@ -290,7 +290,7 @@ fn archive_does_not_enable_xattrs() {
     let args = parse_args(["oc-rsync", "-a", "src", "dest"]).unwrap();
     assert_ne!(
         args.xattrs,
-        Some(true),
+        Some(1),
         "-a should NOT enable extended attributes (requires -X)"
     );
 }
@@ -346,7 +346,7 @@ fn archive_with_acls() {
 fn archive_with_xattrs() {
     let args = parse_args(["oc-rsync", "-a", "-X", "src", "dest"]).unwrap();
     assert!(args.archive);
-    assert_eq!(args.xattrs, Some(true), "-X should enable xattrs with -a");
+    assert_eq!(args.xattrs, Some(1), "-X should enable xattrs with -a");
 }
 
 #[test]

--- a/crates/cli/tests/archive_mode.rs
+++ b/crates/cli/tests/archive_mode.rs
@@ -35,7 +35,7 @@ fn test_archive_does_not_enable_xattrs() {
     let args = parse_args(["oc-rsync", "-a", "src", "dest"]).unwrap();
     assert_ne!(
         args.xattrs,
-        Some(true),
+        Some(1),
         "-a should NOT imply -X (extended attributes)"
     );
 }
@@ -152,7 +152,7 @@ fn test_archive_with_acls() {
 fn test_archive_with_xattrs() {
     let args = parse_args(["oc-rsync", "-a", "-X", "src", "dest"]).unwrap();
     assert!(args.archive);
-    assert_eq!(args.xattrs, Some(true), "-X should enable xattrs");
+    assert_eq!(args.xattrs, Some(1), "-X should enable xattrs");
 }
 
 #[test]

--- a/crates/cli/tests/deprecated_option_aliases.rs
+++ b/crates/cli/tests/deprecated_option_aliases.rs
@@ -185,7 +185,7 @@ fn test_no_capital_x_alias_for_no_xattrs() {
     let args = parse_args(["oc-rsync", "--no-X", "src", "dest"]).unwrap();
     assert_eq!(
         args.xattrs,
-        Some(false),
+        Some(0),
         "--no-X should behave like --no-xattrs"
     );
 }

--- a/crates/cli/tests/option_precedence_tri_state.rs
+++ b/crates/cli/tests/option_precedence_tri_state.rs
@@ -115,7 +115,7 @@ fn test_xattrs_last_wins_positive() {
     let args = parse_args(["oc-rsync", "--no-xattrs", "--xattrs", "src", "dest"]).unwrap();
     assert_eq!(
         args.xattrs,
-        Some(true),
+        Some(1),
         "Last --xattrs should override --no-xattrs"
     );
 }
@@ -125,7 +125,7 @@ fn test_xattrs_last_wins_negative() {
     let args = parse_args(["oc-rsync", "--xattrs", "--no-xattrs", "src", "dest"]).unwrap();
     assert_eq!(
         args.xattrs,
-        Some(false),
+        Some(0),
         "Last --no-xattrs should override --xattrs"
     );
 }

--- a/crates/core/src/client/config/builder/metadata.rs
+++ b/crates/core/src/client/config/builder/metadata.rs
@@ -10,21 +10,24 @@ impl ClientConfigBuilder {
     }
 
     #[cfg(all(any(unix, windows), feature = "xattr"))]
-    /// Enables or disables extended attribute preservation for the transfer.
+    /// Sets the extended-attribute preservation level (0 = off, 1 = `-X`,
+    /// 2 = `-XX`).
     ///
-    /// On Windows `-X` maps onto NTFS Alternate Data Streams.
+    /// On Windows `-X` maps onto NTFS Alternate Data Streams. Level 2 doubles
+    /// the compact `X` letter forwarded to the remote peer (upstream
+    /// options.c:2698-2704).
     #[must_use]
     #[doc(alias = "--xattrs")]
     #[doc(alias = "-X")]
-    pub const fn xattrs(mut self, preserve: bool) -> Self {
-        self.preserve_xattrs = preserve;
+    pub const fn xattrs(mut self, level: u8) -> Self {
+        self.preserve_xattrs = level;
         self
     }
 
     #[cfg(not(all(any(unix, windows), feature = "xattr")))]
     /// No-op on platforms without xattr support.
     #[must_use]
-    pub const fn xattrs(self, _preserve: bool) -> Self {
+    pub const fn xattrs(self, _level: u8) -> Self {
         self
     }
 
@@ -129,15 +132,17 @@ impl ClientConfigBuilder {
         self
     }
 
-    /// Requests that access times be preserved when applying metadata.
+    /// Sets the access-time preservation level (0 = off, 1 = `-U`, 2 = `-UU`).
     ///
-    /// When enabled, the source file's access time (atime) is preserved on the
-    /// destination. This corresponds to the `-U` / `--atimes` flag in upstream rsync.
+    /// The source file's access time (atime) is preserved on the destination.
+    /// This corresponds to the `-U` / `--atimes` flag in upstream rsync; level 2
+    /// doubles the compact `U` letter forwarded to the remote peer (upstream
+    /// options.c:2681-2685).
     #[must_use]
     #[doc(alias = "--atimes")]
     #[doc(alias = "-U")]
-    pub const fn atimes(mut self, preserve: bool) -> Self {
-        self.preserve_atimes = preserve;
+    pub const fn atimes(mut self, level: u8) -> Self {
+        self.preserve_atimes = level;
         self
     }
 

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -158,7 +158,7 @@ pub struct ClientConfigBuilder {
     fake_super: bool,
     super_user: bool,
     preserve_times: bool,
-    preserve_atimes: bool,
+    preserve_atimes: u8,
     preserve_crtimes: bool,
     owner_override: Option<u32>,
     group_override: Option<u32>,
@@ -176,6 +176,8 @@ pub struct ClientConfigBuilder {
     compression_setting: CompressionSetting,
     compression_threads: Option<std::num::NonZeroU8>,
     skip_compress: SkipCompressList,
+    skip_compress_spec: Option<String>,
+    cvs_exclude: bool,
     open_noatime: bool,
     whole_file: Option<bool>,
     xxh64_dedup: bool,
@@ -279,7 +281,7 @@ pub struct ClientConfigBuilder {
     #[cfg(all(any(unix, windows), feature = "acl"))]
     preserve_acls: bool,
     #[cfg(all(any(unix, windows), feature = "xattr"))]
-    preserve_xattrs: bool,
+    preserve_xattrs: u8,
 }
 
 impl ClientConfigBuilder {
@@ -417,6 +419,8 @@ impl ClientConfigBuilder {
             compression_setting: self.compression_setting,
             compression_threads: self.compression_threads,
             skip_compress: self.skip_compress,
+            skip_compress_spec: self.skip_compress_spec,
+            cvs_exclude: self.cvs_exclude,
             open_noatime: self.open_noatime,
             whole_file: self.whole_file,
             xxh64_dedup: self.xxh64_dedup,

--- a/crates/core/src/client/config/builder/performance.rs
+++ b/crates/core/src/client/config/builder/performance.rs
@@ -83,6 +83,17 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Records the raw `--skip-compress` spec to forward to the remote sender.
+    ///
+    /// `Some` marks the suffix list as explicitly set so the builder emits
+    /// `--skip-compress=<spec>` verbatim, matching upstream options.c:2858-2860.
+    #[must_use]
+    #[doc(alias = "--skip-compress")]
+    pub fn skip_compress_spec(mut self, spec: Option<String>) -> Self {
+        self.skip_compress_spec = spec;
+        self
+    }
+
     /// Records the requested zstd worker thread count.
     ///
     /// `None` (the default) lets the codec pick its own worker count. The

--- a/crates/core/src/client/config/builder/selection.rs
+++ b/crates/core/src/client/config/builder/selection.rs
@@ -40,6 +40,9 @@ impl ClientConfigBuilder {
         force_replacements: bool,
         /// Enables or disables pruning of empty directories after filters apply.
         prune_empty_dirs: bool,
+        /// Requests `-C` / `--cvs-exclude`; forwarded to the peer as the compact
+        /// `C` letter (upstream options.c:2709).
+        cvs_exclude: bool,
     }
 
     /// Enables or disables creation of parent directories implied by the source path.

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -415,13 +415,13 @@ fn times_false_clears_flag() {
 
 #[test]
 fn atimes_sets_flag() {
-    let config = builder().atimes(true).build();
+    let config = builder().atimes(1).build();
     assert!(config.preserve_atimes());
 }
 
 #[test]
 fn atimes_false_clears_flag() {
-    let config = builder().atimes(true).atimes(false).build();
+    let config = builder().atimes(1).atimes(0).build();
     assert!(!config.preserve_atimes());
 }
 

--- a/crates/core/src/client/config/client/filters.rs
+++ b/crates/core/src/client/config/client/filters.rs
@@ -7,6 +7,17 @@ impl ClientConfig {
         &self.filter_rules
     }
 
+    /// Reports whether `-C` / `--cvs-exclude` was requested.
+    ///
+    /// Forwarded to the remote peer as the compact `C` letter so it runs
+    /// `get_cvs_excludes()` itself, mirroring upstream `options.c:2709`.
+    #[must_use]
+    #[doc(alias = "--cvs-exclude")]
+    #[doc(alias = "-C")]
+    pub const fn cvs_exclude(&self) -> bool {
+        self.cvs_exclude
+    }
+
     /// Returns the debug categories requested via `--debug`.
     #[must_use]
     #[doc(alias = "--debug")]

--- a/crates/core/src/client/config/client/metadata.rs
+++ b/crates/core/src/client/config/client/metadata.rs
@@ -107,6 +107,15 @@ impl ClientConfig {
     #[doc(alias = "--atimes")]
     #[doc(alias = "-U")]
     pub const fn preserve_atimes(&self) -> bool {
+        self.preserve_atimes >= 1
+    }
+
+    /// Returns the access-time preservation level (0 = off, 1 = `-U`, 2 = `-UU`).
+    ///
+    /// Level 2 doubles the compact `U` letter in the server flag string,
+    /// matching upstream `options.c:2681-2685`.
+    #[must_use]
+    pub const fn preserve_atimes_level(&self) -> u8 {
         self.preserve_atimes
     }
 
@@ -161,7 +170,7 @@ impl ClientConfig {
     #[doc(alias = "--xattrs")]
     #[doc(alias = "-X")]
     pub const fn preserve_xattrs(&self) -> bool {
-        self.preserve_xattrs
+        self.preserve_xattrs >= 1
     }
 
     /// Always returns `false` on platforms without xattr support.
@@ -169,6 +178,24 @@ impl ClientConfig {
     #[must_use]
     pub const fn preserve_xattrs(&self) -> bool {
         false
+    }
+
+    /// Returns the extended-attribute preservation level (0 = off, 1 = `-X`,
+    /// 2 = `-XX`).
+    ///
+    /// Level 2 doubles the compact `X` letter in the server flag string,
+    /// matching upstream `options.c:2698-2704`.
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
+    #[must_use]
+    pub const fn preserve_xattrs_level(&self) -> u8 {
+        self.preserve_xattrs
+    }
+
+    /// Always returns `0` on platforms without xattr support.
+    #[cfg(not(all(any(unix, windows), feature = "xattr")))]
+    #[must_use]
+    pub const fn preserve_xattrs_level(&self) -> u8 {
+        0
     }
 
     /// Returns whether hard links should be preserved when copying files.

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -82,7 +82,8 @@ pub struct ClientConfig {
     pub(super) fake_super: bool,
     pub(super) super_user: bool,
     pub(super) preserve_times: bool,
-    pub(super) preserve_atimes: bool,
+    /// Access-time preservation level: 0 = off, 1 = `-U`, 2 = `-UU`.
+    pub(super) preserve_atimes: u8,
     pub(super) preserve_crtimes: bool,
     pub(super) owner_override: Option<u32>,
     pub(super) group_override: Option<u32>,
@@ -121,6 +122,14 @@ pub struct ClientConfig {
     /// `token.c:701 ZSTD_c_nbWorkers`.
     pub(super) compression_threads: Option<std::num::NonZeroU8>,
     pub(super) skip_compress: SkipCompressList,
+    /// Raw `--skip-compress` spec forwarded verbatim to the remote sender.
+    ///
+    /// `Some` only when the suffix list was explicitly set (CLI or environment);
+    /// the built-in default list forwards nothing, matching upstream's NULL
+    /// `skip_compress` global (options.c:150).
+    pub(super) skip_compress_spec: Option<String>,
+    /// Whether `-C` / `--cvs-exclude` was requested (upstream `cvs_exclude`).
+    pub(super) cvs_exclude: bool,
     pub(super) open_noatime: bool,
     pub(super) whole_file: Option<bool>,
     /// Internal-only xxh64 file-dedup heuristic toggle.
@@ -269,8 +278,9 @@ pub struct ClientConfig {
     pub(super) embedded_ssh_config: Option<EmbeddedSshOptions>,
     #[cfg(all(any(unix, windows), feature = "acl"))]
     pub(super) preserve_acls: bool,
+    /// Extended-attribute preservation level: 0 = off, 1 = `-X`, 2 = `-XX`.
     #[cfg(all(any(unix, windows), feature = "xattr"))]
-    pub(super) preserve_xattrs: bool,
+    pub(super) preserve_xattrs: u8,
 }
 
 /// Options for the embedded SSH transport (russh-based).
@@ -327,7 +337,7 @@ impl Default for ClientConfig {
             fake_super: false,
             super_user: false,
             preserve_times: false,
-            preserve_atimes: false,
+            preserve_atimes: 0,
             preserve_crtimes: false,
             owner_override: None,
             group_override: None,
@@ -345,6 +355,8 @@ impl Default for ClientConfig {
             compression_setting: CompressionSetting::default(),
             compression_threads: None,
             skip_compress: SkipCompressList::default(),
+            skip_compress_spec: None,
+            cvs_exclude: false,
             open_noatime: false,
             whole_file: None,
             xxh64_dedup: false,
@@ -448,7 +460,7 @@ impl Default for ClientConfig {
             #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls: false,
             #[cfg(all(any(unix, windows), feature = "xattr"))]
-            preserve_xattrs: false,
+            preserve_xattrs: 0,
         }
     }
 }

--- a/crates/core/src/client/config/client/performance.rs
+++ b/crates/core/src/client/config/client/performance.rs
@@ -62,6 +62,17 @@ impl ClientConfig {
         &self.skip_compress
     }
 
+    /// Returns the raw `--skip-compress` spec to forward to the remote sender.
+    ///
+    /// `Some` only when the suffix list was explicitly set; the built-in default
+    /// list is never forwarded, matching upstream's NULL `skip_compress` global
+    /// (options.c:150, forwarded at options.c:2858-2860).
+    #[must_use]
+    #[doc(alias = "--skip-compress")]
+    pub fn skip_compress_spec(&self) -> Option<&str> {
+        self.skip_compress_spec.as_deref()
+    }
+
     /// Returns the requested zstd worker thread count, when set.
     ///
     /// `None` keeps zstd single-threaded. Propagated to the local copy engine

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -405,6 +405,13 @@ pub(super) fn build_full_daemon_args(
         // flags::sender_super_stats_args so both transports forward the same
         // trailer on a push.
         args.extend(flags::sender_super_stats_args(config).map(str::to_owned));
+    } else if let Some(spec) = config.skip_compress_spec() {
+        // upstream: options.c:2858-2860 - `else { if (skip_compress)
+        // safe_arg("--skip-compress", skip_compress); }`. Forwarded only on a
+        // PULL (the remote sender performs the compression). Only an
+        // explicitly-set spec is sent; the built-in default list is never
+        // forwarded.
+        args.push(format!("--skip-compress={spec}"));
     }
 
     // upstream: options.c:2863-2864 - `if (max_alloc_arg && max_alloc !=

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -78,7 +78,8 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.preserve_times() {
         flags.push('t');
     }
-    if config.preserve_atimes() {
+    // upstream: options.c:2681-2685 - `-UU` doubles the letter at level 2.
+    for _ in 0..config.preserve_atimes_level().min(2) {
         flags.push('U');
     }
     if config.preserve_permissions() {
@@ -100,6 +101,12 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.checksum() {
         flags.push('c');
     }
+    // upstream: options.c:2709-2710 - `if (cvs_exclude) 'C'`. Forwarded so the
+    // remote peer runs get_cvs_excludes() itself; duplicate excludes are
+    // idempotent with the transmitted CVS filter rules.
+    if config.cvs_exclude() {
+        flags.push('C');
+    }
     if config.preserve_hard_links() {
         flags.push('H');
     }
@@ -111,7 +118,8 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
         flags.push('A');
     }
     #[cfg(all(unix, feature = "xattr"))]
-    if config.preserve_xattrs() {
+    // upstream: options.c:2698-2704 - `-XX` doubles the letter at level 2.
+    for _ in 0..config.preserve_xattrs_level().min(2) {
         flags.push('X');
     }
     // upstream: 'n' = dry_run (!do_xfers), NOT numeric_ids.

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -529,6 +529,17 @@ impl<'a> RemoteInvocationBuilder<'a> {
         if am_sender && self.config.size_only() {
             args.push(OsString::from("--size-only"));
         }
+
+        // upstream: options.c:2858-2860 - `else { if (skip_compress)
+        // safe_arg("--skip-compress", skip_compress); }`. The else is the
+        // `!am_sender` branch, so `--skip-compress` is forwarded only on a PULL
+        // (RemoteRole::Receiver): the remote sender performs the compression and
+        // must skip the same suffixes. Only an explicitly-set spec is forwarded;
+        // the built-in default suffix list is never sent (upstream's
+        // skip_compress global is NULL unless --skip-compress was given).
+        if !am_sender && let Some(spec) = self.config.skip_compress_spec() {
+            args.push(OsString::from(format!("--skip-compress={spec}")));
+        }
         // upstream: options.c:2918-2923 - --ignore-existing and --existing
         // (sent as --existing for ignore_non_existing) both sit inside the
         // `if (am_sender)` block: they steer the remote receiver's generator,
@@ -925,8 +936,10 @@ impl<'a> RemoteInvocationBuilder<'a> {
         if self.config.preserve_times() {
             flags.push('t');
         }
-        // upstream: options.c:2681-2685 - preserve_atimes.
-        if self.config.preserve_atimes() {
+        // upstream: options.c:2681-2685 - `if (preserve_atimes) { 'U'; if
+        // (preserve_atimes > 1) 'U'; }`. Level 2 (`-UU`) doubles the letter so
+        // the peer also preserves directory access times.
+        for _ in 0..self.config.preserve_atimes_level().min(2) {
             flags.push('U');
         }
         // upstream: options.c:2686-2689 - preserve_crtimes.
@@ -947,8 +960,10 @@ impl<'a> RemoteInvocationBuilder<'a> {
             flags.push('A');
         }
         #[cfg(all(unix, feature = "xattr"))]
-        if self.config.preserve_xattrs() {
-            // upstream: options.c:2698-2704 - preserve_xattrs (before r).
+        // upstream: options.c:2698-2704 - `if (preserve_xattrs) { 'X'; if
+        // (preserve_xattrs > 1) 'X'; }` (before r). Level 2 (`-XX`) doubles the
+        // letter so the peer transfers xattrs even in a fake-super store.
+        for _ in 0..self.config.preserve_xattrs_level().min(2) {
             flags.push('X');
         }
         // upstream: options.c:2705-2706 - recurse.
@@ -958,6 +973,13 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // upstream: options.c:2707-2708 - always_checksum.
         if self.config.checksum() {
             flags.push('c');
+        }
+        // upstream: options.c:2709-2710 - `if (cvs_exclude) argstr[x++] = 'C';`.
+        // Forwarded so the remote peer runs get_cvs_excludes() itself (matching
+        // upstream, which also forwards the letter alongside the transmitted CVS
+        // rules); duplicate excludes are idempotent.
+        if self.config.cvs_exclude() {
+            flags.push('C');
         }
         // upstream: options.c:2711-2712 - ignore_times rides in the compact
         // flag string as `I`, NOT as a long-form `--ignore-times`. Emitting the

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -1316,9 +1316,131 @@ fn devices_and_specials_produce_single_d_flag() {
 
 #[test]
 fn includes_atimes_flag() {
-    let config = ClientConfig::builder().atimes(true).build();
+    let config = ClientConfig::builder().atimes(1).build();
     let flags = sender_flag_string(&config);
     assert!(flags.contains('U'), "expected 'U' in flags: {flags}");
+}
+
+// upstream: options.c:2681-2685 - `if (preserve_atimes) { 'U'; if
+// (preserve_atimes > 1) 'U'; }`. Level 1 emits a single `-U`, level 2 must emit
+// the doubled `-UU` so the remote also preserves directory access times.
+// WHY: dropping the doubled letter silently downgrades `-UU` to `-U`, so the
+// peer skips directory atimes the user explicitly requested.
+#[test]
+fn atimes_level_one_emits_single_u() {
+    let config = ClientConfig::builder().atimes(1).build();
+    let flags = sender_flag_string(&config);
+    assert_eq!(
+        flags.matches('U').count(),
+        1,
+        "-U (level 1) must emit exactly one 'U': {flags}"
+    );
+}
+
+#[test]
+fn atimes_level_two_emits_doubled_uu() {
+    let config = ClientConfig::builder().atimes(2).build();
+    let flags = sender_flag_string(&config);
+    assert_eq!(
+        flags.matches('U').count(),
+        2,
+        "-UU (level 2) must emit doubled 'UU': {flags}"
+    );
+}
+
+// upstream: options.c:2698-2704 - `if (preserve_xattrs) { 'X'; if
+// (preserve_xattrs > 1) 'X'; }`. WHY: a `-XX` request that collapses to `-X`
+// tells the remote to omit xattrs in a fake-super store, diverging from the
+// user's explicit level-2 intent.
+#[cfg(all(unix, feature = "xattr"))]
+#[test]
+fn xattrs_level_one_emits_single_x() {
+    let config = ClientConfig::builder().xattrs(1).build();
+    let flags = sender_flag_string(&config);
+    assert_eq!(
+        flags.matches('X').count(),
+        1,
+        "-X (level 1) must emit exactly one 'X': {flags}"
+    );
+}
+
+#[cfg(all(unix, feature = "xattr"))]
+#[test]
+fn xattrs_level_two_emits_doubled_xx() {
+    let config = ClientConfig::builder().xattrs(2).build();
+    let flags = sender_flag_string(&config);
+    assert_eq!(
+        flags.matches('X').count(),
+        2,
+        "-XX (level 2) must emit doubled 'XX': {flags}"
+    );
+}
+
+// upstream: options.c:2709-2710 - `if (cvs_exclude) argstr[x++] = 'C';`. The
+// letter is forwarded unconditionally (outside the am_sender block) so the
+// remote peer runs get_cvs_excludes() itself. WHY: without the letter, an
+// upstream peer never activates its own CVS-ignore handling ($HOME/.cvsignore,
+// $CVSIGNORE), diverging from a real `rsync -C` invocation.
+#[test]
+fn cvs_exclude_forwards_compact_c_letter() {
+    let config = ClientConfig::builder().cvs_exclude(true).build();
+    let flags = sender_flag_string(&config);
+    assert!(
+        flags.contains('C'),
+        "-C must forward the compact 'C' letter: {flags}"
+    );
+}
+
+#[test]
+fn cvs_exclude_absent_by_default() {
+    let config = ClientConfig::builder().build();
+    let flags = sender_flag_string(&config);
+    assert!(
+        !flags.contains('C'),
+        "default config must not emit the 'C' letter: {flags}"
+    );
+}
+
+// upstream: options.c:2858-2860 - `else { if (skip_compress)
+// safe_arg("--skip-compress", skip_compress); }`. Emitted only in the
+// `!am_sender` (PULL) branch so the remote sender skips the same suffixes.
+// WHY: an explicit `--skip-compress` list that is not forwarded makes the
+// remote sender re-compress already-compressed data, wasting CPU and diverging
+// from upstream's wire output.
+#[test]
+fn skip_compress_forwarded_on_pull_when_set() {
+    let config = ClientConfig::builder()
+        .skip_compress_spec(Some("gz/zip/mp4".to_owned()))
+        .build();
+    let args = build_receiver_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--skip-compress=gz/zip/mp4"),
+        "explicit --skip-compress must be forwarded on a pull: {args:?}"
+    );
+}
+
+#[test]
+fn skip_compress_not_forwarded_when_default() {
+    let config = ClientConfig::builder().build();
+    let args = build_receiver_args(&config);
+    assert!(
+        !args.iter().any(|a| a.starts_with("--skip-compress")),
+        "default (built-in) skip-compress list must not be forwarded: {args:?}"
+    );
+}
+
+#[test]
+fn skip_compress_not_forwarded_on_push() {
+    // upstream: the `--skip-compress` arg lives in the `else` (!am_sender)
+    // branch, so a PUSH (local sender) never forwards it.
+    let config = ClientConfig::builder()
+        .skip_compress_spec(Some("gz/zip".to_owned()))
+        .build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a.starts_with("--skip-compress")),
+        "--skip-compress must not be forwarded on a push: {args:?}"
+    );
 }
 
 #[test]
@@ -1658,7 +1780,7 @@ fn includes_acl_flag() {
 #[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn includes_xattr_flag() {
-    let config = ClientConfig::builder().xattrs(true).build();
+    let config = ClientConfig::builder().xattrs(1).build();
     let flags = sender_flag_string(&config);
     assert!(flags.contains('X'), "expected 'X' in flags: {flags}");
 }
@@ -2520,7 +2642,7 @@ fn all_flags_enabled_produces_valid_invocation() {
         .devices(true)
         .specials(true)
         .times(true)
-        .atimes(true)
+        .atimes(1)
         .permissions(true)
         .executability(true)
         .recursive(true)
@@ -2528,7 +2650,7 @@ fn all_flags_enabled_produces_valid_invocation() {
         .checksum(true)
         .hard_links(true)
         .acls(true)
-        .xattrs(true)
+        .xattrs(1)
         .numeric_ids(true)
         .trust_sender(true)
         .checksum_seed(Some(42))

--- a/crates/core/src/client/tests/builder_metadata.rs
+++ b/crates/core/src/client/tests/builder_metadata.rs
@@ -129,7 +129,7 @@ fn builder_preserves_acls_flag() {
 fn builder_preserves_xattrs_flag() {
     let config = ClientConfig::builder()
         .transfer_args([OsString::from("src"), OsString::from("dst")])
-        .xattrs(true)
+        .xattrs(1)
         .build();
 
     assert!(config.preserve_xattrs());

--- a/crates/core/tests/client_integration.rs
+++ b/crates/core/tests/client_integration.rs
@@ -265,7 +265,7 @@ fn test_atimes_preservation() {
         let config = ClientConfig::builder()
             .transfer_args([source_arg, dest_root.clone().into_os_string()])
             .mkpath(true)
-            .atimes(true)
+            .atimes(1)
             .times(true)
             .build();
 

--- a/crates/daemon/src/tests/chunks/daemon_xattr_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_xattr_push.rs
@@ -105,7 +105,7 @@ fn daemon_xattr_push_preserves_extended_attributes() {
 
     let client_config = core::client::ClientConfig::builder()
         .transfer_args([source_arg, OsString::from(&rsync_url)])
-        .xattrs(true)
+        .xattrs(1)
         .build();
 
     let result = core::client::run_client(client_config);


### PR DESCRIPTION
## Summary

Completes three server-arg forwarding gaps that required CLI option-model
changes, bringing the SSH and daemon server invocations to `options.c:server_options()`
parity for `-C`, `--skip-compress`, and the doubled `-XX` / `-UU` letters.

Previously these three were carried as deferred follow-ups because the option
model could not express them: `-C` was discarded before it reached the client
config, `--skip-compress` had no way to detect an explicit value or render its
spec, and `-X` / `-U` were booleans that could not represent level 2.

## Changes

### `-C` / `--cvs-exclude` forwarding (options.c:2709-2710)

`cvs_exclude` is now threaded into `ClientConfig` and emitted as the compact
`C` letter (between `c` and `I`) by both the SSH builder and the daemon flag
builder. Upstream forwards `-C` unconditionally alongside the transmitted CVS
filter rules, so the existing wire-rule path is retained; duplicate excludes are
idempotent (first-match-wins), so no double-apply results.

### `--skip-compress` forwarding (options.c:2858-2860)

The raw suffix spec is now preserved on `ClientConfig` (`skip_compress_spec`)
and forwarded verbatim as `--skip-compress=<spec>` in the `!am_sender` (pull)
branch of both builders, matching upstream's placement. Only an explicitly-set
value (via `--skip-compress`) is forwarded; the built-in default suffix list is
never sent, mirroring upstream's NULL `skip_compress` global (options.c:150).
The `RSYNC_SKIP_COMPRESS` environment fallback still applies locally but, like
upstream, is not forwarded.

### `-XX` / `-UU` level-2 doubling (options.c:2681-2685, 2699-2703)

`--xattrs` and `--atimes` are remodelled from booleans to `u8` levels (0/1/2),
mirroring the existing `--one-file-system` (`-xx`) pattern: `ArgAction::Count`
in Clap, a shared `leveled_flag_pair` parser that honours `--no-` ordering via
`overrides_with`, `u8` fields on the config with `preserve_*_level()` accessors,
and the builders emitting the doubled letter at level 2. Level-1 single-letter
output is unchanged.

## Upstream references

- `-C`: `options.c:2709-2710` `if (cvs_exclude) argstr[x++] = 'C';`
- `--skip-compress`: `options.c:2858-2860` `else { if (skip_compress) safe_arg("--skip-compress", skip_compress); }`, global at `options.c:150`
- `-UU`: `options.c:2681-2685` `if (preserve_atimes) { 'U'; if (preserve_atimes > 1) 'U'; }`; parse at `options.c:1585`
- `-XX`: `options.c:2699-2703` `if (preserve_xattrs) { 'X'; if (preserve_xattrs > 1) 'X'; }`; parse at `options.c:1877`

## Tests

New failing-first WHY-tests assert the exact emitted server args:

- `cvs_exclude_forwards_compact_c_letter` / `cvs_exclude_absent_by_default`
- `atimes_level_one_emits_single_u` / `atimes_level_two_emits_doubled_uu`
- `xattrs_level_one_emits_single_x` / `xattrs_level_two_emits_doubled_xx`
- `skip_compress_forwarded_on_pull_when_set` / `_not_forwarded_when_default` / `_not_forwarded_on_push`
- CLI parse: `atimes_double_short_flag_is_level_two` / `xattrs_double_short_flag_is_level_two`

Verified locally: `cargo fmt --all`, `cargo clippy -p core -p cli
--all-features --all-targets --no-deps -D warnings` (clean), and the targeted
`core` + `cli` nextest selections (all green).
