### PR TITLE
fix: client-receiver output fidelity - --progress on pulls, -v/-vi names, flist banner, total-size

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -127,7 +127,13 @@ where
     // `-v` transfers get no banner); additionally require the FLIST info
     // category so `--info=flist0` suppresses the banner even at `-v`, matching
     // upstream's per-category gate rather than a raw verbose-level check.
-    let emit_flist_banner = config.recursive() && info_gte(InfoFlag::Flist, 1);
+    // upstream: flist.c:2251 emits "sending incremental file list" only on the
+    // sender (`!am_server`). The client is the sender on a push and a local
+    // copy, and the receiver on a pull - where the receiver separately prints
+    // "receiving incremental file list" - so suppress the "sending" banner for
+    // a pull to avoid printing both.
+    let emit_flist_banner =
+        config.recursive() && info_gte(InfoFlag::Flist, 1) && !config.is_pull();
     // Capture the preserve-links state before `config` is consumed so the
     // `--list-only` renderer knows whether to append the ` -> <target>` arrow
     // to symlink rows (upstream: generator.c:1183 gates it on preserve_links).

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -132,8 +132,7 @@ where
     // copy, and the receiver on a pull - where the receiver separately prints
     // "receiving incremental file list" - so suppress the "sending" banner for
     // a pull to avoid printing both.
-    let emit_flist_banner =
-        config.recursive() && info_gte(InfoFlag::Flist, 1) && !config.is_pull();
+    let emit_flist_banner = config.recursive() && info_gte(InfoFlag::Flist, 1) && !config.is_pull();
     // Capture the preserve-links state before `config` is consumed so the
     // `--list-only` renderer knows whether to append the ` -> <target>` arrow
     // to symlink rows (upstream: generator.c:1183 gates it on preserve_links).

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -122,16 +122,15 @@ where
     // direction arrow (upstream: log.c:701-704 - `<` for sender, `>` otherwise).
     let is_sender = config.is_local_sender();
     // upstream: flist.c:2251 emits "sending incremental file list" only when
-    // `inc_recurse && INFO_GTE(FLIST, 1) && !am_server`. compat.c:172 disables
-    // inc_recurse when `!recurse`, so mirror the recursion gate (single-file
-    // `-v` transfers get no banner); additionally require the FLIST info
-    // category so `--info=flist0` suppresses the banner even at `-v`, matching
-    // upstream's per-category gate rather than a raw verbose-level check.
-    // upstream: flist.c:2251 emits "sending incremental file list" only on the
-    // sender (`!am_server`). The client is the sender on a push and a local
-    // copy, and the receiver on a pull - where the receiver separately prints
-    // "receiving incremental file list" - so suppress the "sending" banner for
-    // a pull to avoid printing both.
+    // `inc_recurse && INFO_GTE(FLIST, 1) && !am_server`. Mirror each gate:
+    // - compat.c:172 disables inc_recurse when `!recurse`, so a single-file
+    //   `-v` transfer gets no banner (`config.recursive()`);
+    // - the FLIST info category gate lets `--info=flist0` suppress it even at
+    //   `-v` (`info_gte(Flist, 1)`);
+    // - `!am_server` means the sender prints it: the client is the sender on a
+    //   push and a local copy, and the receiver on a pull (which separately
+    //   prints "receiving incremental file list"), so suppress it on a pull
+    //   (`!config.is_pull()`) to avoid printing both banners.
     let emit_flist_banner = config.recursive() && info_gte(InfoFlag::Flist, 1) && !config.is_pull();
     // Capture the preserve-links state before `config` is consumed so the
     // `--list-only` renderer knows whether to append the ` -> <target>` arrow

--- a/crates/core/src/client/config/client/arguments.rs
+++ b/crates/core/src/client/config/client/arguments.rs
@@ -196,6 +196,25 @@ mod tests {
     }
 
     #[test]
+    fn is_pull_true_only_when_a_source_is_remote() {
+        // Pull: a source operand is remote -> local client is the receiver.
+        let pull = ClientConfig::builder()
+            .transfer_args([OsString::from("host:src/"), OsString::from("dst/")])
+            .build();
+        assert!(pull.is_pull());
+        // Push: remote dest, local source -> client is the sender, not a pull.
+        let push = ClientConfig::builder()
+            .transfer_args([OsString::from("src/"), OsString::from("host:dst/")])
+            .build();
+        assert!(!push.is_pull());
+        // Local copy: no remote operand -> client is the sender, not a pull.
+        let local = ClientConfig::builder()
+            .transfer_args([OsString::from("src/"), OsString::from("dst/")])
+            .build();
+        assert!(!local.is_pull());
+    }
+
+    #[test]
     fn is_local_sender_rsync_url_pull_reports_receiver() {
         // Daemon pull via rsync:// URL.
         let config = ClientConfig::builder()

--- a/crates/core/src/client/config/client/arguments.rs
+++ b/crates/core/src/client/config/client/arguments.rs
@@ -102,6 +102,27 @@ impl ClientConfig {
         //   case.
         dest_remote && !any_source_remote
     }
+
+    /// Whether this transfer is a pull: at least one source operand is remote,
+    /// so the local process is the receiver rather than the sender.
+    ///
+    /// A push (remote destination, local sources) and a local copy both send
+    /// the file list from the local process, so neither is a pull.
+    ///
+    /// upstream: `flist.c:2251` prints "sending incremental file list" only on
+    /// the sender (`!am_server`); the client is `am_sender` for a push and a
+    /// local copy, and the receiver for a pull (which prints "receiving").
+    #[must_use]
+    pub fn is_pull(&self) -> bool {
+        use crate::client::remote::operand_is_remote;
+
+        if self.transfer_args.len() < 2 {
+            return false;
+        }
+
+        let (sources, _destination) = self.transfer_args.split_at(self.transfer_args.len() - 1);
+        sources.iter().any(|s| operand_is_remote(s))
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -506,6 +506,12 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // without this. Mirrors the daemon path (daemon_transfer server_config.rs).
     server_config.flags.verbose = config.verbosity() > 0;
     server_config.flags.verbose_level = config.verbosity();
+    // upstream: options.c msgs2stderr - FINFO (`-v` names) go to stderr when
+    // `--msgs2stderr` is set. The in-process client receiver emits `-v` names
+    // in flist order directly (interleaved with `--progress`), so it needs the
+    // routing decision here; the default (None) and `--no-msgs2stderr` keep
+    // names on stdout.
+    server_config.flags.msgs_to_stderr = config.msgs2stderr() == Some(true);
     // upstream: flist.c::iconv_for_local and options.c::recv_iconv_settings -
     // when --iconv is configured, the local process must transcode file-list
     // entries between the local and remote charsets. Without this bridge the

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -111,6 +111,10 @@ pub struct ParsedServerFlags {
     /// generator.c:582-583). Collapsing to the `verbose` bool alone loses the
     /// level needed to surface `-ivv` unchanged rows.
     pub verbose_level: u8,
+    /// Route `-v` name / info output to stderr instead of stdout
+    /// (`--msgs2stderr`). Mirrors upstream's `msgs2stderr` FINFO routing;
+    /// consumed by the in-order `-v` name emitter on a client pull.
+    pub msgs_to_stderr: bool,
     /// Compress during transfer (`z` flag, `--compress`).
     pub compress: bool,
     /// Checksum-based transfer (`c` flag, `--checksum`).

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -289,6 +289,24 @@ pub struct ReceiverContext {
     /// redo re-itemizing an entry. `RefCell` suffices: every emit site runs on
     /// the main driver thread (rayon workers never touch this).
     pub(in crate::receiver) itemize_rows: RefCell<BTreeMap<usize, Vec<String>>>,
+    /// When set, plain `-v` (name-only, no `-i`) client-mode file names are
+    /// emitted in flist-index order as each file is reached in the transfer
+    /// loop - interleaved with `--progress` - instead of being buffered in the
+    /// logging event queue and rendered as a block at end of run. This restores
+    /// upstream's `log_before_transfer` behaviour (`receiver.c:1008-1012`, name
+    /// printed per file just before its data). Only [`Self::run_pipelined`]
+    /// opts in; `-i`/`-vi` itemize output is unaffected and still flows through
+    /// [`Self::itemize_rows`].
+    pub(in crate::receiver) interleave_names: bool,
+    /// Directory (and other pre-transfer) `-v` name lines buffered under their
+    /// flist index while [`Self::interleave_names`] is set, released in
+    /// ascending index order just before each child file is reached (and any
+    /// trailing entries flushed at end) so a directory name precedes its
+    /// children exactly as upstream's single flist-order walk emits them.
+    pub(in crate::receiver) name_rows: RefCell<BTreeMap<usize, Vec<String>>>,
+    /// True when `-v` name output should be routed to stderr rather than stdout
+    /// (`--msgs2stderr`). Mirrors upstream's `msgs2stderr` FINFO routing.
+    pub(in crate::receiver) names_to_stderr: bool,
     /// Count of server-mode hardlink-follower itemize records emitted this phase
     /// that the peer's sender will echo back (upstream `sender.c:286-292` echoes
     /// every non-transfer item). The pipeline response loop is request-count
@@ -396,6 +414,9 @@ impl ReceiverContext {
             hardlink_lookahead_target: 500,
             defer_itemize: false,
             itemize_rows: RefCell::new(BTreeMap::new()),
+            interleave_names: false,
+            name_rows: RefCell::new(BTreeMap::new()),
+            names_to_stderr: false,
             hardlink_follower_echoes: std::cell::Cell::new(0),
             created_stats: std::cell::Cell::new(protocol::stats::CreatedStats::new()),
             delayed_delete_victims: Vec::new(),

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -307,6 +307,12 @@ pub struct ReceiverContext {
     /// True when `-v` name output should be routed to stderr rather than stdout
     /// (`--msgs2stderr`). Mirrors upstream's `msgs2stderr` FINFO routing.
     pub(in crate::receiver) names_to_stderr: bool,
+    /// True when a live `--progress` renderer is active on the client. The
+    /// renderer already prints each transferred file's name before its bar, so
+    /// while it runs the receiver only releases buffered directory names in
+    /// order (the renderer never sees directory entries) and leaves the file
+    /// names to it, avoiding a duplicate name per file.
+    pub(in crate::receiver) progress_active: bool,
     /// Count of server-mode hardlink-follower itemize records emitted this phase
     /// that the peer's sender will echo back (upstream `sender.c:286-292` echoes
     /// every non-transfer item). The pipeline response loop is request-count
@@ -417,6 +423,7 @@ impl ReceiverContext {
             interleave_names: false,
             name_rows: RefCell::new(BTreeMap::new()),
             names_to_stderr: false,
+            progress_active: false,
             hardlink_follower_echoes: std::cell::Cell::new(0),
             created_stats: std::cell::Cell::new(protocol::stats::CreatedStats::new()),
             delayed_delete_victims: Vec::new(),

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -787,7 +787,13 @@ impl ReceiverContext {
             }
         }
 
-        if self.config.flags.verbose && self.config.connection.client_mode {
+        // Under `-i`/`-vi` the itemize row already carries the directory name
+        // (upstream `-vi` uses `%i %n`), so the bare `-v` name is suppressed to
+        // avoid a duplicate line; only plain `-v` emits it.
+        if self.config.flags.verbose
+            && self.config.connection.client_mode
+            && !self.should_emit_itemize()
+        {
             if relative_path.as_os_str() == "." {
                 info_log!(Name, 1, "./");
             } else {

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -390,4 +390,134 @@ impl ReceiverContext {
         }
         Ok(())
     }
+
+    /// Writes one `-v` name line to the client's own output stream, honouring
+    /// `--msgs2stderr` (upstream FINFO routes to stderr when set, else stdout).
+    ///
+    /// Client-mode only: this is the local-pull equivalent of upstream
+    /// `log_item(FCLIENT, ...)`. A server receiver's names travel as wire
+    /// itemize and are printed by the peer's sender, so this is never called
+    /// off the client.
+    fn emit_name_line(&self, line: &str) -> std::io::Result<()> {
+        use std::io::Write as _;
+        if self.names_to_stderr {
+            std::io::stderr().write_all(line.as_bytes())
+        } else {
+            std::io::stdout().write_all(line.as_bytes())
+        }
+    }
+
+    /// Buffers a pre-transfer `-v` name (a directory reached in phase 1) under
+    /// its flist index, to be released in order just before its first child is
+    /// reached in the phase-2 transfer loop.
+    pub(in crate::receiver) fn buffer_deferred_name(&self, flist_idx: usize, line: String) {
+        self.name_rows
+            .borrow_mut()
+            .entry(flist_idx)
+            .or_default()
+            .push(line);
+    }
+
+    /// Records a transferred file's `-v` name at its flist index and flushes
+    /// every buffered name up to and including that index, in ascending order,
+    /// so any directories that precede the file print immediately before it -
+    /// interleaved with `--progress`. Mirrors upstream `log_before_transfer`
+    /// (`receiver.c:1008-1012`, name printed per file just before its data).
+    pub(in crate::receiver) fn emit_name_in_order(
+        &self,
+        flist_idx: usize,
+        line: String,
+    ) -> std::io::Result<()> {
+        self.name_rows
+            .borrow_mut()
+            .entry(flist_idx)
+            .or_default()
+            .push(line);
+        self.flush_names_through(flist_idx)
+    }
+
+    /// Drains buffered `-v` name lines with a flist index `<= upto`, in
+    /// ascending index order, writing each to the client stream.
+    fn flush_names_through(&self, upto: usize) -> std::io::Result<()> {
+        let ready = take_names_through(&mut self.name_rows.borrow_mut(), upto);
+        for line in ready {
+            self.emit_name_line(&line)?;
+        }
+        Ok(())
+    }
+
+    /// Flushes any remaining buffered `-v` names (trailing directories with no
+    /// following transferred child) in ascending flist-index order. Called once
+    /// by the driver after the transfer loop, before finalization.
+    pub(in crate::receiver) fn flush_names_all(&self) -> std::io::Result<()> {
+        let all = take_names_through(&mut self.name_rows.borrow_mut(), usize::MAX);
+        for line in all {
+            self.emit_name_line(&line)?;
+        }
+        Ok(())
+    }
+}
+
+/// Removes every buffered name line whose flist index is `<= upto` and returns
+/// them flattened in ascending index order (and, within an index, in insertion
+/// order). Entries with an index above `upto` stay buffered for a later flush.
+///
+/// This is the watermark that interleaves `-v` directory names with their
+/// children: the transfer loop calls it with each transferred file's index, so
+/// the directories that precede that file drain out immediately before it.
+fn take_names_through(
+    rows: &mut std::collections::BTreeMap<usize, Vec<String>>,
+    upto: usize,
+) -> Vec<String> {
+    let keys: Vec<usize> = rows.range(..=upto).map(|(k, _)| *k).collect();
+    keys.into_iter()
+        .filter_map(|k| rows.remove(&k))
+        .flatten()
+        .collect()
+}
+
+#[cfg(test)]
+mod name_reorder_tests {
+    use super::take_names_through;
+    use std::collections::BTreeMap;
+
+    fn buf(pairs: &[(usize, &str)]) -> BTreeMap<usize, Vec<String>> {
+        let mut m: BTreeMap<usize, Vec<String>> = BTreeMap::new();
+        for (idx, line) in pairs {
+            m.entry(*idx).or_default().push((*line).to_string());
+        }
+        m
+    }
+
+    #[test]
+    fn drains_prefix_in_flist_order_and_retains_the_rest() {
+        // Dirs buffered up front at their flist indices; files reached in order.
+        let mut rows = buf(&[(0, "a/"), (2, "a/b/"), (5, "c/")]);
+
+        // Reaching file at index 1 releases only dir 0 (a/), before the file.
+        assert_eq!(take_names_through(&mut rows, 1), vec!["a/".to_string()]);
+        // File at index 3 releases dir 2 (a/b/) - which precedes it - not dir 5.
+        assert_eq!(take_names_through(&mut rows, 3), vec!["a/b/".to_string()]);
+        // The trailing dir at index 5 flushes only at end (usize::MAX).
+        assert!(take_names_through(&mut rows, 4).is_empty());
+        assert_eq!(
+            take_names_through(&mut rows, usize::MAX),
+            vec!["c/".to_string()]
+        );
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn same_index_preserves_insertion_order() {
+        let mut rows = buf(&[(2, "first"), (2, "second"), (1, "dir/")]);
+        // Ascending index, then insertion order within an index.
+        assert_eq!(
+            take_names_through(&mut rows, 2),
+            vec![
+                "dir/".to_string(),
+                "first".to_string(),
+                "second".to_string()
+            ],
+        );
+    }
 }

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -20,6 +20,28 @@ impl ReceiverContext {
         self.config.flags.info_flags.itemize
     }
 
+    /// Sum of source sizes counted toward the `--stats` "total size".
+    ///
+    /// Only regular files and symlinks contribute, never directories, devices,
+    /// or FIFOs - directory `st_size` in particular would inflate the total.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:690-691` / `flist.c:1242-1243` - `stats.total_size +=
+    ///   F_LENGTH(file)` guarded by `S_ISREG(mode) || S_ISLNK(mode)`.
+    pub(in crate::receiver) fn total_source_size(&self) -> u64 {
+        self.file_list
+            .iter()
+            .filter(|entry| {
+                matches!(
+                    entry.file_type(),
+                    protocol::flist::FileType::Regular | protocol::flist::FileType::Symlink
+                )
+            })
+            .map(|entry| entry.size())
+            .sum()
+    }
+
     /// Computes the itemize flags for an existing (already-present) directory
     /// by comparing its current on-disk metadata against the sender's file-list
     /// entry, mirroring upstream `generator.c:1480-1483` -> `itemize()` for the

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -437,8 +437,10 @@ impl ReceiverContext {
     }
 
     /// Drains buffered `-v` name lines with a flist index `<= upto`, in
-    /// ascending index order, writing each to the client stream.
-    fn flush_names_through(&self, upto: usize) -> std::io::Result<()> {
+    /// ascending index order, writing each to the client stream. Also used on
+    /// the `--progress` path to release directory names in order without
+    /// emitting the file name (the progress renderer prints that).
+    pub(in crate::receiver) fn flush_names_through(&self, upto: usize) -> std::io::Result<()> {
         let ready = take_names_through(&mut self.name_rows.borrow_mut(), upto);
         for line in ready {
             self.emit_name_line(&line)?;

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -59,8 +59,12 @@ impl ReceiverContext {
         }
         #[cfg(not(feature = "incremental-flist"))]
         {
-            let _ = progress;
-            self.run_pipelined(reader, writer, crate::pipeline::PipelineConfig::default())
+            self.run_pipelined(
+                reader,
+                writer,
+                crate::pipeline::PipelineConfig::default(),
+                progress,
+            )
         }
     }
 

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -459,7 +459,10 @@ impl ReceiverContext {
                                     format!("{}\n", file_entry.path().display()),
                                 );
                             }
-                        } else {
+                        } else if !self.should_emit_itemize() {
+                            // Plain `-v`: bare name. Under `-i`/`-vi` the
+                            // itemize row already carries the name, so suppress
+                            // this to avoid a duplicate line.
                             info_log!(Name, 1, "{}", file_entry.path().display());
                         }
                     }
@@ -618,8 +621,12 @@ impl ReceiverContext {
             // notice AFTER the transfer decision is known. In dry-run the
             // sender's echo confirms the file would have been transferred,
             // so emit the "updated" line at the post-decision point to
-            // match upstream wire order.
-            if self.config.flags.verbose && self.config.connection.client_mode {
+            // match upstream wire order. Under `-i`/`-vi` the itemize row
+            // already carries the name, so the bare name is suppressed.
+            if self.config.flags.verbose
+                && self.config.connection.client_mode
+                && !self.should_emit_itemize()
+            {
                 info_log!(Name, 1, "{}", file_entry.path().display());
             }
         }

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -443,15 +443,22 @@ impl ReceiverContext {
                         if self.interleave_names && !is_redo_pass {
                             // upstream: receiver.c:1008-1012 - the client prints
                             // each file's name per file (log_before_transfer),
-                            // in flist order, interleaved with --progress. Emit
-                            // it in order (flushing any preceding directory
-                            // names) instead of buffering for an end-of-run
-                            // block. The phase-2 redo re-transfers already-named
-                            // files, so it must not re-emit.
-                            let _ = self.emit_name_in_order(
-                                file_idx,
-                                format!("{}\n", file_entry.path().display()),
-                            );
+                            // in flist order, interleaved with --progress,
+                            // instead of buffering for an end-of-run block. The
+                            // phase-2 redo re-transfers already-named files, so
+                            // it must not re-emit.
+                            if self.progress_active {
+                                // The live --progress renderer already prints
+                                // this file's name before its bar; only release
+                                // the directory names that precede it (the
+                                // renderer never sees directory entries).
+                                let _ = self.flush_names_through(file_idx);
+                            } else {
+                                let _ = self.emit_name_in_order(
+                                    file_idx,
+                                    format!("{}\n", file_entry.path().display()),
+                                );
+                            }
                         } else {
                             info_log!(Name, 1, "{}", file_entry.path().display());
                         }

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -440,7 +440,21 @@ impl ReceiverContext {
                 // upstream: receiver.c:950 - log_item() after successful file transfer
                 {
                     if self.config.flags.verbose && self.config.connection.client_mode {
-                        info_log!(Name, 1, "{}", file_entry.path().display());
+                        if self.interleave_names && !is_redo_pass {
+                            // upstream: receiver.c:1008-1012 - the client prints
+                            // each file's name per file (log_before_transfer),
+                            // in flist order, interleaved with --progress. Emit
+                            // it in order (flushing any preceding directory
+                            // names) instead of buffering for an end-of-run
+                            // block. The phase-2 redo re-transfers already-named
+                            // files, so it must not re-emit.
+                            let _ = self.emit_name_in_order(
+                                file_idx,
+                                format!("{}\n", file_entry.path().display()),
+                            );
+                        } else {
+                            info_log!(Name, 1, "{}", file_entry.path().display());
+                        }
                     }
                     // upstream: generator.c:1925-1937 - the transfer itemize is
                     // emitted right after the file request. With

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -35,6 +35,7 @@ impl ReceiverContext {
         reader: crate::reader::ServerReader<R>,
         writer: &mut W,
         pipeline_config: PipelineConfig,
+        mut progress: Option<&mut dyn crate::TransferProgressCallback>,
     ) -> io::Result<TransferStats> {
         let _t = PhaseTimer::new("receiver-transfer-pipelined");
         // Buffer itemize rows and flush them once in flist-index order before
@@ -187,7 +188,6 @@ impl ReceiverContext {
         } else {
             let total_files = files_to_transfer.len();
             let redo_config = pipeline_config.clone();
-            let mut no_progress: Option<&mut dyn crate::TransferProgressCallback> = None;
             let redo_indices;
             let delayed;
             (
@@ -207,7 +207,7 @@ impl ReceiverContext {
                 &mut metadata_errors,
                 false,
                 total_files,
-                &mut no_progress,
+                &mut progress,
             )?;
             all_delayed_updates.extend(delayed);
 
@@ -255,7 +255,7 @@ impl ReceiverContext {
                     &mut metadata_errors,
                     true,
                     total_files,
-                    &mut no_progress,
+                    &mut progress,
                 )?;
 
                 files_transferred += redo_transferred;

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -42,6 +42,19 @@ impl ReceiverContext {
         // (upstream's single flist-index-order walk, generator.c:2329-2344)
         // rather than oc's two-phase "all dirs, then all files" emission.
         self.defer_itemize = true;
+        // Interleave plain `-v` (name-only, no `-i`) client-mode file names
+        // with --progress in flist order, matching upstream log_before_transfer
+        // (receiver.c:1008-1012). `-i`/`-vi` itemize output is unaffected (it
+        // flows through the deferred itemize_rows path). Skips the non-transfer
+        // dispatches (list-only, dry-run, only-write-batch) so their existing
+        // emission order is untouched.
+        self.interleave_names = self.config.flags.verbose
+            && self.config.connection.client_mode
+            && !self.should_emit_itemize()
+            && !self.config.flags.list_only
+            && !self.config.flags.dry_run
+            && !self.config.flags.only_write_batch;
+        self.names_to_stderr = self.config.flags.msgs_to_stderr;
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
 
@@ -126,6 +139,32 @@ impl ReceiverContext {
         let mut matched_data: u64 = 0;
         let mut redo_count: usize = 0;
         let mut all_delayed_updates: Vec<(PathBuf, PathBuf)> = Vec::new();
+
+        // Buffer directory `-v` names under their flist index so each is
+        // released immediately before its first child is reached in the
+        // transfer loop below (upstream emits the directory row as its flist
+        // entry is reached, so a directory precedes its children). Trailing
+        // directories with no transferred child flush at end of run.
+        if self.interleave_names {
+            let dir_names: Vec<(usize, String)> = self
+                .file_list
+                .iter()
+                .enumerate()
+                .filter(|(_, entry)| entry.is_dir())
+                .map(|(idx, entry)| {
+                    let rel = entry.path();
+                    let line = if rel.as_os_str() == "." {
+                        "./\n".to_string()
+                    } else {
+                        format!("{}/\n", rel.display())
+                    };
+                    (idx, line)
+                })
+                .collect();
+            for (idx, line) in dir_names {
+                self.buffer_deferred_name(idx, line);
+            }
+        }
 
         // upstream: generator.c:1249 - list-only renders every flist entry via
         // list_file_entry() and sends NO per-file NDX request. Only the existing
@@ -228,7 +267,12 @@ impl ReceiverContext {
             }
         }
 
-        if self.config.flags.verbose && self.config.connection.client_mode {
+        // When interleaving `-v` names (the plain `-v` client pull), directory
+        // names were buffered up front and released in flist order alongside
+        // their children in the transfer loop above, so skip this end-of-run
+        // block; any trailing directories flush just below via flush_names_all.
+        if self.config.flags.verbose && self.config.connection.client_mode && !self.interleave_names
+        {
             for file_entry in &self.file_list {
                 if file_entry.is_dir() {
                     let relative_path = file_entry.path();
@@ -277,8 +321,11 @@ impl ReceiverContext {
         // directory mtimes after file writes clobber them.
         self.touch_up_dirs(&setup.dest_dir, writer);
 
-        // Drain the deferred itemize rows in flist-index order before the
-        // goodbye handshake, matching upstream's single-pass emission ordering.
+        // Flush any trailing buffered `-v` directory names (those with no
+        // transferred child to release them mid-loop), then drain the deferred
+        // itemize rows in flist-index order before the goodbye handshake,
+        // matching upstream's single-pass emission ordering.
+        self.flush_names_all()?;
         self.flush_itemize_rows(writer)?;
 
         self.finalize_transfer(reader, writer)?;

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -56,6 +56,7 @@ impl ReceiverContext {
             && !self.config.flags.dry_run
             && !self.config.flags.only_write_batch;
         self.names_to_stderr = self.config.flags.msgs_to_stderr;
+        self.progress_active = progress.is_some();
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
 

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -272,7 +272,10 @@ impl ReceiverContext {
         // names were buffered up front and released in flist order alongside
         // their children in the transfer loop above, so skip this end-of-run
         // block; any trailing directories flush just below via flush_names_all.
-        if self.config.flags.verbose && self.config.connection.client_mode && !self.interleave_names
+        if self.config.flags.verbose
+            && self.config.connection.client_mode
+            && !self.interleave_names
+            && !self.should_emit_itemize()
         {
             for file_entry in &self.file_list {
                 if file_entry.is_dir() {
@@ -338,7 +341,7 @@ impl ReceiverContext {
         // alone only skips the file and carries no exit-code bits.
         stats.io_error |= reader.take_io_error();
 
-        let total_source_bytes: u64 = self.file_list.iter().map(|e| e.size()).sum();
+        let total_source_bytes: u64 = self.total_source_size();
 
         stats.files_transferred = files_transferred;
         stats.transferred_file_size = transferred_file_size;

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -293,7 +293,7 @@ impl ReceiverContext {
         stats.bytes_received = bytes_received;
         stats.literal_data = literal_data;
         stats.matched_data = matched_data;
-        stats.total_source_bytes = self.file_list.iter().map(|e| e.size()).sum();
+        stats.total_source_bytes = self.total_source_size();
         if !metadata_errors.is_empty() || stats.directories_failed > 0 || stats.files_skipped > 0 {
             stats.io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
         }

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -155,6 +155,7 @@ impl ReceiverContext {
                 if file_entry.is_dir()
                     && self.config.flags.verbose
                     && self.config.connection.client_mode
+                    && !self.should_emit_itemize()
                 {
                     if relative_path.as_os_str() == "." {
                         info_log!(Name, 1, "./");
@@ -555,8 +556,12 @@ impl ReceiverContext {
             // enters the delta loop when the generator selected the file
             // for transfer), so emit the upstream "updated" line. Uptodate
             // files are routed through the event-stream MetadataReused path
-            // and never reach this point.
-            if self.config.flags.verbose && self.config.connection.client_mode {
+            // and never reach this point. Under `-i`/`-vi` the itemize row
+            // already carries the name, so the bare name is suppressed.
+            if self.config.flags.verbose
+                && self.config.connection.client_mode
+                && !self.should_emit_itemize()
+            {
                 info_log!(Name, 1, "{}", relative_path.display());
             }
 
@@ -592,7 +597,7 @@ impl ReceiverContext {
         // alone only skips the file and carries no exit-code bits.
         let sender_io_error = reader.take_io_error();
 
-        let total_source_bytes: u64 = self.file_list.iter().map(|e| e.size()).sum();
+        let total_source_bytes: u64 = self.total_source_size();
 
         // upstream: main.c:794-796 - count the pre-flight-created destination
         // root as a created dir (FLAG_DIR_CREATED -> ITEM_IS_NEW). See the


### PR DESCRIPTION
Closes #6781. **Root-caused, fixed, and validated on the x86_64 Linux host against the real rsync 3.4.4 binary** (SSH pull). A cluster of client-receiver output-fidelity fixes surfaced by that validation.

## 1. `--progress` was a no-op on pulls (the real #6781)
The shipped binary always takes the `run_pipelined` receiver path (`transfer` is pulled `default-features=false` and nothing re-enables `transfer/incremental-flist`), and that path **discarded the `--progress` callback** (`let _ = progress`). So `--progress` produced no per-file output at all - the reporter's "No realtime output with Progress flag." **Fix:** thread the progress callback through `run_pipelined` (main + phase-2 redo).

## 2. `-v` names batched at end instead of interleaving
Names were buffered and flushed as an end-of-run block. **Fix:** emit `-v` names in flist order from the transfer loop (upstream `log_before_transfer`, `receiver.c:1008-1012`) with a directory-name **watermark** so a directory prints just before its first child. When `--progress` is live the CLI renderer already prints file names, so the receiver then releases only directory names (no duplicate). `--msgs2stderr` threaded in for FINFO routing.

## 3. `-vi` printed bare names *and* itemize rows
Upstream `-vi` uses `%i %n%L` - one line per entry, name embedded (`options.c:2354-2374`). oc printed an extra bare name. **Fix:** gate every client bare-name emit on `!should_emit_itemize()` (files/dirs/dry-run/sync/incremental); the itemize row still carries the name.

## 4. Spurious "sending incremental file list" on a pull
Upstream prints "sending" only on the sender (`!am_server`, `flist.c:2251`); a pull client prints "receiving". oc's gate omitted the direction check. **Fix:** add `config.is_pull()` and suppress the sending banner on a pull (push and local copies still print it).

## 5. `--stats` "total size" over-counted by directory sizes
Upstream sums `total_size` over regular files and symlinks only (`flist.c:690-691/1242-1243`). The receiver summed `.size()` over every flist entry, so directory `st_size` inflated the total. **Fix:** a DRY `total_source_size()` helper applying the upstream type filter, used at all three receive paths. (The local-copy accumulator already counts only regular files + symlinks - verified, no change.)

## Host validation (rsync 3.4.4, SSH pull)
```
UPSTREAM  interleaved=True  pattern=NPNPNPNPNPNPNPNPNP
OC-RSYNC  interleaved=True  pattern=NPNPNPNPNPNPNPNPNP
dest trees identical: True
```
`-v --progress`: names interleave with bars, dirs in flist order, dest identical. `-i`, `-vi`, `-v`, and `-v --msgs2stderr` outputs now match upstream except for a pre-existing ~46-byte difference in the `sent N bytes` control-channel counter (transferred data + dest identical; not a stats-counting bug, out of scope).

## Scope / safety
Gated on `client_mode`; server/push mode, `-i`-only, dry-run, list-only, only-write-batch preserved. Phase-2 redo does not re-emit names. `name_reorder_tests` covers the watermark ordering; clippy clean on transfer/core/cli.
