### PR TITLE
docs(fast_io): fix Pages rustdoc broken intra-doc links (cfg-windows-only)

### DIFF
--- a/crates/fast_io/src/win_atomic_commit.rs
+++ b/crates/fast_io/src/win_atomic_commit.rs
@@ -11,12 +11,12 @@
 //!
 //! Windows has no `openat`/`renameat`, but the same guarantee is available via:
 //!
-//! - [`create_new_no_follow`] - `CreateFileW`-equivalent open with
+//! - `create_new_no_follow` - `CreateFileW`-equivalent open with
 //!   `CREATE_NEW` + `FILE_FLAG_OPEN_REPARSE_POINT`, so a reparse point planted
 //!   at the temp leaf is opened as the reparse point itself (and `CREATE_NEW`
 //!   then fails) rather than traversed. This is the analog of `O_EXCL |
 //!   O_NOFOLLOW`.
-//! - [`rename_no_follow`] - a handle-based commit rename. The destination
+//! - `rename_no_follow` - a handle-based commit rename. The destination
 //!   parent is opened no-follow, validated as a real directory (not a reparse
 //!   point), and *pinned* (shared without `FILE_SHARE_DELETE`) so it cannot be
 //!   renamed/removed/replaced with a junction while the rename runs; the temp


### PR DESCRIPTION
## Problem

The `Pages` workflow has been red on `master` (its `Build rustdoc` step runs
`cargo doc --workspace --all-features --no-deps --locked` with
`RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links`):

```
error: unresolved link to `create_new_no_follow`
  --> crates/fast_io/src/lib.rs:195:1
error: unresolved link to `rename_no_follow`
  --> crates/fast_io/src/lib.rs:195:1
```

## Root cause

`crates/fast_io/src/win_atomic_commit.rs`'s **module-level** `//!` doc links
`` [`create_new_no_follow`] `` and `` [`rename_no_follow`] ``. Both functions
are `#[cfg(windows)]`-only (defined in the `imp` submodule, re-exported under a
Windows gate). Module docs are compiled on every target, but the Pages job
builds rustdoc on **Linux**, where those items don't exist — so the intra-doc
links are unresolvable and the denied lint fails the build.

## Fix

Use backtick-only code spans (`` `create_new_no_follow` ``,
`` `rename_no_follow` ``) instead of intra-doc links in the module doc, matching
the repo's established remedy for cfg/re-export doc links. The doc still names
and code-formats the functions; it just no longer emits a link that only
resolves on Windows. Function-level docs inside the `cfg(windows)` module keep
their working links (they're only compiled on Windows).

## Verification

`RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --workspace
--all-features --no-deps --locked` now finishes clean (exit 0, 0 errors) on a
non-Windows host. `cargo fmt --all -- --check` clean. Docs-only change.
