### PR TITLE
docs: fix broken and private intra-doc links for the rustdoc build

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls/metadata_ops.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/metadata_ops.rs
@@ -318,7 +318,8 @@ fn chown_path_libc(link_path: &Path, uid: u32, gid: u32, follow_symlinks: bool) 
     }
 }
 
-/// Chown `path` after walking its parent through [`secure_open_dir`].
+/// Chown `path` after walking its parent through
+/// [`secure_open_dir`](crate::secure_open_dir).
 ///
 /// Symlink-race-safe counterpart to a path-based `fchownat(AT_FDCWD,
 /// path, ..., AT_SYMLINK_NOFOLLOW)`. `AT_SYMLINK_NOFOLLOW` only guards the
@@ -413,7 +414,8 @@ fn utimensat_omit_raw(
 }
 
 /// Set atime/mtime on `path` after walking its parent through
-/// [`secure_open_dir`], with `None` slots left unchanged (`UTIME_OMIT`).
+/// [`secure_open_dir`](crate::secure_open_dir), with `None` slots left
+/// unchanged (`UTIME_OMIT`).
 ///
 /// Symlink-race-safe counterpart to a path-based `utimensat(AT_FDCWD,
 /// path, ...)`. Like [`secure_chown_at`] and [`secure_chmod_at`] the

--- a/crates/fast_io/src/dontcache_writer.rs
+++ b/crates/fast_io/src/dontcache_writer.rs
@@ -178,7 +178,7 @@ fn dontcache_write(fd: RawFd, chunk: &[u8]) -> io::Result<usize> {
 /// for a genuine I/O error or an unexpected short read after some bytes landed.
 /// Uses positioned reads, so the file's seek offset is left untouched.
 ///
-/// Mirrors [`dontcache_write`] on the read side.
+/// Mirrors `dontcache_write` on the read side.
 #[cfg(all(target_os = "linux", feature = "dontcache"))]
 #[allow(unsafe_code)]
 pub fn dontcache_read_exact(file: &File, offset: u64, dst: &mut [u8]) -> io::Result<bool> {

--- a/crates/metadata/src/mapping/user_group.rs
+++ b/crates/metadata/src/mapping/user_group.rs
@@ -31,7 +31,7 @@ impl UserMapping {
 
     /// Applies the mapping to `uid` keyed on the sender-transmitted `name`.
     ///
-    /// See [`NameMapping::map_uid_named`]: name/wildcard rules match against the
+    /// See `NameMapping::map_uid_named`: name/wildcard rules match against the
     /// wire name rather than a receiver-local reverse lookup of the raw id,
     /// mirroring upstream `recv_add_id` (uidlist.c:255-268).
     pub fn map_uid_named(
@@ -78,7 +78,7 @@ impl GroupMapping {
 
     /// Applies the mapping to `gid` keyed on the sender-transmitted `name`.
     ///
-    /// See [`NameMapping::map_gid_named`]: name/wildcard rules match against the
+    /// See `NameMapping::map_gid_named`: name/wildcard rules match against the
     /// wire name rather than a receiver-local reverse lookup of the raw id,
     /// mirroring upstream `recv_add_id` (uidlist.c:255-268).
     pub fn map_gid_named(

--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -167,7 +167,7 @@ impl DualFileList {
     /// Under INC_RECURSE the pass still runs (upstream's `!am_sender ||
     /// inc_recurse` branch): each sub-list is cleaned so its numbering matches
     /// the receiver's identical pass. It reuses
-    /// [`resolve_duplicate`](super::sort::resolve_duplicate) for an identical
+    /// `resolve_duplicate` for an identical
     /// keep/drop tie-break.
     ///
     /// # Panics

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -149,7 +149,7 @@ impl SshCommand {
     /// Forces the address family the spawned `ssh` client uses, mirroring
     /// rsync's `--ipv4`/`--ipv6`. When `Some`, a `-4` or `-6` flag is appended
     /// to the argv, but only when the program basename is `ssh` (see
-    /// [`SshCommand::is_ssh_program`]); a user-supplied non-ssh `-e` wrapper is
+    /// `SshCommand::is_ssh_program`); a user-supplied non-ssh `-e` wrapper is
     /// left untouched.
     ///
     /// upstream: main.c:587-594 `do_cmd()` - `if (default_af_hint == AF_INET &&
@@ -163,7 +163,7 @@ impl SshCommand {
     /// Records rsync's tri-state `--blocking-io`/`--no-blocking-io` preference
     /// for the remote-shell child: `Some(true)` forces blocking I/O,
     /// `Some(false)` forces non-blocking, and `None` (the default) leaves it
-    /// unset so [`SshCommand::resolved_blocking_io`] can apply upstream's
+    /// unset so `SshCommand::resolved_blocking_io` can apply upstream's
     /// `rsh`/`remsh` auto-enable.
     ///
     /// upstream: options.c:144,842-843 - `blocking_io` defaults to `-1` (unset)


### PR DESCRIPTION
## Summary

The `Pages` workflow builds docs with `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links"` and had been failing on master (long-standing, pre-existing). Root cause: two doc comments in `fast_io` used the bare shorthand `[`secure_open_dir`]` without a reference definition in their doc block — unlike the sibling `secure_chmod_at`, which defines `[`secure_open_dir`]: crate::secure_open_dir` — so rustdoc could not resolve them and aborted with `could not document fast_io`.

## Fixes

- **Broken links (build-failing):** `crates/fast_io/.../metadata_ops.rs` — point the two bare `[`secure_open_dir`]` links (on `secure_chown_at` and `secure_utimes_at`) at `[`secure_open_dir`](crate::secure_open_dir)`, the same inline-path form already used and resolving in that module (lines 265/352/438).
- **Private-item links (warnings):** de-link six public-doc references to private items (rustdoc `private_intra_doc_links`) — a public item's docs cannot hyperlink a private one, so keep the code-font name without the link:
  - `rsync_io/src/ssh/builder.rs` — `SshCommand::is_ssh_program`, `SshCommand::resolved_blocking_io`
  - `metadata/src/mapping/user_group.rs` — `NameMapping::map_uid_named`, `NameMapping::map_gid_named`
  - `protocol/src/flist/dual.rs` — `resolve_duplicate`
  - `fast_io/src/dontcache_writer.rs` — `dontcache_write`

Doc-comment only — no code changed. The Pages/rustdoc build only runs on push to master, so it will verify on merge.
