### PR TITLE
fix(daemon): hold max-connections slots with fcntl record locks

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -83,6 +83,10 @@ tracing = { workspace = true, optional = true }
 [target.'cfg(not(windows))'.dependencies]
 checksums = { path = "../checksums" }
 libc = { workspace = true }
+# `process` enables nix::sys::prctl for PR_SET_NO_NEW_PRIVS startup hardening
+# (Linux only); `fs` enables nix::fcntl for the per-slot record locks in the
+# connection limiter, used on every unix target.
+nix = { workspace = true, features = ["process", "fs"] }
 
 # fast_io carries the Landlock LSM defense-in-depth helper (SEC-1.p). On
 # non-Linux targets the stub module compiles with the same public surface
@@ -106,8 +110,6 @@ seccompiler = { version = "0.5", optional = true }
 # Audit-clean per the unsafe-code policy: the crate's public API contains no
 # unsafe blocks the daemon needs to opt into.
 caps = "0.5"
-# `process` enables nix::sys::prctl for PR_SET_NO_NEW_PRIVS startup hardening.
-nix = { workspace = true, features = ["process"] }
 
 [target.'cfg(windows)'.dependencies]
 checksums = { path = "../checksums", default-features = false }

--- a/crates/daemon/src/daemon/module_state/connection_limiter.rs
+++ b/crates/daemon/src/daemon/module_state/connection_limiter.rs
@@ -1,10 +1,15 @@
-use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io;
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+#[cfg(windows)]
+use std::collections::BTreeMap;
+#[cfg(windows)]
+use std::io::{Read, Seek, SeekFrom, Write};
+
+#[cfg(windows)]
 use fs2::FileExt;
 
 use core::message::Role;
@@ -17,14 +22,30 @@ use super::runtime::ModuleConnectionError;
 /// Exit code used when daemon functionality is unavailable.
 const FEATURE_UNAVAILABLE_EXIT_CODE: i32 = 1;
 
-/// File-based connection limiter for cross-process max_connections enforcement.
+/// Width in bytes of a single connection slot in the lock file.
 ///
-/// Uses a shared lock file to coordinate connection counts across multiple
-/// daemon processes. Each module's active count is stored as a line in the file.
+/// upstream: connection.c:38 `lock_range(fd, i*4, 4)` reserves four bytes per
+/// slot, so slot `i` owns the byte range `[i*4, i*4+4)`. Matching the stride
+/// keeps oc-rsync interoperable with an upstream `rsync --daemon` that shares
+/// the same `lock file`.
+#[cfg(unix)]
+const SLOT_LEN: i64 = 4;
+
+/// File-based connection limiter for cross-process `max connections` enforcement.
 ///
-/// upstream: clientserver.c - `claim_connection()` uses `lp_lock_file()` with
-/// `flock()` to atomically check and increment the per-module connection count.
-/// The file format stores `module_name count` pairs, one per line.
+/// Each accepted connection holds an advisory record lock on a distinct byte
+/// range of the lock file for the lifetime of the connection. Because the
+/// kernel releases fcntl locks when the owning process dies - on clean exit,
+/// `SIGKILL`, or a `panic = "abort"` build - a crashed connection can never
+/// leak a slot. A new connection scans the ranges `[0, max_connections)` and
+/// claims the first one it can lock; if every range is held the module is at
+/// capacity.
+///
+/// upstream: connection.c:26 `claim_connection()` opens the lock file and calls
+/// `lock_range(fd, i*4, 4)` for each slot, returning success on the first range
+/// it locks. util1.c:632 `lock_range()` issues `fcntl(fd, F_SETLK, &lock)` with
+/// `l_type = F_WRLCK`. On Windows, which has no equivalent lock-on-death
+/// primitive, the limiter falls back to a counter serialised with `flock`.
 pub(crate) struct ConnectionLimiter {
     path: PathBuf,
 }
@@ -63,7 +84,105 @@ impl ConnectionLimiter {
         Ok(Self { path })
     }
 
+    /// Opens the lock file for read/write access.
+    fn open_file(&self) -> io::Result<File> {
+        OpenOptions::new().read(true).write(true).open(&self.path)
+    }
+}
+
+#[cfg(unix)]
+impl ConnectionLimiter {
     /// Acquires a connection slot for the named module, enforcing the limit.
+    ///
+    /// The `module` name is unused: upstream keys the slot pool by lock file,
+    /// not by module, so modules sharing a `lock file` share its slots
+    /// (rsyncd.conf(5), "lock file"). Isolation is obtained by giving a module
+    /// its own `lock file`, exactly as upstream does.
+    ///
+    /// upstream: connection.c:37-40 - scan `[0, max_connections)` and return the
+    /// first range that locks; a failed lock (`errno` unset) means capacity.
+    pub(crate) fn acquire(
+        self: &Arc<Self>,
+        module: &str,
+        limit: NonZeroU32,
+    ) -> Result<ConnectionLockGuard, ModuleConnectionError> {
+        let _ = module;
+        let file = self.open_file().map_err(ModuleConnectionError::io)?;
+
+        for slot in 0..limit.get() {
+            let lock = slot_lock(i64::from(slot) * SLOT_LEN);
+            match nix::fcntl::fcntl(&file, setlk_arg(&lock)) {
+                Ok(_) => return Ok(ConnectionLockGuard { _file: file }),
+                // The range is held by another connection or process; try the
+                // next slot. upstream: util1.c:642 - `fcntl` returns non-zero
+                // with EACCES/EAGAIN when the lock is contended.
+                Err(nix::errno::Errno::EACCES | nix::errno::Errno::EAGAIN) => continue,
+                Err(err) => {
+                    return Err(ModuleConnectionError::io(io::Error::from_raw_os_error(
+                        err as i32,
+                    )));
+                }
+            }
+        }
+
+        Err(ModuleConnectionError::Limit(limit))
+    }
+}
+
+/// Builds an `F_WRLCK` description for the slot beginning at `offset`.
+///
+/// upstream: util1.c:634-640 sets `l_type = F_WRLCK`, `l_whence = SEEK_SET`,
+/// `l_start = offset`, `l_len = len`.
+#[cfg(unix)]
+fn slot_lock(offset: i64) -> nix::libc::flock {
+    nix::libc::flock {
+        l_type: nix::libc::F_WRLCK as nix::libc::c_short,
+        l_whence: nix::libc::SEEK_SET as nix::libc::c_short,
+        l_start: offset as nix::libc::off_t,
+        l_len: SLOT_LEN as nix::libc::off_t,
+        l_pid: 0,
+    }
+}
+
+/// Selects the non-blocking `F_SETLK` command for the current platform.
+///
+/// Linux prefers open file description locks (`F_OFD_SETLK`) so that two
+/// connection threads in this single daemon process - which upstream would fork
+/// into separate processes - contend on distinct slots rather than sharing one
+/// process-owned lock. OFD locks conflict with traditional POSIX locks, so
+/// coordination with an upstream `rsync --daemon` sharing the file is retained.
+#[cfg(target_os = "linux")]
+fn setlk_arg(lock: &nix::libc::flock) -> nix::fcntl::FcntlArg<'_> {
+    nix::fcntl::FcntlArg::F_OFD_SETLK(lock)
+}
+
+/// Selects the non-blocking `F_SETLK` command on non-Linux unix platforms.
+///
+/// upstream: util1.c:642 uses `fcntl(fd, F_SETLK, &lock)`. Where OFD locks are
+/// unavailable the in-process slot count is enforced by the caller's atomic
+/// counter; `F_SETLK` still coordinates across separate daemon processes.
+#[cfg(all(unix, not(target_os = "linux")))]
+fn setlk_arg(lock: &nix::libc::flock) -> nix::fcntl::FcntlArg<'_> {
+    nix::fcntl::FcntlArg::F_SETLK(lock)
+}
+
+/// RAII guard whose held file descriptor keeps the connection's slot locked.
+///
+/// Dropping the guard closes the descriptor, which releases the record lock.
+/// The same release happens automatically if the process dies, so no explicit
+/// decrement is required and a crash cannot leak the slot.
+#[cfg(unix)]
+pub(crate) struct ConnectionLockGuard {
+    _file: File,
+}
+
+#[cfg(windows)]
+impl ConnectionLimiter {
+    /// Acquires a connection slot for the named module, enforcing the limit.
+    ///
+    /// Windows lacks a byte-range-lock-on-death primitive, so the count is kept
+    /// in the lock file and serialised with an exclusive `flock`, with a RAII
+    /// guard restoring the count on drop.
     pub(crate) fn acquire(
         self: &Arc<Self>,
         module: &str,
@@ -88,11 +207,6 @@ impl ConnectionLimiter {
         let result = self.decrement_count(&mut file, module);
         drop(file);
         result
-    }
-
-    /// Opens the lock file for read/write access.
-    fn open_file(&self) -> io::Result<File> {
-        OpenOptions::new().read(true).write(true).open(&self.path)
     }
 
     /// Increments the module count in the lock file, failing if the limit is reached.
@@ -160,11 +274,13 @@ impl ConnectionLimiter {
 }
 
 /// RAII guard that decrements the lock file count on drop.
+#[cfg(windows)]
 pub(crate) struct ConnectionLockGuard {
     limiter: Arc<ConnectionLimiter>,
     module: String,
 }
 
+#[cfg(windows)]
 impl Drop for ConnectionLockGuard {
     fn drop(&mut self) {
         let _ = self.limiter.decrement(&self.module);

--- a/crates/daemon/src/daemon/module_state/connection_limiter.rs
+++ b/crates/daemon/src/daemon/module_state/connection_limiter.rs
@@ -111,16 +111,22 @@ impl ConnectionLimiter {
 
         for slot in 0..limit.get() {
             let lock = slot_lock(i64::from(slot) * SLOT_LEN);
-            match nix::fcntl::fcntl(&file, setlk_arg(&lock)) {
-                Ok(_) => return Ok(ConnectionLockGuard { _file: file }),
-                // The range is held by another connection or process; try the
-                // next slot. upstream: util1.c:642 - `fcntl` returns non-zero
-                // with EACCES/EAGAIN when the lock is contended.
-                Err(nix::errno::Errno::EACCES | nix::errno::Errno::EAGAIN) => continue,
-                Err(err) => {
-                    return Err(ModuleConnectionError::io(io::Error::from_raw_os_error(
-                        err as i32,
-                    )));
+            loop {
+                match nix::fcntl::fcntl(&file, setlk_arg(&lock)) {
+                    Ok(_) => return Ok(ConnectionLockGuard { _file: file }),
+                    // The range is held by another connection or process; try the
+                    // next slot. upstream: util1.c:642 - `fcntl` returns non-zero
+                    // with EACCES/EAGAIN when the lock is contended.
+                    Err(nix::errno::Errno::EACCES | nix::errno::Errno::EAGAIN) => break,
+                    // A signal interrupted the lock request before it resolved;
+                    // retry the same slot rather than treating it as an error or
+                    // as spurious capacity.
+                    Err(nix::errno::Errno::EINTR) => continue,
+                    Err(err) => {
+                        return Err(ModuleConnectionError::io(io::Error::from_raw_os_error(
+                            err as i32,
+                        )));
+                    }
                 }
             }
         }

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -101,6 +101,7 @@ include!("tests/chunks/clap_parse_error_is_reported_via_message.rs");
 include!("tests/chunks/connection_limiter_enforces_limits_across_guards.rs");
 include!("tests/chunks/connection_limiter_open_preserves_existing_counts.rs");
 include!("tests/chunks/connection_limiter_propagates_io_errors.rs");
+include!("tests/chunks/connection_limiter_reclaims_slot_on_close_without_decrement.rs");
 include!("tests/chunks/connection_status_messages_describe_active_sessions.rs");
 include!("tests/chunks/default_config_candidates_prefer_legacy_for_upstream_brand.rs");
 include!("tests/chunks/default_config_candidates_prefer_oc_branding.rs");

--- a/crates/daemon/src/tests/chunks/connection_limiter_enforces_limits_across_guards.rs
+++ b/crates/daemon/src/tests/chunks/connection_limiter_enforces_limits_across_guards.rs
@@ -1,3 +1,10 @@
+// macOS lacks open file description locks, so two `acquire` calls from this one
+// process both resolve to the same process-owned POSIX lock and cannot contend
+// on distinct slots. There, in-process limiting is the caller's atomic counter's
+// job (see `runtime.rs`); the record lock only coordinates across processes.
+// Linux uses `F_OFD_SETLK` and Windows uses the counter fallback, so both
+// observe the drop-and-reclaim behaviour asserted here.
+#[cfg(not(target_os = "macos"))]
 #[test]
 fn connection_limiter_enforces_limits_across_guards() {
     let temp = tempdir().expect("lock dir");

--- a/crates/daemon/src/tests/chunks/connection_limiter_reclaims_slot_on_close_without_decrement.rs
+++ b/crates/daemon/src/tests/chunks/connection_limiter_reclaims_slot_on_close_without_decrement.rs
@@ -1,0 +1,52 @@
+// Regression test for the max-connections slot leak: the old limiter stored a
+// count in the lock file and relied on a `Drop` guard to decrement it, so a
+// `SIGKILL` or `panic = "abort"` skipped the decrement and permanently lost a
+// slot. The fcntl model persists no count - a slot is held only by an open file
+// descriptor's record lock, which the kernel releases when the descriptor is
+// closed or the process dies. This proves reclamation happens with no explicit
+// decrement and no on-disk state that a crash could leave stale.
+//
+// upstream: connection.c:26 `claim_connection()` never writes a count; it relies
+// solely on `lock_range()` (util1.c:632, `fcntl` `F_SETLK`/`F_WRLCK`), whose
+// locks the kernel drops on process death.
+//
+// Requires open file description locks so the two acquisitions here (one process)
+// contend; only Linux provides them.
+#[cfg(target_os = "linux")]
+#[test]
+fn connection_limiter_reclaims_slot_on_close_without_decrement() {
+    let temp = tempdir().expect("lock dir");
+    let lock_path = temp.path().join("daemon.lock");
+    let limiter = Arc::new(ConnectionLimiter::open(lock_path.clone()).expect("open lock file"));
+    let limit = NonZeroU32::new(1).expect("non-zero");
+
+    let held = limiter.acquire("docs", limit).expect("first slot claimed");
+
+    // At capacity: the sole slot's byte range is locked.
+    assert!(matches!(
+        limiter.acquire("docs", limit),
+        Err(ModuleConnectionError::Limit(l)) if l == limit
+    ));
+
+    // No count is persisted, so a crash here would leave nothing to inflate the
+    // limit on restart.
+    assert_eq!(
+        fs::metadata(&lock_path).expect("lock file exists").len(),
+        0,
+        "fcntl limiter must not persist a connection count"
+    );
+
+    // Closing the descriptor is exactly what the kernel does on process death.
+    // The guard performs no decrement; releasing the lock frees the slot.
+    drop(held);
+
+    limiter
+        .acquire("docs", limit)
+        .expect("slot reclaimed after descriptor closed");
+
+    assert_eq!(
+        fs::metadata(&lock_path).expect("lock file exists").len(),
+        0,
+        "reclaiming a slot must not write any count"
+    );
+}


### PR DESCRIPTION
## Problem

The daemon's file-based `max connections` limiter stored a per-module count in
the lock file and depended on a RAII `Drop` guard to decrement it when a
connection ended. Two failure modes skip that guard entirely:

- a connection process killed by `SIGKILL`, and
- a panic in a `panic = "abort"` release build (the release and dist profiles
  both set `panic = "abort"`).

In either case the count is never decremented. Because the count is persisted in
the lock file, it survives a daemon restart, so capacity shrinks permanently
until the file is cleared by hand.

## Fix

Mirror upstream rsync's mechanism. Each accepted connection holds an advisory
record lock on a distinct four-byte range of the lock file for the lifetime of
the connection. A new connection scans the ranges `[0, max_connections)` and
claims the first one it can lock; if every range is held the module is at
capacity. No count is written to disk.

The kernel releases fcntl locks when the owning process dies - on clean exit,
`SIGKILL`, or `panic = "abort"` - so a crashed connection can no longer leak a
slot. The slot is reclaimed with no explicit decrement and no stale on-disk
state.

### Platform handling

- **Linux** uses open file description locks (`F_OFD_SETLK`) so that two
  connection threads in this single-process daemon - which upstream would fork
  into separate processes - contend on distinct slots. OFD locks still conflict
  with the traditional POSIX locks an upstream `rsync --daemon` takes on a
  shared lock file, so cross-implementation coordination is preserved.
- **Other unix** targets use `F_SETLK`; the caller's existing atomic counter
  enforces the in-process limit, and `F_SETLK` coordinates across separate
  daemon processes.
- **Windows**, which has no byte-range-lock-on-death primitive, keeps the
  counter-plus-`flock` fallback.

The lock primitive is provided by the `nix` crate (a safe wrapper); the daemon
remains free of `unsafe`.

## Upstream references

- `connection.c:26` `claim_connection()` - opens the lock file and returns the
  first range it can lock via `lock_range(fd, i*4, 4)`.
- `util1.c:632` `lock_range()` - `fcntl(fd, F_SETLK, &lock)` with
  `l_type = F_WRLCK`, released by the kernel on process death.

## Tests

- `connection_limiter_reclaims_slot_on_close_without_decrement` (new) proves a
  held slot is reclaimed when its descriptor closes - the same event the kernel
  triggers on process death - with no decrement and no persisted count.
- `connection_limiter_enforces_limits_across_guards` verifies N slots lock up to
  the max, the next is refused, and a dropped slot is reusable.

Verified on aarch64 Linux: `fmt` clean, `clippy -p daemon --all-features
--all-targets -D warnings` clean (Linux and macOS), and the daemon
connection/limit tests pass (`cargo nextest run -p daemon --all-features`,
203 tests).
