### PR TITLE
fix: honor --mkpath for dest parents on local and pull receivers

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -50,6 +50,15 @@ pub(crate) fn build_server_config_for_receiver(
     // client flag, distinct from the module `incoming chmod` the remote daemon
     // applies on the far side.
     server_config.chmod = config.chmod().cloned();
+    // upstream: options.c:2996-2997 - `--mkpath` is forwarded to the remote only
+    // inside the `if (am_sender)` server_options block, so on a pull it never
+    // rides the wire; the local client IS the receiver and creates the dest-arg
+    // path chain itself in get_local_name() (main.c:736 make_path under mkpath).
+    // Carry it onto the local receiver config here. Without this the rsync://
+    // pull to a missing deep destination failed with "failed to create
+    // destination root ... No such file or directory" while local copies honored
+    // --mkpath.
+    server_config.flags.mkpath = config.mkpath();
     // upstream flist.c:flist_sort_and_clean prunes empty dirs on the receiver
     // (prune_empty_dirs && !am_sender); on a pull the local client IS the receiver,
     // and -m is never sent over the wire (options.c gates it on am_sender), so the

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -1138,6 +1138,32 @@ mod server_config_reference_dirs {
         assert!(server_config.chmod.is_none());
     }
 
+    /// On a daemon (rsync://) pull the local client IS the receiver and creates
+    /// the dest-arg path chain itself. `--mkpath` is never forwarded to the
+    /// remote daemon (upstream options.c:2996-2997 gates it on am_sender), so the
+    /// receiver config must carry it (main.c:736 make_path). Regression guard for
+    /// the rsync:// pull that failed with "failed to create destination root ...
+    /// No such file or directory" against a missing deep destination.
+    #[test]
+    fn receiver_config_propagates_mkpath() {
+        let config = ClientConfig::builder().mkpath(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(server_config.flags.mkpath);
+    }
+
+    /// Without `--mkpath` the receiver config leaves the flag clear, so a missing
+    /// destination parent stays a fatal error, matching upstream main.c:787.
+    #[test]
+    fn receiver_config_without_mkpath_stays_clear() {
+        let config = ClientConfig::default();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(!server_config.flags.mkpath);
+    }
+
     #[test]
     fn generator_config_empty_reference_dirs_by_default() {
         let config = ClientConfig::default();

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -533,6 +533,15 @@ fn build_server_config_for_receiver(
     // config here; without this the russh (ssh://) pull left every regular file
     // at its source mode while local copies applied --chmod correctly.
     server_config.chmod = config.chmod().cloned();
+    // upstream: options.c:2996-2997 - `--mkpath` is forwarded to the remote only
+    // inside the `if (am_sender)` server_options block, so on a pull it never
+    // rides the wire; the local client IS the receiver and creates the dest-arg
+    // path chain itself in get_local_name() (main.c:736 make_path under mkpath).
+    // Carry it onto the local receiver config here. Without this the russh
+    // (ssh://) pull to a missing deep destination failed with "failed to create
+    // destination root ... No such file or directory" while local copies honored
+    // --mkpath.
+    server_config.flags.mkpath = config.mkpath();
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,
     // and 'D' now tracks devices only, so carry keep_partial and specials onto
     // the local half here (mirrors --partial / --specials|--no-specials which the
@@ -740,6 +749,32 @@ mod tests {
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
 
         assert!(server_config.chmod.is_none());
+    }
+
+    /// The embedded (russh) pull receiver must carry `--mkpath` onto its
+    /// ServerConfig. `--mkpath` is never forwarded to the remote sender (upstream
+    /// options.c:2996-2997 gates it on am_sender), so on a pull the local client
+    /// IS the receiver and creates the dest-arg path chain itself (main.c:736).
+    /// Regression guard for the `ssh://` pull that failed against a missing deep
+    /// destination while local copies honored `--mkpath`.
+    #[test]
+    fn embedded_receiver_config_propagates_mkpath() {
+        let config = ClientConfig::builder().mkpath(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.mkpath);
+    }
+
+    /// Without `--mkpath` the embedded receiver config leaves the flag clear, so
+    /// a missing destination parent stays a fatal error, matching upstream.
+    #[test]
+    fn embedded_receiver_config_without_mkpath_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.mkpath);
     }
 
     #[test]

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -59,6 +59,14 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
     // config here; without this the ssh pull left every regular file at its
     // source mode while local copies applied --chmod correctly.
     server_config.chmod = config.chmod().cloned();
+    // upstream: options.c:2996-2997 - `--mkpath` is forwarded to the remote only
+    // inside the `if (am_sender)` server_options block, so on a pull it never
+    // rides the wire; the local client IS the receiver and creates the dest-arg
+    // path chain itself in get_local_name() (main.c:736 make_path under mkpath).
+    // Carry it onto the local receiver config here. Without this the ssh pull to
+    // a missing deep destination failed with "failed to create destination root
+    // ... No such file or directory" while local copies honored --mkpath.
+    server_config.flags.mkpath = config.mkpath();
     // upstream: build_server_flag_string no longer packs the compact 'P' letter,
     // and 'D' now tracks devices only, so carry keep_partial and specials onto
     // the local half here (mirrors --partial / --specials|--no-specials which the
@@ -326,5 +334,32 @@ mod tests {
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
 
         assert!(server_config.chmod.is_none());
+    }
+
+    /// On an ssh pull the local client IS the receiver and creates the dest-arg
+    /// path chain itself. `--mkpath` is forwarded to the remote only when
+    /// am_sender (upstream options.c:2996-2997), so on a pull it never rides the
+    /// wire and must be carried onto the receiver config. Regression guard for
+    /// the ssh pull that failed with "failed to create destination root ... No
+    /// such file or directory" against a missing deep destination while local
+    /// copies honored --mkpath.
+    #[test]
+    fn receiver_config_propagates_mkpath() {
+        let config = ClientConfig::builder().mkpath(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.mkpath);
+    }
+
+    /// Without `--mkpath` the receiver config leaves the flag clear, so a missing
+    /// destination parent stays a fatal error, matching upstream main.c:787.
+    #[test]
+    fn receiver_config_without_mkpath_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.mkpath);
     }
 }

--- a/crates/engine/src/local_copy/executor/sources/destination.rs
+++ b/crates/engine/src/local_copy/executor/sources/destination.rs
@@ -47,10 +47,17 @@ pub(crate) fn query_destination_state(path: &Path) -> Result<DestinationState, L
 /// generator emits `created directory %s` only when the pre-flight mkdir
 /// actually created the dest; subsequent runs against the same destination
 /// must remain silent.
+///
+/// The `mkpath` argument selects how many components may be created, mirroring
+/// upstream `get_local_name()`: without `--mkpath` a single `do_mkdir(dest_path)`
+/// creates only the final component and a missing ancestor is a fatal ENOENT
+/// (`main.c:787,796`), whereas `--mkpath` first runs `make_path(dest_path, ...)`
+/// to build the whole leading chain (`main.c:736`).
 pub(crate) fn ensure_destination_directory(
     destination_path: &Path,
     state: &mut DestinationState,
     mode: LocalCopyExecution,
+    mkpath: bool,
 ) -> Result<bool, LocalCopyError> {
     if state.exists {
         if !state.is_dir {
@@ -67,7 +74,15 @@ pub(crate) fn ensure_destination_directory(
         return Ok(true);
     }
 
-    fs::create_dir_all(destination_path).map_err(|error| {
+    // upstream: main.c:736 vs main.c:787 - `--mkpath` runs `make_path()` (full
+    // chain) while the plain path does a single `do_mkdir(dest_path)` that fails
+    // with ENOENT when a leading directory is absent.
+    let outcome = if mkpath {
+        fs::create_dir_all(destination_path)
+    } else {
+        fs::create_dir(destination_path)
+    };
+    outcome.map_err(|error| {
         LocalCopyError::io(
             "create destination directory",
             destination_path.to_path_buf(),

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -85,11 +85,13 @@ pub(crate) fn copy_sources(
             // emit_transfer_summary) and the synthesized `cd+++++++++ ./`
             // root record (rendered by copy_directory_recursive) both fire.
             let mut destination_root_created = false;
+            let mkpath = context.mkpath_enabled();
             if plan.destination_spec().force_directory() {
                 destination_root_created |= ensure_destination_directory(
                     destination_path,
                     &mut destination_state,
                     context.mode(),
+                    mkpath,
                 )?;
             }
 
@@ -98,6 +100,7 @@ pub(crate) fn copy_sources(
                     destination_path,
                     &mut destination_state,
                     context.mode(),
+                    mkpath,
                 )?;
             }
 
@@ -144,6 +147,7 @@ pub(crate) fn copy_sources(
                     destination_path,
                     &mut destination_state,
                     context.mode(),
+                    mkpath,
                 )?;
             }
 

--- a/crates/engine/src/local_copy/tests/execute_directories.rs
+++ b/crates/engine/src/local_copy/tests/execute_directories.rs
@@ -1878,6 +1878,70 @@ fn execute_mkpath_with_directory_source_creates_parents() {
     );
 }
 
+// upstream: main.c:787,796 get_local_name() - without --mkpath the destination
+// root is created with a single do_mkdir(dest_path); when a leading directory is
+// absent that mkdir fails with ENOENT (mkdir_error -> RERR_FILEIO). A recursive
+// directory source into a dest with 2+ missing ancestor levels must therefore
+// error and create nothing, NOT silently materialise the whole chain the way
+// --mkpath would. Regression guard for the local executor over-creating parents.
+#[test]
+fn execute_directory_source_deep_missing_dest_errors_without_mkpath() {
+    let temp = create_tempdir();
+    let source_root = temp.path().join("source");
+    fs::create_dir_all(&source_root).expect("create source");
+    fs::write(source_root.join("file.txt"), b"content").expect("write file");
+
+    let missing_prefix = temp.path().join("new");
+    let dest_root = missing_prefix.join("deep").join("path");
+
+    let operands = vec![
+        source_root.into_os_string(),
+        dest_root.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default();
+
+    let error = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect_err("deep missing dest parent must error without --mkpath");
+
+    match error.kind() {
+        LocalCopyErrorKind::Io { action, source, .. } => {
+            assert_eq!(*action, "create destination directory");
+            assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+        }
+        other => panic!("unexpected error kind: {other:?}"),
+    }
+    assert!(!missing_prefix.exists(), "no ancestor chain must be created");
+    assert!(!dest_root.exists());
+}
+
+// upstream: main.c:787 - a single missing final component is created by the lone
+// do_mkdir(dest_path) even without --mkpath (rsync always makes the immediate
+// destination directory). Only a missing PARENT is fatal.
+#[test]
+fn execute_directory_source_single_missing_dest_succeeds_without_mkpath() {
+    let temp = create_tempdir();
+    let source_root = temp.path().join("source");
+    fs::create_dir_all(&source_root).expect("create source");
+    fs::write(source_root.join("file.txt"), b"content").expect("write file");
+
+    let dest_root = temp.path().join("new");
+
+    let operands = vec![
+        source_root.into_os_string(),
+        dest_root.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default();
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("single missing final component succeeds without --mkpath");
+
+    assert!(dest_root.is_dir());
+    assert!(dest_root.join("source").join("file.txt").exists());
+}
+
 #[test]
 fn execute_mkpath_dry_run_does_not_create_parents() {
     let temp = create_tempdir();


### PR DESCRIPTION
## Summary

Two related destination-parent-directory divergences from upstream rsync
3.4.4 (protocol 32) around `--mkpath`, both confirmed on an x86_64 Arch
host against `/usr/bin/rsync 3.4.4`.

## Divergence matrix (before this change)

| Case | Transport | `--mkpath` | Missing levels | upstream | oc-rsync (before) |
|------|-----------|-----------|----------------|----------|-------------------|
| A | local | no | 2 (`DST/new/deep/path/`) | rc=11, nothing created | **rc=0, whole chain created** |
| A | local | no | 1 (`DST/one/`) | rc=0, `one` created | rc=0, `one` created |
| A | local | yes | 2 | rc=0, chain created | rc=0, chain created |
| B | pull ssh | yes | 2 | rc=0, chain created | **rc=3, "failed to create destination root ... No such file or directory"** |
| B | pull russh | yes | 2 | rc=0, chain created | **rc=3, same failure** |
| B | pull daemon | yes | 2 | rc=0, chain created | **rc=3, same failure** |
| - | push ssh/russh/daemon | yes | 2 | rc=0 | rc=0 (already correct) |

## Root cause

### A - local over-creates missing parents without `--mkpath`

`ensure_destination_directory()` (local-copy executor) unconditionally
called `std::fs::create_dir_all()`, materialising a deep destination's
entire missing ancestor chain regardless of `--mkpath`.

Upstream `get_local_name()` makes only the **final** destination
component with a single `do_mkdir(dest_path)` (`main.c:787`,`796`); a
missing leading directory makes that `mkdir` fail with `ENOENT`
(`mkdir_error:` -> `exit_cleanup(RERR_FILEIO)`). Only `--mkpath` first
runs `make_path(dest_path, ...)` to build the whole chain (`main.c:736`).

### B - pulls ignore `--mkpath` over ssh, russh, and daemon

On a pull (remote sender -> local client receiver) the destination is
local, so the **local client is the receiver**. Upstream forwards
`--mkpath` to the remote only inside the `if (am_sender)` block of
`server_options()` (`options.c:2996-2997`), so on a pull it never rides
the wire - the local receiver must create the destination path chain
itself. The three pull receiver-config builders (ssh, russh, daemon)
never carried the client `--mkpath` onto their `ServerConfig`, so
`config.flags.mkpath` was `false` at `ensure_dest_root_exists()` and the
receiver used a single-level `create_dir` that failed on the missing
parent. Same class of gap as the recent `--link-dest`, `--backup-dir`,
and `--chmod` pull-receiver propagation fixes.

## Fix

- `ensure_destination_directory()` now selects `create_dir` (single
  final component, `ENOENT` on a missing parent) vs `create_dir_all`
  (full chain) based on `--mkpath`, mirroring `main.c:787` vs
  `main.c:736`. The three call sites pass `context.mkpath_enabled()`.
- The ssh, russh, and daemon pull receiver-config builders carry
  `config.mkpath()` onto `server_config.flags.mkpath`.

## Verification (x86_64 host vs `/usr/bin/rsync 3.4.4`)

| Case | Transport | `--mkpath` | upstream | oc-rsync (after) |
|------|-----------|-----------|----------|------------------|
| A | local | no, 2 missing | rc=11, empty | rc=24, empty (errors, nothing created) |
| A | local | no, 1 missing | rc=0, `one` | rc=0, `one` |
| A | local | yes, 2 missing | rc=0, chain | rc=0, chain |
| B | pull ssh | yes | rc=0, chain | rc=0, chain |
| B | pull russh | yes | rc=0, chain | rc=0, chain |
| B | pull daemon | yes | rc=0, chain | rc=0, chain |
| - | push ssh/russh/daemon | yes | rc=0, chain | rc=0, chain |
| - | pull ssh | no | rc=11, empty | rc=3, empty (errors) |

Functional behaviour now matches upstream in every case: without
`--mkpath` a missing parent is fatal and nothing is created; with
`--mkpath` the full chain is built, local and remote, both directions.

### Known follow-up (pre-existing, not introduced here)

The no-`--mkpath` missing-parent **error exit code** still differs from
upstream's `RERR_FILEIO` (11): the local executor reports 24
(`RERR_VANISHED`, its existing `NotFound` heuristic, shared with the
single-file dest-parent path) and the pull receiver reports 3. Aligning
these to 11 means reworking the shared `NotFound`->exit-code
classification (and the `is_vanished_error` recursion/vanished-source
semantics), which is out of scope for this dest-parent-creation change.

## Tests

- Local executor: deep-missing dest errors without `--mkpath` and creates
  nothing; single-missing final component still succeeds.
- Receiver-config propagation of `--mkpath` (present and absent) for all
  three transports.
