### PR TITLE
fix(rsync_io): auto-enable blocking_io for rsh/remsh remote shells

### DIFF
--- a/crates/core/src/client/remote/ssh_transfer/connection.rs
+++ b/crates/core/src/client/remote/ssh_transfer/connection.rs
@@ -56,6 +56,11 @@ pub(super) fn build_ssh_connection(
     // child as -4/-6 (only honoured when the remote shell is `ssh`).
     ssh.set_address_family(ssh_address_family(config.address_mode()));
 
+    // upstream: main.c:600-601 do_cmd() - force blocking_io for the rsh/remsh
+    // remote shells when the user left --blocking-io/--no-blocking-io unset. The
+    // builder applies the auto-enable from the resolved program basename.
+    ssh.set_blocking_io(config.blocking_io());
+
     ssh.set_prefer_aes_gcm(config.prefer_aes_gcm());
     ssh.set_jump_hosts(config.jump_hosts().map(OsString::from));
 

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -55,6 +55,19 @@ pub enum SshAddressFamily {
     V6,
 }
 
+/// Returns whether a remote-shell program basename is one upstream forces
+/// blocking I/O for when `--blocking-io`/`--no-blocking-io` was left unset:
+/// `rsh` or `remsh`, which mishandle a non-blocking child stdout.
+///
+/// The comparison is exact (like upstream `strcmp`), so ssh-family wrappers or
+/// paths embedding those names are not matched.
+///
+/// upstream: main.c:600 `do_cmd()` - `strcmp(t, "rsh") == 0 || strcmp(t,
+/// "remsh") == 0`.
+fn program_forces_blocking_io(basename: &str) -> bool {
+    matches!(basename, "rsh" | "remsh")
+}
+
 /// Builder used to configure and spawn an SSH subprocess.
 #[derive(Clone, Debug)]
 pub struct SshCommand {
@@ -65,6 +78,7 @@ pub struct SshCommand {
     batch_mode: bool,
     bind_address: Option<IpAddr>,
     address_family: Option<SshAddressFamily>,
+    blocking_io: Option<bool>,
     keepalive: bool,
     options: Vec<OsString>,
     connect_timeout: Option<Duration>,
@@ -88,6 +102,7 @@ impl SshCommand {
             batch_mode: true,
             bind_address: None,
             address_family: None,
+            blocking_io: None,
             keepalive: true,
             connect_timeout: Some(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS)),
             io_timeout: None,
@@ -142,6 +157,19 @@ impl SshCommand {
     /// counterpart).
     pub const fn set_address_family(&mut self, family: Option<SshAddressFamily>) -> &mut Self {
         self.address_family = family;
+        self
+    }
+
+    /// Records rsync's tri-state `--blocking-io`/`--no-blocking-io` preference
+    /// for the remote-shell child: `Some(true)` forces blocking I/O,
+    /// `Some(false)` forces non-blocking, and `None` (the default) leaves it
+    /// unset so [`SshCommand::resolved_blocking_io`] can apply upstream's
+    /// `rsh`/`remsh` auto-enable.
+    ///
+    /// upstream: options.c:144,842-843 - `blocking_io` defaults to `-1` (unset)
+    /// and is set to `1`/`0` by `--blocking-io`/`--no-blocking-io`.
+    pub const fn set_blocking_io(&mut self, blocking: Option<bool>) -> &mut Self {
+        self.blocking_io = blocking;
         self
     }
 
@@ -412,6 +440,19 @@ impl SshCommand {
             trace_cmd_argv(&full_argv);
         }
 
+        // upstream: main.c:600-601 do_cmd() forces blocking_io for rsh/remsh
+        // when unset; pipe.c:80-82 then sets the child stdout blocking. Our
+        // `Stdio::piped()` child descriptors are already unconditionally
+        // blocking, so this only records the resolved mode for diagnostics.
+        if logging::debug_gte(logging::DebugFlag::Cmd, 2) {
+            debug_log!(
+                Connect,
+                2,
+                "remote-shell blocking_io resolved to {}",
+                self.resolved_blocking_io()
+            );
+        }
+
         let mut command = Command::new(&program);
         command.stdin(Stdio::piped());
         command.stdout(Stdio::piped());
@@ -617,19 +658,53 @@ impl SshCommand {
         has_hardware_aes() && self.is_ssh_program() && !self.options_contain_cipher_flag()
     }
 
+    /// Returns the configured program's basename (`t` in upstream `do_cmd()`),
+    /// stripped of any directory prefix. Uses case-folding on Windows where
+    /// `SSH.EXE` or `Ssh.exe` are common depending on how the path is resolved.
+    ///
+    /// upstream: main.c:564-567 `do_cmd()` - `if ((t = strrchr(cmd, '/')) !=
+    /// NULL) t++; else t = cmd;`.
+    fn program_basename(&self) -> String {
+        let program = self.program.to_string_lossy();
+        // Handle both forward slash (Unix) and backslash (Windows) path separators.
+        let basename = program.rsplit(['/', '\\']).next().unwrap_or(&program);
+        if cfg!(windows) {
+            basename.to_ascii_lowercase()
+        } else {
+            basename.to_string()
+        }
+    }
+
     /// Checks whether the configured program appears to be an SSH client.
     ///
     /// Uses case-insensitive comparison on Windows where `SSH.EXE` or
     /// `Ssh.exe` are common depending on how the path is resolved.
     fn is_ssh_program(&self) -> bool {
-        let program = self.program.to_string_lossy();
-        // Handle both forward slash (Unix) and backslash (Windows) path separators.
-        let basename = program.rsplit(['/', '\\']).next().unwrap_or(&program);
-        if cfg!(windows) {
-            let lower = basename.to_ascii_lowercase();
-            lower == "ssh" || lower == "ssh.exe"
-        } else {
-            basename == "ssh" || basename == "ssh.exe"
+        let basename = self.program_basename();
+        basename == "ssh" || basename == "ssh.exe"
+    }
+
+    /// Resolves rsync's tri-state blocking-I/O preference for the remote-shell
+    /// child, mirroring upstream `do_cmd()`. An explicit `--blocking-io`
+    /// (`Some(true)`) or `--no-blocking-io` (`Some(false)`) always wins; when
+    /// the user left it unset (`None`), upstream forces blocking I/O for the
+    /// `rsh`/`remsh` shells - which mishandle a non-blocking child stdout - and
+    /// leaves every other program (`ssh`, custom `-e` wrappers) non-blocking.
+    ///
+    /// oc-rsync spawns the remote shell with `std::process::Command` and
+    /// `Stdio::piped()`, whose child pipe descriptors are unconditionally
+    /// blocking on every platform, so the forced-blocking outcome already holds
+    /// by construction; this resolution keeps the semantic state faithful to
+    /// upstream. `blocking_io` is a purely local child-fd concern and is never
+    /// forwarded on the wire (upstream `server_options()` does not emit it).
+    ///
+    /// upstream: main.c:600-601 `do_cmd()` - `if (blocking_io < 0 && (strcmp(t,
+    /// "rsh") == 0 || strcmp(t, "remsh") == 0)) blocking_io = 1;` and
+    /// pipe.c:80-82 where `blocking_io > 0` sets the child stdout blocking.
+    pub(crate) fn resolved_blocking_io(&self) -> bool {
+        match self.blocking_io {
+            Some(explicit) => explicit,
+            None => program_forces_blocking_io(&self.program_basename()),
         }
     }
 

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -2391,3 +2391,64 @@ fn does_not_force_address_family_for_non_ssh_shell() {
         "unexpected -6 in {rendered:?}"
     );
 }
+
+#[test]
+fn blocking_io_auto_enabled_for_rsh_when_unset() {
+    // WHY: rsh mishandles a non-blocking child stdout, so upstream forces
+    // blocking I/O for it whenever the user left the flag unset. Regressing to
+    // non-blocking would corrupt the stream over a real rsh transport.
+    // upstream: main.c:600-601 do_cmd() - blocking_io = 1 for rsh when unset.
+    let mut command = SshCommand::new("example.com");
+    command.set_program("rsh");
+    assert!(command.resolved_blocking_io());
+}
+
+#[test]
+fn blocking_io_auto_enabled_for_remsh_when_unset() {
+    // WHY: remsh (HP-UX) shares rsh's non-blocking-stdout defect, so upstream
+    // forces blocking I/O for it too when the flag is unset.
+    // upstream: main.c:600-601 do_cmd() - `strcmp(t, "remsh") == 0`.
+    let mut command = SshCommand::new("example.com");
+    command.set_program("remsh");
+    assert!(command.resolved_blocking_io());
+}
+
+#[test]
+fn blocking_io_auto_enabled_for_path_qualified_rsh() {
+    // WHY: upstream compares the command basename (`t`), so `/usr/bin/rsh`
+    // triggers the same forced-blocking rule.
+    // upstream: main.c:564-567 do_cmd() strips the directory before the strcmp.
+    let mut command = SshCommand::new("example.com");
+    command.set_program("/usr/bin/rsh");
+    assert!(command.resolved_blocking_io());
+}
+
+#[test]
+fn blocking_io_stays_disabled_for_ssh_when_unset() {
+    // WHY: ssh relies on a non-blocking child stdout, so upstream leaves
+    // blocking_io off for it when the user did not request it.
+    // upstream: main.c:600 do_cmd() - only rsh/remsh match the auto-enable.
+    let command = SshCommand::new("example.com");
+    assert!(!command.resolved_blocking_io());
+}
+
+#[test]
+fn explicit_no_blocking_io_wins_over_rsh_auto_enable() {
+    // WHY: an explicit `--no-blocking-io` is a user override that must beat the
+    // rsh/remsh auto-enable; upstream only auto-enables when `blocking_io < 0`
+    // (still unset). upstream: main.c:600 do_cmd() gate `blocking_io < 0`.
+    let mut command = SshCommand::new("example.com");
+    command.set_program("rsh");
+    command.set_blocking_io(Some(false));
+    assert!(!command.resolved_blocking_io());
+}
+
+#[test]
+fn explicit_blocking_io_forces_for_ssh() {
+    // WHY: `--blocking-io` forces blocking pipes even for ssh, matching
+    // upstream where the explicit value is retained.
+    // upstream: options.c:842 `--blocking-io` sets blocking_io = 1.
+    let mut command = SshCommand::new("example.com");
+    command.set_blocking_io(Some(true));
+    assert!(command.resolved_blocking_io());
+}


### PR DESCRIPTION
## Summary

Mirror upstream rsync's `do_cmd()` rule that auto-enables blocking I/O for the
`rsh`/`remsh` remote shells when the user left `--blocking-io`/`--no-blocking-io`
unset.

upstream: `main.c:600-601` `do_cmd()`

```c
if (blocking_io < 0 && (strcmp(t, "rsh") == 0 || strcmp(t, "remsh") == 0))
    blocking_io = 1;
```

where `t` is the remote-shell command's basename (`main.c:564-567`), the same
`t` used for the `-4`/`-6` and `ssh` gates. The default `blocking_io = -1`
(unset) is set to `1`/`0` by `--blocking-io`/`--no-blocking-io`
(`options.c:144,842-843`); an explicit user value always wins.

## What `blocking_io` does upstream

It is a purely **local, client-side** concern for the remote-shell child's pipe
descriptors. In `pipe.c:80-82`, after fork and before exec, the child's STDIN is
always set blocking; its STDOUT is set blocking only when `blocking_io > 0`:

```c
set_blocking(STDIN_FILENO);
if (blocking_io > 0)
    set_blocking(STDOUT_FILENO);
```

The comment (`pipe.c:40-46`) explains: rsh relies on stdin being blocking and
ssh relies on stdout being non-blocking; `blocking_io` forces stdout blocking too
to cope with broken rsh implementations (e.g. Solaris). `blocking_io` is **never
forwarded on the wire** - `server_options()` does not emit it - so there is no
wire-format change.

## oc-rsync's pipe model (why the observable effect is limited)

oc-rsync spawns the remote shell with `std::process::Command` and
`Stdio::piped()` (see `builder.rs::spawn` and `rsh.rs::spawn_rsh_daemon_stream`).
Rust's `Stdio::piped()` child descriptors are **unconditionally blocking** on
every platform, and oc-rsync's transport reads/writes them with a blocking
threaded model throughout. So the child stdout is already blocking - exactly the
outcome upstream forces for rsh/remsh - and there are no non-blocking child
descriptors to toggle. oc-rsync also cannot flip a child pipe's `O_NONBLOCK`
without `pre_exec`/`fcntl` (unsafe FFI), which is disallowed in `rsync_io`.

This change therefore implements the faithful **resolution state** (parse +
track the `--blocking-io`/`--no-blocking-io` tri-state, apply upstream's
rsh/remsh auto-enable with explicit-wins precedence) rather than inventing new
pipe behavior. The resolved mode is recorded on the CONNECT debug trace at
`--debug=CMD2`.

## Changes

- `crates/rsync_io/src/ssh/builder.rs`
  - Add a `blocking_io: Option<bool>` tri-state field to `SshCommand` and a
    `set_blocking_io` setter.
  - Factor the program-basename computation out of `is_ssh_program` into
    `program_basename()` (mirrors `do_cmd()` `t`), and add
    `program_forces_blocking_io()` (exact `rsh`/`remsh` match, like upstream
    `strcmp`) plus `resolved_blocking_io()` applying the `do_cmd()` rule.
  - Record the resolved mode in the spawn debug trace.
- `crates/core/src/client/remote/ssh_transfer/connection.rs`
  - Wire `config.blocking_io()` into `SshCommand::set_blocking_io` alongside the
    existing address-family forwarding.

## Tests

Resolution-logic tests on the program basename + tri-state (like the
`-4`/`-6` argv tests), encoding WHY (rsh/remsh mishandle non-blocking I/O;
upstream forces blocking):

- `blocking_io_auto_enabled_for_rsh_when_unset`
- `blocking_io_auto_enabled_for_remsh_when_unset`
- `blocking_io_auto_enabled_for_path_qualified_rsh` (basename strip)
- `blocking_io_stays_disabled_for_ssh_when_unset`
- `explicit_no_blocking_io_wins_over_rsh_auto_enable` (explicit override)
- `explicit_blocking_io_forces_for_ssh`

`cargo fmt --all -- --check` and
`cargo clippy -p rsync_io -p core --all-targets --all-features --no-deps -- -D warnings`
are clean; the new tests pass locally.
