### PR TITLE
docs(cli): rustdoc for out-format tokens, filters, and progress

### DIFF
--- a/crates/cli/src/frontend/filter_rules/cvs.rs
+++ b/crates/cli/src/frontend/filter_rules/cvs.rs
@@ -10,6 +10,10 @@ use protocol::SUPPORTED_PROTOCOL_BOUNDS;
 
 use crate::frontend::defaults::CVS_EXCLUDE_PATTERNS;
 
+/// Appends the full `-C`/`--cvs-exclude` rule set to `destination`: the global
+/// CVS default excludes plus the per-directory `.cvsignore` dir-merge. Each rule
+/// is tagged with a CVS origin so the wire projection can honor upstream's
+/// local-only / protocol-gated forwarding.
 pub(crate) fn append_cvs_exclude_rules(
     destination: &mut Vec<FilterRuleSpec>,
 ) -> Result<(), Message> {

--- a/crates/cli/src/frontend/filter_rules/directive.rs
+++ b/crates/cli/src/frontend/filter_rules/directive.rs
@@ -34,6 +34,8 @@ pub(crate) struct MergeDirective {
 }
 
 impl MergeDirective {
+    /// Builds a merge directive for `source`, seeding the options with the
+    /// enforced include/exclude kind when one is supplied.
     pub(crate) fn new(source: OsString, enforced_kind: Option<FilterRuleKind>) -> Self {
         let mut options = DirMergeOptions::default();
         options = match enforced_kind {
@@ -49,20 +51,26 @@ impl MergeDirective {
         Self { source, options }
     }
 
+    /// Replaces the directive's merge options, returning the updated directive.
     pub(crate) const fn with_options(mut self, options: DirMergeOptions) -> Self {
         self.options = options;
         self
     }
 
+    /// Returns the merge file source path.
     pub(crate) fn source(&self) -> &OsStr {
         self.source.as_os_str()
     }
 
+    /// Returns the merge options attached to this directive.
     pub(crate) const fn options(&self) -> &DirMergeOptions {
         &self.options
     }
 }
 
+/// Merges a nested directive's options onto the enclosing `base` options. Each
+/// field takes the nested value when it differs from the default, otherwise it
+/// inherits from `base`, mirroring upstream's per-directory option inheritance.
 pub(crate) fn merge_directive_options(
     base: &DirMergeOptions,
     directive: &MergeDirective,
@@ -138,6 +146,8 @@ pub(crate) fn merge_directive_options(
     merged
 }
 
+/// Converts an `OsString` into a pattern string, falling back to a lossy
+/// conversion when the value is not valid UTF-8.
 pub(crate) fn os_string_to_pattern(value: OsString) -> String {
     match value.into_string() {
         Ok(text) => text,

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -13,6 +13,9 @@ use super::directive::{
 use super::parsing::parse_filter_directive;
 use super::sources::{read_merge_file, read_merge_from_standard_input};
 
+/// Loads a merge file referenced by `directive`, parsing each of its lines and
+/// appending the resulting rules to `destination`. `visited` guards against
+/// recursive merge cycles; stdin (`-`) is read once.
 pub(crate) fn apply_merge_directive(
     directive: MergeDirective,
     base_dir: &Path,
@@ -195,6 +198,9 @@ fn parse_merge_contents(
     Ok(())
 }
 
+/// Parses a single line from a merge file and appends its rule to
+/// `destination`, applying the enclosing merge `options` and recursing into any
+/// nested merge directive the line introduces.
 pub(crate) fn process_merge_directive(
     directive: &str,
     options: &DirMergeOptions,

--- a/crates/cli/src/frontend/filter_rules/parsing/directives.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/directives.rs
@@ -13,6 +13,8 @@ use core::rsync_error;
 use super::super::directive::{FilterDirective, MergeDirective};
 use super::merge::parse_merge_modifiers;
 
+/// Parses a long-form `merge[,MODS] FILE` directive. Returns `None` when the
+/// text does not start with `merge`, or an error when the file path is missing.
 pub(super) fn parse_long_merge_directive(text: &str) -> Option<Result<FilterDirective, Message>> {
     let remainder = text.strip_prefix("merge")?;
     let mut remainder =
@@ -56,6 +58,9 @@ pub(super) fn parse_long_merge_directive(text: &str) -> Option<Result<FilterDire
     Some(Ok(FilterDirective::Merge(directive)))
 }
 
+/// Parses a long-form `dir-merge[,MODS] FILE` directive (and the `per-dir`
+/// alias). Returns `None` when neither alias matches, or an error when the file
+/// name is missing.
 pub(super) fn parse_dir_merge_alias(trimmed: &str) -> Option<Result<FilterDirective, Message>> {
     const DIR_MERGE_ALIASES: [&str; 2] = ["dir-merge", "per-dir"];
 

--- a/crates/cli/src/frontend/filter_rules/parsing/entry.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/entry.rs
@@ -17,6 +17,9 @@ use super::rules::{
     parse_exclude_if_present, parse_keyword_rule, parse_short_include_rule, parse_shorthand_rules,
 };
 
+/// Parses a top-level `--filter` argument into a `FilterDirective`, trying the
+/// short and long merge forms before the general rule dispatcher. Leading
+/// whitespace is preserved to mirror upstream's non-word-split behaviour.
 pub(crate) fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective, Message> {
     let text = argument.to_string_lossy();
     // upstream: exclude.c:1100-1213 parse_rule_tok - leading whitespace is only
@@ -97,6 +100,9 @@ pub(crate) fn parse_old_prefix_rule(
     Ok(FilterDirective::Rule(rule))
 }
 
+/// Dispatches a trimmed rule line (no merge prefix) to the matching parser:
+/// `!`/`clear`, CVS convenience, shorthands, `exclude-if-present`, `+`/`-`
+/// short rules, then the long keyword rules.
 pub(super) fn parse_rule_directive(text: &str) -> Result<FilterDirective, Message> {
     // upstream: exclude.c:1313 parse_rule_tok - the pattern length is strlen, so
     // trailing whitespace is part of the pattern and is never stripped. A rule

--- a/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
@@ -17,6 +17,9 @@ pub(super) fn consume_rule_separator(remainder: &str) -> &str {
     }
 }
 
+/// Splits a `+`/`-` short rule's text into `(modifiers, pattern)` at the first
+/// separator. With no separator the entire text is treated as modifiers and the
+/// pattern is empty, so invalid trailing bytes are rejected by the caller.
 pub(super) fn split_short_rule_modifiers(text: &str) -> (&str, &str) {
     if text.is_empty() {
         return ("", "");
@@ -49,6 +52,10 @@ pub(super) fn split_short_rule_modifiers(text: &str) -> (&str, &str) {
     (text, "")
 }
 
+/// Splits a `.`/`:` merge directive's text into `(modifiers, pattern)`. Only
+/// recognised modifier bytes are consumed; the first unrecognised byte or
+/// separator ends the modifier run. `allow_extended` additionally accepts the
+/// dir-merge-only `e`/`n` modifiers.
 pub(super) fn split_short_merge_modifiers(text: &str, allow_extended: bool) -> (&str, &str) {
     if text.is_empty() {
         return ("", "");
@@ -91,6 +98,8 @@ pub(super) fn split_short_merge_modifiers(text: &str, allow_extended: bool) -> (
     (&text[..end], "")
 }
 
+/// Splits a long-form keyword token into `(name, modifiers)` at the first
+/// comma, returning empty modifiers when no comma is present.
 pub(super) fn split_keyword_modifiers(keyword: &str) -> (&str, &str) {
     if let Some((name, modifiers)) = keyword.split_once(',') {
         (name, modifiers)

--- a/crates/cli/src/frontend/filter_rules/parsing/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/merge.rs
@@ -7,6 +7,10 @@ use core::rsync_error;
 use super::super::directive::{FilterDirective, MergeDirective};
 use super::helpers::split_short_merge_modifiers;
 
+/// Parses the modifier characters that follow a `.`/`:` merge directive into
+/// `DirMergeOptions`. `allow_extended` enables the dir-merge-only modifiers
+/// (`e`, `n`). Returns the options and whether `C` implied `.cvsignore`.
+/// Modifiers are matched case-sensitively to mirror upstream.
 pub(crate) fn parse_merge_modifiers(
     modifiers: &str,
     directive: &str,
@@ -140,6 +144,9 @@ pub(crate) fn parse_merge_modifiers(
     Ok((options, assume_cvsignore))
 }
 
+/// Parses a short merge directive: `. FILE` (merge) or `: FILE` (dir-merge),
+/// including inline modifiers. Returns `None` when the text starts with neither
+/// `.` nor `:`.
 pub(super) fn parse_short_merge_directive(text: &str) -> Option<Result<FilterDirective, Message>> {
     let mut chars = text.chars();
     let first = chars.next()?;

--- a/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
@@ -2,6 +2,7 @@ use core::client::{FilterRuleKind, FilterRuleSpec};
 use core::message::{Message, Role};
 use core::rsync_error;
 
+/// Accumulated rule modifiers parsed from a rule prefix or keyword.
 #[derive(Default)]
 pub(super) struct RuleModifierState {
     anchor_root: bool,
@@ -97,6 +98,8 @@ pub(super) fn parse_rule_modifiers(
     Ok(state)
 }
 
+/// Applies a parsed `RuleModifierState` onto a `FilterRuleSpec`, setting the
+/// anchor, sender/receiver side, perishable, xattr-only, and negate attributes.
 pub(super) fn apply_rule_modifiers(
     mut rule: FilterRuleSpec,
     modifiers: RuleModifierState,

--- a/crates/cli/src/frontend/filter_rules/parsing/rules.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/rules.rs
@@ -14,6 +14,8 @@ use super::helpers::{split_keyword_modifiers, split_short_rule_modifiers};
 use super::modifiers::{apply_rule_modifiers, parse_rule_modifiers};
 use super::shorthand::parse_filter_shorthand;
 
+/// Parses the `P`/`H`/`S`/`R` single-letter shorthand rules (protect, hide,
+/// show, risk). Returns `None` when the text is not one of these forms.
 pub(super) fn parse_shorthand_rules(trimmed: &str) -> Option<Result<FilterDirective, Message>> {
     if let Some(result) = parse_filter_shorthand(trimmed, 'P', "P", FilterRuleSpec::protect) {
         return Some(result);
@@ -34,6 +36,9 @@ pub(super) fn parse_shorthand_rules(trimmed: &str) -> Option<Result<FilterDirect
     None
 }
 
+/// Parses an `exclude-if-present=MARKER` directive. Returns `None` when the
+/// text does not start with the `exclude-if-present` keyword, or an error when
+/// the marker file name is missing.
 pub(super) fn parse_exclude_if_present(trimmed: &str) -> Option<Result<FilterDirective, Message>> {
     const EXCLUDE_IF_PRESENT_PREFIX: &str = "exclude-if-present";
     if trimmed.len() < EXCLUDE_IF_PRESENT_PREFIX.len() {
@@ -66,6 +71,9 @@ pub(super) fn parse_exclude_if_present(trimmed: &str) -> Option<Result<FilterDir
     )))
 }
 
+/// Parses a `+`/`-` short rule (include/exclude) identified by `prefix`,
+/// applying any rule modifiers to the pattern via `builder`. Returns `None`
+/// when the text does not begin with `prefix`.
 pub(super) fn parse_short_include_rule(
     trimmed: &str,
     prefix: char,
@@ -97,6 +105,9 @@ pub(super) fn parse_short_include_rule(
     Some(Ok(FilterDirective::Rule(rule)))
 }
 
+/// Parses a long-form keyword rule (`include`/`exclude`/`show`/`hide`/
+/// `protect`/`risk` plus pattern). Keywords are matched case-sensitively to
+/// mirror upstream; an unknown keyword yields a syntax error.
 pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Message> {
     let mut parts = trimmed.splitn(2, |ch: char| ch.is_ascii_whitespace());
     let keyword = parts.next().expect("split always yields at least one part");

--- a/crates/cli/src/frontend/filter_rules/parsing/shorthand.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/shorthand.rs
@@ -5,6 +5,10 @@ use core::rsync_error;
 use super::super::directive::FilterDirective;
 use super::helpers::consume_rule_separator;
 
+/// Parses a single-character rule prefix (`short`) followed by a separator and
+/// a pattern, building the rule via `builder`. Returns `None` when `short` does
+/// not match case-sensitively or no separator follows; an error when the
+/// pattern is missing.
 pub(super) fn parse_filter_shorthand(
     trimmed: &str,
     short: char,

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -10,6 +10,10 @@ use core::rsync_error;
 use super::directive::FilterDirective;
 use super::parsing::parse_old_prefix_rule;
 
+/// Loads filter patterns from `--include-from` / `--exclude-from` files and
+/// appends the resulting rules to `destination`. Include/exclude files honor the
+/// old-prefix syntax (`- `/`+ `/`!`) with each file's `!` clear scoped locally;
+/// dir-merge is rejected. `eol_nulls` selects NUL-delimited records (`--from0`).
 pub(crate) fn append_filter_rules_from_files(
     destination: &mut Vec<FilterRuleSpec>,
     files: &[OsString],
@@ -70,6 +74,8 @@ pub(crate) fn append_filter_rules_from_files(
     Ok(())
 }
 
+/// Reads the raw pattern lines from a filter file, or from standard input when
+/// `path` is `-`. `eol_nulls` selects NUL-delimited records (`--from0`).
 pub(crate) fn load_filter_file_patterns(
     path: &Path,
     eol_nulls: bool,
@@ -91,6 +97,7 @@ pub(crate) fn load_filter_file_patterns(
     })
 }
 
+/// Reads a merge file's entire contents as a string.
 pub(super) fn read_merge_file(path: &Path) -> Result<String, Message> {
     let display = path.display();
     fs::read_to_string(path).map_err(|error| {
@@ -99,6 +106,7 @@ pub(super) fn read_merge_file(path: &Path) -> Result<String, Message> {
     })
 }
 
+/// Reads an entire merge file from standard input.
 pub(super) fn read_merge_from_standard_input() -> Result<String, Message> {
     #[cfg(test)]
     if let Some(data) = take_filter_stdin_input() {
@@ -116,6 +124,8 @@ pub(super) fn read_merge_from_standard_input() -> Result<String, Message> {
     Ok(buffer)
 }
 
+/// Reads filter pattern lines from standard input. `eol_nulls` selects
+/// NUL-delimited records (`--from0`).
 pub(crate) fn read_filter_patterns_from_standard_input(
     eol_nulls: bool,
 ) -> Result<Vec<String>, Message> {
@@ -136,6 +146,9 @@ pub(crate) fn read_filter_patterns_from_standard_input(
     })
 }
 
+/// Splits a reader into filter pattern records, skipping blank lines and `#`/`;`
+/// comments. Records split on newline, or on NUL when `eol_nulls` is set
+/// (`--from0`), in which case embedded newlines are literal pattern bytes.
 pub(super) fn read_filter_patterns<R: BufRead>(
     reader: &mut R,
     eol_nulls: bool,

--- a/crates/cli/src/frontend/out_format/mod.rs
+++ b/crates/cli/src/frontend/out_format/mod.rs
@@ -1,5 +1,7 @@
 #![deny(unsafe_code)]
 
+//! Parsing and rendering of `--out-format` / `--log-format` specifications.
+
 mod parser;
 mod render;
 mod tokens;

--- a/crates/cli/src/frontend/out_format/parser.rs
+++ b/crates/cli/src/frontend/out_format/parser.rs
@@ -14,6 +14,8 @@ use super::tokens::{
     PlaceholderAlignment, PlaceholderFormat, PlaceholderToken,
 };
 
+/// Parses the optional modifiers preceding a placeholder letter: apostrophes
+/// (humanization), an optional `-` (left align), and a digit run (width).
 fn parse_placeholder_format(chars: &mut Peekable<Chars<'_>>) -> PlaceholderFormat {
     let mut apostrophes = 0usize;
     while matches!(chars.peek(), Some('\'')) {

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -29,9 +29,12 @@ impl OutFormat {
     }
 }
 
+/// A single element of a parsed `--out-format` specification.
 #[derive(Clone, Debug)]
 pub(super) enum OutFormatToken {
+    /// Literal text copied to the output verbatim.
     Literal(String),
+    /// A `%`-placeholder resolved at render time.
     Placeholder(PlaceholderToken),
 }
 

--- a/crates/cli/src/frontend/progress/format/event.rs
+++ b/crates/cli/src/frontend/progress/format/event.rs
@@ -9,6 +9,9 @@ pub(crate) const fn is_progress_event(kind: &ClientEventKind) -> bool {
     kind.is_progress()
 }
 
+/// Reports whether an event should print its name at the given output level:
+/// `UpdatedOnly` (`-v`) lists changed entries, `UpdatedAndUnchanged` (`-vv`)
+/// also lists reused ones, and `Disabled` lists none.
 pub(crate) const fn event_matches_name_level(event: &ClientEvent, level: NameOutputLevel) -> bool {
     match level {
         NameOutputLevel::Disabled => false,

--- a/crates/cli/src/frontend/progress/format/list.rs
+++ b/crates/cli/src/frontend/progress/format/list.rs
@@ -6,6 +6,7 @@ use core::client::{ClientEntryKind, ClientEntryMetadata, ClientEventKind};
 
 use crate::LIST_TIMESTAMP_FORMAT;
 
+/// Reports whether an event kind should appear in `--list-only` output.
 pub(crate) const fn list_only_event(kind: &ClientEventKind) -> bool {
     matches!(
         kind,
@@ -20,6 +21,8 @@ pub(crate) const fn list_only_event(kind: &ClientEventKind) -> bool {
     )
 }
 
+/// Renders a 10-character `ls`-style permission string (type char plus rwx
+/// triples), honoring the setuid, setgid, and sticky bits.
 pub(crate) fn format_list_permissions(metadata: &ClientEntryMetadata) -> String {
     let type_char = match metadata.kind() {
         ClientEntryKind::File => '-',
@@ -82,6 +85,8 @@ pub(crate) fn format_list_permissions(metadata: &ClientEntryMetadata) -> String 
     symbols.iter().collect()
 }
 
+/// Formats a modification time for `--list-only` output, falling back to the
+/// epoch string when the time is absent or cannot be formatted.
 pub(crate) fn format_list_timestamp(modified: Option<SystemTime>) -> String {
     if let Some(time) = modified
         && let Ok(datetime) =

--- a/crates/cli/src/frontend/progress/format/progress.rs
+++ b/crates/cli/src/frontend/progress/format/progress.rs
@@ -31,6 +31,9 @@ pub(crate) fn format_progress_elapsed(elapsed: Duration) -> String {
     format!("{hours}:{minutes:02}:{seconds:02}")
 }
 
+/// Formats a parenthesized breakdown of non-zero stat categories (e.g.
+/// ` (reg: 1,500, dir: 1)`), grouping each sub-count per the human-readable
+/// level. Returns an empty string when every category is zero.
 pub(crate) fn format_stat_categories(
     categories: &[(&str, u64)],
     human_readable: HumanReadableMode,

--- a/crates/cli/src/frontend/progress/format/rate.rs
+++ b/crates/cli/src/frontend/progress/format/rate.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 
 use core::client::HumanReadableMode;
 
+/// Formats the bytes/sec field of the transfer summary trailer: thousands-
+/// grouped with two decimals by default, or unit-suffixed under `-h`/`-hh`.
 pub(crate) fn format_summary_rate(rate: f64, human_readable: HumanReadableMode) -> String {
     if !human_readable.is_enabled() {
         // upstream: main.c output_summary() prints the bytes/sec field with
@@ -18,6 +20,8 @@ pub(crate) fn format_summary_rate(rate: f64, human_readable: HumanReadableMode) 
     format_human_rate(rate, human_readable.unit_base())
 }
 
+/// Formats a rate with a `K`/`M`/`G`/`T`/`P` suffix and two decimals. `base` is
+/// 1000 for `-h` or 1024 for `-hh`; rates below `base` render as plain decimals.
 pub(crate) fn format_human_rate(rate: f64, base: f64) -> String {
     if rate < base {
         return format!("{rate:.2}");
@@ -61,6 +65,8 @@ pub(crate) fn format_progress_rate(
     format_progress_rate_decimal(rate)
 }
 
+/// Formats a bytes/sec rate for the progress line into `kB/s`, `MB/s`, or
+/// `GB/s`, using base-1024 divisors and capping at the `GB/s` tier.
 pub(crate) fn format_progress_rate_decimal(rate: f64) -> String {
     const KIB: f64 = 1024.0;
     const MIB: f64 = KIB * 1024.0;

--- a/crates/cli/src/frontend/progress/format/size.rs
+++ b/crates/cli/src/frontend/progress/format/size.rs
@@ -14,6 +14,8 @@ pub(crate) fn format_progress_bytes(bytes: u64, human_readable: HumanReadableMod
     format_size(bytes, human_readable)
 }
 
+/// Formats a byte count for the active human-readable level: unit-suffixed for
+/// `-h`/`-hh`, comma-grouped at the default level, raw digits under `--no-h`.
 pub(crate) fn format_size(bytes: u64, human_readable: HumanReadableMode) -> String {
     if human_readable.is_enabled() {
         return format_human_bytes(bytes, human_readable.unit_base());
@@ -42,6 +44,7 @@ pub(crate) fn format_count(count: u64, human_readable: HumanReadableMode) -> Str
     }
 }
 
+/// Formats an integer with comma thousands separators (`1,234,567`).
 pub(crate) fn format_decimal_bytes(bytes: u64) -> String {
     if bytes == 0 {
         return String::from("0");
@@ -69,6 +72,9 @@ pub(crate) fn format_decimal_bytes(bytes: u64) -> String {
     String::from(std::str::from_utf8(&buf[pos..]).expect("ASCII-only content"))
 }
 
+/// Formats a byte count with a `K`/`M`/`G`/`T`/`P` suffix and two fractional
+/// digits. `base` is 1000 for `-h` or 1024 for `-hh`; values below `base` render
+/// as plain digits.
 pub(crate) fn format_human_bytes(bytes: u64, base: f64) -> String {
     // upstream: lib/compat.c:do_big_num - values below the multiplier are
     // printed without a unit suffix; otherwise K/M/G/T/P with two fractional
@@ -96,6 +102,8 @@ pub(crate) fn format_human_bytes(bytes: u64, base: f64) -> String {
     bytes.to_string()
 }
 
+/// Formats a file size for `--list-only` output, right-aligned to the level's
+/// fixed size column width.
 pub(crate) fn format_list_size(size: u64, human_readable: HumanReadableMode) -> String {
     let value = format_size(size, human_readable);
     let width = human_readable.size_width();

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -119,6 +119,8 @@ impl<'a> LiveProgress<'a> {
         )
     }
 
+    /// Builds a live progress renderer bound to `writer`, using the given
+    /// progress mode, human-readable level, and terminal/buffering config.
     pub(crate) fn with_output_config(
         writer: &'a mut dyn Write,
         mode: ProgressMode,
@@ -142,6 +144,7 @@ impl<'a> LiveProgress<'a> {
         }
     }
 
+    /// Returns whether at least one progress line has been rendered.
     pub(crate) const fn rendered(&self) -> bool {
         self.rendered
     }
@@ -152,6 +155,8 @@ impl<'a> LiveProgress<'a> {
         }
     }
 
+    /// Finalizes progress output, terminating any active line with a newline
+    /// and surfacing the first I/O error recorded during rendering.
     pub(crate) fn finish(self) -> io::Result<()> {
         if let Some(error) = self.error {
             return Err(error);

--- a/crates/cli/src/frontend/progress/mode.rs
+++ b/crates/cli/src/frontend/progress/mode.rs
@@ -1,6 +1,9 @@
+/// Resolved progress rendering mode used by the live renderer.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ProgressMode {
+    /// Per-file progress (`--progress`).
     PerFile,
+    /// Overall transfer progress (`--info=progress2`).
     Overall,
 }
 
@@ -36,6 +39,8 @@ pub enum NameOutputLevel {
 }
 
 impl ProgressSetting {
+    /// Resolves the setting to a concrete `ProgressMode`, or `None` when
+    /// progress is disabled or unspecified.
     pub(crate) const fn resolved(self) -> Option<ProgressMode> {
         match self {
             Self::PerFile => Some(ProgressMode::PerFile),


### PR DESCRIPTION
Comment/doc-only cleanup across the CLI frontend arguments, filter_rules,
out_format, and progress modules.

- Add rustdoc to the previously undocumented `OutFormatToken` enum and its
  variants, plus a module doc for `out_format`.
- Add concise `///` docs to the undocumented filter-rule parsing/loading
  helpers and the progress size/rate/list/event formatting helpers.

No logic changes. All `upstream:` source citations are preserved verbatim
(net-zero before/after).
