### PR TITLE
fix: leave daemon @RSYNCD handshake untimed like upstream

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -117,8 +117,6 @@ pub(crate) const LEGACY_CONFIG_ENV: &str = "RSYNCD_CONFIG";
 pub(crate) const BRANDED_SECRETS_ENV: &str = "OC_RSYNC_SECRETS";
 /// Legacy environment variable for secrets file override; checked when `OC_RSYNC_SECRETS` is unset.
 pub(crate) const LEGACY_SECRETS_ENV: &str = "RSYNCD_SECRETS";
-/// Timeout applied to accepted sockets to avoid hanging handshakes.
-const SOCKET_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Error payload returned to clients while daemon functionality is incomplete.
 pub(crate) const HANDSHAKE_ERROR_PAYLOAD: &str =

--- a/crates/daemon/src/daemon/sections/module_parsing/module_spec.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/module_spec.rs
@@ -12,15 +12,12 @@ fn apply_module_timeout(stream: &DaemonStream, module: &ModuleDefinition) -> io:
         stream.set_read_timeout(Some(duration))?;
         stream.set_write_timeout(Some(duration))?;
     } else {
-        // #503 (design doc section 4.4): when the module sets no `timeout`,
-        // clear the leaked 10-second accept-time `SOCKET_TIMEOUT` (armed in
-        // listener.rs) so the data phase matches upstream's `io_timeout = 0`
-        // default (io.c:179 short-circuits the timeout check when unset).
-        // Without this, the accept-time guard persists through the delta phase
-        // and fires on a wedged read as `code 23`. This MUST ship with the
-        // Approach C drain thread: alone it would turn the deadlock's abort
-        // into an indefinite hang; the drain thread guarantees the phase
-        // cannot deadlock, so removing the timeout is safe.
+        // When the module sets no `timeout`, the data phase is untimed, matching
+        // upstream's `io_timeout = 0` default (options.c:102; io.c:179
+        // short-circuits the timeout check when unset). Clearing both directions
+        // is defensive: it guarantees the accepted socket carries no inherited
+        // I/O deadline into the delta phase, so a legitimately slow but live
+        // transfer is never aborted as `code 23`.
         stream.set_read_timeout(None)?;
         stream.set_write_timeout(None)?;
     }

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -260,12 +260,6 @@ fn bind_with_backlog(
     Ok(socket.into())
 }
 
-/// Configures read/write timeouts on an accepted client stream.
-fn configure_stream(stream: &DaemonStream) -> io::Result<()> {
-    stream.set_read_timeout(Some(SOCKET_TIMEOUT))?;
-    stream.set_write_timeout(Some(SOCKET_TIMEOUT))
-}
-
 /// One-shot guard so the `--tcp-fastopen=on` unsupported-platform warning
 /// fires at most once per daemon process.
 static TCP_FASTOPEN_UNSUPPORTED_WARNED: std::sync::Once = std::sync::Once::new();

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -62,7 +62,16 @@ fn handle_session(
     // the server to send the @RSYNCD greeting first!
     // Always use Legacy mode for daemon connections.
     let style = SessionStyle::Legacy;
-    configure_stream(&stream)?;
+    // The `@RSYNCD:` greeting exchange is deliberately left untimed, matching
+    // upstream. Upstream keeps io_timeout at 0 (options.c:102) until a module
+    // has been selected, only then arming lp_timeout(module_id)
+    // (clientserver.c:1206); the handshake itself runs with no I/O deadline.
+    // Arming one here tore down connections whose peer was momentarily
+    // CPU-starved under a burst: the handshake read timed out, the worker
+    // returned an error, and dropping the socket with the client's still-unread
+    // request in the kernel buffer sent an RST that the client surfaced as
+    // "Connection reset by peer". The per-module `timeout` directive still
+    // governs the data phase via apply_module_timeout once the module is known.
 
     // upstream: clientserver.c:1298 - read PROXY protocol header before any
     // rsync protocol data when `proxy protocol = true` in the config.

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -223,6 +223,7 @@ include!("tests/chunks/run_daemon_rejects_invalid_port.rs");
 include!("tests/chunks/run_daemon_rejects_unknown_argument.rs");
 include!("tests/chunks/run_daemon_rejects_push_to_read_only_module.rs");
 include!("tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs");
+include!("tests/chunks/run_daemon_serves_slow_handshake.rs");
 include!("tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs");
 include!("tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs");
 include!("tests/chunks/run_daemon_requests_authentication_for_protected_module.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_serves_slow_handshake.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_serves_slow_handshake.rs
@@ -1,0 +1,78 @@
+/// Regression: a client that is slow to complete the `@RSYNCD:` handshake must
+/// still be served, not torn down. The daemon previously armed a hardcoded
+/// 10-second accept-time timeout on the socket, so a peer that paused longer
+/// than that between the greeting and its request had the connection aborted;
+/// dropping the socket with the client's pending bytes unread sent an RST that
+/// the client saw as "Connection reset by peer" (soak run: 14/3000 pulls under
+/// a CPU-starved 64-way burst). Upstream keeps `io_timeout` at 0 (options.c:102)
+/// throughout the greeting exchange, only arming `lp_timeout(module_id)`
+/// (clientserver.c:1206) after a module is selected, so the handshake is
+/// untimed. This test pauses longer than the former 10-second guard and asserts
+/// the module listing is still delivered.
+///
+/// `--no-detach` keeps the daemon in-thread so the assertions run in this
+/// process; without it the daemon forks via `become_daemon()` and the parent
+/// exits before the test body executes.
+#[test]
+fn run_daemon_serves_slow_handshake() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let dir = tempdir().expect("temp dir");
+    let module_dir = dir.path().join("archive");
+    fs::create_dir_all(&module_dir).expect("module dir");
+
+    let config_path = dir.path().join("inline.conf");
+    fs::write(
+        &config_path,
+        format!("[archive]\npath = {}\n", module_dir.display()),
+    )
+    .expect("write config");
+
+    let (port, held_listener) = allocate_test_port();
+
+    let inline_config = format!("--config={}", config_path.display());
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--no-detach"),
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from(inline_config),
+            OsString::from("--once"),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let expected_greeting = legacy_daemon_greeting();
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert_eq!(line, expected_greeting);
+
+    // Pause past the former 10-second accept-time timeout before completing the
+    // handshake. The daemon must wait rather than abort the connection.
+    std::thread::sleep(std::time::Duration::from_secs(11));
+
+    stream.write_all(b"#list\n").expect("send list request");
+    stream.flush().expect("flush list request");
+
+    line.clear();
+    reader
+        .read_line(&mut line)
+        .expect("module listing after slow handshake");
+    assert_eq!(
+        line, "archive        \t\n",
+        "slow handshake must still receive the module listing, not a reset"
+    );
+
+    line.clear();
+    reader.read_line(&mut line).expect("exit line");
+    assert_eq!(line, "@RSYNCD: EXIT\n");
+
+    drop(reader);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary

The daemon armed a hardcoded 10-second read/write timeout on every accepted socket for the duration of the `@RSYNCD:` greeting exchange (`configure_stream` / `SOCKET_TIMEOUT`). Upstream keeps `io_timeout` at 0 (`options.c:102`) throughout the greeting and only arms `lp_timeout(module_id)` **after** a module is selected (`clientserver.c:1206`); the handshake itself is untimed. The accept-time guard was a non-upstream addition.

## Root cause (with evidence)

Under a concurrent connection burst on a CPU-starved runner, a peer cannot always finish the greeting within 10 seconds. When the timeout fires, the worker returns an error and drops the socket while the client's request is still unread in the kernel buffer — closing a socket with unread input sends a TCP **RST**. The client sees:

```
rsync: [Receiver] safe_read failed to read 1 bytes: Connection reset by peer (104)
rsync error: error in rsync protocol data stream (code 12) at io.c(283)
```

The daemon-concurrency soak (1000 pulls/run, 64-way parallel, cap 2000) recorded **14/3000 failed pulls**, and the artifact pinned the mechanism precisely:

- All 14 failures were in the **cold first run** (`wall 109s` vs `14.9s`/`14.3s` warm) — the CPU-starved window.
- Every failed pull's client stderr was the ECONNRESET above.
- The daemon log had **2986** completed transfers and **zero** log lines for the 14 — they were torn down *before* module selection, i.e. mid-handshake.

The failure is independent of any PR — it is a master-level daemon robustness gap. It is a real bug, not a harness flake (the harness client is stock upstream `rsync`, which does not retry a reset handshake).

## Fix

Remove the accept-time handshake timeout so the greeting exchange is untimed, matching upstream. The per-module `timeout` directive still governs the data phase via `apply_module_timeout` once the module is known (unchanged).

- `session_runtime.rs`: drop the `configure_stream` call; document the upstream-parity rationale.
- `listener.rs` / `daemon.rs`: remove the now-unused `configure_stream` helper and `SOCKET_TIMEOUT` constant.
- `module_spec.rs`: refresh the stale comment that referenced the removed accept-time guard.

## Upstream references

- `options.c:102` — `int io_timeout = 0;` (no I/O timeout by default).
- `clientserver.c:1206-1207` — the daemon only arms `set_io_timeout(lp_timeout(module_id))` after module selection.
- `io.c:179` — the timeout check short-circuits when `io_timeout` is unset.

## Verification

- New regression test `run_daemon_serves_slow_handshake`: pauses 11s (past the former guard) then asserts the module listing is still delivered. It **fails** when the 10-second timeout is present and **passes** with it removed (confirmed by temporarily re-introducing the timeout: assertion `slow handshake must still receive the module listing, not a reset` trips).
- End-to-end with the release binary: a client that reads the greeting, waits 12s, then completes the handshake now receives the full module listing (`soak` + `@RSYNCD: EXIT`); the pre-fix binary closed the connection at ~10s.
- `cargo build --workspace`, `cargo fmt --all -- --check`, and `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` are all clean.

The soak invariant is unchanged (still requires `TOTAL_FAIL == 0`); no bar was lowered.
