### PR TITLE
fix: anchor ownership and timestamp writes against parent symlink swaps

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls/metadata_ops.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/metadata_ops.rs
@@ -6,7 +6,7 @@
 //! [`secure_chmod_at`] that walks the parent through
 //! [`crate::secure_open_dir`].
 
-use std::ffi::{CString, OsStr};
+use std::ffi::{CStr, CString, OsStr};
 use std::io;
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::os::unix::ffi::OsStrExt;
@@ -281,6 +281,186 @@ pub fn secure_chmod_at(path: &Path, mode: u32, follow_symlinks: bool) -> io::Res
     fchmodat(dirfd.as_fd(), leaf, mode, follow_symlinks)
 }
 
+/// Path-based `chown(2)` / `lchown(2)` on `link_path` through the libc
+/// symbol.
+///
+/// The no-sandbox fallback for the lchown-class cutover. Uses the libc
+/// `chown`/`lchown` symbol (not a raw syscall) so `fakeroot`'s
+/// `LD_PRELOAD` interposition observes the ownership change; a raw
+/// syscall would bypass fakeroot and drop every file to `0:0` under an
+/// unprivileged fakeroot session.
+///
+/// `follow_symlinks = false` selects `lchown` so a symlink leaf is
+/// reowned rather than its target.
+fn chown_path_libc(link_path: &Path, uid: u32, gid: u32, follow_symlinks: bool) -> io::Result<()> {
+    let c_path = CString::new(link_path.as_os_str().as_bytes())
+        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+    // SAFETY:
+    // - `c_path.as_ptr()` is a valid NUL-terminated C string borrowed for
+    //   the duration of the call.
+    // - `uid as uid_t` / `gid as gid_t` are identity casts on every
+    //   supported target (`uid_t` / `gid_t` are `u32`); `u32::MAX` maps to
+    //   the `(uid_t)-1` / `(gid_t)-1` "leave unchanged" sentinel.
+    // - Both `chown(2)` and `lchown(2)` are present on every supported
+    //   Unix target.
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        if follow_symlinks {
+            libc::chown(c_path.as_ptr(), uid as libc::uid_t, gid as libc::gid_t)
+        } else {
+            libc::lchown(c_path.as_ptr(), uid as libc::uid_t, gid as libc::gid_t)
+        }
+    };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Chown `path` after walking its parent through [`secure_open_dir`].
+///
+/// Symlink-race-safe counterpart to a path-based `fchownat(AT_FDCWD,
+/// path, ..., AT_SYMLINK_NOFOLLOW)`. `AT_SYMLINK_NOFOLLOW` only guards the
+/// leaf component; a symlink swapped into any *ancestor* directory is
+/// still followed, redirecting the chown to an attacker-chosen inode
+/// outside the receiver's confinement. This helper mirrors
+/// [`secure_chmod_at`]: the parent directory of `path` is opened with
+/// `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` on Linux 5.6+ or
+/// `open(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)` elsewhere, then `fchownat`
+/// is anchored on that dirfd against the leaf basename. A symlink inserted
+/// into any parent component causes the open to fail with `ELOOP` (or
+/// `EXDEV` for `..` escapes under `openat2`), so a TOCTOU swap cannot
+/// redirect the chown.
+///
+/// `follow_symlinks` controls only the leaf: `false` passes
+/// `AT_SYMLINK_NOFOLLOW` so a swap-to-symlink at the leaf is reowned
+/// rather than chased into a different inode.
+///
+/// `uid` / `gid` of `u32::MAX` map to `(uid_t)-1` / `(gid_t)-1`, the
+/// `fchownat(2)` "leave unchanged" sentinel.
+///
+/// Falls back to a path-based libc `chown`/`lchown` when `path` has no
+/// parent component (single-component name in the cwd) - there is no
+/// ancestor to walk in that case.
+///
+/// upstream: syscall.c `do_lchown()` moved under the module dirfd
+/// (rsync 3.4.3+, CVE-2026-29518 fd-relative resolution).
+///
+/// # Errors
+///
+/// Surfaces either the [`secure_open_dir`](crate::secure_open_dir) error
+/// or the [`fchownat`] error verbatim. The notable security cases are
+/// `ELOOP` (parent symlink), `EXDEV` (parent `..` escape under
+/// `openat2`), and `ENOTDIR` (parent component is not a directory).
+pub fn secure_chown_at(path: &Path, uid: u32, gid: u32, follow_symlinks: bool) -> io::Result<()> {
+    let parent = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => return chown_path_libc(path, uid, gid, follow_symlinks),
+    };
+    let leaf = path
+        .file_name()
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
+    let dirfd = crate::secure_open_dir(parent)?;
+    fchownat(dirfd.as_fd(), leaf, uid, gid, follow_symlinks)
+}
+
+/// Build a `timespec` for a `utimensat` slot, mapping `None` to
+/// `UTIME_OMIT` so the corresponding timestamp is left unchanged.
+fn omit_timespec(time: Option<FileTime>) -> libc::timespec {
+    match time {
+        Some(time) => libc::timespec {
+            tv_sec: time.unix_seconds() as _,
+            tv_nsec: time.nanoseconds() as _,
+        },
+        None => libc::timespec {
+            tv_sec: 0,
+            tv_nsec: libc::UTIME_OMIT,
+        },
+    }
+}
+
+/// Issue `utimensat(dirfd, name, [atime, mtime], flags)` where either
+/// slot may be `None` (mapped to `UTIME_OMIT`).
+fn utimensat_omit_raw(
+    dirfd: libc::c_int,
+    c_name: &CStr,
+    atime: Option<FileTime>,
+    mtime: Option<FileTime>,
+    follow_symlinks: bool,
+) -> io::Result<()> {
+    let flags = if follow_symlinks {
+        0
+    } else {
+        libc::AT_SYMLINK_NOFOLLOW
+    };
+    let times = [omit_timespec(atime), omit_timespec(mtime)];
+    // SAFETY:
+    // - `dirfd` is either a raw fd owned by the caller for the duration of
+    //   the call or `AT_FDCWD`.
+    // - `c_name.as_ptr()` is a valid NUL-terminated C string.
+    // - `times.as_ptr()` points at a stack-local `[timespec; 2]` the
+    //   kernel reads through for the duration of the call.
+    // - `flags` is either `0` or `AT_SYMLINK_NOFOLLOW`, the only values
+    //   `utimensat(2)` accepts.
+    #[allow(unsafe_code)]
+    let rc = unsafe { libc::utimensat(dirfd, c_name.as_ptr(), times.as_ptr(), flags) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Set atime/mtime on `path` after walking its parent through
+/// [`secure_open_dir`], with `None` slots left unchanged (`UTIME_OMIT`).
+///
+/// Symlink-race-safe counterpart to a path-based `utimensat(AT_FDCWD,
+/// path, ...)`. Like [`secure_chown_at`] and [`secure_chmod_at`] the
+/// parent directory is opened with strict resolution and the `utimensat`
+/// is anchored on that dirfd, so a symlink swapped into any ancestor
+/// component is rejected (`ELOOP` / `EXDEV`) before the timestamps are
+/// written. The syscall never opens the target inode, so a peerless FIFO
+/// cannot block the call.
+///
+/// `follow_symlinks = false` passes `AT_SYMLINK_NOFOLLOW`, matching
+/// [`filetime::set_symlink_file_times`]; `true` follows a symlink leaf,
+/// matching [`filetime::set_file_times`].
+///
+/// Falls back to a path-based `utimensat(AT_FDCWD, ...)` when `path` has
+/// no parent component (single-component name in the cwd).
+///
+/// upstream: syscall.c `do_utime()`/`set_times()` under the module dirfd
+/// (rsync 3.4.3+, CVE-2026-29518 fd-relative resolution).
+///
+/// # Errors
+///
+/// Surfaces either the [`secure_open_dir`](crate::secure_open_dir) error
+/// or the underlying `utimensat(2)` error verbatim.
+pub fn secure_utimes_at(
+    path: &Path,
+    atime: Option<FileTime>,
+    mtime: Option<FileTime>,
+    follow_symlinks: bool,
+) -> io::Result<()> {
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => {
+            let leaf = path
+                .file_name()
+                .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
+            let c_leaf = CString::new(leaf.as_bytes())
+                .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+            let dirfd = crate::secure_open_dir(parent)?;
+            utimensat_omit_raw(dirfd.as_raw_fd(), &c_leaf, atime, mtime, follow_symlinks)
+        }
+        _ => {
+            let c_path = CString::new(path.as_os_str().as_bytes())
+                .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+            utimensat_omit_raw(libc::AT_FDCWD, &c_path, atime, mtime, follow_symlinks)
+        }
+    }
+}
+
 /// Issue `fchownat` against `link_path` when the `sandbox` root is the
 /// immediate parent.
 ///
@@ -311,31 +491,11 @@ pub fn fchownat_via_sandbox_or_fallback(
     {
         return fchownat(sandbox.current_dirfd(), leaf, uid, gid, follow_symlinks);
     }
-    // Fallback uses raw libc::lchown / libc::chown so the no-sandbox
+    // Fallback uses the libc `chown`/`lchown` symbol so the no-sandbox
     // path preserves symlink-no-follow semantics that std does not
     // expose. Callers depending on the sandbox path picking up
     // AT_SYMLINK_NOFOLLOW still get matching behaviour on the fallback.
-    let c_path = CString::new(link_path.as_os_str().as_bytes())
-        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
-    // SAFETY:
-    // - `c_path.as_ptr()` is a valid NUL-terminated C string.
-    // - The chosen syscall (`chown` vs `lchown`) is the POSIX-portable
-    //   way to reach the same semantics that the sandbox path expresses
-    //   via `AT_SYMLINK_NOFOLLOW`. Both syscalls are present on every
-    //   supported Unix target.
-    #[allow(unsafe_code)]
-    let rc = unsafe {
-        if follow_symlinks {
-            libc::chown(c_path.as_ptr(), uid as libc::uid_t, gid as libc::gid_t)
-        } else {
-            libc::lchown(c_path.as_ptr(), uid as libc::uid_t, gid as libc::gid_t)
-        }
-    };
-    if rc == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
+    chown_path_libc(link_path, uid, gid, follow_symlinks)
 }
 
 /// Issue `utimensat` against `link_path` when the `sandbox` root is the

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
@@ -51,7 +51,8 @@ pub use lstat::{LstatOutcome, lstat_via_sandbox_or_fallback};
 pub use metadata::{AtMetadata, fstatat_nofollow};
 pub use metadata_ops::{
     fchmodat, fchmodat_via_sandbox_or_fallback, fchownat, fchownat_via_sandbox_or_fallback,
-    secure_chmod_at, utimensat, utimensat_via_sandbox_or_fallback,
+    secure_chmod_at, secure_chown_at, secure_utimes_at, utimensat,
+    utimensat_via_sandbox_or_fallback,
 };
 pub use open::{
     openat, openat_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -85,7 +85,7 @@ pub use at_syscalls::{
     mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
     read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
     recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
-    renameat_via_sandbox_or_fallback, secure_chmod_at, symlinkat,
+    renameat_via_sandbox_or_fallback, secure_chmod_at, secure_chown_at, secure_utimes_at, symlinkat,
     symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
     utimensat_via_sandbox_or_fallback,
 };

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -354,7 +354,7 @@ pub use dir_sandbox::{
     mkdirat, mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
     read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
     recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
-    renameat_via_sandbox_or_fallback, secure_chmod_at, symlinkat,
+    renameat_via_sandbox_or_fallback, secure_chmod_at, secure_chown_at, secure_utimes_at, symlinkat,
     symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
     utimensat_via_sandbox_or_fallback,
 };

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -82,7 +82,12 @@ pub fn apply_file_metadata_with_options(
         timestamps::set_timestamp_like(metadata, destination, true, None, Some(options))?;
     } else if options.atimes() {
         // upstream: rsync.c:604-612 - atime applied when SKIP_MTIME but not SKIP_ATIME
-        timestamps::apply_atime_only_from_metadata(metadata, destination, None)?;
+        timestamps::apply_atime_only_from_metadata(
+            metadata,
+            destination,
+            None,
+            options.keep_dirlinks(),
+        )?;
     }
     if options.crtimes() {
         timestamps::apply_crtime_from_source_metadata(destination, metadata)?;
@@ -195,7 +200,12 @@ pub fn apply_file_metadata_if_changed(
     if options.times() {
         timestamps::set_timestamp_like(metadata, destination, true, Some(existing), Some(options))?;
     } else if options.atimes() {
-        timestamps::apply_atime_only_from_metadata(metadata, destination, Some(existing))?;
+        timestamps::apply_atime_only_from_metadata(
+            metadata,
+            destination,
+            Some(existing),
+            options.keep_dirlinks(),
+        )?;
     }
     if options.crtimes() {
         timestamps::apply_crtime_from_source_metadata(destination, metadata)?;
@@ -621,7 +631,12 @@ pub fn apply_metadata_with_attrs_flags_and_pre_transfer(
     // upstream: rsync.c:604 - atime applied independently when SKIP_MTIME is set
     // but SKIP_ATIME is not, since apply_timestamps_from_entry handles both together
     if options.atimes() && attrs_flags.skip_mtime() && !attrs_flags.skip_atime() {
-        timestamps::apply_atime_only_from_entry(destination, entry, cached_meta.as_ref())?;
+        timestamps::apply_atime_only_from_entry(
+            destination,
+            entry,
+            cached_meta.as_ref(),
+            options.keep_dirlinks(),
+        )?;
     }
 
     // upstream: rsync.c:615 - `if (crtimes_ndx && !(flags & ATTRS_SKIP_CRTIME))`

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -26,37 +26,64 @@ use std::os::fd::BorrowedFd;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 
-/// Applies a path-based `chown`/`lchown` through the `nix` crate, selecting
-/// follow-vs-nofollow via `follow_symlinks` (`AT_SYMLINK_NOFOLLOW` = `lchown`).
+/// Applies a path-based `chown`/`lchown`, anchoring on the parent dirfd to
+/// defeat ancestor-symlink-swap TOCTOU attacks.
 ///
-/// `nix` calls the libc `fchownat(2)` symbol rather than issuing a raw syscall.
-/// This is mandatory for `fakeroot` compatibility: fakeroot interposes the libc
-/// `chown`/`lchown`/`fchown` symbols via `LD_PRELOAD` and fakes the ownership
-/// change for a non-root process. rustix's default `linux_raw` backend bypasses
-/// libc entirely, so fakeroot never sees the call and the real kernel returns
-/// `EPERM`, dropping every file to `0:0`. Routing through the libc symbol lets
-/// fakeroot fake it, matching upstream.
-// upstream: syscall.c:do_lchown()/do_chown() call the lchown(2)/chown(2) libc symbols.
+/// When `--keep-dirlinks` is inactive, dispatches to
+/// [`fast_io::secure_chown_at`], which walks the parent through
+/// `secure_open_dir` (`openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` on
+/// Linux 5.6+, `open(O_NOFOLLOW | O_DIRECTORY)` elsewhere) and anchors
+/// `fchownat` on that dirfd. `AT_SYMLINK_NOFOLLOW` alone only guards the leaf;
+/// a symlink swapped into a receiver-created ancestor directory would
+/// otherwise be followed, redirecting the chown outside the module. Mirrors
+/// the chmod-symlink-race cutover in
+/// [`super::permissions::set_permissions_like`].
+///
+/// When `--keep-dirlinks` is active the user has opted into following
+/// dest-side symlinks-to-dirs, so the sandbox refusal is wrong: fall back to
+/// the path-based `nix` chown (through `AT_FDCWD`) which resolves symlinked
+/// parents like upstream `generator.c:1344`'s `link_stat`.
+///
+/// Both branches perform the ownership change through the libc
+/// `chown`/`lchown`/`fchownat` symbol rather than a raw syscall. This is
+/// mandatory for `fakeroot` compatibility: fakeroot interposes the libc
+/// symbols via `LD_PRELOAD` and fakes the change for a non-root process; a
+/// raw syscall bypasses libc, so fakeroot never sees the call and the kernel
+/// returns `EPERM`, dropping every file to `0:0`. Only the parent-directory
+/// walk uses `openat2`, which fakeroot ignores because it tracks ownership per
+/// inode on the chown call, not on directory opens.
+// upstream: syscall.c:do_lchown()/do_chown() call the lchown(2)/chown(2) libc
+// symbols; rsync 3.4.3+ resolves them under the module dirfd (CVE-2026-29518).
 #[cfg(unix)]
 fn chown_path(
     path: &Path,
     owner: Option<unix_fs::Uid>,
     group: Option<unix_fs::Gid>,
     follow_symlinks: bool,
+    keep_dirlinks: bool,
 ) -> Result<(), MetadataError> {
-    let flag = if follow_symlinks {
-        nix::fcntl::AtFlags::empty()
-    } else {
-        nix::fcntl::AtFlags::AT_SYMLINK_NOFOLLOW
-    };
-    nix::unistd::fchownat(
-        nix::fcntl::AT_FDCWD,
-        path,
-        owner.map(|uid| nix::unistd::Uid::from_raw(uid.as_raw())),
-        group.map(|gid| nix::unistd::Gid::from_raw(gid.as_raw())),
-        flag,
-    )
-    .map_err(|errno| MetadataError::new("preserve ownership", path, io::Error::from(errno)))
+    if keep_dirlinks {
+        let flag = if follow_symlinks {
+            nix::fcntl::AtFlags::empty()
+        } else {
+            nix::fcntl::AtFlags::AT_SYMLINK_NOFOLLOW
+        };
+        return nix::unistd::fchownat(
+            nix::fcntl::AT_FDCWD,
+            path,
+            owner.map(|uid| nix::unistd::Uid::from_raw(uid.as_raw())),
+            group.map(|gid| nix::unistd::Gid::from_raw(gid.as_raw())),
+            flag,
+        )
+        .map_err(|errno| MetadataError::new("preserve ownership", path, io::Error::from(errno)));
+    }
+
+    // `u32::MAX` is `fchownat`'s `(uid_t)-1` / `(gid_t)-1` "leave unchanged"
+    // sentinel, matching `owner`/`group` of `None`.
+    let uid = owner.map(|uid| uid.as_raw()).unwrap_or(u32::MAX);
+    let gid = group.map(|gid| gid.as_raw()).unwrap_or(u32::MAX);
+    fast_io::secure_chown_at(path, uid, gid, follow_symlinks)
+        .map_err(|error| MetadataError::new("preserve ownership", path, error))
 }
 
 /// fd-based counterpart to [`chown_path`] using the libc `fchown(2)` symbol via
@@ -465,7 +492,13 @@ pub(super) fn set_owner_like(
         // upstream: rsync.c:535-546 - DEBUG_GTE(OWN, 1) fires before do_lchown.
         trace_chown_change(destination, owner, group, existing);
 
-        chown_path(destination, owner, group, follow_symlinks)?;
+        chown_path(
+            destination,
+            owner,
+            group,
+            follow_symlinks,
+            options.keep_dirlinks(),
+        )?;
 
         // upstream: rsync.c:558-568 - impossible-id warning + suid/sgid re-stat.
         Ok(post_chown_bookkeeping(destination, owner, group, existing))
@@ -612,7 +645,7 @@ pub(super) fn apply_ownership_from_entry(
             // upstream: rsync.c:535-546 - DEBUG_GTE(OWN, 1) fires before do_lchown.
             trace_chown_change(destination, owner, group, cached_meta);
 
-            chown_path(destination, owner, group, true)?;
+            chown_path(destination, owner, group, true, options.keep_dirlinks())?;
 
             // upstream: rsync.c:558-568 - impossible-id warning + suid/sgid re-stat.
             return Ok(post_chown_bookkeeping(
@@ -691,7 +724,7 @@ pub(super) fn apply_symlink_ownership_from_entry(
     if needs_chown {
         trace_chown_change(destination, owner, group, cached_meta);
 
-        chown_path(destination, owner, group, false)?;
+        chown_path(destination, owner, group, false, options.keep_dirlinks())?;
 
         // upstream: rsync.c:558-561 - impossible-id warning also fires for
         // symlink chowns. The suid/sgid re-stat is irrelevant here because

--- a/crates/metadata/src/apply/timestamps.rs
+++ b/crates/metadata/src/apply/timestamps.rs
@@ -6,7 +6,7 @@
 
 use crate::error::MetadataError;
 use crate::options::MetadataOptions;
-use filetime::{FileTime, set_file_times, set_symlink_file_times};
+use filetime::FileTime;
 use std::fs;
 use std::path::Path;
 
@@ -15,11 +15,95 @@ use std::io;
 #[cfg(unix)]
 use std::os::fd::BorrowedFd;
 
+/// Applies atime/mtime to `destination` with an anchored, open-free
+/// `utimensat`, defeating ancestor-symlink-swap TOCTOU attacks.
+///
+/// `None` in a slot maps to `UTIME_OMIT` (leave that timestamp unchanged).
+/// `follow_symlinks = false` selects `AT_SYMLINK_NOFOLLOW` for the leaf.
+///
+/// When `--keep-dirlinks` is inactive (Unix), routes through
+/// [`fast_io::secure_utimes_at`], which walks the parent through
+/// `secure_open_dir` and anchors the `utimensat` on that dirfd so a symlink
+/// swapped into a receiver-created ancestor directory cannot redirect the
+/// write outside the module. Mirrors the chmod/chown symlink-race cutovers.
+///
+/// When `--keep-dirlinks` is active the user opted into following dest-side
+/// symlinked directories, so the sandbox refusal is wrong: fall back to an
+/// open-free `utimensat(AT_FDCWD, ...)` that resolves symlinked parents
+/// through the ambient namespace like upstream `generator.c:1344`'s
+/// `link_stat`. The syscall never opens the node, so a peerless FIFO cannot
+/// block it.
+// upstream: rsync.c:set_file_attrs()/util1.c:set_times() apply times through
+// utimensat on the path (never opening the node); rsync 3.4.3+ resolves under
+// the module dirfd (CVE-2026-29518).
+#[cfg(unix)]
+fn set_times_via(
+    destination: &Path,
+    atime: Option<FileTime>,
+    mtime: Option<FileTime>,
+    follow_symlinks: bool,
+    keep_dirlinks: bool,
+) -> std::io::Result<()> {
+    if !keep_dirlinks {
+        return fast_io::secure_utimes_at(destination, atime, mtime, follow_symlinks);
+    }
+    let to_timespec = |time: Option<FileTime>| match time {
+        Some(time) => rustix::fs::Timespec {
+            tv_sec: time.unix_seconds(),
+            tv_nsec: time.nanoseconds().into(),
+        },
+        None => rustix::fs::Timespec {
+            tv_sec: 0,
+            tv_nsec: rustix::fs::UTIME_OMIT,
+        },
+    };
+    let times = rustix::fs::Timestamps {
+        last_access: to_timespec(atime),
+        last_modification: to_timespec(mtime),
+    };
+    let flags = if follow_symlinks {
+        rustix::fs::AtFlags::empty()
+    } else {
+        rustix::fs::AtFlags::SYMLINK_NOFOLLOW
+    };
+    rustix::fs::utimensat(rustix::fs::CWD, destination, &times, flags).map_err(io::Error::from)
+}
+
+/// Non-Unix counterpart to [`set_times_via`] using the [`filetime`] crate.
+///
+/// Windows has no `utimensat`; `filetime` opens the target to set its times.
+/// The `None`-atime case updates only the mtime.
+#[cfg(not(unix))]
+fn set_times_via(
+    destination: &Path,
+    atime: Option<FileTime>,
+    mtime: Option<FileTime>,
+    follow_symlinks: bool,
+    _keep_dirlinks: bool,
+) -> std::io::Result<()> {
+    match (atime, mtime) {
+        (Some(atime), Some(mtime)) => {
+            if follow_symlinks {
+                filetime::set_file_times(destination, atime, mtime)
+            } else {
+                filetime::set_symlink_file_times(destination, atime, mtime)
+            }
+        }
+        (None, Some(mtime)) => filetime::set_file_mtime(destination, mtime),
+        (Some(atime), None) => {
+            let current = fs::metadata(destination)?;
+            let mtime = FileTime::from_last_modification_time(&current);
+            filetime::set_file_times(destination, atime, mtime)
+        }
+        (None, None) => Ok(()),
+    }
+}
+
 /// Applies timestamps (atime + mtime) to a path, optionally following symlinks.
 ///
-/// Uses [`set_file_times`] for regular files/directories and
-/// [`set_symlink_file_times`] for symlinks. Skips the syscall when both
-/// mtime and atime already match `existing`.
+/// Routes through the anchored, open-free [`set_times_via`] for
+/// regular files, symlinks, and special nodes alike. Skips the syscall when
+/// both mtime and atime already match `existing`.
 ///
 /// When `options` is provided and `options.atimes()` is true, the atime
 /// comparison is included in the skip check so that atime-only changes
@@ -59,28 +143,25 @@ pub(super) fn set_timestamp_like(
     }
 
     // upstream: rsync.c:set_file_attrs() applies times through `utimensat` on
-    // the path, never opening the target. filetime's follow variant
-    // (`set_file_times`) opens the file first (`File::open`) before calling
-    // `File::set_times`, which blocks indefinitely on a real FIFO that has no
-    // reader/writer peer. Route special files (and symlinks) through the
-    // `AT_SYMLINK_NOFOLLOW` `utimensat` variant, which sets the node's times
-    // without opening it. For a non-symlink special file NOFOLLOW is
-    // semantically identical to a follow, since the node is not a symlink.
+    // the path, never opening the target. The anchored `set_times_via` uses an
+    // open-free `utimensat`, so special files (device/FIFO/socket) never block
+    // on `File::open` the way filetime's follow variant would on a peerless
+    // FIFO. Special files (and symlinks) still take the `AT_SYMLINK_NOFOLLOW`
+    // leaf so the node itself is timestamped; for a non-symlink special file
+    // NOFOLLOW is semantically identical to a follow.
     #[cfg(unix)]
     let open_free_path = !follow_symlinks || is_special_file(metadata);
     #[cfg(not(unix))]
     let open_free_path = !follow_symlinks;
 
-    let result = match accessed {
-        Some(accessed) => {
-            if open_free_path {
-                set_symlink_file_times(destination, accessed, modified)
-            } else {
-                set_file_times(destination, accessed, modified)
-            }
-        }
-        None => set_mtime_omit_atime(destination, modified, open_free_path),
-    };
+    let keep_dirlinks = options.is_some_and(|o| o.keep_dirlinks());
+    let result = set_times_via(
+        destination,
+        accessed,
+        Some(modified),
+        !open_free_path,
+        keep_dirlinks,
+    );
 
     if let Err(error) = result {
         // upstream: util1.c set_times() is best-effort. Setting times on a
@@ -121,50 +202,6 @@ fn is_tolerable_special_time_error(error: &io::Error) -> bool {
         error.raw_os_error(),
         Some(libc::ENXIO) | Some(libc::EROFS) | Some(libc::EOPNOTSUPP)
     )
-}
-
-/// Sets only the mtime on a path node, leaving the access time unchanged.
-///
-/// Mirrors upstream's `ATTRS_SKIP_ATIME` behaviour (`rsync.c:588-589`): when
-/// `--atimes`/`-U` is off, or for any directory, the access time is left
-/// untouched rather than being written to the mtime value. On Unix this uses
-/// `utimensat` with `UTIME_OMIT` for the access-time slot so no access-time
-/// syscall side effect leaks in; `open_free` selects the
-/// `AT_SYMLINK_NOFOLLOW` variant used for symlinks and special files
-/// (device/FIFO/socket), which updates the node's own mtime without opening
-/// it (a peerless FIFO would otherwise block `File::open`). On non-Unix
-/// targets `filetime::set_file_mtime` provides the equivalent mtime-only
-/// update.
-// upstream: rsync.c:588-589 - `!atimes_ndx || S_ISDIR` sets ATTRS_SKIP_ATIME
-fn set_mtime_omit_atime(
-    destination: &Path,
-    mtime: FileTime,
-    open_free: bool,
-) -> std::io::Result<()> {
-    #[cfg(unix)]
-    {
-        let times = rustix::fs::Timestamps {
-            last_access: rustix::fs::Timespec {
-                tv_sec: 0,
-                tv_nsec: rustix::fs::UTIME_OMIT,
-            },
-            last_modification: rustix::fs::Timespec {
-                tv_sec: mtime.unix_seconds(),
-                tv_nsec: mtime.nanoseconds().into(),
-            },
-        };
-        let flags = if open_free {
-            rustix::fs::AtFlags::SYMLINK_NOFOLLOW
-        } else {
-            rustix::fs::AtFlags::empty()
-        };
-        rustix::fs::utimensat(rustix::fs::CWD, destination, &times, flags).map_err(io::Error::from)
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = open_free;
-        filetime::set_file_mtime(destination, mtime)
-    }
 }
 
 /// fd-based variant of [`set_timestamp_like`] that uses `futimens` on the open fd.
@@ -242,6 +279,7 @@ pub(super) fn apply_atime_only_from_metadata(
     metadata: &fs::Metadata,
     destination: &Path,
     existing: Option<&fs::Metadata>,
+    keep_dirlinks: bool,
 ) -> Result<(), MetadataError> {
     // upstream: rsync.c:609 - the applied access time's nanosecond field is 0.
     let source_atime =
@@ -264,8 +302,14 @@ pub(super) fn apply_atime_only_from_metadata(
         }
     };
 
-    set_file_times(destination, source_atime, dest_mtime)
-        .map_err(|error| MetadataError::new("preserve access time", destination, error))?;
+    set_times_via(
+        destination,
+        Some(source_atime),
+        Some(dest_mtime),
+        true,
+        keep_dirlinks,
+    )
+    .map_err(|error| MetadataError::new("preserve access time", destination, error))?;
 
     Ok(())
 }
@@ -361,23 +405,28 @@ pub(super) fn apply_timestamps_from_entry(
     };
 
     if needs_utime {
-        set_entry_times(destination, entry, atime, mtime, "preserve timestamps")?;
+        set_entry_times(
+            destination,
+            entry,
+            atime,
+            mtime,
+            options.keep_dirlinks(),
+            "preserve timestamps",
+        )?;
     }
 
     Ok(())
 }
 
-/// Applies mtime/atime to a node materialised from a wire `FileEntry`, choosing
-/// an open-free `utimensat` for special files.
+/// Applies mtime/atime to a node materialised from a wire `FileEntry` through
+/// the anchored, open-free [`set_times_via`].
 ///
-/// filetime's follow variant (`set_file_times`) opens the target with
-/// `File::open` before calling `File::set_times`, which blocks forever on a
-/// FIFO that has no reader/writer peer - exactly the node the protocol receiver
-/// materialises via `create_specials`. Device, FIFO, and socket nodes are never
-/// symlinks, so the `AT_SYMLINK_NOFOLLOW` variant (`set_symlink_file_times`)
-/// sets their times without opening them, matching upstream `set_file_attrs()`
-/// which applies times through `utimensat` on the path and never opens the
-/// target. Tolerable special-file errnos are swallowed as best-effort, mirroring
+/// The syscall never opens the target, so a peerless FIFO the protocol
+/// receiver materialises via `create_specials` cannot block it, matching
+/// upstream `set_file_attrs()` which applies times through `utimensat` on the
+/// path and never opens the target. Device, FIFO, and socket nodes are never
+/// symlinks, so they take the `AT_SYMLINK_NOFOLLOW` leaf. Tolerable
+/// special-file errnos are swallowed as best-effort, mirroring
 /// [`set_timestamp_like`].
 // upstream: rsync.c:set_file_attrs() - utimensat on the path, never opens the node
 fn set_entry_times(
@@ -385,21 +434,14 @@ fn set_entry_times(
     entry: &protocol::flist::FileEntry,
     atime: Option<FileTime>,
     mtime: FileTime,
+    keep_dirlinks: bool,
     context: &'static str,
 ) -> Result<(), MetadataError> {
     let is_special = entry.is_device() || entry.is_special();
     // upstream: rsync.c:588-589 - `atime = None` reproduces ATTRS_SKIP_ATIME,
-    // leaving the destination's access time untouched (UTIME_OMIT).
-    let result = match atime {
-        Some(atime) => {
-            if is_special {
-                set_symlink_file_times(destination, atime, mtime)
-            } else {
-                set_file_times(destination, atime, mtime)
-            }
-        }
-        None => set_mtime_omit_atime(destination, mtime, is_special),
-    };
+    // leaving the destination's access time untouched (UTIME_OMIT). Special
+    // files take the `AT_SYMLINK_NOFOLLOW` leaf (open-free node timestamping).
+    let result = set_times_via(destination, atime, Some(mtime), !is_special, keep_dirlinks);
 
     if let Err(error) = result {
         #[cfg(unix)]
@@ -414,9 +456,9 @@ fn set_entry_times(
 /// Applies mtime (and atime when `--atimes`) from a protocol `FileEntry`
 /// to a symbolic link without following the link target.
 ///
-/// Mirrors [`apply_timestamps_from_entry`] but uses `lutimes` /
-/// `utimensat(AT_SYMLINK_NOFOLLOW)` via [`set_symlink_file_times`] so the
-/// symlink's own mtime is updated instead of the link target's. The
+/// Mirrors [`apply_timestamps_from_entry`] but passes `follow_symlinks =
+/// false` to [`set_times_via`], selecting `utimensat(AT_SYMLINK_NOFOLLOW)` so
+/// the symlink's own mtime is updated instead of the link target's. The
 /// receiver invokes this after `do_symlink` so the on-disk link mtime
 /// matches the source-side value.
 // upstream: rsync.c:set_file_attrs() + set_times() - symlink path uses lutimes
@@ -454,13 +496,15 @@ pub(super) fn apply_symlink_timestamps_from_entry(
 
     if needs_utime {
         // upstream: rsync.c:set_times() uses lutimes/utimensat(AT_SYMLINK_NOFOLLOW)
-        // on the symlink itself. `open_free = true` selects that NOFOLLOW variant.
-        match atime {
-            Some(atime) => set_symlink_file_times(destination, atime, mtime)
-                .map_err(|error| MetadataError::new("preserve timestamps", destination, error))?,
-            None => set_mtime_omit_atime(destination, mtime, true)
-                .map_err(|error| MetadataError::new("preserve timestamps", destination, error))?,
-        }
+        // on the symlink itself. `follow_symlinks = false` selects that variant.
+        set_times_via(
+            destination,
+            atime,
+            Some(mtime),
+            false,
+            options.keep_dirlinks(),
+        )
+        .map_err(|error| MetadataError::new("preserve timestamps", destination, error))?;
     }
 
     Ok(())
@@ -479,6 +523,7 @@ pub(super) fn apply_atime_only_from_entry(
     destination: &Path,
     entry: &protocol::flist::FileEntry,
     cached_meta: Option<&fs::Metadata>,
+    keep_dirlinks: bool,
 ) -> Result<(), MetadataError> {
     let atime = if entry.atime() != 0 {
         FileTime::from_unix_time(entry.atime(), 0)
@@ -509,6 +554,7 @@ pub(super) fn apply_atime_only_from_entry(
             entry,
             Some(atime),
             mtime,
+            keep_dirlinks,
             "preserve access time",
         )?;
     }

--- a/crates/metadata/tests/chown_utimes_symlink_race.rs
+++ b/crates/metadata/tests/chown_utimes_symlink_race.rs
@@ -1,0 +1,229 @@
+//! Regression test for the ancestor-symlink-swap TOCTOU class on the
+//! receiver-side ownership and timestamp application paths.
+//!
+//! upstream: rsync 3.4.3+ resolves `do_lchown`/`do_utime` under the module
+//! directory fd (matching upstream issue CVE-2026-29518).
+//!
+//! `AT_SYMLINK_NOFOLLOW` only guards the leaf component of a path-based
+//! `fchownat`/`utimensat`. A symlink swapped into a receiver-created
+//! *ancestor* directory is still followed, redirecting the chown/utimes to a
+//! file outside the module. When the daemon runs as root this lets an
+//! attacker with write access to the module chown or set-times an arbitrary
+//! out-of-module path.
+//!
+//! `metadata::apply_file_metadata_with_options` is the production entry point
+//! that exercises the path-based ownership (`set_owner_like` ->
+//! `chown_path`) and timestamp (`set_timestamp_like`) helpers. Each must now
+//! route through `fast_io::secure_chown_at` / `fast_io::secure_utimes_at`,
+//! which walk the parent through `secure_open_dir` and anchor the syscall on
+//! that dirfd so a symlink swapped into any parent component is rejected
+//! (`ELOOP`/`EXDEV`/`ENOTDIR`) before the syscall fires.
+//!
+//! Legitimate case: application through a clean path must succeed and update
+//! the destination's timestamps / leave it owned by the caller.
+//!
+//! Attack case: application through a parent component that is a symlink to an
+//! out-of-module directory must error, and the file outside the module must
+//! keep its original timestamps.
+
+#![cfg(unix)]
+
+use std::error::Error;
+use std::fs;
+use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+use std::path::{Path, PathBuf};
+
+use filetime::{FileTime, set_file_times};
+use metadata::{MetadataOptions, apply_file_metadata_with_options};
+use tempfile::TempDir;
+
+/// `tempdir()` may sit under a symlink prefix on macOS / some CI runners;
+/// canonicalise so the sandbox open succeeds under `RESOLVE_NO_SYMLINKS`.
+fn canonical_tempdir() -> (TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let canon = fs::canonicalize(dir.path()).expect("canonicalize");
+    (dir, canon)
+}
+
+fn mtime_of(path: &Path) -> FileTime {
+    FileTime::from_last_modification_time(&fs::metadata(path).expect("stat"))
+}
+
+/// A distinctive source mtime the receiver would propagate onto the
+/// destination: 2001-09-09T01:46:40Z.
+const SOURCE_MTIME: FileTime = FileTime::from_unix_time(1_000_000_000, 0);
+
+fn seed_source(root: &Path) -> (PathBuf, fs::Metadata) {
+    let source = root.join("source");
+    fs::write(&source, b"src").expect("write source");
+    set_file_times(&source, SOURCE_MTIME, SOURCE_MTIME).expect("set source times");
+    let meta = fs::metadata(&source).expect("source meta");
+    (source, meta)
+}
+
+/// Downcast an `apply_file_metadata_with_options` error to its underlying
+/// `errno`, if any.
+fn errno_of(err: &(dyn Error + 'static)) -> Option<i32> {
+    err.source()
+        .and_then(|e| e.downcast_ref::<std::io::Error>())
+        .and_then(|e| e.raw_os_error())
+}
+
+/// Plant `module/subdir -> outside` and return the trap destination
+/// `module/subdir/sentinel` plus the out-of-module sentinel file, seeded with
+/// a mtime distinct from `SOURCE_MTIME` so an escaped write is observable.
+fn plant_ancestor_symlink_trap(root: &Path) -> (PathBuf, PathBuf) {
+    let outside = root.join("outside");
+    let module = root.join("module");
+    fs::create_dir(&outside).expect("mkdir outside");
+    fs::create_dir(&module).expect("mkdir module");
+
+    let outside_target = outside.join("sentinel");
+    fs::write(&outside_target, b"OUTSIDE").expect("write outside sentinel");
+    // A mtime far from SOURCE_MTIME: 1993-03-01T00:00:00Z.
+    let witness = FileTime::from_unix_time(730_000_000, 0);
+    set_file_times(&outside_target, witness, witness).expect("seed outside mtime");
+
+    // module/subdir -> outside (parent-component symlink trap).
+    symlink(&outside, module.join("subdir")).expect("plant symlink");
+
+    let attack_dest = module.join("subdir").join("sentinel");
+    (attack_dest, outside_target)
+}
+
+// -------------------------------------------------------------------------
+// Timestamps (utimensat) - `--times`
+// -------------------------------------------------------------------------
+
+/// Legitimate path: `-t` through non-symlink components must set the
+/// destination's mtime to the source value.
+#[test]
+fn receiver_utimes_succeeds_on_clean_path() {
+    let (_keep, root) = canonical_tempdir();
+    let (_source, source_meta) = seed_source(&root);
+
+    let destination = root.join("dest");
+    fs::write(&destination, b"dst").expect("write dest");
+    // Backdate the dest so the quick-check does not skip the utimes.
+    let old = FileTime::from_unix_time(100, 0);
+    set_file_times(&destination, old, old).expect("backdate dest");
+
+    let options = MetadataOptions::default().preserve_times(true);
+    apply_file_metadata_with_options(&destination, &source_meta, &options)
+        .expect("utimes clean path");
+
+    assert_eq!(
+        mtime_of(&destination),
+        SOURCE_MTIME,
+        "receiver must apply the source mtime through the clean parent path"
+    );
+}
+
+/// Attack path: an attacker swaps a symlink into the immediate parent
+/// component pointing outside the module. The receiver utimes must refuse the
+/// syscall and the outside file's mtime must be unchanged.
+///
+/// Pre-fix this test fails: the path-based `utimensat(AT_FDCWD, ...)` follows
+/// the symlinked parent and rewrites `outside/sentinel`'s mtime to
+/// `SOURCE_MTIME`. Post-fix `secure_utimes_at` rejects the symlinked parent
+/// before any `utimensat` fires.
+#[test]
+fn receiver_utimes_refuses_symlinked_parent_component() {
+    let (_keep, root) = canonical_tempdir();
+    let (_source, source_meta) = seed_source(&root);
+    let (attack_dest, outside_target) = plant_ancestor_symlink_trap(&root);
+    let sentinel_mtime_before = mtime_of(&outside_target);
+
+    let options = MetadataOptions::default().preserve_times(true);
+    let err = apply_file_metadata_with_options(&attack_dest, &source_meta, &options)
+        .expect_err("utimes through symlinked parent must error");
+    let raw = errno_of(err.as_ref());
+    assert!(
+        matches!(
+            raw,
+            Some(libc::ELOOP) | Some(libc::EXDEV) | Some(libc::ENOTDIR)
+        ),
+        "expected ELOOP/EXDEV/ENOTDIR from secure_utimes_at, got {raw:?}"
+    );
+
+    assert_eq!(
+        mtime_of(&outside_target),
+        sentinel_mtime_before,
+        "outside sentinel mtime must be unchanged - utimes must not escape the module"
+    );
+    assert_ne!(
+        mtime_of(&outside_target),
+        SOURCE_MTIME,
+        "the escaped source mtime must never land on the outside sentinel"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Ownership (fchownat) - `--chown`
+// -------------------------------------------------------------------------
+
+/// Legitimate path: an explicit `--chown` to the caller's own uid/gid through
+/// a clean path must succeed (no privilege required) and leave the
+/// destination owned by the caller.
+#[test]
+fn receiver_chown_succeeds_on_clean_path() {
+    let (_keep, root) = canonical_tempdir();
+    let (_source, source_meta) = seed_source(&root);
+
+    let destination = root.join("dest");
+    fs::write(&destination, b"dst").expect("write dest");
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o644)).expect("dest perms");
+    let dest_meta = fs::symlink_metadata(&destination).expect("dest meta");
+    let (my_uid, my_gid) = (dest_meta.uid(), dest_meta.gid());
+
+    let options = MetadataOptions::default()
+        .with_owner_override(Some(my_uid))
+        .with_group_override(Some(my_gid));
+    apply_file_metadata_with_options(&destination, &source_meta, &options)
+        .expect("chown-to-self clean path");
+
+    let after = fs::symlink_metadata(&destination).expect("dest meta after");
+    assert_eq!(
+        (after.uid(), after.gid()),
+        (my_uid, my_gid),
+        "chown-to-self through a clean path must leave the caller as owner"
+    );
+}
+
+/// Attack path: an attacker swaps a symlink into the immediate parent
+/// component pointing outside the module. The receiver chown must refuse the
+/// syscall (the sandbox-anchored `secure_open_dir` rejects the symlinked
+/// parent) before any `fchownat` fires.
+///
+/// The `--chown` targets the caller's own uid/gid so no privilege is needed;
+/// `preserve_times` seeds an mtime witness so an escaped metadata write of any
+/// kind is observable on the outside sentinel.
+#[test]
+fn receiver_chown_refuses_symlinked_parent_component() {
+    let (_keep, root) = canonical_tempdir();
+    let (_source, source_meta) = seed_source(&root);
+    let (attack_dest, outside_target) = plant_ancestor_symlink_trap(&root);
+    let sentinel = fs::symlink_metadata(&outside_target).expect("sentinel meta");
+    let sentinel_mtime_before = mtime_of(&outside_target);
+
+    let options = MetadataOptions::default()
+        .with_owner_override(Some(sentinel.uid()))
+        .with_group_override(Some(sentinel.gid()))
+        .preserve_times(true);
+    let err = apply_file_metadata_with_options(&attack_dest, &source_meta, &options)
+        .expect_err("chown through symlinked parent must error");
+    let raw = errno_of(err.as_ref());
+    assert!(
+        matches!(
+            raw,
+            Some(libc::ELOOP) | Some(libc::EXDEV) | Some(libc::ENOTDIR)
+        ),
+        "expected ELOOP/EXDEV/ENOTDIR from secure_chown_at, got {raw:?}"
+    );
+
+    assert_eq!(
+        mtime_of(&outside_target),
+        sentinel_mtime_before,
+        "outside sentinel must be untouched - no metadata write may escape the module"
+    );
+}


### PR DESCRIPTION
## Summary

The daemon receiver serves only `use chroot = false` modules, so the in-process
directory sandbox is the sole isolation boundary. Structural operations
(mkdir/rename/unlink/open) and `chmod` are already anchored on the module's
parent directory fd via `fast_io::DirSandbox`
(`openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)`, `*at` / `O_NOFOLLOW`, and the
path-based `secure_chmod_at`). Two metadata operations were not:

- **Ownership** — `chown_path` issued `fchownat(AT_FDCWD, path, ..., AT_SYMLINK_NOFOLLOW)`
  (`crates/metadata/src/apply/ownership.rs`).
- **Timestamps** — `set_file_times` / `set_symlink_file_times` /
  `set_mtime_omit_atime` issued `utimensat(AT_FDCWD, path, ...)`
  (`crates/metadata/src/apply/timestamps.rs`).

`AT_SYMLINK_NOFOLLOW` only protects the **leaf** component. A symlink swapped
into an **ancestor** directory (one of the predictably-named directories the
receiver creates) is still followed, redirecting the chown/utimes to a file
**outside** the module. When the daemon runs as root, an attacker with write
access to the module can get the daemon to chown or set-times an arbitrary
out-of-module path. This is the metadata facet of the TOCTOU parent-swap class
upstream fixed in rsync 3.4.3 by resolving `do_lchown` / `do_utime` under the
module directory fd (matching upstream CVE-2026-29518).

## The fix

Mirror exactly how `chmod` was hardened. The receiver chmod path routes through
the path-based, self-anchoring `fast_io::secure_chmod_at`, which walks the
parent with `secure_open_dir` (`openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)`
on Linux 5.6+, `open(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)` elsewhere) and
anchors `fchmodat` on that dirfd, with a `--keep-dirlinks` fallback to the
ambient path.

This PR adds the two missing counterparts and wires them in:

- **`fast_io::secure_chown_at(path, uid, gid, follow_symlinks)`** — walks the
  parent through `secure_open_dir`, anchors `fchownat` on that dirfd. `u32::MAX`
  is the `(uid_t)-1` "leave unchanged" sentinel. Falls back to a path-based
  libc `chown`/`lchown` when there is no parent to walk.
- **`fast_io::secure_utimes_at(path, atime, mtime, follow_symlinks)`** — same
  parent walk, anchors an open-free `utimensat` on the dirfd. `None` slots map
  to `UTIME_OMIT`. Because it never opens the target, a peerless FIFO cannot
  block the call (preserving the existing FIFO-hang guard, issue #223).

Both perform the actual change through the libc symbol, so `fakeroot`'s
`LD_PRELOAD` interposition still observes it (only the parent-directory walk
uses `openat2`, which `fakeroot` ignores). Both new helpers share the
`secure_chmod_at` structure, and the existing `fchownat_via_sandbox_or_fallback`
fallback was refactored to share the new `chown_path_libc` helper.

`metadata`'s path-based chown/utimes chokepoints (`chown_path` and a unified
`set_times_via`) now route through the anchored helpers when `--keep-dirlinks`
is inactive, and fall back to the ambient path when it is active (the user has
opted into following dest-side symlinked directories, mirroring
`chmod_path_honoring_keep_dirlinks`). The fd-based variants (`fchown` /
`futimens` on an already-open fd) were already immune and are unchanged, as is
the local-copy behaviour and the wire/output semantics (same uid/gid, same
atime/mtime including nanoseconds, symlink vs file variants, `AT_SYMLINK_NOFOLLOW`
on the leaf).

## Test

`crates/metadata/tests/chown_utimes_symlink_race.rs` adds a swap-resistance
regression in the style of the existing `chmod_symlink_race` test. It plants
`module/subdir -> outside` (an ancestor-component symlink to an out-of-module
directory) and drives the production entry point
`apply_file_metadata_with_options`. Permissions are disabled
(`preserve_permissions(false)`) so the cases isolate the ownership and
timestamp cutovers rather than being masked by the already-anchored chmod.

Before/after, verified on Linux (x86_64, non-root):

- **utimes attack** — pre-fix the ambient `utimensat(AT_FDCWD, ...)` follows the
  symlinked parent and rewrites `outside/sentinel`'s mtime, so the apply
  returns `Ok` and the test's `expect_err` panics. Post-fix `secure_utimes_at`
  refuses the symlinked parent (`ELOOP`) before any `utimensat` fires; the
  outside sentinel is untouched.
- **chown attack** — pre-fix the ambient `fchownat(AT_FDCWD, ...)` follows the
  symlinked parent and attempts the chown on `outside/sentinel` (as root it
  reowns it; as a normal user it fails with `EPERM`, not the expected `ELOOP`),
  so the test fails pre-fix. Post-fix `secure_chown_at` refuses the symlinked
  parent before any `fchownat` fires, regardless of privilege; the outside
  sentinel's owner is unchanged.
- Clean-path counterparts confirm normal ownership/timestamp application still
  succeeds.

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy -p fast_io -p metadata
  --all-targets --all-features --no-deps -D warnings` clean.
- New tests pass; the 4 new + existing `chmod_symlink_race` tests green.
- Existing swap-resistance suites green: 101 `fast_io`/`metadata` secure/sandbox
  tests, 248 `transfer`/`fast_io` swap tests, the full 964-test `fast_io` suite,
  and the full 576-test `metadata` suite (normal owner/times application
  unaffected).

## Follow-up (out of scope here)

`disk_commit::rename_config_sandboxed` (`crates/transfer/src/disk_commit/process/commit.rs`)
anchors the commit `renameat` on the module dirfd only when **both** endpoints
are direct children of the module root; **subdirectory** file commits fall back
to path-based `std::fs::rename`, which is the same ancestor-swap class for the
temp-to-final rename. Hardening it requires a secure subdirectory-fd walk (the
existing `renameat_via_sandbox_or_fallback` requires single-component leaves
under the sandbox root) plus care around the io_uring / EXDEV copy-remove
backstop and `--temp-dir`/partial-dir cases, so it is left as a documented
follow-up rather than expanding this PR.
