### PR TITLE
fix(daemon): surface Landlock best-effort downgrade instead of hiding it

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -320,7 +320,10 @@ fn engage_landlock_sandbox(
     module: &ModuleRuntime,
     extra_allowed_paths: &[&Path],
 ) -> io::Result<bool> {
-    use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
+    use fast_io::landlock::{
+        EnforcementStatus, LandlockOutcome, best_effort_fs_downgrade, is_supported,
+        restrict_to_module_paths,
+    };
 
     if module.pre_xfer_exec.is_some() || module.post_xfer_exec.is_some() {
         if let Some(log) = ctx.log_sink {
@@ -362,12 +365,43 @@ fn engage_landlock_sandbox(
     match restrict_to_module_paths(&roots) {
         LandlockOutcome::Enforced(status) => {
             if let Some(log) = ctx.log_sink {
-                let text = format!(
-                    "module '{}': landlock engaged ({status:?}) over {} root(s)",
-                    ctx.request,
-                    roots.len(),
-                );
-                let message = rsync_info!(text).with_role(Role::Daemon);
+                let message = match status {
+                    // Full confinement: routine, log at info.
+                    EnforcementStatus::FullyEnforced => {
+                        let text = format!(
+                            "module '{}': landlock fully enforced over {} root(s)",
+                            ctx.request,
+                            roots.len(),
+                        );
+                        rsync_info!(text).with_role(Role::Daemon)
+                    }
+                    // Best-effort downgrade silently dropped rights because the
+                    // kernel is too old. Do NOT bury this at info: name exactly
+                    // what is missing so the operator understands the sandbox is
+                    // weaker than intended - the lost `refer` right breaks
+                    // cross-directory renames (--delay-updates / --backup-dir).
+                    EnforcementStatus::PartiallyEnforced => {
+                        let dropped = best_effort_fs_downgrade()
+                            .unwrap_or_else(|| "some requested access rights".to_owned());
+                        let text = format!(
+                            "module '{}': landlock PARTIALLY enforced over {} root(s) - this kernel's Landlock ABI is missing {}. The sandbox is weaker than requested; upgrade to Linux 5.19+ (6.2+ for truncate, 6.10+ for ioctl_dev) for the full allowlist.",
+                            ctx.request,
+                            roots.len(),
+                            dropped,
+                        );
+                        rsync_warning!(text).with_role(Role::Daemon)
+                    }
+                    // The kernel accepted the ruleset but applied nothing:
+                    // equivalent to no sandbox. Warn - SEC-1 *at* helpers are
+                    // now the only defense.
+                    EnforcementStatus::NotEnforced => {
+                        let text = format!(
+                            "module '{}': landlock NOT enforced - the kernel accepted the ruleset but applied no confinement; SEC-1 *at* helpers remain the sole defense.",
+                            ctx.request,
+                        );
+                        rsync_warning!(text).with_role(Role::Daemon)
+                    }
+                };
                 log_message(log, &message);
             }
             Ok(true)

--- a/crates/fast_io/src/landlock.rs
+++ b/crates/fast_io/src/landlock.rs
@@ -215,7 +215,43 @@ pub fn restrict_to_module_paths(allowed_roots: &[&Path]) -> LandlockOutcome {
 /// staging renames depend on and which the kernel omits before Linux 5.19.
 #[must_use]
 pub fn best_effort_fs_downgrade() -> Option<String> {
-    describe_fs_downgrade(ABI::new_current())
+    describe_fs_downgrade(current_fs_abi())
+}
+
+/// Queries the running kernel's highest supported Landlock filesystem ABI.
+///
+/// Issues the version-probe form of `landlock_create_ruleset(2)` (NULL attr,
+/// zero size, `LANDLOCK_CREATE_RULESET_VERSION`), which returns the supported
+/// ABI number without creating a ruleset or restricting the calling thread.
+/// The `landlock` crate runs the identical probe in its private
+/// `LandlockStatus::current()` but does not expose the effective ABI publicly,
+/// so it is replicated here for the informational downgrade summary. Returns
+/// [`ABI::Unsupported`] when the syscall fails (pre-5.13 kernel or Landlock
+/// disabled at boot), which [`describe_fs_downgrade`] then reports as the full
+/// set of filesystem rights dropped.
+fn current_fs_abi() -> ABI {
+    // Version-query flag, identical to the landlock crate's private uapi
+    // `LANDLOCK_CREATE_RULESET_VERSION` constant.
+    const LANDLOCK_CREATE_RULESET_VERSION: u32 = 1;
+    // SAFETY: the version-probe form of landlock_create_ruleset - a NULL attr
+    // pointer with zero size and the version flag. The kernel reads no user
+    // memory and creates no ruleset, so the call has no side effects beyond
+    // returning the ABI number (or -errno) and is sound to invoke from any
+    // thread at any time.
+    #[allow(unsafe_code)]
+    let raw = unsafe {
+        libc::syscall(
+            libc::SYS_landlock_create_ruleset,
+            std::ptr::null::<libc::c_void>(),
+            0_usize,
+            LANDLOCK_CREATE_RULESET_VERSION,
+        )
+    };
+    if raw < 0 {
+        ABI::Unsupported
+    } else {
+        ABI::from(raw as i32)
+    }
 }
 
 /// Pure core of [`best_effort_fs_downgrade`]: given the highest Landlock ABI
@@ -615,6 +651,9 @@ mod tests {
     fn best_effort_downgrade_matches_current_abi() {
         // The public probe must agree with the pure mapping for whatever ABI
         // this host exposes, and must never panic.
-        assert_eq!(best_effort_fs_downgrade(), describe_fs_downgrade(ABI::new_current()));
+        assert_eq!(
+            best_effort_fs_downgrade(),
+            describe_fs_downgrade(current_fs_abi())
+        );
     }
 }

--- a/crates/fast_io/src/landlock.rs
+++ b/crates/fast_io/src/landlock.rs
@@ -36,19 +36,46 @@ use landlock::{
 /// distributions without turning into a hard error.
 const READONLY_SYSTEM_PATHS: &[&str] = &["/etc", "/lib", "/lib64", "/usr", "/proc", "/run", "/var"];
 
+/// Filesystem-access enforcement tier of an engaged Landlock ruleset.
+///
+/// Mirrors the `landlock` crate's `RulesetStatus` without leaking that type
+/// into fast_io's public API, so the same variants are matchable on every
+/// target (the non-Linux stub carries a structurally identical enum).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnforcementStatus {
+    /// Every requested access right was honoured by the kernel.
+    FullyEnforced,
+    /// Best-effort downgrade dropped some requested rights: the running
+    /// kernel's Landlock ABI is older than the one requested, so the sandbox
+    /// is weaker than intended. Call [`best_effort_fs_downgrade`] for the list
+    /// of rights this kernel is missing.
+    PartiallyEnforced,
+    /// The kernel accepted the ruleset but applied no restrictions at all -
+    /// equivalent to running without a sandbox.
+    NotEnforced,
+}
+
+impl From<RulesetStatus> for EnforcementStatus {
+    fn from(status: RulesetStatus) -> Self {
+        match status {
+            RulesetStatus::FullyEnforced => Self::FullyEnforced,
+            RulesetStatus::PartiallyEnforced => Self::PartiallyEnforced,
+            RulesetStatus::NotEnforced => Self::NotEnforced,
+        }
+    }
+}
+
 /// Outcome of a [`crate::landlock::restrict_to_module_paths`] call.
 ///
 /// Carries enough detail for the daemon to log the actual enforcement level
 /// without leaking the `landlock` crate's types into the public API.
 #[derive(Debug)]
 pub enum LandlockOutcome {
-    /// The ruleset was created and applied. The carried [`RulesetStatus`]
-    /// distinguishes `FullyEnforced` (every requested right was honoured),
-    /// `PartiallyEnforced` (best-effort downgrade dropped some rights -
-    /// typically REFER on 5.13-5.18 and TRUNCATE on 5.13-6.1), and
-    /// `NotEnforced` (the kernel accepted the ruleset but applied nothing,
-    /// equivalent to no sandbox).
-    Enforced(RulesetStatus),
+    /// The ruleset was created and applied. The carried [`EnforcementStatus`]
+    /// distinguishes fully enforced, a best-effort partial downgrade (some
+    /// rights dropped - see [`best_effort_fs_downgrade`]), and a no-op ruleset
+    /// the kernel accepted but did not apply.
+    Enforced(EnforcementStatus),
     /// The kernel does not expose Landlock at all (pre-5.13, or the LSM is
     /// not enabled at boot). SEC-1 `*at` helpers remain the only defense.
     Unavailable,
@@ -89,7 +116,8 @@ pub fn is_supported() -> bool {
 /// subset it supports and silently drops the rest. ABI::V5 lands on Linux
 /// 6.7+ and adds the IPC scoping surface; older kernels degrade to V4/V3
 /// without surfacing as an error. The returned [`LandlockOutcome`] carries
-/// the [`RulesetStatus`] so callers can log the actual enforcement level.
+/// the [`EnforcementStatus`] so callers can log the actual enforcement level
+/// (and call [`best_effort_fs_downgrade`] to name the dropped rights).
 ///
 /// Call exactly once per daemon connection, after privilege drop and any
 /// chroot have completed, before any user-controlled file operation begins.
@@ -166,8 +194,56 @@ pub fn restrict_to_module_paths(allowed_roots: &[&Path]) -> LandlockOutcome {
     }
 
     match created.restrict_self() {
-        Ok(status) => LandlockOutcome::Enforced(status.ruleset),
+        Ok(status) => LandlockOutcome::Enforced(EnforcementStatus::from(status.ruleset)),
         Err(err) => LandlockOutcome::Error(io::Error::other(err.to_string())),
+    }
+}
+
+/// Names the filesystem access rights the running kernel's Landlock ABI lacks
+/// relative to the `ABI::V5` set that [`restrict_to_module_paths`] requests.
+///
+/// A [`EnforcementStatus::PartiallyEnforced`] outcome means best-effort
+/// downgrade silently dropped one or more requested rights because the kernel
+/// is too old. This turns that opaque tier into an actionable message so the
+/// operator learns exactly what the sandbox is missing rather than discovering
+/// it as a mysterious `EACCES` at transfer time.
+///
+/// Returns `None` when the kernel honours the full requested set (nothing was
+/// dropped). Otherwise returns a human-readable summary naming each missing
+/// right and the operations it gates - most importantly `refer`
+/// (cross-directory rename), which `--delay-updates` and `--backup-dir`
+/// staging renames depend on and which the kernel omits before Linux 5.19.
+#[must_use]
+pub fn best_effort_fs_downgrade() -> Option<String> {
+    describe_fs_downgrade(ABI::new_current())
+}
+
+/// Pure core of [`best_effort_fs_downgrade`]: given the highest Landlock ABI
+/// the running kernel supports, lists the filesystem rights dropped from the
+/// requested `ABI::V5` set. Factored out so the ABI-to-right mapping is
+/// unit-testable without a specific kernel.
+///
+/// Boundaries follow the `landlock` crate's ABI table: `refer` arrives in
+/// `ABI::V2` (Linux 5.19), `truncate` in `ABI::V3` (Linux 6.2), and
+/// `ioctl_dev` in `ABI::V5` (Linux 6.10); `ABI::V4` adds only network scopes,
+/// so it introduces no new filesystem right over `V3`.
+fn describe_fs_downgrade(current: ABI) -> Option<String> {
+    let mut missing: Vec<&str> = Vec::new();
+    if current < ABI::V2 {
+        missing.push(
+            "refer (cross-directory rename; --delay-updates and --backup-dir staging renames fail, added in Linux 5.19)",
+        );
+    }
+    if current < ABI::V3 {
+        missing.push("truncate (open-handle truncation, added in Linux 6.2)");
+    }
+    if current < ABI::V5 {
+        missing.push("ioctl_dev (device ioctls, added in Linux 6.10)");
+    }
+    if missing.is_empty() {
+        None
+    } else {
+        Some(missing.join("; "))
     }
 }
 
@@ -257,7 +333,7 @@ mod tests {
         run_isolated(move || {
             let outcome = restrict_to_module_paths(&[allowed_path.as_path()]);
             match outcome {
-                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(EnforcementStatus::NotEnforced) => return Ok(()),
                 LandlockOutcome::Enforced(_) => {}
                 LandlockOutcome::Unavailable => return Ok(()),
                 LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
@@ -290,7 +366,7 @@ mod tests {
         run_isolated(move || {
             let outcome = restrict_to_module_paths(&[module_path.as_path(), extra_path.as_path()]);
             match outcome {
-                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(EnforcementStatus::NotEnforced) => return Ok(()),
                 LandlockOutcome::Enforced(_) => {}
                 LandlockOutcome::Unavailable => return Ok(()),
                 LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
@@ -324,7 +400,7 @@ mod tests {
         run_isolated(move || {
             let outcome = restrict_to_module_paths(&[module_path.as_path(), extra_path.as_path()]);
             match outcome {
-                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(EnforcementStatus::NotEnforced) => return Ok(()),
                 LandlockOutcome::Enforced(_) => {}
                 LandlockOutcome::Unavailable => return Ok(()),
                 LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
@@ -351,7 +427,7 @@ mod tests {
         run_isolated(move || {
             let outcome = restrict_to_module_paths(&[]);
             match outcome {
-                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(EnforcementStatus::NotEnforced) => return Ok(()),
                 LandlockOutcome::Enforced(_) => {}
                 LandlockOutcome::Unavailable => return Ok(()),
                 LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
@@ -386,7 +462,7 @@ mod tests {
             assert!(is_supported(), "probe must remain idempotent");
             let outcome = restrict_to_module_paths(&[allowed_path.as_path()]);
             match outcome {
-                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(EnforcementStatus::NotEnforced) => return Ok(()),
                 LandlockOutcome::Enforced(_) => {}
                 LandlockOutcome::Unavailable => return Ok(()),
                 LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
@@ -409,7 +485,7 @@ mod tests {
         run_isolated(move || {
             let first = restrict_to_module_paths(&[allowed_path.as_path()]);
             match first {
-                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(EnforcementStatus::NotEnforced) => return Ok(()),
                 LandlockOutcome::Enforced(_) => {}
                 LandlockOutcome::Unavailable => return Ok(()),
                 LandlockOutcome::Error(err) => return Err(format!("first call: {err}")),
@@ -449,7 +525,7 @@ mod tests {
         run_isolated(move || {
             let outcome = restrict_to_module_paths(&[module_path.as_path()]);
             match outcome {
-                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(EnforcementStatus::NotEnforced) => return Ok(()),
                 LandlockOutcome::Enforced(_) => {}
                 LandlockOutcome::Unavailable => return Ok(()),
                 LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
@@ -478,7 +554,7 @@ mod tests {
         run_isolated(move || {
             let outcome = restrict_to_module_paths(&[module_path.as_path()]);
             match outcome {
-                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(EnforcementStatus::NotEnforced) => return Ok(()),
                 LandlockOutcome::Enforced(_) => {}
                 LandlockOutcome::Unavailable => return Ok(()),
                 LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
@@ -494,5 +570,51 @@ mod tests {
         })
         .expect("readonly-system-path scenario");
         drop(module);
+    }
+
+    #[test]
+    fn downgrade_on_v1_names_every_dropped_right() {
+        // A 5.13-5.18 kernel (ABI::V1) drops refer, truncate, and ioctl_dev
+        // from the requested V5 set. The operator must be told each one - the
+        // refer loss silently breaks --delay-updates / --backup-dir renames,
+        // which is the whole reason this message exists.
+        let msg = describe_fs_downgrade(ABI::V1).expect("V1 must report a downgrade");
+        assert!(msg.contains("refer"), "V1 must name refer: {msg}");
+        assert!(msg.contains("truncate"), "V1 must name truncate: {msg}");
+        assert!(msg.contains("ioctl_dev"), "V1 must name ioctl_dev: {msg}");
+        assert!(
+            msg.contains("--delay-updates"),
+            "refer loss must spell out the --delay-updates consequence: {msg}"
+        );
+    }
+
+    #[test]
+    fn downgrade_tiers_track_the_abi_boundaries() {
+        // refer arrives at V2 (5.19), truncate at V3 (6.2), ioctl_dev at V5
+        // (6.10); V4 (6.7) adds only network scopes, so it still lacks
+        // ioctl_dev but nothing else on the filesystem axis.
+        let v2 = describe_fs_downgrade(ABI::V2).expect("V2 still misses truncate + ioctl_dev");
+        assert!(!v2.contains("refer"), "V2 has refer: {v2}");
+        assert!(v2.contains("truncate") && v2.contains("ioctl_dev"), "{v2}");
+
+        let v3 = describe_fs_downgrade(ABI::V3).expect("V3 still misses ioctl_dev");
+        assert!(!v3.contains("refer") && !v3.contains("truncate"), "{v3}");
+        assert!(v3.contains("ioctl_dev"), "{v3}");
+
+        let v4 = describe_fs_downgrade(ABI::V4).expect("V4 still misses ioctl_dev");
+        assert_eq!(v3, v4, "V4 adds no new filesystem right over V3");
+    }
+
+    #[test]
+    fn full_v5_reports_no_downgrade() {
+        // A kernel honouring the full requested set has nothing to warn about.
+        assert!(describe_fs_downgrade(ABI::V5).is_none());
+    }
+
+    #[test]
+    fn best_effort_downgrade_matches_current_abi() {
+        // The public probe must agree with the pure mapping for whatever ABI
+        // this host exposes, and must never panic.
+        assert_eq!(best_effort_fs_downgrade(), describe_fs_downgrade(ABI::new_current()));
     }
 }

--- a/crates/fast_io/src/landlock_stub.rs
+++ b/crates/fast_io/src/landlock_stub.rs
@@ -59,6 +59,14 @@ pub fn restrict_to_module_paths(_allowed_roots: &[&Path]) -> LandlockOutcome {
     LandlockOutcome::Unavailable
 }
 
+/// Always returns `None` on this build: Landlock is unavailable, so there is
+/// no engaged ruleset that could have been downgraded. Mirrors the Linux
+/// signature so the daemon reports downgrades without `#[cfg]` branching.
+#[must_use]
+pub fn best_effort_fs_downgrade() -> Option<String> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Problem

The daemon's Landlock sandbox requests the full `ABI::V5` access set with best-effort compatibility, so a kernel older than the requested ABI silently drops the rights it does not support:

- `refer` (cross-directory rename) is unavailable before Linux 5.19
- `truncate` before Linux 6.2
- `ioctl_dev` before Linux 6.10

The engagement path logged every enforcement tier - fully enforced, partially enforced, and not enforced - identically at **info** level with an opaque `{status:?}` token. A weakened or absent sandbox was therefore easy to miss. The dropped `refer` right is the most consequential: without it the kernel denies cross-directory rename, which silently breaks `--delay-updates` and `--backup-dir` staging (the receiver stages into `<dir>/.~tmp~/<name>` and renames into place).

## Fix

Make the downgrade loud and specific instead of hiding it:

- **`fast_io` owns its enforcement enum.** A new `EnforcementStatus` (`FullyEnforced` / `PartiallyEnforced` / `NotEnforced`) replaces the leaked `landlock::RulesetStatus` in `LandlockOutcome::Enforced`, matching the non-Linux stub so callers match the same variants on every target (and honouring the module's existing "without leaking the landlock crate's types" contract).
- **`best_effort_fs_downgrade()`** names exactly which rights the running kernel is missing, derived from the crate's ABI table (`refer`=V2/5.19, `truncate`=V3/6.2, `ioctl_dev`=V5/6.10; V4 adds only network scopes). The version-to-right mapping is factored into a pure `describe_fs_downgrade(ABI)` so it is unit-testable without a specific kernel.
- **The daemon logs by severity.** `FullyEnforced` stays at info; `PartiallyEnforced` and `NotEnforced` are now **warnings** that spell out what was dropped, the `--delay-updates` / `--backup-dir` consequence, and the kernel version needed to restore full confinement.

## Tests

- `describe_fs_downgrade` at every ABI tier (V1 names all three dropped rights plus the `--delay-updates` consequence; V2/V3/V4 track the exact boundaries; V5 reports no downgrade).
- `best_effort_fs_downgrade()` agrees with the pure mapping for the host ABI and never panics.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p fast_io -p daemon --all-features --all-targets --no-deps -D warnings`
- `cargo nextest run -p fast_io -p daemon --all-features`
