### PR TITLE
fix: reject batch files from a newer protocol than supported

### DIFF
--- a/crates/batch/src/reader/mod.rs
+++ b/crates/batch/src/reader/mod.rs
@@ -105,6 +105,20 @@ impl BatchReader {
                 ))
             })?;
 
+            // A batch written by a newer rsync than this build supports cannot
+            // be replayed correctly, so abort rather than adopt an unsupported
+            // protocol. The comparison uses this build's maximum supported
+            // protocol, matching upstream's `remote_protocol > protocol_version`
+            // (for --read-batch `protocol_version` is the client's compiled max).
+            // upstream: compat.c:609-613 setup_protocol()
+            let max_supported = i32::from(protocol::SUPPORTED_PROTOCOL_BOUNDS.1);
+            if header.protocol_version > max_supported {
+                return Err(BatchError::Io(protocol::protocol_violation(format!(
+                    "The protocol version in the batch file is too new ({} > {})",
+                    header.protocol_version, max_supported
+                ))));
+            }
+
             // Adopt protocol version, compat flags, and checksum seed from
             // the batch header. upstream: compat.c:setup_protocol() reads
             // these values from the batch fd and uses them directly, so the

--- a/crates/batch/src/reader/tests.rs
+++ b/crates/batch/src/reader/tests.rs
@@ -114,12 +114,15 @@ mod header_tests {
         let config = BatchConfig::new(
             BatchMode::Read,
             batch_path.to_string_lossy().to_string(),
-            28, // mismatched: batch was written with 30
+            28, // config placeholder; the batch was written with 30
         );
 
         let mut reader = BatchReader::new(config).unwrap();
         reader.read_header().unwrap();
 
+        // The reader adopts the batch's recorded protocol (30), which this build
+        // supports (<= 32). Only a protocol newer than the build supports is
+        // rejected (see read_header_rejects_batch_from_newer_protocol).
         assert_eq!(reader.config().protocol_version, 30);
         assert_eq!(reader.header().unwrap().protocol_version, 30);
     }

--- a/crates/batch/src/tests.rs
+++ b/crates/batch/src/tests.rs
@@ -91,6 +91,37 @@ mod integration {
     }
 
     #[test]
+    fn read_header_rejects_batch_from_newer_protocol() {
+        // A batch written by a future rsync (protocol 33) must be refused by a
+        // client that supports at most protocol 32, rather than silently
+        // adopting an unsupported protocol and replaying it wrong.
+        // upstream: compat.c:609-613 "protocol version in the batch file is too new".
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("too_new.batch");
+
+        let write_config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            33,
+        );
+        let mut writer = BatchWriter::new(write_config).unwrap();
+        writer.write_header(BatchFlags::default()).unwrap();
+        writer.finalize().unwrap();
+
+        let read_config = BatchConfig::new(
+            BatchMode::Read,
+            batch_path.to_string_lossy().to_string(),
+            32,
+        );
+        let mut reader = BatchReader::new(read_config).unwrap();
+        let err = reader.read_header().unwrap_err();
+        assert!(
+            err.to_string().contains("too new"),
+            "expected 'too new' rejection, got: {err}"
+        );
+    }
+
+    #[test]
     fn test_batch_empty_data() {
         let temp_dir = TempDir::new().unwrap();
         let batch_path = temp_dir.path().join("empty.batch");


### PR DESCRIPTION
## Problem

`--read-batch` adopted the protocol version recorded in the batch header with no
bound (`reader/mod.rs` blindly set `config.protocol_version = header.protocol_version`).
A batch produced by a **newer** rsync (protocol > 32) would then be replayed
against an unsupported protocol rather than refused. Upstream aborts:

```c
if (read_batch && remote_protocol > protocol_version) {
    rprintf(FERROR, "The protocol version in the batch file is too new (%d > %d).\n",
        remote_protocol, protocol_version);
    exit_cleanup(RERR_PROTOCOL);
}
```

## Fix

Before adopting the header protocol, compare it against this build's maximum
supported protocol (`protocol::SUPPORTED_PROTOCOL_BOUNDS.1` = 32) and abort with
a protocol-violation error when the batch is too new. The compiled maximum is
used rather than the reader's `config.protocol_version` field, because that field
is a placeholder some callers leave at 0 (verified: an internal reader path uses
0 and must still adopt the header's protocol).

Mirrors upstream `compat.c:609-613`.

## Verification (Linux host)
fmt + clippy clean; `cargo nextest -p batch` → 221 passed. New test writes a
protocol-33 batch and asserts it is refused; the existing adopt-from-header test
still passes (a batch protocol ≤ 32 is adopted normally).
