### PR TITLE
perf(protocol): hash-index xattr wire cache for O(1) dedup lookup

### DIFF
--- a/crates/protocol/src/acl/entry.rs
+++ b/crates/protocol/src/acl/entry.rs
@@ -481,6 +481,13 @@ impl RsyncAcl {
 pub struct AclCache {
     access_acls: Vec<RsyncAcl>,
     default_acls: Vec<RsyncAcl>,
+    /// Index where the previous access-ACL lookup matched, if any.
+    ///
+    /// Mirrors upstream's per-type `static` match cursor so a lookup resumes
+    /// from the last hit (or the list end), since equal ACLs arrive in runs.
+    last_access_match: Option<usize>,
+    /// Index where the previous default-ACL lookup matched, if any.
+    last_default_match: Option<usize>,
 }
 
 impl AclCache {
@@ -490,27 +497,64 @@ impl AclCache {
         Self {
             access_acls: Vec::new(),
             default_acls: Vec::new(),
+            last_access_match: None,
+            last_default_match: None,
         }
     }
 
     /// Finds a matching access ACL in the cache.
     ///
-    /// Returns the index if found, or `None` if no match.
-    pub fn find_access(&self, acl: &RsyncAcl) -> Option<u32> {
-        self.access_acls
-            .iter()
-            .position(|cached| cached == acl)
-            .map(|idx| idx as u32)
+    /// Returns the index if found, or `None` if no match. Because the store
+    /// path only appends ACLs absent from the cache, at most one entry can
+    /// match, so the returned index (and thus the wire output) is identical
+    /// regardless of scan start.
+    pub fn find_access(&mut self, acl: &RsyncAcl) -> Option<u32> {
+        Self::find_matching(&self.access_acls, acl, &mut self.last_access_match)
     }
 
     /// Finds a matching default ACL in the cache.
     ///
-    /// Returns the index if found, or `None` if no match.
-    pub fn find_default(&self, acl: &RsyncAcl) -> Option<u32> {
-        self.default_acls
-            .iter()
-            .position(|cached| cached == acl)
-            .map(|idx| idx as u32)
+    /// Returns the index if found, or `None` if no match. See
+    /// [`find_access`](Self::find_access) for why the resume cursor cannot
+    /// change which index is returned.
+    pub fn find_default(&mut self, acl: &RsyncAcl) -> Option<u32> {
+        Self::find_matching(&self.default_acls, acl, &mut self.last_default_match)
+    }
+
+    /// Scans `acls` for one equal to `acl`, resuming from `last_match`.
+    ///
+    /// Starts at the previous match (or the list end on the first lookup or
+    /// after a miss) and walks backward with wrap-around, since identical ACLs
+    /// tend to arrive in consecutive runs. Updates `last_match` to the hit, or
+    /// clears it on a miss.
+    ///
+    /// # Upstream Reference
+    ///
+    /// See `acls.c:find_matching_rsync_acl()` lines 448-470 - the same
+    /// resume-at-last-match cursor over `rsync_acl_list`.
+    fn find_matching(
+        acls: &[RsyncAcl],
+        acl: &RsyncAcl,
+        last_match: &mut Option<usize>,
+    ) -> Option<u32> {
+        let count = acls.len();
+        if count == 0 {
+            *last_match = None;
+            return None;
+        }
+
+        // upstream: start at the end of the list on the first pass or a prior miss.
+        let mut idx = (*last_match).filter(|&i| i < count).unwrap_or(count - 1);
+        for _ in 0..count {
+            if acls[idx] == *acl {
+                *last_match = Some(idx);
+                return Some(idx as u32);
+            }
+            idx = if idx == 0 { count - 1 } else { idx - 1 };
+        }
+
+        *last_match = None;
+        None
     }
 
     /// Stores an access ACL in the cache.

--- a/crates/protocol/src/acl/tests.rs
+++ b/crates/protocol/src/acl/tests.rs
@@ -225,7 +225,7 @@ mod acl_cache_tests {
 
     #[test]
     fn find_access_returns_none_for_unknown() {
-        let cache = AclCache::new();
+        let mut cache = AclCache::new();
         let acl = RsyncAcl::new();
         assert!(cache.find_access(&acl).is_none());
     }

--- a/crates/protocol/src/flist/write/mod.rs
+++ b/crates/protocol/src/flist/write/mod.rs
@@ -22,7 +22,7 @@ use crate::ProtocolVersion;
 use crate::acl::{AclCache, RsyncAcl, send_acl};
 use crate::codec::{ProtocolCodecEnum, create_protocol_codec};
 use crate::iconv::FilenameConverter;
-use crate::xattr::{XattrCache, XattrList, send_xattr};
+use crate::xattr::{XattrCache, send_xattr};
 
 use super::entry::FileEntry;
 use super::state::{FileListCompressionState, FileListStats};
@@ -527,7 +527,7 @@ impl FileListWriter {
         if self.preserve.xattrs {
             let list = entry.xattr_list().cloned().unwrap_or_default();
             // upstream: xattrs.c:send_xattr() - check cache for matching set
-            let cached_index = self.find_matching_xattr(&list);
+            let cached_index = self.xattr_cache.find(&list);
             send_xattr(writer, &list, cached_index, self.checksum_seed)?;
             if cached_index.is_none() {
                 // upstream: xattrs.c:538 - rsync_xal_store() adds to cache
@@ -553,35 +553,6 @@ impl FileListWriter {
         self.update_stats(entry);
 
         Ok(())
-    }
-
-    /// Finds a matching xattr set in the sender-side cache.
-    ///
-    /// Returns `Some(index)` if an identical xattr set has already been sent,
-    /// allowing the writer to emit a cache reference instead of literal data.
-    ///
-    /// Comparison is by entry count plus name+value equality for each entry.
-    /// This is a linear scan - upstream uses hash-based lookup, but the cache
-    /// is typically small enough that linear scan is adequate.
-    ///
-    /// # Upstream Reference
-    ///
-    /// See `xattrs.c:find_matching_xattr()` - hash-based lookup in `rsync_xal_l`.
-    fn find_matching_xattr(&self, list: &XattrList) -> Option<u32> {
-        for i in 0..self.xattr_cache.len() {
-            if let Some(cached) = self.xattr_cache.get(i) {
-                if cached.len() != list.len() {
-                    continue;
-                }
-                let all_match = cached.iter().zip(list.iter()).all(|(a, b)| {
-                    a.name() == b.name() && a.datum_len() == b.datum_len() && a.datum() == b.datum()
-                });
-                if all_match {
-                    return Some(i as u32);
-                }
-            }
-        }
-        None
     }
 }
 

--- a/crates/protocol/src/xattr/cache.rs
+++ b/crates/protocol/src/xattr/cache.rs
@@ -16,28 +16,49 @@
 //! - `xattrs.c:receive_xattr()` - reads index or literal data, stores in cache
 //! - `xattrs.c:rsync_xal_store()` - adds xattr list to global cache
 
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hasher;
 use std::io::{self, Read};
 
 use crate::varint::read_varint;
 use crate::xattr::prefix::wire_to_local;
 use crate::xattr::{MAX_FULL_DATUM, MAX_XATTR_DIGEST_LEN, RSYNC_PREFIX, XattrEntry, XattrList};
 
-/// Cache of received xattr sets, indexed for deduplication.
+/// Cache of xattr sets, indexed for deduplication.
 ///
 /// Mirrors upstream's `rsync_xal_l` item list. Each file entry references
 /// an xattr set by index into this cache, avoiding duplicate storage of
 /// identical xattr sets across multiple files.
+///
+/// A hash index (`by_hash`) mirrors upstream's `rsync_xal_h` hash table
+/// (`xattrs.c:xattr_lookup_hash`), giving [`find`](Self::find) amortized
+/// O(1) lookup instead of a linear scan over every stored set. The index is
+/// maintained only by [`store`](Self::store) (the sole insertion path), so
+/// it stays consistent with `lists`. [`get_mut`](Self::get_mut) can mutate a
+/// stored set's datum after the fact, which would stale the hash for that
+/// slot; that path is receiver-only and never feeds [`find`](Self::find)
+/// (a sender-only operation), so lookup correctness is unaffected.
 #[derive(Debug, Default, Clone)]
 pub struct XattrCache {
     /// Stored xattr lists, indexed by position.
     lists: Vec<XattrList>,
+    /// Maps an xattr set's content hash to the slot indices sharing it.
+    ///
+    /// Collisions (and distinct sets that hash alike) are disambiguated by a
+    /// full element-wise comparison in [`find`](Self::find), matching
+    /// upstream's collision walk in `xattrs.c:find_matching_xattr()`.
+    by_hash: HashMap<u64, Vec<u32>>,
 }
 
 impl XattrCache {
     /// Creates an empty xattr cache.
     #[must_use]
     pub fn new() -> Self {
-        Self { lists: Vec::new() }
+        Self {
+            lists: Vec::new(),
+            by_hash: HashMap::new(),
+        }
     }
 
     /// Returns the number of cached xattr sets.
@@ -63,11 +84,87 @@ impl XattrCache {
     }
 
     /// Stores an xattr list in the cache and returns its index.
+    ///
+    /// Also records the set's content hash in the lookup index so subsequent
+    /// [`find`](Self::find) calls resolve in amortized O(1).
+    ///
+    /// # Upstream Reference
+    ///
+    /// See `xattrs.c:rsync_xal_store()` - appends to `rsync_xal_l` and inserts
+    /// the computed key into `rsync_xal_h`.
     #[must_use]
     pub fn store(&mut self, list: XattrList) -> u32 {
-        let index = self.lists.len();
+        let index = self.lists.len() as u32;
+        let key = Self::hash_list(&list);
+        self.by_hash.entry(key).or_default().push(index);
         self.lists.push(list);
-        index as u32
+        index
+    }
+
+    /// Finds a stored xattr set identical to `list`, returning its index.
+    ///
+    /// Uses the content-hash index to select candidate slots, then confirms a
+    /// match with a full element-wise comparison (entry count plus per-entry
+    /// name, datum length, and datum equality). Returns the index of the first
+    /// stored set that matches, or `None` if none does.
+    ///
+    /// This is the sender-side deduplication lookup: a hit lets the writer emit
+    /// a compact cache reference instead of re-transmitting the literal set.
+    /// The returned index is the 1-based-minus-one slot number used for the
+    /// wire abbreviation, so the assignment order (and thus the wire output) is
+    /// identical to a linear scan.
+    ///
+    /// # Upstream Reference
+    ///
+    /// See `xattrs.c:find_matching_xattr()` - hashed lookup in `rsync_xal_h`
+    /// followed by an element-wise walk of the colliding candidates.
+    #[must_use]
+    pub fn find(&self, list: &XattrList) -> Option<u32> {
+        let key = Self::hash_list(list);
+        for &index in self.by_hash.get(&key)? {
+            if let Some(cached) = self.lists.get(index as usize) {
+                if Self::lists_equal(cached, list) {
+                    return Some(index);
+                }
+            }
+        }
+        None
+    }
+
+    /// Element-wise equality of two xattr sets.
+    ///
+    /// Two sets match when they have the same entry count and, positionally,
+    /// each entry shares the same name, datum length, and datum bytes (the
+    /// datum being the checksum for abbreviated entries). Mirrors the compare
+    /// loop in `xattrs.c:find_matching_xattr()`.
+    fn lists_equal(a: &XattrList, b: &XattrList) -> bool {
+        a.len() == b.len()
+            && a.iter().zip(b.iter()).all(|(x, y)| {
+                x.name() == y.name() && x.datum_len() == y.datum_len() && x.datum() == y.datum()
+            })
+    }
+
+    /// Computes a content hash for an xattr set consistent with
+    /// [`lists_equal`](Self::lists_equal).
+    ///
+    /// Hashes the entry count followed by each entry's name, datum length, and
+    /// datum bytes in list order. Equal sets always hash identically; unequal
+    /// sets that collide are separated by the full comparison in
+    /// [`find`](Self::find).
+    ///
+    /// # Upstream Reference
+    ///
+    /// See `xattrs.c:xattr_lookup_hash()` - folds the count and each entry's
+    /// name and datum into the lookup key.
+    fn hash_list(list: &XattrList) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        hasher.write_usize(list.len());
+        for entry in list.iter() {
+            hasher.write(entry.name());
+            hasher.write_usize(entry.datum_len());
+            hasher.write(entry.datum());
+        }
+        hasher.finish()
     }
 
     /// Receives an xattr set from the wire during file list reading.
@@ -786,5 +883,134 @@ mod tests {
         assert!(is_rsync_internal_attr(&aacl_name));
         assert!(!is_rsync_internal_attr(&normal_name));
         assert!(!is_rsync_internal_attr(b"regular_attr"));
+    }
+
+    /// Builds an [`XattrList`] from `(name, value)` pairs, as the sender would
+    /// present it to [`XattrCache::store`] / [`XattrCache::find`].
+    fn list_from(pairs: &[(&[u8], &[u8])]) -> XattrList {
+        let mut list = XattrList::new();
+        for (num, &(name, value)) in pairs.iter().enumerate() {
+            let mut entry = XattrEntry::new(name.to_vec(), value.to_vec());
+            entry.set_num((num + 1) as u32);
+            list.push(entry);
+        }
+        list
+    }
+
+    /// Reference linear scan matching the pre-index sender lookup: entry count
+    /// plus positional name/datum_len/datum equality. Used to prove the hashed
+    /// [`XattrCache::find`] assigns identical dedup indices (and thus identical
+    /// wire output).
+    fn linear_find(lists: &[XattrList], list: &XattrList) -> Option<u32> {
+        for (i, cached) in lists.iter().enumerate() {
+            if cached.len() != list.len() {
+                continue;
+            }
+            let all_match = cached.iter().zip(list.iter()).all(|(a, b)| {
+                a.name() == b.name() && a.datum_len() == b.datum_len() && a.datum() == b.datum()
+            });
+            if all_match {
+                return Some(i as u32);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn find_resolves_stored_set_by_content() {
+        let mut cache = XattrCache::new();
+        let ndx0 = cache.store(list_from(&[(b"user.a", b"1")]));
+        let ndx1 = cache.store(list_from(&[(b"user.b", b"2"), (b"user.c", b"3")]));
+        assert_eq!(ndx0, 0);
+        assert_eq!(ndx1, 1);
+
+        // A structurally identical set (fresh entries) resolves to the stored slot.
+        assert_eq!(cache.find(&list_from(&[(b"user.a", b"1")])), Some(0));
+        assert_eq!(
+            cache.find(&list_from(&[(b"user.b", b"2"), (b"user.c", b"3")])),
+            Some(1),
+        );
+        // Absent sets miss: unknown name, differing value, and differing order.
+        assert_eq!(cache.find(&list_from(&[(b"user.z", b"9")])), None);
+        assert_eq!(cache.find(&list_from(&[(b"user.a", b"2")])), None);
+        assert_eq!(
+            cache.find(&list_from(&[(b"user.c", b"3"), (b"user.b", b"2")])),
+            None,
+        );
+    }
+
+    #[test]
+    fn find_dedup_indices_match_linear_scan() {
+        // A stream of files with repeated + distinct xattr sets. The hashed
+        // find must assign exactly the indices a linear scan would, so the
+        // wire NUM abbreviation (and thus the byte output) is unchanged.
+        let files = [
+            list_from(&[(b"user.a", b"1")]),
+            list_from(&[(b"user.b", b"2")]),
+            list_from(&[(b"user.a", b"1")]), // dup of file 0
+            list_from(&[(b"user.c", b"3"), (b"user.d", b"4")]),
+            list_from(&[(b"user.b", b"2")]), // dup of file 1
+            list_from(&[(b"user.c", b"3"), (b"user.d", b"4")]), // dup of file 3
+            XattrList::new(),                // empty set, distinct
+            XattrList::new(),                // dup of the empty set
+        ];
+
+        let mut cache = XattrCache::new();
+        let mut reference: Vec<XattrList> = Vec::new();
+
+        for file in &files {
+            let hashed = cache.find(file);
+            let linear = linear_find(&reference, file);
+            assert_eq!(hashed, linear, "hashed find diverged from linear scan");
+
+            if hashed.is_none() {
+                let ndx = cache.store(file.clone());
+                assert_eq!(ndx as usize, reference.len(), "store index diverged");
+                reference.push(file.clone());
+            }
+        }
+
+        // Deduplication collapsed the four unique sets to four slots.
+        assert_eq!(cache.len(), 4);
+    }
+
+    #[test]
+    fn find_is_hash_based_at_scale() {
+        // Populate the cache with many distinct sets, then confirm each is
+        // resolved to its own slot. A linear scan would be O(n) per lookup;
+        // this exercises the hash index at a size where correctness (not just
+        // adequacy) matters.
+        const N: u32 = 5000;
+        let mut cache = XattrCache::new();
+        for i in 0..N {
+            let name = format!("user.attr{i}").into_bytes();
+            let value = format!("value{i}").into_bytes();
+            let ndx = cache.store(list_from(&[(&name, &value)]));
+            assert_eq!(ndx, i);
+        }
+
+        for i in 0..N {
+            let name = format!("user.attr{i}").into_bytes();
+            let value = format!("value{i}").into_bytes();
+            assert_eq!(cache.find(&list_from(&[(&name, &value)])), Some(i));
+        }
+
+        // A set that was never stored misses.
+        assert_eq!(cache.find(&list_from(&[(b"user.absent", b"nope")])), None,);
+    }
+
+    #[test]
+    fn find_confirms_on_hash_collision_candidates() {
+        // Store two sets that differ only in datum; regardless of whether their
+        // hashes collide, find must return the exact matching slot and never a
+        // near-miss sharing the same bucket.
+        let mut cache = XattrCache::new();
+        let ndx0 = cache.store(list_from(&[(b"user.k", b"aaaa")]));
+        let ndx1 = cache.store(list_from(&[(b"user.k", b"bbbb")]));
+        assert_eq!((ndx0, ndx1), (0, 1));
+
+        assert_eq!(cache.find(&list_from(&[(b"user.k", b"aaaa")])), Some(0));
+        assert_eq!(cache.find(&list_from(&[(b"user.k", b"bbbb")])), Some(1));
+        assert_eq!(cache.find(&list_from(&[(b"user.k", b"cccc")])), None);
     }
 }


### PR DESCRIPTION
## Summary

The sender-side xattr wire cache resolved deduplication hits with a **linear scan** over every stored xattr set (`crates/protocol/src/flist/write/mod.rs`, old `find_matching_xattr`). On a large tree with many distinct xattr sets this is **O(n^2)** sender CPU during file-list generation.

Upstream rsync de-dups identical xattr sets through a **hash table** keyed on the set contents (`xattrs.c:380` `xattr_lookup_hash` / `xattrs.c:397` `find_matching_xattr`, backed by `rsync_xal_h`), giving amortized **O(1)** lookup.

## Change

- Add a content-hash index (`by_hash: HashMap<u64, Vec<u32>>`) inside `XattrCache`, mirroring upstream's `rsync_xal_h`. `store()` records each set's hash; the new `find()` selects candidate slots by hash, then confirms with a full element-wise comparison (entry count + per-entry name, datum length, datum bytes) exactly as upstream's collision walk does.
- The index is encapsulated inside the cache type (single responsibility); callers just call `cache.find(&list)`. The old linear-scan helper is removed.
- Slot-assignment order is preserved exactly, so the wire abbreviation `NUM` (`ndx - 1` reference) and the resulting bytes are **identical**. This is a pure internal performance change, not a wire change.

Also mirrors upstream's ACL **resume-at-last-match** cursor (`acls.c:448` `find_matching_rsync_acl`) so repeated ACLs arriving in a run are found without a full rescan. Because the store path never inserts duplicate ACLs, the matched index is unique and the returned value (hence wire output) is unchanged.

## Wire output unchanged - proof

Existing sender/round-trip tests continue to pass, confirming byte-level behavior:

- `xattr_cache_deduplicates_identical_sets` - second identical set still encodes as the compact varint index (strictly fewer bytes than the literal).
- `xattr_write_roundtrip_with_reader` - full write -> read reconstructs identical xattr data via the cache index.

New tests added:

- `find_dedup_indices_match_linear_scan` - drives a stream of repeated + distinct sets and asserts the hashed `find` assigns exactly the indices a linear scan would (identical `NUM` assignment).
- `find_resolves_stored_set_by_content`, `find_confirms_on_hash_collision_candidates`, `find_is_hash_based_at_scale` (5000 distinct sets) - correctness of hashed lookup incl. collision disambiguation and absence.

## Verification

- `cargo build -p protocol`
- `cargo nextest run -p protocol --all-features -E 'test(xattr) or test(flist) or test(cache) or test(dedup) or test(acl)'` -> 1169 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p protocol --all-targets --all-features --no-deps -- -D warnings` -> clean
