### PR TITLE
docs(transfer): rustdoc/comment cleanup (generator)

### DIFF
--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -264,7 +264,6 @@ impl GeneratorContext {
             combined
         };
 
-        // Convert wire format to FilterChain
         if !combined.is_empty() {
             let (filter_set, merge_configs) = self.parse_received_filters(&combined)?;
             self.filter_chain = FilterChain::new(filter_set);
@@ -434,7 +433,6 @@ impl GeneratorContext {
                 RuleType::Protect => FilterRule::protect(reconstructed_pattern),
                 RuleType::Risk => FilterRule::risk(reconstructed_pattern),
                 RuleType::Clear => {
-                    // Clear rule removes all previous rules
                     rules.push(
                         FilterRule::clear()
                             .with_sides(wire_rule.sender_side, wire_rule.receiver_side),
@@ -744,12 +742,6 @@ mod tests {
         assert_eq!(config.filename(), ".rsync-filter");
     }
 
-    /// `:C .cvsignore` (FILTRULE_CVS_IGNORE on a DirMerge) must switch the
-    /// `DirMergeConfig` into CVS-mode so the chain parses each whitespace
-    /// token in `.cvsignore` as an exclude rule. Without this, lines like
-    /// `one-in-one-out` fail standard merge parsing and abort the walk.
-    /// Upstream's `:C` does NOT exclude the merge file itself; only the
-    /// explicit `e` modifier does.
     /// A `:w .filt` dir-merge arrives over the wire with `word_split=true`.
     /// The remote sender must carry that onto the `DirMergeConfig` so the
     /// per-directory file is tokenised on whitespace, matching the local path.
@@ -776,6 +768,12 @@ mod tests {
         assert!(config.no_prefixes());
     }
 
+    /// `:C .cvsignore` (FILTRULE_CVS_IGNORE on a DirMerge) must switch the
+    /// `DirMergeConfig` into CVS-mode so the chain parses each whitespace
+    /// token in `.cvsignore` as an exclude rule. Without this, lines like
+    /// `one-in-one-out` fail standard merge parsing and abort the walk.
+    /// Upstream's `:C` does NOT exclude the merge file itself; only the
+    /// explicit `e` modifier does.
     #[test]
     fn wire_rule_to_dir_merge_config_cvs_flag_enables_cvs_mode() {
         let mut wire_rule = make_dir_merge_wire_rule(".cvsignore");

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -100,8 +100,9 @@ impl GeneratorContext {
     /// file owners via `match_acl_ids()` (`uidlist.c:483-484`).
     ///
     /// Must run after the file list is sent (so the ACL cache is fully
-    /// populated) and before [`Self::send_id_lists`]. No-op under `numeric_ids`
-    /// or when the sender-side ACL cache is unavailable.
+    /// populated) and before [`Self::send_id_lists`]. No-op under `numeric_ids`,
+    /// when `--acls` is disabled, or when the sender-side ACL cache is
+    /// unavailable.
     #[cfg(unix)]
     pub(crate) fn collect_acl_id_mappings(&mut self) {
         use metadata::id_lookup::{lookup_group_name_cached, lookup_user_name_cached};
@@ -407,10 +408,12 @@ impl GeneratorContext {
 
     /// Emits itemize output when conditions are met.
     ///
-    /// In server mode (daemon/SSH), sends the formatted itemize string
-    /// (`"%i %n%L\n"`) as a MSG_INFO multiplexed message to the client.
-    /// In client mode, writes directly to the process stdout via the
-    /// itemize callback, matching upstream's `rwrite()` `FCLIENT` path.
+    /// In client mode, writes the formatted itemize string directly to
+    /// process stdout via the itemize callback, matching upstream's
+    /// `rwrite()` `FCLIENT` path. In server mode (daemon/SSH) this is a
+    /// no-op: the client-visible itemize row is owned by the receiver-side
+    /// generator instead, so forwarding a sender-direction row here would
+    /// duplicate every entry under `-ii`/`-vv`.
     ///
     /// Upstream `generator.c:582-583` emits when ANY of four OR'd conditions
     /// hold: significant flags set, `INFO_GTE(NAME, 2)`, `stdout_format_has_i


### PR DESCRIPTION
## Summary

Documentation and comment cleanup across the generator subtree of
`crates/transfer/src/generator/` (31 files, ~18k LoC). Comments and rustdoc
only - zero logic or behavior change. Code is treated as the source of truth.

All 31 in-scope files were read in full. The subtree was already in very good
shape: 29 of 31 files needed no changes. Two files had genuine fixes.

## Changes

### `filters.rs`
- Deleted two restatement comments that merely echoed the adjacent code
  (`// Convert wire format to FilterChain` above a `FilterChain::new(...)`
  call, and `// Clear rule removes all previous rules` above
  `FilterRule::clear()`).
- Fixed a misplaced `///` doc block: the CVS-mode (`:C .cvsignore`)
  explanation was concatenated onto the word-split test's doc while the CVS
  test it actually describes had no doc. Moved the CVS-mode text onto
  `wire_rule_to_dir_merge_config_cvs_flag_enables_cvs_mode`.

### `protocol_io.rs`
- Fixed a stale doc on `maybe_emit_itemize` (highest-value fix). The doc
  claimed server mode "sends the formatted itemize string as a MSG_INFO
  multiplexed message to the client." The code's non-client branch is a
  documented no-op (`let _ = writer;`) - the client-visible itemize row is
  owned by the receiver-side generator, so forwarding a sender-direction row
  here would duplicate every entry under `-ii`/`-vv`. Rewrote the doc to
  match the real behavior and its inline upstream annotation.
- Completed the `collect_acl_id_mappings` no-op list to include the
  `--acls`-disabled early-return branch.

## Verification

- Upstream references preserved byte-for-byte: 384 `upstream:` references in
  the subtree before and after; the `upstream:` lines in both touched files
  are identical between `HEAD` and the working tree.
- Diff is strictly comment/doc-only: 2 files changed, +15/-14, no executable
  code, string literals, attributes, or code whitespace touched.
- No new intra-doc `[links]` introduced; existing backtick-only conventions
  retained.
- `rustfmt --edition 2024 --check` passes on both edited files.

## Notes

- No orphan or dead files found in the subtree.
- The remaining 29 files already satisfied the cleanup rules (verbatim
  upstream citations, accurate `///` on public items, no restatement,
  banner, debug, or commented-out code) and were left untouched to avoid
  churn.
