### PR TITLE
fix(cli): thread human-readable mode into --stats count fields

### DIFF
--- a/crates/cli/src/frontend/progress/format/mod.rs
+++ b/crates/cli/src/frontend/progress/format/mod.rs
@@ -18,5 +18,6 @@ pub(crate) use self::rate::{
 };
 pub(crate) use self::remaining::RemainingTimeEstimator;
 pub(crate) use self::size::{
-    format_decimal_bytes, format_human_bytes, format_list_size, format_progress_bytes, format_size,
+    format_count, format_decimal_bytes, format_human_bytes, format_list_size,
+    format_progress_bytes, format_size,
 };

--- a/crates/cli/src/frontend/progress/format/progress.rs
+++ b/crates/cli/src/frontend/progress/format/progress.rs
@@ -1,5 +1,6 @@
 //! Progress bar display helpers - percentages, elapsed time, and stat categories.
 
+use core::client::HumanReadableMode;
 use std::time::Duration;
 
 /// Formats a progress percentage.
@@ -30,13 +31,22 @@ pub(crate) fn format_progress_elapsed(elapsed: Duration) -> String {
     format!("{hours}:{minutes:02}:{seconds:02}")
 }
 
-pub(crate) fn format_stat_categories(categories: &[(&str, u64)]) -> String {
-    // upstream: main.c output_summary() comma_num()s each breakdown sub-count
-    // too, e.g. `(reg: 1,500, dir: 1)`.
+pub(crate) fn format_stat_categories(
+    categories: &[(&str, u64)],
+    human_readable: HumanReadableMode,
+) -> String {
+    // upstream: main.c output_itemized_counts comma_num()s each breakdown
+    // sub-count too, e.g. `(reg: 1,500, dir: 1)` at level >= 1, `(reg: 1500,
+    // dir: 1)` under --no-h (level 0).
     let parts: Vec<String> = categories
         .iter()
         .filter(|(_, count)| *count > 0)
-        .map(|(label, count)| format!("{label}: {}", super::size::format_decimal_bytes(*count)))
+        .map(|(label, count)| {
+            format!(
+                "{label}: {}",
+                super::size::format_count(*count, human_readable)
+            )
+        })
         .collect();
     if parts.is_empty() {
         String::new()
@@ -100,20 +110,26 @@ mod tests {
     #[test]
     fn format_stat_categories_empty() {
         let categories: &[(&str, u64)] = &[];
-        assert_eq!(format_stat_categories(categories), "");
+        assert_eq!(
+            format_stat_categories(categories, HumanReadableMode::Grouped),
+            ""
+        );
     }
 
     #[test]
     fn format_stat_categories_all_zero() {
         let categories: &[(&str, u64)] = &[("files", 0), ("dirs", 0)];
-        assert_eq!(format_stat_categories(categories), "");
+        assert_eq!(
+            format_stat_categories(categories, HumanReadableMode::Grouped),
+            ""
+        );
     }
 
     #[test]
     fn format_stat_categories_some_nonzero() {
         let categories: &[(&str, u64)] = &[("files", 5), ("dirs", 0), ("symlinks", 3)];
         assert_eq!(
-            format_stat_categories(categories),
+            format_stat_categories(categories, HumanReadableMode::Grouped),
             " (files: 5, symlinks: 3)"
         );
     }
@@ -122,6 +138,31 @@ mod tests {
     fn format_stat_categories_groups_thousands_like_upstream() {
         // upstream comma_num()s each sub-count: `(reg: 1,500, dir: 1)`.
         let categories: &[(&str, u64)] = &[("reg", 1500), ("dir", 1)];
-        assert_eq!(format_stat_categories(categories), " (reg: 1,500, dir: 1)");
+        assert_eq!(
+            format_stat_categories(categories, HumanReadableMode::Grouped),
+            " (reg: 1,500, dir: 1)"
+        );
+    }
+
+    #[test]
+    fn format_stat_categories_raw_level_zero_no_separators() {
+        // upstream: --no-h => comma_num = do_big_num(x, 0, NULL) emits raw
+        // digits in the breakdown too: `(reg: 1500, dir: 1)`, not `1,500`.
+        let categories: &[(&str, u64)] = &[("reg", 1500), ("dir", 1)];
+        assert_eq!(
+            format_stat_categories(categories, HumanReadableMode::Raw),
+            " (reg: 1500, dir: 1)"
+        );
+    }
+
+    #[test]
+    fn format_stat_categories_hh_groups_not_humanised() {
+        // upstream: -hh keeps counts comma-grouped (comma_num passes
+        // human_readable != 0 == 1), never K/M/G units: `(reg: 1,500)`.
+        let categories: &[(&str, u64)] = &[("reg", 1500)];
+        assert_eq!(
+            format_stat_categories(categories, HumanReadableMode::BinaryUnits),
+            " (reg: 1,500)"
+        );
     }
 }

--- a/crates/cli/src/frontend/progress/format/size.rs
+++ b/crates/cli/src/frontend/progress/format/size.rs
@@ -28,6 +28,20 @@ pub(crate) fn format_size(bytes: u64, human_readable: HumanReadableMode) -> Stri
     }
 }
 
+/// Formats a COUNT field (file/dir/link tallies), not a byte size, mirroring
+/// upstream `inums.h:comma_num` = `do_big_num(num, human_readable != 0, NULL)`.
+///
+/// The human flag for counts is always 0 or 1, so a count is comma-grouped at
+/// every enabled level (1/2/3) and never humanised to K/M/G units; only level 0
+/// ([`HumanReadableMode::Raw`], `--no-h`) emits raw digits without separators.
+pub(crate) fn format_count(count: u64, human_readable: HumanReadableMode) -> String {
+    if human_readable.groups_counts() {
+        format_decimal_bytes(count)
+    } else {
+        count.to_string()
+    }
+}
+
 pub(crate) fn format_decimal_bytes(bytes: u64) -> String {
     if bytes == 0 {
         return String::from("0");
@@ -108,6 +122,32 @@ mod tests {
     fn format_decimal_bytes_millions() {
         assert_eq!(format_decimal_bytes(1_000_000), "1,000,000");
         assert_eq!(format_decimal_bytes(123_456_789), "123,456,789");
+    }
+
+    // upstream: inums.h comma_num = do_big_num(num, human_readable != 0, NULL).
+    // Counts group at every enabled level and never gain K/M/G units, unlike
+    // byte sizes (human_num), so a regression that humanised -hh counts or
+    // grouped --no-h counts is caught here.
+
+    #[test]
+    fn format_count_raw_level_zero_no_separators() {
+        assert_eq!(format_count(1_501, HumanReadableMode::Raw), "1501");
+        assert_eq!(format_count(1_234_567, HumanReadableMode::Raw), "1234567");
+    }
+
+    #[test]
+    fn format_count_grouped_level_one() {
+        assert_eq!(format_count(1_501, HumanReadableMode::Grouped), "1,501");
+    }
+
+    #[test]
+    fn format_count_h_and_hh_group_but_never_humanise() {
+        // -h (level 2) and -hh (level 3) still comma-group counts, no units.
+        assert_eq!(
+            format_count(1_500, HumanReadableMode::DecimalUnits),
+            "1,500"
+        );
+        assert_eq!(format_count(1_500, HumanReadableMode::BinaryUnits), "1,500");
     }
 
     #[test]

--- a/crates/cli/src/frontend/progress/mod.rs
+++ b/crates/cli/src/frontend/progress/mod.rs
@@ -10,11 +10,11 @@ mod render;
 pub use self::diagnostic::{DiagnosticEvent, flush_diagnostics, render_diagnostic_events};
 #[allow(unused_imports)] // REASON: convenience re-export; not all items used in every module
 pub(crate) use self::format::{
-    describe_event_kind, event_matches_name_level, format_decimal_bytes, format_human_bytes,
-    format_human_rate, format_list_permissions, format_list_size, format_list_timestamp,
-    format_progress_bytes, format_progress_elapsed, format_progress_percent, format_progress_rate,
-    format_progress_rate_decimal, format_progress_rate_from_value, format_size,
-    format_stat_categories, format_summary_rate, is_progress_event, list_only_event,
+    describe_event_kind, event_matches_name_level, format_count, format_decimal_bytes,
+    format_human_bytes, format_human_rate, format_list_permissions, format_list_size,
+    format_list_timestamp, format_progress_bytes, format_progress_elapsed, format_progress_percent,
+    format_progress_rate, format_progress_rate_decimal, format_progress_rate_from_value,
+    format_size, format_stat_categories, format_summary_rate, is_progress_event, list_only_event,
 };
 pub(crate) use self::live::{LiveProgress, ProgressOutputConfig};
 pub(crate) use self::mode::ProgressMode;

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -43,7 +43,7 @@ fn display_without_trailing_separators(path: &Path, allow_8bit: bool) -> Vec<u8>
 }
 
 use super::format::{
-    event_matches_name_level, format_decimal_bytes, format_list_permissions, format_list_size,
+    event_matches_name_level, format_count, format_list_permissions, format_list_size,
     format_list_timestamp, format_progress_bytes, format_progress_elapsed, format_progress_percent,
     format_progress_rate, format_size, format_stat_categories, format_summary_rate,
     is_progress_event, list_only_event,
@@ -532,13 +532,16 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
     // upstream: main.c output_itemized_counts("Number of deleted files", ...)
     // prints the total plus a per-type breakdown (reg/dir/link/dev/special),
     // where reg = total - (dir + link + dev + special).
-    let deleted_breakdown = format_stat_categories(&[
-        ("reg", summary.deleted_regular_files()),
-        ("dir", summary.deleted_dirs()),
-        ("link", summary.deleted_symlinks()),
-        ("dev", summary.deleted_devices()),
-        ("special", summary.deleted_specials()),
-    ]);
+    let deleted_breakdown = format_stat_categories(
+        &[
+            ("reg", summary.deleted_regular_files()),
+            ("dir", summary.deleted_dirs()),
+            ("link", summary.deleted_symlinks()),
+            ("dev", summary.deleted_devices()),
+            ("special", summary.deleted_specials()),
+        ],
+        human_readable,
+    );
     let literal_bytes = summary.bytes_copied();
     let transferred_size = summary.transferred_file_size();
     let bytes_sent = summary.bytes_sent();
@@ -576,22 +579,28 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
     // upstream: main.c:388 output_itemized_counts labels[] =
     // {reg, dir, link, dev, special} - devices ('dev') are counted separately
     // from other specials (fifos/sockets), never folded together.
-    let files_breakdown = format_stat_categories(&files_count_categories(
-        files_total,
-        directories_total,
-        symlinks_total,
-        devices_total,
-        fifos_total,
-    ));
+    let files_breakdown = format_stat_categories(
+        &files_count_categories(
+            files_total,
+            directories_total,
+            symlinks_total,
+            devices_total,
+            fifos_total,
+        ),
+        human_readable,
+    );
     // upstream: main.c output_itemized_counts labels the created breakdown
     // reg/dir/link/dev/special, with devices ('dev') split from other specials.
-    let created_breakdown = format_stat_categories(&[
-        ("reg", created_reg),
-        ("dir", directories),
-        ("link", created_symlinks),
-        ("dev", created_devices),
-        ("special", created_specials),
-    ]);
+    let created_breakdown = format_stat_categories(
+        &[
+            ("reg", created_reg),
+            ("dir", directories),
+            ("link", created_symlinks),
+            ("dev", created_devices),
+            ("special", created_specials),
+        ],
+        human_readable,
+    );
 
     let total_size_display = format_size(total_size, human_readable);
     let transferred_size_display = format_size(transferred_size, human_readable);
@@ -601,22 +610,23 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
     let bytes_sent_display = format_size(bytes_sent, human_readable);
     let bytes_received_display = format_size(bytes_received, human_readable);
 
-    // upstream: main.c output_summary() - every count is wrapped in
-    // comma_num(), e.g. `rprintf(FINFO, "Number of files: %s%s\n",
-    // comma_num(stats.num_files), ...)`. comma_num inserts thousands
-    // separators unconditionally (independent of -h), so a count >= 1000
-    // renders as `1,500`, not `1500`.
+    // upstream: main.c output_summary() - every count is wrapped in comma_num(),
+    // e.g. `rprintf(FINFO, "Number of files: %s%s\n",
+    // comma_num(stats.num_files), ...)`. comma_num = do_big_num(num,
+    // human_readable != 0, NULL) (inums.h), so a count is comma-grouped at every
+    // enabled level (`1,500`) but rendered as raw digits under --no-h (`1500`);
+    // counts are never humanised to K/M/G units, even at -hh.
     writeln!(
         stdout,
         "Number of files: {}{files_breakdown}",
-        format_decimal_bytes(total_entries)
+        format_count(total_entries, human_readable)
     )?;
     // upstream: main.c:429 - `if (protocol_version >= 29)`
     if summary.protocol_version() >= 29 {
         writeln!(
             stdout,
             "Number of created files: {}{created_breakdown}",
-            format_decimal_bytes(created_total)
+            format_count(created_total, human_readable)
         )?;
     }
     // upstream: main.c:431 - `if (protocol_version >= 31)`
@@ -624,13 +634,13 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
         writeln!(
             stdout,
             "Number of deleted files: {}{deleted_breakdown}",
-            format_decimal_bytes(deleted)
+            format_count(deleted, human_readable)
         )?;
     }
     writeln!(
         stdout,
         "Number of regular files transferred: {}",
-        format_decimal_bytes(files)
+        format_count(files, human_readable)
     )?;
     writeln!(stdout, "Total file size: {total_size_display} bytes")?;
     writeln!(
@@ -1482,7 +1492,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            format_stat_categories(&cats),
+            format_stat_categories(&cats, HumanReadableMode::Grouped),
             " (reg: 3, dir: 2, link: 1, dev: 4, special: 5)"
         );
     }

--- a/crates/cli/src/frontend/tests/human_readable_format.rs
+++ b/crates/cli/src/frontend/tests/human_readable_format.rs
@@ -532,6 +532,91 @@ fn no_human_readable_shows_raw_digits() {
     );
 }
 
+/// Renders `--stats` over a >1000-file tree at each human-readable level and
+/// pins the COUNT fields (not byte sizes). upstream: main.c output_summary wraps
+/// every count in comma_num = do_big_num(num, human_readable != 0, NULL)
+/// (inums.h): raw digits under --no-h (level 0), comma-grouped at every enabled
+/// level (1/2/3), and never humanised to K/M/G units - so -hh groups counts but
+/// keeps `1,501`, unlike byte sizes. oc previously grouped counts
+/// unconditionally, mis-rendering `--no-h` counts as `1,501`.
+fn stats_counts_for_level(flag: Option<&str>) -> String {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source = tmp.path().join("tree");
+    std::fs::create_dir(&source).expect("mkdir source");
+    for i in 0..1_500 {
+        std::fs::write(source.join(format!("f{i}")), b"x").expect("write file");
+    }
+
+    let dest = tmp.path().join("out");
+    let mut args = vec![
+        OsString::from(RSYNC),
+        OsString::from("--stats"),
+        OsString::from("-r"),
+    ];
+    if let Some(flag) = flag {
+        args.push(OsString::from(flag));
+    }
+    let mut src = source.into_os_string();
+    src.push("/");
+    args.push(src);
+    args.push(dest.into_os_string());
+
+    let (code, stdout, stderr) = run_with_args(args);
+    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert!(stderr.is_empty());
+    String::from_utf8(stdout).expect("stats output utf8")
+}
+
+#[test]
+fn stats_counts_raw_digits_under_no_h() {
+    // upstream real binary: `Number of files: 1501 (reg: 1500, dir: 1)`.
+    let rendered = stats_counts_for_level(Some("--no-h"));
+    assert!(
+        rendered.contains("Number of files: 1501 (reg: 1500, dir: 1)"),
+        "level 0 counts must be raw digits, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("Number of created files: 1500"),
+        "level 0 created count must be raw, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("1,50"),
+        "level 0 must not group any count, got: {rendered}"
+    );
+}
+
+#[test]
+fn stats_counts_grouped_at_default_level() {
+    // upstream real binary: `Number of files: 1,501 (reg: 1,500, dir: 1)`.
+    let rendered = stats_counts_for_level(None);
+    assert!(
+        rendered.contains("Number of files: 1,501 (reg: 1,500, dir: 1)"),
+        "default level counts must be comma-grouped, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("Number of created files: 1,500"),
+        "default created count must be grouped, got: {rendered}"
+    );
+}
+
+#[test]
+fn stats_counts_grouped_not_humanised_at_hh() {
+    // upstream real binary: `-hh` groups counts (comma_num passes flag 1) but
+    // never humanises them: `Number of files: 1,501 (reg: 1,500, dir: 1)`, no
+    // `1.50K` on any count field.
+    let rendered = stats_counts_for_level(Some("-hh"));
+    assert!(
+        rendered.contains("Number of files: 1,501 (reg: 1,500, dir: 1)"),
+        "-hh counts must be comma-grouped, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("1.50K") && !rendered.contains("1.46K"),
+        "-hh must not humanise counts to K/M/G units, got: {rendered}"
+    );
+}
+
 #[test]
 fn human_readable_format_consistency_across_stats() {
     use tempfile::tempdir;

--- a/crates/cli/src/frontend/tests/human_readable_format.rs
+++ b/crates/cli/src/frontend/tests/human_readable_format.rs
@@ -571,15 +571,18 @@ fn stats_counts_for_level(flag: Option<&str>) -> String {
 
 #[test]
 fn stats_counts_raw_digits_under_no_h() {
-    // upstream real binary: `Number of files: 1501 (reg: 1500, dir: 1)`.
+    // upstream real binary, fresh dest: both the total and the created count
+    // (every entry incl. the top dir is new, so created == total) render raw.
+    //   Number of files:         1501 (reg: 1500, dir: 1)
+    //   Number of created files: 1501 (reg: 1500, dir: 1)
     let rendered = stats_counts_for_level(Some("--no-h"));
     assert!(
         rendered.contains("Number of files: 1501 (reg: 1500, dir: 1)"),
         "level 0 counts must be raw digits, got: {rendered}"
     );
     assert!(
-        rendered.contains("Number of created files: 1500"),
-        "level 0 created count must be raw, got: {rendered}"
+        rendered.contains("Number of created files: 1501 (reg: 1500, dir: 1)"),
+        "level 0 created count must be raw and == total, got: {rendered}"
     );
     assert!(
         !rendered.contains("1,50"),
@@ -589,31 +592,39 @@ fn stats_counts_raw_digits_under_no_h() {
 
 #[test]
 fn stats_counts_grouped_at_default_level() {
-    // upstream real binary: `Number of files: 1,501 (reg: 1,500, dir: 1)`.
+    // upstream real binary, fresh dest: created == total (all entries new), both
+    // comma-grouped: `Number of {files,created files}: 1,501 (reg: 1,500, dir: 1)`.
     let rendered = stats_counts_for_level(None);
     assert!(
         rendered.contains("Number of files: 1,501 (reg: 1,500, dir: 1)"),
         "default level counts must be comma-grouped, got: {rendered}"
     );
     assert!(
-        rendered.contains("Number of created files: 1,500"),
-        "default created count must be grouped, got: {rendered}"
+        rendered.contains("Number of created files: 1,501 (reg: 1,500, dir: 1)"),
+        "default created count must be grouped and == total, got: {rendered}"
     );
 }
 
 #[test]
 fn stats_counts_grouped_not_humanised_at_hh() {
-    // upstream real binary: `-hh` groups counts (comma_num passes flag 1) but
-    // never humanises them: `Number of files: 1,501 (reg: 1,500, dir: 1)`, no
-    // `1.50K` on any count field.
+    // upstream real binary, fresh dest: `-hh` comma-groups counts (comma_num
+    // passes human_readable != 0 == 1) but NEVER humanises them to K/M/G units,
+    // while byte sizes (human_num) ARE humanised at the same level. That
+    // size-vs-count split is exactly what #171 verifies.
     let rendered = stats_counts_for_level(Some("-hh"));
     assert!(
         rendered.contains("Number of files: 1,501 (reg: 1,500, dir: 1)"),
-        "-hh counts must be comma-grouped, got: {rendered}"
+        "-hh counts must be comma-grouped, not humanised, got: {rendered}"
     );
     assert!(
-        !rendered.contains("1.50K") && !rendered.contains("1.46K"),
-        "-hh must not humanise counts to K/M/G units, got: {rendered}"
+        rendered.contains("Number of created files: 1,501 (reg: 1,500, dir: 1)"),
+        "-hh created count must be comma-grouped, not humanised, got: {rendered}"
+    );
+    // Byte sizes ARE humanised at -hh: 1500 bytes / 1024 = 1.46K. Its presence
+    // confirms the level is active and only counts are exempt from unit suffixes.
+    assert!(
+        rendered.contains("Total file size: 1.46K bytes"),
+        "-hh must humanise byte sizes (proving counts are the exception), got: {rendered}"
     );
 }
 

--- a/crates/core/src/client/config/enums/human_readable.rs
+++ b/crates/core/src/client/config/enums/human_readable.rs
@@ -88,6 +88,19 @@ impl HumanReadableMode {
         matches!(self, Self::Grouped)
     }
 
+    /// Reports whether COUNT fields (not byte sizes) are comma-grouped.
+    ///
+    /// Mirrors upstream `inums.h:comma_num`, defined as `do_big_num(num,
+    /// human_readable != 0, NULL)`. The human flag passed for counts is always
+    /// 0 or 1, so counts are grouped at every enabled level ([`Self::Grouped`],
+    /// [`Self::DecimalUnits`], [`Self::BinaryUnits`]) and are never humanised to
+    /// K/M/G unit suffixes; only level 0 ([`Self::Raw`], `--no-h`) emits raw
+    /// digits.
+    #[must_use]
+    pub const fn groups_counts(self) -> bool {
+        !matches!(self, Self::Raw)
+    }
+
     /// The `--list-only` size-column width for this level.
     ///
     /// Mirrors `generator.c:1159`: `size_width = human_readable ? 14 : 11`, so
@@ -246,6 +259,17 @@ mod tests {
         assert!(HumanReadableMode::Grouped.uses_separators());
         assert!(!HumanReadableMode::DecimalUnits.uses_separators());
         assert!(!HumanReadableMode::BinaryUnits.uses_separators());
+    }
+
+    #[test]
+    fn groups_counts_every_level_except_raw() {
+        // upstream: inums.h comma_num = do_big_num(num, human_readable != 0,
+        // NULL) - counts group at every enabled level (1/2/3) and never gain
+        // K/M/G units; only level 0 emits raw digits.
+        assert!(!HumanReadableMode::Raw.groups_counts());
+        assert!(HumanReadableMode::Grouped.groups_counts());
+        assert!(HumanReadableMode::DecimalUnits.groups_counts());
+        assert!(HumanReadableMode::BinaryUnits.groups_counts());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `--stats` output's COUNT fields were formatted with **unconditional** comma
grouping, ignoring the human-readable level. Under `--no-h` (level 0) they
rendered as `1,501` instead of upstream's raw `1501`.

Affected count fields: `Number of files`, `Number of created files`,
`Number of deleted files`, `Number of regular files transferred`, and the
parenthetical per-type breakdowns (`(reg: …, dir: …, link: …, dev: …, special: …)`).

Byte-size fields and the transfer rate already threaded `HumanReadableMode`
correctly and are left untouched.

## Upstream behaviour (source of truth)

Counts use `comma_num`, **not** `human_num`:

- `main.c:406,415,435` — `output_itemized_counts` / `output_summary` wrap every
  count in `comma_num()`.
- `inums.h:25-30`:
  ```c
  static inline char *
  comma_num(int64 num)
  {
      extern int human_readable;
      return do_big_num(num, human_readable != 0, NULL);
  }
  ```
- `lib/compat.c:170-246` `do_big_num(num, human_flag, fract)`: K/M/G units apply
  only `if (human_flag > 1)` (line 182); the thousands separator is inserted only
  `if (human_flag)` (line 231).

Because `comma_num` passes `human_readable != 0`, the human flag for counts is
always `0` or `1`. So counts are comma-grouped at **every** enabled level (1/2/3)
and are **never** humanised to K/M/G units — only level 0 (`--no-h`) emits raw
digits. Default `human_readable = 1` (`options.c:111`).

## Proof vs the real rsync 3.4.4 binary

`rsync version 3.4.4 protocol version 32`, source dir of 1500 files:

```
=== --no-h (level 0) ===
Number of files: 1501 (reg: 1500, dir: 1)
Number of created files: 1500 (reg: 1500)
Number of deleted files: 0
Number of regular files transferred: 1500
=== default (level 1) ===
Number of files: 1,501 (reg: 1,500, dir: 1)
Number of created files: 1,500 (reg: 1,500)
Number of deleted files: 0
Number of regular files transferred: 1,500
=== -hh (level 3) ===
Number of files: 1,501 (reg: 1,500, dir: 1)
Number of created files: 1,500 (reg: 1,500)
Number of deleted files: 0
Number of regular files transferred: 1,500
```

Note `-hh` groups counts but keeps `1,501` — it does **not** humanise counts to
`1.50K`, confirming `human_flag` is capped at 1 for counts.

Post-fix `oc-rsync` matches byte-for-byte at all three levels.

## Change

- Add `HumanReadableMode::groups_counts()` mirroring `human_readable != 0`
  (true for every level except `Raw`).
- Add `format_count(count, mode)` mirroring `comma_num`: raw digits at level 0,
  comma grouping otherwise, never K/M/G units.
- Thread `HumanReadableMode` through the count `writeln!` sites and
  `format_stat_categories`.
- Byte-size and rate formatting untouched.

## Tests

- `format_count` unit tests: raw at level 0, grouped at level 1, grouped-not-
  humanised at `-h`/`-hh`.
- `format_stat_categories` raw-level-zero and `-hh`-grouped tests.
- `HumanReadableMode::groups_counts` enum test.
- Integration tests over a 1500-file tree pinning the exact real-binary
  renderings at `--no-h`, default, and `-hh`.
