### PR TITLE
docs(cli): drop echo comments in frontend a-m tests

### DIFF
--- a/crates/cli/src/frontend/tests/error_recovery_integration.rs
+++ b/crates/cli/src/frontend/tests/error_recovery_integration.rs
@@ -319,7 +319,6 @@ fn file_grows_between_syncs_transfers_updated_content() {
 
     std::fs::create_dir(&src).expect("create src");
 
-    // Initial content
     let original = b"original content here";
     std::fs::write(src.join("growing.txt"), original).expect("write original");
 
@@ -390,14 +389,12 @@ fn file_shrinks_between_syncs_transfers_updated_content() {
 
     std::fs::create_dir(&src).expect("create src");
 
-    // Initial large content
     let large = b"this is a substantially longer piece of content that will later be replaced by something much shorter to test shrink handling";
     std::fs::write(src.join("shrinking.txt"), large).expect("write large");
 
     let mut src_trailing = src.clone().into_os_string();
     src_trailing.push("/");
 
-    // First sync
     let (code, _stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("-r"),
@@ -421,7 +418,6 @@ fn file_shrinks_between_syncs_transfers_updated_content() {
     let new_mtime = FileTime::from_unix_time(1_800_000_000, 0);
     set_file_times(src.join("shrinking.txt"), new_mtime, new_mtime).expect("set shrunk mtime");
 
-    // Re-sync
     let (code, _stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("-r"),
@@ -528,7 +524,6 @@ fn vanished_source_directory_yields_error_remaining_files_transfer() {
     std::fs::write(src.join("keep/kept.txt"), b"kept").expect("write kept");
     std::fs::write(src.join("gone/lost.txt"), b"lost").expect("write lost");
 
-    // Initial full sync
     let mut src_trailing = src.clone().into_os_string();
     src_trailing.push("/");
 

--- a/crates/cli/src/frontend/tests/files_from.rs
+++ b/crates/cli/src/frontend/tests/files_from.rs
@@ -618,7 +618,6 @@ fn files_from_integration_copies_listed_files() {
     let source_dir = tmp.path().join("source");
     std::fs::create_dir(&source_dir).expect("create source");
 
-    // Create source files
     std::fs::write(source_dir.join("file1.txt"), b"content1").expect("write file1");
     std::fs::write(source_dir.join("file2.txt"), b"content2").expect("write file2");
     std::fs::write(source_dir.join("file3.txt"), b"content3").expect("write file3");
@@ -1513,7 +1512,6 @@ fn files_from_integration_with_from0_copies_listed_files() {
     let source_dir = tmp.path().join("source");
     std::fs::create_dir(&source_dir).expect("create source");
 
-    // Create source files
     std::fs::write(source_dir.join("file1.txt"), b"content1").expect("write file1");
     std::fs::write(source_dir.join("file2.txt"), b"content2").expect("write file2");
     std::fs::write(source_dir.join("file3.txt"), b"content3").expect("write file3");


### PR DESCRIPTION
Comment-only cleanup of CLI frontend test files (basenames a-m).

Removes seven pure restatement/echo comments (`// Initial content`,
`// First sync`, `// Re-sync`, `// Create source files`, etc.) that merely
narrated the immediately following code. No logic, signatures, or control
flow changed. All `upstream:` citations and WHY/intent comments preserved
(89 upstream refs, identical before and after).
