### PR TITLE
fix: use the bare rsync. fake-super xattr name off Linux

### DIFF
--- a/crates/metadata/src/fake_super.rs
+++ b/crates/metadata/src/fake_super.rs
@@ -7,7 +7,8 @@
 //!
 //! # Wire Format
 //!
-//! The `user.rsync.%stat` xattr stores metadata in the format matching upstream:
+//! The fake-super stat xattr (`user.rsync.%stat` on Linux, `rsync.%stat`
+//! elsewhere) stores metadata in the format matching upstream:
 //! ```text
 //! <mode_octal> <rdev_major>,<rdev_minor> <uid>:<gid>
 //! ```
@@ -24,7 +25,18 @@ use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
 /// The xattr name used to store fake-super metadata.
+///
+/// Linux extended attributes require the `user.` namespace prefix; other
+/// platforms use a flat xattr namespace, so upstream stores the attribute under
+/// bare `rsync.` there. Using the Linux name unconditionally would write an
+/// attribute literally called `user.rsync.%stat` on macOS/BSD and break
+/// fake-super interop and round-trip. upstream: xattrs.c:64-70 RSYNC_PREFIX
+/// (`HAVE_LINUX_XATTRS`).
+#[cfg(target_os = "linux")]
 pub const FAKE_SUPER_XATTR: &str = "user.rsync.%stat";
+/// The fake-super stat xattr name on non-Linux platforms (flat namespace).
+#[cfg(not(target_os = "linux"))]
+pub const FAKE_SUPER_XATTR: &str = "rsync.%stat";
 
 /// Parsed fake-super metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -379,6 +391,17 @@ pub fn remove_fake_super(_path: &Path) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fake_super_xattr_name_matches_platform_namespace() {
+        // Linux xattrs need the `user.` prefix; other platforms use a flat
+        // namespace and store the attribute under bare `rsync.`.
+        // upstream: xattrs.c:64-70 RSYNC_PREFIX.
+        #[cfg(target_os = "linux")]
+        assert_eq!(FAKE_SUPER_XATTR, "user.rsync.%stat");
+        #[cfg(not(target_os = "linux"))]
+        assert_eq!(FAKE_SUPER_XATTR, "rsync.%stat");
+    }
 
     #[test]
     fn test_encode_regular_file() {


### PR DESCRIPTION
## Problem (non-Linux fake-super interop)

The fake-super stat attribute was stored under a hardcoded `user.rsync.%stat`
name on every platform:

```rust
pub const FAKE_SUPER_XATTR: &str = "user.rsync.%stat";
```

The `user.` prefix is a **Linux** xattr-namespace requirement. macOS/BSD/Solaris
use a flat namespace, so upstream stores the attribute under bare `rsync.`:

```c
#ifdef HAVE_LINUX_XATTRS
#define RSYNC_PREFIX USER_PREFIX "rsync."   /* user.rsync. */
#else
#define RSYNC_PREFIX "rsync."
#endif
#define XSTAT_ATTR RSYNC_PREFIX "%" "stat"
```

On macOS/BSD oc wrote an attribute literally named `user.rsync.%stat`, breaking
`--fake-super` round-trip and interop with upstream — and diverging from oc's own
non-Linux sibling logic in `xattr.rs`, which already uses the bare name.

## Fix

Gate `FAKE_SUPER_XATTR` on `target_os = "linux"`: `user.rsync.%stat` on Linux,
`rsync.%stat` elsewhere — mirroring upstream `RSYNC_PREFIX`.

## Verification (Linux host)
fmt + clippy clean; `cargo nextest -p metadata` (fake_super) → 19 passed. The
Linux value is unchanged (no regression on the tested platform); a new test
asserts the platform-correct name on both branches.
