### PR TITLE
docs(engine): fix stale temp-file naming doc in local_copy executor

### DIFF
--- a/crates/engine/src/local_copy/executor/file/partial.rs
+++ b/crates/engine/src/local_copy/executor/file/partial.rs
@@ -13,7 +13,7 @@
 //! # Behavior
 //!
 //! Without `--partial`:
-//! - Temp files use `.rsync-tmp-*` naming
+//! - Temp files use `.~tmp~*` naming
 //! - Deleted on transfer failure or interruption
 //!
 //! With `--partial`:

--- a/crates/engine/src/local_copy/executor/file/sparse/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/tests.rs
@@ -2558,9 +2558,7 @@ fn sparse_reader_with_none_strategy_handles_empty_file() {
     assert!(regions.is_empty());
 }
 
-// ---------------------------------------------------------------------------
 // SparseWriter decorator tests
-// ---------------------------------------------------------------------------
 
 #[test]
 fn sparse_writer_all_zero_buffer_produces_only_seeks() {


### PR DESCRIPTION
Comment/doc-only cleanup of `crates/engine/src/local_copy/executor/` and the
root-level `crates/engine/src/local_copy/*.rs` files. No logic changes.

- Fix a stale module doc in `executor/file/partial.rs`: non-partial temp files
  are named `.~tmp~<name>.<pid>.<n>` (see `paths.rs::temporary_destination_path`),
  not `.rsync-tmp-*`.
- Drop a decorative dashed divider around a test section header in
  `executor/file/sparse/tests.rs`, keeping the informational label.

The rest of the scope was already accurate and well-documented. All `upstream:`
references are preserved (net change 0).
