### PR TITLE
docs(core): tidy client remote comment headers

### DIFF
--- a/crates/core/src/client/remote/batch_support.rs
+++ b/crates/core/src/client/remote/batch_support.rs
@@ -1,8 +1,8 @@
-// Shared batch recording support for SSH and daemon transfer paths.
-//
-// Provides the adapter and context types needed to wire `--write-batch` into
-// any transfer path that uses `run_server_with_handshake`. Extracted from
-// the SSH transfer module to avoid duplication with the daemon transfer path.
+//! Shared batch recording support for SSH and daemon transfer paths.
+//!
+//! Provides the adapter and context types needed to wire `--write-batch` into
+//! any transfer path that uses `run_server_with_handshake`. Extracted from
+//! the SSH transfer module to avoid duplication with the daemon transfer path.
 
 use std::sync::{Arc, Mutex};
 

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -3672,9 +3672,7 @@ fn unix_secs_to_utc_y2k() {
     assert_eq!((y, m, d, h, min), (2000, 1, 1, 0, 0));
 }
 
-// -----------------------------------------------------------------------
 // Remote option (-M / --remote-option) forwarding
-// -----------------------------------------------------------------------
 
 #[test]
 fn remote_options_appended_to_sender_invocation() {


### PR DESCRIPTION
Comment/doc-only cleanup in `crates/core/src/client/{remote,module_list,tests}`.

- Convert the `batch_support.rs` file-header comment from `//` to `//!` module doc (it is a real named module file).
- Drop a decorative divider banner around a test section label in `invocation/tests.rs`; the label is kept.

No logic, signature, or control-flow changes. All `upstream:` citations preserved (before/after count identical). The rest of the scope was already accurately documented and needed no changes.
