### PR TITLE
docs(engine): reline drifted upstream citations to rsync 3.4.4

### DIFF
--- a/crates/engine/src/delete/plan.rs
+++ b/crates/engine/src/delete/plan.rs
@@ -218,7 +218,7 @@ impl DeletePlan {
     /// file `a` - diverging from upstream's traversal and, under
     /// `--max-delete`, changing which entries survive when the cap trips.
     /// The sort is unstable to match upstream's `qsort` choice (upstream:
-    /// `flist.c:3217-3343`, `generator.c:320`).
+    /// `flist.c:3252-3378`, `generator.c:320`).
     pub fn sort_by_name(&mut self) {
         let dir = &self.directory;
         self.extras.sort_unstable_by(|a, b| {

--- a/crates/engine/src/delete/traversal.rs
+++ b/crates/engine/src/delete/traversal.rs
@@ -1,7 +1,7 @@
 //! [`DirTraversalCursor`] - yields directories in upstream traversal order.
 //!
 //! The cursor reproduces upstream rsync's depth-first walk over the
-//! sender's flist (`generator.c:2282-2354`,
+//! sender's flist (`generator.c:2299-2371`,
 //! `do_delete_pass`/`delete_in_dir`). Each parent's child directories are
 //! emitted in `f_name_cmp` ascending order, the root is emitted first,
 //! and the cursor descends fully into one subtree before moving on to the

--- a/crates/engine/src/local_copy/context_impl/options/batch.rs
+++ b/crates/engine/src/local_copy/context_impl/options/batch.rs
@@ -243,7 +243,7 @@ impl<'a> CopyContext<'a> {
     /// (protocol >= 30), sum_init ignores the seed - the checksum is plain
     /// MD5 of the file bytes.
     ///
-    /// upstream: receiver.c:408 - read_buf(f_in, sender_file_sum, xfer_sum_len)
+    /// upstream: receiver.c:515 - read_buf(f_in, sender_file_sum, xfer_sum_len)
     pub(crate) fn finalize_batch_file_delta(
         &mut self,
         source: &std::path::Path,

--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -84,7 +84,7 @@ impl<'a> CopyContext<'a> {
     /// `source` is not a copy-devices device and the caller should use the stat
     /// length as usual.
     ///
-    /// Mirrors upstream `flist.c:1419-1424 make_file()`, which opens the device
+    /// Mirrors upstream `flist.c:1451-1456 make_file()`, which opens the device
     /// and records `get_device_size()` in place of the (zero) stat length. See
     /// [`crate::local_copy::LocalCopyMetadata::virtualize_copy_device_as_file`]
     /// for the matching reporting override.

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -2,8 +2,8 @@ impl<'a> CopyContext<'a> {
     /// Records a skip event for a non-regular file (e.g. socket, unknown type).
     ///
     /// Emits an `--info=NONREG` notice mirroring upstream rsync 3.4.1
-    /// (generator.c:1684) under `INFO_GTE(NONREG, 1)`. NONREG is part of
-    /// `info_verbosity[0]` (options.c:240), so the flag is enabled by
+    /// (generator.c:1696) under `INFO_GTE(NONREG, 1)`. NONREG is part of
+    /// `info_verbosity[0]` (options.c:250), so the flag is enabled by
     /// default and fires regardless of `-v`. The wording matches upstream
     /// byte-for-byte: `skipping non-regular file "%s"`.
     pub(super) fn record_skipped_non_regular(&mut self, relative: Option<&Path>) {

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -244,7 +244,7 @@ impl<'a> CopyContext<'a> {
     /// `SetNamedSecurityInfoW`) O(1) per cohort instead of O(N) per follower.
     ///
     /// upstream: hlink.c::hard_link_check returns 1 for followers so
-    /// generator.c:1540 exits before `set_file_attrs()` and therefore never
+    /// generator.c:1552 exits before `set_file_attrs()` and therefore never
     /// calls `set_acl()` on a follower alias.
     #[cfg(all(any(unix, windows), feature = "acl"))]
     pub(super) fn register_acl_cohort_leader(&mut self, reference: &Path) -> bool {
@@ -570,11 +570,11 @@ impl<'a> CopyContext<'a> {
     /// exactly matches the source node, returning its path so the receiver can
     /// hard-link it into place (`hD`/`hS` + blank) instead of recreating it.
     ///
-    /// Mirrors upstream `generator.c:1052-1140` try_dests_non(): a `LINK_DEST`
+    /// Mirrors upstream `generator.c:1064-1152` try_dests_non(): a `LINK_DEST`
     /// basis entry of the same file-type bucket (`FT_DEVICE`/`FT_SPECIAL`) whose
     /// device number (devices) or `_S_IFMT` (specials) matches
-    /// (`generator.c:657-671` quick_check_ok) AND whose preserved attributes are
-    /// unchanged (`generator.c:461-500` unchanged_attrs) reaches match_level 3
+    /// (`generator.c:664-678` quick_check_ok) AND whose preserved attributes are
+    /// unchanged (`generator.c:468-507` unchanged_attrs) reaches match_level 3
     /// and is hard-linked, itemizing as an exact match. `CAN_HARDLINK_SPECIAL`
     /// is defined on Linux, so devices and specials participate.
     #[cfg(unix)]
@@ -631,7 +631,7 @@ impl<'a> CopyContext<'a> {
                 continue;
             }
 
-            // upstream: generator.c:461-500 unchanged_attrs - preserved mtime,
+            // upstream: generator.c:468-507 unchanged_attrs - preserved mtime,
             // perms and ownership must match for the match_level-3 hard-link.
             if metadata_options.times()
                 && !mtimes_within_window(metadata, &candidate_metadata, modify_window)

--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -420,7 +420,7 @@ pub(crate) fn plan_directory_entries<'a>(
 ///
 /// The reorder is skipped entirely when a `--link-dest`/`--copy-dest`/
 /// `--compare-dest` basis is configured. Upstream's LAST-member deferral lives
-/// at `generator.c:1803`, *after* the alt-dest handling (`generator.c:995-1052`
+/// at `generator.c:1803`, *after* the alt-dest handling (`generator.c:1007-1064`
 /// try_dests_reg); a cohort member satisfied from a basis is placed in name
 /// order and never reaches the deferral, so the FIRST name-sorted member stays
 /// the holder (e.g. `hf f1` / `hf f2 => f1`). Reordering those would swap the

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -78,7 +78,7 @@ pub(super) fn apply_final_directory_metadata(
         context.record_finalized_directory(destination, mtime, restore_mode);
     }
 
-    // upstream: generator.c:1410 - implied parent dirs are finalized via
+    // upstream: generator.c:1422 - implied parent dirs are finalized via
     // set_file_attrs() when --implied-dirs is active (the default). With
     // --no-implied-dirs upstream skips them via FLAG_IMPLIED_DIR.
     if let Some(rel) = relative
@@ -159,7 +159,7 @@ fn keep_directory_writable(
 /// Reproduces upstream's transfer-root self-lock when a `--chmod` strips the
 /// root directory's owner-execute bit.
 ///
-/// upstream: generator.c:1503-1520 - the generator chmods a directory to its
+/// upstream: generator.c:1515-1532 - the generator chmods a directory to its
 /// tweaked mode and then re-adds owner-`rwx` (`do_chmod_at(fname, mode | S_IRWXU)`)
 /// so it can write the directory's contents. The transfer root is addressed as
 /// `dst/.`, so that re-add chmod must resolve `.` *inside* `dst`; a tweak that

--- a/crates/engine/src/local_copy/executor/directory/recursive/entry.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/entry.rs
@@ -56,7 +56,7 @@ pub(super) fn process_planned_entry(
             return Ok(true);
         }
         EntryAction::SkipMountPoint => {
-            // upstream: flist.c:1319 - INFO_GTE(MOUNT, 1) gates
+            // upstream: flist.c:1347 - INFO_GTE(MOUNT, 1) gates
             // `rprintf(FINFO, "[%s] skipping mount-point dir %s", who_am_i(), thisname)`
             // when `--one-file-system` (`-xx`) prunes a cross-device directory.
             // The role prefix (`[sender]`) is added downstream by the renderer.

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -88,7 +88,7 @@ pub(crate) fn copy_directory_recursive(
 
 /// Walks a directory's immediate children even when global recursion is off.
 ///
-/// Mirrors upstream `flist.c:2442` which honours `(xfer_dirs && name_type != NORMAL_NAME)`
+/// Mirrors upstream `flist.c:2477` which honours `(xfer_dirs && name_type != NORMAL_NAME)`
 /// to walk one level beneath SLASH_ENDING_NAME / DOTDIR_NAME source arguments
 /// (and `--files-from` entries with the corresponding markers). Subdirectories
 /// encountered during this one-level walk are NOT recursed into further,
@@ -222,7 +222,7 @@ fn copy_directory_recursive_inner(
     let mut created_directory_on_disk = false;
     let creation_record_pending = destination_missing && relative.is_some();
     let mut record_emitted = false;
-    // upstream: main.c:794-796 + generator.c:566-572 - when the receiver
+    // upstream: main.c:803-805 + generator.c:566-572 - when the receiver
     // mkdirs the destination root, `flist->files[0]->flags |= FLAG_DIR_CREATED`
     // and `itemize()` emits `cd+++++++++ ./` for the synthesized "." entry.
     // Synthesize a "." relative path for the root when the destination root
@@ -231,7 +231,7 @@ fn copy_directory_recursive_inner(
     // Subsequent runs against an existing destination still see relative=None
     // here, so no record is synthesized and the `-i` output omits the `./`
     // entry as upstream does (test line 74-79).
-    // upstream: main.c:794-796 + generator.c:566-572 - when the receiver
+    // upstream: main.c:803-805 + generator.c:566-572 - when the receiver
     // mkdirs the destination root, `flist->files[0]->flags |= FLAG_DIR_CREATED`
     // and `itemize()` emits `cd+++++++++ ./` for the synthesized "." entry.
     // The root flist entry has relative=None here because `non_empty_path("")`
@@ -314,7 +314,7 @@ fn copy_directory_recursive_inner(
     // the context flags `emit_unchanged` (mirroring `INFO_GTE(NAME, 2)`), so
     // non-verbose runs continue to omit unchanged dirs while `-vv` surfaces
     // them as `.d` rows.
-    // upstream: generator.c:1480-1535 - for an existing directory the itemize
+    // upstream: generator.c:1492-1547 - for an existing directory the itemize
     // row precedes the child transfer rows, but a `--delete-before`/`during`
     // sweep of that directory's extraneous entries is emitted BEFORE the
     // directory's own row (do_delete_pass runs first for `before`;
@@ -435,7 +435,7 @@ fn copy_directory_recursive_inner(
         Ok(())
     };
 
-    // upstream: flist.c:2442 - global recursion off AND not a trailing-slash
+    // upstream: flist.c:2477 - global recursion off AND not a trailing-slash
     // / DOTDIR source: emit the directory entry only and stop. Trailing-slash
     // sources (`force_walk_one_level`) fall through to walk one level so
     // upstream's `(xfer_dirs && name_type != NORMAL_NAME)` semantics hold.
@@ -559,7 +559,7 @@ fn copy_directory_recursive_inner(
                 }
             }
             Err(error) if error.is_vanished_error() => {
-                // upstream: flist.c:1289 / sender.c:358 - vanished files produce
+                // upstream: flist.c:1317 / sender.c:389 - vanished files produce
                 // a warning and set IOERR_VANISHED (exit code 24).
                 // full_fname() wraps the path in double quotes (util1.c:1228).
                 eprintln!("file has vanished: \"{}\"", planned.entry.path.display());

--- a/crates/engine/src/local_copy/executor/file/backup_trace.rs
+++ b/crates/engine/src/local_copy/executor/file/backup_trace.rs
@@ -16,7 +16,7 @@
 //! - `backup.c:299-300` - `"make_backup: SYMLINK %s successful.\n"`
 //! - `backup.c:333-334` - `"make_backup: COPY %s successful.\n"`
 //!
-//! The flag table entry at `options.c:289` is
+//! The flag table entry at `options.c:299` is
 //! `DEBUG_WORD(BACKUP, W_REC, "Debug backup actions (levels 1-2)")`.
 //! Upstream's help text mentions a level 2 but only level 1 sites exist
 //! in `backup.c`; this module mirrors that reality. `%s` is the source

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -198,7 +198,7 @@ pub(super) fn process_links(
             link_target.display()
         );
 
-        // upstream: hlink.c:215-224 / generator.c:1008-1013 - a `--link-dest`
+        // upstream: hlink.c:215-224 / generator.c:1020-1025 - a `--link-dest`
         // cluster member is linked from the basis, so it ends up sharing the
         // same inode as its already-placed in-transfer leader. `maybe_hard_link`
         // then takes the same-inode branch, itemizing with an empty xname and
@@ -626,7 +626,7 @@ pub(super) fn process_links(
     {
         match decision {
             ReferenceDecision::Skip(basis) => {
-                // upstream: generator.c:1010,1133 / rsync.c:676 - "is uptodate"
+                // upstream: generator.c:1022,1145 / rsync.c:676 - "is uptodate"
                 // emitted at INFO_GTE(NAME, 2) when a reference-directory match
                 // means no transfer is needed. Rendered by the CLI from the
                 // MetadataReused event (cli::frontend::progress::render) so
@@ -771,7 +771,7 @@ pub(super) fn process_links(
                     // shared inode and followers inherit for free.
                     //
                     // upstream: hlink.c::hard_link_check returns 1 for
-                    // followers; generator.c:1540 exits before
+                    // followers; generator.c:1552 exits before
                     // set_file_attrs() so set_acl() is never invoked on a
                     // follower alias.
                     #[cfg(all(any(unix, windows), feature = "acl"))]

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -141,7 +141,7 @@ pub(crate) fn copy_file(
 
     // upstream: generator.c:1704-1719 recv_generator() - the max-size/min-size
     // filter runs after the "not creating new" (--existing) check at
-    // generator.c:1368, so an out-of-range file absent from the destination
+    // generator.c:1380, so an out-of-range file absent from the destination
     // reports "not creating new file" rather than a size skip.
     //
     // Record the skip as a client event rather than emitting it via `info_log!`

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -424,7 +424,7 @@ pub(in crate::local_copy) fn execute_transfer(
         let file = match open_source_file(override_path, context.open_noatime_enabled()) {
             Ok(file) => file,
             Err(error) => {
-                // upstream: generator.c:919 - rsyserr(FINFO, errno,
+                // upstream: generator.c:931 - rsyserr(FINFO, errno,
                 // "copy_file %s => %s", full_fname(src), copy_to) under
                 // INFO_GTE(COPY, 1). The override path is the alt-base
                 // (`--copy-dest` / `--link-dest` after cross-device degrade)

--- a/crates/engine/src/local_copy/executor/iconv.rs
+++ b/crates/engine/src/local_copy/executor/iconv.rs
@@ -15,7 +15,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `flist.c:1579-1603` `send_file_name()` - `iconvbufs(ic_send, ...)`
+//! - `flist.c:1615-1639` `send_file_name()` - `iconvbufs(ic_send, ...)`
 //!   transcodes the filename before it leaves the sender.
 //! - `flist.c:738-754` `recv_file_entry()` - `iconvbufs(ic_recv, ...)`
 //!   transcodes the filename before the receiver hits the filesystem.

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -63,7 +63,7 @@ pub(crate) struct ReferenceQuery<'a> {
 }
 
 /// Reports whether a reference basis already carries the source's preserved
-/// attributes, mirroring upstream `generator.c:468 unchanged_attrs()`.
+/// attributes, mirroring upstream `generator.c:475 unchanged_attrs()`.
 ///
 /// A `true` result is upstream match_level 3 (data and attributes both match):
 /// the basis is hard-linked (`--link-dest`) or treated as up-to-date
@@ -77,7 +77,7 @@ pub(crate) struct ReferenceQuery<'a> {
 /// permission bits (`perms_differ`), owner/group (`ownership_differs`), mtime
 /// (`any_time_differs`), and, when `-X` is active, the transferable extended
 /// attributes (`xattrs_differ`), each gated on the corresponding preserve option.
-// upstream: generator.c:468-502 unchanged_attrs - perms/ownership/time/xattr.
+// upstream: generator.c:475-509 unchanged_attrs - perms/ownership/time/xattr.
 pub(crate) fn reference_attrs_unchanged(
     basis: &Path,
     source: &Path,
@@ -96,7 +96,7 @@ pub(crate) fn reference_attrs_unchanged(
         return false;
     }
 
-    // upstream: generator.c:485 any_time_differs - the mtime must match for a
+    // upstream: generator.c:492 any_time_differs - the mtime must match for a
     // level-3 basis. Compared through `SystemTime` (like the quick-check
     // `unchanged_file` path) so the check holds on every platform, not just Unix
     // where `st_mtime` is available.
@@ -107,7 +107,7 @@ pub(crate) fn reference_attrs_unchanged(
         }
     }
 
-    // upstream: generator.c:487 perms_differ - Unix compares the full permission
+    // upstream: generator.c:494 perms_differ - Unix compares the full permission
     // bits; on platforms without POSIX modes (Windows) the only preserved
     // permission is the read-only attribute, matching how oc applies and
     // quick-checks permissions there.
@@ -166,7 +166,7 @@ fn reference_permissions_match(source_meta: &fs::Metadata, basis_meta: &fs::Meta
 /// picks an earlier data-only basis over a later exact one, forcing an
 /// unnecessary copy/transfer and (for `--link-dest`) reapplying attrs onto a
 /// shared basis inode. The winning level then drives the action
-/// (generator.c:995-1054):
+/// (generator.c:1007-1066):
 ///
 /// - `--compare-dest`: level 3 is up-to-date (skip, no write); level 2 copies the
 ///   basis in and reapplies attrs (`copy_altdest_file`).

--- a/crates/engine/src/local_copy/executor/sources/destination.rs
+++ b/crates/engine/src/local_copy/executor/sources/destination.rs
@@ -74,7 +74,7 @@ pub(crate) fn ensure_destination_directory(
         return Ok(true);
     }
 
-    // upstream: main.c:736 vs main.c:787 - `--mkpath` runs `make_path()` (full
+    // upstream: main.c:736 vs main.c:796 - `--mkpath` runs `make_path()` (full
     // chain) while the plain path does a single `do_mkdir(dest_path)` that fails
     // with ENOENT when a leading directory is absent.
     let outcome = if mkpath {

--- a/crates/engine/src/local_copy/executor/sources/handlers.rs
+++ b/crates/engine/src/local_copy/executor/sources/handlers.rs
@@ -168,7 +168,7 @@ pub(super) fn handle_directory_copy(
         return Ok(());
     }
 
-    // upstream: main.c:778 get_local_name() - when `file_total > 1 ||
+    // upstream: main.c:787 get_local_name() - when `file_total > 1 ||
     // trailing_slash` the destination is treated as a directory and the source
     // directory name is kept as a path component. For a no-trailing-slash
     // directory source `file_total > 1` holds exactly when the directory is

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -77,7 +77,7 @@ pub(crate) fn copy_sources(
                 destination_state.is_dir = true;
             }
 
-            // upstream: main.c:794-799 - the receiver pre-flight-mkdirs the
+            // upstream: main.c:803-808 - the receiver pre-flight-mkdirs the
             // destination root, flags the synthetic "." flist entry with
             // FLAG_DIR_CREATED, and emits `created directory %s\n` when
             // INFO_GTE(NAME, 1) || stdout_format_has_i. Surface the same
@@ -104,7 +104,7 @@ pub(crate) fn copy_sources(
                 )?;
             }
 
-            // upstream: main.c:778 get_local_name() - `if (file_total > 1 ||
+            // upstream: main.c:787 get_local_name() - `if (file_total > 1 ||
             // trailing_slash) { do_mkdir(dest_path); ... }`. The transfer-level
             // decision is made ONCE, from the flist entry count. For a single
             // no-trailing-slash directory source `file_total > 1` requires the
@@ -170,7 +170,7 @@ pub(crate) fn copy_sources(
                 );
                 if let Err(error) = result {
                     if error.is_vanished_error() {
-                        // upstream: flist.c:1289 - vanished files produce a warning
+                        // upstream: flist.c:1317 - vanished files produce a warning
                         // and set IOERR_VANISHED, but transfer continues.
                         // full_fname() wraps the path in double quotes (util1.c:1228).
                         eprintln!("file has vanished: \"{}\"", source.path().display());
@@ -203,7 +203,7 @@ pub(crate) fn copy_sources(
             }
 
             // Write the flist end-of-list marker, ID lists, then delta data.
-            // upstream: flist.c:2513-2514 - without INC_RECURSE, send_id_lists()
+            // upstream: flist.c:2548-2549 - without INC_RECURSE, send_id_lists()
             // writes uid/gid name mappings after the flist end marker.
             // Since names are already embedded inline via XMIT_USER_NAME_FOLLOWS,
             // the ID lists are empty (just varint30(0) terminators), but they
@@ -374,7 +374,7 @@ fn process_single_source(
                                 .as_deref()
                                 .and_then(|p| non_empty_path(p))
                                 .or_else(|| source_path.file_name().map(Path::new));
-                            // upstream: flist.c:1319 - INFO_GTE(MOUNT, 1) gates
+                            // upstream: flist.c:1347 - INFO_GTE(MOUNT, 1) gates
                             // `rprintf(FINFO, "[%s] skipping mount-point dir %s", who_am_i(),
                             // thisname)` when `-xx` prunes a root-level mount-point source.
                             // The role prefix is added downstream by the renderer.

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -50,7 +50,7 @@ pub(crate) fn copy_device(
     #[cfg(not(all(any(unix, windows), feature = "acl")))]
     let _ = mode;
 
-    // upstream: generator.c:558-563 / 550-556 - a replace itemize reports
+    // upstream: generator.c:565-570 / 550-556 - a replace itemize reports
     // ITEM_REPORT_XATTR / ITEM_REPORT_ACL when those features are active and the
     // basis differs. Mirror the enabled flags across all platforms so the
     // recreate change-set is derivable without cfg branching at the record site.
@@ -111,7 +111,7 @@ pub(crate) fn copy_device(
         return Ok(());
     }
 
-    // upstream: generator.c:1627-1630 - a device whose destination already
+    // upstream: generator.c:1639-1642 - a device whose destination already
     // holds another device (same FT_DEVICE bucket) is recreated rather than
     // treated as new; quick_check_ok() (generator.c:661-671) compares st_rdev
     // to decide. Snapshot the existing device and its rdev-difference before
@@ -419,7 +419,7 @@ pub(crate) fn copy_device(
                 Some(metadata_snapshot),
             );
             let record = if let Some(existing) = replaced_device.as_ref() {
-                // upstream: generator.c:1665-1669 - a device replacing another
+                // upstream: generator.c:1677-1681 - a device replacing another
                 // device of the same FT_DEVICE bucket recreates it and itemizes
                 // via ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE (`cDc.T.`), not
                 // ITEM_IS_NEW. Derive the change-set from the rdev comparison.

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -54,7 +54,7 @@ pub(crate) fn copy_fifo(
     #[cfg(not(all(any(unix, windows), feature = "acl")))]
     let _ = mode;
 
-    // upstream: generator.c:558-563 / 550-556 - a replace itemize reports
+    // upstream: generator.c:565-570 / 550-556 - a replace itemize reports
     // ITEM_REPORT_XATTR / ITEM_REPORT_ACL when those features are active and the
     // basis differs. Surface the enabled flags on all platforms so the recreate
     // change-set is derivable without cfg branching at the record site.
@@ -115,7 +115,7 @@ pub(crate) fn copy_fifo(
         return Ok(());
     }
 
-    // upstream: generator.c:1615-1630 - a special file (FIFO/socket) whose
+    // upstream: generator.c:1627-1642 - a special file (FIFO/socket) whose
     // destination already holds another special of the same FT_SPECIAL bucket is
     // recreated rather than treated as new; quick_check_ok() (generator.c:657-660)
     // compares the `_S_IFMT` bits (FIFO vs socket). Snapshot the existing special
@@ -426,7 +426,7 @@ pub(crate) fn copy_fifo(
             Some(metadata_snapshot),
         );
         let record = if let Some(existing) = replaced_special.as_ref() {
-            // upstream: generator.c:1665-1669 - a special replacing a differing
+            // upstream: generator.c:1677-1681 - a special replacing a differing
             // special of the same FT_SPECIAL bucket recreates it and itemizes via
             // ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE, not ITEM_IS_NEW. Derive the
             // change-set from the `_S_IFMT` comparison.

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -220,7 +220,7 @@ pub(crate) fn copy_symlink(
     // If the link is unsafe but we were told to copy what it points to, do that.
     if unsafe_target {
         if context.copy_unsafe_links_enabled() {
-            // upstream: flist.c:217 - INFO_GTE(SYMSAFE, 1) fires before
+            // upstream: flist.c:229 - INFO_GTE(SYMSAFE, 1) fires before
             // an unsafe symlink is dereferenced into a regular entry.
             info_log!(
                 Symsafe,

--- a/crates/engine/src/local_copy/hard_links/unix.rs
+++ b/crates/engine/src/local_copy/hard_links/unix.rs
@@ -13,7 +13,7 @@ pub(crate) struct HardLinkTracker {
     /// per cohort instead of O(N) per follower.
     ///
     /// upstream: hlink.c::hard_link_check returns 1 for followers so
-    /// generator.c:1540 exits before set_file_attrs(); the inode keeps the
+    /// generator.c:1552 exits before set_file_attrs(); the inode keeps the
     /// leader's metadata for free.
     #[cfg(any(test, feature = "acl"))]
     acl_cohort_leaders: rustc_hash::FxHashSet<PathBuf>,

--- a/crates/engine/src/local_copy/hard_links/windows.rs
+++ b/crates/engine/src/local_copy/hard_links/windows.rs
@@ -14,7 +14,7 @@ pub(crate) struct HardLinkTracker {
     /// same DACL through each alias produces N identical inode-level writes.
     ///
     /// upstream: hlink.c::hard_link_check returns 1 for followers so
-    /// generator.c:1540 exits before set_file_attrs(); the inode keeps the
+    /// generator.c:1552 exits before set_file_attrs(); the inode keeps the
     /// leader's DACL for free.
     #[cfg(any(test, feature = "acl"))]
     acl_cohort_leaders: rustc_hash::FxHashSet<PathBuf>,

--- a/crates/engine/src/local_copy/options/backup.rs
+++ b/crates/engine/src/local_copy/options/backup.rs
@@ -40,7 +40,7 @@ impl LocalCopyOptions {
                 self.backup = true;
             }
             None => {
-                // upstream: options.c:2278-2279
+                // upstream: options.c:2296-2297
                 // backup_suffix = backup_dir ? "" : BACKUP_SUFFIX
                 if self.backup_dir.is_some() {
                     self.backup_suffix = OsString::new();
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn with_backup_suffix_none_empty_when_backup_dir_set() {
-        // upstream: options.c:2278-2279 - backup_suffix = backup_dir ? "" : BACKUP_SUFFIX
+        // upstream: options.c:2296-2297 - backup_suffix = backup_dir ? "" : BACKUP_SUFFIX
         let opts = LocalCopyOptions::new()
             .with_backup_directory(Some("/backups"))
             .with_backup_suffix::<OsString>(None);

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -21,7 +21,7 @@ impl LocalCopyOptionsBuilder {
             });
         }
 
-        // upstream: options.c:2382 - --append cannot be used with --whole-file.
+        // upstream: options.c:2400 - --append cannot be used with --whole-file.
         // Only an explicit `whole_file = Some(true)` conflicts; the default
         // (None) and `--no-whole-file` (Some(false)) are accepted.
         if self.append && self.whole_file == Some(true) {

--- a/crates/engine/src/local_copy/options/metadata/accessors.rs
+++ b/crates/engine/src/local_copy/options/metadata/accessors.rs
@@ -133,7 +133,7 @@ impl LocalCopyOptions {
     /// path, mirroring upstream's `am_root < 0` sentinel.
     // upstream: options.c:89 - am_root tri-state: 0 normal, 1 root, 2 --super,
     //                          -1 --fake-super (negative is "fake")
-    // upstream: clientserver.c:1102-1105 - daemon `fake super = yes` forces am_root=-1
+    // upstream: clientserver.c:1116-1119 - daemon `fake super = yes` forces am_root=-1
     // upstream: syscall.c do_mknod() - am_root<0 sentinel substitutes 0600 placeholder
     #[must_use]
     pub fn am_root(&self) -> bool {

--- a/crates/engine/src/local_copy/plan/change_set/detection.rs
+++ b/crates/engine/src/local_copy/plan/change_set/detection.rs
@@ -138,7 +138,7 @@ impl LocalCopyChangeSet {
 
     /// Computes a change set for an existing destination directory.
     ///
-    /// Mirrors upstream `itemize()` (`generator.c:511-572`) for the directory
+    /// Mirrors upstream `itemize()` (`generator.c:518-579`) for the directory
     /// branch reached via `generator.c:1480-1483` when `statret == 0`: the
     /// receiver flags `ITEM_REPORT_TIME` when `mtime_differs` (gated by
     /// `!omit_dir_times`), `ITEM_REPORT_PERMS` when the masked mode bits
@@ -161,7 +161,7 @@ impl LocalCopyChangeSet {
         if times_preserved {
             let new_mtime = metadata_modified_time(source);
             let old_mtime = metadata_modified_time(existing);
-            // upstream: generator.c:526 - itemize() sets ITEM_REPORT_TIME via
+            // upstream: generator.c:533 - itemize() sets ITEM_REPORT_TIME via
             // `!same_time(file->modtime, 0, &sxp->st)`. same_time() (util1.c:1478)
             // compares whole seconds under `--modify-window`, so a sub-second
             // mtime drift on a directory must NOT light the `t` glyph. This is
@@ -219,7 +219,7 @@ impl LocalCopyChangeSet {
     ///
     /// The mtime comparison uses `same_time()` semantics via
     /// `system_time_within_window`, not exact equality: upstream `itemize()` at
-    /// `generator.c:526-527` calls `mtime_differs()` ->
+    /// `generator.c:533-534` calls `mtime_differs()` ->
     /// `same_time(stp->st_mtime, ..., file->modtime, ...)` (util1.c:1478), which
     /// with the default `modify_window == 0` compares WHOLE SECONDS only
     /// (`f1_sec == f2_sec`) and ignores the fractional part. Two links whose
@@ -259,7 +259,7 @@ impl LocalCopyChangeSet {
     /// Computes a change set for a device or special file whose existing
     /// destination is being recreated because it differs from the source.
     ///
-    /// Mirrors upstream `generator.c:1665-1670`: after `atomic_create()`
+    /// Mirrors upstream `generator.c:1677-1682`: after `atomic_create()`
     /// recreates the node, `itemize()` runs with
     /// `ITEM_LOCAL_CHANGE|ITEM_REPORT_CHANGE` and `statret == 0`.
     /// `ITEM_REPORT_CHANGE` lights the position-2 `c` glyph; its source is the
@@ -271,7 +271,7 @@ impl LocalCopyChangeSet {
     /// (rendered `t` when preserving mtimes and they differ, `T` when mtimes
     /// are not preserved because `ITEM_LOCAL_CHANGE` marks a fresh recreate),
     /// `ITEM_REPORT_PERMS`, and owner/group. Size is never reported because
-    /// `S_ISREG` is false for device and special nodes (`generator.c:514`).
+    /// `S_ISREG` is false for device and special nodes (`generator.c:521`).
     #[allow(clippy::too_many_arguments)]
     pub fn for_recreated_device(
         source: &fs::Metadata,
@@ -284,7 +284,7 @@ impl LocalCopyChangeSet {
     ) -> Self {
         let mut change_set = Self::new();
 
-        // upstream: generator.c:1668-1669 - the recreate path passes
+        // upstream: generator.c:1680-1681 - the recreate path passes
         // ITEM_REPORT_CHANGE, but it is only reached because quick_check_ok()
         // found a differing device number / special type. Light the `c` glyph
         // from that same comparison.
@@ -292,7 +292,7 @@ impl LocalCopyChangeSet {
             change_set = change_set.with_checksum_changed(true);
         }
 
-        // upstream: generator.c:519-523 - with preserve_mtimes (`keep_time`),
+        // upstream: generator.c:526-530 - with preserve_mtimes (`keep_time`),
         // ITEM_REPORT_TIME fires only when the mtime differs (rendered `t`).
         // Without preserve_mtimes, the ITEM_LOCAL_CHANGE branch sets
         // ITEM_REPORT_TIME unconditionally for a freshly recreated node
@@ -364,7 +364,7 @@ fn determine_time_change(
         let new_mtime = metadata_modified_time(metadata);
         let old_mtime = existing.and_then(metadata_modified_time);
 
-        // upstream: generator.c:526 - the ITEM_REPORT_TIME bit is set via
+        // upstream: generator.c:533 - the ITEM_REPORT_TIME bit is set via
         // `!same_time(file->modtime, 0, &sxp->st)`. same_time() (util1.c:1478)
         // treats two mtimes as equal when their whole-second delta is within
         // `--modify-window`, so a sub-window drift must NOT light the `t` glyph.

--- a/crates/engine/src/local_copy/plan/change_set/tests.rs
+++ b/crates/engine/src/local_copy/plan/change_set/tests.rs
@@ -469,7 +469,7 @@ fn for_file_times_not_changed_existing_no_write() {
     assert!(change_set.time_change().is_none());
 }
 
-/// upstream: generator.c:526 - the ITEM_REPORT_TIME (`t`) glyph is gated by
+/// upstream: generator.c:533 - the ITEM_REPORT_TIME (`t`) glyph is gated by
 /// `!same_time(...)`, which honours `--modify-window`. A same-size file whose
 /// mtime drifts by less than the window must therefore leave the time slot
 /// blank so the itemize line is suppressed. Guards the itemize path exercised
@@ -698,7 +698,7 @@ fn for_existing_directory_flags_time_change_when_mtimes_differ() {
     assert!(change_set.has_any_change());
 }
 
-/// upstream: generator.c:526 via same_time() (util1.c:1478) - directory
+/// upstream: generator.c:533 via same_time() (util1.c:1478) - directory
 /// itemize compares whole seconds under modify_window == 0, so a sub-second
 /// mtime drift within the same whole second must NOT report a time change.
 /// This mirrors the file/symlink paths, which already ignore sub-second drift.
@@ -956,7 +956,7 @@ fn for_recreated_device_sets_checksum_and_time_when_content_differs() {
         false,
     );
 
-    // upstream: generator.c:1668-1669 rdev/type diff drives ITEM_REPORT_CHANGE
+    // upstream: generator.c:1680-1681 rdev/type diff drives ITEM_REPORT_CHANGE
     // (`c`); with preserve-times and a differing mtime, ITEM_REPORT_TIME renders
     // `t` (`cDc.t.....`). Devices never report size.
     assert!(change_set.checksum_changed());

--- a/crates/engine/src/local_copy/plan/change_set/types.rs
+++ b/crates/engine/src/local_copy/plan/change_set/types.rs
@@ -210,7 +210,7 @@ impl LocalCopyChangeSet {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:574-576` - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
+    /// - `generator.c:581-583` - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
     #[must_use]
     pub const fn has_any_change(&self) -> bool {
         self.checksum_changed

--- a/crates/engine/src/local_copy/plan/metadata.rs
+++ b/crates/engine/src/local_copy/plan/metadata.rs
@@ -194,7 +194,7 @@ impl LocalCopyMetadata {
     /// reporting, so `--list-only` and itemized output show `-rw-...` with the
     /// device's readable byte length instead of `brw-...`/`crw-...` and `0`.
     ///
-    /// Mirrors upstream `flist.c:1419-1428 make_file()`, which rewrites the
+    /// Mirrors upstream `flist.c:1451-1460 make_file()`, which rewrites the
     /// device stat to `S_IFREG | (mode & ACCESSPERMS)` with `get_device_size()`
     /// before the entry is ever itemized. A no-op for non-device kinds.
     #[must_use]

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -122,7 +122,7 @@ pub struct LocalCopySummary {
     fifos_created: u64,
     // Per-type counts of entries whose destination did NOT previously exist,
     // mirroring upstream's `stats.created_{files,symlinks,devices,specials}`
-    // accounting (receiver.c:733-746 / sender.c:295-308): every ITEM_IS_NEW
+    // accounting (receiver.c:733-746 / sender.c:301-314): every ITEM_IS_NEW
     // entry bumps the created counter for its type, whether or not it moved
     // file data. Kept distinct from the "copied" tallies above, which also
     // count in-place updates of pre-existing files/symlinks/nodes. `created_dirs`
@@ -506,7 +506,7 @@ impl LocalCopySummary {
 
     /// Returns `true` when the transfer materialised the destination root directory.
     ///
-    /// upstream: main.c:798-799 - `rprintf(FINFO, "created directory %s\n", dest_path)`
+    /// upstream: main.c:807-808 - `rprintf(FINFO, "created directory %s\n", dest_path)`
     /// gated on `INFO_GTE(NAME, 1) || stdout_format_has_i`. The CLI mirrors this
     /// gate to emit the notice ahead of the per-entry itemize lines so the
     /// upstream `testsuite/itemize.test` golden matches.

--- a/crates/engine/src/local_copy/tests/delete.rs
+++ b/crates/engine/src/local_copy/tests/delete.rs
@@ -651,7 +651,7 @@ fn delete_during_deletes_directory_before_transferring_its_children() {
 
 #[test]
 fn delete_before_keeps_in_source_file() {
-    // upstream: generator.c:279-351 delete_in_dir() / do_delete_pass() - a
+    // upstream: generator.c:286-358 delete_in_dir() / do_delete_pass() - a
     // destination entry is deleted only when flist_find_ignore_dirness() fails
     // to find it in the source file list. --delete-before shares that keep
     // decision with --delete-during/-after, so a file that exists in the

--- a/crates/engine/src/local_copy/tests/execute_directories.rs
+++ b/crates/engine/src/local_copy/tests/execute_directories.rs
@@ -1916,7 +1916,7 @@ fn execute_directory_source_deep_missing_dest_errors_without_mkpath() {
     assert!(!dest_root.exists());
 }
 
-// upstream: main.c:787 - a single missing final component is created by the lone
+// upstream: main.c:796 - a single missing final component is created by the lone
 // do_mkdir(dest_path) even without --mkpath (rsync always makes the immediate
 // destination directory). Only a missing PARENT is fatal.
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_modify_window.rs
+++ b/crates/engine/src/local_copy/tests/execute_modify_window.rs
@@ -836,7 +836,7 @@ fn modify_window_dry_run_reports_correctly() {
 }
 
 /// A dry-run itemize must apply `--modify-window` to the quick check exactly
-/// as a real run does. Upstream `generator.c:526,645` runs `same_time()` in
+/// as a real run does. Upstream `generator.c:533,652` runs `same_time()` in
 /// both modes, so a destination whose only drift is a sub-window mtime
 /// difference is up-to-date and is NOT reported as a transfer. This is the
 /// exact scenario the upstream `compare` testsuite exercises with

--- a/crates/engine/src/local_copy/tests/execute_one_file_system.rs
+++ b/crates/engine/src/local_copy/tests/execute_one_file_system.rs
@@ -836,7 +836,7 @@ fn one_file_system_emits_info_mount_notice() {
 
 /// Verifies that the default verbosity configuration (no `--info=MOUNT`)
 /// suppresses the notice, matching upstream's `INFO_GTE(MOUNT, 1)` gate
-/// (flist.c:1319). MOUNT is not in `info_verbosity[0]`, so it stays silent
+/// (flist.c:1347). MOUNT is not in `info_verbosity[0]`, so it stays silent
 /// unless explicitly enabled.
 #[test]
 fn one_file_system_default_verbosity_suppresses_info_mount_notice() {

--- a/crates/engine/src/local_copy/tests/execute_special.rs
+++ b/crates/engine/src/local_copy/tests/execute_special.rs
@@ -196,7 +196,7 @@ fn execute_without_specials_records_skip_event() {
 /// Verifies that skipping a non-regular source emits the upstream
 /// `--info=NONREG` notice through the diagnostic event queue.
 ///
-/// NONREG sits in upstream's `info_verbosity[0]` table (options.c:240) and
+/// NONREG sits in upstream's `info_verbosity[0]` table (options.c:250) and
 /// is therefore enabled by default at level 1, independent of `-v`. The
 /// emitted wording mirrors `generator.c:1687`:
 /// `skipping non-regular file "<path>"`.
@@ -248,7 +248,7 @@ fn skipping_non_regular_emits_info_nonreg_notice() {
 }
 
 /// Verifies that `--info=nononreg` (level 0) suppresses the NONREG notice,
-/// matching upstream's `INFO_GTE(NONREG, 1)` gate (generator.c:1684).
+/// matching upstream's `INFO_GTE(NONREG, 1)` gate (generator.c:1696).
 #[cfg(unix)]
 #[test]
 fn nononreg_suppresses_info_nonreg_notice() {
@@ -1870,7 +1870,7 @@ fn copy_unsafe_links_emits_info_symsafe_notice() {
 
 /// Verifies that the default verbosity configuration (no `--info=SYMSAFE`)
 /// suppresses the notice during a `--copy-unsafe-links` dereference,
-/// matching upstream's `INFO_GTE(SYMSAFE, 1)` gate (flist.c:216).
+/// matching upstream's `INFO_GTE(SYMSAFE, 1)` gate (flist.c:228).
 #[cfg(unix)]
 #[test]
 fn copy_unsafe_links_default_verbosity_suppresses_info_symsafe_notice() {

--- a/crates/engine/src/local_copy/tests/itemize_changes.rs
+++ b/crates/engine/src/local_copy/tests/itemize_changes.rs
@@ -702,7 +702,7 @@ fn itemize_size_change_detected_correctly() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // The position-2 `c` glyph (ITEM_REPORT_CHANGE) only fires under
-    // --checksum (upstream: generator.c:1929 - `if (always_checksum > 0)
+    // --checksum (upstream: generator.c:1942 - `if (always_checksum > 0)
     // iflags |= ITEM_REPORT_CHANGE`), so enable checksum mode to assert
     // `checksum_changed()` below.
     let options = LocalCopyOptions::default()


### PR DESCRIPTION
## Summary
Relines only the `// upstream: <file>.c:<LINE>` citations in the `engine` crate that are **provably** drifted from rsync 3.4.1 to 3.4.4. 76 citations across 38 files; comment-only, no code changes.

## Method (strict per-citation, not a blanket offset)
Engine citations are a mix: many already reference correct 3.4.4 lines (stable lines, or previously migrated), while some still carry drifted 3.4.1 numbers. A citation is changed **only** when a distinctive upstream anchor from its doc comment - a string literal (e.g. `created directory %s\n`, `[%s] skipping mount-point dir %s`) or a function/macro with few occurrences (e.g. `try_dests_non`, `BACKUP_SUFFIX`, `FLAG_DIR_CREATED`, `f_name_cmp`) - sits at the NEW 3.4.4 line and is absent from the OLD line. Every kept change was spot-checked against `rsync-3.4.4` source.

## Left unchanged (correct as-is or unverifiable)
- Citations whose OLD number already lands on the described 3.4.4 content (already 3.4.4-correct - e.g. `generator.c:1155` = `list_file_entry`, `flist.c:2548` = `if (numeric_ids <= 0 && !inc_recurse)`, `generator.c:2093` = `touch_up_dirs`, `generator.c:954` = `try_dests_reg`).
- Citations to stable files (`delete`/`exclude`/`backup`/`hlink`/`checksum`/`fileio`/`syscall`/`rsync`/`match`/`log`).
- Literal versioned doc paths (`target/interop/upstream-src/rsync-3.4.1/...`) and comments explicitly labelled "in upstream rsync 3.4.1".
- Any citation that could not be positively verified against 3.4.4 source. Per policy, a stale line is preferable to a wrong one.

## Test plan
- [x] Diff is comment-only; `git diff --word-diff` confirms every change is a digit-only edit inside a `c:NNN` citation.
- [x] `cargo fmt -p engine -- --check` on aarch64 host: FMT_OK.
- [x] Kept changes spot-checked against `rsync-3.4.4` source (function defs, string literals, macro sites), including range endpoints and multi-number citations.
