### PR TITLE
fix(filters): abort like upstream on perishable rule sent to a proto<30 peer

### DIFF
--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -345,6 +345,45 @@ fn wire_rule_crosses_wire(
     true
 }
 
+/// Fatal diagnostic emitted when a filter rule cannot be represented on a
+/// pre-30 peer's wire, matching upstream `send_rules()` byte-for-byte
+/// (exclude.c:1625). oc's error layer appends the standard `(code 2) at ...`
+/// trailer, mirroring upstream's `exclude.c(1627) [sender=<ver>]`.
+pub(crate) const TOO_MODERN_FILTER_RULES_MSG: &str =
+    "filter rules are too modern for remote rsync.";
+
+/// Reports whether the transmitted filter list is too modern for the peer and
+/// the transfer must abort, mirroring upstream `send_rules()`.
+///
+/// Upstream `get_rule_prefix()` (exclude.c:1573-1577) returns NULL for a
+/// perishable rule when building the wire form (`for_xfer`) at a protocol below
+/// 30 **and** the local side is the sender: the pre-30 wire has no `p` modifier,
+/// so the rule cannot be represented. `send_rules()` (exclude.c:1624-1628)
+/// treats that NULL as fatal - it prints "filter rules are too modern for remote
+/// rsync." and calls `exit_cleanup(RERR_PROTOCOL)` (exit code 2) rather than
+/// silently dropping the rule. A receiver at a pre-30 protocol instead omits the
+/// `p` char and keeps the rule (the `else if (am_sender)` guard at
+/// exclude.c:1576 does not fire), so this predicate never aborts on a pull.
+///
+/// The check runs over `wire_rules` - the rules that survive
+/// [`wire_rule_crosses_wire`] - because those are exactly the rules that reach
+/// `get_rule_prefix()` in upstream's loop; a rule elided as local (LOCAL_RULE)
+/// never triggers the NULL return.
+///
+/// # Upstream Reference
+///
+/// `exclude.c:1573-1577` (`get_rule_prefix`, the NULL return); `exclude.c:1624-1628`
+/// (`send_rules`, the fatal abort).
+fn perishable_rules_too_modern(
+    wire_rules: &[protocol::filters::FilterRuleWireFormat],
+    client_is_sender: bool,
+    protocol: protocol::ProtocolVersion,
+) -> bool {
+    client_is_sender
+        && !protocol.supports_perishable_modifier()
+        && wire_rules.iter().any(|rule| rule.perishable)
+}
+
 /// Determines whether the output stream should use multiplexed framing.
 ///
 /// Upstream rsync activates multiplex output differently depending on
@@ -796,6 +835,10 @@ pub fn run_server_with_handshake_adopting<W: Write>(
             })
             .cloned()
             .collect();
+        if perishable_rules_too_modern(&wire_rules, client_is_sender, handshake.protocol) {
+            // upstream: exclude.c:1624-1628 send_rules() aborts the transfer here.
+            return Err(protocol::protocol_violation(TOO_MODERN_FILTER_RULES_MSG));
+        }
         protocol::filters::write_filter_list(&mut writer, &wire_rules, handshake.protocol)?;
         writer.flush()?;
     }

--- a/crates/transfer/src/tests/filter_list_gate.rs
+++ b/crates/transfer/src/tests/filter_list_gate.rs
@@ -11,7 +11,10 @@
 use protocol::ProtocolVersion;
 use protocol::filters::{FilterRuleWireFormat, RuleType};
 
-use crate::{receiver_wants_filter_list, wire_rule_crosses_wire};
+use crate::{
+    TOO_MODERN_FILTER_RULES_MSG, perishable_rules_too_modern, receiver_wants_filter_list,
+    wire_rule_crosses_wire,
+};
 
 // -- receiver_wants_list truth table (exclude.c:1647-1648, 1676-1677) --
 
@@ -332,4 +335,99 @@ fn manual_dir_merge_without_cvs_origin_not_gated() {
         false,
         ProtocolVersion::V32
     ));
+}
+
+// -- perishable "too modern" abort (exclude.c:1573-1577 / 1624-1628) --
+
+fn perishable_exclude() -> FilterRuleWireFormat {
+    FilterRuleWireFormat::exclude("*.tmp".to_owned()).with_perishable(true)
+}
+
+/// (a) A sending client at a pre-30 protocol with a perishable rule must abort.
+/// upstream `get_rule_prefix()` returns NULL for the rule (the pre-30 wire has no
+/// `p` modifier) and `send_rules()` turns that into a fatal RERR_PROTOCOL rather
+/// than silently dropping it - oc previously accepted the transfer, an
+/// observable-fidelity divergence (exit code + stderr), so this asserts the
+/// predicate fires at both legacy protocols the sender can negotiate.
+#[test]
+fn perishable_rule_aborts_on_push_pre_protocol_30() {
+    let rules = [perishable_exclude()];
+    assert!(perishable_rules_too_modern(
+        &rules,
+        true,
+        ProtocolVersion::V28
+    ));
+    assert!(perishable_rules_too_modern(
+        &rules,
+        true,
+        ProtocolVersion::V29
+    ));
+}
+
+/// (b) At protocol >= 30 the `p` modifier is encodable, so the same rule is sent
+/// (with `p`, verified by the prefix builder tests) and never aborts.
+#[test]
+fn perishable_rule_sent_at_protocol_30_and_above() {
+    let rules = [perishable_exclude()];
+    assert!(!perishable_rules_too_modern(
+        &rules,
+        true,
+        ProtocolVersion::V30
+    ));
+    assert!(!perishable_rules_too_modern(
+        &rules,
+        true,
+        ProtocolVersion::V32
+    ));
+}
+
+/// (c) A receiver (pull) at a pre-30 protocol keeps the rule and merely omits the
+/// `p` char (upstream's `else if (am_sender)` guard does not fire), so it must
+/// NOT abort - only the sender direction is fatal.
+#[test]
+fn perishable_rule_kept_on_pull_pre_protocol_30() {
+    let rules = [perishable_exclude()];
+    assert!(!perishable_rules_too_modern(
+        &rules,
+        false,
+        ProtocolVersion::V28
+    ));
+    assert!(!perishable_rules_too_modern(
+        &rules,
+        false,
+        ProtocolVersion::V29
+    ));
+}
+
+/// (d) A non-perishable rule is representable on every wire, so a pre-30 push is
+/// unaffected - the abort is scoped strictly to the perishable flag.
+#[test]
+fn non_perishable_rule_unaffected_pre_protocol_30() {
+    let rules = [FilterRuleWireFormat::exclude("*.tmp".to_owned())];
+    assert!(!perishable_rules_too_modern(
+        &rules,
+        true,
+        ProtocolVersion::V28
+    ));
+}
+
+/// The abort maps to upstream's exact observable outcome: the stderr diagnostic
+/// text is byte-for-byte `filter rules are too modern for remote rsync.`
+/// (exclude.c:1625) and it is tagged as a protocol violation, which the core
+/// exit-code mapper renders as RERR_PROTOCOL (exit code 2) - the same class as
+/// upstream's `exit_cleanup(RERR_PROTOCOL)`.
+#[test]
+fn too_modern_abort_message_and_exit_class() {
+    assert_eq!(
+        TOO_MODERN_FILTER_RULES_MSG,
+        "filter rules are too modern for remote rsync."
+    );
+    let err = protocol::protocol_violation(TOO_MODERN_FILTER_RULES_MSG);
+    assert_eq!(err.to_string(), TOO_MODERN_FILTER_RULES_MSG);
+    assert!(
+        err.get_ref()
+            .and_then(|inner| inner.downcast_ref::<protocol::ProtocolViolation>())
+            .is_some(),
+        "abort must be tagged ProtocolViolation so it maps to RERR_PROTOCOL (2)"
+    );
 }


### PR DESCRIPTION
## Problem

When the local client is the **sender** and the negotiated protocol is **< 30**, a
perishable filter rule (the `p` modifier, e.g. `--filter='-p *.tmp'`) cannot be
represented on the wire - the pre-30 filter wire has no `p` modifier. Upstream rsync
does **not** silently drop the rule: it aborts the transfer.

`exclude.c:1573-1577` (`get_rule_prefix`, building the wire form with `for_xfer`):

```c
if (rule->rflags & FILTRULE_PERISHABLE) {
        if (!for_xfer || protocol_version >= 30)
                *op++ = 'p';
        else if (am_sender)
                return NULL;
}
```

`exclude.c:1624-1628` (`send_rules`) turns that NULL into a fatal error:

```c
p = get_rule_prefix(ent, ent->pattern, 1, &plen);
if (!p) {
        rprintf(FERROR, "filter rules are too modern for remote rsync.\n");
        exit_cleanup(RERR_PROTOCOL);
}
```

oc-rsync instead emitted the rule without `p` (protocol < 30) and let the transfer
succeed - an **observable-fidelity divergence** (exit code + stderr), not a
wire-content one: oc silently accepted a transfer upstream aborts.

## Real-binary proof (rsync 3.4.4)

```
$ rsync -av --protocol=29 --filter='-p *.tmp' src/ dst/
filter rules are too modern for remote rsync.
rsync error: received SIGUSR1 (code 19) at main.c(1622) [Receiver=3.4.4]
rsync error: protocol incompatibility (code 2) at exclude.c(1627) [sender=3.4.4]
$ echo $?
2
```

## Fix

At the wire-list build site (`transfer/src/lib.rs`), before writing the filter list,
abort when the client is the sender, the negotiated protocol does not support the
perishable modifier (< 30), and any rule that crosses the wire is perishable. The
abort reuses oc's `protocol::protocol_violation`, which carries the exact stderr
message `filter rules are too modern for remote rsync.` and maps to `RERR_PROTOCOL`
(exit code 2); oc's error layer appends the standard `(code 2) at <path>:<line>
[<role>=<version>]` trailer, mirroring upstream's `exclude.c(1627) [sender=3.4.4]`.

The check runs over the post-elision `wire_rules` set - exactly the rules that reach
`get_rule_prefix()` in upstream's `send_rules()` loop (a rule elided as local never
triggers the NULL return).

### Unchanged behaviour

- **Receiver (pull), protocol < 30, perishable rule** - sent WITHOUT `p`, kept
  (upstream's `else if (am_sender)` guard at exclude.c:1576 does not fire).
- **Protocol >= 30** - rule sent WITH `p`.
- **Non-perishable rules at any protocol** - unaffected.

## Tests

`crates/transfer/src/tests/filter_list_gate.rs`:

- (a) sender + protocol 28/29 + perishable rule -> abort predicate fires.
- (b) sender + protocol 30/32 + same rule -> no abort (rule crosses with `p`,
  wire-content locked by existing `prefix.rs` tests).
- (c) receiver + protocol 28/29 + perishable rule -> no abort (kept without `p`).
- (d) non-perishable rule + protocol 28 + sender -> no abort.
- The abort's observable identity: stderr text is byte-for-byte
  `filter rules are too modern for remote rsync.` and it is tagged
  `ProtocolViolation` so the core exit-code mapper renders `RERR_PROTOCOL` (2).

## Upstream reference

`exclude.c:1573-1577` (`get_rule_prefix` NULL return); `exclude.c:1624-1628`
(`send_rules` fatal abort).
