### PR TITLE
fix: restore remote-pull stats breakdown and dry-run itemize

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -64,6 +64,12 @@ pub(super) fn convert_server_stats_to_summary(
                 transfer_stats.matched_data,
                 transfer_stats.delete_stats,
                 transfer_stats.created_stats,
+                engine::local_copy::FileTypeTotals {
+                    dirs: transfer_stats.num_dirs,
+                    symlinks: transfer_stats.num_symlinks,
+                    devices: transfer_stats.num_devices,
+                    specials: transfer_stats.num_specials,
+                },
             );
             (s, transfer_stats.io_error, transfer_stats.error_count)
         }

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -41,6 +41,12 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
                 transfer_stats.matched_data,
                 transfer_stats.delete_stats,
                 transfer_stats.created_stats,
+                engine::local_copy::FileTypeTotals {
+                    dirs: transfer_stats.num_dirs,
+                    symlinks: transfer_stats.num_symlinks,
+                    devices: transfer_stats.num_devices,
+                    specials: transfer_stats.num_specials,
+                },
             );
             (s, transfer_stats.io_error, transfer_stats.error_count)
         }

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -411,6 +411,10 @@ fn replay_batch(
             files: files_transferred as u64,
             ..protocol::CreatedStats::new()
         },
+        // The --read-batch replay engine does not reconstruct a per-type file
+        // breakdown, so leave the tallies at zero: reg = files_listed, the
+        // pre-existing behaviour.
+        engine::local_copy::FileTypeTotals::default(),
     );
     Ok(ClientSummary::from_summary(summary))
 }

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -89,9 +89,9 @@ pub use buffer_pool::{
 pub use deferred_sync::{DeferredSync, SyncStrategy};
 
 pub use plan::{
-    CopyMethodKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyExecution, LocalCopyFileKind,
-    LocalCopyMetadata, LocalCopyPlan, LocalCopyProgress, LocalCopyRecord, LocalCopyRecordHandler,
-    LocalCopyReport, LocalCopySummary, TimeChange,
+    CopyMethodKind, FileTypeTotals, LocalCopyAction, LocalCopyChangeSet, LocalCopyExecution,
+    LocalCopyFileKind, LocalCopyMetadata, LocalCopyPlan, LocalCopyProgress, LocalCopyRecord,
+    LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary, TimeChange,
 };
 
 pub use options::{

--- a/crates/engine/src/local_copy/plan/mod.rs
+++ b/crates/engine/src/local_copy/plan/mod.rs
@@ -24,7 +24,7 @@ pub use plan_impl::LocalCopyPlan;
 pub use progress::LocalCopyProgress;
 pub use record::{LocalCopyRecord, LocalCopyRecordHandler};
 pub use report::LocalCopyReport;
-pub use summary::{CopyMethodKind, LocalCopySummary};
+pub use summary::{CopyMethodKind, FileTypeTotals, LocalCopySummary};
 
 #[cfg(test)]
 pub(crate) use super::filter_program::FilterOutcome;

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -1,5 +1,28 @@
 use std::time::Duration;
 
+/// Per-type file-list tallies used to reconstruct the `--stats` "Number of
+/// files" breakdown for a remote transfer.
+///
+/// The regular-file count is not carried here: upstream derives it as the
+/// remainder (`total - (dirs + symlinks + devices + specials)`), and
+/// [`LocalCopySummary::from_receiver_stats`] does the same.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:2699-2712` - `recv_file_list()` per-type tally.
+/// - `main.c:387-411` - `output_itemized_counts()` derives `reg`.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct FileTypeTotals {
+    /// Directories in the file list (`stats.num_dirs`).
+    pub dirs: u64,
+    /// Symbolic links in the file list (`stats.num_symlinks`).
+    pub symlinks: u64,
+    /// Device nodes, block and character (`stats.num_devices`).
+    pub devices: u64,
+    /// FIFOs and sockets (`stats.num_specials`).
+    pub specials: u64,
+}
+
 /// I/O technology the local-copy executor used to materialise a whole-file
 /// copy. Tracked so the `Copy method` stats line can report which kernel
 /// acceleration ran. Upstream rsync has no equivalent - it always reconstructs
@@ -524,9 +547,26 @@ impl LocalCopySummary {
         matched_data: u64,
         delete_stats: protocol::DeleteStats,
         created_stats: protocol::CreatedStats,
+        file_type_totals: FileTypeTotals,
     ) -> Self {
+        // upstream: main.c:387-411 output_itemized_counts() - the "Number of
+        // files" line reports the total plus a per-type breakdown where the
+        // regular-file count is the remainder (total minus dirs/links/devs/
+        // specials). The receiver classifies the file list into these tallies
+        // (flist.c:2699-2712); reg is derived here so a remote pull prints the
+        // same `reg: R, dir: D, link: L` line as a local copy instead of
+        // counting every entry as a regular file.
+        let non_regular = file_type_totals
+            .dirs
+            .saturating_add(file_type_totals.symlinks)
+            .saturating_add(file_type_totals.devices)
+            .saturating_add(file_type_totals.specials);
         Self {
-            regular_files_total: files_listed as u64,
+            regular_files_total: (files_listed as u64).saturating_sub(non_regular),
+            directories_total: file_type_totals.dirs,
+            symlinks_total: file_type_totals.symlinks,
+            devices_total: file_type_totals.devices,
+            fifos_total: file_type_totals.specials,
             files_copied: files_transferred as u64,
             // upstream: receiver.c:784 stats.total_transferred_size, computed
             // locally by the pulling client's receiver (never sent on the wire).
@@ -844,6 +884,7 @@ mod tests {
             0,
             protocol::DeleteStats::new(),
             protocol::CreatedStats::new(),
+            FileTypeTotals::default(),
         );
         assert_eq!(summary.regular_files_total(), 100);
         assert_eq!(summary.files_copied(), 50);
@@ -855,6 +896,43 @@ mod tests {
         assert_eq!(summary.bytes_sent(), 256);
         assert_eq!(summary.total_source_bytes(), 8192);
         assert_eq!(summary.total_elapsed(), Duration::from_secs(5));
+    }
+
+    /// A remote pull (ssh or daemon) must reconstruct the `--stats` "Number of
+    /// files" breakdown from the file-list type tallies: `reg` is the remainder
+    /// (total minus dirs/links/devs/specials), and each typed total is surfaced.
+    /// Before the fix the receiver forwarded only the aggregate count, so every
+    /// entry was reported as `reg` and the dir/link/dev/special totals were zero
+    /// (`Number of files: 6 (reg: 6)` instead of `(reg: 2, dir: 3, link: 1)`).
+    ///
+    /// upstream: flist.c:2699-2712 per-type tally; main.c:387-411 derives `reg`.
+    #[test]
+    fn from_receiver_stats_derives_file_type_breakdown() {
+        let summary = LocalCopySummary::from_receiver_stats(
+            6,
+            2,
+            100,
+            50,
+            10,
+            100,
+            Duration::from_secs(1),
+            0,
+            0,
+            protocol::DeleteStats::new(),
+            protocol::CreatedStats::new(),
+            FileTypeTotals {
+                dirs: 3,
+                symlinks: 1,
+                devices: 0,
+                specials: 0,
+            },
+        );
+        // reg = 6 - (3 + 1) = 2; the typed totals feed the reg/dir/link line.
+        assert_eq!(summary.regular_files_total(), 2);
+        assert_eq!(summary.directories_total(), 3);
+        assert_eq!(summary.symlinks_total(), 1);
+        assert_eq!(summary.devices_total(), 0);
+        assert_eq!(summary.fifos_total(), 0);
     }
 
     #[test]
@@ -871,6 +949,7 @@ mod tests {
             1200,
             protocol::DeleteStats::new(),
             protocol::CreatedStats::new(),
+            FileTypeTotals::default(),
         );
         assert_eq!(summary.bytes_copied(), 800);
         assert_eq!(summary.matched_bytes(), 1200);
@@ -940,6 +1019,7 @@ mod tests {
             0,
             delete_stats,
             protocol::CreatedStats::new(),
+            FileTypeTotals::default(),
         );
         assert_eq!(summary.items_deleted(), 3);
         assert_eq!(summary.deleted_regular_files(), 2);
@@ -978,6 +1058,7 @@ mod tests {
             0,
             protocol::DeleteStats::new(),
             created_stats,
+            FileTypeTotals::default(),
         );
         assert_eq!(summary.created_regular_files(), 1);
         assert_eq!(summary.directories_created(), 3);

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -20,6 +20,39 @@ impl ReceiverContext {
         self.config.flags.info_flags.itemize
     }
 
+    /// Classifies the received file list into the per-type counts the pulling
+    /// client needs to reconstruct the `--stats` "Number of files" breakdown.
+    ///
+    /// Returns `(dirs, symlinks, devices, specials)`; the regular-file count is
+    /// the remainder (`files_listed - sum`). Mirrors upstream's per-type tally
+    /// as the file list is received, so a remote pull reports the same
+    /// `reg: R, dir: D, link: L` line as a local copy.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2699-2712` - `recv_file_list()` bumps `stats.num_dirs` /
+    ///   `num_symlinks` / `num_devices` / `num_specials` per entry.
+    /// - `main.c:387-411` - `output_itemized_counts()` derives `reg` as the
+    ///   total minus the other four categories.
+    pub(in crate::receiver) fn file_type_counts(&self) -> (u64, u64, u64, u64) {
+        let mut dirs = 0u64;
+        let mut symlinks = 0u64;
+        let mut devices = 0u64;
+        let mut specials = 0u64;
+        for entry in &self.file_list {
+            if entry.is_dir() {
+                dirs += 1;
+            } else if entry.is_symlink() {
+                symlinks += 1;
+            } else if entry.is_device() {
+                devices += 1;
+            } else if entry.is_special() {
+                specials += 1;
+            }
+        }
+        (dirs, symlinks, devices, specials)
+    }
+
     /// Sum of source sizes counted toward the `--stats` "total size".
     ///
     /// Only regular files and symlinks contribute, never directories, devices,

--- a/crates/transfer/src/receiver/stats.rs
+++ b/crates/transfer/src/receiver/stats.rs
@@ -66,6 +66,29 @@ pub struct ListOnlyEntry {
 pub struct TransferStats {
     /// Number of files in the received file list.
     pub files_listed: usize,
+    /// Directories in the received file list.
+    ///
+    /// Per-type tallies classified from the file list so the pulling client can
+    /// reconstruct the `--stats` "Number of files" breakdown
+    /// (`reg: R, dir: D, link: L, dev: V, special: S`). Upstream counts each
+    /// type as the file list is transmitted/received and derives `reg` as the
+    /// remainder; `files_listed` is the total, and `reg = files_listed - (dirs +
+    /// symlinks + devices + specials)`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:422-438` / `flist.c:2699-2712` - `stats.num_dirs++` etc.
+    /// - `main.c:387-411` - `output_itemized_counts()` derives `reg` as the
+    ///   total minus the other four categories.
+    pub num_dirs: u64,
+    /// Symbolic links in the received file list (upstream `stats.num_symlinks`).
+    pub num_symlinks: u64,
+    /// Device nodes (block + character) in the received file list
+    /// (upstream `stats.num_devices`).
+    pub num_devices: u64,
+    /// FIFOs and sockets in the received file list
+    /// (upstream `stats.num_specials`).
+    pub num_specials: u64,
     /// Number of files actually transferred.
     pub files_transferred: usize,
     /// Summed length of every transferred file (upstream: `total_transferred_size`).

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -149,6 +149,10 @@ fn incremental_receiver_mark_directory_created() {
 fn transfer_stats_has_incremental_fields() {
     let stats = TransferStats {
         files_listed: 0,
+        num_dirs: 0,
+        num_symlinks: 0,
+        num_devices: 0,
+        num_specials: 0,
         files_transferred: 0,
         transferred_file_size: 0,
         bytes_received: 0,

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -414,6 +414,140 @@ impl ReceiverContext {
         files_to_transfer
     }
 
+    /// Records the deferred itemize rows for a `--dry-run` receive, one per
+    /// file-list entry in flist-index order.
+    ///
+    /// Upstream runs the identical `recv_generator()` per-entry loop under
+    /// `--dry-run`; only the data transfer and the filesystem mutation are
+    /// suppressed (`set_file_attrs()` returns early when `dry_run`, rsync.c;
+    /// `do_mkdir`/`do_open` sit behind `if (!do_xfers) goto notify_others`).
+    /// The `itemize()` call itself always runs, so `-ni` prints a row for every
+    /// entry (`>f+++++++++`, `cd+++++++++`, `cL+++++++++`, ...). oc's shipped
+    /// remote receive path (`run_pipelined`) instead early-returns out of the
+    /// directory-creation and candidate passes when `skip_dest_writes()` is set,
+    /// so no itemize row was ever recorded on a network dry run. This read-only
+    /// pass restores the rows without writing anything to the destination.
+    ///
+    /// Recording (not immediate emission) keeps the rows interleaved in
+    /// flist-index order via the deferred flush (`flush_itemize_rows`), matching
+    /// upstream's single flist-index-order walk. `record_itemize` already gates
+    /// on `should_emit_itemize() && client_mode`, so this is a no-op for a plain
+    /// `-n` (no `-i`) and for a server-mode receiver (a push dry run, whose rows
+    /// travel as wire iflags and are printed by the client's sender).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1481-1483` - directory `itemize()` (runs under dry-run).
+    /// - `generator.c:1935-1947` - regular-file `itemize()` at `notify_others`,
+    ///   reached even when `!do_xfers`.
+    /// - `generator.c:1594` / `generator.c:1462` - symlink / special `itemize()`.
+    /// - `rsync.c` `set_file_attrs()` - `if (dry_run) return 1;` (no mutation).
+    pub(in crate::receiver) fn record_dry_run_itemize(&self, dest_dir: &Path) {
+        if !self.should_emit_itemize() || !self.config.connection.client_mode {
+            return;
+        }
+        let preserve_times = self.config.flags.times && !self.config.flags.ignore_times;
+        let size_only = self.config.file_selection.size_only;
+        let modify_window = self.config.file_selection.modify_window;
+        let always_checksum = if self.config.flags.checksum {
+            Some(self.get_checksum_algorithm())
+        } else {
+            None
+        };
+        for (idx, entry) in self.file_list.iter().enumerate() {
+            let rel = entry.path();
+            let dest_path = if rel.as_os_str() == "." {
+                dest_dir.to_path_buf()
+            } else {
+                dest_dir.join(rel)
+            };
+            let iflags = crate::generator::ItemFlags::from_raw(self.dry_run_entry_iflags(
+                entry,
+                &dest_path,
+                preserve_times,
+                size_only,
+                always_checksum,
+                modify_window,
+            ));
+            self.record_itemize(idx, &iflags, entry);
+        }
+    }
+
+    /// Computes the itemize flags a single entry would carry on a `--dry-run`
+    /// receive, by comparing the sender's file-list entry against the current
+    /// (pre-transfer) destination via a read-only `lstat`.
+    ///
+    /// The classification mirrors the non-dry-run record sites so a dry run
+    /// predicts exactly what the real transfer would print: a new entry
+    /// (destination absent) is `ITEM_IS_NEW`; an existing one OR-s the per-attr
+    /// report bits computed by [`Self::itemize_existing_flags`] /
+    /// [`Self::existing_dir_iflags`]. `render_itemize_line`'s significance gate
+    /// then drops an all-unchanged existing entry, matching upstream.
+    fn dry_run_entry_iflags(
+        &self,
+        entry: &FileEntry,
+        dest_path: &Path,
+        preserve_times: bool,
+        size_only: bool,
+        always_checksum: Option<protocol::ChecksumAlgorithm>,
+        modify_window: metadata::ModifyWindow,
+    ) -> u32 {
+        use crate::generator::ItemFlags;
+        let new_iflags = |base: u32| base | ItemFlags::ITEM_IS_NEW;
+        if entry.is_dir() {
+            // upstream: generator.c:1481-1483 - new dir -> ITEM_LOCAL_CHANGE |
+            // ITEM_IS_NEW; existing dir -> itemize() attribute diff.
+            match fs::metadata(dest_path) {
+                Ok(_) => self.existing_dir_iflags(entry, dest_path),
+                Err(_) => new_iflags(ItemFlags::ITEM_LOCAL_CHANGE),
+            }
+        } else if entry.is_symlink() {
+            // upstream: generator.c:1561-1594 - an up-to-date symlink (same
+            // target) is metadata-only; an absent, obstructed, or re-pointed one
+            // is (re)created and itemized ITEM_LOCAL_CHANGE (+ ITEM_IS_NEW when
+            // absent). Mirror the receiver's own create_symlinks classification.
+            match fs::symlink_metadata(dest_path) {
+                Ok(meta) if meta.file_type().is_symlink() => match fs::read_link(dest_path) {
+                    Ok(target) if entry.link_target() == Some(&target) => 0,
+                    _ => new_iflags(ItemFlags::ITEM_LOCAL_CHANGE),
+                },
+                Ok(_) => new_iflags(ItemFlags::ITEM_LOCAL_CHANGE),
+                Err(_) => new_iflags(ItemFlags::ITEM_LOCAL_CHANGE),
+            }
+        } else if entry.is_device() || entry.is_special() {
+            // upstream: generator.c:1462 - a node newly materialised via do_mknod
+            // is ITEM_IS_NEW; an existing node of the same type is metadata-only.
+            match fs::symlink_metadata(dest_path) {
+                Ok(_) => 0,
+                Err(_) => new_iflags(ItemFlags::ITEM_LOCAL_CHANGE),
+            }
+        } else {
+            // upstream: generator.c:1935-1947 - regular file at notify_others:
+            // absent -> ITEM_TRANSFER | ITEM_IS_NEW; present and quick-check
+            // match -> itemize(...,0,...); present and differing -> ITEM_TRANSFER
+            // plus the attribute diff.
+            match fs::symlink_metadata(dest_path) {
+                Ok(meta) => {
+                    let base = if quick_check_matches(
+                        entry,
+                        dest_path,
+                        &meta,
+                        preserve_times,
+                        size_only,
+                        always_checksum,
+                        modify_window,
+                    ) {
+                        0
+                    } else {
+                        ItemFlags::ITEM_TRANSFER
+                    };
+                    self.itemize_existing_flags(entry, &meta, base)
+                }
+                Err(_) => new_iflags(ItemFlags::ITEM_TRANSFER),
+            }
+        }
+    }
+
     /// Computes the attribute-comparison itemize flags for a destination file
     /// that already exists, mirroring upstream `generator.c:508-549` `itemize()`.
     ///
@@ -814,6 +948,97 @@ mod itemize_order_tests {
             rows[3].1.starts_with(">f") && rows[3].1.contains("b/f2"),
             "row 3 must be the new file b/f2: {:?}",
             rows[3].1
+        );
+    }
+
+    /// A `--dry-run` remote pull must itemize every file-list entry, matching
+    /// upstream's per-entry `itemize()` which runs even when `!do_xfers`. The
+    /// shipped receive path early-returns out of the directory-creation and
+    /// candidate passes under `skip_dest_writes()`, so before the fix `-ni`
+    /// printed zero itemize lines over the network. `record_dry_run_itemize`
+    /// records one deferred row per entry (in flist-index order) without writing
+    /// anything to the destination.
+    ///
+    /// upstream: generator.c:1481-1483 / :1935-1947 / :1594 - itemize() under
+    /// dry-run; rsync.c set_file_attrs() returns early when dry_run (no mutation).
+    #[test]
+    fn dry_run_itemize_records_a_row_per_entry_without_writing() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+
+        let hs = handshake();
+        let mut ctx = ReceiverContext::new_for_test(&hs, itemize_client_config());
+        ctx.defer_itemize = true;
+        ctx.file_list = vec![
+            FileEntry::new_directory("d".into(), 0o755),  // idx 0
+            FileEntry::new_file("d/f1".into(), 5, 0o644), // idx 1
+            FileEntry::new_symlink("d/lnk".into(), "target".into()), // idx 2
+        ];
+
+        // Read-only pass against an empty destination: every entry is new.
+        ctx.record_dry_run_itemize(dest);
+
+        let rows: Vec<(usize, String)> = ctx
+            .itemize_rows
+            .borrow()
+            .iter()
+            .map(|(idx, lines)| (*idx, lines[0].clone()))
+            .collect();
+
+        let keys: Vec<usize> = rows.iter().map(|(idx, _)| *idx).collect();
+        assert_eq!(
+            keys,
+            vec![0, 1, 2],
+            "one itemize row per entry, in flist-index order"
+        );
+        assert!(
+            rows[0].1.starts_with("cd") && rows[0].1.contains('d'),
+            "new directory row: {:?}",
+            rows[0].1
+        );
+        assert!(
+            rows[1].1.starts_with(">f") && rows[1].1.contains("d/f1"),
+            "new regular-file row: {:?}",
+            rows[1].1
+        );
+        assert!(
+            rows[2].1.starts_with("cL") && rows[2].1.contains("d/lnk"),
+            "new symlink row: {:?}",
+            rows[2].1
+        );
+
+        // The pass writes nothing: the destination stays empty.
+        let entries: Vec<_> = std::fs::read_dir(dest)
+            .expect("dest readable")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("dest entries");
+        assert!(
+            entries.is_empty(),
+            "dry-run itemize must not create any destination entry"
+        );
+    }
+
+    /// Without `-i`, the dry-run itemize pass records nothing (the bare `-v`
+    /// name path handles verbose output instead), and a server-mode receiver
+    /// (a push dry run) records nothing here either - its rows travel as wire
+    /// iflags printed by the client's sender.
+    #[test]
+    fn dry_run_itemize_is_noop_without_itemize_flag() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+
+        let hs = handshake();
+        let mut config = itemize_client_config();
+        config.flags.info_flags.itemize = false;
+        let mut ctx = ReceiverContext::new_for_test(&hs, config);
+        ctx.defer_itemize = true;
+        ctx.file_list = vec![FileEntry::new_file("f".into(), 1, 0o644)];
+
+        ctx.record_dry_run_itemize(dest);
+
+        assert!(
+            ctx.itemize_rows.borrow().is_empty(),
+            "no itemize rows recorded without -i"
         );
     }
 }

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -98,8 +98,17 @@ impl ReceiverContext {
         // upstream: receiver.c:653-654 DEBUG_GTE(RECV, 1)
         debug_log!(Recv, 1, "recv_files({}) starting", file_count);
 
+        // upstream: flist.c:2699-2712 - classify the received file list into the
+        // per-type tallies so the pulling client reconstructs the `--stats`
+        // "Number of files" breakdown (`reg: R, dir: D, link: L, ...`). Without
+        // this the client counted every entry as a regular file.
+        let (num_dirs, num_symlinks, num_devices, num_specials) = self.file_type_counts();
         let mut stats = TransferStats {
             files_listed: file_count,
+            num_dirs,
+            num_symlinks,
+            num_devices,
+            num_specials,
             entries_received: file_count as u64,
             io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
                 | self.flist_io_error,
@@ -185,6 +194,13 @@ impl ReceiverContext {
             // because only-write-batch sets both flags.
             self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
         } else if self.config.flags.dry_run {
+            // upstream: recv_generator() itemizes every entry even under
+            // --dry-run (only the data transfer and filesystem mutation are
+            // skipped). The directory-creation and candidate passes above
+            // early-return under skip_dest_writes(), so record the deferred
+            // itemize rows here in flist-index order; flush_itemize_rows below
+            // drains them. Read-only: nothing is written to the destination.
+            self.record_dry_run_itemize(&setup.dest_dir);
             self.run_dry_run_loop(reader, writer, &files_to_transfer)?;
         } else {
             let total_files = files_to_transfer.len();

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -294,6 +294,16 @@ impl ReceiverContext {
         stats.literal_data = literal_data;
         stats.matched_data = matched_data;
         stats.total_source_bytes = self.total_source_size();
+        // upstream: flist.c:2699-2712 - classify the (now fully materialized,
+        // including any INC_RECURSE sub-lists) file list into per-type tallies so
+        // the `--stats` "Number of files" breakdown matches upstream. Computed
+        // after the loop because incremental recursion appends sub-list segments
+        // as the transfer proceeds.
+        let (num_dirs, num_symlinks, num_devices, num_specials) = self.file_type_counts();
+        stats.num_dirs = num_dirs;
+        stats.num_symlinks = num_symlinks;
+        stats.num_devices = num_devices;
+        stats.num_specials = num_specials;
         if !metadata_errors.is_empty() || stats.directories_failed > 0 || stats.files_skipped > 0 {
             stats.io_error |= crate::generator::io_error_flags::IOERR_GENERAL;
         }

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -606,8 +606,16 @@ impl ReceiverContext {
             self.record_created(protocol::flist::FileType::Directory.to_mode_bits());
         }
 
+        // upstream: flist.c:2699-2712 - per-type tally so the client
+        // reconstructs the `--stats` "Number of files" breakdown.
+        let (num_dirs, num_symlinks, num_devices, num_specials) = self.file_type_counts();
+
         Ok(TransferStats {
             files_listed: file_count,
+            num_dirs,
+            num_symlinks,
+            num_devices,
+            num_specials,
             files_transferred,
             transferred_file_size,
             bytes_received,

--- a/crates/transfer/tests/incremental_transfer.rs
+++ b/crates/transfer/tests/incremental_transfer.rs
@@ -18,6 +18,10 @@ use wire_format_generator::{
 fn transfer_stats_incremental_fields_exist() {
     let stats = TransferStats {
         files_listed: 10,
+        num_dirs: 0,
+        num_symlinks: 0,
+        num_devices: 0,
+        num_specials: 0,
         files_transferred: 5,
         transferred_file_size: 5000,
         bytes_received: 1000,


### PR DESCRIPTION
## Summary

Two drop-in fidelity gaps showed up only on remote receives (ssh subprocess,
embedded russh, and rsync daemon) and never on local copies. Both are fixed in
the shared receive path with no per-transport branching.

### Divergence 1 - `--stats` file-type breakdown wrong over the network

A remote pull printed every file-list entry as a regular file:

```
Number of files: 6 (reg: 6)                       # before (oc, ssh pull)
Number of files: 6 (reg: 2, dir: 3, link: 1)      # upstream 3.4.4
```

**Root cause.** The receiver result struct (`receiver::stats::TransferStats`)
carried only the aggregate `files_listed` count, never the per-type tallies.
`from_receiver_stats` (engine) then stored that total in `regular_files_total`
and left `directories_total` / `symlinks_total` at zero. The local-copy
executor, by contrast, increments each type as it walks the tree, so local
`--stats` was already correct.

**Fix.** Classify the received file list into per-type tallies
(dirs/symlinks/devices/specials) and thread them through
`ServerStats::Receiver` -> `from_receiver_stats`, which derives `reg` as the
remainder. This mirrors upstream: `flist.c:2699-2712` tallies each type during
`recv_file_list()`, and `main.c:387-411` `output_itemized_counts()` derives the
regular count as `total - (dirs + links + devs + specials)`.

### Divergence 2 - `-n -i` produced no itemize output over the network

`oc -rlptgoD -ni localhost:SRC/ DST/` printed zero itemize lines; upstream
prints one per entry.

**Root cause.** The shipped remote receive path (`run_pipelined`, with the
`incremental-flist` feature off) early-returns out of the directory-creation and
candidate passes when `skip_dest_writes()` is set (dry-run). Those passes are the
only sites that record itemize rows, so a network dry run recorded none, and
`run_dry_run_loop` never itemized locally.

Upstream runs the identical `recv_generator()` per-entry loop under `--dry-run`:
`itemize()` is called before any data moves (`generator.c:1481-1483` for dirs,
`:1935-1947` for regular files at `notify_others`, `:1594`/`:1462` for
symlinks/specials). Only the data transfer and the filesystem mutation are
skipped - `set_file_attrs()` returns early when `dry_run` (rsync.c), and the
`do_mkdir`/`do_open` calls sit behind `if (!do_xfers) goto notify_others`.

**Fix.** Add a read-only dry-run itemize pass that walks the file list in
flist-index order and records one deferred itemize row per entry, computing the
flags from a pre-transfer `lstat` and reusing the existing
`itemize_existing_flags` / `existing_dir_iflags` / `quick_check_matches`
primitives. It writes nothing to the destination; the deferred flush emits the
rows in flist order, matching upstream's single walk.

## Host validation (Arch, oc-rsync vs `/usr/bin/rsync` 3.4.4, protocol 32)

Source tree: 2 regular files, 3 directories (`.`, `dir_a`, `dir_b`), 1 symlink.

SSH pull (`-e ssh --rsync-path=/usr/bin/rsync`):

```
--stats Number of files
  upstream : Number of files: 6 (reg: 2, dir: 3, link: 1)
  oc (before): Number of files: 6 (reg: 6)
  oc (after) : Number of files: 6 (reg: 2, dir: 3, link: 1)

-ni dry run
  upstream:  >f+++++++++ file1 / >f+++++++++ file2 / cL+++++++++ sym -> file1
             cd+++++++++ dir_a/ / cd+++++++++ dir_b/
  oc (before): (no output)
  oc (after) : byte-for-byte identical to upstream; destination left empty
```

Daemon pull (`rsync://`, upstream daemon as sender): `Number of files` line and
`-ni` output both byte-for-byte identical to upstream; dry-run destination empty.

Regressions checked: local `--stats` and local `-ni` unchanged; a normal
(non-dry-run) remote pull still delivers an identical tree (`diff -r`).

## Tests

- `engine`: `from_receiver_stats_derives_file_type_breakdown` - reg is the
  derived remainder, typed totals surfaced.
- `transfer`: `dry_run_itemize_records_a_row_per_entry_without_writing` and
  `dry_run_itemize_is_noop_without_itemize_flag`.
