### PR TITLE
fix(transfer): promote present -H member when group leader absent

### DIFF
--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -6,7 +6,7 @@
 //! reception, so this module handles both protocol versions uniformly.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use logging::{debug_log, info_log};
 #[cfg(any(unix, windows))]
@@ -551,6 +551,57 @@ impl ReceiverContext {
         Ok(())
     }
 
+    /// Resolves the on-disk hard-link target for a group, promoting the next
+    /// present member when the recorded leader never materialized on disk.
+    ///
+    /// The receiver only transfers a group's leader (`hlink_first`); followers
+    /// are hard-linked to it afterwards. When the leader's own transfer is
+    /// skipped or errors, its destination is absent and it must not be used as
+    /// a link source. This mirrors upstream `hlink.c` exactly:
+    ///
+    /// - `skip_hard_link()` (hlink.c:546-565) sets `FLAG_SKIP_HLINK` on a
+    ///   member that was not transferred.
+    /// - `check_prior()` (hlink.c:246-282) walks the group's `F_HL_PREV` chain
+    ///   past every `FLAG_SKIP_HLINK` member to find the next still-present one.
+    /// - `hard_link_check()` (hlink.c:299-310) promotes that member to the
+    ///   group's "virtual first" link source.
+    ///
+    /// Returns the promoted leader's path - recording it in the tracker so the
+    /// remaining followers reuse it - or `None` when no member of the group
+    /// materialized on disk.
+    fn promote_hardlink_leader(
+        file_list: &[protocol::flist::FileEntry],
+        tracker: &mut engine::HardlinkApplyTracker,
+        gnum: u32,
+        dest_dir: &Path,
+    ) -> Option<PathBuf> {
+        // A previously recorded leader is only valid while its file is still
+        // present (its transfer may have errored after we recorded it).
+        if let Some(recorded) = tracker.leader_path(gnum) {
+            if recorded.symlink_metadata().is_ok() {
+                return Some(recorded.to_path_buf());
+            }
+        }
+        // upstream: hlink.c:253-265 - walk the group in list (ndx) order and
+        // promote the first member whose file materialized on disk.
+        for member in file_list {
+            if member.hardlink_idx() != Some(gnum) {
+                continue;
+            }
+            let relative_path = member.path();
+            let candidate = if relative_path.as_os_str() == "." {
+                dest_dir.to_path_buf()
+            } else {
+                dest_dir.join(relative_path)
+            };
+            if candidate.symlink_metadata().is_ok() {
+                tracker.record_leader(gnum, candidate.clone());
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
     /// Creates hard links for hardlink follower entries after the leader has been transferred.
     ///
     /// Hardlinked files are grouped by a shared `hardlink_idx`. The first file in
@@ -607,6 +658,18 @@ impl ReceiverContext {
                     } else {
                         dest_dir.join(relative_path)
                     };
+                    // upstream: hlink.c:546-565 skip_hard_link() sets
+                    // FLAG_SKIP_HLINK on a group member that was not transferred
+                    // (e.g. its own transfer errored), and check_prior()
+                    // (hlink.c:246-282) then refuses it as a link source. Only
+                    // record a leader whose file actually materialized on disk;
+                    // an absent leader is left unrecorded so the second pass can
+                    // promote the next present group member (hlink.c:299-310
+                    // "virtual first") instead of hard-linking to a path that
+                    // does not exist (ENOENT -> fatal abort).
+                    if dest_path.symlink_metadata().is_err() {
+                        continue;
+                    }
                     // No deferred followers expected here since we process
                     // followers in the second pass below.
                     let _ = tracker.record_leader(gnum, dest_path);
@@ -624,20 +687,32 @@ impl ReceiverContext {
                 };
 
                 let entry_name = entry.path().display().to_string();
-                let leader_path = match tracker.leader_path(leader_idx) {
-                    Some(p) => p.to_path_buf(),
+                let leader_path = match Self::promote_hardlink_leader(
+                    &self.file_list,
+                    &mut tracker,
+                    leader_idx,
+                    dest_dir,
+                ) {
+                    Some(p) => p,
                     None => {
-                        // upstream: hlink.c HLINK debug emissions
-                        // No leader recorded: matches `virtual first` in upstream
-                        // when a prior file in the group was skipped.
+                        // upstream: hlink.c:299-310 - when every prior member of
+                        // the group carries FLAG_SKIP_HLINK (their transfers were
+                        // skipped or errored) check_prior() returns no leader and
+                        // hard_link_check() treats the member as a "virtual
+                        // first" that upstream would transfer anew. In this
+                        // post-transfer apply pass there is no data left to link,
+                        // so the group is left unlinked with a soft I/O error
+                        // (IOERR_GENERAL -> RERR_PARTIAL, exit 23) - never a fatal
+                        // receiver abort.
                         trace_virtual_first(follower_ndx as i32, &entry_name, leader_idx as i32);
                         debug_log!(
                             Recv,
                             1,
-                            "hardlink follower {} references unknown leader index {}",
-                            entry.name(),
-                            leader_idx
+                            "hardlink group {} has no leader materialized on disk; leaving follower {} unlinked",
+                            leader_idx,
+                            entry.name()
                         );
+                        self.flist_io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
                         continue;
                     }
                 };
@@ -766,6 +841,17 @@ impl ReceiverContext {
                     // the follower silently missing. ELOOP / EOPNOTSUPP
                     // from sandbox-anchored refusals are also fail-loud.
                     if e.kind() == std::io::ErrorKind::PermissionDenied {
+                        continue;
+                    }
+                    // upstream: hlink.c:246-282 check_prior() re-derives a group
+                    // whose prior member has gone away rather than aborting. A
+                    // NotFound here means the resolved leader's file vanished
+                    // after we stat'd it (its transfer errored, or a concurrent
+                    // unlink): leave this follower unlinked with a soft error
+                    // (IOERR_GENERAL -> RERR_PARTIAL, exit 23) instead of a fatal
+                    // receiver desync (exit 12).
+                    if e.kind() == std::io::ErrorKind::NotFound {
+                        self.flist_io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
                         continue;
                     }
                     // Restore the tracker before propagating so the

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -730,6 +730,17 @@ impl ReceiverContext {
                 let relative_path = entry.path();
                 let link_path = dest_dir.join(relative_path);
 
+                // The promoted "virtual first" (hlink.c:299-310) can be this
+                // very follower when its own file is the only group member that
+                // materialized on disk. There is nothing to link a file to
+                // itself, and removing it to re-link would destroy the group's
+                // sole copy. The Unix quick-check below catches this via a
+                // dev/ino match, but Windows metadata exposes no inode, so guard
+                // the self-link case explicitly on every platform.
+                if link_path == leader_path {
+                    continue;
+                }
+
                 // Quick-check: if destination already hard-links to the leader, skip.
                 //
                 // SEC-1.f: the `link_path` stat goes through the sandbox

--- a/crates/transfer/src/receiver/tests/hard_links.rs
+++ b/crates/transfer/src/receiver/tests/hard_links.rs
@@ -143,6 +143,92 @@ fn create_hardlinks_multiple_groups() {
     );
 }
 
+/// When a `-H` group's leader is absent on disk (its own transfer errored or
+/// was skipped) but another group member did materialize, upstream promotes
+/// that present member to a "virtual first" and links the rest to it rather
+/// than aborting. This mirrors upstream `hlink.c`: `skip_hard_link()`
+/// (hlink.c:546-565) flags the absent leader `FLAG_SKIP_HLINK`, `check_prior()`
+/// (hlink.c:246-282) walks past it to the next present member, and
+/// `hard_link_check()` (hlink.c:299-310) promotes it. Before this fix the
+/// receiver recorded the absent leader unconditionally and `fast_io::hard_link`
+/// returned ENOENT, which propagated as a fatal receiver abort.
+#[test]
+fn create_hardlinks_promotes_present_member_when_leader_absent() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    // The leader's transfer errored: its file is absent. A later group member
+    // ("present.txt") did land on disk and must become the promoted leader.
+    std::fs::write(dest.join("present.txt"), "promoted payload").unwrap();
+
+    let entries = vec![
+        make_hlink_leader("leader.txt", 16, 91),
+        make_hlink_follower("present.txt", 16, 91),
+        make_hlink_follower("orphan.txt", 16, 91),
+    ];
+
+    let mut ctx = receiver_with_hardlinks(entries);
+    let mut writer = TestDeletionWriter;
+    // Must NOT abort: create_hardlinks returns Ok even though leader.txt is gone.
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
+
+    assert!(
+        !dest.join("leader.txt").exists(),
+        "absent leader must not be resurrected"
+    );
+    let orphan = dest.join("orphan.txt");
+    assert!(
+        orphan.exists(),
+        "remaining follower must be linked to the promoted member"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&orphan).unwrap(),
+        "promoted payload"
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let present_ino = std::fs::metadata(dest.join("present.txt")).unwrap().ino();
+        let orphan_ino = std::fs::metadata(&orphan).unwrap().ino();
+        assert_eq!(
+            present_ino, orphan_ino,
+            "orphan must hard-link to the promoted member's inode"
+        );
+    }
+}
+
+/// When a `-H` group's leader is absent and no other member materialized, the
+/// group has no data to link. Upstream leaves it unlinked (the earlier transfer
+/// error already set io_error); the receiver must record a soft error and keep
+/// going, never abort with a fatal ENOENT. upstream: hlink.c:299-310 virtual
+/// first with no present member; `maybe_hard_link()` failure is non-fatal.
+#[test]
+fn create_hardlinks_leader_absent_no_members_is_non_fatal() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    // Nothing on disk: the whole group failed to transfer.
+    let entries = vec![
+        make_hlink_leader("leader.txt", 8, 55),
+        make_hlink_follower("follower.txt", 8, 55),
+    ];
+
+    let mut ctx = receiver_with_hardlinks(entries);
+    let mut writer = TestDeletionWriter;
+    // Must NOT abort.
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
+
+    assert!(
+        !dest.join("follower.txt").exists(),
+        "follower must not be created when no group member has data"
+    );
+    assert_ne!(
+        ctx.flist_io_error, 0,
+        "an unlinkable hardlink group must set a soft I/O error (RERR_PARTIAL)"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn create_hardlinks_skips_already_linked() {


### PR DESCRIPTION
## Problem

When a `-H` hardlink group's leader is present in the file list but does not
materialize on disk (its own transfer errored, or was skipped), the receiver
still recorded that leader's destination path unconditionally and then linked
every follower to it. `fast_io::hard_link` returned `ENOENT`, which was
classified as a fatal error and aborted the receiver (exit 12). This was
reachable on any per-file transfer error inside a `-H` group.

## Upstream behaviour (rsync 3.4.4, `hlink.c`)

Upstream promotes a present group member to a "virtual first" instead of
aborting:

- `skip_hard_link()` (hlink.c:546-565) sets `FLAG_SKIP_HLINK` on a member that
  was not transferred.
- `check_prior()` (hlink.c:246-282) walks the group's `F_HL_PREV` chain past
  every `FLAG_SKIP_HLINK` member to find the next still-present one.
- `hard_link_check()` (hlink.c:299-310) promotes that member to the group's
  link source; the remaining members link to it. `maybe_hard_link()` failure is
  non-fatal (sets `io_error`, drives a non-zero exit, never a fatal desync).

## Fix

In `create_hardlinks` (`receiver/directory/links.rs`):

1. First pass now records a leader only if its file actually materialized on
   disk. An absent leader is left unrecorded (mirrors `FLAG_SKIP_HLINK`).
2. New `promote_hardlink_leader()` mirrors `check_prior()`: when the recorded
   leader is absent, it walks the group in list order and promotes the first
   member present on disk, recording it so the remaining followers reuse it.
3. When no member of the group materialized, the group is left unlinked with a
   soft `IOERR_GENERAL` (RERR_PARTIAL, exit 23) - never a fatal abort.
4. A follower `hard_link` that returns `NotFound` (the resolved leader vanished
   after we stat'd it) is now a soft error, not a fatal receiver desync.

## Tests

Two deterministic tests in `receiver/tests/hard_links.rs`, each citing
`hlink.c`:

- `create_hardlinks_promotes_present_member_when_leader_absent` - leader absent,
  a follower present: asserts the remaining follower is promoted/linked (shares
  the promoted member's inode on Unix) and the call does not abort. Fails on the
  pre-fix code (fatal ENOENT).
- `create_hardlinks_leader_absent_no_members_is_non_fatal` - leader absent, no
  member present: asserts the call does not abort and records a soft I/O error.

`cargo fmt --all -- --check`, `cargo clippy -p transfer -p engine
--all-features --all-targets --no-deps -- -D warnings`, and the targeted
`nextest` run all pass.

## Note (out of scope)

`create_hardlinks` does not re-consult `--existing` / `--ignore-existing` /
`--max-size` per follower; upstream filters those per-member in the generator
before linking. This is a pre-existing divergence unrelated to this fix and is
left untouched to keep the change surgical.
