### PR TITLE
docs(engine): rustdoc/comment cleanup (delete)

### DIFF
--- a/crates/engine/src/delete/context/core.rs
+++ b/crates/engine/src/delete/context/core.rs
@@ -404,7 +404,6 @@ impl DeleteContext {
     ///
     /// Surfaces any fatal error from [`DeleteEmitter::emit_all`] (or the
     /// parallel consumer's equivalent under the feature flag).
-    // DEL-2.d: feature-gated dispatch, parallel-delete-consumer opt-in
     #[cfg(not(feature = "parallel-delete-consumer"))]
     pub fn emit_one<F: DeleteFs>(self, fs: F) -> io::Result<DrainOutcome<F>> {
         let mut emitter = self.into_emitter(fs)?;
@@ -431,7 +430,6 @@ impl DeleteContext {
     /// code the parallel path dispatches through per cohort, so the delete
     /// events, stats, and exit code are byte-identical either way; only the
     /// scheduling wrapper is skipped.
-    // DEL-2.d: feature-gated dispatch, parallel-delete-consumer opt-in
     #[cfg(feature = "parallel-delete-consumer")]
     pub fn emit_one<F: DeleteFs + Sync + Send + 'static>(
         self,
@@ -455,7 +453,6 @@ impl DeleteContext {
     /// # Errors
     ///
     /// Surfaces any fatal error from [`DeleteEmitter::emit_all`].
-    // DEL-2.d: feature-gated dispatch, parallel-delete-consumer opt-in
     #[cfg(not(feature = "parallel-delete-consumer"))]
     pub fn emit_all<F: DeleteFs>(self, fs: F) -> io::Result<DrainOutcome<F>> {
         self.emit_one(fs)
@@ -463,7 +460,6 @@ impl DeleteContext {
 
     /// Parallel-feature variant of [`Self::emit_all`]; bounds widened to
     /// match [`Self::emit_one`].
-    // DEL-2.d: feature-gated dispatch, parallel-delete-consumer opt-in
     #[cfg(feature = "parallel-delete-consumer")]
     pub fn emit_all<F: DeleteFs + Sync + Send + 'static>(
         self,
@@ -600,7 +596,7 @@ impl DeleteContext {
 
     /// Extracts the owned drain inputs (plan map, traversal cursor,
     /// emitter policy) from this context. Shared by [`Self::into_emitter`]
-    /// (sequential path) and the parallel `emit_via_parallel_consumer`
+    /// (sequential path) and the parallel `emit_parallel_from_parts`
     /// path under the `parallel-delete-consumer` feature. The
     /// channel-shutdown semantics and `Arc::try_unwrap` invariant are
     /// preserved exactly because both paths consume `self` by value.

--- a/crates/engine/src/delete/context/mod.rs
+++ b/crates/engine/src/delete/context/mod.rs
@@ -39,12 +39,14 @@
 //! # Concurrency
 //!
 //! [`DeletePlanMap`](super::plan_map::DeletePlanMap) already provides
-//! interior mutability via a global mutex; the traversal cursor is
-//! wrapped in a [`Mutex`](std::sync::Mutex) here. The observation API
-//! takes `&self`, so the context can live inside an
-//! [`Arc`](std::sync::Arc) shared between the receiver and worker
-//! threads. The drain consumes the context by value (`mut self`) and is
-//! therefore the single-writer path that owns the emitter.
+//! interior mutability via a global mutex; cursor observations from
+//! workers are queued through a `crossbeam_channel::unbounded`
+//! producer-consumer channel rather than a shared
+//! `Arc<Mutex<DirTraversalCursor>>`. The observation API takes `&self`,
+//! so the context can live inside an [`Arc`](std::sync::Arc) shared
+//! between the receiver and worker threads. The drain consumes the
+//! context by value and is therefore the single-writer path that owns
+//! the emitter.
 //!
 //! # Submodules
 //!

--- a/crates/engine/src/delete/emitter/policy.rs
+++ b/crates/engine/src/delete/emitter/policy.rs
@@ -13,7 +13,8 @@ pub const EMITTER_PARTIAL_EXIT_CODE: i32 = 23;
 /// upstream `errcode.h::RERR_VANISHED` and `core::exit_code::ExitCode::Vanished`.
 pub const EMITTER_VANISHED_EXIT_CODE: i32 = 24;
 
-/// Upstream `IOERR_GENERAL`: the only bit the delete pass currently sets.
+/// Upstream `IOERR_GENERAL`: the general-error bit the delete pass sets
+/// for non-fatal failures other than a vanished destination entry.
 pub(super) const IOERR_GENERAL: i32 = 1;
 
 /// Sentinel bit set when the only failure observed was a vanished

--- a/crates/engine/src/delete/extras.rs
+++ b/crates/engine/src/delete/extras.rs
@@ -12,8 +12,9 @@
 //! The function is intentionally side-effect-free apart from
 //! `read_dir`/`symlink_metadata` syscalls on `dest_dir`; it never
 //! unlinks, never opens files for reading, and never touches the
-//! hardlink table. Hardlink-cohort tagging is layered on by task
-//! DDP-D2.
+//! hardlink table. Hardlink-cohort tagging is available through the
+//! `compute_extras_with_cohorts` variant, which reads a pre-built
+//! `CohortIndex` snapshot instead of mutating hardlink state.
 //!
 //! # Upstream Reference
 //!

--- a/crates/engine/src/delete/parallel_consumer.rs
+++ b/crates/engine/src/delete/parallel_consumer.rs
@@ -8,11 +8,12 @@
 //! # Scope
 //!
 //! - The module is gated behind the `parallel-delete-consumer` Cargo
-//!   feature so production builds remain byte-for-byte unchanged. DEL-2.d
-//!   migrates the receiver-side call site that today routes through
-//!   [`super::emitter::DeleteEmitter::emit_all`]. This change is additive
-//!   only: with the feature off, the symbols here are not compiled and the
-//!   existing sequential emitter remains the only consumer.
+//!   feature so production builds remain byte-for-byte unchanged. When the
+//!   feature is enabled, `DeleteContext::emit_one` (DEL-2.d) routes the
+//!   receiver-side drain through this consumer instead of the sequential
+//!   [`super::emitter::DeleteEmitter`]. This wiring is additive only: with
+//!   the feature off, the symbols here are not compiled and the existing
+//!   sequential emitter remains the only consumer.
 //! - The consumer preserves the DEL-1.a strict cross-cohort wire ordering
 //!   for `NDX_DEL_STATS` accumulation: cohort `N + 1` cannot begin
 //!   dispatch until every op in cohort `N` has completed. Within a

--- a/crates/engine/src/delete/reorder_buffer.rs
+++ b/crates/engine/src/delete/reorder_buffer.rs
@@ -3,9 +3,10 @@
 //! This module is the buffer primitive specified by DEL-1.b (see
 //! `docs/design/del-1b-reordering-buffer.md`) and the batching strategy
 //! resolved by DEL-1.c (see
-//! `docs/design/del-1c-cohort-batching-strategy.md`). It is the DEL-2.a
-//! deliverable: the data structure only, with no wiring into the production
-//! [`super::emitter::DeleteEmitter`] yet (that is DEL-2.c).
+//! `docs/design/del-1c-cohort-batching-strategy.md`). Originally the
+//! DEL-2.a deliverable (the data structure alone), it is now wired into
+//! the parallel consumer (`super::parallel_consumer`, DEL-2.c) under the
+//! `parallel-delete-consumer` feature.
 //!
 //! # What this buffer does
 //!
@@ -103,9 +104,7 @@ pub const DRAIN_BATCH_CAP: usize = 8;
 
 /// Per-deletion-attempt record the buffer carries.
 ///
-/// The buffer is the DEL-2.a primitive; full wiring into
-/// [`super::emitter::DeleteEmitter`] lands in DEL-2.c. Until then this
-/// struct is a minimal payload that captures everything a consumer
+/// A minimal payload that captures everything the parallel consumer
 /// needs to either re-issue the dispatch or emit a `MSG_DELETED`
 /// frame: the absolute destination path, the leaf name (for
 /// SEC-1.q-style dirfd-anchored dispatch), and the kind for stats


### PR DESCRIPTION
## Summary

Documentation-only cleanup of `crates/engine/src/delete/`. Every change is
to a `//`, `///`, or `//!` comment; no code, signatures, or behaviour are
touched. The diff is confined entirely to `src/delete/` (6 files).

The primary value is fixing stale rustdoc that contradicted the code -
several module and item docs still described the delete pipeline as
pre-refactor, forward-referencing task work that has since landed.

## Stale-doc fixes (contradicted the code)

- **`extras.rs`** - the module header claimed hardlink-cohort tagging was
  future work ("layered on by task DDP-D2"), but `compute_extras_with_cohorts`
  already implements it via `CohortIndex::cohort_of` / `DeleteEntry::with_cohort`.
  Rewritten to point at the existing variant.
- **`emitter/policy.rs`** - `IOERR_GENERAL` was documented as "the only bit
  the delete pass currently sets", but `record_nonfatal` also sets
  `IOERR_VANISHED_ONLY` for vanished (`NotFound`) entries. Corrected to
  describe it as the general-error bit.
- **`context/mod.rs`** - the Concurrency section said the traversal cursor is
  "wrapped in a `Mutex` here". It is not: cursor observations are queued
  through a `crossbeam_channel::unbounded` handoff (as `context/core.rs`'s own
  header documents). Also corrected `mut self` to `self` for the drain, which
  consumes the context by value.
- **`context/core.rs`** - `into_drain_parts` doc referenced a non-existent
  `emit_via_parallel_consumer`; the real helper is `emit_parallel_from_parts`.
- **`reorder_buffer.rs`** - two docs claimed the buffer has "no wiring into the
  production emitter yet (that is DEL-2.c)". The wiring exists: the parallel
  consumer consumes `DeleteOperation` / `DeleteCohortKey` and `context/core.rs`
  builds the cohorts. Rewritten to describe current state.
- **`parallel_consumer.rs`** - the Scope section described DEL-2.d as pending
  ("migrates the call site that today routes through `DeleteEmitter::emit_all`").
  That routing already exists behind the feature via `DeleteContext::emit_one`.

## Restatement comments removed

- **`context/core.rs`** - four identical `// DEL-2.d: feature-gated dispatch,
  parallel-delete-consumer opt-in` comments that only restated the adjacent
  `#[cfg(feature = "parallel-delete-consumer")]` attribute.

## Upstream references: before == after

All upstream C-source references (`generator.c:272-347`, `delete.c:130-225`,
`del.c`, `main.c:225-247`, `flist.c`, `hlink.c`, and the `# Upstream reference`
blocks) are preserved byte-for-byte. Verified by extracting every
upstream/`*.c`/`*.h` line before and after and diffing the content
independently of line-number shifts: the only content delta is the intended
`IOERR_GENERAL` wording fix, which is not a C-source citation.

## Notes

- The rest of `src/delete/` was already well-documented: no missing public-item
  docs, no `//`-to-`///` promotions needed, no commented-out code, no decorative
  dividers, no orphan/dead files.
- Left `cohort_batcher.rs` and `context/mod.rs`'s "single-threaded drain"
  wording untouched: with the `parallel-delete-consumer` feature off (the
  default), the adapter is genuinely dormant and the sequential emitter is the
  sole path, so those statements remain substantively correct for production
  builds.
- No new intra-doc `[links]` were introduced; new cross-references use
  backtick-only names.

## Verification

- `cargo fmt --all -- --check` passes.
- Diff is comment/doc-only (no non-comment line changed) and scoped to
  `src/delete/`.
