### PR TITLE
docs(engine): tidy local_copy executor rustdoc

### DIFF
--- a/crates/engine/src/local_copy/deferred_sync.rs
+++ b/crates/engine/src/local_copy/deferred_sync.rs
@@ -31,7 +31,6 @@ use std::path::{Path, PathBuf};
 use std::os::unix::io::AsRawFd;
 
 /// Strategy for when to perform filesystem sync operations.
-///
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyncStrategy {
     /// Sync immediately after each file write.
@@ -70,7 +69,6 @@ impl Default for SyncStrategy {
 ///
 /// Tracks files that need syncing and flushes them according to the
 /// configured [`SyncStrategy`].
-///
 #[derive(Debug)]
 pub struct DeferredSync {
     /// Files pending sync.

--- a/crates/engine/src/local_copy/executor/file/sparse/writer.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/writer.rs
@@ -232,13 +232,13 @@ impl<W: Write + Seek> SparseWriter<W> {
 
     /// Finalizes sparse writing by flushing any remaining pending zeros.
     ///
-    /// Returns the final stream position after all pending zeros have been
-    /// flushed. The caller should use this position to set the file length
-    /// (via `set_len`) to materialize trailing holes.
+    /// Returns the unwrapped inner writer and the write statistics. Use
+    /// `finish_and_position` when the final stream position is needed to
+    /// `set_len` and materialize trailing holes.
     ///
     /// # Errors
     ///
-    /// Returns an I/O error if seeking or querying the stream position fails.
+    /// Returns an I/O error if seeking fails while flushing pending zeros.
     pub fn finish(mut self) -> io::Result<(W, SparseWriteStats)> {
         if self.pending_zeros > 0 {
             self.stats.zero_runs_detected = self.stats.zero_runs_detected.saturating_add(1);

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -77,7 +77,6 @@ pub(crate) struct ReferenceQuery<'a> {
 /// permission bits (`perms_differ`), owner/group (`ownership_differs`), mtime
 /// (`any_time_differs`), and, when `-X` is active, the transferable extended
 /// attributes (`xattrs_differ`), each gated on the corresponding preserve option.
-///
 // upstream: generator.c:468-502 unchanged_attrs - perms/ownership/time/xattr.
 pub(crate) fn reference_attrs_unchanged(
     basis: &Path,


### PR DESCRIPTION
Comment/doc-only cleanup of the `local_copy` executor and root modules in the engine crate. No logic, signature, or control-flow changes.

- Fix a stale rustdoc on `SparseWriter::finish` (it claimed to return the stream position; it returns `(W, SparseWriteStats)` - callers wanting the position use `finish_and_position`).
- Drop three stray empty `///` lines dangling before items (`SyncStrategy`, `DeferredSync`, `reference_attrs_unchanged`).

All `upstream:` citations preserved verbatim (net-zero: 0 removed, 0 added). The bulk of the scope was already clean from prior documentation passes.
