### PR TITLE
docs: rustdoc/comment cleanup (test-support, branding, signature, logging, flist)

### DIFF
--- a/crates/flist/src/batched_stat/dir_stat.rs
+++ b/crates/flist/src/batched_stat/dir_stat.rs
@@ -71,7 +71,7 @@ impl DirectoryStatBatch {
         let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
 
         // SAFETY: `self.dir_fd` is a valid file descriptor borrowed from this
-        // `DirStat`. `c_name` is a NUL-terminated C string that outlives the
+        // `DirectoryStatBatch`. `c_name` is a NUL-terminated C string that outlives the
         // call. `stat_buf` is sized and aligned correctly.
         let ret = unsafe { libc::fstatat(self.dir_fd, c_name.as_ptr(), &mut stat_buf, flags) };
 
@@ -120,7 +120,7 @@ impl DirectoryStatBatch {
         let mut statx_buf: libc::statx = unsafe { std::mem::zeroed() };
 
         // SAFETY: `self.dir_fd` is a valid file descriptor borrowed from this
-        // `DirStat`. `c_name` is a NUL-terminated C string that outlives the
+        // `DirectoryStatBatch`. `c_name` is a NUL-terminated C string that outlives the
         // call. `statx_buf` is sized and aligned correctly.
         let ret = unsafe {
             libc::syscall(

--- a/crates/flist/src/batched_stat/mod.rs
+++ b/crates/flist/src/batched_stat/mod.rs
@@ -21,7 +21,7 @@
 //! # Example
 //!
 //! ```ignore
-//! use flist::batched_stat::{BatchedStatCache, StatBatch};
+//! use flist::batched_stat::BatchedStatCache;
 //! use std::path::Path;
 //!
 //! let mut cache = BatchedStatCache::new();
@@ -32,7 +32,7 @@
 //! ];
 //!
 //! // Fetch metadata in parallel
-//! let results = cache.stat_batch(&paths);
+//! let results = cache.stat_batch(&paths, false);
 //! for (path, result) in paths.iter().zip(results) {
 //!     if let Ok(metadata) = result {
 //!         println!("{}: {} bytes", path.display(), metadata.len());

--- a/crates/flist/src/lazy_entry.rs
+++ b/crates/flist/src/lazy_entry.rs
@@ -13,7 +13,7 @@
 //! # Example
 //!
 //! ```ignore
-//! use flist::lazy_entry::LazyFileListEntry;
+//! use flist::LazyFileListEntry;
 //! use std::path::PathBuf;
 //!
 //! let entry = LazyFileListEntry::new(

--- a/crates/flist/src/lazy_metadata.rs
+++ b/crates/flist/src/lazy_metadata.rs
@@ -14,7 +14,7 @@
 //! # Example
 //!
 //! ```ignore
-//! use flist::lazy_metadata::LazyMetadata;
+//! use flist::LazyMetadata;
 //! use std::path::PathBuf;
 //!
 //! let mut meta = LazyMetadata::new(PathBuf::from("/some/file"), false);

--- a/crates/flist/src/parallel.rs
+++ b/crates/flist/src/parallel.rs
@@ -295,7 +295,7 @@ pub fn collect_with_batched_stats(
 ///
 /// * `root` - Root directory to traverse
 /// * `follow_symlinks` - Whether to follow symlinks
-/// * `chunk_size` - Number of paths to stat in each parallel batch (default: 8192)
+/// * `chunk_size` - Number of paths to stat in each parallel batch
 ///
 /// # Performance
 ///

--- a/crates/logging/src/error_format.rs
+++ b/crates/logging/src/error_format.rs
@@ -19,7 +19,7 @@
 ///
 /// Given a `CARGO_MANIFEST_DIR` like `/home/user/project/crates/logging` and a
 /// `file!()` path like `/home/user/project/crates/logging/src/lib.rs`, this
-/// returns `logging/src/lib.rs` - the path relative to the `crates/` directory.
+/// returns `crates/logging/src/lib.rs` - the path relative to the repository root.
 ///
 /// If the path does not contain `crates/`, the full `file!()` value is returned
 /// unchanged.

--- a/crates/signature/src/async_gen.rs
+++ b/crates/signature/src/async_gen.rs
@@ -108,10 +108,10 @@ pub struct AsyncSignatureConfig {
     /// Default: Number of CPU cores, capped at 4.
     pub num_threads: usize,
 
-    /// Maximum number of pending requests before blocking.
+    /// Configured target for the number of in-flight signature requests.
     ///
-    /// This bounds memory usage and prevents overwhelming workers.
-    /// Default: 16
+    /// Advisory only: the request channel is unbounded, so this value does not
+    /// by itself block senders or cap memory. Default: 16.
     pub max_pending: usize,
 }
 
@@ -239,8 +239,6 @@ impl AsyncSignatureGenerator {
     /// Requests signature generation for a file.
     ///
     /// Returns the request ID that can be used to match the result.
-    ///
-    /// This may block if the request queue is full (backpressure).
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary

Documentation/comment-only cleanup across five crates: `test-support`, `branding`, `signature`, `logging`, and the standalone `flist` crate. Code is the source of truth; this PR only makes rustdoc/comments match the code they describe. No logic, control-flow, signature, or behavior changes - the diff is exclusively `//`, `///`, and `//!` lines.

Applied the standard comment-cleanup rules: keep every `// upstream:` reference and every why/invariant/quirk comment verbatim, fix stale docs that contradict current code, and delete restatement/decorative/dead comments (none were found).

## Per-crate results

### test-support - already clean, no changes
Every public item already carries accurate `///` rustdoc; comments explain intent ("why"). No restatement, dividers, dead code, or stale docs. `upstream:` refs: 1 before == 1 after.

### branding - already clean, no changes
All 20 source files audited; every explanation above a `pub` item already uses `///`; doctests verified against code. No banners, commented-out code, or stale docs. Note: the crate has zero `// upstream:` reference comments; the 3 raw `upstream:` grep hits are code identifiers (`upstream: BrandProfile` field, `let upstream: Version` doctest binding), untouched. Count: 3 before == 3 after.

### signature - 2 stale-doc fixes (async_gen.rs)
`AsyncSignatureConfig::max_pending` and `AsyncSignatureGenerator::request_signature` documented queue-bounding and backpressure ("blocks if the request queue is full"), but the request channel is an unbounded `mpsc::channel()` and `max_pending` is never wired to any bound (only stored/settable, and read solely by tests). Updated both docs to describe actual behavior. `upstream:` refs: 12 before == 12 after.

### logging - 1 stale-doc fix (error_format.rs)
`strip_repo_prefix`'s rustdoc example claimed it returns `logging/src/lib.rs` "relative to the `crates/` directory", but the code strips only the pre-`crates/` prefix and returns `crates/logging/src/lib.rs` (repo-root-relative) - as the `strips_prefix_when_crates_present` test asserts. Corrected the example and the description. `upstream:` refs: 39 before == 39 after.

### flist (standalone crate) - 4 stale-doc fixes
- `batched_stat/mod.rs`: module example imported a nonexistent `StatBatch` type and called `stat_batch(&paths)` with the wrong arity; the real signature is `stat_batch(&self, paths: &[&Path], follow_symlinks: bool)`. Fixed the import and the call.
- `batched_stat/dir_stat.rs`: two `SAFETY:` comments referenced a stale/renamed type `DirStat`; the struct is `DirectoryStatBatch`. Updated the references (SAFETY content otherwise preserved verbatim).
- `lazy_entry.rs` / `lazy_metadata.rs`: module examples imported through the private module paths `flist::lazy_entry::` / `flist::lazy_metadata::`; both types are re-exported at the crate root. Fixed to `flist::LazyFileListEntry` / `flist::LazyMetadata`.
- `parallel.rs`: `collect_paths_chunked_parallel`'s `chunk_size` arg doc claimed "(default: 8192)", but `chunk_size` is a mandatory parameter and `8192` appears nowhere in code. Removed the phantom default.

No orphan/dead source files found; all 17 files are reachable via `mod` declarations. `upstream:` refs: 9 before == 9 after.

## Verification
- `cargo fmt --all -- --check`: pass.
- `cargo clippy -p {signature,logging,flist} --all-targets --all-features --no-deps -- -D warnings`: pass.
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D warnings" cargo doc -p {signature,logging,flist} --no-deps --all-features`: pass.
- `upstream:` reference counts identical before and after in every crate (1 / 3 / 12 / 39 / 9).
- Zero logic change: `git diff` touches only comment/doc lines.

### Pre-existing note (not introduced here)
`cargo run -p xtask -- no-placeholders` already exits 1 on the base commit, flagging 27 unrelated files across the workspace (including xtask's own detector self-test). None of the seven files edited in this PR are flagged, and this PR adds no placeholder markers. This is pre-existing tool drift, out of scope for a docs cleanup.
