### PR TITLE
fix(transfer): count created files/dirs for new non-transferring items in --stats

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -483,11 +483,8 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
     let files_total = summary.regular_files_total();
     let directories = summary.directories_created();
     let directories_total = summary.directories_total();
-    let symlinks = summary.symlinks_copied();
     let symlinks_total = summary.symlinks_total();
-    let devices = summary.devices_created();
     let devices_total = summary.devices_total();
-    let fifos = summary.fifos_created();
     let fifos_total = summary.fifos_total();
     let deleted = summary.items_deleted();
     // upstream: main.c output_itemized_counts("Number of deleted files", ...)
@@ -513,15 +510,26 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
     let file_list_transfer = summary.file_list_transfer_time().as_secs_f64();
 
     let special_total = devices_total.saturating_add(fifos_total);
-    let special_created = devices.saturating_add(fifos);
     let total_entries = files_total
         .saturating_add(directories_total)
         .saturating_add(symlinks_total)
         .saturating_add(special_total);
-    let created_total = files
+
+    // upstream: receiver.c:733-746 / sender.c:295-308 - "Number of created
+    // files" counts ITEM_IS_NEW entries per type (new dirs, symlinks, devices,
+    // specials and empty files included), NOT the "copied/updated" tallies. An
+    // in-place update of a pre-existing file/symlink is transferred but never
+    // ITEM_IS_NEW, so it must not inflate the created counts. `created_dirs`
+    // uses `directories_created`, already new-only (mkdir + synthesized root).
+    let created_reg = summary.created_regular_files();
+    let created_symlinks = summary.created_symlinks();
+    let created_devices = summary.created_devices();
+    let created_specials = summary.created_specials();
+    let created_total = created_reg
         .saturating_add(directories)
-        .saturating_add(symlinks)
-        .saturating_add(special_created);
+        .saturating_add(created_symlinks)
+        .saturating_add(created_devices)
+        .saturating_add(created_specials);
 
     let files_breakdown = format_stat_categories(&[
         ("reg", files_total),
@@ -529,11 +537,14 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
         ("link", symlinks_total),
         ("special", special_total),
     ]);
+    // upstream: main.c output_itemized_counts labels the created breakdown
+    // reg/dir/link/dev/special, with devices ('dev') split from other specials.
     let created_breakdown = format_stat_categories(&[
-        ("reg", files),
+        ("reg", created_reg),
         ("dir", directories),
-        ("link", symlinks),
-        ("special", special_created),
+        ("link", created_symlinks),
+        ("dev", created_devices),
+        ("special", created_specials),
     ]);
 
     let total_size_display = format_size(total_size, human_readable);

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -226,6 +226,45 @@ impl ClientSummary {
         self.stats.fifos_total()
     }
 
+    /// Returns the number of newly created regular files (destination absent
+    /// before the transfer), for the `--stats` "Number of created files"
+    /// `reg:` sub-count. Distinct from [`Self::files_copied`], which also
+    /// counts in-place updates.
+    ///
+    /// upstream: receiver.c:733-746 / sender.c:295-308 - the reg portion of
+    /// `stats.created_files`.
+    #[must_use]
+    pub const fn created_regular_files(&self) -> u64 {
+        self.stats.created_regular_files()
+    }
+
+    /// Returns the number of newly created symbolic links for the `link:`
+    /// sub-count of "Number of created files".
+    ///
+    /// upstream: receiver.c:740-741 `stats.created_symlinks++`.
+    #[must_use]
+    pub const fn created_symlinks(&self) -> u64 {
+        self.stats.created_symlinks()
+    }
+
+    /// Returns the number of newly created device nodes for the `dev:`
+    /// sub-count of "Number of created files".
+    ///
+    /// upstream: receiver.c:743-744 `stats.created_devices++`.
+    #[must_use]
+    pub const fn created_devices(&self) -> u64 {
+        self.stats.created_devices()
+    }
+
+    /// Returns the number of newly created special files (FIFOs, sockets) for
+    /// the `special:` sub-count of "Number of created files".
+    ///
+    /// upstream: receiver.c:745-746 `stats.created_specials++`.
+    #[must_use]
+    pub const fn created_specials(&self) -> u64 {
+        self.stats.created_specials()
+    }
+
     /// Returns the number of extraneous entries removed due to `--delete`.
     #[must_use]
     pub const fn items_deleted(&self) -> u64 {

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -511,6 +511,25 @@ impl<'a> CopyContext<'a> {
     }
 
     pub(super) fn record(&mut self, record: LocalCopyRecord) {
+        // upstream: receiver.c:733-746 / sender.c:295-308 - every ITEM_IS_NEW
+        // entry bumps `stats.created_*` for its type, whether or not file data
+        // moved. `was_created()` is the ITEM_IS_NEW mirror; classify by action
+        // to hit the right per-type counter. Directories are counted separately
+        // via `record_directory`/`mark_destination_root_created` (which also
+        // covers the synthesized root that has no record here), so they are
+        // skipped. Runs for both real and dry-run records, matching upstream's
+        // dry-run `--stats` accounting.
+        if record.was_created() {
+            match record.action() {
+                LocalCopyAction::DataCopied | LocalCopyAction::HardLink => {
+                    self.summary.record_created_regular_file();
+                }
+                LocalCopyAction::SymlinkCopied => self.summary.record_created_symlink(),
+                LocalCopyAction::DeviceCopied => self.summary.record_created_device(),
+                LocalCopyAction::FifoCopied => self.summary.record_created_special(),
+                _ => {}
+            }
+        }
         if let Some(observer) = &mut self.observer {
             observer.handle(record.clone());
         }

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -97,6 +97,18 @@ pub struct LocalCopySummary {
     hard_links_created: u64,
     devices_created: u64,
     fifos_created: u64,
+    // Per-type counts of entries whose destination did NOT previously exist,
+    // mirroring upstream's `stats.created_{files,symlinks,devices,specials}`
+    // accounting (receiver.c:733-746 / sender.c:295-308): every ITEM_IS_NEW
+    // entry bumps the created counter for its type, whether or not it moved
+    // file data. Kept distinct from the "copied" tallies above, which also
+    // count in-place updates of pre-existing files/symlinks/nodes. `created_dirs`
+    // reuses `directories_created`, which is already new-only (a mkdir plus the
+    // synthesized destination root).
+    created_regular_files: u64,
+    created_symlinks: u64,
+    created_devices: u64,
+    created_specials: u64,
     items_deleted: u64,
     // Per-type deletion counts, mirroring upstream's `stats.deleted_*` fields
     // (main.c write_del_stats/read_del_stats). `items_deleted` is the total;
@@ -212,6 +224,46 @@ impl LocalCopySummary {
     #[must_use]
     pub const fn fifos_created(&self) -> u64 {
         self.fifos_created
+    }
+
+    /// Returns the number of newly created regular files (destination absent
+    /// before the transfer). Distinct from [`Self::files_copied`], which also
+    /// counts in-place updates of pre-existing files.
+    ///
+    /// upstream: receiver.c:733-746 / sender.c:295-308 - the reg portion of
+    /// `stats.created_files`, reported by `--stats` as
+    /// `Number of created files: N (reg: X, ...)`.
+    #[must_use]
+    pub const fn created_regular_files(&self) -> u64 {
+        self.created_regular_files
+    }
+
+    /// Returns the number of newly created symbolic links (destination absent
+    /// before the transfer). Distinct from [`Self::symlinks_copied`], which
+    /// also counts re-pointed pre-existing links.
+    ///
+    /// upstream: receiver.c:740-741 `stats.created_symlinks++`.
+    #[must_use]
+    pub const fn created_symlinks(&self) -> u64 {
+        self.created_symlinks
+    }
+
+    /// Returns the number of newly created device nodes (destination absent
+    /// before the transfer).
+    ///
+    /// upstream: receiver.c:743-744 `stats.created_devices++`.
+    #[must_use]
+    pub const fn created_devices(&self) -> u64 {
+        self.created_devices
+    }
+
+    /// Returns the number of newly created special files - FIFOs and sockets -
+    /// (destination absent before the transfer).
+    ///
+    /// upstream: receiver.c:745-746 `stats.created_specials++`.
+    #[must_use]
+    pub const fn created_specials(&self) -> u64 {
+        self.created_specials
     }
 
     /// Returns the number of FIFOs encountered in the source set.
@@ -474,6 +526,12 @@ impl LocalCopySummary {
         Self {
             regular_files_total: files_listed as u64,
             files_copied: files_transferred as u64,
+            // Remote transfers do not carry a per-entry new/updated breakdown
+            // (upstream never sends `stats.created_*` over the wire - the client
+            // recomputes it locally from its own itemize pass). Absent that
+            // stream, mirror the historical reg-created figure so remote
+            // `--stats` output is unchanged by the local-copy accounting fix.
+            created_regular_files: files_transferred as u64,
             bytes_received,
             bytes_sent,
             bytes_copied: literal_data,
@@ -512,6 +570,10 @@ impl LocalCopySummary {
         Self {
             regular_files_total: files_listed as u64,
             files_copied: files_transferred as u64,
+            // See `from_receiver_stats`: no per-entry new/updated breakdown is
+            // available for remote transfers, so preserve the historical
+            // reg-created figure.
+            created_regular_files: files_transferred as u64,
             bytes_received,
             bytes_sent,
             bytes_copied: literal_data,
@@ -552,6 +614,10 @@ impl LocalCopySummary {
             hard_links_created: 0,
             devices_created: 0,
             fifos_created: 0,
+            created_regular_files: 0,
+            created_symlinks: 0,
+            created_devices: 0,
+            created_specials: 0,
             items_deleted: 0,
             deleted_dirs: 0,
             deleted_symlinks: 0,
@@ -671,6 +737,31 @@ impl LocalCopySummary {
 
     pub(in crate::local_copy) const fn record_fifo(&mut self) {
         self.fifos_created = self.fifos_created.saturating_add(1);
+    }
+
+    /// Records the creation of one new entry (destination did not previously
+    /// exist), bumping the per-type `created_*` counter for its kind. Directory
+    /// creations are tracked separately via [`Self::record_directory`], so they
+    /// are ignored here. Called once per ITEM_IS_NEW record, in both real and
+    /// dry-run modes, so `--stats` counts match upstream even when no file data
+    /// moved (a new empty file, symlink, device, FIFO, or empty directory).
+    ///
+    /// upstream: receiver.c:733-746 / sender.c:295-308 - `stats.created_*++`
+    /// under the `iflags & ITEM_IS_NEW` guard, keyed by the entry's mode.
+    pub(in crate::local_copy) const fn record_created_regular_file(&mut self) {
+        self.created_regular_files = self.created_regular_files.saturating_add(1);
+    }
+
+    pub(in crate::local_copy) const fn record_created_symlink(&mut self) {
+        self.created_symlinks = self.created_symlinks.saturating_add(1);
+    }
+
+    pub(in crate::local_copy) const fn record_created_device(&mut self) {
+        self.created_devices = self.created_devices.saturating_add(1);
+    }
+
+    pub(in crate::local_copy) const fn record_created_special(&mut self) {
+        self.created_specials = self.created_specials.saturating_add(1);
     }
 
     pub(in crate::local_copy) const fn record_fifo_total(&mut self) {

--- a/crates/engine/src/local_copy/tests/execute_created_stats.rs
+++ b/crates/engine/src/local_copy/tests/execute_created_stats.rs
@@ -1,0 +1,142 @@
+// Tests for the per-type "created" stat counters that feed `--stats`
+// "Number of created files: N (reg: .., dir: .., link: .., dev: .., special: ..)".
+//
+// upstream: receiver.c:733-746 / sender.c:295-308 - every ITEM_IS_NEW entry
+// bumps `stats.created_*` for its type, whether or not it transferred file
+// data. An in-place update of a pre-existing file/symlink is transferred but
+// is NOT ITEM_IS_NEW, so it must never inflate the created counts. These tests
+// pin that new-vs-updated distinction, which the "copied" tallies (files_copied,
+// symlinks_copied) deliberately do not make.
+
+fn build_new_source_tree(root: &std::path::Path) {
+    fs::create_dir_all(root).expect("create source root");
+    fs::create_dir_all(root.join("subdir")).expect("create subdir");
+    // A brand-new empty file transfers no data but is still ITEM_IS_NEW, so it
+    // must count as a created regular file.
+    fs::write(root.join("empty"), b"").expect("write empty file");
+    fs::write(root.join("data"), b"payload").expect("write data file");
+    std::os::unix::fs::symlink("data", root.join("link")).expect("create symlink");
+}
+
+#[cfg(unix)]
+#[test]
+fn created_counts_include_new_nontransferring_entries() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    build_new_source_tree(&source);
+
+    let options = LocalCopyOptions::builder()
+        .archive()
+        .build()
+        .expect("valid options");
+    let operands = vec![
+        source.clone().into_os_string(),
+        dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("recursive copy succeeds");
+
+    // Both regular files are newly created, including the zero-byte one that
+    // moved no data. upstream counts it via `stats.created_files++` on the
+    // ITEM_IS_NEW path even though `!(iflags & ITEM_TRANSFER)` skips the body.
+    assert_eq!(
+        summary.created_regular_files(),
+        2,
+        "new empty + data files must both count as created reg"
+    );
+    assert_eq!(
+        summary.created_symlinks(),
+        1,
+        "the new symlink must count as a created link"
+    );
+    // The created directory tally covers the freshly made subdir; the executor
+    // also counts the synthesized destination root, so at least both dirs show.
+    assert!(
+        summary.directories_created() >= 2,
+        "new subdir + destination root must count as created dirs, got {}",
+        summary.directories_created()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn updated_entries_are_not_counted_as_created() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    build_new_source_tree(&source);
+
+    let operands = vec![
+        source.clone().into_os_string(),
+        dest.clone().into_os_string(),
+    ];
+
+    // First run materialises everything.
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::builder().archive().build().expect("options"),
+    )
+    .expect("initial copy succeeds");
+
+    // Mutate a pre-existing file (different size) and re-point the symlink so
+    // both are re-transferred on the second run. Neither destination is new.
+    fs::write(source.join("data"), b"payload-grown-larger").expect("rewrite data file");
+    fs::remove_file(source.join("link")).expect("remove symlink");
+    std::os::unix::fs::symlink("empty", source.join("link")).expect("recreate symlink");
+
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::builder().archive().build().expect("options"),
+        )
+        .expect("second copy succeeds");
+
+    // The changed file IS transferred (files_copied bumps) but was NOT created;
+    // upstream leaves ITEM_IS_NEW clear because the destination already existed.
+    assert!(
+        summary.files_copied() >= 1,
+        "the modified file must be re-transferred"
+    );
+    assert_eq!(
+        summary.created_regular_files(),
+        0,
+        "an in-place update must not count as a created reg file"
+    );
+    assert_eq!(
+        summary.created_symlinks(),
+        0,
+        "a re-pointed pre-existing symlink must not count as created"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn dry_run_counts_created_entries_like_a_real_run() {
+    // upstream: a dry-run still walks itemize() and bumps `stats.created_*`, so
+    // `--dry-run --stats` reports the same created counts as a real transfer.
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    build_new_source_tree(&source);
+
+    let operands = vec![
+        source.clone().into_os_string(),
+        dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::DryRun,
+            LocalCopyOptions::builder().archive().build().expect("options"),
+        )
+        .expect("dry run succeeds");
+
+    assert_eq!(summary.created_regular_files(), 2);
+    assert_eq!(summary.created_symlinks(), 1);
+    assert!(!dest.exists(), "dry run must not touch the destination");
+}

--- a/crates/engine/src/local_copy/tests/mod.rs
+++ b/crates/engine/src/local_copy/tests/mod.rs
@@ -981,6 +981,8 @@ include!("execute_executability.rs");
 include!("execute_special.rs");
 include!("execute_specials.rs");
 include!("execute_directories.rs");
+#[cfg(unix)]
+include!("execute_created_stats.rs");
 include!("execute_prune_empty_dirs.rs");
 include!("execute_hardlinks.rs");
 include!("execute_link_dest.rs");


### PR DESCRIPTION
## Summary

`--stats` / `--info=STATS` reported the wrong `Number of created files` breakdown. The per-type sub-counts were derived from the "copied/updated" tallies (`files_copied`, `symlinks_copied`, `devices_created`, `fifos_created`), so:

- an in-place update of a pre-existing file or symlink was wrongly counted as **created**, and
- device nodes were folded into `special:` instead of getting their own `dev:` label.

## Upstream behaviour

Upstream counts only `ITEM_IS_NEW` entries, keyed by the entry's mode (`receiver.c:733-746`, `sender.c:295-308`):

```
if (iflags & ITEM_IS_NEW) {
    stats.created_files++;
    if      (S_ISREG(file->mode)) { /* reg */ }
    else if (S_ISDIR(file->mode))  stats.created_dirs++;
    else if (S_ISLNK(file->mode))  stats.created_symlinks++;
    else if (IS_DEVICE(file->mode)) stats.created_devices++;
    else                            stats.created_specials++;
}
```

A brand-new directory, symlink, device, special, or empty file bumps its type's created counter **whether or not it moved file data**, while a transferred in-place update never does (its destination already existed, so `ITEM_IS_NEW` stays clear). The breakdown labels are `reg/dir/link/dev/special` (`main.c:387` `output_itemized_counts`).

## Fix

- Add dedicated new-only per-type counters (`created_regular_files`, `created_symlinks`, `created_devices`, `created_specials`) to the local-copy summary.
- Increment them at the single record funnel, keyed by the record's `was_created()` flag and action, so counting runs identically for real and dry-run transfers and does not depend on verbose/`-i` event collection. Directories reuse the existing new-only `directories_created` (a `mkdir` plus the synthesized destination root, which has no per-entry record).
- Render `Number of created files` from these counters and split `dev:` from `special:`.
- Remote transfers carry no per-entry new/updated breakdown over the wire (upstream never sends `stats.created_*`; the client recomputes locally), so the reg-created figure is seeded from files-transferred to leave remote output unchanged.

## Output matched (byte-for-byte vs rsync 3.4.4)

```
Number of created files: N (reg: X, dir: Y, link: Z, dev: A, special: B)
```

## Tests

Engine tests pin the distinction that the "copied" tallies deliberately do not make:
- a new empty file and a new symlink count as created even though the empty file moves no data;
- a re-transferred in-place update (changed file, re-pointed symlink) is **not** counted as created;
- dry-run reports the same created counts as a real run.

## Verification (x86_64, upstream rsync 3.4.4, protocol 32)

`cargo fmt --all` clean, `cargo clippy -p transfer -p core -p cli -p protocol -p engine --all-features --all-targets --no-deps -- -D warnings` clean, targeted `cargo nextest` green.

Real-binary `--stats` diff (`oc-rsync` vs `/usr/bin/rsync`), all MATCH:

| Scenario | `Number of created files` |
|----------|---------------------------|
| all new (dirs+symlink+empty+data) | `7 (reg: 3, dir: 3, link: 1)` |
| incremental (1 update + 3 new) | `3 (reg: 1, dir: 1, link: 1)` |
| updated symlink + file, none new | `0` |
| file + FIFO + dirs (new) | `4 (reg: 1, dir: 2, special: 1)` |

Before the fix the incremental case reported `4 (reg: 2, ...)` and the update-only case `2 (reg: 1, link: 1)`.
