### PR TITLE
fix(metadata): filter received xattrs on apply via xattr_name_allowed

### DIFF
--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -304,14 +304,22 @@ pub fn sync_xattrs(
 /// * `destination` - Path to apply xattrs to.
 /// * `xattr_list` - Parsed xattr name-value pairs from the wire protocol.
 /// * `follow_symlinks` - Whether to follow symlinks when setting xattrs.
+/// * `filter` - Optional `x`-modifier filter predicate. When present, a name for
+///   which it returns `false` is neither applied to the destination nor removed
+///   from it, mirroring upstream's `saw_xattr_filter` screening.
 ///
 /// # Upstream Reference
 ///
-/// Mirrors `xattrs.c:set_xattr()` - applies received xattr data to destination files.
+/// Mirrors `xattrs.c:set_xattr()` - applies received xattr data to destination
+/// files. The `filter` argument mirrors the receive-side screening upstream
+/// performs in `receive_xattr()` (xattrs.c:822, drop an excluded received name)
+/// and `rsync_xal_set()` (xattrs.c:1026, keep an excluded destination name),
+/// both gated on `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)`.
 pub fn apply_xattrs_from_list(
     destination: &Path,
     xattr_list: &XattrList,
     follow_symlinks: bool,
+    filter: Option<&dyn Fn(&str) -> bool>,
 ) -> Result<(), MetadataError> {
     let mut applied_names: HashSet<Vec<u8>> = HashSet::with_capacity(xattr_list.len());
 
@@ -339,6 +347,13 @@ pub fn apply_xattrs_from_list(
             continue;
         }
 
+        // upstream: xattrs.c:822 receive_xattr() drops a received xattr whose
+        // name is excluded by an `x`-modifier filter rule before it is stored,
+        // so it is never applied to the destination.
+        if !filter.is_none_or(|predicate| predicate(&name_str)) {
+            continue;
+        }
+
         // Skip the reserved SDDL slot on every platform: Windows has
         // already applied it via the DACL path, POSIX targets do not have
         // a corresponding native sink.
@@ -358,7 +373,11 @@ pub fn apply_xattrs_from_list(
     for name in &dest_attrs {
         if !applied_names.contains(name) {
             let name_str = String::from_utf8_lossy(name);
-            if is_xattr_permitted(&name_str) {
+            // upstream: xattrs.c:1026 rsync_xal_set() skips the removal of a
+            // destination xattr whose name is excluded by an `x`-modifier
+            // filter rule, leaving the pre-existing value in place.
+            if is_xattr_permitted(&name_str) && filter.is_none_or(|predicate| predicate(&name_str))
+            {
                 remove_attribute(destination, name, follow_symlinks)?;
             }
         }
@@ -850,7 +869,7 @@ mod tests {
             b"value2".to_vec(),
         ));
 
-        apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
 
         let attr1 = test_xattr_name("attr1");
         let attr2 = test_xattr_name("attr2");
@@ -866,6 +885,101 @@ mod tests {
                 .expect("read")
                 .expect("attr2"),
             b"value2"
+        );
+    }
+
+    // Receive-side mirror of the send-side x-modifier filter (#128): a received
+    // xattr whose name the filter excludes must never be applied to the
+    // destination, even though the sender put it on the wire, while an allowed
+    // name IS applied. upstream: xattrs.c:822 receive_xattr() drops an excluded
+    // received name via name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS).
+    #[test]
+    fn apply_xattrs_from_list_filter_drops_excluded_received() {
+        let dir = tempdir().expect("create temp dir");
+        let file = dir.path().join("dest.txt");
+        fs::write(&file, "content").expect("write file");
+
+        if !xattrs_supported(&file) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        let mut list = XattrList::new();
+        list.push(XattrEntry::new(test_xattr_name("keep"), b"kept".to_vec()));
+        list.push(XattrEntry::new(
+            test_xattr_name("skipme"),
+            b"dropped".to_vec(),
+        ));
+
+        // Exclude any name containing "skip" (matches on the local xattr name,
+        // which carries the `user.` prefix on Linux and is bare elsewhere).
+        let filter = |name: &str| !name.contains("skip");
+        apply_xattrs_from_list(&file, &list, false, Some(&filter)).expect("apply xattrs");
+
+        // The allowed attr is applied.
+        assert_eq!(
+            read_attribute(&file, &test_xattr_name("keep"), false)
+                .expect("read")
+                .expect("keep"),
+            b"kept"
+        );
+        // The excluded attr the sender transmitted is NOT applied.
+        assert!(
+            read_attribute(&file, &test_xattr_name("skipme"), false)
+                .expect("read")
+                .is_none(),
+            "filtered received xattr must not land on the destination"
+        );
+    }
+
+    // A destination xattr the filter excludes must be preserved even when it is
+    // absent from the received list, while a non-excluded stale attr is still
+    // removed. upstream: xattrs.c:1026 rsync_xal_set() skips the removal of an
+    // excluded destination name.
+    #[test]
+    fn apply_xattrs_from_list_filter_preserves_excluded_dest_attr() {
+        let dir = tempdir().expect("create temp dir");
+        let file = dir.path().join("dest.txt");
+        fs::write(&file, "content").expect("write file");
+
+        if !xattrs_supported(&file) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        // Excluded pre-existing attr (not in the received list).
+        let excluded = test_xattr_name("skipme");
+        write_attribute(&file, &excluded, b"local", false).expect("write excluded");
+        // Non-excluded stale attr (not in the received list).
+        let stale = test_xattr_name("stale");
+        write_attribute(&file, &stale, b"old", false).expect("write stale");
+
+        let mut list = XattrList::new();
+        list.push(XattrEntry::new(test_xattr_name("keep"), b"kept".to_vec()));
+
+        let filter = |name: &str| !name.contains("skip");
+        apply_xattrs_from_list(&file, &list, false, Some(&filter)).expect("apply xattrs");
+
+        // Excluded destination attr is preserved.
+        assert_eq!(
+            read_attribute(&file, &excluded, false)
+                .expect("read")
+                .expect("excluded preserved"),
+            b"local"
+        );
+        // Non-excluded stale attr is removed.
+        assert!(
+            read_attribute(&file, &stale, false)
+                .expect("read")
+                .is_none(),
+            "non-excluded stale dest xattr must be removed"
+        );
+        // The received attr is applied.
+        assert_eq!(
+            read_attribute(&file, &test_xattr_name("keep"), false)
+                .expect("read")
+                .expect("keep"),
+            b"kept"
         );
     }
 
@@ -890,7 +1004,7 @@ mod tests {
             b"new_value".to_vec(),
         ));
 
-        apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
 
         // Stale attr should be removed
         assert!(
@@ -933,7 +1047,7 @@ mod tests {
             b"full_value".to_vec(),
         ));
 
-        apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
 
         // Abbreviated entry should not be set
         let abbrev = test_xattr_name("abbrev");
@@ -969,7 +1083,7 @@ mod tests {
         write_attribute(&file, &attr, b"value", false).expect("write existing");
 
         let list = XattrList::new();
-        apply_xattrs_from_list(&file, &list, false).expect("apply empty list");
+        apply_xattrs_from_list(&file, &list, false, None).expect("apply empty list");
 
         // All permitted xattrs should be removed
         assert!(read_attribute(&file, &attr, false).expect("read").is_none());
@@ -995,7 +1109,7 @@ mod tests {
             b"new_value".to_vec(),
         ));
 
-        apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
 
         assert_eq!(
             read_attribute(&file, &attr, false)
@@ -1019,7 +1133,7 @@ mod tests {
         let mut list = XattrList::new();
         list.push(XattrEntry::new(test_xattr_name("empty_val"), b"".to_vec()));
 
-        apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
+        apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
 
         let attr = test_xattr_name("empty_val");
         let value = read_attribute(&file, &attr, false)

--- a/crates/metadata/src/xattr_stub.rs
+++ b/crates/metadata/src/xattr_stub.rs
@@ -75,6 +75,7 @@ pub fn apply_xattrs_from_list(
     _destination: &Path,
     _xattr_list: &XattrList,
     _follow_symlinks: bool,
+    _filter: Option<&dyn Fn(&str) -> bool>,
 ) -> Result<(), MetadataError> {
     warn_xattr_unsupported();
     Ok(())
@@ -120,7 +121,7 @@ mod tests {
     fn apply_xattrs_from_list_returns_ok() {
         let dst = Path::new("/nonexistent/dst");
         let xattr_list = XattrList::new();
-        let result = apply_xattrs_from_list(dst, &xattr_list, false);
+        let result = apply_xattrs_from_list(dst, &xattr_list, false, None);
         assert!(result.is_ok());
     }
 
@@ -128,7 +129,7 @@ mod tests {
     fn apply_xattrs_from_list_follow_symlinks_returns_ok() {
         let dst = Path::new("/nonexistent/dst");
         let xattr_list = XattrList::new();
-        let result = apply_xattrs_from_list(dst, &xattr_list, true);
+        let result = apply_xattrs_from_list(dst, &xattr_list, true, None);
         assert!(result.is_ok());
     }
 }

--- a/crates/metadata/tests/security_selinux_roundtrip.rs
+++ b/crates/metadata/tests/security_selinux_roundtrip.rs
@@ -143,7 +143,7 @@ fn security_selinux_xattr_preserved_via_wire_path() {
         FIXTURE_LABEL.to_vec(),
     ));
 
-    apply_xattrs_from_list(&destination, &list, false).expect("apply wire xattrs");
+    apply_xattrs_from_list(&destination, &list, false, None).expect("apply wire xattrs");
 
     let landed = xattr::get(&destination, "security.selinux")
         .expect("read dest label")

--- a/crates/metadata/tests/windows_long_path_metadata.rs
+++ b/crates/metadata/tests/windows_long_path_metadata.rs
@@ -105,7 +105,7 @@ fn ads_supported(file: &Path) -> bool {
     let probe_name = b"oc_rsync_longpath_probe".to_vec();
     let mut probe = XattrList::new();
     probe.push(XattrEntry::new(probe_name, b"1".to_vec()));
-    match apply_xattrs_from_list(file, &probe, false) {
+    match apply_xattrs_from_list(file, &probe, false, None) {
         Ok(()) => true,
         Err(error) => {
             eprintln!("ADS not supported on this volume ({error}); skipping");
@@ -186,7 +186,7 @@ fn long_path_ads_round_trip() {
     let stream_value = b"[ZoneTransfer]\r\nZoneId=3\r\n".to_vec();
     let mut list = XattrList::new();
     list.push(XattrEntry::new(local_name.to_vec(), stream_value.clone()));
-    apply_xattrs_from_list(&file, &list, false).expect("apply ADS on long path");
+    apply_xattrs_from_list(&file, &list, false, None).expect("apply ADS on long path");
 
     // Read the xattrs back; the boundary path here is
     // `xattr_windows::path_to_wide` feeding `FindFirstStreamW`. The wire

--- a/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
+++ b/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
@@ -122,7 +122,7 @@ fn xattrs_supported(path: &Path) -> bool {
     let mut list = XattrList::new();
     list.push(XattrEntry::new(probe_name, b"1".to_vec()));
 
-    if apply_xattrs_from_list(path, &list, false).is_err() {
+    if apply_xattrs_from_list(path, &list, false, None).is_err() {
         return false;
     }
 
@@ -130,7 +130,7 @@ fn xattrs_supported(path: &Path) -> bool {
     // Cleanup failure is non-fatal; the test bodies push a fresh full
     // list whose apply step removes any stale entries left behind.
     let cleared = XattrList::new();
-    let _ = apply_xattrs_from_list(path, &cleared, false);
+    let _ = apply_xattrs_from_list(path, &cleared, false, None);
     true
 }
 
@@ -169,7 +169,7 @@ fn simulated_windows_xattr_dropped_on_linux() {
     list.push(XattrEntry::new(standard_a, b"alpha".to_vec()));
     list.push(XattrEntry::new(standard_b, b"beta".to_vec()));
 
-    apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
+    apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
 
     let after = read_back(&file);
 
@@ -240,7 +240,7 @@ fn simulated_windows_xattr_applied_on_windows() {
     // The apply call must succeed regardless of whether the WAS-5
     // dispatch is wired yet; failure here would indicate a regression
     // in the cross-platform xattr backend.
-    apply_xattrs_from_list(&file, &list, false).expect("apply xattrs on Windows");
+    apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs on Windows");
 
     // Once WAS-5 lands, the DACL is applied via `write_dacl_sddl` and
     // the descriptor can be read back. The returned descriptor must
@@ -276,7 +276,7 @@ fn pure_posix_acl_roundtrip_unaffected_by_reserved_slot() {
         b"second".to_vec(),
     ));
 
-    apply_xattrs_from_list(&file, &list, false).expect("apply xattrs");
+    apply_xattrs_from_list(&file, &list, false, None).expect("apply xattrs");
 
     let after = read_back(&file);
 

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -8,6 +8,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use filters::FilterSet;
 use metadata::MetadataOptions;
 use protocol::acl::AclCache;
 
@@ -124,6 +125,13 @@ pub struct DiskCommitConfig {
     ///
     /// upstream: acls.c:1059-1081 `match_acl_ids()`.
     pub acl_id_map: Option<Arc<metadata::AclIdMapper>>,
+    /// Compiled `x`-modifier xattr-name filter, shared via `Arc`. When `Some`,
+    /// the disk thread screens each received xattr name before applying it and
+    /// preserves excluded names already on the destination.
+    ///
+    /// upstream: `saw_xattr_filter` gate in `receive_xattr()` (xattrs.c:822)
+    /// and `rsync_xal_set()` (xattrs.c:1026).
+    pub xattr_filter: Option<Arc<FilterSet>>,
     /// SPSC channel capacity for the disk commit thread.
     ///
     /// Controls how many `FileMessage` items can be buffered between the
@@ -207,6 +215,7 @@ impl Default for DiskCommitConfig {
             backup: None,
             acl_cache: None,
             acl_id_map: None,
+            xattr_filter: None,
             channel_capacity: DEFAULT_CHANNEL_CAPACITY,
             io_uring_policy: fast_io::IoUringPolicy::Auto,
             io_uring_depth: None,

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -44,6 +44,7 @@ pub(super) fn apply_file_metadata(
             config.acl_cache.as_deref(),
             config.acl_id_map.as_deref(),
             begin.xattr_list.as_ref(),
+            config.xattr_filter.as_deref(),
         )
     }
 }
@@ -64,6 +65,7 @@ fn apply_metadata_acls_and_xattrs(
     acl_cache: Option<&AclCache>,
     acl_id_map: Option<&AclIdMapper>,
     xattr_list: Option<&protocol::xattr::XattrList>,
+    xattr_filter: Option<&filters::FilterSet>,
 ) -> Option<(PathBuf, String)> {
     let (opts, entry) = match (metadata_opts, file_entry) {
         (Some(o), Some(e)) => (o, e),
@@ -97,7 +99,9 @@ fn apply_metadata_acls_and_xattrs(
 
     // upstream: xattrs.c:set_xattr() - apply xattrs after metadata and ACLs
     if let Some(xattr_list) = xattr_list {
-        if let Err(e) = metadata::apply_xattrs_from_list(file_path, xattr_list, true) {
+        let filter = xattr_filter.map(|set| move |name: &str| set.xattr_name_allowed(name));
+        let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
+        if let Err(e) = metadata::apply_xattrs_from_list(file_path, xattr_list, true, filter_ref) {
             return Some((file_path.to_path_buf(), e.to_string()));
         }
     }

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -680,6 +680,30 @@ impl ReceiverContext {
         reader.xattr_cache().get(ndx as usize).cloned()
     }
 
+    /// Returns the `x`-modifier xattr-name filter to screen received xattrs
+    /// when applying them, or `None` when the transfer carries no such rules.
+    ///
+    /// The returned set is consulted via [`FilterSet::xattr_name_allowed`] at
+    /// each xattr apply site so an excluded name is neither written to nor
+    /// removed from the destination.
+    ///
+    /// # Upstream Reference
+    ///
+    /// Mirrors upstream's `saw_xattr_filter` gate: `receive_xattr()`
+    /// (xattrs.c:822) and `rsync_xal_set()` (xattrs.c:1026) both consult
+    /// `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)`.
+    pub(in crate::receiver) fn xattr_name_filter(&self) -> Option<&FilterSet> {
+        let global = self.filter_chain.global();
+        global.has_xattr_rules().then_some(global)
+    }
+
+    /// Owned (`Arc`) form of [`xattr_name_filter`](Self::xattr_name_filter) for
+    /// apply sites that run on the disk-commit thread or in a parallel map and
+    /// therefore cannot borrow `self`.
+    pub(in crate::receiver) fn xattr_name_filter_arc(&self) -> Option<Arc<FilterSet>> {
+        self.xattr_name_filter().map(|set| Arc::new(set.clone()))
+    }
+
     /// Determines if input multiplex should be activated based on mode and protocol.
     ///
     /// The activation threshold differs by mode:

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -393,6 +393,7 @@ impl ReceiverContext {
 
         let acl_cache_clone = acl_cache.cloned();
         let acl_id_map_clone = acl_id_map.cloned();
+        let xattr_filter = self.xattr_name_filter_arc();
         let results = crate::parallel_io::map_blocking(
             entry_snapshots,
             self.parallel_thresholds
@@ -415,7 +416,13 @@ impl ReceiverContext {
                 }
                 // upstream: xattrs.c:set_xattr() - apply xattrs after metadata
                 if let Some(ref xattr_list) = xattr_list {
-                    if let Err(e) = metadata::apply_xattrs_from_list(&dir_path, xattr_list, true) {
+                    let filter = xattr_filter
+                        .as_ref()
+                        .map(|set| move |name: &str| set.xattr_name_allowed(name));
+                    let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
+                    if let Err(e) =
+                        metadata::apply_xattrs_from_list(&dir_path, xattr_list, true, filter_ref)
+                    {
                         return Some((dir_path, e.to_string()));
                     }
                 }
@@ -697,7 +704,13 @@ impl ReceiverContext {
             }
         } else if let Some(ref xattr_list) = self.resolve_xattr_list(entry) {
             // upstream: xattrs.c:set_xattr() - apply xattrs after metadata
-            if let Err(e) = metadata::apply_xattrs_from_list(&dir_path, xattr_list, true) {
+            let filter = self
+                .xattr_name_filter()
+                .map(|set| move |name: &str| set.xattr_name_allowed(name));
+            let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
+            if let Err(e) =
+                metadata::apply_xattrs_from_list(&dir_path, xattr_list, true, filter_ref)
+            {
                 if self.config.flags.verbose && self.config.connection.client_mode {
                     info_log!(
                         Misc,

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -639,7 +639,13 @@ impl ReceiverContext {
         // upstream: xattrs.c:set_xattr() - apply xattrs after metadata
         if has_xattrs {
             if let Some(ref xattr_list) = self.resolve_xattr_list(entry) {
-                if let Err(e) = metadata::apply_xattrs_from_list(file_path, xattr_list, true) {
+                let filter = self
+                    .xattr_name_filter()
+                    .map(|set| move |name: &str| set.xattr_name_allowed(name));
+                let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
+                if let Err(e) =
+                    metadata::apply_xattrs_from_list(file_path, xattr_list, true, filter_ref)
+                {
                     metadata_errors.push((file_path.to_path_buf(), e.to_string()));
                 }
             }

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -184,6 +184,7 @@ impl ReceiverContext {
             backup,
             acl_cache: setup.acl_cache.clone(),
             acl_id_map: setup.acl_id_map.clone(),
+            xattr_filter: self.xattr_name_filter_arc(),
             io_uring_policy: self.config.write.io_uring_policy,
             io_uring_depth: self.config.write.io_uring_depth,
             partial_mode,

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -503,7 +503,13 @@ impl ReceiverContext {
                 metadata_errors.push((file_path.clone(), meta_err.to_string()));
             } else if let Some(ref xattr_list) = self.resolve_xattr_list(file_entry) {
                 // upstream: xattrs.c:set_xattr() - apply xattrs after metadata
-                if let Err(e) = metadata::apply_xattrs_from_list(&file_path, xattr_list, true) {
+                let filter = self
+                    .xattr_name_filter()
+                    .map(|set| move |name: &str| set.xattr_name_allowed(name));
+                let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
+                if let Err(e) =
+                    metadata::apply_xattrs_from_list(&file_path, xattr_list, true, filter_ref)
+                {
                     metadata_errors.push((file_path.clone(), e.to_string()));
                 }
             }


### PR DESCRIPTION
## Summary

Received extended attributes were applied to the destination without consulting the `x`-modifier filter rules. The send-side already honors these rules (a sender omits excluded xattr names), but a peer that still transmits an excluded name had it written to the destination anyway. This completes the receive/apply side.

## Upstream reference

Upstream screens received xattrs at both ends via `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)`, gated on `saw_xattr_filter`:

- `xattrs.c:822` `receive_xattr()` — drops an excluded received name before it is stored, so it is never applied.
- `xattrs.c:1026` `rsync_xal_set()` — skips the removal of an excluded name that already exists on the destination, leaving its value in place.

## The gap

`metadata::apply_xattrs_from_list` (the wire receive/apply path) applied every decoded xattr subject only to the namespace privilege check, ignoring the `x`-modifier rules that the send side already honored. The two directions were asymmetric.

## Fix

- `apply_xattrs_from_list` gains an optional `filter: Option<&dyn Fn(&str) -> bool>` predicate (mirroring the existing `sync_xattrs` local-copy path). An excluded received name is not written; an excluded destination name is not removed.
- The compiled `x`-modifier filter (`FilterSet::xattr_name_allowed`) is threaded to every receiver apply site: the streaming disk-commit thread (via `DiskCommitConfig`), the parallel directory-metadata map, the whole-file sync path, and the candidate-apply path. A `ReceiverContext` helper exposes the global filter set only when `has_xattr_rules()` is set, preserving upstream's `saw_xattr_filter` fast path.

## Tests

- New receive-side unit tests in `metadata`: an excluded received name is not applied while an allowed name is; an excluded pre-existing destination name is preserved while a non-excluded stale name is still removed.
- Existing send-side coverage is unchanged.

## Verification (x86_64 Linux, real user-xattr filesystem)

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p metadata -p transfer -p protocol -p engine -p filters --all-features --all-targets --no-deps -- -D warnings`: clean.
- `cargo nextest run`: metadata xattr tests (incl. the two new receive-side tests, exercised on a real xattr filesystem) and 3761 transfer + filters tests pass.
- End-to-end wire interop vs rsync 3.4.4: with a rsync 3.4.4 daemon as sender and `-X --filter='-x user.skip*'` on the pull, the oc receiver and the rsync 3.4.4 receiver produce byte-identical destination xattr sets (`user.keep` kept, `user.skipme` absent). Without the filter, the oc receiver applies both names, confirming the excluded name is genuinely transmitted over the wire and dropped on apply.
