### PR TITLE
fix(batch): seed batch header from --checksum-seed and enforce MAX_BATCH_NAME_LEN

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -42,6 +42,14 @@ use super::{
 /// `#define MAX_BASIS_DIRS 20`.
 const MAX_BASIS_DIRS: usize = 20;
 
+/// Maximum length of a `--write-batch`/`--only-write-batch`/`--read-batch`
+/// file name. upstream: options.c:225 `#define MAX_BATCH_NAME_LEN 256`
+/// ("Must be less than MAXPATHLEN-13"). A longer name is rejected by
+/// `parse_arguments()` with `RERR_SYNTAX` (1). All three batch options write
+/// the same upstream `batch_name` variable, so the cap applies to whichever
+/// one is present.
+pub(super) const MAX_BATCH_NAME_LEN: usize = 256;
+
 /// Enforces upstream's [`MAX_BASIS_DIRS`] cap on alt-dest directories.
 ///
 /// upstream: options.c:1749-1754 rejects the arg that would push the shared
@@ -922,6 +930,23 @@ where
                 format!("--read-batch cannot be used with --remove-{which}-files\n"),
             ));
         }
+    }
+
+    // upstream: options.c:2169-2174 - the shared `batch_name` (set by
+    // --write-batch, --only-write-batch, or --read-batch) must be at most
+    // MAX_BATCH_NAME_LEN bytes, else parse_arguments() aborts with
+    // RERR_SYNTAX (1). Length is measured in bytes (strlen), matching
+    // upstream's `strlen(batch_name) > MAX_BATCH_NAME_LEN`.
+    if let Some(name) = write_batch
+        .as_ref()
+        .or(only_write_batch.as_ref())
+        .or(read_batch.as_ref())
+        && name.len() > MAX_BATCH_NAME_LEN
+    {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::ValueValidation,
+            format!("the batch-file name must be {MAX_BATCH_NAME_LEN} characters or less.\n"),
+        ));
     }
 
     // upstream: options.c:2299-2304 - a `--suffix` containing a slash is rejected

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -1,3 +1,4 @@
+use super::entry::MAX_BATCH_NAME_LEN;
 use super::*;
 use core::client::HumanReadableMode;
 
@@ -1034,4 +1035,75 @@ fn alt_dest_types_cannot_be_mixed() {
         err.to_string().contains("cannot be used with"),
         "expected a conflict diagnostic, got: {err}"
     );
+}
+
+/// upstream: options.c:2169 uses `strlen(batch_name) > MAX_BATCH_NAME_LEN`, so a
+/// name of exactly MAX_BATCH_NAME_LEN (256) bytes is the boundary and must be
+/// accepted. This is observable behaviour a drop-in must not regress: rejecting
+/// a legal name would break scripts that upstream rsync accepts.
+#[test]
+fn batch_name_at_max_len_accepted() {
+    let name = "a".repeat(MAX_BATCH_NAME_LEN);
+    let result = parse_test_args([
+        format!("--write-batch={name}"),
+        "src/".into(),
+        "dst/".into(),
+    ]);
+    assert!(
+        result.is_ok(),
+        "batch name of exactly {MAX_BATCH_NAME_LEN} bytes must be accepted"
+    );
+}
+
+/// upstream: options.c:2169-2174 rejects a batch name longer than
+/// MAX_BATCH_NAME_LEN with the verbatim message
+/// `the batch-file name must be 256 characters or less.` and exits
+/// `RERR_SYNTAX` (1). The exact wording and the syntax exit code are both
+/// observable output a drop-in must mirror byte-for-byte, so this test asserts
+/// the message text and the `ValueValidation` kind (which
+/// `clap_parse_error_exit_code` maps to 1, unlike the `--checksum-choice`
+/// special case that maps to 4).
+#[test]
+fn batch_name_over_max_len_rejected_with_exact_message() {
+    let name = "a".repeat(MAX_BATCH_NAME_LEN + 1);
+    let err = parse_test_args([
+        format!("--write-batch={name}"),
+        "src/".into(),
+        "dst/".into(),
+    ])
+    .expect_err("batch name over the cap must be rejected");
+    assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+    assert!(
+        err.to_string()
+            .contains("the batch-file name must be 256 characters or less."),
+        "unexpected message: {err}"
+    );
+}
+
+/// upstream: options.c:796-798 - `--write-batch`, `--only-write-batch`, and
+/// `--read-batch` all set the same `batch_name`, so the length cap fires for
+/// whichever one is present. `--read-batch` takes a dest-only operand.
+#[test]
+fn batch_name_cap_enforced_for_each_option() {
+    let over = "a".repeat(MAX_BATCH_NAME_LEN + 1);
+    let at = "a".repeat(MAX_BATCH_NAME_LEN);
+    for (flag, extra) in [
+        ("--write-batch", vec!["src/", "dst/"]),
+        ("--only-write-batch", vec!["src/", "dst/"]),
+        ("--read-batch", vec!["dst/"]),
+    ] {
+        let build = |name: &str| {
+            let mut args = vec![format!("{flag}={name}")];
+            args.extend(extra.iter().map(|s| (*s).to_string()));
+            args
+        };
+        assert!(
+            parse_test_args(build(&over)).is_err(),
+            "{flag} name over the cap must be rejected"
+        );
+        assert!(
+            parse_test_args(build(&at)).is_ok(),
+            "{flag} name of exactly {MAX_BATCH_NAME_LEN} bytes must be accepted"
+        );
+    }
 }

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -612,18 +612,13 @@ where
         flags.bits() as i32
     };
 
-    // upstream: compat.c:750 - checksum_seed = (int32)time(NULL) ^ (getpid() << 6)
-    // Batch files record the seed so the receiver can verify checksums during
-    // replay. Without a proper seed, upstream's --read-batch rejects the file.
-    let batch_checksum_seed = {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i32;
-        let pid = std::process::id() as i32;
-        timestamp ^ (pid << 6)
-    };
+    // upstream: compat.c:811-814 setup_protocol() -
+    //   if (!checksum_seed) checksum_seed = time(NULL) ^ (getpid() << 6);
+    //   write_int(f_out, checksum_seed);
+    // The finalised seed is what io.c:2524 start_write_batch() records in the
+    // batch header, so an explicit --checksum-seed=N (options.c:847) must flow
+    // through unchanged and only an unset seed is derived from time/pid.
+    let batch_checksum_seed = explicit_batch_seed(checksum_seed).unwrap_or_else(derive_batch_seed);
 
     // upstream: batch.c:259 - write_arg(raw_argv[0]) writes the exact binary
     // path the user invoked into the generated BATCH.sh. Mirror that by
@@ -1125,6 +1120,36 @@ fn resolve_old_args(explicit: Option<bool>, protect_args: Option<bool>) -> Optio
     }
 }
 
+/// Returns the explicit checksum seed to record in a batch header, or `None`
+/// when the seed must be derived from time/pid.
+///
+/// upstream: compat.c:811-812 `if (!checksum_seed) checksum_seed = ...` - the
+/// parsed `--checksum-seed=N` (options.c:847, an `int` defaulting to 0) is only
+/// treated as user-supplied when it is non-zero. An explicit `--checksum-seed=0`
+/// is indistinguishable from an unset seed and therefore derives a fresh one,
+/// exactly like omitting the flag. The bit pattern of `N` is preserved across
+/// the `u32 -> i32` cast so that seeds above `i32::MAX` round-trip through the
+/// batch header verbatim.
+fn explicit_batch_seed(parsed: Option<u32>) -> Option<i32> {
+    match parsed {
+        Some(n) if n != 0 => Some(n as i32),
+        _ => None,
+    }
+}
+
+/// Derives a checksum seed from the current time and pid.
+///
+/// upstream: compat.c:812 `checksum_seed = time(NULL) ^ (getpid() << 6)`.
+fn derive_batch_seed() -> i32 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i32;
+    let pid = std::process::id() as i32;
+    timestamp ^ (pid << 6)
+}
+
 /// Opens a log file for appending, creating it if it does not exist.
 fn open_log_file(path: &PathBuf) -> io::Result<File> {
     let mut options = OpenOptions::new();
@@ -1134,4 +1159,48 @@ fn open_log_file(path: &PathBuf) -> io::Result<File> {
         options.mode(0o666);
     }
     options.open(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{derive_batch_seed, explicit_batch_seed};
+
+    /// An explicit non-zero `--checksum-seed=N` must be recorded in the batch
+    /// header verbatim so `--read-batch` replays with the identical seed.
+    /// upstream: compat.c:813-814 writes the parsed seed unchanged; io.c:2524
+    /// tees that same value into the header. Regressing this (e.g. always
+    /// deriving a fresh seed) makes upstream `--read-batch` compute mismatched
+    /// checksums against a batch oc-rsync wrote.
+    #[test]
+    fn explicit_nonzero_seed_flows_through() {
+        assert_eq!(explicit_batch_seed(Some(12345)), Some(12345));
+    }
+
+    /// Seeds above `i32::MAX` must round-trip by bit pattern, matching upstream's
+    /// `int checksum_seed` storage.
+    #[test]
+    fn explicit_large_seed_preserves_bit_pattern() {
+        assert_eq!(
+            explicit_batch_seed(Some(0xDEAD_BEEF)),
+            Some(0xDEAD_BEEFu32 as i32)
+        );
+    }
+
+    /// upstream: compat.c:811 `if (!checksum_seed)` treats an explicit
+    /// `--checksum-seed=0` as unset, so it derives a fresh seed just like
+    /// omitting the flag. Both must return `None` from the explicit-seed
+    /// selector so the caller falls back to derivation.
+    #[test]
+    fn zero_and_unset_seed_derive() {
+        assert_eq!(explicit_batch_seed(Some(0)), None);
+        assert_eq!(explicit_batch_seed(None), None);
+    }
+
+    /// The derivation is `time ^ (pid << 6)`; the pid term is non-zero for any
+    /// real process, so the derived seed is a defined value the header can
+    /// carry. This guards the fallback path from panicking.
+    #[test]
+    fn derive_seed_is_defined() {
+        let _ = derive_batch_seed();
+    }
 }

--- a/crates/cli/tests/option_validation_parity.rs
+++ b/crates/cli/tests/option_validation_parity.rs
@@ -168,6 +168,26 @@ fn read_batch_conflicts_with_remove_source_files() {
     );
 }
 
+// upstream: options.c:2169-2174 - a batch-file name longer than
+// MAX_BATCH_NAME_LEN (rsync.h/options.c:225 = 256) is rejected verbatim and
+// exits RERR_SYNTAX (1). A name of exactly 256 bytes is the boundary and must
+// be accepted (the check is `strlen(batch_name) > MAX_BATCH_NAME_LEN`).
+#[test]
+fn write_batch_name_length_cap_matches_upstream() {
+    let at = "a".repeat(256);
+    parse_args(["oc-rsync", &format!("--write-batch={at}"), "src", "dest"])
+        .expect("256-byte batch name must be accepted");
+
+    let over = "a".repeat(257);
+    let err =
+        parse_args(["oc-rsync", &format!("--write-batch={over}"), "src", "dest"]).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("the batch-file name must be 256 characters or less."),
+        "wrong wording: {err}"
+    );
+}
+
 // upstream: options.c:2299-2304 - a `--suffix` containing a slash is rejected.
 #[test]
 fn suffix_with_slash_is_rejected() {


### PR DESCRIPTION
## Summary

Two local batch-mode parity fixes against upstream rsync 3.4.4 (protocol 32).

### 1. Seed the batch header from a parsed `--checksum-seed=N`

Previously the local `--write-batch` / `--only-write-batch` header always
derived a fresh time/pid seed, ignoring any explicit `--checksum-seed`. That
means a batch written with `--checksum-seed=12345` recorded a different seed in
its header, so an upstream (or oc) `--read-batch` replays with the wrong seed
and computes mismatched checksums.

Upstream mechanism:

- `options.c:847` parses `--checksum-seed` into `int checksum_seed` (default 0).
- `compat.c:811-814` `setup_protocol()`:
  ```c
  if (!checksum_seed)
      checksum_seed = time(NULL) ^ (getpid() << 6);
  write_int(f_out, checksum_seed);
  ```
  The parsed value is used verbatim unless it is unset (0), in which case a
  time/pid seed is derived.
- `io.c:2524` `start_write_batch()` tees that same finalized `checksum_seed`
  into the batch header (`write_int(batch_fd, checksum_seed)`).

Fix: `crates/cli/src/frontend/execution/drive/workflow/run.rs` now selects
`explicit_batch_seed(checksum_seed).unwrap_or_else(derive_batch_seed)`, so an
explicit non-zero seed flows through unchanged and only an unset seed is derived.

Note on `--checksum-seed=0`: upstream's `if (!checksum_seed)` treats an explicit
`0` as unset (0 is the default), so `--checksum-seed=0` derives a fresh seed just
like omitting the flag. This is mirrored exactly, so `0` is not stored as a
literal header seed. Verified end-to-end against the built binary:
`--checksum-seed=12345` writes `0x3039` into the header; no-flag and
`--checksum-seed=0` both derive distinct time/pid seeds; `--read-batch` of the
seed-12345 batch replays successfully.

### 2. Enforce `MAX_BATCH_NAME_LEN` (256) with the exact message + exit 1

The batch-file name length was previously unchecked. Upstream `parse_arguments()`
(`options.c:2169-2174`) rejects a name longer than `MAX_BATCH_NAME_LEN`
(`options.c:225` = 256, "Must be less than MAXPATHLEN-13") set by any of
`--write-batch`, `--only-write-batch`, or `--read-batch` (they share the single
`batch_name`, `options.c:796-798`):

```c
if (batch_name && strlen(batch_name) > MAX_BATCH_NAME_LEN) {
    snprintf(err_buf, sizeof err_buf,
        "the batch-file name must be %d characters or less.\n",
        MAX_BATCH_NAME_LEN);
    goto cleanup;   /* -> RERR_SYNTAX (errcode.h:25 = 1) */
}
```

The check is `strlen > MAX_BATCH_NAME_LEN`, so a 256-byte name is accepted and a
257-byte name rejected. Fix: `crates/cli/src/frontend/arguments/parser/entry.rs`
adds the length gate (byte length, matching `strlen`) emitting
`the batch-file name must be 256 characters or less.` via `clap::Error::raw`,
which `clap_parse_error_exit_code` maps to exit 1 (RERR_SYNTAX). Verified against
the built binary: 257 bytes -> `syntax or usage error: the batch-file name must
be 256 characters or less.` exit 1; 256 bytes passes the gate.

## Tests

- `run.rs` unit tests: `explicit_nonzero_seed_flows_through`,
  `explicit_large_seed_preserves_bit_pattern` (bit pattern preserved across
  `u32 -> i32`), `zero_and_unset_seed_derive` (0 and unset both derive),
  `derive_seed_is_defined`.
- `parser/tests.rs`: `batch_name_at_max_len_accepted`,
  `batch_name_over_max_len_rejected_with_exact_message` (asserts the exact
  message and `ValueValidation` kind, which maps to exit 1),
  `batch_name_cap_enforced_for_each_option` (all three batch options).
- `crates/cli/tests/option_validation_parity.rs`:
  `write_batch_name_length_cap_matches_upstream` (256 accepted / 257 rejected
  with verbatim wording through the public parse path).

`cargo fmt --all -- --check` and `cargo clippy -p cli --all-targets
--all-features --no-deps -- -D warnings` are clean.
