### PR TITLE
fix(daemon): unconditionally enable SO_KEEPALIVE on accepted client socket

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -271,6 +271,10 @@ fn handle_accepted_connection(
     state: &mut AcceptLoopState<'_>,
 ) -> bool {
     apply_accepted_stream_tcp_notsent_lowat(&tcp_stream);
+    // upstream: clientserver.c:1396 - the daemon unconditionally enables
+    // SO_KEEPALIVE on the accepted client socket, independent of the per-module
+    // `socket options` config applied below.
+    enable_accepted_stream_keepalive(&tcp_stream, state.log_sink.as_ref());
 
     let Some(mut stream) = wrap_accepted_stream(tcp_stream, state) else {
         return false;

--- a/crates/daemon/src/daemon/sections/server_runtime/connection_context.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection_context.rs
@@ -122,6 +122,10 @@ impl ConnectionContext {
         raw_peer_addr: SocketAddr,
     ) -> io::Result<()> {
         apply_accepted_stream_tcp_notsent_lowat(&tcp_stream);
+        // upstream: clientserver.c:1396 - daemon unconditionally enables
+        // SO_KEEPALIVE on the accepted client socket, independent of the
+        // per-module `socket options` config applied below.
+        enable_accepted_stream_keepalive(&tcp_stream, self.log_sink.as_ref());
         let stream = DaemonStream::plain(tcp_stream);
         apply_client_options(&stream, &self.client_socket_options, self.log_sink.as_ref());
         self.serve_session(stream, raw_peer_addr)

--- a/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
@@ -291,6 +291,25 @@ fn apply_socket_options_to_stream(
     apply_socket_options_impl(socket2::SockRef::from(stream), options, log_sink);
 }
 
+/// Unconditionally enables `SO_KEEPALIVE` on a freshly accepted client stream.
+///
+/// upstream: clientserver.c:1396 - daemon unconditionally enables SO_KEEPALIVE
+/// on the accepted client socket via `set_socket_options(f_in, "SO_KEEPALIVE")`
+/// in `start_daemon()`, before the protocol handshake and independent of the
+/// per-module `socket options` config (which is a separate concern applied via
+/// `lp_socket_options()`). Without it, idle daemon connections can be silently
+/// dropped by NAT/firewall timeouts. Best-effort: a failed `setsockopt(2)`
+/// warns and the session still proceeds, mirroring upstream's warn-and-continue
+/// in socket.c:730-733.
+fn enable_accepted_stream_keepalive(stream: &TcpStream, log_sink: Option<&SharedLogSink>) {
+    if let Err(error) = socket2::SockRef::from(stream).set_keepalive(true) {
+        warn_socket_option(
+            log_sink,
+            format!("failed to set socket option SO_KEEPALIVE: {error}"),
+        );
+    }
+}
+
 /// Shared implementation for applying socket options to any socket reference.
 ///
 /// upstream: socket.c:730-733 - `set_socket_options()` applies each option

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -699,6 +699,39 @@ fn apply_stream_socket_options_nodelay_keepalive() {
     assert!(sock.keepalive().expect("query keepalive"));
 }
 
+/// upstream: clientserver.c:1396 - `start_daemon()` unconditionally enables
+/// SO_KEEPALIVE on the freshly accepted client socket, independent of any
+/// `socket options` config. This matters because idle daemon connections that
+/// traverse NAT or stateful firewalls are silently dropped without keepalive
+/// probes, so the option must be set even when the operator configured no
+/// `socket options` at all. Accept a real loopback connection (the same path
+/// the accept engines feed) and assert keepalive is on with an empty option
+/// set - proving the enablement is unconditional and not a side effect of
+/// parsing a `SO_KEEPALIVE` directive.
+#[test]
+fn enable_accepted_stream_keepalive_is_unconditional() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("local addr");
+    let _client = TcpStream::connect(addr).expect("connect");
+    let (accepted, _peer) = listener.accept().expect("accept");
+
+    let sock = socket2::SockRef::from(&accepted);
+    assert!(
+        !sock.keepalive().expect("query keepalive"),
+        "a freshly accepted socket must start without keepalive so the test \
+         proves the helper is what enables it",
+    );
+
+    enable_accepted_stream_keepalive(&accepted, None);
+
+    assert!(
+        socket2::SockRef::from(&accepted)
+            .keepalive()
+            .expect("query keepalive"),
+        "SO_KEEPALIVE must be enabled unconditionally on the accepted socket",
+    );
+}
+
 #[test]
 fn apply_stream_socket_options_buffer_sizes() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");


### PR DESCRIPTION
## Summary

The daemon must unconditionally enable `SO_KEEPALIVE` on every accepted client
socket, matching upstream rsync.

## Upstream behaviour

In `start_daemon()`, upstream sets keepalive on the accepted client fd before
the protocol handshake and independent of any configuration:

```c
if (am_daemon > 0) {
    set_socket_options(f_in, "SO_KEEPALIVE");   // clientserver.c:1396
    set_nonblocking(f_in);
}
```

`set_socket_options(fd, "SO_KEEPALIVE")` resolves to
`setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &1, ...)` (socket.c:641, 678). This is
a distinct concern from the per-module `socket options` directive, which is
applied separately via `lp_socket_options()` at bind/connect time
(socket.c:279, 450-452).

## Divergence

oc only enabled `SO_KEEPALIVE` on the accepted stream when the operator had
listed it in the `socket options` config string (`apply_client_options` ->
`apply_socket_options_to_stream`). With no `socket options` configured, keepalive
was never enabled, so idle daemon connections traversing NAT or stateful
firewalls could be silently dropped.

## Fix

- Add `enable_accepted_stream_keepalive()`, a safe helper that enables
  `SO_KEEPALIVE` on the accepted `TcpStream` via `socket2::SockRef::set_keepalive(true)`.
  No unsafe is introduced (the daemon crate denies unsafe). On a failed
  `setsockopt(2)` it warns and the session proceeds, mirroring upstream's
  warn-and-continue in socket.c:730-733.
- Call it in both accept paths (`handle_accepted_connection` for the sync
  engines and `serve_one_connection` for the async engine), right after the
  existing per-connection socket tuning and before the per-module `socket
  options` application, which remains a separate concern.

## Test

`enable_accepted_stream_keepalive_is_unconditional` accepts a real loopback
connection (the same path the accept engines feed), asserts the freshly accepted
socket starts without keepalive, applies the helper, and asserts keepalive is
enabled - proving the enablement is unconditional and not a side effect of
parsing a `SO_KEEPALIVE` directive. The test encodes why this matters: idle
daemon connections must not be silently dropped by NAT/firewall timeouts.
`SO_KEEPALIVE` and its `socket2` getter are available on Linux, macOS, and
Windows.
