### PR TITLE
fix: propagate receiver-only options onto remote pull configs

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -83,6 +83,35 @@ pub(crate) fn build_server_config_for_receiver(
     // never sent over the wire, so carry it onto the local receiver config here.
     // Without this the receiver updates files in place, defeating --delay-updates.
     server_config.write.delay_updates = config.delay_updates();
+    // upstream: options.c:2912-2913 - `if (am_sender) { if (usermap) ... }`
+    // forwards --usermap to the remote only on a push. On a pull the local
+    // client IS the receiver and applies the uid name-map itself as it reads
+    // the incoming id list (receiver/file_list/id_lists.rs). Carry it onto the
+    // local receiver config here; without this the daemon pull silently ignored
+    // --usermap while local pulls remapped ownership. This is the client flag,
+    // distinct from the module `uid`/`gid` the remote daemon applies far-side.
+    server_config.user_mapping = config.user_mapping().cloned();
+    // upstream: options.c:2915-2916 - `if (am_sender) { if (groupmap) ... }`
+    // is the gid counterpart of --usermap above; same pull rationale.
+    server_config.group_mapping = config.group_mapping().cloned();
+    // upstream: options.c:2979-2980 - `if (write_devices && am_sender)
+    // --write-devices`. --write-devices makes the receiver write file content
+    // in-place into an existing device node (receiver.c: write_devices &&
+    // IS_DEVICE), so on a pull the local client IS the receiver and must carry
+    // it; it rides the wire only on a push.
+    server_config.write.write_devices = config.write_devices();
+    // upstream: options.c:2641-2643 - `if (am_sender) { if (keep_dirlinks)
+    // argstr[x++] = 'K'; }`. -K makes the receiver follow a symlink-to-dir at
+    // the destination instead of clobbering it (receiver/directory/creation.rs),
+    // so on a pull the local client IS the receiver and must carry the flag; the
+    // compact 'K' letter is emitted only when the local side is the sender.
+    server_config.flags.keep_dirlinks = config.keep_dirlinks();
+    // upstream: options.c:2650-2655 - `if (am_sender) { if (fuzzy_basis) {
+    // argstr[x++] = 'y'; ... } }`. -y/--fuzzy lets the receiver pick a similar
+    // basis file for the delta, so on a pull the local client IS the receiver
+    // and must carry the fuzzy level; the compact 'y' letter is emitted only
+    // when the local side is the sender.
+    server_config.flags.fuzzy_level = config.fuzzy_level();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -1138,6 +1138,100 @@ mod server_config_reference_dirs {
         assert!(server_config.chmod.is_none());
     }
 
+    /// On a daemon pull the local client IS the receiver and applies --usermap
+    /// itself as it reads the incoming id list. Upstream options.c:2912-2913
+    /// forwards --usermap to the remote only when am_sender, so on a pull it
+    /// never rides the wire and must be carried onto the receiver config.
+    /// Regression guard for the daemon pull that ignored --usermap.
+    #[cfg(unix)]
+    #[test]
+    fn receiver_config_propagates_usermap() {
+        let mapping = ::metadata::UserMapping::parse("*:5678").expect("parse usermap");
+        let config = ClientConfig::builder()
+            .user_mapping(Some(mapping.clone()))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert_eq!(server_config.user_mapping.as_ref(), Some(&mapping));
+    }
+
+    /// The gid counterpart of --usermap (upstream options.c:2915-2916).
+    #[cfg(unix)]
+    #[test]
+    fn receiver_config_propagates_groupmap() {
+        let mapping = ::metadata::GroupMapping::parse("*:1234").expect("parse groupmap");
+        let config = ClientConfig::builder()
+            .group_mapping(Some(mapping.clone()))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert_eq!(server_config.group_mapping.as_ref(), Some(&mapping));
+    }
+
+    /// Without --usermap/--groupmap the receiver config carries no id maps.
+    #[test]
+    fn receiver_config_without_id_maps_has_none() {
+        let config = ClientConfig::default();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(server_config.user_mapping.is_none());
+        assert!(server_config.group_mapping.is_none());
+    }
+
+    /// On a daemon pull the local client IS the receiver and writes file content
+    /// in-place into an existing device node under --write-devices. Upstream
+    /// options.c:2979-2980 forwards it to the remote only when am_sender, so on a
+    /// pull it must be carried onto the receiver config.
+    #[test]
+    fn receiver_config_propagates_write_devices() {
+        let config = ClientConfig::builder().write_devices(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(server_config.write.write_devices);
+    }
+
+    /// On a daemon pull the local client IS the receiver and follows a
+    /// symlink-to-dir at the destination under -K. Upstream options.c:2641-2643
+    /// packs the compact 'K' only when am_sender, so on a pull it must be carried
+    /// onto the receiver config.
+    #[test]
+    fn receiver_config_propagates_keep_dirlinks() {
+        let config = ClientConfig::builder().keep_dirlinks(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(server_config.flags.keep_dirlinks);
+    }
+
+    /// On a daemon pull the local client IS the receiver and picks a fuzzy basis
+    /// under -y/--fuzzy. Upstream options.c:2650-2655 packs the compact 'y' only
+    /// when am_sender, so on a pull the fuzzy level must be carried onto the
+    /// receiver config.
+    #[test]
+    fn receiver_config_propagates_fuzzy_level() {
+        let config = ClientConfig::builder().fuzzy_level(2).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert_eq!(server_config.flags.fuzzy_level, 2);
+    }
+
+    /// Without -K/-y/--write-devices the receiver config leaves those flags clear.
+    #[test]
+    fn receiver_config_without_receiver_only_flags_stays_clear() {
+        let config = ClientConfig::default();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(!server_config.write.write_devices);
+        assert!(!server_config.flags.keep_dirlinks);
+        assert_eq!(server_config.flags.fuzzy_level, 0);
+    }
+
     #[test]
     fn generator_config_empty_reference_dirs_by_default() {
         let config = ClientConfig::default();

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -559,6 +559,56 @@ fn build_server_config_for_receiver(
     // existing_only above. Without this the ssh:// pull re-transferred and
     // overwrote existing destination files instead of skipping them.
     server_config.file_selection.ignore_existing = config.ignore_existing();
+    // upstream: options.c:2194 / generator.c:1249 - a single source operand with
+    // no destination implies list-only. On a pull the local client IS the
+    // receiver and `list_only` is a long-form-only concern absent from the
+    // compact letter string, so carry it onto the local receiver config here.
+    // Mirrors the subprocess-ssh and daemon receiver builders; without it the
+    // single-operand ssh:// pull renders the flist AND writes files.
+    server_config.flags.list_only = config.list_only();
+    // upstream: options.c:777 / receiver.c:656,1029-1050 - --delay-updates is a
+    // plain receiver-side option (no am_sender gate) that stages updates into
+    // the partial dir and renames them in the phase-2 sweep. options.c:2886-2892
+    // forwards it to the remote only on a push; on a pull the local client IS the
+    // receiver and the flag never rides the wire, so carry it here. Mirrors the
+    // subprocess-ssh and daemon receiver builders; without it the ssh:// pull
+    // updates files in place, defeating --delay-updates.
+    server_config.write.delay_updates = config.delay_updates();
+    // upstream: options.c:2912-2913 - `if (am_sender) { if (usermap) ... }`
+    // forwards --usermap to the remote only on a push. On a pull the local
+    // client IS the receiver and applies the uid name-map itself as it reads
+    // the incoming id list (receiver/file_list/id_lists.rs). Carry it onto the
+    // local receiver config here; without this the ssh:// pull silently ignored
+    // --usermap while local and daemon pulls remapped ownership.
+    server_config.user_mapping = config.user_mapping().cloned();
+    // upstream: options.c:2915-2916 - `if (am_sender) { if (groupmap) ... }`
+    // is the gid counterpart of --usermap above; same pull rationale.
+    server_config.group_mapping = config.group_mapping().cloned();
+    // upstream: options.c:2930-2931 - `if (am_sender && do_fsync) --fsync`.
+    // --fsync is applied by the receiver, which fsync()s each committed file
+    // (syscall.c do_fsync), so on a pull the local client IS the receiver and
+    // must carry the flag; it rides the wire only on a push. The daemon pull
+    // already sets this in apply_common_daemon_config; both ssh builders dropped
+    // it, so the ssh:// pull never fsync'd its writes.
+    server_config.write.fsync = config.fsync();
+    // upstream: options.c:2979-2980 - `if (write_devices && am_sender)
+    // --write-devices`. --write-devices makes the receiver write file content
+    // in-place into an existing device node (receiver.c: write_devices &&
+    // IS_DEVICE), so on a pull the local client IS the receiver and must carry
+    // it; it rides the wire only on a push.
+    server_config.write.write_devices = config.write_devices();
+    // upstream: options.c:2641-2643 - `if (am_sender) { if (keep_dirlinks)
+    // argstr[x++] = 'K'; }`. -K makes the receiver follow a symlink-to-dir at
+    // the destination instead of clobbering it (receiver/directory/creation.rs),
+    // so on a pull the local client IS the receiver and must carry the flag; the
+    // compact 'K' letter is emitted only when the local side is the sender.
+    server_config.flags.keep_dirlinks = config.keep_dirlinks();
+    // upstream: options.c:2650-2655 - `if (am_sender) { if (fuzzy_basis) {
+    // argstr[x++] = 'y'; ... } }`. -y/--fuzzy lets the receiver pick a similar
+    // basis file for the delta, so on a pull the local client IS the receiver
+    // and must carry the fuzzy level; the compact 'y' letter is emitted only
+    // when the local side is the sender.
+    server_config.flags.fuzzy_level = config.fuzzy_level();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
@@ -740,6 +790,132 @@ mod tests {
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
 
         assert!(server_config.chmod.is_none());
+    }
+
+    /// The embedded (russh) pull receiver must carry `list_only` onto its
+    /// ServerConfig for parity with the subprocess-ssh and daemon receiver
+    /// builders. Upstream options.c:2194 / generator.c:1249 - a single source
+    /// operand with no destination implies list-only; it is a long-form-only
+    /// concern the local receiver applies itself. Regression guard for the
+    /// `ssh://` single-operand pull that rendered the flist AND wrote files.
+    #[test]
+    fn embedded_receiver_config_propagates_list_only() {
+        let config = ClientConfig::builder().list_only(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.list_only);
+    }
+
+    /// The embedded (russh) pull receiver must carry `--delay-updates` onto its
+    /// ServerConfig for parity with the subprocess-ssh and daemon receiver
+    /// builders. Upstream options.c:777 / receiver.c:656 - a plain receiver-side
+    /// option that stages updates and renames them in the phase-2 sweep; on a
+    /// pull it never rides the wire. Regression guard for the `ssh://` pull that
+    /// updated files in place, defeating --delay-updates.
+    #[test]
+    fn embedded_receiver_config_propagates_delay_updates() {
+        let config = ClientConfig::builder().delay_updates(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.write.delay_updates);
+    }
+
+    /// The embedded (russh) pull receiver must carry --usermap onto its
+    /// ServerConfig. Upstream options.c:2912-2913 forwards --usermap to the
+    /// remote only when am_sender, so on a pull the local receiver applies the
+    /// uid name-map itself (receiver/file_list/id_lists.rs).
+    #[cfg(unix)]
+    #[test]
+    fn embedded_receiver_config_propagates_usermap() {
+        let mapping = ::metadata::UserMapping::parse("*:5678").expect("parse usermap");
+        let config = ClientConfig::builder()
+            .user_mapping(Some(mapping.clone()))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert_eq!(server_config.user_mapping.as_ref(), Some(&mapping));
+    }
+
+    /// The gid counterpart of --usermap (upstream options.c:2915-2916).
+    #[cfg(unix)]
+    #[test]
+    fn embedded_receiver_config_propagates_groupmap() {
+        let mapping = ::metadata::GroupMapping::parse("*:1234").expect("parse groupmap");
+        let config = ClientConfig::builder()
+            .group_mapping(Some(mapping.clone()))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert_eq!(server_config.group_mapping.as_ref(), Some(&mapping));
+    }
+
+    /// The embedded (russh) pull receiver must carry --fsync onto its
+    /// ServerConfig. Upstream options.c:2930-2931 forwards it to the remote only
+    /// when am_sender, so on a pull the local receiver fsync()s its writes.
+    #[test]
+    fn embedded_receiver_config_propagates_fsync() {
+        let config = ClientConfig::builder().fsync(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.write.fsync);
+    }
+
+    /// The embedded (russh) pull receiver must carry --write-devices onto its
+    /// ServerConfig. Upstream options.c:2979-2980 forwards it to the remote only
+    /// when am_sender.
+    #[test]
+    fn embedded_receiver_config_propagates_write_devices() {
+        let config = ClientConfig::builder().write_devices(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.write.write_devices);
+    }
+
+    /// The embedded (russh) pull receiver must carry -K onto its ServerConfig.
+    /// Upstream options.c:2641-2643 packs the compact 'K' only when am_sender.
+    #[test]
+    fn embedded_receiver_config_propagates_keep_dirlinks() {
+        let config = ClientConfig::builder().keep_dirlinks(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.keep_dirlinks);
+    }
+
+    /// The embedded (russh) pull receiver must carry the fuzzy level onto its
+    /// ServerConfig. Upstream options.c:2650-2655 packs the compact 'y' only
+    /// when am_sender.
+    #[test]
+    fn embedded_receiver_config_propagates_fuzzy_level() {
+        let config = ClientConfig::builder().fuzzy_level(2).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert_eq!(server_config.flags.fuzzy_level, 2);
+    }
+
+    /// Without any of the receiver-only options the embedded receiver config
+    /// leaves them clear, so a normal `ssh://` pull is unaffected.
+    #[test]
+    fn embedded_receiver_config_without_receiver_only_flags_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.list_only);
+        assert!(!server_config.write.delay_updates);
+        assert!(!server_config.write.fsync);
+        assert!(!server_config.write.write_devices);
+        assert!(!server_config.flags.keep_dirlinks);
+        assert_eq!(server_config.flags.fuzzy_level, 0);
+        assert!(server_config.user_mapping.is_none());
+        assert!(server_config.group_mapping.is_none());
     }
 
     #[test]

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -100,6 +100,41 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
     // never sent over the wire, so carry it onto the local receiver config here.
     // Without this the receiver updates files in place, defeating --delay-updates.
     server_config.write.delay_updates = config.delay_updates();
+    // upstream: options.c:2912-2913 - `if (am_sender) { if (usermap) ... }`
+    // forwards --usermap to the remote only on a push. On a pull the local
+    // client IS the receiver and applies the uid name-map itself as it reads
+    // the incoming id list (receiver/file_list/id_lists.rs). Carry it onto the
+    // local receiver config here; without this the ssh pull silently ignored
+    // --usermap while local and daemon pulls remapped ownership.
+    server_config.user_mapping = config.user_mapping().cloned();
+    // upstream: options.c:2915-2916 - `if (am_sender) { if (groupmap) ... }`
+    // is the gid counterpart of --usermap above; same pull rationale.
+    server_config.group_mapping = config.group_mapping().cloned();
+    // upstream: options.c:2930-2931 - `if (am_sender && do_fsync) --fsync`.
+    // --fsync is applied by the receiver, which fsync()s each committed file
+    // (syscall.c do_fsync), so on a pull the local client IS the receiver and
+    // must carry the flag; it rides the wire only on a push. The daemon pull
+    // already sets this in apply_common_daemon_config; both ssh builders dropped
+    // it, so the ssh pull never fsync'd its writes.
+    server_config.write.fsync = config.fsync();
+    // upstream: options.c:2979-2980 - `if (write_devices && am_sender)
+    // --write-devices`. --write-devices makes the receiver write file content
+    // in-place into an existing device node (receiver.c: write_devices &&
+    // IS_DEVICE), so on a pull the local client IS the receiver and must carry
+    // it; it rides the wire only on a push.
+    server_config.write.write_devices = config.write_devices();
+    // upstream: options.c:2641-2643 - `if (am_sender) { if (keep_dirlinks)
+    // argstr[x++] = 'K'; }`. -K makes the receiver follow a symlink-to-dir at
+    // the destination instead of clobbering it (receiver/directory/creation.rs),
+    // so on a pull the local client IS the receiver and must carry the flag; the
+    // compact 'K' letter is emitted only when the local side is the sender.
+    server_config.flags.keep_dirlinks = config.keep_dirlinks();
+    // upstream: options.c:2650-2655 - `if (am_sender) { if (fuzzy_basis) {
+    // argstr[x++] = 'y'; ... } }`. -y/--fuzzy lets the receiver pick a similar
+    // basis file for the delta, so on a pull the local client IS the receiver
+    // and must carry the fuzzy level; the compact 'y' letter is emitted only
+    // when the local side is the sender.
+    server_config.flags.fuzzy_level = config.fuzzy_level();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
@@ -326,5 +361,113 @@ mod tests {
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
 
         assert!(server_config.chmod.is_none());
+    }
+
+    /// On an ssh pull the local client IS the receiver and applies --usermap
+    /// itself as it reads the incoming id list (receiver/file_list/id_lists.rs).
+    /// Upstream options.c:2912-2913 forwards --usermap to the remote only when
+    /// am_sender, so on a pull it never rides the wire and must be carried onto
+    /// the receiver config. Regression guard for the ssh pull that ignored
+    /// --usermap while the daemon pull remapped ownership.
+    #[cfg(unix)]
+    #[test]
+    fn receiver_config_propagates_usermap() {
+        let mapping = ::metadata::UserMapping::parse("*:5678").expect("parse usermap");
+        let config = ClientConfig::builder()
+            .user_mapping(Some(mapping.clone()))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert_eq!(server_config.user_mapping.as_ref(), Some(&mapping));
+    }
+
+    /// The gid counterpart of --usermap (upstream options.c:2915-2916).
+    #[cfg(unix)]
+    #[test]
+    fn receiver_config_propagates_groupmap() {
+        let mapping = ::metadata::GroupMapping::parse("*:1234").expect("parse groupmap");
+        let config = ClientConfig::builder()
+            .group_mapping(Some(mapping.clone()))
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert_eq!(server_config.group_mapping.as_ref(), Some(&mapping));
+    }
+
+    /// Without --usermap/--groupmap the receiver config carries no id maps.
+    #[test]
+    fn receiver_config_without_id_maps_has_none() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.user_mapping.is_none());
+        assert!(server_config.group_mapping.is_none());
+    }
+
+    /// On an ssh pull the local client IS the receiver and fsync()s each
+    /// committed file under --fsync. Upstream options.c:2930-2931 forwards
+    /// --fsync to the remote only when am_sender, so on a pull it must be carried
+    /// onto the receiver config. Regression guard for the ssh pull that never
+    /// fsync'd its writes while the daemon pull did.
+    #[test]
+    fn receiver_config_propagates_fsync() {
+        let config = ClientConfig::builder().fsync(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.write.fsync);
+    }
+
+    /// On an ssh pull the local client IS the receiver and writes file content
+    /// in-place into an existing device node under --write-devices. Upstream
+    /// options.c:2979-2980 forwards it to the remote only when am_sender.
+    #[test]
+    fn receiver_config_propagates_write_devices() {
+        let config = ClientConfig::builder().write_devices(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.write.write_devices);
+    }
+
+    /// On an ssh pull the local client IS the receiver and follows a
+    /// symlink-to-dir at the destination under -K. Upstream options.c:2641-2643
+    /// packs the compact 'K' only when am_sender.
+    #[test]
+    fn receiver_config_propagates_keep_dirlinks() {
+        let config = ClientConfig::builder().keep_dirlinks(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.keep_dirlinks);
+    }
+
+    /// On an ssh pull the local client IS the receiver and picks a fuzzy basis
+    /// under -y/--fuzzy. Upstream options.c:2650-2655 packs the compact 'y' only
+    /// when am_sender.
+    #[test]
+    fn receiver_config_propagates_fuzzy_level() {
+        let config = ClientConfig::builder().fuzzy_level(2).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert_eq!(server_config.flags.fuzzy_level, 2);
+    }
+
+    /// Without --fsync/-K/-y/--write-devices the receiver config leaves those
+    /// flags clear, so a normal ssh pull is unaffected.
+    #[test]
+    fn receiver_config_without_receiver_only_flags_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.write.fsync);
+        assert!(!server_config.write.write_devices);
+        assert!(!server_config.flags.keep_dirlinks);
+        assert_eq!(server_config.flags.fuzzy_level, 0);
     }
 }


### PR DESCRIPTION
## Summary

Several receiver-applied options that upstream `options.c server_options()` forwards to the remote **only** under `if (am_sender)` (or `&& am_sender`) are never sent over the wire on a **pull**. On a pull the local client **is** the receiver and must apply them itself. These fields already exist on `ServerConfig`/`ParsedServerFlags` and are consumed by the in-process receiver; they were simply never assigned from `config` in the remote receiver-config builders, so they silently no-op'd on ssh / russh / daemon pulls while local copies worked. Same class as the previously merged link-dest / backup / chmod / ignore-existing / mkpath / temp-dir / omit-dir-times fixes.

## Gap table

| Option | upstream (options.c 3.4.4) | Missing from builder(s) | Receiver field carried |
|---|---|---|---|
| `--usermap` | `2912-2913` `if (am_sender) { if (usermap) … }` | ssh, russh, daemon | `server_config.user_mapping` |
| `--groupmap` | `2915-2916` `if (am_sender) { if (groupmap) … }` | ssh, russh, daemon | `server_config.group_mapping` |
| `--fsync` | `2930-2931` `if (am_sender && do_fsync) --fsync` | ssh, russh (daemon already set it) | `server_config.write.fsync` |
| `--write-devices` | `2979-2980` `if (write_devices && am_sender)` | ssh, russh, daemon | `server_config.write.write_devices` |
| `-K` / `--keep-dirlinks` | `2641-2643` `if (am_sender) { … 'K' }` | ssh, russh, daemon | `server_config.flags.keep_dirlinks` |
| `-y` / `--fuzzy` | `2650-2655` `if (am_sender) { … 'y' }` | ssh, russh, daemon | `server_config.flags.fuzzy_level` |
| `list_only` | `2194` / `generator.c:1249` | russh only (ssh + daemon already set it) | `server_config.flags.list_only` |
| `--delay-updates` | `777` / `receiver.c:656` | russh only (ssh + daemon already set it) | `server_config.write.delay_updates` |

Builders touched:
- `crates/core/src/client/remote/ssh_transfer/server_config.rs` (`build_server_config_for_receiver`)
- `crates/core/src/client/remote/embedded_ssh_transfer.rs` (russh `build_server_config_for_receiver`)
- `crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs` (`build_server_config_for_receiver`)

All are receiver-only options (upstream forwards them to the remote only on a push), so they are carried onto the receiver builders, mirroring the neighbouring reference-directories / chmod / ignore-existing propagations. The compact `-K`/`-y` letters and the `--usermap`/`--groupmap`/`--fsync`/`--write-devices` long-form args are never emitted onto the wire on a pull, so the in-process receiver never learned them.

## Tests

Added targeted propagation-guard regression tests to each builder's test module (mirroring the existing `receiver_config_propagates_*` tests): each new option asserts the field is carried when the option is set and stays clear by default. 19 new tests; `cargo clippy -p core --all-features --tests -D warnings` clean, `cargo fmt --all --check` clean.

## Host validation (Arch x86_64, oc-rsync local receiver vs `/usr/bin/rsync` 3.4.4 remote sender over ssh / russh / daemon; non-root)

- **`--fsync` (ssh pull):** the local receiver commits via io_uring, so `--fsync` is issued as an `IORING_OP_FSYNC` SQE (invisible to `strace -e trace=fsync`). Measured `io_uring_enter` for a 6-file pull: **12 with `--fsync` vs 6 without** — exactly one extra fsync submission per file. Dest tree byte-identical to upstream. (Before the fix the ssh receiver config carried `fsync=false`, so no fsync op was submitted.)
- **`-aK` keep-dirlinks (ssh pull):** dest has a symlink-to-dir at a name that is a real dir in src. oc `-aK` keeps `dest/sub` a **symlink** and writes the file **through** it into the link target — identical to upstream `-aK`.
- **`-a --fuzzy` (ssh pull):** basis file renamed at dest. oc reports **matched=500000, literal=0**, identical to upstream; delivered bytes correct.
- **russh `--list-only` (ssh://, 2 operands):** **0 files written** to the destination (list-only honoured; before the fix the russh receiver wrote them). Note: oc's embedded entry requires a source **and** a destination operand, so the single-operand `ssh://SRC` form is rejected before reaching the builder; the 2-operand `--list-only` form exercises the propagation.
- **russh `--delay-updates` (ssh://):** full tree delivered correctly.
- **`--usermap` / `--groupmap` / `--write-devices` (ssh pull):** flag now carried, transfer succeeds with exit 0 and files delivered. Full ownership remap / device-node write require root (not available on the host); asserted the flag is accepted and non-fatal, with unit tests confirming the field is carried.
- **Local + normal pulls unaffected:** local `--fsync` still issues 3 `fsync(2)` calls; the default-clear guard tests confirm none of the new fields are set without the corresponding option.
