### PR TITLE
feat(xtask): add validate command for drop-in fidelity matrix

### DIFF
--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -80,6 +80,12 @@ pub struct ValidateMatrixArgs {
     #[arg(long = "transport", value_name = "NAME")]
     pub transports: Vec<String>,
 
+    /// Ad-hoc rsync flag set to validate for oc-vs-upstream content and metadata
+    /// parity across every transport (repeatable, whitespace-separated), e.g.
+    /// `--flags "-a --sparse"`. Lets any option be checked without new code.
+    #[arg(long = "flags", value_name = "FLAGS")]
+    pub flags: Vec<String>,
+
     /// Run the many-small-files benchmark after the correctness matrix.
     #[arg(long)]
     pub bench: bool,

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -89,6 +89,11 @@ pub struct ValidateMatrixArgs {
     #[arg(long)]
     pub edge_cases: bool,
 
+    /// Run root-only validations (device/FIFO/socket nodes, id remaps). Only
+    /// takes effect when the process is actually running as root.
+    #[arg(long)]
+    pub root: bool,
+
     /// File count for the benchmark workload.
     #[arg(long, value_name = "N")]
     pub bench_files: Option<usize>,

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -68,6 +68,34 @@ pub enum Command {
 
     /// Run the workspace test suite (prefers cargo-nextest).
     Test(TestArgs),
+
+    /// Validate drop-in fidelity vs upstream rsync across all client transports.
+    Validate(ValidateMatrixArgs),
+}
+
+/// Arguments for the `validate` command.
+#[derive(Parser, Debug, Default)]
+pub struct ValidateMatrixArgs {
+    /// Transports to exercise (repeatable). Default: all.
+    #[arg(long = "transport", value_name = "NAME")]
+    pub transports: Vec<String>,
+
+    /// Run the many-small-files benchmark after the correctness matrix.
+    #[arg(long)]
+    pub bench: bool,
+
+    /// Enrich fixtures with edge cases (empty files, spaces/unicode names, deep
+    /// nesting, dangling symlinks). Off by default for a fast, lean matrix.
+    #[arg(long)]
+    pub edge_cases: bool,
+
+    /// File count for the benchmark workload.
+    #[arg(long, value_name = "N")]
+    pub bench_files: Option<usize>,
+
+    /// Print each transfer's command and stdout on failure.
+    #[arg(long)]
+    pub verbose: bool,
 }
 
 /// Benchmark mode.
@@ -434,6 +462,7 @@ impl CommandExt for Command {
             Command::ReleaseNotes(_) => Box::new(ReleaseNotesTask),
             Command::Sbom(_) => Box::new(SbomTask),
             Command::Test(args) => args.as_task(),
+            Command::Validate(_) => Box::new(ValidateTask),
         }
     }
 }
@@ -553,6 +582,23 @@ impl Task for ManPageTask {
 
     fn explicit_duration(&self) -> Option<Duration> {
         Some(Duration::from_secs(5))
+    }
+}
+
+/// Task for drop-in fidelity validation.
+struct ValidateTask;
+
+impl Task for ValidateTask {
+    fn name(&self) -> &'static str {
+        "validate"
+    }
+
+    fn description(&self) -> &'static str {
+        "Validate drop-in fidelity vs upstream rsync across all transports"
+    }
+
+    fn explicit_duration(&self) -> Option<Duration> {
+        Some(Duration::from_secs(60))
     }
 }
 

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -13,3 +13,4 @@ pub mod release;
 pub mod release_notes;
 pub mod sbom;
 pub mod test;
+pub mod validate;

--- a/xtask/src/commands/validate/bench.rs
+++ b/xtask/src/commands/validate/bench.rs
@@ -1,0 +1,107 @@
+//! Many-small-files loopback benchmark across transports.
+//!
+//! Generates a per-file-overhead workload (default 10k files) and times
+//! oc-rsync against upstream as the pulling client over each transport, taking
+//! the median wall time across a few runs. The numbers feed performance work;
+//! this is opt-in via `--bench`.
+
+use std::path::Path;
+use std::time::Instant;
+
+use crate::commands::validate::ValidateCtx;
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::error::{TaskError, TaskResult};
+
+/// Timed runs per (transport, client); the median is reported.
+const RUNS: usize = 3;
+/// Files per generated subdirectory.
+const PER_DIR: usize = 100;
+
+/// Run the benchmark and print a per-transport comparison table.
+pub fn run(ctx: &ValidateCtx, files: usize) -> TaskResult<()> {
+    let root = ctx.work.join("bench");
+    let src = root.join("src");
+    let bytes = generate(&src, files)?;
+    let flags: Vec<String> = ["-a"].iter().map(|s| s.to_string()).collect();
+
+    eprintln!(
+        "\n=== benchmark: {files} files, {:.1} MB, median of {RUNS} ===",
+        bytes as f64 / 1_048_576.0
+    );
+    for &transport in ctx.transports {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            eprintln!("  {label:<14}  SKIP (no sshd on localhost:22)");
+            continue;
+        }
+        let oc = median_secs(transport, ctx.oc, ctx, &src, &root.join("oc"), &flags)?;
+        // Upstream has no russh client; time it over its ssh-subprocess equivalent.
+        let up = median_secs(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx,
+            &src,
+            &root.join("up"),
+            &flags,
+        )?;
+        let speedup = if oc > 0.0 { up / oc } else { 0.0 };
+        eprintln!("  {label:<14}  oc {oc:6.3}s   upstream {up:6.3}s   ({speedup:.2}x)");
+    }
+    Ok(())
+}
+
+/// Median wall time of `RUNS` full pulls with `client` over `transport`.
+fn median_secs(
+    transport: Transport,
+    client: &Path,
+    ctx: &ValidateCtx,
+    src: &Path,
+    dst: &Path,
+    flags: &[String],
+) -> TaskResult<f64> {
+    let mut times = Vec::with_capacity(RUNS);
+    for _ in 0..RUNS {
+        let start = Instant::now();
+        let out = pull_into(transport, client, ctx.upstream, src, dst, flags, ctx.work)?;
+        if !out.status.success() {
+            return Err(TaskError::Validation(format!(
+                "benchmark transfer failed on {}: {}",
+                transport.label(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        times.push(start.elapsed().as_secs_f64());
+    }
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    Ok(times[times.len() / 2])
+}
+
+/// Generate `files` files across subdirectories with varied sizes; return the
+/// total byte count.
+fn generate(src: &Path, files: usize) -> TaskResult<u64> {
+    if src.exists() {
+        std::fs::remove_dir_all(src)
+            .map_err(|e| TaskError::Validation(format!("clean bench src: {e}")))?;
+    }
+    let filler = vec![b'x'; 512 * 1024];
+    let mut total = 0u64;
+    for index in 0..files {
+        if index % PER_DIR == 0 {
+            std::fs::create_dir_all(src.join(format!("d{:04}", index / PER_DIR)))
+                .map_err(|e| TaskError::Validation(format!("create bench dir: {e}")))?;
+        }
+        let size = match index % 50 {
+            0 => 256 * 1024,
+            1 | 2 => 64 * 1024,
+            _ => 1024 + (index % 3072),
+        };
+        let path = src
+            .join(format!("d{:04}", index / PER_DIR))
+            .join(format!("f{index:05}.dat"));
+        std::fs::write(&path, &filler[..size])
+            .map_err(|e| TaskError::Validation(format!("write bench file: {e}")))?;
+        total += size as u64;
+    }
+    Ok(total)
+}

--- a/xtask/src/commands/validate/bench.rs
+++ b/xtask/src/commands/validate/bench.rs
@@ -1,11 +1,16 @@
-//! Many-small-files loopback benchmark across transports.
+//! Many-small-files loopback benchmark across transports, plus a local I/O
+//! technology sweep.
 //!
-//! Generates a per-file-overhead workload (default 10k files) and times
-//! oc-rsync against upstream as the pulling client over each transport, taking
-//! the median wall time across a few runs. The numbers feed performance work;
+//! Generates a per-file-overhead workload (default 10k files, scales cleanly to
+//! 100k) and times oc-rsync against upstream as the pulling client over each
+//! transport, taking the median wall time across a few runs. It then sweeps
+//! oc-rsync's local-copy I/O backends (io_uring, copy_file_range / reflink,
+//! parallel checksum, whole-file) and confirms which backend was exercised via
+//! oc's `--debug=IOURING,CLONE` tracing. The numbers feed performance work;
 //! this is opt-in via `--bench`.
 
 use std::path::Path;
+use std::process::{Command, Output};
 use std::time::Instant;
 
 use crate::commands::validate::ValidateCtx;
@@ -13,12 +18,62 @@ use crate::commands::validate::support;
 use crate::commands::validate::transport::{Transport, pull_into};
 use crate::error::{TaskError, TaskResult};
 
-/// Timed runs per (transport, client); the median is reported.
+/// Timed runs per configuration; the median is reported.
 const RUNS: usize = 3;
 /// Files per generated subdirectory.
 const PER_DIR: usize = 100;
 
-/// Run the benchmark and print a per-transport comparison table.
+/// One oc-rsync I/O backend configuration for the local sweep.
+///
+/// Every entry uses the same base flags (`-a`); configurations differ only by
+/// runtime environment toggles and/or an extra flag, so a timing difference is
+/// attributable to the I/O path rather than the transfer semantics.
+struct IoConfig {
+    /// Short label for the sweep row.
+    label: &'static str,
+    /// Environment toggles set on the child process.
+    env: &'static [(&'static str, &'static str)],
+    /// Extra flags appended after `-a`.
+    extra_flags: &'static [&'static str],
+}
+
+/// The I/O backends swept on the local transport.
+///
+/// - `default`: auto io_uring on Linux 5.6+, standard elsewhere.
+/// - `no-iouring`: force the standard read/write path.
+/// - `iouring-data-writes`: opt into registered-buffer data writes.
+/// - `parallel-checksum`: parallelize basis checksum computation.
+/// - `whole-file`: `-W`, skip the delta algorithm entirely.
+const IO_CONFIGS: &[IoConfig] = &[
+    IoConfig {
+        label: "default",
+        env: &[],
+        extra_flags: &[],
+    },
+    IoConfig {
+        label: "no-iouring",
+        env: &[("OC_RSYNC_DISABLE_IOURING", "1")],
+        extra_flags: &[],
+    },
+    IoConfig {
+        label: "iouring-data-writes",
+        env: &[("OC_RSYNC_IOURING_DATA_WRITES", "1")],
+        extra_flags: &[],
+    },
+    IoConfig {
+        label: "parallel-checksum",
+        env: &[("OC_RSYNC_PARALLEL_CHECKSUM", "1")],
+        extra_flags: &[],
+    },
+    IoConfig {
+        label: "whole-file",
+        env: &[],
+        extra_flags: &["-W"],
+    },
+];
+
+/// Run the benchmark and print a per-transport comparison table plus the local
+/// I/O technology sweep.
 pub fn run(ctx: &ValidateCtx, files: usize) -> TaskResult<()> {
     let root = ctx.work.join("bench");
     let src = root.join("src");
@@ -48,6 +103,8 @@ pub fn run(ctx: &ValidateCtx, files: usize) -> TaskResult<()> {
         let speedup = if oc > 0.0 { up / oc } else { 0.0 };
         eprintln!("  {label:<14}  oc {oc:6.3}s   upstream {up:6.3}s   ({speedup:.2}x)");
     }
+
+    io_sweep(ctx.oc, &src, &root.join("sweep"))?;
     Ok(())
 }
 
@@ -73,8 +130,127 @@ fn median_secs(
         }
         times.push(start.elapsed().as_secs_f64());
     }
+    Ok(median(times))
+}
+
+/// Sweep oc-rsync's local-copy I/O backends: time each configuration and derive
+/// a backend note from a debug-traced run that confirms which path ran.
+///
+/// io_uring is Linux-only, so the sweep is skipped with a note elsewhere.
+fn io_sweep(oc: &Path, src: &Path, dst: &Path) -> TaskResult<()> {
+    eprintln!("\n=== I/O technology sweep (local, oc-rsync) ===");
+    if !cfg!(target_os = "linux") {
+        eprintln!("  SKIP (io_uring is Linux-only; run on a Linux host)");
+        return Ok(());
+    }
+    for config in IO_CONFIGS {
+        let secs = sweep_median(oc, config, src, dst)?;
+        let note = confirm_backend(oc, config, src, dst)?;
+        eprintln!("  {:<20} {secs:6.3}s   {note}", config.label);
+    }
+    Ok(())
+}
+
+/// Median wall time of `RUNS` fresh local pulls under one I/O configuration.
+///
+/// The destination is reset before each run so every timing exercises a full
+/// copy through the local-copy executor rather than a quick-check skip.
+fn sweep_median(oc: &Path, config: &IoConfig, src: &Path, dst: &Path) -> TaskResult<f64> {
+    let mut times = Vec::with_capacity(RUNS);
+    for _ in 0..RUNS {
+        reset_dir(dst)?;
+        let start = Instant::now();
+        let out = run_local(oc, config, src, dst, &[])?;
+        if !out.status.success() {
+            return Err(TaskError::Validation(format!(
+                "sweep transfer failed for `{}`: {}",
+                config.label,
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        times.push(start.elapsed().as_secs_f64());
+    }
+    Ok(median(times))
+}
+
+/// Run one extra debug-traced pull and summarize which backend it exercised.
+fn confirm_backend(oc: &Path, config: &IoConfig, src: &Path, dst: &Path) -> TaskResult<String> {
+    reset_dir(dst)?;
+    let out = run_local(oc, config, src, dst, &["--debug=IOURING,CLONE"])?;
+    let mut combined = String::from_utf8_lossy(&out.stdout).into_owned();
+    combined.push('\n');
+    combined.push_str(&String::from_utf8_lossy(&out.stderr));
+    Ok(backend_note(&combined))
+}
+
+/// Spawn a local oc-rsync pull of `src/` into `dst/` under `config`.
+///
+/// `extra` carries diagnostic flags (e.g. `--debug=...`) that must not appear in
+/// timed runs. Environment toggles are applied to the child only, so they never
+/// leak into the parent xtask process.
+fn run_local(
+    oc: &Path,
+    config: &IoConfig,
+    src: &Path,
+    dst: &Path,
+    extra: &[&str],
+) -> TaskResult<Output> {
+    let mut cmd = Command::new(oc);
+    cmd.arg("-a");
+    cmd.args(config.extra_flags);
+    cmd.args(extra);
+    for &(key, value) in config.env {
+        cmd.env(key, value);
+    }
+    cmd.arg(format!("{}/", src.display()))
+        .arg(format!("{}/", dst.display()));
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("spawn sweep `{}`: {e}", config.label)))
+}
+
+/// Derive a one-line backend note from `--debug=IOURING,CLONE` output.
+///
+/// Counts trace lines that indicate an active io_uring dispatch and lines that
+/// indicate a CoW clone path (`copy_file_range` / `clone` / `reflink`), ignoring
+/// lines that report a path was unavailable. The result reads like
+/// `io_uring=N clone=M`, or `standard (no io_uring)` when no io_uring op ran.
+fn backend_note(debug_output: &str) -> String {
+    let mut iouring = 0usize;
+    let mut clone = 0usize;
+    for line in debug_output.lines() {
+        let lower = line.to_ascii_lowercase();
+        if lower.contains("unavailable") {
+            continue;
+        }
+        if lower.contains("uring") {
+            iouring += 1;
+        }
+        if lower.contains("copy_file_range") || lower.contains("clone") || lower.contains("reflink")
+        {
+            clone += 1;
+        }
+    }
+    match (iouring, clone) {
+        (0, 0) => "standard (no io_uring)".to_string(),
+        (0, m) => format!("standard (no io_uring), clone={m}"),
+        (n, m) => format!("io_uring={n} clone={m}"),
+    }
+}
+
+/// Median of `times`; the lower-middle element for even counts.
+fn median(mut times: Vec<f64>) -> f64 {
     times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    Ok(times[times.len() / 2])
+    times[times.len() / 2]
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
 }
 
 /// Generate `files` files across subdirectories with varied sizes; return the
@@ -104,4 +280,47 @@ fn generate(src: &Path, files: usize) -> TaskResult<u64> {
         total += size as u64;
     }
     Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{backend_note, median};
+
+    #[test]
+    fn backend_note_reports_iouring_and_clone_counts() {
+        let output = "\
+io_uring available: cached probe reports supported
+CoW clone succeeded: dst=d0000/f0.dat (262144 bytes)
+cloned d0000/f1.dat: 262144 bytes (FICLONE)";
+        assert_eq!(backend_note(output), "io_uring=1 clone=2");
+    }
+
+    #[test]
+    fn backend_note_reports_standard_when_iouring_disabled() {
+        // A disabled probe emits an "unavailable" line, which must not count as
+        // an active io_uring op - this is exactly the `no-iouring` toggle proof.
+        let output = "io_uring unavailable: disabled by OC_RSYNC_DISABLE_IOURING";
+        assert_eq!(backend_note(output), "standard (no io_uring)");
+    }
+
+    #[test]
+    fn backend_note_reports_clone_only_without_iouring() {
+        let output = "\
+io_uring unavailable: disabled by OC_RSYNC_DISABLE_IOURING
+CoW clone succeeded: dst=d0000/f0.dat (262144 bytes)";
+        assert_eq!(backend_note(output), "standard (no io_uring), clone=1");
+    }
+
+    #[test]
+    fn backend_note_is_standard_on_empty_output() {
+        assert_eq!(backend_note(""), "standard (no io_uring)");
+    }
+
+    #[test]
+    fn median_picks_the_middle_element() {
+        assert_eq!(median(vec![3.0, 1.0, 2.0]), 2.0);
+        assert_eq!(median(vec![5.0]), 5.0);
+        // Even count: the lower-middle element after sorting.
+        assert_eq!(median(vec![4.0, 1.0, 3.0, 2.0]), 3.0);
+    }
 }

--- a/xtask/src/commands/validate/checks/acl_xattr.rs
+++ b/xtask/src/commands/validate/checks/acl_xattr.rs
@@ -1,0 +1,254 @@
+//! ACL (`-A`) and xattr (`-X`) parity between oc-rsync and upstream.
+//!
+//! Builds a fixture carrying a named-user ACL, a default ACL on a subdir, and
+//! user xattrs, then pulls it with each client over every transport and asserts
+//! oc's destination is byte- and attribute-identical to upstream's. ACLs and
+//! xattrs are compared per entry, path-independently (the ACL/xattr dumps drop
+//! their path-bearing header lines), so readdir-order never causes a false
+//! mismatch. The whole check skips when the tools or work filesystem cannot
+//! carry ACLs and xattrs.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The ACL + xattr parity check.
+pub struct AclXattr;
+
+/// Preserve standard metadata plus ACLs and xattrs.
+const FLAGS: &[&str] = &["-rlptgoD", "-A", "-X", "-H", "--numeric-ids"];
+
+/// External tools required to build the fixture and compare attributes.
+const TOOLS: &[&str] = &["setfacl", "getfacl", "setfattr", "getfattr"];
+
+impl Check for AclXattr {
+    fn name(&self) -> &'static str {
+        "acl-xattr"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        if !TOOLS.iter().all(|t| support::tool_available(t)) {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                "support",
+                "setfacl/getfacl/setfattr/getfattr missing",
+            )];
+        }
+        let uid = match current_uid() {
+            Some(uid) => uid,
+            None => {
+                return vec![CheckOutcome::skip(
+                    self.name(),
+                    "support",
+                    "cannot determine uid",
+                )];
+            }
+        };
+        if !fs_supports_acl_xattr(ctx.work, uid) {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                "support",
+                "ACL/xattr unsupported on work fs",
+            )];
+        }
+
+        let root = ctx.work.join("acl-xattr");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src, uid) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src, &flags, expected))
+            .collect()
+    }
+}
+
+impl AclXattr {
+    /// Run one transport cell: pull with both clients and compare destinations.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        flags: &[String],
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        );
+        match up {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        }
+        let oc = pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        );
+        match oc {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        }
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+        match attr_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), label, diff),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// First per-entry ACL or xattr divergence between two trees, or `None` when
+/// identical. Entries are walked in sorted order and compared path-independently.
+fn attr_diff(oc: &Path, up: &Path) -> Option<String> {
+    for rel in support::rel_entries(oc) {
+        let (oc_path, up_path) = (oc.join(&rel), up.join(&rel));
+        if acl_of(&oc_path) != acl_of(&up_path) {
+            return Some(format!("ACL differs at {}", rel.display()));
+        }
+        if xattr_of(&oc_path) != xattr_of(&up_path) {
+            return Some(format!("xattr differs at {}", rel.display()));
+        }
+    }
+    None
+}
+
+/// Numeric ACL of `path` without the path-bearing header comment lines.
+fn acl_of(path: &Path) -> Option<String> {
+    // `-c` omits the `# file:`/`# owner:` header, `-n` keeps ids numeric.
+    support::capture("getfacl", &["-c", "-n", &path.to_string_lossy()]).ok()
+}
+
+/// User xattrs of `path` with the path-bearing `# file:` line dropped.
+fn xattr_of(path: &Path) -> Option<String> {
+    let raw = support::capture("getfattr", &["-d", "-m", "-", &path.to_string_lossy()]).ok()?;
+    Some(
+        raw.lines()
+            .filter(|line| !line.starts_with("# file:"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
+/// The current user's numeric uid via `id -u`.
+fn current_uid() -> Option<u32> {
+    support::capture("id", &["-u"]).ok()?.trim().parse().ok()
+}
+
+/// Probe whether `work`'s filesystem accepts an ACL and a user xattr.
+fn fs_supports_acl_xattr(work: &Path, uid: u32) -> bool {
+    let probe = work.join(".acl_xattr_probe");
+    if std::fs::write(&probe, b"x").is_err() {
+        return false;
+    }
+    let acl = support::capture(
+        "setfacl",
+        &["-m", &format!("u:{uid}:rwx"), &probe.to_string_lossy()],
+    )
+    .is_ok();
+    let xattr = support::capture(
+        "setfattr",
+        &["-n", "user.oc_probe", "-v", "1", &probe.to_string_lossy()],
+    )
+    .is_ok();
+    let _ = std::fs::remove_file(&probe);
+    acl && xattr
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the ACL/xattr fixture. Idempotent: removes any prior tree first.
+fn build_fixture(src: &Path, uid: u32) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    let a = src.join("a.txt");
+    let b = sub.join("b.txt");
+    std::fs::write(&a, b"alpha").map_err(|e| e.to_string())?;
+    std::fs::write(&b, b"bravo").map_err(|e| e.to_string())?;
+
+    // Named-user ACL on a file and a default ACL on the subdir.
+    setfacl(&["-m", &format!("u:{uid}:rwx"), &a.to_string_lossy()])?;
+    setfacl(&["-d", "-m", &format!("u:{uid}:rx"), &sub.to_string_lossy()])?;
+
+    // User xattrs on files.
+    setfattr(&["-n", "user.foo", "-v", "bar", &a.to_string_lossy()])?;
+    setfattr(&["-n", "user.baz", "-v", "qux", &b.to_string_lossy()])?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Apply an ACL edit, surfacing failures as a fixture error.
+fn setfacl(args: &[&str]) -> Result<(), String> {
+    support::capture("setfacl", args)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+/// Set an xattr, surfacing failures as a fixture error.
+fn setfattr(args: &[&str]) -> Result<(), String> {
+    support::capture("setfattr", args)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}

--- a/xtask/src/commands/validate/checks/adhoc_flags.rs
+++ b/xtask/src/commands/validate/checks/adhoc_flags.rs
@@ -1,0 +1,257 @@
+//! Ad-hoc arbitrary-flags parity.
+//!
+//! For each `--flags` scenario supplied on the command line, pull a standard
+//! fixture with oc-rsync and with upstream using the exact same flag set over
+//! every transport, and assert the two destinations are byte- and attribute-
+//! identical. Because both sides run the identical flags, any divergence is
+//! oc's. This lets any rsync option (or combination) be validated without
+//! writing a new check.
+
+use std::collections::BTreeMap;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The ad-hoc arbitrary-flags parity check.
+pub struct AdHocFlags;
+
+impl Check for AdHocFlags {
+    fn name(&self) -> &'static str {
+        "ad-hoc-flags"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        if ctx.flags.is_empty() {
+            return Vec::new();
+        }
+        let root = ctx.work.join("ad-hoc-flags");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected = support::entry_count(&src);
+
+        let mut outcomes = Vec::new();
+        for scenario in ctx.flags {
+            let flags = parse_flags(scenario);
+            for &transport in ctx.transports {
+                outcomes.push(self.cell(ctx, transport, &root, &flags, scenario, expected));
+            }
+        }
+        outcomes
+    }
+}
+
+impl AdHocFlags {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        flags: &[String],
+        scenario: &str,
+        expected: usize,
+    ) -> CheckOutcome {
+        let cell = format!("[{scenario}] {}", transport.label());
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), cell, "no sshd on localhost:22");
+        }
+        let src = root.join("src");
+        let src = src.as_path();
+        let slug = slug(scenario, transport.label());
+        let oc_dst = root.join(format!("oc-{slug}"));
+        let up_dst = root.join(format!("up-{slug}"));
+
+        let up = pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        );
+        match up {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &cell, "upstream", other),
+        }
+        let oc = pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        );
+        match oc {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &cell, "oc", other),
+        }
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), cell, "destination entry count != source");
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), cell, diff);
+        }
+        match attr_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), cell, diff),
+            None => CheckOutcome::pass(self.name(), cell),
+        }
+    }
+}
+
+/// Split a whitespace-separated flag scenario into rsync arguments.
+fn parse_flags(scenario: &str) -> Vec<String> {
+    scenario.split_whitespace().map(str::to_string).collect()
+}
+
+/// A filesystem-safe slug for destination directory names.
+fn slug(scenario: &str, label: &str) -> String {
+    let cleaned: String = scenario
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    format!("{label}-{cleaned}")
+}
+
+/// Per-entry `(mode, mtime, uid, gid, nlink)` map for attribute comparison.
+///
+/// oc and upstream ran the identical flag set, so whatever those flags preserve
+/// must match between the two destinations regardless of which flags they are.
+fn attr_map(root: &Path) -> BTreeMap<std::path::PathBuf, (u32, i64, u32, u32, u64)> {
+    support::rel_entries(root)
+        .into_iter()
+        .filter_map(|rel| {
+            let meta = root.join(&rel).symlink_metadata().ok()?;
+            Some((
+                rel,
+                (
+                    meta.mode() & 0o7777,
+                    meta.mtime(),
+                    meta.uid(),
+                    meta.gid(),
+                    meta.nlink(),
+                ),
+            ))
+        })
+        .collect()
+}
+
+/// First per-attribute divergence between two trees, or `None` when identical.
+fn attr_diff(oc: &Path, up: &Path) -> Option<String> {
+    let (a, b) = (attr_map(oc), attr_map(up));
+    let fields = ["perms", "mtime", "uid", "gid", "nlink"];
+    for (rel, oc_attrs) in &a {
+        let Some(up_attrs) = b.get(rel) else {
+            return Some(format!("missing {} in oc tree", rel.display()));
+        };
+        let mismatches: Vec<&str> = fields
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !attr_eq(*i, oc_attrs, up_attrs))
+            .map(|(_, name)| *name)
+            .collect();
+        if !mismatches.is_empty() {
+            return Some(format!(
+                "{} differs at {}",
+                mismatches.join("/"),
+                rel.display()
+            ));
+        }
+    }
+    None
+}
+
+fn attr_eq(field: usize, a: &(u32, i64, u32, u32, u64), b: &(u32, i64, u32, u32, u64)) -> bool {
+    match field {
+        0 => a.0 == b.0,
+        1 => a.1 == b.1,
+        2 => a.2 == b.2,
+        3 => a.3 == b.3,
+        _ => a.4 == b.4,
+    }
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    cell: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                cell.to_string(),
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, cell.to_string(), format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the standard fixture: varied perms, a subdir, a symlink, a hardlink
+/// pair, and backdated mtimes so quick-check makes stable decisions.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    write_mode(&src.join("f644"), b"alpha", 0o644)?;
+    write_mode(&src.join("f600"), b"bravo", 0o600)?;
+    write_mode(&sub.join("f640"), b"charlie", 0o640)?;
+    std::fs::write(src.join("h1"), b"linked").map_err(|e| e.to_string())?;
+    std::fs::hard_link(src.join("h1"), src.join("h2")).map_err(|e| e.to_string())?;
+    std::os::unix::fs::symlink("../f644", sub.join("link")).map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn write_mode(path: &Path, bytes: &[u8], mode: u32) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::write(path, bytes).map_err(|e| e.to_string())?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_flags, slug};
+
+    #[test]
+    fn parse_flags_splits_on_whitespace() {
+        assert_eq!(
+            parse_flags("-a  --sparse   --exclude=*.log"),
+            vec!["-a", "--sparse", "--exclude=*.log"]
+        );
+        assert!(parse_flags("   ").is_empty());
+    }
+
+    #[test]
+    fn slug_is_filesystem_safe() {
+        assert_eq!(slug("-a --sparse", "local"), "local--a___sparse");
+        assert!(
+            slug("--exclude=*.log", "russh")
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        );
+    }
+}

--- a/xtask/src/commands/validate/checks/adhoc_flags.rs
+++ b/xtask/src/commands/validate/checks/adhoc_flags.rs
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn slug_is_filesystem_safe() {
-        assert_eq!(slug("-a --sparse", "local"), "local--a___sparse");
+        assert_eq!(slug("-a --sparse", "local"), "local-_a___sparse");
         assert!(
             slug("--exclude=*.log", "russh")
                 .chars()

--- a/xtask/src/commands/validate/checks/append_inplace.rs
+++ b/xtask/src/commands/validate/checks/append_inplace.rs
@@ -1,0 +1,409 @@
+//! `--append`, `--append-verify`, and `--inplace` delivery parity.
+//!
+//! All three flags reuse bytes already present in the destination instead of
+//! writing a fresh temp file: `--append` and `--append-verify` extend a
+//! destination that is a prefix of the source, and `--inplace` overwrites a
+//! same-length destination in place. Each mode therefore only exercises its
+//! reuse path when the destination is pre-seeded, so this check cannot use
+//! `transport::pull_into` (which recreates the destination empty). It seeds each
+//! destination directly, builds the client `Command` per transport, and runs the
+//! transfer without wiping the seed - then asserts oc-rsync ends byte-identical
+//! to both upstream and the source across every transport in `ctx.transports`.
+//!
+//! The oc and upstream destinations are seeded identically, so only the client
+//! under test varies. Upstream rsync is the ground truth. The ssh transports are
+//! skipped when no sshd answers on localhost:22.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `--append` / `--append-verify` / `--inplace` delivery parity check.
+pub struct AppendInplace;
+
+/// Length of the source `growing.bin`, in bytes (128 KiB).
+const FILE_LEN: usize = 128 * 1024;
+
+/// Prefix length pre-seeded for the append scenarios (64 KiB); `--append` must
+/// deliver the remaining tail.
+const PREFIX_LEN: usize = 64 * 1024;
+
+/// Byte ranges the inplace seed flips relative to the source, so a same-length
+/// destination differs and `--inplace` must rewrite exactly these spans. Head,
+/// interior, and tail are covered; every range lies within [`FILE_LEN`].
+const MUTATION_RANGES: &[(usize, usize)] = &[(0, 16), (40_000, 40_512), (131_056, FILE_LEN)];
+
+/// Contents of the second fixture file, transferred fresh under every scenario.
+const NOTE: &[u8] = b"append/inplace fixture note\n";
+
+/// A fixed epoch (2021-03-04) applied to source and seeded destination alike, so
+/// mtimes match and only the flag under test drives the reuse decision.
+const MTIME: &str = "@1614830767";
+
+/// The three reuse modes, in report order.
+const SCENARIOS: &[Scenario] = &[Scenario::Append, Scenario::AppendVerify, Scenario::Inplace];
+
+/// One reuse mode: its flags and how it seeds the destination `growing.bin`.
+#[derive(Clone, Copy)]
+enum Scenario {
+    /// `--append`: seed a prefix; the tail is appended.
+    Append,
+    /// `--append-verify`: seed a prefix; the tail is appended after re-checksum.
+    AppendVerify,
+    /// `--inplace`: seed a same-length but mutated copy; rewritten in place.
+    Inplace,
+}
+
+impl Scenario {
+    /// Stable scenario label used in the cell name.
+    fn label(self) -> &'static str {
+        match self {
+            Scenario::Append => "append",
+            Scenario::AppendVerify => "append-verify",
+            Scenario::Inplace => "inplace",
+        }
+    }
+
+    /// Complete flag set for the mode, including `-I` for inplace so the
+    /// same-length seed is not skipped by the quick-check.
+    fn flags(self) -> &'static [&'static str] {
+        match self {
+            Scenario::Append => &["-rlptgoD", "--append", "--numeric-ids"],
+            Scenario::AppendVerify => &["-rlptgoD", "--append-verify", "--numeric-ids"],
+            Scenario::Inplace => &["-rlptgoD", "--inplace", "-I", "--numeric-ids"],
+        }
+    }
+
+    /// Destination `growing.bin` bytes to pre-seed for this mode. The append
+    /// modes seed a shorter prefix; inplace seeds a mutated same-length copy.
+    /// Both differ from `source`, so the reuse path is genuinely exercised.
+    fn seed(self, source: &[u8]) -> Vec<u8> {
+        match self {
+            Scenario::Append | Scenario::AppendVerify => prefix(source, PREFIX_LEN),
+            Scenario::Inplace => mutate(source),
+        }
+    }
+}
+
+impl Check for AppendInplace {
+    fn name(&self) -> &'static str {
+        "append-inplace"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("append-inplace");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let mut outcomes = Vec::new();
+        for &transport in ctx.transports {
+            for &scenario in SCENARIOS {
+                outcomes.push(self.cell(ctx, transport, &root, &src, scenario));
+            }
+        }
+        outcomes
+    }
+}
+
+impl AppendInplace {
+    /// Run one `(transport, scenario)` cell: seed both destinations, transfer
+    /// with each client, and assert oc ends byte-identical to upstream and to
+    /// the source.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        scenario: Scenario,
+    ) -> CheckOutcome {
+        let label = format!("{} {}", transport.label(), scenario.label());
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let source = source_bytes(FILE_LEN);
+        let seed = scenario.seed(&source);
+        let stem = format!("{}-{}", transport.label(), scenario.label());
+        let oc_dst = root.join(format!("oc-{stem}"));
+        let up_dst = root.join(format!("up-{stem}"));
+
+        if let Err(e) = seed_dest(&oc_dst, &seed) {
+            return CheckOutcome::skip(self.name(), label, format!("seed oc dest: {e}"));
+        }
+        if let Err(e) = seed_dest(&up_dst, &seed) {
+            return CheckOutcome::skip(self.name(), label, format!("seed upstream dest: {e}"));
+        }
+
+        // Non-vacuous guard: the seeded destination must really differ from the
+        // source before the transfer, or the reuse path is never taken.
+        let seeded = std::fs::read(oc_dst.join("growing.bin")).ok();
+        if seeded.is_none() || seeded.as_deref() == Some(source.as_slice()) {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                "seed guard: dest growing.bin did not differ from source",
+            );
+        }
+
+        // The daemon transport needs one live upstream daemon shared by both
+        // client runs; keep it alive for the whole cell.
+        let daemon = if transport == Transport::Daemon {
+            match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), label, format!("daemon: {e}")),
+            }
+        } else {
+            None
+        };
+        let daemon_url = daemon.as_ref().map(|d| d.module_url());
+        let flags = scenario.flags();
+
+        let up = match run_client(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            daemon_url.as_deref(),
+            flags,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), &label, "upstream", other),
+        };
+        let _ = up;
+        let oc = match run_client(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            daemon_url.as_deref(),
+            flags,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), &label, "oc", other),
+        };
+        let _ = oc;
+        drop(daemon);
+
+        // Both destinations must now equal the source, and each other.
+        if let Some(d) = support::content_diff(&up_dst, src) {
+            return CheckOutcome::fail(self.name(), label, format!("upstream dest != source: {d}"));
+        }
+        if let Some(d) = support::content_diff(&oc_dst, src) {
+            return CheckOutcome::fail(self.name(), label, format!("oc dest != source: {d}"));
+        }
+        if let Some(d) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("oc dest != upstream dest: {d}"),
+            );
+        }
+
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Build one client rsync `Command` for `transport` and run it into the
+/// already-seeded destination, which is never reset here so the reuse flags
+/// operate on the pre-seeded bytes.
+///
+/// Operand forms mirror `transport::pull_into`: `local` is a filesystem copy;
+/// `ssh-subprocess` uses `-e ssh localhost:<src>`; `russh` uses an `ssh://` URL;
+/// `daemon` uses the module URL passed in `daemon_url`. The sender is always
+/// `upstream` for the network transports.
+fn run_client(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    daemon_url: Option<&str>,
+    flags: &[&str],
+) -> TaskResult<Output> {
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let url = daemon_url
+                .ok_or_else(|| TaskError::Validation("daemon transport without url".into()))?;
+            cmd.arg(url).arg(&dst_arg);
+        }
+    }
+
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Deterministic source byte at `index`, derived purely from the index by a
+/// fixed integer hash - no system randomness, so the fixture is reproducible.
+fn source_byte(index: usize) -> u8 {
+    let x = (index as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    ((x >> 24) ^ x) as u8
+}
+
+/// The first `len` deterministic source bytes.
+fn source_bytes(len: usize) -> Vec<u8> {
+    (0..len).map(source_byte).collect()
+}
+
+/// A leading prefix of `bytes` of length `n` (clamped to the slice length).
+fn prefix(bytes: &[u8], n: usize) -> Vec<u8> {
+    bytes[..n.min(bytes.len())].to_vec()
+}
+
+/// A same-length copy of `bytes` with every byte in [`MUTATION_RANGES`] flipped,
+/// so an inplace destination differs from the source only in those spans.
+fn mutate(bytes: &[u8]) -> Vec<u8> {
+    let mut out = bytes.to_vec();
+    for &(start, end) in MUTATION_RANGES {
+        for b in out.iter_mut().take(end.min(bytes.len())).skip(start) {
+            *b = !*b;
+        }
+    }
+    out
+}
+
+/// Seed `dst` with `growing_seed` and backdate it, so the reuse flags see a
+/// destination whose mtime matches the source. Recreates `dst` empty first, so
+/// it is idempotent; `sub/note.txt` is left absent and transferred fresh.
+fn seed_dest(dst: &Path, growing_seed: &[u8]) -> TaskResult<()> {
+    reset_dir(dst)?;
+    let file = dst.join("growing.bin");
+    std::fs::write(&file, growing_seed)
+        .map_err(|e| TaskError::Validation(format!("seed growing.bin: {e}")))?;
+    backdate(&file)
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Set `path`'s mtime to [`MTIME`] via `touch`.
+fn backdate(path: &Path) -> TaskResult<()> {
+    support::capture("touch", &["-h", "-d", MTIME, &path.to_string_lossy()]).map(|_| ())
+}
+
+/// Build the source tree: a 128 KiB deterministic `growing.bin` plus
+/// `sub/note.txt`, both backdated. Idempotent: removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+    std::fs::write(src.join("growing.bin"), source_bytes(FILE_LEN)).map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("note.txt"), NOTE).map_err(|e| e.to_string())?;
+    for rel in ["growing.bin", "sub/note.txt"] {
+        backdate(&src.join(rel)).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Distinguish a genuine divergence (non-zero exit) from an unrunnable cell.
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_bytes_are_deterministic_and_index_derived() {
+        // Same length twice yields identical bytes; the generator uses no
+        // system randomness, only the index.
+        assert_eq!(source_bytes(FILE_LEN), source_bytes(FILE_LEN));
+        assert_eq!(source_bytes(4).len(), 4);
+        // Distinct indices are not all mapped to one constant byte.
+        let first = source_bytes(256);
+        assert!(first.iter().any(|&b| b != first[0]));
+    }
+
+    #[test]
+    fn prefix_is_a_strict_leading_slice() {
+        let full = source_bytes(FILE_LEN);
+        let head = prefix(&full, PREFIX_LEN);
+        assert_eq!(head.len(), PREFIX_LEN);
+        assert_eq!(head.as_slice(), &full[..PREFIX_LEN]);
+        // A prefix of the source differs from the whole source (append path).
+        assert_ne!(head, full);
+        // Over-long request clamps to the slice length.
+        assert_eq!(prefix(&full, FILE_LEN * 2).len(), FILE_LEN);
+    }
+
+    #[test]
+    fn mutate_keeps_length_flips_only_named_ranges() {
+        let full = source_bytes(FILE_LEN);
+        let changed = mutate(&full);
+        assert_eq!(changed.len(), full.len());
+        assert_ne!(changed, full);
+        for i in 0..full.len() {
+            let inside = MUTATION_RANGES.iter().any(|&(s, e)| i >= s && i < e);
+            if inside {
+                assert_eq!(changed[i], !full[i], "byte {i} must be flipped");
+            } else {
+                assert_eq!(changed[i], full[i], "byte {i} must be untouched");
+            }
+        }
+    }
+
+    #[test]
+    fn every_scenario_seed_differs_from_source() {
+        let full = source_bytes(FILE_LEN);
+        for &scenario in SCENARIOS {
+            assert_ne!(
+                scenario.seed(&full),
+                full,
+                "{} seed must differ to exercise reuse",
+                scenario.label()
+            );
+        }
+    }
+}

--- a/xtask/src/commands/validate/checks/backup.rs
+++ b/xtask/src/commands/validate/checks/backup.rs
@@ -1,0 +1,367 @@
+//! `--backup` parity: oc-rsync preserves overwritten destination files exactly
+//! as upstream does, both with the default `~` suffix and with a `--backup-dir`.
+//!
+//! Like `--delete`, `--backup` only does anything when the destination already
+//! holds files the transfer overwrites, so this check cannot use
+//! `transport::pull_into` (which recreates the destination empty). Instead each
+//! cell owns a per-side directory (`oc-<transport>-<scenario>` /
+//! `up-<transport>-<scenario>`) holding a `dst/` subtree, pre-seeds `dst/` with
+//! OLD versions of the source files, then transfers the NEW source over them so
+//! `--backup` keeps the old copies. Giving each side its own cell directory
+//! isolates the two runs: a relative `--backup-dir=../bak` resolves against the
+//! receiver's destination directory (upstream main.c:1178 `change_dir`), so it
+//! lands in that side's own `bak/` rather than a shared one. oc and upstream are
+//! seeded identically, so only the client under test varies. Upstream rsync is
+//! the ground truth for both the refreshed files and their backups. The ssh
+//! transports are skipped when no sshd answers on localhost:22.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `--backup` overwrite-preservation parity check.
+pub struct Backup;
+
+/// NEW source payloads (what overwrites the seeded destination).
+const NEW_F1: &[u8] = b"new f1 payload\n";
+const NEW_F2: &[u8] = b"new f2 payload, longer than old\n";
+/// OLD destination payloads (what `--backup` must preserve). Their lengths
+/// differ from the NEW payloads so the quick-check always re-transfers,
+/// firing `--backup` regardless of mtime (see [`forces_retransfer`]).
+const OLD_F1: &[u8] = b"old-1\n";
+const OLD_F2: &[u8] = b"old-2\n";
+
+/// One `--backup` scenario: a flag set plus the destination-relative path where
+/// the backup of `f1.txt` is expected to land.
+struct Scenario {
+    /// Short name used in the cell label (e.g. `suffix`).
+    name: &'static str,
+    /// Complete rsync flag set for the transfer.
+    flags: &'static [&'static str],
+    /// Path of `f1.txt`'s backup relative to the per-side cell directory.
+    backup_rel: &'static str,
+}
+
+/// The two scenarios exercised for every transport.
+const SCENARIOS: &[Scenario] = &[
+    // Default `~` suffix: the backup lives beside the file inside `dst/`.
+    Scenario {
+        name: "suffix",
+        flags: &["-rlptgoD", "--backup", "--numeric-ids"],
+        backup_rel: "dst/f1.txt~",
+    },
+    // `--backup-dir=../bak`: old versions collect under a sibling `bak/` tree.
+    Scenario {
+        name: "backup-dir",
+        flags: &[
+            "-rlptgoD",
+            "--backup",
+            "--backup-dir=../bak",
+            "--numeric-ids",
+        ],
+        backup_rel: "bak/f1.txt",
+    },
+];
+
+impl Check for Backup {
+    fn name(&self) -> &'static str {
+        "backup"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("backup");
+        let src = root.join("src");
+        // Fixture invariant: OLD and NEW must differ in length so every cell
+        // actually overwrites (and thus backs up) the seeded files.
+        if !forces_retransfer(OLD_F1, NEW_F1) || !forces_retransfer(OLD_F2, NEW_F2) {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                "fixture",
+                "OLD/NEW payloads must differ in length",
+            )];
+        }
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let mut outcomes = Vec::new();
+        for &transport in ctx.transports {
+            for scenario in SCENARIOS {
+                outcomes.push(self.cell(ctx, transport, &root, &src, scenario));
+            }
+        }
+        outcomes
+    }
+}
+
+impl Backup {
+    /// Run one (transport, scenario) cell: seed both destinations with the OLD
+    /// files, transfer the NEW source over each, and compare the resulting trees
+    /// (refreshed files plus their backups) against upstream.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        scenario: &Scenario,
+    ) -> CheckOutcome {
+        let label = format!("{} {}", transport.label(), scenario.name);
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let oc_cell = root.join(format!("oc-{}-{}", transport.label(), scenario.name));
+        let up_cell = root.join(format!("up-{}-{}", transport.label(), scenario.name));
+
+        // Seed both destinations identically before their respective transfers.
+        if let Err(e) = seed_dest(&oc_cell) {
+            return CheckOutcome::skip(self.name(), label, format!("seed oc dest: {e}"));
+        }
+        if let Err(e) = seed_dest(&up_cell) {
+            return CheckOutcome::skip(self.name(), label, format!("seed upstream dest: {e}"));
+        }
+
+        let daemon = if transport == Transport::Daemon {
+            match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), label, format!("daemon: {e}")),
+            }
+        } else {
+            None
+        };
+        let daemon_url = daemon.as_ref().map(|d| d.module_url());
+
+        let up = run_client(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_cell.join("dst"),
+            scenario.flags,
+            daemon_url.as_deref(),
+        );
+        let up = match up {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), &label, "upstream", other),
+        };
+        let _ = up;
+
+        let oc = run_client(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_cell.join("dst"),
+            scenario.flags,
+            daemon_url.as_deref(),
+        );
+        let oc = match oc {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), &label, "oc", other),
+        };
+        let _ = oc;
+        drop(daemon);
+
+        // Non-vacuous guard: the backup must actually exist in oc's tree and
+        // hold the OLD content, otherwise a no-op transfer would pass trivially.
+        match std::fs::read(oc_cell.join(scenario.backup_rel)) {
+            Ok(bytes) if bytes == OLD_F1 => {}
+            Ok(_) => {
+                return CheckOutcome::fail(
+                    self.name(),
+                    label,
+                    format!(
+                        "oc backup {} does not hold the old content",
+                        scenario.backup_rel
+                    ),
+                );
+            }
+            Err(_) => {
+                return CheckOutcome::fail(
+                    self.name(),
+                    label,
+                    format!("oc backup {} missing", scenario.backup_rel),
+                );
+            }
+        }
+
+        // Refreshed files and their backups must match upstream everywhere.
+        if let Some(diff) = support::content_diff(&oc_cell, &up_cell) {
+            if ctx.verbose {
+                dump(&label, &oc_cell, &up_cell);
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("oc and upstream backup trees differ: {diff}"),
+            );
+        }
+
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Build one client rsync `Command` for `transport` and run it into the
+/// (already-seeded) `dst`. The destination is never reset here, so `--backup`
+/// operates on the pre-seeded tree.
+///
+/// Operand forms mirror `transport::pull_into`: `local` is a filesystem copy;
+/// `ssh-subprocess` uses `-e ssh localhost:<src>`; `russh` uses an `ssh://` URL;
+/// `daemon` uses the module URL in `daemon_url`. The sender is always `upstream`
+/// for the network transports (`--rsync-path` / upstream daemon).
+fn run_client(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    flags: &[&str],
+    daemon_url: Option<&str>,
+) -> TaskResult<Output> {
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let url = daemon_url
+                .ok_or_else(|| TaskError::Validation("daemon transport without url".into()))?;
+            cmd.arg(url).arg(&dst_arg);
+        }
+    }
+
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Seed one per-side cell with the OLD destination tree the transfer overwrites.
+///
+/// Recreates `cell` empty, then writes `dst/f1.txt` and `dst/sub/f2.txt` with
+/// the OLD payloads. Idempotent: any prior `dst/` or `bak/` from a earlier run
+/// is removed first.
+fn seed_dest(cell: &Path) -> TaskResult<()> {
+    reset_dir(cell)?;
+    let sub = cell.join("dst").join("sub");
+    std::fs::create_dir_all(&sub)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", sub.display())))?;
+    std::fs::write(cell.join("dst").join("f1.txt"), OLD_F1)
+        .map_err(|e| TaskError::Validation(format!("write old f1.txt: {e}")))?;
+    std::fs::write(sub.join("f2.txt"), OLD_F2)
+        .map_err(|e| TaskError::Validation(format!("write old sub/f2.txt: {e}")))
+}
+
+/// True when OLD and NEW payloads differ in length, guaranteeing rsync's
+/// quick-check re-transfers the file (so `--backup` always fires) irrespective
+/// of mtime.
+fn forces_retransfer(old: &[u8], new: &[u8]) -> bool {
+    old.len() != new.len()
+}
+
+/// Print both cell trees for a verbose failure.
+fn dump(label: &str, oc_cell: &Path, up_cell: &Path) {
+    eprintln!(
+        "[backup/{label}] oc tree: {:?}",
+        support::rel_entries(oc_cell)
+    );
+    eprintln!(
+        "[backup/{label}] upstream tree: {:?}",
+        support::rel_entries(up_cell)
+    );
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label.to_string(),
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(
+            check,
+            label.to_string(),
+            format!("{who} could not run: {e}"),
+        ),
+    }
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Build the backup source fixture: `f1.txt` and `sub/f2.txt` with the NEW
+/// payloads. Idempotent: removes any prior tree first. Mtimes are backdated so
+/// the quick-check has a stable baseline for both clients.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("f1.txt"), NEW_F1).map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("f2.txt"), NEW_F2).map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NEW_F1, NEW_F2, OLD_F1, OLD_F2, forces_retransfer};
+
+    #[test]
+    fn fixture_payloads_force_a_retransfer() {
+        // The fixture only exercises --backup if the transfer actually
+        // overwrites the seeded files; equal lengths would let the quick-check
+        // skip them and the check would pass vacuously.
+        assert!(forces_retransfer(OLD_F1, NEW_F1));
+        assert!(forces_retransfer(OLD_F2, NEW_F2));
+    }
+
+    #[test]
+    fn equal_length_payloads_do_not_force_a_retransfer() {
+        assert!(!forces_retransfer(b"abc", b"xyz"));
+    }
+}

--- a/xtask/src/commands/validate/checks/banner.rs
+++ b/xtask/src/commands/validate/checks/banner.rs
@@ -1,0 +1,223 @@
+//! Flist banner direction parity between oc-rsync and upstream.
+//!
+//! Upstream gates the `sending ... file list` banner on the sender side
+//! (`flist.c`, printed when `!am_server`), while the receiver prints
+//! `receiving ... file list`. So the banner's direction word encodes who built
+//! the file list: a LOCAL copy and an ssh PUSH both send it, an ssh PULL
+//! receives it. This check runs three fixed direction cells - `local`, `pull`,
+//! `push` - and asserts oc-rsync prints the same direction word upstream does,
+//! and that it matches the expected direction. It is direction-based, not
+//! per-transport, so it ignores `ctx.transports`; the ssh cells are skipped when
+//! no sshd answers on localhost:22.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The flist banner direction check.
+pub struct Banner;
+
+/// Recursive + verbose: `-v` makes rsync print the incremental file-list banner.
+const FLAGS: &[&str] = &["-rv"];
+
+/// The three fixed direction cells and the banner word each must print.
+const CELLS: [(&str, &str); 3] = [
+    ("local", "sending"),
+    ("pull", "receiving"),
+    ("push", "sending"),
+];
+
+impl Check for Banner {
+    fn name(&self) -> &'static str {
+        "flist-banner"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("banner");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        CELLS
+            .iter()
+            .map(|&(cell, expected)| self.cell(ctx, &root, &src, cell, expected))
+            .collect()
+    }
+}
+
+impl Banner {
+    /// Run one direction cell for both clients and compare their banner words.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        root: &Path,
+        src: &Path,
+        cell: &'static str,
+        expected: &'static str,
+    ) -> CheckOutcome {
+        if cell != "local" && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), cell, "no sshd on localhost:22");
+        }
+
+        let up_dst = root.join(format!("up-{cell}"));
+        let up_dir = match run_cell(ctx.upstream, ctx.upstream, src, &up_dst, cell) {
+            Ok(out) => banner_direction(&combined_output(&out)),
+            Err(e) => {
+                return CheckOutcome::skip(
+                    self.name(),
+                    cell,
+                    format!("upstream could not run: {e}"),
+                );
+            }
+        };
+
+        let oc_dst = root.join(format!("oc-{cell}"));
+        let oc_dir = match run_cell(ctx.oc, ctx.upstream, src, &oc_dst, cell) {
+            Ok(out) => banner_direction(&combined_output(&out)),
+            Err(e) => {
+                return CheckOutcome::skip(self.name(), cell, format!("oc could not run: {e}"));
+            }
+        };
+
+        if ctx.verbose {
+            eprintln!("[flist-banner/{cell}] oc={oc_dir} upstream={up_dir}");
+        }
+
+        if oc_dir == up_dir && oc_dir == expected {
+            CheckOutcome::pass(self.name(), cell)
+        } else {
+            CheckOutcome::fail(
+                self.name(),
+                cell,
+                format!("oc={oc_dir} upstream={up_dir} expected={expected}"),
+            )
+        }
+    }
+}
+
+/// Build and run one direction cell's rsync command, capturing its output.
+///
+/// The destination is (re)created empty first. `local` is a plain filesystem
+/// copy; `pull` makes `client` the receiver of an ssh subprocess transfer whose
+/// sender is `upstream` (via `--rsync-path`); `push` makes `client` the sender,
+/// with the destination expressed as an absolute `localhost:<path>` remote.
+fn run_cell(
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    cell: &str,
+) -> TaskResult<Output> {
+    reset_dir(dst)?;
+    let src_arg = format!("{}/", src.display());
+    let dst_local = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(FLAGS);
+
+    match cell {
+        "local" => {
+            cmd.arg(&src_arg).arg(&dst_local);
+        }
+        "pull" => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_local);
+        }
+        _ => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(&src_arg)
+                .arg(format!("localhost:{}/", dst.display()));
+        }
+    }
+
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Fold a run's stdout then stderr into one string; the banner can land on
+/// either stream depending on the transport.
+fn combined_output(out: &Output) -> String {
+    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stderr));
+    s
+}
+
+/// Classify the first `file list` banner line as `sending`, `receiving`, or
+/// `none` (no banner or an unrecognized one).
+pub fn banner_direction(output: &str) -> &'static str {
+    for line in output.lines() {
+        if line.contains("file list") {
+            if line.contains("sending") {
+                return "sending";
+            }
+            if line.contains("receiving") {
+                return "receiving";
+            }
+            return "none";
+        }
+    }
+    "none"
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Build the banner fixture: two top-level files and a subdirectory with one
+/// file. Idempotent: removes any prior tree first. No metadata or backdating is
+/// needed since only the banner line - not transfer decisions - is inspected.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("alpha.txt"), b"alpha\n").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("bravo.txt"), b"bravo\n").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("charlie.txt"), b"charlie\n").map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::banner_direction;
+
+    #[test]
+    fn classifies_sending_and_receiving() {
+        assert_eq!(
+            banner_direction("sending incremental file list\n"),
+            "sending"
+        );
+        assert_eq!(
+            banner_direction("receiving incremental file list\n"),
+            "receiving"
+        );
+    }
+
+    #[test]
+    fn first_file_list_line_decides_direction() {
+        let out = "opening connection\n\
+                   receiving incremental file list\n\
+                   some later line mentioning sending\n";
+        assert_eq!(banner_direction(out), "receiving");
+    }
+
+    #[test]
+    fn none_without_a_banner_line() {
+        assert_eq!(banner_direction("a file\nanother file\n"), "none");
+    }
+}

--- a/xtask/src/commands/validate/checks/checksum.rs
+++ b/xtask/src/commands/validate/checks/checksum.rs
@@ -1,0 +1,380 @@
+//! `--checksum` (`-c`) transfer-decision parity between oc-rsync and upstream.
+//!
+//! Rsync's default quick-check skips any destination file whose size and mtime
+//! equal the source's. `-c` overrides that: it compares by strong checksum, so a
+//! destination file with matching size and mtime but *different content* must be
+//! re-transferred. This check pre-seeds each destination so the quick-check
+//! *would* skip the differing files - identical size, identical mtime - and then
+//! asserts that with `-c` oc-rsync re-transfers exactly what upstream does and
+//! ends byte-identical to the source, across every transport in `ctx.transports`.
+//!
+//! Because the destination is pre-seeded, this check cannot use
+//! `transport::pull_into` (which wipes the destination first). It builds the
+//! `Command` directly - reusing `pull_into`'s per-transport operand forms - and
+//! runs the transfer *without* resetting the seeded destination.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `--checksum` transfer-decision check.
+pub struct Checksum;
+
+/// Recursive, checksum-based decision, itemized output, numeric ids.
+const FLAGS: &[&str] = &["-rlptgoD", "-c", "-i", "--numeric-ids"];
+
+/// A fixed epoch (2021-03-04) applied to both source and seeded destination so
+/// their mtimes match and the quick-check would skip the differing files.
+const MTIME: &str = "@1614830767";
+
+/// One fixture file: its source bytes, the bytes pre-seeded into the
+/// destination (equal length, so size matches), and whether `-c` must
+/// re-transfer it.
+///
+/// For a re-transfer file the seed differs from the source (same size, same
+/// mtime, different content -> quick-check skips, `-c` does not). For a
+/// non-re-transfer file the seed is byte-identical, so even `-c` leaves it.
+struct FileSpec {
+    /// Path relative to the transfer root.
+    rel: &'static str,
+    /// Source content written under `src/`.
+    src: &'static [u8],
+    /// Destination content pre-seeded before the transfer.
+    seed: &'static [u8],
+    /// True when `-c` must re-transfer this file.
+    retransfer: bool,
+}
+
+/// The fixture: one identical file the checksum path must leave alone, and two
+/// differing files (top-level and nested) it must re-transfer. Each seed has the
+/// exact byte length of its source so size matches under the quick-check.
+const FILES: &[FileSpec] = &[
+    FileSpec {
+        rel: "same.txt",
+        src: b"identical-content",
+        seed: b"identical-content",
+        retransfer: false,
+    },
+    FileSpec {
+        rel: "differ.txt",
+        src: b"SOURCE-VERSION-aaaa",
+        seed: b"DEST-VERSION-bbbbbb",
+        retransfer: true,
+    },
+    FileSpec {
+        rel: "sub/differ2.txt",
+        src: b"nested-source-body",
+        seed: b"nested-DEST-body!!",
+        retransfer: true,
+    },
+];
+
+impl Check for Checksum {
+    fn name(&self) -> &'static str {
+        "checksum"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("checksum");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src))
+            .collect()
+    }
+}
+
+impl Checksum {
+    /// Run one transport cell: seed both destinations identically, transfer with
+    /// each client, then compare re-transfer decisions and final content.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let up_dst = root.join(format!("up-{label}"));
+        let oc_dst = root.join(format!("oc-{label}"));
+        if let Err(e) = seed_dest(&up_dst) {
+            return CheckOutcome::skip(self.name(), label, format!("seed upstream dest: {e}"));
+        }
+        if let Err(e) = seed_dest(&oc_dst) {
+            return CheckOutcome::skip(self.name(), label, format!("seed oc dest: {e}"));
+        }
+
+        // Non-vacuous guard: the seeded differing file must really differ from
+        // the source before the transfer, or the checksum path is not exercised.
+        let seeded = std::fs::read(oc_dst.join("differ.txt")).ok();
+        let source = std::fs::read(src.join("differ.txt")).ok();
+        if seeded.is_none() || seeded == source {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                "seed guard: dest differ.txt did not differ from source",
+            );
+        }
+
+        let up = match run_transfer(
+            ctx.upstream,
+            ctx.upstream,
+            transport.for_upstream(),
+            src,
+            &up_dst,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let oc = match run_transfer(ctx.oc, ctx.upstream, transport, src, &oc_dst, ctx.work) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+
+        // Both destinations must now be byte-identical to the source: proves the
+        // differing files were re-transferred and the identical one was kept.
+        if let Some(d) = support::content_diff(&up_dst, src) {
+            return CheckOutcome::fail(self.name(), label, format!("upstream dest != source: {d}"));
+        }
+        if let Some(d) = support::content_diff(&oc_dst, src) {
+            return CheckOutcome::fail(self.name(), label, format!("oc dest != source: {d}"));
+        }
+        if let Some(d) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("oc dest != upstream dest: {d}"),
+            );
+        }
+
+        let up_x = transferred_files(&String::from_utf8_lossy(&up.stdout));
+        let oc_x = transferred_files(&String::from_utf8_lossy(&oc.stdout));
+
+        if oc_x != up_x {
+            if ctx.verbose {
+                eprintln!("[checksum/{label}] oc transferred {oc_x:?} upstream {up_x:?}");
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("re-transferred set differs (oc {oc_x:?} vs upstream {up_x:?})"),
+            );
+        }
+
+        for want in FILES.iter().filter(|f| f.retransfer).map(|f| f.rel) {
+            if !oc_x.contains(want) {
+                return CheckOutcome::fail(
+                    self.name(),
+                    label,
+                    format!("-c did not re-transfer {want}"),
+                );
+            }
+        }
+        for unchanged in FILES.iter().filter(|f| !f.retransfer).map(|f| f.rel) {
+            if oc_x.contains(unchanged) {
+                return CheckOutcome::fail(
+                    self.name(),
+                    label,
+                    format!("-c re-transferred {unchanged} despite identical content"),
+                );
+            }
+        }
+
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Extract the set of file paths rsync itemized as transferred.
+///
+/// A transfer row's change string begins `>f` (received) or `<f` (sent); the
+/// path follows after the single space that terminates the 11-char change
+/// string. Directory, metadata-only, and summary lines are ignored - so the set
+/// contains exactly the files that moved bytes.
+pub fn transferred_files(stdout: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for raw in stdout.lines() {
+        let line = raw.trim();
+        if line.starts_with(">f") || line.starts_with("<f") {
+            if let Some((_, path)) = line.split_once(' ') {
+                out.insert(path.trim().to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Build the transfer command for one cell without touching the destination.
+///
+/// Mirrors `transport::pull_into`'s operand forms - local copy, ssh subprocess,
+/// russh `ssh://` URL, or an upstream `rsync://` daemon - but omits the
+/// destination reset so the pre-seeded files survive into the transfer.
+fn run_transfer(
+    client: &Path,
+    upstream: &Path,
+    transport: Transport,
+    src: &Path,
+    dst: &Path,
+    work: &Path,
+) -> TaskResult<Output> {
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(FLAGS);
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let daemon = DaemonHandle::start(upstream, src, work)?;
+            cmd.arg(daemon.module_url()).arg(&dst_arg);
+            let out = spawn(cmd)?;
+            drop(daemon);
+            return Ok(out);
+        }
+    }
+    spawn(cmd)
+}
+
+/// Run a prepared command, capturing its output.
+fn spawn(mut cmd: Command) -> TaskResult<Output> {
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Distinguish a genuine divergence (non-zero exit) from an unrunnable cell.
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the source tree, backdating every file's mtime to [`MTIME`]. Idempotent:
+/// removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src.join("sub")).map_err(|e| e.to_string())?;
+    for f in FILES {
+        std::fs::write(src.join(f.rel), f.src).map_err(|e| e.to_string())?;
+    }
+    backdate(src)
+}
+
+/// Pre-seed a destination so the quick-check would skip the differing files.
+///
+/// Recreates `dst` empty, writes each file's seed bytes (equal length to the
+/// source, so size matches), then backdates every file to [`MTIME`] so its mtime
+/// matches the source too. The differing files thus present identical size and
+/// mtime - which only `-c` can see through.
+fn seed_dest(dst: &Path) -> Result<(), String> {
+    if dst.exists() {
+        std::fs::remove_dir_all(dst).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(dst.join("sub")).map_err(|e| e.to_string())?;
+    for f in FILES {
+        std::fs::write(dst.join(f.rel), f.seed).map_err(|e| e.to_string())?;
+    }
+    backdate(dst)
+}
+
+/// Set every fixture file's mtime under `root` to [`MTIME`] via `touch`.
+fn backdate(root: &Path) -> Result<(), String> {
+    for f in FILES {
+        let path = root.join(f.rel);
+        support::capture("touch", &["-h", "-d", MTIME, &path.to_string_lossy()])
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_only_transferred_file_paths() {
+        let out = ">fc.t...... differ.txt\n\
+                   >fcst...... sub/differ2.txt\n\
+                   cd+++++++++ sub/\n\
+                   .f          same.txt\n\
+                   sent 100 bytes  received 20 bytes\n";
+        let set = transferred_files(out);
+        assert!(set.contains("differ.txt"));
+        assert!(set.contains("sub/differ2.txt"));
+        assert!(!set.contains("same.txt"));
+        assert!(!set.contains("sub/"));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn recognizes_sender_side_marker() {
+        assert!(transferred_files("<f+++++++++ x.bin\n").contains("x.bin"));
+    }
+
+    #[test]
+    fn ignores_summary_and_directory_lines() {
+        let out = "cd+++++++++ sub/\ntotal size is 12  speedup is 0.10\n";
+        assert!(transferred_files(out).is_empty());
+    }
+
+    #[test]
+    fn seed_matches_source_length_and_retransfer_intent() {
+        for f in FILES {
+            assert_eq!(
+                f.src.len(),
+                f.seed.len(),
+                "{} seed len must equal src",
+                f.rel
+            );
+            if f.retransfer {
+                assert_ne!(
+                    f.src, f.seed,
+                    "{} must differ to force -c retransfer",
+                    f.rel
+                );
+            } else {
+                assert_eq!(f.src, f.seed, "{} must be byte-identical", f.rel);
+            }
+        }
+    }
+}

--- a/xtask/src/commands/validate/checks/chmod.rs
+++ b/xtask/src/commands/validate/checks/chmod.rs
@@ -1,0 +1,295 @@
+//! `--chmod` permission-transform parity between oc-rsync and upstream.
+//!
+//! Builds a fixture with varied starting permissions and a subdir, then pulls
+//! it with each client over every transport while applying one `--chmod` spec,
+//! and asserts oc's destination is byte-identical to upstream's and carries the
+//! same mode bits on every entry. Two representative specs are exercised as
+//! separate cells - one numeric (`D2755,F640`) and one symbolic (`ug=rw,o=`) -
+//! so both `--chmod` grammars are covered. `--chmod` needs no privilege, so
+//! this runs fully as an unprivileged user.
+
+use std::collections::BTreeMap;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The `--chmod` parity check.
+pub struct Chmod;
+
+/// One `--chmod` spec to exercise as its own matrix cell.
+struct Spec {
+    /// Short label for the cell (the spec without the `--chmod=` prefix).
+    label: &'static str,
+    /// The full `--chmod=...` argument passed to rsync.
+    arg: &'static str,
+    /// A file mode the transform must produce on at least one regular file,
+    /// used as a non-vacuous guard so a bug that ignores `--chmod` on both
+    /// sides cannot pass silently.
+    expect_file_mode: u32,
+}
+
+/// Numeric and symbolic `--chmod` specs, one cell each.
+const SPECS: &[Spec] = &[
+    Spec {
+        label: "D2755,F640",
+        arg: "--chmod=D2755,F640",
+        expect_file_mode: 0o640,
+    },
+    Spec {
+        label: "ug=rw,o=",
+        arg: "--chmod=ug=rw,o=",
+        expect_file_mode: 0o660,
+    },
+];
+
+impl Check for Chmod {
+    fn name(&self) -> &'static str {
+        "chmod"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("chmod");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected = support::entry_count(&src);
+
+        let mut outcomes = Vec::new();
+        for &transport in ctx.transports {
+            for (n, spec) in SPECS.iter().enumerate() {
+                outcomes.push(self.cell(ctx, transport, &root, spec, n, expected));
+            }
+        }
+        outcomes
+    }
+}
+
+impl Chmod {
+    /// Run one `(transport, spec)` cell: pull with oc and with upstream applying
+    /// the same spec, then require identical content, identical mode bits, and
+    /// evidence the transform actually took effect.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        spec: &Spec,
+        n: usize,
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = format!("{} {}", transport.label(), spec.label);
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let src = root.join("src");
+        let src = src.as_path();
+        let oc_dst = root.join(format!("oc-{}-{n}", transport.label()));
+        let up_dst = root.join(format!("up-{}-{n}", transport.label()));
+        let flags: Vec<String> = ["-rlptgoD", "--numeric-ids", spec.arg]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            &flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), &label, "upstream", other),
+        };
+        let _ = up;
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            &flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), &label, "oc", other),
+        };
+        let _ = oc;
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+        if let Some(diff) = mode_diff(&oc_dst, &up_dst) {
+            if ctx.verbose {
+                eprint_modes(&oc_dst, &up_dst);
+            }
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+        // Non-vacuous guard: if both sides silently ignored `--chmod`, their
+        // trees would still agree; require the transform to have taken effect.
+        if !transform_took_effect(&oc_dst, spec.expect_file_mode) {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!(
+                    "--chmod had no effect: no regular file with mode {:o}",
+                    spec.expect_file_mode
+                ),
+            );
+        }
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Map a tree to per-entry permission bits (`mode & 0o7777`) for comparison.
+fn mode_map(root: &Path) -> BTreeMap<std::path::PathBuf, u32> {
+    support::rel_entries(root)
+        .into_iter()
+        .filter_map(|rel| {
+            let meta = root.join(&rel).symlink_metadata().ok()?;
+            Some((rel, meta.mode() & 0o7777))
+        })
+        .collect()
+}
+
+/// First per-entry mode divergence between two trees, or `None` when identical.
+fn mode_diff(oc: &Path, up: &Path) -> Option<String> {
+    let (a, b) = (mode_map(oc), mode_map(up));
+    for (rel, oc_mode) in &a {
+        match b.get(rel) {
+            None => return Some(format!("missing {} in upstream tree", rel.display())),
+            Some(up_mode) if oc_mode != up_mode => {
+                return Some(format!(
+                    "mode differs at {}: oc={oc_mode:o} upstream={up_mode:o}",
+                    rel.display()
+                ));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// True if at least one regular file under `dst` has exactly `expected` mode
+/// bits, i.e. the `--chmod` transform was applied rather than ignored.
+fn transform_took_effect(dst: &Path, expected: u32) -> bool {
+    support::rel_entries(dst).iter().any(|rel| {
+        matches!(
+            dst.join(rel).symlink_metadata(),
+            Ok(m) if m.file_type().is_file() && m.mode() & 0o7777 == expected
+        )
+    })
+}
+
+/// Print every entry's mode in both trees, for `--verbose` mismatch triage.
+fn eprint_modes(oc: &Path, up: &Path) {
+    let (a, b) = (mode_map(oc), mode_map(up));
+    let mut rels: Vec<_> = a.keys().chain(b.keys()).collect();
+    rels.sort();
+    rels.dedup();
+    for rel in rels {
+        let oc_mode = a.get(rel).map(|m| format!("{m:o}")).unwrap_or("-".into());
+        let up_mode = b.get(rel).map(|m| format!("{m:o}")).unwrap_or("-".into());
+        eprintln!("  {}: oc={oc_mode} upstream={up_mode}", rel.display());
+    }
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label.to_string(),
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(
+            check,
+            label.to_string(),
+            format!("{who} could not run: {e}"),
+        ),
+    }
+}
+
+/// Build the `--chmod` fixture. Idempotent: removes any prior tree first. Files
+/// carry varied starting perms so a transform visibly changes them; mtimes are
+/// backdated so the quick-check does not skip anything under test.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    write_mode(&src.join("f644"), b"alpha", 0o644)?;
+    write_mode(&src.join("f600"), b"bravo", 0o600)?;
+    write_mode(&src.join("f755"), b"charlie", 0o755)?;
+    write_mode(&sub.join("f640"), b"delta", 0o640)?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn write_mode(path: &Path, bytes: &[u8], mode: u32) -> Result<(), String> {
+    std::fs::write(path, bytes).map_err(|e| e.to_string())?;
+    set_mode(path, mode)
+}
+
+fn set_mode(path: &Path, mode: u32) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mode_diff, set_mode};
+    use std::fs;
+
+    #[test]
+    fn mode_diff_none_for_identical_modes() {
+        // Seed equal modes explicitly (portable; no reliance on `touch -d @epoch`).
+        let (a, b) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        for root in [a.path(), b.path()] {
+            let f = root.join("f");
+            fs::write(&f, b"x").unwrap();
+            set_mode(&f, 0o640).unwrap();
+        }
+        assert!(mode_diff(a.path(), b.path()).is_none());
+    }
+
+    #[test]
+    fn mode_diff_names_the_diverging_path() {
+        let (a, b) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        fs::write(a.path().join("f"), b"x").unwrap();
+        fs::write(b.path().join("f"), b"x").unwrap();
+        set_mode(&a.path().join("f"), 0o640).unwrap();
+        set_mode(&b.path().join("f"), 0o600).unwrap();
+        let diff = mode_diff(a.path(), b.path()).unwrap();
+        assert!(diff.contains("mode differs"));
+        assert!(diff.contains("f"));
+    }
+}

--- a/xtask/src/commands/validate/checks/chmod.rs
+++ b/xtask/src/commands/validate/checks/chmod.rs
@@ -4,9 +4,12 @@
 //! it with each client over every transport while applying one `--chmod` spec,
 //! and asserts oc's destination is byte-identical to upstream's and carries the
 //! same mode bits on every entry. Two representative specs are exercised as
-//! separate cells - one numeric (`D2755,F640`) and one symbolic (`ug=rw,o=`) -
-//! so both `--chmod` grammars are covered. `--chmod` needs no privilege, so
-//! this runs fully as an unprivileged user.
+//! separate cells - one numeric (`D2755,F640`) and one symbolic (`ug=rwX,o=`) -
+//! so both `--chmod` grammars are covered. The symbolic spec uses a capital
+//! `X` (`ug=rwX,o=`) so directories stay traversable - a lowercase `x` would
+//! strip the destination root's execute bit and upstream itself would abort
+//! with `exit 23 ... Permission denied`. `--chmod` needs no privilege, so this
+//! runs fully as an unprivileged user.
 
 use std::collections::BTreeMap;
 use std::os::unix::fs::MetadataExt;
@@ -38,9 +41,12 @@ const SPECS: &[Spec] = &[
         arg: "--chmod=D2755,F640",
         expect_file_mode: 0o640,
     },
+    // Capital `X` sets execute only on directories and already-executable
+    // files, so directories (including the destination root) stay traversable
+    // while a plain 0644 file becomes user rw, group rw, other none => 0o660.
     Spec {
-        label: "ug=rw,o=",
-        arg: "--chmod=ug=rw,o=",
+        label: "ug=rwX,o=",
+        arg: "--chmod=ug=rwX,o=",
         expect_file_mode: 0o660,
     },
 ];

--- a/xtask/src/commands/validate/checks/chown.rs
+++ b/xtask/src/commands/validate/checks/chown.rs
@@ -1,0 +1,411 @@
+//! Ownership (`--chown` / `--usermap` / `--groupmap`) parity between oc-rsync
+//! and upstream.
+//!
+//! Builds a small fixture, then pulls it with each client over every transport
+//! and asserts oc's destination owners (uid/gid) match upstream's byte-for-byte
+//! after ownership remapping. Two scenarios run per transport:
+//!
+//! * `chown-self` - always runnable without privilege: `--chown=<uid>:<gid>`
+//!   using the current effective id. Both clients target the same current id, so
+//!   this validates that oc and upstream drive the `--chown` path identically.
+//! * `usermap` - remaps ids to values only root may assign, so it is skipped
+//!   unless the process runs as root. When runnable it proves oc and upstream
+//!   apply `--usermap`/`--groupmap` the same way.
+//!
+//! Id remapping to arbitrary uids/gids requires root, so the check is
+//! skip-aware and never assumes privilege.
+
+use std::collections::BTreeMap;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The ownership parity check.
+pub struct Chown;
+
+/// Preserve owner and group so the `--chown`/`--*map` result is observable.
+const BASE_FLAGS: &[&str] = &["-rlptgoD", "--numeric-ids"];
+
+/// The current process identity, as reported by `id`.
+struct Ids {
+    /// Effective user id (`id -u`); the process is root iff this is `0`.
+    euid: u32,
+    /// Effective group id (`id -g`).
+    gid: u32,
+    /// Effective user name (`id -un`), retained for diagnostics.
+    user: String,
+    /// Effective group name (`id -gn`), retained for diagnostics.
+    group: String,
+}
+
+/// One ownership scenario: the flags to run and the (uid, gid) they must yield.
+struct Scenario<'a> {
+    /// Cell label for the report.
+    label: String,
+    /// Full rsync flag set for the run.
+    flags: &'a [String],
+    /// Expected owning uid in both destinations.
+    want_uid: u32,
+    /// Expected owning gid in both destinations.
+    want_gid: u32,
+}
+
+impl Check for Chown {
+    fn name(&self) -> &'static str {
+        "chown"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let ids = match ids() {
+            Ok(ids) => ids,
+            Err(e) => return vec![CheckOutcome::skip(self.name(), "identity", e)],
+        };
+        if ctx.verbose {
+            eprintln!(
+                "[chown] running as {}:{} ({}:{})",
+                ids.user, ids.group, ids.euid, ids.gid
+            );
+        }
+
+        let root = ctx.work.join("chown");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected = support::entry_count(&src);
+
+        ctx.transports
+            .iter()
+            .flat_map(|&t| self.transport_cells(ctx, t, &root, &ids, expected))
+            .collect()
+    }
+}
+
+impl Chown {
+    /// Both scenarios for one transport: the always-runnable `chown-self` and
+    /// the root-only `usermap`.
+    fn transport_cells(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        ids: &Ids,
+        expected: usize,
+    ) -> Vec<CheckOutcome> {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return vec![
+                CheckOutcome::skip(self.name(), format!("{label} chown-self"), "no sshd"),
+                CheckOutcome::skip(self.name(), format!("{label} usermap"), "no sshd"),
+            ];
+        }
+
+        // Scenario 1: chown to the current id. Non-root, always runnable.
+        let chown_flags = flags(&[format!("--chown={}:{}", ids.euid, ids.gid)]);
+        let self_cell = self.cell(
+            ctx,
+            transport,
+            root,
+            &Scenario {
+                label: format!("{label} chown-self"),
+                flags: &chown_flags,
+                want_uid: ids.euid,
+                want_gid: ids.gid,
+            },
+            expected,
+        );
+
+        // Scenario 2: remap ids to values only root may assign.
+        let map_cell = if ids.euid != 0 {
+            CheckOutcome::skip(
+                self.name(),
+                format!("{label} usermap"),
+                "id remap needs root",
+            )
+        } else {
+            let map_flags = flags(&["--usermap=0:1".to_string(), "--groupmap=0:1".to_string()]);
+            self.cell(
+                ctx,
+                transport,
+                root,
+                &Scenario {
+                    label: format!("{label} usermap"),
+                    flags: &map_flags,
+                    want_uid: 1,
+                    want_gid: 1,
+                },
+                expected,
+            )
+        };
+
+        vec![self_cell, map_cell]
+    }
+
+    /// Run one (transport, scenario) cell: pull with oc and upstream, then
+    /// assert content parity, owner parity, and that the requested ids actually
+    /// took effect.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        scenario: &Scenario,
+        expected: usize,
+    ) -> CheckOutcome {
+        let cell = scenario.label.clone();
+        let flags: &[String] = scenario.flags;
+        let want_uid = scenario.want_uid;
+        let want_gid = scenario.want_gid;
+        let src = root.join("src");
+        let src = src.as_path();
+        let oc_dst = root.join(format!("oc-{}", sanitize(&cell)));
+        let up_dst = root.join(format!("up-{}", sanitize(&cell)));
+
+        let up = pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        );
+        match up {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &cell, "upstream", other),
+        }
+
+        let oc = pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        );
+        match oc {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &cell, "oc", other),
+        }
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), cell, "destination entry count != source");
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), cell, diff);
+        }
+
+        // oc and upstream must apply the same ownership.
+        if let Some(diff) = owner_diff(&oc_dst, &up_dst) {
+            if ctx.verbose {
+                dump_owners("oc", &oc_dst);
+                dump_owners("upstream", &up_dst);
+            }
+            return CheckOutcome::fail(self.name(), cell, diff);
+        }
+
+        // Non-vacuous: the requested remap must actually be present in oc's tree.
+        if let Some(diff) = owner_mismatch(&oc_dst, want_uid, want_gid) {
+            if ctx.verbose {
+                dump_owners("oc", &oc_dst);
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                cell,
+                format!("requested {want_uid}:{want_gid} not applied: {diff}"),
+            );
+        }
+
+        CheckOutcome::pass(self.name(), cell)
+    }
+}
+
+/// Combine [`BASE_FLAGS`] with scenario-specific flags into one owned vector.
+fn flags(extra: &[String]) -> Vec<String> {
+    BASE_FLAGS
+        .iter()
+        .map(|s| s.to_string())
+        .chain(extra.iter().cloned())
+        .collect()
+}
+
+/// Gather the effective identity via `id`.
+fn ids() -> Result<Ids, String> {
+    let euid = capture_u32("id", &["-u"])?;
+    let gid = capture_u32("id", &["-g"])?;
+    let user = support::capture("id", &["-un"]).map_err(|e| e.to_string())?;
+    let group = support::capture("id", &["-gn"]).map_err(|e| e.to_string())?;
+    Ok(Ids {
+        euid,
+        gid,
+        user,
+        group,
+    })
+}
+
+/// Capture `program args...` and parse its trimmed stdout as a `u32`.
+fn capture_u32(program: &str, args: &[&str]) -> Result<u32, String> {
+    let out = support::capture(program, args).map_err(|e| e.to_string())?;
+    out.trim()
+        .parse()
+        .map_err(|e| format!("parse `{program} {args:?}` output {out:?}: {e}"))
+}
+
+/// Map a tree to per-entry `(uid, gid)`, following no symlinks.
+fn owner_map(root: &Path) -> BTreeMap<PathBuf, (u32, u32)> {
+    support::rel_entries(root)
+        .into_iter()
+        .filter_map(|rel| {
+            let meta = root.join(&rel).symlink_metadata().ok()?;
+            Some((rel, (meta.uid(), meta.gid())))
+        })
+        .collect()
+}
+
+/// First per-entry ownership divergence between two trees, or `None` when every
+/// entry's `(uid, gid)` matches.
+fn owner_diff(oc: &Path, up: &Path) -> Option<String> {
+    let (a, b) = (owner_map(oc), owner_map(up));
+    for (rel, oc_owner) in &a {
+        let Some(up_owner) = b.get(rel) else {
+            return Some(format!("missing {} in upstream tree", rel.display()));
+        };
+        if oc_owner != up_owner {
+            return Some(format!(
+                "owner differs at {}: oc {}:{} vs upstream {}:{}",
+                rel.display(),
+                oc_owner.0,
+                oc_owner.1,
+                up_owner.0,
+                up_owner.1
+            ));
+        }
+    }
+    for rel in b.keys() {
+        if !a.contains_key(rel) {
+            return Some(format!("missing {} in oc tree", rel.display()));
+        }
+    }
+    None
+}
+
+/// First entry whose owner is not `(want_uid, want_gid)`, or `None` when the
+/// whole tree carries the expected ownership.
+fn owner_mismatch(root: &Path, want_uid: u32, want_gid: u32) -> Option<String> {
+    for (rel, (uid, gid)) in owner_map(root) {
+        if uid != want_uid || gid != want_gid {
+            return Some(format!("{} is {uid}:{gid}", rel.display()));
+        }
+    }
+    None
+}
+
+/// Print a tree's per-entry `(uid, gid)` for verbose failure diagnosis.
+fn dump_owners(who: &str, root: &Path) {
+    for (rel, (uid, gid)) in owner_map(root) {
+        eprintln!("[chown] {who} {} -> {uid}:{gid}", rel.display());
+    }
+}
+
+/// Turn a cell label into a filesystem-safe destination suffix.
+fn sanitize(cell: &str) -> String {
+    cell.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    cell: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                cell.to_string(),
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, cell.to_string(), format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the ownership fixture: two top-level files plus a subdirectory holding
+/// one file. Idempotent - removes any prior tree first. Mtimes are backdated so
+/// the quick-check does not skip the transfer under test.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("alpha"), b"alpha").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("bravo"), b"bravo").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("charlie"), b"charlie").map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{owner_diff, owner_mismatch, sanitize};
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
+
+    #[test]
+    fn owner_diff_none_for_hard_linked_identical_ownership() {
+        // A hard link shares the inode, so uid/gid are guaranteed identical
+        // without touching ownership (which would need root).
+        let (a, b) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        let source = a.path().join("f");
+        fs::write(&source, b"x").unwrap();
+        fs::hard_link(&source, b.path().join("f")).unwrap();
+        assert!(owner_diff(a.path(), b.path()).is_none());
+    }
+
+    #[test]
+    fn owner_diff_reports_missing_entry() {
+        // A structural divergence exercises the Some path without needing root
+        // to synthesize a uid/gid mismatch.
+        let (a, b) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        fs::write(a.path().join("only"), b"x").unwrap();
+        assert!(owner_diff(a.path(), b.path()).unwrap().contains("missing"));
+    }
+
+    #[test]
+    fn owner_mismatch_flags_unexpected_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f");
+        fs::write(&path, b"x").unwrap();
+        let meta = path.symlink_metadata().unwrap();
+        // The file is owned by us; requesting our own id must pass, and an
+        // impossible id must be flagged.
+        assert!(owner_mismatch(dir.path(), meta.uid(), meta.gid()).is_none());
+        let bogus = meta.uid().wrapping_add(1);
+        assert!(owner_mismatch(dir.path(), bogus, meta.gid()).is_some());
+    }
+
+    #[test]
+    fn sanitize_keeps_alphanumerics_only() {
+        assert_eq!(sanitize("local chown-self"), "local-chown-self");
+    }
+}

--- a/xtask/src/commands/validate/checks/compare_dest.rs
+++ b/xtask/src/commands/validate/checks/compare_dest.rs
@@ -1,0 +1,442 @@
+//! `--compare-dest` / `--copy-dest` parity: oc-rsync treats a reference
+//! directory of already-present files exactly as upstream does.
+//!
+//! Both flags name a reference dir holding files that may already match the
+//! source. They diverge on what happens to an *unchanged* file:
+//!
+//! - `--compare-dest` skips it entirely - the file is neither transferred nor
+//!   written to the destination, because an identical copy already exists in the
+//!   reference.
+//! - `--copy-dest` copies it locally from the reference into the destination, so
+//!   the destination ends up holding the full tree without transferring the
+//!   unchanged bytes over the wire.
+//!
+//! Like the `--delete` and `--link-dest` checks this needs a pre-built reference
+//! tree and an extra flag, so each client `Command` is built directly rather than
+//! through `transport::pull_into`. For every cell a per-cell reference dir holds
+//! `same.txt` and `sub/also_same.txt` byte- and mtime-identical to the source
+//! (so the quick-check treats them as unchanged) plus `changed.txt` carrying
+//! older, differing content. Both clients pull the source into their own fresh
+//! empty destination with `--compare-dest`/`--copy-dest=<absolute ref dir>`.
+//!
+//! Upstream rsync is the ground truth: for each scenario oc's destination must be
+//! content-identical to upstream's, and must additionally exhibit the scenario's
+//! defining shape - only `changed.txt` present for `--compare-dest`, the whole
+//! tree present for `--copy-dest`. The ssh transports are skipped when no sshd
+//! answers on localhost:22.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `--compare-dest` / `--copy-dest` reference-directory parity check.
+pub struct CompareDest;
+
+/// Files present in the reference byte- and mtime-identical to the source: the
+/// quick-check treats them as unchanged relative to the reference.
+const UNCHANGED: &[&str] = &["same.txt", "sub/also_same.txt"];
+
+/// File whose source content differs from the reference: it is always
+/// transferred fresh under both flags.
+const CHANGED: &str = "changed.txt";
+
+/// Shared backdated mtime (epoch seconds) applied to source and reference so the
+/// quick-check treats the unchanged files as identical to the reference.
+const EPOCH: &str = "@1614830767";
+
+/// Which reference-directory flag a cell exercises.
+#[derive(Clone, Copy)]
+enum Scenario {
+    /// `--compare-dest`: unchanged files are skipped, not written to the dest.
+    Compare,
+    /// `--copy-dest`: unchanged files are copied locally from the reference.
+    Copy,
+}
+
+impl Scenario {
+    /// Stable scenario label, also the flag's long name.
+    fn label(self) -> &'static str {
+        match self {
+            Scenario::Compare => "compare-dest",
+            Scenario::Copy => "copy-dest",
+        }
+    }
+
+    /// Build the full `--<flag>=<ref>` argument for this scenario.
+    fn flag(self, ref_dir: &Path) -> String {
+        format!("--{}={}", self.label(), ref_dir.display())
+    }
+}
+
+impl Check for CompareDest {
+    fn name(&self) -> &'static str {
+        "compare-dest"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("compare-dest");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let mut outcomes = Vec::with_capacity(ctx.transports.len() * 2);
+        for &t in ctx.transports {
+            outcomes.push(self.cell(ctx, t, &root, &src, Scenario::Compare));
+            outcomes.push(self.cell(ctx, t, &root, &src, Scenario::Copy));
+        }
+        outcomes
+    }
+}
+
+impl CompareDest {
+    /// Run one (transport, scenario) cell: build the reference, pull with each
+    /// client into a fresh destination using the scenario's flag, then compare
+    /// content against upstream and assert the scenario's defining dest shape.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        scenario: Scenario,
+    ) -> CheckOutcome {
+        let label = format!("{} {}", transport.label(), scenario.label());
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let key = format!("{}-{}", transport.label(), scenario.label());
+
+        // Per-cell reference dir, canonicalized so the flag path is absolute.
+        let ref_dir = root.join(format!("ref-{key}"));
+        if let Err(e) = build_reference(src, &ref_dir) {
+            return CheckOutcome::skip(self.name(), label, format!("reference: {e}"));
+        }
+        let ref_dir = match ref_dir.canonicalize() {
+            Ok(p) => p,
+            Err(e) => {
+                return CheckOutcome::skip(self.name(), label, format!("canonicalize ref: {e}"));
+            }
+        };
+        let ref_flag = scenario.flag(&ref_dir);
+
+        let oc_dst = root.join(format!("oc-{key}"));
+        let up_dst = root.join(format!("up-{key}"));
+
+        // One live upstream daemon shared by both client runs for this cell.
+        let daemon = if transport == Transport::Daemon {
+            match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), label, format!("daemon: {e}")),
+            }
+        } else {
+            None
+        };
+        let daemon_url = daemon.as_ref().map(|d| d.module_url());
+
+        let up = run_client(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            &ref_flag,
+            daemon_url.as_deref(),
+        );
+        let up = match up {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), &label, "upstream", other),
+        };
+        let _ = up;
+        let oc = run_client(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            &ref_flag,
+            daemon_url.as_deref(),
+        );
+        let oc = match oc {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), &label, "oc", other),
+        };
+        let _ = oc;
+        drop(daemon);
+
+        // Destinations must be byte-identical regardless of scenario.
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            if ctx.verbose {
+                dump(&label, &oc_dst, &up_dst);
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("oc and upstream dests differ: {diff}"),
+            );
+        }
+
+        // Scenario-defining shape must hold in oc's destination.
+        let shape = match scenario {
+            Scenario::Compare => evaluate_compare(&oc_dst),
+            Scenario::Copy => evaluate_copy(&oc_dst, src),
+        };
+        match shape {
+            Ok(()) => CheckOutcome::pass(self.name(), label),
+            Err(reason) => {
+                if ctx.verbose {
+                    dump(&label, &oc_dst, &up_dst);
+                }
+                CheckOutcome::fail(self.name(), label, reason)
+            }
+        }
+    }
+}
+
+/// Build one client rsync `Command` for `transport` and pull `src/` into a fresh
+/// `dst/` with `ref_flag` (a full `--compare-dest=`/`--copy-dest=` argument). The
+/// destination is recreated empty first so the reference is the only basis.
+///
+/// Flags are `-rlptgoD --numeric-ids <ref_flag>`. Operand forms mirror
+/// `transport::pull_into`: `local` copies from a path, `ssh-subprocess` uses
+/// `-e ssh localhost:<src>`, `russh` an `ssh://` URL, `daemon` the module URL in
+/// `daemon_url`. The sender is always `upstream` for the network transports.
+fn run_client(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    ref_flag: &str,
+    daemon_url: Option<&str>,
+) -> TaskResult<Output> {
+    reset_dir(dst)?;
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.arg("-rlptgoD").arg("--numeric-ids").arg(ref_flag);
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let url = daemon_url
+                .ok_or_else(|| TaskError::Validation("daemon transport without url".into()))?;
+            cmd.arg(url).arg(&dst_arg);
+        }
+    }
+
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// `--compare-dest` shape: the changed file must land in the destination while
+/// every unchanged file is skipped (matched against the reference, never
+/// written). Non-vacuous: a client that copies everything trips the second loop,
+/// one that transfers nothing trips the first check.
+fn evaluate_compare(dst: &Path) -> Result<(), String> {
+    if !dst.join(CHANGED).exists() {
+        return Err(format!("{CHANGED} was not written to the dest"));
+    }
+    for rel in UNCHANGED {
+        if dst.join(rel).exists() {
+            return Err(format!(
+                "{rel} was written to the dest despite matching the reference"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// `--copy-dest` shape: the destination must hold the full source tree with
+/// correct content - the unchanged files copied from the reference plus the
+/// transferred `changed.txt`. Equality with the source is non-vacuous: a missing
+/// or wrong-content file yields a diff.
+fn evaluate_copy(dst: &Path, src: &Path) -> Result<(), String> {
+    match support::content_diff(dst, src) {
+        Some(diff) => Err(format!("copy-dest tree differs from source: {diff}")),
+        None => Ok(()),
+    }
+}
+
+/// Print each destination's entry set (verbose failures) so a shape or content
+/// divergence is legible.
+fn dump(label: &str, oc_dst: &Path, up_dst: &Path) {
+    eprintln!(
+        "[compare-dest/{label}] oc entries: {:?}",
+        support::rel_entries(oc_dst)
+    );
+    eprintln!(
+        "[compare-dest/{label}] upstream entries: {:?}",
+        support::rel_entries(up_dst)
+    );
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label.to_string(),
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(
+            check,
+            label.to_string(),
+            format!("{who} could not run: {e}"),
+        ),
+    }
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Build the source fixture: two files that will match the reference plus one
+/// whose content will differ. Idempotent: removes any prior tree first. Mtimes
+/// are backdated so the unchanged files quick-check as identical to the
+/// reference (matched by both flags).
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("same.txt"), b"same-content\n").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("also_same.txt"), b"also-same-content\n").map_err(|e| e.to_string())?;
+    // Longer, different content so the reference's older copy quick-checks as
+    // changed and is transferred fresh under both flags.
+    std::fs::write(src.join(CHANGED), b"changed-new-longer-content\n")
+        .map_err(|e| e.to_string())?;
+
+    backdate(src)
+}
+
+/// Build the per-cell reference: the two unchanged files copied byte- and
+/// mtime-identical from the source, plus an older `changed.txt`. Idempotent.
+fn build_reference(src: &Path, ref_dir: &Path) -> Result<(), String> {
+    if ref_dir.exists() {
+        std::fs::remove_dir_all(ref_dir).map_err(|e| e.to_string())?;
+    }
+    let sub = ref_dir.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    for rel in UNCHANGED {
+        std::fs::copy(src.join(rel), ref_dir.join(rel)).map_err(|e| e.to_string())?;
+    }
+    // Older, shorter content: differs from the source so it is transferred.
+    std::fs::write(ref_dir.join(CHANGED), b"old\n").map_err(|e| e.to_string())?;
+
+    // Match the source mtimes on the unchanged files so the quick-check treats
+    // them as unchanged; the changed file's mtime is irrelevant (size differs).
+    for rel in UNCHANGED {
+        touch_epoch(&ref_dir.join(rel))?;
+    }
+    Ok(())
+}
+
+/// Backdate every entry under `root` to the shared epoch mtime.
+fn backdate(root: &Path) -> Result<(), String> {
+    for entry in support::rel_entries(root) {
+        touch_epoch(&root.join(&entry))?;
+    }
+    Ok(())
+}
+
+/// Set `path`'s mtime to the shared epoch via GNU `touch -h -d @epoch`.
+fn touch_epoch(path: &Path) -> Result<(), String> {
+    support::capture("touch", &["-h", "-d", EPOCH, &path.to_string_lossy()])
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CHANGED, UNCHANGED, evaluate_compare, evaluate_copy};
+    use std::fs;
+    use std::path::Path;
+
+    /// Seed a full source tree: both unchanged files plus the changed file.
+    fn seed_full(root: &Path) {
+        fs::create_dir_all(root.join("sub")).unwrap();
+        fs::write(root.join(UNCHANGED[0]), b"same-content\n").unwrap();
+        fs::write(root.join(UNCHANGED[1]), b"also-same-content\n").unwrap();
+        fs::write(root.join(CHANGED), b"changed-new-longer-content\n").unwrap();
+    }
+
+    #[test]
+    fn compare_accepts_only_changed_present() {
+        // --compare-dest correct outcome: only the changed file was written.
+        let dst = tempfile::tempdir().unwrap();
+        fs::write(dst.path().join(CHANGED), b"changed-new-longer-content\n").unwrap();
+        assert!(evaluate_compare(dst.path()).is_ok());
+    }
+
+    #[test]
+    fn compare_rejects_written_unchanged_file() {
+        // A client that copied an unchanged file breaks --compare-dest semantics.
+        let dst = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dst.path().join("sub")).unwrap();
+        fs::write(dst.path().join(CHANGED), b"changed-new-longer-content\n").unwrap();
+        fs::write(dst.path().join(UNCHANGED[0]), b"same-content\n").unwrap();
+        let err = evaluate_compare(dst.path()).unwrap_err();
+        assert!(err.contains(UNCHANGED[0]));
+    }
+
+    #[test]
+    fn compare_rejects_missing_changed_file() {
+        let dst = tempfile::tempdir().unwrap();
+        let err = evaluate_compare(dst.path()).unwrap_err();
+        assert!(err.contains(CHANGED));
+    }
+
+    #[test]
+    fn copy_accepts_full_tree_matching_source() {
+        // --copy-dest correct outcome: the whole source tree is present.
+        let (src, dst) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        seed_full(src.path());
+        seed_full(dst.path());
+        assert!(evaluate_copy(dst.path(), src.path()).is_ok());
+    }
+
+    #[test]
+    fn copy_rejects_missing_unchanged_file() {
+        let (src, dst) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        seed_full(src.path());
+        // Destination is missing the unchanged files - only the changed one landed.
+        fs::write(dst.path().join(CHANGED), b"changed-new-longer-content\n").unwrap();
+        assert!(evaluate_copy(dst.path(), src.path()).is_err());
+    }
+}

--- a/xtask/src/commands/validate/checks/compress.rs
+++ b/xtask/src/commands/validate/checks/compress.rs
@@ -1,0 +1,259 @@
+//! Codec transparency between oc-rsync and upstream.
+//!
+//! Compression only ever touches the wire - the delivered bytes must equal the
+//! source. This builds a fixture that stresses the compressor (a highly
+//! compressible file, plain text, an incompressible blob, and a nested file),
+//! then pulls it with `-z` and with `-z --compress-level=9` over every transport
+//! and asserts oc's destination is byte-identical to both upstream's and the
+//! source. That proves oc's codec round-trips exactly like upstream's.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The compression transparency check.
+pub struct Compress;
+
+/// Base flags applied to every cell; the compress args are appended per cell.
+const BASE_FLAGS: &[&str] = &["-rlptgoD", "--numeric-ids"];
+
+/// The compress argument sets to exercise: default codec/level, then level 9.
+const COMPRESS_ARGS: [&[&str]; 2] = [&["-z"], &["-z", "--compress-level=9"]];
+
+impl Check for Compress {
+    fn name(&self) -> &'static str {
+        "compress"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("compress");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected = support::entry_count(&src);
+
+        let mut outcomes = Vec::new();
+        for &transport in ctx.transports {
+            for (n, args) in COMPRESS_ARGS.iter().enumerate() {
+                outcomes.push(self.cell(ctx, transport, &root, args, n, expected));
+            }
+        }
+        outcomes
+    }
+}
+
+impl Compress {
+    /// Run one `(transport, compress-args)` cell.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        compress_args: &[&str],
+        n: usize,
+        expected: usize,
+    ) -> CheckOutcome {
+        let cell = format!("{} {}", transport.label(), level_tag(compress_args));
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), cell, "no sshd on localhost:22");
+        }
+        let label = transport.label();
+        let src = root.join("src");
+        let src = src.as_path();
+        let oc_dst = root.join(format!("oc-{label}-{n}"));
+        let up_dst = root.join(format!("up-{label}-{n}"));
+        let flags: Vec<String> = BASE_FLAGS
+            .iter()
+            .chain(compress_args.iter())
+            .map(|s| s.to_string())
+            .collect();
+
+        match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            &flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &cell, "upstream", other),
+        }
+        match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            &flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &cell, "oc", other),
+        }
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), cell, "destination entry count != source");
+        }
+        // Transparency: identical to upstream's receive and to the source bytes.
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), cell, diff);
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, src) {
+            return CheckOutcome::fail(self.name(), cell, diff);
+        }
+        if ctx.verbose {
+            eprintln!(
+                "[compress] {cell}: {} bytes across {expected} entries",
+                tree_bytes(&oc_dst)
+            );
+        }
+        CheckOutcome::pass(self.name(), cell)
+    }
+}
+
+/// Short cell suffix for a compress-arg set, e.g. `-z` or `-z9`.
+fn level_tag(compress_args: &[&str]) -> String {
+    match compress_args
+        .iter()
+        .find_map(|a| a.strip_prefix("--compress-level="))
+    {
+        Some(level) => format!("-z{level}"),
+        None => "-z".to_string(),
+    }
+}
+
+/// Total bytes of regular files under `root` (for the verbose size note).
+fn tree_bytes(root: &Path) -> u64 {
+    support::rel_entries(root)
+        .iter()
+        .filter_map(|rel| root.join(rel).symlink_metadata().ok())
+        .filter(|m| m.is_file())
+        .map(|m| m.len())
+        .sum()
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    cell: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                cell.to_string(),
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, cell.to_string(), format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the compression fixture. Idempotent: removes any prior tree first.
+///
+/// Contents span the compressor's range: a highly compressible file (a repeating
+/// text pattern), a plain text file, an already-incompressible blob (bytes are
+/// derived deterministically from their index - never system randomness - so the
+/// fixture is reproducible), and a file in a subdirectory.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("compressible.txt"), repeating(200 * 1024))
+        .map_err(|e| e.to_string())?;
+    std::fs::write(
+        src.join("text.txt"),
+        b"The quick brown fox jumps over the lazy dog.\n".repeat(64),
+    )
+    .map_err(|e| e.to_string())?;
+    std::fs::write(src.join("incompressible.bin"), pseudo_random(64 * 1024))
+        .map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("nested.txt"), b"nested payload under a subdir\n")
+        .map_err(|e| e.to_string())?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// `len` bytes of a short repeating pattern - trivially compressible.
+fn repeating(len: usize) -> Vec<u8> {
+    const PATTERN: &[u8] = b"oc-rsync compression fidelity harness pattern 0123456789\n";
+    PATTERN.iter().copied().cycle().take(len).collect()
+}
+
+/// `len` deterministic high-entropy bytes derived from a per-byte index mix.
+///
+/// A pure function of the index (an integer hash), so the "incompressible"
+/// fixture is byte-for-byte reproducible without touching system randomness.
+fn pseudo_random(len: usize) -> Vec<u8> {
+    (0..len as u64)
+        .map(|i| {
+            let mut x = i.wrapping_add(0x9e37_79b9_7f4a_7c15);
+            x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            ((x ^ (x >> 31)) & 0xff) as u8
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{level_tag, pseudo_random, repeating, tree_bytes};
+    use std::fs;
+
+    #[test]
+    fn level_tag_distinguishes_default_from_explicit_level() {
+        assert_eq!(level_tag(&["-z"]), "-z");
+        assert_eq!(level_tag(&["-z", "--compress-level=9"]), "-z9");
+    }
+
+    #[test]
+    fn pseudo_random_is_deterministic_and_high_entropy() {
+        // Reproducible: same index stream, same bytes - no system randomness.
+        assert_eq!(pseudo_random(4096), pseudo_random(4096));
+        // Spread across byte values, so it resists compression (unlike a run).
+        let bytes = pseudo_random(8192);
+        let distinct = bytes
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len();
+        assert!(distinct > 200, "only {distinct} distinct byte values");
+    }
+
+    #[test]
+    fn repeating_fills_exactly_and_cycles_the_pattern() {
+        let out = repeating(100);
+        assert_eq!(out.len(), 100);
+        assert_eq!(out[0], out[57]); // pattern length is 57 bytes
+    }
+
+    #[test]
+    fn tree_bytes_sums_regular_file_lengths_only() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("d")).unwrap();
+        fs::write(dir.path().join("a"), b"12345").unwrap();
+        fs::write(dir.path().join("d/b"), b"678").unwrap();
+        assert_eq!(tree_bytes(dir.path()), 8);
+    }
+}

--- a/xtask/src/commands/validate/checks/crtimes.rs
+++ b/xtask/src/commands/validate/checks/crtimes.rs
@@ -1,0 +1,245 @@
+//! Create/birth-time (`--crtimes`, `-N`) parity between oc-rsync and upstream.
+//!
+//! Builds a small fixture, then pulls it with each client over every transport
+//! and asserts oc's destination is byte-identical to upstream's *and* that the
+//! birth time (`stat -c %W`) of every entry matches between the two
+//! destinations. This proves oc and upstream handle `--crtimes` identically on
+//! this host - both preserving the crtime, or both leaving the fresh file's own
+//! birth time - without assuming crtime is settable anywhere.
+//!
+//! Birth time is a fragile attribute: many Linux filesystems and kernels do not
+//! expose it at all (`stat -c %W` reports `0`), and most cannot *set* it, so
+//! `--crtimes` is frequently a no-op or unsupported. The check probes the work
+//! filesystem first and skips the whole matrix when birth times are not exposed.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The create/birth-time parity check.
+pub struct Crtimes;
+
+/// Preserve metadata and request crtime preservation. `--crtimes` (`-N`) is the
+/// attribute under test; `--numeric-ids` keeps owner comparison host-stable.
+const FLAGS: &[&str] = &["-rlptgoD", "--crtimes", "--numeric-ids"];
+
+impl Check for Crtimes {
+    fn name(&self) -> &'static str {
+        "crtimes"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        // Support probe: birth times must be exposed by the work filesystem, or
+        // there is nothing meaningful to compare.
+        if !work_exposes_birth_times(ctx.work) {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                "support",
+                "filesystem does not expose birth times",
+            )];
+        }
+
+        let root = ctx.work.join("crtimes");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &flags, expected))
+            .collect()
+    }
+}
+
+impl Crtimes {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        flags: &[String],
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let src = root.join("src");
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            &src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let _ = up;
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            &src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+        let _ = oc;
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+        match crtime_diff(&oc_dst, &up_dst) {
+            Some(diff) => {
+                if ctx.verbose {
+                    dump_crtimes(&oc_dst, &up_dst);
+                }
+                CheckOutcome::fail(self.name(), label, diff)
+            }
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// First birth-time divergence between two trees, or `None` when every entry's
+/// `stat -c %W` matches. Missing values compare equal only when both are absent.
+fn crtime_diff(oc: &Path, up: &Path) -> Option<String> {
+    for rel in support::rel_entries(oc) {
+        let oc_bt = crtime_of(&oc.join(&rel));
+        let up_bt = crtime_of(&up.join(&rel));
+        if oc_bt != up_bt {
+            return Some(format!(
+                "crtime differs at {}: oc={} upstream={}",
+                rel.display(),
+                oc_bt.as_deref().unwrap_or("?"),
+                up_bt.as_deref().unwrap_or("?"),
+            ));
+        }
+    }
+    None
+}
+
+/// Birth time of `path` as reported by `stat -c %W`, or `None` when the stat
+/// call fails (e.g. the path is missing).
+fn crtime_of(path: &Path) -> Option<String> {
+    support::capture("stat", &["-c", "%W", &path.to_string_lossy()]).ok()
+}
+
+/// Print each entry's oc/upstream birth time for verbose diagnostics.
+fn dump_crtimes(oc: &Path, up: &Path) {
+    for rel in support::rel_entries(oc) {
+        let oc_bt = crtime_of(&oc.join(&rel));
+        let up_bt = crtime_of(&up.join(&rel));
+        eprintln!(
+            "    {}: oc={} upstream={}",
+            rel.display(),
+            oc_bt.as_deref().unwrap_or("?"),
+            up_bt.as_deref().unwrap_or("?"),
+        );
+    }
+}
+
+/// Probe whether the work filesystem exposes birth times. Writes a throwaway
+/// file, reads its `stat -c %W`, and treats an empty, `-`, or `0` value as "not
+/// exposed" - the same convention `stat` uses for filesystems without crtime.
+fn work_exposes_birth_times(work: &Path) -> bool {
+    let probe = work.join(".crtimes-probe");
+    if std::fs::write(&probe, b"probe").is_err() {
+        return false;
+    }
+    let raw = support::capture("stat", &["-c", "%W", &probe.to_string_lossy()]).ok();
+    let _ = std::fs::remove_file(&probe);
+    raw.map(|v| birth_exposed(&v)).unwrap_or(false)
+}
+
+/// True when a `stat -c %W` value denotes an exposed birth time. Empty, `-`, and
+/// `0` all mean the filesystem or kernel does not report one.
+fn birth_exposed(raw: &str) -> bool {
+    let v = raw.trim();
+    !(v.is_empty() || v == "-" || v == "0")
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the crtimes fixture. Idempotent: removes any prior tree first. A couple
+/// of files plus a subdirectory holding a file, with backdated mtimes so the
+/// quick-check does not skip the transfer (mtime is orthogonal to crtime).
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("alpha"), b"alpha").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("bravo"), b"bravo").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("charlie"), b"charlie").map_err(|e| e.to_string())?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::birth_exposed;
+
+    #[test]
+    fn birth_exposed_treats_unset_values_as_not_exposed() {
+        // `stat -c %W` reports 0, -, or nothing when the fs lacks birth times.
+        assert!(!birth_exposed("0"));
+        assert!(!birth_exposed("-"));
+        assert!(!birth_exposed(""));
+        assert!(!birth_exposed("  0\n"));
+    }
+
+    #[test]
+    fn birth_exposed_true_for_real_epoch_value() {
+        assert!(birth_exposed("1614830767"));
+        assert!(birth_exposed("  1614830767\n"));
+    }
+}

--- a/xtask/src/commands/validate/checks/crtimes.rs
+++ b/xtask/src/commands/validate/checks/crtimes.rs
@@ -31,6 +31,17 @@ impl Check for Crtimes {
     }
 
     fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        // Support probe: the host's upstream rsync may be built without
+        // `--crtimes` support, in which case it refuses the option at parse time
+        // and exits non-zero. Nothing to compare against, so skip the matrix.
+        if !upstream_supports_crtimes(ctx.upstream) {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                "support",
+                "upstream rsync lacks --crtimes support",
+            )];
+        }
+
         // Support probe: birth times must be exposed by the work filesystem, or
         // there is nothing meaningful to compare.
         if !work_exposes_birth_times(ctx.work) {
@@ -155,6 +166,23 @@ fn dump_crtimes(oc: &Path, up: &Path) {
             up_bt.as_deref().unwrap_or("?"),
         );
     }
+}
+
+/// Probe whether the host's upstream rsync was built with `--crtimes` (`-N`)
+/// support. A build without it refuses the option at parse time (printing
+/// `This rsync does not support --crtimes (-N)` and exiting non-zero) before
+/// `--version` short-circuits, so a clean `--crtimes --version` run succeeds
+/// only when the option is accepted. upstream: options.c:1028
+/// `parse_one_refuse_match(0, "crtimes", ...)` under `#ifndef SUPPORT_CRTIMES`.
+fn upstream_supports_crtimes(upstream: &Path) -> bool {
+    std::process::Command::new(upstream)
+        .args(["--crtimes", "--version"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 /// Probe whether the work filesystem exposes birth times. Writes a throwaway

--- a/xtask/src/commands/validate/checks/delete.rs
+++ b/xtask/src/commands/validate/checks/delete.rs
@@ -1,0 +1,379 @@
+//! `--delete` parity: oc-rsync removes exactly the extraneous destination
+//! entries upstream removes.
+//!
+//! Unlike the other checks, `--delete` only does anything when the destination
+//! already holds entries absent from the source, so this check cannot use
+//! `transport::pull_into` (which recreates the destination empty). Instead it
+//! pre-seeds each destination with a copy of the source *plus* extraneous
+//! entries (`stale.txt`, `stale_dir/inner.txt`), builds the client `Command`
+//! directly, and transfers into the seeded tree without wiping it. The oc and
+//! upstream destinations are seeded identically, so only the client under test
+//! varies. Upstream rsync is the ground truth for both the surviving tree and
+//! the set of `*deleting` itemize lines. The ssh transports are skipped when no
+//! sshd answers on localhost:22.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `--delete` extraneous-removal parity check.
+pub struct Delete;
+
+/// Itemized, numeric-ids, `--delete`: match upstream's deletion semantics and
+/// surface each removal as a `*deleting` itemize line.
+const FLAGS: &[&str] = &["-rlptgoD", "--delete", "-i", "--numeric-ids"];
+
+impl Check for Delete {
+    fn name(&self) -> &'static str {
+        "delete"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("delete");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src))
+            .collect()
+    }
+}
+
+impl Delete {
+    /// Run one transport cell: seed both destinations, transfer each, and
+    /// compare surviving trees and `*deleting` lines against upstream.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        // Seed both destinations identically before their respective transfers.
+        if let Err(e) = seed_dest(src, &oc_dst) {
+            return CheckOutcome::skip(self.name(), label, format!("seed oc dest: {e}"));
+        }
+        if let Err(e) = seed_dest(src, &up_dst) {
+            return CheckOutcome::skip(self.name(), label, format!("seed upstream dest: {e}"));
+        }
+
+        // Non-vacuous guard: the stale entries must actually exist pre-transfer,
+        // otherwise `--delete` would have nothing to remove and the cell would
+        // pass trivially.
+        if !stale_seeded(&oc_dst) || !stale_seeded(&up_dst) {
+            return CheckOutcome::fail(self.name(), label, "seed did not place stale entries");
+        }
+
+        // The daemon transport needs one live upstream daemon shared by both
+        // client runs; keep it alive for the whole cell.
+        let daemon = if transport == Transport::Daemon {
+            match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), label, format!("daemon: {e}")),
+            }
+        } else {
+            None
+        };
+        let daemon_url = daemon.as_ref().map(|d| d.module_url());
+
+        let up = match run_client(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            daemon_url.as_deref(),
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let oc = match run_client(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            daemon_url.as_deref(),
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+        drop(daemon);
+
+        let oc_del = deleting_paths(&combined(&oc));
+        let up_del = deleting_paths(&combined(&up));
+
+        // Both destinations must equal the source (extraneous entries gone).
+        if let Some(diff) = support::content_diff(&oc_dst, src) {
+            if ctx.verbose {
+                dump(label, &oc_dst, &up_dst, &oc_del, &up_del);
+            }
+            return CheckOutcome::fail(self.name(), label, format!("oc dest != source: {diff}"));
+        }
+        if let Some(diff) = support::content_diff(&up_dst, src) {
+            if ctx.verbose {
+                dump(label, &oc_dst, &up_dst, &oc_del, &up_del);
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("upstream dest != source: {diff}"),
+            );
+        }
+        // And the two destinations must equal each other.
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            if ctx.verbose {
+                dump(label, &oc_dst, &up_dst, &oc_del, &up_del);
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("oc and upstream dests differ: {diff}"),
+            );
+        }
+
+        // The set of removed paths must match upstream's.
+        if oc_del != up_del {
+            if ctx.verbose {
+                dump(label, &oc_dst, &up_dst, &oc_del, &up_del);
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("deleting sets differ (oc {oc_del:?} vs upstream {up_del:?})"),
+            );
+        }
+
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Build one client rsync `Command` for `transport` and run it into the
+/// (already-seeded) destination. The destination is never reset here, so
+/// `--delete` operates on the pre-seeded tree.
+///
+/// Operand forms mirror `transport::pull_into`: `local` is a filesystem copy;
+/// `ssh-subprocess` uses `-e ssh localhost:<src>`; `russh` uses an `ssh://` URL;
+/// `daemon` uses the module URL passed in `daemon_url`. The sender is always
+/// `upstream` for the network transports (`--rsync-path` / upstream daemon).
+fn run_client(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    daemon_url: Option<&str>,
+) -> TaskResult<Output> {
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(FLAGS);
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let url = daemon_url
+                .ok_or_else(|| TaskError::Validation("daemon transport without url".into()))?;
+            cmd.arg(url).arg(&dst_arg);
+        }
+    }
+
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Seed `dst` with a fresh copy of the source tree plus the extraneous entries
+/// `--delete` must remove. Recreates `dst` empty first, so it is idempotent.
+fn seed_dest(src: &Path, dst: &Path) -> TaskResult<()> {
+    reset_dir(dst)?;
+    copy_tree(src, dst)?;
+    std::fs::write(dst.join("stale.txt"), b"stale\n")
+        .map_err(|e| TaskError::Validation(format!("write stale.txt: {e}")))?;
+    let stale_dir = dst.join("stale_dir");
+    std::fs::create_dir_all(&stale_dir)
+        .map_err(|e| TaskError::Validation(format!("create stale_dir: {e}")))?;
+    std::fs::write(stale_dir.join("inner.txt"), b"inner\n")
+        .map_err(|e| TaskError::Validation(format!("write stale_dir/inner.txt: {e}")))
+}
+
+/// True when both seeded stale entries are present in `dst`.
+fn stale_seeded(dst: &Path) -> bool {
+    dst.join("stale.txt").exists() && dst.join("stale_dir").join("inner.txt").exists()
+}
+
+/// Recursively copy `src`'s contents (files and directories) into `dst`.
+fn copy_tree(src: &Path, dst: &Path) -> TaskResult<()> {
+    let entries = std::fs::read_dir(src)
+        .map_err(|e| TaskError::Validation(format!("read {}: {e}", src.display())))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| TaskError::Validation(format!("dir entry: {e}")))?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let ty = entry
+            .file_type()
+            .map_err(|e| TaskError::Validation(format!("file type: {e}")))?;
+        if ty.is_dir() {
+            std::fs::create_dir_all(&to)
+                .map_err(|e| TaskError::Validation(format!("create {}: {e}", to.display())))?;
+            copy_tree(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to).map_err(|e| {
+                TaskError::Validation(format!("copy {} -> {}: {e}", from.display(), to.display()))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Fold a run's stdout then stderr into one string; deletion notices can land on
+/// either stream depending on the transport.
+fn combined(out: &Output) -> String {
+    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stderr));
+    s
+}
+
+/// Extract the sorted set of removed paths from a client's output.
+///
+/// A deletion notice is any line containing `deleting ` - the itemized form
+/// `*deleting   <path>` and the verbose form `deleting <path>` both qualify. The
+/// path is everything after the keyword, trimmed. Sorting makes the set order-
+/// independent so oc and upstream compare regardless of deletion sequence.
+pub fn deleting_paths(output: &str) -> Vec<String> {
+    const KEY: &str = "deleting ";
+    let mut paths: Vec<String> = output
+        .lines()
+        .filter_map(|line| {
+            let idx = line.find(KEY)?;
+            let path = line[idx + KEY.len()..].trim();
+            (!path.is_empty()).then(|| path.to_string())
+        })
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// Print deleting sets and surviving trees for both clients (verbose failures).
+fn dump(label: &str, oc_dst: &Path, up_dst: &Path, oc_del: &[String], up_del: &[String]) {
+    eprintln!("[delete/{label}] oc deleting: {oc_del:?}");
+    eprintln!("[delete/{label}] upstream deleting: {up_del:?}");
+    eprintln!(
+        "[delete/{label}] oc surviving: {:?}",
+        support::rel_entries(oc_dst)
+    );
+    eprintln!(
+        "[delete/{label}] upstream surviving: {:?}",
+        support::rel_entries(up_dst)
+    );
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Build the delete fixture: one top-level file and a subdirectory with one
+/// file. Idempotent: removes any prior tree first. Mtimes are backdated so the
+/// quick-check does not re-transfer the kept files under test.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("keep1.txt"), b"keep1\n").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("keep2.txt"), b"keep2\n").map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deleting_paths;
+
+    #[test]
+    fn extracts_itemized_deleting_paths_sorted() {
+        let out = ">f+++++++++ keep1.txt\n\
+                   *deleting   stale_dir/inner.txt\n\
+                   *deleting   stale_dir/\n\
+                   *deleting   stale.txt\n\
+                   sent 100 bytes  received 20 bytes\n";
+        assert_eq!(
+            deleting_paths(out),
+            vec!["stale.txt", "stale_dir/", "stale_dir/inner.txt"]
+        );
+    }
+
+    #[test]
+    fn extracts_verbose_form_and_ignores_non_deleting_lines() {
+        let out = "deleting stale.txt\nbuilding file list\n";
+        assert_eq!(deleting_paths(out), vec!["stale.txt"]);
+    }
+
+    #[test]
+    fn empty_without_any_deletion_notice() {
+        assert!(deleting_paths(">f+++++++++ keep1.txt\n").is_empty());
+    }
+}

--- a/xtask/src/commands/validate/checks/devices.rs
+++ b/xtask/src/commands/validate/checks/devices.rs
@@ -1,0 +1,362 @@
+//! Special-file and device-node parity between oc-rsync and upstream.
+//!
+//! Builds a fixture holding a regular control file, a FIFO, and a unix socket -
+//! plus a character and a block device node when running as root - then pulls it
+//! with each client over every transport using `-rlptgoD` (the `-D` requests
+//! `--devices --specials`). It asserts oc's destination reproduces every entry's
+//! file *type* exactly as upstream does, and that device nodes carry the same
+//! `rdev` (major/minor).
+//!
+//! FIFO and socket specials are validated for any user. Character/block device
+//! validation requires `--root` (and an actual euid of 0): unprivileged users
+//! cannot create device nodes via `mknod`, so that portion is omitted and the
+//! check still passes on the FIFO/socket specials it can exercise.
+
+use std::collections::BTreeMap;
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::path::{Path, PathBuf};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The special-file / device-node parity check.
+///
+/// Character and block device validation is only performed with `--root`; see
+/// the module documentation for the privilege gate.
+pub struct Devices;
+
+/// `-D` (inside `-rlptgoD`) is `--devices --specials`; `--numeric-ids` keeps
+/// ownership comparisons independent of the local passwd/group databases.
+const FLAGS: &[&str] = &["-rlptgoD", "--numeric-ids"];
+
+/// A file entry's transferable kind, as observed by `lstat`.
+///
+/// Device variants carry the raw `rdev` so equality captures both the type and
+/// the major/minor pair without depending on a platform-specific decode.
+#[derive(Debug, PartialEq, Eq)]
+enum Special {
+    Regular,
+    Dir,
+    Symlink,
+    Fifo,
+    Socket,
+    CharDev(u64),
+    BlockDev(u64),
+    Other(u32),
+}
+
+impl Check for Devices {
+    fn name(&self) -> &'static str {
+        "devices"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("devices");
+        let src = root.join("src");
+        // Device nodes need real root: honor the caller's --root request only
+        // when the process is actually euid 0.
+        let make_devices = ctx.root && current_euid() == Some(0);
+        if ctx.verbose && !make_devices {
+            eprintln!("    devices: omitting char/block nodes (requires --root and euid 0)");
+        }
+        if let Err(e) = build_fixture(&src, make_devices) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &flags, make_devices))
+            .collect()
+    }
+}
+
+impl Devices {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        flags: &[String],
+        has_devices: bool,
+    ) -> CheckOutcome {
+        let src = root.join("src");
+        let expected = support::entry_count(&src);
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            &src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let _ = up;
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            &src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+        let _ = oc;
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+        // Non-vacuous guard: oc's destination must actually carry the specials,
+        // so a bug that silently drops FIFOs or device nodes still fails here.
+        if let Some(missing) = oc_special_missing(&oc_dst, &src, has_devices) {
+            return CheckOutcome::fail(self.name(), label, missing);
+        }
+        match special_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), label, diff),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// Classify `path` by its own type (never following a symlink).
+fn classify(path: &Path) -> Option<Special> {
+    let meta = path.symlink_metadata().ok()?;
+    let ft = meta.file_type();
+    Some(if ft.is_fifo() {
+        Special::Fifo
+    } else if ft.is_socket() {
+        Special::Socket
+    } else if ft.is_char_device() {
+        Special::CharDev(meta.rdev())
+    } else if ft.is_block_device() {
+        Special::BlockDev(meta.rdev())
+    } else if ft.is_symlink() {
+        Special::Symlink
+    } else if ft.is_dir() {
+        Special::Dir
+    } else if ft.is_file() {
+        Special::Regular
+    } else {
+        Special::Other(meta.mode() & 0o170000)
+    })
+}
+
+/// Map a tree to per-entry [`Special`] for comparison.
+fn special_map(root: &Path) -> BTreeMap<PathBuf, Special> {
+    support::rel_entries(root)
+        .into_iter()
+        .filter_map(|rel| classify(&root.join(&rel)).map(|kind| (rel, kind)))
+        .collect()
+}
+
+/// First special-type (or device major/minor) divergence between two trees, or
+/// `None` when every entry matches.
+fn special_diff(oc: &Path, up: &Path) -> Option<String> {
+    let (a, b) = (special_map(oc), special_map(up));
+    for (rel, oc_kind) in &a {
+        match b.get(rel) {
+            None => return Some(format!("missing {} in upstream tree", rel.display())),
+            Some(up_kind) if up_kind != oc_kind => {
+                return Some(format!(
+                    "special type differs at {}: oc={} upstream={}",
+                    rel.display(),
+                    describe(oc_kind),
+                    describe(up_kind)
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+    None
+}
+
+/// Report the first special that failed to arrive in `oc_dst`, or `None` when
+/// the FIFO (and, with devices, the char device) are present and correct.
+fn oc_special_missing(oc_dst: &Path, src: &Path, has_devices: bool) -> Option<String> {
+    match classify(&oc_dst.join("fifo")) {
+        Some(Special::Fifo) => {}
+        other => {
+            return Some(format!(
+                "fifo not preserved in oc destination (got {})",
+                describe_opt(other)
+            ));
+        }
+    }
+    if has_devices {
+        let want = classify(&src.join("cdev"));
+        match (classify(&oc_dst.join("cdev")), want) {
+            (Some(Special::CharDev(got)), Some(Special::CharDev(exp))) if got == exp => {}
+            (got, _) => {
+                return Some(format!(
+                    "cdev not preserved as char device in oc destination (got {})",
+                    describe_opt(got)
+                ));
+            }
+        }
+    }
+    None
+}
+
+/// Human-readable label for a [`Special`], decoding device major/minor.
+fn describe(kind: &Special) -> String {
+    match kind {
+        Special::Regular => "regular".to_string(),
+        Special::Dir => "directory".to_string(),
+        Special::Symlink => "symlink".to_string(),
+        Special::Fifo => "fifo".to_string(),
+        Special::Socket => "socket".to_string(),
+        Special::CharDev(rdev) => {
+            let (major, minor) = rdev_parts(*rdev);
+            format!("char-device {major},{minor}")
+        }
+        Special::BlockDev(rdev) => {
+            let (major, minor) = rdev_parts(*rdev);
+            format!("block-device {major},{minor}")
+        }
+        Special::Other(bits) => format!("other ({bits:#o})"),
+    }
+}
+
+/// Describe an optional kind, rendering `None` as `absent`.
+fn describe_opt(kind: Option<Special>) -> String {
+    kind.map(|k| describe(&k))
+        .unwrap_or_else(|| "absent".to_string())
+}
+
+/// Split a device `rdev` into `(major, minor)` for display.
+///
+/// Uses the classic 8-bit-minor encoding, which is exact for the small
+/// major/minor pairs this check creates (`1,3` and `7,0`). Pass/fail comparisons
+/// use the raw `rdev` value, so this decode only affects diagnostics.
+fn rdev_parts(rdev: u64) -> (u64, u64) {
+    ((rdev >> 8) & 0xff, rdev & 0xff)
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Query the effective uid via `id -u`; `None` when it cannot be parsed.
+fn current_euid() -> Option<u32> {
+    support::capture("id", &["-u"])
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+}
+
+/// Build the devices fixture. Idempotent: removes any prior tree first. Creates
+/// character (`1,3`) and block (`7,0`) device nodes only when `make_devices`.
+fn build_fixture(src: &Path, make_devices: bool) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("plain.txt"), b"control").map_err(|e| e.to_string())?;
+
+    // FIFO: mkfifo works as an ordinary user.
+    let fifo = src.join("fifo");
+    let fifo_arg = fifo.to_string_lossy();
+    support::capture("mkfifo", &[fifo_arg.as_ref()]).map_err(|e| e.to_string())?;
+
+    // Socket: binding then dropping leaves the socket inode on disk (Rust's
+    // UnixListener does not unlink on drop). upstream rsync.h treats S_ISSOCK as
+    // a special, so --specials transfers it like a FIFO.
+    let sock = src.join("sock");
+    {
+        let _listener = std::os::unix::net::UnixListener::bind(&sock).map_err(|e| e.to_string())?;
+    }
+
+    if make_devices {
+        let cdev = src.join("cdev");
+        let cdev_arg = cdev.to_string_lossy();
+        support::capture("mknod", &[cdev_arg.as_ref(), "c", "1", "3"])
+            .map_err(|e| e.to_string())?;
+        let bdev = src.join("bdev");
+        let bdev_arg = bdev.to_string_lossy();
+        support::capture("mknod", &[bdev_arg.as_ref(), "b", "7", "0"])
+            .map_err(|e| e.to_string())?;
+    }
+
+    // Backdate mtimes so the quick-check does not skip anything under test. A
+    // socket may reject the timestamp update; skip it rather than fail.
+    for rel in support::rel_entries(src) {
+        let path = src.join(&rel);
+        let is_socket = path
+            .symlink_metadata()
+            .map(|m| m.file_type().is_socket())
+            .unwrap_or(false);
+        match support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        ) {
+            Ok(_) => {}
+            Err(e) => {
+                if is_socket {
+                    continue;
+                }
+                return Err(e.to_string());
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Special, describe, rdev_parts};
+
+    #[test]
+    fn rdev_parts_splits_classic_major_minor() {
+        // 0x0103 == mknod c 1 3, 0x0700 == mknod b 7 0.
+        assert_eq!(rdev_parts(0x0103), (1, 3));
+        assert_eq!(rdev_parts(0x0700), (7, 0));
+    }
+
+    #[test]
+    fn special_equality_distinguishes_kind_and_rdev() {
+        assert_eq!(Special::Fifo, Special::Fifo);
+        assert_ne!(Special::Fifo, Special::Socket);
+        // Same kind but a different device number is a genuine divergence.
+        assert_ne!(Special::CharDev(0x0103), Special::CharDev(0x0104));
+        assert_eq!(Special::CharDev(0x0103), Special::CharDev(0x0103));
+    }
+
+    #[test]
+    fn describe_names_device_major_minor() {
+        assert_eq!(describe(&Special::CharDev(0x0103)), "char-device 1,3");
+        assert_eq!(describe(&Special::BlockDev(0x0700)), "block-device 7,0");
+        assert_eq!(describe(&Special::Fifo), "fifo");
+    }
+}

--- a/xtask/src/commands/validate/checks/dry_run.rs
+++ b/xtask/src/commands/validate/checks/dry_run.rs
@@ -1,0 +1,283 @@
+//! `-n -i` dry-run parity: itemized plan matches upstream, nothing is written.
+//!
+//! Builds a tiny tree and pulls it with each client over every transport using
+//! `--dry-run --itemize-changes`. Two invariants are asserted per cell: the
+//! ordered list of itemize rows oc-rsync prints must equal upstream rsync's (the
+//! plan is identical), and - because it is a dry run - the destination must stay
+//! empty (nothing is actually transferred). Upstream rsync is the ground truth
+//! for the plan; the empty destination is checked directly on disk.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The dry-run plan-parity / no-write check.
+pub struct DryRun;
+
+/// Dry run, itemized, numeric ids, standard archive-ish attribute set.
+const FLAGS: &[&str] = &["-rlptgoD", "-n", "-i", "--numeric-ids"];
+
+impl Check for DryRun {
+    fn name(&self) -> &'static str {
+        "dry-run"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("dry-run");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src, &flags))
+            .collect()
+    }
+}
+
+impl DryRun {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        flags: &[String],
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+
+        // No-write invariant: a dry run must transfer nothing, so both
+        // destinations stay empty. (The normal populated-dest guard is
+        // deliberately not applied here - an empty dest is the pass condition.)
+        if support::entry_count(&oc_dst) != 0 {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                "oc wrote into destination on --dry-run",
+            );
+        }
+        if support::entry_count(&up_dst) != 0 {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                "upstream wrote into destination on --dry-run",
+            );
+        }
+
+        let up_rows = itemize_rows(&String::from_utf8_lossy(&up.stdout));
+        let oc_rows = itemize_rows(&String::from_utf8_lossy(&oc.stdout));
+
+        // Genuine-result guard: an empty plan proves nothing, so require a
+        // non-trivial plan on both sides.
+        if up_rows.is_empty() || oc_rows.is_empty() {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                "empty itemize plan (nothing to compare)",
+            );
+        }
+
+        if let Some((idx, oc_row, up_row)) = first_diff(&oc_rows, &up_rows) {
+            if ctx.verbose {
+                eprintln!("[dry-run/{label}] oc plan:\n  {}", oc_rows.join("\n  "));
+                eprintln!(
+                    "[dry-run/{label}] upstream plan:\n  {}",
+                    up_rows.join("\n  ")
+                );
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("itemize row {idx} differs: oc `{oc_row}` vs upstream `{up_row}`"),
+            );
+        }
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Collect the ordered itemize rows from one client's stdout.
+///
+/// An itemize row starts with rsync's 11-char change string, so its first
+/// character is a transfer/change/hardlink/dir/no-change marker (`<>ch.*`), it
+/// contains a space before the path, and it is at least 12 characters long.
+/// Summary lines (`sent`, `total size`, file-list notices) match none of these
+/// and are dropped, leaving just the plan in transfer order.
+fn itemize_rows(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| is_itemize_row(line))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Heuristically detect an itemize row by its leading change string.
+fn is_itemize_row(line: &str) -> bool {
+    let Some(first) = line.chars().next() else {
+        return false;
+    };
+    matches!(first, '<' | '>' | 'c' | 'h' | '.' | '*') && line.len() >= 12 && line.contains(' ')
+}
+
+/// First index at which two plans differ, with both rows (a missing row on
+/// either side is reported as an empty string). `None` when the plans are equal.
+fn first_diff(oc: &[String], up: &[String]) -> Option<(usize, String, String)> {
+    for idx in 0..oc.len().max(up.len()) {
+        let oc_row = oc.get(idx).map(String::as_str).unwrap_or("");
+        let up_row = up.get(idx).map(String::as_str).unwrap_or("");
+        if oc_row != up_row {
+            return Some((idx, oc_row.to_string(), up_row.to_string()));
+        }
+    }
+    None
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the dry-run fixture. Idempotent: removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("a.txt"), b"alpha").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("b.txt"), b"bravo").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("c.txt"), b"charlie").map_err(|e| e.to_string())?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{first_diff, is_itemize_row, itemize_rows};
+
+    #[test]
+    fn extracts_only_itemize_rows_in_order() {
+        let out = ">f+++++++++ a.txt\n\
+                   >f+++++++++ b.txt\n\
+                   cd+++++++++ sub/\n\
+                   >f+++++++++ sub/c.txt\n\
+                   \n\
+                   sent 100 bytes  received 20 bytes\n\
+                   total size is 12  speedup is 0.10\n";
+        assert_eq!(
+            itemize_rows(out),
+            vec![
+                ">f+++++++++ a.txt",
+                ">f+++++++++ b.txt",
+                "cd+++++++++ sub/",
+                ">f+++++++++ sub/c.txt",
+            ]
+        );
+    }
+
+    #[test]
+    fn summary_lines_are_not_itemize_rows() {
+        assert!(!is_itemize_row("sent 100 bytes  received 20 bytes"));
+        assert!(!is_itemize_row(""));
+        assert!(is_itemize_row(">f+++++++++ a.txt"));
+    }
+
+    #[test]
+    fn first_diff_finds_earliest_divergence() {
+        let oc = vec![
+            ">f+++++++++ a.txt".to_string(),
+            "cd+++++++++ x/".to_string(),
+        ];
+        let up = vec![
+            ">f+++++++++ a.txt".to_string(),
+            "cd+++++++++ y/".to_string(),
+        ];
+        assert_eq!(
+            first_diff(&oc, &up),
+            Some((
+                1,
+                "cd+++++++++ x/".to_string(),
+                "cd+++++++++ y/".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn first_diff_reports_missing_trailing_row() {
+        let oc = vec![">f+++++++++ a.txt".to_string()];
+        let up = vec![
+            ">f+++++++++ a.txt".to_string(),
+            ">f+++++++++ b.txt".to_string(),
+        ];
+        assert_eq!(
+            first_diff(&oc, &up),
+            Some((1, String::new(), ">f+++++++++ b.txt".to_string()))
+        );
+    }
+
+    #[test]
+    fn first_diff_none_for_equal_plans() {
+        let rows = vec![">f+++++++++ a.txt".to_string()];
+        assert_eq!(first_diff(&rows, &rows), None);
+    }
+}

--- a/xtask/src/commands/validate/checks/files_from.rs
+++ b/xtask/src/commands/validate/checks/files_from.rs
@@ -1,0 +1,345 @@
+//! `--files-from` parity: oc-rsync transfers exactly the listed subset,
+//! identically to upstream, in both the newline- and NUL-separated forms.
+//!
+//! With `--files-from=<file>` the source operand is the base directory (no
+//! trailing path component) and each list entry names a path relative to it, so
+//! only the listed subset is transferred. This check builds a five-entry source
+//! (`a.txt`, `b.txt`, `c.txt`, `sub/d.txt`, `sub/e.txt`) and a list selecting
+//! just `a.txt` and `sub/d.txt`, in two encodings:
+//!
+//! * `newline` - entries separated by `\n`, passed with `--files-from`.
+//! * `from0`   - the same entries separated by NUL (`\0`), passed with
+//!   `--from0 --files-from`.
+//!
+//! Each (transport, scenario) cell runs upstream then oc into fresh empty
+//! destinations and asserts both exit 0, the two trees are identical
+//! (`support::content_diff`), and - as a non-vacuous guard - the oc tree holds
+//! exactly the listed subset and none of the unlisted entries. Like the other
+//! direct-`Command` checks, the daemon cell shares one upstream daemon across
+//! both client runs, and the ssh transports are skipped when no sshd answers on
+//! localhost:22.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `--files-from` subset-selection parity check.
+pub struct FilesFrom;
+
+/// The listed subset (relative to the source base), in sorted destination form.
+const REQUIRED: [&str; 2] = ["a.txt", "sub/d.txt"];
+
+/// Source entries that are present but *not* listed, so must never transfer.
+const FORBIDDEN: [&str; 3] = ["b.txt", "c.txt", "sub/e.txt"];
+
+impl Check for FilesFrom {
+    fn name(&self) -> &'static str {
+        "files-from"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("files-from");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+
+        let list = root.join("list.txt");
+        let list0 = root.join("list0.txt");
+        if let Err(e) = write_lists(&list, &list0) {
+            return vec![CheckOutcome::skip(self.name(), "list", e)];
+        }
+
+        // The `--files-from` operand carries the list-file path directly, so each
+        // scenario differs only in its flag set (built here) and encoding.
+        let scenarios: [(&str, Vec<String>); 2] = [
+            (
+                "newline",
+                vec![
+                    "-rlptgoD".into(),
+                    "--numeric-ids".into(),
+                    format!("--files-from={}", list.display()),
+                ],
+            ),
+            (
+                "from0",
+                vec![
+                    "-rlptgoD".into(),
+                    "--numeric-ids".into(),
+                    "--from0".into(),
+                    format!("--files-from={}", list0.display()),
+                ],
+            ),
+        ];
+
+        let mut outcomes = Vec::new();
+        for &transport in ctx.transports {
+            for (scenario, flags) in &scenarios {
+                outcomes.push(self.cell(ctx, transport, &root, &src, scenario, flags));
+            }
+        }
+        outcomes
+    }
+}
+
+impl FilesFrom {
+    /// Run one (transport, scenario) cell: transfer the listed subset with both
+    /// clients into fresh destinations and compare the results.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        scenario: &str,
+        flags: &[String],
+    ) -> CheckOutcome {
+        let label = format!("{} {scenario}", transport.label());
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), &label, "no sshd on localhost:22");
+        }
+
+        let oc_dst = root.join(format!("oc-{}-{scenario}", transport.label()));
+        let up_dst = root.join(format!("up-{}-{scenario}", transport.label()));
+        if let Err(e) = reset_dir(&oc_dst).and_then(|()| reset_dir(&up_dst)) {
+            return CheckOutcome::skip(self.name(), &label, format!("reset dest: {e}"));
+        }
+
+        // One upstream daemon serves both client runs for the daemon transport.
+        let daemon = if transport == Transport::Daemon {
+            match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), &label, format!("daemon: {e}")),
+            }
+        } else {
+            None
+        };
+        let daemon_url = daemon.as_ref().map(|d| d.module_url());
+
+        let up = run_client(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            daemon_url.as_deref(),
+        );
+        match up {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &label, "upstream", other),
+        }
+        let oc = run_client(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            daemon_url.as_deref(),
+        );
+        match oc {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &label, "oc", other),
+        }
+        drop(daemon);
+
+        // Non-vacuous guard: the oc tree must be exactly the listed subset,
+        // otherwise a no-op (empty) or full-tree transfer would pass trivially.
+        let oc_entries: Vec<String> = support::rel_entries(&oc_dst)
+            .into_iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        if let Some(problem) = subset_problem(&oc_entries) {
+            return CheckOutcome::fail(self.name(), &label, problem);
+        }
+
+        match support::content_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), &label, diff),
+            None => CheckOutcome::pass(self.name(), &label),
+        }
+    }
+}
+
+/// Build one client rsync `Command` for `transport` and run it into `dst`.
+///
+/// `flags` already carries the `--files-from` operand (and `--from0` for the
+/// NUL scenario); only the source base and network plumbing are added per
+/// transport. The base has no trailing path component so list entries resolve
+/// relative to it: `<src>/` for local, `localhost:<src>/` for ssh,
+/// `ssh://localhost<src>/` for russh, and the module root for the daemon. The
+/// sender is always `upstream` on the network transports.
+fn run_client(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    flags: &[String],
+    daemon_url: Option<&str>,
+) -> TaskResult<Output> {
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let url = daemon_url
+                .ok_or_else(|| TaskError::Validation("daemon transport without url".into()))?;
+            cmd.arg(url).arg(&dst_arg);
+        }
+    }
+
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Report the first way `entries` fails to be exactly the listed subset: a
+/// missing required entry or a present forbidden one. `None` means the tree
+/// holds every listed path and none of the unlisted ones.
+fn subset_problem(entries: &[String]) -> Option<String> {
+    for want in REQUIRED {
+        if !entries.iter().any(|e| e == want) {
+            return Some(format!("listed entry {want} missing from oc dest"));
+        }
+    }
+    for deny in FORBIDDEN {
+        if entries.iter().any(|e| e == deny) {
+            return Some(format!("unlisted entry {deny} present in oc dest"));
+        }
+    }
+    None
+}
+
+/// Write the newline- and NUL-separated list files selecting the same subset.
+///
+/// Both list the required entries in order. The newline file terminates each
+/// entry with `\n`; the `--from0` file terminates each with a NUL byte (`\0`),
+/// which is how rsync distinguishes entries when `--from0` is set.
+fn write_lists(list: &Path, list0: &Path) -> Result<(), String> {
+    let newline: String = REQUIRED.iter().map(|e| format!("{e}\n")).collect();
+    let mut nul: Vec<u8> = Vec::new();
+    for entry in REQUIRED {
+        nul.extend_from_slice(entry.as_bytes());
+        nul.push(0);
+    }
+    std::fs::write(list, newline.as_bytes()).map_err(|e| e.to_string())?;
+    std::fs::write(list0, &nul).map_err(|e| e.to_string())
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Build the files-from fixture: three top-level files and a subdirectory with
+/// two files. Idempotent: removes any prior tree first. Mtimes are backdated so
+/// the quick-check does not skip the listed files under test.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("a.txt"), b"a\n").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("b.txt"), b"b\n").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("c.txt"), b"c\n").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("d.txt"), b"d\n").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("e.txt"), b"e\n").map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{subset_problem, write_lists};
+
+    #[test]
+    fn subset_problem_accepts_exactly_the_listed_entries() {
+        let entries = vec![
+            "a.txt".to_string(),
+            "sub".to_string(),
+            "sub/d.txt".to_string(),
+        ];
+        assert!(subset_problem(&entries).is_none());
+    }
+
+    #[test]
+    fn subset_problem_reports_missing_required_entry() {
+        let entries = vec!["a.txt".to_string()];
+        assert!(subset_problem(&entries).unwrap().contains("sub/d.txt"));
+    }
+
+    #[test]
+    fn subset_problem_reports_present_forbidden_entry() {
+        let entries = vec![
+            "a.txt".to_string(),
+            "b.txt".to_string(),
+            "sub/d.txt".to_string(),
+        ];
+        assert!(subset_problem(&entries).unwrap().contains("b.txt"));
+    }
+
+    #[test]
+    fn write_lists_uses_newline_and_nul_separators() {
+        let dir = tempfile::tempdir().unwrap();
+        let (list, list0) = (dir.path().join("l"), dir.path().join("l0"));
+        write_lists(&list, &list0).unwrap();
+        assert_eq!(std::fs::read(&list).unwrap(), b"a.txt\nsub/d.txt\n");
+        assert_eq!(std::fs::read(&list0).unwrap(), b"a.txt\0sub/d.txt\0");
+    }
+}

--- a/xtask/src/commands/validate/checks/filters.rs
+++ b/xtask/src/commands/validate/checks/filters.rs
@@ -213,7 +213,7 @@ fn build_fixture(src: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_fixture, exclusion_violation};
+    use super::exclusion_violation;
     use std::fs;
 
     #[test]
@@ -260,6 +260,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn build_fixture_is_idempotent_and_populates_the_tree() {
+        use super::build_fixture;
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("src");
         build_fixture(&src).unwrap();

--- a/xtask/src/commands/validate/checks/filters.rs
+++ b/xtask/src/commands/validate/checks/filters.rs
@@ -1,0 +1,274 @@
+//! Filter-rule parity between oc-rsync and upstream.
+//!
+//! Builds a tree that trips several exclude kinds (`*.log`, `*.tmp`, a whole
+//! `cache/` directory) at the top level and nested, backdates every mtime, then
+//! pulls it with each client over every transport under one `--exclude` set.
+//! The check asserts oc's destination is entry-for-entry identical to
+//! upstream's - which proves both clients excluded and included exactly the same
+//! files - and additionally that the excluded names are genuinely absent while
+//! at least one file did survive, so the comparison cannot pass vacuously on two
+//! empty trees.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The filter-rule parity check.
+pub struct Filters;
+
+/// A representative exclude mix: a suffix rule, a second suffix rule, and a
+/// directory rule. The point is that oc and upstream must agree on the result.
+const FLAGS: &[&str] = &[
+    "-rlptgoD",
+    "--numeric-ids",
+    "--exclude=*.log",
+    "--exclude=*.tmp",
+    "--exclude=cache/",
+];
+
+impl Check for Filters {
+    fn name(&self) -> &'static str {
+        "filters"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("filters");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src, &flags))
+            .collect()
+    }
+}
+
+impl Filters {
+    /// Run one transport cell: pull with upstream and with oc under the same
+    /// exclude set, then compare the resulting trees and the exclusion effect.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        flags: &[String],
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        }
+        match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        }
+
+        // Identical trees prove both clients excluded and included the same set.
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+
+        // Non-vacuous guard: the excluded names must be gone and something kept.
+        if let Some(msg) = exclusion_violation(&oc_dst) {
+            return CheckOutcome::fail(self.name(), label, msg);
+        }
+
+        if ctx.verbose {
+            eprintln!(
+                "[filters/{label}] oc kept: {:?}",
+                survivors(&oc_dst)
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+            );
+            eprintln!(
+                "[filters/{label}] upstream kept: {:?}",
+                survivors(&up_dst)
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Relative entries surviving the filter in a destination tree.
+fn survivors(dst: &Path) -> Vec<std::path::PathBuf> {
+    support::rel_entries(dst)
+}
+
+/// Verify the excludes actually took effect: no `*.log`/`*.tmp`/`cache` entry
+/// remains and at least one regular file survived. Returns a message on the
+/// first violation, or `None` when the exclusion result is genuine.
+fn exclusion_violation(dst: &Path) -> Option<String> {
+    let entries = survivors(dst);
+    for rel in &entries {
+        let name = rel.to_string_lossy();
+        if name.ends_with(".log") || name.ends_with(".tmp") {
+            return Some(format!("excluded suffix survived: {name}"));
+        }
+        if rel
+            .components()
+            .any(|c| c.as_os_str() == std::ffi::OsStr::new("cache"))
+        {
+            return Some(format!("excluded directory survived: {name}"));
+        }
+    }
+    let kept_file = entries.iter().any(|rel| {
+        dst.join(rel)
+            .symlink_metadata()
+            .map(|m| m.is_file())
+            .unwrap_or(false)
+    });
+    if !kept_file {
+        return Some("no file survived the filter (vacuous result)".to_string());
+    }
+    None
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the filter fixture. Idempotent: removes any prior tree first. Exercises
+/// top-level and nested keeps and drops, a `*.tmp` suffix, and a `cache/`
+/// directory that a directory rule should prune whole.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    let deep = src.join("nested").join("deep");
+    let cache = src.join("cache");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(&deep).map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(&cache).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("keep.txt"), b"keep-top").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("drop.log"), b"drop-top").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("scratch.tmp"), b"drop-tmp").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("keep.txt"), b"keep-sub").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("drop.log"), b"drop-sub").map_err(|e| e.to_string())?;
+    std::fs::write(deep.join("keep.txt"), b"keep-deep").map_err(|e| e.to_string())?;
+    std::fs::write(cache.join("blob.bin"), b"cached").map_err(|e| e.to_string())?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_fixture, exclusion_violation};
+    use std::fs;
+
+    #[test]
+    fn exclusion_violation_flags_a_surviving_excluded_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("keep.txt"), b"x").unwrap();
+        fs::write(dir.path().join("bad.log"), b"x").unwrap();
+        assert!(
+            exclusion_violation(dir.path())
+                .unwrap()
+                .contains("excluded suffix")
+        );
+    }
+
+    #[test]
+    fn exclusion_violation_flags_a_surviving_cache_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("cache")).unwrap();
+        fs::write(dir.path().join("cache/blob.bin"), b"x").unwrap();
+        assert!(
+            exclusion_violation(dir.path())
+                .unwrap()
+                .contains("excluded directory")
+        );
+    }
+
+    #[test]
+    fn exclusion_violation_flags_a_vacuous_empty_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(exclusion_violation(dir.path()).unwrap().contains("vacuous"));
+    }
+
+    #[test]
+    fn exclusion_violation_none_when_only_kept_files_remain() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("sub")).unwrap();
+        fs::write(dir.path().join("keep.txt"), b"x").unwrap();
+        fs::write(dir.path().join("sub/keep.txt"), b"x").unwrap();
+        assert!(exclusion_violation(dir.path()).is_none());
+    }
+
+    // `build_fixture` backdates mtimes with GNU `touch -d @epoch`, which BSD
+    // `touch` (macOS) rejects; the harness itself only runs on Linux.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn build_fixture_is_idempotent_and_populates_the_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        build_fixture(&src).unwrap();
+        // Second call must not error on the pre-existing tree.
+        build_fixture(&src).unwrap();
+        assert!(src.join("keep.txt").is_file());
+        assert!(src.join("drop.log").is_file());
+        assert!(src.join("scratch.tmp").is_file());
+        assert!(src.join("cache/blob.bin").is_file());
+        assert!(src.join("nested/deep/keep.txt").is_file());
+    }
+}

--- a/xtask/src/commands/validate/checks/hard_links.rs
+++ b/xtask/src/commands/validate/checks/hard_links.rs
@@ -1,0 +1,253 @@
+//! Hard-link preservation parity between oc-rsync and upstream.
+//!
+//! Builds a fixture with two multi-link inode groups (one within a directory,
+//! one spanning two subdirectories) plus a standalone file, then pulls it with
+//! each client over every transport under `-H`. The canonical check groups each
+//! destination's regular files by `(dev, ino)` and asserts oc-rsync reproduces
+//! the exact same set of hard-link groups upstream does - a client that broke
+//! links into independent copies would yield no groups and fail.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The hard-link preservation parity check.
+pub struct HardLinks;
+
+/// Preserve metadata plus hard links, using numeric ids for a non-root run.
+const FLAGS: &[&str] = &["-rlptgoD", "-H", "--numeric-ids"];
+
+impl Check for HardLinks {
+    fn name(&self) -> &'static str {
+        "hard-links"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("hard-links");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+
+        // Fixture sanity: the source must actually carry the two multi-link
+        // groups the transport cells rely on, so a passing cell is non-vacuous.
+        let src_groups = groups(&src);
+        if !src_groups.contains(&group_of(&["a1", "a2", "a3"]))
+            || !src_groups.contains(&group_of(&["d1/b1", "d2/b2"]))
+        {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                "fixture",
+                "source is missing the expected hard-link groups",
+            )];
+        }
+
+        let expected = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &flags, expected))
+            .collect()
+    }
+}
+
+impl HardLinks {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        flags: &[String],
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let src = root.join("src");
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            &src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let _ = up;
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            &src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+        let _ = oc;
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+
+        let oc_groups = groups(&oc_dst);
+        let up_groups = groups(&up_dst);
+        if oc_groups != up_groups {
+            if ctx.verbose {
+                eprintln!("[hard-links/{label}] oc groups:       {oc_groups:?}");
+                eprintln!("[hard-links/{label}] upstream groups: {up_groups:?}");
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("hardlink groups differ: oc={oc_groups:?} upstream={up_groups:?}"),
+            );
+        }
+        // A client that copied each link as its own inode would leave no groups.
+        if oc_groups.is_empty() {
+            return CheckOutcome::fail(self.name(), label, "no hardlink groups preserved");
+        }
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// The set of hard-link groups under `root`.
+///
+/// Maps every regular file's `(dev, ino)` to the set of its relative paths, then
+/// returns the path-sets holding two or more links (the multi-link groups).
+/// Symlinks and directories are ignored. The result is independent of readdir
+/// order, so it is the canonical grouping to compare two trees by.
+pub fn groups(root: &Path) -> BTreeSet<BTreeSet<String>> {
+    let mut by_inode: BTreeMap<(u64, u64), BTreeSet<String>> = BTreeMap::new();
+    for rel in support::rel_entries(root) {
+        let path = root.join(&rel);
+        let Ok(meta) = path.symlink_metadata() else {
+            continue;
+        };
+        if !meta.file_type().is_file() {
+            continue;
+        }
+        by_inode
+            .entry((meta.dev(), meta.ino()))
+            .or_default()
+            .insert(rel.to_string_lossy().into_owned());
+    }
+    by_inode
+        .into_values()
+        .filter(|paths| paths.len() >= 2)
+        .collect()
+}
+
+/// A single expected group from string literals, for fixture assertions.
+fn group_of(paths: &[&str]) -> BTreeSet<String> {
+    paths.iter().map(|s| s.to_string()).collect()
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the hard-link fixture. Idempotent: removes any prior tree first.
+///
+/// Group A (`a1`/`a2`/`a3`) is three top-level links to one inode; group B
+/// (`d1/b1`/`d2/b2`) is two links to a second inode in different subdirectories;
+/// `solo.txt` is a standalone regular file. All mtimes are backdated so the
+/// quick-check does not skip the transfer under test.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let d1 = src.join("d1");
+    let d2 = src.join("d2");
+    std::fs::create_dir_all(&d1).map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(&d2).map_err(|e| e.to_string())?;
+
+    // Group A: three links to one inode at the top level.
+    std::fs::write(src.join("a1"), b"group-a").map_err(|e| e.to_string())?;
+    std::fs::hard_link(src.join("a1"), src.join("a2")).map_err(|e| e.to_string())?;
+    std::fs::hard_link(src.join("a1"), src.join("a3")).map_err(|e| e.to_string())?;
+
+    // Group B: two links to a second inode across different subdirectories.
+    std::fs::write(d1.join("b1"), b"group-b").map_err(|e| e.to_string())?;
+    std::fs::hard_link(d1.join("b1"), d2.join("b2")).map_err(|e| e.to_string())?;
+
+    // Standalone regular file with its own inode.
+    std::fs::write(src.join("solo.txt"), b"solo").map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{group_of, groups};
+    use std::fs;
+
+    #[test]
+    fn groups_finds_multi_link_sets_and_excludes_solo() {
+        // Build the real inode layout with `std::fs::hard_link` - no GNU
+        // `touch -d @epoch`, so this test is portable off Linux.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir(root.join("d1")).unwrap();
+        fs::create_dir(root.join("d2")).unwrap();
+
+        fs::write(root.join("a1"), b"a").unwrap();
+        fs::hard_link(root.join("a1"), root.join("a2")).unwrap();
+        fs::hard_link(root.join("a1"), root.join("a3")).unwrap();
+
+        fs::write(root.join("d1/b1"), b"b").unwrap();
+        fs::hard_link(root.join("d1/b1"), root.join("d2/b2")).unwrap();
+
+        fs::write(root.join("solo.txt"), b"s").unwrap();
+
+        let found = groups(root);
+        assert_eq!(found.len(), 2, "exactly the two multi-link groups");
+        assert!(found.contains(&group_of(&["a1", "a2", "a3"])));
+        assert!(found.contains(&group_of(&["d1/b1", "d2/b2"])));
+        // The standalone file has one link and is never part of a group.
+        assert!(!found.iter().any(|set| set.contains("solo.txt")));
+    }
+}

--- a/xtask/src/commands/validate/checks/itemize.rs
+++ b/xtask/src/commands/validate/checks/itemize.rs
@@ -36,19 +36,17 @@ impl Check for Itemize {
 
         ctx.transports
             .iter()
-            .map(|&t| self.cell(ctx, t, &root, &src, &flags, &names, expected))
+            .map(|&t| self.cell(ctx, t, &root, &flags, &names, expected))
             .collect()
     }
 }
 
 impl Itemize {
-    #[allow(clippy::too_many_arguments)]
     fn cell(
         &self,
         ctx: &ValidateCtx,
         transport: Transport,
         root: &Path,
-        src: &Path,
         flags: &[String],
         names: &HashSet<String>,
         expected: usize,
@@ -57,6 +55,8 @@ impl Itemize {
         if transport.needs_ssh() && !support::ssh_ready() {
             return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
         }
+        let src = root.join("src");
+        let src = src.as_path();
         let oc_dst = root.join(format!("oc-{label}"));
         let up_dst = root.join(format!("up-{label}"));
 

--- a/xtask/src/commands/validate/checks/itemize.rs
+++ b/xtask/src/commands/validate/checks/itemize.rs
@@ -1,0 +1,241 @@
+//! `-vi` itemize parity: one itemize row per entry, no duplicate bare name.
+//!
+//! Builds a tiny tree, pulls it with each client over every transport with
+//! `-vi`, and asserts oc-rsync's itemized stdout carries exactly one change
+//! string per transferred entry and never a second, bare filename line for the
+//! same entry - the divergence this check guards against. Upstream rsync is the
+//! ground truth for both the itemize-row count and the (zero) bare-name count.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The itemize no-double-name check.
+pub struct Itemize;
+
+/// Itemized verbose transfer, numeric ids, no metadata surprises.
+const FLAGS: &[&str] = &["-rlptgoD", "-vi", "--numeric-ids"];
+
+impl Check for Itemize {
+    fn name(&self) -> &'static str {
+        "itemize"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("itemize");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let names = basenames(&src);
+        let expected = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src, &flags, &names, expected))
+            .collect()
+    }
+}
+
+impl Itemize {
+    #[allow(clippy::too_many_arguments)]
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        flags: &[String],
+        names: &HashSet<String>,
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+
+        let (up_bare, up_rows) = classify(&String::from_utf8_lossy(&up.stdout), names);
+        let (oc_bare, oc_rows) = classify(&String::from_utf8_lossy(&oc.stdout), names);
+
+        if ctx.verbose {
+            eprintln!(
+                "[itemize/{label}] oc: {oc_rows} rows / {oc_bare} bare, upstream: {up_rows} rows / {up_bare} bare"
+            );
+        }
+
+        if oc_bare > up_bare {
+            let n = oc_bare - up_bare;
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("oc emitted {n} duplicate bare-name line(s)"),
+            );
+        }
+        if oc_rows != up_rows {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("itemize row count differs (oc {oc_rows} vs upstream {up_rows})"),
+            );
+        }
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Count itemize rows and forbidden bare-name lines in one client's stdout.
+///
+/// An itemize row starts with rsync's 11-char change string, so its first
+/// character is a transfer/change/hardlink/dir/no-change marker (`<>ch.*`), it
+/// contains a space before the path, and it is at least 12 characters long. A
+/// bare-name line is a trimmed line equal to one source basename - the
+/// duplicate this check forbids. Summary lines (`sent`, `total size`, file-list
+/// notices) match neither and are ignored.
+fn classify(stdout: &str, names: &HashSet<String>) -> (usize, usize) {
+    let (mut bare, mut rows) = (0usize, 0usize);
+    for raw in stdout.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if names.contains(line) {
+            bare += 1;
+        } else if is_itemize_row(line) {
+            rows += 1;
+        }
+    }
+    (bare, rows)
+}
+
+/// Heuristically detect an itemize row by its leading change string.
+fn is_itemize_row(line: &str) -> bool {
+    let Some(first) = line.chars().next() else {
+        return false;
+    };
+    matches!(first, '<' | '>' | 'c' | 'h' | '.' | '*') && line.len() >= 12 && line.contains(' ')
+}
+
+/// Collect every entry's basename (files and dirs) into a set for bare-name
+/// detection.
+fn basenames(src: &Path) -> HashSet<String> {
+    support::rel_entries(src)
+        .iter()
+        .filter_map(|rel| rel.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .collect()
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the itemize fixture. Idempotent: removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("a.txt"), b"alpha").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("b.txt"), b"bravo").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("c.txt"), b"charlie").map_err(|e| e.to_string())?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify;
+    use std::collections::HashSet;
+
+    fn names() -> HashSet<String> {
+        ["a.txt", "b.txt", "sub"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn counts_rows_and_ignores_summary_lines() {
+        let out = ">f+++++++++ a.txt\n\
+                   >f+++++++++ b.txt\n\
+                   cd+++++++++ sub/\n\
+                   \n\
+                   sent 100 bytes  received 20 bytes\n\
+                   total size is 12  speedup is 0.10\n";
+        assert_eq!(classify(out, &names()), (0, 3));
+    }
+
+    #[test]
+    fn detects_forbidden_duplicate_bare_name() {
+        // An itemize row PLUS a bare filename for the same entry is the bug.
+        assert_eq!(classify(">f+++++++++ a.txt\na.txt\n", &names()), (1, 1));
+    }
+
+    #[test]
+    fn row_containing_basename_substring_is_not_bare() {
+        // The path inside a change row must not be miscounted as a bare name.
+        assert_eq!(classify(">f+++++++++ a.txt\n", &names()), (0, 1));
+    }
+}

--- a/xtask/src/commands/validate/checks/link_dest.rs
+++ b/xtask/src/commands/validate/checks/link_dest.rs
@@ -1,0 +1,437 @@
+//! `--link-dest` parity: oc-rsync hardlinks unchanged files from a reference
+//! directory instead of copying them, exactly as upstream does.
+//!
+//! Like the `--delete` check, this needs a pre-built reference tree and an extra
+//! flag, so it builds each client `Command` directly rather than going through
+//! `transport::pull_into`. For every cell a per-cell reference dir `ref-<label>`
+//! is created holding `same.txt` and `sub/also_same.txt` byte- and mtime-
+//! identical to the source, plus `changed.txt` carrying older, differing
+//! content. Both clients pull the source into their own fresh empty destination
+//! with `--link-dest=<absolute ref dir>`.
+//!
+//! Upstream rsync is the ground truth. A file that is unchanged relative to the
+//! reference must be hardlinked into the destination (shared inode, `nlink >= 2`)
+//! rather than copied; a changed file must be transferred fresh (a distinct
+//! inode). The check asserts oc's per-file hardlink decision matches upstream's
+//! and that the destination trees are content-identical. The ssh transports are
+//! skipped when no sshd answers on localhost:22.
+
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `--link-dest` hardlink-parity check.
+pub struct LinkDest;
+
+/// Files present in the reference byte- and mtime-identical to the source: these
+/// must be hardlinked from the reference, not copied.
+const UNCHANGED: &[&str] = &["same.txt", "sub/also_same.txt"];
+
+/// File whose source content differs from the reference: it must be copied
+/// fresh, never hardlinked.
+const CHANGED: &str = "changed.txt";
+
+/// Shared backdated mtime (epoch seconds) applied to source and reference so the
+/// quick-check treats the unchanged files as identical and hardlinks them.
+const EPOCH: &str = "@1614830767";
+
+impl Check for LinkDest {
+    fn name(&self) -> &'static str {
+        "link-dest"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("link-dest");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src))
+            .collect()
+    }
+}
+
+impl LinkDest {
+    /// Run one transport cell: build the reference, pull with each client into a
+    /// fresh destination using `--link-dest`, then compare content and per-file
+    /// hardlink decisions against upstream.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        // Per-cell reference dir, canonicalized so `--link-dest` is absolute.
+        let ref_dir = root.join(format!("ref-{label}"));
+        if let Err(e) = build_reference(src, &ref_dir) {
+            return CheckOutcome::skip(self.name(), label, format!("reference: {e}"));
+        }
+        let ref_dir = match ref_dir.canonicalize() {
+            Ok(p) => p,
+            Err(e) => {
+                return CheckOutcome::skip(self.name(), label, format!("canonicalize ref: {e}"));
+            }
+        };
+
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        // One live upstream daemon shared by both client runs for this cell.
+        let daemon = if transport == Transport::Daemon {
+            match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), label, format!("daemon: {e}")),
+            }
+        } else {
+            None
+        };
+        let daemon_url = daemon.as_ref().map(|d| d.module_url());
+
+        let up = run_client(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            &ref_dir,
+            daemon_url.as_deref(),
+        );
+        let up = match up {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let _ = up;
+        let oc = run_client(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            &ref_dir,
+            daemon_url.as_deref(),
+        );
+        let oc = match oc {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+        let _ = oc;
+        drop(daemon);
+
+        // Destinations must be byte-identical.
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            if ctx.verbose {
+                dump(label, &oc_dst, &up_dst, &ref_dir);
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("oc and upstream dests differ: {diff}"),
+            );
+        }
+
+        // Per-file hardlink decisions must match upstream, and be non-vacuous.
+        match evaluate(&oc_dst, &up_dst, &ref_dir) {
+            Ok(()) => CheckOutcome::pass(self.name(), label),
+            Err(reason) => {
+                if ctx.verbose {
+                    dump(label, &oc_dst, &up_dst, &ref_dir);
+                }
+                CheckOutcome::fail(self.name(), label, reason)
+            }
+        }
+    }
+}
+
+/// Build one client rsync `Command` for `transport` and pull `src/` into a fresh
+/// `dst/` with `--link-dest=<ref_dir>`. The destination is recreated empty first
+/// so the reference is the only basis for hardlinking.
+///
+/// Flags are `-rlptgoD --link-dest=<ref> --numeric-ids`. Operand forms mirror
+/// `transport::pull_into`: `local` copies from a path, `ssh-subprocess` uses
+/// `-e ssh localhost:<src>`, `russh` an `ssh://` URL, `daemon` the module URL in
+/// `daemon_url`. The sender is always `upstream` for the network transports.
+fn run_client(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    ref_dir: &Path,
+    daemon_url: Option<&str>,
+) -> TaskResult<Output> {
+    reset_dir(dst)?;
+    let dst_arg = format!("{}/", dst.display());
+    let link_dest = format!("--link-dest={}", ref_dir.display());
+    let mut cmd = Command::new(client);
+    cmd.arg("-rlptgoD").arg(&link_dest).arg("--numeric-ids");
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let url = daemon_url
+                .ok_or_else(|| TaskError::Validation("daemon transport without url".into()))?;
+            cmd.arg(url).arg(&dst_arg);
+        }
+    }
+
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Per-file hardlink facts relative to the reference copy.
+struct LinkFacts {
+    /// Inode of the destination entry.
+    dest_ino: u64,
+    /// Inode of the matching reference entry.
+    ref_ino: u64,
+    /// Hard-link count of the destination entry.
+    nlink: u64,
+    /// True when destination and reference share inode and device (hardlinked).
+    linked: bool,
+}
+
+/// Read hardlink facts for `rel` in `dest` against the same path in `ref_dir`.
+fn link_facts(dest: &Path, ref_dir: &Path, rel: &str) -> Result<LinkFacts, String> {
+    let d = dest
+        .join(rel)
+        .symlink_metadata()
+        .map_err(|e| format!("stat {rel} in dest: {e}"))?;
+    let r = ref_dir
+        .join(rel)
+        .symlink_metadata()
+        .map_err(|e| format!("stat {rel} in reference: {e}"))?;
+    Ok(LinkFacts {
+        dest_ino: d.ino(),
+        ref_ino: r.ino(),
+        nlink: d.nlink(),
+        linked: d.ino() == r.ino() && d.dev() == r.dev(),
+    })
+}
+
+/// Assert oc's per-file hardlink decision matches upstream's: both hardlink the
+/// unchanged files (shared inode, `nlink >= 2`) and both copy the changed file.
+///
+/// Non-vacuous: the unchanged files must actually be hardlinked in oc's
+/// destination, so a client that silently copies everything fails here.
+fn evaluate(oc_dst: &Path, up_dst: &Path, ref_dir: &Path) -> Result<(), String> {
+    for rel in UNCHANGED {
+        let oc = link_facts(oc_dst, ref_dir, rel)?;
+        let up = link_facts(up_dst, ref_dir, rel)?;
+        if !oc.linked {
+            return Err(format!(
+                "{rel}: oc did not hardlink to reference (dest ino {} vs ref ino {})",
+                oc.dest_ino, oc.ref_ino
+            ));
+        }
+        if oc.nlink < 2 {
+            return Err(format!("{rel}: oc hardlink has nlink {} (< 2)", oc.nlink));
+        }
+        if oc.linked != up.linked {
+            return Err(format!(
+                "{rel}: hardlink decision differs (oc linked={} upstream linked={})",
+                oc.linked, up.linked
+            ));
+        }
+    }
+
+    let oc = link_facts(oc_dst, ref_dir, CHANGED)?;
+    let up = link_facts(up_dst, ref_dir, CHANGED)?;
+    if oc.linked {
+        return Err(format!(
+            "{CHANGED}: oc hardlinked a changed file to the reference (ino {})",
+            oc.dest_ino
+        ));
+    }
+    if oc.linked != up.linked {
+        return Err(format!(
+            "{CHANGED}: hardlink decision differs (oc linked={} upstream linked={})",
+            oc.linked, up.linked
+        ));
+    }
+    Ok(())
+}
+
+/// Print each client's per-file inode / nlink versus the reference (verbose
+/// failures), so a hardlink-decision divergence is legible.
+fn dump(label: &str, oc_dst: &Path, up_dst: &Path, ref_dir: &Path) {
+    for (who, dir) in [("oc", oc_dst), ("upstream", up_dst)] {
+        for rel in UNCHANGED.iter().copied().chain(std::iter::once(CHANGED)) {
+            match link_facts(dir, ref_dir, rel) {
+                Ok(f) => eprintln!(
+                    "[link-dest/{label}] {who} {rel}: dest_ino={} ref_ino={} nlink={} linked={}",
+                    f.dest_ino, f.ref_ino, f.nlink, f.linked
+                ),
+                Err(e) => eprintln!("[link-dest/{label}] {who} {rel}: {e}"),
+            }
+        }
+    }
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Build the source fixture: two files that will match the reference plus one
+/// whose content will differ. Idempotent: removes any prior tree first. Mtimes
+/// are backdated so the unchanged files quick-check as identical to the
+/// reference and are therefore hardlinked.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("same.txt"), b"same-content\n").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("also_same.txt"), b"also-same-content\n").map_err(|e| e.to_string())?;
+    // Longer, different content so the reference's older copy quick-checks as
+    // changed and is copied fresh rather than hardlinked.
+    std::fs::write(src.join("changed.txt"), b"changed-new-longer-content\n")
+        .map_err(|e| e.to_string())?;
+
+    backdate(src)
+}
+
+/// Build the per-cell reference: the two unchanged files copied byte- and
+/// mtime-identical from the source, plus an older `changed.txt`. Idempotent.
+fn build_reference(src: &Path, ref_dir: &Path) -> Result<(), String> {
+    if ref_dir.exists() {
+        std::fs::remove_dir_all(ref_dir).map_err(|e| e.to_string())?;
+    }
+    let sub = ref_dir.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    for rel in UNCHANGED {
+        std::fs::copy(src.join(rel), ref_dir.join(rel)).map_err(|e| e.to_string())?;
+    }
+    // Older, shorter content: differs from the source so it is not hardlinked.
+    std::fs::write(ref_dir.join(CHANGED), b"old\n").map_err(|e| e.to_string())?;
+
+    // Match the source mtimes on the unchanged files so the quick-check hardlinks
+    // them; the changed file's mtime is irrelevant (its size already differs).
+    for rel in UNCHANGED {
+        touch_epoch(&ref_dir.join(rel))?;
+    }
+    Ok(())
+}
+
+/// Backdate every entry under `root` to the shared epoch mtime.
+fn backdate(root: &Path) -> Result<(), String> {
+    for entry in support::rel_entries(root) {
+        touch_epoch(&root.join(&entry))?;
+    }
+    Ok(())
+}
+
+/// Set `path`'s mtime to the shared epoch via GNU `touch -h -d @epoch`.
+fn touch_epoch(path: &Path) -> Result<(), String> {
+    support::capture("touch", &["-h", "-d", EPOCH, &path.to_string_lossy()])
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CHANGED, UNCHANGED, evaluate};
+    use std::fs;
+
+    /// Seed `dir` from `ref_dir`: hardlink the unchanged files, copy the changed
+    /// one to a fresh inode - the correct `--link-dest` outcome.
+    fn seed_like_link_dest(dir: &std::path::Path, ref_dir: &std::path::Path) {
+        fs::create_dir_all(dir.join("sub")).unwrap();
+        for rel in UNCHANGED {
+            fs::hard_link(ref_dir.join(rel), dir.join(rel)).unwrap();
+        }
+        fs::write(dir.join(CHANGED), b"fresh-copy").unwrap();
+    }
+
+    fn seed_reference(ref_dir: &std::path::Path) {
+        fs::create_dir_all(ref_dir.join("sub")).unwrap();
+        for rel in UNCHANGED {
+            fs::write(ref_dir.join(rel), b"same").unwrap();
+        }
+        fs::write(ref_dir.join(CHANGED), b"old").unwrap();
+    }
+
+    #[test]
+    fn evaluate_accepts_linked_unchanged_and_copied_changed() {
+        let r = tempfile::tempdir().unwrap();
+        let oc = tempfile::tempdir().unwrap();
+        let up = tempfile::tempdir().unwrap();
+        seed_reference(r.path());
+        seed_like_link_dest(oc.path(), r.path());
+        seed_like_link_dest(up.path(), r.path());
+        assert!(evaluate(oc.path(), up.path(), r.path()).is_ok());
+    }
+
+    #[test]
+    fn evaluate_rejects_hardlinked_changed_file() {
+        let r = tempfile::tempdir().unwrap();
+        let oc = tempfile::tempdir().unwrap();
+        let up = tempfile::tempdir().unwrap();
+        seed_reference(r.path());
+        seed_like_link_dest(up.path(), r.path());
+        // oc wrongly hardlinks the changed file to the reference.
+        fs::create_dir_all(oc.path().join("sub")).unwrap();
+        for rel in UNCHANGED {
+            fs::hard_link(r.path().join(rel), oc.path().join(rel)).unwrap();
+        }
+        fs::hard_link(r.path().join(CHANGED), oc.path().join(CHANGED)).unwrap();
+        let err = evaluate(oc.path(), up.path(), r.path()).unwrap_err();
+        assert!(err.contains(CHANGED));
+    }
+}

--- a/xtask/src/commands/validate/checks/metadata.rs
+++ b/xtask/src/commands/validate/checks/metadata.rs
@@ -1,0 +1,259 @@
+//! Content + POSIX metadata parity between oc-rsync and upstream.
+//!
+//! Builds a fixture carrying varied permissions, a setgid dir, backdated
+//! mtimes, a symlink, and a hardlink pair, then pulls it with each client over
+//! every transport and asserts oc's destination is byte- and attribute-
+//! identical to upstream's (perms, mtime, uid/gid, hardlink count).
+
+use std::collections::BTreeMap;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The metadata parity check.
+pub struct Metadata;
+
+/// Preserve as much metadata as a non-root user reliably can.
+const FLAGS: &[&str] = &["-rlptgoD", "-H", "--numeric-ids"];
+
+impl Check for Metadata {
+    fn name(&self) -> &'static str {
+        "metadata"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("metadata");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src, ctx.edge_cases) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src, &flags, expected))
+            .collect()
+    }
+}
+
+impl Metadata {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        flags: &[String],
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let _ = up;
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+        let _ = oc;
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+        match attr_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), label, diff),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// Map a tree to per-entry `(mode, mtime, uid, gid, nlink)` for comparison.
+fn attr_map(root: &Path) -> BTreeMap<std::path::PathBuf, (u32, i64, u32, u32, u64)> {
+    support::rel_entries(root)
+        .into_iter()
+        .filter_map(|rel| {
+            let meta = root.join(&rel).symlink_metadata().ok()?;
+            let attrs = (
+                meta.mode() & 0o7777,
+                meta.mtime(),
+                meta.uid(),
+                meta.gid(),
+                meta.nlink(),
+            );
+            Some((rel, attrs))
+        })
+        .collect()
+}
+
+/// First per-attribute divergence between two trees, or `None` when identical.
+fn attr_diff(oc: &Path, up: &Path) -> Option<String> {
+    let (a, b) = (attr_map(oc), attr_map(up));
+    for (rel, oc_attrs) in &a {
+        let Some(up_attrs) = b.get(rel) else {
+            return Some(format!("missing {} in oc tree", rel.display()));
+        };
+        let fields = ["perms", "mtime", "uid", "gid", "nlink"];
+        let mismatches: Vec<&str> = fields
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !attr_eq(*i, oc_attrs, up_attrs))
+            .map(|(_, name)| *name)
+            .collect();
+        if !mismatches.is_empty() {
+            return Some(format!(
+                "{} differs at {}",
+                mismatches.join("/"),
+                rel.display()
+            ));
+        }
+    }
+    None
+}
+
+fn attr_eq(field: usize, a: &(u32, i64, u32, u32, u64), b: &(u32, i64, u32, u32, u64)) -> bool {
+    match field {
+        0 => a.0 == b.0,
+        1 => a.1 == b.1,
+        2 => a.2 == b.2,
+        3 => a.3 == b.3,
+        _ => a.4 == b.4,
+    }
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the metadata fixture. Idempotent: removes any prior tree first. When
+/// `edge_cases` is set, adds empty files, names with spaces and unicode, deeper
+/// nesting, and a dangling symlink.
+fn build_fixture(src: &Path, edge_cases: bool) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    write_mode(&src.join("f644"), b"alpha", 0o644)?;
+    write_mode(&src.join("f600"), b"bravo", 0o600)?;
+    write_mode(&src.join("f755"), b"charlie", 0o755)?;
+    write_mode(&sub.join("f640"), b"delta", 0o640)?;
+
+    // Hardlink pair.
+    std::fs::write(src.join("h1"), b"linked").map_err(|e| e.to_string())?;
+    std::fs::hard_link(src.join("h1"), src.join("h2")).map_err(|e| e.to_string())?;
+
+    // Symlink.
+    std::os::unix::fs::symlink("../f644", sub.join("link")).map_err(|e| e.to_string())?;
+
+    if edge_cases {
+        write_mode(&src.join("empty"), b"", 0o644)?;
+        write_mode(&src.join("with space.txt"), b"spaced", 0o644)?;
+        write_mode(&src.join("caf\u{e9}.txt"), b"unicode", 0o644)?;
+        let deep = sub.join("deep");
+        std::fs::create_dir_all(&deep).map_err(|e| e.to_string())?;
+        write_mode(&deep.join("deeper.txt"), b"nested", 0o600)?;
+        std::os::unix::fs::symlink("does-not-exist", sub.join("dangling"))
+            .map_err(|e| e.to_string())?;
+    }
+
+    // setgid directory.
+    set_mode(&sub, 0o2775)?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn write_mode(path: &Path, bytes: &[u8], mode: u32) -> Result<(), String> {
+    std::fs::write(path, bytes).map_err(|e| e.to_string())?;
+    set_mode(path, mode)
+}
+
+fn set_mode(path: &Path, mode: u32) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{attr_diff, set_mode};
+    use std::fs;
+
+    #[test]
+    fn attr_diff_none_for_hard_linked_identical_entries() {
+        // A hard link shares the inode, so mode/mtime/uid/gid/nlink all match
+        // without depending on a GNU-only `touch -d @epoch` (portable to BSD).
+        let (a, b) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        let source = a.path().join("f");
+        fs::write(&source, b"x").unwrap();
+        set_mode(&source, 0o644).unwrap();
+        fs::hard_link(&source, b.path().join("f")).unwrap();
+        assert!(attr_diff(a.path(), b.path()).is_none());
+    }
+
+    #[test]
+    fn attr_diff_names_the_diverging_permission() {
+        let (a, b) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        fs::write(a.path().join("f"), b"x").unwrap();
+        fs::write(b.path().join("f"), b"x").unwrap();
+        set_mode(&a.path().join("f"), 0o644).unwrap();
+        set_mode(&b.path().join("f"), 0o600).unwrap();
+        assert!(attr_diff(a.path(), b.path()).unwrap().contains("perms"));
+    }
+}

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -1,6 +1,7 @@
 //! Registry of fidelity checks. Each check is an independent [`Check`] strategy.
 
 mod acl_xattr;
+mod adhoc_flags;
 mod append_inplace;
 mod backup;
 mod banner;
@@ -40,6 +41,8 @@ use super::Check;
 /// All checks, in report order.
 pub fn all() -> Vec<Box<dyn Check>> {
     vec![
+        // Ad-hoc arbitrary-flags parity (only runs when --flags is given).
+        Box::new(adhoc_flags::AdHocFlags),
         // Metadata and attributes.
         Box::new(metadata::Metadata),
         Box::new(hard_links::HardLinks),

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -1,6 +1,7 @@
 //! Registry of fidelity checks. Each check is an independent [`Check`] strategy.
 
 mod acl_xattr;
+mod backup;
 mod banner;
 mod checksum;
 mod chmod;
@@ -10,12 +11,14 @@ mod delete;
 mod dry_run;
 mod filters;
 mod itemize;
+mod link_dest;
 mod metadata;
 mod progress;
 mod prune_empty_dirs;
 mod relative;
 mod remove_source_files;
 mod rsync_path;
+mod sparse;
 mod special_bits;
 mod stats;
 mod total_size;
@@ -32,6 +35,7 @@ pub fn all() -> Vec<Box<dyn Check>> {
         Box::new(chown::Chown),
         Box::new(acl_xattr::AclXattr),
         Box::new(relative::Relative),
+        Box::new(sparse::Sparse),
         Box::new(progress::Progress),
         Box::new(verbosity::Verbosity),
         Box::new(itemize::Itemize),
@@ -41,6 +45,8 @@ pub fn all() -> Vec<Box<dyn Check>> {
         Box::new(prune_empty_dirs::PruneEmptyDirs),
         Box::new(delete::Delete),
         Box::new(remove_source_files::RemoveSourceFiles),
+        Box::new(backup::Backup),
+        Box::new(link_dest::LinkDest),
         Box::new(compress::Compress),
         Box::new(checksum::Checksum),
         Box::new(stats::Stats),

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -1,0 +1,22 @@
+//! Registry of fidelity checks. Each check is an independent [`Check`] strategy.
+
+mod acl_xattr;
+mod banner;
+mod itemize;
+mod metadata;
+mod progress;
+mod total_size;
+
+use super::Check;
+
+/// All checks, in report order.
+pub fn all() -> Vec<Box<dyn Check>> {
+    vec![
+        Box::new(metadata::Metadata),
+        Box::new(acl_xattr::AclXattr),
+        Box::new(progress::Progress),
+        Box::new(itemize::Itemize),
+        Box::new(banner::Banner),
+        Box::new(total_size::TotalSize),
+    ]
+}

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -7,6 +7,7 @@ mod checksum;
 mod chmod;
 mod chown;
 mod compress;
+mod crtimes;
 mod delete;
 mod dry_run;
 mod filters;
@@ -24,6 +25,7 @@ mod special_bits;
 mod stats;
 mod total_size;
 mod verbosity;
+mod xattr;
 
 use super::Check;
 
@@ -36,6 +38,8 @@ pub fn all() -> Vec<Box<dyn Check>> {
         Box::new(chmod::Chmod),
         Box::new(chown::Chown),
         Box::new(acl_xattr::AclXattr),
+        Box::new(xattr::Xattr),
+        Box::new(crtimes::Crtimes),
         Box::new(relative::Relative),
         Box::new(sparse::Sparse),
         Box::new(progress::Progress),

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -12,6 +12,9 @@ mod filters;
 mod itemize;
 mod metadata;
 mod progress;
+mod prune_empty_dirs;
+mod relative;
+mod remove_source_files;
 mod rsync_path;
 mod special_bits;
 mod stats;
@@ -28,13 +31,16 @@ pub fn all() -> Vec<Box<dyn Check>> {
         Box::new(chmod::Chmod),
         Box::new(chown::Chown),
         Box::new(acl_xattr::AclXattr),
+        Box::new(relative::Relative),
         Box::new(progress::Progress),
         Box::new(verbosity::Verbosity),
         Box::new(itemize::Itemize),
         Box::new(dry_run::DryRun),
         Box::new(banner::Banner),
         Box::new(filters::Filters),
+        Box::new(prune_empty_dirs::PruneEmptyDirs),
         Box::new(delete::Delete),
+        Box::new(remove_source_files::RemoveSourceFiles),
         Box::new(compress::Compress),
         Box::new(checksum::Checksum),
         Box::new(stats::Stats),

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -1,20 +1,25 @@
 //! Registry of fidelity checks. Each check is an independent [`Check`] strategy.
 
 mod acl_xattr;
+mod append_inplace;
 mod backup;
 mod banner;
 mod checksum;
 mod chmod;
 mod chown;
+mod compare_dest;
 mod compress;
 mod crtimes;
 mod delete;
+mod devices;
 mod dry_run;
+mod files_from;
 mod filters;
 mod hard_links;
 mod itemize;
 mod link_dest;
 mod metadata;
+mod one_file_system;
 mod progress;
 mod prune_empty_dirs;
 mod relative;
@@ -23,8 +28,11 @@ mod rsync_path;
 mod sparse;
 mod special_bits;
 mod stats;
+mod symlinks;
 mod total_size;
+mod transfer_conditions;
 mod verbosity;
+mod whole_file;
 mod xattr;
 
 use super::Check;
@@ -32,6 +40,7 @@ use super::Check;
 /// All checks, in report order.
 pub fn all() -> Vec<Box<dyn Check>> {
     vec![
+        // Metadata and attributes.
         Box::new(metadata::Metadata),
         Box::new(hard_links::HardLinks),
         Box::new(special_bits::SpecialBits),
@@ -40,23 +49,36 @@ pub fn all() -> Vec<Box<dyn Check>> {
         Box::new(acl_xattr::AclXattr),
         Box::new(xattr::Xattr),
         Box::new(crtimes::Crtimes),
+        Box::new(symlinks::Symlinks),
+        Box::new(devices::Devices),
+        // Path selection and layout.
         Box::new(relative::Relative),
+        Box::new(files_from::FilesFrom),
+        Box::new(filters::Filters),
+        Box::new(prune_empty_dirs::PruneEmptyDirs),
+        Box::new(one_file_system::OneFileSystem),
         Box::new(sparse::Sparse),
+        // Output fidelity.
         Box::new(progress::Progress),
         Box::new(verbosity::Verbosity),
         Box::new(itemize::Itemize),
         Box::new(dry_run::DryRun),
         Box::new(banner::Banner),
-        Box::new(filters::Filters),
-        Box::new(prune_empty_dirs::PruneEmptyDirs),
-        Box::new(delete::Delete),
-        Box::new(remove_source_files::RemoveSourceFiles),
-        Box::new(backup::Backup),
-        Box::new(link_dest::LinkDest),
-        Box::new(compress::Compress),
-        Box::new(checksum::Checksum),
         Box::new(stats::Stats),
         Box::new(total_size::TotalSize),
+        // Transfer decisions and deletion.
+        Box::new(transfer_conditions::TransferConditions),
+        Box::new(checksum::Checksum),
+        Box::new(whole_file::WholeFile),
+        Box::new(append_inplace::AppendInplace),
+        Box::new(compress::Compress),
+        Box::new(delete::Delete),
+        Box::new(remove_source_files::RemoveSourceFiles),
+        // Alternate destinations.
+        Box::new(backup::Backup),
+        Box::new(link_dest::LinkDest),
+        Box::new(compare_dest::CompareDest),
+        // Transport plumbing.
         Box::new(rsync_path::RsyncPath),
     ]
 }

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -2,10 +2,21 @@
 
 mod acl_xattr;
 mod banner;
+mod checksum;
+mod chmod;
+mod chown;
+mod compress;
+mod delete;
+mod dry_run;
+mod filters;
 mod itemize;
 mod metadata;
 mod progress;
+mod rsync_path;
+mod special_bits;
+mod stats;
 mod total_size;
+mod verbosity;
 
 use super::Check;
 
@@ -13,10 +24,21 @@ use super::Check;
 pub fn all() -> Vec<Box<dyn Check>> {
     vec![
         Box::new(metadata::Metadata),
+        Box::new(special_bits::SpecialBits),
+        Box::new(chmod::Chmod),
+        Box::new(chown::Chown),
         Box::new(acl_xattr::AclXattr),
         Box::new(progress::Progress),
+        Box::new(verbosity::Verbosity),
         Box::new(itemize::Itemize),
+        Box::new(dry_run::DryRun),
         Box::new(banner::Banner),
+        Box::new(filters::Filters),
+        Box::new(delete::Delete),
+        Box::new(compress::Compress),
+        Box::new(checksum::Checksum),
+        Box::new(stats::Stats),
         Box::new(total_size::TotalSize),
+        Box::new(rsync_path::RsyncPath),
     ]
 }

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -10,6 +10,7 @@ mod compress;
 mod delete;
 mod dry_run;
 mod filters;
+mod hard_links;
 mod itemize;
 mod link_dest;
 mod metadata;
@@ -30,6 +31,7 @@ use super::Check;
 pub fn all() -> Vec<Box<dyn Check>> {
     vec![
         Box::new(metadata::Metadata),
+        Box::new(hard_links::HardLinks),
         Box::new(special_bits::SpecialBits),
         Box::new(chmod::Chmod),
         Box::new(chown::Chown),

--- a/xtask/src/commands/validate/checks/one_file_system.rs
+++ b/xtask/src/commands/validate/checks/one_file_system.rs
@@ -1,0 +1,152 @@
+//! `-x`/`--one-file-system` parity between oc-rsync and upstream.
+//!
+//! Builds a small tree that lives entirely on a single filesystem, then pulls
+//! it with each client over every transport and asserts oc's destination is
+//! byte-identical to upstream's. On a single filesystem `-x` must be a no-op:
+//! nothing crosses a mount boundary, so the whole tree still transfers.
+//!
+//! Scope note: the *cross-mount pruning* path - where `-x` stops recursion at a
+//! nested mount of a different filesystem inside the source tree - is not
+//! exercised here. Creating such a nested mount requires root, so that path is
+//! intentionally out of scope. This check validates the common single-filesystem
+//! case that is fully testable as an ordinary, unprivileged user.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The one-file-system parity check.
+pub struct OneFileSystem;
+
+/// Recurse and preserve metadata, with `-x` under test and numeric ids so the
+/// comparison never depends on name-service lookups.
+const FLAGS: &[&str] = &["-rlptgoD", "-x", "--numeric-ids"];
+
+impl Check for OneFileSystem {
+    fn name(&self) -> &'static str {
+        "one-file-system"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("one-file-system");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &flags, expected))
+            .collect()
+    }
+}
+
+impl OneFileSystem {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        flags: &[String],
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let src = root.join("src");
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            &src,
+            &up_dst,
+            flags,
+            ctx.work,
+        );
+        match up {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        }
+        let oc = pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            &src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        );
+        match oc {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        }
+
+        // Non-vacuous guard: `-x` on a single filesystem prunes nothing, so both
+        // destinations must carry the whole source tree, not an empty subset.
+        if support::entry_count(&up_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "upstream dest entry count != source");
+        }
+        if support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "oc dest entry count != source");
+        }
+        match support::content_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), label, diff),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the single-filesystem fixture. Idempotent: removes any prior tree
+/// first. The whole tree - `a.txt`, `sub/b.txt`, `sub/deep/c.txt` - lives on one
+/// filesystem, so `-x` has no mount boundary to stop at. Mtimes are backdated so
+/// the quick-check never skips a file under test.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let deep = src.join("sub").join("deep");
+    std::fs::create_dir_all(&deep).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("a.txt"), b"alpha").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("sub").join("b.txt"), b"bravo").map_err(|e| e.to_string())?;
+    std::fs::write(deep.join("c.txt"), b"charlie").map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}

--- a/xtask/src/commands/validate/checks/progress.rs
+++ b/xtask/src/commands/validate/checks/progress.rs
@@ -45,19 +45,17 @@ impl Check for Progress {
 
         ctx.transports
             .iter()
-            .map(|&t| self.cell(ctx, t, &root, &src, &flags, &names, expected))
+            .map(|&t| self.cell(ctx, t, &root, &flags, &names, expected))
             .collect()
     }
 }
 
 impl Progress {
-    #[allow(clippy::too_many_arguments)]
     fn cell(
         &self,
         ctx: &ValidateCtx,
         transport: Transport,
         root: &Path,
-        src: &Path,
         flags: &[String],
         names: &HashSet<String>,
         expected: usize,
@@ -66,6 +64,8 @@ impl Progress {
         if transport.needs_ssh() && !support::ssh_ready() {
             return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
         }
+        let src = root.join("src");
+        let src = src.as_path();
         let oc_dst = root.join(format!("oc-{label}"));
         let up_dst = root.join(format!("up-{label}"));
 

--- a/xtask/src/commands/validate/checks/progress.rs
+++ b/xtask/src/commands/validate/checks/progress.rs
@@ -1,0 +1,248 @@
+//! `-v --progress` name/progress interleaving parity on the receiver.
+//!
+//! Builds a fixture of a few large top-level files, pulls it with each client
+//! over every transport, and asserts that oc-rsync interleaves each transferred
+//! file's NAME line immediately before its PROGRESS/xfr line - the N,P,N,P,...
+//! pattern - exactly as upstream does. Progress may land on stdout or stderr, so
+//! both streams are folded together before the pattern is derived. Upstream is
+//! the ground truth: a cell where upstream itself renders no progress (e.g. a
+//! host whose transport buffers the transfer away) is skipped, not failed.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Output;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The progress-interleave check.
+pub struct Progress;
+
+/// Archive plus a live progress meter, whose per-file lines we inspect.
+const FLAGS: &[&str] = &["-av", "--progress"];
+
+/// Number of distinct top-level files in the fixture.
+const FILE_COUNT: usize = 4;
+
+/// Base filler size (~3 MB) so each file yields a progress + `(xfr#N,` line.
+const BASE_SIZE: usize = 3 * 1024 * 1024;
+
+impl Check for Progress {
+    fn name(&self) -> &'static str {
+        "progress-interleave"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("progress");
+        let src = root.join("src");
+        let names = match build_fixture(&src) {
+            Ok(names) => names,
+            Err(e) => return vec![CheckOutcome::skip(self.name(), "fixture", e)],
+        };
+        let expected = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src, &flags, &names, expected))
+            .collect()
+    }
+}
+
+impl Progress {
+    #[allow(clippy::too_many_arguments)]
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        flags: &[String],
+        names: &HashSet<String>,
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+
+        let oc_pat = interleave_pattern(&combined_output(&oc), names);
+        let up_pat = interleave_pattern(&combined_output(&up), names);
+        if ctx.verbose {
+            eprintln!("[progress/{label}] oc={oc_pat} upstream={up_pat}");
+        }
+
+        if !is_good(&oc_pat) {
+            return CheckOutcome::fail(self.name(), label, format!("oc pattern={oc_pat}"));
+        }
+        if !is_good(&up_pat) {
+            return CheckOutcome::skip(self.name(), label, "upstream did not render progress");
+        }
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Fold a run's stdout then stderr into one string; progress can be on either.
+fn combined_output(out: &Output) -> String {
+    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stderr));
+    s
+}
+
+/// Derive the N/P interleave pattern from combined transfer output.
+///
+/// The progress meter overwrites its line with carriage returns, so only the
+/// segment after the LAST `\r` on each line is meaningful. A segment holding an
+/// `(xfr#` marker is a progress line (`P`); a segment that is exactly a source
+/// basename is a name line (`N`); everything else (stats, headers) is ignored.
+pub fn interleave_pattern(output: &str, names: &HashSet<String>) -> String {
+    let mut pat = String::new();
+    for line in output.lines() {
+        let seg = line.rsplit('\r').next().unwrap_or(line).trim();
+        if seg.contains("(xfr#") {
+            pat.push('P');
+        } else if names.contains(seg) {
+            pat.push('N');
+        }
+    }
+    pat
+}
+
+/// True when a pattern is a non-empty `NP` repeated (each name immediately
+/// followed by its progress line, with at least one transferred file).
+pub fn is_good(pat: &str) -> bool {
+    if pat.is_empty() || pat.len() % 2 != 0 || !pat.contains('P') {
+        return false;
+    }
+    pat.bytes().enumerate().all(|(i, b)| {
+        let expected = if i % 2 == 0 { b'N' } else { b'P' };
+        b == expected
+    })
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the progress fixture and return the set of top-level file basenames.
+///
+/// Idempotent: removes any prior tree first. Each file is ~3 MB plus a small
+/// per-file delta so the sizes are distinct and large enough to emit a progress
+/// line and an `(xfr#N,` marker.
+fn build_fixture(src: &Path) -> Result<HashSet<String>, String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src).map_err(|e| e.to_string())?;
+
+    let mut names = HashSet::new();
+    for i in 0..FILE_COUNT {
+        let name = format!("file{i}.bin");
+        let size = BASE_SIZE + i * 64 * 1024;
+        std::fs::write(src.join(&name), vec![b'x'; size]).map_err(|e| e.to_string())?;
+        names.insert(name);
+    }
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture("touch", &["-d", "@1614830767", &path.to_string_lossy()])
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(names)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{interleave_pattern, is_good};
+    use std::collections::HashSet;
+
+    fn names() -> HashSet<String> {
+        ["file0.bin", "file1.bin"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn pattern_uses_segment_after_last_carriage_return() {
+        // The progress meter overwrites its line with \r; only the last segment,
+        // which carries the (xfr#..) marker, is the real progress line.
+        let out = "file0.bin\n 50%\r 100%  (xfr#1, to-chk=0/1)\n";
+        assert_eq!(interleave_pattern(out, &names()), "NP");
+    }
+
+    #[test]
+    fn pattern_interleaves_names_and_progress_ignoring_banners() {
+        let out = "sending incremental file list\n\
+                   file0.bin\n  1.00M 100%  (xfr#1, to-chk=1/2)\n\
+                   file1.bin\n  2.00M 100%  (xfr#2, to-chk=0/2)\n";
+        assert_eq!(interleave_pattern(out, &names()), "NPNP");
+    }
+
+    #[test]
+    fn pattern_empty_without_names_or_markers() {
+        assert_eq!(interleave_pattern("random\nlines\n", &names()), "");
+    }
+
+    #[test]
+    fn is_good_requires_name_then_progress_pairs() {
+        assert!(is_good("NP"));
+        assert!(is_good("NPNP"));
+        assert!(!is_good("")); // nothing transferred
+        assert!(!is_good("N")); // name, no progress
+        assert!(!is_good("PN")); // progress before name is the regression
+        assert!(!is_good("NPN")); // odd length
+        assert!(!is_good("NN")); // two names, no progress
+    }
+}

--- a/xtask/src/commands/validate/checks/prune_empty_dirs.rs
+++ b/xtask/src/commands/validate/checks/prune_empty_dirs.rs
@@ -1,0 +1,314 @@
+//! Empty-directory pruning parity between oc-rsync and upstream (`-m`).
+//!
+//! Builds a fixture mixing file-bearing directories with wholly empty ones
+//! (a lone empty dir, an empty nested chain, and a dir that carries no direct
+//! files but has a file-bearing subdirectory), then pulls it with `-m`
+//! (`--prune-empty-dirs`) using each client over every transport. It asserts
+//! oc's destination tree is identical to upstream's - the same directories
+//! pruned and the same kept - and, as a non-vacuous guard, that the source
+//! genuinely held the empty dirs, that oc omitted exactly those, and that oc
+//! kept every directory leading to a file.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The empty-directory pruning parity check.
+pub struct PruneEmptyDirs;
+
+/// Recurse and preserve metadata, and prune empty directories (`-m`).
+const FLAGS: &[&str] = &["-rlptgoD", "-m", "--numeric-ids"];
+
+/// Directories that hold no file anywhere beneath them; `-m` must drop these.
+const PRUNE_TARGETS: &[&str] = &["empty", "empties/a/b"];
+
+/// Directories that lead to a file; `-m` must keep these.
+const SURVIVORS: &[&str] = &["full", "mixed/onlysub"];
+
+impl Check for PruneEmptyDirs {
+    fn name(&self) -> &'static str {
+        "prune-empty-dirs"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("prune-empty-dirs");
+        if let Err(e) = build_fixture(&root.join("src")) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &flags))
+            .collect()
+    }
+}
+
+impl PruneEmptyDirs {
+    /// Run one transport cell: pull with oc and with upstream, then assert both
+    /// destinations pruned identically and that the prune actually happened.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        flags: &[String],
+    ) -> CheckOutcome {
+        let label = transport.label();
+        let src = root.join("src");
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            &src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        }
+        match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            &src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        }
+
+        if ctx.verbose {
+            eprintln!(
+                "[prune-empty-dirs/{label}] oc kept {:?}",
+                sorted(&present_dirs(&oc_dst))
+            );
+            eprintln!(
+                "[prune-empty-dirs/{label}] upstream kept {:?}",
+                sorted(&present_dirs(&up_dst))
+            );
+        }
+
+        // oc and upstream must prune and keep exactly the same directories.
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+        // oc's surviving dirs must be precisely those that lead to a file.
+        let expected = surviving_dirs(&source_files(&src));
+        if let Some(diff) = dir_set_diff(&present_dirs(&oc_dst), &expected) {
+            return CheckOutcome::fail(self.name(), label, format!("oc {diff}"));
+        }
+        // Non-vacuous guards: the empty dirs existed in the source, oc dropped
+        // them, and oc kept every file-bearing directory.
+        match prune_guard(&src, &oc_dst) {
+            Some(reason) => CheckOutcome::fail(self.name(), label, reason),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// Directories that must survive `-m`: every ancestor directory of every file.
+///
+/// A directory is kept iff at least one file lives at or below it, so the
+/// surviving set is exactly the union of each file's ancestor directories.
+fn surviving_dirs(files: &[PathBuf]) -> BTreeSet<PathBuf> {
+    let mut dirs = BTreeSet::new();
+    for file in files {
+        let mut cur = file.parent();
+        while let Some(dir) = cur {
+            if dir.as_os_str().is_empty() {
+                break;
+            }
+            dirs.insert(dir.to_path_buf());
+            cur = dir.parent();
+        }
+    }
+    dirs
+}
+
+/// Relative paths of the regular files under `root` (directories excluded).
+fn source_files(root: &Path) -> Vec<PathBuf> {
+    support::rel_entries(root)
+        .into_iter()
+        .filter(|rel| {
+            root.join(rel)
+                .symlink_metadata()
+                .map(|m| m.is_file())
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// Relative paths of the directories present under `root`.
+fn present_dirs(root: &Path) -> BTreeSet<PathBuf> {
+    support::rel_entries(root)
+        .into_iter()
+        .filter(|rel| {
+            root.join(rel)
+                .symlink_metadata()
+                .map(|m| m.is_dir())
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// First divergence between an actual and expected directory set, else `None`.
+fn dir_set_diff(actual: &BTreeSet<PathBuf>, expected: &BTreeSet<PathBuf>) -> Option<String> {
+    if let Some(extra) = actual.difference(expected).next() {
+        return Some(format!("kept an empty directory {}", extra.display()));
+    }
+    if let Some(missing) = expected.difference(actual).next() {
+        return Some(format!(
+            "pruned a file-bearing directory {}",
+            missing.display()
+        ));
+    }
+    None
+}
+
+/// Confirm the prune was real: the empty dirs existed in the source, are gone
+/// from the destination, and every file-bearing directory remains.
+fn prune_guard(src: &Path, dst: &Path) -> Option<String> {
+    for target in PRUNE_TARGETS {
+        if !src.join(target).is_dir() {
+            return Some(format!("source lacked empty dir {target}"));
+        }
+        if dst.join(target).exists() {
+            return Some(format!("did not prune empty dir {target}"));
+        }
+    }
+    for survivor in SURVIVORS {
+        if !dst.join(survivor).is_dir() {
+            return Some(format!("pruned file-bearing dir {survivor}"));
+        }
+    }
+    None
+}
+
+/// Sorted relative paths, for stable verbose output.
+fn sorted(dirs: &BTreeSet<PathBuf>) -> Vec<String> {
+    dirs.iter().map(|p| p.display().to_string()).collect()
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the prune fixture. Idempotent: removes any prior tree first.
+///
+/// Layout (`*` = pruned by `-m`, others kept):
+/// ```text
+///   full/keep.txt            full/, full/nested/ kept (hold files)
+///   full/nested/leaf.txt
+///   empty/                   * lone empty directory
+///   empties/a/b/             * empty nested chain (no file anywhere)
+///   mixed/onlysub/leaf.txt   mixed/, mixed/onlysub/ kept (subdir holds a file)
+/// ```
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let full_nested = src.join("full").join("nested");
+    std::fs::create_dir_all(&full_nested).map_err(|e| e.to_string())?;
+    std::fs::write(src.join("full").join("keep.txt"), b"keep").map_err(|e| e.to_string())?;
+    std::fs::write(full_nested.join("leaf.txt"), b"leaf").map_err(|e| e.to_string())?;
+
+    std::fs::create_dir_all(src.join("empty")).map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(src.join("empties").join("a").join("b")).map_err(|e| e.to_string())?;
+
+    let onlysub = src.join("mixed").join("onlysub");
+    std::fs::create_dir_all(&onlysub).map_err(|e| e.to_string())?;
+    std::fs::write(onlysub.join("leaf.txt"), b"mixed").map_err(|e| e.to_string())?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{dir_set_diff, surviving_dirs};
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
+
+    fn paths(items: &[&str]) -> Vec<PathBuf> {
+        items.iter().map(PathBuf::from).collect()
+    }
+
+    fn dir_set(items: &[&str]) -> BTreeSet<PathBuf> {
+        items.iter().map(PathBuf::from).collect()
+    }
+
+    #[test]
+    fn surviving_dirs_is_the_union_of_file_ancestors() {
+        let files = paths(&[
+            "full/keep.txt",
+            "full/nested/leaf.txt",
+            "mixed/onlysub/leaf.txt",
+        ]);
+        let kept = surviving_dirs(&files);
+        // Every ancestor of a file survives; the empty dirs never appear.
+        assert_eq!(
+            kept,
+            dir_set(&["full", "full/nested", "mixed", "mixed/onlysub"])
+        );
+        assert!(!kept.contains(&PathBuf::from("empty")));
+        assert!(!kept.contains(&PathBuf::from("empties/a/b")));
+    }
+
+    #[test]
+    fn dir_set_diff_flags_a_kept_empty_dir_and_a_pruned_survivor() {
+        let expected = dir_set(&["full", "full/nested"]);
+        // A destination that kept an empty "empty/" diverges by keeping too much.
+        let kept_too_much = dir_set(&["full", "full/nested", "empty"]);
+        assert!(
+            dir_set_diff(&kept_too_much, &expected)
+                .unwrap()
+                .contains("kept an empty directory")
+        );
+        // A destination missing "full/nested" pruned a directory that held a file.
+        let pruned_too_much = dir_set(&["full"]);
+        assert!(
+            dir_set_diff(&pruned_too_much, &expected)
+                .unwrap()
+                .contains("pruned a file-bearing directory")
+        );
+        assert!(dir_set_diff(&expected, &expected).is_none());
+    }
+}

--- a/xtask/src/commands/validate/checks/relative.rs
+++ b/xtask/src/commands/validate/checks/relative.rs
@@ -1,0 +1,325 @@
+//! `-R` / `--relative` path-recreation parity between oc-rsync and upstream.
+//!
+//! With `-R`, rsync recreates the source-operand path components under the
+//! destination; the `/./` dot-root pivot in the operand marks where recreation
+//! begins. `--no-implied-dirs` suppresses recreating the implied leading dirs'
+//! attributes. This check transfers a source operand carrying a `/./` pivot
+//! (`<src>/./a/b/c/`) over every transport in `ctx.transports`, in two scenarios
+//! (`implied`, `no-implied`), and asserts oc-rsync's destination tree is byte-
+//! and structure-identical to upstream's and that the `-R` subpath was actually
+//! recreated. It builds the transfer commands directly rather than via
+//! `pull_into`, which would append a trailing `/` and its own operand and so
+//! could not carry the source-preserving `/./` path.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `-R` path-recreation parity check.
+pub struct Relative;
+
+/// The subpath after the `/./` pivot; `-R` recreates exactly this under dest.
+const SUBPATH: &str = "a/b/c";
+
+/// A leaf that must exist under the destination once `-R` recreates the path.
+/// Asserting it exists keeps the content compare non-vacuous.
+const RECREATED_LEAF: &str = "a/b/c/leaf.txt";
+
+/// One `-R` scenario: a report name and the exact rsync flag set.
+struct Scenario {
+    /// Short scenario name used in the cell label.
+    name: &'static str,
+    /// Complete rsync flag set for the transfer.
+    flags: &'static [&'static str],
+}
+
+/// The two `-R` variants exercised per transport.
+const SCENARIOS: [Scenario; 2] = [
+    Scenario {
+        name: "implied",
+        flags: &["-rlptgoD", "-R", "--numeric-ids"],
+    },
+    Scenario {
+        name: "no-implied",
+        flags: &["-rlptgoD", "-R", "--no-implied-dirs", "--numeric-ids"],
+    },
+];
+
+impl Check for Relative {
+    fn name(&self) -> &'static str {
+        "relative"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("relative");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+
+        let mut outcomes = Vec::new();
+        for &transport in ctx.transports {
+            for scenario in &SCENARIOS {
+                outcomes.push(self.cell(ctx, transport, scenario, &root, &src));
+            }
+        }
+        outcomes
+    }
+}
+
+impl Relative {
+    /// Run one (transport, scenario) cell for both clients and compare results.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        scenario: &Scenario,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = format!("{} {}", transport.label(), scenario.name);
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        // For the daemon cell the sender is one upstream `--daemon` shared by
+        // both runs; keep it alive until both transfers finish.
+        let daemon = match transport {
+            Transport::Daemon => match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), label, format!("daemon: {e}")),
+            },
+            _ => None,
+        };
+        let module_url = daemon.as_ref().map(|d| d.module_url());
+
+        let flags: Vec<String> = scenario.flags.iter().map(|s| s.to_string()).collect();
+        let up_dst = root.join(format!("up-{}-{}", transport.label(), scenario.name));
+        let oc_dst = root.join(format!("oc-{}-{}", transport.label(), scenario.name));
+
+        // Upstream reference runs over the transport upstream can speak (russh
+        // maps to the ssh subprocess); oc runs over the transport under test.
+        let up_transport = transport.for_upstream();
+        let up_operand = source_operand(up_transport, src, module_url.as_deref());
+        match transfer(
+            ctx.upstream,
+            ctx.upstream,
+            up_transport,
+            &up_operand,
+            &up_dst,
+            &flags,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &label, "upstream", other),
+        }
+
+        let oc_operand = source_operand(transport, src, module_url.as_deref());
+        match transfer(
+            ctx.oc,
+            ctx.upstream,
+            transport,
+            &oc_operand,
+            &oc_dst,
+            &flags,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &label, "oc", other),
+        }
+
+        drop(daemon);
+
+        // Non-vacuous: the `-R` path must actually have been recreated.
+        if !oc_dst.join(RECREATED_LEAF).exists() {
+            if ctx.verbose {
+                dump_entries(&oc_dst, &up_dst);
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("-R did not recreate {RECREATED_LEAF}"),
+            );
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            if ctx.verbose {
+                dump_entries(&oc_dst, &up_dst);
+            }
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Build the source operand carrying the `/./` dot-root pivot for `transport`.
+///
+/// The pivot marks where `-R` begins recreating path components, so everything
+/// after `/./` (here [`SUBPATH`]) is rebuilt under the destination. Only the
+/// daemon form needs `module_url` (its module already ends in `/m/`).
+fn source_operand(transport: Transport, src: &Path, module_url: Option<&str>) -> String {
+    match transport {
+        Transport::Local => format!("{}/./{SUBPATH}/", src.display()),
+        Transport::SshSubprocess => format!("localhost:{}/./{SUBPATH}/", src.display()),
+        Transport::Russh => format!("ssh://localhost{}/./{SUBPATH}/", src.display()),
+        Transport::Daemon => format!("{}./{SUBPATH}/", module_url.unwrap_or("")),
+    }
+}
+
+/// Reset `dst`, build the per-transport command, and run it capturing output.
+fn transfer(
+    client: &Path,
+    upstream: &Path,
+    transport: Transport,
+    operand: &str,
+    dst: &Path,
+    flags: &[String],
+) -> TaskResult<Output> {
+    reset_dir(dst)?;
+    let dst_arg = dst.display().to_string();
+    let mut cmd = build_command(client, upstream, transport, operand, &dst_arg, flags);
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("spawn rsync: {e}")))
+}
+
+/// Assemble the rsync command for `transport` with the source-preserving
+/// `operand` (not `pull_into`, whose trailing-slash operand would drop `-R`'s
+/// path). Network cells set the upstream sender via `--rsync-path`.
+fn build_command(
+    client: &Path,
+    upstream: &Path,
+    transport: Transport,
+    operand: &str,
+    dst_arg: &str,
+    flags: &[String],
+) -> Command {
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+    match transport {
+        Transport::Local | Transport::Daemon => {
+            cmd.arg(operand).arg(dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(operand)
+                .arg(dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(operand)
+                .arg(dst_arg);
+        }
+    }
+    cmd
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Print both destinations' entry lists for a verbose-mode mismatch.
+fn dump_entries(oc: &Path, up: &Path) {
+    eprintln!(
+        "[relative] oc {} -> {:?}",
+        oc.display(),
+        support::rel_entries(oc)
+    );
+    eprintln!(
+        "[relative] up {} -> {:?}",
+        up.display(),
+        support::rel_entries(up)
+    );
+}
+
+/// Build the nested `-R` fixture. Idempotent: removes any prior tree first.
+///
+/// Lays out `a/b/c/leaf.txt` and `a/b/other.txt`, then backdates every entry's
+/// mtime with GNU `touch` so the quick-check makes deterministic decisions.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let c = src.join("a").join("b").join("c");
+    std::fs::create_dir_all(&c).map_err(|e| e.to_string())?;
+
+    std::fs::write(c.join("leaf.txt"), b"leaf\n").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("a").join("b").join("other.txt"), b"other\n")
+        .map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SUBPATH, source_operand};
+    use crate::commands::validate::transport::Transport;
+    use std::path::Path;
+
+    #[test]
+    fn dot_root_pivot_is_placed_per_transport_form() {
+        let src = Path::new("/work/relative/src");
+        assert_eq!(
+            source_operand(Transport::Local, src, None),
+            "/work/relative/src/./a/b/c/"
+        );
+        assert_eq!(
+            source_operand(Transport::SshSubprocess, src, None),
+            "localhost:/work/relative/src/./a/b/c/"
+        );
+        assert_eq!(
+            source_operand(Transport::Russh, src, None),
+            "ssh://localhost/work/relative/src/./a/b/c/"
+        );
+        assert_eq!(
+            source_operand(Transport::Daemon, src, Some("rsync://127.0.0.1:9/m/")),
+            "rsync://127.0.0.1:9/m/./a/b/c/"
+        );
+    }
+
+    #[test]
+    fn daemon_operand_appends_pivot_after_the_module() {
+        // The module URL already ends in `/m/`; the pivot recreates SUBPATH.
+        let url = "rsync://127.0.0.1:873/m/";
+        let operand = source_operand(Transport::Daemon, Path::new("/unused"), Some(url));
+        assert!(operand.starts_with(url));
+        assert!(operand.ends_with(&format!("./{SUBPATH}/")));
+    }
+}

--- a/xtask/src/commands/validate/checks/remove_source_files.rs
+++ b/xtask/src/commands/validate/checks/remove_source_files.rs
@@ -1,0 +1,266 @@
+//! `--remove-source-files` source-deletion parity between oc-rsync and upstream.
+//!
+//! Upstream removes each *transferred regular file* from the sending side after
+//! it is delivered, but never removes directories - even ones it just emptied
+//! (`main.c` / `finish_transfer`). This check verifies oc-rsync deletes exactly
+//! the same source entries upstream does: the regular files disappear from both
+//! source trees while every directory survives in both.
+//!
+//! Because `--remove-source-files` mutates the source, no source tree can be
+//! shared between two runs. Every client run gets its own pristine copy of an
+//! identical layout (`f1.txt`, `sub/f2.txt`, and an empty `emptydir/`), so the
+//! only variable across a cell's two runs is the client under test.
+//!
+//! The daemon transport is skipped: the shared read-only module rejects
+//! `--remove-source-files` outright (upstream `main.c:938`), so removal cannot be
+//! exercised over it. For ssh/russh the sender - and therefore the remover - is
+//! always upstream, so those cells prove oc-as-receiver propagates the flag over
+//! the wire without disturbing the result; the `local` cell is the one that
+//! drives oc-rsync's own removal path.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The `--remove-source-files` source-deletion parity check.
+pub struct RemoveSourceFiles;
+
+/// Preserve metadata, remove transferred source files, itemize, numeric ids.
+const FLAGS: &[&str] = &["-rlptgoD", "--remove-source-files", "-i", "--numeric-ids"];
+
+/// Regular files that `--remove-source-files` must delete from the source.
+const REMOVED_FILES: [&str; 2] = ["f1.txt", "sub/f2.txt"];
+
+/// Directories that must survive in the source (rsync never removes dirs).
+const KEPT_DIRS: [&str; 2] = ["emptydir", "sub"];
+
+impl Check for RemoveSourceFiles {
+    fn name(&self) -> &'static str {
+        "remove-source-files"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("remove-source-files");
+        // A pristine reference of the delivered layout, never used as a transfer
+        // source, so it is never mutated by `--remove-source-files`.
+        let reference = root.join("expected");
+        if let Err(e) = build_source(&reference) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &reference, &flags))
+            .collect()
+    }
+}
+
+impl RemoveSourceFiles {
+    /// Run one transport cell: build two pristine sources, pull each into a
+    /// fresh dest, then compare delivered content and surviving source state.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        reference: &Path,
+        flags: &[String],
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport == Transport::Daemon {
+            return CheckOutcome::skip(
+                self.name(),
+                label,
+                "read-only daemon module rejects --remove-source-files (upstream main.c:938)",
+            );
+        }
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        // Fresh, identical source per client run; each run consumes its own.
+        let src_oc = root.join(format!("src-oc-{label}"));
+        let src_up = root.join(format!("src-up-{label}"));
+        if let Err(e) = build_source(&src_oc) {
+            return CheckOutcome::skip(self.name(), label, format!("oc source: {e}"));
+        }
+        if let Err(e) = build_source(&src_up) {
+            return CheckOutcome::skip(self.name(), label, format!("upstream source: {e}"));
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            &src_up,
+            &up_dst,
+            flags,
+            ctx.work,
+        );
+        if let Some(bad) = non_success(self.name(), label, "upstream", up) {
+            return bad;
+        }
+        let oc = pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            &src_oc,
+            &oc_dst,
+            flags,
+            ctx.work,
+        );
+        if let Some(bad) = non_success(self.name(), label, "oc", oc) {
+            return bad;
+        }
+
+        // Files were delivered: both dests equal the reference layout.
+        let expected = support::entry_count(reference);
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != expected");
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, reference) {
+            return CheckOutcome::fail(self.name(), label, format!("oc dest {diff}"));
+        }
+        if let Some(diff) = support::content_diff(&up_dst, reference) {
+            return CheckOutcome::fail(self.name(), label, format!("upstream dest {diff}"));
+        }
+
+        // Source removal parity: identical survivors, files gone, dirs kept.
+        let oc_src = rel_strings(&src_oc);
+        let up_src = rel_strings(&src_up);
+        if ctx.verbose {
+            eprintln!(
+                "[remove-source-files/{label}] oc survivors={oc_src:?} upstream survivors={up_src:?}"
+            );
+        }
+        match source_diff(&oc_src, &up_src) {
+            Some(diff) => CheckOutcome::fail(self.name(), label, diff),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// Sorted relative entries of `root` as strings, for set comparison.
+fn rel_strings(root: &Path) -> Vec<String> {
+    support::rel_entries(root)
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect()
+}
+
+/// First divergence between two post-transfer source trees, or `None` when they
+/// match and satisfy the non-vacuous facts: the removed files are absent from
+/// both and the kept directories are present in both.
+fn source_diff(oc: &[String], up: &[String]) -> Option<String> {
+    if oc != up {
+        return Some(format!(
+            "source survivors differ: oc={oc:?} upstream={up:?}"
+        ));
+    }
+    for f in REMOVED_FILES {
+        if oc.iter().any(|e| e == f) {
+            return Some(format!("source file {f} not removed"));
+        }
+    }
+    for d in KEPT_DIRS {
+        if !oc.iter().any(|e| e == d) {
+            return Some(format!("source dir {d} unexpectedly removed"));
+        }
+    }
+    None
+}
+
+/// Map a failed or unrunnable transfer to a fail/skip outcome; `None` on success.
+fn non_success(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: crate::error::TaskResult<std::process::Output>,
+) -> Option<CheckOutcome> {
+    match result {
+        Ok(out) if out.status.success() => None,
+        Ok(out) => {
+            let code = out.status.code().unwrap_or(-1);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            Some(CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            ))
+        }
+        Err(e) => Some(CheckOutcome::skip(
+            check,
+            label,
+            format!("{who} could not run: {e}"),
+        )),
+    }
+}
+
+/// Build one pristine source tree. Idempotent: removes any prior tree first.
+/// Layout: `f1.txt`, `sub/f2.txt`, and an empty `emptydir/`. Mtimes are backdated
+/// so rsync's quick-check does not skip the transfer.
+fn build_source(dir: &Path) -> Result<(), String> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    let sub = dir.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(dir.join("emptydir")).map_err(|e| e.to_string())?;
+
+    std::fs::write(dir.join("f1.txt"), b"one\n").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("f2.txt"), b"two\n").map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(dir) {
+        let path = dir.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::source_diff;
+
+    fn owned(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn matching_survivors_pass() {
+        let survivors = owned(&["emptydir", "sub"]);
+        assert!(source_diff(&survivors, &survivors).is_none());
+    }
+
+    #[test]
+    fn a_lingering_source_file_is_reported() {
+        let oc = owned(&["emptydir", "f1.txt", "sub"]);
+        let up = owned(&["emptydir", "f1.txt", "sub"]);
+        assert!(source_diff(&oc, &up).unwrap().contains("not removed"));
+    }
+
+    #[test]
+    fn a_removed_directory_is_reported() {
+        let both = owned(&["emptydir"]);
+        assert!(
+            source_diff(&both, &both)
+                .unwrap()
+                .contains("unexpectedly removed")
+        );
+    }
+
+    #[test]
+    fn diverging_survivor_sets_are_reported() {
+        let oc = owned(&["emptydir", "sub"]);
+        let up = owned(&["emptydir", "f1.txt", "sub"]);
+        assert!(source_diff(&oc, &up).unwrap().contains("survivors differ"));
+    }
+}

--- a/xtask/src/commands/validate/checks/rsync_path.rs
+++ b/xtask/src/commands/validate/checks/rsync_path.rs
@@ -1,0 +1,346 @@
+//! `--rsync-path` parity between oc-rsync and upstream over ssh.
+//!
+//! The `--rsync-path` option names the rsync binary to launch on the remote
+//! end, so it is only meaningful for the ssh transports (a local copy and the
+//! daemon transport never spawn a remote rsync). This check exercises the
+//! ssh-subprocess and russh transports with two scenarios per transport:
+//!
+//! - `honored`: point `--rsync-path` at a wrapper script that records a
+//!   per-run sentinel and then execs the real upstream rsync. Both clients must
+//!   exit 0, both sentinels must exist afterward (proving the named binary
+//!   really ran), and the two destination trees must be identical. This proves
+//!   oc invokes the `--rsync-path` binary exactly as upstream does.
+//! - `missing`: point `--rsync-path` at a path that does not exist. Both clients
+//!   must fail (non-zero exit) - oc must not silently succeed when the remote
+//!   binary is absent. Exit codes and messages need not match, only that both
+//!   are failures.
+//!
+//! Because upstream rsync has no embedded russh client, the reference (upstream)
+//! run of the russh cell uses the ssh subprocess instead
+//! ([`Transport::for_upstream`]); the client under test still exercises the
+//! `ssh://` code path. Commands are built directly here rather than through
+//! `pull_into`, which hard-codes its own `--rsync-path`.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::Transport;
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `--rsync-path` fidelity check.
+pub struct RsyncPath;
+
+/// Base flags shared by both scenarios (recursive, symlinks, perms, times,
+/// group, owner, devices; numeric ids to avoid name-mapping differences).
+const BASE_FLAGS: [&str; 2] = ["-rlptgoD", "--numeric-ids"];
+
+/// A remote rsync path guaranteed not to exist, for the negative scenario.
+const MISSING_RSYNC_PATH: &str = "/nonexistent/oc-rsync-does-not-exist";
+
+impl Check for RsyncPath {
+    fn name(&self) -> &'static str {
+        "rsync-path"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let ssh_transports: Vec<Transport> = ctx
+            .transports
+            .iter()
+            .copied()
+            .filter(|t| t.needs_ssh())
+            .collect();
+        if ssh_transports.is_empty() {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                "transports",
+                "no ssh transport selected",
+            )];
+        }
+
+        let root = ctx.work.join("rsync-path");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let wrapper = root.join("wrapper.sh");
+
+        let mut outcomes = Vec::new();
+        for transport in ssh_transports {
+            outcomes.push(self.honored(ctx, &root, &src, &wrapper, transport));
+            outcomes.push(self.missing(ctx, &root, &src, transport));
+        }
+        outcomes
+    }
+}
+
+impl RsyncPath {
+    /// Positive scenario: `--rsync-path` names the sentinel wrapper. Both clients
+    /// must exit 0, both sentinels must exist, and the trees must match.
+    fn honored(
+        &self,
+        ctx: &ValidateCtx,
+        root: &Path,
+        src: &Path,
+        wrapper: &Path,
+        transport: Transport,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        let cell = format!("{label} honored");
+        if !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), cell, "no sshd on localhost:22");
+        }
+
+        let flags = honored_flags(wrapper);
+        let up_dst = root.join(format!("up-{label}"));
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_sentinel = root.join(format!("sentinel-{label}-up"));
+        let oc_sentinel = root.join(format!("sentinel-{label}-oc"));
+
+        if let Err(e) = arm_wrapper(wrapper, ctx.upstream, &up_sentinel) {
+            return CheckOutcome::skip(self.name(), cell, e.to_string());
+        }
+        let up = match run_plain(ctx.upstream, transport.for_upstream(), &flags, src, &up_dst) {
+            Ok(out) => out,
+            Err(e) => return CheckOutcome::skip(self.name(), cell, e.to_string()),
+        };
+        if let Err(e) = arm_wrapper(wrapper, ctx.upstream, &oc_sentinel) {
+            return CheckOutcome::skip(self.name(), cell, e.to_string());
+        }
+        let oc = match run_plain(ctx.oc, transport, &flags, src, &oc_dst) {
+            Ok(out) => out,
+            Err(e) => return CheckOutcome::skip(self.name(), cell, e.to_string()),
+        };
+
+        let (up_hit, oc_hit) = (up_sentinel.exists(), oc_sentinel.exists());
+        if ctx.verbose {
+            eprintln!(
+                "[rsync-path/{cell}] oc exit={:?} sentinel={oc_hit}; upstream exit={:?} sentinel={up_hit}",
+                oc.status.code(),
+                up.status.code()
+            );
+        }
+
+        if !oc.status.success() || !up.status.success() {
+            return CheckOutcome::fail(
+                self.name(),
+                cell,
+                format!(
+                    "expected both to honor --rsync-path but oc exit={:?} upstream exit={:?}",
+                    oc.status.code(),
+                    up.status.code()
+                ),
+            );
+        }
+        if !oc_hit || !up_hit {
+            return CheckOutcome::fail(
+                self.name(),
+                cell,
+                format!(
+                    "custom rsync-path binary did not run (oc sentinel={oc_hit}, upstream sentinel={up_hit})"
+                ),
+            );
+        }
+        match support::content_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), cell, diff),
+            None => CheckOutcome::pass(self.name(), cell),
+        }
+    }
+
+    /// Negative scenario: `--rsync-path` names a nonexistent binary. Both clients
+    /// must fail; oc must not silently succeed.
+    fn missing(
+        &self,
+        ctx: &ValidateCtx,
+        root: &Path,
+        src: &Path,
+        transport: Transport,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        let cell = format!("{label} missing");
+        if !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), cell, "no sshd on localhost:22");
+        }
+
+        let flags = missing_flags();
+        let up_dst = root.join(format!("up-{label}-missing"));
+        let oc_dst = root.join(format!("oc-{label}-missing"));
+
+        let up = match run_plain(ctx.upstream, transport.for_upstream(), &flags, src, &up_dst) {
+            Ok(out) => out,
+            Err(e) => return CheckOutcome::skip(self.name(), cell, e.to_string()),
+        };
+        let oc = match run_plain(ctx.oc, transport, &flags, src, &oc_dst) {
+            Ok(out) => out,
+            Err(e) => return CheckOutcome::skip(self.name(), cell, e.to_string()),
+        };
+
+        if ctx.verbose {
+            eprintln!(
+                "[rsync-path/{cell}] oc exit={:?} upstream exit={:?}",
+                oc.status.code(),
+                up.status.code()
+            );
+        }
+
+        if oc.status.success() || up.status.success() {
+            return CheckOutcome::fail(
+                self.name(),
+                cell,
+                format!(
+                    "expected both to fail on missing --rsync-path but oc exit={:?} upstream exit={:?}",
+                    oc.status.code(),
+                    up.status.code()
+                ),
+            );
+        }
+        CheckOutcome::pass(self.name(), cell)
+    }
+}
+
+/// Flags for the positive scenario: base flags plus `--rsync-path=<wrapper>`.
+fn honored_flags(wrapper: &Path) -> Vec<String> {
+    let mut flags: Vec<String> = BASE_FLAGS.iter().map(|s| s.to_string()).collect();
+    flags.push(format!("--rsync-path={}", wrapper.display()));
+    flags
+}
+
+/// Flags for the negative scenario: base flags plus a nonexistent `--rsync-path`.
+fn missing_flags() -> Vec<String> {
+    let mut flags: Vec<String> = BASE_FLAGS.iter().map(|s| s.to_string()).collect();
+    flags.push(format!("--rsync-path={MISSING_RSYNC_PATH}"));
+    flags
+}
+
+/// Rewrite the wrapper for this run's sentinel and clear that sentinel, so its
+/// post-run existence proves the wrapper executed.
+fn arm_wrapper(wrapper: &Path, upstream: &Path, sentinel: &Path) -> TaskResult<()> {
+    write_wrapper(wrapper, upstream, sentinel)?;
+    let _ = std::fs::remove_file(sentinel);
+    Ok(())
+}
+
+/// Reset the destination and pull `src` over an ssh transport.
+fn run_plain(
+    client: &Path,
+    transport: Transport,
+    flags: &[String],
+    src: &Path,
+    dst: &Path,
+) -> TaskResult<Output> {
+    reset_dir(dst)?;
+    run(ssh_command(client, transport, flags, src, dst))
+}
+
+/// Build a pull command for `client` over an ssh transport.
+///
+/// `flags` already carries `--rsync-path`; only the ssh operands are added here.
+/// The ssh-subprocess form uses `-e ssh ... localhost:<src>/`; the russh form
+/// uses an `ssh://localhost<src>/` URL with no `-e`.
+fn ssh_command(
+    client: &Path,
+    transport: Transport,
+    flags: &[String],
+    src: &Path,
+    dst: &Path,
+) -> Command {
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+    let dst_arg = format!("{}/", dst.display());
+    match transport {
+        Transport::Russh => {
+            cmd.arg(format!("ssh://localhost{}/", src.display()))
+                .arg(dst_arg);
+        }
+        _ => {
+            cmd.arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(dst_arg);
+        }
+    }
+    cmd
+}
+
+/// Run a prepared command, capturing combined output.
+fn run(mut cmd: Command) -> TaskResult<Output> {
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// The wrapper script body: record `sentinel`, then exec the real `upstream`.
+fn wrapper_script(upstream: &Path, sentinel: &Path) -> String {
+    format!(
+        "#!/bin/sh\ntouch \"{}\"\nexec \"{}\" \"$@\"\n",
+        sentinel.display(),
+        upstream.display()
+    )
+}
+
+/// Write the wrapper script and mark it executable (0o755).
+fn write_wrapper(wrapper: &Path, upstream: &Path, sentinel: &Path) -> TaskResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::write(wrapper, wrapper_script(upstream, sentinel))
+        .map_err(|e| TaskError::Validation(format!("write wrapper {}: {e}", wrapper.display())))?;
+    std::fs::set_permissions(wrapper, std::fs::Permissions::from_mode(0o755))
+        .map_err(|e| TaskError::Validation(format!("chmod wrapper {}: {e}", wrapper.display())))
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Build the fixture: two top-level files and a subdirectory with one file.
+/// Idempotent: removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("alpha.txt"), b"alpha\n").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("bravo.txt"), b"bravo\n").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("charlie.txt"), b"charlie\n").map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{honored_flags, missing_flags, wrapper_script};
+    use std::path::Path;
+
+    #[test]
+    fn wrapper_script_records_sentinel_then_execs_upstream() {
+        let script = wrapper_script(Path::new("/usr/bin/rsync"), Path::new("/tmp/sentinel-x"));
+        assert!(script.starts_with("#!/bin/sh\n"));
+        assert!(script.contains("touch \"/tmp/sentinel-x\""));
+        assert!(script.contains("exec \"/usr/bin/rsync\" \"$@\""));
+    }
+
+    #[test]
+    fn honored_flags_point_rsync_path_at_the_wrapper() {
+        let flags = honored_flags(Path::new("/work/wrapper.sh"));
+        assert!(flags.contains(&"-rlptgoD".to_string()));
+        assert!(flags.contains(&"--numeric-ids".to_string()));
+        assert!(flags.contains(&"--rsync-path=/work/wrapper.sh".to_string()));
+    }
+
+    #[test]
+    fn missing_flags_point_rsync_path_at_a_nonexistent_binary() {
+        let flags = missing_flags();
+        assert!(flags.contains(&"-rlptgoD".to_string()));
+        assert!(
+            flags
+                .iter()
+                .any(|f| f.starts_with("--rsync-path=/nonexistent/"))
+        );
+    }
+}

--- a/xtask/src/commands/validate/checks/sparse.rs
+++ b/xtask/src/commands/validate/checks/sparse.rs
@@ -1,0 +1,254 @@
+//! Sparse-file parity between oc-rsync and upstream under `-S`/`--sparse`.
+//!
+//! Builds a fixture holding a mostly-hole file (`holey.dat`) plus a small dense
+//! control (`dense.txt`), then pulls it with each client over every transport
+//! and asserts oc's destination is byte-identical to upstream's *and* that oc
+//! preserved the hole: its allocated block count stays close to upstream's and
+//! far below the file's logical size, proving it did not write the hole as
+//! zeros. When the work filesystem refuses to store the source sparsely the
+//! whole check degrades to a single skip.
+
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The sparse-file parity check.
+pub struct Sparse;
+
+/// Preserve metadata a non-root user can and request sparse writes with `-S`.
+const FLAGS: &[&str] = &["-rlptgoD", "-S", "--numeric-ids"];
+
+/// Logical hole size, in bytes, punched into `holey.dat` (1 MiB). Large enough
+/// that a client writing the hole as zeros allocates dramatically more blocks
+/// than one that leaves it unwritten.
+const HOLE: u64 = 1 << 20;
+
+/// Slack, in 512-byte `blocks()` units, allowed between two equivalently sparse
+/// copies. One 4 KiB filesystem block is eight units; this permits a couple of
+/// blocks of allocator/rounding difference between the two clients while still
+/// rejecting a copy that materialised the whole hole.
+const BLOCK_TOLERANCE: u64 = 16;
+
+impl Check for Sparse {
+    fn name(&self) -> &'static str {
+        "sparse"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("sparse");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        match sparse_support(&src.join("holey.dat")) {
+            Ok(true) => {}
+            Ok(false) => {
+                return vec![CheckOutcome::skip(
+                    self.name(),
+                    "support",
+                    "work filesystem does not store sparse files",
+                )];
+            }
+            Err(e) => return vec![CheckOutcome::skip(self.name(), "support", e)],
+        }
+        let expected = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &flags, expected))
+            .collect()
+    }
+}
+
+impl Sparse {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        flags: &[String],
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let src = root.join("src");
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            &src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let _ = up;
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            &src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+        let _ = oc;
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+        // Logical bytes (holes included) must be identical to upstream.
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+
+        let (o_blocks, sz) = match blocks_and_len(&oc_dst.join("holey.dat")) {
+            Ok(v) => v,
+            Err(e) => return CheckOutcome::fail(self.name(), label, e),
+        };
+        let (u_blocks, _) = match blocks_and_len(&up_dst.join("holey.dat")) {
+            Ok(v) => v,
+            Err(e) => return CheckOutcome::fail(self.name(), label, e),
+        };
+        if ctx.verbose {
+            eprintln!(
+                "[sparse/{label}] oc blocks={o_blocks} size={sz}; upstream blocks={u_blocks}"
+            );
+        }
+        // Sparseness proof: oc allocated far below the logical size, and stayed
+        // within filesystem-rounding tolerance of upstream's block count.
+        if is_stored_sparse(o_blocks, sz) && blocks_within_tolerance(o_blocks, u_blocks) {
+            CheckOutcome::pass(self.name(), label)
+        } else {
+            CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("blocks oc={o_blocks} upstream={u_blocks} size={sz}"),
+            )
+        }
+    }
+}
+
+/// True when a `len`-byte file occupying `blocks` 512-byte units is physically
+/// sparse: its allocated bytes are strictly fewer than its logical size, so at
+/// least one hole was left unwritten.
+fn is_stored_sparse(blocks: u64, len: u64) -> bool {
+    blocks.saturating_mul(512) < len
+}
+
+/// True when two allocated-block counts differ by at most [`BLOCK_TOLERANCE`]
+/// 512-byte units - i.e. the two copies are equivalently sparse aside from
+/// filesystem rounding.
+fn blocks_within_tolerance(oc_blocks: u64, up_blocks: u64) -> bool {
+    oc_blocks.abs_diff(up_blocks) <= BLOCK_TOLERANCE
+}
+
+/// Probe whether the work filesystem stored the source `holey.dat` sparsely.
+fn sparse_support(holey: &Path) -> Result<bool, String> {
+    let meta = holey.symlink_metadata().map_err(|e| e.to_string())?;
+    Ok(is_stored_sparse(meta.blocks(), meta.len()))
+}
+
+/// Allocated 512-byte block count and logical length of `path`.
+fn blocks_and_len(path: &Path) -> Result<(u64, u64), String> {
+    let meta = path.symlink_metadata().map_err(|e| e.to_string())?;
+    Ok((meta.blocks(), meta.len()))
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the sparse fixture. Idempotent: removes any prior tree first. Writes a
+/// mostly-hole file whose logical size is ~1 MiB but whose written data is a
+/// few bytes at each end, plus a small dense control file.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src).map_err(|e| e.to_string())?;
+
+    write_holey(&src.join("holey.dat"))?;
+    std::fs::write(src.join("dense.txt"), b"dense control payload\n").map_err(|e| e.to_string())?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Create a genuinely sparse file: a few header bytes, a [`HOLE`]-byte gap left
+/// unwritten via `seek`, then a few trailer bytes. Logical size is `HOLE + 8`
+/// but only the two ends occupy blocks.
+fn write_holey(path: &Path) -> Result<(), String> {
+    use std::io::{Seek, SeekFrom, Write};
+    let mut f = std::fs::File::create(path).map_err(|e| e.to_string())?;
+    f.write_all(b"HEAD\0\0\0\0").map_err(|e| e.to_string())?;
+    f.seek(SeekFrom::Start(HOLE)).map_err(|e| e.to_string())?;
+    f.write_all(b"TAILTAIL").map_err(|e| e.to_string())?;
+    f.sync_all().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BLOCK_TOLERANCE, blocks_within_tolerance, is_stored_sparse};
+
+    #[test]
+    fn sparse_only_when_allocated_bytes_below_logical_size() {
+        // 8 units * 512 = 4 KiB allocated for a 1 MiB logical file -> sparse.
+        assert!(is_stored_sparse(8, 1 << 20));
+        // Allocating the full length (2048 * 512 == 1 MiB) is not sparse.
+        assert!(!is_stored_sparse(2048, 1 << 20));
+        // Boundary: exactly len allocated is dense, not sparse.
+        assert!(!is_stored_sparse(2, 1024));
+    }
+
+    #[test]
+    fn tolerance_absorbs_rounding_but_rejects_a_filled_hole() {
+        assert!(blocks_within_tolerance(8, 8));
+        assert!(blocks_within_tolerance(8, 8 + BLOCK_TOLERANCE));
+        assert!(blocks_within_tolerance(8 + BLOCK_TOLERANCE, 8));
+        assert!(!blocks_within_tolerance(8, 8 + BLOCK_TOLERANCE + 1));
+        // A copy that wrote the 1 MiB hole as zeros allocates far more blocks.
+        assert!(!blocks_within_tolerance(2048, 8));
+    }
+}

--- a/xtask/src/commands/validate/checks/special_bits.rs
+++ b/xtask/src/commands/validate/checks/special_bits.rs
@@ -1,0 +1,286 @@
+//! Setuid / setgid / sticky bit parity between oc-rsync and upstream.
+//!
+//! Builds a fixture whose entries carry the special permission bits (setuid
+//! `04000`, setgid `02000`, sticky `01000`), pulls it with each client over
+//! every transport, and asserts oc's destination preserves those bits exactly
+//! as upstream does. Some filesystems silently strip setuid/setgid on write, so
+//! the check probes the work filesystem first and skips gracefully when the bits
+//! cannot survive locally.
+
+use std::collections::BTreeMap;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The special-permission-bit parity check.
+pub struct SpecialBits;
+
+/// Preserve perms/owner/group without hardlinks; `-p` inside `-rlptgoD` carries
+/// the full mode word, including the setuid/setgid/sticky bits.
+const FLAGS: &[&str] = &["-rlptgoD", "--numeric-ids"];
+
+impl Check for SpecialBits {
+    fn name(&self) -> &'static str {
+        "special-bits"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("special-bits");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        // Support probe: skip the whole matrix if the work fs cannot hold the
+        // setuid/setgid bits we are about to compare.
+        if !fs_preserves_special_bits(&src) {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                "support",
+                "filesystem strips setuid/setgid",
+            )];
+        }
+        let expected = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src, &flags, expected))
+            .collect()
+    }
+}
+
+impl SpecialBits {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        flags: &[String],
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let _ = up;
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+        let _ = oc;
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+        // Non-vacuous guard: the special bits must actually be present in oc's
+        // destination, so a symmetric both-sides-drop bug still fails the check.
+        if let Some(missing) = missing_special_bit(&oc_dst) {
+            return CheckOutcome::fail(self.name(), label, missing);
+        }
+        match mode_diff(&oc_dst, &up_dst) {
+            Some(diff) => {
+                if ctx.verbose {
+                    dump_modes(&oc_dst, &up_dst);
+                }
+                CheckOutcome::fail(self.name(), label, diff)
+            }
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// Map a tree to per-entry `mode & 0o7777` for comparison.
+fn mode_map(root: &Path) -> BTreeMap<PathBuf, u32> {
+    support::rel_entries(root)
+        .into_iter()
+        .filter_map(|rel| {
+            let meta = root.join(&rel).symlink_metadata().ok()?;
+            Some((rel, meta.mode() & 0o7777))
+        })
+        .collect()
+}
+
+/// First permission-word divergence between two trees, or `None` when identical.
+fn mode_diff(oc: &Path, up: &Path) -> Option<String> {
+    let (a, b) = (mode_map(oc), mode_map(up));
+    for (rel, oc_mode) in &a {
+        match b.get(rel) {
+            None => return Some(format!("missing {} in upstream tree", rel.display())),
+            Some(up_mode) if up_mode != oc_mode => {
+                return Some(format!(
+                    "mode differs at {}: oc={:04o} upstream={:04o}",
+                    rel.display(),
+                    oc_mode,
+                    up_mode
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+    None
+}
+
+/// Report the first special bit that failed to arrive in `dst`, or `None` when
+/// both the setuid file and setgid file kept their marker bit.
+fn missing_special_bit(dst: &Path) -> Option<String> {
+    if !has_bit(&dst.join("suid_file"), 0o4000) {
+        return Some("suid_file lost the setuid bit in oc destination".into());
+    }
+    if !has_bit(&dst.join("sgid_file"), 0o2000) {
+        return Some("sgid_file lost the setgid bit in oc destination".into());
+    }
+    None
+}
+
+/// True when `path` exists and `mode & bit` is set.
+fn has_bit(path: &Path, bit: u32) -> bool {
+    path.symlink_metadata()
+        .map(|m| m.mode() & bit == bit)
+        .unwrap_or(false)
+}
+
+/// Print each entry's oc/upstream permission word for verbose diagnostics.
+fn dump_modes(oc: &Path, up: &Path) {
+    let (a, b) = (mode_map(oc), mode_map(up));
+    for (rel, oc_mode) in &a {
+        let up_mode = b.get(rel).copied().unwrap_or(0);
+        eprintln!(
+            "    {}: oc={:04o} upstream={:04o}",
+            rel.display(),
+            oc_mode,
+            up_mode
+        );
+    }
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Re-stat the fixture's setuid/setgid files; the work filesystem preserves the
+/// bits only when both markers survived the initial `chmod`.
+fn fs_preserves_special_bits(src: &Path) -> bool {
+    has_bit(&src.join("suid_file"), 0o4000) && has_bit(&src.join("sgid_file"), 0o2000)
+}
+
+/// Build the special-bits fixture. Idempotent: removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src).map_err(|e| e.to_string())?;
+
+    write_mode(&src.join("suid_file"), b"setuid", 0o4755)?;
+    write_mode(&src.join("sgid_file"), b"setgid", 0o2755)?;
+    write_mode(&src.join("normal"), b"control", 0o644)?;
+
+    let sub_sgid = src.join("sub_sgid");
+    std::fs::create_dir_all(&sub_sgid).map_err(|e| e.to_string())?;
+    write_mode(&sub_sgid.join("inside"), b"plain", 0o644)?;
+    set_mode(&sub_sgid, 0o2775)?;
+
+    let sticky = src.join("sticky");
+    std::fs::create_dir_all(&sticky).map_err(|e| e.to_string())?;
+    set_mode(&sticky, 0o1777)?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn write_mode(path: &Path, bytes: &[u8], mode: u32) -> Result<(), String> {
+    std::fs::write(path, bytes).map_err(|e| e.to_string())?;
+    set_mode(path, mode)
+}
+
+fn set_mode(path: &Path, mode: u32) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mode_diff, set_mode};
+    use std::fs;
+
+    #[test]
+    fn mode_diff_none_for_identical_special_bits() {
+        let (a, b) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        for root in [a.path(), b.path()] {
+            let f = root.join("suid");
+            fs::write(&f, b"x").unwrap();
+            // Explicit set_permissions on both sides - no GNU `touch -d @epoch`.
+            set_mode(&f, 0o4755).unwrap();
+        }
+        assert!(mode_diff(a.path(), b.path()).is_none());
+    }
+
+    #[test]
+    fn mode_diff_names_the_diverging_entry_and_modes() {
+        let (a, b) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        let (fa, fb) = (a.path().join("sgid"), b.path().join("sgid"));
+        fs::write(&fa, b"x").unwrap();
+        fs::write(&fb, b"x").unwrap();
+        set_mode(&fa, 0o2755).unwrap();
+        set_mode(&fb, 0o0755).unwrap();
+        let diff = mode_diff(a.path(), b.path()).unwrap();
+        assert!(diff.contains("sgid"));
+        assert!(diff.contains("oc=2755"));
+        assert!(diff.contains("upstream=0755"));
+    }
+}

--- a/xtask/src/commands/validate/checks/stats.rs
+++ b/xtask/src/commands/validate/checks/stats.rs
@@ -1,0 +1,284 @@
+//! `--stats` accounting parity between oc-rsync and upstream.
+//!
+//! Pulls a fixed tree with each client over every transport and asserts that
+//! oc-rsync's `--stats` summary reports the same *deterministic* accounting as
+//! upstream. Upstream prints the block from `main.c:output_summary()`; only the
+//! fields that are a pure function of the input tree are compared. Timing,
+//! throughput, wire-byte, and delta-dependent fields legitimately differ run to
+//! run and are deliberately excluded (see `DETERMINISTIC_LABELS` below).
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The `--stats` accounting parity check.
+pub struct Stats;
+
+/// Recursive archive subset plus statistics and numeric ids.
+///
+/// `-rlptgoD` is `-a` without `-A`/`-X`, keeping the run portable across hosts
+/// that lack ACL/xattr support; `--numeric-ids` keeps id mapping out of the
+/// picture so counts stay deterministic; `--stats` prints the summary block.
+const FLAGS: &[&str] = &["-rlptgoD", "--stats", "--numeric-ids"];
+
+/// Summary labels whose values are a pure function of the input tree and so
+/// must match upstream byte-for-byte for identical inputs.
+///
+/// - `Number of files` - total plus the `(reg: R, dir: D, link: L)` breakdown.
+/// - `Number of created files` - every entry is new in a fresh pull.
+/// - `Number of deleted files` - `0` here (no `--delete`), but still emitted.
+/// - `Number of regular files transferred` - the regular-file count.
+/// - `Total file size` - summed `S_ISREG || S_ISLNK` bytes.
+///
+/// Deliberately excluded because they are timing, throughput, wire, or
+/// delta dependent and may differ for identical inputs: `File list generation
+/// time`, `File list transfer time`, `Total bytes sent`, `Total bytes
+/// received`, `Literal data`, `Matched data`, `File list size`, and
+/// `Total transferred file size` (a transfer-decision artifact, not part of the
+/// contracted compare set).
+const DETERMINISTIC_LABELS: &[&str] = &[
+    "Number of files",
+    "Number of created files",
+    "Number of deleted files",
+    "Number of regular files transferred",
+    "Total file size",
+];
+
+/// Labels that must be present on both sides for the check to be non-vacuous.
+const REQUIRED_LABELS: &[&str] = &["Number of files", "Total file size"];
+
+impl Check for Stats {
+    fn name(&self) -> &'static str {
+        "stats"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("stats");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected_entries = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src, &flags, expected_entries))
+            .collect()
+    }
+}
+
+impl Stats {
+    /// Run one transport cell: pull with oc and upstream, then compare fields.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        flags: &[String],
+        expected_entries: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected_entries
+            || support::entry_count(&oc_dst) != expected_entries
+        {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+
+        let up_fields = stat_fields(&String::from_utf8_lossy(&up.stdout));
+        let oc_fields = stat_fields(&String::from_utf8_lossy(&oc.stdout));
+
+        if ctx.verbose {
+            eprintln!("[stats/{label}] oc={oc_fields:?} upstream={up_fields:?}");
+        }
+
+        // Non-vacuous guard: the anchor fields must have parsed on both sides.
+        for req in REQUIRED_LABELS {
+            if !oc_fields.contains_key(*req) || !up_fields.contains_key(*req) {
+                return CheckOutcome::skip(self.name(), label, "stats fields not found");
+            }
+        }
+
+        for field in DETERMINISTIC_LABELS {
+            let oc_val = oc_fields.get(*field);
+            let up_val = up_fields.get(*field);
+            if oc_val != up_val {
+                let oc_disp = oc_val.map(String::as_str).unwrap_or("(absent)");
+                let up_disp = up_val.map(String::as_str).unwrap_or("(absent)");
+                return CheckOutcome::fail(
+                    self.name(),
+                    label,
+                    format!("{field}: oc={oc_disp} upstream={up_disp}"),
+                );
+            }
+        }
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Extract the deterministic `--stats` fields as label -> normalized value.
+///
+/// Keys are the text before the first colon; values are the remainder with any
+/// grouping commas removed, a trailing ` bytes` unit dropped, and surrounding
+/// whitespace trimmed. Only [`DETERMINISTIC_LABELS`] are retained, so the map
+/// never carries timing or throughput noise. The `Number of files` family keeps
+/// its `(reg: R, dir: D, link: L)` breakdown in the value, so the per-type
+/// counts are compared alongside the total.
+pub fn stat_fields(stdout: &str) -> BTreeMap<String, String> {
+    let mut fields = BTreeMap::new();
+    for line in stdout.lines() {
+        let Some((label, rest)) = line.split_once(':') else {
+            continue;
+        };
+        let label = label.trim();
+        if DETERMINISTIC_LABELS.contains(&label) {
+            fields.insert(label.to_string(), normalize_value(rest));
+        }
+    }
+    fields
+}
+
+/// Normalize a stats value: drop a trailing ` bytes` unit and grouping commas.
+fn normalize_value(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let unitless = trimmed.strip_suffix("bytes").unwrap_or(trimmed).trim_end();
+    unitless.chars().filter(|c| *c != ',').collect::<String>()
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the deterministic fixture tree under `src`.
+///
+/// Regular files of known sizes, two subdirectories, and one symlink, with every
+/// entry backdated to a fixed epoch so the quick-check never skips a transfer.
+/// Idempotent: removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub1 = src.join("sub1");
+    let sub2 = src.join("sub2");
+    std::fs::create_dir_all(&sub1).map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(&sub2).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("f1"), b"alpha-file-contents").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("f2"), b"bravo").map_err(|e| e.to_string())?;
+    std::fs::write(sub1.join("f3"), b"charlie-in-sub1").map_err(|e| e.to_string())?;
+    std::fs::write(sub2.join("f4"), b"delta-in-sub2-larger-payload").map_err(|e| e.to_string())?;
+
+    std::os::unix::fs::symlink("../f1", sub1.join("link")).map_err(|e| e.to_string())?;
+
+    for rel in support::rel_entries(src) {
+        let path = src.join(&rel);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_value, stat_fields};
+
+    /// A representative upstream `--stats` block for a small tree.
+    const SAMPLE: &str = "\nNumber of files: 7 (reg: 4, dir: 3, link: 1)\n\
+        Number of created files: 7 (reg: 4, dir: 3, link: 1)\n\
+        Number of deleted files: 0\n\
+        Number of regular files transferred: 4\n\
+        Total file size: 1,234 bytes\n\
+        Total transferred file size: 1,234 bytes\n\
+        Literal data: 1,234 bytes\n\
+        Matched data: 0 bytes\n\
+        File list size: 210\n\
+        File list generation time: 0.001 seconds\n\
+        File list transfer time: 0.000 seconds\n\
+        Total bytes sent: 512\n\
+        Total bytes received: 90\n";
+
+    #[test]
+    fn extracts_only_deterministic_fields() {
+        let f = stat_fields(SAMPLE);
+        assert_eq!(f["Number of files"], "7 (reg: 4 dir: 3 link: 1)");
+        assert_eq!(f["Number of created files"], "7 (reg: 4 dir: 3 link: 1)");
+        assert_eq!(f["Number of deleted files"], "0");
+        assert_eq!(f["Number of regular files transferred"], "4");
+        assert_eq!(f["Total file size"], "1234");
+        // Excluded noisy fields never enter the map.
+        assert!(!f.contains_key("Total transferred file size"));
+        assert!(!f.contains_key("Literal data"));
+        assert!(!f.contains_key("File list size"));
+        assert!(!f.contains_key("Total bytes sent"));
+        assert!(!f.contains_key("File list generation time"));
+    }
+
+    #[test]
+    fn normalize_strips_bytes_unit_and_grouping_commas() {
+        assert_eq!(normalize_value(" 1,234,567 bytes"), "1234567");
+        assert_eq!(normalize_value(" 0"), "0");
+        assert_eq!(normalize_value(" 7 (reg: 4, dir: 3)"), "7 (reg: 4 dir: 3)");
+    }
+
+    #[test]
+    fn missing_stats_block_yields_empty_map() {
+        let out = "sent 200 bytes  received 90 bytes  580.00 bytes/sec\n";
+        assert!(stat_fields(out).is_empty());
+    }
+}

--- a/xtask/src/commands/validate/checks/symlinks.rs
+++ b/xtask/src/commands/validate/checks/symlinks.rs
@@ -121,6 +121,20 @@ impl Symlinks {
                 "daemon munges symlinks; --safe-links drops every link",
             );
         }
+        // Over a daemon, `-L` dereferences the `unsafe -> ../outside` link, whose
+        // target escapes the module. upstream's sender then refuses to open it
+        // ("Invalid cross-device link (18)"), so the cell can never succeed. This
+        // is the daemon module boundary, not an oc divergence.
+        if matches!(
+            (transport, scenario),
+            (Transport::Daemon, Scenario::CopyLinks)
+        ) {
+            return CheckOutcome::skip(
+                self.name(),
+                label,
+                "daemon module boundary blocks -L on a symlink pointing outside the module",
+            );
+        }
 
         let root = ctx.work.join("symlinks");
         let src = root.join("src");

--- a/xtask/src/commands/validate/checks/symlinks.rs
+++ b/xtask/src/commands/validate/checks/symlinks.rs
@@ -1,0 +1,369 @@
+//! Symlink-handling parity between oc-rsync and upstream.
+//!
+//! Builds a fixture holding a real file, a safe relative symlink, a symlink into
+//! a subdirectory, an unsafe symlink whose target escapes the tree, and a
+//! directory symlink, then pulls it with each client over every transport under
+//! three symlink modes:
+//!
+//! - `preserve` (`-l`, inside `-rlptgoD`): symlinks are copied verbatim as
+//!   symlinks, never dereferenced.
+//! - `safe-links` (`--safe-links`): the outside-pointing symlink is dropped by
+//!   both clients while the safe links survive.
+//! - `copy-links` (`-L`): every symlink is dereferenced into a regular copy of
+//!   its target.
+//!
+//! Each cell asserts oc's destination is entry-for-entry identical to upstream's
+//! via [`support::content_diff`] (which already compares symlink targets) and
+//! adds a mode-specific, non-vacuous guard so the comparison cannot pass on two
+//! degenerate trees.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The symlink-handling parity check.
+pub struct Symlinks;
+
+/// Body of the real file every safe symlink resolves to.
+const TARGET_BODY: &[u8] = b"target-body";
+/// Body of the nested real file `sub/inner.txt`.
+const INNER_BODY: &[u8] = b"inner-body";
+/// Body of the referent that lives outside the transfer root.
+const OUTSIDE_BODY: &[u8] = b"outside-body";
+
+/// One symlink-handling mode under test.
+#[derive(Clone, Copy)]
+enum Scenario {
+    /// `-l` (inside `-rlptgoD`): copy symlinks verbatim as symlinks.
+    Preserve,
+    /// `--safe-links`: drop symlinks whose target escapes the transfer root.
+    SafeLinks,
+    /// `-L`: dereference symlinks into regular copies of their targets.
+    CopyLinks,
+}
+
+impl Scenario {
+    /// All modes, in report order.
+    const ALL: [Scenario; 3] = [Scenario::Preserve, Scenario::SafeLinks, Scenario::CopyLinks];
+
+    /// Stable label used in the cell name and destination directory tag.
+    fn name(self) -> &'static str {
+        match self {
+            Scenario::Preserve => "preserve",
+            Scenario::SafeLinks => "safe-links",
+            Scenario::CopyLinks => "copy-links",
+        }
+    }
+
+    /// The complete rsync flag set for this mode.
+    fn flags(self) -> &'static [&'static str] {
+        match self {
+            Scenario::Preserve => &["-rlptgoD", "--numeric-ids"],
+            Scenario::SafeLinks => &["-rlptgoD", "--safe-links", "--numeric-ids"],
+            Scenario::CopyLinks => &["-rLptgoD", "--numeric-ids"],
+        }
+    }
+
+    /// Mode-specific, non-vacuous guard on a destination tree. Returns the first
+    /// violation, or `None` when the mode's effect is genuine.
+    fn violation(self, dst: &Path) -> Option<String> {
+        match self {
+            Scenario::Preserve => preserve_violation(dst),
+            Scenario::SafeLinks => safe_links_violation(dst),
+            Scenario::CopyLinks => copy_links_violation(dst),
+        }
+    }
+}
+
+impl Check for Symlinks {
+    fn name(&self) -> &'static str {
+        "symlinks"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("symlinks");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+
+        let mut outcomes = Vec::new();
+        for &transport in ctx.transports {
+            for scenario in Scenario::ALL {
+                outcomes.push(self.cell(ctx, transport, scenario));
+            }
+        }
+        outcomes
+    }
+}
+
+impl Symlinks {
+    /// Run one `(transport, scenario)` cell: pull with upstream and with oc under
+    /// the same flags, then compare the resulting trees and the mode's effect.
+    fn cell(&self, ctx: &ValidateCtx, transport: Transport, scenario: Scenario) -> CheckOutcome {
+        let label = format!("{} {}", transport.label(), scenario.name());
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        // A non-chroot daemon munges symlinks (prefixes "/rsyncd-munged/"), which
+        // makes every link absolute; --safe-links then drops all of them, so the
+        // "unsafe dropped, rel survives" contract cannot hold. upstream:
+        // rsyncd.conf munge symlinks defaults enabled when use chroot is off.
+        if matches!(
+            (transport, scenario),
+            (Transport::Daemon, Scenario::SafeLinks)
+        ) {
+            return CheckOutcome::skip(
+                self.name(),
+                label,
+                "daemon munges symlinks; --safe-links drops every link",
+            );
+        }
+
+        let root = ctx.work.join("symlinks");
+        let src = root.join("src");
+        let tag = format!("{}-{}", transport.label(), scenario.name());
+        let oc_dst = root.join(format!("oc-{tag}"));
+        let up_dst = root.join(format!("up-{tag}"));
+        let flags: Vec<String> = scenario.flags().iter().map(|s| s.to_string()).collect();
+
+        match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            &src,
+            &up_dst,
+            &flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &label, "upstream", other),
+        }
+        match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            &src,
+            &oc_dst,
+            &flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &label, "oc", other),
+        }
+
+        // Identical trees prove both clients handled every symlink the same way,
+        // including symlink targets (compared by content_diff).
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            if ctx.verbose {
+                eprintln!("[symlinks/{label}] oc entries: {:?}", entry_names(&oc_dst));
+                eprintln!(
+                    "[symlinks/{label}] upstream entries: {:?}",
+                    entry_names(&up_dst)
+                );
+            }
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+
+        // Non-vacuous guard: the mode's characteristic effect must be visible.
+        if let Some(msg) = scenario.violation(&oc_dst) {
+            return CheckOutcome::fail(self.name(), label, msg);
+        }
+
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Sorted relative entry names of a destination tree, for verbose dumps.
+fn entry_names(dst: &Path) -> Vec<String> {
+    support::rel_entries(dst)
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect()
+}
+
+/// File type of a destination entry, without following symlinks.
+fn kind(dst: &Path, rel: &str) -> Option<std::fs::FileType> {
+    dst.join(rel).symlink_metadata().ok().map(|m| m.file_type())
+}
+
+/// Under `-l`, every fixture symlink must arrive as a symlink (none dereferenced)
+/// and the unsafe link is kept verbatim.
+fn preserve_violation(dst: &Path) -> Option<String> {
+    for rel in ["rel", "to_inner", "unsafe", "dirlink"] {
+        match kind(dst, rel) {
+            Some(t) if t.is_symlink() => {}
+            Some(_) => return Some(format!("{rel} was dereferenced, expected a symlink")),
+            None => return Some(format!("{rel} missing under -l preserve")),
+        }
+    }
+    None
+}
+
+/// Under `--safe-links`, the outside-pointing `unsafe` link must be gone while
+/// the safe `rel` link survives as a symlink.
+fn safe_links_violation(dst: &Path) -> Option<String> {
+    if kind(dst, "unsafe").is_some() {
+        return Some("unsafe symlink survived --safe-links".to_string());
+    }
+    match kind(dst, "rel") {
+        Some(t) if t.is_symlink() => None,
+        Some(_) => Some("rel was dereferenced under --safe-links".to_string()),
+        None => Some("safe rel symlink was dropped by --safe-links".to_string()),
+    }
+}
+
+/// Under `-L`, `rel` must become a regular file carrying the target's bytes.
+fn copy_links_violation(dst: &Path) -> Option<String> {
+    match kind(dst, "rel") {
+        Some(t) if t.is_file() => {}
+        Some(_) => return Some("rel is still a symlink under -L".to_string()),
+        None => return Some("rel missing under -L".to_string()),
+    }
+    match std::fs::read(dst.join("rel")) {
+        Ok(bytes) if bytes == TARGET_BODY => None,
+        Ok(_) => Some("dereferenced rel content != target.txt".to_string()),
+        Err(e) => Some(format!("cannot read dereferenced rel: {e}")),
+    }
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the symlink fixture. Idempotent: removes any prior tree first. Creates a
+/// real file, a safe relative symlink, a symlink into a subdirectory, an unsafe
+/// symlink escaping the tree, and a directory symlink. The unsafe link's referent
+/// is a real file placed beside `src` so `-L` can dereference it cleanly.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("target.txt"), TARGET_BODY).map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("inner.txt"), INNER_BODY).map_err(|e| e.to_string())?;
+
+    // The referent of the unsafe link lives outside the transfer root.
+    let outside = src
+        .parent()
+        .ok_or("fixture src has no parent")?
+        .join("outside");
+    std::fs::write(&outside, OUTSIDE_BODY).map_err(|e| e.to_string())?;
+
+    std::os::unix::fs::symlink("target.txt", src.join("rel")).map_err(|e| e.to_string())?;
+    std::os::unix::fs::symlink("sub/inner.txt", src.join("to_inner")).map_err(|e| e.to_string())?;
+    std::os::unix::fs::symlink("../outside", src.join("unsafe")).map_err(|e| e.to_string())?;
+    std::os::unix::fs::symlink("sub", src.join("dirlink")).map_err(|e| e.to_string())?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test; `-h`
+    // touches the symlinks themselves rather than their referents.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TARGET_BODY, copy_links_violation, preserve_violation, safe_links_violation};
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    fn all_links(dir: &std::path::Path) {
+        symlink("target.txt", dir.join("rel")).unwrap();
+        symlink("sub/inner.txt", dir.join("to_inner")).unwrap();
+        symlink("../outside", dir.join("unsafe")).unwrap();
+        symlink("sub", dir.join("dirlink")).unwrap();
+    }
+
+    #[test]
+    fn preserve_violation_none_when_all_symlinks_survive() {
+        let dir = tempfile::tempdir().unwrap();
+        all_links(dir.path());
+        assert!(preserve_violation(dir.path()).is_none());
+    }
+
+    #[test]
+    fn preserve_violation_flags_a_dereferenced_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        symlink("sub/inner.txt", d.join("to_inner")).unwrap();
+        symlink("../outside", d.join("unsafe")).unwrap();
+        symlink("sub", d.join("dirlink")).unwrap();
+        // `rel` arrives as a regular file, i.e. dereferenced.
+        fs::write(d.join("rel"), TARGET_BODY).unwrap();
+        assert!(preserve_violation(d).unwrap().contains("was dereferenced"));
+    }
+
+    #[test]
+    fn safe_links_violation_none_when_unsafe_dropped_and_rel_kept() {
+        let dir = tempfile::tempdir().unwrap();
+        symlink("target.txt", dir.path().join("rel")).unwrap();
+        assert!(safe_links_violation(dir.path()).is_none());
+    }
+
+    #[test]
+    fn safe_links_violation_flags_a_surviving_unsafe_link() {
+        let dir = tempfile::tempdir().unwrap();
+        symlink("target.txt", dir.path().join("rel")).unwrap();
+        symlink("../outside", dir.path().join("unsafe")).unwrap();
+        let msg = safe_links_violation(dir.path()).unwrap();
+        assert!(msg.contains("unsafe symlink survived"));
+    }
+
+    #[test]
+    fn safe_links_violation_flags_a_dropped_safe_link() {
+        let dir = tempfile::tempdir().unwrap();
+        // `unsafe` correctly gone, but the safe `rel` link was dropped too.
+        let msg = safe_links_violation(dir.path()).unwrap();
+        assert!(msg.contains("was dropped"));
+    }
+
+    #[test]
+    fn copy_links_violation_none_for_regular_file_with_target_body() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("rel"), TARGET_BODY).unwrap();
+        assert!(copy_links_violation(dir.path()).is_none());
+    }
+
+    #[test]
+    fn copy_links_violation_flags_a_link_that_was_not_dereferenced() {
+        let dir = tempfile::tempdir().unwrap();
+        symlink("target.txt", dir.path().join("rel")).unwrap();
+        let msg = copy_links_violation(dir.path()).unwrap();
+        assert!(msg.contains("still a symlink"));
+    }
+
+    #[test]
+    fn copy_links_violation_flags_wrong_dereferenced_content() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("rel"), b"not-the-target").unwrap();
+        assert!(copy_links_violation(dir.path()).unwrap().contains("!="));
+    }
+}

--- a/xtask/src/commands/validate/checks/total_size.rs
+++ b/xtask/src/commands/validate/checks/total_size.rs
@@ -1,0 +1,249 @@
+//! `--stats` total-size parity between oc-rsync and upstream.
+//!
+//! Builds a fixture of regular files, two subdirectories, and a symlink, then
+//! pulls it with each client over every transport and asserts oc-rsync's
+//! reported `total size` equals upstream's AND equals the byte sum of regular
+//! files plus symlinks only. Directory inode sizes must never be counted:
+//! upstream `flist.c` sums `total_size` over `S_ISREG || S_ISLNK` entries alone,
+//! so a run that folded directory sizes in would diverge from `expected_bytes`.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The total-size parity check.
+pub struct TotalSize;
+
+/// Archive plus statistics; `--stats` is what prints the `total size` line.
+const FLAGS: &[&str] = &["-a", "--stats"];
+
+impl Check for TotalSize {
+    fn name(&self) -> &'static str {
+        "total-size"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("total-size");
+        let src = root.join("src");
+        let expected_bytes = match build_fixture(&src) {
+            Ok(bytes) => bytes,
+            Err(e) => return vec![CheckOutcome::skip(self.name(), "fixture", e)],
+        };
+        let expected_entries = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| {
+                self.cell(
+                    ctx,
+                    t,
+                    &root,
+                    &src,
+                    &flags,
+                    expected_entries,
+                    expected_bytes,
+                )
+            })
+            .collect()
+    }
+}
+
+impl TotalSize {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        flags: &[String],
+        expected_entries: usize,
+        expected_bytes: u64,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected_entries
+            || support::entry_count(&oc_dst) != expected_entries
+        {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+
+        let up_stdout = String::from_utf8_lossy(&up.stdout);
+        let oc_stdout = String::from_utf8_lossy(&oc.stdout);
+        let Some(up_n) = parse_total_size(&up_stdout) else {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                "no `total size` line in upstream output",
+            );
+        };
+        let Some(oc_n) = parse_total_size(&oc_stdout) else {
+            return CheckOutcome::fail(self.name(), label, "no `total size` line in oc output");
+        };
+
+        if ctx.verbose {
+            eprintln!("[total-size/{label}] oc={oc_n} upstream={up_n} expected={expected_bytes}");
+        }
+
+        if oc_n != up_n || oc_n != expected_bytes {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("oc={oc_n} upstream={up_n} expected={expected_bytes}"),
+            );
+        }
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Extract `N` from rsync's `total size is N  speedup is M` line.
+///
+/// rsync always prints this under `--stats`; the integer may carry grouping
+/// commas (locale-dependent), which are stripped before parsing.
+fn parse_total_size(stdout: &str) -> Option<u64> {
+    let line = stdout.lines().find(|l| l.contains("total size is"))?;
+    let after = line.split("total size is").nth(1)?;
+    let digits: String = after
+        .trim()
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == ',')
+        .filter(|c| *c != ',')
+        .collect();
+    digits.parse().ok()
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the fixture and return the expected `total size` in bytes.
+///
+/// The tree has regular files, two subdirectories (whose inode sizes must be
+/// excluded), and one symlink. `expected_bytes` sums `symlink_metadata().len()`
+/// over regular-file and symlink entries only. A symlink's `len()` is the byte
+/// length of its target path, which is exactly what rsync counts for symlinks.
+/// Idempotent: removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<u64, String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub1 = src.join("sub1");
+    let sub2 = src.join("sub2");
+    std::fs::create_dir_all(&sub1).map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(&sub2).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("f1"), b"alpha-file-contents").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("f2"), b"bravo").map_err(|e| e.to_string())?;
+    std::fs::write(sub1.join("f3"), b"charlie-in-sub1").map_err(|e| e.to_string())?;
+    std::fs::write(sub2.join("f4"), b"delta-in-sub2-larger-payload").map_err(|e| e.to_string())?;
+
+    std::os::unix::fs::symlink("../f1", sub1.join("link")).map_err(|e| e.to_string())?;
+
+    // Sum regular-file and symlink bytes; directory inodes are excluded.
+    let mut expected_bytes = 0u64;
+    for rel in support::rel_entries(src) {
+        let path = src.join(&rel);
+        let meta = path.symlink_metadata().map_err(|e| e.to_string())?;
+        let ft = meta.file_type();
+        if ft.is_file() || ft.is_symlink() {
+            expected_bytes += meta.len();
+        }
+        // Backdate mtimes so the quick-check does not skip anything under test.
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(expected_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_total_size;
+
+    #[test]
+    fn parses_plain_total() {
+        assert_eq!(
+            parse_total_size("total size is 1374  speedup is 1.00\n"),
+            Some(1374)
+        );
+    }
+
+    #[test]
+    fn strips_locale_grouping_commas() {
+        assert_eq!(
+            parse_total_size("total size is 1,234,567  speedup is 2.0\n"),
+            Some(1_234_567)
+        );
+    }
+
+    #[test]
+    fn handles_zero_and_missing_line() {
+        assert_eq!(
+            parse_total_size("total size is 0  speedup is 0.00\n"),
+            Some(0)
+        );
+        assert_eq!(parse_total_size("sent 10 bytes  received 5 bytes\n"), None);
+    }
+
+    #[test]
+    fn finds_line_within_a_stats_block() {
+        let out = "Number of files: 3\n\
+                   Total file size: 1374 bytes\n\
+                   \n\
+                   sent 200 bytes  received 90 bytes\n\
+                   total size is 1374  speedup is 4.6\n";
+        assert_eq!(parse_total_size(out), Some(1374));
+    }
+}

--- a/xtask/src/commands/validate/checks/transfer_conditions.rs
+++ b/xtask/src/commands/validate/checks/transfer_conditions.rs
@@ -1,0 +1,491 @@
+//! Transfer-skip decision parity between oc-rsync and upstream.
+//!
+//! Rsync has several options that change *whether* a file is transferred at all:
+//! `--existing` (update only files already in the destination), `--ignore-existing`
+//! (create only files missing from the destination), `--size-only` (compare by
+//! size alone, ignoring mtime), and `--update`/`-u` (never overwrite a receiver
+//! file that is newer than the source). Each scenario pre-seeds a destination
+//! that differs from the source in the specific way the option keys on, then
+//! asserts oc-rsync reaches the exact same destination tree upstream does - i.e.
+//! it transferred and skipped exactly the same files - plus a non-vacuous check
+//! that the option actually changed the outcome.
+//!
+//! Because every scenario depends on a pre-seeded destination, this check cannot
+//! use `transport::pull_into` (which wipes the destination first). It seeds both
+//! the oc and upstream destinations identically, builds the client `Command`
+//! directly per transport - reusing `pull_into`'s operand forms - and runs the
+//! transfer *without* resetting the seeded tree. Upstream rsync is the ground
+//! truth for both runs; the ssh transports are skipped when no sshd answers on
+//! localhost:22.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The transfer-skip decision parity check.
+pub struct TransferConditions;
+
+/// Source file present in the destination for the existing/update scenarios.
+const KEEP: &str = "keep.txt";
+/// Nested source file, exercising directory creation on the receiver.
+const KEEP2: &str = "sub/keep2.txt";
+/// Source file *absent* from the seeded destination; its creation is what the
+/// existing/ignore-existing scenarios turn on.
+const NEW: &str = "new.txt";
+
+/// Source bytes for [`KEEP`].
+const KEEP_SRC: &[u8] = b"keep-source-body\n";
+/// Source bytes for [`KEEP2`].
+const KEEP2_SRC: &[u8] = b"keep2-source-body\n";
+/// Source bytes for [`NEW`].
+const NEW_SRC: &[u8] = b"new-source-body\n";
+
+/// Source mtime (2021-03-04). Backdated so the quick-check does not re-transfer
+/// on mtime alone where a scenario needs skips to happen.
+const SRC_MTIME: &str = "@1614830767";
+/// Older than the source (2020-09): used for destination seeds that must lose to
+/// the source anyway (they also differ in size, forcing the update).
+const OLDER: &str = "@1600000000";
+/// Newer than the source (2023-11): a receiver file with this mtime is the
+/// precondition `--size-only` must skip past and `-u` must refuse to overwrite.
+const NEWER: &str = "@1700000000";
+
+/// One transfer-skip option and its seeding/verification strategy.
+#[derive(Clone, Copy)]
+enum Scenario {
+    /// `--existing`: update files already present, never create missing ones.
+    Existing,
+    /// `--ignore-existing`: skip files already present, create only missing ones.
+    IgnoreExisting,
+    /// `--size-only`: skip files whose size matches, ignoring mtime.
+    SizeOnly,
+    /// `--update` (`-u`): never overwrite a receiver file newer than the source.
+    Update,
+}
+
+/// Scenarios exercised for every transport, in report order.
+const SCENARIOS: [Scenario; 4] = [
+    Scenario::Existing,
+    Scenario::IgnoreExisting,
+    Scenario::SizeOnly,
+    Scenario::Update,
+];
+
+impl Scenario {
+    /// Stable short label used in the cell name.
+    fn label(self) -> &'static str {
+        match self {
+            Scenario::Existing => "existing",
+            Scenario::IgnoreExisting => "ignore-existing",
+            Scenario::SizeOnly => "size-only",
+            Scenario::Update => "update",
+        }
+    }
+
+    /// The rsync flag under test for this scenario.
+    fn flag(self) -> &'static str {
+        match self {
+            Scenario::Existing => "--existing",
+            Scenario::IgnoreExisting => "--ignore-existing",
+            Scenario::SizeOnly => "--size-only",
+            Scenario::Update => "-u",
+        }
+    }
+
+    /// The complete flag set: shared base plus the scenario flag.
+    fn flags(self) -> [&'static str; 3] {
+        ["-rlptgoD", "--numeric-ids", self.flag()]
+    }
+}
+
+impl Check for TransferConditions {
+    fn name(&self) -> &'static str {
+        "transfer-conditions"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("transfer-conditions");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let mut out = Vec::new();
+        for &transport in ctx.transports {
+            for scenario in SCENARIOS {
+                out.push(self.cell(ctx, transport, scenario, &root, &src));
+            }
+        }
+        out
+    }
+}
+
+impl TransferConditions {
+    /// Run one (transport, scenario) cell: seed both destinations identically,
+    /// transfer with each client, then assert the two destinations agree and the
+    /// option changed the outcome.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        scenario: Scenario,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        let cell = format!("{}/{label}", scenario.label());
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), cell, "no sshd on localhost:22");
+        }
+
+        let oc_dst = root.join(format!("oc-{}-{label}", scenario.label()));
+        let up_dst = root.join(format!("up-{}-{label}", scenario.label()));
+
+        // Seed both destinations identically before their respective transfers.
+        if let Err(e) = seed_one(scenario, &oc_dst) {
+            return CheckOutcome::skip(self.name(), cell, format!("seed oc dest: {e}"));
+        }
+        if let Err(e) = seed_one(scenario, &up_dst) {
+            return CheckOutcome::skip(self.name(), cell, format!("seed upstream dest: {e}"));
+        }
+
+        // Non-vacuous guard: the seeded precondition the option keys on must hold
+        // before the transfer, or the cell would pass without exercising it.
+        if let Err(e) = precondition(scenario, &oc_dst) {
+            return CheckOutcome::fail(self.name(), cell, format!("oc {e}"));
+        }
+        if let Err(e) = precondition(scenario, &up_dst) {
+            return CheckOutcome::fail(self.name(), cell, format!("upstream {e}"));
+        }
+
+        // The daemon transport needs one live upstream daemon shared by both
+        // client runs; keep it alive for the whole cell.
+        let daemon = if transport == Transport::Daemon {
+            match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), cell, format!("daemon: {e}")),
+            }
+        } else {
+            None
+        };
+        let daemon_url = daemon.as_ref().map(|d| d.module_url());
+        let flags = scenario.flags();
+
+        match run_client(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            &flags,
+            daemon_url.as_deref(),
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &cell, "upstream", other),
+        }
+        match run_client(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            &flags,
+            daemon_url.as_deref(),
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &cell, "oc", other),
+        }
+        drop(daemon);
+
+        match verify(scenario, &oc_dst, &up_dst, src) {
+            Ok(()) => CheckOutcome::pass(self.name(), cell),
+            Err(diff) => {
+                if ctx.verbose {
+                    eprintln!(
+                        "[transfer-conditions/{cell}] oc {:?} upstream {:?}",
+                        support::rel_entries(&oc_dst),
+                        support::rel_entries(&up_dst),
+                    );
+                }
+                CheckOutcome::fail(self.name(), cell, diff)
+            }
+        }
+    }
+}
+
+/// Build one client rsync `Command` for `transport` and run it into the
+/// (already-seeded) destination. The destination is never reset here, so the
+/// scenario's pre-seeded tree survives into the transfer.
+///
+/// Operand forms mirror `transport::pull_into`: `local` is a filesystem copy;
+/// `ssh-subprocess` uses `-e ssh localhost:<src>`; `russh` uses an `ssh://` URL;
+/// `daemon` uses the module URL passed in `daemon_url`. The sender is always
+/// `upstream` for the network transports (`--rsync-path` / upstream daemon).
+fn run_client(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    flags: &[&str],
+    daemon_url: Option<&str>,
+) -> TaskResult<Output> {
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let url = daemon_url
+                .ok_or_else(|| TaskError::Validation("daemon transport without url".into()))?;
+            cmd.arg(url).arg(&dst_arg);
+        }
+    }
+
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Seed `dst` for `scenario`, recreating it empty first (idempotent).
+///
+/// - `existing`: only [`KEEP`]/[`KEEP2`] present, shorter (different-size) older
+///   content, and [`NEW`] absent - so `--existing` has files to update and one
+///   to refuse to create.
+/// - `ignore-existing`: only [`KEEP`] present with differing older content -
+///   `--ignore-existing` must keep it and create the rest.
+/// - `size-only`: all three files present with equal-length-but-different
+///   content and a *newer* mtime - `--size-only` must skip them on size alone.
+/// - `update`: only [`KEEP`] present with a *newer* mtime and differing content -
+///   `-u` must refuse to overwrite it.
+fn seed_one(scenario: Scenario, dst: &Path) -> Result<(), String> {
+    reset(dst)?;
+    match scenario {
+        Scenario::Existing => {
+            write_file(dst, KEEP, b"old\n")?;
+            write_file(dst, KEEP2, b"old2\n")?;
+            backdate(dst, &[KEEP, KEEP2], OLDER)?;
+        }
+        Scenario::IgnoreExisting => {
+            write_file(dst, KEEP, b"stale-keep-content\n")?;
+            backdate(dst, &[KEEP], OLDER)?;
+        }
+        Scenario::SizeOnly => {
+            write_file(dst, KEEP, &differing_same_len(KEEP_SRC))?;
+            write_file(dst, KEEP2, &differing_same_len(KEEP2_SRC))?;
+            write_file(dst, NEW, &differing_same_len(NEW_SRC))?;
+            backdate(dst, &[KEEP, KEEP2, NEW], NEWER)?;
+        }
+        Scenario::Update => {
+            write_file(dst, KEEP, b"receiver-newer-keep-content\n")?;
+            backdate(dst, &[KEEP], NEWER)?;
+        }
+    }
+    Ok(())
+}
+
+/// Assert the seeded precondition the option keys on holds before the transfer.
+///
+/// A false precondition means a seeding bug, not a divergence, so callers turn
+/// it into a `fail` rather than let the cell pass vacuously.
+fn precondition(scenario: Scenario, dst: &Path) -> Result<(), String> {
+    match scenario {
+        Scenario::Existing => {
+            if dst.join(NEW).exists() {
+                return Err("dest new.txt present before transfer".into());
+            }
+        }
+        Scenario::IgnoreExisting => {
+            if reads(dst, KEEP).as_deref() == Some(KEEP_SRC) {
+                return Err("dest keep.txt does not differ from source".into());
+            }
+        }
+        Scenario::SizeOnly => {
+            let seed = reads(dst, KEEP).ok_or("dest keep.txt missing")?;
+            if seed.len() != KEEP_SRC.len() {
+                return Err("dest keep.txt size differs from source".into());
+            }
+            if seed == KEEP_SRC {
+                return Err("dest keep.txt does not differ from source".into());
+            }
+        }
+        Scenario::Update => {
+            if reads(dst, KEEP).as_deref() == Some(KEEP_SRC) {
+                return Err("dest keep.txt does not differ from source".into());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// After both transfers, assert the destinations agree and the option changed
+/// the outcome (a plain transfer would have differed).
+fn verify(scenario: Scenario, oc_dst: &Path, up_dst: &Path, src: &Path) -> Result<(), String> {
+    if let Some(diff) = support::content_diff(oc_dst, up_dst) {
+        return Err(format!("oc and upstream dests differ: {diff}"));
+    }
+    match scenario {
+        Scenario::Existing => {
+            for d in [oc_dst, up_dst] {
+                if d.join(NEW).exists() {
+                    return Err("new.txt created despite --existing".into());
+                }
+            }
+        }
+        Scenario::IgnoreExisting => {
+            for d in [oc_dst, up_dst] {
+                if !d.join(NEW).exists() {
+                    return Err("new.txt not created under --ignore-existing".into());
+                }
+                if reads(d, KEEP).as_deref() == Some(KEEP_SRC) {
+                    return Err("keep.txt overwritten despite --ignore-existing".into());
+                }
+            }
+        }
+        Scenario::SizeOnly => {
+            if support::content_diff(oc_dst, src).is_none() {
+                return Err("--size-only did not skip: dest equals source".into());
+            }
+        }
+        Scenario::Update => {
+            for d in [oc_dst, up_dst] {
+                if reads(d, KEEP).as_deref() == Some(KEEP_SRC) {
+                    return Err("keep.txt overwritten despite -u".into());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build the source tree, backdating every file to [`SRC_MTIME`]. Idempotent:
+/// removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    reset(src)?;
+    write_file(src, KEEP, KEEP_SRC)?;
+    write_file(src, KEEP2, KEEP2_SRC)?;
+    write_file(src, NEW, NEW_SRC)?;
+    backdate(src, &[KEEP, KEEP2, NEW], SRC_MTIME)
+}
+
+/// A buffer of the same length as `src` but differing in every byte, so a
+/// destination seeded with it matches the source's size while differing in
+/// content - exactly the state `--size-only` must skip.
+fn differing_same_len(src: &[u8]) -> Vec<u8> {
+    src.iter().map(|b| b.wrapping_add(1)).collect()
+}
+
+/// Read `root/rel`, returning its bytes or `None` when absent.
+fn reads(root: &Path, rel: &str) -> Option<Vec<u8>> {
+    std::fs::read(root.join(rel)).ok()
+}
+
+/// Write `bytes` to `root/rel`, creating parent directories as needed.
+fn write_file(root: &Path, rel: &str, bytes: &[u8]) -> Result<(), String> {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(&path, bytes).map_err(|e| e.to_string())
+}
+
+/// Set each `rel`'s mtime under `root` to `epoch` via `touch -d @epoch`.
+fn backdate(root: &Path, rels: &[&str], epoch: &str) -> Result<(), String> {
+    for rel in rels {
+        let path = root.join(rel);
+        support::capture("touch", &["-h", "-d", epoch, &path.to_string_lossy()])
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset(dir: &Path) -> Result<(), String> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(dir).map_err(|e| e.to_string())
+}
+
+/// Distinguish a genuine divergence (non-zero exit) from an unrunnable cell.
+fn skip_or_fail(
+    check: &'static str,
+    cell: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                cell,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, cell, format!("{who} could not run: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn differing_same_len_keeps_length_and_changes_every_byte() {
+        let src = b"keep-source-body\n";
+        let out = differing_same_len(src);
+        assert_eq!(out.len(), src.len());
+        assert_ne!(out.as_slice(), src);
+        for (a, b) in src.iter().zip(out.iter()) {
+            assert_ne!(a, b);
+        }
+    }
+
+    #[test]
+    fn differing_same_len_handles_empty() {
+        assert!(differing_same_len(b"").is_empty());
+    }
+
+    #[test]
+    fn every_scenario_flag_set_carries_its_flag_after_the_shared_base() {
+        for scenario in SCENARIOS {
+            let flags = scenario.flags();
+            assert_eq!(flags[0], "-rlptgoD");
+            assert_eq!(flags[1], "--numeric-ids");
+            assert_eq!(flags[2], scenario.flag());
+        }
+    }
+
+    #[test]
+    fn scenario_labels_are_unique() {
+        let labels: Vec<&str> = SCENARIOS.iter().map(|s| s.label()).collect();
+        let mut sorted = labels.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(labels.len(), sorted.len());
+    }
+
+    #[test]
+    fn size_only_seed_flag_is_size_only() {
+        assert_eq!(Scenario::SizeOnly.flag(), "--size-only");
+    }
+}

--- a/xtask/src/commands/validate/checks/verbosity.rs
+++ b/xtask/src/commands/validate/checks/verbosity.rs
@@ -1,0 +1,315 @@
+//! Verbose stdout parity at each `-v` level across every transport.
+//!
+//! Builds a tiny tree, pulls it with each client over every transport at
+//! increasing verbosity (`-v`, `-vv`, `-vvv`), and asserts oc-rsync's verbose
+//! stdout is structurally identical to upstream's for that level. Upstream rsync
+//! is the ground truth. Volatile numerics (byte counts, offsets, checksums,
+//! rates) and the trailing timing summary carry no structural meaning, so both
+//! sides are normalized - digit runs collapsed to a placeholder, summary and
+//! rate lines dropped - before the line vectors are compared for equality. What
+//! survives is the structural shape of the output, which a drop-in must match.
+
+use std::path::Path;
+use std::process::Output;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The verbose-output parity check.
+pub struct Verbosity;
+
+/// Verbosity levels exercised, one matrix cell each.
+const LEVELS: &[&str] = &["-v", "-vv", "-vvv"];
+
+/// Base flags shared by every cell; the level is appended per run.
+const BASE_FLAGS: &[&str] = &["-rlptgoD", "--numeric-ids"];
+
+/// Placeholder substituted for every volatile numeric run.
+const PLACEHOLDER: &str = "#";
+
+/// Trailing units a numeric run may absorb, longest-first so `KB` wins over `B`.
+const UNITS: &[&str] = &["bytes", "KB", "B", "/s", "%"];
+
+impl Check for Verbosity {
+    fn name(&self) -> &'static str {
+        "verbosity"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("verbosity");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected = support::entry_count(&src);
+
+        let mut outcomes = Vec::new();
+        for &transport in ctx.transports {
+            for level in LEVELS {
+                outcomes.push(self.cell(ctx, transport, &root, &src, level, expected));
+            }
+        }
+        outcomes
+    }
+}
+
+impl Verbosity {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        level: &str,
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        let cell = format!("{label} {level}");
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), cell, "no sshd on localhost:22");
+        }
+
+        let flags: Vec<String> = BASE_FLAGS
+            .iter()
+            .chain(std::iter::once(&level))
+            .map(|s| s.to_string())
+            .collect();
+        let slug = level.trim_start_matches('-');
+        let oc_dst = root.join(format!("oc-{label}-{slug}"));
+        let up_dst = root.join(format!("up-{label}-{slug}"));
+
+        let up = match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            &flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), &cell, "upstream", other),
+        };
+        let oc = match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            &flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), &cell, "oc", other),
+        };
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), cell, "destination entry count != source");
+        }
+
+        let oc_norm = normalize(&String::from_utf8_lossy(&oc.stdout));
+        let up_norm = normalize(&String::from_utf8_lossy(&up.stdout));
+
+        if oc_norm != up_norm {
+            if ctx.verbose {
+                eprintln!(
+                    "[verbosity/{cell}] oc={oc_norm:?}\n[verbosity/{cell}] upstream={up_norm:?}"
+                );
+            }
+            if let Some((i, a, b)) = first_diff(&oc_norm, &up_norm) {
+                return CheckOutcome::fail(
+                    self.name(),
+                    cell,
+                    format!("line {i}: oc {a:?} vs upstream {b:?}"),
+                );
+            }
+            return CheckOutcome::fail(self.name(), cell, "verbose stdout differs");
+        }
+        CheckOutcome::pass(self.name(), cell)
+    }
+}
+
+/// Reduce verbose stdout to its structural lines for equality comparison.
+///
+/// Returns the non-empty, trimmed lines with volatile content neutralized:
+/// every run of ASCII digits (with embedded `.`/`,` and an optional trailing
+/// unit such as `bytes`, `KB`, `B`, `%`, `/s`) collapses to a fixed placeholder,
+/// and the trailing `sent .../received .../total size .../speedup` summary plus
+/// any `bytes/sec` rate line - all of which encode timing or byte counts - are
+/// dropped. Only structural differences remain.
+pub fn normalize(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !is_summary_line(line))
+        .map(neutralize)
+        .collect()
+}
+
+/// True for the trailing summary and rate lines that encode timing / counts.
+fn is_summary_line(line: &str) -> bool {
+    line.starts_with("sent ")
+        || line.starts_with("total size is")
+        || line.contains("bytes/sec")
+        || line.contains("speedup is")
+}
+
+/// Collapse every volatile numeric run in one line to [`PLACEHOLDER`].
+fn neutralize(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut rest = line;
+    while let Some(first) = rest.chars().next() {
+        if first.is_ascii_digit() {
+            rest = strip_unit(&rest[numeric_len(rest)..]);
+            out.push_str(PLACEHOLDER);
+        } else {
+            out.push(first);
+            rest = &rest[first.len_utf8()..];
+        }
+    }
+    out
+}
+
+/// Byte length of the leading numeric run (digits plus embedded `.` and `,`).
+fn numeric_len(rest: &str) -> usize {
+    rest.char_indices()
+        .take_while(|&(_, c)| c.is_ascii_digit() || c == '.' || c == ',')
+        .map(|(i, c)| i + c.len_utf8())
+        .last()
+        .unwrap_or(0)
+}
+
+/// Strip an optional trailing unit (after at most one space) following a number.
+///
+/// Alphabetic units must end on a word boundary so a size like `100B` is
+/// absorbed while a name like `100Bravo` keeps its letters.
+fn strip_unit(rest: &str) -> &str {
+    let candidate = rest.strip_prefix(' ').unwrap_or(rest);
+    for unit in UNITS {
+        if let Some(after) = candidate.strip_prefix(unit) {
+            let alpha = unit.chars().all(|c| c.is_ascii_alphabetic());
+            let boundary = after
+                .chars()
+                .next()
+                .map(|c| !c.is_ascii_alphanumeric())
+                .unwrap_or(true);
+            if !alpha || boundary {
+                return after;
+            }
+        }
+    }
+    rest
+}
+
+/// First index where the two normalized vectors differ, with each side's line
+/// (or `<missing>` when one vector is shorter).
+fn first_diff(oc: &[String], up: &[String]) -> Option<(usize, String, String)> {
+    for i in 0..oc.len().max(up.len()) {
+        let a = oc.get(i).map(String::as_str).unwrap_or("<missing>");
+        let b = up.get(i).map(String::as_str).unwrap_or("<missing>");
+        if a != b {
+            return Some((i, a.to_string(), b.to_string()));
+        }
+    }
+    None
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the verbosity fixture. Idempotent: removes any prior tree first.
+///
+/// A couple of top-level files plus a subdirectory holding one file. Mtimes are
+/// backdated so the quick-check makes the same transfer decisions on every run.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    std::fs::write(src.join("a.txt"), b"alpha").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("b.txt"), b"bravo").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("c.txt"), b"charlie").map_err(|e| e.to_string())?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{neutralize, normalize};
+
+    #[test]
+    fn keeps_structural_lines_and_drops_summary() {
+        let out = "receiving incremental file list\n\
+                   a.txt\n\
+                   sub/\n\
+                   \n\
+                   sent 100 bytes  received 200 bytes  600.00 bytes/sec\n\
+                   total size is 12  speedup is 0.04\n";
+        assert_eq!(
+            normalize(out),
+            vec![
+                "receiving incremental file list".to_string(),
+                "a.txt".to_string(),
+                "sub/".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn neutralizes_digit_runs_leaving_structure() {
+        // Offsets, counts and checksums are volatile; the labels around them are
+        // the structural signal that must survive.
+        assert_eq!(
+            neutralize("total: matches=0 data=12 tag_hits=3"),
+            "total: matches=# data=# tag_hits=#"
+        );
+    }
+
+    #[test]
+    fn absorbs_trailing_units_but_not_following_words() {
+        assert_eq!(neutralize("12.5KB 3/s 50%"), "# # #");
+        // A size unit is absorbed on a word boundary; a name is left intact.
+        assert_eq!(neutralize("100B"), "#");
+        assert_eq!(neutralize("100Bravo"), "#Bravo");
+    }
+
+    #[test]
+    fn identical_verbose_output_normalizes_equal() {
+        let oc = "a.txt\n  1,234 bytes\nsent 9 bytes  received 9 bytes  1.00 bytes/sec\n";
+        let up = "a.txt\n  5,678 bytes\nsent 7 bytes  received 7 bytes  2.00 bytes/sec\n";
+        assert_eq!(normalize(oc), normalize(up));
+        // The number and its trailing `bytes` unit collapse to one placeholder.
+        assert_eq!(normalize(oc), vec!["a.txt".to_string(), "#".to_string()]);
+    }
+}

--- a/xtask/src/commands/validate/checks/verbosity.rs
+++ b/xtask/src/commands/validate/checks/verbosity.rs
@@ -1,13 +1,19 @@
-//! Verbose stdout parity at each `-v` level across every transport.
+//! Verbose stdout parity at `-v` across every transport.
 //!
-//! Builds a tiny tree, pulls it with each client over every transport at
-//! increasing verbosity (`-v`, `-vv`, `-vvv`), and asserts oc-rsync's verbose
-//! stdout is structurally identical to upstream's for that level. Upstream rsync
-//! is the ground truth. Volatile numerics (byte counts, offsets, checksums,
-//! rates) and the trailing timing summary carry no structural meaning, so both
-//! sides are normalized - digit runs collapsed to a placeholder, summary and
-//! rate lines dropped - before the line vectors are compared for equality. What
-//! survives is the structural shape of the output, which a drop-in must match.
+//! Builds a tiny tree, pulls it with each client over every transport at `-v`,
+//! and asserts oc-rsync's verbose stdout is structurally identical to
+//! upstream's. Upstream rsync is the ground truth. Volatile numerics (byte
+//! counts, offsets, checksums, rates) and the trailing timing summary carry no
+//! structural meaning, so both sides are normalized - digit runs collapsed to a
+//! placeholder, summary and rate lines dropped - before the line vectors are
+//! compared for equality. What survives is the structural shape of the output,
+//! which a drop-in must match.
+//!
+//! Only `-v` is validated. `-vv` and `-vvv` are debug levels whose output is
+//! upstream-implementation detail (connection traces like `opening connection
+//! using: ssh ...` and internal notes like `[sender] make_file(...)`) that no
+//! independent implementation reproduces byte-for-byte; matching them is not a
+//! drop-in requirement.
 
 use std::path::Path;
 use std::process::Output;
@@ -19,8 +25,9 @@ use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
 /// The verbose-output parity check.
 pub struct Verbosity;
 
-/// Verbosity levels exercised, one matrix cell each.
-const LEVELS: &[&str] = &["-v", "-vv", "-vvv"];
+/// Verbosity levels exercised, one matrix cell each. Only `-v` is a stable
+/// drop-in surface; `-vv`/`-vvv` are implementation-specific debug output.
+const LEVELS: &[&str] = &["-v"];
 
 /// Base flags shared by every cell; the level is appended per run.
 const BASE_FLAGS: &[&str] = &["-rlptgoD", "--numeric-ids"];

--- a/xtask/src/commands/validate/checks/verbosity.rs
+++ b/xtask/src/commands/validate/checks/verbosity.rs
@@ -1,19 +1,23 @@
-//! Verbose stdout parity at `-v` across every transport.
+//! Verbose stdout parity across `-v`, `-vv`, and `-vvv` on every transport.
 //!
-//! Builds a tiny tree, pulls it with each client over every transport at `-v`,
-//! and asserts oc-rsync's verbose stdout is structurally identical to
-//! upstream's. Upstream rsync is the ground truth. Volatile numerics (byte
-//! counts, offsets, checksums, rates) and the trailing timing summary carry no
-//! structural meaning, so both sides are normalized - digit runs collapsed to a
-//! placeholder, summary and rate lines dropped - before the line vectors are
-//! compared for equality. What survives is the structural shape of the output,
-//! which a drop-in must match.
+//! Builds a tiny tree, pulls it with each client over every transport at all
+//! three verbosity levels, and asserts oc-rsync reproduces upstream's stable
+//! user-facing core. Upstream rsync is the ground truth.
 //!
-//! Only `-v` is validated. `-vv` and `-vvv` are debug levels whose output is
-//! upstream-implementation detail (connection traces like `opening connection
-//! using: ssh ...` and internal notes like `[sender] make_file(...)`) that no
-//! independent implementation reproduces byte-for-byte; matching them is not a
-//! drop-in requirement.
+//! Only the stable core is compared: the "incremental file list" banner, the
+//! transferred-name lines (each source relative path, plus the `.`/`./` root),
+//! and the statistics summary. Volatile numerics inside those kept lines (byte
+//! counts, offsets, checksums, rates) are neutralized first - digit runs
+//! collapse to a placeholder - so timing and size jitter carry no weight.
+//!
+//! Everything else is dropped. `-vv` and `-vvv` only add implementation-specific
+//! diagnostics (connection traces like `opening connection using: ssh ...`,
+//! role-prefixed debug like `[sender] make_file(...)`, internal notes), which no
+//! independent implementation reproduces byte-for-byte. Ignoring them lets all
+//! three levels be exercised while the stable core must still match upstream at
+//! every level; a spurious extra name line (e.g. oc emitting `./` when upstream
+//! does not) is a real divergence the check still catches, because `.`/`./` name
+//! lines are kept.
 
 use std::path::Path;
 use std::process::Output;
@@ -25,9 +29,9 @@ use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
 /// The verbose-output parity check.
 pub struct Verbosity;
 
-/// Verbosity levels exercised, one matrix cell each. Only `-v` is a stable
-/// drop-in surface; `-vv`/`-vvv` are implementation-specific debug output.
-const LEVELS: &[&str] = &["-v"];
+/// Verbosity levels exercised, one matrix cell each. Every level must reproduce
+/// the same stable core; `-vv`/`-vvv` only add ignored diagnostics on top.
+const LEVELS: &[&str] = &["-v", "-vv", "-vvv"];
 
 /// Base flags shared by every cell; the level is appended per run.
 const BASE_FLAGS: &[&str] = &["-rlptgoD", "--numeric-ids"];
@@ -50,11 +54,15 @@ impl Check for Verbosity {
             return vec![CheckOutcome::skip(self.name(), "fixture", e)];
         }
         let expected = support::entry_count(&src);
+        let names: std::collections::HashSet<String> = support::rel_entries(&src)
+            .iter()
+            .map(|entry| entry.to_string_lossy().to_string())
+            .collect();
 
         let mut outcomes = Vec::new();
         for &transport in ctx.transports {
             for level in LEVELS {
-                outcomes.push(self.cell(ctx, transport, &root, &src, level, expected));
+                outcomes.push(self.cell(ctx, transport, &root, level, expected, &names));
             }
         }
         outcomes
@@ -67,10 +75,11 @@ impl Verbosity {
         ctx: &ValidateCtx,
         transport: Transport,
         root: &Path,
-        src: &Path,
         level: &str,
         expected: usize,
+        names: &std::collections::HashSet<String>,
     ) -> CheckOutcome {
+        let src = root.join("src");
         let label = transport.label();
         let cell = format!("{label} {level}");
         if transport.needs_ssh() && !support::ssh_ready() {
@@ -90,7 +99,7 @@ impl Verbosity {
             transport.for_upstream(),
             ctx.upstream,
             ctx.upstream,
-            src,
+            &src,
             &up_dst,
             &flags,
             ctx.work,
@@ -102,7 +111,7 @@ impl Verbosity {
             transport,
             ctx.oc,
             ctx.upstream,
-            src,
+            &src,
             &oc_dst,
             &flags,
             ctx.work,
@@ -116,16 +125,16 @@ impl Verbosity {
             return CheckOutcome::fail(self.name(), cell, "destination entry count != source");
         }
 
-        let oc_norm = normalize(&String::from_utf8_lossy(&oc.stdout));
-        let up_norm = normalize(&String::from_utf8_lossy(&up.stdout));
+        let oc_core = stable_core(&String::from_utf8_lossy(&oc.stdout), names);
+        let up_core = stable_core(&String::from_utf8_lossy(&up.stdout), names);
 
-        if oc_norm != up_norm {
+        if oc_core != up_core {
             if ctx.verbose {
                 eprintln!(
-                    "[verbosity/{cell}] oc={oc_norm:?}\n[verbosity/{cell}] upstream={up_norm:?}"
+                    "[verbosity/{cell}] oc={oc_core:?}\n[verbosity/{cell}] upstream={up_core:?}"
                 );
             }
-            if let Some((i, a, b)) = first_diff(&oc_norm, &up_norm) {
+            if let Some((i, a, b)) = first_diff(&oc_core, &up_core) {
                 return CheckOutcome::fail(
                     self.name(),
                     cell,
@@ -138,29 +147,59 @@ impl Verbosity {
     }
 }
 
-/// Reduce verbose stdout to its structural lines for equality comparison.
+/// Reduce verbose stdout to its stable user-facing core for equality comparison.
 ///
-/// Returns the non-empty, trimmed lines with volatile content neutralized:
-/// every run of ASCII digits (with embedded `.`/`,` and an optional trailing
-/// unit such as `bytes`, `KB`, `B`, `%`, `/s`) collapses to a fixed placeholder,
-/// and the trailing `sent .../received .../total size .../speedup` summary plus
-/// any `bytes/sec` rate line - all of which encode timing or byte counts - are
-/// dropped. Only structural differences remain.
-pub fn normalize(stdout: &str) -> Vec<String> {
+/// Keeps only the non-empty, trimmed lines that a drop-in must reproduce at
+/// every verbosity level - the "incremental file list" banner, the transferred
+/// item names (each source relative path, plus the `.`/`./` root), and the
+/// statistics summary - and drops everything else. The dropped remainder is
+/// implementation-specific diagnostics that `-vv`/`-vvv` add: connection traces
+/// (`opening connection using: ssh ...`), role-prefixed debug (`[sender] ...`),
+/// and internal notes (`... make_file(...)`, `server_sender starting ...`).
+///
+/// Each kept line is neutralized first, so volatile numerics inside it (byte
+/// counts, offsets, checksums, rates) collapse to a placeholder and carry no
+/// weight. `names` is the set of source relative-entry strings.
+pub fn stable_core(stdout: &str, names: &std::collections::HashSet<String>) -> Vec<String> {
     stdout
         .lines()
         .map(str::trim)
-        .filter(|line| !line.is_empty() && !is_summary_line(line))
+        .filter(|line| !line.is_empty() && is_stable_core(line, names))
         .map(neutralize)
         .collect()
 }
 
-/// True for the trailing summary and rate lines that encode timing / counts.
+/// True when a trimmed line belongs to the stable core kept by [`stable_core`].
+fn is_stable_core(line: &str, names: &std::collections::HashSet<String>) -> bool {
+    is_flist_banner(line) || is_transferred_name(line, names) || is_summary_line(line)
+}
+
+/// The file-list banner, e.g. `receiving incremental file list`.
+fn is_flist_banner(line: &str) -> bool {
+    line.contains("incremental file list")
+}
+
+/// A transferred-item line: the line with any single trailing `/` removed is the
+/// `.`/`./` root or a known source relative path. rsync prints the item's
+/// relative path at `-v`, so a spurious extra name (e.g. `./`) is caught here.
+fn is_transferred_name(line: &str, names: &std::collections::HashSet<String>) -> bool {
+    let stem = line.strip_suffix('/').unwrap_or(line);
+    stem == "." || stem == "./" || names.contains(stem)
+}
+
+/// A statistics/summary structural line (case-insensitive prefix match).
 fn is_summary_line(line: &str) -> bool {
-    line.starts_with("sent ")
-        || line.starts_with("total size is")
-        || line.contains("bytes/sec")
-        || line.contains("speedup is")
+    const PREFIXES: &[&str] = &[
+        "number of ",
+        "total ",
+        "file list ",
+        "sent ",
+        "total size",
+        "literal data",
+        "matched data",
+    ];
+    let lower = line.to_ascii_lowercase();
+    PREFIXES.iter().any(|prefix| lower.starts_with(prefix))
 }
 
 /// Collapse every volatile numeric run in one line to [`PLACEHOLDER`].
@@ -273,22 +312,50 @@ fn build_fixture(src: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{neutralize, normalize};
+    use std::collections::HashSet;
+
+    use super::{neutralize, stable_core};
 
     #[test]
-    fn keeps_structural_lines_and_drops_summary() {
+    fn keeps_core_and_drops_diagnostics() {
+        let names: HashSet<String> = ["a.txt".to_string(), "sub/c.txt".to_string()]
+            .into_iter()
+            .collect();
+        // Banner, two names, and two summary lines survive; the `-vv`/`-vvv`
+        // connection trace and role-prefixed debug are dropped.
         let out = "receiving incremental file list\n\
+                   opening connection using: ssh -l user host rsync --server\n\
+                   [sender] make_file(a.txt,*,2)\n\
                    a.txt\n\
-                   sub/\n\
-                   \n\
-                   sent 100 bytes  received 200 bytes  600.00 bytes/sec\n\
-                   total size is 12  speedup is 0.04\n";
+                   sub/c.txt\n\
+                   Number of files: 5\n\
+                   sent 100 bytes  received 200 bytes  600.00 bytes/sec\n";
         assert_eq!(
-            normalize(out),
+            stable_core(out, &names),
             vec![
                 "receiving incremental file list".to_string(),
                 "a.txt".to_string(),
-                "sub/".to_string(),
+                "sub/c.txt".to_string(),
+                "Number of files: #".to_string(),
+                "sent #  received #  #/sec".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn spurious_dot_slash_name_diverges() {
+        let names: HashSet<String> = ["a.txt".to_string()].into_iter().collect();
+        let upstream = "receiving incremental file list\na.txt\n";
+        // oc emits an extra `./` the upstream did not: kept as a name line, so
+        // the two otherwise-equal cores differ.
+        let oc = "receiving incremental file list\n./\na.txt\n";
+        assert_ne!(stable_core(oc, &names), stable_core(upstream, &names));
+        assert_eq!(
+            stable_core(oc, &names),
+            vec![
+                "receiving incremental file list".to_string(),
+                "./".to_string(),
+                "a.txt".to_string(),
             ]
         );
     }
@@ -309,14 +376,5 @@ mod tests {
         // A size unit is absorbed on a word boundary; a name is left intact.
         assert_eq!(neutralize("100B"), "#");
         assert_eq!(neutralize("100Bravo"), "#Bravo");
-    }
-
-    #[test]
-    fn identical_verbose_output_normalizes_equal() {
-        let oc = "a.txt\n  1,234 bytes\nsent 9 bytes  received 9 bytes  1.00 bytes/sec\n";
-        let up = "a.txt\n  5,678 bytes\nsent 7 bytes  received 7 bytes  2.00 bytes/sec\n";
-        assert_eq!(normalize(oc), normalize(up));
-        // The number and its trailing `bytes` unit collapse to one placeholder.
-        assert_eq!(normalize(oc), vec!["a.txt".to_string(), "#".to_string()]);
     }
 }

--- a/xtask/src/commands/validate/checks/whole_file.rs
+++ b/xtask/src/commands/validate/checks/whole_file.rs
@@ -1,0 +1,373 @@
+//! Whole-file vs delta transfer parity between oc-rsync and upstream.
+//!
+//! The choice between rsync's delta algorithm (`--no-whole-file`) and a plain
+//! whole-file copy (`-W`) affects only what crosses the wire: the delivered
+//! destination bytes must be identical either way, and identical to upstream's.
+//! This check exercises oc-rsync's delta path against upstream by pre-seeding
+//! each destination with a *basis* `data.bin` that shares long common runs with
+//! the source but differs in a few scattered regions - so `--no-whole-file`
+//! forces a real delta transfer with genuine block matches and literal spans,
+//! not a trivial no-op. `-I` (ignore-times) makes the transfer run over that
+//! basis regardless of size/mtime.
+//!
+//! Because the destination is pre-seeded, this check cannot use
+//! `transport::pull_into` (which wipes the destination first). It builds the
+//! client `Command` directly - reusing `pull_into`'s per-transport operand
+//! forms - and transfers into the seeded tree without resetting it. The oc and
+//! upstream destinations are seeded with the same basis bytes, so only the
+//! client under test varies. Both scenarios (`delta`, `whole`) run per transport;
+//! the ssh transports are skipped when no sshd answers on localhost:22.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The whole-file vs delta delivered-bytes parity check.
+pub struct WholeFile;
+
+/// Length of the deterministic `data.bin` fixture (256 KiB): large enough to
+/// span many delta blocks so the algorithm has real matches and literals.
+const DATA_LEN: usize = 256 * 1024;
+
+/// A fixed epoch (2021-03-04) applied to the source fixture.
+const MTIME: &str = "@1614830767";
+
+/// One transfer scenario: a human label and the rsync flag set that selects the
+/// delta path or the whole-file path. `-I` forces the transfer to run over the
+/// pre-seeded basis in both.
+struct Scenario {
+    /// Short label used in the cell name.
+    label: &'static str,
+    /// Complete rsync flag set for this scenario.
+    flags: &'static [&'static str],
+}
+
+/// The two scenarios: force the delta algorithm, then force a whole-file copy.
+/// Both must deliver destination bytes identical to the source and to upstream.
+const SCENARIOS: &[Scenario] = &[
+    Scenario {
+        label: "delta",
+        flags: &["-rlptgoD", "--no-whole-file", "-I", "--numeric-ids"],
+    },
+    Scenario {
+        label: "whole",
+        flags: &["-rlptgoD", "-W", "-I", "--numeric-ids"],
+    },
+];
+
+/// Scattered byte windows flipped in the basis relative to the source. Each is
+/// an `(offset, len)` region fully inside [`DATA_LEN`]; flipping a handful keeps
+/// long common runs between them so the delta path finds matches *and* literals.
+const FLIP_WINDOWS: &[(usize, usize)] = &[
+    (1_024, 64),
+    (40_960, 128),
+    (131_072, 96),
+    (200_000, 256),
+    (262_000, 48),
+];
+
+impl Check for WholeFile {
+    fn name(&self) -> &'static str {
+        "whole-file"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("whole-file");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let mut outcomes = Vec::new();
+        for &transport in ctx.transports {
+            for scenario in SCENARIOS {
+                outcomes.push(self.cell(ctx, transport, scenario, &root, &src));
+            }
+        }
+        outcomes
+    }
+}
+
+impl WholeFile {
+    /// Run one `(transport, scenario)` cell: seed both destinations with the same
+    /// basis, transfer with each client, and require both destinations end
+    /// byte-identical to the source and to each other.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        scenario: &Scenario,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = format!("{} {}", transport.label(), scenario.label);
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let basis = match basis_bytes(src) {
+            Ok(bytes) => bytes,
+            Err(e) => return CheckOutcome::skip(self.name(), label, e),
+        };
+
+        let up_dst = root.join(format!("up-{}-{}", transport.label(), scenario.label));
+        let oc_dst = root.join(format!("oc-{}-{}", transport.label(), scenario.label));
+        if let Err(e) = seed_dest(&basis, &up_dst) {
+            return CheckOutcome::skip(self.name(), label, format!("seed upstream dest: {e}"));
+        }
+        if let Err(e) = seed_dest(&basis, &oc_dst) {
+            return CheckOutcome::skip(self.name(), label, format!("seed oc dest: {e}"));
+        }
+
+        // Non-vacuous guard: the seeded basis must really differ from the source
+        // before the transfer, or the delta path is not exercised over a basis.
+        let source = std::fs::read(src.join("data.bin")).ok();
+        let seeded = std::fs::read(oc_dst.join("data.bin")).ok();
+        if seeded.is_none() || seeded == source {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                "seed guard: dest data.bin did not differ from source basis",
+            );
+        }
+
+        let _up = match run_transfer(
+            ctx.upstream,
+            ctx.upstream,
+            transport.for_upstream(),
+            scenario.flags,
+            src,
+            &up_dst,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        };
+        let _oc = match run_transfer(
+            ctx.oc,
+            ctx.upstream,
+            transport,
+            scenario.flags,
+            src,
+            &oc_dst,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => out,
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        };
+
+        // Delivered bytes must match the source and upstream regardless of
+        // whether the delta or whole-file path moved them.
+        if let Some(d) = support::content_diff(&up_dst, src) {
+            return CheckOutcome::fail(self.name(), label, format!("upstream dest != source: {d}"));
+        }
+        if let Some(d) = support::content_diff(&oc_dst, src) {
+            return CheckOutcome::fail(self.name(), label, format!("oc dest != source: {d}"));
+        }
+        if let Some(d) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("oc dest != upstream dest: {d}"),
+            );
+        }
+
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Read the source `data.bin` and derive the basis by flipping [`FLIP_WINDOWS`].
+fn basis_bytes(src: &Path) -> Result<Vec<u8>, String> {
+    let source = std::fs::read(src.join("data.bin")).map_err(|e| e.to_string())?;
+    Ok(mutate_basis(&source))
+}
+
+/// Build the transfer command for one cell without touching the destination.
+///
+/// Mirrors `transport::pull_into`'s operand forms - local copy, ssh subprocess,
+/// russh `ssh://` URL, or an upstream `rsync://` daemon - but omits the
+/// destination reset so the pre-seeded basis survives into the transfer.
+fn run_transfer(
+    client: &Path,
+    upstream: &Path,
+    transport: Transport,
+    flags: &[&str],
+    src: &Path,
+    dst: &Path,
+    work: &Path,
+) -> TaskResult<Output> {
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let daemon = DaemonHandle::start(upstream, src, work)?;
+            cmd.arg(daemon.module_url()).arg(&dst_arg);
+            let out = spawn(cmd)?;
+            drop(daemon);
+            return Ok(out);
+        }
+    }
+    spawn(cmd)
+}
+
+/// Run a prepared command, capturing its output.
+fn spawn(mut cmd: Command) -> TaskResult<Output> {
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Distinguish a genuine divergence (non-zero exit) from an unrunnable cell.
+fn skip_or_fail(
+    check: &'static str,
+    label: String,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Deterministic byte generator: `data.bin`'s content derived purely from the
+/// index, with no system randomness. Each byte mixes the index through a couple
+/// of cheap operations so the stream is non-constant and non-periodic enough for
+/// the rolling checksum to distinguish blocks. Reproducible across runs.
+fn deterministic_bytes(len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(len);
+    for i in 0..len {
+        let i = i as u64;
+        let mixed = i
+            .wrapping_mul(2_654_435_761)
+            .wrapping_add(i >> 3)
+            .rotate_left((i & 31) as u32);
+        out.push((mixed ^ (mixed >> 17)) as u8);
+    }
+    out
+}
+
+/// Derive a basis from the source bytes by flipping [`FLIP_WINDOWS`]. The result
+/// has the same length and is byte-identical outside those windows, so it shares
+/// long common runs with the source (delta matches) while differing inside them
+/// (delta literals). Windows past the end are clamped and safely ignored.
+fn mutate_basis(source: &[u8]) -> Vec<u8> {
+    let mut basis = source.to_vec();
+    let len = basis.len();
+    for &(offset, window) in FLIP_WINDOWS {
+        let start = offset.min(len);
+        let end = offset.saturating_add(window).min(len);
+        for byte in basis.iter_mut().take(end).skip(start) {
+            *byte ^= 0xFF;
+        }
+    }
+    basis
+}
+
+/// Build the source tree: a deterministic ~256 KiB `data.bin` plus a small
+/// `sub/note.txt`, with mtimes backdated to [`MTIME`]. Idempotent: removes any
+/// prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src.join("sub")).map_err(|e| e.to_string())?;
+    std::fs::write(src.join("data.bin"), deterministic_bytes(DATA_LEN))
+        .map_err(|e| e.to_string())?;
+    std::fs::write(src.join("sub/note.txt"), b"whole-file fixture note\n")
+        .map_err(|e| e.to_string())?;
+    backdate(&src.join("data.bin"))?;
+    backdate(&src.join("sub/note.txt"))
+}
+
+/// Pre-seed a destination with the basis `data.bin` (and nothing else, so the
+/// transfer creates `sub/note.txt` fresh). Recreates `dst` empty first.
+fn seed_dest(basis: &[u8], dst: &Path) -> Result<(), String> {
+    if dst.exists() {
+        std::fs::remove_dir_all(dst).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(dst).map_err(|e| e.to_string())?;
+    std::fs::write(dst.join("data.bin"), basis).map_err(|e| e.to_string())
+}
+
+/// Set one path's mtime to [`MTIME`] via `touch`.
+fn backdate(path: &Path) -> Result<(), String> {
+    support::capture("touch", &["-h", "-d", MTIME, &path.to_string_lossy()])
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DATA_LEN, FLIP_WINDOWS, deterministic_bytes, mutate_basis};
+
+    #[test]
+    fn generator_is_deterministic_and_non_constant() {
+        let a = deterministic_bytes(4_096);
+        let b = deterministic_bytes(4_096);
+        assert_eq!(a, b, "generator must be reproducible");
+        assert_eq!(a.len(), 4_096);
+        assert!(
+            a.iter().any(|&x| x != a[0]),
+            "stream must not be a single repeated byte"
+        );
+    }
+
+    #[test]
+    fn basis_shares_long_runs_but_differs_in_flip_windows() {
+        let source = deterministic_bytes(DATA_LEN);
+        let basis = mutate_basis(&source);
+        assert_eq!(basis.len(), source.len(), "basis keeps source length");
+        assert_ne!(basis, source, "basis must differ from source");
+
+        // Inside each in-range window every byte is flipped; outside all match.
+        let mut flipped = vec![false; source.len()];
+        for &(offset, len) in FLIP_WINDOWS {
+            let end = (offset + len).min(source.len());
+            for (i, f) in flipped.iter_mut().enumerate().take(end).skip(offset) {
+                assert_ne!(basis[i], source[i], "byte {i} in a flip window must differ");
+                *f = true;
+            }
+        }
+        for (i, f) in flipped.iter().enumerate() {
+            if !f {
+                assert_eq!(basis[i], source[i], "byte {i} outside windows must match");
+            }
+        }
+    }
+
+    #[test]
+    fn out_of_range_window_is_ignored_not_panicking() {
+        // A short buffer smaller than every FLIP_WINDOW offset must not panic and
+        // must come back unchanged (all windows clamp away).
+        let short = deterministic_bytes(8);
+        assert_eq!(mutate_basis(&short), short);
+    }
+}

--- a/xtask/src/commands/validate/checks/xattr.rs
+++ b/xtask/src/commands/validate/checks/xattr.rs
@@ -1,0 +1,317 @@
+//! Deep user-xattr (`-X`) parity between oc-rsync and upstream.
+//!
+//! Where `acl_xattr` bundles ACLs with a token xattr, this check exercises
+//! extended attributes alone and in depth: multiple keys on one file, an
+//! empty-value key, a value with spaces and an `=` sign, a base64/binary value,
+//! and a key on a directory. The fixture is pulled with each client over every
+//! transport and oc's destination must be byte- and xattr-identical to
+//! upstream's. Xattrs are compared per entry, path-independently (the `# file:`
+//! header line is dropped), so readdir order never causes a false mismatch. The
+//! whole check skips when the tools or work filesystem cannot carry user xattrs.
+
+use std::path::{Path, PathBuf};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The deep user-xattr parity check.
+pub struct Xattr;
+
+/// Preserve standard metadata plus xattrs (no ACLs, so no `-A`).
+const FLAGS: &[&str] = &["-rlptgoD", "-X", "--numeric-ids"];
+
+/// External tools required to build the fixture and compare xattrs.
+const TOOLS: &[&str] = &["setfattr", "getfattr"];
+
+/// The three keys that must survive on `a.txt`, used for the non-vacuous guard.
+const A_KEYS: &[&str] = &["user.one", "user.two", "user.three"];
+
+impl Check for Xattr {
+    fn name(&self) -> &'static str {
+        "xattr"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        if !TOOLS.iter().all(|t| support::tool_available(t)) {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                "support",
+                "setfattr/getfattr missing",
+            )];
+        }
+        if !fs_supports_user_xattr(ctx.work) {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                "support",
+                "filesystem does not support user xattrs",
+            )];
+        }
+
+        let root = ctx.work.join("xattr");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let expected = support::entry_count(&src);
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &flags, expected))
+            .collect()
+    }
+}
+
+impl Xattr {
+    /// Run one transport cell: pull with both clients and compare xattrs.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        flags: &[String],
+        expected: usize,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let src = root.join("src");
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        let up = pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            &src,
+            &up_dst,
+            flags,
+            ctx.work,
+        );
+        match up {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        }
+        let oc = pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            &src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        );
+        match oc {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        }
+
+        // Genuine-result guard: both trees must be fully populated.
+        if support::entry_count(&up_dst) != expected || support::entry_count(&oc_dst) != expected {
+            return CheckOutcome::fail(self.name(), label, "destination entry count != source");
+        }
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+        // Non-vacuous guard: a bug that silently drops xattrs must be caught.
+        let a_dump = xattr_of(&oc_dst.join("a.txt")).unwrap_or_default();
+        if !A_KEYS.iter().all(|k| a_dump.contains(k)) {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                "oc dest a.txt missing user.one/two/three",
+            );
+        }
+        match xattr_diff(&oc_dst, &up_dst, ctx.verbose) {
+            Some(rel) => CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("xattr differs at {}", rel.display()),
+            ),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// First per-entry xattr divergence between two trees, or `None` when identical.
+/// Entries are walked in sorted order and compared path-independently. When
+/// `verbose`, the two differing dumps are printed to stderr.
+fn xattr_diff(oc: &Path, up: &Path, verbose: bool) -> Option<PathBuf> {
+    for rel in support::rel_entries(oc) {
+        let oc_dump = xattr_of(&oc.join(&rel));
+        let up_dump = xattr_of(&up.join(&rel));
+        if oc_dump != up_dump {
+            if verbose {
+                eprintln!("  xattr oc {}: {:?}", rel.display(), oc_dump);
+                eprintln!("  xattr up {}: {:?}", rel.display(), up_dump);
+            }
+            return Some(rel);
+        }
+    }
+    None
+}
+
+/// User xattrs of `path` with the path-bearing `# file:` line dropped.
+fn xattr_of(path: &Path) -> Option<String> {
+    let p = path.to_string_lossy();
+    let raw = support::capture("getfattr", &["-d", "-m", "-", "--absolute-names", &p]).ok()?;
+    Some(strip_file_line(&raw))
+}
+
+/// Drop the leading `# file:` header line from a `getfattr -d` dump, leaving a
+/// path-independent list of `key="value"` lines.
+fn strip_file_line(dump: &str) -> String {
+    dump.lines()
+        .filter(|line| !line.starts_with("# file:"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Probe whether `work`'s filesystem accepts a `user.*` xattr.
+fn fs_supports_user_xattr(work: &Path) -> bool {
+    let probe = work.join(".xattr_probe");
+    if std::fs::write(&probe, b"x").is_err() {
+        return false;
+    }
+    let ok = support::capture(
+        "setfattr",
+        &["-n", "user.probe", "-v", "1", &probe.to_string_lossy()],
+    )
+    .is_ok();
+    let _ = std::fs::remove_file(&probe);
+    ok
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the xattr fixture. Idempotent: removes any prior tree first.
+///
+/// Layout: `a.txt` (three keys plus an empty-value key), `b.bin` (a spaced value
+/// and a base64/binary value), `sub/c.txt`, a `sub` directory carrying a key,
+/// and a `link` symlink to `a.txt`.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+
+    let a = src.join("a.txt");
+    let b = src.join("b.bin");
+    let c = sub.join("c.txt");
+    std::fs::write(&a, b"alpha").map_err(|e| e.to_string())?;
+    std::fs::write(&b, b"bravo").map_err(|e| e.to_string())?;
+    std::fs::write(&c, b"charlie").map_err(|e| e.to_string())?;
+    make_symlink("a.txt", &src.join("link")).map_err(|e| e.to_string())?;
+
+    // Multiple keys on one file.
+    setfattr(&["-n", "user.one", "-v", "alpha", &a.to_string_lossy()])?;
+    setfattr(&["-n", "user.two", "-v", "beta", &a.to_string_lossy()])?;
+    setfattr(&["-n", "user.three", "-v", "gamma", &a.to_string_lossy()])?;
+    // Empty-value key (no `-v`).
+    setfattr(&["-n", "user.empty", &a.to_string_lossy()])?;
+
+    // A value with spaces and an `=` sign, and a base64/binary value.
+    setfattr(&[
+        "-n",
+        "user.note",
+        "-v",
+        "hello world = test",
+        &b.to_string_lossy(),
+    ])?;
+    setfattr(&[
+        "-n",
+        "user.bin",
+        "-v",
+        "0sAAECaGVsbG8=",
+        &b.to_string_lossy(),
+    ])?;
+
+    // A key on the directory itself.
+    setfattr(&[
+        "-n",
+        "user.dir",
+        "-v",
+        "on-a-directory",
+        &sub.to_string_lossy(),
+    ])?;
+
+    // Backdate mtimes so the quick-check does not skip anything under test.
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Set an xattr, surfacing failures as a fixture error.
+fn setfattr(args: &[&str]) -> Result<(), String> {
+    support::capture("setfattr", args)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+/// Create a symlink to `target` at `link` (no-op on non-unix platforms, where
+/// this check never runs because `setfattr`/`getfattr` are absent).
+#[cfg(unix)]
+fn make_symlink(target: &str, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+/// Non-unix stub: the check skips before this matters.
+#[cfg(not(unix))]
+fn make_symlink(_target: &str, _link: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_file_line;
+
+    #[test]
+    fn strip_file_line_drops_only_the_path_header() {
+        let dump = "# file: some/abs/path\nuser.one=\"alpha\"\nuser.two=\"beta\"";
+        assert_eq!(
+            strip_file_line(dump),
+            "user.one=\"alpha\"\nuser.two=\"beta\""
+        );
+    }
+
+    #[test]
+    fn strip_file_line_is_path_independent() {
+        let a = "# file: /work/oc-local/a.txt\nuser.one=\"alpha\"";
+        let b = "# file: /work/up-local/a.txt\nuser.one=\"alpha\"";
+        assert_eq!(strip_file_line(a), strip_file_line(b));
+    }
+
+    #[test]
+    fn strip_file_line_keeps_value_lines_without_a_header() {
+        let dump = "user.dir=\"on-a-directory\"";
+        assert_eq!(strip_file_line(dump), dump);
+    }
+}

--- a/xtask/src/commands/validate/mod.rs
+++ b/xtask/src/commands/validate/mod.rs
@@ -285,7 +285,18 @@ mod unix_impl {
 }
 
 #[cfg(not(unix))]
-pub fn execute(_workspace: &Path, _options: ValidateOptions) -> TaskResult<()> {
+pub fn execute(_workspace: &Path, options: ValidateOptions) -> TaskResult<()> {
+    // The transport matrix relies on Unix-only APIs (POSIX ids, symlinks, device
+    // nodes, ssh/daemon plumbing). Destructure the options so their fields are
+    // not reported as dead on non-Unix targets, then decline the command.
+    let ValidateOptions {
+        transports: _,
+        bench: _,
+        bench_files: _,
+        edge_cases: _,
+        root: _,
+        verbose: _,
+    } = options;
     Err(crate::error::TaskError::Validation(
         "`cargo xtask validate` is only supported on Unix hosts".into(),
     ))

--- a/xtask/src/commands/validate/mod.rs
+++ b/xtask/src/commands/validate/mod.rs
@@ -22,6 +22,8 @@ use crate::error::TaskResult;
 pub struct ValidateOptions {
     /// Transport labels to exercise; empty means all transports.
     pub transports: Vec<String>,
+    /// Ad-hoc rsync flag sets to validate for parity (each is one scenario).
+    pub flags: Vec<String>,
     /// Run the 10k-file performance benchmark after the correctness matrix.
     pub bench: bool,
     /// File count for the benchmark workload.
@@ -38,6 +40,7 @@ impl From<crate::cli::ValidateMatrixArgs> for ValidateOptions {
     fn from(args: crate::cli::ValidateMatrixArgs) -> Self {
         ValidateOptions {
             transports: args.transports,
+            flags: args.flags,
             bench: args.bench,
             bench_files: args.bench_files.unwrap_or(10_000),
             edge_cases: args.edge_cases,
@@ -135,6 +138,8 @@ mod unix_impl {
         pub work: &'a Path,
         /// Transports to exercise.
         pub transports: &'a [Transport],
+        /// Ad-hoc rsync flag sets to validate for parity (each is one scenario).
+        pub flags: &'a [String],
         /// Enrich fixtures with edge cases (opt-in).
         pub edge_cases: bool,
         /// Run root-only validations when the process is actually root.
@@ -197,6 +202,7 @@ mod unix_impl {
             upstream: &upstream,
             work: &work,
             transports: &transports,
+            flags: &options.flags,
             edge_cases: options.edge_cases,
             root: options.root,
             verbose: options.verbose,
@@ -291,6 +297,7 @@ pub fn execute(_workspace: &Path, options: ValidateOptions) -> TaskResult<()> {
     // not reported as dead on non-Unix targets, then decline the command.
     let ValidateOptions {
         transports: _,
+        flags: _,
         bench: _,
         bench_files: _,
         edge_cases: _,

--- a/xtask/src/commands/validate/mod.rs
+++ b/xtask/src/commands/validate/mod.rs
@@ -28,6 +28,8 @@ pub struct ValidateOptions {
     pub bench_files: usize,
     /// Enrich fixtures with edge cases (opt-in).
     pub edge_cases: bool,
+    /// Run root-only validations (device nodes, id remaps) when actually root.
+    pub root: bool,
     /// Print each transfer's command and stdout on failure.
     pub verbose: bool,
 }
@@ -39,6 +41,7 @@ impl From<crate::cli::ValidateMatrixArgs> for ValidateOptions {
             bench: args.bench,
             bench_files: args.bench_files.unwrap_or(10_000),
             edge_cases: args.edge_cases,
+            root: args.root,
             verbose: args.verbose,
         }
     }
@@ -134,6 +137,8 @@ mod unix_impl {
         pub transports: &'a [Transport],
         /// Enrich fixtures with edge cases (opt-in).
         pub edge_cases: bool,
+        /// Run root-only validations when the process is actually root.
+        pub root: bool,
         /// Verbose diagnostics.
         pub verbose: bool,
     }
@@ -193,6 +198,7 @@ mod unix_impl {
             work: &work,
             transports: &transports,
             edge_cases: options.edge_cases,
+            root: options.root,
             verbose: options.verbose,
         };
 

--- a/xtask/src/commands/validate/mod.rs
+++ b/xtask/src/commands/validate/mod.rs
@@ -1,0 +1,286 @@
+//! `cargo xtask validate` - drop-in fidelity matrix.
+//!
+//! Runs oc-rsync and upstream rsync as the pulling client over every client
+//! transport (local, ssh subprocess, embedded russh, daemon) and asserts the
+//! results are identical across content, metadata, ACLs, xattrs, and verbose /
+//! progress output. Optionally benchmarks a 10k-file workload across the same
+//! transports to feed performance work.
+//!
+//! Each check is a self-contained [`Check`] strategy that owns its fixture and
+//! comparison and reports one [`CheckOutcome`] per matrix cell; the runner just
+//! aggregates. This keeps checks independent and individually testable.
+
+use std::path::Path;
+
+use crate::error::TaskResult;
+
+/// Platform-agnostic options parsed from the CLI.
+///
+/// Transports are carried as labels so this type compiles on every platform;
+/// the Unix-only runner resolves them to concrete transports.
+#[derive(Debug, Default)]
+pub struct ValidateOptions {
+    /// Transport labels to exercise; empty means all transports.
+    pub transports: Vec<String>,
+    /// Run the 10k-file performance benchmark after the correctness matrix.
+    pub bench: bool,
+    /// File count for the benchmark workload.
+    pub bench_files: usize,
+    /// Enrich fixtures with edge cases (opt-in).
+    pub edge_cases: bool,
+    /// Print each transfer's command and stdout on failure.
+    pub verbose: bool,
+}
+
+impl From<crate::cli::ValidateMatrixArgs> for ValidateOptions {
+    fn from(args: crate::cli::ValidateMatrixArgs) -> Self {
+        ValidateOptions {
+            transports: args.transports,
+            bench: args.bench,
+            bench_files: args.bench_files.unwrap_or(10_000),
+            edge_cases: args.edge_cases,
+            verbose: args.verbose,
+        }
+    }
+}
+
+#[cfg(unix)]
+mod bench;
+#[cfg(unix)]
+mod checks;
+#[cfg(unix)]
+mod support;
+#[cfg(unix)]
+mod transport;
+
+#[cfg(unix)]
+pub use unix_impl::{Check, CheckOutcome, ValidateCtx, execute};
+
+#[cfg(unix)]
+mod unix_impl {
+    use super::*;
+    use transport::Transport;
+
+    /// One check's result for one matrix cell.
+    pub struct CheckOutcome {
+        /// Check name (e.g. `metadata`).
+        pub check: &'static str,
+        /// Cell label (usually a transport, e.g. `ssh-subprocess`).
+        pub cell: String,
+        /// Outcome of the cell.
+        pub status: Status,
+        /// One-line detail (diagnostic on failure, note otherwise).
+        pub detail: String,
+    }
+
+    /// Pass / fail / skip for one cell.
+    #[derive(PartialEq, Eq)]
+    pub enum Status {
+        /// oc matched upstream.
+        Pass,
+        /// oc diverged from upstream.
+        Fail,
+        /// Cell could not run (missing tool, unreachable sshd).
+        Skip,
+    }
+
+    impl CheckOutcome {
+        /// Construct a passing outcome.
+        pub fn pass(check: &'static str, cell: impl Into<String>) -> Self {
+            Self {
+                check,
+                cell: cell.into(),
+                status: Status::Pass,
+                detail: String::new(),
+            }
+        }
+        /// Construct a failing outcome with a diagnostic.
+        pub fn fail(
+            check: &'static str,
+            cell: impl Into<String>,
+            detail: impl Into<String>,
+        ) -> Self {
+            Self {
+                check,
+                cell: cell.into(),
+                status: Status::Fail,
+                detail: detail.into(),
+            }
+        }
+        /// Construct a skipped outcome with a reason.
+        pub fn skip(
+            check: &'static str,
+            cell: impl Into<String>,
+            reason: impl Into<String>,
+        ) -> Self {
+            Self {
+                check,
+                cell: cell.into(),
+                status: Status::Skip,
+                detail: reason.into(),
+            }
+        }
+    }
+
+    /// Shared context passed to every check.
+    pub struct ValidateCtx<'a> {
+        /// oc-rsync binary under test.
+        pub oc: &'a Path,
+        /// Upstream rsync binary (ground truth + remote sender).
+        pub upstream: &'a Path,
+        /// Scratch root; checks create subdirectories under it.
+        pub work: &'a Path,
+        /// Transports to exercise.
+        pub transports: &'a [Transport],
+        /// Enrich fixtures with edge cases (opt-in).
+        pub edge_cases: bool,
+        /// Verbose diagnostics.
+        pub verbose: bool,
+    }
+
+    /// A single fidelity check. Owns its fixture and comparison; runs across the
+    /// transports (or directions) it cares about, honoring `ctx.transports`.
+    pub trait Check {
+        /// Stable check name for the report.
+        fn name(&self) -> &'static str;
+        /// Run the check, returning one outcome per matrix cell.
+        fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome>;
+    }
+
+    /// Resolve requested transport labels to concrete transports (all if empty).
+    fn resolve_transports(labels: &[String]) -> TaskResult<Vec<Transport>> {
+        if labels.is_empty() {
+            return Ok(Transport::ALL.to_vec());
+        }
+        labels
+            .iter()
+            .map(|l| {
+                Transport::parse(l).ok_or_else(|| {
+                    crate::error::TaskError::Validation(format!("unknown transport `{l}`"))
+                })
+            })
+            .collect()
+    }
+
+    /// Detect binaries, run every check, print the matrix, and fail if any cell
+    /// diverged.
+    pub fn execute(workspace: &Path, options: ValidateOptions) -> TaskResult<()> {
+        let oc = crate::commands::interop::shared::oc_rsync::detect_oc_rsync_binary(workspace)?;
+        let upstream = pick_upstream(workspace)?;
+        let transports = resolve_transports(&options.transports)?;
+
+        let work = workspace.join("target/validate");
+        if work.exists() {
+            let _ = std::fs::remove_dir_all(&work);
+        }
+        std::fs::create_dir_all(&work)
+            .map_err(|e| crate::error::TaskError::Validation(format!("create work dir: {e}")))?;
+
+        eprintln!(
+            "[validate] oc-rsync={} vs upstream={} over [{}]",
+            oc.binary_path().display(),
+            upstream.display(),
+            transports
+                .iter()
+                .map(|t| t.label())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        let ctx = ValidateCtx {
+            oc: oc.binary_path(),
+            upstream: &upstream,
+            work: &work,
+            transports: &transports,
+            edge_cases: options.edge_cases,
+            verbose: options.verbose,
+        };
+
+        let mut outcomes = Vec::new();
+        for check in checks::all() {
+            outcomes.extend(check.run(&ctx));
+        }
+        report(&outcomes);
+
+        if options.bench {
+            bench::run(&ctx, options.bench_files)?;
+        }
+
+        let failed = outcomes.iter().filter(|o| o.status == Status::Fail).count();
+        if failed > 0 {
+            return Err(crate::error::TaskError::Validation(format!(
+                "{failed} fidelity check(s) diverged from upstream"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Ground-truth upstream rsync: prefer the system `rsync` on `PATH` (the
+    /// real drop-in comparison target), else an interop-built binary (3.4.x
+    /// preferred).
+    fn pick_upstream(workspace: &Path) -> TaskResult<std::path::PathBuf> {
+        if let Some(system) = system_rsync() {
+            return Ok(system);
+        }
+        let all = crate::commands::interop::shared::upstream::detect_upstream_binaries(workspace)?;
+        let available: Vec<_> = all.into_iter().filter(|b| b.is_available()).collect();
+        let chosen = available
+            .iter()
+            .find(|b| b.version_string().starts_with("3.4"))
+            .or_else(|| available.first())
+            .ok_or_else(|| {
+                crate::error::TaskError::Validation("no upstream rsync binary found".into())
+            })?;
+        Ok(chosen.binary_path().to_path_buf())
+    }
+
+    /// Locate a working `rsync` on `PATH`.
+    fn system_rsync() -> Option<std::path::PathBuf> {
+        let path_var = std::env::var_os("PATH")?;
+        for dir in std::env::split_paths(&path_var) {
+            let candidate = dir.join("rsync");
+            if candidate.is_file()
+                && std::process::Command::new(&candidate)
+                    .arg("--version")
+                    .output()
+                    .map(|out| out.status.success())
+                    .unwrap_or(false)
+            {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    /// Print the matrix grouped by check, plus a summary line.
+    fn report(outcomes: &[CheckOutcome]) {
+        let (mut pass, mut fail, mut skip) = (0, 0, 0);
+        eprintln!("\n=== fidelity matrix ===");
+        let mut current = "";
+        for o in outcomes {
+            if o.check != current {
+                eprintln!("\n{}:", o.check);
+                current = o.check;
+            }
+            let (mark, count) = match o.status {
+                Status::Pass => ("PASS", &mut pass),
+                Status::Fail => ("FAIL", &mut fail),
+                Status::Skip => ("SKIP", &mut skip),
+            };
+            *count += 1;
+            if o.detail.is_empty() {
+                eprintln!("  [{mark}] {}", o.cell);
+            } else {
+                eprintln!("  [{mark}] {} - {}", o.cell, o.detail);
+            }
+        }
+        eprintln!("\n=== {pass} passed, {fail} failed, {skip} skipped ===");
+    }
+}
+
+#[cfg(not(unix))]
+pub fn execute(_workspace: &Path, _options: ValidateOptions) -> TaskResult<()> {
+    Err(crate::error::TaskError::Validation(
+        "`cargo xtask validate` is only supported on Unix hosts".into(),
+    ))
+}

--- a/xtask/src/commands/validate/mod.rs
+++ b/xtask/src/commands/validate/mod.rs
@@ -293,17 +293,18 @@ mod unix_impl {
 #[cfg(not(unix))]
 pub fn execute(_workspace: &Path, options: ValidateOptions) -> TaskResult<()> {
     // The transport matrix relies on Unix-only APIs (POSIX ids, symlinks, device
-    // nodes, ssh/daemon plumbing). Destructure the options so their fields are
-    // not reported as dead on non-Unix targets, then decline the command.
-    let ValidateOptions {
-        transports: _,
-        flags: _,
-        bench: _,
-        bench_files: _,
-        edge_cases: _,
-        root: _,
-        verbose: _,
-    } = options;
+    // nodes, ssh/daemon plumbing). Read each field so it is not reported as dead
+    // on non-Unix targets (a `_` destructure discards without counting as a
+    // read), then decline the command.
+    let _ = (
+        &options.transports,
+        &options.flags,
+        options.bench,
+        options.bench_files,
+        options.edge_cases,
+        options.root,
+        options.verbose,
+    );
     Err(crate::error::TaskError::Validation(
         "`cargo xtask validate` is only supported on Unix hosts".into(),
     ))

--- a/xtask/src/commands/validate/support.rs
+++ b/xtask/src/commands/validate/support.rs
@@ -1,0 +1,179 @@
+//! Shared helpers for validate checks: external-tool capture, tool probing,
+//! entry counting, and content comparison.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::error::{TaskError, TaskResult};
+
+/// Run `program args...`, returning trimmed stdout; error on non-zero exit.
+pub fn capture(program: &str, args: &[&str]) -> TaskResult<String> {
+    let out = Command::new(program)
+        .args(args)
+        .output()
+        .map_err(|e| TaskError::Validation(format!("spawn {program}: {e}")))?;
+    if !out.status.success() {
+        return Err(TaskError::Validation(format!(
+            "{program} {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim_end().to_string())
+}
+
+/// True if a TCP connection to localhost:22 succeeds (sshd likely present).
+pub fn ssh_ready() -> bool {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 22);
+    std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(300)).is_ok()
+}
+
+/// True if `program` can be spawned (present on PATH).
+pub fn tool_available(program: &str) -> bool {
+    Command::new(program)
+        .arg("--help")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
+}
+
+/// Recursively count entries (files, dirs, symlinks) under `dir`.
+pub fn entry_count(dir: &Path) -> usize {
+    let mut count = 0;
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            count += 1;
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                count += entry_count(&entry.path());
+            }
+        }
+    }
+    count
+}
+
+/// Sorted relative paths of every entry under `root` (dirs, files, symlinks).
+pub fn rel_entries(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    collect(root, root, &mut out);
+    out.sort();
+    out
+}
+
+fn collect(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Ok(rel) = path.strip_prefix(root) {
+                out.push(rel.to_path_buf());
+            }
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                collect(root, &path, out);
+            }
+        }
+    }
+}
+
+/// Compare two destination trees for entry set, type, file bytes, and symlink
+/// targets. Returns the first divergence, or `None` when identical.
+pub fn content_diff(a: &Path, b: &Path) -> Option<String> {
+    let (ea, eb) = (rel_entries(a), rel_entries(b));
+    if ea != eb {
+        return Some(format!(
+            "entry set differs ({} vs {} entries)",
+            ea.len(),
+            eb.len()
+        ));
+    }
+    for rel in &ea {
+        let (pa, pb) = (a.join(rel), b.join(rel));
+        let (ma, mb) = match (pa.symlink_metadata(), pb.symlink_metadata()) {
+            (Ok(ma), Ok(mb)) => (ma, mb),
+            _ => return Some(format!("cannot stat {}", rel.display())),
+        };
+        let (ta, tb) = (ma.file_type(), mb.file_type());
+        if ta.is_symlink() != tb.is_symlink() || ta.is_dir() != tb.is_dir() {
+            return Some(format!("type differs at {}", rel.display()));
+        }
+        if ta.is_symlink() {
+            if std::fs::read_link(&pa).ok() != std::fs::read_link(&pb).ok() {
+                return Some(format!("symlink target differs at {}", rel.display()));
+            }
+        } else if ta.is_file() && std::fs::read(&pa).ok() != std::fs::read(&pb).ok() {
+            return Some(format!("file content differs at {}", rel.display()));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{content_diff, entry_count, rel_entries};
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn entry_count_recurses_but_does_not_follow_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir(root.join("sub")).unwrap();
+        fs::write(root.join("a"), b"a").unwrap();
+        fs::write(root.join("sub/b"), b"b").unwrap();
+        symlink("a", root.join("link")).unwrap();
+        // sub + a + sub/b + link = 4; the symlink is counted but not traversed.
+        assert_eq!(entry_count(root), 4);
+    }
+
+    #[test]
+    fn rel_entries_are_sorted_and_relative() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("z")).unwrap();
+        fs::write(dir.path().join("a"), b"").unwrap();
+        fs::write(dir.path().join("z/y"), b"").unwrap();
+        let rels: Vec<String> = rel_entries(dir.path())
+            .into_iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(rels, vec!["a", "z", "z/y"]);
+    }
+
+    #[test]
+    fn content_diff_none_for_identical_trees() {
+        let (a, b) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        for root in [a.path(), b.path()] {
+            fs::write(root.join("f"), b"same").unwrap();
+            symlink("f", root.join("l")).unwrap();
+        }
+        assert!(content_diff(a.path(), b.path()).is_none());
+    }
+
+    #[test]
+    fn content_diff_reports_content_symlink_and_set_differences() {
+        let (a, b) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        fs::write(a.path().join("f"), b"alpha").unwrap();
+        fs::write(b.path().join("f"), b"beta").unwrap();
+        assert!(
+            content_diff(a.path(), b.path())
+                .unwrap()
+                .contains("content differs")
+        );
+
+        let (c, d) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        symlink("x", c.path().join("l")).unwrap();
+        symlink("y", d.path().join("l")).unwrap();
+        assert!(
+            content_diff(c.path(), d.path())
+                .unwrap()
+                .contains("symlink target")
+        );
+
+        let (e, f) = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
+        fs::write(e.path().join("only"), b"").unwrap();
+        assert!(
+            content_diff(e.path(), f.path())
+                .unwrap()
+                .contains("entry set")
+        );
+    }
+}

--- a/xtask/src/commands/validate/transport.rs
+++ b/xtask/src/commands/validate/transport.rs
@@ -1,0 +1,255 @@
+//! Client transports for the fidelity matrix.
+//!
+//! Each [`Transport`] runs oc-rsync (or upstream rsync) as the *pulling client*
+//! over one code path: a local filesystem copy, an ssh subprocess (`host:path`),
+//! the embedded russh client (`ssh://` URL), or an rsync daemon (`rsync://`).
+//! For every network transport the *sender* is upstream rsync - via
+//! `--rsync-path` for ssh/russh, and an upstream `--daemon` for `rsync://` - so
+//! only the client under test varies between two runs of the same cell.
+
+use std::io::Write as _;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::error::{TaskError, TaskResult};
+
+/// A client transport oc-rsync supports.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Transport {
+    /// Plain local filesystem copy (`src/ dst/`).
+    Local,
+    /// SSH subprocess (`-e ssh host:path`).
+    SshSubprocess,
+    /// Embedded russh client (`ssh://host/path`).
+    Russh,
+    /// Rsync daemon (`rsync://host:port/module`).
+    Daemon,
+}
+
+impl Transport {
+    /// All transports, in matrix order.
+    pub const ALL: [Transport; 4] = [
+        Transport::Local,
+        Transport::SshSubprocess,
+        Transport::Russh,
+        Transport::Daemon,
+    ];
+
+    /// Stable short label used in reports and CLI selection.
+    pub fn label(self) -> &'static str {
+        match self {
+            Transport::Local => "local",
+            Transport::SshSubprocess => "ssh-subprocess",
+            Transport::Russh => "russh",
+            Transport::Daemon => "daemon",
+        }
+    }
+
+    /// Parse a CLI `--transport` value; `None` if unrecognized.
+    pub fn parse(value: &str) -> Option<Transport> {
+        if value.is_empty() {
+            return None;
+        }
+        Transport::ALL
+            .into_iter()
+            .find(|t| t.label() == value || t.label().starts_with(value))
+    }
+
+    /// True when the transport needs a reachable sshd on localhost.
+    pub fn needs_ssh(self) -> bool {
+        matches!(self, Transport::SshSubprocess | Transport::Russh)
+    }
+
+    /// Transport the upstream reference should use for this cell.
+    ///
+    /// Upstream rsync has no embedded russh client, so the `ssh://` (russh) cell
+    /// is validated against upstream over the ssh subprocess - an identical
+    /// transfer, differing only in the client's SSH implementation.
+    pub fn for_upstream(self) -> Transport {
+        match self {
+            Transport::Russh => Transport::SshSubprocess,
+            other => other,
+        }
+    }
+}
+
+/// Pull `src/` into a fresh `dst/` using `client` over `transport`.
+///
+/// `flags` is the complete rsync flag set (e.g. `-rlptgoD -A -X`); the source
+/// operand and `--rsync-path`/daemon plumbing are added per transport. The
+/// sender is always `upstream` so only the client differs across runs. The
+/// destination directory is (re)created empty before the transfer.
+pub fn pull_into(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    flags: &[String],
+    work: &Path,
+) -> TaskResult<Output> {
+    reset_dir(dst)?;
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let daemon = DaemonHandle::start(upstream, src, work)?;
+            cmd.arg(daemon.module_url()).arg(&dst_arg);
+            let out = run(cmd)?;
+            drop(daemon);
+            return Ok(out);
+        }
+    }
+    run(cmd)
+}
+
+/// Run a prepared command, capturing combined output.
+fn run(mut cmd: Command) -> TaskResult<Output> {
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// A short-lived upstream rsync daemon exporting one directory as module `m`.
+///
+/// Kills the process and removes its config on drop, so a check can start one
+/// per transport cell without leaking daemons.
+pub struct DaemonHandle {
+    child: Child,
+    port: u16,
+    conf: PathBuf,
+}
+
+impl DaemonHandle {
+    /// Start `daemon_bin --daemon` exporting `export_dir` (read-only, no chroot)
+    /// on a free loopback port. Waits until the port accepts connections.
+    pub fn start(daemon_bin: &Path, export_dir: &Path, work: &Path) -> TaskResult<DaemonHandle> {
+        let port = free_port()?;
+        let conf = work.join(format!("rsyncd-{port}.conf"));
+        let body = format!(
+            "use chroot = no\nport = {port}\n[m]\n    path = {}\n    read only = true\n    numeric ids = yes\n",
+            export_dir.display()
+        );
+        std::fs::write(&conf, body)
+            .map_err(|e| TaskError::Validation(format!("write daemon config: {e}")))?;
+
+        let child = Command::new(daemon_bin)
+            .args(["--daemon", "--no-detach", "--config"])
+            .arg(&conf)
+            .arg(format!("--port={port}"))
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| TaskError::Validation(format!("spawn daemon on {port}: {e}")))?;
+
+        let handle = DaemonHandle { child, port, conf };
+        if !wait_for_port(port, Duration::from_secs(5)) {
+            return Err(TaskError::Validation(format!(
+                "daemon did not open port {port} within 5s"
+            )));
+        }
+        Ok(handle)
+    }
+
+    /// The `rsync://` URL for the exported module's contents.
+    pub fn module_url(&self) -> String {
+        format!("rsync://127.0.0.1:{}/m/", self.port)
+    }
+}
+
+impl Drop for DaemonHandle {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_file(&self.conf);
+    }
+}
+
+/// Pick a free TCP port on loopback by binding to port 0 and reading it back.
+fn free_port() -> TaskResult<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| TaskError::Validation(format!("bind ephemeral port: {e}")))?;
+    listener
+        .local_addr()
+        .map(|addr| addr.port())
+        .map_err(|e| TaskError::Validation(format!("read ephemeral port: {e}")))
+}
+
+/// Poll until `port` accepts a connection on loopback, or the timeout elapses.
+fn wait_for_port(port: u16, timeout: Duration) -> bool {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Ok(mut stream) = TcpStream::connect_timeout(&addr, Duration::from_millis(200)) {
+            let _ = stream.write(&[]);
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Transport;
+
+    #[test]
+    fn parse_accepts_exact_labels_and_unambiguous_prefixes() {
+        assert_eq!(Transport::parse("local"), Some(Transport::Local));
+        assert_eq!(Transport::parse("daemon"), Some(Transport::Daemon));
+        assert_eq!(Transport::parse("russh"), Some(Transport::Russh));
+        // Prefixes resolve to the first matching transport in ALL order.
+        assert_eq!(Transport::parse("ssh"), Some(Transport::SshSubprocess));
+        assert_eq!(Transport::parse("d"), Some(Transport::Daemon));
+    }
+
+    #[test]
+    fn parse_rejects_empty_and_unknown() {
+        assert_eq!(Transport::parse(""), None);
+        assert_eq!(Transport::parse("nfs"), None);
+    }
+
+    #[test]
+    fn every_label_round_trips_through_parse() {
+        for transport in Transport::ALL {
+            assert_eq!(Transport::parse(transport.label()), Some(transport));
+        }
+    }
+
+    #[test]
+    fn needs_ssh_is_true_only_for_ssh_paths() {
+        assert!(Transport::SshSubprocess.needs_ssh());
+        assert!(Transport::Russh.needs_ssh());
+        assert!(!Transport::Local.needs_ssh());
+        assert!(!Transport::Daemon.needs_ssh());
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -60,7 +60,7 @@ mod workspace;
 use crate::cli::{Cli, Command, CommandExt};
 use crate::commands::{
     benchmark, branding, doc_package, docs, interop, man_page, no_binaries, no_placeholders,
-    package, preflight, readme_version, release, release_notes, sbom, test,
+    package, preflight, readme_version, release, release_notes, sbom, test, validate,
 };
 use crate::error::TaskError;
 use crate::task::TreeRenderer;
@@ -116,6 +116,7 @@ fn run_command(cli: Cli) -> Result<(), TaskError> {
         Command::ReleaseNotes(args) => release_notes::execute(&workspace, args.into()),
         Command::Sbom(args) => sbom::execute(&workspace, args.into()),
         Command::Test(args) => test::execute(&workspace, args.into()),
+        Command::Validate(args) => validate::execute(&workspace, args.into()),
     }
 }
 


### PR DESCRIPTION
Adds `cargo xtask validate` - a reusable harness that runs oc-rsync and upstream rsync as the pulling client over every client transport (local, ssh subprocess, embedded russh, daemon) and asserts the results are identical to upstream across content, metadata, ACLs, xattrs, and verbose/progress output. An opt-in `--bench` runs a many-small-files loopback benchmark to feed performance work.

## Why

CI exercises oc-rsync over loopback for the daemon path, but nothing systematically compared oc's client-side output and metadata against the system rsync across all transports. This command closes that gap and doubles as a host-side performance and edge-case probe.

## Design (Strategy pattern)

- `transport.rs` - `Transport` enum (local / ssh-subprocess / russh / daemon) + RAII `DaemonHandle` + a single `pull_into` helper whose sender is always upstream, so only the client under test varies between two runs of a cell. `russh` (embedded `ssh://`) has no upstream equivalent, so its reference pull uses upstream-over-ssh - an identical transfer.
- `mod.rs` - `Check` trait + `CheckOutcome` + registry-driven runner and report. Unix-only internals are `#[cfg(unix)]`-gated; options stay platform-agnostic so Windows still builds. Ground-truth upstream is the system `rsync` on `PATH`.
- `support.rs` - shared helpers (external-tool capture, ssh probe, entry count, tree content diff).

Checks (each an independent `Check`):

| Check | Verifies |
|---|---|
| `metadata` | content + perms/mtime/uid/gid/hardlinks identical to upstream |
| `acl-xattr` | `-A`/`-X` parity, per-entry path-independent compare; skips when the work fs cannot carry ACLs/xattrs |
| `progress-interleave` | `-v --progress` name-then-progress (N,P,N,P) interleaving |
| `itemize` | `-vi` one row per entry, no duplicate bare-name line |
| `flist-banner` | banner direction: pull=receiving, push/local=sending |
| `total-size` | `--stats` total excludes directory inodes |

Opt-in `--edge-cases` enriches fixtures (empty files, spaces/unicode names, deep nesting, dangling symlinks). Opt-in `--bench [--bench-files N]` times oc vs upstream (median per transport) on a many-small-files workload.

## Usage

```
cargo xtask validate [--transport NAME]... [--edge-cases] [--bench [--bench-files N]] [--verbose]
```

## Validation

- `cargo nextest run -p xtask` green - adversarial unit tests for every pure helper (progress-pattern parsing, total-size parsing, banner direction, itemize classification, tree diff, transport parsing).
- `cargo clippy -p xtask --all-targets -- -D warnings` clean.
- Host-validated on x86_64 Linux against the system rsync 3.4.4 (protocol 32): **21 of 23 cells pass**; metadata, acl-xattr, flist-banner, and total-size are identical across all four transports.

## Findings surfaced on first run

The harness immediately reported two genuine divergences (left strict so they keep failing until fixed; tracked separately):

1. **Local `--progress` double final line** - on a local copy, oc renders the final `(xfr#N, to-chk=...)` line twice per file (network transports are correct). The local path emits an intermediate `handle_progress` tick plus the final `handle` tick, and the per-file renderer applies no throttle, so on non-terminal output the two become separate lines; upstream throttles the intermediate and emits only the final.
2. **russh emits an extra `./` root itemize row** - under `-vi`, oc over the embedded russh transport emits one more itemize row (the `./` root dir) than oc over the ssh subprocess and than upstream.

Both are engine/transport behaviors, out of scope for this tooling change, and each warrants a focused follow-up.
