### PR TITLE
fix(protocol): reject zero run count in compressed-token decoder

### DIFF
--- a/crates/protocol/src/wire/compressed_token/step.rs
+++ b/crates/protocol/src/wire/compressed_token/step.rs
@@ -366,6 +366,15 @@ impl TokenDecodeCore {
                     self.rx_token = token;
                     self.rx_run = u16::from_le_bytes([input[0], input[1]]) as i32;
                     self.phase = Phase::Idle;
+                    if self.rx_run <= 0 {
+                        // upstream: token.c:548 recv_compressed_token_num -
+                        // `if (rx_run <= 0 ...) invalid_compressed_token()` ->
+                        // exit_cleanup(RERR_PROTOCOL) (exit 2). A zero run count
+                        // is malformed; abort instead of accepting it silently.
+                        return Err(crate::protocol_violation::protocol_violation(
+                            "invalid token number in compressed stream",
+                        ));
+                    }
                     return Ok(TokenStep::Emit(CompressedToken::BlockMatch(
                         self.rx_token as u32,
                     )));
@@ -396,6 +405,15 @@ impl TokenDecodeCore {
                     self.rx_token = token;
                     self.rx_run = u16::from_le_bytes([input[0], input[1]]) as i32;
                     self.phase = Phase::Idle;
+                    if self.rx_run <= 0 {
+                        // upstream: token.c:548 recv_compressed_token_num -
+                        // `if (rx_run <= 0 ...) invalid_compressed_token()` ->
+                        // exit_cleanup(RERR_PROTOCOL) (exit 2). A zero run count
+                        // is malformed; abort instead of accepting it silently.
+                        return Err(crate::protocol_violation::protocol_violation(
+                            "invalid token number in compressed stream",
+                        ));
+                    }
                     return Ok(TokenStep::Emit(CompressedToken::BlockMatch(
                         self.rx_token as u32,
                     )));

--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -1570,6 +1570,53 @@ fn zlib_decoder_rejects_i32_min_token() {
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
 }
 
+/// A run flag with a zero 16-bit run count must be rejected, not accepted
+/// silently.
+///
+/// Upstream `recv_compressed_token_num` reads the 2-byte run count and aborts
+/// with `RERR_PROTOCOL` when it is not positive:
+///
+/// ```c
+/// if (rx_run <= 0 || rx_token > MAX_TOKEN_INDEX - rx_run)
+///     invalid_compressed_token();
+/// ```
+///
+/// Reference: upstream `token.c:548`. Both the long (`TOKENRUN_LONG`) and
+/// relative (`TOKENRUN_REL`) run encodings feed the same check.
+fn assert_rejects_zero_run_count(wire: &[u8]) {
+    let mut decoder = CompressedTokenDecoder::new();
+    let mut cursor = Cursor::new(wire);
+    let err = decoder
+        .recv_token(&mut cursor)
+        .expect_err("decoder must reject a zero run count");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    // upstream token.c:548 invalid_compressed_token() exits RERR_PROTOCOL (2),
+    // not RERR_STREAMIO(12); the error must carry the ProtocolViolation marker.
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::ProtocolViolation>()),
+        "zero run count must be tagged RERR_PROTOCOL",
+    );
+    assert_eq!(err.to_string(), "invalid token number in compressed stream");
+}
+
+#[test]
+fn decoder_rejects_zero_run_count_long() {
+    // TOKENRUN_LONG, token 100, run count 0.
+    let mut wire = Vec::new();
+    wire.push(TOKENRUN_LONG);
+    wire.extend_from_slice(&100i32.to_le_bytes());
+    wire.extend_from_slice(&0u16.to_le_bytes());
+    assert_rejects_zero_run_count(&wire);
+}
+
+#[test]
+fn decoder_rejects_zero_run_count_rel() {
+    // TOKENRUN_REL with relative offset 10, run count 0.
+    let wire = [TOKENRUN_REL | 10, 0x00, 0x00];
+    assert_rejects_zero_run_count(&wire);
+}
+
 /// CVE-2026-43618 regression: the decoder must reject `TOKEN_REL`
 /// accumulation that would overflow `rx_token` past `i32::MAX`.
 ///


### PR DESCRIPTION
## Problem

The compressed-token decoder accepted a run count of `0` where upstream rsync aborts the transfer. Upstream `recv_compressed_token_num()` reads the 16-bit run count and rejects any non-positive value:

```c
/* token.c:546-549 */
rx_run = read_byte(f);
rx_run += read_byte(f) << 8;
if (rx_run <= 0 || rx_token > MAX_TOKEN_INDEX - rx_run)
    invalid_compressed_token();
```

`invalid_compressed_token()` calls `exit_cleanup(RERR_PROTOCOL)` (exit 2). Our sans-io decoder (`crates/protocol/src/wire/compressed_token/step.rs`) decoded the run count in the `RunCount` and `LongRunCount` phases but never checked it, so a malformed or adversarial peer sending a zero run count (via `TOKENRUN_LONG` or `TOKENRUN_REL`) was accepted silently instead of aborting - a wire-robustness divergence from upstream.

## Fix

After decoding the run count in both the `RunCount` and `LongRunCount` phases, reject `rx_run <= 0` by returning a protocol violation, reusing the existing `protocol_violation()` marker so the exit-code mapper yields `RERR_PROTOCOL` (2) rather than `RERR_STREAMIO` (12) - the same mechanism already used for the negative-token rejection in the adjacent `LongToken` phase. This mirrors upstream's abort semantics exactly.

Reference: upstream `token.c:548` (`recv_compressed_token_num`).

## Test

Added decoder unit tests feeding a crafted zero run count through both encodings (`TOKENRUN_LONG` and `TOKENRUN_REL`) and asserting the decoder returns the `ProtocolViolation`-tagged `InvalidData` error rather than accepting it. Verified the tests fail against the pre-fix decoder (nextest exit 100) and pass with the fix.

## Verify

- `cargo build -p protocol`
- `cargo nextest run -p protocol --all-features -E 'test(token) or test(compressed) or test(run_count) or test(decoder)'` - green
- `cargo fmt --all -- --check`
- `cargo clippy -p protocol --all-targets --all-features --no-deps -- -D warnings`
