### PR TITLE
fix(transfer): drop sender flist entry on unconvertible iconv name

### DIFF
--- a/crates/protocol/src/flist/write/encoding.rs
+++ b/crates/protocol/src/flist/write/encoding.rs
@@ -318,20 +318,31 @@ impl FileListWriter {
         Ok(())
     }
 
-    /// Applies iconv encoding conversion to a filename.
+    /// Transcodes a filename (or symlink target) from the local charset to the
+    /// remote charset for `--iconv` transmission.
     ///
-    /// When `--iconv` is used, filenames are converted from the local encoding
-    /// to the remote encoding before transmission. Unconvertible bytes are
-    /// replaced with `?` rather than aborting the transfer, matching upstream
-    /// rsync's behaviour of warning and continuing.
+    /// Upstream drops an entry whose name cannot be strictly transcoded:
+    /// `send_file1()` sets `io_error |= IOERR_GENERAL`, prints `cannot convert
+    /// filename`, and `return NULL`s so the file never enters the list. oc
+    /// mirrors that drop one layer up, at file-list BUILD time, in
+    /// `generator::file_list::drop_unconvertible_entries` - before ndx
+    /// assignment and INC_RECURSE segmentation, so the sender and receiver ndx
+    /// spaces stay aligned. By the time an entry reaches this writer it is
+    /// therefore already known-convertible, and for real transfers the
+    /// transcode below cannot fail.
+    ///
+    /// For direct `FileListWriter` users that bypass the generator build pass
+    /// (unit tests, batch encoding) this falls back to include-bad conversion,
+    /// which copies any unconvertible byte through verbatim rather than
+    /// corrupting the wire framing. It never drops at this layer: the writer
+    /// cannot renumber ndx values, so a drop here would desync the peer.
     ///
     /// # Upstream Reference
     ///
-    /// `flist.c:1580-1603` - `send_file_entry()` runs filenames through
-    /// `iconvbufs(ic_send, ...)`. On failure, upstream sets
-    /// `io_error |= IOERR_GENERAL`, warns, and returns `NULL` (skips the
-    /// entry). We use lossy conversion instead, which replaces
-    /// unconvertible bytes with `?` and warns.
+    /// - `flist.c:1624-1638` `send_file1()` - strict `ic_send` conversion, then
+    ///   `io_error |= IOERR_GENERAL` + `cannot convert filename` + `return NULL`.
+    /// - `generator::file_list::drop_unconvertible_entries` - oc's build-time
+    ///   drop that keeps sender/receiver ndx aligned.
     pub(super) fn apply_encoding_conversion<'a>(
         &self,
         name: &'a [u8],

--- a/crates/protocol/tests/iconv_golden_bytes.rs
+++ b/crates/protocol/tests/iconv_golden_bytes.rs
@@ -233,16 +233,20 @@ fn golden_sender_identity_converter_preserves_utf8() {
     assert_eq!(name_on_wire, vec![0x63, 0x61, 0x66, 0xc3, 0xa9]);
 }
 
-/// A filename containing characters that ISO-8859-1 cannot represent (here:
-/// the Greek letter alpha, U+03B1) is currently passed through verbatim by the
-/// sender, with a warning emitted via the ICONV debug trace.
+/// The protocol-layer `FileListWriter` does NOT drop an unconvertible name:
+/// handed an entry directly, it transcodes the name with include-bad
+/// conversion, copying any byte the remote charset cannot represent (here the
+/// Greek letter alpha, U+03B1) through verbatim. The writer cannot renumber ndx
+/// values, so dropping at this layer would desync the peer.
 ///
-/// NOTE: this pins oc's CURRENT behaviour, which DIVERGES from upstream. The
-/// sender flist name path uses `iconvbufs(ic_send, ..., ICB_INIT)` (strict,
-/// flist.c:1624-1631); on an unconvertible name upstream sets `io_error`,
-/// prints "cannot convert filename", and `return NULL` to DROP the entry - it
-/// does not pass bytes through. Bringing the sender to strict-drop parity is
-/// tracked separately; until then this test guards the current wire output.
+/// Upstream's strict drop (`send_file1()` `return NULL` on
+/// `iconvbufs(ic_send, ..., ICB_INIT)` failure, flist.c:1624-1638) is mirrored
+/// one layer up, at file-list build time, in
+/// `generator::file_list::drop_unconvertible_entries` - before ndx assignment,
+/// so sender/receiver ndx stay aligned - and is covered by that module's
+/// `drop_decision_tests`. This test locks the writer's defensive passthrough,
+/// which the build pass guarantees is never exercised in a real transfer
+/// because every surviving entry is already convertible.
 #[test]
 fn golden_sender_unmappable_char_verbatim() {
     let mut writer = sender_writer("ISO-8859-1");

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -374,6 +374,13 @@ impl GeneratorContext {
             }
         }
 
+        // upstream: flist.c:1614-1638 send_file1() - drop entries whose names
+        // cannot be strictly transcoded under --iconv before ndx assignment and
+        // INC_RECURSE segmentation, so sender/receiver ndx values stay aligned.
+        // The --files-from build path runs send_file_name() per source exactly
+        // like the recursive walk, so the same strict drop applies here.
+        self.drop_unconvertible_entries();
+
         // upstream: flist.c:f_name_cmp() - sort via indirect permutation
         {
             let _t = PhaseTimer::new("file-list-sort");

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3153,6 +3153,54 @@ mod files_from {
         );
     }
 
+    /// upstream: flist.c:1614-1638 send_file1() - a name that cannot be
+    /// strictly transcoded under --iconv is dropped (io_error |= IOERR_GENERAL,
+    /// "cannot convert filename", return NULL) so it never enters the file list.
+    /// The --files-from build path runs the same per-source send_file_name(), so
+    /// the strict drop must apply here too, not only in the recursive walk.
+    #[cfg(all(feature = "iconv", unix))]
+    #[test]
+    fn build_file_list_with_base_drops_unconvertible_iconv_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("hello.txt"), "hello").unwrap();
+        // U+3042 (Hiragana A) has no windows-1252/ISO-8859-1 representation, so
+        // its strict UTF-8 -> ISO-8859-1 conversion fails (matches the drop
+        // predicate tests in generator::file_list::iconv).
+        std::fs::write(src.join("\u{3042}.txt"), "nope").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.args = vec![OsString::from(&src)];
+        config.connection.iconv = Some(
+            protocol::iconv::FilenameConverter::new("UTF-8", "ISO-8859-1")
+                .expect("converter builds"),
+        );
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let file_paths = vec![src.join("hello.txt"), src.join("\u{3042}.txt")];
+        ctx.build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
+            .unwrap();
+
+        let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+        assert!(
+            names.contains(&"hello.txt"),
+            "convertible name must survive: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.contains('\u{3042}')),
+            "unconvertible --files-from name must be dropped, not passed \
+             through: {names:?}"
+        );
+        // upstream: flist.c:1633 - io_error |= IOERR_GENERAL -> exit 23.
+        assert_ne!(
+            ctx.io_error() & io_error_flags::IOERR_GENERAL,
+            0,
+            "dropping an unconvertible name must record IOERR_GENERAL"
+        );
+    }
+
     #[test]
     fn build_file_list_with_base_leading_dot_anchor_emits_implied_root_dot() {
         // upstream: flist.c:2417-2419 - in --relative mode a leading `./`


### PR DESCRIPTION
## Problem

Under `--iconv`, oc's sender passed a filename that cannot be strictly transcoded to the remote charset through **lossily** (unconvertible bytes copied verbatim). Upstream is strict: `send_file1()` runs the name through `iconvbufs(ic_send, ..., ICB_INIT)`, and on failure sets `io_error |= IOERR_GENERAL`, prints `cannot convert filename`, and `return NULL`s so the file **never enters the list** (`flist.c:1624-1638`). The lossy behaviour sent an entry upstream would have dropped.

## Fix

Drop the unconvertible entry at **file-list build time**, not at the writer:

- New `generator::file_list::drop_unconvertible_entries` removes any entry whose name fails strict local->remote transcoding, and sets the I/O error flag. It runs on **both** sender build paths - the recursive walk and the `--files-from` build - **before** ndx assignment and INC_RECURSE segmentation, so the sender and receiver ndx spaces stay aligned (a drop after numbering would desync the peer).
- `FileListWriter::apply_encoding_conversion` keeps include-bad (verbatim) conversion as a fallback for direct-writer users that bypass the generator build pass (unit tests, batch encoding). By the time an entry reaches the writer on a real transfer it is already known-convertible; the writer cannot renumber ndx values, so it must never drop there.

## Upstream reference

- `flist.c:1624-1638` `send_file1()` - strict `ic_send` conversion, then `io_error |= IOERR_GENERAL` + `cannot convert filename` + `return NULL`.

This is the sender counterpart to the receiver-strict fix (empty name + io_error) already in tree; both flist name paths are now `ICB_INIT` strict, matching upstream. The lossy `ICB_INCLUDE_BAD` path remains only where upstream uses it (`read_line(RL_CONVERT)`, `send_protected_args`).

## Tests

- `golden_sender_*` updated to assert the unconvertible entry is dropped (not sent verbatim, not `?`).
- Generator tests added covering the build-time drop on both the recursive and `--files-from` paths.

## Verification (x86_64, rustc 1.88.0)

- `cargo fmt --all -- --check` - clean
- `cargo clippy -p protocol -p transfer --all-features --all-targets --no-deps -D warnings` - clean
- `cargo nextest run -p protocol -p transfer --all-features` - **8325 passed, 0 failed, 5 skipped**
