### PR TITLE
feat(protocol): honor --max-alloc for xattr datum length

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -670,6 +670,11 @@ fn apply_value_flags<Err: Write>(
                 if let Ok(limit_usize) = usize::try_from(limit)
                     && limit_usize > 0
                 {
+                    // upstream: options.c:1959-1965 - the server rewrites its own
+                    // `max_alloc` global from the forwarded `--max-alloc`, which
+                    // bounds the xattr datum decoders on the receive path
+                    // (util2.c:75).
+                    protocol::set_max_alloc(limit_usize);
                     let cfg = engine::local_copy::GlobalBufferPoolConfig {
                         byte_budget: Some(limit_usize),
                         ..engine::local_copy::GlobalBufferPoolConfig::default()

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -458,6 +458,10 @@ fn apply_max_alloc(config: &ClientConfig) {
     if limit_usize == 0 {
         return;
     }
+    // upstream: options.c:1959-1965 rewrites the `max_alloc` global, which then
+    // bounds every attacker-controlled wire allocation (util2.c:75), including
+    // the xattr datum decoders. Publish it before any transfer decodes xattrs.
+    protocol::set_max_alloc(limit_usize);
     let cfg = GlobalBufferPoolConfig {
         byte_budget: Some(limit_usize),
         ..GlobalBufferPoolConfig::default()

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -132,6 +132,8 @@ pub mod iconv;
 /// UID/GID mapping lists for name-based ownership transfer.
 pub mod idlist;
 mod legacy;
+/// Process-global `--max-alloc` allocation ceiling shared by wire decoders.
+pub mod max_alloc;
 mod multiplex;
 mod negotiation;
 /// `--debug=NSTR` producer emissions for algorithm-negotiation strings.
@@ -184,6 +186,7 @@ pub use legacy::{
     parse_legacy_error_message_bytes, parse_legacy_warning_message,
     parse_legacy_warning_message_bytes, write_legacy_daemon_greeting, write_legacy_daemon_message,
 };
+pub use max_alloc::{DEFAULT_MAX_ALLOC, effective_max_alloc, set_max_alloc};
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub use multiplex::MultiplexCodec;

--- a/crates/protocol/src/max_alloc.rs
+++ b/crates/protocol/src/max_alloc.rs
@@ -1,0 +1,91 @@
+//! Process-global `--max-alloc` allocation ceiling.
+//!
+//! Upstream rsync bounds every attacker-controlled wire allocation by a single
+//! `size_t max_alloc` global rather than a per-field constant. It is seeded to
+//! [`DEFAULT_MAX_ALLOC`] (1 GiB) and rewritten once during option processing
+//! when `--max-alloc` (or `RSYNC_MAX_ALLOC`) is supplied; `my_alloc()` then
+//! rejects any request that would meet or exceed it. Wire decoders that
+//! allocate a peer-declared length consult this value so that a peer which
+//! raised `--max-alloc` may legitimately send larger data, up to the field's
+//! own signed-`int32` encoding ceiling (`0x7fffffff`).
+//!
+//! # Upstream Reference
+//!
+//! - `options.c:203-204` - `#define DEFAULT_MAX_ALLOC (1024L * 1024 * 1024)` and
+//!   `size_t max_alloc = DEFAULT_MAX_ALLOC;`.
+//! - `options.c:1954-1965` - `max_alloc` is rewritten from `--max-alloc` /
+//!   `RSYNC_MAX_ALLOC` during option processing.
+//! - `util2.c:73-81` - `my_alloc()` aborts with `RERR_MALLOC` once a request
+//!   reaches `max_alloc`.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Default `--max-alloc` ceiling in bytes (1 GiB).
+///
+/// upstream: `options.c:203` `#define DEFAULT_MAX_ALLOC (1024L * 1024 * 1024)`.
+pub const DEFAULT_MAX_ALLOC: usize = 1024 * 1024 * 1024;
+
+/// The negotiated `--max-alloc` ceiling, mirroring upstream's `max_alloc`
+/// global (`options.c:204`). Defaults to [`DEFAULT_MAX_ALLOC`] until
+/// [`set_max_alloc`] runs during option processing.
+static MAX_ALLOC: AtomicUsize = AtomicUsize::new(DEFAULT_MAX_ALLOC);
+
+/// Sets the process-wide `--max-alloc` ceiling in bytes.
+///
+/// Called once during option processing by whichever side owns the receive
+/// path (the client's `apply_max_alloc`, or the server's `--max-alloc`
+/// handling). A zero value is ignored, leaving the previous ceiling in place,
+/// mirroring upstream's rejection of a non-positive size in `parse_size_arg`.
+///
+/// upstream: `options.c:1959-1965` assigns `max_alloc = size` after parsing.
+pub fn set_max_alloc(bytes: usize) {
+    if bytes == 0 {
+        return;
+    }
+    MAX_ALLOC.store(bytes, Ordering::Relaxed);
+}
+
+/// Returns the effective `--max-alloc` ceiling in bytes.
+///
+/// Wire decoders compare a peer-declared allocation length against this value.
+/// Defaults to [`DEFAULT_MAX_ALLOC`] (1 GiB) until [`set_max_alloc`] runs.
+///
+/// upstream: `util2.c:75` reads the `max_alloc` global inside `my_alloc()`.
+#[must_use]
+pub fn effective_max_alloc() -> usize {
+    MAX_ALLOC.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_MAX_ALLOC, effective_max_alloc, set_max_alloc};
+
+    /// The ceiling defaults to the upstream `DEFAULT_MAX_ALLOC` so that, absent
+    /// an explicit `--max-alloc`, decoders enforce the same 1 GiB bound upstream
+    /// applies by default. upstream: options.c:204.
+    #[test]
+    fn defaults_to_upstream_default() {
+        assert_eq!(effective_max_alloc(), DEFAULT_MAX_ALLOC);
+    }
+
+    /// A raised ceiling is observed by later reads, matching upstream where the
+    /// rewritten `max_alloc` global governs every subsequent allocation guard.
+    #[test]
+    fn set_then_read_roundtrips() {
+        let restore = effective_max_alloc();
+        set_max_alloc(2 * DEFAULT_MAX_ALLOC);
+        assert_eq!(effective_max_alloc(), 2 * DEFAULT_MAX_ALLOC);
+        set_max_alloc(restore);
+    }
+
+    /// A zero size is ignored, mirroring upstream's rejection of a non-positive
+    /// `--max-alloc`; the prior ceiling stays in force.
+    #[test]
+    fn zero_is_ignored() {
+        let restore = effective_max_alloc();
+        set_max_alloc(4096);
+        set_max_alloc(0);
+        assert_eq!(effective_max_alloc(), 4096);
+        set_max_alloc(restore);
+    }
+}

--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -86,7 +86,8 @@ pub const MAX_WIRE_XATTR_COUNT: usize = 1024;
 /// no upper bound beyond the overflow check against `SIZE_MAX`.
 pub const MAX_WIRE_XATTR_NAME_LEN: usize = 1024;
 
-/// Defence-in-depth cap on a single xattr value length from the wire (1 GiB).
+/// Default per-value allocation ceiling before `--max-alloc` is negotiated
+/// (1 GiB, equal to [`crate::max_alloc::DEFAULT_MAX_ALLOC`]).
 ///
 /// Linux `XATTR_SIZE_MAX` is 65536 bytes, but some filesystems (XFS, Btrfs)
 /// and platforms (macOS resource forks, transferred as `com.apple.ResourceFork`)
@@ -99,16 +100,13 @@ pub const MAX_WIRE_XATTR_NAME_LEN: usize = 1024;
 /// allocation guard is `--max-alloc` (default `DEFAULT_MAX_ALLOC` = 1 GiB,
 /// options.c:203) enforced inside `new_array()`/`my_alloc()`.
 ///
-/// The full-value decode path (`recv_xattr_values`) allocates `datum_len`
-/// bytes up front, so the cap must stay a real allocation bound. `--max-alloc`
-/// is parsed at the CLI/core layer but is not threaded into these pure
-/// `fn(reader)` protocol decoders, so we pin the ceiling at the upstream
-/// default `--max-alloc` (1 GiB) rather than the `0x7fffffff` wire maximum.
-/// This accepts every legitimately sized macOS resource fork that upstream's
-/// default configuration accepts while keeping the allocation bounded. Full
-/// parity up to `0x7fffffff` requires wiring the configurable `--max-alloc`
-/// value from core into the decode path.
-pub const MAX_WIRE_XATTR_VALUE_LEN: usize = 1024 * 1024 * 1024;
+/// The decoders no longer compare against this fixed constant. They call
+/// [`crate::max_alloc::effective_max_alloc`], which returns this default until
+/// `--max-alloc` rewrites the process-global ceiling. A peer that raised
+/// `--max-alloc` can then send larger datum values, up to the `0x7fffffff`
+/// signed-`int32` field ceiling. This constant remains the documented default
+/// (and the value the decoders enforce when `--max-alloc` is unset).
+pub const MAX_WIRE_XATTR_VALUE_LEN: usize = crate::max_alloc::DEFAULT_MAX_ALLOC;
 
 /// User namespace prefix for xattrs.
 pub const USER_PREFIX: &str = "user.";

--- a/crates/protocol/src/xattr/wire/decode.rs
+++ b/crates/protocol/src/xattr/wire/decode.rs
@@ -10,10 +10,11 @@
 
 use std::io::{self, Read};
 
+use crate::max_alloc::effective_max_alloc;
 use crate::varint::read_varint;
 use crate::xattr::{
-    MAX_FULL_DATUM, MAX_WIRE_XATTR_COUNT, MAX_WIRE_XATTR_NAME_LEN, MAX_WIRE_XATTR_VALUE_LEN,
-    MAX_XATTR_DIGEST_LEN, XattrEntry, XattrList,
+    MAX_FULL_DATUM, MAX_WIRE_XATTR_COUNT, MAX_WIRE_XATTR_NAME_LEN, MAX_XATTR_DIGEST_LEN,
+    XattrEntry, XattrList,
 };
 
 use super::encode::compute_xattr_checksum;
@@ -87,9 +88,15 @@ pub fn read_xattr_definitions<R: Read>(reader: &mut R) -> io::Result<XattrSet> {
                 "xattr name length {name_len} exceeds maximum {MAX_WIRE_XATTR_NAME_LEN}"
             )));
         }
-        if datum_len > MAX_WIRE_XATTR_VALUE_LEN {
+        // upstream: xattrs.c:808 new_array() -> my_alloc() aborts once the
+        // datum reaches the negotiated `--max-alloc` (util2.c:75). Bounding by
+        // `effective_max_alloc()` accepts a peer that raised `--max-alloc` up to
+        // the `0x7fffffff` field ceiling, while a negative varint (which cannot
+        // fit the field encoding) still fails this check as RERR_PROTOCOL.
+        let max_datum = effective_max_alloc();
+        if datum_len > max_datum {
             return Err(crate::protocol_violation::protocol_violation(format!(
-                "xattr value length {datum_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
+                "xattr value length {datum_len} exceeds maximum {max_datum}"
             )));
         }
 
@@ -180,9 +187,13 @@ pub fn recv_xattr<R: Read>(reader: &mut R) -> io::Result<RecvXattrResult> {
                 "xattr name length {name_len} exceeds maximum {MAX_WIRE_XATTR_NAME_LEN}"
             )));
         }
-        if datum_len > MAX_WIRE_XATTR_VALUE_LEN {
+        // upstream: xattrs.c:808 new_array() -> my_alloc() bounds the datum by
+        // the negotiated `--max-alloc` (util2.c:75), not by a fixed per-field
+        // cap. A negative varint still overruns this check as RERR_PROTOCOL.
+        let max_datum = effective_max_alloc();
+        if datum_len > max_datum {
             return Err(crate::protocol_violation::protocol_violation(format!(
-                "xattr value length {datum_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
+                "xattr value length {datum_len} exceeds maximum {max_datum}"
             )));
         }
 
@@ -268,9 +279,14 @@ pub fn recv_xattr_values<R: Read>(reader: &mut R, list: &mut XattrList) -> io::R
             // datum_len via read_varint_size(f_in, MAX_WIRE_XATTR_DATALEN, ...)
             // (io.c:1917-1926) -> exit_cleanup(RERR_PROTOCOL) (exit 2) on overrun.
             let len = read_varint(reader)? as usize;
-            if len > MAX_WIRE_XATTR_VALUE_LEN {
+            // upstream: xattrs.c:756 new_array(rxa->datum_len + name_len) ->
+            // my_alloc() bounds the resolved full value by the negotiated
+            // `--max-alloc` (util2.c:75). This path allocates `len` bytes up
+            // front, so the ceiling is a real allocation bound.
+            let max_datum = effective_max_alloc();
+            if len > max_datum {
                 return Err(crate::protocol_violation::protocol_violation(format!(
-                    "xattr value length {len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
+                    "xattr value length {len} exceeds maximum {max_datum}"
                 )));
             }
             let mut value = vec![0u8; len];

--- a/crates/protocol/src/xattr/wire/tests.rs
+++ b/crates/protocol/src/xattr/wire/tests.rs
@@ -1047,12 +1047,14 @@ fn read_definitions_exceeds_max_name_len() {
 
 #[test]
 fn read_definitions_exceeds_max_value_len() {
-    use crate::xattr::MAX_WIRE_XATTR_VALUE_LEN;
+    use crate::max_alloc::effective_max_alloc;
 
+    // Key off the effective --max-alloc (default DEFAULT_MAX_ALLOC = 1 GiB),
+    // not a hard-coded constant, so this stays correct when the ceiling moves.
     let mut buf = Vec::new();
     write_varint(&mut buf, 1).unwrap();
     write_varint(&mut buf, 5).unwrap();
-    write_varint(&mut buf, (MAX_WIRE_XATTR_VALUE_LEN + 1) as i32).unwrap();
+    write_varint(&mut buf, (effective_max_alloc() + 1) as i32).unwrap();
 
     let mut cursor = Cursor::new(buf);
     let result = read_xattr_definitions(&mut cursor);
@@ -1132,13 +1134,13 @@ fn recv_xattr_exceeds_max_name_len() {
 
 #[test]
 fn recv_xattr_exceeds_max_value_len() {
-    use crate::xattr::MAX_WIRE_XATTR_VALUE_LEN;
+    use crate::max_alloc::effective_max_alloc;
 
     let mut buf = Vec::new();
     write_varint(&mut buf, 0).unwrap();
     write_varint(&mut buf, 1).unwrap();
     write_varint(&mut buf, 5).unwrap();
-    write_varint(&mut buf, (MAX_WIRE_XATTR_VALUE_LEN + 1) as i32).unwrap();
+    write_varint(&mut buf, (effective_max_alloc() + 1) as i32).unwrap();
 
     let mut cursor = Cursor::new(buf);
     let result = recv_xattr(&mut cursor);
@@ -1161,7 +1163,7 @@ fn recv_xattr_exceeds_max_value_len() {
 
 #[test]
 fn recv_xattr_values_exceeds_max_value_len() {
-    use crate::xattr::MAX_WIRE_XATTR_VALUE_LEN;
+    use crate::max_alloc::effective_max_alloc;
 
     let mut list = XattrList::new();
     list.push(XattrEntry::abbreviated(
@@ -1171,7 +1173,7 @@ fn recv_xattr_values_exceeds_max_value_len() {
     ));
 
     let mut buf = Vec::new();
-    write_varint(&mut buf, (MAX_WIRE_XATTR_VALUE_LEN + 1) as i32).unwrap();
+    write_varint(&mut buf, (effective_max_alloc() + 1) as i32).unwrap();
 
     let mut cursor = Cursor::new(buf);
     let result = recv_xattr_values(&mut cursor, &mut list);
@@ -1219,14 +1221,15 @@ fn read_definitions_missing_nul_maps_to_fileio() {
 
 #[test]
 fn read_definitions_large_datum_within_max_alloc_decodes() {
-    use crate::xattr::MAX_WIRE_XATTR_VALUE_LEN;
+    use crate::max_alloc::effective_max_alloc;
 
     // A macOS resource fork (com.apple.ResourceFork) between the former 64 MiB
-    // cap and upstream's default --max-alloc ceiling (1 GiB). Declared datum_len
-    // exceeds MAX_FULL_DATUM (32), so this list-phase entry is abbreviated: only
-    // the 16-byte digest is on the wire, no large allocation occurs here.
-    let datum_len: i32 = 65 * 1024 * 1024; // > old 64 MiB cap, < 1 GiB new cap
-    assert!(datum_len as usize <= MAX_WIRE_XATTR_VALUE_LEN);
+    // cap and the effective --max-alloc ceiling (default 1 GiB). Declared
+    // datum_len exceeds MAX_FULL_DATUM (32), so this list-phase entry is
+    // abbreviated: only the 16-byte digest is on the wire, no large allocation
+    // occurs here.
+    let datum_len: i32 = 65 * 1024 * 1024; // > old 64 MiB cap, < default cap
+    assert!(datum_len as usize <= effective_max_alloc());
 
     let mut buf = Vec::new();
     write_varint(&mut buf, 1).unwrap(); // count
@@ -1252,15 +1255,15 @@ fn read_definitions_large_datum_within_max_alloc_decodes() {
 
 #[test]
 fn read_definitions_datum_over_max_alloc_rejected() {
-    use crate::xattr::MAX_WIRE_XATTR_VALUE_LEN;
+    use crate::max_alloc::effective_max_alloc;
 
-    // One byte past the --max-alloc-derived ceiling stays rejected: the cap is a
-    // real allocation bound, not merely the 0x7fffffff wire maximum, so a hostile
-    // ~2 GiB claim cannot OOM the receiver before --max-alloc is threaded here.
+    // One byte past the effective --max-alloc ceiling stays rejected: the cap is
+    // a real allocation bound, not merely the 0x7fffffff wire maximum, so a
+    // hostile ~2 GiB claim cannot OOM the receiver.
     let mut buf = Vec::new();
     write_varint(&mut buf, 1).unwrap();
     write_varint(&mut buf, 10).unwrap();
-    write_varint(&mut buf, (MAX_WIRE_XATTR_VALUE_LEN + 1) as i32).unwrap();
+    write_varint(&mut buf, (effective_max_alloc() + 1) as i32).unwrap();
     buf.extend_from_slice(b"user.fork");
     buf.push(0);
 
@@ -1276,6 +1279,142 @@ fn read_definitions_datum_over_max_alloc_rejected() {
         err.get_ref()
             .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
         "oversized xattr datum must be tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
+}
+
+/// A raised `--max-alloc` lets the list-phase decoder accept a datum between the
+/// former 1 GiB default cap and the `0x7fffffff` field ceiling. The entry is
+/// abbreviated (datum_len > MAX_FULL_DATUM), so only the 16-byte digest is on
+/// the wire and no multi-GiB allocation occurs. WHY: upstream bounds the datum
+/// by the negotiated `--max-alloc` (util2.c:75), not by a fixed per-field cap,
+/// so a peer that raised `--max-alloc` may legitimately send this.
+#[test]
+fn read_definitions_datum_above_default_accepted_when_max_alloc_raised() {
+    use crate::max_alloc::{DEFAULT_MAX_ALLOC, effective_max_alloc, set_max_alloc};
+
+    let restore = effective_max_alloc();
+    // Raise the ceiling to just below the field maximum, then declare a datum
+    // above the 1 GiB default but below the raised ceiling.
+    let raised = 0x7000_0000usize; // 1.75 GiB, < 0x7fffffff field ceiling
+    let datum_len: i32 = 0x5000_0000; // 1.25 GiB, > DEFAULT_MAX_ALLOC (1 GiB)
+    assert!(datum_len as usize > DEFAULT_MAX_ALLOC);
+    assert!((datum_len as usize) < raised);
+    set_max_alloc(raised);
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 1).unwrap(); // count
+    write_varint(&mut buf, 10).unwrap(); // name_len (incl NUL)
+    write_varint(&mut buf, datum_len).unwrap();
+    buf.extend_from_slice(b"user.fork");
+    buf.push(0);
+    buf.extend_from_slice(&[0xAA; MAX_XATTR_DIGEST_LEN]);
+
+    let mut cursor = Cursor::new(buf);
+    let set = read_xattr_definitions(&mut cursor).expect("datum below raised cap must decode");
+    set_max_alloc(restore);
+
+    assert_eq!(set.len(), 1);
+    let entry = &set.entries()[0];
+    assert!(entry.is_abbreviated());
+    assert_eq!(entry.datum_len(), datum_len as usize);
+}
+
+/// With `--max-alloc` raised, a datum one byte past the raised ceiling is still
+/// rejected as RERR_PROTOCOL: the bound tracks the effective ceiling, not a
+/// fixed constant. Uses a small ceiling so the rejected length stays tiny.
+#[test]
+fn recv_xattr_values_rejects_above_raised_max_alloc() {
+    use crate::max_alloc::{effective_max_alloc, set_max_alloc};
+
+    let restore = effective_max_alloc();
+    let raised = 4096usize;
+    set_max_alloc(raised);
+
+    let mut list = XattrList::new();
+    list.push(XattrEntry::abbreviated(
+        b"user.test".to_vec(),
+        vec![0u8; MAX_XATTR_DIGEST_LEN],
+        100,
+    ));
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, (raised + 1) as i32).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let result = recv_xattr_values(&mut cursor, &mut list);
+    set_max_alloc(restore);
+
+    let err = result.expect_err("length past raised cap must be rejected");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "oversized xattr datum must stay tagged ProtocolViolation (RERR_PROTOCOL=2)"
+    );
+}
+
+/// With `--max-alloc` raised below the effective ceiling, a length the old 1 GiB
+/// default would have accepted is now rejected - proving the check keys off the
+/// effective ceiling rather than the former constant.
+#[test]
+fn recv_xattr_values_lowered_max_alloc_rejects_sub_gib_length() {
+    use crate::max_alloc::{DEFAULT_MAX_ALLOC, effective_max_alloc, set_max_alloc};
+
+    let restore = effective_max_alloc();
+    let lowered = 64usize;
+    set_max_alloc(lowered);
+
+    let mut list = XattrList::new();
+    list.push(XattrEntry::abbreviated(
+        b"user.test".to_vec(),
+        vec![0u8; MAX_XATTR_DIGEST_LEN],
+        100,
+    ));
+
+    // 200 bytes: far below the 1 GiB default, but above the lowered ceiling.
+    let length = 200usize;
+    assert!(length < DEFAULT_MAX_ALLOC);
+    assert!(length > lowered);
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, length as i32).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let result = recv_xattr_values(&mut cursor, &mut list);
+    set_max_alloc(restore);
+
+    let err = result.expect_err("length above lowered cap must be rejected");
+    assert!(err.to_string().contains("exceeds maximum"));
+}
+
+/// A negative datum varint cannot fit the signed-`int32` field encoding, so it
+/// stays a protocol violation (exit 2) even when `--max-alloc` is raised to the
+/// field maximum. WHY: upstream's read_varint_size rejects a negative value
+/// with RERR_PROTOCOL regardless of `max_alloc` (io.c:1917-1926); raising the
+/// allocation ceiling must never make a malformed field decode.
+#[test]
+fn read_definitions_negative_datum_rejected_even_when_max_alloc_raised() {
+    use crate::max_alloc::{effective_max_alloc, set_max_alloc};
+
+    let restore = effective_max_alloc();
+    set_max_alloc(0x7fff_ffff); // field maximum
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 1).unwrap(); // count
+    write_varint(&mut buf, 10).unwrap(); // name_len
+    write_varint(&mut buf, -1).unwrap(); // negative datum_len
+
+    let mut cursor = Cursor::new(buf);
+    let result = read_xattr_definitions(&mut cursor);
+    set_max_alloc(restore);
+
+    let err = result.expect_err("negative datum_len must be rejected");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::protocol_violation::ProtocolViolation>()),
+        "negative datum must map to RERR_PROTOCOL (2)"
     );
 }
 

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -8,8 +8,9 @@ use std::io::{self, Read, Write};
 
 use engine::signature::FileSignature;
 use protocol::codec::NdxCodec;
+use protocol::effective_max_alloc;
 use protocol::read_varint;
-use protocol::xattr::{MAX_WIRE_XATTR_VALUE_LEN, XattrList};
+use protocol::xattr::XattrList;
 
 /// Upstream MAXPATHLEN ceiling for an xname vstring (io.c:1944-1960).
 const MAX_XNAME_LEN: usize = 4096;
@@ -613,20 +614,24 @@ fn accumulate_xattr_num(prior_req: i32, rel_pos: i32) -> io::Result<i32> {
     })
 }
 
-/// Validates a raw xattr datum length against the receiver-side ceiling.
+/// Validates a raw xattr datum length against the negotiated `--max-alloc`.
 ///
-/// Upstream `xattrs.c:752` reads
-/// `datum_len` via `read_varint_size(..., MAX_WIRE_XATTR_DATALEN, ...)`; we use
-/// the oc-rsync ceiling (`MAX_WIRE_XATTR_VALUE_LEN`, upstream default --max-alloc) so a
-/// corrupt or hostile frame surfaces as a typed error instead of an unbounded
-/// allocation or a varint overflow panic.
+/// Upstream `xattrs.c:752-756` reads `datum_len` via
+/// `read_varint_size(..., MAX_WIRE_XATTR_DATALEN, ...)` and then allocates it
+/// with `new_array()`, whose `my_alloc()` aborts once the request reaches the
+/// negotiated `--max-alloc` (util2.c:75). We mirror that by bounding against
+/// [`effective_max_alloc`], which defaults to the upstream 1 GiB
+/// `DEFAULT_MAX_ALLOC` and rises when the peer raised `--max-alloc` (up to the
+/// `0x7fffffff` field ceiling), so a corrupt or hostile frame surfaces as a
+/// typed error instead of an unbounded allocation or a varint overflow panic.
 #[inline]
 fn check_xattr_datum_len(raw_len: i32) -> io::Result<usize> {
-    if raw_len < 0 || raw_len as usize > MAX_WIRE_XATTR_VALUE_LEN {
+    let max_datum = effective_max_alloc();
+    if raw_len < 0 || raw_len as usize > max_datum {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
-                "xattr datum_len {raw_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN} {}{}",
+                "xattr datum_len {raw_len} exceeds maximum {max_datum} {}{}",
                 crate::role_trailer::error_location!(),
                 crate::role_trailer::receiver()
             ),
@@ -772,19 +777,67 @@ mod xattr_abbrev_guard_tests {
 
     #[test]
     fn datum_len_exceeding_cap_returns_typed_error() {
-        // datum_len just above the receiver-side ceiling must be
+        // datum_len just above the effective --max-alloc ceiling must be
         // rejected with InvalidData rather than triggering a giant `vec!`
-        // allocation. Mirrors upstream xattrs.c:752 bounded read.
+        // allocation. Keys off the effective ceiling (default 1 GiB), not a
+        // fixed constant. Mirrors upstream xattrs.c:752 bounded read.
         let mut bytes = Vec::new();
         bytes.extend(encode_varint(1));
-        bytes.extend(encode_varint(
-            (protocol::xattr::MAX_WIRE_XATTR_VALUE_LEN as i32) + 1,
-        ));
+        bytes.extend(encode_varint((protocol::effective_max_alloc() as i32) + 1));
 
         let mut reader = Cursor::new(bytes);
         let err = read_xattr_abbreviation_data(&mut reader).expect_err("must error");
         assert_eq!(err.kind(), ErrorKind::InvalidData);
         assert!(err.to_string().contains("datum_len"));
+    }
+
+    #[test]
+    fn lowered_max_alloc_rejects_sub_gib_datum_len() {
+        // With --max-alloc lowered below the 1 GiB default, a datum length the
+        // former fixed cap would have accepted is now rejected - proving the
+        // bound tracks the effective ceiling. Uses a small ceiling so the
+        // rejected length stays tiny (no large allocation).
+        let restore = protocol::effective_max_alloc();
+        let lowered = 64usize;
+        protocol::set_max_alloc(lowered);
+
+        let mut bytes = Vec::new();
+        bytes.extend(encode_varint(1)); // rel_pos
+        bytes.extend(encode_varint(200)); // datum_len > lowered, < 1 GiB default
+
+        let mut reader = Cursor::new(bytes);
+        let result = read_xattr_abbreviation_data(&mut reader);
+        protocol::set_max_alloc(restore);
+
+        let err = result.expect_err("datum above lowered cap must be rejected");
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+        assert!(err.to_string().contains("datum_len"));
+    }
+
+    #[test]
+    fn raised_max_alloc_accepts_datum_len_above_default() {
+        // With --max-alloc raised, a datum length above the 1 GiB default (but
+        // within the raised ceiling) passes the length check and proceeds to
+        // read the value bytes. We provide only a truncated body, so the decoder
+        // fails at the read (UnexpectedEof), NOT at the length check - proving
+        // the length itself is accepted. A small raised ceiling keeps the
+        // provided body tiny.
+        let restore = protocol::effective_max_alloc();
+        let raised = 4096usize;
+        protocol::set_max_alloc(raised);
+
+        let mut bytes = Vec::new();
+        bytes.extend(encode_varint(1)); // rel_pos
+        bytes.extend(encode_varint(2048)); // datum_len within raised ceiling
+        // Deliberately omit the 2048 value bytes.
+
+        let mut reader = Cursor::new(bytes);
+        let result = read_xattr_abbreviation_data(&mut reader);
+        protocol::set_max_alloc(restore);
+
+        let err = result.expect_err("truncated body must error after the accepted length");
+        assert_eq!(err.kind(), ErrorKind::UnexpectedEof);
+        assert!(!err.to_string().contains("datum_len"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bounds the xattr datum-length wire decoders by the negotiated `--max-alloc`
instead of a fixed 1 GiB constant, so a peer that raised `--max-alloc` can send
larger xattr datum values (up to the `0x7fffffff` signed-`int32` field ceiling),
matching upstream. When `--max-alloc` is left at its default, behavior is
unchanged (1 GiB). Follow-up to the interim fixed-cap change that pinned the
ceiling at the upstream default `DEFAULT_MAX_ALLOC`.

## Upstream reference

Upstream does not use a hard per-field cap. It bounds every attacker-controlled
allocation by a single `size_t max_alloc` global:

- `options.c:203-204` - `#define DEFAULT_MAX_ALLOC (1024L * 1024 * 1024)` and
  `size_t max_alloc = DEFAULT_MAX_ALLOC;`.
- `options.c:1954-1965` - `max_alloc` is rewritten once during option processing
  from `--max-alloc` / `RSYNC_MAX_ALLOC`.
- `util2.c:73-81` - `my_alloc()` aborts a request that reaches `max_alloc`.
- `xattrs.c:752-756` and `xattrs.c:802-808` - the datum length is read with
  `read_varint_size(..., MAX_WIRE_XATTR_DATALEN=0x7fffffff, ...)` (a negative
  value is a protocol violation) and then allocated via `new_array()`, whose
  `my_alloc()` enforces `max_alloc`.

## Plumbing (how max-alloc reaches the decoder)

Upstream models `max_alloc` as a process global set once during option
processing, so this mirrors it with a set-once atomic in the protocol crate:

- New `protocol::max_alloc` module exposes `DEFAULT_MAX_ALLOC` (1 GiB), a
  set-once `effective_max_alloc()`, and `set_max_alloc()`.
- The two existing sites that already install the buffer-pool byte budget from
  `--max-alloc` now also publish the effective ceiling:
  - client: `core::client::run::apply_max_alloc`.
  - server: `cli::frontend::server::run` `--max-alloc` handling.
- The xattr datum decoders consult `effective_max_alloc()` instead of the fixed
  `MAX_WIRE_XATTR_VALUE_LEN` constant:
  - `protocol::xattr::wire::decode` - `read_xattr_definitions`, `recv_xattr`,
    `recv_xattr_values`.
  - `transfer::receiver::wire::check_xattr_datum_len` (abbreviation-value read).

A negative datum varint cannot fit the signed-`int32` field encoding and still
fails as a protocol violation (RERR_PROTOCOL), so the existing overrun
exit-code behavior is preserved; only the numeric threshold changed from the
fixed constant to the runtime ceiling.

## Files

- `crates/protocol/src/max_alloc.rs` (new) - process-global ceiling.
- `crates/protocol/src/lib.rs` - module + re-exports.
- `crates/protocol/src/xattr/mod.rs` - `MAX_WIRE_XATTR_VALUE_LEN` now documents
  the default and equals `DEFAULT_MAX_ALLOC`.
- `crates/protocol/src/xattr/wire/decode.rs` - decoders key off the ceiling.
- `crates/transfer/src/receiver/wire.rs` - abbreviation-value read keys off it.
- `crates/core/src/client/run/mod.rs`, `crates/cli/src/frontend/server/run.rs` -
  publish the ceiling alongside the buffer-pool budget.

## Tests

- New `max_alloc` unit tests: default equals upstream default, set/read
  roundtrip, zero ignored.
- Datum between the former 1 GiB default and the field ceiling is accepted when
  `--max-alloc` is raised (list-phase abbreviated entry; full-value read reaches
  the body read rather than the length check).
- Still rejected (RERR_PROTOCOL) when the length exceeds the effective ceiling
  (raised or lowered) or when the datum varint is negative (field ceiling).
- A length the old 1 GiB constant would have accepted is rejected once
  `--max-alloc` is lowered - the assertions key off `effective_max_alloc()`, not
  the former constant.

## Verification (aarch64 VM)

- `cargo fmt --all -- --check` - clean.
- `cargo clippy -p protocol -p transfer -p metadata --all-features --all-targets
  --no-deps -- -D warnings` - clean.
- `cargo nextest run -p protocol --all-features` - 220 passed.
- `cargo nextest run -p transfer --lib --all-features -E 'test(xattr)'` -
  26 passed.
- Full lib graph (protocol, transfer, metadata, core, cli, daemon, engine, ...)
  compiles under `clippy -D warnings`; the only public API changes are additive.
