### PR TITLE
docs(daemon): rustdoc/comment cleanup (roots + connection)

### DIFF
--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -171,7 +171,7 @@ impl DaemonConfigBuilder {
         self
     }
 
-    /// Supplies the arguments that should be forwarded to the daemon loop once implemented.
+    /// Supplies the arguments that should be forwarded to the daemon loop.
     #[must_use]
     pub fn arguments<I, S>(mut self, arguments: I) -> Self
     where


### PR DESCRIPTION
## Summary

Documentation-only cleanup of the daemon crate roots plus the connection
state machine. Scope: `crates/daemon/src/connection/**` and the top-level
`crates/daemon/src/*.rs` files (`async_listener`, `auth`, `cli`, `config`,
`daemon_stream`, `daemon.rs`, `error`, `systemd`, `test_env`, `tests.rs`,
`lib.rs`). The `daemon/` subdirectory and `tests/` chunk modules are out of
scope (handled separately).

Every in-scope `.rs` file was read comment-by-comment. Zero behavior change:
the diff touches a single doc-comment line and nothing else.

## Fix

- **`config.rs` — stale doc on `DaemonConfigBuilder::arguments`.** The comment
  read "Supplies the arguments that should be forwarded to the daemon loop
  once implemented." The daemon loop (`run_daemon`) is fully implemented and
  consumes `config.arguments()`, so "once implemented" is a leftover from an
  earlier stub era. Removed the trailing clause.

## Already clean (no churn)

The rest of the scoped surface was already in excellent shape and left
untouched:

- `lib.rs`, `connection/mod.rs`, `connection/state.rs` — module docs, the
  state-machine narrative, and the `transition()` const-context why-comment
  are all accurate. Public items fully `///`-documented.
- `auth.rs`, `daemon.rs`, `daemon_stream.rs`, `async_listener.rs`,
  `cli.rs`, `error.rs`, `systemd.rs`, `test_env.rs` — public items carry
  `///` docs; why/invariant/safety comments add value; no restatement,
  divider, debug, or commented-out code found.
- `tests.rs` — `include!` list with light navigational group labels; no
  public items and no stale docs.

## Upstream references preserved

All `// upstream:` references (`clientserver.c`, `authenticate.c`,
`compat.c`, `main.c`, `errcode.h`, `log.c`, `options.c`) are unchanged. The
diff contains no added or removed `upstream:` lines (verified before ==
after).

## Verification

- Confirmed the diff is comment/doc-only (`git diff --stat`: 1 file, 1
  line changed).
- `cargo fmt` reflows code, not doc comments; the edited line keeps the same
  `///` prefix, indentation, and stays well under 100 columns, so formatting
  is unaffected. The local toolchains lack the `rustfmt` component, so
  `cargo fmt --all -- --check` could not be run here; CI's fmt+clippy gate
  will confirm.
- No new intra-doc links introduced.
