### PR TITLE
fix(io): emit generator keepalive during delete scan and final dir-retouch

### DIFF
--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -792,7 +792,15 @@ impl ReceiverContext {
     ///   S_IWUSR)` restores the real directory mode.
     /// - `generator.c:2398-2399` - `need_retouch_dir_times` gating:
     ///   `preserve_mtimes && !omit_dir_times`.
-    pub(in crate::receiver) fn touch_up_dirs(&self, dest_dir: &Path) {
+    /// - `generator.c:2138-2144` - the retouch loop pokes `maybe_send_keepalive`
+    ///   every `loopchk_limit` iterations so a remote sender's `--timeout` does
+    ///   not fire while the generator re-sets directory mtimes/perms across a
+    ///   large tree without writing anything to the socket.
+    pub(in crate::receiver) fn touch_up_dirs<W: crate::writer::MsgInfoSender + ?Sized>(
+        &self,
+        dest_dir: &Path,
+        writer: &mut W,
+    ) {
         if self.config.flags.skip_dest_writes() {
             return;
         }
@@ -819,6 +827,11 @@ impl ReceiverContext {
         // Iterate in reverse so deepest directories are touched first.
         // upstream: generator.c:2083 - for (i = dir_flist->used - 1; i >= 0; i--)
         for entry in self.file_list.iter().rev() {
+            // upstream: generator.c:2138-2144 - poke a keepalive once the I/O
+            // lull has elapsed so a remote sender does not time out while this
+            // final metadata pass walks a large directory tree. A strict no-op
+            // unless --timeout is set (allowed_lull None).
+            let _ = writer.maybe_send_keepalive();
             if !entry.is_dir() {
                 continue;
             }
@@ -1028,7 +1041,10 @@ mod touch_up_dirs_tests {
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.file_list = vec![entry];
 
-        ctx.touch_up_dirs(dir.path());
+        ctx.touch_up_dirs(
+            dir.path(),
+            &mut crate::writer::ServerWriter::new_plain(Vec::new()),
+        );
 
         let meta = fs::metadata(&sub).unwrap();
         let actual = FileTime::from_last_modification_time(&meta);
@@ -1106,7 +1122,10 @@ mod touch_up_dirs_tests {
 
         // After the transfer the restrictive mode must be reinstated (skipped
         // under root / --fake-super, matching upstream fix_dir_perms).
-        ctx.touch_up_dirs(dest);
+        ctx.touch_up_dirs(
+            dest,
+            &mut crate::writer::ServerWriter::new_plain(Vec::new()),
+        );
         if !metadata::am_root() {
             let mode = fs::metadata(&sub).unwrap().permissions().mode() & 0o777;
             assert_eq!(
@@ -1135,7 +1154,10 @@ mod touch_up_dirs_tests {
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.file_list = vec![entry];
 
-        ctx.touch_up_dirs(dir.path());
+        ctx.touch_up_dirs(
+            dir.path(),
+            &mut crate::writer::ServerWriter::new_plain(Vec::new()),
+        );
 
         let after = FileTime::from_last_modification_time(&fs::metadata(&sub).unwrap());
         assert_eq!(
@@ -1171,7 +1193,10 @@ mod touch_up_dirs_tests {
         // Parent comes first in file list (natural order).
         ctx.file_list = vec![parent_entry, child_entry];
 
-        ctx.touch_up_dirs(dir.path());
+        ctx.touch_up_dirs(
+            dir.path(),
+            &mut crate::writer::ServerWriter::new_plain(Vec::new()),
+        );
 
         let parent_actual = FileTime::from_last_modification_time(&fs::metadata(&parent).unwrap());
         let child_actual = FileTime::from_last_modification_time(&fs::metadata(&child).unwrap());
@@ -1202,7 +1227,10 @@ mod touch_up_dirs_tests {
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.file_list = vec![entry];
 
-        ctx.touch_up_dirs(dir.path());
+        ctx.touch_up_dirs(
+            dir.path(),
+            &mut crate::writer::ServerWriter::new_plain(Vec::new()),
+        );
 
         let actual = FileTime::from_last_modification_time(&fs::metadata(dir.path()).unwrap());
         let expected = FileTime::from_unix_time(desired_secs, 0);
@@ -1228,7 +1256,10 @@ mod touch_up_dirs_tests {
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.file_list = vec![file_entry];
 
-        ctx.touch_up_dirs(dir.path());
+        ctx.touch_up_dirs(
+            dir.path(),
+            &mut crate::writer::ServerWriter::new_plain(Vec::new()),
+        );
 
         let actual = FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
         assert_eq!(

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -407,6 +407,16 @@ impl ReceiverContext {
         use std::sync::Arc;
         use std::sync::atomic::{AtomicU64, Ordering};
 
+        // upstream: generator.c:295-296 - delete_in_dir() pokes a keepalive
+        // (`if (allowed_lull) maybe_send_keepalive(...)`) as it begins scanning a
+        // directory, so a remote sender does not time out while the generator is
+        // busy sweeping the destination tree without writing to the socket. oc
+        // scans directories in parallel workers that cannot reach the writer, so
+        // the poke is emitted at the pass boundaries here (entry, and again after
+        // the parallel scan) plus per-directory in the serial capped executor.
+        // A strict no-op unless --timeout is set (allowed_lull None).
+        writer.maybe_send_keepalive()?;
+
         let max_delete = self.config.deletion.max_delete;
 
         // --one-file-system boundary device. When `-x` is active the transfer
@@ -948,6 +958,12 @@ impl ReceiverContext {
                 },
             );
 
+        // upstream: generator.c:295-296 - the parallel scan above ran the
+        // per-directory delete_in_dir work with no writer access, so poke the
+        // keepalive here at the far edge of that silent window before the serial
+        // emission loop. A strict no-op unless --timeout is set.
+        writer.maybe_send_keepalive()?;
+
         let mut combined = DeleteStats::new();
         // UTS-16.b: any worker that hit a fail-loud sandbox class (ELOOP /
         // EOPNOTSUPP / ENOTDIR / EPERM) surfaces IOERR_GENERAL here so the
@@ -1063,6 +1079,10 @@ impl ReceiverContext {
         };
 
         for dir_relative in dirs_to_scan {
+            // upstream: generator.c:295-296 - poke a keepalive at the start of
+            // each per-directory scan, matching delete_in_dir()'s cadence
+            // exactly on this serial path. A strict no-op unless --timeout is set.
+            state.writer.maybe_send_keepalive()?;
             // Stop scanning once the cap is exhausted: every further candidate
             // would only add to the skipped count, and upstream stops issuing
             // deletions the moment the limit is reached.

--- a/crates/transfer/src/receiver/tests/generator_keepalive.rs
+++ b/crates/transfer/src/receiver/tests/generator_keepalive.rs
@@ -1,0 +1,264 @@
+//! Generator keepalive emission during local disk work.
+//!
+//! Upstream rsync's generator pokes `maybe_send_keepalive()` while it is busy
+//! with local disk work so a remote sender's `--timeout` does not fire during a
+//! long silent stretch. The three sites are `delete_in_dir()`
+//! (generator.c:295-296), `touch_up_dirs()` (generator.c:2138-2144), and the
+//! `generate_files()` per-file loop (generator.c:2348-2353).
+//!
+//! These tests drive each oc phase with a multiplexed writer and assert:
+//!
+//! - with a lull configured (`--timeout` set) and the lull elapsed, the phase
+//!   emits at least one empty `MSG_DATA` keepalive frame, and
+//! - with no lull (`--timeout` unset), the phase writes nothing - proving the
+//!   change is a strict no-op that leaves the default transfer path
+//!   byte-for-byte identical.
+//!
+//! Elapsed time is driven deterministically by configuring the lull to
+//! `Duration::ZERO` (any elapsed interval already exceeds it), never by sleeping.
+
+use std::ffi::OsString;
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use metadata::MetadataOptions;
+use protocol::ProtocolVersion;
+use protocol::flist::FileEntry;
+
+use super::super::ReceiverContext;
+use super::support::{test_config, test_handshake};
+use crate::config::ServerConfig;
+use crate::flags::ParsedServerFlags;
+use crate::receiver::stats::TransferStats;
+use crate::role::ServerRole;
+use crate::writer::{CountingWriter, MsgInfoSender, ServerWriter};
+
+/// The exact wire bytes of an empty `MSG_DATA` keepalive frame: a 4-byte header
+/// with tag `MPLEX_BASE (7) + MSG_DATA (0)` in the high byte and a zero payload
+/// length, little-endian (`0x07000000` -> `[0, 0, 0, 7]`).
+const KEEPALIVE_FRAME: [u8; 4] = [0, 0, 0, 7];
+
+/// A `Write` sink that captures every byte into a shared buffer so a test can
+/// inspect the multiplexed wire output after driving a receiver phase.
+#[derive(Clone, Default)]
+struct SharedSink(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedSink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl SharedSink {
+    fn bytes(&self) -> Vec<u8> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+/// Builds a multiplexed [`ServerWriter`] over a capturing sink with the given
+/// lull. `Some(Duration::ZERO)` makes every elapsed interval exceed the lull, so
+/// each `maybe_send_keepalive()` deterministically emits; `None` mirrors an
+/// unset `--timeout` and must stay a strict no-op.
+fn mux_writer(lull: Option<Duration>) -> (ServerWriter<SharedSink>, SharedSink) {
+    let sink = SharedSink::default();
+    let mut writer = ServerWriter::new_plain(sink.clone())
+        .activate_multiplex()
+        .expect("activate multiplex");
+    writer.set_allowed_lull(lull);
+    (writer, sink)
+}
+
+/// Asserts the captured bytes are one or more empty `MSG_DATA` keepalive frames
+/// and nothing else, so the phase's only wire output was keepalives.
+fn assert_only_keepalives(bytes: &[u8]) {
+    assert!(
+        !bytes.is_empty(),
+        "expected at least one keepalive frame, got none"
+    );
+    assert_eq!(
+        bytes.len() % KEEPALIVE_FRAME.len(),
+        0,
+        "captured bytes are not a whole number of keepalive frames: {bytes:?}"
+    );
+    for chunk in bytes.chunks_exact(KEEPALIVE_FRAME.len()) {
+        assert_eq!(
+            chunk, KEEPALIVE_FRAME,
+            "captured a non-keepalive frame: {bytes:?}"
+        );
+    }
+}
+
+/// A receiver config with `--times` so `touch_up_dirs` does real work (and thus
+/// walks the file list, poking keepalives) rather than returning early.
+fn config_with_times() -> ServerConfig {
+    ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        flags: ParsedServerFlags {
+            times: true,
+            ..ParsedServerFlags::default()
+        },
+        args: vec![OsString::from(".")],
+        ..Default::default()
+    }
+}
+
+/// The delete pass (upstream `delete_in_dir`) pokes a keepalive at the start of
+/// the scan when a lull is configured, and nothing when it is not.
+#[test]
+fn delete_pass_keepalive_gated_on_timeout() {
+    let hs = test_handshake();
+    let dir = test_support::create_tempdir();
+
+    // Lull configured: the entry poke (plus the post-parallel-scan poke) emits.
+    let ctx = ReceiverContext::new_for_test(&hs, test_config());
+    let (mut writer, sink) = mux_writer(Some(Duration::ZERO));
+    ctx.delete_extraneous_files(
+        dir.path(),
+        #[cfg(unix)]
+        None,
+        &mut writer,
+    )
+    .expect("delete pass succeeds");
+    assert_only_keepalives(&sink.bytes());
+
+    // No lull: strict no-op, nothing crosses the wire.
+    let (mut writer, sink) = mux_writer(None);
+    ctx.delete_extraneous_files(
+        dir.path(),
+        #[cfg(unix)]
+        None,
+        &mut writer,
+    )
+    .expect("delete pass succeeds");
+    assert!(
+        sink.bytes().is_empty(),
+        "delete pass must be a strict no-op without --timeout"
+    );
+}
+
+/// The final directory-metadata retouch (upstream `touch_up_dirs`) pokes a
+/// keepalive per directory entry when a lull is configured, and nothing when it
+/// is not.
+#[test]
+fn touch_up_dirs_keepalive_gated_on_timeout() {
+    let hs = test_handshake();
+    let dir = test_support::create_tempdir();
+
+    let mut ctx = ReceiverContext::new_for_test(&hs, config_with_times());
+    ctx.file_list = vec![
+        FileEntry::new_directory("a".into(), 0o755),
+        FileEntry::new_directory("b".into(), 0o755),
+    ];
+
+    let (mut writer, sink) = mux_writer(Some(Duration::ZERO));
+    ctx.touch_up_dirs(dir.path(), &mut writer);
+    assert_only_keepalives(&sink.bytes());
+
+    let (mut writer, sink) = mux_writer(None);
+    ctx.touch_up_dirs(dir.path(), &mut writer);
+    assert!(
+        sink.bytes().is_empty(),
+        "touch_up_dirs must be a strict no-op without --timeout"
+    );
+}
+
+/// The per-file generate loop (upstream `generate_files`) pokes a keepalive per
+/// candidate when a lull is configured, and nothing when it is not.
+#[test]
+fn build_files_to_transfer_keepalive_gated_on_timeout() {
+    let hs = test_handshake();
+    let dir = test_support::create_tempdir();
+    let opts = MetadataOptions::default();
+
+    let mut ctx = ReceiverContext::new_for_test(&hs, test_config());
+    // New regular files with no destination present take the no-output new-file
+    // path, so the loop's only wire output is the per-file keepalive.
+    ctx.file_list = vec![
+        FileEntry::new_file("f1".into(), 4, 0o644),
+        FileEntry::new_file("f2".into(), 4, 0o644),
+    ];
+
+    let (mut writer, sink) = mux_writer(Some(Duration::ZERO));
+    let mut errors = Vec::new();
+    let mut stats = TransferStats::default();
+    let _ = ctx.build_files_to_transfer(
+        &mut writer,
+        dir.path(),
+        &opts,
+        None,
+        &mut errors,
+        &mut stats,
+        None,
+        None,
+    );
+    assert_only_keepalives(&sink.bytes());
+
+    let (mut writer, sink) = mux_writer(None);
+    let mut errors = Vec::new();
+    let mut stats = TransferStats::default();
+    let _ = ctx.build_files_to_transfer(
+        &mut writer,
+        dir.path(),
+        &opts,
+        None,
+        &mut errors,
+        &mut stats,
+        None,
+        None,
+    );
+    assert!(
+        sink.bytes().is_empty(),
+        "build_files_to_transfer must be a strict no-op without --timeout"
+    );
+}
+
+/// The receiver's production writer is a `CountingWriter<&mut ServerWriter>`.
+/// This pins that the keepalive method forwards through that wrapper (and stays
+/// gated), so the phases above reach the real lull-gated emitter at runtime.
+#[test]
+fn counting_writer_forwards_keepalive() {
+    let (mut inner, sink) = mux_writer(Some(Duration::ZERO));
+    {
+        let mut cw = CountingWriter::new(&mut inner);
+        assert!(
+            cw.maybe_send_keepalive().expect("keepalive"),
+            "wrapped writer must emit when the lull has elapsed"
+        );
+    }
+    assert_eq!(sink.bytes(), KEEPALIVE_FRAME);
+
+    let (mut inner, sink) = mux_writer(None);
+    {
+        let mut cw = CountingWriter::new(&mut inner);
+        assert!(
+            !cw.maybe_send_keepalive().expect("keepalive"),
+            "wrapped writer must stay silent without --timeout"
+        );
+    }
+    assert!(sink.bytes().is_empty());
+}
+
+/// A plain (non-multiplexed) writer never emits a keepalive even with a lull
+/// configured, matching upstream's `am_server`-gated emission: keepalives ride
+/// the multiplexed server stream only.
+#[test]
+fn plain_writer_never_emits_keepalive() {
+    let mut writer = ServerWriter::new_plain(Vec::new());
+    writer.set_allowed_lull(Some(Duration::ZERO));
+    assert!(
+        !MsgInfoSender::maybe_send_keepalive(&mut writer).expect("keepalive"),
+        "plain-mode writer must never emit a keepalive"
+    );
+    match writer {
+        ServerWriter::Plain(buf) => assert!(buf.is_empty()),
+        _ => panic!("writer should still be plain"),
+    }
+}

--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -20,6 +20,7 @@ mod create_specials;
 mod delta_apply;
 mod errors_and_timeouts;
 mod file_list;
+mod generator_keepalive;
 mod hard_links;
 #[cfg(unix)]
 mod munge_symlinks;

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -237,6 +237,13 @@ impl ReceiverContext {
         let needs_metadata_apply = metadata_opts.requires_apply();
         let mut files_to_transfer = Vec::with_capacity(stat_results.len() / 4 + 1);
         for (idx, file_path, dest_meta) in stat_results {
+            // upstream: generator.c:2348-2353 generate_files() - the per-file
+            // generate loop pokes maybe_send_keepalive once the I/O lull has
+            // elapsed so a remote sender's --timeout does not fire while the
+            // generator quick-checks a long run of up-to-date files without
+            // writing any NDX request. A strict no-op unless --timeout is set
+            // (allowed_lull None), keeping the default path wire-identical.
+            let _ = writer.maybe_send_keepalive();
             let entry = &self.file_list[idx];
             if let Some(ref meta) = dest_meta {
                 if ignore_existing {

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -264,7 +264,7 @@ impl ReceiverContext {
 
         // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
         // directory mtimes after file writes clobber them.
-        self.touch_up_dirs(&setup.dest_dir);
+        self.touch_up_dirs(&setup.dest_dir, writer);
 
         // Drain the deferred itemize rows in flist-index order before the
         // goodbye handshake, matching upstream's single-pass emission ordering.

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -275,7 +275,7 @@ impl ReceiverContext {
 
         // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
         // directory mtimes after file writes clobber them.
-        self.touch_up_dirs(&setup.dest_dir);
+        self.touch_up_dirs(&setup.dest_dir, writer);
 
         stats.files_transferred = files_transferred;
         stats.bytes_received = bytes_received;

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -563,7 +563,7 @@ impl ReceiverContext {
 
         // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
         // directory mtimes after file writes clobber them.
-        self.touch_up_dirs(&dest_dir);
+        self.touch_up_dirs(&dest_dir, writer);
 
         self.finalize_transfer(reader, writer)?;
 

--- a/crates/transfer/src/writer/msg_info.rs
+++ b/crates/transfer/src/writer/msg_info.rs
@@ -81,6 +81,29 @@ pub trait MsgInfoSender {
     fn send_msg_success(&mut self, _ndx: i32) -> io::Result<()> {
         Ok(())
     }
+
+    /// Emits a lull keepalive if a `--timeout` is configured and the keepalive
+    /// interval has elapsed with no output, returning `true` when an empty
+    /// `MSG_DATA` frame was written.
+    ///
+    /// The generator/receiver calls this while it is busy with local disk work
+    /// (the delete scan, the final directory-metadata retouch, and the per-file
+    /// generate loop) so a remote sender does not trip its `--timeout` during a
+    /// long silent stretch. The default implementation is a strict no-op,
+    /// matching [`Self::send_msg_info`]; concrete multiplex writers override it
+    /// to forward to the lull-gated emitter. It is a no-op unless `--timeout`
+    /// is set (`allowed_lull` is `None`), so the default transfer path stays
+    /// byte-for-byte identical.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:maybe_send_keepalive()` - the lull-gated empty-`MSG_DATA` emitter.
+    /// - `generator.c:296` `delete_in_dir()`, `generator.c:2138-2144`
+    ///   `touch_up_dirs()`, `generator.c:2348-2353` `generate_files()` - the
+    ///   three generator sites that poke it during local disk work.
+    fn maybe_send_keepalive(&mut self) -> io::Result<bool> {
+        Ok(false)
+    }
 }
 
 impl<W: Write> MsgInfoSender for ServerWriter<W> {
@@ -122,6 +145,17 @@ impl<W: Write> MsgInfoSender for ServerWriter<W> {
             Ok(())
         }
     }
+
+    fn maybe_send_keepalive(&mut self) -> io::Result<bool> {
+        // Delegate to the lull-gated emitter. Duplicating the tiny variant match
+        // (rather than calling the inherent method of the same name) keeps the
+        // call unambiguous with this trait method.
+        match self {
+            Self::Multiplex(mux) => mux.maybe_send_keepalive(),
+            Self::Compressed(compressed) => compressed.inner_mut().maybe_send_keepalive(),
+            Self::Plain(_) | Self::Taken => Ok(false),
+        }
+    }
 }
 
 impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
@@ -140,6 +174,10 @@ impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
     fn send_msg_success(&mut self, ndx: i32) -> io::Result<()> {
         (**self).send_msg_success(ndx)
     }
+
+    fn maybe_send_keepalive(&mut self) -> io::Result<bool> {
+        (**self).maybe_send_keepalive()
+    }
 }
 
 impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
@@ -157,5 +195,9 @@ impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
 
     fn send_msg_success(&mut self, ndx: i32) -> io::Result<()> {
         self.inner_ref_mut().send_msg_success(ndx)
+    }
+
+    fn maybe_send_keepalive(&mut self) -> io::Result<bool> {
+        self.inner_ref_mut().maybe_send_keepalive()
     }
 }


### PR DESCRIPTION
## Summary

The receiver-side generator does long stretches of local disk work with no
socket writes. When a remote sender has `--timeout` set, upstream rsync's
generator pokes `maybe_send_keepalive()` at three such sites so the sender does
not time out mid-work. oc-rsync emitted nothing at these sites.

This wires the same lull-gated keepalive into the three receiver phases, mirroring
upstream `generator.c` (proto 32, 3.4.4):

- **Delete scan** - `generator.c:295-296` `delete_in_dir()` pokes at the start of
  each per-directory scan. oc scans directories in parallel workers that cannot
  reach the writer, so the poke is emitted at the pass boundaries (entry and again
  after the parallel scan) plus per-directory in the serial `--max-delete` /
  `--one-file-system` capped executor.
- **Final directory-metadata retouch** - `generator.c:2138-2144` `touch_up_dirs()`
  pokes every `loopchk_limit` iterations; oc pokes per directory in the reverse
  file-list walk.
- **Per-file generate loop** - `generator.c:2348-2353` `generate_files()` pokes
  every `next_loopchk` files; oc pokes per candidate in the quick-check loop
  (`build_files_to_transfer`), which is where a large run of up-to-date files
  produces no wire request.

`maybe_send_keepalive()` is added to the `MsgInfoSender` trait (no-op default,
forwarded through `ServerWriter` and `CountingWriter`, the exact writer the
receiver holds at runtime), reusing the existing lull-gated emitter rather than a
new mechanism.

## No-op without `--timeout`

The emitter early-returns when `allowed_lull` is `None`, which is the case unless
`--timeout` is set. Every added call is therefore a strict no-op on the default
path: no `MSG_DATA` frame, no flush, no wire-output change. The common transfer
stays byte-for-byte identical.

## Tests

Deterministic, no sleeps: each phase is driven with a multiplexed capturing writer
and a zero lull (any elapsed interval already exceeds it), asserting exactly one
empty `MSG_DATA` keepalive frame per poke with a lull set, and nothing at all
without one. Two further tests pin that the production `CountingWriter` wrapper
forwards the keepalive (and its gating) and that a plain, non-multiplexed writer
never emits - matching upstream's `am_server`-gated emission.

## Verification (aarch64)

- `cargo fmt --all -- --check` - clean
- `cargo clippy -p transfer -p engine -p protocol --all-features --all-targets --no-deps -- -D warnings` - clean
- `cargo nextest run -p transfer -p engine -p protocol --all-features` - green
- New tests repeated 3x - stable
