### PR TITLE
docs(daemon): reline drifted upstream citations to rsync 3.4.4

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -123,17 +123,17 @@ pub(crate) const HANDSHAKE_ERROR_PAYLOAD: &str =
     "@ERROR: daemon functionality is unavailable in this build";
 /// Error payload sent when a host is denied access to a module.
 ///
-/// upstream: clientserver.c:733 - `@ERROR: access denied to %s from %s (%s)\n`
+/// upstream: clientserver.c:735 - `@ERROR: access denied to %s from %s (%s)\n`
 /// where args are (name, host, addr).
 pub(crate) const ACCESS_DENIED_PAYLOAD: &str =
     "@ERROR: access denied to {module} from {host} ({addr})";
 /// Error payload sent when authentication fails on a protected module.
 ///
-/// upstream: clientserver.c:762 - `@ERROR: auth failed on module %s\n`
+/// upstream: clientserver.c:764 - `@ERROR: auth failed on module %s\n`
 pub(crate) const AUTH_FAILED_PAYLOAD: &str = "@ERROR: auth failed on module {module}";
 /// Error payload returned when a requested module does not exist.
 ///
-/// upstream: clientserver.c:730 - `@ERROR: Unknown module '%s'\n`
+/// upstream: clientserver.c:732 - `@ERROR: Unknown module '%s'\n`
 pub(crate) const UNKNOWN_MODULE_PAYLOAD: &str = "@ERROR: Unknown module '{module}'";
 /// Error payload returned when a `#`-prefixed request is not a recognized command.
 ///
@@ -146,32 +146,32 @@ pub(crate) const UNKNOWN_MODULE_PAYLOAD: &str = "@ERROR: Unknown module '{module
 pub(crate) const UNKNOWN_COMMAND_PAYLOAD: &str = "@ERROR: Unknown command '{command}'";
 /// Error payload returned when a module reaches its connection cap.
 ///
-/// upstream: clientserver.c:752 - `@ERROR: max connections (%d) reached -- try again later\n`
+/// upstream: clientserver.c:754 - `@ERROR: max connections (%d) reached -- try again later\n`
 pub(crate) const MODULE_MAX_CONNECTIONS_PAYLOAD: &str =
     "@ERROR: max connections ({limit}) reached -- try again later";
 /// Error payload returned when opening the module connection lock file fails.
 ///
-/// upstream: clientserver.c:748 - `@ERROR: failed to open lock file\n`
+/// upstream: clientserver.c:750 - `@ERROR: failed to open lock file\n`
 pub(crate) const MODULE_LOCK_ERROR_PAYLOAD: &str = "@ERROR: failed to open lock file";
 /// Error payload returned when chroot fails during module setup.
 ///
-/// upstream: clientserver.c:981 - `@ERROR: chroot failed\n`
+/// upstream: clientserver.c:985 - `@ERROR: chroot failed\n`
 pub(crate) const CHROOT_FAILED_PAYLOAD: &str = "@ERROR: chroot failed";
 /// Error payload returned when chdir fails during module setup.
 ///
-/// upstream: clientserver.c:647 - `@ERROR: chdir failed\n`
+/// upstream: clientserver.c:649 - `@ERROR: chdir failed\n`
 pub(crate) const CHDIR_FAILED_PAYLOAD: &str = "@ERROR: chdir failed";
 /// Error payload returned when setuid fails after chroot.
 ///
-/// upstream: clientserver.c:1039 - `@ERROR: setuid failed\n`
+/// upstream: clientserver.c:1053 - `@ERROR: setuid failed\n`
 pub(crate) const SETUID_FAILED_PAYLOAD: &str = "@ERROR: setuid failed";
 /// Error payload returned when setgid fails after chroot.
 ///
-/// upstream: clientserver.c:1010 - `@ERROR: setgid failed\n`
+/// upstream: clientserver.c:1024 - `@ERROR: setgid failed\n`
 pub(crate) const SETGID_FAILED_PAYLOAD: &str = "@ERROR: setgid failed";
 /// Error payload returned when setgroups fails after chroot.
 ///
-/// upstream: clientserver.c:1017 - `@ERROR: setgroups failed\n`
+/// upstream: clientserver.c:1031 - `@ERROR: setgroups failed\n`
 pub(crate) const SETGROUPS_FAILED_PAYLOAD: &str = "@ERROR: setgroups failed";
 /// Error payload template returned when a module's uid NAME cannot be resolved
 /// at connection time. `{uid}` is replaced with the offending name. This is a
@@ -243,7 +243,7 @@ include!("daemon/sections/group_expansion.rs");
 /// (inetd/connect-program mode) or binds a TCP listener and enters the
 /// connection accept loop.
 ///
-/// upstream: clientserver.c:1496-1510 - `daemon_main()` checks
+/// upstream: clientserver.c:1546-1560 - `daemon_main()` checks
 /// `is_a_socket(STDIN_FILENO)` before binding TCP. When stdin is a socket
 /// (inetd, xinetd, systemd socket activation, or `RSYNC_CONNECT_PROG`),
 /// the daemon serves one session over the inherited file descriptors and
@@ -265,7 +265,7 @@ pub fn run_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
 
     apply_verbosity(options.verbosity());
 
-    // upstream: clientserver.c:1498 - `if (is_a_socket(STDIN_FILENO))`
+    // upstream: clientserver.c:1548 - `if (is_a_socket(STDIN_FILENO))`
     // When stdin is a socket, serve a single session over stdio (inetd mode)
     // instead of binding a TCP listener.
     if is_stdin_socket() {
@@ -303,7 +303,7 @@ pub(crate) fn apply_verbosity(level: u8) {
 /// the module table, and serves a single connection on the provided
 /// stdin/stdout streams. No TCP binding or signal handler registration occurs.
 ///
-/// upstream: main.c:1843-1844 - `if (am_server && am_daemon) return
+/// upstream: main.c:1867-1868 - `if (am_server && am_daemon) return
 /// start_daemon(STDIN_FILENO, STDOUT_FILENO);`
 ///
 /// # Errors
@@ -688,7 +688,7 @@ pub(crate) fn async_max_inflight(max_connections: Option<usize>) -> usize {
 /// Writes the upstream-compatible max-connections refusal to an accepted
 /// async socket, then lets it drop.
 ///
-/// upstream: clientserver.c:752 - `@ERROR: max connections (%d) reached --
+/// upstream: clientserver.c:754 - `@ERROR: max connections (%d) reached --
 /// try again later\n`. Mirrors the sync accept loop's `refuse_if_at_capacity`
 /// wording so clients see an identical reply regardless of accept engine.
 #[cfg(feature = "async-daemon")]

--- a/crates/daemon/src/daemon/module_state/definition.rs
+++ b/crates/daemon/src/daemon/module_state/definition.rs
@@ -7,7 +7,7 @@ use crate::daemon::HostPattern;
 
 /// Resolved `gid` directive for a daemon module's privilege drop.
 ///
-/// upstream: clientserver.c:791-822 `rsync_module()` parses `lp_gid()` as a
+/// upstream: clientserver.c:793-824 `rsync_module()` parses `lp_gid()` as a
 /// whitespace/comma-separated list via `conf_strtok`. A leading `*` requests
 /// all groups the target user belongs to (`getgrouplist`, clientserver.c:797
 /// `want_all_groups`); any remaining tokens are explicit groups added with
@@ -72,7 +72,7 @@ pub(crate) struct ModuleDefinition {
     /// the daemon falls back to no-chroot with a notice instead of refusing the
     /// connection.
     ///
-    /// upstream: clientserver.c:831-838 `rsync_module()`.
+    /// upstream: clientserver.c:833-840 `rsync_module()`.
     pub(crate) use_chroot_explicit: bool,
     pub(crate) max_connections: Option<NonZeroU32>,
     pub(crate) incoming_chmod: Option<String>,
@@ -389,7 +389,7 @@ impl ModuleDefinition {
     /// (`/./`) with a non-empty inner path, mirroring upstream's
     /// `module_dirlen > 0`.
     ///
-    /// upstream: clientserver.c:845-872 - when `use chroot` is set and the
+    /// upstream: clientserver.c:847-874 - when `use chroot` is set and the
     /// module path contains a `/./` marker, the normalized inner path length
     /// (`module_dirlen`) is non-zero. A `/./` at the very end (empty inner
     /// path) normalizes to `/` and resets `module_dirlen` back to 0.

--- a/crates/daemon/src/daemon/runtime_options/accessors.rs
+++ b/crates/daemon/src/daemon/runtime_options/accessors.rs
@@ -42,7 +42,7 @@ impl RuntimeOptions {
 
     /// Returns whether incoming connections require a PROXY protocol header.
     ///
-    /// upstream: clientserver.c:1298 - checked before accepting client data.
+    /// upstream: clientserver.c:1312 - checked before accepting client data.
     #[allow(dead_code)] // REASON: accessor for daemon listener; wired when async daemon starts
     pub(crate) fn proxy_protocol(&self) -> bool {
         self.proxy_protocol

--- a/crates/daemon/src/daemon/runtime_options/types.rs
+++ b/crates/daemon/src/daemon/runtime_options/types.rs
@@ -12,7 +12,7 @@ pub(crate) struct RuntimeOptions {
     /// and closed without dispatching a session, while the accept loop keeps
     /// running. Distinct from `max_sessions`, which caps total served sessions.
     ///
-    /// upstream: clientserver.c:744-756 - `claim_connection()` enforces the
+    /// upstream: clientserver.c:746-758 - `claim_connection()` enforces the
     /// per-module `max connections` directive and emits the same error.
     max_connections: Option<NonZeroUsize>,
     pub(crate) modules: Vec<ModuleDefinition>,

--- a/crates/daemon/src/daemon/sections/config_helpers/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/tests.rs
@@ -225,7 +225,7 @@ mod config_helpers_tests {
         assert_eq!(parse_numeric_identifier("-1"), None);
     }
 
-    /// WHY: upstream clientserver.c:791-817 - a module `gid` is a
+    /// WHY: upstream clientserver.c:793-819 - a module `gid` is a
     /// whitespace/comma-separated list. Every entry must reach `setgroups`, so
     /// the parser must preserve order and count rather than collapse to one gid.
     #[test]
@@ -242,7 +242,7 @@ mod config_helpers_tests {
         );
     }
 
-    /// WHY: upstream clientserver.c:793-799 - a leading `*` requests all of the
+    /// WHY: upstream clientserver.c:795-801 - a leading `*` requests all of the
     /// target user's groups (`want_all_groups`), and may be followed by extra
     /// explicit gids.
     #[test]
@@ -257,7 +257,7 @@ mod config_helpers_tests {
         );
     }
 
-    /// WHY: upstream clientserver.c:793 - `The "*" gid must be the first item in
+    /// WHY: upstream clientserver.c:794 - `The "*" gid must be the first item in
     /// the list.` A `*` appearing later is a configuration error.
     #[test]
     fn parse_gid_setting_rejects_non_leading_star() {

--- a/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
@@ -294,7 +294,7 @@ pub(crate) fn parse_uid_setting(value: &str) -> Option<u32> {
 /// `*` requests every group the target user belongs to; it must appear first,
 /// and any following tokens are extra explicit gids.
 ///
-/// upstream: clientserver.c:791-822 `rsync_module()` splits `lp_gid()` with
+/// upstream: clientserver.c:793-824 `rsync_module()` splits `lp_gid()` with
 /// `conf_strtok`; `*` triggers `want_all_groups`, and each remaining token is
 /// added via `add_a_group`. The whole list is later installed with
 /// `setgroups`, clearing inherited supplementary groups.

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -3129,7 +3129,7 @@ mod config_parsing_tests {
         );
     }
 
-    // WHY: upstream clientserver.c:781 - an explicit per-module `uid` overrides
+    // WHY: upstream clientserver.c:783 - an explicit per-module `uid` overrides
     // the inherited global default, exactly like every other P_LOCAL parameter.
     #[test]
     fn module_uid_overrides_global_uid_default() {

--- a/crates/daemon/src/daemon/sections/daemonize.rs
+++ b/crates/daemon/src/daemon/sections/daemonize.rs
@@ -3,7 +3,7 @@
 ///
 /// Delegates to `platform::daemonize::become_daemon()`.
 ///
-/// upstream: clientserver.c:1463 - `become_daemon()`
+/// upstream: clientserver.c:1513 - `become_daemon()`
 #[cfg(unix)]
 fn become_daemon() -> Result<(), DaemonError> {
     platform::daemonize::become_daemon().map_err(|e| daemonize_error("become_daemon", e))

--- a/crates/daemon/src/daemon/sections/greeting.rs
+++ b/crates/daemon/src/daemon/sections/greeting.rs
@@ -69,7 +69,7 @@ pub(crate) fn cached_legacy_daemon_greeting() -> &'static [u8] {
 /// stop. Returns `None` when the line is a well-formed greeting or is not a
 /// version banner at all, in which case normal parsing proceeds.
 ///
-/// upstream: clientserver.c:180-211 `exchange_protocols()` with `am_client == 0`.
+/// upstream: clientserver.c:182-213 `exchange_protocols()` with `am_client == 0`.
 /// The daemon reads the protocol number with `sscanf(buf, "@RSYNCD: %d.%d", ...)`;
 /// a missing `.subprotocol` leaves `remote_sub < 0` and, for `remote_protocol >= 30`,
 /// yields `@ERROR: your client omitted the subprotocol value: %s`. A missing digest
@@ -134,7 +134,7 @@ pub(crate) fn advertised_capability_lines(modules: &[ModuleRuntime]) -> Vec<Stri
 mod greeting_validation_tests {
     use super::reject_malformed_client_greeting;
 
-    // upstream: clientserver.c:188-197 - a protocol >= 30 greeting without a
+    // upstream: clientserver.c:190-199 - a protocol >= 30 greeting without a
     // ".subprotocol" suffix leaves remote_sub < 0 and is fatal. The @ERROR line
     // must echo the raw greeting so the client can report what it sent.
     #[test]
@@ -149,7 +149,7 @@ mod greeting_validation_tests {
         );
     }
 
-    // upstream: clientserver.c:199-211 - protocol > 31 must carry a digest name
+    // upstream: clientserver.c:201-213 - protocol > 31 must carry a digest name
     // list; its absence is fatal even when the subprotocol value is present.
     #[test]
     fn rejects_greeting_missing_digest_list() {
@@ -159,7 +159,7 @@ mod greeting_validation_tests {
         );
     }
 
-    // upstream: clientserver.c:205 - the digest gate is `remote_protocol > 31`, so
+    // upstream: clientserver.c:207 - the digest gate is `remote_protocol > 31`, so
     // protocol 31 needs the subprotocol but not a digest list.
     #[test]
     fn protocol_31_requires_subprotocol_not_digest() {
@@ -170,7 +170,7 @@ mod greeting_validation_tests {
         assert_eq!(reject_malformed_client_greeting("@RSYNCD: 31.0"), None);
     }
 
-    // upstream: clientserver.c:196 - protocol < 30 defaults remote_sub to 0 and
+    // upstream: clientserver.c:198 - protocol < 30 defaults remote_sub to 0 and
     // needs no digest list, so a bare legacy version is accepted.
     #[test]
     fn accepts_legacy_greeting_without_subprotocol_or_digest() {

--- a/crates/daemon/src/daemon/sections/inetd.rs
+++ b/crates/daemon/src/daemon/sections/inetd.rs
@@ -1,6 +1,6 @@
 // Inetd/connect-program stdin detection for standalone daemon mode.
 //
-// upstream: clientserver.c:1496-1510 - `daemon_main()` checks
+// upstream: clientserver.c:1546-1560 - `daemon_main()` checks
 // `is_a_socket(STDIN_FILENO)` before entering the TCP accept loop. When stdin
 // is a socket (inetd invocation or `RSYNC_CONNECT_PROG` pipe), the daemon
 // serves a single session over stdin/stdout instead of binding a TCP listener.
@@ -43,7 +43,7 @@ fn is_stdin_socket() -> bool {
 /// descriptors, then exits. No TCP binding, signal registration, or
 /// daemonization occurs.
 ///
-/// upstream: clientserver.c:1498-1509 - when `is_a_socket(STDIN_FILENO)` is
+/// upstream: clientserver.c:1548-1559 - when `is_a_socket(STDIN_FILENO)` is
 /// true, `daemon_main()` redirects stdout/stderr to `/dev/null` and calls
 /// `start_daemon(STDIN_FILENO, STDIN_FILENO)`.
 fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
@@ -95,7 +95,7 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
     }
 
     // Build a DaemonStream::Stdio from process stdin/stdout.
-    // upstream: clientserver.c:1509 - start_daemon(STDIN_FILENO, STDIN_FILENO)
+    // upstream: clientserver.c:1559 - start_daemon(STDIN_FILENO, STDIN_FILENO)
     // passes the same fd for both read and write. We use separate stdin/stdout
     // handles since Rust's std::io separates them.
     let stdin = io::stdin();

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -5,9 +5,9 @@
 // SSH-mode server invocation). The daemon parses these to configure the
 // transfer engine with the correct flags, paths, and options.
 //
-// upstream: io.c:1292 - `read_args()` reads null/newline-terminated arguments.
-// options.c:2737-2980 - `server_options()` emits the long-form options.
-// clientserver.c:1059-1073 - two-phase secluded-args reading.
+// upstream: io.c:1308 - `read_args()` reads null/newline-terminated arguments.
+// options.c:2755-2998 - `server_options()` emits the long-form options.
+// clientserver.c:1073-1087 - two-phase secluded-args reading.
 //
 // This file is `include!`d into the `crate::daemon` scope (see
 // `module_access.rs`), so the sub-parts below are textually included rather

--- a/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
@@ -160,7 +160,7 @@ fn read_client_arguments<R: BufRead>(
 /// capability string, e.g. `.iLsfxCIvu`). Characters after `e` must NOT be
 /// treated as flags - the `s` in `sfxCIvu` is SYMLINK_ICONV, not secluded-args.
 ///
-/// upstream: options.c:792 - `{secluded-args, 's', POPT_ARG_VAL, &protect_args, 1}`
+/// upstream: options.c:804 - `{secluded-args, 's', POPT_ARG_VAL, &protect_args, 1}`
 fn has_secluded_args_flag(args: &[String]) -> bool {
     args.iter().any(|a| {
         if a == "-s" || a == "--protect-args" || a == "--secluded-args" {
@@ -200,7 +200,7 @@ fn has_secluded_args_flag(args: &[String]) -> bool {
 ///
 /// # Upstream Reference
 ///
-/// - `clientserver.c:1059-1073` - two-phase `read_args()` for protect_args
+/// - `clientserver.c:1073-1087` - two-phase `read_args()` for protect_args
 fn read_and_log_client_args(
     ctx: &mut ModuleRequestContext<'_>,
     negotiated_protocol: Option<ProtocolVersion>,
@@ -215,14 +215,14 @@ fn read_and_log_client_args(
     };
 
     // Detect secluded-args flag in phase-1 args.
-    // upstream: clientserver.c:1066 - if (protect_args && ret)
-    // upstream: options.c:792 - `-s` is a short option for `--secluded-args`
+    // upstream: clientserver.c:1080 - if (protect_args && ret)
+    // upstream: options.c:804 - `-s` is a short option for `--secluded-args`
     // Protocol 28/29 clients may bundle `-s` into compact flag strings like `-logDtprs`.
     let has_secluded = has_secluded_args_flag(&phase1_args);
 
     let client_args = if has_secluded {
         // Phase 2: read the real args via secluded-args wire format.
-        // upstream: clientserver.c:1068-1071 - read_args with rl_nulls=1.
+        // upstream: clientserver.c:1082-1085 - read_args with rl_nulls=1.
         //
         // The two phases carry disjoint slices of the original argv:
         // - Phase 1 (cmdline): `--server`, `--sender`, the compact flag

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -3,7 +3,7 @@
 // never reach the daemon.
 /// Applies long-form arguments from the client to the server configuration.
 ///
-/// Upstream rsync's `server_options()` (options.c:2737-2980) sends many options
+/// Upstream rsync's `server_options()` (options.c:2755-2998) sends many options
 /// as long-form arguments that are not encoded in the compact flag string.
 /// The daemon must parse these to correctly configure the transfer.
 ///
@@ -11,18 +11,18 @@
 /// reaches the daemon. The caller surfaces that as an `@ERROR` and exits
 /// instead of letting the unrecognised option drive a silent connection
 /// close mid file-list framing. Upstream mirrors this at
-/// `options.c:1444-1449` with `rsync: <BAD>: <err> (in daemon mode)` then
-/// `daemon_error:` (`options.c:1464-1466`) exiting `RERR_SYNTAX`.
+/// `options.c:1460-1465` with `rsync: <BAD>: <err> (in daemon mode)` then
+/// `daemon_error:` (`options.c:1480-1482`) exiting `RERR_SYNTAX`.
 ///
 /// # Upstream Reference
 ///
-/// - `options.c:1444-1449` - daemon-mode unknown option error path
-/// - `options.c:2818-2829` - delete mode variants
-/// - `options.c:2836-2837` - `--size-only`
-/// - `options.c:2878-2879` - `--ignore-errors`
-/// - `options.c:2888` - `--numeric-ids`
-/// - `options.c:2891` - `--use-qsort`
-/// - `options.c:2737-2740` - `--compress-level=N`
+/// - `options.c:1460-1465` - daemon-mode unknown option error path
+/// - `options.c:2836-2847` - delete mode variants
+/// - `options.c:2854-2855` - `--size-only`
+/// - `options.c:2896-2897` - `--ignore-errors`
+/// - `options.c:2906` - `--numeric-ids`
+/// - `options.c:2909` - `--use-qsort`
+/// - `options.c:2755-2758` - `--compress-level=N`
 fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Option<String> {
     // Positional path args follow the standalone `.` separator. Upstream
     // `glob_expand_module()` consumes them through a different code path, so
@@ -38,7 +38,7 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
             continue;
         }
         match arg.as_str() {
-            // upstream: options.c:2818-2829 - delete mode variants
+            // upstream: options.c:2836-2847 - delete mode variants
             "--delete" | "--delete-before" | "--delete-during" => {
                 config.flags.delete = true;
             }
@@ -57,30 +57,30 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
             "--delete-excluded" => {
                 config.flags.delete = true;
             }
-            // upstream: options.c:2838-2839 - --stats sets do_stats which causes
+            // upstream: options.c:2856-2857 - --stats sets do_stats which causes
             // INFO_STATS to level 2+. Without this flag, the generator does not
             // emit NDX_DEL_STATS during the goodbye phase and the client sender's
             // "Number of deleted files" line stays at zero on daemon uploads.
             "--stats" => {
                 config.do_stats = true;
             }
-            // upstream: options.c:2836-2837
+            // upstream: options.c:2854-2855
             "--size-only" => {
                 config.file_selection.size_only = true;
             }
-            // upstream: options.c:2878-2879
+            // upstream: options.c:2896-2897
             "--ignore-errors" => {
                 config.deletion.ignore_errors = true;
             }
-            // upstream: options.c:2881-2882
+            // upstream: options.c:2899-2900
             "--copy-unsafe-links" => {
                 config.flags.copy_unsafe_links = true;
             }
-            // upstream: options.c:2884-2885
+            // upstream: options.c:2902-2903
             "--safe-links" => {
                 config.flags.safe_links = true;
             }
-            // upstream: options.c:2887-2888 - an explicit client --numeric-ids
+            // upstream: options.c:2905-2906 - an explicit client --numeric-ids
             // sets `numeric_ids = 1` (drops the wire name-list entirely).
             "--numeric-ids" => {
                 config.flags.numeric_ids = core::server::NumericIds::Explicit;
@@ -92,26 +92,26 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
             "--no-implied-dirs" => {
                 config.flags.no_implied_dirs = true;
             }
-            // upstream: options.c:2890-2891
+            // upstream: options.c:2908-2909
             "--use-qsort" => {
                 config.qsort = true;
             }
-            // upstream: options.c:2893-2897
+            // upstream: options.c:2918-2919
             "--ignore-existing" => {
                 config.file_selection.ignore_existing = true;
             }
-            // upstream: options.c:2899-2900
+            // upstream: options.c:2922-2923
             "--existing" => {
                 config.file_selection.existing_only = true;
             }
-            // upstream: options.c:817-818
+            // upstream: options.c:2870-2871
             "--ignore-missing-args" => {
                 config.file_selection.ignore_missing_args = true;
             }
             "--delete-missing-args" => {
                 config.file_selection.delete_missing_args = true;
             }
-            // upstream: options.c:2933-2942
+            // upstream: options.c:2951-2960
             "--inplace" => {
                 config.write.inplace = true;
             }
@@ -125,11 +125,11 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                 }
                 config.flags.append = true;
             }
-            // upstream: options.c:2934-2935
+            // upstream: options.c:2891-2892
             "--delay-updates" => {
                 config.write.delay_updates = true;
             }
-            // upstream: options.c:2964-2965
+            // upstream: options.c:2930-2931
             "--fsync" => {
                 config.write.fsync = true;
             }
@@ -147,8 +147,8 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                 config.write.zero_copy_policy = fast_io::ZeroCopyPolicy::Disabled;
             }
             // upstream: options.c:2996-2997 - --mkpath forwarded to the daemon
-            // receiver on a push. Gates dest-arg path creation (main.c:736
-            // make_path vs main.c:788 single do_mkdir).
+            // receiver on a push. Gates dest-arg path creation (main.c:738
+            // make_path vs main.c:796 single do_mkdir).
             "--mkpath" => {
                 config.flags.mkpath = true;
             }
@@ -167,7 +167,7 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                 config.flags.backup = true;
             }
             // Two-arg options: upstream sends option and value as separate args.
-            // upstream: options.c:2915-2923 - reference directories
+            // upstream: options.c:2933-2941 - reference directories
             "--compare-dest" => {
                 if let Some(dir) = client_args.get(i + 1) {
                     config.reference_directories.push(ReferenceDirectory {
@@ -195,7 +195,7 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                     i += 1;
                 }
             }
-            // upstream: options.c:2787-2790 - backup-dir as separate args
+            // upstream: options.c:2805-2808 - backup-dir as separate args
             "--backup-dir" => {
                 config.flags.backup = true;
                 if let Some(dir) = client_args.get(i + 1) {
@@ -203,7 +203,7 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                     i += 1;
                 }
             }
-            // upstream: options.c:2791-2793 - suffix as separate args
+            // upstream: options.c:2809-2811 - suffix as separate args
             // When --backup-dir is specified without explicit --suffix,
             // upstream changes the default suffix from "~" to "" and sends
             // --suffix as a two-arg form (not --suffix=VALUE).
@@ -213,14 +213,14 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                     i += 1;
                 }
             }
-            // upstream: options.c:2907-2909 - temp-dir as separate args
+            // upstream: options.c:2925-2927 - temp-dir as separate args
             "--temp-dir" => {
                 if let Some(dir) = client_args.get(i + 1) {
                     config.temp_dir = Some(std::path::PathBuf::from(dir));
                     i += 1;
                 }
             }
-            // upstream: options.c:2800-2805 - --compress-choice, --new-compress, --old-compress
+            // upstream: options.c:2818-2823 - --compress-choice, --new-compress, --old-compress
             "--new-compress" => {
                 config.flags.compress = true;
                 if config.connection.compression_level.is_none() {
@@ -236,7 +236,7 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                 }
             }
             _ => {
-                // upstream: options.c:2800-2805 - --compress-choice=ALGO
+                // upstream: options.c:2818-2823 - --compress-choice=ALGO
                 if let Some(_choice) = arg
                     .strip_prefix("--compress-choice=")
                     .or_else(|| arg.strip_prefix("--zc="))
@@ -248,14 +248,14 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                         config.connection.compression_level =
                             Some(compress::zlib::CompressionLevel::Default);
                     }
-                // upstream: options.c:2737-2740
+                // upstream: options.c:2755-2758
                 } else if let Some(level_str) = arg.strip_prefix("--compress-level=") {
                     if let Ok(level) = level_str.parse::<u32>() {
                         if let Ok(cl) = compress::zlib::CompressionLevel::from_numeric(level) {
                             config.connection.compression_level = Some(cl);
                         }
                     }
-                // upstream: options.c:2807-2810
+                // upstream: options.c:2825-2828
                 } else if let Some(val) = arg.strip_prefix("--max-delete=") {
                     if let Ok(n) = val.parse::<i64>() {
                         if n >= 0 {
@@ -304,7 +304,7 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                     config.temp_dir = Some(std::path::PathBuf::from(dir));
                 } else if let Some(path) = arg.strip_prefix("--files-from=") {
                     config.file_selection.files_from_path = Some(path.to_owned());
-                // upstream: options.c:2904 / 2907 - --usermap=SPEC / --groupmap=SPEC.
+                // upstream: options.c:2912 / 2915 - --usermap=SPEC / --groupmap=SPEC.
                 // After unbackslash_arg / secluded-args delivery the spec arrives
                 // verbatim (`*:1234` wildcards intact) so we hand it directly to
                 // the metadata parser. Without this step the daemon-mode receiver
@@ -330,7 +330,7 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                     // upstream: options.c:940 - --from0 sets NUL-delimited mode
                     // for --files-from content read from the protocol stream.
                     config.file_selection.from0 = true;
-                // upstream: options.c:773,963 - --log-format is the deprecated
+                // upstream: options.c:785,975 - --log-format is the deprecated
                 // alias for --out-format. The server parses it to set
                 // stdout_format_has_i (options.c:2345-2348): `%i` sets has_i = 1
                 // (itemize significant items) and `%I` sets has_i = 2, the `-ii`
@@ -347,10 +347,10 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                         config.flags.info_flags.itemize_unchanged = true;
                     }
                 } else if unknown.is_none() && is_client_only_flag_reaching_daemon(arg) {
-                    // upstream: options.c:1444-1449 - the daemon's popt loop
+                    // upstream: options.c:1460-1465 - the daemon's popt loop
                     // emits `rsync: <BAD>: <err> (in daemon mode)` on the
                     // first unrecognised option and jumps to `daemon_error:`
-                    // (options.c:1464-1466), exiting `RERR_SYNTAX`. We mirror
+                    // (options.c:1480-1482), exiting `RERR_SYNTAX`. We mirror
                     // that fail-loud surface for batch-family flags that the
                     // client-side sanitiser should have stripped. Catching
                     // them here converts the previously silent connection

--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -75,7 +75,7 @@ fn resolve_receiver_dest(
     module_name: &str,
 ) -> Option<std::path::PathBuf> {
     let positionals = extract_module_relative_paths(client_args, module_name);
-    // upstream: main.c:1203-1204 - `local_name = get_local_name(flist, argv[0])`
+    // upstream: main.c:1212-1213 - `local_name = get_local_name(flist, argv[0])`
     // uses the FIRST remaining positional (after the `.` placeholder has been
     // consumed by `do_server_recv` at line 1166). For a receiver that
     // translates to the last wire positional - the destination.

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -130,7 +130,7 @@ fn build_server_config(
     // upstream: clientserver.c - clamp verbose to lp_max_verbosity(i)
     let flag_string = clamp_verbose_flags(&flag_string, module.max_verbosity);
 
-    // upstream: clientserver.c:1127 `limit_output_verbosity(lp_max_verbosity(i))`
+    // upstream: clientserver.c:1141 `limit_output_verbosity(lp_max_verbosity(i))`
     // caps the per-connection log verbosity once the module is selected. Each
     // oc-rsync connection runs on its own worker thread whose thread-local
     // `logging::VerbosityConfig` starts at level 0, so seed it from the clamped
@@ -188,9 +188,9 @@ fn build_server_config(
             // than silently dropping the option and continuing into a wire
             // path that closes mid file-list framing.
             //
-            // upstream: options.c:1444-1449 - daemon-mode unknown option
+            // upstream: options.c:1460-1465 - daemon-mode unknown option
             // emits `rsync: <BAD>: <err> (in daemon mode)` and exits
-            // `RERR_SYNTAX` via `daemon_error:` (options.c:1464-1466).
+            // `RERR_SYNTAX` via `daemon_error:` (options.c:1480-1482).
             if let Some(offender) = apply_long_form_args(client_args, &mut cfg) {
                 if let Some(log) = ctx.log_sink {
                     let text = format!(
@@ -206,7 +206,7 @@ fn build_server_config(
                 return Ok(None);
             }
 
-            // upstream: options.c:2737-2740 - when -z is in the compact flag string
+            // upstream: options.c:2755-2758 - when -z is in the compact flag string
             // but no explicit --compress-level=N was sent, default to level 6 (the
             // upstream default). Without this, compression_level stays None and the
             // transfer pipeline won't activate token-level compression.
@@ -214,7 +214,7 @@ fn build_server_config(
                 cfg.connection.compression_level = Some(compress::zlib::CompressionLevel::Default);
             }
 
-            // upstream: main.c:1199-1206 calls `check_alt_basis_dirs()` after
+            // upstream: main.c:1217-1224 calls `check_alt_basis_dirs()` after
             // `get_local_name(flist, argv[0])` chdir's into the dest directory,
             // so relative basis paths like `--link-dest=../01` resolve against
             // the receiver's destination (a sibling of `dest/00/`), not against
@@ -277,7 +277,7 @@ fn build_server_config(
                 }
             }
 
-            // upstream: clientserver.c:712-716 - `iconv_opt = lp_charset(i);
+            // upstream: clientserver.c:714-718 - `iconv_opt = lp_charset(i);
             // if (*iconv_opt) setup_iconv();` resolves the module's `charset =`
             // directive into the iconv handles used for filename transcoding.
             // Without this wiring the daemon would parse `charset = LATIN1` but
@@ -292,7 +292,7 @@ fn build_server_config(
             // window once the original CVE-2026-29518 fix landed.
             cfg.connection.is_daemon_connection = true;
 
-            // upstream: clientserver.c:1106-1107 - `fake super = yes` on the
+            // upstream: clientserver.c:1120-1121 - `fake super = yes` on the
             // daemon module demotes the receiver's am_root and forces fake-super
             // semantics regardless of whether the client requested --fake-super.
             // The directive is purely daemon-config-driven; client --fake-super
@@ -322,7 +322,7 @@ fn build_server_config(
                 }
             }
 
-            // upstream: clientserver.c:992-993 - `munge_symlinks = lp_munge_symlinks(i)`
+            // upstream: clientserver.c:997-998 - `munge_symlinks = lp_munge_symlinks(i)`
             // with `!use_chroot || module_dirlen` as the auto default. The bit is
             // purely daemon-config-driven (no client-side override) and travels
             // through the transfer layer so the sender strips `/rsyncd-munged/`

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -4,7 +4,7 @@
 /// Runs the module's `post-xfer exec` hook, if one is configured and exec
 /// hooks are enabled, with the given transfer `exit_status`.
 ///
-/// upstream: clientserver.c:906-931 - the daemon forks a child that runs the
+/// upstream: clientserver.c:908-933 - the daemon forks a child that runs the
 /// whole module session while the parent waits for the child's exit status and
 /// then runs `post-xfer exec` with it. Because the parent waits for *any* child
 /// outcome, the hook fires regardless of transfer success - including a refused
@@ -192,7 +192,7 @@ fn process_approved_module(
     // to multiplexed input. The error must travel as `MSG_ERROR_XFER` +
     // `MSG_ERROR_EXIT` frames; raw `@ERROR:` text would surface on the
     // receiver as `unexpected tag 77` (the 'T' from "The server ..." minus
-    // `MPLEX_BASE = 7`). upstream: clientserver.c:1146 io_start_multiplex_out
+    // `MPLEX_BASE = 7`). upstream: clientserver.c:1169 io_start_multiplex_out
     // immediately followed by `rwrite(FERROR, ...)`.
     if let Some(refused) = refused_client_arg(module, &client_args) {
         return handle_refused_option_post_handshake(
@@ -229,7 +229,7 @@ fn process_approved_module(
     // check is unaffected: upstream's auth override only touches `read_only`.
     let role = determine_server_role(&client_args);
     let effective_read_only = access_effective_read_only(module.read_only, auth_access_level);
-    // upstream: clientserver.c:906-931 - the post-xfer parent waits for the
+    // upstream: clientserver.c:908-933 - the post-xfer parent waits for the
     // module child and runs `post-xfer exec` regardless of outcome. A refused
     // read-only push / write-only pull exits `RERR_SYNTAX` (1) in the child, so
     // the hook still fires with `RSYNC_EXIT_STATUS=1`. Emit the framed
@@ -301,7 +301,7 @@ fn process_approved_module(
         None => return Ok(()),
     };
 
-    // upstream: clientserver.c:962-969 - spawn name converter after privilege
+    // upstream: clientserver.c:964-971 - spawn name converter after privilege
     // reduction so it runs with reduced privileges inside the chroot.
     #[cfg(unix)]
     let _name_converter_guard = if let Some(ref cmd) = module.name_converter {
@@ -334,7 +334,7 @@ fn process_approved_module(
     // process is not chrooted, so the real absolute module path must be
     // preserved. The inner directory is "/" unless the module path carried a
     // `/./` marker, in which case it is the normalized remainder after it.
-    // upstream: clientserver.c:845-862 - `module_dir` after the `/./` split.
+    // upstream: clientserver.c:847-864 - `module_dir` after the `/./` split.
     let effective_module;
     let config_module = if privilege_outcome.chroot_applied {
         let mut adjusted = module.definition.clone();

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -4,10 +4,10 @@
 /// `@ERROR` messages on failure.
 ///
 /// Upstream sends distinct error strings for each failure type:
-/// - `@ERROR: chroot failed` (clientserver.c:981)
-/// - `@ERROR: setgid failed` (clientserver.c:1010)
-/// - `@ERROR: setgroups failed` (clientserver.c:1017)
-/// - `@ERROR: setuid failed` (clientserver.c:1039)
+/// - `@ERROR: chroot failed` (clientserver.c:985)
+/// - `@ERROR: setgid failed` (clientserver.c:1024)
+/// - `@ERROR: setgroups failed` (clientserver.c:1031)
+/// - `@ERROR: setuid failed` (clientserver.c:1053)
 ///
 /// Returns `Ok(Some(outcome))` when restrictions applied successfully or were
 /// not configured; `outcome.chroot_applied` records whether the process is
@@ -17,7 +17,7 @@ fn apply_privilege_restrictions_with_upstream_errors(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleRuntime,
 ) -> io::Result<Option<PrivilegeOutcome>> {
-    // upstream: clientserver.c:779-780 - `uid = MY_UID(); am_root = (uid ==
+    // upstream: clientserver.c:778-779 - `uid = MY_UID(); am_root = (uid ==
     // ROOT_UID)`. A root daemon drops to `nobody:nobody` by default even when
     // the module sets no explicit uid/gid.
     let am_root = daemon_is_root();
@@ -38,7 +38,7 @@ fn apply_privilege_restrictions_with_upstream_errors(
         }
     };
 
-    // upstream: clientserver.c:978-984 - chroot first, then privilege drop.
+    // upstream: clientserver.c:980-989 - chroot first, then privilege drop.
     // A rootless auto-fallback (unset `use chroot` + failing probe) yields
     // `Ok(false)`; an explicit `use chroot = yes` that fails is fatal.
     let mut chroot_applied = false;
@@ -53,8 +53,8 @@ fn apply_privilege_restrictions_with_upstream_errors(
             }
             Err(err) => {
                 // Operator demanded chroot explicitly: a failure is fatal.
-                // upstream: clientserver.c:981 - `@ERROR: chroot failed\n`
-                // upstream: clientserver.c:647 - `@ERROR: chdir failed\n`
+                // upstream: clientserver.c:985 - `@ERROR: chroot failed\n`
+                // upstream: clientserver.c:649 - `@ERROR: chdir failed\n`
                 let text = err.to_string();
                 let payload = if text.contains("chdir") {
                     CHDIR_FAILED_PAYLOAD
@@ -68,7 +68,7 @@ fn apply_privilege_restrictions_with_upstream_errors(
     }
 
     if needs_privdrop {
-        // upstream: clientserver.c:781-822 - resolve the effective uid and full
+        // upstream: clientserver.c:783-824 - resolve the effective uid and full
         // group set (nobody defaults, `gid = *` expansion) before dropping.
         let target = match resolve_drop_target(module, am_root) {
             Ok(target) => target,
@@ -78,7 +78,7 @@ fn apply_privilege_restrictions_with_upstream_errors(
                 // SYSCALL failures handled below: it yields `@ERROR: invalid
                 // uid <name>` / `@ERROR: invalid gid <name>` with a matching
                 // FLOG `Invalid uid/gid <name>`.
-                // upstream: clientserver.c:784-786 (uid) / 656-658 (gid).
+                // upstream: clientserver.c:784-786 (uid) / 657-659 (gid).
                 let (flog, payload) = err.upstream_reply();
                 let message = rsync_error!(1, flog).with_role(Role::Daemon);
                 log_message(log_sink, &message);
@@ -90,7 +90,7 @@ fn apply_privilege_restrictions_with_upstream_errors(
         if target.uid.is_some() || !target.gids.is_empty() {
             if let Err(err) = drop_privileges(target.uid, &target.gids, log_sink) {
                 // Distinguish upstream error messages based on the error text.
-                // upstream: clientserver.c:1010/1017/1039
+                // upstream: clientserver.c:1024/1031/1053
                 let text = err.to_string();
                 let payload = if text.contains("setgroups") {
                     SETGROUPS_FAILED_PAYLOAD
@@ -118,7 +118,7 @@ struct PrivilegeOutcome {
     /// failed (rootless fallback) - downstream path handling must then treat
     /// the module as non-chrooted.
     ///
-    /// upstream: clientserver.c:831-862 - the effective `use_chroot` decides
+    /// upstream: clientserver.c:833-864 - the effective `use_chroot` decides
     /// whether the module path is rewritten to the post-chroot inner path.
     chroot_applied: bool,
     /// The post-chroot working directory to serve from, when `chroot_applied`
@@ -126,7 +126,7 @@ struct PrivilegeOutcome {
     /// marker, in which case it is the normalized remainder after the
     /// marker (e.g. `/module` for `path = /var/data/./module`).
     ///
-    /// upstream: clientserver.c:845-862 - `module_dir` after the `/./` split.
+    /// upstream: clientserver.c:847-864 - `module_dir` after the `/./` split.
     inner_module_path: Option<PathBuf>,
 }
 

--- a/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
@@ -156,7 +156,7 @@ fn short_option_long_name(letter: char) -> &'static str {
 /// short-letter alias. Used by the refuse-list matcher so rules can reference
 /// either the long or short form (`!verbose` and `!v` are equivalent).
 ///
-/// upstream: options.c:594-... - the `shortName` column on each `long_options[]`
+/// upstream: options.c:604-... - the `shortName` column on each `long_options[]`
 /// entry; upstream's `parse_one_refuse_match` calls `wildmatch(ref, shortName)`
 /// as a fallback when the long-name comparison fails.
 fn long_option_short_letter(long_name: &str) -> Option<char> {
@@ -353,7 +353,7 @@ fn is_option_refused(
             continue;
         }
 
-        // upstream: options.c:904 - `a` / `archive` rules expand to the
+        // upstream: options.c:916 - `a` / `archive` rules expand to the
         // character class containing every short letter implied by `-a`.
         let mut is_glob = pattern.contains('*') || pattern.contains('?') || pattern.contains('[');
         if pattern == "a" || pattern == "archive" {
@@ -361,7 +361,7 @@ fn is_option_refused(
             is_glob = true;
         }
 
-        // upstream: options.c:953-968 - vital options carry `descrip = "a="`
+        // upstream: options.c:965-980 - vital options carry `descrip = "a="`
         // and `parse_one_refuse_match` only updates them when the rule is
         // exact, never wild. Mirror that here so administrators cannot wreck
         // the handshake with `refuse options = *`.
@@ -369,7 +369,7 @@ fn is_option_refused(
             continue;
         }
 
-        // upstream: options.c:909-921 - the rule is tried against both
+        // upstream: options.c:921-933 - the rule is tried against both
         // `op->longName` and `op->shortName` so `!verbose` and `!v` refer to
         // the same option. Glob patterns additionally need the original-case
         // short letter (so `[ardlptgoD]` matches `-D` via the upper-case `D`).

--- a/crates/daemon/src/daemon/sections/name_converter.rs
+++ b/crates/daemon/src/daemon/sections/name_converter.rs
@@ -4,7 +4,7 @@
 /// NSS lookups (getpwuid, getpwnam, getgrgid, getgrnam) with a simple
 /// line-based protocol over stdin/stdout pipes.
 ///
-/// upstream: clientserver.c:962-969 - the name converter is spawned after
+/// upstream: clientserver.c:964-971 - the name converter is spawned after
 /// privilege reduction and communicates via stdin/stdout pipes. Requests are
 /// `"{cmd} {arg}\n"`, responses are single lines.
 #[cfg(unix)]

--- a/crates/daemon/src/daemon/sections/privilege.rs
+++ b/crates/daemon/src/daemon/sections/privilege.rs
@@ -100,7 +100,7 @@ fn drop_privileges(
 /// of the inner directory reachable inside the jail for modules that need
 /// to share a parent directory with other served paths.
 ///
-/// upstream: clientserver.c:845-862 `rsync_module()` - `strstr(module_dir,
+/// upstream: clientserver.c:847-864 `rsync_module()` - `strstr(module_dir,
 /// "/./")` locates the marker; the outer half becomes `module_chdir` (the
 /// chroot target) and the normalized remainder becomes `module_dir` (the
 /// post-chroot `change_dir` target).
@@ -260,7 +260,7 @@ impl From<DropResolutionError> for io::Error {
 /// Delegates to the `platform` crate, which owns the `nix` dependency on every
 /// Unix target (the daemon crate links `nix` only on Linux).
 ///
-/// upstream: clientserver.c:780 `am_root = (uid == ROOT_UID)`. Non-Unix
+/// upstream: clientserver.c:779 `am_root = (uid == ROOT_UID)`. Non-Unix
 /// platforms have no root uid and use the impersonation path instead.
 fn daemon_is_root() -> bool {
     platform::privilege::is_effective_root()
@@ -316,7 +316,7 @@ fn resolve_drop_target(
 
 /// Resolves the `nobody` user to its uid via NSS.
 ///
-/// upstream: clientserver.c:782 `user_to_uid(NOBODY_USER, ...)`; NOBODY_USER is
+/// upstream: clientserver.c:783 `user_to_uid(NOBODY_USER, ...)`; NOBODY_USER is
 /// `"nobody"` (config.h). Errors when the account is absent, mirroring
 /// upstream's `@ERROR: invalid uid nobody`.
 #[cfg(unix)]
@@ -521,7 +521,7 @@ mod privilege_tests {
         );
     }
 
-    /// WHY: upstream clientserver.c:779-780 recomputes `am_root` from the live
+    /// WHY: upstream clientserver.c:778-779 recomputes `am_root` from the live
     /// uid; a non-root daemon with an unconfigured module leaves the identity
     /// untouched (`set_uid = 0`, empty `gid_list`). Guarantees we never attempt
     /// a spurious drop that would EPERM and break unprivileged daemons.
@@ -671,7 +671,7 @@ mod privilege_tests {
         );
     }
 
-    /// WHY: upstream clientserver.c:845-862 - a module path without `/./`
+    /// WHY: upstream clientserver.c:847-864 - a module path without `/./`
     /// chroots into the whole path and starts the session at the new root.
     /// Pure path-string logic, no syscall involved.
     #[test]
@@ -681,7 +681,7 @@ mod privilege_tests {
         assert_eq!(inner, PathBuf::from("/"));
     }
 
-    /// WHY: upstream clientserver.c:846-855 - a `/./` marker splits the path
+    /// WHY: upstream clientserver.c:848-857 - a `/./` marker splits the path
     /// into the outer chroot root and the inner post-chroot working
     /// directory, e.g. `path = /var/data/./module` chroots to `/var/data`
     /// then starts the session at `/module` (still reachable: siblings of

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -264,7 +264,7 @@ fn serve_connections(
     // Detach from terminal if --detach is active (Unix default).
     // Must happen after binding so startup errors reach stderr, and before
     // PID file creation so the file records the child's PID.
-    // upstream: clientserver.c:1518-1521 -- become_daemon() called before accept loop.
+    // upstream: clientserver.c:1568-1571 -- become_daemon() called before accept loop.
     #[cfg(unix)]
     if detach {
         become_daemon()?;
@@ -287,7 +287,7 @@ fn serve_connections(
     // PID file. Order matches upstream: chroot first (while still root), then
     // setgid, then setuid. Any failure is fatal so the daemon never continues
     // running as root after a partial privilege drop.
-    // upstream: clientserver.c:1301-1339 start_accept_loop() applies
+    // upstream: clientserver.c:1337-1389 start_accept_loop() applies
     // lp_daemon_chroot() then lp_daemon_gid()/lp_daemon_uid() before the accept
     // loop services any client.
     if daemon_chroot.is_some() || daemon_uid.is_some() || daemon_gid.is_some() {

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -13,7 +13,7 @@ struct AcceptLoopState<'a> {
     /// Concurrent connection cap consulted by the accept loop before
     /// dispatching a worker. `None` disables the check.
     ///
-    /// upstream: clientserver.c:744-756 enforces the per-module `max
+    /// upstream: clientserver.c:746-758 enforces the per-module `max
     /// connections` directive via `claim_connection()`; this cap mirrors
     /// the same behaviour at the daemon level.
     max_connections: Option<usize>,
@@ -113,7 +113,7 @@ fn check_signals_and_maintain(
 /// stream (matching upstream's wording byte for byte). The accept loop
 /// keeps running.
 ///
-/// upstream: clientserver.c:744-756 - `claim_connection()` enforces the
+/// upstream: clientserver.c:746-758 - `claim_connection()` enforces the
 /// per-module `lp_max_connections()` cap and emits
 /// `@ERROR: max connections (%d) reached -- try again later\n` to the
 /// client via `io_printf(f_out, ...)`.

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1066,7 +1066,7 @@ fn accept_loop_refuses_when_at_capacity() {
     let line = read_error_line(&mut client_stream);
     assert_eq!(
         line, "@ERROR: max connections (2) reached -- try again later",
-        "refusal payload must mirror upstream clientserver.c:752"
+        "refusal payload must mirror upstream clientserver.c:754"
     );
 
     // The accept loop is expected to keep running: dropping the server

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -73,7 +73,7 @@ fn handle_session(
     // "Connection reset by peer". The per-module `timeout` directive still
     // governs the data phase via apply_module_timeout once the module is known.
 
-    // upstream: clientserver.c:1298 - read PROXY protocol header before any
+    // upstream: clientserver.c:1312 - read PROXY protocol header before any
     // rsync protocol data when `proxy protocol = true` in the config.
     let mut stream = stream;
     let peer_addr = if proxy_protocol {
@@ -249,7 +249,7 @@ fn handle_legacy_session(
         cached_legacy_daemon_greeting(),
     )?;
 
-    // upstream: clientserver.c:158-170 exchange_protocols() - immediately after
+    // upstream: clientserver.c:160-172 exchange_protocols() - immediately after
     // the greeting the daemon dumps the MOTD file verbatim and appends a single
     // trailing newline (write_sbuf(f_out, "\n")), before reading the client's
     // version/module request. Emitting it here (rather than only in the module
@@ -273,7 +273,7 @@ fn handle_legacy_session(
     fast_io::rearm_tcp_quickack(reader.get_ref().tcp_stream());
     while let Some(line) = read_trimmed_line(&mut reader)? {
         fast_io::rearm_tcp_quickack(reader.get_ref().tcp_stream());
-        // upstream: clientserver.c:180-211 exchange_protocols() (am_client == 0) -
+        // upstream: clientserver.c:182-213 exchange_protocols() (am_client == 0) -
         // before proceeding the daemon validates the client's version greeting,
         // refusing one that omits the subprotocol value (protocol >= 30) or the
         // digest name list (protocol > 31). The refusal is a fatal pre-OK
@@ -325,7 +325,7 @@ fn handle_legacy_session(
             Err(_) => {}
         }
 
-        // upstream: clientserver.c:1357-1368 - the daemon checks if the first
+        // upstream: clientserver.c:1407-1418 - the daemon checks if the first
         // non-@RSYNCD line is `#early_input=<len>`. If so, it reads <len> bytes
         // of raw data and then reads the next line as the module name.
         if let Some(data) = read_early_input(&line, &mut reader)? {
@@ -409,7 +409,7 @@ const EARLY_INPUT_MAX_SIZE: usize = 5120;
 /// data was read successfully, `Ok(None)` when the line is not an early-input
 /// command, or an I/O error if reading fails or the length is invalid.
 ///
-/// upstream: clientserver.c:1357-1364 - `rsync_module()` reads early input data
+/// upstream: clientserver.c:1407-1414 - `rsync_module()` reads early input data
 /// and stores it for later delivery to the pre-xfer exec script.
 fn read_early_input(line: &str, reader: &mut impl Read) -> io::Result<Option<Vec<u8>>> {
     let len_str = match line.strip_prefix(EARLY_INPUT_CMD) {

--- a/crates/daemon/src/daemon/sections/stdio_session.rs
+++ b/crates/daemon/src/daemon/sections/stdio_session.rs
@@ -1,11 +1,11 @@
 // Stdio daemon session - runs a single daemon session over stdin/stdout.
 //
-// upstream: main.c:1843-1844 - when both `am_server` and `am_daemon` are set,
+// upstream: main.c:1867-1868 - when both `am_server` and `am_daemon` are set,
 // upstream rsync calls `start_daemon(STDIN_FILENO, STDOUT_FILENO)`. This runs
 // the daemon protocol over the process's stdin and stdout, used by remote-shell
 // daemon mode (`rsync -e ssh host::module`) and by `RSYNC_CONNECT_PROG`.
 //
-// upstream: clientserver.c:1496-1509 - `daemon_main()` detects
+// upstream: clientserver.c:1546-1559 - `daemon_main()` detects
 // `is_a_socket(STDIN_FILENO)` for inetd-style invocations and calls
 // `start_daemon(STDIN_FILENO, STDIN_FILENO)`.
 
@@ -51,7 +51,7 @@ pub fn run_stdio_session(
     }
 
     // When no --config was given, search for a config file.
-    // upstream: clientserver.c:1263-1267 - load_config() uses RSYNCD_USERCONF
+    // upstream: clientserver.c:1277-1281 - load_config() uses RSYNCD_USERCONF
     // ("rsyncd.conf" relative to CWD) for rsh-daemon non-root invocations,
     // and RSYNCD_SYSCONF ("/etc/rsyncd.conf") otherwise.
     if !has_explicit_config {
@@ -106,7 +106,7 @@ pub fn run_stdio_session(
     let pair = crate::daemon_stream::StdioPair::new(Box::new(stdin), Box::new(stdout));
     let stream = DaemonStream::stdio(pair);
 
-    // upstream: clientserver.c:1286-1287 - for rsh-daemon, am_daemon is set
+    // upstream: clientserver.c:1300-1301 - for rsh-daemon, am_daemon is set
     // to -1 as a flag distinguishing it from a network daemon. We use a
     // loopback address as the synthetic peer for log messages and access checks.
     let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -274,7 +274,7 @@ fn is_option_refused_re_refuse_after_negation() {
 
 #[test]
 fn is_option_refused_short_letter_rule_matches_long_option() {
-    // upstream: options.c:909-921 `parse_one_refuse_match` compares each rule
+    // upstream: options.c:921-933 `parse_one_refuse_match` compares each rule
     // against BOTH `op->longName` and `op->shortName`. A `!v` rule must
     // un-refuse the same option that `!verbose` would, so allow-list
     // configurations that use short-letter shorthands behave the same as
@@ -286,7 +286,7 @@ fn is_option_refused_short_letter_rule_matches_long_option() {
 
 #[test]
 fn is_option_refused_archive_rule_expands_to_short_letter_set() {
-    // upstream: options.c:904-906 - the `archive` (and `a`) rules expand to
+    // upstream: options.c:916-918 - the `archive` (and `a`) rules expand to
     // the character class `[ardlptgoD]` and so refuse every short letter that
     // `-a` implies, not just the `--archive` long name.
     let module = module_with_refuse(vec!["archive".to_owned()]);
@@ -298,7 +298,7 @@ fn is_option_refused_archive_rule_expands_to_short_letter_set() {
 
 #[test]
 fn is_option_refused_pure_allowlist_does_not_refuse_anything() {
-    // upstream: options.c:947-968 - every option starts marked as accepted
+    // upstream: options.c:959-980 - every option starts marked as accepted
     // (`a*` or `a=`). A refuse list of only negations therefore touches
     // nothing - no option flips to refused. Sanity-check the obvious cases.
     let module = module_with_refuse(vec!["!verbose".to_owned(), "!archive".to_owned()]);
@@ -381,7 +381,7 @@ fn wildcard_all_spares_vital_log_format_but_refuses_out_format() {
 
 #[test]
 fn exact_rule_refuses_vital_log_format() {
-    // upstream: options.c:909-940 - a non-wild exact rule still marks a vital
+    // upstream: options.c:921-952 - a non-wild exact rule still marks a vital
     // option refused, so `refuse options = log-format` rejects `--log-format`.
     let module = module_with_refuse(vec!["log-format".to_owned()]);
     assert_eq!(
@@ -487,7 +487,7 @@ fn refused_client_arg_allowlist_module_passes_bundled_av() {
     // refuse-list matcher; upstream rsync flips each option's `descrip` back
     // to "accepted" once the explicit `!verbose` / `!archive` rule lands.
     //
-    // upstream: options.c:977-991 - rules are processed in order and the last
+    // upstream: options.c:989-1003 - rules are processed in order and the last
     // match wins; the negated rule after the catch-all wildcard un-refuses
     // both the long-form name and its short-letter alias.
     let module = ModuleDefinition {
@@ -506,7 +506,7 @@ fn refused_client_arg_allowlist_module_passes_bundled_av() {
 
 #[test]
 fn refused_client_arg_allowlist_short_letter_negation_passes_av() {
-    // upstream: options.c:909-921 - `parse_one_refuse_match` matches each
+    // upstream: options.c:921-933 - `parse_one_refuse_match` matches each
     // rule against both `op->longName` and `op->shortName`. A short-letter
     // allow-list `!v !a` therefore un-refuses the same options that
     // `!verbose !archive` would. Pinning this behaviour prevents a relapse of
@@ -524,7 +524,7 @@ fn refused_client_arg_allowlist_short_letter_negation_passes_av() {
 fn refused_client_arg_pure_negation_allowlist_passes_av() {
     // A pure-negation refuse list never marks anything as refused (nothing
     // was refused to begin with), so an `-av` transfer must succeed.
-    // upstream: options.c:947-968 - every option starts as `a*`/`a=`
+    // upstream: options.c:959-980 - every option starts as `a*`/`a=`
     // (accepted); only explicit non-negated rules flip the descrip to
     // `r*`/`r=`.
     let module = ModuleDefinition {
@@ -667,7 +667,7 @@ fn refused_client_arg_delete_rule_allows_non_delete_transfer() {
 fn refused_client_arg_delete_negation_clears_semantic_refusal() {
     // `refuse options = !delete` un-refuses the `delete` entry, so the
     // semantic delete-mode pass must not fire. With no other refuse rule a
-    // bare `--delete` transfer is allowed. upstream: options.c:977-991 - the
+    // bare `--delete` transfer is allowed. upstream: options.c:989-1003 - the
     // negated rule flips the `delete` descrip back to accepted, clearing
     // `refused_delete`, so options.c:2238 never triggers.
     let module = ModuleDefinition {
@@ -680,7 +680,7 @@ fn refused_client_arg_delete_negation_clears_semantic_refusal() {
 
 #[test]
 fn refused_client_arg_archive_rule_refuses_implied_short_letters() {
-    // upstream: options.c:904-906 - the `archive` rule rewrites itself to the
+    // upstream: options.c:916-918 - the `archive` rule rewrites itself to the
     // character class `[ardlptgoD]`. A module configured with
     // `refuse options = archive` must therefore reject `-r`, `-l`, `-D`, etc.
     // (and not just `--archive` itself).

--- a/crates/daemon/src/daemon/sections/xfer_exec.rs
+++ b/crates/daemon/src/daemon/sections/xfer_exec.rs
@@ -94,7 +94,7 @@ fn build_pre_xfer_command(command: &str, ctx: &XferExecContext<'_>) -> ProcessCo
 /// Builds the post-xfer exec environment: the shared base only.
 ///
 /// The caller adds `RSYNC_EXIT_STATUS` (and, on Unix, `RSYNC_RAW_STATUS`).
-/// upstream: clientserver.c:915-930 - the post-xfer parent sets only the shared
+/// upstream: clientserver.c:917-932 - the post-xfer parent sets only the shared
 /// env plus the status variables; it never sets `RSYNC_REQUEST` or
 /// `RSYNC_ARG<n>`, so a post-xfer hook must not see them.
 fn build_post_xfer_command(command: &str, ctx: &XferExecContext<'_>) -> ProcessCommand {
@@ -205,7 +205,7 @@ fn run_pre_xfer_exec(
     let mut child = cmd.spawn()?;
 
     // Pipe early-input data to the child's stdin, then close it.
-    // upstream: clientserver.c:583-584 - write_buf(write_fd, early_input, early_input_len)
+    // upstream: clientserver.c:585-586 - write_buf(write_fd, early_input, early_input_len)
     if let Some(data) = early_input {
         if let Some(mut stdin) = child.stdin.take() {
             // Best-effort write; ignore broken pipe if the child exits early.

--- a/crates/daemon/src/daemon_stream.rs
+++ b/crates/daemon/src/daemon_stream.rs
@@ -7,7 +7,7 @@
 //!
 //! The `Stdio` variant supports the `--server --daemon` remote-shell daemon
 //! mode where stdin/stdout are used instead of a TCP socket.
-//! upstream: main.c:1843-1844 - `if (am_server && am_daemon)
+//! upstream: main.c:1867-1868 - `if (am_server && am_daemon)
 //! return start_daemon(STDIN_FILENO, STDOUT_FILENO);`
 
 use std::io::{self, Read, Write};

--- a/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
+++ b/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
@@ -5,11 +5,11 @@
 // drift breaks downstream classification. Each row pins one upstream
 // citation to its oc-rsync constant.
 //
-// upstream: clientserver.c:647,656,730,733,748,752,762,783,981,1010,1017,1039
+// upstream: clientserver.c:649,658,732,735,750,754,764,785,985,1024,1031,1053
 
 #[test]
 fn daemon_error_payloads_match_upstream_wording() {
-    // upstream: clientserver.c:730 - `@ERROR: Unknown module '%s'\n`
+    // upstream: clientserver.c:732 - `@ERROR: Unknown module '%s'\n`
     assert_eq!(
         crate::daemon::UNKNOWN_MODULE_PAYLOAD,
         "@ERROR: Unknown module '{module}'",
@@ -21,67 +21,67 @@ fn daemon_error_payloads_match_upstream_wording() {
         "@ERROR: Unknown command '{command}'",
     );
 
-    // upstream: clientserver.c:733-734 - `@ERROR: access denied to %s from %s (%s)\n`
+    // upstream: clientserver.c:735-736 - `@ERROR: access denied to %s from %s (%s)\n`
     assert_eq!(
         crate::daemon::ACCESS_DENIED_PAYLOAD,
         "@ERROR: access denied to {module} from {host} ({addr})",
     );
 
-    // upstream: clientserver.c:748 - `@ERROR: failed to open lock file\n`
+    // upstream: clientserver.c:750 - `@ERROR: failed to open lock file\n`
     assert_eq!(
         crate::daemon::MODULE_LOCK_ERROR_PAYLOAD,
         "@ERROR: failed to open lock file",
     );
 
-    // upstream: clientserver.c:752 - `@ERROR: max connections (%d) reached -- try again later\n`
+    // upstream: clientserver.c:754 - `@ERROR: max connections (%d) reached -- try again later\n`
     assert_eq!(
         crate::daemon::MODULE_MAX_CONNECTIONS_PAYLOAD,
         "@ERROR: max connections ({limit}) reached -- try again later",
     );
 
-    // upstream: clientserver.c:762 - `@ERROR: auth failed on module %s\n`
+    // upstream: clientserver.c:764 - `@ERROR: auth failed on module %s\n`
     assert_eq!(
         crate::daemon::AUTH_FAILED_PAYLOAD,
         "@ERROR: auth failed on module {module}",
     );
 
-    // upstream: clientserver.c:981 - `@ERROR: chroot failed\n`
+    // upstream: clientserver.c:985 - `@ERROR: chroot failed\n`
     assert_eq!(
         crate::daemon::CHROOT_FAILED_PAYLOAD,
         "@ERROR: chroot failed",
     );
 
-    // upstream: clientserver.c:647 - `@ERROR: chdir failed\n`
+    // upstream: clientserver.c:649 - `@ERROR: chdir failed\n`
     assert_eq!(
         crate::daemon::CHDIR_FAILED_PAYLOAD,
         "@ERROR: chdir failed",
     );
 
-    // upstream: clientserver.c:1039 - `@ERROR: setuid failed\n`
+    // upstream: clientserver.c:1053 - `@ERROR: setuid failed\n`
     assert_eq!(
         crate::daemon::SETUID_FAILED_PAYLOAD,
         "@ERROR: setuid failed",
     );
 
-    // upstream: clientserver.c:1010 - `@ERROR: setgid failed\n`
+    // upstream: clientserver.c:1024 - `@ERROR: setgid failed\n`
     assert_eq!(
         crate::daemon::SETGID_FAILED_PAYLOAD,
         "@ERROR: setgid failed",
     );
 
-    // upstream: clientserver.c:1017 - `@ERROR: setgroups failed\n`
+    // upstream: clientserver.c:1031 - `@ERROR: setgroups failed\n`
     assert_eq!(
         crate::daemon::SETGROUPS_FAILED_PAYLOAD,
         "@ERROR: setgroups failed",
     );
 
-    // upstream: clientserver.c:783 - `@ERROR: invalid uid %s\n`
+    // upstream: clientserver.c:785 - `@ERROR: invalid uid %s\n`
     assert_eq!(
         crate::daemon::INVALID_UID_PAYLOAD,
         "@ERROR: invalid uid {uid}",
     );
 
-    // upstream: clientserver.c:656 - `@ERROR: invalid gid %s\n`
+    // upstream: clientserver.c:658 - `@ERROR: invalid gid %s\n`
     assert_eq!(
         crate::daemon::INVALID_GID_PAYLOAD,
         "@ERROR: invalid gid {gid}",
@@ -139,7 +139,7 @@ fn send_error_framing_matches_upstream() {
 /// `@ERROR: Unknown module` instead of `@ERROR: access denied`,
 /// matching upstream's `list = false` behaviour.
 ///
-/// upstream: clientserver.c:729-735 - when `!lp_list(i)`, the daemon hides
+/// upstream: clientserver.c:731-737 - when `!lp_list(i)`, the daemon hides
 /// the module's existence by reporting it as unknown.
 #[test]
 fn deny_hidden_module_sends_unknown_module_error() {

--- a/crates/daemon/src/tests/chunks/daemon_munge_symlinks_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_munge_symlinks_pull.rs
@@ -57,7 +57,7 @@ fn daemon_munge_symlinks_pull_strips_prefix() {
     unix_fs::symlink("/rsyncd-munged/../escape", source_dir.join("parent_link"))
         .expect("create parent_link");
 
-    // upstream: flist.c:222 - targets that lack the prefix pass through
+    // upstream: flist.c:234 - targets that lack the prefix pass through
     // unchanged via the `llen > SYMLINK_PREFIX_LEN && strncmp(...) == 0`
     // guard. Cover that branch alongside the strip path.
     unix_fs::symlink("already_unmunged", source_dir.join("bare_link"))
@@ -113,7 +113,7 @@ fn daemon_munge_symlinks_pull_strips_prefix() {
         std::path::Path::new("/etc/passwd"),
         "daemon sender must strip the `/rsyncd-munged/` prefix before writing \
          the wire entry so the client receives the original absolute target \
-         (upstream flist.c:222-226)",
+         (upstream flist.c:234-238)",
     );
 
     let rel_link = fs::read_link(dest_dir.join("rel_link")).expect("read rel_link target");

--- a/crates/daemon/src/tests/chunks/daemon_munge_symlinks_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_munge_symlinks_push.rs
@@ -99,7 +99,7 @@ fn daemon_munge_symlinks_push_prepends_prefix() {
         std::path::Path::new("/rsyncd-munged//etc/passwd"),
         "absolute targets must carry the `/rsyncd-munged/` prefix verbatim \
          so the kernel cannot follow them out of the module root \
-         (upstream flist.c:1122-1126)",
+         (upstream flist.c:1150-1154)",
     );
 
     let rel_link = fs::read_link(dest_dir.join("rel_link")).expect("read rel_link target");

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_authentication.rs
@@ -188,7 +188,7 @@ fn daemon_negotiation_auth_denies_wrong_password() {
         .expect("send wrong credentials");
     stream.flush().expect("flush");
 
-    // upstream: clientserver.c:762 - auth failure sends
+    // upstream: clientserver.c:764 - auth failure sends
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("response");
@@ -280,7 +280,7 @@ fn daemon_negotiation_auth_denies_unknown_user() {
         .expect("send unknown user");
     stream.flush().expect("flush");
 
-    // upstream: clientserver.c:762 - auth failure sends
+    // upstream: clientserver.c:764 - auth failure sends
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("response");
@@ -428,7 +428,7 @@ fn daemon_negotiation_auth_denies_empty_credentials() {
         .expect("send empty credentials");
     stream.flush().expect("flush");
 
-    // upstream: clientserver.c:762 - auth failure sends
+    // upstream: clientserver.c:764 - auth failure sends
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("response");

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_empty_module_lists_modules.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_empty_module_lists_modules.rs
@@ -37,7 +37,7 @@ fn daemon_negotiation_empty_module_lists_modules() {
     reader.read_line(&mut line).expect("greeting");
     assert_eq!(line, expected_greeting);
 
-    // Send only a bare newline. upstream: clientserver.c:1373 treats this
+    // Send only a bare newline. upstream: clientserver.c:1423 treats this
     // as equivalent to `#list`.
     stream.write_all(b"\n").expect("send empty request");
     stream.flush().expect("flush empty request");

--- a/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs
@@ -88,7 +88,7 @@ fn run_daemon_auth_failure_rejects_wrong_credentials() {
         .expect("send wrong credentials");
     stream.flush().expect("flush wrong credentials");
 
-    // upstream: clientserver.c:762 - auth failure sends
+    // upstream: clientserver.c:764 - auth failure sends
     // "@ERROR: auth failed on module %s\n"
     line.clear();
     reader.read_line(&mut line).expect("denied message");

--- a/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_denies_module_when_host_not_allowed.rs
@@ -46,7 +46,7 @@ fn run_daemon_denies_module_when_host_not_allowed() {
     stream.write_all(b"docs\n").expect("send module request");
     stream.flush().expect("flush module request");
 
-    // upstream: clientserver.c:733 - access denied sends
+    // upstream: clientserver.c:735 - access denied sends
     // "@ERROR: access denied to %s from %s (%s)\n" with (name, host, addr)
     // The host may be resolved to "localhost" or remain as "127.0.0.1"
     // depending on the system's DNS configuration.

--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_module_connection_limit.rs
@@ -110,7 +110,7 @@ fn run_daemon_enforces_module_connection_limit() {
     first_reader
         .read_line(&mut line)
         .expect("first denial message");
-    // upstream: clientserver.c:762 - auth failure uses
+    // upstream: clientserver.c:764 - auth failure uses
     // "@ERROR: auth failed on module %s\n"
     assert!(line.starts_with("@ERROR: auth failed on module"));
 

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_module_timeout.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_module_timeout.rs
@@ -6,8 +6,8 @@
 /// # Why this matters
 ///
 /// Upstream applies a module's timeout only *after* a module has been
-/// selected (`clientserver.c:1192` sets the io timeout against the chosen
-/// `module_id`). The module listing (`clientserver.c:1373`,
+/// selected (`clientserver.c:1206` sets the io timeout against the chosen
+/// `module_id`). The module listing (`clientserver.c:1423`,
 /// `send_listing()`) runs *before* any module is selected, so a per-module
 /// timeout must neither gate nor block the pre-selection listing path. A
 /// naive implementation that armed the module read/write timeout before
@@ -43,7 +43,7 @@ fn run_daemon_lists_modules_with_module_timeout() {
     reader.read_line(&mut line).expect("greeting");
     assert_eq!(line, expected_greeting);
 
-    // upstream: clientserver.c:1373 - an empty request lists modules.
+    // upstream: clientserver.c:1423 - an empty request lists modules.
     stream.write_all(b"\n").expect("send empty request");
     stream.flush().expect("flush empty request");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
@@ -1,6 +1,6 @@
 /// Regression test for the post-`@RSYNCD: OK` refused-options wire shape.
 ///
-/// upstream: clientserver.c:1146-1186 - once the daemon has acknowledged
+/// upstream: clientserver.c:1160-1200 - once the daemon has acknowledged
 /// the module, the multiplex framing on the client side starts
 /// immediately after `setup_protocol()` completes. Refused options
 /// detected by `parse_arguments()` flow through `rwrite(FERROR, ...)`,

--- a/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
@@ -3,7 +3,7 @@
 /// the module child and runs the hook regardless of outcome, so a refused push
 /// (child exits `RERR_SYNTAX`) fires the hook with `RSYNC_EXIT_STATUS=1`.
 ///
-/// upstream: clientserver.c:906-931 - post-xfer exec runs after the child exits
+/// upstream: clientserver.c:908-933 - post-xfer exec runs after the child exits
 /// for any reason; main.c:1166-1169 - the read-only push child exits
 /// `RERR_SYNTAX` (1). Regression guard for the daemon skipping the hook on the
 /// refuse early-return path.

--- a/crates/daemon/src/tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_sends_motd_before_unknown_module_error.rs
@@ -54,7 +54,7 @@ fn run_daemon_sends_motd_before_unknown_module_error() {
     reader.read_line(&mut line).expect("motd trailing blank");
     assert_eq!(line, "\n");
 
-    // upstream: clientserver.c:730 - "@ERROR: Unknown module '%s'\n"
+    // upstream: clientserver.c:732 - "@ERROR: Unknown module '%s'\n"
     line.clear();
     reader.read_line(&mut line).expect("error message");
     assert_eq!(line, "@ERROR: Unknown module 'nosuchmod'\n");


### PR DESCRIPTION
## Summary

Relines the `// upstream: <file>.c:<line>` source citations in the `daemon`
crate that were pinned to rsync 3.4.1 line numbers. The referenced code has
drifted in the current source of truth, rsync 3.4.4, after upstream inserted
lines into `clientserver.c`, `options.c`, `main.c`, `flist.c`, and `io.c`.

The largest source of drift is `clientserver.c`, which grew ~50 lines
(1538 -> 1588) between 3.4.1 and 3.4.4 - concentrated in `rsync_module()` and
the new daemon chroot / reverse-DNS-lookup blocks - so most daemon citations
into that file needed relining.

## Method

Every citation was relocated by locating the referenced code in the 3.4.4 C
source (quoted `@ERROR:` strings, function names, variables) rather than by
arithmetic offsetting, then cross-checked against 3.4.1 to confirm the
direction of drift. Citations that already matched 3.4.4 were left untouched;
a handful that could not be confidently relocated (wrong-file references or
paraphrases with no single anchor line) were left unchanged.

## Scope

- 40 files, 173 line-for-line replacements.
- Comment-only: every changed line differs from its original by digits alone -
  no code, wording, or formatting was touched.
- Verified: `cargo fmt -p daemon -- --check` passes.

## Fixed upstream files

`clientserver.c`, `options.c`, `main.c`, `flist.c`, `io.c`. Citations to stable
files (`exclude.c`, `delete.c`, `log.c`, `socket.c`, `util*.c`, etc.) were left
as-is.
