### PR TITLE
fix(engine): mirror upstream backup-dir intermediate handling

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -34,12 +34,12 @@ use super::{
     LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind, LocalCopyExecution,
     LocalCopyMetadata, LocalCopyOptions, LocalCopyProgress, LocalCopyRecord,
     LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary, NestedDirMerge, ReferenceDirectory,
-    SparseWriteState, compute_backup_path, copy_entry_to_backup, delete_extraneous_entries,
-    filter_program_local_error, follow_symlink_metadata, load_dir_merge_rules_recursive,
-    map_metadata_error, record_directory_subtree, remove_source_entry_if_requested,
-    resolve_dir_merge_path, should_skip_copy, symlink_target_is_safe, trace_make_backup_copy,
-    trace_make_backup_device, trace_make_backup_rename, trace_make_backup_symlink,
-    write_sparse_chunk,
+    SparseWriteState, compute_backup_path, copy_entry_to_backup, create_backup_parents,
+    delete_extraneous_entries, filter_program_local_error, follow_symlink_metadata,
+    load_dir_merge_rules_recursive, map_metadata_error, record_directory_subtree,
+    remove_source_entry_if_requested, resolve_dir_merge_path, should_skip_copy,
+    symlink_target_is_safe, trace_make_backup_copy, trace_make_backup_device,
+    trace_make_backup_rename, trace_make_backup_symlink, write_sparse_chunk,
 };
 use crate::delta::DeltaSignatureIndex;
 use crate::signature::SignatureBlock;

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -842,8 +842,15 @@ impl<'a> CopyContext<'a> {
         if let Some(parent) = backup_path.parent()
             && !parent.as_os_str().is_empty()
         {
-            fs::create_dir_all(parent)
-                .map_err(|error| LocalCopyError::io("create backup directory", parent, error))?;
+            // upstream: backup.c:copy_valid_path() - create any new backup
+            // subdirectories, mirroring the source dir attrs onto each and
+            // clearing non-directory obstructions.
+            create_backup_parents(
+                self.destination_root(),
+                self.options.backup_directory(),
+                parent,
+                &self.metadata_options(),
+            )?;
         }
 
         // Track which backup strategy succeeded so we can emit the matching
@@ -1048,8 +1055,15 @@ impl<'a> CopyContext<'a> {
         if let Some(parent) = backup_path.parent()
             && !parent.as_os_str().is_empty()
         {
-            fs::create_dir_all(parent)
-                .map_err(|error| LocalCopyError::io("create backup directory", parent, error))?;
+            // upstream: backup.c:copy_valid_path() - create any new backup
+            // subdirectories, mirroring the source dir attrs onto each and
+            // clearing non-directory obstructions.
+            create_backup_parents(
+                self.destination_root(),
+                self.options.backup_directory(),
+                parent,
+                &self.metadata_options(),
+            )?;
         }
 
         // upstream: generator.c:1866 copy_file() - duplicate the pre-image; the

--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -77,6 +77,138 @@ pub fn compute_backup_path(
     base
 }
 
+/// Creates the intermediate directories leading to a backup path, mirroring
+/// upstream's `copy_valid_path` (backup.c:61-154).
+///
+/// For each path element that does not yet exist, a directory is created and -
+/// when `--backup-dir` is in use - the corresponding destination directory's
+/// mode/owner/mtime is copied onto it, exactly as upstream does after each
+/// `do_mkdir_at` via `x_stat` + `make_file` + `set_file_attrs`
+/// (backup.c:101-142). Pre-existing directories are left untouched, matching
+/// upstream's `EEXIST`/`validate_backup_dir` skip (backup.c:102-105).
+///
+/// A path element that exists but is not a directory is cleared before the
+/// directory is created, mirroring `validate_backup_dir` (backup.c:48-53),
+/// where a non-directory triggers `delete_item(...DEL_FOR_BACKUP|DEL_RECURSE)`
+/// so the element can be recreated as a directory.
+///
+/// When `--backup-dir` is not set the backup lands alongside the destination
+/// and every element already exists, so no directory is created and no
+/// attribute copy is performed (upstream only runs `copy_valid_path` when
+/// `backup_dir` is set - backup.c:159).
+pub(crate) fn create_backup_parents(
+    destination_root: &Path,
+    backup_dir: Option<&Path>,
+    parent: &Path,
+    metadata_options: &::metadata::MetadataOptions,
+) -> Result<(), LocalCopyError> {
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+
+    // Without --backup-dir the backup lands alongside the destination and its
+    // parent already exists; upstream runs no copy_valid_path here (backup.c:159
+    // vs :179), so a plain create_dir_all suffices with no attribute copy.
+    let Some(backup_dir) = backup_dir else {
+        return fs::create_dir_all(parent)
+            .map_err(|error| LocalCopyError::io("create backup directory", parent, error));
+    };
+
+    // Root of the backup tree. Only the relative portion *below* this root is
+    // validated and created element-by-element - mirroring upstream, which
+    // walks `rel = backup_dir_buf + backup_dir_len` (backup.c:67) and never
+    // re-validates the pre-existing path above backup_dir. Walking from the
+    // filesystem root instead would misread symlinked ancestors (e.g. macOS
+    // `/var` -> `/private/var`) as obstructions.
+    let backup_root = if backup_dir.is_absolute() {
+        backup_dir.to_path_buf()
+    } else {
+        destination_root.join(backup_dir)
+    };
+
+    // upstream: backup.c:165 make_path(backup_dir_buf, 0) - ensure the backup
+    // directory root exists (with default perms) before validating subdirs.
+    fs::create_dir_all(&backup_root)
+        .map_err(|error| LocalCopyError::io("create backup directory", &backup_root, error))?;
+
+    let Ok(rel) = parent.strip_prefix(&backup_root) else {
+        // parent is not under backup_root (unexpected path shape); fall back to
+        // a plain create so the backup still lands somewhere valid.
+        return fs::create_dir_all(parent)
+            .map_err(|error| LocalCopyError::io("create backup directory", parent, error));
+    };
+
+    let mut current = backup_root.clone();
+    for component in rel.components() {
+        current.push(component.as_os_str());
+        match fs::symlink_metadata(&current) {
+            Ok(meta) if meta.is_dir() => continue,
+            // upstream: backup.c:48-53 - a non-directory (including a symlink) in
+            // the way is removed so it can be recreated as a directory.
+            Ok(_) => remove_backup_obstruction(&current)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(LocalCopyError::io(
+                    "stat backup directory",
+                    current.as_path(),
+                    error,
+                ));
+            }
+        }
+
+        fs::create_dir(&current).map_err(|error| {
+            LocalCopyError::io("create backup directory", current.as_path(), error)
+        })?;
+
+        apply_backup_dir_attrs(destination_root, &backup_root, &current, metadata_options);
+    }
+
+    Ok(())
+}
+
+/// Removes a non-directory that obstructs a backup directory element.
+///
+/// A non-directory is never a recursive tree, so a plain unlink mirrors
+/// upstream's `delete_item` for this case (backup.c:50). `remove_file` also
+/// removes a symlink without following it, matching the `lstat`-based check.
+fn remove_backup_obstruction(path: &Path) -> Result<(), LocalCopyError> {
+    fs::remove_file(path)
+        .map_err(|error| LocalCopyError::io("remove backup directory obstruction", path, error))
+}
+
+/// Copies a freshly-created backup subdirectory's attributes from the
+/// corresponding destination directory, mirroring backup.c:115-138.
+///
+/// The backup subdirectory at `<backup_root>/<rel>` inherits from the
+/// destination directory at `<destination_root>/<rel>`, matching upstream's
+/// `x_stat(rel, ...)` where `rel` is the relative path under the transfer's
+/// destination cwd (backup.c:67,117).
+///
+/// Best-effort: upstream logs and continues when the source stat or attribute
+/// application fails (backup.c:117-118, 121-122), so a missing or unreadable
+/// destination directory simply leaves the backup subdirectory with default
+/// permissions rather than aborting the transfer.
+fn apply_backup_dir_attrs(
+    destination_root: &Path,
+    backup_root: &Path,
+    created: &Path,
+    metadata_options: &::metadata::MetadataOptions,
+) {
+    let Ok(rel) = created.strip_prefix(backup_root) else {
+        return;
+    };
+    if rel.as_os_str().is_empty() {
+        return;
+    }
+
+    let source_dir = destination_root.join(rel);
+    if let Ok(meta) = fs::symlink_metadata(&source_dir)
+        && meta.is_dir()
+    {
+        let _ = ::metadata::apply_file_metadata_with_options(created, &meta, metadata_options);
+    }
+}
+
 /// Copies a regular file, recreates a symlink, or re-materialises a
 /// device/FIFO/socket node at the backup path.
 ///

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -13,7 +13,7 @@ mod preallocate;
 mod sparse;
 
 pub use backup::compute_backup_path;
-pub(crate) use backup::copy_entry_to_backup;
+pub(crate) use backup::{copy_entry_to_backup, create_backup_parents};
 pub use backup_trace::{
     trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,
     trace_make_backup_rename, trace_make_backup_symlink,

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -23,7 +23,8 @@ pub(crate) use directory::{
 pub(crate) use file::take_fsync_call_count;
 pub(crate) use file::{
     CopyComparison, DEFAULT_XXH64_DEDUP_SIZE_LIMIT, SparseWriteState, copy_entry_to_backup,
-    copy_file, should_skip_copy, system_time_within_window, write_sparse_chunk,
+    copy_file, create_backup_parents, should_skip_copy, system_time_within_window,
+    write_sparse_chunk,
 };
 pub use file::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -2461,3 +2461,107 @@ fn backup_delete_skips_already_suffixed_extraneous_file() {
         "already-suffixed file must be unlinked, not re-backed-up to stale~~"
     );
 }
+
+/// #229: a nested `--backup-dir` must copy the corresponding destination
+/// directory's attributes onto each freshly-created backup subdirectory.
+///
+/// upstream: backup.c:copy_valid_path() (101-142) - after each `do_mkdir_at`
+/// upstream runs `x_stat` + `make_file` + `set_file_attrs(backup_dir_buf, ...)`
+/// so the backup subdirectory inherits mode/owner/mtime from the source-tree
+/// directory instead of defaulting to `0755 & ~umask`. Without the fix the
+/// created intermediate lands at the umask default, not the source dir's mode.
+#[test]
+#[cfg(unix)]
+fn backup_dir_intermediate_inherits_source_dir_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let source_dir = source.join("dir");
+    fs::create_dir_all(&source_dir).expect("create nested source");
+    fs::set_permissions(&source_dir, fs::Permissions::from_mode(0o700)).expect("chmod source dir");
+    fs::write(source_dir.join("file.txt"), b"new contents").expect("write source");
+
+    let dest_root = dest.join("source");
+    let dest_dir = dest_root.join("dir");
+    fs::create_dir_all(&dest_dir).expect("create dest dir");
+    fs::write(dest_dir.join("file.txt"), b"old contents").expect("write dest");
+    // The backup subdirectory must inherit *this* mode, proving it mirrors the
+    // destination-tree directory rather than the umask default.
+    fs::set_permissions(&dest_dir, fs::Permissions::from_mode(0o700)).expect("chmod dest dir");
+
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .permissions(true)
+        .with_backup_directory(Some(PathBuf::from("backups")));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let backup = dest.join("backups").join("source").join("dir").join("file.txt~");
+    assert!(backup.exists(), "backup missing at {}", backup.display());
+    assert_eq!(fs::read(&backup).expect("read backup"), b"old contents");
+
+    let backup_intermediate = dest.join("backups").join("source").join("dir");
+    let mode = fs::symlink_metadata(&backup_intermediate)
+        .expect("stat backup intermediate")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        mode, 0o700,
+        "backup intermediate must inherit the source dir's 0700, got {mode:o}"
+    );
+}
+
+/// #230: a non-directory obstructing a `--backup-dir` path element must be
+/// cleared so the element can be recreated as a directory.
+///
+/// upstream: backup.c:validate_backup_dir() (48-53) - when a backup path
+/// element exists but is not a directory, `delete_item(...DEL_FOR_BACKUP|
+/// DEL_RECURSE)` removes it before it is recreated. Without the fix
+/// `create_dir_all` fails with `NotADirectory` and the transfer aborts.
+#[test]
+fn backup_dir_clears_nondir_obstruction() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let source_dir = source.join("dir");
+    fs::create_dir_all(&source_dir).expect("create nested source");
+    fs::write(source_dir.join("file.txt"), b"new contents").expect("write source");
+
+    let dest_root = dest.join("source");
+    let dest_dir = dest_root.join("dir");
+    fs::create_dir_all(&dest_dir).expect("create dest dir");
+    fs::write(dest_dir.join("file.txt"), b"old contents").expect("write dest");
+
+    // Stale non-directory exactly where the backup tree needs a directory
+    // (backup path is dest/backups/source/dir/file.txt~).
+    let backups = dest.join("backups");
+    fs::create_dir_all(&backups).expect("create backups root");
+    let obstruction = backups.join("source");
+    fs::write(&obstruction, b"stale file").expect("write obstruction");
+
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default().with_backup_directory(Some(PathBuf::from("backups")));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("transfer must succeed after clearing the obstruction");
+
+    assert!(
+        obstruction.is_dir(),
+        "obstructing file must be replaced by a directory"
+    );
+    let backup = backups.join("source").join("dir").join("file.txt~");
+    assert!(backup.exists(), "backup missing at {}", backup.display());
+    assert_eq!(fs::read(&backup).expect("read backup"), b"old contents");
+}


### PR DESCRIPTION
## Summary

Fixes two `--backup-dir` parity gaps in the local-copy engine where the created
backup directory tree diverged from upstream rsync 3.4.4 (`backup.c`).

Both backup entry points previously created intermediate backup directories with
a bare `fs::create_dir_all(parent)`, which applied no metadata and aborted on a
non-directory in the way. Upstream's `copy_valid_path` does considerably more.

### Backup intermediates now mirror the source directory's attributes

Upstream `copy_valid_path` (`backup.c:101-142`), after each
`do_mkdir_at(..., ACCESSPERMS)`, runs `x_stat` + `make_file` +
`set_file_attrs(backup_dir_buf, ...)` so every freshly-created backup
subdirectory inherits mode/owner/mtime from the corresponding source-tree
directory. Without this, under `-a`/root with a nested `--backup-dir`, backup
subdirectories landed at `0755 & ~umask` with the umask owner/mtime instead of
the source directory's. Backup file contents were already correct; only the
created intermediate directories were affected.

The new `create_backup_parents` walks only the relative portion **below** the
backup-dir root (mirroring upstream's `rel = backup_dir_buf + backup_dir_len`,
`backup.c:67`) and copies the corresponding destination directory's attributes
onto each newly-created component. Pre-existing directories are left untouched,
matching upstream's `EEXIST` skip (`backup.c:102-105`).

### Non-directory obstructions in the backup tree are now cleared

Upstream `validate_backup_dir` (`backup.c:48-53`): when a backup path element
exists but is not a directory, `delete_item(...DEL_FOR_BACKUP|DEL_RECURSE)`
removes it so the element can be recreated as a directory. The old code returned
`NotADirectory` from `create_dir_all`, propagated a hard I/O error, and aborted
the transfer. The obstruction is now cleared and the mkdir retried.

## Upstream references

- `backup.c:38-55` `validate_backup_dir` - non-directory obstruction removal.
- `backup.c:61-154` `copy_valid_path` - per-component directory creation and
  attribute mirroring.
- `backup.c:101-142` - `do_mkdir_at` + `x_stat`/`make_file`/`set_file_attrs`.
- `backup.c:159-177` `get_backup_name` - `copy_valid_path` runs only with
  `--backup-dir`; `make_path` seeds the backup root with default perms.

## Tests

Two deterministic tests added to `crates/engine/src/local_copy/tests/backups.rs`
(run non-root):

- `backup_dir_intermediate_inherits_source_dir_permissions` - a nested
  `--backup-dir` transfer with a `0700` destination directory produces a backup
  intermediate directory at `0700`, not the umask default.
- `backup_dir_clears_nondir_obstruction` - a stale regular file where the backup
  tree needs a directory is cleared and the transfer succeeds instead of
  aborting.

`cargo fmt --all -- --check`, `cargo clippy -p engine --all-features
--all-targets --no-deps -- -D warnings`, and the full 123-test `engine` backup
suite all pass.
