### PR TITLE
fix: apply --sockopts before connect(2)/listen(2), not after

### DIFF
--- a/crates/core/src/client/module_list/connect/direct.rs
+++ b/crates/core/src/client/module_list/connect/direct.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::io;
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::time::Duration;
@@ -5,6 +6,7 @@ use std::time::Duration;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
 use super::super::DaemonAddress;
+use super::super::socket_options::apply_socket_options;
 use crate::client::{
     AddressMode, ClientError, SOCKET_IO_EXIT_CODE, TcpFastOpenMode, connect_timeout_error,
     daemon_error, socket_error,
@@ -14,7 +16,9 @@ use crate::client::{
 ///
 /// Resolves the daemon address, iterates through candidates filtered by
 /// `address_mode`, and returns the first successful connection. I/O timeouts
-/// are applied to the resulting stream.
+/// are applied to the resulting stream. `sockopts`, when given, is applied to
+/// each candidate socket before `connect(2)` (upstream: socket.c:279-280), so
+/// options that shape the SYN (e.g. `SO_SNDBUF`/`SO_RCVBUF`) take effect.
 pub(crate) fn connect_direct(
     addr: &DaemonAddress,
     connect_timeout: Option<Duration>,
@@ -22,12 +26,13 @@ pub(crate) fn connect_direct(
     address_mode: AddressMode,
     bind_address: Option<SocketAddr>,
     tfo: TcpFastOpenMode,
+    sockopts: Option<&OsStr>,
 ) -> Result<TcpStream, ClientError> {
     let addresses = resolve_daemon_addresses(addr, address_mode)?;
     let mut last_error: Option<(SocketAddr, io::Error)> = None;
 
     for candidate in addresses {
-        match connect_with_optional_bind(candidate, bind_address, connect_timeout, tfo) {
+        match connect_with_optional_bind(candidate, bind_address, connect_timeout, tfo, sockopts) {
             Ok(stream) => {
                 if let Some(duration) = io_timeout {
                     stream.set_read_timeout(Some(duration)).map_err(|error| {
@@ -138,12 +143,20 @@ pub(crate) fn resolve_daemon_addresses(
 /// an ephemeral port. A `connect_timeout`, when given, is forwarded to the
 /// underlying socket. The connection is always built through a `socket2`
 /// socket so a `TCP_FASTOPEN_CONNECT` option can be set before `connect(2)`
-/// when `tfo` requests it.
+/// when `tfo` requests it, and so `sockopts` (`--sockopts`), when given, can
+/// be applied before `connect(2)` too.
+///
+/// upstream: socket.c:267-280 `open_socket_out()` - `try_bind_local()` runs
+/// first, then `set_socket_options(s, sockopts)`, then `connect(s, ...)`.
+/// Applying `--sockopts` after `connect(2)` returns is a no-op for options
+/// that shape the SYN (e.g. `SO_SNDBUF`/`SO_RCVBUF` window scaling), so the
+/// order here must match: bind, then sockopts, then connect.
 pub(crate) fn connect_with_optional_bind(
     target: SocketAddr,
     bind_address: Option<SocketAddr>,
     timeout: Option<Duration>,
     tfo: TcpFastOpenMode,
+    sockopts: Option<&OsStr>,
 ) -> io::Result<TcpStream> {
     let domain = if target.is_ipv4() {
         Domain::IPV4
@@ -166,6 +179,12 @@ pub(crate) fn connect_with_optional_bind(
             SocketAddr::V6(addr) => addr.set_port(0),
         }
         socket.bind(&SockAddr::from(bind_addr))?;
+    }
+
+    // upstream: socket.c:279 - set_socket_options(s, sockopts) runs here,
+    // after the optional bind and before connect(2).
+    if let Some(options) = sockopts {
+        apply_socket_options(&socket, options);
     }
 
     // Request client-side TCP Fast Open before connect. On Linux this sets
@@ -274,5 +293,46 @@ mod tests {
         let error = io::Error::new(io::ErrorKind::ConnectionRefused, "refused");
         let mapped = map_connect_failure(Some(Duration::from_secs(5)), candidate(), error);
         assert_eq!(mapped.exit_code(), 10);
+    }
+
+    // upstream: socket.c:279-280 - set_socket_options(s, sockopts) runs before
+    // connect(s, ...), so options that shape the SYN (e.g. SO_SNDBUF/SO_RCVBUF
+    // window scaling) take effect. connect_with_optional_bind applies sockopts
+    // to the socket2::Socket before either connect() or connect_timeout() is
+    // called; a --sockopts value applied only after connect(2) returns would
+    // be a no-op for the handshake. This proves --sockopts is wired all the
+    // way through the connect helper and takes effect on the live socket
+    // (setting it post-connect on an already-established stream would report
+    // the identical read-back value, so this also guards against the
+    // parameter silently failing to reach the socket).
+    #[test]
+    fn connect_with_optional_bind_applies_sockopts() {
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+        let target = listener.local_addr().expect("listener addr");
+        let handle = std::thread::spawn(move || {
+            let _ = listener.accept();
+        });
+
+        let stream = connect_with_optional_bind(
+            target,
+            None,
+            None,
+            TcpFastOpenMode::Auto,
+            Some(std::ffi::OsStr::new("SO_SNDBUF=131072")),
+        )
+        .expect("connect with sockopts");
+
+        let reported = socket2::SockRef::from(&stream)
+            .send_buffer_size()
+            .expect("query send buffer size");
+        assert!(
+            reported >= 131_072,
+            "SO_SNDBUF=131072 must be applied via --sockopts, got {reported}"
+        );
+
+        drop(stream);
+        handle.join().expect("accept thread completes");
     }
 }

--- a/crates/core/src/client/module_list/connect/direct.rs
+++ b/crates/core/src/client/module_list/connect/direct.rs
@@ -315,11 +315,15 @@ mod tests {
             let _ = listener.accept();
         });
 
+        // TFO Off so connect() performs a full handshake; with TFO the handshake
+        // is deferred to the first write (which this test never issues), so on
+        // some platforms the listener's accept() would block until the test
+        // times out. Sockopt application is independent of the TFO mode.
         let stream = connect_with_optional_bind(
             target,
             None,
             None,
-            TcpFastOpenMode::Auto,
+            TcpFastOpenMode::Off,
             Some(std::ffi::OsStr::new("SO_SNDBUF=131072")),
         )
         .expect("connect with sockopts");

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -225,7 +225,10 @@ pub(crate) fn build_io_timeout_reapply(
 /// Opens a plain TCP connection to a daemon.
 ///
 /// Respects `RSYNC_CONNECT_PROG` and `RSYNC_PROXY` environment
-/// variables.
+/// variables. `sockopts` (`--sockopts`), when given, is applied to the
+/// connecting socket before `connect(2)` for both the direct and proxied
+/// paths; it has no effect on a connect program, matching upstream (a
+/// connect program bypasses `open_socket_out()` entirely).
 pub(crate) fn open_daemon_stream(
     addr: &DaemonAddress,
     connect_timeout: Option<Duration>,
@@ -234,15 +237,22 @@ pub(crate) fn open_daemon_stream(
     connect_program: Option<&OsStr>,
     bind_address: Option<SocketAddr>,
     tfo: TcpFastOpenMode,
+    sockopts: Option<&OsStr>,
 ) -> Result<DaemonStream, ClientError> {
     if let Some(program) = program::load_daemon_connect_program(connect_program)? {
         return program::connect_via_program(addr, &program);
     }
 
     let stream = match load_daemon_proxy()? {
-        Some(proxy) => {
-            proxy::connect_via_proxy(addr, &proxy, connect_timeout, io_timeout, bind_address, tfo)?
-        }
+        Some(proxy) => proxy::connect_via_proxy(
+            addr,
+            &proxy,
+            connect_timeout,
+            io_timeout,
+            bind_address,
+            tfo,
+            sockopts,
+        )?,
         None => connect_direct(
             addr,
             connect_timeout,
@@ -250,6 +260,7 @@ pub(crate) fn open_daemon_stream(
             address_mode,
             bind_address,
             tfo,
+            sockopts,
         )?,
     };
 

--- a/crates/core/src/client/module_list/connect/proxy.rs
+++ b/crates/core/src/client/module_list/connect/proxy.rs
@@ -1,4 +1,5 @@
 use std::env::{self, VarError};
+use std::ffi::OsStr;
 use std::io::{self, ErrorKind, Read, Write};
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::time::Duration;
@@ -13,6 +14,13 @@ use crate::client::{ClientError, SOCKET_IO_EXIT_CODE, TcpFastOpenMode, socket_er
 use crate::message::Role;
 use crate::rsync_error;
 
+/// Connects to `addr`'s daemon through an HTTP(S) CONNECT proxy.
+///
+/// `sockopts`, when given, is applied to the socket used to reach the proxy
+/// before `connect(2)` - upstream `open_socket_out()` resolves and connects to
+/// the proxy host in place of the daemon host (socket.c:200-242), so
+/// `set_socket_options(s, sockopts)` at socket.c:279 runs against that same
+/// proxy-bound socket before its `connect(2)`.
 pub(crate) fn connect_via_proxy(
     addr: &DaemonAddress,
     proxy: &ProxyConfig,
@@ -20,6 +28,7 @@ pub(crate) fn connect_via_proxy(
     io_timeout: Option<Duration>,
     bind_address: Option<SocketAddr>,
     tfo: TcpFastOpenMode,
+    sockopts: Option<&OsStr>,
 ) -> Result<TcpStream, ClientError> {
     let target = (proxy.host.as_str(), proxy.port);
     let addrs = target
@@ -30,7 +39,7 @@ pub(crate) fn connect_via_proxy(
     let mut stream_result: Option<TcpStream> = None;
 
     for candidate in addrs {
-        match connect_with_optional_bind(candidate, bind_address, connect_timeout, tfo) {
+        match connect_with_optional_bind(candidate, bind_address, connect_timeout, tfo, sockopts) {
             Ok(stream) => {
                 stream_result = Some(stream);
                 break;

--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -35,7 +35,6 @@ use super::connect::{
 use super::errors::{legacy_daemon_error_payload, map_daemon_handshake_error, read_trimmed_line};
 use super::request::ModuleListOptions;
 use super::request::ModuleListRequest;
-use super::socket_options::apply_socket_options;
 use super::types::DaemonAddress;
 use crate::auth::{parse_daemon_digest_list, select_daemon_digest};
 
@@ -223,6 +222,7 @@ pub fn run_module_list_with_password_and_options(
             options.connect_program(),
             options.bind_address(),
             options.tcp_fastopen(),
+            options.sockopts(),
         )?
     };
 
@@ -468,9 +468,8 @@ fn configure_daemon_stream(
     addr: &DaemonAddress,
 ) -> Result<(), ClientError> {
     if let super::connect::DaemonStream::Tcp(socket) = stream {
-        if let Some(values) = options.sockopts() {
-            apply_socket_options(socket, values);
-        }
+        // --sockopts is applied pre-connect inside open_daemon_stream (upstream:
+        // socket.c:279-280 - set_socket_options() must run before connect(2)).
 
         // Module listing has no transfer, so no bwlimit pacing applies.
         super::tcp_perf::apply_client_tcp_perf_options(socket, options.tcp_fastopen(), None);

--- a/crates/core/src/client/module_list/socket_options/apply.rs
+++ b/crates/core/src/client/module_list/socket_options/apply.rs
@@ -1,18 +1,17 @@
-//! Public entry point for applying socket options to a TCP stream.
+//! Public entry point for applying socket options to a pre-connect socket.
 //!
 //! Parses a comma/whitespace-separated option string and applies each
 //! option via platform-specific `setsockopt` calls.
 // upstream: socket.c:set_socket_options()
 
 use std::ffi::OsStr;
-use std::net::TcpStream;
 
 use super::lookup::{intern_name, lookup_socket_option, parse_socket_option_value};
 use super::types::ParsedSocketOption;
 #[cfg(not(target_family = "windows"))]
 use super::types::SocketOptionKind;
 
-/// Applies caller-provided socket options to the supplied TCP stream.
+/// Applies caller-provided socket options to the supplied socket.
 ///
 /// The option string is a comma/whitespace-separated list of names with
 /// optional `=value` suffixes:
@@ -22,11 +21,17 @@ use super::types::SocketOptionKind;
 /// - `TCP_NODELAY`
 /// - `IPTOS_LOWDELAY` (Unix only)
 ///
+/// Must be called on `socket` before `connect(2)` - upstream:
+/// socket.c:279-280 applies `set_socket_options(s, sockopts)` immediately
+/// before `connect(s, ...)` so options that shape the SYN (e.g.
+/// `SO_SNDBUF`/`SO_RCVBUF` window scaling) actually take effect; setting
+/// them after `connect(2)` returns is a no-op for the handshake.
+///
 /// upstream: socket.c:set_socket_options() is `void` - every parse or
 /// `setsockopt(2)` failure warns to stderr and `continue`s the loop, so a bad
 /// option never aborts the connection. We mirror that warn-and-continue
 /// contract rather than propagating a fatal error.
-pub(crate) fn apply_socket_options(stream: &TcpStream, options: &OsStr) {
+pub(crate) fn apply_socket_options(socket: &socket2::Socket, options: &OsStr) {
     let list = options.to_string_lossy();
 
     if list.trim().is_empty() {
@@ -92,7 +97,7 @@ pub(crate) fn apply_socket_options(stream: &TcpStream, options: &OsStr) {
     }
 
     for option in parsed {
-        if let Err(error) = option.apply(stream) {
+        if let Err(error) = option.apply(socket) {
             // upstream: socket.c:730-733 - a failed `setsockopt(2)` reports
             // `rsyserr(FERROR, errno, "failed to set socket option %s")` and
             // keeps applying the remaining options.

--- a/crates/core/src/client/module_list/socket_options/mod.rs
+++ b/crates/core/src/client/module_list/socket_options/mod.rs
@@ -1,7 +1,7 @@
 //! Socket option parsing and application for rsync daemon connections.
 //!
 //! Translates user-facing option strings (e.g. `SO_KEEPALIVE,TCP_NODELAY`)
-//! into platform-specific `setsockopt` calls on a `TcpStream`.
+//! into platform-specific `setsockopt` calls on the pre-connect socket.
 // upstream: socket.c:set_socket_options()
 
 mod apply;

--- a/crates/core/src/client/module_list/socket_options/types.rs
+++ b/crates/core/src/client/module_list/socket_options/types.rs
@@ -1,9 +1,6 @@
 //! Socket option type definitions.
 
 use std::io;
-use std::net::TcpStream;
-
-use fast_io::set_socket_int_option;
 
 /// Classifies a socket option by how its value is interpreted.
 #[derive(Clone, Copy)]
@@ -30,7 +27,12 @@ pub(super) enum SocketOptionKind {
 /// A single parsed socket option ready to be applied.
 ///
 /// Decouples parsing from execution: `apply` performs the actual
-/// `setsockopt` call via the safe `fast_io::set_socket_int_option` wrapper.
+/// `setsockopt` call via the safe `fast_io::set_socket_int_option_raw`
+/// wrapper. It runs on the pre-connect `socket2::Socket` (see
+/// `connect::connect_with_optional_bind`) rather than a connected
+/// `TcpStream` - upstream: socket.c:279 `set_socket_options(s, sockopts)`
+/// runs before `connect(s, ...)` at socket.c:280 so options that affect the
+/// SYN (e.g. `SO_SNDBUF`/`SO_RCVBUF` window scaling) take effect.
 pub(super) struct ParsedSocketOption {
     pub(super) kind: SocketOptionKind,
     pub(super) explicit_value: Option<libc::c_int>,
@@ -43,32 +45,38 @@ impl ParsedSocketOption {
         self.name
     }
 
-    /// Applies this option to the provided stream (Unix).
+    /// Applies this option to the provided socket (Unix).
     #[cfg(not(target_family = "windows"))]
-    pub(super) fn apply(&self, stream: &TcpStream) -> io::Result<()> {
+    pub(super) fn apply(&self, socket: &socket2::Socket) -> io::Result<()> {
+        use std::os::fd::AsRawFd;
+
+        let fd = socket.as_raw_fd();
         match self.kind {
             SocketOptionKind::Bool { level, option } | SocketOptionKind::Int { level, option } => {
                 let value = self.explicit_value.unwrap_or(1);
-                set_socket_int_option(stream, level, option, value)
+                fast_io::set_socket_int_option_raw(fd, level, option, value)
             }
             SocketOptionKind::On {
                 level,
                 option,
                 value,
-            } => set_socket_int_option(stream, level, option, value),
+            } => fast_io::set_socket_int_option_raw(fd, level, option, value),
         }
     }
 
-    /// Applies this option to the provided stream (Windows).
+    /// Applies this option to the provided socket (Windows).
     ///
     /// IPTOS_* options are not available on Windows, so only `Bool`/`Int`
     /// variants are reachable.
     #[cfg(target_family = "windows")]
-    pub(super) fn apply(&self, stream: &TcpStream) -> io::Result<()> {
+    pub(super) fn apply(&self, socket: &socket2::Socket) -> io::Result<()> {
+        use std::os::windows::io::AsRawSocket;
+
+        let raw = socket.as_raw_socket();
         match self.kind {
             SocketOptionKind::Bool { level, option } | SocketOptionKind::Int { level, option } => {
                 let value = self.explicit_value.unwrap_or(1);
-                set_socket_int_option(stream, level, option, value)
+                fast_io::set_socket_int_option_raw(raw, level, option, value)
             }
         }
     }

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -33,8 +33,7 @@ use super::super::DAEMON_SOCKET_TIMEOUT;
 use super::super::config::ClientConfig;
 use super::super::error::{ClientError, invalid_argument_error, socket_error};
 use super::super::module_list::{
-    RshDaemonSpawn, apply_socket_options, open_daemon_stream, resolve_connect_timeout,
-    spawn_rsh_daemon_stream,
+    RshDaemonSpawn, open_daemon_stream, resolve_connect_timeout, spawn_rsh_daemon_stream,
 };
 use super::super::progress::ClientProgressObserver;
 use super::super::summary::ClientSummary;
@@ -131,16 +130,13 @@ pub fn run_daemon_transfer(
         config.connect_program(),
         config.bind_address().map(|b| b.socket()),
         config.tcp_fastopen(),
+        config.sockopts(),
     )?;
 
-    // upstream: clientserver.c - start_daemon_client() calls set_socket_options()
-    // on the daemon socket before the handshake. Only applies to TCP connections,
-    // not connect programs.
-    if let Some(sockopts) = config.sockopts() {
-        if let Some(tcp) = stream.as_tcp_stream() {
-            apply_socket_options(tcp, sockopts);
-        }
-    }
+    // upstream: socket.c:279-280 - set_socket_options(s, sockopts) is applied
+    // pre-connect inside open_daemon_stream, before start_daemon_client()'s
+    // handshake. Only applies to TCP connections, not connect programs (that
+    // gate lives inside connect_direct/connect_via_proxy).
 
     // Apply oc-rsync-specific TCP perf options (TCP_NOTSENT_LOWAT for the
     // client side; client-side TFO is deferred to a follow-up). These are

--- a/crates/core/src/client/tests/builder_compress.rs
+++ b/crates/core/src/client/tests/builder_compress.rs
@@ -507,6 +507,7 @@ fn connect_direct_applies_io_timeout() {
         AddressMode::Default,
         None,
         crate::client::TcpFastOpenMode::Auto,
+        None,
     )
     .expect("connect directly");
 
@@ -558,6 +559,7 @@ fn connect_via_proxy_applies_io_timeout() {
         timeout,
         None,
         crate::client::TcpFastOpenMode::Auto,
+        None,
     )
     .expect("proxy connect");
 

--- a/crates/core/src/client/tests/module_list_socket_options.rs
+++ b/crates/core/src/client/tests/module_list_socket_options.rs
@@ -1,6 +1,12 @@
 use crate::client::module_list::apply_socket_options;
 
-fn connected_stream() -> (std::net::TcpStream, std::thread::JoinHandle<()>) {
+/// Builds a connected `socket2::Socket`, mirroring the pre-connect socket
+/// `apply_socket_options` now runs against (upstream: socket.c:279-280 -
+/// `set_socket_options()` must run before `connect(2)`). The accept thread
+/// only needs to complete the handshake; the options under test are applied
+/// (and read back) after connect for test convenience, which does not
+/// change the option semantics being exercised here.
+fn connected_socket() -> (socket2::Socket, std::thread::JoinHandle<()>) {
     let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("listener");
     let addr = listener.local_addr().expect("addr");
 
@@ -9,22 +15,19 @@ fn connected_stream() -> (std::net::TcpStream, std::thread::JoinHandle<()>) {
     });
 
     let stream = std::net::TcpStream::connect(addr).expect("connect");
-    (stream, handle)
+    (socket2::Socket::from(stream), handle)
 }
 
 #[test]
 fn apply_socket_options_sets_send_buffer_size() {
-    let (stream, handle) = connected_stream();
+    let (socket, handle) = connected_socket();
 
-    apply_socket_options(&stream, std::ffi::OsStr::new("SO_SNDBUF=32768"));
+    apply_socket_options(&socket, std::ffi::OsStr::new("SO_SNDBUF=32768"));
 
-    let sockref = socket2::SockRef::from(&stream);
-    let reported = sockref
-        .send_buffer_size()
-        .expect("query send buffer size");
+    let reported = socket.send_buffer_size().expect("query send buffer size");
     assert!(reported >= 32768);
 
-    drop(stream);
+    drop(socket);
     handle.join().expect("accept thread completes");
 }
 
@@ -35,17 +38,16 @@ fn apply_socket_options_sets_send_buffer_size() {
 /// continued past the unknown token instead of bailing out.
 #[test]
 fn apply_socket_options_warns_and_continues_on_unknown_name() {
-    let (stream, handle) = connected_stream();
+    let (socket, handle) = connected_socket();
 
-    apply_socket_options(&stream, std::ffi::OsStr::new("SO_NOTREAL=1,SO_SNDBUF=32768"));
+    apply_socket_options(&socket, std::ffi::OsStr::new("SO_NOTREAL=1,SO_SNDBUF=32768"));
 
-    let sockref = socket2::SockRef::from(&stream);
     assert!(
-        sockref.send_buffer_size().expect("query send buffer size") >= 32768,
+        socket.send_buffer_size().expect("query send buffer size") >= 32768,
         "valid option after an unknown one must still apply"
     );
 
-    drop(stream);
+    drop(socket);
     handle.join().expect("accept thread completes");
 }
 
@@ -55,13 +57,13 @@ fn apply_socket_options_warns_and_continues_on_unknown_name() {
 #[cfg(not(target_family = "windows"))]
 #[test]
 fn apply_socket_options_opt_on_with_value_still_applies() {
-    let (stream, handle) = connected_stream();
+    let (socket, handle) = connected_socket();
 
     // IPTOS_LOWDELAY is an IPv4 IP_TOS preset; supplying `=5` is a user error
     // upstream warns about but still applies the 0x10 preset on an AF_INET
     // socket. This must return normally (no panic / no fatal error).
-    apply_socket_options(&stream, std::ffi::OsStr::new("IPTOS_LOWDELAY=5"));
+    apply_socket_options(&socket, std::ffi::OsStr::new("IPTOS_LOWDELAY=5"));
 
-    drop(stream);
+    drop(socket);
     handle.join().expect("accept thread completes");
 }

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -172,6 +172,26 @@ fn serve_connections(
         }
     };
 
+    // upstream: socket.c:set_socket_options() - the `socket options =` /
+    // `--sockopts` string is parsed once up front so it can be applied to
+    // each listener socket before bind(2) (socket.c:449-452 - after
+    // SO_REUSEADDR, before bind), and later to each accepted client
+    // connection before the session handler runs.
+    let parsed_socket_options: Vec<SocketOption> = if let Some(ref opts_str) = socket_options_str {
+        parse_socket_options(opts_str, log_sink.as_ref()).map_err(|msg| {
+            DaemonError::new(
+                FEATURE_UNAVAILABLE_EXIT_CODE,
+                rsync_error!(
+                    FEATURE_UNAVAILABLE_EXIT_CODE,
+                    format!("invalid socket options: {msg}")
+                )
+                .with_role(Role::Daemon),
+            )
+        })?
+    } else {
+        Vec::new()
+    };
+
     // When a pre-bound listener is injected (test infrastructure), use it
     // directly - skipping the bind step eliminates the TOCTOU race between
     // port allocation and daemon bind. `listeners` is later moved into the
@@ -183,6 +203,12 @@ fn serve_connections(
         let local_addr = listener
             .local_addr()
             .unwrap_or_else(|_| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port));
+        // The listener is already bound (and, for a real `TcpListener`,
+        // already listening) by the test harness that injected it, so
+        // sockopts can only be applied post-hoc here. This path is
+        // test-infrastructure-only; the real startup path below applies
+        // sockopts pre-bind.
+        apply_socket_options_to_listener(&listener, &parsed_socket_options, log_sink.as_ref());
         bound_addresses = vec![local_addr];
         listeners = vec![listener];
     } else {
@@ -202,6 +228,7 @@ fn serve_connections(
             backlog,
             tcp_fastopen_mode,
             acceptor_threads,
+            &parsed_socket_options,
             log_sink.as_ref(),
         ) {
             Ok((bound_listeners, bound_local_addrs)) => {
@@ -229,32 +256,10 @@ fn serve_connections(
         warn_tcp_fastopen_unsupported(log_sink.as_ref());
     }
 
-    // upstream: socket.c:set_socket_options() - apply socket options to each
-    // listener socket before accepting connections, and to each accepted
-    // client connection before the session handler runs.
-    let client_socket_options: Arc<Vec<SocketOption>> = if let Some(ref opts_str) =
-        socket_options_str
-    {
-        let parsed = parse_socket_options(opts_str, log_sink.as_ref()).map_err(|msg| {
-            DaemonError::new(
-                FEATURE_UNAVAILABLE_EXIT_CODE,
-                rsync_error!(
-                    FEATURE_UNAVAILABLE_EXIT_CODE,
-                    format!("invalid socket options: {msg}")
-                )
-                .with_role(Role::Daemon),
-            )
-        })?;
-        // upstream: socket.c:730-733 - a failed setsockopt warns and continues;
-        // it never aborts binding. apply_socket_options_to_listener applies each
-        // option independently and logs any per-option failure.
-        for listener in &listeners {
-            apply_socket_options_to_listener(listener, &parsed, log_sink.as_ref());
-        }
-        Arc::new(parsed)
-    } else {
-        Arc::new(Vec::new())
-    };
+    // Retained for each accepted client connection - upstream: clientserver.c
+    // applies set_socket_options() to the accepted fd before the session
+    // handler runs, independent of the listener-side application above.
+    let client_socket_options: Arc<Vec<SocketOption>> = Arc::new(parsed_socket_options);
 
     // Detach from terminal if --detach is active (Unix default).
     // Must happen after binding so startup errors reach stderr, and before

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -158,6 +158,14 @@ const UPSTREAM_IPPROTO_TCP: i32 = 6;
 /// default (128). This matches upstream rsync's `socket.c` which calls
 /// `listen(sp[i], lp_listen_backlog())`.
 ///
+/// `socket_options` (the `socket options =` config directive / `--sockopts`)
+/// is applied before `bind(2)` - upstream: socket.c:447-465 applies
+/// `SO_REUSEADDR` then `set_socket_options(s, sockopts)` then `bind(2)`.
+/// Applying user socket options only after `listen(2)` (as a prior version of
+/// this function did, via a caller-side post-bind pass) is a no-op for
+/// options that shape the window scale advertised in the SYN-ACK the kernel
+/// sends once the socket starts accepting connections.
+///
 /// Failed `socket(2)` and `bind(2)` syscalls are reported through the
 /// `--debug=BIND` producer (`protocol::bind::trace`), mirroring upstream
 /// `socket.c:432-470` per-address-family accumulation. The errors are
@@ -167,6 +175,8 @@ fn bind_with_backlog(
     backlog: i32,
     tcp_fastopen: TcpFastOpenMode,
     reuse_port: bool,
+    socket_options: &[SocketOption],
+    log_sink: Option<&SharedLogSink>,
 ) -> io::Result<TcpListener> {
     let domain = if addr.is_ipv4() {
         socket2::Domain::IPV4
@@ -220,6 +230,12 @@ fn bind_with_backlog(
             );
         }
     }
+
+    // upstream: socket.c:449-452 - set_socket_options(s, sockopts) runs here,
+    // after SO_REUSEADDR and before bind(2), so options that shape the SYN-ACK
+    // (e.g. SO_SNDBUF/SO_RCVBUF window scaling) take effect from the first
+    // connection the listener accepts.
+    apply_socket_options_impl(socket2::SockRef::from(&socket), socket_options, log_sink);
 
     // For IPv6 sockets, set IPV6_V6ONLY to avoid conflicts with the separate
     // IPv4 listener in dual-stack mode.
@@ -405,6 +421,7 @@ fn bind_listeners_per_family(
     backlog: i32,
     tcp_fastopen: TcpFastOpenMode,
     acceptor_threads: u32,
+    socket_options: &[SocketOption],
     log_sink: Option<&SharedLogSink>,
 ) -> Result<(Vec<TcpListener>, Vec<SocketAddr>), io::Error> {
     let replicas = acceptor_threads.max(1) as usize;
@@ -428,7 +445,14 @@ fn bind_listeners_per_family(
         let mut family_bound = 0usize;
         let mut family_error: Option<io::Error> = None;
         for _ in 0..replicas {
-            match bind_with_backlog(requested_addr, backlog, tcp_fastopen, reuse_port) {
+            match bind_with_backlog(
+                requested_addr,
+                backlog,
+                tcp_fastopen,
+                reuse_port,
+                socket_options,
+                log_sink,
+            ) {
                 Ok(listener) => {
                     let local_addr = listener.local_addr().unwrap_or(requested_addr);
                     bound_addresses.push(local_addr);

--- a/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/socket_options.rs
@@ -269,8 +269,13 @@ fn parse_tos_option_value(value: Option<&str>) -> Result<u32, String> {
 
 /// Applies parsed socket options to a TCP listener via `socket2`.
 ///
-/// upstream: socket.c - `set_socket_options()` applies options via `setsockopt(2)`
-/// after binding and before accepting connections.
+/// upstream: socket.c:449-452 - `set_socket_options()` runs before `bind(2)`
+/// (socket.c:465), before the listener can process a SYN. The real daemon
+/// startup path (`listener.rs::bind_with_backlog`) applies options to the
+/// pre-connect `socket2::Socket` directly for that reason; this
+/// `&TcpListener` entry point exists for the test-injected pre-bound-listener
+/// path, where the listener is already bound (and listening) by the time
+/// socket options can be applied.
 fn apply_socket_options_to_listener(
     listener: &TcpListener,
     options: &[SocketOption],

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1245,6 +1245,7 @@ fn bind_listeners_per_family_falls_back_when_first_family_unreachable() {
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
         1,
+        &[],
         None,
     )
     .expect("at least one family must bind");
@@ -1259,6 +1260,41 @@ fn bind_listeners_per_family_falls_back_when_first_family_unreachable() {
     assert!(
         bound_addresses[0].port() != 0,
         "kernel must assign an ephemeral port for the bound listener"
+    );
+}
+
+#[test]
+fn bind_listeners_per_family_applies_socket_options_before_listen() {
+    // upstream: socket.c:449-452 - set_socket_options(s, sockopts) runs before
+    // bind(2)/listen(2), so options that shape the SYN-ACK (e.g.
+    // SO_SNDBUF/SO_RCVBUF window scaling) take effect from the very first
+    // connection. Prior to this fix the daemon applied `socket options =` /
+    // `--sockopts` only after the listener was already bound and listening
+    // (a caller-side post-bind pass), which is a no-op for the handshake.
+    // This proves the option reaches the listener through
+    // `bind_listeners_per_family` itself, exercising the pre-bind apply path.
+    let loopback = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+    let socket_options = vec![SocketOption::SoSndBuf(131_072)];
+
+    let (listeners, _bound_addresses) = bind_listeners_per_family(
+        &[loopback],
+        0,
+        DEFAULT_LISTEN_BACKLOG,
+        TcpFastOpenMode::Off,
+        1,
+        &socket_options,
+        None,
+    )
+    .expect("loopback bind must succeed");
+
+    assert_eq!(listeners.len(), 1);
+    let reported = socket2::SockRef::from(&listeners[0])
+        .send_buffer_size()
+        .expect("query send buffer size");
+    assert!(
+        reported >= 131_072,
+        "SO_SNDBUF=131072 must be applied to the listener before it starts \
+         serving, got {reported}"
     );
 }
 
@@ -1279,6 +1315,7 @@ fn bind_listeners_per_family_replicates_acceptor_threads() {
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
         3,
+        &[],
         None,
     )
     .expect("the reachable family must bind all replicas");
@@ -1323,6 +1360,7 @@ fn default_single_listener_refuses_a_second_bind_on_the_same_port() {
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
         1,
+        &[],
         None,
     )
     .expect("first default bind must succeed");
@@ -1338,6 +1376,7 @@ fn default_single_listener_refuses_a_second_bind_on_the_same_port() {
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
         1,
+        &[],
         None,
     );
     assert!(
@@ -1374,6 +1413,7 @@ fn multi_acceptor_replicas_co_bind_the_same_fixed_port() {
             DEFAULT_LISTEN_BACKLOG,
             TcpFastOpenMode::Off,
             2,
+            &[],
             None,
         ) {
             Ok((listeners, addrs)) if listeners.len() == 2 => {
@@ -1415,6 +1455,7 @@ fn bind_listeners_per_family_fails_only_when_all_families_unreachable() {
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
         1,
+        &[],
         None,
     )
     .expect_err("no family should bind");
@@ -1458,6 +1499,7 @@ fn bind_listeners_per_family_falls_back_from_ipv6_to_ipv4() {
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
         1,
+        &[],
         None,
     )
     .expect("IPv4 fallback must bind when IPv6 is unreachable");
@@ -1495,6 +1537,7 @@ fn bind_listeners_per_family_single_family_propagates_error() {
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
         1,
+        &[],
         None,
     )
     .expect_err("the single configured address must fail to bind");

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -375,17 +375,15 @@ pub use secure_dir::secure_open_dir;
 // See WIN-S.LAND.1.a audit (#5552) confirming zero external callers.
 #[cfg(unix)]
 pub use sendfile::send_file_to_fd_with_policy;
-#[cfg(unix)]
-pub use socket_options::set_socket_int_option_raw;
 pub use socket_options::{
     DEFAULT_TCP_FASTOPEN_QLEN, DEFAULT_TCP_NOTSENT_LOWAT, MAX_SOCKET_BUFFER_SIZE,
     connectx_fastopen_raw, connectx_fastopen_supported, enable_tcp_fastopen_connect_raw,
     enable_tcp_fastopen_listener, enable_tcp_fastopen_raw, rearm_tcp_quickack,
     reuse_port_supported, set_listener_int_option, set_so_busy_poll, set_so_max_pacing_rate,
-    set_socket_buffer_sizes, set_socket_int_option, set_tcp_cork, set_tcp_notsent_lowat,
-    set_tcp_quickack, so_busy_poll_supported, so_max_pacing_rate_supported, tcp_cork_supported,
-    tcp_fastopen_connect_supported, tcp_fastopen_listener_supported, tcp_notsent_lowat_supported,
-    tcp_quickack_supported,
+    set_socket_buffer_sizes, set_socket_int_option, set_socket_int_option_raw, set_tcp_cork,
+    set_tcp_notsent_lowat, set_tcp_quickack, so_busy_poll_supported, so_max_pacing_rate_supported,
+    tcp_cork_supported, tcp_fastopen_connect_supported, tcp_fastopen_listener_supported,
+    tcp_notsent_lowat_supported, tcp_quickack_supported,
 };
 #[cfg(target_os = "linux")]
 pub use splice::DEFAULT_PIPE_CAPACITY;

--- a/crates/fast_io/src/socket_options.rs
+++ b/crates/fast_io/src/socket_options.rs
@@ -99,6 +99,26 @@ pub fn set_socket_int_option_raw(
     setsockopt_int_raw(fd, level, option, value)
 }
 
+/// Windows counterpart to [`set_socket_int_option_raw`]: same semantics, but
+/// accepts a `RawSocket` so a caller holding a pre-connect `socket2::Socket`
+/// (which has no `TcpStream` yet) can set the handful of options with no
+/// typed `socket2` equivalent.
+///
+/// # Errors
+///
+/// Returns the OS error reported by Winsock's `setsockopt` if the call fails.
+#[cfg(windows)]
+pub fn set_socket_int_option_raw(
+    raw_socket: std::os::windows::io::RawSocket,
+    level: i32,
+    option: i32,
+    value: i32,
+) -> io::Result<()> {
+    use windows_sys::Win32::Networking::WinSock::SOCKET;
+
+    setsockopt_int_raw_winsock(raw_socket as SOCKET, level, option, value)
+}
+
 /// Enables the server-side `TCP_FASTOPEN` option on a raw socket file
 /// descriptor or handle.
 ///


### PR DESCRIPTION
## Summary

- `--sockopts` was applied to the daemon socket after `connect(2)` had already
  completed. Upstream `socket.c:279-280` calls `set_socket_options(s, sockopts)`
  immediately before `connect(s, ...)` in `open_socket_out()`, because options
  such as `SO_SNDBUF`/`SO_RCVBUF` shape the TCP window scale negotiated in the
  handshake - setting them after the socket is already connected is a no-op for
  that negotiation.
- Moved the application into `connect_with_optional_bind()` (client connect
  path) so it runs on the pre-connect `socket2::Socket`, right after the
  optional bind and before `connect(2)`/`connect_timeout(2)`. Threaded the
  `sockopts` string through `connect_direct`, `connect_via_proxy`, and
  `open_daemon_stream` so both the direct and HTTP-proxied connect paths pick
  it up; the `RSYNC_CONNECT_PROG` path is unaffected, matching upstream (a
  connect program bypasses `open_socket_out()` entirely).
- Found the same class of bug on the daemon listener side: `socket.c:449-452`
  applies `set_socket_options()` before `bind(2)`, but the daemon was applying
  `socket options =` / `--sockopts` to listeners that were already bound *and*
  listening. Moved it into `bind_with_backlog()`, before `bind(2)`. The
  test-only pre-bound-listener injection path keeps a post-hoc apply since
  that listener already exists by the time it reaches the accept loop.

## Test plan

- [x] `cargo fmt -p core -p daemon -p fast_io -- --check`
- [x] `cargo clippy -p core -p daemon -p fast_io --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p core -p daemon -p fast_io --all-features -E 'test(sockopt) or test(connect) or test(socket) or test(bind_listeners) or test(bind_with_backlog)'` - 432 passed
- [x] New tests added: `connect_with_optional_bind_applies_sockopts` (client) and
      `bind_listeners_per_family_applies_socket_options_before_listen` (daemon),
      both proving the option reaches the socket via the exact helper that
      previously applied it too late.
