### PR TITLE
fix: gate MODULE_ABORT_EXIT_CODE test import to unix

### DIFF
--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -23,7 +23,6 @@ use crate::daemon::{
     FEATURE_UNAVAILABLE_EXIT_CODE,
     HostPattern,
     LEGACY_CONFIG_ENV,
-    MODULE_ABORT_EXIT_CODE,
     ModuleConnectionError,
     ModuleDefinition,
     ModuleRuntime,
@@ -70,6 +69,11 @@ use crate::daemon::{
     set_test_hostname_override,
     set_test_netgroup_members,
 };
+
+// Only the unix-only post-xfer-exec abort test references this constant, so
+// keep the import unix-gated to avoid an unused-import error on Windows.
+#[cfg(unix)]
+use crate::daemon::MODULE_ABORT_EXIT_CODE;
 
 use core::{
     bandwidth::{BandwidthLimiter, LimiterChange},


### PR DESCRIPTION
Fix a Windows build break on master (non-required Windows jobs: `Windows ACL/xattr`, `Windows daemon`, and several `Feature flag combinations` on windows-latest).

The daemon test module unconditionally imported `MODULE_ABORT_EXIT_CODE`, but its only user - the `run_daemon_runs_post_xfer_exec_on_early_exec_failure` test - is `#[cfg(unix)]` (its shell-based `post-xfer exec` scenario cannot run on Windows). On Windows the import was therefore unused, tripping `-D warnings` and failing `daemon (lib test)` compilation.

Gate the import with `#[cfg(unix)]` to match its only consumer. Linux/macOS builds are unaffected (the constant is still imported and used there); Windows no longer sees an unused import.

Verified `cargo fmt`/`cargo clippy -p daemon -D warnings` clean on Linux.
