### PR TITLE
fix(cli): --max-delete must not enable deletion + option validation parity

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -282,10 +282,15 @@ where
         None => None,
     };
 
+    // upstream: options.c:2210 - the multiple-delete-WHEN check counts
+    // `delete_before + !!delete_during + delete_after`, where both
+    // `--delete-during`/`--del` and `--delete-delay` write the single
+    // `delete_during` counter (options.c:724-725). Combining `--del` with
+    // `--delete-delay` therefore selects one "during" term and is NOT an error;
+    // only distinct WHEN phases (before/during/after) conflict.
     let delete_mode_conflicts = [
         delete_before_flag,
-        delete_during_flag,
-        delete_delay_flag,
+        delete_during_flag || delete_delay_flag,
         delete_after_flag,
     ]
     .into_iter()
@@ -295,10 +300,13 @@ where
     if delete_mode_conflicts > 1 {
         return Err(clap::Error::raw(
             clap::error::ErrorKind::ArgumentConflict,
-            "--delete-before, --delete-during, --delete-delay, and --delete-after are mutually exclusive",
+            "You may not combine multiple --delete-WHEN options.\n",
         ));
     }
 
+    // upstream: options.c:2182-2185,2215-2217 - a negative `--max-delete` is
+    // clamped to 0 ("no deletions") but NEVER enables deletion; delete mode is
+    // turned on only by an explicit `--delete*`/`--delete-excluded`.
     let mut delete_mode = if delete_before_flag {
         DeleteMode::Before
     } else if delete_delay_flag {
@@ -316,22 +324,14 @@ where
     if delete_excluded && !delete_mode.is_enabled() {
         delete_mode = DeleteMode::DuringDefault;
     }
-    if max_delete.is_some() && !delete_mode.is_enabled() {
-        delete_mode = DeleteMode::DuringDefault;
-    }
-
-    // Mirror upstream: --delete requires --recursive or --dirs
-    if delete_mode.is_enabled() && !recursive && dirs != Some(true) {
-        return Err(clap::Error::raw(
-            clap::error::ErrorKind::MissingRequiredArgument,
-            "--delete does not work without --recursive (-r) or --dirs (-d).\n",
-        ));
-    }
 
     let mut backup = matches.get_flag("backup");
     let backup_dir = matches.remove_one::<OsString>("backup-dir");
     let backup_suffix = matches.remove_one::<OsString>("suffix");
-    if backup_dir.is_some() || backup_suffix.is_some() {
+    // upstream: options.c:2305-2307 - only `--backup-dir` implies `--backup`
+    // (`make_backups = 1`). `--suffix` alone merely sets the suffix string and
+    // never enables backups, so it must not flip `backup` on here.
+    if backup_dir.is_some() {
         backup = true;
     }
     let compress_count = matches.get_count("compress");
@@ -820,7 +820,7 @@ where
     }
     let cvs_exclude = matches.get_flag("cvs-exclude");
     let apple_double_skip = matches.get_flag("apple-double-skip");
-    let files_from = matches
+    let files_from: Vec<OsString> = matches
         .remove_many::<OsString>("files-from")
         .map(Iterator::collect)
         .unwrap_or_default();
@@ -887,6 +887,82 @@ where
     let mut no_motd = matches.get_flag("no-motd");
     if matches.get_flag("motd") {
         no_motd = false;
+    }
+
+    // upstream: options.c:2126-2130 - `--fake-super` (am_root < 0) conflicts with
+    // `-XX` (preserve_xattrs > 1); `-X`/`-XX` map to xattr levels 1/2 here.
+    if fake_super == Some(true) && xattrs == Some(2) {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::ArgumentConflict,
+            "--fake-super conflicts with -XX\n",
+        ));
+    }
+
+    // upstream: options.c:2158-2167 - `--read-batch` cannot be combined with
+    // `--files-from` or `--remove-source-files`/`--remove-sent-files`.
+    if read_batch.is_some() {
+        if !files_from.is_empty() {
+            return Err(clap::Error::raw(
+                clap::error::ErrorKind::ArgumentConflict,
+                "--read-batch cannot be used with --files-from\n",
+            ));
+        }
+        if remove_source_files {
+            let which = if remove_sent_files { "sent" } else { "source" };
+            return Err(clap::Error::raw(
+                clap::error::ErrorKind::ArgumentConflict,
+                format!("--read-batch cannot be used with --remove-{which}-files\n"),
+            ));
+        }
+    }
+
+    // upstream: options.c:2299-2304 - a `--suffix` containing a slash is rejected
+    // regardless of `--backup-dir`.
+    if let Some(suffix) = backup_suffix.as_ref()
+        && suffix.to_string_lossy().contains('/')
+    {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::ValueValidation,
+            format!(
+                "--suffix cannot contain slashes: {}\n",
+                suffix.to_string_lossy()
+            ),
+        ));
+    }
+
+    // upstream: options.c:2328-2335 - an empty `--suffix` is only valid together
+    // with a `--backup-dir`; otherwise it is rejected.
+    if backup_dir.is_none()
+        && backup_suffix
+            .as_ref()
+            .is_some_and(|suffix| suffix.is_empty())
+    {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::ValueValidation,
+            "--suffix cannot be empty without a --backup-dir\n",
+        ));
+    }
+
+    // upstream: options.c:2187-2203,2230-2234 - `--delete` needs `--recursive`
+    // (-r) or `--dirs` (-d), gated on the RESOLVED xfer_dirs. When neither -r nor
+    // an explicit -d is given, `--files-from` (options.c:2190-2191) and
+    // `--list-only` (options.c:2203) still set xfer_dirs, so `--delete` is
+    // permitted in those cases.
+    if delete_mode.is_enabled() {
+        let xfer_dirs = if recursive || old_dirs {
+            true
+        } else {
+            match dirs {
+                Some(value) => value,
+                None => !files_from.is_empty() || list_only,
+            }
+        };
+        if !xfer_dirs {
+            return Err(clap::Error::raw(
+                clap::error::ErrorKind::MissingRequiredArgument,
+                "--delete does not work without --recursive (-r) or --dirs (-d).\n",
+            ));
+        }
     }
 
     Ok(ParsedArgs {

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -17,7 +17,11 @@ fn delete_modes_are_mutually_exclusive_two_flags() {
     let result = parse_test_args(["-r", "--delete-before", "--delete-after", "src/", "dst/"]);
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(err.to_string().contains("mutually exclusive"));
+    // upstream: options.c:2211-2212 exact wording.
+    assert!(
+        err.to_string()
+            .contains("You may not combine multiple --delete-WHEN options.")
+    );
 }
 
 #[test]
@@ -66,11 +70,13 @@ fn delete_excluded_activates_delete_mode() {
 }
 
 #[test]
-fn max_delete_activates_delete_mode() {
+fn max_delete_does_not_activate_delete_mode() {
+    // upstream: options.c:2215-2217 - `--max-delete` never enables deletion; it
+    // only caps the count once an explicit `--delete*` has enabled it.
     let result = parse_test_args(["-r", "--max-delete=10", "src/", "dst/"]);
     assert!(result.is_ok());
     let parsed = result.unwrap();
-    assert!(parsed.delete_mode.is_enabled());
+    assert!(!parsed.delete_mode.is_enabled());
 }
 
 #[test]
@@ -199,11 +205,13 @@ fn backup_dir_implies_backup() {
 }
 
 #[test]
-fn backup_suffix_implies_backup() {
+fn backup_suffix_does_not_imply_backup() {
+    // upstream: options.c:2296-2307 - only `--backup-dir` implies `--backup`; a
+    // bare `--suffix` sets the suffix string without enabling backups.
     let result = parse_test_args(["--suffix=.bak", "src/", "dst/"]);
     assert!(result.is_ok());
     let parsed = result.unwrap();
-    assert!(parsed.backup);
+    assert!(!parsed.backup);
 }
 
 #[test]

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1190,7 +1190,8 @@ mod option_values {
     fn suffix_with_equals() {
         let parsed = parse_test_args(["--suffix=.bak", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.backup_suffix, Some(OsString::from(".bak")));
-        assert!(parsed.backup); // suffix implies backup
+        // upstream: options.c:2296-2307 - a bare --suffix does not enable backups.
+        assert!(!parsed.backup);
     }
 
     #[test]
@@ -1314,7 +1315,8 @@ mod option_values {
     fn max_delete_with_equals() {
         let parsed = parse_test_args(["-r", "--max-delete=100", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.max_delete, Some(OsString::from("100")));
-        assert!(parsed.delete_mode.is_enabled()); // max-delete implies delete
+        // upstream: options.c:2215-2217 - --max-delete never enables deletion.
+        assert!(!parsed.delete_mode.is_enabled());
     }
 
     #[test]
@@ -1774,7 +1776,11 @@ mod delete_modes {
         let result = parse_test_args(["-r", "--delete-before", "--delete-after", "src/", "dst/"]);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("mutually exclusive"));
+        // upstream: options.c:2211-2212 exact wording.
+        assert!(
+            err.to_string()
+                .contains("You may not combine multiple --delete-WHEN options.")
+        );
     }
 
     #[test]

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -246,11 +246,10 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         } else {
             inputs.dirs.unwrap_or(inputs.list_only)
         })
-        .delete(
-            inputs.delete_mode.is_enabled()
-                || inputs.delete_excluded
-                || inputs.max_delete_limit.is_some(),
-        )
+        // upstream: options.c:2215-2217 - delete mode is enabled only by an
+        // explicit `--delete*` or `--delete-excluded`. `--max-delete` merely caps
+        // the count (options.c:2182-2185) and must never enable deletion.
+        .delete(inputs.delete_mode.is_enabled() || inputs.delete_excluded)
         .delete_excluded(inputs.delete_excluded)
         .delete_missing_args(inputs.delete_missing_args)
         .ignore_errors(inputs.ignore_errors)

--- a/crates/cli/src/frontend/execution/options/mod.rs
+++ b/crates/cli/src/frontend/execution/options/mod.rs
@@ -100,8 +100,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_max_delete_argument_negative() {
-        assert!(parse_max_delete_argument(&os("-10")).is_err());
+    fn parse_max_delete_argument_negative_clamps_to_zero() {
+        // upstream: options.c:2182-2185 - a negative `--max-delete` is clamped to
+        // a 0 cap ("no deletions") and parsing continues; it is not an error.
+        assert_eq!(parse_max_delete_argument(&os("-10")).unwrap(), 0);
+        assert_eq!(parse_max_delete_argument(&os("-1")).unwrap(), 0);
     }
 
     #[test]

--- a/crates/cli/src/frontend/execution/options/numeric.rs
+++ b/crates/cli/src/frontend/execution/options/numeric.rs
@@ -64,9 +64,13 @@ pub(crate) fn parse_timeout_argument(value: &OsStr) -> Result<TransferTimeout, M
     }
 }
 
-/// Parses the `--max-delete` argument as a non-negative `u64` deletion limit.
+/// Parses the `--max-delete` argument into a non-negative deletion cap.
 ///
-/// A leading `+` prefix is permitted and ignored.
+/// A leading `+` prefix is permitted and ignored. Mirroring upstream
+/// (`options.c:2182-2185`), a negative value is not an error: it is clamped to
+/// `0` ("no deletions") and parsing continues. Deletion itself is still gated on
+/// an explicit `--delete*`, so a clamped cap of `0` only takes effect when
+/// deletion is already enabled.
 pub(crate) fn parse_max_delete_argument(value: &OsStr) -> Result<u64, Message> {
     let text = value.to_string_lossy();
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
@@ -80,24 +84,16 @@ pub(crate) fn parse_max_delete_argument(value: &OsStr) -> Result<u64, Message> {
         return Err(rsync_error!(1, "--max-delete value must not be empty").with_role(Role::Client));
     }
 
-    if trimmed.starts_with('-') {
-        return Err(rsync_error!(
-            1,
-            format!(
-                "invalid --max-delete '{}': deletion limit must be non-negative",
-                display
-            )
-        )
-        .with_role(Role::Client));
-    }
-
     let normalized = trimmed.strip_prefix('+').unwrap_or(trimmed);
 
-    match normalized.parse::<u64>() {
-        Ok(value) => Ok(value),
+    // upstream stores `--max-delete` as a signed int and clamps any negative
+    // value (other than the INT_MIN "unlimited" sentinel, which oc models as an
+    // absent limit) to 0. Parse as `i64` so negatives round-trip to a 0 cap.
+    match normalized.parse::<i64>() {
+        Ok(parsed) => Ok(parsed.max(0) as u64),
         Err(error) => {
             let detail = match error.kind() {
-                IntErrorKind::InvalidDigit => "deletion limit must be an unsigned integer",
+                IntErrorKind::InvalidDigit => "deletion limit must be an integer",
                 IntErrorKind::PosOverflow | IntErrorKind::NegOverflow => {
                     "deletion limit exceeds the supported range"
                 }

--- a/crates/cli/src/frontend/tests/backup.rs
+++ b/crates/cli/src/frontend/tests/backup.rs
@@ -119,9 +119,12 @@ fn backup_suffix_flag_overrides_default_suffix() {
     );
     filetime::set_file_mtime(dest_root.join("file.txt"), one_hour_ago).expect("backdate dest");
 
+    // upstream: options.c:2296-2307 - `--suffix` sets the suffix string but does
+    // NOT enable backups on its own; `--backup` must be given explicitly.
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("-r"),
+        OsString::from("--backup"),
         OsString::from("--suffix"),
         OsString::from(".bak"),
         source_dir.into_os_string(),

--- a/crates/cli/src/frontend/tests/parse_max.rs
+++ b/crates/cli/src/frontend/tests/parse_max.rs
@@ -8,14 +8,11 @@ fn parse_max_delete_argument_accepts_zero() {
 }
 
 #[test]
-fn parse_max_delete_argument_rejects_negative() {
-    let error =
-        parse_max_delete_argument(OsStr::new("-4")).expect_err("negative limit should fail");
-    let rendered = error.to_string();
-    assert!(
-        rendered.contains("deletion limit must be non-negative"),
-        "diagnostic missing detail: {rendered}"
-    );
+fn parse_max_delete_argument_clamps_negative_to_zero() {
+    // upstream: options.c:2182-2185 - a negative `--max-delete` is clamped to a
+    // 0 cap ("no deletions") rather than rejected.
+    let limit = parse_max_delete_argument(OsStr::new("-4")).expect("negative clamps to zero");
+    assert_eq!(limit, 0);
 }
 
 #[test]
@@ -24,7 +21,7 @@ fn parse_max_delete_argument_rejects_non_numeric() {
         parse_max_delete_argument(OsStr::new("abc")).expect_err("non-numeric limit should fail");
     let rendered = error.to_string();
     assert!(
-        rendered.contains("deletion limit must be an unsigned integer"),
-        "diagnostic missing unsigned message: {rendered}"
+        rendered.contains("deletion limit must be an integer"),
+        "diagnostic missing integer message: {rendered}"
     );
 }

--- a/crates/cli/tests/argument_errors.rs
+++ b/crates/cli/tests/argument_errors.rs
@@ -70,17 +70,19 @@ fn test_delete_during_and_after_conflict() {
 }
 
 #[test]
-fn test_delete_during_and_delay_conflict() {
+fn test_delete_during_and_delay_are_same_when_term() {
+    // upstream: options.c:724-725,2210 - `--delete-during` and `--delete-delay`
+    // both write the single `delete_during` counter, so combining them is not a
+    // conflict (`!!delete_during` counts once).
     let result = parse_args([
         "oc-rsync",
+        "--dirs",
         "--delete-during",
         "--delete-delay",
         "src",
         "dest",
     ]);
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    assert!(result.is_ok(), "unexpected error: {:?}", result.err());
 }
 
 #[test]

--- a/crates/cli/tests/mutually_exclusive_options.rs
+++ b/crates/cli/tests/mutually_exclusive_options.rs
@@ -74,20 +74,23 @@ fn test_delete_during_and_after_conflict() {
 }
 
 #[test]
-fn test_delete_during_and_delay_conflict() {
+fn test_delete_during_and_delay_are_same_when_term() {
+    // upstream: options.c:724-725,2210 - `--delete-during` and `--delete-delay`
+    // both write the single `delete_during` counter, so combining them selects
+    // one "during" WHEN term and is NOT a conflict (`!!delete_during` == 1).
     let result = parse_args([
         "oc-rsync",
+        "--dirs",
         "--delete-during",
         "--delete-delay",
         "src",
         "dest",
     ]);
     assert!(
-        result.is_err(),
-        "--delete-during and --delete-delay should be mutually exclusive"
+        result.is_ok(),
+        "--delete-during and --delete-delay share the 'during' WHEN term: {:?}",
+        result.err()
     );
-    let err = result.unwrap_err();
-    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
 }
 
 #[test]

--- a/crates/cli/tests/option_combinations_delete.rs
+++ b/crates/cli/tests/option_combinations_delete.rs
@@ -18,17 +18,20 @@ fn test_delete_excluded_enables_delete_during() {
 }
 
 #[test]
-fn test_max_delete_enables_delete_during() {
+fn test_max_delete_does_not_enable_delete_mode() {
+    // upstream: options.c:2182-2185,2215-2217 - `--max-delete` only sets the cap
+    // and never enables deletion. Promoting it to a delete mode would silently
+    // delete extraneous destination files, which is a data-loss bug.
     let args = parse_args(["oc-rsync", "--max-delete=100", "--dirs", "src", "dest"]).unwrap();
     assert_eq!(
         args.delete_mode,
-        DeleteMode::DuringDefault,
-        "--max-delete should implicitly enable delete mode (DuringDefault)"
+        DeleteMode::Disabled,
+        "--max-delete alone must NOT enable delete mode"
     );
     assert_eq!(
         args.max_delete,
         Some("100".into()),
-        "--max-delete value should be captured"
+        "--max-delete value should still be captured"
     );
 }
 
@@ -80,11 +83,13 @@ fn test_delete_excluded_without_delete_mode() {
 }
 
 #[test]
-fn test_max_delete_without_delete_mode() {
+fn test_max_delete_alone_leaves_delete_disabled() {
+    // upstream: options.c:2215-2217 - deletion is enabled only by an explicit
+    // `--delete*`/`--delete-excluded`, never by `--max-delete`.
     let args = parse_args(["oc-rsync", "--max-delete=10", "--dirs", "src", "dest"]).unwrap();
     assert!(
-        args.delete_mode.is_enabled(),
-        "--max-delete alone should enable delete mode"
+        !args.delete_mode.is_enabled(),
+        "--max-delete alone must leave delete mode disabled"
     );
 }
 

--- a/crates/cli/tests/option_combinations_flags.rs
+++ b/crates/cli/tests/option_combinations_flags.rs
@@ -24,9 +24,14 @@ fn test_backup_dir_implies_backup() {
 }
 
 #[test]
-fn test_backup_suffix_implies_backup() {
+fn test_backup_suffix_does_not_imply_backup() {
+    // upstream: options.c:2296-2307 - `--suffix` sets the suffix string but does
+    // not enable backups; only `--backup`/`--backup-dir` do.
     let args = parse_args(["oc-rsync", "--suffix=.bak", "src", "dest"]).unwrap();
-    assert!(args.backup, "--suffix should implicitly enable backup mode");
+    assert!(
+        !args.backup,
+        "--suffix must not implicitly enable backup mode"
+    );
     assert_eq!(args.backup_suffix, Some(".bak".into()));
 }
 

--- a/crates/cli/tests/option_validation_parity.rs
+++ b/crates/cli/tests/option_validation_parity.rs
@@ -1,0 +1,206 @@
+//! Option-parsing/interaction parity with upstream rsync 3.4.4 (`options.c`).
+//!
+//! Each test pins an upstream validation or interaction rule so that oc-rsync
+//! rejects, clamps, or accepts option combinations byte-for-byte the way the
+//! reference implementation does.
+
+use cli::test_utils::parse_args;
+use core::client::DeleteMode;
+
+// upstream: options.c:2182-2185,2215-2217 - `--max-delete` only caps the count
+// and must never enable deletion. Promoting it silently deletes extraneous
+// destination files (data loss).
+#[test]
+fn max_delete_alone_does_not_enable_deletion() {
+    let args = parse_args(["oc-rsync", "--max-delete=5", "--dirs", "src", "dest"]).unwrap();
+    assert_eq!(args.delete_mode, DeleteMode::Disabled);
+    assert_eq!(args.max_delete, Some("5".into()));
+}
+
+// With an explicit `--delete`, the cap is retained alongside the enabled mode.
+#[test]
+fn max_delete_with_delete_caps_and_enables() {
+    let args = parse_args([
+        "oc-rsync",
+        "--delete",
+        "--max-delete=5",
+        "--dirs",
+        "src",
+        "dest",
+    ])
+    .unwrap();
+    assert_eq!(args.delete_mode, DeleteMode::DuringDefault);
+    assert_eq!(args.max_delete, Some("5".into()));
+}
+
+// upstream: options.c:2182-2185 - a negative `--max-delete` is clamped to a 0
+// cap and parsing continues; it is not an error and does not enable deletion.
+#[test]
+fn negative_max_delete_is_accepted_and_does_not_enable_deletion() {
+    let args = parse_args(["oc-rsync", "--max-delete=-1", "--dirs", "src", "dest"]).unwrap();
+    assert_eq!(args.delete_mode, DeleteMode::Disabled);
+    assert_eq!(args.max_delete, Some("-1".into()));
+}
+
+// upstream: options.c:724-725,2210 - `--delete-during`/`--del` and
+// `--delete-delay` share the single `delete_during` term, so combining them is
+// NOT a conflict.
+#[test]
+fn delete_during_and_delay_share_a_when_term() {
+    let result = parse_args([
+        "oc-rsync",
+        "--dirs",
+        "--del",
+        "--delete-delay",
+        "src",
+        "dest",
+    ]);
+    assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+}
+
+// upstream: options.c:2210-2213 - distinct WHEN phases conflict with the exact
+// wording below.
+#[test]
+fn multiple_delete_when_phases_use_upstream_wording() {
+    let err = parse_args([
+        "oc-rsync",
+        "--delete-before",
+        "--delete-after",
+        "--dirs",
+        "src",
+        "dest",
+    ])
+    .unwrap_err();
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    assert!(
+        err.to_string()
+            .contains("You may not combine multiple --delete-WHEN options."),
+        "wrong wording: {err}"
+    );
+}
+
+// upstream: options.c:2187-2203,2230-2234 - `--delete` needs a resolved
+// xfer_dirs. `--files-from` sets xfer_dirs=1, so `--delete --files-from` is
+// permitted even without `-r`/`-d`.
+#[test]
+fn delete_with_files_from_is_permitted_without_recursive() {
+    let result = parse_args([
+        "oc-rsync",
+        "--delete",
+        "--files-from=list.txt",
+        "src",
+        "dest",
+    ]);
+    assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+}
+
+// upstream: options.c:2203 - `--list-only` also resolves xfer_dirs, permitting
+// `--delete` without `-r`/`-d`.
+#[test]
+fn delete_with_list_only_is_permitted_without_recursive() {
+    let result = parse_args(["oc-rsync", "--delete", "--list-only", "src"]);
+    assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+}
+
+// upstream: options.c:2230-2234 - without `-r`/`-d` (and no files-from/list-only
+// to resolve xfer_dirs), `--delete` is rejected.
+#[test]
+fn delete_without_dirs_is_rejected() {
+    let err = parse_args(["oc-rsync", "--delete", "src", "dest"]).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("--delete does not work without --recursive (-r) or --dirs (-d)."),
+        "wrong wording: {err}"
+    );
+}
+
+// upstream: options.c:2126-2130 - `--fake-super` conflicts with `-XX`.
+#[test]
+fn fake_super_conflicts_with_double_x() {
+    let err = parse_args(["oc-rsync", "--fake-super", "-XX", "src", "dest"]).unwrap_err();
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    assert!(
+        err.to_string().contains("--fake-super conflicts with -XX"),
+        "wrong wording: {err}"
+    );
+}
+
+// A single `-X` with `--fake-super` is fine.
+#[test]
+fn fake_super_with_single_x_is_accepted() {
+    let result = parse_args(["oc-rsync", "--fake-super", "-X", "src", "dest"]);
+    assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+}
+
+// upstream: options.c:2158-2162 - `--read-batch` with `--files-from` is an error.
+#[test]
+fn read_batch_conflicts_with_files_from() {
+    let err = parse_args([
+        "oc-rsync",
+        "--read-batch=b",
+        "--files-from=list.txt",
+        "src",
+        "dest",
+    ])
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("--read-batch cannot be used with --files-from"),
+        "wrong wording: {err}"
+    );
+}
+
+// upstream: options.c:2163-2167 - `--read-batch` with `--remove-source-files`.
+#[test]
+fn read_batch_conflicts_with_remove_source_files() {
+    let err = parse_args([
+        "oc-rsync",
+        "--read-batch=b",
+        "--remove-source-files",
+        "src",
+        "dest",
+    ])
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("--read-batch cannot be used with --remove-source-files"),
+        "wrong wording: {err}"
+    );
+}
+
+// upstream: options.c:2299-2304 - a `--suffix` containing a slash is rejected.
+#[test]
+fn suffix_with_slash_is_rejected() {
+    let err = parse_args(["oc-rsync", "--suffix=a/b", "src", "dest"]).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("--suffix cannot contain slashes: a/b"),
+        "wrong wording: {err}"
+    );
+}
+
+// upstream: options.c:2328-2335 - an empty `--suffix` without `--backup-dir`.
+#[test]
+fn empty_suffix_without_backup_dir_is_rejected() {
+    let err = parse_args(["oc-rsync", "--suffix=", "src", "dest"]).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("--suffix cannot be empty without a --backup-dir"),
+        "wrong wording: {err}"
+    );
+}
+
+// An empty `--suffix` paired with `--backup-dir` is valid.
+#[test]
+fn empty_suffix_with_backup_dir_is_accepted() {
+    let result = parse_args(["oc-rsync", "--suffix=", "--backup-dir=bak", "src", "dest"]);
+    assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+}
+
+// upstream: options.c:2296-2307 - `--suffix` alone does not enable backups.
+#[test]
+fn suffix_alone_does_not_enable_backup() {
+    let args = parse_args(["oc-rsync", "--suffix=.bak", "src", "dest"]).unwrap();
+    assert!(!args.backup, "--suffix must not imply --backup");
+    assert_eq!(args.backup_suffix, Some(".bak".into()));
+}

--- a/crates/core/src/client/config/builder/paths.rs
+++ b/crates/core/src/client/config/builder/paths.rs
@@ -71,10 +71,9 @@ impl ClientConfigBuilder {
     #[must_use]
     #[doc(alias = "--suffix")]
     pub fn backup_suffix<S: Into<OsString>>(mut self, suffix: Option<S>) -> Self {
+        // upstream: options.c:2296-2307 - only `--backup-dir` implies `--backup`.
+        // Setting a suffix stores the string but never enables backups.
         self.backup_suffix = suffix.map(Into::into);
-        if self.backup_suffix.is_some() {
-            self.backup = true;
-        }
         self
     }
 }

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1347,9 +1347,11 @@ fn backup_suffix_sets_value() {
 }
 
 #[test]
-fn backup_suffix_enables_backup() {
+fn backup_suffix_does_not_enable_backup() {
+    // upstream: options.c:2296-2307 - only `--backup-dir` implies `--backup`.
+    // A suffix alone stores the string without enabling backups.
     let config = builder().backup_suffix(Some(".bak")).build();
-    assert!(config.backup());
+    assert!(!config.backup());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Aligns CLI option parsing and interaction rules with upstream rsync 3.4.4
(`options.c`, protocol 32). The headline change fixes a data-loss bug where
`--max-delete=N` silently enabled deletion of extraneous destination files.

Every rule below was re-verified against `options.c` before implementing; the
error strings and exit codes match upstream byte-for-byte.

## Fixes

### HIGH - data loss: `--max-delete` no longer enables deletion
- Upstream `options.c:2182-2185` only clamps a negative `max_delete` to 0; it
  never turns deletion on. Deletion is enabled solely by an explicit
  `--delete*`/`--delete-excluded` (`options.c:2215-2217`).
- oc previously promoted `max_delete.is_some()` to delete mode in two places
  (the argument parser and the `CoreConfig` drive builder), so
  `rsync --max-delete=100 src/ dst/` deleted extraneous files. Both promotions
  are removed; `--max-delete` now only sets the cap.

### Validation / semantics parity
- **Negative `--max-delete`** clamps to a 0 cap and continues instead of
  erroring (`options.c:2182-2185`).
- **`--suffix` no longer implies `--backup`**; only `--backup-dir` does
  (`options.c:2296-2307`). Removed the invented implication in the parser and
  the `ClientConfig` builder.
- **Multiple `--delete-WHEN`** now uses the exact upstream wording
  `You may not combine multiple --delete-WHEN options.` and treats
  `--del`/`--delete-during` and `--delete-delay` as the single `delete_during`
  term, so combining them is not an error (`options.c:724-725,2210-2213`).
- **`--delete` recursion gate** now uses the resolved xfer_dirs, so
  `--files-from` (`options.c:2190-2191`) and `--list-only` (`options.c:2203`)
  permit `--delete` without `-r`/`-d` (`options.c:2230-2234`).
- **`--suffix` with a slash** is rejected: `--suffix cannot contain slashes: %s`
  (`options.c:2299-2304`).
- **Empty `--suffix` without `--backup-dir`** is rejected:
  `--suffix cannot be empty without a --backup-dir` (`options.c:2328-2335`).
- **`--fake-super` with `-XX`** is rejected: `--fake-super conflicts with -XX`
  (`options.c:2126-2130`).
- **`--read-batch` with `--files-from`** is rejected
  (`options.c:2158-2162`).
- **`--read-batch` with `--remove-source-files`/`--remove-sent-files`** is
  rejected (`options.c:2163-2167`).

All rejections use exit code 1, matching upstream `RERR_SYNTAX`.

## Tests
- New `crates/cli/tests/option_validation_parity.rs` pins each rule (including
  the data-loss regression and the negative-clamp behavior).
- Existing tests that encoded the old promotion/implication behavior are updated
  to the upstream-correct expectations (max-delete no longer enables deletion,
  suffix no longer implies backup, during+delay is not a conflict, exact
  delete-WHEN wording).

## Verification (aarch64)
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p cli -p core --all-features --all-targets --no-deps -D warnings`
  clean.
- `cargo nextest run -p cli -p core --all-features`: 6195 passed, 82 skipped.

## Deferred (not in this PR)
- `--max-alloc=0` -> unlimited and the <1MiB floor, and `--block-size` accept
  0 -> default / reject >131072: both require reworking the block-size /
  max-alloc value representation (currently `NonZeroU32` / non-zero `u64`) into
  an Option/sentinel that plumbs through core config; left out to keep this
  change focused.
- `--files-from` argc usage error: needs positional-operand-count wiring.
- `--compress-choice=auto` accept-and-null and `--compress-level=0` = ON:
  entangled with the compression codec/level representation.
- Optional `--write-devices`/`--delay-updates`/`RSYNC_PARTIAL_DIR`/`-UU`
  interactions: deferred as entangled.
