### PR TITLE
fix: emit remote receiver deletion line once under -vi

### DIFF
--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -64,25 +64,23 @@ fn emit_delete_notification<W: crate::writer::MsgInfoSender + ?Sized>(
             return;
         }
     }
-    // upstream: log.c:872-874 - a local/client receiver renders "deleting %n"
-    // directly; %n (log.c:633-641) appends a trailing slash for a directory.
-    if is_dir {
-        info_log!(Del, 1, "deleting {}/", rel.display());
-    } else {
-        info_log!(Del, 1, "deleting {}", rel.display());
-    }
+    // upstream: log.c:868-874 - a local/client receiver renders exactly ONE
+    // FCLIENT line via log_formatted(): the itemized "%i %n" form when
+    // --itemize-changes is active (stdout_format_has_o_or_i), otherwise the
+    // plain "deleting %n". The two forms are mutually exclusive, never both.
+    // `%n` (log.c:633-641) appends a trailing slash for a directory, so both
+    // forms carry the same slash.
     if emit_itemize {
-        // upstream: log.c:log_delete() emits the "*deleting" itemize row when
-        // --itemize-changes is active. The name is rendered through `%n`
-        // (log.c:633-641), which appends a trailing slash for a directory, so
-        // the itemize row carries the same slash the plain "deleting %n" line
-        // above does.
         let line = if is_dir {
             format!("*deleting   {}/\n", rel.display())
         } else {
             format!("*deleting   {}\n", rel.display())
         };
         let _ = writer.send_msg_info(line.as_bytes());
+    } else if is_dir {
+        info_log!(Del, 1, "deleting {}/", rel.display());
+    } else {
+        info_log!(Del, 1, "deleting {}", rel.display());
     }
 }
 
@@ -1806,6 +1804,40 @@ mod emit_notification_tests {
                 b"*deleting   stale.txt\n".to_vec(),
                 b"*deleting   stale_dir/\n".to_vec(),
             ],
+        );
+    }
+
+    /// A client receiver under `-i` renders the itemized `*deleting` row ONLY;
+    /// it must NOT also emit the plain `deleting %n` Del line. Upstream
+    /// `log.c:868-874` picks one FCLIENT format
+    /// (`stdout_format_has_o_or_i ? stdout_format : "deleting %n"`) and calls
+    /// `log_formatted()` once, never both. Regression for the remote-pull
+    /// double-log where each deletion printed as both `*deleting NAME` and
+    /// `deleting NAME` under `-vi` (delayed `--delete-delay`/`--delete-after`
+    /// and immediate paths share this emitter).
+    #[test]
+    fn itemize_suppresses_plain_deleting_line() {
+        let mut cfg = VerbosityConfig::default();
+        cfg.info.del = 1;
+        init(cfg);
+        let _ = drain_events();
+
+        let mut w = RecordingWriter::default();
+        // Client receiver, itemize active, at -v (Del level 1): the plain line
+        // would fire if not suppressed by the itemize branch.
+        emit_delete_notification(&mut w, Path::new("stale.txt"), false, false, 32, true);
+        emit_delete_notification(&mut w, Path::new("stale_dir"), true, false, 32, true);
+
+        assert_eq!(
+            w.info,
+            vec![
+                b"*deleting   stale.txt\n".to_vec(),
+                b"*deleting   stale_dir/\n".to_vec(),
+            ],
+        );
+        assert!(
+            del_events().is_empty(),
+            "itemize must not also emit the plain `deleting` line",
         );
     }
 


### PR DESCRIPTION
## Problem

On a remote receive (ssh and daemon) with `-vi` and any `--delete*` mode, the
receiver logged every removed entry **twice**: once as an itemized
`*deleting   NAME` row and once as a plain `deleting NAME` line. Upstream, and
oc's local-copy executor, log each removed entry exactly once. The final tree
and stats were always correct; only the deletion log was duplicated.

The duplication was most visible on `--delete-delay` / `--delete-after`, whose
deferred phase-2 sweep is the common way to exercise `-vi` deletion, but it
affected every mode that reaches the remote receiver's shared emitter,
including immediate `--delete` / `--delete-before`.

## Root cause

`crates/transfer/src/receiver/directory/deletion.rs::emit_delete_notification`
is the single emitter shared by the immediate, capped/serial, and deferred
(`--delete-delay`/`--delete-after`) paths. For a local/client receiver (a pull,
where oc is the generator/receiver) its render branch unconditionally emitted
the plain `deleting %n` line via `info_log!(Del, ...)` **and then** additionally
emitted the itemized `*deleting` row when `-i` was active.

Upstream `log_delete()` renders exactly one FCLIENT line and the two forms are
mutually exclusive:

```c
/* log.c:868-874 */
fmt = stdout_format_has_o_or_i ? stdout_format : "deleting %n";
log_formatted(FCLIENT, fmt, "del.", file, fname, ITEM_DELETED, NULL);
```

The itemized `%i %n` form (`stdout_format`) is used when `--itemize-changes`
is active, otherwise the plain `deleting %n` form - never both.

## Fix

Make the render branch emit the itemized row when `-i` is active, otherwise the
plain line - a single line per removed entry, matching upstream `log.c:868-874`.
The `server_mode` MSG_DELETED forwarding path (`log.c:866`) and the local-copy
executor are untouched. Directory trailing-slash handling and the recursive
delete ordering established earlier are preserved.

Adds a regression test asserting that an itemizing client receiver emits the
`*deleting` row only and no accompanying plain `deleting` Del line.

## Verification (Linux host vs /usr/bin/rsync 3.4.4)

Pre-seeded a destination with extraneous files, dirs (recursive), and a symlink,
then pulled `-a <mode> -vi` over **ssh** and **daemon** for
`--delete-delay`, `--delete-after`, `--delete`, and `--delete-before`. Every
combination now produces a deletion log byte-identical to upstream (same order,
same `*deleting` / trailing-slash form). Local delete and the final tree are
unchanged.

Before (oc, ssh `--delete-delay -vi`):

```
*deleting   extra1.txt
deleting extra1.txt
*deleting   extradir/nested/deep.txt
deleting extradir/nested/deep.txt
...
```

After (oc, ssh `--delete-delay -vi`) - identical to upstream:

```
*deleting   extra1.txt
*deleting   extra2.txt
*deleting   extradir/
*deleting   extradir/e.txt
*deleting   extradir/nested/
*deleting   extradir/nested/deep.txt
*deleting   extralink
```

`cargo fmt --all -- --check` and `cargo clippy -p transfer -D warnings` are
clean; targeted deletion/itemize test suites pass.
