### PR TITLE
docs: re-anchor drifted upstream citation line numbers to 3.4.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,35 @@ manual run from your branch is equivalent.
 
 ---
 
+## Upstream source citations
+
+Non-obvious protocol and wire behaviour is annotated with a citation to the
+upstream rsync C source, e.g. `// upstream: sender.c:477 - "sender finished"`.
+
+- **One pinned baseline.** Every citation line number is anchored to the single
+  pinned upstream tree at `target/interop/upstream-src/rsync-3.4.4/`. Do **not**
+  append a version to each citation - the baseline is recorded once, in
+  `tools/ci/citation_drift_audit.py` (`VER`) and `docs/UPSTREAM_COMPARISON.md`.
+  Repeating it across thousands of comments would turn a version bump into a
+  thousand-line edit instead of a one-constant edit.
+- **Quote a distinctive anchor.** Include a short verbatim string or symbol from
+  the cited line (`"sender finished"`, `csum_length = SHORT_SUM_LENGTH`) so the
+  reference can be relocated by content when line numbers move.
+- **On an upstream bump.** Line numbers drift between releases as files gain and
+  lose lines. After updating the source tree and `VER`, run the drift auditor to
+  list citations whose line no longer matches their anchor string:
+
+  ```sh
+  python3 tools/ci/citation_drift_audit.py            # all crates
+  python3 tools/ci/citation_drift_audit.py engine cli # scoped
+  ```
+
+  Re-anchor each flagged citation individually against the new source. Never
+  bulk-shift line numbers by a fixed offset: already-correct citations drift by
+  different amounts (or not at all), so a blind shift corrupts them.
+
+---
+
 ## Opening a pull request
 
 - **Branch naming.** Use `<category>/<short-description>[-<task-id>]`, for

--- a/crates/cli/src/frontend/execution/module_list.rs
+++ b/crates/cli/src/frontend/execution/module_list.rs
@@ -23,7 +23,7 @@ pub(crate) fn render_module_list<W: Write, E: Write>(
         }
     }
 
-    // upstream: clientserver.c:1254 - `io_printf(fd, "%-15s\t%s\n", name, comment)`
+    // upstream: clientserver.c:1268 - `io_printf(fd, "%-15s\t%s\n", name, comment)`
     // always emits the name, a tab, then the (possibly empty) comment. The name
     // already carries its `%-15s` padding (preserved by the `\t` split in
     // ModuleListEntry::from_line), so a comment-less module renders as

--- a/crates/cli/src/frontend/filter_rules/arguments.rs
+++ b/crates/cli/src/frontend/filter_rules/arguments.rs
@@ -108,7 +108,7 @@ pub(crate) fn build_filter_order(matches: &ArgMatches, args: &[OsString]) -> Vec
         }
 
         // Short-option cluster: `-F` and `-C` may ride alongside other flags.
-        // upstream: options.c:1589-1598 - each `-F` expands to a filter
+        // upstream: options.c:1605-1608 - each `-F` expands to a filter
         // directive (first: dir-merge, second: exclude) at its argv position.
         if text.starts_with('-') && !text.starts_with("--") && text.len() > 1 {
             for ch in text[1..].chars() {
@@ -204,7 +204,7 @@ fn inline_filter_option(
 
 /// Maps an `-F` occurrence to the filter directive it expands to.
 ///
-/// upstream: options.c:1589-1598 - the first `-F` adds `: /.rsync-filter`
+/// upstream: options.c:1608 - the first `-F` adds `: /.rsync-filter`
 /// (dir-merge), the second adds `- .rsync-filter` (exclude); third and later
 /// occurrences are ignored.
 fn rsync_filter_shortcut_directive(occurrence: usize) -> Option<OsString> {

--- a/crates/cli/src/frontend/server/daemon.rs
+++ b/crates/cli/src/frontend/server/daemon.rs
@@ -63,7 +63,7 @@ pub(crate) fn server_mode_requested(args: &[OsString]) -> bool {
 /// remote shell wrappers (e.g., `lsh.sh`) that invoke rsync as:
 ///   `rsync --config=<file> --server --daemon .`
 ///
-/// upstream: main.c:1843-1844 - when both `am_server` and `am_daemon` are set,
+/// upstream: main.c:1867-1868 - when both `am_server` and `am_daemon` are set,
 /// `start_daemon(STDIN_FILENO, STDOUT_FILENO)` is called.
 pub(crate) fn server_daemon_mode_requested(args: &[OsString]) -> bool {
     let mut has_server = false;
@@ -129,7 +129,7 @@ where
 /// inherited file descriptors. Used by remote shells (e.g., SSH) that invoke:
 ///   `oc-rsync --config=<file> --server --daemon .`
 ///
-/// upstream: main.c:1843-1844 - `start_daemon(STDIN_FILENO, STDOUT_FILENO)`.
+/// upstream: main.c:1868 - `start_daemon(STDIN_FILENO, STDOUT_FILENO)`.
 #[cfg(unix)]
 pub(crate) fn run_server_daemon_mode<Err>(args: &[OsString], stderr: &mut Err) -> i32
 where

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -549,7 +549,7 @@ impl LocalCopySummary {
         created_stats: protocol::CreatedStats,
         file_type_totals: FileTypeTotals,
     ) -> Self {
-        // upstream: main.c:387-411 output_itemized_counts() - the "Number of
+        // upstream: main.c:429 output_itemized_counts() - the "Number of
         // files" line reports the total plus a per-type breakdown where the
         // regular-file count is the remainder (total minus dirs/links/devs/
         // specials). The receiver classifies the file list into these tallies
@@ -621,7 +621,7 @@ impl LocalCopySummary {
         created_stats: protocol::CreatedStats,
         file_type_totals: FileTypeTotals,
     ) -> Self {
-        // upstream: main.c:387-411 output_itemized_counts() - "Number of files"
+        // upstream: main.c:429 output_itemized_counts() - "Number of files"
         // reports the total plus a per-type breakdown where reg is the
         // remainder. The sender tallies the typed counts in send_file_entry()
         // (flist.c:421-438); reg is derived here so a push prints the same

--- a/crates/transfer/src/generator/transfer/mod.rs
+++ b/crates/transfer/src/generator/transfer/mod.rs
@@ -94,7 +94,7 @@ mod send_debug_emission_tests {
 
     #[test]
     fn sender_finished_matches_upstream() {
-        // upstream: sender.c:445-446 - "sender finished %s%s%s"
+        // upstream: sender.c:477 - "sender finished %s%s%s"
         init_send_level1();
         let name = PathBuf::from("dir/file.txt");
         debug_log!(Send, 1, "sender finished {}", name.display());
@@ -107,7 +107,7 @@ mod send_debug_emission_tests {
 
     #[test]
     fn send_files_finished_matches_upstream() {
-        // upstream: sender.c:457-458 - "send files finished"
+        // upstream: sender.c:489 - "send files finished"
         init_send_level1();
         debug_log!(Send, 1, "send files finished");
         let msgs = send_messages();

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -73,7 +73,7 @@ pub use self::wire::{
 /// signature wire size. The `derive_strong_sum_length()` heuristic computes
 /// a dynamic length between 2-16 bytes based on file and block sizes.
 ///
-/// (upstream: generator.c:2157 `csum_length = SHORT_SUM_LENGTH`)
+/// (upstream: generator.c:2205 `csum_length = SHORT_SUM_LENGTH`)
 const PHASE1_CHECKSUM_LENGTH: NonZeroU8 =
     NonZeroU8::new(signature::block_size::SHORT_SUM_LENGTH).unwrap();
 

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -380,7 +380,7 @@ mod genr_debug_emission_tests {
 
     #[test]
     fn generator_starting_matches_upstream() {
-        // upstream: generator.c:2260-2261 - "generator starting pid=%d"
+        // upstream: generator.c:2277-2278 - "generator starting pid=%d"
         init_genr_level1();
         let pid: u32 = 12345;
         debug_log!(Genr, 1, "generator starting pid={}", pid);


### PR DESCRIPTION
Re-anchors eight `// upstream: file.c:LINE` citations whose line numbers
carried over from rsync 3.4.1 and drifted in 3.4.4. Each was re-anchored to
the exact 3.4.4 line by its quoted-string anchor (verified against
`target/interop/upstream-src/rsync-3.4.4/`), not by a blind offset:

| File | Anchor | Was | Now |
|------|--------|-----|-----|
| engine `local_copy/plan/summary.rs` | `output_itemized_counts("Number of files", ...)` | main.c:387-411 | main.c:429 |
| transfer `generator/transfer/mod.rs` | `"sender finished %s%s%s"` | sender.c:445-446 | sender.c:477 |
| transfer `generator/transfer/mod.rs` | `"send files finished"` | sender.c:457-458 | sender.c:489 |
| transfer `receiver/transfer/phases.rs` | `"generator starting pid=%d"` | generator.c:2260-2261 | generator.c:2277-2278 |
| transfer `receiver/mod.rs` | `csum_length = SHORT_SUM_LENGTH` | generator.c:2157 | generator.c:2205 |
| cli `execution/module_list.rs` | `io_printf(fd, "%-15s\t%s\n", ...)` | clientserver.c:1254 | clientserver.c:1268 |
| cli `server/daemon.rs` | `start_daemon(STDIN_FILENO, STDOUT_FILENO)` | main.c:1843-1844 | main.c:1867-1868 / 1868 |
| cli `filter_rules/arguments.rs` | `parse_filter_str(": /.rsync-filter")` | options.c:1589-1598 | options.c:1605-1608 / 1608 |

Function-definition cites (e.g. `output_itemized_counts()` at main.c:387) and
already-correct adjacent cites (`csum_length = SUM_LENGTH` at generator.c:2178;
the daemon `descrip="a="` inside the existing `options.c:965-980` range) were
left untouched after per-citation verification.

Comment-only; no behavior change.


---

**Also documents the convention** (CONTRIBUTING.md) so this does not silently
recur: the baseline version lives in one place (`citation_drift_audit.py` `VER`
+ `UPSTREAM_COMPARISON.md`) rather than duplicated across 5,251 comments, and a
version bump is handled by re-running the drift auditor and re-anchoring each
flagged citation individually.
