### PR TITLE
docs(transfer): fix stale doc and trim debug narration comments

### DIFF
--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -459,10 +459,6 @@ impl PipelinedReceiver {
         self.redo_indices.len()
     }
 
-    /// Sends `Shutdown` and joins the disk thread.
-    ///
-    /// Implicitly drains remaining results. Returns the final accumulated
-    /// (bytes_written, metadata_errors).
     /// Drains accumulated warning/error messages from checksum verification and
     /// permission failures. Each is paired with the upstream `rwrite()` message
     /// code so the caller routes it through the matching multiplex frame:

--- a/crates/transfer/src/reorder_buffer/tests/metrics.rs
+++ b/crates/transfer/src/reorder_buffer/tests/metrics.rs
@@ -141,9 +141,7 @@ fn queue_depth_tracks_buffered_count() {
     buf.insert(4, "e").unwrap();
     assert_eq!(buf.metrics().current_depth, 3);
 
-    // Insert head - drains 0 items since 0 is missing, but seq 3 is
-    // head-adjacent. Actually next_expected is 0, so inserting 3,5,4
-    // leaves the head at 0. Nothing drains.
+    // Head (0) never arrived, so nothing drains; depth stays at 3.
     assert_eq!(buf.metrics().current_depth, 3);
     assert_eq!(buf.metrics().current_depth, buf.buffered_count() as u64);
 }

--- a/crates/transfer/src/reorder_buffer/tests/mod.rs
+++ b/crates/transfer/src/reorder_buffer/tests/mod.rs
@@ -79,10 +79,7 @@ fn window_advancement_opens_new_slots() {
     // Fill 4, 5, 6 to drain through 7.
     let d = buf.insert(4, 'e').unwrap();
     assert_eq!(d, vec!['e']);
-    // 4 drained, next_expected=5, but 5 not present - empty.
-    // Wait, 4 drains immediately since next_expected=4 and item 4 arrives.
-    // Actually insert(4) sees next_expected=4, inserts, drains 4 (only 4 consecutive).
-    // next_expected becomes 5. 5 not in buffer. Returns ['e'].
+    // insert(4) fills the head: drains only 4 (5 is absent), next_expected = 5.
 
     let d = buf.insert(5, 'f').unwrap();
     assert_eq!(d, vec!['f']);
@@ -122,8 +119,7 @@ fn window_remaining_tracks_capacity() {
     buf.insert(3, "y").unwrap();
     assert_eq!(buf.window_remaining(), 2);
 
-    // Fill gap - drains 0, 1 not present, so only 2, 3 stay buffered.
-    // Actually 0 is not in buffer either, so nothing drains.
+    // Head (0) never arrived, so nothing drains; 2 and 3 stay buffered.
     assert_eq!(buf.buffered_count(), 2);
 }
 


### PR DESCRIPTION
Comment/doc-only cleanup across the transfer mid-tier subsystems (pipeline, reader, writer, reorder_buffer, setup, shared, transfer_ops).

- pipeline/receiver.rs: remove a stale copy-pasted doc header on `drain_warnings` that described shutdown/join semantics the function does not perform.
- reorder_buffer/tests/{mod,metrics}.rs: replace self-correcting "Wait... Actually..." debug narration with single accurate explanations of the drain behavior.

No logic, signature, or control-flow changes. All `upstream:` citations preserved (removed 0, added 0).
