### PR TITLE
fix: stage local-copy temp as .name.XXXXXX per get_tmpname

### DIFF
--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::Ordering as AtomicOrdering;
 use crate::local_copy::LocalCopyError;
 
 use super::super::super::NEXT_TEMP_FILE_ID;
-use super::paths::{partial_dir_fname, temp_name_with_suffix, temporary_destination_path};
+use super::paths::{partial_dir_fname, temp_name_with_suffix};
 use crate::CleanupManager;
 
 /// Where an interrupted `--partial` temp file is finalised, and how the temp is
@@ -139,10 +139,12 @@ enum GuardStrategy {
 ///
 /// # Modes
 ///
-/// - **Normal mode** (`partial = false`): Temporary files are created with a unique
-///   name (including process ID and counter) and are automatically cleaned up on failure.
-/// - **Partial mode** (`partial = true`): Temporary files are preserved on failure to
-///   allow for transfer resumption. These files use the `.rsync-partial-` prefix.
+/// - **Normal mode** (`partial = false`): Temporary files are staged beside the
+///   destination as `.<name>.XXXXXX` (upstream `get_tmpname()`) and are
+///   automatically cleaned up on failure.
+/// - **Partial mode** (`partial = true`): The temp is staged the same way but is
+///   preserved on failure - moved onto the destination (`--partial`) or into the
+///   `--partial-dir` - so the transfer can resume.
 /// - **Anonymous mode** (Linux only): Uses `O_TMPFILE` + `linkat(2)` for zero-cleanup
 ///   atomic writes. No directory entry exists until commit.
 ///
@@ -209,12 +211,7 @@ impl DestinationWriteGuard {
         // the destination (or in --temp-dir), regardless of partial mode; the
         // partial only appears at its final resting place on interrupt/success.
         loop {
-            let temp_path = if partial {
-                temp_name_with_suffix(destination, temp_dir, &temp_suffix())
-            } else {
-                let unique = NEXT_TEMP_FILE_ID.fetch_add(1, AtomicOrdering::Relaxed);
-                temporary_destination_path(destination, unique, temp_dir)
-            };
+            let temp_path = temp_name_with_suffix(destination, temp_dir, &temp_suffix());
             match fs::OpenOptions::new()
                 .write(true)
                 .create_new(true)

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -33,7 +33,7 @@ pub use partial::{PartialFileManager, PartialMode};
 #[cfg(test)]
 pub(crate) use paths::partial_destination_path;
 #[cfg(test)]
-pub(crate) use paths::temporary_destination_path;
+pub(crate) use paths::temp_name_with_suffix;
 #[cfg(test)]
 pub(crate) use preallocate::maybe_preallocate_destination;
 pub use sparse::{

--- a/crates/engine/src/local_copy/executor/file/partial.rs
+++ b/crates/engine/src/local_copy/executor/file/partial.rs
@@ -13,7 +13,7 @@
 //! # Behavior
 //!
 //! Without `--partial`:
-//! - Temp files use `.~tmp~*` naming
+//! - Temp files use upstream `get_tmpname()` naming (`.<name>.XXXXXX`)
 //! - Deleted on transfer failure or interruption
 //!
 //! With `--partial`:

--- a/crates/engine/src/local_copy/executor/file/paths.rs
+++ b/crates/engine/src/local_copy/executor/file/paths.rs
@@ -1,22 +1,16 @@
 //! Temporary, partial, and destination path computation.
 //!
-//! Generates temp file paths (`.~tmp~` prefix with PID), partial transfer
-//! paths (`--partial-dir`), and resolves the final destination for each file.
+//! Generates temp file paths (`.<name>.XXXXXX`, upstream `get_tmpname()`),
+//! partial transfer paths (`--partial-dir`), and resolves the final destination
+//! for each file.
 
 // upstream: receiver.c - temp file naming, util1.c:partial_dir_fname()
 
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 
 use crate::local_copy::LocalCopyError;
-
-/// Cached process ID to avoid a `getpid` syscall per temp file.
-fn cached_pid() -> u32 {
-    static PID: OnceLock<u32> = OnceLock::new();
-    *PID.get_or_init(std::process::id)
-}
 
 /// Computes the partial-file path by prefixing the filename with `.rsync-partial-`.
 pub(crate) fn partial_destination_path(destination: &Path) -> PathBuf {
@@ -119,26 +113,6 @@ pub(crate) fn partial_dir_fname(destination: &Path, partial_dir: &Path) -> PathB
     base_dir.join(file_name)
 }
 
-/// Computes the temporary file path used during atomic writes.
-///
-/// The name includes the PID and a unique counter to prevent collisions.
-// upstream: receiver.c:get_tmpname()
-pub(crate) fn temporary_destination_path(
-    destination: &Path,
-    unique: usize,
-    temp_dir: Option<&Path>,
-) -> PathBuf {
-    let file_name = destination.file_name().map_or_else(
-        || "temp".to_owned(),
-        |name| name.to_string_lossy().to_string(),
-    );
-    let temp_name = format!(".~tmp~{file_name}.{}.{}", cached_pid(), unique);
-    match temp_dir {
-        Some(dir) => dir.join(temp_name),
-        None => destination.with_file_name(temp_name),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,39 +140,28 @@ mod tests {
     }
 
     #[test]
-    fn temporary_destination_path_adds_prefix() {
+    fn temp_name_with_suffix_uses_upstream_naming() {
         let dest = Path::new("/path/to/file.txt");
-        let temp = temporary_destination_path(dest, 42, None);
-        assert!(temp.to_string_lossy().contains(".~tmp~"));
-        assert!(temp.to_string_lossy().contains("file.txt"));
-    }
-
-    #[test]
-    fn temporary_destination_path_includes_unique_id() {
-        let dest = Path::new("/path/to/file.txt");
-        let temp = temporary_destination_path(dest, 123, None);
-        assert!(temp.to_string_lossy().contains("123"));
-    }
-
-    #[test]
-    fn temporary_destination_path_uses_temp_dir() {
-        let dest = Path::new("/path/to/file.txt");
-        let temp_dir = Path::new("/tmp/rsync");
-        let temp = temporary_destination_path(dest, 1, Some(temp_dir));
-        assert!(temp.starts_with(temp_dir));
-    }
-
-    #[test]
-    fn temporary_destination_path_preserves_directory_without_temp_dir() {
-        let dest = Path::new("/path/to/file.txt");
-        let temp = temporary_destination_path(dest, 1, None);
+        let temp = temp_name_with_suffix(dest, None, "ABCDEF");
+        assert_eq!(temp.file_name().unwrap().to_string_lossy(), ".file.txt.ABCDEF");
         assert_eq!(temp.parent(), dest.parent());
     }
 
     #[test]
-    fn temporary_destination_path_handles_no_filename() {
-        let dest = Path::new("/");
-        let temp = temporary_destination_path(dest, 1, None);
-        assert!(temp.to_string_lossy().contains("temp"));
+    fn temp_name_with_suffix_uses_temp_dir() {
+        let dest = Path::new("/path/to/file.txt");
+        let temp_dir = Path::new("/tmp/rsync");
+        let temp = temp_name_with_suffix(dest, Some(temp_dir), "ABCDEF");
+        assert!(temp.starts_with(temp_dir));
+        // In --temp-dir the name has no leading dot (upstream get_tmpname()).
+        assert_eq!(temp.file_name().unwrap().to_string_lossy(), "file.txt.ABCDEF");
+    }
+
+    #[test]
+    fn temp_name_with_suffix_elides_leading_dot() {
+        let dest = Path::new("/path/to/.hidden");
+        let temp = temp_name_with_suffix(dest, None, "ABCDEF");
+        // A base that already starts with a dot has it elided (no double dot).
+        assert_eq!(temp.file_name().unwrap().to_string_lossy(), ".hidden.ABCDEF");
     }
 }

--- a/crates/engine/src/local_copy/executor/file/paths.rs
+++ b/crates/engine/src/local_copy/executor/file/paths.rs
@@ -143,7 +143,10 @@ mod tests {
     fn temp_name_with_suffix_uses_upstream_naming() {
         let dest = Path::new("/path/to/file.txt");
         let temp = temp_name_with_suffix(dest, None, "ABCDEF");
-        assert_eq!(temp.file_name().unwrap().to_string_lossy(), ".file.txt.ABCDEF");
+        assert_eq!(
+            temp.file_name().unwrap().to_string_lossy(),
+            ".file.txt.ABCDEF"
+        );
         assert_eq!(temp.parent(), dest.parent());
     }
 
@@ -154,7 +157,10 @@ mod tests {
         let temp = temp_name_with_suffix(dest, Some(temp_dir), "ABCDEF");
         assert!(temp.starts_with(temp_dir));
         // In --temp-dir the name has no leading dot (upstream get_tmpname()).
-        assert_eq!(temp.file_name().unwrap().to_string_lossy(), "file.txt.ABCDEF");
+        assert_eq!(
+            temp.file_name().unwrap().to_string_lossy(),
+            "file.txt.ABCDEF"
+        );
     }
 
     #[test]
@@ -162,6 +168,9 @@ mod tests {
         let dest = Path::new("/path/to/.hidden");
         let temp = temp_name_with_suffix(dest, None, "ABCDEF");
         // A base that already starts with a dot has it elided (no double dot).
-        assert_eq!(temp.file_name().unwrap().to_string_lossy(), ".hidden.ABCDEF");
+        assert_eq!(
+            temp.file_name().unwrap().to_string_lossy(),
+            ".hidden.ABCDEF"
+        );
     }
 }

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -36,7 +36,7 @@ pub use file::{
 #[cfg(test)]
 pub(crate) use file::{
     files_checksum_match, maybe_preallocate_destination, partial_destination_path,
-    temporary_destination_path,
+    temp_name_with_suffix,
 };
 pub(crate) use iconv::{
     emit_cannot_convert_filename, name_is_convertible, transcode_filename_component,

--- a/crates/engine/src/local_copy/tests/execute_direct_write.rs
+++ b/crates/engine/src/local_copy/tests/execute_direct_write.rs
@@ -60,7 +60,7 @@ fn direct_write_does_not_create_temp_files() {
     plan.execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
         .expect("copy succeeds");
 
-    // Verify no temp files remain - temp files use the `.~tmp~` prefix
+    // Verify no temp files remain - the in-flight temp is `.<name>.XXXXXX`.
     let entries: Vec<_> = fs::read_dir(&dest_dir)
         .expect("read dest dir")
         .filter_map(|e| e.ok())
@@ -169,14 +169,12 @@ fn direct_write_handles_multiple_files_in_directory() {
         b"gamma content"
     );
 
+    // upstream get_tmpname() stages the in-flight temp as a hidden `.<name>.XXXXXX`
+    // beside the destination; none should survive a successful transfer.
     let entries: Vec<_> = fs::read_dir(&dest_dir)
         .expect("read dest dir")
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with(".~tmp~")
-        })
+        .filter(|e| e.file_name().to_string_lossy().starts_with('.'))
         .collect();
     assert!(
         entries.is_empty(),

--- a/crates/engine/src/local_copy/tests/execute_long_paths.rs
+++ b/crates/engine/src/local_copy/tests/execute_long_paths.rs
@@ -89,8 +89,8 @@ fn execute_copies_file_with_long_name() {
     let dest = temp.path().join("dest");
     fs::create_dir(&source).expect("create source");
 
-    // Create file with long filename (220 bytes to leave room for temp file prefix/suffix)
-    // rsync adds ".~tmp~" prefix and ".PID.N" suffix to temp files
+    // Create file with long filename (220 bytes to leave room for the temp name)
+    // upstream get_tmpname() adds a leading `.` and a `.XXXXXX` suffix to temps.
     let long_filename = create_filename_of_length(220, ".txt");
     let source_file = source.join(&long_filename);
     fs::write(&source_file, b"long name content").expect("write source");

--- a/crates/engine/src/local_copy/tests/execute_temp_dir.rs
+++ b/crates/engine/src/local_copy/tests/execute_temp_dir.rs
@@ -841,10 +841,12 @@ fn execute_without_temp_dir_creates_temps_alongside_destination() {
         b"no temp dir test"
     );
     let parent = destination.parent().unwrap();
+    // upstream get_tmpname() stages `.dest.txt.XXXXXX` beside the destination;
+    // none should survive a successful transfer.
     let stray_temps: Vec<_> = fs::read_dir(parent)
         .expect("read dir")
         .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().contains(".~tmp~"))
+        .filter(|e| e.file_name().to_string_lossy().starts_with(".dest.txt."))
         .collect();
     assert!(
         stray_temps.is_empty(),
@@ -854,33 +856,29 @@ fn execute_without_temp_dir_creates_temps_alongside_destination() {
 
 
 #[test]
-fn execute_with_temp_dir_uses_upstream_temp_prefix() {
-    // Verify the temp file uses .~tmp~ prefix matching upstream rsync
-    let temp_path = temporary_destination_path(Path::new("/path/to/file.txt"), 42, None);
+fn execute_with_temp_dir_uses_upstream_temp_name() {
+    // upstream get_tmpname(): beside the destination the temp is `.<name>.XXXXXX`
+    // with a leading dot and a six-character suffix.
+    let temp_path = temp_name_with_suffix(Path::new("/path/to/file.txt"), None, "ABCDEF");
     let name = temp_path
         .file_name()
         .expect("file name")
         .to_string_lossy();
-    assert!(
-        name.starts_with(".~tmp~"),
-        "temp file should use .~tmp~ prefix: got {name}"
-    );
-    assert!(
-        name.contains("file.txt"),
-        "temp file name should contain original filename: got {name}"
-    );
-    assert!(
-        name.contains(&std::process::id().to_string()),
-        "temp file name should contain process ID: got {name}"
+    assert_eq!(name, ".file.txt.ABCDEF", "got {name}");
+    assert_eq!(
+        temp_path.parent().unwrap(),
+        Path::new("/path/to"),
+        "temp file stages beside the destination"
     );
 }
 
 #[test]
 fn execute_with_temp_dir_format_in_custom_directory() {
-    // When temp_dir is set, temp file should go into that directory
+    // When temp_dir is set, the temp goes into that directory with no leading
+    // dot: upstream get_tmpname() only prepends a dot without --temp-dir.
     let temp_dir = Path::new("/my/temp");
     let temp_path =
-        temporary_destination_path(Path::new("/destination/subdir/file.txt"), 1, Some(temp_dir));
+        temp_name_with_suffix(Path::new("/destination/subdir/file.txt"), Some(temp_dir), "ABCDEF");
     assert!(
         temp_path.starts_with(temp_dir),
         "temp file should be in custom temp directory"
@@ -889,12 +887,8 @@ fn execute_with_temp_dir_format_in_custom_directory() {
         .file_name()
         .expect("file name")
         .to_string_lossy();
-    assert!(
-        name.starts_with(".~tmp~"),
-        "temp file in custom dir should use .~tmp~ prefix"
-    );
-    assert!(
-        name.contains("file.txt"),
+    assert_eq!(
+        name, "file.txt.ABCDEF",
         "temp file should use filename only, not full subpath"
     );
     assert_eq!(
@@ -1100,11 +1094,12 @@ fn execute_with_temp_dir_and_checksum_mode() {
 
 #[test]
 fn execute_with_temp_dir_unique_temp_names_across_files() {
-    // Verify that multiple files in the same temp dir get unique temp names
+    // Verify that multiple files in the same temp dir get distinct temp names,
+    // driven by the per-destination basename.
     let td = Path::new("/tmp/staging");
 
-    let temp1 = temporary_destination_path(Path::new("/dest/file1.txt"), 0, Some(td));
-    let temp2 = temporary_destination_path(Path::new("/dest/file2.txt"), 1, Some(td));
+    let temp1 = temp_name_with_suffix(Path::new("/dest/file1.txt"), Some(td), "ABCDEF");
+    let temp2 = temp_name_with_suffix(Path::new("/dest/file2.txt"), Some(td), "ABCDEF");
 
     assert_ne!(
         temp1, temp2,
@@ -1115,17 +1110,18 @@ fn execute_with_temp_dir_unique_temp_names_across_files() {
 }
 
 #[test]
-fn execute_with_temp_dir_unique_counter_per_file() {
-    // Same destination file with different unique IDs should get different temp paths
+fn execute_with_temp_dir_unique_suffix_per_file() {
+    // The same destination collides only when the six-character suffix repeats;
+    // distinct suffixes (upstream's mkstemp `.XXXXXX`) yield distinct temp paths.
     let td = Path::new("/tmp/staging");
     let dest = Path::new("/dest/file.txt");
 
-    let temp1 = temporary_destination_path(dest, 0, Some(td));
-    let temp2 = temporary_destination_path(dest, 1, Some(td));
+    let temp1 = temp_name_with_suffix(dest, Some(td), "AAAAAA");
+    let temp2 = temp_name_with_suffix(dest, Some(td), "BBBBBB");
 
     assert_ne!(
         temp1, temp2,
-        "same destination with different unique IDs should get different temp paths"
+        "different suffixes should get different temp paths"
     );
 }
 

--- a/crates/engine/tests/atomic_rename.rs
+++ b/crates/engine/tests/atomic_rename.rs
@@ -42,9 +42,16 @@ fn temp_file_is_created_during_transfer() {
         dest.as_path(),
         "staging path should differ from destination"
     );
+    // upstream get_tmpname(): the in-flight temp is `.<name>.XXXXXX` beside dest.
+    let staging_name = staging.file_name().unwrap().to_string_lossy();
     assert!(
-        staging.to_string_lossy().contains(".~tmp~"),
-        "staging path should have upstream rsync .~tmp~ prefix"
+        staging_name.starts_with(".final.txt."),
+        "staging name should match upstream get_tmpname(): got {staging_name}"
+    );
+    assert_eq!(
+        staging_name.len(),
+        ".final.txt.".len() + 6,
+        "six-character mkstemp-style suffix: got {staging_name}"
     );
     assert!(!dest.exists(), "destination should not exist until commit");
 

--- a/crates/engine/tests/atomic_rename.rs
+++ b/crates/engine/tests/atomic_rename.rs
@@ -64,24 +64,6 @@ fn temp_file_is_created_during_transfer() {
 }
 
 #[test]
-fn temp_file_path_includes_process_id() {
-    let temp = tempdir().expect("tempdir");
-    let dest = temp.path().join("file.txt");
-
-    let (guard, _file) =
-        DestinationWriteGuard::new(&dest, false, None, None).expect("create guard");
-
-    let staging = guard.staging_path();
-    let pid = std::process::id();
-    assert!(
-        staging.to_string_lossy().contains(&pid.to_string()),
-        "staging path should include process ID for uniqueness"
-    );
-
-    guard.discard();
-}
-
-#[test]
 fn temp_file_path_includes_unique_counter() {
     let temp = tempdir().expect("tempdir");
     let dest = temp.path().join("file.txt");

--- a/tests/delete_during_stream_error_1895.rs
+++ b/tests/delete_during_stream_error_1895.rs
@@ -169,7 +169,19 @@ fn count_dst_tmp_files(dst: &Path) -> usize {
     while let Some(entry) = stack.pop() {
         let name = entry.file_name();
         let s = name.to_string_lossy();
-        if s.starts_with(".oc-rsync-tmp") || s.starts_with(".~tmp~") || s.contains(".oc-rsync.") {
+        // upstream get_tmpname() stages the in-flight temp as a hidden
+        // `.<name>.XXXXXX` with a six-character mkstemp-style suffix.
+        let is_get_tmpname = s.starts_with('.')
+            && s.rsplit_once('.').is_some_and(|(stem, suffix)| {
+                !stem.is_empty()
+                    && suffix.len() == 6
+                    && suffix.chars().all(|c| c.is_ascii_alphanumeric())
+            });
+        if s.starts_with(".oc-rsync-tmp")
+            || s.starts_with(".~tmp~")
+            || s.contains(".oc-rsync.")
+            || is_get_tmpname
+        {
             count += 1;
         }
         if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {


### PR DESCRIPTION
## Summary

The non-partial in-flight temp file created by the local-copy executor was
named `.~tmp~<name>.<pid>.<N>` instead of upstream rsync's `.<name>.XXXXXX`.

Upstream `receiver.c:get_tmpname()` always stages `.<name>.XXXXXX` beside the
destination (or inside `--temp-dir`) regardless of partial mode - the partial
file only appears at its final resting place on interrupt or success. Our
network receiver pipeline already used `.<name>.XXXXXX`; only the local-copy
path diverged.

## Change

- `DestinationWriteGuard::new` now stages every temp - partial and non-partial
  alike - through `temp_name_with_suffix()`, the faithful `get_tmpname()`
  implementation. Uniqueness comes from a collision-safe six-character suffix
  plus the existing `O_EXCL` (`create_new`) loop that retries on the rare
  collision, matching upstream's `mkstemp` behaviour.
- Removed the now-dead `temporary_destination_path()` helper (and its cached
  PID plumbing) and its re-exports.
- Updated the affected tests to assert the `get_tmpname()` naming
  (`.<name>.XXXXXX`, or `<name>.XXXXXX` under `--temp-dir`) rather than the old
  `.~tmp~` prefix.

## Upstream reference

`receiver.c:get_tmpname()` - stages `.<name>.XXXXXX` unconditionally; the
leading dot is only added when `--temp-dir` is not in effect, and a basename
that already starts with a dot has it elided to avoid a double dot.

## Testing

Local `cargo` runs are not available in this environment; verification runs in
CI (fmt+clippy, nextest, cross-platform matrices). No behavioural change to the
network transfer path, which already matched upstream.
