### PR TITLE
fix: advertise server symlink-times/iconv from own capability

### DIFF
--- a/crates/transfer/src/setup/capability.rs
+++ b/crates/transfer/src/setup/capability.rs
@@ -368,7 +368,16 @@ pub(crate) fn build_compat_flags_from_client_info(
             continue;
         }
 
-        if client_info.contains(mapping.char) {
+        // upstream: compat.c:713-718 sets CF_SYMLINK_TIMES / CF_SYMLINK_ICONV
+        // from the server's OWN compile-time capability (`#ifdef`), NOT from the
+        // client's advertisement - only f/x/C/I/v/u are client_info-gated. The
+        // platform_ok / requires_iconv guards above already encode that own
+        // capability, so set these two whenever we support them, even for a peer
+        // (e.g. a non-unix sender) whose -e string omits 'L'. Matches
+        // build_default_flags on the client path.
+        let own_server_capability = mapping.flag == CompatibilityFlags::SYMLINK_TIMES
+            || mapping.flag == CompatibilityFlags::SYMLINK_ICONV;
+        if own_server_capability || client_info.contains(mapping.char) {
             flags |= mapping.flag;
         }
     }

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -230,11 +230,22 @@ fn build_compat_flags_enables_symlink_times_when_client_advertises_l() {
 }
 
 #[test]
-fn build_compat_flags_skips_symlink_times_when_client_missing_l() {
+fn build_compat_flags_sets_symlink_times_from_own_capability_when_client_missing_l() {
+    // upstream: compat.c:713 sets CF_SYMLINK_TIMES from the server's OWN
+    // compile-time capability (`#ifdef CAN_SET_SYMLINK_TIMES`), NOT from the
+    // client's 'L'. A peer that omits 'L' (e.g. a non-unix sender pushing to a
+    // Unix server) must still get symlink-time preservation. The client-sender
+    // reads this advertised flag as `receiver_symlink_times` (compat.c:756-761).
     let flags = build_compat_flags_from_client_info("fxCIvu", true);
+    #[cfg(unix)]
+    assert!(
+        flags.contains(CompatibilityFlags::SYMLINK_TIMES),
+        "SYMLINK_TIMES must come from our own capability, regardless of client 'L'"
+    );
+    #[cfg(not(unix))]
     assert!(
         !flags.contains(CompatibilityFlags::SYMLINK_TIMES),
-        "SYMLINK_TIMES should not be enabled when client doesn't advertise 'L'"
+        "SYMLINK_TIMES stays off where the platform cannot set symlink times"
     );
 }
 


### PR DESCRIPTION
## Upstream behaviour

Upstream's `setup_protocol()` sets `CF_SYMLINK_TIMES` / `CF_SYMLINK_ICONV` in the
server's advertised `compat_flags` from its **own** compile-time capability, not
the client's `-e` letters:

```c
#ifdef CAN_SET_SYMLINK_TIMES
    compat_flags |= CF_SYMLINK_TIMES;
#endif
#ifdef ICONV_OPTION
    compat_flags |= CF_SYMLINK_ICONV;
#endif
if (strchr(client_info, 'f')) compat_flags |= CF_SAFE_FLIST;   /* only f/x/C/I/v/u are client-gated */
```

The client then reads the advertised flag as `receiver_symlink_times` for the
push case (`compat.c:756-761`).

## Problem

oc's `build_compat_flags_from_client_info` looped **all** capability rows through
`client_info.contains(char)`, including `'L'`/`'s'`. So a peer that omits `'L'`
(e.g. a non-unix sender pushing to a Unix oc server) would not be told the
server preserves symlink times — a wire divergence. Masked in the common case
because a unix client always sends `'L'`; the client/SSH path was already correct
(`build_default_flags` sets both unconditionally).

## Fix (mirror upstream — applicable and advantageous)

Set `CF_SYMLINK_TIMES`/`CF_SYMLINK_ICONV` from our own capability (the existing
`platform_ok`/`requires_iconv` guards already encode `#ifdef CAN_SET_SYMLINK_TIMES`
/ `#ifdef ICONV_OPTION`), keeping `f/x/C/I/v/u` client-gated. Byte-identical to
upstream in the common case; fixes the omitted-`'L'` push case with zero downside.

## Verification (Linux host)
fmt + clippy clean; `cargo nextest -p transfer` (compat/capability) → 163 passed.
The prior test that asserted the client-gated behaviour is corrected to the
upstream semantics (own-capability, platform-aware).
