### PR TITLE
feat: stash ACLs under fake-super instead of dropping them

### DIFF
--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -382,7 +382,14 @@ impl<'a> CopyContext<'a> {
 
         #[cfg(all(any(unix, windows), feature = "acl"))]
         {
-            sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+            sync_acls_if_requested(
+                preserve_acls,
+                self.options.fake_super_enabled(),
+                mode,
+                source,
+                destination,
+                true,
+            )?;
         }
 
         #[cfg(not(any(all(unix, feature = "xattr"), all(any(unix, windows), feature = "acl"))))]

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -98,7 +98,14 @@ pub(super) fn apply_final_directory_metadata(
     )?;
 
     #[cfg(all(any(unix, windows), feature = "acl"))]
-    sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+    sync_acls_if_requested(
+        preserve_acls,
+        context.options().fake_super_enabled(),
+        mode,
+        source,
+        destination,
+        true,
+    )?;
 
     // Suppress unused variable warnings when features are disabled
     let _ = source;

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -268,13 +268,13 @@ pub(super) fn process_links(
             )?;
             #[cfg(all(any(unix, windows), feature = "acl"))]
             sync_acls_if_requested(
-                        preserve_acls,
-                        context.options().fake_super_enabled(),
-                        mode,
-                        source,
-                        destination,
-                        true,
-                    )?;
+                preserve_acls,
+                context.options().fake_super_enabled(),
+                mode,
+                source,
+                destination,
+                true,
+            )?;
         }
         return Ok(LinkOutcome {
             copy_source_override: None,
@@ -310,13 +310,13 @@ pub(super) fn process_links(
             )?;
             #[cfg(all(any(unix, windows), feature = "acl"))]
             sync_acls_if_requested(
-                        preserve_acls,
-                        context.options().fake_super_enabled(),
-                        mode,
-                        source,
-                        destination,
-                        true,
-                    )?;
+                preserve_acls,
+                context.options().fake_super_enabled(),
+                mode,
+                source,
+                destination,
+                true,
+            )?;
             context.record_hard_link(metadata, destination);
             context.summary_mut().record_regular_file_matched();
             let total_bytes = Some(metadata.len());
@@ -777,13 +777,13 @@ pub(super) fn process_links(
                     #[cfg(all(any(unix, windows), feature = "acl"))]
                     if context.register_acl_cohort_leader(&path) {
                         sync_acls_if_requested(
-                        preserve_acls,
-                        context.options().fake_super_enabled(),
-                        mode,
-                        source,
-                        destination,
-                        true,
-                    )?;
+                            preserve_acls,
+                            context.options().fake_super_enabled(),
+                            mode,
+                            source,
+                            destination,
+                            true,
+                        )?;
                     }
                     // upstream: hlink.c:236 - "%s => %s" at INFO_GTE(NAME, 1)
                     // when a hard link is created from a reference directory.

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -267,7 +267,14 @@ pub(super) fn process_links(
                 context.filter_program(),
             )?;
             #[cfg(all(any(unix, windows), feature = "acl"))]
-            sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+            sync_acls_if_requested(
+                        preserve_acls,
+                        context.options().fake_super_enabled(),
+                        mode,
+                        source,
+                        destination,
+                        true,
+                    )?;
         }
         return Ok(LinkOutcome {
             copy_source_override: None,
@@ -302,7 +309,14 @@ pub(super) fn process_links(
                 context.filter_program(),
             )?;
             #[cfg(all(any(unix, windows), feature = "acl"))]
-            sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+            sync_acls_if_requested(
+                        preserve_acls,
+                        context.options().fake_super_enabled(),
+                        mode,
+                        source,
+                        destination,
+                        true,
+                    )?;
             context.record_hard_link(metadata, destination);
             context.summary_mut().record_regular_file_matched();
             let total_bytes = Some(metadata.len());
@@ -762,7 +776,14 @@ pub(super) fn process_links(
                     // follower alias.
                     #[cfg(all(any(unix, windows), feature = "acl"))]
                     if context.register_acl_cohort_leader(&path) {
-                        sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+                        sync_acls_if_requested(
+                        preserve_acls,
+                        context.options().fake_super_enabled(),
+                        mode,
+                        source,
+                        destination,
+                        true,
+                    )?;
                     }
                     // upstream: hlink.c:236 - "%s => %s" at INFO_GTE(NAME, 1)
                     // when a hard link is created from a reference directory.

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
@@ -168,7 +168,14 @@ pub(super) fn record_metadata_only_skip(
         context.filter_program(),
     )?;
     #[cfg(all(any(unix, windows), feature = "acl"))]
-    sync_acls_if_requested(flags.preserve_acls, mode, source, destination, true)?;
+    sync_acls_if_requested(
+        flags.preserve_acls,
+        context.options().fake_super_enabled(),
+        mode,
+        source,
+        destination,
+        true,
+    )?;
 
     context.record_hard_link(metadata, destination);
     context.summary_mut().record_regular_file_matched();

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -280,7 +280,14 @@ pub(crate) fn copy_device(
                 context.filter_program(),
             )?;
             #[cfg(all(any(unix, windows), feature = "acl"))]
-            sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+            sync_acls_if_requested(
+                preserve_acls,
+                context.options().fake_super_enabled(),
+                mode,
+                source,
+                destination,
+                true,
+            )?;
 
             context.record_hard_link(metadata, destination);
             context.summary_mut().record_hard_link();
@@ -374,7 +381,14 @@ pub(crate) fn copy_device(
             context.filter_program(),
         )?;
         #[cfg(feature = "acl")]
-        sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+        sync_acls_if_requested(
+                preserve_acls,
+                context.options().fake_super_enabled(),
+                mode,
+                source,
+                destination,
+                true,
+            )?;
 
         // Under fake-super, capture the would-be device's mode/uid/gid/rdev
         // in the rsync.%stat xattr so the destination can be restored later.

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -382,13 +382,13 @@ pub(crate) fn copy_device(
         )?;
         #[cfg(feature = "acl")]
         sync_acls_if_requested(
-                preserve_acls,
-                context.options().fake_super_enabled(),
-                mode,
-                source,
-                destination,
-                true,
-            )?;
+            preserve_acls,
+            context.options().fake_super_enabled(),
+            mode,
+            source,
+            destination,
+            true,
+        )?;
 
         // Under fake-super, capture the would-be device's mode/uid/gid/rdev
         // in the rsync.%stat xattr so the destination can be restored later.

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -290,7 +290,14 @@ pub(crate) fn copy_fifo(
                 context.filter_program(),
             )?;
             #[cfg(all(any(unix, windows), feature = "acl"))]
-            sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+            sync_acls_if_requested(
+                preserve_acls,
+                context.options().fake_super_enabled(),
+                mode,
+                source,
+                destination,
+                true,
+            )?;
 
             context.record_hard_link(metadata, destination);
             context.summary_mut().record_hard_link();
@@ -384,7 +391,14 @@ pub(crate) fn copy_fifo(
         context.filter_program(),
     )?;
     #[cfg(all(any(unix, windows), feature = "acl"))]
-    sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+    sync_acls_if_requested(
+                preserve_acls,
+                context.options().fake_super_enabled(),
+                mode,
+                source,
+                destination,
+                true,
+            )?;
 
     // Under fake-super, capture the would-be FIFO/socket's mode/uid/gid in
     // the rsync.%stat xattr so the destination can be restored later.

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -392,13 +392,13 @@ pub(crate) fn copy_fifo(
     )?;
     #[cfg(all(any(unix, windows), feature = "acl"))]
     sync_acls_if_requested(
-                preserve_acls,
-                context.options().fake_super_enabled(),
-                mode,
-                source,
-                destination,
-                true,
-            )?;
+        preserve_acls,
+        context.options().fake_super_enabled(),
+        mode,
+        source,
+        destination,
+        true,
+    )?;
 
     // Under fake-super, capture the would-be FIFO/socket's mode/uid/gid in
     // the rsync.%stat xattr so the destination can be restored later.

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -754,7 +754,14 @@ pub(crate) fn copy_symlink(
         context.filter_program(),
     )?;
     #[cfg(all(any(unix, windows), feature = "acl"))]
-    sync_acls_if_requested(preserve_acls, mode, source, destination, false)?;
+    sync_acls_if_requested(
+        preserve_acls,
+        context.options().fake_super_enabled(),
+        mode,
+        source,
+        destination,
+        false,
+    )?;
 
     context.record_hard_link(metadata, destination);
     context.summary_mut().record_symlink();

--- a/crates/engine/src/local_copy/metadata_sync.rs
+++ b/crates/engine/src/local_copy/metadata_sync.rs
@@ -19,7 +19,7 @@ use super::LocalCopyExecution;
 use super::FilterProgram;
 
 #[cfg(all(any(unix, windows), feature = "acl"))]
-use ::metadata::sync_acls;
+use ::metadata::{sync_acls, sync_acls_via_fake_super};
 
 #[cfg(all(unix, feature = "xattr"))]
 use ::metadata::sync_xattrs;
@@ -64,22 +64,38 @@ pub(crate) fn sync_xattrs_if_requested(
 
 /// Synchronizes POSIX/extended ACLs from source to destination if requested.
 ///
-/// No-op when `preserve_acls` is false or in dry-run mode.
-/// Unsupported-filesystem errors are silently ignored.
+/// No-op when `preserve_acls` is false or in dry-run mode. Under
+/// `--fake-super`, the ACL is stashed in the destination's `%aacl`/`%dacl`
+/// xattr instead of being applied with a real `setfacl` - an unprivileged
+/// fake-super receiver cannot reliably apply an arbitrary ACL (particularly
+/// named user/group entries), matching how ownership is stashed in `%stat`
+/// ([`store_effective_fake_super_if_requested`]). Unsupported-filesystem
+/// errors are silently ignored.
 ///
 /// # Errors
 ///
 /// Returns [`LocalCopyError`] if ACL synchronization fails.
+///
+/// # Upstream Reference
+///
+/// Mirrors the `am_root < 0` branches of `get_rsync_acl()`/`set_rsync_acl()`
+/// in `acls.c` lines 472-509 and 933-971.
 #[cfg(all(any(unix, windows), feature = "acl"))]
 pub(crate) fn sync_acls_if_requested(
     preserve_acls: bool,
+    fake_super: bool,
     mode: LocalCopyExecution,
     source: &Path,
     destination: &Path,
     follow_symlinks: bool,
 ) -> Result<(), LocalCopyError> {
     if preserve_acls && !mode.is_dry_run() {
-        sync_acls(source, destination, follow_symlinks).map_err(map_metadata_error)?;
+        if fake_super {
+            sync_acls_via_fake_super(source, destination, follow_symlinks)
+                .map_err(map_metadata_error)?;
+        } else {
+            sync_acls(source, destination, follow_symlinks).map_err(map_metadata_error)?;
+        }
     }
     Ok(())
 }

--- a/crates/metadata/src/acl_exacl/apply.rs
+++ b/crates/metadata/src/acl_exacl/apply.rs
@@ -118,3 +118,72 @@ pub fn apply_acls_from_cache(
 
     Ok(())
 }
+
+/// Stores parsed ACLs from an [`AclCache`] into `--fake-super` xattrs instead
+/// of applying them with a real `setfacl`.
+///
+/// An unprivileged account cannot reliably apply an arbitrary POSIX ACL -
+/// particularly named user/group entries - via a real `setfacl`, so under
+/// `--fake-super` the encoded ACL is stashed in `%aacl`/`%dacl` xattrs
+/// instead, mirroring how ownership is stashed in `%stat`
+/// ([`crate::fake_super::store_fake_super`]).
+///
+/// Symbolic links are skipped: they do not support ACLs (or, for the xattr
+/// route, portable `lsetxattr`) on any platform.
+///
+/// # Arguments
+///
+/// * `destination` - Path to store the fake-super ACL xattrs on.
+/// * `cache` - The ACL cache populated during file list reception.
+/// * `access_ndx` - Index into the access ACL cache.
+/// * `default_ndx` - Optional index into the default ACL cache (directories only).
+/// * `follow_symlinks` - Whether to process this entry at all. If `false`,
+///   returns immediately.
+///
+/// # Errors
+///
+/// Returns [`MetadataError`] if the underlying xattr operation fails.
+///
+/// # Upstream Reference
+///
+/// Mirrors the `am_root < 0` branch of `set_rsync_acl()` in `acls.c` lines
+/// 933-971.
+#[allow(clippy::module_name_repetitions)]
+pub fn store_acls_via_fake_super(
+    destination: &Path,
+    cache: &AclCache,
+    access_ndx: u32,
+    default_ndx: Option<u32>,
+    follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    use crate::fake_super::{remove_fake_super_default_acl, store_fake_super_acl};
+
+    if !follow_symlinks {
+        return Ok(());
+    }
+
+    if let Some(acl) = cache.get_access(access_ndx) {
+        store_fake_super_acl(destination, true, acl)
+            .map_err(|e| MetadataError::new("store fake-super access ACL", destination, e))?;
+    }
+
+    if let Some(def_ndx) = default_ndx {
+        match cache.get_default(def_ndx) {
+            // upstream: acls.c:934-935 - user_obj == NO_ENTRY means "no default
+            // ACL", so the xattr is removed rather than storing an empty ACL.
+            Some(def_acl) if !def_acl.has_user_obj() => {
+                remove_fake_super_default_acl(destination).map_err(|e| {
+                    MetadataError::new("remove fake-super default ACL", destination, e)
+                })?;
+            }
+            Some(def_acl) => {
+                store_fake_super_acl(destination, false, def_acl).map_err(|e| {
+                    MetadataError::new("store fake-super default ACL", destination, e)
+                })?;
+            }
+            None => {}
+        }
+    }
+
+    Ok(())
+}

--- a/crates/metadata/src/acl_exacl/mod.rs
+++ b/crates/metadata/src/acl_exacl/mod.rs
@@ -62,7 +62,7 @@ mod sync;
 #[cfg(test)]
 mod tests;
 
-pub use apply::apply_acls_from_cache;
+pub use apply::{apply_acls_from_cache, store_acls_via_fake_super};
 pub use default_perms::default_perms_for_dir;
 pub use read::get_rsync_acl;
 pub use sync::sync_acls;

--- a/crates/metadata/src/acl_exacl/mod.rs
+++ b/crates/metadata/src/acl_exacl/mod.rs
@@ -65,4 +65,4 @@ mod tests;
 pub use apply::{apply_acls_from_cache, store_acls_via_fake_super};
 pub use default_perms::default_perms_for_dir;
 pub use read::get_rsync_acl;
-pub use sync::sync_acls;
+pub use sync::{sync_acls, sync_acls_via_fake_super};

--- a/crates/metadata/src/acl_exacl/sync.rs
+++ b/crates/metadata/src/acl_exacl/sync.rs
@@ -143,3 +143,90 @@ pub fn sync_acls(
 
     Ok(())
 }
+
+/// Synchronizes ACLs from `source` to `destination` via `--fake-super` xattrs
+/// instead of applying them with a real `setfacl`.
+///
+/// Mirrors [`sync_acls`], but the destination write stashes the ACL in
+/// `%aacl`/`%dacl` rather than calling `sys_acl_set_file`/`setfacl` -
+/// matching how the network receive path stashes ACLs under fake-super
+/// (`store_acls_via_fake_super`). The *effective* source ACL is used: a prior
+/// fake-super receive at `source` may have stashed the ACL rather than
+/// applying it for real, so that stash - not the placeholder's real (and
+/// possibly reset) filesystem ACL - is preferred when present.
+///
+/// Symbolic links do not support ACLs; when `follow_symlinks` is `false`,
+/// this function returns immediately without performing any work.
+///
+/// # Errors
+///
+/// Returns [`MetadataError`] when reading the source's ACL or writing the
+/// destination's fake-super xattr fails.
+///
+/// # Upstream Reference
+///
+/// Mirrors the `am_root < 0` branches of `get_rsync_acl()` (`acls.c` lines
+/// 472-509) and `set_rsync_acl()` (`acls.c` lines 933-971).
+#[allow(clippy::module_name_repetitions)]
+pub fn sync_acls_via_fake_super(
+    source: &Path,
+    destination: &Path,
+    follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if !follow_symlinks {
+        return Ok(());
+    }
+
+    if !source.exists() {
+        return Err(MetadataError::new(
+            "read ACL",
+            source,
+            io::Error::new(io::ErrorKind::NotFound, "source does not exist"),
+        ));
+    }
+
+    let source_mode = fs::metadata(source)
+        .map_err(|e| MetadataError::new("stat", source, e))?
+        .permissions()
+        .mode();
+
+    // Prefer a stashed access ACL (an earlier fake-super receive at `source`);
+    // otherwise read the real filesystem ACL.
+    let access_acl = crate::fake_super::load_fake_super_acl(source, true)
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| super::read::get_rsync_acl(source, source_mode, false));
+
+    crate::fake_super::store_fake_super_acl(destination, true, &access_acl)
+        .map_err(|e| MetadataError::new("store fake-super access ACL", destination, e))?;
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    {
+        let is_dir = fs::symlink_metadata(source)
+            .map_err(|e| MetadataError::new("stat", source, e))?
+            .is_dir();
+
+        if is_dir {
+            let default_acl = crate::fake_super::load_fake_super_acl(source, false)
+                .ok()
+                .flatten()
+                .unwrap_or_else(|| super::read::get_rsync_acl(source, source_mode, true));
+
+            // upstream: acls.c:934-935 - user_obj == NO_ENTRY means "no default
+            // ACL", so the xattr is removed rather than storing an empty ACL.
+            if default_acl.has_user_obj() {
+                crate::fake_super::store_fake_super_acl(destination, false, &default_acl).map_err(
+                    |e| MetadataError::new("store fake-super default ACL", destination, e),
+                )?;
+            } else {
+                crate::fake_super::remove_fake_super_default_acl(destination).map_err(|e| {
+                    MetadataError::new("remove fake-super default ACL", destination, e)
+                })?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/metadata/src/acl_exacl/tests.rs
+++ b/crates/metadata/src/acl_exacl/tests.rs
@@ -6,7 +6,7 @@ use super::reconstruct::{reconstruct_acl, rsync_acl_to_entries};
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use super::reset::clear_default_acl;
 use super::reset::reset_acl_from_mode;
-use super::sync::sync_acls;
+use super::sync::{sync_acls, sync_acls_via_fake_super};
 
 use exacl::{AclEntryKind, Perm};
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -49,6 +49,72 @@ fn sync_acls_works_with_directories() {
 
     let result = sync_acls(&source, &destination, true);
     assert!(result.is_ok());
+}
+
+#[test]
+fn sync_acls_via_fake_super_skips_when_not_following_symlinks() {
+    let dir = tempdir().expect("tempdir");
+    let source = dir.path().join("src");
+    let destination = dir.path().join("dst");
+    File::create(&source).expect("create src");
+    File::create(&destination).expect("create dst");
+
+    let result = sync_acls_via_fake_super(&source, &destination, false);
+    assert!(result.is_ok());
+}
+
+// A named-user ACL entry set on the source (via a real `setfacl`) must land
+// in the destination's `%aacl` xattr - not as a real ACL - confirming the
+// fake-super local-copy path stashes rather than applies. Mirrors the
+// wire/receive-path coverage in `fake_super.rs`'s
+// `store_and_load_fake_super_acl_roundtrips`, but exercised through the
+// source-to-destination sync entry point used by `engine::local_copy`.
+#[test]
+fn sync_acls_via_fake_super_stashes_named_entry_instead_of_applying() {
+    use crate::fake_super::load_fake_super_acl;
+
+    let dir = tempdir().expect("tempdir");
+    let source = dir.path().join("src");
+    let destination = dir.path().join("dst");
+    File::create(&source).expect("create src");
+    File::create(&destination).expect("create dst");
+
+    // Skip on filesystems without user xattr support (matches other
+    // fake-super tests in this crate).
+    if load_fake_super_acl(&source, true).is_err() {
+        return;
+    }
+
+    let entries = vec![exacl::AclEntry::allow_user(
+        "1000",
+        Perm::READ | Perm::WRITE,
+        None,
+    )];
+    if exacl::setfacl(&[&source], &entries, None).is_err() {
+        return;
+    }
+
+    if sync_acls_via_fake_super(&source, &destination, true).is_err() {
+        return;
+    }
+
+    let stashed = load_fake_super_acl(&destination, true)
+        .expect("load must succeed")
+        .expect("access ACL xattr must be present");
+    assert!(
+        !stashed.names.is_empty(),
+        "named entry must be stashed in the destination's %aacl xattr"
+    );
+
+    // The destination must NOT have picked up a real POSIX ACL: fake-super
+    // stashes instead of applying.
+    let real_acl = exacl::getfacl(&destination, None).unwrap_or_default();
+    assert!(
+        !real_acl
+            .iter()
+            .any(|e| e.kind == AclEntryKind::User && e.name == "1000"),
+        "fake-super must not apply a real ACL to the destination"
+    );
 }
 
 #[test]

--- a/crates/metadata/src/acl_noop.rs
+++ b/crates/metadata/src/acl_noop.rs
@@ -66,6 +66,22 @@ pub fn apply_acls_from_cache(
     Ok(())
 }
 
+/// Stores parsed ACLs from an [`AclCache`] into `--fake-super` xattrs.
+///
+/// On platforms without ACL support, emits a one-time warning and
+/// returns `Ok(())`.
+#[allow(clippy::module_name_repetitions)]
+pub fn store_acls_via_fake_super(
+    _destination: &Path,
+    _cache: &AclCache,
+    _access_ndx: u32,
+    _default_ndx: Option<u32>,
+    _follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    warn_acl_unsupported();
+    Ok(())
+}
+
 /// Returns the umask-derived default permissions for `dir`.
 ///
 /// Platforms without POSIX default-ACL support fall straight through to the
@@ -128,6 +144,14 @@ mod tests {
         let dst = Path::new("/nonexistent/dst");
         let cache = AclCache::new();
         let result = apply_acls_from_cache(dst, &cache, 0, Some(1), true, Some(0o644), None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn store_acls_via_fake_super_returns_ok() {
+        let dst = Path::new("/nonexistent/dst");
+        let cache = AclCache::new();
+        let result = store_acls_via_fake_super(dst, &cache, 0, Some(1), true);
         assert!(result.is_ok());
     }
 }

--- a/crates/metadata/src/acl_noop.rs
+++ b/crates/metadata/src/acl_noop.rs
@@ -35,6 +35,18 @@ pub fn sync_acls(
     Ok(())
 }
 
+/// No-op fake-super ACL synchronisation with a one-time warning.
+///
+/// Mirrors [`sync_acls`]'s behaviour: no work, one-time warning, `Ok(())`.
+pub fn sync_acls_via_fake_super(
+    _source: &Path,
+    _destination: &Path,
+    _follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    warn_acl_unsupported();
+    Ok(())
+}
+
 /// Synthesises an [`RsyncAcl`] from `mode`, since this platform cannot read a
 /// filesystem ACL.
 ///
@@ -112,6 +124,14 @@ mod tests {
         let src = Path::new("/nonexistent/src");
         let dst = Path::new("/nonexistent/dst");
         let result = sync_acls(src, dst, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sync_acls_via_fake_super_returns_ok() {
+        let src = Path::new("/nonexistent/src");
+        let dst = Path::new("/nonexistent/dst");
+        let result = sync_acls_via_fake_super(src, dst, true);
         assert!(result.is_ok());
     }
 

--- a/crates/metadata/src/acl_stub.rs
+++ b/crates/metadata/src/acl_stub.rs
@@ -82,6 +82,23 @@ pub fn apply_acls_from_cache(
     Ok(())
 }
 
+/// Stores parsed ACLs from an [`AclCache`] into `--fake-super` xattrs.
+///
+/// On iOS/tvOS/watchOS platforms without ACL support, emits a one-time
+/// warning and returns `Ok(())`.
+#[allow(clippy::module_name_repetitions)]
+pub fn store_acls_via_fake_super(
+    destination: &Path,
+    cache: &AclCache,
+    access_ndx: u32,
+    default_ndx: Option<u32>,
+    follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    let _ = (destination, cache, access_ndx, default_ndx, follow_symlinks);
+    warn_acl_unsupported();
+    Ok(())
+}
+
 /// Returns the umask-derived default permissions for `dir`.
 ///
 /// iOS/tvOS/watchOS lack POSIX default-ACL support, so this stub returns
@@ -128,6 +145,14 @@ mod tests {
         let dst = Path::new("/nonexistent/dst");
         let cache = AclCache::new();
         let result = apply_acls_from_cache(dst, &cache, 0, None, false, None, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn store_acls_via_fake_super_returns_ok() {
+        let dst = Path::new("/nonexistent/dst");
+        let cache = AclCache::new();
+        let result = store_acls_via_fake_super(dst, &cache, 0, None, false);
         assert!(result.is_ok());
     }
 }

--- a/crates/metadata/src/acl_stub.rs
+++ b/crates/metadata/src/acl_stub.rs
@@ -40,6 +40,20 @@ pub fn sync_acls(
     Ok(())
 }
 
+/// Stub fake-super ACL synchronisation for iOS/tvOS/watchOS platforms.
+///
+/// Mirrors [`sync_acls`]'s behaviour: no work, one-time warning, `Ok(())`.
+#[allow(clippy::module_name_repetitions)]
+pub fn sync_acls_via_fake_super(
+    source: &Path,
+    destination: &Path,
+    follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    let _ = (source, destination, follow_symlinks);
+    warn_acl_unsupported();
+    Ok(())
+}
+
 /// Synthesises an [`RsyncAcl`] from `mode`, since iOS/tvOS/watchOS cannot read a
 /// filesystem ACL.
 ///
@@ -121,6 +135,14 @@ mod tests {
         let src = Path::new("/nonexistent/src");
         let dst = Path::new("/nonexistent/dst");
         let result = sync_acls(src, dst, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sync_acls_via_fake_super_returns_ok() {
+        let src = Path::new("/nonexistent/src");
+        let dst = Path::new("/nonexistent/dst");
+        let result = sync_acls_via_fake_super(src, dst, false);
         assert!(result.is_ok());
     }
 

--- a/crates/metadata/src/acl_windows/dacl.rs
+++ b/crates/metadata/src/acl_windows/dacl.rs
@@ -290,6 +290,28 @@ pub fn apply_acls_from_cache(
     apply_rsync_acl_to_path(destination, &reconstructed)
 }
 
+/// Stores parsed ACLs from an [`AclCache`] into `--fake-super` xattrs.
+///
+/// `--fake-super`'s `%aacl`/`%dacl` stashing is a POSIX-ACL-only mechanism
+/// (upstream: `acls.c`'s `am_root < 0` branch operates on `SMB_ACL_T`, which
+/// has no Windows equivalent). Windows ACLs are already persisted via their
+/// own SDDL xattr (`WINDOWS_SDDL_XATTR_NAME`), so this falls straight through
+/// to the normal apply path unchanged.
+///
+/// # Errors
+///
+/// Returns [`MetadataError`] on unrecoverable Win32 failures.
+#[allow(clippy::module_name_repetitions)]
+pub fn store_acls_via_fake_super(
+    destination: &Path,
+    cache: &AclCache,
+    access_ndx: u32,
+    default_ndx: Option<u32>,
+    follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    apply_acls_from_cache(destination, cache, access_ndx, default_ndx, follow_symlinks, None, None)
+}
+
 /// Returns the umask-derived default permissions for `dir`.
 ///
 /// Windows lacks POSIX default ACLs, so this returns `ACCESSPERMS & ~umask`

--- a/crates/metadata/src/acl_windows/dacl.rs
+++ b/crates/metadata/src/acl_windows/dacl.rs
@@ -309,7 +309,15 @@ pub fn store_acls_via_fake_super(
     default_ndx: Option<u32>,
     follow_symlinks: bool,
 ) -> Result<(), MetadataError> {
-    apply_acls_from_cache(destination, cache, access_ndx, default_ndx, follow_symlinks, None, None)
+    apply_acls_from_cache(
+        destination,
+        cache,
+        access_ndx,
+        default_ndx,
+        follow_symlinks,
+        None,
+        None,
+    )
 }
 
 /// Returns the umask-derived default permissions for `dir`.

--- a/crates/metadata/src/acl_windows/mod.rs
+++ b/crates/metadata/src/acl_windows/mod.rs
@@ -59,7 +59,7 @@ pub use dacl::{
 };
 pub use posix_map::{dacl_to_posix_mode, posix_mode_to_dacl};
 pub use sddl::{read_dacl_sddl, read_sddl_with_sacl, write_dacl_sddl};
-pub use sync::sync_acls;
+pub use sync::{sync_acls, sync_acls_via_fake_super};
 pub use xattr::{
     WINDOWS_SDDL_XATTR_NAME, apply_sddl_from_xattrs, find_sddl_in_xattrs, sddl_xattr_entry,
 };

--- a/crates/metadata/src/acl_windows/mod.rs
+++ b/crates/metadata/src/acl_windows/mod.rs
@@ -54,7 +54,9 @@ mod xattr;
 #[cfg(test)]
 mod tests;
 
-pub use dacl::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl};
+pub use dacl::{
+    apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, store_acls_via_fake_super,
+};
 pub use posix_map::{dacl_to_posix_mode, posix_mode_to_dacl};
 pub use sddl::{read_dacl_sddl, read_sddl_with_sacl, write_dacl_sddl};
 pub use sync::sync_acls;

--- a/crates/metadata/src/acl_windows/sync.rs
+++ b/crates/metadata/src/acl_windows/sync.rs
@@ -73,3 +73,21 @@ pub fn sync_acls(
 
     apply_rsync_acl_to_path(destination, &acl)
 }
+
+/// Fake-super variant of [`sync_acls`] for Windows.
+///
+/// `--fake-super`'s `%aacl`/`%dacl` stashing is a POSIX-ACL-only mechanism
+/// (see [`super::dacl::store_acls_via_fake_super`]); Windows ACLs are already
+/// persisted via their own SDDL xattr, so this falls straight through to the
+/// normal sync path unchanged.
+///
+/// # Errors
+///
+/// Returns [`MetadataError`] on unrecoverable Win32 failures.
+pub fn sync_acls_via_fake_super(
+    source: &Path,
+    destination: &Path,
+    follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    sync_acls(source, destination, follow_symlinks)
+}

--- a/crates/metadata/src/fake_super.rs
+++ b/crates/metadata/src/fake_super.rs
@@ -38,6 +38,26 @@ pub const FAKE_SUPER_XATTR: &str = "user.rsync.%stat";
 #[cfg(not(target_os = "linux"))]
 pub const FAKE_SUPER_XATTR: &str = "rsync.%stat";
 
+/// The xattr name used to store a fake-super access ACL.
+///
+/// Follows the same platform-prefix rule as [`FAKE_SUPER_XATTR`].
+/// upstream: `xattrs.c:75-76` `XACC_ACL_ATTR` (`RSYNC_PREFIX "%aacl"`).
+#[cfg(target_os = "linux")]
+pub const FAKE_SUPER_ACCESS_ACL_XATTR: &str = "user.rsync.%aacl";
+/// The fake-super access-ACL xattr name on non-Linux platforms.
+#[cfg(not(target_os = "linux"))]
+pub const FAKE_SUPER_ACCESS_ACL_XATTR: &str = "rsync.%aacl";
+
+/// The xattr name used to store a fake-super default (directory) ACL.
+///
+/// Follows the same platform-prefix rule as [`FAKE_SUPER_XATTR`].
+/// upstream: `xattrs.c:77-78` `XDEF_ACL_ATTR` (`RSYNC_PREFIX "%dacl"`).
+#[cfg(target_os = "linux")]
+pub const FAKE_SUPER_DEFAULT_ACL_XATTR: &str = "user.rsync.%dacl";
+/// The fake-super default-ACL xattr name on non-Linux platforms.
+#[cfg(not(target_os = "linux"))]
+pub const FAKE_SUPER_DEFAULT_ACL_XATTR: &str = "rsync.%dacl";
+
 /// Parsed fake-super metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FakeSuperStat {
@@ -268,6 +288,84 @@ pub fn remove_fake_super(path: &Path) -> io::Result<()> {
     }
 }
 
+/// Returns the fake-super xattr name for an access or default ACL.
+#[cfg(all(unix, feature = "xattr"))]
+const fn fake_super_acl_xattr(is_access_acl: bool) -> &'static str {
+    if is_access_acl {
+        FAKE_SUPER_ACCESS_ACL_XATTR
+    } else {
+        FAKE_SUPER_DEFAULT_ACL_XATTR
+    }
+}
+
+/// Stores an ACL as a fake-super xattr on a file.
+///
+/// Called when `--fake-super` is enabled and `--acls` is active: an
+/// unprivileged account cannot reliably apply an arbitrary POSIX ACL (in
+/// particular named user/group entries) via a real `setfacl`, so the encoded
+/// ACL is stashed in `%aacl`/`%dacl` instead, mirroring how ownership is
+/// stashed in `%stat`.
+///
+/// # Upstream Reference
+///
+/// Mirrors the `am_root < 0` branch of `set_rsync_acl()` in `acls.c` lines
+/// 950-971, which calls `set_xattr_acl()` (`xattrs.c` lines 1118-1126).
+#[cfg(all(unix, feature = "xattr"))]
+pub fn store_fake_super_acl(
+    path: &Path,
+    is_access_acl: bool,
+    acl: &protocol::acl::RsyncAcl,
+) -> io::Result<()> {
+    xattr::set(path, fake_super_acl_xattr(is_access_acl), &acl.to_fake_super_bytes())
+}
+
+/// Retrieves a fake-super ACL from a file's xattr.
+///
+/// Returns `None` if the xattr does not exist. Returns an error if the xattr
+/// exists but its byte layout is corrupt (mirrors upstream's `get_rsync_acl()`
+/// returning an error on a malformed length, `acls.c` lines 483-486).
+#[cfg(all(unix, feature = "xattr"))]
+pub fn load_fake_super_acl(
+    path: &Path,
+    is_access_acl: bool,
+) -> io::Result<Option<protocol::acl::RsyncAcl>> {
+    let name = fake_super_acl_xattr(is_access_acl);
+    match xattr::get(path, name) {
+        Ok(Some(bytes)) => protocol::acl::RsyncAcl::from_fake_super_bytes(&bytes)
+            .map(Some)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("corrupt {name} xattr: {} bytes", bytes.len()),
+                )
+            }),
+        Ok(None) => Ok(None),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Removes the fake-super default-ACL xattr from a file.
+///
+/// Called when a directory's default ACL was removed at the source (encoded
+/// as `user_obj == NO_ENTRY`, i.e. [`protocol::acl::RsyncAcl::has_user_obj`]
+/// is `false`): upstream deletes the `%dacl` xattr in that case rather than
+/// storing an empty ACL.
+///
+/// # Upstream Reference
+///
+/// Mirrors `del_def_xattr_acl()` in `xattrs.c` lines 1128-1131, called from
+/// `set_rsync_acl()`'s default-ACL-removal branch (`acls.c` lines 933-949).
+#[cfg(all(unix, feature = "xattr"))]
+pub fn remove_fake_super_default_acl(path: &Path) -> io::Result<()> {
+    match xattr::remove(path, FAKE_SUPER_DEFAULT_ACL_XATTR) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) if is_absent_xattr(&e) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 /// Computes the *effective* fake-super stat for a source file.
 ///
 /// Under `--fake-super`, a source placeholder file may already carry a
@@ -385,6 +483,34 @@ pub fn load_fake_super(_path: &Path) -> io::Result<Option<FakeSuperStat>> {
 /// No-op on platforms without xattr support.
 #[cfg(not(all(unix, feature = "xattr")))]
 pub fn remove_fake_super(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+/// Returns `Unsupported` on platforms without xattr support.
+#[cfg(not(all(unix, feature = "xattr")))]
+pub fn store_fake_super_acl(
+    _path: &Path,
+    _is_access_acl: bool,
+    _acl: &protocol::acl::RsyncAcl,
+) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "fake-super requires xattr support",
+    ))
+}
+
+/// Always returns `Ok(None)` on platforms without xattr support.
+#[cfg(not(all(unix, feature = "xattr")))]
+pub fn load_fake_super_acl(
+    _path: &Path,
+    _is_access_acl: bool,
+) -> io::Result<Option<protocol::acl::RsyncAcl>> {
+    Ok(None)
+}
+
+/// No-op on platforms without xattr support.
+#[cfg(not(all(unix, feature = "xattr")))]
+pub fn remove_fake_super_default_acl(_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
@@ -606,6 +732,101 @@ mod tests {
         remove_fake_super(&path).expect("remove of absent fake-super xattr must be Ok");
     }
 
+    // Verifies the `%aacl`/`%dacl` xattr names follow the same platform-prefix
+    // rule as `%stat` (upstream: xattrs.c:64-78 RSYNC_PREFIX + XACC_ACL_ATTR /
+    // XDEF_ACL_ATTR).
+    #[test]
+    fn fake_super_acl_xattr_names_match_platform_namespace() {
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(FAKE_SUPER_ACCESS_ACL_XATTR, "user.rsync.%aacl");
+            assert_eq!(FAKE_SUPER_DEFAULT_ACL_XATTR, "user.rsync.%dacl");
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert_eq!(FAKE_SUPER_ACCESS_ACL_XATTR, "rsync.%aacl");
+            assert_eq!(FAKE_SUPER_DEFAULT_ACL_XATTR, "rsync.%dacl");
+        }
+    }
+
+    // A stored access ACL must read back byte-for-byte identical, including
+    // named user/group entries - the exact round trip a `--fake-super --acls`
+    // receive-then-resend cycle depends on.
+    #[cfg(all(unix, feature = "xattr"))]
+    #[test]
+    fn store_and_load_fake_super_acl_roundtrips() {
+        use protocol::acl::{IdAccess, RsyncAcl};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("acl-file");
+        std::fs::write(&path, b"body").expect("write");
+
+        let mut acl = RsyncAcl::new();
+        acl.user_obj = 0x07;
+        acl.group_obj = 0x05;
+        acl.mask_obj = 0x07;
+        acl.other_obj = 0x04;
+        acl.names.push(IdAccess::user(1000, 0x07));
+
+        // Skip when the FS can't hold user xattrs (e.g. tmpfs without support).
+        if store_fake_super_acl(&path, true, &acl).is_err() {
+            return;
+        }
+
+        let loaded = load_fake_super_acl(&path, true)
+            .expect("load must succeed")
+            .expect("xattr must be present");
+        assert_eq!(loaded, acl);
+
+        // The default-ACL xattr is a separate attribute; it must not exist yet.
+        assert!(
+            load_fake_super_acl(&path, false)
+                .expect("load must succeed")
+                .is_none()
+        );
+    }
+
+    // `remove_fake_super_default_acl` on a file that never had a `%dacl` xattr
+    // must succeed, mirroring `remove_fake_super_absent_xattr_is_ok` above.
+    #[cfg(all(unix, feature = "xattr"))]
+    #[test]
+    fn remove_fake_super_default_acl_absent_is_ok() {
+        use protocol::acl::RsyncAcl;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        // Confirm the FS supports user xattrs at all; skip otherwise.
+        let probe = temp.path().join("probe");
+        std::fs::write(&probe, b"probe").expect("write");
+        if store_fake_super_acl(&probe, true, &RsyncAcl::new()).is_err() {
+            return;
+        }
+
+        let path = temp.path().join("no-dacl");
+        std::fs::write(&path, b"body").expect("write");
+        remove_fake_super_default_acl(&path)
+            .expect("remove of absent fake-super default ACL xattr must be Ok");
+    }
+
+    // A corrupt xattr value (bad length) must surface as an error, not a
+    // silent `None`, mirroring upstream's `get_rsync_acl()` error path
+    // (acls.c:483-486).
+    #[cfg(all(unix, feature = "xattr"))]
+    #[test]
+    fn load_fake_super_acl_rejects_corrupt_value() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("corrupt-acl");
+        std::fs::write(&path, b"body").expect("write");
+
+        // 5 bytes: shorter than the 16-byte base header.
+        if xattr::set(&path, FAKE_SUPER_ACCESS_ACL_XATTR, &[0u8; 5]).is_err() {
+            return;
+        }
+
+        let err = load_fake_super_acl(&path, true).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
     #[cfg(not(all(unix, feature = "xattr")))]
     mod stub_tests {
         use super::*;
@@ -636,6 +857,28 @@ mod tests {
         fn remove_fake_super_stub_returns_ok() {
             let path = Path::new("/nonexistent/file");
             let result = remove_fake_super(path);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn store_fake_super_acl_stub_returns_unsupported() {
+            let path = Path::new("/nonexistent/file");
+            let acl = protocol::acl::RsyncAcl::new();
+            let err = store_fake_super_acl(path, true, &acl).unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+        }
+
+        #[test]
+        fn load_fake_super_acl_stub_returns_none() {
+            let path = Path::new("/nonexistent/file");
+            let result = load_fake_super_acl(path, true).unwrap();
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn remove_fake_super_default_acl_stub_returns_ok() {
+            let path = Path::new("/nonexistent/file");
+            let result = remove_fake_super_default_acl(path);
             assert!(result.is_ok());
         }
     }

--- a/crates/metadata/src/fake_super.rs
+++ b/crates/metadata/src/fake_super.rs
@@ -316,7 +316,11 @@ pub fn store_fake_super_acl(
     is_access_acl: bool,
     acl: &protocol::acl::RsyncAcl,
 ) -> io::Result<()> {
-    xattr::set(path, fake_super_acl_xattr(is_access_acl), &acl.to_fake_super_bytes())
+    xattr::set(
+        path,
+        fake_super_acl_xattr(is_access_acl),
+        &acl.to_fake_super_bytes(),
+    )
 }
 
 /// Retrieves a fake-super ACL from a file's xattr.

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -209,7 +209,7 @@ pub use acl_idmap::AclIdMapper;
 ))]
 pub use acl_exacl::{
     apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, store_acls_via_fake_super,
-    sync_acls,
+    sync_acls, sync_acls_via_fake_super,
 };
 
 #[cfg(all(
@@ -218,14 +218,15 @@ pub use acl_exacl::{
 ))]
 pub use acl_stub::{
     apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, store_acls_via_fake_super,
-    sync_acls,
+    sync_acls, sync_acls_via_fake_super,
 };
 
 #[cfg(all(feature = "acl", windows))]
 pub use acl_windows::{
     WINDOWS_SDDL_XATTR_NAME, apply_acls_from_cache, apply_sddl_from_xattrs, dacl_to_posix_mode,
     default_perms_for_dir, find_sddl_in_xattrs, get_rsync_acl, posix_mode_to_dacl, read_dacl_sddl,
-    read_sddl_with_sacl, sddl_xattr_entry, store_acls_via_fake_super, sync_acls, write_dacl_sddl,
+    read_sddl_with_sacl, sddl_xattr_entry, store_acls_via_fake_super, sync_acls,
+    sync_acls_via_fake_super, write_dacl_sddl,
 };
 
 #[cfg(not(any(
@@ -244,7 +245,7 @@ pub use acl_windows::{
 )))]
 pub use acl_noop::{
     apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, store_acls_via_fake_super,
-    sync_acls,
+    sync_acls, sync_acls_via_fake_super,
 };
 
 #[cfg(unix)]

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -207,19 +207,25 @@ pub use acl_idmap::AclIdMapper;
     feature = "acl",
     any(target_os = "linux", target_os = "macos", target_os = "freebsd")
 ))]
-pub use acl_exacl::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
+pub use acl_exacl::{
+    apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, store_acls_via_fake_super,
+    sync_acls,
+};
 
 #[cfg(all(
     feature = "acl",
     any(target_os = "ios", target_os = "tvos", target_os = "watchos")
 ))]
-pub use acl_stub::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
+pub use acl_stub::{
+    apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, store_acls_via_fake_super,
+    sync_acls,
+};
 
 #[cfg(all(feature = "acl", windows))]
 pub use acl_windows::{
     WINDOWS_SDDL_XATTR_NAME, apply_acls_from_cache, apply_sddl_from_xattrs, dacl_to_posix_mode,
     default_perms_for_dir, find_sddl_in_xattrs, get_rsync_acl, posix_mode_to_dacl, read_dacl_sddl,
-    read_sddl_with_sacl, sddl_xattr_entry, sync_acls, write_dacl_sddl,
+    read_sddl_with_sacl, sddl_xattr_entry, store_acls_via_fake_super, sync_acls, write_dacl_sddl,
 };
 
 #[cfg(not(any(
@@ -236,7 +242,10 @@ pub use acl_windows::{
     ),
     all(feature = "acl", windows),
 )))]
-pub use acl_noop::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
+pub use acl_noop::{
+    apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, store_acls_via_fake_super,
+    sync_acls,
+};
 
 #[cfg(unix)]
 pub use apply::{
@@ -284,8 +293,9 @@ pub use xattr_stub::{
 pub use copy_as::{CopyAsGuard, CopyAsIds, parse_copy_as_spec, switch_effective_ids};
 
 pub use fake_super::{
-    FAKE_SUPER_XATTR, FakeSuperStat, effective_source_stat, load_fake_super, remove_fake_super,
-    store_fake_super,
+    FAKE_SUPER_ACCESS_ACL_XATTR, FAKE_SUPER_DEFAULT_ACL_XATTR, FAKE_SUPER_XATTR, FakeSuperStat,
+    effective_source_stat, load_fake_super, load_fake_super_acl, remove_fake_super,
+    remove_fake_super_default_acl, store_fake_super, store_fake_super_acl,
 };
 
 pub use symlink_munge::{SYMLINK_MUNGE_PREFIX, munge_symlink, unmunge_symlink};

--- a/crates/protocol/src/acl/entry.rs
+++ b/crates/protocol/src/acl/entry.rs
@@ -269,6 +269,77 @@ impl RsyncAcl {
         }
         flags
     }
+
+    /// Encodes this ACL into upstream's `--fake-super` xattr byte format.
+    ///
+    /// Four little-endian `u32` base fields (`user_obj`, `group_obj`,
+    /// `mask_obj`, `other_obj` - zero-extended from the `u8` permission value
+    /// or the `NO_ENTRY` sentinel), followed by one 8-byte `(id: u32 LE,
+    /// access: u32 LE)` record per named entry in `names`. `access` is the
+    /// raw in-memory value, including the `NAME_IS_USER` high bit.
+    ///
+    /// # Upstream Reference
+    ///
+    /// Mirrors the blob written by `set_rsync_acl()` (`acls.c` lines 933-970)
+    /// via `set_xattr_acl()` (`xattrs.c` lines 1112-1125).
+    #[must_use]
+    pub fn to_fake_super_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(16 + self.names.len() * 8);
+        buf.extend_from_slice(&u32::from(self.user_obj).to_le_bytes());
+        buf.extend_from_slice(&u32::from(self.group_obj).to_le_bytes());
+        buf.extend_from_slice(&u32::from(self.mask_obj).to_le_bytes());
+        buf.extend_from_slice(&u32::from(self.other_obj).to_le_bytes());
+        for ida in self.names.iter() {
+            buf.extend_from_slice(&ida.id.to_le_bytes());
+            buf.extend_from_slice(&ida.access.to_le_bytes());
+        }
+        buf
+    }
+
+    /// Decodes an ACL from upstream's `--fake-super` xattr byte format.
+    ///
+    /// Returns `None` when `buf` is shorter than the 16-byte base header or
+    /// its length is not `16 + 8*n` for some named-entry count `n`, mirroring
+    /// `get_rsync_acl()`'s length validation (`acls.c` lines 483-486).
+    ///
+    /// # Upstream Reference
+    ///
+    /// Mirrors the `am_root < 0` branch of `get_rsync_acl()` in `acls.c`
+    /// lines 472-509.
+    #[must_use]
+    pub fn from_fake_super_bytes(buf: &[u8]) -> Option<Self> {
+        if buf.len() < 16 {
+            return None;
+        }
+        let names_len = buf.len() - 16;
+        if names_len % 8 != 0 {
+            return None;
+        }
+        let count = names_len / 8;
+
+        let u32_at = |offset: usize| -> u32 {
+            u32::from_le_bytes(buf[offset..offset + 4].try_into().unwrap_or([0; 4]))
+        };
+
+        let mut acl = Self {
+            names: IdaEntries::with_capacity(count),
+            user_obj: u32_at(0) as u8,
+            group_obj: u32_at(4) as u8,
+            mask_obj: u32_at(8) as u8,
+            other_obj: u32_at(12) as u8,
+        };
+
+        for i in 0..count {
+            let offset = 16 + i * 8;
+            acl.names.push(IdAccess {
+                id: u32_at(offset),
+                access: u32_at(offset + 4),
+                name: None,
+            });
+        }
+
+        Some(acl)
+    }
 }
 
 /// POSIX ACL tag type for permission extraction from file mode bits.

--- a/crates/protocol/src/acl/tests.rs
+++ b/crates/protocol/src/acl/tests.rs
@@ -182,6 +182,78 @@ mod rsync_acl_tests {
     }
 }
 
+/// Tests for the `--fake-super` xattr byte format (`%aacl`/`%dacl` blobs).
+///
+/// Upstream: `acls.c:472-509` `get_rsync_acl()` and `acls.c:933-970`
+/// `set_rsync_acl()` (the `am_root < 0` branches).
+mod fake_super_bytes_tests {
+    use super::*;
+
+    #[test]
+    fn empty_acl_encodes_to_16_byte_header() {
+        let acl = RsyncAcl::new();
+        let bytes = acl.to_fake_super_bytes();
+        assert_eq!(bytes.len(), 16);
+        // All four base fields are NO_ENTRY (0x80), zero-extended to u32 LE.
+        assert_eq!(&bytes[0..4], &[0x80, 0, 0, 0]);
+        assert_eq!(&bytes[4..8], &[0x80, 0, 0, 0]);
+        assert_eq!(&bytes[8..12], &[0x80, 0, 0, 0]);
+        assert_eq!(&bytes[12..16], &[0x80, 0, 0, 0]);
+    }
+
+    #[test]
+    fn roundtrip_base_entries_only() {
+        let mut acl = RsyncAcl::new();
+        acl.user_obj = 0x07;
+        acl.group_obj = 0x05;
+        acl.mask_obj = 0x07;
+        acl.other_obj = 0x04;
+
+        let bytes = acl.to_fake_super_bytes();
+        let decoded = RsyncAcl::from_fake_super_bytes(&bytes).expect("valid blob");
+        assert_eq!(decoded, acl);
+    }
+
+    #[test]
+    fn roundtrip_with_named_entries() {
+        let mut acl = RsyncAcl::new();
+        acl.user_obj = 0x07;
+        acl.group_obj = 0x05;
+        acl.mask_obj = 0x07;
+        acl.other_obj = 0x04;
+        acl.names.push(IdAccess::user(1000, 0x07));
+        acl.names.push(IdAccess::group(100, 0x05));
+
+        let bytes = acl.to_fake_super_bytes();
+        assert_eq!(bytes.len(), 16 + 2 * 8);
+        let decoded = RsyncAcl::from_fake_super_bytes(&bytes).expect("valid blob");
+        assert_eq!(decoded, acl);
+        // The user entry's NAME_IS_USER bit (bit 31) must survive the round trip
+        // since it distinguishes user from group entries in the ida list.
+        assert!(decoded.names.iter().next().unwrap().is_user());
+    }
+
+    #[test]
+    fn from_bytes_rejects_short_header() {
+        assert!(RsyncAcl::from_fake_super_bytes(&[0u8; 15]).is_none());
+        assert!(RsyncAcl::from_fake_super_bytes(&[]).is_none());
+    }
+
+    #[test]
+    fn from_bytes_rejects_misaligned_trailer() {
+        // 16-byte header plus a partial (non-multiple-of-8) named entry.
+        assert!(RsyncAcl::from_fake_super_bytes(&[0u8; 20]).is_none());
+        assert!(RsyncAcl::from_fake_super_bytes(&[0u8; 23]).is_none());
+    }
+
+    #[test]
+    fn from_bytes_accepts_exact_multiple_of_8_trailer() {
+        assert!(RsyncAcl::from_fake_super_bytes(&[0u8; 16]).is_some());
+        assert!(RsyncAcl::from_fake_super_bytes(&[0u8; 24]).is_some());
+        assert!(RsyncAcl::from_fake_super_bytes(&[0u8; 32]).is_some());
+    }
+}
+
 /// Tests for `AclCache` structure.
 mod acl_cache_tests {
     use super::*;

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -107,15 +107,30 @@ fn apply_metadata_acls_and_xattrs(
     if let Some(cache) = acl_cache {
         if let Some(access_ndx) = entry.acl_ndx() {
             let follow = !entry.is_symlink();
-            if let Err(e) = metadata::apply_acls_from_cache(
-                file_path,
-                cache,
-                access_ndx,
-                entry.def_acl_ndx(),
-                follow,
-                Some(entry.mode()),
-                acl_id_map,
-            ) {
+            // upstream: acls.c:930-971 - under `--fake-super`, set_rsync_acl()
+            // stashes the ACL in an xattr instead of calling sys_acl_set_file(),
+            // since an unprivileged account cannot reliably apply an arbitrary
+            // ACL (particularly named user/group entries).
+            let result = if opts.fake_super_enabled() {
+                metadata::store_acls_via_fake_super(
+                    file_path,
+                    cache,
+                    access_ndx,
+                    entry.def_acl_ndx(),
+                    follow,
+                )
+            } else {
+                metadata::apply_acls_from_cache(
+                    file_path,
+                    cache,
+                    access_ndx,
+                    entry.def_acl_ndx(),
+                    follow,
+                    Some(entry.mode()),
+                    acl_id_map,
+                )
+            };
+            if let Err(e) = result {
                 return Some((file_path.to_path_buf(), e.to_string()));
             }
         }

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -11,6 +11,7 @@
 //! - `sender.c:120` - `receive_sums()` reads signature blocks
 
 use std::io::{self, IoSlice, Read, Write};
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use logging::{InfoFlag, PhaseTimer, debug_log, info_gte};
@@ -786,16 +787,47 @@ impl GeneratorContext {
         let mode = entry.mode();
 
         // upstream: acls.c:560-561 - read access ACL
-        let access_acl = metadata::get_rsync_acl(&full_path, mode, false);
+        let access_acl = self.read_source_acl(&full_path, mode, false);
 
         // upstream: acls.c:566-569 - read default ACL for directories
         let default_acl = if entry.is_dir() {
-            Some(metadata::get_rsync_acl(&full_path, mode, true))
+            Some(self.read_source_acl(&full_path, mode, true))
         } else {
             None
         };
 
         flist_writer.set_pending_acl(access_acl, default_acl);
+    }
+
+    /// Reads the effective ACL for a source path, preferring a stashed
+    /// `--fake-super` xattr over the real filesystem ACL when present.
+    ///
+    /// A source placeholder written by an earlier `--fake-super --acls`
+    /// receive carries its logical ACL in `%aacl`/`%dacl`, not in a real
+    /// POSIX ACL on disk (an unprivileged receiver cannot apply one). Reading
+    /// the placeholder's real ACL would silently drop that stashed ACL on
+    /// re-send, so - mirroring `%stat`'s `fake_super_override` analogue for
+    /// ownership - the xattr wins when it decodes successfully.
+    ///
+    /// # Upstream Reference
+    ///
+    /// Mirrors the `am_root < 0` branch of `get_rsync_acl()` in `acls.c`
+    /// lines 472-509, reached via `x_lstat()`'s xattr-backed stat layering.
+    #[cfg(unix)]
+    fn read_source_acl(&self, full_path: &Path, mode: u32, is_default: bool) -> protocol::acl::RsyncAcl {
+        if self.config.fake_super
+            && let Ok(Some(acl)) = metadata::load_fake_super_acl(full_path, !is_default)
+        {
+            return acl;
+        }
+        metadata::get_rsync_acl(full_path, mode, is_default)
+    }
+
+    /// Non-Unix fallback: always reads the real filesystem ACL, since
+    /// `--fake-super`'s xattr stash is a POSIX-only mechanism.
+    #[cfg(not(unix))]
+    fn read_source_acl(&self, full_path: &Path, mode: u32, is_default: bool) -> protocol::acl::RsyncAcl {
+        metadata::get_rsync_acl(full_path, mode, is_default)
     }
 
     /// Sends `NDX_FLIST_EOF` and flushes, marking incremental sending as complete.

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -814,7 +814,12 @@ impl GeneratorContext {
     /// Mirrors the `am_root < 0` branch of `get_rsync_acl()` in `acls.c`
     /// lines 472-509, reached via `x_lstat()`'s xattr-backed stat layering.
     #[cfg(unix)]
-    fn read_source_acl(&self, full_path: &Path, mode: u32, is_default: bool) -> protocol::acl::RsyncAcl {
+    fn read_source_acl(
+        &self,
+        full_path: &Path,
+        mode: u32,
+        is_default: bool,
+    ) -> protocol::acl::RsyncAcl {
         if self.config.fake_super
             && let Ok(Some(acl)) = metadata::load_fake_super_acl(full_path, !is_default)
         {
@@ -826,7 +831,12 @@ impl GeneratorContext {
     /// Non-Unix fallback: always reads the real filesystem ACL, since
     /// `--fake-super`'s xattr stash is a POSIX-only mechanism.
     #[cfg(not(unix))]
-    fn read_source_acl(&self, full_path: &Path, mode: u32, is_default: bool) -> protocol::acl::RsyncAcl {
+    fn read_source_acl(
+        &self,
+        full_path: &Path,
+        mode: u32,
+        is_default: bool,
+    ) -> protocol::acl::RsyncAcl {
         metadata::get_rsync_acl(full_path, mode, is_default)
     }
 


### PR DESCRIPTION
## Summary

- `--fake-super` already stashed ownership/mode in the `%stat` xattr when the receiver can't chown/chmod for real, but had no equivalent for ACLs: the receive path always called a real `setfacl`, and the local-copy path always called a real `getfacl`/`setfacl` round trip. Under `--fake-super --acls`, both paths silently applied (or attempted to apply) a real ACL instead of stashing it, and could lose named user/group entries an unprivileged account can't set.
- Add `%aacl`/`%dacl` xattr storage mirroring upstream's `acls.c` `set_rsync_acl()`/`get_rsync_acl()` `am_root < 0` branches: same `user.`-prefix platform rule as `%stat`, same little-endian 4x`u32` header (`user_obj`/`group_obj`/`mask_obj`/`other_obj`) followed by one 8-byte `(id, access)` record per named entry.
- Wire the new storage into both the network/daemon/SSH receive path (`transfer::disk_commit`) and the same-host local-copy path (`engine::local_copy`), plus the generator's source-ACL read path so a previously-stashed ACL is preferred over a placeholder's real (possibly reset) ACL when re-sending.

## Details

- `protocol::acl::RsyncAcl::to_fake_super_bytes()` / `from_fake_super_bytes()`: the wire-compatible byte format, validated byte-for-byte against a hand-decode of upstream's `SIVAL`/`IVAL` layout.
- `metadata::fake_super`: `FAKE_SUPER_ACCESS_ACL_XATTR` / `FAKE_SUPER_DEFAULT_ACL_XATTR` constants (Linux `user.rsync.%aacl`/`%dacl`, elsewhere bare `rsync.%aacl`/`%dacl`) plus `store_fake_super_acl` / `load_fake_super_acl` / `remove_fake_super_default_acl`.
- `metadata::store_acls_via_fake_super` (receive path) and `metadata::sync_acls_via_fake_super` (local-copy path), implemented for the `exacl` backend (Linux/macOS/FreeBSD) with matching stubs for iOS/tvOS/watchOS, Windows, and the universal no-op backend.
- `transfer::disk_commit::process::metadata`: branches on `MetadataOptions::fake_super_enabled()` to call the new stash function instead of `apply_acls_from_cache`.
- `transfer::generator::protocol_io`: prefers a stashed source ACL over the real filesystem ACL when `--fake-super` is active, mirroring the existing `%stat` override.
- `engine::local_copy`: `sync_acls_if_requested` takes a `fake_super` flag and stashes instead of applying; threaded through all local-copy executors (regular files, hard links, directories, devices, symlinks, FIFOs).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p protocol -p metadata -p engine -p transfer --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run` for `protocol`/`metadata`/`engine`/`transfer` scoped to `fake_super`/`acl`/`sync_acls` (437 tests, all green) on an aarch64 Linux host
- [x] New unit tests: byte-format round trip (`protocol`), xattr store/load/remove including a corrupt-value rejection (`metadata::fake_super`), and a real-filesystem test that a named-user `setfacl` entry on the source is stashed rather than applied (`metadata::acl_exacl`)
- [x] Manual end-to-end check on the aarch64 host: `oc-rsync -a --fake-super --acls src/ dst/` on a tree with a named-user ACL and a directory default ACL now writes `user.rsync.%aacl`/`%dacl` (hand-decoded and confirmed to match the source ACL bit-for-bit) instead of a real `system.posix_acl_access`/`_default` xattr
