### PR TITLE
docs(core): tidy client config/run/summary comments

### DIFF
--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -473,8 +473,6 @@ mod tests {
         );
     }
 
-    // --- serialize_filter_rules tests ---
-
     #[test]
     fn serialize_empty_rules_returns_empty_string() {
         assert_eq!(serialize_filter_rules(&[]), "");


### PR DESCRIPTION
Comment/doc-only cleanup for crates/core/src/client config/run/summary modules.

Reviewed all 54 files. The scope was already thoroughly documented, so the only
change is removing a decorative `// --- serialize_filter_rules tests ---` divider
in run/batch.rs. No logic changes. All 174 `upstream:` reference lines preserved.
