### PR TITLE
fix: map compressed-token index overflow to RERR_PROTOCOL

### DIFF
--- a/crates/protocol/src/wire/compressed_token/step.rs
+++ b/crates/protocol/src/wire/compressed_token/step.rs
@@ -21,6 +21,13 @@ use std::io::{self, Read};
 
 use super::{CHUNK_SIZE, CompressedToken, DEFLATED_DATA, END_FLAG, TOKEN_REL};
 
+/// Largest legal token index in the compressed stream. A run increment or
+/// relative token that pushes the running index past this is a malformed
+/// stream that must abort with a protocol violation rather than be accepted.
+/// upstream: token.c `#define MAX_TOKEN_INDEX ((int32)0x7ffffffe)` and
+/// `invalid_compressed_token()` -> `exit_cleanup(RERR_PROTOCOL)`.
+const MAX_TOKEN_INDEX: i32 = 0x7fff_fffe;
+
 /// The outcome of a single decoder step.
 ///
 /// The state machine that produces these owns all decode state; the driver only
@@ -238,12 +245,17 @@ impl TokenDecodeCore {
 
     fn next_run_token(&mut self) -> io::Result<CompressedToken> {
         self.rx_run -= 1;
-        self.rx_token = self.rx_token.checked_add(1).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "token index overflow in compressed stream run",
-            )
-        })?;
+        // upstream: token.c recv_deflated_token - a run increment past
+        // MAX_TOKEN_INDEX is invalid_compressed_token() -> RERR_PROTOCOL.
+        self.rx_token = self
+            .rx_token
+            .checked_add(1)
+            .filter(|&t| t <= MAX_TOKEN_INDEX)
+            .ok_or_else(|| {
+                crate::protocol_violation::protocol_violation(
+                    "token index overflow in compressed stream run",
+                )
+            })?;
         Ok(CompressedToken::BlockMatch(self.rx_token as u32))
     }
 
@@ -436,12 +448,17 @@ impl TokenDecodeCore {
 
         if flag & TOKEN_REL != 0 {
             let rel = (flag & 0x3F) as i32;
-            self.rx_token = self.rx_token.checked_add(rel).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "token index overflow in compressed stream",
-                )
-            })?;
+            // upstream: token.c invalid_compressed_token() -> RERR_PROTOCOL when
+            // the relative token index exceeds MAX_TOKEN_INDEX.
+            self.rx_token = self
+                .rx_token
+                .checked_add(rel)
+                .filter(|&t| t <= MAX_TOKEN_INDEX)
+                .ok_or_else(|| {
+                    crate::protocol_violation::protocol_violation(
+                        "token index overflow in compressed stream",
+                    )
+                })?;
             if (flag >> 6) & 1 != 0 {
                 self.phase = Phase::RunCount {
                     token: self.rx_token,

--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -1675,17 +1675,15 @@ fn lz4_decoder_rejects_token_rel_overflow() {
 /// CVE-2026-43618 regression: the decoder must reject run emission that
 /// would overflow `rx_token` past `i32::MAX`.
 ///
-/// A TOKENRUN_LONG starting near `i32::MAX` with a non-trivial run count
-/// causes the run emission loop to increment `rx_token` past the signed
-/// maximum. Without checked arithmetic, the counter wraps to negative and
-/// `as u32` produces a huge block index.
+/// A TOKENRUN_LONG whose run pushes `rx_token` past `MAX_TOKEN_INDEX`
+/// (0x7ffffffe) must abort with a protocol violation rather than wrap the
+/// counter negative and produce a huge `as u32` block index.
 ///
-/// upstream: token.c defence-in-depth (3.4.3) - bounded run emission
+/// upstream: token.c invalid_compressed_token() -> exit_cleanup(RERR_PROTOCOL).
 fn assert_rejects_run_overflow(mut decoder: CompressedTokenDecoder) {
-    // TOKENRUN_LONG with token = i32::MAX - 1 and run count = 5.
-    // The first token (i32::MAX - 1) succeeds, then the run emits
-    // tokens at i32::MAX - 1 + 1 = i32::MAX (ok), then +1 = overflow.
-    let start: i32 = i32::MAX - 1;
+    // TOKENRUN_LONG with the base token at MAX_TOKEN_INDEX (the largest legal
+    // index) and a run: the base token is valid, the next increment exceeds it.
+    let start: i32 = 0x7fff_fffe; // MAX_TOKEN_INDEX
     let run_count: u16 = 5;
     let mut wire = Vec::new();
     wire.push(TOKENRUN_LONG);
@@ -1693,19 +1691,20 @@ fn assert_rejects_run_overflow(mut decoder: CompressedTokenDecoder) {
     wire.extend_from_slice(&run_count.to_le_bytes());
 
     let mut cursor = Cursor::new(&wire);
-    // First token: BlockMatch(i32::MAX - 1) - succeeds
+    // First token: BlockMatch(MAX_TOKEN_INDEX) - the largest legal index.
     let t1 = decoder.recv_token(&mut cursor).unwrap();
-    assert!(matches!(t1, CompressedToken::BlockMatch(v) if v == (i32::MAX - 1) as u32));
+    assert!(matches!(t1, CompressedToken::BlockMatch(v) if v == 0x7fff_fffe));
 
-    // Second token: rx_token = i32::MAX - succeeds
-    let t2 = decoder.recv_token(&mut cursor).unwrap();
-    assert!(matches!(t2, CompressedToken::BlockMatch(v) if v == i32::MAX as u32));
-
-    // Third token: rx_token = i32::MAX + 1 - must overflow
+    // Next token would be MAX_TOKEN_INDEX + 1 - must be rejected.
     let err = decoder
         .recv_token(&mut cursor)
         .expect_err("decoder must reject run overflow");
-    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    // upstream aborts with RERR_PROTOCOL(2), not RERR_STREAMIO(12).
+    assert!(
+        err.get_ref()
+            .is_some_and(|e| e.is::<crate::ProtocolViolation>()),
+        "run overflow must be tagged RERR_PROTOCOL, got: {err}",
+    );
     assert!(
         err.to_string().contains("token index overflow"),
         "unexpected error message: {err}"


### PR DESCRIPTION
## Problem

A run increment or relative token that pushed the compressed-stream token index
out of range was reported as `io::ErrorKind::InvalidData` → `RERR_STREAMIO`
(exit 12). Upstream treats an out-of-range token as a malformed stream and aborts:

```c
#define MAX_TOKEN_INDEX ((int32)0x7ffffffe)
static NORETURN void invalid_compressed_token(void) { ...; exit_cleanup(RERR_PROTOCOL); }
```

oc's bound was also the raw `i32` overflow point (`0x7fffffff`), one past
upstream's `MAX_TOKEN_INDEX` (`0x7ffffffe`).

## Fix

Add a `MAX_TOKEN_INDEX` constant and, in both overflow arms (run increment and
relative token), reject an index exceeding it via `protocol_violation` so the
exit code is `RERR_PROTOCOL` (2). The sibling zero-run / negative-token cases
already used `protocol_violation`.

## Verification (Linux host)
fmt + clippy clean; `cargo nextest -p protocol` (token/compressed) → 158 passed.
The run-overflow test is corrected to the upstream `MAX_TOKEN_INDEX` boundary and
asserts the `ProtocolViolation` tag.
