### PR TITLE
docs(protocol): fix stale InvalidFnameCmpType doc

### DIFF
--- a/crates/protocol/src/fnamecmp.rs
+++ b/crates/protocol/src/fnamecmp.rs
@@ -222,9 +222,11 @@ impl TryFrom<u8> for FnameCmpType {
     }
 }
 
-/// Error returned when a wire byte does not correspond to a valid `FnameCmpType`.
+/// Error type for the fallible `TryFrom<u8>` conversion into `FnameCmpType`.
 ///
-/// Values 0x84-0xFF are undefined in the upstream protocol.
+/// The `from_wire` mapping is total - every byte decodes, with 0x83-0xFF
+/// mapping to `Fuzzy` offsets - so this error is never produced today. It is
+/// retained for the `TryFrom` contract and forward compatibility.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InvalidFnameCmpType(
     /// The invalid wire byte.


### PR DESCRIPTION
Comment/doc-only cleanup for the root-level files of `crates/protocol/src`.

Corrects a stale doc on `InvalidFnameCmpType`: it claimed wire bytes
0x84-0xFF are "undefined", but `FnameCmpType::from_wire` maps every byte
0x83-0xFF to a `Fuzzy` offset, so the error is never produced. The doc now
describes it accurately as the retained `TryFrom` error type.

No logic changes. All `upstream:` references preserved (0 removed, 0 added).
