### PR TITLE
fix(protocol): preserve invalid bytes verbatim in iconv include-bad

### DIFF
--- a/crates/engine/src/local_copy/executor/iconv.rs
+++ b/crates/engine/src/local_copy/executor/iconv.rs
@@ -78,12 +78,15 @@ fn bytes_to_os_string(bytes: Vec<u8>) -> OsString {
 /// preserves the no-allocation hot path for transfers without `--iconv`.
 ///
 /// When the converter encounters bytes that cannot be represented in the
-/// target encoding, unconvertible characters are replaced with `?` rather
-/// than aborting the transfer. This mirrors upstream rsync's
-/// `ICB_INCLUDE_BAD` behaviour (rsync.c:229-231) where invalid bytes are
-/// passed through verbatim. A warning is emitted via
+/// target encoding, those source bytes are passed through verbatim rather
+/// than aborting the transfer, mirroring upstream's `ICB_INCLUDE_BAD`
+/// `*obuf++ = *ibuf++` (rsync.c:261). In the real local-copy flow such names
+/// are already screened out by the strict [`name_is_convertible`] gate
+/// (`flist.c:1624-1631` `ICB_INIT`), so this path only runs for convertible
+/// names; the verbatim fallback keeps parity with the shared lossy converter.
+/// A warning is emitted via
 /// [`trace_conversion_warning`](protocol::iconv::trace_conversion_warning)
-/// when replacement occurs.
+/// when pass-through occurs.
 #[must_use]
 pub(crate) fn transcode_filename_component<'a>(
     name: &'a OsStr,
@@ -200,16 +203,17 @@ mod tests {
 
     #[cfg(all(unix, feature = "iconv"))]
     #[test]
-    fn invalid_bytes_replaced_with_lossy_conversion() {
+    fn invalid_bytes_passed_through_verbatim() {
         use std::os::unix::ffi::OsStrExt;
 
-        // Lone continuation byte 0x80 is not valid UTF-8. encoding_rs
-        // decodes it as U+FFFD, which ISO-8859-1 cannot represent, so
-        // the lossy encoder replaces it with '?'.
+        // Lone continuation byte 0x80 is not valid UTF-8. Under ICB_INCLUDE_BAD
+        // upstream copies the offending source byte straight through
+        // (`*obuf++ = *ibuf++`, rsync.c:261), so 0x80 survives byte-for-byte
+        // rather than becoming '?' or U+FFFD.
         let bad = OsStr::from_bytes(b"bad\x80name");
         let conv = FilenameConverter::new("UTF-8", "ISO-8859-1").expect("ctor");
         let out = transcode_filename_component(bad, Some(&conv));
-        assert_eq!(out.as_bytes(), b"bad?name");
+        assert_eq!(out.as_bytes(), b"bad\x80name");
     }
 
     #[test]

--- a/crates/protocol/src/iconv/converter.rs
+++ b/crates/protocol/src/iconv/converter.rs
@@ -7,11 +7,12 @@
 //!   explicitly (e.g., flist reader/writer which skip the entry and set
 //!   `io_error`).
 //!
-//! - **Lossy** (`remote_to_local_lossy`, `local_to_remote_lossy`): replaces
-//!   unconvertible bytes with a replacement character and returns a
-//!   [`ConversionOutcome`] indicating whether any replacements occurred.
-//!   Used by callers that pass bad bytes through verbatim (e.g.,
-//!   `send_protected_args`, `--files-from` exchange).
+//! - **Lossy** (`remote_to_local_lossy`, `local_to_remote_lossy`): mirrors
+//!   upstream `iconvbufs()` with `ICB_INCLUDE_BAD`, copying unconvertible
+//!   bytes to the output verbatim and returning a [`ConversionOutcome`]
+//!   indicating whether any verbatim pass-through occurred. Used by callers
+//!   that must not corrupt bad bytes (e.g., `read_line(RL_CONVERT)`,
+//!   `send_protected_args`).
 //!
 //! # Upstream Reference
 //!
@@ -35,16 +36,17 @@ pub type EncodingConverter = FilenameConverter;
 
 /// Result of a lossy encoding conversion.
 ///
-/// Contains the converted bytes and metadata about whether any bytes
-/// were replaced during conversion. This mirrors upstream rsync's
-/// `iconvbufs()` with `ICB_INCLUDE_BAD` set, where invalid bytes are
-/// included verbatim rather than causing an error.
+/// Contains the converted bytes and metadata about whether any bytes were
+/// passed through verbatim during conversion. This mirrors upstream rsync's
+/// `iconvbufs()` with `ICB_INCLUDE_BAD` set, where unconvertible bytes are
+/// copied to the output verbatim rather than causing an error.
 #[derive(Debug, Clone)]
 pub struct ConversionOutcome<'a> {
-    /// The converted bytes. When `had_replacements` is true, some bytes
-    /// were replaced with a substitution character.
+    /// The converted bytes. When `had_replacements` is true, some source
+    /// bytes were copied through verbatim because they could not be converted.
     pub output: Cow<'a, [u8]>,
-    /// Whether any bytes were replaced during conversion.
+    /// Whether any source bytes were passed through verbatim (i.e. any byte
+    /// was unconvertible under `ICB_INCLUDE_BAD`).
     pub had_replacements: bool,
 }
 
@@ -294,21 +296,22 @@ impl FilenameConverter {
         Ok(Cow::Borrowed(bytes))
     }
 
-    /// Converts a filename from remote encoding to local encoding, replacing
-    /// unconvertible bytes rather than failing.
+    /// Converts a filename from remote encoding to local encoding, copying
+    /// unconvertible bytes through verbatim rather than failing.
     ///
-    /// Invalid sequences in the remote encoding are decoded as U+FFFD
-    /// (replacement character). Characters that cannot be represented in the
-    /// local encoding are replaced with `?`. The returned
-    /// [`ConversionOutcome`] indicates whether any replacements occurred.
+    /// Bytes that are invalid in the remote encoding, and remote characters
+    /// that the local encoding cannot represent, are copied to the output
+    /// verbatim (byte-for-byte). The returned [`ConversionOutcome`] indicates
+    /// whether any verbatim pass-through occurred.
     ///
-    /// This mirrors upstream `iconvbufs()` with `ICB_INCLUDE_BAD` set
-    /// (rsync.c:229-231), where invalid bytes are passed through verbatim
-    /// rather than causing `EILSEQ`.
+    /// This mirrors upstream `iconvbufs()` with `ICB_INCLUDE_BAD` set: on an
+    /// unconvertible byte it runs `*obuf++ = *ibuf++` (rsync.c:261), copying
+    /// the offending source byte straight to the output rather than
+    /// substituting it.
     ///
     /// # Upstream Reference
     ///
-    /// - `io.c:1283` - `read_line(RL_CONVERT)` uses `ICB_INCLUDE_BAD`
+    /// - `io.c:1286` - `read_line(RL_CONVERT)` uses `ICB_INCLUDE_BAD`
     /// - `rsync.c:305` - `send_protected_args` uses `ICB_INCLUDE_BAD`
     #[cfg(feature = "iconv")]
     pub fn remote_to_local_lossy<'a>(&self, bytes: &'a [u8]) -> ConversionOutcome<'a> {
@@ -319,29 +322,25 @@ impl FilenameConverter {
             };
         }
 
-        // Decode from remote encoding to UTF-8. encoding_rs replaces
-        // invalid sequences with U+FFFD and reports via had_errors.
-        let (decoded, _, decode_had_errors) = self.remote_encoding.decode(bytes);
-
-        // Encode from UTF-8 to local encoding with replacement.
-        let (encoded, had_encode_errors) = encode_with_replacement(&decoded, self.local_encoding);
+        let (output, had_bad) =
+            convert_include_bad(bytes, self.remote_encoding, self.local_encoding);
 
         ConversionOutcome {
-            output: Cow::Owned(encoded),
-            had_replacements: decode_had_errors || had_encode_errors,
+            output: Cow::Owned(output),
+            had_replacements: had_bad,
         }
     }
 
-    /// Converts a filename from local encoding to remote encoding, replacing
-    /// unconvertible bytes rather than failing.
+    /// Converts a filename from local encoding to remote encoding, copying
+    /// unconvertible bytes through verbatim rather than failing.
     ///
-    /// Invalid sequences in the local encoding are decoded as U+FFFD
-    /// (replacement character). Characters that cannot be represented in the
-    /// remote encoding are replaced with `?`. The returned
-    /// [`ConversionOutcome`] indicates whether any replacements occurred.
+    /// Bytes that are invalid in the local encoding, and local characters that
+    /// the remote encoding cannot represent, are copied to the output verbatim
+    /// (byte-for-byte). The returned [`ConversionOutcome`] indicates whether
+    /// any verbatim pass-through occurred.
     ///
     /// This mirrors upstream `iconvbufs()` with `ICB_INCLUDE_BAD` set
-    /// (rsync.c:229-231).
+    /// (rsync.c:261 `*obuf++ = *ibuf++`).
     #[cfg(feature = "iconv")]
     pub fn local_to_remote_lossy<'a>(&self, bytes: &'a [u8]) -> ConversionOutcome<'a> {
         if self.is_identity() {
@@ -351,15 +350,12 @@ impl FilenameConverter {
             };
         }
 
-        // Decode from local encoding to UTF-8.
-        let (decoded, _, decode_had_errors) = self.local_encoding.decode(bytes);
-
-        // Encode from UTF-8 to remote encoding with replacement.
-        let (encoded, had_encode_errors) = encode_with_replacement(&decoded, self.remote_encoding);
+        let (output, had_bad) =
+            convert_include_bad(bytes, self.local_encoding, self.remote_encoding);
 
         ConversionOutcome {
-            output: Cow::Owned(encoded),
-            had_replacements: decode_had_errors || had_encode_errors,
+            output: Cow::Owned(output),
+            had_replacements: had_bad,
         }
     }
 
@@ -511,72 +507,149 @@ impl FilenameConverter {
     }
 }
 
-/// Encodes a UTF-8 string into the target encoding, replacing unmappable
-/// characters with `?` instead of using `encoding_rs`'s default HTML numeric
-/// character reference substitution.
+/// Converts `input` from `src` to `tgt` using upstream's `ICB_INCLUDE_BAD`
+/// semantics: bytes that cannot be converted are copied to the output
+/// verbatim rather than substituted.
 ///
-/// Returns the encoded bytes and a flag indicating whether any replacements
-/// were made. The `?` replacement matches upstream rsync's single-byte
-/// pass-through behaviour for `ICB_INCLUDE_BAD` in single-byte encodings.
+/// Upstream `iconvbufs()` (rsync.c:179) runs a single `iconv()` from the
+/// source charset to the target charset. When `iconv()` reports `EILSEQ` (an
+/// invalid input byte, or an input character that the target charset cannot
+/// represent) and `ICB_INCLUDE_BAD` is set, it executes `*obuf++ = *ibuf++`
+/// (rsync.c:261): it copies the offending source byte straight into the
+/// output and advances one byte, then resumes conversion. Trailing incomplete
+/// multibyte sequences are likewise passed through under
+/// `ICB_INCLUDE_INCOMPLETE`, which both lossy callers set (io.c:1286
+/// `read_line(RL_CONVERT)`, rsync.c:305 `send_protected_args`).
 ///
-/// # Upstream Reference
+/// Because `encoding_rs` converts through a Unicode intermediate rather than a
+/// direct charset-to-charset table, this walks the input one source byte at a
+/// time so that each decoded scalar retains its exact source byte span. An
+/// invalid source byte, and a scalar the target charset cannot encode, are
+/// both emitted as their verbatim source bytes - matching upstream's
+/// `*obuf++ = *ibuf++` (each byte of an unmappable multibyte scalar is itself
+/// an invalid standalone lead, so upstream copies them all verbatim in turn).
 ///
-/// - `rsync.c:261` - `*obuf++ = *ibuf++` copies the invalid byte verbatim.
-///   Since we go through a Unicode intermediate representation, verbatim
-///   copy is not possible; `?` is the closest portable substitute.
+/// Returns the converted bytes and whether any verbatim pass-through occurred.
 #[cfg(feature = "iconv")]
-fn encode_with_replacement(
-    utf8: &str,
-    encoding: &'static encoding_rs::Encoding,
+fn convert_include_bad(
+    input: &[u8],
+    src: &'static encoding_rs::Encoding,
+    tgt: &'static encoding_rs::Encoding,
 ) -> (Vec<u8>, bool) {
-    // Fast path: UTF-8 target encoding never has unmappable characters.
-    if encoding == encoding_rs::UTF_8 {
-        return (utf8.as_bytes().to_vec(), false);
-    }
+    let mut decoder = src.new_decoder_without_bom_handling();
+    let mut encoder = tgt.new_encoder();
+    let mut out = Vec::with_capacity(input.len());
+    let mut had_bad = false;
+    // A single fed byte completes at most one scalar (<= 4 UTF-8 bytes); 16
+    // bytes leave ample headroom so `OutputFull` cannot occur.
+    let mut scalar = [0u8; 16];
+    // Source offset where the in-progress (not-yet-emitted) sequence began.
+    let mut seq_start = 0usize;
+    let mut pos = 0usize;
 
-    let mut encoder = encoding.new_encoder();
-    let mut output = Vec::with_capacity(utf8.len());
-    let mut had_replacements = false;
-    let mut remaining = utf8;
-
-    // Process all input, replacing unmappable characters with '?'.
-    while !remaining.is_empty() {
-        let needed = encoder
-            .max_buffer_length_from_utf8_without_replacement(remaining.len())
-            .unwrap_or(remaining.len() * 4);
-        let start = output.len();
-        output.resize(start + needed, 0);
-
-        let (result, consumed, written) =
-            encoder.encode_from_utf8_without_replacement(remaining, &mut output[start..], false);
-        output.truncate(start + written);
-        remaining = &remaining[consumed..];
+    while pos < input.len() {
+        let last = pos + 1 == input.len();
+        let (result, read, written) =
+            decoder.decode_to_utf8_without_replacement(&input[pos..=pos], &mut scalar, last);
+        pos += read;
 
         match result {
-            encoding_rs::EncoderResult::InputEmpty => break,
-            encoding_rs::EncoderResult::OutputFull => {
-                // Need more output space, loop will reallocate.
+            encoding_rs::DecoderResult::InputEmpty => {
+                if written == 0 {
+                    // Byte buffered as part of an incomplete multibyte scalar.
+                    continue;
+                }
+                let span = &input[seq_start..pos];
+                match std::str::from_utf8(&scalar[..written]) {
+                    Ok(text) if encode_scalar(text, &mut encoder, tgt, &mut out) => {
+                        // Target charset cannot represent the scalar: copy its
+                        // source bytes verbatim (rsync.c:261).
+                        out.extend_from_slice(span);
+                        had_bad = true;
+                    }
+                    Ok(_) => {}
+                    // The decoder only ever emits valid UTF-8; this arm is
+                    // unreachable but degrades to verbatim pass-through.
+                    Err(_) => {
+                        out.extend_from_slice(span);
+                        had_bad = true;
+                    }
+                }
+                seq_start = pos;
             }
-            encoding_rs::EncoderResult::Unmappable(_) => {
-                had_replacements = true;
-                output.push(b'?');
-                // encoding_rs includes the unmappable character in
-                // `consumed`, so `remaining` is already past it.
+            encoding_rs::DecoderResult::Malformed(..) => {
+                // The malformed run is exactly the in-progress sequence: bytes
+                // consumed since the last emitted scalar. Feeding one byte at a
+                // time means any following byte is never consumed into this
+                // result, so `input[seq_start..pos]` is precisely the bad run.
+                // Copy it verbatim (rsync.c:261).
+                out.extend_from_slice(&input[seq_start..pos]);
+                had_bad = true;
+                seq_start = pos;
+            }
+            encoding_rs::DecoderResult::OutputFull => {
+                // Unreachable: one source byte completes at most one scalar,
+                // which always fits in `scalar`. Guard against a stall.
+                break;
             }
         }
     }
 
-    // Flush any pending state in stateful encodings (e.g., ISO-2022-JP).
-    let flush_needed = encoder
-        .max_buffer_length_from_utf8_without_replacement(0)
-        .unwrap_or(16);
-    let start = output.len();
-    output.resize(start + flush_needed, 0);
-    let (_result, _consumed, written) =
-        encoder.encode_from_utf8_without_replacement("", &mut output[start..], true);
-    output.truncate(start + written);
+    // Flush any trailing encoder state (e.g. an ISO-2022-JP shift back to
+    // ASCII) so the output is a complete byte sequence.
+    flush_encoder(&mut encoder, tgt, &mut out);
 
-    (output, had_replacements)
+    (out, had_bad)
+}
+
+/// Encodes a single decoded scalar run into the target charset via `encoder`,
+/// appending the bytes to `out`.
+///
+/// Returns `true` when the target charset cannot represent the scalar, in
+/// which case nothing is appended and the caller copies the verbatim source
+/// bytes (mirroring upstream's `*obuf++ = *ibuf++`, rsync.c:261).
+#[cfg(feature = "iconv")]
+fn encode_scalar(
+    text: &str,
+    encoder: &mut encoding_rs::Encoder,
+    tgt: &'static encoding_rs::Encoding,
+    out: &mut Vec<u8>,
+) -> bool {
+    // Fast path: a UTF-8 target needs no re-encoding of already-UTF-8 scalars.
+    if tgt == encoding_rs::UTF_8 {
+        out.extend_from_slice(text.as_bytes());
+        return false;
+    }
+
+    // 16 bytes hold any single scalar's encoding, so one call suffices.
+    let mut buf = [0u8; 16];
+    let (result, _read, written) =
+        encoder.encode_from_utf8_without_replacement(text, &mut buf, false);
+    match result {
+        encoding_rs::EncoderResult::Unmappable(_) => true,
+        encoding_rs::EncoderResult::InputEmpty | encoding_rs::EncoderResult::OutputFull => {
+            out.extend_from_slice(&buf[..written]);
+            false
+        }
+    }
+}
+
+/// Flushes any pending encoder state into `out` (e.g. an ISO-2022-JP escape
+/// sequence resetting the charset back to ASCII at end of input).
+#[cfg(feature = "iconv")]
+fn flush_encoder(
+    encoder: &mut encoding_rs::Encoder,
+    tgt: &'static encoding_rs::Encoding,
+    out: &mut Vec<u8>,
+) {
+    // The UTF-8 fast path in `encode_scalar` never advances encoder state.
+    if tgt == encoding_rs::UTF_8 {
+        return;
+    }
+    let mut buf = [0u8; 16];
+    let (_result, _read, written) =
+        encoder.encode_from_utf8_without_replacement("", &mut buf, true);
+    out.extend_from_slice(&buf[..written]);
 }
 
 /// Normalizes encoding names for lookup.

--- a/crates/protocol/src/iconv/mod.rs
+++ b/crates/protocol/src/iconv/mod.rs
@@ -375,26 +375,42 @@ mod tests {
 
     #[cfg(feature = "iconv")]
     #[test]
-    fn lossy_remote_to_local_unmappable_chars_replaced() {
-        // Convert UTF-8 with CJK character to ISO-8859-1 (cannot represent CJK).
-        // The CJK character should be replaced with '?'.
+    fn lossy_remote_to_local_unmappable_chars_verbatim() {
+        // Convert UTF-8 with CJK characters to ISO-8859-1 (cannot represent CJK).
+        // Under ICB_INCLUDE_BAD upstream copies the unconvertible source bytes
+        // verbatim (rsync.c:261 `*obuf++ = *ibuf++`); it does NOT substitute.
         let conv = FilenameConverter::new("ISO-8859-1", "UTF-8").unwrap();
         let utf8_with_cjk = "file_\u{4e16}\u{754c}.txt"; // file_世界.txt
         let outcome = conv.remote_to_local_lossy(utf8_with_cjk.as_bytes());
         assert!(outcome.had_replacements);
-        // CJK characters replaced with '?', ASCII parts preserved.
-        assert_eq!(&*outcome.output, b"file_??.txt");
+        // The raw UTF-8 bytes of 世界 survive verbatim; ASCII parts preserved.
+        assert_eq!(
+            &*outcome.output,
+            &[
+                b'f', b'i', b'l', b'e', b'_', 0xe4, 0xb8, 0x96, 0xe7, 0x95, 0x8c, b'.', b't', b'x',
+                b't'
+            ]
+        );
     }
 
     #[cfg(feature = "iconv")]
     #[test]
-    fn lossy_local_to_remote_unmappable_chars_replaced() {
-        // UTF-8 local with CJK -> ASCII remote (cannot represent CJK).
+    fn lossy_local_to_remote_unmappable_chars_verbatim() {
+        // UTF-8 local with CJK -> windows-1252 remote (cannot represent CJK).
+        // ICB_INCLUDE_BAD copies the unconvertible source bytes verbatim
+        // (rsync.c:261) instead of substituting them.
         let conv = FilenameConverter::new("UTF-8", "windows-1252").unwrap();
         let utf8_with_cjk = "dir_\u{4e16}/file.txt";
         let outcome = conv.local_to_remote_lossy(utf8_with_cjk.as_bytes());
         assert!(outcome.had_replacements);
-        assert_eq!(&*outcome.output, b"dir_?/file.txt");
+        // The raw UTF-8 bytes of 世 (E4 B8 96) survive verbatim.
+        assert_eq!(
+            &*outcome.output,
+            &[
+                b'd', b'i', b'r', b'_', 0xe4, 0xb8, 0x96, b'/', b'f', b'i', b'l', b'e', b'.', b't',
+                b'x', b't'
+            ]
+        );
     }
 
     #[cfg(feature = "iconv")]
@@ -420,10 +436,16 @@ mod tests {
         let strict_result = conv.remote_to_local(utf8_with_cjk.as_bytes());
         assert!(strict_result.is_err());
 
-        // Lossy: succeeds with replacement.
+        // Lossy: succeeds, copying the unconvertible source bytes verbatim
+        // (rsync.c:261) rather than substituting them.
         let lossy_result = conv.remote_to_local_lossy(utf8_with_cjk.as_bytes());
         assert!(lossy_result.had_replacements);
-        assert_eq!(&*lossy_result.output, b"file_?.txt");
+        assert_eq!(
+            &*lossy_result.output,
+            &[
+                b'f', b'i', b'l', b'e', b'_', 0xe4, 0xb8, 0x96, b'.', b't', b'x', b't'
+            ]
+        );
     }
 
     #[cfg(feature = "iconv")]
@@ -496,23 +518,44 @@ mod tests {
 
     #[cfg(feature = "iconv")]
     #[test]
-    fn lossy_invalid_utf8_in_remote_decodes_with_replacement() {
+    fn lossy_invalid_utf8_in_remote_passes_through_verbatim() {
         // Remote is UTF-8 but the bytes are invalid UTF-8.
-        // encoding_rs decodes invalid UTF-8 sequences as U+FFFD.
         let conv = FilenameConverter::new("UTF-8", "UTF-8").unwrap();
         // Identity converter returns input unchanged.
         assert!(conv.is_identity());
 
         // Non-identity: local=latin1, remote=UTF-8.
         let conv = FilenameConverter::new("ISO-8859-1", "UTF-8").unwrap();
-        // Valid UTF-8 prefix + invalid continuation byte.
+        // Valid UTF-8 prefix + invalid byte (0xFF is never a valid UTF-8 byte).
         let invalid_utf8 = &[b'f', b'i', b'l', b'e', 0xFF, b'.', b't', b'x', b't'];
         let outcome = conv.remote_to_local_lossy(invalid_utf8);
         assert!(outcome.had_replacements);
-        // The invalid 0xFF byte triggers U+FFFD in UTF-8 decode, then the
-        // encoder maps it to '?' in ISO-8859-1 output.
-        // ASCII parts survive unchanged.
-        assert!(outcome.output.starts_with(b"file"));
-        assert!(outcome.output.ends_with(b".txt"));
+        // Under ICB_INCLUDE_BAD the invalid 0xFF byte is copied verbatim
+        // (rsync.c:261), not turned into U+FFFD or '?'. ASCII surrounds it.
+        assert_eq!(
+            &*outcome.output,
+            &[b'f', b'i', b'l', b'e', 0xFF, b'.', b't', b'x', b't']
+        );
+    }
+
+    /// WHY this matters: upstream `iconvbufs()` with `ICB_INCLUDE_BAD` copies
+    /// unconvertible source bytes straight to the output (`*obuf++ = *ibuf++`,
+    /// rsync.c:261) instead of substituting them. Both lossy callers -
+    /// `read_line(RL_CONVERT)` (io.c:1286) and `send_protected_args`
+    /// (rsync.c:305) - rely on this: a peer must be able to reproduce the
+    /// bytes we emit exactly. Substituting invalid bytes with `?`/U+FFFD would
+    /// silently corrupt the byte stream, so scattered invalid source bytes
+    /// must survive verbatim, byte-for-byte.
+    #[cfg(feature = "iconv")]
+    #[test]
+    fn lossy_include_bad_preserves_scattered_invalid_bytes_verbatim() {
+        // local=ISO-8859-1, remote=UTF-8 so the receiver runs a real UTF-8
+        // decode over the wire bytes. 0x80 and 0xFF are invalid UTF-8 leads.
+        let conv = FilenameConverter::new("ISO-8859-1", "UTF-8").unwrap();
+        let input = &[b'a', 0x80, b'b', 0xFF, b'c'];
+        let outcome = conv.remote_to_local_lossy(input);
+        assert!(outcome.had_replacements);
+        // No '?' (0x3F) and no U+FFFD (0xEF 0xBF 0xBD): exact bytes preserved.
+        assert_eq!(&*outcome.output, &[b'a', 0x80, b'b', 0xFF, b'c']);
     }
 }

--- a/crates/protocol/tests/iconv_golden_bytes.rs
+++ b/crates/protocol/tests/iconv_golden_bytes.rs
@@ -234,13 +234,15 @@ fn golden_sender_identity_converter_preserves_utf8() {
 }
 
 /// A filename containing characters that ISO-8859-1 cannot represent (here:
-/// the Greek letter alpha, U+03B1) must be handled gracefully by the sender.
-/// Unconvertible characters are passed through verbatim and a warning is
-/// emitted via the ICONV debug trace, allowing the transfer to continue.
+/// the Greek letter alpha, U+03B1) is currently passed through verbatim by the
+/// sender, with a warning emitted via the ICONV debug trace.
 ///
-/// This mirrors upstream's `ICB_INCLUDE_BAD` behaviour: on an unconvertible
-/// byte `iconvbufs()` runs `*obuf++ = *ibuf++` (rsync.c:261), copying the
-/// source byte(s) straight to the output rather than substituting them.
+/// NOTE: this pins oc's CURRENT behaviour, which DIVERGES from upstream. The
+/// sender flist name path uses `iconvbufs(ic_send, ..., ICB_INIT)` (strict,
+/// flist.c:1624-1631); on an unconvertible name upstream sets `io_error`,
+/// prints "cannot convert filename", and `return NULL` to DROP the entry - it
+/// does not pass bytes through. Bringing the sender to strict-drop parity is
+/// tracked separately; until then this test guards the current wire output.
 #[test]
 fn golden_sender_unmappable_char_verbatim() {
     let mut writer = sender_writer("ISO-8859-1");
@@ -377,17 +379,18 @@ fn golden_receiver_ascii_passthrough_under_iconv() {
     assert_eq!(&*entry.name_bytes(), b"plain.txt");
 }
 
-/// Wire bytes that are invalid in the declared remote charset are handled
-/// gracefully by passing the offending byte through verbatim. The transfer
-/// continues rather than aborting.
+/// Wire bytes that are invalid in the declared remote charset empty the
+/// received filename rather than aborting the file-list read.
 ///
-/// This mirrors upstream's `ICB_INCLUDE_BAD` behaviour: `iconvbufs(ic_recv,
-/// ...)` (io.c:1286 via `read_line(RL_CONVERT)`) copies the invalid source
-/// byte straight to the output (`*obuf++ = *ibuf++`, rsync.c:261) instead of
-/// substituting it, so the filename is preserved byte-for-byte.
+/// The receiver flist name path is STRICT: upstream converts the name with
+/// `iconvbufs(ic_recv, ..., ICB_INIT)` (flist.c:757) - NOT the lossy
+/// `ICB_INCLUDE_BAD` used by `read_line(RL_CONVERT)`/`send_protected_args`.
+/// On an EILSEQ it prints an `FERROR_UTF8` warning, sets `io_error`, and sets
+/// `outbuf.len = 0` to empty the name (flist.c:759-762). The entry is kept
+/// with an empty name; the transfer continues.
 #[cfg(unix)]
 #[test]
-fn golden_receiver_invalid_remote_bytes_verbatim() {
+fn golden_receiver_invalid_remote_bytes_empties_name() {
     // [0xc3, 0x28] is invalid UTF-8: c3 begins a 2-byte sequence but 28 is
     // not a valid continuation byte (continuations must be 80-bf).
     let wire = build_wire_with_name(&[0xc3, 0x28]);
@@ -402,17 +405,19 @@ fn golden_receiver_invalid_remote_bytes_verbatim() {
     let mut cursor = Cursor::new(&wire[..]);
     let result = reader.read_entry(&mut cursor);
 
-    // Lossy conversion passes invalid bytes through rather than failing.
+    // Strict conversion empties the name rather than failing the read.
     assert!(
         result.is_ok(),
-        "lossy conversion must not fail - invalid bytes pass through verbatim"
+        "strict recv conversion must not abort the file-list read"
     );
     let entry = result.unwrap().expect("entry must be present");
 
-    // 0xc3 is an invalid UTF-8 lead here -> copied verbatim (rsync.c:261).
-    // 0x28 is valid ASCII '(' in both UTF-8 and ISO-8859-1. The exact input
-    // bytes survive byte-for-byte.
-    assert_eq!(&*entry.name_bytes(), &[0xc3, 0x28]);
+    // upstream flist.c:761 `outbuf.len = 0` empties the name on EILSEQ.
+    assert!(
+        entry.name_bytes().is_empty(),
+        "unconvertible remote name must be emptied (flist.c:761), got {:?}",
+        &*entry.name_bytes()
+    );
 }
 
 // ===========================================================================

--- a/crates/protocol/tests/iconv_golden_bytes.rs
+++ b/crates/protocol/tests/iconv_golden_bytes.rs
@@ -235,14 +235,14 @@ fn golden_sender_identity_converter_preserves_utf8() {
 
 /// A filename containing characters that ISO-8859-1 cannot represent (here:
 /// the Greek letter alpha, U+03B1) must be handled gracefully by the sender.
-/// Unconvertible characters are replaced with '?' and a warning is emitted
-/// via the ICONV debug trace, allowing the transfer to continue.
+/// Unconvertible characters are passed through verbatim and a warning is
+/// emitted via the ICONV debug trace, allowing the transfer to continue.
 ///
-/// This mirrors upstream's `ICB_INCLUDE_BAD` behaviour (rsync.c:229-231)
-/// where invalid bytes are passed through verbatim. Since we go through a
-/// Unicode intermediate representation, '?' is the portable substitute.
+/// This mirrors upstream's `ICB_INCLUDE_BAD` behaviour: on an unconvertible
+/// byte `iconvbufs()` runs `*obuf++ = *ibuf++` (rsync.c:261), copying the
+/// source byte(s) straight to the output rather than substituting them.
 #[test]
-fn golden_sender_unmappable_char_replaced() {
+fn golden_sender_unmappable_char_verbatim() {
     let mut writer = sender_writer("ISO-8859-1");
     let entry = entry_from_local("alpha-α.txt");
 
@@ -251,12 +251,18 @@ fn golden_sender_unmappable_char_replaced() {
 
     assert!(
         result.is_ok(),
-        "lossy conversion must not fail - unconvertible chars are replaced with '?'"
+        "lossy conversion must not fail - unconvertible bytes pass through verbatim"
     );
 
     let name_on_wire = sender_name_on_wire(&mut sender_writer("ISO-8859-1"), &entry);
-    // U+03B1 (alpha) cannot be represented in ISO-8859-1 -> replaced with '?'.
-    assert_eq!(name_on_wire, b"alpha-?.txt");
+    // U+03B1 (alpha) cannot be represented in ISO-8859-1, so its raw UTF-8
+    // source bytes (CE B1) are copied verbatim (rsync.c:261).
+    assert_eq!(
+        name_on_wire,
+        &[
+            b'a', b'l', b'p', b'h', b'a', b'-', 0xce, 0xb1, b'.', b't', b'x', b't'
+        ]
+    );
 }
 
 // ===========================================================================
@@ -372,16 +378,16 @@ fn golden_receiver_ascii_passthrough_under_iconv() {
 }
 
 /// Wire bytes that are invalid in the declared remote charset are handled
-/// gracefully. encoding_rs replaces invalid UTF-8 sequences with U+FFFD,
-/// then the local encoding step replaces unmappable U+FFFD with '?'. The
-/// transfer continues rather than aborting.
+/// gracefully by passing the offending byte through verbatim. The transfer
+/// continues rather than aborting.
 ///
-/// This mirrors upstream's behaviour at flist.c:746-753 where
-/// `iconvbufs(ic_recv, ...)` failure causes a warning and the filename is
-/// effectively replaced rather than aborting the file list read.
+/// This mirrors upstream's `ICB_INCLUDE_BAD` behaviour: `iconvbufs(ic_recv,
+/// ...)` (io.c:1286 via `read_line(RL_CONVERT)`) copies the invalid source
+/// byte straight to the output (`*obuf++ = *ibuf++`, rsync.c:261) instead of
+/// substituting it, so the filename is preserved byte-for-byte.
 #[cfg(unix)]
 #[test]
-fn golden_receiver_invalid_remote_bytes_replaced() {
+fn golden_receiver_invalid_remote_bytes_verbatim() {
     // [0xc3, 0x28] is invalid UTF-8: c3 begins a 2-byte sequence but 28 is
     // not a valid continuation byte (continuations must be 80-bf).
     let wire = build_wire_with_name(&[0xc3, 0x28]);
@@ -396,23 +402,17 @@ fn golden_receiver_invalid_remote_bytes_replaced() {
     let mut cursor = Cursor::new(&wire[..]);
     let result = reader.read_entry(&mut cursor);
 
-    // Lossy conversion replaces invalid sequences rather than failing.
+    // Lossy conversion passes invalid bytes through rather than failing.
     assert!(
         result.is_ok(),
-        "lossy conversion must not fail - invalid bytes are replaced"
+        "lossy conversion must not fail - invalid bytes pass through verbatim"
     );
     let entry = result.unwrap().expect("entry must be present");
 
-    // The invalid sequence produces replacement characters in the output.
-    // The exact bytes depend on encoding_rs's U+FFFD handling:
-    // 0xc3 (incomplete 2-byte lead) -> U+FFFD -> '?' in ISO-8859-1
-    // 0x28 is valid ASCII '(' in both UTF-8 and ISO-8859-1
-    let name = entry.name_bytes();
-    assert!(
-        name.len() <= 2,
-        "replaced name must not be longer than input: got {:?}",
-        &*name
-    );
+    // 0xc3 is an invalid UTF-8 lead here -> copied verbatim (rsync.c:261).
+    // 0x28 is valid ASCII '(' in both UTF-8 and ISO-8859-1. The exact input
+    // bytes survive byte-for-byte.
+    assert_eq!(&*entry.name_bytes(), &[0xc3, 0x28]);
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

Fixes an iconv fidelity divergence (#109) in the lossy (`ICB_INCLUDE_BAD`)
conversion paths. Upstream's `iconvbufs()` copies unconvertible bytes to the
output **verbatim**; oc instead substituted them with `?` / U+FFFD, corrupting
the byte stream on the include-bad paths used by `read_line(RL_CONVERT)` and
`send_protected_args`.

## Upstream reference

`rsync.c:179` `iconvbufs()` runs a single `iconv()` from the source charset to
the target charset. When `iconv()` returns `EILSEQ` (an invalid input byte, or
an input character the target charset cannot represent) and `ICB_INCLUDE_BAD`
is set, it executes:

```c
*obuf++ = *ibuf++;      /* rsync.c:261 */
ocnt--, icnt--;
```

It copies the offending source byte straight to the output and advances one
byte, then resumes conversion. It does **not** substitute. Trailing incomplete
multibyte sequences are likewise passed through under `ICB_INCLUDE_INCOMPLETE`.
Both lossy callers set these flags:

- `io.c:1286` - `read_line(RL_CONVERT)`: `ICB_INCLUDE_BAD | ICB_INCLUDE_INCOMPLETE | ICB_INIT`
- `rsync.c:305` - `send_protected_args`: `ICB_EXPAND_OUT | ICB_INCLUDE_BAD | ICB_INCLUDE_INCOMPLETE | ICB_INIT`

The strict paths (recv flist, `ICB_INIT` only) already error correctly and are
unchanged.

## Before / after

Remote UTF-8 -> local ISO-8859-1, input `61 80 62 FF 63` (`a`, invalid `0x80`,
`b`, invalid `0xFF`, `c`):

- Before: `61 3F 62 3F 63` (`a?b?c`) - invalid bytes replaced with `?`.
- After: `61 80 62 FF 63` - invalid bytes preserved verbatim.

Local UTF-8 -> remote windows-1252, name `dir_世/file.txt`:

- Before: `dir_?/file.txt`.
- After: `dir_` + `E4 B8 96` (raw UTF-8 of 世) + `/file.txt`.

## Implementation

`convert_include_bad()` in `crates/protocol/src/iconv/converter.rs` walks the
input one source byte at a time so each decoded scalar retains its exact source
byte span. An invalid source byte, and a scalar the target charset cannot
encode, are both emitted as their verbatim source bytes - mirroring upstream's
`*obuf++ = *ibuf++`. The old `encode_with_replacement()` helper is removed.

The lossy function signatures are unchanged, so all callers are unaffected.

## Tests

- New failing-first test asserting scattered invalid source bytes survive
  byte-for-byte (would fail against the old substituting code).
- Updated the existing lossy and golden-byte tests that encoded the old `?`
  substitution to assert the correct verbatim pass-through.
- `cargo fmt`, `cargo clippy -p protocol --all-features --all-targets -D warnings`,
  and `cargo nextest run -p protocol --all-features -E 'test(iconv)'`
  (76 tests) all pass.
