### PR TITLE
fix(transfer): report real Total transferred file size on remote transfers

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -55,6 +55,7 @@ pub(super) fn convert_server_stats_to_summary(
             let s = LocalCopySummary::from_receiver_stats(
                 transfer_stats.files_listed,
                 transfer_stats.files_transferred,
+                transfer_stats.transferred_file_size,
                 transfer_stats.bytes_received,
                 transfer_stats.bytes_sent,
                 transfer_stats.total_source_bytes,
@@ -74,6 +75,7 @@ pub(super) fn convert_server_stats_to_summary(
             let s = LocalCopySummary::from_generator_stats(
                 generator_stats.files_listed,
                 generator_stats.files_transferred,
+                generator_stats.transferred_file_size,
                 generator_stats.bytes_read,
                 generator_stats.bytes_sent,
                 generator_stats.total_size,

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -32,6 +32,7 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
             let s = LocalCopySummary::from_receiver_stats(
                 transfer_stats.files_listed,
                 transfer_stats.files_transferred,
+                transfer_stats.transferred_file_size,
                 transfer_stats.bytes_received,
                 transfer_stats.bytes_sent,
                 transfer_stats.total_source_bytes,
@@ -49,6 +50,7 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
             let s = LocalCopySummary::from_generator_stats(
                 generator_stats.files_listed,
                 generator_stats.files_transferred,
+                generator_stats.transferred_file_size,
                 generator_stats.bytes_read,
                 generator_stats.bytes_sent,
                 generator_stats.total_size,

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -393,6 +393,9 @@ fn replay_batch(
     let summary = LocalCopySummary::from_receiver_stats(
         files_listed,
         files_transferred,
+        // upstream: receiver.c:784 total_transferred_size - the replay materialises
+        // every flist entry, so the summed transferred-file length is total_size.
+        total_size,
         total_size,
         total_size,
         total_size,

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -515,6 +515,7 @@ impl LocalCopySummary {
     pub fn from_receiver_stats(
         files_listed: usize,
         files_transferred: usize,
+        transferred_file_size: u64,
         bytes_received: u64,
         bytes_sent: u64,
         total_source_bytes: u64,
@@ -527,6 +528,9 @@ impl LocalCopySummary {
         Self {
             regular_files_total: files_listed as u64,
             files_copied: files_transferred as u64,
+            // upstream: receiver.c:784 stats.total_transferred_size, computed
+            // locally by the pulling client's receiver (never sent on the wire).
+            transferred_file_size,
             // upstream never sends `stats.created_*` over the wire - the client
             // recomputes the "Number of created files" breakdown locally from
             // its own itemize pass (receiver.c:733-746). For a remote pull the
@@ -566,6 +570,7 @@ impl LocalCopySummary {
     pub fn from_generator_stats(
         files_listed: usize,
         files_transferred: usize,
+        transferred_file_size: u64,
         bytes_received: u64,
         bytes_sent: u64,
         total_source_bytes: u64,
@@ -578,6 +583,9 @@ impl LocalCopySummary {
         Self {
             regular_files_total: files_listed as u64,
             files_copied: files_transferred as u64,
+            // upstream: sender.c:343 stats.total_transferred_size, computed
+            // locally by the pushing client's sender (never sent on the wire).
+            transferred_file_size,
             // See `from_receiver_stats`: on a push the local sender reconstructs
             // the created breakdown from the `ITEM_IS_NEW` iflags it reads off
             // the wire (sender.c:295-308), so map each per-type count through.
@@ -827,6 +835,7 @@ mod tests {
         let summary = LocalCopySummary::from_receiver_stats(
             100,
             50,
+            7000,
             1024,
             256,
             8192,
@@ -838,6 +847,10 @@ mod tests {
         );
         assert_eq!(summary.regular_files_total(), 100);
         assert_eq!(summary.files_copied(), 50);
+        // #178: the receiver-accumulated total_transferred_size (sum of F_LENGTH
+        // over transferred files) must reach the summary; a pulling client that
+        // dropped it printed "Total transferred file size: 0" on all remote pulls.
+        assert_eq!(summary.transferred_file_size(), 7000);
         assert_eq!(summary.bytes_received(), 1024);
         assert_eq!(summary.bytes_sent(), 256);
         assert_eq!(summary.total_source_bytes(), 8192);
@@ -849,6 +862,7 @@ mod tests {
         let summary = LocalCopySummary::from_receiver_stats(
             10,
             5,
+            2000,
             2048,
             512,
             4096,
@@ -860,6 +874,9 @@ mod tests {
         );
         assert_eq!(summary.bytes_copied(), 800);
         assert_eq!(summary.matched_bytes(), 1200);
+        // literal + matched of a fully received file equals its F_LENGTH; the
+        // summed transferred-file size is threaded through independently.
+        assert_eq!(summary.transferred_file_size(), 2000);
         assert_eq!(summary.files_copied(), 5);
         assert_eq!(summary.bytes_received(), 2048);
     }
@@ -881,6 +898,7 @@ mod tests {
         let summary = LocalCopySummary::from_generator_stats(
             10,
             5,
+            0,
             0,
             2048,
             0,
@@ -913,6 +931,7 @@ mod tests {
         let summary = LocalCopySummary::from_receiver_stats(
             10,
             5,
+            2000,
             2048,
             512,
             4096,
@@ -950,6 +969,7 @@ mod tests {
             // files_transferred is 5 (includes in-place updates); the created
             // reg count must NOT come from this - it is derived from created_stats.
             5,
+            8192,
             4096,
             256,
             8192,
@@ -983,6 +1003,7 @@ mod tests {
             10,
             3,
             0,
+            0,
             2048,
             0,
             Duration::from_secs(1),
@@ -1004,6 +1025,7 @@ mod tests {
         let summary = LocalCopySummary::from_generator_stats(
             200,
             75,
+            204_800,
             1793,
             2048,
             204_800,
@@ -1019,6 +1041,10 @@ mod tests {
         // #477: the sender-accumulated literal_data must reach the summary
         // (previously dropped, so daemon/ssh-push --stats printed 0).
         assert_eq!(summary.bytes_copied(), 2800);
+        // #178: the sender-accumulated total_transferred_size must reach the
+        // summary too (previously dropped, so daemon/ssh-push --stats printed
+        // "Total transferred file size: 0").
+        assert_eq!(summary.transferred_file_size(), 204_800);
         assert_eq!(summary.total_elapsed(), Duration::from_secs(3));
     }
 

--- a/crates/transfer/src/generator/stats.rs
+++ b/crates/transfer/src/generator/stats.rs
@@ -23,6 +23,11 @@ use protocol::stats::{CreatedStats, DeleteStats};
 pub(crate) struct TransferLoopResult {
     /// Number of files actually transferred.
     pub(crate) files_transferred: usize,
+    /// Summed length of every transferred file (upstream: `total_transferred_size`).
+    ///
+    /// Mirrors `sender.c:343` `stats.total_transferred_size += F_LENGTH(file)`,
+    /// accumulated at the same point as `files_transferred`.
+    pub(crate) transferred_file_size: u64,
     /// Total bytes sent during transfer.
     pub(crate) bytes_sent: u64,
     /// Bytes covered by block matches across all files (upstream: matched_data).
@@ -55,6 +60,12 @@ pub struct GeneratorStats {
     pub files_listed: usize,
     /// Number of files actually transferred (delta or whole-file).
     pub files_transferred: usize,
+    /// Summed length of every transferred file (upstream: `total_transferred_size`).
+    ///
+    /// On a push the local sender computes this itself (`sender.c:343`); upstream
+    /// never sends it over the wire in `handle_stats()`, so the pushing client
+    /// reports it straight from this locally accumulated total.
+    pub transferred_file_size: u64,
     /// Total bytes sent to the receiver (delta data + literals).
     pub bytes_sent: u64,
     /// Total bytes read from the receiver (signatures, NDX requests).

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -321,6 +321,7 @@ impl GeneratorContext {
         Ok(GeneratorStats {
             files_listed: file_count,
             files_transferred: transfer_result.files_transferred,
+            transferred_file_size: transfer_result.transferred_file_size,
             bytes_sent: transfer_result.bytes_sent,
             bytes_read: self.timing.total_bytes_read,
             matched_data: transfer_result.matched_data,

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -119,6 +119,10 @@ impl GeneratorContext {
         let deadline = TransferDeadline::from_system_time(self.config.stop_at);
 
         let mut files_transferred = 0;
+        // upstream: sender.c:343 - stats.total_transferred_size += F_LENGTH(file),
+        // accumulated at the same point as xferred_files (dry-run included, since
+        // the increment precedes the `if (!do_xfers)` continue at sender.c:346).
+        let mut transferred_file_size = 0u64;
         // upstream: sender.c:319-335,480 - FLAG_FILE_SENT per file. A resend of
         // an already-sent entry (the redo pass) is a full-content transfer, not
         // another append delta, so track which entries have been sent once.
@@ -497,6 +501,7 @@ impl GeneratorContext {
                     cb.on_itemize(&format!("{name}\n"));
                 }
                 files_transferred += 1;
+                transferred_file_size += file_entry.size();
                 flush_with_count(writer)?;
                 continue;
             }
@@ -848,6 +853,7 @@ impl GeneratorContext {
                 literal_data += file_size;
             }
             files_transferred += 1;
+            transferred_file_size += file_size;
             // upstream: sender.c:480 - `file->flags |= FLAG_FILE_SENT` once the
             // entry has actually been transferred, so a later redo request for
             // it clears append_mode/make_backups above. Skipped items
@@ -974,6 +980,7 @@ impl GeneratorContext {
 
         Ok(TransferLoopResult {
             files_transferred,
+            transferred_file_size,
             bytes_sent,
             matched_data,
             literal_data,
@@ -1617,15 +1624,19 @@ mod append_redo_tests {
     }
 
     /// Drives the sender loop over a crafted receiver stream, returning
-    /// `(files_transferred, bytes_consumed_from_reader)`.
-    fn drive(ctx: &mut GeneratorContext, incoming: Vec<u8>) -> io::Result<(usize, u64)> {
+    /// `(files_transferred, transferred_file_size, bytes_consumed_from_reader)`.
+    fn drive(ctx: &mut GeneratorContext, incoming: Vec<u8>) -> io::Result<(usize, u64, u64)> {
         let mut reader = Cursor::new(incoming);
         let mut writer = ServerWriter::new_plain(Vec::new());
         let mut progress: Option<&mut dyn crate::TransferProgressCallback> = None;
         let mut itemize: Option<&mut dyn crate::ItemizeCallback> = None;
         let result =
             ctx.run_transfer_loop(&mut reader, &mut writer, &mut progress, &mut itemize)?;
-        Ok((result.files_transferred, reader.position()))
+        Ok((
+            result.files_transferred,
+            result.transferred_file_size,
+            reader.position(),
+        ))
     }
 
     /// A file first sent as an append delta and then re-requested on the redo
@@ -1672,12 +1683,22 @@ mod append_redo_tests {
         rx.write_ndx_done(&mut wire).unwrap();
         let total = wire.len() as u64;
 
-        let (files, consumed) = drive(&mut ctx, wire).expect("append redo must not desync");
+        let (files, transferred_file_size, consumed) =
+            drive(&mut ctx, wire).expect("append redo must not desync");
 
         // Both the append send and the full-content redo completed.
         assert_eq!(
             files, 2,
             "append send + redo resend both count as transfers"
+        );
+        // #178: total_transferred_size accumulates F_LENGTH at each transfer
+        // point (sender.c:343), in lockstep with files_transferred. Both sends
+        // of the 100-byte file count, so the sender-side total is 2 * 100 = 200.
+        // A generator that never summed the length reports 0 here, which is what
+        // made every remote push print `Total transferred file size: 0`.
+        assert_eq!(
+            transferred_file_size, 200,
+            "sender must sum F_LENGTH for every transfer (append send + redo)"
         );
         // Every crafted byte was consumed: the resend read the full block
         // signature instead of leaving it on the wire. The static-append bug

--- a/crates/transfer/src/receiver/stats.rs
+++ b/crates/transfer/src/receiver/stats.rs
@@ -68,6 +68,13 @@ pub struct TransferStats {
     pub files_listed: usize,
     /// Number of files actually transferred.
     pub files_transferred: usize,
+    /// Summed length of every transferred file (upstream: `total_transferred_size`).
+    ///
+    /// On a pull the local receiver computes this itself (`receiver.c:784`
+    /// `stats.total_transferred_size += F_LENGTH(file)`); upstream never sends
+    /// it over the wire in `handle_stats()`, so the pulling client reports it
+    /// straight from this locally accumulated total.
+    pub transferred_file_size: u64,
     /// Total bytes received from the sender (file data, deltas, etc.).
     pub bytes_received: u64,
     /// Total bytes sent to the sender (signatures, file indices, etc.).

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -157,6 +157,7 @@ fn transfer_stats_has_incremental_fields() {
     let stats = TransferStats {
         files_listed: 0,
         files_transferred: 0,
+        transferred_file_size: 0,
         bytes_received: 0,
         bytes_sent: 0,
         total_source_bytes: 0,

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -29,8 +29,19 @@ use crate::transfer_ops::{
 };
 
 /// Result type for the pipelined transfer closure:
-/// `(files_transferred, bytes, literal, matched, redo_indices, delayed_updates)`.
-type PipelineResult = (usize, u64, u64, u64, Vec<usize>, Vec<(PathBuf, PathBuf)>);
+/// `(files_transferred, transferred_file_size, bytes, literal, matched, redo_indices,
+/// delayed_updates)`. `transferred_file_size` mirrors upstream `receiver.c:784`
+/// `stats.total_transferred_size += F_LENGTH(file)`, summed at the same point as
+/// `files_transferred`.
+type PipelineResult = (
+    usize,
+    u64,
+    u64,
+    u64,
+    u64,
+    Vec<usize>,
+    Vec<(PathBuf, PathBuf)>,
+);
 
 impl ReceiverContext {
     /// Emits `MSG_SUCCESS(ndx)` to the sender for every file whose commit was
@@ -96,7 +107,7 @@ impl ReceiverContext {
         // upstream: generator.c sends itemize immediately per-file via rwrite()
         if files_to_transfer.is_empty() {
             writer.flush()?;
-            return Ok((0, 0, 0, 0, Vec::new(), Vec::new()));
+            return Ok((0, 0, 0, 0, 0, Vec::new(), Vec::new()));
         }
 
         let deadline = TransferDeadline::from_system_time(self.config.stop_at);
@@ -143,6 +154,9 @@ impl ReceiverContext {
         let mut pending_files_info: VecDeque<(usize, PathBuf, &FileEntry, u32)> =
             VecDeque::with_capacity(pipeline.window_size());
         let mut files_transferred = 0usize;
+        // upstream: receiver.c:784 stats.total_transferred_size += F_LENGTH(file),
+        // summed at the same point as files_transferred.
+        let mut transferred_file_size = 0u64;
         let mut bytes_received = 0u64;
         let mut total_literal_bytes = 0u64;
         let mut total_matched_bytes = 0u64;
@@ -421,6 +435,7 @@ impl ReceiverContext {
                 total_literal_bytes += result.literal_bytes;
                 total_matched_bytes += result.matched_bytes;
                 files_transferred += 1;
+                transferred_file_size += file_entry.size();
 
                 // upstream: receiver.c:950 - log_item() after successful file transfer
                 {
@@ -497,6 +512,7 @@ impl ReceiverContext {
 
             Ok((
                 files_transferred,
+                transferred_file_size,
                 bytes_received,
                 total_literal_bytes,
                 total_matched_bytes,

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -119,6 +119,8 @@ impl ReceiverContext {
         );
 
         let mut files_transferred: usize = 0;
+        // upstream: receiver.c:784 total_transferred_size, summed with files_transferred.
+        let mut transferred_file_size: u64 = 0;
         let mut bytes_received: u64 = 0;
         let mut literal_data: u64 = 0;
         let mut matched_data: u64 = 0;
@@ -151,6 +153,7 @@ impl ReceiverContext {
             let delayed;
             (
                 files_transferred,
+                transferred_file_size,
                 bytes_received,
                 literal_data,
                 matched_data,
@@ -196,20 +199,28 @@ impl ReceiverContext {
                     })
                     .collect();
 
-                let (redo_transferred, redo_bytes, redo_literal, redo_matched, _, redo_delayed) =
-                    self.run_pipeline_loop_decoupled(
-                        reader,
-                        writer,
-                        redo_config,
-                        &setup,
-                        redo_files,
-                        &mut metadata_errors,
-                        true,
-                        total_files,
-                        &mut no_progress,
-                    )?;
+                let (
+                    redo_transferred,
+                    redo_transferred_size,
+                    redo_bytes,
+                    redo_literal,
+                    redo_matched,
+                    _,
+                    redo_delayed,
+                ) = self.run_pipeline_loop_decoupled(
+                    reader,
+                    writer,
+                    redo_config,
+                    &setup,
+                    redo_files,
+                    &mut metadata_errors,
+                    true,
+                    total_files,
+                    &mut no_progress,
+                )?;
 
                 files_transferred += redo_transferred;
+                transferred_file_size += redo_transferred_size;
                 bytes_received += redo_bytes;
                 literal_data += redo_literal;
                 matched_data += redo_matched;
@@ -282,6 +293,7 @@ impl ReceiverContext {
         let total_source_bytes: u64 = self.file_list.iter().map(|e| e.size()).sum();
 
         stats.files_transferred = files_transferred;
+        stats.transferred_file_size = transferred_file_size;
         stats.bytes_received = bytes_received;
         stats.literal_data = literal_data;
         stats.matched_data = matched_data;

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -154,6 +154,8 @@ impl ReceiverContext {
         );
 
         let mut files_transferred: usize = 0;
+        // upstream: receiver.c:784 total_transferred_size, summed with files_transferred.
+        let mut transferred_file_size: u64 = 0;
         let mut bytes_received: u64 = 0;
         let mut literal_data: u64 = 0;
         let mut matched_data: u64 = 0;
@@ -175,6 +177,7 @@ impl ReceiverContext {
             let delayed;
             (
                 files_transferred,
+                transferred_file_size,
                 bytes_received,
                 literal_data,
                 matched_data,
@@ -220,20 +223,28 @@ impl ReceiverContext {
                     })
                     .collect();
 
-                let (redo_transferred, redo_bytes, redo_literal, redo_matched, _, redo_delayed) =
-                    self.run_pipeline_loop_decoupled(
-                        reader,
-                        writer,
-                        redo_config,
-                        &setup,
-                        redo_files,
-                        &mut metadata_errors,
-                        true,
-                        total_files,
-                        &mut progress,
-                    )?;
+                let (
+                    redo_transferred,
+                    redo_transferred_size,
+                    redo_bytes,
+                    redo_literal,
+                    redo_matched,
+                    _,
+                    redo_delayed,
+                ) = self.run_pipeline_loop_decoupled(
+                    reader,
+                    writer,
+                    redo_config,
+                    &setup,
+                    redo_files,
+                    &mut metadata_errors,
+                    true,
+                    total_files,
+                    &mut progress,
+                )?;
 
                 files_transferred += redo_transferred;
+                transferred_file_size += redo_transferred_size;
                 bytes_received += redo_bytes;
                 literal_data += redo_literal;
                 matched_data += redo_matched;
@@ -278,6 +289,7 @@ impl ReceiverContext {
         self.touch_up_dirs(&setup.dest_dir, writer);
 
         stats.files_transferred = files_transferred;
+        stats.transferred_file_size = transferred_file_size;
         stats.bytes_received = bytes_received;
         stats.literal_data = literal_data;
         stats.matched_data = matched_data;

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -62,6 +62,8 @@ impl ReceiverContext {
         debug_log!(Recv, 1, "recv_files({}) starting", file_count);
 
         let mut files_transferred = 0;
+        // upstream: receiver.c:784 total_transferred_size, summed with files_transferred.
+        let mut transferred_file_size = 0u64;
         let mut bytes_received = 0u64;
 
         // First pass: create directories and symlinks from file list.
@@ -563,6 +565,7 @@ impl ReceiverContext {
             // read fd, so exclude them from bytes_received.
             bytes_received += literal_bytes;
             files_transferred += 1;
+            transferred_file_size += file_entry.size();
         }
 
         // upstream: generator.c:2169 finish_hard_link() itemizes every follower
@@ -601,6 +604,7 @@ impl ReceiverContext {
         Ok(TransferStats {
             files_listed: file_count,
             files_transferred,
+            transferred_file_size,
             bytes_received,
             bytes_sent: 0,
             total_source_bytes,

--- a/crates/transfer/tests/daemon_total_transferred_size_stats.rs
+++ b/crates/transfer/tests/daemon_total_transferred_size_stats.rs
@@ -1,0 +1,352 @@
+//! Daemon end-to-end guard for the `--stats` "Total transferred file size" line.
+//!
+//! # Background
+//!
+//! Upstream accumulates `stats.total_transferred_size` by adding each
+//! transferred file's `F_LENGTH` at the exact point it bumps `xferred_files`:
+//!
+//! - `sender.c:343`   - `stats.total_transferred_size += F_LENGTH(file);`
+//! - `receiver.c:784` - `stats.total_transferred_size += F_LENGTH(file);`
+//!
+//! The value never crosses the wire: `main.c:handle_stats()` (3.4.4:325-385)
+//! exchanges only `total_read`, `total_written`, `total_size` and the two
+//! flist timing counters. Each side computes `total_transferred_size` locally,
+//! and for every direction the process that runs the transfer loop is the
+//! client that prints the summary - on a push the client is the sender
+//! (`sender.c`), on a pull the client is the receiver (`receiver.c`). So a
+//! correct implementation reports the real summed length in BOTH directions
+//! purely from its own accumulation. `main.c:439` / `log.c:output_summary()`
+//! renders the `Total transferred file size: %s bytes` line from it.
+//!
+//! # What this test pins
+//!
+//! oc-rsync previously accumulated this total only in the local-copy executor,
+//! so every remote (daemon / ssh) push AND pull printed
+//! `Total transferred file size: 0 bytes` even though real file data moved.
+//! This is the twin of the `bytes_copied` / `Literal data` gap fixed in #477.
+//!
+//! For both upload (client pushes into a daemon module) and download (client
+//! pulls from a daemon module) into a FRESH empty destination - so every
+//! regular file is transferred and the summed length is deterministic:
+//!
+//! 1. The transfer exits cleanly (status 0).
+//! 2. The client's `--stats` summary reports the real non-zero
+//!    `Total transferred file size: N bytes`, where `N` is the sum of the
+//!    transferred regular files' lengths. A regression that drops the
+//!    accumulation (push) or fails to adopt it into the client summary (pull)
+//!    prints `0` here.
+//!
+//! # Platform gate
+//!
+//! `#![cfg(unix)]` - matches the sibling daemon-stats nextest guards
+//! (`uts_nextest_daemon_delete_stats.rs`). Windows daemon mode has separate
+//! coverage.
+//!
+//! # Upstream References
+//!
+//! - `sender.c:343` / `receiver.c:784` - `total_transferred_size += F_LENGTH`.
+//! - `main.c:325-385` - `handle_stats()`: the stat is NOT sent on the wire.
+//! - `main.c:439` / `log.c:output_summary()` - the summary line.
+
+#![cfg(unix)]
+
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use tempfile::{TempDir, tempdir};
+
+/// Byte lengths of the three regular source files. Kept small (sum < 1000) so
+/// the rendered figure carries no thousands separator and the assertion can
+/// match the exact `Total transferred file size: N bytes` text. Distinct sizes
+/// also guard against a stub that reported a file count instead of a length.
+const FILE_SIZES: [usize; 3] = [300, 150, 70];
+
+/// Sum of every transferred regular file's length - the expected value of the
+/// `Total transferred file size` line for a fresh (all-new) destination.
+fn expected_transferred_size() -> usize {
+    FILE_SIZES.iter().sum()
+}
+
+/// Locate the workspace `oc-rsync` binary the test runner built.
+fn locate_oc_rsync() -> Option<PathBuf> {
+    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    let exe = env::current_exe().ok()?;
+    let mut dir = exe.parent()?;
+    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
+    while !dir.ends_with("target") {
+        let candidate = dir.join(&name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    for sub in ["debug", "release"] {
+        let candidate = dir.join(sub).join(&name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Write an `rsyncd.conf` exposing a single module. `use chroot = false` lets
+/// the unprivileged test process drive the daemon; `read only` is parameterised
+/// so the same writer covers push (RW) and pull (RO) shapes.
+fn write_daemon_config(
+    config_path: &Path,
+    pid_path: &Path,
+    log_path: &Path,
+    module_name: &str,
+    module_root: &Path,
+    read_only: bool,
+) -> io::Result<()> {
+    let body = format!(
+        "pid file = {pid}\n\
+         log file = {log}\n\
+         use chroot = false\n\
+         max connections = 4\n\
+         \n\
+         [{module}]\n\
+         path = {root}\n\
+         comment = total-transferred-size stats guard\n\
+         read only = {ro}\n\
+         list = true\n",
+        pid = pid_path.display(),
+        log = log_path.display(),
+        module = module_name,
+        root = module_root.display(),
+        ro = if read_only { "true" } else { "false" },
+    );
+    fs::write(config_path, body)
+}
+
+/// Guard that kills the daemon child on drop.
+struct DaemonGuard {
+    child: Child,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn `oc-rsync --daemon` on a free port and wait until it accepts.
+fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
+}
+
+/// Seed a source tree of three regular files with the fixed `FILE_SIZES`
+/// lengths. Content bytes are position-varied so a size mismatch is obvious.
+fn seed_source(dir: &Path) -> io::Result<()> {
+    fs::create_dir_all(dir)?;
+    for (idx, &size) in FILE_SIZES.iter().enumerate() {
+        let name = format!("file_{idx}.dat");
+        fs::write(dir.join(name), vec![b'a' + idx as u8; size])?;
+    }
+    Ok(())
+}
+
+/// Drive one `oc-rsync` invocation and capture `(status, stdout, stderr)`.
+fn run_oc_rsync_capture(
+    bin: &Path,
+    args: &[&std::ffi::OsStr],
+) -> io::Result<(std::process::ExitStatus, String, String)> {
+    let output = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+    Ok((
+        output.status,
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    ))
+}
+
+/// Assert the `--stats` summary reports the real summed transferred-file
+/// length, not the pre-fix zero.
+fn assert_transferred_size(stdout: &str, stderr: &str, expected: usize) {
+    let needle = format!("Total transferred file size: {expected} bytes");
+    assert!(
+        stdout.contains(&needle),
+        "missing `{needle}` line in --stats output.\n\
+         A remote transfer that failed to accumulate total_transferred_size \
+         (push: sender.c:343) or to adopt it into the client summary (pull: \
+         receiver.c:784) prints `Total transferred file size: 0 bytes` here.\n\
+         stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        !stdout.contains("Total transferred file size: 0 bytes"),
+        "reported zero transferred file size despite real data moving.\n\
+         stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+}
+
+/// Shared scratch: tempdir + daemon log/pid/config paths.
+struct DaemonScratch {
+    _tmp: TempDir,
+    root: PathBuf,
+    config: PathBuf,
+    log: PathBuf,
+    pid: PathBuf,
+}
+
+impl DaemonScratch {
+    fn new() -> Option<Self> {
+        let tmp = tempdir().ok()?;
+        let root = tmp.path().to_path_buf();
+        let config = root.join("rsyncd.conf");
+        let log = root.join("rsyncd.log");
+        let pid = root.join("rsyncd.pid");
+        Some(Self {
+            _tmp: tmp,
+            root,
+            config,
+            log,
+            pid,
+        })
+    }
+}
+
+/// Push direction: client is the sender, so it accumulates
+/// `total_transferred_size` itself (`sender.c:343`). Destination starts empty
+/// so all three files transfer and the summed length is deterministic.
+#[test]
+fn daemon_push_reports_total_transferred_file_size() {
+    let Some(oc_bin) = locate_oc_rsync() else {
+        eprintln!("skipping: oc-rsync binary not found in target/");
+        return;
+    };
+    let Some(scratch) = DaemonScratch::new() else {
+        eprintln!("skipping: tempdir or test port allocation failed");
+        return;
+    };
+
+    let source_dir = scratch.root.join("source");
+    let module_root = scratch.root.join("dest");
+    seed_source(&source_dir).expect("seed source");
+    fs::create_dir_all(&module_root).expect("create empty module root");
+
+    write_daemon_config(
+        &scratch.config,
+        &scratch.pid,
+        &scratch.log,
+        "pushmod",
+        &module_root,
+        false,
+    )
+    .expect("write daemon config");
+
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &scratch.config) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping: could not start oc-rsync --daemon: {e}");
+            return;
+        }
+    };
+
+    let mut source_arg = source_dir.clone().into_os_string();
+    source_arg.push("/");
+    let dst_url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{port}/pushmod/"));
+
+    let args: &[&std::ffi::OsStr] = &[
+        std::ffi::OsStr::new("--stats"),
+        std::ffi::OsStr::new("--recursive"),
+        std::ffi::OsStr::new("--times"),
+        &source_arg,
+        &dst_url,
+    ];
+
+    let (status, stdout, stderr) =
+        run_oc_rsync_capture(&oc_bin, args).expect("spawn oc-rsync client (push)");
+
+    assert!(
+        status.success(),
+        "client push exited non-zero: {status:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert_transferred_size(&stdout, &stderr, expected_transferred_size());
+}
+
+/// Pull direction: client is the receiver, so it accumulates
+/// `total_transferred_size` itself (`receiver.c:784`) and must adopt it into
+/// the client summary. Regression guard for the opposite direction.
+#[test]
+fn daemon_pull_reports_total_transferred_file_size() {
+    let Some(oc_bin) = locate_oc_rsync() else {
+        eprintln!("skipping: oc-rsync binary not found in target/");
+        return;
+    };
+    let Some(scratch) = DaemonScratch::new() else {
+        eprintln!("skipping: tempdir or test port allocation failed");
+        return;
+    };
+
+    let module_root = scratch.root.join("source");
+    let dest_dir = scratch.root.join("dest");
+    seed_source(&module_root).expect("seed source (module)");
+    fs::create_dir_all(&dest_dir).expect("create empty local destination");
+
+    // Read-only module: the daemon only serves; the client runs the receiver.
+    write_daemon_config(
+        &scratch.config,
+        &scratch.pid,
+        &scratch.log,
+        "pullmod",
+        &module_root,
+        true,
+    )
+    .expect("write daemon config");
+
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &scratch.config) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping: could not start oc-rsync --daemon: {e}");
+            return;
+        }
+    };
+
+    let src_url = std::ffi::OsString::from(format!("rsync://127.0.0.1:{port}/pullmod/"));
+    let mut dest_arg = dest_dir.clone().into_os_string();
+    dest_arg.push("/");
+
+    let args: &[&std::ffi::OsStr] = &[
+        std::ffi::OsStr::new("--stats"),
+        std::ffi::OsStr::new("--recursive"),
+        std::ffi::OsStr::new("--times"),
+        &src_url,
+        &dest_arg,
+    ];
+
+    let (status, stdout, stderr) =
+        run_oc_rsync_capture(&oc_bin, args).expect("spawn oc-rsync client (pull)");
+
+    assert!(
+        status.success(),
+        "client pull exited non-zero: {status:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert_transferred_size(&stdout, &stderr, expected_transferred_size());
+}

--- a/crates/transfer/tests/incremental_transfer.rs
+++ b/crates/transfer/tests/incremental_transfer.rs
@@ -19,6 +19,7 @@ fn transfer_stats_incremental_fields_exist() {
     let stats = TransferStats {
         files_listed: 10,
         files_transferred: 5,
+        transferred_file_size: 5000,
         bytes_received: 1000,
         bytes_sent: 100,
         total_source_bytes: 5000,


### PR DESCRIPTION
## Summary

Remote (ssh + daemon) push **and** pull printed `Total transferred file size: 0 bytes` in the `--stats` summary for every transfer, even when real file data moved. Upstream reports the summed length of the transferred files. This restores that value in both directions.

## Upstream behaviour (source of truth)

Upstream accumulates `stats.total_transferred_size` by adding each transferred file's `F_LENGTH` at the exact point it bumps `xferred_files`:

- `sender.c:343` — `stats.total_transferred_size += F_LENGTH(file);`
- `receiver.c:784` — `stats.total_transferred_size += F_LENGTH(file);`

The value **never crosses the wire**: `main.c:handle_stats()` (3.4.4:325-385) exchanges only `total_read`, `total_written`, `total_size` and the two flist timing counters. Each side computes `total_transferred_size` locally, and the process that runs the transfer loop is always the client that prints the summary:

- **push** — the client is the sender (`sender.c`), so it accumulates the total itself;
- **pull** — the client is the receiver (`receiver.c`), so it accumulates the total itself.

`main.c:439` / `log.c:output_summary()` renders `Total transferred file size: %s bytes` from it.

## The gap

oc summed transferred-file length only in the local-copy executor (`LocalCopySummary::record_file`). Neither the generator (push) nor the receiver (pull) tracked it, and the two remote-summary constructors (`from_generator_stats` / `from_receiver_stats`) dropped it via `..Default::default()`, so it stayed `0`:

- **Push gap** — no accumulator in the generator transfer loop → not on `TransferLoopResult` / `GeneratorStats` → not passed to `from_generator_stats`.
- **Pull gap** — no accumulator in the receiver pipeline → not on `TransferStats` → not passed to `from_receiver_stats`.

This is the twin of the `Literal data` / `bytes_copied` remote gap fixed in #477.

## Fix

Mirror upstream exactly: accumulate `F_LENGTH` in lockstep with `files_transferred` at every transfer point, and thread it through to the client summary.

- Generator (push): sum `file_entry.size()` at both `files_transferred += 1` sites in `generator/transfer/transfer_loop.rs` (dry-run/no-xfers and real send, matching that upstream increments before the `if (!do_xfers)` continue), carry it on `TransferLoopResult` → `GeneratorStats`.
- Receiver (pull): sum `file_entry.size()` at the transfer point in `run_pipeline_loop_decoupled`, carry it out of the pipeline (including the phase-2 redo pass) into `TransferStats` for both `run_pipelined` and `run_pipelined_incremental` (and the legacy `run_sync`).
- Adopt it into `LocalCopySummary` via a new argument to `from_generator_stats` / `from_receiver_stats`; the CLI already renders `summary.transferred_file_size()`.

The value is computed locally on each side exactly as upstream does, so nothing new is added to the wire and the change stays byte-for-byte wire-compatible.

## Tests

- `append_redo_reads_full_signature_without_desync` (generator loop, in-process): the accumulated total is `2 * 100` for an append send + redo resend of a 100-byte file — proving the sender-side accumulation and its lockstep with `files_transferred`.
- Engine summary constructor tests: `from_receiver_stats` / `from_generator_stats` now assert the threaded-through `transferred_file_size` for both directions.
- `daemon_total_transferred_size_stats.rs` (new, daemon end-to-end): drives a real push and a real pull into a fresh destination and asserts the rendered `Total transferred file size: N bytes` line is non-zero and equals the summed source length in both directions. A regression prints `0`.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings` clean on the touched crates.
- Targeted tests pass locally, including the daemon end-to-end guard driving the real binary.