### PR TITLE
fix(filters): per-dir `!` clears inherited ancestor merge rules

### DIFF
--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -46,7 +46,7 @@ pub use config::DirMergeConfig;
 pub use error::FilterChainError;
 pub use scope::DirFilterGuard;
 
-use scope::{DirScope, scope_has_deletion_match, scope_has_transfer_match};
+use scope::{ClearedScope, DirScope, scope_has_deletion_match, scope_has_transfer_match};
 
 /// Per-directory scoped filter chain with push/pop semantics.
 ///
@@ -82,6 +82,11 @@ pub struct FilterChain {
     merge_configs: Vec<DirMergeConfig>,
     /// Ordered from outermost to innermost; evaluation iterates in reverse.
     scopes: Vec<DirScope>,
+    /// Ancestor scopes removed by a `!` (clear-list) rule, tagged with the
+    /// depth at which the clear fired so they can be restored when that
+    /// directory is left. Mirrors upstream `exclude.c:pop_local_filters()`,
+    /// which rebuilds the pre-descent mergelist for sibling directories.
+    cleared_scopes: Vec<ClearedScope>,
     current_depth: usize,
     /// Mirrors upstream's `delete_excluded` global. When `true`, per-token
     /// rules expanded from merge files acquire an implicit FILTRULE_SENDER_SIDE
@@ -115,6 +120,7 @@ impl FilterChain {
             global,
             merge_configs: Vec::new(),
             scopes: Vec::new(),
+            cleared_scopes: Vec::new(),
             current_depth: 0,
             delete_excluded: false,
             transfer_root: None,
@@ -409,6 +415,20 @@ impl FilterChain {
             // its tokens into this scope.
             let (rules, mut dir_merge_descriptors) = split_dir_merge_rules(rules);
 
+            // upstream: exclude.c:1393-1401 parse_filter_str() - a `!`
+            // (FILTRULE_CLEAR_LIST) in a per-directory merge file runs
+            // `pop_filter_list(listp)` and THEN `listp->head = NULL`, so it
+            // drops the mergelist's inherited ancestor rules, not just this
+            // directory's own section. Only an inheriting config accumulates
+            // ancestor rules to clear (a non-inheriting `:C`-style list is
+            // re-read fresh per directory), so gate on `config.inherits()` to
+            // match the engine local-copy path (context_impl/transfer.rs, which
+            // clears `layers[index]` only when `rule.options().inherit_rules()`).
+            let clears_inherited = config.inherits()
+                && rules
+                    .iter()
+                    .any(|r| matches!(r.action(), FilterAction::Clear));
+
             if rules.is_empty() && dir_merge_descriptors.is_empty() && !config.excludes_self() {
                 continue;
             }
@@ -453,6 +473,10 @@ impl FilterChain {
                 modified_rules.push(FilterRule::exclude(config.filename().to_owned()));
             }
 
+            // Capture before the mutable-borrow clear below drops the `config`
+            // reference into `self.merge_configs`.
+            let config_inherits = config.inherits();
+
             let filter_set = match FilterSet::from_rules(modified_rules) {
                 Ok(set) => set,
                 Err(e) => {
@@ -462,11 +486,25 @@ impl FilterChain {
                 }
             };
 
+            // upstream: exclude.c:1393-1401 - drop the inherited ancestor rules
+            // of THIS mergelist (same `config_index`) before the current
+            // directory's own section is pushed. The removed scopes are stashed
+            // in `cleared_scopes` and restored when this directory is left, so a
+            // sibling directory without a `!` still sees the parent rules
+            // (exclude.c:pop_local_filters rebuilds the pre-descent mergelist).
+            // Runs even when `filter_set` is empty (a lone `!`), so the clear is
+            // never a no-op. FilterSet::from_rules already applied the
+            // within-file clear (rules before `!` in this same file).
+            if clears_inherited {
+                self.clear_inherited_scopes(config_index, depth);
+            }
+
             if !filter_set.is_empty() {
                 self.scopes.push(DirScope {
                     depth,
                     filter_set,
-                    inherits: config.inherits(),
+                    inherits: config_inherits,
+                    config_index: Some(config_index),
                 });
                 pushed_count += 1;
             }
@@ -617,6 +655,16 @@ impl FilterChain {
             return Ok(0);
         }
 
+        // An inheriting `:` dir-merge is also registered as a persistent config
+        // (see enter_directory), so descendant loads run through the main loop
+        // under that config's index. Tag this one-shot scope with the same
+        // index so a descendant `!` clears it as one mergelist; unregistered
+        // (no-inherit) variants have no cross-directory identity.
+        let config_index = self
+            .merge_configs
+            .iter()
+            .position(|c| c.filename() == descriptor.filename);
+
         // upstream: exclude.c:1248-1254 - `:C` implies FILTRULE_NO_INHERIT,
         // so the loaded rules apply only to the directory containing the
         // outer merge file, not to descendants. Other dir-merge variants
@@ -625,6 +673,7 @@ impl FilterChain {
             depth,
             filter_set,
             inherits: !descriptor.no_inherit,
+            config_index,
         });
         Ok(1)
     }
@@ -639,6 +688,7 @@ impl FilterChain {
     /// state from before entering the directory.
     pub fn leave_directory(&mut self, guard: DirFilterGuard) {
         self.pop_scopes_at_depth(guard.depth);
+        self.restore_cleared_scopes(guard.depth);
         self.current_depth = self.current_depth.saturating_sub(1);
     }
 
@@ -682,6 +732,51 @@ impl FilterChain {
         self.scopes.retain(|scope| scope.depth != depth);
     }
 
+    /// Removes the inherited ancestor scopes of the given merge config,
+    /// stashing them for restoration when the clearing directory is left.
+    ///
+    /// Mirrors upstream `exclude.c:1393-1401`, where a per-directory `!`
+    /// clears the mergelist's inherited head. Only scopes with the same
+    /// `config_index` are removed, matching `pop_filter_list(listp)` operating
+    /// on a single list; scopes belonging to other per-directory merge files
+    /// (a different `listp`) are left untouched.
+    fn clear_inherited_scopes(&mut self, config_index: usize, depth: usize) {
+        let mut i = 0;
+        while i < self.scopes.len() {
+            if self.scopes[i].config_index == Some(config_index) {
+                let scope = self.scopes.remove(i);
+                self.cleared_scopes.push(ClearedScope { depth, scope });
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    /// Restores scopes cleared by a `!` at the given depth, re-establishing the
+    /// pre-descent mergelist for sibling directories.
+    ///
+    /// Mirrors upstream `exclude.c:pop_local_filters()`. Restored scopes are
+    /// re-inserted in stack order (by depth, then config index) so evaluation
+    /// still walks innermost-to-outermost correctly.
+    fn restore_cleared_scopes(&mut self, depth: usize) {
+        if !self.cleared_scopes.iter().any(|c| c.depth == depth) {
+            return;
+        }
+        let mut i = 0;
+        while i < self.cleared_scopes.len() {
+            if self.cleared_scopes[i].depth == depth {
+                let restored = self.cleared_scopes.remove(i).scope;
+                self.scopes.push(restored);
+            } else {
+                i += 1;
+            }
+        }
+        self.scopes.sort_by(|a, b| {
+            (a.depth, a.config_index.unwrap_or(usize::MAX))
+                .cmp(&(b.depth, b.config_index.unwrap_or(usize::MAX)))
+        });
+    }
+
     /// Pushes a pre-built filter set as a per-directory scope.
     ///
     /// This is useful for testing or when rules are obtained from sources
@@ -696,6 +791,7 @@ impl FilterChain {
                 depth,
                 filter_set,
                 inherits: true,
+                config_index: None,
             });
         }
         DirFilterGuard {

--- a/crates/filters/src/chain/scope.rs
+++ b/crates/filters/src/chain/scope.rs
@@ -27,6 +27,28 @@ pub(super) struct DirScope {
     /// deeper directories. When `false`, the scope is only consulted at
     /// its own depth, mirroring upstream `FILTRULE_NO_INHERIT`.
     pub(super) inherits: bool,
+    /// Index into `FilterChain::merge_configs` of the per-directory merge
+    /// config that produced this scope, or `None` for scopes not tied to a
+    /// persistent config (e.g. `push_scope`). Scopes sharing a `config_index`
+    /// form a single logical mergelist across directories, matching upstream's
+    /// per-`dir-merge` `filter_rule_list`. A `!` (clear-list) rule clears only
+    /// the scopes of the same `config_index` (`exclude.c:pop_filter_list()`
+    /// operates on one `listp`).
+    pub(super) config_index: Option<usize>,
+}
+
+/// An ancestor scope removed from the stack by a `!` (clear-list) rule.
+///
+/// Upstream's `!` drops the mergelist's inherited ancestor rules for the
+/// duration of the clearing directory and its descendants, then the state is
+/// restored when leaving that directory (`exclude.c:pop_local_filters()`
+/// rebuilds the pre-descent mergelist). `depth` records the directory depth at
+/// which the clear fired so the scope is re-inserted when that directory is
+/// left, keeping sibling directories' inherited rules intact.
+#[derive(Clone, Debug)]
+pub(super) struct ClearedScope {
+    pub(super) depth: usize,
+    pub(super) scope: DirScope,
 }
 
 /// Checks whether a `FilterSet` has any sender-side rule that matches the

--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -722,6 +722,7 @@ fn filter_chain_non_inheriting_scope_falls_through_to_outer_inherited() {
         depth: inner_depth,
         filter_set: inner_set,
         inherits: false,
+        config_index: None,
     });
 
     // At depth 2 with a no-inherit inner scope that does not match
@@ -1037,4 +1038,130 @@ fn anchored_root_exclude_does_not_match_nested_basename() {
     // Nested `sub/drop.txt` is NOT excluded by the anchored rule.
     assert!(chain.allows(Path::new("sub/drop.txt"), false));
     assert!(chain.allows(Path::new("keep.txt"), false));
+}
+
+// upstream: exclude.c:1393-1401 parse_filter_str() - a `!` (FILTRULE_CLEAR_LIST)
+// in a per-directory merge file runs `pop_filter_list(listp)` and THEN sets
+// `listp->head = NULL`, so it drops the mergelist's INHERITED ancestor rules,
+// not just the current directory's own section. Here a parent `.rsync-filter`
+// excludes `secret.txt`; a child `.rsync-filter` clears the list with `!` and
+// re-includes `secret.txt`. On the protocol FilterChain path the inherited
+// parent exclude must be gone so the file transfers - matching the engine
+// local-copy path (context_impl/transfer.rs, which clears `layers[index]` on a
+// `clear_inherited` directive). The two oc paths must agree on this outcome.
+#[test]
+fn dir_merge_bang_clears_inherited_ancestor_rules() {
+    let root = TempDir::new().unwrap();
+    let parent = root.path().join("parent");
+    fs::create_dir(&parent).unwrap();
+    fs::write(parent.join(".rsync-filter"), "- secret.txt\n").unwrap();
+
+    let child = parent.join("child");
+    fs::create_dir(&child).unwrap();
+    // `!` clears the inherited parent exclude; `+ secret.txt` re-includes it.
+    fs::write(child.join(".rsync-filter"), "!\n+ secret.txt\n").unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".rsync-filter"));
+
+    let parent_guard = chain.enter_directory(&parent).unwrap();
+    // In the parent, the inherited exclude applies.
+    assert!(
+        !chain.allows(Path::new("secret.txt"), false),
+        "parent .rsync-filter must exclude secret.txt",
+    );
+
+    let child_guard = chain.enter_directory(&child).unwrap();
+    // In the child, `!` cleared the inherited parent exclude, so the child's
+    // `+ secret.txt` (and the absence of any surviving exclude) lets it through.
+    assert!(
+        chain.allows(Path::new("secret.txt"), false),
+        "child `!` must clear the inherited parent exclude so secret.txt transfers",
+    );
+
+    chain.leave_directory(child_guard);
+    chain.leave_directory(parent_guard);
+}
+
+// upstream: exclude.c:pop_local_filters() - leaving a directory restores the
+// pre-descent mergelist, so a `!` in one child must NOT permanently destroy the
+// parent's inherited rules for a SIBLING child that has no clear. This guards
+// against over-broadening the clear (it is scoped to the clearing directory and
+// its descendants only).
+#[test]
+fn dir_merge_bang_clear_is_restored_for_sibling() {
+    let root = TempDir::new().unwrap();
+    let parent = root.path().join("parent");
+    fs::create_dir(&parent).unwrap();
+    fs::write(parent.join(".rsync-filter"), "- secret.txt\n").unwrap();
+
+    // clearing_child clears the inherited exclude with a lone `!`.
+    let clearing = parent.join("clearing");
+    fs::create_dir(&clearing).unwrap();
+    fs::write(clearing.join(".rsync-filter"), "!\n").unwrap();
+
+    // plain_child has no .rsync-filter and must still see the parent exclude.
+    let plain = parent.join("plain");
+    fs::create_dir(&plain).unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".rsync-filter"));
+
+    let parent_guard = chain.enter_directory(&parent).unwrap();
+
+    let clearing_guard = chain.enter_directory(&clearing).unwrap();
+    assert!(
+        chain.allows(Path::new("secret.txt"), false),
+        "lone `!` in clearing child must drop the inherited parent exclude",
+    );
+    chain.leave_directory(clearing_guard);
+
+    // Sibling with no clear: the parent exclude must be back in force.
+    let plain_guard = chain.enter_directory(&plain).unwrap();
+    assert!(
+        !chain.allows(Path::new("secret.txt"), false),
+        "sibling child without `!` must still inherit the parent exclude",
+    );
+    chain.leave_directory(plain_guard);
+
+    // Back in the parent proper, the exclude also still applies.
+    assert!(!chain.allows(Path::new("secret.txt"), false));
+    chain.leave_directory(parent_guard);
+}
+
+// A `!` in one per-directory mergelist must NOT clear a DIFFERENT mergelist's
+// inherited rules. upstream: exclude.c:pop_filter_list() operates on a single
+// `listp`, so `!` in `.rsync-filter` leaves a separate `.cvsignore`-style list
+// untouched. Encodes the precise (per-config) scope of the clear.
+#[test]
+fn dir_merge_bang_only_clears_its_own_mergelist() {
+    let root = TempDir::new().unwrap();
+    let parent = root.path().join("parent");
+    fs::create_dir(&parent).unwrap();
+    fs::write(parent.join(".rsync-filter"), "- from_rf.txt\n").unwrap();
+    fs::write(parent.join(".extra-filter"), "- from_extra.txt\n").unwrap();
+
+    let child = parent.join("child");
+    fs::create_dir(&child).unwrap();
+    // `!` in .rsync-filter clears only the .rsync-filter mergelist.
+    fs::write(child.join(".rsync-filter"), "!\n").unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".rsync-filter"));
+    chain.add_merge_config(DirMergeConfig::new(".extra-filter"));
+
+    let parent_guard = chain.enter_directory(&parent).unwrap();
+    let child_guard = chain.enter_directory(&child).unwrap();
+    // The .rsync-filter exclude is cleared...
+    assert!(
+        chain.allows(Path::new("from_rf.txt"), false),
+        "`!` in .rsync-filter must clear its own inherited exclude",
+    );
+    // ...but the separate .extra-filter mergelist is untouched.
+    assert!(
+        !chain.allows(Path::new("from_extra.txt"), false),
+        "`!` in .rsync-filter must NOT clear the separate .extra-filter list",
+    );
+    chain.leave_directory(child_guard);
+    chain.leave_directory(parent_guard);
 }

--- a/crates/filters/tests/mdf_5_2_negation_reset_scope_isolation.rs
+++ b/crates/filters/tests/mdf_5_2_negation_reset_scope_isolation.rs
@@ -1,17 +1,26 @@
 //! MDF-5.2 gap-cell coverage: a `!` (FILTRULE_CLEAR_LIST) inside a
-//! per-directory merge file must clear only that scope's rules, not rules
-//! inherited from outer merge files. Closes the row .2 x MDF-5 cell from
-//! FIL-AUD-2 (`docs/design/fil-aud-exclude-vs-mdf-matrix.md`).
+//! per-directory merge file clears the WHOLE mergelist, including the rules
+//! inherited from outer directories' merge files. Closes the row .2 x MDF-5
+//! cell from FIL-AUD-2 (`docs/design/fil-aud-exclude-vs-mdf-matrix.md`).
 //!
-//! UTS-DD-exclude.2 root cause: the receiver previously allowed a `!` line
-//! in a nested `.rsync-filter` to wipe rules from the outer scope's list,
-//! diverging from upstream `exclude.c::parse_rule_tok` around the
-//! `FILTRULE_CLEAR_LIST` handler (upstream 3.4.1: `exclude.c:1393-1402` in
-//! the FIL-AUD-3 spec; see the existing oc-rsync comment at
-//! `crates/filters/src/merge/read.rs:87` and the implementation at
-//! `crates/filters/src/set.rs::apply_clear_rule`). `pop_filter_list(listp)`
-//! only touches the local-scope rules between `head` and `tail` and leaves
-//! the inherited list alone.
+//! Upstream mechanism (rsync 3.4.4 `exclude.c`): `push_local_filters()` at
+//! `exclude.c:801` sets `lp->tail = NULL` when entering a directory, which
+//! reclassifies the parent directory's rules as the INHERITED tail of the
+//! same mergelist `lp`. The `FILTRULE_CLEAR_LIST` handler
+//! (`exclude.c:1399-1400`) then runs `pop_filter_list(listp)` - which
+//! early-returns at `exclude.c:579` when `!` is the file's first line because
+//! `listp->tail` is NULL - and, crucially, ALSO runs `listp->head = NULL`.
+//! That final `head = NULL` drops the inherited parent rules, so a nested `!`
+//! resets the entire list, not just the current file's own section. Verified
+//! against the real rsync 3.4.4 binary: with `src/.rsync-filter` = `- *.outer`
+//! and `src/inner/.rsync-filter` = `!` + `- *.inner`, `rsync -n -r -i -F`
+//! transfers `inner/f.outer` (the inherited exclude was cleared) while still
+//! excluding `src/top.outer`.
+//!
+//! (The `.`-style single-shot `merge` path is a distinct mechanism whose `!`
+//! is scope-local - see `crates/filters/src/set.rs::apply_clear_rule`; this
+//! test covers the per-directory `dir-merge` traversal path in
+//! `crates/filters/src/chain/mod.rs`.)
 //!
 //! FIL-AUD-3 spec section 2.2.
 
@@ -21,15 +30,16 @@ use std::path::Path;
 use filters::{DirMergeConfig, FilterChain, FilterRule, FilterSet};
 use tempfile::TempDir;
 
-/// `!` inside `inner/.rsync-filter` must only clear rules accumulated within
-/// that file's scope. The outer `.rsync-filter` exclude of `*.outer` survives
-/// while the new exclude `- *.inner` (parsed after the clear) takes effect
-/// alongside the still-active outer rule.
+/// `!` inside `inner/.rsync-filter` clears the whole mergelist for that
+/// directory and its descendants, so the inherited outer exclude of `*.outer`
+/// no longer fires. The new exclude `- *.inner` (parsed after the clear) still
+/// takes effect. When `inner` is left, the outer rule is restored for the rest
+/// of `src` (and its siblings), mirroring `exclude.c:pop_local_filters()`.
 ///
-/// upstream: exclude.c:1393-1402 - FILTRULE_CLEAR_LIST in parse_rule_tok
-/// runs pop_filter_list on the local list only.
+/// upstream: exclude.c:801 push_local_filters (parent rules become inherited)
+/// + exclude.c:1399-1400 FILTRULE_CLEAR_LIST (pop_filter_list then head=NULL).
 #[test]
-fn inner_bang_clear_does_not_wipe_outer_scope() {
+fn inner_bang_clear_wipes_inherited_outer_scope() {
     let root = TempDir::new().unwrap();
     let src = root.path().join("src");
     let inner = src.join("inner");
@@ -49,14 +59,15 @@ fn inner_bang_clear_does_not_wipe_outer_scope() {
         "inner's `- *.inner` (parsed after the clear) must fire",
     );
     assert!(
-        !chain.allows(Path::new("f.outer"), false),
-        "outer scope's `- *.outer` must survive inner's local `!`",
+        chain.allows(Path::new("f.outer"), false),
+        "inner's `!` clears the inherited `- *.outer`, so f.outer transfers \
+         (real rsync 3.4.4 emits `>f+++++++++ inner/f.outer`)",
     );
 
     chain.leave_directory(inner_guard);
     assert!(
         !chain.allows(Path::new("f.outer"), false),
-        "after popping inner, outer scope's rule still applies in src",
+        "after popping inner, the outer scope's rule is restored in src",
     );
 
     chain.leave_directory(src_guard);

--- a/docs/design/fil-aud-exclude-vs-mdf-matrix.md
+++ b/docs/design/fil-aud-exclude-vs-mdf-matrix.md
@@ -71,9 +71,15 @@ on `chain.allows(...)` rather than on the deletion-pass walker.
 
 MDF-1 enumerates the `!` modifier in the upstream `add_rule()` audit
 and MDF-5 exercises per-directory rule scoping, but no MDF test
-asserts that a `!` inside an inner merge file does NOT clear rules
-parsed by an outer merge file. The cross-scope leak that PR #5898
-closed was untested.
+asserts how a `!` inside an inner per-directory merge file interacts
+with rules inherited from an outer directory's merge file. Per upstream
+`exclude.c` (3.4.4), a per-directory `!` clears the WHOLE mergelist,
+inherited outer rules included: `push_local_filters()` (`exclude.c:801`)
+reclassifies the parent's rules as the inherited tail of the same list,
+and the `FILTRULE_CLEAR_LIST` handler (`exclude.c:1399-1400`) runs
+`pop_filter_list()` then `listp->head = NULL`, dropping that inherited
+tail. Verified against the real rsync 3.4.4 binary (`rsync -n -r -i -F`
+transfers `inner/f.outer` after `inner/.rsync-filter` = `!`).
 
 ### Row .3 - directory-only unanchored `/**` synthesis
 
@@ -106,8 +112,9 @@ file (`uts_dd_exclude_5_no_double_recursive_wildcard.rs`).
   `DecisionContext::Deletion` does not see synthetic descendants from
   a sibling per-directory merge file (closes .1).
 - `MDF-5.2 negation_reset_scope_isolation`: assert `!` inside an inner
-  merge file does NOT clear an exclude introduced by the outer merge
-  file (closes .2).
+  per-directory merge file DOES clear the inherited exclude introduced
+  by the outer merge file (whole-mergelist reset), matching upstream
+  `exclude.c:1399-1400` and the real 3.4.4 binary (closes .2).
 - `MDF-2.1 dir_only_unanchored_no_descendants`: assert wire-byte
   parity for `- foo/*/` against upstream `--debug=FILTER` output,
   including the absence of a synthesised descendant rule (closes .3).


### PR DESCRIPTION
## Problem

A per-directory merge-file `!` (clear-list) rule must reset the whole mergelist, including the rules **inherited** from outer directories' merge files. The protocol `FilterChain` path only cleared the current directory's own `DirScope` rule set, so an inherited ancestor exclude survived and silently overrode a child merge file's intent on pull/daemon transfers. With `--delete` this could also cause wrong deletions.

The engine local-copy path already handled this correctly (via its `clear_inherited` flag in `context_impl/transfer.rs`); the two paths now agree.

## Upstream source of truth (rsync 3.4.4 `exclude.c`)

- `push_local_filters()` (`exclude.c:801`) sets `lp->tail = NULL` when entering a directory, reclassifying the parent's rules as the **inherited tail** of the same mergelist `lp`.
- The `FILTRULE_CLEAR_LIST` handler (`exclude.c:1399-1400`) runs `pop_filter_list(listp)` then `listp->head = NULL`:
  - `pop_filter_list()` (`exclude.c:574-590`) early-returns at line 579 when `!` is the file's first line (`listp->tail` is `NULL`), otherwise frees the local head..tail section.
  - the subsequent `listp->head = NULL` drops the **inherited** tail too.
- Net effect: a nested `!` resets the entire list, inherited ancestor rules included. The clear targets a single `listp`, so a `!` in one per-dir mergelist leaves a different per-dir mergelist untouched.

## Real-binary verification

With `src/.rsync-filter` = `- *.outer` and `src/inner/.rsync-filter` = `!` + `- *.inner`:

```
$ rsync -n -r -i -F src/ dst/
>f+++++++++ inner/f.outer      # inherited `- *.outer` cleared by inner's `!`
# inner/f.inner                # excluded by inner's `- *.inner`
# src/top.outer                # still excluded in src (no clear there)
```

A sibling directory without a `!` still inherits the parent exclude (`plain/b.outer` is excluded), confirming the clear is scoped to the clearing directory and its descendants.

## Change

`FilterChain` now tags each per-directory scope with its merge-config identity (`config_index`). On a `!` in an inheriting config it removes the ancestor scopes of that same mergelist before pushing the current directory's scope. The removed scopes are stashed and restored when the clearing directory is left, so sibling directories still see the parent rules (mirrors `exclude.c:pop_local_filters()` rebuilding the pre-descent list). Runs even when the resulting scope is empty (a lone `!`), so the clear is never a no-op.

## Tests

- `dir_merge_bang_clears_inherited_ancestor_rules` - parent excludes `secret.txt`; child `!` + re-include -> transfers on the protocol path.
- `dir_merge_bang_clear_is_restored_for_sibling` - lone `!` in one child clears inherited; a sibling without `!` still inherits the exclude.
- `dir_merge_bang_only_clears_its_own_mergelist` - `!` in `.rsync-filter` does not clear a separate `.extra-filter` list (precise per-config scope).
- `mdf_5_2` `inner_bang_clear_*` corrected from the prior (upstream-contradicting) premise to the real 3.4.4 behavior; its module doc and the `fil-aud` design-matrix rows updated to match.

Full `filters` crate suite: 1420 passed. `cargo fmt --all -- --check` clean; `cargo clippy -p filters --all-features --all-targets --no-deps -- -D warnings` clean.

Note: the single-shot `.`/`merge` path (`scope_local_clear` in `merge/read.rs`) is a separate mechanism and is intentionally left untouched by this scoped fix.
