### PR TITLE
fix(cli): case-sensitive filter modifiers + side-keyword guard

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
@@ -42,7 +42,11 @@ pub(super) fn split_short_rule_modifiers(text: &str) -> (&str, &str) {
         }
     }
 
-    ("", text)
+    // upstream: exclude.c:1214-1287 - after a `+`/`-` prefix, every byte up to the
+    // first ` `/`_` separator is a modifier. With no separator at all the whole
+    // remainder is modifiers (and the pattern is empty), so `+foo`/`+S` are
+    // rejected as invalid modifiers rather than silently treated as a pattern.
+    (text, "")
 }
 
 pub(super) fn split_short_merge_modifiers(text: &str, allow_extended: bool) -> (&str, &str) {
@@ -134,8 +138,11 @@ mod tests {
     }
 
     #[test]
-    fn split_short_rule_modifiers_no_modifiers() {
-        assert_eq!(split_short_rule_modifiers("pattern"), ("", "pattern"));
+    fn split_short_rule_modifiers_no_separator_is_all_modifiers() {
+        // upstream: exclude.c:1214-1287 - with no ` `/`_` separator after the
+        // prefix, every byte is a modifier and the pattern is empty. The caller
+        // then rejects the unknown modifier bytes (e.g. `+foo` -> invalid 'f').
+        assert_eq!(split_short_rule_modifiers("pattern"), ("pattern", ""));
     }
 
     #[test]

--- a/crates/cli/src/frontend/filter_rules/parsing/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/merge.rs
@@ -22,9 +22,13 @@ pub(crate) fn parse_merge_modifiers(
     let mut saw_exclude = false;
     let mut assume_cvsignore = false;
 
+    // upstream: exclude.c:1214-1287 parse_rule_tok - merge-file modifiers switch
+    // on the literal byte, so they are strictly case-sensitive. The cvs-ignore
+    // modifier is the uppercase `C`; a lowercase `c` (and any uppercased form of
+    // the other modifiers) reaches the `default:` arm and is rejected as an
+    // invalid modifier (RERR_SYNTAX). Match each byte verbatim.
     for modifier in modifiers.chars() {
-        let lower = modifier.to_ascii_lowercase();
-        match lower {
+        match modifier {
             '-' => {
                 if saw_include {
                     let message = rsync_error!(
@@ -49,7 +53,7 @@ pub(crate) fn parse_merge_modifiers(
                 saw_include = true;
                 enforced = Some(DirMergeEnforcedKind::Include);
             }
-            'c' => {
+            'C' => {
                 if saw_include {
                     let message = rsync_error!(
                         1,

--- a/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
@@ -12,27 +12,58 @@ pub(super) struct RuleModifierState {
     negate: bool,
 }
 
+fn unsupported_modifier(directive: &str, modifier: char) -> Message {
+    rsync_error!(
+        1,
+        format!("filter rule '{directive}' uses unsupported modifier '{modifier}'")
+    )
+    .with_role(Role::Client)
+}
+
+/// Parses the modifier characters that may trail a rule prefix or keyword.
+///
+/// upstream: exclude.c:1214-1287 parse_rule_tok - the modifier loop switches on
+/// the literal byte, so modifiers are strictly case-sensitive. An uppercase or
+/// otherwise unknown character reaches the `default:` arm and raises
+/// "invalid modifier" (RERR_SYNTAX). We mirror that by matching the char
+/// verbatim rather than lower-casing it first.
+///
+/// `prefix_specifies_side` is set for the `H`/`S`/`P`/`R` (hide/show/protect/
+/// risk) rules, whose prefix already binds the rule to a side. Upstream then
+/// rejects the `s`/`r` modifiers as invalid on those rules
+/// (exclude.c:1269-1277); `p` (perishable) carries no such guard and stays
+/// valid everywhere (exclude.c:1265-1267).
 pub(super) fn parse_rule_modifiers(
     modifiers: &str,
     directive: &str,
     allow_perishable: bool,
     allow_xattr: bool,
+    prefix_specifies_side: bool,
 ) -> Result<RuleModifierState, Message> {
     let mut state = RuleModifierState::default();
 
     for modifier in modifiers.chars() {
-        let lower = modifier.to_ascii_lowercase();
-        match lower {
+        match modifier {
             '/' => {
                 state.anchor_root = true;
             }
             's' => {
+                // upstream: exclude.c:1275-1276 - `s` is invalid once the prefix
+                // has already fixed the rule's side.
+                if prefix_specifies_side {
+                    return Err(unsupported_modifier(directive, modifier));
+                }
                 state.sender = Some(true);
                 if state.receiver.is_none() {
                     state.receiver = Some(false);
                 }
             }
             'r' => {
+                // upstream: exclude.c:1270-1271 - `r` is invalid once the prefix
+                // has already fixed the rule's side.
+                if prefix_specifies_side {
+                    return Err(unsupported_modifier(directive, modifier));
+                }
                 state.receiver = Some(true);
                 if state.sender.is_none() {
                     state.sender = Some(false);
@@ -47,42 +78,18 @@ pub(super) fn parse_rule_modifiers(
                 if allow_perishable {
                     state.perishable = true;
                 } else {
-                    let message = rsync_error!(
-                        1,
-                        format!(
-                            "filter rule '{directive}' uses unsupported modifier '{}'",
-                            modifier
-                        )
-                    )
-                    .with_role(Role::Client);
-                    return Err(message);
+                    return Err(unsupported_modifier(directive, modifier));
                 }
             }
             'x' => {
                 if allow_xattr {
                     state.xattr_only = true;
                 } else {
-                    let message = rsync_error!(
-                        1,
-                        format!(
-                            "filter rule '{directive}' uses unsupported modifier '{}'",
-                            modifier
-                        )
-                    )
-                    .with_role(Role::Client);
-                    return Err(message);
+                    return Err(unsupported_modifier(directive, modifier));
                 }
             }
             _ => {
-                let message = rsync_error!(
-                    1,
-                    format!(
-                        "filter rule '{directive}' uses unsupported modifier '{}'",
-                        modifier
-                    )
-                )
-                .with_role(Role::Client);
-                return Err(message);
+                return Err(unsupported_modifier(directive, modifier));
             }
         }
     }
@@ -154,7 +161,7 @@ mod tests {
 
     #[test]
     fn parse_rule_modifiers_empty_string() {
-        let result = parse_rule_modifiers("", "+", true, true).expect("parse");
+        let result = parse_rule_modifiers("", "+", true, true, false).expect("parse");
         assert!(!result.anchor_root);
         assert!(result.sender.is_none());
         assert!(result.receiver.is_none());
@@ -162,64 +169,64 @@ mod tests {
 
     #[test]
     fn parse_rule_modifiers_anchor_root() {
-        let result = parse_rule_modifiers("/", "+", true, true).expect("parse");
+        let result = parse_rule_modifiers("/", "+", true, true, false).expect("parse");
         assert!(result.anchor_root);
     }
 
     #[test]
     fn parse_rule_modifiers_sender_only() {
-        let result = parse_rule_modifiers("s", "+", true, true).expect("parse");
+        let result = parse_rule_modifiers("s", "+", true, true, false).expect("parse");
         assert_eq!(result.sender, Some(true));
         assert_eq!(result.receiver, Some(false));
     }
 
     #[test]
     fn parse_rule_modifiers_receiver_only() {
-        let result = parse_rule_modifiers("r", "+", true, true).expect("parse");
+        let result = parse_rule_modifiers("r", "+", true, true, false).expect("parse");
         assert_eq!(result.receiver, Some(true));
         assert_eq!(result.sender, Some(false));
     }
 
     #[test]
     fn parse_rule_modifiers_sender_and_receiver() {
-        let result = parse_rule_modifiers("sr", "+", true, true).expect("parse");
+        let result = parse_rule_modifiers("sr", "+", true, true, false).expect("parse");
         assert_eq!(result.sender, Some(true));
         assert_eq!(result.receiver, Some(true));
     }
 
     #[test]
     fn parse_rule_modifiers_perishable_when_allowed() {
-        let result = parse_rule_modifiers("p", "+", true, true).expect("parse");
+        let result = parse_rule_modifiers("p", "+", true, true, false).expect("parse");
         assert!(result.perishable);
     }
 
     #[test]
     fn parse_rule_modifiers_perishable_when_disallowed() {
-        let result = parse_rule_modifiers("p", "+", false, true);
+        let result = parse_rule_modifiers("p", "+", false, true, false);
         assert!(result.is_err());
     }
 
     #[test]
     fn parse_rule_modifiers_xattr_when_allowed() {
-        let result = parse_rule_modifiers("x", "+", true, true).expect("parse");
+        let result = parse_rule_modifiers("x", "+", true, true, false).expect("parse");
         assert!(result.xattr_only);
     }
 
     #[test]
     fn parse_rule_modifiers_xattr_when_disallowed() {
-        let result = parse_rule_modifiers("x", "+", true, false);
+        let result = parse_rule_modifiers("x", "+", true, false, false);
         assert!(result.is_err());
     }
 
     #[test]
     fn parse_rule_modifiers_negate() {
-        let result = parse_rule_modifiers("!", "-", true, true).expect("parse");
+        let result = parse_rule_modifiers("!", "-", true, true, false).expect("parse");
         assert!(result.negate);
     }
 
     #[test]
     fn parse_rule_modifiers_negate_with_others() {
-        let result = parse_rule_modifiers("!s", "-", true, true).expect("parse");
+        let result = parse_rule_modifiers("!s", "-", true, true, false).expect("parse");
         assert!(result.negate);
         assert_eq!(result.sender, Some(true));
         assert_eq!(result.receiver, Some(false));
@@ -227,20 +234,39 @@ mod tests {
 
     #[test]
     fn parse_rule_modifiers_unknown_modifier() {
-        let result = parse_rule_modifiers("z", "+", true, true);
+        let result = parse_rule_modifiers("z", "+", true, true, false);
         assert!(result.is_err());
     }
 
     #[test]
-    fn parse_rule_modifiers_case_insensitive() {
-        let result = parse_rule_modifiers("SR", "+", true, true).expect("parse");
-        assert_eq!(result.sender, Some(true));
-        assert_eq!(result.receiver, Some(true));
+    fn parse_rule_modifiers_case_sensitive_rejects_upper() {
+        // upstream: exclude.c:1214-1287 - modifiers are matched by literal byte,
+        // so the uppercase `S`/`R` reach the `default:` arm and are rejected as
+        // invalid modifiers (RERR_SYNTAX). Their lowercase forms remain valid.
+        assert!(parse_rule_modifiers("S", "+", true, true, false).is_err());
+        assert!(parse_rule_modifiers("R", "+", true, true, false).is_err());
+        assert!(parse_rule_modifiers("X", "+", true, true, false).is_err());
+    }
+
+    #[test]
+    fn parse_rule_modifiers_side_prefix_rejects_s_and_r() {
+        // upstream: exclude.c:1269-1277 - when the prefix already fixes the side
+        // (hide/show/protect/risk), the `s`/`r` modifiers are invalid.
+        assert!(parse_rule_modifiers("s", "protect", false, false, true).is_err());
+        assert!(parse_rule_modifiers("r", "show", false, false, true).is_err());
+    }
+
+    #[test]
+    fn parse_rule_modifiers_side_prefix_allows_perishable() {
+        // upstream: exclude.c:1265-1267 - `p` (perishable) is valid on every
+        // rule kind, including the side-bound hide/show/protect/risk rules.
+        let result = parse_rule_modifiers("p", "protect", true, false, true).expect("parse");
+        assert!(result.perishable);
     }
 
     #[test]
     fn parse_rule_modifiers_complex_combination() {
-        let result = parse_rule_modifiers("/srp", "+", true, true).expect("parse");
+        let result = parse_rule_modifiers("/srp", "+", true, true, false).expect("parse");
         assert!(result.anchor_root);
         assert_eq!(result.sender, Some(true));
         assert_eq!(result.receiver, Some(true));

--- a/crates/cli/src/frontend/filter_rules/parsing/rules.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/rules.rs
@@ -73,7 +73,9 @@ pub(super) fn parse_short_include_rule(
 ) -> Option<Result<FilterDirective, Message>> {
     let remainder = trimmed.strip_prefix(prefix)?;
     let (modifier_text, remainder) = split_short_rule_modifiers(remainder);
-    let modifiers = match parse_rule_modifiers(modifier_text, trimmed, true, true) {
+    // `+`/`-` rules never bind a side via their prefix, so the `s`/`r` modifiers
+    // stay valid (prefix_specifies_side = false). upstream: exclude.c:1186-1190.
+    let modifiers = match parse_rule_modifiers(modifier_text, trimmed, true, true, false) {
         Ok(state) => state,
         Err(error) => return Some(Err(error)),
     };
@@ -107,7 +109,8 @@ pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Messa
 
     let build_rule = |builder: fn(String) -> FilterRuleSpec,
                       allow_perishable: bool,
-                      allow_xattr: bool|
+                      allow_xattr: bool,
+                      prefix_specifies_side: bool|
      -> Result<FilterDirective, Message> {
         if pattern.is_empty() {
             let text = format!("filter rule '{trimmed}' is missing a pattern after '{keyword}'");
@@ -115,8 +118,13 @@ pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Messa
             return Err(message);
         }
 
-        let modifiers =
-            parse_rule_modifiers(keyword_modifiers, trimmed, allow_perishable, allow_xattr)?;
+        let modifiers = parse_rule_modifiers(
+            keyword_modifiers,
+            trimmed,
+            allow_perishable,
+            allow_xattr,
+            prefix_specifies_side,
+        )?;
         let rule = builder(pattern.to_owned());
         let rule = apply_rule_modifiers(rule, modifiers, trimmed)?;
         Ok(FilterDirective::Rule(rule))
@@ -128,28 +136,33 @@ pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Messa
     // `EXCLUDE`/`Include` therefore never matches; it reaches the inner switch
     // default and raises "Unknown filter rule" (RERR_SYNTAX). Compare exactly so
     // this parser mirrors that behaviour rather than silently coercing the case.
+    // upstream: exclude.c:1155-1177 - include/exclude do not bind a side, so
+    // `s`/`r`/`p` modifiers are all valid (prefix_specifies_side = false).
     if keyword == "include" {
-        return build_rule(FilterRuleSpec::include, true, true);
+        return build_rule(FilterRuleSpec::include, true, true, false);
     }
 
     if keyword == "exclude" {
-        return build_rule(FilterRuleSpec::exclude, true, true);
+        return build_rule(FilterRuleSpec::exclude, true, true, false);
     }
 
+    // upstream: exclude.c:1163-1206 - show/hide/protect/risk map to the S/H/R/P
+    // prefixes that set prefix_specifies_side, so `s`/`r` are invalid while `p`
+    // (perishable) stays valid.
     if keyword == "show" {
-        return build_rule(FilterRuleSpec::show, false, false);
+        return build_rule(FilterRuleSpec::show, true, false, true);
     }
 
     if keyword == "hide" {
-        return build_rule(FilterRuleSpec::hide, false, false);
+        return build_rule(FilterRuleSpec::hide, true, false, true);
     }
 
     if keyword == "protect" {
-        return build_rule(FilterRuleSpec::protect, false, false);
+        return build_rule(FilterRuleSpec::protect, true, false, true);
     }
 
     if keyword == "risk" {
-        return build_rule(FilterRuleSpec::risk, false, false);
+        return build_rule(FilterRuleSpec::risk, true, false, true);
     }
 
     let message = rsync_error!(

--- a/crates/cli/src/frontend/filter_rules/parsing/shorthand.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/shorthand.rs
@@ -13,7 +13,12 @@ pub(super) fn parse_filter_shorthand(
 ) -> Option<Result<FilterDirective, Message>> {
     let mut chars = trimmed.chars();
     let first = chars.next()?;
-    if !first.eq_ignore_ascii_case(&short) {
+    // upstream: exclude.c:1137-1178 - the single-char rule prefixes H/S/P/R are
+    // matched case-sensitively (they reach the `switch (*s)` default arm). A
+    // lowercase `h`/`s`/`p`/`r` is instead the first byte of a long keyword and,
+    // when it is not one, raises "Unknown filter rule". Match the prefix exactly
+    // so `s foo`/`h foo` are rejected rather than treated as show/hide.
+    if first != short {
         return None;
     }
 
@@ -91,9 +96,12 @@ mod tests {
     }
 
     #[test]
-    fn case_insensitive_matching() {
+    fn case_sensitive_no_match_on_wrong_case() {
+        // upstream: exclude.c:1137-1178 - single-char rule prefixes are
+        // case-sensitive, so an uppercase char never matches a lowercase prefix
+        // (and vice versa). This parser must return None so the caller can reject
+        // the line as an unknown rule.
         let result = parse_filter_shorthand("E pattern", 'e', "exclude", mock_builder);
-        assert!(result.is_some());
-        assert!(result.unwrap().is_ok());
+        assert!(result.is_none());
     }
 }

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -786,3 +786,87 @@ fn parse_literal_dash_pattern_is_not_cvs() {
         other => panic!("expected exclude Rule, got {other:?}"),
     }
 }
+
+// The following tests pin the single-char prefix / modifier case-sensitivity and
+// the side-bound keyword guard to upstream rsync 3.4.4 (protocol 32). Every
+// expectation was ground-truthed against the `rsync --filter=...` binary; the
+// cited exit codes are RERR_SYNTAX (1). upstream: exclude.c:1137-1287.
+
+#[test]
+fn short_prefix_uppercase_modifier_is_rejected() {
+    // upstream: `+S` / `-R` -> "invalid modifier 'S'/'R'" (exclude.c:1226). The
+    // byte after a `+`/`-` prefix is a modifier, matched case-sensitively, so the
+    // uppercase form is not silently remapped to a sender/receiver rule.
+    let _ = parse_filter_directive(OsStr::new("+S")).expect_err("+S must be rejected");
+    let _ = parse_filter_directive(OsStr::new("-R")).expect_err("-R must be rejected");
+}
+
+#[test]
+fn merge_prefix_lowercase_c_modifier_is_rejected() {
+    // upstream: `:c` -> "invalid modifier 'c'" (exclude.c:1226). The cvs-ignore
+    // merge modifier is the uppercase `C`; the lowercase `c` is invalid.
+    let _ = parse_filter_directive(OsStr::new(":c")).expect_err(":c must be rejected");
+}
+
+#[test]
+fn lowercase_single_char_side_prefix_is_unknown_rule() {
+    // upstream: `s foo` / `h foo` -> "Unknown filter rule" (exclude.c:1213). The
+    // single-char side prefixes are the uppercase S/H/P/R; a lowercase spelling
+    // is only ever the first byte of a long keyword, so a bare `s`/`h` is not a
+    // rule and must be rejected rather than treated as show/hide.
+    let _ = parse_filter_directive(OsStr::new("s foo")).expect_err("s foo must be rejected");
+    let _ = parse_filter_directive(OsStr::new("h foo")).expect_err("h foo must be rejected");
+}
+
+#[test]
+fn keyword_uppercase_modifier_is_rejected() {
+    // upstream: `include,X foo` / `exclude,S foo` -> "invalid modifier 'X'/'S'"
+    // (exclude.c:1226). Keyword modifiers are case-sensitive too.
+    let _ = parse_filter_directive(OsStr::new("include,X foo"))
+        .expect_err("include,X must be rejected");
+    let _ = parse_filter_directive(OsStr::new("exclude,S foo"))
+        .expect_err("exclude,S must be rejected");
+}
+
+#[test]
+fn side_keyword_rejects_s_and_r_modifiers() {
+    // upstream: exclude.c:1269-1277 - show/hide/protect/risk set
+    // prefix_specifies_side, so the `s`/`r` modifiers are invalid there
+    // ("invalid modifier", exclude.c:1226). These were previously accepted as a
+    // silent side-flip.
+    let _ = parse_filter_directive(OsStr::new("show,r foo")).expect_err("show,r must be rejected");
+    let _ = parse_filter_directive(OsStr::new("protect,s foo"))
+        .expect_err("protect,s must be rejected");
+    let _ = parse_filter_directive(OsStr::new("hide,s foo")).expect_err("hide,s must be rejected");
+    let _ = parse_filter_directive(OsStr::new("risk,r foo")).expect_err("risk,r must be rejected");
+}
+
+#[test]
+fn side_keyword_accepts_perishable_modifier() {
+    // upstream: exclude.c:1265-1267 - `p` (perishable) carries no side guard, so
+    // it is valid on protect/show/etc. (upstream `protect,p foo` exits 0). This
+    // was previously rejected as an unsupported modifier.
+    match parse_filter_directive(OsStr::new("protect,p foo")).expect("protect,p foo must parse") {
+        FilterDirective::Rule(spec) => assert_eq!(spec.kind(), FilterRuleKind::Protect),
+        other => panic!("expected protect Rule, got {other:?}"),
+    }
+    parse_filter_directive(OsStr::new("show,p foo")).expect("show,p foo must parse");
+}
+
+#[test]
+fn lowercase_modifiers_and_uppercase_prefixes_still_parse() {
+    // Regression guard: the case-sensitivity fix must not reject the forms that
+    // upstream accepts. Lowercase `s`/`x` modifiers on include/exclude, and the
+    // uppercase single-char S/P prefixes, all remain valid (upstream exit 0).
+    parse_filter_directive(OsStr::new("+s foo")).expect("+s foo must parse");
+    parse_filter_directive(OsStr::new("include,s foo")).expect("include,s foo must parse");
+    parse_filter_directive(OsStr::new("include,x foo")).expect("include,x foo must parse");
+    match parse_filter_directive(OsStr::new("S public/**")).expect("S shorthand must parse") {
+        FilterDirective::Rule(spec) => assert_eq!(spec.kind(), FilterRuleKind::Include),
+        other => panic!("expected show(include) Rule, got {other:?}"),
+    }
+    match parse_filter_directive(OsStr::new("P backups/**")).expect("P shorthand must parse") {
+        FilterDirective::Rule(spec) => assert_eq!(spec.kind(), FilterRuleKind::Protect),
+        other => panic!("expected protect Rule, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

The `--filter`/`--include`/`--exclude` parser lower-cased every single-char prefix and modifier byte, silently accepting and remapping input that upstream rsync rejects. This aligns the CLI parser with upstream `parse_rule_tok` (`exclude.c:1137-1287`, protocol 32), which matches these bytes verbatim. The merge-file rule parser was already case-correct; this closes the remaining single-char / modifier gap.

## Single-char prefix and modifier case-sensitivity

Modifiers and single-char prefixes are now matched by literal byte, mirroring upstream's `switch` on the raw character:

- Rule modifiers (`+`/`-` short rules and the long keyword forms) match the exact byte, so uppercase `S`/`R`/`X` reach the `default:` arm and are rejected as invalid modifiers (`exclude.c:1214-1287`) instead of being folded to `s`/`r`/`x`.
- After a `+`/`-` prefix, every byte up to the first ` `/`_` separator is a modifier (`exclude.c:1214-1287`). `+S`, `-R`, and `+foo` are now rejected rather than silently treated as a literal pattern.
- The single-char side prefixes `H`/`S`/`P`/`R` match case-sensitively (`exclude.c:1137-1178`), so `s foo` / `h foo` become unknown rules instead of show/hide.
- Merge-file modifiers match verbatim: the cvs-ignore modifier is the uppercase `C`, so `:c` is rejected as an invalid modifier.

## Side-bound keyword guard

`show`/`hide`/`protect`/`risk` map to the `S`/`H`/`P`/`R` prefixes that set `prefix_specifies_side` upstream. That makes the `s`/`r` modifiers invalid on those rules (`exclude.c:1269-1277`), while `p` (perishable) carries no such guard and stays valid everywhere (`exclude.c:1265-1267`).

- `show,r` / `protect,s` were silently accepted (a side-flip); now rejected.
- `protect,p` was wrongly rejected as unsupported; the `p` modifier is now valid.

## Verification

Behaviour was compared byte for byte against the real `rsync 3.4.4` binary. Exit codes now match upstream for every case:

| rule | upstream | oc (before) | oc (after) |
|------|----------|-------------|------------|
| `+S` / `-R` | 1 (invalid modifier) | 0 | 1 |
| `:c` | 1 (invalid modifier) | 0 | 1 |
| `s foo` / `h foo` | 1 (unknown rule) | 0 | 1 |
| `include,X foo` / `exclude,S foo` | 1 (invalid modifier) | 0 | 1 |
| `show,r foo` / `protect,s foo` | 1 (invalid modifier) | 0 | 1 |
| `protect,p foo` / `show,p foo` | 0 | 1 | 0 |
| `+s foo` / `include,x foo` (lowercase) | 0 | 0 | 0 |
| `S public/x` / `P back/x` (uppercase prefix) | 0 | 0 | 0 |

All rejections exit with `RERR_SYNTAX` (1). Lowercase modifiers and the uppercase single-char prefixes keep working unchanged.

## Tests

- Unit tests in `modifiers.rs`, `shorthand.rs`, `helpers.rs` updated for the case-sensitive contract and the side-keyword guard.
- New end-to-end dispatch tests in `parsing/tests.rs` pin every case above through `parse_filter_directive`, each citing the upstream source line.

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, and the targeted `cli` filter test suites all pass.
