### PR TITLE
fix: enforce the daemon open-noatime module directive

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -102,6 +102,13 @@ fn apply_module_transfer_directives(module: &ModuleDefinition, cfg: &mut ServerC
     if cfg.flags.numeric_ids.is_off() && module_forces_numeric_ids {
         cfg.flags.numeric_ids = core::server::NumericIds::DaemonForced;
     }
+
+    // upstream: loadparm `open noatime` - the module directive makes the
+    // daemon (as sender) open source files with O_NOATIME. It can only enable
+    // the flag, never clear a value the client already requested.
+    if module.open_noatime {
+        cfg.write.open_noatime = true;
+    }
 }
 
 /// Builds the server configuration from client arguments.

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -3131,6 +3131,29 @@ mod module_access_tests {
         assert!(!cfg.deletion.ignore_errors);
     }
 
+    // upstream: loadparm `open noatime` - the module directive makes the daemon
+    // (as sender) open source files with O_NOATIME. Without wiring it into the
+    // server config the directive was parsed but never enforced.
+    #[test]
+    fn module_open_noatime_forces_config_flag() {
+        let module = ModuleDefinition {
+            open_noatime: true,
+            ..Default::default()
+        };
+        let mut cfg = ServerConfig::default();
+        assert!(!cfg.write.open_noatime);
+        apply_module_transfer_directives(&module, &mut cfg);
+        assert!(cfg.write.open_noatime);
+    }
+
+    #[test]
+    fn module_without_open_noatime_leaves_config_untouched() {
+        let module = ModuleDefinition::default();
+        let mut cfg = ServerConfig::default();
+        apply_module_transfer_directives(&module, &mut cfg);
+        assert!(!cfg.write.open_noatime);
+    }
+
     // upstream: clientserver.c:1201-1204 - `numeric ids = yes` forces
     // `numeric_ids = -1` for the session (NOT `1`), except under chroot when a
     // `name converter` is configured (the converter maps names inside the


### PR DESCRIPTION
## Problem

The `open noatime` rsyncd.conf module directive was parsed and stored
(`ModuleDefinition::open_noatime`) but never propagated to the transfer, so a
module configured with `open noatime = yes` still bumped source atimes on read.
The transfer already honours the flag (`generator/context.rs` opens source files
with `O_NOATIME` when `write.open_noatime` is set) and the client
`--open-noatime` path wires it (`flags.rs:491`), but the daemon per-module
directive did not reach the server-side `ServerConfig`.

## Fix

Set `cfg.write.open_noatime` from `module.open_noatime` in
`apply_module_transfer_directives`, next to the other module transfer directives.
It only enables the flag (never clears a client-requested value).

`ignore nonreadable` is a separate, larger gap: the transfer has no
skip-unreadable-source path, so wiring the directive would be a no-op today — it
needs transfer-side support first (tracked).

## Verification (Linux host)
fmt + clippy clean; `cargo nextest -p daemon` → all pass. New tests assert the
directive forces `cfg.write.open_noatime` and that the default leaves it off.
