### PR TITLE
docs(cli): tidy frontend test comments (n-z)

### DIFF
--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -1,8 +1,8 @@
-// Output parity tests: verify oc-rsync output format matches upstream rsync conventions.
-//
-// These tests call the formatting functions directly with known inputs and verify
-// that the rendered output matches the structure and content expected by upstream
-// rsync's --stats, --verbose, and --itemize-changes modes.
+//! Output parity tests: verify oc-rsync output format matches upstream rsync conventions.
+//!
+//! These tests call the formatting functions directly with known inputs and verify
+//! that the rendered output matches the structure and content expected by upstream
+//! rsync's --stats, --verbose, and --itemize-changes modes.
 
 use super::common::{RSYNC, run_with_args};
 use super::*;

--- a/crates/cli/src/frontend/tests/progress2_format_parity.rs
+++ b/crates/cli/src/frontend/tests/progress2_format_parity.rs
@@ -224,10 +224,6 @@ fn split_progress2_lines(output: &str) -> Vec<&str> {
         .collect()
 }
 
-// ---------------------------------------------------------------------------
-// End-to-end format validation tests
-// ---------------------------------------------------------------------------
-
 /// Upstream: progress.c:78-82 - the final tick of the last file emits
 /// `(xfr#N, to-chk=0/T)` with a trailing newline.
 #[test]
@@ -418,10 +414,6 @@ fn progress2_multiple_files_all_final_ticks_match_format() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Field width and padding validation
-// ---------------------------------------------------------------------------
-
 /// upstream: progress.c:129 - the bytes field width is 15 chars.
 /// Verify `format_progress_bytes` + right-align produces 15-char field.
 #[test]
@@ -546,10 +538,6 @@ fn progress2_rate_from_value_matches_cumulative_tiers() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Human-readable mode format parity
-// ---------------------------------------------------------------------------
-
 /// When `--human-readable` is active, bytes field uses K/M/G suffixes
 /// instead of thousands separators. The progress2 structure must still
 /// match the upstream field layout.
@@ -591,10 +579,6 @@ fn progress2_human_readable_structural_parity() {
         validate_progress2_line(line).unwrap_or_else(|e| panic!("{e}"));
     }
 }
-
-// ---------------------------------------------------------------------------
-// End-to-end via run_with_args (exercises the full CLI path)
-// ---------------------------------------------------------------------------
 
 /// Validate that `--info=progress2` through the full CLI path produces
 /// lines matching the upstream format.
@@ -679,10 +663,6 @@ fn progress2_cli_multiple_files_format_parity() {
         "multi-file progress2 should have xfr# final ticks: {rendered:?}"
     );
 }
-
-// ---------------------------------------------------------------------------
-// Upstream format string field composition
-// ---------------------------------------------------------------------------
 
 /// Verifies that the composed progress2 line (bytes + pct + rate + time +
 /// trailer) produces the correct field order and separators when assembled

--- a/crates/cli/src/frontend/tests/transfer_request_with_duplicates.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_duplicates.rs
@@ -54,7 +54,6 @@ fn duplicate_source_operands_copy_each_file_once() {
 
     assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
 
-    // Verify files were copied to the destination
     assert_eq!(
         std::fs::read(dest_dir.join("name1")).expect("read name1"),
         b"This is the file"


### PR DESCRIPTION
Comment/doc-only cleanup of the n-z half of `crates/cli/src/frontend/tests/`.

- Removed five decorative banner/divider comment blocks in `progress2_format_parity.rs`.
- Promoted the file-level `//` description in `output_parity.rs` to a `//!` module doc.
- Dropped one pure-restatement comment in `transfer_request_with_duplicates.rs`.

No logic, signature, or control-flow changes. Every `upstream:` reference is preserved (71 before and after).
