### PR TITLE
docs(cli): rustdoc cleanup for frontend execution and command builder

### DIFF
--- a/crates/cli/src/frontend/command_builder/mod.rs
+++ b/crates/cli/src/frontend/command_builder/mod.rs
@@ -2,6 +2,8 @@ mod sections;
 
 pub(super) use clap::{Arg, ArgAction, Command as ClapCommand, builder::OsStringValueParser};
 
+/// Builds the full clap command by layering the base, transfer-behaviour, and
+/// connection/logging argument groups.
 pub(crate) fn clap_command(program_name: &'static str) -> ClapCommand {
     let command = sections::build_base_command(program_name);
     let command = sections::add_transfer_behavior_options(command);

--- a/crates/cli/src/frontend/command_builder/sections/connection_and_logging_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/connection_and_logging_options.rs
@@ -1,5 +1,8 @@
+//! Clap definitions for connection, transport, and logging/output options.
+
 use super::super::{Arg, ArgAction, ClapCommand, OsStringValueParser};
 
+/// Adds the connection and logging argument group to the command.
 pub(crate) fn add_connection_and_logging_options(command: ClapCommand) -> ClapCommand {
     command
         .arg(

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -1,5 +1,9 @@
+//! Clap definitions for transfer-behaviour options: partial/temp/batch handling,
+//! delta and I/O tuning, deletion, filters, metadata preservation, and limits.
+
 use super::super::{Arg, ArgAction, ClapCommand, OsStringValueParser};
 
+/// Adds the transfer-behaviour argument group to the command.
 pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand {
     command
             .arg(

--- a/crates/cli/src/frontend/execution/chown.rs
+++ b/crates/cli/src/frontend/execution/chown.rs
@@ -1,3 +1,5 @@
+//! Parsing for the `--chown=USER:GROUP` argument.
+
 use std::ffi::{OsStr, OsString};
 
 use crate::platform::{gid_t, uid_t};
@@ -7,6 +9,9 @@ use core::{
     rsync_error,
 };
 
+/// A resolved `--chown` spec: the numeric owner and/or group to apply, plus the
+/// original spec text. Either `owner` or `group` may be absent (`USER`, `:GROUP`
+/// forms), but not both.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ParsedChown {
     spec: OsString,
@@ -15,10 +20,12 @@ pub(crate) struct ParsedChown {
 }
 
 impl ParsedChown {
+    /// Returns the resolved owner UID, if the spec named one.
     pub(crate) const fn owner(&self) -> Option<uid_t> {
         self.owner
     }
 
+    /// Returns the resolved group GID, if the spec named one.
     pub(crate) const fn group(&self) -> Option<gid_t> {
         self.group
     }
@@ -30,6 +37,11 @@ impl ParsedChown {
     }
 }
 
+/// Parses a `--chown=USER:GROUP` spec, resolving names to numeric IDs.
+///
+/// Accepts `USER`, `USER:GROUP`, or `:GROUP`. Names are resolved via the
+/// platform lookup; a numeric field is used verbatim. An empty spec, or one
+/// that resolves to neither an owner nor a group, is rejected.
 pub(crate) fn parse_chown_argument(value: &OsStr) -> Result<ParsedChown, Message> {
     let text = value.to_string_lossy();
     let trimmed = text.trim();

--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -1,3 +1,6 @@
+//! Parsing for the compression-related flags: `--compress-level`,
+//! `--compress-choice`, `--compress-threads`, and `--bwlimit`.
+
 use std::ffi::OsStr;
 use std::num::NonZeroU8;
 
@@ -10,8 +13,11 @@ use core::{
     rsync_error,
 };
 
+/// A resolved `--compress-level` value after clamping into the codec's range.
 pub(crate) enum CompressLevelArg {
+    /// The level resolved to "no compression" for the selected codec.
     Disable,
+    /// A concrete compression level to apply.
     Level(CompressionLevel),
 }
 
@@ -90,6 +96,10 @@ fn clamp_level(codec: CompressionAlgorithm, raw: i32) -> CompressLevelArg {
     }
 }
 
+/// Parses `--compress-level=N` and clamps it into `codec`'s range.
+///
+/// Any integer is accepted; an out-of-range value is clamped rather than
+/// rejected. Empty or non-numeric input yields a `--compress-level` error.
 pub(crate) fn parse_compress_level(
     argument: &OsStr,
     codec: CompressionAlgorithm,
@@ -99,6 +109,11 @@ pub(crate) fn parse_compress_level(
         .map_err(CompressionLevelParseError::into_flag_message)
 }
 
+/// Parses `--compress-choice=NAME` into a `CompressChoice`.
+///
+/// `auto` yields `CompressChoice::Auto`, `none` yields
+/// `CompressChoice::Disabled`, and any other value is parsed as a codec name.
+/// An empty or unknown name is rejected with exit code 4 (`RERR_UNSUPPORTED`).
 pub(crate) fn parse_compress_choice(argument: &OsStr) -> Result<CompressChoice, Message> {
     let original = argument.to_string_lossy().into_owned();
     let trimmed = original.trim();
@@ -153,6 +168,10 @@ fn render_compress_choice_error(err: CompressionAlgorithmParseError, trimmed: &s
     rsync_error!(4, rendered).with_role(Role::Client)
 }
 
+/// Parses `--bwlimit=RATE[:BURST]` into an optional bandwidth limit.
+///
+/// Returns `Ok(None)` when the value disables the limit. Invalid, too-small,
+/// and too-large values are rejected with a `--bwlimit` error.
 pub(crate) fn parse_bandwidth_limit(argument: &OsStr) -> Result<Option<BandwidthLimit>, Message> {
     let text = argument.to_string_lossy();
     match BandwidthLimit::parse(&text) {
@@ -223,6 +242,10 @@ pub(crate) fn parse_compress_threads(argument: &OsStr) -> Result<Option<NonZeroU
     }
 }
 
+/// Parses `--compress-level` directly into a `CompressionSetting`.
+///
+/// Like `parse_compress_level` but folds the clamped result into an
+/// enabled/disabled compression setting, with argument-style error messages.
 pub(crate) fn parse_compress_level_argument(
     value: &OsStr,
     codec: CompressionAlgorithm,

--- a/crates/cli/src/frontend/execution/file_list/loader.rs
+++ b/crates/cli/src/frontend/execution/file_list/loader.rs
@@ -72,6 +72,11 @@ pub(crate) fn load_file_list_operands(
     Ok(entries)
 }
 
+/// Reads file-list entries from `reader`, appending them to `entries`.
+///
+/// Splits on `\0` when `zero_terminated` is set, otherwise on newlines (with
+/// trailing `\r` stripped). Comment lines starting with `#` or `;` are skipped
+/// in both modes, matching upstream.
 pub(crate) fn read_file_list_from_reader<R: BufRead>(
     reader: &mut R,
     zero_terminated: bool,
@@ -133,6 +138,7 @@ pub(crate) fn read_file_list_from_reader<R: BufRead>(
     Ok(())
 }
 
+/// Pushes a single file-list entry, dropping trailing `\r` and empty entries.
 pub(super) fn push_file_list_entry(bytes: &[u8], entries: &mut Vec<OsString>) {
     if bytes.is_empty() {
         return;

--- a/crates/cli/src/frontend/execution/file_list/parser.rs
+++ b/crates/cli/src/frontend/execution/file_list/parser.rs
@@ -187,6 +187,11 @@ fn operand_has_windows_prefix(path: &OsStr) -> bool {
     false
 }
 
+/// Returns `true` when an operand references a remote path.
+///
+/// Recognises `rsync://`/`ssh://` URLs, daemon module specs (`host::module`),
+/// and SSH hostspecs (`host:path`). Local paths, including Windows drive letters
+/// (`C:\...`) and UNC prefixes, return `false`.
 pub(crate) fn operand_is_remote(path: &OsStr) -> bool {
     let text = path.to_string_lossy();
 

--- a/crates/cli/src/frontend/execution/module_list.rs
+++ b/crates/cli/src/frontend/execution/module_list.rs
@@ -1,7 +1,12 @@
+//! Renders a daemon module listing to stdout, matching upstream's layout.
+
 use std::io::{self, Write};
 
 use core::client::ModuleList;
 
+/// Writes a daemon module listing: warnings to stderr, then the MOTD (unless
+/// suppressed) and one tab-separated `name<pad>\tcomment` row per module to
+/// stdout.
 pub(crate) fn render_module_list<W: Write, E: Write>(
     stdout: &mut W,
     stderr: &mut E,

--- a/crates/cli/src/frontend/execution/operands.rs
+++ b/crates/cli/src/frontend/execution/operands.rs
@@ -1,3 +1,5 @@
+//! Positional operand extraction and `--address` bind-address parsing.
+
 use std::ffi::{OsStr, OsString};
 use std::io::{self, ErrorKind};
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
@@ -10,16 +12,21 @@ use core::{
 
 use super::super::defaults::SUPPORTED_OPTIONS_LIST;
 
+/// An option token this build does not recognise, captured so the caller can
+/// render a branded "unknown option" diagnostic.
 #[derive(Debug)]
 pub(crate) struct UnsupportedOption {
     option: OsString,
 }
 
 impl UnsupportedOption {
+    /// Wraps the offending option token.
     pub(crate) const fn new(option: OsString) -> Self {
         Self { option }
     }
 
+    /// Renders the diagnostic listing the currently supported options, with
+    /// exit code 1 and the client role trailer.
     pub(crate) fn to_message(&self) -> Message {
         let option = self.option.to_string_lossy();
         let text = format!(
@@ -37,6 +44,10 @@ fn is_option(argument: &OsStr) -> bool {
     matches!(chars.next(), Some('-')) && chars.next().is_some()
 }
 
+/// Splits transfer operands from options, rejecting any unrecognised option.
+///
+/// Tokens after a `--` terminator are always treated as operands, even when
+/// they start with `-`. A lone `-` is an operand (stdin/stdout), not an option.
 pub(crate) fn extract_operands(
     arguments: Vec<OsString>,
 ) -> Result<Vec<OsString>, UnsupportedOption> {
@@ -61,6 +72,9 @@ pub(crate) fn extract_operands(
     Ok(operands)
 }
 
+/// Parses the `--address` value into a `BindAddress`, resolving a hostname
+/// when the value is not already a literal IP. The resolved socket keeps the
+/// user's raw text and uses port 0 (the client picks the port later).
 pub(crate) fn parse_bind_address_argument(value: &OsStr) -> Result<BindAddress, Message> {
     if value.is_empty() {
         return Err(rsync_error!(1, "--address requires a non-empty value").with_role(Role::Client));

--- a/crates/cli/src/frontend/execution/stop.rs
+++ b/crates/cli/src/frontend/execution/stop.rs
@@ -1,3 +1,5 @@
+//! Parsing for the `--stop-after` (duration) and `--stop-at` (deadline) flags.
+
 use std::ffi::OsStr;
 use std::time::{Duration, SystemTime};
 
@@ -5,6 +7,10 @@ use core::message::{Message, Role};
 use core::rsync_error;
 use time::{Date, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
+/// Parses `--stop-after=MINUTES` into an absolute deadline `MINUTES` from now.
+///
+/// The value is a positive integer (an optional leading `+` is allowed). Zero,
+/// empty, and non-numeric input is rejected.
 pub(crate) fn parse_stop_after_argument(value: &OsStr) -> Result<SystemTime, Message> {
     let text = value.to_string_lossy();
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());
@@ -40,6 +46,11 @@ pub(crate) fn parse_stop_after_argument(value: &OsStr) -> Result<SystemTime, Mes
     Ok(deadline)
 }
 
+/// Parses a `--stop-at` timestamp into an absolute deadline.
+///
+/// Accepts upstream's flexible `[YEAR-MON-DAY][THOUR:MIN]` grammar (see
+/// `parse_stop_at_internal`), interpreted in the process's local timezone.
+/// Rejects malformed input and any time that does not resolve to the future.
 pub(crate) fn parse_stop_at_argument(value: &OsStr) -> Result<SystemTime, Message> {
     let text = value.to_string_lossy();
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -399,14 +399,6 @@ where
     }
 }
 
-/// Maps a `clap` argument-parse failure to an rsync exit code.
-///
-/// Most usage errors map to `RERR_SYNTAX` (1). An unusable `--checksum-choice`
-/// name is the exception: upstream `checksum.c:139 parse_checksum_choice()`
-/// exits with `RERR_UNSUPPORTED` (4, errcode.h:28). `--checksum-choice` is
-/// validated inside the `clap` value flow (unlike `--compress-choice`, which is
-/// validated later in the pipeline where the message code survives), so its
-/// intended exit code is reconstructed here from the diagnostic text we emit.
 /// Renders a `clap` parse failure into the detail text used to compose an
 /// rsync-style diagnostic, stripping clap's own leading `error: ` header.
 ///
@@ -426,6 +418,14 @@ fn clap_error_detail(error: &clap::Error) -> String {
     }
 }
 
+/// Maps a `clap` argument-parse failure to an rsync exit code.
+///
+/// Most usage errors map to `RERR_SYNTAX` (1). An unusable `--checksum-choice`
+/// name is the exception: upstream `checksum.c:139 parse_checksum_choice()`
+/// exits with `RERR_UNSUPPORTED` (4, errcode.h:28). `--checksum-choice` is
+/// validated inside the `clap` value flow (unlike `--compress-choice`, which is
+/// validated later in the pipeline where the message code survives), so its
+/// intended exit code is reconstructed here from the diagnostic text we emit.
 fn clap_parse_error_exit_code(error: &clap::Error) -> i32 {
     if error.kind() == clap::error::ErrorKind::ValueValidation
         && error.to_string().contains("--checksum-choice")


### PR DESCRIPTION
Documentation-only cleanup of `crates/cli/src/frontend/` (execution, command_builder, and root modules).

- Add missing module (`//!`) and item (`///`) rustdoc on undocumented public items: operand extraction, `--chown`/`--stop-*`/compression/bwlimit parsers, file-list loading, module listing, and the clap command-builder sections.
- Relocate a misplaced doc comment in `frontend/mod.rs` so it documents `clap_parse_error_exit_code` instead of `clap_error_detail`.
- Comment/doc lines only: no logic, signature, or control-flow changes. Backtick-only spans (no new intra-doc links).
- Every `upstream:` reference is preserved: 151 before and after.
