### PR TITLE
fix: chmod owned read-only dirs before deleting their contents

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls/metadata.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/metadata.rs
@@ -76,6 +76,13 @@ impl AtMetadata {
         widen_mode(self.stat.st_mode)
     }
 
+    /// Owning user id (`st_uid`). `uid_t` is `u32` on every supported
+    /// target, so no widening is needed.
+    #[must_use]
+    pub fn uid(&self) -> u32 {
+        self.stat.st_uid
+    }
+
     /// Size of the file in bytes (or the length of the symlink target
     /// when [`is_symlink`](Self::is_symlink) is `true`).
     #[must_use]

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
@@ -1396,6 +1396,92 @@ fn recursive_unlinkat_via_sandbox_or_fallback_with_no_sandbox_removes_tree() {
     assert!(!target.exists());
 }
 
+/// `true` when the test runs as root, in which case every permission
+/// bit is bypassed and the `DEL_NO_UID_WRITE` chmod-before-delete fix
+/// below is both meaningless and untestable.
+fn running_as_root() -> bool {
+    // SAFETY: `geteuid(2)` is a pure accessor with no arguments and no
+    // failure mode.
+    #[allow(unsafe_code)]
+    let euid = unsafe { libc::geteuid() };
+    euid == 0
+}
+
+// DEL_NO_UID_WRITE chmod-before-delete tests (upstream delete.c:100-101 /
+// 141-142): a directory we own but cannot write to must still be emptied
+// and removed under --delete rather than failing with EACCES.
+
+#[test]
+fn recursive_unlinkat_removes_owned_read_only_directory() {
+    if running_as_root() {
+        return;
+    }
+
+    let (_keep, root) = canonical_tempdir();
+    let tree = root.join("readonly");
+    std::fs::create_dir(&tree).expect("mkdir");
+    std::fs::write(tree.join("extraneous"), b"x").expect("write");
+    std::fs::set_permissions(&tree, std::fs::Permissions::from_mode(0o555)).expect("chmod 0555");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+    let leaf = Path::new("readonly");
+    let result = recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &tree);
+    // Defensive restore so a failed assertion below still leaves the
+    // tempdir removable by the `TempDir` drop.
+    let _ = std::fs::set_permissions(&tree, std::fs::Permissions::from_mode(0o755));
+
+    result.expect("a read-only owned directory must be removable, matching upstream");
+    assert!(!tree.exists(), "read-only directory must be gone");
+}
+
+#[test]
+fn recursive_unlinkat_removes_nested_owned_read_only_directory() {
+    // Exercises the recursive (non-top-level) call site: upstream's
+    // delete_dir_contents() chmods a doomed child before descending into
+    // it, not just the top-level delete_item() candidate.
+    if running_as_root() {
+        return;
+    }
+
+    let (_keep, root) = canonical_tempdir();
+    let tree = root.join("tree");
+    let nested = tree.join("readonly-child");
+    std::fs::create_dir_all(&nested).expect("mkdir -p");
+    std::fs::write(nested.join("extraneous"), b"x").expect("write");
+    std::fs::set_permissions(&nested, std::fs::Permissions::from_mode(0o555)).expect("chmod 0555");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+    let leaf = Path::new("tree");
+    let result = recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &tree);
+    let _ = std::fs::set_permissions(&nested, std::fs::Permissions::from_mode(0o755));
+
+    result.expect("a nested owned read-only directory must not block removal");
+    assert!(!tree.exists());
+}
+
+#[test]
+fn recursive_unlinkat_fallback_removes_owned_read_only_directory() {
+    // Same fix exercised through the no-sandbox std::fs::remove_dir_all
+    // retry path (recursive_unlinkat_via_sandbox_or_fallback's fallback
+    // arm).
+    if running_as_root() {
+        return;
+    }
+
+    let (_keep, root) = canonical_tempdir();
+    let tree = root.join("readonly");
+    std::fs::create_dir(&tree).expect("mkdir");
+    std::fs::write(tree.join("extraneous"), b"x").expect("write");
+    std::fs::set_permissions(&tree, std::fs::Permissions::from_mode(0o555)).expect("chmod 0555");
+
+    let result =
+        recursive_unlinkat_via_sandbox_or_fallback(None, &root, Path::new("readonly"), &tree);
+    let _ = std::fs::set_permissions(&tree, std::fs::Permissions::from_mode(0o755));
+
+    result.expect("the no-sandbox fallback must also honor DEL_NO_UID_WRITE");
+    assert!(!tree.exists());
+}
+
 // read_dir_via_sandbox_or_fallback tests (SEC-1.q2)
 
 fn collect_names(outcome: ReadDirOutcome) -> Vec<std::ffi::OsString> {

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
@@ -16,13 +16,21 @@ use std::os::fd::AsRawFd;
 use std::os::fd::BorrowedFd;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::Path;
+use std::sync::OnceLock;
 
 use super::errno_location;
 use super::lstat::single_component_leaf;
-use super::metadata::fstatat_nofollow;
+use super::metadata::{AtMetadata, fstatat_nofollow};
+use super::metadata_ops::fchmodat;
 use super::nested::{ParentAnchor, anchor_parent};
 use super::open::openat;
 use std::ffi::CString;
+
+/// Owner write bit (`S_IWUSR`). A plain `u32` constant rather than
+/// `libc::S_IWUSR` (whose type varies by target) sidesteps a
+/// platform-conditional cast, matching the existing convention in
+/// `metadata::chmod`.
+const S_IWUSR: u32 = 0o200;
 
 /// Selector for [`unlinkat`].
 ///
@@ -220,10 +228,59 @@ pub fn recursive_unlinkat_via_sandbox_or_fallback(
     {
         return recursive_unlinkat(dirfd.as_fd(), name);
     }
+    remove_dir_all_with_uid_write_fix(target_path)
+}
+
+/// Path-based sibling of the dirfd-anchored recursive removal above, used
+/// only when no sandbox could resolve `target_path`.
+///
+/// Tries the plain `remove_dir_all` first so the common (already-writable)
+/// case pays no extra syscalls. On `EACCES` - which upstream avoids by
+/// proactively chmodding `DEL_NO_UID_WRITE` candidates before ever
+/// attempting the unlink (`delete.c:100-101`/`141-142`) - this walks the
+/// subtree once, grants owner-write on every directory this process owns
+/// but cannot write to, and retries exactly once. Best-effort: a failed
+/// chmod during the walk is swallowed and surfaces later as the retry's
+/// own `EACCES`.
+fn remove_dir_all_with_uid_write_fix(target_path: &Path) -> io::Result<()> {
     match std::fs::remove_dir_all(target_path) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::PermissionDenied => {
+            fix_uid_write_recursive(target_path);
+            match std::fs::remove_dir_all(target_path) {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(err) => Err(err),
+            }
+        }
         Err(err) => Err(err),
+    }
+}
+
+/// Grants owner-write on `path` and every directory beneath it that this
+/// process owns but cannot write to, mirroring the dirfd-anchored check in
+/// [`recursive_unlinkat_inner`]. A symlink is never followed (`is_dir()` on
+/// [`std::fs::symlink_metadata`] is `false` for a symlink regardless of its
+/// target), matching the dirfd path's `O_NOFOLLOW` descent.
+fn fix_uid_write_recursive(path: &Path) {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        return;
+    };
+    if !meta.is_dir() {
+        return;
+    }
+    if meta.mode() & S_IWUSR == 0 && effective_uid() != 0 && meta.uid() == effective_uid() {
+        let mode = meta.mode() | S_IWUSR;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
+    }
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        fix_uid_write_recursive(&entry.path());
     }
 }
 
@@ -257,6 +314,34 @@ pub fn recursive_unlinkat(parent_dirfd: BorrowedFd<'_>, leaf: &OsStr) -> io::Res
     recursive_unlinkat_inner(parent_dirfd, leaf, &mut visited)
 }
 
+/// Caches the process effective uid (`geteuid(2)` never changes for the
+/// life of the process absent a `setuid` call this codebase never makes).
+fn effective_uid() -> u32 {
+    static EUID: OnceLock<u32> = OnceLock::new();
+    *EUID.get_or_init(|| {
+        // SAFETY: `geteuid(2)` is a pure accessor with no arguments and no
+        // failure mode.
+        #[allow(unsafe_code)]
+        unsafe {
+            libc::geteuid()
+        }
+    })
+}
+
+/// Reports whether `meta` needs the upstream `DEL_NO_UID_WRITE` chmod: it
+/// lacks the owner-write bit, we own it, and we are not root (root can
+/// always write regardless of the mode bit, so upstream never bothers).
+///
+/// # Upstream Reference
+///
+/// - `delete.c:100` / `generator.c:342` -
+///   `!(fp->mode & S_IWUSR) && !am_root && fp->flags & FLAG_OWNED_BY_US`
+/// - `flist.c:1513-1514` - `FLAG_OWNED_BY_US` is set when
+///   `am_generator && st.st_uid == our_uid`.
+fn needs_uid_write_fix(meta: &AtMetadata) -> bool {
+    meta.mode() & S_IWUSR == 0 && effective_uid() != 0 && meta.uid() == effective_uid()
+}
+
 /// Inner recursive walker shared by the public entry point and the
 /// per-entry subdir recursion. Threads the cycle-detection set through
 /// each descent level so a `(dev, ino)` we have already entered aborts
@@ -288,6 +373,26 @@ fn recursive_unlinkat_inner(
     let key = (leaf_meta.dev(), leaf_meta.ino());
     if !visited.insert(key) {
         return Err(io::Error::from_raw_os_error(libc::ELOOP));
+    }
+
+    // upstream: delete.c:100-101 `delete_dir_contents()` chmods a doomed
+    // directory it owns but cannot write to (mode lacks S_IWUSR) before
+    // descending into it, and delete.c:141-142 `delete_item()` does the
+    // same for the top-level candidate before recursing. This function
+    // serves both call sites (it is entered once for the top-level
+    // directory and again for every nested subdirectory), so a single
+    // check here covers both. The result is ignored, matching upstream's
+    // unchecked `do_chmod_at()` call - a failed chmod just means the
+    // subsequent unlinks fail with their own `EACCES`, same as if this
+    // were never attempted. Only directories are load-bearing: unlink(2)
+    // permission is governed by the *containing* directory's mode, not
+    // the removed entry's own mode, so a read-only file being deleted
+    // does not need this fix (upstream's identical file-side chmod is a
+    // no-op under POSIX unlink semantics). `leaf` is always a directory
+    // here - the `openat` above used `O_DIRECTORY` and would have failed
+    // with `ENOTDIR` otherwise.
+    if needs_uid_write_fix(&leaf_meta) {
+        let _ = fchmodat(parent_dirfd, leaf, leaf_meta.mode() | S_IWUSR, false);
     }
 
     // Step 3a: drain the children. Names are collected up-front so the

--- a/crates/transfer/tests/delete_sandbox_swap.rs
+++ b/crates/transfer/tests/delete_sandbox_swap.rs
@@ -235,3 +235,39 @@ fn sandbox_off_fallback_matches_std_for_legitimate_delete() {
         .expect("recursive unlink fallback");
     assert!(!dir.exists(), "fallback recursive unlink must remove dir");
 }
+
+/// upstream: `delete.c:100-101`/`141-142` `DEL_NO_UID_WRITE` - a destination
+/// directory we own but cannot write to (no owner-write bit) must still be
+/// emptied and removed under `--delete`, via a proactive chmod +w rather
+/// than failing with `EACCES`. Exercised at the same sandbox anchor the
+/// receiver's `delete_extraneous_files` recursive branch uses.
+#[test]
+fn delete_removes_owned_read_only_directory_containing_extraneous_file() {
+    // SAFETY: geteuid(2) is a pure accessor; root bypasses every
+    // permission check, which would make this test meaningless.
+    #[allow(unsafe_code)]
+    let euid = unsafe { libc::geteuid() };
+    if euid == 0 {
+        return;
+    }
+
+    let (_keep, root) = canonical_tempdir();
+    let dir = root.join("readonly");
+    std::fs::create_dir(&dir).expect("mkdir readonly");
+    std::fs::write(dir.join("extraneous"), b"stale").expect("write extraneous");
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).expect("chmod 0555");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+    let result = recursive_unlinkat_via_sandbox_or_fallback(
+        Some(&sandbox),
+        &root,
+        Path::new("readonly"),
+        &dir,
+    );
+    // Defensive restore so tempdir cleanup can proceed even if the
+    // assertion below fails.
+    let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755));
+
+    result.expect("a read-only owned directory must be removable under --delete");
+    assert!(!dir.exists(), "read-only directory must be gone");
+}

--- a/crates/transfer/tests/delete_sandbox_swap.rs
+++ b/crates/transfer/tests/delete_sandbox_swap.rs
@@ -22,7 +22,7 @@
 
 #![cfg(unix)]
 
-use std::os::unix::fs::symlink;
+use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::{Path, PathBuf};
 
 use fast_io::{


### PR DESCRIPTION
## Summary

Upstream `delete.c` grants a destination directory temporary owner-write
permission before deleting entries inside it, whenever that directory is
owned by the current uid but its mode lacks the owner-write bit
(`DEL_NO_UID_WRITE`, `delete.c:100-101` / `delete.c:141-142`). Without this,
`--delete` against a read-only-to-us directory (e.g. mode `0555`) fails with
`EACCES` on every child unlink, since removing an entry requires write
permission on its *containing* directory, not on the entry itself.

The receiver's delete path did not implement this: `fast_io`'s
`recursive_unlinkat` walker treated a child `EACCES` as a silent skip
instead of proactively fixing the permission, so a read-only owned
directory was left non-empty and its own `rmdir` then failed with
`ENOTEMPTY`, surfacing as a failed deletion where upstream succeeds.

## Fix

- `fast_io::recursive_unlinkat_inner` (the shared descent used by both the
  receiver's `delete_extraneous_files` and the local-copy engine's delete
  emitter): before touching a directory's contents, checks whether the
  directory's own mode lacks owner-write, is owned by the current euid, and
  we are not root, and if so grants owner-write via `fchmodat` before
  descending (matches both the top-level `delete_item()` chmod and the
  per-child `delete_dir_contents()` chmod upstream applies, since this
  function serves both call sites).
- The plain `std::fs::remove_dir_all` fallback (used when no sandbox dirfd
  is available) gets the same fix via an optimistic try-then-chmod-and-retry
  wrapper, so non-sandboxed callers are not left behind.
- Only directories are load-bearing: `unlink(2)`/`rmdir(2)` permission is
  governed by the containing directory's mode, not the removed entry's own
  mode, so upstream's identical file-side chmod is a functional no-op under
  POSIX semantics and is intentionally not replicated.

## Test plan

- [x] New unit tests in `crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs`:
      top-level read-only owned dir, nested read-only owned dir, and the
      no-sandbox fallback path.
- [x] New integration test in `crates/transfer/tests/delete_sandbox_swap.rs`
      at the same sandbox anchor the receiver uses.
- [x] Verified all 4 new tests fail with the fix reverted (`DirectoryNotEmpty`
      / `PermissionDenied`) and pass with it restored.
- [x] `cargo fmt -p transfer -p fast_io -- --check`
- [x] `cargo clippy -p fast_io -p transfer --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p fast_io -p transfer --all-features -E 'test(delet) | test(uid_write) | test(read_only)'` - 84 passed
