### PR TITLE
fix(cli): render %C from negotiated checksum, not hardcoded MD5

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -6,7 +6,7 @@ use std::io::{self, Write};
 use core::{
     client::{
         ClientConfig, ClientProgressObserver, ClientSummary, HumanReadableMode,
-        run_client_with_observer,
+        StrongChecksumAlgorithm, run_client_with_observer,
     },
     message::Message,
 };
@@ -136,6 +136,15 @@ where
     // `--list-only` renderer knows whether to append the ` -> <target>` arrow
     // to symlink rows (upstream: generator.c:1183 gates it on preserve_links).
     let preserve_links = config.links();
+    // Capture the negotiated checksum before `config` is consumed so the `%C`
+    // renderer reports the negotiated algorithm's digest (upstream: log.c:687-690
+    // selects `file_sum_nni` under `--checksum`, else `xfer_sum_nni`).
+    let always_checksum = config.checksum();
+    let full_checksum_algorithm = if always_checksum {
+        config.checksum_choice().file()
+    } else {
+        config.checksum_choice().transfer()
+    };
 
     let result = {
         let observer = live_progress
@@ -168,7 +177,8 @@ where
                 .with_emit_unchanged(emit_unchanged)
                 .with_itemize_repeated(itemize_repeated)
                 .with_eight_bit_output(eight_bit_output)
-                .with_preserve_links(preserve_links);
+                .with_preserve_links(preserve_links)
+                .with_full_checksum(full_checksum_algorithm, always_checksum);
             if let Err(error) = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
                 emit_transfer_summary(
                     &summary,
@@ -217,6 +227,8 @@ where
                     show_crtimes,
                     eight_bit_output,
                     preserve_links,
+                    full_checksum_algorithm,
+                    always_checksum,
                 })
             {
                 let _ = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
@@ -276,6 +288,11 @@ struct EmitLogOutputParams<'a> {
     /// `--links` / `-l`: whether symlink rows in `--list-only` log output get
     /// the ` -> <target>` arrow (upstream: generator.c:1183).
     preserve_links: bool,
+    /// Negotiated `%C` checksum algorithm (upstream: log.c:687-690).
+    full_checksum_algorithm: StrongChecksumAlgorithm,
+    /// `--checksum` / `-c` (upstream `always_checksum`), gating `%C` for
+    /// untransferred regular files.
+    always_checksum: bool,
 }
 
 /// Writes the transfer summary to the configured log file.
@@ -295,6 +312,8 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         show_crtimes,
         eight_bit_output,
         preserve_links,
+        full_checksum_algorithm,
+        always_checksum,
     } = params;
     // upstream: generator.c:582-583 - mirror the `INFO_GTE(NAME, 2)` arm of
     // the itemize emit gate in the log-file renderer so `-vv` / `--info=name2`
@@ -305,7 +324,8 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         .with_emit_unchanged(emit_unchanged)
         .with_itemize_repeated(itemize_repeated)
         .with_eight_bit_output(eight_bit_output)
-        .with_preserve_links(preserve_links);
+        .with_preserve_links(preserve_links)
+        .with_full_checksum(full_checksum_algorithm, always_checksum);
     // The FCLIENT "sending incremental file list" banner is stdout only;
     // upstream's parallel "building file list" line (flist.c:2248) is an FLOG
     // log-file message that a plain client without --log-file discards.

--- a/crates/cli/src/frontend/out_format/render/checksum.rs
+++ b/crates/cli/src/frontend/out_format/render/checksum.rs
@@ -1,59 +1,165 @@
 #![deny(unsafe_code)]
 
-//! Full-file MD5 checksum computation for the `%C` out-format placeholder.
+//! Full-file checksum rendering for the `%C` out-format placeholder.
 
 use std::fmt::Write as FmtWrite;
 use std::fs::File;
 use std::io::{ErrorKind, Read};
+use std::path::Path;
 
-use checksums::strong::Md5;
-use core::client::{ClientEntryKind, ClientEvent, ClientEventKind};
+use checksums::strong::{Md4, Md5, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64};
+use core::client::{ClientEntryKind, ClientEvent, ClientEventKind, StrongChecksumAlgorithm};
 
-/// Computes and formats the full-file MD5 checksum for an event's destination file.
+use crate::frontend::out_format::tokens::OutFormatContext;
+
+/// Byte order upstream `util2.c:sum_as_hex` applies when formatting a digest.
 ///
-/// Returns a 32-character hex string, or 32 spaces when the checksum is not applicable
-/// (non-file entries, non-transfer events, or I/O errors).
-pub(super) fn format_full_checksum(event: &ClientEvent) -> String {
-    const EMPTY_CHECKSUM: &str = "                                ";
+/// Mirrors `checksum.c:canonical_checksum`: MD4/MD5/SHA return `-1` (the public
+/// hex is the digest's natural order), the xxHash family returns `1` (the public
+/// hex is the digest reversed), and non-canonical types return `0` (upstream
+/// emits `NULL`, rendered here as spaces).
+#[derive(Clone, Copy)]
+enum SumByteOrder {
+    /// Emit the digest bytes in natural order (MD4/MD5/SHA, canonical `-1`).
+    Forward,
+    /// Emit the digest bytes reversed (xxHash family, canonical `1`).
+    Reversed,
+}
 
-    if !matches!(
-        event.kind(),
-        ClientEventKind::DataCopied
-            | ClientEventKind::ReferenceCopied
-            | ClientEventKind::MetadataReused
-            | ClientEventKind::HardLink,
-    ) {
-        return EMPTY_CHECKSUM.to_owned();
-    }
+/// Computes and formats the `%C` full-file checksum for an event.
+///
+/// Mirrors upstream `log.c:685-697`: `%C` reports the negotiated checksum
+/// (`file_sum_nni` under `--checksum`, otherwise `xfer_sum_nni`) of a regular
+/// file, using the digest length and byte order of `util2.c:sum_as_hex`. A
+/// non-regular entry, an untransferred file without `--checksum`, or a
+/// non-canonical algorithm renders `sum_len * 2` spaces.
+///
+/// The digest is recomputed over the committed destination. Every canonical
+/// algorithm's whole-file sum is unseeded (`checksum.c:558 sum_init` resets the
+/// xxHash state with seed `0`; `file_checksum` likewise resets with `0`; MD5/MD4
+/// take no seed), so the recomputed bytes are identical to the `F_SUM` /
+/// `sender_file_sum` the protocol carries for the same content.
+pub(super) fn format_full_checksum(event: &ClientEvent, context: &OutFormatContext) -> String {
+    let algorithm = context.full_checksum_algorithm();
+    let spaces = || " ".repeat(hex_width(algorithm));
 
+    // upstream: log.c:686 - only a regular file (`S_ISREG`) carries a %C sum.
     if let Some(metadata) = event.metadata()
         && metadata.kind() != ClientEntryKind::File
     {
-        return EMPTY_CHECKSUM.to_owned();
+        return spaces();
     }
 
-    let path = event.destination_path();
-    let mut file = match File::open(&path) {
-        Ok(file) => file,
-        Err(_) => return EMPTY_CHECKSUM.to_owned(),
+    // upstream: log.c:687-690 - render `F_SUM` for any regular file under
+    // `--checksum`, else `sender_file_sum` only for a transferred file
+    // (`ITEM_TRANSFER`, i.e. a `DataCopied` event).
+    let emit_sum = context.always_checksum() || matches!(event.kind(), ClientEventKind::DataCopied);
+    if !emit_sum {
+        return spaces();
+    }
+
+    // upstream: util2.c:98 - `sum_as_hex` returns NULL for a non-canonical
+    // algorithm, which `log.c:691-696` renders as spaces.
+    let Some(order) = canonical_order(algorithm) else {
+        return spaces();
     };
 
-    let mut hasher = Md5::new();
-    let mut buffer = vec![0u8; 32 * 1024];
+    match hash_destination(algorithm, &event.destination_path()) {
+        Some(digest) => render_hex(&digest, order),
+        // A digest we cannot recompute (e.g. the destination is unreadable)
+        // falls back to the space-padded field width.
+        None => spaces(),
+    }
+}
+
+/// Renders the digest bytes as hex in the requested byte order.
+fn render_hex(digest: &[u8], order: SumByteOrder) -> String {
+    let mut rendered = String::with_capacity(digest.len() * 2);
+    match order {
+        SumByteOrder::Forward => {
+            for byte in digest {
+                // write! to String is infallible
+                let _ = write!(rendered, "{byte:02x}");
+            }
+        }
+        SumByteOrder::Reversed => {
+            for byte in digest.iter().rev() {
+                let _ = write!(rendered, "{byte:02x}");
+            }
+        }
+    }
+    rendered
+}
+
+/// Returns the space-padded field width (`sum_len * 2`) for an algorithm.
+///
+/// upstream: log.c:691-694 - the empty `%C` field is `csum_len_for_type(...) * 2`
+/// spaces wide.
+const fn hex_width(algorithm: StrongChecksumAlgorithm) -> usize {
+    digest_len(algorithm) * 2
+}
+
+/// Digest length in bytes, mirroring `checksum.c:csum_len_for_type`.
+const fn digest_len(algorithm: StrongChecksumAlgorithm) -> usize {
+    match algorithm {
+        // `auto` negotiates xxh128 for a modern protocol-31+ transfer.
+        StrongChecksumAlgorithm::Auto
+        | StrongChecksumAlgorithm::Xxh128
+        | StrongChecksumAlgorithm::Md5
+        | StrongChecksumAlgorithm::Md4 => 16,
+        StrongChecksumAlgorithm::Sha1 => 20,
+        StrongChecksumAlgorithm::Xxh64 | StrongChecksumAlgorithm::Xxh3 => 8,
+        // upstream: checksum.c:217 - `csum_len_for_type(CSUM_NONE)` is 1.
+        StrongChecksumAlgorithm::None => 1,
+    }
+}
+
+/// Byte order for an algorithm, or `None` when it is non-canonical.
+///
+/// upstream: checksum.c:255-278 `canonical_checksum`.
+const fn canonical_order(algorithm: StrongChecksumAlgorithm) -> Option<SumByteOrder> {
+    match algorithm {
+        StrongChecksumAlgorithm::Md5
+        | StrongChecksumAlgorithm::Md4
+        | StrongChecksumAlgorithm::Sha1 => Some(SumByteOrder::Forward),
+        StrongChecksumAlgorithm::Auto
+        | StrongChecksumAlgorithm::Xxh128
+        | StrongChecksumAlgorithm::Xxh64
+        | StrongChecksumAlgorithm::Xxh3 => Some(SumByteOrder::Reversed),
+        StrongChecksumAlgorithm::None => None,
+    }
+}
+
+/// Computes the unseeded whole-file digest of `path` with `algorithm`.
+///
+/// Returns `None` for the non-canonical [`None`](StrongChecksumAlgorithm::None)
+/// algorithm or when the file cannot be read.
+fn hash_destination(algorithm: StrongChecksumAlgorithm, path: &Path) -> Option<Vec<u8>> {
+    match algorithm {
+        StrongChecksumAlgorithm::Md5 => stream_digest::<Md5>(path),
+        StrongChecksumAlgorithm::Md4 => stream_digest::<Md4>(path),
+        StrongChecksumAlgorithm::Sha1 => stream_digest::<Sha1>(path),
+        StrongChecksumAlgorithm::Xxh64 => stream_digest::<Xxh64>(path),
+        StrongChecksumAlgorithm::Xxh3 => stream_digest::<Xxh3>(path),
+        StrongChecksumAlgorithm::Auto | StrongChecksumAlgorithm::Xxh128 => {
+            stream_digest::<Xxh3_128>(path)
+        }
+        StrongChecksumAlgorithm::None => None,
+    }
+}
+
+/// Streams `path` through a [`StrongDigest`] and returns its digest bytes.
+fn stream_digest<S: StrongDigest>(path: &Path) -> Option<Vec<u8>> {
+    let mut file = File::open(path).ok()?;
+    let mut hasher = S::new();
+    let mut buffer = vec![0u8; 64 * 1024];
     loop {
         match file.read(&mut buffer) {
             Ok(0) => break,
             Ok(read) => hasher.update(&buffer[..read]),
             Err(error) if error.kind() == ErrorKind::Interrupted => continue,
-            Err(_) => return EMPTY_CHECKSUM.to_owned(),
+            Err(_) => return None,
         }
     }
-
-    let digest = hasher.finalize();
-    let mut rendered = String::with_capacity(32);
-    for byte in digest {
-        // write! to String is infallible
-        let _ = write!(rendered, "{byte:02x}");
-    }
-    rendered
+    Some(hasher.finalize().as_ref().to_vec())
 }

--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -147,7 +147,9 @@ pub(super) fn render_placeholder_value(
         OutFormatPlaceholder::ModulePath => {
             Some(remote_placeholder_value(context.module_path.as_deref(), 'P').into_bytes())
         }
-        OutFormatPlaceholder::FullChecksum => Some(format_full_checksum(event).into_bytes()),
+        OutFormatPlaceholder::FullChecksum => {
+            Some(format_full_checksum(event, context).into_bytes())
+        }
     }
 }
 

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1710,6 +1710,8 @@ fn render_remote_host_with_context_populated() {
         itemize_repeated: false,
         eight_bit_output: false,
         preserve_links: false,
+        full_checksum_algorithm: None,
+        always_checksum: false,
     };
     assert_eq!(
         render_format_with_context("%h", &event, &context),
@@ -1735,6 +1737,8 @@ fn render_remote_address_with_context_populated() {
         itemize_repeated: false,
         eight_bit_output: false,
         preserve_links: false,
+        full_checksum_algorithm: None,
+        always_checksum: false,
     };
     assert_eq!(
         render_format_with_context("%a", &event, &context),
@@ -1760,6 +1764,8 @@ fn render_module_name_with_context_populated() {
         itemize_repeated: false,
         eight_bit_output: false,
         preserve_links: false,
+        full_checksum_algorithm: None,
+        always_checksum: false,
     };
     assert_eq!(render_format_with_context("%m", &event, &context), "data\n");
 }
@@ -1782,6 +1788,8 @@ fn render_module_path_with_context_populated() {
         itemize_repeated: false,
         eight_bit_output: false,
         preserve_links: false,
+        full_checksum_algorithm: None,
+        always_checksum: false,
     };
     assert_eq!(
         render_format_with_context("%P", &event, &context),
@@ -1807,6 +1815,8 @@ fn render_all_remote_placeholders_with_full_context() {
         itemize_repeated: false,
         eight_bit_output: false,
         preserve_links: false,
+        full_checksum_algorithm: None,
+        always_checksum: false,
     };
     let rendered = render_format_with_context("%h %a %m %P", &event, &context);
     assert_eq!(rendered, "host addr mod /path\n");

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -2,6 +2,8 @@
 
 //! Token definitions backing `--out-format` parsing and rendering.
 
+use core::client::StrongChecksumAlgorithm;
+
 /// Maximum width accepted for placeholder formatting.
 pub(super) const MAX_PLACEHOLDER_WIDTH: usize = 4096;
 
@@ -188,6 +190,19 @@ pub(crate) struct OutFormatContext {
     /// `preserve_links && S_ISLNK(f->mode)`; without `-l` the symlink is
     /// still listed (with its target-length size) but no target string.
     pub(super) preserve_links: bool,
+    /// Negotiated strong-checksum algorithm applied to the `%C` placeholder.
+    ///
+    /// Upstream `log.c:687-690` renders `%C` from the negotiated checksum
+    /// (`file_sum_nni` under `--checksum`, otherwise `xfer_sum_nni`). `None`
+    /// means the default negotiated algorithm (auto, i.e. xxh128 for a modern
+    /// protocol-31+ transfer - `checksum.c` `negotiate_the_strings`).
+    pub(super) full_checksum_algorithm: Option<StrongChecksumAlgorithm>,
+    /// `--checksum` / `-c` (upstream `always_checksum`).
+    ///
+    /// Upstream `log.c:687-688` renders `%C` from the file-list checksum
+    /// (`F_SUM`) for every regular file when this is set; otherwise `%C` is
+    /// only populated for a transferred file (`ITEM_TRANSFER`).
+    pub(super) always_checksum: bool,
 }
 
 impl OutFormatContext {
@@ -265,6 +280,39 @@ impl OutFormatContext {
     #[must_use]
     pub(crate) const fn preserve_links(&self) -> bool {
         self.preserve_links
+    }
+
+    /// Sets the negotiated `%C` checksum algorithm and the `--checksum` flag.
+    ///
+    /// upstream: log.c:687-690 - `%C` renders the negotiated file/transfer
+    /// checksum, not a hardcoded MD5. The algorithm selects the digest length
+    /// and byte order (`util2.c:sum_as_hex`), and `always_checksum` decides
+    /// whether an untransferred regular file still shows its file-list sum.
+    #[must_use]
+    pub(crate) fn with_full_checksum(
+        mut self,
+        algorithm: StrongChecksumAlgorithm,
+        always_checksum: bool,
+    ) -> Self {
+        self.full_checksum_algorithm = Some(algorithm);
+        self.always_checksum = always_checksum;
+        self
+    }
+
+    /// Returns the negotiated `%C` checksum algorithm, resolving the default to
+    /// [`Auto`](StrongChecksumAlgorithm::Auto) (xxh128 for a modern transfer).
+    #[must_use]
+    pub(super) const fn full_checksum_algorithm(&self) -> StrongChecksumAlgorithm {
+        match self.full_checksum_algorithm {
+            Some(algorithm) => algorithm,
+            None => StrongChecksumAlgorithm::Auto,
+        }
+    }
+
+    /// Returns whether `--checksum` (`always_checksum`) is in effect.
+    #[must_use]
+    pub(super) const fn always_checksum(&self) -> bool {
+        self.always_checksum
     }
 }
 
@@ -405,6 +453,8 @@ mod tests {
             itemize_repeated: false,
             eight_bit_output: false,
             preserve_links: false,
+            full_checksum_algorithm: None,
+            always_checksum: false,
         };
         assert_eq!(ctx.remote_host.as_deref(), Some("server.example.com"));
         assert_eq!(ctx.remote_address.as_deref(), Some("192.168.1.1"));

--- a/crates/cli/src/frontend/tests/out/checksum.rs
+++ b/crates/cli/src/frontend/tests/out/checksum.rs
@@ -1,9 +1,41 @@
 use super::*;
-use checksums::strong::Md5;
+use core::client::StrongChecksumAlgorithm;
 use core::client::run_client;
 
+/// Transfers `contents` locally and returns the `DataCopied` event whose
+/// committed destination the `%C` renderer will digest.
+fn data_copy_event(summary: &core::client::ClientSummary) -> &core::client::ClientEvent {
+    summary
+        .events()
+        .iter()
+        .find(|event| matches!(event.kind(), ClientEventKind::DataCopied))
+        .expect("data copy event present")
+}
+
+fn render_full_checksum(
+    event: &core::client::ClientEvent,
+    algorithm: StrongChecksumAlgorithm,
+) -> String {
+    let context = OutFormatContext::default().with_full_checksum(algorithm, false);
+    let mut output = Vec::new();
+    parse_out_format(OsStr::new("%C"))
+        .expect("parse %C")
+        .render(event, &context, &mut output)
+        .expect("render %C");
+    String::from_utf8(output)
+        .expect("utf8")
+        .trim_end_matches('\n')
+        .to_owned()
+}
+
+// upstream: log.c:687-690 + util2.c:93 `sum_as_hex` - `%C` reports the
+// negotiated checksum with that algorithm's digest length and byte order, NOT
+// a hardcoded forward MD5. The expected hex strings below are the canonical
+// digests of `"checksum payload"` produced by independent tools (`md5`,
+// `xxhsum -H2/-H1/-H3`, `openssl sha1`), so they prove bytes + width + order
+// against upstream rather than against the renderer's own hashing.
 #[test]
-fn out_format_renders_full_checksum_for_files() {
+fn out_format_renders_full_checksum_per_negotiated_algorithm() {
     let temp = tempfile::tempdir().expect("tempdir");
     let src_dir = temp.path().join("src");
     let dst_dir = temp.path().join("dst");
@@ -11,8 +43,7 @@ fn out_format_renders_full_checksum_for_files() {
     std::fs::create_dir(&dst_dir).expect("create dst dir");
 
     let source = src_dir.join("file.bin");
-    let contents = b"checksum payload";
-    std::fs::write(&source, contents).expect("write source");
+    std::fs::write(&source, b"checksum payload").expect("write source");
     let destination = dst_dir.join("file.bin");
 
     let config = ClientConfig::builder()
@@ -24,25 +55,80 @@ fn out_format_renders_full_checksum_for_files() {
         .build();
 
     let summary = run_client(config).expect("run client");
+    let event = data_copy_event(&summary);
+
+    // MD5 (canonical -1): natural byte order, 32 hex.
+    assert_eq!(
+        render_full_checksum(event, StrongChecksumAlgorithm::Md5),
+        "6c4606710d880afec7b782e2c9d6c558",
+    );
+    // XXH128 (canonical 1): reversed byte order, 32 hex - the canonical
+    // xxhsum -H2 output. A forward-MD5 renderer cannot produce this.
+    assert_eq!(
+        render_full_checksum(event, StrongChecksumAlgorithm::Xxh128),
+        "101f112992f1057ebc29c5880344b907",
+    );
+    // `auto` negotiates xxh128, so the default matches XXH128.
+    assert_eq!(
+        render_full_checksum(event, StrongChecksumAlgorithm::Auto),
+        "101f112992f1057ebc29c5880344b907",
+    );
+    // XXH3-64 (canonical 1): reversed, 16 hex - width differs from MD5.
+    assert_eq!(
+        render_full_checksum(event, StrongChecksumAlgorithm::Xxh3),
+        "b9280f7200d2cd0b",
+    );
+    // XXH64 (canonical 1): reversed, 16 hex.
+    assert_eq!(
+        render_full_checksum(event, StrongChecksumAlgorithm::Xxh64),
+        "98da654e1eb37d9c",
+    );
+    // SHA1 (canonical -1): natural byte order, 40 hex.
+    assert_eq!(
+        render_full_checksum(event, StrongChecksumAlgorithm::Sha1),
+        "be6f9f10fabcfdee6bdcae41ac52c174dd428da2",
+    );
+}
+
+// upstream: log.c:687-690 - without `--checksum`, `%C` is only populated for a
+// transferred file (`ITEM_TRANSFER`). An untransferred regular file (a
+// quick-check `MetadataReused` skip) renders the space-padded field, not a sum.
+#[test]
+fn out_format_full_checksum_untransferred_file_is_spaces_without_checksum() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src_dir = temp.path().join("src");
+    let dst_dir = temp.path().join("dst");
+    std::fs::create_dir(&src_dir).expect("create src");
+    std::fs::create_dir(&dst_dir).expect("create dst");
+
+    let source = src_dir.join("unchanged.txt");
+    std::fs::write(&source, b"same contents").expect("write source");
+    let destination = dst_dir.join("unchanged.txt");
+
+    let build_config = || {
+        ClientConfig::builder()
+            .transfer_args([
+                source.as_os_str().to_os_string(),
+                destination.as_os_str().to_os_string(),
+            ])
+            .times(true)
+            .force_event_collection(true)
+            .build()
+    };
+
+    run_client(build_config()).expect("initial copy");
+    let summary = run_client(build_config()).expect("re-run");
 
     let event = summary
         .events()
         .iter()
-        .find(|event| event.relative_path().to_string_lossy() == "file.bin")
-        .expect("file event present");
+        .find(|event| matches!(event.kind(), ClientEventKind::MetadataReused))
+        .expect("metadata reuse event present");
 
-    let mut output = Vec::new();
-    parse_out_format(OsStr::new("%C"))
-        .expect("parse %C")
-        .render(event, &OutFormatContext::default(), &mut output)
-        .expect("render %C");
-
-    let rendered = String::from_utf8(output).expect("utf8");
-    let mut hasher = Md5::new();
-    hasher.update(contents);
-    let digest = hasher.finalize();
-    let expected: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
-    assert_eq!(rendered, format!("{expected}\n"));
+    // Default (auto/xxh128) => 16-byte digest => 32-space field.
+    let rendered = render_full_checksum(event, StrongChecksumAlgorithm::Xxh128);
+    assert_eq!(rendered.len(), 32);
+    assert!(rendered.chars().all(|ch| ch == ' '));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

The `%C` out-format / log-format escape rendered the wrong checksum. It
hardcoded a fresh, unseeded, forward byte-order **MD5** of the destination
file at a fixed 32-hex width, regardless of the negotiated algorithm.

Upstream `log.c:685-697` renders `%C` from the **negotiated** checksum:
`file_sum_nni` under `--checksum`, otherwise `xfer_sum_nni` (which defaults
to **xxh128** on protocol 31+). It formats via `util2.c:93 sum_as_hex`,
using the algorithm's true digest **length** (xxh3/xxh64 = 8B -> 16 hex;
md5/xxh128 = 16B -> 32 hex; sha1 = 20B -> 40 hex) and `canonical_checksum`
**byte order** (xxHash digests are byte-reversed; MD4/MD5/SHA are natural
order).

So oc showed the wrong hash, wrong width, and wrong byte order whenever the
negotiated algorithm was not MD5 - i.e. on essentially every modern transfer.

## Fix

- Thread the negotiated algorithm and the `--checksum` flag into the `%C`
  renderer (`OutFormatContext`), captured from `ClientConfig` before it is
  consumed.
- Format via a single, well-named `(algorithm, digest-bytes) -> canonical-hex`
  mapping that mirrors `sum_as_hex` width and byte order, plus the
  `canonical_checksum` non-canonical case (spaces).
- Narrow the non-`--checksum` path to transferred files only
  (`ITEM_TRANSFER`): an untransferred regular file now renders the
  space-padded field, matching upstream, instead of a spurious sum.

### Why recomputing over the destination is correct

Every canonical algorithm's whole-file sum is **unseeded**: `checksum.c:558
sum_init` resets the xxHash state with seed `0`, `file_checksum` likewise
resets with `0`, and MD5/MD4 take no seed. So the digest recomputed over the
committed destination is byte-identical to the `F_SUM` / `sender_file_sum`
the protocol carries for the same content.

## Test vectors (independent oracle)

Digests of `"checksum payload"`, cross-checked with `md5`, `xxhsum -H2/-H1/-H3`,
and `openssl sha1`, and confirmed byte-for-byte against **rsync 3.4.4**
(`--out-format='%C'`):

| algo | `%C` output |
|------|-------------|
| md5 | `6c4606710d880afec7b782e2c9d6c558` |
| xxh128 (default) | `101f112992f1057ebc29c5880344b907` |
| xxh64 | `98da654e1eb37d9c` |
| xxh3 | `b9280f7200d2cd0b` |

New unit tests assert these exact strings (they fail against the old
hardcoded-MD5 renderer for every non-MD5 algorithm), plus the
untransferred-file space-padding case.

## Verification

- `cargo build -p cli`, `cargo clippy -p cli --all-targets --all-features
  --no-deps -D warnings`, `cargo fmt --all --check`: clean.
- `cargo nextest run -p cli` (out_format / checksum / render): 402 passed.
- End-to-end vs rsync 3.4.4: `%C` output for md5, xxh128 (default), xxh64,
  xxh3, and the directory space-padding are byte-identical.

Refs: `log.c:685-697` (`%C`), `util2.c:93-118` (`sum_as_hex`),
`checksum.c:214-278` (`csum_len_for_type`, `canonical_checksum`),
`checksum.c:558` (`sum_init` seed handling).
