### PR TITLE
fix: apply dest_mode to new files on remote receive without -p

### DIFF
--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -861,13 +861,28 @@ pub(super) fn apply_permissions_from_entry(
             // the temp file's `0o600`/umask-default permissions); for a new
             // destination it applies `source_mode & (~CHMOD_BITS | dflt_perms)`.
             // Only the regular-file branch ships - upstream restricts the
-            // `S_ISREG(flist_mode)` chmod-on-rename loop to data files. Skip
-            // when the caller has supplied neither a pre-transfer stat nor a
-            // cached post-rename stat: we cannot distinguish a fresh-from-
-            // rename temp file from an untouched destination, and the source-
-            // `Metadata` apply path already handles both cases via
-            // `apply_dest_mode_pre_transfer`.
-            if entry.file_type().is_regular() && pre_transfer_meta.is_some() {
+            // `S_ISREG(flist_mode)` chmod-on-rename loop to data files.
+            //
+            // `pre_transfer_meta.is_some()` marks an existing destination:
+            // apply the exists=true `dest_mode()` (keep the prior perm bits).
+            // `cached_meta.is_none()` marks a freshly-committed file: every
+            // receiver commit path (pipelined disk-commit, streaming sync,
+            // alt-dest materialise) passes `cached_meta = None` to apply
+            // unconditionally, so a brand-new file - which correctly has NO
+            // pre-transfer stat - still gets the exists=false `dest_mode()`
+            // (`source_mode & (~CHMOD_BITS | dflt_perms)`). Without this, a
+            // network-received new file kept the temp file's `0o600` creation
+            // mode over ssh/daemon instead of the umask-masked source mode a
+            // local copy and upstream both land.
+            //
+            // Skip only when a cached post-rename stat is present but no
+            // pre-transfer stat is (public API / quick-check skip on an
+            // untouched existing file): the file already exists, upstream
+            // keeps its bits, and applying the new-file formula would wrongly
+            // mask them.
+            if entry.file_type().is_regular()
+                && (pre_transfer_meta.is_some() || cached_meta.is_none())
+            {
                 let new_mode = dest_mode_for_existing_or_new(entry, pre_transfer_meta);
                 let fresh_meta;
                 let current_meta = if let Some(meta) = cached_meta {

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -583,6 +583,97 @@ fn apply_permissions_from_entry_no_change_when_disabled() {
     assert_eq!(mode, 0o666);
 }
 
+/// Remote-pull regression: on a transfer WITHOUT `--perms`, a newly-created
+/// destination file must land at the SOURCE entry's mode masked by the umask
+/// (upstream `rsync.c:dest_mode()` `exists=false` branch), NOT the temp
+/// file's `0o600` creation mode. The receiver commit paths (pipelined
+/// disk-commit, streaming sync) pass `cached_meta = None` to signal a fresh
+/// commit and `pre_transfer_meta = None` for a brand-new file; the
+/// chmod-on-commit `dest_mode()` must still fire. Before the fix these files
+/// silently kept the temp file's `0o600` mode over ssh/daemon (e.g. a source
+/// 0o644 file corrupted to 0o600), while a local copy and upstream both land
+/// the umask-masked source mode.
+// upstream: rsync.c:449-472 dest_mode() + rsync.c:954-965 set_file_attrs().
+#[cfg(unix)]
+#[test]
+fn no_perms_new_file_from_entry_gets_umask_masked_source_mode() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    // Pin the umask so the expected dest_mode is deterministic under nextest's
+    // process-per-test isolation (the crate caches the umask on first read).
+    let prev = nix::sys::stat::umask(nix::sys::stat::Mode::from_bits_truncate(0o022));
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false);
+
+    // (source entry mode, expected on-disk mode == source & (~CHMOD_BITS | 0o755))
+    for (src_mode, want) in [
+        (0o644, 0o644),
+        (0o640, 0o640),
+        (0o600, 0o600),
+        (0o777, 0o755),
+    ] {
+        let temp = tempdir().expect("tempdir");
+        let dest = temp.path().join("newfile.bin");
+        fs::write(&dest, b"payload").expect("write dest");
+        // Seed the temp file's O_TMPFILE creation mode the receiver commits.
+        fs::set_permissions(&dest, PermissionsExt::from_mode(0o600)).expect("seed temp mode");
+
+        let entry = FileEntry::new_file("newfile.bin".into(), 7, src_mode);
+        // cached_meta = None (fresh commit), pre_transfer_meta = None (new file).
+        apply_metadata_with_cached_stat(&dest, &entry, &opts, None).expect("apply from entry");
+
+        let got = current_mode(&dest) & 0o7777;
+        assert_eq!(
+            got, want,
+            "no-perms new file from entry 0o{src_mode:o} must land 0o{want:o} \
+             (dest_mode under umask 022), got 0o{got:o}",
+        );
+    }
+
+    nix::sys::stat::umask(prev);
+}
+
+/// Companion to the new-file regression: on a `--no-perms` transfer over an
+/// EXISTING destination the receiver must KEEP the destination's prior
+/// permission bits (upstream `dest_mode()` `exists=true` branch), threading
+/// the pre-transfer stat so the temp file's `0o600` never leaks through.
+// upstream: rsync.c:454-456 dest_mode() exists branch.
+#[cfg(unix)]
+#[test]
+fn no_perms_existing_file_from_entry_keeps_prior_mode() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    // The committed (post-rename) file carries the temp file's 0o600 mode.
+    let dest = temp.path().join("existing.bin");
+    fs::write(&dest, b"payload").expect("write dest");
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o600)).expect("seed temp mode");
+
+    // The destination existed pre-transfer at 0o755 (captured before rename).
+    let pre = temp.path().join("pre.bin");
+    fs::write(&pre, b"old").expect("write pre");
+    fs::set_permissions(&pre, PermissionsExt::from_mode(0o755)).expect("seed pre mode");
+    let pre_meta = fs::metadata(&pre).expect("pre metadata");
+
+    let entry = FileEntry::new_file("existing.bin".into(), 7, 0o644);
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false);
+
+    apply_metadata_with_pre_transfer_stat(&dest, &entry, &opts, None, Some(pre_meta))
+        .expect("apply from entry");
+
+    assert_eq!(
+        current_mode(&dest) & 0o7777,
+        0o755,
+        "no-perms existing file must keep its prior 0o755 mode, not adopt temp 0o600 or source 0o644",
+    );
+}
+
 #[test]
 fn epoch_timestamp_zero_seconds_is_preserved() {
     let temp = tempdir().expect("tempdir");

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -37,6 +37,20 @@ pub(super) fn apply_file_metadata(
     if begin.is_device_target {
         None
     } else {
+        // upstream: rsync.c:954-965 dest_mode() runs against the PRE-transfer
+        // destination stat. When metadata is applied to a temp/staged file
+        // (target_path != final path), the final destination still holds the
+        // file it had before this transfer, so stat it to reproduce
+        // dest_mode()'s `stat_mode`/`exists` inputs: `Some(meta)` -> keep the
+        // prior perm bits; a missing final path (`None`) -> brand-new file,
+        // apply the umask-masked source mode. When metadata is applied
+        // directly to the final path (inplace/device/cross-device), the
+        // pre-transfer state is already gone, so pass `None`.
+        let pre_transfer_meta = if target_path != begin.file_path {
+            std::fs::symlink_metadata(&begin.file_path).ok()
+        } else {
+            None
+        };
         apply_metadata_acls_and_xattrs(
             target_path,
             file_entry,
@@ -45,6 +59,7 @@ pub(super) fn apply_file_metadata(
             config.acl_id_map.as_deref(),
             begin.xattr_list.as_ref(),
             config.xattr_filter.as_deref(),
+            pre_transfer_meta,
         )
     }
 }
@@ -66,16 +81,25 @@ fn apply_metadata_acls_and_xattrs(
     acl_id_map: Option<&AclIdMapper>,
     xattr_list: Option<&protocol::xattr::XattrList>,
     xattr_filter: Option<&filters::FilterSet>,
+    pre_transfer_meta: Option<std::fs::Metadata>,
 ) -> Option<(PathBuf, String)> {
     let (opts, entry) = match (metadata_opts, file_entry) {
         (Some(o), Some(e)) => (o, e),
         _ => return None,
     };
 
-    // Skip the stat inside apply_metadata_from_file_entry: the file was
-    // just renamed into place from a temp file, so its metadata will not
-    // match the desired entry. Pass None to apply unconditionally.
-    if let Err(e) = metadata::apply_metadata_with_cached_stat(file_path, entry, opts, None) {
+    // Skip the cached post-rename stat: the file was just committed from a
+    // temp file, so its on-disk metadata will not match the desired entry.
+    // Pass the PRE-transfer stat instead so `set_file_attrs()`'s dest_mode()
+    // chmod keeps an existing file's prior perm bits and applies the
+    // umask-masked source mode to a brand-new file.
+    if let Err(e) = metadata::apply_metadata_with_pre_transfer_stat(
+        file_path,
+        entry,
+        opts,
+        None,
+        pre_transfer_meta,
+    ) {
         return Some((file_path.to_path_buf(), e.to_string()));
     }
 

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -633,9 +633,14 @@ fn hard_link_reference_non(ref_path: &Path, dest_path: &Path) -> bool {
 /// Applies the source entry's metadata and ACLs onto a freshly materialised
 /// destination (hard link or copy), recording any failures in `metadata_errors`.
 ///
-/// The cached stat is deliberately `None`: the destination was just created, so
-/// its on-disk metadata does not yet match the entry and an extra stat would be
-/// wasted.
+/// The freshly-materialised file's own stat is passed as the cached stat so the
+/// `!--perms` `dest_mode()` chmod-on-commit path treats this as an existing
+/// destination and never rewrites the mode. For a `--link-dest` hard link that
+/// stat is the SHARED reference inode's mode, so passing it (rather than `None`,
+/// which the receiver-commit paths use to signal a brand-new data file) keeps
+/// `dest_mode()` from chmod'ing the reference tree when the source and basis
+/// perms differ under `--no-perms`. Under `-p`/`--chmod` the stat also lets the
+/// permission-apply path skip a redundant chmod when the mode already matches.
 fn apply_altdest_metadata(
     entry: &FileEntry,
     dest_path: &Path,
@@ -644,7 +649,8 @@ fn apply_altdest_metadata(
     acl_cache: Option<&AclCache>,
     acl_id_map: Option<&AclIdMapper>,
 ) {
-    if let Err(e) = apply_metadata_with_cached_stat(dest_path, entry, metadata_opts, None) {
+    let cached_meta = fs::symlink_metadata(dest_path).ok();
+    if let Err(e) = apply_metadata_with_cached_stat(dest_path, entry, metadata_opts, cached_meta) {
         metadata_errors.push((dest_path.to_path_buf(), e.to_string()));
     }
     if let Err(e) =


### PR DESCRIPTION
## Summary

On a remote pull (ssh subprocess or `rsync://` daemon) **without** `--perms`/`-p`,
newly-created destination files were assigned the wrong per-file permission mode -
silent permission corruption. Local copies and `-p` transfers were correct. Adding
`-p` masked the bug.

The receiver must create each new file at the **source entry's mode masked by the
umask** (upstream `rsync.c:dest_mode()` `exists=false` branch), exactly as a local
copy and upstream rsync do.

## Divergence (Linux host, `/usr/bin/rsync` 3.4.4, umask 022)

Source tree: `f600`=0600, `f644`=0644, `h1`=0644, `h2`=0644 (`h1`/`h2` hard-linked),
`sub/f640`=0640. Pull with `-rl` (recurse + links, no `-p`) into a fresh dest.

| file       | source | upstream ssh | oc local `-rl` | oc ssh `-rl` (before) |
|------------|:------:|:------------:|:--------------:|:---------------------:|
| `f600`     | 600    | 600          | 600            | 600                   |
| `f644`     | 644    | 644          | 644            | **600**               |
| `h1`       | 644    | 644          | 644            | **600**               |
| `h2`       | 644    | 644          | 644            | **600**               |
| `sub/f640` | 640    | 640          | 640            | **644**               |

Over ssh/daemon every new file collapsed toward the temp file's raw creation mode
(top-level files to `600`; the sub-dir file surfaced as `644`) instead of the
umask-masked source mode.

## Root cause

The receiver commit paths that run over the wire - the pipelined disk-commit
(`crates/transfer/src/disk_commit/process/metadata.rs`) and the streaming sync
path - apply metadata from the wire `FileEntry` with `cached_meta = None` to force
an unconditional apply after the temp file is renamed into place.

In `metadata::apply_permissions_from_entry` the `!--perms` `dest_mode()`
chmod-on-commit for a regular data file was gated on `pre_transfer_meta.is_some()`:

```rust
if entry.file_type().is_regular() && pre_transfer_meta.is_some() {
    let new_mode = dest_mode_for_existing_or_new(entry, pre_transfer_meta);
    ...
}
```

A brand-new file correctly has **no** pre-transfer stat (`pre_transfer_meta = None`),
so this branch never ran and the file kept the temp file's `0o600` `O_TMPFILE`
creation mode. The comment justified the skip by pointing at the source-`Metadata`
apply path (`apply_dest_mode_pre_transfer`) - but that path only covers the local
executor. Over the wire there is no source `fs::Metadata`, only the `FileEntry`, so
nothing applied `dest_mode()` to new files.

Upstream computes `dest_mode()` for every non-`--perms` regular file and chmods the
post-rename destination to it:

- `rsync.c:449-472` `dest_mode()` - `exists=false` returns
  `flist_mode & (~CHMOD_BITS | dflt_perms)` with `dflt_perms = ACCESSPERMS & ~umask`.
- `rsync.c:954-965` - the receiver mutates `file->mode = dest_mode(...)` and
  `set_file_attrs()` chmods the renamed file to it.

## Fix

- Fire the regular-file `dest_mode()` branch for a **fresh commit**
  (`cached_meta.is_none()`) as well: a new file (`pre_transfer_meta = None`) now
  lands `source_mode & (~CHMOD_BITS | dflt_perms)`, and an existing file keeps its
  prior bits. The skip is preserved only when a cached post-rename stat is present
  but no pre-transfer stat is (public API / quick-check skip on an untouched
  existing file), where upstream keeps the existing bits and the new-file formula
  must not mask them.
- Thread the pre-transfer destination stat through the disk-commit metadata apply
  (stat the final path while the temp file still holds it, before rename) so an
  existing-file re-transfer keeps its prior mode (`dest_mode()` `exists=true`).
- The alt-dest (`--link-dest`/`--copy-dest`) materialise path now passes the
  freshly-created file's own stat as `cached_meta`, so a shared `--link-dest`
  reference inode is never chmod'd by the new-file path.

## Verification (Linux host, vs `/usr/bin/rsync` 3.4.4, umask 022)

After the fix, every remote path matches upstream byte-for-byte:

| scenario                            | f600 | f644 | h1  | h2  | sub/f640 |
|-------------------------------------|:----:|:----:|:---:|:---:|:--------:|
| source                              | 600  | 644  | 644 | 644 | 640      |
| upstream ssh `-rl`                  | 600  | 644  | 644 | 644 | 640      |
| oc local `-rl`                      | 600  | 644  | 644 | 644 | 640      |
| oc ssh `-rl` (oc sender)            | 600  | 644  | 644 | 644 | 640      |
| oc ssh `-rl` (upstream sender)      | 600  | 644  | 644 | 644 | 640      |
| oc daemon `-rl`                     | 600  | 644  | 644 | 644 | 640      |

Regressions checked (exact source modes preserved): oc ssh `-rlp`, oc ssh `-a`,
oc local `-a`.

A targeted regression test covers the new-file (umask-masked source mode) and
existing-file (keep prior mode) receiver-commit paths through the wire `FileEntry`
apply. `cargo fmt --all -- --check` and `cargo clippy -p metadata -p transfer -D warnings`
are clean.
