### PR TITLE
fix(metadata): --usermap/--groupmap must match the sender-transmitted name (upstream parity)

### DIFF
--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -264,25 +264,34 @@ fn resolve_owner_uid(
 ) -> Option<unix_fs::Uid> {
     entry.uid().and_then(|uid| {
         let numeric = options.numeric_ids_enabled();
-        let mut base = uid as RawUid;
-        let mut mapped = false;
-        if let Some(mapping) = options.user_mapping()
-            && let Ok(Some(target)) = mapping.map_uid(base, numeric)
+        let raw = uid as RawUid;
+        let name = entry.user_name();
+        // upstream: uidlist.c:255-280 recv_add_id - a `--usermap` rule is scanned
+        // FIRST, keyed on the sender-transmitted name (name/wildcard rules) or
+        // the raw sender id (numeric rules), before any receiver-local name
+        // resolution. The name-list path (non-INC_RECURSE) resolves entries in
+        // `remap_flist_ownership_from_id_lists`; this per-entry path serves the
+        // INC_RECURSE inline-name case, so the map is consulted only when the
+        // sender transmitted an inline name here.
+        if let Some(name) = name
+            && let Some(mapping) = options.user_mapping()
+            && let Ok(Some(target)) = mapping.map_uid_named(raw, Some(name.as_bytes()), numeric)
         {
-            base = target;
-            mapped = true;
+            return Some(ownership::uid_from_raw(target));
         }
-        if !mapped
-            && !numeric
-            && let Some(name) = entry.user_name()
-        {
+        // upstream: uidlist.c:273-280 - no map rule matched; fall back to
+        // user_to_uid(name), i.e. resolve the sender name against the receiver's
+        // user database so ownership follows the name across differing id
+        // namespaces. Skipped under --numeric-ids (the sender omits names).
+        if !numeric && let Some(name) = name {
             let local = lookup_user_by_name(name.as_bytes())
                 .ok()
                 .flatten()
-                .unwrap_or(base);
+                .unwrap_or(raw);
             return Some(ownership::uid_from_raw(local));
         }
-        map_uid(base, numeric)
+        // No transmitted name: receiver-local resolution of the raw id.
+        map_uid(raw, numeric)
     })
 }
 
@@ -299,25 +308,28 @@ fn resolve_group_gid(
 ) -> Option<unix_fs::Gid> {
     entry.gid().and_then(|gid| {
         let numeric = options.numeric_ids_enabled();
-        let mut base = gid as RawGid;
-        let mut mapped = false;
-        if let Some(mapping) = options.group_mapping()
-            && let Ok(Some(target)) = mapping.map_gid(base, numeric)
+        let raw = gid as RawGid;
+        let name = entry.group_name();
+        // upstream: uidlist.c:255-280 recv_add_id - see `resolve_owner_uid`; the
+        // group `--groupmap` scan is keyed on the sender-transmitted group name
+        // (or the raw sender gid for numeric rules) before receiver-local
+        // resolution. Consulted per-entry only for the INC_RECURSE inline-name
+        // case; the id-list path resolves in
+        // `remap_flist_ownership_from_id_lists`.
+        if let Some(name) = name
+            && let Some(mapping) = options.group_mapping()
+            && let Ok(Some(target)) = mapping.map_gid_named(raw, Some(name.as_bytes()), numeric)
         {
-            base = target;
-            mapped = true;
+            return Some(ownership::gid_from_raw(target));
         }
-        if !mapped
-            && !numeric
-            && let Some(name) = entry.group_name()
-        {
+        if !numeric && let Some(name) = name {
             let local = lookup_group_by_name(name.as_bytes())
                 .ok()
                 .flatten()
-                .unwrap_or(base);
+                .unwrap_or(raw);
             return Some(ownership::gid_from_raw(local));
         }
-        map_gid(base, numeric)
+        map_gid(raw, numeric)
     })
 }
 
@@ -954,6 +966,97 @@ mod own_debug_tests {
             resolve_owner_uid(&entry, &opts_num).map(|u| u.as_raw()),
             Some(4_000_123),
             "--numeric-ids must keep the raw sender id"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn usermap_matches_sender_inline_name_not_raw_id() {
+        // upstream: uidlist.c:255-268 recv_add_id - a `--usermap` NAME rule is
+        // keyed on the sender-transmitted (inline, INC_RECURSE) name, not a name
+        // re-derived from the raw sender id on the receiver. Sender uid 1500 does
+        // not exist locally; the inline name "deploy" drives the rule. Target 0
+        // is numeric so the assertion needs no /etc/passwd entry.
+        use protocol::flist::FileEntry;
+
+        let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
+        entry.set_uid(1500);
+        entry.set_user_name("deploy".to_string());
+
+        let opts = MetadataOptions::new()
+            .preserve_owner(true)
+            .numeric_ids(false)
+            .with_user_mapping(Some(crate::UserMapping::parse("deploy:0").unwrap()));
+        assert_eq!(
+            resolve_owner_uid(&entry, &opts).map(|u| u.as_raw()),
+            Some(0),
+            "usermap must match the sender name 'deploy', not the local uid 1500"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn usermap_numeric_rule_keys_on_raw_sender_id() {
+        // upstream: uidlist.c:262-267 - a numeric `--usermap` rule matches the
+        // raw sender id regardless of the transmitted name.
+        use protocol::flist::FileEntry;
+
+        let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
+        entry.set_uid(1500);
+        entry.set_user_name("deploy".to_string());
+
+        let opts = MetadataOptions::new()
+            .preserve_owner(true)
+            .numeric_ids(false)
+            .with_user_mapping(Some(crate::UserMapping::parse("1500:5000").unwrap()));
+        assert_eq!(
+            resolve_owner_uid(&entry, &opts).map(|u| u.as_raw()),
+            Some(5000),
+            "numeric usermap must map the raw sender id 1500 to 5000"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn usermap_wildcard_matches_sender_inline_name() {
+        // upstream: uidlist.c:256-258 - NFLAGS_WILD_NAME_MATCH wildmatch on the
+        // transmitted name.
+        use protocol::flist::FileEntry;
+
+        let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
+        entry.set_uid(1500);
+        entry.set_user_name("deploy".to_string());
+
+        let opts = MetadataOptions::new()
+            .preserve_owner(true)
+            .numeric_ids(false)
+            .with_user_mapping(Some(crate::UserMapping::parse("dep*:0").unwrap()));
+        assert_eq!(
+            resolve_owner_uid(&entry, &opts).map(|u| u.as_raw()),
+            Some(0),
+            "wildcard usermap must match the sender name 'deploy'"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn groupmap_matches_sender_inline_name_symmetric() {
+        // upstream: uidlist.c:317-337 match_gid - group counterpart keyed on the
+        // sender-transmitted group name.
+        use protocol::flist::FileEntry;
+
+        let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
+        entry.set_gid(2500);
+        entry.set_group_name("build".to_string());
+
+        let opts = MetadataOptions::new()
+            .preserve_group(true)
+            .numeric_ids(false)
+            .with_group_mapping(Some(crate::GroupMapping::parse("build:0").unwrap()));
+        assert_eq!(
+            resolve_group_gid(&entry, &opts).map(|g| g.as_raw()),
+            Some(0),
+            "groupmap must match the sender name 'build', not the local gid 2500"
         );
     }
 }

--- a/crates/metadata/src/mapping/name_mapping.rs
+++ b/crates/metadata/src/mapping/name_mapping.rs
@@ -176,6 +176,79 @@ impl NameMapping {
         Ok(None)
     }
 
+    /// Finds the first matching rule keyed on the sender-transmitted name.
+    ///
+    /// Unlike [`Self::resolve_rule`], name and wildcard matchers are tested
+    /// against `name` - the user/group name the sender carried on the id-list
+    /// wire (or inline under INC_RECURSE) - rather than a name re-derived from
+    /// the raw id via the receiver's `getpwuid`/`getgrgid`. This mirrors
+    /// upstream `recv_add_id` (uidlist.c:255-268), whose `uidmap`/`gidmap` scan
+    /// does `wildmatch(node->u.name, name)` / `strcmp(node->u.name, name)`
+    /// against the transmitted `name`, not a receiver-local reverse lookup. A
+    /// missing name is normalized to `""` (upstream: `if (!name) name = ""`), so
+    /// an empty-name matcher matches a nameless id while named/wildcard matchers
+    /// do not. Under `numeric_ids` the sender omits names, so the presented name
+    /// is empty and only numeric rules can match.
+    fn resolve_rule_named(
+        &self,
+        identifier: u32,
+        name: Option<&[u8]>,
+        numeric_ids: bool,
+    ) -> io::Result<Option<&MappingRule>> {
+        if self.rules.is_empty() {
+            return Ok(None);
+        }
+
+        let wire_name = if numeric_ids {
+            String::new()
+        } else {
+            String::from_utf8_lossy(name.unwrap_or(b"")).into_owned()
+        };
+
+        for rule in &self.rules {
+            if rule
+                .matcher
+                .matches(identifier, || Ok(Some(wire_name.clone())))?
+            {
+                return Ok(Some(rule));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Applies the mapping to a UID keyed on the sender-transmitted `name`.
+    ///
+    /// See [`Self::resolve_rule_named`]: numeric rules match on the raw sender
+    /// id, name/wildcard rules on the wire name. Used by the receiver's id-list
+    /// remap and per-entry ownership resolution, mirroring upstream `match_uid`
+    /// (uidlist.c:297-315) which folds the `--usermap` scan into `recv_add_id`.
+    pub(crate) fn map_uid_named(
+        &self,
+        uid: RawUid,
+        name: Option<&[u8]>,
+        numeric_ids: bool,
+    ) -> io::Result<Option<RawUid>> {
+        self.resolve_rule_named(uid, name, numeric_ids)?
+            .map(|rule| rule.target.resolve_uid())
+            .transpose()
+    }
+
+    /// Applies the mapping to a GID keyed on the sender-transmitted `name`.
+    ///
+    /// Group counterpart of [`Self::map_uid_named`], mirroring upstream
+    /// `match_gid` (uidlist.c:317-337).
+    pub(crate) fn map_gid_named(
+        &self,
+        gid: RawGid,
+        name: Option<&[u8]>,
+        numeric_ids: bool,
+    ) -> io::Result<Option<RawGid>> {
+        self.resolve_rule_named(gid, name, numeric_ids)?
+            .map(|rule| rule.target.resolve_gid())
+            .transpose()
+    }
+
     /// Resolves an identifier to a name using the appropriate system lookup.
     fn lookup_name(&self, identifier: u32) -> io::Result<Option<String>> {
         match self.kind {

--- a/crates/metadata/src/mapping/tests.rs
+++ b/crates/metadata/src/mapping/tests.rs
@@ -743,3 +743,162 @@ fn parse_target_empty_fails() {
     let error = parse_target(MappingKind::User, "", "x:").unwrap_err();
     assert!(error.to_string().contains("No name found after colon"));
 }
+
+// --- Sender-name-keyed resolution (upstream recv_add_id, uidlist.c:255-268) ---
+
+#[test]
+fn map_uid_named_matches_sender_name_not_receiver_lookup() {
+    // upstream: uidlist.c:257-261 - a NAME/WILD rule is compared against the
+    // name the SENDER transmitted, not a name re-derived from the raw id on the
+    // receiver. The raw sender uid (1500) need not exist locally; the rule keys
+    // on "deploy". Target 0 is numeric so the assertion needs no /etc/passwd.
+    let mapping = UserMapping::parse("deploy:0").unwrap();
+    assert_eq!(
+        mapping.map_uid_named(1500, Some(b"deploy"), false).unwrap(),
+        Some(0),
+        "a name usermap must map by the sender-transmitted name"
+    );
+    // A different transmitted name does not match, and there is no receiver-local
+    // reverse-lookup fallback inside the matcher.
+    assert_eq!(
+        mapping
+            .map_uid_named(1500, Some(b"someone-else"), false)
+            .unwrap(),
+        None,
+        "the rule must not match a non-matching sender name"
+    );
+}
+
+#[test]
+fn map_uid_named_wildcard_matches_sender_name() {
+    // upstream: uidlist.c:256-258 - NFLAGS_WILD_NAME_MATCH uses wildmatch on the
+    // transmitted name. `dep*` matches "deploy".
+    let mapping = UserMapping::parse("dep*:0").unwrap();
+    assert_eq!(
+        mapping.map_uid_named(1500, Some(b"deploy"), false).unwrap(),
+        Some(0)
+    );
+    assert_eq!(
+        mapping.map_uid_named(1500, Some(b"other"), false).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn map_uid_named_numeric_rule_keys_on_raw_id_regardless_of_name() {
+    // upstream: uidlist.c:262-267 - a numeric (max_id / exact-id) rule matches on
+    // the raw sender id, independent of the transmitted name. This is the case a
+    // premature local-name F_OWNER rewrite would break (the id would no longer be
+    // 1500 by the time the map ran).
+    let mapping = UserMapping::parse("1500:5000").unwrap();
+    assert_eq!(
+        mapping.map_uid_named(1500, Some(b"deploy"), false).unwrap(),
+        Some(5000)
+    );
+    // Name is irrelevant to a numeric rule.
+    assert_eq!(
+        mapping.map_uid_named(1500, None, false).unwrap(),
+        Some(5000)
+    );
+    assert_eq!(
+        mapping.map_uid_named(1499, Some(b"deploy"), false).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn map_uid_named_numeric_ids_drops_name_but_keeps_numeric_rules() {
+    // upstream: uidlist.c - under --numeric-ids the sender omits names, so
+    // recv_add_id sees name="": NAME/WILD rules cannot match, numeric rules still can.
+    let name_rule = UserMapping::parse("deploy:0").unwrap();
+    assert_eq!(
+        name_rule
+            .map_uid_named(1500, Some(b"deploy"), true)
+            .unwrap(),
+        None,
+        "name rules must not match under numeric-ids (name dropped)"
+    );
+    let numeric_rule = UserMapping::parse("1500:5000").unwrap();
+    assert_eq!(
+        numeric_rule
+            .map_uid_named(1500, Some(b"deploy"), true)
+            .unwrap(),
+        Some(5000),
+        "numeric rules still key on the raw id under numeric-ids"
+    );
+}
+
+#[test]
+fn map_gid_named_matches_sender_name_symmetric() {
+    // Group counterpart: `--groupmap` keys on the sender-transmitted group name.
+    let mapping = GroupMapping::parse("build:0").unwrap();
+    assert_eq!(
+        mapping.map_gid_named(2500, Some(b"build"), false).unwrap(),
+        Some(0)
+    );
+    assert_eq!(
+        mapping.map_gid_named(2500, Some(b"nope"), false).unwrap(),
+        None
+    );
+    let numeric = GroupMapping::parse("2500:6000").unwrap();
+    assert_eq!(
+        numeric.map_gid_named(2500, None, false).unwrap(),
+        Some(6000)
+    );
+}
+
+#[test]
+fn map_uid_named_empty_name_matcher_matches_nameless_id() {
+    // upstream: uidlist.c:252-253 + 259-261 - `if (!name) name = ""`, so an
+    // empty-name matcher (`:7`) matches a nameless id and remaps it.
+    let mapping = UserMapping::parse(":7").unwrap();
+    assert_eq!(mapping.map_uid_named(4242, None, false).unwrap(), Some(7));
+    assert_eq!(
+        mapping.map_uid_named(4242, Some(b""), false).unwrap(),
+        Some(7)
+    );
+    // A non-empty transmitted name does not match the empty-name matcher.
+    assert_eq!(
+        mapping.map_uid_named(4242, Some(b"joe"), false).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn map_uid_named_first_match_wins() {
+    // upstream: uidlist.c:255-269 - recv_add_id breaks on the first matching
+    // node; rules are stored in declaration order.
+    let mapping = UserMapping::parse("dep*:1,deploy:2").unwrap();
+    assert_eq!(
+        mapping.map_uid_named(1500, Some(b"deploy"), false).unwrap(),
+        Some(1),
+        "the earlier wildcard rule wins over a later exact rule"
+    );
+}
+
+// --- wildmatch parity (upstream lib/wildmatch.c) for the cases --usermap uses ---
+
+#[test]
+fn wildmatch_parity_common_cases() {
+    // upstream: lib/wildmatch.c dowild - the patterns actually reachable from a
+    // `--usermap`/`--groupmap` source. Names contain no '/', so `*` and `**`
+    // behave identically (both span the whole remaining name).
+    assert!(wildcard_matches("dep*", "deploy"));
+    assert!(wildcard_matches("**", "anything"));
+    assert!(wildcard_matches("*", "anything"));
+    assert!(wildcard_matches("w?w-data", "www-data"));
+    assert!(wildcard_matches("[a-z]ww-data", "www-data"));
+    assert!(wildcard_matches("[!x]ww-data", "www-data"));
+    assert!(!wildcard_matches("dep?", "deploy"));
+    assert!(!wildcard_matches("adm*", "deploy"));
+    assert!(!wildcard_matches("[a-z]ww", "1ww"));
+}
+
+#[test]
+fn wildmatch_parity_star_spans_multiple_chars() {
+    // upstream: lib/wildmatch.c - `*` backtracks to span any run of characters.
+    assert!(wildcard_matches("a*z", "abcxyz"));
+    assert!(wildcard_matches("*data", "www-data"));
+    assert!(wildcard_matches("www-*", "www-data"));
+    assert!(!wildcard_matches("a*z", "abcxy"));
+}

--- a/crates/metadata/src/mapping/user_group.rs
+++ b/crates/metadata/src/mapping/user_group.rs
@@ -29,6 +29,20 @@ impl UserMapping {
         self.0.map_uid(uid, numeric_ids)
     }
 
+    /// Applies the mapping to `uid` keyed on the sender-transmitted `name`.
+    ///
+    /// See [`NameMapping::map_uid_named`]: name/wildcard rules match against the
+    /// wire name rather than a receiver-local reverse lookup of the raw id,
+    /// mirroring upstream `recv_add_id` (uidlist.c:255-268).
+    pub fn map_uid_named(
+        &self,
+        uid: RawUid,
+        name: Option<&[u8]>,
+        numeric_ids: bool,
+    ) -> io::Result<Option<RawUid>> {
+        self.0.map_uid_named(uid, name, numeric_ids)
+    }
+
     /// Reports whether the mapping contains any rules.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
@@ -60,6 +74,20 @@ impl GroupMapping {
     /// Applies the mapping to the supplied GID.
     pub(crate) fn map_gid(&self, gid: RawGid, numeric_ids: bool) -> io::Result<Option<RawGid>> {
         self.0.map_gid(gid, numeric_ids)
+    }
+
+    /// Applies the mapping to `gid` keyed on the sender-transmitted `name`.
+    ///
+    /// See [`NameMapping::map_gid_named`]: name/wildcard rules match against the
+    /// wire name rather than a receiver-local reverse lookup of the raw id,
+    /// mirroring upstream `recv_add_id` (uidlist.c:255-268).
+    pub fn map_gid_named(
+        &self,
+        gid: RawGid,
+        name: Option<&[u8]>,
+        numeric_ids: bool,
+    ) -> io::Result<Option<RawGid>> {
+        self.0.map_gid_named(gid, name, numeric_ids)
     }
 
     /// Reports whether the mapping contains any rules.

--- a/crates/metadata/src/mapping_win.rs
+++ b/crates/metadata/src/mapping_win.rs
@@ -68,6 +68,31 @@ impl UserMapping {
     pub fn spec(&self) -> &str {
         ""
     }
+
+    /// Reports whether the mapping contains any rules.
+    ///
+    /// Always `true` on Windows: the type cannot be constructed, so this is
+    /// only provided to keep the cross-platform API surface uniform.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        true
+    }
+
+    /// Never maps on Windows (no POSIX user database).
+    ///
+    /// Provided so the receiver's id-list remap compiles cross-platform; the
+    /// value can never be constructed, so this is never actually called.
+    ///
+    /// # Errors
+    /// Never returns an error.
+    pub fn map_uid_named(
+        &self,
+        _uid: u32,
+        _name: Option<&[u8]>,
+        _numeric_ids: bool,
+    ) -> std::io::Result<Option<u32>> {
+        Ok(None)
+    }
 }
 
 /// Group mapping placeholder for Windows.
@@ -92,6 +117,31 @@ impl GroupMapping {
     #[must_use]
     pub fn spec(&self) -> &str {
         ""
+    }
+
+    /// Reports whether the mapping contains any rules.
+    ///
+    /// Always `true` on Windows: the type cannot be constructed, so this is
+    /// only provided to keep the cross-platform API surface uniform.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        true
+    }
+
+    /// Never maps on Windows (no POSIX group database).
+    ///
+    /// Provided so the receiver's id-list remap compiles cross-platform; the
+    /// value can never be constructed, so this is never actually called.
+    ///
+    /// # Errors
+    /// Never returns an error.
+    pub fn map_gid_named(
+        &self,
+        _gid: u32,
+        _name: Option<&[u8]>,
+        _numeric_ids: bool,
+    ) -> std::io::Result<Option<u32>> {
+        Ok(None)
     }
 }
 

--- a/crates/protocol/src/idlist/mod.rs
+++ b/crates/protocol/src/idlist/mod.rs
@@ -165,6 +165,21 @@ impl IdList {
             .collect()
     }
 
+    /// Returns an owned `remote id -> transmitted name` snapshot.
+    ///
+    /// Only ids that carried a name on the wire are included. Used by the
+    /// receiver to key `--usermap`/`--groupmap` rules on the sender-transmitted
+    /// name while it rewrites the file list, mirroring upstream `recv_add_id`'s
+    /// use of the wire `name` (uidlist.c:255-268) rather than a receiver-local
+    /// reverse lookup of the raw id.
+    #[must_use]
+    pub fn names_snapshot(&self) -> HashMap<u32, Vec<u8>> {
+        self.entries
+            .iter()
+            .filter_map(|(id, entry)| entry.name.as_ref().map(|name| (*id, name.clone())))
+            .collect()
+    }
+
     /// Writes the ID list to the wire.
     ///
     /// # Wire Format

--- a/crates/transfer/src/receiver/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/file_list/id_lists.rs
@@ -131,18 +131,24 @@ impl ReceiverContext {
     }
 
     /// Remaps every file-list entry's uid/gid from the sender's raw ids to the
-    /// local ids resolved from the transmitted name lists.
+    /// local ids chosen by upstream `match_uid`/`match_gid`.
     ///
-    /// Mirrors upstream `recv_id_list()`, which rewrites `F_OWNER`/`F_GROUP` for
-    /// every flist entry via `match_uid`/`match_gid` after the name lists are
-    /// read. Without this the receiver would chown files to the raw sender id,
-    /// which is wrong when that id is absent locally or bound to a different
-    /// name than on the sender - the very purpose of the non-numeric name list
-    /// is that ownership follows the *name* across hosts with different id
-    /// namespaces. Ids not present in the sent list keep their raw value,
-    /// matching `match_uid`'s `recv_add_id(..., NULL)` fallback (`--usermap`,
-    /// which upstream folds into `match_uid`, is applied later in
-    /// `metadata::apply`).
+    /// Mirrors upstream `recv_id_list()` (uidlist.c:483-494), which rewrites
+    /// `F_OWNER`/`F_GROUP` for every flist entry after the name lists are read.
+    /// For each entry this applies `recv_add_id`'s precedence (uidlist.c:255-282)
+    /// on the RAW sender id and its transmitted name:
+    ///
+    /// 1. Scan the `--usermap`/`--groupmap` rules FIRST - numeric rules keyed on
+    ///    the raw sender id, name/wildcard rules on the transmitted wire name
+    ///    (uidlist.c:255-268). The map result wins.
+    /// 2. Otherwise fall back to `user_to_uid(name)` - the id-list's
+    ///    name-resolved local id (uidlist.c:273-280).
+    /// 3. Otherwise keep the raw id (uidlist.c:281-282 / `recv_add_id(.., NULL)`).
+    ///
+    /// The map is keyed on the raw sender id and the wire name here, before
+    /// `F_OWNER` is overwritten: a numeric rule (`--usermap=1000:5000`) keys on
+    /// the raw id and a name/wildcard rule (`--usermap=deploy:www-data`) on the
+    /// sender name, neither of which survives a premature local-name rewrite.
     ///
     /// Only applied for `numeric_ids == 0` (upstream's `!numeric_ids` gate): an
     /// explicit or daemon-forced numeric transfer keeps the raw ids. Non-root
@@ -153,30 +159,45 @@ impl ReceiverContext {
     /// # Upstream Reference
     ///
     /// - `uidlist.c:483-494` - `recv_id_list()` remap loop
+    /// - `uidlist.c:255-282` - `recv_add_id()` map-then-name precedence
     pub(crate) fn remap_flist_ownership_from_id_lists(&mut self) {
         if !self.config.flags.numeric_ids.is_off() {
             return;
         }
         if self.config.flags.owner {
+            let mapping = self.config.user_mapping.clone();
             let uid_map = self.uid_list.resolved_map();
-            if !uid_map.is_empty() {
+            let names = self.uid_list.names_snapshot();
+            let has_rules = mapping.as_ref().is_some_and(|m| !m.is_empty());
+            if !uid_map.is_empty() || has_rules {
                 for entry in self.file_list.iter_mut() {
-                    if let Some(uid) = entry.uid()
-                        && let Some(&local) = uid_map.get(&uid)
-                    {
-                        entry.set_uid(local);
+                    if let Some(uid) = entry.uid() {
+                        let mapped = mapping.as_ref().and_then(|m| {
+                            m.map_uid_named(uid, names.get(&uid).map(Vec::as_slice), false)
+                                .ok()
+                                .flatten()
+                        });
+                        let resolved = mapped.unwrap_or_else(|| *uid_map.get(&uid).unwrap_or(&uid));
+                        entry.set_uid(resolved);
                     }
                 }
             }
         }
         if self.config.flags.group {
+            let mapping = self.config.group_mapping.clone();
             let gid_map = self.gid_list.resolved_map();
-            if !gid_map.is_empty() {
+            let names = self.gid_list.names_snapshot();
+            let has_rules = mapping.as_ref().is_some_and(|m| !m.is_empty());
+            if !gid_map.is_empty() || has_rules {
                 for entry in self.file_list.iter_mut() {
-                    if let Some(gid) = entry.gid()
-                        && let Some(&local) = gid_map.get(&gid)
-                    {
-                        entry.set_gid(local);
+                    if let Some(gid) = entry.gid() {
+                        let mapped = mapping.as_ref().and_then(|m| {
+                            m.map_gid_named(gid, names.get(&gid).map(Vec::as_slice), false)
+                                .ok()
+                                .flatten()
+                        });
+                        let resolved = mapped.unwrap_or_else(|| *gid_map.get(&gid).unwrap_or(&gid));
+                        entry.set_gid(resolved);
                     }
                 }
             }

--- a/crates/transfer/src/receiver/tests/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/tests/file_list/id_lists.rs
@@ -186,3 +186,94 @@ fn remap_keeps_raw_uid_under_numeric_ids() {
         "--numeric-ids must keep the raw sender id"
     );
 }
+
+/// Builds a receiver context whose uid list carries `(id, name)` and applies the
+/// remap with the supplied `--usermap`, returning the entry's resolved uid.
+#[cfg(unix)]
+fn remap_uid_with_usermap(sender_uid: u32, sender_name: &[u8], usermap: &str) -> Option<u32> {
+    use protocol::flist::FileEntry;
+    use protocol::idlist::IdList;
+
+    let handshake = test_handshake();
+    let mut config = config_with_flags(true, false, NumericIds::Off);
+    config.user_mapping = Some(metadata::UserMapping::parse(usermap).unwrap());
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    let proto = ctx.protocol().as_u8();
+
+    let mut sender = IdList::new();
+    sender.add_id(sender_uid, Some(sender_name.to_vec()));
+    let mut wire = Vec::new();
+    sender
+        .write(&mut wire, false, proto)
+        .expect("write uid list");
+
+    let mut cursor = Cursor::new(wire);
+    ctx.receive_id_lists(&mut cursor).expect("read uid list");
+
+    let mut entry = FileEntry::new_file("f".into(), 0, 0o644);
+    entry.set_uid(sender_uid);
+    ctx.file_list.push(entry);
+
+    ctx.remap_flist_ownership_from_id_lists();
+    ctx.file_list[0].uid()
+}
+
+/// Bug #1 (name keying): a NAME `--usermap` rule must match the sender's
+/// transmitted name, not a name re-derived from the raw id on the receiver.
+///
+/// upstream: uidlist.c:257-261 recv_add_id - `strcmp(node->u.name, name)` where
+/// `name` is the transmitted wire name. Sender uid 1500 need not exist locally.
+#[test]
+#[cfg(unix)]
+fn remap_usermap_name_rule_matches_sender_name() {
+    assert_eq!(
+        remap_uid_with_usermap(1500, b"deploy", "deploy:0"),
+        Some(0),
+        "usermap must map by the sender-transmitted name 'deploy'"
+    );
+}
+
+/// Bug #1 (wildcard keying): a WILD `--usermap` rule matches the sender name.
+///
+/// upstream: uidlist.c:256-258 - `wildmatch(node->u.name, name)`.
+#[test]
+#[cfg(unix)]
+fn remap_usermap_wildcard_rule_matches_sender_name() {
+    assert_eq!(
+        remap_uid_with_usermap(1500, b"deploy", "dep*:0"),
+        Some(0),
+        "wildcard usermap must map by the sender name 'deploy'"
+    );
+}
+
+/// Bug #2 (ordering): a NUMERIC `--usermap` rule keys on the RAW sender id and
+/// must win over the id-list's local-name resolution. Here the sender name
+/// "root" resolves locally to uid 0, so a premature F_OWNER rewrite to 0 (the
+/// old behaviour) would make the numeric rule `1500:5000` miss. The map must be
+/// applied on the raw id 1500 first.
+///
+/// upstream: uidlist.c:262-267 + 483-494 - the uidmap scan runs on the raw id
+/// inside match_uid before F_OWNER is rewritten.
+#[test]
+#[cfg(unix)]
+fn remap_usermap_numeric_rule_wins_over_local_name_resolution() {
+    assert_eq!(
+        remap_uid_with_usermap(1500, b"root", "1500:5000"),
+        Some(5000),
+        "numeric usermap on the raw id must win over name resolution"
+    );
+}
+
+/// No `--usermap` rule matches: fall back to the id-list's name-resolved local
+/// id (upstream user_to_uid(name)). Sender name "root" resolves to local uid 0.
+///
+/// upstream: uidlist.c:273-280 recv_add_id fallback.
+#[test]
+#[cfg(unix)]
+fn remap_falls_back_to_local_name_resolution_when_no_rule_matches() {
+    assert_eq!(
+        remap_uid_with_usermap(1500, b"root", "nomatch:9"),
+        Some(0),
+        "with no matching rule, ownership follows the local getpwnam(name)"
+    );
+}


### PR DESCRIPTION
## Problem

`--usermap`/`--groupmap` name and wildcard rules matched against the wrong
name, silently mis-mapping ownership when the sender and receiver have
different id namespaces.

Upstream `recv_add_id` (uidlist.c:255-268) scans the `uidmap`/`gidmap`
against the **sender-transmitted name** carried on the id-list wire -
`wildmatch(node->u.name, name)` / `strcmp(node->u.name, name)` where `name`
is the wire name - and only falls back to `user_to_uid(name)` (local
`getpwnam`) when no rule matches (uidlist.c:273-282). The map is consulted
**first** on the raw sender id and its transmitted name; local name
resolution is the fallback. The remap loop then rewrites `F_OWNER`/`F_GROUP`
via `match_uid`/`match_gid` (uidlist.c:483-494).

### Two bugs

1. **Name keying.** `resolve_rule` re-derived the name from the receiver's
   local db (`getpwuid`/`getgrgid` of the raw id) and matched *that* against
   the map, so a name/wildcard rule never saw the sender's name. A file from
   sender uid 1500 named `deploy` (absent locally) under
   `--usermap=deploy:www-data` kept raw uid 1500 instead of mapping to
   `www-data`.

2. **Ordering.** The id-list remap rewrote `F_OWNER`/`F_GROUP` to the local
   name-resolved id **first**, then `metadata::apply` ran the map on the
   already-remapped id, so a numeric rule (`--usermap=1500:5000`) missed when
   sender uid 1500's name resolved to a different local id first.

## Fix

Mirror `recv_add_id` precedence - a single resolution keyed on the raw
sender id + its transmitted name, before any local-name rewrite:

- Thread the sender-transmitted name into the matcher
  (`map_uid_named`/`map_gid_named`): numeric rules key on the raw id,
  name/wildcard rules on the wire name, never a receiver-local reverse
  lookup. A missing name normalizes to `""` (upstream `if (!name) name = ""`);
  under `--numeric-ids` the name is dropped so only numeric rules match.
- Apply the map in the id-list resolution stage
  (`remap_flist_ownership_from_id_lists`) on the raw sender id and the
  id-list name, with `map -> user_to_uid(name) -> raw id` precedence,
  baking the final local id into `F_OWNER`/`F_GROUP` (fixes both the name
  keying and the ordering for the non-INC_RECURSE path).
- The per-entry INC_RECURSE path (`resolve_owner_uid`/`resolve_group_gid`)
  keys the map on the inline transmitted name (`XMIT_USER_NAME_FOLLOWS`).

Preserved: id-list wire format, numeric-ids gating (daemon-forced `-1`
still consumes the list; explicit client `--numeric-ids` skips the map +
resolution), non-root `FLAG_SKIP_GROUP` gid skip, the impossible-id (`-1`)
warning, and the suid/sgid re-stat. Windows mapping stubs gain matching
no-op methods so the cross-platform remap compiles.

## Wildmatch

The bespoke glob (`mapping/wildcard.rs`) matches upstream `lib/wildmatch.c`
for the patterns `--usermap`/`--groupmap` sources actually use (`*`, `**`,
`?`, `[a-z]`, `[!x]`, `dep*`). Names contain no `/`, so `*` and `**` behave
identically. A parity test pins these cases.

## Tests

- id-list remap: name rule keyed on the sender name, wildcard rule keyed on
  the sender name, numeric rule keyed on the raw id winning over local name
  resolution, and no-match fallback to local `getpwnam(name)`.
- inline-name (INC_RECURSE) path: name/numeric/wildcard usermap and groupmap
  symmetry keyed on the transmitted name.
- unit: sender-name keying vs receiver reverse lookup, numeric-ids drops name
  rules but keeps numeric rules, empty-name matcher matches a nameless id,
  first-match-wins, and wildmatch parity.

## Verification

- `cargo fmt --all` clean.
- `cargo clippy -p metadata -p transfer -p protocol --all-features
  --all-targets --no-deps -D warnings` clean.
- `cargo nextest run -p metadata --all-features` - 534 passed.
- `cargo nextest run -p transfer --all-features` (file-list/ownership/id-list
  filters) - 263 passed; new remap tests green.
