### PR TITLE
docs(daemon): correct stale connection-limit and Windows gid docs

### DIFF
--- a/crates/daemon/src/daemon/sections/name_converter.rs
+++ b/crates/daemon/src/daemon/sections/name_converter.rs
@@ -133,11 +133,9 @@ impl metadata::id_lookup::NameConverterCallbacks for WindowsNameConverter {
         platform::name_resolution::rid_to_account_name(uid)
     }
     fn gid_to_name(&mut self, gid: u32) -> Option<String> {
-        // On Windows, GIDs map to group RIDs. Reuse the same enum-and-match
-        // approach. For groups, we could enumerate local groups, but the
-        // rid_to_account_name only enumerates users. For now, return None
-        // for group reverse lookups - groups are less commonly preserved.
-        // A full implementation would enumerate via NetLocalGroupEnum.
+        // On Windows, GIDs map to group RIDs. Resolve them through the same
+        // rid_to_account_name path used for user RIDs, which matches accounts
+        // by RID regardless of whether they name a user or a local group.
         platform::name_resolution::rid_to_account_name(gid)
     }
     fn name_to_uid(&mut self, name: &str) -> Option<u32> {

--- a/crates/daemon/src/daemon/sections/server_runtime/connection_counter.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection_counter.rs
@@ -6,9 +6,11 @@
 /// automatically decrements the counter when dropped.
 ///
 /// The counter is wrapped in an `Arc` so it can be shared between the main
-/// accept loop and spawned worker threads. This enables future max-connections
-/// enforcement at the daemon level (as opposed to the per-module limits
-/// already tracked by `ModuleRuntime::active_connections`).
+/// accept loop and spawned worker threads. The accept loop consults
+/// `ConnectionCounter::active` before spawning a worker and refuses the
+/// connection once `--max-connections` is reached, enforcing the daemon-level
+/// limit (as opposed to the per-module limits already tracked by
+/// `ModuleRuntime::active_connections`).
 ///
 /// upstream: clientserver.c - `count_connections()` tracks active children
 /// for the `max connections` global directive.


### PR DESCRIPTION
Comment/doc-only cleanup for the daemon rsyncd.conf parser and server_runtime sections. No logic, signature, or control-flow changes.

- `server_runtime/connection_counter.rs`: `ConnectionCounter` doc claimed daemon-level max-connections enforcement was a "future" feature. The accept loop already consults the counter and refuses connections at the limit, so the doc is reworded to present tense.
- `name_converter.rs`: the Windows `gid_to_name` comment said it returns `None` for group reverse lookups, but the code delegates to `rid_to_account_name(gid)`. Reworded to describe the actual RID-resolution path.

All `upstream:` citations preserved verbatim (net zero: 0 removed, 0 added).
