### PR TITLE
docs: correct stale doc claims and add missing module docs

### DIFF
--- a/crates/cli/src/frontend/command_builder/mod.rs
+++ b/crates/cli/src/frontend/command_builder/mod.rs
@@ -1,3 +1,5 @@
+//! Assembles the clap `Command` from staged option-group sections.
+
 mod sections;
 
 pub(super) use clap::{Arg, ArgAction, Command as ClapCommand, builder::OsStringValueParser};

--- a/crates/cli/src/frontend/command_builder/sections/mod.rs
+++ b/crates/cli/src/frontend/command_builder/sections/mod.rs
@@ -1,3 +1,5 @@
+//! Option-group sections that extend the clap command in stages.
+
 mod build_base_command;
 mod connection_and_logging_options;
 mod transfer_behavior_options;

--- a/crates/cli/src/frontend/execution/chown.rs
+++ b/crates/cli/src/frontend/execution/chown.rs
@@ -30,7 +30,7 @@ impl ParsedChown {
         self.group
     }
 
-    /// Returns the original spec string
+    /// Returns the original spec string.
     #[allow(dead_code)] // REASON: accessor used in unit tests
     pub(crate) const fn spec(&self) -> &OsString {
         &self.spec

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -195,14 +195,10 @@ where
                 name_overridden = true;
             }
 
-            // Apply all resolved info flag levels to the thread-local
-            // VerbosityConfig. This replaces the prior token-by-token loop
-            // which could not handle composite tokens like "all", "none",
-            // or bare numeric levels (those tokens silently failed in
-            // logging::apply_info_flag). The resolved InfoFlagSettings
-            // already handles all token forms correctly, so applying the
-            // fully-resolved per-flag levels ensures the thread-local
-            // config matches what the user requested.
+            // Apply the fully-resolved per-flag levels to the thread-local
+            // VerbosityConfig. Resolving first is what lets composite tokens
+            // like "all", "none", and bare numeric levels take effect; a
+            // token-by-token apply cannot decode them.
             // upstream: options.c set_output_verbosity / parse_output_words
             settings.apply_to_thread_local();
 

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -16,8 +16,8 @@
 //!
 //! | CLI flag | Cargo feature | Check site | Error string |
 //! |----------|---------------|------------|--------------|
-//! | `--acls`, `-A` | `acl` (CLI) -> `core/acl` | `preflight.rs:216` ([`validate_feature_support`]) | `POSIX ACLs are not supported on this client` |
-//! | `--xattrs`, `-X` | `xattr` (CLI) -> `core/xattr` | `preflight.rs:226` ([`validate_feature_support`]) | `extended attributes are not supported on this client` |
+//! | `--acls`, `-A` | `acl` (CLI) -> `core/acl` | `preflight.rs:234` ([`validate_feature_support`]) | `POSIX ACLs are not supported on this client` |
+//! | `--xattrs`, `-X` | `xattr` (CLI) -> `core/xattr` | `preflight.rs:245` ([`validate_feature_support`]) | `extended attributes are not supported on this client` |
 //!
 //! Cfg expression for both gates: `not(all(any(unix, windows), feature = "<feat>"))`.
 //! The gate fires only when the user explicitly opts in to the flag

--- a/crates/cli/src/frontend/execution/module_list.rs
+++ b/crates/cli/src/frontend/execution/module_list.rs
@@ -45,7 +45,5 @@ mod tests {
     // and implementation are straightforward write operations.
 
     #[test]
-    fn module_compiles() {
-        // This test ensures the module compiles correctly
-    }
+    fn module_compiles() {}
 }

--- a/crates/cli/src/frontend/execution/options/numeric.rs
+++ b/crates/cli/src/frontend/execution/options/numeric.rs
@@ -1,7 +1,7 @@
 //! Parsers for simple numeric command-line arguments.
 //!
-//! Handles `--timeout`, `--max-delete`, `--checksum-seed`, `--modify-window`,
-//! and `--human-readable` options with upstream-compatible error messages.
+//! Handles `--timeout`, `--max-delete`, `--checksum-seed`, and `--modify-window`
+//! options with upstream-compatible error messages.
 
 use std::ffi::OsStr;
 use std::num::{IntErrorKind, NonZeroU64};

--- a/crates/cli/src/frontend/outbuf.rs
+++ b/crates/cli/src/frontend/outbuf.rs
@@ -1,3 +1,4 @@
+//! Output buffering modes and writer adapter for the `--outbuf` option.
 #![deny(unsafe_code)]
 
 use std::ffi::OsStr;

--- a/crates/cli/src/frontend/password.rs
+++ b/crates/cli/src/frontend/password.rs
@@ -1,7 +1,7 @@
 //! Password and authentication helpers for the CLI front-end.
 //!
-//! This module centralises password loading logic so the sprawling argument
-//! parser in `lib.rs` can delegate to cohesive helpers. The functions here keep
+//! This module centralises password loading logic so the CLI's argument
+//! parser can delegate to cohesive helpers. The functions here keep
 //! responsibility focused on reading passwords from standard input, from
 //! filesystem paths, or from external commands while enforcing upstream rsync's
 //! permission checks.

--- a/crates/protocol/src/flist/hardlink/tests.rs
+++ b/crates/protocol/src/flist/hardlink/tests.rs
@@ -119,7 +119,7 @@ mod basic {
 /// Tests for collision handling in the hardlink lookup table.
 ///
 /// These tests verify correct behavior when:
-/// - Multiple files have the same dev/ino pair (from different systems)
+/// - Multiple files share the same dev/ino pair on one filesystem (true hardlinks)
 /// - Hash collisions occur in the underlying FxHashMap
 /// - Large numbers of hardlinks stress the table
 #[cfg(test)]
@@ -128,7 +128,7 @@ mod collision {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    /// Test that files from different systems with same dev/ino are correctly linked.
+    /// Test that files on the same system with the same dev/ino are correctly linked.
     ///
     /// When syncing from the same source filesystem, files with identical
     /// (dev, ino) pairs are true hardlinks and should be linked together.


### PR DESCRIPTION
Final comment/doc-only cleanup salvaged from the sweep (10 files). Includes real stale-doc corrections:
- `protocol/flist/hardlink/tests.rs` — the doc claimed files "from different systems" with the same dev/ino are hardlinked; hardlinks are same-filesystem. Corrected.
- `cli/.../preflight.rs` — refreshed stale line numbers in the feature-gate doc table.
- `cli/.../numeric.rs` — removed `--human-readable` (handled elsewhere) from the module doc.
- Added missing module docs (`command_builder`, `sections`, `outbuf`); trimmed echo comments.

Comment/doc-only; zero logic changes; every `upstream:` citation preserved (net 0).
