### PR TITLE
docs: update interop matrices to the 3.4.4 tested baseline

### DIFF
--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -1,9 +1,9 @@
 # oc-rsync Interoperability Tests
 
-**Last Updated**: 2025-11-25
+**Last Updated**: 2026-07-23
 **Status**: RESTORED TO CI PIPELINE
 
-This document defines the upstream compatibility test scenarios used to validate oc-rsync's parity with rsync 2.6.9, 3.0.9, 3.1.3, 3.4.1, and 3.4.2.
+This document defines the upstream compatibility test scenarios used to validate oc-rsync's parity with rsync 2.6.9, 3.0.9, 3.1.3, and 3.4.4.
 
 ---
 
@@ -12,8 +12,7 @@ This document defines the upstream compatibility test scenarios used to validate
 - `rsync-2.6.9` (always built from source; protocol-28 cutoff peer)
 - `rsync-3.0.9` (via old-releases.ubuntu.com or source build)
 - `rsync-3.1.3` (via archive.ubuntu.com or source build)
-- `rsync-3.4.1` (via deb.debian.org or source build)
-- `rsync-3.4.2` (via deb.debian.org or source build)
+- `rsync-3.4.4` (built from source; latest release, supersedes 3.4.1/3.4.2/3.4.3)
 
 ---
 
@@ -26,7 +25,7 @@ This document defines the upstream compatibility test scenarios used to validate
 | Remote copy via SSH (sender/recv)   | `-av host:/src /dest`                     | ✅        | Native SSH transport integrated |
 | Daemon transfer (host::module)      | `-av rsync://host/module/ /dest`         | ✅        | Auth + transfers fixed in Phase 3 |
 | Filters (include/exclude/filter)    | Deep ruleset match                        | ✅        | Comprehensive coverage |
-| Compression level                   | `-z --compress-level=9`                  | ✅        | Verified against rsync 3.4.1 |
+| Compression level                   | `-z --compress-level=9`                  | ✅        | Verified against rsync 3.4.4 |
 | Metadata flags                      | `-aHAX --numeric-ids`                    | ✅        | POSIX ACLs (access+default, mask, named user/group) wire-faithful vs upstream on Linux/macOS/FreeBSD; Windows DACL supported (SACL/inheritance deferred) |
 | Delete options                      | `--delete-excluded`, etc.                | ✅        | All variants working |
 | File list diffing                   | Match order, mtime, permission checks     | ✅        | Deterministic ordering |
@@ -46,8 +45,8 @@ This document defines the upstream compatibility test scenarios used to validate
 - **Runs**: Bidirectional interop tests against upstream rsync versions
 - **Script**: `tools/ci/run_interop.sh`
 - **Tests**:
-  - Upstream rsync 3.0.9/3.1.3/3.4.1 client → oc-rsync daemon
-  - oc-rsync client → Upstream rsync 3.0.9/3.1.3/3.4.1 daemon
+  - Upstream rsync 3.0.9/3.1.3/3.4.4 client → oc-rsync daemon
+  - oc-rsync client → Upstream rsync 3.0.9/3.1.3/3.4.4 daemon
 - **Result validation**:
   - File transfer success
   - Payload file existence
@@ -120,7 +119,7 @@ Upstream binaries are obtained via multi-tier fallback:
 1. **Try Debian/Ubuntu packages** (fastest, most reliable)
    - 3.0.9: old-releases.ubuntu.com
    - 3.1.3: archive.ubuntu.com
-   - 3.4.1: deb.debian.org
+   - 3.4.4: source build (no Debian package yet; falls through to tarball/git)
 2. **Try release tarballs** from rsync.samba.org
 3. **Try git clone** from github.com/RsyncProject/rsync
 4. **Build from source** with `./configure && make && make install`
@@ -167,11 +166,11 @@ bash scripts/rsync-interop-client.sh
 # Build oc-rsync
 cargo build --profile dist --bin oc-rsync
 
-# Ensure upstream rsync 3.4.1 is available
-rsync_341=/path/to/upstream/rsync-3.4.1/bin/rsync
+# Ensure upstream rsync 3.4.4 is available
+rsync_344=/path/to/upstream/rsync-3.4.4/bin/rsync
 
 # Test oc-rsync client → upstream daemon
-$rsync_341 --daemon --config=test.conf --no-detach --port=2873 &
+$rsync_344 --daemon --config=test.conf --no-detach --port=2873 &
 sleep 1
 ./target/dist/oc-rsync -av /source/ rsync://127.0.0.1:2873/module/
 kill %1
@@ -179,7 +178,7 @@ kill %1
 # Test upstream client → oc-rsync daemon
 ./target/dist/oc-rsync --daemon --config=test.conf --port=2873 &
 sleep 1
-$rsync_341 -av /source/ rsync://127.0.0.1:2873/module/
+$rsync_344 -av /source/ rsync://127.0.0.1:2873/module/
 kill %1
 ```
 

--- a/docs/interop-status.md
+++ b/docs/interop-status.md
@@ -22,9 +22,7 @@ validated for every version on every CI run.
 | rsync 2.6.9      | 28-29    | Always source-built | Non-blocking |
 | rsync 3.0.9      | 30       | Ubuntu package or source | Required |
 | rsync 3.1.3      | 31       | Ubuntu package or source | Required |
-| rsync 3.4.1      | 32       | Debian package or source | Required |
-| rsync 3.4.2      | 32       | Debian package or source | Required |
-| rsync 3.4.3      | 32       | Source-built (security release) | Required |
+| rsync 3.4.4      | 32       | Source-built (latest release) | Required |
 
 Upstream binaries are obtained via multi-tier fallback: Debian/Ubuntu packages
 first, then release tarballs from rsync.samba.org, then source build from
@@ -79,8 +77,8 @@ transfers. Without it, transfers fall back to MD5.
 ## Transfer Modes
 
 All tested bidirectionally (oc-rsync client to upstream daemon, upstream client
-to oc-rsync daemon) against 3.0.9, 3.1.3, and 3.4.x. Versions 3.4.2 and 3.4.3
-share protocol 32 with 3.4.1 and pass the identical test matrix.
+to oc-rsync daemon) against 3.0.9, 3.1.3, and 3.4.4. 3.4.4 supersedes the
+3.4.1/3.4.2/3.4.3 point releases on the same protocol (32).
 
 | Feature | Flags | 3.0.9 | 3.1.3 | 3.4.x |
 |---------|-------|-------|-------|-------|
@@ -180,8 +178,8 @@ the codec.
 
 | Direction | Versions Tested |
 |-----------|-----------------|
-| oc-rsync client -> upstream daemon (push) | 2.6.9, 3.0.9, 3.1.3, 3.4.1, 3.4.2, 3.4.3 |
-| Upstream client -> oc-rsync daemon (pull) | 2.6.9, 3.0.9, 3.1.3, 3.4.1, 3.4.2, 3.4.3 |
+| oc-rsync client -> upstream daemon (push) | 2.6.9, 3.0.9, 3.1.3, 3.4.4 |
+| Upstream client -> oc-rsync daemon (pull) | 2.6.9, 3.0.9, 3.1.3, 3.4.4 |
 
 ### SSH Transport
 
@@ -211,7 +209,7 @@ reads these files correctly.
 
 ## Upstream rsync Testsuite
 
-oc-rsync runs upstream rsync's own `testsuite/*.test` corpus (from rsync 3.4.2)
+oc-rsync runs upstream rsync's own `testsuite/*.test` corpus (from rsync 3.4.4)
 with oc-rsync substituted as `$RSYNC`. This is the canonical "does oc-rsync
 look like rsync from upstream's perspective" check. The harness reuses
 upstream's `rsync.fns`, `tls`, `getgroups`, and `support/lsh.sh` helper tools.

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -46,7 +46,7 @@ rsync without conflict.
 ## Protocol Compatibility
 
 **oc-rsync** supports rsync protocol versions 28 through 32 and has been
-validated against upstream rsync versions 3.0.9, 3.1.3, 3.4.1, and 3.4.2.
+validated against upstream rsync versions 3.0.9, 3.1.3, and 3.4.4.
 Incremental recursion, checksum negotiation (including XXH3 and XXH128),
 and all standard wire-format features are supported.
 
@@ -59,8 +59,7 @@ and transfer-mode combinations:
 | 2.6.9          | 29       | pull (daemon)            | non-blocking (RP28.d) |
 | 3.0.9          | 30       | push, pull, daemon       | gating |
 | 3.1.3          | 31       | push, pull, daemon       | gating |
-| 3.4.1          | 32       | push, pull, daemon, SSH  | gating |
-| 3.4.2          | 32       | push, pull, daemon       | gating |
+| 3.4.4          | 32       | push, pull, daemon, SSH  | gating |
 
 Wire format is verified byte-identical to upstream rsync via CI golden-byte
 tests for the listed versions. Other versions may work but are not
@@ -298,7 +297,7 @@ NEON) are used where available, with automatic scalar fallbacks.
     that does not resolve locally, see `docs/user-guide/acl-id-mapping.md`.
     Since PR #4742 (commit `07f81641f`), unmappable named entries are
     preserved with their raw wire id rather than silently dropped, matching
-    upstream rsync 3.4.2 `acls.c::recv_ida_entries`.
+    upstream rsync 3.4.4 `acls.c::recv_ida_entries`.
 
     On Windows, **--acls** preserves the NTFS discretionary ACL (DACL) via
     `GetNamedSecurityInfoW`/`SetNamedSecurityInfoW`. The Windows path is a
@@ -1336,8 +1335,7 @@ partial file does not occupy the final destination path.
 - Upstream rsync 2.6.9 (protocol 29) - daemon push/pull validated via RP28 series
 - Upstream rsync 3.0.9 (protocol 30)
 - Upstream rsync 3.1.3 (protocol 31)
-- Upstream rsync 3.4.1 (protocol 32)
-- Upstream rsync 3.4.2 (protocol 32)
+- Upstream rsync 3.4.4 (protocol 32)
 
 Both as a client connecting to upstream rsync servers and as a server
 accepting connections from upstream rsync clients.

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -2,7 +2,7 @@
 
 This document describes oc-rsync's wire protocol compatibility with upstream
 rsync across protocol versions 28-32 and upstream releases 2.6.9, 3.0.9,
-3.1.3, 3.4.1, and 3.4.2. All claims are backed by automated CI tests that
+3.1.3, and 3.4.4. All claims are backed by automated CI tests that
 run on every pull request and nightly.
 
 ---
@@ -49,12 +49,11 @@ Every CI run tests both directions for each upstream version:
 | rsync 2.6.9      | 29       | Non-blocking (RP28.d) | Non-blocking (RP28.c) |
 | rsync 3.0.9      | 30       | Pass                  | Pass                  |
 | rsync 3.1.3      | 31       | Pass                  | Pass                  |
-| rsync 3.4.1      | 32       | Pass                  | Pass                  |
-| rsync 3.4.2      | 32       | Pass                  | Pass                  |
+| rsync 3.4.4      | 32       | Pass                  | Pass                  |
 
 ### SSH Transport Interop
 
-SSH interop is tested with upstream rsync 3.4.1 on the PATH:
+SSH interop is tested with upstream rsync 3.4.4 on the PATH:
 
 | Direction                          | Status |
 |------------------------------------|--------|
@@ -78,15 +77,15 @@ Batch files written by one implementation can be read by the other:
 
 The table below lists every feature tested in the comprehensive interop suite.
 Each feature is tested bidirectionally (upstream client -> oc-rsync daemon and
-oc-rsync client -> upstream daemon) against 3.0.9, 3.1.3, and 3.4.1. Rsync
-3.4.2 uses the same protocol (32) as 3.4.1 and passes the identical test
-matrix - it is not shown separately. Rsync 2.6.9 (protocol 29) interop is
+oc-rsync client -> upstream daemon) against 3.0.9, 3.1.3, and 3.4.4. Rsync
+3.4.4 supersedes the 3.4.1/3.4.2/3.4.3 point releases on the same protocol
+(32), so those intermediate releases are not tested separately. Rsync 2.6.9 (protocol 29) interop is
 validated via dedicated daemon push/pull cells (RP28.c/RP28.d) rather than
 the full feature matrix below.
 
 ### Transfer Modes
 
-| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.1 |
+| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.4 |
 |----------------------|---------------------------|-------|-------|-------|
 | Archive mode         | `-av`                     | Pass  | Pass  | Pass  |
 | Recursive only       | `-rv`                     | Pass  | Pass  | Pass  |
@@ -107,7 +106,7 @@ the full feature matrix below.
 
 ### Metadata and Attributes
 
-| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.1 |
+| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.4 |
 |----------------------|---------------------------|-------|-------|-------|
 | Permissions          | `-rlpv`                   | Pass  | Pass  | Pass  |
 | Numeric IDs          | `-av --numeric-ids`       | Pass  | Pass  | Pass  |
@@ -117,7 +116,7 @@ the full feature matrix below.
 
 ### Links
 
-| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.1 |
+| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.4 |
 |----------------------|---------------------------|-------|-------|-------|
 | Symlinks             | `-rlptv`                  | Pass  | Pass  | Pass  |
 | Hard links           | `-avH`                    | Pass  | Pass  | Pass  |
@@ -127,7 +126,7 @@ the full feature matrix below.
 
 ### Comparison and Selection
 
-| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.1 |
+| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.4 |
 |----------------------|---------------------------|-------|-------|-------|
 | Checksum mode        | `-avc`                    | Pass  | Pass  | Pass  |
 | Checksum skip        | `-avc` (identical files)  | Pass  | Pass  | Pass  |
@@ -139,7 +138,7 @@ the full feature matrix below.
 
 ### Delete and Backup
 
-| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.1 |
+| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.4 |
 |----------------------|---------------------------|-------|-------|-------|
 | Delete               | `-av --delete`            | Pass  | Pass  | Pass  |
 | Delete after         | `-av --delete-after`      | Pass  | Pass  | Pass  |
@@ -151,7 +150,7 @@ the full feature matrix below.
 
 ### Filters and Paths
 
-| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.1 |
+| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.4 |
 |----------------------|---------------------------|-------|-------|-------|
 | Exclude pattern      | `-av --exclude=*.log`     | Pass  | Pass  | Pass  |
 | Relative paths       | `-avR`                    | Pass  | Pass  | Pass  |
@@ -159,13 +158,13 @@ the full feature matrix below.
 
 ### Output
 
-| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.1 |
+| Feature              | Flags                     | 3.0.9 | 3.1.3 | 3.4.4 |
 |----------------------|---------------------------|-------|-------|-------|
 | Itemize changes      | `-avi`                    | Known limitation | Known limitation | Known limitation |
 
 ### Protocol Forcing
 
-| Feature              | Flags                     | 3.4.1 |
+| Feature              | Flags                     | 3.4.4 |
 |----------------------|---------------------------|-------|
 | Force protocol 28    | `-av --protocol=28`       | Known limitation (daemon transfers) |
 | Force protocol 29    | `-av --protocol=29`       | Known limitation (daemon transfers) |
@@ -239,7 +238,7 @@ Interop testing is distributed across several CI workflows:
 
 | Workflow                        | File                                  | Scope |
 |---------------------------------|---------------------------------------|-------|
-| CI (interop job)                | `.github/workflows/ci.yml`            | Basic bidirectional daemon + SSH interop for 3.0.9, 3.1.3, 3.4.1. Comprehensive scenarios for all features. Protocol forcing for v28-v32. Standalone tests. |
+| CI (interop job)                | `.github/workflows/ci.yml`            | Basic bidirectional daemon + SSH interop for 3.0.9, 3.1.3, 3.4.4. Comprehensive scenarios for all features. Protocol forcing for v28-v32. Standalone tests. |
 | Interop Validation              | `.github/workflows/interop-validation.yml` | Exit code validation, message format validation, behavior comparison, batch mode interop. Runs on push, PR, and nightly. |
 | Interop Tests (reusable)        | `.github/workflows/_interop.yml`      | Reusable workflow called by CI. Builds upstream binaries, sets up SSH loopback, runs full interop suite. |
 
@@ -252,4 +251,4 @@ Interop testing is distributed across several CI workflows:
 - Interop test details: [docs/INTEROP.md](INTEROP.md)
 - Interop testing guide: [docs/interop_testing.md](interop_testing.md)
 - Interop test script: `tools/ci/run_interop.sh`
-- Upstream rsync source: `target/interop/upstream-src/rsync-3.4.1/`
+- Upstream rsync source: `target/interop/upstream-src/rsync-3.4.4/`


### PR DESCRIPTION
The interop harness canonically tests `versions=(3.0.9 3.1.3 3.4.4)` with 2.6.9
built as the protocol-28 cutoff peer (`tools/ci/run_interop.sh`), and the
`Upstream Testsuite` workflow runs rsync 3.4.4's own `testsuite/*.test` corpus
(`upstream_rsync_version: '3.4.4'`). Per the harness comment, **3.4.4 supersedes
the 3.4.1/3.4.2/3.4.3 point releases** on the same protocol 32, so testing the
intermediate releases is redundant. The published compatibility matrices still
listed 3.4.1/3.4.2/3.4.3 as the tested versions - stale.

Re-anchors the **tested-version** references to the real harness set
(3.0.9, 3.1.3, 3.4.4; 2.6.9 build-only) across:

- `docs/interop-status.md` - support table, prose, version lists, and the
  upstream-testsuite corpus version.
- `docs/protocol-compatibility.md` - intro, bidirectional/SSH tables, the 7
  feature-matrix column headers, CI-workflow scope, and the upstream source-dir
  path.
- `docs/INTEROP.md` - parity statement, binary list, CI test description,
  package-fallback note, and the worked example (`rsync_341` -> `rsync_344`).
- `docs/oc-rsync.1.md` - validated-versions list, support table, and the
  `acls.c::recv_ida_entries` citation.

**Preserved as historical facts** (verified, not changed): the
protocol-32-introduced-in-**3.4.0** rows and the "3.0.9 does not support
protocol 31" note. Pass/Pass results are unchanged - the versions share
protocol 32 and the `interop` check is green on master. No results fabricated;
every version claim is anchored to `run_interop.sh` and the testsuite workflow.
