### PR TITLE
feat: auto-probe daemon chroot and split /./ module paths

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -329,14 +329,19 @@ fn process_approved_module(
     #[cfg(windows)]
     let _name_converter_guard = Some(install_windows_name_converter());
 
-    // Rewrite the module path to "/" only when chroot was actually applied.
-    // After a rootless auto-fallback (D3) the process is not chrooted, so the
-    // real absolute module path must be preserved.
-    // upstream: clientserver.c:848-862 - the post-chroot inner path is "/".
+    // Rewrite the module path to the post-chroot inner directory only when
+    // chroot was actually applied. After a rootless auto-fallback (D3) the
+    // process is not chrooted, so the real absolute module path must be
+    // preserved. The inner directory is "/" unless the module path carried a
+    // `/./` marker, in which case it is the normalized remainder after it.
+    // upstream: clientserver.c:845-862 - `module_dir` after the `/./` split.
     let effective_module;
     let config_module = if privilege_outcome.chroot_applied {
         let mut adjusted = module.definition.clone();
-        adjusted.path = PathBuf::from("/");
+        adjusted.path = privilege_outcome
+            .inner_module_path
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("/"));
         effective_module = ModuleRuntime::from(adjusted);
         &effective_module
     } else {

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -42,9 +42,15 @@ fn apply_privilege_restrictions_with_upstream_errors(
     // A rootless auto-fallback (unset `use chroot` + failing probe) yields
     // `Ok(false)`; an explicit `use chroot = yes` that fails is fatal.
     let mut chroot_applied = false;
+    let mut inner_module_path = None;
     if needs_chroot {
         match chroot_or_fallback(module, log_sink) {
-            Ok(applied) => chroot_applied = applied,
+            Ok((applied, inner)) => {
+                chroot_applied = applied;
+                if applied {
+                    inner_module_path = Some(inner);
+                }
+            }
             Err(err) => {
                 // Operator demanded chroot explicitly: a failure is fatal.
                 // upstream: clientserver.c:981 - `@ERROR: chroot failed\n`
@@ -99,7 +105,10 @@ fn apply_privilege_restrictions_with_upstream_errors(
         }
     }
 
-    Ok(Some(PrivilegeOutcome { chroot_applied }))
+    Ok(Some(PrivilegeOutcome {
+        chroot_applied,
+        inner_module_path,
+    }))
 }
 
 /// Result of applying a module's chroot and privilege restrictions.
@@ -110,8 +119,15 @@ struct PrivilegeOutcome {
     /// the module as non-chrooted.
     ///
     /// upstream: clientserver.c:831-862 - the effective `use_chroot` decides
-    /// whether the module path is rewritten to `/`.
+    /// whether the module path is rewritten to the post-chroot inner path.
     chroot_applied: bool,
+    /// The post-chroot working directory to serve from, when `chroot_applied`
+    /// is `true`. `/` unless the module path carried a `/./` inner/outer
+    /// marker, in which case it is the normalized remainder after the
+    /// marker (e.g. `/module` for `path = /var/data/./module`).
+    ///
+    /// upstream: clientserver.c:845-862 - `module_dir` after the `/./` split.
+    inner_module_path: Option<PathBuf>,
 }
 
 impl PrivilegeOutcome {
@@ -119,6 +135,7 @@ impl PrivilegeOutcome {
     const fn not_chrooted() -> Self {
         Self {
             chroot_applied: false,
+            inner_module_path: None,
         }
     }
 }

--- a/crates/daemon/src/daemon/sections/privilege.rs
+++ b/crates/daemon/src/daemon/sections/privilege.rs
@@ -90,29 +90,90 @@ fn drop_privileges(
     Ok(())
 }
 
-/// Applies chroot for a module, auto-falling back to no-chroot when `use
-/// chroot` was unset and the runtime chroot probe fails.
+/// Splits a module path at the first `/./` marker into the outer chroot
+/// root and the inner post-chroot working directory.
 ///
-/// Returns `Ok(true)` when the process is chrooted, `Ok(false)` after a
-/// rootless auto-fallback, and `Err` when chroot was demanded explicitly but
-/// failed (the caller then refuses the connection).
+/// A path without `/./` chroots into the whole path, starting the session
+/// at the new root (inner = `/`). A path with `/./` chroots into only the
+/// portion before the marker and starts the session at the (still-absolute)
+/// portion after it - upstream's inner/outer split, which leaves siblings
+/// of the inner directory reachable inside the jail for modules that need
+/// to share a parent directory with other served paths.
 ///
-/// upstream: clientserver.c:831-838 `rsync_module()` - `use_chroot < 0` (unset)
-/// probes `chroot("/")`; on failure it logs "Switching 'use chroot' from unset
-/// to false" and clears the flag. An explicit `use chroot = yes` has no such
-/// escape and aborts the connection.
-fn chroot_or_fallback(module: &ModuleDefinition, log_sink: &SharedLogSink) -> io::Result<bool> {
-    match apply_chroot(&module.path, log_sink) {
-        Ok(()) => Ok(true),
-        Err(err) if !module.use_chroot_explicit => {
+/// upstream: clientserver.c:845-862 `rsync_module()` - `strstr(module_dir,
+/// "/./")` locates the marker; the outer half becomes `module_chdir` (the
+/// chroot target) and the normalized remainder becomes `module_dir` (the
+/// post-chroot `change_dir` target).
+fn split_chroot_path(path: &Path) -> (PathBuf, PathBuf) {
+    let Some((outer, inner)) = path.to_str().and_then(|s| s.split_once("/./")) else {
+        return (path.to_path_buf(), PathBuf::from("/"));
+    };
+    let outer = if outer.is_empty() { "/" } else { outer };
+    let inner = inner.trim_start_matches('/');
+    let inner_path = if inner.is_empty() {
+        PathBuf::from("/")
+    } else {
+        PathBuf::from(format!("/{inner}"))
+    };
+    (PathBuf::from(outer), inner_path)
+}
+
+/// Resolves the effective per-module chroot decision, mirroring upstream's
+/// tri-state `use_chroot` (`0`/`1`/unset).
+///
+/// - An explicit `use chroot = yes|no` always wins.
+/// - Unset with a `/./` inner/outer marker in the path is treated as an
+///   implicit `yes`: the path itself signals chroot intent, so no probe runs.
+/// - Unset otherwise probes chroot capability with a no-op `chroot("/")`;
+///   success resolves to `yes`, failure (typically `EPERM`, the common
+///   rootless-daemon case) resolves to `no` with a log notice matching
+///   upstream's wording.
+///
+/// upstream: clientserver.c:706,831-844 `rsync_module()`.
+fn resolve_use_chroot(module: &ModuleDefinition, log_sink: &SharedLogSink) -> bool {
+    if module.use_chroot_explicit {
+        return module.use_chroot;
+    }
+    if module.path.to_str().is_some_and(|s| s.contains("/./")) {
+        return true;
+    }
+    match platform::privilege::probe_chroot_capability() {
+        Ok(()) => true,
+        Err(err) => {
             let notice =
                 format!("chroot test failed: {err}. Switching 'use chroot' from unset to false.");
             let message = rsync_warning!(notice).with_role(Role::Daemon);
             log_message(log_sink, &message);
-            Ok(false)
+            false
         }
-        Err(err) => Err(err),
     }
+}
+
+/// Applies chroot for a module, resolving the tri-state `use chroot`
+/// decision and (when enabled) chrooting into the possibly `/./`-split
+/// module path.
+///
+/// Returns `Ok((chroot_applied, inner_dir))`. `chroot_applied` is `false`
+/// when chroot is disabled outright (`use chroot = no`) or was unset and the
+/// capability probe failed; `inner_dir` is the post-chroot working directory
+/// the caller must serve from (`/` unless the path carried a `/./`
+/// inner/outer marker). Once `use_chroot` resolves true - explicitly, via
+/// `/./`, or via a successful probe - a failure of the real `chroot(2)` call
+/// is always fatal, matching upstream's unconditional `@ERROR: chroot
+/// failed` once the tri-state is settled.
+///
+/// upstream: clientserver.c:831-990 `rsync_module()`.
+fn chroot_or_fallback(
+    module: &ModuleDefinition,
+    log_sink: &SharedLogSink,
+) -> io::Result<(bool, PathBuf)> {
+    if !resolve_use_chroot(module, log_sink) {
+        return Ok((false, module.path.clone()));
+    }
+
+    let (outer, inner) = split_chroot_path(&module.path);
+    apply_chroot(&outer, log_sink)?;
+    Ok((true, inner))
 }
 
 /// The uid and complete group set the daemon will drop to for a connection.
@@ -529,7 +590,7 @@ mod privilege_tests {
             ..Default::default()
         };
         let sink = test_log_sink();
-        let applied = chroot_or_fallback(&module, &sink)
+        let (applied, _inner) = chroot_or_fallback(&module, &sink)
             .expect("unset use chroot must fall back, not error");
         assert!(!applied, "rootless fallback must report chroot NOT applied");
     }
@@ -607,6 +668,86 @@ mod privilege_tests {
         assert!(
             chroot_or_fallback(&module, &sink).is_err(),
             "explicit use chroot must not silently fall back"
+        );
+    }
+
+    /// WHY: upstream clientserver.c:845-862 - a module path without `/./`
+    /// chroots into the whole path and starts the session at the new root.
+    /// Pure path-string logic, no syscall involved.
+    #[test]
+    fn split_chroot_path_without_marker_chroots_whole_path() {
+        let (outer, inner) = split_chroot_path(Path::new("/var/data/module"));
+        assert_eq!(outer, PathBuf::from("/var/data/module"));
+        assert_eq!(inner, PathBuf::from("/"));
+    }
+
+    /// WHY: upstream clientserver.c:846-855 - a `/./` marker splits the path
+    /// into the outer chroot root and the inner post-chroot working
+    /// directory, e.g. `path = /var/data/./module` chroots to `/var/data`
+    /// then starts the session at `/module` (still reachable: siblings of
+    /// `module` under `/var/data` remain inside the jail).
+    #[test]
+    fn split_chroot_path_splits_at_first_slash_dot_marker() {
+        let (outer, inner) = split_chroot_path(Path::new("/var/data/./module"));
+        assert_eq!(outer, PathBuf::from("/var/data"));
+        assert_eq!(inner, PathBuf::from("/module"));
+    }
+
+    /// WHY: a marker at the very end of the path (empty inner segment)
+    /// normalizes to the root, matching upstream's `module_dirlen` resetting
+    /// to 0 for a trailing `/./`.
+    #[test]
+    fn split_chroot_path_trailing_marker_normalizes_inner_to_root() {
+        let (outer, inner) = split_chroot_path(Path::new("/var/data/./"));
+        assert_eq!(outer, PathBuf::from("/var/data"));
+        assert_eq!(inner, PathBuf::from("/"));
+    }
+
+    /// WHY: only the FIRST `/./` marker is a split point; a nested module
+    /// tree that happens to contain a second `/./` further down stays part
+    /// of the inner half, matching `strstr`'s first-match semantics.
+    #[test]
+    fn split_chroot_path_only_splits_at_first_marker() {
+        let (outer, inner) = split_chroot_path(Path::new("/a/./b/./c"));
+        assert_eq!(outer, PathBuf::from("/a"));
+        assert_eq!(inner, PathBuf::from("/b/./c"));
+    }
+
+    /// WHY: upstream clientserver.c:832-833 - `strstr(module_dir, "/./") !=
+    /// NULL` short-circuits the tri-state straight to enabled, with no
+    /// `chroot("/")` probe at all. This must hold even on an unprivileged
+    /// runner (no root guard needed), because the marker check happens
+    /// before the probe would ever run.
+    #[test]
+    fn resolve_use_chroot_slash_dot_marker_skips_probe() {
+        let module = ModuleDefinition {
+            path: PathBuf::from("/some/outer/./inner"),
+            use_chroot: true,
+            use_chroot_explicit: false,
+            ..Default::default()
+        };
+        let sink = test_log_sink();
+        assert!(
+            resolve_use_chroot(&module, &sink),
+            "a /./ marker must resolve to chroot-enabled without probing"
+        );
+    }
+
+    /// WHY: an explicit `use chroot = no` always wins, even when the path
+    /// carries a `/./` marker - upstream only consults the marker when the
+    /// tri-state is unset (`use_chroot < 0`).
+    #[test]
+    fn resolve_use_chroot_explicit_false_overrides_slash_dot_marker() {
+        let module = ModuleDefinition {
+            path: PathBuf::from("/some/outer/./inner"),
+            use_chroot: false,
+            use_chroot_explicit: true,
+            ..Default::default()
+        };
+        let sink = test_log_sink();
+        assert!(
+            !resolve_use_chroot(&module, &sink),
+            "explicit 'use chroot = no' must not be overridden by a /./ marker"
         );
     }
 }

--- a/crates/platform/src/privilege.rs
+++ b/crates/platform/src/privilege.rs
@@ -65,6 +65,31 @@ pub fn apply_chroot(_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
+/// Probes chroot capability with a no-op `chroot("/")`, without touching any
+/// module path.
+///
+/// Used only when a module's `use chroot` directive is unset: the daemon
+/// tries this harmless self-chroot to determine whether the process has
+/// `CAP_SYS_CHROOT` before deciding the tri-state default. Success leaves
+/// the process root unchanged (chrooting to `/` is a no-op); failure (almost
+/// always `EPERM`) means the daemon is unprivileged.
+///
+/// upstream: clientserver.c:834 `rsync_module()` - `chroot("/") < 0` probes
+/// capability before the real `chroot(module_chdir)` later in the function.
+#[cfg(unix)]
+pub fn probe_chroot_capability() -> io::Result<()> {
+    nix::unistd::chroot("/").map_err(nix_to_io)?;
+    std::env::set_current_dir("/")?;
+    Ok(())
+}
+
+/// No-op chroot probe on non-Unix platforms: chroot never applies there, so
+/// the tri-state always resolves to "enabled" (harmlessly unused).
+#[cfg(not(unix))]
+pub fn probe_chroot_capability() -> io::Result<()> {
+    Ok(())
+}
+
 /// Drops process privileges to the specified uid and group list.
 ///
 /// `gids` is the complete group set to install, primary group first (as
@@ -403,6 +428,26 @@ mod tests {
                 None => std::env::remove_var("TZ"),
             }
             tzset();
+        }
+    }
+
+    /// `probe_chroot_capability` must never touch a module path - it always
+    /// targets `"/"`. On a non-root test runner it fails with `EPERM`
+    /// (lack of `CAP_SYS_CHROOT`); on a root runner it succeeds harmlessly
+    /// (chrooting to `/` changes nothing). Either outcome is valid; the
+    /// test only pins that the call never panics and returns an `io::Error`
+    /// on failure rather than something unexpected.
+    #[cfg(unix)]
+    #[test]
+    fn probe_chroot_capability_succeeds_or_reports_permission_denied() {
+        match probe_chroot_capability() {
+            Ok(()) => {}
+            Err(err) => assert_eq!(
+                err.kind(),
+                io::ErrorKind::PermissionDenied,
+                "unexpected probe failure kind: {:?}",
+                err.kind()
+            ),
         }
     }
 


### PR DESCRIPTION
## Summary

`rsync_module()`'s chroot handling has a tri-state `use_chroot` (yes/no/unset)
and an inner/outer `/./` path split that oc-rsync only partially mirrored.

- **Auto-probe**: when `use chroot` is unset, upstream tests capability with
  a harmless `chroot("/")` before ever touching the module path. oc-rsync's
  fallback reused the *real* per-module `chroot()` call as its own probe, so
  a module with a path-specific problem (not lack of `CAP_SYS_CHROOT`) would
  silently serve unchrooted instead of refusing the connection like upstream
  does once `use_chroot` resolves true.
- **`/./` split**: a module `path` containing `/./` is supposed to chroot to
  the outer half and start the session at the inner half (e.g.
  `path = /var/data/./module` chroots to `/var/data`, then serves from
  `/module`). oc-rsync passed the raw path straight to `chroot(2)` (the
  marker collapses harmlessly during path resolution, landing on the inner
  dir) and always rewrote the post-chroot path to `/`, so the split never
  took effect.

## Changes

- `platform::privilege::probe_chroot_capability()` - dedicated no-op
  `chroot("/")` probe, separate from the real per-module chroot.
- `daemon::sections::privilege::split_chroot_path()` - pure path-splitting
  helper for the `/./` marker.
- `daemon::sections::privilege::resolve_use_chroot()` - resolves the
  tri-state: explicit setting wins; unset + `/./` marker implies chroot;
  otherwise probes capability.
- `chroot_or_fallback()` now separates probe-driven fallback (only for the
  unset case) from the real chroot, which is always fatal once
  `use_chroot` resolves true - matching upstream's unconditional
  `@ERROR: chroot failed`.
- Threaded the resolved inner directory through `PrivilegeOutcome` so the
  module path rewrite after chroot uses the correct inner directory instead
  of a hardcoded `/`.

## Test plan

- [x] Unit tests for `split_chroot_path` (marker/no-marker/trailing-marker/
      multiple-markers) - pure string logic, no root required.
- [x] Unit tests for `resolve_use_chroot` (marker skips probe; explicit
      `no` overrides a marker) - no root required.
- [x] `probe_chroot_capability` smoke test (accepts either outcome
      depending on runner privilege).
- [x] Existing chroot fallback/fatal tests updated for the new
      `(bool, PathBuf)` return type; behavior preserved.
- [ ] Full end-to-end real-chroot-then-split validation needs root
      (`CAP_SYS_CHROOT`) and isn't exercised here to avoid permanently
      chrooting the shared nextest process; the decision logic and path
      math are covered directly instead.

Validated on aarch64 Linux: `cargo fmt -p daemon -p platform -- --check`,
`cargo clippy -p daemon -p platform --all-targets --all-features --no-deps -- -D warnings`,
and targeted `cargo nextest run` (49 + 37 tests) all pass.
