### PR TITLE
docs(compress): rustdoc and comment cleanup

### DIFF
--- a/crates/compress/src/strategy/adaptive_level.rs
+++ b/crates/compress/src/strategy/adaptive_level.rs
@@ -464,8 +464,6 @@ mod tests {
         assert!(s.smoothed_ratio().unwrap().is_finite());
     }
 
-    // --- AdaptiveLevelController tests ---
-
     #[test]
     fn controller_initial_level_clamped_to_bounds() {
         let ctrl = AdaptiveLevelController::for_zlib(100);


### PR DESCRIPTION
## Summary

Documentation-only pass over the `compress` crate (`crates/compress/src/**`). No
code logic, control flow, signatures, or behavior changed - only comment/doc
lines.

The crate was already in excellent documentation shape: `#![deny(missing_docs)]`
forces every public item to carry `///`, and a review of all source and test
modules confirmed the existing rustdoc and internal comments are accurate,
non-stale, and each carries genuine value (a "why", a wire/codec quirk, or a
safety invariant). The single item that fit the project coding standards "delete" rules was one
decorative divider comment inside the `adaptive_level` tests.

## Changes

- Removed the decorative divider comment `// --- AdaptiveLevelController tests
  ---` (and its now-redundant blank line) in
  `crates/compress/src/strategy/adaptive_level.rs`. Decorative divider/banner
  comments are explicitly listed for deletion.

## Upstream references preserved

- `// upstream: <file>:<fn>` reference count: **76 before == 76 after** (proof of
  full preservation). Every upstream C-source reference was kept verbatim.

## Comments converted to rustdoc

- None required. Every public type, trait, function, method, const, and enum
  variant already has an accurate `///`. The only leading `//` comments that
  precede public items are verbatim `// upstream:` references, which the rules
  require be kept as-is (not folded into rustdoc).

## Noise removed

- One decorative divider comment (2 lines total, including the trailing blank
  line).

## Notes

- Multi-line `//` explanatory comments containing paragraph-separating empty
  `//` lines (e.g. the Z_SYNC_FLUSH per-token flush explanation in
  `zlib/tests.rs`) were kept - they convey non-obvious wire-format rationale with
  upstream references.
- `strategy/type_state.rs` is an orphan file (no `mod type_state;` declaration
  anywhere, so it is not compiled); it was left untouched.

## Zero logic changes confirmed

`git diff` contains only removed comment/blank lines. No expression, signature,
or control-flow change.

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy -p compress --all-targets --all-features --no-deps -- -D
  warnings` - no issues
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D warnings" cargo doc -p
  compress --no-deps --all-features` - builds clean
- `tools/no_placeholders.sh` - no new violations in `compress`