### PR TITLE
feat: add xtask gap-report for receiver-option propagation

### DIFF
--- a/xtask/gap_report_baseline.txt
+++ b/xtask/gap_report_baseline.txt
@@ -1,0 +1,16 @@
+# gap-report baseline - receiver-option propagation gaps
+#
+# Upstream options.c server_options() gates receiver-applied options behind
+# `if (am_sender)`, so they are never sent over the wire on a pull. The local
+# client is the receiver and must carry each such option onto its own
+# ServerConfig. Each line below is a KNOWN gap: an option whose ServerConfig
+# field is not assigned in the named receiver builder.
+#
+# `cargo xtask gap-report --check` exits non-zero when a gap appears that is
+# not listed here (a regression, or a newly added upstream option). Regenerate
+# on an upstream version bump: run `cargo xtask gap-report` and copy the
+# "Current gap set (baseline format)" block into this file.
+#
+# format: <upstream-option> <builder-id>
+--delay-updates embedded-ssh
+--list-only embedded-ssh

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -36,6 +36,9 @@ pub enum Command {
     /// Generate and package rustdoc for distribution.
     DocPackage(DocPackageArgs),
 
+    /// Report receiver-option propagation coverage vs upstream rsync.
+    GapReport(GapReportArgs),
+
     /// Validate interoperability with upstream rsync.
     Interop(InteropArgs),
 
@@ -71,6 +74,15 @@ pub enum Command {
 
     /// Validate drop-in fidelity vs upstream rsync across all client transports.
     Validate(ValidateMatrixArgs),
+}
+
+/// Arguments for the `gap-report` command.
+#[derive(Parser, Debug, Default)]
+pub struct GapReportArgs {
+    /// Compare the current gap set against the committed baseline and exit
+    /// non-zero when a new gap appears, instead of printing the report.
+    #[arg(long)]
+    pub check: bool,
 }
 
 /// Arguments for the `validate` command.
@@ -462,6 +474,7 @@ impl CommandExt for Command {
             Command::Branding(args) => args.as_task(),
             Command::Docs(args) => args.as_task(),
             Command::DocPackage(args) => args.as_task(),
+            Command::GapReport(args) => args.as_task(),
             Command::Interop(args) => args.as_task(),
             Command::ManPage => Box::new(ManPageTask),
             Command::NoBinaries => Box::new(NoBinariesTask),
@@ -502,6 +515,12 @@ impl CommandExt for DocsArgs {
 impl CommandExt for DocPackageArgs {
     fn as_task(&self) -> Box<dyn Task> {
         Box::new(DocPackageTask { open: self.open })
+    }
+}
+
+impl CommandExt for GapReportArgs {
+    fn as_task(&self) -> Box<dyn Task> {
+        Box::new(GapReportTask)
     }
 }
 
@@ -640,6 +659,23 @@ impl Task for ReadmeVersionTask {
 
     fn description(&self) -> &'static str {
         "Validate README version references"
+    }
+
+    fn explicit_duration(&self) -> Option<Duration> {
+        Some(Duration::from_secs(1))
+    }
+}
+
+/// Task for the receiver-option propagation gap report.
+struct GapReportTask;
+
+impl Task for GapReportTask {
+    fn name(&self) -> &'static str {
+        "gap-report"
+    }
+
+    fn description(&self) -> &'static str {
+        "Report receiver-option propagation coverage"
     }
 
     fn explicit_duration(&self) -> Option<Duration> {

--- a/xtask/src/commands/gap_report/catalog.rs
+++ b/xtask/src/commands/gap_report/catalog.rs
@@ -1,0 +1,379 @@
+#![deny(unsafe_code)]
+
+//! Curated catalog of upstream receiver-applied options.
+//!
+//! Upstream `options.c` `server_options()` builds the remote argv. Options
+//! wrapped in `if (am_sender)` are never sent over the wire on a pull, so the
+//! local client (which is the receiver) must apply them itself by carrying them
+//! onto its `ServerConfig`. This catalog is the single source of truth for that
+//! set: each entry records the upstream option, the `options.c` reference used
+//! to re-verify it, the `ClientConfig` getter that reads the value, and the
+//! `ServerConfig` leaf field the value should land on.
+//!
+//! Entries with no leaf field (`server_field` is `None`) are propagated by a
+//! different mechanism (wire argv, the compact flag string, or the local-copy
+//! path), or have no receiver handling yet. They are reported as `NO-FIELD` and
+//! never counted as gaps.
+//!
+//! Regenerate on an upstream version bump: diff the new `options.c`
+//! `server_options()` against this table, add any newly `am_sender`-gated
+//! option, and refresh the line references below.
+
+/// A receiver config builder that constructs a `ServerConfig` for a pull.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Builder {
+    /// External `ssh`/`rsh` transport (`ssh_transfer/server_config.rs`).
+    Ssh,
+    /// Embedded SSH (`russh`, `ssh://`) transport (`embedded_ssh_transfer.rs`).
+    EmbeddedSsh,
+    /// `rsync://` daemon transport
+    /// (`daemon_transfer/orchestration/server_config.rs`).
+    Daemon,
+}
+
+impl Builder {
+    /// Every receiver builder, in report order.
+    pub const ALL: [Builder; 3] = [Builder::Ssh, Builder::EmbeddedSsh, Builder::Daemon];
+
+    /// Stable machine identifier used in the baseline file.
+    pub const fn id(self) -> &'static str {
+        match self {
+            Builder::Ssh => "ssh",
+            Builder::EmbeddedSsh => "embedded-ssh",
+            Builder::Daemon => "daemon",
+        }
+    }
+
+    /// Workspace-relative path to the builder source file.
+    pub const fn relative_path(self) -> &'static str {
+        match self {
+            Builder::Ssh => "crates/core/src/client/remote/ssh_transfer/server_config.rs",
+            Builder::EmbeddedSsh => "crates/core/src/client/remote/embedded_ssh_transfer.rs",
+            Builder::Daemon => {
+                "crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs"
+            }
+        }
+    }
+}
+
+/// The receiver builders on which an option's `ServerConfig` field is expected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Applicability {
+    /// Every SSH and daemon receiver builder must propagate the field.
+    AllReceivers,
+    /// Daemon-only receiver concern; SSH transports do not apply it.
+    DaemonOnly,
+}
+
+impl Applicability {
+    /// Returns `true` when `builder` must propagate the option's field.
+    pub fn includes(self, builder: Builder) -> bool {
+        match self {
+            Applicability::AllReceivers => true,
+            Applicability::DaemonOnly => builder == Builder::Daemon,
+        }
+    }
+}
+
+/// One curated upstream receiver-applied option.
+#[derive(Debug, Clone, Copy)]
+pub struct OptionSpec {
+    /// Canonical upstream option token (single word, e.g. `--list-only`).
+    pub upstream_name: &'static str,
+    /// `options.c` reference used to re-verify the `am_sender` gating.
+    pub options_c: &'static str,
+    /// `ClientConfig` getter that reads the value (documentation only).
+    pub getter: &'static str,
+    /// `ServerConfig` leaf field the value lands on, or `None` when the option
+    /// is propagated by another mechanism or not yet handled.
+    pub server_field: Option<&'static str>,
+    /// Builders on which the leaf field is expected (unused when no field).
+    pub applicability: Applicability,
+    /// Human note: mechanism, rationale, or the reason there is no field.
+    pub note: &'static str,
+}
+
+use Applicability::{AllReceivers, DaemonOnly};
+
+/// The curated catalog of upstream receiver-applied (`am_sender`-gated)
+/// options relevant to a pull, mirrored from rsync 3.4.4 `options.c`.
+pub const CATALOG: &[OptionSpec] = &[
+    OptionSpec {
+        upstream_name: "--link-dest",
+        options_c: "options.c:2933",
+        getter: "reference_directories",
+        server_field: Some("reference_directories"),
+        applicability: AllReceivers,
+        note: "alt-dest family: --compare-dest/--copy-dest/--link-dest (basis_dir)",
+    },
+    OptionSpec {
+        upstream_name: "--backup-dir",
+        options_c: "options.c:2805",
+        getter: "backup_directory",
+        server_field: Some("backup_dir"),
+        applicability: AllReceivers,
+        note: "long-form value finalized in local popt parse",
+    },
+    OptionSpec {
+        upstream_name: "--suffix",
+        options_c: "options.c:2813",
+        getter: "backup_suffix",
+        server_field: Some("backup_suffix"),
+        applicability: AllReceivers,
+        note: "without it effective_backup_suffix() falls back to '~'",
+    },
+    OptionSpec {
+        upstream_name: "--chmod",
+        options_c: "options.c:1762",
+        getter: "chmod",
+        server_field: Some("chmod"),
+        applicability: AllReceivers,
+        note: "parsed into chmod_modes; never placed in server_options",
+    },
+    OptionSpec {
+        upstream_name: "--ignore-existing",
+        options_c: "options.c:2918",
+        getter: "ignore_existing",
+        server_field: Some("ignore_existing"),
+        applicability: AllReceivers,
+        note: "receiver skips files already present (generator.c:1395)",
+    },
+    OptionSpec {
+        upstream_name: "--existing",
+        options_c: "options.c:2922",
+        getter: "existing_only",
+        server_field: Some("existing_only"),
+        applicability: AllReceivers,
+        note: "ignore_non_existing; receiver never creates absent files",
+    },
+    OptionSpec {
+        upstream_name: "--prune-empty-dirs",
+        options_c: "options.c:2644",
+        getter: "prune_empty_dirs",
+        server_field: Some("prune_empty_dirs"),
+        applicability: AllReceivers,
+        note: "flist_sort_and_clean prunes on the receiver",
+    },
+    OptionSpec {
+        upstream_name: "--delay-updates",
+        options_c: "options.c:2891",
+        getter: "delay_updates",
+        server_field: Some("delay_updates"),
+        applicability: AllReceivers,
+        note: "receiver stages then renames updates at the end",
+    },
+    OptionSpec {
+        upstream_name: "--size-only",
+        options_c: "options.c:2854",
+        getter: "size_only",
+        server_field: Some("size_only"),
+        applicability: AllReceivers,
+        note: "quick-check variation applied by the receiver",
+    },
+    OptionSpec {
+        upstream_name: "--numeric-ids",
+        options_c: "options.c:2905",
+        getter: "numeric_ids",
+        server_field: Some("numeric_ids"),
+        applicability: AllReceivers,
+        note: "receiver skips id->name mapping",
+    },
+    OptionSpec {
+        upstream_name: "--delete",
+        options_c: "options.c:2845",
+        getter: "delete_mode",
+        server_field: Some("delete"),
+        applicability: AllReceivers,
+        note: "delete decision runs on the receiver/generator",
+    },
+    OptionSpec {
+        upstream_name: "--partial",
+        options_c: "options.c:2894",
+        getter: "partial",
+        server_field: Some("partial"),
+        applicability: AllReceivers,
+        note: "keep_partial; receiver retains partial transfers",
+    },
+    OptionSpec {
+        upstream_name: "--devices",
+        options_c: "options.c:2761",
+        getter: "preserve_devices",
+        server_field: Some("devices"),
+        applicability: AllReceivers,
+        note: "'D' now tracks devices only in the compact flag string",
+    },
+    OptionSpec {
+        upstream_name: "--specials",
+        options_c: "options.c:2766",
+        getter: "preserve_specials",
+        server_field: Some("specials"),
+        applicability: AllReceivers,
+        note: "specials carried separately from devices",
+    },
+    OptionSpec {
+        upstream_name: "--list-only",
+        options_c: "options.c:2747",
+        getter: "list_only",
+        server_field: Some("list_only"),
+        applicability: AllReceivers,
+        note: "long-form-only flag absent from the compact letter string",
+    },
+    OptionSpec {
+        upstream_name: "--fsync",
+        options_c: "options.c:2930",
+        getter: "fsync",
+        server_field: Some("fsync"),
+        applicability: DaemonOnly,
+        note: "receiver fsync wired only in the daemon write path",
+    },
+    OptionSpec {
+        upstream_name: "--usermap",
+        options_c: "options.c:2912",
+        getter: "user_mapping",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "applied via invocation argv (invocation/builder.rs), no ServerConfig field",
+    },
+    OptionSpec {
+        upstream_name: "--groupmap",
+        options_c: "options.c:2915",
+        getter: "group_mapping",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "applied via invocation argv (invocation/builder.rs), no ServerConfig field",
+    },
+    OptionSpec {
+        upstream_name: "--temp-dir",
+        options_c: "options.c:2926",
+        getter: "temp_directory",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "no receiver ServerConfig field yet",
+    },
+    OptionSpec {
+        upstream_name: "--mkpath",
+        options_c: "options.c:2996",
+        getter: "mkpath",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "no receiver ServerConfig field yet",
+    },
+    OptionSpec {
+        upstream_name: "--omit-dir-times",
+        options_c: "options.c:2646",
+        getter: "omit_dir_times",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "no receiver ServerConfig field yet",
+    },
+    OptionSpec {
+        upstream_name: "--omit-link-times",
+        options_c: "options.c:2648",
+        getter: "omit_link_times",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "no receiver ServerConfig field yet",
+    },
+    OptionSpec {
+        upstream_name: "--write-devices",
+        options_c: "options.c:2979",
+        getter: "write_devices",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "no receiver ServerConfig field yet",
+    },
+    OptionSpec {
+        upstream_name: "--keep-dirlinks",
+        options_c: "options.c:2642",
+        getter: "keep_dirlinks",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "no receiver ServerConfig field yet",
+    },
+    OptionSpec {
+        upstream_name: "--fuzzy",
+        options_c: "options.c:2650",
+        getter: "fuzzy",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "no receiver ServerConfig field yet",
+    },
+    OptionSpec {
+        upstream_name: "--force",
+        options_c: "options.c:2848",
+        getter: "force_replacements",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "force_delete; no receiver ServerConfig field yet",
+    },
+    OptionSpec {
+        upstream_name: "--preserve-executability",
+        options_c: "options.c:2692",
+        getter: "preserve_executability",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "no receiver ServerConfig field yet",
+    },
+    OptionSpec {
+        upstream_name: "--super",
+        options_c: "options.c:2853",
+        getter: "super_user",
+        server_field: None,
+        applicability: AllReceivers,
+        note: "emitted as a wire arg; no receiver ServerConfig field",
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upstream_names_are_single_tokens_and_unique() {
+        let mut seen = std::collections::BTreeSet::new();
+        for spec in CATALOG {
+            assert!(
+                !spec.upstream_name.contains(char::is_whitespace),
+                "option token must be a single word: {}",
+                spec.upstream_name
+            );
+            assert!(
+                seen.insert(spec.upstream_name),
+                "duplicate option token: {}",
+                spec.upstream_name
+            );
+        }
+    }
+
+    #[test]
+    fn options_c_references_are_populated() {
+        for spec in CATALOG {
+            assert!(
+                spec.options_c.starts_with("options.c:"),
+                "expected options.c reference for {}, got {}",
+                spec.upstream_name,
+                spec.options_c
+            );
+        }
+    }
+
+    #[test]
+    fn daemon_only_applies_to_daemon_only() {
+        assert!(DaemonOnly.includes(Builder::Daemon));
+        assert!(!DaemonOnly.includes(Builder::Ssh));
+        assert!(!DaemonOnly.includes(Builder::EmbeddedSsh));
+    }
+
+    #[test]
+    fn all_receivers_applies_everywhere() {
+        for builder in Builder::ALL {
+            assert!(AllReceivers.includes(builder));
+        }
+    }
+
+    #[test]
+    fn builder_ids_are_stable_and_distinct() {
+        let ids: Vec<&str> = Builder::ALL.iter().map(|b| b.id()).collect();
+        assert_eq!(ids, ["ssh", "embedded-ssh", "daemon"]);
+    }
+}

--- a/xtask/src/commands/gap_report/mod.rs
+++ b/xtask/src/commands/gap_report/mod.rs
@@ -1,0 +1,447 @@
+#![deny(unsafe_code)]
+
+//! `gap-report` command: receiver-option propagation coverage.
+//!
+//! This command institutionalizes a bug-discovery method. Upstream
+//! `options.c` `server_options()` gates receiver-applied options behind
+//! `if (am_sender)`, so those options are never sent over the wire on a pull.
+//! The local client is the receiver and must carry each such option onto its
+//! own `ServerConfig`. Any option whose `ServerConfig` field is never assigned
+//! from `config` in a receiver builder is a latent propagation gap.
+//!
+//! The command reads the three receiver config builders (plus the shared flag
+//! helper, which every builder invokes), statically checks each catalog option
+//! for field propagation, and prints a coverage table. In `--check` mode it
+//! compares the current gap set against a committed baseline and exits non-zero
+//! when a new gap appears, matching the repository's other `--check` gates.
+
+mod catalog;
+mod scanner;
+
+use crate::error::{TaskError, TaskResult};
+use crate::util::read_file_with_context;
+use catalog::{Builder, CATALOG, OptionSpec};
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::path::Path;
+
+/// Workspace-relative path to the committed gap baseline.
+const BASELINE_PATH: &str = "xtask/gap_report_baseline.txt";
+
+/// Workspace-relative path to the shared flag helper every builder invokes.
+const SHARED_FLAGS_PATH: &str = "crates/core/src/client/remote/flags.rs";
+
+/// Arguments for the `gap-report` command.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GapReportArgs {
+    /// Compare the current gap set against the committed baseline and fail on a
+    /// new gap instead of printing the human report.
+    pub check: bool,
+}
+
+impl From<crate::cli::GapReportArgs> for GapReportArgs {
+    fn from(args: crate::cli::GapReportArgs) -> Self {
+        GapReportArgs { check: args.check }
+    }
+}
+
+/// A single gap: an option whose field is not propagated by a builder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Gap {
+    option: &'static str,
+    builder: &'static str,
+}
+
+/// Verdict for one catalog option.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Verdict {
+    /// Field propagated on every applicable builder.
+    Ok,
+    /// Field missing on at least one applicable builder.
+    Gap,
+    /// No `ServerConfig` field: propagated by another mechanism or unhandled.
+    NoField,
+}
+
+/// Per-builder propagation cell in the report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Cell {
+    Propagated,
+    Missing,
+    NotApplicable,
+    NoField,
+}
+
+impl Cell {
+    const fn glyph(self) -> &'static str {
+        match self {
+            Cell::Propagated => "yes",
+            Cell::Missing => "NO",
+            Cell::NotApplicable => "n/a",
+            Cell::NoField => "-",
+        }
+    }
+}
+
+/// Evaluated row for one catalog option.
+struct Row {
+    spec: &'static OptionSpec,
+    cells: Vec<Cell>,
+    verdict: Verdict,
+}
+
+/// Builder source, concatenated with the shared flag helper it invokes.
+struct BuilderSources {
+    contents: Vec<(Builder, String)>,
+}
+
+impl BuilderSources {
+    /// Loads each receiver builder file joined with the shared flag helper.
+    ///
+    /// Every builder calls `apply_common_server_flags`, so a field assigned in
+    /// the shared helper counts as propagated for all builders.
+    fn load(workspace: &Path) -> TaskResult<Self> {
+        let shared = read_file_with_context(&workspace.join(SHARED_FLAGS_PATH))?;
+        let mut contents = Vec::with_capacity(Builder::ALL.len());
+        for builder in Builder::ALL {
+            let source = read_file_with_context(&workspace.join(builder.relative_path()))?;
+            contents.push((builder, format!("{source}\n{shared}")));
+        }
+        Ok(Self { contents })
+    }
+
+    /// Returns the concatenated source for `builder`.
+    fn source(&self, builder: Builder) -> &str {
+        self.contents
+            .iter()
+            .find(|(candidate, _)| *candidate == builder)
+            .map(|(_, source)| source.as_str())
+            .unwrap_or_default()
+    }
+}
+
+/// Executes the `gap-report` command.
+pub fn execute(workspace: &Path, args: GapReportArgs) -> TaskResult<()> {
+    let sources = BuilderSources::load(workspace)?;
+    let rows: Vec<Row> = CATALOG
+        .iter()
+        .map(|spec| evaluate(spec, &sources))
+        .collect();
+    let gaps = current_gaps(&rows);
+
+    if args.check {
+        run_check(workspace, &gaps)
+    } else {
+        print!("{}", render_report(&rows, &gaps));
+        Ok(())
+    }
+}
+
+/// Evaluates one catalog option against every receiver builder.
+fn evaluate(spec: &'static OptionSpec, sources: &BuilderSources) -> Row {
+    let Some(field) = spec.server_field else {
+        return Row {
+            spec,
+            cells: Builder::ALL.iter().map(|_| Cell::NoField).collect(),
+            verdict: Verdict::NoField,
+        };
+    };
+
+    let mut cells = Vec::with_capacity(Builder::ALL.len());
+    let mut has_gap = false;
+    for builder in Builder::ALL {
+        let cell = if !spec.applicability.includes(builder) {
+            Cell::NotApplicable
+        } else if scanner::field_assigned_from_config(sources.source(builder), field) {
+            Cell::Propagated
+        } else {
+            has_gap = true;
+            Cell::Missing
+        };
+        cells.push(cell);
+    }
+
+    Row {
+        spec,
+        cells,
+        verdict: if has_gap { Verdict::Gap } else { Verdict::Ok },
+    }
+}
+
+/// Collects the current gap set from evaluated rows.
+fn current_gaps(rows: &[Row]) -> BTreeSet<Gap> {
+    let mut gaps = BTreeSet::new();
+    for row in rows {
+        for (builder, cell) in Builder::ALL.iter().zip(&row.cells) {
+            if *cell == Cell::Missing {
+                gaps.insert(Gap {
+                    option: row.spec.upstream_name,
+                    builder: builder.id(),
+                });
+            }
+        }
+    }
+    gaps
+}
+
+/// Renders the human-readable coverage report.
+fn render_report(rows: &[Row], gaps: &BTreeSet<Gap>) -> String {
+    let mut out = String::new();
+    out.push_str("Receiver-option propagation coverage (upstream rsync 3.4.4)\n");
+    out.push_str(
+        "Options gated by `if (am_sender)` in options.c server_options() are not\n\
+         sent on a pull; the local receiver must carry them onto its ServerConfig.\n\n",
+    );
+
+    let header = format!(
+        "{:<26} {:<16} {:<24} {:<5} {:<13} {:<7} {}\n",
+        "OPTION", "OPTIONS.C", "CLIENTCONFIG GETTER", "ssh", "embedded-ssh", "daemon", "VERDICT"
+    );
+    out.push_str(&header);
+    out.push_str(&"-".repeat(header.len().saturating_sub(1)));
+    out.push('\n');
+
+    for row in rows {
+        let cells: Vec<&str> = row.cells.iter().map(|cell| cell.glyph()).collect();
+        let _ = writeln!(
+            out,
+            "{:<26} {:<16} {:<24} {:<5} {:<13} {:<7} {}",
+            row.spec.upstream_name,
+            row.spec.options_c,
+            row.spec.getter,
+            cells[0],
+            cells[1],
+            cells[2],
+            verdict_label(row.verdict),
+        );
+    }
+
+    let ok = rows.iter().filter(|r| r.verdict == Verdict::Ok).count();
+    let gap = rows.iter().filter(|r| r.verdict == Verdict::Gap).count();
+    let no_field = rows
+        .iter()
+        .filter(|r| r.verdict == Verdict::NoField)
+        .count();
+    let _ = writeln!(
+        out,
+        "\n{} options: {ok} OK, {gap} GAP, {no_field} NO-FIELD",
+        rows.len()
+    );
+
+    let annotated: Vec<&Row> = rows
+        .iter()
+        .filter(|row| row.verdict != Verdict::Ok)
+        .collect();
+    if !annotated.is_empty() {
+        out.push_str("\nNotes (GAP and NO-FIELD options):\n");
+        for row in annotated {
+            let _ = writeln!(
+                out,
+                "  {} [{}]: {}",
+                row.spec.upstream_name,
+                verdict_label(row.verdict),
+                row.spec.note,
+            );
+        }
+    }
+
+    out.push_str("\nCurrent gap set (baseline format):\n");
+    if gaps.is_empty() {
+        out.push_str("  (none)\n");
+    } else {
+        for entry in gaps {
+            let _ = writeln!(out, "  {} {}", entry.option, entry.builder);
+        }
+    }
+    out
+}
+
+/// Returns the display label for a verdict.
+const fn verdict_label(verdict: Verdict) -> &'static str {
+    match verdict {
+        Verdict::Ok => "OK",
+        Verdict::Gap => "GAP",
+        Verdict::NoField => "NO-FIELD",
+    }
+}
+
+/// Compares the current gap set against the committed baseline.
+fn run_check(workspace: &Path, gaps: &BTreeSet<Gap>) -> TaskResult<()> {
+    let baseline_path = workspace.join(BASELINE_PATH);
+    let baseline_text = read_file_with_context(&baseline_path)?;
+    let baseline = parse_baseline(&baseline_text);
+
+    let new_gaps: Vec<&Gap> = gaps.iter().filter(|gap| !baseline.contains(*gap)).collect();
+    let resolved: Vec<&Gap> = baseline.iter().filter(|gap| !gaps.contains(*gap)).collect();
+
+    if !new_gaps.is_empty() {
+        let mut message = String::from(
+            "gap-report: new receiver-option propagation gap(s) detected.\n\
+             An upstream am_sender-gated option is not carried onto a receiver\n\
+             builder's ServerConfig. Fix the builder or, if intentional, update\n",
+        );
+        let _ = writeln!(message, "{BASELINE_PATH}:");
+        for gap in new_gaps {
+            let _ = writeln!(message, "  {} {}", gap.option, gap.builder);
+        }
+        return Err(TaskError::Validation(message.trim_end().to_string()));
+    }
+
+    if resolved.is_empty() {
+        println!(
+            "gap-report: no new gaps ({} baseline gap(s)).",
+            baseline.len()
+        );
+    } else {
+        println!(
+            "gap-report: no new gaps; {} baseline gap(s) now resolved.",
+            resolved.len()
+        );
+        println!("Tighten the guard by removing resolved entries from {BASELINE_PATH}:");
+        for gap in resolved {
+            println!("  {} {}", gap.option, gap.builder);
+        }
+    }
+    Ok(())
+}
+
+/// Parses baseline lines into a gap set, ignoring comments and blank lines.
+///
+/// Each significant line is `<upstream-option> <builder-id>`. The tokens are
+/// leaked to `'static` so parsed gaps compare directly against catalog-derived
+/// gaps; the process is short-lived and the set is bounded by the catalog size.
+fn parse_baseline(text: &str) -> BTreeSet<Gap> {
+    let mut gaps = BTreeSet::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        if let (Some(option), Some(builder), None) = (parts.next(), parts.next(), parts.next()) {
+            gaps.insert(Gap {
+                option: Box::leak(option.to_owned().into_boxed_str()),
+                builder: Box::leak(builder.to_owned().into_boxed_str()),
+            });
+        }
+    }
+    gaps
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_sources(embedded_missing: bool) -> BuilderSources {
+        let common = "\
+            server_config.flags.list_only = config.list_only();\n\
+            server_config.write.delay_updates = config.delay_updates();\n\
+            server_config.flags.numeric_ids = config.numeric_ids();\n";
+        let embedded = if embedded_missing {
+            "server_config.flags.numeric_ids = config.numeric_ids();\n"
+        } else {
+            common
+        };
+        BuilderSources {
+            contents: vec![
+                (Builder::Ssh, common.to_string()),
+                (Builder::EmbeddedSsh, embedded.to_string()),
+                (
+                    Builder::Daemon,
+                    format!("{common}server_config.write.fsync = config.fsync();\n"),
+                ),
+            ],
+        }
+    }
+
+    fn spec(name: &'static str, field: &'static str) -> OptionSpec {
+        OptionSpec {
+            upstream_name: name,
+            options_c: "options.c:1",
+            getter: "getter",
+            server_field: Some(field),
+            applicability: catalog::Applicability::AllReceivers,
+            note: "",
+        }
+    }
+
+    #[test]
+    fn fully_propagated_option_is_ok() {
+        let sources = sample_sources(false);
+        let leaked: &'static OptionSpec = Box::leak(Box::new(spec("--list-only", "list_only")));
+        let row = evaluate(leaked, &sources);
+        assert_eq!(row.verdict, Verdict::Ok);
+        assert!(row.cells.iter().all(|c| *c == Cell::Propagated));
+    }
+
+    #[test]
+    fn missing_embedded_field_is_a_gap() {
+        let sources = sample_sources(true);
+        let leaked: &'static OptionSpec = Box::leak(Box::new(spec("--list-only", "list_only")));
+        let row = evaluate(leaked, &sources);
+        assert_eq!(row.verdict, Verdict::Gap);
+        assert_eq!(row.cells[1], Cell::Missing);
+        let gaps = current_gaps(std::slice::from_ref(&row));
+        assert!(gaps.contains(&Gap {
+            option: "--list-only",
+            builder: "embedded-ssh",
+        }));
+    }
+
+    #[test]
+    fn no_field_option_is_never_a_gap() {
+        let sources = sample_sources(true);
+        let no_field = OptionSpec {
+            upstream_name: "--usermap",
+            options_c: "options.c:1",
+            getter: "user_mapping",
+            server_field: None,
+            applicability: catalog::Applicability::AllReceivers,
+            note: "",
+        };
+        let leaked: &'static OptionSpec = Box::leak(Box::new(no_field));
+        let row = evaluate(leaked, &sources);
+        assert_eq!(row.verdict, Verdict::NoField);
+        assert!(current_gaps(std::slice::from_ref(&row)).is_empty());
+    }
+
+    #[test]
+    fn daemon_only_option_not_a_gap_on_ssh() {
+        let sources = sample_sources(false);
+        let mut fsync = spec("--fsync", "fsync");
+        fsync.applicability = catalog::Applicability::DaemonOnly;
+        let leaked: &'static OptionSpec = Box::leak(Box::new(fsync));
+        let row = evaluate(leaked, &sources);
+        assert_eq!(row.cells[0], Cell::NotApplicable);
+        assert_eq!(row.cells[2], Cell::Propagated);
+        assert_eq!(row.verdict, Verdict::Ok);
+    }
+
+    #[test]
+    fn parse_baseline_ignores_comments_and_blanks() {
+        let text = "# header\n\n--list-only embedded-ssh\n  --delay-updates embedded-ssh  \n";
+        let parsed = parse_baseline(text);
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed.contains(&Gap {
+            option: "--delay-updates",
+            builder: "embedded-ssh",
+        }));
+    }
+
+    #[test]
+    fn parse_baseline_rejects_malformed_lines() {
+        let parsed = parse_baseline("--only-one-token\n--a b c\n");
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn render_report_lists_gap_set() {
+        let sources = sample_sources(true);
+        let leaked: &'static OptionSpec = Box::leak(Box::new(spec("--list-only", "list_only")));
+        let row = evaluate(leaked, &sources);
+        let gaps = current_gaps(std::slice::from_ref(&row));
+        let report = render_report(std::slice::from_ref(&row), &gaps);
+        assert!(report.contains("GAP"));
+        assert!(report.contains("--list-only embedded-ssh"));
+    }
+}

--- a/xtask/src/commands/gap_report/scanner.rs
+++ b/xtask/src/commands/gap_report/scanner.rs
@@ -1,0 +1,179 @@
+#![deny(unsafe_code)]
+
+//! Textual propagation scanner.
+//!
+//! The scanner answers a single, deterministic question about a receiver
+//! config builder: does its source assign a given `ServerConfig` leaf field
+//! from the client `config`? Upstream rsync gates receiver-applied options
+//! behind `if (am_sender)` in `server_options()`, so those options are never
+//! sent over the wire on a pull. The local client is the receiver and must
+//! carry each such option onto its own `ServerConfig`. An option whose field is
+//! never assigned from `config` is a latent propagation gap.
+//!
+//! The check is intentionally AST-lite: it scans for a whole-word assignment to
+//! the leaf field (`... .<field> = <expr>;`) whose right-hand side references
+//! `config`. This is robust against sub-string collisions (`delete` vs
+//! `delete_excluded`), getter calls (`config.partial()` is not an assignment),
+//! and comparison operators (`==`, `!=`, `<=`, `>=`).
+
+/// Returns `true` when `source` assigns the `ServerConfig` leaf field `field`
+/// from a `config` expression.
+///
+/// A match requires a whole-word occurrence of `field` immediately followed by
+/// an `=` assignment (not a comparison) whose right-hand side, up to the
+/// terminating `;`, references the identifier `config`.
+pub fn field_assigned_from_config(source: &str, field: &str) -> bool {
+    assignment_right_hand_sides(source, field).any(|rhs| references_identifier(rhs, "config"))
+}
+
+/// Yields the right-hand side (from just after `=` up to the next `;`) of each
+/// whole-word assignment to `field` found in `source`.
+fn assignment_right_hand_sides<'a>(
+    source: &'a str,
+    field: &'a str,
+) -> impl Iterator<Item = &'a str> {
+    let bytes = source.as_bytes();
+    let mut cursor = 0usize;
+
+    std::iter::from_fn(move || {
+        while let Some(offset) = source[cursor..].find(field) {
+            let start = cursor + offset;
+            let end = start + field.len();
+            cursor = end;
+
+            if start > 0 && is_ident_byte(bytes[start - 1]) {
+                continue;
+            }
+            if end < bytes.len() && is_ident_byte(bytes[end]) {
+                continue;
+            }
+
+            let mut index = end;
+            while index < bytes.len() && matches!(bytes[index], b' ' | b'\t') {
+                index += 1;
+            }
+            if index >= bytes.len() || bytes[index] != b'=' {
+                continue;
+            }
+            // Reject `==` (the only comparison whose first byte is `=`). Other
+            // comparisons (`!=`, `<=`, `>=`) place a non-`=` byte before the
+            // `=`, which the whitespace skip above never crosses.
+            if bytes.get(index + 1) == Some(&b'=') {
+                continue;
+            }
+
+            let rhs_start = index + 1;
+            let rhs_end = source[rhs_start..]
+                .find(';')
+                .map_or(bytes.len(), |terminator| rhs_start + terminator);
+            return Some(&source[rhs_start..rhs_end]);
+        }
+        None
+    })
+}
+
+/// Returns `true` when `haystack` contains `identifier` as a whole word.
+fn references_identifier(haystack: &str, identifier: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    let mut cursor = 0usize;
+    while let Some(offset) = haystack[cursor..].find(identifier) {
+        let start = cursor + offset;
+        let end = start + identifier.len();
+        cursor = end;
+        let left_ok = start == 0 || !is_ident_byte(bytes[start - 1]);
+        let right_ok = end >= bytes.len() || !is_ident_byte(bytes[end]);
+        if left_ok && right_ok {
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns `true` when `byte` may appear inside a Rust identifier.
+fn is_ident_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_statement_assignment_from_config() {
+        let source = "    server_config.flags.list_only = config.list_only();";
+        assert!(field_assigned_from_config(source, "list_only"));
+    }
+
+    #[test]
+    fn detects_multiline_assignment_from_config() {
+        let source =
+            "server_config.backup_suffix = config\n    .backup_suffix()\n    .map(|s| s.into());";
+        assert!(field_assigned_from_config(source, "backup_suffix"));
+    }
+
+    #[test]
+    fn detects_wrapped_constructor_assignment() {
+        let source =
+            "server_config.flags.numeric_ids = NumericIds::from_client(config.numeric_ids());";
+        assert!(field_assigned_from_config(source, "numeric_ids"));
+    }
+
+    #[test]
+    fn missing_field_is_not_propagated() {
+        let source = "server_config.flags.numeric_ids = config.numeric_ids();";
+        assert!(!field_assigned_from_config(source, "list_only"));
+    }
+
+    #[test]
+    fn getter_call_is_not_an_assignment() {
+        // `config.partial()` reads the value but never assigns the field.
+        let source = "let value = config.partial();";
+        assert!(!field_assigned_from_config(source, "partial"));
+    }
+
+    #[test]
+    fn substring_field_does_not_match_longer_identifier() {
+        // `delete` must not match inside `delete_excluded` or `delete_mode`.
+        let source = "server_config.deletion.delete_excluded = config.delete_mode().is_enabled();";
+        assert!(!field_assigned_from_config(source, "delete"));
+    }
+
+    #[test]
+    fn real_delete_assignment_matches() {
+        let source = "server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();";
+        assert!(field_assigned_from_config(source, "delete"));
+    }
+
+    #[test]
+    fn comparison_is_not_an_assignment() {
+        let source = "if server_config.flags.list_only == config.list_only() { work(); }";
+        assert!(!field_assigned_from_config(source, "list_only"));
+    }
+
+    #[test]
+    fn assignment_from_literal_is_not_from_config() {
+        // A hard-coded assignment does not carry the client's choice.
+        let source = "server_config.flags.list_only = true;";
+        assert!(!field_assigned_from_config(source, "list_only"));
+    }
+
+    #[test]
+    fn partial_field_ignores_partial_dir_assignments() {
+        let source = "server_config.write.partial_dir = config.partial_dir().map(Into::into);";
+        assert!(!field_assigned_from_config(source, "partial"));
+    }
+
+    #[test]
+    fn devices_field_ignores_preserve_devices_getter_shape() {
+        let source = "server_config.flags.devices = config.preserve_devices();";
+        assert!(field_assigned_from_config(source, "devices"));
+    }
+
+    #[test]
+    fn rhs_does_not_leak_past_semicolon() {
+        // The field is assigned from a literal; a later, unrelated statement
+        // mentions config. The scanner must not join them across the `;`.
+        let source = "server_config.flags.list_only = false; let x = config.foo();";
+        assert!(!field_assigned_from_config(source, "list_only"));
+    }
+}

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod benchmark;
 pub mod branding;
 pub mod doc_package;
 pub mod docs;
+pub mod gap_report;
 pub mod interop;
 pub mod man_page;
 pub mod no_binaries;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -59,8 +59,9 @@ mod workspace;
 
 use crate::cli::{Cli, Command, CommandExt};
 use crate::commands::{
-    benchmark, branding, doc_package, docs, interop, man_page, no_binaries, no_placeholders,
-    package, preflight, readme_version, release, release_notes, sbom, test, validate,
+    benchmark, branding, doc_package, docs, gap_report, interop, man_page, no_binaries,
+    no_placeholders, package, preflight, readme_version, release, release_notes, sbom, test,
+    validate,
 };
 use crate::error::TaskError;
 use crate::task::TreeRenderer;
@@ -105,6 +106,7 @@ fn run_command(cli: Cli) -> Result<(), TaskError> {
         Command::Branding(args) => branding::execute(&workspace, args.into()),
         Command::Docs(args) => docs::execute(&workspace, args.into()),
         Command::DocPackage(args) => doc_package::execute(&workspace, args.into()),
+        Command::GapReport(args) => gap_report::execute(&workspace, args.into()),
         Command::Interop(args) => interop::execute(&workspace, args.into()),
         Command::ManPage => man_page::execute(&workspace),
         Command::NoBinaries => no_binaries::execute(&workspace),


### PR DESCRIPTION
## What

Adds `cargo xtask gap-report`, a static source-analysis command that reports
receiver-option propagation coverage against upstream rsync 3.4.4 and gates CI
against regressions.

## Why

Upstream `options.c` `server_options()` builds the remote argv. Options wrapped
in `if (am_sender)` are never sent over the wire on a pull, so the local client
(which is the receiver) must apply them itself by carrying them onto its
`ServerConfig`. Every such option that a receiver builder fails to propagate is
a latent bug that only surfaces on real pull transfers. A manual enumeration of
this exact gap previously found eight real bugs. This command turns that
one-off audit into a repeatable, reviewable, CI-gated report.

## How it works

- **Catalog** (`catalog.rs`) - pure data table of the upstream receiver-applied
  (`am_sender`-gated) options relevant to a pull. Each entry records the
  upstream option, its `options.c` line reference (a static string, so the tool
  needs no upstream source at runtime), the `ClientConfig` getter, the
  `ServerConfig` leaf field it should land on (or `None` for options propagated
  by another mechanism), and applicability. This table is the single source of
  truth, regenerated on an upstream version bump.
- **Scanner** (`scanner.rs`) - a pure, unit-tested textual check: does a
  builder assign a given `ServerConfig` leaf field from `config`? It is robust
  against sub-string collisions (`delete` vs `delete_excluded`), getter calls,
  comparisons, and cross-statement leakage.
- **Report + gate** (`mod.rs`) - reads the three receiver config builders
  (`ssh_transfer`, `embedded_ssh_transfer`, `daemon_transfer`) plus the shared
  `flags::apply_common_server_flags`, evaluates each option per builder, and
  prints a coverage table with an `OK` / `GAP` / `NO-FIELD` verdict. `--check`
  compares the current gap set against a committed baseline and exits non-zero
  when a new gap appears.

## Baseline

`xtask/gap_report_baseline.txt` records the current known gaps:

```
--delay-updates embedded-ssh
--list-only embedded-ssh
```

Both options are propagated in the external-SSH and daemon receiver builders but
not in the embedded-SSH (`russh`, `ssh://`) receiver builder - two genuine
latent gaps the tool surfaces today. They are recorded as the known baseline so
`--check` stays green until a fix lands or a new gap appears. Twelve options
report `NO-FIELD`: usermap/groupmap are applied via the invocation argv rather
than a `ServerConfig` field, and the rest have no receiver field yet.

## Run it

```
cargo xtask gap-report          # print the coverage table
cargo xtask gap-report --check  # CI gate: fail on a new gap
```

On an upstream version bump: diff the new `server_options()` for newly
`am_sender`-gated options, update the catalog line references, run
`cargo xtask gap-report`, and copy the printed gap set into the baseline.

## Tests

- Scanner unit tests cover propagated vs missing, multi-line assignments,
  wrapped constructors, sub-string safety, comparisons, and semicolon
  boundaries.
- Command tests cover OK / GAP / NO-FIELD verdicts, daemon-only applicability,
  baseline parsing, and the report rendering.
- `cargo nextest run -p xtask`, `cargo fmt --all -- --check`, and
  `cargo clippy -p xtask --all-targets --all-features --no-deps -- -D warnings`
  all pass.
