### PR TITLE
docs(engine): rustdoc/comment cleanup (concurrent_delta)

### DIFF
--- a/crates/engine/src/concurrent_delta/config.rs
+++ b/crates/engine/src/concurrent_delta/config.rs
@@ -17,10 +17,11 @@
 //! # Backwards compatibility
 //!
 //! The legacy fields `spill_threshold_bytes` and `spill_dir` were collapsed
-//! into [`SpillPolicy`]. The matching `with_spill_threshold` / `with_spill_dir`
-//! constructors plus the [`spill_threshold_bytes`](ConcurrentDeltaConfig::spill_threshold_bytes)
+//! into [`SpillPolicy`]. The [`spill_threshold_bytes`](ConcurrentDeltaConfig::spill_threshold_bytes)
 //! and [`spill_dir`](ConcurrentDeltaConfig::spill_dir) accessors are kept as
 //! deprecated shims that forward to [`spill_policy`](ConcurrentDeltaConfig::spill_policy).
+//! The `with_spill_threshold` / `with_spill_dir` constructors are not
+//! deprecated; they remain the supported way to populate the policy.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/engine/src/concurrent_delta/consumer/mod.rs
+++ b/crates/engine/src/concurrent_delta/consumer/mod.rs
@@ -197,7 +197,7 @@ impl DeltaConsumer {
     ///
     /// # Panics
     ///
-    /// Panics if `reorder_capacity` is zero and `bypass_reorder` is `false`.
+    /// Panics if `reorder_capacity` is zero.
     #[must_use]
     pub fn spawn(rx: WorkQueueReceiver, reorder_capacity: usize) -> Self {
         spawn_inner(

--- a/crates/engine/src/concurrent_delta/consumer/tests.rs
+++ b/crates/engine/src/concurrent_delta/consumer/tests.rs
@@ -10,7 +10,7 @@ use super::*;
 use crate::concurrent_delta::DeltaWork;
 use crate::concurrent_delta::work_queue;
 
-/// Helper: sends `count` whole-file work items with sequential sequence numbers.
+/// Helper: creates a bounded work queue sized to hold `count` items.
 fn spawn_producer(count: u32) -> (work_queue::WorkQueueSender, work_queue::WorkQueueReceiver) {
     work_queue::bounded_with_capacity(count.max(1) as usize)
 }

--- a/crates/engine/src/concurrent_delta/parallel_apply/drain.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/drain.rs
@@ -66,9 +66,9 @@ impl ParallelDeltaApplier {
         // Drop the BarrierState Arc before try_unwrap so DecrementGuard
         // clones are the only remaining strong references. After the
         // DG-3 split (BarrierState/SlotData), struct field drop order
-        // guarantees SlotHandle's barrier drops before its _decrement
-        // guard fires the Condvar notify - so by the time flush_workers
-        // returns, no worker holds a SlotData clone.
+        // guarantees SlotHandle's `data` payload clone drops before its
+        // _decrement guard fires the Condvar notify - so by the time
+        // flush_workers returns, no worker holds a SlotData clone.
         let SlotEntry { data, barrier } = entry;
         drop(barrier);
         let slot_data = Arc::try_unwrap(data).map_err(|still_shared| {

--- a/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
@@ -387,8 +387,12 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
         }
     }
 
-    /// Writes a tag-prefixed length-prefixed record to the spill file, opening
-    /// it lazily.
+    /// Writes the caller-supplied `header` followed by `payload` to the spill
+    /// file, opening it lazily.
+    ///
+    /// The header is opaque here: the per-item path passes a tag+length header
+    /// (`build_header`) while the whole-batch path passes a length-only
+    /// header, so this writer stays agnostic to the record framing.
     ///
     /// Returns the number of bytes written (always `header.len() + payload.len()`
     /// on success). All `write_all` calls obey the standard library contract

--- a/crates/engine/src/concurrent_delta/work_queue/limiter/config.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/limiter/config.rs
@@ -10,8 +10,8 @@ use super::AimdLimiter;
 ///
 /// Construct with [`LimiterConfig::new`], then chain setters and call
 /// [`LimiterConfig::build`] to produce an `AimdLimiter`. Sensible defaults
-/// match the design RFC: alpha=1, beta=1/2, min_limit=rayon thread count,
-/// max_limit=8x rayon thread count.
+/// match the design RFC: alpha=1, beta=1/2, min_limit=1,
+/// max_limit=8x initial_target.
 #[derive(Debug, Clone)]
 #[must_use]
 pub struct LimiterConfig {


### PR DESCRIPTION
## Summary

Documentation-only cleanup of `crates/engine/src/concurrent_delta/` (73 files, ~21.7k LoC). Every in-scope `.rs` file was read in full. No logic, behavior, signatures, string literals, or attributes were changed - the diff is comments/docstrings only.

The module tree was already in excellent shape. The valuable work was correcting six stale doc comments that contradicted the code.

## Stale-doc fixes

- **`config.rs`** - The "Backwards compatibility" note claimed the `with_spill_threshold` / `with_spill_dir` constructors were "deprecated shims". In the code only the `spill_threshold_bytes()` / `spill_dir()` accessors carry `#[deprecated]`; the constructors are the current supported API. Doc corrected to match.
- **`consumer/mod.rs`** - `DeltaConsumer::spawn` `# Panics` referenced a phantom `bypass_reorder` parameter that exists nowhere in the codebase. `spawn` always builds `ReorderMode::Bare`, and `ReorderBuffer::new` asserts `capacity > 0`, so the panic condition is simply "`reorder_capacity` is zero".
- **`consumer/tests.rs`** - `spawn_producer` doc said it "sends `count` work items"; it only sizes a bounded work queue (`bounded_with_capacity`). Doc corrected to what the helper does.
- **`parallel_apply/drain.rs`** - Field-drop-order comment named a non-existent `barrier` field on `SlotHandle` (its fields are `data` and `_decrement`). Corrected to "`data` payload clone drops before its `_decrement` guard fires the Condvar notify", matching the authoritative invariant in `handle.rs`.
- **`spill/buffer/spill.rs`** - `write_record` doc claimed all records are "tag-prefixed". The per-item path passes a tag+length header while the whole-batch path passes a length-only header; the writer is framing-agnostic. Doc corrected to describe the caller-supplied opaque header.
- **`work_queue/limiter/config.rs`** - `LimiterConfig` doc claimed `min_limit=rayon thread count, max_limit=8x rayon thread count`. `LimiterConfig::new` actually sets `min_limit=1` and `max_limit=8x initial_target`. Doc corrected to match code (and this file's own module-level doc, which was already correct).

## Upstream references

All 37 `upstream` mentions in scope (including the `receiver.c:recv_files()` / `receiver.c:receive_data()` / `compat.c:get_default_nonce` / `rsync.h` references and the `# Upstream Reference` sections) are preserved byte-for-byte. Verified `grep -rin upstream` before == after: identical.

## Notes

- All why/invariant/safety comments preserved verbatim: AIMD limiter control law and injectable-clock notes, work-queue backpressure/bounding rationale, SPSC/ArrayQueue and reorder high-water invariants, spill policy / RSS-threshold / ENOSPC-degradation rationale, `apply_batch` serial-write and SlotHandle/DecrementGuard release-race invariants.
- The injectable AIMD debounce clock docs (`rate.rs`, `limiter/tests/mod.rs`) were checked and already correctly describe the injectable-clock design - no fix needed.
- No new intra-doc links introduced (backtick-only in new/edited text); existing reference links left intact.
- `cargo fmt --all -- --check` passes.

## Zero behavior change

Diff touches 6 files, 16 insertions / 11 deletions, all within comment/docstring lines. No code tokens changed.
