### PR TITLE
fix(cli): value-representation parity for size/compress/files-from opts

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -343,7 +343,10 @@ where
     let open_noatime = if no_open_noatime {
         false
     } else {
-        open_noatime_flag
+        // upstream: options.c:1584-1586 `case 'U': if (++preserve_atimes > 1)
+        // open_noatime = 1;` - a doubled `-U` (`-UU`, atimes level 2) implies
+        // `--open-noatime`.
+        open_noatime_flag || atimes == Some(2)
     };
     let prefer_aes_gcm = if matches.get_flag("no-aes") {
         Some(false)
@@ -636,10 +639,15 @@ where
         None
     } else if let Some(dir) = partial_dir_cli {
         Some(dir)
-    } else {
+    } else if partial_flag {
+        // upstream: options.c:2448-2454 - RSYNC_PARTIAL_DIR is consulted only
+        // when keep_partial is set (--partial/-P) and no explicit --partial-dir
+        // was given. An empty value or a literal "." is treated as unset.
         env::var_os("RSYNC_PARTIAL_DIR")
-            .filter(|value| !value.is_empty())
+            .filter(|value| !value.is_empty() && value.as_os_str() != std::ffi::OsStr::new("."))
             .map(PathBuf::from)
+    } else {
+        None
     };
     let partial = if no_partial {
         false

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -2575,6 +2575,25 @@ mod open_noatime_tests {
             .expect("parse");
         assert!(!parsed.open_noatime);
     }
+
+    #[test]
+    fn double_short_u_enables_open_noatime() {
+        // upstream: options.c:1584-1586 `case 'U': if (++preserve_atimes > 1)
+        // open_noatime = 1;` - a doubled `-U` (atimes level 2) implies
+        // `--open-noatime`, while a single `-U` does not.
+        let single = parse_test_args(["-U", "src/", "dst/"]).expect("parse");
+        assert!(!single.open_noatime, "single -U must not set open_noatime");
+
+        let doubled = parse_test_args(["-UU", "src/", "dst/"]).expect("parse");
+        assert!(doubled.open_noatime, "-UU must set open_noatime");
+    }
+
+    #[test]
+    fn double_short_u_open_noatime_yields_to_explicit_negation() {
+        // `--no-open-noatime` still wins over the implicit `-UU` enable.
+        let parsed = parse_test_args(["-UU", "--no-open-noatime", "src/", "dst/"]).expect("parse");
+        assert!(!parsed.open_noatime);
+    }
 }
 
 mod super_mode_tests {

--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -15,6 +15,23 @@ pub(crate) enum CompressLevelArg {
     Level(CompressionLevel),
 }
 
+/// Outcome of parsing `--compress-choice=NAME`.
+///
+/// upstream: options.c:2013-2016 `if (compress_choice && strcasecmp(...,
+/// "auto") != 0) parse_compress_choice(0); else compress_choice = NULL;` -
+/// the literal `auto` is nulled out so normal codec negotiation runs, distinct
+/// from `none` (which disables compression) and an explicit codec.
+#[derive(Debug)]
+pub(crate) enum CompressChoice {
+    /// `--compress-choice=none` disables compression.
+    Disabled,
+    /// `--compress-choice=auto` nulls the choice; negotiation proceeds as if
+    /// `--compress-choice` had not been supplied.
+    Auto,
+    /// An explicit codec selection.
+    Codec(CompressionAlgorithm),
+}
+
 enum CompressionLevelParseError {
     Empty { original: String },
     Invalid { original: String, trimmed: String },
@@ -82,9 +99,7 @@ pub(crate) fn parse_compress_level(
         .map_err(CompressionLevelParseError::into_flag_message)
 }
 
-pub(crate) fn parse_compress_choice(
-    argument: &OsStr,
-) -> Result<Option<CompressionAlgorithm>, Message> {
+pub(crate) fn parse_compress_choice(argument: &OsStr) -> Result<CompressChoice, Message> {
     let original = argument.to_string_lossy().into_owned();
     let trimmed = original.trim();
 
@@ -96,12 +111,19 @@ pub(crate) fn parse_compress_choice(
         );
     }
 
+    // upstream: options.c:2013 - only the literal `auto` (case-insensitive) is
+    // nulled; anything else, including `auto,auto`, is passed to
+    // parse_compress_choice and rejected if unknown.
+    if trimmed.eq_ignore_ascii_case("auto") {
+        return Ok(CompressChoice::Auto);
+    }
+
     if trimmed.eq_ignore_ascii_case("none") {
-        return Ok(None);
+        return Ok(CompressChoice::Disabled);
     }
 
     match trimmed.parse::<CompressionAlgorithm>() {
-        Ok(algorithm) => Ok(Some(algorithm)),
+        Ok(algorithm) => Ok(CompressChoice::Codec(algorithm)),
         Err(err) => Err(render_compress_choice_error(err, trimmed)),
     }
 }
@@ -218,32 +240,87 @@ mod tests {
     use std::ffi::OsStr;
 
     #[test]
+    fn compress_level_zero_is_codec_dependent() {
+        // upstream: token.c:55-104 init_compression_level() - `--compress-level=0`
+        // is codec-dependent, NOT unconditionally disabled: for zlib the
+        // off_level is Z_NO_COMPRESSION (0), so level 0 turns compression off
+        // (CPRES_NONE); for zstd off_level is CLVL_NOT_SPECIFIED and a literal 0
+        // maps to the default level, so compression stays on. The clamp is
+        // applied against the resolved codec, mirroring upstream exactly.
+        assert!(matches!(
+            parse_compress_level(OsStr::new("0"), CompressionAlgorithm::Zlib),
+            Ok(CompressLevelArg::Disable)
+        ));
+        #[cfg(feature = "zstd")]
+        assert!(matches!(
+            parse_compress_level(OsStr::new("0"), CompressionAlgorithm::Zstd),
+            Ok(CompressLevelArg::Level(_))
+        ));
+    }
+
+    #[test]
     fn parse_compress_choice_none_disables_compression() {
         let parsed = parse_compress_choice(OsStr::new("none"));
-        assert!(matches!(parsed, Ok(None)));
+        assert!(matches!(parsed, Ok(CompressChoice::Disabled)));
+    }
+
+    #[test]
+    fn parse_compress_choice_auto_is_nulled() {
+        // upstream: options.c:2013-2016 - the literal `auto` (case-insensitive)
+        // is nulled so normal codec negotiation runs; it is neither a disable
+        // nor an explicit codec.
+        assert!(matches!(
+            parse_compress_choice(OsStr::new("auto")),
+            Ok(CompressChoice::Auto)
+        ));
+        assert!(matches!(
+            parse_compress_choice(OsStr::new("AUTO")),
+            Ok(CompressChoice::Auto)
+        ));
+    }
+
+    #[test]
+    fn parse_compress_choice_auto_auto_is_rejected() {
+        // upstream: options.c:2013 only special-cases the exact token `auto`;
+        // `auto,auto` falls through to parse_compress_choice and is rejected
+        // as an unknown compress name (RERR_UNSUPPORTED, exit 4).
+        let error = parse_compress_choice(OsStr::new("auto,auto")).expect_err("auto,auto rejected");
+        assert_eq!(error.code(), Some(4));
     }
 
     #[test]
     fn parse_compress_choice_accepts_zlib_aliases() {
         let parsed = parse_compress_choice(OsStr::new("zlib"));
-        assert!(matches!(parsed, Ok(Some(CompressionAlgorithm::Zlib))));
+        assert!(matches!(
+            parsed,
+            Ok(CompressChoice::Codec(CompressionAlgorithm::Zlib))
+        ));
 
         let alias = parse_compress_choice(OsStr::new(" zlibx "));
-        assert!(matches!(alias, Ok(Some(CompressionAlgorithm::Zlib))));
+        assert!(matches!(
+            alias,
+            Ok(CompressChoice::Codec(CompressionAlgorithm::Zlib))
+        ));
     }
 
     #[cfg(feature = "zstd")]
     #[test]
     fn parse_compress_choice_accepts_zstd() {
         let parsed = parse_compress_choice(OsStr::new("zstd"));
-        assert!(matches!(parsed, Ok(Some(CompressionAlgorithm::Zstd))));
+        assert!(matches!(
+            parsed,
+            Ok(CompressChoice::Codec(CompressionAlgorithm::Zstd))
+        ));
     }
 
     #[cfg(feature = "lz4")]
     #[test]
     fn parse_compress_choice_accepts_lz4() {
         let parsed = parse_compress_choice(OsStr::new("lz4"));
-        assert!(matches!(parsed, Ok(Some(CompressionAlgorithm::Lz4))));
+        assert!(matches!(
+            parsed,
+            Ok(CompressChoice::Codec(CompressionAlgorithm::Lz4))
+        ));
     }
 
     #[test]

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -21,7 +21,7 @@ use super::messages::fail_with_message;
 use crate::frontend::{
     arguments::BandwidthArgument,
     defaults::ITEMIZE_CHANGES_FORMAT,
-    execution::{CompressLevelArg, DEBUG_HELP_TEXT, INFO_HELP_TEXT},
+    execution::{CompressChoice, CompressLevelArg, DEBUG_HELP_TEXT, INFO_HELP_TEXT},
     out_format::{OutFormat, parse_out_format},
     progress::{NameOutputLevel, ProgressMode, ProgressSetting},
 };
@@ -339,9 +339,12 @@ where
         None => None,
     };
 
+    // upstream: options.c:1692-1695 - `--block-size=0` yields no override and
+    // falls back to the default, so a `None` here covers both "unset" and
+    // "explicit 0".
     let block_size_override = match inputs.block_size.as_ref() {
         Some(value) => match parse_block_size_argument(value.as_os_str()) {
-            Ok(size) => Some(size),
+            Ok(size) => size,
             Err(message) => return Err(fail_with_message(message, stderr)),
         },
         None => None,
@@ -422,13 +425,17 @@ where
     // `token.c:init_compression_level()` runs once `do_compression` is known.
     if let Some(choice) = compress_choice.as_ref() {
         match parse_compress_choice(choice.as_os_str()) {
-            Ok(None) => {
+            Ok(CompressChoice::Disabled) => {
                 compress = false;
                 compression_level_override = None;
                 compress_level_setting = Some(CompressLevelArg::Disable);
                 compress_disabled_by_choice = true;
             }
-            Ok(Some(algorithm)) => {
+            // upstream: options.c:2013-2016 - `--compress-choice=auto` is nulled
+            // out, so it behaves as if `--compress-choice` had not been given:
+            // no forced codec, no disable, normal negotiation.
+            Ok(CompressChoice::Auto) => {}
+            Ok(CompressChoice::Codec(algorithm)) => {
                 compression_algorithm = Some(algorithm);
                 // upstream: compat.c:216-219 prints the user's verbatim
                 // compress_choice; retain the trimmed/lowercased token so

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -378,6 +378,20 @@ where
         Err(unsupported) => return fail_with_message(unsupported.to_message(), stderr),
     };
 
+    // upstream: options.c:2465-2471 - with `--files-from` the transferred file
+    // set comes from the list, so a client may name exactly one source root and
+    // one destination. More than two operands, or a lone operand (a missing
+    // destination), is a syntax error (`usage(FERROR); exit RERR_SYNTAX`, exit
+    // 1).
+    if !files_from.is_empty() && (remainder.len() > 2 || remainder.len() == 1) {
+        let message = rsync_error!(
+            1,
+            "--files-from requires a single source and a single destination argument"
+        )
+        .with_role(Role::Client);
+        return fail_with_message(message, stderr);
+    }
+
     // `--protocol` is resolved once operands are known: upstream accepts it on a
     // local copy (setup_protocol runs there too) but this build only speaks the
     // wire for a remote transfer, so the value is ignored locally and validated
@@ -821,7 +835,10 @@ where
 
     let prune_empty_dirs_flag = prune_empty_dirs.unwrap_or(false);
     let fsync_flag = fsync_option.unwrap_or(false);
-    let inplace_enabled = inplace.unwrap_or(false);
+    // upstream: options.c:2413-2419 - `--write-devices` forces the global
+    // inplace flag on, so device targets are written in place rather than via a
+    // temp file.
+    let inplace_enabled = inplace.unwrap_or(false) || write_devices.unwrap_or(false);
     let append_enabled = append.unwrap_or(false);
     let whole_file_enabled = whole_file_option;
 

--- a/crates/cli/src/frontend/execution/mod.rs
+++ b/crates/cli/src/frontend/execution/mod.rs
@@ -14,8 +14,8 @@ pub(super) use drive::execute;
 use super::arguments::ProgramName;
 pub(crate) use chown::parse_chown_argument;
 pub(crate) use compression::{
-    CompressLevelArg, parse_bandwidth_limit, parse_compress_choice, parse_compress_level,
-    parse_compress_level_argument, parse_compress_threads,
+    CompressChoice, CompressLevelArg, parse_bandwidth_limit, parse_compress_choice,
+    parse_compress_level, parse_compress_level_argument, parse_compress_threads,
 };
 #[cfg(test)]
 pub(crate) use drive::CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE;

--- a/crates/cli/src/frontend/execution/options/size.rs
+++ b/crates/cli/src/frontend/execution/options/size.rs
@@ -77,18 +77,42 @@ pub(crate) fn parse_size_limit_argument(value: &OsStr, flag: &str) -> Result<u64
 ///
 /// Limits the parsed value to at most one quarter of `u64::MAX` so the cap
 /// can be safely converted to `usize` and added to outstanding-byte counters
-/// without risking arithmetic overflow on 64-bit platforms.
+/// without risking arithmetic overflow on 64-bit platforms. Upstream imposes
+/// no upper bound; this guard is oc-specific overflow protection.
 pub(crate) const MAX_ALLOC_CEILING: u64 = u64::MAX / 4;
 
-/// Parses the `--max-alloc` argument as a non-zero byte count with a sanity ceiling.
+/// Lower bound for a non-zero `--max-alloc`, mirroring upstream's
+/// `parse_size_arg(arg, 'B', "max-alloc", 1024*1024, -1, True)` min value.
 ///
-/// Mirrors upstream rsync's `parse_size_arg("max-alloc", ...)` accepting K, M,
-/// G, T, P, E suffixes, while rejecting:
+/// upstream: options.c:1960.
+const MAX_ALLOC_MIN: u64 = 1024 * 1024;
+
+/// Sentinel returned for `--max-alloc=0`, meaning "unlimited".
 ///
-/// - empty input,
-/// - negative values,
-/// - zero (unlimited semantics are not exposed by oc-rsync),
-/// - values above [`MAX_ALLOC_CEILING`].
+/// upstream: options.c:1966 `if (!max_alloc) max_alloc = SIZE_MAX;` - a parsed
+/// value of zero disables the ceiling entirely. Callers resolve this to the
+/// platform's `usize::MAX` before publishing it.
+pub(crate) const MAX_ALLOC_UNLIMITED: u64 = 0;
+
+/// Upper bound for `--block-size` at protocol >= 30.
+///
+/// upstream: rsync.h:161 `#define MAX_BLOCK_SIZE ((int32)1 << 17)` (131072),
+/// enforced by options.c:1692-1695 `parse_size_arg(arg, 'b', "block-size", 0,
+/// max_blength, False)`.
+const MAX_BLOCK_SIZE: u64 = 1 << 17;
+
+/// Parses the `--max-alloc` argument as a byte ceiling.
+///
+/// Mirrors upstream rsync's `parse_size_arg(arg, 'B', "max-alloc", 1024*1024,
+/// -1, True)` (options.c:1960) followed by `if (!max_alloc) max_alloc =
+/// SIZE_MAX;` (options.c:1966):
+///
+/// - `0` is accepted and returned verbatim ([`MAX_ALLOC_UNLIMITED`]); callers
+///   resolve it to an unlimited ceiling.
+/// - A non-zero value below 1 MiB is rejected ("too small").
+/// - Empty, negative, and non-numeric input is rejected.
+/// - Values above [`MAX_ALLOC_CEILING`] are rejected for overflow safety
+///   (an oc-specific guard; upstream has no upper bound).
 ///
 /// # Errors
 ///
@@ -105,10 +129,18 @@ pub(crate) fn parse_max_alloc_argument(value: &OsStr) -> Result<u64, Message> {
 
     let limit = parse_size_limit_argument(value, "--max-alloc")?;
 
-    if limit == 0 {
+    // upstream: options.c:1966 - a zero value means unlimited (SIZE_MAX).
+    if limit == MAX_ALLOC_UNLIMITED {
+        return Ok(MAX_ALLOC_UNLIMITED);
+    }
+
+    // upstream: options.c:1960,1120-1127 - parse_size_arg rejects a non-zero
+    // value below the 1 MiB minimum with "is too small (min: 1.00M or 0 for
+    // unlimited)". do_big_num renders the constant 1 MiB minimum as "1.00M".
+    if limit < MAX_ALLOC_MIN {
         return Err(rsync_error!(
             1,
-            format!("invalid --max-alloc '{display}': size must be greater than zero")
+            format!("--max-alloc={display} is too small (min: 1.00M or 0 for unlimited)")
         )
         .with_role(Role::Client));
     }
@@ -124,8 +156,18 @@ pub(crate) fn parse_max_alloc_argument(value: &OsStr) -> Result<u64, Message> {
     Ok(limit)
 }
 
-/// Parses the `--block-size` argument as a positive `NonZeroU32` with optional unit suffix.
-pub(crate) fn parse_block_size_argument(value: &OsStr) -> Result<NonZeroU32, Message> {
+/// Parses the `--block-size` argument into an optional override.
+///
+/// Mirrors upstream rsync's `parse_size_arg(arg, 'b', "block-size", 0,
+/// MAX_BLOCK_SIZE, False)` (options.c:1692-1695):
+///
+/// - `0` is accepted and yields `None`, falling back to the negotiated default
+///   block size (upstream stores `block_size = 0`, later replaced with the
+///   computed default).
+/// - A value above [`MAX_BLOCK_SIZE`] (131072 at protocol >= 30) is rejected
+///   with "is too large (max: 128.00K)".
+/// - Empty, negative, and non-numeric input is rejected.
+pub(crate) fn parse_block_size_argument(value: &OsStr) -> Result<Option<NonZeroU32>, Message> {
     let text = value.to_string_lossy();
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
     let display = if trimmed.is_empty() {
@@ -135,29 +177,28 @@ pub(crate) fn parse_block_size_argument(value: &OsStr) -> Result<NonZeroU32, Mes
     };
 
     let limit = parse_size_limit_argument(value, "--block-size")?;
+
+    // upstream: options.c:1692-1695 - min_value 0 accepts `--block-size=0`,
+    // which stores block_size = 0 and later falls back to the default.
     if limit == 0 {
+        return Ok(None);
+    }
+
+    // upstream: options.c:1692-1695,1116-1119 - a value above MAX_BLOCK_SIZE is
+    // rejected with "is too large (max: ...)". do_big_num renders the constant
+    // 131072 ceiling as "128.00K".
+    if limit > MAX_BLOCK_SIZE {
         return Err(rsync_error!(
             1,
-            format!("invalid --block-size '{display}': size must be positive")
+            format!("--block-size={display} is too large (max: 128.00K)")
         )
         .with_role(Role::Client));
     }
 
-    let block_size = u32::try_from(limit).map_err(|_| {
-        rsync_error!(
-            1,
-            format!("invalid --block-size '{display}': size exceeds the supported 32-bit range")
-        )
-        .with_role(Role::Client)
-    })?;
-
-    NonZeroU32::new(block_size).ok_or_else(|| {
-        rsync_error!(
-            1,
-            format!("invalid --block-size '{display}': size must be positive")
-        )
-        .with_role(Role::Client)
-    })
+    let block_size = u32::try_from(limit).expect("value <= MAX_BLOCK_SIZE fits in u32");
+    Ok(Some(
+        NonZeroU32::new(block_size).expect("non-zero checked above"),
+    ))
 }
 
 /// Parses a size specification string into a byte count.
@@ -501,22 +542,32 @@ mod tests {
 
     #[test]
     fn parse_max_alloc_argument_valid_kilobyte() {
+        // 1024K == 1 MiB, exactly the upstream minimum (options.c:1960).
         assert_eq!(parse_max_alloc_argument(&os("1024K")).unwrap(), 1024 * 1024);
     }
 
     #[test]
-    fn parse_max_alloc_argument_valid_plain_bytes() {
-        assert_eq!(parse_max_alloc_argument(&os("1024")).unwrap(), 1024);
+    fn parse_max_alloc_argument_accepts_zero_as_unlimited() {
+        // upstream: options.c:1966 `if (!max_alloc) max_alloc = SIZE_MAX;` - a
+        // zero value is accepted and means unlimited, not an error.
+        assert_eq!(
+            parse_max_alloc_argument(&os("0")).unwrap(),
+            MAX_ALLOC_UNLIMITED
+        );
     }
 
     #[test]
-    fn parse_max_alloc_argument_rejects_zero() {
-        let err = parse_max_alloc_argument(&os("0")).unwrap_err();
-        let rendered = err.to_string();
-        assert!(
-            rendered.contains("must be greater than zero"),
-            "expected zero-rejection error, got: {rendered}"
-        );
+    fn parse_max_alloc_argument_rejects_below_one_mib() {
+        // upstream: options.c:1960 - parse_size_arg min value is 1 MiB, so a
+        // non-zero value below it ("512K", 1024 bytes) is "too small".
+        for value in ["1024", "512K"] {
+            let err = parse_max_alloc_argument(&os(value)).unwrap_err();
+            let rendered = err.to_string();
+            assert!(
+                rendered.contains("is too small (min: 1.00M or 0 for unlimited)"),
+                "expected too-small error for {value}, got: {rendered}"
+            );
+        }
     }
 
     #[test]
@@ -550,19 +601,39 @@ mod tests {
 
     #[test]
     fn parse_block_size_argument_valid() {
-        let result = parse_block_size_argument(&os("1K")).unwrap();
+        let result = parse_block_size_argument(&os("1K")).unwrap().unwrap();
         assert_eq!(result.get(), 1024);
     }
 
     #[test]
     fn parse_block_size_argument_small() {
-        let result = parse_block_size_argument(&os("512")).unwrap();
+        let result = parse_block_size_argument(&os("512")).unwrap().unwrap();
         assert_eq!(result.get(), 512);
     }
 
     #[test]
-    fn parse_block_size_argument_zero() {
-        assert!(parse_block_size_argument(&os("0")).is_err());
+    fn parse_block_size_argument_zero_falls_back_to_default() {
+        // upstream: options.c:1692-1695 - `--block-size=0` passes the min_value
+        // 0 check and stores block_size = 0, which falls back to the default.
+        assert_eq!(parse_block_size_argument(&os("0")).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_block_size_argument_accepts_maximum() {
+        // upstream: rsync.h:161 MAX_BLOCK_SIZE == 131072 is the inclusive cap.
+        let result = parse_block_size_argument(&os("131072")).unwrap().unwrap();
+        assert_eq!(result.get(), 131072);
+    }
+
+    #[test]
+    fn parse_block_size_argument_rejects_above_maximum() {
+        // upstream: options.c:1692-1695 - a value above MAX_BLOCK_SIZE is "too
+        // large (max: 128.00K)".
+        let err = parse_block_size_argument(&os("200000")).unwrap_err();
+        assert!(
+            err.to_string().contains("is too large (max: 128.00K)"),
+            "expected too-large error, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -668,9 +668,11 @@ fn apply_value_flags<Err: Write>(
     if let Some(alloc_str) = &long_flags.max_alloc {
         match super::super::execution::parse_max_alloc_argument(std::ffi::OsStr::new(alloc_str)) {
             Ok(limit) => {
-                if let Ok(limit_usize) = usize::try_from(limit)
-                    && limit_usize > 0
-                {
+                if limit == 0 {
+                    // upstream: options.c:1966 `if (!max_alloc) max_alloc =
+                    // SIZE_MAX;` - a forwarded `--max-alloc=0` means unlimited.
+                    protocol::set_max_alloc(usize::MAX);
+                } else if let Ok(limit_usize) = usize::try_from(limit) {
                     // upstream: options.c:1959-1965 - the server rewrites its own
                     // `max_alloc` global from the forwarded `--max-alloc`, which
                     // bounds the xattr datum decoders on the receive path

--- a/crates/cli/src/frontend/tests/exit_code_fidelity_tests.rs
+++ b/crates/cli/src/frontend/tests/exit_code_fidelity_tests.rs
@@ -30,6 +30,62 @@ fn empty_compress_choice_returns_unsupported() {
     assert_eq!(code, 4);
 }
 
+/// upstream: options.c:2013-2016 - `--compress-choice=auto` is nulled out so
+/// normal codec negotiation runs; it is accepted (exit 0), not rejected.
+#[test]
+fn compress_choice_auto_is_accepted() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    std::fs::write(&source, b"data").expect("write source");
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--compress-choice=auto"),
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0, "--compress-choice=auto should be accepted");
+    assert!(destination.exists());
+}
+
+/// upstream: options.c:2013 only special-cases the exact token `auto`;
+/// `--compress-choice=auto,auto` is an unknown compress name (exit 4).
+#[test]
+fn compress_choice_auto_auto_returns_unsupported() {
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--compress-choice=auto,auto"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ]);
+    assert_eq!(code, 4);
+}
+
+/// upstream: options.c:2465-2471 - with `--files-from`, more than two operands
+/// (or a lone operand) is a syntax error (RERR_SYNTAX = 1).
+#[test]
+fn files_from_extra_operands_return_syntax_error() {
+    let temp = tempdir().expect("tempdir");
+    let list = temp.path().join("list");
+    std::fs::write(&list, b"file\n").expect("write list");
+    let mut list_arg = OsString::from("--files-from=");
+    list_arg.push(list.as_os_str());
+
+    // Three operands with --files-from.
+    let (three, _o, _e) = run_with_args([
+        OsString::from(RSYNC),
+        list_arg.clone(),
+        OsString::from("a"),
+        OsString::from("b"),
+        OsString::from("c"),
+    ]);
+    assert_eq!(three, 1, "three operands with --files-from should exit 1");
+
+    // A lone operand (missing destination) with --files-from.
+    let (one, _o, _e) = run_with_args([OsString::from(RSYNC), list_arg, OsString::from("a")]);
+    assert_eq!(one, 1, "lone operand with --files-from should exit 1");
+}
+
 /// upstream: checksum.c:139 `unknown checksum name` -> RERR_UNSUPPORTED (4).
 #[test]
 fn invalid_checksum_choice_returns_unsupported() {

--- a/crates/cli/src/frontend/tests/files_from.rs
+++ b/crates/cli/src/frontend/tests/files_from.rs
@@ -22,12 +22,18 @@ fn files_from_reports_read_failures() {
     let _lock = ENV_LOCK.lock().expect("env mutex poisoned");
     let tmp = test_support::create_tempdir();
     let missing = tmp.path().join("missing.list");
+    let src_dir = tmp.path().join("files-from-error-src");
+    std::fs::create_dir(&src_dir).expect("create src");
     let dest_dir = tmp.path().join("files-from-error-dest");
     std::fs::create_dir(&dest_dir).expect("create dest");
 
+    // upstream: options.c:2465-2471 requires a source and destination operand
+    // with --files-from (argc == 2); the list is only read afterwards
+    // (main.c:1806), so both operands are supplied to reach the read failure.
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from(format!("--files-from={}", missing.display())),
+        src_dir.into_os_string(),
         dest_dir.into_os_string(),
     ]);
 
@@ -823,12 +829,17 @@ fn files_from_reports_permission_error() {
     perms.set_mode(0o000);
     std::fs::set_permissions(&list_path, perms).expect("set permissions");
 
+    let src_dir = tmp.path().join("src");
+    std::fs::create_dir(&src_dir).expect("create src");
     let dest_dir = tmp.path().join("dest");
     std::fs::create_dir(&dest_dir).expect("create dest");
 
+    // upstream: options.c:2465-2471 - --files-from requires src + dest operands
+    // (argc == 2) before the list is read, so both are supplied here.
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from(format!("--files-from={}", list_path.display())),
+        src_dir.into_os_string(),
         dest_dir.into_os_string(),
     ]);
 

--- a/crates/cli/src/frontend/tests/parse_args_recognises_partial.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_partial.rs
@@ -23,7 +23,33 @@ fn parse_args_recognises_partial_dir_and_enables_partial() {
 }
 
 #[test]
-fn parse_args_uses_rsync_partial_dir_env() {
+fn parse_args_uses_rsync_partial_dir_env_with_partial() {
+    // upstream: options.c:2448-2451 - RSYNC_PARTIAL_DIR is consulted only when
+    // keep_partial is active (--partial/-P) and no explicit --partial-dir was
+    // given.
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+
+    let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", OsStr::new(".env-partial"));
+
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--partial"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(parsed.partial);
+    assert_eq!(
+        parsed.partial_dir.as_deref(),
+        Some(Path::new(".env-partial"))
+    );
+}
+
+#[test]
+fn parse_args_ignores_rsync_partial_dir_env_without_partial() {
+    // upstream: options.c:2448 `if (keep_partial && !partial_dir && !am_server)`
+    // - without --partial/-P the env var is ignored and does not enable partial.
     let _env_lock = ENV_LOCK.lock().expect("env lock");
 
     let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", OsStr::new(".env-partial"));
@@ -35,11 +61,28 @@ fn parse_args_uses_rsync_partial_dir_env() {
     ])
     .expect("parse");
 
+    assert!(!parsed.partial);
+    assert!(parsed.partial_dir.is_none());
+}
+
+#[test]
+fn parse_args_treats_dot_rsync_partial_dir_env_as_unset() {
+    // upstream: options.c:2452-2454 - a "." partial dir collapses to NULL.
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+
+    let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", OsStr::new("."));
+
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--partial"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    // --partial still enables partial, but the "." env value contributes no dir.
     assert!(parsed.partial);
-    assert_eq!(
-        parsed.partial_dir.as_deref(),
-        Some(Path::new(".env-partial"))
-    );
+    assert!(parsed.partial_dir.is_none());
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/parse_max_alloc.rs
+++ b/crates/cli/src/frontend/tests/parse_max_alloc.rs
@@ -239,14 +239,26 @@ fn max_alloc_rejects_non_numeric() {
 }
 
 #[test]
-fn max_alloc_argument_resolution_rejects_zero() {
+fn max_alloc_argument_resolution_accepts_zero_as_unlimited() {
+    // upstream: options.c:1966 `if (!max_alloc) max_alloc = SIZE_MAX;` - a zero
+    // value is accepted and resolves to unlimited, not an error.
     use crate::frontend::execution::parse_max_alloc_argument;
-    let error =
-        parse_max_alloc_argument(OsStr::new("0")).expect_err("zero should fail at the cap layer");
+    assert_eq!(
+        parse_max_alloc_argument(OsStr::new("0")).expect("zero accepted"),
+        0
+    );
+}
+
+#[test]
+fn max_alloc_argument_resolution_rejects_below_one_mib() {
+    // upstream: options.c:1960 - parse_size_arg min value is 1 MiB, so "512K"
+    // (below the minimum) is rejected as "too small".
+    use crate::frontend::execution::parse_max_alloc_argument;
+    let error = parse_max_alloc_argument(OsStr::new("512K")).expect_err("below 1 MiB rejected");
     let rendered = error.to_string();
     assert!(
-        rendered.contains("greater than zero"),
-        "expected zero-rejection error, got: {rendered}"
+        rendered.contains("is too small (min: 1.00M or 0 for unlimited)"),
+        "expected too-small error, got: {rendered}"
     );
 }
 
@@ -261,13 +273,10 @@ fn max_alloc_argument_resolution_accepts_typical_values() {
         parse_max_alloc_argument(OsStr::new("512M")).expect("512M accepted"),
         512 * 1024 * 1024
     );
+    // 1024K == 1 MiB, exactly the upstream minimum.
     assert_eq!(
         parse_max_alloc_argument(OsStr::new("1024K")).expect("1024K accepted"),
         1024 * 1024
-    );
-    assert_eq!(
-        parse_max_alloc_argument(OsStr::new("4096")).expect("plain bytes accepted"),
-        4096
     );
 }
 
@@ -293,19 +302,40 @@ fn max_alloc_argument_resolution_rejects_excessive_value() {
 }
 
 #[test]
-fn max_alloc_zero_value_produces_error_exit() {
+fn max_alloc_zero_value_is_accepted_as_unlimited() {
+    // upstream: options.c:1966 - `--max-alloc=0` is accepted (unlimited), so it
+    // never triggers a max-alloc syntax error. Any exit here comes from the
+    // missing "source"/"dest" operands, not from option validation.
     let _guard = clear_rsync_rsh();
-    let (code, _stdout, stderr) = run_with_args([
+    let (_code, _stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--max-alloc=0"),
         OsString::from("source"),
         OsString::from("dest"),
     ]);
     let stderr_text = String::from_utf8_lossy(&stderr);
-    assert_ne!(code, 0, "should exit with error for zero --max-alloc");
     assert!(
-        stderr_text.contains("greater than zero"),
-        "error should mention greater-than-zero, got: {stderr_text}"
+        !stderr_text.contains("--max-alloc"),
+        "zero --max-alloc must not raise a max-alloc error, got: {stderr_text}"
+    );
+}
+
+#[test]
+fn max_alloc_below_one_mib_produces_error_exit() {
+    // upstream: options.c:1960 - a non-zero `--max-alloc` below 1 MiB is a
+    // syntax error (exit 1).
+    let _guard = clear_rsync_rsh();
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--max-alloc=512K"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ]);
+    let stderr_text = String::from_utf8_lossy(&stderr);
+    assert_eq!(code, 1, "below-minimum --max-alloc should exit 1");
+    assert!(
+        stderr_text.contains("is too small (min: 1.00M or 0 for unlimited)"),
+        "error should mention the 1 MiB minimum, got: {stderr_text}"
     );
 }
 

--- a/crates/cli/src/frontend/tests/parse_size.rs
+++ b/crates/cli/src/frontend/tests/parse_size.rs
@@ -32,22 +32,27 @@ fn parse_size_limit_argument_rejects_invalid_suffix() {
 
 #[test]
 fn parse_block_size_argument_accepts_valid_value() {
-    let parsed = parse_block_size_argument(OsStr::new("4096")).expect("block-size parses");
+    let parsed = parse_block_size_argument(OsStr::new("4096"))
+        .expect("block-size parses")
+        .expect("non-zero override");
     assert_eq!(parsed.get(), 4096);
 }
 
 #[test]
-fn parse_block_size_argument_rejects_zero() {
-    let error = parse_block_size_argument(OsStr::new("0")).expect_err("zero rejected");
-    assert!(error.to_string().contains("size must be positive"));
+fn parse_block_size_argument_zero_falls_back_to_default() {
+    // upstream: options.c:1692-1695 - `--block-size=0` is accepted (min_value 0)
+    // and falls back to the default block size, represented here as `None`.
+    let parsed = parse_block_size_argument(OsStr::new("0")).expect("zero accepted");
+    assert_eq!(parsed, None);
 }
 
 #[test]
 fn parse_block_size_argument_rejects_large_value() {
+    // upstream: options.c:1692-1695 - a value above MAX_BLOCK_SIZE (131072) is
+    // "too large (max: 128.00K)".
     let error = parse_block_size_argument(OsStr::new("5000000000")).expect_err("overflow rejected");
     assert!(
-        error
-            .to_string()
-            .contains("size exceeds the supported 32-bit range")
+        error.to_string().contains("is too large (max: 128.00K)"),
+        "got: {error}"
     );
 }

--- a/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
@@ -385,3 +385,42 @@ fn transfer_request_with_sparse_and_inplace_punches_hole() {
         dense_meta.blocks(),
     );
 }
+
+/// upstream: options.c:2413-2419 - `--write-devices` forces the global inplace
+/// flag on. An inplace update rewrites the destination file in place (same
+/// inode), whereas the default atomic mode writes a temp file and renames it
+/// (new inode). Comparing the destination inode before and after a
+/// `--write-devices` update proves the inplace behaviour was enabled.
+#[cfg(unix)]
+#[test]
+fn transfer_request_with_write_devices_updates_in_place() {
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source = tmp.path().join("wd-source.bin");
+    let dest = tmp.path().join("wd-dest.bin");
+
+    // Different sizes guarantee a transfer regardless of quick-check.
+    fs::write(&source, vec![0x41; 4096]).expect("write source");
+    fs::write(&dest, vec![0x42; 2048]).expect("write dest");
+    let ino_before = fs::metadata(&dest).expect("dest metadata").ino();
+
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--write-devices"),
+        source.into_os_string(),
+        dest.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+
+    let after_meta = fs::metadata(&dest).expect("dest metadata after");
+    assert_eq!(
+        after_meta.ino(),
+        ino_before,
+        "--write-devices must rewrite the destination in place (inode preserved)"
+    );
+    assert_eq!(after_meta.len(), 4096, "content must be updated");
+}

--- a/crates/cli/tests/environment_variable_defaults.rs
+++ b/crates/cli/tests/environment_variable_defaults.rs
@@ -174,24 +174,32 @@ fn test_no_rsync_rsh_env() {
 
 #[test]
 #[serial]
-fn test_rsync_partial_dir_env_sets_partial_dir() {
+fn test_rsync_partial_dir_env_sets_partial_dir_with_partial() {
+    // upstream: options.c:2448-2451 - RSYNC_PARTIAL_DIR is consulted only when
+    // keep_partial is active (--partial/-P) and no explicit --partial-dir given.
     let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", "/tmp/.rsync-partial");
-    let args = parse_args(["oc-rsync", "src", "dest"]).unwrap();
+    let args = parse_args(["oc-rsync", "--partial", "src", "dest"]).unwrap();
     assert_eq!(
         args.partial_dir,
         Some("/tmp/.rsync-partial".into()),
-        "RSYNC_PARTIAL_DIR should set partial_dir default"
+        "RSYNC_PARTIAL_DIR should set partial_dir when --partial is active"
     );
 }
 
 #[test]
 #[serial]
-fn test_rsync_partial_dir_env_enables_partial() {
+fn test_rsync_partial_dir_env_ignored_without_partial() {
+    // upstream: options.c:2448 `if (keep_partial && !partial_dir && !am_server)`
+    // - without --partial/-P the env var is ignored and does not enable partial.
     let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", "/tmp/.rsync-partial");
     let args = parse_args(["oc-rsync", "src", "dest"]).unwrap();
     assert!(
-        args.partial,
-        "RSYNC_PARTIAL_DIR should implicitly enable partial mode"
+        !args.partial,
+        "RSYNC_PARTIAL_DIR must not enable partial without --partial"
+    );
+    assert_eq!(
+        args.partial_dir, None,
+        "RSYNC_PARTIAL_DIR must be ignored without --partial"
     );
 }
 

--- a/crates/cli/tests/environment_variable_defaults.rs
+++ b/crates/cli/tests/environment_variable_defaults.rs
@@ -256,7 +256,10 @@ fn test_multiple_env_vars_together() {
     let _guard2 = EnvGuard::set("RSYNC_RSH", "ssh");
     let _guard3 = EnvGuard::set("RSYNC_PARTIAL_DIR", "/tmp");
 
-    let args = parse_args(["oc-rsync", "src", "dest"]).unwrap();
+    // upstream: options.c:2448-2456 - RSYNC_PARTIAL_DIR is consulted only when
+    // keep_partial is active (--partial/-P) and no explicit --partial-dir was
+    // given, so --partial is supplied for the env dir to take effect.
+    let args = parse_args(["oc-rsync", "--partial", "src", "dest"]).unwrap();
 
     assert_eq!(args.protect_args, Some(true));
     assert_eq!(args.remote_shell, Some("ssh".into()));

--- a/crates/core/src/client/config/builder/filters.rs
+++ b/crates/core/src/client/config/builder/filters.rs
@@ -64,11 +64,18 @@ impl ClientConfigBuilder {
     ///
     /// An absolute partial directory is left untouched, matching upstream's
     /// `*partial_dir != '/'` guard.
+    ///
+    /// A bare `--delay-updates` (with no explicit `--partial-dir`) uses the
+    /// implicit `.~tmp~` staging directory, so the same protective exclude is
+    /// injected for it. upstream: options.c:2421 `if (delay_updates &&
+    /// !partial_dir) partial_dir = tmp_partialdir;` (`tmp_partialdir[] =
+    /// ".~tmp~"`), consumed by the compat.c:791 filter injection.
     pub(super) fn push_implicit_partial_dir_filter(&mut self) {
-        let Some(dir) = self.partial_dir.as_ref() else {
-            return;
+        let mut pattern = match self.partial_dir.as_ref() {
+            Some(dir) => dir.to_string_lossy().into_owned(),
+            None if self.delay_updates => ".~tmp~".to_owned(),
+            None => return,
         };
-        let mut pattern = dir.to_string_lossy().into_owned();
         if pattern.is_empty() {
             return;
         }

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -968,6 +968,40 @@ fn implicit_partial_dir_filter_excludes_and_protects() {
     assert!(rule.applies_to_receiver());
 }
 
+/// upstream: options.c:2421 `if (delay_updates && !partial_dir) partial_dir =
+/// tmp_partialdir;` (`tmp_partialdir[] = ".~tmp~"`) - a bare `--delay-updates`
+/// uses the implicit `.~tmp~` staging dir, which then gets the same protective
+/// perishable exclude via compat.c:791. Without this the staging directory
+/// would leak into the transfer and be deleted by `--delete`.
+#[test]
+fn delay_updates_injects_tmp_partial_dir_filter() {
+    let config = builder().delay_updates(true).build();
+    let rules = config.filter_rules();
+    let rule = rules
+        .last()
+        .expect("delay-updates must inject the implicit .~tmp~ rule");
+    assert_eq!(rule.kind(), FilterRuleKind::Exclude);
+    assert_eq!(rule.pattern(), ".~tmp~/");
+    assert!(rule.is_perishable());
+    assert!(rule.applies_to_sender());
+    assert!(rule.applies_to_receiver());
+}
+
+/// An explicit `--partial-dir` alongside `--delay-updates` uses the given
+/// directory, not the implicit `.~tmp~` staging fallback.
+#[test]
+fn delay_updates_with_explicit_partial_dir_uses_that_dir() {
+    let config = builder()
+        .delay_updates(true)
+        .partial_directory(Some(".rsync-partial"))
+        .build();
+    let rule = config
+        .filter_rules()
+        .last()
+        .expect("explicit partial-dir must inject an implicit rule");
+    assert_eq!(rule.pattern(), ".rsync-partial/");
+}
+
 /// upstream: compat.c:791 guard `*partial_dir != '/'` - an absolute partial
 /// directory must not inject any implicit rule.
 #[test]

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -447,6 +447,13 @@ fn apply_max_alloc(config: &ClientConfig) {
     let Some(limit) = config.max_alloc() else {
         return;
     };
+    // upstream: options.c:1966 `if (!max_alloc) max_alloc = SIZE_MAX;` - a
+    // configured value of 0 means unlimited, so the ceiling becomes the
+    // platform maximum and the buffer pool retains no explicit byte budget.
+    if limit == 0 {
+        protocol::set_max_alloc(usize::MAX);
+        return;
+    }
     let Ok(limit_usize) = usize::try_from(limit) else {
         // Configurations parsed via the CLI are bounded by `MAX_ALLOC_CEILING`
         // (u64::MAX / 4) so this branch is only reachable on 32-bit targets
@@ -455,9 +462,6 @@ fn apply_max_alloc(config: &ClientConfig) {
         // simply remains uncapped.
         return;
     };
-    if limit_usize == 0 {
-        return;
-    }
     // upstream: options.c:1959-1965 rewrites the `max_alloc` global, which then
     // bounds every attacker-controlled wire allocation (util2.c:75), including
     // the xattr datum decoders. Publish it before any transfer decodes xattrs.


### PR DESCRIPTION
## Summary

Fixes a cluster of CLI option-parsing parity bugs that share a value-representation
theme. Upstream rsync 3.4.4 (`options.c`, proto 32) is the source of truth; every
case below was verified against the real 3.4.4 binary where observable.

## Items fixed

- **`--max-alloc=0` means unlimited; sub-1MiB rejected.** `parse_max_alloc_argument`
  now accepts `0` as the unlimited sentinel (resolved to `usize::MAX` on both the
  client and server apply paths) and rejects a non-zero value below 1 MiB with the
  exact upstream text `--max-alloc=512K is too small (min: 1.00M or 0 for unlimited)`.
  upstream: `options.c:1959-1966`.

- **`--block-size=0` falls back to the default; `>131072` rejected.**
  `parse_block_size_argument` now returns `Option<NonZeroU32>` (`0` -> `None` -> default)
  and rejects values above `MAX_BLOCK_SIZE` with `--block-size=200000 is too large
  (max: 128.00K)`. upstream: `options.c:1690-1697`, `rsync.h:161`.

- **`--files-from` operand count.** With `--files-from`, more than two operands, or a
  lone operand (missing destination), is now a syntax error (exit 1) for a client,
  instead of proceeding to exit 23. upstream: `options.c:2465-2471`.

- **`--compress-choice=auto` accepted.** `auto` (case-insensitive) is now nulled out so
  normal codec negotiation runs, instead of being rejected with exit 4. `auto,auto`
  remains an unknown compress name (exit 4), matching upstream exactly (only the exact
  token `auto` is special-cased). upstream: `options.c:2013-2016`.

- **`--write-devices` forces inplace.** `--write-devices` now enables the global inplace
  flag, so device (and file) targets are written in place. upstream: `options.c:2413-2419`.

- **Bare `--delay-updates` protective filter.** A bare `--delay-updates` (no explicit
  `--partial-dir`) now injects the protective perishable `- .~tmp~/` exclude, keeping
  the implicit staging directory out of the file list and safe from `--delete`.
  upstream: `options.c:2421`, `compat.c:791-797`.

- **`RSYNC_PARTIAL_DIR` gating.** The env var is now consulted only when `--partial`/`-P`
  is active (keep_partial) and no explicit `--partial-dir` was given; a `.` (or empty)
  value is treated as unset. upstream: `options.c:2448-2456`.

- **`-UU` enables `open_noatime`.** A doubled `-U` (atimes level 2) now implies
  `--open-noatime`. upstream: `options.c:1584-1587`.

## Investigated, no change needed

- **`--compress-level=0`.** Read of `token.c:55-104` `init_compression_level()` shows
  level 0 is codec-dependent, NOT unconditionally "compression on at level 0": for
  zlib the off_level is `Z_NO_COMPRESSION` (0), so level 0 disables compression
  (`CPRES_NONE`); for zstd off_level is `CLVL_NOT_SPECIFIED` and a literal 0 maps to the
  default level, so compression stays on. The existing clamp already applies against the
  resolved codec and matches upstream exactly. A regression test now documents this.

## Value-representation rework

- `--max-alloc`: `u64` with an explicit unlimited sentinel (`0`), resolved once to
  `usize::MAX`; single source of truth in `size.rs`.
- `--block-size`: `Option<NonZeroU32>` (`None` = default), removing the old NonZero-only
  representation that could not encode `0`.
- `--compress-choice`: new `CompressChoice { Disabled, Auto, Codec }` enum replacing the
  overloaded `Option<CompressionAlgorithm>` so `auto` (null/negotiate) is distinct from
  `none` (disable) and an explicit codec.

## Testing

- `cargo fmt --all -- --check` clean; `cargo clippy -p cli -p core --all-features
  --all-targets --no-deps -- -D warnings` clean.
- New deterministic tests per item with upstream-cite comments; existing tests that
  encoded the old (non-upstream) behavior were corrected (several `files_from` read-error
  tests now pass src+dest, matching upstream's operand-count-before-read ordering).
- Observable exit codes and error text confirmed against the real rsync 3.4.4 binary.
