### PR TITLE
docs(protocol): refresh tracked upstream version to 3.4.4 in prose

### DIFF
--- a/crates/protocol/src/bind/mod.rs
+++ b/crates/protocol/src/bind/mod.rs
@@ -1,6 +1,6 @@
 //! `--debug=BIND` producer emissions for socket bind diagnostics.
 //!
-//! Hosts the trace helpers that mirror upstream rsync 3.4.1's
+//! Hosts the trace helpers that mirror upstream rsync 3.4.4's
 //! `DEBUG_GTE(BIND, 1)` diagnostics emitted from `socket.c::open_socket_in`
 //! while iterating per-address-family during daemon listener setup.
 //!

--- a/crates/protocol/src/bind/trace.rs
+++ b/crates/protocol/src/bind/trace.rs
@@ -1,6 +1,6 @@
 //! `--debug=BIND` producer emissions for daemon listener setup.
 //!
-//! Mirrors upstream rsync 3.4.1's `DEBUG_GTE(BIND, 1)` output byte-for-byte
+//! Mirrors upstream rsync 3.4.4's `DEBUG_GTE(BIND, 1)` output byte-for-byte
 //! so wire-comparable diagnostics align across implementations. Upstream
 //! accumulates per-address-family error messages while iterating
 //! `getaddrinfo` results inside `open_socket_in` and flushes them through

--- a/crates/protocol/src/chdir/mod.rs
+++ b/crates/protocol/src/chdir/mod.rs
@@ -1,6 +1,6 @@
 //! `--debug=CHDIR` producer emissions for current-directory changes.
 //!
-//! Hosts the trace helper that mirrors upstream rsync 3.4.1's single
+//! Hosts the trace helper that mirrors upstream rsync 3.4.4's single
 //! `DEBUG_GTE(CHDIR, 1)` emission from `util1.c::change_dir`. Upstream
 //! routes every successful `chdir()` syscall through `change_dir`, so the
 //! single helper here is the wire-equivalent of `[<who>] change_dir(<cwd>)`.

--- a/crates/protocol/src/chdir/trace.rs
+++ b/crates/protocol/src/chdir/trace.rs
@@ -1,6 +1,6 @@
 //! `--debug=CHDIR` producer emissions for the current-directory change path.
 //!
-//! Mirrors upstream rsync 3.4.1's `util1.c::change_dir` `DEBUG_GTE(CHDIR, 1)`
+//! Mirrors upstream rsync 3.4.4's `util1.c::change_dir` `DEBUG_GTE(CHDIR, 1)`
 //! output byte-for-byte so wire-comparable diagnostics align across
 //! implementations. Upstream funnels every `chdir()` syscall through
 //! `change_dir`, which prints `"[%s] change_dir(%s)\n"` (`util1.c:1168-1169`)

--- a/crates/protocol/src/cmd/mod.rs
+++ b/crates/protocol/src/cmd/mod.rs
@@ -1,6 +1,6 @@
 //! `--debug=CMD` producer emissions for command and option construction.
 //!
-//! Hosts the trace helpers that mirror upstream rsync 3.4.1's `DEBUG_GTE(CMD, N)`
+//! Hosts the trace helpers that mirror upstream rsync 3.4.4's `DEBUG_GTE(CMD, N)`
 //! diagnostics emitted from `pipe.c`, `rsync.c`, `clientserver.c`, and `main.c`
 //! during remote command construction, secluded-args transmission, and daemon
 //! argument forwarding.

--- a/crates/protocol/src/cmd/trace.rs
+++ b/crates/protocol/src/cmd/trace.rs
@@ -1,6 +1,6 @@
 //! `--debug=CMD` producer emissions for remote command construction.
 //!
-//! Mirrors upstream rsync 3.4.1's `DEBUG_GTE(CMD, N)` output so wire-comparable
+//! Mirrors upstream rsync 3.4.4's `DEBUG_GTE(CMD, N)` output so wire-comparable
 //! diagnostics align across implementations. All emissions use the upstream
 //! quoting rules from `util1.c:print_child_argv` so that the printed argv
 //! matches what upstream would write to `FCLIENT` byte-for-byte (modulo the

--- a/crates/protocol/src/nstr/trace.rs
+++ b/crates/protocol/src/nstr/trace.rs
@@ -1,6 +1,6 @@
 //! `--debug=NSTR` producer emissions for the algorithm-negotiation strings.
 //!
-//! Mirrors upstream rsync 3.4.1's `compat.c` and `checksum.c`
+//! Mirrors upstream rsync 3.4.4's `compat.c` and `checksum.c`
 //! `DEBUG_GTE(NSTR, N)` output byte-for-byte so wire-comparable diagnostics
 //! line up across implementations. NSTR ("name string") covers the
 //! checksum, compression, and daemon-auth-checksum vstring exchanges that

--- a/crates/protocol/src/version/constants.rs
+++ b/crates/protocol/src/version/constants.rs
@@ -3,19 +3,19 @@
 
 use ::core::ops::RangeInclusive;
 
-/// Lowest protocol version supported by upstream rsync 3.4.1.
+/// Lowest protocol version supported by upstream rsync 3.4.4.
 pub(crate) const OLDEST_SUPPORTED_PROTOCOL: u8 = 28;
-/// Newest protocol version supported by upstream rsync 3.4.1.
+/// Newest protocol version supported by upstream rsync 3.4.4.
 pub(crate) const NEWEST_SUPPORTED_PROTOCOL: u8 = 32;
 /// Protocol revision that introduced the binary negotiation handshake.
 pub(crate) const FIRST_BINARY_NEGOTIATION_PROTOCOL: u8 = 30;
-/// Highest protocol version upstream rsync 3.4.1 tolerates from a peer advertisement.
+/// Highest protocol version upstream rsync 3.4.4 tolerates from a peer advertisement.
 ///
 /// Mirrors `MAX_PROTOCOL_VERSION` from `rsync.h` so future protocol announcements that fall
 /// within upstream's guard range are accepted and clamped to the newest supported revision.
 pub const MAXIMUM_PROTOCOL_ADVERTISEMENT: u8 = 40;
 
-/// Inclusive range of protocol versions that upstream rsync 3.4.1 understands.
+/// Inclusive range of protocol versions that upstream rsync 3.4.4 understands.
 pub(crate) const UPSTREAM_PROTOCOL_RANGE: RangeInclusive<u8> =
     OLDEST_SUPPORTED_PROTOCOL..=NEWEST_SUPPORTED_PROTOCOL;
 

--- a/crates/protocol/src/version/mod.rs
+++ b/crates/protocol/src/version/mod.rs
@@ -5,7 +5,7 @@
 //! highest mutually supported version ([`select_highest_mutual`]) and iterating
 //! over the supported set.
 //!
-//! The supported versions (28 through 32) match upstream rsync 3.4.1. Version
+//! The supported versions (28 through 32) match upstream rsync 3.4.4. Version
 //! 30 is the boundary between the legacy ASCII negotiation and the modern
 //! binary handshake.
 

--- a/crates/protocol/src/version/protocol_version/mod.rs
+++ b/crates/protocol/src/version/protocol_version/mod.rs
@@ -24,7 +24,7 @@ use super::iter::{SupportedProtocolNumbersIter, SupportedVersionsIter};
 /// This type wraps a non-zero byte that identifies which revision of the rsync
 /// wire protocol a session has agreed to use. The supported range is
 /// [`V28`](Self::V28) through [`V32`](Self::V32), matching upstream rsync
-/// 3.4.1. Protocol version 30 marks the boundary between the legacy ASCII
+/// 3.4.4. Protocol version 30 marks the boundary between the legacy ASCII
 /// negotiation (`@RSYNCD:`) and the modern binary handshake.
 ///
 /// # Constructing a Version
@@ -124,10 +124,10 @@ impl ProtocolVersion {
         }
     }
 
-    /// The newest protocol version supported by upstream rsync 3.4.1.
+    /// The newest protocol version supported by upstream rsync 3.4.4.
     pub const NEWEST: ProtocolVersion = ProtocolVersion::new_const(NEWEST_SUPPORTED_PROTOCOL);
 
-    /// The oldest protocol version supported by upstream rsync 3.4.1.
+    /// The oldest protocol version supported by upstream rsync 3.4.4.
     pub const OLDEST: ProtocolVersion = ProtocolVersion::new_const(OLDEST_SUPPORTED_PROTOCOL);
 
     /// Protocol version at which rsync switched from the legacy ASCII
@@ -136,7 +136,7 @@ impl ProtocolVersion {
         ProtocolVersion::new_const(FIRST_BINARY_NEGOTIATION_PROTOCOL);
 
     /// Protocol version 32, the newest revision advertised by upstream rsync
-    /// 3.4.1.
+    /// 3.4.4.
     pub const V32: ProtocolVersion = ProtocolVersion::NEWEST;
 
     /// Protocol version 31, used by upstream rsync 3.1.x releases.


### PR DESCRIPTION
Refresh stale reference-upstream version prose in `crates/protocol/src` from
rsync 3.4.1 to 3.4.4, matching the upstream release the project now tracks.

Comment/doc-only: no logic, signature, or control-flow changes. All `upstream:`
citations preserved (before/after count unchanged). Protocol-32-to-release
version-tie claims (v32 compatibility test docs) were left as-is since they
describe a specific release origin, not the tracked reference version.
