### PR TITLE
fix: apply --chmod on the sender for push transfers

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -103,6 +103,15 @@ pub(crate) fn build_server_config_for_generator(
 
     apply_common_daemon_config(config, &mut server_config, filter_rules);
     server_config.reference_directories = config.reference_directories().to_vec();
+    // upstream: --chmod is parsed into `chmod_modes` (options.c:1762) and is
+    // never placed in server_options, so it is never forwarded to the remote
+    // daemon receiver. On a push the local client IS the sender and applies the
+    // modifiers itself as it builds each outgoing flist entry (flist.c:1580-1581
+    // send_file_name() -> tweak_mode()). Carry them onto the local generator
+    // config here; without this the daemon push left every file at its source
+    // mode while local copies and pulls applied --chmod correctly. The daemon
+    // module's own `incoming chmod` is applied separately on the daemon side.
+    server_config.chmod = config.chmod().cloned();
 
     // upstream: options.c:2476-2501 / main.c:1322-1328 - the local sender
     // resolves a single files-from fd. A local file (LocalFile/Stdin, or a

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -1138,6 +1138,36 @@ mod server_config_reference_dirs {
         assert!(server_config.chmod.is_none());
     }
 
+    /// On a daemon (rsync://) push the local client IS the sender and applies
+    /// `--chmod` itself as it builds each outgoing flist entry (upstream
+    /// flist.c:1580-1581 send_file_name() -> tweak_mode()). `--chmod` is never
+    /// forwarded to the remote daemon receiver, so the generator config must
+    /// carry the parsed modifiers, distinct from the module `incoming chmod` the
+    /// daemon applies. Regression guard for the daemon push that left every file
+    /// at its source mode while local copies and pulls applied `--chmod`.
+    #[test]
+    fn generator_config_propagates_chmod() {
+        let modifiers = ::metadata::ChmodModifiers::parse("D2755,F640").expect("parse chmod spec");
+        let config = ClientConfig::builder()
+            .chmod(Some(modifiers.clone()))
+            .build();
+        let server_config =
+            build_server_config_for_generator(&config, &["src".to_owned()], Vec::new()).unwrap();
+
+        assert_eq!(server_config.chmod.as_ref(), Some(&modifiers));
+    }
+
+    /// Without `--chmod` the daemon generator config carries no chmod modifiers,
+    /// so the source mode travels unchanged.
+    #[test]
+    fn generator_config_without_chmod_has_none() {
+        let config = ClientConfig::default();
+        let server_config =
+            build_server_config_for_generator(&config, &["src".to_owned()], Vec::new()).unwrap();
+
+        assert!(server_config.chmod.is_none());
+    }
+
     #[test]
     fn generator_config_empty_reference_dirs_by_default() {
         let config = ClientConfig::default();

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -593,6 +593,14 @@ fn build_server_config_for_generator(
     // Local-only sender optimization; never emitted onto the wire, so it is
     // carried directly onto the in-process generator's ParsedServerFlags.
     server_config.flags.parallel_delta_scan = config.parallel_delta_scan();
+    // upstream: --chmod is parsed into `chmod_modes` (options.c:1762) and is
+    // never placed in server_options, so it is never forwarded to the remote
+    // receiver. On a push the local client IS the sender and applies the
+    // modifiers itself as it builds each outgoing flist entry (flist.c:1580-1581
+    // send_file_name() -> tweak_mode()). Carry them onto the local generator
+    // config here; without this the ssh push left every file at its source mode
+    // while local copies and pulls applied --chmod correctly.
+    server_config.chmod = config.chmod().cloned();
 
     // upstream: options.c:2476-2501 / main.c:1322-1328 - the local sender
     // resolves a single files-from fd: a local file (Stdin/LocalFile, or a
@@ -738,6 +746,35 @@ mod tests {
         let config = ClientConfig::builder().build();
         let server_config =
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.chmod.is_none());
+    }
+
+    /// On an `ssh://` (russh) push the local client IS the sender and applies
+    /// `--chmod` itself as it builds each outgoing flist entry (upstream
+    /// flist.c:1580-1581 send_file_name() -> tweak_mode()). `--chmod` is never
+    /// forwarded to the remote receiver, so the generator config must carry the
+    /// parsed modifiers. Regression guard for the embedded-ssh push that left
+    /// every file at its source mode while local copies and pulls applied it.
+    #[test]
+    fn embedded_generator_config_propagates_chmod() {
+        let modifiers = ::metadata::ChmodModifiers::parse("D2755,F640").expect("parse chmod spec");
+        let config = ClientConfig::builder()
+            .chmod(Some(modifiers.clone()))
+            .build();
+        let server_config =
+            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
+
+        assert_eq!(server_config.chmod.as_ref(), Some(&modifiers));
+    }
+
+    /// Without `--chmod` the embedded generator config carries no chmod
+    /// modifiers, so the source mode travels unchanged.
+    #[test]
+    fn embedded_generator_config_without_chmod_has_none() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
 
         assert!(server_config.chmod.is_none());
     }

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -142,6 +142,14 @@ pub(in crate::client::remote) fn build_server_config_for_generator(
     server_config.flags.partial = config.partial();
     server_config.flags.devices = config.preserve_devices();
     server_config.flags.specials = config.preserve_specials();
+    // upstream: --chmod is parsed into `chmod_modes` (options.c:1762) and is
+    // never placed in server_options, so it is never forwarded to the remote
+    // receiver. On a push the local client IS the sender and applies the
+    // modifiers itself as it builds each outgoing flist entry (flist.c:1580-1581
+    // send_file_name() -> tweak_mode()). Carry them onto the local generator
+    // config here; without this the ssh push left every file at its source mode
+    // while local copies and pulls applied --chmod correctly.
+    server_config.chmod = config.chmod().cloned();
 
     apply_files_from_for_sender(config, &mut server_config);
 
@@ -324,6 +332,35 @@ mod tests {
         let config = ClientConfig::builder().build();
         let server_config =
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.chmod.is_none());
+    }
+
+    /// On an ssh push the local client IS the sender and applies `--chmod`
+    /// itself as it builds each outgoing flist entry (upstream flist.c:1580-1581
+    /// send_file_name() -> tweak_mode()). `--chmod` is never forwarded to the
+    /// remote receiver, so the generator config must carry the parsed modifiers.
+    /// Regression guard for the ssh push that left files at their source mode
+    /// while local copies and pulls applied `--chmod`.
+    #[test]
+    fn generator_config_propagates_chmod() {
+        let modifiers = ::metadata::ChmodModifiers::parse("D2755,F640").expect("parse chmod spec");
+        let config = ClientConfig::builder()
+            .chmod(Some(modifiers.clone()))
+            .build();
+        let server_config =
+            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
+
+        assert_eq!(server_config.chmod.as_ref(), Some(&modifiers));
+    }
+
+    /// Without `--chmod` the generator config carries no chmod modifiers, so the
+    /// source mode travels unchanged.
+    #[test]
+    fn generator_config_without_chmod_has_none() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
 
         assert!(server_config.chmod.is_none());
     }

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -387,16 +387,29 @@ impl GeneratorContext {
             }
         }
 
-        // upstream: clientserver.c:rsync_module() arms `daemon_chmod_modes`
-        // and flist.c:make_file() applies it as the file_struct is built so
-        // the wire-emitted mode reflects the daemon's `outgoing chmod = SPEC`
-        // directive. We mirror that ordering: rewrite the entry's mode after
-        // every other flist field has been populated but before the caller
-        // serialises it. The chmod parser preserves the file-type bits, so
-        // the entry's S_IFREG/S_IFDIR/etc. classification is untouched.
-        if let Some(modifiers) = self.config.daemon_outgoing_chmod.as_ref() {
-            let rewritten = modifiers.apply(entry.mode(), file_type);
-            entry.set_mode(rewritten);
+        // upstream: flist.c:1580-1581 send_file_name() applies the client
+        // `--chmod` (chmod_modes) to each entry's mode as the sender builds the
+        // file list, and clientserver.c:1217 appends the daemon module
+        // `outgoing chmod` to that same `chmod_modes` list. On a push oc is the
+        // sender, so both modifier sources must rewrite the wire-emitted mode
+        // here; only then does the remote receiver materialise the transformed
+        // mode and itemize the `p` (perms-changed) flag. Applied after every
+        // other flist field is populated but before the caller serialises it.
+        // Symlinks are skipped (upstream `!S_ISLNK(file->mode)`); the chmod
+        // parser preserves the file-type bits, so the entry's S_IFREG/S_IFDIR
+        // classification is untouched. Order mirrors the receiver's
+        // merge_chmod: daemon modes first, then the client's.
+        if !entry.is_symlink() {
+            for modifiers in [
+                self.config.daemon_outgoing_chmod.as_ref(),
+                self.config.chmod.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                let rewritten = modifiers.apply(entry.mode(), file_type);
+                entry.set_mode(rewritten);
+            }
         }
 
         // upstream: flist.c:1444-1447 - `always_checksum && am_sender &&
@@ -820,6 +833,172 @@ mod daemon_outgoing_chmod_tests {
             .expect("create_entry");
 
         assert_eq!(entry.permissions() & 0o7777, 0o664);
+    }
+}
+
+#[cfg(all(test, unix))]
+mod client_chmod_tests {
+    //! Client `--chmod` push regression: on a push the local client IS the
+    //! sender, so `create_entry` must rewrite each outgoing flist entry's mode
+    //! with the parsed `--chmod` modifiers. Mirrors upstream
+    //! `flist.c:1580-1581 send_file_name() -> tweak_mode()`, where the sender
+    //! applies `chmod_modes` to `file->mode` before serialising the entry. The
+    //! transformed mode is what the remote receiver materialises on disk and
+    //! compares against for the itemize `p` (perms-changed) flag; without the
+    //! rewrite a push left every file/dir at its source mode.
+
+    use crate::config::ServerConfig;
+    use crate::generator::GeneratorContext;
+    use crate::handshake::HandshakeResult;
+    use crate::role::ServerRole;
+    use ::metadata::ChmodModifiers;
+    use protocol::ProtocolVersion;
+    use std::ffi::OsString;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn make_generator(chmod: Option<ChmodModifiers>) -> GeneratorContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let mut config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            chmod,
+            ..Default::default()
+        };
+        config.flags.numeric_ids = crate::NumericIds::Explicit;
+        GeneratorContext::new_for_test(&handshake, config)
+    }
+
+    /// `--chmod=Dg+s,Fo-rwx` on a push: a 0644 file becomes 0640 and a 0755
+    /// directory becomes 02755 on the wire. This is the exact spec from the
+    /// drop-in bug report where the ssh/daemon push left both at their source
+    /// modes while the pull applied the same modifiers correctly.
+    #[test]
+    fn client_chmod_dir_setgid_and_file_clear_other() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = tmp.path().join("f644");
+        std::fs::write(&file, b"payload").expect("write");
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644))
+            .expect("set file perms");
+        let dir = tmp.path().join("sub");
+        std::fs::create_dir(&dir).expect("mkdir");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755))
+            .expect("set dir perms");
+
+        let modifiers = ChmodModifiers::parse("Dg+s,Fo-rwx").expect("parse chmod spec");
+        let ctx = make_generator(Some(modifiers));
+
+        let fmeta = std::fs::symlink_metadata(&file).expect("metadata");
+        let fentry = ctx
+            .create_entry(&file, PathBuf::from("f644"), &fmeta)
+            .expect("create_entry file");
+        assert_eq!(
+            fentry.permissions() & 0o7777,
+            0o640,
+            "Fo-rwx must clear other rwx on the wire (0644 -> 0640)",
+        );
+
+        let dmeta = std::fs::symlink_metadata(&dir).expect("metadata");
+        let dentry = ctx
+            .create_entry(&dir, PathBuf::from("sub"), &dmeta)
+            .expect("create_entry dir");
+        assert_eq!(
+            dentry.permissions() & 0o7777,
+            0o2755,
+            "Dg+s must set the setgid bit on the wire (0755 -> 02755)",
+        );
+    }
+
+    /// Numeric `--chmod=D2755,F640` sets exact modes per file type.
+    #[test]
+    fn client_chmod_numeric_dir_and_file_modes() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = tmp.path().join("f");
+        std::fs::write(&file, b"x").expect("write");
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o600))
+            .expect("set file perms");
+        let dir = tmp.path().join("d");
+        std::fs::create_dir(&dir).expect("mkdir");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+            .expect("set dir perms");
+
+        let modifiers = ChmodModifiers::parse("D2755,F640").expect("parse chmod spec");
+        let ctx = make_generator(Some(modifiers));
+
+        let fmeta = std::fs::symlink_metadata(&file).expect("metadata");
+        let fentry = ctx
+            .create_entry(&file, PathBuf::from("f"), &fmeta)
+            .expect("create_entry file");
+        assert_eq!(
+            fentry.permissions() & 0o7777,
+            0o640,
+            "F640 sets file to 0640"
+        );
+
+        let dmeta = std::fs::symlink_metadata(&dir).expect("metadata");
+        let dentry = ctx
+            .create_entry(&dir, PathBuf::from("d"), &dmeta)
+            .expect("create_entry dir");
+        assert_eq!(
+            dentry.permissions() & 0o7777,
+            0o2755,
+            "D2755 sets directory to 02755",
+        );
+    }
+
+    /// Symlinks are exempt from `--chmod` on the sender, matching upstream's
+    /// `!S_ISLNK(file->mode)` guard at flist.c:1580. The link entry's mode must
+    /// survive the rewrite unchanged.
+    #[test]
+    fn client_chmod_skips_symlinks() {
+        let tmp = TempDir::new().expect("tempdir");
+        let link = tmp.path().join("link");
+        symlink("target", &link).expect("symlink");
+
+        let modifiers = ChmodModifiers::parse("Fo-rwx,Do-rwx").expect("parse chmod spec");
+        let ctx = make_generator(Some(modifiers));
+        let meta = std::fs::symlink_metadata(&link).expect("metadata");
+        let before = ctx
+            .create_entry(&link, PathBuf::from("link"), &meta)
+            .expect("create_entry");
+        let unmodified = make_generator(None)
+            .create_entry(&link, PathBuf::from("link"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(
+            before.permissions() & 0o7777,
+            unmodified.permissions() & 0o7777,
+            "symlink entry mode must be untouched by --chmod (upstream !S_ISLNK)",
+        );
+    }
+
+    /// Without `--chmod` the sender emits the on-disk mode verbatim.
+    #[test]
+    fn no_client_chmod_leaves_mode_untouched() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path = tmp.path().join("f");
+        std::fs::write(&path, b"x").expect("write");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("set perms");
+
+        let ctx = make_generator(None);
+        let meta = std::fs::symlink_metadata(&path).expect("metadata");
+        let entry = ctx
+            .create_entry(&path, PathBuf::from("f"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(entry.permissions() & 0o7777, 0o644);
     }
 }
 


### PR DESCRIPTION
## Summary

On a push (local -> remote, over both an ssh subprocess and an `rsync://`
daemon module), the sender did not apply `--chmod` to the outgoing file list.
Destination files and directories kept their source modes instead of the
chmod-transformed modes. A pull applied `--chmod` correctly; only the push
(sender) direction was broken.

## Divergence (before)

Source `f644`=0644, `sub/`=0755, pushed with `--chmod=Dg+s,Fo-rwx`:

| Path        | upstream 3.4.4 push | oc-rsync push (before) |
|-------------|---------------------|------------------------|
| `f644`      | 640                 | 644 (unchanged)        |
| `sub/`      | 2755                | 755 (unchanged)        |
| `sub/inner` | 640                 | 644 (unchanged)        |
| itemize     | `p` flag set        | no `p` flag            |

## Root cause

`--chmod` is a client-side transform. Upstream never forwards it to the remote
side (it is parsed into `chmod_modes` in `options.c:1762` and is absent from
`server_options`). Instead the process holding the modifiers applies them:

- On a **pull** the client is the receiver and applies them as it reads each
  incoming entry - `flist.c:905-906 recv_file_entry() -> tweak_mode()`.
- On a **push** the client is the sender and applies them as it builds each
  outgoing entry - `flist.c:1580-1581 send_file_name() -> tweak_mode()`, right
  after `make_file()` and before the entry is serialised.

oc-rsync only implemented the pull half. The sender's file-list builder
(`crates/transfer/src/generator/file_list/entry/create.rs`) applied only the
daemon module `outgoing chmod` directive (`daemon_outgoing_chmod`) and never the
client `--chmod` (`config.chmod`). Compounding this, the three push
config-builders (`build_server_config_for_generator` for the ssh subprocess,
embedded russh, and daemon paths) never copied the parsed modifiers onto the
local generator `ServerConfig`, so `config.chmod` was `None` on the sender.

Because the sender emitted the un-transformed mode, the remote receiver also
compared its on-disk mode against the un-transformed flist mode, so the itemize
`p` (perms-changed) flag was likewise never raised (`generator.c:547-549` sets
`ITEM_REPORT_PERMS` only when the flist mode differs from the destination mode).

## Fix

1. `create.rs`: after every other flist field is populated, apply both the
   daemon `outgoing chmod` and the client `--chmod` to the entry mode, skipping
   symlinks per upstream's `!S_ISLNK(file->mode)` guard. Order mirrors the
   receiver `merge_chmod` (daemon modes first, then the client's).
2. Propagate `config.chmod` onto the generator `ServerConfig` in all three push
   builders (`ssh_transfer`, `embedded_ssh_transfer`, `daemon_transfer`),
   mirroring the receiver builders that already carried it for the pull path.

Fixing the emitted mode also fixes the itemize `p` flag automatically: the
receiver now sees a transformed flist mode that differs from its on-disk mode.

## Verification (host, oc sender vs `/usr/bin/rsync` 3.4.4 receiver)

After (all match upstream):

| Scenario                              | `f644` | `sub/` | `sub/inner` |
|---------------------------------------|--------|--------|-------------|
| ssh push `Dg+s,Fo-rwx` (oc)           | 640    | 2755   | 640         |
| ssh push `Dg+s,Fo-rwx` (upstream)     | 640    | 2755   | 640         |
| ssh push numeric `D2755,F640` (oc)    | 640    | 2755   | 640         |
| daemon push `Dg+s,Fo-rwx` (oc)        | 640    | 2755   | 640         |
| daemon push `Dg+s,Fo-rwx` (upstream)  | 640    | 2755   | 640         |
| pull `Dg+s,Fo-rwx` (oc, unchanged)    | 640    | 2755   | 640         |
| non-chmod push (oc, unchanged)        | 644    | 755    | 644         |

Itemize on a re-push onto an existing destination (perms differ), oc identical
to upstream byte-for-byte:

```
.d...p..... ./
.f...p..... f644
.d...p..... sub/
.f...p..... sub/inner
```

## Tests

- `crates/transfer/.../entry/create.rs`: new `client_chmod_tests` module -
  `Dg+s,Fo-rwx` (0644 -> 0640, 0755 -> 02755), numeric `D2755,F640`, symlink
  skip, and the no-chmod passthrough.
- Generator config-builder regression guards in the ssh, embedded-ssh, and
  daemon test modules asserting `--chmod` now rides onto the sender config.

`cargo fmt --all -- --check`, `cargo clippy -p transfer -p core --all-features
--no-deps -- -D warnings`, and the targeted tests all pass.
