### PR TITLE
docs(engine): correct buffer-pool clamp and memory-cap doc claims

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/buffer_controller/math.rs
+++ b/crates/engine/src/local_copy/buffer_pool/buffer_controller/math.rs
@@ -1,8 +1,8 @@
 //! Numerical helpers used by the PID controller loop.
 //!
 //! `compute_dt` produces a bounded sample-interval, and `clamp_f64` enforces
-//! the anti-windup window without relying on `f64::clamp` (whose NaN handling
-//! panics in debug builds when `lo > hi`).
+//! the anti-windup window without relying on `f64::clamp`, which panics
+//! (in all builds) when `lo > hi` or when either bound is NaN.
 
 use std::time::{Duration, Instant};
 
@@ -35,8 +35,8 @@ pub(super) fn compute_dt(prev: Option<Instant>, now: Instant, default_ms: u64) -
 
 /// Clamps an `f64` to `[lo, hi]`, treating NaN as `lo`.
 ///
-/// Using a free function avoids relying on `f64::clamp` semantics for NaN,
-/// which panic in debug builds when `lo > hi`.
+/// Using a free function avoids `f64::clamp`, which panics (in all builds)
+/// when `lo > hi` or when either bound is NaN.
 pub(super) fn clamp_f64(v: f64, lo: f64, hi: f64) -> f64 {
     if v.is_nan() {
         return lo;

--- a/crates/engine/src/local_copy/buffer_pool/memory_cap.rs
+++ b/crates/engine/src/local_copy/buffer_pool/memory_cap.rs
@@ -11,7 +11,7 @@ use std::sync::{Condvar, Mutex};
 /// scenarios.
 #[derive(Debug)]
 pub(super) struct MemoryCap {
-    /// Maximum allowed bytes across all outstanding and pooled buffers.
+    /// Maximum allowed bytes of outstanding (checked-out) buffers.
     limit: usize,
     /// Current outstanding bytes (buffers checked out by callers, not in pool).
     outstanding: AtomicUsize,


### PR DESCRIPTION
Comment/doc-only cleanup of the local-copy buffer pool, options, and plan
submodules (crates/engine/src/local_copy/{buffer_pool,options,plan}). No logic,
signature, or control-flow changes.

Two stale doc claims corrected against the code:
- buffer_controller/math.rs: `f64::clamp` panics in all builds (not just debug)
  when `lo > hi` or a bound is NaN.
- memory_cap.rs: the hard cap tracks outstanding (checked-out) bytes only, not
  pooled buffers.

The remaining ~81 files in scope were already accurate and well-documented; no
changes were needed. All `upstream:` references preserved (0 removed / 0 added).
