### PR TITLE
docs(protocol): tidy iconv module comments

### DIFF
--- a/crates/protocol/src/iconv/mod.rs
+++ b/crates/protocol/src/iconv/mod.rs
@@ -1,7 +1,5 @@
 //! Character encoding conversion for rsync's --iconv=LOCAL,REMOTE option.
 //!
-//! Filename encoding conversion (iconv) for cross-platform rsync transfers.
-//!
 //! When the local and remote systems use different character encodings for
 //! filenames, this module handles the conversion. This mirrors rsync's `--iconv`
 //! option.
@@ -335,8 +333,6 @@ mod tests {
         let conv2 = EncodingConverter::identity();
         assert_eq!(conv1, conv2);
     }
-
-    // ---- Lossy conversion tests ----
 
     #[test]
     fn lossy_identity_passes_through_without_replacement() {


### PR DESCRIPTION
Comment/doc-only cleanup in `crates/protocol/src/{iconv,idlist,legacy,error_recovery,filters}`.

- Removed a duplicated module-summary line at the top of `iconv/mod.rs` (two summary sentences said the same thing).
- Removed a decorative divider comment (`// ---- Lossy conversion tests ----`) inside the `iconv` test module.

No logic changes: the diff touches comment lines only. All `upstream:` citations are preserved (0 net removed, 0 net added). The remaining files in scope were already accurate and needed no changes.
