### PR TITLE
fix: render ssh remote-shell login as -l user, not user@host

### DIFF
--- a/crates/core/src/client/module_list/connect/rsh.rs
+++ b/crates/core/src/client/module_list/connect/rsh.rs
@@ -48,9 +48,10 @@ pub(crate) struct RshDaemonSpawn<'a> {
 }
 
 /// Returns whether the remote-shell program is ssh (or an ssh-family binary
-/// such as `/usr/bin/ssh`), which understands the `-o`/`-J`/`-l` connection
+/// such as `/usr/bin/ssh`), which understands the `-o`/`-J` connection
 /// options. A custom `-e` program (`rsh`, the testsuite `lsh.sh`, etc.) does
-/// not, and upstream only injects those SSH flags when the rsh is ssh.
+/// not, and upstream only injects those SSH flags when the rsh is ssh. `-l
+/// <user>` is unaffected by this gate: upstream emits it for any program.
 fn is_ssh_like(program: &OsStr) -> bool {
     let name = std::path::Path::new(program)
         .file_name()
@@ -84,8 +85,8 @@ fn build_rsh_command_argv(spec: &RshDaemonSpawn<'_>) -> (OsString, Vec<OsString>
         args.push(opt.clone());
     }
 
-    // upstream: main.c - the `-o`/`-J`/`-l` connection options are SSH-specific
-    // and are only injected when the remote-shell program is ssh. A custom
+    // upstream: main.c - the `-o`/`-J` connection options are SSH-specific and
+    // are only injected when the remote-shell program is ssh. A custom
     // `-e PROG` (e.g. the testsuite `lsh.sh`, or `rsh`) is spawned verbatim as
     // `PROG <pre-args> <host> "<cmd>"`; passing it `-o ConnectTimeout=...`
     // breaks programs that do not understand SSH flags (lsh.sh reads the next
@@ -110,11 +111,28 @@ fn build_rsh_command_argv(spec: &RshDaemonSpawn<'_>) -> (OsString, Vec<OsString>
                 timeout.as_secs()
             )));
         }
+    }
 
-        if let Some(user) = spec.username {
-            args.push(OsString::from("-l"));
-            args.push(OsString::from(user));
-        }
+    // upstream: main.c:569-586 do_cmd() - `-l user` is emitted as a separate
+    // argument for ANY remote-shell program, not just ssh: `lsh.sh` and
+    // traditional `rsh` both parse `-l USER` (see `support/lsh.sh`), so
+    // rendering `user@host` instead would leave those wrappers unable to
+    // find the host operand. The only case upstream skips re-emitting the
+    // parsed user is `daemon_connection && dash_l_set` - the caller already
+    // wrote a literal `-l <user>` into the `--rsh`/`-e` string:
+    // `for (i = 0; i < argc-1; i++) if (!strcmp(args[i], "-l") &&
+    // args[i+1][0] != '-') dash_l_set = 1;` (main.c:569-573), scanning the
+    // whole tokenized `--rsh` argv. This path is always a daemon connection
+    // (daemon-over-rsh), so the condition reduces to `!dash_l_set`.
+    let dash_l_set = spec
+        .shell_args
+        .windows(2)
+        .any(|w| w[0].to_string_lossy() == "-l" && !w[1].to_string_lossy().starts_with('-'));
+    if let Some(user) = spec.username
+        && !dash_l_set
+    {
+        args.push(OsString::from("-l"));
+        args.push(OsString::from(user));
     }
 
     // upstream: main.c:588-593 do_cmd() - -4/-6 appended when default_af_hint
@@ -130,12 +148,9 @@ fn build_rsh_command_argv(spec: &RshDaemonSpawn<'_>) -> (OsString, Vec<OsString>
         }
     }
 
-    // ssh takes the login via `-l user` above and the bare host here; a custom
-    // rsh program receives `user@host` (upstream do_cmd handling).
-    match (ssh_like, spec.username) {
-        (false, Some(user)) => args.push(OsString::from(format!("{user}@{}", spec.host))),
-        _ => args.push(OsString::from(spec.host)),
-    }
+    // The login was already rendered above as `-l user`; the operand here is
+    // always the bare host (upstream do_cmd() never composes `user@host`).
+    args.push(OsString::from(spec.host));
 
     // upstream: main.c:594-604 - the remote command is
     // `rsync_path --server --daemon .` with no server_options().
@@ -326,6 +341,124 @@ mod tests {
         assert!(
             !rendered.contains(&"-6".to_owned()),
             "unexpected -6 for rsh: {rendered:?}"
+        );
+    }
+
+    fn argv_strings_with_user(shell: &str, username: Option<&str>) -> Vec<String> {
+        let shell_args = vec![OsString::from(shell)];
+        let spec = RshDaemonSpawn {
+            shell_args: &shell_args,
+            host: "example.com",
+            username,
+            port: 873,
+            rsync_path: None,
+            bind_address: None,
+            jump_hosts: None,
+            connect_timeout: None,
+            address_mode: AddressMode::Default,
+        };
+        let (_, args) = build_rsh_command_argv(&spec);
+        args.iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// A username parsed from `user@host::module` must render as a separate
+    /// `-l user` argument ahead of the bare host, even for a non-ssh custom
+    /// `-e` program. WHY: `support/lsh.sh` in the upstream testsuite only
+    /// recognises `-l USER` and matches the literal hostnames `localhost`/
+    /// `lh`; a `user@localhost` operand would fall through to its `*)`
+    /// branch and fail with "unable to connect to host user@localhost",
+    /// silently breaking every `--rsh`/`-e` script written to the
+    /// traditional `rsh -l user host` calling convention.
+    /// upstream: main.c:569-586 do_cmd() emits `-l user` unconditionally.
+    #[test]
+    fn renders_dash_l_user_for_non_ssh_program() {
+        let rendered = argv_strings_with_user("lsh.sh", Some("backup"));
+        let l_idx = rendered.iter().position(|a| a == "-l");
+        let user_idx = rendered.iter().position(|a| a == "backup");
+        let host_idx = rendered.iter().position(|a| a == "example.com");
+        assert_eq!(
+            l_idx.map(|i| i + 1),
+            user_idx,
+            "-l must immediately precede the user: {rendered:?}"
+        );
+        assert!(
+            user_idx.zip(host_idx).is_some_and(|(u, h)| u < h),
+            "-l user must precede the host operand: {rendered:?}"
+        );
+        assert!(
+            !rendered.iter().any(|a| a.contains('@')),
+            "no user@host composite should be rendered: {rendered:?}"
+        );
+    }
+
+    /// The same `-l user` placement applies to `ssh` itself.
+    #[test]
+    fn renders_dash_l_user_for_ssh() {
+        let rendered = argv_strings_with_user("ssh", Some("backup"));
+        assert_eq!(
+            rendered,
+            vec![
+                "-l".to_owned(),
+                "backup".to_owned(),
+                "example.com".to_owned(),
+                "rsync".to_owned(),
+                "--server".to_owned(),
+                "--daemon".to_owned(),
+                ".".to_owned(),
+            ]
+        );
+    }
+
+    /// No username means no `-l` is emitted at all.
+    #[test]
+    fn omits_dash_l_without_username() {
+        let rendered = argv_strings_with_user("ssh", None);
+        assert!(
+            !rendered.contains(&"-l".to_owned()),
+            "unexpected -l with no username: {rendered:?}"
+        );
+    }
+
+    /// When the caller's `--rsh` string already spells out a literal
+    /// `-l <user>` (the `dash_l_set` case), the parsed `user@host` login must
+    /// not be re-emitted as a second `-l`, matching upstream's
+    /// `daemon_connection && dash_l_set` skip.
+    /// upstream: main.c:569-573,583-586.
+    #[test]
+    fn skips_dash_l_when_already_set_in_rsh_string() {
+        let shell_args = vec![
+            OsString::from("ssh"),
+            OsString::from("-l"),
+            OsString::from("preconfigured"),
+        ];
+        let spec = RshDaemonSpawn {
+            shell_args: &shell_args,
+            host: "example.com",
+            username: Some("backup"),
+            port: 873,
+            rsync_path: None,
+            bind_address: None,
+            jump_hosts: None,
+            connect_timeout: None,
+            address_mode: AddressMode::Default,
+        };
+        let (_, args) = build_rsh_command_argv(&spec);
+        let rendered: Vec<String> = args.iter().map(|a| a.to_string_lossy().into_owned()).collect();
+
+        let l_count = rendered.iter().filter(|a| a.as_str() == "-l").count();
+        assert_eq!(
+            l_count, 1,
+            "the pre-existing -l must not be duplicated: {rendered:?}"
+        );
+        assert!(
+            rendered.contains(&"preconfigured".to_owned()),
+            "the literal -l value from the --rsh string must survive: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains(&"backup".to_owned()),
+            "the parsed user@host login must be suppressed: {rendered:?}"
         );
     }
 }

--- a/crates/core/src/client/module_list/connect/rsh.rs
+++ b/crates/core/src/client/module_list/connect/rsh.rs
@@ -445,7 +445,10 @@ mod tests {
             address_mode: AddressMode::Default,
         };
         let (_, args) = build_rsh_command_argv(&spec);
-        let rendered: Vec<String> = args.iter().map(|a| a.to_string_lossy().into_owned()).collect();
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
 
         let l_count = rendered.iter().filter(|a| a.as_str() == "-l").count();
         assert_eq!(

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -573,6 +573,24 @@ impl SshCommand {
             args.push(jump.clone());
         }
 
+        // Emit the remote username as a separate `-l <user>` argument rather
+        // than folding it into a `user@host` operand. Unlike the `-4`/`-6`
+        // and cipher/keepalive injections above, this is unconditional on the
+        // program basename: upstream applies it to any remote-shell program
+        // (ssh, rsh, or a custom `-e` wrapper), which matters for wrappers
+        // such as the testsuite's `lsh.sh` that parse `-l <user>` but do not
+        // understand `user@host`.
+        // upstream: main.c:569-586 `do_cmd()` - `if (user &&
+        // !(daemon_connection && dash_l_set)) { args[argc++] = "-l";
+        // args[argc++] = user; }`. `SshCommand` never drives a
+        // `daemon_connection` invocation (that path is
+        // `client::module_list::connect::rsh::build_rsh_command_argv`), so
+        // the condition reduces to a plain `if (user)`.
+        if let Some(user) = &self.user {
+            args.push(OsString::from("-l"));
+            args.push(user.clone());
+        }
+
         // Force IPv4/IPv6 host resolution by appending `-4`/`-6` right before
         // the destination operand, matching upstream's placement. Gated on the
         // program basename being `ssh` so non-ssh `-e` wrappers are untouched.
@@ -603,15 +621,14 @@ impl SshCommand {
             return Some(target.clone());
         }
 
-        if self.host.is_empty() && self.user.is_none() {
+        if self.host.is_empty() {
             return None;
         }
 
+        // The remote username is rendered as a separate `-l <user>` argument
+        // (see `command_parts`), matching upstream `do_cmd()`, so this
+        // operand is the bare host - never a `user@host` composite.
         let mut target = OsString::new();
-        if let Some(user) = &self.user {
-            target.push(user);
-            target.push("@");
-        }
 
         // Strict validation: IPv6 hosts must parse via `Ipv6Addr::from_str`
         // (with optional `%zone` suffix per RFC 4007). Anything else is

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -585,8 +585,13 @@ impl SshCommand {
         // args[argc++] = user; }`. `SshCommand` never drives a
         // `daemon_connection` invocation (that path is
         // `client::module_list::connect::rsh::build_rsh_command_argv`), so
-        // the condition reduces to a plain `if (user)`.
-        if let Some(user) = &self.user {
+        // the condition reduces to a plain `if (user)`. Skipped when
+        // `target_override` is set: the override fully replaces the computed
+        // destination operand (host and any login), so a caller supplying
+        // their own target string owns the whole operand.
+        if self.target_override.is_none()
+            && let Some(user) = &self.user
+        {
             args.push(OsString::from("-l"));
             args.push(user.clone());
         }

--- a/crates/rsync_io/src/ssh/connect.rs
+++ b/crates/rsync_io/src/ssh/connect.rs
@@ -361,9 +361,20 @@ mod tests {
             rendered.contains(&"-oServerAliveCountMax=3".to_owned()),
             "expected ServerAliveCountMax=3 in {rendered:?}"
         );
+        // upstream: main.c:569-586 do_cmd() renders the parsed username as a
+        // separate `-l <user>` argument ahead of the bare host operand, not
+        // a `user@host` composite.
         assert!(
-            rendered.contains(&"user@example.com".to_owned()),
-            "user@host operand should be rendered: {rendered:?}"
+            rendered.contains(&"-l".to_owned()),
+            "expected -l in {rendered:?}"
+        );
+        assert!(
+            rendered.contains(&"user".to_owned()),
+            "expected user in {rendered:?}"
+        );
+        assert!(
+            rendered.contains(&"example.com".to_owned()),
+            "bare host operand should be rendered: {rendered:?}"
         );
     }
 

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -2354,7 +2354,11 @@ fn dash_l_user_precedes_address_family_and_host() {
         .position(|a| a == "example.com")
         .expect("host present");
 
-    assert_eq!(l_pos + 1, user_pos, "-l must immediately precede the user: {rendered:?}");
+    assert_eq!(
+        l_pos + 1,
+        user_pos,
+        "-l must immediately precede the user: {rendered:?}"
+    );
     assert!(
         user_pos < flag_pos && flag_pos < host_pos,
         "expected order -l user -4 host, got: {rendered:?}"
@@ -2384,7 +2388,11 @@ fn dash_l_user_applies_to_non_ssh_shell_too() {
     assert_eq!(program, OsString::from("rsh"));
     assert_eq!(
         rendered,
-        vec!["-l".to_owned(), "backup".to_owned(), "example.com".to_owned()]
+        vec![
+            "-l".to_owned(),
+            "backup".to_owned(),
+            "example.com".to_owned()
+        ]
     );
 }
 

--- a/crates/rsync_io/src/ssh/tests.rs
+++ b/crates/rsync_io/src/ssh/tests.rs
@@ -56,7 +56,9 @@ fn assembles_command_with_user_port_and_remote_args() {
             "-oServerAliveCountMax=3".to_owned(),
             "-oConnectTimeout=30".to_owned(),
             "-vvv".to_owned(),
-            "backup@rsync.example.com".to_owned(),
+            "-l".to_owned(),
+            "backup".to_owned(),
+            "rsync.example.com".to_owned(),
             "rsync".to_owned(),
             "--server".to_owned(),
             ".".to_owned(),
@@ -115,7 +117,9 @@ fn wraps_ipv6_hosts_with_usernames() {
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
             "-oConnectTimeout=30".to_owned(),
-            "backup@[2001:db8::1]".to_owned(),
+            "-l".to_owned(),
+            "backup".to_owned(),
+            "[2001:db8::1]".to_owned(),
         ]
     );
 }
@@ -135,7 +139,9 @@ fn preserves_explicit_bracketed_ipv6_literals() {
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
             "-oConnectTimeout=30".to_owned(),
-            "backup@[2001:db8::1]".to_owned(),
+            "-l".to_owned(),
+            "backup".to_owned(),
+            "[2001:db8::1]".to_owned(),
         ]
     );
 }
@@ -157,7 +163,9 @@ fn wraps_ipv6_hosts_with_scoped_zone_id() {
             "-oServerAliveInterval=20".to_owned(),
             "-oServerAliveCountMax=3".to_owned(),
             "-oConnectTimeout=30".to_owned(),
-            "backup@[fe80::1%eth0]".to_owned(),
+            "-l".to_owned(),
+            "backup".to_owned(),
+            "[fe80::1%eth0]".to_owned(),
         ]
     );
 }
@@ -2320,6 +2328,63 @@ fn forces_ipv4_flag_for_ssh_program() {
     assert!(
         flag_pos < host_pos,
         "-4 must precede the host: {rendered:?}"
+    );
+}
+
+#[test]
+fn dash_l_user_precedes_address_family_and_host() {
+    // upstream: main.c:569-593 do_cmd() emits `-l user` then `-4`/`-6` then
+    // the bare host, in that order, never `user@host`.
+    let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(false));
+    command.set_user("backup");
+    command.set_address_family(Some(SshAddressFamily::V4));
+
+    let (_, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+
+    let l_pos = rendered.iter().position(|a| a == "-l").expect("-l present");
+    let user_pos = rendered
+        .iter()
+        .position(|a| a == "backup")
+        .expect("user present");
+    let flag_pos = rendered.iter().position(|a| a == "-4").expect("-4 present");
+    let host_pos = rendered
+        .iter()
+        .position(|a| a == "example.com")
+        .expect("host present");
+
+    assert_eq!(l_pos + 1, user_pos, "-l must immediately precede the user: {rendered:?}");
+    assert!(
+        user_pos < flag_pos && flag_pos < host_pos,
+        "expected order -l user -4 host, got: {rendered:?}"
+    );
+    assert!(
+        !rendered.iter().any(|a| a.contains('@')),
+        "no user@host composite should be rendered: {rendered:?}"
+    );
+}
+
+#[test]
+fn dash_l_user_applies_to_non_ssh_shell_too() {
+    // upstream: main.c:569-586 do_cmd() emits `-l user` unconditionally, not
+    // gated on the remote-shell program being `ssh`. A custom `-e` wrapper
+    // (e.g. the testsuite's `lsh.sh`) parses `-l USER` and does not
+    // understand `user@host`.
+    let mut command = SshCommand::new("example.com");
+    command.set_prefer_aes_gcm(Some(false));
+    command
+        .configure_remote_shell(OsStr::new("rsh"))
+        .expect("valid remote shell");
+    command.set_user("backup");
+
+    let (program, args) = command.command_parts_for_testing();
+    let rendered = args_to_strings(&args);
+
+    assert_eq!(program, OsString::from("rsh"));
+    assert_eq!(
+        rendered,
+        vec!["-l".to_owned(), "backup".to_owned(), "example.com".to_owned()]
     );
 }
 


### PR DESCRIPTION
## Summary

Audited oc-rsync's remote-shell (`-e`/`--rsh`) command construction against
upstream rsync 3.4.4's `main.c:do_cmd()` for three suspected divergences.
Two were already fixed; one was real and is fixed here.

- **RSYNC_RSH tokenizer** - already correct. `rsync_io::ssh::parse_remote_shell`
  wraps the `shell-words` crate for POSIX-style quote handling (not naive
  space-splitting). No change needed.
- **IPv6 bracket wrapping** - already correct in `SshCommand::target_argument`
  (strict `Ipv6Addr::from_str` validation, RFC 4007 zone-id support, bracket
  stripping for `[addr]` input). No change needed.
- **`-l user` vs `user@host` placement** - real divergence, fixed. Upstream
  `do_cmd()` (main.c:569-586) always renders the parsed username as a
  separate `-l <user>` argument ahead of the bare host operand, for *any*
  remote-shell program - not only `ssh`. oc-rsync instead folded the
  username into a `user@host` operand everywhere.

  For `ssh` this was only an argv-shape mismatch (ssh accepts both forms).
  For a custom `-e`/`--rsh` program that follows the traditional
  `rsh -l user host` calling convention - such as the upstream testsuite's
  `support/lsh.sh`, which parses `-l USER` and matches only the literal
  hostnames `localhost`/`lh` - a `user@host` operand falls through to its
  error branch and the connection fails outright.

## Changes

- `crates/rsync_io/src/ssh/builder.rs`: `SshCommand::command_parts` now
  emits `-l <user>` as a separate argument (unconditional on program,
  matching upstream) instead of folding the user into the target operand.
  Skipped when `target_override` is set, since the override already owns
  the whole destination operand.
- `crates/core/src/client/module_list/connect/rsh.rs`
  (daemon-over-remote-shell spawn path): same fix, plus upstream's
  `dash_l_set` exception - when the caller's `--rsh` string already
  spells out a literal `-l <user>`, the parsed `user@host` login is not
  re-emitted.
- Updated existing `rsync_io::ssh` tests that asserted the old
  `user@host`/`backup@[...]` shapes, and added new tests covering the
  `-l` ordering, the non-ssh custom-shell case, and the `dash_l_set`
  exception.

## Test plan

- [x] `cargo fmt -p rsync_io -p core -- --check`
- [x] `cargo clippy -p rsync_io -p core --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p rsync_io -p core --all-features` (3745 passed)
- [x] `cargo nextest run -p cli --all-features -E 'test(rsh) or test(ssh) or test(remote_shell)'` (27 passed)
- [x] Validated on aarch64 Linux host
