### PR TITLE
fix: forward --no-r, guard --open-noatime, read iconv/max-alloc env

### DIFF
--- a/crates/cli/src/frontend/arguments/env.rs
+++ b/crates/cli/src/frontend/arguments/env.rs
@@ -28,6 +28,27 @@ pub(crate) fn env_protect_args_default() -> Option<bool> {
     }
 }
 
+/// Returns the default `--iconv` value derived from `RSYNC_ICONV`.
+///
+/// Returns `Some(value)` when the variable is set and non-empty, `None`
+/// otherwise. Mirrors upstream rsync's `options.c:1377-1378`
+/// (`(arg = getenv("RSYNC_ICONV")) != NULL && *arg`), which seeds `iconv_opt`
+/// from the environment when the option was not given on the command line.
+pub(crate) fn env_iconv_default() -> Option<std::ffi::OsString> {
+    env::var_os("RSYNC_ICONV").filter(|value| !value.is_empty())
+}
+
+/// Returns the default `--max-alloc` argument derived from `RSYNC_MAX_ALLOC`.
+///
+/// Returns `Some(value)` when the variable is set and non-empty, `None`
+/// otherwise. Mirrors upstream rsync's `options.c:1954-1957`
+/// (`max_alloc_arg = getenv("RSYNC_MAX_ALLOC"); if (max_alloc_arg &&
+/// !*max_alloc_arg) max_alloc_arg = NULL`), which supplies the default cap when
+/// `--max-alloc` was not given on the command line.
+pub(crate) fn env_max_alloc_default() -> Option<std::ffi::OsString> {
+    env::var_os("RSYNC_MAX_ALLOC").filter(|value| !value.is_empty())
+}
+
 #[cfg(test)]
 #[allow(unsafe_code)]
 mod tests {
@@ -168,5 +189,59 @@ mod tests {
         let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
         let _guard = EnvGuard::set("RSYNC_PROTECT_ARGS", "true");
         assert_eq!(env_protect_args_default(), Some(true));
+    }
+
+    // upstream: options.c:1377-1378 - RSYNC_ICONV seeds the default --iconv value.
+    #[test]
+    fn env_iconv_default_returns_none_when_unset() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _guard = EnvGuard::remove("RSYNC_ICONV");
+        assert_eq!(env_iconv_default(), None);
+    }
+
+    // upstream: options.c:1377-1378 - `*arg` requires a non-empty value.
+    #[test]
+    fn env_iconv_default_ignores_empty_value() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _guard = EnvGuard::set("RSYNC_ICONV", "");
+        assert_eq!(env_iconv_default(), None);
+    }
+
+    // upstream: options.c:1377-1378 - a non-empty value becomes iconv_opt.
+    #[test]
+    fn env_iconv_default_returns_value() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _guard = EnvGuard::set("RSYNC_ICONV", "utf-8,latin1");
+        assert_eq!(
+            env_iconv_default(),
+            Some(std::ffi::OsString::from("utf-8,latin1"))
+        );
+    }
+
+    // upstream: options.c:1954-1957 - RSYNC_MAX_ALLOC seeds the default cap.
+    #[test]
+    fn env_max_alloc_default_returns_none_when_unset() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _guard = EnvGuard::remove("RSYNC_MAX_ALLOC");
+        assert_eq!(env_max_alloc_default(), None);
+    }
+
+    // upstream: options.c:1956-1957 - an empty value is treated as unset.
+    #[test]
+    fn env_max_alloc_default_ignores_empty_value() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _guard = EnvGuard::set("RSYNC_MAX_ALLOC", "");
+        assert_eq!(env_max_alloc_default(), None);
+    }
+
+    // upstream: options.c:1954-1955 - a non-empty value becomes max_alloc_arg.
+    #[test]
+    fn env_max_alloc_default_returns_value() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _guard = EnvGuard::set("RSYNC_MAX_ALLOC", "2G");
+        assert_eq!(
+            env_max_alloc_default(),
+            Some(std::ffi::OsString::from("2G"))
+        );
     }
 }

--- a/crates/cli/src/frontend/arguments/mod.rs
+++ b/crates/cli/src/frontend/arguments/mod.rs
@@ -17,7 +17,7 @@ mod stop;
 mod tests;
 
 pub(crate) use bandwidth::BandwidthArgument;
-pub(crate) use env::env_protect_args_default;
+pub(crate) use env::{env_iconv_default, env_max_alloc_default, env_protect_args_default};
 pub use parsed_args::ParsedArgs; // Changed to pub for test_utils
 pub(crate) use parser::ChecksumThreadsSetting;
 pub use parser::parse_args; // Changed to pub for test_utils

--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -27,7 +27,10 @@ use super::flags::{
     leveled_flag_pair, tri_state_flag_negative_first, tri_state_flag_positive_first,
 };
 use super::values::join_os_values;
-use super::{BandwidthArgument, ParsedArgs, detect_program_name, env_protect_args_default};
+use super::{
+    BandwidthArgument, ParsedArgs, detect_program_name, env_iconv_default, env_max_alloc_default,
+    env_protect_args_default,
+};
 
 /// Maximum number of alt-dest directories rsync accepts across `--compare-dest`,
 /// `--copy-dest`, and `--link-dest` combined.
@@ -391,8 +394,19 @@ where
         // `parse_compression_settings()` once `--compress-choice` is known.
         compress = !setting.is_disabled();
     }
-    let iconv = matches.remove_one::<OsString>("iconv");
     let no_iconv = matches.get_flag("no-iconv");
+    // upstream: options.c:1377-1378 - `if (!am_daemon && protect_args <= 0 &&
+    // (arg = getenv("RSYNC_ICONV")) != NULL && *arg) iconv_opt = strdup(arg);`.
+    // RSYNC_ICONV seeds the default --iconv value when the option is absent,
+    // unless the caller explicitly enabled protect_args (`protect_args > 0`,
+    // i.e. `Some(true)` here). `--no-iconv` still wins over the env default.
+    let iconv = matches.remove_one::<OsString>("iconv").or_else(|| {
+        if no_iconv || protect_args == Some(true) {
+            None
+        } else {
+            env_iconv_default()
+        }
+    });
     let owner = tri_state_flag_positive_first(&matches, "owner", "no-owner");
     let group = tri_state_flag_positive_first(&matches, "group", "no-group");
     let usermap = join_os_values(matches.remove_many::<OsString>("usermap"));
@@ -517,7 +531,12 @@ where
         }
     }
     let outbuf = matches.remove_one::<OsString>("outbuf");
-    let max_alloc = matches.remove_one::<OsString>("max-alloc");
+    // upstream: options.c:1954-1957 - `if (!max_alloc_arg) { max_alloc_arg =
+    // getenv("RSYNC_MAX_ALLOC"); ... }`. RSYNC_MAX_ALLOC supplies the default
+    // cap when --max-alloc is absent; an empty value is treated as unset.
+    let max_alloc = matches
+        .remove_one::<OsString>("max-alloc")
+        .or_else(env_max_alloc_default);
     let stats = matches.get_flag("stats");
     let eight_bit_output = matches.get_flag("8-bit-output");
     let partial_flag = matches.get_flag("partial") || matches.get_count("partial-progress") > 0;

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -18,4 +18,7 @@ mod tests;
 pub use coerce::ChecksumThreadsSetting;
 pub use entry::parse_args;
 
-use super::{BandwidthArgument, ParsedArgs, detect_program_name, env_protect_args_default};
+use super::{
+    BandwidthArgument, ParsedArgs, detect_program_name, env_iconv_default, env_max_alloc_default,
+    env_protect_args_default,
+};

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -3214,3 +3214,109 @@ mod parsed_args_traits {
         assert_ne!(parsed1, parsed2);
     }
 }
+
+/// Environment-derived option defaults (`RSYNC_ICONV`, `RSYNC_MAX_ALLOC`).
+///
+/// These encode WHY the env defaults matter: upstream rsync seeds `--iconv`
+/// (options.c:1377-1378) and `--max-alloc` (options.c:1954-1957) from the
+/// environment so a caller can configure them without repeating the flag.
+#[cfg(test)]
+#[allow(unsafe_code)]
+mod env_option_defaults {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: the test holds ENV_MUTEX, serialising every mutation.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: see `set` above.
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                // SAFETY: still holding ENV_MUTEX at scope exit.
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    // upstream: options.c:1377-1378 - RSYNC_ICONV supplies the default --iconv
+    // value when the option is absent; the transfer must honour it exactly as
+    // if `--iconv=<value>` had been typed.
+    #[test]
+    fn iconv_defaults_to_rsync_iconv_env() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _protect = EnvGuard::remove("RSYNC_PROTECT_ARGS");
+        let _iconv = EnvGuard::set("RSYNC_ICONV", "utf-8,latin1");
+
+        let parsed = parse_test_args(["src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.iconv, Some(OsString::from("utf-8,latin1")));
+    }
+
+    // upstream: options.c:1377-1378 - an explicit --iconv wins over the env.
+    #[test]
+    fn explicit_iconv_overrides_rsync_iconv_env() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _protect = EnvGuard::remove("RSYNC_PROTECT_ARGS");
+        let _iconv = EnvGuard::set("RSYNC_ICONV", "utf-8,latin1");
+
+        let parsed = parse_test_args(["--iconv=.", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.iconv, Some(OsString::from(".")));
+    }
+
+    // upstream: options.c:1377 - `protect_args <= 0` guard: an explicitly
+    // enabled protect_args suppresses the RSYNC_ICONV default.
+    #[test]
+    fn protect_args_suppresses_rsync_iconv_env() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _protect = EnvGuard::remove("RSYNC_PROTECT_ARGS");
+        let _iconv = EnvGuard::set("RSYNC_ICONV", "utf-8,latin1");
+
+        let parsed = parse_test_args(["--protect-args", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.iconv, None);
+    }
+
+    // upstream: options.c:1954-1957 - RSYNC_MAX_ALLOC supplies the default cap
+    // when --max-alloc is absent.
+    #[test]
+    fn max_alloc_defaults_to_rsync_max_alloc_env() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _max = EnvGuard::set("RSYNC_MAX_ALLOC", "2G");
+
+        let parsed = parse_test_args(["src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.max_alloc, Some(OsString::from("2G")));
+    }
+
+    // upstream: options.c:1954 - an explicit --max-alloc wins over the env.
+    #[test]
+    fn explicit_max_alloc_overrides_rsync_max_alloc_env() {
+        let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _max = EnvGuard::set("RSYNC_MAX_ALLOC", "2G");
+
+        let parsed = parse_test_args(["--max-alloc=512M", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.max_alloc, Some(OsString::from("512M")));
+    }
+}

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -275,6 +275,21 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--list-only"));
         }
 
+        // upstream: options.c:2750-2753 - `if (xfer_dirs && !recurse &&
+        // delete_mode && am_sender) args[ac++] = "--no-r"`. When a PUSH deletes
+        // with --dirs but without recursion (`-d --delete` sans `-r`), the
+        // remote receiver must be told recursion is off: the compact flag string
+        // carries 'd' but no 'r', and older receivers gained `--no-r` at the
+        // same time as `-d`, so the explicit negation guarantees the remote does
+        // not re-enable recursion. `--files-from` resolves to xfer_dirs=1,
+        // recurse=0 (options.c:2188-2191), matching `effective_*` below.
+        let files_from_active = self.config.files_from().is_active();
+        let effective_recursive = self.config.recursive() && !files_from_active;
+        let effective_dirs = self.config.dirs() || files_from_active;
+        if am_sender && effective_dirs && !effective_recursive && self.config.delete() {
+            args.push(OsString::from("--no-r"));
+        }
+
         // upstream: options.c:2782-2785 - `if (msgs2stderr == 1) "--msgs2stderr";
         // else if (msgs2stderr == 0) "--no-msgs2stderr"`. The default (2) is not
         // forwarded. Modelled as the tri-state `Option<bool>`.
@@ -688,7 +703,12 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from(arg));
         }
 
-        if self.config.open_noatime() {
+        // upstream: options.c:2993 - `if (open_noatime && preserve_atimes <= 1)
+        // args[ac++] = "--open-noatime"`. When `-UU` (preserve_atimes == 2) is
+        // active the flag is suppressed: at that level the receiver already
+        // opens files with O_NOATIME implicitly, so forwarding it is redundant
+        // and upstream drops it.
+        if self.config.open_noatime() && self.config.preserve_atimes_level() <= 1 {
             args.push(OsString::from("--open-noatime"));
         }
 

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -4096,3 +4096,103 @@ fn bwlimit_forwarded_in_kib_not_bytes() {
         "bwlimit must NOT forward the raw byte count: {args:?}"
     );
 }
+
+// upstream: options.c:2750-2753 - `--no-r` tells the remote receiver that a
+// dirs-mode delete (`-d --delete`) is NOT recursive. Without it the receiver
+// could re-enable recursion and delete beyond the top level, so the flag is
+// load-bearing for delete correctness, not cosmetic.
+#[test]
+fn dirs_delete_push_forwards_no_r() {
+    // `ClientConfig::builder()` presets recursion on, so a `-d --delete` (no
+    // `-r`) transfer must explicitly clear it to reach the guard.
+    let config = ClientConfig::builder()
+        .recursive(false)
+        .dirs(true)
+        .delete(true)
+        .build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--no-r"),
+        "expected --no-r for -d --delete push: {args:?}"
+    );
+}
+
+// upstream: options.c:2752 - the guard requires !recurse; with recursion on the
+// receiver already recurses, so --no-r must NOT be sent.
+#[test]
+fn recursive_delete_push_omits_no_r() {
+    let config = ClientConfig::builder()
+        .dirs(true)
+        .recursive(true)
+        .delete(true)
+        .build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a == "--no-r"),
+        "recursive delete must NOT send --no-r: {args:?}"
+    );
+}
+
+// upstream: options.c:2752 - the guard requires delete_mode; without --delete
+// there is nothing to protect, so --no-r must NOT be sent.
+#[test]
+fn dirs_push_without_delete_omits_no_r() {
+    let config = ClientConfig::builder().recursive(false).dirs(true).build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a == "--no-r"),
+        "dirs push without --delete must NOT send --no-r: {args:?}"
+    );
+}
+
+// upstream: options.c:2752 - the guard requires am_sender; on a PULL the local
+// process is the receiver, so --no-r must NOT be forwarded to the remote sender.
+#[test]
+fn dirs_delete_pull_omits_no_r() {
+    let config = ClientConfig::builder()
+        .recursive(false)
+        .dirs(true)
+        .delete(true)
+        .build();
+    let args = build_receiver_args(&config);
+    assert!(
+        !args.iter().any(|a| a == "--no-r"),
+        "dirs delete PULL must NOT send --no-r: {args:?}"
+    );
+}
+
+// upstream: options.c:2993 - `if (open_noatime && preserve_atimes <= 1)`. Plain
+// --open-noatime (no -U) is below the threshold, so the flag is forwarded.
+#[test]
+fn open_noatime_forwarded_without_atimes() {
+    let config = ClientConfig::builder().open_noatime(true).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--open-noatime"),
+        "expected --open-noatime: {args:?}"
+    );
+}
+
+// upstream: options.c:2993 - a single -U (preserve_atimes == 1) is still <= 1,
+// so --open-noatime is forwarded.
+#[test]
+fn open_noatime_forwarded_with_single_atimes() {
+    let config = ClientConfig::builder().open_noatime(true).atimes(1).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--open-noatime"),
+        "expected --open-noatime with -U: {args:?}"
+    );
+}
+
+// upstream: options.c:2993 - `-UU` (preserve_atimes == 2) exceeds the threshold,
+// so --open-noatime is suppressed even though open_noatime is set.
+#[test]
+fn open_noatime_suppressed_with_double_atimes() {
+    let config = ClientConfig::builder().open_noatime(true).atimes(2).build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a == "--open-noatime"),
+        "-UU must suppress --open-noatime: {args:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Completes the low-severity tail of SSH server-argument forwarding gaps by
mirroring upstream rsync 3.4.4 `server_options()` (options.c) exactly for four
confirmed divergences. Every change is confined to the SSH server-arg builder
(`crates/core`) and CLI argument parsing (`crates/cli`).

## Confirmed gaps fixed

- **`--no-r` forwarding** (options.c:2750-2753). A `-d --delete` push without
  `-r` never emitted `--no-r`, so the compact flag string carried `d` with no
  `r` and no explicit negation. Now emitted when
  `am_sender && xfer_dirs && !recurse && delete_mode`, matching upstream.

- **`--open-noatime` guard** (options.c:2993). The flag was forwarded whenever
  `open_noatime` was set. Upstream guards on `preserve_atimes <= 1`, suppressing
  it under `-UU`. Guard added via the existing `preserve_atimes_level()`
  accessor.

- **`RSYNC_ICONV` environment default** (options.c:1377-1378). The env var was
  never read. It now seeds the default `--iconv` value when the option is
  absent, honouring the `protect_args <= 0` guard (an explicit `--protect-args`
  suppresses it) and letting an explicit `--iconv`/`--no-iconv` win.

- **`RSYNC_MAX_ALLOC` environment default** (options.c:1954-1957). The env var
  was never read. It now seeds the default `--max-alloc` argument when the
  option is absent; an explicit `--max-alloc` wins. Existing forwarding of the
  resolved cap to the peer is unchanged.

The two new env defaults reuse the established `arguments/env.rs` helper pattern
(alongside `env_protect_args_default`) so environment handling stays DRY.

## Already-forwarded but incomplete (not changed here)

- **`--log-format=%o` / `X` escapes** (options.c:2770-2779). The builder already
  forwards `--log-format=%i` / `%i%I` for itemize, but not the `%o` operation
  escape or the `X` fallback. A faithful fix needs a new "out-format contains
  `%o`" signal plumbed from CLI parsing into the config, and must be applied to
  both the SSH and daemon-connection arg builders to avoid asymmetry. Deferred
  to a dedicated change.

- **`--remove-sent-files` deprecated spelling** (options.c:730-731, 2982-2985).
  Upstream forwards `--remove-sent-files` verbatim when the deprecated alias was
  typed; oc canonicalises both spellings to a single boolean and forwards
  `--remove-source-files`. Every oc-supported remote (3.0.9+) accepts both, so
  this is a wire-cosmetic difference only. A faithful fix requires a new public
  config field tracking the alias plus parity across both arg builders.

## Tests

Failing-first WHY-tests added, each citing options.c:

- Builder: `--no-r` emitted for `-d --delete` push; suppressed when recursive,
  when no delete, and on a pull. `--open-noatime` forwarded at atimes level 0/1,
  suppressed at level 2.
- CLI: `RSYNC_ICONV` / `RSYNC_MAX_ALLOC` seed the parsed defaults; explicit flags
  override; `--protect-args` suppresses the iconv default. Plus unit coverage for
  the two new env helpers (unset / empty / value).

`cargo fmt --all`, `cargo clippy -p core -p cli --all-features --all-targets
--no-deps -D warnings`, and the targeted nextest run (477 tests) all pass.
