### PR TITLE
fix: abort multi-address connect on contimeout, tighten proxy parser

### DIFF
--- a/crates/core/src/client/module_list/connect/direct.rs
+++ b/crates/core/src/client/module_list/connect/direct.rs
@@ -29,28 +29,64 @@ pub(crate) fn connect_direct(
     sockopts: Option<&OsStr>,
 ) -> Result<TcpStream, ClientError> {
     let addresses = resolve_daemon_addresses(addr, address_mode)?;
+
+    let result = try_candidates(&addresses, connect_timeout, |candidate| {
+        connect_with_optional_bind(candidate, bind_address, connect_timeout, tfo, sockopts)
+    });
+
+    match result {
+        Ok(stream) => {
+            if let Some(duration) = io_timeout {
+                stream.set_read_timeout(Some(duration)).map_err(|error| {
+                    socket_error("set read timeout on", addr.socket_addr_display(), error)
+                })?;
+                stream.set_write_timeout(Some(duration)).map_err(|error| {
+                    socket_error("set write timeout on", addr.socket_addr_display(), error)
+                })?;
+            }
+            Ok(stream)
+        }
+        Err((candidate, error)) => Err(map_connect_failure(connect_timeout, candidate, error)),
+    }
+}
+
+/// Iterates `candidates` in order, calling `attempt` for each and returning
+/// the first success.
+///
+/// Mirrors upstream's per-address connect loop (upstream: socket.c:262-310
+/// `open_socket_out()`), including one easy-to-miss subtlety: an ordinary
+/// connect failure (e.g. `ECONNREFUSED`) falls through to the next address,
+/// but a `--contimeout` expiry does not. Upstream's retry loop is
+/// `while (connect(...) < 0) { if (connect_timeout < 0) exit_cleanup(RERR_CONTIMEOUT); ... }`
+/// - once the `SIGALRM` handler has set `connect_timeout` negative, the
+/// process exits immediately without ever reaching `res->ai_next`. A plain
+/// connection failure instead `close(s)`s and `break`s out to the outer
+/// `for` loop, which does advance to the next address. `attempt` returning
+/// `io::ErrorKind::TimedOut` while `connect_timeout` is `Some` is treated as
+/// that alarm firing, so iteration stops there rather than trying the
+/// remaining candidates with a fresh timeout budget.
+pub(crate) fn try_candidates<T>(
+    candidates: &[SocketAddr],
+    connect_timeout: Option<Duration>,
+    mut attempt: impl FnMut(SocketAddr) -> io::Result<T>,
+) -> Result<T, (SocketAddr, io::Error)> {
     let mut last_error: Option<(SocketAddr, io::Error)> = None;
 
-    for candidate in addresses {
-        match connect_with_optional_bind(candidate, bind_address, connect_timeout, tfo, sockopts) {
-            Ok(stream) => {
-                if let Some(duration) = io_timeout {
-                    stream.set_read_timeout(Some(duration)).map_err(|error| {
-                        socket_error("set read timeout on", addr.socket_addr_display(), error)
-                    })?;
-                    stream.set_write_timeout(Some(duration)).map_err(|error| {
-                        socket_error("set write timeout on", addr.socket_addr_display(), error)
-                    })?;
+    for &candidate in candidates {
+        match attempt(candidate) {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                let contimeout_expired =
+                    connect_timeout.is_some() && error.kind() == io::ErrorKind::TimedOut;
+                last_error = Some((candidate, error));
+                if contimeout_expired {
+                    break;
                 }
-
-                return Ok(stream);
             }
-            Err(error) => last_error = Some((candidate, error)),
         }
     }
 
-    let (candidate, error) = last_error.expect("no addresses available for daemon connection");
-    Err(map_connect_failure(connect_timeout, candidate, error))
+    Err(last_error.expect("try_candidates requires at least one candidate"))
 }
 
 /// Maps a final `connect(2)` failure to a [`ClientError`] with the correct exit
@@ -63,7 +99,7 @@ pub(crate) fn connect_direct(
 /// socket-I/O code (10).
 ///
 /// upstream: socket.c:280-282 - `if (connect_timeout < 0) exit_cleanup(RERR_CONTIMEOUT);`
-fn map_connect_failure(
+pub(crate) fn map_connect_failure(
     connect_timeout: Option<Duration>,
     candidate: SocketAddr,
     error: io::Error,
@@ -293,6 +329,107 @@ mod tests {
         let error = io::Error::new(io::ErrorKind::ConnectionRefused, "refused");
         let mapped = map_connect_failure(Some(Duration::from_secs(5)), candidate(), error);
         assert_eq!(mapped.exit_code(), 10);
+    }
+
+    fn candidates(n: usize) -> Vec<SocketAddr> {
+        (0..n)
+            .map(|i| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 10_000 + i as u16))
+            .collect()
+    }
+
+    // upstream: socket.c:262-310 - the address loop tries each getaddrinfo()
+    // result in order; a success on the first candidate must never attempt
+    // the rest.
+    #[test]
+    fn try_candidates_stops_on_first_success() {
+        let addrs = candidates(3);
+        let mut attempted = Vec::new();
+        let result = try_candidates(&addrs, None, |candidate| {
+            attempted.push(candidate);
+            Ok::<_, io::Error>(candidate)
+        });
+        assert_eq!(result.unwrap(), addrs[0]);
+        assert_eq!(attempted, vec![addrs[0]]);
+    }
+
+    // upstream: socket.c:285-296 - an ordinary connect() failure (e.g.
+    // ECONNREFUSED) `close(s)`s and falls through to the next
+    // `res->ai_next` address rather than aborting.
+    #[test]
+    fn try_candidates_continues_past_ordinary_failure() {
+        let addrs = candidates(2);
+        let mut attempted = Vec::new();
+        let result = try_candidates(&addrs, None, |candidate| {
+            attempted.push(candidate);
+            if candidate == addrs[0] {
+                Err(io::Error::new(io::ErrorKind::ConnectionRefused, "refused"))
+            } else {
+                Ok(candidate)
+            }
+        });
+        assert_eq!(result.unwrap(), addrs[1]);
+        assert_eq!(attempted, addrs);
+    }
+
+    // upstream: socket.c:280-282 - once the contimeout alarm has fired,
+    // `exit_cleanup(RERR_CONTIMEOUT)` runs immediately from inside the
+    // current address's retry loop; `res->ai_next` is never reached, even
+    // though a second (perhaps reachable) address remains. This is the
+    // GAP L15 fix: previously oc kept iterating past a --contimeout expiry
+    // and gave every remaining candidate a fresh timeout budget.
+    #[test]
+    fn try_candidates_stops_on_contimeout_expiry_without_trying_next() {
+        let addrs = candidates(2);
+        let mut attempted = Vec::new();
+        let result = try_candidates(&addrs, Some(Duration::from_secs(5)), |candidate| {
+            attempted.push(candidate);
+            Err::<SocketAddr, _>(io::Error::new(io::ErrorKind::TimedOut, "timed out"))
+        });
+        let (candidate, error) = result.expect_err("contimeout expiry must fail");
+        assert_eq!(candidate, addrs[0]);
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(
+            attempted,
+            vec![addrs[0]],
+            "must not try the second address after a contimeout expiry"
+        );
+    }
+
+    // upstream never arms the SIGALRM handler unless `connect_timeout > 0`
+    // (`--contimeout` was given), so an OS-level TimedOut error without
+    // --contimeout configured is an ordinary failure that falls through to
+    // the next address like any other errno.
+    #[test]
+    fn try_candidates_without_contimeout_continues_past_os_level_timeout() {
+        let addrs = candidates(2);
+        let mut attempted = Vec::new();
+        let result = try_candidates(&addrs, None, |candidate| {
+            attempted.push(candidate);
+            if candidate == addrs[0] {
+                Err(io::Error::new(io::ErrorKind::TimedOut, "os timeout"))
+            } else {
+                Ok(candidate)
+            }
+        });
+        assert_eq!(result.unwrap(), addrs[1]);
+        assert_eq!(attempted, addrs);
+    }
+
+    // upstream: socket.c:312-323 - when every address fails, upstream
+    // reports on all of them but the caller only needs the final one to
+    // construct the exit-code mapping; the last candidate/error pair must
+    // be preserved.
+    #[test]
+    fn try_candidates_all_fail_returns_last_error() {
+        let addrs = candidates(2);
+        let result = try_candidates(&addrs, None, |candidate| {
+            Err::<SocketAddr, _>(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                format!("refused {candidate}"),
+            ))
+        });
+        let (candidate, _error) = result.expect_err("both candidates fail");
+        assert_eq!(candidate, addrs[1]);
     }
 
     // upstream: socket.c:279-280 - set_socket_options(s, sockopts) runs before

--- a/crates/core/src/client/module_list/connect/direct.rs
+++ b/crates/core/src/client/module_list/connect/direct.rs
@@ -56,9 +56,11 @@ pub(crate) fn connect_direct(
 /// Mirrors upstream's per-address connect loop (upstream: socket.c:262-310
 /// `open_socket_out()`), including one easy-to-miss subtlety: an ordinary
 /// connect failure (e.g. `ECONNREFUSED`) falls through to the next address,
-/// but a `--contimeout` expiry does not. Upstream's retry loop is
-/// `while (connect(...) < 0) { if (connect_timeout < 0) exit_cleanup(RERR_CONTIMEOUT); ... }`
-/// - once the `SIGALRM` handler has set `connect_timeout` negative, the
+/// but a `--contimeout` expiry does not.
+///
+/// Upstream's retry loop is
+/// `while (connect(...) < 0) { if (connect_timeout < 0) exit_cleanup(RERR_CONTIMEOUT); ... }`;
+/// once the `SIGALRM` handler has set `connect_timeout` negative, the
 /// process exits immediately without ever reaching `res->ai_next`. A plain
 /// connection failure instead `close(s)`s and `break`s out to the outer
 /// `for` loop, which does advance to the next address. `attempt` returning

--- a/crates/core/src/client/module_list/connect/proxy.rs
+++ b/crates/core/src/client/module_list/connect/proxy.rs
@@ -330,7 +330,10 @@ mod tests {
     // rejected or specially recognised. oc must not invent scheme support.
     #[test]
     fn parse_proxy_spec_has_no_scheme_concept() {
-        let error = parse_proxy_spec("http://proxy.example.com:3128").unwrap_err();
+        let error = match parse_proxy_spec("http://proxy.example.com:3128") {
+            Ok(_) => panic!("a scheme prefix must not parse as a valid proxy spec"),
+            Err(error) => error,
+        };
         assert!(error.message().to_string().contains("invalid port"));
     }
 
@@ -349,7 +352,10 @@ mod tests {
     // fails to parse as a port rather than being silently stripped.
     #[test]
     fn parse_proxy_spec_leading_trailing_whitespace_is_literal_not_trimmed() {
-        let error = parse_proxy_spec("  proxy.example.com:8080  ").unwrap_err();
+        let error = match parse_proxy_spec("  proxy.example.com:8080  ") {
+            Ok(_) => panic!("literal whitespace must not parse as a valid proxy spec"),
+            Err(error) => error,
+        };
         assert!(error.message().to_string().contains("invalid port"));
     }
 

--- a/crates/core/src/client/module_list/connect/proxy.rs
+++ b/crates/core/src/client/module_list/connect/proxy.rs
@@ -7,8 +7,7 @@ use std::time::Duration;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;
 
-use super::direct::connect_with_optional_bind;
-use crate::client::module_list::parsing::{decode_host_component, hex_value, parse_bracketed_host};
+use super::direct::{connect_with_optional_bind, map_connect_failure, try_candidates};
 use crate::client::module_list::{DaemonAddress, types::SocketAddrDisplay};
 use crate::client::{ClientError, SOCKET_IO_EXIT_CODE, TcpFastOpenMode, socket_error};
 use crate::message::Role;
@@ -31,28 +30,12 @@ pub(crate) fn connect_via_proxy(
     sockopts: Option<&OsStr>,
 ) -> Result<TcpStream, ClientError> {
     let target = (proxy.host.as_str(), proxy.port);
-    let addrs = target
+    let addrs: Vec<SocketAddr> = target
         .to_socket_addrs()
-        .map_err(|error| socket_error("resolve proxy address for", proxy.display(), error))?;
+        .map_err(|error| socket_error("resolve proxy address for", proxy.display(), error))?
+        .collect();
 
-    let mut last_error: Option<(SocketAddr, io::Error)> = None;
-    let mut stream_result: Option<TcpStream> = None;
-
-    for candidate in addrs {
-        match connect_with_optional_bind(candidate, bind_address, connect_timeout, tfo, sockopts) {
-            Ok(stream) => {
-                stream_result = Some(stream);
-                break;
-            }
-            Err(error) => last_error = Some((candidate, error)),
-        }
-    }
-
-    let mut stream = if let Some(stream) = stream_result {
-        stream
-    } else if let Some((candidate, error)) = last_error {
-        return Err(socket_error("connect to", candidate, error));
-    } else {
+    if addrs.is_empty() {
         return Err(socket_error(
             "resolve proxy address for",
             proxy.display(),
@@ -61,6 +44,19 @@ pub(crate) fn connect_via_proxy(
                 "proxy resolution returned no addresses",
             ),
         ));
+    }
+
+    // upstream: socket.c:262-310 - open_socket_out() resolves and connects to
+    // the proxy host in place of the daemon host, so the same per-address
+    // --contimeout semantics (try each address, but abort immediately - not
+    // move to the next address - once the alarm fires) apply here too.
+    let mut stream = match try_candidates(&addrs, connect_timeout, |candidate| {
+        connect_with_optional_bind(candidate, bind_address, connect_timeout, tfo, sockopts)
+    }) {
+        Ok(stream) => stream,
+        Err((candidate, error)) => {
+            return Err(map_connect_failure(connect_timeout, candidate, error));
+        }
     };
 
     establish_proxy_tunnel(&mut stream, addr, proxy)?;
@@ -139,12 +135,14 @@ pub(crate) fn establish_proxy_tunnel(
 
 pub(crate) fn load_daemon_proxy() -> Result<Option<ProxyConfig>, ClientError> {
     match env::var("RSYNC_PROXY") {
+        // upstream: socket.c:202-203 - `proxied = h != NULL && *h != '\0';`
+        // only a zero-length value is treated as "unset"; a whitespace-only
+        // value is proxied (and then fails to parse), not silently ignored.
         Ok(value) => {
-            let trimmed = value.trim();
-            if trimmed.is_empty() {
+            if value.is_empty() {
                 return Ok(None);
             }
-            parse_proxy_spec(trimmed).map(Some)
+            parse_proxy_spec(&value).map(Some)
         }
         Err(VarError::NotPresent) => Ok(None),
         Err(VarError::NotUnicode(_)) => Err(proxy_configuration_error(
@@ -153,59 +151,36 @@ pub(crate) fn load_daemon_proxy() -> Result<Option<ProxyConfig>, ClientError> {
     }
 }
 
+/// Parses an `RSYNC_PROXY` value into a [`ProxyConfig`].
+///
+/// Mirrors upstream's raw buffer-splitting parser exactly (upstream:
+/// socket.c:205-234 `open_socket_out()`): `[USER:PASS@]HOST:PORT`. There is
+/// no URL scheme, no percent-decoding, and no bracketed-IPv6 syntax in
+/// upstream's C parser - those all belong to the separate `rsync://` URL
+/// grammar, not `RSYNC_PROXY`. The `USER:PASS@` prefix is found by the LAST
+/// `@` (`strrchr`); both the `USER:PASS` split and the `HOST:PORT` split use
+/// the FIRST `:` in their segment (`strchr`), so a plain unbracketed IPv6
+/// literal is not representable here, matching upstream's own limitation.
 pub(crate) fn parse_proxy_spec(spec: &str) -> Result<ProxyConfig, ClientError> {
-    let trimmed = spec.trim();
-    if trimmed.is_empty() {
+    if spec.is_empty() {
         return Err(proxy_configuration_error(
             "RSYNC_PROXY must specify a proxy host",
         ));
     }
 
-    let mut remainder = trimmed;
-    if let Some(idx) = trimmed.find("://") {
-        let (scheme, rest_with_separator) = trimmed.split_at(idx);
-        let rest = &rest_with_separator[3..];
-        if rest.is_empty() {
-            return Err(proxy_configuration_error(
-                "RSYNC_PROXY must specify a proxy host",
-            ));
-        }
-
-        if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
-            return Err(proxy_configuration_error(
-                "RSYNC_PROXY scheme must be http:// or https://",
-            ));
-        }
-
-        remainder = rest;
-    }
-
-    if remainder.contains('/') {
-        return Err(proxy_configuration_error(
-            "RSYNC_PROXY must not include a path component",
-        ));
-    }
-
-    let (credentials, remainder) = if let Some(idx) = remainder.rfind('@') {
-        let (userinfo, host_part) = remainder.split_at(idx);
-        if userinfo.is_empty() {
-            return Err(proxy_configuration_error(
-                "RSYNC_PROXY user information must be non-empty when '@' is present",
-            ));
-        }
+    let (credentials, remainder) = if let Some(idx) = spec.rfind('@') {
+        let (userinfo, host_part) = spec.split_at(idx);
 
         let mut segments = userinfo.splitn(2, ':');
         let username = segments.next().unwrap();
         let password = segments.next().ok_or_else(|| {
-            proxy_configuration_error("RSYNC_PROXY credentials must use USER:PASS@HOST:PORT format")
+            proxy_configuration_error("invalid proxy specification: should be USER:PASS@HOST:PORT")
         })?;
 
-        let username = decode_proxy_component(username, "username")?;
-        let password = decode_proxy_component(password, "password")?;
-        let credentials = ProxyCredentials::new(username, password);
+        let credentials = ProxyCredentials::new(username.to_owned(), password.to_owned());
         (Some(credentials), &host_part[1..])
     } else {
-        (None, remainder)
+        (None, spec)
     };
 
     let (host, port) = parse_proxy_host_port(remainder)?;
@@ -217,89 +192,24 @@ pub(crate) fn parse_proxy_spec(spec: &str) -> Result<ProxyConfig, ClientError> {
     })
 }
 
+/// Splits a `HOST:PORT` string at the first `:`, matching upstream's
+/// `strchr(h, ':')` (upstream: socket.c:228-234).
 fn parse_proxy_host_port(input: &str) -> Result<(String, u16), ClientError> {
-    if input.is_empty() {
-        return Err(proxy_configuration_error(
-            "RSYNC_PROXY must specify a proxy host and port",
-        ));
-    }
-
-    if let Some(rest) = input.strip_prefix('[') {
-        let (host, port) = parse_bracketed_host(rest, 0).map_err(|_| {
-            proxy_configuration_error("RSYNC_PROXY contains an invalid bracketed host")
-        })?;
-        if port == 0 {
-            return Err(proxy_configuration_error(
-                "RSYNC_PROXY bracketed host must include a port",
-            ));
-        }
-        return Ok((host, port));
-    }
-
-    let idx = input
-        .rfind(':')
-        .ok_or_else(|| proxy_configuration_error("RSYNC_PROXY must be in HOST:PORT form"))?;
+    let idx = input.find(':').ok_or_else(|| {
+        proxy_configuration_error("invalid proxy specification: should be HOST:PORT")
+    })?;
     let host = &input[..idx];
     let port_text = &input[idx + 1..];
 
-    if port_text.is_empty() {
-        return Err(proxy_configuration_error(
-            "RSYNC_PROXY must include a proxy port",
-        ));
-    }
-
-    let host = decode_host_component(host).map_err(|_| {
-        proxy_configuration_error("RSYNC_PROXY proxy host contains invalid percent-encoding")
-    })?;
+    // upstream copies the raw port text into a 10-byte buffer with no
+    // numeric validation at parse time, deferring any failure to
+    // getaddrinfo(); oc needs a concrete u16 up front to build the
+    // candidate SocketAddrs, so the port must parse as a number here.
     let port = port_text
         .parse::<u16>()
         .map_err(|_| proxy_configuration_error("RSYNC_PROXY specified an invalid port"))?;
 
-    Ok((host, port))
-}
-
-fn decode_proxy_component(input: &str, field: &str) -> Result<String, ClientError> {
-    if !input.contains('%') {
-        return Ok(input.to_owned());
-    }
-
-    let mut decoded = Vec::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] == b'%' {
-            if index + 2 >= bytes.len() {
-                return Err(proxy_configuration_error(format!(
-                    "RSYNC_PROXY {field} contains truncated percent-encoding"
-                )));
-            }
-
-            let hi = hex_value(bytes[index + 1]).ok_or_else(|| {
-                proxy_configuration_error(format!(
-                    "RSYNC_PROXY {field} contains invalid percent-encoding"
-                ))
-            })?;
-            let lo = hex_value(bytes[index + 2]).ok_or_else(|| {
-                proxy_configuration_error(format!(
-                    "RSYNC_PROXY {field} contains invalid percent-encoding"
-                ))
-            })?;
-
-            decoded.push((hi << 4) | lo);
-            index += 3;
-            continue;
-        }
-
-        decoded.push(bytes[index]);
-        index += 1;
-    }
-
-    String::from_utf8(decoded).map_err(|_| {
-        proxy_configuration_error(format!(
-            "RSYNC_PROXY {field} contains invalid UTF-8 after percent-decoding"
-        ))
-    })
+    Ok((host.to_owned(), port))
 }
 
 pub(crate) struct ProxyConfig {
@@ -412,27 +322,16 @@ mod tests {
         assert!(config.credentials.is_none());
     }
 
+    // upstream: socket.c:205-234 - RSYNC_PROXY has no URL-scheme concept at
+    // all; getenv()'s raw value is split directly on '@' and ':'. A
+    // "scheme://" prefix is just more HOST text to upstream's parser, and
+    // (since strchr(':') finds the FIRST ':', which lands right after the
+    // scheme name) it is misparsed as bogus credentials rather than
+    // rejected or specially recognised. oc must not invent scheme support.
     #[test]
-    fn parse_proxy_spec_with_http_scheme() {
-        let config = parse_proxy_spec("http://proxy.example.com:3128").unwrap();
-        assert_eq!(config.host, "proxy.example.com");
-        assert_eq!(config.port, 3128);
-    }
-
-    #[test]
-    fn parse_proxy_spec_with_https_scheme() {
-        let config = parse_proxy_spec("https://proxy.example.com:443").unwrap();
-        assert_eq!(config.host, "proxy.example.com");
-        assert_eq!(config.port, 443);
-    }
-
-    #[test]
-    fn parse_proxy_spec_scheme_case_insensitive() {
-        let config = parse_proxy_spec("HTTP://proxy.example.com:8080").unwrap();
-        assert_eq!(config.host, "proxy.example.com");
-
-        let config = parse_proxy_spec("HTTPS://proxy.example.com:8080").unwrap();
-        assert_eq!(config.host, "proxy.example.com");
+    fn parse_proxy_spec_has_no_scheme_concept() {
+        let error = parse_proxy_spec("http://proxy.example.com:3128").unwrap_err();
+        assert!(error.message().to_string().contains("invalid port"));
     }
 
     #[test]
@@ -443,19 +342,15 @@ mod tests {
         assert!(config.credentials.is_some());
     }
 
+    // upstream never trims the getenv() value: `proxied = h != NULL && *h !=
+    // '\0';` treats any non-empty string (including one that is all
+    // whitespace) as set, then feeds it straight into the buffer splitter.
+    // Leading/trailing whitespace becomes literal host/port text, which
+    // fails to parse as a port rather than being silently stripped.
     #[test]
-    fn parse_proxy_spec_with_scheme_and_credentials() {
-        let config = parse_proxy_spec("http://user:pass@proxy.example.com:8080").unwrap();
-        assert_eq!(config.host, "proxy.example.com");
-        assert_eq!(config.port, 8080);
-        assert!(config.credentials.is_some());
-    }
-
-    #[test]
-    fn parse_proxy_spec_with_whitespace_trimmed() {
-        let config = parse_proxy_spec("  proxy.example.com:8080  ").unwrap();
-        assert_eq!(config.host, "proxy.example.com");
-        assert_eq!(config.port, 8080);
+    fn parse_proxy_spec_leading_trailing_whitespace_is_literal_not_trimmed() {
+        let error = parse_proxy_spec("  proxy.example.com:8080  ").unwrap_err();
+        assert!(error.message().to_string().contains("invalid port"));
     }
 
     #[test]
@@ -464,26 +359,22 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // upstream: socket.c:202-203 - a whitespace-only value is non-empty, so
+    // it is "proxied" and fed to the parser (where it then fails to find a
+    // ':' and errors), unlike an actually-empty value which upstream treats
+    // as "no proxy configured" before ever reaching this parser.
     #[test]
     fn parse_proxy_spec_whitespace_only_returns_error() {
         let result = parse_proxy_spec("   ");
         assert!(result.is_err());
     }
 
+    // A "/path" suffix is not a recognised construct in upstream's parser;
+    // it is just more raw text that ends up in the port field and fails
+    // u16 parsing (upstream would similarly fail later at getaddrinfo()
+    // when handed a bogus "port/path" service string).
     #[test]
-    fn parse_proxy_spec_invalid_scheme_returns_error() {
-        let result = parse_proxy_spec("socks://proxy.example.com:1080");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_proxy_spec_scheme_only_returns_error() {
-        let result = parse_proxy_spec("http://");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_proxy_spec_with_path_returns_error() {
+    fn parse_proxy_spec_with_path_suffix_fails_port_parse() {
         let result = parse_proxy_spec("proxy.example.com:8080/path");
         assert!(result.is_err());
     }
@@ -500,11 +391,14 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // upstream never percent-decodes RSYNC_PROXY components (that grammar
+    // belongs only to rsync:// URLs); a literal "%40" stays literal.
     #[test]
-    fn parse_proxy_spec_percent_encoded_credentials() {
-        let config = parse_proxy_spec("user%40domain:p%40ss@proxy.example.com:8080").unwrap();
-        assert_eq!(config.host, "proxy.example.com");
-        assert!(config.credentials.is_some());
+    fn parse_proxy_spec_does_not_percent_decode_credentials() {
+        let config = parse_proxy_spec("user%40domain:pass@proxy.example.com:8080").unwrap();
+        let creds = config.credentials.expect("credentials present");
+        let decoded = STANDARD.decode(creds.authorization_value()).unwrap();
+        assert_eq!(decoded, b"user%40domain:pass");
     }
 
     #[test]
@@ -514,18 +408,14 @@ mod tests {
         assert_eq!(config.port, 8080);
     }
 
+    // upstream's HOST:PORT split uses strchr() (the FIRST ':'), so a
+    // bracketed IPv6 literal is not recognised: the first ':' lands inside
+    // the brackets, producing a non-numeric "port" and an error. oc must
+    // not accept a syntax upstream cannot parse.
     #[test]
-    fn parse_proxy_spec_ipv6_bracketed() {
-        let config = parse_proxy_spec("[::1]:8080").unwrap();
-        assert_eq!(config.host, "::1");
-        assert_eq!(config.port, 8080);
-    }
-
-    #[test]
-    fn parse_proxy_spec_ipv6_bracketed_full() {
-        let config = parse_proxy_spec("[2001:db8::1]:3128").unwrap();
-        assert_eq!(config.host, "2001:db8::1");
-        assert_eq!(config.port, 3128);
+    fn parse_proxy_spec_does_not_support_bracketed_ipv6() {
+        let result = parse_proxy_spec("[::1]:8080");
+        assert!(result.is_err());
     }
 
     #[test]
@@ -565,73 +455,22 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // upstream's strchr(h, ':') finds the FIRST colon; a host string that
+    // itself contains a colon (as an unbracketed IPv6 literal would) splits
+    // in the wrong place and fails the numeric port check.
     #[test]
-    fn parse_proxy_host_port_ipv6_bracketed() {
-        let (host, port) = parse_proxy_host_port("[::1]:8080").unwrap();
-        assert_eq!(host, "::1");
-        assert_eq!(port, 8080);
-    }
-
-    #[test]
-    fn parse_proxy_host_port_ipv6_no_port_returns_error() {
-        let result = parse_proxy_host_port("[::1]");
+    fn parse_proxy_host_port_first_colon_wins_over_embedded_colon() {
+        let result = parse_proxy_host_port("::1:8080");
         assert!(result.is_err());
     }
 
+    // oc does not percent-decode the host component; a literal "%20"
+    // becomes literal host text (which then fails DNS/getaddrinfo like any
+    // other invalid hostname), matching upstream exactly.
     #[test]
-    fn parse_proxy_host_port_percent_encoded_host() {
+    fn parse_proxy_host_port_does_not_percent_decode_host() {
         let (host, _port) = parse_proxy_host_port("my%20host:8080").unwrap();
-        assert_eq!(host, "my host");
-    }
-
-    #[test]
-    fn decode_proxy_component_plain_text() {
-        let result = decode_proxy_component("username", "test").unwrap();
-        assert_eq!(result, "username");
-    }
-
-    #[test]
-    fn decode_proxy_component_percent_encoded() {
-        let result = decode_proxy_component("user%40domain", "test").unwrap();
-        assert_eq!(result, "user@domain");
-    }
-
-    #[test]
-    fn decode_proxy_component_multiple_encoded() {
-        let result = decode_proxy_component("a%20b%20c", "test").unwrap();
-        assert_eq!(result, "a b c");
-    }
-
-    #[test]
-    fn decode_proxy_component_hex_case_insensitive() {
-        let result1 = decode_proxy_component("a%2Fb", "test").unwrap();
-        let result2 = decode_proxy_component("a%2fb", "test").unwrap();
-        assert_eq!(result1, "a/b");
-        assert_eq!(result2, "a/b");
-    }
-
-    #[test]
-    fn decode_proxy_component_truncated_encoding_returns_error() {
-        let result = decode_proxy_component("user%4", "field");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn decode_proxy_component_invalid_hex_returns_error() {
-        let result = decode_proxy_component("user%ZZ", "field");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn decode_proxy_component_trailing_percent_returns_error() {
-        let result = decode_proxy_component("test%", "field");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn decode_proxy_component_invalid_utf8_returns_error() {
-        let result = decode_proxy_component("%FF%FE", "field");
-        assert!(result.is_err());
+        assert_eq!(host, "my%20host");
     }
 
     #[test]

--- a/crates/core/src/client/tests/module_list_proxy.rs
+++ b/crates/core/src/client/tests/module_list_proxy.rs
@@ -79,34 +79,33 @@ fn run_module_list_reports_invalid_proxy_configuration() {
         error
             .message()
             .to_string()
-            .contains("RSYNC_PROXY must be in HOST:PORT form")
+            .contains("invalid proxy specification: should be HOST:PORT")
     );
 }
 
+// upstream: socket.c:205-234 - RSYNC_PROXY has no URL-scheme concept; oc must
+// not invent one. A "scheme://" prefix is just more raw text to upstream's
+// buffer splitter, and with credentials present the "://" after the scheme
+// name is consumed as part of a bogus password rather than rejected.
 #[test]
-fn parse_proxy_spec_accepts_http_scheme() {
+fn parse_proxy_spec_has_no_scheme_concept() {
     let proxy =
-        parse_proxy_spec("http://user:secret@proxy.example:8080").expect("http proxy parses");
+        parse_proxy_spec("http://user:secret@proxy.example:8080").expect("proxy parses");
     assert_eq!(proxy.host, "proxy.example");
     assert_eq!(proxy.port, 8080);
-    assert_eq!(proxy.authorization_header(), Some("dXNlcjpzZWNyZXQ="));
-}
-
-#[test]
-fn parse_proxy_spec_decodes_percent_encoded_credentials() {
-    let proxy = parse_proxy_spec("http://user%3Aname:p%40ss%25word@proxy.example:1080")
-        .expect("percent-encoded proxy parses");
-    assert_eq!(proxy.host, "proxy.example");
-    assert_eq!(proxy.port, 1080);
-    assert_eq!(
-        proxy.authorization_header(),
-        Some("dXNlcjpuYW1lOnBAc3Mld29yZA==")
-    );
+    // strrchr('@') finds the only '@'; strchr(':') on "http://user" then
+    // finds the FIRST ':' (right after "http"), so upstream's username is
+    // "http" and its password is "//user" - not "user"/"secret" as a
+    // scheme-aware parser might assume.
+    let decoded = STANDARD
+        .decode(proxy.authorization_header().expect("auth header"))
+        .unwrap();
+    assert_eq!(decoded, b"http://user:secret");
 }
 
 #[test]
 fn parse_proxy_spec_caches_authorization_header() {
-    let proxy = parse_proxy_spec("http://user:secret@proxy.example:1080").expect("proxy parses");
+    let proxy = parse_proxy_spec("user:secret@proxy.example:1080").expect("proxy parses");
     let first = proxy.authorization_header().expect("header value");
     let second = proxy
         .authorization_header()
@@ -114,72 +113,6 @@ fn parse_proxy_spec_caches_authorization_header() {
     assert!(
         std::ptr::eq(first, second),
         "authorization header should reuse cached storage"
-    );
-}
-
-#[test]
-fn parse_proxy_spec_accepts_https_scheme() {
-    let proxy = parse_proxy_spec("https://proxy.example:3128").expect("https proxy parses");
-    assert_eq!(proxy.host, "proxy.example");
-    assert_eq!(proxy.port, 3128);
-    assert!(proxy.authorization_header().is_none());
-}
-
-#[test]
-fn parse_proxy_spec_rejects_unknown_scheme() {
-    let error = match parse_proxy_spec("socks5://proxy:1080") {
-        Ok(_) => panic!("invalid proxy scheme should be rejected"),
-        Err(error) => error,
-    };
-    assert_eq!(error.exit_code(), SOCKET_IO_EXIT_CODE);
-    assert!(
-        error
-            .message()
-            .to_string()
-            .contains("RSYNC_PROXY scheme must be http:// or https://")
-    );
-}
-
-#[test]
-fn parse_proxy_spec_rejects_path_component() {
-    let error = match parse_proxy_spec("http://proxy.example:3128/path") {
-        Ok(_) => panic!("proxy specification with path should be rejected"),
-        Err(error) => error,
-    };
-    assert_eq!(error.exit_code(), SOCKET_IO_EXIT_CODE);
-    assert!(
-        error
-            .message()
-            .to_string()
-            .contains("RSYNC_PROXY must not include a path component")
-    );
-}
-
-#[test]
-fn parse_proxy_spec_rejects_invalid_percent_encoding_in_credentials() {
-    let error = match parse_proxy_spec("user%zz:secret@proxy.example:8080") {
-        Ok(_) => panic!("invalid percent-encoding should be rejected"),
-        Err(error) => error,
-    };
-
-    assert_eq!(error.exit_code(), SOCKET_IO_EXIT_CODE);
-    assert!(
-        error
-            .message()
-            .to_string()
-            .contains("RSYNC_PROXY username contains invalid percent-encoding")
-    );
-
-    let error = match parse_proxy_spec("user:secret%@proxy.example:8080") {
-        Ok(_) => panic!("truncated percent-encoding should be rejected"),
-        Err(error) => error,
-    };
-    assert_eq!(error.exit_code(), SOCKET_IO_EXIT_CODE);
-    assert!(
-        error
-            .message()
-            .to_string()
-            .contains("RSYNC_PROXY password contains truncated percent-encoding")
     );
 }
 


### PR DESCRIPTION
## Summary

- The direct and proxy connect paths resolved multiple addresses but did not mirror upstream's abort-on-contimeout-expiry semantics: upstream's per-address loop (`open_socket_out()`, socket.c:262-310) falls through to the next resolved address on an ordinary connect failure, but a `--contimeout` alarm firing causes an immediate `exit_cleanup(RERR_CONTIMEOUT)` without trying the remaining addresses. oc kept iterating past a timed-out address and gave every remaining candidate a fresh timeout budget; the proxy path additionally never mapped a contimeout expiry to exit code 35 at all. Both paths now share a `try_candidates` helper with upstream's exact semantics.
- The `RSYNC_PROXY` parser accepted a superset of upstream's grammar: `http://`/`https://` scheme prefixes, percent-decoded host/user/pass components, bracketed IPv6 literals, and an explicit path-component rejection - none of which exist in upstream's raw `strrchr`/`strchr` buffer-splitting parser (socket.c:205-234). It also split `HOST:PORT` on the last colon instead of the first, and silently trimmed whitespace that upstream treats literally (a whitespace-only value is "proxied" and fails, not silently ignored). Rewritten to match upstream's parser exactly.

## Test plan

- [x] `cargo fmt -p core -- --check`
- [x] `cargo clippy -p core --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p core --all-features -E 'test(contimeout) or test(proxy) or test(connect) or test(addr) or test(try_candidates)'` (196 passed) on aarch64 Linux host
- [x] New unit tests: `try_candidates` multi-address iteration/abort semantics (`crates/core/src/client/module_list/connect/direct.rs`), proxy grammar accept/reject cases (`crates/core/src/client/module_list/connect/proxy.rs`)
