### PR TITLE
docs(rsync_io): rustdoc and comment cleanup

### DIFF
--- a/crates/rsync_io/src/ssh/async_transport.rs
+++ b/crates/rsync_io/src/ssh/async_transport.rs
@@ -15,10 +15,12 @@
 //! `(AsyncRead, AsyncWrite)` split. The downstream
 //! `ChannelReader`/`ChannelWriter` adapters that bridge these halves into
 //! the multiplex framing layer are tracked separately as task #1797.
-//! Likewise, an async stderr drain and async connect-watchdog are deferred:
-//! stderr is currently inherited from the parent, and connect timeouts are
+//! The async connect-watchdog is likewise deferred: connect timeouts are
 //! enforced by the `-o ConnectTimeout=N` option that the shared builder
-//! already injects.
+//! already injects. An async stderr drain has since landed (SSE-4, #2373):
+//! under the `ssh-socketpair-stderr` feature on Unix a socketpair is
+//! installed and drained by `AsyncStderrDrain`, so only default builds
+//! (feature off, or non-Unix) still inherit stderr from the parent.
 //!
 //! # Feature gate
 //!


### PR DESCRIPTION
## Summary

Documentation/comment-only cleanup of the `rsync_io` crate. Every `.rs` file
under `crates/rsync_io/src/**` was read in full and audited against the
comment-cleanup rules (keep upstream refs and why/invariant/safety notes;
convert useful `//` on public items to `///`; fix stale docs that contradict
the code; delete restatement/decorative/dead comments).

The crate was found to be almost entirely clean. Exactly one stale doc was
found and corrected.

## Stale-doc fix

`crates/rsync_io/src/ssh/async_transport.rs` (module doc): the `# Scope`
section claimed that "an async stderr drain ... [is] deferred: stderr is
currently inherited from the parent." This contradicts the code: the struct
carries a `stderr_drain` field and `execute_remote_rsync` installs a
`socketpair(AF_UNIX, SOCK_STREAM, 0)` and hands the parent end to
`AsyncStderrDrain::spawn` when the `ssh-socketpair-stderr` feature is enabled
on Unix (the same SSE-4/#2373 work already referenced in this file's inline
comments and the `stderr_drain` field doc). Only default builds (feature off)
and non-Unix targets still inherit stderr from the parent. The doc now states
this accurately; the connect-watchdog half of the sentence (still genuinely
deferred) is preserved.

## Verification

- Upstream-ref count unchanged: **36 before == 36 after** (`grep -rc 'upstream:'`).
- No new `TODO`/`FIXME`/`XXX`/`todo!`/`unimplemented!` introduced.
- Diff is doc-comment only (5 `//!` lines); zero logic/signature/control-flow change.
- Identifier reference uses backtick-only `` `AsyncStderrDrain` `` (no new
  intra-doc link), respecting the crate's
  `#![deny(rustdoc::broken_intra_doc_links)]`.

## Notes

- The crate is `#![deny(missing_docs)]`, so all public items already carry
  `///` docs; no doc additions were needed or made.
- No decorative dividers, restatement echoes, commented-out code, or
  `//`-on-public-item comments requiring conversion were found anywhere in the
  crate. The ssh, negotiation, session/handshake, and binary/daemon subtrees
  are all clean.
- Orphan-file note (out of scope for this docs-only change, flagged for
  awareness): `crates/rsync_io/src/debug_io.rs` is not declared by any `mod`
  statement in `lib.rs`, so it is not compiled. No edit was made to it.
