### PR TITLE
test(engine): make AIMD debounce tests use a deterministic clock

### DIFF
--- a/crates/engine/src/concurrent_delta/work_queue/limiter/rate.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/limiter/rate.rs
@@ -33,6 +33,10 @@ pub struct AimdLimiter {
     alpha: u32,
     beta_num: u32,
     beta_den: u32,
+    // Monotonic nanosecond clock. Production wires this to `now_nanos`; tests
+    // may inject a deterministic clock so debounce windows are timed against a
+    // controllable virtual clock rather than real wall-clock elapsed time.
+    now: fn() -> u64,
 }
 
 impl AimdLimiter {
@@ -60,7 +64,19 @@ impl AimdLimiter {
             alpha,
             beta_num,
             beta_den,
+            now: Self::now_nanos,
         }
+    }
+
+    /// Constructs a limiter that reads time from `now` instead of the default
+    /// monotonic clock. Test-only: lets debounce/decay behaviour be exercised
+    /// against a deterministic virtual clock. Production always uses
+    /// [`AimdLimiter::new`], which wires `now` to [`AimdLimiter::now_nanos`].
+    #[cfg(test)]
+    pub(super) fn with_clock(config: LimiterConfig, now: fn() -> u64) -> Self {
+        let mut limiter = Self::new(config);
+        limiter.now = now;
+        limiter
     }
 
     /// Returns the current concurrency target.
@@ -95,7 +111,7 @@ impl AimdLimiter {
                 Ordering::Acquire,
             ) {
                 Ok(_) => {
-                    return Some(Ticket::new(self, Self::now_nanos()));
+                    return Some(Ticket::new(self, (self.now)()));
                 }
                 Err(observed) => current = observed,
             }
@@ -104,7 +120,7 @@ impl AimdLimiter {
 
     /// Releases a ticket as a success. Updates RTT EMA and may grow `target`.
     pub(super) fn release_success(&self, acquired_at: u64) {
-        let now = Self::now_nanos();
+        let now = (self.now)();
         let sample = now.saturating_sub(acquired_at);
         self.update_rtt(sample);
         self.in_flight.fetch_sub(1, Ordering::AcqRel);
@@ -130,7 +146,7 @@ impl AimdLimiter {
     /// Releases a ticket as an overload signal. Halves `target` subject to
     /// the `2 * rtt_ema` debounce window.
     pub(super) fn release_overload(&self, acquired_at: u64, _reason: OverloadReason) {
-        let now = Self::now_nanos();
+        let now = (self.now)();
         // Still update the RTT EMA from this sample; the latency carries useful
         // information even on the overload path.
         let sample = now.saturating_sub(acquired_at);

--- a/crates/engine/src/concurrent_delta/work_queue/limiter/tests/aimd.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/limiter/tests/aimd.rs
@@ -7,7 +7,7 @@ use std::thread;
 use std::time::Duration;
 
 use super::super::{AimdLimiter, OverloadReason};
-use super::limiter_with;
+use super::{limiter_with, limiter_with_clock};
 
 #[test]
 fn additive_increase_after_target_successes() {
@@ -60,15 +60,18 @@ fn increase_clamped_to_max_limit() {
 
 #[test]
 fn debounce_suppresses_back_to_back_decreases() {
-    let limiter = limiter_with(8, 1, 16);
-    // Seed a non-trivial RTT EMA so the debounce window has length.
+    // Driven by a virtual clock so "back to back" is guaranteed inside the
+    // debounce window regardless of runner load.
+    let (limiter, _clock) = limiter_with_clock(8, 1, 16);
+    // Seed a non-trivial RTT EMA so the debounce window has length (20 ms).
     limiter.update_rtt(10_000_000); // 10 ms
     // First overload: decreases.
     let t1 = limiter.try_acquire().unwrap();
     t1.record_overload(OverloadReason::RttSpike);
     let after_first = limiter.target();
     assert!(after_first < 8);
-    // Second overload immediately after: suppressed.
+    // Second overload with the clock unadvanced: strictly inside the window,
+    // so the decrease is suppressed.
     let t2 = limiter.try_acquire().unwrap();
     t2.record_overload(OverloadReason::RttSpike);
     assert_eq!(
@@ -237,7 +240,9 @@ fn max_limit_reached_during_slow_start() {
 
 #[test]
 fn debounce_expires_after_twice_rtt_ema() {
-    let limiter = limiter_with(16, 1, 64);
+    // Virtual clock: the window is crossed by advancing the clock explicitly,
+    // never by sleeping, so the assertion cannot race runner scheduling.
+    let (limiter, clock) = limiter_with_clock(16, 1, 64);
     // Seed RTT EMA to 5ms so debounce window = 10ms.
     for _ in 0..16 {
         limiter.update_rtt(5_000_000);
@@ -247,13 +252,13 @@ fn debounce_expires_after_twice_rtt_ema() {
     let after_first = limiter.target();
     assert_eq!(after_first, 8);
 
-    // Immediate second overload: debounce suppresses.
+    // Second overload with the clock unadvanced: debounce suppresses.
     let t = limiter.try_acquire().unwrap();
     t.record_overload(OverloadReason::ErrorRate);
     assert_eq!(limiter.target(), 8, "suppressed within debounce window");
 
-    // Wait past 2 * rtt_ema (~10ms), then overload again.
-    thread::sleep(Duration::from_millis(15));
+    // Advance past 2 * rtt_ema (10ms), then overload again.
+    clock.advance(11_000_000);
     let t = limiter.try_acquire().unwrap();
     t.record_overload(OverloadReason::ErrorRate);
     assert_eq!(
@@ -294,9 +299,12 @@ fn mixed_transient_and_deterministic_errors() {
 fn debounce_prevents_cascading_collapse() {
     // Without debounce, N back-to-back overloads would collapse
     // target to min_limit. With debounce, only the first should
-    // take effect within the window.
-    let limiter = limiter_with(64, 4, 256);
-    // Seed a 5ms RTT so debounce window is ~10ms.
+    // take effect within the window. A virtual clock makes the burst
+    // provably land inside the window regardless of runner scheduling:
+    // the flake was a real-time debounce window expiring mid-burst on a
+    // loaded runner.
+    let (limiter, clock) = limiter_with_clock(64, 4, 256);
+    // Seed a 5ms RTT so debounce window is 10ms.
     for _ in 0..16 {
         limiter.update_rtt(5_000_000);
     }
@@ -307,8 +315,8 @@ fn debounce_prevents_cascading_collapse() {
     let after_first = limiter.target();
     assert_eq!(after_first, 32);
 
-    // Rapid burst of 10 overloads within the debounce window (~10ms).
-    // None should decrease further.
+    // Rapid burst of 10 overloads with the clock unadvanced: every one lands
+    // strictly inside the debounce window, so none may decrease further.
     for _ in 0..10 {
         let t = limiter.try_acquire().unwrap();
         t.record_overload(OverloadReason::QueueSaturated);
@@ -319,8 +327,8 @@ fn debounce_prevents_cascading_collapse() {
         "debounce must prevent cascading collapse from rapid burst",
     );
 
-    // After debounce expires, next overload should take effect.
-    thread::sleep(Duration::from_millis(15));
+    // Advance past the 10ms window; the next overload should take effect.
+    clock.advance(11_000_000);
     let t = limiter.try_acquire().unwrap();
     t.record_overload(OverloadReason::DiskCommitPressure);
     assert_eq!(

--- a/crates/engine/src/concurrent_delta/work_queue/limiter/tests/mod.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/limiter/tests/mod.rs
@@ -8,6 +8,7 @@
 //!   error bursts.
 //! - `concurrent`: multi-threaded contention and panic-path safety.
 
+use std::cell::Cell;
 use std::thread;
 use std::time::Duration;
 
@@ -24,6 +25,45 @@ fn limiter_with(initial: usize, min: usize, max: usize) -> AimdLimiter {
         .min_limit(min)
         .max_limit(max)
         .build()
+}
+
+thread_local! {
+    /// Virtual nanosecond clock for debounce/decay tests. Thread-local so each
+    /// test (which runs on its own thread) drives an independent clock with no
+    /// cross-test interference.
+    static FAKE_CLOCK: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Reads the thread-local virtual clock. Passed to [`AimdLimiter::with_clock`]
+/// as a plain function pointer so the limiter's hot path stays allocation-free.
+fn fake_now() -> u64 {
+    FAKE_CLOCK.with(|c| c.get())
+}
+
+/// Handle that advances the virtual clock a limiter reads via [`fake_now`].
+///
+/// Debounce windows are measured against this clock instead of real elapsed
+/// wall-clock time, so tests are immune to runner load: "within the window"
+/// means the clock is not advanced, and "after the window" means the clock is
+/// advanced explicitly past the debounce span.
+struct TestClock;
+
+impl TestClock {
+    /// Advances the virtual clock by `nanos`.
+    fn advance(&self, nanos: u64) {
+        FAKE_CLOCK.with(|c| c.set(c.get().saturating_add(nanos)));
+    }
+}
+
+/// Builds a limiter driven by the deterministic thread-local virtual clock,
+/// returning the limiter and a handle to advance that clock.
+fn limiter_with_clock(initial: usize, min: usize, max: usize) -> (AimdLimiter, TestClock) {
+    FAKE_CLOCK.with(|c| c.set(1));
+    let limiter = AimdLimiter::with_clock(
+        LimiterConfig::new(initial).min_limit(min).max_limit(max),
+        fake_now,
+    );
+    (limiter, TestClock)
 }
 
 /// Completes one full success window (target consecutive successes).


### PR DESCRIPTION
## Summary

Makes the AIMD limiter's debounce tests deterministic by driving the debounce
window against an injectable virtual clock instead of real wall-clock elapsed
time. No production behavior changes.

## Root cause (timing flake)

`concurrent_delta::work_queue::limiter::tests::aimd::debounce_prevents_cascading_collapse`
seeds a 5ms RTT (debounce window ~10ms), records one overload (target 64 -> 32),
then fires a burst of 10 `record_overload` calls and asserts the target stays 32
because all 10 land inside the ~10ms window. The debounce is measured with real
monotonic time (`Instant::now()` via `now_nanos`), so the assertion's correctness
depends on how fast the burst executes.

On a load-contended runner the burst can be descheduled past 10ms, the window
expires mid-burst, a later overload halves the target to 16, and the assertion
fails. The signature is telling: it failed on the non-required feature-flag
`iconv (macos-latest)` cell while the required `macOS (stable)` nextest ran the
identical test and passed. Same code, same OS, different scheduling pressure -
a classic real-time flake, not a logic bug.

## Fix

- Add an injectable time source to `AimdLimiter`: a plain `now: fn() -> u64`
  field. Production wires it to `now_nanos` in `AimdLimiter::new` (unchanged
  behavior, no allocation, no boxed trait object on the hot path). A test-only
  `with_clock` constructor lets tests supply a deterministic clock.
- Route the three time-source call sites (`try_acquire`, `release_success`,
  `release_overload`) through the injected `now` instead of calling
  `now_nanos` directly.
- Rewrite the three timing-dependent debounce tests
  (`debounce_prevents_cascading_collapse`, `debounce_expires_after_twice_rtt_ema`,
  `debounce_suppresses_back_to_back_decreases`) to drive a thread-local virtual
  clock: "within the window" leaves the clock unadvanced (provably inside the
  window), and "after the window" advances the clock explicitly past the
  debounce span. All `thread::sleep` calls used to cross the debounce window are
  gone, so the tests are immune to runner load.

The assertions are unchanged in strength: they still prove debounce prevents a
cascading collapse and that a decrease resumes once the window expires. Only the
time source becomes deterministic.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo clippy -p engine --all-targets --all-features --no-deps -- -D warnings`
  clean.
- Affected debounce/AIMD tests pass repeatedly; the full limiter suite
  (555 tests) passes. The rewritten debounce tests now complete in ~0.04s
  instead of blocking on 15ms sleeps.
