### PR TITLE
fix(daemon): resolve uid/gid names in rsyncd.conf, not just numeric

### DIFF
--- a/crates/daemon/src/daemon/sections/config_helpers/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/tests.rs
@@ -265,9 +265,65 @@ mod config_helpers_tests {
     }
 
     #[test]
-    fn parse_gid_setting_rejects_empty_and_non_numeric() {
+    fn parse_gid_setting_rejects_empty_and_unresolvable() {
         assert!(parse_gid_setting("   ").is_err());
-        assert!(parse_gid_setting("nobody").is_err());
+        // WHY: upstream group_to_gid() fails when getgrnam() cannot resolve the
+        // name, so a name guaranteed absent from the group database must error
+        // rather than default silently. The `\0`-free control name below is not
+        // a valid group anywhere.
+        assert!(parse_gid_setting("oc_definitely_absent_group").is_err());
+    }
+
+    /// WHY: the canonical rsyncd.conf ships `uid = nobody` / `gid = nogroup`.
+    /// upstream resolves both a numeric id and a name (user_to_uid /
+    /// group_to_gid with num_ok=True); oc must accept the name form too or the
+    /// default config fails to parse. `root`/gid 0 exist on every POSIX host,
+    /// giving a deterministic name to resolve.
+    #[test]
+    #[cfg(unix)]
+    fn parse_uid_setting_resolves_root_name_and_numeric() {
+        assert_eq!(parse_uid_setting("0"), Some(0));
+        assert_eq!(parse_uid_setting("65534"), Some(65534));
+        assert_eq!(
+            parse_uid_setting("root"),
+            Some(0),
+            "the username 'root' must resolve to uid 0"
+        );
+    }
+
+    /// WHY: a name that resolves nowhere must surface as a parse failure (the
+    /// caller wraps `None` into `invalid uid '<value>'`), never a silent
+    /// default. Mirrors upstream `@ERROR: invalid uid <name>`.
+    #[test]
+    fn parse_uid_setting_rejects_empty_and_unresolvable() {
+        assert_eq!(parse_uid_setting(""), None);
+        assert_eq!(parse_uid_setting("   "), None);
+        assert_eq!(parse_uid_setting("oc_definitely_absent_user"), None);
+    }
+
+    /// WHY: `nobody`/`nogroup` are the canonical daemon defaults. They exist on
+    /// most hosts but not all CI images, so resolve-or-skip rather than assert a
+    /// fixed id; when present, the resolved value must be a real numeric id.
+    #[test]
+    #[cfg(unix)]
+    fn parse_uid_setting_resolves_nobody_when_present() {
+        if let Some(uid) = parse_uid_setting("nobody") {
+            assert_eq!(parse_uid_setting(&uid.to_string()), Some(uid));
+        }
+        if let Ok(GidSetting::List(gids)) = parse_gid_setting("nogroup") {
+            assert_eq!(gids.len(), 1, "a single group name yields one gid");
+        }
+    }
+
+    /// WHY: a group name resolves the same as a numeric gid. `root`/`wheel` gid 0
+    /// exists on every POSIX host under one of those two names.
+    #[test]
+    #[cfg(unix)]
+    fn parse_gid_setting_resolves_group_name() {
+        let by_name = parse_gid_setting("root")
+            .or_else(|_| parse_gid_setting("wheel"))
+            .expect("gid 0 is named root or wheel on every POSIX host");
+        assert_eq!(by_name, GidSetting::List(vec![0]));
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
@@ -262,6 +262,32 @@ pub(crate) fn parse_numeric_identifier(value: &str) -> Option<u32> {
     trimmed.parse().ok()
 }
 
+/// Resolves an rsyncd.conf `uid` directive to a numeric uid.
+///
+/// Accepts either a numeric id or a username. An all-digits value parses
+/// directly as a numeric id; any other non-empty value is resolved through the
+/// local NSS database (`getpwnam`). Returns `None` for an empty value or a name
+/// that does not resolve, so the caller emits the same `invalid uid '<value>'`
+/// config error it already produced for a bad numeric id.
+///
+/// upstream: uidlist.c:144 `user_to_uid()` called with `num_ok = True`
+/// (clientserver.c:783) - a value made only of digits is `id_parse()`d, any
+/// other value goes through `getpwnam()`.
+pub(crate) fn parse_uid_setting(value: &str) -> Option<u32> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if trimmed.bytes().all(|byte| byte.is_ascii_digit()) {
+        return parse_numeric_identifier(trimmed);
+    }
+
+    metadata::id_lookup::lookup_user_by_name(trimmed.as_bytes())
+        .ok()
+        .flatten()
+}
+
 /// Parses a module `gid` directive into a [`GidSetting`].
 ///
 /// Accepts a whitespace- or comma-separated list of numeric gids. A leading
@@ -302,16 +328,26 @@ pub(crate) fn parse_gid_setting(value: &str) -> Result<GidSetting, String> {
     }
 }
 
-/// Parses a single gid token (numeric only).
+/// Parses a single gid token, accepting either a numeric id or a group name.
 ///
-/// upstream resolves group *names* via `group_to_gid`, but oc's daemon config
-/// path has always accepted numeric gids only; keeping that here avoids a
-/// behavioural regression. Name resolution remains available on the daemon's
-/// global `uid`/`gid` directives.
+/// An all-digits token parses directly as a numeric gid; any other token is
+/// resolved through the local NSS database (`getgrnam`). An unresolvable token
+/// is an error, matching the config value rejection upstream performs.
+///
+/// upstream: uidlist.c:170 `group_to_gid()` called with `num_ok = True`
+/// (clientserver.c:807 `add_a_group()`) - a digits-only token is `id_parse()`d,
+/// any other token goes through `getgrnam()`.
 fn parse_gid_token(token: &str) -> Result<u32, String> {
-    token
-        .parse::<u32>()
-        .map_err(|_| format!("'{token}' is not a numeric gid"))
+    if token.bytes().all(|byte| byte.is_ascii_digit()) {
+        return token
+            .parse::<u32>()
+            .map_err(|_| format!("'{token}' is not a valid gid"));
+    }
+
+    metadata::id_lookup::lookup_group_by_name(token.as_bytes())
+        .ok()
+        .flatten()
+        .ok_or_else(|| format!("'{token}' is not a valid group name or gid"))
 }
 
 /// Parses a timeout directive value in seconds.

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -465,7 +465,7 @@ fn apply_global_directive(
                     "'uid' directive must not be empty",
                 ));
             }
-            let uid = parse_numeric_identifier(value).ok_or_else(|| {
+            let uid = parse_uid_setting(value).ok_or_else(|| {
                 config_parse_error(path, line_number, format!("invalid uid '{value}'"))
             })?;
             state.module_defaults.uid = Some(uid);

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -167,7 +167,7 @@ fn apply_module_directive(
             }
         }
         "uid" => {
-            let uid = parse_numeric_identifier(value).ok_or_else(|| {
+            let uid = parse_uid_setting(value).ok_or_else(|| {
                 config_parse_error(path, line_number, format!("invalid uid '{value}'"))
             })?;
             builder.set_uid(uid, path, line_number)?;

--- a/crates/daemon/src/daemon/sections/module_parsing/module_spec.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/module_spec.rs
@@ -395,7 +395,7 @@ fn apply_inline_module_options(
                 module.refuse_options = options;
             }
             "uid" => {
-                let uid = parse_numeric_identifier(value)
+                let uid = parse_uid_setting(value)
                     .ok_or_else(|| config_error(format!("invalid uid '{value}'")))?;
                 module.uid = Some(uid);
             }


### PR DESCRIPTION
## The bug

`rsyncd.conf` `uid`/`gid` directives accepted only numeric ids. The canonical
default daemon config uses names:

```
uid = nobody
gid = nogroup
```

Running `oc-rsync --daemon --config=<that conf>` failed at config-parse time with:

```
oc-rsync error: failed to parse config '<path>': invalid uid 'nobody' (line N) (code 1)
```

and exited 1, while upstream `rsync --daemon` accepts the same config. This broke
the most common rsyncd.conf form.

## Upstream behavior (source of truth)

Upstream accepts either a numeric id or a name for `uid`/`gid`, resolving names via
`getpwnam`/`getgrnam`:

- `uidlist.c:144` `user_to_uid()` and `uidlist.c:170` `group_to_gid()`, both called
  with `num_ok = True` (`clientserver.c:783` / `clientserver.c:807`): a value made
  only of digits is parsed as a number, any other value is resolved as a name.

## The fix

- Add `parse_uid_setting()` and extend `parse_gid_token()` in the daemon config
  helpers: an all-digits value parses directly as a numeric id (unchanged); any
  other non-empty value is resolved through NSS.
- Name resolution reuses `metadata::id_lookup::lookup_user_by_name` /
  `lookup_group_by_name`, which already wrap the thread-safe `getpwnam_r`/
  `getgrnam_r` FFI. No unsafe is added to the daemon crate.
- An unresolvable name remains a config parse error (`invalid uid '<value>'`),
  never a silent default. Numeric parsing is byte-identical to before.

## Files changed

- `crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs` - new
  `parse_uid_setting`, name-aware `parse_gid_token`.
- `crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs`,
  `.../config_parsing/module_directives.rs`,
  `.../module_parsing/module_spec.rs` - the three `uid` directive call sites now
  use `parse_uid_setting`.
- `crates/daemon/src/daemon/sections/config_helpers/tests.rs` - tests for name and
  numeric forms, unresolvable-name rejection, and the canonical `nobody`/`nogroup`
  defaults (resolve-or-skip on CI images that lack the accounts).

## Tests

New unit tests (encode why the behavior matters):

- `parse_uid_setting_resolves_root_name_and_numeric` - `root` -> uid 0 and numeric
  ids both parse (deterministic on every POSIX host).
- `parse_gid_setting_resolves_group_name` - group `root`/`wheel` (gid 0) resolves.
- `parse_uid_setting_resolves_nobody_when_present` - canonical `nobody`/`nogroup`
  defaults, guarded for images where the account is absent.
- `parse_uid_setting_rejects_empty_and_unresolvable` and
  `parse_gid_setting_rejects_empty_and_unresolvable` - unresolvable names error.

## Verification (x86_64 Linux, rustc 1.88.0)

- `cargo fmt --all -- --check` - clean.
- `cargo clippy -p daemon -p metadata --all-features --all-targets --no-deps -- -D warnings` - clean.
- `cargo nextest run -p daemon -p metadata --all-features` - 2262 passed, 6 skipped.
- Real repro: `oc-rsync --daemon --config=<conf with uid=nobody gid=nobody>` now
  starts and enters the accept loop (no `invalid uid 'nobody'`); numeric ids still
  start; an unresolvable name (`uid = oc_absent_user_xyz`) still errors with
  `invalid uid '...'` and exit 1.
