### PR TITLE
fix(transfer): reconstruct created_* --stats breakdown for remote transfers

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -62,6 +62,7 @@ pub(super) fn convert_server_stats_to_summary(
                 transfer_stats.literal_data,
                 transfer_stats.matched_data,
                 transfer_stats.delete_stats,
+                transfer_stats.created_stats,
             );
             (s, transfer_stats.io_error, transfer_stats.error_count)
         }
@@ -80,6 +81,7 @@ pub(super) fn convert_server_stats_to_summary(
                 generator_stats.literal_data,
                 generator_stats.matched_data,
                 generator_stats.delete_stats,
+                generator_stats.created_stats,
             );
             (s, generator_stats.io_error, 0u32)
         }

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -39,6 +39,7 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
                 transfer_stats.literal_data,
                 transfer_stats.matched_data,
                 transfer_stats.delete_stats,
+                transfer_stats.created_stats,
             );
             (s, transfer_stats.io_error, transfer_stats.error_count)
         }
@@ -55,6 +56,7 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
                 generator_stats.literal_data,
                 generator_stats.matched_data,
                 generator_stats.delete_stats,
+                generator_stats.created_stats,
             );
             (s, generator_stats.io_error, 0u32)
         }

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -400,6 +400,14 @@ fn replay_batch(
         total_size,
         0,
         protocol::DeleteStats::new(),
+        // The --read-batch replay engine does not reconstruct a per-type
+        // ITEM_IS_NEW breakdown, so carry every replayed entry as a created
+        // regular file (reg = files_transferred, the pre-existing behaviour):
+        // `regular()` derives it from `files` with the typed sub-counts at zero.
+        protocol::CreatedStats {
+            files: files_transferred as u64,
+            ..protocol::CreatedStats::new()
+        },
     );
     Ok(ClientSummary::from_summary(summary))
 }

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -522,16 +522,23 @@ impl LocalCopySummary {
         literal_data: u64,
         matched_data: u64,
         delete_stats: protocol::DeleteStats,
+        created_stats: protocol::CreatedStats,
     ) -> Self {
         Self {
             regular_files_total: files_listed as u64,
             files_copied: files_transferred as u64,
-            // Remote transfers do not carry a per-entry new/updated breakdown
-            // (upstream never sends `stats.created_*` over the wire - the client
-            // recomputes it locally from its own itemize pass). Absent that
-            // stream, mirror the historical reg-created figure so remote
-            // `--stats` output is unchanged by the local-copy accounting fix.
-            created_regular_files: files_transferred as u64,
+            // upstream never sends `stats.created_*` over the wire - the client
+            // recomputes the "Number of created files" breakdown locally from
+            // its own itemize pass (receiver.c:733-746). For a remote pull the
+            // receiver reconstructs it into `created_stats`; map each per-type
+            // count through so the breakdown matches upstream (reg is the
+            // derived remainder, distinct from `files_copied`, which also counts
+            // in-place updates of pre-existing files).
+            created_regular_files: created_stats.regular(),
+            directories_created: created_stats.dirs,
+            created_symlinks: created_stats.symlinks,
+            created_devices: created_stats.devices,
+            created_specials: created_stats.specials,
             bytes_received,
             bytes_sent,
             bytes_copied: literal_data,
@@ -566,14 +573,19 @@ impl LocalCopySummary {
         literal_data: u64,
         matched_data: u64,
         delete_stats: protocol::DeleteStats,
+        created_stats: protocol::CreatedStats,
     ) -> Self {
         Self {
             regular_files_total: files_listed as u64,
             files_copied: files_transferred as u64,
-            // See `from_receiver_stats`: no per-entry new/updated breakdown is
-            // available for remote transfers, so preserve the historical
-            // reg-created figure.
-            created_regular_files: files_transferred as u64,
+            // See `from_receiver_stats`: on a push the local sender reconstructs
+            // the created breakdown from the `ITEM_IS_NEW` iflags it reads off
+            // the wire (sender.c:295-308), so map each per-type count through.
+            created_regular_files: created_stats.regular(),
+            directories_created: created_stats.dirs,
+            created_symlinks: created_stats.symlinks,
+            created_devices: created_stats.devices,
+            created_specials: created_stats.specials,
             bytes_received,
             bytes_sent,
             bytes_copied: literal_data,
@@ -822,6 +834,7 @@ mod tests {
             0,
             0,
             protocol::DeleteStats::new(),
+            protocol::CreatedStats::new(),
         );
         assert_eq!(summary.regular_files_total(), 100);
         assert_eq!(summary.files_copied(), 50);
@@ -843,6 +856,7 @@ mod tests {
             800,
             1200,
             protocol::DeleteStats::new(),
+            protocol::CreatedStats::new(),
         );
         assert_eq!(summary.bytes_copied(), 800);
         assert_eq!(summary.matched_bytes(), 1200);
@@ -874,6 +888,7 @@ mod tests {
             0,
             0,
             delete_stats,
+            protocol::CreatedStats::new(),
         );
         assert_eq!(summary.items_deleted(), 7);
         // reg is derived as total - (dir+link+dev+special), mirroring upstream
@@ -905,10 +920,83 @@ mod tests {
             0,
             0,
             delete_stats,
+            protocol::CreatedStats::new(),
         );
         assert_eq!(summary.items_deleted(), 3);
         assert_eq!(summary.deleted_regular_files(), 2);
         assert_eq!(summary.deleted_dirs(), 1);
+    }
+
+    /// A remote transfer (ssh or daemon) reconstructs the "Number of created
+    /// files" breakdown on the client from the `ITEM_IS_NEW` itemize flags and
+    /// threads it in as a `CreatedStats`. The summary must surface each per-type
+    /// count - and derive `reg` as the remainder - so `--stats` matches upstream
+    /// instead of reporting the old over-count (`files_transferred`) with the
+    /// dir/link/dev/special sub-counts stuck at zero.
+    ///
+    /// upstream: receiver.c:733-746 / sender.c:295-308 - `stats.created_*`.
+    #[test]
+    fn from_receiver_stats_maps_created_breakdown() {
+        let created_stats = protocol::CreatedStats {
+            // 8 total: 3 dirs, 2 symlinks, 1 device, 1 special => 1 reg.
+            files: 8,
+            dirs: 3,
+            symlinks: 2,
+            devices: 1,
+            specials: 1,
+        };
+        let summary = LocalCopySummary::from_receiver_stats(
+            20,
+            // files_transferred is 5 (includes in-place updates); the created
+            // reg count must NOT come from this - it is derived from created_stats.
+            5,
+            4096,
+            256,
+            8192,
+            Duration::from_secs(1),
+            0,
+            0,
+            protocol::DeleteStats::new(),
+            created_stats,
+        );
+        assert_eq!(summary.created_regular_files(), 1);
+        assert_eq!(summary.directories_created(), 3);
+        assert_eq!(summary.created_symlinks(), 2);
+        assert_eq!(summary.created_devices(), 1);
+        assert_eq!(summary.created_specials(), 1);
+        // files_copied still tracks all transferred files, updates included.
+        assert_eq!(summary.files_copied(), 5);
+    }
+
+    /// The push twin of [`from_receiver_stats_maps_created_breakdown`]: a client
+    /// sender reconstructs the same breakdown from the wire iflags.
+    #[test]
+    fn from_generator_stats_maps_created_breakdown() {
+        let created_stats = protocol::CreatedStats {
+            files: 4,
+            dirs: 1,
+            symlinks: 1,
+            devices: 0,
+            specials: 0,
+        };
+        let summary = LocalCopySummary::from_generator_stats(
+            10,
+            3,
+            0,
+            2048,
+            0,
+            Duration::from_secs(1),
+            0,
+            0,
+            protocol::DeleteStats::new(),
+            created_stats,
+        );
+        // reg = 4 - (1 dir + 1 link) = 2.
+        assert_eq!(summary.created_regular_files(), 2);
+        assert_eq!(summary.directories_created(), 1);
+        assert_eq!(summary.created_symlinks(), 1);
+        assert_eq!(summary.created_devices(), 0);
+        assert_eq!(summary.created_specials(), 0);
     }
 
     #[test]
@@ -923,6 +1011,7 @@ mod tests {
             2800,
             202_000,
             protocol::DeleteStats::new(),
+            protocol::CreatedStats::new(),
         );
         assert_eq!(summary.regular_files_total(), 200);
         assert_eq!(summary.files_copied(), 75);

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -206,7 +206,7 @@ pub use negotiation::{
     read_legacy_daemon_line,
 };
 pub use protocol_violation::{ProtocolViolation, protocol_violation};
-pub use stats::{DeleteStats, TransferStats};
+pub use stats::{CreatedStats, DeleteStats, TransferStats};
 pub use varint::{
     decode_varint, encode_varint_to_vec, read_int, read_longint, read_varint, read_varint_bounded,
     read_varint_size, read_varint30_int, read_varlong, read_varlong30, write_int, write_longint,

--- a/crates/protocol/src/stats/created.rs
+++ b/crates/protocol/src/stats/created.rs
@@ -1,0 +1,153 @@
+//! Client-local "created files" statistics accumulator.
+//!
+//! Unlike [`DeleteStats`](super::DeleteStats), these counters are NEVER sent
+//! over the wire. Upstream rsync reconstructs the "Number of created files"
+//! breakdown entirely on the client from its own itemize pass: every entry
+//! whose iflags carry `ITEM_IS_NEW` bumps `stats.created_files` plus the
+//! per-type counter for the entry's mode. A client sender does this in
+//! `sender.c:295-308`; a client receiver in `receiver.c:733-746`. Only
+//! `total_read`/`total_written`/`total_size` (and the `--delete` counters)
+//! cross the wire (main.c `handle_stats`), so the client must tally these
+//! itself while it processes the per-file `NDX + iflags` stream.
+
+use crate::flist::FileType;
+
+/// Per-type tally of entries created at the destination (destination absent
+/// before the transfer), reconstructed on the client from the `ITEM_IS_NEW`
+/// itemize flags.
+///
+/// `files` is the running total across all types; `regular()` derives the
+/// implicit regular-file count exactly as upstream's `output_itemized_counts`
+/// does (`counts[0] -= counts[1..4]`). Feeds the `--stats`
+/// `Number of created files: N (reg: X, dir: Y, link: Z, dev: W, special: V)`
+/// line.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:733-746` / `sender.c:295-308` - `stats.created_*++` under the
+///   `iflags & ITEM_IS_NEW` guard, keyed by the entry's mode.
+/// - `main.c:387-416` - `output_itemized_counts()` renders the breakdown.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreatedStats {
+    /// Total number of entries created, across every type. Upstream's
+    /// `stats.created_files`.
+    pub files: u64,
+    /// Number of directories created. Upstream's `stats.created_dirs`.
+    pub dirs: u64,
+    /// Number of symbolic links created. Upstream's `stats.created_symlinks`.
+    pub symlinks: u64,
+    /// Number of device nodes created. Upstream's `stats.created_devices`.
+    pub devices: u64,
+    /// Number of special files (FIFOs, sockets) created. Upstream's
+    /// `stats.created_specials`.
+    pub specials: u64,
+}
+
+impl CreatedStats {
+    /// Creates an empty accumulator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            files: 0,
+            dirs: 0,
+            symlinks: 0,
+            devices: 0,
+            specials: 0,
+        }
+    }
+
+    /// Records one newly created entry, classifying it by its Unix `mode` bits.
+    ///
+    /// Bumps the running total (`files`) and the per-type counter, mirroring
+    /// upstream's mode dispatch exactly: regular files add only to the total
+    /// (`reg` is derived), directories to `dirs`, symlinks to `symlinks`, block
+    /// and character devices to `devices`, and everything else (FIFOs, sockets,
+    /// and unrecognised modes) to `specials`.
+    ///
+    /// Call once per `ITEM_IS_NEW` entry, whether or not any file data moved -
+    /// a new empty file, directory, symlink, device, or FIFO all count.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:733-746` / `sender.c:296-309` - the `S_ISREG` / `S_ISDIR`
+    ///   / `S_ISLNK` / `IS_DEVICE` / else cascade.
+    pub const fn record(&mut self, mode: u32) {
+        self.files = self.files.saturating_add(1);
+        match FileType::from_mode(mode) {
+            Some(FileType::Regular) => {}
+            Some(FileType::Directory) => self.dirs = self.dirs.saturating_add(1),
+            Some(FileType::Symlink) => self.symlinks = self.symlinks.saturating_add(1),
+            Some(FileType::BlockDevice | FileType::CharDevice) => {
+                self.devices = self.devices.saturating_add(1);
+            }
+            // upstream: the final `else` covers FIFOs, sockets, and any mode the
+            // type mask does not recognise, all of which count as specials.
+            Some(FileType::Fifo | FileType::Socket) | None => {
+                self.specials = self.specials.saturating_add(1);
+            }
+        }
+    }
+
+    /// Returns the derived count of newly created regular files.
+    ///
+    /// Regular files are not tracked directly; upstream derives the `reg`
+    /// sub-count as `total - (dirs + symlinks + devices + specials)`
+    /// (`output_itemized_counts`). Mirrors that so a stale flat count can never
+    /// disagree with the typed sub-counts.
+    #[must_use]
+    pub const fn regular(&self) -> u64 {
+        self.files
+            .saturating_sub(self.dirs)
+            .saturating_sub(self.symlinks)
+            .saturating_sub(self.devices)
+            .saturating_sub(self.specials)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mode constants mirroring the S_IF* bits classified by `record`.
+    const S_IFREG: u32 = 0o100000;
+    const S_IFDIR: u32 = 0o040000;
+    const S_IFLNK: u32 = 0o120000;
+    const S_IFBLK: u32 = 0o060000;
+    const S_IFCHR: u32 = 0o020000;
+    const S_IFIFO: u32 = 0o010000;
+    const S_IFSOCK: u32 = 0o140000;
+
+    #[test]
+    fn record_classifies_each_type_like_upstream() {
+        let mut stats = CreatedStats::new();
+        stats.record(S_IFREG | 0o644);
+        stats.record(S_IFDIR | 0o755);
+        stats.record(S_IFLNK | 0o777);
+        stats.record(S_IFBLK | 0o600);
+        stats.record(S_IFCHR | 0o600);
+        stats.record(S_IFIFO | 0o644);
+        stats.record(S_IFSOCK | 0o644);
+
+        assert_eq!(stats.files, 7);
+        assert_eq!(stats.dirs, 1);
+        assert_eq!(stats.symlinks, 1);
+        // Both block and char devices fold into `devices`, matching IS_DEVICE.
+        assert_eq!(stats.devices, 2);
+        // FIFO + socket both count as specials, matching upstream's else branch.
+        assert_eq!(stats.specials, 2);
+        // reg is derived: 7 total - (1 dir + 1 link + 2 dev + 2 special) = 1.
+        assert_eq!(stats.regular(), 1);
+    }
+
+    #[test]
+    fn record_unrecognised_mode_counts_as_special() {
+        // An all-zero type mask does not match any S_IF* pattern; upstream's
+        // final `else` treats it as a special, so `record` must too.
+        let mut stats = CreatedStats::new();
+        stats.record(0);
+        assert_eq!(stats.files, 1);
+        assert_eq!(stats.specials, 1);
+        assert_eq!(stats.regular(), 0);
+    }
+}

--- a/crates/protocol/src/stats/mod.rs
+++ b/crates/protocol/src/stats/mod.rs
@@ -6,6 +6,7 @@
 //! - Protocol 29: adds flist build/transfer time fields
 //! - Protocol < 29: basic byte counts only
 
+mod created;
 mod delete;
 mod display;
 mod transfer;
@@ -13,5 +14,6 @@ mod transfer;
 #[cfg(test)]
 mod tests;
 
+pub use created::CreatedStats;
 pub use delete::DeleteStats;
 pub use transfer::TransferStats;

--- a/crates/transfer/src/generator/stats.rs
+++ b/crates/transfer/src/generator/stats.rs
@@ -8,7 +8,7 @@
 use std::time::Duration;
 
 use protocol::codec::{MonotonicNdxWriter, NdxCodecEnum};
-use protocol::stats::DeleteStats;
+use protocol::stats::{CreatedStats, DeleteStats};
 
 /// Result from the transfer loop phase of the generator.
 ///
@@ -29,6 +29,10 @@ pub(crate) struct TransferLoopResult {
     pub(crate) matched_data: u64,
     /// Bytes sent as literal data across all files (upstream: literal_data).
     pub(crate) literal_data: u64,
+    /// Per-type tally of entries the receiver reported as created via
+    /// `ITEM_IS_NEW` iflags on the wire (upstream: `stats.created_*` in
+    /// `sender.c:295-308`). Reconstructed locally, never sent over the wire.
+    pub(crate) created_stats: CreatedStats,
     /// NDX read codec state carried over for the goodbye handshake.
     pub(crate) ndx_read_codec: NdxCodecEnum,
     /// NDX write codec state carried over for the goodbye handshake.
@@ -74,6 +78,15 @@ pub struct GeneratorStats {
     pub flist_first_byte_latency: Option<Duration>,
     /// Accumulated deletion statistics from the receiver via `NDX_DEL_STATS`.
     pub delete_stats: DeleteStats,
+    /// Per-type tally of entries created at the destination, reconstructed on
+    /// the local sender from the `ITEM_IS_NEW` iflags read off the wire. Never
+    /// sent over the wire - upstream recomputes the "Number of created files"
+    /// breakdown on the client (here, the sender) from its own itemize pass.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:295-308` - `stats.created_*++` under `iflags & ITEM_IS_NEW`.
+    pub created_stats: CreatedStats,
     /// Accumulated I/O error flags from file list building and transfer.
     ///
     /// Uses [`crate::generator::io_error_flags`] constants. When `IOERR_VANISHED`

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -330,6 +330,7 @@ impl GeneratorContext {
             flist_xfertime_ms: flist_xfertime,
             flist_first_byte_latency: self.timing.flist_first_byte_latency,
             delete_stats: self.delete_stats,
+            created_stats: transfer_result.created_stats,
             io_error: self.io_error,
         })
     }

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -128,6 +128,10 @@ impl GeneratorContext {
         // per token as the sender emits the delta stream.
         let mut matched_data = 0u64;
         let mut literal_data = 0u64;
+        // upstream: sender.c:295-308,333-334 - the sender reconstructs
+        // stats.created_* from the ITEM_IS_NEW iflags the receiver's generator
+        // sends per file, keyed by the entry's mode. Never crosses the wire.
+        let mut created_stats = protocol::stats::CreatedStats::new();
         // upstream: io.c IO_BUFFER_SIZE (32KB)
         let mut stream_buf = Vec::with_capacity(32 * 1024);
 
@@ -404,6 +408,14 @@ impl GeneratorContext {
             }
 
             if !iflags.needs_transfer() {
+                // upstream: sender.c:293-309 - a non-transfer item that is new
+                // (ITEM_IS_NEW) bumps stats.created_files plus the per-type
+                // counter for its mode. This is how a pushed new directory,
+                // symlink, device, or FIFO reaches the "Number of created files"
+                // breakdown even though it carries no file data.
+                if iflags.raw() & ItemFlags::ITEM_IS_NEW != 0 && ndx < self.file_list.len() {
+                    created_stats.record(self.file_list[ndx].mode());
+                }
                 // upstream: sender.c:286-292 - non-transfer items still echo
                 // NDX + iflags + (optional xattr response) via write_ndx_and_attrs
                 // so the receiver can pair the response with its outstanding
@@ -459,6 +471,14 @@ impl GeneratorContext {
                     },
                     pending_xattr_response.as_mut(),
                 )?;
+                // upstream: sender.c:332-334 - the created_files++ for a new
+                // transfer item sits in the else (first-send) branch BEFORE the
+                // `if (!do_xfers)` dry-run continue, so a dry run counts created
+                // files too. A dry run never redoes a file, so every entry here
+                // is a first send.
+                if iflags.raw() & ItemFlags::ITEM_IS_NEW != 0 {
+                    created_stats.record(file_entry.mode());
+                }
                 // upstream: sender.c:395 - log_item(FCLIENT, file, iflags, NULL)
                 if let Some(cb) = itemize {
                     let name = file_entry.path().to_string_lossy();
@@ -493,6 +513,14 @@ impl GeneratorContext {
             // Honouring append here would skip reading those block sums and
             // desync the wire.
             let is_resend = sent_files.is_resend(ndx);
+
+            // upstream: sender.c:327-334 - the created_files++ lives in the
+            // `else` (first-send, not FLAG_FILE_SENT) branch, so a redo-pass
+            // resend never double-counts. A transferred file is always a
+            // regular file, so `record` classifies it as the derived reg count.
+            if !is_resend && iflags.raw() & ItemFlags::ITEM_IS_NEW != 0 {
+                created_stats.record(file_entry.mode());
+            }
 
             // upstream: sender.c:89-95 receive_sums() - in append mode the
             // receiver's generator writes only the sum_head, not the block
@@ -937,6 +965,7 @@ impl GeneratorContext {
             bytes_sent,
             matched_data,
             literal_data,
+            created_stats,
             ndx_read_codec,
             ndx_write_codec,
         })

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -298,6 +298,17 @@ pub struct ReceiverContext {
     /// before [`Self::read_expected_ndx_done`] expects the sender's NDX_DONE.
     /// `Cell` because the emit site runs behind a `&self` pipeline closure.
     pub(in crate::receiver) hardlink_follower_echoes: std::cell::Cell<usize>,
+    /// Per-type tally of entries this receiver created (destination absent
+    /// before the transfer), keyed by `ITEM_IS_NEW`. Reconstructs the
+    /// `--stats` "Number of created files" breakdown locally, exactly as
+    /// upstream's receiver does - the counts never cross the wire. Bumped at
+    /// each new-entry site (directory, symlink, device/FIFO, regular file, and
+    /// new hardlink followers) via [`Self::record_created`], then folded into
+    /// the returned `TransferStats`. `Cell` because most creation sites run
+    /// behind a `&self` receiver method.
+    ///
+    /// upstream: receiver.c:733-746 - `stats.created_*++` under `ITEM_IS_NEW`.
+    pub(in crate::receiver) created_stats: std::cell::Cell<protocol::stats::CreatedStats>,
     /// Extraneous-entry victims decided during the transfer walk for a
     /// `--delete-delay` run, awaiting execution after the transfer completes.
     ///
@@ -387,6 +398,7 @@ impl ReceiverContext {
             defer_itemize: false,
             itemize_rows: RefCell::new(BTreeMap::new()),
             hardlink_follower_echoes: std::cell::Cell::new(0),
+            created_stats: std::cell::Cell::new(protocol::stats::CreatedStats::new()),
             delayed_delete_victims: Vec::new(),
         }
     }

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -308,6 +308,20 @@ impl ReceiverContext {
             }
         }
 
+        // upstream: receiver.c:736-738 - every newly created directory
+        // (ITEM_IS_NEW) bumps stats.created_dirs, independent of itemize
+        // visibility, so the "Number of created files" dir sub-count is correct
+        // even without -i. Runs before (and separate from) the itemize gate
+        // below, which is skipped when the client did not request itemize output.
+        for ((idx, _, dir_path), is_new) in dir_entries.iter().zip(dir_was_new.iter()) {
+            if *is_new
+                && !failed_dir_paths.contains(dir_path)
+                && !skipped_existing_dirs.contains(dir_path)
+            {
+                self.record_created(self.file_list[*idx].mode());
+            }
+        }
+
         // upstream: generator.c:1480-1483 - emit per-directory itemize rows
         // after the mkdir pass and before metadata application, so the row
         // ordering matches upstream's recv_generator() pass over the flist.

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -89,8 +89,17 @@ impl ReceiverContext {
 
             let link_path = dest_dir.join(relative_path);
 
+            // Track whether the destination already existed (symlink or
+            // obstacle) before this create. Upstream only sets ITEM_IS_NEW - and
+            // thus only bumps stats.created_symlinks - when recv_generator's
+            // link_stat finds the destination absent (generator.c:1561,
+            // `statret < 0`); a re-pointed link or a replaced obstacle is a
+            // change, not a creation.
+            let mut dest_existed = false;
+
             // upstream: generator.c:1561 - quick_check_ok(FT_SYMLINK, ...)
             if let Ok(existing_target) = std::fs::read_link(&link_path) {
+                dest_existed = true;
                 if existing_target == *target {
                     // upstream: generator.c:1563 - even on the up-to-date branch
                     // `set_file_attrs(fname, file, &sx, NULL, maybe_ATTRS_REPORT)`
@@ -165,6 +174,7 @@ impl ReceiverContext {
             )
             .is_ok()
             {
+                dest_existed = true;
                 // SEC-1.f: when the sandbox is plumbed and the destination
                 // parent is the sandbox root, the obstacle stat goes through
                 // `fstatat(AT_SYMLINK_NOFOLLOW)` so a TOCTOU symlink swap on
@@ -299,6 +309,11 @@ impl ReceiverContext {
             // upstream: generator.c:1594 - itemize new symlink after creation
             let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
             let _ = self.emit_itemize(writer, &iflags, entry);
+            if !dest_existed {
+                // upstream: receiver.c:740-741 - a newly created symlink
+                // (destination was absent) bumps stats.created_symlinks.
+                self.record_created(entry.mode());
+            }
         }
         Ok(())
     }
@@ -376,8 +391,14 @@ impl ReceiverContext {
 
             let link_path = dest_dir.join(relative_path);
 
+            // Track whether the destination already existed before this create;
+            // only a truly absent destination is ITEM_IS_NEW and bumps
+            // stats.created_symlinks (upstream generator.c:1561, `statret < 0`).
+            let mut dest_existed = false;
+
             // upstream: generator.c:1561 - quick_check_ok(FT_SYMLINK, ...)
             if let Ok(existing_target) = std::fs::read_link(&link_path) {
+                dest_existed = true;
                 if existing_target == *target {
                     // upstream: generator.c:1563 - refresh metadata even when the
                     // link is already up-to-date so a stale mtime is corrected.
@@ -425,6 +446,7 @@ impl ReceiverContext {
                     }
                 }
             } else if fs::symlink_metadata(&link_path).is_ok() {
+                dest_existed = true;
                 // upstream: generator.c:2018-2020 atomic_create - back the old
                 // obstacle up before removal when --backup is set.
                 match self.backup_existing_before_replace(&link_path, relative_path, dest_dir) {
@@ -504,6 +526,11 @@ impl ReceiverContext {
             // upstream: generator.c:1594 - itemize new symlink after creation
             let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
             let _ = self.emit_itemize(writer, &iflags, entry);
+            if !dest_existed {
+                // upstream: receiver.c:740-741 - a newly created symlink
+                // (destination was absent) bumps stats.created_symlinks.
+                self.record_created(entry.mode());
+            }
         }
 
         if unsupported_skip {

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -98,7 +98,17 @@ impl ReceiverContext {
             // only its metadata is refreshed.
             let up_to_date = existing_special_matches(&node_path, entry, is_device);
 
+            // Whether the destination already existed before this create. Only a
+            // truly absent destination is ITEM_IS_NEW and bumps
+            // stats.created_devices / stats.created_specials; a same-type
+            // up-to-date node or a replaced wrong-type obstacle is not a
+            // creation (upstream generator.c:1651-1670, `statret < 0`). Probed
+            // before the obstacle unlink below so a replacement is not
+            // misclassified as new.
+            let mut dest_existed = up_to_date;
+
             if !up_to_date {
+                dest_existed = fs::symlink_metadata(&node_path).is_ok();
                 // upstream: generator.c:1667 - `else if (basis_dir[0] != NULL)`
                 // is reached only when the destination is absent (`statret !=
                 // 0`). An identical node in a `--compare-dest` basis leaves the
@@ -246,6 +256,12 @@ impl ReceiverContext {
                 let iflags =
                     ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
                 let _ = self.emit_itemize(writer, &iflags, entry);
+                if !dest_existed {
+                    // upstream: receiver.c:743-746 - a newly created device
+                    // (created_devices) or FIFO/socket (created_specials),
+                    // classified by mode.
+                    self.record_created(entry.mode());
+                }
             }
         }
         Ok(())

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -50,6 +50,28 @@ impl ReceiverContext {
         }
     }
 
+    /// Records one newly created entry (destination absent before the transfer)
+    /// against the receiver's per-type created tally, classifying it by the
+    /// entry's Unix mode bits.
+    ///
+    /// Call once per `ITEM_IS_NEW` entry - a new directory, symlink, device,
+    /// FIFO, or regular file - regardless of whether any file data moved and
+    /// regardless of `--itemize-changes` visibility. Upstream counts these in
+    /// the receiver independent of the `-i` gate, so the `--stats` breakdown is
+    /// correct even without itemize output. The tally is folded into the
+    /// returned `TransferStats` and never crosses the wire.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:733-746` - `stats.created_files++` plus the per-mode
+    ///   `created_dirs`/`created_symlinks`/`created_devices`/`created_specials`
+    ///   cascade under the `iflags & ITEM_IS_NEW` guard.
+    pub(in crate::receiver) fn record_created(&self, mode: u32) {
+        let mut stats = self.created_stats.get();
+        stats.record(mode);
+        self.created_stats.set(stats);
+    }
+
     /// Routes an already-formatted info line (itemize, skip notice) to the
     /// correct sink: a server receiver multiplexes it as `MSG_INFO`; a client
     /// receiver (pull) writes it directly to stdout.

--- a/crates/transfer/src/receiver/stats.rs
+++ b/crates/transfer/src/receiver/stats.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use protocol::stats::DeleteStats;
+use protocol::stats::{CreatedStats, DeleteStats};
 
 /// A single file-list entry captured for `--list-only` rendering.
 ///
@@ -112,6 +112,17 @@ pub struct TransferStats {
 
     /// Breakdown of extraneous items deleted at the destination (`--delete`).
     pub delete_stats: DeleteStats,
+
+    /// Per-type tally of entries created at the destination (destination absent
+    /// before the transfer), reconstructed locally from the `ITEM_IS_NEW`
+    /// itemize flags. Never sent over the wire - upstream recomputes the
+    /// "Number of created files" breakdown on the client from its own itemize
+    /// pass, and this mirrors that for a remote pull.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:733-746` - `stats.created_*++` under `ITEM_IS_NEW`.
+    pub created_stats: CreatedStats,
 
     /// Whether deletion was stopped due to `--max-delete` limit.
     ///

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -168,6 +168,7 @@ fn transfer_stats_has_incremental_fields() {
         directories_failed: 2,
         files_skipped: 5,
         delete_stats: DeleteStats::new(),
+        created_stats: protocol::stats::CreatedStats::new(),
         delete_limit_exceeded: false,
         literal_data: 0,
         matched_data: 0,

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -380,6 +380,14 @@ impl ReceiverContext {
                         | crate::generator::ItemFlags::ITEM_IS_NEW
                 }
             };
+            if base_iflags & crate::generator::ItemFlags::ITEM_IS_NEW != 0 {
+                // upstream: receiver.c:777-778 - a regular file being received
+                // whose destination was absent (ITEM_IS_NEW) bumps
+                // stats.created_files; reg is the implicit remainder of the
+                // "Number of created files" breakdown. Counts a new empty file
+                // too, since it is still requested and materialised.
+                self.record_created(entry.mode());
+            }
             // upstream: generator.c:1925-1937 - the generator emits the transfer
             // itemize right after write_ndx(ndx), in flist order. With
             // log_before_transfer (`!am_server`, i.e. client mode) the row is

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -291,6 +291,13 @@ impl ReceiverContext {
         }
         stats.metadata_errors = metadata_errors;
         stats.redo_count = redo_count;
+        // upstream: main.c:794-796 - count the pre-flight-created destination
+        // root (FLAG_DIR_CREATED -> ITEM_IS_NEW) as a created dir; oc mkdir's it
+        // out-of-band so the dir loop treats it as existing. See the incremental
+        // path for the full rationale.
+        if self.dest_root_created {
+            self.record_created(protocol::flist::FileType::Directory.to_mode_bits());
+        }
         // Fold the per-type created tally (dirs, symlinks, specials, and new
         // regular files) accumulated across the creation and transfer passes
         // into the returned stats so the client reconstructs the "Number of

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -291,6 +291,11 @@ impl ReceiverContext {
         }
         stats.metadata_errors = metadata_errors;
         stats.redo_count = redo_count;
+        // Fold the per-type created tally (dirs, symlinks, specials, and new
+        // regular files) accumulated across the creation and transfer passes
+        // into the returned stats so the client reconstructs the "Number of
+        // created files" breakdown. upstream: receiver.c:733-746.
+        stats.created_stats = self.created_stats.get();
 
         Ok(stats)
     }

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -82,6 +82,11 @@ impl ReceiverContext {
                     Some((is_new, iflags_raw)) => {
                         if is_new {
                             stats.directories_created += 1;
+                            // upstream: receiver.c:736-738 - a new directory
+                            // (ITEM_IS_NEW) bumps stats.created_dirs. Counts the
+                            // pre-flight-mkdir'd transfer root too, so the
+                            // "Number of created files" dir sub-count matches.
+                            self.record_created(file_entry.mode());
                         }
                         // upstream: generator.c:1480-1483 - itemize each dir with
                         // the flags computed against its pre-apply stat. A new dir
@@ -282,6 +287,11 @@ impl ReceiverContext {
         }
         stats.metadata_errors = metadata_errors;
         stats.redo_count = redo_count;
+        // Fold the per-type created tally accumulated across the directory,
+        // symlink, special, and file-transfer passes into the returned stats so
+        // the client reconstructs the "Number of created files" breakdown.
+        // upstream: receiver.c:733-746 - stats.created_* accumulated locally.
+        stats.created_stats = self.created_stats.get();
 
         // Drain the deferred itemize rows in flist-index order before the
         // goodbye handshake, matching upstream's single-pass emission ordering.

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -287,6 +287,16 @@ impl ReceiverContext {
         }
         stats.metadata_errors = metadata_errors;
         stats.redo_count = redo_count;
+        // upstream: main.c:794-796 - the pre-flight mkdir of the destination
+        // root sets FLAG_DIR_CREATED on flist[0], so the generator itemizes it
+        // with ITEM_IS_NEW and receiver.c:736-738 counts created_dirs for it.
+        // oc creates the root out-of-band (ensure_dest_root_exists), so the root
+        // entry is seen as "existing" in the dir loop above and not counted
+        // there; count it here so the created-dir total includes the synthesized
+        // root (dir:N+1 for a pull into a fresh directory), matching upstream.
+        if self.dest_root_created {
+            self.record_created(protocol::flist::FileType::Directory.to_mode_bits());
+        }
         // Fold the per-type created tally accumulated across the directory,
         // symlink, special, and file-transfer passes into the returned stats so
         // the client reconstructs the "Number of created files" breakdown.

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -584,6 +584,10 @@ impl ReceiverContext {
             directories_failed: 0,
             files_skipped: 0,
             delete_stats: DeleteStats::new(),
+            // Fold the per-type created tally reconstructed from ITEM_IS_NEW so
+            // the client renders the "Number of created files" breakdown.
+            // upstream: receiver.c:733-746.
+            created_stats: self.created_stats.get(),
             delete_limit_exceeded: false,
             literal_data: 0,
             matched_data: 0,

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -568,6 +568,13 @@ impl ReceiverContext {
 
         let total_source_bytes: u64 = self.file_list.iter().map(|e| e.size()).sum();
 
+        // upstream: main.c:794-796 - count the pre-flight-created destination
+        // root as a created dir (FLAG_DIR_CREATED -> ITEM_IS_NEW). See the
+        // incremental path for the full rationale.
+        if self.dest_root_created {
+            self.record_created(protocol::flist::FileType::Directory.to_mode_bits());
+        }
+
         Ok(TransferStats {
             files_listed: file_count,
             files_transferred,

--- a/crates/transfer/tests/incremental_transfer.rs
+++ b/crates/transfer/tests/incremental_transfer.rs
@@ -7,7 +7,7 @@
 
 mod wire_format_generator;
 
-use protocol::stats::DeleteStats;
+use protocol::stats::{CreatedStats, DeleteStats};
 use transfer::receiver::TransferStats;
 use wire_format_generator::{
     generate_flat_directory, generate_nested_directories, generate_out_of_order_entries,
@@ -30,6 +30,7 @@ fn transfer_stats_incremental_fields_exist() {
         directories_failed: 1,
         files_skipped: 2,
         delete_stats: DeleteStats::new(),
+        created_stats: CreatedStats::new(),
         delete_limit_exceeded: false,
         literal_data: 0,
         matched_data: 0,


### PR DESCRIPTION
## Summary

Remote (ssh + daemon) transfers reported a wrong or missing per-type
`Number of created files` breakdown in `--stats`. This reconstructs it on the
client from the itemize stream, matching upstream rsync 3.4.4 byte-for-byte.

## Upstream behaviour

Upstream never sends `stats.created_*` over the wire. `main.c` `handle_stats()`
only exchanges `total_read` / `total_written` / `total_size` (and the `--delete`
counters via `NDX_DEL_STATS`). The client reconstructs the created breakdown
from its own itemize pass: every entry whose iflags carry `ITEM_IS_NEW` bumps
`stats.created_files` plus the per-type counter keyed by the entry's mode:

- `receiver.c:733-746` (client is receiver / pull)
- `sender.c:295-308,333-334` (client is sender / push)
- `main.c:387-416` `output_itemized_counts()` renders
  `Number of created files: N (reg: X, dir: Y, link: Z, dev: W, special: V)`;
  `reg` is the derived remainder `total - (dir + link + dev + special)`.
- `main.c:794-796`: the pre-flight mkdir of the destination root sets
  `FLAG_DIR_CREATED` on `flist[0]`, so the root is itemized `ITEM_IS_NEW` and
  counted as a created dir.

## The gap

The local-copy path already reconstructs this. The remote path did not: the
client summary hard-coded `created_regular_files = files_transferred` (an
over-count that also counts in-place updates of pre-existing files) and left
`dir` / `link` / `dev` / `special` at zero.

## Fix

- New `protocol::stats::CreatedStats` accumulator (client-local, never wire),
  classifying each `ITEM_IS_NEW` entry by mode exactly as upstream (regular ->
  derived remainder, dir, symlink, block/char device -> `dev`,
  FIFO/socket/other -> `special`).
- Pull: the receiver tallies new directories, symlinks, devices/FIFOs and
  regular files at each creation site, folded into `TransferStats`. Guards keep
  a re-pointed symlink or a replaced obstacle from being miscounted as new, and
  the pre-flight-created destination root is counted as a created dir.
- Push: the sender tallies created entries from the `ITEM_IS_NEW` iflags read off
  the wire, in both the non-transfer and first-send transfer branches (including
  dry-run), folded into `GeneratorStats`.
- `from_receiver_stats` / `from_generator_stats` map the per-type counts into the
  client summary; the existing render path already prints the breakdown.
- `--read-batch` replay preserves its prior figure (no per-entry stream exists).

## Real-binary verification (x86_64, upstream rsync 3.4.4 daemon peer)

Source: 3 nested new dirs, 2 symlinks, 3 empty files, 1 data file.

```
PUSH
  upstream: Number of created files: 9 (reg: 4, dir: 3, link: 2)
  oc-rsync: Number of created files: 9 (reg: 4, dir: 3, link: 2)

PULL (dest root newly created)
  upstream: Number of created files: 10 (reg: 4, dir: 4, link: 2)
  oc-rsync: Number of created files: 10 (reg: 4, dir: 4, link: 2)

PULL (dest root pre-existing)
  upstream: Number of created files: 9 (reg: 4, dir: 3, link: 2)
  oc-rsync: Number of created files: 9 (reg: 4, dir: 3, link: 2)
```

## Tests

- `protocol::stats::CreatedStats` mode-classification unit tests (each S_IF*
  type, plus the unrecognised-mode -> special fallback).
- `from_receiver_stats` / `from_generator_stats` per-type mapping tests verifying
  `reg` is derived and `files_transferred` no longer leaks into the created reg
  count.
- `cargo clippy` clean and `cargo nextest` (19,359 tests) green for `protocol`,
  `transfer`, `engine`, `core`, `cli` on x86_64.
