### PR TITLE
docs(transfer): reline drifted upstream citations to rsync 3.4.4

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -155,7 +155,7 @@ impl GeneratorContext {
         config: ServerConfig,
         pipeline: TransferPipeline,
     ) -> Self {
-        // upstream: flist.c:2923 - ndx_start = inc_recurse ? 1 : 0
+        // upstream: flist.c:2958 - ndx_start = inc_recurse ? 1 : 0
         let inc_recurse = handshake
             .compat_flags
             .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
@@ -251,7 +251,7 @@ impl GeneratorContext {
         let segments = &self.incremental.ndx_segments;
         // A gap NDX `g` satisfies `g + 1 == ndx_start` for exactly one sub-list;
         // no regular entry's NDX can equal a sub-list start minus one (the +1
-        // gap is reserved, flist.c:2931). Binary search is valid because
+        // gap is reserved, flist.c:2966). Binary search is valid because
         // `ndx_start` values are strictly increasing.
         if let Ok(seg_idx) =
             segments.binary_search_by(|&(_, ndx_start)| ndx_start.cmp(&(wire_ndx + 1)))
@@ -275,7 +275,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:2321` - `ndx = i + cur_flist->ndx_start`
+    /// - `generator.c:2338` - `ndx = i + cur_flist->ndx_start`
     #[cfg(test)]
     pub(crate) fn flat_to_wire_ndx(&self, flat_idx: usize) -> i32 {
         let segments = &self.incremental.ndx_segments;
@@ -477,11 +477,11 @@ impl GeneratorContext {
     ///
     /// The activation threshold differs by mode:
     ///
-    /// **Server mode** (daemon sender - `main.c:1252-1257` `start_server am_sender`):
+    /// **Server mode** (daemon sender - `main.c:1270-1275` `start_server am_sender`):
     /// - For protocol >= 30, `need_messages_from_generator = 1` (compat.c:776)
     /// - `if (need_messages_from_generator) io_start_multiplex_in(f_in);`
     ///
-    /// **Client mode** (client pushing to daemon - `main.c:1304-1305` `client_run am_sender`):
+    /// **Client mode** (client pushing to daemon - `main.c:1322-1323` `client_run am_sender`):
     /// - `if (protocol_version >= 31 || (!filesfrom_host && protocol_version >= 23))`
     /// - We don't support filesfrom, so this simplifies to >= 23
     ///
@@ -787,8 +787,8 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2945 flist_free()` - frees completed file list segments
-    /// - `sender.c:244` - `flist_free(first_flist)` in sender transfer loop
+    /// - `flist.c:2980 flist_free()` - frees completed file list segments
+    /// - `sender.c:248` - `flist_free(first_flist)` in sender transfer loop
     pub(crate) fn reclaim_oldest_segment(&mut self) {
         let segments = &self.incremental.ndx_segments;
         let first = self.incremental.first_segment_idx;

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -163,8 +163,8 @@ impl GeneratorContext {
             #[cfg(not(unix))]
             let mode = 0o755;
 
-            // upstream: flist.c:1465 - `file->len32 = (uint32)st.st_size` runs for
-            // every entry; only devices/specials are zeroed (flist.c:1452-1454).
+            // upstream: flist.c:1501 - `file->len32 = (uint32)st.st_size` runs for
+            // every entry; only devices/specials are zeroed (flist.c:1484-1486).
             // Directories therefore carry their on-disk inode size on the wire,
             // which feeds `--list-only`, `%l`, and the `--stats` total.
             let mut entry = FileEntry::new_directory(relative_path, mode);
@@ -209,7 +209,7 @@ impl GeneratorContext {
             // re-applies the prefix when the link is materialized on disk.
             let target = strip_symlink_munge_prefix(self.config.munge_symlinks, raw_target);
 
-            // upstream: flist.c:1465 - symlinks carry `st_size`, which lstat
+            // upstream: flist.c:1501 - symlinks carry `st_size`, which lstat
             // reports as the byte length of the link target. The receiver gets
             // the target separately, so this length is purely the size shown by
             // `--list-only`/`%l` and summed into the `--stats` total.
@@ -299,7 +299,7 @@ impl GeneratorContext {
                 .as_ref()
                 .map_or_else(|| metadata.uid(), |s| s.uid);
             entry.set_uid(uid);
-            // upstream: flist.c:466-470 - add_uid() looks up name for inline
+            // upstream: flist.c:478-482 - add_uid() looks up name for inline
             // sending via XMIT_USER_NAME_FOLLOWS when INC_RECURSE is active.
             // Without names, the receiver can't map uid->name on the remote.
             if self.config.flags.numeric_ids.is_off() {
@@ -316,7 +316,7 @@ impl GeneratorContext {
                 .as_ref()
                 .map_or_else(|| metadata.gid(), |s| s.gid);
             entry.set_gid(gid);
-            // upstream: flist.c:476-480 - add_gid() looks up name for inline
+            // upstream: flist.c:488-492 - add_gid() looks up name for inline
             // sending via XMIT_GROUP_NAME_FOLLOWS when INC_RECURSE is active.
             if self.config.flags.numeric_ids.is_off() {
                 if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_group_name_cached(gid) {
@@ -1261,11 +1261,11 @@ mod windows_reparse_tests {
 mod entry_length_tests {
     //! `F_LENGTH` parity regression for directory and symlink entries.
     //!
-    //! upstream: flist.c:1465 - `file->len32 = (uint32)st.st_size` runs for
-    //! every entry type; only devices and specials are zeroed at flist.c:1452
-    //! and flist.c:1454. Directories therefore carry their on-disk inode size
+    //! upstream: flist.c:1501 - `file->len32 = (uint32)st.st_size` runs for
+    //! every entry type; only devices and specials are zeroed at flist.c:1484
+    //! and flist.c:1486. Directories therefore carry their on-disk inode size
     //! and symlinks carry `st_size` (the target byte length). That field is
-    //! summed into the `--stats` "Total file size" total at flist.c:679 and
+    //! summed into the `--stats` "Total file size" total at flist.c:691 and
     //! rendered by `--list-only` and `%l`, so emitting 0 here would diverge
     //! from upstream's observable output byte-for-byte.
 
@@ -1322,7 +1322,7 @@ mod entry_length_tests {
         assert_eq!(
             entry.size(),
             meta.len(),
-            "directory F_LENGTH must mirror st_size (upstream flist.c:1465), \
+            "directory F_LENGTH must mirror st_size (upstream flist.c:1501), \
              not the hardcoded 0 from FileEntry::new_directory",
         );
     }

--- a/crates/transfer/src/generator/file_list/entry/munge.rs
+++ b/crates/transfer/src/generator/file_list/entry/munge.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 /// Strips the `/rsyncd-munged/` prefix from a symlink target when munging is active.
 ///
-/// Mirrors upstream `flist.c:222-226`: when the daemon module has
+/// Mirrors upstream `flist.c:234-238`: when the daemon module has
 /// `munge symlinks = yes`, the sender restores the original target before it
 /// is encoded onto the wire so the receiver can reapply the prefix on its
 /// side. The receiver-side write path uses the matching
@@ -22,7 +22,7 @@ pub(super) fn strip_symlink_munge_prefix(munge_symlinks: bool, target: PathBuf) 
         return target;
     }
     let prefix_len = ::metadata::SYMLINK_MUNGE_PREFIX.len();
-    // upstream: flist.c:222 - the strncmp guard requires `llen > SYMLINK_PREFIX_LEN`,
+    // upstream: flist.c:234 - the strncmp guard requires `llen > SYMLINK_PREFIX_LEN`,
     // so a target consisting of exactly the prefix is left untouched.
     #[cfg(unix)]
     {
@@ -78,7 +78,7 @@ mod munge_strip_tests {
 
     #[test]
     fn does_not_strip_exact_prefix_match() {
-        // upstream: flist.c:222 - `llen > SYMLINK_PREFIX_LEN` is strict, so a
+        // upstream: flist.c:234 - `llen > SYMLINK_PREFIX_LEN` is strict, so a
         // target whose entire content is the prefix is left untouched. Without
         // the strict check we would emit an empty target onto the wire and
         // diverge from upstream byte-for-byte.

--- a/crates/transfer/src/generator/file_list/hardlinks.rs
+++ b/crates/transfer/src/generator/file_list/hardlinks.rs
@@ -85,7 +85,7 @@ impl GeneratorContext {
     pub fn collect_id_mappings(&mut self) {
         use metadata::id_lookup::{lookup_group_name_cached, lookup_user_name_cached};
 
-        // upstream: flist.c:478 gates add_uid()/add_gid() on `!numeric_ids`, so
+        // upstream: flist.c:490 gates add_uid()/add_gid() on `!numeric_ids`, so
         // the id-list is populated only when names are active (`numeric_ids ==
         // 0`). Both daemon-forced and explicit numeric-ids leave it empty.
         if self.config.flags.numeric_ids.maps_numeric() {

--- a/crates/transfer/src/generator/file_list/iconv.rs
+++ b/crates/transfer/src/generator/file_list/iconv.rs
@@ -11,7 +11,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `flist.c:1614-1638` `send_file1()` - strict `ic_send` conversion + skip.
+//! - `flist.c:1650-1674` `send_file1()` - strict `ic_send` conversion + skip.
 //! - `flist.c:757` `recv_file_entry()` - the receiver mirrors this.
 
 use protocol::CompatibilityFlags;
@@ -35,7 +35,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:1631` `send_file1()` - name failure: `rprintf(FERROR_XFER,
+    /// - `flist.c:1667` `send_file1()` - name failure: `rprintf(FERROR_XFER,
     ///   "[%s] cannot convert filename: %s (%s)\n", ...)` then `return NULL`.
     /// - `flist.c:1642-1651` `send_file1()` - symlink-target failure (guarded by
     ///   `symlink_len && sender_symlink_iconv`): `rprintf(FERROR_XFER, "[%s]
@@ -177,7 +177,7 @@ mod drop_decision_tests {
     }
 
     /// An unconvertible NAME is always a drop cause, independent of the symlink
-    /// gate. upstream: flist.c:1631 `return NULL`.
+    /// gate. upstream: flist.c:1667 `return NULL`.
     #[test]
     fn unconvertible_name_always_dropped() {
         let conv = latin1_converter();

--- a/crates/transfer/src/generator/file_list/inc_recurse.rs
+++ b/crates/transfer/src/generator/file_list/inc_recurse.rs
@@ -12,7 +12,7 @@
 //! 2. For each sub-list (received in depth-first order): dirs in that sub-list
 //!
 //! Our `parent_dir_ndx` values in `PendingSegment` must match these indices
-//! exactly, or the receiver's dirname validation at `flist.c:2652-2659` will
+//! exactly, or the receiver's dirname validation at `flist.c:2687-2694` will
 //! reject entries with "ABORTING due to invalid path from sender".
 //!
 //! # Upstream Reference

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `flist.c:2192` - `send_file_list()` main file list builder
+//! - `flist.c:2227` - `send_file_list()` main file list builder
 //! - `flist.c:1456` - `send_file_entry()` per-file encoding
 //! - `hlink.c:match_hard_links()` - post-sort hardlink index assignment
 
@@ -67,7 +67,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2192` - `send_file_list()` - Main file list builder
+    /// - `flist.c:2227` - `send_file_list()` - Main file list builder
     /// - `flist.c:1456` - `send_file_entry()` - Per-file encoding
     ///
     /// Mirrors upstream recursive directory scanning and file list construction behavior.
@@ -117,7 +117,7 @@ impl GeneratorContext {
             // --no-implied-dirs. At protocol < 30 the flag is honoured
             // (flist.c:2468 `else if (implied_dirs && ...)`), so
             // --no-implied-dirs omits the implied parents from the flist and the
-            // receiver recreates them via make_path (generator.c:1317) without
+            // receiver recreates them via make_path (generator.c:1329) without
             // their source metadata. Mirror both: emit when implied dirs are on
             // OR the protocol forces them.
             if relative_paths && (!self.config.flags.no_implied_dirs || self.protocol.as_u8() >= 30)
@@ -183,7 +183,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2240-2264` - `change_dir(argv[0])` then read relative filenames
+    /// - `flist.c:2275-2299` - `change_dir(argv[0])` then read relative filenames
     /// - `flist.c:2316-2330` - per-entry `/./` anchor split
     /// - `flist.c:2368-2419` - `implied_dot_dir` gates the transfer-root `.`
     ///   emission via `send_file_name(".", ..., FLAG_IMPLIED_DIR & ~FLAG_CONTENT_DIR, ...)`
@@ -283,7 +283,7 @@ impl GeneratorContext {
         // protocol >= 30 regardless of --no-implied-dirs; at protocol < 30 the
         // flag is honoured (flist.c:2468 `else if (implied_dirs && ...)`), so
         // --no-implied-dirs omits the implied parents from the --files-from
-        // flist and the receiver recreates them via make_path (generator.c:1317)
+        // flist and the receiver recreates them via make_path (generator.c:1329)
         // without their source metadata. Mirror the same gate as the positional
         // path (build_file_list): emit only in relative mode, and then when
         // implied dirs are on OR the protocol forces them. When suppressed,
@@ -327,7 +327,7 @@ impl GeneratorContext {
         // Directories emitted purely as implied parents of some other entry
         // (i.e. not also listed explicitly in --files-from). The top-level
         // walk skips these so we do not produce a duplicate file-list entry
-        // that upstream's `implied_filter_list` check (flist.c:998) would
+        // that upstream's `implied_filter_list` check (flist.c:1026) would
         // reject as "unrequested". Explicit --files-from dirs remain walkable
         // so their recursive contents continue to flow normally.
         let implied_only_dirs: HashSet<(PathBuf, PathBuf)> =
@@ -425,7 +425,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:1901-1980` - `send_implied_dirs()`
+    /// - `flist.c:1937-2016` - `send_implied_dirs()`
     /// - `generator.c:1300-1315` - parent dir presence check
     fn emit_implied_parents(
         &mut self,
@@ -456,7 +456,7 @@ impl GeneratorContext {
                 continue;
             }
             let full = base.join(&relative_ancestor);
-            // upstream: flist.c:1949 - `copy_links = 1` is set before
+            // upstream: flist.c:1985 - `copy_links = 1` is set before
             // emitting implied parents, so stat() follows symlinks. On
             // macOS /var is a symlink to /private/var; using
             // symlink_metadata would skip it (is_dir() false for a
@@ -492,7 +492,7 @@ impl GeneratorContext {
 /// The returned `base` is what `walk_path` strips from each child path to
 /// compute its wire-side relative name.
 fn relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
-    // upstream: flist.c:2316 - `if ((p = strstr(fbuf, "/./")) != NULL)`
+    // upstream: flist.c:2351 - `if ((p = strstr(fbuf, "/./")) != NULL)`
     if let Some(anchor) = find_dot_dir_anchor(path) {
         let path_str = path.as_os_str().to_string_lossy();
         let (head, tail) = path_str.split_at(anchor);

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -56,7 +56,7 @@ impl GeneratorContext {
     /// children of the same directory still reach the receiver via their own
     /// top-level walks, and re-walking here would produce a duplicate parent
     /// entry that upstream's `implied_filter_list` check rejects with
-    /// "rejecting unrequested file-list name" (flist.c:998).
+    /// "rejecting unrequested file-list name" (flist.c:1026).
     ///
     /// `emitted_dirs` is `Some` only from `build_file_list_with_base`, which
     /// passes the set of directories already emitted by its implied-parent
@@ -65,9 +65,9 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:998` - `check_filter(&implied_filter_list, ...)` rejects
+    /// - `flist.c:1026` - `check_filter(&implied_filter_list, ...)` rejects
     ///   second occurrences as "unrequested file-list name".
-    /// - `flist.c:1901` - `send_implied_dirs()` is upstream's equivalent
+    /// - `flist.c:1937` - `send_implied_dirs()` is upstream's equivalent
     ///   single emission point for the same logical directory.
     pub(in crate::generator) fn try_walk_source_entry_dedup(
         &mut self,
@@ -80,7 +80,7 @@ impl GeneratorContext {
         // exclude.c add_rule XFLG_ANCHORED2ABS). Idempotent across source
         // entries; `base` is the same root for the whole walk.
         self.filter_chain.set_transfer_root(base.to_path_buf());
-        // upstream: flist.c:2390 - link_stat() once, then pass &st to
+        // upstream: flist.c:2425 - link_stat() once, then pass &st to
         // send_file_name(). Reuse the metadata to avoid a redundant stat
         // inside walk_path_with_metadata.
         match self.resolve_symlink_metadata(path, base) {
@@ -113,7 +113,7 @@ impl GeneratorContext {
                         self.emit_delete_sentinel(base, path)?;
                         Ok(true)
                     }
-                    // upstream: flist.c:1810 - default: link_stat failed + IOERR_GENERAL
+                    // upstream: flist.c:1846 - default: link_stat failed + IOERR_GENERAL
                     _ => {
                         // FFV-4: emit the correct error message and error flag
                         // for a source that never existed at flist build time.
@@ -239,7 +239,7 @@ impl GeneratorContext {
             }
         }
 
-        // upstream: flist.c:1332 - is_excluded() applied during make_file()
+        // upstream: flist.c:1360 - is_excluded() applied during make_file()
         // FilterChain evaluates per-directory scoped rules (innermost first)
         // then global rules. If no rules are configured, allows() returns true.
         if !self.filter_chain.allows(&relative, metadata.is_dir()) {
@@ -288,7 +288,7 @@ impl GeneratorContext {
             match std::fs::read_dir(&path) {
                 Ok(entries) => Some(entries),
                 Err(e) => {
-                    // upstream: flist.c:1842 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
+                    // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                     eprintln!(
                         "rsync: [sender] opendir \"{}\" failed: {}",
                         path.display(),
@@ -387,7 +387,7 @@ impl GeneratorContext {
         match std::fs::read_dir(dir_path) {
             Ok(entries) => self.process_dir_entries_batched(base, dir_path, entries),
             Err(e) => {
-                // upstream: flist.c:1842 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
+                // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                 eprintln!(
                     "rsync: [sender] opendir \"{}\" failed: {}",
                     dir_path.display(),
@@ -415,7 +415,7 @@ impl GeneratorContext {
             match entry {
                 Ok(de) => child_paths.push(de.path()),
                 Err(e) => {
-                    // upstream: flist.c:1888 - rsyserr(FERROR_XFER, errno, "readdir(%s)", ...)
+                    // upstream: flist.c:1924 - rsyserr(FERROR_XFER, errno, "readdir(%s)", ...)
                     eprintln!(
                         "rsync: [sender] readdir(\"{}\"): {}",
                         dir_path.display(),
@@ -471,7 +471,7 @@ impl GeneratorContext {
                                 target.as_os_str(),
                                 relative,
                             ) {
-                                // upstream: flist.c:217 - INFO_GTE(SYMSAFE, 1)
+                                // upstream: flist.c:229 - INFO_GTE(SYMSAFE, 1)
                                 // fires before the target is dereferenced.
                                 info_log!(
                                     Symsafe,
@@ -510,10 +510,10 @@ impl GeneratorContext {
     /// matching upstream `flist.c:1286-1294` error reporting.
     fn log_stat_error(&self, path: &Path, e: &io::Error) {
         if e.kind() == io::ErrorKind::NotFound {
-            // upstream: flist.c:1289 - rprintf(c, "file has vanished: %s\n", full_fname(...))
+            // upstream: flist.c:1317 - rprintf(c, "file has vanished: %s\n", full_fname(...))
             eprintln!("file has vanished: \"{}\"", path.display());
         } else {
-            // upstream: flist.c:1810 - rsyserr(FERROR_XFER, errno, "link_stat %s failed", ...)
+            // upstream: flist.c:1846 - rsyserr(FERROR_XFER, errno, "link_stat %s failed", ...)
             eprintln!(
                 "rsync: [sender] link_stat \"{}\" failed: {}",
                 path.display(),
@@ -532,8 +532,8 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:205-232` - `readlink_stat()`
-    /// - `flist.c:215` - `copy_unsafe_links && unsafe_symlink(linkbuf, path)`
+    /// - `flist.c:217-244` - `readlink_stat()`
+    /// - `flist.c:227` - `copy_unsafe_links && unsafe_symlink(linkbuf, path)`
     pub(in crate::generator) fn resolve_symlink_metadata(
         &self,
         path: &Path,
@@ -582,7 +582,7 @@ impl GeneratorContext {
             let relative = path.strip_prefix(base).unwrap_or(path);
             if super::super::super::symlink_safety::is_unsafe_symlink(target.as_os_str(), relative)
             {
-                // upstream: flist.c:217 - INFO_GTE(SYMSAFE, 1) fires before
+                // upstream: flist.c:229 - INFO_GTE(SYMSAFE, 1) fires before
                 // the unsafe symlink is dereferenced into a regular entry.
                 info_log!(
                     Symsafe,
@@ -610,7 +610,7 @@ mod rsyserr_wording_tests {
     /// refactor that re-inserts the source-location or role-version trailer
     /// will fail these asserts.
     const CASES: &[(&str, &str)] = &[
-        // upstream: flist.c:1810 - "link_stat %s failed"
+        // upstream: flist.c:1846 - "link_stat %s failed"
         (
             "rsync: [sender] link_stat \"{path}\" failed: No such file or directory (2)",
             "rsync: [sender] link_stat \"/p\" failed: No such file or directory (2)",
@@ -620,7 +620,7 @@ mod rsyserr_wording_tests {
             "rsync: [sender] opendir \"{path}\" failed: Permission denied (13)",
             "rsync: [sender] opendir \"/p\" failed: Permission denied (13)",
         ),
-        // upstream: flist.c:1888 - "readdir(%s)"
+        // upstream: flist.c:1924 - "readdir(%s)"
         (
             "rsync: [sender] readdir(\"{path}\"): Input/output error (5)",
             "rsync: [sender] readdir(\"/p\"): Input/output error (5)",
@@ -630,9 +630,9 @@ mod rsyserr_wording_tests {
             "rsync: [sender] make_file failed for \"{path}\": Permission denied (13)",
             "rsync: [sender] make_file failed for \"/p\": Permission denied (13)",
         ),
-        // upstream: flist.c:1289 / sender.c:358 - "file has vanished: %s" via full_fname()
+        // upstream: flist.c:1317 / sender.c:389 - "file has vanished: %s" via full_fname()
         ("file has vanished: \"{path}\"", "file has vanished: \"/p\""),
-        // upstream: sender.c:362 - "send_files failed to open %s"
+        // upstream: sender.c:393 - "send_files failed to open %s"
         (
             "rsync: [sender] send_files failed to open \"{path}\": Permission denied (13)",
             "rsync: [sender] send_files failed to open \"/p\": Permission denied (13)",
@@ -656,7 +656,7 @@ mod symsafe_emission_tests {
     //! Wording tests for `--info=SYMSAFE` producer emissions on the
     //! sender side.
     //!
-    //! Upstream rsync 3.4.1 fires `INFO_GTE(SYMSAFE, 1)` at `flist.c:217`
+    //! Upstream rsync 3.4.1 fires `INFO_GTE(SYMSAFE, 1)` at `flist.c:229`
     //! when `--copy-unsafe-links` triggers a dereference. The exact line
     //! emitted (per `rprintf(FINFO, ...)`) is matched byte-for-byte so
     //! interop harnesses that grep for the literal continue to find it.
@@ -685,7 +685,7 @@ mod symsafe_emission_tests {
 
     #[test]
     fn copying_unsafe_symlink_wording_matches_upstream() {
-        // upstream: flist.c:217 -
+        // upstream: flist.c:229 -
         //     rprintf(FINFO, "copying unsafe symlink \"%s\" -> \"%s\"\n",
         //             path, linkbuf);
         init_symsafe_level1();

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -10,7 +10,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `main.c:1258` - `recv_filter_list()` in server mode
+//! - `main.c:1276` - `recv_filter_list()` in server mode
 //! - `flist.c:2240-2264` - `--files-from` filename reading and resolution
 //! - `exclude.c:push_local_filters()` - per-directory merge file loading
 
@@ -87,7 +87,7 @@ fn has_leading_dot_anchor(name: &str) -> bool {
 /// (before sanitisation) ended with `/`, including the `/./` DOTDIR form.
 /// Upstream `flist.c:2329` flags those lines as `SLASH_ENDING_NAME` /
 /// `DOTDIR_NAME` and recurses into their children even when global `-r` is
-/// off (`options.c:2189` clears `recurse` whenever `--files-from` is
+/// off (`options.c:2207` clears `recurse` whenever `--files-from` is
 /// active), so we propagate the flag onto [`FilesFromEntry::recurse`] for
 /// `build_file_list_with_base` to honour.
 ///
@@ -99,7 +99,7 @@ fn has_leading_dot_anchor(name: &str) -> bool {
 /// instead of promoting `from` to the per-entry walk base.
 ///
 /// `relative_paths` selects the upstream split branch. In relative mode
-/// (`flist.c:2350-2365`) the entry is split on its first `/./` anchor as
+/// (`flist.c:2385-2400`) the entry is split on its first `/./` anchor as
 /// above. Under `--no-relative` (`relative_paths == 0`, `flist.c:2338-2349`)
 /// upstream instead splits on the entry's LAST `/`: the parent becomes the
 /// chdir target (walk base) and only the basename is transmitted, so nested
@@ -227,8 +227,8 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - Server mode: `recv_filter_list()` at `main.c:1258`
-    /// - Client mode: `send_filter_list()` at `main.c:1308` (done in mod.rs)
+    /// - Server mode: `recv_filter_list()` at `main.c:1276`
+    /// - Client mode: `send_filter_list()` at `main.c:1326` (done in mod.rs)
     pub(super) fn receive_filter_list_if_server<R: Read>(
         &mut self,
         reader: &mut R,
@@ -236,7 +236,7 @@ impl GeneratorContext {
         if self.config.connection.client_mode {
             // Client mode: apply filters from config for local file list building.
             // Filter rules were already sent to the daemon in mod.rs.
-            // upstream: flist.c:1332 - is_excluded() applied during make_file()
+            // upstream: flist.c:1360 - is_excluded() applied during make_file()
             if !self.config.connection.filter_rules.is_empty() {
                 let (filter_set, merge_configs) =
                     self.parse_received_filters(&self.config.connection.filter_rules.clone())?;
@@ -291,7 +291,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2262` - `read_line(filesfrom_fd, ...)` reads one name at a time
+    /// - `flist.c:2297` - `read_line(filesfrom_fd, ...)` reads one name at a time
     /// - `flist.c:2316-2330` - `/./` anchor split for relative-name emission
     /// - `main.c:681-685` - `filesfrom_fd` set to `STDIN_FILENO` for `--files-from=-`
     /// - `io.c:start_filesfrom_forwarding()` - client forwards local file over socket
@@ -306,7 +306,7 @@ impl GeneratorContext {
         };
 
         // Determine base directory: use the first positional arg (source dir).
-        // upstream: flist.c:2240-2244 - change_dir(argv[0]) before reading filenames.
+        // upstream: flist.c:2275-2279 - change_dir(argv[0]) before reading filenames.
         let base_dir = original_paths
             .first()
             .cloned()
@@ -348,7 +348,7 @@ impl GeneratorContext {
             if name.is_empty() {
                 continue;
             }
-            // upstream: flist.c:2264 - sanitize_path(fbuf, fbuf, "", 0, SP_KEEP_DOT_DIRS)
+            // upstream: flist.c:2299 - sanitize_path(fbuf, fbuf, "", 0, SP_KEEP_DOT_DIRS)
             // Always sanitize files_from entries to prevent directory traversal.
             // This collapses ".." components and strips leading "/" to confine
             // paths within the transfer root. `SP_KEEP_DOT_DIRS` preserves the
@@ -671,7 +671,7 @@ fn append_cvsignore_tokens(rules: &mut Vec<FilterRule>, source: &str, perishable
 /// # Upstream Reference
 ///
 /// - `main.c:675-679` - `open(files_from, O_RDONLY)` for local file
-/// - `flist.c:2262` - `read_line(filesfrom_fd, ...)` reads lines
+/// - `flist.c:2297` - `read_line(filesfrom_fd, ...)` reads lines
 pub(super) fn read_files_from_local_path(path: &str, from0: bool) -> io::Result<Vec<String>> {
     let file = std::fs::File::open(path)?;
     let mut reader = io::BufReader::new(file);
@@ -870,7 +870,7 @@ mod tests {
         // UTS-21.REOPEN regression: `from/./dir/subdir` must split so that
         // the wire-side relative name (path.strip_prefix(base)) is just
         // `dir/subdir`. Otherwise upstream's `implied_filter_list` check
-        // (flist.c:998) rejects `from/dir/subdir` as "unrequested".
+        // (flist.c:1026) rejects `from/dir/subdir` as "unrequested".
         let base = PathBuf::from("/src");
         let split = split_files_from_entry(&base, "from/./dir/subdir", false, true);
         assert_eq!(split.base, PathBuf::from("/src/from"));

--- a/crates/transfer/src/generator/itemize.rs
+++ b/crates/transfer/src/generator/itemize.rs
@@ -220,7 +220,7 @@ pub(crate) fn format_iflags(
 ///
 /// # Upstream Reference
 ///
-/// - `options.c:2336-2338` - `stdout_format = "%i %n%L"` for `-i`
+/// - `options.c:2354-2356` - `stdout_format = "%i %n%L"` for `-i`
 /// - `log.c:627-636` - `%n` expansion (filename with trailing `/` for dirs)
 /// - `log.c:643-655` - `%L` expansion: ` => hlink` when the xname is non-empty,
 ///   else ` -> target` for symlinks

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -54,14 +54,14 @@
 //!
 //! ## Upstream Reference
 //!
-//! - `flist.c:2192 send_file_list()` - top-level + initial segment dispatch.
+//! - `flist.c:2227 send_file_list()` - top-level + initial segment dispatch.
 //! - `flist.c:send_extra_file_list()` - per-directory sub-segments,
 //!   `MIN_FILECNT_LOOKAHEAD` throttling, `NDX_FLIST_EOF` finalization.
-//! - `sender.c:199 send_files()` - main send loop, calls into segment
+//! - `sender.c:203 send_files()` - main send loop, calls into segment
 //!   scheduling at the top and bottom of each iteration (lines ~227, ~261).
-//! - `generator.c:2226 generate_files()` - peer side that consumes the
+//! - `generator.c:2243 generate_files()` - peer side that consumes the
 //!   segmented stream and drives signature/data exchange.
-//! - `receiver.c:522 recv_files()` - receiver-side counterpart to the
+//! - `receiver.c:632 recv_files()` - receiver-side counterpart to the
 //!   sender's segmented dispatch.
 //! - `compat.c:161 set_allow_inc_recurse()` - capability negotiation gate
 //!   (`allow_inc_recurse` is cleared when `!recurse || use_qsort` or when

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -6,7 +6,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `flist.c:2192-2545` - File list building and sending
+//! - `flist.c:2227-2580` - File list building and sending
 //! - `uidlist.c:407-414` - `send_id_lists()` for name-based ownership
 //! - `sender.c:120` - `receive_sums()` reads signature blocks
 
@@ -27,7 +27,7 @@ use super::item_flags::ItemFlags;
 /// payload on the wire.
 ///
 /// Bundles the NDX with the iflags-gated trailing fields that always travel
-/// together (upstream `sender.c:180-189`): `fnamecmp_type` is emitted when
+/// together (upstream `sender.c:184-193`): `fnamecmp_type` is emitted when
 /// `iflags.has_basis_type()` and `xname` when `iflags.has_xname()`. Grouping
 /// them as a single parameter object keeps the two writer methods below at a
 /// manageable arity and prevents the four fields from drifting apart at call
@@ -59,7 +59,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2513-2514` - `if (numeric_ids <= 0 && !inc_recurse) send_id_lists(f);`
+    /// - `flist.c:2548-2549` - `if (numeric_ids <= 0 && !inc_recurse) send_id_lists(f);`
     /// - `uidlist.c:407-414` - `send_id_lists()`
     pub(crate) fn send_id_lists<W: Write>(&self, writer: &mut W) -> io::Result<()> {
         let inc_recurse = self
@@ -153,7 +153,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2517-2518`: `write_int(f, ignore_errors ? 0 : io_error);`
+    /// - `flist.c:2552-2553`: `write_int(f, ignore_errors ? 0 : io_error);`
     pub(super) fn send_io_error_flag<W: Write>(&self, writer: &mut W) -> io::Result<()> {
         if self.protocol.uses_fixed_encoding() {
             // upstream: flist.c:2517-2518
@@ -187,7 +187,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `sender.c:280-284` - `recv_xattr_request()` called when
+    /// - `sender.c:286-290` - `recv_xattr_request()` called when
     ///   `preserve_xattrs && iflags & ITEM_REPORT_XATTR && do_xfers
     ///    && !(want_xattr_optim && BITS_SET(iflags, ITEM_XNAME_FOLLOWS|ITEM_LOCAL_CHANGE))`
     /// - `xattrs.c:681-758` - `recv_xattr_request()` sender path marks entries
@@ -204,7 +204,7 @@ impl GeneratorContext {
         if iflags.raw() & ItemFlags::ITEM_REPORT_XATTR == 0 {
             return Ok(None);
         }
-        // upstream: sender.c:281 also gates on the want_xattr_optim hardlink
+        // upstream: sender.c:287 also gates on the want_xattr_optim hardlink
         // optimisation. upstream: compat.c:747 -
         // `want_xattr_optim = protocol_version >= 31 && !(compat_flags & CF_AVOID_XATTR_OPTIM)`.
         // The optimisation only exists at protocol 31+, so it must stay off for
@@ -248,13 +248,13 @@ impl GeneratorContext {
     /// xattr_request body) with the immediately following `write_sum_head()`
     /// call. When `xattr_response` is `Some` and the file has entries the
     /// generator requested, the full xattr values are written between iflags
-    /// and sum_head, matching the byte order of upstream sender.c:411-412.
+    /// and sum_head, matching the byte order of upstream sender.c:442-443.
     ///
     /// # Upstream Reference
     ///
-    /// - `sender.c:180-196` - `write_ndx_and_attrs()` body (calls
+    /// - `sender.c:184-200` - `write_ndx_and_attrs()` body (calls
     ///   `send_xattr_request(fname, file, f_out)` when ITEM_REPORT_XATTR set)
-    /// - `sender.c:411-412` - `write_ndx_and_attrs()` followed by
+    /// - `sender.c:442-443` - `write_ndx_and_attrs()` followed by
     ///   `write_sum_head(f_xfer, s)`
     pub(super) fn write_ndx_and_attrs<W: Write>(
         &self,
@@ -317,7 +317,7 @@ impl GeneratorContext {
             }
         }
         if iflags.has_xname() {
-            // upstream: sender.c:189 write_vstring(f_out, xname, strlen(xname)).
+            // upstream: sender.c:193 write_vstring(f_out, xname, strlen(xname)).
             // The xname length prefix is a 1- or 2-byte vstring (io.c:2297), NOT
             // a varint: the two encodings only agree for len <= 0x7F, so a longer
             // fuzzy basename or hard-link leader name would desync the receiver's
@@ -325,7 +325,7 @@ impl GeneratorContext {
             // byte.
             protocol::write_vstring(writer, xname.unwrap_or(&[]))?;
         }
-        // upstream: sender.c:192-196 - send_xattr_request(fname, file, f_out)
+        // upstream: sender.c:196-200 - send_xattr_request(fname, file, f_out)
         // is invoked from inside write_ndx_and_attrs() when ITEM_REPORT_XATTR
         // is set in iflags. Skipping this body causes the receiver to read the
         // following bytes as a stale xattr request, desyncing the goodbye phase.
@@ -362,11 +362,11 @@ impl GeneratorContext {
     ) -> io::Result<()> {
         if error.kind() == io::ErrorKind::NotFound {
             self.io_error |= super::io_error_flags::IOERR_VANISHED;
-            // upstream: sender.c:358 - rprintf(c, "file has vanished: %s\n", full_fname(...))
+            // upstream: sender.c:389 - rprintf(c, "file has vanished: %s\n", full_fname(...))
             eprintln!("file has vanished: \"{path_display}\"");
         } else {
             self.io_error |= super::io_error_flags::IOERR_GENERAL;
-            // upstream: sender.c:362 - rsyserr(FERROR_XFER, errno, "send_files failed to open %s", ...)
+            // upstream: sender.c:393 - rsyserr(FERROR_XFER, errno, "send_files failed to open %s", ...)
             eprintln!(
                 "rsync: [sender] send_files failed to open \"{path_display}\": {}",
                 engine::local_copy::upstream_io_error(error),
@@ -427,8 +427,8 @@ impl GeneratorContext {
     /// - `generator.c:582-583` - emit gate: `(iflags & (SIGNIFICANT_ITEM_FLAGS
     ///   | ITEM_REPORT_XATTR)) || INFO_GTE(NAME, 2) || stdout_format_has_i > 1
     ///   || (xname && *xname)`
-    /// - `sender.c:287` - `maybe_log_item()` for non-transfer items
-    /// - `sender.c:430` - `log_item()` after file transfer
+    /// - `sender.c:293` - `maybe_log_item()` for non-transfer items
+    /// - `sender.c:461` - `log_item()` after file transfer
     /// - `log.c:330-340` - `rwrite()`: when `am_server`, sends MSG_INFO;
     ///   when `!am_server`, writes to stdout (FCLIENT)
     pub(super) fn maybe_emit_itemize<W: Write>(
@@ -580,8 +580,8 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2192` - `send_file_list()` main entry point
-    /// - `flist.c:2518` - `write_int(f, io_error)` end marker with SAFE_FILE_LIST
+    /// - `flist.c:2227` - `send_file_list()` main entry point
+    /// - `flist.c:2553` - `write_int(f, io_error)` end marker with SAFE_FILE_LIST
     pub fn send_file_list<W: Write>(&mut self, writer: &mut W) -> io::Result<usize> {
         let _t = PhaseTimer::new("file-list-send");
         // upstream: stats.flist_xfertime
@@ -620,7 +620,7 @@ impl GeneratorContext {
             self.flist_send_stats.record(entry);
         }
 
-        // upstream: flist.c:2518 - write io_error with end marker (SAFE_FILE_LIST)
+        // upstream: flist.c:2553 - write io_error with end marker (SAFE_FILE_LIST)
         let io_error_for_end = if self.io_error != 0 {
             Some(self.io_error)
         } else {
@@ -657,7 +657,7 @@ impl GeneratorContext {
     /// # Upstream Reference
     ///
     /// - `flist.c:send_extra_file_list()` - sends one directory's entries
-    /// - `flist.c:2931` - `ndx_start = prev->ndx_start + prev->used + 1`
+    /// - `flist.c:2966` - `ndx_start = prev->ndx_start + prev->used + 1`
     pub(super) fn encode_and_send_segment<W: Write>(
         &mut self,
         writer: &mut W,
@@ -688,7 +688,7 @@ impl GeneratorContext {
         ndx_codec: &mut NdxCodecEnum,
     ) -> io::Result<()> {
         // Compute ndx_start for this sub-list.
-        // upstream: flist.c:2931 - flist->ndx_start = prev->ndx_start + prev->used + 1
+        // upstream: flist.c:2966 - flist->ndx_start = prev->ndx_start + prev->used + 1
         let &(prev_flat_start, prev_ndx_start) = self
             .incremental
             .ndx_segments
@@ -708,7 +708,7 @@ impl GeneratorContext {
             .push(segment.parent_flat_idx as i32);
 
         // Signal new sub-list to receiver.
-        // upstream: flist.c:2117 - write_ndx(f, NDX_FLIST_OFFSET - dir_ndx)
+        // upstream: flist.c:2152 - write_ndx(f, NDX_FLIST_OFFSET - dir_ndx)
         ndx_codec.write_ndx(writer, NDX_FLIST_OFFSET - segment.parent_dir_ndx)?;
 
         // Set first_ndx so abbreviated vs unabbreviated followers are
@@ -728,7 +728,7 @@ impl GeneratorContext {
         }
 
         // End-of-flist marker (zero byte).
-        // upstream: flist.c:2139-2146 - always sends write_end_of_flist()
+        // upstream: flist.c:2174-2181 - always sends write_end_of_flist()
         flist_writer.write_end(writer, None)?;
 
         debug_log!(
@@ -757,7 +757,7 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// Mirrors `flist.c:1627-1656` where `get_acl()` reads filesystem ACLs
+    /// Mirrors `flist.c:1663-1692` where `get_acl()` reads filesystem ACLs
     /// and `send_acl()` strips and sends them.
     fn prepare_pending_acl(
         &self,

--- a/crates/transfer/src/generator/segments.rs
+++ b/crates/transfer/src/generator/segments.rs
@@ -10,7 +10,7 @@
 //!
 //! - `flist.c:46` - `#define MIN_FILECNT_LOOKAHEAD 1000`
 //! - `flist.c:2498-2510` - `send_extra_file_list()` lookahead throttling
-//! - `sender.c:227,261` - send loop calls into segment scheduling at top/bottom
+//! - `sender.c:231,265` - send loop calls into segment scheduling at top/bottom
 
 /// Minimum file count lookahead before the sender emits the next incremental
 /// sub-list. The sender accumulates at least this many unsent entries before
@@ -30,13 +30,13 @@ pub const MIN_FILECNT_LOOKAHEAD: usize = 1000;
 /// # Upstream Reference
 ///
 /// - `flist.c:send_extra_file_list()` - sends one directory's entries as a sub-list
-/// - `flist.c:2931` - `ndx_start = prev->ndx_start + prev->used + 1`
+/// - `flist.c:2966` - `ndx_start = prev->ndx_start + prev->used + 1`
 #[derive(Debug)]
 pub(crate) struct PendingSegment {
     /// Wire `dir_ndx` of the owning directory in the receiver's `dir_flist`.
     ///
     /// Written to the wire as `NDX_FLIST_OFFSET - parent_dir_ndx`
-    /// (flist.c:2117) to identify which directory this sub-list belongs to.
+    /// (flist.c:2152) to identify which directory this sub-list belongs to.
     pub(crate) parent_dir_ndx: i32,
     /// Flat `GeneratorContext::file_list` index of the owning directory entry.
     ///
@@ -84,11 +84,11 @@ pub(crate) struct DirSegment {
 /// Controls *when* sub-lists are sent during the transfer loop using
 /// upstream's `MIN_FILECNT_LOOKAHEAD` throttling heuristic. The transfer
 /// loop calls `next_if_needed()` at top and bottom of each iteration,
-/// matching upstream `sender.c:227,261`.
+/// matching upstream `sender.c:231,265`.
 ///
 /// # Upstream Reference
 ///
-/// - `sender.c:227,261` - checks `inc_recurse` at top/bottom of send loop
+/// - `sender.c:231,265` - checks `inc_recurse` at top/bottom of send loop
 /// - `flist.c:2498` - `send_extra_file_list()` uses `MIN_FILECNT_LOOKAHEAD`
 #[derive(Debug)]
 pub(crate) struct SegmentScheduler {
@@ -167,7 +167,7 @@ pub(crate) struct IncrementalState {
     /// Segment boundary table for mapping wire NDX values to flat array indices.
     ///
     /// With INC_RECURSE, the sender sends segmented file lists with +1 gaps
-    /// between segments (upstream `flist.c:2931`). When the receiver sends
+    /// between segments (upstream `flist.c:2966`). When the receiver sends
     /// wire NDX values back, this table maps them to flat array indices.
     /// Each entry is `(flat_start, ndx_start)`.
     ///
@@ -202,7 +202,7 @@ pub(crate) struct IncrementalState {
     /// # Upstream Reference
     ///
     /// - `flist.c:101` - `first_flist` pointer
-    /// - `sender.c:244` - `flist_free(first_flist)` advances `first_flist`
+    /// - `sender.c:248` - `flist_free(first_flist)` advances `first_flist`
     pub(crate) first_segment_idx: usize,
 }
 

--- a/crates/transfer/src/generator/stats.rs
+++ b/crates/transfer/src/generator/stats.rs
@@ -203,7 +203,7 @@ pub struct GeneratorStats {
 /// # Upstream Reference
 ///
 /// - `sender.c:225-232` - tolerant error handling for dry-run
-/// - `main.c:875-906` - `read_final_goodbye()` with early close tolerance
+/// - `main.c:893-924` - `read_final_goodbye()` with early close tolerance
 pub(crate) fn is_early_close_error(e: &std::io::Error) -> bool {
     matches!(
         e.kind(),

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -375,7 +375,7 @@ fn inc_recurse_gap_ndx_round_trip_preserves_original() {
     // 0 + (0 - 1) as usize = usize::MAX, and flat_to_wire_ndx(usize::MAX)
     // produced a garbage value instead of 0.
     //
-    // upstream: sender.c:263-266 - gap NDX echoed unchanged
+    // upstream: sender.c:267-272 - gap NDX echoed unchanged
     use protocol::CompatibilityFlags;
 
     let mut handshake = test_handshake_with_protocol(32);
@@ -473,7 +473,7 @@ fn inc_recurse_gap_ndx_itemizes_parent_directory() {
 
     // Dispatching sub/'s sub-list appends its (flat_start, ndx_start) and
     // owning-flat rows, exactly as encode_and_send_segment does in the transfer
-    // loop. upstream flist.c:2931: ndx_start = prev(1) + prev_used(2) + 1 = 4,
+    // loop. upstream flist.c:2966: ndx_start = prev(1) + prev_used(2) + 1 = 4,
     // so sub/'s gap NDX is 3. The initial list keeps ndx_start 1, gap NDX 0.
     ctx.incremental.ndx_segments = vec![(0, 1), (2, 4)];
     ctx.incremental.segment_parent_flat = vec![0, 1];
@@ -1913,7 +1913,7 @@ fn send_io_error_flag_with_errors_protocol_29() {
 
 #[test]
 fn send_io_error_flag_ignore_errors_suppresses_value() {
-    // Tests upstream behavior: flist.c:2518: write_int(f, ignore_errors ? 0 : io_error);
+    // Tests upstream behavior: flist.c:2553: write_int(f, ignore_errors ? 0 : io_error);
     let handshake = test_handshake_with_protocol(29);
     let mut config = test_config();
     config.deletion.ignore_errors = true;
@@ -2227,7 +2227,7 @@ fn walk_skips_fifo_when_preserve_specials_is_false() {
     // Trailing-slash source enters upstream's DOTDIR_NAME branch
     // (flist.c:2312-2322) so the file list contains `.` + the base
     // directory's children, matching `rsync <dir>/ dst/`. Without it the
-    // non-relative walk-base split (flist.c:2338-2349) would emit only
+    // non-relative walk-base split (flist.c:2373-2384) would emit only
     // the source basename instead of `.` plus its children.
     let count = build_file_list_for_contents(&mut ctx, base_path);
 
@@ -2673,7 +2673,7 @@ fn to_exit_code_no_errors_returns_zero() {
 /// a single NDX_DONE (4-byte LE) and the sender (generator) reads it.
 /// No NDX_DEL_STATS or extended goodbye round-trip occurs.
 ///
-/// upstream: main.c:875-906 `read_final_goodbye()`
+/// upstream: main.c:893-924 `read_final_goodbye()`
 mod legacy_goodbye_tests {
     use super::*;
     use protocol::codec::{MonotonicNdxWriter, create_ndx_codec};
@@ -2684,7 +2684,7 @@ mod legacy_goodbye_tests {
 
     /// NDX_DONE as encoded by the modern (protocol >= 30) codec.
     ///
-    /// upstream io.c:2259-2262 - single 0x00 byte with no side effects.
+    /// upstream io.c:2334-2337 - single 0x00 byte with no side effects.
     const NDX_DONE_MODERN: [u8; 1] = [0x00];
 
     /// Creates a `GeneratorContext` for a specific protocol version.
@@ -2808,7 +2808,7 @@ mod legacy_goodbye_tests {
     // the four marker bytes in user-space while the receiver is already
     // shutting down the socket - the symptom upstream's batch-mode interop
     // surfaced as a silent close at byte ~2241725. Mirroring
-    // `main.c:875-906 read_final_goodbye()` requires the flush to happen
+    // `main.c:893-924 read_final_goodbye()` requires the flush to happen
     // before close on every protocol-31+ goodbye.
     #[test]
     fn handle_goodbye_proto31_flushes_ndx_done_before_close() {
@@ -3203,7 +3203,7 @@ mod files_from {
         );
     }
 
-    /// upstream: flist.c:1614-1638 send_file1() - a name that cannot be
+    /// upstream: flist.c:1650-1674 send_file1() - a name that cannot be
     /// strictly transcoded under --iconv is dropped (io_error |= IOERR_GENERAL,
     /// "cannot convert filename", return NULL) so it never enters the file list.
     /// The --files-from build path runs the same per-source send_file_name(), so
@@ -3335,7 +3335,7 @@ mod files_from {
         // directory (e.g. `dir/subdir`) and a file inside it (e.g.
         // `dir/subdir/child.txt`), the directory must appear in the wire
         // file list exactly ONCE. Upstream's `implied_filter_list` check
-        // (flist.c:998) rejects the second occurrence as
+        // (flist.c:1026) rejects the second occurrence as
         // "rejecting unrequested file-list name: dir/subdir", which broke
         // upstream's `files-from.test` interop suite in the pull direction.
         //
@@ -3480,7 +3480,7 @@ mod files_from {
             "expected child to retain path prefix in {names:?}"
         );
         // Every parent ancestor must be present so the receiver can resolve
-        // generator.c:1313 parent-lookup without ABORTING.
+        // generator.c:1325 parent-lookup without ABORTING.
         for ancestor in src_dir
             .ancestors()
             .skip(1)
@@ -3810,7 +3810,7 @@ mod files_from {
 
     #[test]
     fn non_relative_mode_emits_source_basename() {
-        // upstream: flist.c:2338-2349 - non-relative mode splits each
+        // upstream: flist.c:2373-2384 - non-relative mode splits each
         // positional on its last `/`: `dir` becomes the chdir target,
         // `fn` is link_stat'd. For source `<tmp>/payload`, dir = <tmp>
         // and fn = payload, so the wire entries carry the basename
@@ -3917,7 +3917,7 @@ mod files_from {
             "no implied root . for a non-anchored list"
         );
 
-        // upstream: flist.c:1810 - ENOENT for a --files-from entry that never
+        // upstream: flist.c:1846 - ENOENT for a --files-from entry that never
         // existed should set IOERR_GENERAL (exit 23), not IOERR_VANISHED (exit 24).
         assert_ne!(
             ctx.io_error() & io_error_flags::IOERR_GENERAL,
@@ -4219,7 +4219,7 @@ fn generator_skips_files_matching_per_directory_merge_rules() {
     // Trailing-slash source exercises upstream's DOTDIR_NAME branch
     // (flist.c:2312-2322) so the file list is `.` + the directory's
     // children, matching `rsync <dir>/ dst/`. Without it, the non-relative
-    // walk-base split (flist.c:2338-2349) emits only the source basename.
+    // walk-base split (flist.c:2373-2384) emits only the source basename.
     let count = build_file_list_for_contents(&mut ctx, base);
 
     // Should have "." + "keep.txt" + ".rsync-filter" but not "skip.log"
@@ -4259,7 +4259,7 @@ fn generator_nested_directories_cascading_merge_rules() {
     // Trailing-slash source exercises upstream's DOTDIR_NAME branch
     // (flist.c:2312-2322) so the file list is `.` + the directory's
     // children, matching `rsync <dir>/ dst/`. Without it, the non-relative
-    // walk-base split (flist.c:2338-2349) prefixes every name with the
+    // walk-base split (flist.c:2373-2384) prefixes every name with the
     // source basename.
     let _count = build_file_list_for_contents(&mut ctx, base);
     let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
@@ -4319,7 +4319,7 @@ fn generator_merge_filters_properly_scoped() {
     // Trailing-slash source exercises upstream's DOTDIR_NAME branch
     // (flist.c:2312-2322) so the file list is `.` + the directory's
     // children, matching `rsync <dir>/ dst/`. Without it, the non-relative
-    // walk-base split (flist.c:2338-2349) prefixes every name with the
+    // walk-base split (flist.c:2373-2384) prefixes every name with the
     // source basename and the exact-equality assertions below would miss.
     let _count = build_file_list_for_contents(&mut ctx, base);
     let names: Vec<String> = ctx
@@ -4384,7 +4384,7 @@ fn generator_no_merge_configs_unchanged_behavior() {
     // Trailing-slash source exercises upstream's DOTDIR_NAME branch
     // (flist.c:2312-2322) so the file list is `.` + the directory's
     // children, matching `rsync <dir>/ dst/`. Without it, the non-relative
-    // walk-base split (flist.c:2338-2349) emits only the source basename.
+    // walk-base split (flist.c:2373-2384) emits only the source basename.
     let count = build_file_list_for_contents(&mut ctx, base);
 
     // Should have "." + 2 files = 3 entries
@@ -4445,7 +4445,7 @@ fn server_mode_flushes_writer_before_filter_list_read() {
     // client's filter list. Without this flush, the client may wait for
     // server output before sending its filter list, causing a deadlock.
     //
-    // upstream: main.c:1248-1258 - io_start_multiplex_out() then recv_filter_list()
+    // upstream: main.c:1266-1276 - io_start_multiplex_out() then recv_filter_list()
     // upstream: io.c:perform_io() - flushes output buffer while waiting for input
 
     use std::sync::Arc;
@@ -5170,7 +5170,7 @@ mod itemize_emit_gate {
         );
     }
 
-    /// upstream: generator.c:583 - `(xname && *xname)` (encoded as
+    /// upstream: generator.c:590 - `(xname && *xname)` (encoded as
     /// `ITEM_XNAME_FOLLOWS` on the wire) forces emission. Verbose level 0
     /// proves the new branch alone is sufficient.
     #[test]

--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -5,7 +5,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `main.c:875-906` - `read_final_goodbye()` with del_stats handling
+//! - `main.c:893-924` - `read_final_goodbye()` with del_stats handling
 
 use std::io::{self, Read, Write};
 
@@ -36,9 +36,9 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `main.c:875-906` - `read_final_goodbye()`
-    /// - `main.c:883` - protocol < 29 uses `read_int(f_in)`
-    /// - `main.c:885-886` - protocol >= 29 uses `read_ndx_and_attrs()`
+    /// - `main.c:893-924` - `read_final_goodbye()`
+    /// - `main.c:901` - protocol < 29 uses `read_int(f_in)`
+    /// - `main.c:903-904` - protocol >= 29 uses `read_ndx_and_attrs()`
     /// - `rsync.c:337-342` - NDX_DEL_STATS handling in `read_ndx_and_attrs()`
     /// - `main.c:225-238` - `write_del_stats()` format
     /// - `generator.c:2376-2381` - early del_stats path
@@ -99,7 +99,7 @@ impl GeneratorContext {
         }
 
         // Read first NDX_DONE from receiver, skipping any NDX_DEL_STATS.
-        // upstream: main.c:886 - read_ndx_and_attrs() handles NDX_DEL_STATS internally.
+        // upstream: main.c:904 - read_ndx_and_attrs() handles NDX_DEL_STATS internally.
         // Connection may close early in dry-run or when the remote daemon exits before
         // completing the goodbye exchange - treat this as acceptable.
         let ndx = match self.read_ndx_skipping_del_stats(reader, ndx_read_codec) {
@@ -123,7 +123,7 @@ impl GeneratorContext {
         //
         // Upstream gates del_stats sending on INFO_GTE(STATS, 2) (i.e. --stats was passed)
         // and splits it into early vs late paths depending on deletion timing:
-        // - Early (generator.c:2376-2381): !(delete_during==2 || delete_after) =>
+        // - Early (generator.c:2393-2398): !(delete_during==2 || delete_after) =>
         //   send del_stats only when (do_stats && (delete_mode || force_delete))
         // - Late (generator.c:2420-2425): (delete_during==2 || delete_after) =>
         //   send del_stats when do_stats

--- a/crates/transfer/src/generator/transfer/mod.rs
+++ b/crates/transfer/src/generator/transfer/mod.rs
@@ -12,7 +12,7 @@
 //! # Upstream Reference
 //!
 //! - `sender.c:send_files()` - Main transfer loop (lines 210-462)
-//! - `main.c:875-906` - `read_final_goodbye()` with del_stats handling
+//! - `main.c:893-924` - `read_final_goodbye()` with del_stats handling
 
 mod goodbye;
 mod orchestrator;
@@ -66,7 +66,7 @@ mod send_debug_emission_tests {
 
     #[test]
     fn send_files_phase_matches_upstream() {
-        // upstream: sender.c:254-255 - "send_files phase=%d"
+        // upstream: sender.c:258-259 - "send_files phase=%d"
         init_send_level1();
         let phase: i32 = 2;
         debug_log!(Send, 1, "send_files phase={}", phase);
@@ -79,7 +79,7 @@ mod send_debug_emission_tests {
 
     #[test]
     fn send_files_per_file_matches_upstream() {
-        // upstream: sender.c:277-278 - "send_files(%d, %s%s%s)"
+        // upstream: sender.c:283-284 - "send_files(%d, %s%s%s)"
         // F_PATHNAME unset -> path/slash empty, only fname emitted.
         init_send_level1();
         let ndx: i32 = 7;

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -7,8 +7,8 @@
 //! # Upstream Reference
 //!
 //! - `sender.c:send_files()` - Main transfer loop
-//! - `flist.c:2192` - `send_file_list()` builds and sends file list
-//! - `main.c:875-906` - `read_final_goodbye()` protocol finalization
+//! - `flist.c:2227` - `send_file_list()` builds and sends file list
+//! - `main.c:893-924` - `read_final_goodbye()` protocol finalization
 
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
@@ -31,8 +31,8 @@ impl GeneratorContext {
     /// # Upstream Reference
     ///
     /// - `sender.c:send_files()` - Main transfer loop
-    /// - `flist.c:2192` - `send_file_list()` builds and sends file list
-    /// - `main.c:875-906` - `read_final_goodbye()` protocol finalization
+    /// - `flist.c:2227` - `send_file_list()` builds and sends file list
+    /// - `main.c:893-924` - `read_final_goodbye()` protocol finalization
     pub fn run<R: Read, W: Write>(
         &mut self,
         mut reader: super::super::super::reader::ServerReader<R>,
@@ -54,7 +54,7 @@ impl GeneratorContext {
             })?;
         }
 
-        // upstream: main.c:1248-1258 - flush pending multiplex output before
+        // upstream: main.c:1266-1276 - flush pending multiplex output before
         // blocking on recv_filter_list(). Upstream's perform_io() flushes the
         // output buffer while waiting for input via select(), but our separate
         // read/write streams cannot do that. Without this flush, any buffered
@@ -65,7 +65,7 @@ impl GeneratorContext {
             writer.flush()?;
         }
 
-        // upstream: main.c:1258 - recv_filter_list() in server mode
+        // upstream: main.c:1276 - recv_filter_list() in server mode
         self.receive_filter_list_if_server(&mut reader)?;
 
         // upstream: flist.c:2240-2264 - resolve --files-from paths if configured
@@ -78,7 +78,7 @@ impl GeneratorContext {
 
         let reader = &mut reader;
 
-        // upstream: flist.c:2192 - send_file_list()
+        // upstream: flist.c:2227 - send_file_list()
         let file_count = {
             let _t = PhaseTimer::new("file-list-build-send");
             if files_from_entries.is_empty() {
@@ -116,7 +116,7 @@ impl GeneratorContext {
             .advance_to(TransferPhase::Finalization)
             .map_err(crate::fsm_error)?;
 
-        // upstream: main.c:960-962 - do_server_sender() calls io_flush then handle_stats
+        // upstream: main.c:978-980 - do_server_sender() calls io_flush then handle_stats
         // before read_final_goodbye. Server-sender writes transfer stats; client-sender
         // handle_stats(-1) is a no-op (main.c:339-345).
         if !self.config.connection.client_mode {

--- a/crates/transfer/src/generator/transfer/stats.rs
+++ b/crates/transfer/src/generator/transfer/stats.rs
@@ -23,7 +23,7 @@ impl GeneratorContext {
     /// # Upstream Reference
     ///
     /// - `main.c:347-357` - `handle_stats()` server-sender write path
-    /// - `main.c:960-962` - `do_server_sender()` calls `handle_stats(f_out)`
+    /// - `main.c:978-980` - `do_server_sender()` calls `handle_stats(f_out)`
     pub(super) fn send_stats<W: Write>(
         &self,
         writer: &mut W,

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -99,7 +99,7 @@ impl GeneratorContext {
         };
         use super::super::protocol_io::{read_signature_blocks_keepalive, signature_read_lull_mod};
 
-        // upstream: sender.c:217-218 - rprintf(FINFO, "send_files starting\n")
+        // upstream: sender.c:221-222 - rprintf(FINFO, "send_files starting\n")
         debug_log!(Send, 1, "send_files starting");
 
         // upstream: sender.c:218 - int save_io_error = io_error;
@@ -205,7 +205,7 @@ impl GeneratorContext {
         // transition. This counter tracks how many flist-free echoes remain.
         let mut flist_done_remaining: usize = 0;
 
-        // upstream: flist.c:104,2160 - file_total tracks entries the receiver
+        // upstream: flist.c:104,2195 - file_total tracks entries the receiver
         // knows about (initial segment + dispatched sub-lists). Used for the
         // MIN_FILECNT_LOOKAHEAD comparison in send_extra_file_list().
         // Unlike self.file_list.len() which includes undispatched segments,
@@ -221,7 +221,7 @@ impl GeneratorContext {
         loop {
             // upstream: sender.c:227 - send extra file lists at top of loop
             if inc_recurse {
-                // upstream: flist.c:2104 - file_total - file_old_total < at_least
+                // upstream: flist.c:2139 - file_total - file_old_total < at_least
                 // remaining = entries the receiver knows about minus transferred
                 let remaining = dispatched_entry_count.saturating_sub(files_transferred);
                 while let Some(seg) = scheduler.next_if_needed(remaining) {
@@ -270,14 +270,14 @@ impl GeneratorContext {
             if ndx < 0 {
                 match ndx {
                     NDX_DONE => {
-                        // upstream: sender.c:242-257 - INC_RECURSE flist-free path.
+                        // upstream: sender.c:246-261 - INC_RECURSE flist-free path.
                         // With INC_RECURSE, the client sends one NDX_DONE per
                         // completed sub-file-list before the actual phase transitions.
                         // Echo these without incrementing phase, matching upstream's
                         // flist_free(first_flist) loop.
                         if inc_recurse && flist_done_remaining > 0 {
                             flist_done_remaining -= 1;
-                            // upstream: sender.c:243-244 -
+                            // upstream: sender.c:247-248 -
                             // file_old_total -= first_flist->used; flist_free(first_flist).
                             // Reclaim heap data from the oldest completed segment to
                             // reduce RSS. Entries stay in place for NDX indexing but
@@ -317,13 +317,13 @@ impl GeneratorContext {
                             continue;
                         }
 
-                        // upstream: sender.c:252-257 - phase transition.
+                        // upstream: sender.c:256-261 - phase transition.
                         // Increment phase first, break without echo if past max_phase.
                         phase += 1;
                         if phase > max_phase {
                             break;
                         }
-                        // upstream: sender.c:254-255
+                        // upstream: sender.c:258-259
                         // rprintf(FINFO, "send_files phase=%d\n", phase)
                         debug_log!(Send, 1, "send_files phase={}", phase);
                         if let Err(e) = ndx_write_codec
@@ -374,7 +374,7 @@ impl GeneratorContext {
                 }
             }
 
-            // upstream: sender.c:263-266 - preserve the original wire NDX for
+            // upstream: sender.c:267-272 - preserve the original wire NDX for
             // echo-back. When INC_RECURSE is active, the receiver sends "gap
             // NDX" values (ndx_start - 1 per sub-list) that fall below
             // cur_flist->ndx_start. Upstream echoes the original NDX unchanged;
@@ -400,7 +400,7 @@ impl GeneratorContext {
             // exact wire bytes consumed so this count never drifts from the wire.
             self.timing.total_bytes_read += trailing_bytes;
 
-            // upstream: sender.c:280-284 - drain the generator's xattr request
+            // upstream: sender.c:286-290 - drain the generator's xattr request
             // when preserve_xattrs && ITEM_REPORT_XATTR is set. The generator
             // always emits at least a 0 terminator (varint) under this gate, so
             // skipping it desyncs the subsequent sum_head read and aborts the
@@ -414,7 +414,7 @@ impl GeneratorContext {
             let mut pending_xattr_response =
                 self.read_generator_xattr_request_if_any(&mut *reader, ndx, &iflags)?;
 
-            // upstream: sender.c:277-278
+            // upstream: sender.c:283-284
             // rprintf(FINFO, "send_files(%d, %s%s%s)\n", ndx, path,slash,fname)
             // F_PATHNAME is unset for the in-band file list we build, so the
             // path/slash prefix is empty and we emit just the relative name.
@@ -469,7 +469,7 @@ impl GeneratorContext {
                 )));
             }
 
-            // upstream: sender.c:341-344 - dry_run (!do_xfers) logs the item and
+            // upstream: sender.c:347-350 - dry_run (!do_xfers) logs the item and
             // echoes write_ndx_and_attrs() without calling receive_sums(). The
             // echo still carries the xattr response when ITEM_REPORT_XATTR is
             // set so the receiver can pair its outstanding request.
@@ -495,7 +495,7 @@ impl GeneratorContext {
                 if iflags.raw() & ItemFlags::ITEM_IS_NEW != 0 {
                     created_stats.record(file_entry.mode());
                 }
-                // upstream: sender.c:341-344 - a dry run logs the transfer item
+                // upstream: sender.c:347-350 - a dry run logs the transfer item
                 // via log_item(FCLIENT) without sending data: the `-i` itemize
                 // row or, under plain `-v`, the bare `%n%L` name line.
                 self.emit_client_item(writer, &iflags, ndx, xname.as_deref(), itemize, true)?;
@@ -520,7 +520,7 @@ impl GeneratorContext {
             let source_path = self.reconstruct_source_path(ndx);
             let source_path_display = source_path.display().to_string();
 
-            // upstream: sender.c:319-335 - when a file arrives again on the redo
+            // upstream: sender.c:325-341 - when a file arrives again on the redo
             // pass (`file->flags & FLAG_FILE_SENT`), the sender negates
             // append_mode and make_backups so the resend is a full-content
             // transfer. The receiver's generator has already restored
@@ -772,7 +772,7 @@ impl GeneratorContext {
                 };
                 bytes_sent += wire_bytes;
             } else {
-                // upstream: sender.c:354-369 - whole-file path; MSG_NO_SEND on open failure
+                // upstream: sender.c:385-400 - whole-file path; MSG_NO_SEND on open failure
                 // Use unbuffered reader: stream_whole_file_transfer manages its
                 // own 256 KB staging buffer with read_exact, so a BufReader would
                 // only add an extra memcpy per byte through its internal buffer.
@@ -878,7 +878,7 @@ impl GeneratorContext {
             // rprintf(FINFO, "sender finished %s%s%s\n", path,slash,fname)
             debug_log!(Send, 1, "sender finished {}", file_entry.path().display());
 
-            // upstream: sender.c:430 - log_item(log_code, file, iflags, xname)
+            // upstream: sender.c:461 - log_item(log_code, file, iflags, xname)
             self.emit_client_item(writer, &iflags, ndx, xname.as_deref(), itemize, true)?;
 
             if let Some(cb) = progress.as_mut() {
@@ -946,7 +946,7 @@ impl GeneratorContext {
         // Cache flist_writer back for potential reuse (e.g., phase 2).
         self.incremental.flist_writer_cache = Some(flist_writer);
 
-        // upstream: sender.c:457-458
+        // upstream: sender.c:488-489
         // rprintf(FINFO, "send files finished\n")
         debug_log!(Send, 1, "send files finished");
 
@@ -964,7 +964,7 @@ impl GeneratorContext {
             }
         }
 
-        // upstream: sender.c:454-462 - after the transfer loop exits, the sender
+        // upstream: sender.c:485-493 - after the transfer loop exits, the sender
         // sends io_error (if changed) and a final NDX_DONE. This NDX_DONE is the
         // "goodbye" that tells the client's generator to proceed with its own
         // goodbye handshake. Without it, the client hangs waiting for this marker.

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -157,7 +157,7 @@ impl SignatureGenerationConfig {
 ///
 /// # Upstream Reference
 ///
-/// - `generator.c:963-983` - `try_dests_reg()` scans `basis_dir[j]` in order;
+/// - `generator.c:975-995` - `try_dests_reg()` scans `basis_dir[j]` in order;
 ///   the first existing regular file sets `best_match = j` (match_level 1).
 /// - `generator.c:1054` - `return FNAMECMP_BASIS_DIR_LOW + j` when the file
 ///   exists in the reference dir but its content differs (match_level 1).
@@ -286,7 +286,7 @@ fn try_fuzzy_match(
     let fuzzy_matcher = FuzzyMatcher::with_level(fuzzy_level).with_fuzzy_basis_dirs(basis_dirs);
     let fuzzy_match =
         fuzzy_matcher.find_fuzzy_basis(target_name, dest_dir, target_size, Some(target_mtime))?;
-    // upstream: generator.c:1775 - announce the selected fuzzy basis at
+    // upstream: generator.c:1788 - announce the selected fuzzy basis at
     // FUZZY,1 the moment the matcher returns a candidate, before we attempt
     // to open it.
     trace_fuzzy_basis_selected(
@@ -619,7 +619,7 @@ fn compute_basis_signature<R: std::io::Read>(
 /// - `generator.c:1580` - Fuzzy matching via `find_fuzzy_basis()`
 /// - `generator.c:1400` - Reference directory checking
 pub fn find_basis_file_with_config(config: &BasisFileConfig<'_>) -> BasisFileResult {
-    // Upstream `generator.c:1949`: when `whole_file` is set, no basis file
+    // Upstream `generator.c:1962`: when `whole_file` is set, no basis file
     // is used - the entire file is sent as literals.
     if config.whole_file {
         return BasisFileResult::EMPTY;

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -63,7 +63,7 @@ pub struct ReceiverContext {
     /// Each entry is `(flat_start, ndx_start)`.
     /// Without INC_RECURSE, contains a single entry `(0, 0)`.
     ///
-    /// upstream: flist.c:2931 - `flist->ndx_start = prev->ndx_start + prev->used + 1`
+    /// upstream: flist.c:2966 - `flist->ndx_start = prev->ndx_start + prev->used + 1`
     pub(in crate::receiver) ndx_segments: Vec<(usize, i32)>,
     /// Index into `ndx_segments` of the oldest unreclaimed segment.
     ///
@@ -74,7 +74,7 @@ pub struct ReceiverContext {
     /// # Upstream Reference
     ///
     /// - `flist.c:101` - `first_flist` pointer
-    /// - `receiver.c:573` - `flist_free(first_flist)` advances `first_flist`
+    /// - `receiver.c:683` - `flist_free(first_flist)` advances `first_flist`
     pub(in crate::receiver) first_segment_idx: usize,
     /// Count of directory entries received so far across the initial file list
     /// and every INC_RECURSE sub-list, mirroring upstream's `dir_flist->used`.
@@ -113,7 +113,7 @@ pub struct ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2685` - `f_name(dir_flist->files[dir_ndx], NULL)` names the
+    /// - `flist.c:2720` - `f_name(dir_flist->files[dir_ndx], NULL)` names the
     ///   parent that every entry in the sub-list must live under.
     pub(in crate::receiver) dir_flist_names: Vec<PathBuf>,
     /// Cached file list reader for compression state continuity across sub-lists.
@@ -135,9 +135,9 @@ pub struct ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:599-604` - `check_filter(&daemon_filter_list, ...)` rejects
+    /// - `receiver.c:711-716` - `check_filter(&daemon_filter_list, ...)` rejects
     ///   excluded files before accepting transfer data
-    /// - `flist.c:254-272` - `path_is_daemon_excluded()` checks each path
+    /// - `flist.c:266-284` - `path_is_daemon_excluded()` checks each path
     ///   component against the daemon filter list
     pub(in crate::receiver) daemon_filter_set: Option<FilterSet>,
     /// Per-directory scoped filter chain for deletion protection.
@@ -192,7 +192,7 @@ pub struct ReceiverContext {
     /// Accumulated I/O error flags from the sender's file list for protocol < 30.
     ///
     /// For protocol < 30, the sender writes a 4-byte LE io_error flag after the
-    /// id lists (upstream: flist.c:2517-2518). Protocol >= 30 uses MSG_IO_ERROR
+    /// id lists (upstream: flist.c:2552-2553). Protocol >= 30 uses MSG_IO_ERROR
     /// or SAFE_FILE_LIST instead.
     pub(in crate::receiver) flist_io_error: i32,
     /// Per-operation thresholds for switching between sequential and parallel execution.
@@ -368,7 +368,7 @@ impl ReceiverContext {
         config: ServerConfig,
         pipeline: TransferPipeline,
     ) -> Self {
-        // upstream: flist.c:2923 - ndx_start = inc_recurse ? 1 : 0
+        // upstream: flist.c:2958 - ndx_start = inc_recurse ? 1 : 0
         let inc_recurse = handshake
             .compat_flags
             .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
@@ -385,7 +385,7 @@ impl ReceiverContext {
             None
         };
 
-        // upstream: clientserver.c:874-893 - daemon_filter_list is built from
+        // upstream: clientserver.c:876-895 - daemon_filter_list is built from
         // module filter/exclude/include directives and used by all roles.
         let daemon_filter_set = compile_daemon_filter_set(&config.daemon_filter_rules);
 
@@ -526,7 +526,7 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:2321` - `ndx = i + cur_flist->ndx_start`
+    /// - `generator.c:2338` - `ndx = i + cur_flist->ndx_start`
     pub(in crate::receiver) fn flat_to_wire_ndx(&self, flat_idx: usize) -> i32 {
         let segments = &self.ndx_segments;
         NDX_CONVERT_CALLS.fetch_add(1, Ordering::Relaxed);
@@ -664,7 +664,7 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:2051-2056` - `need_unsorted_flist = 1` when `iconv_opt`
+    /// - `options.c:2069-2074` - `need_unsorted_flist = 1` when `iconv_opt`
     /// - `flist.c:2496-2498` - "both sides keep an unsorted file-list array
     ///   because the names will differ on the sending and receiving sides"
     /// - `flist.c:2149-2153` - allocates a separate `flist->sorted[]`
@@ -750,7 +750,7 @@ impl ReceiverContext {
     /// **Client mode** (daemon pull - `main.c:1342-1343` `client_run !am_sender`):
     /// - `if (protocol_version >= 23) io_start_multiplex_in(f_in);`
     ///
-    /// **Server mode** (daemon/SSH receiver - `main.c:1167-1168` `do_recv`):
+    /// **Server mode** (daemon/SSH receiver - `main.c:1185-1186` `do_recv`):
     /// - `if (protocol_version >= 30) io_start_multiplex_in(f_in);`
     /// - Protocol < 30 uses `io_start_buffering_in()` instead (no multiplex).
     #[must_use]
@@ -832,8 +832,8 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2945 flist_free()` - frees completed file list segments
-    /// - `receiver.c:573` - `flist_free(first_flist)` in receiver transfer loop
+    /// - `flist.c:2980 flist_free()` - frees completed file list segments
+    /// - `receiver.c:683` - `flist_free(first_flist)` in receiver transfer loop
     pub(in crate::receiver) fn reclaim_oldest_segment(&mut self) {
         let first = self.first_segment_idx;
 

--- a/crates/transfer/src/receiver/dest_root.rs
+++ b/crates/transfer/src/receiver/dest_root.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 /// Reports whether a destination operand was written with a trailing path
 /// separator.
 ///
-/// Upstream rsync inspects the raw `dest_path` argument (`main.c:724-725`)
+/// Upstream rsync inspects the raw `dest_path` argument (`main.c:733-734`)
 /// after a final `strrchr('/')` to decide whether the operand ends with a
 /// directory marker. The detection is byte-level on Unix and matches either
 /// `'/'` or `'\\'` on Windows so paths produced by either separator convention
@@ -64,7 +64,7 @@ pub(in crate::receiver) fn dest_arg_has_trailing_slash(arg: &OsStr) -> bool {
 /// # `--mkpath` gating
 ///
 /// Upstream creates the destination root with a *single* `do_mkdir(dest_path)`
-/// (`main.c:788-792`), which fails with `ENOENT` when an ancestor directory is
+/// (`main.c:797-801`), which fails with `ENOENT` when an ancestor directory is
 /// missing. The whole missing chain is created only under `--mkpath`, via
 /// `make_path(dest_path)` (`main.c:736`). This helper mirrors that: with
 /// `mkpath == false` it uses [`std::fs::create_dir`] (single level), with
@@ -100,7 +100,7 @@ pub(in crate::receiver) fn dest_arg_has_trailing_slash(arg: &OsStr) -> bool {
 ///   `make_path(dest_path, ...)` creates the whole missing chain.
 /// - `main.c:778-792` - `get_local_name()` pre-flight `do_mkdir(dest_path, ACCESSPERMS)`
 ///   (single level, no ancestor creation) when `--mkpath` was not requested.
-/// - `main.c:794-796` - sets `FLAG_DIR_CREATED` on the first flist entry when
+/// - `main.c:803-805` - sets `FLAG_DIR_CREATED` on the first flist entry when
 ///   its basename is `.` (deferred follow-up; oc-rsync's delete path does
 ///   not currently consume that flag).
 pub fn ensure_dest_root_exists(
@@ -113,7 +113,7 @@ pub fn ensure_dest_root_exists(
     if dry_run {
         return Ok(false);
     }
-    // upstream: main.c:788 - the non-mkpath dir branch only fires for a
+    // upstream: main.c:797 - the non-mkpath dir branch only fires for a
     // multi-file transfer or a trailing-slash operand. A single-file
     // no-slash operand names the destination file itself (the operand
     // basename was already split off by `apply_single_file_rename`), so
@@ -159,7 +159,7 @@ pub fn ensure_dest_root_exists(
                 ));
             }
             // upstream: main.c:736 make_path (full chain) only under --mkpath;
-            // otherwise main.c:788 do_mkdir creates a single level and fails
+            // otherwise main.c:797 do_mkdir creates a single level and fails
             // with ENOENT when an ancestor is missing.
             if mkpath {
                 std::fs::create_dir_all(dest_root).map(|()| true)

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -137,7 +137,7 @@ impl ReceiverContext {
             return Ok(Vec::new());
         }
 
-        // upstream: generator.c:1261-1262 - check_filter(&daemon_filter_list, ...)
+        // upstream: generator.c:1273-1274 - check_filter(&daemon_filter_list, ...)
         // skips daemon-excluded directories before creation.
         let daemon_filters = self.daemon_filter_set();
         let dir_entries: Vec<(usize, PathBuf, PathBuf)> = self
@@ -182,7 +182,7 @@ impl ReceiverContext {
         // `cd+++++++++ <name>/`, an existing one emits a metadata-only row
         // gated by the standard significance check.
         let mut dir_was_new: Vec<bool> = Vec::with_capacity(dir_entries.len());
-        // upstream: generator.c:1337-1340 - probe each new parent directory's
+        // upstream: generator.c:1349-1352 - probe each new parent directory's
         // default POSIX ACL when !preserve_perms so dest_mode() folds the bits
         // in. The probe also drives the `DEBUG_GTE(ACL, 1)` emission in
         // `acls.c:1133-1134`. Mirror the gating exactly: only probe when
@@ -263,7 +263,7 @@ impl ReceiverContext {
                 if probe_default_perms {
                     if let Some(parent) = dir_path.parent() {
                         if probed_parents.insert(parent.to_path_buf()) {
-                            // upstream: generator.c:1339 dflt_perms = default_perms_for_dir(dn)
+                            // upstream: generator.c:1351 dflt_perms = default_perms_for_dir(dn)
                             // Pass umask = 0; upstream prints the ACL-derived bits, not
                             // the umask-derived fallback, so the trace value is umask-independent.
                             let _ = ::metadata::default_perms_for_dir(parent, 0);
@@ -514,9 +514,9 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:1317-1326` - `make_path()` for missing parents when
+    /// - `generator.c:1329-1338` - `make_path()` for missing parents when
     ///   `relative_paths && !implied_dirs`
-    /// - `generator.c:1472-1475` - retry `mkdir` after `make_path()` when
+    /// - `generator.c:1484-1487` - retry `mkdir` after `make_path()` when
     ///   `relative_paths` and initial `mkdir` returns `ENOENT`
     pub(in crate::receiver) fn ensure_relative_parents(&self, dest_dir: &Path) {
         if !self.config.flags.relative || self.config.flags.skip_dest_writes() {
@@ -600,7 +600,7 @@ impl ReceiverContext {
     /// # Upstream Reference
     ///
     /// - `generator.c:1432` - `recv_generator()` creates directories
-    /// - `generator.c:1472-1475` - retry `mkdir` after `make_path()`
+    /// - `generator.c:1484-1487` - retry `mkdir` after `make_path()`
     /// - `generator.c:1480-1483` - `itemize()` before metadata application
     pub(in crate::receiver) fn create_directory_incremental(
         &self,
@@ -858,7 +858,7 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:2080-2133` - `touch_up_dirs(dir_flist, -1)` iterates in
+    /// - `generator.c:2093-2146` - `touch_up_dirs(dir_flist, -1)` iterates in
     ///   reverse order and repairs perms then times.
     /// - `generator.c:2122-2127` - `fix_dir_perms = !am_root && !(mode &
     ///   S_IWUSR)` restores the real directory mode.
@@ -1167,7 +1167,7 @@ mod touch_up_dirs_tests {
     /// mtime with the current time. `touch_up_dirs` must re-apply the
     /// original mtime from the file list entry.
     ///
-    /// upstream: generator.c:2080-2133 - touch_up_dirs()
+    /// upstream: generator.c:2093-2146 - touch_up_dirs()
     #[test]
     fn restores_directory_mtime_after_file_writes() {
         let dir = test_support::create_tempdir();

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -49,8 +49,8 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:1544` - `if (preserve_links && ftype == FT_SYMLINK)`
-    /// - `generator.c:1591` - `atomic_create(file, fname, sl, ...)`
+    /// - `generator.c:1556` - `if (preserve_links && ftype == FT_SYMLINK)`
+    /// - `generator.c:1603` - `atomic_create(file, fname, sl, ...)`
     #[cfg(unix)]
     pub(in crate::receiver) fn create_symlinks<W: crate::writer::MsgInfoSender + ?Sized>(
         &self,
@@ -117,11 +117,11 @@ impl ReceiverContext {
             // change, not a creation.
             let mut dest_existed = false;
 
-            // upstream: generator.c:1561 - quick_check_ok(FT_SYMLINK, ...)
+            // upstream: generator.c:1573 - quick_check_ok(FT_SYMLINK, ...)
             if let Ok(existing_target) = std::fs::read_link(&link_path) {
                 dest_existed = true;
                 if existing_target == *target {
-                    // upstream: generator.c:1563 - even on the up-to-date branch
+                    // upstream: generator.c:1575 - even on the up-to-date branch
                     // `set_file_attrs(fname, file, &sx, NULL, maybe_ATTRS_REPORT)`
                     // still runs so a stale on-disk mtime is corrected.
                     let symlink_options = MetadataOptions::new()
@@ -146,7 +146,7 @@ impl ReceiverContext {
                     let iflags = ItemFlags::from_raw(0);
                     let _ = self.emit_itemize(writer, &iflags, entry);
                     // upstream: log.c log_item / send_directory NAME emissions
-                    // upstream: generator.c:1133 - "%s is uptodate" at INFO_GTE(NAME, 2)
+                    // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
                 }
@@ -259,12 +259,12 @@ impl ReceiverContext {
             }
 
             // Ensure parent directory exists for --relative paths.
-            // upstream: generator.c:1317-1326 - make_path() for relative_paths
+            // upstream: generator.c:1329-1338 - make_path() for relative_paths
             if let Some(parent) = link_path.parent() {
                 let _ = fs::create_dir_all(parent);
             }
 
-            // upstream: generator.c:1591 - atomic_create() -> do_symlink()
+            // upstream: generator.c:1603 - atomic_create() -> do_symlink()
             //
             // SEC-1.h: when the sandbox is plumbed and the destination
             // parent is the sandbox root, the create goes through
@@ -302,7 +302,7 @@ impl ReceiverContext {
                 }
                 return Err(e);
             }
-            // upstream: generator.c:1592 - `set_file_attrs(fname, file, NULL, NULL, 0)`
+            // upstream: generator.c:1604 - `set_file_attrs(fname, file, NULL, NULL, 0)`
             // runs immediately after `atomic_create` -> `do_symlink` so the new
             // symlink's mtime matches the sender-supplied value. Without this
             // step the receiver-created symlink wears the wall-clock time from
@@ -352,8 +352,8 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:1544` - `if (preserve_links && ftype == FT_SYMLINK)`
-    /// - `generator.c:1591` - `atomic_create(file, fname, sl, ...)`
+    /// - `generator.c:1556` - `if (preserve_links && ftype == FT_SYMLINK)`
+    /// - `generator.c:1603` - `atomic_create(file, fname, sl, ...)`
     #[cfg(windows)]
     pub(in crate::receiver) fn create_symlinks<W: crate::writer::MsgInfoSender + ?Sized>(
         &mut self,
@@ -416,7 +416,7 @@ impl ReceiverContext {
             // stats.created_symlinks (upstream generator.c:1561, `statret < 0`).
             let mut dest_existed = false;
 
-            // upstream: generator.c:1561 - quick_check_ok(FT_SYMLINK, ...)
+            // upstream: generator.c:1573 - quick_check_ok(FT_SYMLINK, ...)
             if let Ok(existing_target) = std::fs::read_link(&link_path) {
                 dest_existed = true;
                 if existing_target == *target {
@@ -443,7 +443,7 @@ impl ReceiverContext {
                     // upstream: generator.c:1565 - symlink up-to-date, metadata only
                     let iflags = ItemFlags::from_raw(0);
                     let _ = self.emit_itemize(writer, &iflags, entry);
-                    // upstream: generator.c:1133 - "%s is uptodate" at INFO_GTE(NAME, 2)
+                    // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
                 }
@@ -488,12 +488,12 @@ impl ReceiverContext {
             }
 
             // Ensure parent directory exists for --relative paths.
-            // upstream: generator.c:1317-1326 - make_path() for relative_paths
+            // upstream: generator.c:1329-1338 - make_path() for relative_paths
             if let Some(parent) = link_path.parent() {
                 let _ = fs::create_dir_all(parent);
             }
 
-            // upstream: generator.c:1591 - atomic_create() -> do_symlink().
+            // upstream: generator.c:1603 - atomic_create() -> do_symlink().
             if let Err(e) = create_windows_symlink(target, &link_path) {
                 // A Windows file symbolic link cannot be created without
                 // privilege and has no junction fallback (directory links do
@@ -522,7 +522,7 @@ impl ReceiverContext {
                 return Err(e);
             }
 
-            // upstream: generator.c:1592 - set_file_attrs() runs immediately
+            // upstream: generator.c:1604 - set_file_attrs() runs immediately
             // after atomic_create -> do_symlink so the new link's mtime matches
             // the sender-supplied value.
             let symlink_options = MetadataOptions::new()
@@ -644,7 +644,7 @@ impl ReceiverContext {
     ///
     /// - `hlink.c:hard_link_check()` - skips followers, links to leader
     /// - `hlink.c:finish_hard_link()` - creates links after leader transfer completes
-    /// - `generator.c:1539` - `F_HLINK_NOT_FIRST` check before `hard_link_check()`
+    /// - `generator.c:1551` - `F_HLINK_NOT_FIRST` check before `hard_link_check()`
     pub(in crate::receiver) fn create_hardlinks<W: crate::writer::MsgInfoSender + ?Sized>(
         &mut self,
         dest_dir: &Path,
@@ -937,7 +937,7 @@ impl ReceiverContext {
 
 /// Prepends the `/rsyncd-munged/` prefix to a symlink target.
 ///
-/// Mirrors upstream `flist.c:1122-1126` where the receiver prepends
+/// Mirrors upstream `flist.c:1150-1154` where the receiver prepends
 /// `SYMLINK_PREFIX` to the wire target so the on-disk symlink cannot resolve
 /// outside the module root when followed. Only invoked when the daemon module
 /// has `munge symlinks = yes` (or the `!use_chroot` auto default).

--- a/crates/transfer/src/receiver/directory/missing_args.rs
+++ b/crates/transfer/src/receiver/directory/missing_args.rs
@@ -10,7 +10,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `generator.c:1348-1354` - `if (missing_args == 2 && file->mode == 0)`:
+//! - `generator.c:1360-1366` - `if (missing_args == 2 && file->mode == 0)`:
 //!   apply the filter list, then `delete_item()` when `statret == 0`.
 //! - `flist.c:2254-2258` - `missing_args == 2` sender branch that emits
 //!   the mode-0 sentinel this handler consumes.
@@ -51,7 +51,7 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:1348-1354` - `missing_args == 2 && file->mode == 0`
+    /// - `generator.c:1360-1366` - `missing_args == 2 && file->mode == 0`
     ///   branch that calls `delete_item()` for an existing destination
     ///   and falls through (no creation) for a missing destination.
     pub(in crate::receiver) fn process_missing_args_sentinels(

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -55,7 +55,7 @@ impl ReceiverContext {
     /// # Upstream Reference
     ///
     /// - `generator.c:1627` - `if (preserve_devices && IS_DEVICE(file->mode))`
-    /// - `generator.c:1663` - `atomic_create(file, fname, NULL, ...)`
+    /// - `generator.c:1675` - `atomic_create(file, fname, NULL, ...)`
     #[cfg(unix)]
     pub(in crate::receiver) fn create_specials<W: crate::writer::MsgInfoSender + ?Sized>(
         &self,
@@ -88,7 +88,7 @@ impl ReceiverContext {
             let node_path = dest_dir.join(relative_path);
 
             // Ensure parent directory exists for --relative paths.
-            // upstream: generator.c:1317-1326 make_path() for relative_paths
+            // upstream: generator.c:1329-1338 make_path() for relative_paths
             if let Some(parent) = node_path.parent() {
                 let _ = fs::create_dir_all(parent);
             }
@@ -109,7 +109,7 @@ impl ReceiverContext {
 
             if !up_to_date {
                 dest_existed = fs::symlink_metadata(&node_path).is_ok();
-                // upstream: generator.c:1667 - `else if (basis_dir[0] != NULL)`
+                // upstream: generator.c:1679 - `else if (basis_dir[0] != NULL)`
                 // is reached only when the destination is absent (`statret !=
                 // 0`). An identical node in a `--compare-dest` basis leaves the
                 // destination absent; a `--link-dest` basis is hard-linked. A
@@ -190,7 +190,7 @@ impl ReceiverContext {
                     }
                 }
 
-                // upstream: generator.c:1663 atomic_create -> do_mknod_at
+                // upstream: generator.c:1675 atomic_create -> do_mknod_at
                 let create_result = if is_device {
                     create_device_node_from_parts(
                         &node_path,
@@ -246,7 +246,7 @@ impl ReceiverContext {
             }
 
             if up_to_date {
-                // upstream: generator.c:1133 - "%s is uptodate" at INFO_GTE(NAME, 2)
+                // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                 let iflags = ItemFlags::from_raw(0);
                 let _ = self.emit_itemize(writer, &iflags, entry);
                 info_log!(Name, 2, "{} is uptodate", relative_path.display());

--- a/crates/transfer/src/receiver/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/file_list/filter_recheck.rs
@@ -54,7 +54,7 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:1021-1024` `recv_file_entry()`
+    /// - `flist.c:1049-1052` `recv_file_entry()`
     pub(in crate::receiver) fn recheck_received_filter(&self) -> io::Result<()> {
         // upstream: flist.c:1021 - `!trust_sender_filter` guards the whole
         // re-check (options.c:2512/main.c:1496 set it for local/--trust-sender).

--- a/crates/transfer/src/receiver/file_list/incremental.rs
+++ b/crates/transfer/src/receiver/file_list/incremental.rs
@@ -49,7 +49,7 @@ pub struct IncrementalFileListReceiver<R> {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:2051-2056` - `need_unsorted_flist = 1` when `iconv_opt`
+    /// - `options.c:2069-2074` - `need_unsorted_flist = 1` when `iconv_opt`
     /// - `flist.c:2496-2498` - "both sides keep an unsorted file-list array
     ///   because the names will differ on the sending and receiving sides"
     pub(in crate::receiver) iconv_reorder_suppressed: bool,

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -27,7 +27,7 @@
 //!
 //! - `rsync.c:318-429` - `read_ndx_and_attrs()` frame dispatch
 //! - `io.c:1750-1786` - `wait_for_receiver()` one-frame fetch
-//! - `generator.c:2299-2368` - `generate_files()` on-demand fetch loop
+//! - `generator.c:2316-2385` - `generate_files()` on-demand fetch loop
 
 use std::io::{self, Read};
 
@@ -400,7 +400,7 @@ mod tests {
     /// `overflow in read_varint`, since `int_byte_extra[0xFF >> 2] = 5 > 4`).
     ///
     /// upstream: flist.c:2152 `write_ndx(NDX_FLIST_OFFSET - dir_ndx)`,
-    /// io.c:2243 `write_ndx()`, flist.c:2112 `write_end_of_flist()`.
+    /// io.c:2318 `write_ndx()`, flist.c:2112 `write_end_of_flist()`.
     #[rustfmt::skip]
     const UPSTREAM_INC_RECURSE_FRAME: &[u8] = &[
         0xac, 0x01, 0x01, 0x2e, 0x00, 0x00, 0x10, 0x6a, 0x66, 0x1f, 0x52, 0xf0,
@@ -656,7 +656,7 @@ mod tests {
 
     /// A sub-list entry whose dirname escapes its declared parent must be rejected.
     ///
-    /// WHY: upstream `flist.c:2684-2695` compares every sub-list entry's dirname
+    /// WHY: upstream `flist.c:2719-2730` compares every sub-list entry's dirname
     /// against `f_name(dir_flist->files[dir_ndx])` and, on a mismatch, aborts with
     /// `exit_cleanup(RERR_UNSUPPORTED)` ("ABORTING due to invalid path from
     /// sender"). Without this check a hostile sender could frame a sub-list for a

--- a/crates/transfer/src/receiver/file_list/prune.rs
+++ b/crates/transfer/src/receiver/file_list/prune.rs
@@ -77,7 +77,7 @@ pub(in crate::receiver) fn prune_empty_dirs_pass(
         let depth = entry_depth(entry) as i64;
 
         if is_dir && depth > 0 {
-            // upstream: flist.c:3133-3140 - "Dump empty dirs when coming back
+            // upstream: flist.c:3168-3175 - "Dump empty dirs when coming back
             // down." Walk back through the candidate chain via prev_i,
             // clearing any candidates whose depth is at or below the current
             // dir's depth that were never reprieved.

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -61,7 +61,7 @@ impl ReceiverContext {
             self.flist_io_error |= flist_reader.io_error();
         }
 
-        // upstream: flist.c:2726-2727 - recv_id_list() called when !inc_recurse
+        // upstream: flist.c:2761-2762 - recv_id_list() called when !inc_recurse
         let inc_recurse = self
             .compat_flags
             .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
@@ -89,7 +89,7 @@ impl ReceiverContext {
             self.remap_flist_ownership_from_id_lists();
         }
 
-        // upstream: flist.c:2738-2742 - read io_error flag for protocol < 30.
+        // upstream: flist.c:2773-2777 - read io_error flag for protocol < 30.
         // The sender writes write_int(f, io_error) as a 4-byte LE integer after
         // the id lists. Protocol >= 30 uses MSG_IO_ERROR or SAFE_FILE_LIST instead.
         if self.protocol.uses_fixed_encoding() {
@@ -101,7 +101,7 @@ impl ReceiverContext {
             }
         }
 
-        // upstream: flist.c:1646 - send_file_entry() is called with flist->used
+        // upstream: flist.c:1682 - send_file_entry() is called with flist->used
         // (readdir-order position) BEFORE flist_sort_and_clean(). Leader GNUM values
         // (F_HL_GNUM) are readdir-order wire NDXes. Replace the u32::MAX sentinel
         // with the actual readdir-order wire NDX so followers can find their leader
@@ -116,10 +116,10 @@ impl ReceiverContext {
             }
         }
 
-        // upstream: flist.c:2736 - flist_sort_and_clean() after recv_id_list()
+        // upstream: flist.c:2771 - flist_sort_and_clean() after recv_id_list()
         //
         // When `--iconv` is in effect, upstream sets `need_unsorted_flist = 1`
-        // (options.c:2056) so the receiver's NDX-addressed `flist->files[]`
+        // (options.c:2074) so the receiver's NDX-addressed `flist->files[]`
         // array stays in sender scan order; only a separate `flist->sorted[]`
         // pointer array is reordered. We do not maintain a parallel pointer
         // array, so we mirror upstream by skipping the in-place reorder when
@@ -140,7 +140,7 @@ impl ReceiverContext {
         // are not surfaced elsewhere.
         //
         // When `--iconv` is in effect, upstream sets `need_unsorted_flist = 1`
-        // (options.c:2056) so the receiver's NDX-addressed `flist->files[]`
+        // (options.c:2074) so the receiver's NDX-addressed `flist->files[]`
         // array stays in sender scan order; only a separate `flist->sorted[]`
         // pointer array is reordered and dedup-cleared. We do not maintain a
         // parallel pointer array, so we mirror upstream by skipping the in-place
@@ -274,7 +274,7 @@ impl ReceiverContext {
     /// # Upstream Reference
     ///
     /// - `flist.c:recv_file_list()` - per-sub-list entry decode
-    /// - `flist.c:2931` - `ndx_start = prev->ndx_start + prev->used + 1`
+    /// - `flist.c:2966` - `ndx_start = prev->ndx_start + prev->used + 1`
     pub(in crate::receiver) fn receive_one_extra_segment<R: Read + ?Sized>(
         &mut self,
         reader: &mut R,
@@ -378,7 +378,7 @@ impl ReceiverContext {
         self.dir_flist_used += count_directories(&self.file_list[flat_start..]);
         self.record_dir_flist_names(flat_start);
 
-        // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
+        // upstream: flist.c:2966 - ndx_start = prev->ndx_start + prev->used + 1
         self.ndx_segments.push((flat_start, seg_ndx_start));
 
         // Restore the cached reader so the next segment continues the same
@@ -543,7 +543,7 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:272-347` `delete_in_dir()` - per-directory extras
+    /// - `generator.c:279-354` `delete_in_dir()` - per-directory extras
     ///   computation that this hook publishes a plan for.
     pub(in crate::receiver) fn publish_segment_to_delete_pipeline(
         &self,

--- a/crates/transfer/src/receiver/file_list/sanitize.rs
+++ b/crates/transfer/src/receiver/file_list/sanitize.rs
@@ -25,7 +25,7 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:757`: `clean_fname(thisname, CFN_REFUSE_DOT_DOT_DIRS)`
+    /// - `flist.c:769`: `clean_fname(thisname, CFN_REFUSE_DOT_DOT_DIRS)`
     /// - `options.c:2595`: `trust_sender_args = trust_sender_filter = 1`
     pub(in crate::receiver) fn sanitize_file_list(&mut self) -> usize {
         let relative_paths = self.config.flags.relative;
@@ -39,7 +39,7 @@ impl ReceiverContext {
                 let path = entry.path();
 
                 // Check for absolute paths (reject unless --relative is active).
-                // upstream: flist.c:757 `!relative_paths && *thisname == '/'`
+                // upstream: flist.c:769 `!relative_paths && *thisname == '/'`
                 if !relative_paths && path.has_root() {
                     info_log!(
                         Misc,
@@ -80,7 +80,7 @@ impl ReceiverContext {
                 }
 
                 // Check for `..` path components (always rejected).
-                // upstream: flist.c:757 `clean_fname(thisname, CFN_REFUSE_DOT_DOT_DIRS) < 0`
+                // upstream: flist.c:769 `clean_fname(thisname, CFN_REFUSE_DOT_DOT_DIRS) < 0`
                 if path_contains_dot_dot(path) {
                     info_log!(
                         Misc,
@@ -99,7 +99,7 @@ impl ReceiverContext {
             original_len - self.file_list.len()
         };
 
-        // upstream: flist.c:3071-3084 - strip_root in flist_sort_and_clean()
+        // upstream: flist.c:3106-3119 - strip_root in flist_sort_and_clean()
         // Runs unconditionally: leading-slash stripping is a functional
         // requirement for --relative mode, not a security check.
         if relative_paths {

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -109,7 +109,7 @@ impl ReceiverContext {
     /// Upstream emits a directory's `-v` name only when `set_file_attrs()`
     /// changed it (`generator.c:1503-1505`). For the implied root `.` that is
     /// true when oc created the destination root (`FLAG_DIR_CREATED`,
-    /// `main.c:794-796`) or when the root's pre-transfer attributes differ from
+    /// `main.c:803-805`) or when the root's pre-transfer attributes differ from
     /// the source entry. Must be consulted BEFORE `create_directories` applies
     /// the root's metadata (and before child mkdirs bump the root mtime), so the
     /// stat reflects the pre-transfer state - the same pre-mkdir gate the `-i`
@@ -245,14 +245,14 @@ impl ReceiverContext {
     /// # Upstream Reference
     ///
     /// - `generator.c:574-576` - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
-    /// - `main.c:794-796` - `FLAG_DIR_CREATED` for a pre-flight-mkdir'd root
+    /// - `main.c:803-805` - `FLAG_DIR_CREATED` for a pre-flight-mkdir'd root
     /// - `log.c:707-710` - direction glyph selection
     pub(in crate::receiver) fn render_itemize_line(
         &self,
         iflags: &crate::generator::ItemFlags,
         entry: &protocol::flist::FileEntry,
     ) -> Option<String> {
-        // upstream: main.c:794-796 - when the receiver pre-flight-mkdirs the
+        // upstream: main.c:803-805 - when the receiver pre-flight-mkdirs the
         // destination root, `flist->files[0]->flags |= FLAG_DIR_CREATED`. The
         // generator's `itemize()` then sees `statret < 0` for the root entry,
         // ORs in `ITEM_IS_NEW`, and emits `cd+++++++++ ./`. oc-rsync's
@@ -274,7 +274,7 @@ impl ReceiverContext {
             return None;
         }
         let effective_iflags = if is_created_root_dir {
-            // upstream: generator.c:1468-1471 + generator.c:566-572 - a root that
+            // upstream: generator.c:1480-1483 + generator.c:573-579 - a root that
             // the pre-flight mkdir created this run is itemize()'d with
             // `statret < 0`, which takes the `else` branch and ORs
             // `ITEM_LOCAL_CHANGE | ITEM_IS_NEW` WITHOUT computing any attribute
@@ -355,7 +355,7 @@ impl ReceiverContext {
     /// each follower from `finish_hard_link()` -> `maybe_hard_link()`, which
     /// writes `NDX + write_shortint(iflags) + write_vstring(xname)` to
     /// `sock_f_out`; the peer's sender reads those attrs and logs the row
-    /// (`sender.c:287` `maybe_log_item`). Without this a server-mode receiver
+    /// (`sender.c:293` `maybe_log_item`). Without this a server-mode receiver
     /// (the remote end of a push) drops every follower row, because
     /// [`emit_itemize`](Self::emit_itemize) is a no-op off the client.
     ///

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -82,7 +82,7 @@ const PHASE1_CHECKSUM_LENGTH: NonZeroU8 =
 /// Upstream rsync switches to `SUM_LENGTH` (16) for phase 2 redo to ensure
 /// maximum integrity after a whole-file checksum failure.
 ///
-/// (upstream: generator.c:2163 `csum_length = SUM_LENGTH`)
+/// (upstream: generator.c:2178 `csum_length = SUM_LENGTH`)
 const REDO_CHECKSUM_LENGTH: NonZeroU8 =
     NonZeroU8::new(signature::block_size::MAX_SUM_LENGTH).unwrap();
 

--- a/crates/transfer/src/receiver/pipeline_setup.rs
+++ b/crates/transfer/src/receiver/pipeline_setup.rs
@@ -96,13 +96,13 @@ pub(in crate::receiver) fn apply_acls_from_receiver_cache(
 /// Returns `Some(filter_set)` when rules are present, `None` when empty.
 /// Used by the receiver to reject daemon-excluded files before accepting
 /// transfer data, mirroring upstream `check_filter(&daemon_filter_list, ...)`
-/// in `receiver.c:599-604`.
+/// in `receiver.c:711-716`.
 ///
 /// # Upstream Reference
 ///
 /// - `clientserver.c:874-893` - daemon filter list is built from module
 ///   filter/exclude/include/exclude_from/include_from directives
-/// - `receiver.c:599-604` - per-file check against daemon_filter_list
+/// - `receiver.c:711-716` - per-file check against daemon_filter_list
 pub(in crate::receiver) fn compile_daemon_filter_set(
     rules: &[FilterRuleWireFormat],
 ) -> Option<FilterSet> {

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -29,7 +29,7 @@ use super::apply_acls_from_receiver_cache;
 ///
 /// # Upstream Reference
 ///
-/// - `generator.c:1539` - `F_HLINK_NOT_FIRST(file)` check
+/// - `generator.c:1551` - `F_HLINK_NOT_FIRST(file)` check
 /// - `hlink.c:284` - `hard_link_check()` called for non-first entries
 pub(super) fn is_hardlink_follower(entry: &FileEntry) -> bool {
     entry.hlinked() && !entry.hlink_first()
@@ -39,7 +39,7 @@ pub(super) fn is_hardlink_follower(entry: &FileEntry) -> bool {
 ///
 /// Returns `true` when the destination file matches the source entry (skip transfer).
 ///
-/// Follows upstream `generator.c:617 quick_check_ok()` evaluation order:
+/// Follows upstream `generator.c:624 quick_check_ok()` evaluation order:
 /// 1. Size mismatch - always needs transfer
 /// 2. `always_checksum` - compute file checksum and compare (ignores mtime)
 /// 3. `size_only` - size matched, skip transfer
@@ -58,7 +58,7 @@ pub(super) fn quick_check_matches(
     if dest_meta.len() != entry.size() {
         return false;
     }
-    // upstream: generator.c:626 - always_checksum compares file checksums
+    // upstream: generator.c:633 - always_checksum compares file checksums
     // instead of relying on mtime. Takes priority over size_only and ignore_times.
     if let Some(algorithm) = always_checksum {
         return match entry.checksum() {
@@ -68,11 +68,11 @@ pub(super) fn quick_check_matches(
             None => false,
         };
     }
-    // upstream: generator.c:632 - `if (size_only) return 1;` after size match
+    // upstream: generator.c:639 - `if (size_only) return 1;` after size match
     if size_only {
         return true;
     }
-    // upstream: generator.c:635 - ignore_times forces transfer
+    // upstream: generator.c:642 - ignore_times forces transfer
     if !preserve_times {
         return false;
     }
@@ -110,7 +110,7 @@ pub(super) fn quick_check_matches(
 ///
 /// Used by `--update` (`-u`) to skip files where the destination is already newer.
 ///
-/// upstream: generator.c:1709 - `file->modtime - sx.st.st_mtime < modify_window`
+/// upstream: generator.c:1722 - `file->modtime - sx.st.st_mtime < modify_window`
 /// with modify_window=0, this simplifies to `dest_mtime > source_mtime`.
 pub(super) fn dest_mtime_newer(dest_meta: &fs::Metadata, source_entry: &FileEntry) -> bool {
     #[cfg(unix)]
@@ -242,14 +242,14 @@ struct ReferenceMatch<'a> {
 ///
 /// Upstream keeps the FIRST directory that reaches the highest `match_level`: a
 /// later directory only wins by strictly exceeding the current level, and a
-/// level-3 (attrs-exact) match ends the scan immediately (generator.c:967-983).
+/// level-3 (attrs-exact) match ends the scan immediately (generator.c:979-995).
 /// Directories whose basis file is missing, non-regular, or fails
 /// `quick_check_ok` contribute at most match_level 1 and are ignored here.
 ///
 /// The basis-dir entry is stat'd with `lstat` by default to mirror upstream
 /// `link_stat(cmpbuf, &sxp->st, 0)`. When `copy_links` is set (`-L`), it is
 /// stat'd with `stat` so a basis-dir symlink to a regular file is accepted,
-/// matching `link_stat()`'s dispatch to `x_stat` (flist.c:234).
+/// matching `link_stat()`'s dispatch to `x_stat` (flist.c:246).
 ///
 /// # Upstream Reference
 ///
@@ -387,7 +387,7 @@ pub(super) fn try_reference_dest(
     let dest_path = dest_dir.join(relative_path);
     match best.ref_dir.kind {
         ReferenceDirectoryKind::Compare => {
-            // upstream: generator.c:995-1023 - a COMPARE_DEST match at level 3 is
+            // upstream: generator.c:1007-1035 - a COMPARE_DEST match at level 3 is
             // already correct, so the file finishes with no local copy and the
             // destination stays absent. At level 2 (attrs differ) it falls
             // through to copy_altdest_file so the destination reflects the
@@ -603,7 +603,7 @@ pub(super) fn try_reference_dest_non(
         ReferenceDirectoryKind::Compare => true,
         // upstream: generator.c:1118-1136 - LINK_DEST hard-links the basis node.
         ReferenceDirectoryKind::Link => hard_link_reference_non(&ref_path, &dest_path),
-        // upstream: generator.c:1591/1667 - COPY_DEST (and any non-level-3 match)
+        // upstream: generator.c:1603/1667 - COPY_DEST (and any non-level-3 match)
         // falls through to atomic_create, which materialises the node from the
         // flist entry. There is no payload to copy for a non-regular file.
         ReferenceDirectoryKind::Copy => false,
@@ -728,10 +728,10 @@ fn copy_reference_file(
             true
         }
         Err(error) => {
-            // upstream: generator.c:919 - rsyserr(FINFO, errno,
+            // upstream: generator.c:931 - rsyserr(FINFO, errno,
             // "copy_file %s => %s", full_fname(src), copy_to) under
             // INFO_GTE(COPY, 1). The flag is part of info_verbosity[1]
-            // (options.c:241) so this fires at `-v` or `--info=COPY`. Wording
+            // (options.c:251) so this fires at `-v` or `--info=COPY`. Wording
             // mirrors upstream's rsyserr format: `copy_file SRC => DST: ERRSTR (ERRNO)`.
             let errno = error.raw_os_error().unwrap_or(0);
             info_log!(
@@ -844,10 +844,10 @@ mod io_uring_linkat_tests {
 
 /// Pinning tests for `--info=COPY` emissions on `--copy-dest` failures.
 ///
-/// upstream: generator.c:919 - `INFO_GTE(COPY, 1)` gates an `rsyserr` call in
+/// upstream: generator.c:931 - `INFO_GTE(COPY, 1)` gates an `rsyserr` call in
 /// `copy_altdest_file()` whose wording reads:
 ///   `copy_file SRC => DST: STRERROR (ERRNO)`
-/// COPY sits in `info_verbosity[1]` (options.c:241) so the flag is enabled at
+/// COPY sits in `info_verbosity[1]` (options.c:251) so the flag is enabled at
 /// `-v` and any explicit `--info=COPY`.
 #[cfg(unix)]
 #[cfg(test)]
@@ -1009,10 +1009,10 @@ mod info_copy_emission_tests {
 /// Regression tests for symlink handling in basis-dir lookups under
 /// `--copy-dest` / `--link-dest` / `--compare-dest`.
 ///
-/// upstream: `generator.c:953` — `link_stat(cmpbuf, &sxp->st, 0)` followed by
+/// upstream: `generator.c:965` — `link_stat(cmpbuf, &sxp->st, 0)` followed by
 /// `!S_ISREG(sxp->st.st_mode)` filters out a basis-dir entry that is itself a
 /// symlink (unless `copy_links` is set, in which case `link_stat()` falls
-/// through to `x_stat()` per `flist.c:234`). Without this gate the receiver
+/// through to `x_stat()` per `flist.c:246`). Without this gate the receiver
 /// would silently copy or hard-link from a symlink target it should not have
 /// consumed, diverging from upstream over remote-shell transports where the
 /// upstream `alt-dest.test` exercises the same scenario via `lsh.sh`.

--- a/crates/transfer/src/receiver/stats.rs
+++ b/crates/transfer/src/receiver/stats.rs
@@ -121,7 +121,7 @@ pub struct TransferStats {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2518`: `write_int(f, ignore_errors ? 0 : io_error);`
+    /// - `flist.c:2553`: `write_int(f, ignore_errors ? 0 : io_error);`
     pub io_error: i32,
     /// Number of `MSG_ERROR` messages received from the remote sender.
     ///
@@ -191,7 +191,7 @@ pub struct TransferStats {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:970-974` - `send_msg_int(MSG_REDO, ndx)` queues for redo
+    /// - `receiver.c:1093-1097` - `send_msg_int(MSG_REDO, ndx)` queues for redo
     /// - `generator.c:2160-2199` - generator processes redo queue in phase 2
     pub redo_count: usize,
 

--- a/crates/transfer/src/receiver/tests/create_specials.rs
+++ b/crates/transfer/src/receiver/tests/create_specials.rs
@@ -59,7 +59,7 @@ fn special_receiver_config() -> ServerConfig {
     }
 }
 
-/// upstream: generator.c:1663 - `FT_SPECIAL` entries are materialised via
+/// upstream: generator.c:1675 - `FT_SPECIAL` entries are materialised via
 /// `atomic_create -> do_mknod_at`. Without `create_specials` the receiver
 /// dropped the FIFO entirely; this test fails (dest is empty) on the pre-fix
 /// receiver and passes once the node is created.

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/finalize_flush_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/finalize_flush_tests.rs
@@ -14,9 +14,9 @@
 //!
 //! # Upstream Reference
 //!
-//! - `main.c:1067` - `do_recv()` child path `io_flush(FULL_FLUSH)` after the
+//! - `main.c:1085` - `do_recv()` child path `io_flush(FULL_FLUSH)` after the
 //!   receiver writes its final NDX_DONE.
-//! - `main.c:1117` / `main.c:1123` - `do_recv()` parent path
+//! - `main.c:1135` / `main.c:1141` - `do_recv()` parent path
 //!   `io_flush(FULL_FLUSH)` after `handle_stats(-1)` and after the final
 //!   NDX_DONE write.
 

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/legacy_goodbye_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/legacy_goodbye_tests.rs
@@ -4,7 +4,7 @@
 //! just NDX_DONE as 4-byte little-endian i32, without NDX_FLIST_EOF
 //! or NDX_DEL_STATS messages.
 //!
-//! upstream: main.c:875-906 `read_final_goodbye()`
+//! upstream: main.c:893-924 `read_final_goodbye()`
 
 use std::ffi::OsString;
 use std::io::Cursor;

--- a/crates/transfer/src/receiver/tests/file_list/iconv_wire_order.rs
+++ b/crates/transfer/src/receiver/tests/file_list/iconv_wire_order.rs
@@ -9,11 +9,11 @@
 //!
 //! # Upstream Reference
 //!
-//! - `options.c:2051-2056` - sets `need_unsorted_flist = 1` when `--iconv`
+//! - `options.c:2069-2074` - sets `need_unsorted_flist = 1` when `--iconv`
 //!   is in effect (and not disabled by `--iconv=-`).
 //! - `flist.c:2496-2498` - "both sides keep an unsorted file-list array
 //!   because the names will differ on the sending and receiving sides".
-//! - `flist.c:2149-2153` - allocates a separate `flist->sorted[]` pointer
+//! - `flist.c:2184-2188` - allocates a separate `flist->sorted[]` pointer
 //!   array so `flist->files[]` (NDX-addressed) stays in scan order.
 
 use std::ffi::OsString;
@@ -132,7 +132,7 @@ fn no_iconv_path_still_sorts_entries() {
 /// An iconv converter whose local and remote encodings are identical
 /// performs no transcoding, so the NDX-addressed array cannot diverge
 /// from the sender's wire view. Mirrors upstream's check at
-/// `options.c:2053` that nulls out `iconv_opt` on `--iconv=-`, leaving
+/// `options.c:2071` that nulls out `iconv_opt` on `--iconv=-`, leaving
 /// `need_unsorted_flist` unset.
 #[test]
 fn identity_iconv_does_not_suppress_reorder() {

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -311,7 +311,7 @@ mod create_directory_incremental_tests {
     /// entry must report `ITEM_REPORT_TIME`, so the transfer root `.` (and any
     /// existing directory) emits a `.d..t......` itemize row.
     ///
-    /// WHY: upstream's `itemize()` (`generator.c:511-572`, reached from
+    /// WHY: upstream's `itemize()` (`generator.c:518-579`, reached from
     /// `generator.c:1480-1483` with `statret == 0`) sets `ITEM_REPORT_TIME`
     /// whenever `mtime_differs(&sxp->st, file)` for a directory under `--times`
     /// (`keep_time` true). This is independent of `--checksum`: a quick-check

--- a/crates/transfer/src/receiver/tests/file_list/missing_args_sentinel.rs
+++ b/crates/transfer/src/receiver/tests/file_list/missing_args_sentinel.rs
@@ -9,7 +9,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `generator.c:1348-1354` - `missing_args == 2 && file->mode == 0`
+//! - `generator.c:1360-1366` - `missing_args == 2 && file->mode == 0`
 //!   branch that calls `delete_item()` when the destination exists and
 //!   falls through (no creation) otherwise.
 

--- a/crates/transfer/src/receiver/tests/file_list/proto_io_error.rs
+++ b/crates/transfer/src/receiver/tests/file_list/proto_io_error.rs
@@ -1,6 +1,6 @@
 //! Protocol 28/29 trailing `io_error` int after the file-list end marker.
 //!
-//! upstream: flist.c:2738-2742 - the sender writes `write_int(f, io_error)`
+//! upstream: flist.c:2773-2777 - the sender writes `write_int(f, io_error)`
 //! after the id lists. Without this read, subsequent wire data is misaligned,
 //! causing "received request to transfer non-regular file" errors.
 

--- a/crates/transfer/src/receiver/tests/munge_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/munge_symlinks.rs
@@ -1,6 +1,6 @@
 //! Receiver-side `munge symlinks` regression tests.
 //!
-//! Mirrors the on-disk transform upstream applies in `flist.c:1122-1126`:
+//! Mirrors the on-disk transform upstream applies in `flist.c:1150-1154`:
 //! when the daemon module has `munge symlinks = yes`, every symlink that the
 //! receiver materializes carries the `/rsyncd-munged/` prefix so that
 //! following the link cannot escape the module root. The complementary
@@ -8,10 +8,10 @@
 //!
 //! # Upstream Reference
 //!
-//! - `clientserver.c:992-1004` - daemon resolves `munge_symlinks` from
+//! - `clientserver.c:997-1009` - daemon resolves `munge_symlinks` from
 //!   `lp_munge_symlinks()` and aborts if `rsyncd-munged` already exists at
 //!   the module root.
-//! - `flist.c:1122-1126` - receiver prepends `SYMLINK_PREFIX` to the wire
+//! - `flist.c:1150-1154` - receiver prepends `SYMLINK_PREFIX` to the wire
 //!   target before the link is written to disk.
 
 use std::ffi::OsString;
@@ -124,7 +124,7 @@ fn receiver_prepends_munge_prefix_to_on_disk_symlink() {
 /// share the same upstream-parity rule (`PermissionDenied` is the
 /// only non-fatal class).
 ///
-/// upstream: generator.c:1591 atomic_create -> do_symlink - EACCES is
+/// upstream: generator.c:1603 atomic_create -> do_symlink - EACCES is
 /// non-fatal (increment io_error and continue); every other class is
 /// a security boundary the receiver must surface.
 #[cfg(unix)]
@@ -192,7 +192,7 @@ fn create_symlinks_surfaces_non_eacces_error() {
 ///    the exact second. Upstream's diff drops nanoseconds; matching seconds is
 ///    the load-bearing invariant.
 ///
-/// upstream: generator.c:1592 `set_file_attrs(fname, file, NULL, NULL, 0)`
+/// upstream: generator.c:1604 `set_file_attrs(fname, file, NULL, NULL, 0)`
 /// upstream: rsync.c:set_times() uses `lutimes`/`utimensat(AT_SYMLINK_NOFOLLOW)`
 #[cfg(unix)]
 #[test]

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -106,7 +106,7 @@ fn render_itemize_root_directory_emits_creation_glyph_when_freshly_created() {
     // create_directory_incremental cannot observe the pre-flight mkdir
     // performed by `ensure_dest_root_exists`. When that pre-flight actually
     // created the root (`dest_root_created == true`), mirror upstream
-    // main.c:794-796 FLAG_DIR_CREATED by forcing the created-directory glyph.
+    // main.c:803-805 FLAG_DIR_CREATED by forcing the created-directory glyph.
     let handshake = test_handshake();
     let config = receiver_config_with_itemize();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
@@ -123,7 +123,7 @@ fn render_itemize_root_directory_emits_creation_glyph_when_freshly_created() {
 
 #[test]
 fn render_itemize_root_directory_no_glyph_when_dest_root_preexisted() {
-    // upstream main.c:794-796 only sets FLAG_DIR_CREATED when the receiver
+    // upstream main.c:803-805 only sets FLAG_DIR_CREATED when the receiver
     // had to mkdir the destination root. When the root already existed
     // (e.g. `up1/ -> up2/` where up2 is present), the flag stays clear and
     // the root reports a metadata-only row that the significance gate drops

--- a/crates/transfer/src/receiver/tests/windows_receiver_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/windows_receiver_symlinks.rs
@@ -11,8 +11,8 @@
 //!
 //! # Upstream Reference
 //!
-//! - `generator.c:1544` - `if (preserve_links && ftype == FT_SYMLINK)`
-//! - `generator.c:1591` - `atomic_create(file, fname, sl, ...)`
+//! - `generator.c:1556` - `if (preserve_links && ftype == FT_SYMLINK)`
+//! - `generator.c:1603` - `atomic_create(file, fname, sl, ...)`
 
 #![cfg(windows)]
 

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -303,12 +303,12 @@ pub(in crate::receiver) enum DeletePassPhase {
 /// Renames all delayed-update files from their `.~tmp~` staging paths to
 /// their final destinations, then removes the empty `.~tmp~` directories.
 ///
-/// Mirrors upstream `receiver.c:422-450 handle_delayed_updates()` which
+/// Mirrors upstream `receiver.c:529-557 handle_delayed_updates()` which
 /// iterates `delayed_bits`, renames each file from its `partial_dir_fname()`
 /// path to the final destination, and calls `handle_partial_dir(PDIR_DELETE)`.
 ///
 /// When `backup_config` is `Some`, backs up the existing destination file
-/// before the rename (upstream: `receiver.c:431 make_backup(fname, False)`).
+/// before the rename (upstream: `receiver.c:538 make_backup(fname, False)`).
 ///
 /// A failed rename (or backup) is logged and does not abort the sweep -
 /// remaining files are still renamed, matching upstream which calls
@@ -340,7 +340,7 @@ pub(in crate::receiver) fn handle_delayed_updates(
     let mut io_error = 0;
 
     for (staging_path, final_path) in delayed {
-        // upstream: receiver.c:431-432 - make_backup(fname, False)
+        // upstream: receiver.c:538-539 - make_backup(fname, False)
         if let Some(ref bc) = backup_config {
             if final_path.exists() {
                 let backup_path = engine::compute_backup_path(
@@ -391,7 +391,7 @@ pub(in crate::receiver) fn handle_delayed_updates(
             }
         }
 
-        // upstream: receiver.c:433-435 - DEBUG_GTE(RECV, 1) rename notice
+        // upstream: receiver.c:540-542 - DEBUG_GTE(RECV, 1) rename notice
         debug_log!(
             Recv,
             1,
@@ -400,7 +400,7 @@ pub(in crate::receiver) fn handle_delayed_updates(
             final_path.display()
         );
 
-        // upstream: receiver.c:439 - do_rename(partialptr, fname)
+        // upstream: receiver.c:546 - do_rename(partialptr, fname)
         if let Err(e) = fs::rename(staging_path, final_path) {
             // upstream: rsyserr(FERROR_XFER, ...) sets got_xfer_error ->
             // RERR_PARTIAL (exit 23). On kernels 5.13-5.18 the Landlock
@@ -422,7 +422,7 @@ pub(in crate::receiver) fn handle_delayed_updates(
         }
     }
 
-    // upstream: receiver.c:446 - handle_partial_dir(partialptr, PDIR_DELETE)
+    // upstream: receiver.c:553 - handle_partial_dir(partialptr, PDIR_DELETE)
     // Remove empty .~tmp~ staging directories.
     for dir in &staging_dirs {
         let _ = fs::remove_dir(dir);
@@ -587,7 +587,7 @@ mod tests {
     /// `BackupConfig` is supplied.
     ///
     /// This is the receiver-side equivalent of upstream
-    /// `receiver.c:431-432 make_backup(fname, False)` -> `backup.c:make_backup`
+    /// `receiver.c:538-539 make_backup(fname, False)` -> `backup.c:make_backup`
     /// which renames the existing file out of the way and emits the
     /// `backed up X to Y` info_log via `INFO_GTE(BACKUP, 1)` at
     /// `backup.c:352-353`. Upstream `testsuite/backup.test:43,56` greps for
@@ -882,7 +882,7 @@ mod tests {
     /// propagates the error before reaching the sweep call in `pipelined.rs`),
     /// leaving staged files intact for the next resume attempt.
     ///
-    /// upstream: receiver.c:584-585 - handle_delayed_updates() only after
+    /// upstream: receiver.c:694-695 - handle_delayed_updates() only after
     /// successful completion of both transfer phases.
     #[test]
     fn interrupt_skips_sweep_files_persist_in_staging() {

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -7,8 +7,8 @@
 //! # Upstream Reference
 //!
 //! - `generator.c:recv_generator()` - per-file quick-check and skip logic
-//! - `generator.c:942` - `try_dests_reg()` for reference directory handling
-//! - `generator.c:617` - `quick_check_ok()` evaluation order
+//! - `generator.c:954` - `try_dests_reg()` for reference directory handling
+//! - `generator.c:624` - `quick_check_ok()` evaluation order
 
 use std::fs;
 use std::io::Write;
@@ -93,7 +93,7 @@ impl ReceiverContext {
         acl_cache: Option<&protocol::acl::AclCache>,
         acl_id_map: Option<&metadata::AclIdMapper>,
     ) -> Vec<(usize, &'a FileEntry, PathBuf, u32)> {
-        // upstream: generator.c:1234-1235 - "recv_generator(%s,%d)" emitted at
+        // upstream: generator.c:1246-1247 - "recv_generator(%s,%d)" emitted at
         // the top of recv_generator() for every file the generator considers
         // (regular files, directories, symlinks, devices, specials). Skipping
         // the loop when the flag is off keeps the hot path allocation-free.
@@ -128,7 +128,7 @@ impl ReceiverContext {
             .filter(|(_, e)| e.is_file())
             .filter(|(_, e)| !is_hardlink_follower(e))
             .filter(|(_, e)| {
-                // upstream: receiver.c:599-604 - check_filter(&daemon_filter_list, ...)
+                // upstream: receiver.c:711-716 - check_filter(&daemon_filter_list, ...)
                 // rejects daemon-excluded files before accepting transfer data.
                 if has_daemon_filters {
                     let filters = daemon_filters.unwrap();
@@ -158,13 +158,13 @@ impl ReceiverContext {
             })
             .collect();
 
-        // upstream: generator.c:1845 - dry_run (!do_xfers) skips stat and data
+        // upstream: generator.c:1858 - dry_run (!do_xfers) skips stat and data
         // transfer but still builds the candidate list so NDX requests are sent
         // to the sender, which logs each file name for verbose output. List-only
         // also skips the destination stat/quick-check; its caller never issues
         // per-file NDX requests (the list_only branch in `run_pipelined`).
         if self.config.flags.skip_dest_writes() {
-            // upstream: generator.c:1925-1926 - dry-run still itemizes with
+            // upstream: generator.c:1938-1939 - dry-run still itemizes with
             // ITEM_TRANSFER; the dry-run loop writes the bare ITEM_TRANSFER
             // attrs over the wire and does not consume this precomputed value.
             return candidates
@@ -333,7 +333,7 @@ impl ReceiverContext {
                 }
             } else {
                 if existing_only {
-                    // upstream: generator.c:1368-1383 - --existing /
+                    // upstream: generator.c:1380-1395 - --existing /
                     // --ignore-non-existing never creates an absent
                     // destination; a missing regular file is skipped with a
                     // SKIP-gated "not creating new file" notice. Directories
@@ -371,7 +371,7 @@ impl ReceiverContext {
                     continue;
                 }
             }
-            // upstream: generator.c:504-572 itemize() - compute the base itemize
+            // upstream: generator.c:511-579 itemize() - compute the base itemize
             // flags before the data transfer so the row reflects attribute
             // changes against the pre-transfer destination. A non-existent dest
             // (statret < 0) is ITEM_IS_NEW; an existing one OR-s the per-attr
@@ -395,7 +395,7 @@ impl ReceiverContext {
                 // too, since it is still requested and materialised.
                 self.record_created(entry.mode());
             }
-            // upstream: generator.c:1925-1937 - the generator emits the transfer
+            // upstream: generator.c:1938-1950 - the generator emits the transfer
             // itemize right after write_ndx(ndx), in flist order. With
             // log_before_transfer (`!am_server`, i.e. client mode) the row is
             // written to stdout before the data moves, so emit it here in the
@@ -549,7 +549,7 @@ impl ReceiverContext {
     }
 
     /// Computes the attribute-comparison itemize flags for a destination file
-    /// that already exists, mirroring upstream `generator.c:508-549` `itemize()`.
+    /// that already exists, mirroring upstream `generator.c:515-556` `itemize()`.
     ///
     /// `base` is `ITEM_TRANSFER` for a file being transferred, or `0` for an
     /// up-to-date file (quick-check match). The returned raw flags OR `base`
@@ -569,11 +569,11 @@ impl ReceiverContext {
     ) -> u32 {
         use crate::generator::ItemFlags;
         let mut iflags = base;
-        // upstream: generator.c:514 - S_ISREG(file->mode) && F_LENGTH(file) != st_size
+        // upstream: generator.c:521 - S_ISREG(file->mode) && F_LENGTH(file) != st_size
         if entry.is_file() && entry.size() != dest_meta.len() {
             iflags |= ItemFlags::ITEM_REPORT_SIZE;
         }
-        // upstream: generator.c:519-523 - keep_time ? mtime_differs(&st, file).
+        // upstream: generator.c:526-530 - keep_time ? mtime_differs(&st, file).
         // For regular files keep_time == preserve_mtimes (`--times`).
         if self.config.flags.times {
             #[cfg(unix)]
@@ -598,14 +598,14 @@ impl ReceiverContext {
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt;
-            // upstream: generator.c:540-542 - preserve_perms && CHMOD_BITS differ
+            // upstream: generator.c:547-549 - preserve_perms && CHMOD_BITS differ
             if self.config.flags.perms {
                 const CHMOD_BITS: u32 = 0o7777;
                 if (dest_meta.mode() & CHMOD_BITS) != (entry.mode() & CHMOD_BITS) {
                     iflags |= ItemFlags::ITEM_REPORT_PERMS;
                 }
             }
-            // upstream: generator.c:546-547 - uid_ndx && am_root && uid differs
+            // upstream: generator.c:553-554 - uid_ndx && am_root && uid differs
             if self.config.flags.owner && metadata::am_root() {
                 if let Some(uid) = entry.uid() {
                     if dest_meta.uid() != uid {
@@ -613,7 +613,7 @@ impl ReceiverContext {
                     }
                 }
             }
-            // upstream: generator.c:548-549 - gid_ndx && !FLAG_SKIP_GROUP && gid differs
+            // upstream: generator.c:555-556 - gid_ndx && !FLAG_SKIP_GROUP && gid differs
             if self.config.flags.group {
                 if let Some(gid) = entry.gid() {
                     if dest_meta.gid() != gid {
@@ -723,7 +723,7 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:1814` - `set_file_attrs()` on quick-check match
+    /// - `generator.c:1827` - `set_file_attrs()` on quick-check match
     /// - `generator.c:1816` - `itemize()` on quick-check match
     #[allow(clippy::too_many_arguments)]
     fn apply_no_change_metadata<W: Write + crate::writer::MsgInfoSender + ?Sized>(
@@ -755,7 +755,7 @@ impl ReceiverContext {
             let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
         }
 
-        // upstream: generator.c:461 unchanged_attrs() - fast-path check avoids
+        // upstream: generator.c:468 unchanged_attrs() - fast-path check avoids
         // the per-function-call overhead of apply_metadata when all attributes
         // already match. Skip entirely when no preservation flags are active.
         // On a no-change scan this eliminates ownership mapping, permission
@@ -1190,7 +1190,7 @@ mod skip_notice_tests {
         assert!(run(cfg(), 0, files(), dest).is_empty());
     }
 
-    /// #44 - upstream: generator.c:1368-1383. With `--existing`, a regular file
+    /// #44 - upstream: generator.c:1380-1395. With `--existing`, a regular file
     /// absent at the destination is never created; upstream prints `not
     /// creating new file "%s"` (literal quotes) at `INFO_GTE(SKIP, 1)`, silent
     /// otherwise.

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -6,7 +6,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `main.c:875-906` - `read_final_goodbye()` with extended goodbye
+//! - `main.c:893-924` - `read_final_goodbye()` with extended goodbye
 //! - `main.c:356-384` - `handle_stats()` sends/receives statistics
 //! - `io.c:read_ndx()` / `write_ndx()` - NDX wire encoding
 
@@ -49,7 +49,7 @@ impl ReceiverContext {
         if inc_recurse {
             let num_segments = self.ndx_segments.len();
             for _ in 0..num_segments {
-                // upstream: receiver.c:573 - flist_free(first_flist)
+                // upstream: receiver.c:683 - flist_free(first_flist)
                 // Reclaim heap data from the oldest completed segment
                 // to reduce RSS before sending the per-segment NDX_DONE.
                 self.reclaim_oldest_segment();
@@ -58,7 +58,7 @@ impl ReceiverContext {
                 self.read_expected_ndx_done(ndx_read_codec, reader, "segment completion")?;
             }
 
-            // upstream: generator.c:2355-2357 - phase++ then "generate_files phase=%d"
+            // upstream: generator.c:2372-2374 - phase++ then "generate_files phase=%d"
             // The first `phase++` after the per-segment loop advances 0 -> 1.
             let mut phase: i32 = 1;
             // upstream: receiver.c:692-693 DEBUG_GTE(RECV, 1)
@@ -95,7 +95,7 @@ impl ReceiverContext {
                 phase += 1;
                 // upstream: receiver.c:692-693 DEBUG_GTE(RECV, 1)
                 debug_log!(Recv, 1, "recv_files phase={}", phase);
-                // upstream: generator.c:2355-2357, 2366-2368, 2392-2394
+                // upstream: generator.c:2372-2374, 2366-2368, 2392-2394
                 // "generate_files phase=%d" emitted after each phase++.
                 debug_log!(Genr, 1, "generate_files phase={}", phase);
                 if phase > max_phase {
@@ -172,7 +172,7 @@ impl ReceiverContext {
     /// # Upstream Reference
     ///
     /// - `main.c:1107-1132` - daemon-recv parent process runs `generate_files`
-    /// - `generator.c:2393-2398` - early `write_del_stats(f_out)` emission
+    /// - `generator.c:2410-2415` - early `write_del_stats(f_out)` emission
     /// - `main.c:225-238` - `write_del_stats()` wire format
     pub(in crate::receiver) fn handle_goodbye<R: Read, W: Write + ?Sized>(
         &self,
@@ -204,7 +204,7 @@ impl ReceiverContext {
         writer.flush()?;
 
         if self.protocol.supports_extended_goodbye() {
-            // upstream: main.c:875-906 read_final_goodbye() - the sender may
+            // upstream: main.c:893-924 read_final_goodbye() - the sender may
             // send NDX_DEL_STATS before the NDX_DONE echo. Loop to skip it.
             loop {
                 let ndx = ndx_read_codec.read_ndx(reader)?;
@@ -288,7 +288,7 @@ impl ReceiverContext {
 
         self.handle_goodbye(reader, writer, &mut ndx_write_codec, &mut ndx_read_codec)?;
 
-        // upstream: main.c:1067 do_recv() child path and main.c:1117/1123
+        // upstream: main.c:1085 do_recv() child path and main.c:1135/1123
         // do_recv() parent path both call io_flush(FULL_FLUSH) immediately
         // after the final NDX_DONE write so the kernel ships the goodbye
         // frame (and any trailing multiplexed MSG_INFO frames) before the
@@ -313,7 +313,7 @@ impl ReceiverContext {
         // upstream: receiver.c:1114-1115 DEBUG_GTE(RECV, 1)
         debug_log!(Recv, 1, "recv_files finished");
 
-        // upstream: generator.c:2436-2437 - "generate_files finished" emitted at
+        // upstream: generator.c:2453-2454 - "generate_files finished" emitted at
         // the bottom of generate_files() after the final goodbye handshake.
         debug_log!(Genr, 1, "generate_files finished");
 
@@ -393,7 +393,7 @@ mod genr_debug_emission_tests {
 
     #[test]
     fn recv_generator_per_file_matches_upstream() {
-        // upstream: generator.c:1234-1235 - "recv_generator(%s,%d)"
+        // upstream: generator.c:1246-1247 - "recv_generator(%s,%d)"
         init_genr_level1();
         let name = PathBuf::from("dir/file.txt");
         let ndx: i32 = 7;
@@ -407,7 +407,7 @@ mod genr_debug_emission_tests {
 
     #[test]
     fn generate_files_phase_matches_upstream() {
-        // upstream: generator.c:2355-2357, 2366-2368, 2392-2394
+        // upstream: generator.c:2372-2374, 2366-2368, 2392-2394
         // "generate_files phase=%d" - the phase counter advances 1 -> 2 -> 3
         // across the regular, redo, and protocol-29+ delay-updates phases.
         init_genr_level1();
@@ -426,7 +426,7 @@ mod genr_debug_emission_tests {
 
     #[test]
     fn generate_files_finished_matches_upstream() {
-        // upstream: generator.c:2436-2437 - "generate_files finished"
+        // upstream: generator.c:2453-2454 - "generate_files finished"
         init_genr_level1();
         debug_log!(Genr, 1, "generate_files finished");
         let msgs = genr_messages();

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -559,7 +559,7 @@ impl ReceiverContext {
     /// sender. No sum head or file data is exchanged. This allows the sender to
     /// log each file name for verbose output.
     ///
-    /// upstream: generator.c:1845-1946 - `!do_xfers` path sends write_ndx() then
+    /// upstream: generator.c:1858-1959 - `!do_xfers` path sends write_ndx() then
     /// goto cleanup, skipping write_sum_head(). sender.c:394-399 - `!do_xfers`
     /// logs the item and echoes write_ndx_and_attrs() without receive_sums().
     pub(in crate::receiver) fn run_dry_run_loop<
@@ -589,7 +589,7 @@ impl ReceiverContext {
         // for input. We flush once before blocking on each response read, but
         // only when needed (the multiplex dirty-flag skips redundant syscalls).
         for &(file_idx, file_entry, _, base_iflags) in files_to_transfer {
-            // upstream: generator.c:1925 - write_ndx(f_out, ndx)
+            // upstream: generator.c:1938 - write_ndx(f_out, ndx)
             let wire_ndx = self.flat_to_wire_ndx(file_idx);
             ndx_write_codec.write_ndx(&mut *writer, wire_ndx)?;
 

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -81,7 +81,7 @@ impl ReceiverContext {
             Vec::new()
         };
 
-        // upstream: generator.c:1317-1326 - make_path() for relative_paths
+        // upstream: generator.c:1329-1338 - make_path() for relative_paths
         self.ensure_relative_parents(&setup.dest_dir);
         let mut metadata_errors = self.create_directories(
             &setup.dest_dir,
@@ -101,7 +101,7 @@ impl ReceiverContext {
         #[cfg(not(unix))]
         self.create_specials(&setup.dest_dir, writer)?;
 
-        // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
+        // upstream: generator.c:1360-1366 - missing_args == 2 && file->mode == 0
         // deletes the destination path and skips any creation for the sentinel.
         self.process_missing_args_sentinels(
             &setup.dest_dir,
@@ -232,7 +232,7 @@ impl ReceiverContext {
             if !redo_indices.is_empty() {
                 setup.checksum_length = REDO_CHECKSUM_LENGTH;
 
-                // upstream: generator.c:1926 - the phase-2 redo re-itemizes with
+                // upstream: generator.c:1939 - the phase-2 redo re-itemizes with
                 // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
                 let redo_files: Vec<(usize, &FileEntry, PathBuf, u32)> = redo_indices
                     .iter()
@@ -329,7 +329,7 @@ impl ReceiverContext {
             )?;
         }
 
-        // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
+        // upstream: generator.c:2093-2146 - touch_up_dirs() re-applies
         // directory mtimes after file writes clobber them.
         self.touch_up_dirs(&setup.dest_dir, writer);
 
@@ -362,7 +362,7 @@ impl ReceiverContext {
         }
         stats.metadata_errors = metadata_errors;
         stats.redo_count = redo_count;
-        // upstream: main.c:794-796 - count the pre-flight-created destination
+        // upstream: main.c:803-805 - count the pre-flight-created destination
         // root (FLAG_DIR_CREATED -> ITEM_IS_NEW) as a created dir; oc mkdir's it
         // out-of-band so the dir loop treats it as existing. See the incremental
         // path for the full rationale.

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -63,7 +63,7 @@ impl ReceiverContext {
         let mut failed_dirs = crate::receiver::directory::FailedDirectories::new();
         let mut metadata_errors: Vec<(PathBuf, String)> = Vec::new();
 
-        // upstream: generator.c:1317-1326 - make_path() for relative_paths
+        // upstream: generator.c:1329-1338 - make_path() for relative_paths
         self.ensure_relative_parents(&setup.dest_dir);
 
         for (flist_idx, file_entry) in self.file_list.iter().enumerate() {
@@ -116,7 +116,7 @@ impl ReceiverContext {
         #[cfg(not(unix))]
         self.create_specials(&setup.dest_dir, writer)?;
 
-        // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
+        // upstream: generator.c:1360-1366 - missing_args == 2 && file->mode == 0
         // deletes the destination path and skips any creation for the sentinel.
         self.process_missing_args_sentinels(
             &setup.dest_dir,
@@ -201,7 +201,7 @@ impl ReceiverContext {
             if !redo_indices.is_empty() {
                 setup.checksum_length = REDO_CHECKSUM_LENGTH;
 
-                // upstream: generator.c:1926 - the phase-2 redo re-itemizes with
+                // upstream: generator.c:1939 - the phase-2 redo re-itemizes with
                 // ITEM_TRANSFER; the basis comparison is not re-run for the retry.
                 let redo_files: Vec<(usize, &FileEntry, PathBuf, u32)> = redo_indices
                     .iter()
@@ -284,7 +284,7 @@ impl ReceiverContext {
             )?;
         }
 
-        // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
+        // upstream: generator.c:2093-2146 - touch_up_dirs() re-applies
         // directory mtimes after file writes clobber them.
         self.touch_up_dirs(&setup.dest_dir, writer);
 
@@ -309,7 +309,7 @@ impl ReceiverContext {
         }
         stats.metadata_errors = metadata_errors;
         stats.redo_count = redo_count;
-        // upstream: main.c:794-796 - the pre-flight mkdir of the destination
+        // upstream: main.c:803-805 - the pre-flight mkdir of the destination
         // root sets FLAG_DIR_CREATED on flist[0], so the generator itemizes it
         // with ITEM_IS_NEW and receiver.c:736-738 counts created_dirs for it.
         // oc creates the root out-of-band (ensure_dest_root_exists), so the root

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -129,7 +129,7 @@ impl ReceiverContext {
             .advance_to(TransferPhase::FileListTransfer)
             .map_err(crate::fsm_error)?;
 
-        // upstream: main.c:1173-1180 - server-receiver opened a local
+        // upstream: main.c:1191-1198 - server-receiver opened a local
         // `--files-from` file (filesfrom_fd) and now forwards its contents
         // to the sender (the client) over f_out so the sender can build the
         // file list. Upstream interleaves this with `recv_file_list` via the
@@ -138,7 +138,7 @@ impl ReceiverContext {
         // are decoupled (no select() loop fanning across them).
         self.forward_files_from_to_sender(writer)?;
 
-        // upstream: flist.c:2604-2607 recv_file_list() - the first list arrival
+        // upstream: flist.c:2639-2642 recv_file_list() - the first list arrival
         // prints `receiving incremental file list` on the client's own output.
         // Write it DIRECTLY to the client stream here instead of through the
         // deferred `info_log!` event buffer: that buffer is only drained by the
@@ -241,7 +241,7 @@ impl ReceiverContext {
             .preserve_owner(self.config.flags.owner)
             .preserve_group(self.config.flags.group)
             .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
-            // upstream: generator.c:1344 - `link_stat(fname, &sx.st,
+            // upstream: generator.c:1356 - `link_stat(fname, &sx.st,
             // keep_dirlinks && is_dir)` follows a destination symlink-to-dir
             // at stat time instead of rejecting it. The
             // `chmod_path_honoring_keep_dirlinks` helper in
@@ -348,7 +348,7 @@ impl ReceiverContext {
         self.dest_root_created = created_dest_root;
         if created_dest_root {
             debug_log!(Recv, 1, "created destination root {}", dest_dir.display());
-            // upstream: main.c:798-799 - `rprintf(FINFO, "created directory %s\n", dest_path)`
+            // upstream: main.c:807-808 - `rprintf(FINFO, "created directory %s\n", dest_path)`
             // gated on `INFO_GTE(NAME, 1) || stdout_format_has_i`. The notice
             // is for the receiver's destination root only; alt-basis dirs
             // (`--copy-dest`, `--link-dest`, `--compare-dest`) never produce
@@ -373,7 +373,7 @@ impl ReceiverContext {
         // directory via the stat path in ensure_dest_root_exists, lock the
         // canonical target in here so every downstream open (DirSandbox,
         // per-entry `*at` syscalls) operates on the resolved directory.
-        // Upstream `main.c:748` reaches the same state by calling
+        // Upstream `main.c:757` reaches the same state by calling
         // `change_dir(dest_path, CD_NORMAL)` after `S_ISDIR` succeeds: the
         // kernel resolves the link once and every subsequent syscall is
         // relative to the resolved cwd. We mirror that by canonicalizing
@@ -630,7 +630,7 @@ impl ReceiverContext {
     /// # Upstream Reference
     ///
     /// - `main.c:805-832` - `get_local_name()` rename branch
-    /// - `receiver.c:594` - `fname = local_name ? local_name : f_name(...)`
+    /// - `receiver.c:706` - `fname = local_name ? local_name : f_name(...)`
     fn apply_single_file_rename(
         &mut self,
         dest_dir: PathBuf,
@@ -714,7 +714,7 @@ impl ReceiverContext {
     /// Forwards a server-receiver-side `--files-from=<localpath>` file to the
     /// sender (peer) over the protocol writer.
     ///
-    /// Upstream's `main.c:1173-1180` server-receiver opens `filesfrom_fd`
+    /// Upstream's `main.c:1191-1198` server-receiver opens `filesfrom_fd`
     /// locally and registers it with `start_filesfrom_forwarding`. The I/O
     /// scheduler then interleaves writes to `f_out` (toward the sender) with
     /// reads from `f_in` (the incoming flist). The sender's `send_file_list`
@@ -731,7 +731,7 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `main.c:1173-1180` - `start_filesfrom_forwarding(filesfrom_fd)`
+    /// - `main.c:1191-1198` - `start_filesfrom_forwarding(filesfrom_fd)`
     /// - `io.c:370-381` - `forward_filesfrom_data()` core loop
     /// - `options.c:2944-2956` - server-side `--files-from <path>` arg form
     fn forward_files_from_to_sender<W: io::Write + ?Sized>(
@@ -746,7 +746,7 @@ impl ReceiverContext {
             _ => return Ok(()),
         };
 
-        // upstream: options.c:2483 open(files_from, O_RDONLY|O_BINARY).
+        // upstream: options.c:2501 open(files_from, O_RDONLY|O_BINARY).
         let file = std::fs::File::open(path).map_err(|err| {
             io::Error::new(
                 err.kind(),

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -67,7 +67,7 @@ impl ReceiverContext {
         let mut bytes_received = 0u64;
 
         // First pass: create directories and symlinks from file list.
-        // upstream: generator.c:1317-1326 - make_path() for relative_paths
+        // upstream: generator.c:1329-1338 - make_path() for relative_paths
         self.ensure_relative_parents(&dest_dir);
         let mut metadata_errors = self.create_directories(
             &dest_dir,
@@ -87,7 +87,7 @@ impl ReceiverContext {
         #[cfg(not(unix))]
         self.create_specials(&dest_dir, writer)?;
 
-        // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
+        // upstream: generator.c:1360-1366 - missing_args == 2 && file->mode == 0
         // deletes the destination path and skips any creation for the sentinel.
         self.process_missing_args_sentinels(
             &dest_dir,
@@ -170,7 +170,7 @@ impl ReceiverContext {
                 continue;
             }
 
-            // upstream: generator.c:1704-1718 - skip files outside the
+            // upstream: generator.c:1716-1731 - skip files outside the
             // min-size/max-size window with a SKIP-gated notice on FINFO.
             if self.emit_size_bound_skip(
                 writer,
@@ -584,7 +584,7 @@ impl ReceiverContext {
         #[cfg(not(unix))]
         self.create_hardlinks(&dest_dir, writer)?;
 
-        // upstream: generator.c:2080-2133 - touch_up_dirs() re-applies
+        // upstream: generator.c:2093-2146 - touch_up_dirs() re-applies
         // directory mtimes after file writes clobber them.
         self.touch_up_dirs(&dest_dir, writer);
 
@@ -599,7 +599,7 @@ impl ReceiverContext {
 
         let total_source_bytes: u64 = self.total_source_size();
 
-        // upstream: main.c:794-796 - count the pre-flight-created destination
+        // upstream: main.c:803-805 - count the pre-flight-created destination
         // root as a created dir (FLAG_DIR_CREATED -> ITEM_IS_NEW). See the
         // incremental path for the full rationale.
         if self.dest_root_created {

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -38,7 +38,7 @@ fn parse_fnamecmp_type(byte: u8) -> io::Result<protocol::FnameCmpType> {
 ///
 /// If the high bit of `len_byte` is set the length spans two bytes
 /// (`(len_byte & 0x7F) * 256 + second`); otherwise it is `len_byte`. Upstream
-/// `io.c:1944-1960` `read_vstring()`.
+/// `io.c:2004-2020` `read_vstring()`.
 #[inline]
 fn xname_len_from_bytes(len_byte: u8, second: Option<u8>) -> usize {
     if len_byte & 0x80 != 0 {
@@ -66,7 +66,7 @@ fn check_xname_len(xname_len: usize) -> io::Result<()> {
 
 /// Decides whether the sender-response frame carries xattr abbreviation data.
 ///
-/// Mirrors upstream `receiver.c:609-611`: read when xattrs are preserved and
+/// Mirrors upstream `receiver.c:721-723`: read when xattrs are preserved and
 /// `ITEM_REPORT_XATTR` is set, unless the xattr hardlink optimization elides it
 /// for a local-change rename.
 #[inline]
@@ -292,7 +292,7 @@ impl SumHead {
 ///
 /// # Upstream Reference
 ///
-/// - `sender.c:180` - `write_ndx_and_attrs()` sends these
+/// - `sender.c:184` - `write_ndx_and_attrs()` sends these
 /// - `rsync.c:383` - `read_ndx_and_attrs()` reads them
 /// - `xattrs.c:623` - `send_xattr_request()` writes abbreviated xattr values
 #[derive(Debug, Clone, Default)]
@@ -352,9 +352,9 @@ impl SenderAttrs {
     ///
     /// # Upstream Reference
     ///
-    /// - `io.c:2289-2318` - `read_ndx()` for NDX decoding
+    /// - `io.c:2364-2393` - `read_ndx()` for NDX decoding
     /// - `rsync.c:383` - `read_ndx_and_attrs()` reads NDX + iflags
-    /// - `receiver.c:609-611` - receiver reads xattr data when ITEM_REPORT_XATTR set
+    /// - `receiver.c:721-723` - receiver reads xattr data when ITEM_REPORT_XATTR set
     /// - `xattrs.c:681` - `recv_xattr_request()` reads abbreviated values
     pub fn read_with_codec<R: Read>(
         reader: &mut R,
@@ -398,7 +398,7 @@ impl SenderAttrs {
         };
 
         let xname = if iflags & Self::ITEM_XNAME_FOLLOWS != 0 {
-            // Read vstring: upstream io.c:1944-1960 read_vstring()
+            // Read vstring: upstream io.c:2004-2020 read_vstring()
             // Format: first byte is length; if bit 7 set, length = (byte & 0x7F) * 256 + next_byte
             let mut len_byte = [0u8; 1];
             reader.read_exact(&mut len_byte)?;
@@ -421,7 +421,7 @@ impl SenderAttrs {
             None
         };
 
-        // upstream: receiver.c:609-611 - read xattr data when ITEM_REPORT_XATTR is set
+        // upstream: receiver.c:721-723 - read xattr data when ITEM_REPORT_XATTR is set
         // Condition mirrors upstream: preserve_xattrs && iflags & ITEM_REPORT_XATTR && do_xfers
         // && !(want_xattr_optim && BITS_SET(iflags, ITEM_XNAME_FOLLOWS|ITEM_LOCAL_CHANGE))
         let xattr_values = if want_xattr_read(preserve_xattrs, iflags, want_xattr_optim) {


### PR DESCRIPTION
## Summary

- Relines `// upstream: <file>.c:<line>` citations in `crates/transfer/src/receiver/` and `crates/transfer/src/generator/` that were pinned to rsync 3.4.1 and drifted in the 3.4.4 source of truth used by this repo (`target/interop/upstream-src/rsync-3.4.4`).
- Comment-only change: every remapped citation was individually verified against the actual 3.4.4 source line before being applied (function/macro/identifier text at the target line checked against the comment's description). 346 citations updated across 57 files.
- Citations already pointing at the correct 3.4.4 line, or that could not be confidently relocated (ambiguous/paraphrased descriptions with no distinguishing signal, or upstream logic changes between 3.4.1 and 3.4.4 that removed the quoted condition), were left untouched rather than guessed.

## Test plan

- [x] `cargo fmt -p transfer -- --check` (local and on aarch64 host worktree)
- [x] Diffed every changed line pairwise against HEAD to confirm the change is digit-only (no wording/code touched)
- [x] Manually verified a representative sample of remapped and left-unchanged citations against `rsync-3.4.4/*.c`
