### PR TITLE
fix(transfer): copy backup across filesystems when rename fails

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -10,7 +10,9 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use engine::{CleanupManager, compute_backup_path, trace_make_backup_rename};
+use engine::{
+    CleanupManager, compute_backup_path, trace_make_backup_copy, trace_make_backup_rename,
+};
 
 use crate::pipeline::messages::{BackupNotice, BeginMessage};
 use crate::temp_guard::TempFileGuard;
@@ -439,29 +441,132 @@ pub(super) fn is_cross_device(e: &io::Error) -> bool {
     }
 }
 
+/// Moves an existing destination file to its backup path, falling back to a
+/// copy when the rename cannot cross a filesystem boundary.
+///
+/// Returns `Ok(false)` when a plain rename moved the file and `Ok(true)` when
+/// the cross-device (`EXDEV`) copy+unlink fallback ran - the case a
+/// `--backup-dir` (or `--backup` suffix landing on another mount) on a
+/// different filesystem than the destination triggers.
+///
+/// upstream: `backup.c:226` `make_backup()` - after `link_or_rename()` cannot
+/// move the pre-image across the mount (`do_rename_at` fails with `EXDEV`),
+/// rsync falls back to `copy_file()` + unlink (`backup.c:270`). oc reuses the
+/// same `fs::copy` + `fs::remove_file` mechanism the tmp->dest commit uses in
+/// [`rename_with_io_uring_fallback`] (`util1.c:robust_rename()`), so `fs::copy`
+/// carries the mode bits exactly as upstream's `copy_file(..., file->mode)`.
+fn backup_rename_or_copy(old_path: &Path, new_path: &Path) -> io::Result<bool> {
+    match backup_rename_syscall(old_path, new_path) {
+        Ok(()) => Ok(false),
+        Err(e) if is_cross_device(&e) => {
+            // upstream: backup.c:270-284 - copy_file() then keep_backup unlinks
+            // the source; the backup ends up on the other filesystem.
+            fs::copy(old_path, new_path)?;
+            fs::remove_file(old_path)?;
+            Ok(true)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Issues the backup rename. In production this is a bare [`fs::rename`]; under
+/// `cfg(test)` a fault-injection guard can force a cross-device (`EXDEV`) error
+/// so the copy fallback in [`backup_rename_or_copy`] can be exercised
+/// deterministically on filesystems that would otherwise complete the rename.
+#[cfg(not(test))]
+#[inline]
+fn backup_rename_syscall(old_path: &Path, new_path: &Path) -> io::Result<()> {
+    fs::rename(old_path, new_path)
+}
+
+#[cfg(test)]
+fn backup_rename_syscall(old_path: &Path, new_path: &Path) -> io::Result<()> {
+    if force_exdev_active() {
+        return Err(simulated_cross_device_error());
+    }
+    fs::rename(old_path, new_path)
+}
+
+// Test-only fault injection for the backup rename boundary. A thread-local flag
+// (nextest runs each test in its own process, and the guard is thread-scoped
+// regardless) makes `backup_rename_syscall` report a cross-device error,
+// driving the EXDEV copy+remove path without a real second filesystem.
+#[cfg(test)]
+thread_local! {
+    static FORCE_EXDEV: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+fn force_exdev_active() -> bool {
+    FORCE_EXDEV.with(std::cell::Cell::get)
+}
+
+/// Builds an error `is_cross_device` recognizes on the current platform.
+#[cfg(test)]
+fn simulated_cross_device_error() -> io::Error {
+    #[cfg(unix)]
+    {
+        io::Error::from_raw_os_error(libc::EXDEV)
+    }
+    #[cfg(windows)]
+    {
+        io::Error::from_raw_os_error(17)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        io::Error::other("simulated cross-device")
+    }
+}
+
+/// Test-only RAII guard that forces [`backup_rename_syscall`] onto the
+/// cross-device path for its lifetime, exercising the copy fallback.
+#[cfg(test)]
+pub(super) struct ForceExdev;
+
+#[cfg(test)]
+impl ForceExdev {
+    pub(super) fn new() -> Self {
+        FORCE_EXDEV.with(|c| c.set(true));
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for ForceExdev {
+    fn drop(&mut self) {
+        FORCE_EXDEV.with(|c| c.set(false));
+    }
+}
+
 /// SEC-1.j: dirfd-anchor the `--backup` rename against the receiver's
-/// destination sandbox, otherwise `std::fs::rename`.
+/// destination sandbox, otherwise rename with a cross-device copy fallback.
 ///
 /// The backup rename moves an existing destination file to its backup name
 /// (`file~` or `<backup-dir>/...`). When the sandbox is present and both the
 /// original and the backup are single components directly under `dest_dir`, the
 /// rename resolves both leaves against the pinned dirfd so a symlink swap on the
-/// parent cannot redirect the backup outside the tree. Otherwise it falls back
-/// to the original path-based [`std::fs::rename`] with no behavior change (no
-/// io_uring/EXDEV path is introduced on the backup rename, matching prior
-/// semantics).
+/// parent cannot redirect the backup outside the tree; both endpoints then
+/// share the destination filesystem, so `EXDEV` cannot arise and the call
+/// returns `Ok(false)`.
+///
+/// Otherwise - the common `--backup-dir` case, where the backup tree may live
+/// on a different mount than the destination - it falls back to
+/// [`backup_rename_or_copy`], which renames and, on a cross-device failure,
+/// copies the pre-image and unlinks the original (upstream `backup.c:226`).
+/// Returns `Ok(true)` when that copy fallback ran so the caller can emit the
+/// upstream `make_backup: COPY` trace instead of `RENAME`.
 #[cfg(unix)]
 fn backup_rename_sandboxed(
     config: &DiskCommitConfig,
     old_path: &Path,
     new_path: &Path,
-) -> io::Result<()> {
+) -> io::Result<bool> {
     if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref())
         && let (Some(old_leaf), Some(new_leaf)) = (old_path.file_name(), new_path.file_name())
         && old_path.parent() == Some(dest_dir)
         && new_path.parent() == Some(dest_dir)
     {
-        return fast_io::renameat_via_sandbox_or_fallback(
+        fast_io::renameat_via_sandbox_or_fallback(
             Some(sandbox.as_ref()),
             dest_dir,
             Path::new(old_leaf),
@@ -470,9 +575,10 @@ fn backup_rename_sandboxed(
             Path::new(new_leaf),
             new_path,
             true,
-        );
+        )?;
+        return Ok(false);
     }
-    fs::rename(old_path, new_path)
+    backup_rename_or_copy(old_path, new_path)
 }
 
 #[cfg(not(unix))]
@@ -480,8 +586,8 @@ fn backup_rename_sandboxed(
     _config: &DiskCommitConfig,
     old_path: &Path,
     new_path: &Path,
-) -> io::Result<()> {
-    fs::rename(old_path, new_path)
+) -> io::Result<bool> {
+    backup_rename_or_copy(old_path, new_path)
 }
 
 /// SEC-1.j: create the `--backup-dir` parent, dirfd-anchoring the leaf `mkdir`
@@ -554,10 +660,16 @@ pub(super) fn make_backup(
         }
     }
 
-    backup_rename_sandboxed(config, file_path, &backup_path)?;
-    // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1) on the RENAME success
-    // branch of link_or_rename. disk_commit always uses rename here.
-    trace_make_backup_rename(&file_path.display().to_string());
+    let was_copy = backup_rename_sandboxed(config, file_path, &backup_path)?;
+    if was_copy {
+        // upstream: backup.c:284 - DEBUG_GTE(BACKUP, 1) "make_backup: COPY %s
+        // successful." when the cross-device copy tier moved the pre-image.
+        trace_make_backup_copy(&file_path.display().to_string());
+    } else {
+        // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1) on the RENAME success
+        // branch of link_or_rename.
+        trace_make_backup_rename(&file_path.display().to_string());
+    }
     // upstream: backup.c:352 - INFO_GTE(BACKUP, 1) fires on success label for
     // every successful backup. Paths are displayed relative to the destination
     // root to match upstream test assertions (testsuite/backup.test). The

--- a/crates/transfer/src/disk_commit/process/mod.rs
+++ b/crates/transfer/src/disk_commit/process/mod.rs
@@ -28,6 +28,8 @@ pub(super) use self::file_ops::{process_file, process_whole_file};
 
 // Re-exported for the in-module test suite (`use super::*`), which exercises
 // the rename/cross-device/backup helpers and the writer selector directly.
+#[cfg(test)]
+use self::commit::ForceExdev;
 #[cfg(all(test, unix))]
 use self::commit::rename_config_sandboxed;
 #[cfg(test)]

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -355,6 +355,60 @@ fn make_backup_returns_destination_relative_notice() {
     assert_eq!(notice.backup, PathBuf::from("payload.bin~"));
 }
 
+/// Verifies `make_backup` succeeds when the backup path is on a different
+/// filesystem than the destination: the bare rename fails cross-device
+/// (`EXDEV`) and upstream's copy tier moves the pre-image by copying its bytes
+/// to the backup and unlinking the original.
+///
+/// Before the copy fallback existed, `make_backup` did a bare rename with no
+/// `EXDEV` handling, so a `--backup-dir` on another mount propagated the error
+/// and failed the commit. The cross-device condition is injected at the rename
+/// boundary via [`ForceExdev`] so the test is deterministic on a single-
+/// filesystem CI runner. If the copy tier were removed the rename error would
+/// surface and this test would fail.
+///
+/// upstream: backup.c:226 make_backup() - `copy_file()` + unlink when
+/// `do_rename_at` cannot cross the mount.
+#[test]
+fn make_backup_cross_device_uses_copy_fallback() {
+    use std::ffi::OsString;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("payload.bin");
+    fs::write(&file_path, b"pre-transfer content").unwrap();
+
+    let config = BackupConfig {
+        dest_dir: dir.path().to_path_buf(),
+        backup_dir: None,
+        suffix: OsString::from("~"),
+    };
+
+    let notice = {
+        let _force = ForceExdev::new();
+        make_backup(&file_path, &config, &DiskCommitConfig::default())
+            .expect("cross-device backup must succeed via the copy fallback")
+            .expect("notice produced when an existing file is backed up")
+    };
+
+    let backup_path = file_path.with_extension("bin~");
+    assert!(
+        backup_path.exists(),
+        "backup must exist after the copy fallback"
+    );
+    assert!(
+        !file_path.exists(),
+        "original must be unlinked once the copy completes"
+    );
+    assert_eq!(
+        fs::read(&backup_path).unwrap(),
+        b"pre-transfer content",
+        "backup must hold the original pre-transfer bytes"
+    );
+
+    assert_eq!(notice.original, PathBuf::from("payload.bin"));
+    assert_eq!(notice.backup, PathBuf::from("payload.bin~"));
+}
+
 /// Verifies `make_backup` is a no-op (and returns `None`) when the file
 /// does not exist, mirroring upstream `backup.c:make_backup()` which
 /// short-circuits when `stat(fname, &st) != 0`.

--- a/crates/transfer/src/receiver/directory/backup.rs
+++ b/crates/transfer/src/receiver/directory/backup.rs
@@ -40,6 +40,16 @@ enum BackupPlacement {
     Hardlinked,
     /// Renamed (upstream "RENAME" fallback). The original path is now free.
     Renamed,
+    /// Recreated as a symlink on a different filesystem after both the
+    /// hard-link and the rename failed cross-device (upstream copy tier
+    /// "SYMLINK" branch, `backup.c:296-300`). The original was already
+    /// unlinked while recreating, so the path is free.
+    CopiedSymlink,
+    /// Recreated as a FIFO, socket, or device node on a different filesystem
+    /// after both the hard-link and the rename failed cross-device (upstream
+    /// copy tier "DEVICE" branch, `backup.c:288-291`). The original was
+    /// already unlinked while recreating, so the path is free.
+    CopiedNode,
 }
 
 /// Places `existing` into `backup_path`, mirroring upstream `link_or_rename`
@@ -63,19 +73,69 @@ fn place_existing_backup(existing: &Path, backup_path: &Path) -> io::Result<Back
             let _ = fs::remove_file(backup_path);
             match fast_io::hard_link(existing, backup_path) {
                 Ok(()) => Ok(BackupPlacement::Hardlinked),
-                Err(_) => {
-                    fs::rename(existing, backup_path)?;
-                    Ok(BackupPlacement::Renamed)
-                }
+                Err(_) => rename_or_copy_existing(existing, backup_path),
             }
         }
         // upstream: backup.c:210 - rename fallback when the item cannot be
         // hard-linked (cross-device, or a type/fs without CAN_HARDLINK_*).
-        Err(_) => {
-            fs::rename(existing, backup_path)?;
-            Ok(BackupPlacement::Renamed)
-        }
+        Err(_) => rename_or_copy_existing(existing, backup_path),
     }
+}
+
+/// Renames `existing` to `backup_path`, falling back to recreating the node on
+/// a different filesystem when the rename fails cross-device (`EXDEV`).
+///
+/// upstream: `backup.c:226` `make_backup()` - once `link_or_rename()` cannot
+/// move the item across the mount (a `--backup-dir` on another filesystem),
+/// rsync makes a copy: `copy_file()` for regular files, or recreates the node
+/// via `do_symlink_at`/`do_mknod_at` for symlinks and specials
+/// (`backup.c:288-300`), then `keep_backup` unlinks the source.
+#[cfg(any(unix, windows))]
+fn rename_or_copy_existing(existing: &Path, backup_path: &Path) -> io::Result<BackupPlacement> {
+    match fs::rename(existing, backup_path) {
+        Ok(()) => Ok(BackupPlacement::Renamed),
+        #[cfg(unix)]
+        Err(e) if e.raw_os_error() == Some(libc::EXDEV) => {
+            copy_existing_cross_device(existing, backup_path)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Cross-device copy tier for a non-regular entry: recreates the symlink,
+/// FIFO, socket, or device node at `backup_path`, then unlinks the original.
+///
+/// upstream: `backup.c:288-300` `make_backup()` copy tier - `do_mknod_at` for
+/// devices/specials (SYMLINK/DEVICE traces) and `do_symlink_at` for symlinks,
+/// used when neither hard-link nor rename can cross the filesystem boundary.
+#[cfg(unix)]
+fn copy_existing_cross_device(existing: &Path, backup_path: &Path) -> io::Result<BackupPlacement> {
+    use std::os::unix::fs::FileTypeExt;
+
+    let meta = fs::symlink_metadata(existing)?;
+    let file_type = meta.file_type();
+    let placement = if file_type.is_symlink() {
+        // upstream: backup.c:296-300 - do_symlink_at recreates the link target.
+        let target = fs::read_link(existing)?;
+        std::os::unix::fs::symlink(&target, backup_path)?;
+        BackupPlacement::CopiedSymlink
+    } else if file_type.is_fifo() || file_type.is_socket() {
+        // upstream: backup.c:288-291 - IS_SPECIAL -> do_mknod_at.
+        metadata::create_fifo(backup_path, &meta).map_err(io::Error::other)?;
+        BackupPlacement::CopiedNode
+    } else if file_type.is_block_device() || file_type.is_char_device() {
+        // upstream: backup.c:288-291 - IS_DEVICE -> do_mknod_at (needs root).
+        metadata::create_device_node(backup_path, &meta).map_err(io::Error::other)?;
+        BackupPlacement::CopiedNode
+    } else {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "cannot back up unsupported non-regular file across filesystems",
+        ));
+    };
+    // upstream: keep_backup unlinks the source once the copy tier recreates it.
+    fs::remove_file(existing)?;
+    Ok(placement)
 }
 
 /// Emits the `--debug=BACKUP` mechanism trace and the `--info=BACKUP` notice
@@ -94,6 +154,10 @@ fn report_backup(
         BackupPlacement::Hardlinked => engine::trace_make_backup_hlink(&existing_display),
         // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1) RENAME success.
         BackupPlacement::Renamed => engine::trace_make_backup_rename(&existing_display),
+        // upstream: backup.c:299-300 - DEBUG_GTE(BACKUP, 1) SYMLINK success.
+        BackupPlacement::CopiedSymlink => engine::trace_make_backup_symlink(&existing_display),
+        // upstream: backup.c:290-291 - DEBUG_GTE(BACKUP, 1) DEVICE success.
+        BackupPlacement::CopiedNode => engine::trace_make_backup_device(&existing_display),
     }
     // upstream: backup.c:352-353 - INFO_GTE(BACKUP, 1) "backed up %s to %s".
     let file_rel = existing.strip_prefix(dest_dir).unwrap_or(existing);
@@ -210,7 +274,9 @@ mod tests {
     //! emitted (HLINK where hard-linking the type is supported) and suppressed
     //! below level 1.
 
-    use super::{BackupPlacement, place_existing_backup, report_backup};
+    use super::{
+        BackupPlacement, copy_existing_cross_device, place_existing_backup, report_backup,
+    };
     use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
     use std::fs;
     use std::os::unix::fs::FileTypeExt;
@@ -278,6 +344,12 @@ mod tests {
             BackupPlacement::Renamed => {
                 format!("make_backup: RENAME {} successful.", link.display())
             }
+            BackupPlacement::CopiedSymlink => {
+                format!("make_backup: SYMLINK {} successful.", link.display())
+            }
+            BackupPlacement::CopiedNode => {
+                format!("make_backup: DEVICE {} successful.", link.display())
+            }
         };
         assert!(
             backup_debug_messages().contains(&expected),
@@ -299,6 +371,58 @@ mod tests {
         assert!(
             fs::symlink_metadata(&backup).unwrap().file_type().is_fifo(),
             "backup of a FIFO must itself be a FIFO"
+        );
+    }
+
+    /// A cross-device backup of an existing symlink must succeed via the copy
+    /// tier: the link is recreated at the backup path with its target intact
+    /// and the original is unlinked, mirroring upstream's `do_symlink_at`
+    /// fallback when neither hard-link nor rename can cross the filesystem.
+    ///
+    /// upstream: backup.c:296-300 make_backup() SYMLINK copy tier.
+    #[test]
+    fn cross_device_symlink_recreated_at_backup() {
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("link");
+        let backup = dir.path().join("link~");
+        std::os::unix::fs::symlink("original/target", &link).unwrap();
+
+        let placement = copy_existing_cross_device(&link, &backup).unwrap();
+        assert!(matches!(placement, BackupPlacement::CopiedSymlink));
+
+        assert_eq!(
+            fs::read_link(&backup).unwrap(),
+            std::path::Path::new("original/target"),
+            "recreated backup must preserve the symlink target"
+        );
+        assert!(
+            fs::symlink_metadata(&link).is_err(),
+            "original symlink must be unlinked after the copy tier"
+        );
+    }
+
+    /// A cross-device backup of an existing FIFO must succeed via the copy
+    /// tier: the node is recreated at the backup path as a FIFO and the
+    /// original is unlinked (upstream `do_mknod_at` IS_SPECIAL branch).
+    ///
+    /// upstream: backup.c:288-291 make_backup() DEVICE copy tier.
+    #[test]
+    fn cross_device_fifo_recreated_at_backup() {
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("pipe");
+        let backup = dir.path().join("pipe~");
+        metadata::create_fifo_node_from_parts(&fifo, 0o644, false, false).unwrap();
+
+        let placement = copy_existing_cross_device(&fifo, &backup).unwrap();
+        assert!(matches!(placement, BackupPlacement::CopiedNode));
+
+        assert!(
+            fs::symlink_metadata(&backup).unwrap().file_type().is_fifo(),
+            "recreated backup of a FIFO must itself be a FIFO"
+        );
+        assert!(
+            fs::symlink_metadata(&fifo).is_err(),
+            "original FIFO must be unlinked after the copy tier"
         );
     }
 

--- a/crates/transfer/src/receiver/directory/backup.rs
+++ b/crates/transfer/src/receiver/directory/backup.rs
@@ -44,11 +44,16 @@ enum BackupPlacement {
     /// hard-link and the rename failed cross-device (upstream copy tier
     /// "SYMLINK" branch, `backup.c:296-300`). The original was already
     /// unlinked while recreating, so the path is free.
+    // Only the `#[cfg(unix)]` cross-device copy tier constructs this; the
+    // variant stays visible so `report_backup`/placement matches compile on
+    // every platform.
+    #[cfg_attr(not(unix), allow(dead_code))]
     CopiedSymlink,
     /// Recreated as a FIFO, socket, or device node on a different filesystem
     /// after both the hard-link and the rename failed cross-device (upstream
     /// copy tier "DEVICE" branch, `backup.c:288-291`). The original was
     /// already unlinked while recreating, so the path is free.
+    #[cfg_attr(not(unix), allow(dead_code))]
     CopiedNode,
 }
 


### PR DESCRIPTION
## Problem

A `--backup-dir` (or a `--backup` suffix path) that lands on a **different filesystem** than the destination made every backed-up file's commit fail with a cross-device (`EXDEV`) I/O error, so the whole transfer aborted.

- The regular-file backup path (`disk_commit/process/commit.rs::backup_rename_sandboxed`) did a bare `rename(2)` with no cross-device fallback - its own comment even noted "no EXDEV path is introduced on the backup rename", unlike the tmp->dest commit which already had one.
- The non-regular path (`receiver/directory/backup.rs::place_existing_backup`, for symlinks / FIFOs / sockets / devices) tried hard-link then rename, but also had no cross-device tier.

## Upstream reference

`backup.c:226 make_backup()` moves a file to its backup via `link_or_rename()` (hard-link, then rename) and, when neither can cross the mount, falls back to a **copy**:

- `copy_file()` + unlink for regular files (`backup.c:270-284`),
- `do_symlink_at` / `do_mknod_at` node recreation for symlinks and specials (`backup.c:288-300`).

## Fix

- **Regular files** (`commit.rs`): the non-anchored backup rename now renames and, on `EXDEV`, copies the pre-image and unlinks the original - reusing the same `fs::copy` + `fs::remove_file` mechanism the tmp->dest commit uses (`rename_with_io_uring_fallback`, `util1.c:robust_rename()`). `fs::copy` carries the mode bits exactly as upstream's `copy_file(..., file->mode)`. Emits the upstream `make_backup: COPY` trace on the copy tier instead of `RENAME`.
- **Non-regular files** (`backup.rs`): on `EXDEV` the entry is recreated at the backup path by type (symlink target via `symlink(2)`, FIFO/socket/device via the `metadata` mknod helpers) and the original unlinked, emitting the upstream `SYMLINK` / `DEVICE` traces.

## Sandbox anchoring (#6823) preserved

The `renameat`/`RESOLVE_BENEATH` destination-sandbox anchoring from #6823 is untouched: the anchored branch is taken only when both endpoints live directly under the destination root, where they share the destination filesystem and `EXDEV` cannot arise (the anchored call returns `Ok(false)`). Only the path-based fallback - the case that actually reaches a different mount - gained the copy tier.

## Tests

- `make_backup_cross_device_uses_copy_fallback` injects `EXDEV` at the rename boundary (deterministic on a single-filesystem runner) and asserts the backup exists with the original bytes and the source is gone. It fails before the fix (rename error propagates: "Cross-device link") and passes after.
- `cross_device_symlink_recreated_at_backup` / `cross_device_fifo_recreated_at_backup` exercise the non-regular copy tier.

## Verification

- `cargo build --workspace`
- `cargo nextest run -p transfer --all-features -E 'test(backup) or test(exdev) or test(cross_device) or test(rename) or test(commit)'` - 153 passed
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
