### PR TITLE
docs(transfer): rustdoc/comment cleanup (disk_commit)

### DIFF
--- a/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
+++ b/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
@@ -1,24 +1,24 @@
-// Parity validation: partial interrupt behavior must match upstream rsync.
-//
-// Upstream rsync's cleanup.c and receiver.c define the authoritative behavior
-// for what happens to temp files when a transfer is interrupted:
-//
-//   1. PartialMode::None (default): temp file is deleted on any interrupt.
-//   2. PartialMode::Partial (--partial): temp file is renamed to the final
-//      destination, and modtime is stamped to epoch (0). The mtime=0 stamp
-//      prevents --update from skipping the partial file on subsequent runs.
-//      upstream: cleanup.c:130-135, cleanup.c:174-178
-//   3. PartialMode::PartialDir (--partial-dir=DIR): temp file is moved to
-//      DIR/filename. No mtime=0 stamp. upstream: cleanup.c:105-115
-//
-// This test module validates the full behavioral matrix: 3 modes x 3 interrupt
-// types (Shutdown, Abort, channel Disconnect), plus edge cases for
-// CleanupManager integration and zero-byte partial suppression.
-//
-// upstream references:
-//   - cleanup.c:105-135  partial retention decision
-//   - cleanup.c:174-178  mtime=0 stamp for plain --partial
-//   - receiver.c:340-345 do_rename(partialptr, fname) on interrupt
+//! Parity validation: partial interrupt behavior must match upstream rsync.
+//!
+//! Upstream rsync's cleanup.c and receiver.c define the authoritative behavior
+//! for what happens to temp files when a transfer is interrupted:
+//!
+//!   1. PartialMode::None (default): temp file is deleted on any interrupt.
+//!   2. PartialMode::Partial (--partial): temp file is renamed to the final
+//!      destination, and modtime is stamped to epoch (0). The mtime=0 stamp
+//!      prevents --update from skipping the partial file on subsequent runs.
+//!      upstream: cleanup.c:130-135, cleanup.c:174-178
+//!   3. PartialMode::PartialDir (--partial-dir=DIR): temp file is moved to
+//!      DIR/filename. No mtime=0 stamp. upstream: cleanup.c:105-115
+//!
+//! This test module validates the full behavioral matrix: 3 modes x 3 interrupt
+//! types (Shutdown, Abort, channel Disconnect), plus edge cases for
+//! CleanupManager integration and zero-byte partial suppression.
+//!
+//! upstream references:
+//!   - cleanup.c:105-135  partial retention decision
+//!   - cleanup.c:174-178  mtime=0 stamp for plain --partial
+//!   - receiver.c:340-345 do_rename(partialptr, fname) on interrupt
 
 use std::fs;
 


### PR DESCRIPTION
## Summary

Documentation-only cleanup pass over `crates/transfer/src/disk_commit/**` (12 files, ~12.3k loc including tests). No logic or behavior change; the diff touches comments/docs only.

## What changed

The directory was already in excellent shape: every public item under `disk_commit` carries `///` rustdoc, every `// upstream:` reference and every why/invariant/safety comment (temp-file commit/rename, `--inplace`, `--direct-write`, fsync/defer, atomic-commit, sparse finalization, EXDEV fallback, partial retention) is intact, and there is no restatement, debug, divider, or commented-out cruft to remove.

The single fix:

- `tests_partial_interrupt_parity.rs` carried its file-level header (partial-interrupt behavioral matrix plus `cleanup.c`/`receiver.c` upstream references) as plain `//` comments. It is a true module file (declared via `mod` in `mod.rs`, not `include!()`), and every other module file in the directory uses `//!` for its header. Converted the header block from `//` to `//!` so the documentation actually renders as module docs and conforms to the directory convention. Text preserved verbatim.

## Zero-logic confirmation

- Diff is one file, 21 lines, marker-only (`//` -> `//!`).
- `// upstream:` reference count in scope: **82 before == 82 after** (verbatim).
- `cargo fmt --all -- --check` passes.

## Notes

- No orphan/dead `.rs` files found in scope.
- No stale docs contradicting code were found; all upstream references and invariants match the implementation.
- No new intra-doc links added (backtick-only, per existing convention).
