### PR TITLE
docs(transfer): reline drifted upstream citations to rsync 3.4.4

### DIFF
--- a/crates/transfer/src/compressed_writer.rs
+++ b/crates/transfer/src/compressed_writer.rs
@@ -65,7 +65,7 @@ impl<W: Write> CompressedWriter<W> {
 
     /// Like [`new`](Self::new) but plumbs `--compress-threads=N` through to
     /// `ZSTD_c_nbWorkers` when zstd is the active codec. `workers` is ignored
-    /// for zlib and LZ4. upstream: `token.c:701`.
+    /// for zlib and LZ4. upstream: `token.c:749`.
     pub fn with_workers(
         inner: W,
         algorithm: CompressionAlgorithm,
@@ -149,7 +149,7 @@ impl<W: Write> CompressedWriter<W> {
     /// Calls `Z_SYNC_FLUSH` (or equivalent) on the compressor so the receiver
     /// can decompress all data written so far without waiting for more input.
     ///
-    /// upstream: `token.c:send_deflated_token()` lines 433-434 uses
+    /// upstream: `token.c:send_deflated_token()` lines 442-443 uses
     /// `Z_SYNC_FLUSH` at token boundaries for independent decompressibility.
     fn flush_compressed(&mut self) -> io::Result<()> {
         // upstream: token.c uses Z_SYNC_FLUSH after each token's data so the
@@ -413,7 +413,7 @@ mod tests {
 
         assert!(!buf.is_empty(), "flush must produce compressed output");
 
-        // upstream: token.c:send_deflated_token lines 433-434.
+        // upstream: token.c:send_deflated_token lines 442-443.
         let full = decompress_to_vec(&buf).unwrap();
         let mut expected = Vec::new();
         expected.extend_from_slice(token_data);

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -231,7 +231,7 @@ impl ServerConfigBuilder {
     /// Forwarded to `ZSTD_c_nbWorkers` when zstd is the negotiated
     /// compression algorithm.
     ///
-    /// upstream: `options.c:89`, `token.c:701`
+    /// upstream: `options.c:89`, `token.c:749`
     pub fn compression_threads(&mut self, threads: Option<std::num::NonZeroU8>) -> &mut Self {
         self.connection.compression_threads = threads;
         self
@@ -500,7 +500,7 @@ impl ServerConfigBuilder {
     ///
     /// # Upstream Reference
     ///
-    /// - `clientserver.c:1106-1107` - daemon `fake super = yes` demotes
+    /// - `clientserver.c:1120-1121` - daemon `fake super = yes` demotes
     ///   `am_root` and forces `--fake-super` semantics on the receiver
     /// - `loadparm.c` - `fake super` module parameter
     pub fn fake_super(&mut self, enabled: bool) -> &mut Self {
@@ -551,8 +551,8 @@ impl ServerConfigBuilder {
     ///
     /// - `clientserver.c:992-1004` - daemon resolves `munge_symlinks` from
     ///   `lp_munge_symlinks()` and the `use_chroot` auto default.
-    /// - `flist.c:222-226` - sender-side strip.
-    /// - `flist.c:1122-1126` - receiver-side prepend.
+    /// - `flist.c:234-238` - sender-side strip.
+    /// - `flist.c:1150-1154` - receiver-side prepend.
     pub fn munge_symlinks(&mut self, enabled: bool) -> &mut Self {
         self.munge_symlinks = enabled;
         self

--- a/crates/transfer/src/config/builder_tests.rs
+++ b/crates/transfer/src/config/builder_tests.rs
@@ -208,7 +208,7 @@ mod defaults {
     /// `ServerConfig.fake_super`, which the receiver then forwards into
     /// `MetadataOptions.fake_super` so ownership/special-file metadata is
     /// stored in the `user.rsync.%stat` xattr instead of being applied to
-    /// inodes (upstream: `clientserver.c:1106-1107`).
+    /// inodes (upstream: `clientserver.c:1120-1121`).
     #[test]
     fn fake_super_round_trips_through_builder() {
         let enabled = ServerConfigBuilder::new()

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -37,7 +37,7 @@ pub struct WriteConfig {
     /// # Upstream Reference
     ///
     /// - `compat.c:777-778`: `if (compat_flags & CF_INPLACE_PARTIAL_DIR) inplace_partial = 1;`
-    /// - `receiver.c:797`: `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR;`
+    /// - `receiver.c:910`: `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR;`
     pub inplace_partial: bool,
     /// Write data to device files instead of creating with mknod (`--write-devices`).
     pub write_devices: bool,
@@ -50,7 +50,7 @@ pub struct WriteConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:2934-2935`: `--delay-updates` option handling
+    /// - `options.c:2891-2892`: `--delay-updates` option handling
     /// - `receiver.c`: deferred rename sweep at end of transfer
     pub delay_updates: bool,
     /// Policy controlling io_uring usage for file I/O.
@@ -170,7 +170,7 @@ pub struct ConnectionConfig {
     /// # Upstream Reference
     ///
     /// - `compat.c:543`: compression vstrings skipped when compress_choice is set
-    /// - `options.c:2800-2805`: `--compress-choice=ALGO` sent as long-form arg
+    /// - `options.c:2818-2823`: `--compress-choice=ALGO` sent as long-form arg
     pub compress_choice: Option<protocol::CompressionAlgorithm>,
     /// Worker thread count for zstd's `ZSTD_c_nbWorkers` (`--compress-threads=N`).
     ///
@@ -181,7 +181,7 @@ pub struct ConnectionConfig {
     /// # Upstream Reference
     ///
     /// - `options.c:89`: `do_compression_threads` global
-    /// - `token.c:701`: `ZSTD_CCtx_setParameter(.., ZSTD_c_nbWorkers, ..)`
+    /// - `token.c:749`: `ZSTD_CCtx_setParameter(.., ZSTD_c_nbWorkers, ..)`
     pub compression_threads: Option<std::num::NonZeroU8>,
     /// Whole-stream compression store triggered by a daemon module's
     /// `dont compress = *` (upstream's match-all special case).
@@ -215,7 +215,7 @@ pub struct ConnectionConfig {
     /// # Upstream Reference
     ///
     /// - `io.c:forward_filesfrom_data()` - forwards local file to socket
-    /// - `main.c:1354-1356` - `start_filesfrom_forwarding(filesfrom_fd)`
+    /// - `main.c:1372-1374` - `start_filesfrom_forwarding(filesfrom_fd)`
     pub files_from_data: Option<Vec<u8>>,
     /// Remote source arguments the client requested on a pull, recorded as
     /// implied includes to validate the received file list (CVE-2022-29154).
@@ -350,7 +350,7 @@ pub struct ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:835`: `--checksum-seed=NUM`
+    /// - `options.c:847`: `--checksum-seed=NUM`
     /// - `compat.c:750`: `checksum_seed = (int32)time(NULL);` (default)
     pub checksum_seed: Option<u32>,
     /// Optional checksum algorithm override from `--checksum-choice`.
@@ -371,7 +371,7 @@ pub struct ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:757`: `clean_fname(thisname, CFN_REFUSE_DOT_DOT_DIRS)`
+    /// - `flist.c:769`: `clean_fname(thisname, CFN_REFUSE_DOT_DOT_DIRS)`
     /// - `options.c:797`: `--trust-sender` option definition
     /// - `options.c:2493`: trust_sender logic for args and filter
     pub trust_sender: bool,
@@ -398,7 +398,7 @@ pub struct ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2991`: `if (use_qsort) qsort(...); else merge_sort(...);`
+    /// - `flist.c:1787`: `if (use_qsort) qsort(...); else merge_sort(...);`
     /// - `options.c`: `--qsort` flag definition
     pub qsort: bool,
     /// Whether `--partial-dir` is configured on the client.
@@ -410,7 +410,7 @@ pub struct ServerConfig {
     /// # Upstream Reference
     ///
     /// - `compat.c:777-778`: `if (compat_flags & CF_INPLACE_PARTIAL_DIR) inplace_partial = 1;`
-    /// - `receiver.c:797`: `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR;`
+    /// - `receiver.c:910`: `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR;`
     pub has_partial_dir: bool,
     /// Directory path for storing partial files on interrupt (`--partial-dir=DIR`).
     ///
@@ -430,7 +430,7 @@ pub struct ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:2854-2870`: `--backup-dir=DIR` server option
+    /// - `options.c:2805-2809`: `--backup-dir=DIR` server option
     pub backup_dir: Option<String>,
     /// Backup file suffix (long-form `--backup-suffix=SUFFIX`).
     ///
@@ -439,7 +439,7 @@ pub struct ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:2871-2876`: `--backup-suffix=SUFFIX` server option
+    /// - `options.c:2812-2813`: `--backup-suffix=SUFFIX` server option
     pub backup_suffix: Option<String>,
     /// Daemon-side filter rules from module configuration.
     ///
@@ -462,8 +462,8 @@ pub struct ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:2046-2048`: `do_stats` sets `info_levels[INFO_STATS]` to 2+
-    /// - `generator.c:2377,2422`: `INFO_GTE(STATS, 2)` gates `write_del_stats()`
+    /// - `options.c:2064-2066`: `do_stats` sets `info_levels[INFO_STATS]` to 2+
+    /// - `generator.c:2393,2438`: `INFO_GTE(STATS, 2)` gates `write_del_stats()`
     pub do_stats: bool,
     /// Temporary directory for receiving files before final placement.
     ///
@@ -476,7 +476,7 @@ pub struct ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:2907-2909`: `--temp-dir` server option
+    /// - `options.c:2924-2927`: `--temp-dir` server option
     /// - `receiver.c:766`: `open_tmpfile()` uses `tmpdir` when set
     /// - `loadparm.c`: `temp dir` daemon module parameter
     pub temp_dir: Option<std::path::PathBuf>,
@@ -497,7 +497,7 @@ pub struct ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `clientserver.c:1106-1107` - daemon `fake super = yes` demotes
+    /// - `clientserver.c:1120-1121` - daemon `fake super = yes` demotes
     ///   `am_root` and forces `--fake-super` semantics on the receiver
     /// - `loadparm.c` - `fake super` module parameter
     /// - `rsync.c:set_file_attrs()` - fake-super stores ownership in xattrs
@@ -589,8 +589,8 @@ pub struct ServerConfig {
     ///
     /// - `clientserver.c:992-1004` - daemon sets `munge_symlinks` from
     ///   `lp_munge_symlinks()`.
-    /// - `flist.c:222-226` - sender strips the prefix.
-    /// - `flist.c:1122-1126` - receiver prepends the prefix.
+    /// - `flist.c:234-238` - sender strips the prefix.
+    /// - `flist.c:1150-1154` - receiver prepends the prefix.
     pub munge_symlinks: bool,
 }
 
@@ -638,7 +638,7 @@ impl ServerConfig {
     ///
     /// # Upstream Reference
     ///
-    /// - `options.c:2278-2279`: `backup_suffix = backup_dir ? "" : BACKUP_SUFFIX`
+    /// - `options.c:2296-2297`: `backup_suffix = backup_dir ? "" : BACKUP_SUFFIX`
     pub fn effective_backup_suffix(&self) -> &str {
         match self.backup_suffix.as_deref() {
             Some(s) => s,
@@ -888,7 +888,7 @@ mod tests {
 
     #[test]
     fn effective_backup_suffix_empty_when_backup_dir_set() {
-        // upstream: options.c:2278-2279 - backup_suffix = backup_dir ? "" : BACKUP_SUFFIX
+        // upstream: options.c:2296-2297 - backup_suffix = backup_dir ? "" : BACKUP_SUFFIX
         let config = ServerConfig {
             backup_dir: Some(".backups".to_owned()),
             ..Default::default()

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -2,7 +2,7 @@
 //!
 //! Contains the `DeltaApplicator` that applies delta data received from a sender
 //! to reconstruct files. Mirrors upstream rsync's `receive_data()` function from
-//! `receiver.c:240`.
+//! `receiver.c:305`.
 
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
@@ -613,7 +613,7 @@ impl<'a> DeltaApplicator<'a> {
     /// every block reference the basis bytes are fed back into the
     /// decompressor dictionary via [`TokenReader::see_token`] so the inflate
     /// state stays synchronized with the sender's deflate state - the critical
-    /// step that plain raw-`i32` reads omit (upstream: `token.c:631`
+    /// step that plain raw-`i32` reads omit (upstream: `token.c:685`
     /// `see_deflate_token()`; mirrors `sync.rs:629`).
     ///
     /// Uses the applicator's reusable `TokenBuffer` for `Pending` literal
@@ -651,7 +651,7 @@ impl<'a> DeltaApplicator<'a> {
             }
             DeltaToken::BlockRef(block_idx) => {
                 self.apply_block_ref(block_idx)?;
-                // upstream: token.c:631 see_deflate_token() - keep the inflate
+                // upstream: token.c:685 see_deflate_token() - keep the inflate
                 // dictionary synced with the sender after every block match.
                 // Mirrors the live receiver loop (sync.rs:629). Only the
                 // compressed reader needs the bytes; for the plain reader
@@ -829,7 +829,7 @@ impl<'a> DeltaApplicator<'a> {
             ));
         }
 
-        // upstream: receiver.c:240 receive_data() emits the same summary line.
+        // upstream: receiver.c:305 receive_data() emits the same summary line.
         debug_log!(
             Deltasum,
             1,
@@ -858,7 +858,7 @@ pub fn apply_delta_stream<R: Read>(
     applicator: &mut DeltaApplicator<'_>,
     token_reader: &mut TokenReader,
 ) -> io::Result<()> {
-    // upstream: receiver.c:240 receive_data() logs the same start marker.
+    // upstream: receiver.c:305 receive_data() logs the same start marker.
     debug_log!(Deltasum, 2, "recv delta stream start");
 
     while applicator.apply_token(reader, token_reader)? {}

--- a/crates/transfer/src/delta_apply/mod.rs
+++ b/crates/transfer/src/delta_apply/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module encapsulates the logic for applying delta data received from a sender
 //! to reconstruct files. It mirrors upstream rsync's `receive_data()` function from
-//! `receiver.c:240`.
+//! `receiver.c:305`.
 //!
 //! # Submodules
 //!
@@ -21,7 +21,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `receiver.c:240` - `receive_data()` - Main delta application loop
+//! - `receiver.c:305` - `receive_data()` - Main delta application loop
 //! - `receiver.c:315` - Token processing loop (literal vs block reference)
 //! - `receiver.c:374-382` - Sparse file finalization
 //! - `receiver.c:408` - File checksum verification

--- a/crates/transfer/src/delta_pipeline/chunk_builder.rs
+++ b/crates/transfer/src/delta_pipeline/chunk_builder.rs
@@ -31,7 +31,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `token.c:284` `simple_recv_token()` - the wire decoder this adapter
+//! - `token.c:285` `simple_recv_token()` - the wire decoder this adapter
 //!   layers on top of.
 //! - `match.c:288` `find_match()` - sender-side block matcher; the strong
 //!   digest at that site is the same one we compare against here.

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -47,7 +47,7 @@ pub enum PartialMode {
 /// # Upstream Reference
 ///
 /// - `backup.c:make_backup()` - renames existing file to backup path
-/// - `options.c:2854-2876` - `--backup`, `--backup-dir`, `--suffix`
+/// - `options.c:2805-2813` - `--backup`, `--backup-dir`, `--suffix`
 #[derive(Debug, Clone)]
 pub struct BackupConfig {
     /// Destination root directory for computing relative backup paths.
@@ -183,8 +183,8 @@ pub struct DiskCommitConfig {
     /// # Upstream Reference
     ///
     /// - `receiver.c:546-547`: `delayed_bits = bitbag_create()`
-    /// - `receiver.c:906-929`: staging to partial dir when `delay_updates`
-    /// - `receiver.c:584-585`: `handle_delayed_updates()` at phase 2
+    /// - `receiver.c:1029-1052`: staging to partial dir when `delay_updates`
+    /// - `receiver.c:694-695`: `handle_delayed_updates()` at phase 2
     pub delay_updates: bool,
     /// Whether `--append-verify` (append_mode == 2) is active for the session.
     ///

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -78,8 +78,8 @@ pub(super) struct CommitOutcome {
 ///
 /// # Upstream Reference
 ///
-/// - `receiver.c:906-929`: delay_updates stages to partial dir
-/// - `receiver.c:422-450`: `handle_delayed_updates()` bulk rename
+/// - `receiver.c:1029-1052`: delay_updates stages to partial dir
+/// - `receiver.c:529-557`: `handle_delayed_updates()` bulk rename
 pub(super) fn commit_file(
     begin: &BeginMessage,
     config: &DiskCommitConfig,
@@ -114,7 +114,7 @@ pub(super) fn commit_file(
     };
 
     if needs_rename && config.delay_updates {
-        // upstream: receiver.c:916-929 - stage to partial dir (.~tmp~)
+        // upstream: receiver.c:1039-1052 - stage to partial dir (.~tmp~)
         let staging_path = partial_dir_path(&begin.file_path);
         if let Some(parent) = staging_path.parent() {
             fs::create_dir_all(parent)?;
@@ -202,7 +202,7 @@ const DELAY_UPDATES_PARTIAL_DIR: &str = ".~tmp~";
 
 /// Computes the `.~tmp~/<filename>` staging path for a destination file.
 ///
-/// upstream: receiver.c:430 - `partial_dir_fname(fname)` returns
+/// upstream: receiver.c:537 - `partial_dir_fname(fname)` returns
 /// `<parent>/.~tmp~/<basename>`.
 pub(super) fn partial_dir_path(file_path: &Path) -> PathBuf {
     let parent = file_path.parent().unwrap_or(Path::new("."));

--- a/crates/transfer/src/disk_commit/process/delayed.rs
+++ b/crates/transfer/src/disk_commit/process/delayed.rs
@@ -2,7 +2,7 @@
 //!
 //! Files staged to `.~tmp~/<filename>` during commit are renamed to their
 //! final destinations after all files are committed, mirroring upstream
-//! `receiver.c:422-450` `handle_delayed_updates()`.
+//! `receiver.c:529-557` `handle_delayed_updates()`.
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -29,7 +29,7 @@ pub struct DelayedUpdateEntry {
 /// `.~tmp~/` subdirectories), this function renames each staged file to its
 /// final destination and removes the now-empty staging directories.
 ///
-/// Mirrors upstream `receiver.c:422-450` which iterates the list of delayed
+/// Mirrors upstream `receiver.c:529-557` which iterates the list of delayed
 /// files, calls `handle_partial_dir(partialptr, PDIR_DELETE)` to rename each
 /// file from the partial directory to its final path, then removes the
 /// partial directory itself.
@@ -41,7 +41,7 @@ pub struct DelayedUpdateEntry {
 /// upstream rsync behavior where a failed rename is logged and the sweep
 /// continues.
 pub fn handle_delayed_updates(outcomes: &[DelayedUpdateEntry]) -> io::Result<()> {
-    // upstream: receiver.c:422-450 - iterate delayed_bits, rename each file
+    // upstream: receiver.c:529-557 - iterate delayed_bits, rename each file
     // from partialptr to fname, then handle_partial_dir(partialptr, PDIR_DELETE)
     let mut staging_dirs = std::collections::BTreeSet::new();
 
@@ -56,7 +56,7 @@ pub fn handle_delayed_updates(outcomes: &[DelayedUpdateEntry]) -> io::Result<()>
             }
         }
 
-        // upstream: receiver.c:435 - do_rename(partialptr, fname)
+        // upstream: receiver.c:542 - do_rename(partialptr, fname)
         if let Some(parent) = outcome.final_path.parent() {
             if !parent.exists() {
                 std::fs::create_dir_all(parent)?;
@@ -73,7 +73,7 @@ pub fn handle_delayed_updates(outcomes: &[DelayedUpdateEntry]) -> io::Result<()>
         );
     }
 
-    // upstream: receiver.c:447 - handle_partial_dir(partialptr, PDIR_DELETE)
+    // upstream: receiver.c:554 - handle_partial_dir(partialptr, PDIR_DELETE)
     // Remove empty staging directories after all renames complete.
     for dir in staging_dirs.iter().rev() {
         let _ = std::fs::remove_dir(dir);
@@ -96,7 +96,7 @@ pub fn handle_delayed_updates(outcomes: &[DelayedUpdateEntry]) -> io::Result<()>
 ///
 /// # Upstream Reference
 ///
-/// - `receiver.c:410-415` - compute `partialptr` from `partial_dir` + `fname`
+/// - `receiver.c:820` - compute `partialptr` from `partial_dir` + `fname`
 pub fn delay_updates_staging_path(final_path: &Path) -> PathBuf {
     let parent = final_path.parent().unwrap_or_else(|| Path::new("."));
     let file_name = final_path.file_name().unwrap_or(final_path.as_os_str());

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -53,7 +53,7 @@ fn sum_append_prefix(
         return Ok(());
     };
 
-    // Append implies inplace (receiver.c:855), so the prefix lives at the final
+    // Append implies inplace (receiver.c:968), so the prefix lives at the final
     // destination and is untouched until the appended tail is written.
     let mut file = fs::File::open(&begin.file_path)?;
     let mut remaining = begin.append_offset;
@@ -374,7 +374,7 @@ pub(in crate::disk_commit) fn process_file(
                 // When delay_updates staged the file, apply metadata to
                 // the staging path (it will be renamed to final later).
                 let metadata_error = if outcome.delayed_path.is_some() {
-                    // upstream: receiver.c:924 - finish_transfer(partialptr, ...)
+                    // upstream: receiver.c:1047 - finish_transfer(partialptr, ...)
                     // applies metadata to the staged partial file.
                     let staged = outcome.delayed_path.as_ref().unwrap();
                     apply_file_metadata(staged, &begin, config)
@@ -689,7 +689,7 @@ fn make_inplace_backup(
 /// # Upstream Reference
 ///
 /// - `receiver.c`: `write_devices && IS_DEVICE(st.st_mode)` - inplace write to device
-/// - `receiver.c:855-860`: opens destination directly when inplace
+/// - `receiver.c:968-984`: opens destination directly when inplace
 fn open_output_file(
     begin: &BeginMessage,
     config: &DiskCommitConfig,
@@ -706,7 +706,7 @@ fn open_output_file(
             false,
         ))
     } else if begin.is_inplace {
-        // upstream: receiver.c:855 - do_open(fname, O_WRONLY|O_CREAT, 0600)
+        // upstream: receiver.c:968 - do_open(fname, O_WRONLY|O_CREAT, 0600)
         let opened = fs::OpenOptions::new()
             .write(true)
             .create(true)
@@ -725,7 +725,7 @@ fn open_output_file(
             other => other,
         };
         let mut file = opened?;
-        // upstream: receiver.c:307-308 - in append mode, seek past existing content
+        // upstream: receiver.c:372-373 - in append mode, seek past existing content
         if begin.append_offset > 0 {
             use std::io::Seek;
             file.seek(io::SeekFrom::Start(begin.append_offset))?;

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -679,7 +679,7 @@ fn commit_file_rename_replaces_existing_via_io_uring_or_fallback() {
 /// to `.~tmp~/<filename>` instead of renaming to the final destination.
 /// The final rename is deferred to the receiver's phase 2 sweep.
 ///
-/// upstream: receiver.c:906-929 - delay_updates stages to partial dir
+/// upstream: receiver.c:1029-1052 - delay_updates stages to partial dir
 #[test]
 fn delay_updates_stages_to_partial_dir() {
     let _registry_lock = test_support::cleanup_registry_test_guard();
@@ -2777,7 +2777,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
 /// when the transfer is interrupted, so partially-transferred files stay in
 /// the staging directory as valid partials for resume.
 ///
-/// upstream: receiver.c:584-585 - handle_delayed_updates() only at phase 2
+/// upstream: receiver.c:694-695 - handle_delayed_updates() only at phase 2
 #[test]
 fn delay_updates_interrupt_leaves_committed_files_in_staging() {
     let _registry_lock = test_support::cleanup_registry_test_guard();
@@ -2870,7 +2870,7 @@ fn delay_updates_interrupt_leaves_committed_files_in_staging() {
 /// file's temp file is cleaned up but any previously committed files remain
 /// staged in `.~tmp~/`.
 ///
-/// upstream: receiver.c:584 - handle_delayed_updates() only after successful
+/// upstream: receiver.c:694 - handle_delayed_updates() only after successful
 /// completion; interrupted transfers leave staged files for resume.
 #[test]
 fn delay_updates_interrupt_mid_file_retains_prior_staged_files() {
@@ -2952,7 +2952,7 @@ fn delay_updates_interrupt_mid_file_retains_prior_staged_files() {
 /// staged content is valid and complete. Without the sweep, files remain
 /// as partials for resume.
 ///
-/// upstream: receiver.c:422-450 - handle_delayed_updates() bulk rename
+/// upstream: receiver.c:529-557 - handle_delayed_updates() bulk rename
 #[test]
 fn delay_updates_manual_sweep_after_commit_moves_to_final() {
     let _registry_lock = test_support::cleanup_registry_test_guard();

--- a/crates/transfer/src/disk_commit/thread.rs
+++ b/crates/transfer/src/disk_commit/thread.rs
@@ -40,7 +40,7 @@ pub struct DiskThreadHandle {
 
 /// Spawns the disk commit thread and returns channels + join handle.
 ///
-/// Buffer recycling mirrors upstream rsync's `simple_recv_token` (token.c:284)
+/// Buffer recycling mirrors upstream rsync's `simple_recv_token` (token.c:285)
 /// which uses a single static buffer that is never freed. Here, the disk thread
 /// sends used `Vec<u8>` buffers back through `buf_return_rx` for reuse by the
 /// network thread, eliminating per-chunk malloc/free overhead.

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -106,7 +106,7 @@ pub struct ParsedServerFlags {
     pub verbose: bool,
     /// Count of `v` flags in the packed server flag string. Upstream derives
     /// info/debug levels from this count via `info_verbosity[]`
-    /// (options.c:239-243); `-vv` sets `info.name = 2`, which gates the
+    /// (options.c:250-253); `-vv` sets `info.name = 2`, which gates the
     /// itemize line for an unchanged entry (`INFO_GTE(NAME, 2)`,
     /// generator.c:582-583). Collapsing to the `verbose` bool alone loses the
     /// level needed to surface `-ivv` unchanged rows.
@@ -228,7 +228,7 @@ pub struct ParsedServerFlags {
     /// (`K` flag, `--keep-dirlinks`).
     ///
     /// Upstream: options.c:688 `{"keep-dirlinks", 'K', ...}` and
-    /// generator.c:1344 `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`.
+    /// generator.c:1356 `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`.
     /// On the receiver this prevents replacing a destination symlink-to-dir
     /// with a real directory and lets per-file operations (basis open, chmod
     /// of the file leaf) follow the dir-symlink instead of being refused by
@@ -268,7 +268,7 @@ pub struct ParsedServerFlags {
     pub append_verify: bool,
     /// Make backups before overwriting (`b` flag, `--backup`).
     ///
-    /// Upstream: `options.c:2613` - `argstr[x++] = 'b'`.
+    /// Upstream: `options.c:2631` - `argstr[x++] = 'b'`.
     pub backup: bool,
     /// Fuzzy basis file matching level (`y` flag, `--fuzzy`).
     ///
@@ -290,7 +290,7 @@ pub struct ParsedServerFlags {
     /// Remove source files after successful transfer (long-form `--remove-source-files`).
     ///
     /// Not part of the compact flag string; set via long-form args (upstream
-    /// `options.c:2964-2965` emits `--remove-source-files` whenever the client
+    /// `options.c:2982-2983` emits `--remove-source-files` whenever the client
     /// requested it). When true, the sender unlinks each source file after the
     /// receiver acknowledges a successful transfer.
     ///
@@ -439,7 +439,7 @@ impl ParsedServerFlags {
     /// the corresponding feature (`acl` or `xattr`), the flag is cleared
     /// and the feature name is returned so the caller can emit a warning.
     ///
-    /// This mirrors upstream rsync's `options.c:1842-1857` where
+    /// This mirrors upstream rsync's `options.c:1858-1873` where
     /// `SUPPORT_ACLS` / `SUPPORT_XATTRS` guards produce an error. We
     /// choose a graceful fallback instead - warn and continue without the
     /// unsupported feature.
@@ -534,10 +534,10 @@ impl ParsedServerFlags {
             b'A' => self.acls = true,
             b'X' => self.xattrs = true,
             // upstream: 'n' = dry_run (!do_xfers), NOT numeric_ids.
-            // numeric_ids is long-form only (options.c:2887 sends --numeric-ids).
+            // numeric_ids is long-form only (options.c:2905 sends --numeric-ids).
             b'n' => self.dry_run = true,
             // upstream: 'd' = --dirs (xfer_dirs without recursion), NOT delete.
-            // delete is long-form only (options.c:2818-2827 sends --delete-*).
+            // delete is long-form only (options.c:2836-2845 sends --delete-*).
             b'd' => self.dirs = true,
             b'W' => self.whole_file = true,
             b'S' => self.sparse = true,
@@ -545,7 +545,7 @@ impl ParsedServerFlags {
             b'R' => self.relative = true,
             b'P' => self.partial = true,
             b'u' => self.update = true,
-            // upstream: options.c:2613 - 'b' = backup.
+            // upstream: options.c:2631 - 'b' = backup.
             b'b' => self.backup = true,
             b'N' => self.crtimes = true,
             // upstream: options.c:764 - 'L' = copy_links (resolve symlinks).
@@ -830,7 +830,7 @@ mod tests {
     /// no clearing occurs. When the feature is absent, the flag is cleared
     /// and the feature name is returned.
     ///
-    /// upstream: options.c:1842-1857 - SUPPORT_ACLS guard
+    /// upstream: options.c:1858-1873 - SUPPORT_ACLS guard
     #[test]
     fn clear_unsupported_features_handles_acls() {
         let mut flags = ParsedServerFlags::parse("-A").unwrap();
@@ -854,7 +854,7 @@ mod tests {
     /// no clearing occurs. When the feature is absent, the flag is cleared
     /// and the feature name is returned.
     ///
-    /// upstream: options.c:1859-1868 - SUPPORT_XATTRS guard
+    /// upstream: options.c:1875-1884 - SUPPORT_XATTRS guard
     #[test]
     fn clear_unsupported_features_handles_xattrs() {
         let mut flags = ParsedServerFlags::parse("-X").unwrap();
@@ -877,7 +877,7 @@ mod tests {
     /// When both ACLs and xattrs are requested but the platform lacks support,
     /// both are cleared and reported.
     ///
-    /// upstream: options.c:1842-1868 - both guards apply independently
+    /// upstream: options.c:1858-1884 - both guards apply independently
     #[test]
     fn clear_unsupported_features_handles_both_acl_and_xattr() {
         let mut flags = ParsedServerFlags::parse("-AX").unwrap();

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -389,10 +389,10 @@ fn perishable_rules_too_modern(
 /// Upstream rsync activates multiplex output differently depending on
 /// the execution context:
 ///
-/// - **Server mode** (`--server`): always for protocol >= 23 (main.c:1247-1248).
-/// - **Client sender** (push): always for protocol >= 30 (main.c:1300-1301).
+/// - **Server mode** (`--server`): always for protocol >= 23 (main.c:1265-1266).
+/// - **Client sender** (push): always for protocol >= 30 (main.c:1318-1319).
 /// - **Client receiver** (pull): when `need_messages_from_generator` is set
-///   (main.c:1344-1347). Upstream sets this unconditionally for protocol >= 30
+///   (main.c:1362-1365). Upstream sets this unconditionally for protocol >= 30
 ///   (compat.c:776), so the client always activates multiplex output for pull.
 fn requires_multiplex_output(
     client_mode: bool,
@@ -401,7 +401,7 @@ fn requires_multiplex_output(
     _compat_flags: Option<protocol::CompatibilityFlags>,
 ) -> bool {
     if client_mode {
-        // upstream: both sender (main.c:1300) and receiver (main.c:1344)
+        // upstream: both sender (main.c:1318) and receiver (main.c:1362)
         // activate multiplex output when need_messages_from_generator is set,
         // which is unconditional for protocol >= 30 (compat.c:776).
         protocol.supports_generator_messages()
@@ -562,7 +562,7 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         Box::new(buffered.chain(stdin))
     };
 
-    // upstream: main.c:1245 start_server() → setup_protocol(f_out, f_in)
+    // upstream: main.c:1263 start_server() → setup_protocol(f_out, f_in)
     // Performs compat flags exchange + capability negotiation in RAW mode,
     // before multiplex activation.
     let is_server = !config.connection.client_mode;
@@ -573,7 +573,7 @@ pub fn run_server_with_handshake_adopting<W: Write>(
 
     // upstream: compat.c - do_compression is set by -z (short option) or by
     // --new-compress, --old-compress, --compress-choice=ALGO (long options).
-    // upstream: options.c:2704 only puts 'z' in argstr for CPRES_ZLIB.
+    // upstream: options.c:2722 only puts 'z' in argstr for CPRES_ZLIB.
     // For zlibx, zstd, lz4, upstream sends long options instead.
     let (do_compression, compress_choice) = if config.connection.client_mode {
         // upstream: compat.c - client knows its own compress_choice from CLI args.
@@ -590,7 +590,7 @@ pub fn run_server_with_handshake_adopting<W: Write>(
             .iter()
             .any(|arg| arg.starts_with('-') && !arg.starts_with("--") && arg.contains('z'));
 
-        // upstream: options.c:2800-2805 - long options for non-ZLIB compression:
+        // upstream: options.c:2818-2823 - long options for non-ZLIB compression:
         //   CPRES_ZLIBX → --new-compress
         //   CPRES_ZLIB with explicit choice → --old-compress
         //   other (zstd/lz4) → --compress-choice=ALGO
@@ -613,7 +613,7 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         // compression intent from the parsed flag string (`config.flags.compress`
         // for `-z`) and the explicit `--compress-choice` / `--new-compress` /
         // `--old-compress` long options preserved on `config.connection`.
-        // upstream: options.c:2696-2805 - server_options() emits `-z` in the
+        // upstream: options.c:2714-2823 - server_options() emits `-z` in the
         // compact arg string for CPRES_ZLIB, and the long-form variants for
         // other algorithms. Both flow through to ServerConfig here.
         let choice = config.connection.compress_choice.map(|algo| algo.as_str());
@@ -688,7 +688,7 @@ pub fn run_server_with_handshake_adopting<W: Write>(
     // upstream: compat.c:777-778 - apply CF_INPLACE_PARTIAL_DIR after compat exchange.
     // When the server advertises this flag and a partial directory is configured,
     // enable per-file inplace for partial-dir basis files.
-    // upstream: receiver.c:797 - one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR
+    // upstream: receiver.c:910 - one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR
     if let Some(flags) = setup_result.compat_flags {
         if flags.contains(protocol::CompatibilityFlags::INPLACE_PARTIAL_DIR)
             && config.has_partial_dir
@@ -707,7 +707,7 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         // sender and desynced the proto-30 flist ("xa index out of range").
     }
 
-    // upstream: options.c:1842-1868 - when compiled without SUPPORT_ACLS or
+    // upstream: options.c:1858-1884 - when compiled without SUPPORT_ACLS or
     // SUPPORT_XATTRS, the server rejects -A/-X from the client. We mirror this
     // by clearing feature-gated flags and warning instead of hard-failing, so
     // the transfer proceeds without the unsupported metadata type.
@@ -803,7 +803,7 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         handshake.protocol,
     );
 
-    // upstream: main.c:1258 - daemon sender always calls recv_filter_list(f_in).
+    // upstream: main.c:1276 - daemon sender always calls recv_filter_list(f_in).
     let should_send_filter_list = if config.connection.client_mode {
         match config.role {
             ServerRole::Generator => receiver_wants_filter_list,
@@ -843,7 +843,7 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         writer.flush()?;
     }
 
-    // upstream: main.c:1354-1356 - after sending filter list, forward
+    // upstream: main.c:1372-1374 - after sending filter list, forward
     // pre-read --files-from data to the remote daemon's generator so it
     // can build the file list from the forwarded filenames.
     // This applies only in client-mode pull (Receiver), where the daemon's
@@ -855,7 +855,7 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         }
     }
 
-    // upstream: main.c:1249-1250 - server sends MSG_IO_TIMEOUT to client.
+    // upstream: main.c:1267-1268 - server sends MSG_IO_TIMEOUT to client.
     if !config.connection.client_mode
         && let Some(timeout_secs) = handshake.io_timeout
         && handshake.protocol.supports_extended_goodbye()

--- a/crates/transfer/src/pipeline/messages.rs
+++ b/crates/transfer/src/pipeline/messages.rs
@@ -114,7 +114,7 @@ pub struct BeginMessage {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:307-308` - `offset = sum.flength; do_lseek(fd, offset, SEEK_SET)`
+    /// - `receiver.c:372-373` - `offset = sum.flength; do_lseek(fd, offset, SEEK_SET)`
     pub append_offset: u64,
     /// Xattr list resolved from the wire protocol cache for this file.
     ///
@@ -187,7 +187,7 @@ pub struct CommitResult {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:927-928`: `bitbag_set_bit(delayed_bits, ndx)`
+    /// - `receiver.c:1050-1051`: `bitbag_set_bit(delayed_bits, ndx)`
     pub delayed_path: Option<PathBuf>,
     /// Backup notice when `--backup` renamed a pre-existing file. The main
     /// thread emits this as `INFO_GTE(BACKUP, 1)` so the `--info=backup`

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -8,7 +8,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `receiver.c:970-976` - `send_msg_int(MSG_REDO, ndx)` on checksum failure
+//! - `receiver.c:1093-1099` - `send_msg_int(MSG_REDO, ndx)` on checksum failure
 //! - `generator.c:2160-2199` - `check_for_finished_files()` processes redo queue
 //! - `receiver.c:580-587` - phase transition on `NDX_DONE`
 
@@ -92,7 +92,7 @@ pub struct PipelinedReceiver {
     /// # Upstream Reference
     ///
     /// - `receiver.c:546-547`: `delayed_bits = bitbag_create()`
-    /// - `receiver.c:584-585`: `handle_delayed_updates()` sweep
+    /// - `receiver.c:694-695`: `handle_delayed_updates()` sweep
     delayed_updates: Vec<(PathBuf, PathBuf)>,
     /// Flat file indices whose commit was confirmed (finish_transfer succeeded,
     /// checksum verified). The receiver drains these and, when
@@ -342,11 +342,11 @@ impl PipelinedReceiver {
     ///
     /// When `redo_enabled` is true (phase 1), checksum mismatches queue the file
     /// index into `redo_indices` and log a warning - mirroring upstream
-    /// `receiver.c:960-973` which sends `MSG_REDO` and continues.
+    /// `receiver.c:1083-1096` which sends `MSG_REDO` and continues.
     ///
     /// When `redo_enabled` is false (phase 2), checksum mismatches are logged
     /// as errors but do not abort the transfer - mirroring upstream
-    /// `receiver.c:948-957` where `redoing=1` uses `FERROR_XFER`.
+    /// `receiver.c:1071-1080` where `redoing=1` uses `FERROR_XFER`.
     fn verify_checksum(&mut self, result: &CommitResult) -> io::Result<()> {
         let pending = match self.expected_checksums.pop_front() {
             Some(p) => p,
@@ -445,7 +445,7 @@ impl PipelinedReceiver {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:584-585`: `handle_delayed_updates()` at phase 2
+    /// - `receiver.c:694-695`: `handle_delayed_updates()` at phase 2
     pub fn take_delayed_updates(&mut self) -> Vec<(PathBuf, PathBuf)> {
         std::mem::take(&mut self.delayed_updates)
     }
@@ -461,7 +461,7 @@ impl PipelinedReceiver {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:970-974`: `send_msg_int(MSG_REDO, ndx)` sent immediately
+    /// - `receiver.c:1093-1097`: `send_msg_int(MSG_REDO, ndx)` sent immediately
     ///   when a checksum mismatch is detected during phase 1.
     pub fn drain_new_redo_indices(&mut self) -> Vec<usize> {
         std::mem::take(&mut self.redo_indices)
@@ -1256,7 +1256,7 @@ mod tests {
     /// renamed. The caller never calls `handle_delayed_updates()`, so files
     /// persist as valid partials for resume.
     ///
-    /// upstream: receiver.c:584-585 - handle_delayed_updates() only after
+    /// upstream: receiver.c:694-695 - handle_delayed_updates() only after
     /// successful transfer; interruption leaves staged files intact.
     #[test]
     fn delay_updates_drop_without_sweep_preserves_staged_files() {

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -120,7 +120,7 @@ impl DeletedRender {
 ///
 /// # Upstream Reference
 ///
-/// - `io.c:1521-1528`: receiver reads `MSG_IO_ERROR`, OR's value into
+/// - `io.c:1542-1549`: receiver reads `MSG_IO_ERROR`, OR's value into
 ///   `io_error`, and forwards it to the generator when `am_receiver`.
 /// - `io.c:1618-1627`: `MSG_NO_SEND` received on the sender/receiver pipe;
 ///   if `am_generator`, calls `got_flist_entry_status(FES_NO_SEND, val)`,
@@ -130,13 +130,13 @@ pub(crate) struct MultiplexReader<R> {
     pub(super) buffer: Vec<u8>,
     pub(super) pos: usize,
     /// Accumulated I/O error flags from `MSG_IO_ERROR` messages.
-    /// upstream: io.c:1526 `io_error |= val;`
+    /// upstream: io.c:1547 `io_error |= val;`
     pub(super) io_error: i32,
     /// File indices received via `MSG_NO_SEND` from the sender.
     /// upstream: io.c:1618-1627, sender.c:367-368
     pub(super) no_send_indices: Vec<i32>,
     /// File indices received via `MSG_REDO` from the receiver.
-    /// upstream: io.c:1514-1519, receiver.c:970-974
+    /// upstream: io.c:1535-1540, receiver.c:1093-1097
     pub(super) redo_indices: Vec<i32>,
     /// File indices received via `MSG_SUCCESS` from the peer's generator or
     /// receiver, each confirming that the file was fully received and committed
@@ -146,7 +146,7 @@ pub(crate) struct MultiplexReader<R> {
     /// upstream: io.c:1623-1637, sender.c:131-182 `successful_send()`.
     pub(super) success_indices: Vec<i32>,
     /// Exit code from MSG_ERROR_EXIT. When set, the remote has requested
-    /// immediate termination. upstream: io.c:1663-1701 calls _exit_cleanup().
+    /// immediate termination. upstream: io.c:1684-1722 calls _exit_cleanup().
     pub(super) error_exit_code: Option<i32>,
     /// Count of MSG_ERROR_XFER messages received from the remote.
     ///
@@ -181,7 +181,7 @@ pub(crate) struct MultiplexReader<R> {
 /// Exit code for partial transfer due to error.
 ///
 /// upstream: errcode.h `RERR_PARTIAL = 23`. Produced only when
-/// `got_xfer_error` is set (cleanup.c:217-218, main.c:1608-1609).
+/// `got_xfer_error` is set (cleanup.c:217-218, main.c:1630-1631).
 pub(super) const RERR_PARTIAL: i32 = 23;
 
 /// Typed error carrying the exit code a remote peer requested via
@@ -198,7 +198,7 @@ pub(super) const RERR_PARTIAL: i32 = 23;
 /// inline string form (`"remote error exit (code N)"`), so any diagnostic that
 /// rendered the wrapping `io::Error` verbatim is unchanged.
 ///
-/// upstream: io.c:1663-1701 - on `MSG_ERROR_EXIT` the client calls the NORETURN
+/// upstream: io.c:1684-1722 - on `MSG_ERROR_EXIT` the client calls the NORETURN
 /// `_exit_cleanup(val)`, exiting with the peer-supplied code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RemoteExitError {
@@ -293,7 +293,7 @@ impl<R> MultiplexReader<R> {
     ///
     /// # Upstream Reference
     ///
-    /// - `io.c:1526-1528`: `io_error |= val; if (am_receiver) send_msg_int(MSG_IO_ERROR, val);`
+    /// - `io.c:1547-1549`: `io_error |= val; if (am_receiver) send_msg_int(MSG_IO_ERROR, val);`
     pub(super) fn take_io_error(&mut self) -> i32 {
         std::mem::take(&mut self.io_error)
     }
@@ -307,7 +307,7 @@ impl<R> MultiplexReader<R> {
     /// # Upstream Reference
     ///
     /// - `log.c:311`: receipt of `FERROR_XFER` sets `got_xfer_error = 1`
-    /// - `main.c:1635`: `if (got_xfer_error) _exit(RERR_PARTIAL);`
+    /// - `main.c:1630-1631`: `if (got_xfer_error) _exit(RERR_PARTIAL);`
     pub(super) fn xfer_error_count(&self) -> u32 {
         self.xfer_error_count
     }
@@ -326,8 +326,8 @@ impl<R> MultiplexReader<R> {
     ///
     /// # Upstream Reference
     ///
-    /// - `io.c:1514-1519`: `MSG_REDO` received, calls `got_flist_entry_status(FES_REDO, val)`.
-    /// - `receiver.c:970-974`: receiver sends `MSG_REDO` when `!redoing`.
+    /// - `io.c:1535-1540`: `MSG_REDO` received, calls `got_flist_entry_status(FES_REDO, val)`.
+    /// - `receiver.c:1093-1097`: receiver sends `MSG_REDO` when `!redoing`.
     pub(super) fn take_redo_indices(&mut self) -> Vec<i32> {
         std::mem::take(&mut self.redo_indices)
     }
@@ -374,13 +374,13 @@ impl<R> MultiplexReader<R> {
     /// (confirming the daemon filter scenario) or the connection closes
     /// naturally via EOF.
     ///
-    /// upstream: generator.c:1269 - `rprintf(FERROR_XFER, "daemon refused...")`
+    /// upstream: generator.c:1281 - `rprintf(FERROR_XFER, "daemon refused...")`
     /// upstream: log.c:311 - `got_xfer_error = 1;` on FERROR_XFER receipt
-    /// upstream: main.c:1608-1609 - `if (got_xfer_error) _exit(RERR_PARTIAL);`
+    /// upstream: main.c:1630-1631 - `if (got_xfer_error) _exit(RERR_PARTIAL);`
     fn check_error_exit(&self) -> io::Result<()> {
         if let Some(code) = self.error_exit_code {
             // RERR_PARTIAL is only produced when got_xfer_error is set
-            // (upstream cleanup.c:217-218, main.c:1608-1609), so receiving
+            // (upstream cleanup.c:217-218, main.c:1630-1631), so receiving
             // exit code 23 guarantees that FERROR_XFER messages exist in the
             // wire even if we haven't read them yet. Suppression is always
             // safe - FERROR_XFER may still be in flight due to the msg2sndr
@@ -400,7 +400,7 @@ impl<R> MultiplexReader<R> {
     /// Handles a `MSG_IO_ERROR` payload by accumulating the error flags.
     ///
     /// The payload must be exactly 4 bytes (little-endian `i32`).
-    /// upstream: io.c:1522-1526
+    /// upstream: io.c:1543-1547
     fn handle_io_error_msg(&mut self) {
         if self.buffer.len() == 4 {
             let val = i32::from_le_bytes([
@@ -416,7 +416,7 @@ impl<R> MultiplexReader<R> {
     /// Handles a `MSG_REDO` payload by recording the file index.
     ///
     /// The payload must be exactly 4 bytes (little-endian `i32` file index).
-    /// upstream: io.c:1514-1519
+    /// upstream: io.c:1535-1540
     fn handle_redo_msg(&mut self) {
         if self.buffer.len() == 4 {
             let ndx = i32::from_le_bytes([
@@ -603,7 +603,7 @@ impl<R> MultiplexReader<R> {
                 }
             }
             protocol::MessageCode::ErrorExit => {
-                // upstream: io.c:1663-1701 - MSG_ERROR_EXIT carries a 4-byte
+                // upstream: io.c:1684-1722 - MSG_ERROR_EXIT carries a 4-byte
                 // exit code. Upon receipt, upstream calls _exit_cleanup(val)
                 // which is NORETURN. We propagate it as an io::Error so the
                 // transfer loop can abort cleanly.
@@ -620,7 +620,7 @@ impl<R> MultiplexReader<R> {
                 self.error_exit_code = Some(exit_code);
             }
             protocol::MessageCode::IoError => {
-                // upstream: io.c:1521-1526
+                // upstream: io.c:1542-1547
                 self.handle_io_error_msg();
             }
             protocol::MessageCode::NoSend => {
@@ -628,7 +628,7 @@ impl<R> MultiplexReader<R> {
                 self.handle_no_send_msg();
             }
             protocol::MessageCode::Redo => {
-                // upstream: io.c:1514-1519
+                // upstream: io.c:1535-1540
                 self.handle_redo_msg();
             }
             protocol::MessageCode::Success => {

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -217,7 +217,7 @@ impl<R: Read> ServerReader<R> {
     ///
     /// # Upstream Reference
     ///
-    /// - `io.c:1521-1528`: receiver accumulates `io_error |= val` and forwards
+    /// - `io.c:1542-1549`: receiver accumulates `io_error |= val` and forwards
     ///   via `send_msg_int(MSG_IO_ERROR, val)` when `am_receiver`.
     pub fn take_io_error(&mut self) -> i32 {
         match &mut self.inner {
@@ -237,7 +237,7 @@ impl<R: Read> ServerReader<R> {
     /// # Upstream Reference
     ///
     /// - `log.c:311`: receipt of `FERROR_XFER` sets `got_xfer_error = 1`
-    /// - `main.c:1635`: `if (got_xfer_error) _exit(RERR_PARTIAL);`
+    /// - `main.c:1630-1631`: `if (got_xfer_error) _exit(RERR_PARTIAL);`
     pub fn xfer_error_count(&mut self) -> u32 {
         match &mut self.inner {
             ServerReaderInner::Multiplex(mux) => mux.xfer_error_count(),
@@ -281,9 +281,9 @@ impl<R: Read> ServerReader<R> {
     ///
     /// # Upstream Reference
     ///
-    /// - `io.c:1514-1519`: `MSG_REDO` dispatches to `got_flist_entry_status(FES_REDO, val)`
+    /// - `io.c:1535-1540`: `MSG_REDO` dispatches to `got_flist_entry_status(FES_REDO, val)`
     ///   on the generator side, pushing the NDX to `redo_list`.
-    /// - `receiver.c:970-974`: receiver sends `send_msg_int(MSG_REDO, ndx)` on checksum failure.
+    /// - `receiver.c:1093-1097`: receiver sends `send_msg_int(MSG_REDO, ndx)` on checksum failure.
     pub fn take_redo_indices(&mut self) -> Vec<i32> {
         match &mut self.inner {
             ServerReaderInner::Multiplex(mux) => mux.take_redo_indices(),

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -176,7 +176,7 @@ fn multiplex_reader_buffered_partial_read() {
 
 #[test]
 fn multiplex_reader_accumulates_msg_io_error() {
-    // upstream: io.c:1521-1526
+    // upstream: io.c:1542-1547
     let mut stream = Vec::new();
 
     let io_err_val: i32 = 1; // IOERR_GENERAL
@@ -222,7 +222,7 @@ fn multiplex_reader_accumulates_msg_io_error() {
 
 #[test]
 fn multiplex_reader_io_error_wrong_payload_length_ignored() {
-    // upstream: io.c:1522 `if (msg_bytes != 4) goto invalid_msg;`
+    // upstream: io.c:1543 `if (msg_bytes != 4) goto invalid_msg;`
     let mut stream = Vec::new();
 
     protocol::send_msg(&mut stream, protocol::MessageCode::IoError, &[1, 0, 0]).unwrap();
@@ -310,7 +310,7 @@ fn msg_io_error_round_trip_through_multiplex_layer() {
     // 3. Receiver forwards accumulated flags via multiplex writer
     // 4. Generator receives the forwarded MSG_IO_ERROR
     //
-    // upstream: io.c:1521-1528
+    // upstream: io.c:1542-1549
     use crate::io_error_flags;
     use protocol::{MessageCode, MplexWriter};
     use std::io::Write;
@@ -430,7 +430,7 @@ fn multiplex_reader_accumulates_msg_no_send() {
 
 #[test]
 fn multiplex_reader_no_send_wrong_payload_length_ignored() {
-    // upstream: io.c:1619 `if (msg_bytes != 4) goto invalid_msg;`
+    // upstream: io.c:1640 `if (msg_bytes != 4) goto invalid_msg;`
     let mut stream = Vec::new();
 
     protocol::send_msg(&mut stream, protocol::MessageCode::NoSend, &[1, 0, 0]).unwrap();
@@ -481,7 +481,7 @@ fn server_reader_take_no_send_indices_multiplex_accumulates() {
 
 #[test]
 fn multiplex_reader_accumulates_msg_redo() {
-    // upstream: io.c:1514-1519, receiver.c:970-974
+    // upstream: io.c:1535-1540, receiver.c:1093-1097
     let mut stream = Vec::new();
 
     let ndx1: i32 = 5;
@@ -526,7 +526,7 @@ fn multiplex_reader_accumulates_msg_redo() {
 
 #[test]
 fn multiplex_reader_redo_wrong_payload_length_ignored() {
-    // upstream: io.c:1516 reads exactly 4 bytes for val
+    // upstream: io.c:1537 reads exactly 4 bytes for val
     let mut stream = Vec::new();
 
     protocol::send_msg(&mut stream, protocol::MessageCode::Redo, &[1, 0, 0]).unwrap();

--- a/crates/transfer/src/sanitize_path.rs
+++ b/crates/transfer/src/sanitize_path.rs
@@ -12,9 +12,9 @@
 //! # Upstream Reference
 //!
 //! - `util1.c:1035` - `sanitize_path(dest, p, rootdir, depth, flags)`
-//! - `flist.c:762` - applied to received file names in daemon mode
-//! - `flist.c:2264` - applied to `--files-from` entries
-//! - `flist.c:1154` - applied to symlink targets when `sanitize_paths && !munge_symlinks`
+//! - `flist.c:774` - applied to received file names in daemon mode
+//! - `flist.c:2299` - applied to `--files-from` entries
+//! - `flist.c:1182` - applied to symlink targets when `sanitize_paths && !munge_symlinks`
 
 /// Sanitizes a path to prevent directory traversal beyond the module root.
 ///
@@ -42,7 +42,7 @@ pub fn sanitize_path(path: &str) -> String {
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:2264` - `sanitize_path(fbuf, fbuf, "", 0, SP_KEEP_DOT_DIRS)`
+/// - `flist.c:2299` - `sanitize_path(fbuf, fbuf, "", 0, SP_KEEP_DOT_DIRS)`
 pub fn sanitize_path_keep_dot_dirs(path: &str) -> String {
     sanitize_path_with_depth(path, 0, true)
 }

--- a/crates/transfer/src/setup/capability.rs
+++ b/crates/transfer/src/setup/capability.rs
@@ -159,7 +159,7 @@ const fn iconv_capability_compiled_in() -> bool {
 /// advertise. Used when the capability string must be a standalone argument
 /// (e.g., daemon text protocol where args are newline-separated).
 ///
-/// Mirrors upstream `options.c:3003-3050 maybe_add_e_option()`.
+/// Mirrors upstream `options.c:3021-3068 maybe_add_e_option()`.
 pub fn build_capability_string(allow_inc_recurse: bool) -> String {
     let mut result = String::from("-e.");
     append_capability_chars(&mut result, allow_inc_recurse);
@@ -168,13 +168,13 @@ pub fn build_capability_string(allow_inc_recurse: bool) -> String {
 
 /// Builds the `e.xxx` capability suffix for embedding into a compact flag string.
 ///
-/// Upstream `options.c:2710` appends the capability characters directly into
+/// Upstream `options.c:2728` appends the capability characters directly into
 /// the same argstr buffer that holds the transfer flags, producing a single
 /// argument like `-logDtprHve.iLsfxCIvu`. This function returns the `e.xxx`
 /// portion without the leading `-` so callers can concatenate it with their
 /// flag string.
 ///
-/// Mirrors upstream `options.c:3003-3050 maybe_add_e_option()`.
+/// Mirrors upstream `options.c:3021-3068 maybe_add_e_option()`.
 pub fn build_capability_string_suffix(allow_inc_recurse: bool) -> String {
     let mut result = String::from("e.");
     append_capability_chars(&mut result, allow_inc_recurse);

--- a/crates/transfer/src/setup/negotiator.rs
+++ b/crates/transfer/src/setup/negotiator.rs
@@ -97,7 +97,7 @@ pub trait CapabilityNegotiator {
 pub trait ChecksumSeedExchanger {
     /// Generates (or uses a fixed) seed and writes it to the output stream.
     ///
-    /// # Seed generation (upstream `options.c:835`)
+    /// # Seed generation (upstream `options.c:847`)
     ///
     /// - `None` or `Some(0)`: generate from `time() ^ (pid << 6)`
     /// - `Some(n)`: use `n` as the fixed seed
@@ -184,7 +184,7 @@ impl CapabilityNegotiator for RsyncNegotiator {
 
 impl ChecksumSeedExchanger for RsyncNegotiator {
     fn write_seed(&self, writer: &mut dyn Write, fixed_seed: Option<u32>) -> io::Result<i32> {
-        // upstream: options.c:835 - seed generation
+        // upstream: options.c:847 - seed generation
         let seed = match fixed_seed {
             Some(0) | None => {
                 use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -30,7 +30,7 @@ fn parse_client_info_returns_empty_when_not_found() {
 
 #[test]
 fn parse_client_info_from_compact_server_flag_string() {
-    // upstream: options.c:2710 - maybe_add_e_option appends -e.LsfxCIvu
+    // upstream: options.c:2728 - maybe_add_e_option appends -e.LsfxCIvu
     // to the compact flag string. parse_client_info must extract it.
     let args = vec!["-logDtprze.iLsfxCIvu".to_owned()];
     let info = parse_client_info(&args);
@@ -1711,7 +1711,7 @@ fn server_parses_client_acl_and_xattr_flags() {
 /// (CF_AVOID_XATTR_OPTIM), since our build always compiles with xattr wire
 /// protocol support. This is how remote peers detect xattr awareness.
 ///
-/// upstream: options.c:3003-3050 - maybe_add_e_option() builds -e.xxx
+/// upstream: options.c:3021-3068 - maybe_add_e_option() builds -e.xxx
 #[test]
 fn capability_string_always_includes_xattr_marker() {
     use super::build_capability_string;

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -188,7 +188,7 @@ fn open_tmpfile_inner(
                 // parent chain at temp-file open time; a missing destination
                 // ancestor is a hard error (`mkstemp %s failed`). In-tree
                 // subdirectories are created up-front by the receiver's
-                // directory pass (generator.c:1317-1326 / create_directories),
+                // directory pass (generator.c:1329-1338 / create_directories),
                 // and the dest-arg path is created only under `--mkpath` in
                 // `ensure_dest_root_exists` (upstream main.c:736). Auto-creating
                 // here would resurrect the no-`--mkpath` deep-path bug, so we

--- a/crates/transfer/src/tests/multiplex_protocol_version.rs
+++ b/crates/transfer/src/tests/multiplex_protocol_version.rs
@@ -2,7 +2,7 @@
 //!
 //! Upstream rsync activates multiplex output at different thresholds depending
 //! on the execution context:
-//! - Server mode: protocol >= 23 (main.c:1247-1248)
+//! - Server mode: protocol >= 23 (main.c:1265-1266)
 //! - Client mode: protocol >= 30 (need_messages_from_generator, compat.c:776)
 //!
 //! These tests exercise `requires_multiplex_output` for each supported protocol

--- a/crates/transfer/src/token_reader.rs
+++ b/crates/transfer/src/token_reader.rs
@@ -22,7 +22,7 @@
 //! # Upstream Reference
 //!
 //! - `token.c:271` - `recv_token()` dispatch
-//! - `token.c:284` - `simple_recv_token()` plain format
+//! - `token.c:285` - `simple_recv_token()` plain format
 //! - `token.c:500` - `recv_deflated_token()` compressed format
 
 use std::io::{self, Read};
@@ -173,7 +173,7 @@ impl TokenReader {
     ///
     /// # Upstream Reference
     ///
-    /// - `token.c:631` - `see_deflate_token()` called after each block match
+    /// - `token.c:685` - `see_deflate_token()` called after each block match
     ///
     /// # Errors
     ///

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -99,7 +99,7 @@ pub struct RequestConfig<'a> {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:855-860`: opens destination directly when inplace
+    /// - `receiver.c:968-984`: opens destination directly when inplace
     pub inplace: bool,
     /// Per-file inplace for partial-dir basis files (CF_INPLACE_PARTIAL_DIR).
     ///
@@ -108,7 +108,7 @@ pub struct RequestConfig<'a> {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:797`: `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR`
+    /// - `receiver.c:910`: `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR`
     pub inplace_partial: bool,
     /// Policy controlling io_uring usage for file I/O (`--io-uring` / `--no-io-uring`).
     pub io_uring_policy: fast_io::IoUringPolicy,
@@ -141,7 +141,7 @@ pub struct RequestConfig<'a> {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:775-776` - generator skips writing signature blocks in append mode
+    /// - `generator.c:787-788` - generator skips writing signature blocks in append mode
     /// - `sender.c:87-92` - `receive_sums()` returns early without reading blocks
     pub append: bool,
     /// Whether append-verify mode is active (`--append-verify`, append_mode == 2).
@@ -170,7 +170,7 @@ impl RequestConfig<'_> {
     /// # Upstream Reference
     ///
     /// - `token.c:271` - `recv_token()` selects plain or compressed based on `-z`
-    /// - `token.c:807-810` - zstd `r_init` only resets `rx_token`, not the DCtx
+    /// - `token.c:863-866` - zstd `r_init` only resets `rx_token`, not the DCtx
     ///
     /// # Errors
     ///
@@ -243,7 +243,7 @@ pub struct ResponseContext<'a> {
 ///
 /// # Upstream Reference
 ///
-/// - `receiver.c:855` - append mode implies inplace.
+/// - `receiver.c:968` - append mode implies inplace.
 /// - `receiver.c:910` - `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR`.
 /// - `receiver.c:969` - `fnametmp = one_inplace ? partialptr : fname`.
 /// - `cleanup.c:105-115` - `handle_partial_dir()` moves the temp into the partial dir.
@@ -304,7 +304,7 @@ fn read_response_header<R: Read>(
         sender_attrs.fnamecmp_type,
     );
 
-    // upstream: receiver.c:287-307 - in append mode, seek output fd to existing file length
+    // upstream: receiver.c:352-372 - in append mode, seek output fd to existing file length
     // (derived from echoed sum_head) before writing new data
     let append_offset = if ctx.config.append {
         echoed_sum_head.flength()
@@ -342,7 +342,7 @@ struct ResponseHeader {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:307-308` - `offset = sum.flength; do_lseek(fd, offset, SEEK_SET)`
+    /// - `receiver.c:372-373` - `offset = sum.flength; do_lseek(fd, offset, SEEK_SET)`
     append_offset: u64,
     /// Abbreviated xattr values from the sender (1-based num, value pairs).
     ///
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn resolve_use_inplace_writes_to_destination_for_inplace_and_append() {
-        // upstream: receiver.c:855 - append implies inplace; both write to the
+        // upstream: receiver.c:968 - append implies inplace; both write to the
         // destination directly.
         assert!(resolve_use_inplace(true, false, false, None));
         assert!(resolve_use_inplace(false, true, false, None));

--- a/crates/transfer/src/transfer_ops/request.rs
+++ b/crates/transfer/src/transfer_ops/request.rs
@@ -175,7 +175,7 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
     };
     sum_head.write(writer)?;
 
-    // upstream: generator.c:775-776 - in append mode, generator skips writing
+    // upstream: generator.c:787-788 - in append mode, generator skips writing
     // signature blocks after sum_head. The sender's receive_sums() (sender.c:87-92)
     // returns early without reading blocks, using sum_head to calculate existing length.
     if !config.append {

--- a/crates/transfer/src/transfer_ops/response.rs
+++ b/crates/transfer/src/transfer_ops/response.rs
@@ -81,7 +81,7 @@ pub fn process_file_response<R: Read>(
 
     // Inplace: write directly to destination. Otherwise temp+rename for atomicity.
     let (mut file, mut cleanup_guard, needs_rename) = if use_inplace {
-        // upstream: receiver.c:855 - do_open(fname, O_WRONLY|O_CREAT, 0600)
+        // upstream: receiver.c:968 - do_open(fname, O_WRONLY|O_CREAT, 0600)
         let f = fs::OpenOptions::new()
             .write(true)
             .create(true)
@@ -110,7 +110,7 @@ pub fn process_file_response<R: Read>(
         cleanup_guard.mark_registered();
     }
 
-    // upstream: receiver.c:307-308 - in append mode, seek past existing content
+    // upstream: receiver.c:372-373 - in append mode, seek past existing content
     // so new data is written at the end of the file
     let append_offset = header.append_offset;
     if append_offset > 0 {
@@ -157,7 +157,7 @@ pub fn process_file_response<R: Read>(
         None
     };
 
-    // upstream: token.c:807-810 - reset per-file token state. For zstd the
+    // upstream: token.c:863-866 - reset per-file token state. For zstd the
     // decompression context is preserved (single continuous stream across all
     // files); for zlib it reinitializes the inflate context (per-file streams).
     token_reader.reset();
@@ -278,7 +278,7 @@ pub fn process_file_response<R: Read>(
                     }
                     checksum_verifier.update(block_data);
 
-                    // upstream: token.c:631 - see_deflate_token() keeps the
+                    // upstream: token.c:685 - see_deflate_token() keeps the
                     // decompressor dictionary in sync after block matches.
                     token_reader.see_token(block_data)?;
 

--- a/crates/transfer/src/transfer_ops/streaming.rs
+++ b/crates/transfer/src/transfer_ops/streaming.rs
@@ -129,7 +129,7 @@ pub fn process_file_response_streaming<R: Read>(
         file_entry_index,
         checksum_verifier: Some(disk_verifier),
         is_device_target,
-        // upstream: receiver.c:797 - one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR
+        // upstream: receiver.c:910 - one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR
         is_inplace: header.use_inplace,
         append_offset: header.append_offset,
         xattr_list,
@@ -145,7 +145,7 @@ pub fn process_file_response_streaming<R: Read>(
 
     let mut total_bytes: u64 = 0;
 
-    // upstream: token.c:807-810 - reset per-file token state. For zstd the
+    // upstream: token.c:863-866 - reset per-file token state. For zstd the
     // decompression context is preserved (single continuous stream across all
     // files); for zlib it reinitializes the inflate context (per-file streams).
     token_reader.reset();

--- a/crates/transfer/src/transfer_ops/token_loop.rs
+++ b/crates/transfer/src/transfer_ops/token_loop.rs
@@ -6,7 +6,7 @@
 //!
 //! # Buffer Recycling
 //!
-//! Mirrors upstream rsync's `simple_recv_token` (token.c:284) single-buffer
+//! Mirrors upstream rsync's `simple_recv_token` (token.c:285) single-buffer
 //! pattern. Buffers flow from the network thread to the disk thread and back
 //! through a return channel, avoiding per-chunk allocation.
 
@@ -25,7 +25,7 @@ use super::streaming::StreamingResult;
 
 /// Try to reuse a buffer returned by the disk thread, or allocate a new one.
 ///
-/// Mirrors upstream rsync's `simple_recv_token` (token.c:284) which uses a
+/// Mirrors upstream rsync's `simple_recv_token` (token.c:285) which uses a
 /// single static buffer. Here we recycle buffers through a return channel.
 #[inline]
 pub(super) fn recycle_or_alloc(
@@ -188,7 +188,7 @@ pub(super) fn process_remaining_tokens<R: Read>(
 
                     let block_data = basis_map.map_ptr(offset, bytes_to_copy)?;
 
-                    // upstream: token.c:631 - see_deflate_token() keeps the
+                    // upstream: token.c:685 - see_deflate_token() keeps the
                     // decompressor dictionary in sync after block matches.
                     token_reader.see_token(block_data)?;
 

--- a/crates/transfer/src/transfer_state.rs
+++ b/crates/transfer/src/transfer_state.rs
@@ -50,7 +50,7 @@ pub enum TransferPhase {
     ///
     /// Client-mode or server-mode writes/reads the filter rule list over
     /// the wire. Multiplex I/O is activated before this phase.
-    /// (upstream: `exclude.c:recv_filter_list()`, `main.c:1258`)
+    /// (upstream: `exclude.c:recv_filter_list()`, `main.c:1276`)
     FilterExchange,
 
     /// File list build, transmission, or reception.

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -84,7 +84,7 @@ impl<W: Write> ServerWriter<W> {
     }
 
     /// Like [`activate_compression`](Self::activate_compression) but plumbs
-    /// `--compress-threads=N` into `ZSTD_c_nbWorkers`. upstream: `token.c:701`.
+    /// `--compress-threads=N` into `ZSTD_c_nbWorkers`. upstream: `token.c:749`.
     pub fn activate_compression_with_workers(
         self,
         algorithm: CompressionAlgorithm,
@@ -252,8 +252,8 @@ impl<W: Write> ServerWriter<W> {
     ///
     /// # Upstream Reference
     ///
-    /// - `receiver.c:970-974`: `send_msg_int(MSG_REDO, ndx)` on checksum failure
-    /// - `io.c:1514-1519`: generator-side handler queues index to `redo_list`
+    /// - `receiver.c:1093-1097`: `send_msg_int(MSG_REDO, ndx)` on checksum failure
+    /// - `io.c:1535-1540`: generator-side handler queues index to `redo_list`
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary
- Re-lines `upstream: <file>.c:<LINE>` citations in `crates/transfer/src` (excluding `receiver/` and `generator/`, owned by a parallel effort) that were still pinned to rsync 3.4.1 line numbers, remapping them to rsync 3.4.4 (the project's source-of-truth version).
- Covers `sender.c`, `io.c`, `token.c`, `main.c`, `options.c`, `generator.c`, `receiver.c`, `flist.c`, and `clientserver.c` citations that appear in scope.
- Each remapped citation was verified against the actual 3.4.4 source text before changing; citations that already matched 3.4.4 (from earlier partial fixes) were left untouched, and a handful of citations that didn't match either 3.4.1 or 3.4.4 content are left as-is (could not be confidently relocated).
- Comment-only change; no functional code was touched.

## Test plan
- [x] Confirmed every changed line is a comment (`///`, `//`, `//!`) via diff inspection.
- [x] Confirmed all diffs are digit-only citation changes (no wording changes).
- [x] `cargo fmt -p transfer -- --check` passes (verified on aarch64 host).
- [x] `cargo clippy -p transfer --all-targets --all-features --no-deps -- -D warnings` passes (verified on aarch64 host).
