### PR TITLE
fix: honor --temp-dir and --omit-dir-times on remote pull receivers

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -69,6 +69,21 @@ pub(crate) fn build_server_config_for_receiver(
     // existing_only above. Without this the daemon pull re-transferred and
     // overwrote existing destination files instead of skipping them.
     server_config.file_selection.ignore_existing = config.ignore_existing();
+    // upstream: options.c:2907-2909 forwards --temp-dir to the remote only inside
+    // the `if (am_sender)` server_options block, so on a pull it is never sent
+    // over the wire; the local client IS the receiver and stages the temp file
+    // itself (receiver.c:766 open_tmpfile() honours tmpdir). Carry it onto the
+    // local receiver config here - without this the daemon pull staged the temp
+    // file in the destination directory, ignoring --temp-dir. Distinct from the
+    // module `temp dir` directive the remote daemon applies on the far side.
+    server_config.temp_dir = config.temp_directory().map(std::path::Path::to_path_buf);
+    // upstream rsync.c:583 adds ATTRS_SKIP_MTIME for `omit_dir_times && S_ISDIR`,
+    // and generator.c:2271 gates need_retouch_dir_times on !omit_dir_times.
+    // options.c:2646-2647 packs the compact 'O' into server_options only when
+    // am_sender, so on a pull -O never rides the wire; the local client IS the
+    // receiver and must apply it itself. Carry it onto the local receiver config
+    // here - without this the daemon pull set directory mtimes from the source.
+    server_config.flags.omit_dir_times = config.omit_dir_times();
     // upstream: options.c:2194 / generator.c:1249 - a single source operand with
     // no destination implies --list-only. On a pull the local client IS the
     // receiver and list_only is a long-form-only flag absent from the compact

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -1138,6 +1138,62 @@ mod server_config_reference_dirs {
         assert!(server_config.chmod.is_none());
     }
 
+    /// On a daemon pull the local client IS the receiver and stages the temp
+    /// file itself (upstream receiver.c:766 open_tmpfile() honours tmpdir).
+    /// options.c:2907-2909 forwards --temp-dir to the remote only when am_sender,
+    /// so on a pull it never rides the wire and must be carried onto the receiver
+    /// config, distinct from the module `temp dir` directive the far side
+    /// applies. Regression guard for the daemon pull that staged temps in the
+    /// destination directory.
+    #[test]
+    fn receiver_config_propagates_temp_dir() {
+        let config = ClientConfig::builder()
+            .temp_directory(Some("/var/tmp/rsync"))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert_eq!(
+            server_config.temp_dir.as_deref(),
+            Some(std::path::Path::new("/var/tmp/rsync"))
+        );
+    }
+
+    /// Without --temp-dir the receiver config leaves temp_dir unset.
+    #[test]
+    fn receiver_config_without_temp_dir_stays_none() {
+        let config = ClientConfig::default();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(server_config.temp_dir.is_none());
+    }
+
+    /// On a daemon pull the local client IS the receiver and applies
+    /// --omit-dir-times itself (upstream rsync.c:583 skips a directory's mtime,
+    /// generator.c:2271 gates the retouch pass). options.c:2646-2647 packs the
+    /// compact 'O' only when am_sender, so on a pull it never rides the wire and
+    /// must be carried onto the receiver config. Regression guard for the daemon
+    /// pull that set directory mtimes from the source.
+    #[test]
+    fn receiver_config_propagates_omit_dir_times() {
+        let config = ClientConfig::builder().omit_dir_times(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(server_config.flags.omit_dir_times);
+    }
+
+    /// Without --omit-dir-times the receiver config leaves the flag clear.
+    #[test]
+    fn receiver_config_without_omit_dir_times_stays_clear() {
+        let config = ClientConfig::default();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(!server_config.flags.omit_dir_times);
+    }
+
     #[test]
     fn generator_config_empty_reference_dirs_by_default() {
         let config = ClientConfig::default();

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -559,6 +559,20 @@ fn build_server_config_for_receiver(
     // existing_only above. Without this the ssh:// pull re-transferred and
     // overwrote existing destination files instead of skipping them.
     server_config.file_selection.ignore_existing = config.ignore_existing();
+    // upstream: options.c:2907-2909 forwards --temp-dir to the remote only inside
+    // the `if (am_sender)` server_options block, so on a pull it is never sent
+    // over the wire; the local client IS the receiver and stages the temp file
+    // itself (receiver.c:766 open_tmpfile() honours tmpdir). Carry it onto the
+    // local receiver config here - without this the ssh:// pull staged the temp
+    // file in the destination directory, ignoring --temp-dir.
+    server_config.temp_dir = config.temp_directory().map(std::path::Path::to_path_buf);
+    // upstream rsync.c:583 adds ATTRS_SKIP_MTIME for `omit_dir_times && S_ISDIR`,
+    // and generator.c:2271 gates need_retouch_dir_times on !omit_dir_times.
+    // options.c:2646-2647 packs the compact 'O' into server_options only when
+    // am_sender, so on a pull -O never rides the wire; the local client IS the
+    // receiver and must apply it itself. Carry it onto the local receiver config
+    // here - without this the ssh:// pull set directory mtimes from the source.
+    server_config.flags.omit_dir_times = config.omit_dir_times();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
@@ -740,6 +754,60 @@ mod tests {
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
 
         assert!(server_config.chmod.is_none());
+    }
+
+    /// The embedded (russh) pull receiver must carry --temp-dir onto its
+    /// ServerConfig. Upstream receiver.c:766 open_tmpfile() honours tmpdir, and
+    /// options.c:2907-2909 forwards the flag to the remote only when am_sender,
+    /// so on a pull it never rides the wire. Regression guard for the `ssh://`
+    /// pull that staged temps in the destination directory.
+    #[test]
+    fn embedded_receiver_config_propagates_temp_dir() {
+        let config = ClientConfig::builder()
+            .temp_directory(Some("/var/tmp/rsync"))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert_eq!(
+            server_config.temp_dir.as_deref(),
+            Some(std::path::Path::new("/var/tmp/rsync"))
+        );
+    }
+
+    /// Without --temp-dir the receiver config leaves temp_dir unset.
+    #[test]
+    fn embedded_receiver_config_without_temp_dir_stays_none() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.temp_dir.is_none());
+    }
+
+    /// The embedded (russh) pull receiver must carry --omit-dir-times onto its
+    /// ServerConfig. Upstream rsync.c:583 skips a directory's mtime and
+    /// generator.c:2271 gates the retouch pass; options.c:2646-2647 packs the
+    /// compact 'O' only when am_sender, so on a pull it never rides the wire.
+    /// Regression guard for the `ssh://` pull that set directory mtimes from the
+    /// source.
+    #[test]
+    fn embedded_receiver_config_propagates_omit_dir_times() {
+        let config = ClientConfig::builder().omit_dir_times(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.omit_dir_times);
+    }
+
+    /// Without --omit-dir-times the receiver config leaves the flag clear.
+    #[test]
+    fn embedded_receiver_config_without_omit_dir_times_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.omit_dir_times);
     }
 
     #[test]

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -85,6 +85,21 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
     // existing_only above. Without this the ssh pull re-transferred and
     // overwrote existing destination files instead of skipping them.
     server_config.file_selection.ignore_existing = config.ignore_existing();
+    // upstream: options.c:2907-2909 forwards --temp-dir to the remote only inside
+    // the `if (am_sender)` server_options block, so on a pull it is never sent
+    // over the wire; the local client IS the receiver and stages the temp file
+    // itself (receiver.c:766 open_tmpfile() honours tmpdir). Carry it onto the
+    // local receiver config here - without this the ssh pull staged the temp file
+    // in the destination directory, ignoring --temp-dir (local copies honoured it).
+    server_config.temp_dir = config.temp_directory().map(std::path::Path::to_path_buf);
+    // upstream rsync.c:583 adds ATTRS_SKIP_MTIME for `omit_dir_times && S_ISDIR`,
+    // and generator.c:2271 gates need_retouch_dir_times on !omit_dir_times.
+    // options.c:2646-2647 packs the compact 'O' into server_options only when
+    // am_sender, so on a pull -O never rides the wire; the local client IS the
+    // receiver and must apply it itself. Carry it onto the local receiver config
+    // here - without this the ssh pull set directory mtimes from the source while
+    // local copies left them at the current time.
+    server_config.flags.omit_dir_times = config.omit_dir_times();
     // upstream: options.c:2194 / generator.c:1249 - a single source operand with
     // no destination implies list-only. On a pull the local client IS the
     // receiver and `list_only` is a long-form-only concern absent from the
@@ -326,5 +341,62 @@ mod tests {
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
 
         assert!(server_config.chmod.is_none());
+    }
+
+    /// On an ssh pull the local client IS the receiver and stages the temp file
+    /// itself (upstream receiver.c:766 open_tmpfile() honours tmpdir).
+    /// options.c:2907-2909 forwards --temp-dir to the remote only when am_sender,
+    /// so on a pull it never rides the wire and must be carried onto the receiver
+    /// config. Regression guard for the ssh pull that staged temps in the
+    /// destination directory instead of --temp-dir.
+    #[test]
+    fn receiver_config_propagates_temp_dir() {
+        let config = ClientConfig::builder()
+            .temp_directory(Some("/var/tmp/rsync"))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert_eq!(
+            server_config.temp_dir.as_deref(),
+            Some(std::path::Path::new("/var/tmp/rsync"))
+        );
+    }
+
+    /// Without --temp-dir the receiver config leaves temp_dir unset, so temps
+    /// stage alongside the destination exactly as before.
+    #[test]
+    fn receiver_config_without_temp_dir_stays_none() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.temp_dir.is_none());
+    }
+
+    /// On an ssh pull the local client IS the receiver and applies
+    /// --omit-dir-times itself (upstream rsync.c:583 skips a directory's mtime,
+    /// generator.c:2271 gates the retouch pass). options.c:2646-2647 packs the
+    /// compact 'O' only when am_sender, so on a pull it never rides the wire and
+    /// must be carried onto the receiver config. Regression guard for the ssh
+    /// pull that set directory mtimes from the source.
+    #[test]
+    fn receiver_config_propagates_omit_dir_times() {
+        let config = ClientConfig::builder().omit_dir_times(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.omit_dir_times);
+    }
+
+    /// Without --omit-dir-times the receiver config leaves the flag clear, so
+    /// directory mtimes are preserved as before.
+    #[test]
+    fn receiver_config_without_omit_dir_times_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.omit_dir_times);
     }
 }

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -331,6 +331,19 @@ pub struct ParsedServerFlags {
     /// it, `main.c:736` calls `make_path()` to create the whole chain.
     pub mkpath: bool,
 
+    /// Omit directory modification times (long-form `--omit-dir-times` / `-O`).
+    ///
+    /// Receiver-side only. Not part of the compact flag string: upstream
+    /// `options.c:2646-2647` packs `'O'` into `server_options` only inside the
+    /// `if (am_sender)` block, so on a pull the flag is never sent over the
+    /// wire and the local client (which IS the receiver) must apply it itself.
+    /// When set, the receiver skips a directory's mtime both at creation
+    /// (upstream `rsync.c:583` - `omit_dir_times && S_ISDIR` sets
+    /// `ATTRS_SKIP_MTIME`) and in the final retouch pass (upstream
+    /// `generator.c:2271` - `need_retouch_dir_times = preserve_mtimes &&
+    /// !omit_dir_times`).
+    pub omit_dir_times: bool,
+
     /// Engage the opt-in parallel sender-side delta scan for large files
     /// (long-form `--parallel-delta-scan`).
     ///

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -386,7 +386,17 @@ impl ReceiverContext {
         }
 
         // Build owned data for parallel metadata application, skipping failed dirs.
-        let metadata_opts_clone = metadata_opts.clone();
+        // upstream: rsync.c:583 - `omit_dir_times && S_ISDIR(...)` adds
+        // ATTRS_SKIP_MTIME, so a directory's mtime is never applied under -O.
+        // On a pull the local client IS the receiver and -O rides no wire bit
+        // (options.c:2646-2647 gates 'O' on am_sender), so clear preserve_times
+        // for the directory apply here, mirroring the local executor's
+        // apply_final_directory_metadata.
+        let metadata_opts_clone = if self.config.flags.omit_dir_times {
+            metadata_opts.clone().preserve_times(false)
+        } else {
+            metadata_opts.clone()
+        };
         // upstream: generator.c:1512-1520 - grant a transient u+rwx to any
         // directory whose final mode is not writable by us so the receiver can
         // create temp files inside it; the real mode is restored in
@@ -867,10 +877,11 @@ impl ReceiverContext {
             return;
         }
 
-        // upstream: generator.c:2398 - need_retouch_dir_times =
+        // upstream: generator.c:2271 - need_retouch_dir_times =
         // preserve_mtimes && !omit_dir_times. The backup skip (generator.c:2101)
         // only concerns the mtime repair (backup file creation moves mtimes).
         let retouch_times = self.config.flags.times
+            && !self.config.flags.omit_dir_times
             && !(self.config.flags.backup && self.config.backup_dir.is_none());
 
         // upstream: generator.c:2122 - fix_dir_perms = !am_root && !(mode &
@@ -1187,6 +1198,47 @@ mod touch_up_dirs_tests {
         assert_eq!(
             actual, expected,
             "directory mtime should be restored to the file list value"
+        );
+    }
+
+    /// Under `--omit-dir-times` the retouch pass must NOT re-apply the source
+    /// directory mtime, leaving the directory at its (current) on-disk mtime.
+    ///
+    /// upstream: generator.c:2271 - `need_retouch_dir_times = preserve_mtimes
+    /// && !omit_dir_times`. On a remote pull the local client IS the receiver
+    /// and `-O` never rides the wire (options.c:2646-2647 gates the compact
+    /// 'O' on am_sender), so the receiver config must carry `omit_dir_times`
+    /// and honor it here. Regression guard for the remote pull that applied the
+    /// source directory mtime despite `-O`.
+    #[test]
+    fn omit_dir_times_skips_directory_mtime_restore() {
+        let dir = test_support::create_tempdir();
+        let sub = dir.path().join("subdir");
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("file.txt"), b"hello").unwrap();
+
+        // Source mtime is in the past; with -O it must NOT be applied.
+        let source_secs: i64 = 1_577_836_800;
+        let mut entry = FileEntry::new_directory("subdir".into(), 0o755);
+        entry.set_mtime(source_secs, 0);
+
+        let hs = handshake();
+        let mut config = config_with_times(true);
+        config.flags.omit_dir_times = true;
+        let mut ctx = ReceiverContext::new_for_test(&hs, config);
+        ctx.file_list = vec![entry];
+
+        ctx.touch_up_dirs(
+            dir.path(),
+            &mut crate::writer::ServerWriter::new_plain(Vec::new()),
+        );
+
+        let meta = fs::metadata(&sub).unwrap();
+        let actual = FileTime::from_last_modification_time(&meta);
+        let source_mtime = FileTime::from_unix_time(source_secs, 0);
+        assert_ne!(
+            actual, source_mtime,
+            "under --omit-dir-times the source directory mtime must NOT be applied"
         );
     }
 


### PR DESCRIPTION
## Summary

On a remote pull (ssh subprocess, embedded russh, or rsync daemon) the local client is the receiver and applies receiver-side options itself. Two long-form-only options were never carried onto the local receiver `ServerConfig`, so they were silently ignored on remote pulls while local copies honored them:

- **`--temp-dir=DIR` (`-T`)** - the receiver staged temp files alongside the destination instead of in `DIR`.
- **`--omit-dir-times` (`-O`)** - the receiver applied the source directory mtimes anyway instead of leaving them current.

Both are the same class as the previously merged receiver-config propagation fixes for `--link-dest`, `--backup-dir`/`--suffix`, `--chmod`, `--ignore-existing`, and `--existing`.

## Root cause

Upstream `server_options()` forwards these options to the remote peer only inside the `if (am_sender)` block, so on a pull they never ride the wire - the local client, which *is* the receiver, must apply them itself:

- `--temp-dir`: `options.c:2907-2909` gates the forward on `am_sender`. The receiver stages the temp in `tmpdir` itself (`receiver.c:766` `open_tmpfile()`).
- `--omit-dir-times`: the compact `'O'` is packed into `server_options` only when `am_sender` (`options.c:2646-2647`). The receiver skips a directory's mtime at `set_file_attrs` (`rsync.c:583` - `omit_dir_times && S_ISDIR(...)` adds `ATTRS_SKIP_MTIME`) and gates the final retouch pass (`generator.c:2271` - `need_retouch_dir_times = preserve_mtimes && !omit_dir_times`).

The three receiver-config builders already propagated the other receiver-only options but not these two. `--omit-dir-times` additionally had no representation in the transfer-side config at all.

## Fix

- Propagate `config.temp_directory()` onto `ServerConfig.temp_dir` and a new `ParsedServerFlags.omit_dir_times` onto the receiver config in all three builders (`ssh_transfer/server_config.rs`, `embedded_ssh_transfer.rs`, `daemon_transfer/orchestration/server_config.rs`).
- Honor `omit_dir_times` in the receiver: clear `preserve_times` for the directory metadata apply in `create_directories` (mirrors `rsync.c:583`) and gate the `touch_up_dirs` retouch pass on `!omit_dir_times` (mirrors `generator.c:2271`).

## Verification (Linux, vs `/usr/bin/rsync` 3.4.4)

Remote pulls with `--rsync-path=/usr/bin/rsync` (remote sender is upstream, local receiver is oc):

| Scenario | Before | After | Upstream |
|---|---|---|---|
| ssh pull `--omit-dir-times`, backdated dirs | dir mtime = source (ignored) | dir mtime = now | dir mtime = now |
| ssh pull `--temp-dir=T` (poll) | temp staged in dest | temp staged in `T` | temp staged in `T` |
| daemon pull `--omit-dir-times` | dir mtime = source (ignored) | dir mtime = now | dir mtime = now |
| daemon pull `--temp-dir=T` (poll) | temp staged in dest | temp staged in `T` | temp staged in `T` |

Unaffected paths reconfirmed: normal ssh pull (no flags) preserves content and directory mtimes; local `--omit-dir-times` and local `--temp-dir` behave as before; daemon transfers produce byte-identical destinations.

## Tests

- Propagation regression tests added to all three receiver-config builders (present/absent for each option).
- A transfer-crate behavior test asserts `touch_up_dirs` does not re-apply the source directory mtime under `--omit-dir-times`, alongside the existing test that proves it does without it.

## Scope note

This PR covers `--temp-dir` and `--omit-dir-times`. A separate `--partial-dir` divergence (an interrupted remote pull not relocating the in-progress file into the partial directory) was investigated and found to have an unrelated root cause: the partial directory is already propagated onto the receiver config, but the interrupt/abort path does not route the in-flight temp into it. That is a distinct receiver-abort/signal-handling defect and is left for a focused follow-up rather than bundled here.
