### PR TITLE
docs(metadata): rustdoc and comment cleanup

### DIFF
--- a/crates/metadata/src/acl_exacl/apply.rs
+++ b/crates/metadata/src/acl_exacl/apply.rs
@@ -35,6 +35,9 @@ use super::special::restore_special_mode_bits;
 /// * `access_ndx` - Index into the access ACL cache.
 /// * `default_ndx` - Optional index into the default ACL cache (directories only).
 /// * `follow_symlinks` - Whether to follow symlinks. If `false`, returns immediately.
+/// * `mode` - Optional file mode. When present, its bits reconstruct the
+///   stripped base ACL entries and restore the setuid/setgid/sticky bits that
+///   `setfacl` clears when it re-derives permissions from the ACL.
 /// * `id_map` - Optional cross-host id remapper for named ACL entries. When
 ///   present, each named user/group id is remapped through the received id-list
 ///   and `--usermap`/`--groupmap`, matching upstream `match_acl_ids()`.

--- a/crates/metadata/src/acl_noop.rs
+++ b/crates/metadata/src/acl_noop.rs
@@ -35,9 +35,11 @@ pub fn sync_acls(
     Ok(())
 }
 
-/// Reads the filesystem ACL for `path` and converts it to an [`RsyncAcl`].
+/// Synthesises an [`RsyncAcl`] from `mode`, since this platform cannot read a
+/// filesystem ACL.
 ///
-/// On platforms without ACL support, returns a fake ACL derived from mode.
+/// A default-ACL request (`is_default`) yields an empty ACL; otherwise the ACL
+/// is derived from the mode bits.
 pub fn get_rsync_acl(_path: &Path, mode: u32, is_default: bool) -> RsyncAcl {
     if is_default {
         RsyncAcl::new()

--- a/crates/metadata/src/acl_stub.rs
+++ b/crates/metadata/src/acl_stub.rs
@@ -40,9 +40,11 @@ pub fn sync_acls(
     Ok(())
 }
 
-/// Reads the filesystem ACL for `path` and converts it to an [`RsyncAcl`].
+/// Synthesises an [`RsyncAcl`] from `mode`, since iOS/tvOS/watchOS cannot read a
+/// filesystem ACL.
 ///
-/// On iOS/tvOS/watchOS, returns a fake ACL derived from mode.
+/// A default-ACL request (`is_default`) yields an empty ACL; otherwise the ACL
+/// is derived from the mode bits.
 #[allow(clippy::module_name_repetitions)]
 pub fn get_rsync_acl(path: &Path, mode: u32, is_default: bool) -> RsyncAcl {
     let _ = path;

--- a/crates/metadata/src/acl_windows/mod.rs
+++ b/crates/metadata/src/acl_windows/mod.rs
@@ -13,13 +13,15 @@
 //!
 //! # Scope
 //!
-//! - Only the discretionary ACL (DACL) is read and written. The system ACL
-//!   (SACL) requires the `SE_SECURITY_NAME` privilege and is intentionally
-//!   skipped to avoid surprising privilege escalations on standard
-//!   accounts.
-//! - SACL preservation, inheritance flag round-tripping, and protected
-//!   DACL bits are deliberately left as follow-on work; the current
-//!   implementation focuses on Tier 1C beta parity.
+//! - The default read path (`read_dacl_sddl`) covers the owner, group, and
+//!   discretionary ACL (DACL). The system ACL (SACL) requires the
+//!   `SE_SECURITY_NAME` privilege and is read only on the opt-in
+//!   `read_sddl_with_sacl` path, avoiding surprising privilege escalations
+//!   on standard accounts.
+//! - Applied DACLs set the protected (`P`) bit so the destination does not
+//!   silently inherit ACEs from its parent. SACL entries carried in an SDDL
+//!   payload are written only when the calling token holds
+//!   `SE_SECURITY_NAME`.
 //!
 //! # SID/UID Mapping
 //!

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -131,7 +131,7 @@ mod ownership_stub;
 #[allow(unused_imports)] // REASON: used on non-unix as the ownership implementation
 use ownership_stub as ownership;
 
-/// Optimized metadata caching with statx support on Linux.
+/// Optimized metadata caching with a libc `lstat` readback on Linux.
 pub mod stat_cache;
 
 mod special;

--- a/crates/metadata/src/special.rs
+++ b/crates/metadata/src/special.rs
@@ -272,8 +272,7 @@ fn create_device_node_inner(
 
     // The source rdev already encodes major/minor for this platform, so it can
     // be handed straight to mknod (matching upstream do_mknod, which forwards
-    // the device word verbatim). try_into guards the rare targets where dev_t
-    // is narrower than the u64 returned by MetadataExt::rdev.
+    // the device word verbatim).
     // try_into guards narrow-dev_t targets; on Linux dev_t is u64 so the
     // conversion is a no-op there, which clippy would otherwise flag.
     #[allow(clippy::useless_conversion)]

--- a/crates/metadata/src/stat_cache.rs
+++ b/crates/metadata/src/stat_cache.rs
@@ -30,7 +30,7 @@ pub struct MetadataCache {
     misses: usize,
 }
 
-/// Cached metadata fields extracted from a stat or statx call.
+/// Cached metadata fields extracted from a stat call.
 ///
 /// Contains only the fields needed for permission and ownership checks,
 /// keeping the struct small and cheap to clone.

--- a/crates/metadata/src/xattr_unix.rs
+++ b/crates/metadata/src/xattr_unix.rs
@@ -28,7 +28,7 @@ pub fn list_attributes(path: &Path, follow_symlinks: bool) -> io::Result<Vec<OsS
 
 /// Reads a single xattr value as raw bytes, or `Ok(None)` if missing.
 ///
-/// On macOS the read is routed through [`read_attribute_macos`] so resource
+/// On macOS the read is routed through the macOS variant so resource
 /// forks larger than the kernel's 64 MiB single-call ceiling are fetched in
 /// full via positioned `getxattr(2)` calls, matching upstream rsync's
 /// `sys_lgetxattr` (`lib/sysxattrs.c:60-80`). On other Unix platforms the


### PR DESCRIPTION
## Summary

Documentation and comment cleanup across the `metadata` crate. Every `.rs`
file under `crates/metadata/src/` was read; changes are strictly limited to
comment and doc lines. Zero code, signature, import, whitespace, or test
behaviour changed.

The crate was already in good shape (`#![deny(missing_docs)]` guarantees every
public item carries docs), so most files needed no edits. The value here is a
handful of stale docs that contradicted the code, plus a couple of small
restatement/duplicate-comment removals.

## Upstream references preserved

All `// upstream:` references are preserved verbatim.

- Before: 348 `upstream:` reference lines
- After: 348 `upstream:` reference lines
- Per-file counts identical to baseline; no `upstream:` line appears as an
  addition or removal in the diff.

## Stale-doc fixes (highest value)

- `stat_cache.rs` + `lib.rs` — docs claimed "statx support on Linux". The Linux
  readback was migrated off raw statx to the libc `lstat(2)` symbol (so
  `fakeroot`'s LD_PRELOAD wrapper is observed; see `stat_cache.rs:166-177` and
  `// upstream: syscall.c:do_lstat()`). Corrected both the module re-export doc
  and the `CachedMetadata` field doc to say `lstat`.
- `acl_windows/mod.rs` — module header claimed the SACL is always skipped and
  that protected-DACL bits and SACL handling were "follow-on work". The code
  has since added an opt-in `read_sddl_with_sacl` path and applies the protected
  (`P`) bit on DACLs (`sddl.rs:70,82`, `posix_map` protected-flag test).
  Rewrote the header to match current behaviour.
- `acl_noop.rs` + `acl_stub.rs` — `get_rsync_acl` docs claimed the function
  "reads the filesystem ACL", but these are the no-op/unsupported-platform
  fallbacks that synthesise an ACL from the mode bits (and return an empty ACL
  for a default-ACL request). Corrected to describe the actual synthesis.
- `acl_exacl/apply.rs` — the `mode` parameter was undocumented in the function's
  argument list; added its `///` entry describing how the mode reconstructs the
  stripped base entries and restores setuid/setgid/sticky bits.
- `xattr_unix.rs` — a doc referenced a phantom `read_attribute_macos` item (a
  broken intra-doc link; no such function exists). Replaced with plain prose
  ("the macOS variant"); no new intra-doc link introduced.

## Comment cleanup

- `special.rs` — removed a duplicated `try_into` narrow-`dev_t` explanation; kept
  the more informative variant (which also carries the clippy `useless_conversion`
  rationale).

## Orphan / dead files (noted, not modified)

Two files in the crate are not wired into the module tree and do not compile
into the crate. They were left untouched per the docs-only scope, but are worth
flagging for a future decision:

- `crates/metadata/src/chmod/comprehensive_tests.rs` — no `mod comprehensive_tests;`
  declaration in `chmod/mod.rs` (which declares only `apply`, `parse`, `spec`,
  `tests`) and no `include!` anywhere. Holds 8 `upstream:` references.
- `crates/metadata/src/apply_batch.rs` — `lib.rs` declares `mod apply;` but no
  `mod apply_batch;`. Its `BatchMetadataContext` is referenced only within the
  uncompiled file itself. Holds 3 `upstream:` references.

## Verification

- `cargo fmt --all -- --check` passes.
- Diff is comment/doc lines only across 8 files (`+24 / -16`); no code tokens,
  signatures, imports, `// SAFETY:` comments, or `// upstream:` lines altered.
- No new intra-doc links introduced (crate has
  `#![deny(rustdoc::broken_intra_doc_links)]`); one pre-existing broken link
  removed.
