### PR TITLE
fix(transfer): defer --remove-source-files unlink until MSG_SUCCESS

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -392,6 +392,17 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // receiver never fallocate()s its destination files. Inert on a push (the
     // remote receiver picks it up from the forwarded --preallocate arg).
     server_config.flags.preallocate = config.preallocate();
+    // upstream: options.c:730-731 - `--remove-source-files` is a long-form-only
+    // flag with no compact letter, so build_server_flag_string never packs it
+    // into the capability string this local ServerConfig is parsed from. It
+    // governs the local half of BOTH roles: on a push the local client is the
+    // sender and must run the deferred unlink of its own sources once the remote
+    // receiver confirms each commit with MSG_SUCCESS (sender.c:131-182); on a
+    // pull the local client is the generator/receiver and must emit MSG_SUCCESS
+    // to the remote sender so it can unlink the remote sources (receiver.c:1063-1069).
+    // Without carrying it here the removal is silently skipped for every remote
+    // transfer, so it must ride onto the local config exactly like `--preallocate`.
+    server_config.flags.remove_source_files = config.remove_source_files();
     server_config.has_partial_dir = config.partial_directory().is_some();
     server_config.partial_dir = config.partial_directory().map(std::path::Path::to_path_buf);
     server_config.file_selection.min_file_size = config.min_file_size();

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -108,6 +108,13 @@ pub struct GeneratorContext {
     /// I/O error flags accumulated during file list building and transfer.
     /// Uses [`io_error_flags`] constants (IOERR_GENERAL, IOERR_VANISHED, etc.).
     pub(crate) io_error: i32,
+    /// Flat file-list indices whose `--remove-source-files` unlink is deferred
+    /// until the peer confirms the commit via `MSG_SUCCESS`. Empty and unused
+    /// unless `--remove-source-files` is active.
+    ///
+    /// upstream: sender.c:131-182 `successful_send()` unlinks on confirmation,
+    /// never inline at send time (io.c:1623-1637 `MSG_SUCCESS` handler).
+    pub(crate) pending_source_removals: super::pending_removal::PendingSourceRemovals,
     /// Incremental recursion (INC_RECURSE) state for segmented file list sending.
     pub(crate) incremental: IncrementalState,
     /// Accumulated deletion statistics received via NDX_DEL_STATS messages.
@@ -167,6 +174,7 @@ impl GeneratorContext {
             uid_list: IdList::new(),
             gid_list: IdList::new(),
             io_error: 0,
+            pending_source_removals: super::pending_removal::PendingSourceRemovals::default(),
             incremental: IncrementalState::new(initial_ndx_start),
             delete_stats: DeleteStats::new(),
             parallel_thresholds: crate::parallel_io::ParallelThresholds::default(),
@@ -469,8 +477,20 @@ impl GeneratorContext {
     /// **Client mode** (client pushing to daemon - `main.c:1304-1305` `client_run am_sender`):
     /// - `if (protocol_version >= 31 || (!filesfrom_host && protocol_version >= 23))`
     /// - We don't support filesfrom, so this simplifies to >= 23
+    ///
+    /// **`--remove-source-files`** (`options.c:2243-2251`): the sender must
+    /// receive `MSG_SUCCESS` before it may unlink a source, so upstream sets
+    /// `need_messages_from_generator = 1` unconditionally when the flag is
+    /// active, forcing input multiplex regardless of protocol version. Both
+    /// peers share the option, so both force it and the stream stays in sync.
     #[must_use]
     pub(crate) const fn should_activate_input_multiplex(&self) -> bool {
+        // upstream: options.c:2243-2251 - --remove-source-files always needs the
+        // generator->sender message channel so MSG_SUCCESS can drive the
+        // deferred unlink, independent of protocol version.
+        if self.config.flags.remove_source_files {
+            return true;
+        }
         if self.config.connection.client_mode {
             // Client mode: >= 23 (upstream main.c:1304-1305, no filesfrom)
             self.protocol.supports_multiplex_io()

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -86,6 +86,7 @@ pub mod io_error_flags;
 mod item_flags;
 pub mod itemize;
 mod open_source;
+mod pending_removal;
 mod protocol_io;
 mod segments;
 mod stats;

--- a/crates/transfer/src/generator/pending_removal.rs
+++ b/crates/transfer/src/generator/pending_removal.rs
@@ -1,0 +1,117 @@
+#![deny(unsafe_code)]
+//! Deferred `--remove-source-files` bookkeeping for the sender.
+//!
+//! Upstream rsync never unlinks a source file inline right after sending it.
+//! Instead the receiver/generator sends `MSG_SUCCESS(ndx)` back to the sender
+//! only once the file has been fully received and committed to its final
+//! destination, and the sender's `successful_send()` unlinks the source in
+//! response (`io.c:1623-1637`, `sender.c:131-182`). This keeps
+//! `--remove-source-files` crash-safe: an interrupted, failed, or redone
+//! transfer never deletes a source that did not safely land at the destination.
+//!
+//! [`PendingSourceRemovals`] is the focused seam that records which file-list
+//! entries the sender has transmitted but not yet had confirmed. Entries are
+//! keyed by their flat file-list index, which is all that is needed to recover
+//! the on-disk source path (`reconstruct_source_path`) and the recorded
+//! identity guard (`FileEntry` size/mtime) at confirmation time - exactly what
+//! upstream's `successful_send()` recomputes from `flist_for_ndx(ndx)`. Storing
+//! only the index keeps the sender's resident set flat: the paths and identity
+//! already live in the file list.
+//!
+//! # Upstream Reference
+//!
+//! - `sender.c:131-182` - `successful_send()` re-stats and unlinks on confirmation.
+//! - `io.c:1096-1111` / `io.c:1623-1637` - `MSG_SUCCESS` wire round-trip.
+
+use std::collections::HashSet;
+
+/// Set of flat file-list indices whose `--remove-source-files` unlink has been
+/// deferred until the peer confirms the commit via `MSG_SUCCESS`.
+///
+/// The sender inserts an index once it has finished transmitting that file
+/// ([`mark_pending`](Self::mark_pending)) and removes it when the matching
+/// `MSG_SUCCESS` arrives ([`confirm`](Self::confirm)). Any index still present
+/// at the end of a transfer belongs to a file whose commit was never
+/// confirmed, so its source is intentionally left in place.
+#[derive(Debug, Default)]
+pub(crate) struct PendingSourceRemovals {
+    pending: HashSet<usize>,
+}
+
+impl PendingSourceRemovals {
+    /// Records that entry `flat_ndx` has been transmitted and its source unlink
+    /// is now pending the peer's `MSG_SUCCESS` confirmation.
+    ///
+    /// upstream: sender.c:480 marks `FLAG_FILE_SENT`; the unlink itself is
+    /// deferred to `successful_send()` on `MSG_SUCCESS` receipt.
+    pub(crate) fn mark_pending(&mut self, flat_ndx: usize) {
+        self.pending.insert(flat_ndx);
+    }
+
+    /// Consumes a `MSG_SUCCESS` confirmation for `flat_ndx`.
+    ///
+    /// Returns `true` when the index was pending (so the caller must now unlink
+    /// the source), and `false` when it was not - a confirmation the sender did
+    /// not defer a removal for (e.g. an up-to-date file the peer's generator
+    /// reported, or a duplicate), which is ignored just as upstream's
+    /// `successful_send()` becomes a no-op guard when the file no longer
+    /// matches.
+    ///
+    /// upstream: io.c:1623-1637 -> sender.c:131-182.
+    pub(crate) fn confirm(&mut self, flat_ndx: usize) -> bool {
+        self.pending.remove(&flat_ndx)
+    }
+
+    /// Returns `true` when no deferred removals remain outstanding.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    /// Returns the number of deferred removals still awaiting confirmation.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PendingSourceRemovals;
+
+    /// A confirmation for a marked index reports the source must be unlinked,
+    /// and clears the pending entry so a duplicate confirmation is a no-op.
+    ///
+    /// Encodes the upstream invariant that `successful_send()` runs exactly once
+    /// per file, on `MSG_SUCCESS` receipt, not inline at send time.
+    #[test]
+    fn remove_source_confirm_marked_index_unlinks_once() {
+        let mut pending = PendingSourceRemovals::default();
+        pending.mark_pending(7);
+        assert_eq!(pending.len(), 1);
+
+        // First confirmation drives the unlink.
+        assert!(pending.confirm(7));
+        assert!(pending.is_empty());
+
+        // A duplicate MSG_SUCCESS for the same ndx does nothing.
+        assert!(!pending.confirm(7));
+    }
+
+    /// A confirmation for an index the sender never deferred is ignored - the
+    /// sender must not unlink a file it did not transmit and mark pending.
+    ///
+    /// This is the crash-safety guard: an unexpected `MSG_SUCCESS` can never
+    /// trigger a spurious source deletion.
+    #[test]
+    fn remove_source_confirm_unmarked_index_ignored() {
+        let mut pending = PendingSourceRemovals::default();
+        pending.mark_pending(1);
+
+        assert!(!pending.confirm(2));
+        // The genuinely pending entry is untouched.
+        assert_eq!(pending.len(), 1);
+        assert!(pending.confirm(1));
+        assert!(pending.is_empty());
+    }
+}

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -5177,3 +5177,79 @@ fn source_base_interning_round_trips_and_shares() {
         "distinct source bases must not share an allocation",
     );
 }
+
+/// A source is removed only after its commit is confirmed by `MSG_SUCCESS`.
+///
+/// Encodes the crash-safety contract of upstream `successful_send()`
+/// (sender.c:131-182): the unlink runs from the `MSG_SUCCESS` handler
+/// (io.c:1623-1637), never inline at send time. Here the sender has transmitted
+/// the file (so its removal is marked pending) and the peer then confirms the
+/// commit - only then does the source disappear.
+#[test]
+fn remove_source_files_unlinks_after_msg_success() {
+    let temp = create_test_files(&[("keep.txt", b"payload")]);
+    let src = temp.path().join("keep.txt");
+    let (_h, mut ctx) = test_generator_for_path(&src, false);
+    ctx.config.flags.remove_source_files = true;
+    build_file_list_for(&mut ctx, &src);
+
+    let flat = (0..ctx.file_list.len())
+        .find(|&i| ctx.file_list[i].is_file())
+        .expect("the single-file source produces one file entry");
+    let wire = ctx.flat_to_wire_ndx(flat);
+
+    // The sender finished transmitting the file: its unlink is deferred, not run.
+    ctx.pending_source_removals.mark_pending(flat);
+    assert!(
+        src.exists(),
+        "the source must survive until the commit is confirmed"
+    );
+
+    // MSG_SUCCESS(ndx) confirms the commit and drives the deferred unlink.
+    let io_error = ctx.confirm_source_removal(wire);
+    assert_eq!(io_error, 0, "a clean removal sets no io_error bits");
+    assert!(!src.exists(), "a confirmed source must be removed");
+    assert!(
+        ctx.pending_source_removals.is_empty(),
+        "the confirmed entry must be cleared from the pending set"
+    );
+}
+
+/// An interrupted or failed transfer never deletes the source, because no
+/// `MSG_SUCCESS` arrives to confirm the commit.
+///
+/// This is the data-loss fix: the previous inline unlink removed the source the
+/// instant the bytes were sent, before the receiver committed, so a broken
+/// transfer could destroy a source that never safely landed. With the deferral,
+/// an unconfirmed pending entry leaves its source untouched, and a stray
+/// confirmation for an index the sender never marked is ignored.
+#[test]
+fn remove_source_files_defers_until_msg_success() {
+    let temp = create_test_files(&[("keep.txt", b"payload")]);
+    let src = temp.path().join("keep.txt");
+    let (_h, mut ctx) = test_generator_for_path(&src, false);
+    ctx.config.flags.remove_source_files = true;
+    build_file_list_for(&mut ctx, &src);
+
+    let flat = (0..ctx.file_list.len())
+        .find(|&i| ctx.file_list[i].is_file())
+        .expect("the single-file source produces one file entry");
+
+    // The sender transmitted the file, then the transfer is interrupted: the
+    // pending removal is recorded but no MSG_SUCCESS is ever consumed.
+    ctx.pending_source_removals.mark_pending(flat);
+    assert!(src.exists(), "an unconfirmed source must stay in place");
+
+    // A confirmation for an index the sender never marked pending must not
+    // trigger a spurious deletion.
+    let bogus_wire = ctx.flat_to_wire_ndx(flat) + 100;
+    assert_eq!(ctx.confirm_source_removal(bogus_wire), 0);
+    assert!(
+        src.exists(),
+        "a stray MSG_SUCCESS must never delete an unrelated source"
+    );
+    assert!(
+        !ctx.pending_source_removals.is_empty(),
+        "the genuine pending entry must remain until its own confirmation"
+    );
+}

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -165,6 +165,19 @@ impl GeneratorContext {
             },
         )?;
 
+        // upstream: io.c:1623-1637 - MSG_SUCCESS(ndx) frames arrive interleaved
+        // with the receiver's NDX requests and are demultiplexed as the sender
+        // drives the transfer loop and goodbye handshake. Now that the wire is
+        // drained, run the deferred --remove-source-files unlink for every file
+        // the peer confirmed committed (sender.c:131-182 successful_send()). A
+        // file the peer never confirmed keeps its source: an interrupted or
+        // failed transfer returns via `?` above and never reaches this point,
+        // so its source is intentionally left in place. This is the crash-safe
+        // ordering the inline unlink violated.
+        for wire_ndx in reader.take_success_indices() {
+            self.io_error |= self.confirm_source_removal(wire_ndx);
+        }
+
         // UTS-V3.A drain barrier: explicit user-space drain after
         // `handle_goodbye_with_finalizer` returns and before the writer
         // graph drops. The audit traced the cluster-A wire-cutoffs

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -815,23 +815,19 @@ impl GeneratorContext {
             // matching upstream which sets the flag only after a real send.
             sent_files.mark_sent(ndx);
 
-            // upstream: sender.c:131-182 successful_send() - unlink the source
-            // when --remove-source-files is active and the transfer succeeded.
-            // Upstream defers the unlink to the MSG_SUCCESS handshake so the
-            // receiver's commit is confirmed; we run inline here at the
-            // file-transfer boundary because the generator does not exchange
-            // an MSG_SUCCESS round-trip with the receiver. The re-stat and
-            // changed-file guards still run, so a source that vanished or was
-            // modified since it entered the file list is never removed, and a
-            // guard refusal or unlink failure sets io_error -> exit 23.
-            let recorded_identity = RecordedSourceIdentity {
-                size: file_entry.size(),
-                mtime: file_entry.mtime(),
-                mtime_nsec: file_entry.mtime_nsec(),
-            };
-            let remove_io_error =
-                self.remove_source_file_if_requested(&source_path, recorded_identity);
-            self.io_error |= remove_io_error;
+            // upstream: sender.c:131-182 successful_send() - the source unlink is
+            // DEFERRED, never run inline at send time. Upstream waits for the
+            // receiver/generator to confirm the commit with MSG_SUCCESS(ndx)
+            // (io.c:1623-1637) and only then unlinks in successful_send().
+            // Recording this entry as pending - instead of unlinking now - is
+            // what makes --remove-source-files crash-safe: an interrupted,
+            // failed, or redone transfer never deletes a source that did not
+            // safely land at the destination. The re-stat and changed-file
+            // guards still run later, at confirmation time, inside
+            // confirm_source_removal() -> remove_source_file_if_requested().
+            if self.config.flags.remove_source_files && !self.config.flags.dry_run {
+                self.pending_source_removals.mark_pending(ndx);
+            }
 
             // upstream: sender.c:445-446
             // rprintf(FINFO, "sender finished %s%s%s\n", path,slash,fname)
@@ -1061,6 +1057,48 @@ impl GeneratorContext {
                 IOERR_GENERAL
             }
         }
+    }
+
+    /// Runs the deferred `--remove-source-files` unlink for a file the peer has
+    /// confirmed committed via `MSG_SUCCESS(wire_ndx)`.
+    ///
+    /// This is the sender-side reaction to a received `MSG_SUCCESS`, mirroring
+    /// upstream's `successful_send()` being invoked from the message handler
+    /// (`io.c:1637`). The wire index is mapped back to its flat file-list entry
+    /// and the source is unlinked only if this sender actually deferred a
+    /// removal for it - an index the sender never marked pending (a duplicate
+    /// confirmation, or an up-to-date entry the sender never transmitted) is
+    /// ignored, so a stray `MSG_SUCCESS` can never trigger a spurious deletion.
+    /// The re-stat and changed-file guards in
+    /// [`remove_source_file_if_requested`](Self::remove_source_file_if_requested)
+    /// still gate the unlink, so a source that vanished or changed since it
+    /// entered the file list is never removed. Returns the `io_error` bits the
+    /// caller must OR into the transfer's accumulated error state.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:1623-1637` - `MSG_SUCCESS` receipt drives `successful_send(val)`.
+    /// - `sender.c:131-182` - `successful_send()` unlink + guards.
+    #[must_use]
+    pub(crate) fn confirm_source_removal(&mut self, wire_ndx: i32) -> i32 {
+        if wire_ndx < 0 {
+            return 0;
+        }
+        let flat_ndx = self.wire_to_flat_ndx(wire_ndx);
+        if flat_ndx >= self.file_list.len() {
+            return 0;
+        }
+        if !self.pending_source_removals.confirm(flat_ndx) {
+            return 0;
+        }
+        let source_path = self.reconstruct_source_path(flat_ndx);
+        let entry = &self.file_list[flat_ndx];
+        let recorded = RecordedSourceIdentity {
+            size: entry.size(),
+            mtime: entry.mtime(),
+            mtime_nsec: entry.mtime_nsec(),
+        };
+        self.remove_source_file_if_requested(&source_path, recorded)
     }
 }
 

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -86,6 +86,16 @@ pub struct PipelinedReceiver {
     /// - `receiver.c:546-547`: `delayed_bits = bitbag_create()`
     /// - `receiver.c:584-585`: `handle_delayed_updates()` sweep
     delayed_updates: Vec<(PathBuf, PathBuf)>,
+    /// Flat file indices whose commit was confirmed (finish_transfer succeeded,
+    /// checksum verified). The receiver drains these and, when
+    /// `--remove-source-files` is active, sends `MSG_SUCCESS(ndx)` to the sender
+    /// so it can unlink the confirmed source. Mirrors upstream's
+    /// `send_msg_success()` at `recv_ok == 1`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:1063-1069`: `send_msg_success(fname, ndx)` on `recv_ok == 1`.
+    success_indices: Vec<usize>,
 }
 
 impl PipelinedReceiver {
@@ -109,6 +119,7 @@ impl PipelinedReceiver {
             permission_error_count: 0,
             warnings: Vec::new(),
             delayed_updates: Vec::new(),
+            success_indices: Vec::new(),
         })
     }
 
@@ -338,6 +349,12 @@ impl PipelinedReceiver {
             }
         }
 
+        // upstream: receiver.c:1063-1069 - the file committed cleanly
+        // (finish_transfer succeeded and any wire checksum verified), i.e.
+        // `recv_ok == 1`. Record it as a confirmed success so the receiver can
+        // emit MSG_SUCCESS(ndx) to the sender, which drives the deferred
+        // --remove-source-files unlink of the confirmed source.
+        self.success_indices.push(pending.file_index);
         Ok(())
     }
 
@@ -409,6 +426,23 @@ impl PipelinedReceiver {
     ///   when a checksum mismatch is detected during phase 1.
     pub fn drain_new_redo_indices(&mut self) -> Vec<usize> {
         std::mem::take(&mut self.redo_indices)
+    }
+
+    /// Drains the flat file indices whose commit has been confirmed since the
+    /// last call.
+    ///
+    /// Call this after `drain_ready_results` / `drain_all_results`. When
+    /// `--remove-source-files` is active the caller maps each index to its wire
+    /// NDX and sends `MSG_SUCCESS(ndx)` to the sender so it unlinks the
+    /// confirmed source; otherwise the drained indices are simply discarded, so
+    /// this stays bounded even when the flag is off.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:1063-1069`: `send_msg_success(fname, ndx)` on `recv_ok == 1`.
+    /// - `io.c:1623-1637`: sender-side `MSG_SUCCESS` handler -> `successful_send`.
+    pub fn drain_new_success_indices(&mut self) -> Vec<usize> {
+        std::mem::take(&mut self.success_indices)
     }
 
     /// Returns the list of file indices that need redo (failed checksum in phase 1).

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -142,6 +142,13 @@ pub(crate) struct MultiplexReader<R> {
     /// File indices received via `MSG_REDO` from the receiver.
     /// upstream: io.c:1514-1519, receiver.c:970-974
     pub(super) redo_indices: Vec<i32>,
+    /// File indices received via `MSG_SUCCESS` from the peer's generator or
+    /// receiver, each confirming that the file was fully received and committed
+    /// to its final destination. The sender drains these to drive the deferred
+    /// `--remove-source-files` unlink - a source is removed only after its
+    /// transfer is confirmed, never inline right after the bytes are sent.
+    /// upstream: io.c:1623-1637, sender.c:131-182 `successful_send()`.
+    pub(super) success_indices: Vec<i32>,
     /// Exit code from MSG_ERROR_EXIT. When set, the remote has requested
     /// immediate termination. upstream: io.c:1663-1701 calls _exit_cleanup().
     pub(super) error_exit_code: Option<i32>,
@@ -246,6 +253,7 @@ impl<R> MultiplexReader<R> {
             io_error: 0,
             no_send_indices: Vec::new(),
             redo_indices: Vec::new(),
+            success_indices: Vec::new(),
             error_exit_code: None,
             xfer_error_count: 0,
             io_timeout: None,
@@ -326,6 +334,22 @@ impl<R> MultiplexReader<R> {
     /// - `receiver.c:970-974`: receiver sends `MSG_REDO` when `!redoing`.
     pub(super) fn take_redo_indices(&mut self) -> Vec<i32> {
         std::mem::take(&mut self.redo_indices)
+    }
+
+    /// Returns and drains the accumulated `MSG_SUCCESS` file indices.
+    ///
+    /// Each index is a file the peer's generator/receiver has confirmed as
+    /// fully received and committed. The sender consumes them to unlink the
+    /// corresponding `--remove-source-files` source only after the commit is
+    /// confirmed.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:1623-1637`: `MSG_SUCCESS` received; when `!am_generator` it
+    ///   drives `successful_send(val)`.
+    /// - `sender.c:131-182`: `successful_send()` performs the deferred unlink.
+    pub(super) fn take_success_indices(&mut self) -> Vec<i32> {
+        std::mem::take(&mut self.success_indices)
     }
 
     /// Returns an error if MSG_ERROR_EXIT has been received.
@@ -422,6 +446,30 @@ impl<R> MultiplexReader<R> {
                 self.buffer[3],
             ]);
             self.no_send_indices.push(ndx);
+        }
+    }
+
+    /// Handles a `MSG_SUCCESS` payload by recording the confirmed file index.
+    ///
+    /// The peer's generator/receiver emits `MSG_SUCCESS` only after a file has
+    /// been fully received and committed to its final destination, so the index
+    /// is safe to act on (it drives the deferred `--remove-source-files`
+    /// unlink on the sender). A non-`local_server` peer frames the payload as a
+    /// bare 4-byte little-endian file index (`send_msg_int(MSG_SUCCESS, ndx)`);
+    /// a `local_server` peer prepends the same 4-byte index with an 8+8 byte
+    /// dev/ino guard. oc's wire sender is never `local_server` (same-host
+    /// copies take the engine path), so only the leading 4-byte index is read.
+    ///
+    /// upstream: io.c:1071-1086 `send_msg_success()`, io.c:1623-1637 handler.
+    fn handle_success_msg(&mut self) {
+        if self.buffer.len() >= 4 {
+            let ndx = i32::from_le_bytes([
+                self.buffer[0],
+                self.buffer[1],
+                self.buffer[2],
+                self.buffer[3],
+            ]);
+            self.success_indices.push(ndx);
         }
     }
 
@@ -586,6 +634,13 @@ impl<R> MultiplexReader<R> {
             protocol::MessageCode::Redo => {
                 // upstream: io.c:1514-1519
                 self.handle_redo_msg();
+            }
+            protocol::MessageCode::Success => {
+                // upstream: io.c:1623-1637 - MSG_SUCCESS carries a committed
+                // file index. On the sender it drives successful_send() (the
+                // deferred --remove-source-files unlink); accumulate it here so
+                // the transfer driver can consume it, instead of dropping it.
+                self.handle_success_msg();
             }
             protocol::MessageCode::IoTimeout => {
                 // upstream: io.c:1551-1561
@@ -1051,5 +1106,49 @@ mod io_timeout_adoption_tests {
             reader.check_io_timeout().is_ok(),
             "a non-adopting reader must not abort on MSG_IO_TIMEOUT"
         );
+    }
+}
+
+#[cfg(test)]
+mod success_dispatch_tests {
+    use super::*;
+
+    /// A `MSG_SUCCESS` frame must be dispatched to the success accumulator, not
+    /// dropped. The sender's deferred `--remove-source-files` unlink depends on
+    /// reading `MSG_SUCCESS(ndx)`; the previous catch-all `_ => {}` arm silently
+    /// discarded it, so a sender that defers its unlink would never learn a
+    /// commit was confirmed and would never remove the source. This test fails
+    /// against the drop-on-the-floor behaviour.
+    ///
+    /// upstream: io.c:1623-1637 - `!am_generator` runs `successful_send(val)`.
+    #[test]
+    fn msg_success_is_dispatched_not_dropped() {
+        let mut reader = MultiplexReader::new(io::empty());
+        // A non-local_server MSG_SUCCESS payload is the bare 4-byte LE ndx
+        // (io.c:1086 send_msg_int(MSG_SUCCESS, ndx)).
+        reader.buffer = 42i32.to_le_bytes().to_vec();
+        let is_data = reader.dispatch_message_with(protocol::MessageCode::Success, &mut RealSink);
+        assert!(!is_data, "MSG_SUCCESS is a control frame, not MSG_DATA");
+        assert_eq!(
+            reader.take_success_indices(),
+            vec![42],
+            "the committed ndx must be captured for the deferred unlink"
+        );
+        assert!(
+            reader.take_success_indices().is_empty(),
+            "draining must leave the accumulator empty"
+        );
+    }
+
+    /// Multiple confirmations accumulate in receipt order so the sender can
+    /// unlink every confirmed source once the transfer's wire drains.
+    #[test]
+    fn msg_success_indices_accumulate_in_order() {
+        let mut reader = MultiplexReader::new(io::empty());
+        for ndx in [1i32, 5, 9] {
+            reader.buffer = ndx.to_le_bytes().to_vec();
+            reader.dispatch_message_with(protocol::MessageCode::Success, &mut RealSink);
+        }
+        assert_eq!(reader.take_success_indices(), vec![1, 5, 9]);
     }
 }

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -291,6 +291,30 @@ impl<R: Read> ServerReader<R> {
             ServerReaderInner::Plain(_) => Vec::new(),
         }
     }
+
+    /// Returns and drains accumulated `MSG_SUCCESS` file indices from the peer.
+    ///
+    /// The peer's generator/receiver sends `MSG_SUCCESS` with a 4-byte
+    /// little-endian file index once a file has been fully received and
+    /// committed. The sender drains these to run the deferred
+    /// `--remove-source-files` unlink for confirmed files only.
+    ///
+    /// Returns an empty `Vec` for plain-mode readers.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:1623-1637`: `MSG_SUCCESS` received; `!am_generator` calls
+    ///   `successful_send(val)`.
+    /// - `sender.c:131-182`: `successful_send()` performs the deferred unlink.
+    pub fn take_success_indices(&mut self) -> Vec<i32> {
+        match &mut self.inner {
+            ServerReaderInner::Multiplex(mux) => mux.take_success_indices(),
+            ServerReaderInner::Compressed(compressed) => {
+                compressed.get_mut().take_success_indices()
+            }
+            ServerReaderInner::Plain(_) => Vec::new(),
+        }
+    }
 }
 
 impl<R: Read> Read for ServerReader<R> {

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -33,6 +33,36 @@ use crate::transfer_ops::{
 type PipelineResult = (usize, u64, u64, u64, Vec<usize>, Vec<(PathBuf, PathBuf)>);
 
 impl ReceiverContext {
+    /// Emits `MSG_SUCCESS(ndx)` to the sender for every file whose commit was
+    /// confirmed since the last drain, when `--remove-source-files` is active.
+    ///
+    /// The sender defers its source unlink until it receives this confirmation,
+    /// so this is what lets the sender remove a source only after the file has
+    /// safely landed at the destination. When the flag is off the confirmed
+    /// indices are drained and discarded, keeping the accumulator bounded.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:1063-1069` - `send_msg_success(fname, ndx)` on `recv_ok == 1`.
+    /// - `io.c:1623-1637` - sender-side `MSG_SUCCESS` handler -> `successful_send`.
+    fn emit_confirmed_source_removals<W>(
+        &self,
+        writer: &mut W,
+        pipelined_receiver: &mut crate::pipeline::receiver::PipelinedReceiver,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        let confirmed = pipelined_receiver.drain_new_success_indices();
+        if !self.config.flags.remove_source_files {
+            return Ok(());
+        }
+        for flat_idx in confirmed {
+            writer.send_msg_success(self.flat_to_wire_ndx(flat_idx))?;
+        }
+        Ok(())
+    }
+
     /// Pipelined transfer loop with decoupled network/disk I/O.
     ///
     /// Fills a sliding window of file requests, computes signatures in parallel
@@ -363,6 +393,12 @@ impl ReceiverContext {
                 let (_disk_bytes, disk_meta_errors) = pipelined_receiver.drain_ready_results()?;
                 metadata_errors.extend(disk_meta_errors);
 
+                // upstream: receiver.c:1063-1069 - a committed file (recv_ok == 1)
+                // gets an immediate MSG_SUCCESS so the sender can unlink its
+                // --remove-source-files source. Emit for every file the drain
+                // just confirmed committed.
+                self.emit_confirmed_source_removals(writer, &mut pipelined_receiver)?;
+
                 // Route accumulated warnings through the multiplexed writer
                 // instead of eprintln (which deadlocks in daemon handler threads).
                 // Fatal transfer errors ride MSG_ERROR_XFER so the peer sets
@@ -427,6 +463,11 @@ impl ReceiverContext {
             // Drain all remaining disk results
             let (_disk_bytes, disk_meta_errors) = pipelined_receiver.drain_all_results()?;
             metadata_errors.extend(disk_meta_errors);
+
+            // upstream: receiver.c:1063-1069 - flush MSG_SUCCESS for the final
+            // batch of files the blocking drain just confirmed committed, so the
+            // sender unlinks their --remove-source-files sources.
+            self.emit_confirmed_source_removals(writer, &mut pipelined_receiver)?;
 
             // Route accumulated warnings through the multiplexed writer.
             // Fatal transfer errors ride MSG_ERROR_XFER so the peer sets

--- a/crates/transfer/src/writer/msg_info.rs
+++ b/crates/transfer/src/writer/msg_info.rs
@@ -64,6 +64,23 @@ pub trait MsgInfoSender {
     fn send_msg_deleted(&mut self, _data: &[u8]) -> io::Result<()> {
         Ok(())
     }
+
+    /// Sends a `MSG_SUCCESS` frame carrying the committed file's wire NDX.
+    ///
+    /// The receiver emits this once a file has been fully received and committed
+    /// (`recv_ok == 1`), telling the sender it is now safe to unlink that file's
+    /// `--remove-source-files` source. The payload is the bare 4-byte
+    /// little-endian file index.
+    ///
+    /// The default implementation is a no-op, matching [`Self::send_msg_info`].
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:1063-1069` - `send_msg_success(fname, ndx)` on `recv_ok == 1`.
+    /// - `io.c:1071-1086` - `send_msg_int(MSG_SUCCESS, ndx)` wire framing.
+    fn send_msg_success(&mut self, _ndx: i32) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 impl<W: Write> MsgInfoSender for ServerWriter<W> {
@@ -94,6 +111,17 @@ impl<W: Write> MsgInfoSender for ServerWriter<W> {
             Ok(())
         }
     }
+
+    fn send_msg_success(&mut self, ndx: i32) -> io::Result<()> {
+        // upstream: receiver.c:1063-1069 - MSG_SUCCESS only rides the
+        // multiplexed server stream back to the sender; plain mode (e.g. tests)
+        // never reaches this branch.
+        if self.is_multiplexed() {
+            self.send_success(ndx)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
@@ -108,6 +136,10 @@ impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
     fn send_msg_deleted(&mut self, data: &[u8]) -> io::Result<()> {
         (**self).send_msg_deleted(data)
     }
+
+    fn send_msg_success(&mut self, ndx: i32) -> io::Result<()> {
+        (**self).send_msg_success(ndx)
+    }
 }
 
 impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
@@ -121,5 +153,9 @@ impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
 
     fn send_msg_deleted(&mut self, data: &[u8]) -> io::Result<()> {
         self.inner_ref_mut().send_msg_deleted(data)
+    }
+
+    fn send_msg_success(&mut self, ndx: i32) -> io::Result<()> {
+        self.inner_ref_mut().send_msg_success(ndx)
     }
 }

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -263,6 +263,31 @@ impl<W: Write> ServerWriter<W> {
         self.send_message(MessageCode::Redo, &ndx.to_le_bytes())
     }
 
+    /// Sends a `MSG_SUCCESS` message for the given committed file index.
+    ///
+    /// The generator/receiver emits this only after a file has been fully
+    /// received and committed to its final destination, telling the sender it
+    /// is now safe to unlink that file's `--remove-source-files` source. The
+    /// payload is the bare 4-byte little-endian file index used by every
+    /// non-`local_server` peer; oc never runs as a `local_server` on the wire
+    /// (same-host copies take the engine path), so the 8+8 byte dev/ino guard
+    /// variant is not emitted.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:1071-1086`: `send_msg_success()` -> `send_msg_int(MSG_SUCCESS, ndx)`.
+    /// - `receiver.c:1063-1069`: emitted on `recv_ok == 1` (finish_transfer succeeded).
+    /// - `generator.c:1834-1839`: emitted for an already up-to-date source.
+    /// - `io.c:1623-1637`: sender-side handler runs `successful_send(ndx)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the writer is not in multiplex mode or the underlying
+    /// I/O operation fails.
+    pub fn send_success(&mut self, ndx: i32) -> io::Result<()> {
+        self.send_message(MessageCode::Success, &ndx.to_le_bytes())
+    }
+
     /// Sends a `MSG_IO_ERROR` message carrying the accumulated io_error bits.
     ///
     /// After the transfer loop, the sender reports any io_error accumulated


### PR DESCRIPTION
# fix(transfer): defer --remove-source-files unlink until MSG_SUCCESS

## Problem (HIGH severity, data loss)

With `--remove-source-files`, the sender unlinked each source file **inline**,
right after transmitting it - before the receiver had committed the file to
disk. In parallel, the multiplex reader dropped `MSG_SUCCESS` frames on the
floor (`reader/multiplex.rs` catch-all `_ => {}`). Together this meant a source
file could be deleted even though its transfer never safely landed (an
interrupted or failed transfer, or a redo), destroying data.

Upstream never does this. The generator/receiver sends `MSG_SUCCESS(ndx)` to the
sender **only after** the file is fully received and committed, and the sender's
`successful_send()` defers the unlink until that confirmation arrives.

## Upstream behaviour (source of truth: rsync 3.4.4, protocol 32)

- `io.c:1071-1086` `send_msg_success()` - frames `MSG_SUCCESS` as a bare 4-byte
  LE file index (`send_msg_int(MSG_SUCCESS, ndx)`) for a non-`local_server`
  peer.
- `io.c:1623-1637` - on receipt, a non-generator peer (the sender) runs
  `successful_send(val)`; the generator runs `got_flist_entry_status`.
- `sender.c:131-182` `successful_send()` - re-stats the source, applies the
  changed-file guard, and unlinks it - invoked from the `MSG_SUCCESS` handler,
  never inline at send time.
- `receiver.c:1063-1069` - emits `send_msg_success(fname, ndx)` on `recv_ok == 1`
  (finish_transfer succeeded).
- `generator.c:1834-1839` - emits `MSG_SUCCESS` for an already up-to-date source.
- `options.c:2243-2251` - `--remove-source-files` forces
  `need_messages_from_generator = 1`, so the generator->sender message channel
  (and thus `MSG_SUCCESS`) exists regardless of protocol version.

## Change

Receiver/generator side (emit):
- The pipelined receiver records each file whose commit is confirmed
  (checksum verified, `recv_ok == 1`) and, when `--remove-source-files` is
  active, sends `MSG_SUCCESS(ndx)` to the sender after the disk commit is
  drained (`pipeline/receiver.rs`, `receiver/transfer/pipeline.rs`).
- `MSG_SUCCESS` is emitted through a new `MsgInfoSender::send_msg_success` /
  `ServerWriter::send_success`.

Sender side (defer):
- The inline unlink is removed. Transmitted files are recorded in a focused
  `PendingSourceRemovals` set keyed by flat file-list index; the unlink runs
  only when `MSG_SUCCESS(ndx)` is consumed, via `confirm_source_removal()`,
  which still applies the existing re-stat / changed-file guards. A stray
  confirmation for an index the sender never marked is ignored.
- The multiplex reader now dispatches `MSG_SUCCESS` into a `success_indices`
  accumulator (`reader/multiplex.rs`, `reader/server.rs`) instead of dropping
  it; the sender drains it after the goodbye handshake.
- `should_activate_input_multiplex()` forces the generator->sender channel on
  when `--remove-source-files` is set, mirroring `options.c:2251`.

Flag plumbing:
- The client never threaded `--remove-source-files` onto its own in-process
  `ServerConfig`, so removal was silently skipped for every **remote** transfer
  (only local copies, handled by the engine, worked). Threaded it via
  `apply_common_server_flags` (the shared long-form-flag seam) so both the local
  sender (push) and the local generator/receiver (pull) act on it.

## Both-direction wire behaviour

- **Push** (oc sender -> peer receiver): oc marks each sent file pending, reads
  `MSG_SUCCESS(ndx)` from the peer's generator/receiver, and unlinks the local
  source only then.
- **Pull** (peer sender -> oc receiver): oc's receiver emits `MSG_SUCCESS(ndx)`
  after each commit so the peer sender unlinks its remote source.

## Tests (failing-first)

- `msg_success_is_dispatched_not_dropped` / `msg_success_indices_accumulate_in_order`
  - `MSG_SUCCESS` is dispatched, not dropped (fails against the `_ => {}` drop).
- `remove_source_files_unlinks_after_msg_success` - a source is removed only
  after the confirming `MSG_SUCCESS`.
- `remove_source_files_defers_until_msg_success` - an unconfirmed / interrupted
  transfer never deletes the source, and a stray confirmation is ignored.
- `remove_source_confirm_*` - the pending-removal set unlinks a marked index
  exactly once and ignores unmarked confirmations.

## Real-binary validation (upstream rsync 3.4.4, protocol 32)

- Push (oc sender -> upstream daemon receiver): local sources removed only after
  the upstream receiver's `MSG_SUCCESS`; destination committed.
- Pull (upstream daemon sender -> oc receiver): the upstream sender removed its
  module sources, driven by the `MSG_SUCCESS` oc's receiver emits after commit.

`cargo fmt --all`, `cargo clippy -p transfer -p core --all-features
--all-targets --no-deps -- -D warnings`, and the targeted transfer tests all
pass.
