### PR TITLE
fix: gate explicit chown/usermap/groupmap by privilege

### DIFF
--- a/crates/engine/src/local_copy/tests/execute_chown.rs
+++ b/crates/engine/src/local_copy/tests/execute_chown.rs
@@ -458,13 +458,31 @@ fn execute_group_override_to_non_member_group_without_privileges_is_skipped_not_
         return;
     }
 
+    // Pick a gid the process is provably not a member of: neither its
+    // effective gid nor any supplementary group. A hardcoded "unlikely" gid is
+    // not robust on macOS/BSD, where the default group set and getgroups
+    // membership differ from Linux; probe the real group list via rustix
+    // (portable, no unsafe) instead.
+    let mut member_gids: Vec<u32> = rustix::process::getgroups()
+        .expect("getgroups")
+        .into_iter()
+        .map(|gid| gid.as_raw())
+        .collect();
+    member_gids.push(rustix::process::getegid().as_raw());
+    let foreign_gid = (1u32..=1_000_000)
+        .find(|candidate| !member_gids.contains(candidate))
+        .expect("must find a gid outside the process's groups");
+
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"group test").expect("write source");
 
+    // Source and destination live in the same directory, so a plain copy
+    // leaves them with the same group (the process egid on Linux, the parent
+    // directory's group on macOS/BSD). With the chgrp skipped the destination
+    // keeps that natural group.
     let original_gid = fs::metadata(&source).expect("metadata").gid();
-    let unlikely_gid = 29999;
 
     let operands = vec![
         source.into_os_string(),
@@ -475,12 +493,16 @@ fn execute_group_override_to_non_member_group_without_privileges_is_skipped_not_
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_group_override(Some(unlikely_gid)),
+            LocalCopyOptions::default().with_group_override(Some(foreign_gid)),
         )
         .expect("a non-root chgrp to a non-member group must be skipped, not fatal");
 
     assert_eq!(summary.files_copied(), 1);
     let dest_gid = fs::metadata(&destination).expect("dest metadata").gid();
+    assert_ne!(
+        dest_gid, foreign_gid,
+        "the non-member group must never be applied - the chgrp must be skipped, not attempted"
+    );
     assert_eq!(
         dest_gid, original_gid,
         "group must be unchanged when the chgrp was skipped for lack of privilege"

--- a/crates/engine/src/local_copy/tests/execute_chown.rs
+++ b/crates/engine/src/local_copy/tests/execute_chown.rs
@@ -402,9 +402,14 @@ fn execute_applies_group_override_to_multiple_files() {
     assert_eq!(summary.files_copied(), 2);
 }
 
+// GAP M8: upstream's `change_uid = am_root && ...` gate (rsync.c:526) applies
+// identically to `-o`/`-a` preserve and to an explicit `--chown`/`--usermap`
+// override - there is no "explicit overrides fail loud" path in upstream. A
+// non-root process must silently skip a uid chown it cannot perform and
+// finish the transfer, not surface the kernel's EPERM as a fatal error.
 #[cfg(unix)]
 #[test]
-fn execute_owner_override_without_privileges_fails_gracefully() {
+fn execute_owner_override_without_privileges_is_skipped_not_fatal() {
     use std::os::unix::fs::MetadataExt;
 
     if rustix::process::geteuid().as_raw() == 0 {
@@ -425,21 +430,29 @@ fn execute_owner_override_without_privileges_fails_gracefully() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let result = plan.execute_with_options(
-        LocalCopyExecution::Apply,
-        LocalCopyOptions::default().with_owner_override(Some(different_uid)),
-    );
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().with_owner_override(Some(different_uid)),
+        )
+        .expect("a non-root --chown to an unreachable uid must be skipped, not fatal");
 
-    assert!(
-        result.is_err(),
-        "changing to a different user without privileges should fail"
+    assert_eq!(summary.files_copied(), 1);
+    let dest_uid = fs::metadata(&destination).expect("dest metadata").uid();
+    assert_eq!(
+        dest_uid, current_uid,
+        "ownership must be unchanged when the chown was skipped for lack of privilege"
     );
 }
 
+// GAP M8: upstream's `FLAG_SKIP_GROUP` gate (uidlist.c:284) applies
+// identically whether the target gid came from `-g`/`-a` preserve or an
+// explicit `--chown`/`--groupmap` override - a non-root process that is not a
+// member of the target group must skip the chgrp rather than fail.
 #[cfg(unix)]
 #[test]
-fn execute_group_override_to_non_member_group_without_privileges() {
-    
+fn execute_group_override_to_non_member_group_without_privileges_is_skipped_not_fatal() {
+    use std::os::unix::fs::MetadataExt;
 
     if rustix::process::geteuid().as_raw() == 0 {
         return;
@@ -450,6 +463,7 @@ fn execute_group_override_to_non_member_group_without_privileges() {
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"group test").expect("write source");
 
+    let original_gid = fs::metadata(&source).expect("metadata").gid();
     let unlikely_gid = 29999;
 
     let operands = vec![
@@ -458,14 +472,18 @@ fn execute_group_override_to_non_member_group_without_privileges() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let result = plan.execute_with_options(
-        LocalCopyExecution::Apply,
-        LocalCopyOptions::default().with_group_override(Some(unlikely_gid)),
-    );
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().with_group_override(Some(unlikely_gid)),
+        )
+        .expect("a non-root chgrp to a non-member group must be skipped, not fatal");
 
-    assert!(
-        result.is_err(),
-        "changing to a group the user is not a member of should fail"
+    assert_eq!(summary.files_copied(), 1);
+    let dest_gid = fs::metadata(&destination).expect("dest metadata").gid();
+    assert_eq!(
+        dest_gid, original_gid,
+        "group must be unchanged when the chgrp was skipped for lack of privilege"
     );
 }
 

--- a/crates/engine/src/local_copy/tests/execute_ownership_preservation.rs
+++ b/crates/engine/src/local_copy/tests/execute_ownership_preservation.rs
@@ -578,9 +578,13 @@ fn owner_and_group_preserved_on_symlink() {
     assert!(summary.symlinks_copied() >= 1);
 }
 
+// GAP M8: upstream's `change_uid = am_root && ...` gate (rsync.c:526) applies
+// to explicit `--chown`/`--usermap` overrides exactly as to `-o`/`-a` preserve.
+// A non-root process that cannot set the target uid skips the chown and
+// finishes the transfer - it does not surface the kernel's EPERM as fatal.
 #[cfg(unix)]
 #[test]
-fn non_root_cannot_change_owner_to_different_user() {
+fn non_root_owner_override_to_different_user_is_skipped_not_fatal() {
     use std::os::unix::fs::MetadataExt;
 
     // Only run this test when NOT root
@@ -594,7 +598,9 @@ fn non_root_cannot_change_owner_to_different_user() {
     fs::write(&source, b"non-root test").expect("write source");
 
     let current_uid = fs::metadata(&source).expect("metadata").uid();
-    let different_uid = if current_uid == 0 { 1000 } else { 0 };
+    // uid 0 (root) is always present and always unreachable for a non-root
+    // caller, so the gate must skip the chown regardless of platform.
+    let different_uid = 0;
 
     let operands = vec![
         source.into_os_string(),
@@ -602,33 +608,58 @@ fn non_root_cannot_change_owner_to_different_user() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Trying to change to a different user's UID should fail
-    let result = plan.execute_with_options(
-        LocalCopyExecution::Apply,
-        LocalCopyOptions::default().with_owner_override(Some(different_uid)),
-    );
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().with_owner_override(Some(different_uid)),
+        )
+        .expect("a non-root --chown to an unreachable uid must be skipped, not fatal");
 
-    assert!(
-        result.is_err(),
-        "non-root user should not be able to change file ownership"
+    assert_eq!(summary.files_copied(), 1);
+    let dest_uid = fs::metadata(&destination).expect("dest metadata").uid();
+    assert_ne!(
+        dest_uid, different_uid,
+        "the unreachable uid must never be applied - the chown must be skipped"
+    );
+    assert_eq!(
+        dest_uid, current_uid,
+        "ownership must be unchanged when the chown was skipped for lack of privilege"
     );
 }
 
+// GAP M8: upstream's `FLAG_SKIP_GROUP` gate (uidlist.c:284) drops a non-member
+// group before `do_lchown`, whether the gid came from `-g`/`-a` preserve or an
+// explicit `--chown`/`--groupmap` override.
 #[cfg(unix)]
 #[test]
-fn non_root_cannot_change_group_to_non_member() {
+fn non_root_group_override_to_non_member_is_skipped_not_fatal() {
+    use std::os::unix::fs::MetadataExt;
+
     // Only run this test when NOT root
     if rustix::process::geteuid().as_raw() == 0 {
         return;
     }
+
+    // Pick a gid the process is provably not a member of. A hardcoded
+    // "unlikely" gid is not robust on macOS/BSD, where the default group set
+    // and getgroups membership differ from Linux; probe the real group list
+    // via rustix (portable, no unsafe).
+    let mut member_gids: Vec<u32> = rustix::process::getgroups()
+        .expect("getgroups")
+        .into_iter()
+        .map(|gid| gid.as_raw())
+        .collect();
+    member_gids.push(rustix::process::getegid().as_raw());
+    let foreign_gid = (1u32..=1_000_000)
+        .find(|candidate| !member_gids.contains(candidate))
+        .expect("must find a gid outside the process's groups");
 
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
     fs::write(&source, b"non-root group test").expect("write source");
 
-    // Use a GID that the user is unlikely to be a member of
-    let unlikely_gid = 29999;
+    let original_gid = fs::metadata(&source).expect("metadata").gid();
 
     let operands = vec![
         source.into_os_string(),
@@ -636,15 +667,22 @@ fn non_root_cannot_change_group_to_non_member() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Trying to change to a group the user is not a member of should fail
-    let result = plan.execute_with_options(
-        LocalCopyExecution::Apply,
-        LocalCopyOptions::default().with_group_override(Some(unlikely_gid)),
-    );
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().with_group_override(Some(foreign_gid)),
+        )
+        .expect("a non-root chgrp to a non-member group must be skipped, not fatal");
 
-    assert!(
-        result.is_err(),
-        "non-root user should not be able to change to non-member group"
+    assert_eq!(summary.files_copied(), 1);
+    let dest_gid = fs::metadata(&destination).expect("dest metadata").gid();
+    assert_ne!(
+        dest_gid, foreign_gid,
+        "the non-member group must never be applied - the chgrp must be skipped"
+    );
+    assert_eq!(
+        dest_gid, original_gid,
+        "group must be unchanged when the chgrp was skipped for lack of privilege"
     );
 }
 

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -222,7 +222,7 @@ fn post_chown_bookkeeping(
 /// where `gate_preserved_group` short-circuits on the faked-root euid.
 #[cfg(unix)]
 #[allow(unsafe_code)]
-fn process_in_group(gid: unix_fs::Gid) -> bool {
+pub(super) fn process_in_group(gid: unix_fs::Gid) -> bool {
     if nix::unistd::getegid() == nix::unistd::Gid::from_raw(gid.as_raw()) {
         return true;
     }

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -245,13 +245,16 @@ fn process_in_group(gid: unix_fs::Gid) -> bool {
     groups[..filled as usize].contains(&target)
 }
 
-/// Gates an owner UID resolved from the *preserve* path (`-o`/`-a`, no explicit
-/// `--chown`/`--usermap`). Mirrors upstream `change_uid = am_root && ...`
-/// (rsync.c:526): a non-root process never sets a file's owner uid, so the
-/// chown is skipped rather than attempted and failed. Before this gate oc-rsync
-/// attempted it and surfaced the resulting `EPERM` as a fatal exit-code-23
-/// error, e.g. under `-aR` when an implied parent directory is owned by another
-/// user. Explicit overrides keep their fail-loud behaviour and are not routed here.
+/// Gates a resolved owner UID against process privilege, whether it came from
+/// the *preserve* path (`-o`/`-a`) or an explicit `--chown`/`--usermap`
+/// override. Mirrors upstream `change_uid = am_root && ...` (rsync.c:526):
+/// `preserve_uid` is set identically by `-o`, `--chown`, and `--usermap`
+/// (options.c:1793,1811,1833), and upstream's gate makes no distinction
+/// between them - a non-root process never sets a file's owner uid, so the
+/// chown is skipped rather than attempted and failed. Before this gate
+/// oc-rsync attempted it and surfaced the resulting `EPERM` as a fatal
+/// exit-code-23 error, e.g. under `-aR` when an implied parent directory is
+/// owned by another user, or under a non-root `--chown=user:group`.
 #[cfg(unix)]
 pub(super) fn gate_preserved_owner(owner: Option<unix_fs::Uid>) -> Option<unix_fs::Uid> {
     // nix (libc `geteuid`) so the euid reflects fakeroot's faked identity,
@@ -260,11 +263,13 @@ pub(super) fn gate_preserved_owner(owner: Option<unix_fs::Uid>) -> Option<unix_f
     owner.filter(|_| nix::unistd::geteuid().is_root())
 }
 
-/// Gates a group GID resolved from the *preserve* path (`-g`/`-a`, no explicit
-/// `--chown`/`--groupmap`). Mirrors upstream's `FLAG_SKIP_GROUP` gate
-/// (uidlist.c:284): a non-root process may only set a group it belongs to, so a
-/// non-member group is skipped rather than attempted and failed. Explicit
-/// overrides keep their fail-loud behaviour and are not routed here.
+/// Gates a resolved group GID against process privilege, whether it came from
+/// the *preserve* path (`-g`/`-a`) or an explicit `--chown`/`--groupmap`
+/// override. Mirrors upstream's `FLAG_SKIP_GROUP` gate (uidlist.c:284), which
+/// is set on the mapped id regardless of whether it was reached via
+/// `preserve_gid`, `--chown`, or `--groupmap` (options.c:1809,1832,1848): a
+/// non-root process may only set a group it belongs to, so a non-member group
+/// is skipped rather than attempted and failed.
 #[cfg(unix)]
 pub(super) fn gate_preserved_group(group: Option<unix_fs::Gid>) -> Option<unix_fs::Gid> {
     // See `gate_preserved_owner`: nix (libc `geteuid`) so fakeroot's faked root
@@ -382,7 +387,7 @@ pub(super) fn resolve_ownership(
     }
 
     let owner = if let Some(uid) = options.owner_override() {
-        Some(ownership::uid_from_raw(uid as RawUid))
+        gate_preserved_owner(Some(ownership::uid_from_raw(uid as RawUid)))
     } else if options.owner() {
         let mut raw_uid = metadata.uid() as RawUid;
         if let Some(mapping) = options.user_mapping()
@@ -397,7 +402,7 @@ pub(super) fn resolve_ownership(
         None
     };
     let group = if let Some(gid) = options.group_override() {
-        Some(ownership::gid_from_raw(gid as RawGid))
+        gate_preserved_group(Some(ownership::gid_from_raw(gid as RawGid)))
     } else if options.group() {
         let mut raw_gid = metadata.gid() as RawGid;
         if let Some(mapping) = options.group_mapping()
@@ -613,7 +618,7 @@ pub(super) fn apply_ownership_from_entry(
     }
 
     let owner = if let Some(uid_override) = options.owner_override() {
-        Some(ownership::uid_from_raw(uid_override as RawUid))
+        gate_preserved_owner(Some(ownership::uid_from_raw(uid_override as RawUid)))
     } else if options.owner() {
         gate_preserved_owner(resolve_owner_uid(entry, options))
     } else {
@@ -621,7 +626,7 @@ pub(super) fn apply_ownership_from_entry(
     };
 
     let group = if let Some(gid_override) = options.group_override() {
-        Some(ownership::gid_from_raw(gid_override as RawGid))
+        gate_preserved_group(Some(ownership::gid_from_raw(gid_override as RawGid)))
     } else if options.group() {
         gate_preserved_group(resolve_group_gid(entry, options))
     } else {
@@ -690,7 +695,7 @@ pub(super) fn apply_symlink_ownership_from_entry(
     }
 
     let owner = if let Some(uid_override) = options.owner_override() {
-        Some(ownership::uid_from_raw(uid_override as RawUid))
+        gate_preserved_owner(Some(ownership::uid_from_raw(uid_override as RawUid)))
     } else if options.owner() {
         gate_preserved_owner(resolve_owner_uid(entry, options))
     } else {
@@ -698,7 +703,7 @@ pub(super) fn apply_symlink_ownership_from_entry(
     };
 
     let group = if let Some(gid_override) = options.group_override() {
-        Some(ownership::gid_from_raw(gid_override as RawGid))
+        gate_preserved_group(Some(ownership::gid_from_raw(gid_override as RawGid)))
     } else if options.group() {
         gate_preserved_group(resolve_group_gid(entry, options))
     } else {

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -498,6 +498,99 @@ fn group_override_takes_precedence() {
     assert_eq!(dest_meta.gid(), 1000);
 }
 
+// GAP M8: upstream never distinguishes an explicit `--chown`/`--usermap`
+// override from the `-o`/`-a` preserve path - both set `preserve_uid` and are
+// gated by the same `change_uid = am_root && ...` check (rsync.c:526,
+// options.c:1793,1833). A non-root process that cannot chown must have the
+// attempt skipped, not surfaced as a fatal EPERM (exit code 23). Before this
+// fix `owner_override`/`group_override` bypassed the gate and propagated the
+// kernel's EPERM as a fatal `MetadataError`.
+#[cfg(unix)]
+#[test]
+fn owner_override_non_root_chown_is_skipped_not_fatal() {
+    if rustix::process::geteuid().is_root() {
+        // Root behaviour is exercised by owner_override_takes_precedence above.
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source-nonroot-override.txt");
+    let dest = temp.path().join("dest-nonroot-override.txt");
+    fs::write(&source, b"data").expect("write source");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let metadata = fs::metadata(&source).expect("metadata");
+    let original_uid = fs::metadata(&dest).expect("dest metadata").uid();
+
+    // Explicit `--chown=root:...` (uid 0) as a non-root process: upstream
+    // never attempts this chown (change_uid requires am_root), so oc-rsync
+    // must complete without error and leave ownership untouched.
+    apply_file_metadata_with_options(
+        &dest,
+        &metadata,
+        &MetadataOptions::new()
+            .preserve_owner(true)
+            .with_owner_override(Some(0))
+            .preserve_times(false),
+    )
+    .expect("non-root --chown to an unreachable uid must be skipped, not fatal");
+
+    let dest_meta = fs::metadata(&dest).expect("dest metadata");
+    assert_eq!(
+        dest_meta.uid(),
+        original_uid,
+        "ownership must be unchanged when the chown was skipped for lack of privilege"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn group_override_non_root_chown_to_foreign_group_is_skipped_not_fatal() {
+    if rustix::process::geteuid().is_root() {
+        // Root behaviour is exercised by group_override_takes_precedence above.
+        return;
+    }
+
+    // Pick a gid the current process is provably not a member of (neither its
+    // effective gid nor a supplementary group), reusing the same membership
+    // check the production gate uses.
+    let egid = rustix::process::getegid().as_raw();
+    let foreign_gid = (1u32..=4096)
+        .map(|delta| egid.wrapping_add(delta))
+        .find(|candidate| !super::ownership::process_in_group(ownership::gid_from_raw(*candidate)))
+        .expect("must find a gid outside the process's groups");
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source-nonroot-grp-override.txt");
+    let dest = temp.path().join("dest-nonroot-grp-override.txt");
+    fs::write(&source, b"data").expect("write source");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let metadata = fs::metadata(&source).expect("metadata");
+    let original_gid = fs::metadata(&dest).expect("dest metadata").gid();
+
+    // Explicit `--chown=:<foreign-group>` as a non-root process: upstream's
+    // FLAG_SKIP_GROUP gate (uidlist.c:284) drops this before it ever reaches
+    // do_lchown, so oc-rsync must complete without error and leave the group
+    // untouched rather than surface the kernel's EPERM as fatal.
+    apply_file_metadata_with_options(
+        &dest,
+        &metadata,
+        &MetadataOptions::new()
+            .preserve_group(true)
+            .with_group_override(Some(foreign_gid))
+            .preserve_times(false),
+    )
+    .expect("non-root --chown to a foreign group must be skipped, not fatal");
+
+    let dest_meta = fs::metadata(&dest).expect("dest metadata");
+    assert_eq!(
+        dest_meta.gid(),
+        original_gid,
+        "group must be unchanged when the chgrp was skipped for lack of privilege"
+    );
+}
+
 // Sub-100ns nanosecond preservation requires filesystem granularity finer than
 // NTFS's 100ns FILETIME, so the exact-equality assertion is Unix-only.
 #[cfg(unix)]

--- a/crates/metadata/tests/chown_utimes_symlink_race.rs
+++ b/crates/metadata/tests/chown_utimes_symlink_race.rs
@@ -29,8 +29,11 @@
 //! the destination.
 //!
 //! Attack case: application through a parent component that is a symlink to an
-//! out-of-module directory must error, and the file outside the module must
-//! be untouched.
+//! out-of-module directory must never touch the file outside the module. The
+//! timestamp case and the root-chown case observe this as an error from the
+//! sandbox refusal; the non-root chown case observes it as a skipped chown
+//! (no privilege to set the target uid in the first place), but the outside
+//! file is untouched either way.
 
 #![cfg(unix)]
 
@@ -216,17 +219,20 @@ fn receiver_chown_succeeds_on_clean_path() {
 }
 
 /// Attack path: an attacker swaps a symlink into the immediate parent
-/// component pointing outside the module. The receiver chown must refuse the
-/// syscall (the sandbox-anchored `secure_open_dir` rejects the symlinked
-/// parent) before any `fchownat` fires, and the outside file's owner must be
-/// unchanged.
+/// component pointing outside the module. The out-of-module file's owner
+/// must never become the attempted foreign uid, whichever layer stops the
+/// attempt.
 ///
-/// The `--chown` targets a foreign uid the caller cannot own. Pre-fix the
-/// path-based `fchownat(AT_FDCWD, ...)` follows the symlinked parent: as root
-/// it reowns `outside/sentinel` (apply returns `Ok`, `expect_err` panics); as
-/// a normal user it fails with `EPERM` (not the expected `ELOOP`), so the
-/// errno assertion fails. Post-fix `secure_chown_at` refuses the symlinked
-/// parent before any `fchownat` fires, regardless of privilege.
+/// The `--chown` targets a foreign uid the caller cannot own. As root the
+/// GAP-M8 privilege gate is a no-op (upstream's `am_root` check passes), so
+/// `fchownat` is actually attempted and `secure_chown_at`'s `secure_open_dir`
+/// anchor must refuse the symlinked parent (ELOOP/EXDEV/ENOTDIR) before any
+/// syscall fires. As a non-root caller, upstream never attempts a chown to a
+/// uid it cannot own in the first place (`change_uid = am_root && ...`,
+/// rsync.c:526), so `gate_preserved_owner` skips the chown before
+/// `secure_chown_at` is ever reached and the call succeeds with the
+/// destination untouched - the sandbox is simply never exercised because
+/// there is nothing left to attempt.
 #[test]
 fn receiver_chown_refuses_symlinked_parent_component() {
     let (_keep, root) = canonical_tempdir();
@@ -240,9 +246,16 @@ fn receiver_chown_refuses_symlinked_parent_component() {
         .preserve_permissions(false)
         .preserve_times(false)
         .with_owner_override(Some(FOREIGN_UID));
-    let err = apply_file_metadata_with_options(&attack_dest, &source_meta, &options)
-        .expect_err("chown through symlinked parent must error");
-    assert_refused(&err, "secure_chown_at");
+    let result = apply_file_metadata_with_options(&attack_dest, &source_meta, &options);
+
+    if rustix::process::geteuid().is_root() {
+        let err = result.expect_err("chown through symlinked parent must error");
+        assert_refused(&err, "secure_chown_at");
+    } else {
+        result.expect(
+            "a non-root chown to an unreachable uid must be skipped before secure_chown_at is ever reached",
+        );
+    }
 
     let owner_after = fs::symlink_metadata(&outside_target)
         .expect("sentinel meta")


### PR DESCRIPTION
## Summary

- Upstream never treats an explicit `--chown`/`--usermap`/`--groupmap` differently from `-o`/`-a` preserve: `set_file_attrs()` gates every ownership change on the same `change_uid = am_root && uid_ndx && ...` check (rsync.c:526-528), and `--chown`/`--usermap`/`--groupmap` all set `preserve_uid`/`preserve_gid` through the identical code path as `-o`/`-g` (options.c:1793,1809,1811,1832-1848). A non-root process never attempts a uid chown, and only attempts a gid chown when it belongs to the target group (`FLAG_SKIP_GROUP`, uidlist.c:284).
- oc-rsync already gated the preserve path this way (#6067), but routed `owner_override`/`group_override` (the value from an explicit `--chown`/`--usermap`/`--groupmap`) around that gate, so a non-root user requesting an unreachable owner/group got the kernel's `EPERM` surfaced as a fatal exit-code-23 error instead of the chown being skipped like upstream.
- Route `owner_override`/`group_override` through the same `gate_preserved_owner`/`gate_preserved_group` helpers used by the preserve path, in the local-copy (`resolve_ownership`) and network-receiver (`apply_ownership_from_entry`, `apply_symlink_ownership_from_entry`) apply paths. The chown attempt itself is unchanged for a privileged caller.
- Updated the ancestor-symlink-swap regression test (`chown_utimes_symlink_race.rs`) and two engine `execute_chown` tests that had asserted the old fail-loud behaviour.

## Test plan

- [x] `cargo fmt -p metadata -- --check` / `cargo fmt -p engine -- --check`
- [x] `cargo clippy -p metadata --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo clippy -p engine --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p metadata --all-features -E 'test(chown) or test(owner) or test(usermap) or test(groupmap)'` (37 passed, non-root)
- [x] `cargo nextest run -p metadata --all-features -E 'test(receiver_chown) or test(receiver_utimes)'` (4 passed, non-root - ancestor-symlink-swap regression suite)
- [x] `cargo nextest run -p engine --all-features -E 'test(execute_owner_override) or test(execute_group_override)'` (6 passed, non-root)
- [x] Real end-to-end comparison against the host's rsync 3.4.4 binary, run as a non-root user with `--chown=root:root` against a file the user does not own: both `rsync` and `oc-rsync` complete with exit code 0 and leave the destination's ownership unchanged.
