### PR TITLE
fix: skip transfer-root self-lock under --fake-super (xattrs.test)

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -115,6 +115,17 @@ pub(super) fn enforce_transfer_root_self_lock(
 ) -> Result<Option<LocalCopyError>, LocalCopyError> {
     use std::os::unix::fs::PermissionsExt;
 
+    // upstream: generator.c:1512 - the transfer-root owner-rwx re-add (whose
+    // failure is the self-lock) is guarded by `!am_root`. Under --fake-super
+    // upstream sets am_root = -1, so `!am_root` is false and the strict tweaked
+    // mode is never applied to the real inode: set_stat_xattr() (rsync.c:577-578)
+    // forces the directory to 0700 and stashes the intended mode in the
+    // `user.rsync.%stat` xattr. The root therefore cannot self-lock, so skip the
+    // check entirely and let the fake-super permission apply do its work.
+    if context.options().fake_super_enabled() {
+        return Ok(None);
+    }
+
     let existing = fs::symlink_metadata(destination).ok();
     let Some(existing_meta) = existing.as_ref().filter(|meta| meta.is_dir()) else {
         return Ok(None);

--- a/crates/engine/src/local_copy/tests/execute_super.rs
+++ b/crates/engine/src/local_copy/tests/execute_super.rs
@@ -423,6 +423,84 @@ fn fake_super_with_directory_tree() {
     }
 }
 
+/// Regression: `--fake-super` with a `--chmod` that strips the transfer-root
+/// directory's owner-execute bit must NOT self-lock the root.
+///
+/// upstream: generator.c:1512 gates the transfer-root owner-`rwx` re-add (whose
+/// failure is the self-lock, exit 23) on `!am_root`. Under `--fake-super`
+/// upstream sets `am_root = -1`, so that block is skipped: `set_stat_xattr()`
+/// (rsync.c:577-578, xattrs.c:1219) forces the real directory mode to `0700`
+/// and stashes the intended `a=` (`0000`) mode in the `user.rsync.%stat` xattr.
+/// Verified against upstream rsync 3.4.4: `--fake-super --chmod=a=` on a
+/// directory tree exits 0 with the root left at `0700` (`drwx------`), whereas
+/// the plain `--chmod=a=` self-lock (see `uts_chmod_option.rs`) exits 23. A
+/// prior oc regression ran the self-lock unconditionally, applied the strict
+/// `0000` mode to the real inode, and failed with EACCES on `dst/.`.
+#[cfg(unix)]
+#[test]
+fn fake_super_chmod_all_clear_does_not_self_lock_root() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // The self-lock is a non-root phenomenon: root traverses any directory
+    // regardless of mode, so upstream's `!am_root` gate is moot.
+    if rustix::process::geteuid().is_root() {
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("to");
+    fs::create_dir_all(source.join("sub")).expect("mkdir src/sub");
+    fs::write(source.join("file0"), b"hi\n").expect("write file0");
+    fs::write(source.join("sub/file5"), b"deep\n").expect("write file5");
+    fs::set_permissions(&source, fs::Permissions::from_mode(0o755)).expect("chmod src");
+
+    let mut source_operand = source.into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let result = plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default()
+            .fake_super(true)
+            .owner(true)
+            .group(true)
+            .permissions(true)
+            .with_chmod(Some(ChmodModifiers::parse("a=").expect("parse chmod"))),
+    );
+
+    match result {
+        Ok(summary) => {
+            // The root is forced owner-accessible (0700), never the strict 0000
+            // that would lock the owner out - proving the self-lock was skipped.
+            assert_eq!(
+                fs::symlink_metadata(&dest)
+                    .expect("dest metadata")
+                    .permissions()
+                    .mode()
+                    & 0o7777,
+                0o700,
+                "fake-super forces the transfer root to 0700, not the strict a= mode",
+            );
+            assert_eq!(summary.files_copied(), 2);
+            test_helpers::assert_file_content(&dest.join("file0"), b"hi\n");
+            test_helpers::assert_file_content(&dest.join("sub/file5"), b"deep\n");
+        }
+        Err(error) => {
+            // A filesystem without user-xattr support (e.g. tmpfs) can fail the
+            // %stat write; that is acceptable. What must NEVER recur is the
+            // transfer-root self-lock, whose signature is a permission-modify
+            // error on the destination root.
+            let message = error.to_string();
+            assert!(
+                !message.contains("modify permissions"),
+                "fake-super must not self-lock the transfer root, got: {message}",
+            );
+        }
+    }
+}
+
 #[test]
 fn fake_super_copies_file_without_xattr_feature() {
     // Even without xattr feature enabled at the test level, fake_super should


### PR DESCRIPTION
## Summary

Under `--fake-super`, a `--chmod` that strips the transfer-root directory's
owner-execute bit (e.g. `--chmod=a=`) must not "self-lock" the destination root.
oc-rsync ran the transfer-root self-lock check unconditionally, applied the
strict `0000` mode to the real inode, and aborted:

```
oc-rsync error: failed to modify permissions on 'to/.': Permission denied (13) (code 23)
```

Upstream rsync 3.4.4 completes the same transfer (exit 0), leaving the root at
`0700` (`drwx------`) and each file at `0600`, with the intended `a=` mode
recorded in the `user.rsync.%stat` xattr.

This is exercised by upstream `testsuite/xattrs.test` at the
`--fake-super --chmod=a=` step. With this fix that test passes at both root and
non-root on an xattr-capable filesystem.

## Failing assertion

`testsuite/xattrs.test`:

```
checkit "$RSYNC -aiX $XFILT $dashH --fake-super --chmod=a= . ../to" "$chkdir" "$todir"
```

oc-rsync aborted here with exit 23 (`failed to modify permissions on '../to/.'`),
so the destination was left unreadable and the subsequent `xls | diff` never ran.

## Upstream reference

`generator.c:1512`:

```c
/* We need to ensure that the dirs in the transfer have both
 * readable and writable permissions during the time we are
 * putting files within them. ... */
if (!am_root && (file->mode & S_IRWXU) != S_IRWXU && dir_tweaking) {
    mode_t mode = file->mode | S_IRWXU;
    if (do_chmod_at(fname, mode) < 0)
        rsyserr(FERROR_XFER, errno, "failed to modify permissions on %s", ...);
    need_retouch_dir_perms = 1;
}
```

The owner-`rwx` re-add - whose failure on the transfer root (`dst/.`) is the
self-lock - is gated on `!am_root`. Under `--fake-super` upstream sets
`am_root = -1`, so `!am_root` is false and the whole block is skipped. The
strict tweaked mode is never applied to the real inode: `set_stat_xattr()`
(`rsync.c:577-578`, `xattrs.c:1219`) forces the real directory mode to `0700`
and stashes the intended mode in `user.rsync.%stat`. The root therefore cannot
self-lock.

## Root cause

`enforce_transfer_root_self_lock()` in
`crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs`
reproduces upstream's non-fake-super self-lock but did not honour the
`!am_root` gate. Under `--fake-super` it still applied the strict mode and
raised the EACCES error, whereas oc's own fake-super permission apply
(`apply_fake_super_mode`, already correct) would have forced the directory to
`0700` and recorded the intended mode in `%stat`.

## Fix

Skip the transfer-root self-lock check when `--fake-super` is active, matching
upstream's `!am_root` gate. The existing fake-super permission apply then sets
the real mode to `0700`/`0600` and writes the `%stat` xattr.

## Verification

Root `xattrs` test (the required `upstream-testsuite (root)` gate), on an
xattr-capable ext4 filesystem, before and after - still passes:

```
PASS    xattrs
```

Full sudo suite: 55 passed / 2 skipped (crtimes, simd-checksum) / 0 failed.

Non-root `xattrs` test - previously FAILED at `--fake-super --chmod=a=`, now
passes and matches upstream rsync 3.4.4 byte-for-byte:

```
PASS    xattrs
```

Minimal repro after the fix (`--fake-super --chmod=a=`): dest root `0700`,
files `0600`, intended mode in `user.rsync.%stat` - identical to upstream 3.4.4.

Added an engine regression test
(`fake_super_chmod_all_clear_does_not_self_lock_root`) asserting the transfer
root lands at `0700` (never the strict `0000`) and the transfer does not
self-lock.
