### PR TITLE
test(xtask): add modify-window, dirs, trimslash, duplicates fidelity checks

### DIFF
--- a/xtask/src/commands/validate/checks/dirs.rs
+++ b/xtask/src/commands/validate/checks/dirs.rs
@@ -1,0 +1,193 @@
+//! `-d` / `--dirs` non-recursive directory parity between oc-rsync and upstream.
+//!
+//! With `-d` (`--dirs`) rsync includes directories it encounters but does not
+//! recurse into them: a directory named on the command line with a trailing
+//! slash has its immediate entries transferred, yet any subdirectory among those
+//! entries is created empty rather than descended. This check pulls a two-level
+//! fixture (`top.txt` plus `subdir/nested.txt`) with `-d` (no `-r`) over every
+//! transport and asserts oc-rsync's destination is byte- and structure-identical
+//! to upstream's, plus a non-vacuous guard that `-d` actually stopped the
+//! recursion: the subdirectory exists in the destination but its nested file
+//! does not.
+//!
+//! upstream: options.c:628 `{"dirs", 'd', ..., &xfer_dirs, 2, ...}`; the man page
+//! is explicit that a directory's contents are copied only when the operand ends
+//! in a trailing slash (or is `.`), while nested subdirectories are never
+//! descended without `--recursive`.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The `-d` / `--dirs` non-recursive directory parity check.
+pub struct Dirs;
+
+/// Preserve metadata and request non-recursive directory transfer. `-d` is the
+/// option under test; deliberately no `-r`. `--numeric-ids` keeps owner
+/// comparison host-stable.
+const FLAGS: &[&str] = &["-dlptgoD", "--numeric-ids"];
+
+/// Top-level file whose presence proves the immediate entries were transferred.
+const TOP: &str = "top.txt";
+/// Subdirectory encountered among the immediate entries; `-d` creates it empty.
+const SUBDIR: &str = "subdir";
+/// File nested one level below the operand; `-d` must NOT transfer it.
+const NESTED: &str = "subdir/nested.txt";
+
+impl Check for Dirs {
+    fn name(&self) -> &'static str {
+        "dirs"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("dirs");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src, &flags))
+            .collect()
+    }
+}
+
+impl Dirs {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+        flags: &[String],
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+
+        match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        }
+        match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        }
+
+        // Non-vacuous: `-d` transferred the immediate entries (top file present,
+        // subdir created) but did not recurse (nested file absent). Assert on
+        // both destinations so upstream anchors the expected semantics.
+        for (who, dst) in [("oc", &oc_dst), ("upstream", &up_dst)] {
+            if !dst.join(TOP).exists() {
+                return CheckOutcome::fail(self.name(), label, format!("{who} missing {TOP}"));
+            }
+            if !dst.join(SUBDIR).is_dir() {
+                return CheckOutcome::fail(
+                    self.name(),
+                    label,
+                    format!("{who} did not create {SUBDIR}"),
+                );
+            }
+            if dst.join(NESTED).exists() {
+                return CheckOutcome::fail(
+                    self.name(),
+                    label,
+                    format!("{who} recursed into {SUBDIR} despite -d"),
+                );
+            }
+        }
+
+        match support::content_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), label, diff),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// Build the two-level fixture. Idempotent: removes any prior tree first. Every
+/// entry's mtime is backdated with GNU `touch` so the quick-check makes
+/// deterministic decisions and does not re-transfer on mtime alone.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join(SUBDIR);
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+    std::fs::write(src.join(TOP), b"top-level file\n").map_err(|e| e.to_string())?;
+    std::fs::write(src.join(NESTED), b"nested file\n").map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nested_lives_below_the_named_subdir() {
+        // `-d` keys on this layering: NESTED is one level deeper than SUBDIR, so
+        // a non-recursing transfer creates SUBDIR but never NESTED.
+        assert_eq!(NESTED, format!("{SUBDIR}/nested.txt"));
+        assert!(NESTED.starts_with(SUBDIR));
+        assert_ne!(TOP, NESTED);
+    }
+
+    #[test]
+    fn flags_request_dirs_without_recursion() {
+        // The bundled short-flag group must carry `d` but never `r`, so the
+        // transfer includes directories without recursing into them.
+        assert!(FLAGS[0].contains('d'));
+        assert!(!FLAGS[0].contains('r'));
+    }
+}

--- a/xtask/src/commands/validate/checks/duplicates.rs
+++ b/xtask/src/commands/validate/checks/duplicates.rs
@@ -1,0 +1,253 @@
+//! Duplicate source-operand parity between oc-rsync and upstream.
+//!
+//! A user may name the same source more than once on the command line (via shell
+//! variables or wildcard expansion). Rsync's `clean_flist()` sorts the file list
+//! and drops the duplicates so each name is generated and updated exactly once,
+//! rather than racing two copies of the same name through the pipeline. This
+//! check names one source directory's contents several times in a single
+//! transfer over every transport and asserts oc-rsync reaches the exact same
+//! destination upstream does - one clean copy - with a successful exit, plus a
+//! non-vacuous guard that the destination equals the source (no doubled or
+//! corrupted entry survived the de-duplication).
+//!
+//! It builds the transfer commands directly rather than via `pull_into`, which
+//! appends a single source operand and so cannot list the source repeatedly.
+//!
+//! upstream: flist.c `clean_flist()` (referenced by `testsuite/duplicates.test`),
+//! which removes duplicate names after sorting the file list.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The duplicate source-operand parity check.
+pub struct Duplicates;
+
+/// How many times the same source is named in the transfer command.
+const REPEATS: usize = 4;
+
+/// Preserve metadata; `--numeric-ids` keeps owner comparison host-stable.
+const FLAGS: &[&str] = &["-rlptgoD", "--numeric-ids"];
+
+impl Check for Duplicates {
+    fn name(&self) -> &'static str {
+        "duplicates"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("duplicates");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src))
+            .collect()
+    }
+}
+
+impl Duplicates {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let daemon = match transport {
+            Transport::Daemon => match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), label, format!("daemon: {e}")),
+            },
+            _ => None,
+        };
+        let module_url = daemon.as_ref().map(|d| d.module_url());
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        let up_dst = root.join(format!("up-{label}"));
+        let oc_dst = root.join(format!("oc-{label}"));
+
+        let up_transport = transport.for_upstream();
+        let up_operand = source_operand(up_transport, src, module_url.as_deref());
+        match transfer(
+            ctx.upstream,
+            ctx.upstream,
+            up_transport,
+            &up_operand,
+            &up_dst,
+            &flags,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        }
+        let oc_operand = source_operand(transport, src, module_url.as_deref());
+        match transfer(
+            ctx.oc,
+            ctx.upstream,
+            transport,
+            &oc_operand,
+            &oc_dst,
+            &flags,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        }
+        drop(daemon);
+
+        // Non-vacuous: de-duplication must yield exactly the source tree in both
+        // destinations - no doubled or corrupted entry survived.
+        if let Some(diff) = support::content_diff(&oc_dst, src) {
+            return CheckOutcome::fail(self.name(), label, format!("oc dest != source: {diff}"));
+        }
+        if let Some(diff) = support::content_diff(&up_dst, src) {
+            return CheckOutcome::fail(
+                self.name(),
+                label,
+                format!("upstream dest != source: {diff}"),
+            );
+        }
+        match support::content_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), label, diff),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// The single source-operand form for `transport`; the caller pushes [`REPEATS`]
+/// copies of it onto the command to name the same source repeatedly.
+fn source_operand(transport: Transport, src: &Path, module_url: Option<&str>) -> String {
+    match transport {
+        Transport::Local => format!("{}/", src.display()),
+        Transport::SshSubprocess => format!("localhost:{}/", src.display()),
+        Transport::Russh => format!("ssh://localhost{}/", src.display()),
+        Transport::Daemon => module_url.unwrap_or("").to_string(),
+    }
+}
+
+/// Reset `dst`, append [`REPEATS`] copies of the source operand plus the
+/// destination, and run the transfer capturing output.
+fn transfer(
+    client: &Path,
+    upstream: &Path,
+    transport: Transport,
+    operand: &str,
+    dst: &Path,
+    flags: &[String],
+) -> TaskResult<Output> {
+    reset_dir(dst)?;
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+    if !matches!(transport, Transport::Local | Transport::Daemon) {
+        cmd.arg(format!("--rsync-path={}", upstream.display()));
+    }
+    if matches!(transport, Transport::SshSubprocess) {
+        cmd.arg("-e")
+            .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no");
+    }
+    for _ in 0..REPEATS {
+        cmd.arg(operand);
+    }
+    cmd.arg(&dst_arg);
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("spawn rsync: {e}")))
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the source tree. Idempotent: removes any prior tree first. A couple of
+/// files plus a nested file, all mtime-backdated so the quick-check is
+/// deterministic. Distinct names let the content compare catch any accidental
+/// duplication.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+    std::fs::write(src.join("name1"), b"the first file\n").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("name2"), b"the second file\n").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("name3"), b"the nested file\n").map_err(|e| e.to_string())?;
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn source_operand_carries_trailing_slash_per_transport() {
+        let src = Path::new("/work/duplicates/src");
+        assert_eq!(
+            source_operand(Transport::Local, src, None),
+            "/work/duplicates/src/"
+        );
+        assert_eq!(
+            source_operand(Transport::SshSubprocess, src, None),
+            "localhost:/work/duplicates/src/"
+        );
+        assert_eq!(
+            source_operand(Transport::Daemon, src, Some("rsync://127.0.0.1:9/m/")),
+            "rsync://127.0.0.1:9/m/"
+        );
+    }
+
+    #[test]
+    fn repeats_yields_multiple_identical_operands() {
+        // The transfer names the source [`REPEATS`] times; mirror that expansion
+        // and assert it produces more than one copy of the same operand - the
+        // duplicate condition the check exercises.
+        let operand = source_operand(Transport::Local, Path::new("/s"), None);
+        let args: Vec<String> = (0..REPEATS).map(|_| operand.clone()).collect();
+        assert!(args.len() > 1);
+        assert!(args.iter().all(|a| a == &operand));
+    }
+}

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -15,7 +15,9 @@ mod crtimes;
 mod cvs_exclude;
 mod delete;
 mod devices;
+mod dirs;
 mod dry_run;
+mod duplicates;
 mod executability;
 mod files_from;
 mod filters;
@@ -25,6 +27,7 @@ mod itemize;
 mod link_dest;
 mod metadata;
 mod mkpath;
+mod modify_window;
 mod one_file_system;
 mod progress;
 mod prune_empty_dirs;
@@ -37,6 +40,7 @@ mod stats;
 mod symlinks;
 mod total_size;
 mod transfer_conditions;
+mod trimslash;
 mod verbosity;
 mod whole_file;
 mod xattr;
@@ -63,6 +67,9 @@ pub fn all() -> Vec<Box<dyn Check>> {
         Box::new(devices::Devices),
         // Path selection and layout.
         Box::new(relative::Relative),
+        Box::new(trimslash::TrimSlash),
+        Box::new(dirs::Dirs),
+        Box::new(duplicates::Duplicates),
         Box::new(mkpath::Mkpath),
         Box::new(files_from::FilesFrom),
         Box::new(filters::Filters),
@@ -80,6 +87,7 @@ pub fn all() -> Vec<Box<dyn Check>> {
         Box::new(total_size::TotalSize),
         // Transfer decisions and deletion.
         Box::new(transfer_conditions::TransferConditions),
+        Box::new(modify_window::ModifyWindow),
         Box::new(checksum::Checksum),
         Box::new(whole_file::WholeFile),
         Box::new(append_inplace::AppendInplace),

--- a/xtask/src/commands/validate/checks/modify_window.rs
+++ b/xtask/src/commands/validate/checks/modify_window.rs
@@ -1,0 +1,348 @@
+//! `--modify-window=N` quick-check tolerance parity between oc-rsync and upstream.
+//!
+//! Rsync's quick-check skips a file whose size and modification time both match
+//! the destination. `--modify-window=N` widens the mtime comparison so two times
+//! within `N` seconds count as equal (`same_time()` in util1.c). This check
+//! pre-seeds a destination whose file has the *same size* but *different content*
+//! and an mtime one second past the source's, then transfers with
+//! `--modify-window=2` over every transport. Because the mtimes fall inside the
+//! window and the sizes match, the quick-check must skip the file: oc-rsync's
+//! destination must equal upstream's and both must still hold the seeded
+//! (differing) content. A control run without the window - where the one-second
+//! mtime gap forces a transfer - anchors the non-vacuous claim that the option
+//! actually changed the decision.
+//!
+//! Like `transfer_conditions`, every scenario depends on a pre-seeded
+//! destination, so it cannot use `pull_into` (which wipes the destination). It
+//! seeds both destinations identically and runs the client directly without
+//! resetting the seeded tree.
+//!
+//! upstream: util1.c:1477 `same_time()` (returns equal when `|f1-f2| <=
+//! modify_window`); generator.c:1722 applies it in the unchanged-file path.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The `--modify-window` quick-check tolerance parity check.
+pub struct ModifyWindow;
+
+/// The single file exercised: same size in source and seed, differing content.
+const FILE: &str = "data.txt";
+/// Source bytes for [`FILE`].
+const SRC_BODY: &[u8] = b"modify-window-source-body\n";
+
+/// Source mtime (2021-03-04). Backdated so the quick-check does not re-transfer
+/// on mtime alone in the windowed run.
+const SRC_MTIME: &str = "@1614830767";
+/// Destination seed mtime: exactly one second past the source. Inside the
+/// window (2s) the quick-check treats it as equal; without the window the gap
+/// forces a transfer.
+const SEED_MTIME: &str = "@1614830768";
+
+/// The modify-window width, in seconds. Two exceeds the one-second seed gap.
+const WINDOW: &str = "--modify-window=2";
+
+/// Shared metadata-preserving base for both the windowed and control runs.
+const BASE: [&str; 2] = ["-rlptgoD", "--numeric-ids"];
+
+impl Check for ModifyWindow {
+    fn name(&self) -> &'static str {
+        "modify-window"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("modify-window");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        // Control probe (host-local, transport-independent): confirm the seeded
+        // one-second mtime gap really forces a transfer without the window, so
+        // the windowed skip below is a genuine behavior change, not a no-op.
+        if let Err(e) = assert_control_transfers(ctx.upstream, &src, &root) {
+            return vec![CheckOutcome::skip(self.name(), "control", e)];
+        }
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src))
+            .collect()
+    }
+}
+
+impl ModifyWindow {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let oc_dst = root.join(format!("oc-{label}"));
+        let up_dst = root.join(format!("up-{label}"));
+        if let Err(e) = seed(&oc_dst).and_then(|()| seed(&up_dst)) {
+            return CheckOutcome::skip(self.name(), label, format!("seed: {e}"));
+        }
+        // Non-vacuous precondition: the seed must differ from the source in
+        // content while matching its size, or the window would have nothing to
+        // skip past.
+        if let Err(e) = precondition(&oc_dst) {
+            return CheckOutcome::fail(self.name(), label, e);
+        }
+
+        let daemon = match transport {
+            Transport::Daemon => match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), label, format!("daemon: {e}")),
+            },
+            _ => None,
+        };
+        let module_url = daemon.as_ref().map(|d| d.module_url());
+        let flags = windowed_flags();
+
+        match run_client(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            &flags,
+            module_url.as_deref(),
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        }
+        match run_client(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            &flags,
+            module_url.as_deref(),
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        }
+        drop(daemon);
+
+        // The window must have skipped the file: both destinations still hold
+        // the seeded content, which differs from the source.
+        for (who, dst) in [("oc", &oc_dst), ("upstream", &up_dst)] {
+            if std::fs::read(dst.join(FILE)).ok().as_deref() == Some(SRC_BODY) {
+                return CheckOutcome::fail(
+                    self.name(),
+                    label,
+                    format!("{who} overwrote {FILE} despite --modify-window"),
+                );
+            }
+        }
+        match support::content_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), label, diff),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// The windowed flag set: shared base plus `--modify-window=2`.
+fn windowed_flags() -> Vec<String> {
+    BASE.iter()
+        .map(|s| s.to_string())
+        .chain(std::iter::once(WINDOW.to_string()))
+        .collect()
+}
+
+/// Verify the seeded one-second mtime gap forces a transfer *without* the
+/// window: a local run with only [`BASE`] must overwrite the seed with the
+/// source content. Otherwise the windowed skip would be indistinguishable from
+/// a quick-check that skipped for some unrelated reason.
+fn assert_control_transfers(upstream: &Path, src: &Path, root: &Path) -> Result<(), String> {
+    let dst = root.join("control");
+    seed(&dst)?;
+    let flags: Vec<String> = BASE.iter().map(|s| s.to_string()).collect();
+    let out = run_client(
+        Transport::Local,
+        upstream,
+        upstream,
+        src,
+        &dst,
+        &flags,
+        None,
+    )
+    .map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Err(format!(
+            "control run exited {}",
+            out.status.code().unwrap_or(-1)
+        ));
+    }
+    if std::fs::read(dst.join(FILE)).ok().as_deref() != Some(SRC_BODY) {
+        return Err("control run did not overwrite seed without --modify-window".into());
+    }
+    Ok(())
+}
+
+/// Build one client rsync command for `transport` and run it into the
+/// already-seeded `dst` without resetting it. Mirrors the operand forms of
+/// `transport::pull_into`, but leaves the seeded tree in place.
+fn run_client(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    flags: &[String],
+    module_url: Option<&str>,
+) -> TaskResult<Output> {
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let url = module_url
+                .ok_or_else(|| TaskError::Validation("daemon transport without url".into()))?;
+            cmd.arg(url).arg(&dst_arg);
+        }
+    }
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("spawn rsync: {e}")))
+}
+
+/// (Re)seed `dst` with a same-size, differing-content file whose mtime is one
+/// second past the source's.
+fn seed(dst: &Path) -> Result<(), String> {
+    if dst.exists() {
+        std::fs::remove_dir_all(dst).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(dst).map_err(|e| e.to_string())?;
+    std::fs::write(dst.join(FILE), differing_same_len(SRC_BODY)).map_err(|e| e.to_string())?;
+    support::capture(
+        "touch",
+        &["-h", "-d", SEED_MTIME, &dst.join(FILE).to_string_lossy()],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Assert the seeded precondition holds: same size as the source, different
+/// content. A false precondition is a seeding bug, not a divergence.
+fn precondition(dst: &Path) -> Result<(), String> {
+    let seed = std::fs::read(dst.join(FILE)).map_err(|e| e.to_string())?;
+    if seed.len() != SRC_BODY.len() {
+        return Err("seed size differs from source".into());
+    }
+    if seed == SRC_BODY {
+        return Err("seed content does not differ from source".into());
+    }
+    Ok(())
+}
+
+/// A buffer of the same length as `src` but differing in every byte, so the
+/// seeded destination matches the source's size while differing in content.
+fn differing_same_len(src: &[u8]) -> Vec<u8> {
+    src.iter().map(|b| b.wrapping_add(1)).collect()
+}
+
+/// Build the single-file source, backdated to [`SRC_MTIME`]. Idempotent.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src).map_err(|e| e.to_string())?;
+    std::fs::write(src.join(FILE), SRC_BODY).map_err(|e| e.to_string())?;
+    support::capture(
+        "touch",
+        &["-h", "-d", SRC_MTIME, &src.join(FILE).to_string_lossy()],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn differing_same_len_keeps_length_and_changes_every_byte() {
+        let out = differing_same_len(SRC_BODY);
+        assert_eq!(out.len(), SRC_BODY.len());
+        assert_ne!(out.as_slice(), SRC_BODY);
+        for (a, b) in SRC_BODY.iter().zip(out.iter()) {
+            assert_ne!(a, b);
+        }
+    }
+
+    #[test]
+    fn seed_mtime_is_one_second_past_source() {
+        // The gap must be positive and smaller than the window; encode both.
+        let src: i64 = SRC_MTIME.trim_start_matches('@').parse().unwrap();
+        let seed: i64 = SEED_MTIME.trim_start_matches('@').parse().unwrap();
+        assert_eq!(seed - src, 1);
+        assert_eq!(WINDOW, "--modify-window=2");
+    }
+
+    #[test]
+    fn windowed_flags_carry_base_then_window() {
+        let flags = windowed_flags();
+        assert_eq!(flags[0], "-rlptgoD");
+        assert_eq!(flags.last().unwrap(), WINDOW);
+    }
+
+    #[test]
+    fn precondition_rejects_a_seed_equal_to_the_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dst = tmp.path().join("dst");
+        std::fs::create_dir_all(&dst).unwrap();
+        // Same-size, differing content passes; identical content is rejected as a
+        // vacuous seed (no window skip to observe).
+        std::fs::write(dst.join(FILE), differing_same_len(SRC_BODY)).unwrap();
+        assert!(precondition(&dst).is_ok());
+        std::fs::write(dst.join(FILE), SRC_BODY).unwrap();
+        assert!(precondition(&dst).is_err());
+    }
+}

--- a/xtask/src/commands/validate/checks/trimslash.rs
+++ b/xtask/src/commands/validate/checks/trimslash.rs
@@ -1,0 +1,342 @@
+//! Trailing-slash source-operand layout parity between oc-rsync and upstream.
+//!
+//! A trailing slash on the source operand changes the destination layout: `rsync
+//! src dst/` copies the directory itself, creating `dst/src/...`, whereas `rsync
+//! src/ dst/` copies the *contents* of `src` directly into `dst`. This is one of
+//! rsync's most load-bearing conventions, so this check runs both operand forms
+//! over every transport and asserts oc-rsync reproduces upstream's destination
+//! tree exactly in each, plus a non-vacuous guard that the two forms actually
+//! produced different layouts (the named subdirectory is present under the
+//! no-slash form and absent under the slash form).
+//!
+//! It builds the transfer commands directly rather than via `pull_into`, which
+//! always appends a trailing slash and so could not exercise the no-slash form.
+//!
+//! upstream: the trailing-slash convention is implemented by trimming the slash
+//! and recording whether it was present (see `flist.c` `send_file_name` /
+//! `f_name` handling and the `sanitize_path`/trailing-slash logic in `options.c`);
+//! the behavior is what `testsuite/trimslash.test` guards at the primitive level.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The trailing-slash source-operand layout parity check.
+pub struct TrimSlash;
+
+/// Name of the source directory. Under the no-slash form this becomes a
+/// subdirectory of the destination; under the slash form it disappears.
+const SRC_NAME: &str = "tree";
+/// A file inside the source tree; its destination path differs between forms.
+const LEAF: &str = "leaf.txt";
+
+/// Preserve metadata; `--numeric-ids` keeps owner comparison host-stable. No
+/// path-altering option (`-R`, `-d`) so the trailing slash is the only variable.
+const FLAGS: &[&str] = &["-rlptgoD", "--numeric-ids"];
+
+/// One operand form: whether the source operand carries a trailing slash.
+#[derive(Clone, Copy)]
+enum Form {
+    /// `src` (no trailing slash): copies the directory, creating `dst/src/...`.
+    NoSlash,
+    /// `src/` (trailing slash): copies the contents directly into `dst`.
+    Slash,
+}
+
+/// Both operand forms, in report order.
+const FORMS: [Form; 2] = [Form::NoSlash, Form::Slash];
+
+impl Form {
+    /// Stable short label used in the cell name.
+    fn label(self) -> &'static str {
+        match self {
+            Form::NoSlash => "no-slash",
+            Form::Slash => "slash",
+        }
+    }
+
+    /// The trailing-slash suffix appended after the source directory path.
+    fn suffix(self) -> &'static str {
+        match self {
+            Form::NoSlash => "",
+            Form::Slash => "/",
+        }
+    }
+}
+
+impl Check for TrimSlash {
+    fn name(&self) -> &'static str {
+        "trimslash"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("trimslash");
+        let src = root.join(SRC_NAME);
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        let mut out = Vec::new();
+        for &transport in ctx.transports {
+            for form in FORMS {
+                out.push(self.cell(ctx, transport, form, &root, &src));
+            }
+        }
+        out
+    }
+}
+
+impl TrimSlash {
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        form: Form,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = format!("{} {}", transport.label(), form.label());
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let daemon = match transport {
+            Transport::Daemon => match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), label, format!("daemon: {e}")),
+            },
+            _ => None,
+        };
+        let module_url = daemon.as_ref().map(|d| d.module_url());
+        let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
+
+        let up_dst = root.join(format!("up-{}-{}", transport.label(), form.label()));
+        let oc_dst = root.join(format!("oc-{}-{}", transport.label(), form.label()));
+
+        let up_transport = transport.for_upstream();
+        let up_operand = source_operand(up_transport, src, form, module_url.as_deref());
+        match transfer(
+            ctx.upstream,
+            ctx.upstream,
+            up_transport,
+            &up_operand,
+            &up_dst,
+            &flags,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &label, "upstream", other),
+        }
+        let oc_operand = source_operand(transport, src, form, module_url.as_deref());
+        match transfer(
+            ctx.oc,
+            ctx.upstream,
+            transport,
+            &oc_operand,
+            &oc_dst,
+            &flags,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), &label, "oc", other),
+        }
+        drop(daemon);
+
+        // Non-vacuous: the layout must match the form. The no-slash form nests
+        // the tree under its own name (`dst/tree/leaf.txt`); the slash form
+        // drops the leaf directly into `dst` (`dst/leaf.txt`, no `tree`). The
+        // daemon module already exports the tree's contents, so its "no-slash"
+        // operand (the bare module) behaves like the slash form; skip the layout
+        // assertion there and rely on the oc-vs-upstream compare.
+        if !matches!(transport, Transport::Daemon) {
+            if let Err(e) = check_layout(form, &oc_dst, "oc") {
+                return CheckOutcome::fail(self.name(), label, e);
+            }
+            if let Err(e) = check_layout(form, &up_dst, "upstream") {
+                return CheckOutcome::fail(self.name(), label, e);
+            }
+        }
+
+        match support::content_diff(&oc_dst, &up_dst) {
+            Some(diff) => CheckOutcome::fail(self.name(), label, diff),
+            None => CheckOutcome::pass(self.name(), label),
+        }
+    }
+}
+
+/// Assert `dst`'s layout matches `form`, so the check cannot pass vacuously.
+fn check_layout(form: Form, dst: &Path, who: &str) -> Result<(), String> {
+    match form {
+        Form::NoSlash => {
+            if !dst.join(SRC_NAME).join(LEAF).exists() {
+                return Err(format!(
+                    "{who}: no-slash form did not nest {SRC_NAME}/{LEAF}"
+                ));
+            }
+        }
+        Form::Slash => {
+            if !dst.join(LEAF).exists() {
+                return Err(format!(
+                    "{who}: slash form did not place {LEAF} at dest root"
+                ));
+            }
+            if dst.join(SRC_NAME).exists() {
+                return Err(format!("{who}: slash form wrongly nested {SRC_NAME}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build the source operand for `transport` and `form`. `SRC_NAME` is always the
+/// final path component so the no-slash form has a name to nest under; the slash
+/// form appends a trailing `/`.
+fn source_operand(
+    transport: Transport,
+    src: &Path,
+    form: Form,
+    module_url: Option<&str>,
+) -> String {
+    let suffix = form.suffix();
+    match transport {
+        Transport::Local => format!("{}{suffix}", src.display()),
+        Transport::SshSubprocess => format!("localhost:{}{suffix}", src.display()),
+        Transport::Russh => format!("ssh://localhost{}{suffix}", src.display()),
+        // The daemon exports the tree as module `m`; the bare module URL already
+        // ends in `/m/`, so both forms transfer the module contents.
+        Transport::Daemon => module_url.unwrap_or("").to_string(),
+    }
+}
+
+/// Reset `dst`, build the per-transport command, and run it capturing output.
+fn transfer(
+    client: &Path,
+    upstream: &Path,
+    transport: Transport,
+    operand: &str,
+    dst: &Path,
+    flags: &[String],
+) -> TaskResult<Output> {
+    reset_dir(dst)?;
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+    match transport {
+        Transport::Local | Transport::Daemon => {
+            cmd.arg(operand).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(operand)
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(operand)
+                .arg(&dst_arg);
+        }
+    }
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("spawn rsync: {e}")))
+}
+
+/// Recreate `dir` as an empty directory.
+fn reset_dir(dir: &Path) -> TaskResult<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)
+            .map_err(|e| TaskError::Validation(format!("remove {}: {e}", dir.display())))?;
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| TaskError::Validation(format!("create {}: {e}", dir.display())))
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label,
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
+    }
+}
+
+/// Build the source tree. Idempotent: removes any prior tree first. A single
+/// backdated leaf file is enough to observe the layout difference.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src).map_err(|e| e.to_string())?;
+    std::fs::write(src.join(LEAF), b"leaf body\n").map_err(|e| e.to_string())?;
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture(
+            "touch",
+            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn slash_form_appends_trailing_slash_only_when_requested() {
+        let src = Path::new("/work/trimslash/tree");
+        assert_eq!(
+            source_operand(Transport::Local, src, Form::NoSlash, None),
+            "/work/trimslash/tree"
+        );
+        assert_eq!(
+            source_operand(Transport::Local, src, Form::Slash, None),
+            "/work/trimslash/tree/"
+        );
+    }
+
+    #[test]
+    fn network_forms_prefix_the_host_and_preserve_the_suffix() {
+        let src = Path::new("/work/trimslash/tree");
+        assert_eq!(
+            source_operand(Transport::SshSubprocess, src, Form::NoSlash, None),
+            "localhost:/work/trimslash/tree"
+        );
+        assert_eq!(
+            source_operand(Transport::Russh, src, Form::Slash, None),
+            "ssh://localhost/work/trimslash/tree/"
+        );
+    }
+
+    #[test]
+    fn check_layout_enforces_the_form_specific_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("no-slash");
+        std::fs::create_dir_all(nested.join(SRC_NAME)).unwrap();
+        std::fs::write(nested.join(SRC_NAME).join(LEAF), b"x").unwrap();
+        assert!(check_layout(Form::NoSlash, &nested, "oc").is_ok());
+        assert!(check_layout(Form::Slash, &nested, "oc").is_err());
+
+        let flat = tmp.path().join("slash");
+        std::fs::create_dir_all(&flat).unwrap();
+        std::fs::write(flat.join(LEAF), b"x").unwrap();
+        assert!(check_layout(Form::Slash, &flat, "oc").is_ok());
+        assert!(check_layout(Form::NoSlash, &flat, "oc").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Extends the `cargo xtask validate` fidelity matrix with four upstream-parity
checks covering options that were previously not exercised. Each check runs
oc-rsync against upstream rsync as the pulling client over every transport
(local, ssh-subprocess, russh, daemon) and asserts identical destinations, with
a non-vacuous guard proving the option under test actually changed the outcome.

## Checks added

- **modify-window** (`checks/modify_window.rs`) - `--modify-window=N` quick-check
  tolerance. Pre-seeds a same-size, differing-content destination whose mtime is
  one second past the source; with `--modify-window=2` the quick-check must skip
  it. A control run without the window (where the one-second gap forces a
  transfer) anchors the non-vacuous claim. Sibling of `transfer-conditions`.
- **dirs** (`checks/dirs.rs`) - `-d`/`--dirs` includes directories without
  recursing: the named subdirectory is created but its nested file is not
  transferred.
- **trimslash** (`checks/trimslash.rs`) - trailing-slash source-operand layout.
  `src` nests under `dst/src/...`; `src/` copies contents into `dst`. Both forms
  are exercised and the layout difference is asserted.
- **duplicates** (`checks/duplicates.rs`) - the same source named several times
  is de-duplicated into one clean copy with a successful exit.

## Candidates skipped

None. All four candidate gaps were verified genuinely uncovered by the existing
~40 checks before implementation.

## Validation

- `cargo build -p xtask`, `cargo clippy -p xtask --all-targets --all-features
  --no-deps -- -D warnings`, and `cargo fmt --all -- --check` all clean.
- `cargo nextest run -p xtask`: 390 tests run, 390 passed.
- Behavior validated against system rsync 3.4.4 on an x86_64 Linux host for all
  four options: `-d` creates the subdir but skips the nested file; the
  trailing-slash forms produce the expected nested vs flat layout; duplicate
  operands yield one clean copy at exit 0; and `--modify-window=2` skips an
  equal-size file whose mtime is within the window while a windowless control
  transfers it.

The only shared file touched is `checks/mod.rs` (module declarations plus
registry entries in report order).
