### PR TITLE
fix: tolerate malformed-bracket filter patterns like upstream

### DIFF
--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -172,10 +172,10 @@ impl CompiledRule {
         // Anchored patterns (`/**/*`) whose stem starts with `**` after the
         // leading-`/` strip are NOT WILD2_PREFIX and must not get the prepend.
         let wild2_prefix = !anchored && core_pattern.starts_with("**");
-        let direct_matchers = compile_patterns(direct_patterns, &pattern, wild2_prefix)?;
-        let descendant_matchers = compile_patterns(descendant_patterns, &pattern, wild2_prefix)?;
+        let direct_matchers = compile_patterns(direct_patterns, wild2_prefix)?;
+        let descendant_matchers = compile_patterns(descendant_patterns, wild2_prefix)?;
         let deletion_descendant_matchers =
-            compile_patterns(deletion_descendant_patterns, &pattern, wild2_prefix)?;
+            compile_patterns(deletion_descendant_patterns, wild2_prefix)?;
 
         Ok(Self {
             action,

--- a/crates/filters/src/compiled/pattern.rs
+++ b/crates/filters/src/compiled/pattern.rs
@@ -2,17 +2,18 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::Path;
 
-use globset::GlobBuilder;
-
 use crate::FilterError;
 use crate::wildmatch::wildmatch;
 
 /// A compiled filter pattern matched with upstream rsync's `wildmatch()`.
 ///
 /// Matching is delegated to [`wildmatch`] so `*`, `**`, `?`, `[...]`, and `\`
-/// behave byte-for-byte like `lib/wildmatch.c:dowild()`. globset is still used
-/// at compile time to reject malformed patterns, keeping [`FilterError`]
-/// behaviour unchanged.
+/// behave byte-for-byte like `lib/wildmatch.c:dowild()`. Compilation never
+/// rejects a pattern: upstream rsync stores every filter pattern verbatim
+/// (exclude.c:add_rule) and a malformed bracket expression like `[`, `[!`, or
+/// a trailing `\` simply fails to match rather than raising a parse error, so
+/// gating compilation on a stricter glob validator would diverge from
+/// upstream.
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledPattern {
     bytes: Vec<u8>,
@@ -73,22 +74,22 @@ fn path_match_bytes(path: &Path) -> Vec<u8> {
 
 /// Compiles a set of glob pattern strings into sorted, deduplicated matchers.
 ///
-/// Patterns are sorted for deterministic evaluation order. Each pattern is
-/// built with `literal_separator(true)` so that `*` does not match `/`,
-/// matching upstream rsync's wildcard semantics.
+/// Patterns are sorted for deterministic evaluation order. Matching is
+/// delegated to [`wildmatch`], so compilation is infallible: upstream rsync
+/// never rejects a filter pattern (exclude.c:add_rule stores it verbatim; a
+/// malformed bracket expression fails to match instead of erroring). The
+/// [`FilterError`] slot is retained for API stability.
 ///
 /// Bare interior `**` sequences carry the upstream wildmatch semantic
-/// "match anything including `/`". globset's `literal_separator(true)`
-/// only treats `**` as recursive when it is bounded by `/`, so the input
-/// pattern is expanded into TWO variants: the original (covers the
-/// in-segment case where `**` behaves like a single-segment `*`) and a
-/// slash-bounded rewrite (covers the cross-segment case). Both are added
-/// to the matcher set so either form can satisfy upstream parity.
+/// "match anything including `/`". The input pattern is expanded into TWO
+/// variants: the original (covers the in-segment case where `**` behaves like
+/// a single-segment `*`) and a slash-bounded rewrite (covers the cross-segment
+/// case). Both are added to the matcher set so either form can satisfy
+/// upstream parity.
 ///
 /// upstream: `lib/wildmatch.c:dowild()` - `**` always matches across `/`.
 pub(crate) fn compile_patterns(
     patterns: HashSet<String>,
-    original: &str,
     wild2_prefix: bool,
 ) -> Result<Vec<CompiledPattern>, FilterError> {
     let mut expanded: HashSet<String> = HashSet::with_capacity(patterns.len() * 2);
@@ -108,13 +109,6 @@ pub(crate) fn compile_patterns(
 
     let mut matchers = Vec::with_capacity(unique.len());
     for pattern in unique {
-        // globset still validates the pattern so malformed globs surface as
-        // FilterError exactly as before; matching is delegated to wildmatch.
-        GlobBuilder::new(&pattern)
-            .literal_separator(true)
-            .backslash_escape(true)
-            .build()
-            .map_err(|error| FilterError::new(original.to_owned(), error))?;
         matchers.push(CompiledPattern {
             bytes: pattern.into_bytes(),
             wild2_prefix,

--- a/crates/filters/src/compiled/xattr.rs
+++ b/crates/filters/src/compiled/xattr.rs
@@ -42,7 +42,7 @@ impl CompiledXattrRule {
         debug_assert!(rule.xattr_only, "non-xattr rule compiled as xattr rule");
         let mut patterns = std::collections::HashSet::with_capacity(1);
         patterns.insert(rule.pattern.clone());
-        let matchers = compile_patterns(patterns, &rule.pattern, false)?;
+        let matchers = compile_patterns(patterns, false)?;
         Ok(Self {
             action: rule.action,
             matchers,

--- a/crates/filters/src/error.rs
+++ b/crates/filters/src/error.rs
@@ -2,12 +2,16 @@
 
 use thiserror::Error;
 
-/// Error produced when a [`FilterRule`](crate::FilterRule) cannot be compiled
-/// into a glob matcher.
+/// Error slot for filter-rule compilation, retained for API stability.
 ///
-/// This error is returned by [`FilterSet::from_rules`](crate::FilterSet::from_rules)
-/// when a pattern expands to an invalid glob expression. The error retains the
-/// offending pattern and the underlying [`globset::Error`] for diagnostics.
+/// This is the error type of
+/// [`FilterSet::from_rules`](crate::FilterSet::from_rules) and the
+/// [`FilterSetError::Filter`](crate::FilterSetError::Filter) variant. Filter
+/// compilation is infallible - matching is delegated to a byte-for-byte port
+/// of `lib/wildmatch.c:dowild()`, and upstream rsync never rejects a filter
+/// pattern (exclude.c:add_rule stores every pattern verbatim; a malformed
+/// bracket expression fails to match rather than erroring). The type is kept
+/// so the fallible signature remains source-compatible for callers.
 #[derive(Debug, Error)]
 #[error("failed to compile filter pattern '{pattern}': {source}")]
 pub struct FilterError {
@@ -17,32 +21,9 @@ pub struct FilterError {
 }
 
 impl FilterError {
-    /// Creates a new [`FilterError`] for the given pattern and source error.
-    pub(crate) const fn new(pattern: String, source: globset::Error) -> Self {
-        Self { pattern, source }
-    }
-
     /// Filter pattern that triggered this error.
     #[must_use]
     pub fn pattern(&self) -> &str {
         &self.pattern
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::FilterError;
-    use globset::GlobBuilder;
-    use std::error::Error as _;
-
-    #[test]
-    fn filter_error_preserves_pattern_and_source() {
-        let glob_err = GlobBuilder::new("[").build().unwrap_err();
-        let error = FilterError::new("[".into(), glob_err.clone());
-
-        assert_eq!(error.pattern(), "[");
-        assert!(error.to_string().contains("failed to compile"));
-        assert!(error.source().is_some());
-        assert_eq!(error.source().unwrap().to_string(), glob_err.to_string());
     }
 }

--- a/crates/filters/src/implied.rs
+++ b/crates/filters/src/implied.rs
@@ -183,29 +183,67 @@ impl ImpliedIncludes {
 
     /// Compiles and stores one anchored include rule, de-duplicating repeats.
     ///
-    /// A pattern that fails to compile (e.g. an unbalanced `[` in a wildcard
-    /// arg) is retried with its glob metacharacters escaped so it matches
-    /// literally - stricter than a wildcard, never more permissive, and always
-    /// valid. This mirrors upstream falling back to a literal-bracket rule
-    /// (`maybe_add_literal_brackets_rule`).
+    /// When the pattern contains a live (unescaped) `[`, an additional rule with
+    /// every such `[` escaped is stored so the *literal* bracketed name is also
+    /// accepted. A remote shell may return a file matching the literal brackets
+    /// when a `[foo]` glob idiom failed to expand, so upstream adds both the
+    /// wildcard rule and the escaped-literal rule.
+    ///
+    /// upstream: `exclude.c:312` `maybe_add_literal_brackets_rule()`, invoked
+    /// after each implied rule with a live `[` (exclude.c:494, 526, 569).
     fn push_rule(&mut self, pattern: &str, directory_only: bool) -> Result<(), FilterError> {
-        if !self.seen.insert(pattern.to_owned()) {
-            return Ok(());
+        if self.seen.insert(pattern.to_owned()) {
+            let compiled = CompiledRule::new(FilterRule::include(pattern))?;
+            debug_assert_eq!(compiled.is_directory_only(), directory_only);
+            self.rules.push(compiled);
         }
-        let rule = FilterRule::include(pattern);
-        let compiled = match CompiledRule::new(rule) {
-            Ok(compiled) => compiled,
-            Err(_) => CompiledRule::new(FilterRule::include(globset::escape(pattern)))?,
-        };
-        debug_assert_eq!(compiled.is_directory_only(), directory_only);
-        self.rules.push(compiled);
+        if let Some(escaped) = escape_live_brackets(pattern) {
+            if self.seen.insert(escaped.clone()) {
+                let compiled = CompiledRule::new(FilterRule::include(escaped))?;
+                debug_assert_eq!(compiled.is_directory_only(), directory_only);
+                self.rules.push(compiled);
+            }
+        }
         Ok(())
     }
 }
 
+/// Escapes every live (unescaped) `[` in `pattern` as `\[`, returning `None`
+/// when the pattern has no live `[`.
+///
+/// upstream: `exclude.c:312` `maybe_add_literal_brackets_rule()` - a `\`
+/// consumes the following byte (so an already-escaped `\[` is left alone), and
+/// each remaining `[` is prefixed with a backslash so it matches literally.
+fn escape_live_brackets(pattern: &str) -> Option<String> {
+    let bytes = pattern.as_bytes();
+    let mut out = String::with_capacity(pattern.len() + 4);
+    let mut cut = 0;
+    let mut i = 0;
+    let mut changed = false;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            // Skip the escape pair verbatim so `\[` is not re-escaped.
+            i += 2;
+        } else if bytes[i] == b'[' {
+            out.push_str(&pattern[cut..i]);
+            out.push('\\');
+            cut = i;
+            changed = true;
+            i += 1;
+        } else {
+            i += 1;
+        }
+    }
+    if !changed {
+        return None;
+    }
+    out.push_str(&pattern[cut..]);
+    Some(out)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ImpliedIncludeOptions, ImpliedIncludes};
+    use super::{ImpliedIncludeOptions, ImpliedIncludes, escape_live_brackets};
     use std::path::Path;
 
     fn covers(implied: &ImpliedIncludes, name: &str, is_dir: bool) -> bool {
@@ -416,9 +454,11 @@ mod tests {
     }
 
     #[test]
-    fn unbalanced_bracket_arg_falls_back_to_literal() {
-        // A malformed glob must not abort rule construction; it is matched
-        // literally instead (stricter, never more permissive).
+    fn live_bracket_arg_also_admits_literal_name() {
+        // upstream: exclude.c:312 maybe_add_literal_brackets_rule() - an arg
+        // with a live `[` gets an extra escaped-bracket rule so the literal
+        // name is admitted when the glob idiom failed to expand remotely. It is
+        // stricter than a wildcard, never more permissive.
         let opts = ImpliedIncludeOptions {
             recurse: true,
             ..Default::default()
@@ -426,5 +466,17 @@ mod tests {
         let implied = ImpliedIncludes::from_args(opts, ["a[b"]).unwrap();
         assert!(covers(&implied, "a[b", true));
         assert!(!covers(&implied, "evil", false));
+    }
+
+    #[test]
+    fn escape_live_brackets_escapes_only_live_brackets() {
+        assert_eq!(escape_live_brackets("a[b").as_deref(), Some("a\\[b"));
+        assert_eq!(
+            escape_live_brackets("/x[y]z/**").as_deref(),
+            Some("/x\\[y]z/**")
+        );
+        // Already-escaped `\[` is left alone; no live `[` means no rewrite.
+        assert_eq!(escape_live_brackets("a\\[b"), None);
+        assert_eq!(escape_live_brackets("plain/name"), None);
     }
 }

--- a/crates/filters/src/tests.rs
+++ b/crates/filters/src/tests.rs
@@ -114,10 +114,13 @@ fn wildcard_patterns_match_expected_paths() {
     assert!(set.allows(Path::new("note.txt"), false));
 }
 
+/// upstream rsync never rejects a malformed-bracket pattern: `--exclude='['`
+/// compiles and matches nothing (exclude.c:add_rule stores it verbatim;
+/// lib/wildmatch.c:dowild returns ABORT_ALL). Compilation must mirror that.
 #[test]
-fn invalid_pattern_reports_error() {
-    let error = FilterSet::from_rules([FilterRule::exclude("[")]).expect_err("invalid");
-    assert_eq!(error.pattern(), "[");
+fn malformed_bracket_pattern_compiles_and_never_matches() {
+    let set = FilterSet::from_rules([FilterRule::exclude("[")]).expect("`[` must compile");
+    assert!(set.allows(Path::new("note.txt"), false));
 }
 
 #[test]

--- a/crates/filters/tests/edge_cases.rs
+++ b/crates/filters/tests/edge_cases.rs
@@ -276,39 +276,37 @@ fn very_long_pattern() {
     assert!(!set.allows(Path::new(&matching), false));
 }
 
-/// Verifies invalid pattern reports error.
+/// upstream rsync accepts an unbalanced `[` and simply never matches it:
+/// exclude.c:add_rule() stores the pattern verbatim and
+/// lib/wildmatch.c:dowild() returns ABORT_ALL for the malformed class rather
+/// than raising a parse error. Compilation must not turn that no-op into an
+/// error. Verified against rsync 3.4.4: `--exclude='['` exits 0 and transfers
+/// every file.
 #[test]
-fn invalid_pattern_unclosed_bracket() {
-    let result = FilterSet::from_rules([FilterRule::exclude("[")]);
-    assert!(result.is_err());
-
-    let error = result.unwrap_err();
-    assert_eq!(error.pattern(), "[");
+fn unclosed_bracket_compiles_and_never_matches() {
+    let set = FilterSet::from_rules([FilterRule::exclude("[")]).expect("`[` must compile");
+    assert!(set.allows(Path::new("foo.txt"), false));
 }
 
-/// Verifies error preserves pattern text.
+/// An unterminated character class (`[invalid`) is likewise tolerated by
+/// upstream and never matches - dowild() runs off the end of the pattern and
+/// returns ABORT_ALL.
 #[test]
-fn error_preserves_pattern() {
-    let result = FilterSet::from_rules([FilterRule::exclude("[invalid")]);
-
-    match result {
-        Err(error) => {
-            assert_eq!(error.pattern(), "[invalid");
-            assert!(error.to_string().contains("failed to compile"));
-        }
-        Ok(_) => panic!("Expected error"),
-    }
+fn unterminated_class_compiles_and_never_matches() {
+    let set = FilterSet::from_rules([FilterRule::exclude("[invalid")]).expect("must compile");
+    assert!(set.allows(Path::new("invalid"), false));
+    assert!(set.allows(Path::new("[invalid"), false));
 }
 
-/// Verifies valid rules still work after invalid one fails.
+/// A batch mixing a well-formed rule with a malformed-bracket rule compiles
+/// as a whole (upstream never rejects the batch); the well-formed rule still
+/// excludes its matches while the malformed rule matches nothing.
 #[test]
-fn valid_rules_compile_before_invalid() {
-    // First rule is valid, second is invalid
-    let rules = [FilterRule::exclude("*.txt"), FilterRule::exclude("[")];
-
-    // The whole batch fails because one is invalid
-    let result = FilterSet::from_rules(rules);
-    assert!(result.is_err());
+fn valid_and_malformed_rules_all_compile() {
+    let set = FilterSet::from_rules([FilterRule::exclude("*.txt"), FilterRule::exclude("[")])
+        .expect("both rules compile");
+    assert!(!set.allows(Path::new("a.txt"), false));
+    assert!(set.allows(Path::new("foo"), false));
 }
 
 /// Verifies all filter actions can be created.
@@ -383,17 +381,34 @@ fn filter_set_debug() {
     assert!(debug.contains("FilterSet"));
 }
 
-/// Verifies FilterError can be accessed.
+/// Malformed bracket / character-class patterns that upstream rsync accepts
+/// syntactically and never matches. Verified against rsync 3.4.4:
+/// `rsync -r --exclude=<pat> src/ dst/` exits 0 and transfers every file for
+/// each pattern below (exclude.c:add_rule stores the pattern verbatim;
+/// lib/wildmatch.c:dowild returns ABORT_ALL/FALSE, never a parse error).
 #[test]
-fn filter_error_access() {
-    let result = FilterSet::from_rules([FilterRule::exclude("[")]);
-
-    if let Err(error) = result {
-        assert_eq!(error.pattern(), "[");
-        // Error should have source
-        assert!(!error.to_string().is_empty());
-    } else {
-        panic!("Expected error");
+fn malformed_bracket_patterns_compile_and_never_match() {
+    let malformed = [
+        "[",
+        "[!",
+        "a[]b",
+        "[a-",
+        "[[:notaclass:]]",
+        "\\",
+        "ab[",
+        "[-",
+    ];
+    for pat in malformed {
+        let set = FilterSet::from_rules([FilterRule::exclude(pat)])
+            .unwrap_or_else(|e| panic!("pattern {pat:?} must compile, got {e}"));
+        assert!(
+            set.allows(Path::new("foo.txt"), false),
+            "pattern {pat:?} must not exclude foo.txt (upstream parity: no match)"
+        );
+        assert!(
+            set.allows(Path::new("a]b"), false),
+            "pattern {pat:?} must not exclude a]b (upstream parity: no match)"
+        );
     }
 }
 

--- a/crates/filters/tests/exclude_patterns.rs
+++ b/crates/filters/tests/exclude_patterns.rs
@@ -1134,13 +1134,12 @@ mod edge_cases {
         assert!(set.allows(Path::new("file.gz"), false));
     }
 
-    /// Test: Pattern invalid syntax reports error.
+    /// upstream rsync never rejects a malformed-bracket pattern: `--exclude='['`
+    /// compiles and matches nothing (exclude.c:add_rule stores it verbatim;
+    /// lib/wildmatch.c:dowild returns ABORT_ALL). Compilation must mirror that.
     #[test]
-    fn invalid_pattern_error() {
-        let result = FilterSet::from_rules([FilterRule::exclude("[")]);
-        assert!(result.is_err());
-
-        let error = result.unwrap_err();
-        assert_eq!(error.pattern(), "[");
+    fn malformed_bracket_pattern_compiles_and_never_matches() {
+        let set = FilterSet::from_rules([FilterRule::exclude("[")]).expect("`[` must compile");
+        assert!(set.allows(Path::new("file.txt"), false));
     }
 }

--- a/crates/filters/tests/filter_rule_syntax.rs
+++ b/crates/filters/tests/filter_rule_syntax.rs
@@ -1268,11 +1268,14 @@ mod error_handling {
         assert!(result.is_err());
     }
 
+    /// A malformed-bracket glob (`- [`) parses as a rule and compiles: upstream
+    /// rsync stores it verbatim (exclude.c:add_rule) and never matches it
+    /// (lib/wildmatch.c:dowild returns ABORT_ALL), so compilation must not error.
     #[test]
-    fn invalid_glob_pattern() {
+    fn malformed_glob_pattern_compiles() {
         let rules = parse_rules("- [", Path::new("test")).unwrap();
-        let result = FilterSet::from_rules(rules);
-        assert!(result.is_err());
+        let set = FilterSet::from_rules(rules).expect("malformed glob must compile");
+        assert!(set.allows(Path::new("file.txt"), false));
     }
 }
 

--- a/crates/filters/tests/proptest_fuzz.rs
+++ b/crates/filters/tests/proptest_fuzz.rs
@@ -698,9 +698,11 @@ fn filter_set_only_wildcards() {
 
 #[test]
 fn filter_set_unclosed_bracket() {
-    let result = FilterSet::from_rules([FilterRule::exclude("[")]);
-    // Should be an error (invalid glob), not a panic
-    assert!(result.is_err());
+    // upstream tolerates an unclosed bracket: it compiles and matches nothing
+    // (exclude.c:add_rule stores it verbatim; lib/wildmatch.c:dowild returns
+    // ABORT_ALL), never erroring and never panicking.
+    let set = FilterSet::from_rules([FilterRule::exclude("[")]).expect("`[` must compile");
+    assert!(set.allows(Path::new("file.txt"), false));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Filter-rule compilation gated pattern acceptance on globset's
`GlobBuilder::build()` (`crates/filters/src/compiled/pattern.rs`), which rejects
malformed bracket / character-class patterns with a hard `FilterError` at parse
time. Upstream rsync never rejects a filter pattern: `exclude.c:add_rule()`
stores every pattern verbatim, and `lib/wildmatch.c:dowild()` returns
`ABORT_ALL`/`FALSE` for a malformed class rather than raising a parse error, so
a bad `[` simply never matches.

oc already matches through the ported `dowild` (`crates/filters/src/wildmatch.rs`),
so the globset gate turned a silent no-op rule into a user-facing error - a real
behavioral divergence. globset's build result was discarded (matching never used
it), so the gate provided no optimization, only the divergence.

## Differential evidence (rsync 3.4.4)

For each pattern below, `rsync -r --exclude=<pat> src/ dst/` exits 0 and transfers
every file (the rule matches nothing); oc previously returned `FilterError`:

| pattern | upstream 3.4.4 | oc (before) |
|---------|----------------|-------------|
| `[` | accept, no match (rc=0) | `FilterError` |
| `[!` | accept, no match (rc=0) | `FilterError` |
| `a[]b` | accept, no match (rc=0) | `FilterError` |
| `[a-` | accept, no match (rc=0) | `FilterError` |
| `[[:notaclass:]]` | accept, no match (rc=0) | `FilterError` |
| `\` (trailing) | accept, no match (rc=0) | `FilterError` |
| `ab[` | accept, no match (rc=0) | `FilterError` |
| `[-` | accept, no match (rc=0) | `FilterError` |

These are also present in upstream's own `wildtest.txt` corpus (already mirrored
in `wildmatch.rs`), where `dowild()` returns false for each - never an error.

## Fix

Remove the globset gate: filter-pattern compilation is now infallible, matching
upstream's tolerance. The public `FilterSet::from_rules` signature and the
`FilterError` type are retained for source compatibility.

The implied-include mechanism (CVE-2022-29154) previously relied on the compile
error to trigger upstream's escaped-literal fallback. That is replaced with a
faithful port of `exclude.c:312 maybe_add_literal_brackets_rule()`: when an
implied-include arg contains a live `[`, an additional rule with each live `[`
escaped is stored so the literal bracketed name is still admitted.

## Tests

- New parametrized test proving each malformed pattern compiles and matches
  nothing (parity with upstream `dowild`). Fails before the fix (`FilterError`).
- Flipped the former error-asserting tests to assert compile-success + no-match.
- Added `escape_live_brackets` unit coverage for the implied-include port.

## Verify

- `cargo build -p filters` / `-p transfer` / `-p engine`: clean
- `cargo nextest run -p filters --all-features`: 1420 passed
- `cargo fmt --all -- --check`: clean
- `cargo clippy -p filters --all-targets --all-features --no-deps -- -D warnings`: clean
