### PR TITLE
fix: sender-side --stats breakdown and -v names on push

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -90,6 +90,12 @@ pub(super) fn convert_server_stats_to_summary(
                 generator_stats.matched_data,
                 generator_stats.delete_stats,
                 generator_stats.created_stats,
+                engine::local_copy::FileTypeTotals {
+                    dirs: generator_stats.num_dirs,
+                    symlinks: generator_stats.num_symlinks,
+                    devices: generator_stats.num_devices,
+                    specials: generator_stats.num_specials,
+                },
             );
             (s, generator_stats.io_error, 0u32)
         }

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -185,7 +185,10 @@ pub(crate) fn run_push_transfer(
     // pre-rendered MSG_INFO line (see receiver::emit_itemize). This restores
     // output for oc-client -> upstream-daemon pushes, where upstream never
     // forwards oc's itemize.
-    let wants_itemize = config.itemize_changes();
+    // upstream: sender.c:449 - plain `-v` (no `-i`) prints the bare `%n%L` name
+    // per file too, so the callback must be wired whenever the sender has any
+    // client-visible per-file output, not only under `-i`.
+    let wants_client_output = config.itemize_changes() || config.verbosity() >= 1;
     let stdout_handle = std::io::stdout();
     let mut itemize_cb = move |line: &str| {
         let mut out = stdout_handle.lock();
@@ -199,7 +202,7 @@ pub(crate) fn run_push_transfer(
         writer,
         progress,
         batch_recording,
-        if wants_itemize {
+        if wants_client_output {
             Some(&mut itemize_cb as &mut dyn crate::server::ItemizeCallback)
         } else {
             None

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -376,14 +376,16 @@ fn run_server_over_ssh_connection(
     }
     let negotiated_protocol = handshake.protocol.as_u8();
 
-    // upstream: sender.c:461 log_item(FCLIENT) - on an SSH push the local side
-    // is the sender (ServerRole::Generator) and prints the client-visible
-    // itemize row from the iflags the remote receiver's generator writes over
-    // the wire (generator.c:583-599). The remote generator never forwards the
-    // row itself (log.c:822 gates FCLIENT on `!am_server`). On a pull the local
-    // side is the receiver, which itemizes to its own stdout via
-    // receiver::emit_itemize, so no sender callback is needed there.
-    let wants_itemize = config.role == ServerRole::Generator && config.flags.info_flags.itemize;
+    // upstream: sender.c:449-461 log_item(FCLIENT) - on an SSH push the local
+    // side is the sender (ServerRole::Generator) and prints each file's
+    // client-visible line to its own stdout: the `-i` itemize row (built from
+    // the iflags the remote receiver's generator writes over the wire,
+    // generator.c:583-599) or, under plain `-v`, the bare `%n%L` name. The
+    // remote generator never forwards either itself (log.c:822 gates FCLIENT on
+    // `!am_server`). On a pull the local side is the receiver, which prints via
+    // receiver::emit_itemize / emit_name, so no sender callback is needed there.
+    let wants_client_output = config.role == ServerRole::Generator
+        && (config.flags.info_flags.itemize || config.flags.verbose);
     let stdout_handle = std::io::stdout();
     let mut itemize_cb = move |line: &str| {
         let mut out = stdout_handle.lock();
@@ -397,7 +399,7 @@ fn run_server_over_ssh_connection(
         &mut writer,
         progress,
         batch_recording,
-        if wants_itemize {
+        if wants_client_output {
             Some(&mut itemize_cb as &mut dyn crate::server::ItemizeCallback)
         } else {
             None

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -65,6 +65,12 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
                 generator_stats.matched_data,
                 generator_stats.delete_stats,
                 generator_stats.created_stats,
+                engine::local_copy::FileTypeTotals {
+                    dirs: generator_stats.num_dirs,
+                    symlinks: generator_stats.num_symlinks,
+                    devices: generator_stats.num_devices,
+                    specials: generator_stats.num_specials,
+                },
             );
             (s, generator_stats.io_error, 0u32)
         }

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -619,9 +619,25 @@ impl LocalCopySummary {
         matched_data: u64,
         delete_stats: protocol::DeleteStats,
         created_stats: protocol::CreatedStats,
+        file_type_totals: FileTypeTotals,
     ) -> Self {
+        // upstream: main.c:387-411 output_itemized_counts() - "Number of files"
+        // reports the total plus a per-type breakdown where reg is the
+        // remainder. The sender tallies the typed counts in send_file_entry()
+        // (flist.c:421-438); reg is derived here so a push prints the same
+        // `reg: R, dir: D, link: L` line as a local copy instead of counting
+        // every entry as a regular file.
+        let non_regular = file_type_totals
+            .dirs
+            .saturating_add(file_type_totals.symlinks)
+            .saturating_add(file_type_totals.devices)
+            .saturating_add(file_type_totals.specials);
         Self {
-            regular_files_total: files_listed as u64,
+            regular_files_total: (files_listed as u64).saturating_sub(non_regular),
+            directories_total: file_type_totals.dirs,
+            symlinks_total: file_type_totals.symlinks,
+            devices_total: file_type_totals.devices,
+            fifos_total: file_type_totals.specials,
             files_copied: files_transferred as u64,
             // upstream: sender.c:343 stats.total_transferred_size, computed
             // locally by the pushing client's sender (never sent on the wire).
@@ -986,6 +1002,7 @@ mod tests {
             0,
             delete_stats,
             protocol::CreatedStats::new(),
+            FileTypeTotals::default(),
         );
         assert_eq!(summary.items_deleted(), 7);
         // reg is derived as total - (dir+link+dev+special), mirroring upstream
@@ -1092,6 +1109,7 @@ mod tests {
             0,
             protocol::DeleteStats::new(),
             created_stats,
+            FileTypeTotals::default(),
         );
         // reg = 4 - (1 dir + 1 link) = 2.
         assert_eq!(summary.created_regular_files(), 2);
@@ -1099,6 +1117,45 @@ mod tests {
         assert_eq!(summary.created_symlinks(), 1);
         assert_eq!(summary.created_devices(), 0);
         assert_eq!(summary.created_specials(), 0);
+    }
+
+    /// The push twin of [`from_receiver_stats_derives_file_type_breakdown`]: a
+    /// client sender reconstructs the `--stats` "Number of files" breakdown from
+    /// the per-type tallies its `send_file_entry()` loop accumulated, deriving
+    /// `reg` as the remainder. Before the fix the sender threaded no per-type
+    /// data, so every entry was reported as `reg` (`Number of files: 6 (reg:
+    /// 6)` instead of `(reg: 3, dir: 2, link: 1)`).
+    ///
+    /// upstream: flist.c:421-438 per-type tally; main.c:387-411 derives `reg`.
+    #[test]
+    fn from_generator_stats_derives_file_type_breakdown() {
+        let summary = LocalCopySummary::from_generator_stats(
+            6,
+            3,
+            15,
+            0,
+            91,
+            20,
+            Duration::from_secs(1),
+            0,
+            0,
+            protocol::DeleteStats::new(),
+            protocol::CreatedStats::new(),
+            FileTypeTotals {
+                dirs: 2,
+                symlinks: 1,
+                devices: 0,
+                specials: 0,
+            },
+        );
+        // reg = 6 - (2 + 1) = 3; the typed totals feed the reg/dir/link line.
+        assert_eq!(summary.regular_files_total(), 3);
+        assert_eq!(summary.directories_total(), 2);
+        assert_eq!(summary.symlinks_total(), 1);
+        assert_eq!(summary.devices_total(), 0);
+        assert_eq!(summary.fifos_total(), 0);
+        // "Total file size" comes straight from the sender-accumulated total.
+        assert_eq!(summary.total_source_bytes(), 20);
     }
 
     #[test]
@@ -1115,6 +1172,7 @@ mod tests {
             202_000,
             protocol::DeleteStats::new(),
             protocol::CreatedStats::new(),
+            FileTypeTotals::default(),
         );
         assert_eq!(summary.regular_files_total(), 200);
         assert_eq!(summary.files_copied(), 75);

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -120,6 +120,12 @@ pub struct GeneratorContext {
     /// Accumulated deletion statistics received via NDX_DEL_STATS messages.
     /// (upstream: main.c:238-247 `read_del_stats()`)
     pub(crate) delete_stats: DeleteStats,
+    /// Per-type file-list tallies and `total_size`, accumulated as each entry
+    /// is written to the wire (upstream: `send_file_entry()`, flist.c:421-438,
+    /// 690-691). Feeds the `--stats` "Number of files" breakdown and the real
+    /// "Total file size" on a push; accumulated at send time because
+    /// INC_RECURSE drains sent segments from `file_list`.
+    pub(crate) flist_send_stats: super::FlistSendStats,
     /// Per-operation thresholds for switching between sequential and parallel execution.
     ///
     /// Different operations have different overhead profiles: CPU-bound signature
@@ -177,6 +183,7 @@ impl GeneratorContext {
             pending_source_removals: super::pending_removal::PendingSourceRemovals::default(),
             incremental: IncrementalState::new(initial_ndx_start),
             delete_stats: DeleteStats::new(),
+            flist_send_stats: super::FlistSendStats::default(),
             parallel_thresholds: crate::parallel_io::ParallelThresholds::default(),
             pipeline,
         }

--- a/crates/transfer/src/generator/itemize.rs
+++ b/crates/transfer/src/generator/itemize.rs
@@ -233,12 +233,36 @@ pub(crate) fn format_itemize_line(
     ctx: &ItemizeContext,
     xname: Option<&[u8]>,
 ) -> String {
-    use std::fmt::Write;
-
     // Pre-allocate: 11 (iflags) + 1 (space) + ~32 (path estimate) + 1 (newline)
     let mut buf = String::with_capacity(48);
     write_iflags_into(&mut buf, iflags, entry, is_sender, ctx);
     buf.push(' ');
+    buf.push_str(&format_name_line(entry, xname, iflags));
+    buf
+}
+
+/// Renders the upstream `%n%L` name field for a file-list entry, terminated by
+/// a newline: the relative path, a trailing `/` for directories, and the `%L`
+/// suffix (` => <hlink>` for a hard-link leader, else ` -> <target>` for a
+/// symlink).
+///
+/// Shared by the `-i` itemize row (`%i %n%L`, [`format_itemize_line`]) and the
+/// plain-`-v` name line the client sender prints via `log_item(FCLIENT)` with
+/// the default `stdout_format = "%n%L"`.
+///
+/// # Upstream Reference
+///
+/// - `log.c:627-636` - `%n` expansion (path, trailing `/` for directories).
+/// - `log.c:643-655` - `%L` expansion (` => hlink` wins over ` -> target`).
+/// - `options.c:2372` - `stdout_format = "%n%L"` for plain `-v` (no `-i`).
+pub(crate) fn format_name_line(
+    entry: &FileEntry,
+    xname: Option<&[u8]>,
+    iflags: &ItemFlags,
+) -> String {
+    use std::fmt::Write;
+
+    let mut buf = String::with_capacity(40);
 
     // upstream: log.c:627-636 - %n expansion
     let path = entry.path();

--- a/crates/transfer/src/generator/itemize.rs
+++ b/crates/transfer/src/generator/itemize.rs
@@ -745,4 +745,40 @@ mod tests {
         assert!(ctx.preserve_mtimes);
         assert!(ctx.receiver_symlink_times);
     }
+
+    /// The plain-`-v` name line (`%n%L`): a bare path for a regular file, a
+    /// trailing `/` for a directory, and a ` -> target` arrow for a symlink -
+    /// matching what upstream's `log_item(FCLIENT)` prints on a push.
+    ///
+    /// upstream: log.c:627-636 (%n, dir slash), log.c:643-655 (%L arrow).
+    #[test]
+    fn name_line_renders_dir_slash_and_symlink_arrow() {
+        let none = ItemFlags::from_raw(0);
+        assert_eq!(
+            format_name_line(&make_file_entry("a.txt"), None, &none),
+            "a.txt\n"
+        );
+        assert_eq!(
+            format_name_line(&make_dir_entry("sub"), None, &none),
+            "sub/\n"
+        );
+        assert_eq!(
+            format_name_line(&make_symlink_entry("l1"), None, &none),
+            "l1 -> target\n"
+        );
+    }
+
+    /// `%L`'s ` => <hlink>` form wins over the symlink arrow when the entry
+    /// carries a non-empty alternate-basis name (`ITEM_XNAME_FOLLOWS`).
+    ///
+    /// upstream: log.c:643-655 - the `if (hlink && *hlink)` branch precedes the
+    /// symlink case.
+    #[test]
+    fn name_line_hardlink_suffix_wins() {
+        let hl = ItemFlags::from_raw(ItemFlags::ITEM_XNAME_FOLLOWS);
+        assert_eq!(
+            format_name_line(&make_file_entry("dup"), Some(b"leader"), &hl),
+            "dup => leader\n"
+        );
+    }
 }

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -111,7 +111,7 @@ pub use self::stats::GeneratorStats;
 // through `super::*` (matches the pre-decomposition import surface).
 pub(crate) use self::diagnostics::{flush_with_count, record_prepare_acl, record_segment_dispatch};
 pub(crate) use self::segments::{DirSegment, PendingSegment, SegmentScheduler, TaggedIndex};
-pub(crate) use self::stats::{TransferLoopResult, is_early_close_error};
+pub(crate) use self::stats::{FlistSendStats, TransferLoopResult, is_early_close_error};
 
 #[cfg(test)]
 pub(crate) use self::diagnostics::partition_point_depth;

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -493,6 +493,78 @@ impl GeneratorContext {
         }
     }
 
+    /// Emits the client-visible per-file line for entry `ndx`: the `-i` itemize
+    /// row (via [`Self::maybe_emit_itemize`]) and/or the plain-`-v` name line
+    /// (via [`Self::maybe_emit_name`]). The two are mutually exclusive - under
+    /// `-i` the itemize row carries `%n%L` and the bare-name path early-returns,
+    /// so calling both is safe and keeps one call site per transfer stage.
+    ///
+    /// `is_transfer` marks a data-transfer item, which is always named under
+    /// `-v`; a non-transfer item (dir, symlink, unchanged) is named only when it
+    /// carries significant iflags.
+    pub(super) fn emit_client_item<W: Write>(
+        &self,
+        writer: &mut super::super::writer::ServerWriter<W>,
+        iflags: &super::item_flags::ItemFlags,
+        ndx: usize,
+        xname: Option<&[u8]>,
+        itemize_cb: &mut Option<&mut dyn super::super::ItemizeCallback>,
+        is_transfer: bool,
+    ) -> io::Result<()> {
+        self.maybe_emit_itemize(writer, iflags, ndx, xname, itemize_cb)?;
+        self.maybe_emit_name(iflags, ndx, xname, itemize_cb, is_transfer)
+    }
+
+    /// Emits a plain-`-v` name line for entry `ndx` to the client's stdout,
+    /// mirroring upstream `log_item(FCLIENT, ...)` with the default
+    /// `stdout_format = "%n%L"`.
+    ///
+    /// A no-op unless the local side is the client (`!am_server`), `-v` is on,
+    /// and `-i` is off (under `-i` the itemize row already carries the name).
+    /// Non-transfer items are named only when significant, matching upstream's
+    /// `maybe_log_item` gate.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:449-461` - `log_item(FCLIENT, ...)` prints each file's name.
+    /// - `log.c:818-843` - `log_item()` renders via `stdout_format`;
+    ///   `maybe_log_item()` gates non-transfer items on significant iflags.
+    /// - `options.c:2372` - plain `-v` sets `stdout_format = "%n%L"`.
+    pub(super) fn maybe_emit_name(
+        &self,
+        iflags: &super::item_flags::ItemFlags,
+        ndx: usize,
+        xname: Option<&[u8]>,
+        itemize_cb: &mut Option<&mut dyn super::super::ItemizeCallback>,
+        is_transfer: bool,
+    ) -> io::Result<()> {
+        // Under `-i` the itemize row already carries `%n%L`; only plain `-v`
+        // (no `-i`) prints a bare name here.
+        if self.config.flags.info_flags.itemize || !self.config.flags.verbose {
+            return Ok(());
+        }
+        // upstream: log.c:822 - rwrite() forwards FCLIENT to stdout only when
+        // !am_server. A server-sender's names are owned by the peer receiver.
+        if !self.config.connection.client_mode {
+            return Ok(());
+        }
+        // upstream: log.c:828-843 maybe_log_item - a non-transfer item is named
+        // only when it carries significant iflags (a new/changed dir, symlink,
+        // device, or special); a data-transfer item is always named.
+        if !is_transfer && !iflags.has_significant_flags() {
+            return Ok(());
+        }
+        if ndx >= self.file_list.len() {
+            return Ok(());
+        }
+        let entry = &self.file_list[ndx];
+        let line = super::itemize::format_name_line(entry, xname, iflags);
+        if let Some(cb) = itemize_cb.as_mut() {
+            cb.on_itemize(&line);
+        }
+        Ok(())
+    }
+
     /// Sends the file list to the receiver.
     ///
     /// Encodes file entries using the configured `FileListWriter`, writes them to
@@ -542,6 +614,9 @@ impl GeneratorContext {
             let entry = &self.file_list[i];
             self.prepare_pending_acl(entry, i, &mut flist_writer);
             flist_writer.write_entry(&mut probed, entry)?;
+            // upstream: flist.c:421-438,690-691 - send_file_entry() tallies the
+            // per-type counts and total_size as each entry is written.
+            self.flist_send_stats.record(entry);
         }
 
         // upstream: flist.c:2518 - write io_error with end marker (SAFE_FILE_LIST)
@@ -677,6 +752,9 @@ impl GeneratorContext {
             let entry = &self.file_list[i];
             self.prepare_pending_acl(entry, i, flist_writer);
             flist_writer.write_entry(writer, entry)?;
+            // upstream: flist.c:421-438,690-691 - send_file_entry() tallies the
+            // per-type counts and total_size as each entry is written.
+            self.flist_send_stats.record(entry);
         }
 
         // End-of-flist marker (zero byte).

--- a/crates/transfer/src/generator/stats.rs
+++ b/crates/transfer/src/generator/stats.rs
@@ -8,7 +8,69 @@
 use std::time::Duration;
 
 use protocol::codec::{MonotonicNdxWriter, NdxCodecEnum};
+use protocol::flist::FileEntry;
 use protocol::stats::{CreatedStats, DeleteStats};
+
+/// Per-type file-list tallies accumulated as the sender writes each entry to
+/// the wire, mirroring upstream's `send_file_entry()` counting.
+///
+/// Directories, symlinks, devices, and specials are counted per type; the
+/// regular-file count is the remainder and is never stored here (the summary
+/// derives it). `total_size` sums `F_LENGTH` for regular files and symlinks
+/// only, exactly as upstream guards the accumulation. Counting at send time -
+/// rather than summing the flat `file_list` at the end - is required because
+/// INC_RECURSE drains sent segments, leaving only the final sub-list in
+/// `file_list` when the transfer completes.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:421-438` - `send_file_entry()` bumps `stats.num_dirs` /
+///   `num_symlinks` / `num_devices` / `num_specials` per entry.
+/// - `flist.c:690-691` - `stats.total_size += F_LENGTH(file)` guarded by
+///   `S_ISREG(mode) || S_ISLNK(mode)`.
+/// - `main.c:387-411` - `output_itemized_counts()` derives `reg` as the total
+///   minus the four typed categories.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct FlistSendStats {
+    /// Directories sent (upstream `stats.num_dirs`).
+    pub(crate) num_dirs: u64,
+    /// Symbolic links sent (upstream `stats.num_symlinks`).
+    pub(crate) num_symlinks: u64,
+    /// Device nodes, block and character, sent (upstream `stats.num_devices`).
+    pub(crate) num_devices: u64,
+    /// FIFOs and sockets sent (upstream `stats.num_specials`).
+    pub(crate) num_specials: u64,
+    /// Summed `F_LENGTH` for regular files and symlinks (upstream
+    /// `stats.total_size`); directories, devices, and specials contribute 0.
+    pub(crate) total_size: u64,
+}
+
+impl FlistSendStats {
+    /// Classifies one file-list entry as it is written to the wire and updates
+    /// the running per-type counts and `total_size`, mirroring the counting in
+    /// upstream `send_file_entry()`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:421-438` - per-type tally.
+    /// - `flist.c:690-691` - `total_size` for regular files and symlinks only.
+    pub(crate) fn record(&mut self, entry: &FileEntry) {
+        if entry.is_dir() {
+            self.num_dirs += 1;
+        } else if entry.is_symlink() {
+            self.num_symlinks += 1;
+            self.total_size = self.total_size.saturating_add(entry.size());
+        } else if entry.is_device() {
+            self.num_devices += 1;
+        } else if entry.is_special() {
+            self.num_specials += 1;
+        } else {
+            // Regular file (upstream: S_ISREG - the only remaining type that
+            // contributes to total_size).
+            self.total_size = self.total_size.saturating_add(entry.size());
+        }
+    }
+}
 
 /// Result from the transfer loop phase of the generator.
 ///
@@ -58,6 +120,21 @@ pub(crate) struct TransferLoopResult {
 pub struct GeneratorStats {
     /// Number of files in the sent file list.
     pub files_listed: usize,
+    /// Directories in the sent file list (upstream `stats.num_dirs`).
+    ///
+    /// Per-type tallies accumulated as each entry is written to the wire so the
+    /// pushing client can reconstruct the `--stats` "Number of files"
+    /// breakdown (`reg: R, dir: D, link: L, dev: V, special: S`), where `reg`
+    /// is the remainder. Mirrors upstream `send_file_entry()`
+    /// (flist.c:421-438); the receiver-side equivalent lives on `TransferStats`.
+    pub num_dirs: u64,
+    /// Symbolic links in the sent file list (upstream `stats.num_symlinks`).
+    pub num_symlinks: u64,
+    /// Device nodes, block and character, in the sent file list
+    /// (upstream `stats.num_devices`).
+    pub num_devices: u64,
+    /// FIFOs and sockets in the sent file list (upstream `stats.num_specials`).
+    pub num_specials: u64,
     /// Number of files actually transferred (delta or whole-file).
     pub files_transferred: usize,
     /// Summed length of every transferred file (upstream: `total_transferred_size`).

--- a/crates/transfer/src/generator/stats.rs
+++ b/crates/transfer/src/generator/stats.rs
@@ -214,3 +214,38 @@ pub(crate) fn is_early_close_error(e: &std::io::Error) -> bool {
             | std::io::ErrorKind::ConnectionAborted
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// `FlistSendStats::record` classifies each sent entry into the per-type
+    /// tally and adds `F_LENGTH` to `total_size` for regular files and symlinks
+    /// only, mirroring upstream `send_file_entry()` (flist.c:421-438, 690-691).
+    /// A directory and a FIFO must not inflate `total_size`, and a symlink's
+    /// target length must be counted (the sender flist stores the target length
+    /// as the entry size).
+    #[test]
+    fn flist_send_stats_classifies_per_type_and_total_size() {
+        let mut s = FlistSendStats::default();
+        s.record(&FileEntry::new_file(PathBuf::from("a"), 6, 0o644));
+        s.record(&FileEntry::new_file(PathBuf::from("b"), 7, 0o644));
+        s.record(&FileEntry::new_directory(PathBuf::from("d"), 0o755));
+        // The wire flist stores a symlink's size as its target string length;
+        // set it explicitly so the test reflects the on-wire entry.
+        let mut link = FileEntry::new_symlink(PathBuf::from("l"), PathBuf::from("abc"));
+        link.set_size(3);
+        s.record(&link);
+        s.record(&FileEntry::new_fifo(PathBuf::from("f"), 0o644));
+        s.record(&FileEntry::new_char_device(PathBuf::from("c"), 0o644, 1, 3));
+
+        assert_eq!(s.num_dirs, 1);
+        assert_eq!(s.num_symlinks, 1);
+        assert_eq!(s.num_specials, 1);
+        assert_eq!(s.num_devices, 1);
+        // total_size = reg (6 + 7) + symlink target len (3); dir, fifo, and
+        // device contribute 0.
+        assert_eq!(s.total_size, 16);
+    }
+}

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -314,19 +314,28 @@ impl GeneratorContext {
             self.add_io_error(super::super::io_error_flags::IOERR_GENERAL);
         }
 
-        // upstream: handle_stats() reports stats.total_size, the sum of all
-        // flist file sizes (main.c:351 write_varlong30(f, stats.total_size, 3)).
-        let total_size = self.file_list.iter().map(|e| e.size()).sum();
+        // upstream: handle_stats() reports stats.total_size (main.c:351
+        // write_varlong30(f, stats.total_size, 3)), accumulated in
+        // send_file_entry() as `F_LENGTH(file)` for regular files and symlinks
+        // only (flist.c:690-691). Read the value tallied at send time - summing
+        // `self.file_list` here is wrong because INC_RECURSE drains sent
+        // segments, leaving only the final sub-list, and would also count
+        // directory sizes that upstream excludes.
+        let flist_send_stats = self.flist_send_stats;
 
         Ok(GeneratorStats {
             files_listed: file_count,
+            num_dirs: flist_send_stats.num_dirs,
+            num_symlinks: flist_send_stats.num_symlinks,
+            num_devices: flist_send_stats.num_devices,
+            num_specials: flist_send_stats.num_specials,
             files_transferred: transfer_result.files_transferred,
             transferred_file_size: transfer_result.transferred_file_size,
             bytes_sent: transfer_result.bytes_sent,
             bytes_read: self.timing.total_bytes_read,
             matched_data: transfer_result.matched_data,
             literal_data: transfer_result.literal_data,
-            total_size,
+            total_size: flist_send_stats.total_size,
             flist_buildtime_ms: flist_buildtime,
             flist_xfertime_ms: flist_xfertime,
             flist_first_byte_latency: self.timing.flist_first_byte_latency,

--- a/crates/transfer/src/generator/transfer/stats.rs
+++ b/crates/transfer/src/generator/transfer/stats.rs
@@ -31,8 +31,12 @@ impl GeneratorContext {
         flist_buildtime_ms: u64,
         flist_xfertime_ms: u64,
     ) -> io::Result<()> {
-        // upstream: stats.total_size is the sum of all file sizes in the transfer
-        let total_size: u64 = self.file_list.iter().map(|e| e.size()).sum();
+        // upstream: flist.c:690-691 - stats.total_size accumulates F_LENGTH for
+        // regular files and symlinks only, tallied in send_file_entry() as each
+        // entry is written. Read that running total rather than summing
+        // `self.file_list` (which INC_RECURSE has drained down to the final
+        // sub-list, and which would also count directory sizes upstream omits).
+        let total_size: u64 = self.flist_send_stats.total_size;
 
         let stats = TransferStats::with_bytes(
             self.timing.total_bytes_read,

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -437,7 +437,7 @@ impl GeneratorContext {
                 // so the receiver can pair the response with its outstanding
                 // request and apply xattr-only updates. Without this echo the
                 // wire stream stalls when ITEM_REPORT_XATTR is the only delta.
-                self.maybe_emit_itemize(writer, &iflags, ndx, xname.as_deref(), itemize)?;
+                self.emit_client_item(writer, &iflags, ndx, xname.as_deref(), itemize, false)?;
                 self.write_ndx_iflags_and_xattr_response(
                     &mut *writer,
                     &mut ndx_write_codec,
@@ -495,11 +495,10 @@ impl GeneratorContext {
                 if iflags.raw() & ItemFlags::ITEM_IS_NEW != 0 {
                     created_stats.record(file_entry.mode());
                 }
-                // upstream: sender.c:395 - log_item(FCLIENT, file, iflags, NULL)
-                if let Some(cb) = itemize {
-                    let name = file_entry.path().to_string_lossy();
-                    cb.on_itemize(&format!("{name}\n"));
-                }
+                // upstream: sender.c:341-344 - a dry run logs the transfer item
+                // via log_item(FCLIENT) without sending data: the `-i` itemize
+                // row or, under plain `-v`, the bare `%n%L` name line.
+                self.emit_client_item(writer, &iflags, ndx, xname.as_deref(), itemize, true)?;
                 files_transferred += 1;
                 transferred_file_size += file_entry.size();
                 flush_with_count(writer)?;
@@ -880,7 +879,7 @@ impl GeneratorContext {
             debug_log!(Send, 1, "sender finished {}", file_entry.path().display());
 
             // upstream: sender.c:430 - log_item(log_code, file, iflags, xname)
-            self.maybe_emit_itemize(writer, &iflags, ndx, xname.as_deref(), itemize)?;
+            self.emit_client_item(writer, &iflags, ndx, xname.as_deref(), itemize, true)?;
 
             if let Some(cb) = progress.as_mut() {
                 // upstream: progress.c:80 - "to" once the final sub-list has been


### PR DESCRIPTION
## Problem

Two drop-in output-fidelity gaps appear only on a verbose/`--stats` **push** (local -> remote, over both an ssh subprocess and a writable `rsync://` daemon module). Local copies and pulls are correct; only the sender/generator path is wrong.

1. **No per-file NAME lines under `-v`.** Upstream prints each transferred entry's name on the client's stdout (`a.txt`, `sub/`, `link1 -> a.txt`, ...). On a push oc printed nothing per file.
2. **Wrong `--stats` summary.** oc reported `Number of files: N (reg: N)` - counting every directory and symlink as a regular file - and a bogus `Total file size` that did not scale with the tree (a 6-entry and an 11-entry tree both reported a tiny, wrong byte count).

This is the sender-side mirror of the receiver fixes in #6791 (typed `--stats` breakdown) and #6793 (`-v` names) that only covered pulls.

## Root cause

The pushing client runs the generator (sender). Its per-file client output and its `--stats` accounting were never wired the way the receiver's were.

- **Names.** The sender only ever emitted a line when `--itemize-changes` (`-i`) was set; the callback that writes to the client's stdout was likewise gated on `-i` alone. Plain `-v` (no `-i`) has no itemize row, so nothing was printed. Upstream prints the bare name via `log_item(FCLIENT, ...)` with the default `stdout_format = "%n%L"` for every transferred item, and via `maybe_log_item()` for significant non-transfer items (`sender.c:449-461`, `log.c:818-843`, `options.c:2372`).
- **Typed counts.** `LocalCopySummary::from_generator_stats` hard-coded `regular_files_total = files_listed` and left the dir/link/dev/special totals at zero, so `reg` absorbed every type. Upstream tallies each type in `send_file_entry()` (`flist.c:421-438`) and derives `reg` as the remainder in `output_itemized_counts()` (`main.c:387-411`).
- **Total size.** `GeneratorStats.total_size` was computed by summing `self.file_list` sizes at the end of the transfer. Under incremental recursion (`INC_RECURSE`) the flat file list is drained as segments are sent, so only the final sub-list survived - the sum collapsed to a near-constant, and it also wrongly counted directory `st_size`. Upstream accumulates `stats.total_size += F_LENGTH(file)` in `send_file_entry()`, guarded to regular files and symlinks only (`flist.c:690-691`).

## Fix

- Add `FlistSendStats` to the generator context and accumulate the per-type counts and `total_size` (regular files + symlink target lengths) as each entry is written to the wire, in both the initial-segment and INC_RECURSE sub-list send loops - the same point upstream counts in `send_file_entry()`.
- Carry the typed counts on `GeneratorStats`; give `from_generator_stats` a `FileTypeTotals` argument and derive `reg` as the remainder, exactly like `from_receiver_stats`. Feed the accumulated `total_size` (not a post-drain sum) into the summary and the daemon-sender wire stats.
- Extract the shared `%n%L` name renderer (`format_name_line`) and emit a plain-`-v` name line from the sender on each transfer stage (non-transfer item, dry-run, and completed transfer), gated exactly as upstream gates `log_item`/`maybe_log_item`: client-mode, `-v` on, `-i` off, and non-transfer items only when they carry significant iflags. Wire the client stdout callback whenever the sender has any per-file output (`-i` **or** `-v`), for both the ssh and daemon push paths.

Local copies, pulls, and non-verbose pushes are untouched (the name path is client-mode + `-v` + not-`-i`; the summary derivation collapses to the previous values when the typed totals are zero).

## Verification (Linux host, vs `/usr/bin/rsync` 3.4.4)

`-v` push, ssh, before -> after (small tree; the 11-entry tree behaved identically):

```
before (oc):  <no per-file names>            Number of files: 6 (reg: 6)          Total file size: 2 bytes
after  (oc):  a.txt / b.txt / link1 -> a.txt / sub/ / sub/c.txt
              Number of files: 6 (reg: 3, dir: 2, link: 1)                         Total file size: 20 bytes
upstream:     a.txt / b.txt / link1 -> a.txt / sub/ / sub/c.txt
              Number of files: 6 (reg: 3, dir: 2, link: 1)                         Total file size: 20 bytes
```

Two different-size trees prove the total is no longer constant:

| tree | upstream `--stats` | oc `--stats` (after) |
|------|--------------------|----------------------|
| 6 entries  | `6 (reg: 3, dir: 2, link: 1)` / `20 bytes` | `6 (reg: 3, dir: 2, link: 1)` / `20 bytes` |
| 11 entries | `11 (reg: 5, dir: 4, link: 2)` / `42 bytes` | `11 (reg: 5, dir: 4, link: 2)` / `42 bytes` |

- **ssh push** `-a -v`: the per-file name set now matches upstream exactly for both trees.
- **daemon push** into a writable module (`oc -> upstream daemon`, isolating the sender): names and `--stats` match upstream byte-for-byte.
- **No regression:** local `--stats`, ssh pull `--stats`, and pull `-v` names unchanged; a non-verbose push writes nothing to stdout.

`cargo fmt --all -- --check`, `cargo clippy -p transfer -p engine -p core --all-features --all-targets --no-deps -- -D warnings`, and the targeted `transfer`/`engine`/`core` test sweeps all pass.

## Follow-up (separate issue, not in this change)

Pushing to an **oc** receiver (its own daemon or ssh `--server`) still drops directory and symlink names, because the oc receiver, acting as the remote generator, only forwards an `NDX + iflags` to the sender for regular-file transfers and hard-link followers - not for non-transfer items. That is a receiver-side wire gap (the sender here is already correct, as the `oc -> upstream daemon` result shows) and is tracked separately.
