### PR TITLE
fix: honor -J/--omit-link-times and -E on remote pulls

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -136,6 +136,22 @@ pub(crate) fn build_server_config_for_receiver(
     // and must carry the fuzzy level; the compact 'y' letter is emitted only
     // when the local side is the sender.
     server_config.flags.fuzzy_level = config.fuzzy_level();
+    // upstream: options.c:2648-2649 - `if (am_sender) { ... if (omit_link_times)
+    // argstr[x++] = 'J'; }`. -J/--omit-link-times skips a received symlink's
+    // mtime (rsync.c:583 adds ATTRS_SKIP_MTIME for `omit_link_times &&
+    // S_ISLNK`), so on a pull the local client IS the receiver and must carry
+    // the flag; the compact 'J' letter is emitted only when the local side is
+    // the sender. Without this the daemon pull set symlink mtimes from the
+    // source while the local copy executor honoured -J.
+    server_config.flags.omit_link_times = config.omit_link_times();
+    // upstream: options.c:2692-2693 - `else if (preserve_executability &&
+    // am_sender) argstr[x++] = 'E';`. -E/--executability copies the source
+    // executability bits when perms are not otherwise preserved
+    // (rsync.c:457-465), so on a pull the local client IS the receiver and must
+    // carry the flag; the compact 'E' letter is emitted only when the local
+    // side is the sender. Without this the daemon pull left files at their
+    // existing mode while the local copy executor honoured -E.
+    server_config.flags.preserve_executability = config.preserve_executability();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -1276,6 +1276,52 @@ mod server_config_reference_dirs {
         assert!(!server_config.flags.omit_dir_times);
     }
 
+    /// On a daemon (rsync://) pull the local client IS the receiver and applies
+    /// --omit-link-times itself (upstream rsync.c:583). options.c:2648-2649
+    /// packs the compact 'J' only when am_sender, so on a pull it must be
+    /// carried onto the receiver config.
+    #[test]
+    fn receiver_config_propagates_omit_link_times() {
+        let config = ClientConfig::builder().omit_link_times(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(server_config.flags.omit_link_times);
+    }
+
+    /// Without --omit-link-times the receiver config leaves the flag clear.
+    #[test]
+    fn receiver_config_without_omit_link_times_stays_clear() {
+        let config = ClientConfig::default();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(!server_config.flags.omit_link_times);
+    }
+
+    /// On a daemon (rsync://) pull the local client IS the receiver and applies
+    /// -E itself (upstream rsync.c:457-465). options.c:2692-2693 packs the
+    /// compact 'E' only when am_sender, so on a pull it must be carried onto the
+    /// receiver config.
+    #[test]
+    fn receiver_config_propagates_preserve_executability() {
+        let config = ClientConfig::builder().executability(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(server_config.flags.preserve_executability);
+    }
+
+    /// Without -E the receiver config leaves the flag clear.
+    #[test]
+    fn receiver_config_without_preserve_executability_stays_clear() {
+        let config = ClientConfig::default();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()], Vec::new()).unwrap();
+
+        assert!(!server_config.flags.preserve_executability);
+    }
+
     /// On a daemon (rsync://) pull the local client IS the receiver and creates
     /// the dest-arg path chain itself. `--mkpath` is never forwarded to the
     /// remote daemon (upstream options.c:2996-2997 gates it on am_sender), so the

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -632,6 +632,22 @@ fn build_server_config_for_receiver(
     // and must carry the fuzzy level; the compact 'y' letter is emitted only
     // when the local side is the sender.
     server_config.flags.fuzzy_level = config.fuzzy_level();
+    // upstream: options.c:2648-2649 - `if (am_sender) { ... if (omit_link_times)
+    // argstr[x++] = 'J'; }`. -J/--omit-link-times skips a received symlink's
+    // mtime (rsync.c:583 adds ATTRS_SKIP_MTIME for `omit_link_times &&
+    // S_ISLNK`), so on a pull the local client IS the receiver and must carry
+    // the flag; the compact 'J' letter is emitted only when the local side is
+    // the sender. Without this the embedded-ssh pull set symlink mtimes from the
+    // source while the local copy executor honoured -J.
+    server_config.flags.omit_link_times = config.omit_link_times();
+    // upstream: options.c:2692-2693 - `else if (preserve_executability &&
+    // am_sender) argstr[x++] = 'E';`. -E/--executability copies the source
+    // executability bits when perms are not otherwise preserved
+    // (rsync.c:457-465), so on a pull the local client IS the receiver and must
+    // carry the flag; the compact 'E' letter is emitted only when the local
+    // side is the sender. Without this the embedded-ssh pull left files at their
+    // existing mode while the local copy executor honoured -E.
+    server_config.flags.preserve_executability = config.preserve_executability();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
@@ -983,6 +999,52 @@ mod tests {
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
 
         assert!(!server_config.flags.omit_dir_times);
+    }
+
+    /// On an embedded-ssh pull the local client IS the receiver and applies
+    /// --omit-link-times itself (upstream rsync.c:583). options.c:2648-2649
+    /// packs the compact 'J' only when am_sender, so on a pull it must be
+    /// carried onto the receiver config.
+    #[test]
+    fn embedded_receiver_config_propagates_omit_link_times() {
+        let config = ClientConfig::builder().omit_link_times(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.omit_link_times);
+    }
+
+    /// Without --omit-link-times the receiver config leaves the flag clear.
+    #[test]
+    fn embedded_receiver_config_without_omit_link_times_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.omit_link_times);
+    }
+
+    /// On an embedded-ssh pull the local client IS the receiver and applies -E
+    /// itself (upstream rsync.c:457-465). options.c:2692-2693 packs the compact
+    /// 'E' only when am_sender, so on a pull it must be carried onto the
+    /// receiver config.
+    #[test]
+    fn embedded_receiver_config_propagates_preserve_executability() {
+        let config = ClientConfig::builder().executability(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.preserve_executability);
+    }
+
+    /// Without -E the receiver config leaves the flag clear.
+    #[test]
+    fn embedded_receiver_config_without_preserve_executability_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.preserve_executability);
     }
 
     /// The embedded (russh) pull receiver must carry `--mkpath` onto its

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -158,6 +158,22 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
     // and must carry the fuzzy level; the compact 'y' letter is emitted only
     // when the local side is the sender.
     server_config.flags.fuzzy_level = config.fuzzy_level();
+    // upstream: options.c:2648-2649 - `if (am_sender) { ... if (omit_link_times)
+    // argstr[x++] = 'J'; }`. -J/--omit-link-times skips a received symlink's
+    // mtime (rsync.c:583 adds ATTRS_SKIP_MTIME for `omit_link_times &&
+    // S_ISLNK`), so on a pull the local client IS the receiver and must carry
+    // the flag; the compact 'J' letter is emitted only when the local side is
+    // the sender. Without this the ssh pull set symlink mtimes from the source
+    // while the local copy executor honoured -J.
+    server_config.flags.omit_link_times = config.omit_link_times();
+    // upstream: options.c:2692-2693 - `else if (preserve_executability &&
+    // am_sender) argstr[x++] = 'E';`. -E/--executability copies the source
+    // executability bits when perms are not otherwise preserved
+    // (rsync.c:457-465), so on a pull the local client IS the receiver and must
+    // carry the flag; the compact 'E' letter is emitted only when the local
+    // side is the sender. Without this the ssh pull left files at their existing
+    // mode while the local copy executor honoured -E.
+    server_config.flags.preserve_executability = config.preserve_executability();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
@@ -589,6 +605,57 @@ mod tests {
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
 
         assert!(!server_config.flags.omit_dir_times);
+    }
+
+    /// On an ssh pull the local client IS the receiver and applies
+    /// --omit-link-times itself (upstream rsync.c:583 adds ATTRS_SKIP_MTIME for
+    /// a symlink). options.c:2648-2649 packs the compact 'J' only when
+    /// am_sender, so on a pull it never rides the wire and must be carried onto
+    /// the receiver config. Regression guard for the ssh pull that set symlink
+    /// mtimes from the source while the local copy executor honoured -J.
+    #[test]
+    fn receiver_config_propagates_omit_link_times() {
+        let config = ClientConfig::builder().omit_link_times(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.omit_link_times);
+    }
+
+    /// Without --omit-link-times the receiver config leaves the flag clear, so
+    /// symlink mtimes are preserved as before.
+    #[test]
+    fn receiver_config_without_omit_link_times_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.omit_link_times);
+    }
+
+    /// On an ssh pull the local client IS the receiver and applies -E itself
+    /// (upstream rsync.c:457-465 layers the source executability bits on the
+    /// destination mode). options.c:2692-2693 packs the compact 'E' only when
+    /// am_sender, so on a pull it never rides the wire and must be carried onto
+    /// the receiver config. Regression guard for the ssh pull that left files at
+    /// their existing mode while the local copy executor honoured -E.
+    #[test]
+    fn receiver_config_propagates_preserve_executability() {
+        let config = ClientConfig::builder().executability(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.flags.preserve_executability);
+    }
+
+    /// Without -E the receiver config leaves the flag clear.
+    #[test]
+    fn receiver_config_without_preserve_executability_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.flags.preserve_executability);
     }
 
     /// On an ssh pull the local client IS the receiver and creates the dest-arg

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -344,6 +344,30 @@ pub struct ParsedServerFlags {
     /// !omit_dir_times`).
     pub omit_dir_times: bool,
 
+    /// Omit symlink modification times (long-form `--omit-link-times` / `-J`).
+    ///
+    /// Receiver-side only. Not part of the compact flag string built by
+    /// `build_server_flag_string`: upstream `options.c:2648-2649` packs `'J'`
+    /// into `server_options` only inside the `if (am_sender)` block, so on a
+    /// pull the flag is never sent over the wire and the local client (which IS
+    /// the receiver) must apply it itself. When set, the receiver skips a
+    /// symlink's mtime, mirroring upstream `rsync.c:583` where `omit_link_times
+    /// && S_ISLNK` adds `ATTRS_SKIP_MTIME | ATTRS_SKIP_ATIME | ATTRS_SKIP_CRTIME`
+    /// in `set_file_attrs()`.
+    pub omit_link_times: bool,
+
+    /// Preserve executability (long-form `--executability` / `-E`).
+    ///
+    /// Receiver-side only. Not part of the compact flag string built by
+    /// `build_server_flag_string`: upstream `options.c:2692-2693` packs `'E'`
+    /// into `server_options` only inside the `else if (preserve_executability &&
+    /// am_sender)` branch, so on a pull the flag is never sent over the wire and
+    /// the local client (which IS the receiver) must apply it itself. When set
+    /// without `--perms`, the receiver copies only the executability bits from
+    /// the source mode, mirroring upstream `rsync.c:457-465` (`set_file_attrs()`
+    /// layers `-E` on top when `!preserve_perms`).
+    pub preserve_executability: bool,
+
     /// Engage the opt-in parallel sender-side delta scan for large files
     /// (long-form `--parallel-delta-scan`).
     ///

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -17,6 +17,26 @@ use crate::generator::ItemFlags;
 use crate::receiver::ReceiverContext;
 
 impl ReceiverContext {
+    /// Reports whether a received symlink's mtime should be preserved.
+    ///
+    /// True when `--times` is active and `--omit-link-times` (`-J`) is not.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:583` - `set_file_attrs()` adds `ATTRS_SKIP_MTIME |
+    ///   ATTRS_SKIP_ATIME | ATTRS_SKIP_CRTIME` when `omit_link_times &&
+    ///   S_ISLNK(file->mode)`, so a symlink keeps its wall-clock creation time
+    ///   instead of the sender-supplied mtime.
+    /// - `options.c:2648-2649` - `-J` is packed into `server_options` only on a
+    ///   push (`am_sender`), so on a pull the local receiver applies it itself.
+    ///
+    /// Mirrors the local-copy executor, which builds symlink options as
+    /// `metadata_options.clone().preserve_times(false)` when
+    /// `omit_link_times_enabled()` (engine `local_copy/executor/special/symlink.rs`).
+    const fn preserve_symlink_times(&self) -> bool {
+        self.config.flags.times && !self.config.flags.omit_link_times
+    }
+
     /// Creates symbolic links from the file list entries.
     ///
     /// Iterates through the received file list, finds symlink entries with
@@ -107,7 +127,7 @@ impl ReceiverContext {
                     let symlink_options = MetadataOptions::new()
                         .preserve_owner(self.config.flags.owner)
                         .preserve_group(self.config.flags.group)
-                        .preserve_times(self.config.flags.times)
+                        .preserve_times(self.preserve_symlink_times())
                         .preserve_atimes(self.config.flags.atimes)
                         .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
                         .fake_super(self.config.fake_super);
@@ -223,7 +243,7 @@ impl ReceiverContext {
                 let compare_opts = MetadataOptions::new()
                     .preserve_owner(self.config.flags.owner)
                     .preserve_group(self.config.flags.group)
-                    .preserve_times(self.config.flags.times)
+                    .preserve_times(self.preserve_symlink_times())
                     .preserve_atimes(self.config.flags.atimes)
                     .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
                     .fake_super(self.config.fake_super);
@@ -291,7 +311,7 @@ impl ReceiverContext {
             let symlink_options = MetadataOptions::new()
                 .preserve_owner(self.config.flags.owner)
                 .preserve_group(self.config.flags.group)
-                .preserve_times(self.config.flags.times)
+                .preserve_times(self.preserve_symlink_times())
                 .preserve_atimes(self.config.flags.atimes)
                 .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
                 .fake_super(self.config.fake_super);
@@ -405,7 +425,7 @@ impl ReceiverContext {
                     let symlink_options = MetadataOptions::new()
                         .preserve_owner(self.config.flags.owner)
                         .preserve_group(self.config.flags.group)
-                        .preserve_times(self.config.flags.times)
+                        .preserve_times(self.preserve_symlink_times())
                         .preserve_atimes(self.config.flags.atimes)
                         .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
                         .fake_super(self.config.fake_super);
@@ -508,7 +528,7 @@ impl ReceiverContext {
             let symlink_options = MetadataOptions::new()
                 .preserve_owner(self.config.flags.owner)
                 .preserve_group(self.config.flags.group)
-                .preserve_times(self.config.flags.times)
+                .preserve_times(self.preserve_symlink_times())
                 .preserve_atimes(self.config.flags.atimes)
                 .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
                 .fake_super(self.config.fake_super);
@@ -965,6 +985,74 @@ fn create_windows_symlink(target: &Path, link_path: &Path) -> std::io::Result<()
 #[cfg(test)]
 mod tests {
     use std::fs;
+
+    /// The receiver honours `-J`/`--omit-link-times`: a received symlink's mtime
+    /// is preserved only when `--times` is set AND `--omit-link-times` is not.
+    ///
+    /// This is the transfer-side honoring decision fed to every
+    /// `apply_symlink_metadata_from_entry` call in `create_symlinks`. It mirrors
+    /// the local copy executor, which builds symlink options as
+    /// `metadata_options.clone().preserve_times(false)` when
+    /// `omit_link_times_enabled()`.
+    ///
+    /// upstream: rsync.c:583 - `set_file_attrs()` adds `ATTRS_SKIP_MTIME` for a
+    /// symlink when `omit_link_times`. options.c:2648-2649 packs the compact 'J'
+    /// only on a push (`am_sender`), so on a pull the receiver applies it itself.
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn omit_link_times_controls_symlink_mtime_preservation() {
+        use std::ffi::OsString;
+
+        use protocol::ProtocolVersion;
+
+        use crate::config::ServerConfig;
+        use crate::flags::ParsedServerFlags;
+        use crate::handshake::HandshakeResult;
+        use crate::receiver::ReceiverContext;
+        use crate::role::ServerRole;
+
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let make = |times: bool, omit: bool| ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-r".to_owned(),
+            flags: ParsedServerFlags {
+                times,
+                omit_link_times: omit,
+                recursive: true,
+                ..ParsedServerFlags::default()
+            },
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+
+        let ctx = ReceiverContext::new_for_test(&handshake, make(true, false));
+        assert!(
+            ctx.preserve_symlink_times(),
+            "-t without -J must preserve the symlink mtime"
+        );
+
+        let ctx = ReceiverContext::new_for_test(&handshake, make(true, true));
+        assert!(
+            !ctx.preserve_symlink_times(),
+            "-J must suppress the symlink mtime even under -t"
+        );
+
+        let ctx = ReceiverContext::new_for_test(&handshake, make(false, false));
+        assert!(
+            !ctx.preserve_symlink_times(),
+            "without -t there is no source mtime to preserve"
+        );
+    }
 
     /// Verifies `fast_io::hard_link` creates a valid hard link regardless of
     /// whether io_uring handles it or `std::fs::hard_link` does.

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -226,6 +226,15 @@ impl ReceiverContext {
 
         let metadata_opts = MetadataOptions::new()
             .preserve_permissions(self.config.flags.perms)
+            // upstream: options.c:2692-2693 packs the compact 'E' into
+            // server_options only inside `else if (preserve_executability &&
+            // am_sender)`, so on a pull `-E` never rides the wire to the remote
+            // sender; the local client IS the receiver and applies it itself.
+            // rsync.c:457-465 set_file_attrs() layers the source executability
+            // bits onto the destination mode when `!preserve_perms`. Without
+            // this the ssh/daemon pull left files at their existing mode while
+            // the local copy executor honoured `-E` (local_copy metadata.rs:7).
+            .preserve_executability(self.config.flags.preserve_executability)
             .preserve_times(self.config.flags.times)
             .preserve_atimes(self.config.flags.atimes)
             .preserve_crtimes(self.config.flags.crtimes)


### PR DESCRIPTION
## Summary

On a pull the local client IS the receiver, but two receiver-side options are
gated on `am_sender` in `options.c:server_options()`, so neither is ever sent
over the wire to the remote sender - the local receiver must apply them itself.
Both were carried correctly by the local copy executor but dropped on every
remote-receiver path (external ssh, embedded ssh/russh, daemon), so a remote
pull diverged from a local copy.

This adds a `ParsedServerFlags` field per option, propagates each from
`ClientConfig` in all three remote-receiver builders, and wires the receiver to
honor them - mirroring the local copy executor exactly.

## Options fixed

### `-J` / `--omit-link-times`
- **upstream**: `options.c:2648-2649` packs the compact `J` into `server_options`
  only inside `if (am_sender)`; `rsync.c:583` adds
  `ATTRS_SKIP_MTIME | ATTRS_SKIP_ATIME | ATTRS_SKIP_CRTIME` in `set_file_attrs()`
  when `omit_link_times && S_ISLNK`.
- **gap**: the receiver's five symlink metadata-apply sites always used
  `preserve_times(self.config.flags.times)`, so a remote pull set symlink mtimes
  from the source even under `-J`, while the local copy executor
  (`local_copy/executor/special/symlink.rs`) built symlink options as
  `metadata_options.clone().preserve_times(false)`.
- **fix**: new `ReceiverContext::preserve_symlink_times()` returns
  `times && !omit_link_times`; all five sites now feed it.

### `-E` / `--executability`
- **upstream**: `options.c:2692-2693` packs the compact `E` only inside
  `else if (preserve_executability && am_sender)`; `rsync.c:457-465` layers the
  source executability bits onto the destination mode when `!preserve_perms`.
- **gap**: the receiver's `MetadataOptions` builder
  (`receiver/transfer/setup/context.rs`) never set `preserve_executability`, so a
  remote pull left files at their existing mode, while the local copy executor
  (`local_copy/context_impl/options/metadata.rs`) set it. The metadata crate
  already honors `MetadataOptions::preserve_executability()` end to end.
- **fix**: feed `self.config.flags.preserve_executability` into the receiver's
  `MetadataOptions`.

## End-to-end wiring

`ClientConfig` -> `build_server_config_for_receiver` (ssh / embedded ssh /
daemon) sets `server_config.flags.{omit_link_times,preserve_executability}` ->
receiver reads them at metadata-apply time. Neither is packed into the compact
flag string (that string is also sent to the remote sender on a pull, where
upstream sends neither), matching the existing `-O`/`-K`/`-y` direct-propagation
pattern.

## Deferred

- **`--super`**: no local-executor reference to mirror - the local copy models
  super-user via real-root detection (`metadata::am_root()`) plus `--fake-super`
  only, and never treats `am_root > 1` (explicit `--super`) specially. Honoring
  it end to end would require threading a super-user tri-state through
  `metadata::apply` ownership/device handling, a cross-cutting change that would
  also leave the local path inconsistent. Deferred rather than ship a half-wired
  field.
- **`--force`**: force-deletion of non-empty directories during transfer lives
  deep in the receiver's `delete_item`/obstacle-replacement pipeline
  (`delete.c` semantics). Sizing it safely without risking the working delete
  path is beyond this change's scope; deferred.
- **push forwarding**: this change covers the pull path (local client is the
  receiver). Forwarding `-J`/`-E` to a *remote* receiver on a push is a separate
  sender-side concern and is unchanged here.

## Tests

- Builder propagation tests in all three receiver builders (`*_propagates_*` +
  `*_stays_clear`), mirroring the existing keep-both style.
- Transfer behavior test `omit_link_times_controls_symlink_mtime_preservation`
  proving the `-J` honoring decision.

## Verification

- `cargo build --workspace --all-features` - clean
- `cargo nextest run -p core -p transfer --all-features` targeted filter - 105
  passed
- `cargo fmt --all -- --check` - clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
  - clean

Host validation against the real binary was not performed; the gap is
established from the upstream C source and the local-copy reference.
