### PR TITLE
fix: relocate partial-dir resume into partial dir on interrupt

### DIFF
--- a/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
+++ b/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
@@ -41,6 +41,20 @@ fn begin_msg(file_path: std::path::PathBuf, target_size: u64) -> FileMessage {
     }))
 }
 
+/// Creates a BeginMessage for an inplace write directly to `file_path`.
+fn begin_msg_inplace(file_path: std::path::PathBuf, target_size: u64) -> FileMessage {
+    FileMessage::Begin(Box::new(BeginMessage {
+        file_path,
+        target_size,
+        file_entry_index: 0,
+        checksum_verifier: None,
+        is_device_target: false,
+        is_inplace: true,
+        append_offset: 0,
+        xattr_list: None,
+    }))
+}
+
 /// Data pattern for partial content verification. Uses a repeating byte
 /// sequence so partial content can be validated as a prefix.
 fn test_data(size: usize) -> Vec<u8> {
@@ -393,6 +407,59 @@ fn parity_partial_dir_disconnect_retains_without_mtime_zero() {
         filetime::FileTime::from_unix_time(0, 0),
         "--partial-dir must NOT stamp mtime=0 on disconnect"
     );
+}
+
+// Why the receiver must never pick an inplace write for a --partial-dir resume.
+
+/// An inplace write (is_inplace == true, needs_rename == false) targets the live
+/// destination directly, and on interrupt the partial data is LEFT at the live
+/// destination name - it is never relocated into the partial dir. This is the
+/// exact data-integrity hazard the receiver's `resolve_use_inplace` avoids by
+/// keeping a `--partial-dir` resume a temp+rename transfer (see
+/// `crate::transfer_ops`): upstream's one_inplace writes to the partial file
+/// (partialptr), not the live destination (receiver.c:910,969), so the live name
+/// never holds a truncated file.
+#[test]
+fn inplace_partial_dir_would_leave_incomplete_file_at_live_dest() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let dest = dir.path().join("inplace_live.dat");
+    let partial_dir = dir.path().join(".rsync-partial-inplace");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::PartialDir(partial_dir.clone()),
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config).unwrap();
+
+    h.file_tx
+        .send(begin_msg_inplace(dest.clone(), 1024))
+        .unwrap();
+    h.file_tx.send(FileMessage::Chunk(test_data(200))).unwrap();
+    h.file_tx
+        .send(FileMessage::Abort {
+            reason: "mid-transfer interrupt".into(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    // The incomplete data is stranded at the live destination name...
+    assert!(
+        dest.exists(),
+        "inplace write leaves partial data at the live destination"
+    );
+    assert_eq!(fs::read(&dest).unwrap(), test_data(200));
+    // ...and nothing is placed in the partial dir. This is why the decision layer
+    // must route a --partial-dir resume through temp+rename instead.
+    assert!(
+        !partial_dir.join("inplace_live.dat").exists(),
+        "an inplace write never relocates into the partial dir"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
 }
 
 // Upstream parity: zero-byte transfers suppress partial retention.

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -214,6 +214,51 @@ pub struct ResponseContext<'a> {
     pub dest_dir: Option<&'a std::path::Path>,
 }
 
+/// Decides whether the receiver writes this file straight to its final
+/// destination (inplace) or reconstructs it into a temp file that is renamed on
+/// commit.
+///
+/// `--inplace` and `--append` write to the destination in place, preserving
+/// existing content (append implies inplace, and the sender only transmits the
+/// data beyond the existing length).
+///
+/// A `--partial-dir` resume is deliberately excluded. When the `I` capability is
+/// negotiated (`inplace_partial`) and the basis is the partial-dir file
+/// (`FNAMECMP_PARTIAL_DIR`), upstream's `one_inplace` (receiver.c:910) writes the
+/// reconstruction in place to the partial file itself (`partialptr`,
+/// receiver.c:969) and renames it onto the destination only once the transfer
+/// completes, so an interrupt leaves the grown partial inside the partial dir and
+/// never a truncated file at the live destination name. oc reaches the same
+/// observable end state by reconstructing from the partial-dir basis into a temp
+/// file and renaming on commit: keeping the transfer temp+rename
+/// (`needs_rename == true`) lets the disk thread relocate the in-flight temp back
+/// into the partial dir on interrupt (`retain_partial_file`'s `PartialDir` branch,
+/// cleanup.c:105-115). Taking the inplace path for the resume would instead write
+/// the reconstruction directly to the live destination and leave a full-size but
+/// incomplete file there on interrupt - a silent data-integrity hazard.
+///
+/// `--inplace`/`--append` never combine with `--partial-dir` (rejected during
+/// config validation), so the exclusion only ever suppresses the `one_inplace`
+/// case; it is defensive against the two being wired together in the future.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:855` - append mode implies inplace.
+/// - `receiver.c:910` - `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR`.
+/// - `receiver.c:969` - `fnametmp = one_inplace ? partialptr : fname`.
+/// - `cleanup.c:105-115` - `handle_partial_dir()` moves the temp into the partial dir.
+fn resolve_use_inplace(
+    inplace: bool,
+    append: bool,
+    inplace_partial: bool,
+    fnamecmp_type: Option<protocol::FnameCmpType>,
+) -> bool {
+    let write_to_destination = inplace || append;
+    let one_inplace_partial_dir =
+        inplace_partial && fnamecmp_type == Some(protocol::FnameCmpType::PartialDir);
+    write_to_destination && !one_inplace_partial_dir
+}
+
 /// Reads and validates the echoed NDX and sum_head from the sender response.
 ///
 /// Returns the file path, basis path, signature, target size, sender attributes,
@@ -252,13 +297,12 @@ fn read_response_header<R: Read>(
 
     let (file_path, basis_path, signature, target_size) = pending.into_parts();
 
-    // upstream: receiver.c:797 - one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR
-    // upstream: receiver.c:855 - append mode implies inplace (write directly to destination,
-    // preserving existing content; sender only sends data beyond the existing length)
-    let use_inplace = ctx.config.inplace
-        || ctx.config.append
-        || (ctx.config.inplace_partial
-            && sender_attrs.fnamecmp_type == Some(protocol::FnameCmpType::PartialDir));
+    let use_inplace = resolve_use_inplace(
+        ctx.config.inplace,
+        ctx.config.append,
+        ctx.config.inplace_partial,
+        sender_attrs.fnamecmp_type,
+    );
 
     // upstream: receiver.c:287-307 - in append mode, seek output fd to existing file length
     // (derived from echoed sum_head) before writing new data
@@ -309,6 +353,50 @@ struct ResponseHeader {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_use_inplace_writes_to_destination_for_inplace_and_append() {
+        // upstream: receiver.c:855 - append implies inplace; both write to the
+        // destination directly.
+        assert!(resolve_use_inplace(true, false, false, None));
+        assert!(resolve_use_inplace(false, true, false, None));
+    }
+
+    #[test]
+    fn resolve_use_inplace_temp_rename_without_inplace_flags() {
+        assert!(!resolve_use_inplace(false, false, false, None));
+        assert!(!resolve_use_inplace(
+            false,
+            false,
+            false,
+            Some(protocol::FnameCmpType::Fname)
+        ));
+    }
+
+    #[test]
+    fn resolve_use_inplace_partial_dir_resume_stays_temp_rename() {
+        // The one_inplace case (inplace_partial negotiated + partial-dir basis)
+        // must NOT take the inplace path: staying temp+rename keeps
+        // needs_rename == true so an interrupt relocates the in-flight temp into
+        // the partial dir (retain_partial_file's PartialDir branch) instead of
+        // leaving a full-size but incomplete file at the live destination name.
+        // upstream: receiver.c:910,969 write one_inplace to partialptr, never fname.
+        assert!(!resolve_use_inplace(
+            false,
+            false,
+            true,
+            Some(protocol::FnameCmpType::PartialDir)
+        ));
+        // A non-partial-dir basis with the capability negotiated (e.g. a fresh
+        // or exact-name transfer) is likewise temp+rename.
+        assert!(!resolve_use_inplace(
+            false,
+            false,
+            true,
+            Some(protocol::FnameCmpType::Fname)
+        ));
+        assert!(!resolve_use_inplace(false, false, true, None));
+    }
 
     #[test]
     fn request_config_debug() {


### PR DESCRIPTION
## Problem

Interrupting a remote `--partial-dir` **resume** mid-transfer left a full-size but
**incomplete** file at the live destination name, a silent data-integrity hazard.

Reproduce (remote pull over ssh, upstream sender), interrupting each run ~2s in:

```
oc-rsync -a --bwlimit=3m --partial --partial-dir=.rp -e ssh \
    --rsync-path=/usr/bin/rsync localhost:SRC/ DST/
```

- Run 1 (fresh, no basis) interrupted: correct - `DST/.rp/big.bin` holds the
  partial, `DST/big.bin` does not exist.
- Run 2 (resume, `.rp` basis present) interrupted: **wrong** - an incomplete
  `DST/big.bin` is written straight to the live name while `DST/.rp/big.bin`
  stays stale.

The live file looks complete to a casual `ls` but is truncated. Upstream never
leaves an incomplete file at the live destination name.

## Root cause

Upstream handles a partial-dir resume with `one_inplace`
(`receiver.c:910`: `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR`).
When `one_inplace` is set, upstream writes the reconstruction **in place to the
partial-dir file** (`receiver.c:969`: `fnametmp = one_inplace ? partialptr : fname`)
and renames it onto the destination only on success. So an interrupt leaves the
grown partial inside the partial dir, and the live destination name is never
touched until the transfer completes.

oc mapped that same negotiated case (`inplace_partial` + a `FNAMECMP_PARTIAL_DIR`
basis) to `use_inplace = true`, but its inplace writer opens the **live
destination** (`begin.file_path`), not the partial-dir file. With `is_inplace`
true the disk thread takes `needs_rename == false`, so the abort/shutdown handler
skips `retain_partial_file`'s `PartialDir` branch and the `keep_dest` guard leaves
the partially written reconstruction sitting at the live name.

## Fix

Route a `--partial-dir` resume through the receiver's normal temp+rename path
instead of an inplace write to the live destination. The reconstruction lands in
a temp file; on success it is renamed onto the destination and the `.rp` basis is
removed, and on interrupt the disk thread relocates the in-flight temp back into
the partial dir (`retain_partial_file`'s `PartialDir` branch, `cleanup.c:105-115`).
This reaches the same observable end state as upstream's `one_inplace` while
reusing the already-tested partial-dir retention machinery.

`--inplace` and `--append` still write to the destination directly (unchanged),
and they never combine with `--partial-dir` (rejected during config validation).
The decision is factored into a small `resolve_use_inplace` predicate with unit
tests; the disk-layer hazard is pinned by an added parity test.

Note oc's inplace writer already reconstructed from the `.rp` basis into a
*separate* file (the live name), so it was never actually saving the whole-file
copy that upstream's true in-place update avoids - this change only redirects that
write from the live name to a temp, with no added copy cost.

## Verification (Linux host vs `/usr/bin/rsync` 3.4.4)

State after the resume run (run 2) is interrupted:

| | live `DST/big.bin` | `DST/.rp/big.bin` |
|---|---|---|
| oc before | ~11.79 MB, incomplete | 5.86 MB (stale) |
| oc after | absent | ~11.63 MB (grown partial) |
| upstream 3.4.4 | absent | ~11.99 MB (grown partial) |

After the fix a subsequent uninterrupted resume completes and the reconstructed
file matches the source checksum, with `.rp` cleaned. Confirmed unchanged:

- Fresh (run 1) `--partial-dir` interrupt: partial in `.rp`, live absent.
- Plain `--partial` (no dir) interrupt: partial kept at the live name with
  mtime=0 (upstream behavior).
- Local `--partial-dir` interrupt: partial in `.rp`, live absent.
- Clean (non-interrupted) `--partial-dir` pull: final delivered, `.rp` cleaned.

`cargo fmt --all -- --check` and `cargo clippy -p transfer --all-targets
--all-features -- -D warnings` are clean; targeted `transfer` nextest (partial
interrupt parity + `resolve_use_inplace`) passes.

## Scope: daemon path

The incomplete-file-at-live-name hazard is specific to the ssh transport, where the
`I` capability is negotiated and a partial-dir resume engages the inplace path.
Over a daemon pull the partial-dir resume already used temp+rename (verified: an
interrupted daemon transfer leaves a temp, never a file at the live name), so this
change is a no-op there and introduces no regression.

Separately, an in-flight **daemon** transfer does not react to a single `SIGINT`
the way upstream does (the daemon peer is not in the client's process group, the
socket does not break, and the decoupled receive loop does not poll the shutdown
flag under `SA_RESTART`); a forced second `SIGINT` exits leaving a hidden temp
rather than relocating it into the partial dir. That is a pre-existing
signal-responsiveness limitation independent of this fix - it does not leave an
incomplete file at the live name - and addressing it would require broader signal
work outside the scope of this data-integrity fix.
