### PR TITLE
fix: back up extraneous files before the network delete pass unlinks them

### DIFF
--- a/crates/transfer/src/receiver/directory/backup.rs
+++ b/crates/transfer/src/receiver/directory/backup.rs
@@ -325,10 +325,10 @@ pub(in crate::receiver::directory) fn backup_victim(
 
 /// Backs up (when configured) then unlinks a single extraneous file victim.
 ///
-/// This is the shared file-removal step for the `--delete` sites that lack a
-/// [`ReceiverContext`] to call [`ReceiverContext::backup_victim_before_delete`]:
-/// the parallel scan workers and the capped serial executor. When the backup
-/// took ownership of the victim the direct unlink is skipped.
+/// The shared file-removal step for every `--delete` site: the immediate
+/// parallel scan, the deferred `--delete-delay` executor, and the capped
+/// serial executor. When the backup took ownership of the victim the direct
+/// unlink is skipped.
 ///
 /// upstream: `delete.c:165-174` - back up under the guard, otherwise unlink.
 #[cfg(unix)]
@@ -427,37 +427,6 @@ impl ReceiverContext {
         Ok(true)
     }
 
-    /// Backs up an extraneous destination file before the `--delete` pass
-    /// unlinks it, applying upstream's `is_backup_file` guard.
-    ///
-    /// Returns `Ok(true)` when the victim was preserved into the backup area and
-    /// its original path is already clear (the caller must NOT unlink again),
-    /// `Ok(false)` when no backup applies, and `Err` when the backup mechanism
-    /// failed (the caller treats that as a failed deletion).
-    ///
-    /// # Upstream Reference
-    ///
-    /// - `delete.c:165-170` - the `make_backups > 0 && (backup_dir ||
-    ///   !is_backup_file(fbuf))` guard around `make_backup(fbuf, True)`.
-    #[cfg(unix)]
-    pub(in crate::receiver) fn backup_victim_before_delete(
-        &self,
-        existing: &Path,
-        relative_path: &Path,
-        dest_dir: &Path,
-        sandbox: Option<&fast_io::DirSandbox>,
-    ) -> io::Result<bool> {
-        backup_victim(
-            self.config.flags.backup,
-            self.config.backup_dir.as_deref().map(Path::new),
-            self.config.effective_backup_suffix(),
-            existing,
-            relative_path,
-            dest_dir,
-            sandbox,
-        )
-    }
-
     /// Windows variant: no dirfd sandbox, so the post-hard-link removal uses a
     /// path-based `remove_file`, matching the Windows symlink-create path.
     #[cfg(windows)]
@@ -481,24 +450,6 @@ impl ReceiverContext {
             OsStr::new(self.config.effective_backup_suffix()),
         )?;
         Ok(true)
-    }
-
-    /// Windows variant of [`backup_victim_before_delete`]: no dirfd sandbox.
-    ///
-    /// [`backup_victim_before_delete`]: Self::backup_victim_before_delete
-    #[cfg(windows)]
-    pub(in crate::receiver) fn backup_victim_before_delete(
-        &self,
-        existing: &Path,
-        dest_dir: &Path,
-    ) -> io::Result<bool> {
-        backup_victim(
-            self.config.flags.backup,
-            self.config.backup_dir.as_deref().map(Path::new),
-            self.config.effective_backup_suffix(),
-            existing,
-            dest_dir,
-        )
     }
 }
 

--- a/crates/transfer/src/receiver/directory/backup.rs
+++ b/crates/transfer/src/receiver/directory/backup.rs
@@ -22,6 +22,8 @@
 //! - `backup.c:352-353` - `INFO_GTE(BACKUP, 1)` "backed up %s to %s".
 
 #[cfg(any(unix, windows))]
+use std::ffi::OsStr;
+#[cfg(any(unix, windows))]
 use std::fs;
 #[cfg(any(unix, windows))]
 use std::io;
@@ -176,6 +178,212 @@ fn report_backup(
     );
 }
 
+/// Reports whether `name` already ends with the backup `suffix`.
+///
+/// upstream: `delete.c:37-41` `is_backup_file()` - a non-empty suffix that
+/// matches the trailing bytes of the name, with at least one byte preceding it
+/// (`k = strlen(fn) - backup_suffix_len; k > 0 && strcmp(fn+k, suffix) == 0`).
+#[cfg(any(unix, windows))]
+pub(in crate::receiver::directory) fn is_backup_file(name: &OsStr, suffix: &str) -> bool {
+    if suffix.is_empty() {
+        return false;
+    }
+    let name = name.as_encoded_bytes();
+    let suffix = suffix.as_bytes();
+    name.len() > suffix.len() && name.ends_with(suffix)
+}
+
+/// Moves `existing` into its computed backup location, emits the trace, and
+/// clears the original path so the caller need not unlink again.
+///
+/// Shared by the pre-replace and pre-delete backup callers. Only the hard-link
+/// placement leaves the original behind (upstream's copy tier, `ok == 2`); the
+/// rename and cross-device copy tiers already free the path.
+///
+/// upstream: `delete.c:167-170` - `make_backup(fbuf, True)` then, when the copy
+/// tier left the original in place (`ok == 2`), `robust_unlink(fbuf)`.
+#[cfg(unix)]
+fn place_report_and_clear(
+    existing: &Path,
+    relative_path: &Path,
+    dest_dir: &Path,
+    backup_dir: Option<&Path>,
+    suffix: &OsStr,
+    sandbox: Option<&fast_io::DirSandbox>,
+) -> io::Result<()> {
+    let backup_path = engine::compute_backup_path(dest_dir, existing, None, backup_dir, suffix);
+    let placement = place_existing_backup(existing, &backup_path)?;
+    report_backup(&placement, existing, &backup_path, dest_dir);
+    if matches!(placement, BackupPlacement::Hardlinked) {
+        // upstream: delete.c:169-170 - the hard-link tier is upstream's `ok == 2`
+        // here: the original survives as a second link and must be unlinked.
+        // SEC-1.g: route through the sandbox dirfd when the parent is the root.
+        let _ = fast_io::unlink_via_sandbox_or_fallback(
+            sandbox,
+            dest_dir,
+            relative_path,
+            existing,
+            fast_io::UnlinkFlags::File,
+        );
+    }
+    Ok(())
+}
+
+/// Windows variant of [`place_report_and_clear`]: no dirfd sandbox, so the
+/// leftover-original unlink is path-based.
+#[cfg(windows)]
+fn place_report_and_clear(
+    existing: &Path,
+    dest_dir: &Path,
+    backup_dir: Option<&Path>,
+    suffix: &OsStr,
+) -> io::Result<()> {
+    let backup_path = engine::compute_backup_path(dest_dir, existing, None, backup_dir, suffix);
+    let placement = place_existing_backup(existing, &backup_path)?;
+    report_backup(&placement, existing, &backup_path, dest_dir);
+    if matches!(placement, BackupPlacement::Hardlinked) {
+        let _ = fs::remove_file(existing);
+    }
+    Ok(())
+}
+
+/// Backs up an extraneous destination file before the `--delete` pass unlinks
+/// it, applying upstream's `is_backup_file` guard.
+///
+/// Returns `Ok(true)` when the victim was preserved into the backup area and
+/// its original path is now clear (the caller must NOT unlink again); `Ok(false)`
+/// when no backup applies (`--backup` off, an already-suffixed name with no
+/// `--backup-dir`, or nothing at `existing`); `Err` when the backup mechanism
+/// failed, which the caller treats as a failed deletion (upstream `DR_FAILURE`).
+///
+/// upstream: `delete.c:165-170` - `make_backups > 0 && !(flags & DEL_FOR_BACKUP)
+/// && (backup_dir || !is_backup_file(fbuf))` guards `make_backup(fbuf, True)`.
+#[cfg(unix)]
+pub(in crate::receiver::directory) fn backup_victim(
+    backup: bool,
+    backup_dir: Option<&Path>,
+    suffix: &str,
+    existing: &Path,
+    relative_path: &Path,
+    dest_dir: &Path,
+    sandbox: Option<&fast_io::DirSandbox>,
+) -> io::Result<bool> {
+    if !backup {
+        return Ok(false);
+    }
+    // upstream: delete.c:165 - DEL_FOR_BACKUP is never set on this delete path,
+    // so the guard reduces to `backup_dir || !is_backup_file(name)`: a file
+    // already ending in the suffix is unlinked directly unless a --backup-dir
+    // sends it to the separate directory (no `<name><suffix><suffix>`).
+    if backup_dir.is_none()
+        && existing
+            .file_name()
+            .is_some_and(|name| is_backup_file(name, suffix))
+    {
+        return Ok(false);
+    }
+    // upstream: backup.c:236 - a vanished source (x_lstat != 0) needs no backup.
+    if fs::symlink_metadata(existing).is_err() {
+        return Ok(false);
+    }
+    place_report_and_clear(
+        existing,
+        relative_path,
+        dest_dir,
+        backup_dir,
+        OsStr::new(suffix),
+        sandbox,
+    )?;
+    Ok(true)
+}
+
+/// Windows variant of [`backup_victim`]: no dirfd sandbox is threaded through.
+#[cfg(windows)]
+pub(in crate::receiver::directory) fn backup_victim(
+    backup: bool,
+    backup_dir: Option<&Path>,
+    suffix: &str,
+    existing: &Path,
+    dest_dir: &Path,
+) -> io::Result<bool> {
+    if !backup {
+        return Ok(false);
+    }
+    if backup_dir.is_none()
+        && existing
+            .file_name()
+            .is_some_and(|name| is_backup_file(name, suffix))
+    {
+        return Ok(false);
+    }
+    if fs::symlink_metadata(existing).is_err() {
+        return Ok(false);
+    }
+    place_report_and_clear(existing, dest_dir, backup_dir, OsStr::new(suffix))?;
+    Ok(true)
+}
+
+/// Backs up (when configured) then unlinks a single extraneous file victim.
+///
+/// This is the shared file-removal step for the `--delete` sites that lack a
+/// [`ReceiverContext`] to call [`ReceiverContext::backup_victim_before_delete`]:
+/// the parallel scan workers and the capped serial executor. When the backup
+/// took ownership of the victim the direct unlink is skipped.
+///
+/// upstream: `delete.c:165-174` - back up under the guard, otherwise unlink.
+#[cfg(unix)]
+pub(in crate::receiver::directory) fn remove_file_victim(
+    backup: bool,
+    backup_dir: Option<&Path>,
+    suffix: &str,
+    existing: &Path,
+    relative_path: &Path,
+    dest_dir: &Path,
+    sandbox: Option<&fast_io::DirSandbox>,
+) -> io::Result<()> {
+    if backup_victim(
+        backup,
+        backup_dir,
+        suffix,
+        existing,
+        relative_path,
+        dest_dir,
+        sandbox,
+    )? {
+        return Ok(());
+    }
+    fast_io::unlink_via_sandbox_or_fallback(
+        sandbox,
+        dest_dir,
+        relative_path,
+        existing,
+        fast_io::UnlinkFlags::File,
+    )
+}
+
+/// Non-Unix variant of [`remove_file_victim`]: path-based removal, with the
+/// backup step wired only on Windows where the mechanism is supported.
+#[cfg(not(unix))]
+pub(in crate::receiver::directory) fn remove_file_victim(
+    backup: bool,
+    backup_dir: Option<&std::path::Path>,
+    suffix: &str,
+    existing: &std::path::Path,
+    dest_dir: &std::path::Path,
+) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        if backup_victim(backup, backup_dir, suffix, existing, dest_dir)? {
+            return Ok(());
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = (backup, backup_dir, suffix, dest_dir);
+    }
+    std::fs::remove_file(existing)
+}
+
 impl ReceiverContext {
     /// Backs up an existing destination entry before it is replaced by a fresh
     /// symlink, FIFO, socket, or device node.
@@ -208,34 +416,46 @@ impl ReceiverContext {
             return Ok(false);
         }
 
-        let backup_path = engine::compute_backup_path(
-            dest_dir,
+        place_report_and_clear(
             existing,
-            None,
+            relative_path,
+            dest_dir,
             self.config.backup_dir.as_deref().map(Path::new),
-            std::ffi::OsStr::new(self.config.effective_backup_suffix()),
-        );
-
-        let placement = place_existing_backup(existing, &backup_path)?;
-        report_backup(&placement, existing, &backup_path, dest_dir);
-
-        if matches!(placement, BackupPlacement::Hardlinked) {
-            // The original still exists as a second link; remove it so the new
-            // node can take its place. upstream: atomic_create's rename over
-            // `fname` does this implicitly.
-            //
-            // SEC-1.g: route the removal through the sandbox dirfd when the
-            // destination parent is the sandbox root so a TOCTOU swap on the
-            // original path cannot redirect the unlink.
-            let _ = fast_io::unlink_via_sandbox_or_fallback(
-                sandbox,
-                dest_dir,
-                relative_path,
-                existing,
-                fast_io::UnlinkFlags::File,
-            );
-        }
+            OsStr::new(self.config.effective_backup_suffix()),
+            sandbox,
+        )?;
         Ok(true)
+    }
+
+    /// Backs up an extraneous destination file before the `--delete` pass
+    /// unlinks it, applying upstream's `is_backup_file` guard.
+    ///
+    /// Returns `Ok(true)` when the victim was preserved into the backup area and
+    /// its original path is already clear (the caller must NOT unlink again),
+    /// `Ok(false)` when no backup applies, and `Err` when the backup mechanism
+    /// failed (the caller treats that as a failed deletion).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:165-170` - the `make_backups > 0 && (backup_dir ||
+    ///   !is_backup_file(fbuf))` guard around `make_backup(fbuf, True)`.
+    #[cfg(unix)]
+    pub(in crate::receiver) fn backup_victim_before_delete(
+        &self,
+        existing: &Path,
+        relative_path: &Path,
+        dest_dir: &Path,
+        sandbox: Option<&fast_io::DirSandbox>,
+    ) -> io::Result<bool> {
+        backup_victim(
+            self.config.flags.backup,
+            self.config.backup_dir.as_deref().map(Path::new),
+            self.config.effective_backup_suffix(),
+            existing,
+            relative_path,
+            dest_dir,
+            sandbox,
+        )
     }
 
     /// Windows variant: no dirfd sandbox, so the post-hard-link removal uses a
@@ -254,21 +474,31 @@ impl ReceiverContext {
             return Ok(false);
         }
 
-        let backup_path = engine::compute_backup_path(
-            dest_dir,
+        place_report_and_clear(
             existing,
-            None,
+            dest_dir,
             self.config.backup_dir.as_deref().map(Path::new),
-            std::ffi::OsStr::new(self.config.effective_backup_suffix()),
-        );
-
-        let placement = place_existing_backup(existing, &backup_path)?;
-        report_backup(&placement, existing, &backup_path, dest_dir);
-
-        if matches!(placement, BackupPlacement::Hardlinked) {
-            let _ = fs::remove_file(existing);
-        }
+            OsStr::new(self.config.effective_backup_suffix()),
+        )?;
         Ok(true)
+    }
+
+    /// Windows variant of [`backup_victim_before_delete`]: no dirfd sandbox.
+    ///
+    /// [`backup_victim_before_delete`]: Self::backup_victim_before_delete
+    #[cfg(windows)]
+    pub(in crate::receiver) fn backup_victim_before_delete(
+        &self,
+        existing: &Path,
+        dest_dir: &Path,
+    ) -> io::Result<bool> {
+        backup_victim(
+            self.config.flags.backup,
+            self.config.backup_dir.as_deref().map(Path::new),
+            self.config.effective_backup_suffix(),
+            existing,
+            dest_dir,
+        )
     }
 }
 

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -468,18 +468,15 @@ impl ReceiverContext {
                 // gone, so the direct unlink is skipped.
                 #[cfg(unix)]
                 {
-                    match self.backup_victim_before_delete(&path, &entry.rel, dest_dir, sandbox_ref)
-                    {
-                        Ok(true) => Ok(()),
-                        Ok(false) => fast_io::unlink_via_sandbox_or_fallback(
-                            sandbox_ref,
-                            dest_dir,
-                            &entry.rel,
-                            &path,
-                            fast_io::UnlinkFlags::File,
-                        ),
-                        Err(e) => Err(e),
-                    }
+                    super::backup::remove_file_victim(
+                        self.config.flags.backup,
+                        self.config.backup_dir.as_deref().map(Path::new),
+                        self.config.effective_backup_suffix(),
+                        &path,
+                        &entry.rel,
+                        dest_dir,
+                        sandbox_ref,
+                    )
                 }
                 #[cfg(not(unix))]
                 {

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -463,19 +463,33 @@ impl ReceiverContext {
                     std::fs::remove_dir_all(&path)
                 }
             } else {
+                // upstream: delete.c:165-174 - back up the victim (when
+                // --backup) before unlinking; a preserved victim is already
+                // gone, so the direct unlink is skipped.
                 #[cfg(unix)]
                 {
-                    fast_io::unlink_via_sandbox_or_fallback(
-                        sandbox_ref,
-                        dest_dir,
-                        &entry.rel,
-                        &path,
-                        fast_io::UnlinkFlags::File,
-                    )
+                    match self.backup_victim_before_delete(&path, &entry.rel, dest_dir, sandbox_ref)
+                    {
+                        Ok(true) => Ok(()),
+                        Ok(false) => fast_io::unlink_via_sandbox_or_fallback(
+                            sandbox_ref,
+                            dest_dir,
+                            &entry.rel,
+                            &path,
+                            fast_io::UnlinkFlags::File,
+                        ),
+                        Err(e) => Err(e),
+                    }
                 }
                 #[cfg(not(unix))]
                 {
-                    std::fs::remove_file(&path)
+                    super::backup::remove_file_victim(
+                        self.config.flags.backup,
+                        self.config.backup_dir.as_deref().map(Path::new),
+                        self.config.effective_backup_suffix(),
+                        &path,
+                        dest_dir,
+                    )
                 }
             };
             match result {
@@ -829,6 +843,14 @@ impl ReceiverContext {
         #[cfg(unix)]
         let sandbox_for_workers = sandbox.cloned();
 
+        // upstream: delete.c:165-174 - each file victim is backed up (when
+        // --backup) before it is unlinked. The workers hold no `self`, so carry
+        // the backup settings as owned values the `move` closure can consult.
+        let backup_enabled = self.config.flags.backup;
+        let backup_dir_owned: Option<PathBuf> =
+            self.config.backup_dir.as_deref().map(PathBuf::from);
+        let backup_suffix: String = self.config.effective_backup_suffix().to_owned();
+
         // Collect deleted relative paths for post-parallel itemize emission.
         // The writer is not Send, so MSG_INFO frames are emitted sequentially
         // after parallel deletion completes.
@@ -1069,20 +1091,31 @@ impl ReceiverContext {
                                 std::fs::remove_dir_all(&path)
                             }
                         } else {
-                            // SEC-1.q2 audit row #7
+                            // upstream: delete.c:165-174 - back up the file
+                            // victim (when --backup) before unlinking it.
+                            // SEC-1.q2 audit row #7: the fallback unlink still
+                            // routes through the sandbox dirfd.
                             #[cfg(unix)]
                             {
-                                fast_io::unlink_via_sandbox_or_fallback(
-                                    sandbox_ref,
-                                    &dest_dir_owned,
-                                    &entry_rel,
+                                super::backup::remove_file_victim(
+                                    backup_enabled,
+                                    backup_dir_owned.as_deref(),
+                                    &backup_suffix,
                                     &path,
-                                    fast_io::UnlinkFlags::File,
+                                    &entry_rel,
+                                    &dest_dir_owned,
+                                    sandbox_ref,
                                 )
                             }
                             #[cfg(not(unix))]
                             {
-                                std::fs::remove_file(&path)
+                                super::backup::remove_file_victim(
+                                    backup_enabled,
+                                    backup_dir_owned.as_deref(),
+                                    &backup_suffix,
+                                    &path,
+                                    &dest_dir_owned,
+                                )
                             }
                         };
 
@@ -1243,7 +1276,6 @@ impl ReceiverContext {
         #[cfg(unix)] boundary_dev: Option<u64>,
     ) -> io::Result<(DeleteStats, bool, i32)> {
         let mut state = CappedDeleteState {
-            #[cfg(unix)]
             dest_dir,
             #[cfg(unix)]
             sandbox,
@@ -1257,6 +1289,9 @@ impl ReceiverContext {
             emit_itemize: self.should_emit_itemize(),
             server_mode: !self.config.connection.client_mode,
             protocol: self.protocol.as_u8(),
+            backup: self.config.flags.backup,
+            backup_dir: self.config.backup_dir.as_deref().map(PathBuf::from),
+            backup_suffix: self.config.effective_backup_suffix().to_owned(),
             writer,
         };
 
@@ -1396,9 +1431,8 @@ struct CappedCandidate {
 
 /// Mutable bookkeeping threaded through the recursive capped deletion walk.
 struct CappedDeleteState<'w, W: ?Sized> {
-    // Only read by the Unix sandbox-anchored scan path; the non-Unix scan
-    // walks `target_path` directly, so gate the field like `sandbox` below.
-    #[cfg(unix)]
+    /// Deletion root. Anchors the Unix sandbox-anchored scan path and the
+    /// per-victim backup-path computation on every platform.
     dest_dir: &'w Path,
     #[cfg(unix)]
     sandbox: Option<&'w std::sync::Arc<fast_io::DirSandbox>>,
@@ -1423,6 +1457,12 @@ struct CappedDeleteState<'w, W: ?Sized> {
     server_mode: bool,
     /// Negotiated protocol version, gating the `>= 29` `MSG_DELETED` path.
     protocol: u8,
+    /// `--backup`: back up each file victim before unlinking it.
+    backup: bool,
+    /// `--backup-dir` destination (relative to the deletion root, or absolute).
+    backup_dir: Option<PathBuf>,
+    /// Effective backup suffix (`~` by default, `""` when `--backup-dir` is set).
+    backup_suffix: String,
     writer: &'w mut W,
 }
 
@@ -1603,22 +1643,31 @@ impl<W: crate::writer::MsgInfoSender + ?Sized> CappedDeleteState<'_, W> {
         }
     }
 
-    /// Performs the unlink/rmdir syscall, anchored through the sandbox helper
-    /// on Unix.
+    /// Performs the rmdir (directory) or backup-then-unlink (file) removal for
+    /// one leaf, anchored through the sandbox helper on Unix.
+    ///
+    /// A file victim is first backed up when `--backup` is set (upstream
+    /// delete.c:165-174); directories are never backed up here.
     fn raw_unlink(&self, rel: &Path, path: &Path, is_dir: bool) -> io::Result<()> {
         #[cfg(unix)]
         {
-            let flags = if is_dir {
-                fast_io::UnlinkFlags::Dir
-            } else {
-                fast_io::UnlinkFlags::File
-            };
-            fast_io::unlink_via_sandbox_or_fallback(
-                self.sandbox.map(|a| &**a),
-                self.dest_dir,
-                rel,
+            if is_dir {
+                return fast_io::unlink_via_sandbox_or_fallback(
+                    self.sandbox.map(|a| &**a),
+                    self.dest_dir,
+                    rel,
+                    path,
+                    fast_io::UnlinkFlags::Dir,
+                );
+            }
+            super::backup::remove_file_victim(
+                self.backup,
+                self.backup_dir.as_deref(),
+                &self.backup_suffix,
                 path,
-                flags,
+                rel,
+                self.dest_dir,
+                self.sandbox.map(|a| &**a),
             )
         }
         #[cfg(not(unix))]
@@ -1627,7 +1676,13 @@ impl<W: crate::writer::MsgInfoSender + ?Sized> CappedDeleteState<'_, W> {
             if is_dir {
                 std::fs::remove_dir(path)
             } else {
-                std::fs::remove_file(path)
+                super::backup::remove_file_victim(
+                    self.backup,
+                    self.backup_dir.as_deref(),
+                    &self.backup_suffix,
+                    path,
+                    self.dest_dir,
+                )
             }
         }
     }

--- a/crates/transfer/src/receiver/tests/file_list/delete_backup.rs
+++ b/crates/transfer/src/receiver/tests/file_list/delete_backup.rs
@@ -1,0 +1,217 @@
+//! Backup-before-delete on the network receiver's delete pass.
+//!
+//! WHY this matters: over SSH/daemon the receiver drives `--delete` locally.
+//! Upstream backs up each extraneous FILE before unlinking it whenever
+//! `--backup`/`--backup-dir` is set, rather than losing the data outright
+//! (`delete.c:165-174`). These tests pin that behaviour at every file-victim
+//! removal site the receiver uses: the immediate parallel pass
+//! (`delete_extraneous_files`), the deferred `--delete-delay` executor
+//! (`execute_delayed_deletions`), and the capped serial executor
+//! (`--max-delete`). Directories are never backed up here, matching upstream.
+//!
+//! Deterministic-order note: sibling `~` backups are created mid-pass, so the
+//! default-suffix cases are exercised on the two paths that iterate a fixed
+//! snapshot (the delayed victim list and the capped candidate list), never the
+//! streaming `read_dir` fallback. The `--backup-dir` case writes outside the
+//! destination and so is safe on the parallel path.
+
+use std::ffi::OsString;
+
+use protocol::flist::FileEntry;
+
+use super::super::super::ReceiverContext;
+use super::super::support::{TestDeletionWriter, test_config, test_handshake};
+
+/// Builds a receiver whose file list keeps `keep.txt` (so any other
+/// destination entry is an extraneous deletion candidate), with the supplied
+/// backup settings applied. `late_delete` selects the deferred `--delete-delay`
+/// scheduling; `max_delete` routes the immediate pass through the capped serial
+/// executor.
+fn build_receiver(
+    dest: &std::path::Path,
+    backup: bool,
+    backup_dir: Option<&str>,
+    late_delete: bool,
+    max_delete: Option<u64>,
+) -> ReceiverContext {
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = true;
+    config.flags.backup = backup;
+    config.deletion.delete_after = false;
+    config.deletion.late_delete = late_delete;
+    config.deletion.max_delete = max_delete;
+    config.backup_dir = backup_dir.map(str::to_owned);
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("keep.txt".into(), 6, 0o644));
+    ctx
+}
+
+/// Default `~` suffix, exercised on the deferred `--delete-delay` executor
+/// (a fixed victim list, so the sibling backup is never re-scanned). The
+/// extraneous file must land at `<name>~` and its original be gone; the listed
+/// file must survive.
+#[test]
+fn delayed_delete_backs_up_victim_with_default_suffix() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let dest = dir.path();
+    std::fs::write(dest.join("stale.txt"), b"extraneous").unwrap();
+    std::fs::write(dest.join("keep.txt"), b"listed").unwrap();
+
+    let ctx = build_receiver(dest, true, None, true, None);
+    let mut writer = TestDeletionWriter;
+
+    let (victims, _io) = ctx
+        .collect_delayed_deletions(dest, None, &mut writer)
+        .unwrap();
+    let (stats, _io) = ctx
+        .execute_delayed_deletions(dest, None, &victims, &mut writer)
+        .unwrap();
+
+    assert!(
+        !dest.join("stale.txt").exists(),
+        "the extraneous original must be gone after the delete pass"
+    );
+    assert!(
+        dest.join("stale.txt~").exists(),
+        "the victim must be preserved at its default `~` backup path"
+    );
+    assert_eq!(
+        std::fs::read(dest.join("stale.txt~")).unwrap(),
+        b"extraneous",
+        "the backup must carry the victim's original bytes"
+    );
+    assert_eq!(stats.files, 1, "exactly one extraneous file deleted");
+    assert!(dest.join("keep.txt").exists(), "listed file must survive");
+}
+
+/// `--backup-dir` to an external directory, exercised on the immediate parallel
+/// pass. The victim must be relocated under the backup directory (suffix is
+/// empty when `--backup-dir` is set) with its original removed.
+#[test]
+fn immediate_delete_backs_up_victim_into_backup_dir() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let dest = dir.path();
+    let backup_root = tempfile::TempDir::new().unwrap();
+    std::fs::write(dest.join("stale.txt"), b"extraneous").unwrap();
+    std::fs::write(dest.join("keep.txt"), b"listed").unwrap();
+
+    let ctx = build_receiver(
+        dest,
+        true,
+        Some(backup_root.path().to_str().unwrap()),
+        false,
+        None,
+    );
+    let mut writer = TestDeletionWriter;
+
+    let (stats, _limit, _io) = ctx
+        .delete_extraneous_files(dest, None, &mut writer)
+        .unwrap();
+
+    assert!(
+        !dest.join("stale.txt").exists(),
+        "the extraneous original must be gone after the delete pass"
+    );
+    assert!(
+        backup_root.path().join("stale.txt").exists(),
+        "the victim must be relocated into the --backup-dir"
+    );
+    assert!(
+        !dest.join("stale.txt~").exists(),
+        "with --backup-dir the suffix is empty; no sibling `~` file is made"
+    );
+    assert_eq!(stats.files, 1, "exactly one extraneous file deleted");
+    assert!(dest.join("keep.txt").exists(), "listed file must survive");
+}
+
+/// A victim already named like a backup (`foo~`) with NO `--backup-dir` must be
+/// unlinked directly, never re-backed-up to `foo~~`
+/// (upstream `is_backup_file` guard, `delete.c:165`).
+#[test]
+fn already_suffixed_victim_is_not_rebacked_up() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let dest = dir.path();
+    std::fs::write(dest.join("foo~"), b"old backup").unwrap();
+    std::fs::write(dest.join("keep.txt"), b"listed").unwrap();
+
+    let ctx = build_receiver(dest, true, None, false, None);
+    let mut writer = TestDeletionWriter;
+
+    let (stats, _limit, _io) = ctx
+        .delete_extraneous_files(dest, None, &mut writer)
+        .unwrap();
+
+    assert!(
+        !dest.join("foo~").exists(),
+        "an already-suffixed victim must be unlinked directly"
+    );
+    assert!(
+        !dest.join("foo~~").exists(),
+        "it must NOT be re-backed-up to `foo~~` (is_backup_file guard)"
+    );
+    assert_eq!(stats.files, 1, "the victim is still counted as deleted");
+    assert!(dest.join("keep.txt").exists(), "listed file must survive");
+}
+
+/// With `--backup` disabled, an extraneous file is unlinked outright and no
+/// backup is ever created.
+#[test]
+fn delete_without_backup_leaves_no_backup() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let dest = dir.path();
+    std::fs::write(dest.join("stale.txt"), b"extraneous").unwrap();
+    std::fs::write(dest.join("keep.txt"), b"listed").unwrap();
+
+    let ctx = build_receiver(dest, false, None, false, None);
+    let mut writer = TestDeletionWriter;
+
+    let (stats, _limit, _io) = ctx
+        .delete_extraneous_files(dest, None, &mut writer)
+        .unwrap();
+
+    assert!(
+        !dest.join("stale.txt").exists(),
+        "the extraneous file is still deleted with backup off"
+    );
+    assert!(
+        !dest.join("stale.txt~").exists(),
+        "no backup must be created when --backup is off"
+    );
+    assert_eq!(stats.files, 1, "exactly one extraneous file deleted");
+    assert!(dest.join("keep.txt").exists(), "listed file must survive");
+}
+
+/// The capped serial executor (`--max-delete`) must also back up file victims
+/// before unlinking them. Its candidate list is a fixed snapshot, so the
+/// default-suffix sibling backup is safe here too.
+#[test]
+fn capped_delete_backs_up_victim_with_default_suffix() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let dest = dir.path();
+    std::fs::write(dest.join("stale.txt"), b"extraneous").unwrap();
+    std::fs::write(dest.join("keep.txt"), b"listed").unwrap();
+
+    let ctx = build_receiver(dest, true, None, false, Some(100));
+    let mut writer = TestDeletionWriter;
+
+    let (stats, _limit, _io) = ctx
+        .delete_extraneous_files(dest, None, &mut writer)
+        .unwrap();
+
+    assert!(
+        !dest.join("stale.txt").exists(),
+        "the capped executor must remove the extraneous original"
+    );
+    assert!(
+        dest.join("stale.txt~").exists(),
+        "the capped executor must preserve the victim at `<name>~`"
+    );
+    assert_eq!(stats.files, 1, "exactly one extraneous file deleted");
+    assert!(dest.join("keep.txt").exists(), "listed file must survive");
+}

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -26,11 +26,16 @@
 //! - [`delete_timing`] - early vs late (`--delete-after` / `--delete-delay`)
 //!   delete-pass scheduling and the dest-side `.rsync-filter` protection
 //!   invariant that makes deferral load-bearing.
+//! - [`delete_backup`] - `--backup` / `--backup-dir` preservation of each
+//!   extraneous file victim before the receiver's delete pass unlinks it,
+//!   across the immediate, delayed, and capped removal sites.
 //! - [`iconv_wire_order`] - regression coverage for the receiver-side
 //!   `--iconv` ordering invariant (file_list stays in sender wire-emit
 //!   order, never re-sorted on local-charset bytes).
 
 mod dedup;
+#[cfg(unix)]
+mod delete_backup;
 mod delete_pipeline_hook;
 mod delete_timing;
 mod filter_chain;


### PR DESCRIPTION
## Summary

Over SSH/daemon the receiver drives `--delete` locally, but its delete pass
unlinked extraneous destination files directly and never backed them up, even
with `--backup`/`--backup-dir` set - a silent data-loss divergence from
upstream. The local-copy path already preserves victims; this fixes the
remote-vs-local asymmetry in `crates/transfer/src/receiver/directory/`.

Upstream backs up each non-directory victim before removing it
(`delete.c:165-174`): under the
`make_backups > 0 && !(flags & DEL_FOR_BACKUP) && (backup_dir || !is_backup_file(fbuf))`
guard it calls `make_backup(fbuf, True)`, and only the copy tier that leaves the
original in place (`ok == 2`) then `robust_unlink()`s it.

## Changes

A shared `backup_victim` helper (with `is_backup_file` guard) is added beside the
existing non-regular backup machinery and reuses the same
placement/report/clear step as the pre-replace backup path (refactored onto a
common helper). It is wired at every file-victim removal site in `deletion.rs`:

1. **Immediate parallel pass** (`run_delete_scan` worker) - the common
   `--delete-before`/`--delete-during`/`--delete-after` path.
2. **Deferred `--delete-delay` executor** (`execute_delayed_deletions`) - the
   late unlink of the pre-collected victim list.
3. **Capped serial executor** (`--max-delete` / `--one-file-system`,
   `raw_unlink`).

At each site a preserved victim is counted and reported as deleted exactly as
before; only the physical removal changes. Directories are never backed up
here, matching upstream.

## Tests

New `receiver::tests::file_list::delete_backup` module:

- default `~` suffix victim is preserved at `<name>~` (deferred executor) and by
  the capped executor;
- `--backup-dir` relocates the victim into the backup directory (parallel pass);
- an already-suffixed victim (`foo~`) with no `--backup-dir` is unlinked
  directly, never re-backed-up to `foo~~` (the `is_backup_file` guard);
- with `--backup` off, nothing is backed up.

Validated on aarch64 Linux: `cargo fmt -p transfer -- --check`,
`cargo clippy -p transfer --all-targets` (clean), and
`cargo nextest run -p transfer -E 'test(delet) or test(backup)'` (111 passed,
including the 5 new tests).

Upstream reference: `delete.c:165` (the `make_backup` guard) and `delete.c:37`
(`is_backup_file`).
