### PR TITLE
docs(filters): rustdoc and comment cleanup

### DIFF
--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -26,9 +26,13 @@
 //! - `n` - No-inherit (merge rules only: don't inherit parent rules)
 //! - `w` - Word-split (merge rules only: split the merge file at whitespace)
 //! - `C` - CVS mode (add CVS exclusion patterns)
+//! - `/` - Anchor merged rules to the transfer root (merge rules only)
+//! - `-` - Merged lines are literal excludes, prefixes not honoured (merge rules only)
+//! - `+` - Merged lines are literal includes, prefixes not honoured (merge rules only)
 //!
-//! The `e`, `n`, and `w` modifiers are valid only on a merge / dir-merge rule
-//! (upstream `FILTRULE_MERGE_FILE`); on any other rule they are a syntax error.
+//! The `e`, `n`, `w`, `/`, `-`, and `+` modifiers are valid only on a merge /
+//! dir-merge rule (upstream `FILTRULE_MERGE_FILE`); on any other rule they are a
+//! syntax error.
 //!
 //! Example: `-!p *.tmp` excludes files NOT matching `*.tmp`, marked perishable.
 //!

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -352,7 +352,7 @@ impl FilterRule {
     ///
     /// The pattern field contains the filename to look for in each directory
     /// (e.g., `.rsync-filter`). Rules from the file are applied relative to
-    /// that directory. This corresponds to rsync's `,` prefix in filter rules.
+    /// that directory. This corresponds to rsync's `:` prefix in filter rules.
     ///
     /// # Examples
     /// ```

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -380,7 +380,7 @@ impl FilterSet {
     /// read and its rules are inlined at that position. This process is
     /// recursive up to `max_depth` levels to prevent infinite loops.
     ///
-    /// Dir-merge rules (`, FILE`) are skipped since they're processed
+    /// Dir-merge rules (`: FILE`) are skipped since they're processed
     /// per-directory during traversal, not at compilation time.
     ///
     /// # Arguments


### PR DESCRIPTION
## Summary

Documentation-only cleanup of the `filters` crate. No code logic, control flow,
signatures, or behaviour changed — the working diff touches doc comments only.

The crate was already in excellent shape (`#![deny(missing_docs)]` and
`#![deny(rustdoc::broken_intra_doc_links)]` are enforced, so every public item is
documented and all intra-doc links resolve). This pass corrects two genuinely
stale docs and completes one incomplete modifier list.

## Changes

- **Fix stale dir-merge prefix** (`rule.rs`, `set.rs`): two doc comments called
  `,` the dir-merge rule prefix. The parser maps `:` to `DirMerge`
  (`strip_prefix(':')`), and `FilterAction::DirMerge` already documents `:`. The
  `,` is only a modifier separator, never the dir-merge prefix. Corrected both
  to `:`.
- **Complete the merge-modifier list** (`merge/mod.rs`): the module overview
  enumerated modifiers but omitted the three merge-only modifiers `/`, `-`, and
  `+` that `parse.rs` documents and implements. Added them and extended the
  "valid only on a merge / dir-merge rule" note to include them, so the overview
  matches the authoritative `RuleModifiers` table.

## Accounting

- Upstream references preserved: **184 before == 184 after** (`upstream:` lines
  unchanged; a HEAD-vs-worktree line diff of those references is empty — none
  lost or altered).
- Comments converted to rustdoc: 0 (all public items were already `///`/`//!`).
- Noise comments / dead-code blocks removed: 0 (none present — no decorative
  dividers, commented-out code, TODO/FIXME, or restatement comments found).
- Stale docs fixed: 3 lines across 3 files (2 prefix corrections, 1 completeness
  fix).
- Logic changes: **zero**.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p filters --all-targets --all-features --no-deps -- -D warnings` — clean
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D warnings" cargo doc -p filters --no-deps --all-features` — clean
- `tools/no_placeholders.sh` — no offenses in `filters`
