### PR TITLE
test: backdate fixture root so itemize plans are deterministic

### DIFF
--- a/xtask/src/commands/validate/checks/dry_run.rs
+++ b/xtask/src/commands/validate/checks/dry_run.rs
@@ -27,7 +27,7 @@ impl Check for DryRun {
     fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
         let root = ctx.work.join("dry-run");
         let src = root.join("src");
-        if let Err(e) = build_fixture(&src) {
+        if let Err(e) = support::build_backdated_tree(&src) {
             return vec![CheckOutcome::skip(self.name(), "fixture", e)];
         }
         let flags: Vec<String> = FLAGS.iter().map(|s| s.to_string()).collect();
@@ -185,30 +185,6 @@ fn skip_or_fail(
         }
         Err(e) => CheckOutcome::skip(check, label, format!("{who} could not run: {e}")),
     }
-}
-
-/// Build the dry-run fixture. Idempotent: removes any prior tree first.
-fn build_fixture(src: &Path) -> Result<(), String> {
-    if src.exists() {
-        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
-    }
-    let sub = src.join("sub");
-    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
-
-    std::fs::write(src.join("a.txt"), b"alpha").map_err(|e| e.to_string())?;
-    std::fs::write(src.join("b.txt"), b"bravo").map_err(|e| e.to_string())?;
-    std::fs::write(sub.join("c.txt"), b"charlie").map_err(|e| e.to_string())?;
-
-    // Backdate mtimes so the quick-check does not skip anything under test.
-    for entry in support::rel_entries(src) {
-        let path = src.join(&entry);
-        support::capture(
-            "touch",
-            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
-        )
-        .map_err(|e| e.to_string())?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/xtask/src/commands/validate/checks/itemize.rs
+++ b/xtask/src/commands/validate/checks/itemize.rs
@@ -28,7 +28,7 @@ impl Check for Itemize {
     fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
         let root = ctx.work.join("itemize");
         let src = root.join("src");
-        if let Err(e) = build_fixture(&src) {
+        if let Err(e) = support::build_backdated_tree(&src) {
             return vec![CheckOutcome::skip(self.name(), "fixture", e)];
         }
         let names = basenames(&src);
@@ -158,30 +158,6 @@ fn basenames(src: &Path) -> HashSet<String> {
         .iter()
         .filter_map(|rel| rel.file_name().map(|n| n.to_string_lossy().into_owned()))
         .collect()
-}
-
-/// Build the itemize fixture. Idempotent: removes any prior tree first.
-fn build_fixture(src: &Path) -> Result<(), String> {
-    if src.exists() {
-        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
-    }
-    let sub = src.join("sub");
-    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
-
-    std::fs::write(src.join("a.txt"), b"alpha").map_err(|e| e.to_string())?;
-    std::fs::write(src.join("b.txt"), b"bravo").map_err(|e| e.to_string())?;
-    std::fs::write(sub.join("c.txt"), b"charlie").map_err(|e| e.to_string())?;
-
-    // Backdate mtimes so the quick-check does not skip anything under test.
-    for entry in support::rel_entries(src) {
-        let path = src.join(&entry);
-        support::capture(
-            "touch",
-            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
-        )
-        .map_err(|e| e.to_string())?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/xtask/src/commands/validate/support.rs
+++ b/xtask/src/commands/validate/support.rs
@@ -79,11 +79,68 @@ fn collect(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
 /// many checks that reach for `support::content_diff` keep one import path.
 pub use super::comparison::content_diff;
 
+/// Fixed past mtime stamped on every fixture entry and the source root.
+const FIXTURE_MTIME: &str = "@1614830767";
+
+/// Build the shared itemize/dry-run fixture (`a.txt`, `b.txt`, `sub/c.txt`) with
+/// every entry *and the source root itself* backdated to a fixed past mtime.
+///
+/// Backdating the entries stops the quick-check from skipping a transfer.
+/// Backdating the root matters just as much: a freshly-created destination
+/// directory carries a "now" mtime, so a source root left at "now" makes the
+/// `.d..t...... ./` top-directory itemize row appear only when the two land in
+/// different clock seconds - a race that makes two sequentially-run clients'
+/// plans compare unequal. A fixed old root mtime makes that row deterministic
+/// (always present, identical) for every client.
+pub fn build_backdated_tree(src: &Path) -> Result<(), String> {
+    if src.exists() {
+        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
+    }
+    let sub = src.join("sub");
+    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
+    std::fs::write(src.join("a.txt"), b"alpha").map_err(|e| e.to_string())?;
+    std::fs::write(src.join("b.txt"), b"bravo").map_err(|e| e.to_string())?;
+    std::fs::write(sub.join("c.txt"), b"charlie").map_err(|e| e.to_string())?;
+
+    // Backdate the entries, then the root last: the writes above bumped the
+    // root's mtime to "now", so it must be stamped after them.
+    for entry in rel_entries(src) {
+        let path = src.join(&entry);
+        capture(
+            "touch",
+            &["-h", "-d", FIXTURE_MTIME, &path.to_string_lossy()],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    capture("touch", &["-d", FIXTURE_MTIME, &src.to_string_lossy()]).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{entry_count, rel_entries};
+    use super::{build_backdated_tree, entry_count, rel_entries};
     use std::fs;
     use std::os::unix::fs::symlink;
+    use std::time::UNIX_EPOCH;
+
+    #[test]
+    fn backdated_tree_populates_and_backdates_the_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        build_backdated_tree(&src).unwrap();
+        // a.txt + b.txt + sub + sub/c.txt = 4 entries.
+        assert_eq!(entry_count(&src), 4);
+        // The root mtime must be the fixed past value, not "now", so the
+        // top-directory itemize row is deterministic across sequential clients.
+        let secs = fs::metadata(&src)
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert_eq!(secs, 1_614_830_767);
+    }
 
     #[test]
     fn entry_count_recurses_but_does_not_follow_symlinks() {


### PR DESCRIPTION
## Problem

`cargo xtask validate` intermittently failed the `dry-run` and `itemize`
checks, on different transports run-to-run:

```
[FAIL] dry-run/ssh-subprocess - itemize row 0 differs: oc `.d..t...... ./` vs upstream `>f+++++++++ a.txt`
[FAIL] itemize/russh          - itemize row count differs (oc 5 vs upstream 4)
```

## Root cause (host-verified against rsync 3.4.4 on Linux)

rsync itemizes the transfer root as `.d..t...... ./` **only when the source
root's mtime differs from the destination root's**. The fixture backdated its
entries but left the source **root** at a "now" mtime, and the destination is
freshly created (mtime "now") right before each pull. Whether the `./` row
appeared therefore depended on whether the source build and each dest creation
landed in the same clock second.

Upstream and oc run sequentially (upstream first), each creating its own
destination a moment apart, so they could straddle a second boundary
differently and produce different plans. **oc is byte-for-byte faithful** - when
the root mtimes differ, both emit the `./` row; when they match, neither does:

```
# forced root-mtime difference
UPSTREAM: .d..t...... ./ / >f a.txt / >f b.txt / cd sub/ / >f sub/c.txt
OC:       .d..t...... ./ / >f a.txt / >f b.txt / cd sub/ / >f sub/c.txt   # identical
```

## Fix

Backdate the source **root** to the same fixed past mtime as the entries, so the
`./` row is deterministic (always present, identical) for every client. The
`dry-run` and `itemize` fixtures were byte-identical, so they now share one
`support::build_backdated_tree` helper - fixing the flake once and removing the
duplication.

## Verification (Linux, ext4 relatime + tmpfs)

- Forced-timing reproduction: upstream and oc emit identical rows in all cases.
- Post-fix: 8/8 zero-diff iterations (dry + real) directly; two full validate
  matrices with **`dry-run` and `itemize` PASS on all four transports**.
- New unit test asserts the fixture root is backdated.

Test-harness change only; no production code touched.
