### PR TITLE
fix: bound uncompressed literal-token length to CHUNK_SIZE

### DIFF
--- a/crates/batch/src/reader/delta.rs
+++ b/crates/batch/src/reader/delta.rs
@@ -47,6 +47,8 @@ impl BatchReader {
                 match token {
                     None => break,
                     Some(n) if n > 0 => {
+                        protocol::wire::delta::check_literal_token_len(n)
+                            .map_err(BatchError::Io)?;
                         let mut data = vec![0u8; n as usize];
                         reader.read_exact(&mut data).map_err(|e| {
                             BatchError::Io(io::Error::new(

--- a/crates/protocol/src/wire/delta/mod.rs
+++ b/crates/protocol/src/wire/delta/mod.rs
@@ -37,7 +37,7 @@ mod tests;
 pub use self::int_encoding::{read_int, write_int};
 pub use self::internal::{read_delta, read_delta_op, write_delta, write_delta_op};
 pub use self::token::{
-    read_token, write_token_block_match, write_token_end, write_token_literal, write_token_stream,
-    write_whole_file_delta,
+    check_literal_token_len, read_token, write_token_block_match, write_token_end,
+    write_token_literal, write_token_stream, write_whole_file_delta,
 };
 pub use self::types::{CHUNK_SIZE, DeltaOp};

--- a/crates/protocol/src/wire/delta/token.rs
+++ b/crates/protocol/src/wire/delta/token.rs
@@ -222,3 +222,20 @@ pub fn read_token<R: Read>(reader: &mut R) -> io::Result<Option<i32>> {
         Ok(Some(token))
     }
 }
+
+/// Rejects an uncompressed literal-token length larger than [`CHUNK_SIZE`], the
+/// per-token cap the sender enforces when chunking literal data
+/// (`token.c:simple_send_token`). A larger claimed length is a malformed or
+/// hostile stream that must not be allowed to drive an oversized allocation, so
+/// the receiver aborts with a `RERR_PROTOCOL`-mapped error rather than reserving
+/// the buffer. Mirrors the guard in `simple_recv_token`.
+///
+/// upstream: token.c:299-305 simple_recv_token
+pub fn check_literal_token_len(len: i32) -> io::Result<()> {
+    if len > CHUNK_SIZE as i32 {
+        return Err(crate::protocol_violation(format!(
+            "invalid uncompressed token length {len}"
+        )));
+    }
+    Ok(())
+}

--- a/crates/transfer/src/token_reader.rs
+++ b/crates/transfer/src/token_reader.rs
@@ -149,6 +149,7 @@ impl TokenReader {
                 match token.cmp(&0) {
                     std::cmp::Ordering::Equal => Ok(DeltaToken::End),
                     std::cmp::Ordering::Greater => {
+                        protocol::wire::delta::check_literal_token_len(token)?;
                         Ok(DeltaToken::Literal(LiteralData::Pending(token as usize)))
                     }
                     std::cmp::Ordering::Less => Ok(DeltaToken::BlockRef(-(token + 1) as usize)),
@@ -227,6 +228,37 @@ mod tests {
         match reader.read_token(&mut cursor).unwrap() {
             DeltaToken::Literal(LiteralData::Pending(len)) => assert_eq!(len, 5),
             other => panic!("expected Literal(Pending(5)), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plain_reader_rejects_oversized_literal_token() {
+        // A hostile plain literal claiming more than CHUNK_SIZE bytes must be
+        // rejected before any buffer is reserved, matching upstream's
+        // simple_recv_token guard (token.c:299-305): otherwise a peer could
+        // force a multi-gigabyte allocation with four wire bytes.
+        let oversized = (protocol::wire::delta::CHUNK_SIZE as i32 + 1).to_le_bytes();
+        let mut reader = TokenReader::new(None).unwrap();
+        let mut cursor = Cursor::new(oversized.to_vec());
+        let err = reader.read_token(&mut cursor).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("invalid uncompressed token length"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn plain_reader_accepts_max_literal_token() {
+        // Exactly CHUNK_SIZE is the largest a compliant sender emits.
+        let max = (protocol::wire::delta::CHUNK_SIZE as i32).to_le_bytes();
+        let mut reader = TokenReader::new(None).unwrap();
+        let mut cursor = Cursor::new(max.to_vec());
+        match reader.read_token(&mut cursor).unwrap() {
+            DeltaToken::Literal(LiteralData::Pending(len)) => {
+                assert_eq!(len, protocol::wire::delta::CHUNK_SIZE)
+            }
+            other => panic!("expected Pending(CHUNK_SIZE), got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Problem (memory-amplification DoS)

A compliant rsync sender chunks uncompressed literal data at `CHUNK_SIZE`
(32 KiB) per token (`token.c:simple_send_token`). oc's receiver, however,
accepted **any** positive `i32` literal length and reserved a buffer of that
size before reading the bytes:

- `TokenReader::read_token` (plain branch) → `Pending(token as usize)` → consumer `resize()`s it (`token_loop.rs`, `applicator.rs`).
- batch replay `reader/delta.rs` → `vec![0u8; n as usize]`.

A hostile/malformed peer can claim a ~2 GiB literal in four wire bytes and
force an oversized zeroed allocation. Upstream aborts this in
`simple_recv_token`:

```c
if (i > CHUNK_SIZE) {
    rprintf(FERROR, "invalid uncompressed token length %ld [%s]\n", (long)i, who_am_i());
    exit_cleanup(RERR_PROTOCOL);
}
```

## Fix

Add a shared `protocol::wire::delta::check_literal_token_len()` helper next to
the token codec (DRY, single source of the bound) and call it at both
plain-literal producer sites before any allocation: the live delta path
(`TokenReader::read_token`, which feeds every downstream consumer incl. both
applicator arms) and the batch replay path. Over-length literals now fail with
a `RERR_PROTOCOL`-mapped protocol-violation error.

Mirrors upstream `token.c:299-305` exactly. Same bug class as the shipped
zlibx-decoder bound (#6812).

## Verification (Linux host)
fmt + clippy clean; `cargo nextest -p protocol -p transfer -p batch` → 601 passed. New tests assert an oversized literal is rejected pre-allocation and exactly `CHUNK_SIZE` is still accepted.
