### PR TITLE
fix(release): repair release-notes overflow and benchmark chart skew

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -35,17 +35,23 @@ The `-beta` / `-nightly` suffix denotes the **Rust toolchain** the artifact was 
 
 ### Highlights
 
-<!-- Per-release: write 1-2 sentence summaries per category. Delete categories with no changes. -->
+See the [CHANGELOG](https://github.com/oferchen/rsync/blob/master/CHANGELOG.md) for the full, per-category list of changes in this release.
 
-**Daemon features.** <!-- e.g. new directives, auth changes, config parsing -->
+<!-- Optional per-release: add 1-2 sentence summaries per category above the
+     CHANGELOG link. Delete any category with no changes. Keep the CHANGELOG
+     link so the Highlights section is never empty.
+**Daemon features.** e.g. new directives, auth changes, config parsing
+**Transfer options.** e.g. new CLI flags, option wiring, batch mode
+**Performance.** e.g. hot-path optimizations, memory reductions, I/O changes
+**Bug fixes.** e.g. count + notable fixes
+**Testing.** e.g. new test coverage, interop additions
+-->
 
-**Transfer options.** <!-- e.g. new CLI flags, option wiring, batch mode -->
+<!-- Note: the release workflow sets generate_release_notes=false to avoid
+     overflowing GitHub's 125000-char release-body limit on large releases;
+     the CHANGELOG link above is the canonical full change list. -->
 
-**Performance.** <!-- e.g. hot-path optimizations, memory reductions, I/O changes -->
 
-**Bug fixes.** <!-- e.g. count + notable fixes -->
-
-**Testing.** <!-- e.g. new test coverage, interop additions -->
 
 ---
 

--- a/.github/scripts/benchmark_chart.py
+++ b/.github/scripts/benchmark_chart.py
@@ -223,6 +223,24 @@ def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
         if groups:
             y += MODE_GAP
 
+        # Per-group horizontal scale. A single global scale (driven by the one
+        # slowest test across every mode) crushes the sub-second groups into
+        # unreadable stubs while a few multi-second cases stretch across, so
+        # each mode group is scaled to its own slowest bar instead. Absolute
+        # times stay legible via the per-bar ms labels; the ratio column
+        # carries the cross-group comparison.
+        group_times: list[float] = []
+        for t in mode_tests:
+            if _is_three_way_ssh(mode, t):
+                group_times.append(t["upstream_ssh"]["mean"])
+                group_times.append(t["oc_subprocess"]["mean"])
+                group_times.append(t["oc_russh"]["mean"])
+            else:
+                group_times.append(t["upstream"]["mean"])
+                group_times.append(t["oc_rsync"]["mean"])
+        group_max = max(group_times) if group_times else 1.0
+        group_scale = BAR_AREA_WIDTH / (group_max * 1.1)
+
         header_y = y + MODE_HEADER_HEIGHT * 0.7
         y += MODE_HEADER_HEIGHT
 
@@ -257,10 +275,12 @@ def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
                 oc_t = t["oc_rsync"]["mean"]
                 third_t = None
 
-            up_w = max(up_t * scale, MIN_BAR_WIDTH)
-            oc_w = max(oc_t * scale, MIN_BAR_WIDTH)
+            up_w = max(up_t * group_scale, MIN_BAR_WIDTH)
+            oc_w = max(oc_t * group_scale, MIN_BAR_WIDTH)
             third_w = (
-                max(third_t * scale, MIN_BAR_WIDTH) if third_t is not None else None
+                max(third_t * group_scale, MIN_BAR_WIDTH)
+                if third_t is not None
+                else None
             )
 
             if mode in OPENSSL_MODES:
@@ -674,8 +694,8 @@ def generate_chart(data: dict) -> str:
         f"{size_mb} MB, {files} files \u2014 Linux x86_64 CI",
     )
 
-    builder.add_grid(layout.max_time, layout.scale, TOP_MARGIN, layout.content_bottom)
-
+    # No global x-axis grid: with per-group scaling a single shared axis would
+    # be misleading. Each bar carries its own ms label instead.
     for group in layout.groups:
         builder.add_mode_group(group, layout.scale)
 

--- a/.github/scripts/benchmark_report.py
+++ b/.github/scripts/benchmark_report.py
@@ -92,8 +92,12 @@ def highlight_lines(summary):
     lines = ["### Highlights\n"]
     avg = summary.get("avg_ratio")
     if avg is not None:
+        phrase = speedup_phrase(avg)
+        # "at parity" reads "at parity with upstream"; a speedup reads
+        # "Nx faster/slower than upstream".
+        connector = "with" if phrase == "at parity" else "than"
         lines.append(
-            f"- **Overall:** oc-rsync is {speedup_phrase(avg)} than upstream "
+            f"- **Overall:** oc-rsync is {phrase} {connector} upstream "
             f"on average across transfer modes."
         )
     wins = [(m, r) for m, r in ranked if r < 0.95][:3]

--- a/.github/workflows/release-cross.yml
+++ b/.github/workflows/release-cross.yml
@@ -796,7 +796,12 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           body_path: release_body.md
-          generate_release_notes: true
+          # Do NOT auto-generate the full per-PR changelog: a release spanning
+          # ~1000+ PRs overflows GitHub's 125000-char release-body limit, which
+          # truncates the notes mid-entry and makes later body edits (the
+          # benchmark/criterion append steps) fail with HTTP 422. The curated
+          # CHANGELOG.md link in the template body covers the full change list.
+          generate_release_notes: false
           files: |
             dist/**/*.tar.gz
             dist/**/*.deb


### PR DESCRIPTION
The v0.6.4 release exposed several release-output defects, all fixed here so they don't recur.

## 1. Release-notes overflow (empty Highlights + truncated notes + failed benchmark append)
`release-cross.yml` set `generate_release_notes: true` alongside the curated `body_path`, so GitHub's full auto-categorized ~1,200-PR list was appended to the template body and blew past GitHub's **125,000-char release-body limit**: notes truncated mid-entry, the `### Highlights` placeholder left unfilled, and every later body edit (the `Benchmark` / `Criterion` append steps) failed with `HTTP 422: body is too long`.
- **`release-cross.yml`**: `generate_release_notes: false` — the curated `CHANGELOG.md` link is the canonical full change list.
- **`RELEASE_TEMPLATE.md`**: `### Highlights` defaults to a `CHANGELOG` link so it is never empty; per-category authoring prompts move into a comment.

## 2. Skewed benchmark chart
`benchmark_chart.py` computed a single global x-axis scale from the one slowest test across all modes (100K-files at ~3s), crushing every sub-second mode group into unreadable stubs while a few multi-second cases stretched across the width.
- **`benchmark_chart.py`**: scale each mode group to its own slowest bar; per-bar ms labels keep absolute times and the ratio column carries the cross-group comparison. Drop the now-meaningless global grid.

## 3. Benchmark report grammar
- **`benchmark_report.py`**: `oc-rsync is at parity than upstream` → `... at parity with upstream` (speedups still read `Nx faster/slower than upstream`).

## Not in this PR (recommended follow-up)
The benchmark *workload* (148 MB, sub-second) is too small to be representative: fixed per-run overhead (daemon/SSH connection setup) dominates the ratios. A representative run needs a larger workload and, ideally, the stable physical x86_64 host rather than a shared GitHub runner. Tracked separately.

The live v0.6.4 release body was repaired by hand (Highlights -> CHANGELOG v0.6.4 section; skewed benchmark section + png removed).
