### PR TITLE
fix: gate SSH server args by sender role to match server_options()

### DIFF
--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -506,22 +506,29 @@ impl<'a> RemoteInvocationBuilder<'a> {
             )));
         }
 
-        if let Some(dir) = self.config.partial_directory() {
-            let mut arg = OsString::from("--partial-dir=");
-            arg.push(dir.as_os_str());
-            args.push(arg);
-        }
-
-        // upstream: options.c:2884-2893 - `if (partial_dir && am_sender) {
-        // --partial-dir ... } else if (keep_partial && am_sender) --partial`.
-        // Bare --partial is emitted only when the client is the sender (PUSH)
-        // and no --partial-dir is configured; the partial-dir branch above
-        // already conveys keep_partial otherwise. There is no compact 'P'.
-        if self.role == RemoteRole::Sender
-            && self.config.partial()
-            && self.config.partial_directory().is_none()
-        {
-            args.push(OsString::from("--partial"));
+        // upstream: options.c:2886-2894 server_options() -
+        //   if (partial_dir && am_sender) {
+        //       if (partial_dir != tmp_partialdir) --partial-dir <dir>;
+        //       if (delay_updates) --delay-updates;
+        //   } else if (keep_partial && am_sender) --partial
+        // The whole group is am_sender (PUSH) only. --delay-updates implies an
+        // implicit tmp partial_dir upstream, so it is emitted even without an
+        // explicit --partial-dir; config.partial_directory() holds only an
+        // explicit dir, mirroring the `partial_dir != tmp_partialdir` guard.
+        // There is no compact 'P'.
+        if am_sender {
+            if let Some(dir) = self.config.partial_directory() {
+                let mut arg = OsString::from("--partial-dir=");
+                arg.push(dir.as_os_str());
+                args.push(arg);
+                if self.config.delay_updates() {
+                    args.push(OsString::from("--delay-updates"));
+                }
+            } else if self.config.delay_updates() {
+                args.push(OsString::from("--delay-updates"));
+            } else if self.config.partial() {
+                args.push(OsString::from("--partial"));
+            }
         }
 
         // upstream: options.c:2925-2928 - `if (tmpdir) { --temp-dir; ... }`
@@ -534,7 +541,11 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(arg);
         }
 
-        if self.config.inplace() {
+        // upstream: options.c:2951-2960 server_options() - `if (append_mode)
+        // { --append... } else if (inplace) { --inplace }`. append_mode takes
+        // precedence, so --inplace is suppressed when appending (the receiver
+        // derives inplace from append); the two are mutually exclusive.
+        if self.config.inplace() && !self.config.append() {
             args.push(OsString::from("--inplace"));
         }
 
@@ -713,10 +724,6 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // matching upstream's `am_sender` branch (see `am_sender` above).
         if self.config.mkpath() && self.role == RemoteRole::Sender {
             args.push(OsString::from("--mkpath"));
-        }
-
-        if self.config.delay_updates() {
-            args.push(OsString::from("--delay-updates"));
         }
 
         // upstream: options.c:2648-2649 - bare `make_backups` is emitted as the

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -931,6 +931,53 @@ fn includes_delay_updates_long_arg() {
 }
 
 #[test]
+fn partial_dir_not_forwarded_on_pull_receiver() {
+    // upstream: options.c:2886 - `if (partial_dir && am_sender)`. On a pull the
+    // client is the receiver, so --partial-dir stays local and must NOT be
+    // forwarded to the remote sender (upstream turns it into an implied exclude
+    // of that dir on the sender, so forwarding it would change file selection).
+    let config = ClientConfig::builder()
+        .partial_directory(Some(".rsync-partial"))
+        .build();
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
+    assert!(
+        !args
+            .iter()
+            .any(|a| a.to_string_lossy().starts_with("--partial-dir")),
+        "--partial-dir must not be forwarded on a pull (receiver): {args:?}"
+    );
+}
+
+#[test]
+fn delay_updates_not_forwarded_on_pull_receiver() {
+    // upstream: options.c:2891 - --delay-updates is emitted only inside the
+    // `partial_dir && am_sender` block. On a pull the receiver applies it
+    // locally and must not forward it to the remote sender.
+    let config = ClientConfig::builder().delay_updates(true).build();
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
+    assert!(
+        !args.iter().any(|a| a == "--delay-updates"),
+        "--delay-updates must not be forwarded on a pull (receiver): {args:?}"
+    );
+}
+
+#[test]
+fn inplace_suppressed_when_append_mode() {
+    // upstream: options.c:2951-2956 - `if (append_mode) {...} else if (inplace)`.
+    // append_mode takes precedence, so --inplace must not accompany --append.
+    let config = ClientConfig::builder().inplace(true).append(true).build();
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    assert!(
+        !args.iter().any(|a| a == "--inplace"),
+        "--inplace must be suppressed when --append is set: {args:?}"
+    );
+    assert!(
+        args.iter().any(|a| a == "--append"),
+        "--append must still be emitted: {args:?}"
+    );
+}
+
+#[test]
 fn includes_remove_source_files_long_arg() {
     let config = ClientConfig::builder().remove_source_files(true).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);


### PR DESCRIPTION
The SSH remote-invocation builder (`invocation/builder.rs`) forwarded three
server args without upstream's role/precedence gating. The **daemon** arg
builder (`daemon_transfer/orchestration/arguments.rs`) already handles these
correctly - this brings the SSH path in line.

### `--partial-dir` / `--delay-updates` missing the `am_sender` gate
Upstream `server_options()` (`options.c:2886-2894`):
```c
if (partial_dir && am_sender) {
    if (partial_dir != tmp_partialdir) { args[ac++] = "--partial-dir"; args[ac++] = safe_arg("", partial_dir); }
    if (delay_updates) args[ac++] = "--delay-updates";
} else if (keep_partial && am_sender)
    args[ac++] = "--partial";
```
oc emitted `--partial-dir=` and `--delay-updates` **unconditionally**. On a pull
(client = receiver) upstream keeps both local; forwarding `--partial-dir` to the
remote sender is a real divergence because upstream turns it into an **implied
exclude** of that directory on the sender, changing file selection.

Consolidated into one `am_sender` block mirroring upstream and the daemon
builder. `--delay-updates` implies an implicit tmp partial-dir upstream, so it is
emitted even without an explicit `--partial-dir` (matching the daemon builder;
`config.partial_directory()` holds only an explicit dir, like `partial_dir != tmp_partialdir`).

### `--inplace` not mutually exclusive with `--append`
Upstream (`options.c:2951-2956`) is `if (append_mode) {...} else if (inplace)`,
so append takes precedence. oc emitted `--inplace` unconditionally, so
`--inplace --append` sent both. Now `--inplace` is suppressed when appending.

### Tests
Adds `partial_dir_not_forwarded_on_pull_receiver`,
`delay_updates_not_forwarded_on_pull_receiver`, and
`inplace_suppressed_when_append_mode`. Host-validated: fmt + clippy clean, 38
builder tests pass (new + existing positive-emission tests on the sender path).

Found via a fresh upstream-3.4.4 `server_options()` audit; the compact-`z`
non-zlib case and the `--no-W` old-receiver workaround were also noted but are
deferred (compression-negotiation nuance) to keep this change low-risk.
