### PR TITLE
chore: remove deprecated sender-inc-recurse cargo feature

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -415,50 +415,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      # V61D-3 - daemon-push interop with the gated `sender-inc-recurse`
-      # feature enabled. The flag flips the `inc_recursive_send` builder
-      # default ON so push transfers advertise the `'i'` capability bit
-      # (ISI.b, #2739). The full default-OFF interop run already happened
-      # above; this cell rebuilds oc-rsync with `--features
-      # sender-inc-recurse` and re-runs `run_interop.sh` so the
-      # daemon-push scenarios exercise the sender-INC_RECURSE path that
-      # ISI.h will eventually make the default. Non-blocking: failures
-      # surface regressions early but must not gate PRs until ISI.h
-      # flips the default. Memory note:
-      # [[project_v061_daemon_push_increcurse_disable]]. Linux-only
-      # because the harness only runs on Linux runners anyway. Restores
-      # the default-OFF binary at the end so the downstream SSH cell
-      # observes the same binary it would have without this step.
-      - name: Run interop tests with sender-inc-recurse feature (V61D-3)
-        continue-on-error: true
-        run: |
-          set -euo pipefail
-          # Stash the default-OFF dist binary so we can put it back
-          # before the SSH interop cell runs (do not change existing
-          # cell behaviour).
-          ORIG_BIN=""
-          if [[ -x target/dist/oc-rsync ]]; then
-            ORIG_BIN=$(mktemp)
-            cp target/dist/oc-rsync "$ORIG_BIN"
-          fi
-          restore_default_bin() {
-            if [[ -n "$ORIG_BIN" && -f "$ORIG_BIN" ]]; then
-              cp "$ORIG_BIN" target/dist/oc-rsync
-              chmod +x target/dist/oc-rsync
-              rm -f "$ORIG_BIN"
-            fi
-          }
-          trap restore_default_bin EXIT
-
-          # Force a rebuild with the feature so `ensure_workspace_binaries`
-          # inside `run_interop.sh` re-links oc-rsync with
-          # `--features sender-inc-recurse` instead of reusing the
-          # default-OFF binary from the earlier interop step.
-          rm -f target/dist/oc-rsync
-          cargo build --locked --profile dist --bin oc-rsync --features sender-inc-recurse
-          target/dist/oc-rsync --version 2>&1 | head -1
-          bash tools/ci/run_interop.sh
-
       - name: Run SSH interop tests
         run: |
           set -euo pipefail

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,13 +66,6 @@ iconv = ["cli/iconv", "core/iconv"]
 # Trade-offs: Minimal overhead on single-core systems
 parallel = ["cli/parallel", "checksums/parallel"]
 
-
-# DEPRECATED (ISI.h): sender INC_RECURSE is now default-on. Flag
-# retained for one release as an emergency-disable no-op. CLI
-# `--no-inc-recursive` is the recommended override. Remove in the
-# next minor version (ISI.i.2).
-sender-inc-recurse = ["core/sender-inc-recurse", "transfer/sender-inc-recurse"]
-
 # io_uring support for Linux 5.6+ - batched async I/O syscalls
 # Requirements: Linux kernel 5.6+ (runtime fallback on older kernels)
 # Benefits: 20-40% faster I/O on supported systems via syscall batching

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -92,10 +92,6 @@ embedded-ssh = ["dep:tokio", "rsync_io/embedded-ssh"]
 # Async runtime support - enables tokio-based async I/O for core operations
 async = ["dep:tokio", "engine/async"]
 
-# DEPRECATED (ISI.h): sender INC_RECURSE is now default-on. Marker
-# retained for one release until ISI.i.2 retires the feature flag.
-sender-inc-recurse = []
-
 # Async SSH transport: wires `rsync_io::ssh::AsyncSshTransport` into the client
 # remote transfer path. Opt-in at runtime via the `OC_RSYNC_ASYNC_SSH=1` env
 # var until the CLI flag lands (#1806).

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -478,10 +478,9 @@ impl ClientConfigBuilder {
             mkpath: self.mkpath,
             prune_empty_dirs: self.prune_empty_dirs,
             qsort: self.qsort,
-            // ISI.h: sender-side INC_RECURSE is now default-on, matching
+            // ISI.h: sender-side INC_RECURSE is default-on, matching
             // upstream rsync 3.4.x. CLI `--no-inc-recursive` still overrides
-            // to `false`. The `sender-inc-recurse` cargo feature is retained
-            // for one release as a no-op escape hatch; ISI.i.2 retires it.
+            // to `false`.
             inc_recursive_send: self.inc_recursive_send.unwrap_or(true),
             verbosity: self.verbosity,
             progress: self.progress,

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -133,11 +133,6 @@ thread-slab-pool = ["engine/thread-slab-pool"]
 # Incremental file list processing with failed directory tracking
 incremental-flist = []
 
-# DEPRECATED (ISI.h): sender INC_RECURSE is now default-on. Marker
-# retained for one release to keep V61D-2 / V61D-3 interop gates
-# compilable until ISI.i.2 retires both.
-sender-inc-recurse = []
-
 # ============================================================================
 # Debugging Features
 # ============================================================================

--- a/crates/transfer/benches/isi_g_sender_inc_recurse_start_time.rs
+++ b/crates/transfer/benches/isi_g_sender_inc_recurse_start_time.rs
@@ -27,10 +27,10 @@
 //!
 //! Three pipe-driven push transfers against the same source tree:
 //!
-//! | Bench | Sender binary                           | INC_RECURSE on the wire? |
-//! |-------|-----------------------------------------|--------------------------|
-//! | A     | `oc-rsync` built **without** `sender-inc-recurse` | No  (baseline) |
-//! | B     | `oc-rsync` built **with** `sender-inc-recurse`    | Yes (under test) |
+//! | Bench | Sender invocation                             | INC_RECURSE on the wire? |
+//! |-------|------------------------------------------------|--------------------------|
+//! | A     | `oc-rsync` with `--no-inc-recursive`             | No  (baseline) |
+//! | B     | `oc-rsync` with default flags (INC_RECURSE is unconditional since ISI.h) | Yes (under test) |
 //! | C     | upstream `rsync` (protocol >= 30, default ON)     | Yes (reference) |
 //!
 //! Each cell reports two metrics:
@@ -80,9 +80,11 @@
 //! - `OC_RSYNC_BENCH_FIRST_DATA_BYTES` - override the start-time
 //!   threshold (default `1_048_576`). Lower it to measure protocol
 //!   greeting latency, raise it to require more file-list payload.
-//! - `OC_RSYNC_BIN_BASELINE` / `OC_RSYNC_BIN_INC_RECURSE` /
-//!   `OC_RSYNC_BIN_UPSTREAM` - override the binary paths. Defaults match
-//!   the build script convention used by `pip_6_end_to_end_parallel_vs_sequential`.
+//! - `OC_RSYNC_BIN` / `OC_RSYNC_BIN_UPSTREAM` - override the binary paths.
+//!   Defaults match the build script convention used by
+//!   `pip_6_end_to_end_parallel_vs_sequential`. The baseline and under-test
+//!   cells share the same `oc-rsync` binary; only the `--no-inc-recursive`
+//!   flag differs between them.
 //!
 //! # Skip semantics
 //!
@@ -95,23 +97,18 @@
 //!
 //! # How to run
 //!
-//! Three binaries are required. Build them out-of-band:
+//! One `oc-rsync` binary and an upstream reference are required:
 //!
 //! ```sh
-//! # Baseline: default features, sender-inc-recurse OFF
+//! # oc-rsync: INC_RECURSE is unconditional since ISI.h; the bench toggles
+//! # it per-cell via the runtime `--no-inc-recursive` flag.
 //! cargo build --release --bin oc-rsync
-//! mv target/release/oc-rsync target/release/oc-rsync-baseline
-//!
-//! # Under test: sender-inc-recurse ON
-//! cargo build --release --features sender-inc-recurse --bin oc-rsync
-//! mv target/release/oc-rsync target/release/oc-rsync-inc-recurse
 //!
 //! # Upstream reference: rsync 3.4.1 (or any protocol >= 30 build)
 //! bash tools/ci/run_interop.sh
 //!
 //! # Run the bench
-//! OC_RSYNC_BIN_BASELINE=target/release/oc-rsync-baseline \
-//! OC_RSYNC_BIN_INC_RECURSE=target/release/oc-rsync-inc-recurse \
+//! OC_RSYNC_BIN=target/release/oc-rsync \
 //! OC_RSYNC_BIN_UPSTREAM=target/interop/upstream-install/3.4.1/bin/rsync \
 //! cargo bench -p transfer --bench isi_g_sender_inc_recurse_start_time
 //! ```
@@ -121,7 +118,9 @@
 //! - ISI.a (`docs/design/isi-a-sender-inc-recurse-call-graph.md`) -
 //!   sender-side call graph and the single-flip blocker that ISI.b
 //!   lifted.
-//! - ISI.b (`#4802`) - introduces the `sender-inc-recurse` cargo feature.
+//! - ISI.b (`#4802`) - introduced the now-retired `sender-inc-recurse`
+//!   cargo feature; ISI.h made INC_RECURSE unconditional and ISI.i.2
+//!   removed the flag.
 //! - ISI.c (`#4842`) - single-segment push interop.
 //! - ISI.d (`#4846`) - multi-segment push interop.
 //! - ISI.e (`#4859`) - wire-byte parity against upstream sender.
@@ -175,14 +174,17 @@ const FILE_PAYLOAD_BYTES: usize = 16;
 /// same dialect across the test and bench harnesses.
 const UPSTREAM_FLAGS_341: &str = "-vlogDtprze.iLsfxCIvu";
 
-/// The three sender binaries the bench drives.
+/// The two INC_RECURSE modes the bench compares, plus the upstream
+/// reference. Since ISI.h, INC_RECURSE is unconditional on the sender side;
+/// `Baseline` and `IncRecurse` now share the same `oc-rsync` binary and
+/// differ only by the runtime `--no-inc-recursive` flag.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Sender {
-    /// `oc-rsync` built **without** `sender-inc-recurse`. Capability string
+    /// `oc-rsync` invoked with `--no-inc-recursive`. Capability string
     /// strips `'i'`; the upstream peer never enables INC_RECURSE.
     Baseline,
-    /// `oc-rsync` built **with** `sender-inc-recurse`. Capability string
-    /// emits `'i'`; the peer enables INC_RECURSE on its compat flags.
+    /// `oc-rsync` invoked with its default flags. Capability string emits
+    /// `'i'`; the peer enables INC_RECURSE on its compat flags.
     IncRecurse,
     /// Upstream `rsync`. Defaults to INC_RECURSE for protocol >= 30.
     Upstream,
@@ -197,18 +199,26 @@ impl Sender {
         }
     }
 
+    /// Extra CLI args spliced into the sender invocation immediately after
+    /// `--sender`. Only `Baseline` needs one; `IncRecurse` runs with the
+    /// (now unconditional) default and `Upstream` is a separate binary.
+    fn extra_args(self) -> &'static [&'static str] {
+        match self {
+            Sender::Baseline => &["--no-inc-recursive"],
+            Sender::IncRecurse | Sender::Upstream => &[],
+        }
+    }
+
     fn env_var(self) -> &'static str {
         match self {
-            Sender::Baseline => "OC_RSYNC_BIN_BASELINE",
-            Sender::IncRecurse => "OC_RSYNC_BIN_INC_RECURSE",
+            Sender::Baseline | Sender::IncRecurse => "OC_RSYNC_BIN",
             Sender::Upstream => "OC_RSYNC_BIN_UPSTREAM",
         }
     }
 
     fn default_path(self) -> &'static str {
         match self {
-            Sender::Baseline => "target/release/oc-rsync-baseline",
-            Sender::IncRecurse => "target/release/oc-rsync-inc-recurse",
+            Sender::Baseline | Sender::IncRecurse => "target/release/oc-rsync",
             Sender::Upstream => "target/interop/upstream-install/3.4.1/bin/rsync",
         }
     }
@@ -351,6 +361,7 @@ struct PushTiming {
 /// `--server` receiver, copy bytes between them, and record both timings.
 fn run_one_push(
     sender_bin: &Path,
+    extra_sender_args: &[&str],
     receiver_bin: &Path,
     src: &Path,
     dst: &Path,
@@ -361,6 +372,7 @@ fn run_one_push(
     let mut server = Command::new(sender_bin)
         .arg("--server")
         .arg("--sender")
+        .args(extra_sender_args)
         .arg(UPSTREAM_FLAGS_341)
         .arg(".")
         .arg(src.to_string_lossy().as_ref())
@@ -473,6 +485,7 @@ fn bench_sender(
         return;
     };
 
+    let extra_args = sender.extra_args();
     let group_name = format!("isi_g_sender_inc_recurse_start_time/{}", sender.label());
     let mut group = c.benchmark_group(group_name);
     // Each iteration spawns two processes and pumps the full 100 000-file
@@ -493,6 +506,7 @@ fn bench_sender(
                 let dest = TempDir::new().expect("dest tempdir");
                 let timing = run_one_push(
                     &sender_bin,
+                    extra_args,
                     &receiver_bin,
                     src_root,
                     dest.path(),
@@ -530,6 +544,7 @@ fn bench_sender(
                 let dest = TempDir::new().expect("dest tempdir");
                 let timing = run_one_push(
                     &sender_bin,
+                    extra_args,
                     &receiver_bin,
                     src_root,
                     dest.path(),

--- a/crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs
+++ b/crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs
@@ -4,27 +4,19 @@
 //! regression.md`) traced to PR #3557's flip of `inc_recursive_send` to
 //! `true` by default: push transfers (client-as-sender) against an
 //! upstream rsync daemon ran 95-201x slower than the v0.6.0 baseline.
-//! The mitigation (PR #3744) restored the default to `false` and gated
-//! the flip behind the `sender-inc-recurse` cargo feature.
+//! The mitigation (PR #3744) restored the default to `false` behind a
+//! temporary `sender-inc-recurse` cargo feature; ISI.h later re-flipped
+//! the default to `true` unconditionally once the regression was fixed,
+//! and ISI.i.2 retired the now-redundant feature flag.
 //!
-//! This test rebuilds the failure mode under that feature. It pushes a
-//! small (~1 MiB) source tree from `oc-rsync` (sender) to an upstream
+//! This test guards the fixed path permanently. It pushes a small
+//! (~1 MiB) source tree from `oc-rsync` (sender) to an upstream
 //! `rsync --daemon` (receiver) and times the transfer, then repeats the
 //! same push with upstream `rsync` as the sender to capture a baseline.
 //! Asserts the oc-rsync push completes within 5x of the upstream
 //! baseline. The v0.6.1 symptom was 95-201x, so 5x is a generous
 //! threshold that still trips on a real regression while tolerating
 //! normal benchmark noise on CI runners.
-//!
-//! ## Feature gate
-//!
-//! `#[cfg(feature = "sender-inc-recurse")]` - mirrors ISI.c/d/e. Without
-//! the feature, `ClientConfigBuilder::build()` leaves
-//! `inc_recursive_send = false`, the capability string omits `'i'`, the
-//! upstream peer clears `allow_inc_recurse`, and both sides walk the
-//! fully-baked non-INC_RECURSE sender path - exactly the post-mitigation
-//! state where no regression is observable. The feature must be on for
-//! the test to exercise the at-risk path.
 //!
 //! ## Platform gate
 //!
@@ -53,7 +45,7 @@
 //! - PR #3744 / commit `b3a264061` - the mitigation that restored the
 //!   default to `false`.
 
-#![cfg(all(unix, not(target_os = "macos"), feature = "sender-inc-recurse"))]
+#![cfg(all(unix, not(target_os = "macos")))]
 
 use std::env;
 use std::fs::{self, File};
@@ -318,8 +310,8 @@ fn daemon_push_under_inc_recurse_stays_within_5x_of_upstream_sender_baseline() {
         }
     };
 
-    // Sender under test: oc-rsync built with sender-inc-recurse ON. This
-    // is the at-risk path the V61D-1 audit identified.
+    // Sender under test: oc-rsync's default INC_RECURSE-on sender path.
+    // This is the at-risk path the V61D-1 audit identified.
     let oc_elapsed = time_push(&oc_bin, &src, port).expect("oc-rsync push must succeed");
 
     // Reset the destination so the baseline push does not get a

--- a/docs/architecture/dependency-map.md
+++ b/docs/architecture/dependency-map.md
@@ -216,11 +216,6 @@ bin[async] -> daemon/async + core/async -> engine/async + transfer/async
 bin[mmap-free-basis] -> engine/mmap-free-basis + fast_io/mmap-free-basis
 ```
 
-### sender-inc-recurse (deprecated, no-op)
-```
-bin[sender-inc-recurse] -> core/sender-inc-recurse + transfer/sender-inc-recurse
-```
-
 ### openssl / openssl-vendored (checksum acceleration)
 ```
 bin[openssl] -> checksums/openssl (dep:openssl)

--- a/docs/release-notes/sender-inc-recurse-flip.md
+++ b/docs/release-notes/sender-inc-recurse-flip.md
@@ -32,10 +32,10 @@ totals are unchanged.
 
 ## How to revert
 
-- **Build-time:** build without the `sender-inc-recurse` cargo feature
-  (`cargo build --no-default-features --features "<other features>"`).
 - **Runtime per invocation:** pass `--no-inc-recursive` on the client.
   There is no environment variable; the CLI flag is the runtime override.
+  (The `sender-inc-recurse` cargo feature that gated this during the ISI
+  bake-in period was retired in ISI.i.2; there is no build-time toggle.)
 
 ## Reference
 

--- a/tests/inc_recurse_multi_segment_push_isi_d.rs
+++ b/tests/inc_recurse_multi_segment_push_isi_d.rs
@@ -37,15 +37,6 @@
 //! headers on the wire without depending on a particular timing
 //! pattern.
 //!
-//! ## Feature gate
-//!
-//! `#[cfg(feature = "sender-inc-recurse")]` - same temporary bake-up
-//! flag the rest of the ISI series uses. Without it the builder default
-//! is `inc_recursive_send = false`, the `'i'` bit is stripped from the
-//! capability string, and the upstream peer never accepts `INC_RECURSE`
-//! in its compat flags. The cargo feature must be set at the workspace
-//! level so the dependency `oc-rsync` binary is also built with it on.
-//!
 //! ## Platform gate
 //!
 //! `#[cfg(all(unix, not(target_os = "macos")))]` - the upstream rsync
@@ -73,7 +64,7 @@
 //! sentinels in the sender's outbound stream and confirm it equals
 //! the number of sub-list segments the partitioner produced).
 
-#![cfg(all(unix, not(target_os = "macos"), feature = "sender-inc-recurse"))]
+#![cfg(all(unix, not(target_os = "macos")))]
 
 mod integration;
 

--- a/tests/inc_recurse_sender_flist_io_error_isi_f.rs
+++ b/tests/inc_recurse_sender_flist_io_error_isi_f.rs
@@ -45,13 +45,6 @@
 //! test logs `skip:` and succeeds when `geteuid() == 0`. CI runners
 //! run unprivileged; root-only environments simply opt out.
 //!
-//! ## Feature gate
-//!
-//! `#[cfg(feature = "sender-inc-recurse")]` - identical reasoning to
-//! ISI.c/.d/.e. Without the feature the capability string strips `'i'`
-//! and the sender falls back to non-INC_RECURSE walk, exercising the
-//! wrong code path.
-//!
 //! ## Platform gate
 //!
 //! `#[cfg(all(unix, not(target_os = "macos")))]` - the upstream rsync
@@ -61,7 +54,7 @@
 //! would not exercise the same code path even if the upstream binary
 //! were available.
 
-#![cfg(all(unix, not(target_os = "macos"), feature = "sender-inc-recurse"))]
+#![cfg(all(unix, not(target_os = "macos")))]
 
 mod integration;
 

--- a/tests/inc_recurse_sender_wire_parity_isi_e.rs
+++ b/tests/inc_recurse_sender_wire_parity_isi_e.rs
@@ -53,15 +53,6 @@
 //!    keeping `v` (protocol-level varint flist flags advertisement)
 //!    inside the post-`.` capability segment.
 //!
-//! ## Feature gate
-//!
-//! `#[cfg(feature = "sender-inc-recurse")]` - matches ISI.c/ISI.d. The
-//! cargo feature must be set at the workspace level so the dependency
-//! `oc-rsync` binary is built with it on; without the feature the
-//! sender strips `'i'` from its capability advertisement and the
-//! upstream receiver falls back to non-INC_RECURSE mode, producing a
-//! different wire stream than the comparison run.
-//!
 //! ## Platform gate
 //!
 //! `#[cfg(all(unix, not(target_os = "macos")))]` - identical reasoning
@@ -69,7 +60,7 @@
 //! are pre-built only for Linux in `tools/ci/run_interop.sh`; macOS
 //! would be a perpetual skip.
 
-#![cfg(all(unix, not(target_os = "macos"), feature = "sender-inc-recurse"))]
+#![cfg(all(unix, not(target_os = "macos")))]
 
 mod integration;
 

--- a/tests/inc_recurse_single_segment_push_isi_c.rs
+++ b/tests/inc_recurse_single_segment_push_isi_c.rs
@@ -1,9 +1,9 @@
 //! ISI.c - single-segment INC_RECURSE push interop.
 //!
 //! Smallest possible end-to-end exercise of the sender-side INC_RECURSE
-//! path: an oc-rsync `--server --sender` instance built with the
-//! `sender-inc-recurse` cargo feature pushes a 10-file single-directory
-//! tree to an upstream rsync `--server` receiver over wired pipes. The
+//! path: an oc-rsync `--server --sender` instance (INC_RECURSE is
+//! unconditional since ISI.h) pushes a 10-file single-directory tree to
+//! an upstream rsync `--server` receiver over wired pipes. The
 //! destination must match the source byte-for-byte and the capability
 //! string we would emit must include `'i'`.
 //!
@@ -29,16 +29,6 @@
 //! `parent_dir_ndx` alignment on adversarial fixtures. This file is the
 //! regression seed all three build on.
 //!
-//! ## Feature gate
-//!
-//! `#[cfg(feature = "sender-inc-recurse")]` - the temporary bake-up
-//! flag from ISI.b. Without it the builder default is
-//! `inc_recursive_send = false`, the `'i'` bit is stripped, and the
-//! upstream peer never accepts `INC_RECURSE` in its compat flags.
-//! `cfg!(feature = "sender-inc-recurse")` must be passed at the
-//! workspace level so the dependency `oc-rsync` binary is also built
-//! with the feature on.
-//!
 //! ## Platform gate
 //!
 //! `#[cfg(all(unix, not(target_os = "macos")))]` - the upstream rsync
@@ -62,7 +52,7 @@
 //! a buffer in `run_pipe_push`, decode `MSG_DATA` frames, and assert the
 //! `NDX_FLIST` / `NDX_FLIST_EOF` sequence matches the golden trace.
 
-#![cfg(all(unix, not(target_os = "macos"), feature = "sender-inc-recurse"))]
+#![cfg(all(unix, not(target_os = "macos")))]
 
 mod integration;
 
@@ -204,9 +194,9 @@ fn copy_until_eof<R: Read, W: Write>(reader: &mut R, writer: &mut W) -> io::Resu
 /// wired stdio pipes. Mirrors the SSH transport without needing sshd.
 ///
 /// The oc-rsync side is launched **without** `--inc-recursive` on the
-/// CLI: the `sender-inc-recurse` cargo feature flips the builder
-/// default so push transfers advertise the `'i'` bit unconditionally.
-/// That is the precise invariant ISI.c locks in.
+/// CLI: the builder default (unconditional since ISI.h) already
+/// advertises the `'i'` bit on push transfers. That is the precise
+/// invariant ISI.c locks in.
 fn run_pipe_push(oc_bin: &Path, up_bin: &Path, src: &Path, dst: &Path) -> io::Result<()> {
     let mut server = Command::new(oc_bin)
         .arg("--server")
@@ -276,7 +266,7 @@ fn run_pipe_push(oc_bin: &Path, up_bin: &Path, src: &Path, dst: &Path) -> io::Re
     Ok(())
 }
 
-/// Default `ClientConfig` must advertise INC_RECURSE under the feature.
+/// Default `ClientConfig` must advertise INC_RECURSE unconditionally.
 ///
 /// This is the in-process counterpart to the byte-level pipe push: if
 /// the builder default ever regresses to `false` the capability string
@@ -288,7 +278,7 @@ fn default_capability_string_includes_inc_recurse() {
     let config = ClientConfig::builder().build();
     assert!(
         config.inc_recursive_send(),
-        "sender-inc-recurse feature must flip inc_recursive_send default ON"
+        "inc_recursive_send default must be ON"
     );
 
     let caps = build_capability_string(config.inc_recursive_send());
@@ -298,15 +288,14 @@ fn default_capability_string_includes_inc_recurse() {
     );
     assert!(
         caps.contains('i'),
-        "sender-inc-recurse feature must include 'i' in capability string: {caps}"
+        "capability string must include 'i' by default: {caps}"
     );
 }
 
-/// `--no-inc-recursive` must still suppress `'i'` even with the feature on.
+/// `--no-inc-recursive` must still suppress `'i'` even with the default ON.
 ///
 /// Mirrors the upstream `set_allow_inc_recurse()` precedent: the CLI
-/// override wins over the compiled-in default. ISI.h preserves this
-/// invariant when the feature gate is retired.
+/// override wins over the compiled-in default.
 #[test]
 fn no_inc_recursive_override_suppresses_inc_recurse_bit() {
     let config = ClientConfig::builder().inc_recursive_send(false).build();
@@ -314,7 +303,7 @@ fn no_inc_recursive_override_suppresses_inc_recurse_bit() {
     let caps = build_capability_string(config.inc_recursive_send());
     assert!(
         !caps.contains('i'),
-        "--no-inc-recursive override must drop 'i' even with feature on: {caps}"
+        "--no-inc-recursive override must drop 'i' even with the default ON: {caps}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Removes the deprecated `sender-inc-recurse` cargo feature (root, `core`, `transfer`). It had been a bake-in no-op since ISI.h: `inc_recursive_send` already defaults to `true` unconditionally in `crates/core/src/client/config/builder/mod.rs`, with no `#[cfg(feature = "sender-inc-recurse")]` in that path. The runtime `--no-inc-recursive` flag remains the supported override.
- Un-gates the ISI.c/d/e/f interop tests and the V61D-2 daemon-push perf-regression test (previously compiled only under `--features sender-inc-recurse`) so they run unconditionally on Linux non-macOS targets, matching the functionality they guard.
- Updates the ISI.g bench to compare INC_RECURSE on/off via the runtime `--no-inc-recursive` flag on a single binary instead of two separately-built binaries, since there's no longer a build-time toggle.
- Drops the now-redundant V61D-3 CI cell in `_interop.yml` that rebuilt with `--features sender-inc-recurse` (the default interop run already exercises INC_RECURSE-on).
- Updates `docs/architecture/dependency-map.md` and the `sender-inc-recurse-flip` release-notes scaffold to drop the retired build-time toggle.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` (aarch64 host)
- [x] `cargo nextest run` targeted at the previously-gated ISI.c/d/e/f and V61D-2 tests - all pass (upstream binary absent on validation host, so interop cells hit their existing `skip:` path; in-process capability-string assertions ran and passed)
- [x] Repo-wide grep confirms zero remaining `sender-inc-recurse` cfg gates, feature declarations, or CI matrix entries
