### PR TITLE
docs(fast_io): correct stale doc comments in root modules

### DIFF
--- a/crates/fast_io/src/copy_file_range.rs
+++ b/crates/fast_io/src/copy_file_range.rs
@@ -12,7 +12,8 @@
 //! # Performance Characteristics
 //!
 //! - For files < 64KB: Uses read/write directly (lower syscall overhead)
-//! - For files >= 64KB: Attempts io_uring, then `copy_file_range`, then read/write
+//! - For files 64KB to 256KB: Attempts `copy_file_range`, then read/write
+//! - For files >= 256KB: Attempts io_uring, then `copy_file_range`, then read/write
 //! - Fallback path uses 256KB buffer for efficient bulk transfer
 //!
 //! # Example

--- a/crates/fast_io/src/io_uring_ops.rs
+++ b/crates/fast_io/src/io_uring_ops.rs
@@ -493,7 +493,6 @@ mod hard_link_convenience_tests {
 
         hard_link(&src, &dst).unwrap();
 
-        // Overwrite via source path.
         fs::write(&src, b"modified").unwrap();
 
         // Read through destination - should see the modification.

--- a/crates/fast_io/src/kqueue_stub.rs
+++ b/crates/fast_io/src/kqueue_stub.rs
@@ -139,7 +139,7 @@ impl KqueueLoop {
         ))
     }
 
-    /// Stub - always returns an empty `Vec`.
+    /// Stub - always returns `Unsupported`.
     ///
     /// # Errors
     ///
@@ -151,7 +151,7 @@ impl KqueueLoop {
         ))
     }
 
-    /// Stub - always returns an empty `Vec`.
+    /// Stub - always returns `Unsupported`.
     ///
     /// # Errors
     ///

--- a/crates/fast_io/src/lsm.rs
+++ b/crates/fast_io/src/lsm.rs
@@ -89,8 +89,7 @@ pub fn read_active_lsms_from(path: &str) -> Option<Vec<String>> {
 }
 
 /// Returns `true` when the running kernel exposes at least one mandatory
-/// access control LSM (SELinux, AppArmor, Smack, Tomoyo, lockdown, Yama,
-/// or BPF-LSM).
+/// access control LSM (SELinux, AppArmor, Smack, or Tomoyo).
 ///
 /// The result is computed once on first call and cached for the process
 /// lifetime via [`OnceLock`]; subsequent calls are a single atomic load.

--- a/crates/fast_io/src/macos_io.rs
+++ b/crates/fast_io/src/macos_io.rs
@@ -460,8 +460,6 @@ pub fn open_sequential_read(path: &Path) -> io::Result<std::fs::File> {
 /// [`MacosWriter::is_nocache_enabled`] to check the tracked state instead.
 #[cfg(target_os = "macos")]
 pub fn is_nocache_set(_file: &std::fs::File) -> bool {
-    // F_NOCACHE is a set-only fcntl on macOS; there is no corresponding
-    // query command. The MacosWriter tracks this state internally.
     false
 }
 


### PR DESCRIPTION
Comment/doc-only cleanup of root-level `fast_io` source files (basenames a-m plus `lib.rs`). No logic, signature, or control-flow changes.

- Corrected stale rustdoc: `copy_file_range` io_uring threshold (256KB, not 64KB), `kqueue_stub` stubs return `Unsupported` (not an empty `Vec`), `lsm` mandatory-LSM list now matches `MANDATORY_LSM_NAMES`.
- Removed a restatement comment (`io_uring_ops`) and a duplicate body comment (`macos_io`).

All upstream references preserved verbatim; backtick-only doc spans.
