### PR TITLE
fix(daemon): inherit global auth users as per-module default

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -922,9 +922,23 @@ fn apply_global_directive(
                 state.module_defaults.charset = Some(value.to_owned());
             }
         }
-        // P_LOCAL directives that only make sense per-module - silently accepted
-        // but not stored as inheritable defaults.
-        "path" | "authusers" => {}
+        // upstream: daemon-parm.h:262 - `auth users` is P_LOCAL, so a value in
+        // the global section is the default every module inherits unless it sets
+        // its own list (loadparm.c init_section/copy_section). Modules that omit
+        // `auth users` must then still authenticate (authenticate.c:228
+        // auth_server reads lp_auth_users), so store the list as the default.
+        "authusers" => {
+            let users = parse_auth_user_list(value).map_err(|error| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid 'auth users' directive: {error}"),
+                )
+            })?;
+            state.module_defaults.auth_users = Some(users);
+        }
+        // `path` only makes sense per-module - silently accepted, not inherited.
+        "path" => {}
         _ => {
             eprintln!(
                 "warning: unknown global directive '{}' in '{}' line {} [daemon={}]",

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/module_defaults.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/module_defaults.rs
@@ -53,4 +53,10 @@ struct GlobalModuleDefaults {
     // (clientserver.c:1363,1376 `lp_daemon_gid`/`lp_daemon_uid`).
     uid: Option<u32>,
     gid: Option<GidSetting>,
+    // upstream: daemon-parm.h:262 marks `auth users` P_LOCAL, so a global-section
+    // `auth users` becomes every module's default via loadparm.c
+    // init_section()/copy_section(). authenticate.c:228 auth_server() then reads
+    // lp_auth_users(module) and requires authentication whenever it is non-empty,
+    // so a module inheriting the default authenticates like one with its own list.
+    auth_users: Option<Vec<AuthUser>>,
 }

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -3175,4 +3175,70 @@ mod config_parsing_tests {
             "`daemon uid` must arm the process-wide daemon drop",
         );
     }
+
+    /// A global `auth users` is a P_LOCAL default (daemon-parm.h:262): every
+    /// module that omits its own `auth users` must inherit it and therefore
+    /// require authentication (authenticate.c:228 auth_server reads
+    /// lp_auth_users). Before this was wired, the global directive was silently
+    /// dropped and such modules were left open - a fail-open security hole. A
+    /// module that declares its own `auth users` still overrides the default.
+    #[test]
+    fn parse_global_auth_users_inherited_as_module_default() {
+        let dir = TempDir::new().expect("create temp dir");
+        let secrets = dir.path().join("rsyncd.secrets");
+        fs::write(&secrets, "alice:pw\ncarol:pw\n").expect("write secrets");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&secrets, fs::Permissions::from_mode(0o600))
+                .expect("chmod secrets");
+        }
+
+        let open = dir.path().join("open");
+        let own = dir.path().join("own");
+        fs::create_dir(&open).expect("create open dir");
+        fs::create_dir(&own).expect("create own dir");
+
+        let config = format!(
+            "auth users = alice\nsecrets file = {secrets}\n\
+             [inherits]\npath = {open}\n\
+             [overrides]\npath = {own}\nauth users = carol\n",
+            secrets = secrets.display(),
+            open = open.display(),
+            own = own.display(),
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+
+        let inherits = result
+            .modules
+            .iter()
+            .find(|m| m.name == "inherits")
+            .expect("inherits module parsed");
+        assert_eq!(
+            inherits.auth_users.len(),
+            1,
+            "module without its own 'auth users' must inherit the global default and require auth",
+        );
+        assert_eq!(inherits.auth_users[0].username, "alice");
+        assert!(
+            inherits.secrets_file.is_some(),
+            "inherited auth must also inherit the global secrets file",
+        );
+
+        let overrides = result
+            .modules
+            .iter()
+            .find(|m| m.name == "overrides")
+            .expect("overrides module parsed");
+        assert_eq!(
+            overrides.auth_users.len(),
+            1,
+            "module with its own 'auth users' keeps exactly its list",
+        );
+        assert_eq!(
+            overrides.auth_users[0].username, "carol",
+            "a module-level 'auth users' overrides the global default",
+        );
+    }
 }

--- a/crates/daemon/src/daemon/sections/module_definition/finish.rs
+++ b/crates/daemon/src/daemon/sections/module_definition/finish.rs
@@ -92,7 +92,15 @@ impl ModuleDefinitionBuilder {
             ));
         }
 
-        let auth_users = self.auth_users.unwrap_or_default();
+        // upstream: daemon-parm.h:262 - `auth users` is P_LOCAL. A module with
+        // no explicit list inherits the global-section default, so a global
+        // `auth users` forces authentication on every module that lacks its own
+        // (authenticate.c:228 auth_server reads lp_auth_users). Mirrors
+        // hosts_allow below.
+        let auth_users = self
+            .auth_users
+            .or_else(|| defaults.auth_users.clone())
+            .unwrap_or_default();
         let secrets_file = if auth_users.is_empty() {
             self.secrets_file
         } else if let Some(path) = self.secrets_file {


### PR DESCRIPTION
## Problem: fail-open daemon auth

`auth users` is a `P_LOCAL` daemon parameter upstream (`daemon-parm.h:262`).
When it appears in the global section of `rsyncd.conf`, loadparm.c copies it
into every module section as the default (`init_section`/`copy_section`), so a
module that does not declare its own `auth users` inherits the global list and
must authenticate. `authenticate.c:228` `auth_server()` reads
`lp_auth_users(module)` and requires authentication whenever the resolved list
is non-empty.

The daemon silently dropped a global `auth users`:

- `global_directives/dispatch.rs` no-oped the `authusers` key.
- `module_definition/finish.rs` used `self.auth_users.unwrap_or_default()` with
  no fallback to a global default.

Result: an operator who sets a single global `auth users` (intending it to
protect every module) left every module WITHOUT its own `auth users` **open** -
no authentication at all. This is a fail-open security misconfiguration.

## Fix

Treat global `auth users` as the inheritable P_LOCAL default, exactly like the
existing `hosts allow` / `secrets file` inheritance:

- Parse the global `authusers` directive and store it in `GlobalModuleDefaults`.
- In module finalization, fall back to that default:
  `self.auth_users.or_else(|| defaults.auth_users.clone()).unwrap_or_default()`.

A module that declares its own `auth users` still overrides the default. The
secrets-file requirement already inherited the global `secrets file`, so an
inheriting module is fully wired for authentication.

## Test

`parse_global_auth_users_inherited_as_module_default` builds a config with a
global `auth users` + `secrets file` and two modules - one without its own
`auth users` (must inherit and require auth) and one with its own list (must
override). It FAILS before the fix (the inheriting module had an empty auth
list - open) and PASSES after.

## Verification

- `cargo build -p daemon`
- `cargo nextest run -p daemon --all-features -E 'test(auth) or test(module) or test(global) or test(loadparm) or test(inherit)'` - 714 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`

## Upstream references

- `daemon-parm.h:262` - `{"auth users", P_STRING, P_LOCAL, ...}`
- `loadparm.c` `init_section`/`copy_section` - P_LOCAL globals seed module defaults
- `authenticate.c:228` `auth_server()` reads `lp_auth_users(module)` to gate access
- `clientserver.c:761` invokes `auth_server()` during module setup
