### PR TITLE
fix(daemon): run post-xfer exec on module-session abort paths

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -98,6 +98,22 @@ pub(crate) const FEATURE_UNAVAILABLE_EXIT_CODE: i32 = 1;
 /// push and write-only pull rejections call `exit_cleanup(RERR_SYNTAX)`
 /// (main.c:934, main.c:1167).
 pub(crate) const RERR_SYNTAX_EXIT_CODE: i32 = 1;
+/// Exit code for a refused option or a failed `pre-xfer exec` script,
+/// mirroring upstream `RERR_UNSUPPORTED`.
+///
+/// upstream: errcode.h:28 - `#define RERR_UNSUPPORTED 4`. clientserver.c:1183
+/// calls `exit_cleanup(RERR_UNSUPPORTED)` when `parse_arguments()` rejects a
+/// refused option, or when the `pre-xfer exec` script exits non-zero.
+pub(crate) const RERR_UNSUPPORTED_EXIT_CODE: i32 = 4;
+/// Exit code for a generic module-session abort (chroot/setuid/setgid syscall
+/// failure, name-converter or early-exec spawn failure, and similar setup
+/// errors that occur after the module child has been forked).
+///
+/// upstream: clientserver.c - these paths `return -1` from `rsync_module()`
+/// after the `post-xfer exec` fork point (clientserver.c:908-933); the
+/// forked child's `_exit(-1)` truncates to the low 8 bits, so the waiting
+/// parent's `WEXITSTATUS()` observes 255.
+pub(crate) const MODULE_ABORT_EXIT_CODE: i32 = 255;
 /// Exit code returned when socket I/O fails.
 const SOCKET_IO_EXIT_CODE: i32 = 10;
 

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -9,9 +9,11 @@
 /// then runs `post-xfer exec` with it. Because the parent waits for *any* child
 /// outcome, the hook fires regardless of transfer success - including a refused
 /// request (a read-only push or write-only pull exits `RERR_SYNTAX`, so the
-/// hook sees `RSYNC_EXIT_STATUS=1`). This finalizer lets the early-return refuse
-/// paths mirror that "post-xfer always runs" flow, matching the inline
-/// post-xfer dispatch on the success path.
+/// hook sees `RSYNC_EXIT_STATUS=1`) and every other early-return abort that
+/// happens after the fork point (early/pre-xfer exec failures, chroot/setuid
+/// failures, a refused option, and so on). This finalizer lets those
+/// early-return paths mirror that "post-xfer always runs" flow, matching the
+/// inline post-xfer dispatch on the success path.
 fn run_post_xfer_finalizer(
     ctx: &ModuleRequestContext<'_>,
     module: &ModuleRuntime,
@@ -163,6 +165,18 @@ fn process_approved_module(
                 Ok(Err(error_msg)) => {
                     let payload = format!("@ERROR: {error_msg}");
                     send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                    // upstream: clientserver.c:945-949 - early exec runs after
+                    // the post-xfer-exec fork point, so its failure is a
+                    // child exit the waiting parent still observes.
+                    let host_owned = ctx.effective_host().map(str::to_owned);
+                    run_post_xfer_finalizer(
+                        ctx,
+                        module,
+                        host_owned.as_deref(),
+                        auth_user.as_deref(),
+                        &[],
+                        MODULE_ABORT_EXIT_CODE,
+                    );
                     return Ok(());
                 }
                 Err(err) => {
@@ -171,6 +185,15 @@ fn process_approved_module(
                         ctx.request
                     );
                     send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                    let host_owned = ctx.effective_host().map(str::to_owned);
+                    run_post_xfer_finalizer(
+                        ctx,
+                        module,
+                        host_owned.as_deref(),
+                        auth_user.as_deref(),
+                        &[],
+                        MODULE_ABORT_EXIT_CODE,
+                    );
                     return Ok(());
                 }
             }
@@ -195,12 +218,26 @@ fn process_approved_module(
     // `MPLEX_BASE = 7`). upstream: clientserver.c:1169 io_start_multiplex_out
     // immediately followed by `rwrite(FERROR, ...)`.
     if let Some(refused) = refused_client_arg(module, &client_args) {
-        return handle_refused_option_post_handshake(
+        let host_owned = ctx.effective_host().map(str::to_owned);
+        let result = handle_refused_option_post_handshake(
             ctx,
             &refused,
             negotiated_protocol,
             &client_args,
         );
+        // upstream: clientserver.c:1079/1171 - parse_arguments() rejecting a
+        // refused option runs after the post-xfer-exec fork point and exits
+        // via exit_cleanup(RERR_UNSUPPORTED), which the waiting parent
+        // observes and still hooks.
+        run_post_xfer_finalizer(
+            ctx,
+            module,
+            host_owned.as_deref(),
+            auth_user.as_deref(),
+            &client_args,
+            RERR_UNSUPPORTED_EXIT_CODE,
+        );
+        return result;
     }
 
     // Enforce read-only / write-only access restrictions.
@@ -273,6 +310,18 @@ fn process_approved_module(
     }
 
     if !validate_module_path(ctx, module)? {
+        // upstream: clientserver.c:992-993 - change_dir() into the module
+        // path runs after the post-xfer-exec fork point, so a missing/
+        // unreachable path is a child exit the waiting parent still hooks.
+        let host_owned = ctx.effective_host().map(str::to_owned);
+        run_post_xfer_finalizer(
+            ctx,
+            module,
+            host_owned.as_deref(),
+            auth_user.as_deref(),
+            &client_args,
+            MODULE_ABORT_EXIT_CODE,
+        );
         return Ok(());
     }
 
@@ -296,7 +345,12 @@ fn process_approved_module(
     // after auth and arg reading but before the transfer starts.
     // Split into separate steps so each failure sends the correct upstream
     // error message: `@ERROR: chroot failed` vs `@ERROR: setuid failed` etc.
-    let privilege_outcome = match apply_privilege_restrictions_with_upstream_errors(ctx, module)? {
+    let privilege_outcome = match apply_privilege_restrictions_with_upstream_errors(
+        ctx,
+        module,
+        auth_user.as_deref(),
+        &client_args,
+    )? {
         Some(outcome) => outcome,
         None => return Ok(()),
     };
@@ -319,6 +373,18 @@ fn process_approved_module(
             Err(err) => {
                 let payload = format!("@ERROR: name-converter exec failed: {err}");
                 send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+                // upstream: clientserver.c:965-970 - the name-converter spawn
+                // runs after the post-xfer-exec fork point, so its failure
+                // is a child exit the waiting parent still observes.
+                let host_owned = ctx.effective_host().map(str::to_owned);
+                run_post_xfer_finalizer(
+                    ctx,
+                    module,
+                    host_owned.as_deref(),
+                    auth_user.as_deref(),
+                    &client_args,
+                    MODULE_ABORT_EXIT_CODE,
+                );
                 return Ok(());
             }
         }
@@ -350,7 +416,21 @@ fn process_approved_module(
 
     let mut config = match build_server_config(ctx, &client_args, config_module)? {
         Some(cfg) => cfg,
-        None => return Ok(()),
+        None => {
+            // upstream: clientserver.c - config assembly runs after the
+            // post-xfer-exec fork point (post-chroot, post-args), so a
+            // failure here is a child exit the waiting parent still hooks.
+            let host_owned = ctx.effective_host().map(str::to_owned);
+            run_post_xfer_finalizer(
+                ctx,
+                module,
+                host_owned.as_deref(),
+                auth_user.as_deref(),
+                &client_args,
+                MODULE_ABORT_EXIT_CODE,
+            );
+            return Ok(());
+        }
     };
 
     // upstream: clientserver.c:rsync_module() - build daemon_filter_list from
@@ -361,6 +441,15 @@ fn process_approved_module(
         Err(err) => {
             let payload = format!("@ERROR: failed to load module filter rules: {err}");
             send_error(ctx.reader.get_mut(), ctx.limiter, &payload)?;
+            let host_owned = ctx.effective_host().map(str::to_owned);
+            run_post_xfer_finalizer(
+                ctx,
+                module,
+                host_owned.as_deref(),
+                auth_user.as_deref(),
+                &client_args,
+                MODULE_ABORT_EXIT_CODE,
+            );
             return Ok(());
         }
     }
@@ -390,6 +479,15 @@ fn process_approved_module(
         .map(|p| p.as_path())
         .collect();
     if !engage_landlock_sandbox(ctx, module, &extra_allowed)? {
+        let host_owned = ctx.effective_host().map(str::to_owned);
+        run_post_xfer_finalizer(
+            ctx,
+            module,
+            host_owned.as_deref(),
+            auth_user.as_deref(),
+            &client_args,
+            MODULE_ABORT_EXIT_CODE,
+        );
         return Ok(());
     }
 
@@ -418,7 +516,18 @@ fn process_approved_module(
     let zero_copy_policy = config.write.zero_copy_policy;
     let mut streams = match setup_transfer_streams(ctx, arm_drain, zero_copy_policy)? {
         Some(s) => s,
-        None => return Ok(()),
+        None => {
+            let host_owned = ctx.effective_host().map(str::to_owned);
+            run_post_xfer_finalizer(
+                ctx,
+                module,
+                host_owned.as_deref(),
+                auth_user.as_deref(),
+                &client_args,
+                MODULE_ABORT_EXIT_CODE,
+            );
+            return Ok(());
+        }
     };
 
     // Extract host name before building structs that borrow ctx, so the
@@ -488,6 +597,17 @@ fn process_approved_module(
                     let message = rsync_error!(1, err.message).with_role(Role::Daemon);
                     log_message(log, &message);
                 }
+                // upstream: clientserver.c:1098-1100/1171 - finish_pre_exec()
+                // is checked after the post-xfer-exec fork point; a non-zero
+                // pre-xfer exec script exits via exit_cleanup(RERR_UNSUPPORTED).
+                run_post_xfer_finalizer(
+                    ctx,
+                    module,
+                    host_name_owned.as_deref(),
+                    auth_user.as_deref(),
+                    &client_args,
+                    RERR_UNSUPPORTED_EXIT_CODE,
+                );
                 return Ok(());
             }
             Err(io_err) => {
@@ -501,6 +621,16 @@ fn process_approved_module(
                     let message = rsync_error!(1, error_msg).with_role(Role::Daemon);
                     log_message(log, &message);
                 }
+                // upstream: clientserver.c:955-961 - start_pre_exec()
+                // preparation failure returns -1 from the child directly.
+                run_post_xfer_finalizer(
+                    ctx,
+                    module,
+                    host_name_owned.as_deref(),
+                    auth_user.as_deref(),
+                    &client_args,
+                    MODULE_ABORT_EXIT_CODE,
+                );
                 return Ok(());
             }
         }

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -13,9 +13,19 @@
 /// not configured; `outcome.chroot_applied` records whether the process is
 /// actually chrooted (false after a rootless auto-fallback). Returns `Ok(None)`
 /// after sending an error to the client.
+///
+/// A `chroot()`/`setgid()`/`setuid()` syscall failure runs the module's
+/// `post-xfer exec` hook before returning: upstream: clientserver.c:983-1059 -
+/// these syscalls execute after the post-xfer-exec fork point (908-933), so
+/// the waiting parent still observes the child's exit and still fires the
+/// hook. A `resolve_drop_target` uid/gid *name* resolution failure does not:
+/// upstream: clientserver.c:784-786/657-659 - that lookup runs before the
+/// fork point, so the waiting parent never sees a child at all.
 fn apply_privilege_restrictions_with_upstream_errors(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleRuntime,
+    auth_user: Option<&str>,
+    client_args: &[String],
 ) -> io::Result<Option<PrivilegeOutcome>> {
     // upstream: clientserver.c:778-779 - `uid = MY_UID(); am_root = (uid ==
     // ROOT_UID)`. A root daemon drops to `nobody:nobody` by default even when
@@ -62,6 +72,15 @@ fn apply_privilege_restrictions_with_upstream_errors(
                     CHROOT_FAILED_PAYLOAD
                 };
                 send_error(ctx.reader.get_mut(), ctx.limiter, payload)?;
+                let host_owned = ctx.effective_host().map(str::to_owned);
+                run_post_xfer_finalizer(
+                    ctx,
+                    module,
+                    host_owned.as_deref(),
+                    auth_user,
+                    client_args,
+                    MODULE_ABORT_EXIT_CODE,
+                );
                 return Ok(None);
             }
         }
@@ -78,7 +97,9 @@ fn apply_privilege_restrictions_with_upstream_errors(
                 // SYSCALL failures handled below: it yields `@ERROR: invalid
                 // uid <name>` / `@ERROR: invalid gid <name>` with a matching
                 // FLOG `Invalid uid/gid <name>`.
-                // upstream: clientserver.c:784-786 (uid) / 657-659 (gid).
+                // upstream: clientserver.c:784-786 (uid) / 657-659 (gid). This
+                // lookup runs before the post-xfer-exec fork point (908), so
+                // no `post-xfer exec` hook fires here.
                 let (flog, payload) = err.upstream_reply();
                 let message = rsync_error!(1, flog).with_role(Role::Daemon);
                 log_message(log_sink, &message);
@@ -100,6 +121,15 @@ fn apply_privilege_restrictions_with_upstream_errors(
                     SETGID_FAILED_PAYLOAD
                 };
                 send_error(ctx.reader.get_mut(), ctx.limiter, payload)?;
+                let host_owned = ctx.effective_host().map(str::to_owned);
+                run_post_xfer_finalizer(
+                    ctx,
+                    module,
+                    host_owned.as_deref(),
+                    auth_user,
+                    client_args,
+                    MODULE_ABORT_EXIT_CODE,
+                );
                 return Ok(None);
             }
         }

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -23,6 +23,7 @@ use crate::daemon::{
     FEATURE_UNAVAILABLE_EXIT_CODE,
     HostPattern,
     LEGACY_CONFIG_ENV,
+    MODULE_ABORT_EXIT_CODE,
     ModuleConnectionError,
     ModuleDefinition,
     ModuleRuntime,
@@ -223,6 +224,7 @@ include!("tests/chunks/run_daemon_rejects_invalid_port.rs");
 include!("tests/chunks/run_daemon_rejects_unknown_argument.rs");
 include!("tests/chunks/run_daemon_rejects_push_to_read_only_module.rs");
 include!("tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs");
+include!("tests/chunks/run_daemon_runs_post_xfer_exec_on_early_exec_failure.rs");
 include!("tests/chunks/run_daemon_serves_slow_handshake.rs");
 include!("tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs");
 include!("tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_early_exec_failure.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_early_exec_failure.rs
@@ -1,0 +1,103 @@
+/// A failing `early exec` command aborts the module session before any
+/// transfer starts, but the module's `post-xfer exec` hook must still run -
+/// upstream's post-xfer parent waits for the module child and runs the hook
+/// regardless of outcome, so an early-exec abort (child returns `-1`, which
+/// `_exit()` truncates to 255) fires the hook with `RSYNC_EXIT_STATUS=255`.
+///
+/// upstream: clientserver.c:908-933 - post-xfer exec runs after the child
+/// exits for any reason; clientserver.c:945-949 - early exec runs after the
+/// post-xfer-exec fork point, and its failure returns `-1` from the module
+/// child. Regression guard for the daemon skipping the hook on this
+/// early-return abort path.
+#[cfg(unix)]
+#[test]
+fn run_daemon_runs_post_xfer_exec_on_early_exec_failure() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let dir = tempdir().expect("config dir");
+    let module_dir = dir.path().join("module");
+    fs::create_dir_all(&module_dir).expect("module dir");
+
+    // post-xfer exec hook records $RSYNC_EXIT_STATUS to a marker file so the
+    // test can assert the hook ran and saw the aborted-session exit code.
+    let marker = dir.path().join("post.out");
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(
+        &config_path,
+        format!(
+            "[earlytest]\npath = {}\nread only = false\nuse chroot = false\nearly exec = exit 1\npost-xfer exec = echo \"$RSYNC_EXIT_STATUS\" > {}\n",
+            module_dir.display(),
+            marker.display()
+        ),
+    )
+    .expect("write config");
+
+    let (port, held_listener) = allocate_test_port();
+
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--once"),
+            OsString::from("--config"),
+            config_path.as_os_str().to_os_string(),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert!(line.starts_with("@RSYNCD:"), "expected greeting, got: {line}");
+
+    stream
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
+        .expect("send handshake response");
+    stream.flush().expect("flush handshake response");
+
+    stream
+        .write_all(b"earlytest\n")
+        .expect("send module request");
+    stream.flush().expect("flush module request");
+
+    // Daemon sends OK for unauthenticated modules before running early exec.
+    line.clear();
+    reader.read_line(&mut line).expect("ok message");
+    assert_eq!(line, "@RSYNCD: OK\n");
+
+    // Early exec fails immediately - the daemon never waits for client args.
+    line.clear();
+    reader.read_line(&mut line).expect("error message");
+    assert!(
+        line.starts_with("@ERROR:"),
+        "expected @ERROR, got: {line}"
+    );
+
+    drop(reader);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok());
+
+    // The post-xfer hook must have run despite the early-exec abort,
+    // recording the truncated `-1` exit status the child conveyed to the
+    // post-xfer parent.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut contents = String::new();
+    while Instant::now() < deadline {
+        if let Ok(text) = fs::read_to_string(&marker) {
+            if !text.trim().is_empty() {
+                contents = text;
+                break;
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(
+        contents.trim(),
+        MODULE_ABORT_EXIT_CODE.to_string(),
+        "post-xfer exec must run on an early-exec abort with RSYNC_EXIT_STATUS=255",
+    );
+}


### PR DESCRIPTION
## Summary

Upstream's daemon forks the module child right after auth, then waits for
that child and runs `post-xfer exec` regardless of how it exits
(`clientserver.c:908-933`). Several early-return abort paths in the daemon,
all occurring after that same point in the session, sent their `@ERROR` and
returned without ever invoking the hook:

- a failing `early exec` command
- a refused option caught after the post-OK handshake
- a `chroot()`/`setgid()`/`setuid()` syscall failure
- a name-converter spawn failure
- a failed `pre-xfer exec` script
- a few internal setup failures (server config build, filter-rule load,
  Landlock engagement, transfer-stream setup)

Each of these now routes through the existing `run_post_xfer_finalizer`,
using `RSYNC_EXIT_STATUS=4` (`RERR_UNSUPPORTED`) for the two paths that map
to upstream's `exit_cleanup(RERR_UNSUPPORTED)`, and `255` for the rest,
mirroring the `_exit(-1)` truncation upstream's other early `return -1`
paths produce.

The uid/gid *name* resolution failure inside privilege restriction is left
untouched: that lookup runs *before* the fork point in upstream
(`clientserver.c:784-786`/`657-659`), so no hook fires there either -
matching existing behavior.

## Test plan

- [x] `cargo fmt -p daemon -- --check`
- [x] `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p daemon --all-features -E 'test(post_xfer) or test(xfer_exec) or test(exec)'` (37 passed)
- [x] New regression test `run_daemon_runs_post_xfer_exec_on_early_exec_failure` verified independently
