### PR TITLE
fix(engine): try a hard link before renaming into --backup

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -39,7 +39,8 @@ use super::{
     load_dir_merge_rules_recursive, map_metadata_error, record_directory_subtree,
     remove_source_entry_if_requested, resolve_dir_merge_path, should_skip_copy,
     symlink_target_is_safe, trace_make_backup_copy, trace_make_backup_device,
-    trace_make_backup_rename, trace_make_backup_symlink, write_sparse_chunk,
+    trace_make_backup_hlink, trace_make_backup_rename, trace_make_backup_symlink,
+    write_sparse_chunk,
 };
 use crate::delta::DeltaSignatureIndex;
 use crate::signature::SignatureBlock;
@@ -59,7 +60,7 @@ use filters::FilterRule;
 use logging::info_log;
 use protocol::flist::FileListWriter;
 
-use super::overrides::backup_rename;
+use super::overrides::{backup_rename, create_hard_link};
 #[cfg(target_os = "linux")]
 use super::overrides::{cached_parent_device, same_filesystem};
 
@@ -538,13 +539,16 @@ pub(crate) enum CreatedEntryKind {
 
 /// Strategy used to place an existing destination into the backup
 /// location. Mirrors upstream rsync's `make_backup` success branches
-/// (RENAME / COPY / SYMLINK / DEVICE / HLINK) for `--debug=BACKUP`
-/// reporting; oc-rsync's local-copy executor exercises RENAME, COPY
-/// (cross-device fallback for regular files), SYMLINK (cross-device
+/// (HLINK / RENAME / COPY / SYMLINK / DEVICE) for `--debug=BACKUP`
+/// reporting; oc-rsync's local-copy executor exercises HLINK (same-fs
+/// backup, the default when the caller doesn't prefer a rename), RENAME
+/// (delete-pass callers that prefer a rename, and the hard-link fallback),
+/// COPY (cross-device fallback for regular files), SYMLINK (cross-device
 /// fallback for symlinks), and DEVICE (cross-device fallback for
 /// device/FIFO/socket nodes, recreated via mknod).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum BackupStrategy {
+    HardLink,
     Rename,
     Copy,
     Symlink,

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -804,8 +804,16 @@ impl<'a> CopyContext<'a> {
         Ok(())
     }
 
-    /// Renames or copies an existing destination entry to the backup location
-    /// when `--backup` is enabled.
+    /// Hard-links, renames, or copies an existing destination entry to the
+    /// backup location when `--backup` is enabled.
+    ///
+    /// `prefer_rename` mirrors upstream's `make_backup(fname, prefer_rename)`
+    /// parameter: callers backing up an item that is about to be unlinked
+    /// outright (the delete pass) pass `true` to skip straight to the rename
+    /// tier, since the caller removes the original right after regardless of
+    /// which strategy placed the backup (`delete.c:165-167`). Callers backing
+    /// up an item before overwriting it with fresh content pass `false` so
+    /// the hard-link tier runs first (`rsync.c:740`, `receiver.c:538`).
     ///
     /// Emits an `--info=BACKUP` notice mirroring upstream rsync 3.4.1
     /// (backup.c:352) under `INFO_GTE(BACKUP, 1)` once the backup has been
@@ -816,6 +824,7 @@ impl<'a> CopyContext<'a> {
         destination: &Path,
         _relative: Option<&Path>,
         file_type: fs::FileType,
+        prefer_rename: bool,
     ) -> Result<(), LocalCopyError> {
         if !self.options.backup_enabled() || self.mode.is_dry_run() {
             return Ok(());
@@ -853,10 +862,41 @@ impl<'a> CopyContext<'a> {
             )?;
         }
 
+        // upstream: backup.c:200-207 link_or_rename() - try a hard link into
+        // the backup area first when the caller doesn't prefer a rename
+        // outright. A successful link leaves the destination's inode as the
+        // backup, so no metadata reapply is needed below (same as RENAME).
+        let hard_linked = if prefer_rename {
+            None
+        } else {
+            match create_hard_link(destination, &backup_path) {
+                Ok(()) => Some(BackupStrategy::HardLink),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+                // upstream: backup.c:247-256 - a stale backup entry is
+                // removed and the hard link retried once.
+                Err(error) if is_stale_backup_conflict(&error) => {
+                    remove_stale_backup_entry(&backup_path)?;
+                    match create_hard_link(destination, &backup_path) {
+                        Ok(()) => Some(BackupStrategy::HardLink),
+                        Err(_) => None,
+                    }
+                }
+                // Any other failure (e.g. EXDEV across a `--backup-dir` on a
+                // different filesystem, or a type the platform cannot
+                // hard-link) falls through to the rename tier below, mirroring
+                // `link_or_rename`'s in-call rename fallback.
+                Err(_) => None,
+            }
+        };
+
         // Track which backup strategy succeeded so we can emit the matching
-        // upstream `--debug=BACKUP` trace (RENAME, COPY, or SYMLINK).
+        // upstream `--debug=BACKUP` trace (HLINK, RENAME, COPY, SYMLINK, or
+        // DEVICE).
         // upstream: backup.c:link_or_rename and the fall-through copy_file path.
-        let strategy = match backup_rename(destination, &backup_path) {
+        let strategy = if let Some(strategy) = hard_linked {
+            strategy
+        } else {
+            match backup_rename(destination, &backup_path) {
             Ok(()) => BackupStrategy::Rename,
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
             // upstream: backup.c:247-256 - link_or_rename failing with EEXIST or
@@ -871,41 +911,8 @@ impl<'a> CopyContext<'a> {
             // re-stat below still gates removal on the target actually existing,
             // so a genuine permission error falls through to the retry-and-fail
             // path unchanged.
-            Err(error)
-                if error.kind() == io::ErrorKind::AlreadyExists
-                    || error.kind() == io::ErrorKind::IsADirectory
-                    || error.kind() == io::ErrorKind::PermissionDenied =>
-            {
-                match fs::symlink_metadata(&backup_path) {
-                    Ok(meta) if meta.is_dir() => {
-                        fs::remove_dir_all(&backup_path).map_err(|remove_error| {
-                            LocalCopyError::io(
-                                "remove existing backup directory",
-                                backup_path.clone(),
-                                remove_error,
-                            )
-                        })?;
-                    }
-                    Ok(_) => {
-                        if let Err(remove_error) = fs::remove_file(&backup_path)
-                            && remove_error.kind() != io::ErrorKind::NotFound
-                        {
-                            return Err(LocalCopyError::io(
-                                "remove existing backup",
-                                backup_path,
-                                remove_error,
-                            ));
-                        }
-                    }
-                    Err(meta_error) if meta_error.kind() == io::ErrorKind::NotFound => {}
-                    Err(meta_error) => {
-                        return Err(LocalCopyError::io(
-                            "stat existing backup",
-                            backup_path,
-                            meta_error,
-                        ));
-                    }
-                }
+            Err(error) if is_stale_backup_conflict(&error) => {
+                remove_stale_backup_entry(&backup_path)?;
                 fs::rename(destination, &backup_path).map_err(|rename_error| {
                     LocalCopyError::io("create backup", backup_path.clone(), rename_error)
                 })?;
@@ -953,6 +960,7 @@ impl<'a> CopyContext<'a> {
             Err(error) => {
                 return Err(LocalCopyError::io("create backup", backup_path, error));
             }
+            }
         };
 
         // upstream: backup.c:338-341 - set_file_attrs(buf, file, NULL, fname,
@@ -991,12 +999,14 @@ impl<'a> CopyContext<'a> {
             )?;
         }
 
-        // upstream: backup.c:201-202,216-217,299-300,333-334 - DEBUG_GTE(BACKUP, 1)
-        // emits one of HLINK/RENAME/SYMLINK/COPY per success path. oc-rsync's
-        // local-copy executor uses rename as the primary strategy and falls back
-        // to copy or symlink across filesystem boundaries.
+        // upstream: backup.c:201-202,216-217,282-283,299-300,333-334 -
+        // DEBUG_GTE(BACKUP, 1) emits one of HLINK/RENAME/DEVICE/SYMLINK/COPY
+        // per success path. oc-rsync's local-copy executor prefers a
+        // same-filesystem hard link, falls back to rename, then falls back to
+        // copy or symlink recreation across filesystem boundaries.
         let destination_display = destination.display().to_string();
         match strategy {
+            BackupStrategy::HardLink => trace_make_backup_hlink(&destination_display),
             BackupStrategy::Rename => trace_make_backup_rename(&destination_display),
             BackupStrategy::Copy => trace_make_backup_copy(&destination_display),
             BackupStrategy::Symlink => trace_make_backup_symlink(&destination_display),
@@ -1145,7 +1155,11 @@ impl<'a> CopyContext<'a> {
             return Ok(());
         }
 
-        self.backup_existing_entry(destination, relative, file_type)?;
+        // upstream: delete.c:165-167 - `delete_item()` (the callee behind
+        // generator.c:1240's DEL_FOR_FILE removal) always calls
+        // `make_backup(fbuf, True)`, so the hard-link tier is skipped here
+        // exactly as it is for a genuine delete-pass removal.
+        self.backup_existing_entry(destination, relative, file_type, true)?;
 
         if file_type.is_dir() {
             self.record_make_room_contents(destination, relative)?;
@@ -1372,6 +1386,55 @@ impl<'a> CopyContext<'a> {
             info_log!(Nonreg, 1, "IO error encountered -- skipping file deletion");
         }
         true
+    }
+}
+
+/// Returns `true` when a hard-link or rename attempt into the backup area
+/// failed because a stale entry already occupies `backup_path`.
+///
+/// upstream: `backup.c:247` - `link_or_rename()` fails with `EEXIST` or
+/// `EISDIR` when the backup path is already occupied. Windows reports
+/// renaming or linking onto an existing directory as `ERROR_ACCESS_DENIED`
+/// (`PermissionDenied`) rather than `EEXIST`/`EISDIR`, so it is treated the
+/// same way; [`remove_stale_backup_entry`]'s re-stat still gates removal on
+/// the target actually existing, so a genuine permission error falls through
+/// to the retry-and-fail path unchanged.
+fn is_stale_backup_conflict(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::AlreadyExists | io::ErrorKind::IsADirectory | io::ErrorKind::PermissionDenied
+    )
+}
+
+/// Clears whatever occupies `backup_path` so a hard-link or rename retry can
+/// land cleanly.
+///
+/// upstream: `backup.c:247-256` - `make_backup()` lstats the stale backup
+/// target and calls `delete_item(...DEL_FOR_BACKUP | DEL_RECURSE)` before
+/// retrying `link_or_rename()`.
+fn remove_stale_backup_entry(backup_path: &Path) -> Result<(), LocalCopyError> {
+    match fs::symlink_metadata(backup_path) {
+        Ok(meta) if meta.is_dir() => fs::remove_dir_all(backup_path).map_err(|remove_error| {
+            LocalCopyError::io("remove existing backup directory", backup_path, remove_error)
+        }),
+        Ok(_) => {
+            if let Err(remove_error) = fs::remove_file(backup_path)
+                && remove_error.kind() != io::ErrorKind::NotFound
+            {
+                return Err(LocalCopyError::io(
+                    "remove existing backup",
+                    backup_path,
+                    remove_error,
+                ));
+            }
+            Ok(())
+        }
+        Err(meta_error) if meta_error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(meta_error) => Err(LocalCopyError::io(
+            "stat existing backup",
+            backup_path,
+            meta_error,
+        )),
     }
 }
 

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -606,7 +606,10 @@ fn delete_leaf(
         && let Some(name) = path.file_name()
         && context.options().should_backup_before_delete(name)
     {
-        context.backup_existing_entry(path, Some(entry_relative), file_type)?;
+        // upstream: delete.c:167 - the delete pass calls `make_backup(fbuf,
+        // True)`, skipping the hard-link tier since the item is unlinked
+        // outright right after regardless of which strategy placed it.
+        context.backup_existing_entry(path, Some(entry_relative), file_type, true)?;
     }
 
     if !context.options().is_itemize_active() {
@@ -908,7 +911,9 @@ fn apply_delete_side_effects(
                 .options()
                 .should_backup_before_delete(entry.name.as_os_str())
         {
-            context.backup_existing_entry(&path, Some(entry_relative.as_path()), file_type)?;
+            // upstream: delete.c:167 - prefer_rename=True; the item is
+            // unlinked outright right after, so skip the hard-link tier.
+            context.backup_existing_entry(&path, Some(entry_relative.as_path()), file_type, true)?;
         }
         // upstream: log.c:log_delete emits exactly ONE line - the itemize
         // format when stdout_format_has_o_or_i, otherwise "deleting %n".

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -913,7 +913,12 @@ fn apply_delete_side_effects(
         {
             // upstream: delete.c:167 - prefer_rename=True; the item is
             // unlinked outright right after, so skip the hard-link tier.
-            context.backup_existing_entry(&path, Some(entry_relative.as_path()), file_type, true)?;
+            context.backup_existing_entry(
+                &path,
+                Some(entry_relative.as_path()),
+                file_type,
+                true,
+            )?;
         }
         // upstream: log.c:log_delete emits exactly ONE line - the itemize
         // format when stdout_format_has_o_or_i, otherwise "deleting %n".

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -194,7 +194,9 @@ pub(in crate::local_copy) fn execute_transfer(
             // basis override: copy_file_contents rewrites the existing inode via
             // the proven inplace path (which truncates to the final length).
         } else {
-            context.backup_existing_entry(destination, relative, existing.file_type())?;
+            // upstream: rsync.c:740 - `make_backup(fname, False)` tries a
+            // hard link into the backup area before renaming.
+            context.backup_existing_entry(destination, relative, existing.file_type(), false)?;
             // When a rename moved the basis file, delta transfer must read
             // matched blocks from the backup location. The delta signature is
             // only built for regular files, so this condition is sufficient.

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -676,7 +676,9 @@ pub(super) fn delete_missing_source_entry(
         return Ok(());
     }
 
-    context.backup_existing_entry(&target, record_path, file_type)?;
+    // upstream: delete.c:167 - prefer_rename=True; the item is unlinked
+    // outright right after, so skip the hard-link tier.
+    context.backup_existing_entry(&target, record_path, file_type, true)?;
     let removal = if file_type.is_dir() {
         fs::remove_dir_all(&target)
     } else {

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -200,7 +200,10 @@ pub(crate) fn copy_device(
     }
 
     if let Some(existing) = existing_metadata.take() {
-        context.backup_existing_entry(destination, relative, existing.file_type())?;
+        // upstream: generator.c:2019 atomic_create() - `make_backup(fname,
+        // skip_atomic)` with `skip_atomic` false here, so the hard-link tier
+        // runs before the rename.
+        context.backup_existing_entry(destination, relative, existing.file_type(), false)?;
         remove_existing_destination(destination)?;
     }
 

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -210,7 +210,10 @@ pub(crate) fn copy_fifo(
     }
 
     if let Some(existing) = existing_metadata.take() {
-        context.backup_existing_entry(destination, relative, existing.file_type())?;
+        // upstream: generator.c:2019 atomic_create() - `make_backup(fname,
+        // skip_atomic)` with `skip_atomic` false here, so the hard-link tier
+        // runs before the rename.
+        context.backup_existing_entry(destination, relative, existing.file_type(), false)?;
         remove_existing_destination(destination)?;
     }
 

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -443,7 +443,10 @@ pub(crate) fn copy_symlink(
     if !mode.is_dry_run()
         && let Some(existing) = destination_metadata.take()
     {
-        context.backup_existing_entry(destination, relative, existing.file_type())?;
+        // upstream: generator.c:2019 atomic_create() - `make_backup(fname,
+        // skip_atomic)` with `skip_atomic` false here, so the hard-link tier
+        // runs before the rename.
+        context.backup_existing_entry(destination, relative, existing.file_type(), false)?;
         remove_existing_destination(destination)?;
     }
 

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -1,4 +1,67 @@
 
+// `--backup` must hard-link the existing destination into the backup
+// location when it stays on the same filesystem, mirroring upstream's
+// `link_or_rename()` HLINK branch (backup.c:200-207) - the default whenever
+// the caller doesn't prefer a rename outright. A plain rename would still
+// preserve the bytes, but a hard link is what upstream actually does, and it
+// matters: it keeps the backup coherent with any other name pointing at the
+// same inode instead of severing it, and it avoids gratuitously moving data
+// across directories when the backup dir shares a filesystem with the
+// destination. The transfer's rename-into-place then reassigns the
+// destination name to the freshly written content, leaving the backup as
+// the sole remaining link to the original inode.
+#[cfg(unix)]
+#[test]
+fn backup_hard_links_same_filesystem_backup() {
+    use std::os::unix::fs::MetadataExt;
+
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+
+    let source_file = ctx.source.join("file.txt");
+    fs::write(&source_file, b"updated").expect("write source");
+
+    let dest_root = ctx.dest.join("source");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+    let existing = dest_root.join("file.txt");
+    fs::write(&existing, b"original").expect("write dest");
+    let inode_before = fs::metadata(&existing).expect("stat dest").ino();
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default().backup(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let backup = dest_root.join("file.txt~");
+    let backup_meta = fs::metadata(&backup).expect("stat backup");
+    assert_eq!(
+        backup_meta.ino(),
+        inode_before,
+        "same-filesystem backup must be a hard link to the original inode, not a copy"
+    );
+    assert_eq!(
+        backup_meta.nlink(),
+        1,
+        "the destination name was reassigned to the newly written content by \
+         the transfer's rename-into-place, leaving the backup as the sole \
+         remaining link to the original inode"
+    );
+    assert_eq!(
+        fs::read(&backup).expect("read backup"),
+        b"original",
+        "backup must retain the pre-transfer bytes"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("file.txt")).expect("read dest"),
+        b"updated"
+    );
+}
+
 #[test]
 fn backup_creation_uses_default_suffix() {
     let ctx = test_helpers::setup_copy_test();
@@ -590,11 +653,18 @@ fn cross_device_file_backup_preserves_mode_and_mtime() {
         .group(true)
         .with_backup_directory(Some(backup_dir.clone()));
 
-    with_backup_rename_override(
-        |_, _| Some(Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE))),
+    // The hard-link tier is tried first (backup.c:200-207); force it to fail
+    // cross-device too so the rename override below is actually reached.
+    with_hard_link_override(
+        |_, _| Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE)),
         || {
-            plan.execute_with_options(LocalCopyExecution::Apply, options)
-                .expect("copy succeeds")
+            with_backup_rename_override(
+                |_, _| Some(Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE))),
+                || {
+                    plan.execute_with_options(LocalCopyExecution::Apply, options)
+                        .expect("copy succeeds")
+                },
+            )
         },
     );
 
@@ -650,11 +720,18 @@ fn cross_device_symlink_backup_preserves_target_and_mtime() {
         .group(true)
         .with_backup_directory(Some(backup_dir.clone()));
 
-    with_backup_rename_override(
-        |_, _| Some(Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE))),
+    // The hard-link tier is tried first (backup.c:200-207); force it to fail
+    // cross-device too so the rename override below is actually reached.
+    with_hard_link_override(
+        |_, _| Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE)),
         || {
-            plan.execute_with_options(LocalCopyExecution::Apply, options)
-                .expect("copy succeeds")
+            with_backup_rename_override(
+                |_, _| Some(Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE))),
+                || {
+                    plan.execute_with_options(LocalCopyExecution::Apply, options)
+                        .expect("copy succeeds")
+                },
+            )
         },
     );
 

--- a/crates/engine/tests/debug_backup_emissions.rs
+++ b/crates/engine/tests/debug_backup_emissions.rs
@@ -7,8 +7,8 @@
 //!
 //! # Upstream Reference
 //!
-//! - `backup.c:216-217` - `"make_backup: RENAME %s successful.\n"` fires
-//!   on the success branch of `do_rename(from, to)` inside `link_or_rename`,
+//! - `backup.c:200-207` - `"make_backup: HLINK %s successful.\n"` fires
+//!   on the success branch of `do_link_at(from, to)` inside `link_or_rename`,
 //!   which is the strategy oc-rsync's local-copy executor exercises by
 //!   default when `--backup` is on and the destination shares a
 //!   filesystem with the backup location.
@@ -36,13 +36,14 @@ fn backup_debug_messages() -> Vec<String> {
 }
 
 /// Drives a full local-copy that overwrites an existing destination with
-/// `--backup --suffix=~` and confirms the RENAME debug line fires at
+/// `--backup --suffix=~` and confirms the HLINK debug line fires at
 /// level 1 with upstream's exact wording.
 ///
-/// upstream: backup.c:216-217 - `DEBUG_GTE(BACKUP, 1)` on the RENAME
-/// success branch of `link_or_rename`.
+/// upstream: backup.c:200-207 - `DEBUG_GTE(BACKUP, 1)` on the HLINK
+/// success branch of `link_or_rename`, which upstream tries before RENAME
+/// whenever the caller doesn't prefer a rename outright.
 #[test]
-fn local_copy_backup_emits_rename_debug_line() {
+fn local_copy_backup_emits_hlink_debug_line() {
     let mut cfg = VerbosityConfig::default();
     cfg.debug.backup = 1;
     init(cfg);
@@ -69,11 +70,11 @@ fn local_copy_backup_emits_rename_debug_line() {
     plan.execute_with_options(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
 
-    let expected = format!("make_backup: RENAME {} successful.", existing.display());
+    let expected = format!("make_backup: HLINK {} successful.", existing.display());
     let messages = backup_debug_messages();
     assert!(
         messages.iter().any(|m| m == &expected),
-        "expected upstream-format BACKUP,1 RENAME line {expected:?}; got {messages:?}"
+        "expected upstream-format BACKUP,1 HLINK line {expected:?}; got {messages:?}"
     );
 
     assert!(
@@ -83,7 +84,7 @@ fn local_copy_backup_emits_rename_debug_line() {
 }
 
 /// Same scenario as above but with `--debug=BACKUP` disabled. No BACKUP
-/// debug lines should fire even though the rename still happens.
+/// debug lines should fire even though the backup still happens.
 #[test]
 fn backup_debug_level_zero_suppresses_emission() {
     init(VerbosityConfig::default());
@@ -117,6 +118,6 @@ fn backup_debug_level_zero_suppresses_emission() {
 
     assert!(
         dest_root.join("file.txt~").exists(),
-        "rename should still occur regardless of debug flag"
+        "backup should still occur regardless of debug flag"
     );
 }


### PR DESCRIPTION
## Summary

- The local-copy `--backup` path renamed the destination straight into the backup location, never trying a hard link first. Upstream's `link_or_rename()` (backup.c:187-221) hard-links the existing item into the backup area before falling back to rename whenever the caller doesn't prefer a rename outright (`make_backup(fname, prefer_rename)` with `prefer_rename=0`), which `rsync.c:740` (`finish_transfer`), `receiver.c:538`, and `generator.c:2019` (`atomic_create`) all do. A plain rename still preserves the bytes, but skipping the hard-link tier means the backup and the (about-to-be-overwritten) destination stop being two names for the same inode, and it forces a cross-directory move whenever the backup dir happens to share a filesystem.
- Added a hard-link-first tier to `backup_existing_entry` (`crates/engine/src/local_copy/context_impl/state.rs`), gated by a new `prefer_rename: bool` parameter mirroring upstream's `make_backup()` signature exactly. Delete-pass callers (and the make-room type-conflict path, both of which route through upstream's `delete_item()`) pass `true` and skip straight to rename, matching `delete.c:165-167`'s unconditional `make_backup(fbuf, True)` - the item is unlinked right after regardless of which strategy placed the backup, so skipping the hard-link attempt saves a redundant syscall. The five callers that back up an item before overwriting it with fresh content pass `false` so the hard-link tier runs first.
- Added `BackupStrategy::HardLink` and wired the existing (previously unused) `trace_make_backup_hlink` `--debug=BACKUP` emission into the success path.
- Factored the stale-backup-conflict removal (`EEXIST`/`EISDIR`/Windows `PermissionDenied`) into a shared `remove_stale_backup_entry` helper, reused by both the hard-link retry and the rename retry.

## Test plan

- [x] New test `backup_hard_links_same_filesystem_backup` asserts the backup shares the original inode (same `ino()`) after a plain same-filesystem `--backup`, matching upstream's HLINK branch.
- [x] Updated the two cross-device backup tests to also force the hard-link attempt to fail with `EXDEV` (via the existing `with_hard_link_override` test hook) so the already-covered COPY/SYMLINK fallback paths are still exercised.
- [x] Updated `crates/engine/tests/debug_backup_emissions.rs`, which pinned the pre-fix RENAME trace for a same-filesystem backup; it now expects HLINK.
- [x] `cargo fmt -p engine -- --check` clean on aarch64 Linux.
- [x] `cargo clippy -p engine --all-targets --all-features --no-deps -- -D warnings` clean.
- [x] `cargo nextest run -p engine --all-features` - 4895 passed, 0 failed, 26 skipped (includes all 124 backup-focused tests).
