### PR TITLE
refactor: remove dead calculate_checksum_length

### DIFF
--- a/crates/signature/README.md
+++ b/crates/signature/README.md
@@ -16,7 +16,6 @@ using rolling and strong checksums, with block sizing from upstream `generator.c
 - `calculate_signature_layout` - determines block size and checksum length from file size
 - `generate_file_signature` - reads file blocks and computes all checksums
 - `calculate_block_length` - standalone block size calculation (upstream `sum_sizes_sqroot`)
-- `calculate_checksum_length` - strong checksum length for given file/block size
 - `calculate_checksum_count` - number of blocks for a given file size
 
 ## Modules

--- a/crates/signature/src/block_size.rs
+++ b/crates/signature/src/block_size.rs
@@ -18,7 +18,7 @@
 //! # Examples
 //!
 //! ```rust
-//! use signature::block_size::{calculate_block_length, calculate_checksum_length};
+//! use signature::block_size::calculate_block_length;
 //!
 //! // Small file uses default block size
 //! let block_len = calculate_block_length(1024, 31, None);
@@ -32,11 +32,11 @@
 //! // User can override with --block-size
 //! let block_len = calculate_block_length(10 * 1024 * 1024, 31, Some(4096));
 //! assert_eq!(block_len, 4096);
-//!
-//! // Checksum length scales with file size and block size
-//! let checksum_len = calculate_checksum_length(1024 * 1024, 1024, 31, 2);
-//! assert!(checksum_len >= 2);
 //! ```
+//!
+//! Strong checksum length (`s2length`) is computed by
+//! `calculate_signature_layout`, which applies the negotiated
+//! transfer-digest cap upstream requires; see the `layout` module.
 
 /// Default block length used by rsync for small files.
 ///
@@ -60,12 +60,6 @@ pub const MAX_BLOCK_SIZE_OLD: u32 = 1 << 29;
 /// While rsync doesn't enforce this minimum in the protocol, blocks smaller
 /// than 64 bytes are impractical due to overhead.
 pub const MIN_BLOCK_SIZE: u32 = 64;
-
-/// Bias constant used in strong checksum length calculation.
-///
-/// This constant affects how checksum lengths scale with file size.
-/// Mirrors `BLOCKSUM_BIAS` in upstream rsync.
-const BLOCKSUM_BIAS: i32 = 10;
 
 /// Abbreviated strong checksum length used during phase 1 of the transfer.
 ///
@@ -144,93 +138,6 @@ pub fn calculate_block_length(
     };
 
     block_length.min(max_block)
-}
-
-/// Calculates the strong checksum length based on file size and block size.
-///
-/// This implements the checksum length heuristic from upstream rsync's
-/// `generator.c:sum_sizes_sqroot()` (lines 725-738), which adjusts the
-/// checksum length to balance collision probability against overhead.
-///
-/// Behavior depends on the transfer phase:
-/// - **Phase 1** (`requested_checksum_length = SHORT_SUM_LENGTH = 2`): dynamically
-///   computes a length between 2-16 bytes. Smaller files get shorter checksums,
-///   reducing signature size and network overhead.
-/// - **Phase 2 redo** (`requested_checksum_length = MAX_SUM_LENGTH = 16`):
-///   short-circuits to return 16 bytes, ensuring full collision resistance
-///   for files that failed phase 1 verification.
-///
-/// # Arguments
-///
-/// * `file_size` - Size of the file in bytes
-/// * `block_length` - Block size in bytes (from `calculate_block_length`)
-/// * `protocol_version` - Rsync protocol version
-/// * `requested_checksum_length` - Minimum checksum length (`SHORT_SUM_LENGTH`
-///   for phase 1, `MAX_SUM_LENGTH` for phase 2 redo)
-///
-/// # Returns
-///
-/// Strong checksum length in bytes, clamped to
-/// [`requested_checksum_length`, `MAX_SUM_LENGTH`].
-///
-/// # Examples
-///
-/// ```rust
-/// use signature::block_size::{calculate_checksum_length, SHORT_SUM_LENGTH, MAX_SUM_LENGTH};
-///
-/// // Protocol < 27 always returns requested length
-/// assert_eq!(calculate_checksum_length(1024, 700, 26, 8), 8);
-///
-/// // Phase 1: SHORT_SUM_LENGTH (2) - dynamic computation
-/// let len = calculate_checksum_length(10 * 1024 * 1024, 1024, 31, SHORT_SUM_LENGTH);
-/// assert!(len >= SHORT_SUM_LENGTH && len <= MAX_SUM_LENGTH);
-///
-/// // Phase 2 redo: MAX_SUM_LENGTH (16) - always returns 16
-/// assert_eq!(calculate_checksum_length(1024, 700, 31, MAX_SUM_LENGTH), MAX_SUM_LENGTH);
-/// ```
-#[must_use]
-pub fn calculate_checksum_length(
-    file_size: u64,
-    block_length: u32,
-    protocol_version: u8,
-    requested_checksum_length: u8,
-) -> u8 {
-    // Protocol versions < 27 lack adaptive checksum length negotiation.
-    if protocol_version < 27 {
-        return requested_checksum_length;
-    }
-
-    // Phase 2 redo short-circuit: full collision resistance for retransmits.
-    if requested_checksum_length == MAX_SUM_LENGTH {
-        return MAX_SUM_LENGTH;
-    }
-
-    let mut bias = BLOCKSUM_BIAS;
-    let mut l = file_size;
-    while l >> 1 != 0 {
-        l >>= 1;
-        bias += 2;
-    }
-
-    let mut current = block_length;
-    while current >> 1 != 0 && bias > 0 {
-        current >>= 1;
-        bias -= 1;
-    }
-
-    let mut checksum_len = (bias + 1 - 32 + 7) / 8;
-
-    let min_len = i32::from(requested_checksum_length);
-    if checksum_len < min_len {
-        checksum_len = min_len;
-    }
-
-    let max_len = i32::from(MAX_SUM_LENGTH);
-    if checksum_len > max_len {
-        checksum_len = max_len;
-    }
-
-    checksum_len as u8
 }
 
 /// Calculates the number of blocks needed for a file.
@@ -482,54 +389,6 @@ mod tests {
     }
 
     #[test]
-    fn checksum_length_protocol_versions() {
-        // Protocol < 27 always returns the requested length verbatim.
-        assert_eq!(calculate_checksum_length(1024, 700, 26, 8), 8);
-        assert_eq!(calculate_checksum_length(1024 * 1024, 700, 26, 2), 2);
-        assert_eq!(calculate_checksum_length(1024 * 1024, 700, 26, 16), 16);
-
-        // Protocol >= 27 applies the bias heuristic.
-        let len = calculate_checksum_length(1024 * 1024, 1024, 27, 2);
-        assert!((2..=MAX_SUM_LENGTH).contains(&len));
-
-        let len = calculate_checksum_length(1024 * 1024, 1024, 31, 2);
-        assert!((2..=MAX_SUM_LENGTH).contains(&len));
-    }
-
-    #[test]
-    fn checksum_length_max_requested() {
-        assert_eq!(
-            calculate_checksum_length(1024, 700, 31, MAX_SUM_LENGTH),
-            MAX_SUM_LENGTH
-        );
-        assert_eq!(
-            calculate_checksum_length(1024 * 1024, 700, 31, MAX_SUM_LENGTH),
-            MAX_SUM_LENGTH
-        );
-    }
-
-    #[test]
-    fn checksum_length_scales_with_file_size() {
-        let small = calculate_checksum_length(1024, 700, 31, 2);
-        let medium = calculate_checksum_length(1024 * 1024, 700, 31, 2);
-        let large = calculate_checksum_length(100 * 1024 * 1024, 700, 31, 2);
-
-        assert!(small >= 2);
-        assert!(medium >= small);
-        assert!(large >= medium);
-        assert!(large <= MAX_SUM_LENGTH);
-    }
-
-    #[test]
-    fn checksum_length_bounded_by_requested() {
-        for requested in 2..=MAX_SUM_LENGTH {
-            let len = calculate_checksum_length(1024 * 1024, 1024, 31, requested);
-            assert!(len >= requested);
-            assert!(len <= MAX_SUM_LENGTH);
-        }
-    }
-
-    #[test]
     fn roundtrip_block_coverage() {
         let test_sizes = [
             0u64,
@@ -566,48 +425,6 @@ mod tests {
         // upstream: rsync.h:715 `#define SUM_LENGTH 16`
         assert_eq!(MAX_SUM_LENGTH, 16);
         assert!(usize::from(SHORT_SUM_LENGTH) < usize::from(MAX_SUM_LENGTH));
-    }
-
-    #[test]
-    fn sum_length_phase1_uses_dynamic_checksum() {
-        // Phase 1 passes SHORT_SUM_LENGTH; the heuristic widens the result for
-        // larger files, so a 100 MB file should exceed the minimum of 2.
-        let len = calculate_checksum_length(100 * 1024 * 1024, 10_240, 31, SHORT_SUM_LENGTH);
-        assert!(len >= SHORT_SUM_LENGTH);
-        assert!(len <= MAX_SUM_LENGTH);
-        assert!(len > SHORT_SUM_LENGTH);
-    }
-
-    #[test]
-    fn sum_length_phase2_redo_returns_max_immediately() {
-        // Phase 2 redo passes MAX_SUM_LENGTH; the function short-circuits and
-        // returns 16 regardless of file or block size.
-        for &(file_size, block_len) in &[
-            (1024u64, 700u32),
-            (1_048_576, 1024),
-            (100 * 1024 * 1024, 10_240),
-            (1u64 << 30, 32768),
-        ] {
-            let len = calculate_checksum_length(file_size, block_len, 31, MAX_SUM_LENGTH);
-            assert_eq!(
-                len, MAX_SUM_LENGTH,
-                "redo pass must return MAX_SUM_LENGTH for file_size={file_size}"
-            );
-        }
-    }
-
-    #[test]
-    fn sum_length_short_vs_max_differ_for_small_files() {
-        // For small files the phase toggle is observable: phase 1 emits the
-        // shorter checksum while phase 2 emits the maximum.
-        let file_size = 1024u64;
-        let block_len = 700u32;
-        let phase1 = calculate_checksum_length(file_size, block_len, 31, SHORT_SUM_LENGTH);
-        let phase2 = calculate_checksum_length(file_size, block_len, 31, MAX_SUM_LENGTH);
-
-        assert_eq!(phase1, SHORT_SUM_LENGTH);
-        assert_eq!(phase2, MAX_SUM_LENGTH);
-        assert!(phase1 < phase2);
     }
 
     #[test]

--- a/crates/signature/src/lib.rs
+++ b/crates/signature/src/lib.rs
@@ -60,7 +60,7 @@
 //! before generating signatures:
 //!
 //! ```
-//! use signature::{calculate_block_length, calculate_checksum_length, calculate_checksum_count};
+//! use signature::{calculate_block_length, calculate_checksum_count};
 //!
 //! // Calculate optimal block size for a 10 MB file
 //! let file_size = 10 * 1024 * 1024;
@@ -68,14 +68,13 @@
 //! let block_len = calculate_block_length(file_size, protocol_version, None);
 //! assert_eq!(block_len, 3232); // sqrt-based scaling
 //!
-//! // Calculate checksum length
-//! let checksum_len = calculate_checksum_length(file_size, block_len, protocol_version, 2);
-//! assert!(checksum_len >= 2);
-//!
 //! // Calculate number of blocks
 //! let block_count = calculate_checksum_count(file_size, block_len);
 //! assert_eq!(block_count, 3245);
 //! ```
+//!
+//! Strong checksum length is computed as part of `calculate_signature_layout`
+//! (`SignatureLayoutParams`), which applies the negotiated transfer-digest cap.
 
 #![allow(clippy::module_name_repetitions)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -105,7 +104,7 @@ pub use algorithm::{DigestBuf, SignatureAlgorithm};
 pub use block::SignatureBlock;
 pub use block_size::{
     DEFAULT_BLOCK_SIZE, MAX_BLOCK_SIZE_OLD, MAX_BLOCK_SIZE_V30, MAX_SUM_LENGTH, MIN_BLOCK_SIZE,
-    SHORT_SUM_LENGTH, calculate_block_length, calculate_checksum_count, calculate_checksum_length,
+    SHORT_SUM_LENGTH, calculate_block_length, calculate_checksum_count,
 };
 pub use file::FileSignature;
 pub use generation::{SignatureError, generate_file_signature};

--- a/docs/audits/delta-wire-format-audit.md
+++ b/docs/audits/delta-wire-format-audit.md
@@ -296,24 +296,28 @@ oc-rsync conformance:
   and `:82` (`MAX_SUM_LENGTH = 16`). Test
   `sum_length_constants_match_upstream` at `block_size.rs:580-586` enforces
   the values match upstream's `rsync.h:714-715`.
-- Heuristic: `block_size.rs:191-234` (`calculate_checksum_length`) reproduces
-  the bias loop, with the phase-2 short-circuit `if requested ==
-  MAX_SUM_LENGTH return MAX_SUM_LENGTH` (line 204-206) preserving the
-  redo-pass invariant.
+- Heuristic: `layout.rs::derive_strong_sum_length` reproduces the bias loop,
+  with the phase-2 short-circuit `if checksum_length == SUM_LENGTH` returning
+  the negotiated digest width (not an unconditional `MAX_SUM_LENGTH`),
+  preserving the redo-pass invariant while also applying the
+  `max_s2length = MIN(SUM_LENGTH, xfer_sum_len)` cap from
+  `generator.c:705`.
 - Phase distinction: `crates/transfer/src/receiver/mod.rs:75` and `:84`
   document the `csum_length = SHORT_SUM_LENGTH` and `csum_length =
   SUM_LENGTH` upstream call-sites at `generator.c:2157` and `generator.c:2163`
   respectively.
 - Tests:
-  - `sum_length_phase1_uses_dynamic_checksum`
-    (`block_size.rs:589-598`) confirms phase 1 produces a value `>= 2 <= 16`.
-  - `sum_length_phase2_redo_returns_max_immediately`
-    (`block_size.rs:601-616`) confirms phase 2 always returns 16.
-  - `sum_length_short_vs_max_differ_for_small_files`
-    (`block_size.rs:619-630`) confirms the phase 1 value differs from phase 2
-    on a small file.
-  - `specific_upstream_compatibility_values` (`block_size.rs:633-648`) pins
-    the block-length output for several known file sizes against
+  - `sum_length_derive_strong_phase1_is_dynamic` (`layout.rs`) confirms phase 1
+    produces a value `>= SHORT_SUM_LENGTH <= SUM_LENGTH`.
+  - `sum_length_derive_strong_phase2_redo_returns_max` (`layout.rs`) confirms
+    phase 2 returns the full negotiated digest width for any file/block size.
+  - `sum_length_phase_toggle_produces_different_layouts` (`layout.rs`)
+    confirms the phase 1 value differs from phase 2 for the same file.
+  - `phase1_strong_sum_capped_by_narrow_transfer_digest` and
+    `phase2_strong_sum_capped_by_narrow_transfer_digest` (`layout.rs`) confirm
+    the `max_s2length = MIN(SUM_LENGTH, xfer_sum_len)` cap.
+  - `specific_upstream_compatibility_values` (`block_size.rs`) pins the
+    block-length output for several known file sizes against
     upstream-derived values (1 MiB -> 1024, 10 MiB -> 3232, 100 MiB ->
     10240, 1 GiB -> 32768).
 

--- a/docs/audits/newtype-coverage.md
+++ b/docs/audits/newtype-coverage.md
@@ -106,7 +106,7 @@ Block-related quantities flow as plain integers in many places:
 
 | Site | Type used | Conceptual unit |
 |------|-----------|-----------------|
-| `crates/signature/src/block_size.rs:129,194,262` (`calculate_block_length`, `calculate_checksum_length`, `calculate_checksum_count`) | `u32`, `u8`, `u64` | Block length (bytes), checksum length (bytes), block count (blocks). |
+| `crates/signature/src/block_size.rs` (`calculate_block_length`, `calculate_checksum_count`) | `u32`, `u64` | Block length (bytes), block count (blocks). |
 | `crates/protocol/src/wire/signature.rs:107` (`block_length: u32`) | `u32` | Block size in bytes. |
 | `crates/batch/src/replay.rs:198,201,217,815,816,828` | `u32`/`usize` | Block index and `block_index * block_length` offset arithmetic. |
 | `crates/engine/src/local_copy/debug_*` trace helpers (`trace_delta_apply_match`, `trace_match_hit`, `trace_match_false_alarm`, `record_match`, `record_literal`, etc.) | `usize`, `u64`, `u32` | `block_index`, file `offset`, span `length`, weak checksum. |


### PR DESCRIPTION
## Summary
- `calculate_checksum_length` in `crates/signature/src/block_size.rs` had no callers outside its own doctests and unit tests - a dead public function.
- It also lacked the negotiated transfer-digest cap (`max_s2length = MIN(SUM_LENGTH, xfer_sum_len)`, upstream `generator.c:705`) that the live checksum-length path applies, making it a divergent and incorrect duplicate had it ever been wired up.
- The live, correct path is `calculate_signature_layout` / `derive_strong_sum_length` in `crates/signature/src/layout.rs`, which every caller (matching, transfer, engine) already uses and which is covered by tests proving the cap (`phase1_strong_sum_capped_by_narrow_transfer_digest`, `phase2_strong_sum_capped_by_narrow_transfer_digest`).
- Removed the dead function, its now-unused `BLOCKSUM_BIAS` constant in `block_size.rs`, its dedicated tests, and updated doc references (crate docs, README, two stale audit notes) that named it.

## Test plan
- [x] `cargo fmt -p signature -- --check`
- [x] `cargo clippy -p signature --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo clippy -p signature -p matching -p engine -p transfer --no-deps -- -D warnings`
- [x] `cargo nextest run -p signature --all-features` (234 passed)

All run on the aarch64 Linux validation host (cargo isn't available on this machine).
