### PR TITLE
docs(fast_io): rustdoc/comment cleanup (io_uring)

### DIFF
--- a/crates/fast_io/src/io_uring/buffer_ring/allocator.rs
+++ b/crates/fast_io/src/io_uring/buffer_ring/allocator.rs
@@ -222,8 +222,8 @@ fn maybe_warn_namespace_pressure(in_flight: u16) {
 ///   that future [`allocate`](Self::allocate) calls can reuse it.
 /// - Once the monotonic counter reaches `BGID_NAMESPACE_SIZE` (65 536)
 ///   and the free-list is empty, [`allocate`](Self::allocate) returns
-///   [`super::BufferRingError::BgidExhausted`] rather than wrapping and
-///   silently reusing a bgid still held by an active ring.
+///   [`BgidAllocError::Exhausted`] rather than wrapping and silently
+///   reusing a bgid still held by an active ring.
 ///
 /// Callers that create a bounded, fixed number of buffer rings per
 /// process may set [`super::BufferRingConfig::bgid`] directly with known
@@ -424,9 +424,8 @@ impl BgidAllocator {
     ///
     /// Includes both unallocated counter slots and free-list entries
     /// available for reuse. When this reaches zero,
-    /// [`allocate`](Self::allocate) returns
-    /// [`super::BufferRingError::BgidExhausted`]. The value may decrease
-    /// concurrently as other threads allocate.
+    /// [`allocate`](Self::allocate) returns [`BgidAllocError::Exhausted`].
+    /// The value may decrease concurrently as other threads allocate.
     pub fn remaining() -> u32 {
         let used = NEXT_BGID.load(Ordering::Relaxed).min(BGID_NAMESPACE_SIZE);
         let free = bgid_free_list()

--- a/crates/fast_io/src/io_uring/buffer_ring/mod.rs
+++ b/crates/fast_io/src/io_uring/buffer_ring/mod.rs
@@ -552,14 +552,12 @@ impl Drop for BufferRing {
             );
         }
 
-        // Unmap the ring descriptor region.
         // Safety: ring_ptr was returned by a successful mmap call and
         // ring_mmap_size is the same size passed to mmap.
         unsafe {
             libc::munmap(self.ring_ptr.cast(), self.ring_mmap_size);
         }
 
-        // Free the buffer memory.
         // Safety: buffers_ptr was allocated with buffers_layout and has
         // not been freed yet. The kernel no longer references these buffers
         // after unregister completes.

--- a/crates/fast_io/src/io_uring/data_reader.rs
+++ b/crates/fast_io/src/io_uring/data_reader.rs
@@ -1,7 +1,7 @@
 //! Sender/reader-side io_uring slurp wrapper (IUD-6 #2366).
 //!
-//! `IoUringFileReader` is a thin, opt-in entry point that mirrors the
-//! `RegisteredBufferPool`-backed `READ_FIXED` path already implemented by
+//! `IoUringFileReader` is a thin, opt-in entry point that delegates to the
+//! batched `IORING_OP_READ` slurp path already implemented by
 //! [`super::file_reader::IoUringReader`], but exposes a focused
 //! `open` / `read_into` / `read_to_end` surface for the engine's basis-file
 //! slurp dispatch.
@@ -20,9 +20,10 @@
 //!
 //! # Reuse, never duplicate
 //!
-//! All buffer registration and `READ_FIXED` submission goes through
-//! [`super::registered_buffers::RegisteredBufferGroup`] via the existing
-//! [`IoUringReader::read_all_batched`] pipeline. This module adds no new
+//! All submissions go through the existing
+//! [`IoUringReader::read_all_batched`] pipeline, which currently issues plain
+//! `IORING_OP_READ` SQEs against the per-thread ring (the `READ_FIXED`
+//! registered-buffer fast path returns with IUR-3.e). This module adds no new
 //! unsafe code.
 
 use std::io;
@@ -35,10 +36,9 @@ use super::file_reader::IoUringReader;
 
 /// Sender/reader-side io_uring file reader (IUD-6).
 ///
-/// Opens a file read-only and submits `IORING_OP_READ_FIXED` against a
-/// registered buffer pool via the shared [`IoUringReader`] machinery.
-/// Single-purpose API for basis-file slurp paths; for sender-source
-/// streaming through the `Read` trait, use
+/// Opens a file read-only and submits batched `IORING_OP_READ` SQEs via the
+/// shared [`IoUringReader`] machinery. Single-purpose API for basis-file
+/// slurp paths; for sender-source streaming through the `Read` trait, use
 /// [`super::file_reader::IoUringReader`] directly.
 pub struct IoUringFileReader {
     inner: IoUringReader,
@@ -47,23 +47,24 @@ pub struct IoUringFileReader {
 }
 
 impl IoUringFileReader {
-    /// Opens `path` read-only and prepares a registered-buffer io_uring ring.
+    /// Opens `path` read-only through the calling thread's per-thread io_uring
+    /// ring.
     ///
-    /// The ring is configured with `register_buffers = true` so the slurp path
-    /// uses `READ_FIXED` against the shared
-    /// [`RegisteredBufferGroup`](super::registered_buffers::RegisteredBufferGroup)
-    /// when the kernel honours registration. Registration failure transparently
-    /// falls back to plain `IORING_OP_READ` (still io_uring, just without the
-    /// pinned-page fast path) inside [`IoUringReader::read_all_batched`].
+    /// The default config still requests buffer registration, but the
+    /// per-thread [`IoUringReader`] honours that knob for sizing only: the
+    /// slurp path issues plain `IORING_OP_READ` SQEs inside
+    /// [`IoUringReader::read_all_batched`] until IUR-3.e re-introduces the
+    /// `READ_FIXED` fast path via the per-thread bgid lease.
     ///
     /// # Errors
     ///
     /// Returns an error if the file cannot be opened or the io_uring instance
     /// cannot be constructed (e.g. seccomp-blocked, out of memory).
     pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
-        // Default config already requests buffer registration; we surface the
-        // wrapper at this level so future tuning (page-aligned slurp sizing,
-        // SQPOLL opt-in) lives in one place.
+        // Default config requests buffer registration (currently inert on the
+        // per-thread ring; honoured for sizing only until IUR-3.e). We surface
+        // the wrapper at this level so future tuning (page-aligned slurp
+        // sizing, SQPOLL opt-in) lives in one place.
         let config = IoUringConfig::default();
         let inner = IoUringReader::open(path, &config)?;
         let size = inner.size();
@@ -86,9 +87,9 @@ impl IoUringFileReader {
         self.size == 0
     }
 
-    /// Reads up to `dst.len()` bytes at the current cursor position via
-    /// `IORING_OP_READ_FIXED` (registered buffer) when available, advancing
-    /// the cursor by the number of bytes read.
+    /// Reads up to `dst.len()` bytes at the current cursor position via a
+    /// single `IORING_OP_READ` SQE, advancing the cursor by the number of
+    /// bytes read.
     ///
     /// Returns `Ok(0)` at end of file.
     ///
@@ -105,13 +106,13 @@ impl IoUringFileReader {
     }
 
     /// Reads the entire file into a fresh `Vec<u8>` using the batched
-    /// `READ_FIXED` slurp path.
+    /// `IORING_OP_READ` slurp path.
     ///
     /// Internally delegates to
     /// [`IoUringReader::read_all_batched`](super::file_reader::IoUringReader::read_all_batched),
-    /// which submits up to `sq_entries` registered-buffer reads per
-    /// `submit_and_wait` and falls back to plain `IORING_OP_READ` when the
-    /// kernel rejects buffer registration.
+    /// which submits up to `sq_entries` reads per `submit_and_wait` against the
+    /// per-thread ring (the `READ_FIXED` registered-buffer fast path returns
+    /// with IUR-3.e).
     ///
     /// # Errors
     ///

--- a/crates/fast_io/src/io_uring/per_thread_ring.rs
+++ b/crates/fast_io/src/io_uring/per_thread_ring.rs
@@ -24,10 +24,11 @@
 //!
 //! # When NOT to use this
 //!
-//! - **One-shot kernel probes** (`linkat::probe`, `renameat2::probe`,
-//!   `statx::probe`) run once at startup and contribute zero hot-path
-//!   syscalls; per-thread storage would add a TLS slot per probe site for
-//!   no measurable gain. They stay on shared/single rings.
+//! - **One-shot kernel probes** (`linkat::linkat_supported`,
+//!   `renameat2::renameat2_supported`, `statx::statx_supported`) run once at
+//!   startup and contribute zero hot-path syscalls; per-thread storage would
+//!   add a TLS slot per probe site for no measurable gain. They stay on
+//!   shared/single rings.
 //! - **Disk-commit singleton** (`IoUringDiskBatch`) is already `!Send + !Sync`
 //!   and pinned to the disk-commit thread for the life of the session. No
 //!   second thread submits to it.

--- a/crates/fast_io/src/io_uring/registered_buffers/tests/drop_contract.rs
+++ b/crates/fast_io/src/io_uring/registered_buffers/tests/drop_contract.rs
@@ -114,9 +114,10 @@ fn panic_during_slot_use_unwinds_cleanly() {
     let _slot_again = group.checkout().expect("re-checkout after panic");
 }
 
-/// `unregister()` returns an error when the buffer set has already been
-/// released by closing the ring (or never registered). The error must
-/// be reported to the caller; it must NOT cause a panic or abort.
+/// A redundant `unregister()` - one whose buffer set the first
+/// `unregister()` already released against the same live ring - must
+/// surface any kernel error to the caller as a `Result`; it must NOT
+/// panic or abort.
 #[test]
 fn unregister_after_ring_closed_returns_error_or_ok() {
     let Some(ring) = try_ring(4) else { return };


### PR DESCRIPTION
## Summary

Documentation and comment cleanup scoped to `crates/fast_io/src/io_uring/**` (37 files, ~14.4k LoC). Comment/rustdoc only - zero behaviour change; the diff touches no logic, no unsafe blocks, and no intrinsics.

Every in-scope `.rs` file was read in full. Most were already clean (prior doc passes are evident: rich module rustdoc, documented public items, no dividers, no commented-out code). Five files carried genuinely stale or redundant documentation, corrected below.

## Fixes

- **`data_reader.rs`** (highest value): module, struct, `open`, `read_into`, and `read_to_end` docs all claimed `IORING_OP_READ_FIXED` submission against a registered buffer pool. The wrapper delegates entirely to `super::file_reader::IoUringReader`, which on the per-thread-ring topology has registration disabled and always issues plain `IORING_OP_READ` SQEs (the `READ_FIXED` fast path returns with IUR-3.e). Docs reworded to describe what the code actually does; the `IUR-3.e` roadmap caveat is retained.
- **`buffer_ring/allocator.rs`**: the `BgidAllocator` struct doc and `remaining()` doc said `allocate()` returns `BufferRingError::BgidExhausted`. `allocate()` returns `BgidAllocError::Exhausted` (as its own `# Errors` section already states); the `BufferRingError` conversion happens later, inside `new_with_allocator`. Corrected the named type at both sites.
- **`per_thread_ring.rs`**: the "When NOT to use this" note referenced non-existent `linkat::probe` / `renameat2::probe` / `statx::probe` helpers. Corrected to the real public entry points `linkat_supported` / `renameat2_supported` / `statx_supported`.
- **`buffer_ring/mod.rs`**: removed two restatement comments (`// Unmap the ring descriptor region.`, `// Free the buffer memory.`) that merely echoed the `munmap`/`dealloc` calls below them. The adjacent `// Safety:` comments are retained verbatim.
- **`registered_buffers/tests/drop_contract.rs`**: reworded a stale test doc that described releasing the buffer set "by closing the ring"; the test never closes the ring - it exercises a redundant second `unregister()` against the still-open ring.

## Preservation (before == after)

- **Upstream refs**: 4 `// upstream:` references, all unchanged (`shared_ring.rs:258`, `batching.rs:172`, `batching.rs:271`, `tests.rs:1062`).
- **`SAFETY:` blocks**: 68, unchanged. The two comments removed in `buffer_ring/mod.rs` sat *above* `// Safety:` blocks; the safety blocks themselves are intact.
- Kernel-version-floor (5.6+/5.19), SQPOLL, SEND_ZC, BGID, mmap-SIGBUS, shared-ring, and io_uring-opcode explanatory comments all left verbatim.

## Notes

- No new intra-doc links introduced. The corrected `BgidAllocError::Exhausted` link form already resolves elsewhere in the same file.
- Two dead-code observations were deliberately left untouched to keep this strictly comment/doc-only: an unused `_config` binding in `tests.rs` (`test_writer_buffering`) and the now-slightly-misleading test function name `unregister_after_ring_closed_returns_error_or_ok` (its doc was corrected; renaming an identifier is a code change).

## Verification

- `cargo fmt --all -- --check`: clean (Rust 1.88.0).
- Clippy/doc build are Linux-gated (this module is `cfg`-Linux io_uring code) and run in CI.
