### PR TITLE
revert: undo cli citation reline (#6868 mislocated ~89%)

### DIFF
--- a/crates/cli/src/frontend/arguments/env.rs
+++ b/crates/cli/src/frontend/arguments/env.rs
@@ -31,7 +31,7 @@ pub(crate) fn env_protect_args_default() -> Option<bool> {
 /// Returns the default `--iconv` value derived from `RSYNC_ICONV`.
 ///
 /// Returns `Some(value)` when the variable is set and non-empty, `None`
-/// otherwise. Mirrors upstream rsync's `options.c:1393-1394`
+/// otherwise. Mirrors upstream rsync's `options.c:1377-1378`
 /// (`(arg = getenv("RSYNC_ICONV")) != NULL && *arg`), which seeds `iconv_opt`
 /// from the environment when the option was not given on the command line.
 pub(crate) fn env_iconv_default() -> Option<std::ffi::OsString> {
@@ -41,7 +41,7 @@ pub(crate) fn env_iconv_default() -> Option<std::ffi::OsString> {
 /// Returns the default `--max-alloc` argument derived from `RSYNC_MAX_ALLOC`.
 ///
 /// Returns `Some(value)` when the variable is set and non-empty, `None`
-/// otherwise. Mirrors upstream rsync's `options.c:1970-1973`
+/// otherwise. Mirrors upstream rsync's `options.c:1954-1957`
 /// (`max_alloc_arg = getenv("RSYNC_MAX_ALLOC"); if (max_alloc_arg &&
 /// !*max_alloc_arg) max_alloc_arg = NULL`), which supplies the default cap when
 /// `--max-alloc` was not given on the command line.
@@ -191,7 +191,7 @@ mod tests {
         assert_eq!(env_protect_args_default(), Some(true));
     }
 
-    // upstream: options.c:1393-1394 - RSYNC_ICONV seeds the default --iconv value.
+    // upstream: options.c:1377-1378 - RSYNC_ICONV seeds the default --iconv value.
     #[test]
     fn env_iconv_default_returns_none_when_unset() {
         let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
@@ -199,7 +199,7 @@ mod tests {
         assert_eq!(env_iconv_default(), None);
     }
 
-    // upstream: options.c:1393-1394 - `*arg` requires a non-empty value.
+    // upstream: options.c:1377-1378 - `*arg` requires a non-empty value.
     #[test]
     fn env_iconv_default_ignores_empty_value() {
         let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
@@ -207,7 +207,7 @@ mod tests {
         assert_eq!(env_iconv_default(), None);
     }
 
-    // upstream: options.c:1393-1394 - a non-empty value becomes iconv_opt.
+    // upstream: options.c:1377-1378 - a non-empty value becomes iconv_opt.
     #[test]
     fn env_iconv_default_returns_value() {
         let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
@@ -218,7 +218,7 @@ mod tests {
         );
     }
 
-    // upstream: options.c:1970-1973 - RSYNC_MAX_ALLOC seeds the default cap.
+    // upstream: options.c:1954-1957 - RSYNC_MAX_ALLOC seeds the default cap.
     #[test]
     fn env_max_alloc_default_returns_none_when_unset() {
         let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
@@ -226,7 +226,7 @@ mod tests {
         assert_eq!(env_max_alloc_default(), None);
     }
 
-    // upstream: options.c:1972-1973 - an empty value is treated as unset.
+    // upstream: options.c:1956-1957 - an empty value is treated as unset.
     #[test]
     fn env_max_alloc_default_ignores_empty_value() {
         let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
@@ -234,7 +234,7 @@ mod tests {
         assert_eq!(env_max_alloc_default(), None);
     }
 
-    // upstream: options.c:1970-1971 - a non-empty value becomes max_alloc_arg.
+    // upstream: options.c:1954-1955 - a non-empty value becomes max_alloc_arg.
     #[test]
     fn env_max_alloc_default_returns_value() {
         let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");

--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -234,7 +234,7 @@ pub struct ParsedArgs {
     /// (clap `overrides_with` mirrors upstream's last-wins popt semantics). The
     /// deprecated spelling is forwarded verbatim on the wire.
     ///
-    /// upstream: options.c:740, 3000-3003.
+    /// upstream: options.c:730, 2982-2985.
     pub remove_sent_files: bool,
 
     /// `--trust-sender` - trust the sending side's file list.
@@ -555,7 +555,7 @@ pub struct ParsedArgs {
     ///
     /// Distinct from `verbosity == 0` (the default): captured separately so the
     /// server-arg builder can pack the compact `q` letter, which upstream
-    /// (`options.c:2646`) emits only when `quiet && msgs2stderr`.
+    /// (`options.c:2628`) emits only when `quiet && msgs2stderr`.
     pub quiet: bool,
 
     /// `--progress`, `--info=progress2` / `--no-progress`.
@@ -580,7 +580,7 @@ pub struct ParsedArgs {
     ///
     /// Forces the itemize line for entries whose `iflags == 0` (a quick-check
     /// match with no attribute drift), independently of `-vv`. See upstream
-    /// `generator.c:589-590` and `options.c:1597,2372`.
+    /// `generator.c:582-583` and `options.c:1581,2354`.
     pub itemize_repeated: bool,
 
     /// `--out-format` - format string for file transfer messages.

--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -37,14 +37,14 @@ use super::{
 /// `--copy-dest`, and `--link-dest` combined.
 ///
 /// The three options share a single `basis_dir[]` array, so the cap is on their
-/// combined total. A separate conflict rule (upstream: options.c:1757-1761,
+/// combined total. A separate conflict rule (upstream: options.c:1741-1745,
 /// mirrored by `conflicts_with_all` on the args) forbids mixing the types, so in
 /// practice the array only ever holds one type. upstream: rsync.h:196
 /// `#define MAX_BASIS_DIRS 20`.
 const MAX_BASIS_DIRS: usize = 20;
 
 /// Maximum length of a `--write-batch`/`--only-write-batch`/`--read-batch`
-/// file name. upstream: options.c:235 `#define MAX_BATCH_NAME_LEN 256`
+/// file name. upstream: options.c:225 `#define MAX_BATCH_NAME_LEN 256`
 /// ("Must be less than MAXPATHLEN-13"). A longer name is rejected by
 /// `parse_arguments()` with `RERR_SYNTAX` (1). All three batch options write
 /// the same upstream `batch_name` variable, so the cap applies to whichever
@@ -53,7 +53,7 @@ pub(super) const MAX_BATCH_NAME_LEN: usize = 256;
 
 /// Enforces upstream's [`MAX_BASIS_DIRS`] cap on alt-dest directories.
 ///
-/// upstream: options.c:1765-1770 rejects the arg that would push the shared
+/// upstream: options.c:1749-1754 rejects the arg that would push the shared
 /// `basis_dir[]` array past `MAX_BASIS_DIRS`, reporting the alt-dest option in
 /// effect and exiting `RERR_SYNTAX` (1). The reported option is the first
 /// alt-dest option on the command line, mirroring upstream's `alt_dest_opt(0)`,
@@ -123,9 +123,9 @@ where
     let show_lsm_status = matches.get_flag("lsm-status");
 
     // Handle human-readable: `-h`/`--human-readable` take no argument and are
-    // repeatable, so we count occurrences. upstream: options.c:112 defaults
-    // `human_readable` to 1 (rendered as the None case here), options.c:1589
-    // increments it per -h, and options.c:627 resets it to 0 for --no-h. A
+    // repeatable, so we count occurrences. upstream: options.c:111 defaults
+    // `human_readable` to 1 (rendered as the None case here), options.c:1573
+    // increments it per -h, and options.c:617 resets it to 0 for --no-h. A
     // single -h selects base-1000 units; -hh (or more) selects base-1024.
     let mut human_readable = None;
     let h_count = matches.get_count("human-readable");
@@ -149,8 +149,8 @@ where
         tri_state_flag_negative_first(&matches, "omit-link-times", "no-omit-link-times");
     let atimes = leveled_flag_pair(&matches, "atimes", "no-atimes");
     let crtimes = tri_state_flag_negative_first(&matches, "crtimes", "no-crtimes");
-    // upstream: options.c:2384-2385 - only `dry_run` sets `do_xfers = 0` (and
-    // thus the compact `n` letter); `list_only` does NOT (options.c:2652 "Note:
+    // upstream: options.c:2366-2367 - only `dry_run` sets `do_xfers = 0` (and
+    // thus the compact `n` letter); `list_only` does NOT (options.c:2634 "Note:
     // NOT dry_run!"). The receiver skips destination writes under `list_only`
     // independently (see `run_client` mode selection and
     // `TransferFlags::skip_dest_writes`), so we must not conflate the two here.
@@ -201,7 +201,7 @@ where
     let blocking_io = tri_state_flag_positive_first(&matches, "blocking-io", "no-blocking-io");
     let archive = matches.get_flag("archive");
     // Last command-line index of `-a`, used to resolve every archive-implied
-    // dimension in argv order (upstream: options.c:1562 `case 'a'`). Gated on
+    // dimension in argv order (upstream: options.c:1546 `case 'a'`). Gated on
     // `archive` because clap's `SetTrue` args carry an implicit default whose
     // synthetic index `indices_of` reports even when `-a` was never supplied.
     let archive_index = if archive {
@@ -209,13 +209,13 @@ where
     } else {
         None
     };
-    // upstream: options.c:641-642 - `--old-dirs`/`--old-d` set xfer_dirs=4, and
-    // options.c:2215-2217 resolves that to `recurse = xfer_dirs = 1`
+    // upstream: options.c:631-632 - `--old-dirs`/`--old-d` set xfer_dirs=4, and
+    // options.c:2197-2199 resolves that to `recurse = xfer_dirs = 1`
     // unconditionally (after the argv scan), so it forces recursion on even over
     // a `--no-recursive`, and appends the `- /*/*` filter rule (injected below).
     let old_dirs = matches.get_flag("old-dirs");
     let recursive_override = tri_state_flag_negative_first(&matches, "recursive", "no-recursive");
-    // upstream: options.c:1562 `case 'a'` runs `if (!recurse) recurse = 1` in
+    // upstream: options.c:1546 `case 'a'` runs `if (!recurse) recurse = 1` in
     // argv order, so a `--no-recursive` that precedes `-a` is re-enabled by the
     // later `-a`, while one that follows it wins.
     let recursive = if old_dirs {
@@ -284,7 +284,7 @@ where
     let modify_window = match matches.remove_one::<OsString>("modify-window") {
         Some(value) => {
             let s = value.to_string_lossy();
-            // upstream: options.c:670 parses `--modify-window`/`-@` as a signed
+            // upstream: options.c:660 parses `--modify-window`/`-@` as a signed
             // int (`POPT_ARG_INT`); a negative value is valid and requests
             // nanosecond-exact comparison (util1.c:1482), so accept any integer.
             match s.parse::<i32>() {
@@ -300,10 +300,10 @@ where
         None => None,
     };
 
-    // upstream: options.c:2228 - the multiple-delete-WHEN check counts
+    // upstream: options.c:2210 - the multiple-delete-WHEN check counts
     // `delete_before + !!delete_during + delete_after`, where both
     // `--delete-during`/`--del` and `--delete-delay` write the single
-    // `delete_during` counter (options.c:734-735). Combining `--del` with
+    // `delete_during` counter (options.c:724-725). Combining `--del` with
     // `--delete-delay` therefore selects one "during" term and is NOT an error;
     // only distinct WHEN phases (before/during/after) conflict.
     let delete_mode_conflicts = [
@@ -322,7 +322,7 @@ where
         ));
     }
 
-    // upstream: options.c:2200-2203,2233-2235 - a negative `--max-delete` is
+    // upstream: options.c:2182-2185,2215-2217 - a negative `--max-delete` is
     // clamped to 0 ("no deletions") but NEVER enables deletion; delete mode is
     // turned on only by an explicit `--delete*`/`--delete-excluded`.
     let mut delete_mode = if delete_before_flag {
@@ -346,7 +346,7 @@ where
     let mut backup = matches.get_flag("backup");
     let backup_dir = matches.remove_one::<OsString>("backup-dir");
     let backup_suffix = matches.remove_one::<OsString>("suffix");
-    // upstream: options.c:2323-2325 - only `--backup-dir` implies `--backup`
+    // upstream: options.c:2305-2307 - only `--backup-dir` implies `--backup`
     // (`make_backups = 1`). `--suffix` alone merely sets the suffix string and
     // never enables backups, so it must not flip `backup` on here.
     if backup_dir.is_some() {
@@ -361,7 +361,7 @@ where
     let open_noatime = if no_open_noatime {
         false
     } else {
-        // upstream: options.c:1600-1602 `case 'U': if (++preserve_atimes > 1)
+        // upstream: options.c:1584-1586 `case 'U': if (++preserve_atimes > 1)
         // open_noatime = 1;` - a doubled `-U` (`-UU`, atimes level 2) implies
         // `--open-noatime`.
         open_noatime_flag || atimes == Some(2)
@@ -416,7 +416,7 @@ where
         compress = !setting.is_disabled();
     }
     let no_iconv = matches.get_flag("no-iconv");
-    // upstream: options.c:1393-1394 - `if (!am_daemon && protect_args <= 0 &&
+    // upstream: options.c:1377-1378 - `if (!am_daemon && protect_args <= 0 &&
     // (arg = getenv("RSYNC_ICONV")) != NULL && *arg) iconv_opt = strdup(arg);`.
     // RSYNC_ICONV seeds the default --iconv value when the option is absent,
     // unless the caller explicitly enabled protect_args (`protect_args > 0`,
@@ -535,7 +535,7 @@ where
     let implied_dirs = tri_state_flag_positive_first(&matches, "implied-dirs", "no-implied-dirs");
     let msgs_to_stderr = tri_state_flag_positive_first(&matches, "msgs2stderr", "no-msgs2stderr");
     let stderr_mode = matches.remove_one::<OsString>("stderr");
-    // upstream: options.c:1928 OPT_STDERR rejects any value that is not a
+    // upstream: options.c:1912 OPT_STDERR rejects any value that is not a
     // non-empty prefix of "errors", "all", or "client" with this exact message.
     if let Some(value) = stderr_mode.as_ref() {
         let valid = value
@@ -552,7 +552,7 @@ where
         }
     }
     let outbuf = matches.remove_one::<OsString>("outbuf");
-    // upstream: options.c:1970-1973 - `if (!max_alloc_arg) { max_alloc_arg =
+    // upstream: options.c:1954-1957 - `if (!max_alloc_arg) { max_alloc_arg =
     // getenv("RSYNC_MAX_ALLOC"); ... }`. RSYNC_MAX_ALLOC supplies the default
     // cap when --max-alloc is absent; an empty value is treated as unset.
     let max_alloc = matches
@@ -658,7 +658,7 @@ where
     } else if let Some(dir) = partial_dir_cli {
         Some(dir)
     } else if partial_flag {
-        // upstream: options.c:2466-2472 - RSYNC_PARTIAL_DIR is consulted only
+        // upstream: options.c:2448-2454 - RSYNC_PARTIAL_DIR is consulted only
         // when keep_partial is set (--partial/-P) and no explicit --partial-dir
         // was given. An empty value or a literal "." is treated as unset.
         env::var_os("RSYNC_PARTIAL_DIR")
@@ -689,16 +689,16 @@ where
     let link_destinations = link_dest_args;
     let remove_source_files =
         matches.get_flag("remove-source-files") || matches.get_flag("remove-sent-files");
-    // upstream: options.c:740,3000-3003 - the deprecated `--remove-sent-files`
+    // upstream: options.c:730,2982-2985 - the deprecated `--remove-sent-files`
     // spelling is forwarded verbatim. The two flags `.overrides_with` each other
     // (transfer_behavior_options.rs), so `get_flag` yields the effective
     // last-wins spelling, matching upstream's popt `remove_source_files = 2`.
     let remove_sent_files = matches.get_flag("remove-sent-files");
     let inplace = tri_state_flag_positive_first(&matches, "inplace", "no-inplace");
-    // upstream: options.c:1738-1742 - OPT_APPEND increments append_mode only on
+    // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode only on
     // the server (`am_server`); a non-server invocation caps it at 1. A second
     // `--append` on the server wire is the encoding of `--append-verify`
-    // (append_mode == 2). `--append-verify` sets it directly (options.c:729).
+    // (append_mode == 2). `--append-verify` sets it directly (options.c:719).
     let append_count = matches.get_count("append");
     let append_verify_flag =
         matches.get_flag("append-verify") || (server_mode && append_count >= 2);
@@ -720,9 +720,9 @@ where
             ProgressSetting::Unspecified
         };
     let itemize_changes_flag = matches.get_count("itemize-changes") > 0;
-    // upstream: options.c:1597 increments itemize_changes per `-i`, and
-    // options.c:2372 sets `stdout_format_has_i = itemize_changes`; the
-    // emit gate at generator.c:589 fires on `stdout_format_has_i > 1`, i.e.
+    // upstream: options.c:1581 increments itemize_changes per `-i`, and
+    // options.c:2354 sets `stdout_format_has_i = itemize_changes`; the
+    // emit gate at generator.c:582 fires on `stdout_format_has_i > 1`, i.e.
     // the `-i` flag given at least twice.
     let itemize_changes_repeated =
         matches.get_count("itemize-changes") > 1 && !matches.get_flag("no-itemize-changes");
@@ -780,7 +780,7 @@ where
     let compress_choice = matches.remove_one::<OsString>("compress-choice");
     let compress_threads = matches.remove_one::<OsString>("compress-threads");
     let old_compress = matches.get_flag("old-compress");
-    // upstream: options.c:2018 - if (!compress_choice && do_compression > 1)
+    // upstream: options.c:2002 - if (!compress_choice && do_compression > 1)
     //   compress_choice = "zlibx"; -zz selects new-style compression.
     let new_compress = matches.get_flag("new-compress")
         || (compress_count >= 2 && compress_choice.is_none() && !old_compress);
@@ -833,7 +833,7 @@ where
             _ => None,
         })
         .collect();
-    // upstream: options.c:2215-2217 - once the argv scan is complete, xfer_dirs>=4
+    // upstream: options.c:2197-2199 - once the argv scan is complete, xfer_dirs>=4
     // (set by --old-dirs/--old-d) appends `- /*/*` to the TAIL of the filter list
     // via parse_filter_str(&filter_list, "- /*/*", ...). exclude.c:parse_filter_str
     // appends each rule at the end, so this rule evaluates AFTER every user
@@ -857,7 +857,7 @@ where
         .remove_many::<OsString>("info")
         .map(Iterator::collect)
         .unwrap_or_default();
-    // upstream: generator.c:589-590 - the itemize line for an unchanged entry
+    // upstream: generator.c:582-583 - the itemize line for an unchanged entry
     // is emitted only when `INFO_GTE(NAME, 2)` is in effect, which `-vv` and
     // `--info=name2` both set. Resolve the effective NAME info level the same
     // way the logging config does (verbose count + any `--info=` override) so
@@ -875,7 +875,7 @@ where
         cfg.info.get(logging::InfoFlag::Name)
     };
     let name_level = if itemize_changes_flag && !no_itemize_changes_flag {
-        // upstream: generator.c:582-583 - the itemize emit gate fires for an
+        // upstream: generator.c:575-576 - the itemize emit gate fires for an
         // unchanged entry when `stdout_format_has_i > 1` (i.e. `-i` given at
         // least twice, captured by `itemize_changes_repeated`) OR
         // `INFO_GTE(NAME, 2)` (`-vv` / `--info=name2`, captured by
@@ -915,7 +915,7 @@ where
         no_motd = false;
     }
 
-    // upstream: options.c:2144-2148 - `--fake-super` (am_root < 0) conflicts with
+    // upstream: options.c:2126-2130 - `--fake-super` (am_root < 0) conflicts with
     // `-XX` (preserve_xattrs > 1); `-X`/`-XX` map to xattr levels 1/2 here.
     if fake_super == Some(true) && xattrs == Some(2) {
         return Err(clap::Error::raw(
@@ -924,7 +924,7 @@ where
         ));
     }
 
-    // upstream: options.c:2176-2185 - `--read-batch` cannot be combined with
+    // upstream: options.c:2158-2167 - `--read-batch` cannot be combined with
     // `--files-from` or `--remove-source-files`/`--remove-sent-files`.
     if read_batch.is_some() {
         if !files_from.is_empty() {
@@ -942,7 +942,7 @@ where
         }
     }
 
-    // upstream: options.c:2187-2192 - the shared `batch_name` (set by
+    // upstream: options.c:2169-2174 - the shared `batch_name` (set by
     // --write-batch, --only-write-batch, or --read-batch) must be at most
     // MAX_BATCH_NAME_LEN bytes, else parse_arguments() aborts with
     // RERR_SYNTAX (1). Length is measured in bytes (strlen), matching
@@ -959,7 +959,7 @@ where
         ));
     }
 
-    // upstream: options.c:2317-2322 - a `--suffix` containing a slash is rejected
+    // upstream: options.c:2299-2304 - a `--suffix` containing a slash is rejected
     // regardless of `--backup-dir`.
     if let Some(suffix) = backup_suffix.as_ref()
         && suffix.to_string_lossy().contains('/')
@@ -973,7 +973,7 @@ where
         ));
     }
 
-    // upstream: options.c:2346-2353 - an empty `--suffix` is only valid together
+    // upstream: options.c:2328-2335 - an empty `--suffix` is only valid together
     // with a `--backup-dir`; otherwise it is rejected.
     if backup_dir.is_none()
         && backup_suffix
@@ -986,10 +986,10 @@ where
         ));
     }
 
-    // upstream: options.c:2205-2221,2248-2252 - `--delete` needs `--recursive`
+    // upstream: options.c:2187-2203,2230-2234 - `--delete` needs `--recursive`
     // (-r) or `--dirs` (-d), gated on the RESOLVED xfer_dirs. When neither -r nor
-    // an explicit -d is given, `--files-from` (options.c:2208-2209) and
-    // `--list-only` (options.c:2221) still set xfer_dirs, so `--delete` is
+    // an explicit -d is given, `--files-from` (options.c:2190-2191) and
+    // `--list-only` (options.c:2203) still set xfer_dirs, so `--delete` is
     // permitted in those cases.
     if delete_mode.is_enabled() {
         let xfer_dirs = if recursive || old_dirs {

--- a/crates/cli/src/frontend/arguments/parser/flags.rs
+++ b/crates/cli/src/frontend/arguments/parser/flags.rs
@@ -94,7 +94,7 @@ fn tri_state_flag_indexed(
 
 /// Resolves an archive-implied flag pair honoring `-a`'s command-line position.
 ///
-/// upstream: options.c:1562 `case 'a'` expands `-a` in place during the argv
+/// upstream: options.c:1546 `case 'a'` expands `-a` in place during the argv
 /// scan, assigning `preserve_* = 1` for every `-rlptgoD` dimension. Because that
 /// scan is left-to-right and last-wins, a later individual `--no-X` overrides the
 /// archive default and a later `-a` re-enables the dimension (`-a --no-perms`
@@ -129,8 +129,8 @@ fn last_occurrence(matches: &clap::ArgMatches, id: &str) -> Option<usize> {
 /// the negative so clap's left-to-right resolution already reflects the winner:
 /// a later `--no-foo` clears the count, and a later `-ff` clears the negation.
 /// This mirrors upstream rsync's popt processing where `--foo` does `level++`
-/// and `--no-foo` resets `level = 0` (e.g. options.c:1601 `++preserve_atimes`,
-/// options.c:1893 `preserve_xattrs++`). The level is capped at 2 because that is
+/// and `--no-foo` resets `level = 0` (e.g. options.c:1585 `++preserve_atimes`,
+/// options.c:1877 `preserve_xattrs++`). The level is capped at 2 because that is
 /// the highest doubled letter upstream `server_options()` emits.
 ///
 /// Returns `None` when neither flag is present, so callers can distinguish

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -18,7 +18,7 @@ fn delete_modes_are_mutually_exclusive_two_flags() {
     let result = parse_test_args(["-r", "--delete-before", "--delete-after", "src/", "dst/"]);
     assert!(result.is_err());
     let err = result.unwrap_err();
-    // upstream: options.c:2229-2230 exact wording.
+    // upstream: options.c:2211-2212 exact wording.
     assert!(
         err.to_string()
             .contains("You may not combine multiple --delete-WHEN options.")
@@ -72,7 +72,7 @@ fn delete_excluded_activates_delete_mode() {
 
 #[test]
 fn max_delete_does_not_activate_delete_mode() {
-    // upstream: options.c:2233-2235 - `--max-delete` never enables deletion; it
+    // upstream: options.c:2215-2217 - `--max-delete` never enables deletion; it
     // only caps the count once an explicit `--delete*` has enabled it.
     let result = parse_test_args(["-r", "--max-delete=10", "src/", "dst/"]);
     assert!(result.is_ok());
@@ -160,7 +160,7 @@ fn omit_link_times_flag() {
     assert_eq!(parsed.omit_link_times, Some(true));
 }
 
-// upstream: options.c:2384-2385 - `--list-only` does NOT set dry_run (only -n
+// upstream: options.c:2366-2367 - `--list-only` does NOT set dry_run (only -n
 // does). The receiver skips destination writes under list_only independently
 // (run_client mode selection + TransferFlags::skip_dest_writes), so the two
 // must stay decoupled or the server args wrongly pack the compact 'n' letter.
@@ -207,7 +207,7 @@ fn backup_dir_implies_backup() {
 
 #[test]
 fn backup_suffix_does_not_imply_backup() {
-    // upstream: options.c:2314-2325 - only `--backup-dir` implies `--backup`; a
+    // upstream: options.c:2296-2307 - only `--backup-dir` implies `--backup`; a
     // bare `--suffix` sets the suffix string without enabling backups.
     let result = parse_test_args(["--suffix=.bak", "src/", "dst/"]);
     assert!(result.is_ok());
@@ -374,7 +374,7 @@ fn human_readable_long_flag_is_enabled() {
 
 #[test]
 fn human_readable_explicit_argument_is_rejected() {
-    // upstream: options.c:626 declares -h/--human-readable as POPT_ARG_NONE, so
+    // upstream: options.c:616 declares -h/--human-readable as POPT_ARG_NONE, so
     // `--human-readable=N` errors with "option does not take an argument".
     assert!(parse_test_args(["--human-readable=2", "src/", "dst/"]).is_err());
     assert!(parse_test_args(["--human-readable=0", "src/", "dst/"]).is_err());
@@ -382,7 +382,7 @@ fn human_readable_explicit_argument_is_rejected() {
 
 #[test]
 fn human_readable_no_flag_is_raw_level_zero() {
-    // upstream: options.c:627 resets human_readable to 0 (raw digits, width 11).
+    // upstream: options.c:617 resets human_readable to 0 (raw digits, width 11).
     let parsed = parse_test_args(["--no-human-readable", "src/", "dst/"]).expect("parse");
     assert_eq!(parsed.human_readable, Some(HumanReadableMode::Raw));
 }
@@ -973,7 +973,7 @@ fn alt_dest_args(flag: &str, count: usize) -> Vec<String> {
     args
 }
 
-/// upstream: options.c:1765-1770 accepts up to `MAX_BASIS_DIRS` (rsync.h:196)
+/// upstream: options.c:1749-1754 accepts up to `MAX_BASIS_DIRS` (rsync.h:196)
 /// alt-dest args; the boundary itself must not be rejected.
 #[test]
 fn alt_dest_limit_accepts_twenty() {
@@ -981,7 +981,7 @@ fn alt_dest_limit_accepts_twenty() {
     assert!(result.is_ok(), "20 alt-dest dirs must be accepted");
 }
 
-/// upstream: options.c:1768-1769 rejects the 21st alt-dest arg with the verbatim
+/// upstream: options.c:1752-1753 rejects the 21st alt-dest arg with the verbatim
 /// `ERROR: at most 20 <opt> args may be specified` message and RERR_SYNTAX. The
 /// exact wording matters because it is observable output a drop-in must mirror.
 #[test]
@@ -1017,7 +1017,7 @@ fn alt_dest_limit_enforced_for_each_type() {
 }
 
 /// The `basis_dir[]` array is shared, but upstream forbids mixing the three
-/// alt-dest types (options.c:1757-1761), a rule oc mirrors with
+/// alt-dest types (options.c:1741-1745), a rule oc mirrors with
 /// `conflicts_with_all`. So a "combined" total spanning types (here 10
 /// `--compare-dest` + 11 `--link-dest`) can never reach the count check - it is
 /// rejected first by the conflict rule. This proves only one type ever populates
@@ -1037,7 +1037,7 @@ fn alt_dest_types_cannot_be_mixed() {
     );
 }
 
-/// upstream: options.c:2187 uses `strlen(batch_name) > MAX_BATCH_NAME_LEN`, so a
+/// upstream: options.c:2169 uses `strlen(batch_name) > MAX_BATCH_NAME_LEN`, so a
 /// name of exactly MAX_BATCH_NAME_LEN (256) bytes is the boundary and must be
 /// accepted. This is observable behaviour a drop-in must not regress: rejecting
 /// a legal name would break scripts that upstream rsync accepts.
@@ -1055,7 +1055,7 @@ fn batch_name_at_max_len_accepted() {
     );
 }
 
-/// upstream: options.c:2187-2192 rejects a batch name longer than
+/// upstream: options.c:2169-2174 rejects a batch name longer than
 /// MAX_BATCH_NAME_LEN with the verbatim message
 /// `the batch-file name must be 256 characters or less.` and exits
 /// `RERR_SYNTAX` (1). The exact wording and the syntax exit code are both
@@ -1080,7 +1080,7 @@ fn batch_name_over_max_len_rejected_with_exact_message() {
     );
 }
 
-/// upstream: options.c:808-810 - `--write-batch`, `--only-write-batch`, and
+/// upstream: options.c:796-798 - `--write-batch`, `--only-write-batch`, and
 /// `--read-batch` all set the same `batch_name`, so the length cap fires for
 /// whichever one is present. `--read-batch` takes a dest-only operand.
 #[test]

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -247,7 +247,7 @@ mod short_options {
         assert_eq!(parsed.atimes, Some(1));
     }
 
-    // upstream: options.c:1601 `if (++preserve_atimes > 1)` - a doubled `-UU`
+    // upstream: options.c:1585 `if (++preserve_atimes > 1)` - a doubled `-UU`
     // raises the level to 2, which server_options() forwards as `-UU`. Modelled
     // as a count so the emitted server args match a real `rsync -UU`.
     #[test]
@@ -256,7 +256,7 @@ mod short_options {
         assert_eq!(parsed.atimes, Some(2));
     }
 
-    // upstream: options.c:1893 `preserve_xattrs++` - a doubled `-XX` raises the
+    // upstream: options.c:1877 `preserve_xattrs++` - a doubled `-XX` raises the
     // level to 2, forwarded as `-XX`.
     #[test]
     fn xattrs_double_short_flag_is_level_two() {
@@ -594,7 +594,7 @@ mod long_options {
 
     #[test]
     fn doubled_append_in_server_mode_is_append_verify() {
-        // upstream: options.c:1738-1742 - OPT_APPEND increments append_mode on
+        // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode on
         // am_server, so two --append flags select append-verify (append_mode == 2).
         // The client encodes --append-verify this way; the server must recover it.
         let parsed = parse_test_args(["--server", "--sender", "--append", "--append", ".", "src"])
@@ -608,7 +608,7 @@ mod long_options {
 
     #[test]
     fn doubled_append_client_mode_is_not_verify() {
-        // upstream: options.c:1742 - a non-server invocation caps append_mode at 1,
+        // upstream: options.c:1726 - a non-server invocation caps append_mode at 1,
         // so repeated --append on the client stays plain append (trust prefix).
         let parsed = parse_test_args(["--append", "--append", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.append, Some(true));
@@ -771,7 +771,7 @@ mod long_options {
     fn list_only_long_flag() {
         let parsed = parse_test_args(["--list-only", "src/", "dst/"]).expect("parse");
         assert!(parsed.list_only);
-        // upstream: options.c:2384-2385 - list_only does NOT set dry_run.
+        // upstream: options.c:2366-2367 - list_only does NOT set dry_run.
         assert!(!parsed.dry_run);
     }
 
@@ -787,7 +787,7 @@ mod long_options {
     fn remove_sent_files_alias() {
         let parsed = parse_test_args(["--remove-sent-files", "src/", "dst/"]).expect("parse");
         assert!(parsed.remove_source_files);
-        // upstream: options.c:740,3000-3003 - the deprecated spelling is tracked
+        // upstream: options.c:730,2982-2985 - the deprecated spelling is tracked
         // so it can be forwarded verbatim on the wire.
         assert!(parsed.remove_sent_files);
     }
@@ -1190,7 +1190,7 @@ mod option_values {
     fn suffix_with_equals() {
         let parsed = parse_test_args(["--suffix=.bak", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.backup_suffix, Some(OsString::from(".bak")));
-        // upstream: options.c:2314-2325 - a bare --suffix does not enable backups.
+        // upstream: options.c:2296-2307 - a bare --suffix does not enable backups.
         assert!(!parsed.backup);
     }
 
@@ -1315,7 +1315,7 @@ mod option_values {
     fn max_delete_with_equals() {
         let parsed = parse_test_args(["-r", "--max-delete=100", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.max_delete, Some(OsString::from("100")));
-        // upstream: options.c:2233-2235 - --max-delete never enables deletion.
+        // upstream: options.c:2215-2217 - --max-delete never enables deletion.
         assert!(!parsed.delete_mode.is_enabled());
     }
 
@@ -1327,7 +1327,7 @@ mod option_values {
 
     #[test]
     fn block_size_short_b_forms_match_long() {
-        // upstream: options.c:762 {"block-size", 'B', ...}. -B/-B<v>/-B=<v> and
+        // upstream: options.c:752 {"block-size", 'B', ...}. -B/-B<v>/-B=<v> and
         // --block-size all yield the same value (popt/clap strip the '=').
         let expected = Some(OsString::from("4096"));
         for args in [
@@ -1344,7 +1344,7 @@ mod option_values {
 
     #[test]
     fn temp_dir_short_t_forms_match_long() {
-        // upstream: options.c:837 {"temp-dir", 'T', ...}. -T/-T<v>/-T=<v> and
+        // upstream: options.c:825 {"temp-dir", 'T', ...}. -T/-T<v>/-T=<v> and
         // --temp-dir all yield the same DIR (the leading '=' is stripped).
         let expected = Some(std::path::PathBuf::from("/tmp/rsync-temp"));
         for args in [
@@ -1522,7 +1522,7 @@ mod option_values {
 
     #[test]
     fn human_readable_double_short_is_combined() {
-        // -hh increments to level 3 (base-1024 units). upstream: options.c:1589.
+        // -hh increments to level 3 (base-1024 units). upstream: options.c:1573.
         let parsed = parse_test_args(["-hh", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.human_readable, Some(HumanReadableMode::BinaryUnits));
     }
@@ -1776,7 +1776,7 @@ mod delete_modes {
         let result = parse_test_args(["-r", "--delete-before", "--delete-after", "src/", "dst/"]);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        // upstream: options.c:2229-2230 exact wording.
+        // upstream: options.c:2211-2212 exact wording.
         assert!(
             err.to_string()
                 .contains("You may not combine multiple --delete-WHEN options.")
@@ -2578,7 +2578,7 @@ mod open_noatime_tests {
 
     #[test]
     fn double_short_u_enables_open_noatime() {
-        // upstream: options.c:1600-1602 `case 'U': if (++preserve_atimes > 1)
+        // upstream: options.c:1584-1586 `case 'U': if (++preserve_atimes > 1)
         // open_noatime = 1;` - a doubled `-U` (atimes level 2) implies
         // `--open-noatime`, while a single `-U` does not.
         let single = parse_test_args(["-U", "src/", "dst/"]).expect("parse");
@@ -2688,7 +2688,7 @@ mod human_readable_tests {
 
     #[test]
     fn human_readable_rejects_explicit_argument() {
-        // upstream: options.c:626 POPT_ARG_NONE - `--human-readable=N` errors.
+        // upstream: options.c:616 POPT_ARG_NONE - `--human-readable=N` errors.
         assert!(parse_test_args(["--human-readable=0", "src/", "dst/"]).is_err());
         assert!(parse_test_args(["--human-readable=1", "src/", "dst/"]).is_err());
         assert!(parse_test_args(["--human-readable=2", "src/", "dst/"]).is_err());
@@ -2696,7 +2696,7 @@ mod human_readable_tests {
 
     #[test]
     fn no_human_readable_flag_is_raw() {
-        // upstream: options.c:627 sets human_readable = 0 (raw digits, width 11).
+        // upstream: options.c:617 sets human_readable = 0 (raw digits, width 11).
         let parsed = parse_test_args(["--no-human-readable", "src/", "dst/"]).expect("parse");
         assert_eq!(parsed.human_readable, Some(HumanReadableMode::Raw));
     }
@@ -2759,7 +2759,7 @@ mod msgs_stderr_tests {
 
     #[test]
     fn stderr_mode_accepts_upstream_prefixes() {
-        // upstream: options.c:1928 OPT_STDERR accepts any non-empty prefix of
+        // upstream: options.c:1912 OPT_STDERR accepts any non-empty prefix of
         // errors/all/client (strncmp), so e/err/al/cli all parse.
         for value in [
             "e", "err", "error", "errors", "a", "al", "all", "c", "cli", "client",
@@ -2952,7 +2952,7 @@ mod alias_tests {
 
     #[test]
     fn old_dirs_is_independent_of_mkpath() {
-        // upstream: options.c:2215-2217 - --old-dirs forces recursion and is
+        // upstream: options.c:2197-2199 - --old-dirs forces recursion and is
         // unrelated to --mkpath, so an explicit --mkpath is preserved.
         let parsed = parse_test_args(["--mkpath", "--old-dirs", "src/", "dst/"]).expect("parse");
         assert!(parsed.mkpath);
@@ -3145,7 +3145,7 @@ mod name_level_tests {
 
     #[test]
     fn itemize_with_double_verbose_emits_unchanged() {
-        // upstream: generator.c:589 - INFO_GTE(NAME, 2) (set by -vv) forces the
+        // upstream: generator.c:582 - INFO_GTE(NAME, 2) (set by -vv) forces the
         // itemize line for unchanged entries, so `-ivv` must surface unchanged
         // dirs, files, and symlinks rather than capping at the updated-only level.
         let parsed = parse_test_args(["-i", "-vv", "src/", "dst/"]).expect("parse");
@@ -3263,7 +3263,7 @@ mod parsed_args_traits {
 /// Environment-derived option defaults (`RSYNC_ICONV`, `RSYNC_MAX_ALLOC`).
 ///
 /// These encode WHY the env defaults matter: upstream rsync seeds `--iconv`
-/// (options.c:1393-1394) and `--max-alloc` (options.c:1970-1973) from the
+/// (options.c:1377-1378) and `--max-alloc` (options.c:1954-1957) from the
 /// environment so a caller can configure them without repeating the flag.
 #[cfg(test)]
 #[allow(unsafe_code)]
@@ -3308,7 +3308,7 @@ mod env_option_defaults {
         }
     }
 
-    // upstream: options.c:1393-1394 - RSYNC_ICONV supplies the default --iconv
+    // upstream: options.c:1377-1378 - RSYNC_ICONV supplies the default --iconv
     // value when the option is absent; the transfer must honour it exactly as
     // if `--iconv=<value>` had been typed.
     #[test]
@@ -3321,7 +3321,7 @@ mod env_option_defaults {
         assert_eq!(parsed.iconv, Some(OsString::from("utf-8,latin1")));
     }
 
-    // upstream: options.c:1393-1394 - an explicit --iconv wins over the env.
+    // upstream: options.c:1377-1378 - an explicit --iconv wins over the env.
     #[test]
     fn explicit_iconv_overrides_rsync_iconv_env() {
         let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");
@@ -3332,7 +3332,7 @@ mod env_option_defaults {
         assert_eq!(parsed.iconv, Some(OsString::from(".")));
     }
 
-    // upstream: options.c:1393 - `protect_args <= 0` guard: an explicitly
+    // upstream: options.c:1377 - `protect_args <= 0` guard: an explicitly
     // enabled protect_args suppresses the RSYNC_ICONV default.
     #[test]
     fn protect_args_suppresses_rsync_iconv_env() {
@@ -3344,7 +3344,7 @@ mod env_option_defaults {
         assert_eq!(parsed.iconv, None);
     }
 
-    // upstream: options.c:1970-1973 - RSYNC_MAX_ALLOC supplies the default cap
+    // upstream: options.c:1954-1957 - RSYNC_MAX_ALLOC supplies the default cap
     // when --max-alloc is absent.
     #[test]
     fn max_alloc_defaults_to_rsync_max_alloc_env() {
@@ -3355,7 +3355,7 @@ mod env_option_defaults {
         assert_eq!(parsed.max_alloc, Some(OsString::from("2G")));
     }
 
-    // upstream: options.c:1970 - an explicit --max-alloc wins over the env.
+    // upstream: options.c:1954 - an explicit --max-alloc wins over the env.
     #[test]
     fn explicit_max_alloc_overrides_rsync_max_alloc_env() {
         let _lock = ENV_MUTEX.lock().expect("env mutex poisoned");

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/output.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/output.rs
@@ -33,9 +33,9 @@ pub(super) fn add_output_args(command: ClapCommand) -> ClapCommand {
                 .overrides_with("verbose"),
         )
         .arg(
-            // upstream: options.c:626 `{"human-readable", 'h', POPT_ARG_NONE, ...}`
+            // upstream: options.c:616 `{"human-readable", 'h', POPT_ARG_NONE, ...}`
             // takes no argument, so `--human-readable=N` is rejected. Each -h
-            // increments the level (options.c:1589): -h => base-1000 units,
+            // increments the level (options.c:1573): -h => base-1000 units,
             // -hh => base-1024 units.
             Arg::new("human-readable")
                 .short('h')

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/transfer.rs
@@ -183,7 +183,7 @@ pub(super) fn add_transfer_args(command: ClapCommand) -> ClapCommand {
         .arg(
             Arg::new("modify-window")
                 .long("modify-window")
-                // upstream: options.c:670 - `-@` is the short alias, parsed as a
+                // upstream: options.c:660 - `-@` is the short alias, parsed as a
                 // signed int. `allow_hyphen_values` lets a negative window
                 // (e.g. `--modify-window=-1` or `-@-1`) be taken as the value
                 // rather than mistaken for another option.
@@ -276,8 +276,8 @@ pub(super) fn add_transfer_args(command: ClapCommand) -> ClapCommand {
                 .overrides_with("mkpath"),
         )
         .arg(
-            // upstream: options.c:641-642 - `--old-dirs`/`--old-d` set
-            // xfer_dirs=4, which options.c:2215-2217 resolves to recurse=1 plus
+            // upstream: options.c:631-632 - `--old-dirs`/`--old-d` set
+            // xfer_dirs=4, which options.c:2197-2199 resolves to recurse=1 plus
             // an appended `- /*/*` filter rule. It is unrelated to --mkpath.
             Arg::new("old-dirs")
                 .long("old-dirs")

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -114,7 +114,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .overrides_with("remove-source-files"),
             )
             .arg(
-                // upstream: options.c:1738-1742 - OPT_APPEND increments
+                // upstream: options.c:1722-1726 - OPT_APPEND increments
                 // append_mode on the server side; two `--append` flags mean
                 // append_mode == 2 (verify). Count occurrences so the server
                 // parser can recover that from the wire, where a repeated
@@ -436,7 +436,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
             .arg(
                 Arg::new("block-size")
                     .long("block-size")
-                    // upstream: options.c:762 {"block-size", 'B', ...} - short alias.
+                    // upstream: options.c:752 {"block-size", 'B', ...} - short alias.
                     .short('B')
                     .value_name("SIZE")
                     .help("Force the delta-transfer block size to SIZE bytes.")

--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -23,7 +23,7 @@ pub(crate) enum CompressLevelArg {
 
 /// Outcome of parsing `--compress-choice=NAME`.
 ///
-/// upstream: options.c:2031-2034 `if (compress_choice && strcasecmp(...,
+/// upstream: options.c:2013-2016 `if (compress_choice && strcasecmp(...,
 /// "auto") != 0) parse_compress_choice(0); else compress_choice = NULL;` -
 /// the literal `auto` is nulled out so normal codec negotiation runs, distinct
 /// from `none` (which disables compression) and an explicit codec.
@@ -126,7 +126,7 @@ pub(crate) fn parse_compress_choice(argument: &OsStr) -> Result<CompressChoice, 
         );
     }
 
-    // upstream: options.c:2031 - only the literal `auto` (case-insensitive) is
+    // upstream: options.c:2013 - only the literal `auto` (case-insensitive) is
     // nulled; anything else, including `auto,auto`, is passed to
     // parse_compress_choice and rejected if unknown.
     if trimmed.eq_ignore_ascii_case("auto") {
@@ -201,15 +201,15 @@ const COMPRESS_THREADS_MAX: i32 = 64;
 /// Parses `--compress-threads=N` into an optional worker count.
 ///
 /// Returns `Ok(None)` for `0` (delegates the choice to zstd, matching
-/// `do_compression_threads = 0` in upstream `options.c:90`). Returns
+/// `do_compression_threads = 0` in upstream `options.c:89`). Returns
 /// `Ok(Some(n))` for positive integers up to [`COMPRESS_THREADS_MAX`].
 /// Rejects negative values, non-numeric input, and out-of-range positive
 /// integers with a user-facing error message.
 ///
 /// # Upstream Reference
 ///
-/// - `options.c:772-773` - `{"compress-threads", 0, POPT_ARG_INT, &do_compression_threads, 0, 0, 0 }`.
-/// - `options.c:2034-2035` - upstream clamps negative values to 0.
+/// - `options.c:760-761` - `{"compress-threads", 0, POPT_ARG_INT, &do_compression_threads, 0, 0, 0 }`.
+/// - `options.c:2016-2017` - upstream clamps negative values to 0.
 pub(crate) fn parse_compress_threads(argument: &OsStr) -> Result<Option<NonZeroU8>, Message> {
     let original = argument.to_string_lossy().into_owned();
     let trimmed = original.trim();
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn compress_level_zero_is_codec_dependent() {
-        // upstream: token.c:56-105 init_compression_level() - `--compress-level=0`
+        // upstream: token.c:55-104 init_compression_level() - `--compress-level=0`
         // is codec-dependent, NOT unconditionally disabled: for zlib the
         // off_level is Z_NO_COMPRESSION (0), so level 0 turns compression off
         // (CPRES_NONE); for zstd off_level is CLVL_NOT_SPECIFIED and a literal 0
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn parse_compress_choice_auto_is_nulled() {
-        // upstream: options.c:2031-2034 - the literal `auto` (case-insensitive)
+        // upstream: options.c:2013-2016 - the literal `auto` (case-insensitive)
         // is nulled so normal codec negotiation runs; it is neither a disable
         // nor an explicit codec.
         assert!(matches!(
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn parse_compress_choice_auto_auto_is_rejected() {
-        // upstream: options.c:2031 only special-cases the exact token `auto`;
+        // upstream: options.c:2013 only special-cases the exact token `auto`;
         // `auto,auto` falls through to parse_compress_choice and is rejected
         // as an unknown compress name (RERR_UNSUPPORTED, exit 4).
         let error = parse_compress_choice(OsStr::new("auto,auto")).expect_err("auto,auto rejected");

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -143,18 +143,18 @@ pub(crate) struct ConfigInputs {
     pub(crate) link_dests: Vec<PathBuf>,
     pub(crate) remove_source_files: bool,
     /// `--remove-sent-files` - deprecated alias; forwarded verbatim on the wire.
-    /// upstream: options.c:3000-3003.
+    /// upstream: options.c:2982-2985.
     pub(crate) remove_sent_files: bool,
     /// Resolved out-format string carries `%i`; forwards `--log-format=%i`.
     /// Mirrors upstream `stdout_format_has_i`, derived from the resolved format
-    /// string rather than the `-i` flag. upstream: options.c:2363-2376,2790-2793.
+    /// string rather than the `-i` flag. upstream: options.c:2345-2358,2772-2775.
     pub(crate) out_format_forwards_i: bool,
     /// Explicit `--out-format` / `--log-format` contains `%o` but not `%i`;
-    /// forwards `--log-format=%o`. upstream: options.c:2794-2795.
+    /// forwards `--log-format=%o`. upstream: options.c:2776-2777.
     pub(crate) out_format_has_operation: bool,
     /// Explicit `--out-format` / `--log-format` was given with neither `%i` nor
     /// `%o`; forwards the placeholder `--log-format=X` for a non-verbose client.
-    /// upstream: options.c:2796-2797.
+    /// upstream: options.c:2778-2779.
     pub(crate) out_format_placeholder: bool,
     pub(crate) inplace: bool,
     pub(crate) append: bool,
@@ -237,7 +237,7 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         .quiet(inputs.quiet)
         .msgs2stderr(inputs.msgs2stderr)
         .recursive(inputs.recursive)
-        // upstream: options.c:2217-2221 - `else if (recurse) xfer_dirs = 1;
+        // upstream: options.c:2199-2203 - `else if (recurse) xfer_dirs = 1;
         // else if (xfer_dirs < 0) xfer_dirs = list_only ? 1 : 0;`. When neither
         // -r nor an explicit -d/--no-dirs is given, --list-only still transfers
         // (lists) a bare directory operand's own entry.
@@ -246,9 +246,9 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         } else {
             inputs.dirs.unwrap_or(inputs.list_only)
         })
-        // upstream: options.c:2233-2235 - delete mode is enabled only by an
+        // upstream: options.c:2215-2217 - delete mode is enabled only by an
         // explicit `--delete*` or `--delete-excluded`. `--max-delete` merely caps
-        // the count (options.c:2200-2203) and must never enable deletion.
+        // the count (options.c:2182-2185) and must never enable deletion.
         .delete(inputs.delete_mode.is_enabled() || inputs.delete_excluded)
         .delete_excluded(inputs.delete_excluded)
         .delete_missing_args(inputs.delete_missing_args)
@@ -435,7 +435,7 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
     };
 
     builder = builder.itemize_changes(inputs.itemize_changes);
-    // upstream: generator.c:582-583 - emit itemize rows for unchanged entries
+    // upstream: generator.c:575-576 - emit itemize rows for unchanged entries
     // when `-ii` / `--info=name2` / `-vv` raised the level. The parser folds
     // all three into `NameOutputLevel::UpdatedAndUnchanged`.
     builder = builder.itemize_unchanged(matches!(

--- a/crates/cli/src/frontend/execution/drive/filters.rs
+++ b/crates/cli/src/frontend/execution/drive/filters.rs
@@ -117,7 +117,7 @@ fn push_filter_directive(
 /// Adds a CLI-supplied `--exclude`/`--include` pattern to `destination`,
 /// honoring upstream's `XFLG_OLD_PREFIXES` compatibility mode.
 ///
-/// upstream: options.c:1528-1535 routes `--exclude`/`--include` through
+/// upstream: options.c:1512-1519 routes `--exclude`/`--include` through
 /// `parse_filter_str(..., XFLG_OLD_PREFIXES)`, so a value of `- pat` (or
 /// `+ pat`) flips the rule kind and `!` clears the list. Plain patterns
 /// retain `default_kind`.

--- a/crates/cli/src/frontend/execution/drive/metadata/compute.rs
+++ b/crates/cli/src/frontend/execution/drive/metadata/compute.rs
@@ -158,7 +158,7 @@ fn parse_chmod_specs(
                 }
             }
             Err(_error) => {
-                // upstream: options.c:1778-1782 - a rejected spec yields
+                // upstream: options.c:1762-1766 - a rejected spec yields
                 // `Invalid argument passed to --chmod (%s)` (raw arg) then
                 // exit_cleanup(RERR_SYNTAX).
                 let formatted = format!("Invalid argument passed to --chmod ({spec_text})");

--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -112,7 +112,7 @@ struct InfoFlagsResult {
 
 /// Applies upstream's `--progress` ⇒ `--info=name` implication.
 ///
-/// upstream: options.c:2369-2373 - when the `--progress`/`-P` flag set
+/// upstream: options.c:2351-2355 - when the `--progress`/`-P` flag set
 /// `do_progress` (and the run is not a server), an unset NAME level is bumped to
 /// 1 via `parse_output_words("name", DEFAULT_PRIORITY)`. That `DEFAULT_PRIORITY`
 /// assignment cannot override a USER_PRIORITY one, so an explicit `--info=name0`
@@ -202,7 +202,7 @@ where
             // upstream: options.c set_output_verbosity / parse_output_words
             settings.apply_to_thread_local();
 
-            // upstream: options.c:2965 make_output_option() - forward the
+            // upstream: options.c:2947 make_output_option() - forward the
             // explicitly-set info categories to the peer. Normalize to
             // `name{level}` tokens; the remote builders apply the role `where`
             // filter.
@@ -335,7 +335,7 @@ where
         None => None,
     };
 
-    // upstream: options.c:1708-1711 - `--block-size=0` yields no override and
+    // upstream: options.c:1692-1695 - `--block-size=0` yields no override and
     // falls back to the default, so a `None` here covers both "unset" and
     // "explicit 0".
     let block_size_override = match inputs.block_size.as_ref() {
@@ -427,7 +427,7 @@ where
                 compress_level_setting = Some(CompressLevelArg::Disable);
                 compress_disabled_by_choice = true;
             }
-            // upstream: options.c:2031-2034 - `--compress-choice=auto` is nulled
+            // upstream: options.c:2013-2016 - `--compress-choice=auto` is nulled
             // out, so it behaves as if `--compress-choice` had not been given:
             // no forced codec, no disable, normal negotiation.
             Ok(CompressChoice::Auto) => {}
@@ -481,9 +481,9 @@ where
         compress_choice_name = None;
     }
 
-    // upstream: options.c:160 - the `skip_compress` global is NULL unless the
+    // upstream: options.c:150 - the `skip_compress` global is NULL unless the
     // `--skip-compress` option is given, and only that explicit value is
-    // forwarded to the remote sender (options.c:2876-2878). The
+    // forwarded to the remote sender (options.c:2858-2860). The
     // `RSYNC_SKIP_COMPRESS` environment fallback is an oc extension that still
     // applies locally, but - like upstream - it is not forwarded on the wire.
     let mut skip_compress_spec = None;

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -121,7 +121,7 @@ where
     // Threaded into `OutFormatContext` so the itemize renderer picks the correct
     // direction arrow (upstream: log.c:701-704 - `<` for sender, `>` otherwise).
     let is_sender = config.is_local_sender();
-    // upstream: flist.c:2286 emits "sending incremental file list" only when
+    // upstream: flist.c:2251 emits "sending incremental file list" only when
     // `inc_recurse && INFO_GTE(FLIST, 1) && !am_server`. Mirror each gate:
     // - compat.c:172 disables inc_recurse when `!recurse`, so a single-file
     //   `-v` transfer gets no banner (`config.recursive()`);
@@ -134,7 +134,7 @@ where
     let emit_flist_banner = config.recursive() && info_gte(InfoFlag::Flist, 1) && !config.is_pull();
     // Capture the preserve-links state before `config` is consumed so the
     // `--list-only` renderer knows whether to append the ` -> <target>` arrow
-    // to symlink rows (upstream: generator.c:1195 gates it on preserve_links).
+    // to symlink rows (upstream: generator.c:1183 gates it on preserve_links).
     let preserve_links = config.links();
     // Capture the negotiated checksum before `config` is consumed so the `%C`
     // renderer reports the negotiated algorithm's digest (upstream: log.c:687-690
@@ -167,7 +167,7 @@ where
                 });
             }
 
-            // upstream: generator.c:589-590 - `INFO_GTE(NAME, 2)` (i.e. `-vv`
+            // upstream: generator.c:582-583 - `INFO_GTE(NAME, 2)` (i.e. `-vv`
             // or `--info=name2`) keeps emitting itemize lines for unchanged
             // entries. Thread the resolved name-level into the renderer so it
             // bypasses the empty-change-set suppression and surfaces all-dot
@@ -286,7 +286,7 @@ struct EmitLogOutputParams<'a> {
     /// octal escaping in log-file output.
     eight_bit_output: bool,
     /// `--links` / `-l`: whether symlink rows in `--list-only` log output get
-    /// the ` -> <target>` arrow (upstream: generator.c:1195).
+    /// the ` -> <target>` arrow (upstream: generator.c:1183).
     preserve_links: bool,
     /// Negotiated `%C` checksum algorithm (upstream: log.c:687-690).
     full_checksum_algorithm: StrongChecksumAlgorithm,
@@ -315,7 +315,7 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         full_checksum_algorithm,
         always_checksum,
     } = params;
-    // upstream: generator.c:589-590 - mirror the `INFO_GTE(NAME, 2)` arm of
+    // upstream: generator.c:582-583 - mirror the `INFO_GTE(NAME, 2)` arm of
     // the itemize emit gate in the log-file renderer so `-vv` / `--info=name2`
     // surfaces unchanged entries in the log alongside stdout. The `-ii`
     // (`stdout_format_has_i > 1`) arm forces them independently of `-vv`.
@@ -327,7 +327,7 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         .with_preserve_links(preserve_links)
         .with_full_checksum(full_checksum_algorithm, always_checksum);
     // The FCLIENT "sending incremental file list" banner is stdout only;
-    // upstream's parallel "building file list" line (flist.c:2283) is an FLOG
+    // upstream's parallel "building file list" line (flist.c:2248) is an FLOG
     // log-file message that a plain client without --log-file discards.
     emit_transfer_summary(
         summary,

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -149,7 +149,7 @@ where
 ///
 /// `show_version` is a count: 1 = human-readable output (upstream `-V`),
 /// 2+ = machine-readable JSON (upstream `-VV`).
-// upstream: options.c:1956-1958 - version_opt_cnt selects JSON vs human-readable
+// upstream: options.c:1940-1942 - version_opt_cnt selects JSON vs human-readable
 pub(crate) fn maybe_print_help_or_version<Out>(
     show_help: bool,
     show_version: u8,

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -378,7 +378,7 @@ where
         Err(unsupported) => return fail_with_message(unsupported.to_message(), stderr),
     };
 
-    // upstream: options.c:2483-2489 - with `--files-from` the transferred file
+    // upstream: options.c:2465-2471 - with `--files-from` the transferred file
     // set comes from the list, so a client may name exactly one source root and
     // one destination. More than two operands, or a lone operand (a missing
     // destination), is a syntax error (`usage(FERROR); exit RERR_SYNTAX`, exit
@@ -403,7 +403,7 @@ where
             Err(code) => return code,
         };
 
-    // upstream: options.c:2073 `if (do_stats) parse_output_words("stats2", ...)`
+    // upstream: options.c:2055 `if (do_stats) parse_output_words("stats2", ...)`
     // (or "stats3" with `-vv`). The legacy `--stats` flag maps to level 2; with
     // higher verbosity it bumps to level 3. A subsequent `--info=statsN` token
     // overrides this default inside `parse_info_settings`.
@@ -505,7 +505,7 @@ where
         .as_ref()
         .and_then(|value: &ParsedChown| value.group());
 
-    // upstream: options.c:2501 - only open files_from locally when the spec
+    // upstream: options.c:2483 - only open files_from locally when the spec
     // is NOT a hostspec. Remote files-from (`:path` or `host:path`) are read
     // by the server, so the client never opens them.
     let files_from_resolved = resolve_files_from_source(&files_from);
@@ -554,19 +554,19 @@ where
 
     let implied_dirs_option = implied_dirs;
 
-    // upstream: options.c:2187-2195 - --files-from disables default recursion,
+    // upstream: options.c:2169-2177 - --files-from disables default recursion,
     // enables xfer_dirs, and implies --relative.
     //
     // Otherwise honour the parser-computed `recursive` flag, which mirrors
-    // upstream's `recurse` default of 0 (options.c:113) and the `-r` / `-a` /
+    // upstream's `recurse` default of 0 (options.c:112) and the `-r` / `-a` /
     // `--no-recursive` precedence rules (parser/mod.rs:152-158).
     let recursive_effective = if files_from_active {
-        false // upstream: options.c:2192 - if (recurse == 1) recurse = 0
+        false // upstream: options.c:2174 - if (recurse == 1) recurse = 0
     } else {
         recursive
     };
 
-    // upstream: options.c:2194-2195 - xfer_dirs = 1 when files_from is active
+    // upstream: options.c:2176-2177 - xfer_dirs = 1 when files_from is active
     let dirs = if files_from_active { Some(true) } else { dirs };
 
     // upstream: compat.c:710-748 - local transfers negotiate compat_flags
@@ -616,7 +616,7 @@ where
     //   if (!checksum_seed) checksum_seed = time(NULL) ^ (getpid() << 6);
     //   write_int(f_out, checksum_seed);
     // The finalised seed is what io.c:2524 start_write_batch() records in the
-    // batch header, so an explicit --checksum-seed=N (options.c:859) must flow
+    // batch header, so an explicit --checksum-seed=N (options.c:847) must flow
     // through unchanged and only an unset seed is derived from time/pid.
     let batch_checksum_seed = explicit_batch_seed(checksum_seed).unwrap_or_else(derive_batch_seed);
 
@@ -674,7 +674,7 @@ where
     }
 
     // Build transfer operands early so we can check if this is a daemon transfer.
-    // upstream: main.c:789-799 - source dir is chdir target, not a transfer source
+    // upstream: main.c:780-790 - source dir is chdir target, not a transfer source
     // `has_remote_operand` was computed above (protocol resolution needs it).
     let mut transfer_operands = Vec::with_capacity(file_list_operands.len() + remainder.len());
     if files_from_active && !file_list_operands.is_empty() {
@@ -684,7 +684,7 @@ where
             // files_from_path and uses the source dir as base_dir for resolving
             // relative filenames. Individual file entries must NOT be operands -
             // they corrupt the generator's base_dir derivation (paths.first()).
-            // upstream: main.c:1310-1357 - client_run() uses argv[0] as chdir
+            // upstream: main.c:1292-1339 - client_run() uses argv[0] as chdir
             // target, filesfrom_fd is a separate channel.
             transfer_operands.extend(remainder);
         } else {
@@ -743,26 +743,26 @@ where
         }
     });
 
-    // upstream: options.c:807 - `--list-only` sets `list_only = 2`, the explicit
-    // form that server_options() forwards as `--list-only` (options.c:2765
+    // upstream: options.c:795 - `--list-only` sets `list_only = 2`, the explicit
+    // form that server_options() forwards as `--list-only` (options.c:2747
     // `list_only > 1`). The implicit `list_only |= 1` below never reaches 2, so
     // it is never forwarded. Capture the explicit bit before the OR.
     let list_only_arg = list_only;
-    // upstream: options.c:2212-2213 - `if (argc < 2 && !read_batch && !am_server)
+    // upstream: options.c:2194-2195 - `if (argc < 2 && !read_batch && !am_server)
     // list_only |= 1;`. A single remote source with no destination (e.g.
     // `host::module` or `rsync://host/module`) implies list-only mode: list the
     // module's contents instead of erroring "need source and destination".
     let list_only =
         list_only || (transfer_operands.len() == 1 && read_batch.is_none() && is_daemon_transfer);
 
-    // upstream: options.c:2205-2206 - relative_paths defaults to 1 when files_from
+    // upstream: options.c:2187-2188 - relative_paths defaults to 1 when files_from
     let effective_relative = if files_from_active && relative.is_none() {
         Some(true)
     } else {
         relative
     };
 
-    // upstream: options.c:2225-2226 - `if (!relative_paths) implied_dirs = 0;`.
+    // upstream: options.c:2207-2208 - `if (!relative_paths) implied_dirs = 0;`.
     // Implied directories only exist for relative-rooted transfer paths, so
     // when relative paths are disabled implied_dirs is forced off regardless
     // of any explicit `--implied-dirs`. Otherwise it defaults on.
@@ -830,7 +830,7 @@ where
 
     let prune_empty_dirs_flag = prune_empty_dirs.unwrap_or(false);
     let fsync_flag = fsync_option.unwrap_or(false);
-    // upstream: options.c:2431-2437 - `--write-devices` forces the global
+    // upstream: options.c:2413-2419 - `--write-devices` forces the global
     // inplace flag on, so device targets are written in place rather than via a
     // temp file.
     let inplace_enabled = inplace.unwrap_or(false) || write_devices.unwrap_or(false);
@@ -840,7 +840,7 @@ where
     let checksum_for_config = checksum.unwrap_or(false);
     let fuzzy_level_value = fuzzy.unwrap_or(0);
 
-    // upstream: options.c:2363-2376,2393-2394,2786-2798 - the resolved
+    // upstream: options.c:2345-2358,2375-2376,2768-2780 - the resolved
     // out-format string tells the server which placeholders it uses. Upstream
     // derives `stdout_format_has_i` from that resolved string, not from the `-i`
     // flag: an explicit `--out-format` without `%i` clears it even under `-i`
@@ -909,8 +909,8 @@ where
         executability: preserve_executability,
         permissions: preserve_permissions,
         fake_super: fake_super.unwrap_or(false),
-        // upstream: options.c:91 - `am_root > 1` is set only by an explicit
-        // --super (not by running as root). Forwarded on a push (options.c:2870).
+        // upstream: options.c:90 - `am_root > 1` is set only by an explicit
+        // --super (not by running as root). Forwarded on a push (options.c:2852).
         super_user: super_mode == Some(true),
         times: preserve_times,
         // The u8 level (0/1/2) drives the doubled `-UU` compact letter; the
@@ -1096,7 +1096,7 @@ where
 
 /// Resolves the effective `--old-args` setting from the CLI flag and env var.
 ///
-/// upstream: options.c:1968-1980 - when `old_style_args` is not explicitly set
+/// upstream: options.c:1952-1964 - when `old_style_args` is not explicitly set
 /// (`None`), check `RSYNC_OLD_ARGS` env var. The env var is only honoured when
 /// protect_args is not active (upstream: `protect_args <= 0`). When both
 /// `--old-args` and `--protect-args` are explicitly set, upstream rejects the
@@ -1106,7 +1106,7 @@ fn resolve_old_args(explicit: Option<bool>, protect_args: Option<bool>) -> Optio
     if let Some(value) = explicit {
         return Some(value);
     }
-    // upstream: options.c:1969 - only check env when !am_server && protect_args <= 0
+    // upstream: options.c:1953 - only check env when !am_server && protect_args <= 0
     if protect_args.unwrap_or(false) {
         return None;
     }
@@ -1124,7 +1124,7 @@ fn resolve_old_args(explicit: Option<bool>, protect_args: Option<bool>) -> Optio
 /// when the seed must be derived from time/pid.
 ///
 /// upstream: compat.c:811-812 `if (!checksum_seed) checksum_seed = ...` - the
-/// parsed `--checksum-seed=N` (options.c:859, an `int` defaulting to 0) is only
+/// parsed `--checksum-seed=N` (options.c:847, an `int` defaulting to 0) is only
 /// treated as user-supplied when it is non-zero. An explicit `--checksum-seed=0`
 /// is indistinguishable from an unset seed and therefore derives a fresh one,
 /// exactly like omitting the flag. The bit pattern of `N` is preserved across

--- a/crates/cli/src/frontend/execution/file_list/loader.rs
+++ b/crates/cli/src/frontend/execution/file_list/loader.rs
@@ -95,8 +95,8 @@ pub(crate) fn read_file_list_from_reader<R: BufRead>(
                 buffer.pop();
             }
 
-            // upstream: flist.c:2284 sets RL_DUMP_COMMENTS independent of
-            // eol_nulls, and io.c:1279 read_line() strips leading '#'/';'
+            // upstream: flist.c:2249 sets RL_DUMP_COMMENTS independent of
+            // eol_nulls, and io.c:1276 read_line() strips leading '#'/';'
             // comment lines even with NUL delimiters. Strip them here too.
             if buffer
                 .first()

--- a/crates/cli/src/frontend/execution/file_list/parser.rs
+++ b/crates/cli/src/frontend/execution/file_list/parser.rs
@@ -8,12 +8,12 @@ use std::path::{Path, PathBuf};
 
 /// Resolves a `--files-from` CLI value into a [`FilesFromSource`].
 ///
-/// The resolution mirrors upstream rsync's `options.c:2465-2508`:
+/// The resolution mirrors upstream rsync's `options.c:2447-2490`:
 /// - `"-"` means stdin
 /// - `:path` (bare colon prefix) means a remote file opened by the server
 ///   using the host taken from the transfer operand
 /// - `host:path` (hostspec form) means a remote file opened by the named
-///   host (must match the transfer host, validated in `main.c:1438`)
+///   host (must match the transfer host, validated in `main.c:1420`)
 /// - Otherwise, a local file read by the client
 ///
 /// Only the last `--files-from` argument takes effect, matching upstream
@@ -21,10 +21,10 @@ use std::path::{Path, PathBuf};
 ///
 /// # Upstream Reference
 ///
-/// - `options.c:2476` - `check_for_hostspec()` detects `host:path` prefix
-/// - `options.c:2482-2483` - `files_from = p; filesfrom_host = h;`
-/// - `options.c:2484-2487` - `:-` (remote stdin) is rejected
-/// - `options.c:3130-3156` - `check_for_hostspec()` parses `host:path`
+/// - `options.c:2458` - `check_for_hostspec()` detects `host:path` prefix
+/// - `options.c:2464-2465` - `files_from = p; filesfrom_host = h;`
+/// - `options.c:2466-2469` - `:-` (remote stdin) is rejected
+/// - `options.c:3112-3138` - `check_for_hostspec()` parses `host:path`
 pub(crate) fn resolve_files_from_source(files_from: &[OsString]) -> core::client::FilesFromSource {
     use core::client::FilesFromSource;
 
@@ -49,7 +49,7 @@ pub(crate) fn resolve_files_from_source(files_from: &[OsString]) -> core::client
     // module specs (`host::module`). The latter is for daemon transfers,
     // which we do not currently support for files-from.
     if let Some((host, path)) = split_hostspec(&text) {
-        // upstream: options.c:3130-3156 / options.c:2494-2501 -
+        // upstream: options.c:3112-3138 / options.c:2476-2483 -
         // check_for_hostspec strips the host prefix and forwards the path to
         // the remote server. When the host resolves to localhost AND the
         // stripped path is openable on this client, emit the hybrid variant.
@@ -79,7 +79,7 @@ pub(crate) fn resolve_files_from_source(files_from: &[OsString]) -> core::client
 
 /// Returns `true` when the parsed hostspec names the local machine.
 ///
-/// Matches upstream `main.c:1456 strcmp(filesfrom_host, shell_machine)`
+/// Matches upstream `main.c:1438 strcmp(filesfrom_host, shell_machine)`
 /// semantics: a hostspec of `localhost` (case-insensitive) refers to this
 /// client, allowing a hybrid local-open + wire-forward dispatch.
 fn host_is_localhost(host: &str) -> bool {
@@ -90,7 +90,7 @@ fn host_is_localhost(host: &str) -> bool {
 /// hostspec. Returns `None` for local paths, Windows drive letters, daemon
 /// module specs (`::`), and URL forms.
 ///
-/// Mirrors `options.c:3130-3156 check_for_hostspec()`:
+/// Mirrors `options.c:3112-3138 check_for_hostspec()`:
 /// - Reject URL forms (`rsync://`); those are daemon URLs, handled elsewhere
 /// - Reject `host::module` (daemon module spec)
 /// - Reject paths beginning with `/` (no host part)
@@ -121,7 +121,7 @@ fn split_hostspec(text: &str) -> Option<(&str, &str)> {
         return None;
     }
 
-    // Reject `host:-` (upstream options.c:2484-2487 rejects remote stdin).
+    // Reject `host:-` (upstream options.c:2466-2469 rejects remote stdin).
     if rest == "-" {
         return None;
     }

--- a/crates/cli/src/frontend/execution/file_list/resolver.rs
+++ b/crates/cli/src/frontend/execution/file_list/resolver.rs
@@ -14,7 +14,7 @@ use super::parser::operand_is_remote;
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:2351` - `strstr(fbuf, "/./")` detects embedded marker
+/// - `flist.c:2316` - `strstr(fbuf, "/./")` detects embedded marker
 fn entry_contains_dot_marker(operand: &OsStr) -> bool {
     #[cfg(unix)]
     {
@@ -53,8 +53,8 @@ fn entry_contains_dot_marker(operand: &OsStr) -> bool {
 ///
 /// # Upstream Reference
 ///
-/// - `options.c:2205-2206` - `--files-from` implies `--relative`
-/// - `main.c:789-799` - source dir used as chdir base for file list entries
+/// - `options.c:2187-2188` - `--files-from` implies `--relative`
+/// - `main.c:780-790` - source dir used as chdir base for file list entries
 pub(crate) fn resolve_file_list_entries(
     entries: &mut [OsString],
     explicit_operands: &[OsString],
@@ -99,7 +99,7 @@ pub(crate) fn resolve_file_list_entries(
         }
 
         if files_from_active {
-            // upstream: flist.c:2351-2353 - when relative_paths is set and a
+            // upstream: flist.c:2316-2318 - when relative_paths is set and a
             // file list entry contains "/./", upstream splits the entry at that
             // marker: the portion before becomes a chdir prefix (relative to
             // argv[0]), and the portion after becomes the transferred filename.

--- a/crates/cli/src/frontend/execution/file_list/tests.rs
+++ b/crates/cli/src/frontend/execution/file_list/tests.rs
@@ -145,8 +145,8 @@ fn read_file_list_zero_terminated_no_trailing_null() {
 
 #[test]
 fn read_file_list_zero_terminated_strips_hash_and_semicolon_comments() {
-    // upstream: flist.c:2284 sets RL_DUMP_COMMENTS independent of eol_nulls,
-    // and io.c:1279 read_line() strips leading '#'/';' comment lines even with
+    // upstream: flist.c:2249 sets RL_DUMP_COMMENTS independent of eol_nulls,
+    // and io.c:1276 read_line() strips leading '#'/';' comment lines even with
     // NUL delimiters. Comment entries are dropped; normal entries are kept.
     let input = b"#comment\0keep.txt\0;also-comment\0other.txt\0";
     let mut reader = Cursor::new(input);
@@ -466,7 +466,7 @@ fn resolve_files_from_host_colon_prefix() {
     // UTS-V3-D regression: upstream's `testsuite/files-from.test` 4th
     // invocation passes `--files-from=localhost:scratch/filelist`. The
     // parser must recognise the hostspec form (upstream
-    // `options.c:3130-3156 check_for_hostspec`) and emit RemoteFile
+    // `options.c:3112-3138 check_for_hostspec`) and emit RemoteFile
     // with the host stripped. Without this fix the loader hit
     // `loader.rs:54` immediately with "No such file or directory".
     let files = vec![OsString::from("localhost:/remote/path.txt")];
@@ -509,7 +509,7 @@ fn resolve_files_from_daemon_module_spec_is_local() {
 
 #[test]
 fn resolve_files_from_remote_stdin_marker_falls_through() {
-    // upstream `options.c:2484-2487` aborts on `host:-`; we route through
+    // upstream `options.c:2466-2469` aborts on `host:-`; we route through
     // LocalFile so the downstream loader returns a clear error rather
     // than silently routing the literal `-` to the remote side.
     let files = vec![OsString::from("host:-")];

--- a/crates/cli/src/frontend/execution/flags/debug.rs
+++ b/crates/cli/src/frontend/execution/flags/debug.rs
@@ -41,7 +41,7 @@ pub(crate) struct DebugFlagSettings {
 }
 
 /// Maximum debug output level. Levels above this are clamped rather than rejected.
-/// upstream: options.c:255 - #define MAX_OUT_LEVEL 4
+/// upstream: options.c:245 - #define MAX_OUT_LEVEL 4
 const MAX_OUT_LEVEL: u8 = 4;
 
 impl DebugFlagSettings {
@@ -82,7 +82,7 @@ impl DebugFlagSettings {
     }
 
     /// Sets all debug flags to the given level.
-    /// upstream: options.c:462-463 - "all" with numeric suffix sets every flag.
+    /// upstream: options.c:452-453 - "all" with numeric suffix sets every flag.
     fn set_all(&mut self, level: u8) {
         self.acl = Some(level);
         self.backup = Some(level);
@@ -148,7 +148,7 @@ impl DebugFlagSettings {
     pub(super) fn apply(&mut self, token: &str, display: &str) -> Result<(), Message> {
         let lower = token.to_ascii_lowercase();
 
-        // upstream: options.c:460-463 - "none" sets all to 0;
+        // upstream: options.c:450-453 - "none" sets all to 0;
         // "all" with optional numeric suffix sets all flags to min(suffix, MAX_OUT_LEVEL).
         if lower == "0" || lower == "none" {
             self.disable_all();
@@ -170,7 +170,7 @@ impl DebugFlagSettings {
 
         let (normalized, level) = self.parse_flag_and_level(&lower);
 
-        // upstream: options.c:454-455 - clamp to MAX_OUT_LEVEL rather than reject
+        // upstream: options.c:444-445 - clamp to MAX_OUT_LEVEL rather than reject
         let level = level.min(MAX_OUT_LEVEL);
 
         match normalized {
@@ -281,12 +281,12 @@ pub(crate) fn parse_debug_flags(values: &[OsString]) -> Result<DebugFlagSettings
 
 // upstream: options.c output_item_help (rsync-3.4.1:474-510). Reproduced
 // byte-for-byte from upstream's runtime output so `--debug=help` matches
-// `rsync --debug=help`. Layout matches `"%-10s %s\n"` from options.c:488.
+// `rsync --debug=help`. Layout matches `"%-10s %s\n"` from options.c:478.
 // ALL/NONE descriptions inline the sentinel's `--debug` help
-// (options.c:499-505). The per-verbosity summary lines are rendered by
+// (options.c:489-495). The per-verbosity summary lines are rendered by
 // upstream's `make_output_option` over `debug_verbosity[]`
-// (options.c:238-245) and emit names in `debug_words[]` order
-// (options.c:299-325). Levels 0-1 are empty in `debug_verbosity[]`, so the
+// (options.c:228-235) and emit names in `debug_words[]` order
+// (options.c:289-315). Levels 0-1 are empty in `debug_verbosity[]`, so the
 // summary block lists levels 2-5 only.
 pub(crate) const DEBUG_HELP_TEXT: &str = "\
 Use OPT or OPT1 for level 1 output, OPT2 for level 2, etc.; OPT0 silences.\n\

--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -10,7 +10,7 @@ use super::super::super::progress::{NameOutputLevel, ProgressSetting};
 /// Per-flag descriptor for an `--info=` token.
 ///
 /// upstream: options.c `output_struct` (rsync-3.4.1:259-266) plus the
-/// `info_verbosity[]` grouping at options.c:249-253. `max_level` is the
+/// `info_verbosity[]` grouping at options.c:239-243. `max_level` is the
 /// per-flag ceiling used when `--info=all<N>` or `--info=N` fans out
 /// across every flag (it caps each flag at its highest meaningful level,
 /// mirroring upstream's runtime `INFO_GTE(...)` checks). `priority`
@@ -18,7 +18,7 @@ use super::super::super::progress::{NameOutputLevel, ProgressSetting};
 /// from `-v` (NONREG=0, level-1 group covers COPY/DEL/FLIST/MISC/NAME/
 /// STATS/SYMSAFE=1, level-2 group covers BACKUP/MOUNT/REMOVE/SKIP=2). It
 /// is currently informational, exposed for the daemon-side limit handling
-/// tracked by audit I16 (`limit_output_verbosity()`, options.c:537-562).
+/// tracked by audit I16 (`limit_output_verbosity()`, options.c:527-552).
 /// `strict_cap` controls whether a per-token level above `max_level` is
 /// rejected (`--info=flist3`) or silently capped (`--info=backup5`),
 /// preserving oc-rsync's historical usability split.
@@ -193,7 +193,7 @@ impl InfoFlagSettings {
     /// `stats` is intentionally omitted: oc conflates `--stats` and
     /// `--info=stats` into a single stats level and forwards it via the
     /// standalone `--stats` flag (upstream `if (do_stats) --stats`,
-    /// options.c:2874), so re-emitting `--info=stats` here would double-send.
+    /// options.c:2856), so re-emitting `--info=stats` here would double-send.
     /// The remote builders apply upstream's role `where` filter to this list.
     pub(crate) fn iter_enabled_flags(&self) -> Vec<(&'static str, u8)> {
         let mut out: Vec<(&'static str, u8)> = Vec::new();
@@ -202,7 +202,7 @@ impl InfoFlagSettings {
                 out.push((name, level));
             }
         };
-        // upstream: options.c:290-304 info_words[] order.
+        // upstream: options.c:280-294 info_words[] order.
         push("backup", self.backup);
         push("copy", self.copy);
         push("del", self.del);
@@ -238,7 +238,7 @@ impl InfoFlagSettings {
     ///
     /// When `am_server` is `true`, an unrecognised token is silently
     /// accepted instead of producing an error, mirroring upstream rsync's
-    /// `parse_output_words()` (`options.c:475`) where the
+    /// `parse_output_words()` (`options.c:465`) where the
     /// `if (len && !words[j].name && !am_server)` guard skips the
     /// `RERR_SYNTAX` exit. This preserves cross-version compatibility when a
     /// newer client forwards info tokens this server build does not know.
@@ -303,7 +303,7 @@ impl InfoFlagSettings {
 
     // Internal-only extension: `no<flag>` and `-<flag>` are accepted as a
     // negation form mapping to level 0 (e.g. `noprogress` == `progress0`).
-    // Upstream rsync 3.4.1's `parse_output_words` (`options.c:437`) does NOT
+    // Upstream rsync 3.4.1's `parse_output_words` (`options.c:427`) does NOT
     // implement this prefix; it relies on the `flag0` suffix instead. The
     // forms remain accepted for backwards compatibility and to tolerate
     // server-mode token forwarding, but they are intentionally not advertised
@@ -347,7 +347,7 @@ pub(crate) fn parse_info_flags(values: &[OsString]) -> Result<InfoFlagSettings, 
 /// Parses `--info` flag values in server mode, silently ignoring unknown tokens.
 ///
 /// Upstream rsync's `parse_output_words()` checks `!am_server` before raising
-/// `Unknown --info item` (`options.c:475`). The server side accepts whatever
+/// `Unknown --info item` (`options.c:465`). The server side accepts whatever
 /// the (possibly newer) client forwards so the connection survives across
 /// version skew. The client-side parser still rejects unknown tokens via
 /// [`parse_info_flags`] so typos surface at the source.
@@ -390,8 +390,8 @@ fn parse_info_flags_inner(
 // matches `rsync --info=help`. The format string is `"%-10s %s\n"`: each
 // name is left-padded to 10 columns, followed by a single space and the
 // help text. ALL/NONE descriptions inline the sentinel's `--info` help
-// (options.c:499-505). The per-verbosity summary block is rendered by
-// upstream's `make_output_option` over `info_verbosity[]` (options.c:249-
+// (options.c:489-495). The per-verbosity summary block is rendered by
+// upstream's `make_output_option` over `info_verbosity[]` (options.c:239-
 // 243) and emits one line per non-empty level in `info_words[]` order.
 pub(crate) const INFO_HELP_TEXT: &str = "\
 Use OPT or OPT1 for level 1 output, OPT2 for level 2, etc.; OPT0 silences.\n\

--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -174,7 +174,7 @@ fn debug_flag_apply_io() {
     assert_eq!(settings.io, Some(1));
 }
 
-/// upstream: options.c:454-455 - levels beyond MAX_OUT_LEVEL (4) are clamped,
+/// upstream: options.c:444-445 - levels beyond MAX_OUT_LEVEL (4) are clamped,
 /// not rejected. `--debug=IO5` becomes IO level 4 in upstream.
 #[test]
 fn debug_flag_apply_io_level_clamped_to_max() {
@@ -663,7 +663,7 @@ fn debug_flag_all_keywords_accepted() {
     }
 }
 
-/// upstream: options.c:454-455 - all debug levels are clamped to MAX_OUT_LEVEL (4),
+/// upstream: options.c:444-445 - all debug levels are clamped to MAX_OUT_LEVEL (4),
 /// never rejected. Verify that levels at and beyond the documented per-flag maxima
 /// are accepted and clamped.
 #[test]
@@ -727,7 +727,7 @@ fn debug_flag_level_clamping() {
     assert_eq!(settings.time, Some(4));
 }
 
-/// upstream: options.c:462-463 - "all" with a numeric suffix sets every flag to
+/// upstream: options.c:452-453 - "all" with a numeric suffix sets every flag to
 /// min(suffix, MAX_OUT_LEVEL). e.g. `all4` sets all to 4, `all9` clamps to 4.
 #[test]
 fn debug_flag_all_with_level() {
@@ -933,7 +933,7 @@ fn debug_help_text_mentions_all_and_none() {
 
 // upstream: options.c output_item_help (rsync-3.4.1:499-509) prints the
 // per-verbosity summary block. debug_verbosity has levels 0 and 1 empty,
-// so the summary lists levels 2-5 only (options.c:238-245).
+// so the summary lists levels 2-5 only (options.c:228-235).
 #[test]
 fn debug_help_text_lists_verbosity_summary() {
     assert!(DEBUG_HELP_TEXT.contains("Options added at each level of verbosity:"));

--- a/crates/cli/src/frontend/execution/module_list.rs
+++ b/crates/cli/src/frontend/execution/module_list.rs
@@ -23,7 +23,7 @@ pub(crate) fn render_module_list<W: Write, E: Write>(
         }
     }
 
-    // upstream: clientserver.c:1268 - `io_printf(fd, "%-15s\t%s\n", name, comment)`
+    // upstream: clientserver.c:1254 - `io_printf(fd, "%-15s\t%s\n", name, comment)`
     // always emits the name, a tab, then the (possibly empty) comment. The name
     // already carries its `%-15s` padding (preserved by the `\t` split in
     // ModuleListEntry::from_line), so a comment-less module renders as

--- a/crates/cli/src/frontend/execution/options/mod.rs
+++ b/crates/cli/src/frontend/execution/options/mod.rs
@@ -101,7 +101,7 @@ mod tests {
 
     #[test]
     fn parse_max_delete_argument_negative_clamps_to_zero() {
-        // upstream: options.c:2200-2203 - a negative `--max-delete` is clamped to
+        // upstream: options.c:2182-2185 - a negative `--max-delete` is clamped to
         // a 0 cap ("no deletions") and parsing continues; it is not an error.
         assert_eq!(parse_max_delete_argument(&os("-10")).unwrap(), 0);
         assert_eq!(parse_max_delete_argument(&os("-1")).unwrap(), 0);

--- a/crates/cli/src/frontend/execution/options/numeric.rs
+++ b/crates/cli/src/frontend/execution/options/numeric.rs
@@ -67,7 +67,7 @@ pub(crate) fn parse_timeout_argument(value: &OsStr) -> Result<TransferTimeout, M
 /// Parses the `--max-delete` argument into a non-negative deletion cap.
 ///
 /// A leading `+` prefix is permitted and ignored. Mirroring upstream
-/// (`options.c:2200-2203`), a negative value is not an error: it is clamped to
+/// (`options.c:2182-2185`), a negative value is not an error: it is clamped to
 /// `0` ("no deletions") and parsing continues. Deletion itself is still gated on
 /// an explicit `--delete*`, so a clamped cap of `0` only takes effect when
 /// deletion is already enabled.
@@ -157,7 +157,7 @@ pub(crate) fn parse_checksum_seed_argument(value: &OsStr) -> Result<u32, Message
 /// A leading `+` prefix is permitted and ignored. A negative value is accepted
 /// and requests upstream's nanosecond-exact mtime comparison
 /// (`modify_window < 0`, util1.c:1482); upstream parses this option as a signed
-/// `int` (options.c:670, `POPT_ARG_INT`).
+/// `int` (options.c:660, `POPT_ARG_INT`).
 pub(crate) fn parse_modify_window_argument(value: &OsStr) -> Result<i64, Message> {
     let text = value.to_string_lossy();
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());

--- a/crates/cli/src/frontend/execution/options/size.rs
+++ b/crates/cli/src/frontend/execution/options/size.rs
@@ -84,12 +84,12 @@ pub(crate) const MAX_ALLOC_CEILING: u64 = u64::MAX / 4;
 /// Lower bound for a non-zero `--max-alloc`, mirroring upstream's
 /// `parse_size_arg(arg, 'B', "max-alloc", 1024*1024, -1, True)` min value.
 ///
-/// upstream: options.c:1976.
+/// upstream: options.c:1960.
 const MAX_ALLOC_MIN: u64 = 1024 * 1024;
 
 /// Sentinel returned for `--max-alloc=0`, meaning "unlimited".
 ///
-/// upstream: options.c:1982 `if (!max_alloc) max_alloc = SIZE_MAX;` - a parsed
+/// upstream: options.c:1966 `if (!max_alloc) max_alloc = SIZE_MAX;` - a parsed
 /// value of zero disables the ceiling entirely. Callers resolve this to the
 /// platform's `usize::MAX` before publishing it.
 pub(crate) const MAX_ALLOC_UNLIMITED: u64 = 0;
@@ -97,15 +97,15 @@ pub(crate) const MAX_ALLOC_UNLIMITED: u64 = 0;
 /// Upper bound for `--block-size` at protocol >= 30.
 ///
 /// upstream: rsync.h:161 `#define MAX_BLOCK_SIZE ((int32)1 << 17)` (131072),
-/// enforced by options.c:1708-1711 `parse_size_arg(arg, 'b', "block-size", 0,
+/// enforced by options.c:1692-1695 `parse_size_arg(arg, 'b', "block-size", 0,
 /// max_blength, False)`.
 const MAX_BLOCK_SIZE: u64 = 1 << 17;
 
 /// Parses the `--max-alloc` argument as a byte ceiling.
 ///
 /// Mirrors upstream rsync's `parse_size_arg(arg, 'B', "max-alloc", 1024*1024,
-/// -1, True)` (options.c:1976) followed by `if (!max_alloc) max_alloc =
-/// SIZE_MAX;` (options.c:1982):
+/// -1, True)` (options.c:1960) followed by `if (!max_alloc) max_alloc =
+/// SIZE_MAX;` (options.c:1966):
 ///
 /// - `0` is accepted and returned verbatim ([`MAX_ALLOC_UNLIMITED`]); callers
 ///   resolve it to an unlimited ceiling.
@@ -129,12 +129,12 @@ pub(crate) fn parse_max_alloc_argument(value: &OsStr) -> Result<u64, Message> {
 
     let limit = parse_size_limit_argument(value, "--max-alloc")?;
 
-    // upstream: options.c:1982 - a zero value means unlimited (SIZE_MAX).
+    // upstream: options.c:1966 - a zero value means unlimited (SIZE_MAX).
     if limit == MAX_ALLOC_UNLIMITED {
         return Ok(MAX_ALLOC_UNLIMITED);
     }
 
-    // upstream: options.c:1976,1132-1139 - parse_size_arg rejects a non-zero
+    // upstream: options.c:1960,1120-1127 - parse_size_arg rejects a non-zero
     // value below the 1 MiB minimum with "is too small (min: 1.00M or 0 for
     // unlimited)". do_big_num renders the constant 1 MiB minimum as "1.00M".
     if limit < MAX_ALLOC_MIN {
@@ -159,7 +159,7 @@ pub(crate) fn parse_max_alloc_argument(value: &OsStr) -> Result<u64, Message> {
 /// Parses the `--block-size` argument into an optional override.
 ///
 /// Mirrors upstream rsync's `parse_size_arg(arg, 'b', "block-size", 0,
-/// MAX_BLOCK_SIZE, False)` (options.c:1708-1711):
+/// MAX_BLOCK_SIZE, False)` (options.c:1692-1695):
 ///
 /// - `0` is accepted and yields `None`, falling back to the negotiated default
 ///   block size (upstream stores `block_size = 0`, later replaced with the
@@ -178,13 +178,13 @@ pub(crate) fn parse_block_size_argument(value: &OsStr) -> Result<Option<NonZeroU
 
     let limit = parse_size_limit_argument(value, "--block-size")?;
 
-    // upstream: options.c:1708-1711 - min_value 0 accepts `--block-size=0`,
+    // upstream: options.c:1692-1695 - min_value 0 accepts `--block-size=0`,
     // which stores block_size = 0 and later falls back to the default.
     if limit == 0 {
         return Ok(None);
     }
 
-    // upstream: options.c:1708-1711,1128-1131 - a value above MAX_BLOCK_SIZE is
+    // upstream: options.c:1692-1695,1116-1119 - a value above MAX_BLOCK_SIZE is
     // rejected with "is too large (max: ...)". do_big_num renders the constant
     // 131072 ceiling as "128.00K".
     if limit > MAX_BLOCK_SIZE {
@@ -542,13 +542,13 @@ mod tests {
 
     #[test]
     fn parse_max_alloc_argument_valid_kilobyte() {
-        // 1024K == 1 MiB, exactly the upstream minimum (options.c:1976).
+        // 1024K == 1 MiB, exactly the upstream minimum (options.c:1960).
         assert_eq!(parse_max_alloc_argument(&os("1024K")).unwrap(), 1024 * 1024);
     }
 
     #[test]
     fn parse_max_alloc_argument_accepts_zero_as_unlimited() {
-        // upstream: options.c:1982 `if (!max_alloc) max_alloc = SIZE_MAX;` - a
+        // upstream: options.c:1966 `if (!max_alloc) max_alloc = SIZE_MAX;` - a
         // zero value is accepted and means unlimited, not an error.
         assert_eq!(
             parse_max_alloc_argument(&os("0")).unwrap(),
@@ -558,7 +558,7 @@ mod tests {
 
     #[test]
     fn parse_max_alloc_argument_rejects_below_one_mib() {
-        // upstream: options.c:1976 - parse_size_arg min value is 1 MiB, so a
+        // upstream: options.c:1960 - parse_size_arg min value is 1 MiB, so a
         // non-zero value below it ("512K", 1024 bytes) is "too small".
         for value in ["1024", "512K"] {
             let err = parse_max_alloc_argument(&os(value)).unwrap_err();
@@ -613,7 +613,7 @@ mod tests {
 
     #[test]
     fn parse_block_size_argument_zero_falls_back_to_default() {
-        // upstream: options.c:1708-1711 - `--block-size=0` passes the min_value
+        // upstream: options.c:1692-1695 - `--block-size=0` passes the min_value
         // 0 check and stores block_size = 0, which falls back to the default.
         assert_eq!(parse_block_size_argument(&os("0")).unwrap(), None);
     }
@@ -627,7 +627,7 @@ mod tests {
 
     #[test]
     fn parse_block_size_argument_rejects_above_maximum() {
-        // upstream: options.c:1708-1711 - a value above MAX_BLOCK_SIZE is "too
+        // upstream: options.c:1692-1695 - a value above MAX_BLOCK_SIZE is "too
         // large (max: 128.00K)".
         let err = parse_block_size_argument(&os("200000")).unwrap_err();
         assert!(

--- a/crates/cli/src/frontend/execution/stop.rs
+++ b/crates/cli/src/frontend/execution/stop.rs
@@ -107,7 +107,7 @@ impl From<BuildError> for StopAtError {
     }
 }
 
-// upstream: options.c:1167 parse_time() - reference "now" comes from
+// upstream: options.c:1155 parse_time() - reference "now" comes from
 // localtime(&now) and mktime() interprets the constructed tm as local time.
 // We mirror that by capturing the local OffsetDateTime once at the call site
 // and reusing its UTC offset for every candidate datetime.

--- a/crates/cli/src/frontend/filter_rules/arguments.rs
+++ b/crates/cli/src/frontend/filter_rules/arguments.rs
@@ -108,7 +108,7 @@ pub(crate) fn build_filter_order(matches: &ArgMatches, args: &[OsString]) -> Vec
         }
 
         // Short-option cluster: `-F` and `-C` may ride alongside other flags.
-        // upstream: options.c:1605-1614 - each `-F` expands to a filter
+        // upstream: options.c:1589-1598 - each `-F` expands to a filter
         // directive (first: dir-merge, second: exclude) at its argv position.
         if text.starts_with('-') && !text.starts_with("--") && text.len() > 1 {
             for ch in text[1..].chars() {
@@ -204,7 +204,7 @@ fn inline_filter_option(
 
 /// Maps an `-F` occurrence to the filter directive it expands to.
 ///
-/// upstream: options.c:1605-1614 - the first `-F` adds `: /.rsync-filter`
+/// upstream: options.c:1589-1598 - the first `-F` adds `: /.rsync-filter`
 /// (dir-merge), the second adds `- .rsync-filter` (exclude); third and later
 /// occurrences are ignored.
 fn rsync_filter_shortcut_directive(occurrence: usize) -> Option<OsString> {

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -29,7 +29,7 @@ pub(crate) fn append_filter_rules_from_files(
         return Err(message);
     }
 
-    // upstream: options.c:1557-1559 - --exclude-from and --include-from
+    // upstream: options.c:1541-1543 - --exclude-from and --include-from
     // feed parse_filter_file with XFLG_OLD_PREFIXES so per-line `- pat`,
     // `+ pat`, and `!` prefixes flip the rule kind or clear the list. Kinds
     // other than Include/Exclude have no upstream OLD_PREFIXES analogue, so

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -269,7 +269,7 @@ where
     let daemon_alias_requested = daemon_invoked_via_program_name(&args, brand);
 
     // Check for --server --daemon (remote-shell daemon mode) BEFORE plain
-    // --server. upstream: main.c:1867-1868 dispatches start_daemon() when both
+    // --server. upstream: main.c:1843-1844 dispatches start_daemon() when both
     // am_server and am_daemon are set, before the normal server path.
     if server::server_daemon_mode_requested(&args) {
         return server::run_server_daemon_mode(&args, stderr);
@@ -302,7 +302,7 @@ where
     let raw_token_count = args.len();
     let exit_code = match parse_args(args) {
         Ok(parsed) => {
-            // upstream: options.c:2021 - `human_readable > 1 && argc == 2 &&
+            // upstream: options.c:2005 - `human_readable > 1 && argc == 2 &&
             // !am_server` preserves the historic meaning of a lone `-h` as
             // `--help`. When the only command-line token increments the
             // human-readable counter (`-h`, `-hh`, `-avh`, `--human-readable`),

--- a/crates/cli/src/frontend/out_format/render/itemize.rs
+++ b/crates/cli/src/frontend/out_format/render/itemize.rs
@@ -57,7 +57,7 @@ pub(super) fn format_itemized_changes(event: &ClientEvent, is_sender: bool) -> S
         }
         DataCopied => 'c',
         HardLink => 'h',
-        // upstream: generator.c:1051 - copy-dest reconstruction itemizes with
+        // upstream: generator.c:1039 - copy-dest reconstruction itemizes with
         // ITEM_LOCAL_CHANGE, rendered as 'c' by log.c:707-708.
         ReferenceCopied => 'c',
         DirectoryCreated | SymlinkCopied | FifoCopied | DeviceCopied | SourceRemoved => 'c',

--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -57,19 +57,19 @@ impl OutFormat {
 
 /// Returns `true` when the event should be suppressed from `--out-format` output.
 ///
-/// Mirrors the upstream emit gate in `generator.c:589-590`: when `iflags == 0`
+/// Mirrors the upstream emit gate in `generator.c:582-583`: when `iflags == 0`
 /// (no significant attribute changes and the file was not transferred), the
 /// itemize line is suppressed UNLESS `INFO_GTE(NAME, 2)` is in effect (`-vv`
 /// or `--info=name2`). In the local-copy path the unchanged case corresponds
 /// to `MetadataReused` events whose `change_set` reports no changes and that
 /// were not newly created.
 ///
-/// upstream: generator.c:589-590 - emit when `iflags & (SIGNIFICANT_ITEM_FLAGS
+/// upstream: generator.c:582-583 - emit when `iflags & (SIGNIFICANT_ITEM_FLAGS
 /// | ITEM_REPORT_XATTR) || INFO_GTE(NAME, 2) || stdout_format_has_i > 1
 /// || (xname && *xname)`.
 fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> bool {
     if context.emit_unchanged() || context.itemize_repeated() {
-        // upstream: generator.c:589-590 - two separate arms force the itemize
+        // upstream: generator.c:582-583 - two separate arms force the itemize
         // line for unchanged entries: `INFO_GTE(NAME, 2)` (`-vv`, threaded as
         // `emit_unchanged`) and `stdout_format_has_i > 1` (`-ii`, threaded as
         // `itemize_repeated`). Either one surfaces dirs, files, and symlinks
@@ -83,7 +83,7 @@ fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> boo
         return true;
     }
 
-    // upstream: generator.c:589-590 + rsync.h:258 - a `--copy-dest`
+    // upstream: generator.c:582-583 + rsync.h:258 - a `--copy-dest`
     // reconstruction that exactly matches the basis is itemized with only
     // ITEM_LOCAL_CHANGE, which is excluded from `SIGNIFICANT_ITEM_FLAGS`. At
     // plain `-i` (NAME < 2, no `-ii`) the emit gate therefore drops the row.
@@ -106,7 +106,7 @@ fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> boo
         return true;
     }
 
-    // upstream: generator.c:1131-1159 - a `--link-dest` symlink hard-linked
+    // upstream: generator.c:1119-1147 - a `--link-dest` symlink hard-linked
     // from the basis (`hL`) carries only ITEM_LOCAL_CHANGE and no `=> leader`
     // xname, so it is suppressed at plain `-i`. Its `-> target` is the `%L`
     // field, not an xname, so it does not force emission.
@@ -121,7 +121,7 @@ fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> boo
         return true;
     }
 
-    // upstream: hlink.c:215-227 + generator.c:588-590 - a hardlink alias is
+    // upstream: hlink.c:215-227 + generator.c:581-583 - a hardlink alias is
     // itemized via `itemize(..., ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS, 0,
     // xname)`. The generator writes the row only when a significant attribute
     // flag is set, `INFO_GTE(NAME, 2)` (handled above via `emit_unchanged`),
@@ -155,7 +155,7 @@ pub(crate) fn emit_out_format<W: Write + ?Sized>(
     writer: &mut W,
 ) -> io::Result<()> {
     for event in events {
-        // upstream: generator.c:1734-1737 - a file skipped by `--update`
+        // upstream: generator.c:1721-1724 - a file skipped by `--update`
         // because the destination is newer never reaches the itemize call.
         // The generator emits `"%s is newer"` only at INFO_GTE(SKIP, 1) and
         // then `goto cleanup`, so the itemized row is suppressed regardless
@@ -170,7 +170,7 @@ pub(crate) fn emit_out_format<W: Write + ?Sized>(
             }
             continue;
         }
-        // upstream: generator.c:1716-1732 - a file skipped by `--max-size` /
+        // upstream: generator.c:1704-1719 - a file skipped by `--max-size` /
         // `--min-size` never reaches the itemize call. The generator emits the
         // notice only at INFO_GTE(SKIP, 1) and then `goto cleanup`, so the
         // itemized row is suppressed regardless of `-i`/`-ii`.

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -916,7 +916,7 @@ fn itemize_skipped_newer_destination_shows_dot() {
     );
 }
 
-// upstream: generator.c:1734-1737 - an `--update` skip (destination newer)
+// upstream: generator.c:1721-1724 - an `--update` skip (destination newer)
 // emits `"%s is newer"` only at INFO_GTE(SKIP, 1) and never itemizes the
 // entry. These two tests pin that orchestration behavior so the entry is not
 // rendered as an itemized `.f` row when `-ii` is also in effect.
@@ -1960,7 +1960,7 @@ fn render_binary_units_below_threshold_falls_back_to_separator() {
 
 // Regression: upstream `testsuite/itemize.test` line 113-124 expects `-ivvplrtH`
 // to emit all-dot itemize rows for unchanged dirs, files, and symlinks,
-// mirroring the upstream gate `INFO_GTE(NAME, 2)` in `generator.c:589-590`.
+// mirroring the upstream gate `INFO_GTE(NAME, 2)` in `generator.c:582-583`.
 // The renderer's empty-change-set suppression must be bypassed when the
 // context flags `emit_unchanged`.
 
@@ -1968,7 +1968,7 @@ fn render_binary_units_below_threshold_falls_back_to_separator() {
 fn emit_out_format_suppresses_unchanged_metadata_reused_by_default() {
     // Without `emit_unchanged`, a `MetadataReused` event whose change set
     // reports no change and was not created must be omitted from output
-    // (upstream `generator.c:589` default gate).
+    // (upstream `generator.c:582` default gate).
     let event = make_event(
         ClientEventKind::MetadataReused,
         false,
@@ -2009,7 +2009,7 @@ fn emit_out_format_emits_unchanged_metadata_reused_under_double_itemize() {
     // upstream `testsuite/exclude.test:243-247` runs `-aiiO --update` and
     // expects an equal-mtime quick-check match to surface as `.f          `.
     // The `-ii` arm (`stdout_format_has_i > 1`, threaded as `itemize_repeated`)
-    // forces the row independently of `-vv`, mirroring `generator.c:589-590`.
+    // forces the row independently of `-vv`, mirroring `generator.c:582-583`.
     let event = make_event(
         ClientEventKind::MetadataReused,
         false,
@@ -2068,7 +2068,7 @@ fn emit_out_format_emits_unchanged_directory_under_info_name_2() {
 
 #[test]
 fn emit_out_format_suppresses_uptodate_hardlink_alias_by_default() {
-    // upstream: hlink.c:215-227 + generator.c:588-590 - an already-correct
+    // upstream: hlink.c:215-227 + generator.c:581-583 - an already-correct
     // hardlink alias is itemized with an empty xname (no `=> target`) and an
     // empty change-set. Under plain `-i` (NAME<2, has_i==1) the row must be
     // suppressed: the shared inode already carries the leader's attributes, so
@@ -2093,7 +2093,7 @@ fn emit_out_format_suppresses_uptodate_hardlink_alias_by_default() {
 
 #[test]
 fn emit_out_format_emits_uptodate_hardlink_alias_under_info_name_2() {
-    // upstream: generator.c:589 `INFO_GTE(NAME, 2)` arm - under `-ivv` (or
+    // upstream: generator.c:582 `INFO_GTE(NAME, 2)` arm - under `-ivv` (or
     // `--info=name2`) the same up-to-date alias surfaces as `hf          n`.
     let event = make_event(
         ClientEventKind::HardLink,
@@ -2169,7 +2169,7 @@ fn emit_out_format_suppresses_uptodate_hardlink_alias_at_plain_i() {
 
 #[test]
 fn emit_out_format_emits_fresh_hardlink_alias_with_relink_target() {
-    // upstream: generator.c:589 `(xname && *xname)` arm / hlink.c:232-234 - a
+    // upstream: generator.c:582 `(xname && *xname)` arm / hlink.c:232-234 - a
     // freshly atomic_create'd alias (NOT sharing the leader inode, e.g. a
     // `--copy-dest` cluster member linked to a copied leader) itemizes with the
     // relink target as the xname (`=> %s`), forcing the row even at plain `-i`.
@@ -2210,7 +2210,7 @@ fn emit_out_format_emits_unchanged_symlink_under_info_name_2() {
     assert_eq!(rendered, ".L          test.txt\n");
 }
 
-// upstream: generator.c:1051 / log.c:707-749 - a `--copy-dest` reconstruction
+// upstream: generator.c:1039 / log.c:707-749 - a `--copy-dest` reconstruction
 // itemizes the regular file with ITEM_LOCAL_CHANGE (`c`) and, when the source
 // already matched the basis, leaves the attribute columns blank. ITEM_IS_NEW is
 // never set, so the row is `cf` + 9 spaces rather than `>f+++++++++`.
@@ -2239,7 +2239,7 @@ fn itemize_reference_copied_file_reports_basis_drift() {
     assert_eq!(format_itemized_changes(&event, false), "cf..t......");
 }
 
-// upstream: generator.c:1139 do_link_at() - a `--link-dest` exact match
+// upstream: generator.c:1127 do_link_at() - a `--link-dest` exact match
 // hard-links from the basis and itemizes as `hf` + blank when identical.
 #[test]
 fn itemize_link_dest_hardlink_is_h_with_blank_attrs() {
@@ -2278,7 +2278,7 @@ fn itemize_reference_copied_symlink_is_cl_with_blank_attrs() {
     assert_eq!(format_itemized_changes(&event, false), "cL         ");
 }
 
-// upstream: generator.c:589-590 + rsync.h:258 - at plain `-i` (no `-vv`) the
+// upstream: generator.c:582-583 + rsync.h:258 - at plain `-i` (no `-vv`) the
 // blank copy-dest reconstruction rows carry only ITEM_LOCAL_CHANGE, which is
 // excluded from SIGNIFICANT_ITEM_FLAGS, so the emit gate drops them. Only `-vv`
 // (`emit_unchanged`) surfaces the `cf`/`cd`/`cL` rows.

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -163,7 +163,7 @@ pub(crate) struct OutFormatContext {
     /// Whether `INFO_GTE(NAME, 2)` is in effect (i.e. `-vv` or
     /// `--info=name2`).
     ///
-    /// Upstream `generator.c:589-590` keeps emitting itemize lines for
+    /// Upstream `generator.c:582-583` keeps emitting itemize lines for
     /// entries whose `iflags == 0` when this is set, so unchanged dirs,
     /// files, and symlinks still surface as all-dot rows. The render path
     /// uses this to bypass the empty-change-set suppression that mirrors
@@ -172,7 +172,7 @@ pub(crate) struct OutFormatContext {
     /// Whether `-ii` (the `-i` flag repeated) is in effect, i.e. upstream
     /// `stdout_format_has_i > 1`.
     ///
-    /// Upstream `generator.c:589-590` ORs `stdout_format_has_i > 1` into the
+    /// Upstream `generator.c:582-583` ORs `stdout_format_has_i > 1` into the
     /// itemize emit gate as a term separate from `INFO_GTE(NAME, 2)`. Two
     /// `-i` flags therefore surface unchanged (`iflags == 0`) entries as
     /// all-dot rows even without `-vv`. The render path uses this to bypass
@@ -186,7 +186,7 @@ pub(crate) struct OutFormatContext {
     /// preserved.
     ///
     /// Controls whether `--list-only` output appends ` -> <target>` to a
-    /// symlink row. Upstream `generator.c:1195` only sets the arrow when
+    /// symlink row. Upstream `generator.c:1183` only sets the arrow when
     /// `preserve_links && S_ISLNK(f->mode)`; without `-l` the symlink is
     /// still listed (with its target-length size) but no target string.
     pub(super) preserve_links: bool,
@@ -221,7 +221,7 @@ impl OutFormatContext {
 
     /// Sets the `INFO_GTE(NAME, 2)` flag (`-vv` / `--info=name2`).
     ///
-    /// Upstream `generator.c:589-590` ORs `INFO_GTE(NAME, 2)` into the
+    /// Upstream `generator.c:582-583` ORs `INFO_GTE(NAME, 2)` into the
     /// itemize emit gate; mirroring that semantic locally requires the
     /// renderer to skip the "no change set, no creation" suppression so
     /// unchanged entries still print as all-dot rows.
@@ -240,7 +240,7 @@ impl OutFormatContext {
 
     /// Sets the `-ii` flag (`stdout_format_has_i > 1`).
     ///
-    /// Upstream `generator.c:589-590` ORs `stdout_format_has_i > 1` into the
+    /// Upstream `generator.c:582-583` ORs `stdout_format_has_i > 1` into the
     /// itemize emit gate; mirroring it locally makes the renderer skip the
     /// "no change set, no creation" suppression for `-ii` even without `-vv`.
     #[must_use]
@@ -266,7 +266,7 @@ impl OutFormatContext {
 
     /// Sets the `--links` / `-l` (preserve-symlinks) flag.
     ///
-    /// upstream: generator.c:1195 - the ` -> <target>` arrow in `--list-only`
+    /// upstream: generator.c:1183 - the ` -> <target>` arrow in `--list-only`
     /// output is gated on `preserve_links`.
     #[must_use]
     pub(crate) fn with_preserve_links(mut self, preserve_links: bool) -> Self {

--- a/crates/cli/src/frontend/progress/format/rate.rs
+++ b/crates/cli/src/frontend/progress/format/rate.rs
@@ -9,7 +9,7 @@ use core::client::HumanReadableMode;
 /// under `-h`/`-hh`.
 pub(crate) fn format_summary_rate(rate: f64, human_readable: HumanReadableMode) -> String {
     if !human_readable.is_enabled() {
-        // upstream: main.c:427 formats the rate with human_dnum(rate, 2), i.e.
+        // upstream: main.c:418 formats the rate with human_dnum(rate, 2), i.e.
         // do_big_dnum(rate, human_readable, 2). do_big_num (lib/compat.c:62)
         // inserts the thousands separator only when human_flag != 0, so level 0
         // (`--no-h`) renders raw ("1509.61") while the default level 1 groups
@@ -21,7 +21,7 @@ pub(crate) fn format_summary_rate(rate: f64, human_readable: HumanReadableMode) 
         };
     }
 
-    // upstream: main.c:427 human_dnum uses the same do_big_num unit path as the
+    // upstream: main.c:418 human_dnum uses the same do_big_num unit path as the
     // byte counters, so the rate honours the level's base under `-h`/`-hh`.
     format_human_rate(rate, human_readable.unit_base())
 }
@@ -130,7 +130,7 @@ mod tests {
 
     #[test]
     fn summary_rate_raw_under_no_h() {
-        // upstream: --no-h sets human_readable = 0, so main.c:427's human_dnum
+        // upstream: --no-h sets human_readable = 0, so main.c:418's human_dnum
         // passes human_flag 0 and do_big_num inserts no separator. A rate that
         // crosses 1000 must therefore render raw, not grouped, matching the real
         // binary's "sent X bytes  received Y bytes  1509.61 bytes/sec" trailer.

--- a/crates/cli/src/frontend/progress/format/size.rs
+++ b/crates/cli/src/frontend/progress/format/size.rs
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn format_list_size_pads_to_14() {
-        // upstream: generator.c:1171 size_width = 14 (human_readable defaults to 1).
+        // upstream: generator.c:1159 size_width = 14 (human_readable defaults to 1).
         let result = format_list_size(123, HumanReadableMode::Grouped);
         assert_eq!(result.len(), 14);
         assert!(result.trim_start().starts_with("123"));
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn format_list_size_raw_is_width_11_no_commas() {
-        // upstream: generator.c:1171 size_width = 11 for level 0; the value is
+        // upstream: generator.c:1159 size_width = 11 for level 0; the value is
         // right-justified raw digits, matching `-rw-r--r--     1234567 ...`.
         let result = format_list_size(1_234_567, HumanReadableMode::Raw);
         assert_eq!(result, "    1234567");
@@ -335,7 +335,7 @@ mod tests {
 
     #[test]
     fn format_list_size_default_is_width_14_with_commas() {
-        // upstream: generator.c:1171 size_width = 14 for level 1.
+        // upstream: generator.c:1159 size_width = 14 for level 1.
         let result = format_list_size(1_234_567, HumanReadableMode::Grouped);
         assert_eq!(result, "     1,234,567");
         assert_eq!(result.len(), 14);

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -47,7 +47,7 @@ fn tick_throttled(last: Option<Instant>, now: Instant, interval: Duration, is_fi
 /// before any non-progress message. We go further: when the output is not
 /// a terminal, we use `\n` instead of `\r` so piped output is readable.
 ///
-/// upstream: options.c:2030-2052 `--outbuf` controls stdout buffering via
+/// upstream: options.c:2012-2034 `--outbuf` controls stdout buffering via
 /// `setvbuf`. We mirror this by flushing after each progress tick when
 /// the mode is unbuffered or line-buffered.
 #[derive(Clone, Copy, Debug)]
@@ -242,7 +242,7 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
             return;
         }
 
-        // upstream: receiver.c:786-788 - the NDX_DONE end_progress(0) summary
+        // upstream: receiver.c:674-676 - the NDX_DONE end_progress(0) summary
         // is emitted only under --info=progress2. Per-file progress mode has no
         // terminal summary line, so drop the synthetic transfer-complete tick.
         if update.is_transfer_complete() && matches!(self.mode, ProgressMode::PerFile) {
@@ -433,7 +433,7 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                     if final_tick {
                         // upstream: progress.c:131-134 - the very last file's
                         // final tick emits a newline. For progress2, the newline
-                        // is deferred until the summary (main.c:461). We emit
+                        // is deferred until the summary (main.c:452). We emit
                         // it here to separate from the summary block.
                         writeln!(self.writer)?;
                         self.line_active = false;

--- a/crates/cli/src/frontend/progress/mode.rs
+++ b/crates/cli/src/frontend/progress/mode.rs
@@ -67,7 +67,7 @@ pub enum StderrMode {
 impl StderrMode {
     /// Parses a `--stderr` mode value.
     ///
-    /// Mirrors upstream rsync's `options.c:1928` `OPT_STDERR` handler, which
+    /// Mirrors upstream rsync's `options.c:1912` `OPT_STDERR` handler, which
     /// accepts any non-empty, case-sensitive prefix of `errors`, `all`, or
     /// `client` (via `strncmp(word, arg, strlen(arg))`). So `e`/`er`/`err`/
     /// `error`/`errors` all select `Errors`, but `ERRORS` and `errorsX` are

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -28,7 +28,7 @@ fn writeln_wrapped<W: Write + ?Sized>(
 }
 
 /// Renders a path with any trailing platform path separators trimmed as raw
-/// bytes, mirroring upstream rsync's `*cp = '\0'` slash-lopping in `main.c:798`
+/// bytes, mirroring upstream rsync's `*cp = '\0'` slash-lopping in `main.c:789`
 /// before the `created directory %s\n` print.
 fn display_without_trailing_separators(path: &Path, allow_8bit: bool) -> Vec<u8> {
     let mut rendered = escape_path(path, allow_8bit);
@@ -125,10 +125,10 @@ pub(crate) fn emit_transfer_summary(
         return Ok(());
     }
 
-    // upstream: flist.c:2286 - rprintf(FCLIENT, "sending incremental file list\n")
+    // upstream: flist.c:2251 - rprintf(FCLIENT, "sending incremental file list\n")
     // is gated on inc_recurse && INFO_GTE(FLIST, 1) && !am_server. This banner is
     // stdout-only. Upstream's parallel `rprintf(FLOG, "building file list\n")`
-    // (flist.c:2283) targets the log file, which a plain client without
+    // (flist.c:2248) targets the log file, which a plain client without
     // --log-file discards, so it never reaches stdout. Local-copy mode is treated
     // as inc_recurse-equivalent because the source enumeration is interleaved with
     // per-file dispatch.
@@ -136,11 +136,11 @@ pub(crate) fn emit_transfer_summary(
         writeln!(writer, "sending incremental file list")?;
     }
 
-    // upstream: main.c:796-817 - when the receiver pre-flight-mkdirs the
+    // upstream: main.c:787-808 - when the receiver pre-flight-mkdirs the
     // destination root because `file_total > 1 || trailing_slash`, it lops
     // off the trailing slash (`*cp = '\0'`) and prints `created directory
     // %s\n` gated on `INFO_GTE(NAME, 1) || stdout_format_has_i`. The print at
-    // main.c:817 precedes the `dry_run++` at main.c:819, so a dry-run still
+    // main.c:808 precedes the `dry_run++` at main.c:810, so a dry-run still
     // reports the directory it would create. Mirror the same gate plus
     // trailing-slash trim here so `-i` and `-v` invocations - including
     // `--dry-run` - emit the notice ahead of the per-entry itemize lines,
@@ -213,7 +213,7 @@ pub(crate) fn emit_transfer_summary(
         )?;
     }
 
-    // upstream: main.c:468-470 output_summary() emits the
+    // upstream: main.c:459-461 output_summary() emits the
     // `sent/received/total size` trailer only when
     // `verbose > 0 || INFO_GTE(STATS, 1)`. `stats_on` already captures the
     // STATS>=1 arm (it routes to emit_stats below), so the name-only and
@@ -223,7 +223,7 @@ pub(crate) fn emit_transfer_summary(
     let _ = suppress_updated_only_totals;
     let emit_trailer_totals = !stats_on && verbosity > 0;
 
-    // upstream: main.c:436/467 - `output_summary()` unconditionally emits a
+    // upstream: main.c:427/458 - `output_summary()` unconditionally emits a
     // leading `rprintf(FCLIENT, "\n")` before both the STATS>=2 detail block and
     // the STATS>=1 sent/received trailer, separating them from any preceding
     // per-file output. When a per-file block (verbose listing, itemize, or
@@ -313,7 +313,7 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
                 String::new()
             };
             let mut rendered = escape_path(event.relative_path(), eight_bit_output);
-            // upstream: generator.c:1195 list_file_entry() - the ` -> <target>`
+            // upstream: generator.c:1183 list_file_entry() - the ` -> <target>`
             // arrow is emitted only when `preserve_links && S_ISLNK(f->mode)`.
             // Without `--links`/`-l` the symlink is still listed (with its
             // target-length size) but no target string.
@@ -393,7 +393,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
     // directories and symlinks included); the numerator `total - checked`
     // counts down over all of them, mirroring upstream's
     // `num_files - current_file_index - 1`. Only regular-file transfers print a
-    // block and advance `xfr#` (upstream receiver.c:895), so a symlink or
+    // block and advance `xfr#` (upstream receiver.c:782), so a symlink or
     // directory is counted but silent.
     let total = flist_entries.len();
     let transferred_total = flist_entries
@@ -448,7 +448,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
 /// Emits a statistics summary mirroring the subset of counters supported by the local engine.
 ///
 /// Output is gated by `level`, matching upstream rsync's `INFO_GTE(STATS, N)`
-/// checks in `output_summary` (`main.c:425-474`):
+/// checks in `output_summary` (`main.c:416-465`):
 ///
 /// - level 0: emits nothing.
 /// - level 1: emits only the trailing `sent X / total size is Y` summary.
@@ -458,7 +458,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
 ///   single `if (stats.flist_buildtime)` guard.
 ///
 /// Line ordering and label spelling track upstream byte-for-byte. The leading
-/// `\n` (`main.c:428`) is intentionally omitted; the caller is responsible
+/// `\n` (`main.c:419`) is intentionally omitted; the caller is responsible
 /// for the blank-line separator between prior output blocks and stats.
 ///
 /// upstream: main.c output_summary (rsync-3.4.2 lines 416-465)
@@ -560,7 +560,7 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
         .saturating_add(symlinks_total)
         .saturating_add(special_total);
 
-    // upstream: receiver.c:845-858 / sender.c:301-314 - "Number of created
+    // upstream: receiver.c:733-746 / sender.c:295-308 - "Number of created
     // files" counts ITEM_IS_NEW entries per type (new dirs, symlinks, devices,
     // specials and empty files included), NOT the "copied/updated" tallies. An
     // in-place update of a pre-existing file/symlink is transferred but never
@@ -621,7 +621,7 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
         "Number of files: {}{files_breakdown}",
         format_count(total_entries, human_readable)
     )?;
-    // upstream: main.c:438 - `if (protocol_version >= 29)`
+    // upstream: main.c:429 - `if (protocol_version >= 29)`
     if summary.protocol_version() >= 29 {
         writeln!(
             stdout,
@@ -629,7 +629,7 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
             format_count(created_total, human_readable)
         )?;
     }
-    // upstream: main.c:440 - `if (protocol_version >= 31)`
+    // upstream: main.c:431 - `if (protocol_version >= 31)`
     if summary.protocol_version() >= 31 {
         writeln!(
             stdout,
@@ -650,7 +650,7 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
     writeln!(stdout, "Literal data: {literal_bytes_display} bytes")?;
     writeln!(stdout, "Matched data: {matched_bytes_display} bytes")?;
     writeln!(stdout, "File list size: {file_list_size_display}")?;
-    // upstream: main.c:446 `if (stats.flist_buildtime)` gates both timing
+    // upstream: main.c:437 `if (stats.flist_buildtime)` gates both timing
     // lines. The upstream counter is a millisecond integer, so sub-millisecond
     // durations suppress the lines just as on the C side.
     if file_list_generation_ms > 0 {
@@ -680,7 +680,7 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
     let sent = summary.bytes_sent();
     let received = summary.bytes_received();
     let total_size = summary.total_source_bytes();
-    // upstream main.c:427-432: rate = (written+read) / (0.5 + (endtime-starttime)),
+    // upstream main.c:418-423: rate = (written+read) / (0.5 + (endtime-starttime)),
     // a single wall-clock span with a 0.5s floor - never the summed per-file copy
     // durations (which are ~0 for CoW/clonefile and explode the rate).
     let wall_seconds = summary.wall_clock_elapsed().as_secs_f64();
@@ -716,7 +716,7 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
         stdout,
         "sent {sent_display} bytes  received {received_display} bytes  {rate_display} bytes/sec"
     )?;
-    // upstream: main.c:478 - `write_batch < 0 ? " (BATCH ONLY)" : dry_run ?
+    // upstream: main.c:469 - `write_batch < 0 ? " (BATCH ONLY)" : dry_run ?
     // " (DRY RUN)" : ""`. `--only-write-batch` sets `write_batch < 0` and takes
     // precedence over `--dry-run`.
     let speedup_suffix = if only_write_batch {
@@ -726,7 +726,7 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
     } else {
         ""
     };
-    // upstream: main.c:475-477 - speedup uses comma_dnum(_, 2), i.e. thousands
+    // upstream: main.c:466-468 - speedup uses comma_dnum(_, 2), i.e. thousands
     // grouping. Reuse the same helper the --stats path uses (stats_format.rs)
     // so both summary paths group identically.
     let speedup_display = crate::stats_format::format_speedup(speedup);
@@ -740,7 +740,7 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
 /// reorder events so upstream's generator-first / receiver-second wire order
 /// is preserved in verbose mode.
 ///
-/// upstream: hlink.c:218-224, generator.c:1022-1034, rsync.c:672-676 - the
+/// upstream: hlink.c:218-224, generator.c:1010-1022, rsync.c:672-676 - the
 /// generator emits `"is uptodate"` synchronously while the receiver emits
 /// the bare-name notice from `set_file_attrs` only after the transfer
 /// completes. The two processes pipeline so uptodate lines appear ahead of
@@ -755,7 +755,7 @@ fn is_uptodate_event(event: &ClientEvent) -> bool {
 /// phase that prints transferred-file names. Bucketing these with the uptodate
 /// notices reproduces that interleaving.
 ///
-/// upstream: generator.c:1391,1407,1720,1729,1736 (recv_generator)
+/// upstream: generator.c:1379,1395,1708,1716,1723 (recv_generator)
 fn is_generator_phase_skip(event: &ClientEvent) -> bool {
     matches!(
         event.kind(),
@@ -852,7 +852,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
         // generator phase, ahead of the receiver phase that prints the
         // transferred-file names. Bucket those generator-phase notices first
         // so the stable sort reproduces that interleaving.
-        // (generator.c:1391,1407,1736)
+        // (generator.c:1379,1395,1723)
         if is_uptodate_event(event) || is_generator_phase_skip(event) {
             0u8
         } else if is_deferred_hardlink_event(event) {
@@ -879,7 +879,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // through the uptodate phrasing instead of the bare path.
             //
             // Skip directory MetadataReused events: upstream invokes
-            // `set_file_attrs(..., 0)` for dirs (generator.c:1515), so the
+            // `set_file_attrs(..., 0)` for dirs (generator.c:1503), so the
             // rsync.c:676 "is uptodate" notice is gated off for them.
             if matches!(kind, ClientEventKind::MetadataReused) || event.is_hardlink_uptodate() {
                 if event
@@ -918,11 +918,11 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
 
         match kind {
             ClientEventKind::SkippedExisting => {
-                // upstream: generator.c:1409-1421 - `rprintf(FINFO, "%s exists\n",
+                // upstream: generator.c:1397-1409 - `rprintf(FINFO, "%s exists\n",
                 // fname)` for an --ignore-existing skip: the bare relative name
                 // followed by " exists", no descriptor and no quotes. Gated on
                 // INFO_GTE(SKIP, 1), which the info verbosity table raises only
-                // at -vv (options.c:262).
+                // at -vv (options.c:252).
                 if info_gte(InfoFlag::Skip, 1) {
                     writeln_wrapped(
                         stdout,
@@ -935,7 +935,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
             ClientEventKind::SkippedMissingDestination => {
-                // upstream: generator.c:1391-1394 - `rprintf(FINFO,
+                // upstream: generator.c:1379-1382 - `rprintf(FINFO,
                 // "not creating new %s \"%s\"\n", "file", fname)` for an
                 // --existing / --ignore-non-existing skip, gated on
                 // INFO_GTE(SKIP, 1).
@@ -951,7 +951,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
             ClientEventKind::SkippedNewerDestination => {
-                // upstream: generator.c:1736-1737 - `rprintf(FINFO, "%s is
+                // upstream: generator.c:1723-1724 - `rprintf(FINFO, "%s is
                 // newer\n", fname)` for an --update skip: the bare relative name
                 // followed by " is newer", gated on INFO_GTE(SKIP, 1).
                 if info_gte(InfoFlag::Skip, 1) {
@@ -966,7 +966,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
             ClientEventKind::SkippedOverMaxSize => {
-                // upstream: generator.c:1716-1724 - `rprintf(FINFO,
+                // upstream: generator.c:1704-1711 - `rprintf(FINFO,
                 // "%s is over max-size\n", fname)` for a `--max-size` skip: the
                 // bare relative name followed by " is over max-size", gated on
                 // INFO_GTE(SKIP, 1).
@@ -982,7 +982,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
             ClientEventKind::SkippedUnderMinSize => {
-                // upstream: generator.c:1725-1732 - `rprintf(FINFO,
+                // upstream: generator.c:1712-1719 - `rprintf(FINFO,
                 // "%s is under min-size\n", fname)` for a `--min-size` skip: the
                 // bare relative name followed by " is under min-size", gated on
                 // INFO_GTE(SKIP, 1).
@@ -1008,7 +1008,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
             ClientEventKind::SkippedDirectory => {
-                // upstream: flist.c:1366 and flist.c:2487 -
+                // upstream: flist.c:1338 and flist.c:2452 -
                 // `rprintf(FINFO, "skipping directory %s\n", ...)`: the bare
                 // relative name with no surrounding quotes and no trailing
                 // "(no recursion)" suffix.
@@ -1057,7 +1057,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // routing it through the event renderer keeps `is uptodate`
                 // lines ahead of the totals to match upstream's wire order.
                 //
-                // upstream: generator.c:1515 calls `set_file_attrs(..., 0)`
+                // upstream: generator.c:1503 calls `set_file_attrs(..., 0)`
                 // for directories (no ATTRS_REPORT flag), so dirs never trigger
                 // the rsync.c:676 "is uptodate" notice. Symlinks (line 1575)
                 // and regular files (line 1827) DO pass `maybe_ATTRS_REPORT`
@@ -1098,7 +1098,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 }
                 continue;
             }
-            // upstream: generator.c:1033-1034 / 1056-1058 / 1157-1159 - a
+            // upstream: generator.c:1021-1022 / 1044-1046 / 1145-1147 - a
             // `--copy-dest` match that needs no transfer prints `"%s%s is
             // uptodate\n"` at INFO_GTE(NAME, 2), with a trailing `/` for
             // directories, and prints nothing at lower verbosity (the bare
@@ -1119,7 +1119,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 }
                 continue;
             }
-            // upstream: generator.c:1157-1159 - a `--link-dest` symlink
+            // upstream: generator.c:1145-1147 - a `--link-dest` symlink
             // hard-linked from the basis prints `"%s is uptodate"` at NAME>=2.
             ClientEventKind::HardLink if is_hardlinked_symlink_event(event) => {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
@@ -1182,7 +1182,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
         }
 
         // upstream: log.c:log_formatted() emits the default `%n%L` per-file
-        // line at every verbosity tier (set in options.c:2390). The rendered
+        // line at every verbosity tier (set in options.c:2372). The rendered
         // bytes already include the `-> target` suffix for symlinks; higher
         // tiers only add ancillary log messages, never a per-file descriptor
         // prefix or byte-count wrapper.
@@ -1216,7 +1216,7 @@ mod tests {
     fn render_verbose_scenario(events: Vec<ClientEvent>, verbose_level: u8) -> String {
         // Mirror the CLI's per-thread verbosity setup so `info_gte(Skip, ..)`
         // reflects the requested level. `from_verbose_level(2)` raises Skip to 1
-        // (upstream options.c:262), `(1)` leaves it at 0.
+        // (upstream options.c:252), `(1)` leaves it at 0.
         logging::init(logging::VerbosityConfig::from_verbose_level(verbose_level));
         let mut out = Vec::new();
         emit_verbose(
@@ -1262,7 +1262,7 @@ mod tests {
         // notices must surface first, in flist order, with upstream's exact
         // bare-name-plus-" exists" text - never after the transferred names or
         // after the stats block.
-        // upstream: generator.c:1407-1421
+        // upstream: generator.c:1395-1409
         let events = vec![
             transferred_event("big.txt"),
             skip_event("onlyexists.txt", ClientEventKind::SkippedExisting),
@@ -1279,7 +1279,7 @@ mod tests {
     fn skip_notices_suppressed_below_skip_verbosity() {
         // WHY: upstream gates the exists/not-creating/is-newer notices on
         // INFO_GTE(SKIP, 1), which the info verbosity table raises only at -vv
-        // (options.c:262). At plain -v they must be silent, leaving only the
+        // (options.c:252). At plain -v they must be silent, leaving only the
         // transferred-file names - otherwise a drop-in tool sees phantom lines
         // that upstream never emits.
         let events = vec![
@@ -1295,8 +1295,8 @@ mod tests {
     fn not_creating_and_is_newer_use_upstream_text_at_vv() {
         // WHY: the local path previously emitted oc-invented wording ("skipping
         // non-existent destination file", "skipping newer destination file").
-        // Upstream prints `not creating new file "%s"` (generator.c:1392) and
-        // `%s is newer` (generator.c:1737). Drop-in parsers key on the exact
+        // Upstream prints `not creating new file "%s"` (generator.c:1380) and
+        // `%s is newer` (generator.c:1724). Drop-in parsers key on the exact
         // strings, so any deviation breaks compatibility.
         let missing = vec![skip_event(
             "big.txt",
@@ -1322,7 +1322,7 @@ mod tests {
         // order, so the two size-skip notices must surface first, in flist
         // order, with upstream's exact bare-name text - never after the
         // transferred names or after the stats block.
-        // upstream: generator.c:1716-1732
+        // upstream: generator.c:1704-1719
         let events = vec![
             transferred_event("keep.txt"),
             skip_event("big.bin", ClientEventKind::SkippedOverMaxSize),
@@ -1338,7 +1338,7 @@ mod tests {
     #[test]
     fn size_skip_notices_suppressed_below_skip_verbosity() {
         // WHY: upstream gates the size-skip notices on INFO_GTE(SKIP, 1), which
-        // the info verbosity table raises only at -vv (options.c:262). At plain
+        // the info verbosity table raises only at -vv (options.c:252). At plain
         // -v they must be silent, leaving only the transferred name - otherwise
         // a drop-in tool sees phantom lines upstream never emits.
         let events = vec![
@@ -1356,7 +1356,7 @@ mod tests {
         // notices. Mixing all of them must keep every generator-phase notice
         // ahead of the transferred names, in flist order, so adding the size
         // cases does not regress the #6639 ordering.
-        // upstream: generator.c:1391,1407,1720,1729,1736
+        // upstream: generator.c:1379,1395,1708,1716,1723
         let events = vec![
             transferred_event("keep.txt"),
             skip_event("exists.txt", ClientEventKind::SkippedExisting),
@@ -1380,7 +1380,7 @@ mod tests {
             Some(ClientEntryMetadata::for_test(ClientEntryKind::Directory)),
             LocalCopyChangeSet::new(),
         );
-        // upstream: flist.c:1366 and flist.c:2487 emit
+        // upstream: flist.c:1338 and flist.c:2452 emit
         // `rprintf(FINFO, "skipping directory %s\n", ...)` - a bare relative
         // name with no surrounding quotes and no "(no recursion)" suffix. Byte
         // fidelity with upstream requires exactly this form.
@@ -1420,7 +1420,7 @@ mod tests {
 
     #[test]
     fn plain_stats_trailer_starts_with_blank_line() {
-        // upstream: main.c:467 - output_summary() emits an unconditional leading
+        // upstream: main.c:458 - output_summary() emits an unconditional leading
         // `rprintf(FCLIENT, "\n")` before the STATS>=1 sent/received trailer,
         // even when no per-file output preceded it (a plain `--stats` run). oc
         // previously emitted the trailer with no leading blank.
@@ -1440,7 +1440,7 @@ mod tests {
 
     #[test]
     fn stats_detail_block_starts_with_blank_line() {
-        // upstream: main.c:436 - the STATS>=2 detail block is also preceded by an
+        // upstream: main.c:427 - the STATS>=2 detail block is also preceded by an
         // unconditional leading blank.
         let out = render_summary(2, false, false);
         assert!(
@@ -1456,7 +1456,7 @@ mod tests {
 
     #[test]
     fn speedup_suffix_matches_upstream_precedence() {
-        // upstream: main.c:478 - `write_batch < 0 ? " (BATCH ONLY)" : dry_run ?
+        // upstream: main.c:469 - `write_batch < 0 ? " (BATCH ONLY)" : dry_run ?
         // " (DRY RUN)" : ""`. --only-write-batch wins over --dry-run.
         assert!(render_summary(1, false, false).contains("speedup is"));
         assert!(!render_summary(1, false, false).contains("(DRY RUN)"));

--- a/crates/cli/src/frontend/server/daemon.rs
+++ b/crates/cli/src/frontend/server/daemon.rs
@@ -63,7 +63,7 @@ pub(crate) fn server_mode_requested(args: &[OsString]) -> bool {
 /// remote shell wrappers (e.g., `lsh.sh`) that invoke rsync as:
 ///   `rsync --config=<file> --server --daemon .`
 ///
-/// upstream: main.c:1867-1868 - when both `am_server` and `am_daemon` are set,
+/// upstream: main.c:1843-1844 - when both `am_server` and `am_daemon` are set,
 /// `start_daemon(STDIN_FILENO, STDOUT_FILENO)` is called.
 pub(crate) fn server_daemon_mode_requested(args: &[OsString]) -> bool {
     let mut has_server = false;
@@ -129,7 +129,7 @@ where
 /// inherited file descriptors. Used by remote shells (e.g., SSH) that invoke:
 ///   `oc-rsync --config=<file> --server --daemon .`
 ///
-/// upstream: main.c:1867-1868 - `start_daemon(STDIN_FILENO, STDOUT_FILENO)`.
+/// upstream: main.c:1843-1844 - `start_daemon(STDIN_FILENO, STDOUT_FILENO)`.
 #[cfg(unix)]
 pub(crate) fn run_server_daemon_mode<Err>(args: &[OsString], stderr: &mut Err) -> i32
 where

--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -10,7 +10,7 @@ use engine::{ReferenceDirectory, ReferenceDirectoryKind};
 
 /// Detects whether secluded-args mode is requested in the server arguments.
 ///
-/// Upstream rsync's `server_options()` (options.c:2622) embeds `s` in the
+/// Upstream rsync's `server_options()` (options.c:2604) embeds `s` in the
 /// compact flag string when `protect_args` is active - e.g.
 /// `-slogDtprze.iLsfxCIvu`. The `s` appears in the transfer-flag portion
 /// (before the first `.`), never in the capability/info suffix.
@@ -18,7 +18,7 @@ use engine::{ReferenceDirectory, ReferenceDirectoryKind};
 /// This function checks both standalone `-s` and `s` embedded in compact
 /// flag arguments (single-dash args that are not long flags).
 ///
-/// upstream: options.c:804 - `{"secluded-args", 's', ...}`
+/// upstream: options.c:792 - `{"secluded-args", 's', ...}`
 pub(crate) fn detect_secluded_args_flag(args: &[OsString]) -> bool {
     args.iter().skip(1).any(|a| {
         let s = a.to_string_lossy();
@@ -29,7 +29,7 @@ pub(crate) fn detect_secluded_args_flag(args: &[OsString]) -> bool {
         // Only scan the transfer-flag portion (before the first `.`)
         // because `s` after the dot is the symlink-iconv capability char,
         // not secluded-args.
-        // upstream: options.c:2622 - protect_args placed at argstr[1]
+        // upstream: options.c:2604 - protect_args placed at argstr[1]
         if s.starts_with('-') && !s.starts_with("--") && s.len() > 1 {
             let transfer_portion = s[1..].split('.').next().unwrap_or("");
             return transfer_portion.contains('s');
@@ -56,14 +56,14 @@ pub(super) struct ServerLongFlags {
     pub(super) trust_sender: bool,
     /// Keep partially transferred files (upstream: `--partial`, long-form only).
     ///
-    /// upstream: options.c:2911 - `server_options()` emits bare `--partial`
+    /// upstream: options.c:2893 - `server_options()` emits bare `--partial`
     /// (never a compact `P` letter) when the client is the sender and no
     /// `--partial-dir` is configured. The receiver consults `keep_partial`
     /// (receiver.c) to leave interrupted temp files in place.
     pub(super) partial: bool,
     /// Explicit specials override (upstream: `--specials` / `--no-specials`).
     ///
-    /// upstream: options.c:2778-2783 - the compact `D` letter carries
+    /// upstream: options.c:2760-2765 - the compact `D` letter carries
     /// preserve_devices only, so specials arrive separately: `--specials`
     /// (`Some(true)`) or `--no-specials` (`Some(false)`). `None` leaves the
     /// value implied by the compact `D` letter untouched.
@@ -75,7 +75,7 @@ pub(super) struct ServerLongFlags {
     pub(super) max_size: Option<String>,
     /// Memory allocation cap forwarded by the client.
     ///
-    /// upstream: options.c:2863-2864 - `--max-alloc=arg` is emitted by
+    /// upstream: options.c:2845-2846 - `--max-alloc=arg` is emitted by
     /// `server_options()` when the user-supplied value differs from the
     /// default. Each side enforces its own cap, so the server records and
     /// applies the value locally.
@@ -87,23 +87,23 @@ pub(super) struct ServerLongFlags {
     pub(super) inplace: bool,
     /// Append data onto shorter destination files (upstream: `--append`).
     ///
-    /// upstream: options.c:1738-1742 - `OPT_APPEND` increments `append_mode`
+    /// upstream: options.c:1722-1726 - `OPT_APPEND` increments `append_mode`
     /// on the server side, so a single `--append` sets `append_mode == 1`.
-    /// server_options() (options.c:2969-2972) always emits the bare `--append`
+    /// server_options() (options.c:2951-2954) always emits the bare `--append`
     /// long flag (never `--append-verify`); the receiver seeks past the
-    /// existing length and the sender streams only the tail (sender.c:91-97,
-    /// generator.c:798).
+    /// existing length and the sender streams only the tail (sender.c:89-95,
+    /// generator.c:786).
     pub(super) append: bool,
-    /// upstream: options.c:725 / 3008-3009 - `--preallocate` (preallocate_files)
+    /// upstream: options.c:715 / 2990-2991 - `--preallocate` (preallocate_files)
     /// is forwarded to a server receiver, which `fallocate()`s each destination
     /// file to its eventual length before writing to reduce fragmentation.
     pub(super) preallocate: bool,
     /// Re-verify the existing prefix under append (upstream: `--append-verify`,
     /// wire-encoded as a doubled `--append`, `append_mode == 2`).
     ///
-    /// upstream: options.c:1740 - a second `--append` on the server bumps
+    /// upstream: options.c:1724 - a second `--append` on the server bumps
     /// `append_mode` to 2, folding the on-disk prefix into the whole-file
-    /// checksum (match.c:373, receiver.c:464) so a corrupted prefix fails
+    /// checksum (match.c:373, receiver.c:357) so a corrupted prefix fails
     /// verification and triggers a full re-transmit.
     pub(super) append_verify: bool,
     pub(super) size_only: bool,
@@ -125,19 +125,19 @@ pub(super) struct ServerLongFlags {
     /// file (including each destination `.rsync-filter` merge file) has landed,
     /// so per-directory merge protect rules are honoured at delete time.
     ///
-    /// upstream: generator.c:125 - `EARLY_DELETE_DONE_MSG = !(delete_during == 2
-    /// || delete_after)`; generator.c:2442-2445 late delete pass.
+    /// upstream: generator.c:124 - `EARLY_DELETE_DONE_MSG = !(delete_during == 2
+    /// || delete_after)`; generator.c:2425-2428 late delete pass.
     pub(super) late_delete: bool,
     /// Defer the delete *decision* until after the transfer (upstream:
     /// `--delete-after` / `delete_after` only). Set apart from [`late_delete`]
-    /// because `--delete-delay` decides during the walk (generator.c:2332) and
+    /// because `--delete-delay` decides during the walk (generator.c:2315) and
     /// defers only the unlink, so its delete pass runs early like `--delete-during`.
     ///
     /// [`late_delete`]: Self::late_delete
     pub(super) delete_after: bool,
     /// Remove source files after a successful transfer.
     ///
-    /// upstream: options.c:2982-2983 - `server_options()` emits
+    /// upstream: options.c:2964-2965 - `server_options()` emits
     /// `--remove-source-files` (or the legacy alias `--remove-sent-files`)
     /// whenever the client asked for sender-side removal. The flag is
     /// long-form only; the sender's `successful_send()` reads the global
@@ -146,15 +146,15 @@ pub(super) struct ServerLongFlags {
     pub(super) remove_source_files: bool,
     /// Stream device contents as regular files (upstream: `--copy-devices`).
     ///
-    /// upstream: options.c:3005 - `if (copy_devices && !am_sender) args[ac++] =
+    /// upstream: options.c:2987 - `if (copy_devices && !am_sender) args[ac++] =
     /// "--copy-devices"`. The flag is forwarded only when the remote peer is the
     /// sender (a pull), so this server-side process is the sender and must
     /// convert each block/char device into a regular file whose contents are
-    /// streamed (`flist.c:1451`).
+    /// streamed (`flist.c:1419`).
     pub(super) copy_devices: bool,
     /// Whether `--stats` was forwarded by the client.
     ///
-    /// upstream: options.c:2856-2857 - `server_options()` emits `--stats` whenever
+    /// upstream: options.c:2838-2839 - `server_options()` emits `--stats` whenever
     /// the client requested detailed statistics. The server-side `do_stats` flag
     /// gates emission of `NDX_DEL_STATS` during the goodbye phase, which the
     /// client relies on for the "Number of deleted files" stats line.
@@ -167,7 +167,7 @@ pub(super) struct ServerLongFlags {
     pub(super) max_delete: Option<String>,
     /// Iconv specification forwarded by the client (upstream: `--iconv=CHARSET`).
     ///
-    /// upstream: options.c:2734-2741 - client forwards the post-comma half of
+    /// upstream: options.c:2716-2723 - client forwards the post-comma half of
     /// `--iconv=LOCAL,REMOTE` (or the whole spec if no comma) so the server
     /// opens its own iconv context against the wire's UTF-8 charset.
     pub(super) iconv: Option<String>,
@@ -179,11 +179,11 @@ pub(super) struct ServerLongFlags {
     /// `parse_server_flag_string_and_args` and corrupts the destination path.
     pub(super) timeout: Option<String>,
     /// Reference directories for basis file lookup.
-    /// upstream: options.c:2933-2941 - `--compare-dest`, `--copy-dest`, `--link-dest`
+    /// upstream: options.c:2915-2923 - `--compare-dest`, `--copy-dest`, `--link-dest`
     pub(super) reference_directories: Vec<ReferenceDirectory>,
     /// Raw `--info=FLAGS` values forwarded by the client.
     ///
-    /// upstream: options.c:2946-2949 - `server_options()` emits the output of
+    /// upstream: options.c:2928-2931 - `server_options()` emits the output of
     /// `make_output_option(info_words, info_levels, ...)`, so the server
     /// receives `--info=...` whenever the client has non-default info levels.
     pub(super) info: Vec<OsString>,
@@ -193,15 +193,15 @@ pub(super) struct ServerLongFlags {
     /// `make_output_option(debug_words, ...)` so an oc peer raises its debug
     /// output to match (`client/remote/output_option.rs`). The receiving side
     /// parses `--debug=...` the same way upstream parses a user `--debug` arg
-    /// (options.c:1793 `parse_output_words(debug_words, ...)`), silently
-    /// ignoring unknown tokens because `am_server` (options.c:485). Without
+    /// (options.c:1777 `parse_output_words(debug_words, ...)`), silently
+    /// ignoring unknown tokens because `am_server` (options.c:475). Without
     /// capturing it here the token falls through to
     /// `parse_server_flag_string_and_args` and is mistaken for a positional
     /// destination path (`failed to create destination root --debug=hlink4`).
     pub(super) debug: Vec<OsString>,
     /// Explicit compression algorithm forwarded by the client.
     ///
-    /// upstream: options.c:2818-2823 - `server_options()` emits long-form
+    /// upstream: options.c:2800-2805 - `server_options()` emits long-form
     /// `--new-compress` (zlibx), `--old-compress` (zlib), or
     /// `--compress-choice=ALGO` (zstd/lz4) whenever the negotiated codec is
     /// not the default CPRES_ZLIB carried by the compact `-z` flag. Capturing
@@ -210,7 +210,7 @@ pub(super) struct ServerLongFlags {
     pub(super) compress_choice: Option<String>,
     /// Compression level forwarded by the client (`--compress-level=N`).
     ///
-    /// upstream: options.c:2772-2776 - `server_options()` emits
+    /// upstream: options.c:2754-2758 - `server_options()` emits
     /// `--compress-level=%d` whenever `do_compression` is active and the level
     /// differs from the unspecified default. The raw `N` string is captured so
     /// the server can apply the same level to its codec; without recognising
@@ -219,7 +219,7 @@ pub(super) struct ServerLongFlags {
     pub(super) compression_level: Option<String>,
     /// Log format forwarded by the client (upstream: `--log-format=FMT`).
     ///
-    /// upstream: options.c:2768-2780 - the client sends `--log-format=%i`
+    /// upstream: options.c:2750-2762 - the client sends `--log-format=%i`
     /// (or `%i%I`, `%o`, `X`) so the server knows whether the generator
     /// should produce itemize data. The server does not use the full format
     /// string - it only inspects it for `%i` / `%o` tokens to set
@@ -227,7 +227,7 @@ pub(super) struct ServerLongFlags {
     pub(super) log_format: Option<String>,
     /// Partial-directory path forwarded by the client (`--partial-dir=DIR`).
     ///
-    /// upstream: options.c:2904-2908 - `server_options()` emits the option
+    /// upstream: options.c:2886-2890 - `server_options()` emits the option
     /// as TWO separate argv entries (`--partial-dir`, then the value) via
     /// `safe_arg("", partial_dir)`, NOT the `--partial-dir=VALUE` form.
     /// Without recognising the split form, the value lands in
@@ -240,19 +240,19 @@ pub(super) struct ServerLongFlags {
     pub(super) partial_dir: Option<OsString>,
     /// Whether `--delay-updates` was forwarded by the client.
     ///
-    /// upstream: options.c:2909-2910 - `server_options()` emits
+    /// upstream: options.c:2891-2892 - `server_options()` emits
     /// `--delay-updates` alongside `--partial-dir` when both are active.
     pub(super) delay_updates: bool,
     /// Whether `--mkpath` was forwarded by the client (upstream: `--mkpath`).
     ///
-    /// upstream: options.c:3014-3015 - `if (mkpath_dest_arg && am_sender)
+    /// upstream: options.c:2996-2997 - `if (mkpath_dest_arg && am_sender)
     /// args[ac++] = "--mkpath"`. Long-form only. Gates the receiver's
-    /// dest-arg path creation (`main.c:745` `make_path` vs `main.c:797`
+    /// dest-arg path creation (`main.c:736` `make_path` vs `main.c:788`
     /// single `do_mkdir`).
     pub(super) mkpath: bool,
     /// Whether the client forwarded `--list-only` (upstream `list_only > 1`).
     ///
-    /// upstream: options.c:2765-2766 - forwarded so the peer knows the transfer
+    /// upstream: options.c:2747-2748 - forwarded so the peer knows the transfer
     /// is a listing. The receiver renders the flist without writing to the
     /// destination.
     pub(super) list_only: bool,
@@ -260,43 +260,43 @@ pub(super) struct ServerLongFlags {
     /// `write_batch = -1`). Emitted only in the `am_sender` block, so it
     /// reaches this process only when it is the server receiver on a push.
     ///
-    /// upstream: options.c:2868-2869 - `if (write_batch < 0) args[ac++] =
-    /// "--only-write-batch=X"`. On the receiver, main.c:1863 forces
+    /// upstream: options.c:2850-2851 - `if (write_batch < 0) args[ac++] =
+    /// "--only-write-batch=X"`. On the receiver, main.c:1839 forces
     /// `dry_run = 1` (no destination writes) while `do_xfers` stays 1 so the
     /// generator still sends real block checksums; the push sender records the
-    /// batch locally (sender.c:221) and streams no delta data over the wire.
+    /// batch locally (sender.c:217) and streams no delta data over the wire.
     pub(super) only_write_batch: bool,
 
     /// Whether the client forwarded `--no-implied-dirs` (upstream
     /// `implied_dirs == 0`).
     ///
-    /// upstream: options.c:2994-2995 - forwarded to the sender on a pull. As the
+    /// upstream: options.c:2976-2977 - forwarded to the sender on a pull. As the
     /// server-side sender, this process must omit the implied parent dirs from
-    /// the flist at protocol < 30 (flist.c:2503); protocol >= 30 always sends
-    /// them (flist.c:2292-2293).
+    /// the flist at protocol < 30 (flist.c:2468); protocol >= 30 always sends
+    /// them (flist.c:2257-2258).
     pub(super) no_implied_dirs: bool,
 
     /// Whether the client forwarded `--no-r` (upstream `recurse = 0`).
     ///
-    /// upstream: options.c:2768-2771 - `if (xfer_dirs && !recurse &&
+    /// upstream: options.c:2750-2753 - `if (xfer_dirs && !recurse &&
     /// delete_mode && am_sender) args[ac++] = "--no-r"`. A client running
     /// `-d --delete` (e.g. `--files-from --delete`) forwards `--no-r` so the
     /// remote receiver can delete with `-d` sans `-r`; the server-side popt
-    /// table clears `recurse` (options.c:633 `{"no-r", ..., &recurse, 0}`).
+    /// table clears `recurse` (options.c:623 `{"no-r", ..., &recurse, 0}`).
     pub(super) no_recurse: bool,
 
     /// Whether the client forwarded `--no-W` (upstream `whole_file = 0`).
     ///
-    /// upstream: options.c:2973-2977 - under `--inplace`, `if (sparse_files &&
+    /// upstream: options.c:2955-2959 - under `--inplace`, `if (sparse_files &&
     /// !whole_file && am_sender) args[ac++] = "--no-W"` works around an older
     /// remote bug for `--inplace --sparse`. The server-side popt table clears
-    /// `whole_file` (options.c:756 `{"no-W", ..., &whole_file, 0}`).
+    /// `whole_file` (options.c:746 `{"no-W", ..., &whole_file, 0}`).
     pub(super) no_whole_file: bool,
 
     /// Whether the client forwarded `--relative` / `--no-relative`.
     ///
-    /// upstream: options.c:110-111 - `if (relative_paths) argstr[x++] = 'R';`
-    /// packs the compact `R` letter for relative mode, and options.c:378-379
+    /// upstream: options.c:109-110 - `if (relative_paths) argstr[x++] = 'R';`
+    /// packs the compact `R` letter for relative mode, and options.c:368-369
     /// emits the long `--no-relative` when relative paths are off (including the
     /// `--files-from` default, which is otherwise relative). The long form must
     /// be recognised and consumed here; otherwise it falls through to the
@@ -307,7 +307,7 @@ pub(super) struct ServerLongFlags {
 
     /// Whether the client forwarded `--open-noatime` (upstream `open_noatime`).
     ///
-    /// upstream: options.c:3011-3012 - `if (open_noatime && preserve_atimes <= 1)
+    /// upstream: options.c:2993-2994 - `if (open_noatime && preserve_atimes <= 1)
     /// args[ac++] = "--open-noatime"`. Forwarded to the sender so it opens each
     /// source file with `O_NOATIME`, avoiding an atime update on read.
     pub(super) open_noatime: bool,
@@ -315,7 +315,7 @@ pub(super) struct ServerLongFlags {
     /// Whether the client forwarded `--delete-missing-args` (upstream
     /// `missing_args == 2`).
     ///
-    /// upstream: options.c:2886-2887 - `if (missing_args == 2) args[ac++] =
+    /// upstream: options.c:2868-2869 - `if (missing_args == 2) args[ac++] =
     /// "--delete-missing-args"`. Needs both sides: a vanished top-level source
     /// arg becomes a mode-0 sentinel the receiver deletes at the destination.
     pub(super) delete_missing_args: bool,
@@ -323,14 +323,14 @@ pub(super) struct ServerLongFlags {
     /// Whether the client forwarded `--ignore-missing-args` (upstream
     /// `missing_args == 1`).
     ///
-    /// upstream: options.c:2888-2889 - `else if (missing_args == 1 && !am_sender)
+    /// upstream: options.c:2870-2871 - `else if (missing_args == 1 && !am_sender)
     /// args[ac++] = "--ignore-missing-args"`. A vanished top-level source arg is
     /// silently dropped from the file list rather than raising an error.
     pub(super) ignore_missing_args: bool,
 
     /// Backup suffix forwarded by the client (upstream: `--suffix=SUFFIX`).
     ///
-    /// upstream: options.c:2830-2831 - `server_options()` emits
+    /// upstream: options.c:2812-2813 - `server_options()` emits
     /// `safe_arg("--suffix", backup_suffix)` (joined `--suffix=VALUE`) whenever
     /// the suffix differs from the default. The server receiver's backup path
     /// honours it; without recognising the flag the value leaked into the
@@ -339,28 +339,28 @@ pub(super) struct ServerLongFlags {
 
     /// User id/name map spec forwarded by the client (upstream: `--usermap=SPEC`).
     ///
-    /// upstream: options.c:2930-2931 - `safe_arg("--usermap", usermap)` (joined
+    /// upstream: options.c:2912-2913 - `safe_arg("--usermap", usermap)` (joined
     /// `--usermap=VALUE`) is emitted inside the `am_sender` block so a server
     /// receiver maps ownership on the destination.
     pub(super) usermap: Option<String>,
 
     /// Group id/name map spec forwarded by the client (upstream: `--groupmap=SPEC`).
     ///
-    /// upstream: options.c:2933-2934 - `safe_arg("--groupmap", groupmap)` (joined
+    /// upstream: options.c:2915-2916 - `safe_arg("--groupmap", groupmap)` (joined
     /// `--groupmap=VALUE`), emitted alongside `--usermap` in the `am_sender` block.
     pub(super) groupmap: Option<String>,
 
     /// Skip-compress suffix list forwarded by the client (upstream:
     /// `--skip-compress=LIST`).
     ///
-    /// upstream: options.c:2877-2878 - `safe_arg("--skip-compress", skip_compress)`
+    /// upstream: options.c:2859-2860 - `safe_arg("--skip-compress", skip_compress)`
     /// (joined `--skip-compress=VALUE`), emitted in the `else` (client-receiver)
     /// branch so a server sender skips compression for the listed suffixes.
     pub(super) skip_compress: Option<String>,
 
     /// Block size forwarded by the client (upstream: `-B%u`).
     ///
-    /// upstream: options.c:2805-2808 - `asprintf(&arg, "-B%u", block_size)`
+    /// upstream: options.c:2787-2790 - `asprintf(&arg, "-B%u", block_size)`
     /// emits a standalone `-B<digits>` token after the compact flag string.
     /// Recognised here so it is not mistaken for a positional destination path.
     pub(super) block_size: Option<String>,
@@ -453,31 +453,31 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             "--no-zero-copy" => flags.zero_copy_policy = fast_io::ZeroCopyPolicy::Disabled,
             "--write-devices" => flags.write_devices = true,
             "--trust-sender" => flags.trust_sender = true,
-            // upstream: options.c:2911 - bare --partial (no compact 'P').
+            // upstream: options.c:2893 - bare --partial (no compact 'P').
             "--partial" => flags.partial = true,
-            // upstream: options.c:2778-2783 - --specials / --no-specials convey
+            // upstream: options.c:2760-2765 - --specials / --no-specials convey
             // preserve_specials separately from the compact 'D' (devices) letter.
             "--specials" => flags.specials = Some(true),
             "--no-specials" => flags.specials = Some(false),
             "--qsort" => flags.qsort = true,
-            // upstream: options.c:2926-2927 - `if (use_qsort) args[ac++] =
+            // upstream: options.c:2908-2909 - `if (use_qsort) args[ac++] =
             // "--use-qsort"`. This is the spelling server_options() actually
             // emits; it selects the C-library qsort over the stable merge sort
-            // (flist.c:3026). Map it onto the same `qsort` sink as oc's own
+            // (flist.c:2991). Map it onto the same `qsort` sink as oc's own
             // `--qsort` so both forms drive identical flist-ordering behavior.
             "--use-qsort" => flags.qsort = true,
-            // upstream: options.c:3011-3012 - `--open-noatime` forwarded to the
+            // upstream: options.c:2993-2994 - `--open-noatime` forwarded to the
             // sender so it opens source files with O_NOATIME (do_open).
             "--open-noatime" => flags.open_noatime = true,
-            // upstream: options.c:2886-2887 - `--delete-missing-args`
+            // upstream: options.c:2868-2869 - `--delete-missing-args`
             // (missing_args == 2): a vanished top-level source arg becomes a
             // mode-0 sentinel the receiver deletes at the destination.
             "--delete-missing-args" => flags.delete_missing_args = true,
-            // upstream: options.c:2888-2889 - `--ignore-missing-args`
+            // upstream: options.c:2870-2871 - `--ignore-missing-args`
             // (missing_args == 1): a vanished top-level source arg is silently
             // dropped from the file list rather than raising an error.
             "--ignore-missing-args" => flags.ignore_missing_args = true,
-            // upstream: options.c:2866-2867 - `if (force_delete) args[ac++] =
+            // upstream: options.c:2848-2849 - `if (force_delete) args[ac++] =
             // "--force"`, emitted in the am_sender block so it reaches a server
             // acting as the receiver. force_delete only changes behavior when a
             // non-empty directory must be replaced by a non-directory while
@@ -488,7 +488,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // (`--delete` no longer needs `--force`). Recognized here so the arg
             // does not leak into the positional path list.
             "--force" => {}
-            // upstream: options.c:2870-2871 - `if (am_root > 1) args[ac++] =
+            // upstream: options.c:2852-2853 - `if (am_root > 1) args[ac++] =
             // "--super"`, forcing super-user metadata semantics (chown/mknod)
             // even when the receiver is not literally uid 0. oc gates those
             // operations on the runtime `metadata::am_root()` check; when the
@@ -497,7 +497,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // matches upstream. A non-root receiver would only differ by
             // attempting privileged ops that fail with EPERM, which oc omits.
             "--super" => {}
-            // upstream: options.c:3008-3009 - `if (preallocate_files && am_sender)
+            // upstream: options.c:2990-2991 - `if (preallocate_files && am_sender)
             // args[ac++] = "--preallocate"`, forwarded to a server receiver so
             // it fallocate()s each destination file before writing (receiver.c:
             // 320). Preallocation affects only on-disk block allocation, never
@@ -505,31 +505,31 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // results; the flag is carried onto the receiver config to reserve
             // extents up front.
             "--preallocate" => flags.preallocate = true,
-            // upstream: options.c:706 / 2994-2995 - `--no-implied-dirs` is
+            // upstream: options.c:696 / 2976-2977 - `--no-implied-dirs` is
             // forwarded to the sender on a pull. The server-side sender must omit
             // implied parent dirs from the flist at protocol < 30.
             "--no-implied-dirs" => flags.no_implied_dirs = true,
-            // upstream: options.c:633 / 2768-2771 - `--no-r` clears `recurse`
+            // upstream: options.c:623 / 2750-2753 - `--no-r` clears `recurse`
             // on the server-side popt table. A client running `-d --delete`
             // forwards it so the remote can delete with `-d` sans `-r`.
             "--no-r" => flags.no_recurse = true,
-            // upstream: options.c:756 / 2973-2977 - `--no-W` clears `whole_file`
+            // upstream: options.c:746 / 2955-2959 - `--no-W` clears `whole_file`
             // so `--inplace --sparse` streams a delta instead of the whole file.
             "--no-W" => flags.no_whole_file = true,
-            // upstream: options.c:378-379 / 702-704 - the sender packs the
+            // upstream: options.c:368-369 / 692-694 - the sender packs the
             // compact `R` letter for relative mode; when relative paths are off
             // (including the `--files-from` default being explicitly disabled),
             // server_options() emits the long `--no-relative` instead. Recognise
             // and record both so the flag is consumed rather than mistaken for a
             // positional path, and so the server-side sender flattens each
-            // --files-from entry to its basename (flist.c:2373-2384) with no
-            // implied parent directories (options.c:2225-2226).
+            // --files-from entry to its basename (flist.c:2338-2349) with no
+            // implied parent directories (options.c:2207-2208).
             "--no-relative" | "--no-R" => flags.relative = Some(false),
             "--relative" => flags.relative = Some(true),
             "--from0" => flags.from0 = true,
             "--inplace" => flags.inplace = true,
-            // upstream: options.c:1738-1742 - OPT_APPEND increments append_mode
-            // on the server side. server_options() (options.c:2969-2972) emits a
+            // upstream: options.c:1722-1726 - OPT_APPEND increments append_mode
+            // on the server side. server_options() (options.c:2951-2954) emits a
             // single bare `--append` for append_mode == 1 and a doubled
             // `--append --append` for append_mode == 2 (`--append-verify`); the
             // client never forwards the long-form `--append-verify`. So the
@@ -542,21 +542,21 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
                 flags.append = true;
             }
             "--size-only" => flags.size_only = true,
-            // upstream: --numeric-ids is long-form only (options.c:2905-2906)
+            // upstream: --numeric-ids is long-form only (options.c:2887-2888)
             "--numeric-ids" => flags.numeric_ids = true,
-            // upstream: --delete variants are long-form only (options.c:2836-2845)
+            // upstream: --delete variants are long-form only (options.c:2818-2827)
             "--delete" | "--delete-before" | "--delete-during" | "--delete-excluded" => {
                 flags.delete = true;
             }
-            // upstream: generator.c:125 EARLY_DELETE_DONE_MSG = !(delete_during==2
+            // upstream: generator.c:124 EARLY_DELETE_DONE_MSG = !(delete_during==2
             // || delete_after). --delete-delay defers only the goodbye del-stats
             // and the physical unlink; its delete *decision* still runs during the
-            // walk (generator.c:2332), so the delete pass stays early.
+            // walk (generator.c:2315), so the delete pass stays early.
             "--delete-delay" => {
                 flags.delete = true;
                 flags.late_delete = true;
             }
-            // upstream: generator.c:2444-2445 - only --delete-after defers the
+            // upstream: generator.c:2427-2428 - only --delete-after defers the
             // delete *decision* to after the transfer, so a destination
             // `.rsync-filter` merge file transferred by this run protects matching
             // entries at delete time.
@@ -565,31 +565,31 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
                 flags.late_delete = true;
                 flags.delete_after = true;
             }
-            // upstream: options.c:2982-2983 - --remove-source-files is long-form
+            // upstream: options.c:2964-2965 - --remove-source-files is long-form
             // only. --remove-sent-files is the deprecated alias that still names
             // the same option in `parse_arguments()`.
             "--remove-source-files" | "--remove-sent-files" => {
                 flags.remove_source_files = true;
             }
-            // upstream: options.c:3005 - `--copy-devices` is forwarded to the
+            // upstream: options.c:2987 - `--copy-devices` is forwarded to the
             // remote sender (pull) so it streams device contents as a regular
-            // file (flist.c:1451). Long-form only.
+            // file (flist.c:1419). Long-form only.
             "--copy-devices" => flags.copy_devices = true,
-            // upstream: options.c:2856-2857 - --stats forwarded by server_options()
+            // upstream: options.c:2838-2839 - --stats forwarded by server_options()
             // when do_stats was set. The server-side flag drives NDX_DEL_STATS
-            // emission in the goodbye phase (generator.c:2394,2439).
+            // emission in the goodbye phase (generator.c:2377,2422).
             "--stats" => flags.stats = true,
-            // upstream: options.c:2849 - --ignore-existing sent as long-form arg
+            // upstream: options.c:2831 - --ignore-existing sent as long-form arg
             "--ignore-existing" => flags.ignore_existing = true,
-            // upstream: options.c:2851 - --existing (--ignore-non-existing) sent as long-form arg
+            // upstream: options.c:2833 - --existing (--ignore-non-existing) sent as long-form arg
             "--existing" | "--ignore-non-existing" => flags.existing_only = true,
-            // upstream: options.c:2818-2823 - non-ZLIB compression algorithms
+            // upstream: options.c:2800-2805 - non-ZLIB compression algorithms
             // come across the wire as bare long flags. Mapping them to the
             // wire-name strings keeps parity with how the daemon path resolves
             // CompressionAlgorithm in `transfer::run_server_with_handshake`.
             "--new-compress" => flags.compress_choice = Some("zlibx".to_owned()),
             "--old-compress" => flags.compress_choice = Some("zlib".to_owned()),
-            // upstream: options.c:2904-2908 - server_options() emits
+            // upstream: options.c:2886-2890 - server_options() emits
             // `--partial-dir` and its value as TWO separate argv entries.
             // Consume the next arg verbatim as the directory path.
             "--partial-dir" => {
@@ -598,25 +598,25 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
                     idx += 1;
                 }
             }
-            // upstream: options.c:2909-2910 - emitted alongside --partial-dir.
+            // upstream: options.c:2891-2892 - emitted alongside --partial-dir.
             "--delay-updates" => flags.delay_updates = true,
-            // upstream: options.c:3014-3015 - --mkpath forwarded to the server
+            // upstream: options.c:2996-2997 - --mkpath forwarded to the server
             // receiver when the client is the sender (push). --no-mkpath is the
-            // negation (options.c:846). Gates dest-arg path creation below.
+            // negation (options.c:834). Gates dest-arg path creation below.
             "--mkpath" => flags.mkpath = true,
             "--no-mkpath" => flags.mkpath = false,
-            // upstream: options.c:2765-2766 - `--list-only` forwarded when the
+            // upstream: options.c:2747-2748 - `--list-only` forwarded when the
             // client used the explicit flag (list_only > 1). The receiver lists
             // the flist without writing to the destination.
             "--list-only" => flags.list_only = true,
-            // upstream: options.c:2800-2803 - `--msgs2stderr` / `--no-msgs2stderr`
+            // upstream: options.c:2782-2785 - `--msgs2stderr` / `--no-msgs2stderr`
             // control the peer's own diagnostic routing. Recognised here so the
             // flag is consumed rather than treated as a positional path; the
             // server's message routing is handled elsewhere.
             "--msgs2stderr" | "--no-msgs2stderr" => {}
-            // upstream: options.c:2215-2217 - `--old-dirs`/`--old-d` set
+            // upstream: options.c:2197-2199 - `--old-dirs`/`--old-d` set
             // xfer_dirs=4, resolved to recurse=1 plus an appended `- /*/*`
-            // filter. server_options() (options.c:2623) never forwards these
+            // filter. server_options() (options.c:2605) never forwards these
             // deprecated flags; a client encodes them as `-r` in the compact
             // flag string and sends `- /*/*` over the wire filter list. Recognise
             // them here only so a stray forward is consumed rather than mistaken
@@ -640,7 +640,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
                     idx += 2;
                     continue;
                 }
-                // upstream: options.c:2892 - a negative modify_window is
+                // upstream: options.c:2874 - a negative modify_window is
                 // forwarded via the short `-@%d` spelling (e.g. `-@-1`), emitted
                 // as its own argv slot after the compact flag string. The value
                 // is the joined remainder; run.rs parses it via
@@ -648,7 +648,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
                 if let Some(window) = s.strip_prefix("-@") {
                     flags.modify_window = Some(window.to_owned());
                 }
-                // upstream: options.c:2805-2808 - block_size arrives as a
+                // upstream: options.c:2787-2790 - block_size arrives as a
                 // standalone `-B%u` token (e.g. `-B131072`) after the compact
                 // flag string. Guard on trailing digits so only the block-size
                 // spelling is consumed here, never some other `-B...` token.
@@ -688,11 +688,11 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
 ///
 /// # Upstream Reference
 ///
-/// - `options.c:2825-2826` - `--backup-dir`
-/// - `options.c:2944-2945` - `--temp-dir`
-/// - `options.c:2957-2958` - `--copy-dest` / `--link-dest` / `--compare-dest`
+/// - `options.c:2807-2808` - `--backup-dir`
+/// - `options.c:2926-2927` - `--temp-dir`
+/// - `options.c:2939-2940` - `--copy-dest` / `--link-dest` / `--compare-dest`
 ///   via `alt_dest_opt(0)` + `safe_arg("", basis_dir[i])`
-/// - `options.c:2982-2983` - `--files-from`
+/// - `options.c:2964-2965` - `--files-from`
 fn apply_two_arg_long_flag(flag: &str, value: &str, flags: &mut ServerLongFlags) {
     match flag {
         "--compare-dest" => flags.reference_directories.push(ReferenceDirectory::new(
@@ -739,40 +739,40 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
     } else if let Some(value) = s.strip_prefix("--max-delete=") {
         flags.max_delete = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--suffix=") {
-        // upstream: options.c:2830-2831 - safe_arg("--suffix", backup_suffix).
+        // upstream: options.c:2812-2813 - safe_arg("--suffix", backup_suffix).
         flags.backup_suffix = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--usermap=") {
-        // upstream: options.c:2930-2931 - safe_arg("--usermap", usermap).
+        // upstream: options.c:2912-2913 - safe_arg("--usermap", usermap).
         flags.usermap = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--groupmap=") {
-        // upstream: options.c:2933-2934 - safe_arg("--groupmap", groupmap).
+        // upstream: options.c:2915-2916 - safe_arg("--groupmap", groupmap).
         flags.groupmap = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--skip-compress=") {
-        // upstream: options.c:2877-2878 - safe_arg("--skip-compress", skip_compress).
+        // upstream: options.c:2859-2860 - safe_arg("--skip-compress", skip_compress).
         flags.skip_compress = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--iconv=") {
-        // upstream: options.c:2734-2741 - server-side iconv forwarded by client
+        // upstream: options.c:2716-2723 - server-side iconv forwarded by client
         flags.iconv = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--timeout=") {
         // upstream: options.c - server_options() emits `--timeout=%d` from io_timeout
         flags.timeout = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--io-uring-depth=") {
         flags.io_uring_depth = Some(value.to_owned());
-    // upstream: options.c:2818-2823 - `--compress-choice=ALGO` / `--zc=ALGO`
+    // upstream: options.c:2800-2805 - `--compress-choice=ALGO` / `--zc=ALGO`
     // names the negotiated codec when it is not the default CPRES_ZLIB.
     } else if let Some(value) = s
         .strip_prefix("--compress-choice=")
         .or_else(|| s.strip_prefix("--zc="))
     {
         flags.compress_choice = Some(value.to_owned());
-    // upstream: options.c:2772-2776 - `--compress-level=%d` carries the
+    // upstream: options.c:2754-2758 - `--compress-level=%d` carries the
     // explicit compression level so the server codec matches the client.
     } else if let Some(value) = s.strip_prefix("--compress-level=") {
         flags.compression_level = Some(value.to_owned());
-    // upstream: options.c:2768-2780 - client forwards --log-format=%i (or %o,
+    // upstream: options.c:2750-2762 - client forwards --log-format=%i (or %o,
     // %i%I, X) so the server knows whether to generate itemize data.
     } else if s.strip_prefix("--only-write-batch=").is_some() {
-        // upstream: options.c:2868-2869 - server_options() always emits the
+        // upstream: options.c:2850-2851 - server_options() always emits the
         // literal `--only-write-batch=X` placeholder (the real batch path
         // lives on the client). The value carries no server-side meaning; we
         // only latch the flag so run_server_mode forces the receiver into
@@ -781,7 +781,7 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.only_write_batch = true;
     } else if let Some(value) = s.strip_prefix("--log-format=") {
         flags.log_format = Some(value.to_owned());
-    // upstream: options.c:2946-2949 - server_options() forwards info levels.
+    // upstream: options.c:2928-2931 - server_options() forwards info levels.
     // Capture the raw value so run_server_mode can parse it tolerantly via
     // parse_info_flags_server (mirroring `am_server` in parse_output_words).
     } else if let Some(value) = s.strip_prefix("--info=") {
@@ -791,7 +791,7 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
     // (unknown tokens ignored, mirroring `am_server` in parse_output_words).
     } else if let Some(value) = s.strip_prefix("--debug=") {
         flags.debug.push(OsString::from(value));
-    // upstream: options.c:2933-2941 - reference directory args
+    // upstream: options.c:2915-2923 - reference directory args
     } else if let Some(value) = s.strip_prefix("--compare-dest=") {
         flags.reference_directories.push(ReferenceDirectory::new(
             ReferenceDirectoryKind::Compare,
@@ -836,25 +836,25 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--msgs2stderr"
             | "--no-msgs2stderr"
             | "--qsort"
-            // upstream: options.c:2926-2927 - the spelling server_options()
+            // upstream: options.c:2908-2909 - the spelling server_options()
             // actually emits for use_qsort (oc's own forwarder uses --qsort).
             | "--use-qsort"
-            // upstream: options.c:3011-3012 - `--open-noatime` (sender O_NOATIME).
+            // upstream: options.c:2993-2994 - `--open-noatime` (sender O_NOATIME).
             | "--open-noatime"
-            // upstream: options.c:2866-2867 - `--force` (force_delete), am_sender
+            // upstream: options.c:2848-2849 - `--force` (force_delete), am_sender
             // block so it reaches a server receiver.
             | "--force"
-            // upstream: options.c:2870-2871 - `--super` (am_root > 1).
+            // upstream: options.c:2852-2853 - `--super` (am_root > 1).
             | "--super"
-            // upstream: options.c:3008-3009 - `--preallocate` (preallocate_files).
+            // upstream: options.c:2990-2991 - `--preallocate` (preallocate_files).
             | "--preallocate"
-            // upstream: options.c:2886-2889 - missing-args cooperation flags.
+            // upstream: options.c:2868-2871 - missing-args cooperation flags.
             | "--delete-missing-args"
             | "--ignore-missing-args"
             | "--no-implied-dirs"
-            // upstream: options.c:2771/2977/2991 - server_options() emits these
+            // upstream: options.c:2753/2959/2973 - server_options() emits these
             // negations; the server-side popt table clears recurse/whole_file/
-            // relative_paths (options.c:633/756/703). Recognise them so they are
+            // relative_paths (options.c:623/746/693). Recognise them so they are
             // not mistaken for positional destination paths.
             | "--no-r"
             | "--no-W"
@@ -899,7 +899,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--copy-dest=")
         || arg.starts_with("--link-dest=")
         || arg.starts_with("--modify-window=")
-        // upstream: options.c:2892 - a negative modify_window arrives as the
+        // upstream: options.c:2874 - a negative modify_window arrives as the
         // short `-@%d` token (e.g. `-@-1`) after the compact flag string, so it
         // must be recognised here or it leaks into the positional path list.
         || arg.starts_with("-@")
@@ -910,7 +910,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--stop-after=")
         || arg.starts_with("--files-from=")
         || arg.starts_with("--max-delete=")
-        // upstream: options.c:2830-2831 / 2930-2931 / 2933-2934 / 2877-2878 -
+        // upstream: options.c:2812-2813 / 2912-2913 / 2915-2916 / 2859-2860 -
         // server_options() emits these as joined `--flag=value` via safe_arg().
         // Recognise them so they are not mistaken for positional destination
         // paths (same positional-dest leak class as --partial-dir / alt-dest).
@@ -918,7 +918,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--usermap=")
         || arg.starts_with("--groupmap=")
         || arg.starts_with("--skip-compress=")
-        // upstream: options.c:2805-2808 - block_size arrives as a standalone
+        // upstream: options.c:2787-2790 - block_size arrives as a standalone
         // `-B%u` token. Guard on trailing digits so only that spelling matches.
         || (arg.starts_with("-B")
             && arg.len() > 2
@@ -928,13 +928,13 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--io-uring-depth=")
         || arg.starts_with("--log-format=")
         || arg.starts_with("--info=")
-        // upstream: options.c:1793 - `--debug=FLAGS` parsed via
+        // upstream: options.c:1777 - `--debug=FLAGS` parsed via
         // parse_output_words(debug_words, ...). The client forwards it like
         // --info; recognise it so the value is consumed, not mistaken for a
         // positional destination path.
         || arg.starts_with("--debug=")
         || arg.starts_with("--partial-dir=")
-        // upstream: options.c:2868-2869 - `--only-write-batch=X` reaches a
+        // upstream: options.c:2850-2851 - `--only-write-batch=X` reaches a
         // server receiver on a push. Recognise it so the placeholder token is
         // not mistaken for a positional destination path.
         || arg.starts_with("--only-write-batch=")
@@ -958,11 +958,11 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
 ///
 /// # Upstream Reference
 ///
-/// - `options.c:2825-2826` - `--backup-dir`
-/// - `options.c:2944-2945` - `--temp-dir`
-/// - `options.c:2957-2958` - `--copy-dest` / `--link-dest` / `--compare-dest`
+/// - `options.c:2807-2808` - `--backup-dir`
+/// - `options.c:2926-2927` - `--temp-dir`
+/// - `options.c:2939-2940` - `--copy-dest` / `--link-dest` / `--compare-dest`
 ///   (via `alt_dest_opt(0)`)
-/// - `options.c:2982-2983` - `--files-from`
+/// - `options.c:2964-2965` - `--files-from`
 pub(super) fn is_two_arg_server_long_flag(arg: &str) -> bool {
     matches!(
         arg,

--- a/crates/cli/src/frontend/server/parse.rs
+++ b/crates/cli/src/frontend/server/parse.rs
@@ -29,7 +29,7 @@ pub(super) fn parse_server_flag_string_and_args(args: &[OsString]) -> (String, V
         let arg_str = arg.to_string_lossy();
 
         if is_known_server_long_flag(&arg_str) {
-            // upstream: options.c:2904-2908 - `--partial-dir` is emitted as
+            // upstream: options.c:2886-2890 - `--partial-dir` is emitted as
             // TWO separate argv entries by server_options(), so the value
             // that immediately follows must also be skipped here. Without
             // this, the partial-dir VALUE leaks into the positional list and

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -65,7 +65,7 @@ where
     // upstream: main.c::read_args() merges cmdline args with stdin args
     // under --protect-args / secluded-args. rsync.c:283
     // send_protected_args() rewrites args[i] to "rsync" at the NULL
-    // split inserted by options.c:2763; io.c:1324 read_args() then
+    // split inserted by options.c:2745; io.c:1308 read_args() then
     // re-runs parse_arguments() on the server side.
     let effective_args: Vec<OsString>;
     let effective_slice: &[OsString] = if secluded_args {
@@ -120,7 +120,7 @@ where
             }
         };
 
-    // upstream: main.c:1289 - "keep_dirlinks = 0; /* Must be disabled on the
+    // upstream: main.c:1271 - "keep_dirlinks = 0; /* Must be disabled on the
     // sender. */". keep-dirlinks is a receiver-only feature (it follows a
     // destination dir-symlink); the sender reads the source, never the
     // destination, so force it off whenever this process is the sender
@@ -137,11 +137,11 @@ where
     }
 
     // upstream: options.c set_output_verbosity - the packed `-v` count maps to
-    // info/debug levels via info_verbosity[] (options.c:249-253) before any
+    // info/debug levels via info_verbosity[] (options.c:239-243) before any
     // explicit --info override is layered on. Without this, the server thread's
     // thread-local verbosity stays at the zero default, so `-vv` never raises
     // info.name to 2 and the itemize line for an unchanged entry
-    // (INFO_GTE(NAME, 2), generator.c:589-590) is suppressed - exactly the
+    // (INFO_GTE(NAME, 2), generator.c:582-583) is suppressed - exactly the
     // gap that fails the upstream `itemize` test under SSH `--server` mode,
     // where `-vv` arrives as packed `v` letters rather than `--info=name2`.
     if config.flags.verbose_level > 0 {
@@ -171,11 +171,11 @@ where
         }
     }
 
-    // upstream: options.c:1793 / 485 - the client forwards explicitly-set debug
+    // upstream: options.c:1777 / 475 - the client forwards explicitly-set debug
     // levels (`--debug=hlink4`) the same way it forwards `--info`. Apply each
     // forwarded token to the thread-local debug config so debug_log! callsites on
     // the server side honour the client's request. Unknown tokens are silently
-    // ignored because `am_server` (options.c:485), so a newer client can forward
+    // ignored because `am_server` (options.c:475), so a newer client can forward
     // categories this build has not learned yet without aborting the transfer.
     for value in &long_flags.debug {
         let text = value.to_string_lossy();
@@ -193,63 +193,63 @@ where
     config.write.io_uring_policy = long_flags.io_uring_policy;
     config.write.zero_copy_policy = long_flags.zero_copy_policy;
     config.write.write_devices = long_flags.write_devices;
-    // upstream: options.c:2511 - server always trusts sender (am_server implies trust)
+    // upstream: options.c:2493 - server always trusts sender (am_server implies trust)
     config.trust_sender = true;
     config.qsort = long_flags.qsort;
     config.file_selection.files_from_path = long_flags.files_from;
     config.file_selection.from0 = long_flags.from0;
     config.write.inplace = long_flags.inplace;
-    // upstream: options.c:2418-2430 - append mode implies inplace; the transfer
+    // upstream: options.c:2400-2412 - append mode implies inplace; the transfer
     // layer derives that internally (transfer_ops.rs `use_inplace = inplace ||
     // append`), so only the append flags need forwarding. append_verify
     // (append_mode == 2) folds the on-disk prefix into the whole-file checksum
-    // (receiver.c:464, match.c:373). Mirrors the daemon long-form parser.
+    // (receiver.c:357, match.c:373). Mirrors the daemon long-form parser.
     config.flags.append = long_flags.append;
     config.flags.append_verify = long_flags.append_verify;
-    // upstream: receiver.c:390 - a server receiver that was passed --preallocate
+    // upstream: receiver.c:320 - a server receiver that was passed --preallocate
     // fallocate()s each destination file to its eventual length before writing.
     config.flags.preallocate = long_flags.preallocate;
     config.file_selection.size_only = long_flags.size_only;
-    // upstream: options.c:3011-3012 - `--open-noatime` forwarded to the sender so
+    // upstream: options.c:2993-2994 - `--open-noatime` forwarded to the sender so
     // it opens source files with O_NOATIME (do_open), leaving atime untouched.
     config.write.open_noatime = long_flags.open_noatime;
-    // upstream: options.c:2886-2889 - `--delete-missing-args` (missing_args == 2)
+    // upstream: options.c:2868-2871 - `--delete-missing-args` (missing_args == 2)
     // and `--ignore-missing-args` (missing_args == 1) govern how a vanished
     // top-level source arg is handled when building the file list. Mirrors the
     // daemon long-form parser (long_form_args.rs).
     config.file_selection.delete_missing_args = long_flags.delete_missing_args;
     config.file_selection.ignore_missing_args = long_flags.ignore_missing_args;
-    // upstream: options.c:2911 - bare --partial (no compact 'P' letter) tells the
+    // upstream: options.c:2893 - bare --partial (no compact 'P' letter) tells the
     // receiver to keep interrupted temp files. OR with the compact value so a
     // legacy client that still packs 'P' is not clobbered.
     if long_flags.partial {
         config.flags.partial = true;
     }
-    // upstream: options.c:2778-2783 - --specials / --no-specials override the
+    // upstream: options.c:2760-2765 - --specials / --no-specials override the
     // specials bit that the compact 'D' letter set to preserve_devices's value.
     if let Some(specials) = long_flags.specials {
         config.flags.specials = specials;
     }
     config.file_selection.ignore_existing = long_flags.ignore_existing;
     config.file_selection.existing_only = long_flags.existing_only;
-    // upstream: options.c:2994-2995 / flist.c:2503 - `--no-implied-dirs` is
+    // upstream: options.c:2976-2977 / flist.c:2468 - `--no-implied-dirs` is
     // forwarded to the sender on a pull. As the server-side sender this process
     // must omit the implied parent dirs from the flist at protocol < 30; at
-    // protocol >= 30 they are always sent (flist.c:2292-2293).
+    // protocol >= 30 they are always sent (flist.c:2257-2258).
     config.flags.no_implied_dirs = long_flags.no_implied_dirs;
-    // upstream: options.c:633 / 2768-2771 - `--no-r` clears `recurse` via the
+    // upstream: options.c:623 / 2750-2753 - `--no-r` clears `recurse` via the
     // server popt table. The client emits it under `-d --delete` so the remote
     // can delete with `-d` sans `-r`. It overrides the compact `r` letter that
     // `ParsedServerFlags::parse` set, so apply it only when forwarded.
     if long_flags.no_recurse {
         config.flags.recursive = false;
     }
-    // upstream: options.c:756 / 2973-2977 - `--no-W` clears `whole_file` so
+    // upstream: options.c:746 / 2955-2959 - `--no-W` clears `whole_file` so
     // `--inplace --sparse` streams a delta. Overrides the compact `W` letter.
     if long_flags.no_whole_file {
         config.flags.whole_file = false;
     }
-    // upstream: options.c:110-111 / 378-379 - relative mode arrives as the
+    // upstream: options.c:109-110 / 368-369 - relative mode arrives as the
     // compact `R` letter (already parsed into config.flags.relative) or as the
     // long `--no-relative`. Apply the long form when present so an explicit
     // `--no-relative` (which the peer sends without the `R` letter) forces
@@ -259,38 +259,38 @@ where
     }
     config.flags.numeric_ids = core::server::NumericIds::from_client(long_flags.numeric_ids);
     config.flags.delete = long_flags.delete;
-    // upstream: generator.c:125 - --delete-after / --delete-delay both defer the
+    // upstream: generator.c:124 - --delete-after / --delete-delay both defer the
     // goodbye del-stats emission.
     config.deletion.late_delete = long_flags.late_delete;
-    // upstream: generator.c:2444-2445 - only --delete-after defers the delete
+    // upstream: generator.c:2427-2428 - only --delete-after defers the delete
     // *decision* to after the transfer, so the per-directory `.rsync-filter`
     // merge files it just received protect matching destination entries at delete
     // time. --delete-delay decides during the walk and only defers the unlink.
     config.deletion.delete_after = long_flags.delete_after;
-    // upstream: options.c:2982-2983 - `--remove-source-files` is forwarded
+    // upstream: options.c:2964-2965 - `--remove-source-files` is forwarded
     // long-form when the client requested sender-side removal. The flag is
     // consumed by the sender's `successful_send()` after each transferred
     // file is acknowledged.
     config.flags.remove_source_files = long_flags.remove_source_files;
-    // upstream: options.c:3005 / flist.c:1451 - `--copy-devices` is forwarded to
+    // upstream: options.c:2987 / flist.c:1419 - `--copy-devices` is forwarded to
     // the remote sender on a pull. As the server-side sender, this process must
     // convert each block/char device into a regular file and stream its bytes.
     config.flags.copy_devices = long_flags.copy_devices;
-    // upstream: options.c:3014-3015 - `--mkpath` is forwarded long-form to the
+    // upstream: options.c:2996-2997 - `--mkpath` is forwarded long-form to the
     // server receiver on a push. The receiver gates dest-arg path creation on
     // this flag: without it, a missing ancestor chain is an error
-    // (`main.c:797` single `do_mkdir`); with it, the whole chain is created
-    // (`main.c:745` `make_path`).
+    // (`main.c:788` single `do_mkdir`); with it, the whole chain is created
+    // (`main.c:736` `make_path`).
     config.flags.mkpath = long_flags.mkpath;
-    // upstream: options.c:2765-2766 / generator.c:1261 - `--list-only` forwarded
+    // upstream: options.c:2747-2748 / generator.c:1249 - `--list-only` forwarded
     // by the client tells the server to render the flist without writing to the
     // destination (`TransferFlags::skip_dest_writes`).
     config.flags.list_only = long_flags.list_only;
-    // upstream: options.c:2868-2869 / main.c:1863 - a push sender forwards
+    // upstream: options.c:2850-2851 / main.c:1839 - a push sender forwards
     // `--only-write-batch=X`; on the receiver, `write_batch < 0` forces
     // `dry_run = 1` (no destination writes) while `do_xfers` stays 1 so the
     // generator still sends real block checksums. The client records the batch
-    // locally and streams no delta data over the wire (sender.c:221), so the
+    // locally and streams no delta data over the wire (sender.c:217), so the
     // receiver runs the dedicated only-write-batch loop: send sum heads, read
     // the bare NDX+attrs echo, write nothing to the destination. Only the
     // receiver role ever sees this flag - server_options() emits it inside the
@@ -299,18 +299,18 @@ where
         config.flags.only_write_batch = true;
         config.flags.dry_run = true;
     }
-    // upstream: options.c:2064-2066 - do_stats sets info_levels[INFO_STATS] >= 2.
+    // upstream: options.c:2046-2048 - do_stats sets info_levels[INFO_STATS] >= 2.
     // The server-side flag must be set so the generator emits NDX_DEL_STATS
-    // during the goodbye phase (generator.c:2394,2439).
+    // during the goodbye phase (generator.c:2377,2422).
     config.do_stats = long_flags.stats;
     config.reference_directories = long_flags.reference_directories;
-    // upstream: options.c:2830-2831 - server_options() emits `--suffix=SUFFIX`
+    // upstream: options.c:2812-2813 - server_options() emits `--suffix=SUFFIX`
     // (safe_arg) when the backup suffix differs from the default. The server's
     // backup path honours it via effective_backup_suffix().
     if let Some(suffix) = &long_flags.backup_suffix {
         config.backup_suffix = Some(suffix.clone());
     }
-    // upstream: options.c:2930-2931 / 2933-2934 - `--usermap=SPEC` / `--groupmap=SPEC`
+    // upstream: options.c:2912-2913 / 2915-2916 - `--usermap=SPEC` / `--groupmap=SPEC`
     // are emitted in the am_sender block so the server receiver maps ownership.
     // A malformed spec leaves the field unset (mirroring the daemon path,
     // module_access/client_args/long_form_args.rs, and upstream's fall-through
@@ -325,16 +325,16 @@ where
     {
         config.group_mapping = Some(mapping);
     }
-    // upstream: options.c:2877-2878 - `--skip-compress=LIST` is forwarded to the
-    // server sender, but token.c:226 set_compression()'s per-file suffix lookup
+    // upstream: options.c:2859-2860 - `--skip-compress=LIST` is forwarded to the
+    // server sender, but token.c:225 set_compression()'s per-file suffix lookup
     // is compiled out under `#if 0` ("No compression algorithms currently allow
     // mid-stream changing of the level."). So a negotiated codec frames EVERY
-    // file (token.c:1095 send_token() dispatches on the global do_compression);
+    // file (token.c:1065 send_token() dispatches on the global do_compression);
     // the suffix list never switches framing per file. Applying it here would
     // emit plain tokens for a skip-matched file and desync the client-receiver's
     // session-level codec reader. The arg is accepted for compatibility but has
     // no per-file wire effect.
-    // upstream: options.c:2904-2908 - `--partial-dir DIR` forwarded by the
+    // upstream: options.c:2886-2890 - `--partial-dir DIR` forwarded by the
     // sender. The server-side receiver moves interrupted temp files into this
     // directory and looks for resume basis files there. Without applying this
     // value, transfers that pin `--protocol=28` (where the client cannot
@@ -347,17 +347,17 @@ where
         config.partial_dir = Some(path);
         config.has_partial_dir = true;
     }
-    // upstream: options.c:2909-2910 - `--delay-updates` rides alongside
+    // upstream: options.c:2891-2892 - `--delay-updates` rides alongside
     // `--partial-dir` whenever both are active.
     if long_flags.delay_updates {
         config.write.delay_updates = true;
     }
 
-    // upstream: options.c:2363-2366 - the server parses --log-format to set
+    // upstream: options.c:2345-2348 - the server parses --log-format to set
     // stdout_format_has_i, which controls generator itemize output. `%i` sets
     // has_i = 1 (itemize significant items); `%I` sets has_i = 2, the `-ii`
     // level that also itemizes unchanged entries. The client forwards
-    // `--log-format=%i%I` for `-ii` (options.c:174-185 server_options), so a
+    // `--log-format=%i%I` for `-ii` (options.c:164-175 server_options), so a
     // server that sees `%I` must also emit unchanged rows.
     if let Some(fmt) = &long_flags.log_format {
         if fmt.contains("%i") || fmt.contains("%I") {
@@ -370,7 +370,7 @@ where
 
     // upstream: rsync.c:85-147 setup_iconv() - server opens iconv against the
     // wire's UTF-8 charset using the local-side spec forwarded by the client
-    // (options.c:2734-2741). Without this wiring the receiver/generator skip
+    // (options.c:2716-2723). Without this wiring the receiver/generator skip
     // the iconv hook and write/read raw bytes verbatim, breaking transfers
     // with --iconv=LOCAL,REMOTE where the on-disk filenames differ between
     // the two sides.
@@ -389,7 +389,7 @@ where
         }
     }
 
-    // upstream: options.c:2818-2823 - `--compress-choice`, `--new-compress`, and
+    // upstream: options.c:2800-2805 - `--compress-choice`, `--new-compress`, and
     // `--old-compress` carry the explicit codec when the negotiated algorithm is
     // not the default CPRES_ZLIB. Without forwarding it into `ServerConfig`, the
     // SSH server path skips compression entirely (handshake.client_args is None
@@ -410,7 +410,7 @@ where
         }
     }
 
-    // upstream: options.c:2772-2776 - `--compress-level=N` forwarded by the
+    // upstream: options.c:2754-2758 - `--compress-level=N` forwarded by the
     // client sets `do_compression_level` on the server so its codec compresses
     // at the same level. The value is the numeric 0-9 that the client already
     // clamped before forwarding.
@@ -465,7 +465,7 @@ where
                     let mut allowed = vec![root];
 
                     // UTS-V3-D: a remote files-from path (upstream
-                    // `options.c:2962` -> server gets `--files-from <path>`)
+                    // `options.c:2944` -> server gets `--files-from <path>`)
                     // sits outside the destination tree. The receiver
                     // opens it in `forward_files_from_to_sender` to push
                     // filenames back to the sender; the landlock allowlist
@@ -486,7 +486,7 @@ where
                         }
                     }
 
-                    // upstream: generator.c:1368 - with --keep-dirlinks the
+                    // upstream: generator.c:1356 - with --keep-dirlinks the
                     // receiver follows a destination symlink that resolves to a
                     // directory and writes through it, which upstream permits
                     // even when the target lives outside the transfer root. The
@@ -518,7 +518,7 @@ where
         }
     }
 
-    // upstream: main.c:1280 `start_server()` returns into `exit_cleanup(0)`,
+    // upstream: main.c:1262 `start_server()` returns into `exit_cleanup(0)`,
     // which on a clean exit just runs `close_all()` + `exit()`. The kernel
     // closes the inherited stdio descriptors as the process tears down, and
     // the peer (whether upstream rsync over SSH, lsh.sh, or `--rsh=fake_rsh`)
@@ -554,7 +554,7 @@ where
 /// entries so a hostile or pathological destination tree cannot stall receiver
 /// startup. Mirrors upstream's `--keep-dirlinks` trust model: the destination
 /// symlinks the user pre-established are followed even when their targets sit
-/// outside the transfer root (`generator.c:1368`).
+/// outside the transfer root (`generator.c:1356`).
 fn collect_keep_dirlink_targets(root: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
     const MAX_DEPTH: usize = 32;
     const MAX_ENTRIES: usize = 100_000;
@@ -662,18 +662,18 @@ fn apply_value_flags<Err: Write>(
         }
     }
 
-    // upstream: options.c:1959-1966 - server-side `--max-alloc` is parsed and
+    // upstream: options.c:1943-1950 - server-side `--max-alloc` is parsed and
     // applied to the local allocator. We forward it from the client and
     // enforce the cap on the server's buffer pool.
     if let Some(alloc_str) = &long_flags.max_alloc {
         match super::super::execution::parse_max_alloc_argument(std::ffi::OsStr::new(alloc_str)) {
             Ok(limit) => {
                 if limit == 0 {
-                    // upstream: options.c:1982 `if (!max_alloc) max_alloc =
+                    // upstream: options.c:1966 `if (!max_alloc) max_alloc =
                     // SIZE_MAX;` - a forwarded `--max-alloc=0` means unlimited.
                     protocol::set_max_alloc(usize::MAX);
                 } else if let Ok(limit_usize) = usize::try_from(limit) {
-                    // upstream: options.c:1975-1981 - the server rewrites its own
+                    // upstream: options.c:1959-1965 - the server rewrites its own
                     // `max_alloc` global from the forwarded `--max-alloc`, which
                     // bounds the xattr datum decoders on the receive path
                     // (util2.c:75).

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -208,7 +208,7 @@ fn detect_secluded_args_ignores_program_name() {
 
 #[test]
 fn detect_secluded_args_in_compact_flag_string() {
-    // upstream: options.c:2622 - server_options() puts 's' at argstr[1]
+    // upstream: options.c:2604 - server_options() puts 's' at argstr[1]
     // when protect_args is active, producing e.g. `-slogDtprze.iLsfxCIvu`.
     let args: Vec<OsString> = vec![
         OsString::from("rsync"),
@@ -237,7 +237,7 @@ fn detect_secluded_args_in_compact_flag_string_middle() {
 fn detect_secluded_args_ignores_s_in_capability_string() {
     // The 's' after the dot is the symlink-iconv capability char,
     // not secluded-args. Must not trigger secluded-args detection.
-    // upstream: options.c:3045 - 's' in capability string = ICONV_OPTION
+    // upstream: options.c:3027 - 's' in capability string = ICONV_OPTION
     let args: Vec<OsString> = vec![
         OsString::from("rsync"),
         OsString::from("--server"),
@@ -340,7 +340,7 @@ fn parse_server_args_skips_value_bearing_long_flags() {
 }
 
 /// Regression for UTS-SLDB.REOPEN (`symlink-dirlink-basis_test.py` test 7):
-/// upstream `server_options()` (options.c:2904-2908) emits `--partial-dir`
+/// upstream `server_options()` (options.c:2886-2890) emits `--partial-dir`
 /// and its value as TWO separate argv entries. Both `--partial-dir` itself
 /// and the value that follows must be stripped from the positional list,
 /// otherwise the value (`.rsync-partial`) shows up as a destination path
@@ -382,7 +382,7 @@ fn parse_server_args_skips_joined_partial_dir_flag() {
 }
 
 /// Regression for network `--append` over SSH: upstream `server_options()`
-/// (options.c:2969-2972) emits a single bare `--append` for `append_mode == 1`.
+/// (options.c:2951-2954) emits a single bare `--append` for `append_mode == 1`.
 /// Without a match arm the flag fell through to `positional_args[0]`
 /// (parse.rs), so the receiver tried to `mkdir` a destination root literally
 /// named `--append` and exited 12 ("failed to create destination root
@@ -416,10 +416,10 @@ fn long_flags_captures_single_append() {
 }
 
 /// Upstream wire-encodes `--append-verify` (`append_mode == 2`) as a doubled
-/// bare `--append` (options.c:2970-2972); the client never sends the long-form
+/// bare `--append` (options.c:2952-2954); the client never sends the long-form
 /// `--append-verify`. The second occurrence must set `append_verify`,
 /// mirroring the daemon long-form parser and upstream's `am_server`
-/// `append_mode++` (options.c:1738-1742).
+/// `append_mode++` (options.c:1722-1726).
 #[test]
 fn long_flags_captures_doubled_append_as_verify() {
     let args = vec![
@@ -440,7 +440,7 @@ fn append_is_known_server_long_flag() {
 }
 
 /// Task #292: upstream server_options() emits the long `--no-relative` when
-/// relative paths are off (options.c:378-379), and it must be recognised so it
+/// relative paths are off (options.c:368-369), and it must be recognised so it
 /// is consumed as a flag - not treated as the transfer-root positional path.
 /// This reproduces the exact argv an upstream client sends for a
 /// `--files-from --no-relative` pull.
@@ -504,7 +504,7 @@ fn long_flags_captures_joined_partial_dir() {
 }
 
 /// Regression for the `--only-write-batch=X` server arg (task #296). Upstream
-/// `server_options()` (options.c:2868-2869) emits the literal placeholder
+/// `server_options()` (options.c:2850-2851) emits the literal placeholder
 /// `--only-write-batch=X` to a push receiver. Before recognition it leaked into
 /// the positional list and the receiver tried to create a destination root
 /// literally named `--only-write-batch=X` (exit 12). It must be captured as a
@@ -648,7 +648,7 @@ fn long_flags_receiver() {
 /// copies it onto `config.flags.remove_source_files` so the sender
 /// generator can act on it after a successful transfer.
 ///
-/// upstream: options.c:2982-2983 - `server_options()` emits
+/// upstream: options.c:2964-2965 - `server_options()` emits
 /// `--remove-source-files` whenever the client requested it.
 #[test]
 fn long_flags_remove_source_files() {
@@ -686,7 +686,7 @@ fn remove_source_files_recognised_as_known_long_flag() {
     assert!(is_known_server_long_flag("--remove-sent-files"));
 }
 
-/// upstream: options.c:2917-2921 - server_options() emits `--copy-unsafe-links`
+/// upstream: options.c:2899-2903 - server_options() emits `--copy-unsafe-links`
 /// and `--safe-links` as bare flags when the matching booleans are set on the
 /// client side. The flag-string scanner must register them so the path that
 /// follows is not consumed as a positional argument (which causes the sender
@@ -788,7 +788,7 @@ fn long_flags_io_uring_depth_default_is_none() {
     assert!(flags.io_uring_depth.is_none());
 }
 
-// upstream: options.c:2946-2949 - server_options() forwards --info=FLAGS so
+// upstream: options.c:2928-2931 - server_options() forwards --info=FLAGS so
 // the server must recognise it as a long flag and not let it leak into the
 // positional path list.
 #[test]
@@ -819,7 +819,7 @@ fn long_flags_write_devices() {
     assert!(flags.write_devices);
 }
 
-// upstream: options.c:3005 - a PULL client (upstream or oc) forwards
+// upstream: options.c:2987 - a PULL client (upstream or oc) forwards
 // `--copy-devices` to the server sender. The flag-string scanner must treat it
 // as a known long flag; otherwise it leaks into the positional list and becomes
 // a stray source/destination path.
@@ -839,7 +839,7 @@ fn copy_devices_is_known_and_not_positional() {
     assert_eq!(pos_args, vec![OsString::from("src/")]);
 }
 
-// upstream: options.c:2772-2776 - a client that pins `--compress-level=N`
+// upstream: options.c:2754-2758 - a client that pins `--compress-level=N`
 // forwards it to the server. The flag-string scanner must treat it as a known
 // long flag; otherwise it leaks into the positional list and the receiver
 // fails with `failed to create destination root --compress-level=6` (exit 12).
@@ -858,7 +858,7 @@ fn compress_level_is_known_and_not_positional() {
     assert_eq!(pos_args, vec![OsString::from("dst/")]);
 }
 
-// upstream: options.c:2772-2776 - the forwarded level is captured so the
+// upstream: options.c:2754-2758 - the forwarded level is captured so the
 // server codec compresses at the same level the client requested.
 #[test]
 fn long_flags_capture_compress_level() {
@@ -870,7 +870,7 @@ fn long_flags_capture_compress_level() {
     assert_eq!(flags.compression_level.as_deref(), Some("6"));
 }
 
-// upstream: options.c:2830-2831 - `server_options()` emits
+// upstream: options.c:2812-2813 - `server_options()` emits
 // `safe_arg("--suffix", backup_suffix)` (joined `--suffix=VALUE`). Without a
 // match arm the token leaked into the positional list and the receiver failed
 // with `failed to create destination root --suffix=.bak` (exit 12).
@@ -893,7 +893,7 @@ fn suffix_is_known_and_not_positional() {
     );
 }
 
-// upstream: options.c:2830-2831 - the forwarded suffix is captured so the
+// upstream: options.c:2812-2813 - the forwarded suffix is captured so the
 // server's backup path uses the same suffix the client requested.
 #[test]
 fn long_flags_capture_suffix() {
@@ -902,7 +902,7 @@ fn long_flags_capture_suffix() {
     assert_eq!(flags.backup_suffix.as_deref(), Some(".bak"));
 }
 
-// upstream: options.c:2930-2931 - `server_options()` emits
+// upstream: options.c:2912-2913 - `server_options()` emits
 // `safe_arg("--usermap", usermap)` (joined `--usermap=VALUE`) in the am_sender
 // block. It must be recognised so a server receiver maps ownership rather than
 // treating the token as a positional destination path.
@@ -925,7 +925,7 @@ fn usermap_is_known_and_not_positional() {
     );
 }
 
-// upstream: options.c:2930-2931 - the forwarded usermap spec is captured so the
+// upstream: options.c:2912-2913 - the forwarded usermap spec is captured so the
 // server receiver can parse it into a UserMapping and remap ownership.
 #[test]
 fn long_flags_capture_usermap() {
@@ -937,7 +937,7 @@ fn long_flags_capture_usermap() {
     assert_eq!(flags.usermap.as_deref(), Some("0:1000"));
 }
 
-// upstream: options.c:2933-2934 - `server_options()` emits
+// upstream: options.c:2915-2916 - `server_options()` emits
 // `safe_arg("--groupmap", groupmap)` (joined `--groupmap=VALUE`) alongside
 // `--usermap`. Wildcard specs (`*:GID`) must survive intact into the flag list.
 #[test]
@@ -959,7 +959,7 @@ fn groupmap_is_known_and_not_positional() {
     );
 }
 
-// upstream: options.c:2933-2934 - the forwarded groupmap spec is captured
+// upstream: options.c:2915-2916 - the forwarded groupmap spec is captured
 // verbatim (wildcard intact) for GroupMapping::parse.
 #[test]
 fn long_flags_capture_groupmap() {
@@ -971,7 +971,7 @@ fn long_flags_capture_groupmap() {
     assert_eq!(flags.groupmap.as_deref(), Some("*:5678"));
 }
 
-// upstream: options.c:2877-2878 - `server_options()` emits
+// upstream: options.c:2859-2860 - `server_options()` emits
 // `safe_arg("--skip-compress", skip_compress)` (joined `--skip-compress=VALUE`)
 // in the client-receiver branch so a server sender skips compression for the
 // listed suffixes. It must not leak into the positional path list.
@@ -995,7 +995,7 @@ fn skip_compress_is_known_and_not_positional() {
     );
 }
 
-// upstream: options.c:2877-2878 - the forwarded skip-compress list is captured
+// upstream: options.c:2859-2860 - the forwarded skip-compress list is captured
 // so the server sender can build a SkipCompressList.
 #[test]
 fn long_flags_capture_skip_compress() {
@@ -1007,7 +1007,7 @@ fn long_flags_capture_skip_compress() {
     assert_eq!(flags.skip_compress.as_deref(), Some("gz/zip/jpg"));
 }
 
-// upstream: options.c:2805-2808 - block_size is forwarded as a standalone
+// upstream: options.c:2787-2790 - block_size is forwarded as a standalone
 // `-B%u` token (e.g. `-B131072`) after the compact flag string. Without
 // recognition the token leaked into the positional list and the receiver
 // failed with `failed to create destination root -B131072` (exit 12).
@@ -1030,7 +1030,7 @@ fn block_size_is_known_and_not_positional() {
     );
 }
 
-// upstream: options.c:2805-2808 - the forwarded block-size digits are captured.
+// upstream: options.c:2787-2790 - the forwarded block-size digits are captured.
 #[test]
 fn long_flags_capture_block_size() {
     let args = vec![OsString::from("--server"), OsString::from("-B131072")];
@@ -1049,7 +1049,7 @@ fn block_size_guard_rejects_non_digit_suffix() {
     assert_eq!(flags.block_size, None);
 }
 
-// upstream: options.c:2765-2766 - the server recognises the forwarded
+// upstream: options.c:2747-2748 - the server recognises the forwarded
 // `--list-only` and records it so the transfer lists without writing.
 #[test]
 fn long_flags_capture_list_only() {
@@ -1058,7 +1058,7 @@ fn long_flags_capture_list_only() {
     assert!(flags.list_only);
 }
 
-// upstream: options.c:2800-2803 - `--msgs2stderr` / `--no-msgs2stderr` are
+// upstream: options.c:2782-2785 - `--msgs2stderr` / `--no-msgs2stderr` are
 // recognised (consumed) so they never leak into the positional path list.
 #[test]
 fn msgs2stderr_flags_are_known_and_not_positional() {
@@ -1091,7 +1091,7 @@ fn long_flags_qsort() {
     assert!(flags.qsort);
 }
 
-// upstream: options.c:2911 - bare --partial (no compact 'P') tells the receiver
+// upstream: options.c:2893 - bare --partial (no compact 'P') tells the receiver
 // to keep interrupted temp files. The server must parse it, or an oc/upstream
 // client's PUSH loses keep_partial on the oc receiver.
 #[test]
@@ -1109,7 +1109,7 @@ fn long_flags_partial_default_none() {
     assert!(!flags.partial);
 }
 
-// upstream: options.c:2778-2783 - --specials / --no-specials convey
+// upstream: options.c:2760-2765 - --specials / --no-specials convey
 // preserve_specials separately from the compact 'D' (devices) letter.
 #[test]
 fn long_flags_specials_and_no_specials() {
@@ -1128,10 +1128,10 @@ fn long_flags_specials_and_no_specials() {
     assert!(is_known_server_long_flag("--no-specials"));
 }
 
-// upstream: options.c:2768-2771 - `if (xfer_dirs && !recurse && delete_mode &&
+// upstream: options.c:2750-2753 - `if (xfer_dirs && !recurse && delete_mode &&
 // am_sender) args[ac++] = "--no-r"`. A real upstream client running
 // `--files-from --delete` forwards `--no-r`; the server-side popt table clears
-// `recurse` (options.c:633). Without recognition the token leaks into the
+// `recurse` (options.c:623). Without recognition the token leaks into the
 // positional path list and the receiver tries to create a destination root
 // literally named `--no-r`, failing with "Permission denied" (exit 1).
 #[test]
@@ -1145,9 +1145,9 @@ fn long_flags_no_r_recognized_and_parsed() {
     assert!(is_known_server_long_flag("--no-r"));
 }
 
-// upstream: options.c:2973-2977 - under `--inplace`, `if (sparse_files &&
+// upstream: options.c:2955-2959 - under `--inplace`, `if (sparse_files &&
 // !whole_file && am_sender) args[ac++] = "--no-W"`. Clears `whole_file`
-// server-side (options.c:756) so `--inplace --sparse` streams a delta.
+// server-side (options.c:746) so `--inplace --sparse` streams a delta.
 #[test]
 fn long_flags_no_w_recognized_and_parsed() {
     let flags = parse_server_long_flags(&[OsString::from("--server"), OsString::from("--no-W")]);
@@ -1159,9 +1159,9 @@ fn long_flags_no_w_recognized_and_parsed() {
     assert!(is_known_server_long_flag("--no-W"));
 }
 
-// upstream: options.c:2980-2991 - `--no-relative` is emitted with
+// upstream: options.c:2962-2973 - `--no-relative` is emitted with
 // `--files-from` when `!relative_paths`. Clears `relative_paths` server-side
-// (options.c:703).
+// (options.c:693).
 #[test]
 fn long_flags_no_relative_recognized_and_parsed() {
     let flags =
@@ -1177,7 +1177,7 @@ fn long_flags_no_relative_recognized_and_parsed() {
 // Regression: the four `--no-*` negations upstream emits must be split off the
 // compact flag string and never surface as positional destination paths. This
 // reproduces the `--files-from --delete` push where the client sends `--no-r`.
-// upstream: options.c:2771/2977/2991/2995.
+// upstream: options.c:2753/2959/2973/2977.
 #[test]
 fn no_negations_do_not_leak_as_positional_paths() {
     let args = [
@@ -1540,7 +1540,7 @@ fn parse_server_args_iconv_and_timeout_strip_to_dest() {
 
 #[test]
 fn is_known_server_long_flag_compression_choices() {
-    // upstream: options.c:2827-2832 - server_options() emits these whenever the
+    // upstream: options.c:2809-2814 - server_options() emits these whenever the
     // negotiated codec is not the default CPRES_ZLIB carried by the compact `-z`
     // flag. Without them in the known list, the dest path is silently corrupted
     // (same failure mode as the iconv/timeout regression above).
@@ -1603,7 +1603,7 @@ fn parse_server_args_compress_choice_strips_from_dest() {
 
 #[test]
 fn parse_server_long_flags_log_format_itemize() {
-    // upstream: options.c:2775 - client sends --log-format=%i for itemize
+    // upstream: options.c:2757 - client sends --log-format=%i for itemize
     let args = vec![
         OsString::from("--server"),
         OsString::from("--log-format=%i"),
@@ -1614,7 +1614,7 @@ fn parse_server_long_flags_log_format_itemize() {
 
 #[test]
 fn parse_server_long_flags_log_format_itemize_extended() {
-    // upstream: options.c:2773 - %i%I when stdout_format_has_i > 1
+    // upstream: options.c:2755 - %i%I when stdout_format_has_i > 1
     let args = vec![
         OsString::from("--server"),
         OsString::from("--log-format=%i%I"),
@@ -1625,7 +1625,7 @@ fn parse_server_long_flags_log_format_itemize_extended() {
 
 #[test]
 fn parse_server_long_flags_log_format_operation() {
-    // upstream: options.c:2777 - %o when stdout_format_has_o_or_i
+    // upstream: options.c:2759 - %o when stdout_format_has_o_or_i
     let args = vec![
         OsString::from("--server"),
         OsString::from("--log-format=%o"),
@@ -1636,7 +1636,7 @@ fn parse_server_long_flags_log_format_operation() {
 
 #[test]
 fn parse_server_long_flags_log_format_placeholder() {
-    // upstream: options.c:2779 - X when not verbose, no i/o tokens
+    // upstream: options.c:2761 - X when not verbose, no i/o tokens
     let args = vec![OsString::from("--server"), OsString::from("--log-format=X")];
     let flags = parse_server_long_flags(&args);
     assert_eq!(flags.log_format.as_deref(), Some("X"));
@@ -1773,8 +1773,8 @@ fn server_daemon_arguments_sets_daemon_program_name() {
 /// `missing rsync server flag string` against any upstream-client -> oc-rsync
 /// server transfer that sets `-s`.
 ///
-/// upstream: rsync.c:283 send_protected_args() / io.c:1324 read_args() /
-/// main.c::read_args() callsite at main.c:1876.
+/// upstream: rsync.c:283 send_protected_args() / io.c:1308 read_args() /
+/// main.c::read_args() callsite at main.c:1852.
 #[test]
 fn server_mode_merges_cmdline_and_stdin_secluded_args() {
     use std::io::Cursor;
@@ -1866,7 +1866,7 @@ fn server_mode_merges_cmdline_and_stdin_standalone_s_flag() {
 ///
 /// Mirrors the exact wire from the upstream alt-dest test running over
 /// lsh.sh: `--server -vlogDtpre.iLsfxCIvu --copy-dest /tmp/ad/alt3 . /tmp/ad/to/`.
-// upstream: options.c:2957-2958 `alt_dest_opt(0)` + `safe_arg("", basis_dir[i])`
+// upstream: options.c:2939-2940 `alt_dest_opt(0)` + `safe_arg("", basis_dir[i])`
 #[test]
 fn parse_server_args_handles_split_copy_dest_form() {
     let args = vec![
@@ -1890,7 +1890,7 @@ fn parse_server_args_handles_split_copy_dest_form() {
 
 /// `--link-dest` and `--compare-dest` share the same `alt_dest_opt(0)`
 /// emission path in upstream, so their split form must also be skipped.
-// upstream: options.c:2957-2958
+// upstream: options.c:2939-2940
 #[test]
 fn parse_server_args_handles_split_link_dest_and_compare_dest_forms() {
     let args = vec![
@@ -1911,7 +1911,7 @@ fn parse_server_args_handles_split_link_dest_and_compare_dest_forms() {
 /// Upstream also splits `--files-from`, `--backup-dir`, and `--temp-dir`
 /// into two argv slots. Recognising each one drains the value slot so it
 /// cannot masquerade as a positional destination.
-// upstream: options.c:2825-2826 (--backup-dir), 2926-2927 (--temp-dir),
+// upstream: options.c:2807-2808 (--backup-dir), 2926-2927 (--temp-dir),
 //           2964-2965 (--files-from)
 #[test]
 fn parse_server_args_handles_remaining_split_path_flags() {
@@ -1955,7 +1955,7 @@ fn parse_server_args_joined_copy_dest_does_not_eat_positional() {
 /// path even when upstream emits it as two argv slots. Without this, the
 /// alt-dest behaviour (basis-file copy-from instead of delta-from-empty)
 /// is lost: the receiver would fall back to whole-file transfer.
-// upstream: options.c:2957-2958
+// upstream: options.c:2939-2940
 #[test]
 fn long_flags_captures_split_copy_dest_value() {
     use engine::ReferenceDirectoryKind;
@@ -1981,7 +1981,7 @@ fn long_flags_captures_split_copy_dest_value() {
 
 /// Multiple stacked `--copy-dest` and `--compare-dest` flags in split
 /// form must all be captured in argv order. Upstream loops over
-/// `basis_dir_cnt` (options.c:2956-2959) so the server can see a sequence
+/// `basis_dir_cnt` (options.c:2938-2941) so the server can see a sequence
 /// like `--copy-dest /a --copy-dest /b --compare-dest /c`.
 #[test]
 fn long_flags_captures_multiple_split_alt_dest_values() {
@@ -2029,7 +2029,7 @@ fn long_flags_captures_multiple_split_alt_dest_values() {
 /// `parse_server_long_flags` must capture the split-form `--files-from`
 /// value so `--files-from /list` keeps working when upstream emits it
 /// as two argv slots.
-// upstream: options.c:2982-2983 `--files-from`
+// upstream: options.c:2964-2965 `--files-from`
 #[test]
 fn long_flags_captures_split_files_from_value() {
     let args = vec![
@@ -2047,10 +2047,10 @@ fn long_flags_captures_split_files_from_value() {
 // -- that upstream `server_options()` (options.c) emits but oc did not
 // -- recognise in `is_known_server_long_flag`.
 
-/// upstream: options.c:2926-2927 - `if (use_qsort) args[ac++] = "--use-qsort"`.
+/// upstream: options.c:2908-2909 - `if (use_qsort) args[ac++] = "--use-qsort"`.
 /// This is the exact spelling server_options() emits (oc's own forwarder uses
 /// `--qsort`). It must be recognised so it does not leak, and it maps onto the
-/// same `qsort` sink so flist ordering matches upstream (flist.c:3026).
+/// same `qsort` sink so flist ordering matches upstream (flist.c:2991).
 #[test]
 fn long_flags_use_qsort_maps_to_qsort() {
     let args = vec![OsString::from("--server"), OsString::from("--use-qsort")];
@@ -2059,7 +2059,7 @@ fn long_flags_use_qsort_maps_to_qsort() {
     assert!(is_known_server_long_flag("--use-qsort"));
 }
 
-/// upstream: options.c:3011-3012 - `if (open_noatime && preserve_atimes <= 1)
+/// upstream: options.c:2993-2994 - `if (open_noatime && preserve_atimes <= 1)
 /// args[ac++] = "--open-noatime"`, forwarded to the sender.
 #[test]
 fn long_flags_open_noatime() {
@@ -2069,7 +2069,7 @@ fn long_flags_open_noatime() {
     assert!(is_known_server_long_flag("--open-noatime"));
 }
 
-/// upstream: options.c:2886-2889 - `--delete-missing-args` (missing_args == 2)
+/// upstream: options.c:2868-2871 - `--delete-missing-args` (missing_args == 2)
 /// and `--ignore-missing-args` (missing_args == 1). Mirrors the daemon
 /// long-form parser (long_form_args.rs).
 #[test]
@@ -2092,7 +2092,7 @@ fn long_flags_missing_args_variants() {
     assert!(is_known_server_long_flag("--ignore-missing-args"));
 }
 
-/// upstream: options.c:2866-2871 / 3008-3009 - `--force` (force_delete),
+/// upstream: options.c:2848-2853 / 2990-2991 - `--force` (force_delete),
 /// `--super` (am_root > 1), and `--preallocate` (preallocate_files) are emitted
 /// in the am_sender block and reach a server acting as the receiver. oc has no
 /// content-affecting server sink for these (recursive delete already happens,
@@ -2105,7 +2105,7 @@ fn force_super_preallocate_recognised_as_known_long_flags() {
     assert!(is_known_server_long_flag("--preallocate"));
 }
 
-/// upstream: options.c:3008-3009 / receiver.c:390 - a server receiver invoked
+/// upstream: options.c:2990-2991 / receiver.c:320 - a server receiver invoked
 /// with `--preallocate` must fallocate() each destination file. The flag has no
 /// compact letter, so it arrives only as the long-form arg; parsing must set
 /// `preallocate` so `run.rs` can carry it onto `config.flags.preallocate` and

--- a/crates/cli/src/frontend/tests/backup.rs
+++ b/crates/cli/src/frontend/tests/backup.rs
@@ -81,7 +81,7 @@ fn backup_dir_flag_places_backups_in_relative_directory() {
     assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
-    // upstream: options.c:2314-2315 - --backup-dir without --suffix defaults the
+    // upstream: options.c:2296-2297 - --backup-dir without --suffix defaults the
     // suffix to "" (empty). This test pins the empty-suffix layout explicitly via
     // `--suffix ''` so the assertion exercises the upstream rule directly without
     // depending on the implicit default. See also
@@ -119,7 +119,7 @@ fn backup_suffix_flag_overrides_default_suffix() {
     );
     filetime::set_file_mtime(dest_root.join("file.txt"), one_hour_ago).expect("backdate dest");
 
-    // upstream: options.c:2314-2325 - `--suffix` sets the suffix string but does
+    // upstream: options.c:2296-2307 - `--suffix` sets the suffix string but does
     // NOT enable backups on its own; `--backup` must be given explicitly.
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),

--- a/crates/cli/src/frontend/tests/collect.rs
+++ b/crates/cli/src/frontend/tests/collect.rs
@@ -3,7 +3,7 @@ use super::*;
 
 /// `-F` shortcuts interleave with `--filter`/`-f` rules at their argv position.
 ///
-/// upstream: options.c:1605-1614 - the first `-F` adds `dir-merge
+/// upstream: options.c:1589-1598 - the first `-F` adds `dir-merge
 /// /.rsync-filter`, the second adds `exclude .rsync-filter`; each is inserted
 /// where the flag appears on the command line.
 #[test]

--- a/crates/cli/src/frontend/tests/compress_level_upstream.rs
+++ b/crates/cli/src/frontend/tests/compress_level_upstream.rs
@@ -408,7 +408,7 @@ fn parse_compress_level_argument_threads_negative_zstd_to_encoder() {
     // (parse -> CompressionSetting -> CompressionLevel) and map to the raw
     // signed level the zstd encoder feeds to ZSTD_c_compressionLevel. The
     // historical unsigned NonZeroU8 clamp collapsed every negative to 1 here,
-    // long before the resolver saw it. upstream: token.c:74,803.
+    // long before the resolver saw it. upstream: token.c:73,748.
     let resolved = |raw: &str| {
         let setting = parse_compress_level_argument(OsStr::new(raw), CompressionAlgorithm::Zstd)
             .unwrap_or_else(|_| panic!("zstd level {raw} should clamp, not error"));

--- a/crates/cli/src/frontend/tests/dry_run.rs
+++ b/crates/cli/src/frontend/tests/dry_run.rs
@@ -82,7 +82,7 @@ fn dry_run_with_verbose_lists_files_on_stdout() {
 
     // upstream: -v lists the files that would be transferred on stdout.
     // Recurse is required for upstream to descend the source directory
-    // (options.c:113 defaults recurse=0).
+    // (options.c:112 defaults recurse=0).
     let output = String::from_utf8_lossy(&stdout);
     assert!(
         output.contains("file1.txt"),

--- a/crates/cli/src/frontend/tests/error_recovery.rs
+++ b/crates/cli/src/frontend/tests/error_recovery.rs
@@ -5,8 +5,8 @@
 //!
 //! References:
 //! - upstream: errcode.h - RERR_VANISHED = 24
-//! - upstream: flist.c:1314-1322 - vanished file handling during file list build
-//! - upstream: main.c:1356-1363 - io_error to exit code mapping
+//! - upstream: flist.c:1286-1294 - vanished file handling during file list build
+//! - upstream: main.c:1338-1345 - io_error to exit code mapping
 
 use super::common::*;
 use super::*;

--- a/crates/cli/src/frontend/tests/exit_code_fidelity_tests.rs
+++ b/crates/cli/src/frontend/tests/exit_code_fidelity_tests.rs
@@ -30,7 +30,7 @@ fn empty_compress_choice_returns_unsupported() {
     assert_eq!(code, 4);
 }
 
-/// upstream: options.c:2031-2034 - `--compress-choice=auto` is nulled out so
+/// upstream: options.c:2013-2016 - `--compress-choice=auto` is nulled out so
 /// normal codec negotiation runs; it is accepted (exit 0), not rejected.
 #[test]
 fn compress_choice_auto_is_accepted() {
@@ -48,7 +48,7 @@ fn compress_choice_auto_is_accepted() {
     assert!(destination.exists());
 }
 
-/// upstream: options.c:2031 only special-cases the exact token `auto`;
+/// upstream: options.c:2013 only special-cases the exact token `auto`;
 /// `--compress-choice=auto,auto` is an unknown compress name (exit 4).
 #[test]
 fn compress_choice_auto_auto_returns_unsupported() {
@@ -61,7 +61,7 @@ fn compress_choice_auto_auto_returns_unsupported() {
     assert_eq!(code, 4);
 }
 
-/// upstream: options.c:2483-2489 - with `--files-from`, more than two operands
+/// upstream: options.c:2465-2471 - with `--files-from`, more than two operands
 /// (or a lone operand) is a syntax error (RERR_SYNTAX = 1).
 #[test]
 fn files_from_extra_operands_return_syntax_error() {

--- a/crates/cli/src/frontend/tests/files_from.rs
+++ b/crates/cli/src/frontend/tests/files_from.rs
@@ -27,9 +27,9 @@ fn files_from_reports_read_failures() {
     let dest_dir = tmp.path().join("files-from-error-dest");
     std::fs::create_dir(&dest_dir).expect("create dest");
 
-    // upstream: options.c:2483-2489 requires a source and destination operand
+    // upstream: options.c:2465-2471 requires a source and destination operand
     // with --files-from (argc == 2); the list is only read afterwards
-    // (main.c:1830), so both operands are supplied to reach the read failure.
+    // (main.c:1806), so both operands are supplied to reach the read failure.
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from(format!("--files-from={}", missing.display())),
@@ -248,8 +248,8 @@ fn from0_strips_comment_lines() {
     let list_path = tmp.path().join("from0_comments.list");
 
     // upstream: --from0 still strips leading #/; comment lines. RL_DUMP_COMMENTS
-    // is gated on reading_remotely, not eol_nulls (flist.c:2284); read_line drops
-    // #/; regardless of RL_EOL_NULLS (io.c:1279).
+    // is gated on reading_remotely, not eol_nulls (flist.c:2249); read_line drops
+    // #/; regardless of RL_EOL_NULLS (io.c:1276).
     let mut bytes = Vec::new();
     bytes.extend_from_slice(b"#comment");
     bytes.push(0);
@@ -671,7 +671,7 @@ fn files_from_integration_handles_nested_directories() {
     assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
     assert!(stdout.is_empty());
 
-    // upstream: options.c:2205-2206 - --files-from implies --relative, so
+    // upstream: options.c:2187-2188 - --files-from implies --relative, so
     // subdir/nested.txt stays at dest/subdir/nested.txt.
     assert!(dest_dir.join("top.txt").exists());
     assert!(dest_dir.join("subdir").join("nested.txt").exists());
@@ -833,7 +833,7 @@ fn files_from_reports_permission_error() {
     let dest_dir = tmp.path().join("dest");
     std::fs::create_dir(&dest_dir).expect("create dest");
 
-    // upstream: options.c:2483-2489 - --files-from requires src + dest operands
+    // upstream: options.c:2465-2471 - --files-from requires src + dest operands
     // (argc == 2) before the list is read, so both are supplied here.
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
@@ -1572,7 +1572,7 @@ fn files_from_integration_with_recursive_copies_nested_files() {
     assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
     assert!(stdout.is_empty());
 
-    // --files-from implies --relative (upstream options.c:2205-2206), so
+    // --files-from implies --relative (upstream options.c:2187-2188), so
     // listed paths preserve their directory structure at the destination.
     assert!(dest_dir.join("top.txt").exists());
     assert!(dest_dir.join("a/mid.txt").exists());
@@ -1694,7 +1694,7 @@ fn resolve_file_list_entries_with_dot_relative_paths() {
 fn resolve_files_from_entry_with_embedded_dot_marker_skips_extra_marker() {
     use crate::frontend::execution::resolve_file_list_entries;
 
-    // upstream: flist.c:2351-2353 - entries like "from/./dir/subdir" already
+    // upstream: flist.c:2316-2318 - entries like "from/./dir/subdir" already
     // contain a "./" transfer root marker. The resolver must NOT add another
     // "./" because the engine splits at the first marker, and a double marker
     // would incorrectly keep "from/" in the destination path.
@@ -1751,10 +1751,10 @@ fn resolve_files_from_entry_with_leading_dot_slash_skips_extra_marker() {
 /// ```
 ///
 /// Source operand is `$scratchdir` (the parent of `from/`); dest is `$todir/`.
-/// Upstream `flist.c:2351-2475` honours `(xfer_dirs && name_type != NORMAL_NAME)`
+/// Upstream `flist.c:2316-2440` honours `(xfer_dirs && name_type != NORMAL_NAME)`
 /// and calls `send_directory()` for every trailing-slash or dotdir entry, so
 /// `from/./` enumerates one level of `from/`'s children even though `--files-from`
-/// implicitly clears `recurse` (`options.c:2207`). The same applies to
+/// implicitly clears `recurse` (`options.c:2189`). The same applies to
 /// `from/./dir/subdir/subsubdir2/`, which must pull `bin-lt-list` even though
 /// `subsubdir/` (no trailing slash) does not pull `etc-ltr-list`.
 ///

--- a/crates/cli/src/frontend/tests/filter_behavior_comprehensive.rs
+++ b/crates/cli/src/frontend/tests/filter_behavior_comprehensive.rs
@@ -794,7 +794,7 @@ fn filter_order_stops_at_double_dash() {
 
 #[test]
 fn filter_order_interleaves_short_f_and_uppercase_f() {
-    // upstream: options.c:1605-1614 - `-F` expands to a directive inserted at
+    // upstream: options.c:1589-1598 - `-F` expands to a directive inserted at
     // its argv position, so it interleaves with explicit `-f` rules in order.
     let parsed = parse_args([
         OsString::from(RSYNC),

--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -79,7 +79,7 @@ fn progress_implies_name_shows_directory_names() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stdout utf8");
-    // upstream options.c:2369-2373: the `--progress`/`-P` flag sets do_progress,
+    // upstream options.c:2351-2355: the `--progress`/`-P` flag sets do_progress,
     // which bumps NAME to 1, so created directories print their name line even
     // without `-v`. `--info=progress2` (Overall) does NOT set do_progress and
     // stays name-free (info_progress2_enables_progress_output).
@@ -246,7 +246,7 @@ fn debug_flist_levels() {
     let settings = parse_debug_flags(&flags).expect("flags parse");
     assert_eq!(settings.flist, Some(4));
 
-    // upstream: options.c:454-455 - levels above MAX_OUT_LEVEL (4) are clamped, not rejected
+    // upstream: options.c:444-445 - levels above MAX_OUT_LEVEL (4) are clamped, not rejected
     let flags = vec![OsString::from("flist5")];
     let settings = parse_debug_flags(&flags).expect("flags parse");
     assert_eq!(settings.flist, Some(4));
@@ -266,7 +266,7 @@ fn debug_io_levels() {
     let settings = parse_debug_flags(&flags).expect("flags parse");
     assert_eq!(settings.io, Some(4));
 
-    // upstream: options.c:454-455 - levels above MAX_OUT_LEVEL (4) are clamped, not rejected
+    // upstream: options.c:444-445 - levels above MAX_OUT_LEVEL (4) are clamped, not rejected
     let flags = vec![OsString::from("io5")];
     let settings = parse_debug_flags(&flags).expect("flags parse");
     assert_eq!(settings.io, Some(4));
@@ -329,7 +329,7 @@ fn info_name_emits_filenames_without_verbose() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stdout utf8");
     assert!(rendered.contains("name.txt"));
-    // upstream: main.c:468-470 output_summary - the `sent ... total size`
+    // upstream: main.c:459-461 output_summary - the `sent ... total size`
     // trailer prints only under `--stats` or `-v` (INFO_GTE(STATS, 1)).
     // `--info=name` sets INFO_NAME alone, so the trailer is absent; verified
     // against rsync 3.4.4 which emits just the filename line.
@@ -373,7 +373,7 @@ fn info_name0_suppresses_verbose_output() {
 fn info_flist0_suppresses_incremental_banner_at_verbose() {
     use tempfile::tempdir;
 
-    // upstream: flist.c:2286 gates "sending incremental file list" on
+    // upstream: flist.c:2251 gates "sending incremental file list" on
     // `inc_recurse && INFO_GTE(FLIST, 1) && !am_server`. `-v` raises FLIST to 1
     // (options.c info_verbosity[1]), so the banner normally prints; a following
     // `--info=flist0` drops FLIST back to 0 and must suppress the banner even
@@ -419,7 +419,7 @@ fn info_flist0_suppresses_incremental_banner_at_verbose() {
 fn info_name0_suppresses_created_directory_notice_at_verbose() {
     use tempfile::tempdir;
 
-    // upstream: main.c:816-817 gates `created directory %s` on
+    // upstream: main.c:807-808 gates `created directory %s` on
     // `INFO_GTE(NAME, 1) || stdout_format_has_i`. `-v` raises NAME to 1, so the
     // notice normally prints; `--info=name0` drops NAME to 0 and must suppress
     // it even at `-v`. The incremental-file-list banner stays because it is

--- a/crates/cli/src/frontend/tests/itemize_format_upstream.rs
+++ b/crates/cli/src/frontend/tests/itemize_format_upstream.rs
@@ -132,7 +132,7 @@ fn itemize_updated_file_shows_change_indicators() {
 
     assert_eq!(&format_str[0..1], ">");
     assert_eq!(&format_str[1..2], "f");
-    // upstream: generator.c:1955 - ITEM_REPORT_CHECKSUM is set only under
+    // upstream: generator.c:1942 - ITEM_REPORT_CHECKSUM is set only under
     // `always_checksum > 0` (i.e. `--checksum`); without it, position 2 is '.'.
     assert_eq!(
         &format_str[2..3],
@@ -507,8 +507,8 @@ fn itemize_last_toggle_wins_disabled() {
 /// against a non-existent dest emits a created-directory notice, a synthetic
 /// root `cd+++++++++ ./` row, a `cd+++++++++ <subdir>/` row for every
 /// directory entered during the recursive walk (including nested children),
-/// and then the per-file rows. Mirrors upstream `main.c:807-808` +
-/// `generator.c:573-579`.
+/// and then the per-file rows. Mirrors upstream `main.c:798-799` +
+/// `generator.c:566-572`.
 #[test]
 fn itemize_initial_recursive_transfer_emits_dir_rows_for_each_subdir() {
     use tempfile::tempdir;
@@ -566,13 +566,13 @@ fn itemize_initial_recursive_transfer_emits_dir_rows_for_each_subdir() {
 
 /// UTS-IT.15: focused regression for the synthetic root `cd+++++++++ ./` row.
 ///
-/// Upstream `generator.c:573-579` emits a single dir-row for the destination
+/// Upstream `generator.c:566-572` emits a single dir-row for the destination
 /// root on an initial recursive transfer under `-i`/`--itemize-changes`, even
 /// when the source tree contains only top-level files. This locks down that
 /// behaviour in isolation so a regression cannot hide behind a broader test
 /// also asserting per-file rows.
 ///
-/// upstream: generator.c:573-579 root row emission.
+/// upstream: generator.c:566-572 root row emission.
 #[test]
 fn itemize_initial_recursive_transfer_emits_root_dir_row() {
     use tempfile::tempdir;
@@ -635,7 +635,7 @@ fn itemize_initial_recursive_transfer_emits_root_dir_row() {
 /// asserts both rows are present, in upstream order, before the per-file
 /// row inside the nested directory.
 ///
-/// upstream: generator.c:573-579 + flist walk recursion.
+/// upstream: generator.c:566-572 + flist walk recursion.
 #[test]
 fn itemize_initial_recursive_transfer_emits_intermediate_subdir_rows() {
     use tempfile::tempdir;

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -79,8 +79,8 @@ fn list_only_formats_directory_without_trailing_slash() {
 
 /// `--list-only <dir>` with no `-r`/`-d` and no trailing slash must still list
 /// the directory operand's own entry, mirroring upstream's
-/// `xfer_dirs = list_only ? 1 : 0` default (options.c:2221). Without this,
-/// `xfer_dirs` stays 0 and `flist.c:2486` skips the bare directory, so the
+/// `xfer_dirs = list_only ? 1 : 0` default (options.c:2203). Without this,
+/// `xfer_dirs` stays 0 and `flist.c:2451` skips the bare directory, so the
 /// listing is empty - diverging from upstream which prints the `src` row.
 #[test]
 fn list_only_lists_bare_directory_without_recursion_or_slash() {
@@ -1051,7 +1051,7 @@ fn list_only_multiple_files_have_consistent_column_alignment() {
 
 /// Verifies that `--list-only` lists entries without transferring any files.
 ///
-/// upstream: options.c:2384-2385 - list_only does NOT set dry_run, but the
+/// upstream: options.c:2366-2367 - list_only does NOT set dry_run, but the
 /// receiver skips destination writes under list_only independently
 /// (`run_client` mode selection + `TransferFlags::skip_dest_writes`).
 #[test]
@@ -1407,7 +1407,7 @@ fn list_only_mixed_file_types_in_single_listing() {
 /// entry types. Both fields are right-justified in a width of `1 +
 /// strlen(timestamp)` (20 for the 19-char "YYYY/MM/DD HH:MM:SS" form), so a
 /// value carries one leading space and a blank fills the whole column.
-/// upstream: generator.c:1195 list_file_entry() - the ` -> <target>` arrow is
+/// upstream: generator.c:1183 list_file_entry() - the ` -> <target>` arrow is
 /// gated on `preserve_links`. Without `-l` the symlink is still listed (perms
 /// start with `l`, size is the target length) but no target string is shown.
 /// FIFOs, sockets, and devices render their own permstring type char.

--- a/crates/cli/src/frontend/tests/log_file.rs
+++ b/crates/cli/src/frontend/tests/log_file.rs
@@ -124,7 +124,7 @@ fn log_file_multiple_files_produce_multiple_entries() {
     let mut source_trailing = source_dir.into_os_string();
     source_trailing.push(std::path::MAIN_SEPARATOR.to_string());
 
-    // upstream: options.c:113 defaults `recurse = 0` and flist.c:2486 prints
+    // upstream: options.c:112 defaults `recurse = 0` and flist.c:2451 prints
     // `skipping directory %s` for a directory operand without -r/-a/-d, so a
     // trailing-slash directory source must be paired with --recursive to fan
     // out into the per-child %f log entries this test verifies. Mirrors the

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -121,7 +121,7 @@ fn render_itemize(event: &ClientEvent) -> String {
 
 #[test]
 fn info_name_only_suppresses_stats_footer() {
-    // upstream: main.c:468-470 output_summary() gates the
+    // upstream: main.c:459-461 output_summary() gates the
     // `sent %s bytes  received %s bytes` / `total size is %s` trailer on
     // `verbose > 0 || INFO_GTE(STATS, 1)`. `--info=name2` raises only the NAME
     // level, so the trailer must NOT print - previously oc emitted it whenever
@@ -155,14 +155,14 @@ fn info_name_only_suppresses_stats_footer() {
     assert!(
         !out.contains("sent ") && !out.contains("total size is"),
         "name-only output (verbose 0, stats 0) must not print the summary \
-         trailer, matching upstream main.c:468-470:\n{out}"
+         trailer, matching upstream main.c:459-461:\n{out}"
     );
 }
 
 #[test]
 fn verbose_still_emits_stats_footer() {
     // upstream: the verbose level-1 word list raises INFO_STATS to 1
-    // (options.c:261), so plain `-v` still prints the trailer. Guards against
+    // (options.c:251), so plain `-v` still prints the trailer. Guards against
     // over-suppressing the footer when tightening the name-only gate.
     let (summary, _temp) = create_known_summary(&[("file.txt", b"hello world")]);
     let out = render_verbose(&summary, 1);
@@ -216,7 +216,7 @@ fn parity_stats_output_contains_all_upstream_field_labels() {
     );
     // Both File list timing lines are emitted together only when the flist
     // build time exceeds 1 ms, matching upstream's single
-    // `if (stats.flist_buildtime)` guard (main.c:446). Local-only transfers may
+    // `if (stats.flist_buildtime)` guard (main.c:437). Local-only transfers may
     // complete sub-millisecond, in which case both lines are absent (this
     // matches upstream rsync behaviour, so the assertion below tolerates either
     // presence).
@@ -242,7 +242,7 @@ fn parity_stats_output_field_order_matches_upstream() {
     let output = render_stats(&summary, HumanReadableMode::Grouped);
 
     // Upstream rsync emits stats in a fixed order. The File-list timing
-    // lines are conditional on `stats.flist_buildtime > 0` (main.c:446);
+    // lines are conditional on `stats.flist_buildtime > 0` (main.c:437);
     // when both are sub-millisecond they are omitted on both sides.
     let labels = [
         "Number of files:",
@@ -615,7 +615,7 @@ fn parity_stats_level_1_emits_only_summary_lines() {
     let output = render_stats_at_level(&summary, HumanReadableMode::Grouped, 1);
 
     // Level 1 emits only the "sent X bytes received Y bytes" + "total size"
-    // pair, matching upstream's INFO_GTE(STATS, 1) block (main.c:460-470).
+    // pair, matching upstream's INFO_GTE(STATS, 1) block (main.c:451-461).
     assert!(
         output.contains("sent "),
         "level 1 must include 'sent' summary line:\n{output}"
@@ -655,8 +655,8 @@ fn parity_stats_level_2_emits_full_detail_block_plus_summary() {
     let (summary, _temp) = create_known_summary(&[("lvl2.txt", b"level two")]);
     let output = render_stats_at_level(&summary, HumanReadableMode::Grouped, 2);
 
-    // Level 2 emits the full INFO_GTE(STATS, 2) detail block (main.c:427-458)
-    // followed by the level-1 summary (main.c:460-470).
+    // Level 2 emits the full INFO_GTE(STATS, 2) detail block (main.c:418-449)
+    // followed by the level-1 summary (main.c:451-461).
     for required in [
         "Number of files:",
         "Number of created files:",
@@ -679,7 +679,7 @@ fn parity_stats_level_2_emits_full_detail_block_plus_summary() {
     }
 
     // The detail block must precede the summary lines (single blank line
-    // separator, matching upstream's `rprintf(FCLIENT, "\n")` at main.c:461).
+    // separator, matching upstream's `rprintf(FCLIENT, "\n")` at main.c:452).
     let bytes_received_pos = output
         .find("Total bytes received:")
         .expect("Total bytes received: must be present at level 2");
@@ -787,7 +787,7 @@ fn parity_verbose_directory_names_end_with_slash() {
 #[test]
 fn parity_verbose_v2_emits_bare_name_per_upstream() {
     // upstream: log.c:log_formatted() at NAME>=1 emits the default
-    // `%n%L` format set by options.c:2390 - bare name plus optional
+    // `%n%L` format set by options.c:2372 - bare name plus optional
     // ` -> target` for symlinks or ` => hardlink` for hardlinks. Higher
     // verbosity adds ancillary log frames, never a per-file descriptor
     // prefix or byte-count wrapper. The upstream testsuite
@@ -2294,7 +2294,7 @@ fn parity_verbose_v3_produces_output_with_debug_info() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("-vvv"),
-        // upstream recurse defaults to 0 (options.c:113); a trailing-slash
+        // upstream recurse defaults to 0 (options.c:112); a trailing-slash
         // directory operand is "skipping directory ." without -r/-d, so it
         // transfers nothing. Pass --recursive so the top-level file is
         // actually enumerated and the verbose listing has something to show,

--- a/crates/cli/src/frontend/tests/parse_args_recognises_human.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_human.rs
@@ -16,7 +16,7 @@ fn parse_args_recognises_human_readable_flag() {
 
 #[test]
 fn parse_args_recognises_double_short_h() {
-    // upstream: options.c:1589 - each -h increments; -hh reaches level 3
+    // upstream: options.c:1573 - each -h increments; -hh reaches level 3
     // (base-1024 units, HumanReadableMode::BinaryUnits).
     let parsed = parse_args([
         OsString::from(RSYNC),

--- a/crates/cli/src/frontend/tests/parse_args_recognises_list.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_list.rs
@@ -12,6 +12,6 @@ fn parse_args_recognises_list_only_flag() {
     .expect("parse");
 
     assert!(parsed.list_only);
-    // upstream: options.c:2384-2385 - list_only does NOT set dry_run.
+    // upstream: options.c:2366-2367 - list_only does NOT set dry_run.
     assert!(!parsed.dry_run);
 }

--- a/crates/cli/src/frontend/tests/parse_args_recognises_mkpath.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_mkpath.rs
@@ -30,7 +30,7 @@ fn parse_args_recognises_no_mkpath_flag() {
 
 #[test]
 fn parse_args_recognises_old_dirs_flag() {
-    // upstream: options.c:2215-2217 - --old-dirs forces recursion and does not
+    // upstream: options.c:2197-2199 - --old-dirs forces recursion and does not
     // touch --mkpath.
     let parsed = parse_args([
         OsString::from(RSYNC),

--- a/crates/cli/src/frontend/tests/parse_args_recognises_modify.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_modify.rs
@@ -42,7 +42,7 @@ fn parse_args_accepts_negative_modify_window() {
 
 #[test]
 fn parse_args_accepts_short_at_alias_modify_window() {
-    // WHY: upstream options.c:670 defines `-@` as the short alias for
+    // WHY: upstream options.c:660 defines `-@` as the short alias for
     // `--modify-window`. `-@-1`, `-@2`, and `-@ 2` must all parse to the same
     // value the long form yields.
     for (arg, expected) in [("-@-1", "-1"), ("-@2", "2")] {

--- a/crates/cli/src/frontend/tests/parse_args_recognises_partial.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_partial.rs
@@ -24,7 +24,7 @@ fn parse_args_recognises_partial_dir_and_enables_partial() {
 
 #[test]
 fn parse_args_uses_rsync_partial_dir_env_with_partial() {
-    // upstream: options.c:2466-2469 - RSYNC_PARTIAL_DIR is consulted only when
+    // upstream: options.c:2448-2451 - RSYNC_PARTIAL_DIR is consulted only when
     // keep_partial is active (--partial/-P) and no explicit --partial-dir was
     // given.
     let _env_lock = ENV_LOCK.lock().expect("env lock");
@@ -48,7 +48,7 @@ fn parse_args_uses_rsync_partial_dir_env_with_partial() {
 
 #[test]
 fn parse_args_ignores_rsync_partial_dir_env_without_partial() {
-    // upstream: options.c:2466 `if (keep_partial && !partial_dir && !am_server)`
+    // upstream: options.c:2448 `if (keep_partial && !partial_dir && !am_server)`
     // - without --partial/-P the env var is ignored and does not enable partial.
     let _env_lock = ENV_LOCK.lock().expect("env lock");
 
@@ -67,7 +67,7 @@ fn parse_args_ignores_rsync_partial_dir_env_without_partial() {
 
 #[test]
 fn parse_args_treats_dot_rsync_partial_dir_env_as_unset() {
-    // upstream: options.c:2470-2472 - a "." partial dir collapses to NULL.
+    // upstream: options.c:2452-2454 - a "." partial dir collapses to NULL.
     let _env_lock = ENV_LOCK.lock().expect("env lock");
 
     let _guard = EnvGuard::set("RSYNC_PARTIAL_DIR", OsStr::new("."));

--- a/crates/cli/src/frontend/tests/parse_max.rs
+++ b/crates/cli/src/frontend/tests/parse_max.rs
@@ -9,7 +9,7 @@ fn parse_max_delete_argument_accepts_zero() {
 
 #[test]
 fn parse_max_delete_argument_clamps_negative_to_zero() {
-    // upstream: options.c:2200-2203 - a negative `--max-delete` is clamped to a
+    // upstream: options.c:2182-2185 - a negative `--max-delete` is clamped to a
     // 0 cap ("no deletions") rather than rejected.
     let limit = parse_max_delete_argument(OsStr::new("-4")).expect("negative clamps to zero");
     assert_eq!(limit, 0);

--- a/crates/cli/src/frontend/tests/parse_max_alloc.rs
+++ b/crates/cli/src/frontend/tests/parse_max_alloc.rs
@@ -240,7 +240,7 @@ fn max_alloc_rejects_non_numeric() {
 
 #[test]
 fn max_alloc_argument_resolution_accepts_zero_as_unlimited() {
-    // upstream: options.c:1982 `if (!max_alloc) max_alloc = SIZE_MAX;` - a zero
+    // upstream: options.c:1966 `if (!max_alloc) max_alloc = SIZE_MAX;` - a zero
     // value is accepted and resolves to unlimited, not an error.
     use crate::frontend::execution::parse_max_alloc_argument;
     assert_eq!(
@@ -251,7 +251,7 @@ fn max_alloc_argument_resolution_accepts_zero_as_unlimited() {
 
 #[test]
 fn max_alloc_argument_resolution_rejects_below_one_mib() {
-    // upstream: options.c:1976 - parse_size_arg min value is 1 MiB, so "512K"
+    // upstream: options.c:1960 - parse_size_arg min value is 1 MiB, so "512K"
     // (below the minimum) is rejected as "too small".
     use crate::frontend::execution::parse_max_alloc_argument;
     let error = parse_max_alloc_argument(OsStr::new("512K")).expect_err("below 1 MiB rejected");
@@ -303,7 +303,7 @@ fn max_alloc_argument_resolution_rejects_excessive_value() {
 
 #[test]
 fn max_alloc_zero_value_is_accepted_as_unlimited() {
-    // upstream: options.c:1982 - `--max-alloc=0` is accepted (unlimited), so it
+    // upstream: options.c:1966 - `--max-alloc=0` is accepted (unlimited), so it
     // never triggers a max-alloc syntax error. Any exit here comes from the
     // missing "source"/"dest" operands, not from option validation.
     let _guard = clear_rsync_rsh();
@@ -322,7 +322,7 @@ fn max_alloc_zero_value_is_accepted_as_unlimited() {
 
 #[test]
 fn max_alloc_below_one_mib_produces_error_exit() {
-    // upstream: options.c:1976 - a non-zero `--max-alloc` below 1 MiB is a
+    // upstream: options.c:1960 - a non-zero `--max-alloc` below 1 MiB is a
     // syntax error (exit 1).
     let _guard = clear_rsync_rsh();
     let (code, _stdout, stderr) = run_with_args([

--- a/crates/cli/src/frontend/tests/parse_size.rs
+++ b/crates/cli/src/frontend/tests/parse_size.rs
@@ -40,7 +40,7 @@ fn parse_block_size_argument_accepts_valid_value() {
 
 #[test]
 fn parse_block_size_argument_zero_falls_back_to_default() {
-    // upstream: options.c:1708-1711 - `--block-size=0` is accepted (min_value 0)
+    // upstream: options.c:1692-1695 - `--block-size=0` is accepted (min_value 0)
     // and falls back to the default block size, represented here as `None`.
     let parsed = parse_block_size_argument(OsStr::new("0")).expect("zero accepted");
     assert_eq!(parsed, None);
@@ -48,7 +48,7 @@ fn parse_block_size_argument_zero_falls_back_to_default() {
 
 #[test]
 fn parse_block_size_argument_rejects_large_value() {
-    // upstream: options.c:1708-1711 - a value above MAX_BLOCK_SIZE (131072) is
+    // upstream: options.c:1692-1695 - a value above MAX_BLOCK_SIZE (131072) is
     // "too large (max: 128.00K)".
     let error = parse_block_size_argument(OsStr::new("5000000000")).expect_err("overflow rejected");
     assert!(

--- a/crates/cli/src/frontend/tests/progress.rs
+++ b/crates/cli/src/frontend/tests/progress.rs
@@ -226,10 +226,10 @@ fn progress_reports_unknown_totals_with_placeholder() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("progress output is UTF-8");
-    // upstream: receiver.c:843-895 - a lone special (fifo) is not ITEM_TRANSFER,
+    // upstream: receiver.c:731-782 - a lone special (fifo) is not ITEM_TRANSFER,
     // so per-file `--progress` prints no per-file progress block for it. The
     // terminal `end_progress(0)` summary at NDX_DONE fires only under
-    // `--info=progress2` (receiver.c:786-788), not plain `--progress`. The
+    // `--info=progress2` (receiver.c:674-676), not plain `--progress`. The
     // fifo's name still prints via the name-output path. Verified against rsync
     // 3.4.4: `--progress --specials <fifo>` emits just `<fifo>\n` - no `??%`
     // placeholder, no `to-chk` line.

--- a/crates/cli/src/frontend/tests/progress2_format_parity.rs
+++ b/crates/cli/src/frontend/tests/progress2_format_parity.rs
@@ -244,7 +244,7 @@ fn progress2_single_file_final_tick_matches_upstream_format() {
 
     // Final tick should show to-chk=0/2: the trailing-slash copy enumerates the
     // source root directory plus the single file, so `num_files == 2` (reg: 1,
-    // dir: 1). upstream: flist.c:2596 counts directories into stats.num_files,
+    // dir: 1). upstream: flist.c:2561 counts directories into stats.num_files,
     // so `rsync -r source/ dest` reports `to-chk=0/2` here. Verified against
     // rsync 3.4.4: `Number of files: 2 (reg: 1, dir: 1)`.
     assert!(

--- a/crates/cli/src/frontend/tests/progress_live.rs
+++ b/crates/cli/src/frontend/tests/progress_live.rs
@@ -113,7 +113,7 @@ fn live_progress_per_file_renders_xfr_and_to_chk() {
         output.contains("xfr#1"),
         "per-file output should contain xfr#1: {output:?}"
     );
-    // upstream: flist.c:2596 counts the source root directory into num_files, so
+    // upstream: flist.c:2561 counts the source root directory into num_files, so
     // a trailing-slash `source/` copy of one file enumerates dir + file = 2
     // entries. Verified vs rsync 3.4.4: `--progress -r source/ dest` prints
     // `to-chk=0/2`.
@@ -267,7 +267,7 @@ fn live_progress_overall_renders_xfr_and_to_chk() {
         output.contains("xfr#1"),
         "overall mode should contain xfr#: {output:?}"
     );
-    // upstream: flist.c:2596 counts the source root directory into num_files, so
+    // upstream: flist.c:2561 counts the source root directory into num_files, so
     // a trailing-slash `source/` copy of one file enumerates dir + file = 2
     // entries. Verified vs rsync 3.4.4: `--info=progress2 -r source/ dest`
     // prints `to-chk=0/2`.
@@ -654,7 +654,7 @@ fn live_progress_output_matches_upstream_format_pattern() {
     );
 
     // 5. Contains tracking suffix
-    // upstream: flist.c:2596 - the trailing-slash `source/` copy enumerates the
+    // upstream: flist.c:2561 - the trailing-slash `source/` copy enumerates the
     // root dir plus the file (num_files == 2), so the final tick reads
     // `to-chk=0/2`. Verified vs rsync 3.4.4.
     assert!(

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -102,7 +102,7 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
 
     let output = String::from_utf8(rendered).expect("utf8");
     assert!(output.contains("(xfr#1, to-chk="));
-    // upstream emits bare `%n%L` per-file even at -vv (options.c:2390).
+    // upstream emits bare `%n%L` per-file even at -vv (options.c:2372).
     // Do not emit descriptor prefixes like `copied:` - upstream testsuite
     // `duplicates.test` greps for `^name1$` to detect duplicate copies.
     assert!(

--- a/crates/cli/src/frontend/tests/run.rs
+++ b/crates/cli/src/frontend/tests/run.rs
@@ -1,7 +1,7 @@
 use super::common::*;
 use super::*;
 
-// upstream: options.c:1778-1782 - a rejected --chmod arg prints
+// upstream: options.c:1762-1766 - a rejected --chmod arg prints
 // `Invalid argument passed to --chmod (%s)` (verbatim raw arg) and exits
 // RERR_SYNTAX (1). We assert the message and exit code byte-for-byte.
 #[test]
@@ -51,7 +51,7 @@ fn clap_error_uses_canonical_exit_code_text() {
     );
 }
 
-// upstream: options.c:1765-1770 - the 21st alt-dest arg overflows the shared
+// upstream: options.c:1749-1754 - the 21st alt-dest arg overflows the shared
 // `basis_dir[]` array (rsync.h:196 MAX_BASIS_DIRS) and exits RERR_SYNTAX (1)
 // with a verbatim `ERROR: at most 20 <opt> args may be specified` message. We
 // assert both the exit code and the message end-to-end.

--- a/crates/cli/src/frontend/tests/tracing_integration.rs
+++ b/crates/cli/src/frontend/tests/tracing_integration.rs
@@ -180,7 +180,7 @@ fn info_progress2_shows_overall_progress_during_transfer() {
     let (code, stdout, _stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--info=progress2"),
-        // upstream recurse defaults to 0 (options.c:113); a trailing-slash
+        // upstream recurse defaults to 0 (options.c:112); a trailing-slash
         // directory operand is "skipping directory ." without -r/-d, so it
         // transfers nothing and progress2 has no files to count. Pass
         // --recursive so the directory is enumerated, mirroring upstream

--- a/crates/cli/src/frontend/tests/transfer_request_skips_directories_without_recursion.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_skips_directories_without_recursion.rs
@@ -4,18 +4,18 @@ use super::*;
 /// Verifies that `rsync src/ dst/` without `-r`, `-d`, `-a`, or `--files-from`
 /// skips the directory and writes nothing, matching upstream rsync 3.4.4.
 ///
-/// Upstream's `recurse` defaults to `0` (options.c:113) and `xfer_dirs` falls
-/// back to `0` when neither `-r` nor `-d` is supplied (options.c:2218-2221).
-/// In `flist.c:2486`, a directory operand with `!xfer_dirs` triggers
+/// Upstream's `recurse` defaults to `0` (options.c:112) and `xfer_dirs` falls
+/// back to `0` when neither `-r` nor `-d` is supplied (options.c:2200-2203).
+/// In `flist.c:2451`, a directory operand with `!xfer_dirs` triggers
 /// `rprintf(FINFO, "skipping directory %s\n", fbuf)` and is omitted from the
 /// flist, so the destination tree remains empty.
 ///
 /// # Upstream Reference
 ///
-/// - `options.c:113` - `int recurse = 0;` default
-/// - `options.c:2218-2221` - `xfer_dirs = 0` when recurse is off and the user
+/// - `options.c:112` - `int recurse = 0;` default
+/// - `options.c:2200-2203` - `xfer_dirs = 0` when recurse is off and the user
 ///   did not request `-d`
-/// - `flist.c:2486` - `S_ISDIR(st.st_mode) && !xfer_dirs` skips the directory
+/// - `flist.c:2451` - `S_ISDIR(st.st_mode) && !xfer_dirs` skips the directory
 #[test]
 fn trailing_slash_source_without_recursion_skips_directory() {
     use tempfile::tempdir;
@@ -54,7 +54,7 @@ fn trailing_slash_source_without_recursion_skips_directory() {
 /// the source directory entirely.
 ///
 /// Same upstream semantics as the trailing-slash variant: the directory operand
-/// hits the `!xfer_dirs` guard in `flist.c:2486` and is omitted from the flist.
+/// hits the `!xfer_dirs` guard in `flist.c:2451` and is omitted from the flist.
 #[test]
 fn non_trailing_slash_source_without_recursion_skips_directory() {
     use tempfile::tempdir;

--- a/crates/cli/src/frontend/tests/transfer_request_with_cvs.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_cvs.rs
@@ -22,7 +22,7 @@ fn transfer_request_with_cvs_exclude_skips_default_patterns() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // upstream recurse defaults to 0 (options.c:113); a directory operand
+        // upstream recurse defaults to 0 (options.c:112); a directory operand
         // without -r/-d is "skipping directory" and transfers nothing. Pass
         // --recursive so the tree is enumerated and --cvs-exclude filtering is
         // actually exercised, mirroring upstream `rsync -rC src dst`.
@@ -61,7 +61,7 @@ fn transfer_request_with_cvs_exclude_respects_cvsignore_files() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // upstream recurse defaults to 0 (options.c:113); a directory operand
+        // upstream recurse defaults to 0 (options.c:112); a directory operand
         // without -r/-d is "skipping directory" and transfers nothing. Pass
         // --recursive so the tree is enumerated and --cvs-exclude filtering is
         // actually exercised, mirroring upstream `rsync -rC src dst`.
@@ -98,7 +98,7 @@ fn transfer_request_with_cvs_exclude_respects_cvsignore_env() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // upstream recurse defaults to 0 (options.c:113); a directory operand
+        // upstream recurse defaults to 0 (options.c:112); a directory operand
         // without -r/-d is "skipping directory" and transfers nothing. Pass
         // --recursive so the tree is enumerated and --cvs-exclude filtering is
         // actually exercised, mirroring upstream `rsync -rC src dst`.

--- a/crates/cli/src/frontend/tests/transfer_request_with_delete.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_delete.rs
@@ -20,7 +20,7 @@ fn transfer_request_with_delete_excluded_prunes_filtered_entries() {
         OsString::from(RSYNC),
         OsString::from("--delete-excluded"),
         OsString::from("--exclude=*.log"),
-        // upstream recurse defaults to 0 (options.c:113); a non-trailing-slash
+        // upstream recurse defaults to 0 (options.c:112); a non-trailing-slash
         // directory operand under --dirs is added without descending, so its
         // children never transfer. Use --recursive to walk source/ and satisfy
         // --delete's "needs -r or -d" requirement, mirroring upstream.

--- a/crates/cli/src/frontend/tests/transfer_request_with_duplicates.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_duplicates.rs
@@ -11,7 +11,7 @@ use super::*;
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:3039-3047` - `flist_sort_and_clean()` marks duplicate entries
+/// - `flist.c:3004-3012` - `flist_sort_and_clean()` marks duplicate entries
 /// - `testsuite/duplicates.test` - copies source 10 times, asserts each
 ///   file appears exactly once in verbose output
 #[cfg(unix)]

--- a/crates/cli/src/frontend/tests/transfer_request_with_exclude.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_exclude.rs
@@ -18,7 +18,7 @@ fn transfer_request_with_exclude_from_skips_patterns() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // upstream recurse defaults to 0 (options.c:113); a directory operand
+        // upstream recurse defaults to 0 (options.c:112); a directory operand
         // without -r transfers nothing. --recursive walks source/ so the
         // exclude rules are actually exercised, mirroring upstream.
         OsString::from("--recursive"),
@@ -52,7 +52,7 @@ fn transfer_request_with_exclude_from_stdin_skips_patterns() {
     super::set_filter_stdin_input(b"*.tmp\n".to_vec());
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // upstream recurse defaults to 0 (options.c:113); a directory operand
+        // upstream recurse defaults to 0 (options.c:112); a directory operand
         // without -r transfers nothing. --recursive walks source/ so the
         // exclude rules are actually exercised, mirroring upstream.
         OsString::from("--recursive"),

--- a/crates/cli/src/frontend/tests/transfer_request_with_files_from.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_files_from.rs
@@ -49,8 +49,8 @@ fn transfer_request_with_files_from_uses_source_directory_for_relative_entries()
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:2275-2299` - `send_file_list()` reads from `filesfrom_fd`
-/// - `options.c:2187-2195` - `--files-from` disables recursion, enables xfer_dirs
+/// - `flist.c:2240-2264` - `send_file_list()` reads from `filesfrom_fd`
+/// - `options.c:2169-2177` - `--files-from` disables recursion, enables xfer_dirs
 #[test]
 fn files_from_excludes_unlisted_files() {
     use tempfile::tempdir;
@@ -109,7 +109,7 @@ fn files_from_excludes_unlisted_files() {
 /// # Upstream Reference
 ///
 /// - `testsuite/files-from.test` - tests `from/./dir/subdir` entries
-/// - `flist.c:2351-2353` - `strstr(fbuf, "/./")` splits at marker
+/// - `flist.c:2316-2318` - `strstr(fbuf, "/./")` splits at marker
 #[test]
 fn files_from_embedded_dot_marker_determines_destination_structure() {
     use tempfile::tempdir;
@@ -158,7 +158,7 @@ fn files_from_embedded_dot_marker_determines_destination_structure() {
 
 /// Verifies that `--files-from` entries flagged as DOTDIR_NAME (`from/./`) and
 /// SLASH_ENDING_NAME (`dir/`) walk their immediate children even when global
-/// recursion is off, matching upstream `flist.c:2477`.
+/// recursion is off, matching upstream `flist.c:2442`.
 ///
 /// Upstream's `(xfer_dirs && name_type != NORMAL_NAME)` predicate forces
 /// `send_directory()` to emit one level of contents for the listed directory.
@@ -169,8 +169,8 @@ fn files_from_embedded_dot_marker_determines_destination_structure() {
 /// # Upstream Reference
 ///
 /// - `testsuite/files-from.test` - the local invocation exercises this path
-/// - `flist.c:2364` - SLASH_ENDING_NAME / DOTDIR_NAME flagging
-/// - `flist.c:2477-2491` - `(xfer_dirs && name_type != NORMAL_NAME)` walk
+/// - `flist.c:2329` - SLASH_ENDING_NAME / DOTDIR_NAME flagging
+/// - `flist.c:2442-2456` - `(xfer_dirs && name_type != NORMAL_NAME)` walk
 #[test]
 fn files_from_dotdir_entry_walks_immediate_children() {
     use tempfile::tempdir;

--- a/crates/cli/src/frontend/tests/transfer_request_with_filter.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_filter.rs
@@ -15,7 +15,7 @@ fn transfer_request_with_filter_excludes_patterns() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // recurse defaults to 0 (options.c:113); -r walks source/ so the
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
         // filter rules are actually exercised, mirroring upstream.
         OsString::from("--recursive"),
         OsString::from("--filter"),
@@ -47,7 +47,7 @@ fn transfer_request_with_filter_clear_resets_rules() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // recurse defaults to 0 (options.c:113); -r walks source/ so the
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
         // filter rules are actually exercised, mirroring upstream.
         OsString::from("--recursive"),
         OsString::from("--filter"),
@@ -86,7 +86,7 @@ fn transfer_request_with_filter_merge_applies_rules() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // recurse defaults to 0 (options.c:113); -r walks source/ so the
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
         // filter rules are actually exercised, mirroring upstream.
         OsString::from("--recursive"),
         OsString::from("--filter"),
@@ -124,7 +124,7 @@ fn transfer_request_with_filter_merge_clear_resets_rules() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // recurse defaults to 0 (options.c:113); -r walks source/ so the
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
         // filter rules are actually exercised, mirroring upstream.
         OsString::from("--recursive"),
         OsString::from("--filter"),
@@ -229,7 +229,7 @@ fn transfer_request_with_filter_merge_bang_preserves_parent_cli_rule() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // recurse defaults to 0 (options.c:113); -r walks source/ so the
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
         // filter rules are actually exercised, mirroring upstream.
         OsString::from("--recursive"),
         OsString::from("--filter"),
@@ -277,7 +277,7 @@ fn transfer_request_with_filter_nested_merge_bang_preserves_outer_scope() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // recurse defaults to 0 (options.c:113); -r walks source/ so the
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
         // filter rules are actually exercised, mirroring upstream.
         OsString::from("--recursive"),
         OsString::from("--filter"),
@@ -317,7 +317,7 @@ fn transfer_request_with_exclude_from_bang_preserves_parent_cli_rule() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // recurse defaults to 0 (options.c:113); -r walks source/ so the
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
         // filter rules are actually exercised, mirroring upstream.
         OsString::from("--recursive"),
         OsString::from("--filter"),
@@ -366,7 +366,7 @@ fn transfer_request_with_cvsignore_bang_wipes_default_cvs_patterns() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // recurse defaults to 0 (options.c:113); -r walks source/ so the
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
         // cvs-exclude rules are actually exercised, mirroring upstream.
         OsString::from("--recursive"),
         OsString::from("--cvs-exclude"),

--- a/crates/cli/src/frontend/tests/transfer_request_with_from0.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_from0.rs
@@ -68,7 +68,7 @@ fn transfer_request_with_from0_strips_comment_prefix_entries() {
     ]);
 
     // upstream: a leading `#` marks a comment line in a --files-from list even
-    // under --from0 (read_line RL_DUMP_COMMENTS, io.c:1279), so the only entry
+    // under --from0 (read_line RL_DUMP_COMMENTS, io.c:1276), so the only entry
     // is stripped and nothing is transferred.
     assert_eq!(code, 0);
     assert!(!dest_dir.join("#commented.txt").exists());

--- a/crates/cli/src/frontend/tests/transfer_request_with_ignore.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_ignore.rs
@@ -53,7 +53,7 @@ fn ignore_existing_verbose_reports_exists_in_upstream_format() {
     let out = String::from_utf8_lossy(&stdout);
 
     assert_eq!(code, 0, "transfer should succeed: {out}");
-    // upstream: generator.c:1421 - `rprintf(FINFO, "%s exists\n", fname)`.
+    // upstream: generator.c:1409 - `rprintf(FINFO, "%s exists\n", fname)`.
     assert!(
         out.lines().any(|l| l == "keep.txt exists"),
         "expected upstream `keep.txt exists` line: {out}"

--- a/crates/cli/src/frontend/tests/transfer_request_with_include.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_include.rs
@@ -53,7 +53,7 @@ fn transfer_request_with_include_from_reinstate_patterns() {
     // With first-match-wins, --include-from must come before --exclude
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // upstream recurse defaults to 0 (options.c:113); keep/ is a subdir, so
+        // upstream recurse defaults to 0 (options.c:112); keep/ is a subdir, so
         // without -r nothing under it transfers. --recursive walks the tree and
         // lets the include/exclude rules be exercised, mirroring upstream.
         OsString::from("--recursive"),

--- a/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
@@ -393,7 +393,7 @@ fn transfer_request_with_sparse_and_inplace_punches_hole() {
     );
 }
 
-/// upstream: options.c:2431-2437 - `--write-devices` forces the global inplace
+/// upstream: options.c:2413-2419 - `--write-devices` forces the global inplace
 /// flag on. An inplace update rewrites the destination file in place (same
 /// inode), whereas the default atomic mode writes a temp file and renames it
 /// (new inode). Comparing the destination inode before and after a

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -148,7 +148,7 @@ fn level_1_lists_multiple_transferred_files() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // recurse defaults to 0 (options.c:113); a trailing-slash directory
+        // recurse defaults to 0 (options.c:112); a trailing-slash directory
         // without -r is "skipping directory ." and lists nothing. Pass -r so
         // the files transfer and -v lists them, mirroring upstream.
         OsString::from("--recursive"),
@@ -225,7 +225,7 @@ fn verbose_transfer_reports_skipped_specials() {
     assert_eq!(code, 0);
     assert!(std::fs::symlink_metadata(&destination).is_err());
 
-    // The upstream-format NONREG notice (generator.c:1699) must appear on
+    // The upstream-format NONREG notice (generator.c:1687) must appear on
     // either stream: emit_verbose renders it to stdout at -v, and the
     // default-on `--info=NONREG` emission feeds the diagnostic queue.
     let stdout_text = String::from_utf8(stdout).expect("verbose stdout is UTF-8");
@@ -306,7 +306,7 @@ fn verbose_human_readable_combined_formats_sizes() {
 
 /// Verifies that -vv lists files using upstream's bare `%n%L` format
 /// (no `copied:`/`symlink:` descriptor prefix, no byte-count wrapper).
-/// Upstream: options.c:2390 sets `stdout_format = "%n%L"`; log.c:603-659
+/// Upstream: options.c:2372 sets `stdout_format = "%n%L"`; log.c:603-659
 /// expands `%n` to the filename and `%L` to ` -> target` for symlinks.
 /// The upstream testsuite `duplicates.test` greps `^name1$` to detect
 /// duplicate copies, so the per-file line must be bare.
@@ -435,7 +435,7 @@ fn verbose_with_dry_run_lists_files() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        // recurse defaults to 0 (options.c:113); a trailing-slash directory
+        // recurse defaults to 0 (options.c:112); a trailing-slash directory
         // without -r is "skipping directory ." and lists nothing. Pass -r so
         // the files transfer and -v lists them, mirroring upstream.
         OsString::from("--recursive"),
@@ -1047,7 +1047,7 @@ fn verbose_dry_run_with_stats_shows_statistics() {
 /// bare `name1` line and exactly one `name2 -> target` line on -vv stdout.
 /// The test greps `^name1$` / `^name2 -> ` to detect duplicate copies, so
 /// any prefix (`copied:`, `symlink:`) or byte-count wrapper breaks interop.
-/// Upstream: `testsuite/duplicates.test`, options.c:2390 (`stdout_format = "%n%L"`).
+/// Upstream: `testsuite/duplicates.test`, options.c:2372 (`stdout_format = "%n%L"`).
 #[cfg(unix)]
 #[test]
 fn duplicates_testsuite_emits_bare_name_lines() {
@@ -1095,11 +1095,11 @@ fn duplicates_testsuite_emits_bare_name_lines() {
 
 /// Verifies that `-vv` on an all-uptodate tree mirrors upstream rsync 3.4.4:
 ///
-/// 1. The first stdout line is `sending incremental file list` (flist.c:2287).
+/// 1. The first stdout line is `sending incremental file list` (flist.c:2252).
 /// 2. Unchanged files emit `<name> is uptodate` (rsync.c:676) at NAME>=2.
 /// 3. Files are NOT pre-listed as bare names before the uptodate notice -
 ///    upstream gates the bare per-file emission on `INFO_EQ(PROGRESS, 1)`
-///    (receiver.c:1011, sender.c:481), and no `--progress` was requested here.
+///    (receiver.c:1011, sender.c:450), and no `--progress` was requested here.
 #[test]
 fn level_2_all_uptodate_matches_upstream_banner_and_uptodate_lines() {
     use tempfile::tempdir;
@@ -1145,10 +1145,10 @@ fn level_2_all_uptodate_matches_upstream_banner_and_uptodate_lines() {
     );
     assert_eq!(
         lines[0], "sending incremental file list",
-        "first line must be the FCLIENT banner (flist.c:2287), got: {rendered:?}"
+        "first line must be the FCLIENT banner (flist.c:2252), got: {rendered:?}"
     );
 
-    // Per upstream rsync.c:676 + sender.c:481, no bare `<name>` lines should
+    // Per upstream rsync.c:676 + sender.c:450, no bare `<name>` lines should
     // precede the `is uptodate` notice when --progress is absent. A regression
     // would surface as e.g. `foo/a.txt` on its own line right after the banner.
     let uptodate_count = lines.iter().filter(|l| l.ends_with(" is uptodate")).count();
@@ -1299,7 +1299,7 @@ fn level_2_hardlink_uptodate_emits_is_uptodate_notice() {
 /// `testsuite/itemize.test` `v_filt` helper (`sed -e '/^$/,$d'`) can strip the
 /// trailer before diffing.
 ///
-/// upstream: main.c:470 - `output_summary()` emits `rprintf(FCLIENT, "\n")`
+/// upstream: main.c:461 - `output_summary()` emits `rprintf(FCLIENT, "\n")`
 /// before the `INFO_GTE(STATS, 1)` totals block.
 #[test]
 fn level_2_blank_line_precedes_totals_trailer() {


### PR DESCRIPTION
Revert PR #6868 "docs: reline drifted upstream citations in cli crate".

A precise verification (locating each comment's quoted C-string in the rsync-3.4.4 source and comparing to the cited line) found that PR #6868 mislocated ~89% of the cli crate's string-anchored upstream citations. Root cause: the cli crate's `// upstream: <file>.c:<line>` citations were already correct for rsync 3.4.4, but #6868 applied a 3.4.1->3.4.4 drift offset to them, shifting already-correct line numbers to wrong lines (e.g. `flist.c:2251` "sending incremental file list" -> `2286`, where 3.4.4 has that string at 2252; `flist.c:2316` "/./" strstr -> `2351`, actually 2316).

Reverting restores the already-correct citations. Verified post-revert that the mislocation rate drops back to baseline.
