### PR TITLE
fix: drop daemon privileges before @RSYNCD: OK to match upstream

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -424,7 +424,9 @@ fn handle_authentication(
     protocol_version: Option<ProtocolVersion>,
 ) -> io::Result<Option<(Option<String>, UserAccessLevel)>> {
     if !module.requires_authentication() {
-        send_daemon_ok(ctx.reader.get_mut(), ctx.limiter, ctx.messages)?;
+        // `@RSYNCD: OK` is deferred to the caller: upstream emits it only after
+        // chroot + privilege drop succeed (clientserver.c:1071), so those
+        // failures stay raw pre-OK lines instead of desyncing the client.
         // upstream: authenticate.c:238-239 - an empty/absent `auth users` list
         // lets anyone in with no access-level override, so `read only` stays.
         return Ok(Some((None, UserAccessLevel::Default)));
@@ -462,7 +464,8 @@ fn handle_authentication(
             if let Some(log) = ctx.log_sink {
                 log_module_auth_success(log, ctx.effective_host(), ctx.peer_ip, ctx.request);
             }
-            send_daemon_ok(ctx.reader.get_mut(), ctx.limiter, ctx.messages)?;
+            // `@RSYNCD: OK` is deferred to the caller (see the no-auth path
+            // above): it is emitted only after chroot + privilege drop succeed.
             Ok(Some((Some(username), access_level)))
         }
     }

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -200,6 +200,48 @@ fn process_approved_module(
         }
     }
 
+    // upstream: clientserver.c:983-1053 - chroot + setgid + setuid run BEFORE
+    // `@RSYNCD: OK` (1071), so their `@ERROR: chroot/setgid/setuid failed`
+    // replies are raw pre-OK lines the client reads before it switches to the
+    // multiplexed input stream. Run them here, then emit OK, so a failure can
+    // never desync the client's multiplex decoder. Client args are not yet
+    // available (the client blocks on OK before sending its argv), so the
+    // post-xfer-exec hook fires with an empty arg list - matching upstream's
+    // pre-read_args fork position (clientserver.c:908).
+    if !validate_module_path(ctx, module)? {
+        // upstream: clientserver.c:992-993 - the change_dir() into the module
+        // path is post-fork, so a missing/unreachable path still hooks.
+        let host_owned = ctx.effective_host().map(str::to_owned);
+        run_post_xfer_finalizer(
+            ctx,
+            module,
+            host_owned.as_deref(),
+            auth_user.as_deref(),
+            &[],
+            MODULE_ABORT_EXIT_CODE,
+        );
+        return Ok(());
+    }
+
+    // Split into separate steps so each failure sends the correct upstream
+    // error message: `@ERROR: chroot failed` vs `@ERROR: setgid failed` etc.
+    // After chroot the effective module path becomes the post-chroot inner
+    // directory (see `config_module` below).
+    let privilege_outcome = match apply_privilege_restrictions_with_upstream_errors(
+        ctx,
+        module,
+        auth_user.as_deref(),
+        &[],
+    )? {
+        Some(outcome) => outcome,
+        None => return Ok(()),
+    };
+
+    // upstream: clientserver.c:1071 - emit `@RSYNCD: OK` now that chroot and the
+    // privilege drop have succeeded; the client then switches to multiplexed
+    // input and sends its argv, which we read next.
+    send_daemon_ok(ctx.reader.get_mut(), ctx.limiter, ctx.messages)?;
+
     let client_args = match read_and_log_client_args(ctx, negotiated_protocol)? {
         Some(args) => args,
         None => return Ok(()),
@@ -309,22 +351,6 @@ fn process_approved_module(
         return result;
     }
 
-    if !validate_module_path(ctx, module)? {
-        // upstream: clientserver.c:992-993 - change_dir() into the module
-        // path runs after the post-xfer-exec fork point, so a missing/
-        // unreachable path is a child exit the waiting parent still hooks.
-        let host_owned = ctx.effective_host().map(str::to_owned);
-        run_post_xfer_finalizer(
-            ctx,
-            module,
-            host_owned.as_deref(),
-            auth_user.as_deref(),
-            &client_args,
-            MODULE_ABORT_EXIT_CODE,
-        );
-        return Ok(());
-    }
-
     // SEC-1.p: harvest the in-module --temp-dir / --partial-dir /
     // --backup-dir / --compare-dest / --copy-dest / --link-dest paths the
     // operator's configuration permits, so the Landlock allowlist below can
@@ -333,26 +359,15 @@ fn process_approved_module(
     // retain block - upstream `main.c:841 check_alt_basis_dirs` warns on
     // a missing/out-of-tree basis but never aborts, and the standalone
     // link-dest / copy-dest interop fixtures rely on that contract.
-    let Some(validated_client_paths) = validate_client_paths_in_module(ctx, module, &client_args)?
+    //
+    // chroot + the privilege drop already ran pre-OK above, so validate against
+    // the post-chroot root (the process root is now the module dir) when the
+    // module is chrooted, else the real module path. `privilege_outcome` records
+    // which applies.
+    let Some(validated_client_paths) =
+        validate_client_paths_in_module(ctx, module, &client_args, &privilege_outcome)?
     else {
         return Ok(());
-    };
-
-    // Apply chroot and privilege restrictions before building server config.
-    // After chroot the effective module path becomes "/" since the process root
-    // is now the module directory itself.
-    // upstream: clientserver.c:rsync_module() - chroot + setuid/setgid happen
-    // after auth and arg reading but before the transfer starts.
-    // Split into separate steps so each failure sends the correct upstream
-    // error message: `@ERROR: chroot failed` vs `@ERROR: setuid failed` etc.
-    let privilege_outcome = match apply_privilege_restrictions_with_upstream_errors(
-        ctx,
-        module,
-        auth_user.as_deref(),
-        &client_args,
-    )? {
-        Some(outcome) => outcome,
-        None => return Ok(()),
     };
 
     // upstream: clientserver.c:964-971 - spawn name converter after privilege

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -275,11 +275,27 @@ fn validate_client_paths_in_module(
     _ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleRuntime,
     client_args: &[String],
+    privilege_outcome: &PrivilegeOutcome,
 ) -> io::Result<Option<ValidatedClientPaths>> {
-    let Ok(module_root) = module.path.canonicalize() else {
-        // Module path failed to canonicalize - the existence check above
-        // already succeeded, so this is a race or a permission problem; let
-        // the transfer continue and fail with a more precise error later.
+    // chroot + the privilege drop already ran pre-OK. After a chroot the process
+    // root IS the module dir, so a client's absolute --link-dest/--temp-dir path
+    // resolves under the post-chroot root ("/" or the `/./` inner remainder);
+    // validate against that (the kernel chroot already contains every in-module
+    // path). Without chroot (unset + rootless fallback, `use chroot = no`, or a
+    // non-Linux build) validate against the real module path so SEC-1.p still
+    // rejects out-of-tree basis dirs.
+    let root_source = if privilege_outcome.chroot_applied {
+        privilege_outcome
+            .inner_module_path
+            .as_deref()
+            .unwrap_or_else(|| Path::new("/"))
+    } else {
+        module.path.as_path()
+    };
+    let Ok(module_root) = root_source.canonicalize() else {
+        // Root path failed to canonicalize - the existence check above already
+        // succeeded, so this is a race or a permission problem; let the transfer
+        // continue and fail with a more precise error later.
         return Ok(Some(ValidatedClientPaths::default()));
     };
 


### PR DESCRIPTION
## Problem
Upstream `clientserver.c` runs the module's privilege drops **before** it emits
`@RSYNCD: OK`:

```
chroot(983) -> setgid(1022) -> setuid(1046) -> @RSYNCD: OK (1071) -> read_args(1073)
```

so `@ERROR: chroot failed` / `setgid failed` / `setuid failed` are **raw pre-OK
lines** the client reads before it switches to the multiplexed input stream.

oc ran `validate_module_path` + chroot/setgid/setuid **after** `@RSYNCD: OK` and
reported failures with raw `send_error()`. Since OK had already flipped the
client into multiplex mode, a chroot/setuid failure was decoded as a frame
header and desynced the client (`unexpected tag 77` / `invalid multi-message`) -
the same class oc already avoids for refuse-options and read-only via the
multiplexed-error path.

## Fix
Move `validate_module_path` and the chroot/setgid/setuid drop **ahead of** the
OK send, then emit `@RSYNCD: OK` once they succeed. `@RSYNCD: OK` is deferred out
of `handle_authentication` into the orchestrator. Early-exec was already
positioned before `read_args`, so deferring OK makes it pre-OK too - matching
upstream (early-exec runs as root, before setuid).

The client blocks on OK before sending its argv, so the pre-OK sandbox runs with
an empty arg list (matching upstream's pre-`read_args` fork position) and the
post-xfer-exec hook fires with no client args.

**SEC-1.p** client-path validation stays **post-OK** (it needs the client argv)
and now validates against the **post-chroot root** when the module is chrooted
(the process root is the module dir), else the real module path - so out-of-tree
basis-dir rejection is preserved for non-chroot modules and chroot containment
covers the chrooted case.

`refuse options` and `read only`/`write only` rejections are unchanged: upstream
performs those post-OK (`parse_arguments` after `read_args`), so their existing
multiplexed framing already matches.

## Validation (host, aarch64, non-root user)
- fmt + clippy clean; **full `daemon` crate: 1746 tests pass** (6 skipped).
- Behavioral: non-root daemon with `use chroot = yes` -> client receives a clean
  `@ERROR: chroot failed` (exit 5), **no multiplex desync**.
- Normal `use chroot = no` pull + push both succeed (exit 0, trees match) - the
  OK-placement change does not affect the happy path.
- The chroot-**success** + `--link-dest` path requires root and is covered by the
  `upstream-testsuite (root)` CI job.

Found via a fresh upstream-3.4.4 daemon-handshake audit.
