### PR TITLE
fix(transfer): anchor pipelined commit rename for destination subdirs

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -337,20 +337,34 @@ pub(super) fn rename_with_io_uring_fallback(old_path: &Path, new_path: &Path) ->
 /// SEC-1.j: dirfd-anchor the temp→final commit rename against the receiver's
 /// destination sandbox, falling back to [`rename_with_io_uring_fallback`].
 ///
-/// When the `config` carries a [`fast_io::DirSandbox`] rooted at its
-/// `dest_dir`, and both the temp leaf and the final leaf are single components
-/// directly under that root (the default in-destination temp pattern also used
-/// by the temp-file create, see `temp_guard::try_create_new`), the rename routes
-/// through [`fast_io::renameat_via_sandbox_or_fallback`]. Both leaves resolve
-/// against the pinned destination dirfd, so a symlink swap on the commit parent
-/// between temp-create and rename cannot redirect the final file outside the
-/// tree.
+/// When the `config` carries a [`fast_io::DirSandbox`] rooted at its `dest_dir`
+/// and both endpoints live beneath that root, the rename routes through
+/// [`fast_io::renameat_via_sandbox_or_fallback`]. A file directly under the
+/// root resolves its leaf against the pinned destination dirfd; a file in a
+/// destination subdirectory (`sub/file`, the common recursive-copy case) has
+/// its parent opened under `openat2(RESOLVE_BENEATH)` inside the helper. Either
+/// way a concurrent ancestor-symlink swap on the commit parent - including an
+/// *interior* directory - between temp-create and rename cannot redirect the
+/// final file outside the tree.
 ///
-/// In every other case (no sandbox, multi-component relative path, or a
-/// `--temp-dir`/partial-dir on a different parent) it falls back to the existing
-/// io_uring / `std::fs::rename` path with the EXDEV copy+remove backstop, so a
-/// working rename is never regressed. The anchored path shares the destination
-/// parent for both leaves, so EXDEV cannot arise there.
+/// Anchoring the nested (subdir) case closes the CVE-2026-29518 secondary
+/// residual on the pipelined disk-commit path: before this the subdir case fell
+/// through to a path-based `std::fs::rename`, so on a privileged daemon
+/// (`chroot=no`) a swapped interior directory could redirect the committed file
+/// out of the module. This now matches both the non-pipelined receiver
+/// (`transfer_ops::response.rs`) and the primary #6808 ownership/timestamp
+/// anchoring.
+///
+/// upstream: `syscall.c:910` `do_rename_at()` opens each slashed path's parent
+/// via `secure_relative_open()` (openat2 `RESOLVE_BENEATH`) and issues
+/// `renameat()` against the resulting dirfd, gated on `am_daemon &&
+/// !am_chrooted`.
+///
+/// In every other case (no sandbox, or a `--temp-dir`/partial-dir on a
+/// different tree than `dest_dir`) it falls back to the existing io_uring /
+/// `std::fs::rename` path with the EXDEV copy+remove backstop, so a working
+/// rename is never regressed. The anchored path shares the destination subtree
+/// for both endpoints, so EXDEV cannot arise there.
 ///
 /// Returns `Ok(false)` for an in-place rename, `Ok(true)` when the EXDEV
 /// copy+remove fallback ran.
@@ -361,20 +375,23 @@ pub(super) fn rename_config_sandboxed(
     new_path: &Path,
 ) -> io::Result<bool> {
     if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref())
-        && let (Some(old_leaf), Some(new_leaf)) = (old_path.file_name(), new_path.file_name())
-        && old_path.parent() == Some(dest_dir)
-        && new_path.parent() == Some(dest_dir)
+        && let (Ok(old_rel), Ok(new_rel)) = (
+            old_path.strip_prefix(dest_dir),
+            new_path.strip_prefix(dest_dir),
+        )
     {
-        // Both endpoints are single components under the sandbox root, so the
-        // dirfd anchor applies. `replace = true` matches `fs::rename`'s
+        // Both endpoints resolve beneath the sandbox root. The helper picks the
+        // single-component dirfd fast path or the `RESOLVE_BENEATH` parent
+        // anchor per endpoint, so a nested subdir commit is confined exactly
+        // like a root-level one. `replace = true` matches `fs::rename`'s
         // overwrite-the-destination semantics (upstream `do_rename`).
         fast_io::renameat_via_sandbox_or_fallback(
             Some(sandbox.as_ref()),
             dest_dir,
-            Path::new(old_leaf),
+            old_rel,
             old_path,
             dest_dir,
-            Path::new(new_leaf),
+            new_rel,
             new_path,
             true,
         )?;

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -518,6 +518,86 @@ fn commit_rename_refuses_parent_symlink_escape() {
     );
 }
 
+/// CVE-2026-29518 secondary residual: the pipelined disk-commit rename must
+/// anchor a file committed into a destination *subdirectory*, not just a file
+/// directly under the sandbox root. Before the fix the subdir case fell through
+/// to a path-based `std::fs::rename`, letting a swapped interior directory
+/// redirect the committed file out of the module on a privileged daemon.
+///
+/// Staging (deterministic, program order - no threads): the temp source is
+/// planted inside the out-of-tree location and the interior directory `sub`
+/// under the pinned root is a symlink to that location, modelling an attacker
+/// who swapped `dest/sub` for a symlink between temp-create and commit. A
+/// path-based `rename(dest/sub/.tmp, dest/sub/payload.bin)` would resolve both
+/// through the symlink and land the file in `outside/payload.bin` (the escape).
+/// The `openat2(RESOLVE_BENEATH)` parent anchor instead refuses to open `sub`
+/// (its symlink target escapes beneath the root), so the rename fails safe and
+/// nothing lands outside the module.
+///
+/// upstream: `syscall.c:910` `do_rename_at()` opens each slashed path's parent
+/// via `secure_relative_open()` before `renameat()`.
+///
+/// Linux + openat2 only: `RESOLVE_BENEATH` is the confinement primitive and has
+/// no portable equivalent; other targets keep the path-based fallback, matching
+/// upstream's `am_daemon && !am_chrooted` Linux gate.
+#[cfg(target_os = "linux")]
+#[test]
+fn commit_rename_subdir_refuses_interior_symlink_escape() {
+    use std::sync::Arc;
+
+    if !fast_io::openat2_supported() {
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let staging = std::fs::canonicalize(tmp.path()).expect("canon");
+
+    // Pinned destination root (sandbox anchor) with a real interior subdir.
+    let dest_dir = staging.join("dest");
+    fs::create_dir(&dest_dir).unwrap();
+
+    // Out-of-tree location the escape would target; the temp source lives here
+    // so a symlink-followed rename would find a valid source and succeed.
+    let outside = staging.join("outside");
+    fs::create_dir(&outside).unwrap();
+    let temp_path = dest_dir.join("sub").join(".tmp.payload");
+    let final_path = dest_dir.join("sub").join("payload.bin");
+    fs::write(outside.join(".tmp.payload"), b"received content").unwrap();
+
+    // Open the sandbox at the real dest root BEFORE the swap; the dirfd pins the
+    // real root inode.
+    let sandbox = Arc::new(fast_io::DirSandbox::open_root(&dest_dir).expect("open sandbox"));
+    let config = DiskCommitConfig {
+        sandbox: Some(sandbox),
+        dest_dir: Some(dest_dir.clone()),
+        ..DiskCommitConfig::default()
+    };
+
+    // Plant the interior directory as a symlink escaping beneath the root. A
+    // path-based resolver routes `dest/sub/...` to `outside/...`.
+    std::os::unix::fs::symlink(&outside, dest_dir.join("sub")).expect("plant sub symlink");
+
+    // The anchored rename must refuse: opening `sub` under RESOLVE_BENEATH sees
+    // a symlink whose target escapes the root and fails (EXDEV), so the commit
+    // cannot follow the swap.
+    let result = rename_config_sandboxed(&config, &temp_path, &final_path);
+    assert!(
+        result.is_err(),
+        "anchored subdir rename must fail rather than follow the interior symlink swap",
+    );
+
+    // The escape must not have happened: no committed file outside the module,
+    // and the temp source is left untouched.
+    assert!(
+        !outside.join("payload.bin").exists(),
+        "committed file must not land outside the module through the swapped interior dir",
+    );
+    assert!(
+        outside.join(".tmp.payload").exists(),
+        "temp source is left in place when the anchored rename refuses",
+    );
+}
+
 /// Fallback parity: with no sandbox attached, `rename_config_sandboxed` uses
 /// the path-based [`rename_with_io_uring_fallback`], moving the temp file to
 /// its final destination exactly as before. Proves the sandbox wiring never


### PR DESCRIPTION
## Summary

Hardens the pipelined disk-commit temp→final rename so a file committed into a
destination **subdirectory** is confined to the module, closing a residual
symlink-swap TOCTOU on a privileged daemon (`chroot=no`).

The receiver has two commit paths:

- Non-pipelined (`transfer_ops::response.rs`) already strips the destination
  prefix and passes the **full relative path** to
  `fast_io::renameat_via_sandbox_or_fallback`, so a subdir file (`sub/file`)
  has its parent opened under `openat2(RESOLVE_BENEATH)` before `renameat`.
- Pipelined (`disk_commit::process::commit.rs::rename_config_sandboxed`, the
  shipped default receiver) gated the anchored path on
  `old_path.parent() == dest_dir && new_path.parent() == dest_dir`. Any file in
  a destination subdirectory (the common recursive-copy case) fell through to a
  path-based `std::fs::rename`.

On a privileged daemon with `chroot=no`, a concurrent swap of an interior
destination directory for a symlink between temp-create and commit could
therefore redirect the committed file out of the module - the same escape class
as the primary fix (#6808) and the receiver's normal temp→final anchoring.

## Fix

`rename_config_sandboxed` now routes through
`renameat_via_sandbox_or_fallback` whenever both endpoints resolve beneath the
sandbox root (`strip_prefix(dest_dir)` succeeds), passing the full relative
paths. The helper picks the single-component dirfd fast path for root-level
files and the `RESOLVE_BENEATH` parent anchor for nested paths, so a subdir
commit is confined exactly like a root-level one. The no-sandbox and
temp-dir-outside-tree cases still use the io_uring / `std::fs::rename` path with
the EXDEV copy+remove backstop, so no working rename is regressed (both anchored
endpoints share the destination subtree, so EXDEV cannot arise there).

## Upstream reference

`syscall.c:910` `do_rename_at()` opens each slashed path's parent via
`secure_relative_open()` (`openat2` with `RESOLVE_BENEATH`) and issues
`renameat()` against the resulting dirfd, gated on `am_daemon && !am_chrooted`.
This change brings the pipelined path to that semantics, matching the
non-pipelined receiver and the primary #6808 anchoring.

## Tests

Adds `commit_rename_subdir_refuses_interior_symlink_escape` (Linux + `openat2`
only, matching the confinement primitive's availability). It plants an interior
directory as a symlink escaping the pinned root and asserts the anchored rename
refuses rather than following it, with nothing landing outside the module.

Verified on an x86_64 Linux host (`rustc` 1.88.0):
- With the fix: the new test and the existing anchor/fallback tests pass.
- Reverting only the `commit.rs` change: the new test **fails** (the path-based
  rename follows the symlink and the file escapes), confirming it catches the
  regression.

`cargo fmt --all -- --check` and
`cargo clippy -p transfer --all-targets --all-features --no-deps -- -D warnings`
are clean; `cargo build -p transfer --all-features` succeeds.
