### PR TITLE
fix(compress): -z --skip-compress must keep codec framing (wire/interop parity)

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -325,14 +325,15 @@ where
     {
         config.group_mapping = Some(mapping);
     }
-    // upstream: options.c:2859-2860 - `--skip-compress=LIST` is emitted when the
-    // client is the receiver (this process is the server sender); the sender
-    // skips compression for matching suffixes.
-    if let Some(spec) = &long_flags.skip_compress
-        && let Ok(list) = engine::SkipCompressList::parse(spec)
-    {
-        config.skip_compress = Some(list);
-    }
+    // upstream: options.c:2859-2860 - `--skip-compress=LIST` is forwarded to the
+    // server sender, but token.c:225 set_compression()'s per-file suffix lookup
+    // is compiled out under `#if 0` ("No compression algorithms currently allow
+    // mid-stream changing of the level."). So a negotiated codec frames EVERY
+    // file (token.c:1065 send_token() dispatches on the global do_compression);
+    // the suffix list never switches framing per file. Applying it here would
+    // emit plain tokens for a skip-matched file and desync the client-receiver's
+    // session-level codec reader. The arg is accepted for compatibility but has
+    // no per-file wire effect.
     // upstream: options.c:2886-2890 - `--partial-dir DIR` forwarded by the
     // sender. The server-side receiver moves interrupted temp files into this
     // directory and looks for resume basis files there. Without applying this

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -38,7 +38,7 @@ use std::os::unix::fs::PermissionsExt;
 
 use checksums::strong::{Md4, Md5};
 use clap::{Arg, ArgAction, Command, builder::OsStringValueParser};
-use core::client::{SkipCompressList, TcpFastOpenMode};
+use core::client::TcpFastOpenMode;
 use core::{
     auth::{digests_for_protocol, verify_daemon_auth_response},
     bandwidth::{

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -242,15 +242,16 @@ fn build_server_config(
             }
 
             // upstream: loadparm.c - `dont compress` parameter specifies suffixes
-            // that should skip per-file compression during transfer.
+            // that should skip per-file compression during transfer. However,
+            // token.c:225 set_compression()'s per-file suffix lookup is compiled
+            // out under `#if 0` ("No compression algorithms currently allow
+            // mid-stream changing of the level."), so a non-`*` suffix list has no
+            // per-file wire effect. The only live case is a bare `*`, which
+            // collapses the whole zlib stream to store (level 0) at init
+            // (token.c:206-211) - still deflated framing, never plain tokens.
             if let Some(dont_compress) = module.dont_compress.as_deref() {
                 if dont_compress_is_match_all(dont_compress) {
-                    // upstream: token.c:206-211 - a bare `*` collapses the match
-                    // list to a whole-stream store (zlib level 0) and clears the
-                    // per-file suffix tree, so no `skip_compress` list is built.
                     cfg.connection.dont_compress_match_all = true;
-                } else if let Some(list) = parse_daemon_dont_compress(dont_compress) {
-                    cfg.skip_compress = Some(list);
                 }
             }
 

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -190,43 +190,6 @@ fn dont_compress_is_match_all(value: &str) -> bool {
     value.split_whitespace().any(|token| token == "*")
 }
 
-/// Parses the daemon `dont compress` parameter into a `SkipCompressList`.
-///
-/// The daemon format uses space-separated glob-style suffixes (e.g., `"*.gz *.zip *.jpg"`).
-/// Each suffix is stripped of its `*.` prefix and converted to the slash-separated
-/// format that `SkipCompressList::parse` expects. Bare suffixes without `*.` prefix
-/// are also accepted.
-///
-/// Returns `None` if the input is empty or contains no valid suffixes.
-///
-/// # Upstream Reference
-///
-/// - `loadparm.c` - `dont compress` parameter, space-separated globs
-/// - `exclude.c:set_dont_compress_re()` - converts to regex for per-file matching
-fn parse_daemon_dont_compress(value: &str) -> Option<SkipCompressList> {
-    let suffixes: Vec<&str> = value
-        .split_whitespace()
-        .filter_map(|token| {
-            // Strip `*.` prefix used in daemon config notation
-            if let Some(suffix) = token.strip_prefix("*.") {
-                if !suffix.is_empty() {
-                    return Some(suffix);
-                }
-            }
-            // Accept bare suffixes without glob prefix
-            let bare = token.trim_start_matches('.');
-            if !bare.is_empty() { Some(bare) } else { None }
-        })
-        .collect();
-
-    if suffixes.is_empty() {
-        return None;
-    }
-
-    let spec = suffixes.join("/");
-    SkipCompressList::parse(&spec).ok()
-}
-
 /// Builds daemon-side filter rules from the module's filter configuration.
 ///
 /// Upstream rsync's `clientserver.c:rsync_module()` builds `daemon_filter_list` from:

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1399,43 +1399,6 @@ mod module_access_tests {
         assert!(offender.is_none(), "positional paths must not flag: {offender:?}");
     }
 
-    #[test]
-    fn parse_daemon_dont_compress_glob_suffixes() {
-        let list = parse_daemon_dont_compress("*.gz *.zip *.jpg").expect("should parse");
-        assert!(list.matches_path(Path::new("archive.gz")));
-        assert!(list.matches_path(Path::new("bundle.zip")));
-        assert!(list.matches_path(Path::new("photo.jpg")));
-        assert!(!list.matches_path(Path::new("notes.txt")));
-    }
-
-    #[test]
-    fn parse_daemon_dont_compress_bare_suffixes() {
-        let list = parse_daemon_dont_compress("gz zip").expect("should parse");
-        assert!(list.matches_path(Path::new("archive.gz")));
-        assert!(list.matches_path(Path::new("bundle.zip")));
-    }
-
-    #[test]
-    fn parse_daemon_dont_compress_empty_returns_none() {
-        assert!(parse_daemon_dont_compress("").is_none());
-        assert!(parse_daemon_dont_compress("   ").is_none());
-    }
-
-    #[test]
-    fn parse_daemon_dont_compress_case_insensitive() {
-        let list = parse_daemon_dont_compress("*.GZ *.ZIP").expect("should parse");
-        assert!(list.matches_path(Path::new("archive.gz")));
-        assert!(list.matches_path(Path::new("ARCHIVE.GZ")));
-    }
-
-    #[test]
-    fn parse_daemon_dont_compress_mixed_formats() {
-        let list = parse_daemon_dont_compress("*.gz mp3 .bz2").expect("should parse");
-        assert!(list.matches_path(Path::new("file.gz")));
-        assert!(list.matches_path(Path::new("song.mp3")));
-        assert!(list.matches_path(Path::new("archive.bz2")));
-    }
-
     // WHY: upstream token.c:206-211 treats a bare `*` in the dont-compress match
     // list as the whole-stream store signal (not a per-file suffix). A normal
     // suffix list must not be mistaken for it, or ordinary transfers would lose

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -22,7 +22,6 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 use compress::zlib::CompressionLevel;
-use engine::SkipCompressList;
 use metadata::{ChmodModifiers, GroupMapping, ModifyWindow, UserMapping};
 use protocol::FilenameConverter;
 use protocol::ProtocolVersion;
@@ -85,7 +84,6 @@ pub struct ServerConfigBuilder {
     file_selection: FileSelectionConfig,
     do_stats: bool,
     temp_dir: Option<PathBuf>,
-    skip_compress: Option<SkipCompressList>,
     fake_super: bool,
     daemon_incoming_chmod: Option<ChmodModifiers>,
     daemon_outgoing_chmod: Option<ChmodModifiers>,
@@ -127,7 +125,6 @@ impl ServerConfigBuilder {
             file_selection: FileSelectionConfig::default(),
             do_stats: false,
             temp_dir: None,
-            skip_compress: None,
             fake_super: false,
             daemon_incoming_chmod: None,
             daemon_outgoing_chmod: None,
@@ -491,12 +488,6 @@ impl ServerConfigBuilder {
         self
     }
 
-    /// Sets the file suffixes that should skip per-file compression.
-    pub fn skip_compress(&mut self, list: Option<SkipCompressList>) -> &mut Self {
-        self.skip_compress = list;
-        self
-    }
-
     /// Enables or disables daemon-side fake-super metadata storage.
     ///
     /// Sourced from the daemon module's `fake super = yes` directive in
@@ -651,7 +642,6 @@ impl ServerConfigBuilder {
             file_selection: self.file_selection.clone(),
             do_stats: self.do_stats,
             temp_dir: self.temp_dir.clone(),
-            skip_compress: self.skip_compress.clone(),
             fake_super: self.fake_super,
             daemon_incoming_chmod: self.daemon_incoming_chmod.clone(),
             daemon_outgoing_chmod: self.daemon_outgoing_chmod.clone(),

--- a/crates/transfer/src/config/builder_tests.rs
+++ b/crates/transfer/src/config/builder_tests.rs
@@ -201,7 +201,6 @@ mod defaults {
         assert!(config.daemon_filter_rules.is_empty());
         assert!(!config.do_stats);
         assert!(config.temp_dir.is_none());
-        assert!(config.skip_compress.is_none());
         assert!(!config.fake_super);
     }
 

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -10,7 +10,6 @@ use std::ffi::OsString;
 use std::time::SystemTime;
 
 use compress::zlib::CompressionLevel;
-use engine::SkipCompressList;
 use metadata::{ChmodModifiers, GroupMapping, ModifyWindow, UserMapping};
 use protocol::FilenameConverter;
 use protocol::ProtocolVersion;
@@ -456,17 +455,6 @@ pub struct ServerConfig {
     /// - `receiver.c:766`: `open_tmpfile()` uses `tmpdir` when set
     /// - `loadparm.c`: `temp dir` daemon module parameter
     pub temp_dir: Option<std::path::PathBuf>,
-    /// File suffixes that should skip per-file compression.
-    ///
-    /// When compression is enabled, files whose extension matches a suffix in
-    /// this list are sent uncompressed. This is populated from the daemon's
-    /// `dont compress` module parameter or the client's `--skip-compress` option.
-    ///
-    /// # Upstream Reference
-    ///
-    /// - `token.c:do_compression` - per-file compression decision
-    /// - `loadparm.c` - `dont compress` daemon parameter
-    pub skip_compress: Option<SkipCompressList>,
     /// When true, store privileged metadata (uid/gid, devices, special files) in
     /// the `user.rsync.%stat` xattr instead of applying it directly to inodes.
     ///
@@ -590,7 +578,6 @@ impl Default for ServerConfig {
             file_selection: FileSelectionConfig::default(),
             do_stats: false,
             temp_dir: None,
-            skip_compress: None,
             fake_super: false,
             daemon_incoming_chmod: None,
             daemon_outgoing_chmod: None,

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -553,28 +553,6 @@ impl GeneratorContext {
         }
     }
 
-    /// Returns the per-file compression algorithm, respecting the skip-compress list.
-    ///
-    /// When compression is negotiated but the file's extension matches the
-    /// skip-compress list, returns `None` to send the file uncompressed.
-    ///
-    /// # Upstream Reference
-    ///
-    /// - `token.c:do_compression` - checks `dont_compress_re` regex per file
-    /// - `loadparm.c` - `dont compress` daemon parameter populates the regex
-    pub(crate) fn file_compression(
-        &self,
-        path: &std::path::Path,
-    ) -> Option<protocol::CompressionAlgorithm> {
-        let algo = self.negotiated_algorithms.map(|n| n.compression)?;
-        if let Some(ref skip_list) = self.config.skip_compress {
-            if skip_list.matches_path(path) {
-                return None;
-            }
-        }
-        Some(algo)
-    }
-
     /// Opens a source file for reading with `BufReader` buffering.
     ///
     /// Suitable for callers that perform many small or random reads (e.g., the

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -940,6 +940,84 @@ mod tests {
         );
     }
 
+    // WHY: token framing is a session-level concern, not a per-file one. Once a
+    // codec is negotiated (`-z`), EVERY file is framed with that codec on the
+    // wire - upstream token.c:1065 send_token() dispatches purely on the global
+    // `do_compression`, and token.c:225 set_compression()'s per-file suffix
+    // lookup is compiled out under `#if 0`. A `--skip-compress` suffix must NOT
+    // switch a file to plain 4-byte-LE tokens: the receiver builds one
+    // session-level token reader from the negotiated codec and always expects
+    // deflated framing, so plain tokens desync the stream. This pins that a
+    // present encoder emits deflated framing while an absent encoder (no `-z`)
+    // emits plain tokens, for byte-identical input.
+    #[test]
+    fn present_encoder_emits_deflated_framing_not_plain_tokens() {
+        let data: Vec<u8> = (0..64u8).collect();
+        // A single literal chunk in plain framing is a 4-byte little-endian
+        // length prefix followed by the verbatim data (upstream
+        // simple_send_token / match.c send_token()).
+        let plain_prefix = (data.len() as i32).to_le_bytes();
+
+        // No codec negotiated: the correct non-`-z` path emits plain tokens.
+        let mut plain = Vec::new();
+        let mut buf = Vec::new();
+        let plain_res = stream_whole_file_transfer(
+            &mut plain,
+            &data[..],
+            data.len() as u64,
+            ChecksumAlgorithm::MD5,
+            0,
+            None,
+            &mut buf,
+            None,
+        )
+        .expect("plain stream");
+        assert!(
+            plain.starts_with(&plain_prefix) && plain[4..4 + data.len()] == data[..],
+            "no-codec path must emit plain 4-byte-LE tokens carrying verbatim data"
+        );
+
+        // Codec negotiated (as under `-z`, regardless of any skip-compress
+        // suffix): the wire must be deflated framing, never plain tokens with
+        // the literal on the wire verbatim.
+        let mut enc =
+            create_token_encoder(CompressionAlgorithm::Zlib, CompressionLevel::Best, None)
+                .expect("zlib encoder creation should succeed")
+                .expect("zlib produces an encoder");
+        let mut deflated = Vec::new();
+        let mut buf2 = Vec::new();
+        let deflated_res = stream_whole_file_transfer(
+            &mut deflated,
+            &data[..],
+            data.len() as u64,
+            ChecksumAlgorithm::MD5,
+            0,
+            Some(&mut enc),
+            &mut buf2,
+            None,
+        )
+        .expect("deflated stream");
+
+        assert_ne!(
+            deflated, plain,
+            "codec framing must differ from plain token framing"
+        );
+        let emits_plain_verbatim = deflated.len() >= 4 + data.len()
+            && deflated.starts_with(&plain_prefix)
+            && deflated[4..4 + data.len()] == data[..];
+        assert!(
+            !emits_plain_verbatim,
+            "codec path must not fall back to plain tokens (the skip-compress desync bug)"
+        );
+        // Framing changed; the reconstructed data (and its whole-file checksum)
+        // did not.
+        assert_eq!(
+            &plain_res.checksum_buf[..plain_res.checksum_len],
+            &deflated_res.checksum_buf[..deflated_res.checksum_len],
+            "whole-file checksum is codec-independent"
+        );
+    }
+
     #[cfg(feature = "zstd")]
     #[test]
     fn create_token_encoder_zstd_no_workers() {

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -160,6 +160,18 @@ impl GeneratorContext {
             .transpose()?
             .flatten();
 
+        // upstream: token.c:1065 send_token() / token.c:1097 recv_token() dispatch
+        // purely on the global `do_compression` codec, and token.c:225
+        // set_compression()'s per-file suffix lookup is compiled out under `#if 0`
+        // ("No compression algorithms currently allow mid-stream changing of the
+        // level."). So once a codec is negotiated (`-z`), EVERY file is framed with
+        // that codec on the wire; `--skip-compress`/`dont compress` suffix lists
+        // never switch framing per file. A bare `*` is the only live effect and is
+        // handled session-wide above via `dont_compress_match_all` (whole zlib
+        // stream stored at level 0, still deflated framing). The framing decision is
+        // therefore one session-level constant, not a per-file boolean.
+        let use_compression = token_encoder.is_some();
+
         // upstream: io.c:2244-2245 - separate read/write NDX state
         let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
         let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
@@ -598,7 +610,6 @@ impl GeneratorContext {
                 )?;
 
                 let checksum_algorithm = self.get_checksum_algorithm();
-                let use_compression = self.file_compression(&source_path).is_some();
                 let flength = sum_head.flength().min(file_size);
                 let append_verify = self.config.flags.append_verify;
                 let wire_bytes = {
@@ -716,7 +727,6 @@ impl GeneratorContext {
                 let checksum_algorithm = self.get_checksum_algorithm();
                 let use_noatime = self.config.write.open_noatime;
                 let wire_ops = script_to_wire_delta(delta_script, block_length);
-                let use_compression = self.file_compression(&source_path).is_some();
                 let is_zlib = matches!(
                     negotiated_compression,
                     Some(protocol::CompressionAlgorithm::Zlib)
@@ -784,7 +794,6 @@ impl GeneratorContext {
                 )?;
 
                 let checksum_algorithm = self.get_checksum_algorithm();
-                let use_compression = self.file_compression(&source_path).is_some();
                 // upstream: io.c:859 - stats.total_written counts actual wire
                 // bytes after each write() syscall, not the source file size.
                 // Wrap the whole-file stream in a CountingWriter so the summary

--- a/crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs
+++ b/crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs
@@ -769,3 +769,112 @@ fn concurrent_fixtures_get_distinct_ports_and_do_not_cross_talk() {
         "every concurrent fixture must bind a distinct port (no reuse collision)"
     );
 }
+
+/// UTS-NEXTEST-EDGE.e.6 - a daemon module's `dont compress = <suffix>` must keep
+/// codec framing on a `-z` transfer.
+///
+/// Regression for the per-file token-framing desync: the daemon sender used to
+/// switch to plain (uncompressed) 4-byte-LE tokens for any file whose suffix
+/// matched the module's `dont compress` list, while the receiver builds one
+/// session-level token reader from the negotiated codec and always expects
+/// deflated framing. A `.gz` file pulled under `-z` from a module with
+/// `dont compress = gz` therefore desynced the token stream and aborted the
+/// transfer with a `protocol incompatibility` / out-of-range file-list index.
+///
+/// Upstream never does this: `token.c:1065 send_token()` dispatches purely on
+/// the global `do_compression` codec, and `token.c:225 set_compression()`'s
+/// per-file suffix lookup is compiled out under `#if 0` ("No compression
+/// algorithms currently allow mid-stream changing of the level."). The daemon's
+/// `dont compress` suffix list builds a suffix tree (`init_set_compression()`)
+/// that `set_compression()` never consults, so it has no per-file wire effect;
+/// only a bare `*` matters (whole-stream store, still deflated framing).
+///
+/// The `dont compress = gz` module directive is the runtime-reachable trigger
+/// for the daemon-sender path (a bare client `--skip-compress` on a push never
+/// reaches the wire token path). This scenario failed on the pre-fix sender
+/// against both oc and a real upstream receiver; after the fix the daemon keeps
+/// codec framing and the pull round-trips byte-identically.
+#[test]
+fn daemon_dont_compress_suffix_keeps_codec_framing() {
+    let Some(bin) = locate_oc_rsync() else {
+        eprintln!("skip: oc-rsync binary not located");
+        return;
+    };
+
+    let workdir = tempdir().expect("workdir");
+    let module_root = workdir.path().join("module");
+    fs::create_dir_all(&module_root).expect("module root");
+
+    // A `.gz`-suffixed file matching the module's `dont compress = gz`.
+    // Compressible content so the codec is non-trivially engaged; the NAME is
+    // what used to trip the per-file framing switch on the daemon sender.
+    let source = build_compressible(256 * 1024);
+    let src_path = module_root.join("archive.gz");
+    fs::write(&src_path, &source).expect("write daemon-side .gz source");
+
+    // A daemon module whose `dont compress = gz` selects the skip-matched
+    // suffix. `use chroot = false` / `read only = false` keep the unprivileged
+    // test process able to serve the pull.
+    let config_path = workdir.path().join("rsyncd.conf");
+    let body = format!(
+        "pid file = {pid}\n\
+         log file = {log}\n\
+         use chroot = false\n\
+         max connections = 4\n\
+         \n\
+         [gzipmod]\n\
+         path = {module}\n\
+         read only = false\n\
+         dont compress = gz\n\
+         list = true\n",
+        pid = workdir.path().join("rsyncd.pid").display(),
+        log = workdir.path().join("rsyncd.log").display(),
+        module = module_root.display(),
+    );
+    fs::write(&config_path, body).expect("write daemon config");
+
+    let (_daemon, port) = match spawn_oc_rsync_daemon(&bin, &config_path) {
+        Ok(pair) => pair,
+        Err(e) => {
+            eprintln!("skip: could not start oc-rsync daemon: {e}");
+            return;
+        }
+    };
+
+    // Pull the skip-matched `.gz` with `-z`. The module's `dont compress = gz`
+    // drives the daemon sender; no client `--skip-compress` is needed.
+    let dest_dir = tempdir().expect("dest tempdir");
+    let url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{port}/gzipmod/archive.gz"));
+    let dest = dest_dir.path().as_os_str().to_owned();
+    let output = run_client(&[
+        "-a".as_ref(),
+        "-z".as_ref(),
+        "--timeout=30".as_ref(),
+        url.as_ref(),
+        dest.as_ref(),
+    ])
+    .expect("spawn oc-rsync pull client");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert!(
+        output.status.success(),
+        "-z pull from `dont compress = gz` module must exit 0; status={:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status.code(),
+    );
+    // The desync surfaced as a truncated stream (UTS-9 signature) or a corrupt
+    // file-list index / protocol incompatibility once plain tokens were parsed
+    // as deflated framing. Fail loud on either.
+    assert!(
+        !stderr.contains("connection unexpectedly closed")
+            && !stderr.contains("protocol incompatibility")
+            && !stderr.contains("read_ndx_and_attrs"),
+        "-z pull from `dont compress = gz` module desynced the token stream; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        read_all(&dest_dir.path().join("archive.gz")),
+        source,
+        "pulled .gz must be byte-identical when the module sets `dont compress = gz`"
+    );
+}


### PR DESCRIPTION
## Summary

Under `-z`, the token-stream sender switched wire framing **per file**: whenever a file's suffix matched the skip-compress list, it emitted plain 4-byte-LE simple tokens instead of the negotiated codec's framing. The receiver builds a single session-level token reader from the negotiated codec and always expects deflated (or zstd/lz4) framing, so a skip-matched file under `-z` desynced the token stream — against both a real upstream rsync and oc↔oc.

This makes the framing decision a single session-level concern and removes the vestigial per-file suffix plumbing on the wire path.

## Upstream reference (the source of truth)

`token.c` (rsync 3.4.4, protocol 32):

- `send_token()` (~1065) and `recv_token()` (~1097) dispatch **purely on the global `do_compression` codec** — there is no per-file branch.
- `set_compression()` (~225) — the per-file suffix lookup body is compiled out under `#if 0`, with the comment *"No compression algorithms currently allow mid-stream changing of the level."* `init_set_compression()` still builds the suffix tree, but nothing ever consults it.
- The only live effect of the whole mechanism is a bare `*`, which sets `per_file_default_level = skip_compression_level` at init (~206-211) — the whole zlib stream is stored at level 0, but **still with deflated framing**, never plain tokens.
- A non-daemon `--skip-compress` is discarded outright (`f = ""`, ~182).

So once a codec is negotiated, **every** file — including a skip-matched `.gz` — is framed with that codec on the wire.

## The bug

- `crates/transfer/src/generator/context.rs::file_compression()` returned `None` for skip-matched suffixes.
- The transfer loop set `use_compression = file_compression(...).is_some()` per file; when false it routed the file through the plain-token path in `delta.rs` (`(chunk as i32).to_le_bytes()` + `write_token_end`) = upstream `simple_send_token` format.
- The receiver's session-level codec reader then parsed those plain bytes as deflated framing → desync.

The transfer `ServerConfig.skip_compress` list was populated by two runtime-reachable paths: a daemon module's `dont compress = <suffix>` and a client-forwarded `--skip-compress` applied on an SSH `--server` sender.

## The fix

- Framing is now one session-level constant: `use_compression = token_encoder.is_some()`.
- Removed the vestigial per-file suffix plumbing on the wire path: the transfer `ServerConfig.skip_compress` list, the generator `file_compression()`, the daemon module per-suffix list, and the SSH server-sender's per-suffix application.
- **Preserved:** the bare-`*` whole-stream store (`dont_compress_match_all` → zlib level 0, deflated framing; zstd/lz4 unaffected); the forwarded `--skip-compress` server arg (`skip_compress_spec`); the separate local-copy skip-compress path (core `ClientConfig`); and the non-`-z` plain-token path.

## Verification (real upstream rsync 3.4.4, protocol 32)

An oc daemon module with `dont compress = gz`, pulled with `-z`:

| direction | pre-fix (master) | post-fix |
|---|---|---|
| upstream 3.4.4 client ← oc daemon | **FAIL** `protocol incompatibility (code 2)` / file-list index out of range | **PASS** byte-identical |
| oc client ← oc daemon | **FAIL** `NDX … but expected 0 - protocol violation (code 23)` | **PASS** byte-identical |
| oc sender → upstream 3.4.4 receiver, `-z --skip-compress=gz` | n/a | **PASS** byte-identical |
| oc receiver ← upstream 3.4.4 sender, `-z --skip-compress=gz` | n/a | **PASS** byte-identical |

Also on the host: `cargo fmt --all -- --check` clean; `cargo clippy -p transfer -p compress -p protocol -p cli -p daemon --all-features --all-targets --no-deps -- -D warnings` clean; targeted `cargo nextest` for the affected areas (1391 tests across daemon/transfer/cli/compress) all pass.

## Tests

- `present_encoder_emits_deflated_framing_not_plain_tokens` (unit, `delta.rs`): pins that a present encoder emits deflated framing while an absent encoder emits plain 4-byte-LE tokens carrying verbatim data, for byte-identical input.
- `daemon_dont_compress_suffix_keeps_codec_framing` (integration): a `-z` pull from a `dont compress = gz` module round-trips byte-identically with no desync signature. Fails on the pre-fix sender, passes after.
- Removed the obsolete daemon `parse_daemon_dont_compress` suffix-list tests (they encoded the old per-file behavior) and the transfer-config `skip_compress` default-field assertion.
