### PR TITLE
fix(protocol): match upstream ACL/xattr wire caps, cap del-stat

### DIFF
--- a/crates/protocol/src/acl/constants.rs
+++ b/crates/protocol/src/acl/constants.rs
@@ -74,10 +74,12 @@ pub const ACCESS_SHIFT: u32 = 2;
 
 /// Defence-in-depth cap on the number of ACL named entries from the wire.
 ///
-/// POSIX ACLs typically have fewer than a dozen named entries. 4096 is
+/// POSIX ACLs typically have fewer than a dozen named entries. 65536 is
 /// well above any real-world usage while preventing a malicious peer from
 /// forcing unbounded allocations via a crafted count varint.
 ///
-/// upstream: acls.c `recv_ida_entries()` uses `EXPAND_ITEM_LIST` which
-/// reallocs but has no explicit count cap.
-pub const MAX_WIRE_ACL_ENTRIES: usize = 4096;
+/// upstream: acls.c:700 `recv_ida_entries()` reads the count via
+/// `read_varint_bounded(f, 0, MAX_WIRE_ACL_COUNT, "ACL count")`, and
+/// `MAX_WIRE_ACL_COUNT` is 65536 (rsync.h:179). We match that ceiling
+/// exactly so a transfer upstream 3.4.4 accepts is not rejected here.
+pub const MAX_WIRE_ACL_ENTRIES: usize = 65536;

--- a/crates/protocol/src/acl/wire/tests.rs
+++ b/crates/protocol/src/acl/wire/tests.rs
@@ -291,6 +291,28 @@ fn recv_ida_entries_eof_reading_count() {
 }
 
 #[test]
+fn recv_ida_entries_five_thousand_entries_decodes() {
+    // A large-but-legitimate ACL with 5000 named entries: above the former 4096
+    // cap, below upstream's 65536 ceiling. upstream: acls.c:700 reads the count
+    // via read_varint_bounded(f, 0, MAX_WIRE_ACL_COUNT, "ACL count"), where
+    // MAX_WIRE_ACL_COUNT is 65536 (rsync.h:179), then new_array(id_access, count)
+    // succeeds. WHY it matters: a 4096 cap rejected (exit 23) a transfer upstream
+    // 3.4.4 accepts (exit 0); a drop-in tool must accept the same ACLs upstream does.
+    let mut entries = IdaEntries::new();
+    for i in 0..5000u32 {
+        entries.push(IdAccess::user(1000 + i, 0x07));
+    }
+
+    let mut buf = Vec::new();
+    send_ida_entries(&mut buf, &entries, false).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let (received, mask) = recv_ida_entries(&mut cursor).expect("5000 entries must decode");
+    assert_eq!(received.len(), 5000);
+    assert_eq!(mask, 0x07);
+}
+
+#[test]
 fn recv_ida_entries_exceeds_max_count_is_protocol_violation() {
     use crate::acl::constants::MAX_WIRE_ACL_ENTRIES;
     use crate::varint::write_varint;

--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -11,8 +11,13 @@ use std::io::{self, Read, Write};
 /// overflow when the receiver accumulates counts across multiple
 /// `NDX_DEL_STATS` messages.
 ///
-/// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
-const MAX_WIRE_DEL_STAT: i32 = 0x3FFF_FFFF;
+/// upstream: rsync.h:181-187 defines `MAX_WIRE_DEL_STAT` as `(int32)1 << 28`.
+/// `read_del_stats()` accumulates 5 wire-supplied counts into the signed int32
+/// `stats.deleted_files` accumulator, so the per-field cap is held at 2^28 to
+/// keep `5 * 2^28 = 1.34 GB` under `INT32_MAX` (2.15 GB) with margin. A higher
+/// cap would let a hostile peer overflow the accumulator (signed-int UB). Match
+/// upstream exactly.
+const MAX_WIRE_DEL_STAT: i32 = 1 << 28;
 
 /// Deletion statistics exchanged via `NDX_DEL_STATS`.
 ///
@@ -158,7 +163,7 @@ impl DeleteStats {
 ///
 /// Rejects negative values and values exceeding [`MAX_WIRE_DEL_STAT`].
 ///
-/// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
+/// upstream: rsync.h:181-187 - MAX_WIRE_DEL_STAT = `(int32)1 << 28`.
 fn read_capped_del_stat(raw: i32, field: &str) -> io::Result<u32> {
     if !(0..=MAX_WIRE_DEL_STAT).contains(&raw) {
         // upstream: main.c:read_del_stats() reads each field via

--- a/crates/protocol/src/stats/tests.rs
+++ b/crates/protocol/src/stats/tests.rs
@@ -540,12 +540,12 @@ fn delete_stats_total() {
     assert_eq!(empty.total(), 0);
 }
 
-/// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
+/// upstream: rsync.h:181-187 - MAX_WIRE_DEL_STAT = (int32)1 << 28.
 #[test]
 fn delete_stats_rejects_oversized_wire_value() {
     use crate::varint::write_varint;
 
-    // Encode a value just above MAX_WIRE_DEL_STAT (0x3FFF_FFFF = 1_073_741_823)
+    // Encode a value well above MAX_WIRE_DEL_STAT (1 << 28 = 268_435_456).
     let oversized: i32 = 0x3FFF_FFFF + 1;
     let mut buf = Vec::new();
     write_varint(&mut buf, oversized).unwrap();
@@ -571,7 +571,7 @@ fn delete_stats_rejects_oversized_wire_value() {
     );
 }
 
-/// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
+/// upstream: rsync.h:181-187 - MAX_WIRE_DEL_STAT = (int32)1 << 28.
 #[test]
 fn delete_stats_rejects_negative_wire_value() {
     use crate::varint::write_varint;
@@ -597,11 +597,13 @@ fn delete_stats_rejects_negative_wire_value() {
 }
 
 /// Values at exactly MAX_WIRE_DEL_STAT must be accepted.
+///
+/// upstream: rsync.h:181-187 sets MAX_WIRE_DEL_STAT = `(int32)1 << 28`.
 #[test]
 fn delete_stats_accepts_value_at_cap() {
     use crate::varint::write_varint;
 
-    let at_cap: i32 = 0x3FFF_FFFF;
+    let at_cap: i32 = 1 << 28;
     let mut buf = Vec::new();
     write_varint(&mut buf, at_cap).unwrap();
     for _ in 0..4 {
@@ -611,6 +613,43 @@ fn delete_stats_accepts_value_at_cap() {
     let mut cursor = Cursor::new(&buf);
     let decoded = DeleteStats::read_from(&mut cursor).unwrap();
     assert_eq!(decoded.files, at_cap as u32);
+}
+
+/// A value above the lowered cap but at or below the former `0x3FFF_FFFF`
+/// ceiling must now be rejected.
+///
+/// This is the security-tightening WHY: read_del_stats() accumulates 5
+/// wire-supplied counts into the signed int32 `stats.deleted_files`
+/// accumulator (rsync.h:181-187). The former `0x3FFF_FFFF` cap let a hostile
+/// peer supplying 3+ near-max counts overflow that accumulator (signed-int UB).
+/// Holding the per-field cap at `1 << 28` keeps `5 * 2^28 = 1.34 GB` under
+/// `INT32_MAX` with margin. Values that oc formerly accepted are now rejected,
+/// matching upstream.
+#[test]
+fn delete_stats_rejects_value_above_lowered_cap() {
+    use crate::varint::write_varint;
+
+    // In (1<<28, 0x3FFF_FFFF]: accepted under the old cap, rejected under the new.
+    let above_new_cap: i32 = (1 << 28) + 1;
+    assert!(above_new_cap <= 0x3FFF_FFFF);
+    let mut buf = Vec::new();
+    write_varint(&mut buf, above_new_cap).unwrap();
+    for _ in 0..4 {
+        write_varint(&mut buf, 0).unwrap();
+    }
+
+    let mut cursor = Cursor::new(&buf);
+    let err = DeleteStats::read_from(&mut cursor).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("MAX_WIRE_DEL_STAT"),
+        "error should mention MAX_WIRE_DEL_STAT, got: {err}"
+    );
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "over-cap delete-stat must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
 }
 
 /// Oversized value in a non-first field is also rejected.

--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -86,15 +86,29 @@ pub const MAX_WIRE_XATTR_COUNT: usize = 1024;
 /// no upper bound beyond the overflow check against `SIZE_MAX`.
 pub const MAX_WIRE_XATTR_NAME_LEN: usize = 1024;
 
-/// Defence-in-depth cap on a single xattr value length from the wire (64 MiB).
+/// Defence-in-depth cap on a single xattr value length from the wire (1 GiB).
 ///
 /// Linux `XATTR_SIZE_MAX` is 65536 bytes, but some filesystems (XFS, Btrfs)
-/// and platforms (macOS resource forks) allow larger values. 64 MiB is
-/// generous enough for any legitimate xattr while bounding allocation.
+/// and platforms (macOS resource forks, transferred as `com.apple.ResourceFork`)
+/// allow much larger values.
 ///
-/// upstream: xattrs.c does an overflow check against `SIZE_MAX` but has
-/// no practical upper bound.
-pub const MAX_WIRE_XATTR_VALUE_LEN: usize = 64 * 1024 * 1024;
+/// upstream: xattrs.c:803 reads the datum length via
+/// `read_varint_size(f, MAX_WIRE_XATTR_DATALEN, "xattr datum_len")`, where
+/// `MAX_WIRE_XATTR_DATALEN` is `0x7fffffff` (~2 GiB, rsync.h:178). Upstream
+/// does not bound the datum by that wire ceiling directly; the real
+/// allocation guard is `--max-alloc` (default `DEFAULT_MAX_ALLOC` = 1 GiB,
+/// options.c:203) enforced inside `new_array()`/`my_alloc()`.
+///
+/// The full-value decode path (`recv_xattr_values`) allocates `datum_len`
+/// bytes up front, so the cap must stay a real allocation bound. `--max-alloc`
+/// is parsed at the CLI/core layer but is not threaded into these pure
+/// `fn(reader)` protocol decoders, so we pin the ceiling at the upstream
+/// default `--max-alloc` (1 GiB) rather than the `0x7fffffff` wire maximum.
+/// This accepts every legitimately sized macOS resource fork that upstream's
+/// default configuration accepts while keeping the allocation bounded. Full
+/// parity up to `0x7fffffff` requires wiring the configurable `--max-alloc`
+/// value from core into the decode path.
+pub const MAX_WIRE_XATTR_VALUE_LEN: usize = 1024 * 1024 * 1024;
 
 /// User namespace prefix for xattrs.
 pub const USER_PREFIX: &str = "user.";

--- a/crates/protocol/src/xattr/wire/tests.rs
+++ b/crates/protocol/src/xattr/wire/tests.rs
@@ -1217,6 +1217,68 @@ fn read_definitions_missing_nul_maps_to_fileio() {
     );
 }
 
+#[test]
+fn read_definitions_large_datum_within_max_alloc_decodes() {
+    use crate::xattr::MAX_WIRE_XATTR_VALUE_LEN;
+
+    // A macOS resource fork (com.apple.ResourceFork) between the former 64 MiB
+    // cap and upstream's default --max-alloc ceiling (1 GiB). Declared datum_len
+    // exceeds MAX_FULL_DATUM (32), so this list-phase entry is abbreviated: only
+    // the 16-byte digest is on the wire, no large allocation occurs here.
+    let datum_len: i32 = 65 * 1024 * 1024; // > old 64 MiB cap, < 1 GiB new cap
+    assert!(datum_len as usize <= MAX_WIRE_XATTR_VALUE_LEN);
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 1).unwrap(); // count
+    write_varint(&mut buf, 10).unwrap(); // name_len (incl NUL)
+    write_varint(&mut buf, datum_len).unwrap();
+    buf.extend_from_slice(b"user.fork");
+    buf.push(0);
+    buf.extend_from_slice(&[0xAA; MAX_XATTR_DIGEST_LEN]);
+
+    let mut cursor = Cursor::new(buf);
+    let set = read_xattr_definitions(&mut cursor).expect("datum below --max-alloc must decode");
+    // WHY: upstream reads datum_len via read_varint_size(f, MAX_WIRE_XATTR_DATALEN,
+    // ...) at xattrs.c:803, where MAX_WIRE_XATTR_DATALEN is 0x7fffffff (rsync.h:178);
+    // the real bound is --max-alloc (default 1 GiB, options.c:203). A 64 MiB cap
+    // rejected legitimate resource forks that upstream 3.4.4 accepts under its
+    // default config. A drop-in tool must accept the same transfers upstream does.
+    assert_eq!(set.len(), 1);
+    let entry = &set.entries()[0];
+    assert_eq!(entry.name(), b"user.fork");
+    assert!(entry.is_abbreviated());
+    assert_eq!(entry.datum_len(), datum_len as usize);
+}
+
+#[test]
+fn read_definitions_datum_over_max_alloc_rejected() {
+    use crate::xattr::MAX_WIRE_XATTR_VALUE_LEN;
+
+    // One byte past the --max-alloc-derived ceiling stays rejected: the cap is a
+    // real allocation bound, not merely the 0x7fffffff wire maximum, so a hostile
+    // ~2 GiB claim cannot OOM the receiver before --max-alloc is threaded here.
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 1).unwrap();
+    write_varint(&mut buf, 10).unwrap();
+    write_varint(&mut buf, (MAX_WIRE_XATTR_VALUE_LEN + 1) as i32).unwrap();
+    buf.extend_from_slice(b"user.fork");
+    buf.push(0);
+
+    let mut cursor = Cursor::new(buf);
+    let err = read_xattr_definitions(&mut cursor).expect_err("datum over cap must be rejected");
+    // WHY: upstream's new_array()/my_alloc() aborts a transfer whose single datum
+    // exceeds --max-alloc. We hold the same allocation bound and tag it
+    // ProtocolViolation so the core mapper yields RERR_PROTOCOL (2), not the
+    // RERR_STREAMIO (12) a bare InvalidData maps to.
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized xattr datum must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
+}
+
 /// Pins the literal-xattr wire layout to exact bytes and asserts it is
 /// protocol-version independent.
 ///

--- a/crates/protocol/tests/async_wire_read_leaves_parity.rs
+++ b/crates/protocol/tests/async_wire_read_leaves_parity.rs
@@ -271,7 +271,9 @@ async fn read_leaf_parity_delete_stats() {
             specials: 4,
         },
         DeleteStats {
-            files: 0x3FFF_FFFF,
+            // At the MAX_WIRE_DEL_STAT cap (rsync.h:181-187 = 1 << 28); a larger
+            // value is now rejected as a wire-overflow guard.
+            files: 1 << 28,
             dirs: 0,
             symlinks: 1,
             devices: 0x1234,

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -730,7 +730,7 @@ fn accumulate_xattr_num(prior_req: i32, rel_pos: i32) -> io::Result<i32> {
 ///
 /// Shared by the sync and async xattr readers. Upstream `xattrs.c:752` reads
 /// `datum_len` via `read_varint_size(..., MAX_WIRE_XATTR_DATALEN, ...)`; we use
-/// the stricter oc-rsync ceiling (`MAX_WIRE_XATTR_VALUE_LEN`, 64 MiB) so a
+/// the oc-rsync ceiling (`MAX_WIRE_XATTR_VALUE_LEN`, upstream default --max-alloc) so a
 /// corrupt or hostile frame surfaces as a typed error instead of an unbounded
 /// allocation or a varint overflow panic.
 #[inline]
@@ -922,12 +922,14 @@ mod xattr_abbrev_guard_tests {
 
     #[test]
     fn datum_len_exceeding_cap_returns_typed_error() {
-        // datum_len just above the 64 MiB receiver-side ceiling must be
+        // datum_len just above the receiver-side ceiling must be
         // rejected with InvalidData rather than triggering a giant `vec!`
         // allocation. Mirrors upstream xattrs.c:752 bounded read.
         let mut bytes = Vec::new();
         bytes.extend(encode_varint(1));
-        bytes.extend(encode_varint((64 * 1024 * 1024) + 1));
+        bytes.extend(encode_varint(
+            (protocol::xattr::MAX_WIRE_XATTR_VALUE_LEN as i32) + 1,
+        ));
 
         let mut reader = Cursor::new(bytes);
         let err = read_xattr_abbreviation_data(&mut reader).expect_err("must error");


### PR DESCRIPTION
## Summary

Aligns three attacker-controlled wire ceilings in `crates/protocol` with upstream rsync 3.4.4 (protocol 32). Two were stricter than upstream and rejected transfers a real 3.4.4 peer accepts; one was more lenient than upstream and left a signed-int overflow reachable from the wire.

Upstream ceilings (all in `rsync.h:176-187`):

| Cap | Upstream 3.4.4 | oc before | oc after |
|-----|----------------|-----------|----------|
| `MAX_WIRE_ACL_COUNT` | `65536` | `4096` | `65536` |
| `MAX_WIRE_XATTR_DATALEN` | `0x7fffffff` (guarded by `--max-alloc`, default 1 GiB) | `64 MiB` | `1 GiB` (default `--max-alloc`) |
| `MAX_WIRE_DEL_STAT` | `(int32)1 << 28` | `0x3FFFFFFF` | `1 << 28` |

## ACL entry count (was too strict)

`acls.c:700 recv_ida_entries()` reads the entry count via `read_varint_bounded(f, 0, MAX_WIRE_ACL_COUNT, "ACL count")`, and `MAX_WIRE_ACL_COUNT` is `65536` (`rsync.h:179`). oc capped at `4096`. Reproduced against the real binaries: an ACL with 5000 named-user entries (above 4096, below 65536) is accepted by upstream 3.4.4 (`exit 0`) but rejected by oc (`exit 23`). Raised the ceiling to `65536` to match upstream exactly; it stays bounded so a crafted count varint cannot force an unbounded allocation.

## xattr datum length (was too strict; raised to a safe interim bound)

`xattrs.c:803` reads the datum length via `read_varint_size(f, MAX_WIRE_XATTR_DATALEN, "xattr datum_len")`, where `MAX_WIRE_XATTR_DATALEN` is `0x7fffffff` (~2 GiB, `rsync.h:178`). Upstream does not treat that wire ceiling as the real bound: the actual allocation guard is `--max-alloc` (default `DEFAULT_MAX_ALLOC` = 1 GiB, `options.c:203`) enforced inside `new_array()`/`my_alloc()`. oc's `64 MiB` cap rejected a macOS `com.apple.ResourceFork` xattr larger than 64 MiB under `-X`, which upstream's default configuration accepts.

The full-value decode path allocates `datum_len` bytes up front, so the ceiling must remain a real allocation bound rather than the raw `0x7fffffff` wire maximum. oc parses `--max-alloc` at the CLI/core layer (`config.max_alloc()`), but that value is **not** threaded into the pure `fn(reader)` protocol decoders. Wiring the configurable `--max-alloc` into the decode path would require changing the protocol decode signatures and plumbing the value from `core`, which is outside `crates/protocol`.

Rather than raise the ceiling to `0x7fffffff` without an allocation guard (which would let a hostile peer claim ~2 GiB and OOM the receiver), this change pins the ceiling at the upstream **default** `--max-alloc` value of **1 GiB**. This accepts every legitimately sized macOS resource fork that upstream's default configuration accepts while keeping a single-datum allocation bounded at exactly what upstream permits by default. Full parity up to `0x7fffffff` remains available once the configurable `--max-alloc` is threaded into the decode path; that plumbing is noted in the code comment as a follow-up.

## delete-stat cap (was too lenient - security)

`read_del_stats()` accumulates 5 wire-supplied counts into the signed `int32` `stats.deleted_files` accumulator. `rsync.h:181-187` therefore caps each field at `(int32)1 << 28` so `5 * 2^28 = 1.34 GB` stays under `INT32_MAX` (2.15 GB) with margin. oc used `0x3FFFFFFF`, which lets a hostile peer supplying 3+ near-max counts overflow the signed accumulator (signed-int UB / incorrect stats). Lowered to `1 << 28` to mirror upstream exactly.

## Tests

Failing-first WHY-tests, each citing upstream:

- ACL: a 5000-entry payload now decodes (was rejected at 4096); a count above `65536` is still rejected as `ProtocolViolation`.
- xattr: a datum length between the former 64 MiB cap and the new 1 GiB ceiling now decodes (abbreviated list entry, no large allocation); a datum one byte past the ceiling is still cleanly rejected as `ProtocolViolation`, proving the cap is a real allocation bound.
- delete-stat: a value in `(1<<28, 0x3FFFFFFF]` - formerly accepted - is now rejected as `ProtocolViolation`; a value at exactly `1<<28` is still accepted.

Adjacent tests that hardcoded the old ceilings were updated to the new values. `cargo fmt`, `cargo clippy -p protocol --all-features --all-targets --no-deps -- -D warnings`, and the targeted `protocol` nextest suite (`test(acl)+test(xattr)+test(del)+test(wire)`, 1061 tests) all pass.
