### PR TITLE
docs(fast_io): fix stale statx/io_uring docs, drop restatements

### DIFF
--- a/crates/fast_io/src/status.rs
+++ b/crates/fast_io/src/status.rs
@@ -25,8 +25,8 @@ use crate::splice::is_splice_available;
 
 /// Reason io_uring is restricted or unavailable on this system.
 ///
-/// Returned by [`detect_io_uring_restriction`]. The variants map onto the
-/// five outcomes of the startup probe in `io_uring::config` but
+/// Returned by [`detect_io_uring_restriction`]. The variants cover every
+/// compile-time and runtime outcome of the io_uring availability check and
 /// are exposed as a public enum so callers (CLI `--io-uring-status`,
 /// daemon log) can act on them without parsing strings.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/fast_io/src/stdio_blocking.rs
+++ b/crates/fast_io/src/stdio_blocking.rs
@@ -23,9 +23,8 @@ use std::io;
 /// they match upstream rsync's blocking-I/O contract.
 ///
 /// On Unix this calls `fcntl(F_GETFL)` and `fcntl(F_SETFL)` to clear the
-/// `O_NONBLOCK` bit on FDs 0 and 1. The call is idempotent: if the flag is
-/// already cleared, the second `fcntl` is a no-op from the kernel's
-/// perspective.
+/// `O_NONBLOCK` bit on FDs 0 and 1. The call is idempotent: if `F_GETFL`
+/// shows the flag is already cleared, it returns without issuing `F_SETFL`.
 ///
 /// On non-Unix platforms this returns `Ok(())` immediately.
 ///

--- a/crates/fast_io/src/syscall_batch.rs
+++ b/crates/fast_io/src/syscall_batch.rs
@@ -1,8 +1,8 @@
 //! Batched metadata syscall operations with dual-path runtime selection.
 //!
 //! This module provides batched metadata operations that reduce syscall overhead when
-//! processing many files. It uses Linux's `statx()` syscall for more efficient metadata
-//! retrieval and groups operations for improved cache locality.
+//! processing many files by grouping operations of the same type for improved cache
+//! locality.
 //!
 //! # Dual-Path Strategy
 //!
@@ -15,8 +15,8 @@
 //!
 //! # Platform Support
 //!
-//! - **Linux**: Uses `statx()` for improved metadata operations in batched path
-//! - **Other Unix**: Batched path uses standard library calls with grouping optimization
+//! - **Linux**: Confirms accessibility via `statx()`, then materializes metadata through the standard library
+//! - **Other Unix**: Uses standard library calls with grouping optimization
 //! - **Non-Unix (Windows)**: Portable fallbacks - `filetime` crate for timestamps,
 //!   readonly attribute mapping for permissions
 //!
@@ -240,8 +240,8 @@ fn execute_single_op(op: &MetadataOp) -> MetadataResult {
 
 /// Stat a file using the best available syscall.
 ///
-/// On Linux, uses `statx()` for improved performance.
-/// On other platforms, uses standard library calls.
+/// On Linux, tries `try_statx` first and falls back to the standard library.
+/// On other platforms, uses standard library calls directly.
 #[cfg(target_os = "linux")]
 fn stat_file(path: &Path, follow_symlinks: bool) -> io::Result<fs::Metadata> {
     match try_statx(path, follow_symlinks) {
@@ -266,9 +266,10 @@ fn stat_file(path: &Path, follow_symlinks: bool) -> io::Result<fs::Metadata> {
     }
 }
 
-/// Try to use statx syscall for improved performance.
+/// Confirm a path's accessibility with `statx()`, then materialize `Metadata`
+/// via the standard library (no public constructor accepts statx output).
 ///
-/// Returns metadata if successful, otherwise returns an error to trigger fallback.
+/// Returns metadata on success, otherwise an error to trigger the fallback.
 #[cfg(target_os = "linux")]
 fn try_statx(path: &Path, follow_symlinks: bool) -> io::Result<fs::Metadata> {
     use rustix::fs::{AtFlags, StatxFlags};
@@ -299,7 +300,9 @@ fn try_statx(path: &Path, follow_symlinks: bool) -> io::Result<fs::Metadata> {
 
 /// Set file times.
 ///
-/// Uses `filetime` crate equivalent functionality via std::fs.
+/// On Unix this calls `utimensat(2)` directly; on non-Unix platforms it uses
+/// the `filetime` crate. A `None` atime or mtime leaves that timestamp
+/// unchanged.
 fn set_file_times(
     path: &Path,
     atime: Option<SystemTime>,
@@ -342,7 +345,8 @@ fn set_file_times(
     }
 }
 
-/// Convert SystemTime to libc::timespec.
+/// Convert an optional `SystemTime` to a `libc::timespec`, mapping `None` to
+/// `UTIME_OMIT` so the corresponding timestamp is left unchanged.
 #[cfg(unix)]
 fn timespec_from_option(time: Option<SystemTime>) -> libc::timespec {
     match time {
@@ -363,7 +367,6 @@ fn timespec_from_option(time: Option<SystemTime>) -> libc::timespec {
     }
 }
 
-/// Set file permissions.
 #[cfg(unix)]
 fn set_file_permissions(path: &Path, mode: u32) -> io::Result<()> {
     use std::os::unix::fs::PermissionsExt;

--- a/crates/fast_io/src/zero_detect.rs
+++ b/crates/fast_io/src/zero_detect.rs
@@ -173,7 +173,6 @@ unsafe fn find_first_nonzero_avx2_inner(buf: &[u8]) -> usize {
             offset += 32;
         }
 
-        // Handle remaining bytes with scalar
         offset + find_first_nonzero_scalar(&buf[offset..])
     }
 }


### PR DESCRIPTION
Comment/doc-only cleanup of the `crates/fast_io/src` root modules whose
basename starts with a letter in n-z (excluding `lib.rs`).

Fixes doc comments that contradicted the code:
- `status.rs`: `IoUringRestriction` no longer claims "five outcomes of the
  startup probe" (the enum has six variants spanning compile-time and runtime).
- `stdio_blocking.rs`: the idempotency note now matches the early return in
  `clear_nonblock` (no second `fcntl` is issued when `O_NONBLOCK` is clear).
- `syscall_batch.rs`: drops the false "statx for improved performance" claims
  (statx only confirms accessibility, then re-reads via std) and the incorrect
  "filetime via std::fs" note (Unix uses `utimensat(2)` directly).

Also removes two restatement comments (`syscall_batch.rs`, `zero_detect.rs`).

No logic changes; all `upstream:` citations preserved (added/removed counts equal).
