### PR TITLE
fix(core): fold files-from into config dirs() resolver

### DIFF
--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -2046,6 +2046,27 @@ fn dirs_sets_flag() {
     assert!(config.dirs());
 }
 
+// upstream: options.c:2190-2191 - `if (files_from) { if (xfer_dirs < 0)
+// xfer_dirs = 1; }`. A files-from run must resolve xfer_dirs on even when
+// `-d` was never passed, otherwise the bare directories named in the list hit
+// the `!xfer_dirs` guard (flist.c:2451) and are silently skipped.
+#[test]
+fn dirs_folds_in_files_from_when_flag_unset() {
+    let config = builder()
+        .files_from(FilesFromSource::LocalFile(PathBuf::from("/tmp/list")))
+        .build();
+    assert!(!config.recursive());
+    assert!(config.dirs());
+}
+
+// Absent a files-from source and without `-d`, xfer_dirs stays off, so the
+// fold-in must not leak into the default case.
+#[test]
+fn dirs_stays_off_without_files_from_or_flag() {
+    let config = builder().build();
+    assert!(!config.dirs());
+}
+
 #[test]
 fn one_file_system_sets_flag() {
     let config = builder().one_file_system(1).build();

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -528,11 +528,20 @@ impl ClientConfig {
     }
 
     /// Reports whether directory entries should be copied when recursion is disabled.
+    ///
+    /// Folds in `--files-from`: upstream forces `xfer_dirs = 1` whenever a
+    /// files-from source is active and `--dirs`/`--no-dirs` was left unset, so
+    /// the bare directories named in the list are transferred rather than
+    /// skipped by the `!xfer_dirs` guard in `flist.c:2451`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2190-2191` - `if (files_from) { if (xfer_dirs < 0) xfer_dirs = 1; }`
     #[must_use]
     #[doc(alias = "--dirs")]
     #[doc(alias = "-d")]
     pub const fn dirs(&self) -> bool {
-        self.dirs
+        self.dirs || self.files_from.is_active()
     }
 }
 

--- a/crates/core/src/client/config/enums/files_from.rs
+++ b/crates/core/src/client/config/enums/files_from.rs
@@ -86,7 +86,7 @@ pub struct FilesFromPlan {
 impl FilesFromSource {
     /// Returns `true` when a `--files-from` source has been configured.
     #[must_use]
-    pub fn is_active(&self) -> bool {
+    pub const fn is_active(&self) -> bool {
         !matches!(self, Self::None)
     }
 


### PR DESCRIPTION
## Summary

The config-level `dirs()` resolver (`ClientConfig::dirs`) returned the raw
`--dirs`/`-d` flag and ignored `--files-from`. Upstream rsync forces the
transfer-dirs behaviour on whenever a files-from source is active and the
directory flag was left unset, so a files-from-driven run that named bare
directories in its list silently skipped them.

Upstream reference (`options.c:2190-2191`):

    if (files_from) {
        if (recurse == 1) /* preserve recurse == 2 */
            recurse = 0;
        if (xfer_dirs < 0)
            xfer_dirs = 1;
    }

`xfer_dirs = 1` is what makes the directories named in the list transferable;
without it, `flist.c:2451` (`S_ISDIR(st.st_mode) && !xfer_dirs`) drops each bare
directory from the file list.

## Change

`ClientConfig::dirs()` now folds in the files-from source
(`self.dirs || self.files_from.is_active()`). Because this lives in the single
getter, every downstream consumer (server-flag forwarding, flist walk) observes
the corrected value from one source of truth. `FilesFromSource::is_active` is
made `const` so the getter stays `const fn`.

Scope is limited to the config dirs resolver; the flags/filters modules are
untouched.

## Tests

- `dirs_folds_in_files_from_when_flag_unset` - a config built with a files-from
  source and no `-d` resolves `dirs()` to true (encodes why: otherwise the bare
  directories hit the `!xfer_dirs` guard and are skipped).
- `dirs_stays_off_without_files_from_or_flag` - guards against the fold-in
  leaking into the default case.

`cargo fmt --all -- --check` and `cargo clippy -p core --all-features
--all-targets --no-deps -- -D warnings` are clean; the targeted core tests pass.
