### PR TITLE
fix(metadata): restore setuid/setgid/sticky bits after applying ACLs

### DIFF
--- a/crates/metadata/src/acl_exacl/apply.rs
+++ b/crates/metadata/src/acl_exacl/apply.rs
@@ -16,6 +16,7 @@ use super::reconstruct::{reconstruct_acl, rsync_acl_to_entries};
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use super::reset::clear_default_acl;
 use super::reset::reset_acl_from_mode;
+use super::special::restore_special_mode_bits;
 
 /// Applies parsed ACLs from an [`AclCache`] to a destination file.
 ///
@@ -77,6 +78,15 @@ pub fn apply_acls_from_cache(
             }
         } else {
             reset_acl_from_mode(destination)?;
+        }
+
+        // upstream: acls.c:924-932 + rsync.c:659-660 - applying the access ACL
+        // re-derives the permission bits and clears setuid/setgid/sticky, which
+        // are not representable in a POSIX ACL. Restore them from the
+        // transferred mode so setgid/setuid binaries and sticky dirs survive an
+        // ACL transfer.
+        if let Some(mode) = mode {
+            restore_special_mode_bits(destination, mode)?;
         }
     }
 

--- a/crates/metadata/src/acl_exacl/mod.rs
+++ b/crates/metadata/src/acl_exacl/mod.rs
@@ -56,6 +56,7 @@ mod perms;
 mod read;
 mod reconstruct;
 mod reset;
+mod special;
 mod sync;
 
 #[cfg(test)]

--- a/crates/metadata/src/acl_exacl/reconstruct.rs
+++ b/crates/metadata/src/acl_exacl/reconstruct.rs
@@ -31,23 +31,31 @@ pub(super) fn reconstruct_acl(acl: &RsyncAcl, mode: Option<u32>) -> RsyncAcl {
         None => return acl.clone(),
     };
 
+    // upstream: acls.c:931-932 change_sacl_perms() returns
+    // `(old_mode & ~ACCESSPERMS) | (mode & ACCESSPERMS)`, so only the low 0o777
+    // permission bits ever feed the ACL's USER_OBJ/GROUP_OBJ/MASK/OTHER
+    // entries. Mask off setuid/setgid/sticky here so those special bits can
+    // never leak into an ACL entry; they are not representable in a POSIX ACL
+    // and are restored separately via chmod after the ACL is applied.
+    let perm_mode = mode & 0o777;
+
     let mut result = acl.clone();
 
     // upstream: acls.c:892 - user_obj from mode bits 8-6
     if result.user_obj == NO_ENTRY {
-        result.user_obj = ((mode >> 6) & 7) as u8;
+        result.user_obj = ((perm_mode >> 6) & 7) as u8;
     }
     // upstream: acls.c:898 - group_obj from mode bits 5-3
     if result.group_obj == NO_ENTRY {
-        result.group_obj = ((mode >> 3) & 7) as u8;
+        result.group_obj = ((perm_mode >> 3) & 7) as u8;
     }
     // upstream: acls.c:911 - other_obj from mode bits 2-0
     if result.other_obj == NO_ENTRY {
-        result.other_obj = (mode & 7) as u8;
+        result.other_obj = (perm_mode & 7) as u8;
     }
     // upstream: acls.c:900-908 - mask from mode bits 5-3 when needed
     if !result.names.is_empty() && result.mask_obj == NO_ENTRY {
-        result.mask_obj = ((mode >> 3) & 7) as u8;
+        result.mask_obj = ((perm_mode >> 3) & 7) as u8;
     }
 
     result

--- a/crates/metadata/src/acl_exacl/special.rs
+++ b/crates/metadata/src/acl_exacl/special.rs
@@ -1,0 +1,60 @@
+//! Restoration of setuid/setgid/sticky bits after an access ACL is applied.
+//!
+//! Applying a POSIX access ACL via `acl_set_file`/`setfacl` re-derives the
+//! file's permission bits from the ACL's USER_OBJ/GROUP_OBJ/OTHER entries and
+//! clears the high mode bits (setuid/setgid/sticky) that cannot be represented
+//! in a POSIX ACL. Upstream restores them afterwards through the final
+//! `do_chmod_at()` in `set_file_attrs()`; this module provides the equivalent
+//! fixup for oc-rsync, which applies ACLs after the permission chmod.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use crate::MetadataError;
+
+/// Special mode bits not representable in a POSIX ACL: setuid, setgid, sticky.
+const SPECIAL_MODE_BITS: u32 = 0o7000;
+
+/// Re-applies the setuid/setgid/sticky bits from `mode` after an access ACL has
+/// been set, restoring the high bits that `setfacl`/`acl_set_file` clears when
+/// it re-derives the permission bits from the ACL's base entries.
+///
+/// The ACL-derived permission bits (low 0o777) are preserved verbatim; only the
+/// special bits are OR'd back on, so the ACL mask written by `setfacl` is not
+/// disturbed. A `chmod` is issued only when the special bits actually differ
+/// from what is already on disk.
+///
+/// # Upstream Reference
+///
+/// - `acls.c:924-932` `change_sacl_perms()` - keeps the special bits out of the
+///   ACL-derived mode (`(old_mode & ~ACCESSPERMS) | (mode & ACCESSPERMS)`) and,
+///   under `SMB_ACL_LOSES_SPECIAL_MODE_BITS`, forces a later chmod to restore
+///   any lost setid bits.
+/// - `rsync.c:659-660` `set_file_attrs()` - the final
+///   `do_chmod_at(fname, new_mode)` after `set_acl()` re-applies any special
+///   bit the ACL application dropped.
+pub(super) fn restore_special_mode_bits(path: &Path, mode: u32) -> Result<(), MetadataError> {
+    let special = mode & SPECIAL_MODE_BITS;
+    if special == 0 {
+        // setfacl only ever clears special bits, never sets them, so when the
+        // desired mode carries none there is nothing to restore.
+        return Ok(());
+    }
+
+    let current = fs::metadata(path)
+        .map_err(|e| MetadataError::new("inspect permissions", path, e))?
+        .permissions()
+        .mode();
+
+    // upstream: rsync.c:659 - the chmod is skipped when the on-disk mode already
+    // matches, mirroring `BITS_EQUAL(sxp->st.st_mode, new_mode, CHMOD_BITS)`.
+    if current & SPECIAL_MODE_BITS == special {
+        return Ok(());
+    }
+
+    let restored = (current & 0o777) | special;
+    fs::set_permissions(path, fs::Permissions::from_mode(restored)).map_err(|e| {
+        MetadataError::new("restore setuid/setgid/sticky bits after ACL apply", path, e)
+    })
+}

--- a/crates/metadata/src/acl_exacl/sync.rs
+++ b/crates/metadata/src/acl_exacl/sync.rs
@@ -1,6 +1,5 @@
 //! Source-to-destination ACL replication (filesystem read, filesystem write).
 
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -15,6 +14,7 @@ use super::error::is_unsupported_error;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use super::reset::clear_default_acl;
 use super::reset::reset_acl_from_mode;
+use super::special::restore_special_mode_bits;
 
 /// Synchronizes ACLs from `source` to `destination`.
 ///
@@ -106,6 +106,19 @@ pub fn sync_acls(
         }
     } else {
         reset_acl_from_mode(destination)?;
+    }
+
+    // upstream: acls.c:924-932 + rsync.c:659-660 - applying the access ACL
+    // clears setuid/setgid/sticky, which are not representable in a POSIX ACL.
+    // Restore them from the source mode so setgid/setuid binaries and sticky
+    // dirs survive a local copy.
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let source_mode = fs::metadata(source)
+            .map_err(|e| MetadataError::new("stat", source, e))?
+            .permissions()
+            .mode();
+        restore_special_mode_bits(destination, source_mode)?;
     }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]

--- a/crates/metadata/src/acl_exacl/tests.rs
+++ b/crates/metadata/src/acl_exacl/tests.rs
@@ -482,6 +482,82 @@ fn apply_acls_from_cache_missing_index_is_noop() {
 }
 
 #[test]
+fn reconstruct_acl_masks_special_bits_from_mode() {
+    // WHY: setuid/setgid/sticky are not representable in a POSIX ACL. When the
+    // receiver rebuilds stripped base entries from the mode it must use only
+    // the low 0o777 bits, so the special bits never leak into an ACL entry -
+    // they are restored separately via chmod after the ACL is applied.
+    // upstream: acls.c:931-932 change_sacl_perms() returns
+    // `(old_mode & ~ACCESSPERMS) | (mode & ACCESSPERMS)`.
+    use protocol::acl::{IdAccess, NO_ENTRY};
+
+    let mut wire = RsyncAcl::new();
+    // A named entry forces the mask to be reconstructed from the mode too.
+    wire.names.push(IdAccess::user(1000, 0x07));
+    assert_eq!(wire.user_obj, NO_ENTRY);
+
+    // 0o6755 carries setuid+setgid on top of 0o755; the reconstructed base
+    // entries must be identical to plain 0o755.
+    let plain = reconstruct_acl(&wire, Some(0o755));
+    let setid = reconstruct_acl(&wire, Some(0o6755));
+
+    assert_eq!(setid.user_obj, plain.user_obj);
+    assert_eq!(setid.group_obj, plain.group_obj);
+    assert_eq!(setid.other_obj, plain.other_obj);
+    assert_eq!(setid.mask_obj, plain.mask_obj);
+    // Pin the values so a regression that let a high bit bleed into rwx fails.
+    assert_eq!(setid.user_obj, 0x07);
+    assert_eq!(setid.group_obj, 0x05);
+    assert_eq!(setid.other_obj, 0x05);
+    assert_eq!(setid.mask_obj, 0x05);
+}
+
+#[test]
+fn apply_acls_from_cache_preserves_setgid_and_sticky() {
+    // WHY: applying a POSIX access ACL via setfacl re-derives the permission
+    // bits from the ACL's base entries and clears setuid/setgid/sticky, which
+    // are not representable in the ACL. Upstream restores them after set_acl
+    // (acls.c:924-932, rsync.c:659-660). Dropping setgid silently downgrades a
+    // setgid binary or directory - a metadata-fidelity and security regression
+    // (#213). This must hold for an ordinary (non-root) user.
+    use protocol::acl::IdAccess;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("setgid_sticky");
+    File::create(&file).expect("create file");
+
+    // setgid + sticky on a user-owned file are settable without root.
+    let mode = 0o3755u32;
+    std::fs::set_permissions(&file, std::fs::Permissions::from_mode(mode))
+        .expect("chmod special bits");
+
+    // Only assert survival of the bits the filesystem actually accepted, so the
+    // test is robust across filesystems with differing special-bit support.
+    let precondition = std::fs::metadata(&file).expect("stat").permissions().mode() & 0o7000;
+    assert_ne!(
+        precondition, 0,
+        "filesystem must accept at least one special bit for this test to be meaningful"
+    );
+
+    // A named-user entry forces setfacl to write an extended ACL that
+    // re-derives (and, on POSIX-ACL filesystems, clears) the special bits.
+    let mut acl = RsyncAcl::from_mode(mode & 0o777);
+    acl.names.push(IdAccess::user(0, 0x04));
+    let mut cache = AclCache::new();
+    let ndx = cache.store_access(acl);
+
+    apply_acls_from_cache(&file, &cache, ndx, None, true, Some(mode), None)
+        .expect("apply ACL from cache");
+
+    let after = std::fs::metadata(&file).expect("stat").permissions().mode() & 0o7000;
+    assert_eq!(
+        after, precondition,
+        "setuid/setgid/sticky must survive ACL application (upstream restores them)"
+    );
+}
+
+#[test]
 fn default_perms_for_dir_no_acl_returns_umask_default() {
     // No default ACL: upstream returns ACCESSPERMS & ~orig_umask without
     // emitting `DEBUG_GTE(ACL, 1)`.


### PR DESCRIPTION
## Problem

Applying a POSIX access ACL via `setfacl`/`acl_set_file` re-derives the file's
permission bits from the ACL's `USER_OBJ`/`GROUP_OBJ`/`OTHER` entries and
**clears the high mode bits** (setuid `04000`, setgid `02000`, sticky `01000`).
Those bits are not representable in a POSIX ACL.

Upstream rsync restores them after setting the ACL. In `set_file_attrs()` it
calls `set_acl()` first (which updates `sxp->st.st_mode` to the ACL-derived
mode via `change_sacl_perms()`), and then the final
`do_chmod_at(fname, new_mode)` re-applies the full mode including the special
bits:

- `acls.c:924-932` `change_sacl_perms()` returns
  `(old_mode & ~ACCESSPERMS) | (mode & ACCESSPERMS)`, keeping the special bits
  out of the ACL-derived mode, and under `SMB_ACL_LOSES_SPECIAL_MODE_BITS`
  forces a later chmod to restore any lost setid bits.
- `rsync.c:659-660` `set_file_attrs()` runs the final
  `do_chmod_at(fname, new_mode)` after `set_acl()`.

oc-rsync applies ACLs **after** the permission chmod on every receiver and
local-copy path, so `setfacl` was the last operation to touch the mode and
nothing restored the cleared special bits. A setgid binary, setuid helper, or
sticky directory silently lost its bit whenever it was transferred with `-A` -
a metadata-fidelity bug and a security-relevant regression for setuid/setgid
executables.

## Gaps fixed

1. **Post-`setfacl` special-bit re-chmod (the primary gap).** After the access
   ACL is applied, restore setuid/setgid/sticky from the transferred mode
   (wire receiver, `apply_acls_from_cache`) or the source mode (local copy,
   `sync_acls`). The ACL-derived permission bits (`0o777`) are preserved
   verbatim; only the special bits are OR'd back on, so the ACL mask written by
   `setfacl` is not disturbed. A chmod is issued only when the special bits
   actually differ, mirroring upstream's `BITS_EQUAL(...)` guard at
   `rsync.c:659`. Implemented in a small shared helper
   (`acl_exacl/special.rs::restore_special_mode_bits`).

2. **Reconstruct-path special-bit guard.** `reconstruct_acl()` now masks the
   incoming mode to `ACCESSPERMS` (`mode & 0o777`) before deriving the stripped
   base entries, mirroring `change_sacl_perms()`'s
   `(old_mode & ~ACCESSPERMS) | (mode & ACCESSPERMS)`. This makes it explicit
   that the special bits can never leak into an `USER_OBJ`/`GROUP_OBJ`/`MASK`/
   `OTHER` entry; they are handled only by the chmod restore above.

## Tests

- `apply_acls_from_cache_preserves_setgid_and_sticky` - sets setgid+sticky on a
  user-owned file (settable without root), applies an extended ACL through the
  cache, and asserts the special bits survive. Only asserts survival of the
  bits the filesystem actually accepted, so it is robust across filesystems.
  On POSIX-ACL filesystems (Linux CI) this genuinely exercises the clear +
  restore and fails without the fix.
- `reconstruct_acl_masks_special_bits_from_mode` - proves the reconstructed
  base entries for `0o6755` (setuid+setgid) are identical to `0o755`.

Both run as an ordinary user. Encodes *why*: upstream restores these bits and
oc dropped them, which is a fidelity + security divergence for setuid/setgid
binaries.

## Platform

ACL code is gated to Linux/macOS/FreeBSD (the `exacl` backends); the restore
uses only safe `std::fs` chmod. No unsafe, no new `#[allow(unsafe_code)]`, no
new dependency. Windows and non-ACL builds are unaffected.
