### PR TITLE
docs(fast_io): rustdoc/comment cleanup (stubs + small dirs)

### DIFF
--- a/crates/fast_io/src/io_uring_stub/buffer_ring.rs
+++ b/crates/fast_io/src/io_uring_stub/buffer_ring.rs
@@ -79,13 +79,13 @@ impl BufferRing {
     }
 }
 
-/// Returns `false` on non-Linux platforms.
+/// Returns `false` on this platform.
 #[must_use]
 pub fn is_supported() -> bool {
     false
 }
 
-/// Returns `false` on non-Linux platforms.
+/// Returns `false` on this platform.
 ///
 /// Cross-platform alias for `is_supported` matching the
 /// [`crate::pbuf_ring_supported`] re-export.
@@ -138,7 +138,7 @@ impl BgidAllocator {
     }
 }
 
-/// Returns 0 on non-Linux platforms; no bgids are ever issued here.
+/// Returns 0 on this platform; no bgids are ever issued here.
 ///
 /// Mirrors the Linux accessor so cross-platform callers and metrics
 /// exporters compile without `cfg`-gating.
@@ -147,7 +147,7 @@ pub fn bgid_peak_used() -> u16 {
     0
 }
 
-/// Returns 0 on non-Linux platforms; no bgids are ever issued here.
+/// Returns 0 on this platform; no bgids are ever issued here.
 ///
 /// Mirrors the Linux accessor so cross-platform callers and metrics
 /// exporters compile without `cfg`-gating.
@@ -156,7 +156,7 @@ pub fn bgid_inflight() -> u16 {
     0
 }
 
-/// Returns 0 on non-Linux platforms; the stub never produces a fresh
+/// Returns 0 on this platform; the stub never produces a fresh
 /// bgid so the exhaustion counter never advances.
 ///
 /// Mirrors the Linux accessor so cross-platform callers and metrics
@@ -168,7 +168,7 @@ pub fn bgid_exhausted_count() -> u64 {
 
 /// Consistent snapshot of all process-wide bgid allocator counters.
 ///
-/// On non-Linux platforms all fields are zero because no bgids are ever
+/// On this platform all fields are zero because no bgids are ever
 /// issued. Mirrors the Linux type so cross-platform callers compile
 /// without `cfg`-gating.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -183,7 +183,7 @@ pub struct BgidSnapshot {
     pub remaining: u32,
 }
 
-/// Returns a zero-valued snapshot on non-Linux platforms.
+/// Returns a zero-valued snapshot on this platform.
 ///
 /// Mirrors the Linux accessor so cross-platform callers and metrics
 /// exporters compile without `cfg`-gating.
@@ -199,7 +199,7 @@ pub fn bgid_snapshot() -> BgidSnapshot {
 
 /// Per-session bgid exhaustion tracker.
 ///
-/// On non-Linux platforms this is a no-op: exhaustion events never occur
+/// On this platform this is a no-op: exhaustion events never occur
 /// and all counters stay at zero. Mirrors the Linux type so cross-platform
 /// callers compile without `cfg`-gating.
 #[derive(Debug, Clone, Copy)]

--- a/crates/fast_io/src/io_uring_stub/linked_chain.rs
+++ b/crates/fast_io/src/io_uring_stub/linked_chain.rs
@@ -23,11 +23,13 @@ pub struct CqeResult {
 }
 
 impl CqeResult {
-    /// Maps the stub result to an [`io::Result`].
+    /// Maps the raw kernel `result` to an [`io::Result`]: a negative value
+    /// becomes an `Err` built from the OS error code, a non-negative value
+    /// becomes `Ok(result as u32)`.
     ///
-    /// Always succeeds with `0` because the stub cannot run a chain;
-    /// callers that need real error mapping must be on Linux with the
-    /// `io_uring` feature.
+    /// The stub never produces a `CqeResult` itself (`submit_and_wait`
+    /// returns `Unsupported`), but the mapping still runs when callers
+    /// construct one directly.
     pub fn into_io_result(self) -> io::Result<u32> {
         if self.result < 0 {
             Err(io::Error::from_raw_os_error(-self.result))

--- a/crates/fast_io/src/iocp_stub/socket.rs
+++ b/crates/fast_io/src/iocp_stub/socket.rs
@@ -45,7 +45,8 @@ impl IocpSocketReader {
         ))
     }
 
-    /// Override the per-socket completion key reported by the pump.
+    /// Override the per-socket completion key reported by the pump (no-op on
+    /// this platform).
     #[must_use]
     pub fn with_completion_key(self, _key: usize) -> Self {
         self
@@ -87,7 +88,8 @@ impl IocpSocketWriter {
         ))
     }
 
-    /// Override the per-socket completion key reported by the pump.
+    /// Override the per-socket completion key reported by the pump (no-op on
+    /// this platform).
     #[must_use]
     pub fn with_completion_key(self, _key: usize) -> Self {
         self

--- a/crates/fast_io/src/kqueue/mod.rs
+++ b/crates/fast_io/src/kqueue/mod.rs
@@ -194,13 +194,11 @@ impl KqueueLoop {
 
     /// Removes a previously-registered event for the given fd/filter.
     ///
-    /// Idempotent on `ENOENT` (returns `Ok(())` if the event was not
-    /// registered) so callers can deregister unconditionally on
-    /// shutdown.
-    ///
     /// # Errors
     ///
-    /// Returns an `io::Error` for any failure other than `ENOENT`.
+    /// Returns an `io::Error` if `kevent(2)` rejects the removal. Removing
+    /// a filter that was never registered surfaces the kernel's `ENOENT`;
+    /// `EV_DELETE` of an absent filter is not treated as a no-op.
     pub fn remove(&self, fd: RawFd, filter: KEventFilter) -> io::Result<()> {
         let change = make_kevent(fd, filter.as_raw(), libc::EV_DELETE, 0);
         let rc = self.kevent_call(Some(&change), None, None)?;

--- a/crates/fast_io/src/sendfile/mod.rs
+++ b/crates/fast_io/src/sendfile/mod.rs
@@ -117,7 +117,9 @@ pub fn send_file_to_writer<W: Write>(
 /// This function uses the Linux `sendfile` syscall for zero-copy transfer when:
 /// - The platform is Linux
 /// - The file size is >= 64KB (threshold for efficiency)
-/// - The destination file descriptor is a socket
+///
+/// Since Linux 2.6.33 the destination fd may be any file, so no socket
+/// check is performed; the syscall is attempted whenever the threshold is met.
 ///
 /// On failure or unsupported platforms, automatically falls back to buffered read/write.
 ///

--- a/crates/fast_io/src/signal/mod.rs
+++ b/crates/fast_io/src/signal/mod.rs
@@ -35,7 +35,7 @@ static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 /// Marks that a graceful shutdown has been requested.
 ///
-/// Async-signal-safe: performs a single relaxed-ordering atomic store, so it
+/// Async-signal-safe: performs a single atomic store, so it
 /// is safe to call from within a signal handler.
 #[inline]
 pub fn mark_shutdown() {


### PR DESCRIPTION
## Summary

Documentation-only cleanup of the fast_io stub and small-platform-helper
subdirectories. No logic or behavior changes: every changed line is a `///`
rustdoc comment. Verified with `git diff` (all hunks are doc comments) and
`cargo fmt --all -- --check`.

Scope was limited to the stub/small dirs:
`io_uring_stub`, `iocp_stub`, `kqueue`, `o_tmpfile`, `win_tmpfile`, `gcd`,
`signal`, `splice`, `sendfile`.

## Fixes

Highest value: stale docs that contradicted the code.

- `kqueue/mod.rs` — `KqueueLoop::remove` doc claimed it was "idempotent on
  `ENOENT` (returns `Ok(())`)". The implementation surfaces the kernel's
  `ENOENT` as an `Err`, and the test `remove_is_idempotent_on_missing_registration`
  asserts exactly that. Rewrote the doc (and the `# Errors` section) to match
  the real behavior: `EV_DELETE` of an absent filter is not a no-op.
- `signal/mod.rs` — `mark_shutdown` doc said "single relaxed-ordering atomic
  store"; the store uses `Ordering::SeqCst`. Dropped the incorrect ordering
  qualifier (async-signal-safety does not depend on the ordering).
- `sendfile/mod.rs` — `send_file_to_fd` doc listed "the destination fd is a
  socket" as a precondition for the Linux `sendfile` path. The Linux dispatch
  only gates on the 64KB threshold, and `test_send_file_to_fd_pipe` drives
  `sendfile` to a pipe. Corrected the doc to reflect that modern Linux accepts
  any output fd.
- `io_uring_stub/linked_chain.rs` — `CqeResult::into_io_result` doc claimed it
  "always succeeds with `0`", but the body maps a negative `result` to an
  `Err` from the OS error code and a non-negative one to `Ok(result as u32)`.
  Since `CqeResult` has public fields, callers can construct one directly and
  exercise both arms. Rewrote to describe the actual mapping.

Consistency (wording accuracy):

- `io_uring_stub/buffer_ring.rs` — eight function/type docs said "on non-Linux
  platforms"; the module compiles both on non-Linux and on Linux with the
  `io_uring` feature disabled (per the module-level doc). Aligned them to the
  crate's standard "on this platform" phrasing.
- `iocp_stub/socket.rs` — the two `with_completion_key` docs said "override the
  completion key" but the stub setters are no-ops (`completion_key()` is
  hardcoded to `0`). Added "(no-op on this platform)" to match every other
  stub setter's doc.

## Already clean

The remaining files needed no changes. `iocp_stub` (except the two socket
lines above), `o_tmpfile`, `win_tmpfile`, `gcd`, `splice` (all files), and the
rest of `sendfile`/`io_uring_stub` already carry accurate `///` on every public
item, with no restatement, debug, divider, or commented-out code.

## Upstream / SAFETY fidelity

Confirmed before == after in scope: no `// upstream:` reference, `// SAFETY:`
comment, `// Safety:` rationale, no-op-stub rationale, platform-fallback
rationale, or syscall-describing comment (splice/vmsplice/sendfile/kqueue) was
added, removed, or altered. The `// Safety:` casing in `o_tmpfile/low_level.rs`
was left verbatim rather than normalized, to honor the keep-verbatim rule for
safety comments.

## Zero-logic confirmation

`git diff` shows every changed line is a `///` doc comment across 6 files
(+25 / -21). No code, signatures, control flow, or `//` non-doc comments were
touched. Changes are confined to the scoped subdirectories.
