### PR TITLE
fix(filters): keep -C CVS rules local on receiver and gate :C on proto 29

### DIFF
--- a/crates/cli/src/frontend/filter_rules/cvs.rs
+++ b/crates/cli/src/frontend/filter_rules/cvs.rs
@@ -23,7 +23,14 @@ pub(crate) fn append_cvs_exclude_rules(
         .allow_list_clearing(true);
     cvs_rules.push(FilterRuleSpec::dir_merge(".cvsignore".to_owned(), options));
 
-    destination.extend(cvs_rules);
+    // upstream: exclude.c:1652-1668 send_filter_list() - the `-C` built-in
+    // excludes and the `:C` per-directory merge stay local on a receiving client
+    // and (for `:C`) only cross the wire on protocol >= 29. Tag every rule this
+    // path produces so the wire projection can honor that gating; the `-C` flag
+    // is independently forwarded to the peer in argv (remote::flags), which runs
+    // its own get_cvs_excludes(), so transmitting these rules on a pull would be
+    // both redundant and non-upstream.
+    destination.extend(cvs_rules.into_iter().map(|rule| rule.with_cvs_origin(true)));
     Ok(())
 }
 
@@ -115,6 +122,40 @@ where
 mod tests {
     use super::*;
     use core::client::FilterRuleKind;
+
+    #[test]
+    fn append_cvs_exclude_rules_marks_every_rule_cvs_origin() {
+        // upstream: exclude.c:1652-1668 send_filter_list() - the `-C` built-in
+        // excludes and the `:C` per-directory merge follow the CVS send gate
+        // (local on a receiving client, `:C` only on protocol >= 29). Every rule
+        // this path produces must carry the origin marker so build_wire_format_rules
+        // can forward it to the wire projection.
+        let mut rules = Vec::new();
+        append_cvs_exclude_rules(&mut rules).expect("cvs rules build");
+        assert!(!rules.is_empty());
+        assert!(
+            rules.iter().all(FilterRuleSpec::is_cvs_origin),
+            "every -C rule must be tagged cvs_origin"
+        );
+        // The trailing `:C` per-directory merge is present and tagged.
+        let dir_merge = rules
+            .iter()
+            .find(|r| r.kind() == FilterRuleKind::DirMerge)
+            .expect(":C dir-merge present");
+        assert!(dir_merge.is_cvs_origin());
+        assert_eq!(dir_merge.pattern(), ".cvsignore");
+    }
+
+    #[test]
+    fn cvs_default_exclude_rules_are_not_cvs_origin() {
+        // The `--filter` CVS convenience path (FilterDirective::CvsDefaults) uses
+        // cvs_default_exclude_rules() directly and does NOT forward `-C` in argv,
+        // so upstream transmits those rules on the wire; they must not be tagged
+        // cvs_origin (which would wrongly keep them local on a pull).
+        let rules = cvs_default_exclude_rules().expect("cvs defaults build");
+        assert!(!rules.is_empty());
+        assert!(rules.iter().all(|r| !r.is_cvs_origin()));
+    }
 
     #[test]
     fn append_cvsignore_tokens_adds_basic_pattern() {

--- a/crates/core/src/client/config/filters.rs
+++ b/crates/core/src/client/config/filters.rs
@@ -30,6 +30,12 @@ pub struct FilterRuleSpec {
     perishable: bool,
     xattr_only: bool,
     negate: bool,
+    /// Marks a rule produced by the `-C`/`--cvs-exclude` built-in expansion so
+    /// the wire projection can reproduce upstream's CVS send gating (local on a
+    /// receiving client; `:C` only on protocol >= 29).
+    ///
+    /// upstream: exclude.c:1652-1668 send_filter_list().
+    cvs_origin: bool,
 }
 
 impl FilterRuleSpec {
@@ -46,6 +52,7 @@ impl FilterRuleSpec {
             perishable: false,
             xattr_only: false,
             negate: false,
+            cvs_origin: false,
         }
     }
 
@@ -62,6 +69,7 @@ impl FilterRuleSpec {
             perishable: false,
             xattr_only: false,
             negate: false,
+            cvs_origin: false,
         }
     }
 
@@ -77,6 +85,7 @@ impl FilterRuleSpec {
             perishable: false,
             xattr_only: false,
             negate: false,
+            cvs_origin: false,
         }
     }
 
@@ -92,6 +101,7 @@ impl FilterRuleSpec {
             perishable: false,
             xattr_only: false,
             negate: false,
+            cvs_origin: false,
         }
     }
 
@@ -107,6 +117,7 @@ impl FilterRuleSpec {
             perishable: false,
             xattr_only: false,
             negate: false,
+            cvs_origin: false,
         }
     }
 
@@ -123,6 +134,7 @@ impl FilterRuleSpec {
             perishable: false,
             xattr_only: false,
             negate: false,
+            cvs_origin: false,
         }
     }
 
@@ -139,6 +151,7 @@ impl FilterRuleSpec {
             perishable: false,
             xattr_only: false,
             negate: false,
+            cvs_origin: false,
         }
     }
 
@@ -154,6 +167,7 @@ impl FilterRuleSpec {
             perishable: false,
             xattr_only: false,
             negate: false,
+            cvs_origin: false,
         }
     }
 
@@ -169,6 +183,7 @@ impl FilterRuleSpec {
             perishable: false,
             xattr_only: false,
             negate: false,
+            cvs_origin: false,
         }
     }
 
@@ -322,6 +337,24 @@ impl FilterRuleSpec {
     #[must_use]
     pub const fn is_negated(&self) -> bool {
         self.negate
+    }
+
+    /// Marks the rule as originating from the `-C`/`--cvs-exclude` built-in
+    /// expansion.
+    ///
+    /// upstream: exclude.c:1652-1668 send_filter_list() - CVS rules follow a
+    /// distinct wire-vs-local send path keyed on the sending role and protocol
+    /// version.
+    #[must_use]
+    pub const fn with_cvs_origin(mut self, cvs_origin: bool) -> Self {
+        self.cvs_origin = cvs_origin;
+        self
+    }
+
+    /// Reports whether the rule came from the `-C`/`--cvs-exclude` expansion.
+    #[must_use]
+    pub const fn is_cvs_origin(&self) -> bool {
+        self.cvs_origin
     }
 
     /// Anchors the pattern to the root of the transfer when requested.

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -302,6 +302,10 @@ pub(crate) fn build_wire_format_rules(
             receiver_side: wire_receiver_side(spec),
             perishable: spec.is_perishable(),
             negate: spec.is_negated(),
+            // upstream: exclude.c:1652-1668 send_filter_list() gates `-C` rules
+            // on the sending role and protocol; carry the origin so the wire
+            // projection (transfer::wire_rule_crosses_wire) can reproduce it.
+            cvs_origin: spec.is_cvs_origin(),
             ..FilterRuleWireFormat::default()
         };
 
@@ -1034,6 +1038,25 @@ mod tests {
         assert!(rules[0].cvs_exclude);
         assert!(rules[0].no_inherit);
         assert!(rules[0].word_split);
+    }
+
+    /// upstream: exclude.c:1652-1668 send_filter_list() - `-C` rules are gated by
+    /// the sending role and protocol. build_wire_format_rules must forward the
+    /// spec's cvs-origin marker onto the wire rule so transfer::wire_rule_crosses_wire
+    /// can keep them local on a receiving client (and gate `:C` on protocol >= 29).
+    #[test]
+    fn cvs_origin_marker_propagates_to_wire_rule() {
+        let plain = FilterRuleSpec::exclude("*.o").with_cvs_origin(true);
+        let normal = FilterRuleSpec::exclude("*.tmp");
+        let rules = build_wire_format_rules(&[plain, normal], false)
+            .expect("should forward cvs_origin to wire format");
+
+        assert_eq!(rules.len(), 2);
+        assert!(rules[0].cvs_origin, "cvs-origin exclude must be marked");
+        assert!(
+            !rules[1].cvs_origin,
+            "an ordinary --exclude must not be marked cvs-origin"
+        );
     }
 
     /// upstream: exclude.c:1330-1332 - --delete-excluded applies an implicit

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -100,6 +100,19 @@ pub struct FilterRuleWireFormat {
     /// When `no_prefixes && no_prefixes_include`, the merge file's per-dir
     /// rules are treated as include-only; otherwise they are exclude-only.
     pub no_prefixes_include: bool,
+    /// Marks a rule produced by the `-C`/`--cvs-exclude` built-in expansion.
+    ///
+    /// This is transfer-decision metadata, NOT part of the wire encoding: it is
+    /// never serialized and always parses back as `false`. It exists so the
+    /// send path can reproduce upstream's `send_filter_list()` role/protocol
+    /// gating for CVS rules - kept local on a receiving client, and (for the
+    /// `:C` per-directory merge) only crossing the wire on protocol >= 29.
+    ///
+    /// upstream: exclude.c:1652-1668 send_filter_list() - the `-C` rules are
+    /// added to the transmitted list only when `am_sender`, and `:C` only when
+    /// `protocol_version >= 29`; otherwise they are appended after `send_rules()`
+    /// and stay local.
+    pub cvs_origin: bool,
 }
 
 impl FilterRuleWireFormat {
@@ -121,6 +134,7 @@ impl FilterRuleWireFormat {
             negate: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            cvs_origin: false,
         }
     }
 
@@ -142,6 +156,7 @@ impl FilterRuleWireFormat {
             negate: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            cvs_origin: false,
         }
     }
 

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -290,14 +290,41 @@ pub(crate) const fn receiver_wants_filter_list(
 /// `s` modifier - upstream `add_rule()` deliberately spares per-directory merges
 /// from the implicit sender-side flip.
 ///
+/// CVS rules produced by `-C`/`--cvs-exclude` follow a separate gate: upstream's
+/// `send_filter_list()` adds them to the transmitted list only on a sending
+/// client (`am_sender`), and adds the `:C` per-directory merge only when the
+/// negotiated protocol is >= 29; on a receiving client they are appended after
+/// `send_rules()` and never cross the wire. The `-C` flag is forwarded to the
+/// peer in argv, so the peer regenerates them locally - transmitting them on a
+/// pull would be redundant and non-upstream, and emitting `:C` on a legacy peer
+/// would abort with "filter rules are too modern".
+///
 /// # Upstream Reference
 ///
-/// `exclude.c:1605-1612` (`send_rules`); `exclude.c:1330-1332` (`add_rule`).
+/// `exclude.c:1605-1612` (`send_rules`); `exclude.c:1330-1332` (`add_rule`);
+/// `exclude.c:1652-1668` (`send_filter_list`, the CVS role/protocol gate).
 fn wire_rule_crosses_wire(
     rule: &protocol::filters::FilterRuleWireFormat,
     client_is_sender: bool,
     delete_excluded: bool,
+    protocol: protocol::ProtocolVersion,
 ) -> bool {
+    if rule.cvs_origin {
+        // upstream: exclude.c:1652 send_filter_list() - `if (cvs_exclude && am_sender)`
+        // adds the `-C` rules before send_rules(); a receiving client adds them
+        // only afterwards (exclude.c:1663-1668), so they never cross the wire.
+        if !client_is_sender {
+            return false;
+        }
+        // upstream: exclude.c:1653 send_filter_list() - the `:C` per-directory
+        // merge is added to the transmitted list only when protocol_version >= 29;
+        // on a legacy peer it is kept local (exclude.c:1664) instead.
+        if matches!(rule.rule_type, protocol::filters::RuleType::DirMerge)
+            && protocol.uses_old_prefixes()
+        {
+            return false;
+        }
+    }
     let side_local = if client_is_sender {
         rule.sender_side
     } else {
@@ -760,7 +787,12 @@ pub fn run_server_with_handshake_adopting<W: Write>(
             .filter_rules
             .iter()
             .filter(|rule| {
-                wire_rule_crosses_wire(rule, client_is_sender, config.deletion.delete_excluded)
+                wire_rule_crosses_wire(
+                    rule,
+                    client_is_sender,
+                    config.deletion.delete_excluded,
+                    handshake.protocol,
+                )
             })
             .cloned()
             .collect();

--- a/crates/transfer/src/tests/filter_list_gate.rs
+++ b/crates/transfer/src/tests/filter_list_gate.rs
@@ -99,7 +99,12 @@ fn dir_merge(no_prefixes: bool) -> FilterRuleWireFormat {
 #[test]
 fn no_prefix_dir_merge_elided_on_push_under_delete_excluded() {
     let rule = dir_merge(true);
-    assert!(!wire_rule_crosses_wire(&rule, true, true));
+    assert!(!wire_rule_crosses_wire(
+        &rule,
+        true,
+        true,
+        ProtocolVersion::V32
+    ));
 }
 
 /// On a PULL the same rule is REMOTE_RULE and still crosses the wire, WITHOUT a
@@ -109,7 +114,12 @@ fn no_prefix_dir_merge_elided_on_push_under_delete_excluded() {
 #[test]
 fn no_prefix_dir_merge_transmitted_on_pull_under_delete_excluded() {
     let rule = dir_merge(true);
-    assert!(wire_rule_crosses_wire(&rule, false, true));
+    assert!(wire_rule_crosses_wire(
+        &rule,
+        false,
+        true,
+        ProtocolVersion::V32
+    ));
 }
 
 /// A prefixed `:` merge (has prefixes) is never elided - only no-prefix merges
@@ -117,7 +127,12 @@ fn no_prefix_dir_merge_transmitted_on_pull_under_delete_excluded() {
 #[test]
 fn prefixed_dir_merge_not_elided_under_delete_excluded() {
     let rule = dir_merge(false);
-    assert!(wire_rule_crosses_wire(&rule, true, true));
+    assert!(wire_rule_crosses_wire(
+        &rule,
+        true,
+        true,
+        ProtocolVersion::V32
+    ));
 }
 
 /// Without `--delete-excluded`, a no-prefix dir-merge is transmitted normally on
@@ -125,8 +140,18 @@ fn prefixed_dir_merge_not_elided_under_delete_excluded() {
 #[test]
 fn no_prefix_dir_merge_transmitted_without_delete_excluded() {
     let rule = dir_merge(true);
-    assert!(wire_rule_crosses_wire(&rule, true, false));
-    assert!(wire_rule_crosses_wire(&rule, false, false));
+    assert!(wire_rule_crosses_wire(
+        &rule,
+        true,
+        false,
+        ProtocolVersion::V32
+    ));
+    assert!(wire_rule_crosses_wire(
+        &rule,
+        false,
+        false,
+        ProtocolVersion::V32
+    ));
 }
 
 /// Side-local rules are always elided toward the peer regardless of
@@ -139,16 +164,36 @@ fn side_local_rules_are_elided() {
         sender_side: true,
         ..FilterRuleWireFormat::default()
     };
-    assert!(!wire_rule_crosses_wire(&sender_side, true, false));
-    assert!(wire_rule_crosses_wire(&sender_side, false, false));
+    assert!(!wire_rule_crosses_wire(
+        &sender_side,
+        true,
+        false,
+        ProtocolVersion::V32
+    ));
+    assert!(wire_rule_crosses_wire(
+        &sender_side,
+        false,
+        false,
+        ProtocolVersion::V32
+    ));
 
     let receiver_side = FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
         receiver_side: true,
         ..FilterRuleWireFormat::default()
     };
-    assert!(wire_rule_crosses_wire(&receiver_side, true, false));
-    assert!(!wire_rule_crosses_wire(&receiver_side, false, false));
+    assert!(wire_rule_crosses_wire(
+        &receiver_side,
+        true,
+        false,
+        ProtocolVersion::V32
+    ));
+    assert!(!wire_rule_crosses_wire(
+        &receiver_side,
+        false,
+        false,
+        ProtocolVersion::V32
+    ));
 }
 
 /// An explicitly sender-sided no-prefix merge (`:s-`) is handled by the
@@ -163,7 +208,128 @@ fn explicitly_sided_no_prefix_merge_uses_side_check() {
         ..FilterRuleWireFormat::default()
     };
     // Push: elided via the side-local check.
-    assert!(!wire_rule_crosses_wire(&rule, true, true));
+    assert!(!wire_rule_crosses_wire(
+        &rule,
+        true,
+        true,
+        ProtocolVersion::V32
+    ));
     // Pull: sender-side rule still crosses to the remote sender.
-    assert!(wire_rule_crosses_wire(&rule, false, true));
+    assert!(wire_rule_crosses_wire(
+        &rule,
+        false,
+        true,
+        ProtocolVersion::V32
+    ));
+}
+
+// -- CVS-origin send gate (exclude.c:1652-1668 send_filter_list) --
+
+/// A built-in `-C` exclude (e.g. `- *.o`) carries no side flag, so before the
+/// CVS gate it crossed the wire on both directions. Upstream only adds the `-C`
+/// rules to the transmitted list on a sending client (`am_sender`); a receiving
+/// client appends them after `send_rules()` (exclude.c:1663-1668), so they must
+/// stay local on a pull. The `-C` flag is forwarded to the peer in argv, which
+/// regenerates the excludes itself, so transmitting them would be redundant and
+/// non-upstream bytes on the wire.
+#[test]
+fn cvs_origin_exclude_local_on_pull_transmitted_on_push() {
+    let rule = FilterRuleWireFormat {
+        rule_type: RuleType::Exclude,
+        pattern: "*.o".to_owned(),
+        cvs_origin: true,
+        ..FilterRuleWireFormat::default()
+    };
+    // Pull (receiving client): kept local, never transmitted.
+    assert!(!wire_rule_crosses_wire(
+        &rule,
+        false,
+        false,
+        ProtocolVersion::V32
+    ));
+    // Push (sending client): the built-in list crosses at any protocol.
+    assert!(wire_rule_crosses_wire(
+        &rule,
+        true,
+        false,
+        ProtocolVersion::V32
+    ));
+    assert!(wire_rule_crosses_wire(
+        &rule,
+        true,
+        false,
+        ProtocolVersion::V28
+    ));
+}
+
+/// The `:C` per-directory merge is a protocol >= 29 wire feature: upstream adds
+/// it to the transmitted list only when `protocol_version >= 29`
+/// (exclude.c:1653), and keeps it local on a legacy peer (exclude.c:1664).
+/// Emitting it on a pre-29 peer would abort with "filter rules are too modern"
+/// because `get_rule_prefix()` cannot encode a per-directory merge there.
+#[test]
+fn cvs_origin_dir_merge_gated_on_protocol_29() {
+    let rule = FilterRuleWireFormat {
+        rule_type: RuleType::DirMerge,
+        pattern: ".cvsignore".to_owned(),
+        cvs_exclude: true,
+        cvs_origin: true,
+        ..FilterRuleWireFormat::default()
+    };
+    // Push, protocol >= 29: `:C` crosses the wire.
+    assert!(wire_rule_crosses_wire(
+        &rule,
+        true,
+        false,
+        ProtocolVersion::V29
+    ));
+    assert!(wire_rule_crosses_wire(
+        &rule,
+        true,
+        false,
+        ProtocolVersion::V32
+    ));
+    // Push, protocol < 29: `:C` is unsendable and kept local instead.
+    assert!(!wire_rule_crosses_wire(
+        &rule,
+        true,
+        false,
+        ProtocolVersion::V28
+    ));
+    // Pull: kept local at every protocol (receiving client).
+    assert!(!wire_rule_crosses_wire(
+        &rule,
+        false,
+        false,
+        ProtocolVersion::V32
+    ));
+    assert!(!wire_rule_crosses_wire(
+        &rule,
+        false,
+        false,
+        ProtocolVersion::V28
+    ));
+}
+
+/// A manually specified `:C` filter directive (NOT from the `-C` flag) has no
+/// CVS origin marker, so the pull-local / pre-29 gate does not fire for it: it
+/// follows the ordinary send path, matching upstream where such a rule is a
+/// literal filter-list entry that errors on a legacy peer rather than being
+/// silently kept local.
+#[test]
+fn manual_dir_merge_without_cvs_origin_not_gated() {
+    let rule = FilterRuleWireFormat {
+        rule_type: RuleType::DirMerge,
+        pattern: ".cvsignore".to_owned(),
+        cvs_exclude: true,
+        cvs_origin: false,
+        ..FilterRuleWireFormat::default()
+    };
+    // No CVS origin: crosses on a pull (ordinary send path).
+    assert!(wire_rule_crosses_wire(
+        &rule,
+        false,
+        false,
+        ProtocolVersion::V32
+    ));
 }


### PR DESCRIPTION
## Summary

Aligns `-C` / `--cvs-exclude` filter-rule wire placement with upstream rsync 3.4.4 (protocol 32). Two divergences are fixed:

- **(b) CVS rules must stay local on a receiving client (pull).** Upstream keeps them local and never transmits them; oc leaked them onto the wire on a pull.
- **(c) The `:C` per-directory `.cvsignore` merge is a protocol >= 29 wire feature.** Upstream gates it on the negotiated protocol; oc would try to serialize it on a pre-29 peer and abort.

## Upstream reference (the GOAL)

All citations are from `exclude.c` in the upstream 3.4.4 source.

**(a) Which rules `-C` generates, and which are sent vs local.** `get_cvs_excludes()` (`exclude.c:1340-1358`) parses the built-in `default_cvsignore()` list, `$HOME/.cvsignore`, and `$CVSIGNORE` into a separate `cvs_filter_list` (`exclude.c:50`). The transmitted `filter_list` receives only the `-C` marker rule and the `:C` per-directory merge. The `-C` flag itself is forwarded to the peer in argv (`options.c:105-106`, `server_options()`), so the remote independently runs `get_cvs_excludes()` / adds `:C`/`-C` in `recv_filter_list()` (`exclude.c:1689-1694`).

**(b) The role condition making CVS rules local-only.** In `send_filter_list()` (client-only, `exclude.c:1645`):

```c
if (cvs_exclude && am_sender) {                 // exclude.c:1652
    if (protocol_version >= 29)                  // exclude.c:1653
        parse_filter_str(&filter_list, ":C", ...);  // transmitted
    parse_filter_str(&filter_list, "-C", ...);       // transmitted
}
send_rules(f_out, &filter_list);
...
if (cvs_exclude) {                               // exclude.c:1663
    if (!am_sender || protocol_version < 29)
        parse_filter_str(&filter_list, ":C", ...);   // exclude.c:1664-1665 -> local
    if (!am_sender)
        parse_filter_str(&filter_list, "-C", ...);   // exclude.c:1666-1667 -> local
}
```

On a receiving client (`!am_sender`) the CVS rules are added only *after* `send_rules()` and never cross the wire.

**(c) The protocol gate for `:C`.** `exclude.c:1653` adds `:C` to the transmitted list only when `protocol_version >= 29`; on a legacy peer it is kept local instead (`exclude.c:1664`). This is reinforced by `get_rule_prefix()` (`exclude.c:1530-1534`): a per-directory merge rule returns `NULL` (unsendable) when `for_xfer && protocol_version < 29`, which upstream turns into `RERR_PROTOCOL` in `send_rules()` (`exclude.c:1623-1628`).

## The divergence in oc (current master)

oc expands the `-C` rules inline into the shared filter-rule list in `append_cvs_exclude_rules()` (`crates/cli/src/frontend/filter_rules/cvs.rs`): the built-in excludes, `$HOME/.cvsignore` / `$CVSIGNORE` tokens, and the `:C` `.cvsignore` dir-merge. The wire projection in `transfer::wire_rule_crosses_wire` (`crates/transfer/src/lib.rs`) elided only side-local rules and (under `--delete-excluded`) no-prefix dir-merges - it had no CVS handling. As a result:

- **Pull:** every `-C` rule crossed the wire, redundant with the argv `-C` the remote sender already applies, and non-upstream wire bytes.
- **Push, protocol < 29:** the `:C` dir-merge reached `serialize_rule()`, where `build_rule_prefix()` returns `None` for a dir-merge on a pre-29 peer, aborting the transfer with `RERR_PROTOCOL` - where upstream silently keeps `:C` local and continues.

The `receiver_wants_filter_list` gate and the `--delete-excluded` side elision were already correct and are unchanged.

## The fix

- Add a non-serialized `cvs_origin` marker to `FilterRuleSpec` and `FilterRuleWireFormat`. It is transfer-decision metadata only: never written to the wire, always parses back as `false`.
- `append_cvs_exclude_rules()` tags every rule it produces (built-ins, `.cvsignore`/`$CVSIGNORE` tokens, and the `:C` dir-merge). The `--filter` CVS convenience path (`FilterDirective::CvsDefaults`), which does not forward argv `-C`, is deliberately **not** tagged.
- `build_wire_format_rules()` forwards the marker onto the wire rule.
- `wire_rule_crosses_wire()` gains the negotiated protocol and honors the marker: cvs-origin rules are elided on a receiving client (b), and the `:C` dir-merge is additionally elided on protocol < 29 (c). A manually specified `:C` filter directive has no marker and keeps the ordinary send path (erroring on a legacy peer, matching upstream).

The gate uses the **negotiated** `handshake.protocol` (via `ProtocolVersion::uses_old_prefixes`, protocol < 29), not `NEWEST`.

## Tests

- `crates/transfer/src/tests/filter_list_gate.rs`: `cvs_origin_exclude_local_on_pull_transmitted_on_push` (built-in `-C` exclude stays local on a pull, crosses on a push at any protocol); `cvs_origin_dir_merge_gated_on_protocol_29` (`:C` crosses on push at proto >= 29, kept local at proto < 29, local on any pull); `manual_dir_merge_without_cvs_origin_not_gated` (a manual `:C` is unaffected).
- `crates/core/.../flags.rs`: `cvs_origin_marker_propagates_to_wire_rule` (marker survives `build_wire_format_rules`).
- `crates/cli/.../filter_rules/cvs.rs`: `append_cvs_exclude_rules_marks_every_rule_cvs_origin` and `cvs_default_exclude_rules_are_not_cvs_origin` (only the `-C` flag path is tagged).

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` are clean. The affected unit tests pass locally (transfer/core/cli scoped runs); the full protocol filter suite (908 tests) passes unchanged.

## Out of scope

The intra-CVS ordering of oc's inline expansion (built-ins before `:C`, versus upstream's `:C` before the expanded built-ins on a push) is a pre-existing behavior independent of wire placement and is not changed here.
