### PR TITLE
fix(cli): CVS !-clear semantics and --from0 filter files

### DIFF
--- a/crates/cli/src/frontend/execution/drive/filters.rs
+++ b/crates/cli/src/frontend/execution/drive/filters.rs
@@ -23,6 +23,9 @@ use crate::frontend::filter_rules::{
 /// order, mirroring upstream options.c.
 pub(crate) struct FilterInputs {
     pub(crate) order: Vec<FilterOrderToken>,
+    /// `--from0`/`-0`: makes `--exclude-from`/`--include-from` files
+    /// NUL-delimited (upstream exclude.c:1501 parse_filter_file eol_nulls).
+    pub(crate) from0: bool,
 }
 
 /// Applies CLI-provided filter rules to the [`ClientConfigBuilder`].
@@ -43,6 +46,7 @@ where
     let mut filter_rules = Vec::new();
     let mut merge_stack = HashSet::new();
     let merge_base = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let from0 = inputs.from0;
 
     for token in inputs.order {
         let result = match token {
@@ -56,11 +60,13 @@ where
                 &mut filter_rules,
                 std::slice::from_ref(&file),
                 FilterRuleKind::Include,
+                from0,
             ),
             FilterOrderToken::ExcludeFrom(file) => append_filter_rules_from_files(
                 &mut filter_rules,
                 std::slice::from_ref(&file),
                 FilterRuleKind::Exclude,
+                from0,
             ),
             FilterOrderToken::Filter(rule) => push_filter_directive(
                 &mut filter_rules,

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -1015,6 +1015,7 @@ where
 
     let filter_inputs = filters::FilterInputs {
         order: filter_order,
+        from0,
     };
 
     let builder = match filters::apply_filters(builder, filter_inputs, stderr) {

--- a/crates/cli/src/frontend/filter_rules/cvs.rs
+++ b/crates/cli/src/frontend/filter_rules/cvs.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::Path;
 
-use core::client::{DirMergeEnforcedKind, DirMergeOptions, FilterRuleKind, FilterRuleSpec};
+use core::client::{DirMergeEnforcedKind, DirMergeOptions, FilterRuleSpec};
 use core::message::{Message, Role};
 use core::rsync_error;
 use protocol::SUPPORTED_PROTOCOL_BOUNDS;
@@ -49,18 +49,18 @@ pub(crate) fn cvs_default_exclude_rules() -> Result<Vec<FilterRuleSpec>, Message
         .map(|pattern| FilterRuleSpec::exclude((*pattern).to_owned()).with_perishable(perishable))
         .collect();
 
-    // upstream: exclude.c:1393-1402 scopes FILTRULE_CLEAR_LIST ('!') to the
-    // local list section. Parse ~/.cvsignore and $CVSIGNORE into per-scope
-    // buffers so a '!' inside either source cannot wipe the default
-    // CVS_EXCLUDE_PATTERNS already collected in `cvs_rules`.
+    // upstream: exclude.c:1340-1358 get_cvs_excludes() parses default_cvsignore(),
+    // $HOME/.cvsignore, and $CVSIGNORE into ONE shared cvs_filter_list. A bare
+    // '!' token keeps FILTRULE_CLEAR_LIST and pop_filter_list (exclude.c:1399)
+    // wipes the WHOLE list, including the built-in defaults collected before it.
+    // Parse both sources into the shared accumulator (not per-source buffers) so
+    // clearing semantics match upstream.
     if let Some(home) = env::var_os("HOME").filter(|value| !value.is_empty()) {
         let path = Path::new(&home).join(".cvsignore");
         match fs::read(&path) {
             Ok(contents) => {
                 let owned = String::from_utf8_lossy(&contents).into_owned();
-                let mut local = Vec::new();
-                append_cvsignore_tokens(&mut local, owned.split_whitespace());
-                cvs_rules.extend(local);
+                append_cvsignore_tokens(&mut cvs_rules, owned.split_whitespace());
             }
             Err(error) if error.kind() == ErrorKind::NotFound => {}
             Err(error) => {
@@ -75,9 +75,7 @@ pub(crate) fn cvs_default_exclude_rules() -> Result<Vec<FilterRuleSpec>, Message
 
     if let Some(value) = env::var_os("CVSIGNORE").filter(|value| !value.is_empty()) {
         let owned = value.to_string_lossy().into_owned();
-        let mut local = Vec::new();
-        append_cvsignore_tokens(&mut local, owned.split_whitespace());
-        cvs_rules.extend(local);
+        append_cvsignore_tokens(&mut cvs_rules, owned.split_whitespace());
     }
 
     Ok(cvs_rules)
@@ -93,37 +91,30 @@ where
             continue;
         }
 
+        // upstream: exclude.c:1122-1124 parse_rule_tok tentatively sets
+        // FILTRULE_CLEAR_LIST for a leading '!' in a NO_PREFIXES CVS list, but
+        // exclude.c:1322-1323 clears it again once len > 1. So a bare "!"
+        // (len == 1) keeps CLEAR_LIST and pop_filter_list (exclude.c:1399) wipes
+        // the whole shared cvs list, including the built-in defaults, whereas
+        // "!foo" (len > 1) is a LITERAL exclude of a file named "!foo" - the '!'
+        // stays in the pattern because NO_PREFIXES never advances past it.
         if trimmed == "!" {
             destination.clear();
             continue;
         }
 
-        if let Some(remainder) = trimmed.strip_prefix('!') {
-            if remainder.is_empty() {
-                continue;
-            }
-            remove_cvs_pattern(destination, remainder);
-            continue;
-        }
-
-        // upstream: exclude.c:1355-1357 get_cvs_excludes() - the `$HOME/.cvsignore`
-        // and `$CVSIGNORE` sources are parsed with a plain `rule_template(rflags)`,
-        // NOT the perishable template. Only the built-in `default_cvsignore()`
-        // list (exclude.c:1350) carries FILTRULE_PERISHABLE, so these rules must
-        // not be perishable.
+        // The `$HOME/.cvsignore` and `$CVSIGNORE` sources are parsed with a plain
+        // rule_template (exclude.c:1355-1357), NOT the perishable template; only
+        // the built-in default_cvsignore() list (exclude.c:1350) is perishable,
+        // so these literal excludes must not be perishable.
         destination.push(FilterRuleSpec::exclude(trimmed.to_owned()));
     }
-}
-
-fn remove_cvs_pattern(rules: &mut Vec<FilterRuleSpec>, pattern: &str) {
-    rules.retain(|rule| {
-        !(matches!(rule.kind(), FilterRuleKind::Exclude) && rule.pattern() == pattern)
-    });
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::client::FilterRuleKind;
 
     #[test]
     fn append_cvsignore_tokens_adds_basic_pattern() {
@@ -168,14 +159,30 @@ mod tests {
     }
 
     #[test]
-    fn append_cvsignore_tokens_handles_bang_removal() {
+    fn append_cvsignore_tokens_bare_bang_wipes_builtin_defaults() {
+        // upstream: exclude.c:1399 pop_filter_list - a bare "!" (len == 1 keeps
+        // FILTRULE_CLEAR_LIST) clears the ENTIRE shared cvs_filter_list. The
+        // built-in default_cvsignore() patterns collected before it MUST also be
+        // wiped, so a '!' in ~/.cvsignore or $CVSIGNORE removes the defaults too.
+        let mut rules = vec![
+            FilterRuleSpec::exclude("*.o".to_owned()),
+            FilterRuleSpec::exclude("core".to_owned()),
+        ];
+        append_cvsignore_tokens(&mut rules, ["!"].iter().copied());
+        assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn append_cvsignore_tokens_literal_bang_is_exclude_not_removal() {
+        // upstream: exclude.c:1322-1323 - "!foo" has len > 1, so the tentative
+        // FILTRULE_CLEAR_LIST is cleared and the token becomes a LITERAL exclude
+        // of a file named "!foo". It must NOT remove a prior exclude of "*.o".
         let mut rules = Vec::new();
-        append_cvsignore_tokens(&mut rules, ["*.o", "*.a", "*.so"].iter().copied());
-        assert_eq!(rules.len(), 3);
-        append_cvsignore_tokens(&mut rules, ["!*.a"].iter().copied());
+        append_cvsignore_tokens(&mut rules, ["*.o", "!*.o"].iter().copied());
         assert_eq!(rules.len(), 2);
         assert_eq!(rules[0].pattern(), "*.o");
-        assert_eq!(rules[1].pattern(), "*.so");
+        assert_eq!(rules[1].kind(), FilterRuleKind::Exclude);
+        assert_eq!(rules[1].pattern(), "!*.o");
     }
 
     #[test]
@@ -193,54 +200,5 @@ mod tests {
         assert_eq!(rules.len(), 2);
         assert_eq!(rules[0].pattern(), "*.o");
         assert_eq!(rules[1].pattern(), "*.a");
-    }
-
-    #[test]
-    fn remove_cvs_pattern_removes_matching_exclude() {
-        let mut rules = vec![
-            FilterRuleSpec::exclude("*.o".to_owned()),
-            FilterRuleSpec::exclude("*.a".to_owned()),
-        ];
-        remove_cvs_pattern(&mut rules, "*.o");
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].pattern(), "*.a");
-    }
-
-    #[test]
-    fn remove_cvs_pattern_preserves_non_matching() {
-        let mut rules = vec![
-            FilterRuleSpec::exclude("*.o".to_owned()),
-            FilterRuleSpec::exclude("*.a".to_owned()),
-        ];
-        remove_cvs_pattern(&mut rules, "*.xyz");
-        assert_eq!(rules.len(), 2);
-    }
-
-    #[test]
-    fn remove_cvs_pattern_preserves_include_rules() {
-        let mut rules = vec![
-            FilterRuleSpec::exclude("*.o".to_owned()),
-            FilterRuleSpec::include("*.o".to_owned()),
-        ];
-        remove_cvs_pattern(&mut rules, "*.o");
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].kind(), FilterRuleKind::Include);
-    }
-
-    #[test]
-    fn remove_cvs_pattern_removes_all_matching() {
-        let mut rules = vec![
-            FilterRuleSpec::exclude("*.o".to_owned()),
-            FilterRuleSpec::exclude("*.o".to_owned()),
-        ];
-        remove_cvs_pattern(&mut rules, "*.o");
-        assert!(rules.is_empty());
-    }
-
-    #[test]
-    fn remove_cvs_pattern_empty_rules() {
-        let mut rules: Vec<FilterRuleSpec> = Vec::new();
-        remove_cvs_pattern(&mut rules, "*.o");
-        assert!(rules.is_empty());
     }
 }

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -14,6 +14,7 @@ pub(crate) fn append_filter_rules_from_files(
     destination: &mut Vec<FilterRuleSpec>,
     files: &[OsString],
     kind: FilterRuleKind,
+    eol_nulls: bool,
 ) -> Result<(), Message> {
     if matches!(kind, FilterRuleKind::DirMerge) {
         let message = rsync_error!(
@@ -37,7 +38,7 @@ pub(crate) fn append_filter_rules_from_files(
     // file's rules locally so a `!` inside the file clears only that scope
     // and parent CLI rules survive.
     for path in files {
-        let patterns = load_filter_file_patterns(Path::new(path.as_os_str()))?;
+        let patterns = load_filter_file_patterns(Path::new(path.as_os_str()), eol_nulls)?;
         let mut local: Vec<FilterRuleSpec> = Vec::new();
         for pattern in patterns {
             if honor_old_prefixes {
@@ -69,9 +70,12 @@ pub(crate) fn append_filter_rules_from_files(
     Ok(())
 }
 
-pub(crate) fn load_filter_file_patterns(path: &Path) -> Result<Vec<String>, Message> {
+pub(crate) fn load_filter_file_patterns(
+    path: &Path,
+    eol_nulls: bool,
+) -> Result<Vec<String>, Message> {
     if path == Path::new("-") {
-        return read_filter_patterns_from_standard_input();
+        return read_filter_patterns_from_standard_input(eol_nulls);
     }
 
     let path_display = path.display().to_string();
@@ -81,7 +85,7 @@ pub(crate) fn load_filter_file_patterns(path: &Path) -> Result<Vec<String>, Mess
     })?;
 
     let mut reader = BufReader::new(file);
-    read_filter_patterns(&mut reader).map_err(|error| {
+    read_filter_patterns(&mut reader, eol_nulls).map_err(|error| {
         let text = format!("failed to read filter file '{path_display}': {error}");
         rsync_error!(1, text).with_role(Role::Client)
     })
@@ -112,11 +116,13 @@ pub(super) fn read_merge_from_standard_input() -> Result<String, Message> {
     Ok(buffer)
 }
 
-pub(crate) fn read_filter_patterns_from_standard_input() -> Result<Vec<String>, Message> {
+pub(crate) fn read_filter_patterns_from_standard_input(
+    eol_nulls: bool,
+) -> Result<Vec<String>, Message> {
     #[cfg(test)]
     if let Some(data) = take_filter_stdin_input() {
         let mut cursor = io::Cursor::new(data);
-        return read_filter_patterns(&mut cursor).map_err(|error| {
+        return read_filter_patterns(&mut cursor, eol_nulls).map_err(|error| {
             let text = format!("failed to read filter patterns from standard input: {error}");
             rsync_error!(1, text).with_role(Role::Client)
         });
@@ -124,28 +130,37 @@ pub(crate) fn read_filter_patterns_from_standard_input() -> Result<Vec<String>, 
 
     let stdin = io::stdin();
     let mut reader = stdin.lock();
-    read_filter_patterns(&mut reader).map_err(|error| {
+    read_filter_patterns(&mut reader, eol_nulls).map_err(|error| {
         let text = format!("failed to read filter patterns from standard input: {error}");
         rsync_error!(1, text).with_role(Role::Client)
     })
 }
 
-pub(super) fn read_filter_patterns<R: BufRead>(reader: &mut R) -> io::Result<Vec<String>> {
+pub(super) fn read_filter_patterns<R: BufRead>(
+    reader: &mut R,
+    eol_nulls: bool,
+) -> io::Result<Vec<String>> {
     let mut buffer = Vec::new();
     let mut patterns = Vec::new();
 
+    // upstream: exclude.c:1501 parse_filter_file - `if (eol_nulls? !ch : (ch ==
+    // '\n' || ch == '\r'))` splits records on NUL when --from0/-0 is set, so an
+    // exclude-from/include-from file becomes NUL-delimited and embedded newlines
+    // are literal pattern bytes (never stripped).
+    let delimiter = if eol_nulls { b'\0' } else { b'\n' };
+
     loop {
         buffer.clear();
-        let bytes_read = reader.read_until(b'\n', &mut buffer)?;
+        let bytes_read = reader.read_until(delimiter, &mut buffer)?;
 
         if bytes_read == 0 {
             break;
         }
 
-        if buffer.last() == Some(&b'\n') {
+        if buffer.last() == Some(&delimiter) {
             buffer.pop();
         }
-        if buffer.last() == Some(&b'\r') {
+        if !eol_nulls && buffer.last() == Some(&b'\r') {
             buffer.pop();
         }
 
@@ -188,7 +203,7 @@ mod tests {
     fn read_filter_patterns_parses_simple_lines() {
         let input = b"pattern1\npattern2\npattern3\n";
         let mut reader = Cursor::new(input.to_vec());
-        let result = read_filter_patterns(&mut reader).expect("read");
+        let result = read_filter_patterns(&mut reader, false).expect("read");
         assert_eq!(result, vec!["pattern1", "pattern2", "pattern3"]);
     }
 
@@ -196,7 +211,7 @@ mod tests {
     fn read_filter_patterns_skips_empty_lines() {
         let input = b"pattern1\n\npattern2\n";
         let mut reader = Cursor::new(input.to_vec());
-        let result = read_filter_patterns(&mut reader).expect("read");
+        let result = read_filter_patterns(&mut reader, false).expect("read");
         assert_eq!(result, vec!["pattern1", "pattern2"]);
     }
 
@@ -204,7 +219,7 @@ mod tests {
     fn read_filter_patterns_skips_hash_comments() {
         let input = b"pattern1\n# this is a comment\npattern2\n";
         let mut reader = Cursor::new(input.to_vec());
-        let result = read_filter_patterns(&mut reader).expect("read");
+        let result = read_filter_patterns(&mut reader, false).expect("read");
         assert_eq!(result, vec!["pattern1", "pattern2"]);
     }
 
@@ -212,7 +227,7 @@ mod tests {
     fn read_filter_patterns_skips_semicolon_comments() {
         let input = b"pattern1\n; this is a comment\npattern2\n";
         let mut reader = Cursor::new(input.to_vec());
-        let result = read_filter_patterns(&mut reader).expect("read");
+        let result = read_filter_patterns(&mut reader, false).expect("read");
         assert_eq!(result, vec!["pattern1", "pattern2"]);
     }
 
@@ -220,7 +235,7 @@ mod tests {
     fn read_filter_patterns_handles_crlf_line_endings() {
         let input = b"pattern1\r\npattern2\r\npattern3\r\n";
         let mut reader = Cursor::new(input.to_vec());
-        let result = read_filter_patterns(&mut reader).expect("read");
+        let result = read_filter_patterns(&mut reader, false).expect("read");
         assert_eq!(result, vec!["pattern1", "pattern2", "pattern3"]);
     }
 
@@ -228,7 +243,7 @@ mod tests {
     fn read_filter_patterns_handles_no_trailing_newline() {
         let input = b"pattern1\npattern2";
         let mut reader = Cursor::new(input.to_vec());
-        let result = read_filter_patterns(&mut reader).expect("read");
+        let result = read_filter_patterns(&mut reader, false).expect("read");
         assert_eq!(result, vec!["pattern1", "pattern2"]);
     }
 
@@ -236,7 +251,7 @@ mod tests {
     fn read_filter_patterns_handles_empty_input() {
         let input = b"";
         let mut reader = Cursor::new(input.to_vec());
-        let result = read_filter_patterns(&mut reader).expect("read");
+        let result = read_filter_patterns(&mut reader, false).expect("read");
         assert!(result.is_empty());
     }
 
@@ -244,7 +259,7 @@ mod tests {
     fn read_filter_patterns_handles_only_comments() {
         let input = b"# comment 1\n; comment 2\n";
         let mut reader = Cursor::new(input.to_vec());
-        let result = read_filter_patterns(&mut reader).expect("read");
+        let result = read_filter_patterns(&mut reader, false).expect("read");
         assert!(result.is_empty());
     }
 
@@ -252,7 +267,7 @@ mod tests {
     fn read_filter_patterns_handles_whitespace_only_lines() {
         let input = b"pattern1\n   \n\t\npattern2\n";
         let mut reader = Cursor::new(input.to_vec());
-        let result = read_filter_patterns(&mut reader).expect("read");
+        let result = read_filter_patterns(&mut reader, false).expect("read");
         assert_eq!(result, vec!["pattern1", "pattern2"]);
     }
 
@@ -260,7 +275,7 @@ mod tests {
     fn read_filter_patterns_preserves_leading_whitespace() {
         let input = b"  pattern_with_leading_space\n";
         let mut reader = Cursor::new(input.to_vec());
-        let result = read_filter_patterns(&mut reader).expect("read");
+        let result = read_filter_patterns(&mut reader, false).expect("read");
         assert_eq!(result, vec!["  pattern_with_leading_space"]);
     }
 
@@ -269,7 +284,7 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("filter.txt");
         std::fs::write(&path, "pattern1\npattern2\n").expect("write");
-        let result = load_filter_file_patterns(&path).expect("load");
+        let result = load_filter_file_patterns(&path, false).expect("load");
         assert_eq!(result, vec!["pattern1", "pattern2"]);
     }
 
@@ -277,7 +292,7 @@ mod tests {
     fn load_filter_file_patterns_fails_for_missing_file() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("nonexistent.txt");
-        let result = load_filter_file_patterns(&path);
+        let result = load_filter_file_patterns(&path, false);
         assert!(result.is_err());
     }
 
@@ -301,7 +316,7 @@ mod tests {
     #[test]
     fn read_filter_patterns_from_stdin_uses_test_input() {
         set_filter_stdin_input(b"stdin_pattern1\nstdin_pattern2\n".to_vec());
-        let result = read_filter_patterns_from_standard_input().expect("read");
+        let result = read_filter_patterns_from_standard_input(false).expect("read");
         assert_eq!(result, vec!["stdin_pattern1", "stdin_pattern2"]);
     }
 
@@ -315,7 +330,7 @@ mod tests {
     #[test]
     fn load_filter_file_patterns_handles_dash_path() {
         set_filter_stdin_input(b"stdin_pattern\n".to_vec());
-        let result = load_filter_file_patterns(Path::new("-")).expect("load");
+        let result = load_filter_file_patterns(Path::new("-"), false).expect("load");
         assert_eq!(result, vec!["stdin_pattern"]);
     }
 
@@ -329,6 +344,7 @@ mod tests {
             &mut rules,
             &[OsString::from(path)],
             FilterRuleKind::Include,
+            false,
         )
         .expect("append");
         assert_eq!(rules.len(), 2);
@@ -348,6 +364,7 @@ mod tests {
             &mut rules,
             &[OsString::from(path)],
             FilterRuleKind::Exclude,
+            false,
         )
         .expect("append");
         assert_eq!(rules.len(), 1);
@@ -358,7 +375,8 @@ mod tests {
     #[test]
     fn append_filter_rules_from_files_rejects_dir_merge() {
         let mut rules = Vec::new();
-        let result = append_filter_rules_from_files(&mut rules, &[], FilterRuleKind::DirMerge);
+        let result =
+            append_filter_rules_from_files(&mut rules, &[], FilterRuleKind::DirMerge, false);
         assert!(result.is_err());
     }
 
@@ -374,8 +392,51 @@ mod tests {
             &mut rules,
             &[OsString::from(path1), OsString::from(path2)],
             FilterRuleKind::Include,
+            false,
         )
         .expect("append");
         assert_eq!(rules.len(), 2);
+    }
+
+    #[test]
+    fn read_filter_patterns_splits_on_nul_when_eol_nulls() {
+        // upstream: exclude.c:1501 parse_filter_file - with eol_nulls (set by
+        // --from0/-0) records are split on NUL, so embedded newlines are literal
+        // pattern bytes and a NUL-delimited --exclude-from parses one rule per
+        // NUL-separated record rather than one per line.
+        let input = b"*.log\nwith space\0*.tmp\0";
+        let mut reader = Cursor::new(input.to_vec());
+        let result = read_filter_patterns(&mut reader, true).expect("read");
+        assert_eq!(result, vec!["*.log\nwith space", "*.tmp"]);
+    }
+
+    #[test]
+    fn read_filter_patterns_nul_mode_handles_no_trailing_nul() {
+        // upstream: exclude.c:1516-1517 - the final record before EOF is parsed
+        // even without a trailing delimiter.
+        let input = b"only\0last";
+        let mut reader = Cursor::new(input.to_vec());
+        let result = read_filter_patterns(&mut reader, true).expect("read");
+        assert_eq!(result, vec!["only", "last"]);
+    }
+
+    #[test]
+    fn append_filter_rules_from_files_honors_from0_nul_split() {
+        // upstream: exclude.c:1501 parse_filter_file - --exclude-from with
+        // --from0 reads NUL-delimited records; "a\nb" is one literal pattern.
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("exclude0.txt");
+        std::fs::write(&path, b"a\nb\0*.bak\0").expect("write");
+        let mut rules = Vec::new();
+        append_filter_rules_from_files(
+            &mut rules,
+            &[OsString::from(path)],
+            FilterRuleKind::Exclude,
+            true,
+        )
+        .expect("append");
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].pattern(), "a\nb");
+        assert_eq!(rules[1].pattern(), "*.bak");
     }
 }

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -161,7 +161,7 @@ pub(crate) use std::num::NonZeroU64;
 
 #[cfg(test)]
 pub(crate) fn load_filter_file_patterns(path: &Path) -> Result<Vec<String>, Message> {
-    filter_rules::load_filter_file_patterns(path)
+    filter_rules::load_filter_file_patterns(path, false)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/frontend/tests/transfer_request_with_filter.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_filter.rs
@@ -339,17 +339,18 @@ fn transfer_request_with_exclude_from_bang_preserves_parent_cli_rule() {
     assert!(!copied_root.join("skip.log").exists());
 }
 
-/// upstream: exclude.c:1393-1402 - `!` inside `~/.cvsignore` (or `$CVSIGNORE`)
-/// clears only that scope. The default CVS_EXCLUDE_PATTERNS already collected
-/// in the parent accumulator survive.
+/// upstream: exclude.c:1399 pop_filter_list - a bare `!` inside `$CVSIGNORE`
+/// (or `~/.cvsignore`) keeps FILTRULE_CLEAR_LIST and clears the ENTIRE shared
+/// cvs_filter_list, so the built-in CVS_EXCLUDE_PATTERNS collected before it
+/// (e.g. `core`) are wiped too. Only patterns added after the `!` survive.
 #[test]
-fn transfer_request_with_cvsignore_bang_preserves_default_cvs_patterns() {
+fn transfer_request_with_cvsignore_bang_wipes_default_cvs_patterns() {
     use tempfile::tempdir;
 
     let _env_lock = ENV_LOCK.lock().expect("env lock");
     let _home_guard = EnvGuard::set("HOME", OsStr::new(""));
-    // `$CVSIGNORE` is treated as a per-source scope just like ~/.cvsignore,
-    // so a leading `!` must not wipe the built-in CVS_EXCLUDE_PATTERNS.
+    // A leading bare `!` clears the whole shared CVS list, then `*.skip` is the
+    // only surviving exclude.
     let _cvs_guard = EnvGuard::set("CVSIGNORE", OsStr::new("! *.skip"));
 
     let tmp = tempdir().expect("tempdir");
@@ -358,7 +359,8 @@ fn transfer_request_with_cvsignore_bang_preserves_default_cvs_patterns() {
     std::fs::create_dir_all(&source_root).expect("create source root");
     std::fs::create_dir_all(&dest_root).expect("create dest root");
     std::fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
-    // `core` is one of the built-in CVS_EXCLUDE_PATTERNS and must remain excluded.
+    // `core` is a built-in CVS_EXCLUDE_PATTERN, but the bare `!` wipes it, so it
+    // must now be transferred.
     std::fs::write(source_root.join("core"), b"core dump").expect("write core");
     std::fs::write(source_root.join("drop.skip"), b"drop").expect("write skip");
 
@@ -378,8 +380,8 @@ fn transfer_request_with_cvsignore_bang_preserves_default_cvs_patterns() {
 
     let copied_root = dest_root.join("source");
     assert!(copied_root.join("keep.txt").exists());
-    // Default CVS pattern survived the `$CVSIGNORE` scope-local `!`.
-    assert!(!copied_root.join("core").exists());
+    // The built-in `core` pattern was wiped by the `$CVSIGNORE` bare `!`.
+    assert!(copied_root.join("core").exists());
     // `$CVSIGNORE`'s own pattern (after the `!`) still excludes `*.skip`.
     assert!(!copied_root.join("drop.skip").exists());
 }

--- a/crates/cli/src/frontend/tests/transfer_request_with_include.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_include.rs
@@ -28,6 +28,7 @@ fn transfer_request_with_include_from_reinstate_patterns() {
         &mut expected_rules,
         &[include_file.as_os_str().to_os_string()],
         FilterRuleKind::Include,
+        false,
     )
     .expect("load include patterns");
     expected_rules.push(FilterRuleSpec::exclude("*".to_owned()));


### PR DESCRIPTION
## Summary

Two filter-subsystem parity fixes in `crates/cli`, matching upstream rsync 3.4.4 (`exclude.c`). Two related items are deferred because their real fix sites live in `crates/core`.

## Done

### #217 - CVS `.cvsignore` / `$CVSIGNORE` `!` handling
Mirrors upstream `parse_rule_tok`. In a `FILTRULE_NO_PREFIXES` CVS list, a leading `!` tentatively sets `FILTRULE_CLEAR_LIST` (exclude.c:1122-1124), but `len > 1` clears it again (exclude.c:1315-1323), so:

- `!foo` is a **literal exclude** of a file named `!foo` (the `!` stays in the pattern because `NO_PREFIXES` never advances past it) - not a removal of a prior `foo` exclude.
- A **bare `!`** (`len == 1`) keeps `FILTRULE_CLEAR_LIST`, and `pop_filter_list` (exclude.c:1399) wipes the **whole shared** `cvs_filter_list`, including the built-in `default_cvsignore()` patterns.

The previous code invented a `remove_cvs_pattern` path (so `!foo` deleted a prior exclude) and cleared a per-source local buffer (so built-in defaults survived a bare `!`). Both are removed; `~/.cvsignore` and `$CVSIGNORE` now parse into the shared accumulator so a bare `!` wipes the built-ins too.

Files: `crates/cli/src/frontend/filter_rules/cvs.rs`; integration test in `transfer_request_with_filter.rs` rewritten to assert the correct wipe-includes-builtins behavior.

### #218 - `--from0` / eol_nulls for filter FILES
Upstream `parse_filter_file` splits on NUL when `eol_nulls` is set (exclude.c:1501: `if (eol_nulls? !ch : (ch=='\n'||ch=='\r')) break`), so `-0`/`--from0` makes `--exclude-from` / `--include-from` files NUL-delimited. The reader hardcoded `read_until(b'\n')`. The existing `--from0` flag is now threaded through `FilterInputs` -> `apply_filters` -> `append_filter_rules_from_files` -> `load_filter_file_patterns` -> `read_filter_patterns`, which splits on NUL and treats embedded newlines as literal pattern bytes.

Files: `crates/cli/src/frontend/filter_rules/sources.rs`, `execution/drive/filters.rs`, `execution/drive/workflow/run.rs`, `frontend/mod.rs`.

## Deferred (fix site outside crates/cli)

- **#219 - CVS `:C`/`-C` wire placement + proto>=29 gate.** Upstream injects `:C`/`-C` inside `send_filter_list` / `recv_filter_list` with `am_sender`/protocol ordering; the client-receiver adds them local-only, never on the wire, and gates `:C` on proto>=29 (exclude.c:1644-1698). In this codebase the wire send/recv path is `build_wire_format_rules` in `crates/core/src/client/remote/flags.rs` (core), not cli. Skipped per scope guard.
- **#222 - delete-excluded no-prefixes dir-merge elision.** Upstream `send_rules` elides a no-prefixes per-dir-merge under `delete_excluded` (exclude.c:1609-1612). The logic (`apply_implicit_sender_side_for_delete_excluded` and the wire elision in `build_wire_format_rules`) is in `crates/core/src/client/config/filters.rs` and `crates/core/src/client/remote/flags.rs` (core), not cli. Skipped per scope guard.

## Verification

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p cli --all-features --all-targets --no-deps -- -D warnings`: clean.
- Targeted `cargo nextest run -p cli` over filter/cvs/exclude/include tests: 433 passed.
