### PR TITLE
docs(xtask): rustdoc and comment cleanup

### DIFF
--- a/xtask/src/commands/branding/render.rs
+++ b/xtask/src/commands/branding/render.rs
@@ -4,6 +4,7 @@ use crate::workspace::WorkspaceBranding;
 use serde_json::json;
 use std::collections::BTreeMap;
 
+/// Renders the workspace branding summary as plain text or JSON per `format`.
 pub fn render_branding(
     branding: &WorkspaceBranding,
     format: BrandingOutputFormat,

--- a/xtask/src/commands/branding/validate.rs
+++ b/xtask/src/commands/branding/validate.rs
@@ -2,6 +2,10 @@ use crate::error::{TaskError, TaskResult};
 use crate::workspace::WorkspaceBranding;
 use std::path::Path;
 
+/// Validates workspace branding invariants: a non-empty brand, a protocol
+/// version within the supported 28-32 range, well-formed client and daemon
+/// binary names that resolve to a single executable, and named daemon config
+/// and secrets files.
 pub fn validate_branding(branding: &WorkspaceBranding) -> TaskResult<()> {
     if branding.brand.trim().is_empty() {
         return Err(TaskError::Validation(String::from(

--- a/xtask/src/commands/preflight/validation.rs
+++ b/xtask/src/commands/preflight/validation.rs
@@ -11,6 +11,10 @@ mod packaging;
 use packaging::file_name;
 pub(crate) use packaging::validate_packaging_assets;
 
+/// Validates that workspace branding matches the pinned release invariants:
+/// upstream 3.4.1, a `-rust` version suffix, protocol 32, brand-derived binary
+/// and daemon file names, and absolute config/secrets paths within the
+/// configured daemon directory.
 pub(crate) fn validate_branding(branding: &WorkspaceBranding) -> TaskResult<()> {
     let brand = branding.brand.trim();
     ensure(!brand.is_empty(), "workspace brand label must not be empty")?;
@@ -147,6 +151,8 @@ pub(crate) fn validate_branding(branding: &WorkspaceBranding) -> TaskResult<()> 
     Ok(())
 }
 
+/// Ensures the root crate version reported by `cargo metadata` matches the
+/// branded `rust_version`.
 pub(crate) fn validate_package_versions(
     workspace: &Path,
     branding: &WorkspaceBranding,
@@ -183,6 +189,8 @@ pub(crate) fn validate_package_versions(
     Ok(())
 }
 
+/// Ensures `workspace.package.rust-version` in the manifest matches the pinned
+/// CI toolchain (1.88).
 pub(crate) fn validate_workspace_package_rust_version(manifest: &Value) -> TaskResult<()> {
     let workspace = manifest
         .get("workspace")
@@ -207,6 +215,8 @@ pub(crate) fn validate_workspace_package_rust_version(manifest: &Value) -> TaskR
     )
 }
 
+/// Ensures required documentation files contain the branded binary, version,
+/// and daemon-config snippets.
 pub(crate) fn validate_documentation(
     workspace: &Path,
     branding: &WorkspaceBranding,

--- a/xtask/src/commands/preflight/validation/packaging.rs
+++ b/xtask/src/commands/preflight/validation/packaging.rs
@@ -5,6 +5,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use toml::{Value, value::Table as TomlTable};
 
+/// Validates that packaging assets under `packaging/` match the branded daemon
+/// configuration directory and file names.
 pub(crate) fn validate_packaging_assets(
     workspace: &Path,
     branding: &WorkspaceBranding,

--- a/xtask/src/util/commands.rs
+++ b/xtask/src/util/commands.rs
@@ -182,6 +182,8 @@ pub fn run_cargo_tool(
     run_cargo_tool_with_env(workspace, args, &[], display, install_hint)
 }
 
+/// Runs `cargo` with the supplied arguments and environment overrides, mapping
+/// failures to `TaskError` and surfacing captured stdout/stderr on error.
 pub fn run_cargo_tool_with_env(
     workspace: &Path,
     args: Vec<OsString>,

--- a/xtask/src/util/env.rs
+++ b/xtask/src/util/env.rs
@@ -2,8 +2,14 @@ use crate::error::TaskError;
 use std::env;
 use std::io;
 
+/// Environment variable listing cargo tools that should be treated as missing.
+///
+/// Entries are separated by `,`, `;`, or `|` and matched against a tool's
+/// display name, letting tests exercise the tool-unavailable paths.
 pub(crate) const FORCE_MISSING_ENV: &str = "OC_RSYNC_FORCE_MISSING_CARGO_TOOLS";
 
+/// Returns whether `display` is listed in `FORCE_MISSING_ENV`, simulating an
+/// unavailable cargo tool.
 pub(crate) fn should_simulate_missing_tool(display: &str) -> bool {
     let Ok(entries) = env::var(FORCE_MISSING_ENV) else {
         return false;
@@ -15,6 +21,8 @@ pub(crate) fn should_simulate_missing_tool(display: &str) -> bool {
         .any(|value| !value.is_empty() && value == display)
 }
 
+/// Maps a command-spawn error to `TaskError`, reporting `TaskError::ToolMissing`
+/// when the program was not found and otherwise wrapping the I/O error.
 pub(crate) fn map_command_error(error: io::Error, program: &str, install_hint: &str) -> TaskError {
     if error.kind() == io::ErrorKind::NotFound {
         TaskError::ToolMissing(format!("{program} is unavailable; {install_hint}"))
@@ -23,6 +31,8 @@ pub(crate) fn map_command_error(error: io::Error, program: &str, install_hint: &
     }
 }
 
+/// Builds a `TaskError::ToolMissing` naming the unavailable tool and its
+/// install hint.
 pub(crate) fn tool_missing_error(display: &str, install_hint: &str) -> TaskError {
     TaskError::ToolMissing(format!("{display} is unavailable; {install_hint}"))
 }


### PR DESCRIPTION
## Summary

Rustdoc/comment cleanup of the `xtask` crate only. Documentation-only: no logic
or behavior change. Every `.rs` file under `xtask/src/**` was read and audited
against the code as source of truth.

The crate was already in very good shape. The only actionable work was adding
missing `///` doc comments to public and `pub(crate)` items whose siblings were
already documented, restoring consistency.

## Doc comments added (12 items, +29 lines, 0 deletions)

- `util/commands.rs` — `run_cargo_tool_with_env` (its sibling `run_cargo_tool`
  was already documented).
- `util/env.rs` — `FORCE_MISSING_ENV`, `should_simulate_missing_tool`,
  `map_command_error`, `tool_missing_error`.
- `commands/branding/render.rs` — `render_branding`.
- `commands/branding/validate.rs` — `validate_branding`.
- `commands/preflight/validation.rs` — `validate_branding`,
  `validate_package_versions`, `validate_workspace_package_rust_version`,
  `validate_documentation`.
- `commands/preflight/validation/packaging.rs` — `validate_packaging_assets`.

All added docs are derived from the code they describe. Type references use
backtick-only form (no new intra-doc links).

## Zero-logic-change confirmation

- Diff is 29 insertions, all `///` doc-comment lines; 0 deletions; no
  non-comment source line changed.
- `cargo fmt --all -- --check` passes.

## Upstream references

There are zero `// upstream:` reference comments anywhere in `xtask/src`
(the crate is build tooling, not protocol code). before == after: no upstream
ref was added, removed, or altered.

## Already-clean

No stale docs, restatement/echo comments, debug/checkpoint comments,
decorative banner/divider comments, or commented-out code were found. All `//!`
module docs sit in genuine module-root files (no `include!()` usage). Existing
`//` inline comments explain WHY/invariants and were kept verbatim.

## Notes for a human (out of scope — code changes, not touched here)

These were observed during the read-through but are behavior/code issues
outside a docs-only cleanup:

- `xtask` has no `enforce-limits` subcommand, yet `tools/enforce_limits.sh`
  references `cargo xtask enforce-limits`.
- The `no-placeholders` command fails on unrelated files (out of this crate's
  scope).
- Orphaned test file: `commands/branding/tests.rs` imports `parse_args`/`usage`
  from `super::args` (neither exists) and is not declared as a module by
  `branding/mod.rs` (which uses an inline `#[cfg(test)] mod tests`).
- Empty declared test modules: `commands/docs/validation/ci/matrix/tests/
  duplicate_entries.rs` and `.../unexpected_entries.rs` are blank yet declared.
- Computed-then-discarded values:
  `commands/release_notes/publish.rs:136` (`let _stderr = ...`) and the
  `cmd_args[0]` replacement in `commands/interop/messages/extractor.rs` (the
  slot is overwritten but only `cmd_args[1..]` is ever used).
