### PR TITLE
fix: exit RERR_UNSUPPORTED on an unsafe sender pathname

### DIFF
--- a/crates/protocol/src/flist/read/name.rs
+++ b/crates/protocol/src/flist/read/name.rs
@@ -199,8 +199,10 @@ impl FileListReader {
         // Fast path: most names from a well-behaved sender need no cleaning.
         if !needs_cleaning(&name) {
             if !self.relative_paths && name[0] == b'/' {
+                // upstream: flist.c:768 exit_cleanup(RERR_UNSUPPORTED); the
+                // `Unsupported` kind maps to exit 4, not StreamIo(12).
                 return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
+                    io::ErrorKind::Unsupported,
                     format!(
                         "ABORTING due to unsafe pathname from sender: {}",
                         String::from_utf8_lossy(&name)
@@ -216,8 +218,9 @@ impl FileListReader {
 
         // upstream: flist.c:757 - reject absolute paths when not --relative
         if anchored && !self.relative_paths {
+            // upstream: flist.c:768 exit_cleanup(RERR_UNSUPPORTED) -> exit 4.
             return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
+                io::ErrorKind::Unsupported,
                 format!(
                     "ABORTING due to unsafe pathname from sender: {}",
                     String::from_utf8_lossy(&name)
@@ -254,8 +257,9 @@ impl FileListReader {
                 if next == Some(b'.') {
                     let after = name.get(i + 2).copied();
                     if after == Some(b'/') || after.is_none() {
+                        // upstream: flist.c:768 exit_cleanup(RERR_UNSUPPORTED) -> exit 4.
                         return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
+                            io::ErrorKind::Unsupported,
                             format!(
                                 "ABORTING due to unsafe pathname from sender: {}",
                                 String::from_utf8_lossy(&name)

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -2950,9 +2950,12 @@ mod leading_slash_parity {
 
     #[test]
     fn non_relative_double_leading_slash_rejected() {
+        // upstream: flist.c:768 exit_cleanup(RERR_UNSUPPORTED) - refusing an
+        // absolute sender pathname is exit 4, which oc maps from the
+        // `Unsupported` io error kind (not `InvalidData`, which is exit 12).
         assert_eq!(
             run(b"//foo", false).unwrap_err(),
-            std::io::ErrorKind::InvalidData
+            std::io::ErrorKind::Unsupported
         );
     }
 
@@ -2960,7 +2963,16 @@ mod leading_slash_parity {
     fn non_relative_triple_leading_slash_rejected() {
         assert_eq!(
             run(b"///foo", false).unwrap_err(),
-            std::io::ErrorKind::InvalidData
+            std::io::ErrorKind::Unsupported
+        );
+    }
+
+    #[test]
+    fn dot_dot_component_rejected_as_unsupported() {
+        // upstream: util1.c CFN_REFUSE_DOT_DOT_DIRS -> RERR_UNSUPPORTED (exit 4).
+        assert_eq!(
+            run(b"../escape", true).unwrap_err(),
+            std::io::ErrorKind::Unsupported
         );
     }
 }


### PR DESCRIPTION
## Problem

When the file-list reader refused an unsafe pathname (an absolute path without
`--relative`, or a `..` component), it returned a plain
`io::ErrorKind::InvalidData`, which `from_io_error` maps to `RERR_STREAMIO`
(exit 12). Upstream aborts this security check with a different code:

```c
rprintf(FERROR, "ABORTING due to unsafe pathname from sender: %s\n", thisname);
exit_cleanup(RERR_UNSUPPORTED);   /* exit 4 */
```

## Fix

Use `io::ErrorKind::Unsupported` for the three "ABORTING due to unsafe pathname"
sites in `clean_and_validate_name`. `ExitCode::from_io_error` already maps that
kind to `ExitCode::Unsupported` (4), so the exit code now matches upstream. Two
existing tests that pinned the old `InvalidData` kind are corrected, and a
`..`-component case is added.

Mirrors upstream `flist.c:768`.

## Verification (Linux host)
fmt + clippy clean; `cargo nextest -p protocol` (path-validation tests) → all pass.
