### PR TITLE
test(transfer): deterministic mid-commit-kill coverage for --remove-source-files defer-unlink

### DIFF
--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -5301,3 +5301,89 @@ fn remove_source_files_defers_until_msg_success() {
         "the genuine pending entry must remain until its own confirmation"
     );
 }
+
+/// A mid-commit connection drop must leave every not-yet-confirmed source in
+/// place while removing only the sources the peer already confirmed.
+///
+/// This models the adversarial mid-commit-kill: the receiver committed and
+/// acked the first file with `MSG_SUCCESS`, then the connection dropped before
+/// it could commit and ack the rest. The sender's deferred-unlink loop
+/// (orchestrator.rs `for wire_ndx in reader.take_success_indices()`) runs
+/// [`confirm_source_removal`](GeneratorContext::confirm_source_removal) only for
+/// the indices that actually arrived; every index whose `MSG_SUCCESS` never
+/// crossed the wire stays pending, so its source survives. Encodes the
+/// upstream crash-safety contract (sender.c:131-182 `successful_send()`): an
+/// interrupted transfer never deletes a source that did not safely land at the
+/// destination. The kill point is forced by choosing which confirmations are
+/// delivered - no sleeps, no race, fully deterministic.
+#[test]
+fn remove_source_files_mid_commit_teardown_retains_unconfirmed_sources() {
+    let temp = create_test_files(&[
+        ("a.txt", b"alpha"),
+        ("b.txt", b"bravo"),
+        ("c.txt", b"charlie"),
+    ]);
+    let a = temp.path().join("a.txt");
+    let b = temp.path().join("b.txt");
+    let c = temp.path().join("c.txt");
+
+    let (_h, mut ctx) = test_generator_for_path(&a, false);
+    ctx.config.args = vec![OsString::from(&a), OsString::from(&b), OsString::from(&c)];
+    ctx.config.flags.remove_source_files = true;
+    // Build the file list from the three real sources so each entry records the
+    // on-disk size+mtime that the successful_send changed-file guard re-checks.
+    ctx.build_file_list(&[a.clone(), b.clone(), c.clone()])
+        .expect("building the file list for three real files must succeed");
+
+    let file_flats: Vec<usize> = (0..ctx.file_list.len())
+        .filter(|&i| ctx.file_list[i].is_file())
+        .collect();
+    assert_eq!(
+        file_flats.len(),
+        3,
+        "three positional file sources produce three file entries"
+    );
+
+    // Confirm the harness maps each entry back to its real source path before
+    // asserting on removal, so a reconstruction fault can never masquerade as a
+    // benign vanished-source no-op.
+    let sources: Vec<PathBuf> = file_flats
+        .iter()
+        .map(|&flat| ctx.reconstruct_source_path(flat))
+        .collect();
+    for src in &sources {
+        assert!(src.exists(), "each source must exist before the transfer");
+    }
+
+    // The sender finished transmitting all three: every unlink is deferred.
+    for &flat in &file_flats {
+        ctx.pending_source_removals.mark_pending(flat);
+    }
+
+    // The receiver committed and acked only the first file, then the connection
+    // dropped: exactly one MSG_SUCCESS is consumed.
+    let wire_first = ctx.flat_to_wire_ndx(file_flats[0]);
+    assert_eq!(
+        ctx.confirm_source_removal(wire_first),
+        0,
+        "a clean removal sets no io_error bits"
+    );
+
+    assert!(
+        !sources[0].exists(),
+        "the confirmed source must be unlinked once its MSG_SUCCESS arrives"
+    );
+    assert!(
+        sources[1].exists(),
+        "a source whose commit was never confirmed must survive the teardown"
+    );
+    assert!(
+        sources[2].exists(),
+        "every unconfirmed source must survive the teardown"
+    );
+    assert_eq!(
+        ctx.pending_source_removals.len(),
+        2,
+        "the two unconfirmed removals stay pending after the drop"
+    );
+}

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -731,6 +731,126 @@ mod tests {
         drop(pr);
     }
 
+    /// A cleanly committed file is recorded for `MSG_SUCCESS` emission, and only
+    /// once, so the sender is told to unlink the source exactly one time.
+    ///
+    /// This is the receiver half of the `--remove-source-files` crash-safety
+    /// contract: `success_indices` is populated only inside `verify_checksum`
+    /// while draining a post-rename `CommitResult`, so recording an index here
+    /// means the file has durably landed at the destination. A refactor that
+    /// confirmed a source before the commit completed - the data-loss bug this
+    /// mechanism prevents - would have to add a second producer, which this test
+    /// would expose as an out-of-band success.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:1063-1069` - `send_msg_success(fname, ndx)` on `recv_ok == 1`.
+    #[test]
+    fn clean_commit_records_msg_success_once() {
+        use crate::pipeline::messages::ComputedChecksum;
+
+        let mut pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();
+
+        let mut expected = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+        expected[0] = 0xAA;
+        expected[1] = 0xBB;
+
+        pr.expected_checksums.push_back(PendingChecksum {
+            expected,
+            len: 4,
+            file_path: PathBuf::from("/dest/ok.txt"),
+            file_index: 9,
+        });
+
+        // A matching checksum on a committed (post-rename) result confirms the file.
+        let result = CommitResult {
+            bytes_written: 64,
+            file_entry_index: 0,
+            metadata_error: None,
+            computed_checksum: Some(ComputedChecksum {
+                bytes: expected,
+                len: 4,
+            }),
+            delayed_path: None,
+            backup_notice: None,
+        };
+
+        pr.verify_checksum(&result).unwrap();
+
+        // The confirmed index is queued so the caller emits MSG_SUCCESS(ndx).
+        assert_eq!(
+            pr.drain_new_success_indices(),
+            vec![9],
+            "a durably committed file must be confirmed for MSG_SUCCESS"
+        );
+        // Draining clears it, so the sender is never told to unlink twice.
+        assert!(
+            pr.drain_new_success_indices().is_empty(),
+            "a confirmation must not be replayed on a second drain"
+        );
+
+        drop(pr);
+    }
+
+    /// A file that fails checksum verification (a would-be-corrupt commit that is
+    /// discarded and queued for redo) must NOT be confirmed, so no `MSG_SUCCESS`
+    /// reaches the sender and it keeps the source for the retry.
+    ///
+    /// This is the receiver-side guard against data loss on a failed commit: the
+    /// mismatch branch of `verify_checksum` returns before the
+    /// `success_indices.push`, so an interrupted or corrupt transfer never
+    /// tells the sender its source landed safely. Without this assertion a
+    /// refactor could push the success before the checksum check and silently
+    /// re-introduce the inline-unlink data-loss bug.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:965-968` - checksum failure discards the update and redoes it.
+    /// - `receiver.c:1063-1069` - `send_msg_success` runs only on `recv_ok == 1`.
+    #[test]
+    fn checksum_mismatch_withholds_msg_success() {
+        use crate::pipeline::messages::ComputedChecksum;
+
+        let mut pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();
+
+        let mut expected = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+        expected[0] = 0xAA;
+
+        pr.expected_checksums.push_back(PendingChecksum {
+            expected,
+            len: 4,
+            file_path: PathBuf::from("/dest/corrupt.txt"),
+            file_index: 4,
+        });
+
+        // A different computed checksum: the update is discarded and queued for redo.
+        let mut computed_bytes = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+        computed_bytes[0] = 0xBB;
+        let result = CommitResult {
+            bytes_written: 100,
+            file_entry_index: 0,
+            metadata_error: None,
+            computed_checksum: Some(ComputedChecksum {
+                bytes: computed_bytes,
+                len: 4,
+            }),
+            delayed_path: None,
+            backup_notice: None,
+        };
+
+        pr.verify_checksum(&result).unwrap();
+
+        // The file is redone, not confirmed: the sender receives no MSG_SUCCESS
+        // and therefore never unlinks the source of a discarded update.
+        assert_eq!(pr.redo_count(), 1, "a failed verification queues a redo");
+        assert!(
+            pr.drain_new_success_indices().is_empty(),
+            "a discarded update must never confirm a source removal"
+        );
+
+        drop(pr);
+    }
+
     #[cfg(unix)]
     #[test]
     fn permission_denied_on_output_is_recoverable() {


### PR DESCRIPTION
## The invariant under test

With `--remove-source-files`, the sender must **never** unlink a source file
until the receiver has **durably committed** it. The implementation mirrors
upstream rsync 3.4.4: the receiver renames temp to destination and only then
emits `MSG_SUCCESS(ndx)` (receiver.c:1063-1069); the sender consumes
`MSG_SUCCESS` and only then runs the deferred source unlink (io.c:1623-1637,
sender.c:131-182 `successful_send()`). So if the receiver is killed or the
connection drops mid-commit, before `MSG_SUCCESS`, the source file must survive
- no data loss.

This is test hardening for an already-shipped, safety-critical feature. The
goal is deterministic regression tests that encode *why* the behaviour matters,
so a future refactor that breaks the safety property fails loudly.

## Already covered vs added

Already covered:
- `pending_removal.rs` unit tests: confirm-marked-once, confirm-unmarked-ignored.
- `generator/tests.rs`: single-file confirm-then-unlink, and single-file
  defer-until-confirm with a stray confirmation left inert.
- `pipeline/receiver.rs`: `verify_checksum` redo behaviour on match/mismatch -
  but **no** assertion on `success_indices` / `drain_new_success_indices`.
- Integration: happy-path end-to-end unlink and `--dry-run` no-op.

Gaps this PR fills:
1. **Sender seam** - the adversarial *multi-file* mid-commit teardown. Existing
   coverage is single-file only. This adds a case where the receiver committed
   and acked one file, then the connection dropped before it could commit and
   ack the rest: only the confirmed source is unlinked, every unconfirmed source
   survives and stays pending. This is the interrupted-transfer path that must
   not lose data.
2. **Receiver seam** - that `MSG_SUCCESS` is gated on a clean durable commit. A
   clean checksum-match commit records exactly one confirmation (so the sender
   is told to unlink once, not twice); a checksum mismatch (a discarded,
   redone update - the would-be-corrupt commit) withholds `MSG_SUCCESS`
   entirely, so the sender keeps its source for the retry.

## How determinism is guaranteed

No wall-clock sleeps and no race-based `kill -9` timing. The tests drive the
failure at the component seam and force the kill point by choosing which
confirmations are delivered:

- The sender test marks all sources pending, then delivers exactly one
  `confirm_source_removal` and asserts the rest survive - the connection-drop is
  modelled by simply not delivering the other confirmations, which is exactly
  what the orchestrator's `for wire_ndx in reader.take_success_indices()` loop
  sees when the peer dies mid-stream.
- The receiver tests call `verify_checksum` directly on a post-commit
  `CommitResult` and assert on `drain_new_success_indices()`, with no threads
  racing.

Every ordering is forced, not timed. No test-only fault-injection hook was
needed in production code - the existing public seams (`confirm_source_removal`,
`verify_checksum` / `drain_new_success_indices`) are sufficient.

## Verification (aarch64 Linux)

- `cargo fmt --all -- --check` - clean.
- `cargo clippy -p transfer -p core --all-features --all-targets --no-deps -- -D warnings` - clean.
- Targeted suite `test(remove_source) | test(defer) | test(msg_success) | test(unlink) | test(commit)`: 142 passed.
- The 3 new tests run 10x with `--retries 0`: 3 passed every run (deterministic).
- Full `cargo nextest run -p transfer -p core --all-features`: 4853 passed, 0 failed.
