### PR TITLE
docs: fix unresolved rustdoc intra-doc links, restore Pages gate

### DIFF
--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -8,7 +8,7 @@ a single re-export surface so upper layers have a single dependency.
 
 ## Crate Position in the Dependency Graph
 
-```
+```text
 cli ──► core ──► engine, protocol, transport, flist, rsync_io
                  core ──► checksums, filters, compress, bandwidth, metadata
 ```

--- a/crates/core/src/exit_code/codes.rs
+++ b/crates/core/src/exit_code/codes.rs
@@ -333,7 +333,7 @@ impl ExitCode {
     /// A wire-protocol violation that upstream rsync exits with
     /// `RERR_PROTOCOL` (2) is encoded as an `InvalidData` error whose inner
     /// error is a [`protocol::ProtocolViolation`] (see
-    /// [`protocol::protocol_violation`]). Such errors map to
+    /// [`fn@protocol::protocol_violation`]). Such errors map to
     /// [`ExitCode::Protocol`]; every other `InvalidData`/`UnexpectedEof`
     /// (truncated stream, corrupt frame, unexpected EOF) stays
     /// [`ExitCode::StreamIo`] (12), matching upstream's `RERR_STREAMIO`.

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -447,11 +447,11 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
 /// loop is hosted on a tokio multi-thread runtime via
 /// [`crate::async_listener::run_hybrid_listener`]. Each accepted connection is
 /// served by the existing synchronous session handler on a dedicated OS thread
-/// (see [`ConnectionContext::serve_one_connection`]), so the wire protocol,
+/// (see `ConnectionContext::serve_one_connection`), so the wire protocol,
 /// auth, and transfer pipeline stay byte-identical with the sync daemon; only
 /// the accept + task dispatch is asynchronous. The number of concurrent worker
 /// threads is bounded so it never throttles below the configured
-/// `max connections` (see [`async_max_inflight`]).
+/// `max connections` (see `async_max_inflight`).
 ///
 /// # Selection
 ///

--- a/crates/engine/src/concurrent_delta/work_queue/adaptive_semaphore.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/adaptive_semaphore.rs
@@ -108,7 +108,7 @@ struct SemInner {
 
 /// A counting semaphore whose capacity can change while permits are in flight.
 ///
-/// See the [module documentation](self) for the design and resize semantics.
+/// See the module documentation for the design and resize semantics.
 /// The semaphore is `Send + Sync` and is intended to be shared across threads
 /// via `Arc`. Permits are released with [`release`](Self::release); there is no
 /// RAII guard, so callers must pair every successful acquire with exactly one

--- a/crates/engine/src/concurrent_delta/work_queue/bounded.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/bounded.rs
@@ -123,7 +123,7 @@ impl WorkQueueSender {
     ///
     /// Returns `Err(SendError)` if the receiver has been dropped.
     ///
-    /// For a [`CapacitySource::Fixed`] queue (the default), admission is gated
+    /// For a `CapacitySource::Fixed` queue (the default), admission is gated
     /// solely by the bounded channel, so this is identical to a plain channel
     /// send. For a dynamic queue, admission is first gated by the backing
     /// [`AdaptiveSemaphore`] before the item enters the (over-provisioned)
@@ -218,7 +218,7 @@ pub struct DynamicWorkQueue {
 /// permits already granted.
 ///
 /// The returned [`WorkQueueReceiver`] carries a clone of the semaphore and
-/// returns one permit per drained item (see [`PermitGuard`] and the drain
+/// returns one permit per drained item (see `PermitGuard` and the drain
 /// methods), so admission refills as work completes. An
 /// [`AdaptiveQueueController`](super::controller::AdaptiveQueueController) can
 /// then move the ceiling within `[min, max]` in response to the observed block

--- a/crates/engine/src/concurrent_delta/work_queue/controller.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/controller.rs
@@ -124,7 +124,7 @@ pub enum TickOutcome {
 
 /// AIMD grow/shrink controller for a [`DynamicWorkQueue`]'s admission depth.
 ///
-/// See the [module documentation](self) for the control law and opt-in policy.
+/// See the module documentation for the control law and opt-in policy.
 /// The controller owns a shared handle to the queue's [`AdaptiveSemaphore`] and
 /// an internal [`AimdLimiter`] whose `target` tracks the desired depth. Call
 /// [`tick`](Self::tick) periodically (for example once per drained batch) to

--- a/crates/engine/src/delete/context/core.rs
+++ b/crates/engine/src/delete/context/core.rs
@@ -424,7 +424,7 @@ impl DeleteContext {
     /// `ReorderBuffer`, a Condvar-driven consumer thread, and a rayon
     /// dispatch) costs a fixed overhead that dominates when only a handful
     /// of entries are being deleted. When the whole transfer plans fewer
-    /// than [`SMALL_DIR_FAST_PATH_THRESHOLD`] extras, or the process has no
+    /// than `SMALL_DIR_FAST_PATH_THRESHOLD` extras, or the process has no
     /// spare rayon worker to parallelise onto, the drain runs the
     /// sequential [`DeleteEmitter`](super::super::emitter::DeleteEmitter)
     /// directly. That emitter is the exact

--- a/crates/engine/src/delete/emitter/mod.rs
+++ b/crates/engine/src/delete/emitter/mod.rs
@@ -186,7 +186,7 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     /// opened at.
     ///
     /// Identical to [`Self::with_sandbox`] except the emitter also records
-    /// the sandbox root so [`Self::open_plan_dirfd`] can resolve absolute
+    /// the sandbox root so `Self::open_plan_dirfd` can resolve absolute
     /// plan directory keys (the production local-copy cleanup path keys
     /// plans on the absolute destination directory) relative to that root
     /// before the `openat` walk. Callers with plan keys already relative

--- a/crates/engine/src/local_copy/buffer_pool/global.rs
+++ b/crates/engine/src/local_copy/buffer_pool/global.rs
@@ -118,7 +118,7 @@ pub const DEFAULT_BYTE_BUDGET: usize = 32 * 1024 * 1024;
 
 /// Default per-buffer block size for pooled I/O buffers (128 KiB).
 ///
-/// Matches [`COPY_BUFFER_SIZE`](super::super::COPY_BUFFER_SIZE), the size the
+/// Matches `COPY_BUFFER_SIZE` (`super::super::COPY_BUFFER_SIZE`), the size the
 /// pool has always used. This is a purely local performance knob: it governs
 /// how much data each reusable I/O buffer holds during file copy and has no
 /// effect on the wire protocol, delta block size, or on-disk contents.

--- a/crates/matching/src/fuzzy/search.rs
+++ b/crates/matching/src/fuzzy/search.rs
@@ -53,7 +53,7 @@ impl FuzzyMatcher {
     ///
     /// Mirrors upstream `find_fuzzy()`: an exact size + mtime match (when
     /// `target_mtime` is known) returns immediately; otherwise the candidate
-    /// with the lowest [`fuzzy_name_distance`] within the matcher's distance
+    /// with the lowest `fuzzy_name_distance` within the matcher's distance
     /// cap wins. At level 2 the configured `fuzzy_basis_dirs` are scanned after
     /// the destination directory, sharing a single running lowest distance so
     /// ordering and tie-breaks match upstream's single-pass loop.

--- a/crates/matching/src/fuzzy/trace.rs
+++ b/crates/matching/src/fuzzy/trace.rs
@@ -42,7 +42,7 @@ pub fn trace_fuzzy_size_mtime_match(candidate: &str) {
 /// Upstream encodes `dist` as a 32-bit fixed-point value: the high 16 bits are
 /// the integer part (whole Levenshtein units) and the low 16 bits are the
 /// fractional part (accumulated ASCII weighting), printed as `%d.%05d`. We pass
-/// the same `u32` distance produced by [`super::distance::fuzzy_name_distance`]
+/// the same `u32` distance produced by `super::distance::fuzzy_name_distance`
 /// and split it identically so `--debug=FUZZY` output matches byte-for-byte.
 ///
 /// Matches upstream rsync format:

--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -951,14 +951,14 @@ impl DeltaGenerator {
     /// past its stripe end, so a match starting inside its stripe that crosses
     /// the boundary is completed here rather than degrading to literals. Every
     /// match-start offset is therefore scanned with a full window by exactly the
-    /// worker that owns it. [`merge_copy_runs`] takes the union of all workers'
+    /// worker that owns it. `merge_copy_runs` takes the union of all workers'
     /// `Copy` tokens tagged with their absolute source offset and walks a cursor
     /// that emits the earliest match at or after the cursor, then jumps past it -
     /// the identical "first match wins, then skip its bytes" rule the sequential
     /// [`Self::generate`] applies. Gaps are literal bytes taken straight from
     /// `source`, so a boundary can never drop or duplicate a byte, and
-    /// [`resegment_literals`] frames those gaps at the shared
-    /// [`literal_flush_cadence`].
+    /// `resegment_literals` frames those gaps at the shared
+    /// `literal_flush_cadence`.
     ///
     /// # Wire transparency
     ///

--- a/crates/protocol/src/compatibility/flags.rs
+++ b/crates/protocol/src/compatibility/flags.rs
@@ -53,7 +53,7 @@ impl CompatibilityFlags {
     /// per-block strong checksum (`CAP_CONSECUTIVE_MATCH`).
     ///
     /// This is NOT an upstream rsync flag. It occupies a high private bit
-    /// (`0x0200_0000`) deliberately kept out of [`Self::KNOWN_MASK`], the
+    /// (`0x0200_0000`) deliberately kept out of `Self::KNOWN_MASK`, the
     /// default-advertised set, and [`Self::ALL_KNOWN`]. compat_flags is a
     /// varint on the wire (upstream `compat.c:741` `read_varint`), and upstream
     /// tolerates unknown bits by ignoring them, so this private bit transmits

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -229,7 +229,7 @@ pub fn read_filter_list(
 ///
 /// Reads the same length-prefixed rule records (`.await`-driven) in the same
 /// order, terminated by the 4-byte little-endian zero, and runs the identical
-/// [`parse_wire_rule`] decode/validation on each record. It therefore yields the
+/// `parse_wire_rule` decode/validation on each record. It therefore yields the
 /// same `Vec<FilterRuleWireFormat>` and consumes the same bytes for the same
 /// wire input; only the I/O mechanism (await vs blocking) differs. Gated on
 /// `tokio-transfer`.
@@ -241,7 +241,7 @@ pub fn read_filter_list(
 ///
 /// - A negative length prefix yields [`io::ErrorKind::InvalidData`], exactly as
 ///   the blocking reader surfaces it.
-/// - Any decode error from [`parse_wire_rule`] propagates unchanged.
+/// - Any decode error from `parse_wire_rule` propagates unchanged.
 /// - Truncation mid-record surfaces the underlying read error (typically
 ///   [`io::ErrorKind::UnexpectedEof`]).
 #[cfg(feature = "tokio-transfer")]

--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -158,8 +158,8 @@ impl DualFileList {
     /// first) - dedup only collapses adjacent equal names. On a list with no
     /// duplicates this changes neither order nor length.
     ///
-    /// Reuses [`resolve_duplicate`](super::sort::resolve_duplicate) so the
-    /// keep/drop tie-break is identical to the receiver's [`flist_clean`]. oc
+    /// Reuses `resolve_duplicate` (`super::sort::resolve_duplicate`) so the
+    /// keep/drop tie-break is identical to the receiver's `flist_clean`. oc
     /// converges both sides to the same sorted+cleaned list, so it drops
     /// duplicates symmetrically rather than following upstream's `am_sender`
     /// branch (mark a dup dir `FLAG_DUPLICATE` and keep it for the in-place

--- a/crates/protocol/src/protocol_violation.rs
+++ b/crates/protocol/src/protocol_violation.rs
@@ -2,7 +2,7 @@
 //!
 //! Rust's [`std::io::ErrorKind`] has no protocol-violation variant, so oc has
 //! historically encoded wire-protocol violations as
-//! [`io::ErrorKind::InvalidData`]. That kind is shared with truncated-stream
+//! [`std::io::ErrorKind::InvalidData`]. That kind is shared with truncated-stream
 //! and corrupt-frame conditions, which upstream rsync exits with
 //! `RERR_STREAMIO` (12). A subset of `InvalidData` sites correspond instead to
 //! upstream call sites that invoke `exit_cleanup(RERR_PROTOCOL)` (exit code 2)
@@ -10,8 +10,8 @@
 //! transfer request arriving in phase 2.
 //!
 //! [`ProtocolViolation`] tags exactly those sites. It is attached as the inner
-//! error of an `InvalidData` [`io::Error`] via [`protocol_violation`], so the
-//! error's [`kind`](io::Error::kind) and [`Display`](std::fmt::Display) text are
+//! error of an `InvalidData` [`std::io::Error`] via [`fn@protocol_violation`], so the
+//! error's [`kind`](std::io::Error::kind) and [`Display`](std::fmt::Display) text are
 //! unchanged (fully backward compatible), while the exit-code mapper can
 //! downcast the inner error and return `RERR_PROTOCOL` (2) rather than
 //! `RERR_STREAMIO` (12).

--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -123,7 +123,7 @@ impl DeleteStats {
     /// Async twin of [`read_from`](Self::read_from).
     ///
     /// Reads the same five varints (`.await`-driven) in the same order and
-    /// applies the identical [`read_capped_del_stat`] validation, so it yields
+    /// applies the identical `read_capped_del_stat` validation, so it yields
     /// the same `DeleteStats` and consumes the same bytes for the same wire
     /// input. Gated on `tokio-transfer`.
     ///

--- a/crates/signature/src/parallel.rs
+++ b/crates/signature/src/parallel.rs
@@ -235,7 +235,7 @@ pub fn generate_file_signature_auto<R: Read>(
 /// (sized to `available_parallelism()` unless `--rayon-threads` overrode the
 /// global pool). Unlike [`generate_file_signature_parallel`], which buffers the
 /// entire file in memory, this caps resident block buffers at roughly
-/// [`WINDOW_BYTE_BUDGET`] bytes regardless of basis size - so large files scale
+/// `WINDOW_BYTE_BUDGET` bytes regardless of basis size - so large files scale
 /// across cores without the peak-RSS cost of a full-file slurp.
 ///
 /// Output is byte-identical to the sequential

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -854,9 +854,9 @@ impl<'a> DeltaApplicator<'a> {
     /// raw payload `read_exact`. Every byte the token turns into - the literal
     /// write, the basis block copy, the checksum-verifier update, the sparse
     /// bookkeeping, and the `see_token` dictionary feed - runs through the exact
-    /// same synchronous helpers the sync path uses ([`Self::apply_literal_bytes`],
-    /// [`Self::apply_literal_from_buffer`], [`Self::apply_block_ref`],
-    /// [`Self::feed_see_token`]). For the same wire bytes it therefore produces a
+    /// same synchronous helpers the sync path uses (`Self::apply_literal_bytes`,
+    /// `Self::apply_literal_from_buffer`, `Self::apply_block_ref`,
+    /// `Self::feed_see_token`). For the same wire bytes it therefore produces a
     /// byte-identical destination file, an identical [`DeltaApplyResult`], and
     /// leaves the reader positioned exactly where the sync leaf would - including
     /// when the source delivers bytes one at a time across `.await` points.

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -210,7 +210,7 @@ pub fn generate_delta_from_signature<R: Read>(
 /// chunked scan is proportional to the file size, not bounded to a fixed
 /// window; the win is CPU parallelism, not a memory reduction. This
 /// function then reconstructs the signature index (sharing
-/// [`build_signature_index`] with the sequential
+/// `build_signature_index` with the sequential
 /// [`generate_delta_from_signature`], so there is a single reconstruction
 /// path) and decides:
 ///

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -191,7 +191,7 @@ pub(super) const RERR_PARTIAL: i32 = 23;
 /// Typed error carrying the exit code a remote peer requested via
 /// `MSG_ERROR_EXIT`.
 ///
-/// [`MultiplexReader::check_error_exit`] wraps this in an [`io::Error`] as its
+/// `MultiplexReader::check_error_exit` wraps this in an [`io::Error`] as its
 /// inner error so the code survives `?` propagation up the read stack. Callers
 /// that terminate a transfer can `downcast_ref` the inner error to recover the
 /// peer's exact exit code (e.g. `RERR_SYNTAX = 1` for a read-only module

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -288,7 +288,7 @@ impl SumHead {
     /// Async twin of [`read`](Self::read).
     ///
     /// Reads the same 16 bytes (`.await`-driven) and decodes them through the
-    /// shared [`from_wire_bytes`](Self::from_wire_bytes) core, so it yields the
+    /// shared `from_wire_bytes` (`Self::from_wire_bytes`) core, so it yields the
     /// same `SumHead` and consumes the same bytes as the sync leaf. Gated on
     /// `tokio-transfer`.
     #[cfg(feature = "tokio-transfer")]
@@ -468,8 +468,8 @@ impl SenderAttrs {
     /// (NDX + iflags + optional basis-type / xname / xattr-abbreviation data)
     /// off an [`AsyncRead`](tokio::io::AsyncRead), driving the same
     /// `NdxCodecEnum::read_ndx_async` and `read_varint_async` leaves plus
-    /// the shared sans-io decode helpers ([`parse_fnamecmp_type`],
-    /// [`xname_len_from_bytes`], [`check_xname_len`], [`want_xattr_read`]) as
+    /// the shared sans-io decode helpers (`parse_fnamecmp_type`,
+    /// `xname_len_from_bytes`, `check_xname_len`, `want_xattr_read`) as
     /// the sync leaf. For the same wire bytes it yields the same
     /// `(ndx, SenderAttrs)` and consumes the same bytes as the sync path,
     /// including when the source delivers bytes one at a time across `.await`

--- a/crates/transfer/src/writer/mod.rs
+++ b/crates/transfer/src/writer/mod.rs
@@ -8,7 +8,7 @@
 //! # Submodules
 //!
 //! - `server` - Mode-switching writer enum dispatching plain, multiplex, and compressed I/O.
-//! - [`multiplex`] - Buffered writer that frames output in `MSG_DATA` multiplex frames.
+//! - `multiplex` - Buffered writer that frames output in `MSG_DATA` multiplex frames.
 //! - `msg_info` - Trait for sending `MSG_INFO` protocol messages through multiplexed streams.
 //! - `counting` - Byte-counting writer wrapper for transfer statistics.
 

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -346,7 +346,7 @@ impl<W: Write> ServerWriter<W> {
     /// zstd end-of-frame epilogue) before the connection is closed.
     ///
     /// In Plain or Multiplex mode this is a plain [`flush`](Self::flush). In
-    /// Compressed mode it consumes the [`CompressedWriter`], calls its
+    /// Compressed mode it consumes the `CompressedWriter`, calls its
     /// `finish()` to emit the end-of-stream trailer, and downgrades the
     /// `ServerWriter` back to [`Self::Multiplex`]. After this the underlying
     /// multiplex stream is fully drained and any subsequent writes go through
@@ -355,7 +355,7 @@ impl<W: Write> ServerWriter<W> {
     /// upstream: `token.c:send_deflated_token()` issues `Z_FINISH` via
     /// `deflateEnd()` when the sender tears down its compression context at
     /// end of transfer. Without this finalisation, the receiver's
-    /// [`CompressedReader`](crate::compressed_reader::CompressedReader) may be
+    /// `CompressedReader` (`crate::compressed_reader::CompressedReader`) may be
     /// waiting on the closing block of the deflate stream while the daemon
     /// has already shut down the socket, producing the "connection
     /// unexpectedly closed (N bytes received so far)" error mid-goodbye.


### PR DESCRIPTION
## Summary

Restores the GitHub Pages `Build rustdoc (workspace, all features, no deps)`
gate, which was failing with `error: could not document 'protocol'`. The build
runs `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`,
so any unresolved, ambiguous, or private intra-doc link fails the whole run.

The `protocol` failure was the first one rustdoc reported; because the run aborts
on the first crate error, it masked the same class of doc-link breakage in later
crates (`signature`, `matching`, `engine`, `transfer`, `core`, `daemon`). Fixing
only `protocol` would have moved the failure downstream, so every broken link the
gate surfaces is fixed here. Changes are documentation comments and one README
code-fence only - no code behavior changes.

## Links fixed

`protocol`
- `protocol_violation.rs` module docs: fully-qualified `std::io::Error`,
  `std::io::ErrorKind::InvalidData`, `std::io::Error::kind`; disambiguated
  `protocol_violation` (fn vs module) with `fn@`.
- `compatibility/flags.rs`: `Self::KNOWN_MASK` (private) to backticks.
- `filters/wire.rs`: `parse_wire_rule` (private) to backticks.
- `flist/dual.rs`: `resolve_duplicate` (private) to backticks; `flist_clean`
  (upstream C reference) to plain backticks.
- `stats/delete.rs`: `read_capped_del_stat` (private) to backticks.

`signature`
- `parallel.rs`: `WINDOW_BYTE_BUDGET` (private) to backticks.

`matching`
- `fuzzy/search.rs`, `fuzzy/trace.rs`: `fuzzy_name_distance` (private) to backticks.
- `generator.rs`: `merge_copy_runs`, `resegment_literals`, `literal_flush_cadence`
  (private) to backticks.

`engine`
- `concurrent_delta/work_queue/`: dropped `(self)` module links; `CapacitySource::Fixed`,
  `PermitGuard` (private) to backticks.
- `delete/context/core.rs`: `SMALL_DIR_FAST_PATH_THRESHOLD` (private) to backticks.
- `delete/emitter/mod.rs`: `Self::open_plan_dirfd` (private) to backticks.
- `local_copy/buffer_pool/global.rs`: `COPY_BUFFER_SIZE` (private) to backticks.

`transfer`
- `delta_apply/applicator.rs`: private `Self::apply_*`/`feed_see_token` helpers to backticks.
- `generator/delta.rs`: `build_signature_index` (private) to backticks.
- `reader/multiplex.rs`: `MultiplexReader::check_error_exit` (private) to backticks.
- `receiver/wire.rs`: `from_wire_bytes` and the private sans-io decode helpers to backticks.
- `writer/mod.rs`: `multiplex` submodule link to backticks (matching sibling entries).
- `writer/server.rs`: `CompressedWriter`, `CompressedReader` (private) to backticks.

`core`
- `README.md`: tagged the dependency-graph fence as ```` ```text ```` so rustdoc
  stops parsing it as Rust.
- `exit_code/codes.rs`: disambiguated `protocol::protocol_violation` with `fn@`.

`daemon`
- `daemon.rs`: `ConnectionContext::serve_one_connection`, `async_max_inflight`
  (private) to backticks.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
  now exits 0 with zero warnings or errors (the exact Pages gate).
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p protocol --all-features --no-deps -- -D warnings` clean.
