### PR TITLE
fix(cli): match upstream --stats/progress output formatting

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -45,6 +45,9 @@ pub(crate) struct TransferExecutionInputs<'a> {
     pub(crate) verbosity: u8,
     pub(crate) list_only: bool,
     pub(crate) dry_run: bool,
+    /// `--only-write-batch` (upstream `write_batch < 0`): appends the
+    /// `" (BATCH ONLY)"` speedup suffix in the summary trailer.
+    pub(crate) only_write_batch: bool,
     /// `--info=copy`: opt-in to the oc-rsync `Copy method` line that reports
     /// which local-copy I/O acceleration (clonefile/reflink/io_uring) ran.
     pub(crate) show_copy_method: bool,
@@ -87,6 +90,7 @@ where
         verbosity,
         list_only,
         dry_run,
+        only_write_batch,
         show_copy_method,
         show_atimes,
         show_crtimes,
@@ -170,6 +174,7 @@ where
                     progress_rendered_live,
                     list_only,
                     dry_run,
+                    only_write_batch,
                     out_format_template,
                     &out_format_context,
                     name_level,
@@ -307,7 +312,8 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         stats_level,
         false,
         list_only,
-        false,
+        false, // dry_run
+        false, // only_write_batch
         Some(&log.format),
         &context,
         name_level,

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -1063,6 +1063,9 @@ where
             verbosity,
             list_only,
             dry_run,
+            // `--only-write-batch` (upstream `write_batch < 0`) drives the
+            // `" (BATCH ONLY)"` speedup suffix in the summary trailer.
+            only_write_batch: only_write_batch.is_some(),
             // `--info=copy` opts into the oc-rsync `Copy method` stats line.
             show_copy_method,
             // `-U`/`--atimes` and `--crtimes` add the ATIME/CRTIME columns to

--- a/crates/cli/src/frontend/progress/format/mod.rs
+++ b/crates/cli/src/frontend/progress/format/mod.rs
@@ -14,8 +14,7 @@ pub(crate) use self::progress::{
 };
 pub(crate) use self::rate::{
     format_human_rate, format_progress_rate, format_progress_rate_decimal,
-    format_progress_rate_from_value, format_progress_rate_human, format_summary_rate,
-    format_verbose_rate_human,
+    format_progress_rate_from_value, format_summary_rate,
 };
 pub(crate) use self::remaining::RemainingTimeEstimator;
 pub(crate) use self::size::{

--- a/crates/cli/src/frontend/progress/format/progress.rs
+++ b/crates/cli/src/frontend/progress/format/progress.rs
@@ -2,8 +2,13 @@
 
 use std::time::Duration;
 
-/// Formats a progress percentage, producing the upstream `??%` placeholder when totals are
-/// unavailable.
+/// Formats a progress percentage.
+///
+/// upstream: progress.c:128 rprint_progress computes `pct = ofs == size ? 100 :
+/// (int)(100.0 * ofs / size)` and never emits a `??` placeholder for the
+/// percent field (unlike the ETA field, which does). oc emits one progress line
+/// per file at completion (`ofs == size`), so an unknown total resolves to
+/// 100% rather than a sentinel.
 pub(crate) fn format_progress_percent(bytes: u64, total: Option<u64>) -> String {
     match total {
         Some(total_bytes) if total_bytes > 0 => {
@@ -11,8 +16,8 @@ pub(crate) fn format_progress_percent(bytes: u64, total: Option<u64>) -> String 
             let percent = (capped.saturating_mul(100)) / total_bytes;
             format!("{percent}%")
         }
-        Some(_) => "100%".to_owned(),
-        None => "??%".to_owned(),
+        // total 0 (empty file, ofs == size) or unknown: upstream prints 100%.
+        Some(_) | None => "100%".to_owned(),
     }
 }
 
@@ -58,7 +63,10 @@ mod tests {
 
     #[test]
     fn format_progress_percent_no_total() {
-        assert_eq!(format_progress_percent(50, None), "??%");
+        // upstream progress.c:128 never emits `??` for the percent field; an
+        // unknown total resolves to the completion value 100%, not a sentinel.
+        assert_eq!(format_progress_percent(50, None), "100%");
+        assert!(!format_progress_percent(50, None).contains("??"));
     }
 
     #[test]

--- a/crates/cli/src/frontend/progress/format/rate.rs
+++ b/crates/cli/src/frontend/progress/format/rate.rs
@@ -41,54 +41,24 @@ pub(crate) fn format_human_rate(rate: f64, base: f64) -> String {
     format!("{rate:.2}")
 }
 
-pub(crate) fn format_verbose_rate_human(rate: f64) -> (String, &'static str) {
-    const UNITS: &[(&str, f64)] = &[
-        ("PB/s", 1_000_000_000_000_000.0),
-        ("TB/s", 1_000_000_000_000.0),
-        ("GB/s", 1_000_000_000.0),
-        ("MB/s", 1_000_000.0),
-        ("kB/s", 1_000.0),
-    ];
-
-    for (unit, threshold) in UNITS {
-        if rate >= *threshold {
-            let value = rate / *threshold;
-            return (format!("{value:.2}"), *unit);
-        }
-    }
-
-    (format!("{rate:.2}"), "B/s")
-}
-
 /// Formats a transfer rate in the `kB/s`, `MB/s`, or `GB/s` ranges.
+///
+/// upstream: progress.c:108-116 rprint_progress - the progress rate column is
+/// always scaled with base-1024 divisors (kB/s / MB/s / GB/s) and never honours
+/// `-h`/`-hh`; the human-readable modes affect only the byte counters, so the
+/// mode is intentionally ignored here.
 pub(crate) fn format_progress_rate(
     bytes: u64,
     elapsed: Duration,
-    human_readable: HumanReadableMode,
+    _human_readable: HumanReadableMode,
 ) -> String {
-    if bytes == 0 || elapsed.is_zero() {
-        return if human_readable.is_enabled() {
-            "0.00B/s".to_owned()
-        } else {
-            "0.00kB/s".to_owned()
-        };
-    }
-
     let seconds = elapsed.as_secs_f64();
-    if seconds <= 0.0 {
-        return if human_readable.is_enabled() {
-            "0.00B/s".to_owned()
-        } else {
-            "0.00kB/s".to_owned()
-        };
-    }
-
-    let rate = bytes as f64 / seconds;
-    if !human_readable.is_enabled() {
-        return format_progress_rate_decimal(rate);
-    }
-
-    format_progress_rate_human(rate)
+    let rate = if bytes == 0 || seconds <= 0.0 {
+        0.0
+    } else {
+        bytes as f64 / seconds
+    };
+    format_progress_rate_decimal(rate)
 }
 
 pub(crate) fn format_progress_rate_decimal(rate: f64) -> String {
@@ -105,11 +75,6 @@ pub(crate) fn format_progress_rate_decimal(rate: f64) -> String {
     }
 }
 
-pub(crate) fn format_progress_rate_human(rate: f64) -> String {
-    let display = format_verbose_rate_human(rate);
-    format!("{}{}", display.0, display.1)
-}
-
 /// Formats a pre-computed transfer rate (bytes/sec) for the progress line.
 ///
 /// Unlike [`format_progress_rate`] which computes the rate from cumulative
@@ -121,21 +86,10 @@ pub(crate) fn format_progress_rate_human(rate: f64) -> String {
 /// upstream: progress.c:108-116 rprint_progress - rate unit selection
 pub(crate) fn format_progress_rate_from_value(
     rate: f64,
-    human_readable: HumanReadableMode,
+    _human_readable: HumanReadableMode,
 ) -> String {
-    if rate <= 0.0 {
-        return if human_readable.is_enabled() {
-            "0.00B/s".to_owned()
-        } else {
-            "0.00kB/s".to_owned()
-        };
-    }
-
-    if !human_readable.is_enabled() {
-        return format_progress_rate_decimal(rate);
-    }
-
-    format_progress_rate_human(rate)
+    // upstream: progress.c:108-116 - always base-1024, never `-h`/`-hh`.
+    format_progress_rate_decimal(rate.max(0.0))
 }
 
 #[cfg(test)]
@@ -178,25 +132,46 @@ mod tests {
         assert_eq!(format_human_rate(1_048_576.0, 1024.0), "1.00M");
     }
 
+    /// Progress rate always uses base-1024 units regardless of `-h`/`-hh`.
+    /// upstream: progress.c:108-116 rprint_progress never consults human_num.
     #[test]
-    fn format_verbose_rate_human_small() {
-        let (value, unit) = format_verbose_rate_human(500.0);
-        assert_eq!(value, "500.00");
-        assert_eq!(unit, "B/s");
+    fn progress_rate_ignores_human_readable_mode() {
+        // 2 MiB/s must render as `2.00MB/s` in every human-readable mode -
+        // never the base-1000 `2.10MB/s` or a `B/s`/`TB/s` unit.
+        let bytes = 2 * 1024 * 1024;
+        for mode in [
+            HumanReadableMode::Grouped,
+            HumanReadableMode::DecimalUnits,
+            HumanReadableMode::BinaryUnits,
+        ] {
+            assert_eq!(
+                format_progress_rate(bytes, Duration::from_secs(1), mode),
+                "2.00MB/s",
+                "progress rate must stay base-1024 under {mode:?}"
+            );
+            assert_eq!(
+                format_progress_rate_from_value(bytes as f64, mode),
+                "2.00MB/s",
+                "from_value progress rate must stay base-1024 under {mode:?}"
+            );
+        }
     }
 
+    /// A zero rate always renders `0.00kB/s`, never `0.00B/s`.
+    /// upstream: progress.c:113-116 - a zero rate falls into the `kB/s` tier.
     #[test]
-    fn format_verbose_rate_human_kilo() {
-        let (value, unit) = format_verbose_rate_human(1_500.0);
-        assert_eq!(value, "1.50");
-        assert_eq!(unit, "kB/s");
-    }
-
-    #[test]
-    fn format_verbose_rate_human_mega() {
-        let (value, unit) = format_verbose_rate_human(2_500_000.0);
-        assert_eq!(value, "2.50");
-        assert_eq!(unit, "MB/s");
+    fn progress_rate_zero_is_kb_per_sec_in_every_mode() {
+        for mode in [
+            HumanReadableMode::Grouped,
+            HumanReadableMode::DecimalUnits,
+            HumanReadableMode::BinaryUnits,
+        ] {
+            assert_eq!(
+                format_progress_rate(0, Duration::from_secs(1), mode),
+                "0.00kB/s"
+            );
+            assert_eq!(format_progress_rate_from_value(0.0, mode), "0.00kB/s");
+        }
     }
 
     /// Upstream `rprint_progress` (progress.c:108-116) caps its unit scaling

--- a/crates/cli/src/frontend/progress/mod.rs
+++ b/crates/cli/src/frontend/progress/mod.rs
@@ -13,9 +13,8 @@ pub(crate) use self::format::{
     describe_event_kind, event_matches_name_level, format_decimal_bytes, format_human_bytes,
     format_human_rate, format_list_permissions, format_list_size, format_list_timestamp,
     format_progress_bytes, format_progress_elapsed, format_progress_percent, format_progress_rate,
-    format_progress_rate_decimal, format_progress_rate_from_value, format_progress_rate_human,
-    format_size, format_stat_categories, format_summary_rate, format_verbose_rate_human,
-    is_progress_event, list_only_event,
+    format_progress_rate_decimal, format_progress_rate_from_value, format_size,
+    format_stat_categories, format_summary_rate, is_progress_event, list_only_event,
 };
 pub(crate) use self::live::{LiveProgress, ProgressOutputConfig};
 pub(crate) use self::mode::ProgressMode;

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -61,6 +61,9 @@ pub(crate) fn emit_transfer_summary(
     progress_already_rendered: bool,
     list_only: bool,
     dry_run: bool,
+    // `--only-write-batch` (upstream `write_batch < 0`): appends the
+    // `" (BATCH ONLY)"` speedup suffix, taking precedence over `--dry-run`.
+    only_write_batch: bool,
     out_format: Option<&OutFormat>,
     out_format_context: &OutFormatContext,
     name_level: NameOutputLevel,
@@ -101,6 +104,7 @@ pub(crate) fn emit_transfer_summary(
                 writer,
                 human_readable_mode,
                 dry_run,
+                only_write_batch,
                 stats_level,
                 show_copy_method,
             )?;
@@ -113,6 +117,7 @@ pub(crate) fn emit_transfer_summary(
                 writer,
                 human_readable_mode,
                 dry_run,
+                only_write_batch,
                 show_copy_method,
             )?;
         }
@@ -217,12 +222,17 @@ pub(crate) fn emit_transfer_summary(
     let _ = suppress_updated_only_totals;
     let emit_trailer_totals = !stats_on && verbosity > 0;
 
-    // upstream: main.c:461 - `output_summary()` emits a blank
-    // `rprintf(FCLIENT, "\n")` before the INFO_GTE(STATS, 1) totals so the
-    // trailer is visually separated from preceding per-file output.
+    // upstream: main.c:427/458 - `output_summary()` unconditionally emits a
+    // leading `rprintf(FCLIENT, "\n")` before both the STATS>=2 detail block and
+    // the STATS>=1 sent/received trailer, separating them from any preceding
+    // per-file output. When a per-file block (verbose listing, itemize, or
+    // progress) was rendered, its trailing separator above already supplied that
+    // blank; when nothing preceded (a plain `--stats`, or an empty `-v` run) we
+    // still emit exactly one blank so the trailer keeps its upstream framing.
     // `testsuite/itemize.test`'s `v_filt` helper relies on this empty line
     // (`sed -e '/^$/,$d'`) to strip the trailer when matching `-vv` goldens.
-    if emit_verbose_listing && (stats_on || emit_trailer_totals) {
+    let rendered_block = formatted_rendered || progress_rendered || emit_verbose_listing;
+    if (stats_on || emit_trailer_totals) && (emit_verbose_listing || !rendered_block) {
         writeln!(writer)?;
     }
 
@@ -232,6 +242,7 @@ pub(crate) fn emit_transfer_summary(
             writer,
             human_readable_mode,
             dry_run,
+            only_write_batch,
             stats_level,
             show_copy_method,
         )?;
@@ -241,6 +252,7 @@ pub(crate) fn emit_transfer_summary(
             writer,
             human_readable_mode,
             dry_run,
+            only_write_batch,
             show_copy_method,
         )?;
     }
@@ -455,6 +467,7 @@ pub(crate) fn emit_stats<W: Write + ?Sized>(
     stdout: &mut W,
     human_readable: HumanReadableMode,
     dry_run: bool,
+    only_write_batch: bool,
     level: u8,
     show_copy_method: bool,
 ) -> io::Result<()> {
@@ -467,7 +480,36 @@ pub(crate) fn emit_stats<W: Write + ?Sized>(
         writeln!(stdout)?;
     }
 
-    emit_totals(summary, stdout, human_readable, dry_run, show_copy_method)
+    emit_totals(
+        summary,
+        stdout,
+        human_readable,
+        dry_run,
+        only_write_batch,
+        show_copy_method,
+    )
+}
+
+/// Builds the five `Number of files` breakdown categories in upstream order.
+///
+/// upstream: main.c:388 `output_itemized_counts` uses `labels[] = {"reg", "dir",
+/// "link", "dev", "special"}`, keeping device nodes (`dev`) split from other
+/// specials (`special`: fifos/sockets). Folding the two together diverges from
+/// upstream's five-category line.
+fn files_count_categories(
+    reg: u64,
+    dir: u64,
+    link: u64,
+    dev: u64,
+    special: u64,
+) -> [(&'static str, u64); 5] {
+    [
+        ("reg", reg),
+        ("dir", dir),
+        ("link", link),
+        ("dev", dev),
+        ("special", special),
+    ]
 }
 
 /// Emits the level-2+ detail block: file counts, byte-breakdown, file-list
@@ -531,12 +573,16 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
         .saturating_add(created_devices)
         .saturating_add(created_specials);
 
-    let files_breakdown = format_stat_categories(&[
-        ("reg", files_total),
-        ("dir", directories_total),
-        ("link", symlinks_total),
-        ("special", special_total),
-    ]);
+    // upstream: main.c:388 output_itemized_counts labels[] =
+    // {reg, dir, link, dev, special} - devices ('dev') are counted separately
+    // from other specials (fifos/sockets), never folded together.
+    let files_breakdown = format_stat_categories(&files_count_categories(
+        files_total,
+        directories_total,
+        symlinks_total,
+        devices_total,
+        fifos_total,
+    ));
     // upstream: main.c output_itemized_counts labels the created breakdown
     // reg/dir/link/dev/special, with devices ('dev') split from other specials.
     let created_breakdown = format_stat_categories(&[
@@ -618,6 +664,7 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
     stdout: &mut W,
     human_readable: HumanReadableMode,
     dry_run: bool,
+    only_write_batch: bool,
     show_copy_method: bool,
 ) -> io::Result<()> {
     let sent = summary.bytes_sent();
@@ -659,14 +706,23 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
         stdout,
         "sent {sent_display} bytes  received {received_display} bytes  {rate_display} bytes/sec"
     )?;
-    let dry_run_suffix = if dry_run { " (DRY RUN)" } else { "" };
+    // upstream: main.c:469 - `write_batch < 0 ? " (BATCH ONLY)" : dry_run ?
+    // " (DRY RUN)" : ""`. `--only-write-batch` sets `write_batch < 0` and takes
+    // precedence over `--dry-run`.
+    let speedup_suffix = if only_write_batch {
+        " (BATCH ONLY)"
+    } else if dry_run {
+        " (DRY RUN)"
+    } else {
+        ""
+    };
     // upstream: main.c:466-468 - speedup uses comma_dnum(_, 2), i.e. thousands
     // grouping. Reuse the same helper the --stats path uses (stats_format.rs)
     // so both summary paths group identically.
     let speedup_display = crate::stats_format::format_speedup(speedup);
     writeln!(
         stdout,
-        "total size is {total_size_display}  speedup is {speedup_display}{dry_run_suffix}"
+        "total size is {total_size_display}  speedup is {speedup_display}{speedup_suffix}"
     )
 }
 
@@ -1319,5 +1375,115 @@ mod tests {
         // name with no surrounding quotes and no "(no recursion)" suffix. Byte
         // fidelity with upstream requires exactly this form.
         assert_eq!(render_verbose(event), "skipping directory subdir\n");
+    }
+
+    /// Renders the summary trailer for an empty (default) transfer at the given
+    /// stats level with the requested `--dry-run` / `--only-write-batch` flags.
+    fn render_summary(level: u8, dry_run: bool, only_write_batch: bool) -> String {
+        let summary = ClientSummary::default();
+        let mut out = Vec::new();
+        emit_transfer_summary(
+            &summary,
+            0,     // verbosity
+            None,  // progress_mode
+            level, // stats_level
+            false, // progress_already_rendered
+            false, // list_only
+            dry_run,
+            only_write_batch,
+            None, // out_format
+            &OutFormatContext::default(),
+            NameOutputLevel::Disabled,
+            false, // name_overridden
+            HumanReadableMode::Grouped,
+            false, // suppress_updated_only_totals
+            false, // emit_flist_banner
+            false, // show_copy_method
+            false, // show_atimes
+            false, // show_crtimes
+            false, // eight_bit_output
+            &mut out,
+        )
+        .expect("emit_transfer_summary writes to an in-memory buffer");
+        String::from_utf8(out).expect("output is valid UTF-8")
+    }
+
+    #[test]
+    fn plain_stats_trailer_starts_with_blank_line() {
+        // upstream: main.c:458 - output_summary() emits an unconditional leading
+        // `rprintf(FCLIENT, "\n")` before the STATS>=1 sent/received trailer,
+        // even when no per-file output preceded it (a plain `--stats` run). oc
+        // previously emitted the trailer with no leading blank.
+        let out = render_summary(1, false, false);
+        assert!(
+            out.starts_with('\n'),
+            "plain --stats trailer must start with a blank line:\n{out:?}"
+        );
+        assert!(out.contains("sent "));
+        assert!(out.contains("total size is"));
+        // Exactly one leading blank - not a doubled empty line.
+        assert!(
+            !out.starts_with("\n\n"),
+            "leading blank must not double:\n{out:?}"
+        );
+    }
+
+    #[test]
+    fn stats_detail_block_starts_with_blank_line() {
+        // upstream: main.c:427 - the STATS>=2 detail block is also preceded by an
+        // unconditional leading blank.
+        let out = render_summary(2, false, false);
+        assert!(
+            out.starts_with('\n'),
+            "stats block must start blank:\n{out:?}"
+        );
+        assert!(
+            !out.starts_with("\n\n"),
+            "leading blank must not double:\n{out:?}"
+        );
+        assert!(out.contains("Number of files:"));
+    }
+
+    #[test]
+    fn speedup_suffix_matches_upstream_precedence() {
+        // upstream: main.c:469 - `write_batch < 0 ? " (BATCH ONLY)" : dry_run ?
+        // " (DRY RUN)" : ""`. --only-write-batch wins over --dry-run.
+        assert!(render_summary(1, false, false).contains("speedup is"));
+        assert!(!render_summary(1, false, false).contains("(DRY RUN)"));
+        assert!(!render_summary(1, false, false).contains("(BATCH ONLY)"));
+
+        assert!(render_summary(1, true, false).contains(" (DRY RUN)"));
+
+        let batch = render_summary(1, false, true);
+        assert!(batch.contains(" (BATCH ONLY)"), "{batch:?}");
+        assert!(!batch.contains("(DRY RUN)"), "{batch:?}");
+
+        // Precedence: batch beats dry-run when both are set.
+        let both = render_summary(1, true, true);
+        assert!(both.contains(" (BATCH ONLY)"), "{both:?}");
+        assert!(!both.contains("(DRY RUN)"), "{both:?}");
+    }
+
+    #[test]
+    fn files_count_categories_split_dev_from_special() {
+        // upstream: main.c:388 output_itemized_counts labels[] =
+        // {reg, dir, link, dev, special}. Device nodes ('dev') must be counted
+        // separately from other specials (fifos/sockets); folding them into a
+        // single 'special' count diverges from upstream's five-category line.
+        let cats = files_count_categories(3, 2, 1, 4, 5);
+        assert_eq!(
+            cats,
+            [
+                ("reg", 3),
+                ("dir", 2),
+                ("link", 1),
+                ("dev", 4),
+                ("special", 5)
+            ]
+        );
+        assert_eq!(
+            format_stat_categories(&cats),
+            " (reg: 3, dir: 2, link: 1, dev: 4, special: 5)"
+        );
     }
 }

--- a/crates/cli/src/frontend/tests/format.rs
+++ b/crates/cli/src/frontend/tests/format.rs
@@ -9,28 +9,34 @@ fn format_size_combined_uses_base_1024_no_exact() {
 }
 
 #[test]
-fn format_progress_rate_zero_bytes_matches_mode() {
-    assert_eq!(
-        format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::Grouped),
-        "0.00kB/s"
-    );
-    assert_eq!(
-        format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::DecimalUnits),
-        "0.00B/s"
-    );
-    assert_eq!(
-        format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::BinaryUnits),
-        "0.00B/s"
-    );
+fn format_progress_rate_zero_bytes_stays_kb_per_sec_in_every_mode() {
+    // upstream: progress.c:108-116 - the progress rate is always base-1024 and
+    // never honours `-h`/`-hh`; a zero rate falls into the `kB/s` tier in every
+    // human-readable mode.
+    for mode in [
+        HumanReadableMode::Grouped,
+        HumanReadableMode::DecimalUnits,
+        HumanReadableMode::BinaryUnits,
+    ] {
+        assert_eq!(
+            format_progress_rate(0, Duration::from_secs(1), mode),
+            "0.00kB/s"
+        );
+    }
 }
 
 #[test]
-fn format_progress_rate_combined_no_exact_component() {
-    // upstream never appends an exact-value component to the progress rate.
-    let rendered = format_progress_rate(
-        1_048_576,
-        Duration::from_secs(1),
+fn format_progress_rate_is_base_1024_regardless_of_mode() {
+    // upstream: progress.c:108-116 - 1 MiB/s renders as `1.00MB/s` with base-1024
+    // divisors, never the base-1000 `1.05MB/s`, in every human-readable mode.
+    for mode in [
+        HumanReadableMode::Grouped,
+        HumanReadableMode::DecimalUnits,
         HumanReadableMode::BinaryUnits,
-    );
-    assert_eq!(rendered, "1.05MB/s");
+    ] {
+        assert_eq!(
+            format_progress_rate(1_048_576, Duration::from_secs(1), mode),
+            "1.00MB/s"
+        );
+    }
 }

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -231,7 +231,8 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         0, // stats_level
         false,
         false,
-        false,
+        false, // dry_run
+        false, // only_write_batch
         Some(&format),
         &OutFormatContext::default(),
         NameOutputLevel::Disabled,
@@ -255,7 +256,8 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         0, // stats_level
         false,
         false,
-        false,
+        false, // dry_run
+        false, // only_write_batch
         None,
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedOnly,

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -64,6 +64,7 @@ fn render_stats_at_level(
         false, // progress_already_rendered
         false, // list_only
         false, // dry_run
+        false, // only_write_batch
         None,
         &OutFormatContext::default(),
         NameOutputLevel::Disabled,
@@ -91,6 +92,7 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         false, // progress_already_rendered
         false, // list_only
         false, // dry_run
+        false, // only_write_batch
         None,
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged,
@@ -134,6 +136,7 @@ fn info_name_only_suppresses_stats_footer() {
         false, // progress_already_rendered
         false, // list_only
         false, // dry_run
+        false, // only_write_batch
         None,
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged, // --info=name2-style name output
@@ -529,6 +532,7 @@ fn parity_totals_only_without_stats_flag() {
         false,
         false, // list_only
         false, // dry_run
+        false, // only_write_batch
         None,
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged,
@@ -799,6 +803,7 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         false,
         false, // list_only
         false, // dry_run
+        false, // only_write_batch
         None,
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged,

--- a/crates/cli/src/frontend/tests/progress.rs
+++ b/crates/cli/src/frontend/tests/progress.rs
@@ -159,8 +159,12 @@ fn progress_transfer_routes_messages_to_stderr_when_requested() {
 }
 
 #[test]
-fn progress_percent_placeholder_used_for_unknown_totals() {
-    assert_eq!(format_progress_percent(42, None), "??%");
+fn progress_percent_unknown_total_resolves_to_complete() {
+    // upstream: progress.c:128 - `pct = ofs == size ? 100 : ...` never emits a
+    // `??` sentinel for the percent field. oc emits one progress line per file
+    // at completion, so an unknown total resolves to 100%, not `??%`.
+    assert_eq!(format_progress_percent(42, None), "100%");
+    assert!(!format_progress_percent(42, None).contains("??"));
     assert_eq!(format_progress_percent(0, Some(0)), "100%");
     assert_eq!(format_progress_percent(50, Some(200)), "25%");
 }

--- a/crates/cli/src/frontend/tests/progress2_format_parity.rs
+++ b/crates/cli/src/frontend/tests/progress2_format_parity.rs
@@ -10,7 +10,7 @@
 //!
 //! The format string `"\r%15s %3d%% %7.2f%s %s%s"` produces:
 //!   - Right-aligned bytes (15-char field, thousands-separated)
-//!   - Right-aligned percentage (4-char field: ` N%`, `NN%`, `100%`, `??%`)
+//!   - Right-aligned percentage (4-char field: ` N%`, `NN%`, `100%`; never `??%`)
 //!   - Right-aligned transfer rate (11-char field: value + unit suffix kB/s, MB/s, GB/s)
 //!   - Right-aligned time (10-char field: H:MM:SS or ??:??:??)
 //!   - Final tick: `(xfr#N, to-chk=M/T)` or `(xfr#N, ir-chk=M/T)` trailer
@@ -48,7 +48,8 @@ fn validate_final_tick(line: &str) -> Result<(), String> {
         ));
     }
 
-    // Must contain a percentage (digits followed by % or ??%)
+    // Must contain a percentage (digits followed by %; the percent field never
+    // uses a `??` sentinel - progress.c:128).
     if !trimmed.contains('%') {
         return Err(format!("final tick missing percentage: {trimmed:?}"));
     }
@@ -443,7 +444,8 @@ fn progress2_percentage_field_width_4_chars() {
         (0, Some(100), "  0%"),
         (50, Some(100), " 50%"),
         (100, Some(100), "100%"),
-        (0, None, " ??%"),
+        // upstream progress.c:128 - unknown total resolves to 100%, never `??%`.
+        (0, None, "100%"),
     ];
 
     for (bytes, total, expected) in test_cases {

--- a/crates/cli/src/frontend/tests/progress_format_upstream.rs
+++ b/crates/cli/src/frontend/tests/progress_format_upstream.rs
@@ -11,7 +11,8 @@
 //!   - Right-aligned elapsed time (10-char field, `%4u:%02u:%02u`)
 //!   - Transfer count and remaining count: `(xfr#N, to-chk=M/T)`
 //!
-//! When totals are unavailable, percentage shows as `??%`.
+//! The percent field never uses a `??` sentinel (progress.c:128); only the ETA
+//! field does (progress.c:118).
 
 use super::common::*;
 use super::*;
@@ -120,9 +121,12 @@ fn format_progress_percent_zero_total_returns_100() {
 }
 
 #[test]
-fn format_progress_percent_unknown_total_shows_placeholder() {
-    // When the total is not available, upstream shows "??%"
-    assert_eq!(format_progress_percent(42, None), "??%");
+fn format_progress_percent_unknown_total_resolves_to_complete() {
+    // upstream: progress.c:128 - the percent field never uses a `??` sentinel
+    // (only the ETA field does). An unknown total resolves to the completion
+    // value 100%.
+    assert_eq!(format_progress_percent(42, None), "100%");
+    assert!(!format_progress_percent(42, None).contains("??"));
 }
 
 #[test]
@@ -175,42 +179,6 @@ fn format_progress_rate_decimal_gigabyte_rate() {
 }
 
 #[test]
-fn format_progress_rate_human_small() {
-    let rate_str = format_progress_rate_human(500.0);
-    assert!(
-        rate_str.contains("B/s"),
-        "human rate <1000 should use B/s: {rate_str:?}"
-    );
-}
-
-#[test]
-fn format_progress_rate_human_kilo() {
-    let rate_str = format_progress_rate_human(1_500.0);
-    assert!(
-        rate_str.contains("kB/s"),
-        "human rate ~1.5k should use kB/s: {rate_str:?}"
-    );
-}
-
-#[test]
-fn format_progress_rate_human_mega() {
-    let rate_str = format_progress_rate_human(2_500_000.0);
-    assert!(
-        rate_str.contains("MB/s"),
-        "human rate ~2.5M should use MB/s: {rate_str:?}"
-    );
-}
-
-#[test]
-fn format_progress_rate_human_giga() {
-    let rate_str = format_progress_rate_human(2_500_000_000.0);
-    assert!(
-        rate_str.contains("GB/s"),
-        "human rate ~2.5G should use GB/s: {rate_str:?}"
-    );
-}
-
-#[test]
 fn format_progress_rate_zero_elapsed_returns_zero() {
     let rate_str = format_progress_rate(0, Duration::ZERO, HumanReadableMode::Grouped);
     assert_eq!(rate_str, "0.00kB/s");
@@ -223,9 +191,11 @@ fn format_progress_rate_zero_bytes_returns_zero() {
 }
 
 #[test]
-fn format_progress_rate_zero_bytes_human_returns_zero() {
+fn format_progress_rate_zero_bytes_human_stays_kb_per_sec() {
+    // upstream: progress.c:108-116 - the progress rate is always base-1024 and
+    // a zero rate falls into the `kB/s` tier, regardless of `-h`/`-hh`.
     let rate_str = format_progress_rate(0, Duration::from_secs(1), HumanReadableMode::DecimalUnits);
-    assert_eq!(rate_str, "0.00B/s");
+    assert_eq!(rate_str, "0.00kB/s");
 }
 
 #[test]
@@ -561,52 +531,12 @@ fn progress_percent_field_100_is_4_chars() {
 }
 
 #[test]
-fn progress_percent_field_unknown_is_3_chars_right_padded() {
+fn progress_percent_field_unknown_total_is_100_percent() {
+    // upstream: progress.c:128 - the percent field never uses `??`; an unknown
+    // total resolves to the completion value 100% (4 chars, no padding needed).
     let pct = format!("{:>4}", format_progress_percent(0, None));
     assert_eq!(pct.len(), 4);
-    assert_eq!(pct, " ??%");
-}
-
-#[test]
-fn format_verbose_rate_human_byte_range() {
-    let (value, unit) = format_verbose_rate_human(500.0);
-    assert_eq!(value, "500.00");
-    assert_eq!(unit, "B/s");
-}
-
-#[test]
-fn format_verbose_rate_human_kilo_range() {
-    let (value, unit) = format_verbose_rate_human(1_500.0);
-    assert_eq!(value, "1.50");
-    assert_eq!(unit, "kB/s");
-}
-
-#[test]
-fn format_verbose_rate_human_mega_range() {
-    let (value, unit) = format_verbose_rate_human(2_500_000.0);
-    assert_eq!(value, "2.50");
-    assert_eq!(unit, "MB/s");
-}
-
-#[test]
-fn format_verbose_rate_human_giga_range() {
-    let (value, unit) = format_verbose_rate_human(2_500_000_000.0);
-    assert_eq!(value, "2.50");
-    assert_eq!(unit, "GB/s");
-}
-
-#[test]
-fn format_verbose_rate_human_tera_range() {
-    let (value, unit) = format_verbose_rate_human(2_500_000_000_000.0);
-    assert_eq!(value, "2.50");
-    assert_eq!(unit, "TB/s");
-}
-
-#[test]
-fn format_verbose_rate_human_peta_range() {
-    let (value, unit) = format_verbose_rate_human(2_500_000_000_000_000.0);
-    assert_eq!(value, "2.50");
-    assert_eq!(unit, "PB/s");
+    assert_eq!(pct, "100%");
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/progress_live.rs
+++ b/crates/cli/src/frontend/tests/progress_live.rs
@@ -778,7 +778,9 @@ fn format_progress_rate_large_bytes_short_duration() {
 }
 
 #[test]
-fn format_progress_rate_human_nonzero() {
+fn format_progress_rate_small_stays_kb_per_sec_in_human_mode() {
+    // upstream: progress.c:108-116 - the progress rate is always base-1024,
+    // never `-h`/`-hh`; a small rate stays in the `kB/s` tier.
     let rate = format_progress_rate(
         5_000,
         Duration::from_secs(1),
@@ -786,7 +788,7 @@ fn format_progress_rate_human_nonzero() {
     );
     assert!(
         rate.contains("kB/s"),
-        "5000 B/s in human mode should show kB/s: {rate:?}"
+        "5000 B/s should show kB/s regardless of mode: {rate:?}"
     );
 }
 

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -47,7 +47,8 @@ fn emit_transfer_summary_list_only_emits_listing_and_stats() {
         2, // stats_level
         false,
         true,
-        false,
+        false, // dry_run
+        false, // only_write_batch
         None,
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged,
@@ -82,7 +83,8 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         0, // stats_level
         false,
         false,
-        false,
+        false, // dry_run
+        false, // only_write_batch
         None,
         &OutFormatContext::default(),
         NameOutputLevel::UpdatedAndUnchanged,
@@ -125,7 +127,8 @@ fn emit_transfer_summary_out_format_adds_separator_before_stats() {
         2, // stats_level
         false,
         false,
-        false,
+        false, // dry_run
+        false, // only_write_batch
         Some(&format),
         &OutFormatContext::default(),
         NameOutputLevel::Disabled,


### PR DESCRIPTION
Aligns several client-output fidelity gaps in the `--stats`/`--progress`
formatters with upstream rsync 3.4.4 (protocol 32). Each divergence was
re-verified against the upstream C source before fixing.

## Divergences fixed

### `--stats` block missing leading blank line
`output_summary` (`main.c:427`, `:458`) begins both the `STATS>=2` detail
block and the `STATS>=1` sent/received trailer with an unconditional
`rprintf(FCLIENT, "\n")`. A plain `--stats` (verbosity 0) emitted no leading
blank. Now emits exactly one leading blank when no per-file block (verbose
listing, itemize, or progress) already supplied the separator, and never
doubles it when one did.

### Progress rate wrongly honored `-h`/`-hh`
`rprint_progress` (`progress.c:108-116`) always scales the rate with base-1024
divisors (`kB/s`/`MB/s`/`GB/s`) and never consults `human_num`. The renderer
branched on `-h`/`-hh` into base-1000 units with extra `B/s`/`TB/s`/`PB/s`
tiers. The rate column now always uses the base-1024 formatter; the
human-readable branch and its now-orphaned helpers are removed. The byte
counters continue to honor `-h`/`-hh` unchanged.

### `Number of files:` folded dev + special
`output_itemized_counts` (`main.c:388`, `rsync.h:1066`) labels five categories
`reg/dir/link/dev/special`, counting device nodes (`dev`) separately from other
specials (fifos/sockets). The line folded `dev`+`fifo` into a single `special:`
count. Split into `dev:` and `special:` via a small testable helper, matching
the already-correct created/deleted breakdown lines.

### Missing ` (BATCH ONLY)` speedup suffix
`main.c:469` appends `" (BATCH ONLY)"` when `write_batch < 0`, taking
precedence over `--dry-run`'s `" (DRY RUN)"`. Only the dry-run arm was handled.
`--only-write-batch` is now threaded through the summary path and drives the
batch arm with the correct precedence.

### `??%` percent placeholder
`rprint_progress` (`progress.c:128`) computes `pct = ofs == size ? 100 : ...`
and never emits a `??` sentinel for the percent field (only the ETA field
does). An unknown total emitted `??%`; it now resolves to the completion value
`100%`, since one progress line is emitted per file at completion.

## Tests
Deterministic golden/byte coverage added or updated for:
- the `--stats` trailer starting with exactly one blank line (no doubling);
- the progress rate staying base-1024 under `-h` and `-hh` (and a zero rate
  rendering `0.00kB/s`);
- the five-category `Number of files` line with separate `dev`/`special`;
- the `(BATCH ONLY)` suffix and its precedence over `(DRY RUN)`;
- the percent field never emitting a `??` sentinel.

Existing tests that encoded the prior bytes were updated to the upstream form.

## Verification
- `cargo fmt --all -- --check`: clean
- `cargo clippy -p cli -p core --all-features --all-targets --no-deps -- -D warnings`: clean
- `cargo nextest run -p cli -p core --all-features`: 6172 passed, 0 failed
