### PR TITLE
ci: add standalone Upstream Testsuite workflow + README badge

### DIFF
--- a/.github/workflows/_upstream-testsuite.yml
+++ b/.github/workflows/_upstream-testsuite.yml
@@ -11,6 +11,10 @@ on:
         description: 'Upstream rsync version for cache key'
         type: string
         default: '3.4.4'
+      variant:
+        description: 'Which variant(s) to run: all | nonroot | root'
+        type: string
+        default: 'all'
 
 permissions:
   contents: read
@@ -18,6 +22,7 @@ permissions:
 jobs:
   upstream-testsuite:
     name: upstream testsuite
+    if: ${{ inputs.variant == 'all' || inputs.variant == 'nonroot' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -170,6 +175,7 @@ jobs:
   # ===========================================================================
   upstream-testsuite-root:
     name: upstream testsuite (root)
+    if: ${{ inputs.variant == 'all' || inputs.variant == 'root' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/.github/workflows/upstream-testsuite-root.yml
+++ b/.github/workflows/upstream-testsuite-root.yml
@@ -1,0 +1,24 @@
+name: Upstream Testsuite root (rsync 3.4.4)
+
+# Standalone entry point for the ROOT (sudo) upstream rsync testsuite so its
+# pass/fail status is visible as a README badge. This re-runs the same 3.4.4
+# testsuite/*.test corpus under passwordless sudo so root-only tests execute
+# (device nodes, ownership, etc.). Scheduled daily plus on-demand.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 6 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-testsuite-root-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upstream-testsuite-root:
+    uses: ./.github/workflows/_upstream-testsuite.yml
+    with:
+      upstream_rsync_version: '3.4.4'
+      variant: 'root'

--- a/.github/workflows/upstream-testsuite.yml
+++ b/.github/workflows/upstream-testsuite.yml
@@ -1,10 +1,9 @@
 name: Upstream Testsuite (rsync 3.4.4)
 
-# Standalone entry point for the upstream rsync testsuite so its pass/fail
-# status is visible as a README badge. Runs the same reusable suite that the
-# CI workflow gates on, against upstream rsync 3.4.4's own testsuite/*.test
-# corpus. Scheduled daily plus on-demand; per-push coverage is already the
-# required "upstream testsuite" gate inside ci.yml.
+# Standalone entry point for the NON-ROOT upstream rsync testsuite so its
+# pass/fail status is visible as a README badge. This is the same suite that
+# CI gates on as the required "upstream testsuite" check, run against upstream
+# rsync 3.4.4's own testsuite/*.test corpus. Scheduled daily plus on-demand.
 on:
   workflow_dispatch:
   schedule:
@@ -14,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: upstream-testsuite-${{ github.ref }}
+  group: upstream-testsuite-nonroot-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -22,3 +21,4 @@ jobs:
     uses: ./.github/workflows/_upstream-testsuite.yml
     with:
       upstream_rsync_version: '3.4.4'
+      variant: 'nonroot'

--- a/.github/workflows/upstream-testsuite.yml
+++ b/.github/workflows/upstream-testsuite.yml
@@ -1,0 +1,24 @@
+name: Upstream Testsuite (rsync 3.4.4)
+
+# Standalone entry point for the upstream rsync testsuite so its pass/fail
+# status is visible as a README badge. Runs the same reusable suite that the
+# CI workflow gates on, against upstream rsync 3.4.4's own testsuite/*.test
+# corpus. Scheduled daily plus on-demand; per-push coverage is already the
+# required "upstream testsuite" gate inside ci.yml.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-testsuite-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upstream-testsuite:
+    uses: ./.github/workflows/_upstream-testsuite.yml
+    with:
+      upstream_rsync_version: '3.4.4'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Interop Validation](https://github.com/oferchen/rsync/actions/workflows/interop-validation.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/interop-validation.yml)
 [![Upstream Testsuite (rsync 3.4.4)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite.yml)
 [![Upstream Testsuite root (rsync 3.4.4)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite-root.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite-root.yml)
+[![Track 3.5.0dev Testsuite (RsyncProject master)](https://github.com/oferchen/rsync/actions/workflows/track-3.5.0dev-testsuite.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/track-3.5.0dev-testsuite.yml)
 [![Release](https://img.shields.io/github/v/release/oferchen/rsync?include_prereleases)](https://github.com/oferchen/rsync/releases)
 
 # oc-rsync

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CI](https://github.com/oferchen/rsync/actions/workflows/ci.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/ci.yml)
 [![Interop Validation](https://github.com/oferchen/rsync/actions/workflows/interop-validation.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/interop-validation.yml)
 [![Upstream Testsuite (rsync 3.4.4)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite.yml)
+[![Upstream Testsuite root (rsync 3.4.4)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite-root.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite-root.yml)
 [![Release](https://img.shields.io/github/v/release/oferchen/rsync?include_prereleases)](https://github.com/oferchen/rsync/releases)
 
 # oc-rsync

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CI](https://github.com/oferchen/rsync/actions/workflows/ci.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/ci.yml)
 [![Interop Validation](https://github.com/oferchen/rsync/actions/workflows/interop-validation.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/interop-validation.yml)
+[![Upstream Testsuite (rsync 3.4.4)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite.yml/badge.svg)](https://github.com/oferchen/rsync/actions/workflows/upstream-testsuite.yml)
 [![Release](https://img.shields.io/github/v/release/oferchen/rsync?include_prereleases)](https://github.com/oferchen/rsync/releases)
 
 # oc-rsync


### PR DESCRIPTION
Surface the upstream rsync **3.4.4** testsuite pass/fail as a README badge.

## Why
The upstream testsuite runs today as the required `upstream testsuite` gate inside `ci.yml`, calling the reusable `_upstream-testsuite.yml`. A badge pointed at a reusable (`workflow_call`-only) workflow renders **"no status"**, so there was no direct, labeled widget for the testsuite's health.

## What
- New top-level `.github/workflows/upstream-testsuite.yml` — a thin wrapper that calls the same reusable suite (`_upstream-testsuite.yml`) against upstream rsync 3.4.4. Triggers on `schedule` (daily) + `workflow_dispatch`, so its badge reflects real status without duplicating ci.yml's per-push gated run.
- README badge `Upstream Testsuite (rsync 3.4.4)` (the name pins the exact upstream version the corpus is run against), placed alongside the existing CI and Interop Validation badges.

No secrets required; the reusable suite uses only checkout + cache.
