### PR TITLE
docs(engine): correct walk default impl crate to jwalk

### DIFF
--- a/crates/engine/src/walk/mod.rs
+++ b/crates/engine/src/walk/mod.rs
@@ -2,13 +2,13 @@
 //!
 //! This module provides a [`DirectoryWalker`] trait that abstracts directory
 //! traversal, enabling different implementations (walkdir-based, custom, etc.)
-//! to be used interchangeably. The default implementation uses the `walkdir`
-//! crate for efficient, configurable directory walking.
+//! to be used interchangeably. The default implementation uses the `jwalk`
+//! crate for efficient, parallel directory walking.
 //!
 //! # Components
 //!
 //! - [`DirectoryWalker`]: Trait for directory traversal implementations
-//! - [`WalkdirWalker`]: Default implementation using the `walkdir` crate
+//! - [`WalkdirWalker`]: Default implementation using the `jwalk` crate
 //! - [`FilteredWalker`]: Decorator that applies filter rules with early pruning
 //! - [`WalkConfig`]: Builder for traversal configuration options
 //! - [`WalkEntry`]: Represents a single entry yielded during traversal
@@ -63,7 +63,7 @@ use std::path::Path;
 ///
 /// # Implementors
 ///
-/// - [`WalkdirWalker`]: Default implementation using the `walkdir` crate
+/// - [`WalkdirWalker`]: Default implementation using the `jwalk` crate
 pub trait DirectoryWalker: Iterator<Item = Result<WalkEntry, WalkError>> {
     /// Returns the root path being traversed.
     fn root(&self) -> &Path;


### PR DESCRIPTION
Comment/doc-only cleanup of the engine walk and roots-adjacent modules.

The `walk` module documentation described `WalkdirWalker` as using the
`walkdir` crate, but the implementation uses `jwalk` for parallel traversal
(see `walkdir_impl.rs`). This corrects the three stale doc references to
match the code.

No logic changes. All `upstream:` references preserved (before = after).
The remaining files in scope (async_io, util, delta, cleanup, error,
hardlink) were already accurate and needed no edits.
