### PR TITLE
fix: preserve mtime on remote --sparse transfers

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -31,7 +31,14 @@ pub(super) struct SparseFinalize {
 
 /// Truncates `target` to the sparse logical length and punches its in-basis
 /// zero runs. Runs before the file is put into place.
-fn finalize_sparse(target: &Path, sparse: &SparseFinalize) -> io::Result<()> {
+///
+/// upstream: `fileio.c:43` `sparse_end()` runs inside `receive_data()` BEFORE
+/// `receiver.c` calls `finish_transfer()` -> `set_file_attrs()`. Both `set_len`
+/// (ftruncate) and `punch_hole` (fallocate) update the file mtime, so this must
+/// run before the timestamp is applied or the just-set mtime is clobbered. The
+/// temp+rename callers invoke it directly for that reason; the inplace branch
+/// of `commit_file` re-applies metadata afterwards.
+pub(super) fn finalize_sparse(target: &Path, sparse: &SparseFinalize) -> io::Result<()> {
     let mut file = fs::OpenOptions::new().write(true).open(target)?;
     file.set_len(sparse.logical_len)?;
     for &(pos, len) in &sparse.holes {
@@ -79,14 +86,11 @@ pub(super) fn commit_file(
     bytes_written: u64,
     sparse_final: Option<SparseFinalize>,
 ) -> io::Result<CommitOutcome> {
-    // upstream: fileio.c:43 sparse_end() - for the temp+rename path, truncate
-    // and punch the temp file before it is renamed into place. The inplace
-    // path finalizes in its dedicated branch below (after any backup).
-    if needs_rename {
-        if let Some(ref sparse) = sparse_final {
-            finalize_sparse(cleanup_guard.path(), sparse)?;
-        }
-    }
+    // upstream: fileio.c:43 sparse_end() - the temp+rename path truncates and
+    // punches the temp file in the caller BEFORE applying metadata, so the
+    // ftruncate/punch cannot re-stamp the mtime that set_file_attrs applied.
+    // The inplace path finalizes in its dedicated branch below (after any
+    // backup), then the caller re-applies metadata to the destination.
 
     // upstream: backup.c:make_backup() - rename existing file before overwrite.
     // With delay_updates, backup happens during the sweep, not here.

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -22,7 +22,9 @@ use crate::temp_guard::open_tmpfile_sandboxed;
 
 use super::super::config::DiskCommitConfig;
 use super::super::writer::{ReusableBufWriter, Writer};
-use super::commit::{SparseFinalize, commit_file, make_backup_copy, retain_partial_file};
+use super::commit::{
+    SparseFinalize, commit_file, finalize_sparse, make_backup_copy, retain_partial_file,
+};
 use super::metadata::{apply_file_metadata, finalize_checksum};
 
 /// Folds the existing on-disk prefix into the whole-file checksum for
@@ -327,6 +329,17 @@ pub(in crate::disk_commit) fn process_file(
                     ));
                 }
 
+                // upstream: fileio.c:43 sparse_end() runs inside receive_data()
+                // BEFORE receiver.c calls finish_transfer() -> set_file_attrs().
+                // Truncate/punch the temp file first so the ftruncate + punch
+                // (both of which touch mtime) cannot clobber the timestamp the
+                // metadata step is about to apply.
+                if needs_rename {
+                    if let Some(ref sparse) = sparse_final {
+                        finalize_sparse(cleanup_guard.path(), sparse)?;
+                    }
+                }
+
                 // upstream: rsync.c:748 finish_transfer() - "Change
                 // permissions before putting the file into place."
                 // Apply metadata to the temp file before rename so the
@@ -522,6 +535,15 @@ pub(in crate::disk_commit) fn process_whole_file(
             bytes_written,
             computed_checksum,
         ));
+    }
+
+    // upstream: fileio.c:43 sparse_end() runs before finish_transfer() ->
+    // set_file_attrs() (see process_file for full rationale). Truncate/punch
+    // the temp file before applying metadata so the mtime survives.
+    if needs_rename {
+        if let Some(ref sparse) = sparse_final {
+            finalize_sparse(cleanup_guard.path(), sparse)?;
+        }
     }
 
     // upstream: rsync.c:748 finish_transfer() - apply metadata to the

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -3369,3 +3369,189 @@ fn checksum_mismatch_leaves_preexisting_dest_untouched() {
     h.file_tx.send(FileMessage::Shutdown).unwrap();
     h.join_handle.join().unwrap();
 }
+
+/// Backdated source mtime carried by every sparse regression file. Matches the
+/// host reproduction (source files stamped to 2021-03-04 via `touch -d`).
+const SPARSE_MTIME_SECS: i64 = 1_614_830_767;
+
+/// Builds a `DiskCommitConfig` whose file list carries a single regular-file
+/// entry stamped with [`SPARSE_MTIME_SECS`] and whose metadata options preserve
+/// times, so the disk thread applies that mtime via `apply_file_metadata`
+/// (upstream `set_file_attrs()` -> `set_modtime()`).
+fn sparse_mtime_config(sparse: bool, size: u64) -> DiskCommitConfig {
+    let mut entry = protocol::flist::FileEntry::new_file(
+        std::path::PathBuf::from("sparse_mtime.dat"),
+        size,
+        0o644,
+    );
+    entry.set_mtime(SPARSE_MTIME_SECS, 0);
+    DiskCommitConfig {
+        use_sparse: sparse,
+        file_list: Some(std::sync::Arc::new(vec![entry])),
+        metadata_opts: Some(
+            metadata::MetadataOptions::new()
+                .preserve_permissions(true)
+                .preserve_times(true),
+        ),
+        ..DiskCommitConfig::default()
+    }
+}
+
+/// Reads the destination file's last-modification time in whole seconds.
+fn dest_mtime_secs(path: &std::path::Path) -> i64 {
+    filetime::FileTime::from_last_modification_time(&fs::metadata(path).unwrap()).unix_seconds()
+}
+
+/// A sparse payload: leading data, a large zero hole, then trailing data. The
+/// interior zero run forces `SparseWriteState` to leave a hole so the commit
+/// runs `finalize_sparse` (ftruncate + punch), the operation that used to
+/// clobber the applied mtime.
+fn sparse_payload() -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"HEAD");
+    data.extend(std::iter::repeat(0u8).take(64 * 1024));
+    data.extend_from_slice(b"TAIL");
+    data
+}
+
+/// A sparse transfer over the pipelined (remote) receive path must still apply
+/// the source mtime. `finalize_sparse` (set_len + punch_hole) runs before
+/// `apply_file_metadata` on the temp+rename path, matching upstream ordering:
+/// `fileio.c:43 sparse_end()` inside `receive_data()` precedes
+/// `receiver.c` -> `finish_transfer()` -> `set_file_attrs()`. Regression for a
+/// remote `-a --sparse` transfer leaving every destination mtime at wall clock.
+#[test]
+fn sparse_streaming_commit_preserves_source_mtime() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("sparse_stream.dat");
+
+    let payload = sparse_payload();
+    let size = payload.len() as u64;
+    let h = spawn_disk_thread(sparse_mtime_config(true, size)).unwrap();
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: size,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+    h.file_tx.send(FileMessage::Chunk(payload)).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert!(result.metadata_error.is_none(), "metadata must apply");
+    assert_eq!(
+        fs::metadata(&file_path).unwrap().len(),
+        size,
+        "sparse finalize must truncate to the logical length"
+    );
+    assert_eq!(
+        dest_mtime_secs(&file_path),
+        SPARSE_MTIME_SECS,
+        "sparse temp+rename commit must preserve the source mtime, not stamp wall clock"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// The coalesced whole-file path (`process_whole_file`) shares the sparse
+/// finalize-before-metadata ordering fix and must likewise preserve the mtime.
+#[test]
+fn sparse_whole_file_commit_preserves_source_mtime() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("sparse_whole.dat");
+
+    let payload = sparse_payload();
+    let size = payload.len() as u64;
+    let h = spawn_disk_thread(sparse_mtime_config(true, size)).unwrap();
+
+    h.file_tx
+        .send(FileMessage::WholeFile {
+            begin: Box::new(BeginMessage {
+                file_path: file_path.clone(),
+                target_size: size,
+                file_entry_index: 0,
+                checksum_verifier: None,
+                is_device_target: false,
+                is_inplace: false,
+                append_offset: 0,
+                xattr_list: None,
+            }),
+            data: payload,
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert!(result.metadata_error.is_none(), "metadata must apply");
+    assert_eq!(
+        fs::metadata(&file_path).unwrap().len(),
+        size,
+        "sparse finalize must truncate to the logical length"
+    );
+    assert_eq!(
+        dest_mtime_secs(&file_path),
+        SPARSE_MTIME_SECS,
+        "sparse whole-file commit must preserve the source mtime, not stamp wall clock"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// Control: the non-sparse pipelined path already preserved the mtime and must
+/// keep doing so, guarding against a regression that would move the fix's cost
+/// onto the common path.
+#[test]
+fn non_sparse_commit_preserves_source_mtime() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("non_sparse.dat");
+
+    let payload = b"dense payload".to_vec();
+    let size = payload.len() as u64;
+    let h = spawn_disk_thread(sparse_mtime_config(false, size)).unwrap();
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: size,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+    h.file_tx.send(FileMessage::Chunk(payload)).unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert!(result.metadata_error.is_none(), "metadata must apply");
+    assert_eq!(
+        dest_mtime_secs(&file_path),
+        SPARSE_MTIME_SECS,
+        "non-sparse commit must preserve the source mtime"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -3409,7 +3409,7 @@ fn dest_mtime_secs(path: &std::path::Path) -> i64 {
 fn sparse_payload() -> Vec<u8> {
     let mut data = Vec::new();
     data.extend_from_slice(b"HEAD");
-    data.extend(std::iter::repeat(0u8).take(64 * 1024));
+    data.resize(data.len() + 64 * 1024, 0u8);
     data.extend_from_slice(b"TAIL");
     data
 }


### PR DESCRIPTION
## Divergence

On a remote transfer (ssh subprocess or daemon) with `--sparse`, the destination
file's mtime was left at wall-clock "now" instead of the source mtime, silently
defeating `-t`/`-a`'s timestamp preservation. Local `--sparse` and remote without
`--sparse` were already correct, so `-a --sparse` over the network produced files
that looked freshly modified on every run.

Confirmed on a Linux host against `/usr/bin/rsync` 3.4.4 with source files stamped
to `1614830767`:

```
oc -a          ssh:  mtime 1614830767  (preserved, correct)
oc -a --sparse ssh:  mtime 1784621565  (= now, WRONG - every file)
upstream -a --sparse ssh: 1614830767   (correct)
oc -a --sparse LOCAL: 1614830767        (correct)
```

## Root cause

The pipelined remote receive path (`crates/transfer/src/disk_commit/`) applies
metadata to the temp file *before* renaming it into place, mirroring
`rsync.c:748 finish_transfer()` ("Change permissions before putting the file into
place"). For a `--sparse` file the sparse finalization
(`finalize_sparse` -> `set_len` + `punch_hole`) ran *inside* `commit_file`, i.e.
*after* that metadata step. Both `ftruncate` and `fallocate(PUNCH_HOLE)` update the
file mtime, so the just-applied source mtime was overwritten, and the
`needs_rename && !was_copy` branch reused the pre-commit result without re-applying
metadata.

Upstream never has this problem: `fileio.c:43 sparse_end()` runs inside
`receive_data()` (receiver.c) and therefore *precedes*
`finish_transfer()` -> `set_file_attrs()` -> `set_modtime()` (rsync.c). Sparse mode
only affects how bytes are written, never whether or when times are set. The
non-pipelined receiver (`receiver/transfer/sync.rs`) already applies metadata
strictly after finalize, which is why local sparse was correct.

## Fix

Move the temp+rename sparse finalization ahead of metadata application in both
disk-commit callers (`process_file` streaming and `process_whole_file` coalesced),
so the ftruncate/punch can no longer re-stamp the mtime. `commit_file` no longer
finalizes sparse for the temp+rename case (the caller does); the inplace branch is
unchanged and still re-applies metadata after its own finalize. This restores the
upstream ordering (`sparse_end` before `set_file_attrs`). Holes and the logical
length are preserved exactly as before.

## Verification (Linux host vs rsync 3.4.4)

Source: a genuinely sparse 1 MiB file (`blocks=16`) plus a dense file, both stamped
`1614830767`. After the fix, mtime is preserved on every path and the sparse file
stays sparse (identical to upstream):

```
                       file        mtime         size      blocks
oc ssh -a --sparse     sparse.bin  1614830767    1048580   16
oc ssh -a --sparse     dense.bin   1614830767    20000     40
oc daemon -a --sparse  sparse.bin  1614830767    1048580   16
oc local -a --sparse   sparse.bin  1614830767    1048580   16
upstream ssh -a --sp   sparse.bin  1614830767    1048580   16   (reference)
```

Before the fix the same sparse ssh/daemon files reported `mtime` = wall clock;
after the fix all report `1614830767`, and `blocks=16 << logical 1048580` confirms
sparseness is intact. Non-sparse remote (`oc ssh -a`) and local sparse are
unchanged.

Targeted regression tests added in `crates/transfer/src/disk_commit/tests.rs`
drive the disk-commit thread with a backdated file-list entry and a sparse payload
(interior zero hole) over both the streaming and whole-file paths, asserting the
committed mtime equals the source mtime and the logical length is truncated
correctly, plus a non-sparse control. Confirmed these fail on the pre-fix source
(mtime = wall clock) and pass with the fix.

`cargo fmt --all -- --check`, `cargo clippy -p transfer --all-targets --all-features
--no-deps -- -D warnings`, and the disk-commit / sparse test slices are green.
