### PR TITLE
docs(core): rustdoc/comment cleanup (version + small dirs)

### DIFF
--- a/crates/core/src/exit_code/codes.rs
+++ b/crates/core/src/exit_code/codes.rs
@@ -5,7 +5,7 @@
 ///
 /// # Upstream Reference
 ///
-/// Source: `errcode.h` in rsync 3.4.1
+/// Source: `errcode.h` in rsync 3.4.4
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(i32)]
 pub enum ExitCode {

--- a/crates/core/src/exit_code/mod.rs
+++ b/crates/core/src/exit_code/mod.rs
@@ -7,7 +7,7 @@
 //! # Upstream Reference
 //!
 //! Exit codes are defined in `errcode.h` and their string mappings are in `log.c`.
-//! This implementation maintains exact compatibility with rsync 3.4.1.
+//! This implementation maintains exact compatibility with rsync 3.4.4.
 //!
 //! # Examples
 //!

--- a/crates/core/src/version/constants.rs
+++ b/crates/core/src/version/constants.rs
@@ -51,7 +51,7 @@ pub const BUILD_TOOLCHAIN: &str = branding_build_toolchain();
 pub const SUBPROTOCOL_VERSION: u8 = 0;
 
 /// Upstream base version that the Rust implementation tracks.
-#[doc(alias = "3.4.1")]
+#[doc(alias = "3.4.4")]
 pub const UPSTREAM_BASE_VERSION: &str = workspace::UPSTREAM_VERSION;
 
 /// Full version string rendered by user-visible banners.


### PR DESCRIPTION
## Summary

Documentation-only cleanup of `crates/core/src/{version,auth,exit_code,signal,timeout}`.
The scoped subtrees were already in excellent shape - every public item carries
rustdoc, and the modules are free of restatement, divider, debug, or commented-out
code. The one substantive issue was a set of stale upstream-version references that
lagged behind the tracked upstream.

## Fixes

The workspace tracks upstream rsync **3.4.4** (`Cargo.toml: upstream_version = "3.4.4"`,
resolved into `workspace::UPSTREAM_VERSION`). Three docs still cited 3.4.1:

- `version/constants.rs` - `#[doc(alias = "3.4.1")]` on `UPSTREAM_BASE_VERSION`, whose
  value is `workspace::UPSTREAM_VERSION` (= "3.4.4"). The doc alias directly
  contradicted the constant's value; a doc search for the actual version missed it.
  Now `#[doc(alias = "3.4.4")]`.
- `exit_code/mod.rs` - module note "maintains exact compatibility with rsync 3.4.1"
  -> 3.4.4.
- `exit_code/codes.rs` - `ExitCode` source note "errcode.h in rsync 3.4.1" -> 3.4.4.

These leave the exit-code descriptions unchanged; the `errcode.h`/`log.c` strings are
stable across 3.4.1 and 3.4.4, so only the referenced version is corrected for
consistency with the workspace constant.

## Upstream references: before == after

Every `// upstream:` reference in scope is untouched. Notably
`exit_code/tests.rs:335` (`// upstream: errcode.h - verify all codes from rsync 3.4.1`)
is a verbatim upstream reference and was deliberately left as-is per the keep-verbatim
rule; it documents the historical assertion source rather than the tracked version.

## Notes

- No orphan/dead `.rs` files were found in scope.
- No `///` conversions or additions were needed - all public items already documented.
- No new intra-doc links introduced.

## Verification

- Diff is comment/doc-only across three files (3 lines changed), zero logic or
  behavior change; confirmed via `git diff`.
- `cargo fmt` is not runnable on the local macOS host (toolchain proxy limitation);
  the edits are in-line text/string substitutions of equal structure that do not
  affect rustfmt. CI `fmt+clippy` will confirm.
