### PR TITLE
fix: reject the non-upstream per-dir filter alias

### DIFF
--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -270,7 +270,6 @@ fn merge_directive_requires_argument(keyword: &str) -> bool {
         "include" | "exclude" | "show" | "hide" | "protect" | "risk" | "exclude-if-present"
     ) || keyword.starts_with("merge")
         || keyword.starts_with("dir-merge")
-        || keyword.starts_with("per-dir")
         || keyword == "."
         || keyword == ":"
 }
@@ -328,11 +327,6 @@ mod tests {
     #[test]
     fn requires_argument_dir_merge() {
         assert!(merge_directive_requires_argument("dir-merge"));
-    }
-
-    #[test]
-    fn requires_argument_per_dir() {
-        assert!(merge_directive_requires_argument("per-dir"));
     }
 
     #[test]

--- a/crates/cli/src/frontend/filter_rules/parsing/directives.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/directives.rs
@@ -1,4 +1,4 @@
-//! Long `merge` and `dir-merge` / `per-dir` directive parsers.
+//! Long `merge` and `dir-merge` directive parsers.
 //!
 //! Parses the verbose merge-file directives that introduce per-file or
 //! per-directory filter merges, applying their modifier strings and
@@ -58,27 +58,16 @@ pub(super) fn parse_long_merge_directive(text: &str) -> Option<Result<FilterDire
     Some(Ok(FilterDirective::Merge(directive)))
 }
 
-/// Parses a long-form `dir-merge[,MODS] FILE` directive (and the `per-dir`
-/// alias). Returns `None` when neither alias matches, or an error when the file
-/// name is missing.
+/// Parses a long-form `dir-merge[,MODS] FILE` directive. Returns `None` when
+/// the keyword does not match, or an error when the file name is missing.
 pub(super) fn parse_dir_merge_alias(trimmed: &str) -> Option<Result<FilterDirective, Message>> {
-    const DIR_MERGE_ALIASES: [&str; 2] = ["dir-merge", "per-dir"];
-
-    let mut matched_prefix = None;
-    for alias in DIR_MERGE_ALIASES {
-        // upstream: exclude.c:1143 RULE_STRCMP(s, "dir-merge") is a case-sensitive
-        // strncmp reached via `case 'd'`, so `DIR-MERGE`/`Dir-Merge` never match
-        // the keyword. Compare bytes exactly (the `per-dir` alias is an oc-rsync
-        // extension held to the same case-sensitivity for consistency). Every
-        // alias is ASCII, so an equal prefix guarantees `alias.len()` is a char
-        // boundary, keeping the slices below panic-safe.
-        if trimmed.as_bytes().starts_with(alias.as_bytes()) {
-            matched_prefix = Some((&trimmed[..alias.len()], &trimmed[alias.len()..]));
-            break;
-        }
-    }
-
-    let (label, remainder) = matched_prefix?;
+    // upstream: exclude.c:1143 RULE_STRCMP(s, "dir-merge") is a case-sensitive
+    // strncmp reached via `case 'd'`, so `DIR-MERGE`/`Dir-Merge` never match the
+    // keyword. Compare bytes exactly; "dir-merge" is ASCII, so a matching prefix
+    // lands on a char boundary, keeping the slices below panic-safe. (upstream
+    // has no other dir-merge spelling, so no alias is accepted.)
+    const KEYWORD: &str = "dir-merge";
+    let remainder = trimmed.strip_prefix(KEYWORD)?;
     let mut remainder =
         remainder.trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
     let mut modifiers = "";
@@ -101,7 +90,7 @@ pub(super) fn parse_dir_merge_alias(trimmed: &str) -> Option<Result<FilterDirect
         if assume_cvsignore {
             path_text = ".cvsignore";
         } else {
-            let text = format!("filter rule '{trimmed}' is missing a file name after '{label}'");
+            let text = format!("filter rule '{trimmed}' is missing a file name after '{KEYWORD}'");
             return Some(Err(rsync_error!(1, text).with_role(Role::Client)));
         }
     }

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -263,16 +263,15 @@ fn dir_merge_basic() {
 }
 
 #[test]
-fn dir_merge_per_dir_alias() {
-    let result = parse_dir_merge_alias("per-dir filter-file");
-    assert!(result.is_some());
-    let directive = result.unwrap().unwrap();
-    match directive {
-        FilterDirective::Rule(spec) => {
-            assert_eq!(spec.kind(), FilterRuleKind::DirMerge);
-        }
-        _ => panic!("expected Rule directive"),
-    }
+fn per_dir_is_not_a_keyword() {
+    // upstream: exclude.c recognizes only "dir-merge" (case 'd' RULE_STRCMP);
+    // there is no "per-dir" spelling. oc must decline it (returns None) so the
+    // caller rejects the unknown rule, rather than accepting an oc-only alias.
+    assert!(parse_dir_merge_alias("per-dir filter-file").is_none());
+    // The canonical keyword still parses as a dir-merge directive.
+    let ok = parse_dir_merge_alias("dir-merge filter-file");
+    assert!(ok.is_some());
+    assert!(ok.unwrap().is_ok());
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/merge.rs
+++ b/crates/cli/src/frontend/tests/merge.rs
@@ -58,7 +58,7 @@ fn apply_merge_directive_parses_whitespace_risk_and_exclude_if_present() {
 }
 
 #[test]
-fn apply_merge_directive_parses_whitespace_per_dir_alias() {
+fn apply_merge_directive_rejects_per_dir_alias() {
     use std::collections::HashSet;
     use tempfile::tempdir;
 
@@ -71,14 +71,9 @@ fn apply_merge_directive_parses_whitespace_per_dir_alias() {
 
     let mut rules = Vec::new();
     let mut visited = HashSet::new();
-    apply_merge_directive(directive, temp.path(), &mut rules, &mut visited).expect("apply merge");
-
-    assert!(visited.is_empty());
-    let dir_merge_rule = rules
-        .iter()
-        .find(|rule| rule.kind() == FilterRuleKind::DirMerge)
-        .expect("dir-merge rule present");
-    assert_eq!(dir_merge_rule.pattern(), ".rsync-filter");
+    // "per-dir" is not an upstream directive, so a merge file that uses it must
+    // fail to load rather than silently accept the oc-only alias.
+    assert!(apply_merge_directive(directive, temp.path(), &mut rules, &mut visited).is_err());
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/parse_filter.rs
+++ b/crates/cli/src/frontend/tests/parse_filter.rs
@@ -342,16 +342,11 @@ fn parse_filter_directive_accepts_dir_merge_without_modifiers() {
 }
 
 #[test]
-fn parse_filter_directive_accepts_per_dir_alias() {
-    let directive =
-        parse_filter_directive(OsStr::new("per-dir .rsync-filter")).expect("per-dir alias parses");
-    assert_eq!(
-        directive,
-        FilterDirective::Rule(FilterRuleSpec::dir_merge(
-            ".rsync-filter".to_owned(),
-            DirMergeOptions::default(),
-        )),
-    );
+fn parse_filter_directive_rejects_per_dir_alias() {
+    // "per-dir" is not an upstream keyword; it must be rejected rather than
+    // treated as a dir-merge alias. upstream: exclude.c recognizes only
+    // "dir-merge" (case 'd').
+    assert!(parse_filter_directive(OsStr::new("per-dir .rsync-filter")).is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Problem

oc accepted `per-dir` as a spelling of the `dir-merge` filter directive — both in
`--filter` text and inside merge files. Upstream rsync has no such keyword:
`exclude.c` recognizes only `dir-merge` (case `'d'` via `RULE_STRCMP`), so
`per-dir FILE` is an unknown rule upstream rejects. Accepting it is an oc-only
extension diverging from upstream filter semantics.

## Fix

Drop the alias so `per-dir` is declined and the caller reports the same
unknown-rule error upstream would. With only `dir-merge` left:
- the alias array + loop in `parse_dir_merge_alias` collapses to a single
  case-sensitive `strip_prefix` check (cleaner);
- `merge_directive_requires_argument` no longer special-cases `per-dir`.

Three tests that asserted the alias parsed are repurposed to assert it is now
rejected.

Mirrors upstream `exclude.c:1143`.

## Verification (Linux host)
fmt + clippy clean; `cargo nextest -p cli` (filter/merge) → 374 passed.
