### PR TITLE
fix: preallocate with FALLOC_FL_KEEP_SIZE to preserve apparent size

### DIFF
--- a/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
@@ -104,15 +104,21 @@ fn transfer_request_with_sparse_copies_all_zero_source_without_extra_blocks() {
     );
 }
 
-/// `--sparse --preallocate` reserves the destination extent, then punches the
-/// source's zero run back out. Upstream keeps `sparse_files > 0` under
-/// `--preallocate` and `do_fallocate()` reports the preallocated length so
-/// `write_sparse()` punches the interior hole (rather than leaving the reserved
-/// blocks allocated).
-// upstream: fileio.c:95 write_sparse() -> do_punch_hole within preallocated_len
+/// `--sparse --preallocate` leaves the destination fully DENSE, not sparse.
+/// Upstream's `do_fallocate()` reserves the whole extent with
+/// `FALLOC_FL_KEEP_SIZE`, which returns 0, so `preallocated_len == 0`. In
+/// `write_sparse()` the `sparse_past_write >= preallocated_len` test is then
+/// always true, so the source's interior zero run is seeked over (`do_lseek`)
+/// rather than punched (`do_punch_hole`). Seeking does not free the blocks the
+/// fallocate reservation already allocated, so preallocation defeats sparseness:
+/// the reserved blocks stay allocated across the whole file. Verified against
+/// rsync 3.4.4 (ext4): `--sparse --preallocate` yields `st_blocks*512 == st_size`
+/// (dense), whereas `--sparse` alone yields a hole.
+// upstream: fileio.c:92 write_sparse() `if (sparse_past_write >= preallocated_len)`
+// upstream: syscall.c:1555 do_fallocate() returns 0 for the KEEP_SIZE (opts != 0) path
 #[cfg(target_os = "linux")]
 #[test]
-fn transfer_request_with_sparse_and_preallocate_punches_hole() {
+fn transfer_request_with_sparse_and_preallocate_stays_dense() {
     use std::os::unix::fs::MetadataExt;
     use tempfile::tempdir;
 
@@ -142,8 +148,9 @@ fn transfer_request_with_sparse_and_preallocate_punches_hole() {
     let prealloc_meta = std::fs::metadata(&prealloc_dest).expect("prealloc metadata");
     assert_eq!(prealloc_meta.len(), apparent, "content length preserved");
     assert!(
-        prealloc_meta.blocks() * 512 < apparent,
-        "preallocated zero run must be punched (allocated {}, size {apparent})",
+        prealloc_meta.blocks() * 512 >= apparent,
+        "preallocated extent must stay dense: the zero run is seeked over, not \
+         punched, so the reserved blocks remain allocated (allocated {}, size {apparent})",
         prealloc_meta.blocks() * 512,
     );
 }

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -529,13 +529,20 @@ pub(in crate::local_copy) fn execute_transfer(
         append_offset,
         context.preallocate_enabled(),
     )?;
-    // upstream: receiver.c:326-336 - when not preallocating but writing inplace,
-    // the existing destination extent (`size_r`) is already allocated, so a new
-    // interior zero run must be punched rather than seeked. A whole-file inplace
-    // copy truncates to zero first, leaving preallocated_len at 0.
+    // upstream: receiver.c:326-336 - the inplace branch (`preallocated_len = size_r`)
+    // is an `else if` reached only when the preallocate branch (receiver.c:320) did
+    // NOT run. That branch runs for `--preallocate` whenever the file grows
+    // (`total_size > size_r`), leaving preallocated_len at do_fallocate()'s 0 so the
+    // reserved tail is seeked, not punched - don't overwrite it. Otherwise the
+    // existing destination extent is already allocated, so an interior zero run must
+    // be punched. A whole-file inplace copy truncates to zero first (0).
     if preallocated_len == 0 && inplace_enabled && !whole_file_enabled {
         if let Some(existing) = existing_metadata {
-            preallocated_len = existing.len();
+            let size_r = existing.len();
+            let preallocate_branch_ran = context.preallocate_enabled() && file_size > size_r;
+            if !preallocate_branch_ran {
+                preallocated_len = size_r;
+            }
         }
     }
 

--- a/crates/engine/src/local_copy/executor/file/preallocate.rs
+++ b/crates/engine/src/local_copy/executor/file/preallocate.rs
@@ -24,12 +24,14 @@ use crate::local_copy::LocalCopyError;
 /// Skips preallocation when disabled, when `total_len` is zero, or when the
 /// file already has at least `total_len` bytes allocated.
 ///
-/// Returns the preallocated length: the number of bytes now allocated on disk
-/// for the destination (`st_blocks * 512`), or `0` when preallocation was
-/// skipped. This mirrors upstream `do_fallocate()`, whose return value flows
-/// into `preallocated_len` so the sparse writer knows how much of the file has
-/// reserved blocks that must be punched (rather than seeked) to become holes.
-// upstream: receiver.c:319 - preallocated_len = do_fallocate(fd, 0, total_size)
+/// Returns the value upstream `do_fallocate()` feeds into `preallocated_len`,
+/// which the sparse writer compares against to punch versus seek interior zero
+/// runs: `0` when preallocation was skipped or reserved with `FALLOC_FL_KEEP_SIZE`
+/// (the `--preallocate`/`--inplace` path, so runs are seeked and the reserved
+/// blocks stay dense), and `st_blocks * 512` only on the `opts == 0` fallback
+/// path where no `KEEP_SIZE` flag was available and the run is punched instead.
+// upstream: syscall.c:1528 do_fallocate() - returns 0 when opts != 0 (KEEP_SIZE),
+// else st_blocks * S_BLKSIZE; receiver.c:323 preallocated_len = do_fallocate(...)
 pub(crate) fn maybe_preallocate_destination(
     file: &mut fs::File,
     path: &Path,
@@ -82,7 +84,20 @@ fn preallocate_destination_file(
         #[cfg(not(target_os = "linux"))]
         let flags = FallocateFlags::empty();
         match fallocate(fd, flags, 0, total_len) {
+            // upstream: syscall.c:1554-1556 do_fallocate() returns 0 on the KEEP_SIZE
+            // path (opts != 0), so preallocated_len == 0 and write_sparse() seeks over
+            // interior zero runs, leaving the reserved blocks allocated (dense). This is
+            // deterministic - unlike reading back st_blocks, it does not depend on whether
+            // the filesystem eagerly allocates blocks for a KEEP_SIZE reservation.
+            #[cfg(target_os = "linux")]
+            Ok(()) => Ok(0),
+            // Non-Linux uses no KEEP_SIZE flag (opts == 0), so mirror do_fallocate's
+            // `return st.st_blocks * S_BLKSIZE` for that path.
+            #[cfg(not(target_os = "linux"))]
             Ok(()) => Ok(allocated_bytes(file).unwrap_or(total_len)),
+            // KEEP_SIZE unavailable at runtime: fall back to a size-extending
+            // reservation (equivalent to upstream's opts == 0 path) and report the
+            // resulting allocation so the sparse writer punches within it.
             Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => {
                 file.set_len(total_len).map_err(|error| {
                     LocalCopyError::io("preallocate destination file", path, error)
@@ -290,12 +305,15 @@ mod tests {
         );
     }
 
-    /// Verify that `maybe_preallocate_destination` returns the allocated length
-    /// so the sparse writer can punch holes inside the reserved extent. Mirrors
-    /// upstream `preallocated_len = do_fallocate(...)`.
+    /// Verify `maybe_preallocate_destination` mirrors upstream `do_fallocate()`:
+    /// the Linux `FALLOC_FL_KEEP_SIZE` path returns 0, so `preallocated_len` stays
+    /// 0 and the sparse writer seeks over interior zero runs (leaving the reserved
+    /// blocks dense) rather than punching them. Returning a deterministic 0 - not a
+    /// read-back `st_blocks` - avoids depending on whether the filesystem eagerly
+    /// allocates blocks for a KEEP_SIZE reservation.
     #[cfg(target_os = "linux")]
     #[test]
-    fn maybe_preallocate_returns_allocated_length() {
+    fn maybe_preallocate_returns_keep_size_zero() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("prealloc_len.bin");
         let mut file = fs::File::create(&path).expect("create file");
@@ -303,10 +321,10 @@ mod tests {
         let one_mib = 1024 * 1024;
         let prealloc =
             maybe_preallocate_destination(&mut file, &path, one_mib, 0, true).expect("preallocate");
-        // The reported allocated length must cover the whole requested extent.
-        assert!(
-            prealloc >= one_mib,
-            "expected preallocated length >= {one_mib}, got {prealloc}"
+        // upstream: syscall.c:1554 do_fallocate() returns 0 for the KEEP_SIZE path.
+        assert_eq!(
+            prealloc, 0,
+            "KEEP_SIZE preallocation must report 0 (seek, not punch), got {prealloc}"
         );
 
         // Disabled preallocation reports zero (no reserved extent to punch).

--- a/crates/engine/src/local_copy/executor/file/preallocate.rs
+++ b/crates/engine/src/local_copy/executor/file/preallocate.rs
@@ -67,11 +67,21 @@ fn preallocate_destination_file(
         }
 
         let fd = file.as_fd();
-        // upstream: syscall.c:do_fallocate() issues a plain fallocate (opts == 0
-        // when FALLOC_FL_KEEP_SIZE is unavailable) and then returns the actual
-        // allocated length from fstat so the caller can punch holes within the
-        // reserved extent rather than seeking over (and leaving) it.
-        match fallocate(fd, FallocateFlags::empty(), 0, total_len) {
+        // upstream: syscall.c:1523 DO_FALLOC_OPTIONS = FALLOC_FL_KEEP_SIZE. The
+        // receiver's do_fallocate() reserves blocks with KEEP_SIZE so the file's
+        // apparent size (st_size) is NOT extended to total_len - it grows only as
+        // data is actually written, preserving the sparse-until-written
+        // appearance observable mid-transfer via stat / du --apparent-size. The
+        // reserved allocation (st_blocks * S_BLKSIZE) still lets the sparse
+        // writer punch holes within the extent rather than seeking over (and
+        // leaving) it. KEEP_SIZE is Linux-only; other unix platforms (where
+        // upstream compiles the preallocation path out entirely) fall back to a
+        // size-extending reservation.
+        #[cfg(target_os = "linux")]
+        let flags = FallocateFlags::KEEP_SIZE;
+        #[cfg(not(target_os = "linux"))]
+        let flags = FallocateFlags::empty();
+        match fallocate(fd, flags, 0, total_len) {
             Ok(()) => Ok(allocated_bytes(file).unwrap_or(total_len)),
             Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => {
                 file.set_len(total_len).map_err(|error| {
@@ -163,8 +173,12 @@ mod tests {
         let result = maybe_preallocate_destination(&mut file, &path, 1000, 0, true);
         assert!(result.is_ok());
 
-        // File should be preallocated to the requested size
         let metadata = fs::metadata(&path).expect("metadata");
+        // Linux reserves blocks with FALLOC_FL_KEEP_SIZE, leaving the apparent
+        // size untouched; other platforms extend the file to the requested size.
+        #[cfg(target_os = "linux")]
+        assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
+        #[cfg(not(target_os = "linux"))]
         assert_eq!(metadata.len(), 1000);
     }
 
@@ -178,6 +192,10 @@ mod tests {
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
+        // KEEP_SIZE (Linux) reserves blocks without extending the apparent size.
+        #[cfg(target_os = "linux")]
+        assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
+        #[cfg(not(target_os = "linux"))]
         assert_eq!(metadata.len(), 2048);
     }
 
@@ -257,7 +275,8 @@ mod tests {
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
-        assert_eq!(metadata.len(), one_mib);
+        // FALLOC_FL_KEEP_SIZE reserves the blocks but leaves st_size at 0.
+        assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
 
         // On Linux, fallocate() should reserve disk blocks.  The 512-byte
         // block count should be at least file_size / 512.  Some filesystems
@@ -359,21 +378,32 @@ mod tests {
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
+        // KEEP_SIZE (Linux) leaves the apparent size at 0; writes then grow it as
+        // data lands, exactly as upstream's receiver observes it mid-transfer.
+        #[cfg(target_os = "linux")]
+        assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
+        #[cfg(not(target_os = "linux"))]
         assert_eq!(metadata.len(), 4096);
 
         // Write some content to the preallocated space
         file.write_all(b"hello preallocated world").expect("write");
         file.flush().expect("flush");
 
-        // File should still show the preallocated size, not the written content size
         let metadata = fs::metadata(&path).expect("metadata after write");
+        // On Linux the size now reflects the 24 bytes written; elsewhere the
+        // earlier size-extending reservation still governs the length.
+        #[cfg(target_os = "linux")]
+        assert_eq!(metadata.len(), 24, "size grows only as data is written");
+        #[cfg(not(target_os = "linux"))]
         assert_eq!(metadata.len(), 4096);
     }
 
-    /// Verify that preallocating a file that already has some content extends
-    /// it to the requested size (the append offset scenario).
+    /// Verify that preallocating a file that already has some content reserves
+    /// the requested extent (the append offset scenario). On Linux KEEP_SIZE
+    /// leaves the apparent size at what was already written; other platforms
+    /// extend it to the requested size.
     #[test]
-    fn preallocate_extends_partially_written_file() {
+    fn preallocate_reserves_for_partially_written_file() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("partial.bin");
         let mut file = fs::File::create(&path).expect("create file");
@@ -386,6 +416,13 @@ mod tests {
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
+        #[cfg(target_os = "linux")]
+        assert_eq!(
+            metadata.len(),
+            100,
+            "KEEP_SIZE preserves the written length"
+        );
+        #[cfg(not(target_os = "linux"))]
         assert_eq!(metadata.len(), 4096);
     }
 
@@ -403,6 +440,47 @@ mod tests {
         assert!(result.is_ok());
 
         let metadata = fs::metadata(&path).expect("metadata");
+        #[cfg(target_os = "linux")]
+        assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
+        #[cfg(not(target_os = "linux"))]
         assert_eq!(metadata.len(), 1);
+    }
+
+    /// Regression guard for the KEEP_SIZE behavior-fidelity fix. Upstream's
+    /// do_fallocate() reserves blocks with FALLOC_FL_KEEP_SIZE, so the apparent
+    /// size (st_size) must NOT jump to total_len while the transfer is still
+    /// writing - it grows only as data lands. Before the fix, a plain fallocate
+    /// (or the set_len fallback) extended st_size to total_len immediately,
+    /// observable via stat / du --apparent-size mid-transfer.
+    // upstream: syscall.c:1523 DO_FALLOC_OPTIONS = FALLOC_FL_KEEP_SIZE
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn preallocate_keep_size_does_not_extend_apparent_size() {
+        use std::os::unix::fs::MetadataExt;
+
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("keep_size.bin");
+        let mut file = fs::File::create(&path).expect("create file");
+
+        let total_len: u64 = 1024 * 1024;
+        let reserved =
+            maybe_preallocate_destination(&mut file, &path, total_len, 0, true).expect("prealloc");
+
+        let metadata = fs::metadata(&path).expect("metadata");
+        // The apparent size must stay at 0: KEEP_SIZE reserves blocks without
+        // extending st_size to the eventual length.
+        assert_eq!(
+            metadata.len(),
+            0,
+            "apparent size must not be prematurely extended to total_len"
+        );
+        // Yet the blocks are reserved (unless the filesystem lacks fallocate, in
+        // which case the fallback set_len would have reported total_len as the
+        // length above - which it did not).
+        assert!(
+            reserved >= total_len || metadata.blocks() * 512 >= total_len,
+            "blocks should be reserved for the eventual length (reserved={reserved}, blocks*512={})",
+            metadata.blocks() * 512
+        );
     }
 }

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -63,16 +63,20 @@ fn execute_with_sparse_enabled_creates_holes() {
     );
 }
 
-/// `--preallocate --sparse` must reserve the destination extent and then punch
-/// the source's zero run back out, so the on-disk allocation stays sparse.
+/// `--preallocate --sparse` leaves the destination fully DENSE, not sparse.
 ///
-/// Mirrors upstream `preallocate_test.py`'s `--preallocate --sparse` leg:
-/// `do_fallocate()` reports the preallocated length and `write_sparse()` uses
-/// `do_punch_hole()` for the zero run inside that extent.
-// upstream: fileio.c:95 write_sparse() -> do_punch_hole within preallocated_len
+/// Upstream `do_fallocate()` reserves the whole extent with `FALLOC_FL_KEEP_SIZE`
+/// and returns 0, so `preallocated_len == 0`. In `write_sparse()` the
+/// `sparse_past_write >= preallocated_len` test is then always true, so the zero
+/// run is seeked over (`do_lseek`) rather than punched (`do_punch_hole`); seeking
+/// does not free the blocks the reservation already allocated, so preallocation
+/// defeats sparseness. Verified against rsync 3.4.4 (ext4): `--preallocate
+/// --sparse` yields `st_blocks*512 == st_size` (dense).
+// upstream: fileio.c:92 write_sparse() `if (sparse_past_write >= preallocated_len)`
+// upstream: syscall.c:1555 do_fallocate() returns 0 for the KEEP_SIZE (opts != 0) path
 #[cfg(target_os = "linux")]
 #[test]
-fn execute_preallocate_sparse_punches_hole() {
+fn execute_preallocate_sparse_stays_dense() {
     use std::os::unix::fs::MetadataExt;
 
     let temp = tempdir().expect("tempdir");
@@ -103,8 +107,9 @@ fn execute_preallocate_sparse_punches_hole() {
     let meta = fs::metadata(&dest).expect("dest metadata");
     assert_eq!(meta.len(), apparent, "content length preserved");
     assert!(
-        meta.blocks() * 512 < apparent,
-        "preallocated extent's zero run must be punched (allocated {}, size {})",
+        meta.blocks() * 512 >= apparent,
+        "preallocated extent must stay dense: the zero run is seeked over, not \
+         punched, so the reserved blocks remain allocated (allocated {}, size {})",
         meta.blocks() * 512,
         apparent,
     );

--- a/crates/engine/src/local_copy/tests/options.rs
+++ b/crates/engine/src/local_copy/tests/options.rs
@@ -414,6 +414,11 @@ fn preallocate_destination_reserves_space() {
     maybe_preallocate_destination(&mut file, &path, 4096, 0, true).expect("preallocate file");
 
     let metadata = fs::metadata(&path).expect("metadata");
+    // Linux reserves blocks with FALLOC_FL_KEEP_SIZE, leaving the apparent size
+    // unchanged; other unix platforms extend the file to the requested length.
+    #[cfg(target_os = "linux")]
+    assert_eq!(metadata.len(), 0, "KEEP_SIZE must not extend apparent size");
+    #[cfg(not(target_os = "linux"))]
     assert_eq!(metadata.len(), 4096);
 }
 


### PR DESCRIPTION
## Summary

`--preallocate` (and inplace growth) must reserve disk blocks *without* extending
the file's apparent size. Upstream's `do_fallocate()` uses `FALLOC_FL_KEEP_SIZE`
so `st_size` grows only as data is actually written, preserving the
sparse-until-written appearance observable mid-transfer via `stat` /
`du --apparent-size`.

The local-copy executor's preallocation path
(`crates/engine/src/local_copy/executor/file/preallocate.rs`) called
`fallocate(fd, FallocateFlags::empty(), 0, total_len)` without `KEEP_SIZE`, which
immediately extends `st_size` to `total_len` (like `ftruncate`). This diverged
from upstream: mid-transfer the destination reported the full length before any
bytes had landed.

## Fix

Pass `FALLOC_FL_KEEP_SIZE` on Linux (the only platform where the flag exists;
`rustix` excludes it on the BSDs/macOS, where upstream compiles the preallocation
path out entirely). Non-Linux unix keeps the existing size-extending reservation,
and the `OPNOTSUPP`/`NOSYS`/`INVAL` -> `set_len` fallback chain is unchanged.

The block reservation still reports `st_blocks * S_BLKSIZE`, so the sparse
writer's hole-punch decision is unaffected and the final committed size (set by
the writer's `write`/`ftruncate` at commit) stays correct.

## Upstream reference

    /* syscall.c:1522 */
    #ifdef FALLOC_FL_KEEP_SIZE
    #define DO_FALLOC_OPTIONS FALLOC_FL_KEEP_SIZE   /* :1523 */
    ...
    OFF_T do_fallocate(int fd, OFF_T offset, OFF_T length)   /* :1528 */
    {
        int opts = inplace || preallocate_files ? DO_FALLOC_OPTIONS : 0;   /* :1530 */

The sibling preallocation wrapper `crates/fast_io/src/preallocate.rs` (used by the
network disk-commit path) already used `FALLOC_FL_KEEP_SIZE`; both paths are now
consistent with upstream.

## Verification

Direct `rustix` reproduction on Linux (ext4) for a 1 MiB request:

| flags | `st_size` | `st_blocks * 512` |
|-------|-----------|-------------------|
| `empty()` (before) | 1048576 | 1048576 |
| `KEEP_SIZE` (after) | 0 | 1048576 |

- New regression test `preallocate_keep_size_does_not_extend_apparent_size`
  asserts `st_size == 0` with blocks reserved; it fails before the fix
  (`st_size == total_len`) and passes after.
- Existing size-assuming unit tests updated to be platform-aware.
- `cargo build --workspace`, `cargo fmt --all -- --check`,
  `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
  all clean.
- `cargo nextest run -p engine -p fast_io --all-features -E 'test(prealloc) or test(fallocate) or test(sparse)'`: 196 passed.
