### PR TITLE
fix: preserve /./ dot-root pivot in embedded ssh:// URL paths

### DIFF
--- a/crates/rsync_io/src/ssh/embedded/config.rs
+++ b/crates/rsync_io/src/ssh/embedded/config.rs
@@ -314,7 +314,16 @@ impl SshConfig {
             .and_then(|s| s.strip_suffix(']'))
             .unwrap_or(raw_host);
 
-        let raw_path = parsed.path();
+        // Take the path from the original URL string rather than
+        // `parsed.path()`. The `url` crate applies WHATWG dot-segment
+        // normalization, which silently collapses `.`/`..` path segments and
+        // would drop rsync's literal `/./` dot-root pivot used by --relative
+        // (-R). The subprocess SSH path passes the operand through verbatim, so
+        // the embedded transport must preserve `/./` identically.
+        // upstream: flist.c:2351 send_file_list - `strstr(fbuf, "/./")` splits
+        // the source arg at the pivot so -R recreates only the components after
+        // it; without the literal marker the whole absolute path is recreated.
+        let raw_path = raw_url_path(url_str).unwrap_or("");
         if raw_path.is_empty() || raw_path == "/" {
             return Err(SshError::InvalidUrl {
                 reason: "empty path".to_owned(),
@@ -358,6 +367,22 @@ impl SshConfig {
 
         Ok((config, remote_path))
     }
+}
+
+/// Extracts the literal path component of an `ssh://` URL without dot-segment
+/// normalization.
+///
+/// The path begins at the first `/` after the `scheme://authority` prefix and
+/// runs to the query (`?`) or fragment (`#`) delimiter, mirroring how the
+/// subprocess SSH transport slices `host:path` operands. Returns `None` when
+/// the URL has no path component. Preserving the raw slice keeps rsync's `/./`
+/// dot-root pivot intact for `--relative` transfers.
+fn raw_url_path(url_str: &str) -> Option<&str> {
+    let after_scheme = &url_str[url_str.find("://")? + 3..];
+    let start = after_scheme.find('/')?;
+    let path = &after_scheme[start..];
+    let end = path.find(['?', '#']).unwrap_or(path.len());
+    Some(&path[..end])
 }
 
 /// Returns the default `~/.ssh/config` path, or `None` if `$HOME` /
@@ -635,6 +660,51 @@ mod tests {
     fn from_url_absolute_path() {
         let (_cfg, path) = SshConfig::from_url("ssh://host/absolute/path").unwrap();
         assert_eq!(path, "/absolute/path");
+    }
+
+    #[test]
+    fn from_url_preserves_dot_root_pivot() {
+        // The `/./` dot-root pivot marks where --relative (-R) begins recreating
+        // implied dirs. The `url` crate's dot-segment normalization would drop
+        // it; the embedded transport must preserve it exactly like the ssh
+        // subprocess `host:path` split does.
+        let (cfg, path) = SshConfig::from_url("ssh://host/SRC/./a/b/c/").unwrap();
+        assert_eq!(cfg.host, "host");
+        assert_eq!(path, "/SRC/./a/b/c/");
+    }
+
+    #[test]
+    fn from_url_preserves_dot_root_pivot_no_trailing_slash() {
+        let (_cfg, path) = SshConfig::from_url("ssh://host/SRC/./a/b/c").unwrap();
+        assert_eq!(path, "/SRC/./a/b/c");
+    }
+
+    #[test]
+    fn from_url_dot_root_pivot_with_user_and_port() {
+        let (cfg, path) = SshConfig::from_url("ssh://user@host:2222/SRC/./a/b").unwrap();
+        assert_eq!(cfg.host, "host");
+        assert_eq!(cfg.port, 2222);
+        assert_eq!(cfg.username.as_deref(), Some("user"));
+        assert_eq!(path, "/SRC/./a/b");
+    }
+
+    #[test]
+    fn from_url_dot_root_pivot_ipv6() {
+        let (cfg, path) = SshConfig::from_url("ssh://[::1]/SRC/./a/b").unwrap();
+        assert_eq!(cfg.host, "::1");
+        assert_eq!(path, "/SRC/./a/b");
+    }
+
+    #[test]
+    fn from_url_preserves_home_relative_dot_root_pivot() {
+        let (_cfg, path) = SshConfig::from_url("ssh://user@host/~/SRC/./a/b").unwrap();
+        assert_eq!(path, "~/SRC/./a/b");
+    }
+
+    #[test]
+    fn from_url_preserves_trailing_slash() {
+        let (_cfg, path) = SshConfig::from_url("ssh://host/data/").unwrap();
+        assert_eq!(path, "/data/");
     }
 
     #[test]


### PR DESCRIPTION
## Divergence

When pulling with `--relative` (`-R`) and a `/./` dot-root pivot, the embedded
russh transport (`ssh://host/path` URLs) recreated the entire absolute source
path under the destination instead of only the components after `/./`. The ssh
subprocess transport (`-e ssh` with a `host:path` operand) handled it correctly.

Source `SRC/a/b/c/leaf.txt`, pulled with `-rR .../SRC/./a/b/c/`:

| Transport | Result |
|-----------|--------|
| upstream rsync 3.4.4 (`-e ssh`) | `DST/a/b/c/leaf.txt` |
| oc-rsync ssh subprocess (`-e ssh`) | `DST/a/b/c/leaf.txt` |
| oc-rsync russh (`ssh://`) before | `DST/<full-abs-src-path>/a/b/c/leaf.txt` |

## Root cause

`SshConfig::from_url` derived the remote path from `url::Url::path()`. The `url`
crate applies WHATWG/RFC-3986 dot-segment removal, which silently collapses the
literal `/./` marker. rsync uses that marker to split the transfer root from the
implied dirs (upstream `flist.c:2351` `send_file_list`, `strstr(fbuf, "/./")`).
Once the pivot is gone, `-R` sees an ordinary absolute path and recreates all of
it. The subprocess transport slices `host:path` verbatim, so it was unaffected.

Confirmed at the unit level with url 2.5.8:

```
parsed.path()  = "/tmp/x/SRC/a/b/c/"     (pivot dropped)
raw url slice  = "/tmp/x/SRC/./a/b/c/"   (pivot preserved)
```

## Fix

Take the path from the raw URL string (the slice from the first `/` after the
authority up to any `?`/`#`) instead of the normalized `parsed.path()`, matching
how the subprocess transport passes operands through. Host, port, user, and
password are still parsed from the validated `Url`.

## Verification (Linux, /usr/bin/rsync 3.4.4)

All transports now match upstream byte-for-byte:

```
-rR  .../SRC/./a/b/c/                 -> DST/a/b/c/leaf.txt   (russh == subprocess == upstream)
-rR --no-implied-dirs .../SRC/./a/b/c/ -> DST/a/b/c/leaf.txt   (russh == upstream)
-rR  .../SRC/a/b/c/  (no /./)         -> DST/<abs>/SRC/a/b/c/leaf.txt (unchanged, == upstream)
```

Added targeted regression tests in `crates/rsync_io` covering pivot preservation
with trailing slash, user/port, IPv6, home-relative paths, and a plain path.
`cargo fmt --all -- --check` and `cargo clippy -p rsync_io -D warnings` are clean.
