### PR TITLE
docs: rustdoc/comment cleanup (matching, batch, bandwidth)

### DIFF
--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -1,11 +1,12 @@
 //! Bandwidth limit argument parsing compatible with upstream rsync.
 //!
 //! The parsers mirror the `--bwlimit` syntax accepted by upstream rsync's
-//! `util2.c:parse_size_arg()`. Supported features include binary and decimal
+//! `options.c:parse_size_arg()`. Supported features include binary and decimal
 //! suffixes (`K`, `M`, `G`, `T`, `P`, `B`, `iB`), fractional values with
-//! dot or comma separators, scientific notation, leading `+`/`-` signs,
-//! and optional `+1`/`-1` adjustment modifiers. A colon-separated burst
-//! component (`RATE:BURST`) is also handled for daemon configurations.
+//! dot or comma separators, leading `+`/`-` signs, and optional `+1`/`-1`
+//! adjustment modifiers. Scientific notation is rejected, matching upstream.
+//! A colon-separated burst component (`RATE:BURST`) is also handled for daemon
+//! configurations.
 
 use std::num::NonZeroU64;
 

--- a/crates/batch/src/lib.rs
+++ b/crates/batch/src/lib.rs
@@ -146,6 +146,8 @@
 //! - [`BatchError::Io`] - File system or I/O errors
 //! - [`BatchError::InvalidFormat`] - Malformed or incompatible batch files
 //! - [`BatchError::Unsupported`] - Features not yet implemented
+//! - [`BatchError::FlagMismatch`] - A batch stream flag cannot be reconciled
+//!   with the active options (a fatal `--iconv` mismatch)
 //!
 //! # Thread Safety
 //!

--- a/crates/batch/src/replay/mod.rs
+++ b/crates/batch/src/replay/mod.rs
@@ -7,20 +7,18 @@
 //!
 //! # Overview
 //!
-//! Replay proceeds in three phases:
+//! Replay first reads the batch header and reconciles its stream flags against
+//! the active options, then decodes the file list from the protocol flist wire
+//! format (matching the encoding produced during batch write). It then applies
+//! the entries in three phases:
 //!
-//! 1. **Header validation**: The batch header is read and the stream flags
-//!    bitmap is verified against the protocol version.
-//! 2. **File list decoding**: The protocol flist wire format is decoded using
-//!    [`protocol::flist::FileListReader`], matching the encoding produced by
-//!    [`protocol::flist::FileListWriter`] during batch write.
-//! 3. **Directory and metadata application**: Parent directories are created,
-//!    symlinks are materialized, and metadata (permissions, timestamps) is
-//!    applied to all entries.
-//!
-//! Delta replay for regular files is a separate concern - the batch body
-//! after the flist contains delta operations that reference basis files at
-//! the destination.
+//! 1. **Directories and symlinks**: Directories are created and symlinks are
+//!    materialized, and parent directories are ensured for regular files.
+//! 2. **Delta application**: Per-file delta operations from the batch body are
+//!    applied against the basis files at the destination.
+//! 3. **Metadata**: Permissions, timestamps, and ownership are applied to all
+//!    entries, with directories updated last so earlier file writes do not
+//!    disturb their directory timestamps.
 //!
 //! # Submodules
 //!

--- a/crates/matching/src/fuzzy/trace.rs
+++ b/crates/matching/src/fuzzy/trace.rs
@@ -7,7 +7,7 @@
 //!
 //! - `generator.c:1775` - `"fuzzy basis selected for %s: %s"` (level 1).
 //! - `generator.c:847`  - `"fuzzy size/modtime match for %s"` (level 2).
-//! - `generator.c:884`  - `"fuzzy distance for %s = %d.%05d"` (level 2).
+//! - `generator.c:897`  - `"fuzzy distance for %s = %d.%05d"` (level 2).
 
 use logging::debug_log;
 

--- a/crates/matching/src/index/bithash.rs
+++ b/crates/matching/src/index/bithash.rs
@@ -15,7 +15,7 @@
 //!
 //! - Bucket count `2^i` is chosen so that `2^i >= 4 * N` for `N` blocks,
 //!   clamped at a `2^7` minimum to keep the mask stable for tiny basis files.
-//! - Bit count is `2^(i + 1 + BITHASH_BITS)`, i.e. 8 times the bucket count
+//! - Bit count is `2^(i + BITHASH_BITS)`, i.e. 8 times the bucket count
 //!   (zsync's `BITHASHBITS = 3`), giving the canonical 1/8 set-bit density
 //!   and the matching 7/8 reject rate on uniform misses.
 //! - The bit count is capped at `2^28` (32 MiB of bits, 4 MiB of bytes) to
@@ -24,8 +24,8 @@
 /// Logarithm of the per-bucket bit budget.
 ///
 /// Mirrors zsync's `BITHASHBITS` macro from `librcksum/internal.h:83`.
-/// Each `2^i` bucket of the rsum hash table is paired with `2^(BITHASH_BITS+1)
-/// = 16` bithash bits, giving a 1/8 set-bit density at saturation.
+/// Each `2^i` bucket of the rsum hash table is paired with `2^BITHASH_BITS
+/// = 8` bithash bits, giving a 1/8 set-bit density at saturation.
 pub(super) const BITHASH_BITS: u32 = 3;
 
 /// Minimum bithash size in bits, expressed as a power-of-two exponent.

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -941,8 +941,8 @@ impl DeltaSignatureIndex {
     ///
     /// Returns the number of basis block indices yielded by the
     /// `find_all` iterator at the requested `(sum1, sum2)` key. Bench
-    /// harnesses use this to isolate the cache cost of the open-addressed
-    /// probe chain itself from the surrounding match pipeline.
+    /// harnesses use this to isolate the cache cost of the chain-based
+    /// probe walk itself from the surrounding match pipeline.
     #[must_use]
     pub fn lookup_probe(&self, sum1: u16, sum2: u16) -> usize {
         self.lookup.find_all(sum1, sum2).count()


### PR DESCRIPTION
## Summary

Documentation/comment cleanup across three crates: `matching`, `batch`, and
`bandwidth`. Every `.rs` file in each crate's `src/` was read and checked
against the code. This is a **docs-only** change - no code, control-flow,
signature, or behavior changes. `git diff` is entirely comment/doc text.

The highest-value target was stale docs that contradict the current code; all
fixes below are of that kind. No decorative dividers, commented-out code,
restatement, or debug comments were found in any of the three crates, so there
was nothing in those categories to remove.

## Per-crate

### bandwidth (upstream refs: 26 before == 26 after)

- `parse.rs` module doc: cited `util2.c:parse_size_arg()`, but the function
  lives in `options.c` (confirmed against upstream 3.4.4, and consistent with
  the crate's own `size_arg.rs` and the `// upstream: options.c` comment). Also
  claimed "scientific notation" is supported, but `parse_size_arg` explicitly
  rejects it (there is a dedicated `scientific_notation_is_rejected` test).
  Corrected both.

All other bandwidth files (`async_limiter`, `size_arg`, `limiter/*`,
`parse/components`) were already clean and accurate. Crate uses
`#![deny(missing_docs)]`, so public-item coverage is already 100%.

### batch (upstream refs: 147 before == 147 after)

- `lib.rs` error-handling overview listed only `Io`, `InvalidFormat`, and
  `Unsupported`, omitting the real, reachable `BatchError::FlagMismatch`
  variant (returned by `check_batch_flags` on a fatal `--iconv` mismatch).
  Added it.
- `replay/mod.rs` module overview described a "three phases" flow that no
  longer matched `replay()`: it folded directories+metadata into one phase and
  called delta replay "a separate concern", whereas the code runs delta
  application as its labeled Phase 2. Rewrote the overview to match the code
  (header + flist decode, then Phase 1 directories/symlinks, Phase 2 delta,
  Phase 3 metadata).

All other batch files (`error`, `script`, `writer`, `format/*`, `reader/*`,
the rest of `replay/*`) were already clean, with dense `// upstream: batch.c:*`
references verified against the code and preserved verbatim. Crate uses
`#![deny(missing_docs)]`, so public-item coverage is already 100%.

### matching (upstream refs: 76 before == 76 after)

- `index/bithash.rs`: the per-bucket bit-budget arithmetic carried a spurious
  `+1`. The doc wrote `2^(i + 1 + BITHASH_BITS)` while asserting "8 times the
  bucket count", and `2^(BITHASH_BITS+1) = 16` bits per bucket while asserting a
  "1/8 set-bit density". The code (`log2_bits_for` targets `32 * n_blocks`,
  i.e. `1 << (BITHASH_BITS + 2)`, and buckets are `>= 4N`) gives 8 bits per
  bucket = `2^BITHASH_BITS`, and total bits = 8 x bucket-count =
  `2^(i + BITHASH_BITS)`. Corrected both expressions so they agree with the
  code and with their own "8 times" / "1/8 density" clauses.
- `index/mod.rs`: `lookup_probe` doc described the compact lookup as
  "open-addressed", but it is chain-based (`compact_lookup.rs`: "intentionally
  chain-based rather than open-addressed"; `mod.rs`: "chained bucket table").
  Changed to "chain-based probe walk".
- `fuzzy/trace.rs`: the module-header reference for the `"fuzzy distance for
  %s = %d.%05d"` line cited `generator.c:884`, contradicting the sibling
  citations (`generator.c:896-899`) used by the same file's function doc and
  test for the identical string. The rprintf is at `generator.c:897` in
  upstream 3.4.4, so `:884` is stale; corrected to `:897` (within the sibling
  range).

All other matching files (`fuzzy/distance`, `fuzzy/mod`, `fuzzy/search`,
`index/builder`, `index/compact_lookup`, `index/matched_blocks`, `index/trace`,
`generator`, `ring_buffer`, `script`, `optimized_search`, `lib`) were already
clean and accurate.

## Notes (no action taken)

- `matching` does **not** use `#![deny(missing_docs)]`, but all genuinely
  public items in the reviewed files already carry `///` docs; the only
  undocumented items are `pub(crate)`/`pub(super)` internals, which are out of
  scope for the crate's doc policy.
- `crates/matching/src/optimized_search.rs` is a `pub mod` (declared in
  `lib.rs`) whose public types (`TagTable`, `BlockHashTable`, `BlockEntry`,
  `MatchStats`) have no references anywhere in the workspace outside the file
  and its tests - an unused public parallel implementation of the tag-table /
  hash-table matching that `index/` provides. It is reachable via `mod`, not an
  orphan; flagged only for awareness, **not** deleted.
- `#[allow(dead_code)]` remains on `bithash.rs` (`utilization`) and
  `compact_lookup.rs` (bench/test-only helpers); left untouched.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy -p {bandwidth,matching,batch} --all-targets --all-features
  --no-deps -- -D warnings`: pass (all three)
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D warnings" cargo doc -p
  {bandwidth,matching,batch} --no-deps --all-features`: pass (all three)
- `cargo run -p xtask -- no-placeholders`: zero findings in `matching`,
  `batch`, or `bandwidth` (this change introduces no placeholders); the tool's
  pre-existing repo-wide findings are all in unrelated crates.
- Upstream reference counts unchanged: matching 76 == 76, batch 147 == 147,
  bandwidth 26 == 26.
- Zero logic change confirmed: the full diff is comment/doc lines only.
