### PR TITLE
fix(metadata): apply dir perms/setgid without -p and omit atime unless -U (upstream parity)

### DIFF
--- a/crates/core/src/client/tests/client_transfer.rs
+++ b/crates/core/src/client/tests/client_transfer.rs
@@ -250,7 +250,9 @@ fn run_client_preserves_file_metadata() {
     assert_eq!(dest_metadata.permissions().mode() & 0o777, mode);
     let dest_atime = FileTime::from_last_access_time(&dest_metadata);
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
-    assert_eq!(dest_atime, atime);
+    // upstream: rsync.c:588-589 - without --atimes/-U the access time is left
+    // unchanged (ATTRS_SKIP_ATIME); permissions and mtime are preserved.
+    assert_ne!(dest_atime, atime, "atime must not be preserved without -U");
     assert_eq!(dest_mtime, mtime);
     assert_eq!(summary.files_copied(), 1);
 }
@@ -289,7 +291,9 @@ fn run_client_preserves_directory_metadata() {
     assert_eq!(dest_metadata.permissions().mode() & 0o777, mode);
     let dest_atime = FileTime::from_last_access_time(&dest_metadata);
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
-    assert_eq!(dest_atime, atime);
+    // upstream: rsync.c:588-589 - directories always skip atime (S_ISDIR sets
+    // ATTRS_SKIP_ATIME); permissions and mtime are preserved.
+    assert_ne!(dest_atime, atime, "directory atime must never be preserved");
     assert_eq!(dest_mtime, mtime);
     assert!(summary.directories_created() >= 1);
 }
@@ -343,7 +347,12 @@ fn run_client_updates_existing_directory_metadata() {
     assert_eq!(copied_metadata.permissions().mode() & 0o777, source_mode);
     let copied_atime = FileTime::from_last_access_time(&copied_metadata);
     let copied_mtime = FileTime::from_last_modification_time(&copied_metadata);
-    assert_eq!(copied_atime, source_atime);
+    // upstream: rsync.c:588-589 - directories always skip atime; the existing
+    // directory's permissions and mtime are updated to the source values.
+    assert_ne!(
+        copied_atime, source_atime,
+        "directory atime must never be preserved"
+    );
     assert_eq!(copied_mtime, source_mtime);
 }
 

--- a/crates/core/tests/client_integration.rs
+++ b/crates/core/tests/client_integration.rs
@@ -299,7 +299,14 @@ fn test_atimes_preservation() {
         let subdir_atime = FileTime::from_last_access_time(&subdir_meta);
         let subdir_mtime = FileTime::from_last_modification_time(&subdir_meta);
 
-        assert_time_close(subdir_atime, src_dir_atime, "subdir atime");
+        // upstream: rsync.c:588-589 - `!atimes_ndx || S_ISDIR` always sets
+        // ATTRS_SKIP_ATIME for directories, so a directory's access time is
+        // never written even under --atimes; only its mtime is preserved.
+        assert_ne!(
+            subdir_atime.unix_seconds(),
+            src_dir_atime.unix_seconds(),
+            "directory atime must not be preserved even under --atimes"
+        );
         assert_time_close(subdir_mtime, src_dir_mtime, "subdir mtime");
     });
 }

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -251,7 +251,8 @@ pub(super) fn try_clone(
 /// produce, so the finalize step works identically for both paths.
 ///
 /// - Permissions: reset to `source_mode & ~umask` (matching `open()` behavior)
-/// - Timestamps: reset mtime to current time (matching newly created files)
+/// - Timestamps: reset mtime to current time when `--times` is off, and atime to
+///   current time when `--atimes`/`-U` is off (matching newly created files)
 fn normalize_cloned_metadata(
     destination: &Path,
     source_metadata: &fs::Metadata,
@@ -276,19 +277,41 @@ fn normalize_cloned_metadata(
             .map_err(|e| LocalCopyError::io("normalize cloned permissions", destination, e))?;
     }
 
-    // When timestamps are being preserved, finalize will apply source mtime.
-    // When NOT preserving, reset to current time (what a newly created file has).
-    // Use utimensat via rustix to set mtime without needing write access -
-    // clonefile may produce a read-only destination (e.g. source mode 0o444).
-    if !options.times() {
+    // clonefile() copies the source's mtime AND atime verbatim, but an
+    // open()-created file carries fresh (current-time) timestamps that upstream
+    // only overwrites from the source when the matching flag is set: mtime under
+    // --times, atime under --atimes/-U. Reset each timestamp the corresponding
+    // flag leaves alone to "now" so a clone never leaks the source value; the
+    // subsequent finalize metadata apply re-sets the source mtime (under --times)
+    // and source atime (under --atimes) as needed.
+    //
+    // Without the atime reset, a `--no-atimes` copy (the default, including `-a`)
+    // would keep the clonefile-inherited source atime instead of the fresh
+    // access time upstream produces (rsync opens a new file; atime is the write
+    // time). upstream: rsync.c:588-589 - atime is written from source only when
+    // atimes_ndx is set; otherwise the destination keeps its own (fresh) atime.
+    //
+    // Use utimensat via rustix so a read-only clone (e.g. source mode 0o444)
+    // still accepts the timestamp update without needing write access.
+    let reset_mtime = !options.times();
+    let reset_atime = !options.atimes();
+    if reset_mtime || reset_atime {
         let now = rustix::fs::Timestamps {
             last_access: rustix::fs::Timespec {
                 tv_sec: 0,
-                tv_nsec: rustix::fs::UTIME_OMIT,
+                tv_nsec: if reset_atime {
+                    rustix::fs::UTIME_NOW
+                } else {
+                    rustix::fs::UTIME_OMIT
+                },
             },
             last_modification: rustix::fs::Timespec {
                 tv_sec: 0,
-                tv_nsec: rustix::fs::UTIME_NOW,
+                tv_nsec: if reset_mtime {
+                    rustix::fs::UTIME_NOW
+                } else {
+                    rustix::fs::UTIME_OMIT
+                },
             },
         };
         rustix::fs::utimensat(
@@ -299,7 +322,7 @@ fn normalize_cloned_metadata(
         )
         .map_err(|e| {
             LocalCopyError::io(
-                "normalize cloned mtime",
+                "normalize cloned timestamps",
                 destination,
                 std::io::Error::from_raw_os_error(e.raw_os_error()),
             )

--- a/crates/engine/src/local_copy/tests/execute_metadata.rs
+++ b/crates/engine/src/local_copy/tests/execute_metadata.rs
@@ -195,7 +195,9 @@ fn execute_preserves_metadata_when_requested() {
     assert_eq!(metadata.permissions().mode() & 0o777, 0o640);
     let dest_atime = FileTime::from_last_access_time(&metadata);
     let dest_mtime = FileTime::from_last_modification_time(&metadata);
-    assert_eq!(dest_atime, atime);
+    // upstream: rsync.c:588-589 - --times alone leaves the access time unchanged
+    // (ATTRS_SKIP_ATIME); only --atimes/-U would preserve it.
+    assert_ne!(dest_atime, atime, "atime must not be preserved without -U");
     assert_eq!(dest_mtime, mtime);
     assert_eq!(summary.files_copied(), 1);
 }
@@ -367,7 +369,8 @@ fn execute_mode_0000_with_times_preservation() {
     assert_eq!(metadata.permissions().mode() & 0o777, 0o000);
     let dest_atime = FileTime::from_last_access_time(&metadata);
     let dest_mtime = FileTime::from_last_modification_time(&metadata);
-    assert_eq!(dest_atime, atime);
+    // upstream: rsync.c:588-589 - --times alone leaves the access time unchanged.
+    assert_ne!(dest_atime, atime, "atime must not be preserved without -U");
     assert_eq!(dest_mtime, mtime);
     assert_eq!(summary.files_copied(), 1);
 }
@@ -706,7 +709,9 @@ fn execute_round_trip_preserves_all_bits() {
 
     let final_atime = FileTime::from_last_access_time(&final_metadata);
     let final_mtime = FileTime::from_last_modification_time(&final_metadata);
-    assert_eq!(final_atime, atime, "atime should be preserved");
+    // upstream: rsync.c:588-589 - --times alone leaves the access time unchanged;
+    // the round trip preserves permission bits and mtime, not atime.
+    assert_ne!(final_atime, atime, "atime must not be preserved without -U");
     assert_eq!(final_mtime, mtime, "mtime should be preserved");
 }
 

--- a/crates/engine/src/local_copy/tests/execute_numeric_ids.rs
+++ b/crates/engine/src/local_copy/tests/execute_numeric_ids.rs
@@ -475,7 +475,8 @@ fn numeric_ids_with_permissions_and_times() {
     assert_eq!(metadata.permissions().mode() & 0o777, 0o640);
     let dest_atime = FileTime::from_last_access_time(&metadata);
     let dest_mtime = FileTime::from_last_modification_time(&metadata);
-    assert_eq!(dest_atime, atime);
+    // upstream: rsync.c:588-589 - --times alone leaves the access time unchanged.
+    assert_ne!(dest_atime, atime, "atime must not be preserved without -U");
     assert_eq!(dest_mtime, mtime);
     assert_eq!(summary.files_copied(), 1);
 }

--- a/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
+++ b/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
@@ -129,7 +129,7 @@ fn times_flag_preserves_mtime_on_multiple_files() {
 }
 
 #[test]
-fn times_flag_preserves_atime_on_copied_file() {
+fn times_without_u_flag_omits_atime_on_copied_file() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
@@ -157,7 +157,12 @@ fn times_flag_preserves_atime_on_copied_file() {
     let dest_atime = FileTime::from_last_access_time(&dest_metadata);
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
 
-    assert_eq!(dest_atime, atime, "atime should be preserved");
+    // upstream: rsync.c:588-589 - `--times` alone sets ATTRS_SKIP_ATIME, so the
+    // destination access time is left unchanged rather than copied from source.
+    assert_ne!(
+        dest_atime, atime,
+        "atime must not be preserved without --atimes/-U"
+    );
     assert_eq!(dest_mtime, mtime, "mtime should be preserved");
 }
 
@@ -186,9 +191,12 @@ fn atime_and_mtime_can_differ() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
+    // Preserving the atime as a distinct value requires --atimes/-U; --times
+    // alone would leave it unchanged (upstream: rsync.c:588-589). The atime nsec
+    // lands as 0 upstream (rsync.c:609), so compare seconds only.
     plan.execute_with_options(
         LocalCopyExecution::Apply,
-        LocalCopyOptions::default().times(true),
+        LocalCopyOptions::default().times(true).atimes(true),
     )
     .expect("copy succeeds");
 
@@ -196,7 +204,11 @@ fn atime_and_mtime_can_differ() {
     let dest_atime = FileTime::from_last_access_time(&dest_metadata);
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
 
-    assert_eq!(dest_atime, atime, "atime should be preserved as distinct value");
+    assert_eq!(
+        dest_atime.unix_seconds(),
+        atime.unix_seconds(),
+        "atime seconds should be preserved with --atimes"
+    );
     assert_eq!(dest_mtime, mtime, "mtime should be preserved as distinct value");
     assert_ne!(dest_atime, dest_mtime, "atime and mtime should remain different");
 }
@@ -361,7 +373,13 @@ fn times_flag_with_archive_mode() {
     let dest_atime = FileTime::from_last_access_time(&dest_metadata);
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
 
-    assert_eq!(dest_atime, atime);
+    // upstream: archive mode (-a = -rlptgoD) does NOT include --atimes/-U, so
+    // the destination access time is left unchanged (rsync.c:588-589); only the
+    // mtime is preserved.
+    assert_ne!(
+        dest_atime, atime,
+        "archive mode must not preserve atime (no -U)"
+    );
     assert_eq!(dest_mtime, mtime);
 }
 
@@ -424,7 +442,12 @@ fn times_flag_on_symlink() {
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
 
-    assert_eq!(dest_atime, link_atime, "symlink atime should be preserved");
+    // upstream: rsync.c:588-589 - default options preserve times but not atimes,
+    // so the symlink's access time is left unchanged; only its mtime is written.
+    assert_ne!(
+        dest_atime, link_atime,
+        "symlink atime must not be preserved without --atimes"
+    );
     assert_eq!(dest_mtime, link_mtime, "symlink mtime should be preserved");
 }
 

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -143,9 +143,16 @@ fn compute_dest_mode(
         // upstream: dest_mode() for new files:
         // new_mode = flist_mode & (~CHMOD_BITS | dflt_perms)
         let dflt_perms = default_perms_seed(dest_parent);
-        let new_mode = source_mode & (!0o7777 | dflt_perms);
-        // Skip the chmod if the mode already matches
+        let mut new_mode = source_mode & (!0o7777 | dflt_perms);
         if let Some(existing) = existing {
+            // upstream: rsync.c:512-516 - a freshly-created directory that
+            // inherited S_ISGID from a setgid parent keeps that bit even when
+            // !preserve_perms strips it out of the dest_mode() result:
+            // `if (inherit && S_ISDIR(new_mode) && sxp->st.st_mode & S_ISGID)`.
+            if existing.file_type().is_dir() && (existing.permissions().mode() & 0o2000) != 0 {
+                new_mode |= 0o2000;
+            }
+            // Skip the chmod if the mode already matches
             if (existing.permissions().mode() & 0o7777) == (new_mode & 0o7777) {
                 return None;
             }
@@ -872,6 +879,48 @@ pub(super) fn apply_permissions_from_entry(
                     &fresh_meta
                 };
                 if (current_meta.permissions().mode() & 0o7777) != (new_mode & 0o7777) {
+                    chmod_path_honoring_keep_dirlinks(
+                        destination,
+                        new_mode,
+                        options,
+                        "apply dest_mode",
+                    )?;
+                }
+            } else if entry.file_type().is_dir() {
+                // upstream: generator.c:1465-1466 - even when !preserve_perms
+                // the generator runs `file->mode = dest_mode(...)` for
+                // directories, and set_file_attrs() (rsync.c:659-660) chmods
+                // the dir to it. A new dir therefore lands the source mode
+                // masked by dflt_perms (so a source 0700 dir stays 0700 rather
+                // than the mkdir umask default); an existing dir keeps its own
+                // permission bits (pre_transfer_meta = Some -> the exists=true
+                // branch). Without this, a network-received dir was created
+                // `mkdirat(0o777)` and never re-chmod'd, landing 0o755.
+                let mut new_mode = dest_mode_for_existing_or_new(entry, pre_transfer_meta);
+                let fresh_meta;
+                let current_meta = if let Some(meta) = cached_meta {
+                    meta
+                } else {
+                    fresh_meta = fs::metadata(destination).map_err(|error| {
+                        MetadataError::new("inspect destination permissions", destination, error)
+                    })?;
+                    &fresh_meta
+                };
+                let current_mode = current_meta.permissions().mode();
+                // upstream: rsync.c:512-516 - a freshly-created dir (no
+                // pre-transfer stat) that inherited S_ISGID from a setgid
+                // parent keeps that bit even though dest_mode() dropped it.
+                if pre_transfer_meta.is_none() && (current_mode & 0o2000) != 0 {
+                    new_mode |= 0o2000;
+                }
+                // A directory whose target mode lacks owner rwx would block the
+                // receiver from writing its contents. Upstream keeps it
+                // writable during the transfer via the dir_tweaking u+rwx grant
+                // (generator.c:1512) and restores the strict mode in
+                // touch_up_dirs; that grant is gated on --perms here, so in the
+                // !perms path leave such a directory at its umask default
+                // (owner-writable) rather than chmod'ing it non-writable.
+                if (new_mode & 0o700) == 0o700 && (current_mode & 0o7777) != (new_mode & 0o7777) {
                     chmod_path_honoring_keep_dirlinks(
                         destination,
                         new_mode,

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -42,7 +42,13 @@ fn file_permissions_and_times_are_preserved() {
     let dest_meta = fs::metadata(&dest).expect("dest metadata");
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
-    assert_eq!(dest_atime, atime);
+    // upstream: rsync.c:588-589 - without --atimes the destination access time
+    // is left unchanged (ATTRS_SKIP_ATIME); it must NOT be clobbered with the
+    // source atime. The default options preserve times but not atimes.
+    assert_ne!(
+        dest_atime, atime,
+        "atime must not be written to the source value without --atimes"
+    );
     assert_eq!(dest_mtime, mtime);
 
     #[cfg(unix)]
@@ -256,7 +262,13 @@ fn directory_permissions_and_times_are_preserved() {
     let dest_meta = fs::metadata(&dest).expect("dest metadata");
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
-    assert_eq!(dest_atime, atime);
+    // upstream: rsync.c:588-589 - `!atimes_ndx || S_ISDIR` always sets
+    // ATTRS_SKIP_ATIME for directories, so a directory's access time is never
+    // written (not even under --atimes).
+    assert_ne!(
+        dest_atime, atime,
+        "directory atime must never be written (ATTRS_SKIP_ATIME for S_ISDIR)"
+    );
     assert_eq!(dest_mtime, mtime);
 
     #[cfg(unix)]
@@ -288,9 +300,10 @@ fn symlink_times_are_preserved_without_following_target() {
     apply_symlink_metadata(&dest_link, &metadata).expect("apply symlink metadata");
 
     let dest_meta = fs::symlink_metadata(&dest_link).expect("dest metadata");
-    let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
-    assert_eq!(dest_atime, atime);
+    // upstream: rsync.c:588-589 - without --atimes the symlink's access time is
+    // left unchanged; only its mtime is written (via lutimes, without following
+    // the target).
     assert_eq!(dest_mtime, mtime);
 
     let dest_target = fs::read_link(&dest_link).expect("read dest link");
@@ -588,7 +601,12 @@ fn epoch_timestamp_zero_seconds_is_preserved() {
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
 
-    assert_eq!(dest_atime, epoch_time, "atime should be preserved at epoch");
+    // upstream: rsync.c:588-589 - without --atimes the access time is left
+    // unchanged; only the epoch mtime must round-trip.
+    assert_ne!(
+        dest_atime, epoch_time,
+        "atime must not be written without --atimes"
+    );
     assert_eq!(dest_mtime, epoch_time, "mtime should be preserved at epoch");
 }
 
@@ -1772,5 +1790,177 @@ fn non_root_ownership_gate_drops_owner_keeps_member_group() {
     assert!(
         gated_group.is_some(),
         "non-root may set the group to its own effective gid"
+    );
+}
+
+// Task #168 regression coverage: directory permissions without -p over the
+// entry/network path, atime omission without --atimes, directory atime skip,
+// inherited setgid preservation, and zeroed atime nanoseconds under --atimes.
+
+#[cfg(unix)]
+#[test]
+fn dir_without_perms_over_entry_path_lands_source_mode() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let dir = temp.path().join("d");
+    fs::create_dir(&dir).expect("create dir");
+    // Simulate the receiver's mkdirat(0o777) umask-default result.
+    fs::set_permissions(&dir, PermissionsExt::from_mode(0o755)).expect("chmod 0755");
+
+    let entry = FileEntry::new_directory("d".into(), 0o700);
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false);
+    apply_metadata_from_file_entry(&dir, &entry, &opts).expect("apply dir entry");
+
+    // upstream: generator.c:1465-1466 + rsync.c:659-660 - a new directory
+    // without -p lands the source mode masked by dflt_perms, so a 0700 source
+    // dir stays 0700 rather than the mkdir umask default 0755.
+    assert_eq!(
+        current_mode(&dir) & 0o777,
+        0o700,
+        "new directory without -p must land the source mode, not 0755"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn dir_without_perms_over_entry_path_keeps_existing_dir_mode() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let dir = temp.path().join("d");
+    fs::create_dir(&dir).expect("create dir");
+    fs::set_permissions(&dir, PermissionsExt::from_mode(0o700)).expect("chmod 0700");
+    let pre_transfer = fs::metadata(&dir).expect("pre-transfer stat");
+
+    let entry = FileEntry::new_directory("d".into(), 0o777);
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false);
+    // pre_transfer = Some means the dir already existed: upstream keeps its own
+    // permission bits (dest_mode exists=true), never rewriting them.
+    apply_metadata_with_pre_transfer_stat(&dir, &entry, &opts, None, Some(pre_transfer))
+        .expect("apply dir entry");
+
+    assert_eq!(
+        current_mode(&dir) & 0o777,
+        0o700,
+        "an existing directory without -p must keep its own permission bits"
+    );
+}
+
+#[test]
+fn entry_path_omits_atime_without_atimes() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("f.txt");
+    fs::write(&dest, b"data").expect("write dest");
+    let before = FileTime::from_last_access_time(&fs::metadata(&dest).expect("pre meta"));
+
+    let mut entry = FileEntry::new_file("f.txt".into(), 4, 0o644);
+    entry.set_mtime(1_600_000_000, 0);
+    entry.set_atime(1_650_000_000);
+
+    let opts = MetadataOptions::new().preserve_times(true);
+    apply_metadata_from_file_entry(&dest, &entry, &opts).expect("apply entry");
+
+    let dest_meta = fs::metadata(&dest).expect("dest metadata");
+    let dest_atime = FileTime::from_last_access_time(&dest_meta);
+    let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
+    // upstream: rsync.c:588-589 - without --atimes the access time is left
+    // unchanged (UTIME_OMIT); only the mtime is written.
+    assert_eq!(
+        dest_mtime,
+        FileTime::from_unix_time(1_600_000_000, 0),
+        "mtime must be written from the entry"
+    );
+    assert_eq!(
+        dest_atime, before,
+        "atime must be left unchanged without --atimes"
+    );
+    assert_ne!(
+        dest_atime.unix_seconds(),
+        1_650_000_000,
+        "atime must not be clobbered with the entry atime without --atimes"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn setgid_parent_new_dir_keeps_inherited_sgid() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let parent = temp.path().join("sgid-parent");
+    fs::create_dir(&parent).expect("create parent");
+    // Mark the parent setgid so a child directory inherits S_ISGID at mkdir.
+    fs::set_permissions(&parent, PermissionsExt::from_mode(0o2755)).expect("chmod g+s parent");
+
+    let child = parent.join("child");
+    fs::create_dir(&child).expect("create child");
+
+    // Only meaningful when the filesystem propagated the setgid bit at mkdir.
+    let inherited = fs::metadata(&child)
+        .expect("stat child")
+        .permissions()
+        .mode()
+        & 0o2000
+        != 0;
+    if !inherited {
+        return;
+    }
+
+    let entry = FileEntry::new_directory("child".into(), 0o755);
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false);
+    apply_metadata_from_file_entry(&child, &entry, &opts).expect("apply dir entry");
+
+    // upstream: rsync.c:512-516 - a freshly-created dir keeps an inherited
+    // S_ISGID even though dest_mode() strips it from the non-preserved mode.
+    assert_ne!(
+        current_mode(&child) & 0o2000,
+        0,
+        "inherited setgid must be preserved on a new directory without -p"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn local_atimes_zeroes_atime_nsec() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src.txt");
+    let dest = temp.path().join("dst.txt");
+    fs::write(&source, b"data").expect("write source");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let atime = FileTime::from_unix_time(1_700_000_000, 123_456_789);
+    let mtime = FileTime::from_unix_time(1_700_000_100, 0);
+    set_file_times(&source, atime, mtime).expect("set source times");
+
+    let metadata = fs::metadata(&source).expect("metadata");
+    let opts = MetadataOptions::new()
+        .preserve_times(true)
+        .preserve_atimes(true);
+    apply_file_metadata_with_options(&dest, &metadata, &opts).expect("apply metadata");
+
+    let dest_meta = fs::metadata(&dest).expect("dest metadata");
+    let dest_atime = FileTime::from_last_access_time(&dest_meta);
+    // upstream: rsync.c:609 - the applied access time's nanosecond field is 0.
+    assert_eq!(
+        dest_atime.unix_seconds(),
+        1_700_000_000,
+        "atime seconds preserved"
+    );
+    assert_eq!(
+        dest_atime.nanoseconds(),
+        0,
+        "upstream zeroes the atime nanosecond field"
     );
 }

--- a/crates/metadata/src/apply/timestamps.rs
+++ b/crates/metadata/src/apply/timestamps.rs
@@ -33,17 +33,25 @@ pub(super) fn set_timestamp_like(
     existing: Option<&fs::Metadata>,
     options: Option<&MetadataOptions>,
 ) -> Result<(), MetadataError> {
-    let accessed = FileTime::from_last_access_time(metadata);
     let modified = FileTime::from_last_modification_time(metadata);
+
+    // upstream: rsync.c:588-589 - atime is written only when `--atimes`/`-U`
+    // is active AND the node is not a directory (`!atimes_ndx || S_ISDIR`
+    // sets ATTRS_SKIP_ATIME). Otherwise the destination's access time is left
+    // unchanged. upstream: rsync.c:609 - when atime IS applied its nanosecond
+    // field is forced to zero.
+    let apply_atime = options.is_some_and(|o| o.atimes()) && !metadata.file_type().is_dir();
+    let accessed = apply_atime.then(|| {
+        FileTime::from_unix_time(FileTime::from_last_access_time(metadata).unix_seconds(), 0)
+    });
 
     // upstream: rsync.c:597-612 - mtime and atime are checked independently;
     // the utimensat is only skipped when ALL relevant timestamps match.
     if let Some(existing) = existing {
         let mtime_matches = FileTime::from_last_modification_time(existing) == modified;
-        let atime_matches = if options.is_some_and(|o| o.atimes()) {
-            FileTime::from_last_access_time(existing) == accessed
-        } else {
-            true
+        let atime_matches = match accessed {
+            Some(accessed) => FileTime::from_last_access_time(existing) == accessed,
+            None => true,
         };
         if mtime_matches && atime_matches {
             return Ok(());
@@ -63,10 +71,15 @@ pub(super) fn set_timestamp_like(
     #[cfg(not(unix))]
     let open_free_path = !follow_symlinks;
 
-    let result = if open_free_path {
-        set_symlink_file_times(destination, accessed, modified)
-    } else {
-        set_file_times(destination, accessed, modified)
+    let result = match accessed {
+        Some(accessed) => {
+            if open_free_path {
+                set_symlink_file_times(destination, accessed, modified)
+            } else {
+                set_file_times(destination, accessed, modified)
+            }
+        }
+        None => set_mtime_omit_atime(destination, modified, open_free_path),
     };
 
     if let Err(error) = result {
@@ -110,6 +123,50 @@ fn is_tolerable_special_time_error(error: &io::Error) -> bool {
     )
 }
 
+/// Sets only the mtime on a path node, leaving the access time unchanged.
+///
+/// Mirrors upstream's `ATTRS_SKIP_ATIME` behaviour (`rsync.c:588-589`): when
+/// `--atimes`/`-U` is off, or for any directory, the access time is left
+/// untouched rather than being written to the mtime value. On Unix this uses
+/// `utimensat` with `UTIME_OMIT` for the access-time slot so no access-time
+/// syscall side effect leaks in; `open_free` selects the
+/// `AT_SYMLINK_NOFOLLOW` variant used for symlinks and special files
+/// (device/FIFO/socket), which updates the node's own mtime without opening
+/// it (a peerless FIFO would otherwise block `File::open`). On non-Unix
+/// targets `filetime::set_file_mtime` provides the equivalent mtime-only
+/// update.
+// upstream: rsync.c:588-589 - `!atimes_ndx || S_ISDIR` sets ATTRS_SKIP_ATIME
+fn set_mtime_omit_atime(
+    destination: &Path,
+    mtime: FileTime,
+    open_free: bool,
+) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        let times = rustix::fs::Timestamps {
+            last_access: rustix::fs::Timespec {
+                tv_sec: 0,
+                tv_nsec: rustix::fs::UTIME_OMIT,
+            },
+            last_modification: rustix::fs::Timespec {
+                tv_sec: mtime.unix_seconds(),
+                tv_nsec: mtime.nanoseconds().into(),
+            },
+        };
+        let flags = if open_free {
+            rustix::fs::AtFlags::SYMLINK_NOFOLLOW
+        } else {
+            rustix::fs::AtFlags::empty()
+        };
+        rustix::fs::utimensat(rustix::fs::CWD, destination, &times, flags).map_err(io::Error::from)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = open_free;
+        filetime::set_file_mtime(destination, mtime)
+    }
+}
+
 /// fd-based variant of [`set_timestamp_like`] that uses `futimens` on the open fd.
 ///
 /// Avoids a path lookup by operating directly on the file descriptor.
@@ -126,27 +183,41 @@ pub(super) fn set_timestamp_with_fd(
     existing: Option<&fs::Metadata>,
     options: Option<&MetadataOptions>,
 ) -> Result<(), MetadataError> {
-    let accessed = FileTime::from_last_access_time(metadata);
     let modified = FileTime::from_last_modification_time(metadata);
+
+    // upstream: rsync.c:588-589 - atime is written only under `--atimes`/`-U`
+    // and never for directories; rsync.c:609 - the applied atime nsec is 0.
+    let apply_atime = options.is_some_and(|o| o.atimes()) && !metadata.file_type().is_dir();
+    let accessed = apply_atime.then(|| {
+        FileTime::from_unix_time(FileTime::from_last_access_time(metadata).unix_seconds(), 0)
+    });
 
     // upstream: rsync.c:597-612 - mtime and atime are checked independently
     if let Some(existing) = existing {
         let mtime_matches = FileTime::from_last_modification_time(existing) == modified;
-        let atime_matches = if options.is_some_and(|o| o.atimes()) {
-            FileTime::from_last_access_time(existing) == accessed
-        } else {
-            true
+        let atime_matches = match accessed {
+            Some(accessed) => FileTime::from_last_access_time(existing) == accessed,
+            None => true,
         };
         if mtime_matches && atime_matches {
             return Ok(());
         }
     }
 
-    let timestamps = rustix::fs::Timestamps {
-        last_access: rustix::fs::Timespec {
+    // upstream: rsync.c:588-589,609 - omit the access time (UTIME_OMIT) when
+    // it must not be written; otherwise set it with a zeroed nanosecond field.
+    let last_access = match accessed {
+        Some(accessed) => rustix::fs::Timespec {
             tv_sec: accessed.unix_seconds(),
-            tv_nsec: accessed.nanoseconds().into(),
+            tv_nsec: 0,
         },
+        None => rustix::fs::Timespec {
+            tv_sec: 0,
+            tv_nsec: rustix::fs::UTIME_OMIT,
+        },
+    };
+    let timestamps = rustix::fs::Timestamps {
+        last_access,
         last_modification: rustix::fs::Timespec {
             tv_sec: modified.unix_seconds(),
             tv_nsec: modified.nanoseconds().into(),
@@ -172,7 +243,9 @@ pub(super) fn apply_atime_only_from_metadata(
     destination: &Path,
     existing: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
-    let source_atime = FileTime::from_last_access_time(metadata);
+    // upstream: rsync.c:609 - the applied access time's nanosecond field is 0.
+    let source_atime =
+        FileTime::from_unix_time(FileTime::from_last_access_time(metadata).unix_seconds(), 0);
 
     if let Some(existing) = existing {
         if FileTime::from_last_access_time(existing) == source_atime {
@@ -209,7 +282,9 @@ pub(super) fn apply_atime_only_from_metadata_with_fd(
     fd: BorrowedFd<'_>,
     existing: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
-    let source_atime = FileTime::from_last_access_time(metadata);
+    // upstream: rsync.c:609 - the applied access time's nanosecond field is 0.
+    let source_atime =
+        FileTime::from_unix_time(FileTime::from_last_access_time(metadata).unix_seconds(), 0);
 
     if let Some(existing) = existing {
         if FileTime::from_last_access_time(existing) == source_atime {
@@ -260,11 +335,14 @@ pub(super) fn apply_timestamps_from_entry(
 ) -> Result<(), MetadataError> {
     let mtime = FileTime::from_unix_time(entry.mtime(), entry.mtime_nsec());
 
-    // upstream: rsync.c:600-603 - preserves source atime with --atimes, else mtime for both
-    let atime = if options.atimes() && entry.atime() != 0 {
-        FileTime::from_unix_time(entry.atime(), 0)
+    // upstream: rsync.c:588-589 - the access time is written only under
+    // `--atimes`/`-U` and never for directories (`!atimes_ndx || S_ISDIR`
+    // sets ATTRS_SKIP_ATIME); otherwise it is left unchanged (UTIME_OMIT)
+    // rather than being clobbered with the mtime value.
+    let atime = if options.atimes() && !entry.file_type().is_dir() && entry.atime() != 0 {
+        Some(FileTime::from_unix_time(entry.atime(), 0))
     } else {
-        mtime
+        None
     };
 
     // upstream: rsync.c:set_file_attrs() - skips utimensat when timestamps match
@@ -273,9 +351,8 @@ pub(super) fn apply_timestamps_from_entry(
             let current_mtime = FileTime::from_last_modification_time(meta);
             if current_mtime != mtime {
                 true
-            } else if options.atimes() {
-                let current_atime = FileTime::from_last_access_time(meta);
-                current_atime != atime
+            } else if let Some(atime) = atime {
+                FileTime::from_last_access_time(meta) != atime
             } else {
                 false
             }
@@ -306,15 +383,22 @@ pub(super) fn apply_timestamps_from_entry(
 fn set_entry_times(
     destination: &Path,
     entry: &protocol::flist::FileEntry,
-    atime: FileTime,
+    atime: Option<FileTime>,
     mtime: FileTime,
     context: &'static str,
 ) -> Result<(), MetadataError> {
     let is_special = entry.is_device() || entry.is_special();
-    let result = if is_special {
-        set_symlink_file_times(destination, atime, mtime)
-    } else {
-        set_file_times(destination, atime, mtime)
+    // upstream: rsync.c:588-589 - `atime = None` reproduces ATTRS_SKIP_ATIME,
+    // leaving the destination's access time untouched (UTIME_OMIT).
+    let result = match atime {
+        Some(atime) => {
+            if is_special {
+                set_symlink_file_times(destination, atime, mtime)
+            } else {
+                set_file_times(destination, atime, mtime)
+            }
+        }
+        None => set_mtime_omit_atime(destination, mtime, is_special),
     };
 
     if let Err(error) = result {
@@ -344,11 +428,13 @@ pub(super) fn apply_symlink_timestamps_from_entry(
 ) -> Result<(), MetadataError> {
     let mtime = FileTime::from_unix_time(entry.mtime(), entry.mtime_nsec());
 
-    // upstream: rsync.c:600-603 - preserves source atime with --atimes, else mtime for both
+    // upstream: rsync.c:588-589 - a symlink is never a directory, so its atime
+    // is written only under `--atimes`/`-U`; otherwise it is left unchanged
+    // (UTIME_OMIT) rather than being clobbered with the mtime value.
     let atime = if options.atimes() && entry.atime() != 0 {
-        FileTime::from_unix_time(entry.atime(), 0)
+        Some(FileTime::from_unix_time(entry.atime(), 0))
     } else {
-        mtime
+        None
     };
 
     // upstream: rsync.c:set_file_attrs() - skips utimensat when timestamps match
@@ -357,9 +443,8 @@ pub(super) fn apply_symlink_timestamps_from_entry(
             let current_mtime = FileTime::from_last_modification_time(meta);
             if current_mtime != mtime {
                 true
-            } else if options.atimes() {
-                let current_atime = FileTime::from_last_access_time(meta);
-                current_atime != atime
+            } else if let Some(atime) = atime {
+                FileTime::from_last_access_time(meta) != atime
             } else {
                 false
             }
@@ -368,8 +453,14 @@ pub(super) fn apply_symlink_timestamps_from_entry(
     };
 
     if needs_utime {
-        set_symlink_file_times(destination, atime, mtime)
-            .map_err(|error| MetadataError::new("preserve timestamps", destination, error))?;
+        // upstream: rsync.c:set_times() uses lutimes/utimensat(AT_SYMLINK_NOFOLLOW)
+        // on the symlink itself. `open_free = true` selects that NOFOLLOW variant.
+        match atime {
+            Some(atime) => set_symlink_file_times(destination, atime, mtime)
+                .map_err(|error| MetadataError::new("preserve timestamps", destination, error))?,
+            None => set_mtime_omit_atime(destination, mtime, true)
+                .map_err(|error| MetadataError::new("preserve timestamps", destination, error))?,
+        }
     }
 
     Ok(())
@@ -413,7 +504,13 @@ pub(super) fn apply_atime_only_from_entry(
                 FileTime::from_last_modification_time(&meta)
             }
         };
-        set_entry_times(destination, entry, atime, mtime, "preserve access time")?;
+        set_entry_times(
+            destination,
+            entry,
+            Some(atime),
+            mtime,
+            "preserve access time",
+        )?;
     }
 
     Ok(())

--- a/crates/metadata/tests/timestamp_2038.rs
+++ b/crates/metadata/tests/timestamp_2038.rs
@@ -65,9 +65,11 @@ fn file_metadata_preserves_timestamp_at_2038_boundary() {
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
 
-    assert_eq!(
+    // upstream: rsync.c:588-589 - without --atimes the access time is left
+    // unchanged (ATTRS_SKIP_ATIME); the 2038-boundary overflow test is on mtime.
+    assert_ne!(
         dest_atime, atime,
-        "atime should be preserved at 2038 boundary"
+        "atime must not be preserved without --atimes"
     );
     assert_eq!(
         dest_mtime, mtime,
@@ -96,7 +98,11 @@ fn file_metadata_preserves_timestamp_before_2038() {
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
 
-    assert_eq!(dest_atime, atime, "atime should be preserved before 2038");
+    // upstream: rsync.c:588-589 - atime not written without --atimes.
+    assert_ne!(
+        dest_atime, atime,
+        "atime must not be preserved without --atimes"
+    );
     assert_eq!(dest_mtime, mtime, "mtime should be preserved before 2038");
 }
 
@@ -121,7 +127,11 @@ fn file_metadata_preserves_timestamp_after_2038() {
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
 
-    assert_eq!(dest_atime, atime, "atime should be preserved after 2038");
+    // upstream: rsync.c:588-589 - atime not written without --atimes.
+    assert_ne!(
+        dest_atime, atime,
+        "atime must not be preserved without --atimes"
+    );
     assert_eq!(dest_mtime, mtime, "mtime should be preserved after 2038");
 }
 
@@ -146,7 +156,11 @@ fn file_metadata_preserves_timestamp_year_2100() {
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
 
-    assert_eq!(dest_atime, atime, "atime should be preserved for year 2100");
+    // upstream: rsync.c:588-589 - atime not written without --atimes.
+    assert_ne!(
+        dest_atime, atime,
+        "atime must not be preserved without --atimes"
+    );
     assert_eq!(dest_mtime, mtime, "mtime should be preserved for year 2100");
 }
 
@@ -182,7 +196,11 @@ fn file_metadata_preserves_timestamp_year_3000() {
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
 
-    assert_eq!(dest_atime, atime, "atime should be preserved for year 3000");
+    // upstream: rsync.c:588-589 - atime not written without --atimes.
+    assert_ne!(
+        dest_atime, atime,
+        "atime must not be preserved without --atimes"
+    );
     assert_eq!(dest_mtime, mtime, "mtime should be preserved for year 3000");
 }
 
@@ -207,10 +225,8 @@ fn directory_metadata_preserves_timestamp_beyond_2038() {
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
 
-    assert_eq!(
-        dest_atime, atime,
-        "directory atime should be preserved beyond 2038"
-    );
+    // upstream: rsync.c:588-589 - directories always skip atime (S_ISDIR).
+    assert_ne!(dest_atime, atime, "directory atime must never be preserved");
     assert_eq!(
         dest_mtime, mtime,
         "directory mtime should be preserved beyond 2038"
@@ -241,9 +257,10 @@ fn symlink_metadata_preserves_timestamp_beyond_2038() {
     let dest_atime = FileTime::from_last_access_time(&dest_meta);
     let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
 
-    assert_eq!(
+    // upstream: rsync.c:588-589 - symlink atime not written without --atimes.
+    assert_ne!(
         dest_atime, atime,
-        "symlink atime should be preserved beyond 2038"
+        "symlink atime must not be preserved without --atimes"
     );
     assert_eq!(
         dest_mtime, mtime,

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -11,7 +11,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use logging::{debug_log, info_log};
-use metadata::{AclIdMapper, MetadataOptions, apply_metadata_with_cached_stat};
+use metadata::{AclIdMapper, MetadataOptions, apply_metadata_with_pre_transfer_stat};
 use protocol::acl::AclCache;
 use protocol::flist::FileEntry;
 use protocol::xattr::XattrList;
@@ -374,26 +374,43 @@ impl ReceiverContext {
         let preserve_perms = metadata_opts.permissions();
         #[cfg(unix)]
         let fake_super = metadata_opts.fake_super_enabled();
-        let entry_snapshots: Vec<(PathBuf, FileEntry, Option<XattrList>)> = dir_entries
-            .into_iter()
-            .filter(|(_, _, dir_path)| {
-                !failed_dir_paths.contains(dir_path) && !skipped_existing_dirs.contains(dir_path)
-            })
-            .map(|(idx, _, dir_path)| {
-                let entry = &self.file_list[idx];
-                let xattr_list = self.resolve_xattr_list(entry);
-                // `mut` is only exercised by the Unix transient-writable-mode
-                // grant below; on other platforms the clone is never mutated.
-                #[cfg_attr(not(unix), allow(unused_mut))]
-                let mut entry = entry.clone();
-                #[cfg(unix)]
-                if dir_needs_writable_transfer_mode(preserve_perms, fake_super, entry.permissions())
-                {
-                    entry.set_mode(entry.mode() | 0o700);
-                }
-                (dir_path, entry, xattr_list)
-            })
-            .collect();
+        let entry_snapshots: Vec<(PathBuf, FileEntry, Option<XattrList>, Option<fs::Metadata>)> =
+            dir_entries
+                .into_iter()
+                .zip(dir_was_new.iter().copied())
+                .filter(|((_, _, dir_path), _)| {
+                    !failed_dir_paths.contains(dir_path)
+                        && !skipped_existing_dirs.contains(dir_path)
+                })
+                .map(|((idx, _, dir_path), is_new)| {
+                    let entry = &self.file_list[idx];
+                    let xattr_list = self.resolve_xattr_list(entry);
+                    // `mut` is only exercised by the Unix transient-writable-mode
+                    // grant below; on other platforms the clone is never mutated.
+                    #[cfg_attr(not(unix), allow(unused_mut))]
+                    let mut entry = entry.clone();
+                    #[cfg(unix)]
+                    if dir_needs_writable_transfer_mode(
+                        preserve_perms,
+                        fake_super,
+                        entry.permissions(),
+                    ) {
+                        entry.set_mode(entry.mode() | 0o700);
+                    }
+                    // upstream: generator.c:1465 dest_mode(..., statret == 0) -
+                    // an existing dir keeps its own perms (exists=true), a new
+                    // dir gets the source mode masked by dflt_perms
+                    // (exists=false). Supply the pre-transfer stat only for a
+                    // dir that already existed so the !perms dest_mode() apply
+                    // takes the exists=true branch and never rewrites its bits.
+                    let pre_transfer = if is_new {
+                        None
+                    } else {
+                        fs::metadata(&dir_path).ok()
+                    };
+                    (dir_path, entry, xattr_list, pre_transfer)
+                })
+                .collect();
         let dir_creation_errors: Vec<(PathBuf, String)> = failed_dir_paths
             .into_iter()
             .map(|p| {
@@ -412,10 +429,14 @@ impl ReceiverContext {
             entry_snapshots,
             self.parallel_thresholds
                 .for_op(crate::parallel_io::ParallelOp::Metadata),
-            move |(dir_path, entry, xattr_list)| {
-                if let Err(e) =
-                    apply_metadata_with_cached_stat(&dir_path, &entry, &metadata_opts_clone, None)
-                {
+            move |(dir_path, entry, xattr_list, pre_transfer)| {
+                if let Err(e) = apply_metadata_with_pre_transfer_stat(
+                    &dir_path,
+                    &entry,
+                    &metadata_opts_clone,
+                    None,
+                    pre_transfer,
+                ) {
                     return Some((dir_path, e.to_string()));
                 }
                 // Apply cached ACLs after metadata
@@ -631,7 +652,7 @@ impl ReceiverContext {
         // (`cd+++++++++`); an existing dir reports the attribute-diff flags
         // (ITEM_REPORT_{TIME,PERMS,OWNER,GROUP}) so a differing root `.` mtime
         // emits `.d..t......`. For an existing dir the stat must be read now,
-        // before apply_metadata_with_cached_stat below overwrites the mtime.
+        // before apply_metadata_with_pre_transfer_stat below overwrites the mtime.
         let iflags: u32 = if is_new {
             crate::generator::ItemFlags::ITEM_LOCAL_CHANGE
                 | crate::generator::ItemFlags::ITEM_IS_NEW
@@ -705,8 +726,22 @@ impl ReceiverContext {
         let apply_entry = tweaked_entry.as_ref().unwrap_or(entry);
         #[cfg(not(unix))]
         let apply_entry = entry;
-        if let Err(e) = apply_metadata_with_cached_stat(&dir_path, apply_entry, metadata_opts, None)
-        {
+        // upstream: generator.c:1465 dest_mode(..., statret == 0) - supply the
+        // pre-transfer stat only for a dir that already existed so the !perms
+        // dest_mode() apply keeps its own permission bits (exists=true) instead
+        // of rewriting them; a freshly created dir (is_new) uses exists=false.
+        let pre_transfer = if is_new {
+            None
+        } else {
+            fs::metadata(&dir_path).ok()
+        };
+        if let Err(e) = apply_metadata_with_pre_transfer_stat(
+            &dir_path,
+            apply_entry,
+            metadata_opts,
+            None,
+            pre_transfer,
+        ) {
             if self.config.flags.verbose && self.config.connection.client_mode {
                 info_log!(
                     Misc,


### PR DESCRIPTION
## Summary

Fixes a cluster of metadata-application divergences from upstream rsync 3.4.4
(protocol 32), all source-verified against the upstream C. Each divergence is a
focused change with its own test and an upstream file:line citation in a code
comment.

## Upstream references

- `generator.c:1465-1466` — `if (!preserve_perms) file->mode = dest_mode(file->mode, sx.st.st_mode, dflt_perms, statret == 0);` runs for directories too.
- `rsync.c:449-471` — `dest_mode()`: new node gets `flist_mode & (~CHMOD_BITS | dflt_perms)`, existing keeps its own bits.
- `rsync.c:659-660` — `set_file_attrs()` chmods the (post-rename) node to `new_mode`.
- `rsync.c:512-516` — a freshly-created dir keeps an inherited `S_ISGID` even when `!preserve_perms`.
- `rsync.c:588-589` — `if (!atimes_ndx || S_ISDIR(...)) flags |= ATTRS_SKIP_ATIME;`.
- `rsync.c:609` — the applied access time's nanosecond field is set to 0.

## Divergences fixed

1. **Directory permissions without `-p` over the wire (MED-HIGH).** The `!perms`
   `dest_mode()` chmod in `apply_permissions_from_entry` was gated to regular
   files, so a network-received directory created `mkdirat(0o777)` was never
   re-chmod'd and landed `0o755` (umask default) instead of the source mode.
   Fix: extend the branch to directories — a new dir lands the source mode masked
   by `dflt_perms` (source `0700` -> `0700`), an existing dir keeps its own bits
   via a pre-transfer stat plumbed from the receiver's directory-creation passes.
   The local-copy path already handled this via `compute_dest_mode` and is left
   unchanged.

2. **atime written when `--atimes`/`-U` is off (MED).** Both the entry path
   (atime was set to the mtime) and the local path (atime set to the source
   atime) now omit the access time (`UTIME_OMIT`) so it is left unchanged,
   matching `ATTRS_SKIP_ATIME`.

3. **atime applied to directories (LOW).** Directories now always skip the
   access time (in both time paths), even under `--atimes`.

4. **setgid inheritance lost on new dirs without `-p` (MED-LOW).** A freshly
   created directory that inherited `S_ISGID` from a setgid parent now keeps that
   bit after `dest_mode()` strips it, in both `compute_dest_mode` and the entry
   directory path.

5. **Local `-U` atime nanoseconds not zeroed (LOW).** The local time paths now
   zero the applied atime's nanosecond field.

## Scope note

For a source directory whose mode lacks owner-write (e.g. `0555`/`0500`)
transferred without `-p`, the destination retains the umask-default writable
mode (unchanged from prior behaviour) rather than the restrictive source mode.
Applying the restrictive mode requires the receiver's `u+rwx` transfer-window
grant to fire in the `!perms` case (upstream `generator.c:1512`), which is
gated on `--perms` here; extending it is left as a separate change. Directories
with owner-`rwx` (the overwhelming majority) get the exact source mode.

## Tests

- New: a `0700` source dir over the entry path lands `0700`; an existing dir
  keeps its own bits; the entry path omits atime without `-U`; an inherited
  `S_ISGID` survives on a new dir without `-p`; a local `-U` copy zeroes the
  atime nanoseconds.
- Updated the existing metadata/engine/core tests that encoded the pre-fix
  behaviour (atime written without `-U`, atime written to directories) to assert
  the upstream-correct result. `atime_and_mtime_can_differ` now enables
  `--atimes` to exercise real atime preservation.

## Verification (physical x86_64 host, rustc 1.88.0)

- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p metadata -p transfer -p engine --all-features --all-targets --no-deps -- -D warnings` — clean.
- `cargo nextest run -p metadata -p transfer -p engine --all-features` — 7845 passed, 29 skipped.
- `cargo nextest run -p core --all-features` — 2506 passed.
- `cargo nextest run -p daemon --all-features` — 1722 passed.
