### PR TITLE
fix(daemon): align refuse, log-file, dont-compress, backlog defaults

### DIFF
--- a/crates/daemon/src/daemon/module_state/definition.rs
+++ b/crates/daemon/src/daemon/module_state/definition.rs
@@ -401,7 +401,11 @@ impl ModuleDefinition {
     }
 
     /// Returns the per-module log file path, if configured.
-    #[allow(dead_code)] // REASON: wired when per-module log files are opened at connection time
+    ///
+    /// This is upstream's `lp_log_file(module_id)`: the value already carries the
+    /// global-section default inherited at resolution time (finish.rs). The
+    /// daemon reopens its per-connection log sink to this path at module select
+    /// (`reopen_module_log_sink`, mirroring `log_init(1)` at clientserver.c:897).
     pub(crate) fn module_log_file(&self) -> Option<&Path> {
         self.log_file.as_deref()
     }

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -63,6 +63,32 @@ pub(crate) fn open_log_sink(path: &Path, brand: Brand) -> Result<SharedLogSink, 
     Ok(Arc::new(Mutex::new(MessageSink::with_brand(file, brand))))
 }
 
+/// Reopens the connection's log sink to the selected module's `log file`.
+///
+/// upstream: log.c:169-204 `log_init(1)` reopens the daemon logfile to
+/// `lp_log_file(module_id)` at module selection (clientserver.c:897). A module's
+/// resolved `log file` already inherits the global-section default (finish.rs),
+/// so [`ModuleDefinition::module_log_file`] is exactly upstream's
+/// `lp_log_file(module_id)`.
+///
+/// oc opens the startup sink once (from `--log-file`) and shares it across
+/// connection threads, so rather than mutate the shared sink this returns a
+/// fresh per-connection sink pointing at the module's log file; the caller uses
+/// it for the remainder of the connection. A module with no `log file` returns
+/// `None`, keeping the startup sink. A failed reopen is non-fatal - upstream
+/// (log.c:158-166) logs the failure and keeps serving rather than dropping the
+/// connection - so this returns `None` and the caller retains the startup sink.
+fn reopen_module_log_sink(
+    module: &ModuleDefinition,
+    startup_sink: Option<&SharedLogSink>,
+) -> Option<SharedLogSink> {
+    let path = module.module_log_file()?;
+    let brand = startup_sink
+        .and_then(|sink| sink.lock().ok().map(|guard| guard.brand()))
+        .unwrap_or(Brand::Oc);
+    open_log_sink(path, brand).ok()
+}
+
 /// Creates a [`DaemonError`] for log file open failures.
 ///
 /// upstream: log.c:163 - log-open failures produce RERR_MESSAGEIO (13).

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -547,6 +547,14 @@ fn respond_with_module_request(
         );
     };
 
+    // upstream: clientserver.c:897 `log_init(1)` reopens the daemon log to
+    // `lp_log_file(module_id)` once the module is selected, so every subsequent
+    // diagnostic for this connection lands in the module's `log file`. Keep the
+    // reopened sink alive for the rest of the request; shadow `log_sink` so the
+    // bandwidth-change log, refusal path, and transfer all use it.
+    let module_log_sink = reopen_module_log_sink(module, log_sink);
+    let log_sink = module_log_sink.as_ref().or(log_sink);
+
     let change = apply_module_bandwidth_limit(
         limiter,
         module.bandwidth_limit(),

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1412,6 +1412,60 @@ mod module_access_tests {
         assert!(!dont_compress_is_match_all(""));
     }
 
+    #[test]
+    fn reopen_module_log_sink_targets_each_modules_log_file() {
+        // upstream: log.c:169-204 `log_init(1)` at clientserver.c:897 - selecting
+        // a module reopens the daemon log to that module's `log file`, so two
+        // modules with distinct `log file` directives write their diagnostics to
+        // distinct files rather than sharing one sink.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path_a = dir.path().join("a.log");
+        let path_b = dir.path().join("b.log");
+
+        let module_a = ModuleDefinition {
+            log_file: Some(path_a.clone()),
+            ..Default::default()
+        };
+        let module_b = ModuleDefinition {
+            log_file: Some(path_b.clone()),
+            ..Default::default()
+        };
+
+        let sink_a = reopen_module_log_sink(&module_a, None).expect("module a sink");
+        let sink_b = reopen_module_log_sink(&module_b, None).expect("module b sink");
+        log_message(&sink_a, &rsync_info!("entry-for-module-a"));
+        log_message(&sink_b, &rsync_info!("entry-for-module-b"));
+        drop(sink_a);
+        drop(sink_b);
+
+        let a = std::fs::read_to_string(&path_a).expect("read a.log");
+        let b = std::fs::read_to_string(&path_b).expect("read b.log");
+        assert!(a.contains("entry-for-module-a"), "a.log: {a}");
+        assert!(!a.contains("entry-for-module-b"), "a.log leaked b: {a}");
+        assert!(b.contains("entry-for-module-b"), "b.log: {b}");
+        assert!(!b.contains("entry-for-module-a"), "b.log leaked a: {b}");
+    }
+
+    #[test]
+    fn reopen_module_log_sink_none_without_log_file() {
+        // A module with no `log file` leaves the startup sink in place: upstream's
+        // `lp_log_file(module_id)` is empty, so `log_init(1)` keeps the current
+        // log rather than reopening.
+        let module = ModuleDefinition::default();
+        assert!(reopen_module_log_sink(&module, None).is_none());
+    }
+
+    #[test]
+    fn builtin_dont_compress_default_does_not_collapse_stream() {
+        // upstream: token.c:206-211 - only a bare `*` in `dont compress`
+        // collapses the whole compression stream to store level; the per-suffix
+        // lookup in set_compression is compiled out (`#if 0`, token.c:227). The
+        // built-in DEFAULT_DONT_COMPRESS list therefore never matches-all, so a
+        // module that inherits it still compresses a `.gz` exactly as upstream
+        // 3.4.4 does. Seeding the default is config fidelity, not a wire change.
+        assert!(!dont_compress_is_match_all(DEFAULT_DONT_COMPRESS));
+    }
+
 
     fn test_module_with_defaults() -> ModuleRuntime {
         ModuleRuntime::from(ModuleDefinition::default())

--- a/crates/daemon/src/daemon/sections/module_definition/finish.rs
+++ b/crates/daemon/src/daemon/sections/module_definition/finish.rs
@@ -4,6 +4,26 @@
 // applying defaults for unset fields and enforcing cross-field constraints
 // (e.g., `auth users` requires `secrets file`).
 
+/// Built-in `dont compress` suffix list a daemon module inherits when neither
+/// the module nor the global section sets the directive.
+///
+/// Copied verbatim from upstream's generated `default-dont-compress.h`
+/// (`#define DEFAULT_DONT_COMPRESS`), which loadparm.c:46 includes and installs
+/// as the default value of the `dont compress` parameter (`lp_dont_compress`).
+/// The list itself is authored in `rsync.1.md` and extracted by
+/// `define-from-md.awk`. Only a bare `*` collapses the whole compression stream
+/// (token.c:206-211); the per-suffix lookup in `set_compression` is compiled
+/// out (`#if 0`, token.c:227), so this default list is a config-fidelity value
+/// with no per-file wire effect - a daemon still compresses a `.gz` exactly as
+/// upstream 3.4.4 does.
+const DEFAULT_DONT_COMPRESS: &str = "*.3g2 *.3gp *.7z *.aac *.ace *.apk *.avi *.bz2 *.deb \
+*.dmg *.ear *.f4v *.flac *.flv *.gpg *.gz *.iso *.jar *.jpeg *.jpg *.lrz *.lz *.lz4 *.lzma \
+*.lzo *.m1a *.m1v *.m2a *.m2ts *.m2v *.m4a *.m4b *.m4p *.m4r *.m4v *.mka *.mkv *.mov *.mp1 \
+*.mp2 *.mp3 *.mp4 *.mpa *.mpeg *.mpg *.mpv *.mts *.odb *.odf *.odg *.odi *.odm *.odp *.ods \
+*.odt *.oga *.ogg *.ogm *.ogv *.ogx *.opus *.otg *.oth *.otp *.ots *.ott *.oxt *.png *.qt \
+*.rar *.rpm *.rz *.rzip *.spx *.squashfs *.sxc *.sxd *.sxg *.sxm *.sxw *.sz *.tbz *.tbz2 \
+*.tgz *.tlz *.ts *.txz *.tzo *.vob *.war *.webm *.webp *.xz *.z *.zip *.zst";
+
 impl ModuleDefinitionBuilder {
     /// Converts the accumulated builder state into a validated `ModuleDefinition`.
     ///
@@ -165,7 +185,13 @@ impl ModuleDefinitionBuilder {
                         .or_else(|| Some("%o %h [%a] %m (%u) %f %l".to_owned()))
                 }),
             log_file: self.log_file.or_else(|| defaults.log_file.clone()),
-            dont_compress: self.dont_compress.unwrap_or_else(|| defaults.dont_compress.clone()),
+            // upstream: loadparm.c:46 seeds `dont compress` with the built-in
+            // DEFAULT_DONT_COMPRESS list when neither the module nor the global
+            // section sets it, so `lp_dont_compress(module_id)` is never empty.
+            dont_compress: self
+                .dont_compress
+                .unwrap_or_else(|| defaults.dont_compress.clone())
+                .or_else(|| Some(DEFAULT_DONT_COMPRESS.to_owned())),
             early_exec: self.early_exec.unwrap_or_else(|| defaults.early_exec.clone()),
             pre_xfer_exec: self.pre_xfer_exec.unwrap_or_else(|| defaults.pre_xfer_exec.clone()),
             post_xfer_exec: self.post_xfer_exec.unwrap_or_else(|| defaults.post_xfer_exec.clone()),

--- a/crates/daemon/src/daemon/sections/module_definition/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_definition/tests.rs
@@ -746,7 +746,10 @@ fn finish_uses_default_values_for_unset_fields() {
         def.log_format.as_deref(),
         Some("%o %h [%a] %m (%u) %f %l")
     ); // default format
-    assert!(def.dont_compress.is_none());
+    // upstream: loadparm.c:46 - `dont compress` defaults to the built-in
+    // DEFAULT_DONT_COMPRESS suffix list, so a resolved module inherits it when
+    // neither the module nor the global section sets the directive.
+    assert_eq!(def.dont_compress.as_deref(), Some(DEFAULT_DONT_COMPRESS));
     assert!(def.early_exec.is_none());
     assert!(def.pre_xfer_exec.is_none());
     assert!(def.post_xfer_exec.is_none());

--- a/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
@@ -30,7 +30,11 @@ const VITAL_OPTIONS: &[&str] = &[
     "server",
     "rsh",
     "e",
-    "out-format",
+    // upstream: options.c:975 marks the `log-format` long_options[] entry (the
+    // deprecated alias of `out-format`) exact-match only - "aka out-format (NOT
+    // log-file-format)". The wildcard-able `out-format` entry is left refusable,
+    // so `log-format` is the vital name a `refuse options = *` cannot touch.
+    "log-format",
     "sender",
     "dry-run",
     "n",
@@ -75,7 +79,7 @@ fn refused_option<'a>(module: &ModuleDefinition, options: &'a [String]) -> Optio
     options.iter().find_map(|candidate| {
         let canonical = canonical_option(candidate);
         let short = long_option_short_letter(&canonical);
-        if is_option_refused(&module.refuse_options, &canonical, short) {
+        if is_option_refused(module, &canonical, short) {
             Some(candidate.as_str())
         } else {
             None
@@ -235,7 +239,7 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
     // pass catches the timing variants the client actually sends on the wire
     // (oc emits `--delete-during` for a plain `-a --delete`). The reported
     // option is always `--delete`, matching `create_refuse_error(refused_delete)`.
-    if is_option_refused(&module.refuse_options, "delete", None)
+    if is_option_refused(module, "delete", None)
         && client_args.iter().any(|arg| enables_delete_mode(arg))
     {
         return Some("--delete".to_owned());
@@ -249,7 +253,7 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
                 continue;
             }
             let short = long_option_short_letter(&canonical);
-            if is_option_refused(&module.refuse_options, &canonical, short) {
+            if is_option_refused(module, &canonical, short) {
                 return Some(format!("--{canonical}"));
             }
             continue;
@@ -269,7 +273,7 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
                     long.to_owned()
                 };
                 let short_letter = if long.is_empty() { None } else { Some(letter) };
-                if is_option_refused(&module.refuse_options, &long_canonical, short_letter) {
+                if is_option_refused(module, &long_canonical, short_letter) {
                     return Some(if long.is_empty() {
                         format!("-{letter}")
                     } else {
@@ -326,7 +330,11 @@ fn enables_delete_mode(arg: &str) -> bool {
 /// When a rule is a wildcard (`*`, `?`, `[`), it cannot affect vital options
 /// (`--server`, `--sender`, `--dry-run`, `-e`, `-s`, ...). Non-wild rules
 /// can refuse or un-refuse vital options when named explicitly.
-fn is_option_refused(refuse_list: &[String], long_name: &str, short_letter: Option<char>) -> bool {
+fn is_option_refused(
+    module: &ModuleDefinition,
+    long_name: &str,
+    short_letter: Option<char>,
+) -> bool {
     let vital = is_option_vital(long_name, short_letter);
     // upstream: options.c:984-987 - a daemon seeds `copy-devices`/`write-devices`
     // as refused before applying the module's rules. Start from that default so
@@ -334,7 +342,7 @@ fn is_option_refused(refuse_list: &[String], long_name: &str, short_letter: Opti
     let mut refused = DEFAULT_REFUSED_OPTIONS.contains(&long_name);
     let short_lower = short_letter.map(|c| c.to_ascii_lowercase().to_string());
 
-    for rule in refuse_list {
+    for rule in &module.refuse_options {
         let (negated, pattern_raw) = if let Some(rest) = rule.strip_prefix('!') {
             (true, rest)
         } else {
@@ -383,6 +391,29 @@ fn is_option_refused(refuse_list: &[String], long_name: &str, short_letter: Opti
             refused = !negated;
         }
     }
+
+    // upstream: options.c:1005-1011 - once the module's own `refuse options`
+    // rules have been applied, a daemon appends these refusals unconditionally,
+    // so no `!log-file` / `!iconv` negation above can re-enable them:
+    //   - `log-file*` (options.c:1010) refuses both `--log-file` and
+    //     `--log-file-format`, keeping clients from redirecting the daemon's
+    //     server-side logging.
+    //   - `iconv` (options.c:1007-1008) is refused only when the module has no
+    //     `charset` configured (`!*lp_charset(module_id)`).
+    if long_name.starts_with("log-file") {
+        return true;
+    }
+    if long_name == "iconv"
+        && module
+            .charset
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+    {
+        return true;
+    }
+
     refused
 }
 

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -90,12 +90,11 @@ const fn normalize_peer_address(addr: SocketAddr) -> SocketAddr {
 /// Default TCP listen backlog when not overridden by `listen backlog` in the
 /// daemon configuration file.
 ///
-/// Upstream rsync defaults to 5 (`daemon-parm.txt`), which is too low for
-/// production workloads - the kernel drops SYN packets once the backlog queue
-/// is full, creating a hard ceiling around 250 concurrent connections.
-/// A backlog of 128 matches `SOMAXCONN` on most Linux systems and is the
-/// standard default for production TCP servers.
-const DEFAULT_LISTEN_BACKLOG: i32 = 128;
+/// Mirrors upstream rsync's default of 5: `daemon-parm.txt` declares
+/// `INTEGER listen_backlog 5`, and `socket.c:554` passes `lp_listen_backlog()`
+/// to `listen(2)`. An operator who needs a deeper accept queue raises it with
+/// the `listen backlog` directive, exactly as upstream allows.
+const DEFAULT_LISTEN_BACKLOG: i32 = 5;
 
 /// Logs a progress summary when SIGUSR2 is received.
 ///

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1095,12 +1095,12 @@ fn accept_loop_recovers_after_disconnect() {
 }
 
 #[test]
-fn default_listen_backlog_is_128() {
-    // The default backlog must be high enough for production workloads.
-    // A value of 5 (upstream's historical default) causes connection drops
-    // under moderate concurrency. 128 matches SOMAXCONN on most Linux
-    // systems and is the standard default for production TCP servers.
-    assert_eq!(DEFAULT_LISTEN_BACKLOG, 128);
+fn default_listen_backlog_matches_upstream() {
+    // upstream: daemon-parm.txt declares `INTEGER listen_backlog 5` and
+    // socket.c:554 passes `lp_listen_backlog()` to listen(2). The absent-
+    // directive default must match upstream's 5 so a drop-in daemon presents
+    // the same accept-queue depth; operators raise it via `listen backlog`.
+    assert_eq!(DEFAULT_LISTEN_BACKLOG, 5);
 }
 
 #[test]

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+/// Builds a module whose only non-default field is its `refuse options` list.
+fn module_with_refuse(refuse_options: Vec<String>) -> ModuleDefinition {
+    ModuleDefinition {
+        refuse_options,
+        ..Default::default()
+    }
+}
+
 #[test]
 fn parse_daemon_option_extracts_option_payload() {
     assert_eq!(parse_daemon_option("OPTION --list"), Some("--list"));
@@ -250,18 +258,18 @@ fn refused_option_returns_first_refused() {
 
 #[test]
 fn is_option_refused_last_rule_wins() {
-    let refuse = vec!["delete".to_owned(), "!delete".to_owned()];
-    assert!(!is_option_refused(&refuse, "delete", None));
+    let module = module_with_refuse(vec!["delete".to_owned(), "!delete".to_owned()]);
+    assert!(!is_option_refused(&module, "delete", None));
 }
 
 #[test]
 fn is_option_refused_re_refuse_after_negation() {
-    let refuse = vec![
+    let module = module_with_refuse(vec![
         "delete*".to_owned(),
         "!delete-during".to_owned(),
         "delete-during".to_owned(),
-    ];
-    assert!(is_option_refused(&refuse, "delete-during", None));
+    ]);
+    assert!(is_option_refused(&module, "delete-during", None));
 }
 
 #[test]
@@ -271,9 +279,9 @@ fn is_option_refused_short_letter_rule_matches_long_option() {
     // un-refuse the same option that `!verbose` would, so allow-list
     // configurations that use short-letter shorthands behave the same as
     // long-name shorthands.
-    let allow_list = vec!["*".to_owned(), "!v".to_owned(), "!a".to_owned()];
-    assert!(!is_option_refused(&allow_list, "verbose", Some('v')));
-    assert!(!is_option_refused(&allow_list, "archive", Some('a')));
+    let module = module_with_refuse(vec!["*".to_owned(), "!v".to_owned(), "!a".to_owned()]);
+    assert!(!is_option_refused(&module, "verbose", Some('v')));
+    assert!(!is_option_refused(&module, "archive", Some('a')));
 }
 
 #[test]
@@ -281,11 +289,11 @@ fn is_option_refused_archive_rule_expands_to_short_letter_set() {
     // upstream: options.c:904-906 - the `archive` (and `a`) rules expand to
     // the character class `[ardlptgoD]` and so refuse every short letter that
     // `-a` implies, not just the `--archive` long name.
-    let refuse = vec!["archive".to_owned()];
-    assert!(is_option_refused(&refuse, "recursive", Some('r')));
-    assert!(is_option_refused(&refuse, "links", Some('l')));
-    assert!(is_option_refused(&refuse, "devices", Some('D')));
-    assert!(!is_option_refused(&refuse, "compress", Some('z')));
+    let module = module_with_refuse(vec!["archive".to_owned()]);
+    assert!(is_option_refused(&module, "recursive", Some('r')));
+    assert!(is_option_refused(&module, "links", Some('l')));
+    assert!(is_option_refused(&module, "devices", Some('D')));
+    assert!(!is_option_refused(&module, "compress", Some('z')));
 }
 
 #[test]
@@ -293,11 +301,11 @@ fn is_option_refused_pure_allowlist_does_not_refuse_anything() {
     // upstream: options.c:947-968 - every option starts marked as accepted
     // (`a*` or `a=`). A refuse list of only negations therefore touches
     // nothing - no option flips to refused. Sanity-check the obvious cases.
-    let allow_list = vec!["!verbose".to_owned(), "!archive".to_owned()];
-    assert!(!is_option_refused(&allow_list, "verbose", Some('v')));
-    assert!(!is_option_refused(&allow_list, "archive", Some('a')));
-    assert!(!is_option_refused(&allow_list, "compress", Some('z')));
-    assert!(!is_option_refused(&allow_list, "delete", None));
+    let module = module_with_refuse(vec!["!verbose".to_owned(), "!archive".to_owned()]);
+    assert!(!is_option_refused(&module, "verbose", Some('v')));
+    assert!(!is_option_refused(&module, "archive", Some('a')));
+    assert!(!is_option_refused(&module, "compress", Some('z')));
+    assert!(!is_option_refused(&module, "delete", None));
 }
 
 #[test]
@@ -305,6 +313,81 @@ fn is_vital_option_recognises_all_vitals() {
     for &vital in VITAL_OPTIONS {
         assert!(is_vital_option(vital), "expected '{vital}' to be vital");
     }
+}
+
+#[test]
+fn default_refuses_client_log_file_options() {
+    // upstream: options.c:1010 - a daemon always appends `log-file*` to the
+    // refuse list after the module's own rules, refusing both `--log-file` and
+    // `--log-file-format` so a client cannot redirect the server's logging.
+    let module = ModuleDefinition::default();
+    assert_eq!(
+        refused_option(&module, &["--log-file".to_owned()]),
+        Some("--log-file")
+    );
+    assert_eq!(
+        refused_option(&module, &["--log-file-format".to_owned()]),
+        Some("--log-file-format")
+    );
+}
+
+#[test]
+fn default_log_file_refusal_survives_negation() {
+    // upstream: options.c:1005-1011 - the `log-file*` refusal is applied AFTER
+    // the module's `refuse options` rules, so a `!log-file` negation cannot
+    // re-enable it.
+    let module = module_with_refuse(vec!["!log-file".to_owned()]);
+    assert_eq!(
+        refused_option(&module, &["--log-file".to_owned()]),
+        Some("--log-file")
+    );
+}
+
+#[test]
+fn iconv_refused_when_module_has_no_charset() {
+    // upstream: options.c:1007-1008 - `if (!*lp_charset(module_id))
+    // parse_one_refuse_match(0, "iconv", ...)`: a daemon module with no
+    // `charset` configured refuses client `--iconv`.
+    let module = ModuleDefinition::default();
+    assert_eq!(
+        refused_option(&module, &["--iconv".to_owned()]),
+        Some("--iconv")
+    );
+}
+
+#[test]
+fn iconv_allowed_when_module_configures_charset() {
+    // upstream: options.c:1006-1009 - the iconv refusal is skipped when the
+    // module sets a `charset`, so the client may negotiate `--iconv`.
+    let module = ModuleDefinition {
+        charset: Some("LATIN1".to_owned()),
+        ..Default::default()
+    };
+    assert_eq!(refused_option(&module, &["--iconv".to_owned()]), None);
+}
+
+#[test]
+fn wildcard_all_spares_vital_log_format_but_refuses_out_format() {
+    // upstream: options.c:975 - the `log-format` long_options[] entry is
+    // exact-match only (vital), so `refuse options = *` cannot refuse it, while
+    // the wildcard-able `out-format` alias is refused by the same `*`.
+    let module = module_with_refuse(vec!["*".to_owned()]);
+    assert_eq!(refused_option(&module, &["--log-format".to_owned()]), None);
+    assert_eq!(
+        refused_option(&module, &["--out-format".to_owned()]),
+        Some("--out-format")
+    );
+}
+
+#[test]
+fn exact_rule_refuses_vital_log_format() {
+    // upstream: options.c:909-940 - a non-wild exact rule still marks a vital
+    // option refused, so `refuse options = log-format` rejects `--log-format`.
+    let module = module_with_refuse(vec!["log-format".to_owned()]);
+    assert_eq!(
+        refused_option(&module, &["--log-format".to_owned()]),
+        Some("--log-format")
+    );
 }
 
 #[test]


### PR DESCRIPTION
Aligns six daemon config-default behaviours with upstream rsync 3.4.4
(protocol 32). Each item mirrors the upstream C exactly; upstream source is
the sole reference (options.c, loadparm.c, log.c, socket.c, token.c,
daemon-parm.txt).

## Refuse --log-file / --log-file-format by default
set_refuse_options() appends log-file* to every daemon module's refuse list
after the module's own rules, so a client cannot redirect the server's
logging. Implemented as a post-rule forced refusal (un-negatable, matching
the ordering) covering both --log-file and --log-file-format.
- upstream: options.c:1005-1011 (parse_one_refuse_match(0, "log-file*", ...) at :1010).

## Refuse --iconv when the module has no charset
A daemon refuses iconv when !*lp_charset(module_id). Added as a post-rule
forced refusal gated on the module's charset directive; a module that
configures charset still allows --iconv.
- upstream: options.c:1006-1009.

## Reopen the per-module log sink at module select
log_init(1) reopens the daemon logfile to lp_log_file(module_id) when a
module is selected. A module's resolved log file already inherits the
global-section default, so it equals lp_log_file(module_id). Because
oc-rsync shares one startup sink across connection threads (rather than
forking per connection), a selected module with a log file now gets its own
per-connection sink; a failed reopen is non-fatal and keeps serving.
ModuleDefinition::module_log_file is no longer dead code.
- upstream: log.c:169-204 (log_init), clientserver.c:897 (log_init(1)),
  log.c:158-166 (open-failure fallback).

## Seed the built-in dont compress default
loadparm installs the generated DEFAULT_DONT_COMPRESS suffix list as the
default of the dont compress parameter, so lp_dont_compress(module_id) is
never empty. The ~90-suffix list is copied verbatim from upstream's
default-dont-compress.h (authored in rsync.1.md, generated by
define-from-md.awk) and seeded when neither the module nor the global
section sets the directive. This is config fidelity with no per-file wire
effect: only a bare * collapses the compression stream (token.c:206-211);
the per-suffix set_compression lookup is compiled out (#if 0, token.c:227),
so a daemon still compresses a .gz exactly as upstream 3.4.4 does.
- upstream: loadparm.c:46 (#include "default-dont-compress.h"), token.c:180-227.

## listen backlog default 5
The absent-directive listen backlog now defaults to 5, matching upstream,
instead of 128. It stays configurable via the listen backlog directive.
- upstream: daemon-parm.txt:11 (INTEGER listen_backlog 5), socket.c:554
  (listen(sp[i], lp_listen_backlog())).

## Protect log-format (not out-format) in the vital list
The vital (wildcard-immune) refuse entry is log-format, the deprecated alias
marked exact-match-only in long_options[]; the out-format entry is left
wildcard-refusable. Corrected the vital-option name so refuse options = *
spares --log-format and refuses --out-format, matching upstream.
- upstream: options.c:975 (strcmp("log-format", longName) == 0 /* aka
  out-format (NOT log-file-format) */).

## Tests
Deterministic tests added for each item, each citing the upstream source: a
daemon refuses a client --log-file / --log-file-format and the refusal
survives !log-file; a charset-less module refuses --iconv while a
charset-configured module allows it; two modules with distinct log file land
entries in distinct files; the seeded dont compress default does not collapse
the stream (a .gz is still compressed); absent listen backlog resolves to 5;
refuse options = * spares --log-format but refuses --out-format, and an exact
rule refuses --log-format.

cargo fmt --all -- --check clean; cargo clippy -p daemon --all-features
--all-targets --no-deps -- -D warnings clean.
