### PR TITLE
fix(transfer): never truncate the target under --write-devices

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -133,7 +133,11 @@ pub(super) fn commit_file(
         let result = rename_config_sandboxed(config, cleanup_guard.path(), &begin.file_path)?;
         CleanupManager::global().unregister_temp_file(cleanup_guard.path());
         result
-    } else if begin.is_inplace {
+    } else if begin.is_inplace && !begin.is_device_target {
+        // upstream: receiver.c:496 gates the in-place ftruncate on
+        // `!IS_DEVICE(file->mode)`, so `--write-devices` never truncates the
+        // target device - its data lands via the in-place writes and a
+        // block/char device has no length to set (ftruncate would fail EINVAL).
         if let Some(ref sparse) = sparse_final {
             // upstream: fileio.c:47-52 sparse_end() - punch stale basis blocks
             // then ftruncate to the logical length for the in-place update.

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -138,6 +138,57 @@ fn write_file_with_io_uring_auto_policy() {
 }
 
 #[test]
+fn device_target_inplace_commit_does_not_truncate() {
+    // upstream: receiver.c:496 gates the in-place ftruncate on !IS_DEVICE, so
+    // --write-devices writes into the device without ever truncating it (a
+    // block/char device has no settable length; ftruncate would fail EINVAL).
+    // A pre-populated regular file stands in for the device open path: with
+    // is_device_target set, the committer must leave its length untouched and
+    // only overwrite the leading bytes it received in place.
+    let _registry_lock = test_support::cleanup_registry_test_guard();
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("device_target.dat");
+    fs::write(&file_path, vec![b'x'; 100]).unwrap();
+
+    let h = spawn_disk_thread(DiskCommitConfig::default()).unwrap();
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 5,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: true,
+            is_inplace: true,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Chunk(b"AAAAA".to_vec()))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Commit {
+            expected_checksum: Default::default(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert_eq!(result.bytes_written, 5);
+
+    let contents = fs::read(&file_path).unwrap();
+    assert_eq!(
+        contents.len(),
+        100,
+        "device target must not be truncated to target_size"
+    );
+    assert_eq!(&contents[..5], b"AAAAA", "leading bytes written in place");
+    assert_eq!(&contents[5..], &[b'x'; 95], "trailing bytes left intact");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+#[test]
 fn channel_capacity_default_passthrough() {
     let config = DiskCommitConfig::default();
     assert_eq!(config.effective_channel_capacity(), 128);


### PR DESCRIPTION
## Summary

`--write-devices` writes file data into an existing block/char device instead of recreating it. It forces `--inplace` and opens the device `O_WRONLY` to stream bytes in place.

But the in-place commit branch ran `set_len()` (or `finalize_sparse()`, which also truncates) **unconditionally**. `ftruncate` on a device fails with `EINVAL`, so committing a `--write-devices` transfer to a real device errored out at the very end.

Upstream gates the in-place truncate on `!IS_DEVICE(file->mode)` (`receiver.c:496`): a device is never truncated — its data lands via the in-place writes and a device has no settable length. This change adds the same guard (`begin.is_inplace && !begin.is_device_target`).

## Verified against upstream

`receiver.c:496`:
```c
if ((inplace_sizing || preallocated_len > offset) && fd != -1 && !IS_DEVICE(file->mode)) {
    if (do_ftruncate(fd, offset) < 0) ...
```
oc's live path sets `is_device_target = write.write_devices && file_entry.is_device()` (`receiver/transfer/pipeline.rs:387`) and forces inplace, so a device target reaches commit with both flags set — exactly the case upstream skips.

## Test

`device_target_inplace_commit_does_not_truncate` drives a full Begin→Chunk→Commit with `is_device_target: true, is_inplace: true` against a pre-populated 100-byte file and a `target_size` of 5, asserting the file is **not** truncated (length stays 100, leading 5 bytes overwritten in place, trailing bytes intact). This exercises the device-commit path without requiring a real device node / root.
