### PR TITLE
fix(daemon): survive transient accept(2) errors under load

### DIFF
--- a/.github/workflows/bench-daemon-concurrency.yml
+++ b/.github/workflows/bench-daemon-concurrency.yml
@@ -120,15 +120,31 @@ jobs:
             "$OC_RSYNC" --daemon --no-detach \
               --config "$WORK/oc-rsyncd.conf" \
               </dev/null > "$WORK/oc-rsyncd.stdout" 2> "$WORK/oc-rsyncd.stderr" &
+          # PID of the /usr/bin/time wrapper; used only to stop the daemon.
           echo $! > "$WORK/oc-rsyncd.runpid"
 
-          # Wait for the listener to bind before issuing pulls.
-          for _ in $(seq 1 50); do
+          # Deterministic readiness gate: poll the listener until it accepts a
+          # TCP connection, and fail loud if the daemon never comes up (or
+          # exits early). Without this the pulls could race the bind window and
+          # log spurious connection-refused failures. Bail immediately if the
+          # daemon process has already died so we surface its stderr/log.
+          ready=0
+          for _ in $(seq 1 100); do
             if (echo > "/dev/tcp/127.0.0.1/$OC_PORT") >/dev/null 2>&1; then
+              ready=1
+              break
+            fi
+            if ! kill -0 "$(cat "$WORK/oc-rsyncd.runpid")" 2>/dev/null; then
               break
             fi
             sleep 0.1
           done
+          if [ "$ready" -ne 1 ]; then
+            echo "::error::oc-rsync daemon never became ready on 127.0.0.1:$OC_PORT (D10K-7)"
+            echo "----- daemon stderr -----"; cat "$WORK/oc-rsyncd.stderr" 2>/dev/null || true
+            echo "----- daemon log -----"; cat "$WORK/oc-rsyncd.log" 2>/dev/null || true
+            exit 1
+          fi
 
       - name: Run concurrency soak
         env:
@@ -137,8 +153,10 @@ jobs:
         run: |
           set -euo pipefail
           RESULTS="$WORK/results"
-          PULL_LOG="$RESULTS/pull-failures.log"
+          PULL_LOG="$RESULTS/pull-stderr.log"
+          FAIL_LOG="$RESULTS/pull-failures.log"
           : > "$PULL_LOG"
+          : > "$FAIL_LOG"
 
           one_pull() {
             local idx="$1"
@@ -146,36 +164,48 @@ jobs:
             mkdir -p "$out"
             if ! rsync -q "rsync://127.0.0.1:${OC_PORT}/soak/fixture.bin" "$out/" \
                  2>> "$PULL_LOG"; then
-              printf 'pull %s failed\n' "$idx" >> "$PULL_LOG"
+              # Sentinel goes to a dedicated log so the failure count is exactly
+              # the number of failed pulls; rsync's own stderr (which may itself
+              # contain the word "failed") never inflates it.
+              printf 'pull %s failed\n' "$idx" >> "$FAIL_LOG"
               return 1
             fi
           }
           export -f one_pull
-          export WORK OC_PORT PULL_LOG
+          export WORK OC_PORT PULL_LOG FAIL_LOG
           export SOAK_CONNECTIONS SOAK_PARALLELISM
 
           run_soak() {
             local run_idx="$1"
             rm -rf "$WORK/dst"
             mkdir -p "$WORK/dst"
-            : > "$PULL_LOG"
+            : > "$FAIL_LOG"
 
             local start end
             start=$(date +%s.%N)
-            local failures=0
+            # `timeout` returns 124 on a real wall-clock timeout; xargs returns
+            # 123 when one or more pulls exited non-zero. Only a genuine 124 is
+            # recorded as a timeout - failed pulls are counted separately below,
+            # so the two invariants never double-report the same event.
+            local rc=0
             timeout "${SOAK_TIMEOUT_SECONDS}" bash -c '
               seq 1 "${SOAK_CONNECTIONS}" \
                 | xargs -P "${SOAK_PARALLELISM}" -I {} bash -c "one_pull {}"
-            ' || failures=$?
+            ' || rc=$?
             end=$(date +%s.%N)
+
+            local timeout_hit=0
+            if [ "$rc" -eq 124 ]; then
+              timeout_hit=1
+            fi
 
             local wall
             wall=$(python3 -c "print($end - $start)")
             local fail_count
-            fail_count=$(grep -c 'failed' "$PULL_LOG" || true)
+            fail_count=$(grep -c '^pull ' "$FAIL_LOG" || true)
 
             printf '{"run":%s,"wall":%s,"failures":%s,"timeout_exit":%s}\n' \
-              "$run_idx" "$wall" "$fail_count" "$failures" \
+              "$run_idx" "$wall" "$fail_count" "$timeout_hit" \
               >> "$RESULTS/soak-runs.jsonl"
           }
 
@@ -184,11 +214,24 @@ jobs:
             run_soak "$run_idx"
           done
 
-          # Sample daemon peak RSS (VmHWM, kB) while it is still alive;
-          # /usr/bin/time -v only writes its summary on process exit.
-          PID=$(cat "$WORK/oc-rsyncd.runpid")
-          if kill -0 "$PID" 2>/dev/null; then
-            PEAK_RSS_KB=$(awk '/VmHWM/ {print $2}' "/proc/$PID/status")
+          # Sample peak RSS (VmHWM, kB) from the real daemon process while it is
+          # still alive - the pid file records oc-rsync's own PID (written after
+          # bind, under --no-detach), not the /usr/bin/time wrapper in runpid.
+          # Reading the wrapper would measure the wrong process.
+          DAEMON_PID=""
+          if [ -r "$WORK/oc-rsyncd.pid" ]; then
+            DAEMON_PID=$(cat "$WORK/oc-rsyncd.pid")
+          fi
+          if [ -z "$DAEMON_PID" ]; then
+            DAEMON_PID=$(cat "$WORK/oc-rsyncd.runpid")
+          fi
+          if kill -0 "$DAEMON_PID" 2>/dev/null; then
+            echo 1 > "$RESULTS/daemon-alive"
+          else
+            echo 0 > "$RESULTS/daemon-alive"
+          fi
+          if kill -0 "$DAEMON_PID" 2>/dev/null && [ -r "/proc/$DAEMON_PID/status" ]; then
+            PEAK_RSS_KB=$(awk '/VmHWM/ {print $2}' "/proc/$DAEMON_PID/status")
           else
             PEAK_RSS_KB="0"
           fi
@@ -205,6 +248,7 @@ jobs:
           TOTAL_FAIL=$(jq -s '[.[].failures] | add' "$RESULTS/soak-runs.jsonl")
           MAX_TIMEOUT=$(jq -s '[.[].timeout_exit] | max' "$RESULTS/soak-runs.jsonl")
           PEAK_RSS_KB=$(cat "$RESULTS/daemon-peak-rss-kb")
+          DAEMON_ALIVE=$(cat "$RESULTS/daemon-alive")
 
           printf 'soak runs        : %s\n' "${SOAK_RUNS}"
           printf 'connections/run  : %s\n' "${SOAK_CONNECTIONS}"
@@ -212,6 +256,7 @@ jobs:
           printf 'mean wall (s)    : %s\n' "$MEAN_WALL"
           printf 'total failures   : %s\n' "$TOTAL_FAIL"
           printf 'max timeout exit : %s\n' "$MAX_TIMEOUT"
+          printf 'daemon alive     : %s\n' "$DAEMON_ALIVE"
           printf 'daemon peak RSS  : %s kB (limit %s kB)\n' \
             "$PEAK_RSS_KB" "${SOAK_RSS_LIMIT_KB}"
 
@@ -225,10 +270,14 @@ jobs:
             printf '| soak runs | %s |\n' "${SOAK_RUNS}"
             printf '| mean wall (s) | %s |\n' "$MEAN_WALL"
             printf '| total failed pulls | %s |\n' "$TOTAL_FAIL"
+            printf '| daemon survived soak | %s |\n' "$DAEMON_ALIVE"
             printf '| daemon peak RSS (kB) | %s |\n' "$PEAK_RSS_KB"
             printf '| RSS limit (kB) | %s |\n' "${SOAK_RSS_LIMIT_KB}"
           } >> "$GITHUB_STEP_SUMMARY"
 
+          if [ "$DAEMON_ALIVE" -ne 1 ]; then
+            echo "::error::daemon exited during the concurrency soak (D10K-7)"; exit 1
+          fi
           if [ "$TOTAL_FAIL" -ne 0 ]; then
             echo "::error::soak saw $TOTAL_FAIL failed pulls (D10K-7)"; exit 1
           fi
@@ -264,7 +313,9 @@ jobs:
           path: |
             ${{ steps.prep.outputs.WORK }}/results/soak-runs.jsonl
             ${{ steps.prep.outputs.WORK }}/results/daemon-peak-rss-kb
+            ${{ steps.prep.outputs.WORK }}/results/daemon-alive
             ${{ steps.prep.outputs.WORK }}/results/pull-failures.log
+            ${{ steps.prep.outputs.WORK }}/results/pull-stderr.log
             ${{ steps.prep.outputs.WORK }}/oc-rsyncd.log
             ${{ steps.prep.outputs.WORK }}/oc-rsyncd.stderr
             ${{ steps.prep.outputs.WORK }}/oc-rsyncd.time

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
@@ -93,7 +93,19 @@ impl AcceptEngine for SingleListenerEngine {
                 Ok(AcceptOutcome::Idle)
             }
             Err(error) if error.kind() == io::ErrorKind::Interrupted => Ok(AcceptOutcome::Idle),
-            Err(error) => Err(accept_error(self.local_addr, error)),
+            Err(error) => {
+                // upstream: socket.c:593 `if (fd < 0) continue;` - the accept
+                // loop ignores every accept(2) failure and keeps serving. A
+                // transient per-connection error (ECONNABORTED when a client
+                // resets between the handshake and accept, or EMFILE/ENFILE
+                // under a connection burst) must never tear the daemon down.
+                // Log it, back off briefly so a persistent error cannot
+                // hot-spin the accept thread, then treat the poll as idle so
+                // the loop re-checks signal flags and retries.
+                warn_transient_accept_failure(self.log_sink.as_ref(), self.local_addr, &error);
+                thread::sleep(Duration::from_millis(50));
+                Ok(AcceptOutcome::Idle)
+            }
         }
     }
 
@@ -179,11 +191,13 @@ impl MultiListenerEngine {
         let total_acceptors = listeners.len();
         let mut acceptor_handles: Vec<thread::JoinHandle<()>> =
             Vec::with_capacity(total_acceptors);
+        let log_sink = state.log_sink.clone();
 
         for (listener, local_addr) in listeners.into_iter().zip(bound_addresses.iter().copied()) {
             let tx = tx.clone();
             let shutdown = Arc::clone(&shutdown);
             let graceful_exit = Arc::clone(&graceful_exit);
+            let log_sink = log_sink.clone();
 
             // Set non-blocking so acceptor threads can check the shutdown flag
             // without getting stuck in a blocking accept() call.
@@ -221,13 +235,21 @@ impl MultiListenerEngine {
                             continue;
                         }
                         Err(error) => {
-                            let _ = relay_accept_item(
-                                &tx,
-                                Err((local_addr, error)),
-                                &shutdown,
-                                &graceful_exit,
+                            // upstream: socket.c:593 `if (fd < 0) continue;` -
+                            // a raw accept(2) failure (ECONNABORTED, EMFILE,
+                            // ...) is per-connection and must not kill this
+                            // family's acceptor. Log, back off briefly, and
+                            // keep accepting, mirroring the single-listener
+                            // engine. The relay-and-escalate path below stays
+                            // reserved for a genuinely unusable accepted
+                            // socket (set_nonblocking failure above).
+                            warn_transient_accept_failure(
+                                log_sink.as_ref(),
+                                local_addr,
+                                &error,
                             );
-                            break;
+                            thread::sleep(Duration::from_millis(50));
+                            continue;
                         }
                     }
                 }

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -359,6 +359,36 @@ fn warn_per_family_accept_failure(
     }
 }
 
+/// Emits a warning when `accept(2)` fails with a transient, per-connection
+/// error that the accept loop deliberately survives.
+///
+/// upstream: `socket.c:593` - `if (fd < 0) continue;`. The daemon accept loop
+/// ignores every `accept(2)` failure and keeps serving. Errors such as
+/// `ECONNABORTED` (a client reset between the TCP handshake and `accept`) or
+/// `EMFILE`/`ENFILE` (a transient descriptor shortage under a connection
+/// burst) are per-connection: the affected client is dropped, but the listener
+/// stays up. Prior to this the single-listener engine escalated any such error
+/// to a fatal daemon exit, so one aborted connection under load could tear the
+/// whole daemon down. Surfacing the error at warning level keeps operator
+/// visibility into the churn without implying the daemon is degraded.
+fn warn_transient_accept_failure(
+    log: Option<&SharedLogSink>,
+    local_addr: SocketAddr,
+    error: &io::Error,
+) {
+    let payload = format!(
+        "accept on {local_addr} failed: {error}; \
+         dropping the connection and continuing to serve"
+    );
+    let message = rsync_warning!(payload).with_role(Role::Daemon);
+
+    if let Some(sink) = log {
+        log_message(sink, &message);
+    } else {
+        eprintln!("{message}");
+    }
+}
+
 /// Binds one TCP listener per entry in `bind_addresses`, tolerating per-family
 /// failures while at least one family still binds successfully.
 ///

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1640,6 +1640,63 @@ fn single_listener_engine_poll_returns_connection_with_blocking_reset() {
 }
 
 #[test]
+#[cfg(unix)]
+fn single_listener_engine_poll_survives_transient_accept_error() {
+    // Regression: a transient per-connection accept(2) failure (EMFILE under a
+    // descriptor shortage, or ECONNABORTED when a client resets during the
+    // accept window) must NOT tear the daemon down. Upstream socket.c:593
+    // `if (fd < 0) continue;` ignores every accept failure and keeps serving.
+    // Before the fix, SingleListenerEngine::poll escalated such errors to a
+    // fatal DaemonError, so one aborted connection under a burst killed the
+    // whole daemon - the concurrency soak bench saw mass connection-refused
+    // pulls and a peak RSS of 0 (the daemon had already exited).
+    //
+    // Force a real EMFILE: queue a pending connection, exhaust the process
+    // descriptor table so accept(2) cannot allocate a socket, then poll once.
+    // The fixed engine maps the error to a non-fatal Ok; the pre-fix engine
+    // returned Err and the accept loop exited.
+    use std::fs::File;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let local = listener.local_addr().expect("local addr");
+    let mut engine = SingleListenerEngine::new(listener, local, None).expect("engine");
+
+    // Queue a connection so the next accept(2) has work to extract.
+    let _client = TcpStream::connect(local).expect("connect");
+    // Let the kernel finish the loopback handshake and queue the connection.
+    thread::sleep(Duration::from_millis(20));
+
+    // Exhaust the descriptor table so accept(2) fails with EMFILE. The first
+    // File::open error is the exhaustion signal (EMFILE/ENFILE); the bound is
+    // a runaway guard only.
+    let mut hogs: Vec<File> = Vec::new();
+    while hogs.len() < 200_000 {
+        match File::open("/dev/null") {
+            Ok(file) => hogs.push(file),
+            Err(_) => break,
+        }
+    }
+    assert!(
+        !hogs.is_empty(),
+        "test precondition: at least one descriptor opened before exhaustion"
+    );
+
+    // accept(2) now fails with EMFILE because a connection is pending but no
+    // descriptor can be allocated. The fix returns Ok (non-fatal); a fatal
+    // Err here would mean the daemon exits on a transient accept error.
+    let outcome = engine.poll();
+
+    // Release the descriptors before asserting so failure reporting has fds.
+    drop(hogs);
+
+    assert!(
+        outcome.is_ok(),
+        "a transient accept(2) error (EMFILE) must be non-fatal - the daemon \
+         must keep serving instead of exiting"
+    );
+}
+
+#[test]
 fn relay_accept_item_delivers_when_capacity_available() {
     let (tx, rx) = std::sync::mpsc::sync_channel::<AcceptItem>(1);
     let shutdown = AtomicBool::new(false);


### PR DESCRIPTION
## Root cause

The `bench-daemon-concurrency` job failed intermittently on comment-only PRs
with the signature: `total failures 4056`, a timeout, and `daemon peak RSS = 0
kB`. RSS 0 means the daemon process was already dead when the harness sampled
it; the mass connection failures were every pull after the daemon exited getting
`ECONNREFUSED`.

The daemon accept loop was the cause. `SingleListenerEngine::poll` mapped any
`accept(2)` error other than `EWOULDBLOCK`/`EINTR` to a **fatal** `DaemonError`
that propagates out of the accept loop and exits the daemon:

```rust
Err(error) => Err(accept_error(self.local_addr, error)),
```

Under a burst of concurrent connections a transient, per-connection error is
expected - `ECONNABORTED` when a client resets between the TCP handshake and
`accept`, or `EMFILE`/`ENFILE` on a momentary descriptor shortage. Treating any
of these as fatal kills the whole daemon, which is why the failure was
race-dependent (flaky) rather than a code regression. The dual-stack acceptor
threads had the same defect: an accept error made a family's acceptor `break`
and die.

Upstream `socket.c:593` does `if (fd < 0) continue;` - it ignores **every**
`accept(2)` failure and keeps serving.

## Fix

- `crates/daemon` (`fix:`): the single-listener engine now logs a transient
  accept error, backs off 50 ms so a persistent fault cannot hot-spin the accept
  thread, and keeps polling. The dual-stack acceptor threads do the same instead
  of relaying the error and dying. Behaviour now matches upstream.
- Regression test `single_listener_engine_poll_survives_transient_accept_error`
  forces a real `EMFILE` on `accept(2)` (queue a connection, exhaust the
  descriptor table, poll once) and asserts the engine returns a non-fatal
  outcome. It fails on the pre-fix engine.
- Harness hardening so the invariants are trustworthy (no assertion weakened;
  one strengthened):
  - Fail loud if the daemon never becomes ready or exits early, instead of
    silently racing the pulls against the bind window.
  - Sample peak RSS from the real daemon PID (the pid file), not the
    `/usr/bin/time` wrapper, and **assert the daemon is still alive** after the
    soak.
  - Count only the failed-pull sentinel so rsync's own stderr cannot inflate the
    total, and record a timeout only on a genuine `124` exit rather than xargs'
    `123` "a child failed" code.

## Local reproduction

Deterministic repro: start the daemon under a low `RLIMIT_NOFILE`, hold many
concurrent connections open to drive `accept(2)` into `EMFILE`, then probe.

Before (current binary):

```
RESULT alive=NO
daemon stderr: failed to accept connection on 127.0.0.1:...: Too many open files (os error 24) (code 10)
post-burst pull: FAILED -> Connection refused
```

After (this branch):

```
RESULT alive=YES
daemon warning: accept on 127.0.0.1:... failed: Too many open files (os error 24); dropping the connection and continuing to serve
post-burst pull: OK
```

Reduced-scale soak (300 pulls, parallelism 32, default fd limit) after the fix:
`alive=YES failures=0 daemon_rss_kb=9008`.

`cargo fmt --all --check`, `cargo clippy -p daemon --all-targets --all-features
-D warnings`, and the daemon accept-engine tests all pass.
