### PR TITLE
docs: re-line drifted upstream citations to rsync 3.4.4

### DIFF
--- a/crates/bandwidth/src/limiter/change.rs
+++ b/crates/bandwidth/src/limiter/change.rs
@@ -108,7 +108,7 @@ impl FromIterator<LimiterChange> for LimiterChange {
 /// without touching the rate.
 ///
 /// Returns a [`LimiterChange`] describing the transition that occurred.
-// upstream: options.c:2374 - daemon_bwlimit override: strictest rate wins
+// upstream: options.c:2392 - daemon_bwlimit override: strictest rate wins
 pub fn apply_effective_limit(
     limiter: &mut Option<BandwidthLimiter>,
     limit: Option<NonZeroU64>,

--- a/crates/bandwidth/src/limiter/core/limiter.rs
+++ b/crates/bandwidth/src/limiter/core/limiter.rs
@@ -86,7 +86,7 @@ impl BandwidthLimiter {
     /// Recalculates the write-max chunk size for the new rate and resets all
     /// internal accounting (debt, timing, simulated elapsed time). This is
     /// used when a daemon module overrides the client-supplied `--bwlimit`.
-    // upstream: options.c:2374 - daemon_bwlimit override reconfiguration
+    // upstream: options.c:2392 - daemon_bwlimit override reconfiguration
     #[doc(alias = "--bwlimit")]
     pub fn update_configuration(&mut self, limit: NonZeroU64, burst: Option<NonZeroU64>) {
         let write_max = calculate_write_max(limit, burst);
@@ -145,7 +145,7 @@ impl BandwidthLimiter {
     /// The value scales linearly with the configured rate so that pacing
     /// sleeps remain short and responsive. Callers should split writes
     /// larger than this threshold into chunks.
-    // upstream: options.c:2377 - bwlimit_writemax = bwlimit * 128
+    // upstream: options.c:2395 - bwlimit_writemax = bwlimit * 128
     #[inline]
     #[must_use]
     pub const fn write_max_bytes(&self) -> usize {

--- a/crates/bandwidth/src/limiter/core/write_max.rs
+++ b/crates/bandwidth/src/limiter/core/write_max.rs
@@ -2,7 +2,7 @@
 //!
 //! The maximum chunk size scales linearly with the configured rate, keeping
 //! I/O granularity proportional to throughput. This mirrors upstream
-//! `options.c:2377` where `bwlimit_writemax = bwlimit * 128` with a floor
+//! `options.c:2395` where `bwlimit_writemax = bwlimit * 128` with a floor
 //! of 512 bytes so that pacing sleeps remain short and responsive.
 
 use std::num::NonZeroU64;
@@ -14,7 +14,7 @@ use super::super::MIN_WRITE_MAX;
 /// The base write-max scales linearly with KiB of bandwidth, clamped to at
 /// least `MIN_WRITE_MAX`. When a burst override is present it replaces the
 /// calculated value (still respecting the minimum).
-// upstream: options.c:2377-2379 - bwlimit_writemax = bwlimit * 128, min 512
+// upstream: options.c:2395-2397 - bwlimit_writemax = bwlimit * 128, min 512
 pub(super) fn calculate_write_max(limit: NonZeroU64, burst: Option<NonZeroU64>) -> usize {
     let kib = if limit.get() < 1024 {
         1

--- a/crates/bandwidth/src/limiter/mod.rs
+++ b/crates/bandwidth/src/limiter/mod.rs
@@ -44,7 +44,7 @@ pub(super) const MAX_REPRESENTABLE_MICROSECONDS: u128 =
 pub(super) const MAX_SLEEP_DURATION: Duration = Duration::new(i64::MAX as u64, 999_999_999);
 
 /// Floor for the per-write chunk size.
-// upstream: options.c:2378 - `if (bwlimit_writemax < 512) bwlimit_writemax = 512`
+// upstream: options.c:2396 - `if (bwlimit_writemax < 512) bwlimit_writemax = 512`
 pub(super) const MIN_WRITE_MAX: usize = 512;
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/bandwidth/src/limiter/tests/token_bucket_edge_cases.rs
+++ b/crates/bandwidth/src/limiter/tests/token_bucket_edge_cases.rs
@@ -229,7 +229,7 @@ fn burst_handling_u64_max_burst_no_clamping() {
     let mut limiter = BandwidthLimiter::with_burst(nz(1000), Some(nz(u64::MAX)));
 
     // Write 100_000 bytes at 1000 B/s - burst is so large it won't clamp.
-    // upstream: io.c:2025 sleep_for_bwlimit has no burst concept; u64::MAX
+    // upstream: io.c:2100 sleep_for_bwlimit has no burst concept; u64::MAX
     // burst should behave identically (no clamping).
     let sleep = limiter.register(100_000);
 
@@ -238,7 +238,7 @@ fn burst_handling_u64_max_burst_no_clamping() {
     assert_eq!(sleep.requested(), Duration::from_secs(100));
 
     // Debt carries forward after simulated sleep - verify not clamped.
-    // upstream: io.c:2058 - leftover = (sleep_usec - elapsed_usec) * bwlimit / ONE_SEC
+    // upstream: io.c:2133 - leftover = (sleep_usec - elapsed_usec) * bwlimit / ONE_SEC
     // A few real microseconds always elapse during the no-op sleep_for call,
     // causing integer division to lose up to 1 byte of debt. Allow this.
     let debt = limiter.accumulated_debt_for_testing();

--- a/crates/batch/src/format/header.rs
+++ b/crates/batch/src/format/header.rs
@@ -52,23 +52,23 @@ impl BatchHeader {
     ///
     /// Format matches upstream rsync batch file layout:
     /// 1. Stream flags bitmap (i32) - `batch.c:113 write_int(fd, flags)`
-    /// 2. Protocol version (i32) - `io.c:2446 write_int(batch_fd, protocol_version)`
-    /// 3. Compat flags (varint, if protocol >= 30) - `io.c:2448 write_varint(batch_fd, compat_flags)`
-    /// 4. Checksum seed (i32) - `io.c:2449 write_int(batch_fd, checksum_seed)`
+    /// 2. Protocol version (i32) - `io.c:2521 write_int(batch_fd, protocol_version)`
+    /// 3. Compat flags (varint, if protocol >= 30) - `io.c:2523 write_varint(batch_fd, compat_flags)`
+    /// 4. Checksum seed (i32) - `io.c:2524 write_int(batch_fd, checksum_seed)`
     pub fn write_to<W: Write>(&self, writer: &mut W) -> io::Result<()> {
         // upstream: batch.c:113 write_int(fd, flags)
         self.stream_flags
             .write_to_versioned(writer, self.protocol_version)?;
 
-        // upstream: io.c:2446 write_int(batch_fd, protocol_version)
+        // upstream: io.c:2521 write_int(batch_fd, protocol_version)
         write_i32(writer, self.protocol_version)?;
 
-        // upstream: io.c:2447-2448
+        // upstream: io.c:2522-2523
         if let Some(flags) = self.compat_flags {
             write_varint(writer, flags)?;
         }
 
-        // upstream: io.c:2449 write_int(batch_fd, checksum_seed)
+        // upstream: io.c:2524 write_int(batch_fd, checksum_seed)
         write_i32(writer, self.checksum_seed)?;
 
         Ok(())

--- a/crates/batch/src/format/tests.rs
+++ b/crates/batch/src/format/tests.rs
@@ -644,7 +644,7 @@ fn test_batch_header_all_flags_byte_layout() {
 
 /// Verify multi-byte varint compat_flags encoding.
 ///
-/// upstream: io.c:2448 write_varint(batch_fd, compat_flags) - uses the
+/// upstream: io.c:2523 write_varint(batch_fd, compat_flags) - uses the
 /// same varint encoding as io.c:write_varint() where values >= 0x80 use
 /// multiple bytes.
 #[test]

--- a/crates/batch/src/reader/flist.rs
+++ b/crates/batch/src/reader/flist.rs
@@ -120,7 +120,7 @@ impl BatchReader {
             .with_preserve_acls(flags.preserve_acls)
             .with_preserve_xattrs(flags.preserve_xattrs);
 
-        // upstream: flist.c:150 - when always_checksum is set, each regular file
+        // upstream: flist.c:162 - when always_checksum is set, each regular file
         // entry in the flist carries a trailing checksum of flist_csum_len bytes.
         // Without this, the reader would skip those bytes and go out of sync.
         // The checksum length depends on the negotiated algorithm. For batch files
@@ -157,7 +157,7 @@ impl BatchReader {
         // sender reports errors, then breaks the loop without aborting.
         self.io_error = flist_reader.io_error();
 
-        // upstream: flist.c:2726-2728 - recv_id_list(f, flist) when !inc_recurse
+        // upstream: flist.c:2761-2763 - recv_id_list(f, flist) when !inc_recurse
         // The batch stream contains uid/gid name mapping lists after the flist
         // entries. We must consume them to keep the stream position correct for
         // delta replay. Batch files don't record numeric_ids, but if the original
@@ -195,7 +195,7 @@ impl BatchReader {
         // with recv_files() in an event loop.
         if inc_recurse {
             self.ndx_codec = Some(NdxCodecEnum::new(protocol_version.as_u8()));
-            // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
+            // upstream: flist.c:2966 - ndx_start = prev->ndx_start + prev->used + 1
             // The initial flist has ndx_start=1, so the next sub-list starts at
             // 1 + entries.len() + 1 (the +1 gap between segments).
             self.flist_next_ndx_start = 1 + entries.len() as i32 + 1;
@@ -256,7 +256,7 @@ impl BatchReader {
         }
 
         self.io_error |= flist_reader.io_error();
-        // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
+        // upstream: flist.c:2966 - ndx_start = prev->ndx_start + prev->used + 1
         // The current segment started at flist_next_ndx_start (set before
         // reset_for_new_segment). The next segment's ndx_start accounts for
         // the entries in this segment plus the +1 gap.
@@ -269,7 +269,7 @@ impl BatchReader {
 
 /// Returns the default flist checksum length for a batch file.
 ///
-/// Upstream `flist.c:150` computes `flist_csum_len = csum_len_for_type(file_sum_nni->num, 1)`.
+/// Upstream `flist.c:162` computes `flist_csum_len = csum_len_for_type(file_sum_nni->num, 1)`.
 /// Without explicit checksum negotiation (which batch files bypass), the default
 /// file checksum algorithm is MD5 (protocol >= 30) or MD4 (protocol < 30). Both
 /// produce 16-byte digests. Protocol < 27 with `CSUM_MD4_ARCHAIC` uses 2 bytes

--- a/crates/batch/src/reader/tests.rs
+++ b/crates/batch/src/reader/tests.rs
@@ -538,7 +538,7 @@ mod flist_deserialization_tests {
     /// in the flist carries a trailing checksum. If the reader doesn't consume
     /// these bytes, subsequent entries will be deserialized incorrectly.
     ///
-    /// upstream: flist.c:670 writes checksum bytes, flist.c:1202 reads them
+    /// upstream: flist.c:682 writes checksum bytes, flist.c:1230 reads them
     #[test]
     fn protocol_flist_roundtrip_with_always_checksum() {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/batch/src/replay/delta_phase.rs
+++ b/crates/batch/src/replay/delta_phase.rs
@@ -181,9 +181,9 @@ impl CodecState {
 
 /// Build the initial flist-segments table from the batch header.
 ///
-/// upstream: flist.c:2923 - with INC_RECURSE, the first flist has
+/// upstream: flist.c:2958 - with INC_RECURSE, the first flist has
 /// `ndx_start=1`. Subsequent sub-lists have `ndx_start = prev->ndx_start +
-/// prev->used + 1` (flist.c:2931), creating a +1 gap between segments in NDX
+/// prev->used + 1` (flist.c:2966), creating a +1 gap between segments in NDX
 /// space. We track per-segment (ndx_start, entries_offset, count) to map
 /// global NDX values to flat Vec indices, mirroring upstream's
 /// `flist_for_ndx()`.
@@ -245,7 +245,7 @@ fn process_file_ndx(
         return Ok(());
     }
 
-    // upstream: rsync.c:flist_for_ndx() + receiver.c:590 - map global NDX
+    // upstream: rsync.c:flist_for_ndx() + receiver.c:700 - map global NDX
     // to the flat entries Vec index by finding the segment it belongs to.
     let flat_index = match lookup_flat_index(ndx, flist_segments, entries.len())? {
         Some(idx) => idx,
@@ -403,13 +403,13 @@ fn handle_inc_recurse_segment(
 ) -> BatchResult<()> {
     let prev_len = entries.len();
 
-    // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
+    // upstream: flist.c:2966 - ndx_start = prev->ndx_start + prev->used + 1
     let prev_seg = flist_segments.last().expect("at least initial segment");
     let seg_ndx_start = prev_seg.0 + prev_seg.2 as i32 + 1;
 
     reader.read_incremental_flist_segment(entries)?;
 
-    // upstream: flist.c:2736 - sort each sub-list segment after receiving.
+    // upstream: flist.c:2771 - sort each sub-list segment after receiving.
     // INC_RECURSE batches require protocol >= 30, so pre29 is always false.
     sort_file_list(&mut entries[prev_len..], false, false);
 
@@ -443,9 +443,9 @@ fn handle_inc_recurse_segment(
 
 /// Map a global NDX value to a flat entries-Vec index, scanning segments.
 ///
-/// upstream: rsync.c:flist_for_ndx() + receiver.c:590 - each segment has
+/// upstream: rsync.c:flist_for_ndx() + receiver.c:700 - each segment has
 /// `(ndx_start, entries_offset, count)` with +1 gaps between segments
-/// (upstream flist.c:2931).
+/// (upstream flist.c:2966).
 ///
 /// Returns `Ok(Some(index))` for a valid match, `Ok(None)` when the NDX
 /// refers to an INC_RECURSE parent-directory metadata update (which is
@@ -467,7 +467,7 @@ fn lookup_flat_index(
     {
         return Ok(Some(idx));
     }
-    // upstream: receiver.c:590-593 - NDX < first segment's ndx_start refers
+    // upstream: receiver.c:700-705 - NDX < first segment's ndx_start refers
     // to a parent directory entry (INC_RECURSE metadata update). Skip these
     // - directories are already created.
     if ndx < flist_segments.first().map_or(0, |s| s.0) {

--- a/crates/batch/src/replay/dispatch.rs
+++ b/crates/batch/src/replay/dispatch.rs
@@ -105,7 +105,7 @@ pub(super) fn read_iflags_and_skip_meta(
 
 /// Read the 16-byte `sum_head` and return `(block_count, block_length_wire, remainder_wire)`.
 ///
-/// upstream: receiver.c:273 - `read_sum_head()` reads 4 x i32.
+/// upstream: receiver.c:338 - `read_sum_head()` reads 4 x i32.
 /// The `s2length` field is read and discarded - oc-rsync derives the strong
 /// checksum length from the negotiated checksum algorithm, not from the wire.
 pub(super) fn read_sum_head(stream: &mut BufReader<File>) -> BatchResult<(i32, i32, i32)> {
@@ -125,7 +125,7 @@ pub(super) fn read_sum_head(stream: &mut BufReader<File>) -> BatchResult<(i32, i
 
 /// Read the per-file transfer checksum and discard it.
 ///
-/// upstream: receiver.c:408 - `read_buf(f_in, sender_file_sum, xfer_sum_len)`.
+/// upstream: receiver.c:515 - `read_buf(f_in, sender_file_sum, xfer_sum_len)`.
 /// The sender ALWAYS writes `xfer_sum_len` bytes of file checksum after the
 /// delta stream, regardless of `sum_head.s2length`. For protocol 32 the
 /// default xfer checksum is XXH3-128 or MD5 - both 16 bytes. For protocol

--- a/crates/batch/src/replay/mod.rs
+++ b/crates/batch/src/replay/mod.rs
@@ -131,7 +131,7 @@ pub fn replay(
 
     let mut entries = reader.read_protocol_flist()?;
 
-    // upstream: flist.c:2736 - flist_sort_and_clean() after recv_file_list().
+    // upstream: flist.c:2771 - flist_sort_and_clean() after recv_file_list().
     // NDX values from the generator reference sorted positions, not wire order.
     let pre29 = reader.config().protocol_version < 29;
     sort_file_list(&mut entries, false, pre29);
@@ -142,7 +142,7 @@ pub fn replay(
         ..ReplayResult::default()
     };
 
-    // upstream: main.c:778-799 - get_local_name() creates the destination
+    // upstream: main.c:787-808 - get_local_name() creates the destination
     // directory automatically when the transfer involves more than one file or
     // the destination operand ends in a slash. Batch replay reproduces that
     // behaviour so a fresh destination tree can absorb a batch without

--- a/crates/batch/src/tests.rs
+++ b/crates/batch/src/tests.rs
@@ -633,8 +633,8 @@ mod integration {
     /// fix, checksum bytes after each regular file entry are not consumed, causing
     /// subsequent entries to be deserialized incorrectly.
     ///
-    /// upstream: flist.c:670 `write_buf(f, sum, flist_csum_len)` writes the
-    /// checksum, and flist.c:1202 `read_buf(f, bp, flist_csum_len)` reads it.
+    /// upstream: flist.c:682 `write_buf(f, sum, flist_csum_len)` writes the
+    /// checksum, and flist.c:1230 `read_buf(f, bp, flist_csum_len)` reads it.
     #[test]
     fn test_protocol_flist_roundtrip_with_always_checksum() {
         use protocol::flist::{FileEntry, FileListWriter};
@@ -966,13 +966,13 @@ mod integration {
     /// a compressed delta batch with copy tokens (block matches) requires the
     /// decoder to feed matched block data into the inflate dictionary via
     /// see_token(). Without this, inflate fails with "invalid distance too
-    /// far back" (error -3 at token.c:608).
+    /// far back" (error -3 at token.c:665).
     ///
     /// oc-rsync implements proper dictionary sync in batch replay, making it
     /// capable of reading compressed delta batches that upstream itself cannot.
     ///
     /// upstream: token.c:see_deflate_token() - dictionary sync during live transfer
-    /// upstream: token.c:608 - inflate fails without dictionary sync in batch read
+    /// upstream: token.c:665 - inflate fails without dictionary sync in batch read
     #[test]
     fn test_replay_compressed_delta_with_block_matches() {
         use protocol::flist::{FileEntry, FileListWriter};
@@ -1052,7 +1052,7 @@ mod integration {
 
             // Multiple CPRES_ZLIB block matches require see_token() to feed
             // basis bytes into the inflate dictionary; without it, the decoder
-            // fails with "invalid distance too far back" (token.c:608).
+            // fails with "invalid distance too far back" (token.c:665).
             let mut token_buf = Vec::new();
             let mut encoder = CompressedTokenEncoder::default();
             encoder.set_zlibx(false);
@@ -1459,7 +1459,7 @@ mod integration {
     /// This test exercises the exact code path in `replay.rs` where
     /// `decoder.reset()` is called before each file's token reading loop.
     ///
-    /// upstream: token.c:496 - inflateReset per file
+    /// upstream: token.c:589 - inflateReset per file
     /// upstream: token.c:recv_deflated_token() - r_init resets state
     #[test]
     fn test_replay_compressed_multi_file_resets_decoder() {
@@ -1596,11 +1596,11 @@ mod integration {
     /// tokens. The decoder must reset between files AND correctly feed basis
     /// block data via see_token() for each file independently.
     ///
-    /// This exercises the upstream bug scenario (token.c:608 inflate -3) for
+    /// This exercises the upstream bug scenario (token.c:665 inflate -3) for
     /// multiple files in sequence, verifying that oc-rsync handles it correctly.
     ///
     /// upstream: token.c:see_deflate_token() - per-file dictionary sync
-    /// upstream: token.c:608 - inflate error -3 when dictionary sync missing
+    /// upstream: token.c:665 - inflate error -3 when dictionary sync missing
     #[test]
     fn test_replay_compressed_multi_file_with_block_matches() {
         use protocol::flist::{FileEntry, FileListWriter};

--- a/crates/compress/src/algorithm.rs
+++ b/crates/compress/src/algorithm.rs
@@ -150,7 +150,7 @@ impl CompressionAlgorithm {
         match self {
             CompressionAlgorithm::Zlib => clamp_zlib_level(level).map(CompressionLevel::Precise),
             #[cfg(feature = "lz4")]
-            // upstream: token.c:81-87 - lz4 forces min/max/def to 0 and never
+            // upstream: token.c:82-88 - lz4 forces min/max/def to 0 and never
             // disables; oc represents this as the fastest expressible level.
             CompressionAlgorithm::Lz4 => Some(CompressionLevel::Precise(clamped(1))),
             // upstream: token.c:72-79,101-104 - reuse the shared resolver so the
@@ -199,7 +199,7 @@ impl CompressionAlgorithm {
                     raw_level.clamp(zstd_min_level(), ZSTD_MAX_LEVEL)
                 }
             }
-            // upstream: token.c:81-87 - lz4 forces min/max/def to 0.
+            // upstream: token.c:82-88 - lz4 forces min/max/def to 0.
             #[cfg(feature = "lz4")]
             CompressionAlgorithm::Lz4 => 0,
         }

--- a/crates/compress/src/zstd.rs
+++ b/crates/compress/src/zstd.rs
@@ -93,7 +93,7 @@ where
     /// `Some(_)` when the `zstdmt` Cargo feature is disabled returns
     /// `Unsupported` so callers can fall back gracefully.
     ///
-    /// upstream: `token.c:701`, `options.c:89`.
+    /// upstream: `token.c:749`, `options.c:89`.
     pub fn with_sink_workers(
         sink: W,
         level: CompressionLevel,
@@ -257,7 +257,7 @@ pub const fn default_algorithm() -> CompressionAlgorithm {
     CompressionAlgorithm::Zstd
 }
 
-// upstream: token.c:701 - ZSTD_CCtx_setParameter(zstd_cctx, ZSTD_c_nbWorkers, do_compression_threads).
+// upstream: token.c:749 - ZSTD_CCtx_setParameter(zstd_cctx, ZSTD_c_nbWorkers, do_compression_threads).
 fn configure_workers<W: Write>(
     encoder: &mut ZstdEncoder<'static, CountingWriter<W>>,
     workers: Option<NonZeroU8>,

--- a/crates/matching/src/fuzzy/mod.rs
+++ b/crates/matching/src/fuzzy/mod.rs
@@ -44,7 +44,7 @@ pub const FUZZY_LEVEL_1: u8 = 1;
 /// Fuzzy level for `-yy`; searches destination directory plus reference
 /// directories (`--compare-dest`, `--copy-dest`, `--link-dest`).
 ///
-/// upstream: options.c:2120 - when `fuzzy_basis > 1`, the value is set to
+/// upstream: options.c:2083 - when `fuzzy_basis > 1`, the value is set to
 /// `basis_dir_cnt + 1` so the search iterates over the dest dir (index 0)
 /// plus each reference directory.
 pub const FUZZY_LEVEL_2: u8 = 2;

--- a/crates/matching/src/fuzzy/trace.rs
+++ b/crates/matching/src/fuzzy/trace.rs
@@ -5,8 +5,8 @@
 //!
 //! # Upstream Reference
 //!
-//! - `generator.c:1775` - `"fuzzy basis selected for %s: %s"` (level 1).
-//! - `generator.c:847`  - `"fuzzy size/modtime match for %s"` (level 2).
+//! - `generator.c:1789` - `"fuzzy basis selected for %s: %s"` (level 1).
+//! - `generator.c:860`  - `"fuzzy size/modtime match for %s"` (level 2).
 //! - `generator.c:897`  - `"fuzzy distance for %s = %d.%05d"` (level 2).
 
 use logging::debug_log;
@@ -18,7 +18,7 @@ use logging::debug_log;
 /// fuzzy basis selected for path/to/target: path/to/basis
 /// ```
 ///
-/// upstream: generator.c:1775-1778.
+/// upstream: generator.c:1788-1791.
 #[inline]
 pub fn trace_fuzzy_basis_selected(target: &str, basis: &str) {
     debug_log!(Fuzzy, 1, "fuzzy basis selected for {}: {}", target, basis);
@@ -31,7 +31,7 @@ pub fn trace_fuzzy_basis_selected(target: &str, basis: &str) {
 /// fuzzy size/modtime match for path/to/candidate
 /// ```
 ///
-/// upstream: generator.c:847-848.
+/// upstream: generator.c:859-860.
 #[inline]
 pub fn trace_fuzzy_size_mtime_match(candidate: &str) {
     debug_log!(Fuzzy, 2, "fuzzy size/modtime match for {}", candidate);
@@ -94,7 +94,7 @@ mod tests {
 
     /// Pins the level 1 emission to upstream's format byte-for-byte.
     ///
-    /// upstream: generator.c:1775-1778.
+    /// upstream: generator.c:1788-1791.
     #[test]
     fn fuzzy_basis_selected_matches_upstream() {
         setup_fuzzy(1);
@@ -142,7 +142,7 @@ mod tests {
 
     /// Pins the level 2 size/modtime fast-path emission format.
     ///
-    /// upstream: generator.c:847-848.
+    /// upstream: generator.c:859-860.
     #[test]
     fn fuzzy_size_mtime_match_matches_upstream() {
         setup_fuzzy(2);

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -272,7 +272,7 @@ pub fn apply_file_metadata_with_fd_if_changed(
 
 /// Fast check whether all metadata attributes already match the destination.
 ///
-/// Mirrors upstream `generator.c:461 unchanged_attrs()` - a pure in-memory
+/// Mirrors upstream `generator.c:468 unchanged_attrs()` - a pure in-memory
 /// comparison that avoids the function-call overhead of the full
 /// [`apply_metadata_with_cached_stat`] path. Returns `true` when every
 /// preserved attribute (permissions, ownership, timestamps) matches the
@@ -281,9 +281,9 @@ pub fn apply_file_metadata_with_fd_if_changed(
 ///
 /// # Upstream Reference
 ///
-/// - `generator.c:461-502` - `unchanged_attrs()` checks `perms_differ`,
+/// - `generator.c:468-509` - `unchanged_attrs()` checks `perms_differ`,
 ///   `ownership_differs`, `any_time_differs`, `acls_differ`, `xattrs_differ`
-/// - `generator.c:1809-1814` - quick-check match calls `set_file_attrs` only
+/// - `generator.c:1822-1827` - quick-check match calls `set_file_attrs` only
 ///   when `unchanged_attrs` would fail (implicit - upstream always calls
 ///   `set_file_attrs` but its internal guards skip every syscall when nothing
 ///   differs)
@@ -297,13 +297,13 @@ pub fn metadata_unchanged(
     {
         use std::os::unix::fs::MetadataExt;
 
-        // upstream: generator.c:487-488 - perms_differ(file, sxp)
+        // upstream: generator.c:494-495 - perms_differ(file, sxp)
         if options.permissions() && (cached_meta.mode() & 0o7777) != (entry.permissions() & 0o7777)
         {
             return false;
         }
 
-        // upstream: generator.c:489-490 - ownership_differs(file, sxp)
+        // upstream: generator.c:496-497 - ownership_differs(file, sxp)
         if options.owner() {
             if let Some(uid) = entry.uid() {
                 if cached_meta.uid() != uid {
@@ -319,7 +319,7 @@ pub fn metadata_unchanged(
             }
         }
 
-        // upstream: generator.c:485-486 - any_time_differs(sxp, file, fname)
+        // upstream: generator.c:492-493 - any_time_differs(sxp, file, fname)
         // Compare raw seconds + nanoseconds directly instead of constructing
         // FileTime structs on the hot path.
         if options.times()
@@ -446,7 +446,7 @@ pub fn apply_symlink_metadata_with_options(
 ///
 /// - `rsync.c:set_file_attrs()` - skips chmod for symlinks
 /// - `rsync.c:set_times()` - uses `lutimes` when the target is a symlink
-/// - `generator.c:1592` - `set_file_attrs(fname, file, NULL, NULL, 0)` runs
+/// - `generator.c:1604` - `set_file_attrs(fname, file, NULL, NULL, 0)` runs
 ///   after `atomic_create` -> `do_symlink` so the new symlink's mtime matches
 ///   the sender's `F_MOD_NSEC_or_0(file)`.
 pub fn apply_symlink_metadata_from_entry(
@@ -570,7 +570,7 @@ pub fn apply_metadata_with_pre_transfer_stat(
 ///   which timestamps are applied and whether the comparison is exact.
 /// - `rsync.c:585` - `flags |= ATTRS_SKIP_MTIME | ATTRS_SKIP_ATIME | ATTRS_SKIP_CRTIME`
 ///   when `omit_dir_times` or `omit_link_times` is active.
-/// - `generator.c:1814` - Passes `maybe_ATTRS_REPORT | maybe_ATTRS_ACCURATE_TIME`
+/// - `generator.c:1827` - Passes `maybe_ATTRS_REPORT | maybe_ATTRS_ACCURATE_TIME`
 ///   on quick-check match paths.
 pub fn apply_metadata_with_attrs_flags(
     destination: &Path,

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -42,7 +42,7 @@ use std::os::unix::fs::MetadataExt;
 /// When `--keep-dirlinks` is active the user has opted into following
 /// dest-side symlinks-to-dirs, so the sandbox refusal is wrong: fall back to
 /// the path-based `nix` chown (through `AT_FDCWD`) which resolves symlinked
-/// parents like upstream `generator.c:1344`'s `link_stat`.
+/// parents like upstream `generator.c:1356`'s `link_stat`.
 ///
 /// Both branches perform the ownership change through the libc
 /// `chown`/`lchown`/`fchownat` symbol rather than a raw syscall. This is

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -82,14 +82,14 @@ fn cached_umask() -> u32 {
 
 /// Returns the default permission seed for a child created under `parent`.
 ///
-/// Mirrors upstream `generator.c:1337-1339` which calls `default_perms_for_dir(dn)`
+/// Mirrors upstream `generator.c:1349-1351` which calls `default_perms_for_dir(dn)`
 /// when `--perms` is off. The helper folds the parent directory's POSIX default
 /// ACL `user_obj`/`group_obj`/`other_obj` entries into the seed; when there is
 /// no default ACL (or the filesystem does not support POSIX default ACLs) it
 /// returns the umask-derived `ACCESSPERMS & ~orig_umask`.
 ///
 /// upstream: `acls.c:1083-1139` `default_perms_for_dir`
-/// upstream: `generator.c:1337-1340` per-parent `dflt_perms` lookup
+/// upstream: `generator.c:1349-1352` per-parent `dflt_perms` lookup
 #[cfg(unix)]
 fn default_perms_seed(parent: Option<&Path>) -> u32 {
     let umask = cached_umask();
@@ -128,8 +128,8 @@ fn default_perms_seed(parent: Option<&Path>) -> u32 {
 /// umask-derived seed when the parent is unknown or no default ACL is present.
 ///
 /// upstream: rsync.c:449-472 `dest_mode()`
-/// upstream: generator.c:1337-1339 `dflt_perms = default_perms_for_dir(dn)`
-/// upstream: generator.c:2280 `dflt_perms = (ACCESSPERMS & ~orig_umask)`
+/// upstream: generator.c:1349-1351 `dflt_perms = default_perms_for_dir(dn)`
+/// upstream: generator.c:2297 `dflt_perms = (ACCESSPERMS & ~orig_umask)`
 #[cfg(unix)]
 fn compute_dest_mode(
     source_mode: u32,
@@ -609,7 +609,7 @@ pub(super) fn apply_permissions_with_chmod_fd(
 /// parent in our test path is a symlink to a real directory and the chmod must
 /// land on the canonical file. Falls back to `std::fs::set_permissions`, which
 /// resolves symlinks through the OS path walk like upstream
-/// `generator.c:1344`'s `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`.
+/// `generator.c:1356`'s `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`.
 ///
 /// Both branches remain visible to `fakeroot`: `secure_chmod_at` performs the
 /// mode change with the libc `fchmodat(2)` symbol (only the parent-directory
@@ -619,7 +619,7 @@ pub(super) fn apply_permissions_with_chmod_fd(
 /// interposed by fakeroot's LD_PRELOAD wrapper, so no raw-syscall path bypasses
 /// the faked mode here.
 ///
-/// upstream: rsync.c:set_file_attrs() / generator.c:1344 link_stat
+/// upstream: rsync.c:set_file_attrs() / generator.c:1356 link_stat
 #[cfg(unix)]
 fn chmod_path_honoring_keep_dirlinks(
     destination: &Path,
@@ -902,7 +902,7 @@ pub(super) fn apply_permissions_from_entry(
                     )?;
                 }
             } else if entry.file_type().is_dir() {
-                // upstream: generator.c:1465-1466 - even when !preserve_perms
+                // upstream: generator.c:1466-1467 - even when !preserve_perms
                 // the generator runs `file->mode = dest_mode(...)` for
                 // directories, and set_file_attrs() (rsync.c:659-660) chmods
                 // the dir to it. A new dir therefore lands the source mode
@@ -965,7 +965,7 @@ pub(super) fn apply_permissions_from_entry(
                 // symlink swapped into any parent component cannot redirect
                 // the chmod outside the receiver's confinement (testsuite
                 // chdir-symlink-race). Under `--keep-dirlinks` the helper
-                // follows symlinked parents to mirror upstream `generator.c:1344`.
+                // follows symlinked parents to mirror upstream `generator.c:1356`.
                 chmod_path_honoring_keep_dirlinks(
                     destination,
                     mode,
@@ -980,8 +980,8 @@ pub(super) fn apply_permissions_from_entry(
             // upstream: rsync.c:495+518 - `new_mode = file->mode` then
             // `new_mode = tweak_mode(new_mode, daemon_chmod_modes)`. The
             // chmod baseline is the source file's mode (already collapsed
-            // through `dest_mode()` in the generator at generator.c:1455 +
-            // :1535 when `!preserve_perms`), NEVER the destination's
+            // through `dest_mode()` in the generator at generator.c:1467 +
+            // :1547 when `!preserve_perms`), NEVER the destination's
             // tempfile mode. Reading the destination would feed back the
             // `O_TMPFILE` 0o600 default for fresh transfers and produce
             // 0o600 under e.g. `Fo-x` instead of the expected umask
@@ -1026,7 +1026,7 @@ pub(super) fn apply_permissions_from_entry(
             if new_mode != current_mode {
                 // upstream: syscall.c:do_chmod_at() symlink-race-safe variant.
                 // Helper follows symlinked parents under `--keep-dirlinks` to
-                // mirror upstream `generator.c:1344`.
+                // mirror upstream `generator.c:1356`.
                 chmod_path_honoring_keep_dirlinks(destination, new_mode, options, "apply chmod")?;
             }
         } else if options.executability()
@@ -1066,7 +1066,7 @@ pub(super) fn apply_permissions_from_entry(
             if (current_meta.permissions().mode() & 0o7777) != destination_permissions {
                 // upstream: syscall.c:do_chmod_at() symlink-race-safe variant.
                 // Helper follows symlinked parents under `--keep-dirlinks` to
-                // mirror upstream `generator.c:1344`.
+                // mirror upstream `generator.c:1356`.
                 chmod_path_honoring_keep_dirlinks(
                     destination,
                     destination_permissions,

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1718,7 +1718,7 @@ fn apply_permissions_from_entry_refuses_parent_symlink_escape() {
 /// KDL.8: with `--keep-dirlinks` active, a path-based chmod through a
 /// destination whose parent is a symlink-to-a-real-dir must succeed by
 /// resolving the symlink, instead of being refused by the dirfd-anchored
-/// `secure_chmod_at` sandbox. Mirrors upstream `generator.c:1344`'s
+/// `secure_chmod_at` sandbox. Mirrors upstream `generator.c:1356`'s
 /// `link_stat(fname, &sx.st, keep_dirlinks && is_dir)` which follows the
 /// symlinked parent at stat time.
 ///
@@ -1906,7 +1906,7 @@ fn dir_without_perms_over_entry_path_lands_source_mode() {
         .preserve_times(false);
     apply_metadata_from_file_entry(&dir, &entry, &opts).expect("apply dir entry");
 
-    // upstream: generator.c:1465-1466 + rsync.c:659-660 - a new directory
+    // upstream: generator.c:1466-1467 + rsync.c:659-660 - a new directory
     // without -p lands the source mode masked by dflt_perms, so a 0700 source
     // dir stays 0700 rather than the mkdir umask default 0755.
     assert_eq!(

--- a/crates/metadata/src/options/accessors.rs
+++ b/crates/metadata/src/options/accessors.rs
@@ -104,7 +104,7 @@ impl MetadataOptions {
     /// `fast_io::secure_chmod_at`) must bypass that guard, because the user
     /// has explicitly opted into following dest-side symlinks-to-dirs.
     ///
-    /// upstream: generator.c:1344 - `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`.
+    /// upstream: generator.c:1356 - `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`.
     #[must_use]
     pub const fn keep_dirlinks(&self) -> bool {
         self.keep_dirlinks

--- a/crates/metadata/src/options/mod.rs
+++ b/crates/metadata/src/options/mod.rs
@@ -41,7 +41,7 @@ pub struct MetadataOptions {
     /// When true, `--keep-dirlinks` is active: dest-side symlinks pointing to
     /// real directories are followed instead of being replaced.
     ///
-    /// upstream: generator.c:1344 - `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`
+    /// upstream: generator.c:1356 - `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`
     /// resolves symlinked dest dirs at stat time, so subsequent chmod/chown
     /// operations land on the canonical real path. We mirror that by bypassing
     /// the dirfd-anchored sandbox in `secure_chmod_at` when this flag is set:

--- a/crates/metadata/src/options/setters.rs
+++ b/crates/metadata/src/options/setters.rs
@@ -164,7 +164,7 @@ impl MetadataOptions {
     /// default but conflicts with the explicit opt-in to follow dest-side
     /// symlinks-to-dirs that `--keep-dirlinks` represents.
     ///
-    /// upstream: generator.c:1344 - `link_stat` honors `keep_dirlinks` so
+    /// upstream: generator.c:1356 - `link_stat` honors `keep_dirlinks` so
     /// the canonical target path is what subsequent chmod/chown see.
     #[must_use]
     #[doc(alias = "--keep-dirlinks")]

--- a/crates/metadata/src/options/tests.rs
+++ b/crates/metadata/src/options/tests.rs
@@ -128,7 +128,7 @@ fn attrs_flags_upstream_set_file_attrs_scenario() {
 
 #[test]
 fn attrs_flags_upstream_accurate_time_with_report() {
-    // Mirrors upstream generator.c:1814 where quick-check match combines
+    // Mirrors upstream generator.c:1827 where quick-check match combines
     // maybe_ATTRS_REPORT and maybe_ATTRS_ACCURATE_TIME.
     let flags = AttrsFlags::REPORT | AttrsFlags::ACCURATE_TIME;
     assert!(flags.report());

--- a/crates/protocol/src/cmd/trace.rs
+++ b/crates/protocol/src/cmd/trace.rs
@@ -12,11 +12,11 @@
 //!   suffix used by every level-1 CMD emission.
 //! - `pipe.c:54-55` - `print_child_argv("opening connection using:", command)`
 //!   inside `piped_child()` before `fork()`/`execvp()`.
-//! - `clientserver.c:348-349` - `print_child_argv("sending daemon args:", sargs)`
+//! - `clientserver.c:350-351` - `print_child_argv("sending daemon args:", sargs)`
 //!   immediately before writing the argument list to the daemon socket.
 //! - `rsync.c:296-297` - `print_child_argv("protected args:", args + i + 1)`
 //!   inside `send_protected_args()` before the per-arg iconv loop.
-//! - `main.c:620-624` - per-argument enumeration `cmd[%d]=%s ...\n` emitted
+//! - `main.c:629-633` - per-argument enumeration `cmd[%d]=%s ...\n` emitted
 //!   from `do_cmd()` once the final remote argv has been assembled.
 
 use std::ffi::OsStr;
@@ -83,7 +83,7 @@ pub fn trace_opening_connection<S: AsRef<OsStr>>(command: &[S]) {
 
 /// Traces the daemon argument list being sent over the TCP socket (level 1).
 ///
-/// upstream: clientserver.c:348-349 - `print_child_argv("sending daemon args:", sargs)`
+/// upstream: clientserver.c:350-351 - `print_child_argv("sending daemon args:", sargs)`
 /// inside `start_inband_exchange()` right before the per-arg write loop.
 /// `sargs` includes the leading `--server [--sender] -flags . path` argv that
 /// the daemon will hand to its own `parse_arguments()`.
@@ -112,7 +112,7 @@ pub fn trace_protected_args<S: AsRef<OsStr>>(args: &[S]) {
 
 /// Traces the assembled remote argv element-by-element (level 2).
 ///
-/// upstream: main.c:620-624 - inside `do_cmd()` once `args[]` has been
+/// upstream: main.c:629-633 - inside `do_cmd()` once `args[]` has been
 /// finalised:
 ///
 /// ```text
@@ -246,7 +246,7 @@ mod tests {
     }
 
     /// Pins the level 1 `sending daemon args:` emission for the upstream
-    /// `clientserver.c:348-349` site.
+    /// `clientserver.c:350-351` site.
     #[test]
     fn sending_daemon_args_matches_upstream_format() {
         init_cmd(1);
@@ -276,7 +276,7 @@ mod tests {
     }
 
     /// Pins the level 2 `cmd[i]=value` enumeration for the upstream
-    /// `main.c:620-624` site.
+    /// `main.c:629-633` site.
     #[test]
     fn trace_cmd_argv_matches_upstream_enumeration() {
         init_cmd(2);

--- a/crates/protocol/src/files_from.rs
+++ b/crates/protocol/src/files_from.rs
@@ -155,7 +155,7 @@ fn write_filesfrom_entry<W: Write>(
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:2262` - `read_line(filesfrom_fd, fbuf, sizeof fbuf, rl_flags)`
+/// - `flist.c:2297` - `read_line(filesfrom_fd, fbuf, sizeof fbuf, rl_flags)`
 ///   with `RL_EOL_NULLS` set when `reading_remotely`
 /// - `io.c:read_line()` (RL_CONVERT branch) - `iconvbufs(ic_recv, ...)`
 /// - `compat.c:799-806` - `filesfrom_convert` gating predicate

--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -521,7 +521,7 @@ mod tests {
     #[test]
     fn dedup_with_parallel_keeps_directory_over_file() {
         // WHY: a dir must win over a same-named file "because it might have
-        // contents in the list" (flist.c:3060); its base must travel with it.
+        // contents in the list" (flist.c:3065); its base must travel with it.
         let mut list = DualFileList::new();
         list.push(FileEntry::new_file("item".into(), 0, 0o644));
         list.push(FileEntry::new_directory("item".into(), 0o755));

--- a/crates/protocol/src/flist/entry/tests.rs
+++ b/crates/protocol/src/flist/entry/tests.rs
@@ -1453,7 +1453,7 @@ fn extras_presence_bitfield_independence() {
 
 #[test]
 fn set_mode_overrides_constructor_mode() {
-    // upstream: flist.c:2257 - delete-missing-args sets file->mode = 0
+    // upstream: flist.c:2442 - delete-missing-args sets file->mode = 0
     let mut entry = FileEntry::new_file("sentinel.txt".into(), 0, 0o644);
     assert_eq!(entry.mode(), 0o100644); // S_IFREG | 0644
     entry.set_mode(0);

--- a/crates/protocol/src/flist/name_cmp.rs
+++ b/crates/protocol/src/flist/name_cmp.rs
@@ -1,14 +1,14 @@
 //! Foundational byte-wise name comparison for file list entries.
 //!
 //! Ports the upstream `f_name_cmp()` function from `flist.c` (upstream:
-//! flist.c:3217). The comparison is performed in two stages, matching
+//! flist.c:3252). The comparison is performed in two stages, matching
 //! upstream's split between `dirname` and `basename`:
 //!
 //! 1. Compare the parent directory bytes (`dirname`).
 //! 2. If equal, compare the leaf name bytes (`basename`).
 //!
 //! The comparison is a plain unsigned byte compare via `strcmp` in upstream
-//! (`flist.c:3331` - `(int)*c1++ - (int)*c2++`), so bytes with the high bit
+//! (`flist.c:3366` - `(int)*c1++ - (int)*c2++`), so bytes with the high bit
 //! set sort after ASCII. There is no locale awareness and no case folding.
 //!
 //! This module intentionally implements the simple, foundational comparator
@@ -19,11 +19,11 @@
 //!
 //! # Upstream Reference
 //!
-//! - `flist.c:3197` `enum fnc_state { s_DIR, s_SLASH, s_BASE, s_TRAILING }`
-//! - `flist.c:3198` `enum fnc_type { t_PATH, t_ITEM }`
-//! - `flist.c:3217-3334` `int f_name_cmp(const struct file_struct *f1,
+//! - `flist.c:3232` `enum fnc_state { s_DIR, s_SLASH, s_BASE, s_TRAILING }`
+//! - `flist.c:3233` `enum fnc_type { t_PATH, t_ITEM }`
+//! - `flist.c:3252-3369` `int f_name_cmp(const struct file_struct *f1,
 //!   const struct file_struct *f2)`
-//! - `flist.c:3331` `(int)*c1++ - (int)*c2++` - the byte-wise compare
+//! - `flist.c:3366` `(int)*c1++ - (int)*c2++` - the byte-wise compare
 //!   operates on `uchar`, so high bytes sort as unsigned.
 
 use std::cmp::Ordering;
@@ -36,7 +36,7 @@ use super::wire_path::path_bytes_to_wire;
 ///
 /// This is the foundational sort key for the parallel-deterministic-delete
 /// pipeline. It ports upstream rsync's `f_name_cmp()` (upstream:
-/// flist.c:3217) in its simplest form: dirname first, then basename, with
+/// flist.c:3252) in its simplest form: dirname first, then basename, with
 /// every byte compared as `unsigned char`. No locale awareness, no case
 /// folding, no protocol-29 directory-vs-file disambiguation.
 ///
@@ -82,7 +82,7 @@ pub fn f_name_cmp(a: &FileEntry, b: &FileEntry) -> Ordering {
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:3206-3211` documents the trailing-slash equivalence for
+/// - `flist.c:3241-3246` documents the trailing-slash equivalence for
 ///   directory entries at protocol 29+.
 #[must_use]
 pub fn name_cmp_eq(a: &FileEntry, b: &FileEntry) -> bool {
@@ -187,7 +187,7 @@ mod tests {
         use std::os::unix::ffi::OsStrExt;
         // "a<0xC3><0xA9>b" vs "a<0xC2>b" - 0xC3 > 0xC2 as unsigned, so the
         // first sorts after the second. This is upstream's behaviour because
-        // it casts to uchar before subtracting (upstream: flist.c:3331).
+        // it casts to uchar before subtracting (upstream: flist.c:3366).
         let a = FileEntry::new_file(PathBuf::from(OsStr::from_bytes(b"a\xC3\xA9b")), 0, 0o644);
         let b = FileEntry::new_file(PathBuf::from(OsStr::from_bytes(b"a\xC2b")), 0, 0o644);
         assert_eq!(f_name_cmp(&a, &b), Ordering::Greater);
@@ -233,7 +233,7 @@ mod tests {
         // explicit: a basename "subdir" and "subdir/" compare equal under
         // name_cmp_eq. This mirrors upstream's protocol-29 implicit
         // trailing-`/` rule for directory entries (upstream:
-        // flist.c:3206-3211).
+        // flist.c:3241-3246).
         assert_eq!(strip_trailing_slash(b"subdir/"), b"subdir");
         assert_eq!(strip_trailing_slash(b"subdir"), b"subdir");
         assert_eq!(strip_trailing_slash(b""), b"");

--- a/crates/protocol/src/flist/read/extras.rs
+++ b/crates/protocol/src/flist/read/extras.rs
@@ -21,7 +21,7 @@ impl FileListReader {
     ///
     /// Wire format: varint30(len) + raw bytes
     ///
-    /// upstream: flist.c:recv_file_entry() lines 920-935
+    /// upstream: flist.c:recv_file_entry() lines 948-963
     ///
     /// `name` is the entry's already-read wire filename, used only to render the
     /// `cannot convert symlink data for` diagnostic on a strict conversion
@@ -107,7 +107,7 @@ impl FileListReader {
     /// - Major: varint30 (omitted if XMIT_SAME_RDEV_MAJOR set)
     /// - Minor: varint (protocol 30+) or byte/int (protocol 28-29)
     ///
-    /// upstream: flist.c:recv_file_entry() lines 936-970
+    /// upstream: flist.c:recv_file_entry() lines 932-953
     pub(super) fn read_rdev<R: Read + ?Sized>(
         &mut self,
         reader: &mut R,
@@ -165,7 +165,7 @@ impl FileListReader {
     /// - If XMIT_HLINKED is set but not XMIT_HLINK_FIRST: read varint index
     /// - If XMIT_HLINK_FIRST is also set: return u32::MAX (this is the first/leader)
     ///
-    /// upstream: flist.c:recv_file_entry() lines 800-815
+    /// upstream: flist.c:recv_file_entry() lines 791-799
     pub(super) fn read_hardlink_idx<R: Read + ?Sized>(
         &self,
         reader: &mut R,
@@ -226,7 +226,7 @@ impl FileListReader {
             self.state.prev_hardlink_dev()
         } else {
             let raw_dev = crate::read_longint(reader)?;
-            // Upstream stores dev + 1, so subtract 1. upstream: flist.c:1177
+            // Upstream stores dev + 1, so subtract 1. upstream: flist.c:668
             // `dev = read_longint(f)` then the +1 offset is undone with plain
             // int64 arithmetic that wraps; a malicious sender can supply
             // raw_dev == i64::MIN, so wrapping_sub matches upstream's wrap and
@@ -245,7 +245,7 @@ impl FileListReader {
     ///
     /// Wire format: raw bytes of length flist_csum_len
     ///
-    /// upstream: flist.c:recv_file_entry() lines 1010-1030
+    /// upstream: flist.c:recv_file_entry() lines 1219-1231
     pub(super) fn read_checksum<R: Read + ?Sized>(
         &self,
         reader: &mut R,
@@ -315,7 +315,7 @@ mod edg_panic_tests {
 
     /// A malicious sender must not crash the protocol 28-29 hardlink decode by
     /// sending dev == i64::MIN, which would underflow the `raw_dev - 1` offset
-    /// (upstream: flist.c:1177) and panic under overflow-checks (cargo-fuzz /
+    /// (upstream: flist.c:668) and panic under overflow-checks (cargo-fuzz /
     /// debug). The hardened decode mirrors upstream's int64 wraparound and must
     /// return cleanly instead of panicking.
     #[test]

--- a/crates/protocol/src/flist/read/flags.rs
+++ b/crates/protocol/src/flist/read/flags.rs
@@ -52,7 +52,7 @@ impl FileListReader {
     /// `FlagsResult::IoError` for I/O error markers, or
     /// `FlagsResult::Flags` for valid entry flags.
     ///
-    /// upstream: flist.c:recv_file_entry() lines 2625-2670
+    /// upstream: flist.c:recv_file_entry() lines 2660-2705
     pub(super) fn read_flags<R: Read + ?Sized>(&self, reader: &mut R) -> io::Result<FlagsResult> {
         let use_varint = self.use_varint_flags();
 
@@ -90,7 +90,7 @@ impl FileListReader {
             return Ok(FlagsResult::EndOfList);
         }
 
-        // upstream: flist.c:2628 - extended flags only exist in protocol >= 28.
+        // upstream: flist.c:2663 - extended flags only exist in protocol >= 28.
         // In protocol < 28, bit 2 is XMIT_SAME_RDEV_pre28, not XMIT_EXTENDED_FLAGS.
         let (ext_byte, ext16_byte) = if use_varint {
             (

--- a/crates/protocol/src/flist/read/metadata.rs
+++ b/crates/protocol/src/flist/read/metadata.rs
@@ -5,7 +5,7 @@
 //!
 //! # Upstream Reference
 //!
-//! See `flist.c:recv_file_entry()` lines 826-920 for the metadata reading logic.
+//! See `flist.c:recv_file_entry()` lines 839-948 for the metadata reading logic.
 
 use std::io::{self, Read};
 
@@ -57,7 +57,7 @@ pub(crate) struct MetadataResult {
 impl FileListReader {
     /// Reads metadata fields in upstream rsync wire format order.
     ///
-    /// Fields are read in this exact order (matching flist.c recv_file_entry lines 826-920):
+    /// Fields are read in this exact order (matching flist.c recv_file_entry lines 839-948):
     ///
     /// | Order | Field | Condition | Encoding |
     /// |-------|-------|-----------|----------|
@@ -76,7 +76,7 @@ impl FileListReader {
         flags: FileFlags,
     ) -> io::Result<MetadataResult> {
         // 1. Read mtime
-        // upstream: flist.c:828-839 - proto >= 30 uses read_varlong(f, 4),
+        // upstream: flist.c:840-851 - proto >= 30 uses read_varlong(f, 4),
         // proto < 30 uses read_uint(f) (fixed 4-byte unsigned)
         let mtime = if flags.same_time() {
             self.state.prev_mtime()
@@ -132,7 +132,7 @@ impl FileListReader {
         // Upstream validates the FINAL resolved mode, whether freshly read or
         // inherited via XMIT_SAME_MODE, so the check lives outside the branch.
         // mode 0 is the sole exception, and only under --delete-missing-args
-        // (missing_args == 2), the mode-0 sentinel for a vanished arg (flist.c:2257).
+        // (missing_args == 2), the mode-0 sentinel for a vanished arg (flist.c:2442).
         if !(mode == 0 && self.delete_missing_args)
             && crate::flist::FileType::from_mode(mode).is_none()
         {
@@ -164,7 +164,7 @@ impl FileListReader {
         };
 
         // 6. Read UID and optional user name
-        // upstream: flist.c:880-890 - XMIT_USER_NAME_FOLLOWS only exists in
+        // upstream: flist.c:908-918 - XMIT_USER_NAME_FOLLOWS only exists in
         // protocol >= 30. In protocol 28-29 that bit position is
         // XMIT_SAME_DEV_pre30, so we must not interpret it as name_follows.
         let uid_name_follows = self.protocol.as_u8() >= 30 && flags.user_name_follows();
@@ -183,7 +183,7 @@ impl FileListReader {
         };
 
         // 7. Read GID and optional group name
-        // upstream: flist.c:891-902 - XMIT_GROUP_NAME_FOLLOWS only exists in
+        // upstream: flist.c:919-930 - XMIT_GROUP_NAME_FOLLOWS only exists in
         // protocol >= 30. In protocol 28-29 that bit position is
         // XMIT_RDEV_MINOR_8_pre30.
         let gid_name_follows = self.protocol.as_u8() >= 30 && flags.group_name_follows();
@@ -253,7 +253,7 @@ impl FileListReader {
 /// value unchanged. Otherwise reads the ID using fixed or varint encoding,
 /// and optionally reads a name string if `name_follows` is set.
 ///
-/// upstream: flist.c:recv_file_entry() lines 880-910 - uid/gid reading
+/// upstream: flist.c:recv_file_entry() lines 908-938 - uid/gid reading
 fn read_owner_id<R: Read + ?Sized>(
     reader: &mut R,
     same: bool,

--- a/crates/protocol/src/flist/read/mod.rs
+++ b/crates/protocol/src/flist/read/mod.rs
@@ -122,14 +122,14 @@ pub struct FileListReader {
     ///
     /// Controls pathname validation: when false, absolute paths (leading `/`)
     /// are rejected. When true, leading slashes are stripped instead.
-    /// upstream: flist.c:757 `!relative_paths && *thisname == '/'`
+    /// upstream: flist.c:769 `!relative_paths && *thisname == '/'`
     relative_paths: bool,
     /// Wire NDX start of the current flist segment.
     ///
     /// Used to distinguish abbreviated vs unabbreviated hardlink followers.
     /// Abbreviated followers (leader in same segment, idx >= ndx_start) have
     /// metadata skipped on wire. Unabbreviated followers carry full metadata.
-    /// upstream: flist.c:recv_file_entry() line 793
+    /// upstream: flist.c:recv_file_entry() line 805
     ndx_start: i32,
     /// Interner for deduplicating parent directory paths across file entries.
     ///
@@ -402,7 +402,7 @@ impl FileListReader {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:757`: `!relative_paths && *thisname == '/'`
+    /// - `flist.c:769`: `!relative_paths && *thisname == '/'`
     #[inline]
     #[must_use]
     pub const fn with_relative_paths(mut self, relative: bool) -> Self {
@@ -480,7 +480,7 @@ impl FileListReader {
     ///
     /// Unabbreviated followers (leader in a previous flist segment) carry full
     /// metadata on the wire and must NOT skip reading it.
-    /// upstream: flist.c:recv_file_entry() line 793
+    /// upstream: flist.c:recv_file_entry() line 805
     #[inline]
     pub(crate) fn is_abbreviated_follower(
         &self,
@@ -539,7 +539,7 @@ impl FileListReader {
     ///
     /// # Upstream Reference
     ///
-    /// `flist.c:recv_file_entry()` lines 793-822 - receiver copies metadata
+    /// `flist.c:recv_file_entry()` lines 805-834 - receiver copies metadata
     /// from leader and updates static compression variables.
     pub fn read_entry_with_flist<R: Read + ?Sized>(
         &mut self,
@@ -559,7 +559,7 @@ impl FileListReader {
 
         let name = self.read_name(reader, flags)?;
 
-        // upstream: flist.c:1873 - sender rejects empty names; we enforce the
+        // upstream: flist.c:1909 - sender rejects empty names; we enforce the
         // same invariant as defense-in-depth against a malicious sender.
         if name.is_empty() {
             return Err(io::Error::new(
@@ -574,10 +574,10 @@ impl FileListReader {
 
         // Abbreviated followers (leader in same flist segment) have metadata
         // copied from the leader; unabbreviated followers carry full metadata.
-        // upstream: flist.c:recv_file_entry() lines 793-822
+        // upstream: flist.c:recv_file_entry() lines 805-834
         let (size, metadata, link_target, rdev, hardlink_dev_ino, checksum) =
             if self.is_abbreviated_follower(flags, hardlink_idx) {
-                // upstream: flist.c:794 - look up leader in the current segment
+                // upstream: flist.c:806 - look up leader in the current segment
                 // and copy its metadata. The sender's static compression variables
                 // (mode, modtime, uid, gid, atime) were already updated from the
                 // leader's data before `goto the_end`, so the receiver must mirror
@@ -610,7 +610,7 @@ impl FileListReader {
                     )));
                 };
 
-                // upstream: flist.c:795-810 - copy fields from leader
+                // upstream: flist.c:807-822 - copy fields from leader
                 let leader_mode = leader.mode();
                 let leader_mtime = leader.mtime();
                 let leader_uid = leader.uid();
@@ -619,7 +619,7 @@ impl FileListReader {
 
                 // Update compression state to match sender's statics
                 // upstream: sender updates mode/modtime/uid/gid/atime at
-                // flist.c:430-493 BEFORE goto the_end
+                // flist.c:442-505 BEFORE goto the_end
                 self.state.update_mode(leader_mode);
                 self.state.update_mtime(leader_mtime);
                 if let Some(uid) = leader_uid {
@@ -682,7 +682,7 @@ impl FileListReader {
         // sender intended (mirrors upstream's `lastname` semantics).
         let converted_name = self.apply_encoding_conversion(name)?;
 
-        // upstream: flist.c:756-760 - clean_fname(CFN_REFUSE_DOT_DOT_DIRS)
+        // upstream: flist.c:768-772 - clean_fname(CFN_REFUSE_DOT_DOT_DIRS)
         // then reject leading '/' when !relative_paths.
         // In --relative mode, leading slashes are stripped instead.
         let cleaned_name = self.clean_and_validate_name(converted_name)?;
@@ -747,7 +747,7 @@ impl FileListReader {
         }
 
         // Read ACLs from the wire (after checksum, before xattrs).
-        // upstream: flist.c:1205-1207 - ACLs are read for all non-symlink entries,
+        // upstream: flist.c:1233-1235 - ACLs are read for all non-symlink entries,
         // including abbreviated hardlink followers. Symlinks never carry ACLs.
         if self.preserve_acls && !entry.is_symlink() {
             let (access_ndx, def_ndx) =
@@ -759,7 +759,7 @@ impl FileListReader {
         }
 
         // Read xattr index/data from wire (after ACLs).
-        // upstream: flist.c:1209-1212 - receive_xattr() is called after
+        // upstream: flist.c:1237-1240 - receive_xattr() is called after
         // receive_acl() and runs for ALL entries including hardlink followers.
         if self.preserve_xattrs {
             let xattr_ndx =

--- a/crates/protocol/src/flist/read/name.rs
+++ b/crates/protocol/src/flist/read/name.rs
@@ -8,7 +8,7 @@
 //!
 //! - `flist.c:recv_file_entry()` lines 760-800 for name reading
 //! - `util1.c:943`: `clean_fname()` with `CFN_REFUSE_DOT_DOT_DIRS`
-//! - `flist.c:756-760`: pathname safety check
+//! - `flist.c:768-772`: pathname safety check
 
 use std::io::{self, Read};
 
@@ -53,7 +53,7 @@ impl FileListReader {
             0
         };
 
-        // upstream: flist.c:719-722 - XMIT_LONG_NAME uses read_varint30()
+        // upstream: flist.c:731-734 - XMIT_LONG_NAME uses read_varint30()
         // which dispatches to read_int (4-byte LE) for protocol < 30,
         // read_varint for protocol >= 30
         let suffix_len = if flags.long_name() {
@@ -173,7 +173,7 @@ impl FileListReader {
     /// Cleans and validates a filename received from the sender.
     ///
     /// Mirrors upstream `clean_fname(thisname, CFN_REFUSE_DOT_DOT_DIRS)` followed
-    /// by the leading-slash check at flist.c:756-760. Performs in-place on a byte
+    /// by the leading-slash check at flist.c:768-772. Performs in-place on a byte
     /// buffer to avoid allocations on the common (clean) path.
     ///
     /// Normalization:
@@ -190,7 +190,7 @@ impl FileListReader {
     /// # Upstream Reference
     ///
     /// - `util1.c:943`: `clean_fname()` with `CFN_REFUSE_DOT_DOT_DIRS`
-    /// - `flist.c:756-760`: pathname safety check after `clean_fname`
+    /// - `flist.c:768-772`: pathname safety check after `clean_fname`
     pub(super) fn clean_and_validate_name(&self, name: Vec<u8>) -> io::Result<Vec<u8>> {
         if name.is_empty() {
             return Ok(name);
@@ -216,7 +216,7 @@ impl FileListReader {
         let mut out = Vec::with_capacity(name.len());
         let anchored = name[0] == b'/';
 
-        // upstream: flist.c:757 - reject absolute paths when not --relative
+        // upstream: flist.c:769 - reject absolute paths when not --relative
         if anchored && !self.relative_paths {
             // upstream: flist.c:768 exit_cleanup(RERR_UNSUPPORTED) -> exit 4.
             return Err(io::Error::new(

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -1365,7 +1365,7 @@ fn read_entry_accepts_name_below_maxpathlen() {
 }
 
 // Zero-length filename validation tests
-// upstream: flist.c:1873 - sender rejects empty names. These tests verify
+// upstream: flist.c:1909 - sender rejects empty names. These tests verify
 // that the receiver also rejects zero-length filenames as defense-in-depth.
 
 #[test]
@@ -1734,7 +1734,7 @@ fn abbreviated_hardlink_follower_out_of_range_is_protocol_violation() {
 /// same segment) still decodes cleanly and inherits the leader's metadata,
 /// proving the bounds check in
 /// `abbreviated_hardlink_follower_out_of_range_is_protocol_violation` never
-/// rejects a legitimate follower. upstream: flist.c:795-810.
+/// rejects a legitimate follower. upstream: flist.c:807-822.
 #[test]
 fn abbreviated_hardlink_follower_in_range_decodes() {
     use crate::flist::write::FileListWriter;
@@ -2106,7 +2106,7 @@ mod acl_integration {
     }
 
     /// Combined ACL + xattr reading respects upstream wire order.
-    /// upstream: flist.c:1205-1212 - ACLs before xattrs on wire.
+    /// upstream: flist.c:1233-1240 - ACLs before xattrs on wire.
     #[test]
     fn combined_acl_and_xattr_reading() {
         use crate::flist::write::FileListWriter;
@@ -2912,7 +2912,7 @@ fn update_stats_saturates_on_symlink_target_overflow() {
 // fix (commit d4c4f67, NEWS.md:71). The upstream fix lives in `support/rrsync`;
 // here we pin the equivalent oc-rsync site (`clean_and_validate_name`) so any
 // future refactor that switches to a pair-replace strategy is caught.
-// upstream: util1.c clean_fname leading-slash skip + flist.c:3079 strip_root
+// upstream: util1.c clean_fname leading-slash skip + flist.c:3114 strip_root
 mod leading_slash_parity {
     use super::*;
 

--- a/crates/protocol/src/flist/sort.rs
+++ b/crates/protocol/src/flist/sort.rs
@@ -17,7 +17,7 @@
 //!
 //! At protocol < 29, upstream uses plain lexicographic byte comparison
 //! without file-before-directory distinction or implicit trailing '/'.
-//! upstream: flist.c:3223 - `protocol_version >= 29 ? t_PATH : t_ITEM`
+//! upstream: flist.c:3258 - `protocol_version >= 29 ? t_PATH : t_ITEM`
 
 use std::cmp::Ordering;
 
@@ -80,7 +80,7 @@ impl SortKey {
 /// we precompute the last '/' position via `memrchr` once per call and answer
 /// the query in O(1): `last_slash >= i` means a separator remains.
 /// This matches upstream's approach of avoiding forward scans in `f_name_cmp()`
-/// (upstream: flist.c:3217).
+/// (upstream: flist.c:3252).
 #[must_use]
 pub fn compare_file_entries(a: &FileEntry, b: &FileEntry) -> Ordering {
     let key_a = SortKey::new(0, a);
@@ -96,7 +96,7 @@ pub fn compare_file_entries(a: &FileEntry, b: &FileEntry) -> Ordering {
 /// At protocol < 29, upstream `f_name_cmp()` uses `t_path = t_ITEM`,
 /// meaning directories are NOT treated specially - no implicit trailing
 /// slash, no files-before-dirs. This is a simple lexicographic sort.
-/// upstream: flist.c:3223 - `protocol_version >= 29 ? t_PATH : t_ITEM`
+/// upstream: flist.c:3258 - `protocol_version >= 29 ? t_PATH : t_ITEM`
 fn compare_with_keys_pre29(bytes_a: &[u8], bytes_b: &[u8]) -> Ordering {
     // "." always comes first (even at protocol < 29)
     match (bytes_a == b".", bytes_b == b".") {
@@ -202,7 +202,7 @@ fn compare_with_keys(bytes_a: &[u8], key_a: &SortKey, bytes_b: &[u8], key_b: &So
 ///
 /// - `flist.c:flist_sort_and_clean()` - Called after `send_file_list()`
 ///   and `recv_file_list()` to sort entries.
-/// - `flist.c:2991` - `if (use_qsort) qsort(...); else merge_sort(...);`
+/// - `flist.c:1788` - `if (use_qsort) qsort(...); else merge_sort(...);`
 pub fn sort_file_list(file_list: &mut [FileEntry], use_qsort: bool, protocol_pre29: bool) {
     debug_log!(
         Flist,
@@ -226,7 +226,7 @@ pub fn sort_file_list(file_list: &mut [FileEntry], use_qsort: bool, protocol_pre
 
     if protocol_pre29 {
         // Protocol < 29: plain lexicographic sort, no file-before-dir.
-        // upstream: flist.c:3223 - t_path = t_ITEM at protocol < 29.
+        // upstream: flist.c:3258 - t_path = t_ITEM at protocol < 29.
         let cmp = |a: &SortKey, b: &SortKey| {
             let bytes_a = file_list[a.index as usize].name_bytes();
             let bytes_b = file_list[b.index as usize].name_bytes();
@@ -298,7 +298,7 @@ pub struct CleanResult {
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:3050-3082` - "If one is a dir and the other is not, we want to
+/// - `flist.c:3064-3081` - "If one is a dir and the other is not, we want to
 ///   keep the dir because it might have contents in the list. Otherwise keep
 ///   the first one." When both are dirs, upstream merges the vital flags into
 ///   the survivor (`fp->flags |= file->flags & (FLAG_TOP_DIR|FLAG_CONTENT_DIR)`).
@@ -757,7 +757,7 @@ mod tests {
         // A duplicate directory carrying TOP_DIR must pass that flag to the
         // survivor: TOP_DIR scopes --delete, so dropping it on merge would
         // wrongly make the surviving directory eligible for deletion.
-        // upstream: flist.c:3073 `fp->flags |= file->flags & FLAG_TOP_DIR`.
+        // upstream: flist.c:3075 `fp->flags |= file->flags & FLAG_TOP_DIR`.
         let mut dir1 = make_dir("subdir");
         dir1.set_top_dir(false);
         let mut dir2 = make_dir("subdir");
@@ -1012,7 +1012,7 @@ mod tests {
 
     /// Protocol < 29: directories do NOT sort after files at the same level.
     /// Plain lexicographic byte comparison, no implicit trailing '/'.
-    /// upstream: flist.c:3223 - `t_path = t_ITEM` at protocol < 29.
+    /// upstream: flist.c:3258 - `t_path = t_ITEM` at protocol < 29.
     #[test]
     fn pre29_no_files_before_dirs() {
         let mut entries = vec![make_file("zebra.txt"), make_dir("aardvark")];

--- a/crates/protocol/src/flist/write/encoding.rs
+++ b/crates/protocol/src/flist/write/encoding.rs
@@ -25,7 +25,7 @@ impl FileListWriter {
     /// - Protocol 28+: one or two bytes depending on extended flags
     /// - Protocol < 28: single byte
     ///
-    /// upstream: flist.c:send_file_entry() lines 545-565
+    /// upstream: flist.c:send_file_entry() lines 557-577
     pub(super) fn write_flags<W: Write + ?Sized>(
         &self,
         writer: &mut W,
@@ -34,7 +34,7 @@ impl FileListWriter {
     ) -> io::Result<()> {
         if self.use_varint_flags() {
             // Varint mode: avoid xflags=0 which collides with the end marker.
-            // upstream: flist.c:550 write_varint(f, xflags ? xflags : XMIT_EXTENDED_FLAGS)
+            // upstream: flist.c:562 write_varint(f, xflags ? xflags : XMIT_EXTENDED_FLAGS)
             let flags_to_write = if xflags == 0 {
                 XMIT_EXTENDED_FLAGS as u32
             } else {
@@ -54,7 +54,7 @@ impl FileListWriter {
                 writer.write_all(&[xflags_to_write as u8])?;
             }
         } else {
-            // upstream: flist.c:559-562 - dirs use XMIT_LONG_NAME, non-dirs use XMIT_TOP_DIR
+            // upstream: flist.c:571-574 - dirs use XMIT_LONG_NAME, non-dirs use XMIT_TOP_DIR
             let flags_to_write = if (xflags & 0xFF) == 0 {
                 if is_dir {
                     xflags | XMIT_LONG_NAME as u32
@@ -74,7 +74,7 @@ impl FileListWriter {
     /// Encodes the shared prefix length (if `XMIT_SAME_NAME`) and the name
     /// suffix. Long names (> 255 bytes) use varint length encoding.
     ///
-    /// upstream: flist.c:send_file_entry() lines 566-580
+    /// upstream: flist.c:send_file_entry() lines 578-592
     pub(super) fn write_name<W: Write + ?Sized>(
         &self,
         writer: &mut W,
@@ -100,7 +100,7 @@ impl FileListWriter {
     ///
     /// Wire format: varint30(len) + raw bytes (no null terminator)
     ///
-    /// upstream: flist.c:send_file_entry() lines 660-670
+    /// upstream: flist.c:send_file_entry() lines 650-655
     pub(super) fn write_symlink_target<W: Write + ?Sized>(
         &self,
         writer: &mut W,
@@ -114,7 +114,7 @@ impl FileListWriter {
             // Symlink targets use the same wire-form normalisation as filenames:
             // any platform-native backslash separators are translated to forward
             // slashes before transmission.
-            // upstream: flist.c:send_file_entry() lines 660-670 and util1.c:955-961
+            // upstream: flist.c:send_file_entry() lines 650-655 and util1.c:955-961
             let wire_bytes = path_bytes_to_wire(target.as_path());
             // upstream: flist.c:1642 - the target is transcoded through ic_send
             // ONLY when `sender_symlink_iconv` (iconv active AND CF_SYMLINK_ICONV
@@ -143,7 +143,7 @@ impl FileListWriter {
     /// - Major: varint30 (omitted if XMIT_SAME_RDEV_MAJOR set)
     /// - Minor: varint (protocol 30+) or byte/int (protocol 28-29)
     ///
-    /// upstream: flist.c:send_file_entry() lines 640-660
+    /// upstream: flist.c:send_file_entry() lines 633-648
     pub(super) fn write_rdev<W: Write + ?Sized>(
         &mut self,
         writer: &mut W,
@@ -206,7 +206,7 @@ impl FileListWriter {
     /// - If XMIT_HLINKED is set but not XMIT_HLINK_FIRST: write varint index
     /// - If XMIT_HLINK_FIRST is also set: no index (this is the first/leader)
     ///
-    /// upstream: flist.c:send_file_entry() lines 583-595
+    /// upstream: flist.c:send_file_entry() lines 584-590
     pub(super) fn write_hardlink_idx<W: Write + ?Sized>(
         &self,
         writer: &mut W,
@@ -238,7 +238,7 @@ impl FileListWriter {
     /// - If not XMIT_SAME_DEV_PRE30: write longint(dev + 1)
     /// - Always write longint(ino)
     ///
-    /// upstream: flist.c:send_file_entry() lines 670-690
+    /// upstream: flist.c:send_file_entry() lines 656-671
     pub(super) fn write_hardlink_dev_ino<W: Write + ?Sized>(
         &mut self,
         writer: &mut W,
@@ -278,7 +278,7 @@ impl FileListWriter {
     /// - For regular files: actual checksum from entry
     /// - For non-regular files (proto < 28 only): empty_sum (all zeros)
     ///
-    /// upstream: flist.c:send_file_entry() lines 700-720
+    /// upstream: flist.c:send_file_entry() lines 674-683
     pub(super) fn write_checksum<W: Write + ?Sized>(
         &self,
         writer: &mut W,
@@ -350,7 +350,7 @@ impl FileListWriter {
         if let Some(ref converter) = self.iconv {
             let outcome = converter.local_to_remote_lossy(name);
             if outcome.had_replacements {
-                // upstream: flist.c:1597-1600 - warn about unconvertible filename
+                // upstream: flist.c:1633-1636 - warn about unconvertible filename
                 crate::iconv::trace_conversion_warning(
                     crate::iconv::IconvRole::Server,
                     &String::from_utf8_lossy(name),

--- a/crates/protocol/src/flist/write/tests/hardlink.rs
+++ b/crates/protocol/src/flist/write/tests/hardlink.rs
@@ -153,7 +153,7 @@ fn write_hardlink_follower_skips_metadata() {
 
     // Follower metadata is skipped on the wire; the receiver copies it from the
     // leader in the same segment (upstream flist.c:recv_file_entry lines
-    // 793-822), so size and mtime match the leader rather than being blank.
+    // 805-834), so size and mtime match the leader rather than being blank.
     assert_eq!(entries[1].name(), "link.txt");
     assert_eq!(entries[1].size(), 500);
     assert_eq!(entries[1].mtime(), 1700000000);

--- a/crates/protocol/src/flist/write/xflags.rs
+++ b/crates/protocol/src/flist/write/xflags.rs
@@ -5,7 +5,7 @@
 //!
 //! # Upstream Reference
 //!
-//! See `flist.c:send_file_entry()` lines 475-550 for the xflags calculation.
+//! See `flist.c:send_file_entry()` lines 487-562 for the xflags calculation.
 
 use super::super::entry::FileEntry;
 use super::super::flags::{
@@ -67,7 +67,7 @@ impl FileListWriter {
     ///
     /// # Upstream Reference
     ///
-    /// See `flist.c:send_file_entry()` lines 475-550 for the xflags calculation logic.
+    /// See `flist.c:send_file_entry()` lines 487-562 for the xflags calculation logic.
     pub(super) fn calculate_xflags(
         &self,
         entry: &FileEntry,
@@ -102,7 +102,7 @@ impl FileListWriter {
             xflags |= XMIT_SAME_TIME as u32;
         }
 
-        // upstream: flist.c:463 - set XMIT_SAME_UID when !preserve_uid OR
+        // upstream: flist.c:475 - set XMIT_SAME_UID when !preserve_uid OR
         // (uid matches previous AND not the first entry). The *lastname guard
         // prevents false "same" on the first entry where prev_uid is zero.
         let entry_uid = entry.uid().unwrap_or(0);
@@ -111,7 +111,7 @@ impl FileListWriter {
             xflags |= XMIT_SAME_UID as u32;
         }
 
-        // upstream: flist.c:473 - same pattern as UID
+        // upstream: flist.c:485 - same pattern as UID
         let entry_gid = entry.gid().unwrap_or(0);
         if !self.preserve.gid || (entry_gid == self.state.prev_gid() && not_first_entry) {
             xflags |= XMIT_SAME_GID as u32;
@@ -149,7 +149,7 @@ impl FileListWriter {
         }
 
         if is_special {
-            // upstream: flist.c:450-460 - special files don't need a real rdev.
+            // upstream: flist.c:462-472 - special files don't need a real rdev.
             // Set XMIT_SAME_RDEV_MAJOR unconditionally for efficiency, and
             // also XMIT_RDEV_MINOR_8_PRE30 for protocol 28-29.
             xflags |= (XMIT_SAME_RDEV_MAJOR as u32) << 8;
@@ -194,7 +194,7 @@ impl FileListWriter {
             }
         } else if self.protocol.as_u8() >= 28 {
             if let Some(dev) = entry.hardlink_dev() {
-                // upstream: flist.c:530 - XMIT_HLINKED set for ALL hardlink entries,
+                // upstream: flist.c:542 - XMIT_HLINKED set for ALL hardlink entries,
                 // not just protocol 30+. Protocol 28-29 also sets this flag.
                 xflags |= (XMIT_HLINKED as u32) << 8;
                 if dev == self.state.prev_hardlink_dev() {

--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -643,7 +643,7 @@ fn advertised_list<'a>(names: impl IntoIterator<Item = &'a str>, is_server: bool
 
 /// Writes a vstring (variable-length string) using upstream rsync's format.
 ///
-/// Format (upstream io.c:2222-2240 write_vstring):
+/// Format (upstream io.c:2297-2315 write_vstring):
 /// - For len <= 127: 1 byte = len
 /// - For len > 127: 2 bytes = [(len >> 8) | 0x80, len & 0xFF]
 ///

--- a/crates/protocol/src/varint/tests.rs
+++ b/crates/protocol/src/varint/tests.rs
@@ -475,7 +475,7 @@ fn read_varlong_rejects_min_bytes_too_large() {
 /// must produce a typed InvalidData error from read_varint (not a panic or
 /// silent wrap). The 0xFC..=0xFF byte range maps to extra=5,5,6,6 in
 /// INT_BYTE_EXTRA, all of which exceed MAX_EXTRA_BYTES (4).
-/// upstream: io.c:1809 `if (extra >= (int)sizeof u.b) ... "Overflow in
+/// upstream: io.c:1830 `if (extra >= (int)sizeof u.b) ... "Overflow in
 /// read_varint()"`. PULL-VARINT (#4345) cross-check.
 #[test]
 fn read_varint_overflow_full_extra_range() {

--- a/crates/protocol/src/wire/compressed_token/decoder.rs
+++ b/crates/protocol/src/wire/compressed_token/decoder.rs
@@ -96,7 +96,7 @@ impl CompressedTokenDecoder {
     /// For zstd, only resets token index and buffer state - the decompression
     /// context is preserved across files (one continuous stream).
     ///
-    /// upstream: token.c:807-810 (zstd r_init), token.c:496 (zlib inflateReset)
+    /// upstream: token.c:862-865 (zstd r_init), token.c:589 (zlib inflateReset)
     pub fn reset(&mut self) {
         match &mut self.inner {
             DecoderInner::Zlib(dec) => dec.reset(),

--- a/crates/protocol/src/wire/compressed_token/encoder.rs
+++ b/crates/protocol/src/wire/compressed_token/encoder.rs
@@ -66,7 +66,7 @@ impl CompressedTokenEncoder {
     /// `workers` plumbs `--compress-threads=N` through to zstd's
     /// `ZSTD_c_nbWorkers`. `None` keeps the encoder single-threaded.
     ///
-    /// upstream: token.c:send_zstd_token(), token.c:701
+    /// upstream: token.c:send_zstd_token(), token.c:749
     #[cfg(feature = "zstd")]
     pub fn new_zstd(level: i32, workers: Option<std::num::NonZeroU8>) -> io::Result<Self> {
         Ok(Self {
@@ -91,7 +91,7 @@ impl CompressedTokenEncoder {
     /// For zstd, only resets token run-encoding state - the compression
     /// context is preserved across files (one continuous stream).
     ///
-    /// upstream: token.c:700-703 (zstd), token.c:378 (zlib deflateReset)
+    /// upstream: token.c:756-759 (zstd), token.c:387 (zlib deflateReset)
     pub fn reset(&mut self) {
         match &mut self.inner {
             EncoderInner::Zlib(enc) => enc.reset(),

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -117,7 +117,7 @@ impl ZlibTokenEncoder {
     /// Feeds block data into the compressor's dictionary.
     ///
     /// Only active in CPRES_ZLIB mode (noop for zlibx).
-    /// Reference: upstream token.c lines 463-484.
+    /// Reference: upstream token.c lines 472-508.
     ///
     /// # Overflow handling
     ///

--- a/crates/protocol/src/wire/compressed_token/zstd_codec/decoder.rs
+++ b/crates/protocol/src/wire/compressed_token/zstd_codec/decoder.rs
@@ -22,15 +22,15 @@ use super::super::{CompressedToken, MAX_DATA_COUNT};
 /// context between files - the session is one continuous zstd stream.
 ///
 /// Between files, only the token index (rx_token) resets to 0, matching
-/// upstream token.c:807-810 (r_init state just resets rx_token).
+/// upstream token.c:862-865 (r_init state just resets rx_token).
 ///
 /// The decoder processes one DEFLATED_DATA block at a time, matching
 /// upstream's state machine (r_idle -> r_inflating -> r_idle). When all
 /// compressed input is consumed and the output buffer is not full, the
 /// decoder returns to idle to read the next wire flag.
 ///
-/// upstream: token.c:recv_zstd_token() - DCtx created once (line 789),
-/// never reset between files (line 807-810 only resets rx_token)
+/// upstream: token.c:recv_zstd_token() - DCtx created once (line 844),
+/// never reset between files (line 862-865 only resets rx_token)
 pub(in crate::wire::compressed_token) struct ZstdTokenDecoder {
     /// Shared sans-io decode state machine (framing, run index, output chunking).
     core: TokenDecodeCore,
@@ -45,8 +45,8 @@ pub(in crate::wire::compressed_token) struct ZstdTokenDecoder {
 /// [`TokenDecodeCore`] drives all wire framing and delegates one DEFLATED_DATA
 /// block at a time here.
 ///
-/// upstream: token.c:recv_zstd_token() - DCtx created once (line 789),
-/// never reset between files (line 807-810 only resets rx_token)
+/// upstream: token.c:recv_zstd_token() - DCtx created once (line 844),
+/// never reset between files (line 862-865 only resets rx_token)
 struct ZstdDeflate {
     /// Persistent zstd decompression context.
     decoder: ZstdRawDecoder<'static>,
@@ -74,7 +74,7 @@ impl DeflateSink for ZstdDeflate {
     }
 
     fn decompress_into(&mut self, output: &mut Vec<u8>) -> io::Result<()> {
-        // upstream: token.c lines 846-863 (r_inflating state)
+        // upstream: token.c lines 892-909 (r_inflating state)
         let mut input_pos = 0;
 
         while input_pos < self.compressed_input_buf.len() {
@@ -90,7 +90,7 @@ impl DeflateSink for ZstdDeflate {
                 output.extend_from_slice(&self.output_buf[..produced]);
             }
 
-            // upstream: token.c lines 862-863
+            // upstream: token.c lines 908-909
             // If input is fully consumed and output buffer not full,
             // transition back to idle (read next flag).
             if input_pos >= self.compressed_input_buf.len() && produced < self.output_buf.len() {
@@ -102,7 +102,7 @@ impl DeflateSink for ZstdDeflate {
         // After all compressed input is consumed, the decoder may still
         // hold decompressed data internally when the output buffer was
         // full on the last iteration. Flush by feeding empty input.
-        // upstream: token.c lines 846-863 - inflate loop continues until
+        // upstream: token.c lines 892-909 - inflate loop continues until
         // output buffer is not full, indicating decoder is drained.
         loop {
             let mut in_buf = zstd::stream::raw::InBuffer::around(&[]);
@@ -126,7 +126,7 @@ impl ZstdTokenDecoder {
     /// between files; see the type-level documentation.
     pub(in crate::wire::compressed_token) fn new() -> io::Result<Self> {
         let decoder = ZstdRawDecoder::new()?;
-        // upstream: token.c line 795 - out_buffer_size = ZSTD_DStreamOutSize() * 2
+        // upstream: token.c line 851 - out_buffer_size = ZSTD_DStreamOutSize() * 2
         let out_size = zstd::zstd_safe::DCtx::out_size() * 2;
         Ok(Self {
             core: TokenDecodeCore::new(true),
@@ -149,7 +149,7 @@ impl ZstdTokenDecoder {
     /// context is NOT reinitialized - upstream rsync uses a single continuous
     /// stream across all files in the session.
     ///
-    /// upstream: token.c:807-810 - r_init only resets rx_token to 0
+    /// upstream: token.c:862-865 - r_init only resets rx_token to 0
     pub(in crate::wire::compressed_token) fn reset(&mut self) {
         self.core.reset();
         self.deflate.compressed_input_buf.clear();
@@ -160,7 +160,7 @@ impl ZstdTokenDecoder {
     ///
     /// A thin blocking driver over the shared sans-io decode state machine.
     ///
-    /// upstream: token.c:recv_zstd_token() lines 805-877
+    /// upstream: token.c:recv_zstd_token() lines 861-920
     pub(in crate::wire::compressed_token) fn recv_token<R: Read>(
         &mut self,
         reader: &mut R,

--- a/crates/protocol/src/wire/compressed_token/zstd_codec/encoder.rs
+++ b/crates/protocol/src/wire/compressed_token/zstd_codec/encoder.rs
@@ -4,7 +4,7 @@
 //! single persistent compression context across the entire transfer session,
 //! flushing at each token boundary with `ZSTD_e_flush`.
 //!
-//! - upstream: token.c:send_zstd_token() lines 678-776
+//! - upstream: token.c:send_zstd_token() lines 732-832
 
 use std::io::{self, Write};
 
@@ -84,7 +84,7 @@ impl ZstdTokenEncoder {
     /// `ZSTD_c_nbWorkers`. `None` keeps the encoder single-threaded,
     /// matching upstream's `do_compression_threads = 0` default.
     ///
-    /// upstream: token.c:701 - `ZSTD_CCtx_setParameter(zstd_cctx, ZSTD_c_nbWorkers, do_compression_threads)`
+    /// upstream: token.c:749 - `ZSTD_CCtx_setParameter(zstd_cctx, ZSTD_c_nbWorkers, do_compression_threads)`
     pub(in crate::wire::compressed_token) fn new(
         level: i32,
         workers: Option<std::num::NonZeroU8>,
@@ -239,7 +239,7 @@ impl ZstdTokenEncoder {
     }
 
     /// Noop for zstd - no dictionary synchronization needed.
-    /// upstream: token.c:1102-1104 (see_token for CPRES_ZSTD is empty)
+    /// upstream: token.c:1132-1134 (see_token for CPRES_ZSTD is empty)
     pub(in crate::wire::compressed_token) fn see_token(&mut self, _data: &[u8]) -> io::Result<()> {
         Ok(())
     }
@@ -336,12 +336,12 @@ impl ZstdTokenEncoder {
     /// Writes the accumulated output buffer as a single DEFLATED_DATA block.
     ///
     /// Upstream writes the entire output buffer as one DEFLATED_DATA block
-    /// (token.c lines 756-760), then resets the buffer for the next chunk.
+    /// (token.c lines 813-817), then resets the buffer for the next chunk.
     /// The DEFLATED_DATA header uses 14-bit length encoding, so the maximum
     /// block size is `MAX_DATA_COUNT` (16383 bytes).
     fn write_output_buffer<W: Write>(&mut self, writer: &mut W) -> io::Result<()> {
         debug_assert!(self.output_pos <= MAX_DATA_COUNT);
-        // upstream: token.c lines 758-760
+        // upstream: token.c lines 815-817
         write_deflated_data_header(writer, self.output_pos)?;
         writer.write_all(&self.output_buf[..self.output_pos])?;
         self.output_pos = 0;

--- a/crates/protocol/src/wire/compressed_token/zstd_codec/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/zstd_codec/tests.rs
@@ -256,7 +256,7 @@ fn zstd_consecutive_block_matches_use_run_encoding() {
 /// a single buffer, the entire compressed+flushed output should appear
 /// as a single DEFLATED_DATA block, not multiple smaller blocks.
 ///
-/// upstream: token.c lines 755-763
+/// upstream: token.c lines 812-818
 #[test]
 fn zstd_flush_produces_single_deflated_data_block_for_small_input() {
     let mut encoder = ZstdTokenEncoder::new(3, None).unwrap();
@@ -376,7 +376,7 @@ fn zstd_wire_format_ordering() {
 /// each capped at MAX_DATA_COUNT, matching upstream's buffer-full write
 /// pattern.
 ///
-/// upstream: token.c line 755 - write when zstd_out_buff.pos == zstd_out_buff.size
+/// upstream: token.c line 812 - write when zstd_out_buff.pos == zstd_out_buff.size
 #[test]
 fn zstd_large_literal_splits_into_max_data_count_blocks() {
     let mut encoder = ZstdTokenEncoder::new(1, None).unwrap();
@@ -462,8 +462,8 @@ fn zstd_large_literal_splits_into_max_data_count_blocks() {
 /// The encoder and decoder contexts persist across file boundaries -
 /// only token run-encoding state resets between files.
 ///
-/// upstream: token.c:688 (CCtx created once), token.c:700-703 (only
-/// run state resets), token.c:789 (DCtx created once)
+/// upstream: token.c:740 (CCtx created once), token.c:756-759 (only
+/// run state resets), token.c:844 (DCtx created once)
 #[test]
 fn zstd_continuous_stream_across_files() {
     let mut encoder = ZstdTokenEncoder::new(3, None).unwrap();
@@ -536,7 +536,7 @@ fn zstd_block_match_without_literals_no_deflated_data() {
 /// Verifies the 2-byte header encoding: first byte is
 /// `DEFLATED_DATA | (len >> 8)`, second byte is `len & 0xFF`.
 /// This must match upstream's obuf[0]/obuf[1] encoding at
-/// token.c lines 758-759.
+/// token.c lines 815-816.
 #[test]
 fn zstd_deflated_data_header_matches_upstream() {
     let mut encoder = ZstdTokenEncoder::new(3, None).unwrap();

--- a/crates/protocol/src/wire/delta/token.rs
+++ b/crates/protocol/src/wire/delta/token.rs
@@ -230,7 +230,7 @@ pub fn read_token<R: Read>(reader: &mut R) -> io::Result<Option<i32>> {
 /// the receiver aborts with a `RERR_PROTOCOL`-mapped error rather than reserving
 /// the buffer. Mirrors the guard in `simple_recv_token`.
 ///
-/// upstream: token.c:299-305 simple_recv_token
+/// upstream: token.c:298-302 simple_recv_token
 pub fn check_literal_token_len(len: i32) -> io::Result<()> {
     if len > CHUNK_SIZE as i32 {
         return Err(crate::protocol_violation(format!(

--- a/crates/protocol/src/wire/file_entry_decode/hardlink.rs
+++ b/crates/protocol/src/wire/file_entry_decode/hardlink.rs
@@ -2,7 +2,7 @@
 //! Hardlink association decoding.
 //!
 //! Protocol 30+ uses a flist-relative index; protocols 28-29 use a (dev, ino)
-//! pair. upstream: flist.c:recv_file_entry() hardlink branches (lines 950-975).
+//! pair. upstream: flist.c:recv_file_entry() hardlink branches (lines 1189-1216).
 
 use std::io::{self, Read};
 
@@ -51,7 +51,7 @@ pub fn decode_hardlink_idx<R: Read>(reader: &mut R, flags: u32) -> io::Result<Op
 ///
 /// # Upstream Reference
 ///
-/// See `flist.c:recv_file_entry()` lines 950-975
+/// See `flist.c:recv_file_entry()` lines 1200-1207
 pub fn decode_hardlink_dev_ino<R: Read>(
     reader: &mut R,
     flags: u32,

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -428,7 +428,7 @@ impl SshCommand {
         // upstream: pipe.c:54-55 - "opening connection using:" precedes every
         // remote-shell spawn. The argv passed to upstream is the full child
         // command (program + args), so we prepend the program here.
-        // upstream: main.c:620-624 - DEBUG_GTE(CMD, 2) follows with the
+        // upstream: main.c:629-633 - DEBUG_GTE(CMD, 2) follows with the
         // per-index `cmd[i]=value` enumeration once argv is finalised. Both
         // helpers gate internally on `DebugFlag::Cmd`; the surrounding
         // `debug_gte` check avoids the Vec allocation when CMD is disabled.


### PR DESCRIPTION
## Summary

Re-anchor `// upstream:` source-line citations that had drifted. Many were pinned to rsync 3.4.1 line numbers, but the source of truth is rsync 3.4.4, which added/removed lines in several heavily-edited C files. This corrects the cited line numbers to their 3.4.4 locations.

Scope limited to high-drift upstream files whose line numbers actually moved: `flist.c`, `generator.c`, `receiver.c`, `io.c`, `token.c`, `clientserver.c`, `options.c`, `main.c`. Citations to stable files (`exclude.c`, `delete.c`, `rsync.c`, `checksum.c`, `match.c`, etc.) were left untouched.

## Method

Each citation was relocated by matching the function/statement described in the Rust comment against the 3.4.4 source, cross-checking the 3.4.1 source to confirm drift (old line matched 3.4.1, new line matches 3.4.4). Citations already correct for 3.4.4 were left alone. Where the described code could not be confidently relocated, the citation was left unchanged rather than guessed.

## Guarantees

- Comment-only: the sole change on every line is line-number digits. Verified mechanically that all changed lines are comments and each differs from its prior text only in digits. No code, no behavior, no other crates touched.
- `cargo fmt --check` passes for all eight affected crates.

## Stats

Across the affected crates: ~190 citations re-lined; 8 left as could-not-relocate (pre-existing citation/behavior mismatches, not drift), documented in review notes.
