### PR TITLE
feat(xtask): add security and wire category checks to validate

### DIFF
--- a/xtask/src/commands/validate/checks/capability_string.rs
+++ b/xtask/src/commands/validate/checks/capability_string.rs
@@ -1,0 +1,237 @@
+//! Server-args capability-string parity between oc-rsync and upstream.
+//!
+//! When rsync starts a remote-shell transfer it invokes `<rsh> <host> rsync
+//! --server <compact-flags> . <path>`, where the compact-flags token carries the
+//! protocol-32 capability suffix after a `.` - e.g. `-logDtpre.iLsfxCIvu`. The
+//! suffix advertises the client's negotiable capabilities (checksum/compression
+//! choice, incremental recursion, symlink-times, and so on) and must match
+//! upstream byte-for-byte or a peer negotiates the wrong feature set.
+//!
+//! upstream: options.c:2216 `server_options()` builds `argstr` (the compact flag
+//! string) and appends the capability letters; main.c:1187 `do_cmd()` execs the
+//! remote shell with those args.
+//!
+//! The transfer is oriented as a PUSH (`src/ host:dst/`), so the client under
+//! test is the sender and advertises the full capability set including the
+//! inc-recurse `i` letter. This is the direction where the drop-in contract holds
+//! byte-for-byte: on a PULL oc deliberately suppresses `i` because its receive
+//! path clears CF_INC_RECURSE (compat.c:162 `set_allow_inc_recurse()`), so a pull
+//! comparison would flag intended behaviour rather than a regression.
+//!
+//! This check observes the invocation directly: it runs each client with `-e`
+//! pointed at a tiny capture shell that records the exact argv it is handed, then
+//! extracts the compact-flags token and asserts oc's equals upstream's. It needs
+//! no live peer - the capture shell exits immediately - so it is deterministic
+//! and requires neither sshd nor a daemon.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use crate::commands::validate::support;
+use crate::commands::validate::{Category, Check, CheckOutcome, ValidateCtx};
+
+/// The server-args capability-string parity check.
+pub struct CapabilityString;
+
+/// Client flags whose compact encoding carries the capability suffix. `-rlptgoD`
+/// (the `-a` expansion) is stable across versions and forces `--server --sender`
+/// with the full capability string.
+const CLIENT_FLAGS: &[&str] = &["-rlptgoD", "--numeric-ids"];
+
+/// Substring every protocol-32 capability suffix contains. Guards against a
+/// vacuous pass on a token that happens to hold a `.` but no capability letters.
+///
+/// upstream: compat.c - the negotiated suffix always includes the checksum
+/// (`C`), compression (`f`/`x`), and inc-recurse (`i`) capability letters that
+/// spell the `LsfxCIvu` family.
+const CAPABILITY_MARKER: &str = "LsfxCIvu";
+
+impl Check for CapabilityString {
+    fn name(&self) -> &'static str {
+        "capability-string"
+    }
+
+    fn categories(&self) -> &'static [Category] {
+        &[Category::Wire]
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("capability-string");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "server-args", e)];
+        }
+        vec![self.cell(ctx, &root, &src)]
+    }
+}
+
+impl CapabilityString {
+    /// Capture each client's remote-shell argv, extract the compact-flags token,
+    /// and compare oc's against upstream's.
+    fn cell(&self, ctx: &ValidateCtx, root: &Path, src: &Path) -> CheckOutcome {
+        let up = match capture_compact_flags(ctx.upstream, root, src, "up") {
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                return CheckOutcome::skip(
+                    self.name(),
+                    "server-args",
+                    "upstream emitted no compact-flags token (rsh not invoked)",
+                );
+            }
+            Err(e) => return CheckOutcome::skip(self.name(), "server-args", e),
+        };
+        let oc = match capture_compact_flags(ctx.oc, root, src, "oc") {
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                return CheckOutcome::fail(
+                    self.name(),
+                    "server-args",
+                    "oc emitted no compact-flags token; expected the capability string",
+                );
+            }
+            Err(e) => return CheckOutcome::skip(self.name(), "server-args", e),
+        };
+
+        // Non-vacuous: the token must actually carry the capability suffix.
+        if !up.contains(CAPABILITY_MARKER) {
+            return CheckOutcome::skip(
+                self.name(),
+                "server-args",
+                format!("upstream token `{up}` lacks the `{CAPABILITY_MARKER}` capability suffix"),
+            );
+        }
+        if oc != up {
+            if ctx.verbose {
+                eprintln!("[capability-string] oc=`{oc}` upstream=`{up}`");
+            }
+            return CheckOutcome::fail(
+                self.name(),
+                "server-args",
+                format!("capability string differs: oc=`{oc}` upstream=`{up}`"),
+            );
+        }
+        CheckOutcome::pass(self.name(), "server-args")
+    }
+}
+
+/// Run `client` as an rsh-pulling client whose remote shell is a capture script,
+/// returning the single compact-flags token it handed the shell (`None` if the
+/// shell was never invoked, i.e. no capture was written).
+fn capture_compact_flags(
+    client: &Path,
+    root: &Path,
+    src: &Path,
+    tag: &str,
+) -> Result<Option<String>, String> {
+    let capture = root.join(format!("argv-{tag}.txt"));
+    let _ = std::fs::remove_file(&capture);
+    let rsh = write_capture_rsh(root, &capture, tag)?;
+
+    let mut cmd = Command::new(client);
+    cmd.args(CLIENT_FLAGS)
+        .arg("-e")
+        .arg(&rsh)
+        // Push: local source, remote destination. The client is the sender and
+        // advertises the full capability suffix. A fake host forces the
+        // remote-shell path; the capture script ignores it.
+        .arg(format!("{}/", src.display()))
+        .arg(format!(
+            "oc-validate-host:{}/",
+            root.join(format!("dst-{tag}")).display()
+        ));
+    // The capture shell exits immediately, so the client reports a closed
+    // connection; its exit status is irrelevant - only the recorded argv matters.
+    cmd.output().map_err(|e| format!("spawn {client:?}: {e}"))?;
+
+    if !capture.exists() {
+        return Ok(None);
+    }
+    let recorded = std::fs::read_to_string(&capture).map_err(|e| e.to_string())?;
+    Ok(compact_flags_token(&recorded))
+}
+
+/// Write an executable rsh that records each argv entry (one per line) into
+/// `capture` and exits, then does nothing else.
+fn write_capture_rsh(root: &Path, capture: &Path, tag: &str) -> Result<std::path::PathBuf, String> {
+    let script = root.join(format!("capture-rsh-{tag}.sh"));
+    let body = format!(
+        "#!/bin/sh\n{{ for a in \"$@\"; do printf '%s\\n' \"$a\"; done; }} > '{}'\nexit 0\n",
+        capture.display()
+    );
+    std::fs::write(&script, body).map_err(|e| e.to_string())?;
+    let mut perms = std::fs::metadata(&script)
+        .map_err(|e| e.to_string())?
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).map_err(|e| e.to_string())?;
+    Ok(script)
+}
+
+/// Extract the compact-flags token from captured rsh argv: the single-dash token
+/// that carries the `.`-separated capability suffix (e.g. `-logDtpre.iLsfxCIvu`).
+/// Long flags (`--server`), the `.` source marker, and paths are skipped.
+fn compact_flags_token(recorded: &str) -> Option<String> {
+    recorded
+        .lines()
+        .map(str::trim)
+        .find(|line| {
+            line.starts_with('-')
+                && !line.starts_with("--")
+                && line.contains('.')
+                && line[1..]
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_alphabetic())
+        })
+        .map(str::to_owned)
+}
+
+/// Build a one-file source fixture. Idempotent: removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src).map_err(|e| e.to_string())?;
+    std::fs::write(src.join("f.txt"), b"capability-fixture\n").map_err(|e| e.to_string())?;
+    support::capture(
+        "touch",
+        &["-d", "@1614830767", &src.join("f.txt").to_string_lossy()],
+    )
+    .map(|_| ())
+    .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CAPABILITY_MARKER, compact_flags_token};
+
+    #[test]
+    fn extracts_compact_flags_token_with_capability_suffix() {
+        // Push server invocation: the receiver `rsync --server . <dst>` (no
+        // `--sender`) carries the sender's compact-flags token.
+        let recorded = "oc-validate-host\nrsync\n--server\n-logDtpre.iLsfxCIvu\n.\n/tmp/dst/\n";
+        let token = compact_flags_token(recorded).unwrap();
+        assert_eq!(token, "-logDtpre.iLsfxCIvu");
+        assert!(token.contains(CAPABILITY_MARKER));
+    }
+
+    #[test]
+    fn ignores_long_flags_dot_marker_and_paths() {
+        // No single-dash dotted token present: the `.` source marker and the
+        // `--server` long flag must not be mistaken for the capability string.
+        let recorded = "host\nrsync\n--server\n--sender\n.\n/tmp/src/\n";
+        assert!(compact_flags_token(recorded).is_none());
+    }
+
+    #[test]
+    fn ignores_block_size_token_without_capability_dot() {
+        // `-B131072` is single-dash but carries no `.` suffix, so it is not the
+        // capability token.
+        let recorded = "host\nrsync\n--server\n-B131072\n-logDtpre.iLsfxCIvu\n";
+        assert_eq!(
+            compact_flags_token(recorded).unwrap(),
+            "-logDtpre.iLsfxCIvu"
+        );
+    }
+}

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -6,6 +6,7 @@ mod append_inplace;
 mod atimes;
 mod backup;
 mod banner;
+mod capability_string;
 mod checksum;
 mod chmod;
 mod chown;
@@ -30,10 +31,12 @@ mod mkpath;
 mod modify_window;
 mod one_file_system;
 mod progress;
+mod protected_regular;
 mod prune_empty_dirs;
 mod relative;
 mod remove_source_files;
 mod rsync_path;
+mod safe_links;
 mod sparse;
 mod special_bits;
 mod stats;
@@ -100,5 +103,10 @@ pub fn all() -> Vec<Box<dyn Check>> {
         Box::new(compare_dest::CompareDest),
         // Transport plumbing.
         Box::new(rsync_path::RsyncPath),
+        // Security: path-escape and receiver-overwrite safety.
+        Box::new(safe_links::SafeLinks),
+        Box::new(protected_regular::ProtectedRegular),
+        // Wire: server-args capability string.
+        Box::new(capability_string::CapabilityString),
     ]
 }

--- a/xtask/src/commands/validate/checks/protected_regular.rs
+++ b/xtask/src/commands/validate/checks/protected_regular.rs
@@ -1,0 +1,287 @@
+//! Receiver symlink-overwrite safety parity between oc-rsync and upstream.
+//!
+//! A destination that already holds a symlink pointing *outside* the tree must
+//! not be followed when the receiver lands a regular file of the same name: the
+//! outside target has to stay untouched and the destination entry must end up a
+//! plain regular file. Following the link would let a pre-planted symlink redirect
+//! a write anywhere the receiver can reach - the receiver-side symlink-escape
+//! attack. Upstream defeats it by writing a temp file in the destination
+//! directory and atomically renaming over the symlink, never opening the link's
+//! target.
+//!
+//! This check seeds each fresh destination with `payload -> <outside file>`,
+//! transfers a regular `payload` from the source, and asserts for both clients
+//! that (1) the destination `payload` is a regular file carrying the source bytes
+//! and (2) the outside target still holds its original bytes. A crash, a hang, or
+//! a modified outside target is a failure.
+//!
+//! upstream: receiver.c `recv_files()` opens `get_tmpname()` in the destination
+//! dir and finishes via `finish_transfer()` -> `robust_rename()`, so the symlink
+//! at the final name is replaced, never dereferenced.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{DaemonHandle, Transport};
+use crate::commands::validate::{Category, Check, CheckOutcome, ValidateCtx};
+use crate::error::{TaskError, TaskResult};
+
+/// The receiver symlink-overwrite safety parity check.
+pub struct ProtectedRegular;
+
+/// Source bytes for the regular `payload` that lands at the destination.
+const SRC_BODY: &[u8] = b"source-payload-bytes\n";
+/// Bytes the outside target must still hold after the transfer (proof it was
+/// never written through).
+const OUTSIDE_BODY: &[u8] = b"outside-must-not-change\n";
+/// Backdated mtime so the quick-check never skips the transfer.
+const EPOCH: &str = "@1614830767";
+
+impl Check for ProtectedRegular {
+    fn name(&self) -> &'static str {
+        "protected-regular"
+    }
+
+    fn categories(&self) -> &'static [Category] {
+        &[Category::Security]
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("protected-regular");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src))
+            .collect()
+    }
+}
+
+impl ProtectedRegular {
+    /// Run one transport cell: seed the destination with a pre-existing symlink
+    /// pointing outside the tree, transfer the regular file, and assert neither
+    /// client followed the link.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+
+        let daemon = if transport == Transport::Daemon {
+            match DaemonHandle::start(ctx.upstream, src, ctx.work) {
+                Ok(handle) => Some(handle),
+                Err(e) => return CheckOutcome::skip(self.name(), label, format!("daemon: {e}")),
+            }
+        } else {
+            None
+        };
+        let daemon_url = daemon.as_ref().map(|d| d.module_url());
+
+        for who in ["up", "oc"] {
+            let client = if who == "up" { ctx.upstream } else { ctx.oc };
+            let effective = if who == "up" {
+                transport.for_upstream()
+            } else {
+                transport
+            };
+            let dst = root.join(format!("{who}-{label}"));
+            let outside = root.join(format!("{who}-{label}-outside"));
+
+            if let Err(e) = seed_target(&dst, &outside) {
+                return CheckOutcome::skip(self.name(), label, format!("{who} seed: {e}"));
+            }
+            match run_client(
+                effective,
+                client,
+                ctx.upstream,
+                src,
+                &dst,
+                daemon_url.as_deref(),
+            ) {
+                Ok(out) if out.status.success() => {}
+                other => return skip_or_fail(self.name(), label, who, other),
+            }
+            if let Some(msg) = follow_violation(&dst, &outside) {
+                if ctx.verbose {
+                    eprintln!("[protected-regular/{label}] {who}: {msg}");
+                }
+                return CheckOutcome::fail(self.name(), label, format!("{who}: {msg}"));
+            }
+        }
+        drop(daemon);
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Non-vacuous guard: the destination `payload` must be a regular file carrying
+/// the source bytes, and the outside target must be unchanged.
+fn follow_violation(dst: &Path, outside: &Path) -> Option<String> {
+    match dst.join("payload").symlink_metadata() {
+        Ok(m) if m.file_type().is_file() => match std::fs::read(dst.join("payload")) {
+            Ok(bytes) if bytes == SRC_BODY => {}
+            Ok(_) => return Some("dest payload content != source".to_string()),
+            Err(e) => return Some(format!("cannot read dest payload: {e}")),
+        },
+        Ok(m) if m.file_type().is_symlink() => {
+            return Some("dest payload is still a symlink (not replaced)".to_string());
+        }
+        Ok(_) => return Some("dest payload is not a regular file".to_string()),
+        Err(e) => return Some(format!("cannot stat dest payload: {e}")),
+    }
+    match std::fs::read(outside) {
+        Ok(bytes) if bytes == OUTSIDE_BODY => None,
+        Ok(_) => Some("outside target was overwritten through the symlink".to_string()),
+        Err(e) => Some(format!("cannot read outside target: {e}")),
+    }
+}
+
+/// Build one client rsync `Command` for `transport` and pull `src/` into `dst/`
+/// (already seeded). Flags are `-rlptgoD --numeric-ids`; operand forms mirror
+/// `transport::pull_into`. The destination is NOT reset here - the caller seeded
+/// the adversarial symlink and it must persist into the transfer.
+fn run_client(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    daemon_url: Option<&str>,
+) -> TaskResult<Output> {
+    let dst_arg = format!("{}/", dst.display());
+    let mut cmd = Command::new(client);
+    cmd.arg("-rlptgoD").arg("--numeric-ids");
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(format!("{}/", src.display())).arg(&dst_arg);
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(format!("localhost:{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(format!("ssh://localhost{}/", src.display()))
+                .arg(&dst_arg);
+        }
+        Transport::Daemon => {
+            let url = daemon_url
+                .ok_or_else(|| TaskError::Validation("daemon transport without url".into()))?;
+            cmd.arg(url).arg(&dst_arg);
+        }
+    }
+    cmd.output()
+        .map_err(|e| TaskError::Validation(format!("failed to spawn {cmd:?}: {e}")))
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: TaskResult<Output>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label.to_string(),
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(
+            check,
+            label.to_string(),
+            format!("{who} could not run: {e}"),
+        ),
+    }
+}
+
+/// Recreate `dst` empty, write the outside target, and plant `dst/payload` as an
+/// absolute symlink pointing at that outside target.
+fn seed_target(dst: &Path, outside: &Path) -> Result<(), String> {
+    if dst.exists() {
+        std::fs::remove_dir_all(dst).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(dst).map_err(|e| e.to_string())?;
+    std::fs::write(outside, OUTSIDE_BODY).map_err(|e| e.to_string())?;
+    let outside_abs = outside.canonicalize().map_err(|e| e.to_string())?;
+    std::os::unix::fs::symlink(&outside_abs, dst.join("payload")).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Build the source fixture: a single regular `payload`. Idempotent.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src).map_err(|e| e.to_string())?;
+    std::fs::write(src.join("payload"), SRC_BODY).map_err(|e| e.to_string())?;
+    support::capture(
+        "touch",
+        &["-d", EPOCH, &src.join("payload").to_string_lossy()],
+    )
+    .map(|_| ())
+    .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OUTSIDE_BODY, SRC_BODY, follow_violation};
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn violation_none_when_link_replaced_and_outside_untouched() {
+        let dst = tempfile::tempdir().unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let outside = out.path().join("target");
+        fs::write(&outside, OUTSIDE_BODY).unwrap();
+        // Correct receiver outcome: payload is a regular file with source bytes.
+        fs::write(dst.path().join("payload"), SRC_BODY).unwrap();
+        assert!(follow_violation(dst.path(), &outside).is_none());
+    }
+
+    #[test]
+    fn violation_flags_an_unfollowed_symlink_still_present() {
+        let dst = tempfile::tempdir().unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let outside = out.path().join("target");
+        fs::write(&outside, OUTSIDE_BODY).unwrap();
+        symlink(&outside, dst.path().join("payload")).unwrap();
+        assert!(
+            follow_violation(dst.path(), &outside)
+                .unwrap()
+                .contains("still a symlink")
+        );
+    }
+
+    #[test]
+    fn violation_flags_an_overwritten_outside_target() {
+        let dst = tempfile::tempdir().unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let outside = out.path().join("target");
+        // The link was followed: outside now holds the source bytes.
+        fs::write(&outside, SRC_BODY).unwrap();
+        fs::write(dst.path().join("payload"), SRC_BODY).unwrap();
+        assert!(
+            follow_violation(dst.path(), &outside)
+                .unwrap()
+                .contains("overwritten")
+        );
+    }
+}

--- a/xtask/src/commands/validate/checks/safe_links.rs
+++ b/xtask/src/commands/validate/checks/safe_links.rs
@@ -1,0 +1,254 @@
+//! `--safe-links` symlink-safety parity between oc-rsync and upstream.
+//!
+//! `--safe-links` is a security control: the receiver must drop any symlink whose
+//! target escapes the transfer root, so a malicious or careless source tree can
+//! never plant a link that resolves outside the destination (the classic symlink
+//! escape). Two escape classes must both be refused:
+//!
+//! - a relative link that climbs out with `../` (`up -> ../outside`), and
+//! - an absolute link (`abs -> /abs/path/outside`), which is unsafe regardless of
+//!   where it points.
+//!
+//! A genuinely safe in-tree link (`safe -> good.txt`) must survive. This check
+//! pulls the fixture with upstream and with oc under `--safe-links`, asserts the
+//! destination trees are entry-for-entry identical, and adds a non-vacuous guard
+//! that both escape links are gone while the safe link remains a symlink. A crash
+//! or non-zero exit on the adversarial fixture is a failure, not a pass.
+//!
+//! upstream: util1.c `unsafe_symlink()` - a symlink is unsafe when its target is
+//! absolute or uses enough `../` to leave the transfer root; generator.c:2010
+//! `keep_dirlinks`/`safe_symlinks` drops unsafe links before writing them.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into};
+use crate::commands::validate::{Category, Check, CheckOutcome, ValidateCtx};
+
+/// The `--safe-links` symlink-safety parity check.
+pub struct SafeLinks;
+
+/// Body of the in-tree file the safe link resolves to.
+const GOOD_BODY: &[u8] = b"good-body\n";
+/// Body of the referent that lives outside the transfer root (never transferred).
+const OUTSIDE_BODY: &[u8] = b"outside-body\n";
+/// Backdated mtime so the quick-check never skips a fixture entry.
+const EPOCH: &str = "@1614830767";
+
+impl Check for SafeLinks {
+    fn name(&self) -> &'static str {
+        "safe-links"
+    }
+
+    fn categories(&self) -> &'static [Category] {
+        &[Category::Security]
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("safe-links");
+        let src = root.join("src");
+        if let Err(e) = build_fixture(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+        ctx.transports
+            .iter()
+            .map(|&t| self.cell(ctx, t, &root, &src))
+            .collect()
+    }
+}
+
+impl SafeLinks {
+    /// Run one transport cell: pull the fixture with upstream and oc under
+    /// `--safe-links`, compare trees, and assert the drop/keep decisions.
+    fn cell(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        root: &Path,
+        src: &Path,
+    ) -> CheckOutcome {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return CheckOutcome::skip(self.name(), label, "no sshd on localhost:22");
+        }
+        // A non-chroot daemon munges symlinks (prefixes "/rsyncd-munged/"), making
+        // every link absolute so --safe-links drops all of them; the "escape
+        // dropped, safe kept" contract cannot hold. upstream: the daemon's
+        // munge-symlinks default is on when `use chroot` is off.
+        if transport == Transport::Daemon {
+            return CheckOutcome::skip(
+                self.name(),
+                label,
+                "daemon munges symlinks; --safe-links drops every link",
+            );
+        }
+
+        let flags: Vec<String> = ["-rlptgoD", "--safe-links", "--numeric-ids"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let up_dst = root.join(format!("up-{label}"));
+        let oc_dst = root.join(format!("oc-{label}"));
+
+        match pull_into(
+            transport.for_upstream(),
+            ctx.upstream,
+            ctx.upstream,
+            src,
+            &up_dst,
+            &flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "upstream", other),
+        }
+        match pull_into(
+            transport,
+            ctx.oc,
+            ctx.upstream,
+            src,
+            &oc_dst,
+            &flags,
+            ctx.work,
+        ) {
+            Ok(out) if out.status.success() => {}
+            other => return skip_or_fail(self.name(), label, "oc", other),
+        }
+
+        if let Some(diff) = support::content_diff(&oc_dst, &up_dst) {
+            if ctx.verbose {
+                eprintln!(
+                    "[safe-links/{label}] oc entries: {:?}",
+                    support::rel_entries(&oc_dst)
+                );
+                eprintln!(
+                    "[safe-links/{label}] up entries: {:?}",
+                    support::rel_entries(&up_dst)
+                );
+            }
+            return CheckOutcome::fail(self.name(), label, diff);
+        }
+        if let Some(msg) = safe_links_violation(&oc_dst) {
+            return CheckOutcome::fail(self.name(), label, msg);
+        }
+        CheckOutcome::pass(self.name(), label)
+    }
+}
+
+/// Non-vacuous guard: both escape links (`up`, `abs`) must be gone and the safe
+/// `safe` link must survive as a symlink. Returns the first violation.
+fn safe_links_violation(dst: &Path) -> Option<String> {
+    for escaped in ["up", "abs"] {
+        if dst.join(escaped).symlink_metadata().is_ok() {
+            return Some(format!("{escaped} escape symlink survived --safe-links"));
+        }
+    }
+    match dst.join("safe").symlink_metadata() {
+        Ok(m) if m.file_type().is_symlink() => None,
+        Ok(_) => Some("safe link was dereferenced under --safe-links".to_string()),
+        Err(_) => Some("safe in-tree link was dropped by --safe-links".to_string()),
+    }
+}
+
+/// Distinguish a genuine divergence from an unrunnable cell (e.g. ssh refused).
+fn skip_or_fail(
+    check: &'static str,
+    label: &str,
+    who: &str,
+    result: Result<std::process::Output, crate::error::TaskError>,
+) -> CheckOutcome {
+    match result {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let code = out.status.code().unwrap_or(-1);
+            CheckOutcome::fail(
+                check,
+                label.to_string(),
+                format!("{who} exited {code}: {}", stderr.trim()),
+            )
+        }
+        Err(e) => CheckOutcome::skip(
+            check,
+            label.to_string(),
+            format!("{who} could not run: {e}"),
+        ),
+    }
+}
+
+/// Build the fixture: a real file, a safe in-tree link, a `../` escape link, and
+/// an absolute escape link. The escape referent lives outside the transfer root.
+/// Idempotent: removes any prior tree first.
+fn build_fixture(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(src).map_err(|e| e.to_string())?;
+    std::fs::write(src.join("good.txt"), GOOD_BODY).map_err(|e| e.to_string())?;
+
+    let outside = src
+        .parent()
+        .ok_or("fixture src has no parent")?
+        .join("sl-outside");
+    std::fs::write(&outside, OUTSIDE_BODY).map_err(|e| e.to_string())?;
+    let outside_abs = outside.canonicalize().map_err(|e| e.to_string())?;
+
+    std::os::unix::fs::symlink("good.txt", src.join("safe")).map_err(|e| e.to_string())?;
+    std::os::unix::fs::symlink("../sl-outside", src.join("up")).map_err(|e| e.to_string())?;
+    std::os::unix::fs::symlink(&outside_abs, src.join("abs")).map_err(|e| e.to_string())?;
+
+    for entry in support::rel_entries(src) {
+        let path = src.join(&entry);
+        support::capture("touch", &["-h", "-d", EPOCH, &path.to_string_lossy()])
+            .map(|_| ())
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::safe_links_violation;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn violation_none_when_escapes_dropped_and_safe_kept() {
+        let dir = tempfile::tempdir().unwrap();
+        symlink("good.txt", dir.path().join("safe")).unwrap();
+        assert!(safe_links_violation(dir.path()).is_none());
+    }
+
+    #[test]
+    fn violation_flags_a_surviving_relative_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        symlink("good.txt", dir.path().join("safe")).unwrap();
+        symlink("../sl-outside", dir.path().join("up")).unwrap();
+        assert!(
+            safe_links_violation(dir.path())
+                .unwrap()
+                .contains("up escape")
+        );
+    }
+
+    #[test]
+    fn violation_flags_a_surviving_absolute_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        symlink("good.txt", dir.path().join("safe")).unwrap();
+        symlink("/etc/hostname", dir.path().join("abs")).unwrap();
+        assert!(
+            safe_links_violation(dir.path())
+                .unwrap()
+                .contains("abs escape")
+        );
+    }
+
+    #[test]
+    fn violation_flags_a_dropped_safe_link() {
+        let dir = tempfile::tempdir().unwrap();
+        // Escapes correctly gone, but the safe link was dropped too.
+        assert!(
+            safe_links_violation(dir.path())
+                .unwrap()
+                .contains("was dropped")
+        );
+    }
+}

--- a/xtask/src/commands/validate/mod.rs
+++ b/xtask/src/commands/validate/mod.rs
@@ -508,14 +508,47 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn all_checks_default_to_validation() {
+    fn every_check_declares_known_nonempty_categories() {
         for check in checks::all() {
-            assert_eq!(
-                check.categories(),
-                &[Category::Validation],
-                "check `{}` should default to the Validation category",
+            let cats = check.categories();
+            assert!(
+                !cats.is_empty(),
+                "check `{}` declares no category",
                 check.name()
             );
+            for cat in cats {
+                assert!(
+                    Category::ALL.contains(cat),
+                    "check `{}` declares an unknown category {cat:?}",
+                    check.name()
+                );
+            }
         }
+    }
+
+    /// Names of the checks that carry a given category, mirroring the filter in
+    /// `execute()`.
+    #[cfg(unix)]
+    fn checks_in(cat: Category) -> Vec<&'static str> {
+        checks::all()
+            .iter()
+            .filter(|c| c.categories().contains(&cat))
+            .map(|c| c.name())
+            .collect()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn security_flag_selects_exactly_the_security_checks() {
+        assert_eq!(
+            checks_in(Category::Security),
+            ["safe-links", "protected-regular"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wire_flag_selects_exactly_the_wire_checks() {
+        assert_eq!(checks_in(Category::Wire), ["capability-string"]);
     }
 }


### PR DESCRIPTION
## Summary

Adds category-tagged checks to the `cargo xtask validate` fidelity harness, exercising the new `Category` API via each check's `fn categories()` override. `cargo xtask validate --security` now selects exactly the Security checks and `--wire` exactly the Wire checks.

## Security checks (`Category::Security`)

- **safe-links** — under `--safe-links`, both a relative `../` escape symlink and an absolute escape symlink are dropped while a safe in-tree link survives; oc's destination tree must equal upstream's. Non-vacuous guard asserts the escapes are gone and the safe link is still a symlink. A crash or non-zero exit on the adversarial fixture is a failure. Cites `util1.c unsafe_symlink()`.
- **protected-regular** — a destination pre-seeded with `payload -> <outside file>` must have that symlink replaced by a regular file when a regular `payload` is received; the outside target must stay byte-unchanged (proof it was never written through). oc must match upstream. Cites `receiver.c recv_files()` / `robust_rename()`.

Both are host-validated against real rsync 3.4.4 and the oc-rsync release binary on an x86_64 Linux host: identical results in every case (escapes dropped + safe kept; symlink replaced + outside target intact).

## Wire check (`Category::Wire`)

- **capability-string** — captures each client's remote-shell server args through a tiny `-e` capture shell (no sshd or daemon needed) and asserts oc's compact-flags capability token equals upstream's byte-for-byte. Oriented as a push (`src/ host:dst/`) so the client is the sender advertising the full suffix; host-validated: both emit `-logDtpre.iLsfxCIvu`.

## Skipped with reason

- **link-dest / compare-dest escape refusal** — the out-of-module basis-dir refusal is a daemon/server-side control (`clientserver.c` path sanitisation). This harness always uses upstream as the server, so it cannot exercise oc's own refusal path; deferred until an oc-as-server harness exists.
- **MSG_* / flist / token frame diffs** — require a live wire frame-capture facility that is not yet built. Left unimplemented (not stubbed); they await that facility. Only the observable capability-string check is implemented for Wire.

## Notes

- On a pull, oc deliberately omits the inc-recurse `i` capability letter (`-logDtpre.LsfxCIvu` vs upstream `.iLsfxCIvu`) because its receive path clears `CF_INC_RECURSE`; the capability check is therefore oriented on the push direction where the drop-in contract holds. This intended pull-side behaviour is out of scope here and left unchanged.

## Verification

- `cargo build -p xtask`, `cargo fmt --all -- --check`, `cargo clippy -p xtask --all-targets --all-features --no-deps -D warnings`, `cargo check -p xtask --target x86_64-pc-windows-gnu`: all clean.
- `cargo nextest run -p xtask`: 408 passed, 0 skipped (includes new parser, guard, and category-selection tests).
