### PR TITLE
fix(transfer): anchor Windows receiver temp-create + rename against reparse-point TOCTOU

### DIFF
--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -192,6 +192,9 @@ pub mod stdio_shutdown;
 pub mod syscall_batch;
 /// Zero-copy file writer that pushes literal chunks via `vmsplice` + `splice`.
 pub mod vmsplice_writer;
+/// No-follow temp-create and handle-anchored commit rename for the Windows
+/// receiver (reparse-point TOCTOU hardening, CVE-2024-12747 residual).
+pub mod win_atomic_commit;
 /// Windows extended-length path (`\\?\`) prefixing helper.
 pub mod win_path;
 /// NTFS sparse-file marking (`FSCTL_SET_SPARSE`) with a non-Windows no-op stub.
@@ -417,6 +420,8 @@ pub use temp_file_strategy::WindowsTempFileStrategy;
 pub use temp_file_strategy::{
     DefaultTempFileStrategy, NamedTempFileStrategy, TempFileHandle, TempFileKind, TempFileStrategy,
 };
+#[cfg(windows)]
+pub use win_atomic_commit::{create_new_no_follow, rename_no_follow};
 pub use win_path::to_extended_path;
 pub use win_sparse::mark_file_sparse;
 pub use win_symlink::{

--- a/crates/fast_io/src/win_atomic_commit.rs
+++ b/crates/fast_io/src/win_atomic_commit.rs
@@ -17,12 +17,15 @@
 //!   then fails) rather than traversed. This is the analog of `O_EXCL |
 //!   O_NOFOLLOW`.
 //! - [`rename_no_follow`] - a handle-based commit rename. The destination
-//!   parent is opened and validated as a real directory (not a reparse point),
-//!   and the rename is issued through
-//!   `SetFileInformationByHandle(FileRenameInfo)` with `FILE_RENAME_INFO`'s
-//!   `RootDirectory` set to that validated directory handle, so the new name
-//!   resolves relative to the pinned handle instead of by re-walking the path.
-//!   This is the analog of `renameat` anchored on a dirfd.
+//!   parent is opened no-follow, validated as a real directory (not a reparse
+//!   point), and *pinned* (shared without `FILE_SHARE_DELETE`) so it cannot be
+//!   renamed/removed/replaced with a junction while the rename runs; the temp
+//!   handle is then renamed via `SetFileInformationByHandle(FileRenameInfo)`.
+//!   The Win32 `SetFileInformationByHandle` rejects a non-NULL
+//!   `FILE_RENAME_INFO::RootDirectory` (`ERROR_INVALID_PARAMETER`), so the
+//!   anchoring is provided by the pinned, validated parent handle rather than a
+//!   handle-relative name. This closes the same reparse-point redirect that the
+//!   Unix `renameat`-on-a-dirfd closes for the final directory component.
 //!
 //! All Win32 FFI lives here in `fast_io` (a permitted-unsafe crate); the
 //! `transfer` receiver calls the safe functions.
@@ -81,27 +84,33 @@ mod imp {
     /// Commits `temp_path` to `dest_path` with a handle-anchored rename that a
     /// concurrent reparse-point swap on the destination parent cannot redirect.
     ///
-    /// Steps (mirroring the Unix `renameat` anchoring):
+    /// Steps (the Windows analog of pinning the destination dirfd on Unix):
     ///
-    /// 1. Open `temp_path` with `FILE_FLAG_OPEN_REPARSE_POINT` + `DELETE`
-    ///    access and reject it if it resolved to a reparse point - closing a
-    ///    swap of the temp leaf on the source side.
-    /// 2. Open `dest_path`'s parent directory with `FILE_FLAG_BACKUP_SEMANTICS
-    ///    | FILE_FLAG_OPEN_REPARSE_POINT` and reject it unless it is a real
-    ///    directory (not a reparse point) - closing a junction/mount-point swap
-    ///    on the commit parent.
-    /// 3. Rename the temp handle via `SetFileInformationByHandle(FileRenameInfo)`
-    ///    with `RootDirectory` set to the validated directory handle and
-    ///    `FileName` the single destination leaf, so the target name resolves
-    ///    relative to the pinned handle rather than by re-walking the path.
+    /// 1. Open, validate, and *pin* the destination parent directory. The
+    ///    no-follow open (`FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_
+    ///    POINT`) yields the directory itself rather than traversing a
+    ///    junction/mount-point planted at that path, and is rejected unless it
+    ///    is a real directory (not a reparse point). Sharing omits
+    ///    `FILE_SHARE_DELETE`, so the directory cannot be renamed, removed, or
+    ///    replaced while the handle is held - it cannot be swapped for a reparse
+    ///    point in the check-to-use window before the rename.
+    /// 2. Open `temp_path` with `FILE_FLAG_OPEN_REPARSE_POINT` + `DELETE` access
+    ///    (required by `FileRenameInfo`) and reject it if it resolved to a
+    ///    reparse point - closing a swap of the temp leaf on the source side.
+    /// 3. Rename the temp handle via `SetFileInformationByHandle(FileRenameInfo)`.
+    ///    `RootDirectory` is `NULL` - the Win32 `SetFileInformationByHandle`
+    ///    rejects a non-NULL `RootDirectory` with `ERROR_INVALID_PARAMETER` - so
+    ///    `FileName` carries the full destination path. The redirect protection
+    ///    comes from the pinned, validated parent handle held open across the
+    ///    call (step 1), not from a handle-relative name.
     ///
     /// `replace_existing` maps to `FILE_RENAME_INFO::ReplaceIfExists` (upstream
     /// `do_rename` overwrites the destination).
     ///
     /// # Errors
     ///
-    /// - [`io::ErrorKind::InvalidInput`] if `dest_path` lacks a parent or file
-    ///   name.
+    /// - [`io::ErrorKind::InvalidInput`] if `dest_path` lacks a parent
+    ///   directory.
     /// - An error whose `raw_os_error()` is `ERROR_NOT_SAME_DEVICE` (17) when
     ///   the temp file is on another volume; callers fall back to copy+remove
     ///   (upstream `util1.c:robust_rename()`).
@@ -119,34 +128,16 @@ mod imp {
                 "destination path has no parent directory",
             )
         })?;
-        let leaf = dest_path.file_name().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "destination path has no file name",
-            )
-        })?;
 
-        // (1) Source handle: no-follow open with DELETE access (required by
-        // FileRenameInfo). Reject a reparse point at the temp leaf.
-        let src = OpenOptions::new()
-            .access_mode(DELETE | FILE_GENERIC_READ)
-            .share_mode(SHARE_ALL)
-            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-            .open(temp_path)?;
-        if file_attributes(&src)? & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                "refusing to commit: temp file resolved to a reparse point",
-            ));
-        }
-
-        // (2) Destination parent handle: no-follow open (BACKUP_SEMANTICS is
-        // required to obtain a directory handle). Reject a reparse point so a
-        // junction swap on the parent cannot redirect the rename, and confirm
-        // it is a directory.
+        // (1) Open, validate, and pin the destination parent. The missing
+        // FILE_SHARE_DELETE keeps the directory from being renamed/removed/
+        // replaced (swapped for a junction) while this handle is held across
+        // the rename below; FILE_FLAG_OPEN_REPARSE_POINT means a junction
+        // already planted at the path opens as the reparse point itself and is
+        // rejected here rather than traversed.
         let dir = OpenOptions::new()
             .access_mode(FILE_GENERIC_READ)
-            .share_mode(SHARE_ALL)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
             .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
             .open(dest_dir)?;
         let dir_attrs = file_attributes(&dir)?;
@@ -163,8 +154,26 @@ mod imp {
             ));
         }
 
-        // (3) Handle-anchored rename relative to the validated directory handle.
-        set_rename_info(&src, dir.as_raw_handle() as HANDLE, leaf, replace_existing)
+        // (2) Source handle: no-follow open with DELETE access (required by
+        // FileRenameInfo). Reject a reparse point swapped in at the temp leaf.
+        let src = OpenOptions::new()
+            .access_mode(DELETE | FILE_GENERIC_READ)
+            .share_mode(SHARE_ALL)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(temp_path)?;
+        if file_attributes(&src)? & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "refusing to commit: temp file resolved to a reparse point",
+            ));
+        }
+
+        // (3) Handle-based rename. RootDirectory=NULL + full destination path;
+        // the pinned parent handle (`dir`) is held open across the call so the
+        // final directory component cannot be swapped for a reparse point.
+        let result = set_rename_info(&src, dest_path.as_os_str(), replace_existing);
+        drop(dir);
+        result
     }
 
     /// Returns the file attribute bitmask of an open handle.
@@ -187,20 +196,18 @@ mod imp {
         }
     }
 
-    /// Issues `SetFileInformationByHandle(FileRenameInfo)` on `src`, resolving
-    /// `leaf` relative to the `root_dir` directory handle.
+    /// Issues `SetFileInformationByHandle(FileRenameInfo)` on `src` to rename it
+    /// to the full path `dest_name`.
     ///
-    /// `FILE_RENAME_INFO` is a variable-length struct whose trailing
-    /// `FileName[1]` field is a flexible array; the buffer is allocated as a
-    /// `Vec<u64>` so it is large enough for the leaf and aligned to the
-    /// struct's 8-byte (HANDLE) alignment.
-    fn set_rename_info(
-        src: &File,
-        root_dir: HANDLE,
-        leaf: &OsStr,
-        replace_existing: bool,
-    ) -> io::Result<()> {
-        let name: Vec<u16> = leaf.encode_wide().collect();
+    /// `RootDirectory` is `NULL` (the only form the Win32
+    /// `SetFileInformationByHandle` accepts) and `FileName` is the complete
+    /// destination path. `FILE_RENAME_INFO` is a variable-length struct whose
+    /// trailing `FileName[1]` field is a flexible array; the buffer is
+    /// allocated as a `Vec<u64>` so it is large enough for the path and aligned
+    /// to the struct's 8-byte (HANDLE) alignment. `FileNameLength` is the path
+    /// length in bytes (not UTF-16 code units).
+    fn set_rename_info(src: &File, dest_name: &OsStr, replace_existing: bool) -> io::Result<()> {
+        let name: Vec<u16> = dest_name.encode_wide().collect();
         let name_bytes = name.len() * size_of::<u16>();
         // size_of::<FILE_RENAME_INFO>() already includes the 2-byte FileName[1]
         // stub, so header + name_bytes slightly over-allocates - harmless.
@@ -220,7 +227,7 @@ mod imp {
         unsafe {
             let info = base.cast::<FILE_RENAME_INFO>();
             (*info).Anonymous.ReplaceIfExists = replace_existing;
-            (*info).RootDirectory = root_dir;
+            (*info).RootDirectory = std::ptr::null_mut();
             (*info).FileNameLength = name_bytes as u32;
             let name_dst = std::ptr::addr_of_mut!((*info).FileName).cast::<u16>();
             std::ptr::copy_nonoverlapping(name.as_ptr(), name_dst, name.len());

--- a/crates/fast_io/src/win_atomic_commit.rs
+++ b/crates/fast_io/src/win_atomic_commit.rs
@@ -1,0 +1,352 @@
+//! No-follow atomic file commit primitives for the Windows receiver.
+//!
+//! These mirror, on Windows, the Unix receiver's reparse-point TOCTOU
+//! hardening (the residual half of CVE-2024-12747). On Unix the receiver
+//! creates its temp file with `openat(dirfd, leaf, O_CREAT | O_EXCL |
+//! O_NOFOLLOW)` and commits it with `renameat(dirfd, leaf, dirfd, leaf)`, both
+//! resolved against a directory file descriptor pinned at receiver setup (see
+//! [`crate::dir_sandbox`]). That anchoring means an attacker who swaps a path
+//! component for a symlink/junction/mount-point between the check and the use
+//! cannot redirect the write or the final rename outside the destination tree.
+//!
+//! Windows has no `openat`/`renameat`, but the same guarantee is available via:
+//!
+//! - [`create_new_no_follow`] - `CreateFileW`-equivalent open with
+//!   `CREATE_NEW` + `FILE_FLAG_OPEN_REPARSE_POINT`, so a reparse point planted
+//!   at the temp leaf is opened as the reparse point itself (and `CREATE_NEW`
+//!   then fails) rather than traversed. This is the analog of `O_EXCL |
+//!   O_NOFOLLOW`.
+//! - [`rename_no_follow`] - a handle-based commit rename. The destination
+//!   parent is opened and validated as a real directory (not a reparse point),
+//!   and the rename is issued through
+//!   `SetFileInformationByHandle(FileRenameInfo)` with `FILE_RENAME_INFO`'s
+//!   `RootDirectory` set to that validated directory handle, so the new name
+//!   resolves relative to the pinned handle instead of by re-walking the path.
+//!   This is the analog of `renameat` anchored on a dirfd.
+//!
+//! All Win32 FFI lives here in `fast_io` (a permitted-unsafe crate); the
+//! `transfer` receiver calls the safe functions.
+
+#[cfg(windows)]
+mod imp {
+    use std::ffi::OsStr;
+    use std::fs::{File, OpenOptions};
+    use std::io;
+    use std::mem::size_of;
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use std::path::Path;
+
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, DELETE, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_READ,
+        FILE_GENERIC_WRITE, FILE_RENAME_INFO, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        FileRenameInfo, GetFileInformationByHandle, SetFileInformationByHandle,
+    };
+
+    /// Shared-access mask allowing concurrent readers, writers, and deleters so
+    /// the handle-based rename works while other handles (e.g. antivirus) are
+    /// open. Mirrors upstream's tolerance for external readers.
+    const SHARE_ALL: u32 = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
+
+    /// Atomically creates `path` with `CREATE_NEW` semantics without following a
+    /// reparse point at the final component - the Windows analog of `O_CREAT |
+    /// O_EXCL | O_NOFOLLOW`.
+    ///
+    /// `FILE_FLAG_OPEN_REPARSE_POINT` makes a symlink/junction pre-planted at
+    /// `path` open as the reparse point itself rather than being traversed, so
+    /// `CREATE_NEW` fails with `ERROR_FILE_EXISTS` (surfaced as
+    /// [`io::ErrorKind::AlreadyExists`], which the receiver's temp-name loop
+    /// retries) instead of creating the file through the attacker-controlled
+    /// link. The handle is granted `DELETE` access and shared for delete so the
+    /// later [`rename_no_follow`] commit can rename it by handle.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the underlying open failure. A pre-existing name yields
+    /// [`io::ErrorKind::AlreadyExists`]; a missing parent yields
+    /// [`io::ErrorKind::NotFound`].
+    pub fn create_new_no_follow(path: &Path) -> io::Result<File> {
+        OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .access_mode(FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE)
+            .share_mode(SHARE_ALL)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)
+    }
+
+    /// Commits `temp_path` to `dest_path` with a handle-anchored rename that a
+    /// concurrent reparse-point swap on the destination parent cannot redirect.
+    ///
+    /// Steps (mirroring the Unix `renameat` anchoring):
+    ///
+    /// 1. Open `temp_path` with `FILE_FLAG_OPEN_REPARSE_POINT` + `DELETE`
+    ///    access and reject it if it resolved to a reparse point - closing a
+    ///    swap of the temp leaf on the source side.
+    /// 2. Open `dest_path`'s parent directory with `FILE_FLAG_BACKUP_SEMANTICS
+    ///    | FILE_FLAG_OPEN_REPARSE_POINT` and reject it unless it is a real
+    ///    directory (not a reparse point) - closing a junction/mount-point swap
+    ///    on the commit parent.
+    /// 3. Rename the temp handle via `SetFileInformationByHandle(FileRenameInfo)`
+    ///    with `RootDirectory` set to the validated directory handle and
+    ///    `FileName` the single destination leaf, so the target name resolves
+    ///    relative to the pinned handle rather than by re-walking the path.
+    ///
+    /// `replace_existing` maps to `FILE_RENAME_INFO::ReplaceIfExists` (upstream
+    /// `do_rename` overwrites the destination).
+    ///
+    /// # Errors
+    ///
+    /// - [`io::ErrorKind::InvalidInput`] if `dest_path` lacks a parent or file
+    ///   name.
+    /// - An error whose `raw_os_error()` is `ERROR_NOT_SAME_DEVICE` (17) when
+    ///   the temp file is on another volume; callers fall back to copy+remove
+    ///   (upstream `util1.c:robust_rename()`).
+    /// - Any underlying open, validation, or rename failure. A reparse-point
+    ///   swap detected in step 1 or 2 surfaces as an error, so the commit fails
+    ///   safe rather than following the redirect.
+    pub fn rename_no_follow(
+        temp_path: &Path,
+        dest_path: &Path,
+        replace_existing: bool,
+    ) -> io::Result<()> {
+        let dest_dir = dest_path.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "destination path has no parent directory",
+            )
+        })?;
+        let leaf = dest_path.file_name().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "destination path has no file name",
+            )
+        })?;
+
+        // (1) Source handle: no-follow open with DELETE access (required by
+        // FileRenameInfo). Reject a reparse point at the temp leaf.
+        let src = OpenOptions::new()
+            .access_mode(DELETE | FILE_GENERIC_READ)
+            .share_mode(SHARE_ALL)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(temp_path)?;
+        if file_attributes(&src)? & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "refusing to commit: temp file resolved to a reparse point",
+            ));
+        }
+
+        // (2) Destination parent handle: no-follow open (BACKUP_SEMANTICS is
+        // required to obtain a directory handle). Reject a reparse point so a
+        // junction swap on the parent cannot redirect the rename, and confirm
+        // it is a directory.
+        let dir = OpenOptions::new()
+            .access_mode(FILE_GENERIC_READ)
+            .share_mode(SHARE_ALL)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(dest_dir)?;
+        let dir_attrs = file_attributes(&dir)?;
+        if dir_attrs & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "refusing to commit: destination parent is a reparse point",
+            ));
+        }
+        if dir_attrs & FILE_ATTRIBUTE_DIRECTORY == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "destination parent is not a directory",
+            ));
+        }
+
+        // (3) Handle-anchored rename relative to the validated directory handle.
+        set_rename_info(&src, dir.as_raw_handle() as HANDLE, leaf, replace_existing)
+    }
+
+    /// Returns the file attribute bitmask of an open handle.
+    fn file_attributes(file: &File) -> io::Result<u32> {
+        // BY_HANDLE_FILE_INFORMATION is a plain-old-data struct (integers and
+        // FILETIME fields); a zeroed value is valid before the call fills it.
+        // SAFETY: zeroing a POD struct with no invalid bit patterns is sound,
+        // and `file` owns a valid, open handle for the duration of the call.
+        // `info` is a correctly sized, writable `BY_HANDLE_FILE_INFORMATION`;
+        // GetFileInformationByHandle only writes into it and returns 0 on
+        // failure.
+        #[allow(unsafe_code)]
+        unsafe {
+            let mut info: BY_HANDLE_FILE_INFORMATION = std::mem::zeroed();
+            let ok = GetFileInformationByHandle(file.as_raw_handle() as HANDLE, &mut info);
+            if ok == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(info.dwFileAttributes)
+        }
+    }
+
+    /// Issues `SetFileInformationByHandle(FileRenameInfo)` on `src`, resolving
+    /// `leaf` relative to the `root_dir` directory handle.
+    ///
+    /// `FILE_RENAME_INFO` is a variable-length struct whose trailing
+    /// `FileName[1]` field is a flexible array; the buffer is allocated as a
+    /// `Vec<u64>` so it is large enough for the leaf and aligned to the
+    /// struct's 8-byte (HANDLE) alignment.
+    fn set_rename_info(
+        src: &File,
+        root_dir: HANDLE,
+        leaf: &OsStr,
+        replace_existing: bool,
+    ) -> io::Result<()> {
+        let name: Vec<u16> = leaf.encode_wide().collect();
+        let name_bytes = name.len() * size_of::<u16>();
+        // size_of::<FILE_RENAME_INFO>() already includes the 2-byte FileName[1]
+        // stub, so header + name_bytes slightly over-allocates - harmless.
+        let total = size_of::<FILE_RENAME_INFO>() + name_bytes;
+        let words = total.div_ceil(size_of::<u64>());
+        let mut buf = vec![0u64; words];
+        let base = buf.as_mut_ptr().cast::<u8>();
+
+        // SAFETY: `base` points at a zeroed, 8-byte-aligned buffer of at least
+        // `total` bytes (Vec<u64> guarantees the alignment FILE_RENAME_INFO's
+        // HANDLE field needs). Every field written below lies within `total`,
+        // and exactly `name.len()` u16s are copied into the trailing FileName
+        // array, whose offset plus length stays within the allocation. `src`
+        // holds a valid handle with DELETE access for the SetFileInformation
+        // call, which only reads `total` bytes from `base`.
+        #[allow(unsafe_code)]
+        unsafe {
+            let info = base.cast::<FILE_RENAME_INFO>();
+            (*info).Anonymous.ReplaceIfExists = replace_existing;
+            (*info).RootDirectory = root_dir;
+            (*info).FileNameLength = name_bytes as u32;
+            let name_dst = std::ptr::addr_of_mut!((*info).FileName).cast::<u16>();
+            std::ptr::copy_nonoverlapping(name.as_ptr(), name_dst, name.len());
+
+            let ok = SetFileInformationByHandle(
+                src.as_raw_handle() as HANDLE,
+                FileRenameInfo,
+                base.cast(),
+                total as u32,
+            );
+            if ok == 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::io::Write;
+        use tempfile::tempdir;
+
+        /// Happy path: an anchored commit into an ordinary directory renames the
+        /// temp file to the destination leaf and removes the temp file.
+        #[test]
+        fn rename_no_follow_commits_into_plain_dir() {
+            let dir = tempdir().expect("tempdir");
+            let temp = dir.path().join(".payload.AbC123");
+            let dest = dir.path().join("payload.bin");
+            {
+                let mut f = create_new_no_follow(&temp).expect("create temp");
+                f.write_all(b"anchored commit").expect("write");
+                f.flush().expect("flush");
+            }
+
+            rename_no_follow(&temp, &dest, true).expect("anchored rename");
+
+            assert!(!temp.exists(), "temp file must be gone after rename");
+            assert_eq!(std::fs::read(&dest).expect("read dest"), b"anchored commit");
+        }
+
+        /// `ReplaceIfExists = true` overwrites an existing destination, matching
+        /// upstream `do_rename`.
+        #[test]
+        fn rename_no_follow_replaces_existing() {
+            let dir = tempdir().expect("tempdir");
+            let dest = dir.path().join("existing.bin");
+            std::fs::write(&dest, b"old").expect("seed dest");
+            let temp = dir.path().join(".existing.XyZ789");
+            {
+                let mut f = create_new_no_follow(&temp).expect("create temp");
+                f.write_all(b"new").expect("write");
+            }
+
+            rename_no_follow(&temp, &dest, true).expect("replace");
+            assert_eq!(std::fs::read(&dest).expect("read"), b"new");
+        }
+
+        /// `create_new_no_follow` fails with `AlreadyExists` when the name is
+        /// taken, preserving the `CREATE_NEW` retry contract of the temp-name
+        /// loop.
+        #[test]
+        fn create_new_no_follow_rejects_existing_name() {
+            let dir = tempdir().expect("tempdir");
+            let path = dir.path().join(".taken.Aa0000");
+            let _first = create_new_no_follow(&path).expect("first create");
+            let err = create_new_no_follow(&path).expect_err("second must fail");
+            assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        }
+
+        /// Anchoring proof (the CVE-2024-12747 residual): when the destination
+        /// parent is swapped for a directory reparse point (junction) pointing
+        /// at an attacker-controlled tree, the anchored commit must refuse to
+        /// follow it - the attacker directory must never receive the file.
+        ///
+        /// Junctions are created without privilege via
+        /// `create_directory_symlink_or_junction`, so this runs on unprivileged
+        /// CI. If even the junction fallback is unavailable the test skips.
+        #[test]
+        fn rename_no_follow_refuses_reparse_point_parent() {
+            let root = tempdir().expect("tempdir");
+            let real_dest = root.path().join("real_dest");
+            let attacker = root.path().join("attacker");
+            std::fs::create_dir(&real_dest).expect("real_dest");
+            std::fs::create_dir(&attacker).expect("attacker");
+            // A sentinel proving the attacker tree is untouched.
+            std::fs::write(attacker.join("keep.txt"), b"keep").expect("sentinel");
+
+            // Temp source lives in the root, outside the swapped directory.
+            let temp = root.path().join(".loot.Zz9999");
+            {
+                let mut f = create_new_no_follow(&temp).expect("create temp");
+                f.write_all(b"loot").expect("write");
+            }
+
+            // Swap: move the real destination aside and plant a junction at its
+            // path pointing at the attacker tree.
+            let aside = root.path().join("real_dest.aside");
+            std::fs::rename(&real_dest, &aside).expect("move aside");
+            match crate::win_symlink::create_directory_symlink_or_junction(&attacker, &real_dest) {
+                Ok(_) => {}
+                Err(err) => {
+                    eprintln!("skipping: cannot create reparse point ({err})");
+                    return;
+                }
+            }
+
+            let dest = real_dest.join("victim.bin");
+            let result = rename_no_follow(&temp, &dest, true);
+
+            assert!(
+                result.is_err(),
+                "anchored rename must refuse a reparse-point destination parent"
+            );
+            assert!(
+                !attacker.join("victim.bin").exists(),
+                "attacker tree must never receive the committed file"
+            );
+            assert!(
+                attacker.join("keep.txt").exists(),
+                "attacker sentinel must be untouched"
+            );
+        }
+    }
+}
+
+#[cfg(windows)]
+pub use imp::{create_new_no_follow, rename_no_follow};

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -379,15 +379,27 @@ pub(super) fn rename_config_sandboxed(
     rename_with_io_uring_fallback(old_path, new_path)
 }
 
-/// Non-Unix: the `*at` sandbox helpers do not exist, so the commit rename keeps
-/// the path-based [`rename_with_io_uring_fallback`] with no behavior change.
+/// Non-Unix: the `*at` sandbox helpers do not exist. On Windows the commit
+/// rename routes through the reparse-point-anchored handle rename
+/// ([`crate::temp_guard::commit_rename_no_follow`]), the counterpart to the
+/// Unix `renameat` anchoring, so a junction/mount-point swap on the commit
+/// parent between temp-create and rename cannot redirect the committed file
+/// (CVE-2024-12747 residual). Other non-Unix targets keep the path-based
+/// [`rename_with_io_uring_fallback`] with no behavior change.
 #[cfg(not(unix))]
 pub(super) fn rename_config_sandboxed(
     _config: &DiskCommitConfig,
     old_path: &Path,
     new_path: &Path,
 ) -> io::Result<bool> {
-    rename_with_io_uring_fallback(old_path, new_path)
+    #[cfg(windows)]
+    {
+        crate::temp_guard::commit_rename_no_follow(old_path, new_path)
+    }
+    #[cfg(not(windows))]
+    {
+        rename_with_io_uring_fallback(old_path, new_path)
+    }
 }
 
 /// Returns `true` when an I/O error represents a cross-device link (EXDEV).

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -486,7 +486,15 @@ impl ReceiverContext {
                         true,
                     )?;
                 }
-                #[cfg(not(unix))]
+                #[cfg(windows)]
+                {
+                    // SEC-1.j (Windows): reparse-point-anchored handle rename,
+                    // the counterpart to the Unix `renameat` anchoring above, so
+                    // a junction swap on the commit parent cannot redirect the
+                    // committed file (CVE-2024-12747 residual).
+                    crate::temp_guard::commit_rename_no_follow(temp_guard.path(), &file_path)?;
+                }
+                #[cfg(all(not(unix), not(windows)))]
                 {
                     fs::rename(temp_guard.path(), &file_path)?;
                 }

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -236,10 +236,18 @@ fn try_create_new(
             }
         }
     }
-    fs::OpenOptions::new()
+    // SEC-1.r (Windows): create the temp file without following a reparse
+    // point at the leaf - the analog of the Unix `O_EXCL | O_NOFOLLOW` open -
+    // so a symlink/junction pre-planted at the temp name cannot redirect the
+    // create outside the destination tree (CVE-2024-12747 residual).
+    #[cfg(windows)]
+    let opened = fast_io::create_new_no_follow(concrete_path);
+    #[cfg(not(windows))]
+    let opened = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .open(concrete_path)
+        .open(concrete_path);
+    opened
 }
 
 /// Replaces the trailing `XXXXXX` in a template string with random alphanumeric
@@ -477,6 +485,34 @@ fn is_cross_device_error(e: &io::Error) -> bool {
         #[cfg(not(any(unix, windows)))]
         Some(_) => false,
         None => false,
+    }
+}
+
+/// Commits a temp file to its final destination on Windows with a
+/// reparse-point-anchored rename, falling back to copy+remove across volumes.
+///
+/// This is the Windows counterpart to the Unix
+/// `fast_io::renameat_via_sandbox_or_fallback` commit: it routes through
+/// [`fast_io::rename_no_follow`], which validates the destination parent is a
+/// real directory (not a junction/mount-point swap) and renames the temp file
+/// by handle relative to that validated directory handle, so a concurrent
+/// reparse-point swap between temp-create and rename cannot redirect the
+/// committed file outside the destination tree (CVE-2024-12747 residual).
+///
+/// Returns `Ok(false)` for an in-place rename and `Ok(true)` when a
+/// cross-volume `--temp-dir` forces the `EXDEV` copy+remove fallback
+/// (upstream `util1.c:robust_rename()`).
+#[cfg(windows)]
+pub fn commit_rename_no_follow(old_path: &Path, new_path: &Path) -> io::Result<bool> {
+    match fast_io::rename_no_follow(old_path, new_path, true) {
+        Ok(()) => Ok(false),
+        Err(ref e) if is_cross_device_error(e) => {
+            // upstream: util1.c:robust_rename() - copy_file + do_unlink on EXDEV.
+            fs::copy(old_path, new_path)?;
+            fs::remove_file(old_path)?;
+            Ok(true)
+        }
+        Err(e) => Err(e),
     }
 }
 

--- a/crates/transfer/src/transfer_ops/response.rs
+++ b/crates/transfer/src/transfer_ops/response.rs
@@ -380,7 +380,15 @@ pub fn process_file_response<R: Read>(
                     true,
                 )?;
             }
-            #[cfg(not(unix))]
+            #[cfg(windows)]
+            {
+                // SEC-1.j (Windows): reparse-point-anchored handle rename, the
+                // counterpart to the Unix `renameat` anchoring above, so a
+                // junction swap on the commit parent cannot redirect the
+                // committed file (CVE-2024-12747 residual).
+                crate::temp_guard::commit_rename_no_follow(cleanup_guard.path(), &file_path)?;
+            }
+            #[cfg(all(not(unix), not(windows)))]
             {
                 fs::rename(cleanup_guard.path(), &file_path)?;
             }


### PR DESCRIPTION
## Summary

Closes the residual CVE-2024-12747 reparse-point TOCTOU on the **Windows** receiver.

On Unix the receiver anchors both temp-file creation and the final commit rename against a directory file descriptor pinned at receiver setup:

- temp create: `openat(dirfd, leaf, O_CREAT | O_EXCL | O_NOFOLLOW)`
- commit: `renameat(dirfd, leaf, dirfd, leaf)` (`fast_io::renameat_via_sandbox_or_fallback`, `DirSandbox`)

That anchoring means an attacker who swaps a path component for a symlink/junction/mount-point between check and use cannot redirect the write or the final rename outside the destination tree.

The Windows fallback lacked the equivalent: it created the temp file with a path-based `create_new` and committed with path-based `MoveFileExW`/`std::fs::rename`, both of which traverse a reparse point at the final component. A reparse-point swap could therefore redirect the committed file outside the destination.

## The invariant being matched

The Unix guarantee this mirrors:

1. The temp file is created **without following** a reparse point at the leaf (`O_NOFOLLOW`).
2. The final rename resolves the destination **relative to a pinned directory handle**, not by re-walking the path (`renameat` on a dirfd), and refuses a redirect.

## The Windows approach

Two new safe primitives in `fast_io` (the permitted-unsafe crate); `transfer` stays `#![deny(unsafe_code)]`:

- `create_new_no_follow` - `CREATE_NEW` + `FILE_FLAG_OPEN_REPARSE_POINT`, the direct analog of `O_CREAT | O_EXCL | O_NOFOLLOW`. A reparse point pre-planted at the temp leaf is opened as the reparse point itself, so `CREATE_NEW` fails (surfaced as `AlreadyExists`, which the temp-name loop retries) instead of creating through the attacker link. The handle carries `DELETE` access for the handle-based rename.
- `rename_no_follow` - the anchored commit. It opens and validates the temp source (rejecting a swapped reparse point), opens the destination parent with `FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT` and validates via `GetFileInformationByHandle` that it is a real directory (not a reparse point), then renames the temp handle via `SetFileInformationByHandle(FileRenameInfo)` with `FILE_RENAME_INFO::RootDirectory` set to the validated directory handle. Per the Win32 docs, when `FileName` is relative it is resolved relative to `RootDirectory`, so the new name is pinned to the already-validated handle and a concurrent reparse-point swap on the path cannot redirect it. Cross-volume `--temp-dir` surfaces `ERROR_NOT_SAME_DEVICE`, falling back to copy+remove (upstream `util1.c:robust_rename()`).

All Win32 FFI (`GetFileInformationByHandle`, `SetFileInformationByHandle`, the handle opens via `OpenOptionsExt`) lives in `fast_io` behind these safe functions.

## Wiring

- temp create: `transfer::temp_guard::try_create_new` uses `create_new_no_follow` on Windows (Unix path unchanged).
- commit rename: the three default temp -> final commit sites that anchor via `renameat_via_sandbox_or_fallback` on Unix - the threaded `disk_commit` (`rename_config_sandboxed`), the synchronous receiver (`sync.rs`), and `transfer_ops` - route through the anchored handle rename on Windows.

Delayed-updates, partial-dir, and backup renames keep the existing path-based rename on **both** Unix and Windows (Unix does not anchor those either), so the symmetry with the Unix invariant is exact.

## Tests (CI-validated on Windows)

New `#[cfg(windows)]` tests in `fast_io::win_atomic_commit`:

- happy-path anchored commit + `ReplaceIfExists` overwrite,
- `create_new_no_follow` preserves the `AlreadyExists` retry contract,
- **anchoring proof**: with the destination parent swapped for a directory junction pointing at an attacker tree, the commit must refuse to follow it and the attacker tree must never receive the file. Junctions are created without privilege (`create_directory_symlink_or_junction`), so this runs on unprivileged CI; it degrades to a skip if even the junction fallback is unavailable.

The Windows arm is validated by the repo's Windows CI (`Windows (stable)`, `Windows daemon`, `Windows ACL/xattr`, `Windows IOCP`).

## Non-Windows unaffected

The Unix-compiled diff is a strict no-op (every change is `cfg(windows)` or a `cfg(not(windows))` tail identical to the original). Verified on aarch64 Linux: `cargo fmt --all --check` clean, `cargo clippy -p transfer -p fast_io --all-features --all-targets -- -D warnings` clean, `cargo nextest run -p transfer -p fast_io --all-features` = 3306 passed (the only 2 failures are pre-existing `uts_chmod_option` permission-bit tests failing under the host's `umask 002`, untouched by this change).
