### PR TITLE
docs: normalize stale upstream version labels to 3.4.4

### DIFF
--- a/crates/daemon/src/auth.rs
+++ b/crates/daemon/src/auth.rs
@@ -1,4 +1,4 @@
-//! Daemon mode authentication matching upstream rsync 3.4.1.
+//! Daemon mode authentication matching upstream rsync 3.4.4.
 //!
 //! This module implements the rsync daemon challenge-response authentication protocol
 //! that protects modules configured with `auth users`. The implementation mirrors

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -174,7 +174,7 @@
 #[cfg(feature = "async-daemon")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-daemon")))]
 pub mod async_listener;
-/// Daemon mode challenge-response authentication matching upstream rsync 3.4.1.
+/// Daemon mode challenge-response authentication matching upstream rsync 3.4.4.
 pub mod auth;
 mod cli;
 mod config;

--- a/crates/protocol/src/error.rs
+++ b/crates/protocol/src/error.rs
@@ -34,7 +34,7 @@ pub enum NegotiationError {
     },
     /// The peer advertised a protocol version outside the upstream supported range.
     ///
-    /// The Display rendering is byte-identical to upstream rsync 3.4.1's two
+    /// The Display rendering is byte-identical to upstream rsync 3.4.4's two
     /// `FERROR` lines emitted from `compat.c:620-621` when `remote_protocol`
     /// falls outside `[MIN_PROTOCOL_VERSION, MAX_PROTOCOL_VERSION]`. Backup
     /// monitoring tools grep for this exact wording, so changing it would

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -1,7 +1,7 @@
 //! Wire protocol implementation for rsync protocol versions 28-32.
 //!
 //! This crate implements the negotiation and multiplexing primitives for the
-//! rsync wire protocol. It mirrors upstream rsync 3.4.1 behaviour so that
+//! rsync wire protocol. It mirrors upstream rsync 3.4.4 behaviour so that
 //! higher layers can negotiate protocol versions, interpret legacy daemon
 //! banners, exchange multiplexed `MSG_*` frames, encode file lists, and
 //! perform delta transfers without depending on the original C sources.
@@ -86,20 +86,20 @@
 pub mod acl;
 /// `--debug=BIND` producer emissions for daemon listener setup.
 ///
-/// Hosts the trace helpers that mirror upstream rsync 3.4.1's
+/// Hosts the trace helpers that mirror upstream rsync 3.4.4's
 /// `DEBUG_GTE(BIND, 1)` diagnostics emitted from `socket.c::open_socket_in`
 /// while iterating per-address-family during daemon listener setup.
 pub mod bind;
 /// `--debug=CHDIR` producer emissions for current-directory changes.
 ///
-/// Hosts the trace helper that mirrors upstream rsync 3.4.1's single
+/// Hosts the trace helper that mirrors upstream rsync 3.4.4's single
 /// `DEBUG_GTE(CHDIR, 1)` emission from `util1.c::change_dir`. Wires from
 /// every successful `chdir()` syscall (notably the daemon chroot setup
 /// in `crates/daemon/src/daemon/sections/privilege.rs::apply_chroot`).
 pub mod chdir;
 /// `--debug=CMD` producer emissions for remote command construction.
 ///
-/// Hosts the trace helpers that mirror upstream rsync 3.4.1's
+/// Hosts the trace helpers that mirror upstream rsync 3.4.4's
 /// `DEBUG_GTE(CMD, N)` diagnostics emitted from `pipe.c`,
 /// `clientserver.c`, `rsync.c`, and `main.c` during remote command
 /// construction, secluded-args transmission, and daemon argument

--- a/crates/protocol/src/negotiation/capabilities/algorithms.rs
+++ b/crates/protocol/src/negotiation/capabilities/algorithms.rs
@@ -2,7 +2,7 @@ use std::io;
 
 /// Supported checksum algorithms in preference order.
 ///
-/// This list matches upstream rsync 3.4.1's default order.
+/// This list matches upstream rsync 3.4.4's default order.
 /// The client will select the first algorithm in this list that it also supports.
 /// Upstream order: xxh128 xxh3 xxh64 md5 md4 sha1 none
 pub(super) const SUPPORTED_CHECKSUMS: &[&str] =
@@ -52,7 +52,7 @@ pub(super) fn supported_compressions() -> Vec<&'static str> {
 /// and each side selects the first mutually supported entry. For protocol
 /// versions below 30, [`MD4`](Self::MD4) is always used. The variants are
 /// ordered from strongest/newest to weakest/oldest, matching upstream rsync
-/// 3.4.1's preference order.
+/// 3.4.4's preference order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ChecksumAlgorithm {

--- a/crates/protocol/src/varint/mod.rs
+++ b/crates/protocol/src/varint/mod.rs
@@ -11,7 +11,7 @@
 //! The codec exposes a streaming API via [`read_varint`] and [`write_varint`],
 //! plus helpers for working with in-memory buffers. The lookup table that maps
 //! tag prefixes to the number of continuation bytes is copied directly from
-//! upstream, ensuring byte-for-byte equivalence with rsync 3.4.1.
+//! upstream, ensuring byte-for-byte equivalence with rsync 3.4.4.
 //!
 //! # Examples
 //!

--- a/crates/protocol/src/wire/mod.rs
+++ b/crates/protocol/src/wire/mod.rs
@@ -2,7 +2,7 @@
 //! Wire protocol serialization for signatures, deltas, and file entries.
 //!
 //! This module provides the serialization and deserialization logic for the
-//! rsync protocol's data structures. The formats mirror upstream rsync 3.4.1
+//! rsync protocol's data structures. The formats mirror upstream rsync 3.4.4
 //! to ensure interoperability.
 //!
 //! # Submodules

--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -29,7 +29,7 @@
 //!
 //! # Reference
 //!
-//! - Upstream rsync 3.4.1 `xattrs.c`
+//! - Upstream rsync 3.4.4 `xattrs.c`
 
 mod cache;
 mod entry;


### PR DESCRIPTION
## Summary

A partial update left stale generic "upstream rsync 3.4.1" mirror-claims in some `protocol` and `daemon` module docs while the canonical target (`Cargo.toml` `upstream_version = "3.4.4"`) and sibling docs (e.g. `protocol/src/cmd/mod.rs`) already say 3.4.4. This normalizes those generic descriptive labels to 3.4.4.

## What changed

Generic "mirrors / matches / byte-for-byte equivalent to upstream rsync 3.4.1" labels updated to 3.4.4 in:

- `crates/protocol/src/lib.rs` (crate summary + `bind`/`chdir`/`cmd` module docs)
- `crates/protocol/src/wire/mod.rs`
- `crates/protocol/src/varint/mod.rs`
- `crates/protocol/src/error.rs`
- `crates/protocol/src/negotiation/capabilities/algorithms.rs`
- `crates/protocol/src/xattr/mod.rs`
- `crates/daemon/src/auth.rs`
- `crates/daemon/src/lib.rs`

## Deliberately preserved

- Exact source-line and function citations (e.g. `upstream: clientserver.c:read_line / start_inband_exchange (rsync 3.4.1)`, `socket.c ... rsync-3.4.1, lines 428-498`).
- Version-compatibility boundary statements (codes "understood by" / "not known to" rsync 3.4.1) - 3.4.1 remains a real supported interop target.
- Interop version lists (3.0.9 / 3.1.3 / 3.4.1 / 3.4.4).

Doc-only change; no code modified.
