### PR TITLE
docs(transfer): drop echo comments and dividers in root/tests

### DIFF
--- a/crates/transfer/src/compressed_reader.rs
+++ b/crates/transfer/src/compressed_reader.rs
@@ -118,10 +118,8 @@ mod tests {
     fn decompress_round_trip_zlib() {
         let original = b"test data that should be compressed and decompressed";
 
-        // Compress the data first
         let compressed = compress_to_vec(original, CompressionLevel::Default).unwrap();
 
-        // Now decompress using CompressedReader
         let cursor = Cursor::new(compressed);
         let mut reader = CompressedReader::new(cursor, CompressionAlgorithm::Zlib).unwrap();
 
@@ -134,10 +132,8 @@ mod tests {
     fn decompress_multiple_reads() {
         let original = b"first chunk second chunk third chunk";
 
-        // Compress the data first
         let compressed = compress_to_vec(original, CompressionLevel::Default).unwrap();
 
-        // Decompress using multiple read calls
         let cursor = Cursor::new(compressed);
         let mut reader = CompressedReader::new(cursor, CompressionAlgorithm::Zlib).unwrap();
 
@@ -156,13 +152,10 @@ mod tests {
 
     #[test]
     fn decompress_large_data() {
-        // Create large data that will require multiple internal reads
         let original = vec![b'x'; 8192];
 
-        // Compress the data first
         let compressed = compress_to_vec(&original, CompressionLevel::Fast).unwrap();
 
-        // Decompress
         let cursor = Cursor::new(compressed);
         let mut reader = CompressedReader::new(cursor, CompressionAlgorithm::Zlib).unwrap();
 

--- a/crates/transfer/tests/empty_file_handling.rs
+++ b/crates/transfer/tests/empty_file_handling.rs
@@ -22,11 +22,9 @@ fn empty_file_sparse_write_produces_zero_position() {
     let mut state = SparseWriteState::new();
     let mut cursor = Cursor::new(Vec::new());
 
-    // Write empty data
     let result = state.write(&mut cursor, &[]).unwrap();
     assert_eq!(result, 0);
 
-    // Finish should produce position 0
     let pos = state.finish(&mut cursor).unwrap();
     assert_eq!(pos, 0);
 }
@@ -35,7 +33,6 @@ fn empty_file_sparse_write_produces_zero_position() {
 fn empty_file_checksum_verification_md5() {
     let mut verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::MD5);
 
-    // Update with empty data
     verifier.update(&[]);
 
     // Finalize should produce valid MD5 of empty string
@@ -55,7 +52,6 @@ fn empty_file_checksum_verification_md5() {
 fn empty_file_checksum_verification_xxh64() {
     let mut verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::XXH64);
 
-    // Update with empty data
     verifier.update(&[]);
 
     // Finalize should produce valid XXH64 of empty input
@@ -67,7 +63,6 @@ fn empty_file_checksum_verification_xxh64() {
 fn empty_file_checksum_verification_xxh3() {
     let mut verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::XXH3);
 
-    // Update with empty data
     verifier.update(&[]);
 
     let mut buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
@@ -78,7 +73,6 @@ fn empty_file_checksum_verification_xxh3() {
 fn empty_file_checksum_verification_sha1() {
     let mut verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::SHA1);
 
-    // Update with empty data
     verifier.update(&[]);
 
     let mut buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
@@ -98,10 +92,8 @@ fn sparse_state_empty_write_then_finish() {
     let mut state = SparseWriteState::new();
     let mut cursor = Cursor::new(vec![0u8; 100]);
 
-    // Write nothing
     state.write(&mut cursor, &[]).unwrap();
 
-    // Finish
     let pos = state.finish(&mut cursor).unwrap();
     assert_eq!(pos, 0, "empty write should result in position 0");
 }
@@ -111,7 +103,6 @@ fn sparse_state_multiple_empty_writes() {
     let mut state = SparseWriteState::new();
     let mut cursor = Cursor::new(vec![0u8; 100]);
 
-    // Multiple empty writes
     for _ in 0..10 {
         state.write(&mut cursor, &[]).unwrap();
     }
@@ -125,13 +116,10 @@ fn sparse_state_empty_then_data_then_empty() {
     let mut state = SparseWriteState::new();
     let mut cursor = Cursor::new(vec![0u8; 100]);
 
-    // Empty write
     state.write(&mut cursor, &[]).unwrap();
 
-    // Write some data
     state.write(&mut cursor, b"hello").unwrap();
 
-    // Another empty write
     state.write(&mut cursor, &[]).unwrap();
 
     let pos = state.finish(&mut cursor).unwrap();
@@ -143,19 +131,16 @@ fn empty_file_creation_via_sparse_state() {
     let temp = tempdir().expect("tempdir");
     let file_path = temp.path().join("empty.txt");
 
-    // Create file through sparse state
     let file = File::create(&file_path).expect("create file");
     let mut state = SparseWriteState::new();
 
     // Use BufWriter to get a seekable writer
     let mut writer = std::io::BufWriter::new(file);
 
-    // Write empty content
     state.write(&mut writer, &[]).expect("write empty");
     state.finish(&mut writer).expect("finish");
     writer.flush().expect("flush");
 
-    // Verify file exists and is empty
     let metadata = fs::metadata(&file_path).expect("metadata");
     assert_eq!(metadata.len(), 0, "file should be empty");
 }
@@ -311,7 +296,6 @@ fn simulate_empty_to_nonempty_transfer() {
     let mut state = SparseWriteState::new();
     let mut writer = std::io::BufWriter::new(file);
 
-    // Write empty content
     state.write(&mut writer, &[]).expect("write empty");
     state.finish(&mut writer).expect("finish");
     writer.flush().expect("flush");

--- a/crates/transfer/tests/sec_1_n_legitimate_symlinks_interop.rs
+++ b/crates/transfer/tests/sec_1_n_legitimate_symlinks_interop.rs
@@ -126,12 +126,10 @@ fn assert_outcome_is_symlink(outcome: &LstatOutcome, ctx: &str) {
     }
 }
 
-// ----------------------------------------------------------------------
 // Scenario 1: Plain relative symlink.
 // SAFETY invariant: a relative-target symlink lands on disk with its
 // target text preserved verbatim, and the sandbox-anchored stat reports
 // the symlink itself (not the file it points at).
-// ----------------------------------------------------------------------
 
 #[test]
 fn scenario_1_plain_relative_symlink_preserved_verbatim() {
@@ -163,14 +161,12 @@ fn scenario_1_plain_relative_symlink_preserved_verbatim() {
     );
 }
 
-// ----------------------------------------------------------------------
 // Scenario 2: Absolute symlink.
 // SAFETY invariant: an absolute-target symlink lands on disk verbatim,
 // even when the target points outside the destination tree. Without
 // `--copy-unsafe-links`, rsync preserves the symlink rather than
 // dereferencing it; the sandbox-anchored stat reports the symlink
 // itself.
-// ----------------------------------------------------------------------
 
 #[test]
 fn scenario_2_absolute_symlink_preserved_verbatim() {
@@ -196,12 +192,10 @@ fn scenario_2_absolute_symlink_preserved_verbatim() {
     );
 }
 
-// ----------------------------------------------------------------------
 // Scenario 3: Symlink to directory.
 // SAFETY invariant: a symlink to a directory lands as a symlink and
 // the underlying directory contents land once as regular files - the
 // receiver does not duplicate them through the symlink.
-// ----------------------------------------------------------------------
 
 #[test]
 fn scenario_3_symlink_to_directory_preserved_with_unique_contents() {
@@ -246,12 +240,10 @@ fn scenario_3_symlink_to_directory_preserved_with_unique_contents() {
     );
 }
 
-// ----------------------------------------------------------------------
 // Scenario 4: Broken symlink.
 // SAFETY invariant: a symlink whose target does not exist lands as a
 // symlink. The sandbox-anchored stat reports the symlink (not ENOENT
 // from following it) and the receiver does not fail.
-// ----------------------------------------------------------------------
 
 #[test]
 fn scenario_4_broken_symlink_preserved_without_follow_error() {
@@ -289,12 +281,10 @@ fn scenario_4_broken_symlink_preserved_without_follow_error() {
     );
 }
 
-// ----------------------------------------------------------------------
 // Scenario 5: Symlink chain `a -> b -> c -> file.txt`.
 // SAFETY invariant: every link in the chain lands verbatim. The
 // receiver does not flatten the chain or resolve any link to its
 // terminal target.
-// ----------------------------------------------------------------------
 
 #[test]
 fn scenario_5_symlink_chain_preserved_link_by_link() {
@@ -342,14 +332,12 @@ fn scenario_5_symlink_chain_preserved_link_by_link() {
     );
 }
 
-// ----------------------------------------------------------------------
 // Scenario 6: Hardlink siblings plus a symlink pointing at one of them.
 // SAFETY invariant: with `-aH`, the hardlink relationship between
 // `hl1`/`hl2` is preserved (same dev/ino) AND the symlink `sl -> hl1`
 // is preserved as a symlink. The sandbox-anchored stat used by the
 // receiver's hardlink quick-check correctly distinguishes the symlink
 // leaf from its target inode.
-// ----------------------------------------------------------------------
 
 #[test]
 fn scenario_6_hardlink_pair_with_symlink_preserved() {

--- a/crates/transfer/tests/wire_format_generator.rs
+++ b/crates/transfer/tests/wire_format_generator.rs
@@ -191,7 +191,6 @@ impl WireFormatGenerator {
             self.buffer.write_all(&[primary_flags])?;
         }
 
-        // Write name
         if same_len > 0 {
             self.buffer.write_all(&[same_len as u8])?;
         }
@@ -204,15 +203,12 @@ impl WireFormatGenerator {
 
         self.buffer.write_all(suffix)?;
 
-        // Write size (varint30)
         self.write_varint30(entry.size as u32)?;
 
-        // Write mtime if different
         if entry.mtime != self.prev_mtime {
             self.write_varlong4(entry.mtime)?;
         }
 
-        // Write mode if different
         if entry.mode != self.prev_mode {
             if self.config.protocol.0 >= 30 {
                 self.write_varint(entry.mode as i32)?;
@@ -221,14 +217,12 @@ impl WireFormatGenerator {
             }
         }
 
-        // Write symlink target if present
         if let Some(ref target) = entry.link_target {
             let target_bytes = target.as_bytes();
             self.write_varint30(target_bytes.len() as u32)?;
             self.buffer.write_all(target_bytes)?;
         }
 
-        // Update state for next entry
         self.prev_name = name_bytes.to_vec();
         self.prev_mode = entry.mode;
         self.prev_mtime = entry.mtime;
@@ -321,7 +315,6 @@ pub fn generate_nested_directories(depth: usize, files_per_dir: usize) -> Vec<u8
     let mut path = String::new();
 
     for d in 0..depth {
-        // Write directory entry
         if d > 0 {
             path.push('/');
         }
@@ -330,7 +323,6 @@ pub fn generate_nested_directories(depth: usize, files_per_dir: usize) -> Vec<u8
         let dir_entry = TestFileEntry::dir(&path);
         writer.write_entry(&dir_entry).expect("write dir");
 
-        // Write files in this directory
         for f in 0..files_per_dir {
             let file_path = format!("{path}/file{f}.txt");
             let file_entry = TestFileEntry::file(file_path, 100);


### PR DESCRIPTION
Comment/doc-only cleanup of the `transfer` crate root-level source files and
integration tests (no subdirectories). Removes pure restatement comments that
narrate the immediately-following call and decorative divider lines.

Zero logic changes: diff is 43 comment/blank line deletions across 4 files.
All `upstream:` source citations preserved verbatim (removed 0 / added 0).
