### PR TITLE
fix(transfer): gate filter list on delete-excluded + elide no-prefix merge

### DIFF
--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -256,6 +256,68 @@ fn compression_level_to_i32(level: compress::zlib::CompressionLevel) -> i32 {
     }
 }
 
+/// Reports whether the receiver wants the transfer's filter list on the wire.
+///
+/// Upstream computes this identical predicate in both `send_filter_list()` (the
+/// client that transmits the list) and `recv_filter_list()` (the peer that reads
+/// it); keeping it in one place guarantees the two ends stay in lockstep, so a
+/// list is never half-sent. `--prune-empty-dirs` always needs the list;
+/// otherwise it is needed only for `--delete`, and then suppressed under
+/// `--delete-excluded` on a legacy peer because protocol < 29 cannot encode the
+/// sender-side modifier that keeps excluded entries deletable.
+///
+/// # Upstream Reference
+///
+/// `exclude.c:1647-1648` / `exclude.c:1676-1677` -
+/// `receiver_wants_list = prune_empty_dirs || (delete_mode && (!delete_excluded || protocol_version >= 29))`
+pub(crate) const fn receiver_wants_filter_list(
+    prune_empty_dirs: bool,
+    delete_mode: bool,
+    delete_excluded: bool,
+    protocol: protocol::ProtocolVersion,
+) -> bool {
+    prune_empty_dirs || (delete_mode && (!delete_excluded || protocol.as_u8() >= 29))
+}
+
+/// Reports whether a single wire filter rule is transmitted to the peer.
+///
+/// Mirrors the elision performed by upstream `send_rules()`: a rule restricted to
+/// the local side is applied here and never reaches the peer, and under
+/// `--delete-excluded` a no-prefixes per-directory merge (`:-`/`:+`) is elided
+/// from a push (the sender applies it locally) while still crossing the wire on a
+/// pull. Explicitly-sided merges (`:s-`/`:r-`) carry their side flag and are
+/// handled by the side-local check, so the no-prefix branch never adds a spurious
+/// `s` modifier - upstream `add_rule()` deliberately spares per-directory merges
+/// from the implicit sender-side flip.
+///
+/// # Upstream Reference
+///
+/// `exclude.c:1605-1612` (`send_rules`); `exclude.c:1330-1332` (`add_rule`).
+fn wire_rule_crosses_wire(
+    rule: &protocol::filters::FilterRuleWireFormat,
+    client_is_sender: bool,
+    delete_excluded: bool,
+) -> bool {
+    let side_local = if client_is_sender {
+        rule.sender_side
+    } else {
+        rule.receiver_side
+    };
+    if side_local {
+        return false;
+    }
+    if client_is_sender
+        && delete_excluded
+        && matches!(rule.rule_type, protocol::filters::RuleType::DirMerge)
+        && rule.no_prefixes
+        && !rule.sender_side
+        && !rule.receiver_side
+    {
+        return false;
+    }
+    true
+}
+
 /// Determines whether the output stream should use multiplexed framing.
 ///
 /// Upstream rsync activates multiplex output differently depending on
@@ -660,10 +722,20 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         writer.set_allowed_lull(Some(allowed_lull));
     }
 
-    // upstream: exclude.c:1650 - am_sender && !receiver_wants_list skips sending.
-    // Push mode applies exclusion locally in the generator; only delete/prune
-    // needs the filter list on the wire.
-    let receiver_wants_filter_list = config.flags.delete || config.flags.prune_empty_dirs;
+    // upstream: exclude.c:1647-1648 send_filter_list() -
+    //   receiver_wants_list = prune_empty_dirs
+    //       || (delete_mode && (!delete_excluded || protocol_version >= 29));
+    // Push mode applies exclusion locally in the generator; the receiver only
+    // needs the filter list for --prune-empty-dirs or --delete. Under
+    // --delete-excluded on a legacy peer (protocol < 29) the list is suppressed:
+    // the pre-29 wire cannot encode the sender-side modifier that keeps excluded
+    // entries deletable, so upstream neither sends nor reads it there.
+    let receiver_wants_filter_list = receiver_wants_filter_list(
+        config.flags.prune_empty_dirs,
+        config.flags.delete,
+        config.deletion.delete_excluded,
+        handshake.protocol,
+    );
 
     // upstream: main.c:1258 - daemon sender always calls recv_filter_list(f_in).
     let should_send_filter_list = if config.connection.client_mode {
@@ -677,28 +749,18 @@ pub fn run_server_with_handshake_adopting<W: Write>(
 
     if should_send_filter_list {
         // upstream: exclude.c:1605-1614 send_rules() elides any rule that applies
-        // to the local side only, so the peer never sees it. On a pull (client is
-        // the receiver) a receiver-side (`r`) rule is applied locally in the
-        // deletion pass and must NOT reach the sender - otherwise the sender would
-        // wrongly drop the matching file from the transfer (this is exactly the
-        // upstream `elide == LOCAL_RULE -> continue` case). Symmetrically, on a
-        // push (client is the sender) a sender-side (`s`) rule is applied locally
-        // by the generator and must not reach the remote receiver, where it would
-        // wrongly protect a matching destination file from --delete. A both-sided
-        // rule (neither flag set) is always sent. The local deletion chain reads
-        // `config.connection.filter_rules` directly (receiver/transfer/setup),
-        // so this elision changes only the bytes placed on the wire.
+        // to the local side only (and, under --delete-excluded, any no-prefix
+        // per-directory merge on a push) so the peer never sees it - see
+        // wire_rule_crosses_wire(). The local deletion chain reads
+        // `config.connection.filter_rules` directly (receiver/transfer/setup), so
+        // this elision changes only the bytes placed on the wire.
         let client_is_sender = config.role == ServerRole::Generator;
         let wire_rules: Vec<protocol::filters::FilterRuleWireFormat> = config
             .connection
             .filter_rules
             .iter()
             .filter(|rule| {
-                if client_is_sender {
-                    !rule.sender_side
-                } else {
-                    !rule.receiver_side
-                }
+                wire_rule_crosses_wire(rule, client_is_sender, config.deletion.delete_excluded)
             })
             .cloned()
             .collect();

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -739,14 +739,27 @@ impl ReceiverContext {
 
     /// Determines if filter list should be read from sender.
     ///
-    /// For a daemon receiver, the filter list is only read when:
-    /// - `prune_empty_dirs` is enabled, OR
-    /// - `delete_mode` is enabled
+    /// For a daemon receiver, the filter list is only read when
+    /// `--prune-empty-dirs` is active, or `--delete` is active and either
+    /// `--delete-excluded` is off or the negotiated protocol is >= 29. This
+    /// mirrors upstream `recv_filter_list()`'s `receiver_wants_list` and must
+    /// stay in lockstep with the sender's `send_filter_list()` gate so both ends
+    /// agree on whether a list crosses the wire.
     ///
     /// In client mode, skip reading because the client already sent filters to the daemon.
+    ///
+    /// # Upstream Reference
+    ///
+    /// `exclude.c:1676-1677` -
+    /// `receiver_wants_list = prune_empty_dirs || (delete_mode && (!delete_excluded || protocol_version >= 29))`
     #[must_use]
     pub(in crate::receiver) const fn should_read_filter_list(&self) -> bool {
-        let receiver_wants_list = self.config.flags.delete || self.config.flags.prune_empty_dirs;
+        let receiver_wants_list = crate::receiver_wants_filter_list(
+            self.config.flags.prune_empty_dirs,
+            self.config.flags.delete,
+            self.config.deletion.delete_excluded,
+            self.protocol,
+        );
         !self.config.connection.client_mode && receiver_wants_list
     }
 

--- a/crates/transfer/src/tests/filter_list_gate.rs
+++ b/crates/transfer/src/tests/filter_list_gate.rs
@@ -1,0 +1,169 @@
+//! Tests for the filter-list wire gate and per-rule send elision.
+//!
+//! These encode upstream's `send_filter_list()` / `recv_filter_list()` contract
+//! from `exclude.c`: the `receiver_wants_list` predicate that decides whether a
+//! filter list crosses the wire at all, and the `send_rules()` elision that
+//! drops rules the peer must never see. The value of matching upstream here is
+//! wire fidelity - a mismatched gate makes one end send (or read) a list the
+//! other end does not, corrupting the stream, and a leaked rule wrongly protects
+//! or drops files during `--delete`.
+
+use protocol::ProtocolVersion;
+use protocol::filters::{FilterRuleWireFormat, RuleType};
+
+use crate::{receiver_wants_filter_list, wire_rule_crosses_wire};
+
+// -- receiver_wants_list truth table (exclude.c:1647-1648, 1676-1677) --
+
+/// `--prune-empty-dirs` always needs the list, independent of delete flags and
+/// protocol, because the sender cannot prune empty dirs without the receiver's
+/// rules. upstream: `prune_empty_dirs ||` short-circuits the whole expression.
+#[test]
+fn prune_empty_dirs_always_wants_list() {
+    for proto in [ProtocolVersion::V28, ProtocolVersion::V32] {
+        assert!(receiver_wants_filter_list(true, false, false, proto));
+        assert!(receiver_wants_filter_list(true, true, true, proto));
+    }
+}
+
+/// With neither `--delete` nor `--prune-empty-dirs`, no list is wanted: push
+/// mode applies excludes locally in the generator.
+#[test]
+fn no_delete_no_prune_wants_no_list() {
+    assert!(!receiver_wants_filter_list(
+        false,
+        false,
+        false,
+        ProtocolVersion::V32
+    ));
+}
+
+/// `--delete` without `--delete-excluded` always wants the list so the receiver
+/// can honour the same excludes during its deletion pass.
+#[test]
+fn delete_without_excluded_wants_list_every_protocol() {
+    for proto in [
+        ProtocolVersion::V28,
+        ProtocolVersion::V29,
+        ProtocolVersion::V32,
+    ] {
+        assert!(receiver_wants_filter_list(false, true, false, proto));
+    }
+}
+
+/// The regression this restores: `--delete --delete-excluded` on protocol >= 29
+/// still wants the list (the sender-side modifier is encodable), but on a legacy
+/// protocol < 29 peer it must NOT - the pre-29 wire cannot carry the `s`
+/// modifier, so upstream neither sends nor reads the list. Dropping the
+/// `(!delete_excluded || protocol_version >= 29)` gate made oc send/read an extra
+/// list against a legacy peer, desyncing the stream.
+#[test]
+fn delete_excluded_gates_on_protocol_29() {
+    // protocol >= 29: list still wanted.
+    assert!(receiver_wants_filter_list(
+        false,
+        true,
+        true,
+        ProtocolVersion::V29
+    ));
+    assert!(receiver_wants_filter_list(
+        false,
+        true,
+        true,
+        ProtocolVersion::V32
+    ));
+    // protocol < 29: list suppressed.
+    assert!(!receiver_wants_filter_list(
+        false,
+        true,
+        true,
+        ProtocolVersion::V28
+    ));
+}
+
+// -- send_rules per-rule elision (exclude.c:1605-1612) --
+
+fn dir_merge(no_prefixes: bool) -> FilterRuleWireFormat {
+    FilterRuleWireFormat {
+        rule_type: RuleType::DirMerge,
+        no_prefixes,
+        ..FilterRuleWireFormat::default()
+    }
+}
+
+/// A both-sided no-prefix per-directory merge (`:-`) is elided from a PUSH under
+/// `--delete-excluded` (upstream `elide = am_sender ? LOCAL_RULE`), because the
+/// sender applies it locally. Before the fix, oc converted the implicit
+/// sender-side flag only for include/exclude rules, so this merge still crossed
+/// the wire on a push.
+#[test]
+fn no_prefix_dir_merge_elided_on_push_under_delete_excluded() {
+    let rule = dir_merge(true);
+    assert!(!wire_rule_crosses_wire(&rule, true, true));
+}
+
+/// On a PULL the same rule is REMOTE_RULE and still crosses the wire, WITHOUT a
+/// side modifier - the remote sender needs it. upstream `add_rule` spares
+/// per-directory merges from the implicit sender-side flip, so the pull encoding
+/// must stay both-sided (this is why the fix elides rather than marking `s`).
+#[test]
+fn no_prefix_dir_merge_transmitted_on_pull_under_delete_excluded() {
+    let rule = dir_merge(true);
+    assert!(wire_rule_crosses_wire(&rule, false, true));
+}
+
+/// A prefixed `:` merge (has prefixes) is never elided - only no-prefix merges
+/// can be reduced to bare include/excludes and applied locally.
+#[test]
+fn prefixed_dir_merge_not_elided_under_delete_excluded() {
+    let rule = dir_merge(false);
+    assert!(wire_rule_crosses_wire(&rule, true, true));
+}
+
+/// Without `--delete-excluded`, a no-prefix dir-merge is transmitted normally on
+/// both directions.
+#[test]
+fn no_prefix_dir_merge_transmitted_without_delete_excluded() {
+    let rule = dir_merge(true);
+    assert!(wire_rule_crosses_wire(&rule, true, false));
+    assert!(wire_rule_crosses_wire(&rule, false, false));
+}
+
+/// Side-local rules are always elided toward the peer regardless of
+/// `--delete-excluded`: a sender-side rule is dropped on a push, a receiver-side
+/// rule on a pull (upstream `elide == LOCAL_RULE -> continue`).
+#[test]
+fn side_local_rules_are_elided() {
+    let sender_side = FilterRuleWireFormat {
+        rule_type: RuleType::Exclude,
+        sender_side: true,
+        ..FilterRuleWireFormat::default()
+    };
+    assert!(!wire_rule_crosses_wire(&sender_side, true, false));
+    assert!(wire_rule_crosses_wire(&sender_side, false, false));
+
+    let receiver_side = FilterRuleWireFormat {
+        rule_type: RuleType::Exclude,
+        receiver_side: true,
+        ..FilterRuleWireFormat::default()
+    };
+    assert!(wire_rule_crosses_wire(&receiver_side, true, false));
+    assert!(!wire_rule_crosses_wire(&receiver_side, false, false));
+}
+
+/// An explicitly sender-sided no-prefix merge (`:s-`) is handled by the
+/// side-local check on a push, and the no-prefix branch must not also fire (it
+/// requires neither side flag), so no spurious `s` doubling occurs.
+#[test]
+fn explicitly_sided_no_prefix_merge_uses_side_check() {
+    let rule = FilterRuleWireFormat {
+        rule_type: RuleType::DirMerge,
+        no_prefixes: true,
+        sender_side: true,
+        ..FilterRuleWireFormat::default()
+    };
+    // Push: elided via the side-local check.
+    assert!(!wire_rule_crosses_wire(&rule, true, true));
+    // Pull: sender-side rule still crosses to the remote sender.
+    assert!(wire_rule_crosses_wire(&rule, false, true));
+}

--- a/crates/transfer/src/tests/mod.rs
+++ b/crates/transfer/src/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod allow_inc_recurse;
 mod config;
+mod filter_list_gate;
 mod multiplex_protocol_version;
 mod negotiated_algorithms;
 mod transfer_pipeline_wiring;


### PR DESCRIPTION
## Summary

Restores two upstream rsync invariants that govern whether (and which) filter
rules cross the wire, so the transferred filter list is byte-for-byte identical
to upstream 3.4.4. Both fixes live in `crates/transfer`, where the wire gate and
per-rule send elision actually reside.

### #221 - `receiver_wants_list` formula

Upstream computes the identical predicate in both `send_filter_list()`
(`exclude.c:1647-1648`) and `recv_filter_list()` (`exclude.c:1676-1677`):

```
receiver_wants_list = prune_empty_dirs
    || (delete_mode && (!delete_excluded || protocol_version >= 29))
```

oc had dropped the `(!delete_excluded || protocol_version >= 29)` gate on both
sides (`delete || prune_empty_dirs`). Under `--delete-excluded` against a legacy
protocol < 29 peer, oc therefore sent (client send gate) and read (server recv
gate) an extra filter list the other end did not expect - the pre-29 wire cannot
encode the sender-side modifier that keeps excluded entries deletable, so
upstream neither transmits nor reads it. The predicate is now a single `const`
helper used by both the send gate (`lib.rs`) and the receiver read gate
(`receiver/context.rs`), keeping the two ends in lockstep.

### #222 - no-prefix dir-merge elision under `--delete-excluded`

Upstream `send_rules()` (`exclude.c:1609-1612`) elides a no-prefixes
per-directory merge (`:-` / `:+`) from a push under `--delete-excluded`
(`elide = am_sender ? LOCAL_RULE : REMOTE_RULE`): the sender applies it locally,
so it is omitted on a push but still transmitted on a pull. oc previously applied
the implicit sender-side conversion only to include/exclude rules, so a `:-`/`:+`
dir-merge still leaked onto the wire on a push.

The merge is now elided (omitted) on a push rather than marked sender-side,
because `add_rule()` (`exclude.c:1330-1332`) deliberately spares
`FILTRULE_PERDIR_MERGE` from the implicit sender-side flip - so the pull encoding
must stay both-sided with no `s` modifier. Explicitly-sided merges (`:s-`/`:r-`)
keep their side flag and are handled by the existing side-local elision.

### Tests

`crates/transfer/src/tests/filter_list_gate.rs` adds a deterministic truth table
for the wire gate (prune vs delete vs delete-excluded across the protocol-29
boundary) and for the per-rule elision (both transfer directions, prefixed vs
no-prefix merge, side-local rules), each annotated with the upstream cite and the
wire-fidelity reason the behavior matters.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p transfer --all-features --all-targets --no-deps -- -D warnings` clean
- `cargo nextest run -p transfer --all-features -E 'test(filter_list_gate)'` - 10/10 pass
- `cargo nextest run -p transfer --all-features --lib -E 'test(filter)|test(should_read)|test(prune)|test(delete)'` - 116/116 pass

## Scope note

The originating audit expected these fixes in `crates/core`. On current master the
wire gate (`run_server_with_handshake_adopting`) and the `send_rules` elision both
live in `crates/transfer/src/lib.rs`, with the server read gate in
`crates/transfer/src/receiver/context.rs`; `crates/core` only builds the wire-rule
vector and hands it to the transfer layer. The fixes are therefore in transfer.
No `crates/cli` edits were made.

## Deferred

- Keeping the CVS convenience rules (`-C` defaults and the `:C` per-dir
  `.cvsignore` merge) local-only on a pull instead of transmitting them, and
  gating `:C` on protocol >= 29, requires marking CVS-origin rules where they are
  expanded - which is in `crates/cli` (`frontend/filter_rules/cvs.rs` /
  `frontend/execution/drive/filters.rs`). That crate was out of scope, so this
  item is deferred: `crates/core`'s `build_wire_format_rules` cannot distinguish
  CVS-origin rules from user rules without a marker set by the CLI.
