### PR TITLE
test(daemon): close client before joining daemon in negotiation tests

### DIFF
--- a/crates/daemon/src/tests/chunks/daemon_negotiation_version.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_version.rs
@@ -88,8 +88,12 @@ fn daemon_negotiation_version_greeting_format() {
         "Minor version should be numeric"
     );
 
+    // `reader` wraps a clone; the original `stream` handle is still open, so shut
+    // it down to give the daemon's untimed greeting read an EOF before joining.
+    // Otherwise the worker thread blocks and the join wedges (a Windows hang).
     drop(reader);
-    let _ = handle.join();
+    let _ = stream.shutdown(std::net::Shutdown::Both);
+    let _ = finish_daemon(handle);
 }
 
 #[test]

--- a/crates/daemon/src/tests/chunks/run_daemon_handles_binary_negotiation.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_handles_binary_negotiation.rs
@@ -46,8 +46,20 @@ fn run_daemon_handles_binary_negotiation() {
     );
 
     // Daemon will fail after receiving invalid input (binary instead of @RSYNCD response)
-    // but that's expected behavior - the test verifies that daemon sends @RSYNCD first
-    let _result = handle.join().expect("daemon thread");
+    // but that's expected behavior - the test verifies that daemon sends @RSYNCD first.
+    //
+    // The daemon reads the client's greeting line with an unbounded, timeout-free
+    // read (io_timeout=0, upstream-faithful), so its worker thread only returns on a
+    // newline or EOF. The client sent 4 bytes with no newline, so the thread exits
+    // only once every client handle is closed. `reader` still borrows `stream`, so
+    // drop it and shut the socket down before joining, otherwise the daemon blocks
+    // forever waiting for input the client never sends (a hang seen on Windows, where
+    // a lingering handle keeps the connection from reaching EOF).
+    drop(reader);
+    let _ = stream.shutdown(std::net::Shutdown::Both);
+    // Bounded join (join-then-detach) like the sibling negotiation tests, so a
+    // wedged daemon thread can never turn into a job-level 360s hang.
+    let _ = finish_daemon(handle);
     // Don't assert on result - daemon rightfully fails when client sends invalid data
 }
 


### PR DESCRIPTION
## Summary

Two daemon negotiation tests hung for >360s on `windows-latest` (nextest terminates them at the slow-test timeout), turning the feature-flag-combination jobs red across every PR. This is a real client-side deadlock, not a flake.

`run_daemon_handles_binary_negotiation` and `daemon_negotiation_version_greeting_format` keep a live client socket handle open across `handle.join()`:
- the first reads the greeting through `BufReader::new(&mut stream)`, whose borrow is still alive at `join()`;
- the second reads through `stream.try_clone()` and `drop`s only the clone, leaving the original `stream` open.

The daemon reads the client's greeting line with an intentionally untimed read (`io_timeout=0`, upstream-faithful — `sections/greeting.rs`, `session_runtime.rs`), so its `--once` worker thread returns only on a newline or EOF. With the client never closed and no newline sent, the thread blocks forever and the drain-join wedges. Linux/macOS passed only by OS close-timing luck; the deadlock is real on all platforms.

## Fix (test-only)

Close the client stream before finishing, and use the existing bounded `finish_daemon` helper (`join-then-detach`, 20s) that the sibling negotiation tests already use for exactly this Windows hang class:

- `shutdown(Shutdown::Both)` the client so the daemon's greeting read reaches EOF deterministically;
- replace raw `handle.join()` with `finish_daemon(handle)` so a wedged thread can never become a 360s job hang.

No daemon-side change — the untimed handshake read stays upstream-faithful (`io_timeout=0`, matching `clientserver.c`). The many `daemon_handle.join()` calls in the push/pull transfer tests are unaffected: those complete a full exchange, the client disconnects, and the daemon EOFs cleanly.
