### PR TITLE
fix(cli): drop dead --compress-level help and stale exa size doc

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/connection_and_logging_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/connection_and_logging_options.rs
@@ -88,7 +88,6 @@ pub(crate) fn add_connection_and_logging_options(command: ClapCommand) -> ClapCo
                 .long("compress-level")
                 .visible_alias("zl")
                 .value_name("LEVEL")
-                .help("Set compression level (0 disables compression).")
                 .help("Set compression level (0-9). 0 disables compression.")
                 .value_parser(OsStringValueParser::new()),
         )

--- a/crates/cli/src/frontend/execution/options/size.rs
+++ b/crates/cli/src/frontend/execution/options/size.rs
@@ -1,7 +1,7 @@
 //! Size specification parsing for arguments with optional unit suffixes.
 //!
 //! Handles `--block-size`, `--max-size`, `--min-size`, and `--max-alloc` arguments.
-//! Supports binary (K/M/G/T/P/E = powers of 1024) and decimal (KB/MB/GB = powers of 1000)
+//! Supports binary (K/M/G/T/P = powers of 1024) and decimal (KB/MB/GB = powers of 1000)
 //! suffixes, as well as explicit binary suffixes (KiB/MiB/GiB).
 //! Mirrors upstream rsync's size parsing behavior.
 


### PR DESCRIPTION
Two small correctness fixes surfaced while auditing `cli/frontend` (salvaged from a superseded duplicate PR, without its regressions):

- **`--compress-level` dead duplicate `.help()`** — the arg chained two `.help()` calls with *inconsistent* text; clap keeps only the last, so the first was dead code and contradictory. Removed it (effective help text unchanged).
- **`size.rs` stale doc** — the module header listed an `E` (exa) suffix, but the parser rejects it (`parse_size_spec_exa_suffix_rejected`; upstream's suffix switch stops at `P`). Dropped `E` to match the code.

No behavior change; the compress-level help output is identical.
