### PR TITLE
fix(transport): connect timeout only via --contimeout, expiry exit 35

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -417,6 +417,25 @@ pub(crate) fn socket_error(
     ClientError::with_code(code, message)
 }
 
+/// Builds the diagnostic for a `--contimeout` expiry during `connect(2)`.
+///
+/// Upstream's `open_socket_out()` calls `exit_cleanup(RERR_CONTIMEOUT)` (exit
+/// code 35) when the `SIGALRM` armed by `--contimeout` fires mid-connect, rather
+/// than the generic socket-I/O code 10. This mirrors that, and matches the SSH
+/// path which already maps a connect-watchdog expiry to `ConnectionTimeout`.
+///
+/// upstream: socket.c:280-282 - `if (connect_timeout < 0) exit_cleanup(RERR_CONTIMEOUT);`
+#[cold]
+pub(crate) fn connect_timeout_error(target: impl fmt::Display, error: io::Error) -> ClientError {
+    let code = ExitCode::ConnectionTimeout;
+    let text = format!(
+        "failed to connect to {target}: {}",
+        upstream_io_error(&error)
+    );
+    let message = rsync_error!(code.as_i32(), text).with_role(Role::Client);
+    ClientError::with_code(code, message)
+}
+
 /// Builds the canonical "connection unexpectedly closed" diagnostic that
 /// upstream rsync emits when the protocol stream reaches EOF mid-transfer.
 ///

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -135,13 +135,15 @@ use std::time::Duration;
 
 #[allow(unused_imports)] // REASON: convenience re-export; not all items used in every module
 pub(crate) use self::error::{
-    daemon_access_denied_error, daemon_authentication_failed_error,
+    connect_timeout_error, daemon_access_denied_error, daemon_authentication_failed_error,
     daemon_authentication_required_error, daemon_error, daemon_listing_unavailable_error,
     daemon_protocol_error, socket_error,
 };
-/// Default socket timeout for daemon connections.
+/// Default per-read/write socket I/O timeout for the daemon handshake when
+/// `--timeout` is unset.
 ///
-/// Mirrors the connect timeout applied in upstream
-/// `clientserver.c:start_daemon_client()` when no explicit `--contimeout`
-/// is provided.
+/// This governs only I/O on an established stream (the `@RSYNCD:` handshake
+/// reads/writes), never the connect phase. Upstream bounds `connect(2)` solely
+/// via `--contimeout` (socket.c:274-277), with a default of `0` (no bound); the
+/// connect phase is left to the OS SYN timeout unless `--contimeout` is set.
 pub(crate) const DAEMON_SOCKET_TIMEOUT: Duration = Duration::from_secs(10);

--- a/crates/core/src/client/module_list/connect/direct.rs
+++ b/crates/core/src/client/module_list/connect/direct.rs
@@ -6,7 +6,8 @@ use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
 use super::super::DaemonAddress;
 use crate::client::{
-    AddressMode, ClientError, SOCKET_IO_EXIT_CODE, TcpFastOpenMode, daemon_error, socket_error,
+    AddressMode, ClientError, SOCKET_IO_EXIT_CODE, TcpFastOpenMode, connect_timeout_error,
+    daemon_error, socket_error,
 };
 
 /// Establishes a direct TCP connection to an rsync daemon.
@@ -44,7 +45,28 @@ pub(crate) fn connect_direct(
     }
 
     let (candidate, error) = last_error.expect("no addresses available for daemon connection");
-    Err(socket_error("connect to", candidate, error))
+    Err(map_connect_failure(connect_timeout, candidate, error))
+}
+
+/// Maps a final `connect(2)` failure to a [`ClientError`] with the correct exit
+/// code.
+///
+/// A `--contimeout` expiry (`connect_timeout` was `Some`, and `socket2` surfaces
+/// the alarm as [`io::ErrorKind::TimedOut`]) maps to `RERR_CONTIMEOUT` (35),
+/// matching upstream and the SSH path. Every other failure - including a bare
+/// OS SYN timeout when no `--contimeout` was requested - keeps the generic
+/// socket-I/O code (10).
+///
+/// upstream: socket.c:280-282 - `if (connect_timeout < 0) exit_cleanup(RERR_CONTIMEOUT);`
+fn map_connect_failure(
+    connect_timeout: Option<Duration>,
+    candidate: SocketAddr,
+    error: io::Error,
+) -> ClientError {
+    if connect_timeout.is_some() && error.kind() == io::ErrorKind::TimedOut {
+        return connect_timeout_error(candidate, error);
+    }
+    socket_error("connect to", candidate, error)
 }
 
 /// Resolves a [`DaemonAddress`] to a list of [`SocketAddr`]s, filtered by address family.
@@ -213,5 +235,44 @@ fn try_connectx_fastopen(socket: &Socket, target: SocketAddr, tfo: TcpFastOpenMo
     {
         let _ = (socket, target);
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    fn candidate() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 873)
+    }
+
+    // upstream: socket.c:280-282 - a --contimeout expiry mid-connect exits with
+    // RERR_CONTIMEOUT (35). When a connect bound was requested and connect(2)
+    // times out, oc must report 35, not the generic socket-I/O code 10.
+    #[test]
+    fn connect_timeout_expiry_maps_to_contimeout_exit_code() {
+        let error = io::Error::new(io::ErrorKind::TimedOut, "connection timed out");
+        let mapped = map_connect_failure(Some(Duration::from_secs(5)), candidate(), error);
+        assert_eq!(mapped.exit_code(), 35);
+    }
+
+    // Without --contimeout (connect_timeout is None), an OS-level SYN timeout is
+    // an ordinary socket failure: upstream never arms the contimeout alarm, so
+    // the exit code stays RERR_SOCKETIO (10), not RERR_CONTIMEOUT.
+    #[test]
+    fn os_timeout_without_contimeout_stays_socket_io() {
+        let error = io::Error::new(io::ErrorKind::TimedOut, "connection timed out");
+        let mapped = map_connect_failure(None, candidate(), error);
+        assert_eq!(mapped.exit_code(), 10);
+    }
+
+    // A non-timeout failure (e.g. connection refused) is never a contimeout even
+    // when --contimeout was set; only ErrorKind::TimedOut is the alarm.
+    #[test]
+    fn non_timeout_failure_with_contimeout_stays_socket_io() {
+        let error = io::Error::new(io::ErrorKind::ConnectionRefused, "refused");
+        let mapped = map_connect_failure(Some(Duration::from_secs(5)), candidate(), error);
+        assert_eq!(mapped.exit_code(), 10);
     }
 }

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -256,19 +256,24 @@ pub(crate) fn open_daemon_stream(
     Ok(DaemonStream::tcp(stream))
 }
 
-pub(crate) const fn resolve_connect_timeout(
-    connect_timeout: TransferTimeout,
-    fallback: TransferTimeout,
-    default: Duration,
-) -> Option<Duration> {
+/// Resolves the connect-phase timeout for a daemon TCP connection.
+///
+/// Upstream arms a `SIGALRM` around `connect(2)` only when `--contimeout` is set
+/// to a positive value; the default `connect_timeout` is `0`, in which case the
+/// connect blocks for the OS SYN timeout. `--timeout` never bounds the connect
+/// phase - it only governs per-read/write I/O on an established stream. Hence a
+/// connect is bounded only when `--contimeout=N` (`N > 0`) was given.
+///
+/// upstream: socket.c:274-277 `open_socket_out()` installs `alarm(connect_timeout)`
+/// solely for `connect_timeout > 0`; options.c:125 defaults `connect_timeout = 0`.
+pub(crate) const fn resolve_connect_timeout(connect_timeout: TransferTimeout) -> Option<Duration> {
     match connect_timeout {
-        TransferTimeout::Default => match fallback {
-            TransferTimeout::Default => Some(default),
-            TransferTimeout::Disabled => None,
-            TransferTimeout::Seconds(value) => Some(Duration::from_secs(value.get())),
-        },
-        TransferTimeout::Disabled => None,
+        // --contimeout=N (N > 0): bound the connect phase.
         TransferTimeout::Seconds(value) => Some(Duration::from_secs(value.get())),
+        // Unset (Default) or --contimeout=0 (Disabled): leave the connect
+        // unbounded, matching upstream's default connect_timeout=0. --timeout
+        // must not leak into the connect phase.
+        TransferTimeout::Default | TransferTimeout::Disabled => None,
     }
 }
 

--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -193,7 +193,7 @@ pub fn run_module_list_with_password_and_options(
     let address_mode = options.address_mode();
 
     let effective_timeout = effective_timeout(timeout, DAEMON_SOCKET_TIMEOUT);
-    let connect_duration = resolve_connect_timeout(connect_timeout, timeout, DAEMON_SOCKET_TIMEOUT);
+    let connect_duration = resolve_connect_timeout(connect_timeout);
 
     // Precedence mirrors upstream `main.c`: an explicit `-e`/`--rsh` for a
     // `host::` listing reaches the daemon through the remote shell
@@ -563,6 +563,40 @@ mod tests {
         let custom = NonZeroU64::new(60).unwrap();
         let result = effective_timeout(TransferTimeout::Seconds(custom), default);
         assert_eq!(result, Some(Duration::from_secs(60)));
+    }
+
+    // upstream: socket.c:274-277, options.c:125 - connect(2) is alarm-guarded
+    // only when --contimeout > 0; the default connect_timeout is 0. --timeout
+    // governs per-read I/O on an established stream and must never bound the
+    // connect phase. Without --contimeout, a slow connect must NOT be capped.
+    #[test]
+    fn connect_timeout_unset_leaves_connect_unbounded_even_with_timeout() {
+        // --timeout=8 set, --contimeout unset -> connect stays unbounded (None).
+        assert_eq!(resolve_connect_timeout(TransferTimeout::Default), None);
+    }
+
+    // --contimeout=N (N>0) is the sole trigger for bounding connect(2), matching
+    // the alarm(connect_timeout) upstream installs for connect_timeout > 0.
+    #[test]
+    fn connect_timeout_set_bounds_connect() {
+        let contimeout = TransferTimeout::Seconds(NonZeroU64::new(5).unwrap());
+        assert_eq!(
+            resolve_connect_timeout(contimeout),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    // --contimeout=0 parses to Disabled and, like upstream's connect_timeout=0
+    // default, means "no connect bound", never "expire immediately".
+    #[test]
+    fn connect_timeout_zero_disables_bound() {
+        assert_eq!(resolve_connect_timeout(TransferTimeout::Disabled), None);
+    }
+
+    // Default (neither --timeout nor --contimeout) leaves connect unbounded.
+    #[test]
+    fn connect_timeout_default_is_unbounded() {
+        assert_eq!(resolve_connect_timeout(TransferTimeout::Default), None);
     }
 
     fn greeting(

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -119,12 +119,9 @@ pub fn run_daemon_transfer(
         DaemonTransferRequest::parse_double_colon(&daemon_operand_str)?
     };
 
-    // upstream: clientserver.c - start_daemon_client() applies io_timeout to connect.
-    let connect_duration = resolve_connect_timeout(
-        config.connect_timeout(),
-        config.timeout(),
-        DAEMON_SOCKET_TIMEOUT,
-    );
+    // upstream: socket.c:274-277 - open_socket_out() bounds connect(2) only when
+    // --contimeout is set; --timeout never bounds the connect phase.
+    let connect_duration = resolve_connect_timeout(config.connect_timeout());
     let handshake_io_timeout = config.timeout().effective(DAEMON_SOCKET_TIMEOUT);
     let stream = open_daemon_stream(
         &request.address,

--- a/crates/core/src/client/tests/builder_compress.rs
+++ b/crates/core/src/client/tests/builder_compress.rs
@@ -463,35 +463,27 @@ fn local_copy_options_respect_one_file_system_setting() {
 
 #[test]
 fn resolve_connect_timeout_prefers_explicit_setting() {
+    // --contimeout=N bounds the connect phase (upstream: socket.c:274-277).
     let explicit = TransferTimeout::Seconds(NonZeroU64::new(5).unwrap());
-    let resolved =
-        resolve_connect_timeout(explicit, TransferTimeout::Default, Duration::from_secs(30));
-    assert_eq!(resolved, Some(Duration::from_secs(5)));
+    assert_eq!(
+        resolve_connect_timeout(explicit),
+        Some(Duration::from_secs(5))
+    );
 }
 
 #[test]
-fn resolve_connect_timeout_uses_transfer_timeout_when_default() {
-    let transfer = TransferTimeout::Seconds(NonZeroU64::new(8).unwrap());
-    let resolved =
-        resolve_connect_timeout(TransferTimeout::Default, transfer, Duration::from_secs(30));
-    assert_eq!(resolved, Some(Duration::from_secs(8)));
+fn resolve_connect_timeout_ignores_transfer_timeout() {
+    // --timeout must never bound connect; only --contimeout does. With
+    // --contimeout unset the connect stays unbounded regardless of --timeout.
+    assert_eq!(resolve_connect_timeout(TransferTimeout::Default), None);
 }
 
 #[test]
 fn resolve_connect_timeout_disables_when_requested() {
-    let resolved = resolve_connect_timeout(
-        TransferTimeout::Disabled,
-        TransferTimeout::Seconds(NonZeroU64::new(9).unwrap()),
-        Duration::from_secs(30),
-    );
-    assert!(resolved.is_none());
-
-    let resolved_default = resolve_connect_timeout(
-        TransferTimeout::Default,
-        TransferTimeout::Disabled,
-        Duration::from_secs(30),
-    );
-    assert!(resolved_default.is_none());
+    // --contimeout=0 (Disabled) and the unset default both leave connect
+    // unbounded, matching upstream's default connect_timeout=0 (options.c:125).
+    assert!(resolve_connect_timeout(TransferTimeout::Disabled).is_none());
+    assert!(resolve_connect_timeout(TransferTimeout::Default).is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The direct-TCP daemon connect path (`rsync://` and `host::module`) diverged from upstream rsync in two ways. Both are fixed here.

### 1. Connect phase must not be bounded by `--timeout` or a hardcoded default

Upstream only guards `connect(2)` with a `SIGALRM` when `--contimeout` is set to a positive value:

```c
/* socket.c:274-277 (rsync 3.4.4) */
if (connect_timeout > 0) {
        SIGACTION(SIGALRM, contimeout_handler);
        alarm(connect_timeout);
}
```

The default is `int connect_timeout = 0;` (`options.c:125`), so by default the connect blocks for the OS SYN timeout. `--timeout` (io_timeout) never bounds the connect phase.

Previously `resolve_connect_timeout` returned a hardcoded 10s default and also folded `--timeout` into the connect bound. As a result a connect to a slow or loaded daemon failed after 10s (where upstream waits for the OS SYN timeout), and `--timeout=T` wrongly aborted the connect phase.

Fix: the connect is bounded only when `--contimeout=N` (`N > 0`) was explicitly set. `TransferTimeout::Default` (unset) and `TransferTimeout::Disabled` (`--contimeout=0`) both resolve to `None`, matching upstream's default `connect_timeout = 0`. The per-read/write io_timeout (`--timeout`) on the established stream is unchanged. The stale in-code parity comment (which claimed the 10s default mirrored the connect timeout) is corrected.

### 2. `--contimeout` expiry must exit 35, not 10

```c
/* socket.c:280-282 (rsync 3.4.4) */
while (connect(s, res->ai_addr, res->ai_addrlen) < 0) {
        if (connect_timeout < 0)
                exit_cleanup(RERR_CONTIMEOUT);
```

`RERR_CONTIMEOUT` is exit code 35 (`errcode.h:48`). The direct-TCP path previously funnelled a `TimedOut` connect through `socket_error`, yielding `RERR_SOCKETIO` (10). The SSH path already maps a connect-watchdog expiry to 35.

Fix: when a connect bound was requested (`--contimeout`) and `connect(2)` fails with `ErrorKind::TimedOut`, map to `ExitCode::ConnectionTimeout` (35). A bare OS SYN timeout with no `--contimeout` stays 10; a non-timeout failure (e.g. connection refused) with `--contimeout` set also stays 10.

## Tests

Deterministic unit tests in compiled modules:

- `listing.rs`: with only `--timeout` set (no `--contimeout`), the resolved connect timeout is `None`; with `--contimeout=N` it is `Some(N)`; `--contimeout=0` and the unset default both resolve to `None`.
- `direct.rs`: `map_connect_failure` maps a `TimedOut` connect to exit 35 only when a connect bound was requested; an unbounded OS timeout and a non-timeout failure both stay exit 10.

## Note

While placing the tests I found that `crates/core/src/client/tests/` (a `mod.rs` of `include!`d test files) is not declared by any `mod tests;`, so it is not compiled - the pre-existing `resolve_connect_timeout_*` tests there were dead. The new tests were therefore added to compiled modules; the dead copies were also updated for consistency.
