### PR TITLE
fix: apply --link-dest on ssh and russh pull receivers

### DIFF
--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -503,6 +503,15 @@ fn build_server_config_for_receiver(
     server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
+    // upstream: options.c:2911-2934 - the alt-dest args (--compare-dest,
+    // --copy-dest, --link-dest) live inside the `if (am_sender)` server_options
+    // block, so on a pull they are never sent over the wire to the remote
+    // sender; the local client IS the receiver and applies them itself in
+    // try_dests_reg() (generator.c:954). Carry them onto the local receiver
+    // config here so the receiver hard-links / copies / skips unchanged files
+    // against the reference dirs. Without this the russh pull transferred every
+    // file whole, while the daemon pull hard-linked.
+    server_config.reference_directories = config.reference_directories().to_vec();
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,
     // and 'D' now tracks devices only, so carry keep_partial and specials onto
     // the local half here (mirrors --partial / --specials|--no-specials which the
@@ -578,6 +587,42 @@ mod tests {
         assert!(is_ssh_url("ssh://host/path"));
         assert!(is_ssh_url("ssh://user@host/path"));
         assert!(is_ssh_url("ssh://user:pass@host:2222/path"));
+    }
+
+    /// The embedded (russh) pull receiver must carry the alt-dest reference
+    /// directories onto its ServerConfig, exactly like the subprocess ssh and
+    /// daemon receiver builders. On a pull the args are never forwarded to the
+    /// remote sender (upstream options.c:2911-2934 gates them on am_sender), so
+    /// the local receiver applies them itself in try_dests_reg()
+    /// (generator.c:954). Regression guard for the `ssh://` pull that hard-linked
+    /// nothing because reference_directories was empty.
+    #[test]
+    fn embedded_receiver_config_propagates_reference_directories() {
+        use crate::client::config::ReferenceDirectoryKind;
+
+        let config = ClientConfig::builder()
+            .compare_destination("/tmp/compare")
+            .link_destination("/prev")
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert_eq!(server_config.reference_directories.len(), 2);
+        assert_eq!(
+            server_config.reference_directories[0].kind(),
+            ReferenceDirectoryKind::Compare
+        );
+        assert_eq!(
+            server_config.reference_directories[1].kind(),
+            ReferenceDirectoryKind::Link
+        );
+        assert_eq!(
+            server_config.reference_directories[1]
+                .path()
+                .to_str()
+                .unwrap(),
+            "/prev"
+        );
     }
 
     #[test]

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -29,6 +29,15 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
     server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
+    // upstream: options.c:2911-2934 - the alt-dest args (--compare-dest,
+    // --copy-dest, --link-dest) live inside the `if (am_sender)` server_options
+    // block, so on a pull they are never sent over the wire to the remote
+    // sender; the local client IS the receiver and applies them itself in
+    // try_dests_reg() (generator.c:954). Carry them onto the local receiver
+    // config here so the receiver hard-links / copies / skips unchanged files
+    // against the reference dirs. Without this the ssh pull transferred every
+    // file whole, while the daemon pull (server_config.rs:30) hard-linked.
+    server_config.reference_directories = config.reference_directories().to_vec();
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,
     // and 'D' now tracks devices only, so carry keep_partial and specials onto
     // the local half here (mirrors --partial / --specials|--no-specials which the
@@ -137,5 +146,64 @@ fn apply_files_from_for_sender(config: &ClientConfig, server_config: &mut Server
     if let Some(path) = plan.sender_files_from_path {
         server_config.file_selection.files_from_path = Some(path);
         server_config.file_selection.from0 = plan.sender_from0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::config::ReferenceDirectoryKind;
+
+    /// On an ssh pull the local client IS the receiver, and the alt-dest args
+    /// (--compare-dest / --copy-dest / --link-dest) are never sent over the wire
+    /// to the remote sender (upstream options.c:2911-2934 gates them on
+    /// am_sender). The receiver applies them itself in try_dests_reg()
+    /// (generator.c:954), so the ssh receiver config must carry them locally -
+    /// exactly as the daemon receiver builder does. Regression guard for the ssh
+    /// pull that hard-linked nothing because reference_directories was empty
+    /// while local and daemon pulls hard-linked correctly.
+    #[test]
+    fn receiver_config_propagates_reference_directories() {
+        let config = ClientConfig::builder()
+            .compare_destination("/tmp/compare")
+            .link_destination("/prev")
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert_eq!(server_config.reference_directories.len(), 2);
+        assert_eq!(
+            server_config.reference_directories[0].kind(),
+            ReferenceDirectoryKind::Compare
+        );
+        assert_eq!(
+            server_config.reference_directories[0]
+                .path()
+                .to_str()
+                .unwrap(),
+            "/tmp/compare"
+        );
+        assert_eq!(
+            server_config.reference_directories[1].kind(),
+            ReferenceDirectoryKind::Link
+        );
+        assert_eq!(
+            server_config.reference_directories[1]
+                .path()
+                .to_str()
+                .unwrap(),
+            "/prev"
+        );
+    }
+
+    /// Without any alt-dest option the receiver config carries no reference
+    /// directories, so the hard-link/copy/skip path stays disabled and every
+    /// file transfers as before.
+    #[test]
+    fn receiver_config_without_alt_dest_has_no_reference_directories() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+        assert!(server_config.reference_directories.is_empty());
     }
 }


### PR DESCRIPTION
## Divergence

With a reference directory `REF` holding a file byte-identical to the source
(same content and same mtime), `--link-dest=REF` must hard-link the destination
file to `REF/f1` (shared inode, `nlink >= 2`) instead of copying it. This worked
on local copies and on rsync daemon pulls, but on **ssh / russh remote pulls**
oc-rsync copied every unchanged file whole - the destination file had a
different inode from the reference, unlike upstream rsync 3.4.4.

Reproduce:

```
oc-rsync -rlptgoD --numeric-ids --link-dest=REF --rsync-path=/usr/bin/rsync \
    -e 'ssh -o BatchMode=yes -o StrictHostKeyChecking=no' localhost:SRC/ DST/
```

## Root cause

Upstream applies the alternate-basis logic in the generator, which runs on the
receiving side regardless of transport: `try_dests_reg()` (generator.c:954)
hard-links an unchanged file from a `--link-dest` basis before deciding to
transfer. The alt-dest command-line args live inside the `if (am_sender)` block
of `server_options()` (options.c:2911-2934), so on a pull they are never
forwarded over the wire to the remote sender - the local receiver applies them
itself.

oc-rsync gates its receiver-side link-dest handling
(`try_reference_dest`, `crates/transfer/src/receiver/quick_check.rs`) on
`self.config.reference_directories`. That vector is populated for local copies
(from the local copy options) and for daemon pulls
(`daemon_transfer/orchestration/server_config.rs:30`), but the two ssh receiver
config builders never copied it onto the `ServerConfig`:

- `crates/core/src/client/remote/ssh_transfer/server_config.rs` - subprocess ssh
- `crates/core/src/client/remote/embedded_ssh_transfer.rs` - embedded russh (`ssh://`)

With the vector empty, `has_reference_dirs` was false and every file fell
through to a full transfer.

## Fix

Carry the reference directories onto the local receiver `ServerConfig` in both
ssh receiver builders, mirroring the daemon receiver builder. Receiver role
only: the generator (push) case still forwards the flags to the remote receiver
via `invocation/builder.rs` and must not apply them locally, matching upstream's
`am_sender` gate. A changed file still fails the quick-check against the stale
reference and is copied fresh, so no data corruption is possible.

Added targeted regression tests to both builders.

## Verification (Linux host, rsync 3.4.4, x86_64)

Reference `REF/f1` identical to source `f1` (same content + mtime); changed
`f2` where `REF/f2` is stale. Inode / nlink of the destination:

Before the fix the russh (`ssh://`) pull copied f1 (`DST.ino != REF.ino`,
`nlink=1`); after the fix all transports hard-link, matching upstream:

```
UPSTREAM ssh f1: REF.ino=888644 DST.ino=888644 nlink=2   HARDLINKED
OC ssh-pull  f1: REF.ino=888662 DST.ino=888662 nlink=2   HARDLINKED
OC local     f1: REF.ino=888671 DST.ino=888671 nlink=2   HARDLINKED
OC russh     f1: REF.ino=888681 DST.ino=888681 nlink=2   HARDLINKED
OC daemon    f1: REF.ino=888692 DST.ino=888692 nlink=2   HARDLINKED

changed f2 (all transports): REF.ino != DST.ino, DST holds the NEW source
content - copied fresh, never linked to the stale reference.
```

`cargo fmt --all -- --check`, `cargo clippy -p core -D warnings`, and the
targeted receiver-config tests all pass.
