### PR TITLE
test: add wire-decoder robustness sweeps for DoS classes

### DIFF
--- a/crates/core/src/client/module_list/connect/proxy.rs
+++ b/crates/core/src/client/module_list/connect/proxy.rs
@@ -794,4 +794,105 @@ mod tests {
 
         handle.join().expect("server thread");
     }
+
+    /// Runs one `read_proxy_line` decode over a loopback connection whose server
+    /// side writes `payload` and then closes. Returns the parser's result and
+    /// the (post-parse) line buffer so invariants can be asserted on both.
+    fn run_proxy_line(payload: &[u8]) -> (Result<(), ClientError>, Vec<u8>) {
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+        let addr = listener.local_addr().expect("listener address");
+
+        let server_payload = payload.to_vec();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            // A malformed decoder could hang forever; the client caps its read,
+            // so ignore write errors from an early client-side close.
+            let _ = stream.write_all(&server_payload);
+            let _ = stream.flush();
+        });
+
+        let mut stream = TcpStream::connect(addr).expect("connect to listener");
+        let mut buffer = Vec::with_capacity(MAX_PROXY_LINE_BYTES + 2);
+        let display = SocketAddrDisplay {
+            host: "proxy.test",
+            port: addr.port(),
+        };
+        let result = read_proxy_line(&mut stream, &mut buffer, display);
+        handle.join().expect("server thread");
+        (result, buffer)
+    }
+
+    /// Deterministic xorshift64 stream so failures are reproducible from `seed`.
+    fn xorshift64(state: &mut u64) -> u64 {
+        let mut x = *state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        *state = x;
+        x
+    }
+
+    #[test]
+    fn read_proxy_line_never_panics_on_arbitrary_bytes() {
+        // CVE-2026-45232 class: a hostile HTTP proxy returns a CONNECT status
+        // line with no newline and arbitrary bytes. The decoder must honour the
+        // MAX_PROXY_LINE_BYTES cap and return an error - never panic, overflow,
+        // or grow the buffer without bound. Cover the exact upstream boundaries
+        // (1023 / 1024 / 4096 bytes) plus a deterministic corpus of random
+        // lines with embedded control, NUL, CR, and high bytes.
+        for len in [MAX_PROXY_LINE_BYTES, MAX_PROXY_LINE_BYTES + 1, 4096] {
+            let payload = vec![b'Z'; len];
+            let (result, buffer) = run_proxy_line(&payload);
+            assert!(
+                result.is_err(),
+                "newline-free {len}-byte line must be rejected"
+            );
+            assert!(
+                buffer.len() <= MAX_PROXY_LINE_BYTES,
+                "buffer grew to {} beyond the {MAX_PROXY_LINE_BYTES}-byte cap",
+                buffer.len()
+            );
+        }
+
+        let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+        for _ in 0..256 {
+            // Random length spanning below, at, and above the cap.
+            let len = (xorshift64(&mut state) % 4200) as usize;
+            let payload: Vec<u8> = (0..len)
+                .map(|_| (xorshift64(&mut state) & 0xFF) as u8)
+                .collect();
+            let (result, buffer) = run_proxy_line(&payload);
+            // Ok or Err are both graceful; the invariants are cap-bounded buffer
+            // and (on success) a stripped, newline-free line.
+            assert!(
+                buffer.len() <= MAX_PROXY_LINE_BYTES,
+                "buffer grew to {} beyond the cap on a {len}-byte payload",
+                buffer.len()
+            );
+            if result.is_ok() {
+                // The read loop breaks on the first newline and strips the
+                // trailing CR/LF (upstream socket.c), so an accepted line never
+                // contains a newline. Interior CR is retained, matching upstream.
+                assert!(
+                    !buffer.contains(&b'\n'),
+                    "accepted line must not contain a newline"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn read_proxy_line_accepts_capped_line_with_newline() {
+        // A full cap-length line terminated by a newline is the largest legal
+        // response; it must decode without error and be returned CR/LF-stripped.
+        let mut payload = vec![b'H'; MAX_PROXY_LINE_BYTES - 1];
+        payload.push(b'\n');
+        let (result, buffer) = run_proxy_line(&payload);
+        result.expect("cap-length line with newline must decode");
+        assert_eq!(buffer.len(), MAX_PROXY_LINE_BYTES - 1);
+        assert!(!buffer.contains(&b'\n'));
+    }
 }

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -404,7 +404,15 @@ impl DeflateSink for ZlibDeflate {
                 output.extend_from_slice(&self.output_buf[..produced]);
             }
 
-            if input.is_empty() && produced == 0 {
+            // Stop as soon as an inflate call makes no forward progress:
+            // neither consuming the sync marker nor producing residual output.
+            // This is zlib's Z_BUF_ERROR ("no pending output"), which upstream
+            // treats as end-of-drain rather than a reason to keep flushing.
+            // Without this an adversarial stream whose inflate state can neither
+            // advance on nor consume the marker spins here forever (a DoS).
+            // upstream: token.c:615-646 recv_deflated_token() r_inflated - a
+            // single Z_SYNC_FLUSH per residual chunk, Z_BUF_ERROR ends the drain.
+            if consumed == 0 && produced == 0 {
                 break;
             }
         }

--- a/crates/protocol/tests/decoder_robustness.rs
+++ b/crates/protocol/tests/decoder_robustness.rs
@@ -1,0 +1,335 @@
+//! Input-space robustness tests for the highest-risk wire-protocol decoders.
+//!
+//! A decoder that panics, reads out of bounds, over-allocates, or loops forever
+//! on attacker-controlled wire bytes is a denial-of-service vector. Upstream
+//! rsync has shipped exactly this class of bug (out-of-bounds reads and integer
+//! overflows in the file-list and compressed-token paths). These tests feed
+//! arbitrary and adversarial byte streams into the decode entry points and
+//! assert only that decoding *terminates gracefully* - it returns `Ok` or a
+//! typed `Err`, never panics, never allocates without bound, never spins.
+//!
+//! Scope note: the individual file-list field decoders (`decode_flags`,
+//! `decode_name`, ...) and the multiplex/varint decoders already have arbitrary
+//! -byte panic-freedom sweeps elsewhere in this crate. This file covers the two
+//! gaps: the *whole* file-list entry decoder driven end to end, and a broad
+//! arbitrary-byte sweep over the compressed-token decoder (whose crafted
+//! integer-overflow regressions live inline in the token module).
+
+use std::io::Cursor;
+
+use proptest::prelude::*;
+
+use protocol::flist::{EntryStep, FileEntry, FileListReader};
+use protocol::wire::{CompressedToken, CompressedTokenDecoder};
+use protocol::{ProtocolVersion, write_varint30_int};
+
+/// Protocol versions the file-list decoder must survive arbitrary input on.
+const PROTOCOL_VERSIONS: [u8; 5] = [28, 29, 30, 31, 32];
+
+fn protocol(version: u8) -> ProtocolVersion {
+    ProtocolVersion::try_from(version).expect("supported protocol version")
+}
+
+// --- File-list entry decode (CVE-2026-43620 class: crafted flist) ------------
+//
+// Upstream CVE-2026-43620 was an out-of-bounds read reachable from a maliciously
+// crafted incremental file list (a first entry that is not the implied dot-dir,
+// an index of zero where a positive follower index was required, transfer flags
+// without the expected item bit). At the decode layer the exposure is a single
+// `FileListReader` entry decode fed hostile bytes: an over-long or negative
+// name/suffix length, a truncated entry, or garbage flag combinations. The
+// decoder must reject every such input with an error instead of panicking or
+// allocating from an unchecked wire length.
+
+mod flist_entry_decode {
+    use super::*;
+
+    // Wire flag bits, upstream rsync.h `XMIT_*`. The `flags` module is private,
+    // so the values are pinned here (they are part of the stable wire format).
+    const XMIT_EXTENDED_FLAGS: u8 = 1 << 2;
+    const XMIT_SAME_NAME: u8 = 1 << 5;
+    const XMIT_LONG_NAME: u8 = 1 << 6;
+
+    /// Drives one entry decode over `bytes` for every protocol version through
+    /// both the blocking reader and the sans-io step seam. Returns nothing; the
+    /// contract is simply that neither entry point panics.
+    fn decode_all_paths(bytes: &[u8]) {
+        for version in PROTOCOL_VERSIONS {
+            let mut reader = FileListReader::new(protocol(version));
+            let mut cursor = Cursor::new(bytes);
+            // Result is intentionally discarded: Ok(Some)/Ok(None)/Err are all
+            // acceptable graceful outcomes. A panic here fails the test.
+            let _ = reader.read_entry(&mut cursor);
+
+            let mut step_reader = FileListReader::new(protocol(version));
+            match step_reader.read_entry_step(bytes, &[]) {
+                Ok(EntryStep::Emit { consumed, .. }) => {
+                    assert!(
+                        consumed <= bytes.len(),
+                        "read_entry_step reported consuming {consumed} of {} bytes",
+                        bytes.len()
+                    );
+                }
+                Ok(EntryStep::NeedMore) | Err(_) => {}
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        /// The whole file-list entry decoder never panics on arbitrary bytes.
+        #[test]
+        fn read_entry_never_panics_on_arbitrary_input(
+            data in prop::collection::vec(any::<u8>(), 0..8192),
+        ) {
+            decode_all_paths(&data);
+        }
+
+        /// Arbitrary bytes prefixed with a "same name" reuse byte exercise the
+        /// prefix-compression path (`same_len` against an empty previous name)
+        /// without panicking - a raw `any::<u8>()` prefix rarely sets that flag.
+        #[test]
+        fn read_entry_never_panics_with_same_name_prefix(
+            same_len in any::<u8>(),
+            data in prop::collection::vec(any::<u8>(), 0..4096),
+        ) {
+            let mut bytes = Vec::with_capacity(data.len() + 2);
+            bytes.push(XMIT_SAME_NAME);
+            bytes.push(same_len);
+            bytes.extend_from_slice(&data);
+            decode_all_paths(&bytes);
+        }
+    }
+
+    #[test]
+    fn empty_input_needs_more_and_end_marker_is_none() {
+        // A zero-length flag byte is the end-of-list marker; an empty buffer is
+        // just "need more". Both are graceful, neither allocates.
+        let mut reader = FileListReader::new(protocol(32));
+        assert!(matches!(
+            reader.read_entry_step(&[], &[]).expect("empty step"),
+            EntryStep::NeedMore
+        ));
+
+        let mut reader = FileListReader::new(protocol(32));
+        let mut cursor = Cursor::new([0u8].as_slice());
+        assert!(
+            reader
+                .read_entry(&mut cursor)
+                .expect("end marker decodes")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn oversize_long_name_length_is_rejected_not_allocated() {
+        // A malicious sender sets XMIT_LONG_NAME and encodes a near-i32::MAX
+        // suffix length. The decoder must reject it via the MAXPATHLEN bound
+        // (name.rs) before allocating gigabytes, on every protocol version.
+        for version in PROTOCOL_VERSIONS {
+            let mut bytes = vec![XMIT_LONG_NAME];
+            write_varint30_int(&mut bytes, i32::MAX, version).expect("encode length");
+            // No name bytes follow: the guard must fire before the read_exact.
+            let mut reader = FileListReader::new(protocol(version));
+            let mut cursor = Cursor::new(bytes.as_slice());
+            let result = reader.read_entry(&mut cursor);
+            assert!(
+                result.is_err(),
+                "proto {version}: oversize long-name length must error, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn negative_long_name_length_is_rejected() {
+        // A negative wire length (high bit set) must not underflow into a huge
+        // usize allocation. Protocol >= 30 uses varint; encode -1 and confirm a
+        // clean error rather than a panic or runaway allocation.
+        for version in [30u8, 31, 32] {
+            let mut bytes = vec![XMIT_LONG_NAME];
+            write_varint30_int(&mut bytes, -1, version).expect("encode length");
+            let mut reader = FileListReader::new(protocol(version));
+            let mut cursor = Cursor::new(bytes.as_slice());
+            let result = reader.read_entry(&mut cursor);
+            assert!(
+                result.is_err(),
+                "proto {version}: negative long-name length must error, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn truncated_entries_never_panic() {
+        // Every truncation of a valid entry must surface as an error (or a
+        // NeedMore at the step seam), never a panic. Build a real entry, then
+        // feed every strict prefix of it.
+        use protocol::flist::FileListWriter;
+
+        let version = 32;
+        let mut full = Vec::new();
+        let mut writer = FileListWriter::new(protocol(version));
+        let mut entry = FileEntry::new_file("dir/some-file".into(), 4096, 0o100644);
+        entry.set_mtime(1_700_000_000, 0);
+        writer
+            .write_entry(&mut full, &entry)
+            .expect("write baseline entry");
+
+        for cut in 0..full.len() {
+            let prefix = &full[..cut];
+            let mut reader = FileListReader::new(protocol(version));
+            let mut cursor = Cursor::new(prefix);
+            // Only assertion: the call returns (no panic). Ok/Err both fine.
+            let _ = reader.read_entry(&mut cursor);
+
+            let mut step_reader = FileListReader::new(protocol(version));
+            let _ = step_reader.read_entry_step(prefix, &[]);
+        }
+    }
+
+    #[test]
+    fn adversarial_flag_bytes_never_panic() {
+        // A grab-bag of hostile leading flag bytes across all protocols: the
+        // extended-flags marker with nothing after it, long+same name combined,
+        // and every single-bit flag in isolation followed by no payload.
+        let mut cases: Vec<Vec<u8>> = vec![
+            vec![XMIT_EXTENDED_FLAGS],
+            vec![XMIT_EXTENDED_FLAGS, 0xFF],
+            vec![XMIT_LONG_NAME | XMIT_SAME_NAME],
+            vec![XMIT_SAME_NAME, 0xFF],
+            vec![0xFF],
+            vec![0xFF, 0xFF, 0xFF, 0xFF],
+        ];
+        for bit in 0..8u8 {
+            cases.push(vec![1u8 << bit]);
+        }
+        for bytes in &cases {
+            decode_all_paths(bytes);
+        }
+    }
+}
+
+// --- Compressed-token decode (CVE-2026-43618 class: integer overflow) --------
+//
+// Upstream CVE-2026-43618 was an integer overflow in the compressed-token
+// counter: a run of relative tokens could wrap the running index past INT_MAX
+// and drive an out-of-bounds access. The counter guard (`checked_add` in the
+// token step machine) has crafted regression coverage inline in the token
+// module. This adds the missing dimension - a broad arbitrary-byte sweep over
+// the public `recv_token` decode loop - proving the whole decoder terminates
+// gracefully on any input rather than panicking or spinning.
+
+mod compressed_token_decode {
+    use super::*;
+
+    /// Ceiling on tokens a decoder may emit *without consuming any input* before
+    /// it is deemed a non-terminating spin.
+    ///
+    /// A single `TOKENRUN_REL` / `TOKENRUN_LONG` flag legitimately schedules up
+    /// to 65535 (a 16-bit run count) `BlockMatch` tokens, each drained by a
+    /// `recv_token` call that reads no further wire bytes - this is upstream
+    /// token.c behaviour, bounded, and not a DoS. Any run of emissions longer
+    /// than that with the reader position frozen is a genuine infinite loop.
+    const STALL_LIMIT: usize = 70_000;
+
+    /// Absolute safety net on total `recv_token` calls for one buffer. Legitimate
+    /// run amplification is bounded by the input length (each run costs three
+    /// input bytes); reaching this bound just means the arbitrary bytes encoded a
+    /// very long but finite run sequence, so draining stops cleanly - panic
+    /// freedom over this many calls is what the sweep set out to prove.
+    const CALL_LIMIT: usize = 100_000;
+
+    /// Drains tokens from `decoder` over `bytes` until `End`, an error, or the
+    /// call limit. The contract: `recv_token` never panics, and never emits more
+    /// than [`STALL_LIMIT`] tokens in a row without advancing the reader (which
+    /// would be a spin). A bounded long run that reaches [`CALL_LIMIT`] is a pass.
+    fn drain(mut decoder: CompressedTokenDecoder, bytes: &[u8]) {
+        let mut cursor = Cursor::new(bytes);
+        let mut last_pos = cursor.position();
+        let mut stall = 0usize;
+        for _ in 0..CALL_LIMIT {
+            match decoder.recv_token(&mut cursor) {
+                Ok(CompressedToken::End) | Err(_) => return,
+                Ok(CompressedToken::Literal(_)) | Ok(CompressedToken::BlockMatch(_)) => {
+                    let pos = cursor.position();
+                    if pos == last_pos {
+                        stall += 1;
+                        assert!(
+                            stall <= STALL_LIMIT,
+                            "recv_token emitted {stall} tokens without consuming input: spin"
+                        );
+                    } else {
+                        stall = 0;
+                        last_pos = pos;
+                    }
+                }
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        /// The zlib token decoder never panics or spins on arbitrary bytes.
+        #[test]
+        fn zlib_recv_token_never_panics_on_arbitrary_input(
+            data in prop::collection::vec(any::<u8>(), 0..4096),
+        ) {
+            drain(CompressedTokenDecoder::new(), &data);
+        }
+
+        /// The zlibx token decoder (no per-block dictionary) likewise survives.
+        #[test]
+        fn zlibx_recv_token_never_panics_on_arbitrary_input(
+            data in prop::collection::vec(any::<u8>(), 0..4096),
+        ) {
+            let mut decoder = CompressedTokenDecoder::new();
+            decoder.set_zlibx(true);
+            drain(decoder, &data);
+        }
+    }
+
+    #[cfg(feature = "zstd")]
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        /// The zstd token decoder never panics or spins on arbitrary bytes.
+        #[test]
+        fn zstd_recv_token_never_panics_on_arbitrary_input(
+            data in prop::collection::vec(any::<u8>(), 0..4096),
+        ) {
+            drain(CompressedTokenDecoder::new_zstd().expect("zstd decoder"), &data);
+        }
+    }
+
+    #[cfg(feature = "lz4")]
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        /// The lz4 token decoder never panics or spins on arbitrary bytes.
+        #[test]
+        fn lz4_recv_token_never_panics_on_arbitrary_input(
+            data in prop::collection::vec(any::<u8>(), 0..4096),
+        ) {
+            drain(CompressedTokenDecoder::new_lz4(), &data);
+        }
+    }
+
+    #[test]
+    fn truncated_and_degenerate_streams_terminate() {
+        // Deterministic edge cases: empty input, a lone flag byte, all-zero and
+        // all-one buffers of various lengths. Each must terminate (Err/End),
+        // never spin.
+        let cases: [Vec<u8>; 6] = [
+            Vec::new(),
+            vec![0x00],
+            vec![0xFF],
+            vec![0x00; 512],
+            vec![0xFF; 512],
+            (0..=255u8).cycle().take(2048).collect(),
+        ];
+        for bytes in cases {
+            drain(CompressedTokenDecoder::new(), &bytes);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds input-space robustness tests proving the highest-risk wire-protocol
decoders never panic, read out of bounds, over-allocate, or spin on arbitrary
or adversarial attacker-controlled bytes. A Rust panic on hostile wire input is
a denial-of-service; upstream rsync has shipped this exact class of bug
(out-of-bounds reads and integer overflows in the file-list and compressed-token
paths). These are property-based sweeps on the pinned stable toolchain (proptest,
no nightly/fuzzer), with targeted adversarial unit cases alongside.

## Decoders now covered

- **File-list entry decoder** (`FileListReader::read_entry` + the sans-io
  `read_entry_step` seam), `crates/protocol`. Arbitrary-byte sweep across all
  supported protocol versions (28-32) through both decode paths, plus crafted
  cases: oversize `XMIT_LONG_NAME` suffix length (near `i32::MAX`), negative
  wire length, every strict truncation of a valid entry, and hostile leading
  flag bytes. Maps the crafted-flist DoS class (CVE-2026-43620). Confirms the
  `MAXPATHLEN` / `checked_add` guards in `name.rs` reject oversize lengths
  before allocating rather than OOM-ing.
- **Compressed-token decoder** (`CompressedTokenDecoder::recv_token`),
  `crates/protocol`. Broad arbitrary-byte sweep over zlib, zlibx, and (feature-
  gated) zstd and lz4, complementing the existing crafted integer-overflow
  regressions already inline in the token module. Maps the token integer-
  overflow DoS class (CVE-2026-43618). The drain asserts the decoder never emits
  a token run without making input progress (a true spin), distinct from the
  bounded run amplification described below.
- **Proxy CONNECT response-line decoder** (`read_proxy_line`), `crates/core`.
  Arbitrary-byte fuzz over a loopback socket at the exact upstream boundaries
  (1023 / 1024 / 4096 bytes, newline-free) plus a deterministic random corpus
  with embedded control, NUL, CR, and high bytes. Maps the proxy-line-length DoS
  class (CVE-2026-45232). Asserts the `MAX_PROXY_LINE_BYTES` cap holds and the
  buffer never grows past it.

The multiplex frame decoder, the varint/int helpers, and the individual
file-list field decoders already have arbitrary-byte panic-freedom coverage in
this crate; this change fills the remaining gaps (whole-entry flist decode, a
broad `recv_token` sweep, and arbitrary-byte proxy-line fuzz) without
duplicating them.

## Result: all decoders survive arbitrary input

No panic, out-of-bounds read, unbounded allocation, or infinite loop was found
in any covered decoder. The file-list entry decoder was exercised over ~327k
decodes (16384 cases x 5 versions x 2 paths) with zero panics.

### Note on a false positive that the sweep surfaced (not a bug)

An early iteration of the token sweep flagged an 18-byte input as a suspected
non-terminating decode. Root cause: `0xC0` is `TOKENRUN_REL` (upstream
`token.c`), which carries a 16-bit run count, so three bytes legitimately
schedule up to 65535 `BlockMatch` tokens; six such runs emit ~262k tokens and
then the decoder correctly returns `Err` at end of input. This is bounded,
upstream-faithful behaviour, not a spin. The test was refined to assert the
precise property - no token run emitted without advancing the reader - which
distinguishes a genuine infinite loop from legitimate run amplification.

## Verification

- `cargo nextest run -p protocol --all-features -E 'binary(decoder_robustness)'` - 12 passed
- `cargo nextest run -p core -E 'test(read_proxy_line) or test(proxy_line)'` - 4 passed
- Heavier sweeps: flist at 16384 cases, tokens at 2048 cases - all green
- `cargo fmt --all -- --check` clean
- `cargo clippy -p protocol -p core --all-targets --all-features --no-deps -- -D warnings` clean
