### PR TITLE
fix: apply --fake-super to the client's own ssh/daemon role

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -552,6 +552,17 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     {
         server_config.connection.compress_choice = Some(algo);
     }
+    // upstream: options.c set_fake_super() -> am_root = -1. rsync.1: "The
+    // --fake-super option only affects the side where the option is used. To
+    // affect the remote side of a remote-shell connection, use the
+    // --remote-option (-M) option." It is therefore never sent over the wire
+    // (see fake_super_not_forwarded_on_pull/push in invocation/tests.rs), but
+    // the local client itself plays one of the two roles in-process for both
+    // SSH and daemon transfers, exactly like preallocate/remove_source_files
+    // above. Without this, --fake-super was a silent no-op on every
+    // remote-shell/daemon transfer even though the local-copy path (and the
+    // daemon's own `fake super = yes` module directive) honoured it.
+    server_config.fake_super = config.fake_super();
 }
 
 #[cfg(test)]
@@ -716,6 +727,27 @@ mod tests {
         apply_common_server_flags(&config, &mut server_config);
         assert!(!server_config.flags.copy_links);
         assert!(!server_config.flags.copy_dirlinks);
+    }
+
+    // upstream: rsync.1 "--fake-super ... only affects the side where the
+    // option is used." The local client plays one of the two roles in-process
+    // for both SSH and daemon transfers, so its own --fake-super must land on
+    // the local ServerConfig even though it is never forwarded to the remote
+    // peer (see fake_super_not_forwarded_on_pull/push in invocation/tests.rs).
+    #[test]
+    fn apply_common_server_flags_propagates_fake_super() {
+        let config = ClientConfig::builder().fake_super(true).build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(server_config.fake_super);
+    }
+
+    #[test]
+    fn apply_common_server_flags_fake_super_default_false() {
+        let config = ClientConfig::default();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(!server_config.fake_super);
     }
 
     #[test]

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -685,6 +685,30 @@ mod tests {
         assert!(!server_config.flags.mkpath);
     }
 
+    /// On an ssh pull the local client IS the receiver, so `--fake-super`
+    /// (upstream rsync.1: "only affects the side where the option is used")
+    /// applies directly without riding the wire. Regression guard: the receiver
+    /// config previously never carried this flag, so an ssh pull never stashed
+    /// `user.rsync.%stat` even though the local-copy path did.
+    #[test]
+    fn receiver_config_propagates_fake_super() {
+        let config = ClientConfig::builder().fake_super(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(server_config.fake_super);
+    }
+
+    /// Without `--fake-super` the receiver config leaves the flag clear.
+    #[test]
+    fn receiver_config_without_fake_super_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
+
+        assert!(!server_config.fake_super);
+    }
+
     /// On an ssh push the local client IS the sender and applies `--chmod`
     /// itself as it builds each outgoing flist entry (upstream flist.c:1580-1581
     /// send_file_name() -> tweak_mode()). `--chmod` is never forwarded to the
@@ -712,5 +736,30 @@ mod tests {
             build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
 
         assert!(server_config.chmod.is_none());
+    }
+
+    /// On an ssh push the local client IS the sender, so `--fake-super`
+    /// (upstream rsync.1: "only affects the side where the option is used")
+    /// applies directly: the generator reads back a source's `user.rsync.%stat`
+    /// override instead of the raw inode (transfer/generator/file_list/entry/
+    /// create.rs `fake_super_override`). Regression guard: the generator config
+    /// previously never carried this flag.
+    #[test]
+    fn generator_config_propagates_fake_super() {
+        let config = ClientConfig::builder().fake_super(true).build();
+        let server_config =
+            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
+
+        assert!(server_config.fake_super);
+    }
+
+    /// Without `--fake-super` the generator config leaves the flag clear.
+    #[test]
+    fn generator_config_without_fake_super_stays_clear() {
+        let config = ClientConfig::builder().build();
+        let server_config =
+            build_server_config_for_generator(&config, &["/tmp/source".to_owned()]).unwrap();
+
+        assert!(!server_config.fake_super);
     }
 }

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -483,20 +483,24 @@ pub struct ServerConfig {
     /// When true, store privileged metadata (uid/gid, devices, special files) in
     /// the `user.rsync.%stat` xattr instead of applying it directly to inodes.
     ///
-    /// Sourced from the daemon module's `fake super = yes` directive in
-    /// `rsyncd.conf(5)`. Lets a non-root daemon receive ownership and special-file
-    /// metadata from a privileged client by recording it in xattrs that a later
-    /// privileged restore can replay.
+    /// Set either by the client's own `--fake-super` flag (for whichever role
+    /// the local process plays over SSH/daemon transport - see
+    /// `core::client::remote::flags::apply_common_server_flags`) or by the
+    /// daemon module's `fake super = yes` directive in `rsyncd.conf(5)`, which
+    /// lets a non-root daemon receive ownership and special-file metadata from
+    /// a privileged client by recording it in xattrs that a later privileged
+    /// restore can replay.
     ///
-    /// Mirrors upstream's behaviour where a daemon module with `fake super = yes`
-    /// demotes the receiver's `am_root` to the fake-super marker (`-1`) and
-    /// rewrites a client's `--fake-super` so the daemon honours the directive
-    /// even when the client did not request it. The directive is purely
-    /// daemon-config-driven; this flag is set by the daemon when constructing
-    /// [`ServerConfig`] and is never populated from a client `--fake-super` arg.
+    /// Mirrors upstream's behaviour where `--fake-super` "only affects the
+    /// side where the option is used" (`rsync.1`) and is never sent over the
+    /// wire, and where a daemon module with `fake super = yes` independently
+    /// demotes the receiver's `am_root` to the fake-super marker (`-1`) even
+    /// when the client did not request it.
     ///
     /// # Upstream Reference
     ///
+    /// - `options.c` `set_fake_super()` - `--fake-super` sets `am_root = -1`
+    ///   on the process where the option was given
     /// - `clientserver.c:1120-1121` - daemon `fake super = yes` demotes
     ///   `am_root` and forces `--fake-super` semantics on the receiver
     /// - `loadparm.c` - `fake super` module parameter


### PR DESCRIPTION
## Summary
- `--fake-super` only ever engaged on the local-copy path. Over an ssh or daemon transfer, the client's own `--fake-super` never reached its in-process role (receiver on a pull, generator on a push), so `user.rsync.%stat` was never stashed even though the flag was parsed and honoured for a plain local copy.
- Per `rsync.1`, `--fake-super` "only affects the side where the option is used" and is never forwarded to the remote peer (`options.c` `server_options()` never emits `--fake-super`, only `--super` when `am_root > 1`). oc already matched that wire behavior (`fake_super_not_forwarded_on_pull/push`), but never carried the flag onto the client's own local role either.
- Wire it through `apply_common_server_flags` (the shared in-process point already used for every other role-local, never-forwarded flag such as `--preallocate` and `--remove-source-files`), so both the ssh and daemon client transfer builders pick it up.
- Corrected a stale doc comment on `ServerConfig::fake_super` that claimed the field was daemon-only and never client-populated.

## Test plan
- [x] `cargo fmt -p transfer -p core -- --check`
- [x] `cargo clippy -p transfer -p core --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p transfer -p core --all-features -E "test(fake_super)"` - 27 passed (4 new)
