### PR TITLE
fix: apply --backup-dir/--suffix on remote pull receivers

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -28,6 +28,18 @@ pub(crate) fn build_server_config_for_receiver(
 
     apply_common_daemon_config(config, &mut server_config, filter_rules);
     server_config.reference_directories = config.reference_directories().to_vec();
+    // upstream: backup.c:make_backup() runs on the receiver, invoked from
+    // generator.c/receiver.c. `make_backups` rides in the compact flag string as
+    // 'b' (options.c:2630-2631), so flags.backup is already set here; but
+    // --backup-dir / --suffix are long-form values finalized in the local popt
+    // parse (options.c:2285-2298) and never delivered onto the receiver config.
+    // On a pull the local client IS the receiver, so carry backup_dir/backup_suffix
+    // here - otherwise effective_backup_suffix() falls back to "~" and the backup
+    // lands beside the file instead of in --backup-dir.
+    server_config.backup_dir = config.backup_directory().map(|p| p.display().to_string());
+    server_config.backup_suffix = config
+        .backup_suffix()
+        .map(|s| s.to_string_lossy().into_owned());
     // upstream flist.c:flist_sort_and_clean prunes empty dirs on the receiver
     // (prune_empty_dirs && !am_sender); on a pull the local client IS the receiver,
     // and -m is never sent over the wire (options.c gates it on am_sender), so the

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -1052,6 +1052,38 @@ mod server_config_reference_dirs {
         assert!(server_config.reference_directories.is_empty());
     }
 
+    /// On a daemon pull the local client IS the receiver and runs
+    /// backup.c:make_backup() itself. `make_backups` rides in the compact 'b'
+    /// letter, but --backup-dir / --suffix are long-form values (upstream
+    /// options.c:2285-2298) that must be carried onto the receiver config, else
+    /// effective_backup_suffix() falls back to "~" and the backup lands beside the
+    /// file instead of in --backup-dir.
+    #[test]
+    fn receiver_config_propagates_backup_dir_and_suffix() {
+        let config = ClientConfig::builder()
+            .backup(true)
+            .backup_directory(Some("/bak"))
+            .backup_suffix(Some(".old"))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(server_config.flags.backup);
+        assert_eq!(server_config.backup_dir.as_deref(), Some("/bak"));
+        assert_eq!(server_config.backup_suffix.as_deref(), Some(".old"));
+    }
+
+    #[test]
+    fn receiver_config_without_backup_has_no_backup_dir() {
+        let config = ClientConfig::default();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(!server_config.flags.backup);
+        assert!(server_config.backup_dir.is_none());
+        assert!(server_config.backup_suffix.is_none());
+    }
+
     #[test]
     fn generator_config_empty_reference_dirs_by_default() {
         let config = ClientConfig::default();

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -512,6 +512,19 @@ fn build_server_config_for_receiver(
     // against the reference dirs. Without this the russh pull transferred every
     // file whole, while the daemon pull hard-linked.
     server_config.reference_directories = config.reference_directories().to_vec();
+    // upstream: backup.c:make_backup() runs on the receiver, invoked from
+    // generator.c/receiver.c. `make_backups` rides in the compact flag string as
+    // 'b' (options.c:2630-2631), so flags.backup is already set here; but
+    // --backup-dir / --suffix are long-form values finalized in the local popt
+    // parse (options.c:2285-2298) and never delivered onto the receiver config.
+    // On a pull the local client IS the receiver, so carry backup_dir/backup_suffix
+    // here - otherwise effective_backup_suffix() falls back to "~" and the backup
+    // lands beside the file instead of in --backup-dir (local/daemon pulls kept
+    // them and behaved correctly).
+    server_config.backup_dir = config.backup_directory().map(|p| p.display().to_string());
+    server_config.backup_suffix = config
+        .backup_suffix()
+        .map(|s| s.to_string_lossy().into_owned());
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,
     // and 'D' now tracks devices only, so carry keep_partial and specials onto
     // the local half here (mirrors --partial / --specials|--no-specials which the
@@ -623,6 +636,40 @@ mod tests {
                 .unwrap(),
             "/prev"
         );
+    }
+
+    /// The embedded (russh) pull receiver must carry --backup-dir / --suffix onto
+    /// its ServerConfig. `make_backups` rides in the compact 'b' letter so
+    /// flags.backup is set, but the backup directory and suffix are long-form
+    /// values (upstream options.c:2285-2298) the local receiver applies itself in
+    /// backup.c:make_backup(). Regression guard for the `ssh://` pull that wrote a
+    /// "~" backup beside the file instead of into --backup-dir.
+    #[test]
+    fn embedded_receiver_config_propagates_backup_dir_and_suffix() {
+        let config = ClientConfig::builder()
+            .backup(true)
+            .backup_directory(Some("/bak"))
+            .backup_suffix(Some(".old"))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.backup);
+        assert_eq!(server_config.backup_dir.as_deref(), Some("/bak"));
+        assert_eq!(server_config.backup_suffix.as_deref(), Some(".old"));
+    }
+
+    /// Without --backup the receiver config carries no backup directory or suffix,
+    /// so the backup path stays disabled.
+    #[test]
+    fn embedded_receiver_config_without_backup_has_no_backup_dir() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.backup);
+        assert!(server_config.backup_dir.is_none());
+        assert!(server_config.backup_suffix.is_none());
     }
 
     #[test]

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -38,6 +38,19 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
     // against the reference dirs. Without this the ssh pull transferred every
     // file whole, while the daemon pull (server_config.rs:30) hard-linked.
     server_config.reference_directories = config.reference_directories().to_vec();
+    // upstream: backup.c:make_backup() runs on the receiver, invoked from
+    // generator.c/receiver.c. `make_backups` rides in the compact flag string as
+    // 'b' (options.c:2630-2631), so flags.backup is already set here; but
+    // --backup-dir / --suffix are long-form values finalized in the local popt
+    // parse (options.c:2285-2298) and never delivered onto the receiver config.
+    // On a pull the local client IS the receiver, so carry backup_dir/backup_suffix
+    // here - otherwise effective_backup_suffix() falls back to "~" and the backup
+    // lands beside the file instead of in --backup-dir (local/daemon pulls kept
+    // them and behaved correctly).
+    server_config.backup_dir = config.backup_directory().map(|p| p.display().to_string());
+    server_config.backup_suffix = config
+        .backup_suffix()
+        .map(|s| s.to_string_lossy().into_owned());
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,
     // and 'D' now tracks devices only, so carry keep_partial and specials onto
     // the local half here (mirrors --partial / --specials|--no-specials which the
@@ -205,5 +218,40 @@ mod tests {
         let server_config =
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
         assert!(server_config.reference_directories.is_empty());
+    }
+
+    /// On an ssh pull the local client IS the receiver and runs
+    /// backup.c:make_backup() itself. `make_backups` rides in the compact 'b'
+    /// letter, but --backup-dir / --suffix are long-form values finalized in the
+    /// local popt parse (upstream options.c:2285-2298) and must be carried onto
+    /// the receiver config. Regression guard for the ssh pull that wrote a "~"
+    /// backup beside the file because backup_dir/backup_suffix were empty while
+    /// local and daemon pulls placed the backup in --backup-dir.
+    #[test]
+    fn receiver_config_propagates_backup_dir_and_suffix() {
+        let config = ClientConfig::builder()
+            .backup(true)
+            .backup_directory(Some("/bak"))
+            .backup_suffix(Some(".old"))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.backup);
+        assert_eq!(server_config.backup_dir.as_deref(), Some("/bak"));
+        assert_eq!(server_config.backup_suffix.as_deref(), Some(".old"));
+    }
+
+    /// Without --backup the receiver config carries no backup directory or
+    /// suffix, so the backup path stays disabled.
+    #[test]
+    fn receiver_config_without_backup_has_no_backup_dir() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.backup);
+        assert!(server_config.backup_dir.is_none());
+        assert!(server_config.backup_suffix.is_none());
     }
 }


### PR DESCRIPTION
## Divergence

`--backup` with `--backup-dir` did not place backups in the requested
directory on remote pulls. Seeding a destination with an old file and
pulling a new version over ssh, russh (`ssh://`), or an `rsync://`
daemon left the destination updated but the backup directory empty; a
stray `~`-suffixed copy landed beside the file instead. Local copies
behaved correctly.

Upstream 3.4.4, ssh pull:

```
cd DST && rsync -rlptgoD --backup --backup-dir=../bak --numeric-ids \
  -e 'ssh -o BatchMode=yes' localhost:SRC/ ./
# bak/f1 = OLD-CONTENT, DST/f1 = NEW-CONTENT
```

oc-rsync before this change, same invocation:

```
# bak/ absent, DST/f1 = NEW-CONTENT, DST/f1~ = OLD-CONTENT   (wrong location)
```

## Root cause

Backups run on the receiving side: upstream `backup.c:make_backup()` is
invoked from `generator.c` / `receiver.c`. `make_backups` rides in the
compact server flag string as `b` (`options.c:2630-2631`), while
`--backup-dir` and `--suffix` are long-form values finalized in the local
option parse (`options.c:2285-2298`).

On a pull the local client *is* the receiver. The ssh, russh, and daemon
receiver-config builders set `flags.backup` via the compact `b` letter but
never carried `backup_dir` / `backup_suffix` onto their `ServerConfig`, so
`effective_backup_suffix()` fell back to `~` and the backup was written
beside the destination file rather than into the backup directory. The
local-copy path already carried both values, which is why local backups
worked. This is the same class of omission fixed for `--link-dest` in
#6792.

## Fix

Carry `backup_dir` and `backup_suffix` from the client config onto the
local receiver `ServerConfig` in all three remote receiver builders
(subprocess ssh, embedded russh, daemon), mirroring the local-copy path
and the `reference_directories` propagation. The backup args are still not
sent to the remote sender on a pull; only the local receiver applies them.

Regression tests added to each builder assert that `--backup-dir` /
`--suffix` reach the receiver config and that a config without `--backup`
carries neither.

## Verification (Linux host, ssh + russh + daemon vs local, /usr/bin/rsync 3.4.4)

`--backup --backup-dir=../bak`, pulling a new `f1` over each transport:

| Transport | Before | After |
|-----------|--------|-------|
| ssh (`-e ssh`) | `bak/` absent, `DST/f1~` written | `bak/f1` = OLD, `DST/f1` = NEW |
| russh (`ssh://`) | `bak/` absent, `DST/f1~` written | `bak/f1` = OLD, `DST/f1` = NEW |
| daemon (`rsync://`) | `bak/` absent, `DST/f1~` written | `bak/f1` = OLD, `DST/f1` = NEW |
| local (control) | `bak/f1` = OLD | `bak/f1` = OLD (unchanged) |

The default `--backup` (`~`-suffix) form writes `DST/f1~` = OLD both
before and after across all transports. Matches upstream 3.4.4.

`cargo fmt --all -- --check`, `cargo clippy -p core --all-targets
--all-features --no-deps -- -D warnings`, and the targeted receiver-config
tests all pass on the Linux host.
