### PR TITLE
fix(cli): lone -h help, old/secluded conflict, -a flag ordering

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -24,7 +24,8 @@ use core::client::{
 use super::coerce::{parse_checksum_threads, parse_spill_threshold_bytes, parse_thread_count};
 use super::cow::{last_occurrence, parse_reflink_mode, resolve_cow_policy};
 use super::flags::{
-    leveled_flag_pair, tri_state_flag_negative_first, tri_state_flag_positive_first,
+    archive_aware_flag, leveled_flag_pair, tri_state_flag_negative_first,
+    tri_state_flag_positive_first,
 };
 use super::values::join_os_values;
 use super::{
@@ -199,20 +200,29 @@ where
     };
     let blocking_io = tri_state_flag_positive_first(&matches, "blocking-io", "no-blocking-io");
     let archive = matches.get_flag("archive");
+    // Last command-line index of `-a`, used to resolve every archive-implied
+    // dimension in argv order (upstream: options.c:1546 `case 'a'`). Gated on
+    // `archive` because clap's `SetTrue` args carry an implicit default whose
+    // synthetic index `indices_of` reports even when `-a` was never supplied.
+    let archive_index = if archive {
+        matches.indices_of("archive").and_then(Iterator::max)
+    } else {
+        None
+    };
     // upstream: options.c:631-632 - `--old-dirs`/`--old-d` set xfer_dirs=4, and
     // options.c:2197-2199 resolves that to `recurse = xfer_dirs = 1`
     // unconditionally (after the argv scan), so it forces recursion on even over
     // a `--no-recursive`, and appends the `- /*/*` filter rule (injected below).
     let old_dirs = matches.get_flag("old-dirs");
     let recursive_override = tri_state_flag_negative_first(&matches, "recursive", "no-recursive");
+    // upstream: options.c:1546 `case 'a'` runs `if (!recurse) recurse = 1` in
+    // argv order, so a `--no-recursive` that precedes `-a` is re-enabled by the
+    // later `-a`, while one that follows it wins.
     let recursive = if old_dirs {
         true
-    } else if recursive_override == Some(false) {
-        false
-    } else if archive {
-        true
     } else {
-        recursive_override.unwrap_or(false)
+        archive_aware_flag(&matches, "recursive", "no-recursive", archive_index, false)
+            .unwrap_or(archive)
     };
     let inc_recursive =
         tri_state_flag_positive_first(&matches, "inc-recursive", "no-inc-recursive");
@@ -418,8 +428,8 @@ where
             env_iconv_default()
         }
     });
-    let owner = tri_state_flag_positive_first(&matches, "owner", "no-owner");
-    let group = tri_state_flag_positive_first(&matches, "group", "no-group");
+    let owner = archive_aware_flag(&matches, "owner", "no-owner", archive_index, true);
+    let group = archive_aware_flag(&matches, "group", "no-group", archive_index, true);
     let usermap = join_os_values(matches.remove_many::<OsString>("usermap"));
     let groupmap = join_os_values(matches.remove_many::<OsString>("groupmap"));
     let chown = matches.remove_one::<OsString>("chown");
@@ -428,7 +438,7 @@ where
         .remove_many::<OsString>("chmod")
         .map(Iterator::collect)
         .unwrap_or_default();
-    let perms = tri_state_flag_positive_first(&matches, "perms", "no-perms");
+    let perms = archive_aware_flag(&matches, "perms", "no-perms", archive_index, true);
     let executability = if matches.get_flag("executability") {
         Some(true)
     } else {
@@ -436,14 +446,14 @@ where
     };
     let super_mode = tri_state_flag_positive_first(&matches, "super", "no-super");
     let fake_super = tri_state_flag_positive_first(&matches, "fake-super", "no-fake-super");
-    let times = tri_state_flag_positive_first(&matches, "times", "no-times");
+    let times = archive_aware_flag(&matches, "times", "no-times", archive_index, true);
     let omit_dir_times =
         tri_state_flag_positive_first(&matches, "omit-dir-times", "no-omit-dir-times");
     let acls = tri_state_flag_positive_first(&matches, "acls", "no-acls");
     let xattrs = leveled_flag_pair(&matches, "xattrs", "no-xattrs");
     let numeric_ids = tri_state_flag_positive_first(&matches, "numeric-ids", "no-numeric-ids");
     let hard_links = tri_state_flag_positive_first(&matches, "hard-links", "no-hard-links");
-    let links = tri_state_flag_positive_first(&matches, "links", "no-links");
+    let links = archive_aware_flag(&matches, "links", "no-links", archive_index, true);
     let sparse = tri_state_flag_positive_first(&matches, "sparse", "no-sparse");
     let sparse_detect = match matches.remove_one::<OsString>("sparse-detect") {
         Some(value) => {
@@ -504,10 +514,10 @@ where
     let copy_devices = matches.get_flag("copy-devices");
     let archive_devices =
         tri_state_flag_positive_first(&matches, "archive-devices", "no-archive-devices");
-    let devices =
-        tri_state_flag_positive_first(&matches, "devices", "no-devices").or(archive_devices);
-    let specials =
-        tri_state_flag_positive_first(&matches, "specials", "no-specials").or(archive_devices);
+    let devices = archive_aware_flag(&matches, "devices", "no-devices", archive_index, true)
+        .or(archive_devices);
+    let specials = archive_aware_flag(&matches, "specials", "no-specials", archive_index, true)
+        .or(archive_devices);
     let write_devices =
         tri_state_flag_positive_first(&matches, "write-devices", "no-write-devices");
     let relative = tri_state_flag_positive_first(&matches, "relative", "no-relative");

--- a/crates/cli/src/frontend/arguments/parser/flags.rs
+++ b/crates/cli/src/frontend/arguments/parser/flags.rs
@@ -40,12 +40,34 @@ fn tri_state_flag_with_order(
     negative: &str,
     prefer_positive_on_tie: bool,
 ) -> Option<bool> {
+    tri_state_flag_indexed(matches, positive, negative, prefer_positive_on_tie)
+        .map(|(value, _)| value)
+}
+
+/// Resolves a tri-state flag pair, returning both the winning value and the
+/// command-line index that decided it.
+///
+/// Behaves exactly like [`tri_state_flag_with_order`] but exposes the deciding
+/// index so callers can compose the result with another flag in argv order
+/// (see [`archive_aware_flag`]).
+fn tri_state_flag_indexed(
+    matches: &clap::ArgMatches,
+    positive: &str,
+    negative: &str,
+    prefer_positive_on_tie: bool,
+) -> Option<(bool, usize)> {
     let positive_present = matches.get_flag(positive);
     let negative_present = matches.get_flag(negative);
 
     match (positive_present, negative_present) {
-        (true, false) => Some(true),
-        (false, true) => Some(false),
+        (true, false) => Some((
+            true,
+            last_occurrence(matches, positive).unwrap_or(usize::MAX),
+        )),
+        (false, true) => Some((
+            false,
+            last_occurrence(matches, negative).unwrap_or(usize::MAX),
+        )),
         (false, false) => None,
         (true, true) => {
             let positive_index = last_occurrence(matches, positive);
@@ -53,20 +75,45 @@ fn tri_state_flag_with_order(
             match (positive_index, negative_index) {
                 (Some(pos), Some(neg)) => {
                     if pos > neg {
-                        Some(true)
+                        Some((true, pos))
                     } else if neg > pos {
-                        Some(false)
+                        Some((false, neg))
                     } else if prefer_positive_on_tie {
-                        Some(true)
+                        Some((true, pos))
                     } else {
-                        Some(false)
+                        Some((false, neg))
                     }
                 }
-                (Some(_), None) => Some(true),
-                (None, Some(_)) => Some(false),
-                (None, None) => Some(prefer_positive_on_tie),
+                (Some(pos), None) => Some((true, pos)),
+                (None, Some(neg)) => Some((false, neg)),
+                (None, None) => Some((prefer_positive_on_tie, usize::MAX)),
             }
         }
+    }
+}
+
+/// Resolves an archive-implied flag pair honoring `-a`'s command-line position.
+///
+/// upstream: options.c:1546 `case 'a'` expands `-a` in place during the argv
+/// scan, assigning `preserve_* = 1` for every `-rlptgoD` dimension. Because that
+/// scan is left-to-right and last-wins, a later individual `--no-X` overrides the
+/// archive default and a later `-a` re-enables the dimension (`-a --no-perms`
+/// clears perms; `--no-perms -a` keeps them). clap collapses repeated flags, so
+/// the last index of `-a` (`archive_index`) is compared against the explicit
+/// flag's deciding index: when `-a` comes afterwards the explicit setting is
+/// discarded (returns `None`) so the archive default applies downstream via
+/// `unwrap_or(archive)`; otherwise the explicit value stands.
+pub(crate) fn archive_aware_flag(
+    matches: &clap::ArgMatches,
+    positive: &str,
+    negative: &str,
+    archive_index: Option<usize>,
+    prefer_positive_on_tie: bool,
+) -> Option<bool> {
+    match tri_state_flag_indexed(matches, positive, negative, prefer_positive_on_tie) {
+        Some((_, explicit_index)) if archive_index.is_some_and(|a| a > explicit_index) => None,
+        Some((value, _)) => Some(value),
+        None => None,
     }
 }
 

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -297,8 +297,34 @@ where
     install_client_signal_handling();
 
     let mut stderr_sink = MessageSink::with_brand(stderr, brand);
+    // Raw command-line token count (including argv[0]); `== 2` means a single
+    // option token was supplied, mirroring upstream's `argc == 2` test below.
+    let raw_token_count = args.len();
     let exit_code = match parse_args(args) {
         Ok(parsed) => {
+            // upstream: options.c:2005 - `human_readable > 1 && argc == 2 &&
+            // !am_server` preserves the historic meaning of a lone `-h` as
+            // `--help`. When the only command-line token increments the
+            // human-readable counter (`-h`, `-hh`, `-avh`, `--human-readable`),
+            // rsync prints usage to stdout and exits 0 instead of treating it as
+            // a number-formatting request. The server/daemon paths returned
+            // above, so `!am_server` holds here.
+            if raw_token_count == 2
+                && matches!(
+                    parsed.human_readable,
+                    Some(
+                        core::client::HumanReadableMode::DecimalUnits
+                            | core::client::HumanReadableMode::BinaryUnits
+                    )
+                )
+            {
+                let help = render_help(parsed.program_name);
+                if stdout.write_all(help.as_bytes()).is_err() {
+                    let _ = writeln!(stdout, "{help}");
+                }
+                return 0;
+            }
+
             let outbuf_mode = match parsed.outbuf.as_ref() {
                 Some(value) => match parse_outbuf_mode(value.as_os_str()) {
                     Ok(mode) => Some(mode),

--- a/crates/cli/tests/archive_flag_completeness.rs
+++ b/crates/cli/tests/archive_flag_completeness.rs
@@ -230,48 +230,61 @@ fn no_d_after_archive_disables_devices_and_specials() {
     );
 }
 
+// upstream: options.c:1546 `case 'a'` sets `preserve_* = 1` in argv order, so a
+// `--no-X` that PRECEDES `-a` is overridden by the later `-a`. At the parser
+// layer that override clears the explicit setting to `None`, and the archive
+// default (`unwrap_or(archive)` in compute.rs) then re-enables preservation.
+// A `--no-X` that FOLLOWS `-a` still wins (see the `*_after_archive_*` tests).
 #[test]
-fn no_perms_before_archive_stays_disabled() {
+fn no_perms_before_archive_is_reenabled() {
     let args = parse_args(["oc-rsync", "--no-perms", "-a", "src", "dest"]).unwrap();
     assert!(args.archive);
-    // Even with -a, --no-perms specified before should remain
     assert_eq!(
-        args.perms,
-        Some(false),
-        "--no-perms before -a should stay disabled"
+        args.perms, None,
+        "--no-perms before -a is overridden by the later -a (archive default preserves perms)"
     );
 }
 
 #[test]
-fn no_times_before_archive_stays_disabled() {
+fn no_times_before_archive_is_reenabled() {
     let args = parse_args(["oc-rsync", "--no-times", "-a", "src", "dest"]).unwrap();
     assert!(args.archive);
     assert_eq!(
-        args.times,
-        Some(false),
-        "--no-times before -a should stay disabled"
+        args.times, None,
+        "--no-times before -a is overridden by the later -a (archive default preserves times)"
     );
 }
 
 #[test]
-fn no_owner_before_archive_stays_disabled() {
+fn no_owner_before_archive_is_reenabled() {
     let args = parse_args(["oc-rsync", "--no-owner", "-a", "src", "dest"]).unwrap();
     assert!(args.archive);
     assert_eq!(
-        args.owner,
-        Some(false),
-        "--no-owner before -a should stay disabled"
+        args.owner, None,
+        "--no-owner before -a is overridden by the later -a (archive default preserves owner)"
     );
 }
 
 #[test]
-fn no_group_before_archive_stays_disabled() {
+fn no_group_before_archive_is_reenabled() {
     let args = parse_args(["oc-rsync", "--no-group", "-a", "src", "dest"]).unwrap();
     assert!(args.archive);
     assert_eq!(
-        args.group,
-        Some(false),
-        "--no-group before -a should stay disabled"
+        args.group, None,
+        "--no-group before -a is overridden by the later -a (archive default preserves group)"
+    );
+}
+
+#[test]
+fn no_recursive_before_archive_is_reenabled() {
+    // upstream: options.c:1546 `if (!recurse) recurse = 1` re-enables recursion
+    // when `-a` follows `--no-recursive`; the parser resolves the effective
+    // `recursive` flag directly (there is no separate archive default here).
+    let args = parse_args(["oc-rsync", "--no-recursive", "-a", "src", "dest"]).unwrap();
+    assert!(args.archive);
+    assert!(
+        args.recursive,
+        "--no-recursive before -a is overridden by the later -a (recursion stays on)"
     );
 }
 
@@ -644,16 +657,19 @@ fn archive_with_checksum() {
 }
 
 #[test]
-fn archive_preserves_correct_order_of_operations() {
-    // Verify that the order of flags produces correct results
+fn archive_respects_command_line_order() {
+    // upstream: options.c:1546 `case 'a'` expands `-a` in place during the argv
+    // scan, so `-a --no-perms` and `--no-perms -a` are NOT equivalent: the flag
+    // that appears last wins.
     let args1 = parse_args(["oc-rsync", "-a", "--no-perms", "src", "dest"]).unwrap();
     let args2 = parse_args(["oc-rsync", "--no-perms", "-a", "src", "dest"]).unwrap();
 
-    // Both should have archive=true
     assert!(args1.archive);
     assert!(args2.archive);
 
-    // Both should have perms=Some(false) because explicit --no-perms was specified
+    // `-a --no-perms`: the trailing --no-perms wins -> perms explicitly disabled.
     assert_eq!(args1.perms, Some(false));
-    assert_eq!(args2.perms, Some(false));
+    // `--no-perms -a`: the trailing -a overrides --no-perms -> None, so the
+    // archive default (compute.rs `unwrap_or(archive)`) preserves perms.
+    assert_eq!(args2.perms, None);
 }

--- a/crates/cli/tests/archive_flag_ordering.rs
+++ b/crates/cli/tests/archive_flag_ordering.rs
@@ -1,0 +1,81 @@
+//! `-a` expands in command-line order: a later individual flag overrides it.
+//!
+//! upstream: options.c:1546 `case 'a'` assigns `preserve_* = 1` inline during the
+//! left-to-right argv scan, so `-a --no-perms` clears permission preservation
+//! while `--no-perms -a` re-enables it. These tests exercise the observable
+//! outcome (the destination's permission bits after a real local transfer)
+//! rather than the parsed flag, so they fail if the ordering semantics regress.
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+fn mode_of(path: &Path) -> u32 {
+    fs::metadata(path).expect("stat dest").permissions().mode() & 0o777
+}
+
+/// Runs a local transfer and asserts it succeeded.
+fn transfer(args: &[&str]) {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let code = cli::run(args.iter().copied(), &mut stdout, &mut stderr);
+    assert_eq!(
+        code,
+        0,
+        "transfer {args:?} failed: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+}
+
+/// Creates a fresh src (mode 0700) and pre-existing dest (mode 0600) with
+/// differing contents so the quick-check never skips the transfer.
+fn setup(dir: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let src = dir.join("src");
+    let dst = dir.join("dst");
+    fs::write(&src, b"source-contents").expect("write src");
+    fs::write(&dst, b"old").expect("write dst");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o700)).expect("chmod src");
+    fs::set_permissions(&dst, fs::Permissions::from_mode(0o600)).expect("chmod dst");
+    (src, dst)
+}
+
+#[test]
+fn no_perms_before_archive_preserves_permissions() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (src, dst) = setup(dir.path());
+    // `--no-perms -a`: the trailing -a re-enables perms, so the destination
+    // takes the source's 0700.
+    transfer(&[
+        "oc-rsync",
+        "--no-perms",
+        "-a",
+        src.to_str().unwrap(),
+        dst.to_str().unwrap(),
+    ]);
+    assert_eq!(
+        mode_of(&dst),
+        0o700,
+        "-a after --no-perms must re-enable permission preservation"
+    );
+}
+
+#[test]
+fn no_perms_after_archive_drops_permissions() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (src, dst) = setup(dir.path());
+    // `-a --no-perms`: the trailing --no-perms wins, so the destination keeps
+    // its pre-existing 0600.
+    transfer(&[
+        "oc-rsync",
+        "-a",
+        "--no-perms",
+        src.to_str().unwrap(),
+        dst.to_str().unwrap(),
+    ]);
+    assert_eq!(
+        mode_of(&dst),
+        0o600,
+        "--no-perms after -a must disable permission preservation"
+    );
+}

--- a/crates/cli/tests/archive_mode.rs
+++ b/crates/cli/tests/archive_mode.rs
@@ -106,37 +106,36 @@ fn test_no_recursive_overrides_archive() {
 }
 
 #[test]
-fn test_no_perms_before_archive_stays_disabled() {
+fn test_no_perms_before_archive_is_reenabled() {
+    // upstream: options.c:1546 `case 'a'` sets `preserve_perms = 1` in argv
+    // order, so a `--no-perms` that precedes `-a` is overridden by the later
+    // `-a`. At the parser layer that clears the explicit setting to None, and
+    // the archive default (compute.rs `unwrap_or(archive)`) preserves perms.
     let args = parse_args(["oc-rsync", "--no-perms", "-a", "src", "dest"]).unwrap();
-    // -a doesn't re-enable perms if --no-perms was already set
-    // The archive flag is set, but perms stays explicitly disabled
     assert!(args.archive, "-a should set archive flag");
     assert_eq!(
-        args.perms,
-        Some(false),
-        "--no-perms should remain disabled even with -a"
+        args.perms, None,
+        "--no-perms before -a is overridden by the later -a"
     );
 }
 
 #[test]
-fn test_no_owner_before_archive_stays_disabled() {
+fn test_no_owner_before_archive_is_reenabled() {
     let args = parse_args(["oc-rsync", "--no-owner", "-a", "src", "dest"]).unwrap();
     assert!(args.archive);
     assert_eq!(
-        args.owner,
-        Some(false),
-        "--no-owner should remain disabled even with -a"
+        args.owner, None,
+        "--no-owner before -a is overridden by the later -a"
     );
 }
 
 #[test]
-fn test_no_group_before_archive_stays_disabled() {
+fn test_no_group_before_archive_is_reenabled() {
     let args = parse_args(["oc-rsync", "--no-group", "-a", "src", "dest"]).unwrap();
     assert!(args.archive);
     assert_eq!(
-        args.group,
-        Some(false),
-        "--no-group should remain disabled even with -a"
+        args.group, None,
+        "--no-group before -a is overridden by the later -a"
     );
 }
 

--- a/crates/cli/tests/lone_h_help.rs
+++ b/crates/cli/tests/lone_h_help.rs
@@ -1,0 +1,83 @@
+//! A bare `-h` prints help, not human-readable output.
+//!
+//! upstream: options.c:2005 - `human_readable > 1 && argc == 2 && !am_server`
+//! preserves the historic meaning of a lone `-h` as `--help`: when the only
+//! command-line token increments the human-readable counter, rsync prints usage
+//! to stdout and exits 0 instead of failing with a missing-operands error.
+
+fn run(args: &[&str]) -> (i32, String, String) {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let code = cli::run(args.iter().copied(), &mut stdout, &mut stderr);
+    (
+        code,
+        String::from_utf8_lossy(&stdout).into_owned(),
+        String::from_utf8_lossy(&stderr).into_owned(),
+    )
+}
+
+#[test]
+fn lone_dash_h_prints_help_and_exits_zero() {
+    let (code, stdout, stderr) = run(&["oc-rsync", "-h"]);
+    assert_eq!(code, 0, "a bare -h must exit 0 like --help");
+    assert!(
+        stdout.contains("Usage:"),
+        "help text must go to stdout, got: {stdout}"
+    );
+    assert!(
+        stderr.is_empty(),
+        "a bare -h must not emit an error, got: {stderr}"
+    );
+}
+
+#[test]
+fn combined_single_token_with_h_prints_help() {
+    // `-avh` is still a single command-line token (argc == 2), and it bumps the
+    // human-readable counter, so upstream resolves it to help/exit 0 as well.
+    let (code, stdout, stderr) = run(&["oc-rsync", "-avh"]);
+    assert_eq!(code, 0, "-avh alone must exit 0");
+    assert!(stdout.contains("Usage:"), "help must print for -avh");
+    assert!(stderr.is_empty(), "no error expected for -avh: {stderr}");
+}
+
+#[test]
+fn repeated_h_single_token_prints_help() {
+    // `-hh` selects base-1024 units but, as a lone token, still means help.
+    let (code, _stdout, stderr) = run(&["oc-rsync", "-hh"]);
+    assert_eq!(code, 0, "-hh alone must exit 0");
+    assert!(stderr.is_empty(), "no error expected for -hh: {stderr}");
+}
+
+#[test]
+fn lone_token_without_h_is_not_help() {
+    // `-a` alone does NOT bump the human-readable counter, so the historic
+    // `-h`-means-help shortcut must not fire: rsync falls through to the
+    // missing-operands syntax error (exit 1).
+    let (code, _stdout, _stderr) = run(&["oc-rsync", "-a"]);
+    assert_eq!(
+        code, 1,
+        "-a alone has no operands and must exit 1, not print help"
+    );
+}
+
+#[test]
+fn no_human_readable_lone_token_is_not_help() {
+    // `--no-human-readable` sets the counter to 0 (not > 1), so it must not be
+    // treated as the lone-`-h` help shortcut.
+    let (code, _stdout, _stderr) = run(&["oc-rsync", "--no-human-readable"]);
+    assert_eq!(
+        code, 1,
+        "--no-human-readable alone must exit 1, not print help"
+    );
+}
+
+#[test]
+fn two_h_tokens_are_not_help() {
+    // `-h -h` is two command-line tokens (argc == 3), so the argc == 2 guard
+    // fails and it falls through to the missing-operands error (exit 1).
+    let (code, _stdout, _stderr) = run(&["oc-rsync", "-h", "-h"]);
+    assert_eq!(
+        code, 1,
+        "-h -h is two tokens and must exit 1, not print help"
+    );
+}

--- a/crates/cli/tests/mutually_exclusive_options.rs
+++ b/crates/cli/tests/mutually_exclusive_options.rs
@@ -261,6 +261,28 @@ fn test_append_and_whole_file_rejected() {
 }
 
 #[test]
+fn test_old_args_and_secluded_args_rejected() {
+    // upstream: options.c:1977 - `--old-args` and `--secluded-args` are mutually
+    // exclusive and abort with exit 1. Unlike most conflicts, upstream phrases
+    // this one as "--secluded-args conflicts with --old-args." (secluded-args
+    // named first, trailing period), which oc must reproduce verbatim.
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let code = cli::run(
+        ["oc-rsync", "--old-args", "--secluded-args", "src", "dest"],
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(code, 1, "expected RERR_SYNTAX (exit code 1)");
+    let stderr_text = String::from_utf8_lossy(&stderr);
+    assert!(
+        stderr_text.contains("--secluded-args conflicts with --old-args."),
+        "stderr must use upstream's exact phrasing, got: {stderr_text}"
+    );
+}
+
+#[test]
 fn test_append_and_no_whole_file_accepted() {
     // The companion `--no-whole-file` form must remain accepted.
     let result = parse_args(["oc-rsync", "--append", "--no-whole-file", "src", "dest"]);

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -17,6 +17,12 @@ pub struct ConfigConflict {
 
 impl fmt::Display for ConfigConflict {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // upstream: options.c:1977 - the secluded/old-args conflict has a
+        // dedicated phrasing (and operand order) distinct from the generic
+        // "--X cannot be used with --Y" template used for other conflicts.
+        if matches!((self.option1, self.option2), ("old-args", "secluded-args")) {
+            return write!(f, "--secluded-args conflicts with --old-args.");
+        }
         write!(
             f,
             "--{} cannot be used with --{}",

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1214,6 +1214,22 @@ fn validate_append_with_whole_file_conflicts() {
 }
 
 #[test]
+fn validate_old_args_with_secluded_args_conflicts() {
+    // upstream: options.c:1977 - `--old-args` and `--secluded-args`
+    // (`--protect-args`) are mutually exclusive and abort with this exact
+    // wording, which differs from the generic "cannot be used with" template:
+    // the message names --secluded-args first and ends with a period.
+    let b = builder().old_args(Some(true)).protect_args(Some(true));
+    let err = b.validate().unwrap_err();
+    assert_eq!(err.option1, "old-args");
+    assert_eq!(err.option2, "secluded-args");
+    assert_eq!(
+        err.to_string(),
+        "--secluded-args conflicts with --old-args."
+    );
+}
+
+#[test]
 fn validate_append_with_no_whole_file_ok() {
     // Explicit `--no-whole-file` is the upstream-compatible companion to --append.
     let b = builder().append(true).whole_file(false);


### PR DESCRIPTION
## Summary

A cluster of small CLI option-parity fixes, each verified against the real
upstream `rsync 3.4.4` binary and the C source at `rsync-3.4.4/`.

Three genuine divergences are fixed; one item was already correct at the
observable level and is left unchanged (details below).

## (a) Lone `-h` means help, not human-readable — FIXED

**Upstream ground truth** (`options.c:2005`):
```c
if (human_readable > 1 && argc == 2 && !am_server) {
    /* Allow the old meaning of 'h' (--help) on its own. */
    usage(FINFO);
    exit_cleanup(0);
}
```
`argc` here is the raw argv count (including `argv[0]`), reassigned only later at
`options.c:2096`. So a single command-line token that increments the
human-readable counter (`-h`, `-hh`, `-avh`, `--human-readable`) resolves to help
on stdout with exit 0. Verified with the real binary:

| invocation | exit | stream |
|---|---|---|
| `rsync -h` | 0 | help → stdout |
| `rsync -avh` | 0 | help → stdout |
| `rsync -hh` | 0 | help → stdout |
| `rsync --human-readable` | 0 | help → stdout |
| `rsync -a` (no h) | 1 | usage → stderr |
| `rsync --no-human-readable` | 1 | usage → stderr |
| `rsync -h -h` (two tokens) | 1 | usage → stderr |
| `rsync -h src/ dst/` | 0 | transfers (h = human-readable) |

**oc divergence:** `oc-rsync -h` exited **1** and printed an error to stderr
(it fell through to the missing-operands path) instead of exiting 0 with clean
help.

**Change:** `crates/cli/src/frontend/mod.rs` short-circuits after a successful
parse: when the raw token count is 2 and `human_readable` is a real "human" mode
(`DecimalUnits`/`BinaryUnits`, i.e. upstream `> 1`), it prints help to stdout and
returns 0. The server/daemon paths return earlier, so `!am_server` holds.

## (b) `--old-args` / `--secluded-args` conflict message — FIXED

**Upstream ground truth** (`options.c:1977`):
```
rsync: --secluded-args conflicts with --old-args.
rsync error: syntax or usage error (code 1) at main.c(1806) [client=3.4.4]
```
Both orders (`--old-args --secluded-args` and the reverse) produce the same
message and exit 1. Upstream deliberately uses "conflicts with" for this pair,
distinct from the "cannot be used with" phrasing it uses for other conflicts
(`read-batch`/`files-from`, `append`/`whole-file`, etc.).

**oc divergence:** oc detected the conflict and exited 1 (good) but rendered its
generic template: `--old-args cannot be used with --secluded-args` (wrong
phrasing, wrong operand order, no trailing period).

**Change:** `crates/core/src/client/config/builder/mod.rs` — `ConfigConflict`'s
`Display` now special-cases the `old-args`/`secluded-args` pair to emit
`--secluded-args conflicts with --old-args.` verbatim, leaving the generic
template untouched for every other conflict.

## (c) Archive (`-a`) expansion honors command-line order — FIXED

**Upstream ground truth** (`options.c:1546` `case 'a'`): `-a` expands to
`-rlptgoD` *in place during the left-to-right argv scan*, assigning
`preserve_* = 1` for each dimension. Because the scan is last-wins, a later
individual `--no-X` overrides the archive default and a later `-a` re-enables it.
Verified with the real binary (resulting dest mode; source 0700, dest 0600):

| invocation | dest mode |
|---|---|
| `rsync -a --no-perms` | 600 (perms dropped) |
| `rsync --no-perms -a` | 700 (perms re-enabled) |

Same ordering confirmed for `--no-times -a` (times re-enabled) and
`--no-recursive -a` (recursion re-enabled).

**oc divergence:** oc resolved every archive-implied flag order-**insensitively**
— an explicit `--no-perms` always beat `-a` regardless of position. `--no-perms
-a` produced mode 600 (should be 700); `--no-recursive -a` did not recurse.

**Change:**
- `crates/cli/src/frontend/arguments/parser/flags.rs` adds `archive_aware_flag`,
  which compares the explicit flag's deciding argv index against the last index
  of `-a`; when `-a` comes afterwards the explicit setting is discarded so the
  archive default applies. `tri_state_flag_with_order` was refactored to share a
  new index-returning helper (behavior unchanged for its existing callers).
- `crates/cli/src/frontend/arguments/parser/entry.rs` resolves `recursive`,
  `perms`, `times`, `owner`, `group`, `links`, `devices`, `specials` through the
  new helper.
- Note: clap's `SetTrue` args carry an implicit default whose synthetic index
  `indices_of` reports even when the flag is absent, so `archive_index` is gated
  on `get_flag("archive")` to avoid a spurious "archive present" signal.

## (d) Batch `--help` lines — NO CHANGE (reported, out of scope)

**Upstream ground truth** (`help-rsync.h:139`):
```
--write-batch=FILE       write a batched update to FILE
--only-write-batch=FILE  like --write-batch but w/o updating dest
--read-batch=FILE        read a batched update from FILE
```

**Finding:** oc's `--help` (`crates/cli/src/frontend/help.rs`) is a wholesale
independent format (`{program} v{version} revision #...`, an `Options:` list in
oc's own two-column layout) that does not mirror upstream's help byte-for-byte
anywhere, and it has **no** `--write-batch`/`--read-batch`/`--only-write-batch`
lines at all. Splicing three upstream-format lines into an otherwise oc-format
help would be neither faithful to upstream nor coherent with oc's layout, and
the task explicitly scopes this to "those specific lines" and forbids rewriting
unrelated help text. A full upstream help-format parity pass is a separate,
larger effort. Nothing changed here.

## Tests

- `crates/cli/tests/lone_h_help.rs` (new) — lone `-h`/`-avh`/`-hh` → exit 0 +
  help on stdout + empty stderr; `-a`, `--no-human-readable`, and `-h -h` →
  exit 1 (negative controls proving the guard is precise).
- `crates/cli/tests/mutually_exclusive_options.rs` — new test asserts the exact
  `--secluded-args conflicts with --old-args.` stderr and exit 1 via `cli::run`.
- `crates/core/src/client/config/builder/tests.rs` — new unit test asserts
  `ConfigConflict` renders the upstream message.
- `crates/cli/tests/archive_flag_ordering.rs` (new, unix) — real local transfers
  assert dest permission bits differ for `--no-perms -a` (0700) vs `-a
  --no-perms` (0600).
- `crates/cli/tests/archive_flag_completeness.rs` and
  `crates/cli/tests/archive_mode.rs` — the pre-existing
  `*_before_archive_stays_disabled` tests encoded the wrong (order-insensitive)
  behavior; corrected to the upstream ordering semantics, plus a new
  `--no-recursive`-before-`-a` case.

Local: `cargo fmt --all -- --check` clean, `cargo clippy --workspace
--all-targets --all-features --no-deps -- -D warnings` clean. Targeted `cargo
nextest` runs of the affected crates pass (one unrelated failure,
`format_list_timestamp_epoch`, is a timezone-sensitive test that passes under
`TZ=UTC` as CI runs it).
