### PR TITLE
docs(transfer): tidy receiver comments and rustdoc

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -1,9 +1,8 @@
 //! [`ReceiverContext`] state and the bulk of its method surface.
 //!
-//! Extracted verbatim from the receiver hub. Holds protocol state, the
-//! received file list, and the predicates/builders that drive the receive
-//! loop. The itemize/info-line emission methods live in the sibling
-//! [`super::itemize`] module.
+//! Holds protocol state, the received file list, and the predicates/builders
+//! that drive the receive loop. The itemize/info-line emission methods live in
+//! the sibling [`super::itemize`] module.
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};

--- a/crates/transfer/src/receiver/dest_root.rs
+++ b/crates/transfer/src/receiver/dest_root.rs
@@ -1,8 +1,7 @@
 //! Destination-root pre-flight helpers for the receiver.
 //!
-//! Extracted verbatim from the receiver hub. Detects a trailing path
-//! separator on the destination operand and creates the destination root
-//! directory when the transfer needs one.
+//! Detects a trailing path separator on the destination operand and creates
+//! the destination root directory when the transfer needs one.
 
 use std::ffi::OsStr;
 use std::io;

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -1,15 +1,13 @@
 //! Itemize-changes and info-line emission for [`super::ReceiverContext`].
 //!
-//! Extracted verbatim from the receiver hub. Routes already-formatted info
-//! lines (itemize, skip notices) to the correct sink and renders per-entry
-//! itemize output.
+//! Routes already-formatted info lines (itemize, skip notices) to the correct
+//! sink and renders per-entry itemize output.
 
 use super::ReceiverContext;
 
 impl ReceiverContext {
-    /// Returns whether itemize emission should be active.
-    ///
-    /// Whether itemize-changes output should be produced for this transfer.
+    /// Returns whether itemize-changes output should be produced for this
+    /// transfer.
     ///
     /// Emitted whenever the user requested `--itemize-changes` (`-i`). Only a
     /// client receiver (a pull, where oc is the generator/receiver on the

--- a/crates/transfer/src/receiver/pipeline_setup.rs
+++ b/crates/transfer/src/receiver/pipeline_setup.rs
@@ -1,8 +1,8 @@
 //! Receiver pipeline setup state and post-transfer attribute helpers.
 //!
-//! Extracted verbatim from the receiver hub. Carries the checksum, metadata,
-//! and ACL state shared across transfer modes, applies cached ACLs to
-//! destination files, and compiles daemon-side filter rules.
+//! Carries the checksum, metadata, and ACL state shared across transfer modes,
+//! applies cached ACLs to destination files, and compiles daemon-side filter
+//! rules.
 
 use std::num::NonZeroU8;
 use std::path::PathBuf;
@@ -42,9 +42,9 @@ pub(in crate::receiver) struct PipelineSetup {
     /// resolves the destination path. Threaded through the receiver
     /// pipeline so the SEC-1.f-j cutover sites can replace path-based
     /// syscalls with their `*at` siblings without re-walking the path
-    /// through the kernel. This PR (SEC-1.e) wires the carrier through
-    /// to [`ReceiverContext`] but does not migrate any syscalls; the
-    /// existing path-based code paths continue to be the active code.
+    /// through the kernel. The carrier is threaded through to
+    /// [`ReceiverContext`] but no syscalls are migrated yet; the existing
+    /// path-based code paths remain the active code (SEC-1.e).
     ///
     /// `None` on Unix when the destination root cannot be opened (for
     /// example because it does not yet exist - the receiver will create

--- a/crates/transfer/src/receiver/tests/delta_apply.rs
+++ b/crates/transfer/src/receiver/tests/delta_apply.rs
@@ -215,7 +215,6 @@ fn checksum_verifier_md4_for_legacy_protocol() {
     verifier.update(b"test data");
     let mut buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
 
-    // MD4 produces 16 bytes
     assert_eq!(verifier.finalize_into(&mut buf), 16);
 }
 
@@ -228,7 +227,6 @@ fn checksum_verifier_md5_for_modern_protocol() {
     verifier.update(b"test data");
     let mut buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
 
-    // MD5 produces 16 bytes
     assert_eq!(verifier.finalize_into(&mut buf), 16);
 }
 

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
@@ -34,7 +34,6 @@ fn daemon_filter_set_built_from_config_rules() {
     );
 
     let filters = filters.unwrap();
-    // *.tmp should be excluded
     assert!(
         !filters.allows(std::path::Path::new("test.tmp"), false),
         "*.tmp should be excluded by daemon filter"
@@ -124,7 +123,6 @@ fn daemon_filter_rules_prepended_to_receiver_deletion_chain() {
     }];
     let ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    // Daemon filter set should reject secret_ files
     let filters = ctx.daemon_filter_set().unwrap();
     assert!(
         !filters.allows(std::path::Path::new("secret_data.bin"), false),

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -18,12 +18,10 @@ use crate::pipeline::PipelineConfig;
 
 #[test]
 fn incremental_receiver_reads_entries() {
-    // Create test data with a simple file list
     let protocol = ProtocolVersion::try_from(32u8).unwrap();
     let mut data = Vec::new();
     let mut writer = protocol::flist::FileListWriter::new(protocol);
 
-    // Add a directory and a file
     let dir = FileEntry::new_directory("testdir".into(), 0o755);
     let file = FileEntry::new_file("testdir/file.txt".into(), 100, 0o644);
 
@@ -31,25 +29,22 @@ fn incremental_receiver_reads_entries() {
     writer.write_entry(&mut data, &file).unwrap();
     writer.write_end(&mut data, None).unwrap();
 
-    // Create handshake and config
     let handshake = test_handshake();
     let config = test_config();
     let ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    // Create incremental receiver
     let mut receiver = ctx.incremental_file_list_receiver(Cursor::new(&data[..]));
 
-    // First entry should be the directory (it has no parent dependency)
+    // The directory has no parent dependency, so it is ready first.
     let entry1 = receiver.next_ready().unwrap().unwrap();
     assert!(entry1.is_dir());
     assert_eq!(entry1.name(), "testdir");
 
-    // Second entry should be the file (parent dir now exists)
+    // The file is released once its parent dir exists.
     let entry2 = receiver.next_ready().unwrap().unwrap();
     assert!(entry2.is_file());
     assert_eq!(entry2.name(), "testdir/file.txt");
 
-    // No more entries
     assert!(receiver.next_ready().unwrap().is_none());
     assert!(receiver.is_empty());
     assert_eq!(receiver.entries_read(), 2);
@@ -79,7 +74,7 @@ fn incremental_receiver_collect_sorted() {
     let mut data = Vec::new();
     let mut writer = protocol::flist::FileListWriter::new(protocol);
 
-    // Add entries in random order
+    // Entries are supplied out of order to exercise the sort.
     let file1 = FileEntry::new_file("z_file.txt".into(), 50, 0o644);
     let file2 = FileEntry::new_file("a_file.txt".into(), 100, 0o644);
     let dir = FileEntry::new_directory("m_dir".into(), 0o755);
@@ -95,7 +90,6 @@ fn incremental_receiver_collect_sorted() {
 
     let receiver = ctx.incremental_file_list_receiver(Cursor::new(&data[..]));
 
-    // collect_sorted should return entries in sorted order
     let entries = receiver.collect_sorted().unwrap();
     assert_eq!(entries.len(), 3);
 
@@ -121,7 +115,6 @@ fn incremental_receiver_iterator_interface() {
 
     let receiver = ctx.incremental_file_list_receiver(Cursor::new(&data[..]));
 
-    // Use iterator interface
     let entries: Vec<_> = receiver.collect::<Result<Vec<_>, _>>().unwrap();
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].name(), "test.txt");
@@ -695,7 +688,6 @@ mod incremental_mode_tests {
         let temp = TempDir::new().unwrap();
         let dest = temp.path();
 
-        // Create nested directory
         let entry = FileEntry::new_directory("a/b/c".into(), 0o755);
         let opts = metadata::MetadataOptions::default();
         let mut failed = FailedDirectories::new();

--- a/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
@@ -55,7 +55,6 @@ fn try_read_one_returns_false_when_finished() {
         iconv_reorder_suppressed: false,
     };
 
-    // Should return false since already finished
     assert!(!receiver.try_read_one().unwrap());
 }
 
@@ -77,13 +76,11 @@ fn try_read_one_reads_single_entry() {
     let data = encode_entries(&[file]);
     let mut receiver = make_receiver(data);
 
-    // First call reads one entry
     assert!(receiver.try_read_one().unwrap());
     assert_eq!(receiver.entries_read(), 1);
     assert_eq!(receiver.ready_count(), 1);
     assert!(!receiver.is_finished_reading());
 
-    // The entry should be available via pop / next_ready
     let entry = receiver.next_ready().unwrap().unwrap();
     assert_eq!(entry.name(), "hello.txt");
     assert_eq!(entry.size(), 42);
@@ -99,7 +96,6 @@ fn try_read_one_reads_entries_one_at_a_time() {
     let data = encode_entries(&entries);
     let mut receiver = make_receiver(data);
 
-    // Read one at a time
     assert!(receiver.try_read_one().unwrap());
     assert_eq!(receiver.entries_read(), 1);
     assert_eq!(receiver.ready_count(), 1);
@@ -112,11 +108,9 @@ fn try_read_one_reads_entries_one_at_a_time() {
     assert_eq!(receiver.entries_read(), 3);
     assert_eq!(receiver.ready_count(), 3);
 
-    // Next call hits end-of-list
     assert!(!receiver.try_read_one().unwrap());
     assert!(receiver.is_finished_reading());
 
-    // All three entries should be ready
     let names: Vec<String> = std::iter::from_fn(|| receiver.next_ready().ok().flatten())
         .map(|e| e.name().to_string())
         .collect();
@@ -128,11 +122,9 @@ fn try_read_one_after_eof_is_idempotent() {
     let data = encode_entries(&[FileEntry::new_file("only.txt".into(), 1, 0o644)]);
     let mut receiver = make_receiver(data);
 
-    // Read the single entry
     assert!(receiver.try_read_one().unwrap());
-    // Hit EOF
+    // EOF, then subsequent calls stay false.
     assert!(!receiver.try_read_one().unwrap());
-    // Subsequent calls continue to return false
     assert!(!receiver.try_read_one().unwrap());
     assert!(!receiver.try_read_one().unwrap());
     assert!(receiver.is_finished_reading());


### PR DESCRIPTION
Comment and doc-only cleanup for the receiver root modules and receiver tests.

- Removes pure-restatement comments, stale "extracted verbatim" migration notes, and a redundant duplicated doc sentence; tightens a couple of rustdoc lines.
- No logic, signature, or control-flow changes. Every `upstream:` citation is preserved verbatim (net upstream-ref count unchanged).
- Scope: `crates/transfer/src/receiver/*.rs` (root modules) and `crates/transfer/src/receiver/tests/` (excludes the `directory`, `file_list`, and `transfer` receiver submodules handled separately).
