### PR TITLE
docs(protocol): rustdoc/comment cleanup (wire)

### DIFF
--- a/crates/protocol/src/wire/compressed_token/zstd_codec/decoder.rs
+++ b/crates/protocol/src/wire/compressed_token/zstd_codec/decoder.rs
@@ -74,7 +74,6 @@ impl DeflateSink for ZstdDeflate {
     }
 
     fn decompress_into(&mut self, output: &mut Vec<u8>) -> io::Result<()> {
-        // Decompress the block.
         // upstream: token.c lines 846-863 (r_inflating state)
         let mut input_pos = 0;
 
@@ -121,6 +120,10 @@ impl DeflateSink for ZstdDeflate {
 }
 
 impl ZstdTokenDecoder {
+    /// Creates a zstd decoder with a fresh persistent decompression context.
+    ///
+    /// The `ZSTD_DCtx` lives for the whole transfer session and is never reset
+    /// between files; see the type-level documentation.
     pub(in crate::wire::compressed_token) fn new() -> io::Result<Self> {
         let decoder = ZstdRawDecoder::new()?;
         // upstream: token.c line 795 - out_buffer_size = ZSTD_DStreamOutSize() * 2
@@ -135,6 +138,7 @@ impl ZstdTokenDecoder {
         })
     }
 
+    /// Returns whether the decoder has received its first token.
     pub(in crate::wire::compressed_token) fn initialized(&self) -> bool {
         self.core.initialized
     }

--- a/crates/protocol/src/wire/compressed_token/zstd_codec/encoder.rs
+++ b/crates/protocol/src/wire/compressed_token/zstd_codec/encoder.rs
@@ -169,6 +169,11 @@ impl ZstdTokenEncoder {
         Ok(())
     }
 
+    /// Emits a block match token, flushing any pending literal data first.
+    ///
+    /// A literal region's run was already written by `send_literal`; the
+    /// remaining branches output the previous token run for the cases not
+    /// triggered by literals.
     pub(in crate::wire::compressed_token) fn send_block_match<W: Write>(
         &mut self,
         writer: &mut W,


### PR DESCRIPTION
## Summary

Documentation/comment-only cleanup across `crates/protocol/src/wire/**` (all 38 in-scope files, ~11k LoC). No logic or behavior changes. This subsystem is wire-critical, so every `// upstream:` reference and every byte-layout / varint / flag / wire-encoding comment was preserved verbatim.

## Zero-logic confirmation

- Diff touches only two files, adding three `///` doc comments and removing one redundant restatement comment (10 insertions, 1 deletion).
- No executable code changed. `git diff` contains no changes to any statement, signature, or constant.

## Upstream references: before == after

The 94 `// upstream:` references under `wire/` are byte-for-byte unchanged. Verified with `git diff` filtered to `upstream:` lines (none added or removed).

## Changes

`compressed_token/zstd_codec/decoder.rs`
- Added `///` on `ZstdTokenDecoder::new` (sole constructor previously undocumented; siblings all documented).
- Added `///` on `ZstdTokenDecoder::initialized`.
- Removed the redundant `// Decompress the block.` line that merely restated the function it sat in; the load-bearing `// upstream: token.c lines 846-863 (r_inflating state)` reference directly below it is kept.

`compressed_token/zstd_codec/encoder.rs`
- Added `///` on `ZstdTokenEncoder::send_block_match` (only public method in the file without a doc; derived from the existing inline explanation, no new upstream ref invented, backtick-only cross-reference to `send_literal`).

## Already clean (no changes needed)

The remaining 36 files were audited and left untouched:
- `mod.rs`, `signature.rs`, `vectored.rs`
- `compressed_token/{mod,encoder,decoder,step,zlib_codec,lz4_codec,tests,parity_tests}.rs`, `zstd_codec/{mod,tests}.rs`
- `delta/{mod,int_encoding,internal,token,types,tests}.rs`
- `file_entry/{mod,constants,flags,encode,tests}.rs`
- all 11 `file_entry_decode/*.rs`

Their comments are entirely load-bearing (upstream refs, wire/byte-layout notes, tricky-logic explanations) and all public items already carry `///` docs.

## Notes (out of scope, not edited)

- `delta/mod.rs:16` module doc states the end marker is `write_int(-1)`, whereas the code (`delta/token.rs:105`, `write_int(writer, 0)`) and the sibling module header (`delta/token.rs:7`) both state `write_int(0)`. This is a wire-encoding description, so it was deliberately left verbatim rather than "fixed" in a docs-only pass. Flagging for a maintainer to reconcile the module-level prose against the code and `token.rs`.

## Verification

- `rustfmt --check` clean on both changed files.
- clippy / doc lints deferred to CI.
