### PR TITLE
fix(rsync_io): forward --ipv4/--ipv6 to the ssh child as -4/-6

### DIFF
--- a/crates/core/src/client/module_list/connect/rsh.rs
+++ b/crates/core/src/client/module_list/connect/rsh.rs
@@ -19,6 +19,7 @@ use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use super::DaemonStream;
+use crate::client::AddressMode;
 use crate::client::IPC_EXIT_CODE;
 use crate::client::error::{ClientError, invalid_argument_error};
 
@@ -41,6 +42,9 @@ pub(crate) struct RshDaemonSpawn<'a> {
     pub jump_hosts: Option<&'a OsStr>,
     /// Optional `-o ConnectTimeout=` in whole seconds.
     pub connect_timeout: Option<Duration>,
+    /// Forced address family (`--ipv4`/`--ipv6`), appended as `-4`/`-6` when
+    /// the remote-shell program is exactly `ssh`.
+    pub address_mode: AddressMode,
 }
 
 /// Returns whether the remote-shell program is ssh (or an ssh-family binary
@@ -54,23 +58,30 @@ fn is_ssh_like(program: &OsStr) -> bool {
     name == "ssh" || name.ends_with("ssh")
 }
 
-/// Spawns the remote shell and wraps its stdio as a [`DaemonStream`].
-///
-/// Builds `PROG <pre-args> [ssh opts] <host> "<rsync-path> --server --daemon ."`
-/// matching upstream `main.c`'s daemon-over-rsh invocation, then returns a
-/// stream carrying the `@RSYNCD:` protocol over the child's pipes.
-pub(crate) fn spawn_rsh_daemon_stream(
-    spec: RshDaemonSpawn<'_>,
-) -> Result<DaemonStream, ClientError> {
+/// Returns whether the remote-shell program basename is exactly `ssh` (or
+/// `ssh.exe`). Unlike [`is_ssh_like`], this rejects ssh-family wrappers such as
+/// `autossh`/`hpnssh`, matching upstream's `strcmp(t, "ssh") == 0` gate for the
+/// `-4`/`-6` append and `rsync_io`'s `SshCommand::is_ssh_program`.
+fn is_ssh_exact(program: &OsStr) -> bool {
+    let name = std::path::Path::new(program)
+        .file_name()
+        .map_or_else(|| program.to_string_lossy(), |n| n.to_string_lossy());
+    name == "ssh" || name == "ssh.exe"
+}
+
+/// Builds the `(program, argv)` pair for the daemon-over-rsh spawn without
+/// touching the environment or spawning a process, so the argv layout can be
+/// unit-tested deterministically.
+fn build_rsh_command_argv(spec: &RshDaemonSpawn<'_>) -> (OsString, Vec<OsString>) {
     let ssh_program = if spec.shell_args.is_empty() {
         OsStr::new("ssh")
     } else {
         spec.shell_args[0].as_os_str()
     };
-    let mut cmd = Command::new(ssh_program);
 
+    let mut args: Vec<OsString> = Vec::new();
     for opt in spec.shell_args.iter().skip(1) {
-        cmd.arg(opt);
+        args.push(opt.clone());
     }
 
     // upstream: main.c - the `-o`/`-J`/`-l` connection options are SSH-specific
@@ -83,38 +94,71 @@ pub(crate) fn spawn_rsh_daemon_stream(
     let ssh_like = is_ssh_like(ssh_program);
     if ssh_like {
         if let Some(bind_addr) = spec.bind_address {
-            cmd.arg("-o").arg(format!("BindAddress={bind_addr}"));
+            args.push(OsString::from("-o"));
+            args.push(OsString::from(format!("BindAddress={bind_addr}")));
         }
 
         if let Some(jump) = spec.jump_hosts {
-            cmd.arg("-J").arg(jump);
+            args.push(OsString::from("-J"));
+            args.push(jump.to_os_string());
         }
 
         if let Some(timeout) = spec.connect_timeout {
-            cmd.arg("-o")
-                .arg(format!("ConnectTimeout={}", timeout.as_secs()));
+            args.push(OsString::from("-o"));
+            args.push(OsString::from(format!(
+                "ConnectTimeout={}",
+                timeout.as_secs()
+            )));
         }
 
         if let Some(user) = spec.username {
-            cmd.arg("-l").arg(user);
+            args.push(OsString::from("-l"));
+            args.push(OsString::from(user));
+        }
+    }
+
+    // upstream: main.c:588-593 do_cmd() - -4/-6 appended when default_af_hint
+    // set && strcmp(t,"ssh")==0, before the daemon_connection branch (applies
+    // to daemon-over-rsh too). Placed immediately before the host operand,
+    // after any `-l user`. Gated on the exact `ssh` basename, so ssh-family
+    // wrappers (autossh) and non-ssh shells (rsh) are left untouched.
+    if is_ssh_exact(ssh_program) {
+        match spec.address_mode {
+            AddressMode::Ipv4 => args.push(OsString::from("-4")),
+            AddressMode::Ipv6 => args.push(OsString::from("-6")),
+            AddressMode::Default => {}
         }
     }
 
     // ssh takes the login via `-l user` above and the bare host here; a custom
     // rsh program receives `user@host` (upstream do_cmd handling).
     match (ssh_like, spec.username) {
-        (false, Some(user)) => {
-            cmd.arg(format!("{user}@{}", spec.host));
-        }
-        _ => {
-            cmd.arg(spec.host);
-        }
+        (false, Some(user)) => args.push(OsString::from(format!("{user}@{}", spec.host))),
+        _ => args.push(OsString::from(spec.host)),
     }
 
     // upstream: main.c:594-604 - the remote command is
     // `rsync_path --server --daemon .` with no server_options().
     let rsync_path = spec.rsync_path.unwrap_or_else(|| OsStr::new("rsync"));
-    cmd.arg(rsync_path).arg("--server").arg("--daemon").arg(".");
+    args.push(rsync_path.to_os_string());
+    args.push(OsString::from("--server"));
+    args.push(OsString::from("--daemon"));
+    args.push(OsString::from("."));
+
+    (ssh_program.to_os_string(), args)
+}
+
+/// Spawns the remote shell and wraps its stdio as a [`DaemonStream`].
+///
+/// Builds `PROG <pre-args> [ssh opts] <host> "<rsync-path> --server --daemon ."`
+/// matching upstream `main.c`'s daemon-over-rsh invocation, then returns a
+/// stream carrying the `@RSYNCD:` protocol over the child's pipes.
+pub(crate) fn spawn_rsh_daemon_stream(
+    spec: RshDaemonSpawn<'_>,
+) -> Result<DaemonStream, ClientError> {
+    let (program, args) = build_rsh_command_argv(&spec);
+    let mut cmd = Command::new(&program);
+    cmd.args(&args);
 
     // upstream: main.c:1571-1572 - set_env_num("RSYNC_PORT", env_port)
     cmd.env("RSYNC_PORT", spec.port.to_string());
@@ -164,6 +208,7 @@ mod tests {
             bind_address: None,
             jump_hosts: None,
             connect_timeout: None,
+            address_mode: AddressMode::Default,
         };
 
         // `DaemonStream` is not `Debug`, so match instead of `expect_err`.
@@ -179,6 +224,108 @@ mod tests {
         assert!(
             err.to_string().contains("daemon-over-rsh"),
             "error should reference the daemon-over-rsh spawn, got: {err}"
+        );
+    }
+
+    fn argv_strings(shell: &str, mode: AddressMode) -> Vec<String> {
+        let shell_args = vec![OsString::from(shell)];
+        let spec = RshDaemonSpawn {
+            shell_args: &shell_args,
+            host: "example.com",
+            username: None,
+            port: 873,
+            rsync_path: None,
+            bind_address: None,
+            jump_hosts: None,
+            connect_timeout: None,
+            address_mode: mode,
+        };
+        let (_, args) = build_rsh_command_argv(&spec);
+        args.iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// `--ipv4` over daemon-over-ssh must append `-4` immediately before the
+    /// host operand, matching upstream do_cmd() which runs the family append
+    /// before the `daemon_connection` branch. upstream: main.c:588-589.
+    #[test]
+    fn appends_ipv4_flag_before_host_for_ssh() {
+        let rendered = argv_strings("ssh", AddressMode::Ipv4);
+        let flag = rendered.iter().position(|a| a == "-4");
+        let host = rendered.iter().position(|a| a == "example.com");
+        assert!(
+            rendered.contains(&"-4".to_owned()),
+            "expected -4 in {rendered:?}"
+        );
+        assert!(
+            !rendered.contains(&"-6".to_owned()),
+            "unexpected -6 in {rendered:?}"
+        );
+        assert_eq!(
+            flag.zip(host).map(|(f, h)| f + 1 == h),
+            Some(true),
+            "-4 must sit immediately before the host: {rendered:?}"
+        );
+    }
+
+    /// upstream: main.c:592-593 - `--ipv6` appends `-6`.
+    #[test]
+    fn appends_ipv6_flag_for_ssh() {
+        let rendered = argv_strings("ssh", AddressMode::Ipv6);
+        assert!(
+            rendered.contains(&"-6".to_owned()),
+            "expected -6 in {rendered:?}"
+        );
+        assert!(
+            !rendered.contains(&"-4".to_owned()),
+            "unexpected -4 in {rendered:?}"
+        );
+    }
+
+    /// Default address mode injects neither flag; upstream gates the append on
+    /// `default_af_hint` being set. upstream: main.c:588/592.
+    #[test]
+    fn omits_family_flag_for_default_mode() {
+        let rendered = argv_strings("ssh", AddressMode::Default);
+        assert!(
+            !rendered.contains(&"-4".to_owned()),
+            "unexpected -4 in {rendered:?}"
+        );
+        assert!(
+            !rendered.contains(&"-6".to_owned()),
+            "unexpected -6 in {rendered:?}"
+        );
+    }
+
+    /// The gate is exact-`ssh`: an ssh-family wrapper like `autossh` (which
+    /// `ends_with("ssh")`) must NOT receive `-4`, proving we match upstream's
+    /// `strcmp(t,"ssh")==0` rather than a suffix test. upstream: main.c:588.
+    #[test]
+    fn does_not_append_family_flag_for_autossh() {
+        let rendered = argv_strings("autossh", AddressMode::Ipv4);
+        assert!(
+            !rendered.contains(&"-4".to_owned()),
+            "unexpected -4 for autossh: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains(&"-6".to_owned()),
+            "unexpected -6 for autossh: {rendered:?}"
+        );
+    }
+
+    /// A non-ssh custom shell (`rsh`) never receives `-4`/`-6`.
+    /// upstream: main.c:588/592 gate on `strcmp(t,"ssh")==0`.
+    #[test]
+    fn does_not_append_family_flag_for_rsh() {
+        let rendered = argv_strings("rsh", AddressMode::Ipv4);
+        assert!(
+            !rendered.contains(&"-4".to_owned()),
+            "unexpected -4 for rsh: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains(&"-6".to_owned()),
+            "unexpected -6 for rsh: {rendered:?}"
         );
     }
 }

--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -212,6 +212,7 @@ pub fn run_module_list_with_password_and_options(
             bind_address: options.bind_address().map(|addr| addr.ip()),
             jump_hosts: None,
             connect_timeout: connect_duration,
+            address_mode,
         })?
     } else {
         open_daemon_stream(

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -326,6 +326,7 @@ pub fn run_daemon_over_remote_shell(
         bind_address: config.bind_address().map(|addr| addr.socket().ip()),
         jump_hosts: config.jump_hosts(),
         connect_timeout: config.connect_timeout().effective(Duration::from_secs(30)),
+        address_mode: config.address_mode(),
     })?;
 
     let transfer_timeout = config

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -55,3 +55,26 @@ pub use invocation::{
     determine_transfer_role, operand_is_remote,
 };
 pub use ssh_transfer::run_ssh_transfer;
+
+use rsync_io::ssh::SshAddressFamily;
+
+use super::config::AddressMode;
+
+/// Maps the negotiated [`AddressMode`] onto the SSH `-4`/`-6` hint shared by
+/// every `do_cmd()`-equivalent SSH spawn (single-host and remote-to-remote).
+///
+/// [`AddressMode::Default`] yields `None`, leaving the ssh child free to pick
+/// whichever family resolves first; the forced modes map to the matching flag.
+///
+/// upstream: main.c:587-594 `do_cmd()` gates the `-4`/`-6` append on
+/// `default_af_hint` being set (and the remote-shell basename being `ssh`,
+/// which the builder enforces).
+pub(in crate::client::remote) const fn ssh_address_family(
+    mode: AddressMode,
+) -> Option<SshAddressFamily> {
+    match mode {
+        AddressMode::Default => None,
+        AddressMode::Ipv4 => Some(SshAddressFamily::V4),
+        AddressMode::Ipv6 => Some(SshAddressFamily::V6),
+    }
+}

--- a/crates/core/src/client/remote/remote_to_remote.rs
+++ b/crates/core/src/client/remote/remote_to_remote.rs
@@ -201,6 +201,10 @@ fn spawn_ssh_connection(
         ssh.set_bind_address(Some(bind_addr.socket().ip()));
     }
 
+    // upstream: main.c:587-594 do_cmd() - forward --ipv4/--ipv6 to the ssh
+    // child as -4/-6 (only honoured when the remote shell is `ssh`).
+    ssh.set_address_family(super::ssh_address_family(config.address_mode()));
+
     ssh.set_prefer_aes_gcm(config.prefer_aes_gcm());
 
     let connect_timeout = config

--- a/crates/core/src/client/remote/ssh_transfer/connection.rs
+++ b/crates/core/src/client/remote/ssh_transfer/connection.rs
@@ -12,6 +12,7 @@ use rsync_io::ssh::{SshCommand, SshConnection};
 
 use super::super::super::config::ClientConfig;
 use super::super::super::error::{ClientError, invalid_argument_error};
+use super::super::ssh_address_family;
 
 /// Builds and spawns an SSH connection with the remote rsync invocation.
 ///
@@ -50,6 +51,10 @@ pub(super) fn build_ssh_connection(
     if let Some(bind_addr) = config.bind_address() {
         ssh.set_bind_address(Some(bind_addr.socket().ip()));
     }
+
+    // upstream: main.c:587-594 do_cmd() - forward --ipv4/--ipv6 to the ssh
+    // child as -4/-6 (only honoured when the remote shell is `ssh`).
+    ssh.set_address_family(ssh_address_family(config.address_mode()));
 
     ssh.set_prefer_aes_gcm(config.prefer_aes_gcm());
     ssh.set_jump_hosts(config.jump_hosts().map(OsString::from));

--- a/crates/rsync_io/src/lib.rs
+++ b/crates/rsync_io/src/lib.rs
@@ -94,4 +94,6 @@ pub use session::{
     negotiate_session_parts, negotiate_session_parts_from_stream,
     negotiate_session_parts_with_sniffer, negotiate_session_with_sniffer,
 };
-pub use ssh::{RemoteShellParseError, SshCommand, SshConnection, parse_remote_shell};
+pub use ssh::{
+    RemoteShellParseError, SshAddressFamily, SshCommand, SshConnection, parse_remote_shell,
+};

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -38,6 +38,23 @@ const DEFAULT_SERVER_ALIVE_COUNT_MAX: u32 = 3;
 /// `--contimeout` behavior.
 const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 30;
 
+/// Address family forced onto the `ssh` child via `-4`/`-6`.
+///
+/// Mirrors rsync's `--ipv4`/`--ipv6` flags. When set on an [`SshCommand`]
+/// whose program is `ssh`, the corresponding flag is appended to the spawned
+/// argv so the ssh client restricts host resolution to that family.
+///
+/// upstream: main.c:587-594 `do_cmd()` appends `-4`/`-6` when
+/// `default_af_hint` is `AF_INET`/`AF_INET6` and the remote-shell basename is
+/// `ssh`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SshAddressFamily {
+    /// Force IPv4 (`-4`), mirroring rsync's `--ipv4`.
+    V4,
+    /// Force IPv6 (`-6`), mirroring rsync's `--ipv6`.
+    V6,
+}
+
 /// Builder used to configure and spawn an SSH subprocess.
 #[derive(Clone, Debug)]
 pub struct SshCommand {
@@ -47,6 +64,7 @@ pub struct SshCommand {
     port: Option<u16>,
     batch_mode: bool,
     bind_address: Option<IpAddr>,
+    address_family: Option<SshAddressFamily>,
     keepalive: bool,
     options: Vec<OsString>,
     connect_timeout: Option<Duration>,
@@ -69,6 +87,7 @@ impl SshCommand {
             port: None,
             batch_mode: true,
             bind_address: None,
+            address_family: None,
             keepalive: true,
             connect_timeout: Some(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS)),
             io_timeout: None,
@@ -109,6 +128,20 @@ impl SshCommand {
     /// `-o BindAddress=<addr>`.
     pub const fn set_bind_address(&mut self, addr: Option<IpAddr>) -> &mut Self {
         self.bind_address = addr;
+        self
+    }
+
+    /// Forces the address family the spawned `ssh` client uses, mirroring
+    /// rsync's `--ipv4`/`--ipv6`. When `Some`, a `-4` or `-6` flag is appended
+    /// to the argv, but only when the program basename is `ssh` (see
+    /// [`SshCommand::is_ssh_program`]); a user-supplied non-ssh `-e` wrapper is
+    /// left untouched.
+    ///
+    /// upstream: main.c:587-594 `do_cmd()` - `if (default_af_hint == AF_INET &&
+    /// strcmp(t, "ssh") == 0) args[argc++] = "-4";` (and the `AF_INET6`/`-6`
+    /// counterpart).
+    pub const fn set_address_family(&mut self, family: Option<SshAddressFamily>) -> &mut Self {
+        self.address_family = family;
         self
     }
 
@@ -497,6 +530,20 @@ impl SshCommand {
         {
             args.push(OsString::from("-J"));
             args.push(jump.clone());
+        }
+
+        // Force IPv4/IPv6 host resolution by appending `-4`/`-6` right before
+        // the destination operand, matching upstream's placement. Gated on the
+        // program basename being `ssh` so non-ssh `-e` wrappers are untouched.
+        // upstream: main.c:588-593 do_cmd() - `-4`/`-6` are only added when
+        // `default_af_hint` is set and `strcmp(t, "ssh") == 0`.
+        if self.is_ssh_program()
+            && let Some(family) = self.address_family
+        {
+            args.push(OsString::from(match family {
+                SshAddressFamily::V4 => "-4",
+                SshAddressFamily::V6 => "-6",
+            }));
         }
 
         if let Some(target) = self.target_argument()

--- a/crates/rsync_io/src/ssh/mod.rs
+++ b/crates/rsync_io/src/ssh/mod.rs
@@ -107,7 +107,7 @@ mod stall;
 pub use async_stderr_drain::{ASYNC_STDERR_BUFFER_CAP, AsyncStderrDrain, RingBuffer};
 #[cfg(feature = "async-ssh")]
 pub use async_transport::AsyncSshTransport;
-pub use builder::SshCommand;
+pub use builder::{SshAddressFamily, SshCommand};
 pub use connect::{
     DEFAULT_CONNECT_TIMEOUT, DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_KEEPALIVE_MAX_FAILURES,
     KeepAliveConfig, SshConnectConfig,

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -1,6 +1,7 @@
 use super::SshCommand;
 #[cfg(unix)]
 use super::SshConnection;
+use super::builder::SshAddressFamily;
 use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
 use std::io::{Read, Write};
@@ -2290,4 +2291,103 @@ fn has_ssh_compression_rejects_falsey_and_unrelated() {
 fn has_ssh_compression_default_is_false() {
     let command = SshCommand::new("example.com");
     assert!(!command.has_ssh_compression());
+}
+
+#[test]
+fn forces_ipv4_flag_for_ssh_program() {
+    // #227: `rsync -4 -e ssh host:path` must force IPv4 on the ssh child so it
+    // cannot connect over IPv6, matching upstream do_cmd().
+    // upstream: main.c:588-589 - `-4` is appended when default_af_hint ==
+    // AF_INET and the remote-shell basename is `ssh`.
+    let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(false));
+    command.set_address_family(Some(SshAddressFamily::V4));
+
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+
+    let flag_pos = rendered.iter().position(|a| a == "-4");
+    let host_pos = rendered.iter().position(|a| a == "example.com");
+    assert!(
+        rendered.contains(&"-4".to_owned()),
+        "expected -4 in {rendered:?}"
+    );
+    assert!(
+        !rendered.contains(&"-6".to_owned()),
+        "unexpected -6 in {rendered:?}"
+    );
+    // upstream appends the family flag immediately before the host operand.
+    assert!(
+        flag_pos < host_pos,
+        "-4 must precede the host: {rendered:?}"
+    );
+}
+
+#[test]
+fn forces_ipv6_flag_for_ssh_program() {
+    // upstream: main.c:592-593 - `-6` is appended when default_af_hint ==
+    // AF_INET6 and the remote-shell basename is `ssh`.
+    let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(false));
+    command.set_address_family(Some(SshAddressFamily::V6));
+
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+
+    assert!(
+        rendered.contains(&"-6".to_owned()),
+        "expected -6 in {rendered:?}"
+    );
+    assert!(
+        !rendered.contains(&"-4".to_owned()),
+        "unexpected -4 in {rendered:?}"
+    );
+}
+
+#[test]
+fn omits_address_family_flag_when_unset() {
+    // Default address mode leaves the ssh child free to pick a family, so no
+    // -4/-6 is injected. upstream: main.c:588/592 gate on default_af_hint
+    // being set.
+    let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(false));
+    command.set_address_family(None);
+
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+
+    assert!(
+        !rendered.contains(&"-4".to_owned()),
+        "unexpected -4 in {rendered:?}"
+    );
+    assert!(
+        !rendered.contains(&"-6".to_owned()),
+        "unexpected -6 in {rendered:?}"
+    );
+}
+
+#[test]
+fn does_not_force_address_family_for_non_ssh_shell() {
+    // upstream: main.c:588/592 - the `-4`/`-6` append is gated on
+    // `strcmp(t, "ssh") == 0`, so a non-ssh `-e` wrapper (here `rsh`) must
+    // never receive a family flag it cannot understand.
+    let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(false));
+    command
+        .configure_remote_shell(OsStr::new("rsh"))
+        .expect("valid remote shell");
+    command.set_address_family(Some(SshAddressFamily::V4));
+
+    let (program, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+
+    assert_eq!(program, OsString::from("rsh"));
+    assert!(
+        !rendered.contains(&"-4".to_owned()),
+        "unexpected -4 in {rendered:?}"
+    );
+    assert!(
+        !rendered.contains(&"-6".to_owned()),
+        "unexpected -6 in {rendered:?}"
+    );
 }


### PR DESCRIPTION
## Summary

`oc-rsync` did not forward the `--ipv4` (`-4`) / `--ipv6` (`-6`) address-family
selection to the spawned `ssh` child. Only the direct-daemon socket path
honoured the address family, so `oc-rsync -4 -e ssh host:path` could still
connect over IPv6 through `ssh`, where upstream rsync forces IPv4.

Upstream `do_cmd()` appends `-4`/`-6` to the ssh argv when the forced address
family (`default_af_hint`) is set **and** the remote-shell basename is `ssh`:

```
main.c:587-594
#ifdef AF_INET
    if (default_af_hint == AF_INET && strcmp(t, "ssh") == 0)
        args[argc++] = "-4"; /* we're using ssh so we can add a -4 option */
#endif
#ifdef AF_INET6
    if (default_af_hint == AF_INET6 && strcmp(t, "ssh") == 0)
        args[argc++] = "-6"; /* we're using ssh so we can add a -6 option */
#endif
```

The `strcmp(t, "ssh")` basename gate (`t` is set at `main.c:564-567`) means a
custom non-`ssh` `-e`/`--rsh` wrapper never receives the flag.

## Change

- `rsync_io`: new `SshAddressFamily` (`V4`/`V6`) plus
  `SshCommand::set_address_family`. `command_parts()` appends `-4`/`-6`
  immediately before the destination operand, gated on the existing
  `is_ssh_program()` basename check (matching upstream's `strcmp(t, "ssh")`).
  No flag is injected when the family is unset or the shell is non-ssh.
- `core`: both `do_cmd()`-equivalent SSH spawn sites
  (`ssh_transfer::connection::build_ssh_connection` and the remote-to-remote
  relay) now map `config.address_mode()` onto the new hint via a single shared
  `ssh_address_family` adapter.

## Tests

Deterministic argv tests in `crates/rsync_io/src/ssh/tests.rs`:

- `--ipv4` renders `-4` before the host, never `-6`.
- `--ipv6` renders `-6`, never `-4`.
- default address mode injects neither flag.
- a non-`ssh` `-e` wrapper (`rsh`) is never given `-4`/`-6`.

`cargo fmt --all -- --check`, `cargo clippy -p rsync_io -p core
--all-features --all-targets --no-deps -D warnings`, and the new
`cargo nextest run -p rsync_io` tests all pass. No unsafe code added.
