### PR TITLE
docs(protocol): rustdoc/comment cleanup (negotiation)

### DIFF
--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -11,8 +11,6 @@ use crate::ProtocolVersion;
 fn test_checksum_algorithm_roundtrip() {
     for &name in &["md4", "md5", "sha1", "xxh64", "xxh128"] {
         let algo = ChecksumAlgorithm::parse(name).unwrap();
-        // Note: xxh64 wire name is "xxh64" but as_str returns "xxh64"
-        // This is correct as the parsing accepts both "xxh" and "xxh64"
         let roundtrip = algo.as_str();
         let reparsed = ChecksumAlgorithm::parse(roundtrip).unwrap();
         assert_eq!(algo, reparsed, "roundtrip failed for {name}");
@@ -2787,8 +2785,8 @@ fn capability_fallback_xxh_alias_in_list() {
     // "xxh" should be recognized as xxh64
     let remote_list = "xxh md5";
     let result = choose_checksum_algorithm(remote_list, true).unwrap();
-    // Note: "xxh" parses to XXH64, but SUPPORTED_CHECKSUMS has "xxh64" not "xxh"
-    // So this should skip "xxh" and match "md5"
+    // "xxh" parses to XXH64, whose canonical name "xxh64" is in
+    // SUPPORTED_CHECKSUMS, so it matches before "md5".
     assert_eq!(result, ChecksumAlgorithm::XXH64);
 }
 

--- a/crates/protocol/src/negotiation/sniffer/mod.rs
+++ b/crates/protocol/src/negotiation/sniffer/mod.rs
@@ -1,3 +1,17 @@
+//! Buffered sniffer that reads from a transport until the negotiation style is
+//! known, owning the consumed prefix so callers can replay it into the legacy
+//! greeting parser.
+//!
+//! Wraps `NegotiationPrologueDetector` with an owned buffer and drain helpers.
+//! Split into focused submodules:
+//!
+//! - `core` - the `NegotiationPrologueSniffer` type and its accessors
+//! - `observe` - feeding transport bytes and reading until decided
+//! - `legacy` - reading and parsing the `@RSYNCD:` daemon greeting
+//! - `drain` - replaying the buffered prefix and remainder into caller storage
+//! - `util` - shared vectored-copy and capacity helpers
+//! - `async_read` - tokio `AsyncRead` support (feature `async`)
+
 mod core;
 mod drain;
 mod legacy;


### PR DESCRIPTION
## Summary

Documentation and comment cleanup pass over `crates/protocol/src/negotiation/` (36 files, ~12.6k LoC). Comments and rustdoc only - zero behavior change.

The negotiation module was already in excellent shape: every public item carries `///`, and inline `//` comments are explanatory or cite upstream `compat.c`/`checksum.c`/`io.c` line numbers. Only two genuine issues plus one consistency gap were found.

## Changes

**`sniffer/mod.rs`** - added a `//!` module doc. This was the only `mod.rs` in the subtree without one (`capabilities/mod.rs`, `detector/mod.rs`, and `sniffer/drain/mod.rs` all have module docs); the new doc summarises the sniffer's role and lists its submodules, matching the established pattern. Backtick-only type references, no intra-doc links.

**`capabilities/tests.rs`** - fixed two stale comments that contradicted the code they annotate:

- `capability_fallback_xxh_alias_in_list`: the comment claimed the test "should skip 'xxh' and match 'md5'", but the assertion is `ChecksumAlgorithm::XXH64`. Rewrote it to describe the real behaviour - `"xxh"` parses to `XXH64`, whose canonical name `"xxh64"` is in `SUPPORTED_CHECKSUMS`, so it matches before `"md5"`.
- `test_checksum_algorithm_roundtrip`: removed a nonsensical note whose two halves were identical (`... wire name is "xxh64" but as_str returns "xxh64"`) and which referenced `"xxh"` in a loop that only iterates canonical names. It added no value.

## Upstream references

All upstream citations preserved verbatim: 63 `// upstream:` references before and after this change (env_list 9, algorithms 3, negotiate 26, tests 24, observe 1). No capability/checksum-list/compress-list/`CF_*` flag comments were touched.

## Notes

- The 20 non-test source files (types, capabilities, detector, sniffer, drain) were already clean - no restatement, divider, debug, or commented-out-code comments, no `TODO`/`FIXME`.
- Four section-header comment paragraphs in `capabilities/tests.rs` carry bare `//` padding lines; they were left in place because the prose is informative (one cites upstream `compat.c` fallback behaviour) and trimming the padding would be cosmetic churn.
- No orphan or dead files found in scope.

## Verification

- `cargo fmt --all -- --check`: clean.
- Diff is comment/doc-only (16 insertions, 4 deletions across 2 files); no code lines changed.
- Upstream reference count unchanged (63 before == 63 after).
