### PR TITLE
fix(protocol): tombstone flist duplicates to keep NDX aligned

### DIFF
--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -151,20 +151,24 @@ impl DualFileList {
     /// lockstep so a caller-owned array (the generator's `source_bases`) stays
     /// aligned with the cleaned list.
     ///
-    /// This is the sender-side half of upstream's `flist_sort_and_clean`: the
-    /// sender dedups before transmitting so the receiver's identical pass is
-    /// idempotent and both sides keep matching NDX numbering. The list MUST
-    /// already be sorted (call [`sort_with_parallel`](Self::sort_with_parallel)
-    /// first) - dedup only collapses adjacent equal names. On a list with no
-    /// duplicates this changes neither order nor length.
+    /// The list MUST already be sorted (call
+    /// [`sort_with_parallel`](Self::sort_with_parallel) first) - dedup only
+    /// collapses adjacent equal names. On a list with no duplicates this changes
+    /// neither order nor length.
     ///
-    /// Reuses `resolve_duplicate` (`super::sort::resolve_duplicate`) so the
-    /// keep/drop tie-break is identical to the receiver's `flist_clean`. oc
-    /// converges both sides to the same sorted+cleaned list, so it drops
-    /// duplicates symmetrically rather than following upstream's `am_sender`
-    /// branch (mark a dup dir `FLAG_DUPLICATE` and keep it for the in-place
-    /// `dir_flist` tree at `flist.c:3067`); oc has no such tree, and keeping the
-    /// dup only on the sender would desync the NDX count.
+    /// # Sender skip
+    ///
+    /// A non-incremental sender (`am_sender && !inc_recurse`) must NOT remove
+    /// duplicates: upstream skips the clean loop entirely (`flist.c:3039-3042`)
+    /// and transmits every entry as-is, so the receiver's in-place tombstones
+    /// keep both sides' NDX numbering aligned. This method returns immediately in
+    /// that case, leaving the list (and `parallel`) untouched.
+    ///
+    /// Under INC_RECURSE the pass still runs (upstream's `!am_sender ||
+    /// inc_recurse` branch): each sub-list is cleaned so its numbering matches
+    /// the receiver's identical pass. It reuses
+    /// [`resolve_duplicate`](super::sort::resolve_duplicate) for an identical
+    /// keep/drop tie-break.
     ///
     /// # Panics
     ///
@@ -174,11 +178,26 @@ impl DualFileList {
     ///
     /// - `flist.c:2544` - `flist_sort_and_clean(flist, 0)` runs in
     ///   `send_file_list()`; the sender passes `strip_root = 0`.
+    /// - `flist.c:3039-3042` - `am_sender && !inc_recurse` skips the clean loop.
     /// - `flist.c:3046-3082` - the duplicate-removal tie-break this mirrors.
-    pub fn dedup_with_parallel<P>(&mut self, parallel: &mut Vec<P>) -> super::sort::CleanResult {
+    pub fn dedup_with_parallel<P>(
+        &mut self,
+        parallel: &mut Vec<P>,
+        am_sender: bool,
+        inc_recurse: bool,
+    ) -> super::sort::CleanResult {
         let len = self.legacy.len();
         let mut stats = super::sort::CleanResult::default();
         if len == 0 {
+            return stats;
+        }
+        // upstream: flist.c:3039-3042 - a non-incremental sender transmits
+        // duplicates as-is (skips the clean loop) so the receiver's tombstones
+        // keep both sides' NDX numbering aligned. A sender cannot tombstone-skip
+        // a slot without transmitting fewer entries than its array holds, which
+        // would desync the wire NDX; transmitting the full array is the only
+        // NDX-safe behaviour.
+        if am_sender && !inc_recurse {
             return stats;
         }
         debug_assert_eq!(parallel.len(), len);
@@ -449,14 +468,15 @@ mod tests {
 
     #[test]
     fn dedup_with_parallel_noop_on_distinct_names() {
-        // WHY: the sender dedup must not shift order or count for a normal
+        // WHY: the dedup must not shift order or count for a normal
         // (duplicate-free) list, or sender/receiver NDX numbering desyncs.
+        // Exercised in the INC_RECURSE mode where the sender still cleans.
         let mut list = DualFileList::new();
         for n in ["a.txt", "b.txt", "c.txt"] {
             list.push(FileEntry::new_file(n.into(), 0, 0o644));
         }
         let mut bases = vec!["ba", "bb", "bc"];
-        let stats = list.dedup_with_parallel(&mut bases);
+        let stats = list.dedup_with_parallel(&mut bases, true, true);
         assert_eq!(stats.duplicates_removed, 0);
         let names: Vec<&str> = list.iter().map(|e| e.name()).collect();
         assert_eq!(names, ["a.txt", "b.txt", "c.txt"]);
@@ -464,15 +484,33 @@ mod tests {
     }
 
     #[test]
-    fn dedup_with_parallel_removes_dup_and_keeps_base_aligned() {
-        // WHY: when a duplicate is dropped, the survivor's parallel source_base
-        // must travel with it so file_list[i] still maps to source_bases[i].
+    fn dedup_with_parallel_sender_noninc_transmits_duplicates() {
+        // WHY: a non-incremental sender must NOT remove duplicates - it transmits
+        // every entry so the receiver's in-place tombstones keep the wire NDX
+        // aligned. upstream: flist.c:3039-3042.
         let mut list = DualFileList::new();
         list.push(FileEntry::new_file("dup".into(), 0, 0o644));
         list.push(FileEntry::new_file("dup".into(), 0, 0o644));
         list.push(FileEntry::new_file("z".into(), 0, 0o644));
         let mut bases = vec!["first", "second", "zbase"];
-        let stats = list.dedup_with_parallel(&mut bases);
+        let stats = list.dedup_with_parallel(&mut bases, true, false);
+        assert_eq!(stats.duplicates_removed, 0);
+        let names: Vec<&str> = list.iter().map(|e| e.name()).collect();
+        assert_eq!(names, ["dup", "dup", "z"]);
+        assert_eq!(bases, ["first", "second", "zbase"]);
+    }
+
+    #[test]
+    fn dedup_with_parallel_removes_dup_and_keeps_base_aligned() {
+        // WHY: when a duplicate is dropped (INC_RECURSE sender clean), the
+        // survivor's parallel source_base must travel with it so file_list[i]
+        // still maps to source_bases[i].
+        let mut list = DualFileList::new();
+        list.push(FileEntry::new_file("dup".into(), 0, 0o644));
+        list.push(FileEntry::new_file("dup".into(), 0, 0o644));
+        list.push(FileEntry::new_file("z".into(), 0, 0o644));
+        let mut bases = vec!["first", "second", "zbase"];
+        let stats = list.dedup_with_parallel(&mut bases, true, true);
         assert_eq!(stats.duplicates_removed, 1);
         let names: Vec<&str> = list.iter().map(|e| e.name()).collect();
         assert_eq!(names, ["dup", "z"]);
@@ -488,7 +526,7 @@ mod tests {
         list.push(FileEntry::new_file("item".into(), 0, 0o644));
         list.push(FileEntry::new_directory("item".into(), 0o755));
         let mut bases = vec!["file_base", "dir_base"];
-        let stats = list.dedup_with_parallel(&mut bases);
+        let stats = list.dedup_with_parallel(&mut bases, true, true);
         assert_eq!(stats.duplicates_removed, 1);
         assert_eq!(list.len(), 1);
         assert!(list[0].is_dir());
@@ -496,23 +534,35 @@ mod tests {
     }
 
     #[test]
-    fn sender_dedup_makes_receiver_pass_idempotent() {
-        // WHY: the whole point of the sender-side dedup is that the receiver's
-        // identical flist_clean then removes NOTHING, so both sides keep the
-        // same entry count and NDX numbering (no RERR_PROTOCOL desync).
+    fn sender_noninc_transmit_then_receiver_tombstones_align() {
+        // WHY: the non-incremental sender transmits duplicates as-is; the
+        // receiver's flist_clean then TOMBSTONES the duplicate in place, keeping
+        // the array length (and every NDX slot) so both sides stay aligned (no
+        // RERR_PROTOCOL desync). upstream: flist.c:3039-3042 + 3089.
         let mut list = DualFileList::new();
         list.push(FileEntry::new_file("a".into(), 0, 0o644));
         list.push(FileEntry::new_file("dup".into(), 0, 0o644));
         list.push(FileEntry::new_file("dup".into(), 0, 0o644));
         let mut bases = vec!["a", "d1", "d2"];
-        list.dedup_with_parallel(&mut bases);
+        // Non-inc sender: no removal.
+        list.dedup_with_parallel(&mut bases, true, false);
+        assert_eq!(list.len(), 3);
         let transmitted = list.into_vec();
-        // Receiver runs the same clean over the (already-deduped) transmitted list.
-        let (_receiver_list, stats) = crate::flist::sort::flist_clean(transmitted.clone());
+        // Receiver tombstones the second "dup" but preserves the slot count.
+        let (receiver_list, stats) =
+            crate::flist::sort::flist_clean(transmitted.clone(), false, false);
+        assert_eq!(stats.duplicates_removed, 1);
         assert_eq!(
-            stats.duplicates_removed, 0,
-            "receiver must remove nothing from a sender-deduped list"
+            receiver_list.len(),
+            transmitted.len(),
+            "receiver must keep every NDX slot"
         );
+        let active: Vec<&str> = receiver_list
+            .iter()
+            .filter(|e| e.is_active())
+            .map(|e| e.name())
+            .collect();
+        assert_eq!(active, ["a", "dup"]);
     }
 
     #[test]

--- a/crates/protocol/src/flist/entry/accessors.rs
+++ b/crates/protocol/src/flist/entry/accessors.rs
@@ -640,6 +640,42 @@ impl FileEntry {
         type_bits == 0o140000 || type_bits == 0o010000 // S_IFSOCK or S_IFIFO
     }
 
+    /// Returns `true` when this entry is a live file-list slot (not a tombstone).
+    ///
+    /// Mirrors upstream rsync's `F_IS_ACTIVE(f)` macro, which tests
+    /// `basename[0]` (rsync.h:925): a real entry always has a non-empty name,
+    /// while a slot cleared by `clear_file()` (a dropped duplicate) or
+    /// `flist_free()` (a reclaimed INC_RECURSE segment) has an empty name and
+    /// is therefore inactive. Inactive slots keep their array position so NDX
+    /// (file index) values stay aligned with the sender's un-deduped array;
+    /// consumers iterate the list and skip inactive slots without renumbering.
+    #[inline]
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        !self.name.as_os_str().is_empty()
+    }
+
+    /// Marks this entry as a dead-but-present tombstone in place.
+    ///
+    /// The slot keeps its array index (and therefore its NDX) so the file
+    /// list stays aligned with a peer that transmitted the entry, but the
+    /// entry is cleared to an inert state that every consumer skips
+    /// (`is_active()` returns `false`; `is_dir()`/`is_file()` return `false`
+    /// for the zeroed mode). Used by the receiver's duplicate-name clean to
+    /// drop a duplicate without compacting or renumbering the list.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2930 clear_file()` - `memset(file, 0, ...)` zeroes the
+    ///   struct (including `basename[0]`, making `F_IS_ACTIVE` false) while
+    ///   leaving the slot in `flist->files[]` so following NDX values are
+    ///   unaffected.
+    /// - `flist.c:3089` - the receiver's dedup pass calls `clear_file()` on
+    ///   the dropped duplicate.
+    pub fn tombstone(&mut self) {
+        self.reclaim_heap_data();
+    }
+
     /// Releases heap-allocated data from this entry to reduce RSS.
     ///
     /// Clears the `name` (PathBuf), resets `dirname` to a shared empty arc,

--- a/crates/protocol/src/flist/sort.rs
+++ b/crates/protocol/src/flist/sort.rs
@@ -326,74 +326,170 @@ pub(super) fn resolve_duplicate(
     }
 }
 
-/// Cleans a sorted file list in-place by removing duplicates and merging directory flags.
+/// Scans backward from a directory entry for an active, same-named non-dir
+/// earlier in the sorted list.
 ///
-/// This mirrors upstream's `clean_flist()` which operates in-place with zero allocation,
-/// clearing duplicate entries as tombstones rather than building a new list.
-///
-/// # Duplicate Handling Rules
-///
-/// When duplicate paths are found:
-/// 1. If one is a directory and the other isn't, keep the directory
-///    (it may have contents in the list)
-/// 2. If both are directories, keep the first and merge flags
-/// 3. Otherwise, keep the first entry
-///
-/// # Arguments
-///
-/// * `file_list` - A sorted file list (call `sort_file_list` first)
-///
-/// # Returns
-///
-/// A tuple of `(cleaned_list, CleanResult)` where `cleaned_list` contains
-/// deduplicated entries and `CleanResult` has statistics.
+/// The primary adjacent-name check catches a directory whose same-named non-dir
+/// twin sorts immediately before it. This handles the non-adjacent case: files
+/// sort before directories, but an entry such as `item!` (a byte that sorts
+/// before `/`) can sit between the exact same-named non-dir `item` and the
+/// directory `item` (which sorts as `item/`). Only names equal to this dir's
+/// name, or extending it with a byte that sorts before `/`, can lie in that
+/// span, so the scan stops once it leaves the zone. Tombstoned slots keep their
+/// position and are skipped without ending the scan.
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:flist_sort_and_clean()` lines 2979-3069
+/// - `flist.c:3052-3059` - "Make sure that this directory doesn't duplicate a
+///   non-directory earlier in the list." Upstream temporarily sets
+///   `file->mode = S_IFREG` and calls `flist_find()` (a binary search over the
+///   sorted array) to locate the twin.
+fn find_regfile_dup(file_list: &[FileEntry], dir_idx: usize) -> Option<usize> {
+    let dir_name = file_list[dir_idx].name_bytes();
+    let dir_name = dir_name.as_ref();
+    let mut k = dir_idx;
+    while k > 0 {
+        k -= 1;
+        // Tombstones keep their slot; skip them and keep scanning.
+        if !file_list[k].is_active() {
+            continue;
+        }
+        let name = file_list[k].name_bytes();
+        let name = name.as_ref();
+        if name == dir_name {
+            if !file_list[k].is_dir() {
+                return Some(k);
+            }
+            // A same-named dir is handled via the adjacent-name path; keep
+            // scanning past it for an earlier non-dir twin.
+            continue;
+        }
+        // Leave the zone once the name is neither the dir's name nor an
+        // extension of it by a byte that sorts before '/'.
+        let extends_before_slash = name.len() > dir_name.len()
+            && name.starts_with(dir_name)
+            && name[dir_name.len()] < b'/';
+        if !extends_before_slash {
+            break;
+        }
+    }
+    None
+}
+
+/// Cleans a sorted file list in-place by tombstoning duplicate names.
+///
+/// Mirrors upstream's duplicate-clean pass inside `flist_sort_and_clean()`.
+/// The dropped duplicate is cleared in place (see [`FileEntry::tombstone`]) so
+/// the array length and every NDX (file index) slot are preserved: the
+/// receiver's numbering stays aligned with the sender's full un-deduped array.
+/// The list is NOT compacted, truncated, or renumbered. Consumers iterate the
+/// list and skip inactive slots.
+///
+/// # Sender vs receiver
+///
+/// A non-incremental sender (`am_sender && !inc_recurse`) skips the pass
+/// entirely and transmits every entry as-is; the receiver's tombstones then
+/// keep both sides aligned. The receiver (`am_sender == false`) always runs
+/// the pass.
+///
+/// # Duplicate Handling Rules
+///
+/// When duplicate names are found:
+/// 1. If one is a directory and the other isn't, keep the directory
+///    (it may have contents in the list).
+/// 2. If both are directories, keep the first and merge flags.
+/// 3. Otherwise, keep the first entry.
+///
+/// # Arguments
+///
+/// * `file_list` - A sorted file list (call `sort_file_list` first).
+/// * `am_sender` - `true` on the sending side.
+/// * `inc_recurse` - `true` when INC_RECURSE is negotiated.
+///
+/// # Returns
+///
+/// A tuple of `(cleaned_list, CleanResult)` where `cleaned_list` has the same
+/// length as the input, dropped duplicates tombstoned, and `CleanResult`
+/// carries statistics.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:3016-3104 flist_sort_and_clean()` - the sort + duplicate-clean.
+/// - `flist.c:3031-3042` - `am_sender && !inc_recurse` skips the clean loop.
+/// - `flist.c:3089 clear_file()` - the receiver tombstones the dropped slot.
 #[must_use]
-pub fn flist_clean(mut file_list: Vec<FileEntry>) -> (Vec<FileEntry>, CleanResult) {
+pub fn flist_clean(
+    mut file_list: Vec<FileEntry>,
+    am_sender: bool,
+    inc_recurse: bool,
+) -> (Vec<FileEntry>, CleanResult) {
     let len = file_list.len();
+    let mut stats = CleanResult::default();
     if len == 0 {
-        return (file_list, CleanResult::default());
+        return (file_list, stats);
     }
 
-    let mut stats = CleanResult::default();
+    // upstream: flist.c:3039-3042 - a non-incremental sender sets `i = used - 1`
+    // so the clean loop never runs; it transmits duplicates as-is so the
+    // receiver's tombstones keep NDX aligned with this full array.
+    if am_sender && !inc_recurse {
+        return (file_list, stats);
+    }
 
-    // Write cursor: position where the next kept entry goes.
-    // Read cursor `r` scans ahead. Like upstream's in-place tombstone approach,
-    // but we compact immediately so a single truncate suffices.
-    let mut w: usize = 0;
-    let mut r: usize = 1;
+    // upstream: flist.c:3032-3038 - anchor `prev` on the first active entry.
+    // A freshly sorted list has no tombstones, but scan defensively.
+    let mut prev = 0usize;
+    while prev < len && !file_list[prev].is_active() {
+        prev += 1;
+    }
+    if prev >= len {
+        return (file_list, stats);
+    }
 
-    while r < len {
-        if file_list[w].name() != file_list[r].name() {
-            w += 1;
-            if w != r {
-                file_list.swap(w, r);
-            }
-            r += 1;
+    let mut i = prev + 1;
+    while i < len {
+        if !file_list[i].is_active() {
+            i += 1;
             continue;
         }
 
-        // Duplicate found - decide which entry survives at position `w`.
-        // Split the borrow so the write entry is `&mut` and the read entry
-        // `&` simultaneously; a `true` verdict means take the read entry.
-        let (left, right) = file_list.split_at_mut(r);
-        if resolve_duplicate(&mut left[w], &right[0], &mut stats) {
-            file_list.swap(w, r);
+        // upstream: flist.c:3050-3061 - a duplicate is either the same name as
+        // the previous kept entry, or (for a directory) an earlier same-named
+        // non-dir found via flist_find().
+        let dup = if file_list[i].name() == file_list[prev].name() {
+            Some(prev)
+        } else if file_list[i].is_dir() {
+            find_regfile_dup(&file_list, i)
+        } else {
+            None
+        };
+
+        let Some(j) = dup else {
+            prev = i;
+            i += 1;
+            continue;
+        };
+
+        // upstream: flist.c:3062-3090 - keep the directory over a plain file
+        // (it may have contents in the list), else keep the first; the receiver
+        // tombstones the dropped slot in place. `resolve_duplicate` returns
+        // `true` when the later entry `i` wins.
+        let (left, right) = file_list.split_at_mut(i);
+        let take_read = resolve_duplicate(&mut left[j], &right[0], &mut stats);
+        if take_read {
+            file_list[j].tombstone();
+            prev = i;
+        } else {
+            file_list[i].tombstone();
         }
-
-        r += 1;
+        i += 1;
     }
-
-    file_list.truncate(w + 1);
 
     debug_log!(
         Flist,
         2,
-        "cleaned file list: {} entries, {} duplicates removed, {} flags merged",
-        file_list.len(),
+        "cleaned file list: {} slots, {} duplicates tombstoned, {} flags merged",
+        len,
         stats.duplicates_removed,
         stats.flags_merged
     );
@@ -414,9 +510,11 @@ pub fn sort_and_clean_file_list(
     mut file_list: Vec<FileEntry>,
     use_qsort: bool,
     protocol_pre29: bool,
+    am_sender: bool,
+    inc_recurse: bool,
 ) -> (Vec<FileEntry>, CleanResult) {
     sort_file_list(&mut file_list, use_qsort, protocol_pre29);
-    flist_clean(file_list)
+    flist_clean(file_list, am_sender, inc_recurse)
 }
 
 /// Apply a precomputed sort permutation to two parallel slices in lockstep.
@@ -554,10 +652,18 @@ mod tests {
 
     // flist_clean tests
 
+    /// Names of the active (non-tombstone) entries, in array order.
+    fn active_names(list: &[FileEntry]) -> Vec<&str> {
+        list.iter()
+            .filter(|e| e.is_active())
+            .map(FileEntry::name)
+            .collect()
+    }
+
     #[test]
     fn flist_clean_empty_list() {
         let entries: Vec<FileEntry> = vec![];
-        let (cleaned, stats) = flist_clean(entries);
+        let (cleaned, stats) = flist_clean(entries, false, false);
         assert!(cleaned.is_empty());
         assert_eq!(stats.duplicates_removed, 0);
         assert_eq!(stats.flags_merged, 0);
@@ -566,56 +672,75 @@ mod tests {
     #[test]
     fn flist_clean_no_duplicates() {
         let entries = vec![make_file("a.txt"), make_file("b.txt"), make_dir("c")];
-        let (cleaned, stats) = flist_clean(entries);
+        let (cleaned, stats) = flist_clean(entries, false, false);
         assert_eq!(cleaned.len(), 3);
+        assert!(cleaned.iter().all(FileEntry::is_active));
         assert_eq!(stats.duplicates_removed, 0);
     }
 
+    /// The receiver must TOMBSTONE dropped duplicates in place, preserving the
+    /// array length and every NDX slot, rather than compacting and renumbering.
+    /// A shorter list would desync the receiver's NDX from an upstream sender's
+    /// full un-deduped array (received "non-regular file" / silent corruption).
+    /// upstream: flist.c:3089 clear_file() drops the slot without moving others.
     #[test]
-    fn flist_clean_removes_file_duplicates() {
-        // Two files with same name - keep first
+    fn flist_clean_tombstones_file_duplicates_in_place() {
+        // Two files with same name - keep first, tombstone the second slot.
         let entries = vec![make_file("a.txt"), make_file("a.txt"), make_file("b.txt")];
-        let (cleaned, stats) = flist_clean(entries);
-        assert_eq!(cleaned.len(), 2);
+        let (cleaned, stats) = flist_clean(entries, false, false);
+        // Length and NDX slots preserved.
+        assert_eq!(cleaned.len(), 3);
         assert_eq!(stats.duplicates_removed, 1);
-        let mut names = Vec::with_capacity(cleaned.len());
-        names.extend(cleaned.iter().map(|e| e.name()));
-        assert_eq!(names, vec!["a.txt", "b.txt"]);
+        // Slot 0 kept, slot 1 tombstoned, slot 2 kept.
+        assert!(cleaned[0].is_active());
+        assert_eq!(cleaned[0].name(), "a.txt");
+        assert!(!cleaned[1].is_active());
+        assert!(cleaned[2].is_active());
+        assert_eq!(cleaned[2].name(), "b.txt");
+        assert_eq!(active_names(&cleaned), vec!["a.txt", "b.txt"]);
     }
 
     #[test]
     fn flist_clean_keeps_dir_over_file() {
-        // Directory vs file with same name - keep directory
+        // Directory vs file with same name - keep directory, tombstone the file.
         let entries = vec![make_file("item"), make_dir("item")];
-        let (cleaned, stats) = flist_clean(entries);
-        assert_eq!(cleaned.len(), 1);
+        let (cleaned, stats) = flist_clean(entries, false, false);
+        assert_eq!(cleaned.len(), 2);
         assert_eq!(stats.duplicates_removed, 1);
-        assert!(cleaned[0].is_dir());
+        // The file slot (0) is tombstoned; the dir survives at slot 1 so its
+        // NDX still matches the sender's directory entry.
+        assert!(!cleaned[0].is_active());
+        assert!(cleaned[1].is_active());
+        assert!(cleaned[1].is_dir());
     }
 
     #[test]
     fn flist_clean_keeps_dir_over_file_reverse_order() {
-        // Directory first, then file with same name - still keep directory
+        // Directory first, then file with same name - still keep the directory.
         let entries = vec![make_dir("item"), make_file("item")];
-        let (cleaned, stats) = flist_clean(entries);
-        assert_eq!(cleaned.len(), 1);
+        let (cleaned, stats) = flist_clean(entries, false, false);
+        assert_eq!(cleaned.len(), 2);
         assert_eq!(stats.duplicates_removed, 1);
+        assert!(cleaned[0].is_active());
         assert!(cleaned[0].is_dir());
+        assert!(!cleaned[1].is_active());
     }
 
     #[test]
     fn flist_clean_merges_directory_flags() {
-        // Two directories with same name - merge flags, keep first
+        // Two directories with same name - merge flags, keep first.
         let mut dir1 = make_dir("subdir");
         dir1.set_content_dir(false);
         let dir2 = make_dir("subdir"); // content_dir is true by default
         let entries = vec![dir1, dir2];
-        let (cleaned, stats) = flist_clean(entries);
-        assert_eq!(cleaned.len(), 1);
+        let (cleaned, stats) = flist_clean(entries, false, false);
+        assert_eq!(cleaned.len(), 2);
         assert_eq!(stats.duplicates_removed, 1);
         assert_eq!(stats.flags_merged, 1);
-        // Flag should be merged (content_dir should be true since dir2 had it)
+        // Survivor at slot 0 with the merged content-dir flag; slot 1 tombstoned.
+        assert!(cleaned[0].is_active());
         assert!(cleaned[0].content_dir());
+        assert!(!cleaned[1].is_active());
     }
 
     #[test]
@@ -626,9 +751,61 @@ mod tests {
             make_file("a.txt"),
             make_file("b.txt"),
         ];
-        let (cleaned, stats) = flist_clean(entries);
-        assert_eq!(cleaned.len(), 2);
+        let (cleaned, stats) = flist_clean(entries, false, false);
+        // Length preserved; two slots tombstoned.
+        assert_eq!(cleaned.len(), 4);
         assert_eq!(stats.duplicates_removed, 2);
+        assert!(cleaned[0].is_active());
+        assert!(!cleaned[1].is_active());
+        assert!(!cleaned[2].is_active());
+        assert!(cleaned[3].is_active());
+        assert_eq!(active_names(&cleaned), vec!["a.txt", "b.txt"]);
+    }
+
+    /// A non-incremental SENDER must skip the clean pass entirely and transmit
+    /// duplicates as-is; otherwise it would ship fewer entries than the receiver
+    /// tombstones, desyncing the wire NDX. upstream: flist.c:3039-3042.
+    #[test]
+    fn flist_clean_sender_noninc_skips_dedup() {
+        let entries = vec![make_file("dup"), make_file("dup"), make_file("z")];
+        let (kept, stats) = flist_clean(entries, true, false);
+        assert_eq!(stats.duplicates_removed, 0);
+        // Nothing tombstoned: all three transmitted as-is.
+        assert_eq!(kept.len(), 3);
+        assert!(kept.iter().all(FileEntry::is_active));
+        assert_eq!(active_names(&kept), vec!["dup", "dup", "z"]);
+    }
+
+    /// An incremental sender still cleans (upstream `!am_sender || inc_recurse`).
+    #[test]
+    fn flist_clean_sender_inc_recurse_still_cleans() {
+        let entries = vec![make_file("dup"), make_file("dup"), make_file("z")];
+        let (cleaned, stats) = flist_clean(entries, true, true);
+        assert_eq!(stats.duplicates_removed, 1);
+        assert_eq!(cleaned.len(), 3);
+        assert!(!cleaned[1].is_active());
+    }
+
+    /// A directory that duplicates a NON-ADJACENT same-named non-dir (separated
+    /// by an entry that sorts before the dir's implicit trailing '/') must still
+    /// be detected and the file dropped. upstream: flist.c:3052-3059 flist_find()
+    /// as-regfile. This is the #145 half of the fix.
+    #[test]
+    fn flist_clean_dir_dups_nonadjacent_regfile() {
+        // Sorted order: file "item" < file "item!" < dir "item" (= "item/").
+        let mut entries = vec![make_file("item"), make_file("item!"), make_dir("item")];
+        sort_file_list(&mut entries, false, false);
+        assert_eq!(active_names(&entries), vec!["item", "item!", "item"]);
+        let (cleaned, stats) = flist_clean(entries, false, false);
+        assert_eq!(cleaned.len(), 3);
+        assert_eq!(stats.duplicates_removed, 1);
+        // The non-adjacent file "item" is tombstoned; "item!" and the dir survive.
+        let survivors: Vec<(&str, bool)> = cleaned
+            .iter()
+            .filter(|e| e.is_active())
+            .map(|e| (e.name(), e.is_dir()))
+            .collect();
+        assert_eq!(survivors, vec![("item!", false), ("item", true)]);
     }
 
     #[test]
@@ -639,11 +816,11 @@ mod tests {
             make_file("a.txt"),
             make_file("a.txt"), // duplicate
         ];
-        let (cleaned, stats) = sort_and_clean_file_list(entries, false, false);
+        let (cleaned, stats) = sort_and_clean_file_list(entries, false, false, false, false);
         assert_eq!(stats.duplicates_removed, 1);
-        let mut names = Vec::with_capacity(cleaned.len());
-        names.extend(cleaned.iter().map(|e| e.name()));
-        assert_eq!(names, vec!["a.txt", "z.txt", "a"]);
+        // One slot tombstoned; length preserved.
+        assert_eq!(cleaned.len(), 4);
+        assert_eq!(active_names(&cleaned), vec!["a.txt", "z.txt", "a"]);
     }
 
     /// Comprehensive edge-case sort order golden test.
@@ -793,9 +970,14 @@ mod tests {
             make_file("a.txt"),
             make_file("a.txt"), // duplicate
         ];
-        let (cleaned, stats) = sort_and_clean_file_list(entries, true, false);
+        let (cleaned, stats) = sort_and_clean_file_list(entries, true, false, false, false);
         assert_eq!(stats.duplicates_removed, 1);
-        let names: Vec<&str> = cleaned.iter().map(|e| e.name()).collect();
+        assert_eq!(cleaned.len(), 4);
+        let names: Vec<&str> = cleaned
+            .iter()
+            .filter(|e| e.is_active())
+            .map(|e| e.name())
+            .collect();
         assert_eq!(names, vec!["a.txt", "z.txt", "a"]);
     }
 

--- a/crates/protocol/tests/flist_stress_tests.rs
+++ b/crates/protocol/tests/flist_stress_tests.rs
@@ -252,23 +252,34 @@ fn stress_10k_sort_and_clean_with_duplicates() {
     }
 
     let original_count = entries.len();
-    let (cleaned, stats) = sort_and_clean_file_list(entries, false, false);
+    let (cleaned, stats) = sort_and_clean_file_list(entries, false, false, false, false);
 
-    // Should have removed duplicates
-    assert!(
-        cleaned.len() < original_count,
-        "Expected duplicates to be removed"
+    // Duplicates are TOMBSTONED in place, not compacted: the receiver preserves
+    // every NDX slot so its numbering stays aligned with the sender's full
+    // un-deduped array. upstream: flist.c:3089 clear_file().
+    assert_eq!(
+        cleaned.len(),
+        original_count,
+        "clean must preserve the array length (tombstone, not compact)"
     );
     assert!(
         stats.duplicates_removed > 0,
-        "Should have removed some duplicates"
+        "Should have tombstoned some duplicates"
     );
 
-    // Verify no duplicates remain
-    for i in 0..cleaned.len() - 1 {
-        if cleaned[i].name() == cleaned[i + 1].name() {
-            panic!("Duplicate found at index {}: {}", i, cleaned[i].name());
-        }
+    // Verify no duplicate names remain among the ACTIVE (non-tombstone) entries.
+    let active: Vec<&str> = cleaned
+        .iter()
+        .filter(|e| e.is_active())
+        .map(|e| e.name())
+        .collect();
+    for i in 0..active.len().saturating_sub(1) {
+        assert_ne!(
+            active[i],
+            active[i + 1],
+            "duplicate active entry at {i}: {}",
+            active[i]
+        );
     }
 }
 

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -140,21 +140,16 @@ impl GeneratorContext {
                 .sort_with_parallel(&mut self.source_bases, self.config.qsort);
         }
 
-        // upstream: flist.c:2544 flist_sort_and_clean(flist, 0) in send_file_list
-        // - the sender sorts+cleans its built list so its post-clean NDX matches
-        // the receiver's flist.c:2771 pass. We dedup the transmitted list here so
-        // the receiver's identical pass is idempotent and both sides keep the
-        // same NDX numbering. A list with no duplicate names is unchanged
-        // (neither order nor length), so this is a no-op for normal transfers.
-        //
-        // oc converges BOTH sides to the same sorted+cleaned list (wire order =
-        // sorted order), so it drops duplicates symmetrically. Upstream's
-        // am_sender branch instead marks a duplicate dir FLAG_DUPLICATE and keeps
-        // it for its in-place dir_flist tree (flist.c:3067); oc has no such tree,
-        // and keeping the dup only on the sender would desync the NDX count, so a
-        // symmetric drop is the correct mirror for oc's model. INC_RECURSE
-        // (recursive + --relative overlap) stays dest-correct under this pass.
-        self.file_list.dedup_with_parallel(&mut self.source_bases);
+        // upstream: flist.c:3031-3042 flist_sort_and_clean() - a non-incremental
+        // sender does NOT run the duplicate-clean pass; it transmits every entry
+        // as-is so the receiver's in-place tombstones keep both sides' NDX
+        // numbering aligned with this full array. Only under INC_RECURSE does the
+        // sender clean each sub-list (matching the receiver's identical pass).
+        // A list with no duplicate names is unchanged either way, so this is a
+        // no-op for normal transfers.
+        let inc_recurse = self.inc_recurse();
+        self.file_list
+            .dedup_with_parallel(&mut self.source_bases, true, inc_recurse);
 
         // upstream: hlink.c:match_hard_links() - must be called after sort
         #[cfg(unix)]
@@ -386,14 +381,14 @@ impl GeneratorContext {
                 .sort_with_parallel(&mut self.source_bases, self.config.qsort);
         }
 
-        // upstream: flist.c:2544 flist_sort_and_clean(flist, 0) in send_file_list
-        // - dedup the built list before transmit so the receiver's pass is
-        // idempotent and NDX numbering stays in sync. This is the --files-from
-        // build path where a redundant list entry can produce a duplicate name;
-        // deduping here (keep-first, matching the receiver for the non-dir case)
-        // is what fixed the remote files-from RERR_PROTOCOL. No-op when there are
-        // no duplicate names.
-        self.file_list.dedup_with_parallel(&mut self.source_bases);
+        // upstream: flist.c:3031-3042 flist_sort_and_clean() - the --files-from
+        // build path. A non-incremental sender transmits duplicates as-is so the
+        // receiver's in-place tombstones keep NDX aligned; only under INC_RECURSE
+        // does the sender clean each sub-list. No-op when there are no duplicate
+        // names.
+        let inc_recurse = self.inc_recurse();
+        self.file_list
+            .dedup_with_parallel(&mut self.source_bases, true, inc_recurse);
 
         // upstream: hlink.c:match_hard_links() - must be called after sort
         #[cfg(unix)]

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -606,20 +606,20 @@ mod tests {
         assert!(ctx.flist_eof);
     }
 
-    /// A sub-list that repeats a normalized name must collapse to a single entry.
+    /// A sub-list that repeats a normalized name must TOMBSTONE the duplicate
+    /// in place, preserving the slot count so NDX stays aligned.
     ///
     /// WHY: upstream runs `flist_sort_and_clean()` on EACH INC_RECURSE sub-list
     /// (send `flist.c:2190`, recv `flist.c:2771`), whose clean pass
-    /// (`flist.c:3031`, active for the receiver) removes duplicate names. Before
-    /// this fix `receive_one_extra_segment` sorted the sub-list but skipped the
-    /// dedup, so a redundant or hostile duplicate survived and the generator
-    /// requested the same path twice - an NDX divergence driven by untrusted
-    /// bytes, exactly the class of bug the initial-list dedup (#6631) closed. The
-    /// legitimate sender ships deduped sub-lists (partitions of an already-cleaned
-    /// list), so this pass is a no-op there and only collapses a duplicate,
-    /// keeping both sides' NDX numbering identical.
+    /// (`flist.c:3031`, active for the receiver) drops duplicate names by
+    /// `clear_file()` (`flist.c:3089`) - a tombstone that keeps the entry's
+    /// array slot so following NDX values are unaffected. The receiver must NOT
+    /// compact or renumber, or its numbering desyncs from the sender's full
+    /// un-deduped array. The legitimate sender ships un-deduped sub-lists (a
+    /// non-incremental sender skips its clean), so the receiver's tombstone is
+    /// what keeps both sides' NDX numbering identical.
     #[test]
-    fn sublist_duplicate_name_is_deduped() {
+    fn sublist_duplicate_name_is_tombstoned() {
         let wire = encode_segment_with_dir_ndx(
             0,
             &[("x/dup.txt", 10u64), ("x/dup.txt", 10), ("x/z.txt", 20)],
@@ -630,17 +630,27 @@ mod tests {
         let n = ctx
             .receive_extra_file_lists(&mut Cursor::new(wire))
             .expect("legitimate sub-list must be accepted");
-        // Three entries arrive on the wire; the duplicate "x/dup.txt" collapses.
+        // Three entries arrive on the wire; all three slots are preserved.
         assert_eq!(n, 3, "the wire carried three entries");
-        let names: Vec<String> = ctx
+        assert_eq!(
+            ctx.file_list().len(),
+            3,
+            "every NDX slot is preserved (tombstone, not compact)"
+        );
+        // The middle slot is a tombstone (inactive); NDX 0 and 2 stay put.
+        assert!(ctx.file_list()[0].is_active());
+        assert!(!ctx.file_list()[1].is_active());
+        assert!(ctx.file_list()[2].is_active());
+        let active: Vec<String> = ctx
             .file_list()
             .iter()
+            .filter(|e| e.is_active())
             .map(|e| e.name().to_owned())
             .collect();
         assert_eq!(
-            names,
+            active,
             vec!["x/dup.txt".to_owned(), "x/z.txt".to_owned()],
-            "the repeated name must be deduped, leaving two entries"
+            "the repeated name is dropped, leaving two active entries"
         );
     }
 

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -153,7 +153,11 @@ impl ReceiverContext {
         let pre29 = self.protocol.as_u8() < 29;
         if !self.iconv_reorder_suppressed() {
             let list = std::mem::take(&mut self.file_list);
-            let (cleaned, _clean) = sort_and_clean_file_list(list, self.config.qsort, pre29);
+            // am_sender=false: the receiver always runs the duplicate-clean,
+            // tombstoning dropped duplicates in place so NDX stays aligned with
+            // the sender's full un-deduped array (flist.c:3031,3089).
+            let (cleaned, _clean) =
+                sort_and_clean_file_list(list, self.config.qsort, pre29, false, inc_recurse);
             self.file_list = cleaned;
         }
 
@@ -355,7 +359,8 @@ impl ReceiverContext {
         // against the bytes the sender emitted.
         if !self.iconv_reorder_suppressed() {
             let tail = self.file_list.split_off(flat_start);
-            let (cleaned, _clean) = sort_and_clean_file_list(tail, true, false);
+            // Receiver sub-list clean: am_sender=false, inc_recurse=true.
+            let (cleaned, _clean) = sort_and_clean_file_list(tail, true, false, false, true);
             self.file_list.extend(cleaned);
         }
         match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);

--- a/crates/transfer/src/receiver/file_list/receive_async.rs
+++ b/crates/transfer/src/receiver/file_list/receive_async.rs
@@ -104,9 +104,15 @@ impl ReceiverContext {
         // duplicate-clean pass on the receiver; mirror the sync path so both wire
         // surfaces collapse a redundant name identically.
         let pre29 = self.protocol.as_u8() < 29;
+        let inc_recurse = self
+            .compat_flags
+            .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
         if !self.iconv_reorder_suppressed() {
             let list = std::mem::take(&mut self.file_list);
-            let (cleaned, _clean) = sort_and_clean_file_list(list, self.config.qsort, pre29);
+            // am_sender=false: the receiver tombstones dropped duplicates in
+            // place so NDX stays aligned with the sender's full array.
+            let (cleaned, _clean) =
+                sort_and_clean_file_list(list, self.config.qsort, pre29, false, inc_recurse);
             self.file_list = cleaned;
         }
 
@@ -254,7 +260,8 @@ impl ReceiverContext {
             // name collapses identically and the next segment's NDX stays in sync.
             if !self.iconv_reorder_suppressed() {
                 let tail = self.file_list.split_off(flat_start);
-                let (cleaned, _clean) = sort_and_clean_file_list(tail, true, false);
+                // Receiver sub-list clean: am_sender=false, inc_recurse=true.
+                let (cleaned, _clean) = sort_and_clean_file_list(tail, true, false, false, true);
                 self.file_list.extend(cleaned);
             }
             match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);

--- a/crates/transfer/src/receiver/tests/file_list/dedup.rs
+++ b/crates/transfer/src/receiver/tests/file_list/dedup.rs
@@ -122,11 +122,7 @@ fn receiver_keeps_directory_over_file_duplicate() {
     // Both NDX slots are preserved; the plain-file slot is tombstoned and the
     // directory survives so its NDX still matches the sender's dir entry.
     assert_eq!(ctx.file_list().len(), 2);
-    let active: Vec<_> = ctx
-        .file_list()
-        .iter()
-        .filter(|e| e.is_active())
-        .collect();
+    let active: Vec<_> = ctx.file_list().iter().filter(|e| e.is_active()).collect();
     assert_eq!(active.len(), 1);
     assert!(
         active[0].is_dir(),

--- a/crates/transfer/src/receiver/tests/file_list/dedup.rs
+++ b/crates/transfer/src/receiver/tests/file_list/dedup.rs
@@ -1,10 +1,12 @@
 //! Receiver-side duplicate-clean pass coverage.
 //!
 //! Upstream `flist.c:flist_sort_and_clean()` runs three steps after the
-//! receiver decodes the file list: sort, remove duplicate names (keeping the
-//! upstream-correct survivor), then prune empty dirs. These tests pin the
-//! second step - a sender that emits the same normalized name twice (redundant
-//! or hostile) must not leave a duplicate in `self.file_list`.
+//! receiver decodes the file list: sort, drop duplicate names (keeping the
+//! upstream-correct survivor by tombstoning the dropped slot in place), then
+//! prune empty dirs. These tests pin the second step - a sender that emits the
+//! same normalized name twice (redundant or hostile) must leave the dropped
+//! entry as an inactive tombstone that preserves every NDX slot, never a
+//! compacted/renumbered list.
 //!
 //! # Upstream Reference
 //!
@@ -29,14 +31,18 @@ fn encode(protocol: protocol::ProtocolVersion, entries: &[FileEntry]) -> Vec<u8>
     data
 }
 
-/// A file name emitted twice by the sender must collapse to a single entry.
+/// A file name emitted twice by the sender must be TOMBSTONED in place, not
+/// compacted away.
 ///
-/// WHY: upstream removes the duplicate (`clear_file` on the dropped index)
-/// inside `flist_sort_and_clean` before the transfer runs. Leaving both would
-/// make the generator request the same path twice - a wire/NDX divergence and
-/// wasted work driven by untrusted sender bytes.
+/// WHY: upstream drops the duplicate via `clear_file()` on the dropped index
+/// (`flist.c:3089`), which zeroes the entry but leaves its slot in
+/// `flist->files[]` so every following NDX is unchanged. The receiver must
+/// preserve the array length and every NDX slot; compacting/renumbering would
+/// desync the receiver's numbering from the sender's full un-deduped array
+/// (received "non-regular file" / silent corruption). The generator skips the
+/// inactive slot, so the path is never requested twice.
 #[test]
-fn receiver_removes_duplicate_file_name() {
+fn receiver_tombstones_duplicate_file_name() {
     let handshake = test_handshake();
     let config = test_config();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
@@ -51,8 +57,20 @@ fn receiver_removes_duplicate_file_name() {
     let mut cursor = Cursor::new(&data[..]);
     ctx.receive_file_list(&mut cursor).unwrap();
 
-    let names: Vec<_> = ctx.file_list().iter().map(|e| e.name()).collect();
-    assert_eq!(names, vec!["b.txt", "dup.txt"]);
+    // All three NDX slots are preserved; one is an inactive tombstone.
+    assert_eq!(ctx.file_list().len(), 3);
+    let active: Vec<_> = ctx
+        .file_list()
+        .iter()
+        .filter(|e| e.is_active())
+        .map(|e| e.name())
+        .collect();
+    assert_eq!(active, vec!["b.txt", "dup.txt"]);
+    assert_eq!(
+        ctx.file_list().iter().filter(|e| !e.is_active()).count(),
+        1,
+        "the repeated name leaves exactly one tombstone slot"
+    );
 }
 
 /// Legitimately distinct names must all survive - no over-dedup.
@@ -101,9 +119,17 @@ fn receiver_keeps_directory_over_file_duplicate() {
     let mut cursor = Cursor::new(&data[..]);
     ctx.receive_file_list(&mut cursor).unwrap();
 
-    assert_eq!(ctx.file_list().len(), 1);
+    // Both NDX slots are preserved; the plain-file slot is tombstoned and the
+    // directory survives so its NDX still matches the sender's dir entry.
+    assert_eq!(ctx.file_list().len(), 2);
+    let active: Vec<_> = ctx
+        .file_list()
+        .iter()
+        .filter(|e| e.is_active())
+        .collect();
+    assert_eq!(active.len(), 1);
     assert!(
-        ctx.file_list()[0].is_dir(),
+        active[0].is_dir(),
         "duplicate collision must keep the directory, not the plain file"
     );
 }


### PR DESCRIPTION
## Summary

Fixes a HIGH-severity wire-desync and silent-content-corruption bug when a
duplicate name appears in the file list (overlapping/merged source roots such as
`src/ src/`, two roots sharing `foo`, a `-R` duplicate relative dir, or a file
`item` vs a dir `item/child`) and oc-rsync is the **receiver** against a real
upstream rsync **sender**.

## Root cause

A non-incremental upstream **sender** does not deduplicate its file list. In
`flist.c:flist_sort_and_clean()` the guard at lines 3039-3042 sets
`i = flist->used - 1`, so the duplicate-clean loop never runs and every duplicate
name is transmitted as-is.

The upstream **receiver** deduplicates by *tombstoning*: `clear_file()`
(`flist.c:3089`) zeroes the dropped duplicate in place (its `basename[0]` becomes
0, so `F_IS_ACTIVE` is false) **without moving any other entry**. `flist->used`
and every NDX (file index) slot stay aligned with the sender's full un-deduped
array.

oc-rsync's `flist_clean` instead **compacted, truncated, and renumbered** the
list. Against a real upstream sender, the receiver's generator then requested
transfers using its shorter numbering; the sender indexed that NDX into its
*full* array and hit the wrong entry:

- a directory -> `received request to transfer non-regular file` -> exit 12, or
- the wrong regular file -> **exit 0 with wrong content (silent corruption)**.

oc->upstream (oc as sender) passed because oc shipped an already-deduped list and
the upstream receiver's clean was then a no-op; up<->up and oc<->oc also passed
because both sides deduped symmetrically. Only oc-as-receiver against upstream
desynced.

## The fix (mirrors upstream exactly)

1. **Tombstone in place.** `flist_clean` now clears each dropped duplicate via
   `FileEntry::tombstone()` (mirroring `clear_file`, `flist.c:3089`), preserving
   the array length and every NDX slot. The list is never compacted, truncated,
   or renumbered. `FileEntry::is_active()` mirrors `F_IS_ACTIVE` (rsync.h:925).
2. **Skip the clean when `am_sender && !inc_recurse`** (`flist.c:3039-3042`): a
   non-incremental sender transmits duplicates as-is so the receiver's tombstones
   keep both sides aligned. `DualFileList::dedup_with_parallel` (the sender path)
   gains the same guard; a sender cannot tombstone-and-skip a slot without
   shipping fewer entries than its array holds and desyncing the wire NDX.
3. **flist_find-as-regfile check** (`flist.c:3052-3059`): a directory that
   duplicates a *non-adjacent* same-named non-dir is detected (upstream
   temporarily treats the dir as `S_IFREG` and runs `flist_find`) and the file
   dropped.
4. All flist NDX consumers already skip inactive slots: oc encodes an inactive
   entry as an empty name + zero mode, the exact representation the receiver's
   `prune_empty_dirs` pass already produces, and every iteration/index site gates
   on `is_dir()`/`is_file()` (both false for a zeroed mode). Tombstoned slots are
   therefore dead-but-present without renumbering.

The common (duplicate-free) path is byte-unchanged: `flist_clean` tombstones
nothing, so order, length, and wire output are identical (protocol golden tests
pass).

## Verification

`cargo fmt`, `cargo clippy -p protocol -p transfer --all-features --all-targets
-D warnings`, and the full `protocol` + `transfer` nextest suites
(8311 tests) all pass. New unit tests assert the tombstone semantics (exact slot
indices preserved), the `am_sender && !inc_recurse` skip, and the non-adjacent
dir-vs-file detection.

### Real-binary matrix (x86_64, upstream `/usr/bin/rsync` = 3.4.4)

oc as the client, compared against an upstream<->upstream control for the same
operands. PULL = oc receiver + upstream sender; PUSH = oc sender + upstream
receiver.

| Scenario | before (master) | after (this PR) |
|---|---|---|
| same dir twice - PULL | FAIL exit 12, all content wrong | PASS exit 0, matches upstream |
| same dir twice - PUSH | PASS | PASS |
| two roots share `foo` - PULL | FAIL exit 12 | PASS |
| two roots share `foo` - PUSH | PASS | PASS |
| file `item` vs dir `item/child` - PULL | **FAIL exit 0, wrong content (silent corruption)** | PASS, md5 matches upstream |
| file `item` vs dir `item/child` - PUSH | PASS | PASS |
| `-R` duplicate rel dir - PULL | FAIL exit 12 | PASS |
| `-R` duplicate rel dir - PUSH | PASS | PASS |

Every oc-as-receiver case now produces byte-identical destination content to the
upstream control, including the previously silent-corruption file-vs-dir layout.

