### PR TITLE
fix(engine): defer local-copy restricted dir perms to touch_up_dirs

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -412,15 +412,36 @@ pub(crate) struct DeferredOperationQueue {
     pub(crate) delay_staging_dirs: HashSet<PathBuf>,
     /// Newly created paths tracked for rollback on timeout errors.
     pub(crate) created_entries: Vec<CreatedEntry>,
-    /// Transferred directories and their source mtimes, recorded when
-    /// `apply_final_directory_metadata` runs. A single final pass
-    /// (`touch_up_dirs`) re-applies these after all late in-directory mutations
-    /// (delayed-update renames, deletions, backups) so directory timestamps
-    /// survive the wall-clock bump those operations cause.
+    /// Transferred directories with the metadata a single final pass
+    /// (`touch_up_dirs`) re-applies after every late in-directory mutation
+    /// (delayed-update renames, deletions, backups) has run.
     ///
-    /// upstream: generator.c:2093 `touch_up_dirs()` / generator.c:2271
-    /// `need_retouch_dir_times`.
-    pub(crate) finalized_dirs: Vec<(PathBuf, filetime::FileTime)>,
+    /// Each entry carries the source mtime (so directory timestamps survive the
+    /// wall-clock bump those mutations cause) and, for directories whose real
+    /// mode lacks owner write, the restricted mode to reinstate last. The
+    /// directory is kept temporarily writable during the transfer so the
+    /// deferred deletions/updates can still write into it.
+    ///
+    /// upstream: generator.c:2093 `touch_up_dirs()`; generator.c:2271
+    /// `need_retouch_dir_times`; generator.c:2122-2127 `fix_dir_perms`.
+    pub(crate) finalized_dirs: Vec<FinalizedDir>,
+}
+
+/// A directory recorded during traversal for the final `touch_up_dirs` pass.
+///
+/// upstream: generator.c:2089-2136 `touch_up_dirs()` restores the real mode
+/// (`fix_dir_perms`) and re-sets tweaked mtimes after the delayed-update and
+/// deletion phases complete.
+pub(crate) struct FinalizedDir {
+    /// Destination directory path.
+    pub(crate) path: PathBuf,
+    /// Source mtime to re-apply when times are preserved; `None` otherwise.
+    pub(crate) mtime: Option<filetime::FileTime>,
+    /// Real (restricted) mode to reinstate last for a directory that was kept
+    /// writable during the transfer; `None` when no restore is needed. Only
+    /// populated on Unix, where directory-execute traversal semantics apply.
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub(crate) restore_mode: Option<u32>,
 }
 
 /// A directory deletion deferred until after the transfer phase completes.

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -205,55 +205,81 @@ impl<'a> CopyContext<'a> {
         }
     }
 
-    /// Re-applies each transferred directory's source mtime after all late
-    /// in-directory mutations complete - the single final directory touch-up
-    /// pass, run once from the executor finalize after the delayed-update,
-    /// deletion, and sync flushes.
+    /// Restores each transferred directory's real mode and source mtime after
+    /// all late in-directory mutations complete - the single final directory
+    /// touch-up pass, run once from the executor finalize after the
+    /// delayed-update, deletion, and sync flushes.
     ///
-    /// The delayed-update rename sweep, deferred deletions, and backup file
-    /// creation each bump the mtime of the directory they act in, clobbering
-    /// the value `apply_final_directory_metadata` set during the traversal.
-    /// Rather than have every late operation carry its own capture/restore
-    /// guard, this consolidates the "directory mtime survives late in-dir
-    /// mutations" invariant into one pass, mirroring both upstream and the
-    /// receiver driver's `touch_up_dirs`.
+    /// Two repairs happen here, both undoing side effects of keeping the
+    /// directory usable during the transfer:
     ///
-    /// Directories are re-touched deepest-first so setting a child's mtime
-    /// cannot re-clobber a parent processed earlier (utimensat on a directory
-    /// does not disturb its own parent, but the ordering keeps the pass robust
-    /// and matches the receiver's reverse iteration).
+    /// - **Permissions.** A directory whose real mode lacks owner write was
+    ///   kept temporarily writable during the traversal (see
+    ///   `apply_final_directory_metadata`) so the deferred deletions/updates
+    ///   could still write into it. The real, restricted mode is reinstated
+    ///   here - LAST, after those mutations ran - matching upstream, where a
+    ///   `--delete-after` / `--delay-updates` copy into a `0555` directory that
+    ///   needs a child deletion/update would otherwise fail `EACCES`.
+    /// - **Mtimes.** The delayed-update rename sweep, deferred deletions, and
+    ///   backup file creation each bump the mtime of the directory they act in,
+    ///   clobbering the value `apply_final_directory_metadata` set during the
+    ///   traversal. Each directory's mtime is re-set from the source here.
     ///
-    /// Gated identically to `apply_final_directory_metadata` and upstream's
-    /// `need_retouch_dir_times`: only when times are preserved and
-    /// `--omit-dir-times` is off. Skipped when `--backup` is active without a
+    /// Directories are re-touched deepest-first so a child's perm/mtime change
+    /// cannot re-clobber a parent processed earlier, matching the receiver's
+    /// reverse iteration.
+    ///
+    /// The mtime repair is gated on `need_retouch_dir_times` (times preserved,
+    /// `--omit-dir-times` off) and skipped when `--backup` is active without a
     /// backup directory, because backup file creation legitimately changes the
-    /// destination directory mtimes.
+    /// destination directory mtimes. The perm repair is independent of that
+    /// gating and always runs for the directories that were kept writable.
     ///
     /// upstream: generator.c:2449-2451 - touch_up_dirs(dir_flist, -1) runs
-    /// after the receiver's handle_delayed_updates(); generator.c:2093
-    /// touch_up_dirs(); generator.c:2271 need_retouch_dir_times =
-    /// preserve_mtimes && !omit_dir_times.
+    /// after handle_delayed_updates() and the delete phase; generator.c:2089
+    /// touch_up_dirs(); generator.c:2122-2127 fix_dir_perms restores the real
+    /// mode; generator.c:2271 need_retouch_dir_times = preserve_mtimes &&
+    /// !omit_dir_times.
     pub(super) fn touch_up_dirs(&mut self) {
-        let dirs = std::mem::take(&mut self.deferred_ops.finalized_dirs);
+        let mut dirs = std::mem::take(&mut self.deferred_ops.finalized_dirs);
         let preserve_times = self.metadata_options().times() && !self.omit_dir_times_enabled();
-        // upstream: generator.c - skip retouching when make_backups && !backup_dir,
-        // since in-place backup file creation changes directory mtimes on purpose.
+        // upstream: generator.c - skip retouching mtimes when make_backups &&
+        // !backup_dir, since in-place backup file creation changes directory
+        // mtimes on purpose. The perm restore is unaffected by backups.
         let backup_without_dir =
             self.options.backup_enabled() && self.options.backup_directory().is_none();
-        if !preserve_times || backup_without_dir {
-            return;
-        }
-        let mut dirs = dirs;
-        dirs.sort_by(|a, b| b.0.components().count().cmp(&a.0.components().count()));
-        for (dir, mtime) in dirs {
+        let do_times = preserve_times && !backup_without_dir;
+
+        // Deepest-first, mirroring upstream's reverse flist walk, so a child's
+        // perm/mtime change cannot re-clobber a parent handled earlier.
+        // upstream: generator.c:2083 for (i = dir_flist->used - 1; i >= 0; i--).
+        dirs.sort_by(|a, b| b.path.components().count().cmp(&a.path.components().count()));
+        for dir in dirs {
+            // Reinstate the real (restricted) directory mode last, after every
+            // deferred deletion/update ran while the directory was kept
+            // writable. This runs regardless of the mtime gating above.
+            // upstream: generator.c:2124-2126 - fix_dir_perms does
+            // do_chmod_at(fname, file->mode) before the mtime repair.
+            #[cfg(unix)]
+            if let Some(mode) = dir.restore_mode {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = fs::set_permissions(&dir.path, fs::Permissions::from_mode(mode));
+            }
+
+            if !do_times {
+                continue;
+            }
+            let Some(mtime) = dir.mtime else {
+                continue;
+            };
             // upstream: generator.c:2130 - only re-set when mtime_differs(), so
             // directories untouched by a late mutation are left alone.
-            let needs_update = match fs::metadata(&dir) {
+            let needs_update = match fs::metadata(&dir.path) {
                 Ok(meta) => filetime::FileTime::from_last_modification_time(&meta) != mtime,
                 Err(_) => false,
             };
             if needs_update {
-                let _ = filetime::set_file_mtime(&dir, mtime);
+                let _ = filetime::set_file_mtime(&dir.path, mtime);
             }
         }
     }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -719,22 +719,29 @@ impl<'a> CopyContext<'a> {
         self.destination_metadata_cache.clear();
     }
 
-    /// Records a finalized directory and its source mtime for the final
+    /// Records a finalized directory for the final
     /// [`touch_up_dirs`](Self::touch_up_dirs) pass.
     ///
-    /// Called by `apply_final_directory_metadata` right after it applies the
-    /// source mtime during the traversal. Late in-directory mutations (the
-    /// delayed-update rename sweep, deferred deletions, backup file creation)
-    /// bump this mtime again, so the final pass re-applies the recorded value.
+    /// Called by `apply_final_directory_metadata` during the traversal. Late
+    /// in-directory mutations (the delayed-update rename sweep, deferred
+    /// deletions, backup file creation) bump the directory mtime and require the
+    /// directory to stay writable, so the final pass re-applies the recorded
+    /// source mtime and reinstates the restricted mode last.
+    ///
+    /// `mtime` is the source mtime to re-apply (when times are preserved) and
+    /// `restore_mode` is the restricted mode to reinstate for a directory that
+    /// was kept writable during the transfer.
     pub(super) fn record_finalized_directory(
         &mut self,
         destination: &Path,
-        metadata: &fs::Metadata,
+        mtime: Option<filetime::FileTime>,
+        restore_mode: Option<u32>,
     ) {
-        let mtime = filetime::FileTime::from_last_modification_time(metadata);
-        self.deferred_ops
-            .finalized_dirs
-            .push((destination.to_path_buf(), mtime));
+        self.deferred_ops.finalized_dirs.push(FinalizedDir {
+            path: destination.to_path_buf(),
+            mtime,
+            restore_mode,
+        });
     }
 
     /// Queues a deferred update for `--delay-updates` and records the hard-link

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -51,14 +51,31 @@ pub(super) fn apply_final_directory_metadata(
     apply_directory_metadata_with_options(destination, metadata, metadata_options.clone())
         .map_err(map_metadata_error)?;
 
-    // Record the directory and its source mtime for the final touch-up pass.
-    // Late in-directory mutations (delayed-update renames, deletions, backups)
-    // bump this directory's mtime after we set it here, so a single final pass
-    // re-applies the recorded source mtime once everything else is done.
-    // upstream: generator.c:2093 touch_up_dirs() re-touches directory mtimes
-    // after the delayed-update phase completes.
-    if metadata_options.times() {
-        context.record_finalized_directory(destination, metadata);
+    // upstream: generator.c:1508-1521 - a directory whose real mode lacks owner
+    // rwx is kept writable during the transfer so its contents, and the deferred
+    // deletions/updates that run in the final flush, can still write into it;
+    // the real (restricted) mode is reinstated LAST in touch_up_dirs
+    // (generator.c:2122-2127 fix_dir_perms). Applying the restricted mode (e.g.
+    // 0555) now, before the deferred flush, makes a local --delete-after /
+    // --delay-updates / in-place --backup copy fail EACCES when the deferred
+    // rename/unlink tries to write into the now read-only directory.
+    #[cfg(unix)]
+    let restore_mode = keep_directory_writable(destination, &metadata_options)?;
+    #[cfg(not(unix))]
+    let restore_mode: Option<u32> = None;
+
+    // Record the directory for the final touch-up pass. Late in-directory
+    // mutations (delayed-update renames, deletions, backups) bump this
+    // directory's mtime after we set it here, so a single final pass re-applies
+    // the recorded source mtime and reinstates the restricted mode once
+    // everything else is done.
+    // upstream: generator.c:2089 touch_up_dirs() re-touches directory perms and
+    // mtimes after the delayed-update and deletion phases complete.
+    let mtime = metadata_options
+        .times()
+        .then(|| filetime::FileTime::from_last_modification_time(metadata));
+    if mtime.is_some() || restore_mode.is_some() {
+        context.record_finalized_directory(destination, mtime, restore_mode);
     }
 
     // upstream: generator.c:1410 - implied parent dirs are finalized via
@@ -87,6 +104,49 @@ pub(super) fn apply_final_directory_metadata(
     let _ = source;
 
     Ok(())
+}
+
+/// Keeps a directory whose applied mode lacks full owner `rwx` temporarily
+/// writable so the deferred deletions/updates in the final flush can still
+/// write into it, returning the restricted mode for `touch_up_dirs` to
+/// reinstate last (or `None` when no tweak is needed).
+///
+/// Mirrors upstream `generator.c:1508-1521`: when not root, not `--fake-super`,
+/// preserving perms, and the applied mode lacks full owner `rwx`
+/// (`(file->mode & S_IRWXU) != S_IRWXU`), the generator chmods the directory to
+/// `mode | S_IRWXU` and sets `need_retouch_dir_perms` so the real mode is
+/// restored (`generator.c:2122-2127` `fix_dir_perms`) after the delayed-update
+/// and deletion phases. The applied mode is read back from the destination so a
+/// `--chmod` tweak is reflected exactly.
+#[cfg(unix)]
+fn keep_directory_writable(
+    destination: &Path,
+    metadata_options: &::metadata::MetadataOptions,
+) -> Result<Option<u32>, LocalCopyError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    // upstream: generator.c:1512 gate - !am_root && ... && dir_tweaking, plus we
+    // only manage the mode when preserving perms and not under --fake-super
+    // (which stashes the intended mode in an xattr instead of the inode).
+    if !metadata_options.permissions()
+        || metadata_options.fake_super_enabled()
+        || ::metadata::am_root()
+    {
+        return Ok(None);
+    }
+
+    let applied = fs::symlink_metadata(destination)
+        .map_err(|error| LocalCopyError::io("stat", destination, error))?;
+    let mode = applied.permissions().mode() & 0o7777;
+    // upstream: generator.c:1512 - (file->mode & S_IRWXU) != S_IRWXU.
+    if mode & 0o700 == 0o700 {
+        return Ok(None);
+    }
+
+    // upstream: generator.c:1513-1514 - do_chmod_at(fname, mode | S_IRWXU).
+    fs::set_permissions(destination, fs::Permissions::from_mode(mode | 0o700))
+        .map_err(|error| LocalCopyError::io("modify permissions on", destination, error))?;
+    Ok(Some(mode))
 }
 
 /// Reproduces upstream's transfer-root self-lock when a `--chmod` strips the

--- a/crates/engine/src/local_copy/tests/execute_delay_updates_delete.rs
+++ b/crates/engine/src/local_copy/tests/execute_delay_updates_delete.rs
@@ -159,3 +159,150 @@ fn delay_updates_delete_during_removes_extraneous_in_subdirs() {
     }
     assert_no_staging(&dest);
 }
+
+/// A local `-a --delete-after` copy into a destination directory whose real
+/// mode is read-only (0555) must still delete an extraneous child inside it and
+/// then leave the directory at 0555.
+///
+/// This encodes WHY the restricted directory mode must be deferred: upstream
+/// keeps such a directory writable throughout the transfer and restores the
+/// restricted mode LAST, in touch_up_dirs, only after the deletion phase runs
+/// (generator.c:1508-1521 grants `mode | S_IRWXU` during the transfer;
+/// generator.c:2122-2127 `fix_dir_perms` reinstates the real mode;
+/// generator.c:2449-2451 runs touch_up_dirs after the delete phase). Applying
+/// 0555 during traversal - before the deferred unlink - makes the unlink fail
+/// EACCES, so this test fails on that ordering and passes once the mode is
+/// deferred.
+///
+/// Runs as non-root only: root bypasses directory write permission and would
+/// mask the bug.
+#[cfg(unix)]
+#[test]
+fn delete_after_into_readonly_dir_deletes_child_and_restores_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if rustix::process::geteuid().as_raw() == 0 {
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(source.join("ro")).expect("create source/ro");
+    fs::create_dir_all(dest.join("ro")).expect("create dest/ro");
+
+    // Source ro/ keeps one file; make the directory read-only afterward.
+    fs::write(source.join("ro").join("keep.txt"), b"keep").expect("write keep");
+    // Dest ro/ mirrors the kept file and adds an extraneous file to delete.
+    fs::write(dest.join("ro").join("keep.txt"), b"keep").expect("write dest keep");
+    fs::write(dest.join("ro").join("stale.txt"), b"stale").expect("write stale");
+
+    fs::set_permissions(source.join("ro"), PermissionsExt::from_mode(0o555))
+        .expect("chmod source/ro to 0555");
+
+    let mut source_operand = source.clone().into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default()
+                .recursive(true)
+                .permissions(true)
+                .times(true)
+                .delete_after(true),
+        )
+        .expect("--delete-after into a read-only dir must succeed, not fail EACCES");
+
+    assert!(
+        !dest.join("ro").join("stale.txt").exists(),
+        "stale.txt must be deleted from the read-only directory"
+    );
+    assert!(
+        dest.join("ro").join("keep.txt").exists(),
+        "keep.txt must remain"
+    );
+    assert_eq!(summary.items_deleted(), 1, "expected exactly one deletion");
+
+    let mode = fs::symlink_metadata(dest.join("ro"))
+        .expect("stat dest/ro")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o555, "read-only dir mode must be restored to 0555");
+
+    // Restore write so the tempdir can be cleaned up.
+    let _ = fs::set_permissions(dest.join("ro"), PermissionsExt::from_mode(0o755));
+    let _ = fs::set_permissions(source.join("ro"), PermissionsExt::from_mode(0o755));
+}
+
+/// A local `-a --delay-updates` copy into a destination directory whose real
+/// mode is read-only (0555) must still rename the staged child update into it
+/// and then leave the directory at 0555.
+///
+/// Same upstream ordering as the delete-after case: the directory is kept
+/// writable until touch_up_dirs restores 0555 after the delayed-update rename
+/// sweep (generator.c:1508-1521, 2122-2127, 2449-2451). Applying 0555 during
+/// traversal makes the staged rename into the directory fail EACCES.
+///
+/// Runs as non-root only.
+#[cfg(unix)]
+#[test]
+fn delay_updates_into_readonly_dir_renames_child_and_restores_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if rustix::process::geteuid().as_raw() == 0 {
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(source.join("ro")).expect("create source/ro");
+    fs::create_dir_all(dest.join("ro")).expect("create dest/ro");
+
+    // The child differs so a real update (staged rename) is required.
+    fs::write(source.join("ro").join("data.txt"), b"new content").expect("write src data");
+    fs::write(dest.join("ro").join("data.txt"), b"old").expect("write dst data");
+
+    fs::set_permissions(source.join("ro"), PermissionsExt::from_mode(0o555))
+        .expect("chmod source/ro to 0555");
+
+    let mut source_operand = source.clone().into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .permissions(true)
+            .times(true)
+            .delay_updates(true),
+    )
+    .expect("--delay-updates rename into a read-only dir must succeed, not fail EACCES");
+
+    assert_eq!(
+        fs::read(dest.join("ro").join("data.txt")).expect("read data"),
+        b"new content",
+        "the delayed update must be renamed into the read-only directory"
+    );
+    assert!(
+        !dest.join("ro").join(".~tmp~").exists(),
+        ".~tmp~ staging directory must not remain in the read-only directory"
+    );
+
+    let mode = fs::symlink_metadata(dest.join("ro"))
+        .expect("stat dest/ro")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o555, "read-only dir mode must be restored to 0555");
+
+    // Restore write so the tempdir can be cleaned up.
+    let _ = fs::set_permissions(dest.join("ro"), PermissionsExt::from_mode(0o755));
+    let _ = fs::set_permissions(source.join("ro"), PermissionsExt::from_mode(0o755));
+}


### PR DESCRIPTION
## Problem

A local `-a` copy into a destination directory whose real mode lacks owner
write (for example `0555`) failed with `EACCES` when combined with
`--delete-after`, `--delay-updates`, or an in-place `--backup`. The engine
applied the restricted directory mode during traversal, before the deferred
deletion/update flush, so the deferred rename/unlink could no longer write
into the now read-only directory.

Upstream rsync keeps such a directory writable throughout the transfer and
restores the restricted mode last, only after the delayed-update and delete
phases run.

## Fix

Mirror upstream (and the already-correct network-receiver path):

- Keep a directory whose applied mode lacks full owner `rwx` temporarily
  writable during traversal (`mode | S_IRWXU`), reading the applied mode back
  so a `--chmod` tweak is reflected exactly.
- Reinstate the real restricted mode last, in the final `touch_up_dirs` pass,
  after the deferred deletions/updates flush. Directory mtimes are still
  re-applied in that same pass, as before.

The perm restore runs deepest-first and is independent of the mtime gating, so
it also happens under `--backup` without a backup directory. Gated to non-root,
non-`--fake-super`, perms-preserving transfers, matching upstream's
`dir_tweaking` / `fix_dir_perms` conditions. The network path is unchanged.

## Upstream references (rsync 3.4.4, generator.c)

- `generator.c:1508-1521` - keep dir writable during transfer
  (`mode | S_IRWXU`), set `need_retouch_dir_perms`.
- `generator.c:2089-2136` `touch_up_dirs()` / `2122-2127` `fix_dir_perms` -
  restore the real restricted mode last.
- `generator.c:2449-2451` - `touch_up_dirs(dir_flist, -1)` runs after the
  delayed-update and delete phases.

## Tests

Two non-root Unix tests in `execute_delay_updates_delete.rs`:

- `delete_after_into_readonly_dir_deletes_child_and_restores_mode`
- `delay_updates_into_readonly_dir_renames_child_and_restores_mode`

Both fail with `EACCES` on the pre-fix ordering and pass after. Verified that
real rsync 3.4.4 produces the identical result for the same scenario (exit 0,
extraneous child deleted, directory left at `0555`).

`cargo fmt --all -- --check` and `cargo clippy -p engine --all-features
--all-targets --no-deps -- -D warnings` are clean.
