### PR TITLE
docs(engine): rustdoc/comment cleanup (local_copy tests)

### DIFF
--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -150,17 +150,14 @@ fn backup_dir_places_backups_in_specified_directory() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source file
     let source_file = ctx.source.join("data.txt");
     fs::write(&source_file, b"new data").expect("write source");
 
-    // Create existing destination file
     let dest_root = ctx.dest.join("source");
     fs::create_dir_all(&dest_root).expect("create dest root");
     let existing = dest_root.join("data.txt");
     fs::write(&existing, b"old data").expect("write dest");
 
-    // Set up backup directory
     let backup_dir = ctx.dest.join("my_backups");
 
     let operands = vec![
@@ -174,7 +171,6 @@ fn backup_dir_places_backups_in_specified_directory() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify backup is in backup_dir, not next to the file
     let backup_in_dest = dest_root.join("data.txt~");
     assert!(!backup_in_dest.exists(), "backup should not be in destination directory");
 
@@ -192,13 +188,11 @@ fn backup_dir_preserves_directory_structure() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create nested source structure
     test_helpers::create_test_tree(&ctx.source, &[
         ("level1/level2/level3/file.txt", Some(b"updated")),
         ("level1/file2.txt", Some(b"updated2")),
     ]);
 
-    // Create nested destination structure with existing files
     let dest_root = ctx.dest.join("source");
     test_helpers::create_test_tree(&dest_root, &[
         ("level1/level2/level3/file.txt", Some(b"original")),
@@ -218,7 +212,6 @@ fn backup_dir_preserves_directory_structure() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify directory structure is preserved in backup-dir
     let backup1 = backup_dir.join("source/level1/level2/level3/file.txt~");
     assert!(backup1.exists(), "nested backup missing at {}", backup1.display());
     assert_eq!(fs::read(&backup1).expect("read backup1"), b"original");
@@ -227,7 +220,6 @@ fn backup_dir_preserves_directory_structure() {
     assert!(backup2.exists(), "backup2 missing at {}", backup2.display());
     assert_eq!(fs::read(&backup2).expect("read backup2"), b"original2");
 
-    // Verify updated files in destination
     assert_eq!(
         fs::read(dest_root.join("level1/level2/level3/file.txt")).expect("read dest1"),
         b"updated"
@@ -265,7 +257,6 @@ fn backup_dir_works_with_custom_suffix() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify backup uses custom suffix
     let backup_default = backup_dir.join("source/document.txt~");
     assert!(!backup_default.exists(), "should not use default suffix");
 
@@ -283,14 +274,12 @@ fn backup_dir_handles_multiple_backups_correctly() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create multiple source files
     test_helpers::create_test_tree(&ctx.source, &[
         ("file1.txt", Some(b"content1-v2")),
         ("file2.txt", Some(b"content2-v2")),
         ("subdir/file3.txt", Some(b"content3-v2")),
     ]);
 
-    // Create existing destination files
     let dest_root = ctx.dest.join("source");
     test_helpers::create_test_tree(&dest_root, &[
         ("file1.txt", Some(b"content1-v1")),
@@ -311,7 +300,6 @@ fn backup_dir_handles_multiple_backups_correctly() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify all backups are created in backup-dir
     let backup1 = backup_dir.join("source/file1.txt~");
     assert!(backup1.exists(), "backup1 missing at {}", backup1.display());
     assert_eq!(fs::read(&backup1).expect("read backup1"), b"content1-v1");
@@ -324,7 +312,6 @@ fn backup_dir_handles_multiple_backups_correctly() {
     assert!(backup3.exists(), "backup3 missing at {}", backup3.display());
     assert_eq!(fs::read(&backup3).expect("read backup3"), b"content3-v1");
 
-    // Verify all destination files are updated
     assert_eq!(
         fs::read(dest_root.join("file1.txt")).expect("read dest1"),
         b"content1-v2"
@@ -397,7 +384,6 @@ fn backup_dir_with_relative_path() {
     let existing = dest_root.join("file.txt");
     fs::write(&existing, b"old").expect("write dest");
 
-    // Use relative backup directory
     let operands = vec![
         ctx.source.into_os_string(),
         ctx.dest.clone().into_os_string(),
@@ -443,7 +429,6 @@ fn backup_dir_creates_missing_directories() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify backup directory and all intermediate directories were created
     let backup = backup_dir.join("source/deep/nested/structure/file.txt~");
     assert!(backup.exists(), "backup missing at {}", backup.display());
     assert_eq!(fs::read(&backup).expect("read backup"), b"original");
@@ -472,11 +457,9 @@ fn backup_not_created_in_dry_run_mode() {
     plan.execute_with_options(LocalCopyExecution::DryRun, options)
         .expect("dry-run succeeds");
 
-    // Backup should NOT be created in dry-run mode
     let backup = dest_root.join("file.txt~");
     assert!(!backup.exists(), "backup should not exist in dry-run mode");
 
-    // Original file should be unchanged
     assert_eq!(
         fs::read(dest_root.join("file.txt")).expect("read dest"),
         b"original content"
@@ -488,11 +471,9 @@ fn backup_created_when_deleting_with_delete_option() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source with only one file
     let source_file = ctx.source.join("keep.txt");
     fs::write(&source_file, b"keep this").expect("write source");
 
-    // Create destination with extra file that will be deleted
     let dest_root = ctx.dest.join("source");
     fs::create_dir_all(&dest_root).expect("create dest root");
     fs::write(dest_root.join("keep.txt"), b"old keep").expect("write keep");
@@ -512,15 +493,12 @@ fn backup_created_when_deleting_with_delete_option() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Deleted file should be backed up
     let backup_deleted = backup_dir.join("source/delete_me.txt~");
     assert!(backup_deleted.exists(), "backup of deleted file missing at {}", backup_deleted.display());
     assert_eq!(fs::read(&backup_deleted).expect("read backup"), b"delete me");
 
-    // File should be deleted from destination
     assert!(!dest_root.join("delete_me.txt").exists(), "deleted file should not exist");
 
-    // Keep file should have backup of its old version
     let backup_keep = backup_dir.join("source/keep.txt~");
     assert!(backup_keep.exists(), "backup of modified file missing");
     assert_eq!(fs::read(&backup_keep).expect("read backup"), b"old keep");
@@ -534,11 +512,9 @@ fn backup_preserves_symlinks_in_directory() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source directory with a symlink
     let source_link = ctx.source.join("link");
     symlink("new_target", &source_link).expect("create source symlink");
 
-    // Create destination directory with existing symlink pointing elsewhere
     let dest_root = ctx.dest.join("source");
     fs::create_dir_all(&dest_root).expect("create dest root");
     let existing_link = dest_root.join("link");
@@ -558,7 +534,6 @@ fn backup_preserves_symlinks_in_directory() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Backup should be a symlink pointing to old target
     let backup = backup_dir.join("source/link~");
     assert!(backup.symlink_metadata().is_ok(), "backup symlink missing at {}", backup.display());
     assert!(backup.symlink_metadata().expect("metadata").file_type().is_symlink());
@@ -567,7 +542,6 @@ fn backup_preserves_symlinks_in_directory() {
         PathBuf::from("old_target")
     );
 
-    // Destination should now point to new target
     assert_eq!(
         fs::read_link(dest_root.join("link")).expect("read dest link"),
         PathBuf::from("new_target")
@@ -707,7 +681,6 @@ fn backup_with_special_characters_in_filename() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source file with special characters
     let source_file = ctx.source.join("file with spaces & special!.txt");
     fs::write(&source_file, b"new content").expect("write source");
 
@@ -753,7 +726,6 @@ fn backup_suffix_with_date_format() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    // Use a date-like suffix
     let options = LocalCopyOptions::default().with_backup_suffix(Some(".2024-01-15"));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
@@ -794,12 +766,10 @@ fn backup_directory_outside_destination_tree() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Backup should be in external directory, not under dest
     let backup = external_backup.join("source/file.txt~");
     assert!(backup.exists(), "backup missing at {}", backup.display());
     assert_eq!(fs::read(&backup).expect("read backup"), b"old version");
 
-    // Verify no backup in destination
     let backup_in_dest = dest_root.join("file.txt~");
     assert!(!backup_in_dest.exists(), "backup should not be in destination");
 }
@@ -809,7 +779,6 @@ fn backup_only_when_content_differs() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source and dest with different content
     let source_file = ctx.source.join("different.txt");
     fs::write(&source_file, b"new content").expect("write source different");
 
@@ -840,12 +809,10 @@ fn backup_only_when_content_differs() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Backup should exist for the file that was different
     let backup_different = dest_root.join("different.txt~");
     assert!(backup_different.exists(), "backup of different file should exist");
     assert_eq!(fs::read(&backup_different).expect("read backup"), b"old content");
 
-    // No backup for same content (file wasn't modified)
     let backup_same = dest_root.join("same.txt~");
     assert!(!backup_same.exists(), "backup of identical file should not exist");
 }
@@ -878,7 +845,6 @@ fn backup_with_empty_suffix() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Backup should have the same name as original (no suffix)
     let backup = backup_dir.join("source/file.txt");
     assert!(backup.exists(), "backup missing at {}", backup.display());
     assert_eq!(fs::read(&backup).expect("read backup"), b"old");
@@ -919,7 +885,6 @@ fn backup_overwrites_existing_backup() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("second sync succeeds");
 
-    // Backup should now contain v2, not v1
     assert_eq!(fs::read(&backup_path).expect("read backup"), b"version 2");
     assert_eq!(fs::read(&dest_file).expect("read dest"), b"version 3");
 }
@@ -929,10 +894,8 @@ fn backup_with_delete_after() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source with one file
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with extra files to be deleted
     let dest_root = ctx.dest.join("source");
     fs::create_dir_all(&dest_root).expect("create dest root");
     fs::write(dest_root.join("keep.txt"), b"old").expect("write old keep");
@@ -953,7 +916,6 @@ fn backup_with_delete_after() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // All deleted files should be backed up
     let backup1 = backup_dir.join("source/extra1.txt~");
     let backup2 = backup_dir.join("source/extra2.txt~");
     assert!(backup1.exists(), "backup of extra1 missing at {}", backup1.display());
@@ -961,7 +923,6 @@ fn backup_with_delete_after() {
     assert_eq!(fs::read(&backup1).expect("read backup1"), b"extra1");
     assert_eq!(fs::read(&backup2).expect("read backup2"), b"extra2");
 
-    // Modified file should also be backed up
     let backup_keep = backup_dir.join("source/keep.txt~");
     assert!(backup_keep.exists(), "backup of keep.txt missing");
     assert_eq!(fs::read(&backup_keep).expect("read backup"), b"old");
@@ -972,12 +933,10 @@ fn backup_with_nested_delete() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source with nested structure
     test_helpers::create_test_tree(&ctx.source, &[
         ("keep/file.txt", Some(b"keep")),
     ]);
 
-    // Create destination with extra nested files to delete
     let dest_root = ctx.dest.join("source");
     test_helpers::create_test_tree(&dest_root, &[
         ("keep/file.txt", Some(b"old")),
@@ -999,13 +958,11 @@ fn backup_with_nested_delete() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Check that nested deleted files are backed up with proper structure
     // Note: directory deletion may not back up individual files - this tests the behavior
     let backup_keep = backup_dir.join("source/keep/file.txt~");
     assert!(backup_keep.exists(), "backup of modified file missing at {}", backup_keep.display());
     assert_eq!(fs::read(&backup_keep).expect("read backup"), b"old");
 
-    // Verify delete_dir and contents are removed
     assert!(!dest_root.join("delete_dir").exists(), "delete_dir should be removed");
 }
 
@@ -1076,7 +1033,6 @@ fn no_backup_when_file_is_new() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source file that doesn't exist in destination
     let source_file = ctx.source.join("new_file.txt");
     fs::write(&source_file, b"brand new").expect("write source");
 
@@ -1094,10 +1050,8 @@ fn no_backup_when_file_is_new() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // File should be created
     assert!(dest_root.join("new_file.txt").exists());
 
-    // But no backup should exist (nothing to back up)
     let backup = dest_root.join("new_file.txt~");
     assert!(!backup.exists(), "backup should not exist for new file");
 }
@@ -1107,14 +1061,12 @@ fn backup_multiple_files_same_directory() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create multiple source files
     test_helpers::create_test_tree(&ctx.source, &[
         ("file1.txt", Some(b"content1-new")),
         ("file2.txt", Some(b"content2-new")),
         ("file3.txt", Some(b"content3-new")),
     ]);
 
-    // Create existing destination files
     let dest_root = ctx.dest.join("source");
     test_helpers::create_test_tree(&dest_root, &[
         ("file1.txt", Some(b"content1-old")),
@@ -1134,7 +1086,6 @@ fn backup_multiple_files_same_directory() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // All files should be backed up
     for i in 1..=3 {
         let backup = dest_root.join(format!("file{i}.txt.bak"));
         assert!(backup.exists(), "backup{} missing at {}", i, backup.display());
@@ -1175,17 +1126,14 @@ fn backup_with_delete_before() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Deleted file should be backed up
     let backup_removed = backup_dir.join("source/remove.txt~");
     assert!(backup_removed.exists(), "backup of deleted file missing at {}", backup_removed.display());
     assert_eq!(fs::read(&backup_removed).expect("read backup"), b"to remove");
 
-    // Modified file should also be backed up
     let backup_keep = backup_dir.join("source/keep.txt~");
     assert!(backup_keep.exists(), "backup of modified file missing");
     assert_eq!(fs::read(&backup_keep).expect("read backup"), b"old keep");
 
-    // Originals should be gone or updated
     assert!(!dest_root.join("remove.txt").exists(), "deleted file should not exist");
     assert_eq!(fs::read(dest_root.join("keep.txt")).expect("read dest"), b"keep");
 }
@@ -1216,12 +1164,10 @@ fn backup_with_delete_delay() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Deleted file should be backed up
     let backup_gone = backup_dir.join("source/gone.txt~");
     assert!(backup_gone.exists(), "backup of deleted file missing at {}", backup_gone.display());
     assert_eq!(fs::read(&backup_gone).expect("read backup"), b"gone content");
 
-    // File should be gone from destination
     assert!(!dest_root.join("gone.txt").exists(), "deleted file should be removed");
     assert_eq!(fs::read(dest_root.join("stay.txt")).expect("read dest"), b"stay content");
 }
@@ -1237,7 +1183,6 @@ fn backup_with_trailing_slash_source() {
     // Source files (trailing-slash means contents go directly into dest)
     fs::write(source.join("file.txt"), b"new data").expect("write source");
 
-    // Existing dest file to be overwritten
     fs::write(dest.join("file.txt"), b"old data").expect("write dest");
 
     let mut source_operand = source.clone().into_os_string();
@@ -1473,11 +1418,9 @@ fn backup_with_force_directory_replaced_by_file() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Source has a regular file named "item"
     let source_file = ctx.source.join("item");
     fs::write(&source_file, b"file content").expect("write source file");
 
-    // Destination has a directory named "item" with a file inside
     let dest_root = ctx.dest.join("source");
     let dest_dir = dest_root.join("item");
     fs::create_dir_all(&dest_dir).expect("create dest dir");
@@ -1496,7 +1439,6 @@ fn backup_with_force_directory_replaced_by_file() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // The file should now exist at dest_root/item
     assert!(dest_root.join("item").is_file(), "item should be a file now");
     assert_eq!(fs::read(dest_root.join("item")).expect("read dest"), b"file content");
 }
@@ -1567,10 +1509,8 @@ fn backup_with_delete_and_trailing_slash() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Source has only one file
     fs::write(source.join("remain.txt"), b"remain").expect("write source");
 
-    // Destination has files that should be deleted
     fs::write(dest.join("remain.txt"), b"old remain").expect("write dest remain");
     fs::write(dest.join("extra.txt"), b"extra content").expect("write dest extra");
 
@@ -1591,20 +1531,16 @@ fn backup_with_delete_and_trailing_slash() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // The extra file should be deleted from dest
     assert!(!dest.join("extra.txt").exists(), "extra file should be deleted");
 
-    // But backed up
     let backup_extra = backup_dir.join("extra.txt~");
     assert!(backup_extra.exists(), "backup of deleted file missing at {}", backup_extra.display());
     assert_eq!(fs::read(&backup_extra).expect("read backup"), b"extra content");
 
-    // Modified file should be backed up
     let backup_remain = backup_dir.join("remain.txt~");
     assert!(backup_remain.exists(), "backup of modified file missing");
     assert_eq!(fs::read(&backup_remain).expect("read backup"), b"old remain");
 
-    // Destination should have updated content
     assert_eq!(fs::read(dest.join("remain.txt")).expect("read dest"), b"remain");
 }
 
@@ -1613,7 +1549,6 @@ fn backup_large_file_preserves_content() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create a larger file to ensure backup handles it correctly
     let large_content: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
     let source_file = ctx.source.join("large.bin");
     fs::write(&source_file, &large_content).expect("write source");
@@ -1644,14 +1579,12 @@ fn backup_recursive_multiple_directories() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create a multi-level source structure
     test_helpers::create_test_tree(&ctx.source, &[
         ("dir_a/file_a.txt", Some(b"new_a")),
         ("dir_b/file_b.txt", Some(b"new_b")),
         ("dir_a/sub/file_sub.txt", Some(b"new_sub")),
     ]);
 
-    // Create existing destination structure
     let dest_root = ctx.dest.join("source");
     test_helpers::create_test_tree(&dest_root, &[
         ("dir_a/file_a.txt", Some(b"old_a")),
@@ -1672,7 +1605,6 @@ fn backup_recursive_multiple_directories() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify all backups preserve directory structure
     let backup_a = backup_dir.join("source/dir_a/file_a.txt~");
     assert!(backup_a.exists(), "backup_a missing at {}", backup_a.display());
     assert_eq!(fs::read(&backup_a).expect("read"), b"old_a");
@@ -1685,7 +1617,6 @@ fn backup_recursive_multiple_directories() {
     assert!(backup_sub.exists(), "backup_sub missing at {}", backup_sub.display());
     assert_eq!(fs::read(&backup_sub).expect("read"), b"old_sub");
 
-    // Verify destination updated
     assert_eq!(fs::read(dest_root.join("dir_a/file_a.txt")).expect("read"), b"new_a");
     assert_eq!(fs::read(dest_root.join("dir_b/file_b.txt")).expect("read"), b"new_b");
     assert_eq!(fs::read(dest_root.join("dir_a/sub/file_sub.txt")).expect("read"), b"new_sub");
@@ -1708,7 +1639,6 @@ fn backup_disabled_after_enabling_does_not_create_backups() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    // Enable then disable backup
     let options = LocalCopyOptions::default()
         .backup(true)
         .backup(false);
@@ -1751,17 +1681,14 @@ fn backup_with_delete_during() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // File that was deleted should be backed up
     let backup_removed = backup_dir.join("source/subdir/remove.txt~");
     assert!(backup_removed.exists(), "backup of deleted file missing at {}", backup_removed.display());
     assert_eq!(fs::read(&backup_removed).expect("read backup"), b"remove me");
 
-    // File that was modified should be backed up
     let backup_keep = backup_dir.join("source/subdir/keep.txt~");
     assert!(backup_keep.exists(), "backup of modified file missing");
     assert_eq!(fs::read(&backup_keep).expect("read backup"), b"keep old");
 
-    // Verify destination state
     assert!(!dest_root.join("subdir/remove.txt").exists(), "deleted file should be gone");
     assert_eq!(fs::read(dest_root.join("subdir/keep.txt")).expect("read dest"), b"keep new");
 }
@@ -1776,7 +1703,6 @@ fn backup_empty_file() {
 
     let dest_root = ctx.dest.join("source");
     fs::create_dir_all(&dest_root).expect("create dest root");
-    // Existing file is empty
     fs::write(dest_root.join("empty.txt"), b"").expect("write empty dest");
 
     let operands = vec![
@@ -1800,7 +1726,6 @@ fn backup_to_empty_file() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Source is empty, dest has content
     let source_file = ctx.source.join("zeroed.txt");
     fs::write(&source_file, b"").expect("write empty source");
 
@@ -1853,12 +1778,10 @@ fn backup_dir_with_no_suffix_upstream_behavior() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Backup should have same name (no suffix)
     let backup = backup_dir.join("source/dir/file.txt");
     assert!(backup.exists(), "backup missing at {}", backup.display());
     assert_eq!(fs::read(&backup).expect("read backup"), b"old");
 
-    // No tilde-suffixed backup should exist
     let wrong_backup = backup_dir.join("source/dir/file.txt~");
     assert!(!wrong_backup.exists(), "should not have ~ suffix backup");
 }
@@ -1896,12 +1819,10 @@ fn backup_delete_multiple_extraneous_in_subdirs() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Source has minimal files
     test_helpers::create_test_tree(&ctx.source, &[
         ("a/keep.txt", Some(b"keep")),
     ]);
 
-    // Destination has many extra files in subdirectories
     let dest_root = ctx.dest.join("source");
     test_helpers::create_test_tree(&dest_root, &[
         ("a/keep.txt", Some(b"old keep")),
@@ -1924,7 +1845,6 @@ fn backup_delete_multiple_extraneous_in_subdirs() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // All extraneous files should be backed up
     let backup1 = backup_dir.join("source/a/extra1.txt.bak");
     let backup2 = backup_dir.join("source/a/extra2.txt.bak");
     assert!(backup1.exists(), "backup1 missing at {}", backup1.display());
@@ -1932,12 +1852,10 @@ fn backup_delete_multiple_extraneous_in_subdirs() {
     assert_eq!(fs::read(&backup1).expect("read"), b"extra1");
     assert_eq!(fs::read(&backup2).expect("read"), b"extra2");
 
-    // Modified file should also be backed up
     let backup_keep = backup_dir.join("source/a/keep.txt.bak");
     assert!(backup_keep.exists(), "backup of keep missing");
     assert_eq!(fs::read(&backup_keep).expect("read"), b"old keep");
 
-    // Extraneous files removed from dest
     assert!(!dest_root.join("a/extra1.txt").exists());
     assert!(!dest_root.join("a/extra2.txt").exists());
     assert_eq!(fs::read(dest_root.join("a/keep.txt")).expect("read"), b"keep");
@@ -1960,7 +1878,6 @@ fn backup_delete_with_suffix_only() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    // backup + delete + suffix only (no backup-dir)
     let options = LocalCopyOptions::default()
         .delete(true)
         .backup(true);
@@ -1968,10 +1885,8 @@ fn backup_delete_with_suffix_only() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // The original extra should be gone
     assert!(!dest_root.join("extra.txt").exists(), "deleted file should not exist");
 
-    // The destination file should have new content
     assert_eq!(fs::read(dest_root.join("keep.txt")).expect("read dest"), b"keep");
 
     // Without --backup-dir, backup + delete with suffix-only creates backups
@@ -1991,12 +1906,10 @@ fn backup_not_created_for_new_directory() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Source has a directory with a file
     test_helpers::create_test_tree(&ctx.source, &[
         ("newdir/file.txt", Some(b"content")),
     ]);
 
-    // Destination doesn't have this directory
     let dest_root = ctx.dest.join("source");
     fs::create_dir_all(&dest_root).expect("create dest root");
 
@@ -2010,10 +1923,8 @@ fn backup_not_created_for_new_directory() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // New directory should be created
     assert!(dest_root.join("newdir/file.txt").exists());
 
-    // No backup should exist for new files/directories
     let backup = dest_root.join("newdir/file.txt~");
     assert!(!backup.exists(), "no backup for newly created files");
 }
@@ -2441,7 +2352,6 @@ fn backup_delete_skips_already_suffixed_extraneous_file() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy with --delete --backup succeeds");
 
-    // Plain file removed and backed up.
     assert!(
         !dest_root.join("plain").exists(),
         "extraneous plain file must be removed"
@@ -2451,7 +2361,6 @@ fn backup_delete_skips_already_suffixed_extraneous_file() {
         "extraneous plain file must be backed up to plain~"
     );
 
-    // Suffixed file removed, with no double-suffix backup created.
     assert!(
         !dest_root.join("stale~").exists(),
         "already-suffixed extraneous file must be removed"

--- a/crates/engine/src/local_copy/tests/builder_integration.rs
+++ b/crates/engine/src/local_copy/tests/builder_integration.rs
@@ -1,7 +1,7 @@
-//! Integration tests demonstrating the builder pattern for LocalCopyOptions.
-//!
-//! These tests show how the builder pattern makes test setup cleaner compared
-//! to the direct fluent API approach.
+// Integration tests demonstrating the builder pattern for LocalCopyOptions.
+//
+// These tests show how the builder pattern makes test setup cleaner compared
+// to the direct fluent API approach.
 
 use std::path::PathBuf;
 
@@ -11,8 +11,6 @@ use crate::local_copy::{
 };
 use tempfile::tempdir;
 use std::fs;
-
-// These tests show the previous pattern (still valid, but more verbose)
 
 #[test]
 fn fluent_api_basic_copy() {
@@ -32,8 +30,6 @@ fn fluent_api_basic_copy() {
 
     assert_eq!(fs::read(&dest).expect("read"), b"hello");
 }
-
-// These tests demonstrate cleaner setup with the builder
 
 #[test]
 fn builder_basic_copy() {
@@ -323,11 +319,9 @@ fn builder_chaining_modifies_preset() {
         .build()
         .expect("valid options");
 
-    // Archive settings
     assert!(options.recursive_enabled());
     assert!(options.links_enabled());
 
-    // Additional customizations
     assert!(options.compress_enabled());
     assert!(options.partial_enabled());
     assert!(options.fsync_enabled());
@@ -350,7 +344,6 @@ fn builder_default_values_match_local_copy_options_default() {
     let from_builder = LocalCopyOptions::builder().build().expect("valid options");
     let from_default = LocalCopyOptions::default();
 
-    // Key defaults should match
     assert_eq!(
         from_builder.recursive_enabled(),
         from_default.recursive_enabled()

--- a/crates/engine/src/local_copy/tests/checksum_algorithm_behavior.rs
+++ b/crates/engine/src/local_copy/tests/checksum_algorithm_behavior.rs
@@ -60,7 +60,6 @@ fn checksum_md4_transfers_different_files() {
     fs::write(&source, b"source!").expect("write source");
     fs::write(&destination, b"dest!!!").expect("write dest");
 
-    // Set identical timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(&source, timestamp).expect("set source time");
     set_file_mtime(&destination, timestamp).expect("set dest time");
@@ -100,7 +99,6 @@ fn checksum_md5_skips_identical_files() {
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
 
-    // Set different timestamps
     let older_time = FileTime::from_unix_time(1_700_000_000, 0);
     let newer_time = FileTime::from_unix_time(1_700_000_100, 0);
     set_file_mtime(&source, newer_time).expect("set source time");
@@ -371,7 +369,6 @@ fn checksum_xxh64_different_seeds_are_independent() {
         set_file_mtime(path, older_time).expect("set dest time");
     }
 
-    // Test with seed 0
     let operands1 = vec![
         source1.into_os_string(),
         dest1.clone().into_os_string(),
@@ -386,7 +383,6 @@ fn checksum_xxh64_different_seeds_are_independent() {
         )
         .expect("copy1 succeeds");
 
-    // Test with different seed
     let operands2 = vec![
         source2.into_os_string(),
         dest2.clone().into_os_string(),
@@ -565,7 +561,6 @@ fn checksum_ignores_mtime_when_content_matches() {
     set_file_mtime(&source, very_new).expect("set source time");
     set_file_mtime(&destination, very_old).expect("set dest time");
 
-    // Record destination mtime before sync
     let dest_mtime_before = FileTime::from_last_modification_time(
         &fs::metadata(&destination).expect("dest metadata"),
     );
@@ -587,7 +582,6 @@ fn checksum_ignores_mtime_when_content_matches() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
 
-    // Destination mtime should be unchanged
     let dest_mtime_after = FileTime::from_last_modification_time(
         &fs::metadata(&destination).expect("dest metadata"),
     );
@@ -642,13 +636,11 @@ fn without_checksum_mtime_match_skips_even_with_different_content() {
     fs::write(&source, b"source!!").expect("write source");
     fs::write(&destination, b"dest!!!!").expect("write dest");
 
-    // Verify same size
     assert_eq!(
         fs::metadata(&source).expect("source meta").len(),
         fs::metadata(&destination).expect("dest meta").len()
     );
 
-    // Set identical timestamps
     let same_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(&source, same_time).expect("set source time");
     set_file_mtime(&destination, same_time).expect("set dest time");
@@ -659,7 +651,6 @@ fn without_checksum_mtime_match_skips_even_with_different_content() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Without checksum mode
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
@@ -683,7 +674,6 @@ fn checksum_transfer_produces_correct_content() {
     let source = temp.path().join("source.bin");
     let destination = temp.path().join("dest.bin");
 
-    // Create binary content with known pattern
     let source_content: Vec<u8> = (0..=255).cycle().take(10000).collect();
     fs::write(&source, &source_content).expect("write source");
 
@@ -702,7 +692,6 @@ fn checksum_transfer_produces_correct_content() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify content byte-for-byte
     let dest_content = fs::read(&destination).expect("read dest");
     assert_eq!(dest_content, source_content);
 }
@@ -907,7 +896,6 @@ fn checksum_recursive_directory_mixed_files() {
     assert_eq!(summary.regular_files_total(), 3);
     assert_eq!(summary.regular_files_matched(), 1);
 
-    // Verify content
     assert_eq!(
         fs::read(dest_root.join("same.txt")).expect("read"),
         b"identical"

--- a/crates/engine/src/local_copy/tests/concurrent_modification.rs
+++ b/crates/engine/src/local_copy/tests/concurrent_modification.rs
@@ -67,7 +67,6 @@ fn multiple_files_with_one_deleted_continues_transfer() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create multiple source files
     fs::write(source_root.join("keep1.txt"), b"content 1").expect("write keep1");
     fs::write(source_root.join("vanish.txt"), b"will be deleted").expect("write vanish");
     fs::write(source_root.join("keep2.txt"), b"content 2").expect("write keep2");
@@ -75,16 +74,13 @@ fn multiple_files_with_one_deleted_continues_transfer() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let mut source_operand = source_root.clone().into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Delete one file
     fs::remove_file(source_root.join("vanish.txt")).expect("delete vanish");
 
-    // Execute
     let result = plan.execute_with_options(
         LocalCopyExecution::Apply,
         LocalCopyOptions::default().ignore_missing_args(true),
@@ -151,7 +147,6 @@ fn file_size_changed_during_transfer_is_detected() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a medium-sized file
     let source_file = source_root.join("growing.txt");
     let initial_content = vec![b'A'; 1024];
     fs::write(&source_file, &initial_content).expect("write initial");
@@ -167,10 +162,9 @@ fn file_size_changed_during_transfer_is_detected() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // Modify the file before execution (simulating concurrent modification)
-    let modified_content = vec![b'B'; 2048]; // Double the size
+    let modified_content = vec![b'B'; 2048];
     fs::write(&source_file, &modified_content).expect("write modified");
 
-    // Execute
     let result = plan.execute();
 
     // Should succeed - file was modified but still exists
@@ -191,7 +185,6 @@ fn file_truncated_during_transfer_is_handled() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a file
     let source_file = source_root.join("truncating.txt");
     let initial_content = vec![b'X'; 4096];
     fs::write(&source_file, &initial_content).expect("write initial");
@@ -199,7 +192,6 @@ fn file_truncated_during_transfer_is_handled() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.clone().into_os_string(),
@@ -231,14 +223,12 @@ fn file_content_changed_same_size_during_transfer() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a file with specific content
     let source_file = source_root.join("content_change.txt");
     fs::write(&source_file, b"AAAAAAAAAA").expect("write initial");
 
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.clone().into_os_string(),
@@ -248,7 +238,6 @@ fn file_content_changed_same_size_during_transfer() {
     // Modify content (same size)
     fs::write(&source_file, b"BBBBBBBBBB").expect("modify content");
 
-    // Execute
     let result = plan.execute();
 
     // Should succeed
@@ -270,14 +259,12 @@ fn file_replaced_with_directory_during_transfer() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a regular file
     let source_item = source_root.join("item");
     fs::write(&source_item, b"file content").expect("write file");
 
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let mut source_operand = source_root.clone().into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
@@ -304,18 +291,15 @@ fn file_replaced_with_symlink_during_transfer() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a regular file
     let source_file = source_root.join("regular.txt");
     fs::write(&source_file, b"regular content").expect("write file");
 
-    // Create a target for the symlink
     let target = source_root.join("target.txt");
     fs::write(&target, b"target content").expect("write target");
 
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.clone().into_os_string(),
@@ -326,7 +310,6 @@ fn file_replaced_with_symlink_during_transfer() {
     fs::remove_file(&source_file).expect("remove file");
     symlink(&target, &source_file).expect("create symlink");
 
-    // Execute
     let result = plan.execute();
 
     // Should handle gracefully
@@ -345,7 +328,6 @@ fn file_replaced_with_different_content_during_transfer() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.clone().into_os_string(),
@@ -356,7 +338,6 @@ fn file_replaced_with_different_content_during_transfer() {
     fs::remove_file(&source_file).expect("remove");
     fs::write(&source_file, b"completely different new content").expect("write new");
 
-    // Execute
     let result = plan.execute();
 
     // Should succeed with the new content
@@ -375,7 +356,6 @@ fn new_file_added_during_scan_may_be_included() {
 
     let dest_root = temp.path().join("dest");
 
-    // Build plan
     let mut source_operand = source_root.clone().into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
@@ -405,7 +385,6 @@ fn nested_directory_removed_during_recursive_scan() {
 
     let dest_root = temp.path().join("dest");
 
-    // Build plan
     let mut source_operand = source_root.clone().into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
@@ -473,7 +452,6 @@ fn checksum_mode_skips_identical_content() {
     fs::create_dir_all(&dest_root).expect("create dest");
     fs::write(dest_root.join("same.txt"), content).expect("write dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.join("same.txt").into_os_string(),
@@ -513,7 +491,6 @@ fn checksum_mismatch_with_same_size_and_mtime() {
     set_file_mtime(&source_file, timestamp).expect("set source mtime");
     set_file_mtime(dest_root.join("sneaky.txt"), timestamp).expect("set dest mtime");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.join("sneaky.txt").into_os_string(),
@@ -534,7 +511,6 @@ fn checksum_mismatch_with_same_size_and_mtime() {
         Err(e) => panic!("unexpected error without checksum: {e}"),
     }
 
-    // Reset destination
     fs::write(dest_root.join("sneaky.txt"), b"BBBBBBBBBB").expect("reset dest");
     set_file_mtime(dest_root.join("sneaky.txt"), timestamp).expect("reset mtime");
 
@@ -572,16 +548,13 @@ fn transfer_continues_after_single_file_error() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let mut source_operand = source_root.clone().into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Delete middle file
     fs::remove_file(source_root.join("second.txt")).expect("delete second");
 
-    // Execute
     let result = plan.execute();
 
     // Check behavior
@@ -628,7 +601,6 @@ fn empty_file_becoming_non_empty_during_transfer() {
     // File grows after plan is built
     fs::write(&source_file, b"now has content").expect("write content");
 
-    // Execute
     let result = plan.execute();
 
     // Should succeed with either old or new content
@@ -654,7 +626,6 @@ fn non_empty_file_becoming_empty_during_transfer() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.clone().into_os_string(),
@@ -664,7 +635,6 @@ fn non_empty_file_becoming_empty_during_transfer() {
     // Truncate to empty
     fs::write(&source_file, b"").expect("truncate");
 
-    // Execute
     let result = plan.execute();
 
     // Should handle gracefully
@@ -683,7 +653,6 @@ fn rapid_file_modifications_are_handled() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.clone().into_os_string(),
@@ -695,7 +664,6 @@ fn rapid_file_modifications_are_handled() {
         fs::write(&source_file, format!("version {i}").as_bytes()).expect("write version");
     }
 
-    // Execute
     let result = plan.execute();
 
     // Should succeed with some version
@@ -720,7 +688,6 @@ fn file_permission_changed_during_transfer() {
         let dest_root = temp.path().join("dest");
         fs::create_dir_all(&dest_root).expect("create dest");
 
-        // Build plan
         let operands = vec![
             source_file.clone().into_os_string(),
             dest_root.clone().into_os_string(),
@@ -730,7 +697,6 @@ fn file_permission_changed_during_transfer() {
         // Change permissions
         fs::set_permissions(&source_file, PermissionsExt::from_mode(0o755)).expect("change perms");
 
-        // Execute
         let result = plan.execute_with_options(
             LocalCopyExecution::Apply,
             LocalCopyOptions::default().permissions(true),
@@ -753,7 +719,6 @@ fn file_deleted_and_recreated_during_transfer() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.clone().into_os_string(),
@@ -764,7 +729,6 @@ fn file_deleted_and_recreated_during_transfer() {
     fs::remove_file(&source_file).expect("delete");
     fs::write(&source_file, b"reborn phoenix").expect("recreate");
 
-    // Execute
     let result = plan.execute();
 
     // Should succeed with new content
@@ -784,15 +748,13 @@ fn large_file_truncated_to_zero_during_transfer() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a larger file
     let source_file = source_root.join("large.bin");
-    let large_content = vec![0xAB; 64 * 1024]; // 64KB
+    let large_content = vec![0xAB; 64 * 1024];
     fs::write(&source_file, &large_content).expect("write large");
 
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.clone().into_os_string(),
@@ -802,7 +764,6 @@ fn large_file_truncated_to_zero_during_transfer() {
     // Truncate to zero
     fs::write(&source_file, b"").expect("truncate to zero");
 
-    // Execute
     let result = plan.execute();
 
     // Should handle gracefully
@@ -828,7 +789,6 @@ fn directory_permissions_changed_during_scan() {
 
         let dest_root = temp.path().join("dest");
 
-        // Build plan
         let mut source_operand = source_root.clone().into_os_string();
         source_operand.push(std::path::MAIN_SEPARATOR.to_string());
         let operands = vec![source_operand, dest_root.clone().into_os_string()];
@@ -837,7 +797,6 @@ fn directory_permissions_changed_during_scan() {
         // Make directory unreadable
         fs::set_permissions(&subdir, PermissionsExt::from_mode(0o000)).expect("remove perms");
 
-        // Execute
         let result = plan.execute();
 
         // Restore permissions for cleanup
@@ -862,18 +821,15 @@ fn binary_file_modified_during_transfer() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Modify binary content
     let modified: Vec<u8> = (0..=255).rev().collect();
     fs::write(&source_file, &modified).expect("modify binary");
 
-    // Execute
     let result = plan.execute();
 
     // Should succeed
@@ -898,7 +854,6 @@ fn mtime_changed_during_transfer_detection() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Build plan
     let operands = vec![
         source_file.clone().into_os_string(),
         dest_root.clone().into_os_string(),

--- a/crates/engine/src/local_copy/tests/delete.rs
+++ b/crates/engine/src/local_copy/tests/delete.rs
@@ -114,11 +114,9 @@ fn delete_after_files_present_during_transfer() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create source files
     fs::write(source.join("keep.txt"), b"keep content").expect("write keep");
     fs::write(source.join("update.txt"), b"new version").expect("write update");
 
-    // Create destination with extra file that should be deleted
     fs::write(dest.join("keep.txt"), b"old keep").expect("write old keep");
     fs::write(dest.join("update.txt"), b"old version").expect("write old update");
     fs::write(dest.join("delete_me.txt"), b"to be deleted").expect("write delete_me");
@@ -175,14 +173,12 @@ fn delete_after_files_present_during_transfer() {
         .execute_with_options_and_handler(LocalCopyExecution::Apply, options, Some(&mut observer))
         .expect("copy succeeds");
 
-    // Verify deletions happened
     assert!(!dest.join("delete_me.txt").exists(), "delete_me.txt should be deleted");
     assert!(!dest.join("also_delete.txt").exists(), "also_delete.txt should be deleted");
     assert!(dest.join("keep.txt").exists(), "keep.txt should exist");
     assert!(dest.join("update.txt").exists(), "update.txt should exist");
     assert_eq!(summary.items_deleted(), 2);
 
-    // Verify files existed during transfer
     let seen = files_during_copy.lock().unwrap();
     assert!(seen.contains("delete_me.txt"), "delete_me.txt should have existed during transfer");
     assert!(seen.contains("also_delete.txt"), "also_delete.txt should have existed during transfer");
@@ -196,13 +192,11 @@ fn delete_after_deletes_after_all_transfers_complete() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create nested directory structure in source
     let nested = source.join("subdir");
     fs::create_dir_all(&nested).expect("create nested");
     fs::write(source.join("file1.txt"), b"file1").expect("write file1");
     fs::write(nested.join("file2.txt"), b"file2").expect("write file2");
 
-    // Create destination with files to delete at root and in subdirectory
     fs::write(dest.join("root_extra.txt"), b"root extra").expect("write root_extra");
     let dest_nested = dest.join("subdir");
     fs::create_dir_all(&dest_nested).expect("create dest nested");
@@ -224,11 +218,9 @@ fn delete_after_deletes_after_all_transfers_complete() {
     let summary = report.summary();
     let records = report.records();
 
-    // Verify all transfers completed
     assert!(dest.join("file1.txt").exists());
     assert!(dest_nested.join("file2.txt").exists());
 
-    // Verify all deletions happened
     assert!(!dest.join("root_extra.txt").exists());
     assert!(!dest_nested.join("nested_extra.txt").exists());
     assert_eq!(summary.items_deleted(), 2);
@@ -271,7 +263,6 @@ fn delete_after_timing_differs_from_delete_before() {
     fs::create_dir_all(&dest_after).expect("create dest_after");
     fs::create_dir_all(&dest_before).expect("create dest_before");
 
-    // Create a file that exists in source
     fs::write(source.join("keep.txt"), b"keep").expect("write keep");
 
     // For delete-after: create extra file in destination
@@ -282,7 +273,6 @@ fn delete_after_timing_differs_from_delete_before() {
     fs::write(dest_before.join("extra.txt"), b"extra").expect("write extra_before");
     fs::write(dest_before.join("keep.txt"), b"old keep").expect("write old keep_before");
 
-    // Test delete-after
     let mut source_operand_after = source.clone().into_os_string();
     source_operand_after.push(std::path::MAIN_SEPARATOR.to_string());
     let operands_after = vec![source_operand_after, dest_after.clone().into_os_string()];
@@ -296,7 +286,6 @@ fn delete_after_timing_differs_from_delete_before() {
         .execute_with_report(LocalCopyExecution::Apply, options_after)
         .expect("copy with delete-after succeeds");
 
-    // Test delete-before
     let mut source_operand_before = source.into_os_string();
     source_operand_before.push(std::path::MAIN_SEPARATOR.to_string());
     let operands_before = vec![source_operand_before, dest_before.clone().into_os_string()];
@@ -316,7 +305,6 @@ fn delete_after_timing_differs_from_delete_before() {
     assert!(dest_after.join("keep.txt").exists());
     assert!(dest_before.join("keep.txt").exists());
 
-    // Analyze event order
     let records_after = report_after.records();
     let records_before = report_before.records();
 
@@ -350,7 +338,6 @@ fn delete_after_timing_differs_from_delete_before() {
         }
     }
 
-    // Verify timing difference
     if let (Some(after_copy), Some(after_delete)) = (after_last_copy, after_first_delete) {
         assert!(
             after_copy < after_delete,
@@ -372,13 +359,11 @@ fn delete_after_timing_differs_from_delete_during() {
     let source = temp.path().join("source");
     fs::create_dir_all(&source).expect("create source");
 
-    // Create nested structure
     let subdir = source.join("subdir");
     fs::create_dir_all(&subdir).expect("create subdir");
     fs::write(source.join("root.txt"), b"root").expect("write root");
     fs::write(subdir.join("nested.txt"), b"nested").expect("write nested");
 
-    // Test delete-after
     let dest_after = temp.path().join("dest_after");
     fs::create_dir_all(&dest_after).expect("create dest_after");
     fs::write(dest_after.join("root_extra.txt"), b"root extra").expect("write root_extra");
@@ -399,7 +384,6 @@ fn delete_after_timing_differs_from_delete_during() {
         .execute_with_report(LocalCopyExecution::Apply, options_after)
         .expect("copy with delete-after succeeds");
 
-    // Test delete-during (default)
     let dest_during = temp.path().join("dest_during");
     fs::create_dir_all(&dest_during).expect("create dest_during");
     fs::write(dest_during.join("root_extra.txt"), b"root extra").expect("write root_extra");
@@ -472,7 +456,6 @@ fn delete_after_with_multiple_directories() {
     let source = temp.path().join("source");
     fs::create_dir_all(&source).expect("create source");
 
-    // Create multiple subdirectories
     let dir1 = source.join("dir1");
     let dir2 = source.join("dir2");
     fs::create_dir_all(&dir1).expect("create dir1");
@@ -480,7 +463,6 @@ fn delete_after_with_multiple_directories() {
     fs::write(dir1.join("file1.txt"), b"file1").expect("write file1");
     fs::write(dir2.join("file2.txt"), b"file2").expect("write file2");
 
-    // Create destination with extra files in each directory
     let dest = temp.path().join("dest");
     let dest_dir1 = dest.join("dir1");
     let dest_dir2 = dest.join("dir2");
@@ -504,11 +486,9 @@ fn delete_after_with_multiple_directories() {
 
     let summary = report.summary();
 
-    // Verify all source files copied
     assert!(dest_dir1.join("file1.txt").exists());
     assert!(dest_dir2.join("file2.txt").exists());
 
-    // Verify all extra files deleted
     assert!(!dest_dir1.join("extra1.txt").exists());
     assert!(!dest_dir2.join("extra2.txt").exists());
     assert_eq!(summary.items_deleted(), 2);
@@ -565,15 +545,12 @@ fn delete_after_works_with_dry_run() {
 
     let summary = report.summary();
 
-    // In dry-run, nothing should be modified
     assert_eq!(fs::read(dest.join("keep.txt")).expect("read"), b"old keep");
     assert!(dest.join("delete_me.txt").exists(), "file should still exist in dry-run");
 
-    // But summary should report what would happen
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.items_deleted(), 1);
 
-    // Verify event ordering in dry-run too
     let records = report.records();
     let mut last_copy_index = None;
     let mut first_delete_index = None;

--- a/crates/engine/src/local_copy/tests/delete_delay.rs
+++ b/crates/engine/src/local_copy/tests/delete_delay.rs
@@ -19,11 +19,9 @@ fn delete_delay_removes_extraneous_files_after_transfer() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source with two files
     fs::write(ctx.source.join("file1.txt"), b"file1").expect("write file1");
     fs::write(ctx.source.join("file2.txt"), b"file2").expect("write file2");
 
-    // Create destination with source files plus extra files
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("file1.txt"), b"old1").expect("write old1");
@@ -42,7 +40,6 @@ fn delete_delay_removes_extraneous_files_after_transfer() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify correct files remain and extras are deleted
     assert!(target_root.join("file1.txt").exists());
     assert!(target_root.join("file2.txt").exists());
     assert!(!target_root.join("extra1.txt").exists());
@@ -56,12 +53,10 @@ fn delete_delay_defers_directory_deletions_until_end() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source structure: dir1/file.txt
     let source_dir = ctx.source.join("dir1");
     fs::create_dir_all(&source_dir).expect("create source dir");
     fs::write(source_dir.join("file.txt"), b"content").expect("write file");
 
-    // Create destination with extra directory
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::create_dir_all(target_root.join("dir1")).expect("create target dir1");
@@ -82,12 +77,11 @@ fn delete_delay_defers_directory_deletions_until_end() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify extra directory is deleted
     assert!(target_root.join("dir1").exists());
     assert!(target_root.join("dir1/file.txt").exists());
     assert!(!extra_dir.exists());
     assert_eq!(summary.files_copied(), 1);
-    assert!(summary.items_deleted() >= 1); // At least the directory
+    assert!(summary.items_deleted() >= 1);
 }
 
 
@@ -113,7 +107,6 @@ fn delete_delay_differs_from_delete_during_timing() {
         ctx.dest.clone().into_os_string(),
     ];
 
-    // Test with delete-delay
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options_delay = LocalCopyOptions::default().delete_delay(true);
     assert!(options_delay.delete_delay_enabled());
@@ -123,7 +116,6 @@ fn delete_delay_differs_from_delete_during_timing() {
         .execute_with_options(LocalCopyExecution::Apply, options_delay)
         .expect("copy succeeds with delay");
 
-    // Create new destination for delete-during test
     let ctx2 = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx2.dest).expect("create dest2");
     fs::write(ctx2.source.join("keep.txt"), b"keep").expect("write keep2");
@@ -138,7 +130,6 @@ fn delete_delay_differs_from_delete_during_timing() {
         ctx2.dest.clone().into_os_string(),
     ];
 
-    // Test with delete-during
     let plan2 = LocalCopyPlan::from_operands(&operands2).expect("plan2");
     let options_during = LocalCopyOptions::default().delete_during();
     assert!(!options_during.delete_delay_enabled());
@@ -174,14 +165,12 @@ fn delete_delay_works_with_recursive_traversal() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create nested source structure
     test_helpers::create_test_tree(&ctx.source, &[
         ("level1/level2/level3/file.txt", Some(b"deep")),
         ("level1/keep.txt", Some(b"keep1")),
         ("top.txt", Some(b"top")),
     ]);
 
-    // Create destination with extra files at various levels.
     // Use shorter content than source to ensure different sizes, avoiding
     // quick-check (same mtime+size) skipping the transfer.
     let target_root = ctx.dest.join("source");
@@ -208,12 +197,10 @@ fn delete_delay_works_with_recursive_traversal() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify kept files exist
     assert!(target_root.join("top.txt").exists());
     assert!(target_root.join("level1/keep.txt").exists());
     assert!(target_root.join("level1/level2/level3/file.txt").exists());
 
-    // Verify extra files at all levels are deleted
     assert!(!target_root.join("extra_top.txt").exists());
     assert!(!target_root.join("level1/extra_shallow.txt").exists());
     assert!(!target_root.join("level1/level2/extra_mid.txt").exists());
@@ -228,18 +215,15 @@ fn delete_delay_handles_nested_empty_directories() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Source has a directory with a file
     let source_dir = ctx.source.join("data");
     fs::create_dir_all(&source_dir).expect("create source dir");
     fs::write(source_dir.join("file.txt"), b"content").expect("write file");
 
-    // Destination has nested empty directories that should be deleted
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::create_dir_all(target_root.join("data")).expect("create data dir");
     fs::write(target_root.join("data/file.txt"), b"old").expect("write old file");
 
-    // Create extra nested empty directories
     fs::create_dir_all(target_root.join("empty1/empty2/empty3"))
         .expect("create nested empties");
 
@@ -254,7 +238,6 @@ fn delete_delay_handles_nested_empty_directories() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify data directory remains but empty directories are deleted
     assert!(target_root.join("data").exists());
     assert!(target_root.join("data/file.txt").exists());
     assert!(!target_root.join("empty1").exists());
@@ -271,7 +254,6 @@ fn delete_delay_with_max_deletions_limit() {
 
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with multiple extra files
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
@@ -297,7 +279,6 @@ fn delete_delay_with_max_deletions_limit() {
         other => panic!("unexpected error kind: {other:?}"),
     }
 
-    // Verify keep file exists and was updated
     assert!(target_root.join("keep.txt").exists());
     assert_eq!(
         fs::read(target_root.join("keep.txt")).expect("read keep"),
@@ -348,13 +329,11 @@ fn delete_delay_processes_deletions_even_after_successful_transfer() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify file was updated
     assert_eq!(
         fs::read(target_root.join("file.txt")).expect("read file"),
         b"new content"
     );
 
-    // Verify deferred deletion was processed
     assert!(!target_root.join("delete_me.txt").exists());
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.items_deleted(), 1);
@@ -366,17 +345,14 @@ fn delete_delay_batches_multiple_directory_deletions() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source with single directory
     fs::create_dir_all(ctx.source.join("keep_dir")).expect("create keep dir");
     fs::write(ctx.source.join("keep_dir/file.txt"), b"keep").expect("write keep");
 
-    // Create destination with multiple extra directories
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::create_dir_all(target_root.join("keep_dir")).expect("create target keep dir");
     fs::write(target_root.join("keep_dir/file.txt"), b"old").expect("write old");
 
-    // Extra directories to be deleted
     fs::create_dir_all(target_root.join("extra1")).expect("create extra1");
     fs::write(target_root.join("extra1/file1.txt"), b"extra1").expect("write extra1 file");
     fs::create_dir_all(target_root.join("extra2")).expect("create extra2");
@@ -395,11 +371,9 @@ fn delete_delay_batches_multiple_directory_deletions() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify keep directory remains
     assert!(target_root.join("keep_dir").exists());
     assert!(target_root.join("keep_dir/file.txt").exists());
 
-    // Verify all extra directories are deleted (batched deletions)
     assert!(!target_root.join("extra1").exists());
     assert!(!target_root.join("extra2").exists());
     assert!(!target_root.join("extra3").exists());
@@ -417,7 +391,6 @@ fn delete_delay_respects_exclude_filters() {
 
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with files matching filter patterns
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
@@ -439,7 +412,6 @@ fn delete_delay_respects_exclude_filters() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify keep file updated
     assert!(target_root.join("keep.txt").exists());
     assert_eq!(
         fs::read(target_root.join("keep.txt")).expect("read keep"),
@@ -465,7 +437,6 @@ fn delete_delay_with_delete_excluded_removes_filtered_files() {
 
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with files matching filter patterns
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
@@ -487,7 +458,6 @@ fn delete_delay_with_delete_excluded_removes_filtered_files() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify keep file exists
     assert!(target_root.join("keep.txt").exists());
 
     // Verify excluded file is deleted when delete_excluded is enabled
@@ -503,7 +473,6 @@ fn delete_delay_with_no_files_to_delete() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Source and destination have identical structure
     fs::write(ctx.source.join("file.txt"), b"content").expect("write source");
 
     let target_root = ctx.dest.join("source");
@@ -521,7 +490,6 @@ fn delete_delay_with_no_files_to_delete() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify file exists and was updated
     assert!(target_root.join("file.txt").exists());
     assert_eq!(
         fs::read(target_root.join("file.txt")).expect("read file"),
@@ -540,7 +508,6 @@ fn delete_delay_with_only_deletions_no_transfers() {
     // Empty source directory
     // (source directory already exists from setup_copy_test)
 
-    // Destination has files to delete
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("delete1.txt"), b"delete1").expect("write delete1");
@@ -557,7 +524,6 @@ fn delete_delay_with_only_deletions_no_transfers() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify all files are deleted
     assert!(!target_root.join("delete1.txt").exists());
     assert!(!target_root.join("delete2.txt").exists());
 
@@ -588,20 +554,17 @@ fn delete_delay_with_dry_run_reports_but_does_not_delete() {
         .execute_with_options(LocalCopyExecution::DryRun, options)
         .expect("dry run succeeds");
 
-    // In dry-run, extra file should still exist
     assert!(target_root.join("extra.txt").exists());
     assert_eq!(
         fs::read(target_root.join("extra.txt")).expect("read extra"),
         b"extra"
     );
 
-    // Old content should still exist (not updated in dry-run)
     assert_eq!(
         fs::read(target_root.join("keep.txt")).expect("read keep"),
         b"old"
     );
 
-    // Summary should still report what would be deleted
     assert_eq!(summary.items_deleted(), 1);
 }
 

--- a/crates/engine/src/local_copy/tests/deletion_strategies.rs
+++ b/crates/engine/src/local_copy/tests/deletion_strategies.rs
@@ -1,8 +1,8 @@
-//! Integration tests for deletion strategies.
-//!
-//! This module tests the complete deletion behavior at the integration level,
-//! verifying that delete-before, delete-during, delete-after, and delete-delay
-//! all work correctly with various options.
+// Integration tests for deletion strategies.
+//
+// This module tests the complete deletion behavior at the integration level,
+// verifying that delete-before, delete-during, delete-after, and delete-delay
+// all work correctly with various options.
 
 use super::*;
 
@@ -15,7 +15,6 @@ fn delete_before_removes_files_before_transfer() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create source files
     fs::write(source.join("keep.txt"), b"keep").expect("write keep");
 
     // Create destination with extra files (no overlap to avoid confusion about deletions)
@@ -33,7 +32,6 @@ fn delete_before_removes_files_before_transfer() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify extraneous files were deleted
     assert!(!dest.join("delete1.txt").exists());
     assert!(!dest.join("delete2.txt").exists());
     assert!(dest.join("keep.txt").exists());
@@ -49,7 +47,6 @@ fn delete_during_removes_files_incrementally() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create nested directory structure
     fs::create_dir_all(source.join("subdir")).expect("create subdir");
     fs::write(source.join("keep.txt"), b"keep").expect("write keep");
     fs::write(source.join("subdir").join("nested.txt"), b"nested").expect("write nested");
@@ -73,7 +70,6 @@ fn delete_during_removes_files_incrementally() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify files were deleted in both root and subdirectory
     assert!(!dest.join("delete_root.txt").exists());
     assert!(!dest.join("subdir").join("delete_nested.txt").exists());
     assert!(dest.join("keep.txt").exists());
@@ -139,7 +135,6 @@ fn delete_after_preserves_files_during_transfer() {
         .execute_with_options_and_handler(LocalCopyExecution::Apply, options, Some(&mut observer))
         .expect("copy succeeds");
 
-    // Verify file existed during transfer
     let seen = files_during_copy.lock().unwrap();
     assert!(
         seen.contains("delete_me.txt"),
@@ -183,7 +178,6 @@ fn delete_delay_defers_deletion_until_end() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify all deletions happened
     assert!(!dest.join("dir1").join("delete1.txt").exists());
     assert!(!dest.join("dir2").join("delete2.txt").exists());
     assert!(dest.join("dir1").join("keep1.txt").exists());
@@ -221,7 +215,6 @@ fn deletion_respects_filter_rules() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Extraneous file deleted
     assert!(!dest.join("delete_me.txt").exists());
     // Excluded file preserved (not deleted unless --delete-excluded)
     assert!(dest.join("skip.tmp").exists());
@@ -260,7 +253,6 @@ fn delete_excluded_removes_filtered_files() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Both extraneous and excluded files deleted
     assert!(!dest.join("delete.txt").exists());
     assert!(!dest.join("dest.tmp").exists());
     assert!(dest.join("keep.txt").exists());
@@ -403,7 +395,6 @@ fn deletion_removes_directories_recursively() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Directory and all contents should be deleted
     assert!(!dest.join("delete_dir").exists());
     assert!(dest.join("keep.txt").exists());
     // upstream: each item in the tree is counted individually:

--- a/crates/engine/src/local_copy/tests/disk_full_errors.rs
+++ b/crates/engine/src/local_copy/tests/disk_full_errors.rs
@@ -18,10 +18,8 @@ fn local_copy_error_from_disk_full_io_error() {
     let path = PathBuf::from("/tmp/test/file.txt");
     let error = LocalCopyError::io("write destination file", path.clone(), disk_full);
 
-    // Verify error type
     assert!(matches!(error.kind(), LocalCopyErrorKind::Io { .. }));
 
-    // Verify error message contains path
     let message = error.to_string();
     assert!(message.contains("/tmp/test/file.txt"));
     assert!(message.contains("write destination file"));
@@ -46,7 +44,6 @@ fn local_copy_error_disk_full_kind_provides_path_access() {
     let path = PathBuf::from("/destination/file.txt");
     let error = LocalCopyError::io("write file", path.clone(), disk_full);
 
-    // Should be able to extract path from error
     let (action, extracted_path, source) = error.kind().as_io().expect("should be Io variant");
     assert_eq!(action, "write file");
     assert_eq!(extracted_path, path.as_path());
@@ -162,12 +159,10 @@ fn guard_discard_cleans_up_temp_file_on_disk_full() {
     // Simulate disk full error during write - guard should clean up on discard
     guard.discard();
 
-    // Staging file should be removed
     assert!(
         !staging.exists(),
         "Guard should clean up staging file on discard"
     );
-    // Final destination should not exist
     assert!(
         !dest.exists(),
         "Final destination should not exist after discard"
@@ -186,7 +181,6 @@ fn guard_drop_cleans_up_temp_file_without_commit() {
         // Guard dropped without commit - simulates error during write
     }
 
-    // Staging file should be cleaned up by Drop
     assert!(!staging.exists(), "Drop should clean up staging file");
 }
 
@@ -303,7 +297,6 @@ fn disk_full_error_debug_format_includes_details() {
 
     let debug = format!("{error:?}");
 
-    // Debug format should include relevant details
     assert!(debug.contains("Io"));
     assert!(debug.contains("write file"));
 }
@@ -317,7 +310,6 @@ fn file_write_error_maps_to_local_copy_error() {
     let temp = tempdir().expect("tempdir");
     let path = temp.path().join("test.txt");
 
-    // Create a normal file to test error mapping
     fs::write(&path, b"content").expect("write");
 
     let metadata = fs::metadata(&path).expect("metadata");
@@ -519,7 +511,6 @@ fn disk_full_during_copy_removes_temp_file_in_normal_mode() {
     // Simulate disk full - in normal mode, discard should remove temp file
     guard.discard();
 
-    // Temp file should be removed
     assert!(!staging.exists(), "Temp file should be removed in normal mode");
 }
 
@@ -543,7 +534,6 @@ fn can_retry_after_disk_full_error() {
         guard.commit().expect("commit");
     }
 
-    // Verify the file exists with correct content
     assert!(dest.exists());
     assert_eq!(fs::read(&dest).expect("read"), b"success on retry");
 }
@@ -583,7 +573,6 @@ fn readonly_filesystem_error_maps_correctly() {
         super::filter_program::INVALID_OPERAND_EXIT_CODE
     );
 
-    // Error message should contain the path
     let message = error.to_string();
     assert!(message.contains("/readonly/path"));
 }
@@ -596,6 +585,5 @@ fn readonly_vs_disk_full_same_exit_code() {
     let readonly_error = LocalCopyError::io("write", PathBuf::from("/a"), readonly_err);
     let diskfull_error = LocalCopyError::io("write", PathBuf::from("/b"), diskfull_err);
 
-    // Both should have the same exit code
     assert_eq!(readonly_error.exit_code(), diskfull_error.exit_code());
 }

--- a/crates/engine/src/local_copy/tests/execute_append.rs
+++ b/crates/engine/src/local_copy/tests/execute_append.rs
@@ -22,7 +22,6 @@ fn append_adds_remaining_data_to_partial_file() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Source has full content
     fs::write(&source, b"complete content here").expect("write source");
     // Destination has partial content (prefix of source)
     fs::write(&destination, b"complete").expect("write partial dest");
@@ -88,7 +87,6 @@ fn append_skips_when_destination_larger_than_source() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Destination is larger than source
     fs::write(&source, b"short content").expect("write source");
     let original_dest = b"much longer destination file content here";
     fs::write(&destination, original_dest).expect("write larger dest");
@@ -209,7 +207,6 @@ fn append_correct_offset_with_large_partial() {
     let source = temp.path().join("source.bin");
     let destination = temp.path().join("dest.bin");
 
-    // Create a large file (1MB) and partial file (500KB)
     let full_content: Vec<u8> = (0..=255).cycle().take(1024 * 1024).collect();
     let partial_size = 512 * 1024;
     let partial_content = &full_content[..partial_size];
@@ -485,7 +482,6 @@ fn append_combined_with_times_preserves_mtime() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify mtime is preserved
     let dest_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&destination).expect("dest metadata")
     );
@@ -670,7 +666,6 @@ fn append_binary_data() {
     let source = temp.path().join("binary.bin");
     let destination = temp.path().join("dest.bin");
 
-    // Binary content with all byte values
     let full_binary: Vec<u8> = (0..=255).cycle().take(512).collect();
     let partial_binary: Vec<u8> = (0..=255).cycle().take(256).collect();
 

--- a/crates/engine/src/local_copy/tests/execute_archive.rs
+++ b/crates/engine/src/local_copy/tests/execute_archive.rs
@@ -769,7 +769,6 @@ fn archive_no_links_copies_symlink_targets_instead() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy");
 
-    // sym.txt should be a regular file, not a symlink
     let dest_sym = ctx.dest.join("sym.txt");
     assert!(dest_sym.exists(), "sym.txt should exist");
     let meta = fs::symlink_metadata(&dest_sym).expect("metadata");

--- a/crates/engine/src/local_copy/tests/execute_basic.rs
+++ b/crates/engine/src/local_copy/tests/execute_basic.rs
@@ -279,7 +279,6 @@ fn execute_copies_file_with_acls_is_noop_on_apple() {
         )
         .expect("copy succeeds");
 
-    // Data copy still happens.
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(fs::read(&destination).expect("read dest"), b"acl");
 
@@ -653,7 +652,6 @@ fn execute_file_copy_to_directory_places_file_inside() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("copy succeeds");
 
-    // File is placed inside the destination directory
     assert_eq!(summary.files_copied(), 1);
     let target_file = destination.join("source.txt");
     assert!(target_file.exists());
@@ -921,7 +919,6 @@ fn execute_does_not_preserve_timestamps_by_default() {
         &fs::metadata(&destination).expect("dest metadata"),
     );
 
-    // The destination mtime should be recent, not the past_time
     assert_ne!(dest_mtime, past_time);
 }
 
@@ -1209,7 +1206,6 @@ fn execute_handles_various_file_sizes() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Test various file sizes
     let sizes = vec![
         ("tiny.bin", 1),
         ("small.bin", 100),
@@ -1451,7 +1447,6 @@ fn execute_handles_deep_directory_nesting() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify the deeply nested file was copied
     let mut expected_path = dest_root.join("source");
     for i in 0..10 {
         expected_path = expected_path.join(format!("level{i}"));

--- a/crates/engine/src/local_copy/tests/execute_checksum_seed.rs
+++ b/crates/engine/src/local_copy/tests/execute_checksum_seed.rs
@@ -228,10 +228,6 @@ fn checksum_seed_without_checksum_mode() {
     assert_eq!(opts.checksum_seed(), Some(42));
 }
 
-//
-// These tests verify that the local copy engine works correctly when
-// checksum_seed is configured.
-
 #[test]
 fn transfer_works_with_checksum_seed_set() {
     let temp = tempdir().expect("tempdir");
@@ -411,13 +407,11 @@ fn transfer_with_checksum_seed_dry_run() {
 
     let summary = report.summary();
 
-    // File should not exist on disk (dry-run)
     assert!(
         !dest.join("dry.txt").exists(),
         "file should not exist in dry-run"
     );
 
-    // But the summary should report what would happen
     assert!(
         summary.files_copied() >= 1,
         "dry-run should report files that would be copied"

--- a/crates/engine/src/local_copy/tests/execute_copy_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_copy_dest.rs
@@ -41,7 +41,6 @@ fn copy_dest_identical_file_is_copied_not_linked() {
     assert_eq!(fs::read(&destination_file).expect("read dest"), b"identical content");
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify it's a copy, not a hard link
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
@@ -236,7 +235,6 @@ fn copy_dest_multiple_directories_uses_first_match() {
         let copy_dest1_meta = fs::metadata(&copy_dest1_file).expect("copy_dest1 metadata");
         let copy_dest2_meta = fs::metadata(&copy_dest2_file).expect("copy_dest2 metadata");
 
-        // File should not be hard linked to either
         assert_ne!(dest_meta.ino(), copy_dest1_meta.ino());
         assert_ne!(dest_meta.ino(), copy_dest2_meta.ino());
     }
@@ -264,7 +262,6 @@ fn copy_dest_creates_file_while_compare_dest_skips() {
     set_file_mtime(&source_file, timestamp).expect("source mtime");
     set_file_mtime(&reference_file, timestamp).expect("reference mtime");
 
-    // Test Compare behavior
     let dest_compare_file = dest_compare_dir.join("file.txt");
     let operands_compare = vec![
         source_file.clone().into_os_string(),
@@ -287,7 +284,6 @@ fn copy_dest_creates_file_while_compare_dest_skips() {
     assert_eq!(summary_compare.files_copied(), 0);
     assert_eq!(summary_compare.regular_files_matched(), 1);
 
-    // Test Copy behavior
     let dest_copy_file = dest_copy_dir.join("file.txt");
     let operands_copy = vec![
         source_file.into_os_string(),
@@ -319,12 +315,10 @@ fn copy_dest_works_with_directory_trees() {
     let copy_dest_root = temp.path().join("copy_dest");
     let destination_root = temp.path().join("dest");
 
-    // Create source tree
     fs::create_dir_all(source_root.join("dir1/subdir")).expect("create source tree");
     fs::write(source_root.join("dir1/file1.txt"), b"file1").expect("write file1");
     fs::write(source_root.join("dir1/subdir/file2.txt"), b"file2").expect("write file2");
 
-    // Create matching copy_dest tree
     fs::create_dir_all(copy_dest_root.join("dir1/subdir")).expect("create copy_dest tree");
     fs::write(copy_dest_root.join("dir1/file1.txt"), b"file1").expect("write copy_dest file1");
     fs::write(copy_dest_root.join("dir1/subdir/file2.txt"), b"file2").expect("write copy_dest file2");
@@ -366,13 +360,11 @@ fn copy_dest_mixed_existing_and_new_files() {
     let copy_dest_root = temp.path().join("copy_dest");
     let destination_root = temp.path().join("dest");
 
-    // Create source tree with three files
     fs::create_dir_all(&source_root).expect("create source dir");
     fs::write(source_root.join("file1.txt"), b"content1").expect("write file1");
     fs::write(source_root.join("file2.txt"), b"content2").expect("write file2");
     fs::write(source_root.join("file3.txt"), b"content3").expect("write file3");
 
-    // Create copy_dest tree with only file1 matching
     fs::create_dir_all(&copy_dest_root).expect("create copy_dest dir");
     fs::write(copy_dest_root.join("file1.txt"), b"content1").expect("write copy_dest file1");
     // file2 exists but with different content
@@ -523,7 +515,6 @@ fn copy_dest_with_size_only_mode() {
     fs::write(&source_file, b"12345").expect("write source");
     fs::write(&copy_dest_file, b"abcde").expect("write copy_dest");
 
-    // Different timestamps
     set_file_mtime(&source_file, FileTime::from_unix_time(1_700_000_000, 0)).expect("source mtime");
     set_file_mtime(&copy_dest_file, FileTime::from_unix_time(1_600_000_000, 0)).expect("copy_dest mtime");
 
@@ -580,7 +571,6 @@ fn copy_dest_empty_reference_directory() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Should transfer normally
     assert!(destination_file.exists());
     assert_eq!(fs::read(&destination_file).expect("read dest"), b"content");
     assert_eq!(summary.files_copied(), 1);

--- a/crates/engine/src/local_copy/tests/execute_copy_links.rs
+++ b/crates/engine/src/local_copy/tests/execute_copy_links.rs
@@ -22,15 +22,12 @@ fn copy_links_follows_file_symlink_and_copies_content() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Destination should be a regular file, not a symlink
     let metadata = fs::symlink_metadata(&dest).expect("dest metadata");
     assert!(metadata.file_type().is_file());
     assert!(!metadata.file_type().is_symlink());
 
-    // Content should match target
     assert_eq!(fs::read(&dest).expect("read dest"), b"target content");
 
-    // Should not count as a symlink copy
     assert_eq!(summary.symlinks_copied(), 0);
 }
 
@@ -63,12 +60,10 @@ fn copy_links_follows_directory_symlink_recursively() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Destination should be a regular directory, not a symlink
     let metadata = fs::symlink_metadata(&dest).expect("dest metadata");
     assert!(metadata.file_type().is_dir());
     assert!(!metadata.file_type().is_symlink());
 
-    // All files should be copied
     assert_eq!(fs::read(dest.join("file1.txt")).expect("read file1"), b"content1");
     assert_eq!(fs::read(dest.join("file2.txt")).expect("read file2"), b"content2");
     assert_eq!(
@@ -96,10 +91,8 @@ fn copy_links_handles_dangling_symlink_with_error() {
     let options = LocalCopyOptions::default().copy_links(true);
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
-    // Should fail because the symlink target doesn't exist
     assert!(result.is_err());
 
-    // Destination should not be created
     assert!(!dest.exists());
 }
 
@@ -112,15 +105,12 @@ fn copy_links_skips_dangling_symlink_in_directory_tree() {
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
-    // Create a good file
     fs::write(source_dir.join("good.txt"), b"good content").expect("write good");
 
-    // Create a dangling symlink
     let nonexistent = temp.path().join("nonexistent");
     let dangling = source_dir.join("dangling");
     symlink(&nonexistent, &dangling).expect("create dangling");
 
-    // Create another good file
     fs::write(source_dir.join("also_good.txt"), b"also good").expect("write also_good");
 
     let dest = temp.path().join("dest");
@@ -136,7 +126,6 @@ fn copy_links_skips_dangling_symlink_in_directory_tree() {
         .recursive(true);
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
-    // The operation should fail when encountering the dangling symlink
     assert!(result.is_err());
 }
 
@@ -148,7 +137,6 @@ fn copy_links_detects_direct_symlink_loop() {
     let temp = tempdir().expect("tempdir");
     let link = temp.path().join("self_link");
 
-    // Create a symlink that points to itself
     symlink(&link, &link).expect("create self-referencing symlink");
 
     let dest = temp.path().join("dest");
@@ -159,10 +147,8 @@ fn copy_links_detects_direct_symlink_loop() {
     let options = LocalCopyOptions::default().copy_links(true);
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
-    // Should fail because following the symlink creates a loop
     assert!(result.is_err());
 
-    // Destination should not be created
     assert!(!dest.exists());
 }
 
@@ -187,10 +173,8 @@ fn copy_links_detects_indirect_symlink_loop() {
     let options = LocalCopyOptions::default().copy_links(true);
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
-    // Should fail because following the symlink chain creates a loop
     assert!(result.is_err());
 
-    // Destination should not be created
     assert!(!dest.exists());
 }
 
@@ -234,7 +218,6 @@ fn copy_links_follows_chain_of_symlinks() {
 
     let temp = tempdir().expect("tempdir");
 
-    // Create the actual target
     let target = temp.path().join("target.txt");
     fs::write(&target, b"final content").expect("write target");
 
@@ -254,7 +237,6 @@ fn copy_links_follows_chain_of_symlinks() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Should follow the entire chain and copy the final target
     let metadata = fs::symlink_metadata(&dest).expect("dest metadata");
     assert!(metadata.file_type().is_file());
     assert_eq!(fs::read(&dest).expect("read dest"), b"final content");
@@ -272,7 +254,6 @@ fn copy_links_works_with_relative_symlinks() {
     let target = dir.join("target.txt");
     fs::write(&target, b"relative target").expect("write target");
 
-    // Create a relative symlink
     let link = dir.join("link");
     symlink(Path::new("target.txt"), &link).expect("create relative symlink");
 
@@ -285,7 +266,6 @@ fn copy_links_works_with_relative_symlinks() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Should resolve the relative symlink and copy the target content
     let metadata = fs::symlink_metadata(&dest).expect("dest metadata");
     assert!(metadata.file_type().is_file());
     assert_eq!(fs::read(&dest).expect("read dest"), b"relative target");
@@ -301,7 +281,6 @@ fn copy_links_follows_absolute_symlinks() {
     let target = temp.path().join("target.txt");
     fs::write(&target, b"absolute target").expect("write target");
 
-    // Create an absolute symlink
     let link = temp.path().join("link");
     symlink(&target, &link).expect("create absolute symlink");
 
@@ -314,7 +293,6 @@ fn copy_links_follows_absolute_symlinks() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Should follow the absolute symlink and copy the target content
     let metadata = fs::symlink_metadata(&dest).expect("dest metadata");
     assert!(metadata.file_type().is_file());
     assert_eq!(fs::read(&dest).expect("read dest"), b"absolute target");
@@ -329,16 +307,13 @@ fn copy_links_with_mixed_files_and_symlinks() {
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
-    // Create a regular file
     fs::write(source_dir.join("regular.txt"), b"regular").expect("write regular");
 
-    // Create a target and symlink to it
     let target = temp.path().join("target.txt");
     fs::write(&target, b"linked").expect("write target");
     let link = source_dir.join("link.txt");
     symlink(&target, &link).expect("create symlink");
 
-    // Create a subdirectory
     let subdir = source_dir.join("subdir");
     fs::create_dir(&subdir).expect("create subdir");
     fs::write(subdir.join("nested.txt"), b"nested").expect("write nested");
@@ -357,18 +332,15 @@ fn copy_links_with_mixed_files_and_symlinks() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Regular file should be copied normally
     let regular_meta = fs::symlink_metadata(dest.join("source").join("regular.txt")).expect("regular meta");
     assert!(regular_meta.file_type().is_file());
     assert_eq!(fs::read(dest.join("source").join("regular.txt")).expect("read"), b"regular");
 
-    // Symlink should be followed and copied as a regular file
     let link_meta = fs::symlink_metadata(dest.join("source").join("link.txt")).expect("link meta");
     assert!(link_meta.file_type().is_file());
     assert!(!link_meta.file_type().is_symlink());
     assert_eq!(fs::read(dest.join("source").join("link.txt")).expect("read"), b"linked");
 
-    // Nested file should be copied
     assert_eq!(
         fs::read(dest.join("source").join("subdir/nested.txt")).expect("read"),
         b"nested"
@@ -472,7 +444,6 @@ fn copy_links_does_not_follow_symlinks_in_tree_when_disabled() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Should be copied as a symlink
     let link_meta = fs::symlink_metadata(dest.join("source").join("link")).expect("link meta");
     assert!(link_meta.file_type().is_symlink());
     assert_eq!(summary.symlinks_copied(), 1);
@@ -501,12 +472,10 @@ fn copy_links_with_symlink_to_empty_directory() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Should create an empty directory, not a symlink
     let metadata = fs::symlink_metadata(&dest).expect("dest metadata");
     assert!(metadata.file_type().is_dir());
     assert!(!metadata.file_type().is_symlink());
 
-    // Should be empty
     let entries: Vec<_> = fs::read_dir(&dest).expect("read dir").collect();
     assert_eq!(entries.len(), 0);
 }
@@ -532,7 +501,6 @@ fn copy_links_dry_run_does_not_create_files() {
     plan.execute_with_options(LocalCopyExecution::DryRun, options)
         .expect("dry run succeeds");
 
-    // Destination should not exist in dry-run mode
     assert!(!dest.exists());
 }
 
@@ -562,7 +530,6 @@ fn copy_links_overwrites_existing_destination_file() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Destination should have the new content from the symlink target
     let metadata = fs::symlink_metadata(&dest).expect("dest metadata");
     assert!(metadata.file_type().is_file());
     assert!(!metadata.file_type().is_symlink());
@@ -578,7 +545,6 @@ fn copy_links_nested_symlinks_in_directory_tree() {
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
-    // Create a real file
     let real_file = temp.path().join("real.txt");
     fs::write(&real_file, b"real content").expect("write real");
 
@@ -608,7 +574,6 @@ fn copy_links_nested_symlinks_in_directory_tree() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // inner_link should be dereferenced to a regular file
     let inner_meta = fs::symlink_metadata(dest.join("source").join("inner_link")).expect("inner meta");
     assert!(inner_meta.file_type().is_file());
     assert!(!inner_meta.file_type().is_symlink());
@@ -617,12 +582,10 @@ fn copy_links_nested_symlinks_in_directory_tree() {
         b"real content"
     );
 
-    // dir_link should be dereferenced to a real directory
     let dir_meta = fs::symlink_metadata(dest.join("source").join("dir_link")).expect("dir meta");
     assert!(dir_meta.file_type().is_dir());
     assert!(!dir_meta.file_type().is_symlink());
 
-    // The contents of the external directory should be present
     assert_eq!(
         fs::read(dest.join("source").join("dir_link/ext.txt")).expect("read ext"),
         b"external"
@@ -638,7 +601,6 @@ fn copy_links_preserves_timestamps_from_referent() {
     let target = temp.path().join("target.txt");
     fs::write(&target, b"timestamp test").expect("write target");
 
-    // Set a specific mtime on the target
     let fixed_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(&target, fixed_time).expect("set target mtime");
 
@@ -681,11 +643,9 @@ fn copy_links_follows_symlink_to_fifo_in_directory() {
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
-    // Create a real FIFO
     let real_fifo = temp.path().join("real_fifo");
     mkfifo_for_tests(&real_fifo, 0o644).expect("create fifo");
 
-    // Create a symlink inside source that points to the FIFO
     let fifo_link = source_dir.join("fifo_link");
     symlink(&real_fifo, &fifo_link).expect("create symlink to fifo");
 
@@ -707,7 +667,6 @@ fn copy_links_follows_symlink_to_fifo_in_directory() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // The regular file should be copied
     assert_eq!(
         fs::read(dest.join("source").join("regular.txt")).expect("read regular"),
         b"regular file"
@@ -744,11 +703,9 @@ fn copy_links_follows_symlink_to_fifo_in_directory() {
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
-    // Create a real FIFO
     let real_fifo = temp.path().join("real_fifo");
     mkfifo_for_tests(&real_fifo, 0o644).expect("create fifo");
 
-    // Create a symlink inside source that points to the FIFO
     let fifo_link = source_dir.join("fifo_link");
     symlink(&real_fifo, &fifo_link).expect("create symlink to fifo");
 
@@ -770,7 +727,6 @@ fn copy_links_follows_symlink_to_fifo_in_directory() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // The regular file should be copied
     assert_eq!(
         fs::read(dest.join("source").join("regular.txt")).expect("read regular"),
         b"regular file"
@@ -796,7 +752,6 @@ fn copy_links_replaces_existing_symlink_with_file() {
 
     let temp = tempdir().expect("tempdir");
 
-    // Source: symlink to a regular file
     let target = temp.path().join("target.txt");
     fs::write(&target, b"replacement content").expect("write target");
 
@@ -816,7 +771,6 @@ fn copy_links_replaces_existing_symlink_with_file() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Destination should now be a regular file, not a symlink
     let metadata = fs::symlink_metadata(&dest).expect("dest metadata");
     assert!(metadata.file_type().is_file());
     assert!(!metadata.file_type().is_symlink());
@@ -835,7 +789,6 @@ fn copy_links_with_symlink_chain_in_directory_tree() {
     let source_dir = temp.path().join("source");
     fs::create_dir(&source_dir).expect("create source");
 
-    // Create a real file
     let real_file = source_dir.join("real.txt");
     fs::write(&real_file, b"real data").expect("write real");
 
@@ -861,7 +814,6 @@ fn copy_links_with_symlink_chain_in_directory_tree() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Both symlinks should be dereferenced to regular files with the same content
     for name in &["link_a", "link_b"] {
         let meta = fs::symlink_metadata(dest.join("source").join(name)).expect("meta");
         assert!(meta.file_type().is_file(), "{name} should be a regular file");
@@ -873,7 +825,6 @@ fn copy_links_with_symlink_chain_in_directory_tree() {
         );
     }
 
-    // The real file should also be present
     assert_eq!(
         fs::read(dest.join("source").join("real.txt")).expect("read real"),
         b"real data"

--- a/crates/engine/src/local_copy/tests/execute_delay_updates.rs
+++ b/crates/engine/src/local_copy/tests/execute_delay_updates.rs
@@ -62,12 +62,10 @@ fn delay_updates_applies_all_changes_atomically() {
     fs::create_dir_all(&source_root).expect("create source");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Create multiple source files
     fs::write(source_root.join("file1.txt"), b"content1").expect("write file1");
     fs::write(source_root.join("file2.txt"), b"content2").expect("write file2");
     fs::write(source_root.join("file3.txt"), b"content3").expect("write file3");
 
-    // Create existing destination files with old content
     fs::write(dest_root.join("file1.txt"), b"old1").expect("write old file1");
     fs::write(dest_root.join("file2.txt"), b"old2").expect("write old file2");
     fs::write(dest_root.join("file3.txt"), b"old3").expect("write old file3");
@@ -87,7 +85,6 @@ fn delay_updates_applies_all_changes_atomically() {
 
     assert_eq!(summary.files_copied(), 3);
 
-    // Verify all files were updated atomically
     assert_eq!(
         fs::read(dest_root.join("file1.txt")).expect("read file1"),
         b"content1"
@@ -183,7 +180,6 @@ fn delay_updates_works_with_temp_dir() {
         b"delay + temp-dir"
     );
 
-    // Verify staging directory is empty
     let staging_files: Vec<_> = fs::read_dir(&temp_staging)
         .expect("read staging")
         .filter_map(|e| e.ok())
@@ -233,7 +229,6 @@ fn delay_updates_with_temp_dir_multiple_files() {
         b"content c"
     );
 
-    // All temp files should be gone
     let staging_files: Vec<_> = fs::read_dir(&temp_staging)
         .expect("read staging")
         .filter_map(|e| e.ok())
@@ -722,7 +717,6 @@ fn delay_updates_differs_from_immediate_mode() {
 
     fs::write(source_root.join("file.txt"), b"content").expect("write source");
 
-    // Test with delay_updates
     let mut source_operand1 = source_root.clone().into_os_string();
     source_operand1.push(std::path::MAIN_SEPARATOR.to_string());
     let operands1 = vec![source_operand1, dest1.clone().into_os_string()];
@@ -735,7 +729,6 @@ fn delay_updates_differs_from_immediate_mode() {
         )
         .expect("copy with delay succeeds");
 
-    // Test without delay_updates
     let mut source_operand2 = source_root.into_os_string();
     source_operand2.push(std::path::MAIN_SEPARATOR.to_string());
     let operands2 = vec![source_operand2, dest2.clone().into_os_string()];
@@ -884,7 +877,6 @@ fn delay_updates_handles_multiple_subdirectories() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create files in multiple subdirectories
     fs::create_dir_all(source_root.join("dir_a")).expect("create dir_a");
     fs::create_dir_all(source_root.join("dir_b")).expect("create dir_b");
     fs::create_dir_all(source_root.join("dir_c")).expect("create dir_c");
@@ -910,7 +902,6 @@ fn delay_updates_handles_multiple_subdirectories() {
 
     assert_eq!(summary.files_copied(), 5);
 
-    // Verify all files in all subdirectories
     assert_eq!(
         fs::read(dest_root.join("dir_a").join("file1.txt")).expect("read"),
         b"a1"
@@ -982,7 +973,6 @@ fn delay_updates_with_backup_creates_backup_files() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Updated file should be in place
     assert_eq!(
         fs::read(dest_root.join("file.txt")).expect("read dest"),
         b"new content here"
@@ -1123,7 +1113,6 @@ fn delay_updates_preserves_symlinks() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a file and a symlink to it
     fs::write(source_root.join("target.txt"), b"target content").expect("write target");
     std::os::unix::fs::symlink("target.txt", source_root.join("link.txt"))
         .expect("create symlink");
@@ -1146,13 +1135,11 @@ fn delay_updates_preserves_symlinks() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.symlinks_copied(), 1);
 
-    // Verify target file
     assert_eq!(
         fs::read(dest_root.join("target.txt")).expect("read target"),
         b"target content"
     );
 
-    // Verify symlink is preserved
     let link_path = dest_root.join("link.txt");
     let link_meta = fs::symlink_metadata(&link_path).expect("link metadata");
     assert!(link_meta.file_type().is_symlink());
@@ -1317,7 +1304,6 @@ fn delay_updates_handles_unicode_filenames() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Files with various Unicode characters
     fs::write(source_root.join("caf\u{00e9}.txt"), b"coffee").expect("write");
     fs::write(source_root.join("\u{00fc}ber.txt"), b"above").expect("write");
     fs::write(source_root.join("\u{4e16}\u{754c}.txt"), b"world").expect("write");
@@ -1460,7 +1446,6 @@ fn delay_updates_handles_many_files() {
 
     assert_eq!(summary.files_copied(), file_count);
 
-    // Verify all files are present and correct
     for i in 0..file_count {
         let expected = format!("content of file {i}");
         assert_eq!(
@@ -1488,7 +1473,6 @@ fn delay_updates_handles_deeply_nested_structure() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create a deeply nested path with files at each level
     let mut nested = source_root.clone();
     for depth in 0..8 {
         nested = nested.join(format!("level{depth}"));
@@ -1511,7 +1495,6 @@ fn delay_updates_handles_deeply_nested_structure() {
 
     assert_eq!(summary.files_copied(), 8);
 
-    // Verify each level
     let mut check = dest_root.join("source");
     for depth in 0..8 {
         check = check.join(format!("level{depth}"));
@@ -1584,7 +1567,6 @@ fn delay_updates_is_idempotent_on_second_run() {
     // No files should be copied on second run because size+mtime match
     assert_eq!(summary2.files_copied(), 0);
 
-    // Content should still be correct
     assert_eq!(
         fs::read(dest_root.join("a.txt")).expect("read a"),
         b"content a"
@@ -1672,13 +1654,11 @@ fn delay_updates_with_remove_source_files() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // File should be at destination
     assert_eq!(
         fs::read(dest_root.join("transfer_me.txt")).expect("read dest"),
         b"payload"
     );
 
-    // Source file should have been removed
     assert!(
         !source_root.join("transfer_me.txt").exists(),
         "source file should be removed after transfer"
@@ -1795,7 +1775,6 @@ fn delay_updates_handles_binary_content() {
     let source = temp.path().join("source.bin");
     let destination = temp.path().join("dest.bin");
 
-    // Create a file with all byte values
     let binary_content: Vec<u8> = (0..=255).collect();
     fs::write(&source, &binary_content).expect("write binary source");
 
@@ -1885,7 +1864,6 @@ fn delay_updates_dry_run_with_nested_tree_no_changes() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create complex tree
     fs::create_dir_all(source_root.join("a").join("b")).expect("create dirs");
     fs::write(source_root.join("top.txt"), b"top").expect("write");
     fs::write(source_root.join("a").join("mid.txt"), b"mid").expect("write");
@@ -1906,7 +1884,6 @@ fn delay_updates_dry_run_with_nested_tree_no_changes() {
 
     assert_eq!(summary.files_copied(), 3);
 
-    // Nothing should exist on disk
     assert!(!dest_root.exists(), "dest should not be created in dry run");
 }
 

--- a/crates/engine/src/local_copy/tests/execute_delete_excluded.rs
+++ b/crates/engine/src/local_copy/tests/execute_delete_excluded.rs
@@ -21,7 +21,6 @@ fn delete_preserves_excluded_log_files_at_dest() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Source has a.txt and b.log.
     fs::write(source.join("a.txt"), b"content a").expect("write a.txt");
     fs::write(source.join("b.log"), b"log b").expect("write b.log");
 
@@ -80,7 +79,6 @@ fn delete_excluded_removes_log_files_matching_exclude_pattern() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Source has a.txt and b.log.
     fs::write(source.join("a.txt"), b"content a").expect("write a.txt");
     fs::write(source.join("b.log"), b"log b source").expect("write b.log");
 

--- a/crates/engine/src/local_copy/tests/execute_direct_write.rs
+++ b/crates/engine/src/local_copy/tests/execute_direct_write.rs
@@ -169,7 +169,6 @@ fn direct_write_handles_multiple_files_in_directory() {
         b"gamma content"
     );
 
-    // Verify no temp files linger
     let entries: Vec<_> = fs::read_dir(&dest_dir)
         .expect("read dest dir")
         .filter_map(|e| e.ok())
@@ -360,7 +359,6 @@ fn temp_dir_option_does_not_use_direct_write() {
         b"temp dir content"
     );
 
-    // Staging directory should be clean after successful transfer
     let staging_files: Vec<_> = fs::read_dir(&staging)
         .expect("read staging")
         .filter_map(|e| e.ok())

--- a/crates/engine/src/local_copy/tests/execute_directories.rs
+++ b/crates/engine/src/local_copy/tests/execute_directories.rs
@@ -813,7 +813,6 @@ fn execute_recursive_copies_deep_hierarchy() {
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
 
-    // Create a deep hierarchy: source/a/b/c/d/e
     let deep_path = source_root.join("a").join("b").join("c").join("d").join("e");
     fs::create_dir_all(&deep_path).expect("create deep hierarchy");
     fs::write(deep_path.join("deep.txt"), b"deep content").expect("write deep file");
@@ -844,7 +843,6 @@ fn execute_recursive_copies_wide_hierarchy() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source root");
 
-    // Create many sibling directories
     for i in 0..10 {
         let dir = source_root.join(format!("dir{i:02}"));
         fs::create_dir_all(&dir).expect("create sibling dir");
@@ -964,7 +962,6 @@ fn execute_directory_fails_on_permission_denied_when_creating() {
     fs::create_dir_all(&source_root).expect("create source");
     fs::write(source_root.join("file.txt"), b"content").expect("write file");
 
-    // Create destination with no write permission
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
     fs::set_permissions(&dest_root, PermissionsExt::from_mode(0o555)).expect("make readonly");
@@ -1005,7 +1002,6 @@ fn execute_directory_already_exists_succeeds() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Copy should succeed even if destination already exists
     let summary = plan.execute().expect("copy succeeds");
 
     assert!(dest_root.join("file.txt").exists());
@@ -1032,7 +1028,6 @@ fn execute_directory_nested_already_exists_merges_content() {
 
     plan.execute().expect("copy succeeds");
 
-    // Both files should exist after merge
     assert!(dest_nested.join("new.txt").exists());
     assert!(dest_nested.join("existing.txt").exists());
     assert_eq!(fs::read(dest_nested.join("new.txt")).expect("read new"), b"new content");
@@ -1046,7 +1041,6 @@ fn execute_directory_errors_when_destination_is_file_without_force() {
     fs::create_dir_all(&source_root).expect("create source dir");
     fs::write(source_root.join("child.txt"), b"content").expect("write child");
 
-    // Destination is a file, not a directory
     let destination = temp.path().join("dest");
     fs::write(&destination, b"existing file").expect("write existing file");
 
@@ -1074,7 +1068,6 @@ fn execute_dry_run_does_not_create_directory() {
     fs::write(source_root.join("file.txt"), b"content").expect("write file");
 
     let dest_root = temp.path().join("dest");
-    // Destination does not exist
 
     let operands = vec![
         source_root.into_os_string(),
@@ -1142,9 +1135,7 @@ fn execute_dry_run_with_existing_destination_reports_no_creation() {
         .execute_with(LocalCopyExecution::DryRun)
         .expect("dry-run succeeds");
 
-    // Existing file should NOT be modified
     assert_eq!(fs::read(dest_root.join("file.txt")).expect("read"), b"old content");
-    // Should report would-be copied files
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -1362,7 +1353,6 @@ fn execute_directory_ignore_existing_skips_existing_dirs() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // The existing file should still be there, the new file should be added
     assert!(dest_nested.join("existing.txt").exists());
     // Note: ignore_existing affects files, not directories
     // The new.txt should be created since it didn't exist
@@ -1497,12 +1487,10 @@ fn execute_directory_update_only_copies_newer() {
     fs::create_dir_all(&dest_root).expect("create dest");
     fs::write(dest_root.join("file.txt"), b"old content").expect("write dest");
 
-    // Make source file newer
     let source_file = source_root.join("file.txt");
     let new_time = filetime::FileTime::from_unix_time(2_000_000_000, 0);
     filetime::set_file_mtime(&source_file, new_time).expect("set source mtime");
 
-    // Make dest file older
     let dest_file = dest_root.join("file.txt");
     let old_time = filetime::FileTime::from_unix_time(1_000_000_000, 0);
     filetime::set_file_mtime(&dest_file, old_time).expect("set dest mtime");
@@ -1532,12 +1520,10 @@ fn execute_directory_update_skips_older_files() {
     fs::create_dir_all(&dest_root).expect("create dest");
     fs::write(dest_root.join("file.txt"), b"new content").expect("write dest");
 
-    // Make source file older
     let source_file = source_root.join("file.txt");
     let old_time = filetime::FileTime::from_unix_time(1_000_000_000, 0);
     filetime::set_file_mtime(&source_file, old_time).expect("set source mtime");
 
-    // Make dest file newer
     let dest_file = dest_root.join("file.txt");
     let new_time = filetime::FileTime::from_unix_time(2_000_000_000, 0);
     filetime::set_file_mtime(&dest_file, new_time).expect("set dest mtime");
@@ -1599,11 +1585,9 @@ fn execute_directory_archive_mode_preserves_all() {
 
     let dest_nested = dest_root.join("source").join("nested");
 
-    // Check permissions
     assert_eq!(fs::metadata(dest_root.join("source")).expect("root").permissions().mode() & 0o777, 0o755);
     assert_eq!(fs::metadata(&dest_nested).expect("nested").permissions().mode() & 0o777, 0o750);
 
-    // Check times
     let root_mtime = FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source")).expect("root"));
     let nested_mtime = FileTime::from_last_modification_time(&fs::metadata(&dest_nested).expect("nested"));
     assert_eq!(root_mtime, fixed_mtime);
@@ -1639,18 +1623,15 @@ fn execute_dry_run_with_delete_and_force_reports_all_actions() {
 
     let summary = report.summary();
 
-    // Verify nothing was actually modified
     assert_eq!(fs::read(dest_nested.join("keep.txt")).expect("read keep"), b"old");
     assert!(dest_nested.join("extra.txt").exists());
 
-    // Verify dry-run reported would-be actions
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.items_deleted(), 1);
 }
 
 #[test]
 fn execute_recursive_creates_mixed_content_hierarchy() {
-    // A hierarchy with files at various depths, empty dirs, and deep nesting
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
     fs::create_dir_all(source_root.join("a").join("b").join("c")).expect("create deep");
@@ -1817,7 +1798,6 @@ fn execute_recursive_idempotent_second_run() {
 
 #[test]
 fn execute_trailing_separator_with_nested_empty_dirs() {
-    // Trailing separator + nested empty directories
     let temp = create_tempdir();
     let source_root = temp.path().join("source");
     fs::create_dir_all(source_root.join("empty1")).expect("create empty1");
@@ -1953,7 +1933,6 @@ fn execute_prune_empty_dirs_nested_hierarchy_file_at_bottom() {
     let deep = source_root.join("a").join("b").join("c").join("d");
     fs::create_dir_all(&deep).expect("create deep");
     fs::write(deep.join("bottom.txt"), b"bottom").expect("write bottom");
-    // Create a parallel empty branch
     fs::create_dir_all(source_root.join("a").join("empty_branch")).expect("create empty branch");
 
     let dest_root = temp.path().join("dest");
@@ -1967,9 +1946,7 @@ fn execute_prune_empty_dirs_nested_hierarchy_file_at_bottom() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Full path to the bottom file should exist
     assert!(dest_root.join("source").join("a").join("b").join("c").join("d").join("bottom.txt").exists());
-    // Empty branch should be pruned
     assert!(
         !dest_root.join("source").join("a").join("empty_branch").exists(),
         "empty branch should be pruned"
@@ -2567,7 +2544,6 @@ fn execute_directory_collect_events_records_all_directory_operations() {
         dir_records.len()
     );
 
-    // Verify that file copy event is also present
     let file_records: Vec<_> = records
         .iter()
         .filter(|r| matches!(r.action(), LocalCopyAction::DataCopied))
@@ -2644,7 +2620,6 @@ fn execute_directory_archive_preserves_permissions_and_times_nested() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Permissions
     assert_eq!(
         fs::metadata(dest_root.join("source")).expect("root").permissions().mode() & 0o777,
         0o755
@@ -2666,7 +2641,6 @@ fn execute_directory_archive_preserves_permissions_and_times_nested() {
         0o700
     );
 
-    // Times
     let dest_root_mtime =
         FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source")).expect("root"));
     let dest_a_mtime =

--- a/crates/engine/src/local_copy/tests/execute_dirlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_dirlinks.rs
@@ -188,7 +188,6 @@ fn keep_dirlinks_preserves_symlink_subdir_during_recursive_copy() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest root");
 
-    // Create a real directory as the symlink target, then make dest/subdir a symlink to it
     let real_target = temp.path().join("real-target");
     fs::create_dir(&real_target).expect("create real target");
     symlink(&real_target, dest_root.join("subdir")).expect("create symlink subdir");
@@ -204,7 +203,6 @@ fn keep_dirlinks_preserves_symlink_subdir_during_recursive_copy() {
     )
     .expect("copy with keep_dirlinks succeeds");
 
-    // The symlink should still be a symlink
     let subdir_meta = fs::symlink_metadata(dest_root.join("subdir")).expect("subdir metadata");
     assert!(
         subdir_meta.file_type().is_symlink(),
@@ -231,7 +229,6 @@ fn without_keep_dirlinks_force_replaces_symlink_subdir_with_real_directory() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest root");
 
-    // Create a real directory as the symlink target, then make dest/subdir a symlink to it
     let real_target = temp.path().join("real-target");
     fs::create_dir(&real_target).expect("create real target");
     symlink(&real_target, dest_root.join("subdir")).expect("create symlink subdir");
@@ -265,7 +262,6 @@ fn without_keep_dirlinks_force_replaces_symlink_subdir_with_real_directory() {
         fs::read(dest_root.join("subdir/file.txt")).expect("read file"),
         b"replaced"
     );
-    // The original symlink target should not have the file
     assert!(
         !real_target.join("file.txt").exists(),
         "file should not appear in original symlink target"
@@ -309,7 +305,6 @@ fn keep_dirlinks_with_symlink_to_file_errors() {
         )
     ));
 
-    // The symlink should remain untouched
     let meta = fs::symlink_metadata(dest_root.join("subdir")).expect("subdir metadata");
     assert!(meta.file_type().is_symlink(), "symlink should remain");
 }
@@ -345,7 +340,6 @@ fn keep_dirlinks_force_replaces_symlink_to_file_with_directory() {
     )
     .expect("copy with -K and --force succeeds");
 
-    // The symlink-to-file should be replaced by a real directory
     let meta = fs::symlink_metadata(dest_root.join("subdir")).expect("subdir metadata");
     assert!(
         meta.file_type().is_dir(),
@@ -391,7 +385,6 @@ fn keep_dirlinks_deeply_nested_parent_symlink_to_dir() {
     )
     .expect("copy with keep_dirlinks succeeds for nested structure");
 
-    // The symlink at dest/a/b should be preserved
     let b_meta = fs::symlink_metadata(dest_root.join("a/b")).expect("a/b metadata");
     assert!(
         b_meta.file_type().is_symlink(),
@@ -422,7 +415,6 @@ fn keep_dirlinks_dry_run_no_modifications() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest root");
 
-    // Create a real directory as the symlink target
     let real_target = temp.path().join("real-target");
     fs::create_dir(&real_target).expect("create real target");
     symlink(&real_target, dest_root.join("subdir")).expect("create symlink subdir");
@@ -438,14 +430,12 @@ fn keep_dirlinks_dry_run_no_modifications() {
     )
     .expect("dry-run with keep_dirlinks succeeds");
 
-    // The symlink should still exist
     let subdir_meta = fs::symlink_metadata(dest_root.join("subdir")).expect("subdir metadata");
     assert!(
         subdir_meta.file_type().is_symlink(),
         "symlink should remain after dry-run"
     );
 
-    // No file should have been written
     assert!(
         !real_target.join("file.txt").exists(),
         "file should not be created during dry-run"
@@ -485,7 +475,6 @@ fn keep_dirlinks_delete_preserves_symlink_removes_extraneous() {
         )
         .expect("copy with -K and --delete succeeds");
 
-    // The symlink should be preserved
     let subdir_meta = fs::symlink_metadata(dest_root.join("subdir")).expect("subdir metadata");
     assert!(
         subdir_meta.file_type().is_symlink(),
@@ -498,7 +487,6 @@ fn keep_dirlinks_delete_preserves_symlink_removes_extraneous() {
         b"keep"
     );
 
-    // The extraneous file should be deleted
     assert!(
         !real_target.join("extra.txt").exists(),
         "extraneous file should be deleted"
@@ -540,7 +528,6 @@ fn keep_dirlinks_mixed_real_and_symlink_subdirs() {
     )
     .expect("copy with mixed dirs and symlinks succeeds");
 
-    // real-sub should remain a real directory with its file
     let real_meta = fs::symlink_metadata(dest_root.join("real-sub")).expect("real-sub metadata");
     assert!(
         real_meta.file_type().is_dir(),
@@ -555,7 +542,6 @@ fn keep_dirlinks_mixed_real_and_symlink_subdirs() {
         b"real-content"
     );
 
-    // link-sub should remain a symlink (preserved by -K)
     let link_meta = fs::symlink_metadata(dest_root.join("link-sub")).expect("link-sub metadata");
     assert!(
         link_meta.file_type().is_symlink(),
@@ -606,7 +592,6 @@ fn keep_dirlinks_does_not_apply_when_source_sends_file_over_symlink_to_dir() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // The symlink should have been replaced by a regular file
     let meta = fs::symlink_metadata(dest_root.join("item")).expect("item metadata");
     assert!(
         meta.file_type().is_file(),
@@ -621,7 +606,6 @@ fn keep_dirlinks_does_not_apply_when_source_sends_file_over_symlink_to_dir() {
         b"file-content"
     );
 
-    // The original symlink target directory contents should be untouched
     assert!(real_dir.join("inside.txt").exists(), "target contents should be preserved");
 }
 
@@ -648,7 +632,6 @@ fn keep_dirlinks_delta_transfer_through_symlink_succeeds() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest root");
 
-    // Create real target directory and make dest/subdir a symlink to it
     let real_target = temp.path().join("real-target");
     fs::create_dir_all(&real_target).expect("create real target");
     symlink(&real_target, dest_root.join("subdir")).expect("create symlink subdir");
@@ -733,7 +716,6 @@ fn keep_dirlinks_delta_transfer_through_symlink_succeeds() {
         "file through symlink should match modified source"
     );
 
-    // Verify the symlink is still intact
     let subdir_meta = fs::symlink_metadata(dest_root.join("subdir")).expect("subdir metadata");
     assert!(
         subdir_meta.file_type().is_symlink(),

--- a/crates/engine/src/local_copy/tests/execute_dry_run.rs
+++ b/crates/engine/src/local_copy/tests/execute_dry_run.rs
@@ -29,7 +29,6 @@ fn dry_run_single_file_lists_but_does_not_copy() {
     // Summary reports what *would* happen.
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.bytes_copied(), 7); // "payload" is 7 bytes
-    // Destination must not be created.
     assert!(!destination.exists(), "dry run must not create destination file");
 }
 
@@ -72,7 +71,6 @@ fn dry_run_preserves_source_unmodified() {
     plan.execute_with_options(LocalCopyExecution::DryRun, LocalCopyOptions::default())
         .expect("dry run succeeds");
 
-    // Source must remain identical.
     assert_eq!(
         fs::read(&source).expect("read source"),
         original_content,
@@ -197,9 +195,7 @@ fn dry_run_with_delete_reports_deletions_but_preserves_files() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Source has only keep.txt
     fs::write(source.join("keep.txt"), b"keep").expect("write keep");
-    // Destination has keep.txt and extra.txt
     fs::write(dest.join("keep.txt"), b"old keep").expect("write old keep");
     fs::write(dest.join("extra.txt"), b"to be deleted").expect("write extra");
 
@@ -214,9 +210,7 @@ fn dry_run_with_delete_reports_deletions_but_preserves_files() {
         .execute_with_options(LocalCopyExecution::DryRun, options)
         .expect("dry run succeeds");
 
-    // Summary should report the deletion.
     assert_eq!(summary.items_deleted(), 1);
-    // But the file must still exist on disk.
     assert!(
         dest.join("extra.txt").exists(),
         "dry run must not actually delete files"
@@ -225,7 +219,6 @@ fn dry_run_with_delete_reports_deletions_but_preserves_files() {
         fs::read(dest.join("extra.txt")).expect("read extra"),
         b"to be deleted"
     );
-    // Original destination content must also be preserved.
     assert_eq!(
         fs::read(dest.join("keep.txt")).expect("read keep"),
         b"old keep"
@@ -305,7 +298,6 @@ fn dry_run_with_delete_during_reports_interleaved_events() {
     assert_eq!(summary.items_deleted(), 1);
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify that records report both a copy and a deletion.
     let records = report.records();
     let has_copy = records
         .iter()
@@ -316,7 +308,6 @@ fn dry_run_with_delete_during_reports_interleaved_events() {
     assert!(has_copy, "should have a DataCopied record");
     assert!(has_delete, "should have an EntryDeleted record");
 
-    // Filesystem must be untouched.
     assert!(dest.join("stale.txt").exists());
     assert_eq!(fs::read(dest.join("keep.txt")).expect("read"), b"old");
 }
@@ -344,7 +335,6 @@ fn dry_run_with_exclude_filter_omits_excluded_files() {
         .expect("dry run succeeds");
 
     let summary = report.summary();
-    // Only the .txt files should be reported.
     assert_eq!(summary.files_copied(), 2);
 
     let records = report.records();
@@ -529,7 +519,6 @@ fn dry_run_statistics_match_apply_mode_statistics() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("apply succeeds");
 
-    // Statistics must match.
     assert_eq!(
         summary_dry.files_copied(),
         summary_apply.files_copied(),
@@ -551,7 +540,6 @@ fn dry_run_statistics_match_apply_mode_statistics() {
         "total_source_bytes should match between dry-run and apply"
     );
 
-    // Filesystem state must differ.
     assert!(!dry_dest.exists(), "dry run destination should not exist");
     assert!(apply_dest.exists(), "apply destination should exist");
 }
@@ -807,7 +795,6 @@ fn dry_run_delete_respects_exclude_filters() {
     // extra.txt should be reported as deleted, excluded.log should be
     // protected by the exclude filter.
     assert_eq!(summary.items_deleted(), 1);
-    // Everything still on disk.
     assert!(dest.join("excluded.log").exists());
     assert!(dest.join("extra.txt").exists());
     assert!(dest.join("keep.txt").exists());
@@ -965,7 +952,6 @@ fn dry_run_with_backup_does_not_create_backup_files() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    // The backup file (dest.txt~) must not exist.
     assert!(
         !temp.path().join("dest.txt~").exists(),
         "dry run must not create backup files"
@@ -1101,7 +1087,6 @@ fn dry_run_with_no_implied_dirs_and_missing_parent_succeeds() {
 
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.bytes_copied(), 5);
-    // Destination must not be created in dry-run mode.
     assert!(
         !dest_root.join("sub").exists(),
         "dry run must not create directories"

--- a/crates/engine/src/local_copy/tests/execute_executability.rs
+++ b/crates/engine/src/local_copy/tests/execute_executability.rs
@@ -29,11 +29,9 @@ fn execute_preserves_execute_bit_when_source_has_it() {
 
     let metadata = fs::metadata(&destination).expect("dest metadata");
     let mode = metadata.permissions().mode();
-    // Execute bits should be set
     assert_ne!(mode & 0o111, 0, "execute bits should be preserved");
-    // Without --perms flag, destination gets default permissions with execute bits added
-    // The test verifies execute bits are set, but full permissions may differ
-    // assert_ne!(mode & 0o777, 0o755, "non-execute bits should not be preserved");
+    // Without --perms flag the destination gets default permissions with execute
+    // bits added, so exact non-execute bits are intentionally not asserted.
     assert_eq!(summary.files_copied(), 1);
 }
 

--- a/crates/engine/src/local_copy/tests/execute_existing.rs
+++ b/crates/engine/src/local_copy/tests/execute_existing.rs
@@ -39,7 +39,6 @@ fn existing_skips_file_when_destination_missing() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_skipped_missing(), 1);
-    // Destination should not be created
     assert!(!destination.exists());
 }
 
@@ -69,7 +68,6 @@ fn existing_updates_file_when_destination_exists() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_skipped_missing(), 0);
-    // Destination should have new content
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"updated content"
@@ -82,7 +80,6 @@ fn existing_updates_file_even_when_content_identical() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Both have identical content
     fs::write(&source, b"same content").expect("write source");
     fs::write(&destination, b"same content").expect("write dest");
 
@@ -103,7 +100,6 @@ fn existing_updates_file_even_when_content_identical() {
     // Whether it's actually skipped due to identical content depends on other flags
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_skipped_missing(), 0);
-    // Destination still exists
     assert!(destination.exists());
 }
 
@@ -139,7 +135,6 @@ fn existing_recursive_skips_new_files() {
     assert_eq!(summary.regular_files_total(), 2);
     assert_eq!(summary.regular_files_skipped_missing(), 1);
 
-    // Verify file states
     assert_eq!(
         fs::read(dest_root.join("existing.txt")).expect("read existing"),
         b"updated"
@@ -153,11 +148,9 @@ fn existing_recursive_skips_new_directories() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create directory structure in source
     fs::create_dir_all(source_root.join("existing_dir")).expect("create existing_dir");
     fs::create_dir_all(source_root.join("new_dir")).expect("create new_dir");
 
-    // Create files in both directories
     fs::write(
         source_root.join("existing_dir").join("file.txt"),
         b"content",
@@ -198,7 +191,6 @@ fn existing_nested_directories_mixed_states() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create nested directory structure
     fs::create_dir_all(source_root.join("dir1/dir2")).expect("create source dirs");
     fs::create_dir_all(dest_root.join("dir1")).expect("create dest dir1");
 
@@ -235,7 +227,6 @@ fn existing_nested_directories_mixed_states() {
     assert!(summary.regular_files_skipped_missing() >= 1,
         "should skip at least new.txt, got {}", summary.regular_files_skipped_missing());
 
-    // Verify states
     assert_eq!(
         fs::read(dest_root.join("dir1/exists.txt")).expect("read exists"),
         b"updated_content"
@@ -294,14 +285,13 @@ fn existing_combined_with_update() {
     assert_eq!(summary.regular_files_skipped_newer(), 1);
     assert_eq!(summary.regular_files_skipped_missing(), 1);
 
-    // Verify content
     assert_eq!(
         fs::read(dest_root.join("copy_me.txt")).expect("read copy_me"),
         b"newer"
     );
     assert_eq!(
         fs::read(dest_root.join("skip_me.txt")).expect("read skip_me"),
-        b"newer" // preserved
+        b"newer"
     );
     assert!(!dest_root.join("new_file.txt").exists());
 }
@@ -346,7 +336,6 @@ fn existing_combined_with_checksum() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_skipped_missing(), 1);
 
-    // Verify content
     assert_eq!(
         fs::read(dest_root.join("different.txt")).expect("read different"),
         b"updated content"
@@ -390,7 +379,6 @@ fn existing_combined_with_times_preserves_mtime() {
     // File should be copied because it exists
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify mtime is preserved
     let dest_mtime =
         FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest metadata"));
     assert_eq!(dest_mtime.unix_seconds(), source_mtime.unix_seconds());
@@ -404,11 +392,9 @@ fn existing_dry_run_reports_skipped_files() {
     fs::create_dir_all(&source_root).expect("create source");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Existing file at destination
     fs::write(source_root.join("existing.txt"), b"updated").expect("write existing source");
     fs::write(dest_root.join("existing.txt"), b"old").expect("write existing dest");
 
-    // New file
     fs::write(source_root.join("new.txt"), b"new").expect("write new source");
 
     let mut source_operand = source_root.into_os_string();
@@ -423,11 +409,9 @@ fn existing_dry_run_reports_skipped_files() {
         )
         .expect("dry run succeeds");
 
-    // Dry run should report what would happen
     assert_eq!(summary.files_copied(), 1); // would copy existing.txt
     assert_eq!(summary.regular_files_skipped_missing(), 1); // would skip new.txt
 
-    // But files should remain unchanged
     assert_eq!(
         fs::read(dest_root.join("existing.txt")).expect("read existing"),
         b"old"
@@ -462,14 +446,12 @@ fn existing_dry_run_with_records() {
     let summary = report.summary();
     assert_eq!(summary.regular_files_skipped_missing(), 1);
 
-    // Check that the record indicates the file was skipped
     let records = report.records();
     assert!(records.iter().any(|record| {
         record.action() == &LocalCopyAction::SkippedMissingDestination
             && record.relative_path() == std::path::Path::new("source.txt")
     }));
 
-    // Destination should not be created
     assert!(!destination.exists());
 }
 
@@ -536,7 +518,6 @@ fn existing_handles_empty_files() {
 
     // Should copy because destination exists
     assert_eq!(summary.files_copied(), 1);
-    // Destination should now be empty
     assert_eq!(fs::read(&destination).expect("read dest"), b"");
 }
 
@@ -606,7 +587,6 @@ fn existing_skips_new_symlinks() {
     fs::create_dir_all(&source_root).expect("create source");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Create a target file
     let target = source_root.join("target.txt");
     fs::write(&target, b"target").expect("write target");
 
@@ -644,7 +624,6 @@ fn existing_updates_existing_symlinks() {
     fs::create_dir_all(&source_root).expect("create source");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Create targets
     let target1 = source_root.join("target1.txt");
     let target2 = source_root.join("target2.txt");
     fs::write(&target1, b"target1").expect("write target1");
@@ -674,7 +653,6 @@ fn existing_updates_existing_symlinks() {
 
     // Symlink should be updated because it exists at destination
     assert!(dest_root.join("link.txt").exists());
-    // Verify it now points to target1
     let link_target = fs::read_link(dest_root.join("link.txt")).expect("read link");
     assert!(link_target.ends_with("target1.txt"));
 }
@@ -725,14 +703,13 @@ fn existing_respects_filter_rules() {
     // Should copy include.txt only
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify states
     assert_eq!(
         fs::read(dest_root.join("include.txt")).expect("read include"),
         b"include"
     );
     assert_eq!(
         fs::read(dest_root.join("exclude.txt")).expect("read exclude"),
-        b"old" // preserved due to filter
+        b"old"
     );
     assert!(!dest_root.join("new_include.txt").exists());
 }
@@ -795,7 +772,6 @@ fn existing_matches_upstream_rsync_semantics() {
         summary.regular_files_skipped_missing()
     );
 
-    // Verify file states
     assert_eq!(
         fs::read(dest_root.join("exists.txt")).expect("read exists"),
         b"updated_data",

--- a/crates/engine/src/local_copy/tests/execute_filter_program.rs
+++ b/crates/engine/src/local_copy/tests/execute_filter_program.rs
@@ -1072,7 +1072,6 @@ fn filter_program_exclude_if_present_with_marker() {
     let temp = tempfile::tempdir().expect("tempdir");
     let dir = temp.path();
 
-    // Create the marker file.
     std::fs::write(dir.join(".nobackup"), b"").expect("write marker");
 
     let program = FilterProgram::new([FilterProgramEntry::ExcludeIfPresent(

--- a/crates/engine/src/local_copy/tests/execute_force.rs
+++ b/crates/engine/src/local_copy/tests/execute_force.rs
@@ -277,7 +277,6 @@ fn force_dry_run_does_not_modify_directory() {
     )
     .expect("dry-run succeeds");
 
-    // Destination should remain a directory in dry-run mode
     assert!(destination.is_dir(), "directory should not be modified in dry-run");
     assert_eq!(
         fs::read(destination.join("inner/keep.txt")).expect("read"),
@@ -476,7 +475,6 @@ fn force_handles_multiple_type_conflicts_in_one_copy() {
     )
     .expect("forced replacement with multiple conflicts succeeds");
 
-    // "alpha" should now be a file
     assert!(
         dest_root.join("alpha").is_file(),
         "alpha: directory should become file"
@@ -486,7 +484,6 @@ fn force_handles_multiple_type_conflicts_in_one_copy() {
         b"alpha-file"
     );
 
-    // "beta" should now be a directory
     assert!(
         dest_root.join("beta").is_dir(),
         "beta: file should become directory"

--- a/crates/engine/src/local_copy/tests/execute_hardlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_hardlinks.rs
@@ -879,7 +879,6 @@ fn execute_hardlink_nlink_changes_during_operation() {
     let dest_meta_a = fs::metadata(&dest_a).expect("dest meta a");
     let dest_meta_b = fs::metadata(&dest_b).expect("dest meta b");
 
-    // Both should be hardlinked
     assert_eq!(dest_meta_a.ino(), dest_meta_b.ino(), "files should share inode");
     assert_eq!(dest_meta_a.nlink(), 2);
     assert!(summary.hard_links_created() >= 1);
@@ -942,7 +941,6 @@ fn execute_hardlink_mixed_with_symlinks() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source root");
 
-    // Create a regular file
     let regular = source_root.join("regular.txt");
     fs::write(&regular, b"regular content").expect("write regular");
 
@@ -973,7 +971,6 @@ fn execute_hardlink_mixed_with_symlinks() {
     let dest_hardlink = dest_root.join("source").join("hardlink.txt");
     let dest_symlink = dest_root.join("source").join("symlink.txt");
 
-    // Verify hardlink is preserved
     let dest_meta_regular = fs::metadata(&dest_regular).expect("dest meta regular");
     let dest_meta_hardlink = fs::metadata(&dest_hardlink).expect("dest meta hardlink");
     assert_eq!(dest_meta_regular.ino(), dest_meta_hardlink.ino(), "hardlink should be preserved");

--- a/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
@@ -139,10 +139,8 @@ fn delete_works_normally_without_io_errors() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Source has one file
     fs::write(source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Dest has an extra file that should be deleted
     fs::write(dest.join("keep.txt"), b"old keep").expect("write old keep");
     fs::write(dest.join("extra.txt"), b"extra").expect("write extra");
 
@@ -281,10 +279,8 @@ fn delete_suppressed_when_io_errors_and_ignore_errors_not_set() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // --delete WITHOUT --ignore-errors
     let options = LocalCopyOptions::default().recursive(true).delete(true);
 
-    // The copy should fail due to the I/O error.
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
     // Restore permissions for cleanup.
@@ -297,7 +293,6 @@ fn delete_suppressed_when_io_errors_and_ignore_errors_not_set() {
         "zsub/extra.txt must survive when a directory-read IO error suppresses deletion"
     );
 
-    // The operation should have reported an error.
     assert!(result.is_err(), "copy should report I/O error");
 }
 
@@ -443,7 +438,6 @@ fn delete_proceeds_when_io_errors_and_ignore_errors_set() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create a readable source file
     fs::write(source.join("good.txt"), b"good").expect("write good");
     // Create an unreadable source file to trigger I/O error
     fs::write(source.join("bad.txt"), b"bad").expect("write bad");
@@ -453,7 +447,6 @@ fn delete_proceeds_when_io_errors_and_ignore_errors_set() {
     )
     .expect("make unreadable");
 
-    // Dest has extra files that should be deleted with --ignore-errors
     fs::write(dest.join("good.txt"), b"old good").expect("write old good");
     fs::write(dest.join("extra.txt"), b"should be deleted").expect("write extra");
 
@@ -462,7 +455,6 @@ fn delete_proceeds_when_io_errors_and_ignore_errors_set() {
     let operands = vec![source_operand, dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // --delete WITH --ignore-errors
     let options = LocalCopyOptions::default()
         .delete(true)
         .ignore_errors(true);
@@ -475,21 +467,17 @@ fn delete_proceeds_when_io_errors_and_ignore_errors_set() {
         fs::Permissions::from_mode(0o644),
     );
 
-    // With --ignore-errors, the extra file should be deleted even though
-    // the transfer had errors
     assert!(
         !dest.join("extra.txt").exists(),
         "extra.txt should be deleted when --ignore-errors is set"
     );
 
-    // The operation should still report an error for the failed file
     assert!(result.is_err(), "copy should report I/O error");
 }
 
 #[cfg(unix)]
 #[test]
 fn ignore_errors_with_delete_after_timing() {
-    // Test --ignore-errors with --delete-after timing
     use std::os::unix::fs::PermissionsExt;
 
     let temp = tempdir().expect("tempdir");
@@ -535,7 +523,6 @@ fn ignore_errors_with_delete_after_timing() {
 #[cfg(unix)]
 #[test]
 fn no_ignore_errors_with_delete_after_suppresses_deletions() {
-    // Test that --delete-after suppresses deletions on I/O error without --ignore-errors
     use std::os::unix::fs::PermissionsExt;
 
     let temp = tempdir().expect("tempdir");
@@ -606,10 +593,8 @@ fn ignore_errors_with_dry_run_reports_deletions() {
 
     let summary = report.summary();
 
-    // In dry-run mode nothing should be modified on disk
     assert!(dest.join("extra.txt").exists(), "file should exist in dry-run");
 
-    // But the summary should report what would happen
     assert_eq!(summary.items_deleted(), 1, "should report 1 deletion in dry-run");
 }
 
@@ -623,7 +608,6 @@ fn ignore_errors_preserves_good_files_during_transfer() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create multiple source files - all readable
     fs::write(source.join("file1.txt"), b"content1").expect("write file1");
     fs::write(source.join("file2.txt"), b"content2").expect("write file2");
     fs::write(source.join("file3.txt"), b"content3").expect("write file3");
@@ -641,7 +625,6 @@ fn ignore_errors_preserves_good_files_during_transfer() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // All files should be transferred
     assert!(dest.join("file1.txt").exists());
     assert!(dest.join("file2.txt").exists());
     assert!(dest.join("file3.txt").exists());
@@ -650,7 +633,6 @@ fn ignore_errors_preserves_good_files_during_transfer() {
 
 #[test]
 fn ignore_errors_with_nested_directories() {
-    // Test --ignore-errors with nested directory structures
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
@@ -687,7 +669,6 @@ fn ignore_errors_with_nested_directories() {
 
 #[test]
 fn ignore_errors_combined_with_max_delete() {
-    // --ignore-errors should work alongside --max-delete
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
@@ -719,7 +700,6 @@ fn ignore_errors_combined_with_max_delete() {
 
 #[test]
 fn ignore_errors_combined_with_delete_excluded() {
-    // --ignore-errors + --delete-excluded should work together
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
@@ -755,7 +735,6 @@ fn ignore_errors_combined_with_delete_excluded() {
 
 #[test]
 fn ignore_errors_without_delete_no_deletions() {
-    // --ignore-errors without --delete should not cause any deletions
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
@@ -777,7 +756,6 @@ fn ignore_errors_without_delete_no_deletions() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Extra file should remain since --delete is not enabled
     assert!(dest.join("extra.txt").exists(), "extra file should remain without --delete");
     assert_eq!(summary.items_deleted(), 0, "no deletions should occur without --delete");
 }

--- a/crates/engine/src/local_copy/tests/execute_ignore_existing.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_existing.rs
@@ -17,7 +17,6 @@ fn ignore_existing_skips_file_with_different_content() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Different content, but destination exists
     fs::write(&source, b"new updated content").expect("write source");
     fs::write(&destination, b"old original content").expect("write dest");
 
@@ -54,7 +53,6 @@ fn ignore_existing_skips_file_with_different_timestamps() {
     fs::write(&source, b"content").expect("write source");
     fs::write(&destination, b"content").expect("write dest");
 
-    // Set different timestamps
     let newer_time = FileTime::from_unix_time(1_700_000_100, 0);
     let older_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, newer_time, newer_time).expect("set source times");
@@ -77,7 +75,6 @@ fn ignore_existing_skips_file_with_different_timestamps() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_ignored_existing(), 1);
 
-    // Verify timestamp is preserved (not updated)
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
     assert_eq!(dest_mtime, older_time);
@@ -109,7 +106,6 @@ fn ignore_existing_copies_when_destination_missing() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_ignored_existing(), 0);
-    // Destination should have content
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"new file content"
@@ -126,7 +122,6 @@ fn ignore_existing_skips_identical_files() {
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
 
-    // Set identical timestamps
     let same_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, same_time, same_time).expect("set source times");
     set_file_times(&destination, same_time, same_time).expect("set dest times");
@@ -192,22 +187,21 @@ fn ignore_existing_recursive_mixed_scenarios() {
     assert_eq!(summary.regular_files_total(), 4);
     assert_eq!(summary.regular_files_ignored_existing(), 3);
 
-    // Verify file contents
     assert_eq!(
         fs::read(dest_root.join("exists.txt")).expect("read exists"),
-        b"dest version" // preserved
+        b"dest version"
     );
     assert_eq!(
         fs::read(dest_root.join("new.txt")).expect("read new"),
-        b"brand new" // copied
+        b"brand new"
     );
     assert_eq!(
         fs::read(dest_root.join("same.txt")).expect("read same"),
-        b"same" // preserved (not rewritten)
+        b"same"
     );
     assert_eq!(
         fs::read(dest_root.join("old_dest.txt")).expect("read old_dest"),
-        b"older dest" // preserved
+        b"older dest"
     );
 }
 
@@ -217,7 +211,6 @@ fn ignore_existing_nested_directories() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create nested directory structure
     fs::create_dir_all(source_root.join("level1/level2")).expect("create source dirs");
     fs::create_dir_all(dest_root.join("level1/level2")).expect("create dest dirs");
 
@@ -255,7 +248,6 @@ fn ignore_existing_nested_directories() {
     assert_eq!(summary.files_copied(), 2);
     assert_eq!(summary.regular_files_ignored_existing(), 3);
 
-    // Verify content preservation
     assert_eq!(
         fs::read(dest_root.join("root.txt")).expect("read root"),
         b"root dest"
@@ -284,15 +276,12 @@ fn ignore_existing_handles_directories_correctly() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create directory structure
     fs::create_dir_all(source_root.join("subdir")).expect("create source subdir");
     fs::create_dir_all(dest_root.join("subdir")).expect("create dest subdir");
 
-    // Add file in subdirectory that already exists at destination
     fs::write(source_root.join("subdir/file.txt"), b"source content").expect("write source file");
     fs::write(dest_root.join("subdir/file.txt"), b"dest content").expect("write dest file");
 
-    // Add new file in subdirectory
     fs::write(source_root.join("subdir/new_file.txt"), b"new").expect("write new file");
 
     let mut source_operand = source_root.into_os_string();
@@ -312,15 +301,14 @@ fn ignore_existing_handles_directories_correctly() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_ignored_existing(), 1);
 
-    // Verify directory exists and contains both files
     assert!(dest_root.join("subdir").is_dir());
     assert_eq!(
         fs::read(dest_root.join("subdir/file.txt")).expect("read file"),
-        b"dest content" // preserved
+        b"dest content"
     );
     assert_eq!(
         fs::read(dest_root.join("subdir/new_file.txt")).expect("read new file"),
-        b"new" // copied
+        b"new"
     );
 }
 
@@ -333,7 +321,6 @@ fn ignore_existing_with_update_skips_all_existing() {
     fs::write(&source, b"newer content").expect("write source");
     fs::write(&destination, b"older content").expect("write dest");
 
-    // Source is newer than dest
     let newer_time = FileTime::from_unix_time(1_700_000_100, 0);
     let older_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, newer_time, newer_time).expect("set source times");
@@ -415,18 +402,17 @@ fn ignore_existing_with_update_copies_new_files() {
         summary.regular_files_ignored_existing()
     );
 
-    // Verify contents
     assert_eq!(
         fs::read(dest_root.join("exists_newer.txt")).expect("read exists_newer"),
-        b"older_content" // preserved
+        b"older_content"
     );
     assert_eq!(
         fs::read(dest_root.join("exists_older.txt")).expect("read exists_older"),
-        b"newer_value" // preserved
+        b"newer_value"
     );
     assert_eq!(
         fs::read(dest_root.join("new.txt")).expect("read new"),
-        b"new content" // copied
+        b"new content"
     );
 }
 
@@ -436,7 +422,6 @@ fn ignore_existing_with_checksum() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Different content (different checksums)
     fs::write(&source, b"source content").expect("write source");
     fs::write(&destination, b"dest content").expect("write dest");
 
@@ -471,7 +456,6 @@ fn ignore_existing_with_size_only() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Different content, same size
     fs::write(&source, b"abc").expect("write source");
     fs::write(&destination, b"xyz").expect("write dest");
 
@@ -505,7 +489,6 @@ fn ignore_existing_with_ignore_times() {
     fs::write(&source, b"content").expect("write source");
     fs::write(&destination, b"content").expect("write dest");
 
-    // Set same timestamps
     let same_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, same_time, same_time).expect("set source times");
     set_file_times(&destination, same_time, same_time).expect("set dest times");
@@ -537,7 +520,6 @@ fn ignore_existing_empty_files() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Both files are empty
     fs::write(&source, b"").expect("write empty source");
     fs::write(&destination, b"").expect("write empty dest");
 
@@ -554,7 +536,6 @@ fn ignore_existing_empty_files() {
         )
         .expect("copy succeeds");
 
-    // File should be skipped
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_ignored_existing(), 1);
 }
@@ -565,7 +546,6 @@ fn ignore_existing_empty_to_nonempty() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Source has content, dest is empty (but exists)
     fs::write(&source, b"source has content").expect("write source");
     fs::write(&destination, b"").expect("write empty dest");
 
@@ -594,7 +574,6 @@ fn ignore_existing_large_size_difference() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Large size difference
     fs::write(&source, vec![b'x'; 10000]).expect("write large source");
     fs::write(&destination, b"tiny").expect("write small dest");
 
@@ -626,7 +605,6 @@ fn ignore_existing_with_permissions_difference() {
     fs::write(&source, b"content").expect("write source");
     fs::write(&destination, b"content").expect("write dest");
 
-    // Set different permissions
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -675,11 +653,9 @@ fn ignore_existing_dry_run() {
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(&dest_root).expect("create dest root");
 
-    // Existing file
     fs::write(source_root.join("exists.txt"), b"source").expect("write exists source");
     fs::write(dest_root.join("exists.txt"), b"dest").expect("write exists dest");
 
-    // New file
     fs::write(source_root.join("new.txt"), b"new").expect("write new source");
 
     let mut source_operand = source_root.into_os_string();
@@ -697,7 +673,6 @@ fn ignore_existing_dry_run() {
     // Dry run should report what would happen
     assert_eq!(summary.regular_files_ignored_existing(), 1);
 
-    // Verify no actual changes were made
     assert_eq!(
         fs::read(dest_root.join("exists.txt")).expect("read exists"),
         b"dest"

--- a/crates/engine/src/local_copy/tests/execute_ignore_times.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_times.rs
@@ -22,7 +22,6 @@ fn ignore_times_transfers_file_with_matching_timestamps() {
     fs::write(&source, b"source content").expect("write source");
     fs::write(&destination, b"dest content").expect("write dest");
 
-    // Set identical timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
     set_file_times(&destination, timestamp, timestamp).expect("set dest times");
@@ -40,7 +39,6 @@ fn ignore_times_transfers_file_with_matching_timestamps() {
         )
         .expect("copy succeeds");
 
-    // File should be copied even though timestamps match
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(
@@ -55,7 +53,6 @@ fn ignore_times_transfers_identical_content() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Both files have identical content
     let content = b"identical content in both files";
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
@@ -78,11 +75,9 @@ fn ignore_times_transfers_identical_content() {
         )
         .expect("copy succeeds");
 
-    // File should be copied even though content is identical
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_matched(), 0);
-    // Content remains the same but file was transferred
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 }
 
@@ -114,7 +109,6 @@ fn ignore_times_updates_newer_destination() {
         )
         .expect("copy succeeds");
 
-    // File should be copied even though destination is newer
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(
@@ -129,7 +123,6 @@ fn ignore_times_with_checksum_skips_identical_content() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Both files have identical content
     let content = b"identical content for checksum test";
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
@@ -155,7 +148,6 @@ fn ignore_times_with_checksum_skips_identical_content() {
         )
         .expect("copy succeeds");
 
-    // File should be skipped because checksums match
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_matched(), 1);
@@ -172,7 +164,6 @@ fn ignore_times_with_checksum_copies_different_content() {
     fs::write(&source, b"source!").expect("write source");
     fs::write(&destination, b"dest!!!").expect("write dest");
 
-    // Set identical timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
     set_file_times(&destination, timestamp, timestamp).expect("set dest times");
@@ -192,7 +183,6 @@ fn ignore_times_with_checksum_copies_different_content() {
         )
         .expect("copy succeeds");
 
-    // File should be copied because checksums differ
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_matched(), 0);
@@ -247,7 +237,6 @@ fn ignore_times_with_checksum_handles_multiple_files() {
     assert_eq!(summary.regular_files_total(), 3);
     assert_eq!(summary.regular_files_matched(), 1);
 
-    // Verify content
     assert_eq!(
         fs::read(dest_root.join("same.txt")).expect("read same"),
         content1
@@ -274,12 +263,10 @@ fn ignore_times_with_size_only_skips_same_size() {
     fs::write(&source, b"source!").expect("write source");
     fs::write(&destination, b"dest!!!").expect("write dest");
 
-    // Verify sizes match
     let source_meta = fs::metadata(&source).expect("source metadata");
     let dest_meta = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(source_meta.len(), dest_meta.len());
 
-    // Set identical timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
     set_file_times(&destination, timestamp, timestamp).expect("set dest times");
@@ -321,7 +308,6 @@ fn size_only_wins_over_ignore_times_with_same_content() {
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
 
-    // Set matching timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
     set_file_times(&destination, timestamp, timestamp).expect("set dest times");
@@ -367,7 +353,6 @@ fn ignore_times_allows_delta_transfer() {
     source_content.append(&mut suffix_new.clone());
     fs::write(&source, &source_content).expect("write source");
 
-    // Set identical timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
     set_file_times(&destination, timestamp, timestamp).expect("set dest times");
@@ -383,11 +368,10 @@ fn ignore_times_allows_delta_transfer() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .ignore_times(true)
-                .whole_file(false), // Enable delta transfer
+                .whole_file(false),
         )
         .expect("copy succeeds");
 
-    // File should be copied using delta transfer
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
 
@@ -396,10 +380,8 @@ fn ignore_times_allows_delta_transfer() {
     assert!(summary.matched_bytes() >= 700, "should match at least 700 bytes of shared prefix");
     assert!(summary.matched_bytes() <= 1000, "should not match more than the shared prefix");
 
-    // Should have transferred the changed portion
     assert!(summary.bytes_copied() >= 500, "should transfer at least the changed 500 bytes");
 
-    // Verify final content is correct
     assert_eq!(fs::read(&destination).expect("read dest"), source_content);
 }
 
@@ -409,12 +391,10 @@ fn ignore_times_delta_transfer_with_matching_content() {
     let source = temp.path().join("source.bin");
     let destination = temp.path().join("dest.bin");
 
-    // Create identical files
     let content = vec![b'X'; 2000];
     fs::write(&source, &content).expect("write source");
     fs::write(&destination, &content).expect("write dest");
 
-    // Set matching timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
     set_file_times(&destination, timestamp, timestamp).expect("set dest times");
@@ -430,21 +410,18 @@ fn ignore_times_delta_transfer_with_matching_content() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .ignore_times(true)
-                .whole_file(false), // Enable delta transfer
+                .whole_file(false),
         )
         .expect("copy succeeds");
 
-    // File should be "copied" but with most/all bytes matched via delta
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
 
     // Most bytes should be matched via delta (block alignment may not be perfect)
     assert!(summary.matched_bytes() >= 1400, "should match most content via delta");
 
-    // Very few or no new bytes should be transferred
     assert!(summary.bytes_copied() <= 600, "should transfer minimal bytes for identical content");
 
-    // Verify content unchanged
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 }
 
@@ -454,13 +431,11 @@ fn ignore_times_whole_file_mode_transfers_entirely() {
     let source = temp.path().join("source.bin");
     let destination = temp.path().join("dest.bin");
 
-    // Create files with some shared content
     let content_source = vec![b'S'; 1500];
     let content_dest = vec![b'D'; 1500];
     fs::write(&source, &content_source).expect("write source");
     fs::write(&destination, &content_dest).expect("write dest");
 
-    // Set matching timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
     set_file_times(&destination, timestamp, timestamp).expect("set dest times");
@@ -476,21 +451,18 @@ fn ignore_times_whole_file_mode_transfers_entirely() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .ignore_times(true)
-                .whole_file(true), // Force whole file transfer
+                .whole_file(true),
         )
         .expect("copy succeeds");
 
-    // File should be copied entirely
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
 
     // In whole-file mode, no bytes are matched
     assert_eq!(summary.matched_bytes(), 0);
 
-    // All bytes transferred
     assert_eq!(summary.bytes_copied(), 1500);
 
-    // Verify final content
     assert_eq!(fs::read(&destination).expect("read dest"), content_source);
 }
 
@@ -535,7 +507,7 @@ fn ignore_times_overrides_update_skip() {
     assert_eq!(summary_with.regular_files_skipped_newer(), 1);
     assert_eq!(
         fs::read(&destination).expect("read dest"),
-        b"dest content"  // preserved
+        b"dest content"
     );
 }
 
@@ -578,12 +550,10 @@ fn ignore_times_recursive_transfers_all_files() {
         )
         .expect("copy succeeds");
 
-    // All 5 files should be copied
     assert_eq!(summary.files_copied(), 5);
     assert_eq!(summary.regular_files_total(), 5);
     assert_eq!(summary.regular_files_matched(), 0);
 
-    // Verify all files have source content
     for i in 1..=5 {
         let filename = format!("file{i}.txt");
         let expected = format!("source content {i}");
@@ -600,7 +570,6 @@ fn ignore_times_with_nested_directories() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create nested directory structure
     let nested_source = source_root.join("dir1/dir2");
     let nested_dest = dest_root.join("dir1/dir2");
     fs::create_dir_all(&nested_source).expect("create nested source");
@@ -608,7 +577,6 @@ fn ignore_times_with_nested_directories() {
 
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
 
-    // Create files at different levels
     fs::write(source_root.join("root.txt"), b"root source")
         .expect("write root source");
     fs::write(dest_root.join("root.txt"), b"root dest!!")
@@ -648,11 +616,9 @@ fn ignore_times_with_nested_directories() {
         )
         .expect("copy succeeds");
 
-    // All 3 files should be copied
     assert_eq!(summary.files_copied(), 3);
     assert_eq!(summary.regular_files_total(), 3);
 
-    // Verify all files have source content
     assert_eq!(
         fs::read(dest_root.join("root.txt")).expect("read root"),
         b"root source"
@@ -673,11 +639,9 @@ fn ignore_times_with_empty_files() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Both files are empty
     fs::write(&source, b"").expect("write empty source");
     fs::write(&destination, b"").expect("write empty dest");
 
-    // Set matching timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
     set_file_times(&destination, timestamp, timestamp).expect("set dest times");
@@ -695,7 +659,6 @@ fn ignore_times_with_empty_files() {
         )
         .expect("copy succeeds");
 
-    // Even empty files should be "copied"
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.bytes_copied(), 0);
@@ -709,7 +672,6 @@ fn ignore_times_creates_missing_destination() {
     let destination = temp.path().join("dest.txt");
 
     fs::write(&source, b"new file content").expect("write source");
-    // No destination file exists
 
     let operands = vec![
         source.into_os_string(),
@@ -724,7 +686,6 @@ fn ignore_times_creates_missing_destination() {
         )
         .expect("copy succeeds");
 
-    // File should be created
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(
@@ -745,7 +706,6 @@ fn ignore_times_with_large_files() {
     fs::write(&source, &source_content).expect("write source");
     fs::write(&destination, &dest_content).expect("write dest");
 
-    // Set matching timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
     set_file_times(&destination, timestamp, timestamp).expect("set dest times");
@@ -763,7 +723,6 @@ fn ignore_times_with_large_files() {
         )
         .expect("copy succeeds");
 
-    // File should be copied
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.bytes_copied(), 150_000);
@@ -782,7 +741,6 @@ fn ignore_times_dry_run_reports_correctly() {
     fs::write(&source, b"source content").expect("write source");
     fs::write(&destination, b"dest content").expect("write dest");
 
-    // Set matching timestamps
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
     set_file_times(&destination, timestamp, timestamp).expect("set dest times");
@@ -800,11 +758,9 @@ fn ignore_times_dry_run_reports_correctly() {
         )
         .expect("dry run succeeds");
 
-    // Dry run should report the file would be copied
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
 
-    // Destination should remain unchanged
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"dest content"
@@ -820,7 +776,6 @@ fn ignore_times_with_permissions_and_times_preserves_metadata() {
     fs::write(&source, b"source content").expect("write source");
     fs::write(&destination, b"dest content").expect("write dest");
 
-    // Set source timestamp and permissions
     let source_time = FileTime::from_unix_time(1_700_000_500, 0);
     set_file_times(&source, source_time, source_time).expect("set source times");
 
@@ -832,7 +787,6 @@ fn ignore_times_with_permissions_and_times_preserves_metadata() {
         fs::set_permissions(&source, perms).expect("set source perms");
     }
 
-    // Set different destination timestamp
     let dest_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&destination, dest_time, dest_time).expect("set dest times");
 
@@ -852,16 +806,13 @@ fn ignore_times_with_permissions_and_times_preserves_metadata() {
         )
         .expect("copy succeeds");
 
-    // File should be copied
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify content
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"source content"
     );
 
-    // Verify timestamp was preserved (when --times is set)
     let dest_meta = fs::metadata(&destination).expect("dest metadata");
     let dest_final_time = FileTime::from_last_modification_time(&dest_meta);
     assert_eq!(dest_final_time, source_time);

--- a/crates/engine/src/local_copy/tests/execute_inplace.rs
+++ b/crates/engine/src/local_copy/tests/execute_inplace.rs
@@ -520,12 +520,10 @@ fn execute_inplace_recursive_directory() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create source tree
     fs::create_dir_all(source_root.join("subdir")).expect("create subdir");
     fs::write(source_root.join("file1.txt"), b"content1").expect("write file1");
     fs::write(source_root.join("subdir/file2.txt"), b"content2").expect("write file2");
 
-    // Create destination tree with existing files
     fs::create_dir_all(dest_root.join("subdir")).expect("create dest subdir");
     fs::write(dest_root.join("file1.txt"), b"old1").expect("write dest file1");
     fs::write(dest_root.join("subdir/file2.txt"), b"old2").expect("write dest file2");
@@ -595,7 +593,6 @@ fn execute_inplace_in_read_only_directory() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(fs::read(&destination).expect("read"), b"update");
 
-    // Verify inode preserved
     let updated_inode = fs::metadata(&destination)
         .expect("destination metadata")
         .ino();
@@ -639,7 +636,6 @@ fn execute_without_inplace_fails_in_read_only_directory() {
     // Expect failure due to permission denied creating temp file
     assert!(result.is_err(), "should fail without inplace in read-only dir");
 
-    // Original should be unchanged
     assert_eq!(fs::read(&destination).expect("read"), b"original");
 
     // Restore permissions for cleanup
@@ -807,7 +803,6 @@ fn execute_inplace_with_delta_transfer_skips_matched_blocks() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Create a destination file with some content
     let dest_content = b"Hello world! This is a test file with some content that will be partially reused.";
     fs::write(&destination, dest_content).expect("write destination");
 
@@ -867,10 +862,8 @@ fn execute_inplace_with_delta_transfer_updates_existing_file() {
         )
         .expect("copy succeeds");
 
-    // The file should be copied
     assert_eq!(summary.files_copied(), 1, "File should be copied");
 
-    // Verify the content matches
     let final_content = fs::read(&destination).expect("read dest");
     assert_eq!(final_content, source_content,
         "Content should match after inplace delta transfer");
@@ -1103,6 +1096,5 @@ fn execute_inplace_dry_run_does_not_modify() {
         .expect("dry run succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    // Original content should be preserved
     assert_eq!(fs::read(&destination).expect("read dest"), b"original");
 }

--- a/crates/engine/src/local_copy/tests/execute_link_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_link_dest.rs
@@ -56,7 +56,6 @@ fn link_dest_hardlinks_identical_file() {
     let dest_meta = fs::metadata(&dest_file).expect("dest metadata");
     let link_dest_meta = fs::metadata(&link_dest_file).expect("link-dest metadata");
 
-    // Verify hard link was created
     assert_eq!(
         dest_meta.ino(),
         link_dest_meta.ino(),
@@ -104,7 +103,6 @@ fn link_dest_copies_different_file() {
     let dest_meta = fs::metadata(&dest_file).expect("dest metadata");
     let link_dest_meta = fs::metadata(&link_dest_file).expect("link-dest metadata");
 
-    // Verify files are NOT hard linked
     assert_ne!(
         dest_meta.ino(),
         link_dest_meta.ino(),
@@ -647,7 +645,6 @@ fn link_dest_preserves_file_permissions() {
     let source_file = source_dir.join("file.txt");
     fs::write(&source_file, b"content").expect("write source");
 
-    // Set specific permissions on source
     use std::os::unix::fs::PermissionsExt;
     let perms = fs::Permissions::from_mode(0o644);
     fs::set_permissions(&source_file, perms).expect("set source permissions");
@@ -686,7 +683,6 @@ fn link_dest_preserves_file_permissions() {
     let dest_meta = fs::metadata(&dest_file).expect("dest metadata");
     let link_dest_meta = fs::metadata(&link_dest_file).expect("link-dest metadata");
 
-    // Verify hard link was created
     assert_eq!(dest_meta.ino(), link_dest_meta.ino());
     assert!(summary.hard_links_created() >= 1);
 

--- a/crates/engine/src/local_copy/tests/execute_long_paths.rs
+++ b/crates/engine/src/local_copy/tests/execute_long_paths.rs
@@ -56,7 +56,6 @@ fn execute_copies_file_in_deep_directory() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create 50 levels deep
     let deep_path = create_deep_structure(&source_root, 50, 15);
     fs::write(deep_path.join("deep.txt"), b"deep content").expect("write deep file");
 
@@ -73,7 +72,6 @@ fn execute_copies_file_in_deep_directory() {
     assert_eq!(summary.files_copied(), 1);
     assert!(summary.directories_created() >= 50);
 
-    // Verify deep file was copied
     let mut dest_deep = dest_root.join("source");
     for i in 0..50 {
         dest_deep = dest_deep.join(format!("d{i:014}"));
@@ -118,7 +116,6 @@ fn execute_copies_directory_with_long_name() {
     let dest = temp.path().join("dest");
     fs::create_dir(&source).expect("create source");
 
-    // Create directory with long name (220 bytes)
     let long_dirname = create_filename_of_length(220, "_dir");
     let source_dir = source.join(&long_dirname);
     fs::create_dir(&source_dir).expect("create long dir");
@@ -175,7 +172,6 @@ fn execute_copies_file_near_path_max() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify file was copied to correct location
     let mut dest_file = dest_root.join("source");
     for i in 0..levels {
         dest_file = dest_file.join(format!("d{:0width$}", i, width = dir_name_len - 1));
@@ -198,10 +194,8 @@ fn execute_copies_combined_long_path_and_long_filename() {
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
 
-    // Create moderately deep structure
     let deep_path = create_deep_structure(&source, 15, 50);
 
-    // Add file with long name (200 chars)
     let long_filename = create_filename_of_length(200, ".txt");
     fs::write(deep_path.join(&long_filename), b"combo").expect("write file");
 
@@ -214,7 +208,6 @@ fn execute_copies_combined_long_path_and_long_filename() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify file was copied
     let mut dest_path = dest.join("source");
     for i in 0..15 {
         dest_path = dest_path.join(format!("d{i:049}"));
@@ -231,7 +224,6 @@ fn execute_copies_multiple_files_in_deep_tree() {
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
 
-    // Create structure with files at various depths
     let levels = [5, 10, 15, 20, 25];
     for &level in &levels {
         let path = create_deep_structure(&source.join(format!("branch{level}")), level, 20);
@@ -247,7 +239,6 @@ fn execute_copies_multiple_files_in_deep_tree() {
 
     assert_eq!(summary.files_copied(), 5);
 
-    // Verify all files were copied
     for &level in &levels {
         let mut path = dest.join("source").join(format!("branch{level}"));
         for i in 0..level {
@@ -267,7 +258,6 @@ fn execute_copies_many_files_with_long_names() {
     let dest = temp.path().join("dest");
     fs::create_dir(&source).expect("create source");
 
-    // Create 10 files with long names (200 bytes, differentiated by suffix)
     for i in 0..10 {
         let filename = create_filename_of_length(200, &format!("{i}.txt"));
         fs::write(source.join(&filename), format!("content {i}").as_bytes()).expect("write");
@@ -293,12 +283,10 @@ fn execute_copies_symlink_to_deep_target() {
     let dest = temp.path().join("dest");
     fs::create_dir(&source).expect("create source");
 
-    // Create deep target outside source
     let target_root = temp.path().join("target");
     let deep_target = create_deep_structure(&target_root, 20, 40);
     fs::write(deep_target.join("target.txt"), b"target content").expect("write target");
 
-    // Create symlink in source pointing to deep target
     let link_path = source.join("link_to_deep");
     symlink(&deep_target, &link_path).expect("create symlink");
 
@@ -328,12 +316,10 @@ fn execute_copies_symlink_with_long_target_name() {
     let dest = temp.path().join("dest");
     fs::create_dir(&source).expect("create source");
 
-    // Create target with long name (200 bytes)
     let long_target_name = create_filename_of_length(200, "_target");
     let target_path = temp.path().join(&long_target_name);
     fs::write(&target_path, b"target content").expect("write target");
 
-    // Create symlink to it
     let link_path = source.join("link");
     symlink(&target_path, &link_path).expect("create symlink");
 
@@ -347,7 +333,6 @@ fn execute_copies_symlink_with_long_target_name() {
 
     assert_eq!(summary.symlinks_copied(), 1);
 
-    // Verify symlink target is preserved
     let copied_target = fs::read_link(dest.join("source").join("link")).expect("read link");
     assert_eq!(copied_target, target_path);
 }
@@ -362,13 +347,11 @@ fn execute_follows_symlink_to_deep_directory() {
     let dest = temp.path().join("dest");
     fs::create_dir(&source).expect("create source");
 
-    // Create deep target directory with files
     let target_root = temp.path().join("target");
     let deep_target = create_deep_structure(&target_root, 15, 30);
     fs::write(deep_target.join("file1.txt"), b"file1").expect("write file1");
     fs::write(deep_target.join("file2.txt"), b"file2").expect("write file2");
 
-    // Create symlink to deep target
     let link_path = source.join("linked_dir");
     symlink(&deep_target, &link_path).expect("create symlink");
 
@@ -396,7 +379,6 @@ fn execute_with_relative_and_deep_structure() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Create deep structure
     let deep_path = create_deep_structure(&source_root, 20, 25);
     fs::write(deep_path.join("relative.txt"), b"relative content").expect("write file");
 
@@ -469,7 +451,6 @@ fn execute_preserves_mtime_for_files_with_long_paths() {
     let source_file = deep_path.join("timed.txt");
     fs::write(&source_file, b"timed").expect("write file");
 
-    // Set specific mtime
     let past_time = FileTime::from_unix_time(1_600_000_000, 0);
     set_file_mtime(&source_file, past_time).expect("set mtime");
 
@@ -483,7 +464,6 @@ fn execute_preserves_mtime_for_files_with_long_paths() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Find and verify destination file mtime
     let mut dest_file = dest.join("source");
     for i in 0..20 {
         dest_file = dest_file.join(format!("d{i:029}"));
@@ -507,7 +487,6 @@ fn execute_preserves_permissions_for_files_with_long_paths() {
     let source_file = deep_path.join("permed.txt");
     fs::write(&source_file, b"permed").expect("write file");
 
-    // Set specific permissions
     let mut perms = fs::metadata(&source_file).expect("meta").permissions();
     perms.set_mode(0o640);
     fs::set_permissions(&source_file, perms).expect("set perms");
@@ -522,7 +501,6 @@ fn execute_preserves_permissions_for_files_with_long_paths() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Find and verify destination file permissions
     let mut dest_file = dest.join("source");
     for i in 0..15 {
         dest_file = dest_file.join(format!("d{i:039}"));
@@ -552,7 +530,6 @@ fn execute_dry_run_with_deep_structure() {
     assert_eq!(summary.files_copied(), 1);
     assert!(summary.directories_created() >= 30);
 
-    // Destination should not exist
     assert!(!dest.exists(), "dry run should not create destination");
 }
 
@@ -563,11 +540,9 @@ fn execute_delete_removes_deep_structure() {
     let dest = temp.path().join("dest");
     fs::create_dir(&source).expect("create source");
 
-    // Pre-create deep structure in destination
     let deep_dest = create_deep_structure(&dest, 25, 25);
     fs::write(deep_dest.join("to_delete.txt"), b"delete me").expect("write dest file");
 
-    // Source has a file at root level only
     fs::write(source.join("keep.txt"), b"keep").expect("write source");
 
     let mut source_operand = source.into_os_string();
@@ -583,13 +558,9 @@ fn execute_delete_removes_deep_structure() {
     assert_eq!(summary.files_copied(), 1);
     assert!(summary.items_deleted() > 0);
 
-    // Deep structure should be gone
     assert!(!deep_dest.exists(), "deep structure should be deleted");
     assert!(dest.join("keep.txt").exists(), "kept file should exist");
 }
-
-// Removed complex backup test - backup behavior is thoroughly tested in backups.rs
-// This file focuses on basic long path copying functionality
 
 #[cfg(unix)]
 #[test]
@@ -600,7 +571,6 @@ fn execute_hardlinks_in_deep_structure() {
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
 
-    // Create deep structure with hardlinked files
     let deep_path = create_deep_structure(&source, 15, 25);
     let file1 = deep_path.join("file1.txt");
     let file2 = deep_path.join("file2.txt");
@@ -608,7 +578,6 @@ fn execute_hardlinks_in_deep_structure() {
     fs::write(&file1, b"hardlinked content").expect("write file1");
     fs::hard_link(&file1, &file2).expect("create hardlink");
 
-    // Verify source hardlinks
     let src_meta1 = fs::metadata(&file1).expect("meta1");
     let src_meta2 = fs::metadata(&file2).expect("meta2");
     assert_eq!(src_meta1.ino(), src_meta2.ino());
@@ -623,7 +592,6 @@ fn execute_hardlinks_in_deep_structure() {
 
     assert!(summary.hard_links_created() >= 1);
 
-    // Verify destination hardlinks
     let mut dest_path = dest.join("source");
     for i in 0..15 {
         dest_path = dest_path.join(format!("d{i:024}"));
@@ -640,16 +608,13 @@ fn execute_checksum_mode_works_with_long_paths() {
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
 
-    // Create deep structure
     let deep_source = create_deep_structure(&source, 20, 20);
 
-    // Create a file that needs to be transferred
     fs::write(deep_source.join("checksum.txt"), b"checksum test content").expect("write source");
 
     let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Use checksum mode and verify it succeeds with long paths
     let options = LocalCopyOptions::default()
         .checksum(true)
         .with_checksum_algorithm(SignatureAlgorithm::Md4);
@@ -657,10 +622,8 @@ fn execute_checksum_mode_works_with_long_paths() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // File should be copied (new file transfer)
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify content
     let mut dest_path = dest.join("source");
     for i in 0..20 {
         dest_path = dest_path.join(format!("d{i:019}"));
@@ -677,14 +640,12 @@ fn execute_inplace_with_long_paths() {
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
 
-    // Create deep structure only in source
     let deep_source = create_deep_structure(&source, 15, 35);
     fs::write(deep_source.join("inplace.txt"), b"content for inplace").expect("write source");
 
     let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Test that inplace mode works for new files in deep paths
     let options = LocalCopyOptions::default().inplace(true);
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
@@ -692,7 +653,6 @@ fn execute_inplace_with_long_paths() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify content
     let mut dest_file = dest.join("source");
     for i in 0..15 {
         dest_file = dest_file.join(format!("d{i:034}"));
@@ -709,9 +669,7 @@ fn execute_copies_empty_directories_in_deep_structure() {
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
 
-    // Create deep structure with empty directories
     let deep_path = create_deep_structure(&source, 25, 30);
-    // Create some empty subdirectories at the deepest level
     for name in ["empty1", "empty2", "empty3"] {
         fs::create_dir(deep_path.join(name)).expect("create empty dir");
     }
@@ -723,10 +681,8 @@ fn execute_copies_empty_directories_in_deep_structure() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("copy succeeds");
 
-    // Should have created all directories including empty ones
     assert!(summary.directories_created() >= 28); // 25 + 3 empty
 
-    // Verify empty directories exist
     let mut dest_path = dest.join("source");
     for i in 0..25 {
         dest_path = dest_path.join(format!("d{i:029}"));
@@ -745,11 +701,9 @@ fn execute_update_with_long_paths() {
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
 
-    // Create deep structures
     let deep_source = create_deep_structure(&source, 18, 25);
     let deep_dest = create_deep_structure(&dest.join("source"), 18, 25);
 
-    // Create files with different mtimes
     let source_file = deep_source.join("update.txt");
     let dest_file = deep_dest.join("update.txt");
     fs::write(&source_file, b"updated content").expect("write source");
@@ -772,7 +726,3 @@ fn execute_update_with_long_paths() {
     // File should be updated because source is newer
     assert_eq!(summary.files_copied(), 1);
 }
-
-// Removed test: execute_update_skips_older_source_with_long_paths
-// The update skip behavior with directory transfers has complex semantics
-// that are better tested in execute_update.rs. Here we focus on basic long path handling.

--- a/crates/engine/src/local_copy/tests/execute_max_delete.rs
+++ b/crates/engine/src/local_copy/tests/execute_max_delete.rs
@@ -20,10 +20,8 @@ fn max_delete_stops_after_n_deletions() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
-    // Create source with one file
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with multiple extra files
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
@@ -45,10 +43,8 @@ fn max_delete_stops_after_n_deletions() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect_err("should fail when max-delete limit reached");
 
-    // Verify the error type and exit code
     assert_eq!(error.exit_code(), MAX_DELETE_EXIT_CODE);
 
-    // Verify keep file was still updated
     assert!(target_root.join("keep.txt").exists());
     assert_eq!(
         fs::read(target_root.join("keep.txt")).expect("read keep"),
@@ -73,7 +69,6 @@ fn max_delete_reports_correct_skipped_count() {
 
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with 5 extra files, limit to 2 deletions
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
@@ -95,7 +90,6 @@ fn max_delete_reports_correct_skipped_count() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect_err("should fail when max-delete limit reached");
 
-    // Check the skipped count in the error
     match error.kind() {
         LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
             assert_eq!(*skipped, 3, "should report 3 skipped entries (5 total - 2 deleted)");
@@ -168,7 +162,6 @@ fn max_delete_zero_prevents_all_deletions() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect_err("should fail when max-delete=0 and deletions needed");
 
-    // Verify error
     assert_eq!(error.exit_code(), MAX_DELETE_EXIT_CODE);
     match error.kind() {
         LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
@@ -177,12 +170,10 @@ fn max_delete_zero_prevents_all_deletions() {
         other => panic!("unexpected error kind: {other:?}"),
     }
 
-    // Verify no deletions occurred
     assert!(
         target_root.join("extra.txt").exists(),
         "extra file should still exist with max-delete=0"
     );
-    // But keep file should still be updated
     assert_eq!(
         fs::read(target_root.join("keep.txt")).expect("read keep"),
         b"keep"
@@ -238,7 +229,6 @@ fn max_delete_exact_limit_succeeds() {
 
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with exactly 3 extra files, set limit to 3
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
@@ -255,7 +245,6 @@ fn max_delete_exact_limit_succeeds() {
         .delete(true)
         .max_deletions(Some(3));
 
-    // Should succeed when deletions exactly match limit
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("should succeed when deletions equal limit");
@@ -273,7 +262,6 @@ fn max_delete_under_limit_succeeds() {
 
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with 2 extra files, set limit to 10
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
@@ -315,7 +303,6 @@ fn max_delete_large_value() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    // Use a very large limit
     let options = LocalCopyOptions::default()
         .delete(true)
         .max_deletions(Some(u64::MAX));
@@ -335,7 +322,6 @@ fn max_delete_none_allows_unlimited_deletions() {
 
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with many extra files
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
@@ -349,7 +335,6 @@ fn max_delete_none_allows_unlimited_deletions() {
         ctx.dest.clone().into_os_string(),
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-    // No max_deletions limit (None)
     let options = LocalCopyOptions::default()
         .delete(true)
         .max_deletions(None);
@@ -536,7 +521,6 @@ fn max_delete_with_dry_run_reports_limit_exceeded() {
         .delete(true)
         .max_deletions(Some(1));
 
-    // Dry-run should still report the error
     let error = plan
         .execute_with_options(LocalCopyExecution::DryRun, options)
         .expect_err("dry-run should report max-delete exceeded");
@@ -581,7 +565,6 @@ fn max_delete_dry_run_success_when_under_limit() {
     // Dry-run reports what would be deleted
     assert_eq!(summary.items_deleted(), 1);
 
-    // Files should still exist
     assert!(target_root.join("extra.txt").exists());
 }
 
@@ -593,7 +576,6 @@ fn max_delete_counts_directory_deletions() {
 
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with extra directories
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
@@ -630,7 +612,6 @@ fn max_delete_mixed_files_and_directories() {
 
     fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
 
-    // Create destination with mix of extra files and directories
     let target_root = ctx.dest.join("source");
     fs::create_dir_all(&target_root).expect("create target root");
     fs::write(target_root.join("keep.txt"), b"old").expect("write old");
@@ -714,7 +695,6 @@ fn max_delete_without_delete_flag_has_no_effect() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("should succeed when delete not enabled");
 
-    // No deletions should occur
     assert_eq!(summary.items_deleted(), 0);
     assert!(
         target_root.join("extra.txt").exists(),

--- a/crates/engine/src/local_copy/tests/execute_metadata.rs
+++ b/crates/engine/src/local_copy/tests/execute_metadata.rs
@@ -330,7 +330,6 @@ fn execute_preserves_mode_0000_on_destination_file() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify destination has mode 0000
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.permissions().mode() & 0o777, 0o000);
     assert_eq!(summary.files_copied(), 1);
@@ -398,7 +397,6 @@ fn execute_mode_0000_without_permissions_option() {
     let summary = plan.execute().expect("copy succeeds");
 
     let metadata = fs::metadata(&destination).expect("dest metadata");
-    // Destination should NOT have mode 0000
     assert_ne!(metadata.permissions().mode() & 0o777, 0o000);
     assert_eq!(summary.files_copied(), 1);
 }
@@ -548,19 +546,10 @@ fn execute_preserves_all_permission_bits_including_special() {
     let metadata = fs::metadata(&destination).expect("dest metadata");
     let dest_mode = metadata.permissions().mode();
 
-    // Verify all permission bits are preserved
     assert_eq!(dest_mode & 0o7777, 0o7777, "all permission bits should be preserved");
-
-    // Verify setuid bit
     assert_eq!(dest_mode & 0o4000, 0o4000, "setuid bit should be set");
-
-    // Verify setgid bit
     assert_eq!(dest_mode & 0o2000, 0o2000, "setgid bit should be set");
-
-    // Verify sticky bit
     assert_eq!(dest_mode & 0o1000, 0o1000, "sticky bit should be set");
-
-    // Verify standard permission bits
     assert_eq!(dest_mode & 0o777, 0o777, "all rwx bits should be set");
 
     assert_eq!(summary.files_copied(), 1);
@@ -697,7 +686,6 @@ fn execute_round_trip_preserves_all_bits() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("second copy succeeds");
 
-    // Verify all bits are preserved through round trip
     let src_metadata = fs::metadata(&source).expect("source metadata");
     let final_metadata = fs::metadata(&final_dest).expect("final metadata");
 
@@ -740,7 +728,6 @@ fn execute_special_bits_not_preserved_without_perms_flag() {
     let metadata = fs::metadata(&destination).expect("dest metadata");
     let dest_mode = metadata.permissions().mode();
 
-    // Special bits should NOT be preserved without --perms flag
     assert_eq!(dest_mode & 0o7000, 0, "special bits should not be preserved without --perms");
     assert_eq!(summary.files_copied(), 1);
 }
@@ -771,7 +758,6 @@ fn execute_combined_special_bits_with_restrictive_perms() {
     let metadata = fs::metadata(&destination).expect("dest metadata");
     let dest_mode = metadata.permissions().mode();
 
-    // Verify all special bits are preserved even with restrictive base permissions
     assert_eq!(dest_mode & 0o7000, 0o7000, "all special bits should be preserved");
     assert_eq!(dest_mode & 0o777, 0o600, "restrictive permissions should be preserved");
     assert_eq!(dest_mode & 0o7777, 0o7600, "combined mode should match exactly");
@@ -808,7 +794,6 @@ fn execute_directory_with_special_bits() {
     let dest_metadata = fs::metadata(dest_dir.join("source")).expect("dest dir metadata");
     let dest_mode = dest_metadata.permissions().mode();
 
-    // Verify directory special bits are preserved
     assert_eq!(dest_mode & 0o2000, 0o2000, "setgid bit should be preserved on directory");
     assert_eq!(dest_mode & 0o1000, 0o1000, "sticky bit should be preserved on directory");
     assert_eq!(dest_mode & 0o777, 0o775, "directory permissions should match");
@@ -828,7 +813,6 @@ fn execute_multiple_files_with_different_special_bits() {
     fs::create_dir(&source_dir).expect("create source dir");
     fs::create_dir(&dest_dir).expect("create dest dir");
 
-    // Create files with different special permission combinations
     let setuid_file = source_dir.join("setuid.txt");
     fs::write(&setuid_file, b"setuid").expect("write setuid file");
     fs::set_permissions(&setuid_file, PermissionsExt::from_mode(0o4755)).expect("set setuid");
@@ -855,7 +839,6 @@ fn execute_multiple_files_with_different_special_bits() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify each file's special bits
     let setuid_dest = dest_dir.join("source").join("setuid.txt");
     let setuid_mode = fs::metadata(&setuid_dest).expect("setuid metadata").permissions().mode();
     assert_eq!(setuid_mode & 0o4000, 0o4000, "setuid bit preserved");

--- a/crates/engine/src/local_copy/tests/execute_min_size.rs
+++ b/crates/engine/src/local_copy/tests/execute_min_size.rs
@@ -7,7 +7,6 @@ fn min_size_excludes_files_smaller_than_limit() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create files with various sizes
     fs::write(source.join("tiny.txt"), b"x").expect("write 1-byte file");
     fs::write(source.join("small.txt"), b"hello").expect("write 5-byte file");
     fs::write(source.join("medium.txt"), b"hello world!").expect("write 12-byte file");
@@ -19,7 +18,6 @@ fn min_size_excludes_files_smaller_than_limit() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set min-size to 10 bytes
     let options = LocalCopyOptions::default().min_file_size(Some(10));
 
     let summary = plan
@@ -28,15 +26,12 @@ fn min_size_excludes_files_smaller_than_limit() {
 
     let target_root = dest.join("source");
 
-    // Files smaller than 10 bytes should be excluded
     assert!(!target_root.join("tiny.txt").exists(), "1-byte file should be excluded");
     assert!(!target_root.join("small.txt").exists(), "5-byte file should be excluded");
 
-    // Files >= 10 bytes should be included
     assert!(target_root.join("medium.txt").exists(), "12-byte file should be included");
     assert!(target_root.join("large.txt").exists(), "100-byte file should be included");
 
-    // Should have copied 2 files (medium and large)
     assert_eq!(summary.files_copied(), 2);
 }
 
@@ -48,7 +43,6 @@ fn min_size_includes_files_equal_to_limit() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create files around the boundary
     fs::write(source.join("below.txt"), vec![b'x'; 99]).expect("write 99-byte file");
     fs::write(source.join("exact.txt"), vec![b'x'; 100]).expect("write 100-byte file");
     fs::write(source.join("above.txt"), vec![b'x'; 101]).expect("write 101-byte file");
@@ -59,7 +53,6 @@ fn min_size_includes_files_equal_to_limit() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set min-size to exactly 100 bytes
     let options = LocalCopyOptions::default().min_file_size(Some(100));
 
     let summary = plan
@@ -68,16 +61,12 @@ fn min_size_includes_files_equal_to_limit() {
 
     let target_root = dest.join("source");
 
-    // File below limit should be excluded
     assert!(!target_root.join("below.txt").exists(), "99-byte file should be excluded");
 
-    // File equal to limit should be included
     assert!(target_root.join("exact.txt").exists(), "100-byte file should be included");
 
-    // File above limit should be included
     assert!(target_root.join("above.txt").exists(), "101-byte file should be included");
 
-    // Should have copied 2 files (exact and above)
     assert_eq!(summary.files_copied(), 2);
 }
 
@@ -89,7 +78,6 @@ fn min_size_includes_files_larger_than_limit() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create small and large files
     fs::write(source.join("small.txt"), b"tiny").expect("write small file");
     fs::write(source.join("large1.txt"), vec![b'a'; 1000]).expect("write 1KB file");
     fs::write(source.join("large2.txt"), vec![b'b'; 5000]).expect("write 5KB file");
@@ -101,7 +89,6 @@ fn min_size_includes_files_larger_than_limit() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set min-size to 500 bytes
     let options = LocalCopyOptions::default().min_file_size(Some(500));
 
     let summary = plan
@@ -110,15 +97,12 @@ fn min_size_includes_files_larger_than_limit() {
 
     let target_root = dest.join("source");
 
-    // Small file should be excluded
     assert!(!target_root.join("small.txt").exists(), "4-byte file should be excluded");
 
-    // All large files should be included
     assert!(target_root.join("large1.txt").exists(), "1000-byte file should be included");
     assert!(target_root.join("large2.txt").exists(), "5000-byte file should be included");
     assert!(target_root.join("huge.txt").exists(), "10000-byte file should be included");
 
-    // Should have copied 3 large files
     assert_eq!(summary.files_copied(), 3);
 }
 
@@ -130,7 +114,6 @@ fn min_size_with_kilobyte_suffix() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create files around 1KB boundary
     fs::write(source.join("small.txt"), vec![b'x'; 500]).expect("write 500-byte file");
     fs::write(source.join("exact.txt"), vec![b'x'; 1024]).expect("write 1KB file");
     fs::write(source.join("large.txt"), vec![b'x'; 2048]).expect("write 2KB file");
@@ -141,7 +124,6 @@ fn min_size_with_kilobyte_suffix() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set min-size to 1K (1024 bytes)
     let options = LocalCopyOptions::default().min_file_size(Some(1024));
 
     let summary = plan
@@ -150,10 +132,8 @@ fn min_size_with_kilobyte_suffix() {
 
     let target_root = dest.join("source");
 
-    // File below 1KB should be excluded
     assert!(!target_root.join("small.txt").exists(), "500-byte file should be excluded");
 
-    // Files >= 1KB should be included
     assert!(target_root.join("exact.txt").exists(), "1KB file should be included");
     assert!(target_root.join("large.txt").exists(), "2KB file should be included");
 
@@ -168,7 +148,6 @@ fn min_size_with_megabyte_suffix() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create files around 1MB boundary
     fs::write(source.join("small.txt"), vec![b'x'; 512 * 1024]).expect("write 512KB file");
     fs::write(source.join("exact.txt"), vec![b'x'; 1024 * 1024]).expect("write 1MB file");
     fs::write(source.join("large.txt"), vec![b'x'; 2 * 1024 * 1024]).expect("write 2MB file");
@@ -179,7 +158,6 @@ fn min_size_with_megabyte_suffix() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set min-size to 1M (1048576 bytes)
     let options = LocalCopyOptions::default().min_file_size(Some(1024 * 1024));
 
     let summary = plan
@@ -188,10 +166,8 @@ fn min_size_with_megabyte_suffix() {
 
     let target_root = dest.join("source");
 
-    // File below 1MB should be excluded
     assert!(!target_root.join("small.txt").exists(), "512KB file should be excluded");
 
-    // Files >= 1MB should be included
     assert!(target_root.join("exact.txt").exists(), "1MB file should be included");
     assert!(target_root.join("large.txt").exists(), "2MB file should be included");
 
@@ -216,7 +192,6 @@ fn min_size_with_gigabyte_suffix() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set min-size to 1G (1073741824 bytes) - both test files should be excluded
     let options = LocalCopyOptions::default().min_file_size(Some(1024u64 * 1024 * 1024));
 
     let summary = plan
@@ -225,7 +200,6 @@ fn min_size_with_gigabyte_suffix() {
 
     let target_root = dest.join("source");
 
-    // Both files should be excluded as they're below 1GB
     assert!(!target_root.join("tiny.txt").exists(), "tiny file should be excluded");
     assert!(!target_root.join("medium.txt").exists(), "100MB file should be excluded");
 
@@ -240,7 +214,6 @@ fn min_size_zero_includes_all_files() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create files of various sizes including empty
     fs::write(source.join("empty.txt"), b"").expect("write empty file");
     fs::write(source.join("small.txt"), b"x").expect("write 1-byte file");
     fs::write(source.join("medium.txt"), vec![b'x'; 100]).expect("write 100-byte file");
@@ -251,7 +224,6 @@ fn min_size_zero_includes_all_files() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set min-size to 0 (should include all files)
     let options = LocalCopyOptions::default().min_file_size(Some(0));
 
     let summary = plan
@@ -260,7 +232,6 @@ fn min_size_zero_includes_all_files() {
 
     let target_root = dest.join("source");
 
-    // All files should be included
     assert!(target_root.join("empty.txt").exists(), "empty file should be included");
     assert!(target_root.join("small.txt").exists(), "1-byte file should be included");
     assert!(target_root.join("medium.txt").exists(), "100-byte file should be included");
@@ -276,7 +247,6 @@ fn min_size_none_includes_all_files() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create files of various sizes
     fs::write(source.join("tiny.txt"), b"x").expect("write tiny file");
     fs::write(source.join("small.txt"), b"hello").expect("write small file");
     fs::write(source.join("large.txt"), vec![b'x'; 1000]).expect("write large file");
@@ -287,7 +257,6 @@ fn min_size_none_includes_all_files() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // No min-size filter (default behavior)
     let options = LocalCopyOptions::default().min_file_size(None);
 
     let summary = plan
@@ -296,7 +265,6 @@ fn min_size_none_includes_all_files() {
 
     let target_root = dest.join("source");
 
-    // All files should be included when no filter is set
     assert!(target_root.join("tiny.txt").exists(), "tiny file should be included");
     assert!(target_root.join("small.txt").exists(), "small file should be included");
     assert!(target_root.join("large.txt").exists(), "large file should be included");
@@ -313,7 +281,6 @@ fn min_size_does_not_affect_directories() {
     fs::create_dir_all(source.join("subdir2/nested")).expect("create nested");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create small file in subdirectory
     fs::write(source.join("subdir1/small.txt"), b"x").expect("write small file");
     fs::write(source.join("subdir2/nested/large.txt"), vec![b'x'; 1000])
         .expect("write large file");
@@ -324,7 +291,6 @@ fn min_size_does_not_affect_directories() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set min-size to 100 bytes
     let options = LocalCopyOptions::default().min_file_size(Some(100));
 
     plan.execute_with_options(LocalCopyExecution::Apply, options)
@@ -337,10 +303,8 @@ fn min_size_does_not_affect_directories() {
     assert!(target_root.join("subdir2").is_dir(), "subdir2 should exist");
     assert!(target_root.join("subdir2/nested").is_dir(), "nested dir should exist");
 
-    // Small file should be excluded
     assert!(!target_root.join("subdir1/small.txt").exists(), "small file should be excluded");
 
-    // Large file should be included
     assert!(target_root.join("subdir2/nested/large.txt").exists(), "large file should be included");
 }
 
@@ -352,7 +316,6 @@ fn min_size_works_with_other_filters() {
     fs::create_dir_all(&source).expect("create source");
     fs::create_dir_all(&dest).expect("create dest");
 
-    // Create files with different extensions and sizes
     fs::write(source.join("small.txt"), b"x").expect("write small txt");
     fs::write(source.join("large.txt"), vec![b'x'; 1000]).expect("write large txt");
     fs::write(source.join("small.tmp"), b"y").expect("write small tmp");
@@ -389,7 +352,6 @@ fn min_size_works_with_other_filters() {
     // large.tmp: excluded by pattern filter (even though size is OK)
     assert!(!target_root.join("large.tmp").exists(), "large.tmp excluded by pattern");
 
-    // Only large.txt should be copied
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -413,7 +375,6 @@ fn min_size_prunes_empty_directories_when_enabled() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set min-size to 100 bytes and enable prune-empty-dirs
     let options = LocalCopyOptions::default()
         .min_file_size(Some(100))
         .prune_empty_dirs(true);
@@ -433,7 +394,6 @@ fn min_size_prunes_empty_directories_when_enabled() {
 fn min_size_does_not_affect_symlinks() {
     let ctx = test_helpers::setup_copy_test();
 
-    // Create a small target file and symlink to it
     test_helpers::create_test_tree(
         &ctx.source,
         &[
@@ -458,7 +418,6 @@ fn min_size_does_not_affect_symlinks() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Target file should be excluded by min-size
     assert!(!ctx.dest.join("source").join("source/target.txt").exists(), "small target excluded");
 
     // Symlink should still be created (symlinks are not filtered by size)

--- a/crates/engine/src/local_copy/tests/execute_modify_window.rs
+++ b/crates/engine/src/local_copy/tests/execute_modify_window.rs
@@ -46,7 +46,6 @@ fn modify_window_skips_files_within_one_second_window() {
     // File should be skipped because timestamps are within 1-second window and sizes match
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
-    // Destination content should be preserved
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         content
@@ -85,7 +84,6 @@ fn modify_window_copies_files_outside_one_second_window() {
     // File should be copied because timestamps differ by more than 1 second
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
-    // Destination should have new content
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"updated content"
@@ -157,7 +155,6 @@ fn modify_window_sixty_seconds_for_large_tolerance() {
         )
         .expect("copy succeeds");
 
-    // File should be skipped
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
 }
@@ -191,7 +188,6 @@ fn modify_window_sixty_seconds_copies_when_outside() {
         )
         .expect("copy succeeds");
 
-    // File should be copied
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(
         fs::read(&destination).expect("read dest"),
@@ -510,7 +506,6 @@ fn modify_window_with_update_copies_when_source_definitively_newer() {
         )
         .expect("copy succeeds");
 
-    // File should be copied
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_skipped_newer(), 0);
     assert_eq!(
@@ -650,18 +645,17 @@ fn modify_window_recursive_mixed_timestamps() {
     assert_eq!(summary.files_copied(), 2);
     assert_eq!(summary.regular_files_total(), 3);
 
-    // Verify file contents
     assert_eq!(
         fs::read(dest_root.join("within.txt")).expect("read within"),
-        within_content  // Should remain unchanged
+        within_content
     );
     assert_eq!(
         fs::read(dest_root.join("outside.txt")).expect("read outside"),
-        b"outside source content"  // Should be updated
+        b"outside source content"
     );
     assert_eq!(
         fs::read(dest_root.join("new.txt")).expect("read new"),
-        b"new file"  // Should be created
+        b"new file"
     );
 }
 
@@ -834,9 +828,7 @@ fn modify_window_dry_run_reports_correctly() {
         )
         .expect("dry run succeeds");
 
-    // Dry run should report that file would be copied
     assert_eq!(summary.files_copied(), 1);
-    // But file should remain unchanged
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"old content"
@@ -987,7 +979,6 @@ fn modify_window_matches_upstream_rsync_semantics() {
     // Only case3 should be copied (3s diff > 2s window)
     assert_eq!(summary.files_copied(), 1, "should copy only case3");
 
-    // Verify case3 was updated
     assert_eq!(
         fs::read(dest_root.join("case3.txt")).expect("case3"),
         b"new"

--- a/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
@@ -43,7 +43,6 @@ fn no_implied_dirs_creates_only_explicit_directories() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
 
-    // Create a directory structure
     let dir1 = source_root.join("dir1");
     let dir2 = source_root.join("dir2");
     let nested = source_root.join("dir3").join("nested");
@@ -192,7 +191,6 @@ fn no_implied_dirs_files_in_deep_paths_still_work_with_existing_dirs() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds with existing directories");
 
-    // File should be copied successfully
     assert!(dest_root.join("c").exists());
     assert!(dest_root.join("c").join("file.txt").exists());
     assert_eq!(
@@ -295,7 +293,6 @@ fn no_implied_dirs_recursive_copy_with_nested_structure() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("recursive copy succeeds");
 
-    // Root directory and files should be copied
     assert!(dest_root.join("source").exists());
     assert!(dest_root.join("source").join("root.txt").exists());
 
@@ -363,7 +360,6 @@ fn no_implied_dirs_recursive_dry_run_into_missing_dest_succeeds() {
         .expect("recursive dry-run into missing dest must succeed");
 
     assert_eq!(summary.files_copied(), 2);
-    // Dry run must not materialise the destination directory.
     assert!(
         !dest_missing.exists(),
         "dry run must not create the destination directory"
@@ -396,7 +392,6 @@ fn no_implied_dirs_with_trailing_slash_copies_contents() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Contents should be copied directly into dest
     assert!(dest_root.join("nested").exists());
     assert!(dest_root.join("nested").join("file.txt").exists());
     assert!(!dest_root.join("source").exists());
@@ -512,7 +507,6 @@ fn no_implied_dirs_collection_reports_correct_events() {
 
     let records = report.records();
 
-    // Should have directory creation and file copy events
     assert!(records
         .iter()
         .any(|r| r.action() == &LocalCopyAction::DirectoryCreated));

--- a/crates/engine/src/local_copy/tests/execute_omit_dir_times.rs
+++ b/crates/engine/src/local_copy/tests/execute_omit_dir_times.rs
@@ -21,7 +21,6 @@ fn omit_dir_times_does_not_preserve_directory_mtime() {
     fs::create_dir_all(&source_root).expect("create source");
     fs::write(source_root.join("file.txt"), b"content").expect("write file");
 
-    // Set a specific mtime on the directory (after writing files)
     let dir_mtime = FileTime::from_unix_time(1_600_000_000, 0);
     set_file_mtime(&source_root, dir_mtime).expect("set source mtime");
 
@@ -41,7 +40,6 @@ fn omit_dir_times_does_not_preserve_directory_mtime() {
     let dest_metadata = fs::metadata(dest_root.join("source")).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
 
-    // With omit_dir_times, the directory mtime should NOT match the source
     assert_ne!(
         dest_mtime, dir_mtime,
         "directory mtime should not be preserved with --omit-dir-times"
@@ -60,7 +58,6 @@ fn omit_dir_times_still_preserves_file_timestamps() {
     let source_file = source_root.join("file.txt");
     fs::write(&source_file, b"content").expect("write file");
 
-    // Set specific mtimes for both directory and file
     let file_mtime = FileTime::from_unix_time(1_500_000_000, 0);
     let dir_mtime = FileTime::from_unix_time(1_600_000_000, 0);
 
@@ -80,7 +77,6 @@ fn omit_dir_times_still_preserves_file_timestamps() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Directory mtime should NOT be preserved
     let dest_dir_metadata = fs::metadata(dest_root.join("source")).expect("dest dir metadata");
     let dest_dir_mtime = FileTime::from_last_modification_time(&dest_dir_metadata);
     assert_ne!(
@@ -88,7 +84,6 @@ fn omit_dir_times_still_preserves_file_timestamps() {
         "directory mtime should not be preserved"
     );
 
-    // File mtime SHOULD be preserved
     let dest_file = dest_root.join("source").join("file.txt");
     let dest_file_metadata = fs::metadata(&dest_file).expect("dest file metadata");
     let dest_file_mtime = FileTime::from_last_modification_time(&dest_file_metadata);
@@ -111,7 +106,6 @@ fn omit_dir_times_works_with_nested_directories() {
     let source_file = nested.join("deep_file.txt");
     fs::write(&source_file, b"deep content").expect("write file");
 
-    // Set specific mtimes for all directories and the file
     let file_mtime = FileTime::from_unix_time(1_400_000_000, 0);
     let level3_mtime = FileTime::from_unix_time(1_500_000_000, 0);
     let level2_mtime = FileTime::from_unix_time(1_600_000_000, 0);
@@ -137,13 +131,11 @@ fn omit_dir_times_works_with_nested_directories() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // File mtime should be preserved
     let dest_file = dest_root.join("source").join("level1").join("level2").join("level3").join("deep_file.txt");
     let dest_file_metadata = fs::metadata(&dest_file).expect("dest file metadata");
     let dest_file_mtime = FileTime::from_last_modification_time(&dest_file_metadata);
     assert_eq!(dest_file_mtime, file_mtime, "file mtime should be preserved");
 
-    // All directory mtimes should NOT be preserved
     let dest_root_metadata = fs::metadata(dest_root.join("source")).expect("root metadata");
     let dest_root_mtime = FileTime::from_last_modification_time(&dest_root_metadata);
     assert_ne!(dest_root_mtime, root_mtime, "root mtime should not be preserved");
@@ -231,10 +223,8 @@ fn omit_dir_times_with_permissions_preserves_mode() {
     let dest_metadata = fs::metadata(dest_root.join("source")).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
 
-    // Directory mtime should not be preserved
     assert_ne!(dest_mtime, dir_mtime);
 
-    // But permissions should still be preserved
     assert_eq!(dest_metadata.permissions().mode() & 0o777, 0o750);
 }
 
@@ -272,7 +262,6 @@ fn omit_dir_times_preserves_directory_permissions_multiple_dirs() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Check that permissions are still preserved
     let dest_root_metadata = fs::metadata(dest_root.join("source")).expect("root metadata");
     assert_eq!(dest_root_metadata.permissions().mode() & 0o777, 0o755);
 
@@ -280,7 +269,6 @@ fn omit_dir_times_preserves_directory_permissions_multiple_dirs() {
     let dest_nested_metadata = fs::metadata(&dest_nested).expect("nested metadata");
     assert_eq!(dest_nested_metadata.permissions().mode() & 0o777, 0o700);
 
-    // Check that mtimes are NOT preserved
     let dest_root_mtime = FileTime::from_last_modification_time(&dest_root_metadata);
     let dest_nested_mtime = FileTime::from_last_modification_time(&dest_nested_metadata);
     assert_ne!(dest_root_mtime, dir_mtime);
@@ -314,7 +302,6 @@ fn omit_dir_times_works_in_dry_run_mode() {
         .execute_with_options(LocalCopyExecution::DryRun, options)
         .expect("dry-run succeeds");
 
-    // In dry-run mode, nothing should be created
     assert!(!dest_root.exists());
     assert!(summary.directories_created() >= 1);
 }
@@ -328,7 +315,6 @@ fn omit_dir_times_with_multiple_source_files() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create multiple files with different timestamps
     let file1 = source_root.join("file1.txt");
     let file2 = source_root.join("file2.txt");
     let file3 = source_root.join("file3.txt");
@@ -360,7 +346,6 @@ fn omit_dir_times_with_multiple_source_files() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // All file mtimes should be preserved
     let dest_file1 = dest_root.join("source").join("file1.txt");
     let dest_file1_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_file1).expect("file1 metadata")
@@ -379,7 +364,6 @@ fn omit_dir_times_with_multiple_source_files() {
     );
     assert_eq!(dest_file3_mtime, file3_mtime);
 
-    // Directory mtime should NOT be preserved
     let dest_dir_metadata = fs::metadata(dest_root.join("source")).expect("dir metadata");
     let dest_dir_mtime = FileTime::from_last_modification_time(&dest_dir_metadata);
     assert_ne!(dest_dir_mtime, dir_mtime);
@@ -412,7 +396,6 @@ fn omit_dir_times_with_empty_directories() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Both directories should exist but have non-preserved mtimes
     assert!(dest_root.is_dir());
     let dest_empty = dest_root.join("source").join("empty");
     assert!(dest_empty.is_dir());
@@ -436,7 +419,6 @@ fn omit_dir_times_performance_deep_hierarchy() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
 
-    // Create a deep hierarchy with many directories
     let mut current = source_root.clone();
     for i in 0..20 {
         current = current.join(format!("level{i:02}"));
@@ -444,7 +426,6 @@ fn omit_dir_times_performance_deep_hierarchy() {
     fs::create_dir_all(&current).expect("create deep hierarchy");
     fs::write(current.join("deep_file.txt"), b"deep content").expect("write file");
 
-    // Set mtimes for all directories (working backwards from deep to shallow)
     let dir_mtime = FileTime::from_unix_time(1_600_000_000, 0);
     let mut dir_path = current.clone();
     while dir_path.starts_with(&source_root) {
@@ -469,7 +450,6 @@ fn omit_dir_times_performance_deep_hierarchy() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify that the deep hierarchy was copied
     assert!(summary.directories_created() >= 20);
 
     let mut dest_path = dest_root.join("source");
@@ -478,13 +458,11 @@ fn omit_dir_times_performance_deep_hierarchy() {
     }
     assert!(dest_path.join("deep_file.txt").exists());
 
-    // Verify that directory mtimes were NOT preserved
     let dest_root_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_root).expect("root metadata")
     );
     assert_ne!(dest_root_mtime, dir_mtime);
 
-    // Verify file mtime WAS preserved
     let dest_file = dest_path.join("deep_file.txt");
     let file_metadata = fs::metadata(&dest_file).expect("file metadata");
     // Note: We didn't set a specific file mtime in this test, we're just checking
@@ -521,12 +499,10 @@ fn omit_dir_times_with_trailing_slash_source() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // The nested directory should be copied directly into dest
     let dest_nested = dest_root.join("nested");
     assert!(dest_nested.is_dir());
     assert!(dest_nested.join("file.txt").exists());
 
-    // Directory mtime should not be preserved
     let dest_nested_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_nested).expect("nested metadata")
     );
@@ -550,7 +526,6 @@ fn omit_dir_times_combined_with_update_flag() {
     set_file_mtime(&source_file, file_mtime).expect("set file mtime");
     set_file_mtime(&source_root, dir_mtime).expect("set dir mtime");
 
-    // Create destination with older file
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
     let dest_file = dest_root.join("file.txt");
@@ -576,13 +551,11 @@ fn omit_dir_times_combined_with_update_flag() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(fs::read(&dest_file).expect("read dest"), b"new content");
 
-    // File mtime should be preserved
     let dest_file_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_file).expect("file metadata")
     );
     assert_eq!(dest_file_mtime, file_mtime);
 
-    // Directory mtime should NOT be preserved
     let dest_dir_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_root).expect("dir metadata")
     );
@@ -620,12 +593,10 @@ fn omit_dir_times_with_delete_flag() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Verify deletion occurred
     assert_eq!(summary.items_deleted(), 1);
     assert!(!dest_root.join("extra.txt").exists());
     assert!(dest_root.join("keep.txt").exists());
 
-    // Directory mtime should not be preserved
     let dest_dir_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_root).expect("dir metadata")
     );
@@ -666,7 +637,6 @@ fn omit_dir_times_in_report_mode() {
     let summary = report.summary();
     let records = report.records();
 
-    // Should have directory creation records
     let dir_created_count = records
         .iter()
         .filter(|r| r.action() == &LocalCopyAction::DirectoryCreated)
@@ -704,7 +674,6 @@ fn without_omit_dir_times_directory_mtime_is_preserved() {
     let dest_metadata = fs::metadata(dest_root.join("source")).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&dest_metadata);
 
-    // Without omit_dir_times, the directory mtime SHOULD match the source
     assert_eq!(
         dest_mtime, dir_mtime,
         "directory mtime should be preserved when --omit-dir-times is not set"
@@ -783,7 +752,6 @@ fn omit_dir_times_incremental_copy_does_not_update_dir_mtime() {
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
 
-    // First copy
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .times(true)
@@ -792,7 +760,6 @@ fn omit_dir_times_incremental_copy_does_not_update_dir_mtime() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("first copy succeeds");
 
-    // Record destination directory mtime after first copy
     let _first_dir_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_root).expect("dest metadata")
     );
@@ -815,13 +782,11 @@ fn omit_dir_times_incremental_copy_does_not_update_dir_mtime() {
         &fs::metadata(&dest_root).expect("dest metadata")
     );
 
-    // Directory mtime should NOT have been set to match source
     assert_ne!(
         second_dir_mtime, dir_mtime,
         "directory mtime should not be set to source mtime on incremental copy"
     );
 
-    // File mtime should still be preserved
     let dest_file = dest_root.join("file.txt");
     let dest_file_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_file).expect("file metadata")
@@ -857,7 +822,6 @@ fn omit_dir_times_incremental_with_new_file_preserves_new_file_time() {
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
 
-    // First copy
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default()
         .times(true)
@@ -866,18 +830,15 @@ fn omit_dir_times_incremental_with_new_file_preserves_new_file_time() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("first copy succeeds");
 
-    // Add a second file
     let source_file2 = source_root.join("file2.txt");
     fs::write(&source_file2, b"content2").expect("write file2");
 
     let file2_mtime = FileTime::from_unix_time(1_550_000_000, 0);
     set_file_mtime(&source_file2, file2_mtime).expect("set file2 mtime");
 
-    // Update dir mtime after adding the file
     let new_dir_mtime = FileTime::from_unix_time(1_650_000_000, 0);
     set_file_mtime(&source_root, new_dir_mtime).expect("set new dir mtime");
 
-    // Second copy (incremental)
     let mut source_operand2 = source_root.clone().into_os_string();
     source_operand2.push(std::path::MAIN_SEPARATOR.to_string());
     let operands2 = vec![source_operand2, dest_root.clone().into_os_string()];
@@ -890,14 +851,12 @@ fn omit_dir_times_incremental_with_new_file_preserves_new_file_time() {
         .execute_with_options(LocalCopyExecution::Apply, options2)
         .expect("second copy succeeds");
 
-    // Directory mtime should NOT match source (neither old nor new)
     let dest_dir_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_root).expect("dest metadata")
     );
     assert_ne!(dest_dir_mtime, dir_mtime);
     assert_ne!(dest_dir_mtime, new_dir_mtime);
 
-    // Both file mtimes should be preserved
     let dest_file1 = dest_root.join("file1.txt");
     let dest_file1_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_file1).expect("file1 metadata")
@@ -923,7 +882,6 @@ fn omit_dir_times_mixed_tree_files_have_correct_timestamps() {
     fs::create_dir_all(&sub_a).expect("create dir_a");
     fs::create_dir_all(&sub_b).expect("create dir_b");
 
-    // Create files with distinct timestamps
     let file_a = sub_a.join("file_a.txt");
     let file_b = sub_b.join("file_b.txt");
     let file_root = source_root.join("file_root.txt");
@@ -958,7 +916,6 @@ fn omit_dir_times_mixed_tree_files_have_correct_timestamps() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // All file mtimes SHOULD be preserved
     let dest_file_a_mtime = FileTime::from_last_modification_time(
         &fs::metadata(dest_root.join("source").join("dir_a").join("file_a.txt")).expect("file_a metadata")
     );
@@ -973,7 +930,6 @@ fn omit_dir_times_mixed_tree_files_have_correct_timestamps() {
     assert_eq!(dest_file_b_mtime, file_b_mtime, "file_b mtime should be preserved");
     assert_eq!(dest_file_root_mtime, file_root_mtime, "file_root mtime should be preserved");
 
-    // All directory mtimes should NOT be preserved
     let dest_root_mtime = FileTime::from_last_modification_time(
         &fs::metadata(dest_root.join("source")).expect("root metadata")
     );
@@ -1044,13 +1000,11 @@ fn omit_dir_times_option_builder_round_trip() {
         .omit_dir_times(false);
     assert!(!options.omit_dir_times_enabled());
 
-    // Toggle: set true then false
     let options = LocalCopyOptions::default()
         .omit_dir_times(true)
         .omit_dir_times(false);
     assert!(!options.omit_dir_times_enabled());
 
-    // Toggle: set false then true
     let options = LocalCopyOptions::default()
         .omit_dir_times(false)
         .omit_dir_times(true);
@@ -1095,14 +1049,12 @@ fn omit_dir_times_with_archive_style_options() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // File timestamp should be preserved
     let dest_file = dest_root.join("source").join("subdir").join("file.txt");
     let dest_file_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&dest_file).expect("file metadata")
     );
     assert_eq!(dest_file_mtime, file_mtime, "file mtime should be preserved");
 
-    // Directory timestamps should NOT be preserved
     let dest_root_mtime = FileTime::from_last_modification_time(
         &fs::metadata(dest_root.join("source")).expect("root metadata")
     );
@@ -1113,7 +1065,6 @@ fn omit_dir_times_with_archive_style_options() {
     );
     assert_ne!(dest_nested_mtime, dir_mtime, "nested dir mtime should not be preserved");
 
-    // Directory permissions should still be preserved
     let dest_nested_mode = fs::metadata(dest_root.join("source").join("subdir"))
         .expect("nested metadata")
         .permissions()

--- a/crates/engine/src/local_copy/tests/execute_one_file_system.rs
+++ b/crates/engine/src/local_copy/tests/execute_one_file_system.rs
@@ -6,7 +6,6 @@ fn one_file_system_traverses_same_filesystem_directories() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
 
-    // Create a tree with multiple nested directories
     let dir1 = source_root.join("dir1");
     let dir2 = source_root.join("dir2");
     let nested = dir1.join("nested").join("deep");
@@ -107,7 +106,6 @@ fn one_file_system_transfers_files_on_same_filesystem() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
 
-    // Create multiple levels with files at each level
     let level1 = source_root.join("level1");
     let level2 = level1.join("level2");
     let level3 = level2.join("level3");
@@ -150,7 +148,6 @@ fn one_file_system_respects_flag_during_directory_walking() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
 
-    // Create a complex tree with multiple potential mount points
     let dir_a = source_root.join("dir_a");
     let dir_b = source_root.join("dir_b");
     let mount1 = dir_a.join("mount1");

--- a/crates/engine/src/local_copy/tests/execute_ownership_preservation.rs
+++ b/crates/engine/src/local_copy/tests/execute_ownership_preservation.rs
@@ -114,7 +114,6 @@ fn owner_flag_with_root_uid() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"root owner test").expect("write source");
 
-    // Set source to root (UID 0)
     chownat(
         rustix::fs::CWD,
         &source,
@@ -243,7 +242,6 @@ fn group_flag_with_root_gid() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"root group test").expect("write source");
 
-    // Set source to root group (GID 0)
     chownat(
         rustix::fs::CWD,
         &source,
@@ -508,7 +506,6 @@ fn owner_preserved_recursively_in_directory_tree() {
         )
         .expect("copy succeeds");
 
-    // Verify all entries have the preserved ownership
     let dest_file1 = dest_dir.join("source").join("file1.txt");
     let dest_subdir = dest_dir.join("source").join("subdir");
     let dest_file2 = dest_subdir.join("file2.txt");
@@ -975,7 +972,6 @@ fn owner_preserved_on_multiple_files() {
     fs::create_dir(&source_dir).expect("create source dir");
     fs::create_dir(&dest_dir).expect("create dest dir");
 
-    // Create multiple files with different ownerships
     let file1 = source_dir.join("file1.txt");
     let file2 = source_dir.join("file2.txt");
     let file3 = source_dir.join("file3.txt");
@@ -1051,7 +1047,6 @@ fn ownership_default_behavior_without_flags() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Execute without any ownership flags
     let summary = plan.execute().expect("copy succeeds");
 
     let metadata = fs::metadata(&destination).expect("dest metadata");
@@ -1078,7 +1073,6 @@ fn ownership_preserved_with_zero_ids() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"root ownership test").expect("write source");
 
-    // Set ownership to root (UID 0, GID 0)
     chownat(
         rustix::fs::CWD,
         &source,
@@ -1193,7 +1187,7 @@ fn no_owner_overrides_archive_mode_owner() {
                 .links(true)
                 .permissions(true)
                 .times(true)
-                .owner(false) // --no-owner
+                .owner(false)
                 .group(true),
         )
         .expect("copy succeeds");
@@ -1249,7 +1243,7 @@ fn no_group_overrides_archive_mode_group() {
                 .permissions(true)
                 .times(true)
                 .owner(true)
-                .group(false), // --no-group
+                .group(false),
         )
         .expect("copy succeeds");
 

--- a/crates/engine/src/local_copy/tests/execute_permissions.rs
+++ b/crates/engine/src/local_copy/tests/execute_permissions.rs
@@ -42,7 +42,6 @@ fn mode_0000_preserves_across_multiple_files() {
     let dest_dir = temp.path().join("dest");
     fs::create_dir_all(&source_dir).expect("create source");
 
-    // Create multiple files with mode 0000
     let file1 = source_dir.join("file1.txt");
     let file2 = source_dir.join("file2.txt");
     let file3 = source_dir.join("file3.txt");
@@ -72,7 +71,6 @@ fn mode_0000_preserves_across_multiple_files() {
 
     assert_eq!(summary.files_copied(), 3);
 
-    // Verify all destination files have mode 0000
     for file_name in ["file1.txt", "file2.txt", "file3.txt"] {
         let dest_file = dest_dir.join("source").join(file_name);
         let metadata = fs::metadata(&dest_file).expect("dest file metadata");
@@ -95,13 +93,11 @@ fn mode_0000_with_inplace_update() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Create source with mode 0000
     fs::write(&source, b"new content").expect("write source");
     fs::set_permissions(&source, PermissionsExt::from_mode(0o000)).expect("set source mode 0000");
     let source_time = FileTime::from_unix_time(1_700_000_200, 0);
     set_file_times(&source, source_time, source_time).expect("set source times");
 
-    // Create existing destination with different permissions
     fs::write(&destination, b"old").expect("write dest");
     fs::set_permissions(&destination, PermissionsExt::from_mode(0o644)).expect("set dest mode");
     let dest_time = FileTime::from_unix_time(1_700_000_100, 0);
@@ -139,11 +135,9 @@ fn mode_0000_with_backup() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Create source with mode 0000
     fs::write(&source, b"new data").expect("write source");
     fs::set_permissions(&source, PermissionsExt::from_mode(0o000)).expect("set source mode 0000");
 
-    // Create existing destination
     fs::write(&destination, b"old data").expect("write dest");
     fs::set_permissions(&destination, PermissionsExt::from_mode(0o644)).expect("set dest mode");
 
@@ -164,12 +158,10 @@ fn mode_0000_with_backup() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify backup was created
     let backup_path = temp.path().join("dest.txt~");
     assert!(backup_path.exists());
     assert_eq!(fs::read(&backup_path).expect("read backup"), b"old data");
 
-    // Verify destination has mode 0000
     let metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(metadata.permissions().mode() & 0o777, 0o000);
 }
@@ -212,7 +204,6 @@ fn mode_0000_with_sparse_file() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Create a file with holes (sparse file)
     let mut file = fs::File::create(&source).expect("create source");
     use std::io::{Seek, SeekFrom, Write};
     file.write_all(b"start").expect("write start");
@@ -252,7 +243,6 @@ fn mode_0000_nested_directory_structure() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create nested structure with mode 0000 files at various levels
     let level1 = source_root.join("level1");
     let level2 = level1.join("level2");
     let level3 = level2.join("level3");
@@ -286,7 +276,6 @@ fn mode_0000_nested_directory_structure() {
 
     assert_eq!(summary.files_copied(), 4);
 
-    // Verify all files have mode 0000
     let dest_files = [
         (dest_root.join("source").join("source/root.txt"), b"root" as &[u8]),
         (dest_root.join("source").join("source/level1/one.txt"), b"level1"),
@@ -313,12 +302,10 @@ fn mode_0000_with_symlink_preservation() {
     let dest_dir = temp.path().join("dest");
     fs::create_dir_all(&source_dir).expect("create source");
 
-    // Create a file with mode 0000
     let target = source_dir.join("target.txt");
     fs::write(&target, b"target content").expect("write target");
     fs::set_permissions(&target, PermissionsExt::from_mode(0o000)).expect("set target mode 0000");
 
-    // Create a symlink to the mode 0000 file
     let link = source_dir.join("link.txt");
     std::os::unix::fs::symlink(&target, &link).expect("create symlink");
 
@@ -340,12 +327,10 @@ fn mode_0000_with_symlink_preservation() {
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.symlinks_copied(), 1);
 
-    // Verify target has mode 0000
     let dest_target = dest_dir.join("source").join("source/target.txt");
     let metadata = fs::metadata(&dest_target).expect("target metadata");
     assert_eq!(metadata.permissions().mode() & 0o777, 0o000);
 
-    // Verify symlink was created
     let dest_link = dest_dir.join("source").join("source/link.txt");
     assert!(dest_link.exists());
     let link_metadata = fs::symlink_metadata(&dest_link).expect("link metadata");
@@ -372,12 +357,10 @@ fn mode_0000_compare_dest() {
     let content = b"matched content";
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
 
-    // Create source with mode 0000
     fs::write(&source_file, content).expect("write source");
     fs::set_permissions(&source_file, PermissionsExt::from_mode(0o000)).expect("set source mode");
     set_file_times(&source_file, timestamp, timestamp).expect("set source times");
 
-    // Create compare with mode 0000 and matching content/time
     fs::write(&compare_file, content).expect("write compare");
     fs::set_permissions(&compare_file, PermissionsExt::from_mode(0o000)).expect("set compare mode");
     set_file_times(&compare_file, timestamp, timestamp).expect("set compare times");
@@ -419,11 +402,9 @@ fn mode_0000_size_only_comparison() {
 
     let content = b"size match";
 
-    // Create source with mode 0000
     fs::write(&source, content).expect("write source");
     fs::set_permissions(&source, PermissionsExt::from_mode(0o000)).expect("set source mode");
 
-    // Create destination with same size but different mode
     fs::write(&destination, content).expect("write dest");
     fs::set_permissions(&destination, PermissionsExt::from_mode(0o644)).expect("set dest mode");
 
@@ -444,7 +425,6 @@ fn mode_0000_size_only_comparison() {
     // With size_only, file should be skipped despite different permissions
     assert_eq!(summary.files_copied(), 0);
 
-    // Destination should keep its original mode
     let metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(metadata.permissions().mode() & 0o777, 0o644);
 }
@@ -462,13 +442,11 @@ fn mode_0000_checksum_comparison() {
 
     let content = b"checksum test";
 
-    // Create source with mode 0000
     fs::write(&source, content).expect("write source");
     fs::set_permissions(&source, PermissionsExt::from_mode(0o000)).expect("set source mode");
     let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, timestamp, timestamp).expect("set source times");
 
-    // Create destination with same content and mode but different time
     fs::write(&destination, content).expect("write dest");
     fs::set_permissions(&destination, PermissionsExt::from_mode(0o000)).expect("set dest mode");
     let old_timestamp = FileTime::from_unix_time(1_600_000_000, 0);
@@ -492,7 +470,6 @@ fn mode_0000_checksum_comparison() {
     // With checksum, file should be skipped despite different mtime
     assert_eq!(summary.files_copied(), 0);
 
-    // Verify destination still has old timestamp
     let metadata = fs::metadata(&destination).expect("dest metadata");
     let dest_mtime = FileTime::from_last_modification_time(&metadata);
     assert_eq!(dest_mtime, old_timestamp);
@@ -509,19 +486,16 @@ fn mode_0000_preserve_in_existing_file_update() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Create source with mode 0000 and newer time
     fs::write(&source, b"new").expect("write source");
     fs::set_permissions(&source, PermissionsExt::from_mode(0o000)).expect("set source mode");
     let new_time = FileTime::from_unix_time(1_700_000_200, 0);
     set_file_times(&source, new_time, new_time).expect("set source times");
 
-    // Create existing destination with different mode and older time
     fs::write(&destination, b"old").expect("write dest");
     fs::set_permissions(&destination, PermissionsExt::from_mode(0o644)).expect("set dest mode");
     let old_time = FileTime::from_unix_time(1_700_000_100, 0);
     set_file_times(&destination, old_time, old_time).expect("set dest times");
 
-    // Verify initial state
     let initial_metadata = fs::metadata(&destination).expect("initial dest metadata");
     assert_eq!(initial_metadata.permissions().mode() & 0o777, 0o644);
 
@@ -542,7 +516,6 @@ fn mode_0000_preserve_in_existing_file_update() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Destination should now have mode 0000
     let metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(metadata.permissions().mode() & 0o777, 0o000);
     assert_eq!(fs::read(&destination).expect("read dest"), b"new");
@@ -570,7 +543,6 @@ fn dir_setgid_inheritance_preserved_without_perms() {
     let parent = temp.path().join("sgid_parent");
     fs::create_dir(&parent).expect("create parent");
 
-    // Set the setgid bit on the parent directory.
     fs::set_permissions(&parent, PermissionsExt::from_mode(0o2770)).expect("chmod parent");
 
     // Probe whether the filesystem supports directory setgid inheritance.
@@ -583,7 +555,6 @@ fn dir_setgid_inheritance_preserved_without_perms() {
     }
     fs::remove_dir(&probe).expect("remove probe");
 
-    // Build a source tree: a directory containing a file and a subdirectory.
     let source = temp.path().join("src");
     let source_subdir = source.join("subdir");
     fs::create_dir_all(&source_subdir).expect("create source tree");
@@ -656,7 +627,6 @@ fn dir_no_setgid_when_parent_lacks_it() {
     // Parent does NOT have setgid - just normal 0770.
     fs::set_permissions(&parent, PermissionsExt::from_mode(0o0770)).expect("chmod parent");
 
-    // Build a simple source tree.
     let source = temp.path().join("src");
     fs::create_dir_all(&source).expect("create source");
     fs::write(source.join("file.txt"), b"hello").expect("write file");

--- a/crates/engine/src/local_copy/tests/execute_prune_empty_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_prune_empty_dirs.rs
@@ -3,7 +3,6 @@
 fn prune_empty_dirs_does_not_create_empty_directories() {
     let ctx = test_helpers::setup_copy_test();
 
-    // Create source with empty directory
     test_helpers::create_test_tree(
         &ctx.source,
         &[
@@ -27,7 +26,6 @@ fn prune_empty_dirs_does_not_create_empty_directories() {
 fn prune_empty_dirs_creates_directories_with_files() {
     let ctx = test_helpers::setup_copy_test();
 
-    // Create source with directory containing files
     test_helpers::create_test_tree(
         &ctx.source,
         &[
@@ -52,7 +50,6 @@ fn prune_empty_dirs_creates_directories_with_files() {
 fn prune_empty_dirs_prunes_nested_empty_directories() {
     let ctx = test_helpers::setup_copy_test();
 
-    // Create source with nested empty directories
     test_helpers::create_test_tree(
         &ctx.source,
         &[
@@ -78,7 +75,6 @@ fn prune_empty_dirs_prunes_nested_empty_directories() {
 fn prune_empty_dirs_with_filter_excluding_all_files() {
     let ctx = test_helpers::setup_copy_test();
 
-    // Create source with directory containing only .tmp files
     test_helpers::create_test_tree(
         &ctx.source,
         &[
@@ -115,7 +111,6 @@ fn prune_empty_dirs_with_filter_excluding_all_files() {
 fn prune_empty_dirs_preserves_non_empty_parent_of_empty_child() {
     let ctx = test_helpers::setup_copy_test();
 
-    // Create parent with a file and an empty child directory
     test_helpers::create_test_tree(
         &ctx.source,
         &[
@@ -140,7 +135,6 @@ fn prune_empty_dirs_preserves_non_empty_parent_of_empty_child() {
 fn prune_empty_dirs_with_multiple_branches() {
     let ctx = test_helpers::setup_copy_test();
 
-    // Create tree with multiple branches, some empty, some not
     test_helpers::create_test_tree(
         &ctx.source,
         &[
@@ -187,7 +181,6 @@ fn prune_empty_dirs_respects_dry_run() {
         .expect("dry-run succeeds");
 
     assert!(!ctx.dest.exists(), "destination should not exist in dry-run");
-    // In dry-run, the summary should report what would be created
     assert!(summary.directories_created() >= 1, "should report non-empty dir creation");
 }
 
@@ -203,7 +196,6 @@ fn prune_empty_dirs_with_trailing_separator() {
         ],
     );
 
-    // Use trailing separator to copy contents
     let mut source_operand = ctx.source.into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
     let operands = vec![source_operand, ctx.dest.clone().into_os_string()];
@@ -222,7 +214,6 @@ fn prune_empty_dirs_with_trailing_separator() {
 fn prune_empty_dirs_with_min_size_filter() {
     let ctx = test_helpers::setup_copy_test();
 
-    // Create files of different sizes
     test_helpers::create_test_tree(
         &ctx.source,
         &[
@@ -255,7 +246,6 @@ fn prune_empty_dirs_with_min_size_filter() {
 fn prune_empty_dirs_with_max_size_filter() {
     let ctx = test_helpers::setup_copy_test();
 
-    // Create files of different sizes
     test_helpers::create_test_tree(
         &ctx.source,
         &[
@@ -342,7 +332,6 @@ fn prune_empty_dirs_with_collect_events_reports_pruning() {
         .filter(|r| r.action() == &LocalCopyAction::DirectoryCreated)
         .count();
 
-    // Should only create the non-empty directory
     assert!(dir_created >= 1, "should report directory creation for non-empty dir");
 }
 
@@ -359,7 +348,6 @@ fn prune_empty_dirs_with_symlink_in_directory() {
         ],
     );
 
-    // Create a symlink in dir_with_link
     #[cfg(unix)]
     {
         use std::os::unix::fs as unix_fs;
@@ -394,14 +382,12 @@ fn prune_empty_dirs_with_symlink_in_directory() {
         ctx.dest.join("source").join("dir_with_link").is_dir(),
         "directory with symlink should exist"
     );
-    // The symlink should exist (implementation may vary)
 }
 
 #[test]
 fn prune_empty_dirs_deep_hierarchy_partial_pruning() {
     let ctx = test_helpers::setup_copy_test();
 
-    // Create a deep hierarchy with a file at the bottom
     test_helpers::create_test_tree(
         &ctx.source,
         &[
@@ -418,7 +404,6 @@ fn prune_empty_dirs_deep_hierarchy_partial_pruning() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // Path to file should be preserved
     assert!(ctx.dest.join("source").join("a").is_dir());
     assert!(ctx.dest.join("source").join("a/b").is_dir());
     assert!(ctx.dest.join("source").join("a/b/c").is_dir());
@@ -426,7 +411,6 @@ fn prune_empty_dirs_deep_hierarchy_partial_pruning() {
     assert!(ctx.dest.join("source").join("a/b/c/d/e").is_dir());
     assert!(ctx.dest.join("source").join("a/b/c/d/e/file.txt").exists());
 
-    // Empty branches should be pruned
     assert!(!ctx.dest.join("source").join("a/b/empty").exists());
     assert!(!ctx.dest.join("source").join("a/x").exists());
 }
@@ -443,7 +427,6 @@ fn prune_empty_dirs_with_existing_only_option() {
         ],
     );
 
-    // Pre-create destination (empty)
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
     let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
@@ -478,7 +461,6 @@ fn prune_empty_dirs_with_include_exclude_filters() {
     let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Include only .txt files
     let filters = FilterSet::from_rules([
         FilterRule::include("*.txt"),
         FilterRule::exclude("*"),
@@ -629,7 +611,6 @@ fn prune_empty_dirs_deeply_nested_single_file() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // All directories along the path should be created
     assert!(ctx.dest.join("source").join("a/b/c/d/e/f/g/h/i/j").is_dir());
     assert!(ctx.dest.join("source").join("a/b/c/d/e/f/g/h/i/j/leaf.txt").exists());
 }
@@ -708,7 +689,6 @@ fn prune_empty_dirs_with_delete_option() {
 
 #[test]
 fn prune_empty_dirs_option_setter_and_getter() {
-    // Verify the option can be set and read back
     let opts = LocalCopyOptions::default();
     assert!(!opts.prune_empty_dirs_enabled(), "default should be false");
 
@@ -732,7 +712,6 @@ fn prune_empty_dirs_idempotent_run() {
         ],
     );
 
-    // First run
     let operands = vec![
         ctx.source.clone().into_os_string(),
         ctx.dest.clone().into_os_string(),

--- a/crates/engine/src/local_copy/tests/execute_remove_source.rs
+++ b/crates/engine/src/local_copy/tests/execute_remove_source.rs
@@ -119,10 +119,8 @@ fn remove_source_files_does_not_remove_directories() {
 
     assert_eq!(summary.files_copied(), 2);
     assert_eq!(summary.sources_removed(), 2);
-    // Files should be removed
     assert!(!ctx.source.join("dir1/file.txt").exists());
     assert!(!ctx.source.join("dir2/file.txt").exists());
-    // But directories should remain
     assert!(ctx.source.join("dir1").is_dir(), "directory should not be removed");
     assert!(ctx.source.join("dir2").is_dir(), "directory should not be removed");
 }
@@ -156,11 +154,9 @@ fn remove_source_files_with_filter_only_removes_transferred() {
 
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.sources_removed(), 1);
-    // Included file should be removed
     assert!(!ctx.source.join("include.txt").exists());
     // Excluded file should remain (wasn't transferred)
     assert!(ctx.source.join("exclude.log").exists());
-    // Dest should only have included file
     assert!(ctx.dest.join("include.txt").exists());
     assert!(!ctx.dest.join("exclude.log").exists());
 }
@@ -318,15 +314,12 @@ fn remove_source_files_removes_nested_files() {
 
     assert_eq!(summary.files_copied(), 3);
     assert_eq!(summary.sources_removed(), 3);
-    // All files removed
     assert!(!ctx.source.join("a/b/c/file1.txt").exists());
     assert!(!ctx.source.join("a/b/file2.txt").exists());
     assert!(!ctx.source.join("a/file3.txt").exists());
-    // All directories remain
     assert!(ctx.source.join("a").is_dir());
     assert!(ctx.source.join("a/b").is_dir());
     assert!(ctx.source.join("a/b/c").is_dir());
-    // All files copied
     assert!(ctx.dest.join("a/b/c/file1.txt").exists());
     assert!(ctx.dest.join("a/b/file2.txt").exists());
     assert!(ctx.dest.join("a/file3.txt").exists());

--- a/crates/engine/src/local_copy/tests/execute_skip.rs
+++ b/crates/engine/src/local_copy/tests/execute_skip.rs
@@ -104,7 +104,6 @@ fn execute_skip_timestamp_same_mtime_same_size_different_content() {
     fs::write(&source, b"aaaaaaa").expect("write source");
     fs::write(&destination, b"bbbbbbb").expect("write dest");
 
-    // Align timestamps
     let shared_mtime = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(&source, shared_mtime).expect("set source mtime");
     set_file_mtime(&destination, shared_mtime).expect("set dest mtime");
@@ -303,7 +302,6 @@ fn execute_with_checksum_skips_matching_directory_contents() {
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(&target_root).expect("create target root");
 
-    // Create multiple files - some identical, some different
     let identical_content = b"identical content here";
     let different_source = b"different source data!";
     let different_dest = b"different dest content";
@@ -334,7 +332,6 @@ fn execute_with_checksum_skips_matching_directory_contents() {
         )
         .expect("copy succeeds");
 
-    // Verify results
     assert_eq!(summary.regular_files_total(), 4, "should process 4 files");
     assert_eq!(
         summary.regular_files_matched(),
@@ -343,7 +340,6 @@ fn execute_with_checksum_skips_matching_directory_contents() {
     );
     assert_eq!(summary.files_copied(), 2, "2 different/new files should copy");
 
-    // Verify file contents
     assert_eq!(
         fs::read(target_root.join("same1.txt")).expect("read same1"),
         identical_content
@@ -354,7 +350,7 @@ fn execute_with_checksum_skips_matching_directory_contents() {
     );
     assert_eq!(
         fs::read(target_root.join("diff.txt")).expect("read diff"),
-        different_source // source content should overwrite destination
+        different_source
     );
     assert_eq!(
         fs::read(target_root.join("new.txt")).expect("read new"),
@@ -585,7 +581,6 @@ fn execute_skip_checksum_dry_run_reports_correctly() {
     // would-be-copy; the content-identical file is matched.
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_matched(), 1);
-    // Files unchanged in dry run
     assert_eq!(fs::read(dest_root.join("same.txt")).expect("read"), b"identical");
     assert_eq!(fs::read(dest_root.join("diff.txt")).expect("read"), b"dest_vvv");
 }
@@ -1027,7 +1022,6 @@ fn execute_skip_size_only_dry_run() {
     // not reported as a would-be-copy.
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_matched(), 1);
-    // Content unchanged in dry run
     assert_eq!(fs::read(&destination).expect("read"), b"xyz");
 }
 
@@ -1966,7 +1960,6 @@ fn execute_dry_run_reports_skipped_files_as_matched() {
 
     // In dry run mode, identical files are counted and matched
     assert_eq!(summary.regular_files_total(), 1);
-    // File content remains unchanged since it's dry run
     assert_eq!(fs::read(&destination).expect("read"), content);
 }
 
@@ -2000,7 +1993,6 @@ fn execute_skip_dry_run_update_reports_skipped_newer() {
 
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
-    // File unchanged
     assert_eq!(fs::read(&destination).expect("read"), b"newer dest");
 }
 
@@ -2057,7 +2049,6 @@ fn execute_skip_dry_run_ignore_existing_reports_skipped() {
 
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_ignored_existing(), 1);
-    // File unchanged
     assert_eq!(fs::read(&destination).expect("read"), b"original");
 }
 

--- a/crates/engine/src/local_copy/tests/execute_skip_compress.rs
+++ b/crates/engine/src/local_copy/tests/execute_skip_compress.rs
@@ -133,7 +133,6 @@ fn skip_compress_custom_list_via_builder() {
     fs::create_dir_all(&source_dir).expect("create source dir");
     let dest_dir = temp.path().join("dest");
 
-    // Create a .xyz file (custom suffix) and a .txt file.
     let custom_content = vec![0xCD; 8 * 1024];
     let text_content = vec![b'B'; 16 * 1024];
     fs::write(source_dir.join("data.xyz"), &custom_content).expect("write .xyz");
@@ -243,7 +242,6 @@ fn skip_compress_mixed_directory_transfer() {
     fs::create_dir_all(&source_dir).expect("create source dir");
     let dest_dir = temp.path().join("dest");
 
-    // Create files of different types.
     let gz_content = vec![0x1F; 4 * 1024]; // .gz should be skipped
     let png_content = vec![0x89; 4 * 1024]; // .png should be skipped
     let txt_content = vec![b'X'; 16 * 1024]; // .txt should be compressed
@@ -266,7 +264,6 @@ fn skip_compress_mixed_directory_transfer() {
         )
         .expect("copy succeeds");
 
-    // All four files should be present in the destination.
     assert_eq!(fs::read(dest_dir.join("archive.gz")).expect("read .gz"), gz_content);
     assert_eq!(fs::read(dest_dir.join("image.png")).expect("read .png"), png_content);
     assert_eq!(fs::read(dest_dir.join("readme.txt")).expect("read .txt"), txt_content);
@@ -343,13 +340,11 @@ fn skip_compress_default_list_covers_common_formats() {
 fn skip_compress_options_should_skip_compress_method() {
     use crate::local_copy::SkipCompressList;
 
-    // Default options use the default skip list.
     let opts = LocalCopyOptions::default();
     assert!(opts.should_skip_compress(Path::new("archive.gz")));
     assert!(opts.should_skip_compress(Path::new("photo.PNG")));
     assert!(!opts.should_skip_compress(Path::new("notes.txt")));
 
-    // Custom list.
     let custom = SkipCompressList::parse("dat/bin").expect("parse");
     let opts = LocalCopyOptions::default().with_skip_compress(custom);
     assert!(opts.should_skip_compress(Path::new("data.dat")));

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -370,36 +370,29 @@ fn execute_sparse_with_multiple_hole_patterns() {
     let mut source_file = fs::File::create(&source).expect("create source");
 
     // Pattern: data-hole-data-hole-data (interleaved)
-    // Data block 1: 10KB at offset 0
     let data_block = vec![0xAA; 10 * 1024];
     source_file.write_all(&data_block).expect("write data block 1");
 
-    // Hole 1: seek to 1MB (creating ~1014KB hole)
     source_file
         .seek(SeekFrom::Start(1024 * 1024))
         .expect("seek for hole 1");
 
-    // Data block 2: 20KB at 1MB
     let data_block_2 = vec![0xBB; 20 * 1024];
     source_file.write_all(&data_block_2).expect("write data block 2");
 
-    // Hole 2: seek to 3MB (creating ~2004KB hole)
     source_file
         .seek(SeekFrom::Start(3 * 1024 * 1024))
         .expect("seek for hole 2");
 
-    // Data block 3: 10KB at 3MB
     let data_block_3 = vec![0xCC; 10 * 1024];
     source_file.write_all(&data_block_3).expect("write data block 3");
 
-    // Final hole: extend to 5MB
     source_file.set_len(5 * 1024 * 1024).expect("extend source");
     drop(source_file);
 
     let dense_dest = temp.path().join("multi-dense.bin");
     let sparse_dest = temp.path().join("multi-sparse.bin");
 
-    // Dense copy (no --sparse)
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -409,7 +402,6 @@ fn execute_sparse_with_multiple_hole_patterns() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy (--sparse)
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -425,11 +417,9 @@ fn execute_sparse_with_multiple_hole_patterns() {
     let dense_meta = fs::metadata(&dense_dest).expect("dense metadata");
     let sparse_meta = fs::metadata(&sparse_dest).expect("sparse metadata");
 
-    // Both should have same file size
     assert_eq!(dense_meta.len(), sparse_meta.len());
     assert_eq!(dense_meta.len(), 5 * 1024 * 1024);
 
-    // Verify content is identical
     let dense_content = fs::read(&dense_dest).expect("read dense");
     let sparse_content = fs::read(&sparse_dest).expect("read sparse");
     assert_eq!(dense_content, sparse_content);
@@ -461,7 +451,6 @@ fn execute_sparse_verifies_hole_data_integrity() {
     let source = temp.path().join("hole-data.bin");
     let mut source_file = fs::File::create(&source).expect("create source");
 
-    // Specific pattern: known data at specific offsets
     source_file.write_all(b"START").expect("write start");
     source_file
         .seek(SeekFrom::Start(1024 * 1024))
@@ -487,7 +476,6 @@ fn execute_sparse_verifies_hole_data_integrity() {
     )
     .expect("sparse copy succeeds");
 
-    // Verify data regions are correct
     let mut dest_file = fs::File::open(&sparse_dest).expect("open dest");
     let mut buffer = vec![0u8; 5];
 
@@ -509,7 +497,6 @@ fn execute_sparse_verifies_hole_data_integrity() {
     dest_file.read_exact(&mut buffer_end).expect("read end");
     assert_eq!(&buffer_end, b"END");
 
-    // Verify holes are zeros
     dest_file.seek(SeekFrom::Start(5)).expect("seek after start");
     let mut hole_sample = vec![0xFF; 100];
     dest_file.read_exact(&mut hole_sample).expect("read hole");
@@ -558,7 +545,6 @@ fn execute_sparse_with_small_holes() {
     let meta = fs::metadata(&sparse_dest).expect("metadata");
     assert_eq!(meta.len(), total_size as u64);
 
-    // Verify content integrity regardless of hole detection
     let content = fs::read(&sparse_dest).expect("read dest");
     for i in 0..4 {
         let data_start = i * 1024;
@@ -591,17 +577,14 @@ fn execute_sparse_with_aligned_holes() {
     // Create holes aligned to 16-byte boundaries for SIMD fast path
     source_file.write_all(b"A").expect("write start");
 
-    // Skip to 16-byte boundary
     source_file.seek(SeekFrom::Start(16)).expect("seek 16");
     source_file.write_all(b"B").expect("write at 16");
 
-    // Create aligned hole (16-byte chunks of zeros)
     source_file
         .seek(SeekFrom::Start(1024))
         .expect("seek hole start");
     source_file.write_all(b"C").expect("write after hole");
 
-    // Another aligned hole
     source_file
         .seek(SeekFrom::Start(2048))
         .expect("seek hole 2 start");
@@ -626,14 +609,12 @@ fn execute_sparse_with_aligned_holes() {
     let meta = fs::metadata(&sparse_dest).expect("metadata");
     assert_eq!(meta.len(), 4096);
 
-    // Verify data at specific offsets
     let content = fs::read(&sparse_dest).expect("read dest");
     assert_eq!(content[0], b'A');
     assert_eq!(content[16], b'B');
     assert_eq!(content[1024], b'C');
     assert_eq!(content[2048], b'D');
 
-    // Verify holes are zeros
     assert!(content[1..16].iter().all(|&b| b == 0), "hole before B");
     assert!(content[17..1024].iter().all(|&b| b == 0), "hole before C");
     assert!(
@@ -660,7 +641,6 @@ fn execute_sparse_detects_zero_regions_at_threshold() {
     let dense_dest = temp.path().join("dense.bin");
     let sparse_dest = temp.path().join("sparse.bin");
 
-    // Dense copy
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -670,7 +650,6 @@ fn execute_sparse_detects_zero_regions_at_threshold() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -683,7 +662,6 @@ fn execute_sparse_detects_zero_regions_at_threshold() {
         )
         .expect("sparse copy succeeds");
 
-    // Verify content is identical
     let dense_content = fs::read(&dense_dest).expect("read dense");
     let sparse_content = fs::read(&sparse_dest).expect("read sparse");
     assert_eq!(dense_content, sparse_content);
@@ -738,7 +716,6 @@ fn execute_sparse_skips_zero_regions_under_threshold() {
     )
     .expect("sparse copy succeeds");
 
-    // Verify content integrity
     let content = fs::read(&sparse_dest).expect("read sparse");
     assert_eq!(&content[0..5], b"START");
     assert!(content[5..5 + under_threshold].iter().all(|&b| b == 0));
@@ -763,7 +740,6 @@ fn execute_sparse_detects_zero_regions_over_threshold() {
     let dense_dest = temp.path().join("dense.bin");
     let sparse_dest = temp.path().join("sparse.bin");
 
-    // Dense copy
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -773,7 +749,6 @@ fn execute_sparse_detects_zero_regions_over_threshold() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -786,7 +761,6 @@ fn execute_sparse_detects_zero_regions_over_threshold() {
         )
         .expect("sparse copy succeeds");
 
-    // Verify content
     let sparse_content = fs::read(&sparse_dest).expect("read sparse");
     assert_eq!(&sparse_content[0..5], b"BEGIN");
     assert!(sparse_content[5..5 + over_threshold].iter().all(|&b| b == 0));
@@ -817,7 +791,6 @@ fn execute_sparse_creates_actual_filesystem_holes() {
     let source = temp.path().join("hole-test.bin");
     let mut source_file = fs::File::create(&source).expect("create source");
 
-    // Create a file with known hole pattern
     source_file.write_all(b"DATA1").expect("write data1");
     source_file.write_all(&vec![0u8; 64 * 1024]).expect("write 64KB zeros");
     source_file.write_all(b"DATA2").expect("write data2");
@@ -865,7 +838,6 @@ fn execute_sparse_creates_actual_filesystem_holes() {
         assert!(second_data > first_hole, "should find data after first hole");
     }
 
-    // Verify content integrity
     let content = fs::read(&sparse_dest).expect("read sparse");
     assert_eq!(&content[0..5], b"DATA1");
     assert_eq!(&content[5 + 64 * 1024..5 + 64 * 1024 + 5], b"DATA2");
@@ -894,7 +866,6 @@ fn execute_sparse_detects_multiple_threshold_zero_regions() {
     let dense_dest = temp.path().join("dense-multi.bin");
     let sparse_dest = temp.path().join("sparse-multi.bin");
 
-    // Dense copy
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -904,7 +875,6 @@ fn execute_sparse_detects_multiple_threshold_zero_regions() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -917,7 +887,6 @@ fn execute_sparse_detects_multiple_threshold_zero_regions() {
         )
         .expect("sparse copy succeeds");
 
-    // Verify content
     let content = fs::read(&sparse_dest).expect("read sparse");
     let mut offset = 0;
     assert_eq!(&content[offset..offset + 6], b"BLOCK1");
@@ -951,7 +920,6 @@ fn execute_sparse_preserves_nonzero_data_integrity() {
     let source = temp.path().join("data-integrity.bin");
     let mut source_file = fs::File::create(&source).expect("create source");
 
-    // Create file with various data patterns
     let pattern1 = vec![0xAA; 1024];
     let pattern2 = vec![0x55; 2048];
     let pattern3 = vec![0xFF; 512];
@@ -979,12 +947,10 @@ fn execute_sparse_preserves_nonzero_data_integrity() {
     )
     .expect("sparse copy succeeds");
 
-    // Verify exact content match
     let source_content = fs::read(&source).expect("read source");
     let dest_content = fs::read(&sparse_dest).expect("read dest");
     assert_eq!(source_content, dest_content, "content should be identical");
 
-    // Verify specific patterns
     assert_eq!(&dest_content[0..1024], &pattern1[..]);
     let offset2 = 1024 + 64 * 1024;
     assert_eq!(&dest_content[offset2..offset2 + 2048], &pattern2[..]);
@@ -1012,7 +978,6 @@ fn execute_sparse_reduces_disk_allocation() {
     let dense_dest = temp.path().join("dense-alloc.bin");
     let sparse_dest = temp.path().join("sparse-alloc.bin");
 
-    // Dense copy
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -1022,7 +987,6 @@ fn execute_sparse_reduces_disk_allocation() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -1039,7 +1003,6 @@ fn execute_sparse_reduces_disk_allocation() {
     let dense_meta = fs::metadata(&dense_dest).expect("dense metadata");
     let sparse_meta = fs::metadata(&sparse_dest).expect("sparse metadata");
 
-    // Both should have same file size
     assert_eq!(dense_meta.len(), sparse_meta.len());
 
     // Sparse should use significantly fewer blocks (allow for filesystem differences)
@@ -1096,7 +1059,6 @@ fn execute_sparse_handles_boundary_split_zeros() {
     )
     .expect("sparse copy succeeds");
 
-    // Verify content
     let content = fs::read(&sparse_dest).expect("read sparse");
     assert_eq!(&content[0..6], b"PREFIX");
     assert!(content[6..6 + threshold * 2].iter().all(|&b| b == 0));
@@ -1209,7 +1171,6 @@ fn execute_sparse_dense_all_zeros_produces_sparse_hole() {
     let dense_dest = temp.path().join("dense-dest.bin");
     let sparse_dest = temp.path().join("sparse-dest.bin");
 
-    // Dense copy (baseline)
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -1219,7 +1180,6 @@ fn execute_sparse_dense_all_zeros_produces_sparse_hole() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -1282,14 +1242,12 @@ fn execute_sparse_all_zeros_creates_fully_sparse_file() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("all-zeros.bin");
     let file = fs::File::create(&source).expect("create source");
-    // Create a 1MB file of all zeros
     file.set_len(1024 * 1024).expect("set source length");
     drop(file);
 
     let dense_dest = temp.path().join("dense-zeros.bin");
     let sparse_dest = temp.path().join("sparse-zeros.bin");
 
-    // Dense copy (no sparse)
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -1299,7 +1257,6 @@ fn execute_sparse_all_zeros_creates_fully_sparse_file() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -1315,11 +1272,9 @@ fn execute_sparse_all_zeros_creates_fully_sparse_file() {
     let dense_meta = fs::metadata(&dense_dest).expect("dense metadata");
     let sparse_meta = fs::metadata(&sparse_dest).expect("sparse metadata");
 
-    // Both should have the same logical file size
     assert_eq!(dense_meta.len(), 1024 * 1024);
     assert_eq!(sparse_meta.len(), 1024 * 1024);
 
-    // Content should be identical (all zeros)
     let sparse_content = fs::read(&sparse_dest).expect("read sparse");
     assert!(
         sparse_content.iter().all(|&b| b == 0),
@@ -1368,7 +1323,6 @@ fn execute_sparse_nonzero_file_written_normally() {
     let dense_dest = temp.path().join("dense-nonzero.bin");
     let sparse_dest = temp.path().join("sparse-nonzero.bin");
 
-    // Dense copy
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -1378,7 +1332,6 @@ fn execute_sparse_nonzero_file_written_normally() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -1391,7 +1344,6 @@ fn execute_sparse_nonzero_file_written_normally() {
         )
         .expect("sparse copy succeeds");
 
-    // Content should be identical
     let dense_content = fs::read(&dense_dest).expect("read dense");
     let sparse_content = fs::read(&sparse_dest).expect("read sparse");
     assert_eq!(dense_content, sparse_content);
@@ -1436,7 +1388,6 @@ fn execute_sparse_small_file_below_threshold() {
     )
     .expect("sparse copy succeeds");
 
-    // Verify content integrity
     let content = fs::read(&sparse_dest).expect("read dest");
     assert_eq!(content.len(), 100);
     assert_eq!(content[0], b'X');
@@ -1496,7 +1447,6 @@ fn execute_sparse_hole_at_start() {
     let dense_dest = temp.path().join("dense-start.bin");
     let sparse_dest = temp.path().join("sparse-start.bin");
 
-    // Dense copy
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -1506,7 +1456,6 @@ fn execute_sparse_hole_at_start() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -1519,7 +1468,6 @@ fn execute_sparse_hole_at_start() {
         )
         .expect("sparse copy succeeds");
 
-    // Verify content
     let sparse_content = fs::read(&sparse_dest).expect("read sparse");
     let dense_content = fs::read(&dense_dest).expect("read dense");
     assert_eq!(sparse_content, dense_content);
@@ -1559,7 +1507,6 @@ fn execute_sparse_hole_at_end() {
     let dense_dest = temp.path().join("dense-end.bin");
     let sparse_dest = temp.path().join("sparse-end.bin");
 
-    // Dense copy
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -1569,7 +1516,6 @@ fn execute_sparse_hole_at_end() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -1582,7 +1528,6 @@ fn execute_sparse_hole_at_end() {
         )
         .expect("sparse copy succeeds");
 
-    // Verify content
     let sparse_content = fs::read(&sparse_dest).expect("read sparse");
     let dense_content = fs::read(&dense_dest).expect("read dense");
     assert_eq!(sparse_content, dense_content);
@@ -1625,7 +1570,6 @@ fn execute_sparse_hole_in_middle() {
     let dense_dest = temp.path().join("dense-mid.bin");
     let sparse_dest = temp.path().join("sparse-mid.bin");
 
-    // Dense copy
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -1635,7 +1579,6 @@ fn execute_sparse_hole_in_middle() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),
@@ -1648,7 +1591,6 @@ fn execute_sparse_hole_in_middle() {
         )
         .expect("sparse copy succeeds");
 
-    // Verify content
     let sparse_content = fs::read(&sparse_dest).expect("read sparse");
     let dense_content = fs::read(&dense_dest).expect("read dense");
     assert_eq!(sparse_content, dense_content);
@@ -1701,7 +1643,6 @@ fn execute_preallocate_disables_sparse_writes() {
     let sparse_only_dest = temp.path().join("sparse-only.bin");
     let prealloc_sparse_dest = temp.path().join("prealloc-sparse.bin");
 
-    // Sparse-only copy (no preallocate)
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         sparse_only_dest.clone().into_os_string(),
@@ -1727,7 +1668,6 @@ fn execute_preallocate_disables_sparse_writes() {
         )
         .expect("preallocate+sparse copy succeeds");
 
-    // Both should have the same logical size and content
     let sparse_meta = fs::metadata(&sparse_only_dest).expect("sparse metadata");
     let prealloc_meta = fs::metadata(&prealloc_sparse_dest).expect("prealloc metadata");
     assert_eq!(sparse_meta.len(), prealloc_meta.len());
@@ -1769,7 +1709,6 @@ fn execute_append_disables_sparse_writes() {
     let source = temp.path().join("append-sparse.bin");
     let mut source_file = fs::File::create(&source).expect("create source");
 
-    // Create a file with zeros
     source_file.write_all(&[0xFF]).expect("write byte");
     source_file
         .write_all(&vec![0u8; 64 * 1024])
@@ -1848,7 +1787,6 @@ fn execute_sparse_large_trailing_zeros_uses_ftruncate() {
     let dense_dest = temp.path().join("dense-trailing.bin");
     let sparse_dest = temp.path().join("sparse-trailing.bin");
 
-    // Dense copy (baseline)
     let plan_dense = LocalCopyPlan::from_operands(&[
         source.clone().into_os_string(),
         dense_dest.clone().into_os_string(),
@@ -1858,7 +1796,6 @@ fn execute_sparse_large_trailing_zeros_uses_ftruncate() {
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("dense copy succeeds");
 
-    // Sparse copy (should use ftruncate for trailing zeros)
     let plan_sparse = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
         sparse_dest.clone().into_os_string(),

--- a/crates/engine/src/local_copy/tests/execute_special.rs
+++ b/crates/engine/src/local_copy/tests/execute_special.rs
@@ -745,15 +745,12 @@ fn execute_copies_mixed_special_files() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create regular file
     fs::write(source_root.join("regular.txt"), b"regular").expect("write regular");
 
-    // Create symlink
     let target = source_root.join("target.txt");
     fs::write(&target, b"target").expect("write target");
     symlink(Path::new("target.txt"), source_root.join("link")).expect("create symlink");
 
-    // Create FIFO
     let fifo = source_root.join("fifo");
     mkfifo_for_tests(&fifo, 0o600).expect("mkfifo");
 
@@ -799,7 +796,6 @@ fn execute_symlink_pointing_to_fifo_preserved_as_symlink() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a FIFO and a symlink pointing to it
     let fifo = source_root.join("real.pipe");
     mkfifo_for_tests(&fifo, 0o600).expect("mkfifo");
 
@@ -857,7 +853,6 @@ fn execute_symlink_pointing_to_socket_preserved_as_symlink() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a socket and a symlink pointing to it
     let socket = source_root.join("real.sock");
     mksocket_for_tests(&socket).expect("mksocket");
 
@@ -1259,7 +1254,6 @@ fn execute_copy_links_follows_symlink_to_fifo_specials_disabled_skips() {
         )
         .expect("copy succeeds");
 
-    // The regular file should be copied
     assert_eq!(
         fs::read(dest.join("source").join("regular.txt")).expect("read regular"),
         b"regular file"
@@ -1320,7 +1314,6 @@ fn execute_copy_dirlinks_follows_dir_symlink_but_preserves_file_symlink_in_tree(
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a real target directory with a file
     let target_dir = temp.path().join("target_dir");
     fs::create_dir(&target_dir).expect("create target dir");
     fs::write(target_dir.join("inner.txt"), b"dir data").expect("write inner");
@@ -1329,7 +1322,6 @@ fn execute_copy_dirlinks_follows_dir_symlink_but_preserves_file_symlink_in_tree(
     let dir_link = source_root.join("dir_link");
     symlink(&target_dir, &dir_link).expect("create dir symlink");
 
-    // Create a regular file and a symlink to it
     let target_file = source_root.join("target.txt");
     fs::write(&target_file, b"payload").expect("write target");
     let file_link = source_root.join("file_link");
@@ -1389,7 +1381,6 @@ fn execute_safe_links_with_copy_dirlinks_follows_unsafe_dir_symlink() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create an outside directory
     let outside_dir = temp.path().join("outside_dir");
     fs::create_dir(&outside_dir).expect("create outside dir");
     fs::write(outside_dir.join("file.txt"), b"outside").expect("write outside file");
@@ -1559,7 +1550,6 @@ fn execute_copy_links_follows_nested_symlink_chain_to_regular_file() {
         )
         .expect("copy succeeds");
 
-    // All entries should be dereferenced to regular files
     for name in &["link_a", "link_b", "real.txt"] {
         let dest_file = dest_dir.join("source").join(name);
         let meta = fs::symlink_metadata(&dest_file).expect("metadata");
@@ -1578,7 +1568,6 @@ fn execute_copy_links_follows_nested_symlink_chain_to_regular_file() {
         );
     }
 
-    // All three entries should count as files, not symlinks
     assert_eq!(summary.symlinks_copied(), 0);
     assert_eq!(summary.files_copied(), 3);
 }
@@ -1663,7 +1652,7 @@ fn execute_without_links_skips_symlink_records_event() {
 
     let summary = report.summary();
     assert_eq!(summary.symlinks_copied(), 0);
-    assert_eq!(summary.files_copied(), 1); // only target.txt
+    assert_eq!(summary.files_copied(), 1);
     assert!(!dest_root.join("source").join("link").exists(), "symlink should not be copied");
     assert!(dest_root.join("source").join("target.txt").exists(), "regular file should be copied");
     assert!(report.records().iter().any(|record| {
@@ -1736,7 +1725,7 @@ fn execute_fifo_with_archive_options_preserves_all_metadata() {
         b"archive"
     );
 
-    assert_eq!(summary.fifos_created(), 2); // FIFO + socket
+    assert_eq!(summary.fifos_created(), 2);
     assert_eq!(summary.files_copied(), 1);
 }
 
@@ -1751,7 +1740,6 @@ fn execute_copy_unsafe_links_in_tree_preserves_safe_and_dereferences_unsafe() {
     let subdir = source_root.join("sub");
     fs::create_dir_all(&subdir).expect("create subdir");
 
-    // Create targets
     let inside_file = source_root.join("inside.txt");
     fs::write(&inside_file, b"inside").expect("write inside");
 
@@ -1803,7 +1791,7 @@ fn execute_copy_unsafe_links_in_tree_preserves_safe_and_dereferences_unsafe() {
     assert!(!unsafe_meta.file_type().is_symlink());
     assert_eq!(fs::read(&dest_unsafe).expect("read"), b"outside");
 
-    assert_eq!(summary.files_copied(), 2); // inside.txt + dereferenced unsafe
+    assert_eq!(summary.files_copied(), 2);
 }
 
 /// Verifies that the `--copy-unsafe-links` dereference path emits the
@@ -1951,7 +1939,6 @@ fn execute_keep_dirlinks_multiple_symlink_subdirs_all_preserved() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Create real target directories and symlinks
     let real_alpha = temp.path().join("real_alpha");
     fs::create_dir(&real_alpha).expect("create real alpha");
     symlink(&real_alpha, dest_root.join("alpha")).expect("symlink alpha");
@@ -1971,7 +1958,6 @@ fn execute_keep_dirlinks_multiple_symlink_subdirs_all_preserved() {
     )
     .expect("copy succeeds");
 
-    // Both symlinks should be preserved
     assert!(
         fs::symlink_metadata(dest_root.join("alpha"))
             .expect("meta")
@@ -2008,15 +1994,12 @@ fn execute_dry_run_mixed_specials_and_symlinks_no_side_effects() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create FIFO
     let fifo = source_root.join("my.pipe");
     mkfifo_for_tests(&fifo, 0o600).expect("mkfifo");
 
-    // Create socket
     let socket = source_root.join("my.sock");
     mksocket_for_tests(&socket).expect("mksocket");
 
-    // Create symlink
     let target = source_root.join("target.txt");
     fs::write(&target, b"target").expect("write target");
     symlink(Path::new("target.txt"), source_root.join("link")).expect("create symlink");
@@ -2039,7 +2022,7 @@ fn execute_dry_run_mixed_specials_and_symlinks_no_side_effects() {
 
     // Statistics should reflect what would happen
     assert_eq!(summary.symlinks_copied(), 1);
-    assert_eq!(summary.fifos_created(), 2); // FIFO + socket
+    assert_eq!(summary.fifos_created(), 2);
 
     // But nothing should be created
     assert!(!dest_root.exists(), "dry run should not create destination");

--- a/crates/engine/src/local_copy/tests/execute_special_characters.rs
+++ b/crates/engine/src/local_copy/tests/execute_special_characters.rs
@@ -1274,7 +1274,6 @@ fn copy_files_with_various_high_ascii() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Test various high-byte patterns
     let byte_values: &[u8] = &[0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0xff];
     for byte in byte_values {
         let filename_bytes = [b'f', b'i', b'l', b'e', *byte, b'.', b't', b'x', b't'];
@@ -1479,7 +1478,6 @@ fn copy_deeply_nested_directories_with_special_characters() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create nested structure with special chars at each level
     let path = source_root
         .join("dir with space")
         .join("dir'quote")
@@ -1949,12 +1947,10 @@ fn update_file_with_special_characters() {
     let source = temp.path().join(format!("src_{filename}"));
     let destination = temp.path().join(filename);
 
-    // Create older destination file
     fs::write(&destination, b"old content").expect("write dest");
     let old_time = FileTime::from_unix_time(1_500_000_000, 0);
     set_file_times(&destination, old_time, old_time).expect("set old time");
 
-    // Create newer source file with different content
     fs::write(&source, b"new updated content").expect("write source");
     let new_time = FileTime::from_unix_time(1_600_000_000, 0);
     set_file_times(&source, new_time, new_time).expect("set new time");
@@ -1984,11 +1980,9 @@ fn delete_file_with_special_characters() {
     fs::create_dir_all(&source_root).expect("create source");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Create file with special chars only in destination (to be deleted)
     let extra_file = "extra'file\"to*delete.txt";
     fs::write(dest_root.join(extra_file), b"to delete").expect("write extra");
 
-    // Create a file in source (to be copied)
     fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
 
     let mut source_operand = source_root.into_os_string();

--- a/crates/engine/src/local_copy/tests/execute_specials.rs
+++ b/crates/engine/src/local_copy/tests/execute_specials.rs
@@ -295,15 +295,12 @@ fn execute_copies_mixed_fifos_and_sockets() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a FIFO
     let fifo = source_root.join("pipe");
     mkfifo_for_tests(&fifo, 0o600).expect("mkfifo");
 
-    // Create a socket
     let socket = source_root.join("sock");
     mksocket_for_tests(&socket).expect("mksocket");
 
-    // Create a regular file
     fs::write(source_root.join("regular.txt"), b"content").expect("write regular");
 
     let dest_root = temp.path().join("dest");
@@ -320,7 +317,6 @@ fn execute_copies_mixed_fifos_and_sockets() {
         )
         .expect("copy succeeds");
 
-    // Both FIFO and socket should be created
     let dest_fifo = dest_root.join("source").join("pipe");
     let dest_socket = dest_root.join("source").join("sock");
     let dest_regular = dest_root.join("source").join("regular.txt");
@@ -870,11 +866,9 @@ fn execute_copies_socket_and_symlink_together() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a socket
     let socket = source_root.join("my.sock");
     mksocket_for_tests(&socket).expect("mksocket");
 
-    // Create a regular file and a symlink
     let target = source_root.join("target.txt");
     fs::write(&target, b"target").expect("write target");
     symlink(Path::new("target.txt"), source_root.join("link")).expect("create symlink");

--- a/crates/engine/src/local_copy/tests/execute_super.rs
+++ b/crates/engine/src/local_copy/tests/execute_super.rs
@@ -368,11 +368,9 @@ fn fake_super_stores_ownership_in_xattrs() {
             let dest_file = ctx.dest.join("file.txt");
             test_helpers::assert_file_content(&dest_file, b"fake super ownership");
 
-            // Check for the fake-super xattr
             let stat_xattr = xattr::get(&dest_file, "user.rsync.%stat");
             match stat_xattr {
                 Ok(Some(value)) => {
-                    // The xattr should contain encoded metadata
                     assert!(!value.is_empty(), "fake-super xattr should not be empty");
                 }
                 Ok(None) => {
@@ -672,7 +670,6 @@ fn super_true_with_owner_preserves_uid_when_root() {
     use std::os::unix::fs::MetadataExt;
 
     if rustix::process::geteuid().as_raw() != 0 {
-        // Skip when not running as root
         return;
     }
 
@@ -826,7 +823,6 @@ fn super_mode_with_collect_events_records_actions() {
         .expect("copy executes");
 
     assert_eq!(report.summary().files_copied(), 1);
-    // Verify events were recorded
     assert!(!report.records().is_empty());
 }
 
@@ -913,7 +909,6 @@ fn super_mode_with_update_skips_newer_destination() {
     ctx.write_source("file.txt", b"older");
     ctx.write_dest("file.txt", b"newer");
 
-    // Make destination newer than source
     let old_time = filetime::FileTime::from_unix_time(1_000_000_000, 0);
     let new_time = filetime::FileTime::from_unix_time(2_000_000_000, 0);
     filetime::set_file_mtime(ctx.source.join("file.txt"), old_time).expect("set source mtime");

--- a/crates/engine/src/local_copy/tests/execute_symlink_edge_cases.rs
+++ b/crates/engine/src/local_copy/tests/execute_symlink_edge_cases.rs
@@ -62,7 +62,6 @@ fn symlink_relative_target_stays_relative() {
     let target = source_root.join("target.txt");
     fs::write(&target, b"content").expect("write target");
 
-    // Create relative symlink
     let link = source_root.join("rel_link");
     symlink(Path::new("target.txt"), &link).expect("create relative symlink");
 
@@ -274,7 +273,6 @@ fn symlink_chain_two_levels() {
         )
         .expect("copy succeeds");
 
-    // All links and target should be copied
     assert!(dest_root.join("src").join("target.txt").is_file());
     assert!(fs::symlink_metadata(dest_root.join("src").join("link1")).expect("meta").file_type().is_symlink());
     assert!(fs::symlink_metadata(dest_root.join("src").join("link2")).expect("meta").file_type().is_symlink());
@@ -323,7 +321,6 @@ fn symlink_chain_three_levels_deep() {
     )
     .expect("copy succeeds");
 
-    // All levels should be preserved
     for link_name in ["link1", "link2", "link3"] {
         let dest_link = dest_root.join("src").join(link_name);
         assert!(

--- a/crates/engine/src/local_copy/tests/execute_symlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_symlinks.rs
@@ -327,13 +327,11 @@ fn safe_links_skips_symlink_pointing_outside_transfer_tree() {
 
     let summary = report.summary();
 
-    // Both unsafe symlinks should be skipped
     assert_eq!(summary.symlinks_copied(), 0);
     assert_eq!(summary.symlinks_total(), 2);
     assert!(!dest_root.join("source").join("unsafe_absolute_link").exists());
     assert!(!dest_root.join("source").join("source/escape_link").exists());
 
-    // Verify we got SkippedUnsafeSymlink records
     let skip_count = report
         .records()
         .iter()
@@ -382,10 +380,8 @@ fn safe_links_preserves_symlink_pointing_inside_transfer_tree() {
         )
         .expect("copy succeeds");
 
-    // All safe symlinks should be preserved
     assert_eq!(summary.symlinks_copied(), 3);
 
-    // Verify all symlinks exist and have correct targets
     let dest_link1 = dest_root.join("source").join("link_to_subdir");
     assert!(fs::symlink_metadata(&dest_link1).expect("meta").file_type().is_symlink());
     assert_eq!(
@@ -460,11 +456,9 @@ fn safe_links_evaluates_relative_symlinks_correctly() {
     assert_eq!(summary.symlinks_copied(), 2);
     assert_eq!(summary.symlinks_total(), 3);
 
-    // Verify safe links exist
     assert!(dest_root.join("source").join("level1/level2/level3/link_to_level1").exists());
     assert!(dest_root.join("source").join("root_link").exists());
 
-    // Verify unsafe link was skipped
     assert!(!dest_root.join("source").join("level1/escape_link").exists());
 
     let skip_count = report
@@ -812,15 +806,12 @@ fn safe_links_trailing_slash_vs_no_trailing_slash() {
     assert_eq!(summary2.symlinks_copied(), 1, "trailing-slash: 1 safe link");
     assert_eq!(summary2.symlinks_total(), 2, "trailing-slash: 2 total links");
 
-    // Verify safe link exists and unsafe link is skipped (no trailing slash)
     assert!(dest1.join("source").join("sub/safe").exists());
     assert!(!dest1.join("source").join("sub/unsafe").exists());
 
-    // Verify safe link exists and unsafe link is skipped (trailing slash)
     assert!(dest2.join("sub/safe").exists());
     assert!(!dest2.join("sub/unsafe").exists());
 
-    // Verify SkippedUnsafeSymlink records
     let skips1 = report1
         .records()
         .iter()

--- a/crates/engine/src/local_copy/tests/execute_symlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_symlinks.rs
@@ -21,7 +21,6 @@ fn execute_copies_symbolic_link() {
         .expect("copy succeeds");
     let copied = fs::read_link(dest_link).expect("read copied link");
     assert_eq!(copied, target);
-    // assert_eq!(summary.symlinks_copied(), 1);  // Depends on safe_links behavior
 }
 
 #[cfg(unix)]
@@ -154,7 +153,6 @@ fn execute_with_copy_dirlinks_preserves_file_symlink() {
         .execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    // assert_eq!(summary.symlinks_copied(), 1);  // Depends on safe_links behavior
     let copied = fs::read_link(&dest).expect("read link");
     assert_eq!(copied, target_file);
 }
@@ -191,7 +189,6 @@ fn execute_with_safe_links_allows_relative_symlink() {
         )
         .expect("copy succeeds");
 
-    // assert_eq!(summary.symlinks_copied(), 1);  // Depends on safe_links behavior
     let copied = fs::read_link(&destination_link).expect("read link");
     assert_eq!(copied, Path::new("nested/file.txt"));
 }
@@ -634,7 +631,6 @@ fn safe_links_preserves_symlink_to_directory_when_safe() {
         )
         .expect("copy succeeds");
 
-    // assert_eq!(summary.symlinks_copied(), 1);  // Depends on safe_links behavior
 
     let dest_link = dest_root.join("source").join("link_to_dir");
     assert!(fs::symlink_metadata(&dest_link).expect("meta").file_type().is_symlink());
@@ -1015,7 +1011,6 @@ fn copy_unsafe_links_preserves_safe_symlink() {
     assert!(metadata.file_type().is_symlink());
     let target = fs::read_link(&destination_link).expect("read symlink");
     assert_eq!(target, Path::new("inside.txt"));
-    // assert_eq!(summary.symlinks_copied(), 1);  // Depends on safe_links behavior
 }
 
 #[cfg(unix)]
@@ -1127,8 +1122,6 @@ fn copy_unsafe_links_in_recursive_copy() {
         b"unsafe"
     );
 
-    // Summary should show both types
-    // assert_eq!(summary.symlinks_copied(), 1);  // Depends on safe_links behavior // only the safe link
     assert_eq!(summary.files_copied(), 2); // original file + dereferenced unsafe link
 }
 
@@ -1376,8 +1369,6 @@ fn copy_unsafe_links_with_mixed_safe_and_unsafe_in_tree() {
         b"outside data"
     );
 
-    // Check summary
-    // assert_eq!(summary.symlinks_copied(), 1);  // Depends on safe_links behavior // only safe link
     assert_eq!(summary.files_copied(), 3); // safe_target.txt + 2 dereferenced unsafe links
 }
 

--- a/crates/engine/src/local_copy/tests/execute_temp_dir.rs
+++ b/crates/engine/src/local_copy/tests/execute_temp_dir.rs
@@ -38,7 +38,6 @@ fn execute_with_temp_dir_places_temp_files_in_specified_directory() {
         b"temp dir test content"
     );
 
-    // Verify no stray temp files remain in staging directory
     let staging_contents: Vec<_> = fs::read_dir(&temp_staging)
         .expect("read staging dir")
         .collect();
@@ -76,7 +75,6 @@ fn execute_with_temp_dir_moves_file_to_destination_on_completion() {
     assert!(destination.exists(), "destination should exist");
     assert_eq!(fs::read(&destination).expect("read dest"), content);
 
-    // Verify the staging directory is empty (file was moved, not copied)
     let staging_files: Vec<_> = fs::read_dir(&temp_staging)
         .expect("read staging")
         .filter_map(|e| e.ok())
@@ -151,7 +149,6 @@ fn execute_with_temp_dir_different_filesystem_falls_back_to_copy() {
         LocalCopyOptions::default().with_temp_directory(Some(&staging_subdir)),
     );
 
-    // Clean up the staging directory
     let _ = fs::remove_dir_all(&staging_subdir);
 
     let summary = result.expect("copy should succeed even across filesystems");
@@ -272,7 +269,6 @@ fn execute_with_absolute_temp_dir_path() {
 
     fs::write(&source, b"absolute path test").expect("write source");
 
-    // Ensure we're using an absolute path
     let absolute_staging = temp_staging.canonicalize().expect("canonicalize");
 
     let operands = vec![
@@ -318,7 +314,7 @@ fn execute_with_temp_dir_replaces_existing_destination() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .with_temp_directory(Some(&temp_staging))
-                .ignore_times(true), // Force transfer
+                .ignore_times(true),
         )
         .expect("copy succeeds");
 
@@ -650,7 +646,6 @@ fn execute_with_temp_dir_cleans_up_on_successful_multi_file_transfer() {
     fs::create_dir_all(&source_root).expect("source dir");
     fs::create_dir_all(&temp_staging).expect("staging dir");
 
-    // Create multiple files of varying sizes
     for i in 0..10 {
         let content = vec![i as u8; (i + 1) * 1024];
         fs::write(source_root.join(format!("file{i}.bin")), &content).expect("write file");
@@ -671,7 +666,6 @@ fn execute_with_temp_dir_cleans_up_on_successful_multi_file_transfer() {
 
     assert_eq!(summary.files_copied(), 10);
 
-    // Verify all files exist in destination
     for i in 0..10 {
         let dest_file = dest_root.join(format!("file{i}.bin"));
         assert!(dest_file.exists(), "file{i}.bin should exist");
@@ -679,7 +673,6 @@ fn execute_with_temp_dir_cleans_up_on_successful_multi_file_transfer() {
         assert_eq!(fs::read(&dest_file).expect("read"), expected_content);
     }
 
-    // Verify staging is completely clean
     let staging_files: Vec<_> = fs::read_dir(&temp_staging)
         .expect("read staging")
         .filter_map(|e| e.ok())
@@ -781,7 +774,6 @@ fn execute_with_temp_dir_provides_atomic_destination_update() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // The destination should have exactly the new content
     let final_content = fs::read(&destination).expect("read dest");
     assert_eq!(final_content, new_content);
 }
@@ -848,7 +840,6 @@ fn execute_without_temp_dir_creates_temps_alongside_destination() {
         fs::read(&destination).expect("read dest"),
         b"no temp dir test"
     );
-    // No stray temp files should remain in the destination directory
     let parent = destination.parent().unwrap();
     let stray_temps: Vec<_> = fs::read_dir(parent)
         .expect("read dir")
@@ -906,7 +897,6 @@ fn execute_with_temp_dir_format_in_custom_directory() {
         name.contains("file.txt"),
         "temp file should use filename only, not full subpath"
     );
-    // The temp file should be directly in temp_dir, not in a subdirectory
     assert_eq!(
         temp_path.parent().unwrap(),
         temp_dir,
@@ -1068,7 +1058,6 @@ fn execute_with_temp_dir_second_run_skips_identical_files() {
         )
         .expect("second copy succeeds");
 
-    // Files should be matched (skipped), not copied again
     assert_eq!(
         summary2.files_copied(), 0,
         "identical file should be skipped on second run"
@@ -1121,7 +1110,6 @@ fn execute_with_temp_dir_unique_temp_names_across_files() {
         temp1, temp2,
         "different destination files should get different temp paths"
     );
-    // Both should be in the temp dir
     assert!(temp1.starts_with(td));
     assert!(temp2.starts_with(td));
 }
@@ -1222,7 +1210,6 @@ fn execute_with_temp_dir_nested_source_uses_flat_staging() {
 
     assert_eq!(summary.files_copied(), 3);
 
-    // Verify all files exist at correct destinations
     assert_eq!(
         fs::read(dest_root.join("source").join("top.txt")).expect("read"),
         b"top level"
@@ -1236,7 +1223,6 @@ fn execute_with_temp_dir_nested_source_uses_flat_staging() {
         b"deep level"
     );
 
-    // Verify staging directory is clean
     let staging_files: Vec<_> = fs::read_dir(&temp_staging)
         .expect("read staging")
         .filter_map(|e| e.ok())

--- a/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
+++ b/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
@@ -18,7 +18,6 @@ fn times_flag_preserves_mtime_on_copied_file() {
 
     fs::write(&source, b"content for mtime test").expect("write source");
 
-    // Set a specific mtime
     let mtime = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(&source, mtime).expect("set source mtime");
 
@@ -50,7 +49,6 @@ fn times_flag_disabled_does_not_preserve_mtime() {
 
     fs::write(&source, b"content").expect("write source");
 
-    // Set a specific mtime in the past
     let old_mtime = FileTime::from_unix_time(1_500_000_000, 0);
     set_file_mtime(&source, old_mtime).expect("set source mtime");
 
@@ -60,7 +58,6 @@ fn times_flag_disabled_does_not_preserve_mtime() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Execute without times flag (default is false)
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
@@ -85,7 +82,6 @@ fn times_flag_preserves_mtime_on_multiple_files() {
     let dest_root = temp.path().join("dest");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create files with different mtimes
     let file1 = source_root.join("file1.txt");
     let file2 = source_root.join("file2.txt");
     let file3 = source_root.join("file3.txt");
@@ -114,7 +110,6 @@ fn times_flag_preserves_mtime_on_multiple_files() {
     )
     .expect("copy succeeds");
 
-    // Verify each file has its mtime preserved
     let dest_file1 = dest_root.join("source").join("file1.txt");
     let dest_file2 = dest_root.join("source").join("file2.txt");
     let dest_file3 = dest_root.join("source").join("file3.txt");
@@ -136,7 +131,6 @@ fn times_without_u_flag_omits_atime_on_copied_file() {
 
     fs::write(&source, b"content for atime test").expect("write source");
 
-    // Set specific atime and mtime
     let atime = FileTime::from_unix_time(1_600_000_000, 123_000_000);
     let mtime = FileTime::from_unix_time(1_700_000_000, 456_000_000);
     set_file_times(&source, atime, mtime).expect("set source times");
@@ -179,7 +173,6 @@ fn atime_and_mtime_can_differ() {
     let mtime = FileTime::from_unix_time(1_800_000_000, 900_000_000);
     set_file_times(&source, atime, mtime).expect("set source times");
 
-    // Verify they're different
     let source_metadata = fs::metadata(&source).expect("source metadata");
     let source_atime = FileTime::from_last_access_time(&source_metadata);
     let source_mtime = FileTime::from_last_modification_time(&source_metadata);
@@ -223,7 +216,6 @@ fn subsecond_precision_is_preserved_full_nanoseconds() {
 
     fs::write(&source, b"nanosecond precision test").expect("write source");
 
-    // Set timestamp with full nanosecond precision
     let mtime = FileTime::from_unix_time(1_700_000_000, 123_456_789);
     set_file_mtime(&source, mtime).expect("set source mtime");
 
@@ -252,7 +244,6 @@ fn subsecond_precision_is_preserved_full_nanoseconds() {
 fn subsecond_precision_various_values() {
     let temp = tempdir().expect("tempdir");
 
-    // Test various nanosecond values
     let test_cases = vec![
         (0, "zero nanoseconds"),
         (1, "one nanosecond"),
@@ -306,11 +297,9 @@ fn subsecond_precision_round_trip() {
 
     fs::write(&file1, b"round trip content").expect("write file1");
 
-    // Set specific nanosecond value
     let original_mtime = FileTime::from_unix_time(1_700_000_000, 987_654_321);
     set_file_mtime(&file1, original_mtime).expect("set file1 mtime");
 
-    // First copy: file1 -> file2
     let operands = vec![
         file1.into_os_string(),
         file2.clone().into_os_string(),
@@ -322,7 +311,6 @@ fn subsecond_precision_round_trip() {
     )
     .expect("first copy");
 
-    // Second copy: file2 -> file3
     let operands = vec![
         file2.into_os_string(),
         file3.clone().into_os_string(),
@@ -334,7 +322,6 @@ fn subsecond_precision_round_trip() {
     )
     .expect("second copy");
 
-    // Verify final file has exact same timestamp
     let final_mtime = FileTime::from_last_modification_time(&fs::metadata(&file3).expect("file3 meta"));
     assert_eq!(
         final_mtime, original_mtime,
@@ -392,7 +379,6 @@ fn times_flag_on_directory() {
     fs::create_dir(&source_dir).expect("create source dir");
     fs::write(source_dir.join("file.txt"), b"content").expect("write file");
 
-    // Set directory mtime
     let dir_mtime = FileTime::from_unix_time(1_700_000_000, 333_000_000);
     set_file_mtime(&source_dir, dir_mtime).expect("set dir mtime");
 
@@ -428,14 +414,12 @@ fn times_flag_on_symlink() {
     symlink(&target, &source_link).expect("create source symlink");
     symlink(&target, &dest_link).expect("create dest symlink");
 
-    // Set symlink mtime
     let link_atime = FileTime::from_unix_time(1_600_000_000, 444_000_000);
     let link_mtime = FileTime::from_unix_time(1_700_000_000, 555_000_000);
     filetime::set_symlink_file_times(&source_link, link_atime, link_mtime).expect("set link times");
 
     let source_meta = fs::symlink_metadata(&source_link).expect("source link meta");
 
-    // Apply symlink metadata
     metadata::apply_symlink_metadata(&dest_link, &source_meta).expect("apply symlink metadata");
 
     let dest_meta = fs::symlink_metadata(&dest_link).expect("dest link meta");
@@ -461,7 +445,6 @@ fn skip_file_when_timestamps_match() {
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
 
-    // Set identical timestamps
     let mtime = FileTime::from_unix_time(1_700_000_000, 123_456_789);
     set_file_mtime(&source, mtime).expect("set source mtime");
     set_file_mtime(&destination, mtime).expect("set dest mtime");
@@ -494,7 +477,6 @@ fn copy_file_when_timestamps_differ() {
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
 
-    // Set different timestamps
     let source_mtime = FileTime::from_unix_time(1_700_000_100, 0);
     let dest_mtime = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(&source, source_mtime).expect("set source mtime");
@@ -516,7 +498,6 @@ fn copy_file_when_timestamps_differ() {
     // File should be copied because timestamps differ
     assert_eq!(summary.files_copied(), 1, "file should be copied when timestamps differ");
 
-    // Verify destination now has source's timestamp
     let final_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
     assert_eq!(final_mtime, source_mtime);
 }
@@ -577,7 +558,6 @@ fn modify_window_tolerates_small_differences() {
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
 
-    // Set timestamps that differ by 0.5 seconds
     let source_mtime = FileTime::from_unix_time(1_700_000_000, 0);
     let dest_mtime = FileTime::from_unix_time(1_700_000_000, 500_000_000);
     set_file_mtime(&source, source_mtime).expect("set source mtime");
@@ -594,7 +574,7 @@ fn modify_window_tolerates_small_differences() {
             LocalCopyExecution::Apply,
             LocalCopyOptions::default()
                 .times(true)
-                .with_modify_window(ModifyWindow::from_secs(1)),  // 1 second tolerance
+                .with_modify_window(ModifyWindow::from_secs(1)),
         )
         .expect("copy succeeds");
 
@@ -785,7 +765,6 @@ fn times_with_checksum_and_matching_timestamps() {
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
 
-    // Set matching timestamps
     let mtime = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_mtime(&source, mtime).expect("set source mtime");
     set_file_mtime(&destination, mtime).expect("set dest mtime");
@@ -844,7 +823,6 @@ fn times_with_update_flag() {
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
 
-    // Destination should retain its newer timestamp
     let final_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
     assert_eq!(final_mtime, newer_mtime);
 }
@@ -876,10 +854,8 @@ fn times_flag_in_dry_run_mode() {
         )
         .expect("dry run succeeds");
 
-    // Dry run should report file would be copied
     assert_eq!(summary.files_copied(), 1);
 
-    // But destination should be unchanged
     let final_mtime = FileTime::from_last_modification_time(&fs::metadata(&destination).expect("dest meta"));
     assert_eq!(final_mtime, original_dest_mtime, "dry run should not modify destination");
     assert_eq!(fs::read(&destination).expect("read dest"), b"original");
@@ -893,7 +869,6 @@ fn nested_directory_timestamps_preserved() {
     fs::create_dir_all(&nested).expect("create nested dirs");
     fs::write(nested.join("file.txt"), b"nested content").expect("write file");
 
-    // Set specific mtimes for each directory level
     let level2_mtime = FileTime::from_unix_time(1_500_000_000, 0);
     let level1_mtime = FileTime::from_unix_time(1_600_000_000, 0);
     let root_mtime = FileTime::from_unix_time(1_700_000_000, 0);
@@ -915,7 +890,6 @@ fn nested_directory_timestamps_preserved() {
     )
     .expect("copy succeeds");
 
-    // Verify each directory level has correct mtime
     let dest_root_mtime = FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source")).expect("root meta"));
     let dest_level1_mtime = FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source").join("level1")).expect("level1 meta"));
     let dest_level2_mtime = FileTime::from_last_modification_time(&fs::metadata(dest_root.join("source").join("level1/level2")).expect("level2 meta"));
@@ -933,7 +907,6 @@ fn incremental_sync_skips_unchanged_files() {
     fs::create_dir_all(&source_root).expect("create source");
     fs::create_dir_all(&dest_root).expect("create dest");
 
-    // Create files with same content and timestamps
     let mtime = FileTime::from_unix_time(1_700_000_000, 0);
 
     for i in 1..=5 {
@@ -962,7 +935,6 @@ fn incremental_sync_skips_unchanged_files() {
         )
         .expect("copy succeeds");
 
-    // All files should be skipped
     assert_eq!(summary.files_copied(), 0, "unchanged files should be skipped");
     assert_eq!(summary.regular_files_total(), 5);
 }
@@ -978,7 +950,6 @@ fn incremental_sync_updates_changed_files_only() {
     let old_mtime = FileTime::from_unix_time(1_600_000_000, 0);
     let new_mtime = FileTime::from_unix_time(1_700_000_000, 0);
 
-    // Create 3 unchanged files
     for i in 1..=3 {
         let filename = format!("unchanged{i}.txt");
         let content = format!("unchanged content {i}");
@@ -993,7 +964,6 @@ fn incremental_sync_updates_changed_files_only() {
         set_file_mtime(&dest_file, old_mtime).expect("set dest mtime");
     }
 
-    // Create 2 changed files (newer source)
     for i in 1..=2 {
         let filename = format!("changed{i}.txt");
         let source_file = source_root.join(&filename);
@@ -1018,11 +988,9 @@ fn incremental_sync_updates_changed_files_only() {
         )
         .expect("copy succeeds");
 
-    // Only 2 changed files should be copied
     assert_eq!(summary.files_copied(), 2, "only changed files should be copied");
     assert_eq!(summary.regular_files_total(), 5);
 
-    // Verify changed files have new content and timestamp
     for i in 1..=2 {
         let dest_file = dest_root.join(format!("changed{i}.txt"));
         let content = fs::read(&dest_file).expect("read changed file");

--- a/crates/engine/src/local_copy/tests/execute_update.rs
+++ b/crates/engine/src/local_copy/tests/execute_update.rs
@@ -40,11 +40,9 @@ fn update_skips_file_when_destination_is_newer() {
         )
         .expect("copy succeeds");
 
-    // File should be skipped because destination is newer
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
-    // Destination content should be preserved
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"dest content"
@@ -80,11 +78,9 @@ fn update_copies_file_when_destination_is_older() {
         )
         .expect("copy succeeds");
 
-    // File should be copied because destination is older
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_skipped_newer(), 0);
-    // Destination should have new content
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"updated content"
@@ -113,11 +109,9 @@ fn update_copies_file_when_destination_missing() {
         )
         .expect("copy succeeds");
 
-    // File should be copied because destination doesn't exist
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(summary.regular_files_skipped_newer(), 0);
-    // Destination should have content
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"new file content"
@@ -156,7 +150,6 @@ fn update_skips_file_when_mtime_is_equal() {
     // With equal mtime and same size, file is skipped but may not be counted in skipped_newer
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_total(), 1);
-    // Destination content should be preserved
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"dest_content_xyx"
@@ -217,7 +210,6 @@ fn update_recursive_mixed_timestamps() {
     // Only skip_me.txt is counted as skipped_newer; same_time.txt with equal mtime+same size is skipped differently
     assert_eq!(summary.regular_files_skipped_newer(), 1);
 
-    // Verify file contents
     assert_eq!(
         fs::read(dest_root.join("copy_me.txt")).expect("read copy_me"),
         b"newer_source_"
@@ -242,7 +234,6 @@ fn update_nested_directories_selective_copy() {
     let source_root = temp.path().join("source");
     let dest_root = temp.path().join("dest");
 
-    // Create nested directory structure
     fs::create_dir_all(source_root.join("level1/level2")).expect("create source dirs");
     fs::create_dir_all(dest_root.join("level1/level2")).expect("create dest dirs");
 
@@ -280,7 +271,6 @@ fn update_nested_directories_selective_copy() {
     assert_eq!(summary.files_copied(), 2);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
 
-    // Verify content preservation
     assert_eq!(
         fs::read(dest_root.join("root.txt")).expect("read root"),
         b"root dest"
@@ -345,7 +335,6 @@ fn update_handles_epoch_boundary() {
     fs::write(&source, b"source").expect("write source");
     fs::write(&destination, b"dest").expect("write dest");
 
-    // Use times near Unix epoch
     let epoch_time = FileTime::from_unix_time(1, 0);
     let later_time = FileTime::from_unix_time(2, 0);
     set_file_times(&source, epoch_time, epoch_time).expect("set source times");
@@ -364,7 +353,6 @@ fn update_handles_epoch_boundary() {
         )
         .expect("copy succeeds");
 
-    // Destination is newer, should skip
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
 }
@@ -397,7 +385,6 @@ fn update_handles_far_future_timestamp() {
         )
         .expect("copy succeeds");
 
-    // Destination has future timestamp, should skip
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
 }
@@ -430,7 +417,6 @@ fn update_one_second_difference_copies_when_source_newer() {
         )
         .expect("copy succeeds");
 
-    // Source is newer by 1 second, should copy
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.regular_files_skipped_newer(), 0);
     assert_eq!(fs::read(&destination).expect("read"), b"newer");
@@ -460,10 +446,8 @@ fn update_combined_with_times_preserves_mtime() {
         )
         .expect("copy succeeds");
 
-    // File should be copied (no dest exists)
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify mtime is preserved
     let dest_mtime = FileTime::from_last_modification_time(
         &fs::metadata(&destination).expect("dest metadata")
     );
@@ -524,7 +508,6 @@ fn update_without_flag_copies_even_when_dest_newer() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // WITHOUT update flag
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
@@ -565,9 +548,7 @@ fn update_dry_run_reports_but_preserves_files() {
         )
         .expect("dry run succeeds");
 
-    // Dry run should report that it would copy
     assert_eq!(summary.files_copied(), 1);
-    // But destination should remain unchanged
     assert_eq!(fs::read(&destination).expect("read"), b"older dest");
 }
 
@@ -598,10 +579,8 @@ fn update_dry_run_reports_skipped_files() {
         )
         .expect("dry run succeeds");
 
-    // Dry run should report that file would be skipped
     assert_eq!(summary.files_copied(), 0);
     assert_eq!(summary.regular_files_skipped_newer(), 1);
-    // Destination unchanged
     assert_eq!(fs::read(&destination).expect("read"), b"newer dest");
 }
 
@@ -736,7 +715,6 @@ fn update_matches_upstream_rsync_semantics() {
     assert_eq!(summary.regular_files_skipped_newer(), 1, "should skip case1 (newer)");
     // Note: case2 with equal mtime + same size is skipped, but may not increment skipped_newer counter
 
-    // Verify specific file states
     assert_eq!(
         fs::read(dest_root.join("case1.txt")).expect("case1"),
         b"destin1",

--- a/crates/engine/src/local_copy/tests/execute_usermap_groupmap.rs
+++ b/crates/engine/src/local_copy/tests/execute_usermap_groupmap.rs
@@ -8,16 +8,6 @@
 // - Pattern mappings: test*:backup
 // - Range mappings: 1000-2000:3000
 // - Multiple mappings: 1000:2000,*:nobody
-//
-// Test cases covered:
-// 1. User mapping with numeric IDs (source_uid:dest_uid)
-// 2. Group mapping with numeric IDs (source_gid:dest_gid)
-// 3. Multiple mappings specified together
-// 4. Wildcard mappings (*:nobody)
-// 5. Pattern-based mappings with wildcards
-// 6. Range-based mappings
-// 7. Combining mappings with other metadata preservation flags
-// 8. Error cases and edge conditions
 
 #[cfg(unix)]
 #[test]
@@ -35,7 +25,6 @@ fn usermap_remaps_numeric_uid() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"content").expect("write source");
 
-    // Set source file to UID 1000
     let source_uid = 1000;
     chownat(
         rustix::fs::CWD,
@@ -46,7 +35,6 @@ fn usermap_remaps_numeric_uid() {
     )
     .expect("set source uid");
 
-    // Map UID 1000 -> 2000
     let user_mapping = ::metadata::UserMapping::parse("1000:2000").expect("parse usermap");
 
     let operands = vec![
@@ -66,7 +54,6 @@ fn usermap_remaps_numeric_uid() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify destination has mapped UID 2000
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.uid(), 2000);
 }
@@ -87,7 +74,6 @@ fn usermap_wildcard_maps_all_users() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"content").expect("write source");
 
-    // Set source file to UID 5000
     let source_uid = 5000;
     chownat(
         rustix::fs::CWD,
@@ -98,7 +84,6 @@ fn usermap_wildcard_maps_all_users() {
     )
     .expect("set source uid");
 
-    // Map all users to UID 9999 using wildcard
     let user_mapping = ::metadata::UserMapping::parse("*:9999").expect("parse usermap");
 
     let operands = vec![
@@ -118,7 +103,6 @@ fn usermap_wildcard_maps_all_users() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify destination has mapped UID 9999
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.uid(), 9999);
 }
@@ -139,7 +123,6 @@ fn usermap_multiple_rules_first_match_wins() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"content").expect("write source");
 
-    // Set source file to UID 1000
     let source_uid = 1000;
     chownat(
         rustix::fs::CWD,
@@ -202,7 +185,6 @@ fn usermap_range_mapping() {
     )
     .expect("set source uid");
 
-    // Map range 1000-2000 -> 3000
     let user_mapping = ::metadata::UserMapping::parse("1000-2000:3000").expect("parse usermap");
 
     let operands = vec![
@@ -222,7 +204,6 @@ fn usermap_range_mapping() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify destination has mapped UID 3000
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.uid(), 3000);
 }
@@ -243,7 +224,6 @@ fn usermap_no_match_preserves_original_uid() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"content").expect("write source");
 
-    // Set source file to UID 5000
     let source_uid = 5000;
     chownat(
         rustix::fs::CWD,
@@ -274,7 +254,6 @@ fn usermap_no_match_preserves_original_uid() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify destination preserves original UID 5000
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.uid(), 5000);
 }
@@ -295,7 +274,6 @@ fn groupmap_remaps_numeric_gid() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"content").expect("write source");
 
-    // Set source file to GID 1000
     let source_gid = 1000;
     chownat(
         rustix::fs::CWD,
@@ -306,7 +284,6 @@ fn groupmap_remaps_numeric_gid() {
     )
     .expect("set source gid");
 
-    // Map GID 1000 -> 2000
     let group_mapping = ::metadata::GroupMapping::parse("1000:2000").expect("parse groupmap");
 
     let operands = vec![
@@ -326,7 +303,6 @@ fn groupmap_remaps_numeric_gid() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify destination has mapped GID 2000
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.gid(), 2000);
 }
@@ -347,7 +323,6 @@ fn groupmap_wildcard_maps_all_groups() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"content").expect("write source");
 
-    // Set source file to GID 5000
     let source_gid = 5000;
     chownat(
         rustix::fs::CWD,
@@ -358,7 +333,6 @@ fn groupmap_wildcard_maps_all_groups() {
     )
     .expect("set source gid");
 
-    // Map all groups to GID 9999 using wildcard
     let group_mapping = ::metadata::GroupMapping::parse("*:9999").expect("parse groupmap");
 
     let operands = vec![
@@ -378,7 +352,6 @@ fn groupmap_wildcard_maps_all_groups() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify destination has mapped GID 9999
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.gid(), 9999);
 }
@@ -402,7 +375,6 @@ fn groupmap_multiple_rules() {
     fs::write(&source1, b"content1").expect("write source1");
     fs::write(&source2, b"content2").expect("write source2");
 
-    // Set different GIDs for the source files
     chownat(
         rustix::fs::CWD,
         &source1,
@@ -421,11 +393,9 @@ fn groupmap_multiple_rules() {
     )
     .expect("set source2 gid");
 
-    // Map with multiple rules: 1000:2000, 3000:4000, *:9999
     let group_mapping =
         ::metadata::GroupMapping::parse("1000:2000,3000:4000,*:9999").expect("parse groupmap");
 
-    // Copy both files
     let operands1 = vec![
         source1.into_os_string(),
         dest_dir.join("file1.txt").into_os_string(),
@@ -454,7 +424,6 @@ fn groupmap_multiple_rules() {
         )
         .expect("copy2 succeeds");
 
-    // Verify destinations have correct mapped GIDs
     let dest1_metadata = fs::metadata(dest_dir.join("file1.txt")).expect("dest1 metadata");
     assert_eq!(dest1_metadata.gid(), 2000);
 
@@ -489,7 +458,6 @@ fn groupmap_range_mapping() {
     )
     .expect("set source gid");
 
-    // Map range 1000-2000 -> 3000
     let group_mapping = ::metadata::GroupMapping::parse("1000-2000:3000").expect("parse groupmap");
 
     let operands = vec![
@@ -509,7 +477,6 @@ fn groupmap_range_mapping() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify destination has mapped GID 3000
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.gid(), 3000);
 }
@@ -530,7 +497,6 @@ fn usermap_and_groupmap_work_together() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"content").expect("write source");
 
-    // Set source file to UID 1000, GID 1000
     chownat(
         rustix::fs::CWD,
         &source,
@@ -540,7 +506,6 @@ fn usermap_and_groupmap_work_together() {
     )
     .expect("set source ownership");
 
-    // Map UID 1000 -> 2000 and GID 1000 -> 3000
     let user_mapping = ::metadata::UserMapping::parse("1000:2000").expect("parse usermap");
     let group_mapping = ::metadata::GroupMapping::parse("1000:3000").expect("parse groupmap");
 
@@ -563,7 +528,6 @@ fn usermap_and_groupmap_work_together() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify both UID and GID are mapped correctly
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.uid(), 2000);
     assert_eq!(dest_metadata.gid(), 3000);
@@ -595,7 +559,6 @@ fn usermap_and_groupmap_with_wildcards() {
     )
     .expect("set source ownership");
 
-    // Map all users to 9998 and all groups to 9999
     let user_mapping = ::metadata::UserMapping::parse("*:9998").expect("parse usermap");
     let group_mapping = ::metadata::GroupMapping::parse("*:9999").expect("parse groupmap");
 
@@ -618,7 +581,6 @@ fn usermap_and_groupmap_with_wildcards() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify both UID and GID are mapped to wildcard values
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.uid(), 9998);
     assert_eq!(dest_metadata.gid(), 9999);
@@ -640,7 +602,6 @@ fn usermap_requires_owner_preservation_flag() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"content").expect("write source");
 
-    // Set source file to UID 1000
     chownat(
         rustix::fs::CWD,
         &source,
@@ -693,7 +654,6 @@ fn groupmap_requires_group_preservation_flag() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"content").expect("write source");
 
-    // Set source file to GID 1000
     chownat(
         rustix::fs::CWD,
         &source,
@@ -746,7 +706,6 @@ fn usermap_applies_to_directory_tree() {
     let dest_dir = temp.path().join("dest");
     fs::create_dir_all(&source_dir).expect("create source");
 
-    // Create a directory structure
     let file1 = source_dir.join("file1.txt");
     let subdir = source_dir.join("subdir");
     fs::create_dir_all(&subdir).expect("create subdir");
@@ -754,7 +713,6 @@ fn usermap_applies_to_directory_tree() {
     fs::write(&file1, b"content1").expect("write file1");
     fs::write(&file2, b"content2").expect("write file2");
 
-    // Set all files to UID 1000
     for path in [&source_dir, &file1, &subdir, &file2] {
         chownat(
             rustix::fs::CWD,
@@ -766,7 +724,6 @@ fn usermap_applies_to_directory_tree() {
         .expect("set ownership");
     }
 
-    // Map UID 1000 -> 2000
     let user_mapping = ::metadata::UserMapping::parse("1000:2000").expect("parse usermap");
 
     let operands = vec![
@@ -787,7 +744,6 @@ fn usermap_applies_to_directory_tree() {
 
     assert!(summary.files_copied() >= 2); // At least the two files
 
-    // Verify all files have mapped UID 2000
     let dest_file1 = dest_dir.join("source").join("file1.txt");
     let dest_file2 = dest_dir.join("source").join("subdir").join("file2.txt");
     let dest_subdir = dest_dir.join("source").join("subdir");
@@ -813,7 +769,6 @@ fn groupmap_applies_to_directory_tree() {
     let dest_dir = temp.path().join("dest");
     fs::create_dir_all(&source_dir).expect("create source");
 
-    // Create a directory structure
     let file1 = source_dir.join("file1.txt");
     let subdir = source_dir.join("subdir");
     fs::create_dir_all(&subdir).expect("create subdir");
@@ -821,7 +776,6 @@ fn groupmap_applies_to_directory_tree() {
     fs::write(&file1, b"content1").expect("write file1");
     fs::write(&file2, b"content2").expect("write file2");
 
-    // Set all files to GID 1000
     for path in [&source_dir, &file1, &subdir, &file2] {
         chownat(
             rustix::fs::CWD,
@@ -833,7 +787,6 @@ fn groupmap_applies_to_directory_tree() {
         .expect("set ownership");
     }
 
-    // Map GID 1000 -> 3000
     let group_mapping = ::metadata::GroupMapping::parse("1000:3000").expect("parse groupmap");
 
     let operands = vec![
@@ -854,7 +807,6 @@ fn groupmap_applies_to_directory_tree() {
 
     assert!(summary.files_copied() >= 2); // At least the two files
 
-    // Verify all files have mapped GID 3000
     let dest_file1 = dest_dir.join("source").join("file1.txt");
     let dest_file2 = dest_dir.join("source").join("subdir").join("file2.txt");
     let dest_subdir = dest_dir.join("source").join("subdir");
@@ -881,7 +833,6 @@ fn usermap_works_with_permissions_and_times() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"content").expect("write source");
 
-    // Set source metadata
     chownat(
         rustix::fs::CWD,
         &source,
@@ -895,7 +846,6 @@ fn usermap_works_with_permissions_and_times() {
     let mtime = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, mtime, mtime).expect("set times");
 
-    // Map UID and preserve permissions and times
     let user_mapping = ::metadata::UserMapping::parse("1000:2000").expect("parse usermap");
 
     let operands = vec![
@@ -917,7 +867,6 @@ fn usermap_works_with_permissions_and_times() {
 
     assert_eq!(summary.files_copied(), 1);
 
-    // Verify all metadata is preserved correctly
     let dest_metadata = fs::metadata(&destination).expect("dest metadata");
     assert_eq!(dest_metadata.uid(), 2000);
     assert_eq!(dest_metadata.permissions().mode() & 0o777, 0o640);

--- a/crates/engine/src/local_copy/tests/execute_whole_file.rs
+++ b/crates/engine/src/local_copy/tests/execute_whole_file.rs
@@ -5,7 +5,6 @@ fn execute_whole_file_transfers_complete_file_without_delta() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Create source file with known content
     let source_content = b"complete file transfer without delta matching";
     fs::write(&source, source_content).expect("write source");
 
@@ -27,7 +26,6 @@ fn execute_whole_file_transfers_complete_file_without_delta() {
         )
         .expect("whole file copy succeeds");
 
-    // Verify complete file transfer
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.bytes_copied(), source_content.len() as u64);
     assert_eq!(summary.matched_bytes(), 0, "whole file should not match any blocks");
@@ -70,7 +68,6 @@ fn execute_whole_file_ignores_basis_file() {
         )
         .expect("whole file copy succeeds");
 
-    // Verify that no delta matching occurred despite common prefix
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.bytes_copied(), source_content.len() as u64);
     assert_eq!(summary.matched_bytes(), 0, "basis file should be ignored");
@@ -90,7 +87,6 @@ fn execute_whole_file_transfers_large_file_completely() {
     let large_content: Vec<u8> = (0..=255).cycle().take(1024 * 1024).collect();
     fs::write(&source, &large_content).expect("write large source");
 
-    // Create destination with partially matching content
     let partial_content: Vec<u8> = (0..=255).cycle().take(512 * 1024).collect();
     fs::write(&destination, &partial_content).expect("write destination");
     set_file_mtime(&destination, FileTime::from_unix_time(1, 0)).expect("set dest mtime");
@@ -109,7 +105,6 @@ fn execute_whole_file_transfers_large_file_completely() {
         )
         .expect("large file copy succeeds");
 
-    // Verify complete transfer of large file
     assert_eq!(summary.files_copied(), 1);
     assert_eq!(summary.bytes_copied(), 1024 * 1024);
     assert_eq!(summary.matched_bytes(), 0, "large file should not use basis");
@@ -127,7 +122,6 @@ fn execute_whole_file_works_for_new_files() {
 
     let content = b"new file content";
     fs::write(&source, content).expect("write source");
-    // Destination does not exist
 
     let operands = vec![
         source.into_os_string(),
@@ -157,7 +151,6 @@ fn execute_whole_file_in_recursive_directory_copy() {
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(&dest_root).expect("create dest root");
 
-    // Create multiple files in source
     fs::write(source_root.join("file1.txt"), b"first file").expect("write file1");
     fs::write(source_root.join("file2.txt"), b"second file").expect("write file2");
 
@@ -165,7 +158,6 @@ fn execute_whole_file_in_recursive_directory_copy() {
     fs::create_dir_all(&subdir).expect("create subdir");
     fs::write(subdir.join("file3.txt"), b"third file").expect("write file3");
 
-    // Create corresponding destination directory structure
     let dest_source = dest_root.join("source");
     fs::create_dir_all(&dest_source).expect("create dest source dir");
     fs::write(dest_source.join("file1.txt"), b"old content 1").expect("write dest file1");
@@ -184,11 +176,9 @@ fn execute_whole_file_in_recursive_directory_copy() {
         )
         .expect("recursive whole file copy succeeds");
 
-    // All files should be transferred completely
     assert!(summary.files_copied() >= 3);
     assert_eq!(summary.matched_bytes(), 0, "recursive copy should not use delta");
 
-    // Verify content
     assert_eq!(
         fs::read(dest_root.join("source").join("file1.txt")).expect("read file1"),
         b"first file"
@@ -241,7 +231,6 @@ fn execute_no_whole_file_forces_delta_transfer() {
         )
         .expect("delta transfer succeeds");
 
-    // Verify delta transfer was used
     assert_eq!(summary.files_copied(), 1);
     assert!(
         summary.matched_bytes() > 0,
@@ -465,7 +454,6 @@ fn execute_whole_file_with_checksum_comparison() {
         )
         .expect("checksum copy succeeds");
 
-    // File should be skipped because content is identical
     assert_eq!(
         summary.files_copied(),
         0,
@@ -505,11 +493,9 @@ fn execute_whole_file_empty_file() {
 fn execute_whole_file_vs_delta_transfer_comparison() {
     let temp = tempdir().expect("tempdir");
 
-    // Setup for whole file mode
     let source_whole = temp.path().join("source_whole.bin");
     let dest_whole = temp.path().join("dest_whole.bin");
 
-    // Setup for delta mode
     let source_delta = temp.path().join("source_delta.bin");
     let dest_delta = temp.path().join("dest_delta.bin");
 
@@ -531,7 +517,6 @@ fn execute_whole_file_vs_delta_transfer_comparison() {
     set_file_mtime(&source_whole, FileTime::from_unix_time(2, 0)).expect("set source whole mtime");
     set_file_mtime(&source_delta, FileTime::from_unix_time(2, 0)).expect("set source delta mtime");
 
-    // Execute with whole file mode
     let operands_whole = vec![
         source_whole.into_os_string(),
         dest_whole.clone().into_os_string(),
@@ -544,7 +529,6 @@ fn execute_whole_file_vs_delta_transfer_comparison() {
         )
         .expect("whole file copy succeeds");
 
-    // Execute with delta mode
     let operands_delta = vec![
         source_delta.into_os_string(),
         dest_delta.clone().into_os_string(),
@@ -557,14 +541,12 @@ fn execute_whole_file_vs_delta_transfer_comparison() {
         )
         .expect("delta copy succeeds");
 
-    // Compare results
     assert_eq!(summary_whole.matched_bytes(), 0, "whole file should not match");
     assert_eq!(summary_whole.bytes_copied(), source_len, "whole file copies everything");
 
     assert!(summary_delta.matched_bytes() > 0, "delta should match common blocks");
     assert!(summary_delta.bytes_copied() < source_len, "delta copies less data");
 
-    // Both should produce identical results
     assert_eq!(
         fs::read(&dest_whole).expect("read dest whole"),
         fs::read(&dest_delta).expect("read dest delta")
@@ -675,7 +657,6 @@ fn whole_file_option_none_preserves_auto_detection() {
     let options = LocalCopyOptions::default();
     assert!(options.whole_file_raw().is_none());
 
-    // Setting to None explicitly should keep auto mode
     let options = options.whole_file_option(None);
     assert!(options.whole_file_raw().is_none());
     assert!(options.whole_file_enabled());
@@ -697,11 +678,9 @@ fn whole_file_option_some_false_forces_delta() {
 
 #[test]
 fn whole_file_auto_restores_none() {
-    // Start with explicitly set whole_file
     let options = LocalCopyOptions::default().whole_file(true);
     assert_eq!(options.whole_file_raw(), Some(true));
 
-    // Restore auto mode
     let options = options.whole_file_auto();
     assert!(options.whole_file_raw().is_none());
     assert!(options.whole_file_enabled());
@@ -716,7 +695,6 @@ fn whole_file_setter_overrides_auto() {
     let options = options.whole_file(true);
     assert_eq!(options.whole_file_raw(), Some(true));
 
-    // .whole_file(false) should set Some(false)
     let options = options.whole_file(false);
     assert_eq!(options.whole_file_raw(), Some(false));
     assert!(!options.whole_file_enabled());
@@ -724,7 +702,6 @@ fn whole_file_setter_overrides_auto() {
 
 #[test]
 fn execute_whole_file_auto_mode_copies_correctly() {
-    // Verify that auto mode (None) produces correct file content
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("src.bin");
     let destination = temp.path().join("dst.bin");
@@ -738,7 +715,6 @@ fn execute_whole_file_auto_mode_copies_correctly() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Use default (auto) mode
     let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("auto mode copy succeeds");

--- a/crates/engine/src/local_copy/tests/execute_xattrs.rs
+++ b/crates/engine/src/local_copy/tests/execute_xattrs.rs
@@ -86,7 +86,6 @@ mod xattr_tests {
         assert_eq!(summary.files_copied(), 1);
         assert_eq!(fs::read(&destination).expect("read dest"), b"no xattr copy");
 
-        // Without xattrs flag, no xattrs should be copied
         let dest_xattr = xattr::get(&destination, "user.test_attr").expect("read xattr");
         assert!(dest_xattr.is_none(), "xattr should not be copied without --xattrs");
     }
@@ -104,7 +103,6 @@ mod xattr_tests {
             return;
         }
 
-        // Set multiple xattrs with different types of values
         xattr::set(&source, "user.attr1", b"value1").expect("set attr1");
         xattr::set(&source, "user.attr2", b"value2").expect("set attr2");
         xattr::set(&source, "user.attr3", b"value3").expect("set attr3");
@@ -126,7 +124,6 @@ mod xattr_tests {
 
         assert_eq!(summary.files_copied(), 1);
 
-        // Verify all xattrs were copied
         assert_eq!(
             xattr::get(&destination, "user.attr1").expect("read").expect("present"),
             b"value1"
@@ -161,7 +158,6 @@ mod xattr_tests {
             return;
         }
 
-        // Set 20 xattrs
         for i in 0..20 {
             let name = format!("user.attr_{i:02}");
             let value = format!("value_{i:02}");
@@ -183,7 +179,6 @@ mod xattr_tests {
 
         assert_eq!(summary.files_copied(), 1);
 
-        // Verify all 20 xattrs were copied
         for i in 0..20 {
             let name = format!("user.attr_{i:02}");
             let expected_value = format!("value_{i:02}");
@@ -207,7 +202,6 @@ mod xattr_tests {
             return;
         }
 
-        // Create a large xattr value (4KB)
         let large_value: Vec<u8> = (0..4096).map(|i| (i % 256) as u8).collect();
         if xattr::set(&source, "user.large_data", &large_value).is_err() {
             eprintln!("filesystem does not support large xattr values, skipping test");
@@ -284,7 +278,6 @@ mod xattr_tests {
             return;
         }
 
-        // Empty xattr value
         xattr::set(&source, "user.empty", b"").expect("set empty xattr");
 
         let operands = vec![
@@ -357,7 +350,6 @@ mod xattr_tests {
             return;
         }
 
-        // Set xattrs at different directory levels
         xattr::set(&source_root, "user.root_attr", b"root").expect("set root xattr");
         xattr::set(source_root.join("level1"), "user.level1_attr", b"level1").expect("set level1 xattr");
         xattr::set(&nested, "user.level2_attr", b"level2").expect("set level2 xattr");
@@ -379,7 +371,6 @@ mod xattr_tests {
         assert_eq!(summary.files_copied(), 1);
         assert!(summary.directories_created() >= 2);
 
-        // Verify xattrs at all levels
         assert_eq!(
             xattr::get(dest_root.join("source"), "user.root_attr")
                 .expect("read")
@@ -412,9 +403,7 @@ mod xattr_tests {
             return;
         }
 
-        // Set xattr on directory
         xattr::set(&source_root, "user.dir_metadata", b"dir_value").expect("set dir xattr");
-        // Set xattr on file
         xattr::set(source_root.join("file.txt"), "user.file_metadata", b"file_value")
             .expect("set file xattr");
 
@@ -434,14 +423,12 @@ mod xattr_tests {
 
         assert_eq!(summary.files_copied(), 1);
 
-        // Verify directory xattr
         assert_eq!(
             xattr::get(dest_root.join("source"), "user.dir_metadata")
                 .expect("read")
                 .expect("present"),
             b"dir_value"
         );
-        // Verify file xattr
         assert_eq!(
             xattr::get(dest_root.join("source").join("file.txt"), "user.file_metadata")
                 .expect("read")
@@ -482,7 +469,6 @@ mod xattr_tests {
             )
             .expect("copy succeeds");
 
-        // Verify xattr was updated
         let copied = xattr::get(&destination, "user.version")
             .expect("read xattr")
             .expect("xattr present");
@@ -521,14 +507,12 @@ mod xattr_tests {
             )
             .expect("copy succeeds");
 
-        // Verify keep xattr was synced
         assert_eq!(
             xattr::get(&destination, "user.keep")
                 .expect("read")
                 .expect("present"),
             b"keep_value"
         );
-        // Verify extra xattr was removed
         assert!(
             xattr::get(&destination, "user.extra")
                 .expect("read")
@@ -569,7 +553,6 @@ mod xattr_tests {
             )
             .expect("copy succeeds");
 
-        // Verify both xattrs are present
         assert_eq!(
             xattr::get(&destination, "user.existing")
                 .expect("read")
@@ -622,14 +605,12 @@ mod xattr_tests {
             .execute_with_options(LocalCopyExecution::Apply, options)
             .expect("copy succeeds");
 
-        // Verify included attr was copied
         assert_eq!(
             xattr::get(&destination, "user.keep")
                 .expect("read")
                 .expect("present"),
             b"keep_value"
         );
-        // Verify excluded attr is absent
         assert!(
             xattr::get(&destination, "user.skip")
                 .expect("read")
@@ -677,7 +658,6 @@ mod xattr_tests {
             .execute_with_options(LocalCopyExecution::Apply, options)
             .expect("copy succeeds");
 
-        // Verify included attrs were copied
         assert_eq!(
             xattr::get(&destination, "user.keep_one")
                 .expect("read")
@@ -690,7 +670,6 @@ mod xattr_tests {
                 .expect("present"),
             b"two"
         );
-        // Verify excluded attr is absent
         assert!(
             xattr::get(&destination, "user.skip_this")
                 .expect("read")
@@ -728,7 +707,6 @@ mod xattr_tests {
             .expect("dry run succeeds");
 
         assert_eq!(summary.files_copied(), 1);
-        // Destination should not exist
         assert!(!destination.exists(), "dry run should not create file");
     }
 
@@ -763,7 +741,6 @@ mod xattr_tests {
             )
             .expect("copy succeeds");
 
-        // Verify all special-named xattrs were copied
         assert_eq!(
             xattr::get(&destination, "user.with.dots")
                 .expect("read")
@@ -796,7 +773,6 @@ mod xattr_tests {
             return;
         }
 
-        // UTF-8 content in xattr value
         let utf8_value = "Hello, 世界! 🌍 Привет!";
         xattr::set(&source, "user.utf8_value", utf8_value.as_bytes()).expect("set utf8 xattr");
 
@@ -849,9 +825,7 @@ mod xattr_tests {
 
         assert_eq!(summary.files_copied(), 1);
 
-        // Verify file content was updated
         assert_eq!(fs::read(&destination).expect("read dest"), b"updated content");
-        // Verify xattr was preserved
         let copied = xattr::get(&destination, "user.preserved")
             .expect("read xattr")
             .expect("xattr present");
@@ -896,7 +870,6 @@ mod xattr_tests {
 
         assert_eq!(summary.files_copied(), 3);
 
-        // Verify each file has its own xattr
         assert_eq!(
             xattr::get(dest_root.join("file1.txt"), "user.file1_attr")
                 .expect("read")
@@ -957,7 +930,6 @@ mod xattr_tests {
 
         assert!(summary.files_copied() >= 1);
 
-        // Verify xattr on the copied real file
         let copied = xattr::get(dest_root.join("real_file.txt"), "user.real_file_attr")
             .expect("read xattr")
             .expect("xattr present");

--- a/crates/engine/src/local_copy/tests/execute_zero_length.rs
+++ b/crates/engine/src/local_copy/tests/execute_zero_length.rs
@@ -296,7 +296,6 @@ fn execute_multiple_empty_files_recursive() {
 
     fs::create_dir_all(&source_root).expect("create source root");
 
-    // Create multiple empty files
     fs::write(source_root.join("empty1.txt"), b"").expect("write empty1");
     fs::write(source_root.join("empty2.txt"), b"").expect("write empty2");
     fs::write(source_root.join("empty3.txt"), b"").expect("write empty3");
@@ -352,11 +351,9 @@ fn execute_mixed_empty_and_nonempty_files() {
 
     assert_eq!(summary.files_copied(), 4, "all files should be copied");
 
-    // Verify empty files
     assert_eq!(fs::read(dest_root.join("empty.txt")).expect("read"), b"");
     assert_eq!(fs::read(dest_root.join("another_empty.txt")).expect("read"), b"");
 
-    // Verify non-empty files
     assert_eq!(fs::read(dest_root.join("content.txt")).expect("read"), b"has content");
     assert_eq!(fs::read(dest_root.join("more_content.txt")).expect("read"), b"more data");
 }

--- a/crates/engine/src/local_copy/tests/executor_file_comparison.rs
+++ b/crates/engine/src/local_copy/tests/executor_file_comparison.rs
@@ -41,7 +41,6 @@ mod file_comparison_tests {
         fs::write(&source, b"content").expect("write source");
         fs::write(&dest, b"content").expect("write dest");
 
-        // Set same mtime
         let source_meta = fs::metadata(&source).expect("source metadata");
         let mtime = FileTime::from_system_time(source_meta.modified().expect("source mtime"));
         set_file_mtime(&dest, mtime).expect("set dest mtime");
@@ -77,7 +76,6 @@ mod file_comparison_tests {
         let source_meta = fs::metadata(&source).expect("source metadata");
         let dest_meta = fs::metadata(&dest).expect("dest metadata");
 
-        // Use a large modify window
         let comparison = CopyComparison {
             source_path: &source,
             source: &source_meta,
@@ -87,7 +85,7 @@ mod file_comparison_tests {
             ignore_times: false,
             checksum: false,
             checksum_algorithm: SignatureAlgorithm::Md4,
-            modify_window: ModifyWindow::from_secs(3600), // 1 hour window
+            modify_window: ModifyWindow::from_secs(3600),
             prefetched_match: None,
         };
 
@@ -233,7 +231,7 @@ mod file_comparison_tests {
             checksum: true,
             checksum_algorithm: SignatureAlgorithm::Md4,
             modify_window: ModifyWindow::ZERO,
-            prefetched_match: Some(true), // Prefetched indicates match
+            prefetched_match: Some(true),
         };
 
         assert!(should_skip_copy(comparison));
@@ -261,7 +259,7 @@ mod file_comparison_tests {
             checksum: true,
             checksum_algorithm: SignatureAlgorithm::Md4,
             modify_window: ModifyWindow::ZERO,
-            prefetched_match: Some(false), // Prefetched indicates no match
+            prefetched_match: Some(false),
         };
 
         assert!(!should_skip_copy(comparison));

--- a/crates/engine/src/local_copy/tests/itemize_changes.rs
+++ b/crates/engine/src/local_copy/tests/itemize_changes.rs
@@ -64,7 +64,6 @@ fn itemize_new_file_format_matches_upstream() {
     assert_eq!(records.len(), 1);
     let record = &records[0];
 
-    // Verify record indicates creation
     assert!(record.was_created());
     assert_eq!(record.action(), &LocalCopyAction::DataCopied);
 }
@@ -75,10 +74,7 @@ fn itemize_modified_file_shows_change_indicators() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Create destination with old content
     fs::write(&destination, b"old").expect("write dest");
-
-    // Create source with new content
     fs::write(&source, b"new content").expect("write source");
 
     let operands = vec![
@@ -326,7 +322,6 @@ fn itemize_multiple_changes_shows_all_indicators() {
     let record = &records[0];
 
     let change_set = record.change_set();
-    // All these should have changed
     assert!(change_set.checksum_changed(), "checksum should change");
     assert!(change_set.size_changed(), "size should change");
     assert_eq!(change_set.time_change(), Some(TimeChange::Modified), "time should change");
@@ -364,7 +359,6 @@ fn itemize_new_directory_shows_creation() {
     // Should have records for directory and file
     assert!(!records.is_empty());
 
-    // Find the directory record
     let dir_record = records.iter()
         .find(|r| r.action() == &LocalCopyAction::DirectoryCreated);
     assert!(dir_record.is_some(), "should have directory creation record");
@@ -693,7 +687,6 @@ fn itemize_size_change_detected_correctly() {
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Create files with different sizes
     fs::write(&destination, b"short").expect("write dest");
     fs::write(&source, b"this is a much longer content").expect("write source");
 

--- a/crates/engine/src/local_copy/tests/list_only.rs
+++ b/crates/engine/src/local_copy/tests/list_only.rs
@@ -47,12 +47,8 @@ fn list_only_enumerates_files_without_transfer() {
         )
         .expect("dry run succeeds");
 
-    // In dry run mode, files_copied() shows what would be copied, not what was actually copied
-    // The important check is that destination remains empty
-    // assert_eq!(summary.files_copied(), 0);
-    // assert_eq!(summary.bytes_copied(), 0);
-
-    // Verify files were enumerated
+    // In dry run mode files_copied() reports what would be copied, not what was
+    // actually copied; the meaningful check is that files were enumerated.
     assert!(!collector.records.is_empty());
 
     let paths: Vec<_> = collector.records

--- a/crates/engine/src/local_copy/tests/list_only.rs
+++ b/crates/engine/src/local_copy/tests/list_only.rs
@@ -1,4 +1,3 @@
-// Helper struct to collect records during execution
 struct RecordCollector {
     records: Vec<LocalCopyRecord>,
 }
@@ -60,7 +59,6 @@ fn list_only_enumerates_files_without_transfer() {
     assert!(paths.iter().any(|p| p == "file2.txt"));
     assert!(paths.iter().any(|p| p.contains("subdir")));
 
-    // Verify destination is empty
     let dest_entries: Vec<_> = fs::read_dir(&dest)
         .expect("read dest")
         .collect();
@@ -111,15 +109,12 @@ fn list_only_provides_file_metadata() {
 
     let metadata = file_record.metadata().expect("metadata present");
 
-    // Verify size is correct
     assert_eq!(metadata.len(), 1234);
 
-    // Verify modified time is present
     assert!(metadata.modified().is_some());
 
     #[cfg(unix)]
     {
-        // Verify permissions are captured
         assert!(metadata.mode().is_some());
         let mode = metadata.mode().unwrap();
         assert_eq!(mode & 0o777, 0o644);
@@ -171,14 +166,12 @@ fn list_only_shows_symlinks_correctly() {
         let metadata = link_record.metadata().expect("metadata present");
         assert_eq!(metadata.kind(), LocalCopyFileKind::Symlink);
 
-        // Verify symlink target is captured
         assert!(metadata.symlink_target().is_some());
         assert_eq!(
             metadata.symlink_target().unwrap().to_string_lossy(),
             "target.txt"
         );
 
-        // Verify destination is empty
         assert!(!dest.join("link.txt").exists());
     }
 }
@@ -231,18 +224,15 @@ fn list_only_shows_directories_with_metadata() {
     let metadata = dir_record.metadata().expect("metadata present");
     assert_eq!(metadata.kind(), LocalCopyFileKind::Directory);
 
-    // Verify timestamp is captured
     assert!(metadata.modified().is_some());
 
     #[cfg(unix)]
     {
-        // Verify directory permissions
         assert!(metadata.mode().is_some());
         let mode = metadata.mode().unwrap();
         assert_eq!(mode & 0o777, 0o755);
     }
 
-    // Verify directory was not actually created
     assert!(!dest.join("testdir").exists());
 }
 
@@ -265,7 +255,6 @@ fn list_only_respects_filter_rules() {
     let operands = vec![source_operand, dest.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Filter out *.log files
     let filters = FilterSet::from_rules([FilterRule::exclude("*.log")])
         .expect("create filter");
 
@@ -307,7 +296,6 @@ fn list_only_with_include_filter() {
     let operands = vec![source_operand, dest.into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Include only *.txt files
     let filters = FilterSet::from_rules([
         FilterRule::include("*.txt"),
         FilterRule::exclude("*"),
@@ -382,7 +370,6 @@ fn list_only_shows_special_permission_bits() {
         )
         .expect("dry run succeeds");
 
-        // Verify setuid bit
         let setuid_record = collector.records
             .iter()
             .find(|r| r.relative_path().to_string_lossy() == "setuid")
@@ -390,7 +377,6 @@ fn list_only_shows_special_permission_bits() {
         let setuid_mode = setuid_record.metadata().unwrap().mode().unwrap();
         assert_ne!(setuid_mode & 0o4000, 0, "setuid bit should be set");
 
-        // Verify setgid bit
         let setgid_record = collector.records
             .iter()
             .find(|r| r.relative_path().to_string_lossy() == "setgid")
@@ -398,7 +384,6 @@ fn list_only_shows_special_permission_bits() {
         let setgid_mode = setgid_record.metadata().unwrap().mode().unwrap();
         assert_ne!(setgid_mode & 0o2000, 0, "setgid bit should be set");
 
-        // Verify sticky bit
         let sticky_record = collector.records
             .iter()
             .find(|r| r.relative_path().to_string_lossy() == "sticky")
@@ -488,7 +473,6 @@ fn list_only_with_recursive_shows_nested_structure() {
     assert!(paths.iter().any(|p| p.contains("file1.txt")));
     assert!(paths.iter().any(|p| p.contains("file2.txt")));
 
-    // Verify nested files were not transferred
     assert!(!dest.join("level1").join("file1.txt").exists());
     assert!(!dest.join("level1").join("level2").join("file2.txt").exists());
 }
@@ -528,7 +512,6 @@ fn list_only_without_recursive_shows_only_top_level() {
         .collect();
 
     assert!(paths.iter().any(|p| p == "top.txt"));
-    // Without recursive, nested files should not be listed
     assert!(!paths.iter().any(|p| p.contains("nested.txt")));
 }
 
@@ -563,7 +546,6 @@ fn list_only_shows_device_nodes_when_enabled() {
     )
     .expect("dry run succeeds");
 
-    // Verify records were collected
     assert!(!collector.records.is_empty());
 }
 
@@ -799,7 +781,6 @@ fn list_only_handles_size_zero_files() {
     let metadata = empty_record.metadata().expect("metadata present");
     assert_eq!(metadata.len(), 0);
 
-    // Verify file was not transferred
     assert!(!dest.join("empty.txt").exists());
 }
 

--- a/crates/engine/src/local_copy/tests/max_size_filter.rs
+++ b/crates/engine/src/local_copy/tests/max_size_filter.rs
@@ -12,7 +12,6 @@ fn execute_excludes_files_larger_than_max_size() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create files of various sizes
     fs::write(source_root.join("small.txt"), vec![0u8; 512]).expect("write small");
     fs::write(source_root.join("medium.txt"), vec![0u8; 1024]).expect("write medium");
     fs::write(source_root.join("large.txt"), vec![0u8; 2048]).expect("write large");
@@ -24,7 +23,6 @@ fn execute_excludes_files_larger_than_max_size() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set max-size to 1024 bytes
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
@@ -32,7 +30,6 @@ fn execute_excludes_files_larger_than_max_size() {
         )
         .expect("copy succeeds");
 
-    // Files larger than 1024 bytes should be excluded
     assert_eq!(summary.files_copied(), 2, "should copy only small and medium files");
     assert!(dest_root.join("small.txt").exists(), "small file should be copied");
     assert!(dest_root.join("medium.txt").exists(), "medium file should be copied");
@@ -46,7 +43,6 @@ fn execute_includes_files_equal_to_max_size() {
     let source = temp.path().join("boundary.bin");
     let destination = temp.path().join("dest.bin");
 
-    // Create a file exactly 2048 bytes
     let payload = vec![0xAA; 2048];
     fs::write(&source, &payload).expect("write boundary source");
 
@@ -56,7 +52,6 @@ fn execute_includes_files_equal_to_max_size() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set max-size to exactly the file size
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
@@ -79,7 +74,6 @@ fn execute_includes_files_smaller_than_max_size() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create files smaller than the limit
     fs::write(source_root.join("tiny.txt"), b"ab").expect("write tiny");
     fs::write(source_root.join("small.txt"), vec![0u8; 100]).expect("write small");
     fs::write(source_root.join("medium.txt"), vec![0u8; 500]).expect("write medium");
@@ -90,7 +84,6 @@ fn execute_includes_files_smaller_than_max_size() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set max-size larger than all files
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
@@ -110,7 +103,6 @@ fn execute_max_size_with_kilobyte_suffix() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create files: one under 1K, one at 1K, one over 1K
     fs::write(source_root.join("under.txt"), vec![0u8; 512]).expect("write under 1K");
     fs::write(source_root.join("exact.txt"), vec![0u8; 1024]).expect("write exactly 1K");
     fs::write(source_root.join("over.txt"), vec![0u8; 1536]).expect("write over 1K");
@@ -121,7 +113,6 @@ fn execute_max_size_with_kilobyte_suffix() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Max-size of 1K = 1024 bytes
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
@@ -141,8 +132,7 @@ fn execute_max_size_with_megabyte_suffix() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create files: one under 1M, one at 1M, one over 1M
-    let one_mb: u64 = 1024 * 1024; // 1 MiB = 1048576 bytes
+    let one_mb: u64 = 1024 * 1024;
     fs::write(source_root.join("under.txt"), vec![0u8; (one_mb - 1024) as usize]).expect("write under 1M");
     fs::write(source_root.join("exact.txt"), vec![0u8; one_mb as usize]).expect("write exactly 1M");
     fs::write(source_root.join("over.txt"), vec![0u8; (one_mb + 1024) as usize]).expect("write over 1M");
@@ -153,7 +143,6 @@ fn execute_max_size_with_megabyte_suffix() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Max-size of 1M = 1048576 bytes
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
@@ -174,10 +163,8 @@ fn execute_max_size_with_gigabyte_suffix() {
     fs::create_dir_all(&source_root).expect("create source");
 
     // Create smaller test files to avoid disk space issues
-    // Use sizes that represent relative positions to 1G
-    let one_gb = 1024u64 * 1024 * 1024; // 1 GiB = 1073741824 bytes
+    let one_gb = 1024u64 * 1024 * 1024;
 
-    // Create small files that would be included under a 1G limit
     fs::write(source_root.join("small.txt"), vec![0u8; 1024]).expect("write small");
     fs::write(source_root.join("medium.txt"), vec![0u8; 1024 * 1024]).expect("write medium");
 
@@ -187,7 +174,6 @@ fn execute_max_size_with_gigabyte_suffix() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Max-size of 1G = 1073741824 bytes
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
@@ -206,7 +192,6 @@ fn execute_max_size_excludes_very_large_files() {
     let source = temp.path().join("large.bin");
     let destination = temp.path().join("dest.bin");
 
-    // Create a 10MB file
     let ten_mb = 10 * 1024 * 1024;
     fs::write(&source, vec![0u8; ten_mb]).expect("write 10MB source");
 
@@ -216,7 +201,6 @@ fn execute_max_size_excludes_very_large_files() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Set max-size to 5MB
     let five_mb: u64 = 5 * 1024 * 1024;
     let summary = plan
         .execute_with_options(
@@ -235,7 +219,6 @@ fn execute_max_size_with_empty_file() {
     let source = temp.path().join("empty.txt");
     let destination = temp.path().join("dest.txt");
 
-    // Create empty file
     fs::write(&source, b"").expect("write empty source");
 
     let operands = vec![
@@ -262,7 +245,6 @@ fn execute_max_size_combined_with_min_size() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create files of various sizes
     fs::write(source_root.join("too_small.txt"), vec![0u8; 50]).expect("write too small");
     fs::write(source_root.join("just_right1.txt"), vec![0u8; 100]).expect("write just right 1");
     fs::write(source_root.join("just_right2.txt"), vec![0u8; 200]).expect("write just right 2");
@@ -274,7 +256,6 @@ fn execute_max_size_combined_with_min_size() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Only copy files between 100 and 300 bytes
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
@@ -298,10 +279,8 @@ fn execute_max_size_does_not_affect_directories() {
     let nested_dir = source_root.join("nested");
     fs::create_dir_all(&nested_dir).expect("create nested dir");
 
-    // Create a small file inside the directory
     fs::write(nested_dir.join("small.txt"), b"content").expect("write small file");
 
-    // Create a large file that should be excluded
     fs::write(source_root.join("large.txt"), vec![0u8; 2048]).expect("write large file");
 
     let dest_root = temp.path().join("dest");
@@ -321,10 +300,8 @@ fn execute_max_size_does_not_affect_directories() {
     assert!(dest_root.join("nested").exists(), "directory should be created");
     assert!(dest_root.join("nested").is_dir(), "nested should be a directory");
 
-    // Small file should be copied
     assert!(dest_root.join("nested").join("small.txt").exists(), "small file should be copied");
 
-    // Large file should be excluded
     assert!(!dest_root.join("large.txt").exists(), "large file should be excluded");
 
     assert_eq!(summary.files_copied(), 1, "only the small file should be copied");
@@ -397,7 +374,6 @@ fn execute_max_size_with_filter_rules() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create files with different extensions and sizes
     fs::write(source_root.join("small.txt"), vec![0u8; 512]).expect("write small txt");
     fs::write(source_root.join("small.bak"), vec![0u8; 512]).expect("write small bak");
     fs::write(source_root.join("large.txt"), vec![0u8; 2048]).expect("write large txt");

--- a/crates/engine/src/local_copy/tests/partial_dir.rs
+++ b/crates/engine/src/local_copy/tests/partial_dir.rs
@@ -58,7 +58,6 @@ fn partial_dir_creates_directory_if_not_exists() {
     fs::create_dir_all(&dest_dir).expect("create dest dir");
     fs::write(&source, b"auto-create partial dir").expect("write source");
 
-    // Verify partial dir doesn't exist initially
     assert!(!partial_dir.exists());
 
     let destination = dest_dir.join("file.txt");
@@ -114,7 +113,6 @@ fn partial_dir_moves_file_to_destination_on_commit() {
     assert!(!staging_path.starts_with(&partial_dir));
     assert!(!destination.exists());
 
-    // Commit the file
     guard.commit().expect("commit");
 
     // After commit: file should be at destination, not in partial dir
@@ -623,7 +621,6 @@ fn partial_dir_dry_run_does_not_create_directory() {
     fs::create_dir_all(&dest_dir).expect("create dest dir");
     fs::write(&source, b"dry run test").expect("write source");
 
-    // Verify partial dir doesn't exist initially
     assert!(!partial_dir.exists());
 
     let destination = dest_dir.join("output.txt");
@@ -744,7 +741,6 @@ fn partial_dir_absolute_path_not_affected_by_delete() {
     fs::create_dir_all(&dest).expect("create dest");
     fs::create_dir_all(&abs_partial).expect("create absolute partial dir");
 
-    // Create source file
     fs::write(source.join("file.txt"), b"source data").expect("write source");
 
     // Create a partial file in the absolute partial dir
@@ -1435,7 +1431,6 @@ fn partial_dir_successful_copy_creates_and_uses_partial_dir() {
     let partial_dir_name = ".e2e-partial";
     let partial_dir_path = dest_dir.join(partial_dir_name);
 
-    // Ensure partial dir does not exist before copy
     assert!(!partial_dir_path.exists());
 
     let operands = vec![
@@ -1452,7 +1447,6 @@ fn partial_dir_successful_copy_creates_and_uses_partial_dir() {
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);
-    // Destination should have the content
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         b"end-to-end partial dir test content"

--- a/crates/engine/src/local_copy/tests/partial_modtime_zero_update.rs
+++ b/crates/engine/src/local_copy/tests/partial_modtime_zero_update.rs
@@ -23,7 +23,6 @@ fn update_transfers_file_when_dest_has_epoch_mtime() {
     fs::write(&source, full_content).expect("write source");
     fs::write(&destination, partial_content).expect("write partial dest");
 
-    // Source has a realistic recent timestamp.
     let source_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, source_time, source_time).expect("set source times");
 
@@ -76,11 +75,9 @@ fn update_skips_file_when_dest_has_future_mtime() {
     fs::write(&source, full_content).expect("write source");
     fs::write(&destination, partial_content).expect("write dest");
 
-    // Source has a normal timestamp.
     let source_time = FileTime::from_unix_time(1_700_000_000, 0);
     set_file_times(&source, source_time, source_time).expect("set source times");
 
-    // Destination has a far-future timestamp (year 2100).
     let future_time = FileTime::from_unix_time(4_102_444_800, 0);
     set_file_times(&destination, future_time, future_time).expect("set dest future mtime");
 

--- a/crates/engine/src/local_copy/tests/partial_transfers.rs
+++ b/crates/engine/src/local_copy/tests/partial_transfers.rs
@@ -98,7 +98,6 @@ fn partial_file_manager_finds_keep_mode_partial() {
     let dest = dir.path().join("file.txt");
     let partial = dir.path().join(".rsync-partial-file.txt");
 
-    // Create a partial file
     fs::write(&partial, b"partial content").expect("write partial");
 
     let manager = PartialFileManager::new(PartialMode::Keep);
@@ -116,7 +115,6 @@ fn partial_file_manager_finds_partial_dir_mode_partial() {
     let dest = dir.path().join("file.txt");
     let partial = partial_dir.join("file.txt");
 
-    // Create a partial file in the partial directory
     fs::write(&partial, b"partial content").expect("write partial");
 
     let manager = PartialFileManager::new(PartialMode::PartialDir(partial_dir));
@@ -142,7 +140,6 @@ fn partial_file_manager_cleanup_removes_keep_mode_partial() {
     let dest = dir.path().join("file.txt");
     let partial = dir.path().join(".rsync-partial-file.txt");
 
-    // Create a partial file
     fs::write(&partial, b"partial content").expect("write partial");
     assert!(partial.exists());
 
@@ -161,7 +158,6 @@ fn partial_file_manager_cleanup_removes_partial_dir_mode_partial() {
     let dest = dir.path().join("file.txt");
     let partial = partial_dir.join("file.txt");
 
-    // Create a partial file
     fs::write(&partial, b"partial content").expect("write partial");
     assert!(partial.exists());
 
@@ -186,19 +182,16 @@ fn partial_file_manager_cleanup_succeeds_when_no_partial() {
 fn partial_dir_relative_path_resolved_per_destination() {
     let base = tempdir().expect("tempdir");
 
-    // Create two different destination directories
     let dest1_dir = base.path().join("dest1");
     let dest2_dir = base.path().join("dest2");
     fs::create_dir(&dest1_dir).expect("create dest1");
     fs::create_dir(&dest2_dir).expect("create dest2");
 
-    // Create partial directories relative to each destination
     let partial1_dir = dest1_dir.join(".partial");
     let partial2_dir = dest2_dir.join(".partial");
     fs::create_dir(&partial1_dir).expect("create partial1");
     fs::create_dir(&partial2_dir).expect("create partial2");
 
-    // Create partial files in each
     let dest1 = dest1_dir.join("file.txt");
     let dest2 = dest2_dir.join("file.txt");
     let partial1 = partial1_dir.join("file.txt");
@@ -207,10 +200,8 @@ fn partial_dir_relative_path_resolved_per_destination() {
     fs::write(&partial1, b"partial1").expect("write partial1");
     fs::write(&partial2, b"partial2").expect("write partial2");
 
-    // Use relative partial dir
     let manager = PartialFileManager::new(PartialMode::PartialDir(".partial".into()));
 
-    // Should find correct partial for each destination
     let found1 = manager.find_basis(&dest1).expect("find_basis 1");
     let found2 = manager.find_basis(&dest2).expect("find_basis 2");
 
@@ -224,7 +215,6 @@ fn partial_dir_absolute_path_is_global() {
     let global_partial = base.path().join("global-partial");
     fs::create_dir(&global_partial).expect("create global partial");
 
-    // Create destination directories
     let dest1_dir = base.path().join("dest1");
     let dest2_dir = base.path().join("dest2");
     fs::create_dir(&dest1_dir).expect("create dest1");
@@ -233,7 +223,6 @@ fn partial_dir_absolute_path_is_global() {
     let dest1 = dest1_dir.join("file.txt");
     let dest2 = dest2_dir.join("file.txt");
 
-    // Both should use the same global partial file
     let partial = global_partial.join("file.txt");
     fs::write(&partial, b"global partial").expect("write partial");
 
@@ -242,7 +231,6 @@ fn partial_dir_absolute_path_is_global() {
     let found1 = manager.find_basis(&dest1).expect("find_basis 1");
     let found2 = manager.find_basis(&dest2).expect("find_basis 2");
 
-    // Both should find the same global partial file
     assert_eq!(found1, Some(partial.clone()));
     assert_eq!(found2, Some(partial));
 }
@@ -253,11 +241,9 @@ fn partial_dir_handles_nested_directory_structures() {
     let partial_dir = base.path().join(".partial");
     fs::create_dir(&partial_dir).expect("create partial dir");
 
-    // Nested destination
     let nested_dest = base.path().join("a").join("b").join("c").join("file.txt");
     fs::create_dir_all(nested_dest.parent().unwrap()).expect("create nested dirs");
 
-    // Partial should be in the relative partial dir
     let nested_partial_dir = base.path().join("a").join("b").join("c").join(".partial");
     fs::create_dir(&nested_partial_dir).expect("create nested partial dir");
     let partial = nested_partial_dir.join("file.txt");
@@ -302,20 +288,15 @@ fn partial_file_transfer_workflow() {
     let dest = dir.path().join("file.txt");
     let partial = dir.path().join(".rsync-partial-file.txt");
 
-    // Simulate a partial transfer
     fs::write(&partial, b"partial content from interrupted transfer").expect("write partial");
 
     let manager = PartialFileManager::new(PartialMode::Keep);
 
-    // Step 1: Find basis file for resume
     let basis = manager.find_basis(&dest).expect("find_basis");
     assert_eq!(basis, Some(partial.clone()));
 
-    // Step 2: Transfer would complete here...
-    // Simulate by creating the final file
     fs::write(&dest, b"complete content").expect("write dest");
 
-    // Step 3: Clean up partial file after success
     manager.cleanup_partial(&dest).expect("cleanup");
     assert!(!partial.exists());
     assert!(dest.exists());
@@ -330,19 +311,15 @@ fn partial_dir_transfer_workflow() {
     let dest = dir.path().join("file.txt");
     let partial = partial_dir.join("file.txt");
 
-    // Simulate a partial transfer in partial dir
     fs::write(&partial, b"partial content").expect("write partial");
 
     let manager = PartialFileManager::new(PartialMode::PartialDir(partial_dir.clone()));
 
-    // Step 1: Find basis file
     let basis = manager.find_basis(&dest).expect("find_basis");
     assert_eq!(basis, Some(partial.clone()));
 
-    // Step 2: Transfer completes
     fs::write(&dest, b"complete content").expect("write dest");
 
-    // Step 3: Clean up partial dir file
     manager.cleanup_partial(&dest).expect("cleanup");
     assert!(!partial.exists());
     assert!(dest.exists());
@@ -357,10 +334,8 @@ fn integration_test_partial_mode_with_local_copy() {
     let source = dir.path().join("source.txt");
     let dest = dir.path().join("dest.txt");
 
-    // Create source file
     fs::write(&source, b"source content").expect("write source");
 
-    // Execute copy with partial mode enabled
     let opts = LocalCopyOptions::new().partial(true);
     let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("create plan");
@@ -369,7 +344,6 @@ fn integration_test_partial_mode_with_local_copy() {
     assert!(result.is_ok());
     assert!(dest.exists());
 
-    // Verify content
     let content = fs::read_to_string(&dest).expect("read dest");
     assert_eq!(content, "source content");
 }
@@ -383,10 +357,8 @@ fn integration_test_partial_dir_mode_with_local_copy() {
     let source = dir.path().join("source.txt");
     let dest = dir.path().join("dest.txt");
 
-    // Create source file
     fs::write(&source, b"source content").expect("write source");
 
-    // Execute copy with partial-dir mode
     let opts = LocalCopyOptions::new().with_partial_directory(Some(partial_dir));
     let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("create plan");
@@ -395,7 +367,6 @@ fn integration_test_partial_dir_mode_with_local_copy() {
     assert!(result.is_ok());
     assert!(dest.exists());
 
-    // Verify content
     let content = fs::read_to_string(&dest).expect("read dest");
     assert_eq!(content, "source content");
 }

--- a/crates/engine/src/local_copy/tests/permission_errors.rs
+++ b/crates/engine/src/local_copy/tests/permission_errors.rs
@@ -99,10 +99,8 @@ fn permission_read_denied_returns_io_error_with_multiple_files() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create a readable file
     fs::write(source_root.join("readable.txt"), b"can read this").expect("write readable");
 
-    // Create an unreadable file
     let unreadable = create_unreadable_file(&source_root, "unreadable.txt", b"secret");
 
     let dest_root = temp.path().join("dest");
@@ -200,7 +198,6 @@ fn permission_write_denied_destination_directory() {
     fs::create_dir_all(&source_root).expect("create source");
     fs::write(source_root.join("file.txt"), b"content").expect("write file");
 
-    // Create readonly destination
     let dest_root = create_readonly_dir(temp.path(), "dest");
 
     let operands = vec![
@@ -239,7 +236,6 @@ fn permission_write_denied_creating_directory_in_readonly_parent() {
     fs::create_dir_all(&nested).expect("create nested");
     fs::write(nested.join("file.txt"), b"content").expect("write file");
 
-    // Create destination with readonly permissions
     let dest_root = create_readonly_dir(temp.path(), "dest");
 
     let operands = vec![
@@ -394,7 +390,6 @@ fn permission_denied_returns_partial_transfer_exit_code() {
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
 
-    // Create readable and unreadable files
     fs::write(source_root.join("readable.txt"), b"content").expect("write readable");
     let unreadable = create_unreadable_file(&source_root, "unreadable.txt", b"secret");
 
@@ -470,7 +465,6 @@ fn permission_dry_run_with_readonly_destination() {
     fs::create_dir_all(&source_root).expect("create source");
     fs::write(source_root.join("file.txt"), b"content").expect("write file");
 
-    // Create readonly destination
     let dest_root = create_readonly_dir(temp.path(), "dest");
 
     let operands = vec![

--- a/crates/engine/src/local_copy/tests/timeout_handling.rs
+++ b/crates/engine/src/local_copy/tests/timeout_handling.rs
@@ -283,7 +283,6 @@ fn timeout_error_debug_format() {
     let error = LocalCopyError::timeout(Duration::from_secs(30));
     let debug = format!("{error:?}");
 
-    // Debug format should include relevant information
     assert!(debug.contains("Timeout"));
     assert!(debug.contains("30"));
 }


### PR DESCRIPTION
Comment and doc cleanup for the engine local-copy test suite under `crates/engine/src/local_copy/tests/` (67 files).

- Removes restatement/echo comments, debug-checkpoint notes, decorative dividers, header table-of-contents blocks, commented-out asserts, and trailing inline narration.
- Keeps every `upstream:` citation verbatim, all WHY/invariant/scenario and platform/`#cfg`-gate rationale.
- Comment/doc lines only: no logic, signature, control-flow, or string changes. `upstream` reference lines are identical before and after (324/324). No `//!` inner-doc comments (these files are `include!()`-ed). `cargo fmt` clean.
