### PR TITLE
fix: stop sender leaking file-list debug lines on verbose push

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -306,9 +306,9 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         .with_itemize_repeated(itemize_repeated)
         .with_eight_bit_output(eight_bit_output)
         .with_preserve_links(preserve_links);
-    // The log file already carries the parallel "building file list" line via
-    // logging::info_log!(Flist, 1, ...); the FCLIENT "sending incremental file
-    // list" banner is for stdout only (upstream: flist.c:2248 vs 2252).
+    // The FCLIENT "sending incremental file list" banner is stdout only;
+    // upstream's parallel "building file list" line (flist.c:2248) is an FLOG
+    // log-file message that a plain client without --log-file discards.
     emit_transfer_summary(
         summary,
         verbosity,

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -125,12 +125,13 @@ pub(crate) fn emit_transfer_summary(
         return Ok(());
     }
 
-    // upstream: flist.c:2252 - rprintf(FCLIENT, "sending incremental file list\n")
-    // is gated on inc_recurse && INFO_GTE(FLIST, 1) && !am_server. The banner
-    // is FCLIENT-only - the parallel `rprintf(FLOG, "building file list\n")`
-    // covers the log file (already emitted via the logging::info_log! pipeline
-    // in the generator). Local-copy mode is treated as inc_recurse-equivalent
-    // because the source enumeration is interleaved with per-file dispatch.
+    // upstream: flist.c:2251 - rprintf(FCLIENT, "sending incremental file list\n")
+    // is gated on inc_recurse && INFO_GTE(FLIST, 1) && !am_server. This banner is
+    // stdout-only. Upstream's parallel `rprintf(FLOG, "building file list\n")`
+    // (flist.c:2248) targets the log file, which a plain client without
+    // --log-file discards, so it never reaches stdout. Local-copy mode is treated
+    // as inc_recurse-equivalent because the source enumeration is interleaved with
+    // per-file dispatch.
     if emit_flist_banner && verbosity > 0 {
         writeln!(writer, "sending incremental file list")?;
     }

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -30,7 +30,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use logging::{PhaseTimer, debug_log, info_log};
+use logging::{PhaseTimer, debug_log};
 use protocol::flist::FileEntry;
 
 use super::GeneratorContext;
@@ -75,7 +75,6 @@ impl GeneratorContext {
         // upstream: stats.flist_buildtime
         self.timing.flist_build_start = Some(Instant::now());
 
-        info_log!(Flist, 1, "building file list...");
         self.clear_file_list();
 
         // upstream: flist.c:2192 - pre-allocate FLIST_START pointer slots
@@ -161,7 +160,6 @@ impl GeneratorContext {
         self.collect_id_mappings();
 
         let count = self.file_list.len();
-        info_log!(Flist, 1, "built file list with {} entries", count);
         debug_log!(Flist, 2, "file list entries: {:?}", {
             let mut names = Vec::with_capacity(count);
             names.extend(self.file_list.iter().map(FileEntry::name));
@@ -196,7 +194,6 @@ impl GeneratorContext {
     ) -> io::Result<usize> {
         self.timing.flist_build_start = Some(Instant::now());
 
-        info_log!(Flist, 1, "building file list from --files-from...");
         self.clear_file_list();
 
         const FLIST_START: usize = 4096;
@@ -407,7 +404,6 @@ impl GeneratorContext {
         self.collect_id_mappings();
 
         let count = self.file_list.len();
-        info_log!(Flist, 1, "built file list with {} entries", count);
         debug_log!(Flist, 2, "file list entries: {:?}", {
             let mut names = Vec::with_capacity(count);
             names.extend(self.file_list.iter().map(FileEntry::name));

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -13,7 +13,7 @@
 use std::io::{self, IoSlice, Read, Write};
 use std::time::{Duration, Instant};
 
-use logging::{InfoFlag, PhaseTimer, debug_log, info_gte, info_log};
+use logging::{InfoFlag, PhaseTimer, debug_log, info_gte};
 use protocol::CompatibilityFlags;
 use protocol::ProtocolVersion;
 use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum};
@@ -561,37 +561,6 @@ impl GeneratorContext {
 
         self.timing.flist_xfer_end = Some(Instant::now());
         self.timing.flist_first_byte_latency = first_byte_latency;
-
-        if let Some(latency) = first_byte_latency {
-            // INC_RECURSE diagnostic I1: time from function entry to first
-            // wire byte. Surfaced at -vv (info=flist1) and -v --info=stats3.
-            info_log!(
-                Flist,
-                1,
-                "send_file_list first-byte latency: {} us",
-                latency.as_micros()
-            );
-            info_log!(
-                Stats,
-                3,
-                "file list first-byte latency: {} us",
-                latency.as_micros()
-            );
-            debug_log!(
-                Flist,
-                2,
-                "send_file_list first-byte latency: {:?} ({} entries)",
-                latency,
-                count
-            );
-            #[cfg(feature = "tracing")]
-            ::tracing::info!(
-                target: "rsync::flist",
-                latency_us = latency.as_micros() as u64,
-                entries = count,
-                "send_file_list first-byte latency"
-            );
-        }
 
         Ok(self.file_list.len())
     }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -270,6 +270,44 @@ fn send_file_list_first_byte_latency_recorded_for_empty_list() {
 }
 
 #[test]
+fn sender_flist_path_emits_no_debug_instrumentation_at_verbose() {
+    // Regression: a verbose (-v) push must not leak the sender's internal
+    // file-list instrumentation to stdout. Upstream's only stdout file-list
+    // line is the "sending incremental file list" banner (emitted by the CLI
+    // layer). "building file list", "built file list with N", and the
+    // first-byte latency timing are development-only diagnostics with no
+    // upstream stdout analog; every DiagnosticEvent::Info renders to the
+    // client's stdout, so any such event on the sender path is a leak.
+    logging::init(logging::VerbosityConfig::from_verbose_level(1));
+    let _ = logging::drain_events();
+
+    let temp = create_test_files(&[("one.txt", b"a"), ("two.txt", b"bb")]);
+    let (_handshake, mut ctx) = test_generator_for_path(temp.path(), false);
+    build_file_list_for_contents(&mut ctx, temp.path());
+
+    let mut wire = Vec::new();
+    ctx.send_file_list(&mut wire).unwrap();
+
+    let leaked: Vec<String> = logging::drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            logging::DiagnosticEvent::Info { message, .. } => Some(message),
+            logging::DiagnosticEvent::Debug { .. } => None,
+        })
+        .filter(|m| {
+            m.contains("building file list")
+                || m.contains("built file list with")
+                || m.contains("first-byte latency")
+        })
+        .collect();
+
+    assert!(
+        leaked.is_empty(),
+        "sender file-list path leaked instrumentation to stdout: {leaked:?}"
+    );
+}
+
+#[test]
 fn ndx_convert_call_counter_increments() {
     // INC_RECURSE diagnostic I4 (#2199): every wire_to_flat_ndx /
     // flat_to_wire_ndx invocation must bump the global call counter. The


### PR DESCRIPTION
## Problem

A verbose push (`-v` / `-vi`, local to remote over ssh or daemon) leaked three
internal diagnostic lines to **stdout** that upstream rsync 3.4.4 never prints:

```
building file list...
built file list with N entries
send_file_list first-byte latency: N us
```

Every `DiagnosticEvent::Info` renders to the client's stdout (the flag is not
used to pick a sink), so these `info_log!(Flist, 1, ...)` calls in the sender's
file-list path surfaced on stdout at plain `-v` (where `INFO_GTE(FLIST, 1)` is
true, matching upstream `info_verbosity[1]`). They corrupted the drop-in stdout
contract on every verbose push. Non-verbose push was already clean.

## Where they came from

Left-over development instrumentation in the generator's sender file-list code:

- `crates/transfer/src/generator/file_list/mod.rs` - `build_file_list()` and
  `build_file_list_with_base()` each emitted `info_log!(Flist, 1, "building
  file list...")` and `info_log!(Flist, 1, "built file list with N entries")`.
- `crates/transfer/src/generator/protocol_io.rs` - `send_file_list()` logged a
  `send_file_list first-byte latency: N us` timing line.

None of these have an upstream stdout analog. Upstream's only stdout file-list
line is the `sending incremental file list` banner (emitted by the CLI layer
and left untouched). Upstream's parallel `rprintf(FLOG, "building file list\n")`
(flist.c:2248) is a log-file message that a plain client without `--log-file`
discards, so it never reaches stdout either. `built file list with N entries`
and the first-byte latency line exist nowhere in upstream.

## Fix

Removed the four `info_log!(Flist, 1, ...)` calls and the first-byte-latency
logging block. The internal first-byte-latency measurement (`FirstByteWriter`,
`timing.flist_first_byte_latency`, and its propagation into `GeneratorStats`) is
kept - it feeds `--stats` and existing tests and never touches stdout. Only the
stdout-leaking log emission was deleted. Updated two now-inaccurate comments in
the CLI layer that had described the removed lines as a log-file parallel.

Added a regression test (`sender_flist_path_emits_no_debug_instrumentation_at_verbose`)
that drives `build_file_list` + `send_file_list` at verbosity level 1 and
asserts no drained `Info` event contains `building file list`, `built file list
with`, or `first-byte latency`. Verified the test fails when any of the lines is
reintroduced.

## Before / after (SSH push `-a -v`, remote `--rsync-path=/usr/bin/rsync`)

Before:

```
sending incremental file list

sent 89 bytes  received 56 bytes  201.22 bytes/sec
total size is 6  speedup is 0.04
building file list...
built file list with 5 entries
send_file_list first-byte latency: 20 us
```

After:

```
sending incremental file list

sent 89 bytes  received 56 bytes  199.17 bytes/sec
total size is 6  speedup is 0.04
```

Upstream `rsync -a -v` over the same transport prints no `building file list`,
`built file list`, or latency line. Non-verbose push stdout stays empty; `-a -v`
PULL output is unchanged.

Validated on an x86_64 Linux host against `/usr/bin/rsync 3.4.4` over ssh, plus
`cargo fmt --all -- --check` and `cargo clippy -p transfer -p cli
--all-targets --all-features -D warnings` clean.
