### PR TITLE
docs(cli): tidy frontend execution and command_builder docs

### DIFF
--- a/crates/cli/src/frontend/command_builder/mod.rs
+++ b/crates/cli/src/frontend/command_builder/mod.rs
@@ -1,3 +1,5 @@
+//! Assembles the clap Command from staged option-group sections.
+
 mod sections;
 
 pub(super) use clap::{Arg, ArgAction, Command as ClapCommand, builder::OsStringValueParser};

--- a/crates/cli/src/frontend/command_builder/sections/mod.rs
+++ b/crates/cli/src/frontend/command_builder/sections/mod.rs
@@ -1,3 +1,5 @@
+//! Option-group sections that extend the clap command in stages.
+
 mod build_base_command;
 mod connection_and_logging_options;
 mod transfer_behavior_options;

--- a/crates/cli/src/frontend/execution/chown.rs
+++ b/crates/cli/src/frontend/execution/chown.rs
@@ -30,7 +30,7 @@ impl ParsedChown {
         self.group
     }
 
-    /// Returns the original spec string
+    /// Returns the original spec string.
     #[allow(dead_code)] // REASON: accessor used in unit tests
     pub(crate) const fn spec(&self) -> &OsString {
         &self.spec

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -16,8 +16,8 @@
 //!
 //! | CLI flag | Cargo feature | Check site | Error string |
 //! |----------|---------------|------------|--------------|
-//! | `--acls`, `-A` | `acl` (CLI) -> `core/acl` | `preflight.rs:216` ([`validate_feature_support`]) | `POSIX ACLs are not supported on this client` |
-//! | `--xattrs`, `-X` | `xattr` (CLI) -> `core/xattr` | `preflight.rs:226` ([`validate_feature_support`]) | `extended attributes are not supported on this client` |
+//! | `--acls`, `-A` | `acl` (CLI) -> `core/acl` | `preflight.rs:234` ([`validate_feature_support`]) | `POSIX ACLs are not supported on this client` |
+//! | `--xattrs`, `-X` | `xattr` (CLI) -> `core/xattr` | `preflight.rs:245` ([`validate_feature_support`]) | `extended attributes are not supported on this client` |
 //!
 //! Cfg expression for both gates: `not(all(any(unix, windows), feature = "<feat>"))`.
 //! The gate fires only when the user explicitly opts in to the flag

--- a/crates/cli/src/frontend/execution/module_list.rs
+++ b/crates/cli/src/frontend/execution/module_list.rs
@@ -45,7 +45,5 @@ mod tests {
     // and implementation are straightforward write operations.
 
     #[test]
-    fn module_compiles() {
-        // This test ensures the module compiles correctly
-    }
+    fn module_compiles() {}
 }

--- a/crates/cli/src/frontend/execution/options/numeric.rs
+++ b/crates/cli/src/frontend/execution/options/numeric.rs
@@ -1,7 +1,7 @@
 //! Parsers for simple numeric command-line arguments.
 //!
-//! Handles `--timeout`, `--max-delete`, `--checksum-seed`, `--modify-window`,
-//! and `--human-readable` options with upstream-compatible error messages.
+//! Handles `--timeout`, `--max-delete`, `--checksum-seed`, and
+//! `--modify-window` options with upstream-compatible error messages.
 
 use std::ffi::OsStr;
 use std::num::{IntErrorKind, NonZeroU64};

--- a/crates/cli/src/frontend/execution/options/size.rs
+++ b/crates/cli/src/frontend/execution/options/size.rs
@@ -1,7 +1,7 @@
 //! Size specification parsing for arguments with optional unit suffixes.
 //!
 //! Handles `--block-size`, `--max-size`, `--min-size`, and `--max-alloc` arguments.
-//! Supports binary (K/M/G/T/P/E = powers of 1024) and decimal (KB/MB/GB = powers of 1000)
+//! Supports binary (K/M/G/T/P = powers of 1024) and decimal (KB/MB/GB = powers of 1000)
 //! suffixes, as well as explicit binary suffixes (KiB/MiB/GiB).
 //! Mirrors upstream rsync's size parsing behavior.
 

--- a/crates/cli/src/frontend/outbuf.rs
+++ b/crates/cli/src/frontend/outbuf.rs
@@ -1,3 +1,4 @@
+//! Output buffering modes and writer adapter for the --outbuf option.
 #![deny(unsafe_code)]
 
 use std::ffi::OsStr;

--- a/crates/cli/src/frontend/password.rs
+++ b/crates/cli/src/frontend/password.rs
@@ -1,13 +1,11 @@
 //! Password and authentication helpers for the CLI front-end.
 //!
-//! This module centralises password loading logic so the sprawling argument
-//! parser in `lib.rs` can delegate to cohesive helpers. The functions here keep
-//! responsibility focused on reading passwords from standard input, from
-//! filesystem paths, or from external commands while enforcing upstream rsync's
-//! permission checks.
+//! This module centralises password loading logic so the CLI's argument parser
+//! can delegate to cohesive helpers. The functions here keep responsibility
+//! focused on reading passwords from standard input, from filesystem paths, or
+//! from external commands while enforcing upstream rsync's permission checks.
 //! Tests operate through the exported helpers rather than touching the
-//! implementation details directly, which keeps the core file smaller and easier
-//! to audit.
+//! implementation details directly.
 
 use core::{
     message::{Message, Role},


### PR DESCRIPTION
Comment and rustdoc-only cleanup across the CLI frontend `execution/`,
`command_builder/`, and root-level modules. No logic, signature, or
control-flow changes.

- Add missing module (`//!`) docs where a true module file lacked one.
- Fix stale doc claims verified against the code: `numeric.rs` no longer
  lists a nonexistent `--human-readable` parser; `size.rs` drops the
  unsupported exa (`E`) suffix; `preflight.rs` corrects the ACL/xattr
  check-site line numbers; `password.rs` no longer points at a `lib.rs`
  parser that does not exist.
- Remove a restatement comment and tidy trailing punctuation.

All `upstream:` citations preserved verbatim (before/after counts identical).
