### PR TITLE
fix: throttle per-file --progress ticks and gate xfr trailer

### DIFF
--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -265,6 +265,8 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                 let event = update.event();
                 let relative = event.relative_path();
                 let path_changed = self.active_path.as_deref() != Some(relative);
+                let now = Instant::now();
+                let is_final = update.is_final();
 
                 if path_changed {
                     if self.line_active {
@@ -279,10 +281,26 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                     let name = name.replace('\\', "/");
                     writeln!(self.writer, "{name}")?;
                     self.active_path = Some(relative.to_path_buf());
+                    // upstream: progress.c:205-222 - show_progress seeds
+                    // ph_start to the file's transfer start, so a new file's
+                    // throttle baseline is its start rather than a "first tick
+                    // always renders" special-case. A fast single-chunk file
+                    // whose intermediate tick falls within one interval of its
+                    // start therefore renders only the final xfr line.
+                    self.last_tick = Some(now);
+                }
+
+                // upstream: progress.c:224 - show_progress renders an in-flight
+                // tick at most once per interval since the last render, while
+                // end_progress (the final xfr-trailer tick) bypasses the
+                // throttle. Without this the forwarder's intermediate
+                // handle_progress tick and the final handle tick both render,
+                // duplicating the 100% line on non-terminal (piped) output.
+                if tick_throttled(self.last_tick, now, self.tick_interval, is_final) {
+                    return Ok(());
                 }
 
                 let bytes = event.bytes_transferred();
-                let now = Instant::now();
                 let estimator = self
                     .per_file_remaining
                     .entry(relative.to_path_buf())
@@ -302,14 +320,13 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                 );
                 // upstream: progress.c:97-105 prints ETA via the sliding window
                 // mid-transfer and switches to total elapsed for the final tick.
-                let time_text = if update.is_final() {
+                let time_text = if is_final {
                     format_progress_elapsed(event.elapsed())
                 } else {
                     let total = update.total_bytes().unwrap_or(bytes);
                     estimator.render(now, bytes, total)
                 };
                 let time_field = format!("{time_text:>10}");
-                let xfr_index = update.index();
 
                 if self.line_active {
                     if self.output_config.is_terminal {
@@ -319,22 +336,34 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                     }
                 }
 
-                // upstream: progress.c:80 - chk-prefix is "to" once the file
-                // list is complete, "ir" while INC_RECURSE sub-lists are still
-                // arriving on the wire.
-                let chk_prefix = if update.flist_eof() { "to" } else { "ir" };
-                write!(
-                    self.writer,
-                    "{size_field} {percent_field} {rate_field} {time_field} (xfr#{xfr_index}, {chk_prefix}-chk={remaining}/{total})"
-                )?;
-
-                if update.is_final() {
+                if is_final {
+                    // upstream: progress.c:77-92 - the `(xfr#..)` trailer is
+                    // emitted only on the final (is_last) tick; per-file mode
+                    // keeps the trailing newline. progress.c:80 - chk-prefix is
+                    // "to" once the file list is complete, "ir" while
+                    // INC_RECURSE sub-lists are still arriving on the wire.
+                    let chk_prefix = if update.flist_eof() { "to" } else { "ir" };
+                    let xfr_index = update.index();
+                    write!(
+                        self.writer,
+                        "{size_field} {percent_field} {rate_field} {time_field} (xfr#{xfr_index}, {chk_prefix}-chk={remaining}/{total})"
+                    )?;
                     writeln!(self.writer)?;
                     self.line_active = false;
                     self.active_path = None;
                     self.per_file_remaining.remove(relative);
                 } else {
+                    // upstream: progress.c:99-100 - in-flight ticks use a
+                    // trailing `"  "` (two spaces) instead of the xfr trailer.
+                    write!(
+                        self.writer,
+                        "{size_field} {percent_field} {rate_field} {time_field}  "
+                    )?;
                     self.line_active = true;
+                    // upstream: progress.c:224 - the throttle baseline advances
+                    // to the last rendered in-flight tick; the final tick does
+                    // not advance it.
+                    self.last_tick = Some(now);
                     // upstream: progress.c:133 - rflush(FCLIENT) after
                     // every non-final progress tick.
                     self.flush_if_needed()?;
@@ -520,6 +549,79 @@ mod tests {
         let output = String::from_utf8(buf).expect("utf8");
         assert!(output.contains("ir-chk="), "missing ir-chk: {output}");
         assert!(!output.contains("to-chk="), "unexpected to-chk: {output}");
+    }
+
+    /// Builds a per-path in-flight (non-final) update.
+    fn make_mid_for(path: &str) -> ClientProgressUpdate {
+        let event = ClientEvent::for_test(
+            PathBuf::from(path),
+            ClientEventKind::DataCopied,
+            false,
+            None,
+            LocalCopyChangeSet::new(),
+        );
+        ClientProgressUpdate::from_transfer_event_mid(
+            event,
+            1,
+            2,
+            Some(2_048),
+            1_024,
+            Some(2_048),
+            Duration::from_secs(0),
+            true,
+        )
+    }
+
+    /// Builds a per-path final update carrying the xfr trailer.
+    fn make_final_for(path: &str, index: usize) -> ClientProgressUpdate {
+        let event = ClientEvent::for_test(
+            PathBuf::from(path),
+            ClientEventKind::DataCopied,
+            true,
+            None,
+            LocalCopyChangeSet::new(),
+        );
+        ClientProgressUpdate::from_transfer_event(
+            event,
+            index,
+            2,
+            Some(2_048),
+            2_048,
+            Duration::from_secs(0),
+            true,
+        )
+    }
+
+    /// upstream: progress.c:77-92, 224 - a local copy forwards an intermediate
+    /// `handle_progress` tick and a final `handle` tick per file. When both
+    /// fall within one throttle interval (a fast single-chunk file), only the
+    /// final tick renders, and the `(xfr#..)` trailer is emitted solely on
+    /// that final tick. On non-terminal (piped) output each rendered tick is a
+    /// separate line, so exactly one `xfr#` line must appear per file - never
+    /// two. This is the regression guard for the duplicate-line bug.
+    #[test]
+    fn per_file_piped_emits_one_xfr_trailer_per_file() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live = LiveProgress::with_output_config(
+                &mut buf,
+                ProgressMode::PerFile,
+                HumanReadableMode::Grouped,
+                piped_config(),
+            );
+            // Two files, each an intermediate tick immediately followed by its
+            // final tick (well within the default throttle interval).
+            live.on_progress(&make_mid_for("a.bin"));
+            live.on_progress(&make_final_for("a.bin", 1));
+            live.on_progress(&make_mid_for("b.bin"));
+            live.on_progress(&make_final_for("b.bin", 2));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        let xfr_lines = output.lines().filter(|line| line.contains("xfr#")).count();
+        assert_eq!(
+            xfr_lines, 2,
+            "expected exactly one xfr trailer per file: {output:?}"
+        );
     }
 
     /// upstream: progress.c:100 - in-flight progress2 ticks use trailing
@@ -752,6 +854,9 @@ mod tests {
                 HumanReadableMode::Grouped,
                 piped_config(),
             );
+            // Disable throttling so both in-flight ticks render and exercise
+            // the `\n`-vs-`\r` line separator choice under test.
+            live.tick_interval = Duration::ZERO;
             live.on_progress(&make_mid_transfer_update(true));
             live.on_progress(&make_mid_transfer_update(true));
         }
@@ -774,6 +879,9 @@ mod tests {
                 HumanReadableMode::Grouped,
                 terminal_config(),
             );
+            // Disable throttling so both in-flight ticks render and exercise
+            // the `\r` in-place overwrite under test.
+            live.tick_interval = Duration::ZERO;
             live.on_progress(&make_mid_transfer_update(true));
             live.on_progress(&make_mid_transfer_update(true));
         }
@@ -952,6 +1060,9 @@ mod tests {
                 HumanReadableMode::Grouped,
                 config,
             );
+            // Disable throttling so the single in-flight tick renders and
+            // triggers the flush under test.
+            live.tick_interval = Duration::ZERO;
             // Mid-transfer tick should trigger flush
             live.on_progress(&make_mid_transfer_update(true));
         }
@@ -996,6 +1107,9 @@ mod tests {
                 HumanReadableMode::Grouped,
                 config,
             );
+            // Disable throttling so the in-flight tick renders; block-buffered
+            // mode must still not flush.
+            live.tick_interval = Duration::ZERO;
             live.on_progress(&make_mid_transfer_update(true));
         }
         let count = writer.flush_count.load(Ordering::Relaxed);
@@ -1039,6 +1153,9 @@ mod tests {
                 HumanReadableMode::Grouped,
                 config,
             );
+            // Disable throttling so the single in-flight tick renders and
+            // triggers the flush under test.
+            live.tick_interval = Duration::ZERO;
             live.on_progress(&make_mid_transfer_update(true));
         }
         let count = writer.flush_count.load(Ordering::Relaxed);


### PR DESCRIPTION
## Divergence

A local copy with `--progress` printed the final per-file progress line more than once per file when stdout is not a terminal (piped or redirected to a log). Upstream rsync 3.4.4 prints it once. On a real terminal the extras are masked by carriage-return overwrite, so the bug only bites piped/logged output. SSH and daemon transports were already correct - this was local-copy only.

Reproduce (a slow file exaggerates it):

```
oc-rsync -av --progress --bwlimit=5m SRC/ DST/ | tr '\r' '\n' | grep -c 'xfr#'
```

Before this change a single ~20 MB file produced 161 `xfr#` lines; after, it produces 1.

## Root cause

The per-file progress renderer (`crates/cli/src/frontend/progress/live.rs`, the `ProgressMode::PerFile` arm) did two things upstream does not:

1. It wrote the `(xfr#N, to-chk=..)` trailer on **every** progress tick, not just the final one.
2. It applied no time-based throttle, so every intermediate `handle_progress` tick rendered.

On non-terminal output each rendered tick lands on its own line, so the intermediate ticks and the final tick each produced a separate `xfr#` line.

Upstream `progress.c`:

- `rprint_progress` (lines 77-92) emits the `(xfr#..)` trailer only inside `if (is_last)`; non-final ticks use a two-space end-of-line (`strlcpy(eol, "  ", ...)`, line 100).
- `show_progress` (lines 205-224) throttles in-flight ticks to at most one render per interval, with the baseline seeded at the file's transfer start; `end_progress` (the final tick) bypasses the throttle.

The overall (`--info=progress2`) renderer already implemented both rules; the per-file arm did not.

## Fix

Bring the per-file arm in line with the overall arm and upstream:

- Seed the throttle baseline (`last_tick`) to "now" when a new file's name line is emitted, so the baseline is the file's transfer start rather than a "first tick always renders" special case. A fast single-chunk file whose intermediate and final ticks fall inside one interval renders only the final line.
- Drop non-final ticks that fall within the throttle interval via the shared `tick_throttled` helper; final ticks always render.
- Emit the `(xfr#..)` trailer only on final ticks. Non-final ticks use upstream's two-space end-of-line.

Terminal output is unchanged (the intermediate ticks were already overwritten via `\r`), large files still tick during transfer (throttled to the upstream ~1s rate), the interleaved name line still prints once per file, and SSH/daemon transports are untouched.

## Verification

- `cargo build --release --bin oc-rsync`, then the reproduction above: slow 20 MB file 161 -> 1 `xfr#` line; two 8 MB files -> 2 lines (one final each); destination tree byte-identical to source.
- Intermediate ticks now render with the two-space eol and carry no `xfr#` trailer; only the final tick carries `(xfr#1, to-chk=0/2)`.
- New targeted test `per_file_piped_emits_one_xfr_trailer_per_file` drives a fast two-file stream through the per-file renderer with a non-terminal writer and asserts exactly one `xfr#` line per file.
- `cargo nextest run -p cli -E 'test(progress::live)'`: 22 passed.
- `cargo fmt --all -- --check` clean; `cargo clippy -p cli -p core --all-targets --all-features --no-deps -- -D warnings` clean.
