### PR TITLE
test: re-stamp source atimes before each atimes validate pull

### DIFF
--- a/xtask/src/commands/validate/checks/atimes.rs
+++ b/xtask/src/commands/validate/checks/atimes.rs
@@ -31,6 +31,15 @@ const FLAGS: &[&str] = &["-rlptgoD", "--atimes", "--numeric-ids"];
 /// filesystem honors explicitly-set access times.
 const PROBE_ATIME: i64 = 1_600_000_000;
 
+/// Source fixture files: `(relative path, contents, distinct past atime epoch)`.
+/// Shared by `build_fixture` (initial write) and `stamp_source_atimes`
+/// (re-applied before every pull so each client reads the same known atimes).
+const FIXTURE: &[(&str, &[u8], i64)] = &[
+    ("alpha", b"alpha", 1_500_000_000),
+    ("bravo", b"bravo", 1_500_001_000),
+    ("sub/charlie", b"charlie", 1_500_002_000),
+];
+
 impl Check for Atimes {
     fn name(&self) -> &'static str {
         "atimes"
@@ -95,6 +104,17 @@ impl Atimes {
         let oc_dst = root.join(format!("oc-{label}"));
         let up_dst = root.join(format!("up-{label}"));
 
+        // A sender's content read bumps the source atime (neither upstream nor
+        // oc opens the source with O_NOATIME), so a client running second
+        // against a shared source would snapshot the "now" atime the first
+        // client's read left behind and appear to fail. Re-stamp the known
+        // source atimes before every pull so each client reads pristine values;
+        // the dest atime is the flist snapshot taken at transfer start
+        // (upstream: flist.c make_file F_ATIME), so just-in-time restamping
+        // suffices.
+        if let Err(e) = stamp_source_atimes(&src) {
+            return CheckOutcome::skip(self.name(), label, e);
+        }
         let up = match pull_into(
             transport.for_upstream(),
             ctx.upstream,
@@ -108,6 +128,9 @@ impl Atimes {
             other => return skip_or_fail(self.name(), label, "upstream", other),
         };
         let _ = up;
+        if let Err(e) = stamp_source_atimes(&src) {
+            return CheckOutcome::skip(self.name(), label, e);
+        }
         let oc = match pull_into(
             transport,
             ctx.oc,
@@ -306,23 +329,29 @@ fn build_fixture(src: &Path) -> Result<(), String> {
     if src.exists() {
         std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
     }
-    let sub = src.join("sub");
-    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(src.join("sub")).map_err(|e| e.to_string())?;
 
-    // (relative path contents, distinct atime epoch) for each source file.
-    let files: [(PathBuf, &[u8], i64); 3] = [
-        (PathBuf::from("alpha"), b"alpha", 1_500_000_000),
-        (PathBuf::from("bravo"), b"bravo", 1_500_001_000),
-        (PathBuf::from("sub/charlie"), b"charlie", 1_500_002_000),
-    ];
-    for (rel, body, atime) in files {
-        let path = src.join(&rel);
+    for &(rel, body, atime) in FIXTURE {
+        let path = src.join(rel);
         std::fs::write(&path, body).map_err(|e| e.to_string())?;
         let name = path.to_string_lossy().into_owned();
         // Backdate mtime first, then stamp the distinct atime; separate `touch`
         // calls so neither clobbers the other's target field.
         support::capture("touch", &["-m", "-d", "@1614830767", &name])
             .map_err(|e| e.to_string())?;
+        support::capture("touch", &["-a", "-d", &format!("@{atime}"), &name])
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Re-apply each fixture file's known access time to the source. A sender's
+/// content read bumps the source atime (neither upstream nor oc opens with
+/// `O_NOATIME`), so re-stamping before every pull guarantees each client reads
+/// the same pristine values rather than one another's post-read "now".
+fn stamp_source_atimes(src: &Path) -> Result<(), String> {
+    for &(rel, _body, atime) in FIXTURE {
+        let name = src.join(rel).to_string_lossy().into_owned();
         support::capture("touch", &["-a", "-d", &format!("@{atime}"), &name])
             .map_err(|e| e.to_string())?;
     }


### PR DESCRIPTION
## Problem

`cargo xtask validate` reported `--atimes` failures on all four transports
(local, ssh-subprocess, russh, daemon), e.g.:

```
[FAIL] local - atime differs at alpha: oc=<now> upstream=1500000000
[FAIL] daemon - atime not preserved at alpha: oc=<now> source=1500000000
```

## Root cause (host-verified against rsync 3.4.4 on Linux)

The `atimes` check pulls the **same** source tree with upstream first, then oc,
and compares oc's destination access times to a snapshot taken before any
transfer.

A sender's content read bumps the source file's atime - **neither upstream rsync
nor oc opens the source with `O_NOATIME`** - and the fixture's atime (2017)
predates its mtime (2021), so a `relatime`/`tmpfs` mount updates atime on the
first read. Instrumenting the shared source atime at each boundary:

```
0 snapshot src :  atime=1500000000
1 after UPSTREAM: src atime=NOW      up_dst=1500000000   <- upstream's read bumped the source
2 after OC      : src atime=NOW      oc_dst=NOW          <- oc snapshots the already-bumped source
```

Upstream's destination is correct only because it ran against a pristine source
and stamps the flist `F_ATIME` before reading content. Reversing the order makes
**upstream** the victim (`up_dst=NOW`, `oc_dst=1500000000`), proving the
divergence is the harness's shared mutable source, not either client.

## Fix

Re-stamp each fixture file's known atime immediately before every pull, so both
clients read the same pristine values. The destination atime is the flist value
snapshotted at transfer start, so just-in-time restamping is sufficient.

## Verification

On Linux (ext4 `relatime` and `tmpfs`), all four transports now pass:

```
atimes:
  [PASS] local
  [PASS] ssh-subprocess
  [PASS] russh
  [PASS] daemon
```

Test-harness change only; no production code touched.
