### PR TITLE
docs: correct stale module descriptions to match code

### DIFF
--- a/crates/checksums/src/strong/mod.rs
+++ b/crates/checksums/src/strong/mod.rs
@@ -2,8 +2,9 @@
 //!
 //! Upstream rsync negotiates the strong checksum algorithm based on the protocol
 //! version and compile-time feature set. This module exposes streaming wrappers
-//! for MD4, MD5, XXH64, XXH3/64, and XXH3/128 so higher layers can compose the
-//! desired strategy without reimplementing the hashing primitives.
+//! for MD4, MD5, SHA-1, SHA-256, SHA-512, XXH64, XXH3/64, and XXH3/128 so higher
+//! layers can compose the desired strategy without reimplementing the hashing
+//! primitives.
 //!
 //! # Upstream Reference
 //!

--- a/crates/flist/src/lib.rs
+++ b/crates/flist/src/lib.rs
@@ -3,13 +3,18 @@
 
 //! # Overview
 //!
-//! `flist` provides file list generation and traversal for the Rust rsync
-//! implementation, mirroring upstream's `flist.c`. The walker enumerates
-//! regular files, directories, and symbolic links while enforcing relative-path
-//! constraints so callers cannot accidentally escape the configured root. The
-//! implementation keeps ordering stable across platforms by sorting directory
-//! entries lexicographically before yielding them, mirroring upstream rsync's
-//! behaviour when building transfer lists.
+//! `flist` is a standalone filesystem-traversal implementation loosely modelled
+//! on upstream's `flist.c`. The walker enumerates regular files, directories,
+//! and symbolic links while enforcing relative-path constraints so callers
+//! cannot accidentally escape the configured root. It keeps ordering stable
+//! across platforms by sorting directory entries lexicographically before
+//! yielding them.
+//!
+//! This crate is not wired into the active transfer path. The live file-list
+//! machinery used by transfers lives in `protocol::flist`; nothing in the
+//! transfer pipeline consumes [`FileListWalker`] or [`FileListBuilder`]. The
+//! crate is re-exported by `core` but is otherwise a self-contained, legacy
+//! traversal utility retained for its standalone walker API.
 //!
 //! # Design
 //!
@@ -78,10 +83,10 @@
 //!
 //! # See also
 //!
-//! - [`engine`](https://docs.rs/engine/latest/engine/) for the
-//!   transfer planning facilities that will eventually consume the walker.
+//! - `protocol::flist` for the file-list implementation actually used by the
+//!   transfer pipeline (wire encoding, incremental recursion, sorting).
 //! - [`core`](https://docs.rs/core/latest/core/) for the
-//!   central orchestration facade.
+//!   central orchestration facade, which re-exports this crate.
 
 mod builder;
 mod entry;

--- a/crates/matching/src/optimized_search.rs
+++ b/crates/matching/src/optimized_search.rs
@@ -2,8 +2,9 @@
 //!
 //! Each lookup first rejects via the tag table (low 16 bits of the rolling
 //! checksum), then probes the hash table keyed by full rolling checksum, then
-//! verifies with the strong checksum. The sorted constructor enables a
-//! sequential-scan optimization for large block sets.
+//! verifies with the strong checksum. Lookups always resolve through the hash
+//! table; the sorted constructor records that blocks were pre-sorted by
+//! checksum but does not add a distinct sequential-scan lookup path.
 
 use rustc_hash::FxHashMap;
 
@@ -61,7 +62,7 @@ pub struct BlockHashTable {
     blocks: Vec<BlockEntry>,
     /// Tag table for quick rejection.
     tag_table: TagTable,
-    /// Whether blocks are sorted by checksum (enables sequential optimization).
+    /// Whether blocks were pre-sorted by checksum in the constructor.
     sorted: bool,
 }
 
@@ -86,8 +87,10 @@ impl BlockHashTable {
         }
     }
 
-    /// Builds a hash table with pre-sorted blocks, enabling the sequential-scan
-    /// optimization for large block sets.
+    /// Builds a hash table from blocks pre-sorted by checksum.
+    ///
+    /// Sorting is recorded via [`Self::is_sorted`]; lookups still resolve
+    /// through the hash table exactly as [`Self::new`] does.
     pub fn new_sorted(mut blocks: Vec<BlockEntry>) -> Self {
         blocks.sort_by_key(|b| b.checksum);
 
@@ -157,8 +160,7 @@ impl BlockHashTable {
         self.blocks.is_empty()
     }
 
-    /// Returns `true` if blocks are sorted by checksum (sequential-scan
-    /// optimization enabled).
+    /// Returns `true` if blocks were pre-sorted by checksum in the constructor.
     pub fn is_sorted(&self) -> bool {
         self.sorted
     }


### PR DESCRIPTION
Doc-only fixes so three module descriptions match the code.

- `crates/flist/src/lib.rs`: the crate no longer claims to be the active file-list path or that engine/core "will eventually consume the walker". It is a standalone/legacy traversal utility (re-exported by `core`) that is not wired into the transfer pipeline; the live path is `protocol::flist`.
- `crates/checksums/src/strong/mod.rs`: the intro now lists all exported strong-checksum algorithms, adding the SHA family (SHA-1, SHA-256, SHA-512) alongside MD4/MD5/XXH.
- `crates/matching/src/optimized_search.rs`: the module and `sorted`/`is_sorted`/`new_sorted` docs no longer claim a non-existent "sequential-scan optimization". Lookups always resolve through the hash table; the sorted flag only records that blocks were pre-sorted.

No code changes - comment/doc lines only.
