### PR TITLE
fix: emit compact 'z' only for zlib compression, not zstd/lz4/zlibx

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -169,13 +169,18 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.sparse() {
         flags.push('S');
     }
-    // upstream: options.c:2722 - 'z' is only sent when the compression
-    // algorithm is the default (no explicit --compress-choice). For
-    // explicitly chosen algorithms (lz4, zstd), the 'z' flag is omitted
-    // and --compress-choice=ALGO is sent as a long-form arg instead.
+    // upstream: options.c:2722 - the compact 'z' is packed only when
+    // `do_compression == CPRES_ZLIB`. Plain `-z` defaults to zlib and explicit
+    // `--compress-choice=zlib` also packs 'z', but zlibx/zstd/lz4 are forwarded
+    // via the long-form `--new-compress`/`--compress-choice` instead and must
+    // NOT also pack 'z'. `CompressionAlgorithm` folds zlibx onto Zlib, so the
+    // raw choice name (not the enum) distinguishes it.
     if config.compress()
-        && config.compression_algorithm()
-            == compress::algorithm::CompressionAlgorithm::default_algorithm()
+        && (!config.explicit_compress_choice()
+            || config
+                .compress_choice_name()
+                .unwrap_or_else(|| config.compression_algorithm().name())
+                == "zlib")
     {
         flags.push('z');
     }
@@ -623,17 +628,17 @@ mod tests {
     }
 
     #[test]
-    fn server_flag_string_includes_z_for_default_algorithm() {
-        // upstream: options.c:2722 - 'z' is sent for the default compression
-        // algorithm (no explicit --compress-choice).
-        let config = ClientConfig::builder()
-            .compress(true)
-            .compression_algorithm(compress::algorithm::CompressionAlgorithm::default_algorithm())
-            .build();
+    fn server_flag_string_includes_z_for_default_compression() {
+        // upstream: options.c:2722 - plain `-z` (no explicit --compress-choice)
+        // defaults to zlib, so the compact 'z' is packed. Note default_algorithm()
+        // is the best-available codec (zstd), which is NOT zlib - an explicit
+        // choice of it would omit 'z' (see the zstd test) - so the default case
+        // must be expressed as plain compress() with no explicit choice.
+        let config = ClientConfig::builder().compress(true).build();
         let flags = build_server_flag_string(&config);
         assert!(
             flags.contains('z'),
-            "expected 'z' for default algorithm: {flags}"
+            "expected 'z' for default (plain -z) compression: {flags}"
         );
     }
 
@@ -648,6 +653,38 @@ mod tests {
             .build();
         let flags = build_server_flag_string(&config);
         assert!(!flags.contains('z'), "should not send 'z' for lz4: {flags}");
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn server_flag_string_omits_z_for_zstd() {
+        // upstream: options.c:2722 - 'z' NOT sent for zstd; the codec rides as
+        // the long-form --compress-choice=zstd instead.
+        let config = ClientConfig::builder()
+            .compress(true)
+            .compression_algorithm(compress::algorithm::CompressionAlgorithm::Zstd)
+            .build();
+        let flags = build_server_flag_string(&config);
+        assert!(
+            !flags.contains('z'),
+            "should not send 'z' for zstd: {flags}"
+        );
+    }
+
+    #[test]
+    fn server_flag_string_omits_z_for_zlibx() {
+        // zlibx folds onto Zlib in the enum, but the raw choice name keeps it
+        // distinct; upstream sends --new-compress, never the compact 'z'.
+        let config = ClientConfig::builder()
+            .compress(true)
+            .compression_algorithm(compress::algorithm::CompressionAlgorithm::Zlib)
+            .compress_choice_name(Some("zlibx".to_owned()))
+            .build();
+        let flags = build_server_flag_string(&config);
+        assert!(
+            !flags.contains('z'),
+            "should not send 'z' for zlibx: {flags}"
+        );
     }
 
     // upstream: options.c:2625-2626 - `for (i = 0; i < verbose; i++)

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -1099,8 +1099,22 @@ impl<'a> RemoteInvocationBuilder<'a> {
         if self.config.sparse() {
             flags.push('S');
         }
-        // upstream: options.c:2722-2723 - 'z' only for zlib compression.
-        if self.config.compress() {
+        // upstream: options.c:2722-2723 - the compact 'z' is packed only when
+        // `do_compression == CPRES_ZLIB`. Plain `-z` defaults to zlib, but an
+        // explicit `--compress-choice` of zlibx/zstd/lz4 is forwarded via the
+        // long-form `--new-compress`/`--compress-choice` above and must NOT also
+        // pack 'z' (upstream sends `-logDtpre...`, not `-logDtprze...`).
+        // `CompressionAlgorithm` folds zlibx onto Zlib, so the enum's name()
+        // returns "zlib" for zlibx; use the raw `compress_choice_name` to
+        // distinguish it (upstream sends zlibx via --new-compress, no 'z').
+        if self.config.compress()
+            && (!self.config.explicit_compress_choice()
+                || self
+                    .config
+                    .compress_choice_name()
+                    .unwrap_or_else(|| self.config.compression_algorithm().name())
+                    == "zlib")
+        {
             flags.push('z');
         }
         // upstream: options.c has NO compact 'P' letter for --partial. keep_partial

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -196,6 +196,35 @@ fn includes_compress_flag() {
     assert!(flags.contains('z'), "expected 'z' in flags: {flags}");
 }
 
+// upstream: options.c:2722 - the compact 'z' is packed only for
+// do_compression == CPRES_ZLIB. An explicit non-zlib --compress-choice is
+// forwarded as a long-form arg and must NOT also pack 'z'.
+#[cfg(feature = "zstd")]
+#[test]
+fn omits_compress_flag_for_zstd() {
+    let config = ClientConfig::builder()
+        .compress(true)
+        .compression_algorithm(compress::algorithm::CompressionAlgorithm::Zstd)
+        .build();
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    let flags = args[2].to_string_lossy();
+    assert!(!flags.contains('z'), "must not pack 'z' for zstd: {flags}");
+}
+
+#[test]
+fn omits_compress_flag_for_zlibx() {
+    // zlibx folds onto CompressionAlgorithm::Zlib, but the raw choice name
+    // keeps it distinct; upstream sends it via --new-compress, never 'z'.
+    let config = ClientConfig::builder()
+        .compress(true)
+        .compression_algorithm(compress::algorithm::CompressionAlgorithm::Zlib)
+        .compress_choice_name(Some("zlibx".to_owned()))
+        .build();
+    let args = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    let flags = args[2].to_string_lossy();
+    assert!(!flags.contains('z'), "must not pack 'z' for zlibx: {flags}");
+}
+
 #[test]
 fn includes_log_format_for_itemize() {
     // upstream: options.c:2345-2358,2772-2775 - `-i` alone installs the default


### PR DESCRIPTION
Upstream `server_options()` (options.c:2722) packs the compact `z` flag **only** when `do_compression == CPRES_ZLIB`. oc's SSH arg builder packed `z` for *any* compression, so `-z --compress-choice=zstd` sent `-logDtpr**z**e.iLsfxCIvu` where upstream sends `-logDtpre.iLsfxCIvu` plus `--compress-choice=zstd` — a wire-byte divergence.

**Verified against upstream rsync 3.4.4** (oc vs upstream server-args, before → after):
| codec | upstream | oc before | oc after |
|-------|----------|-----------|----------|
| plain `-z` | `…prze…` (z) | `…prze…` | `…prze…` ✓ |
| `--compress-choice=zlib` | `…prze…` (z) | `…prze…` | `…prze…` ✓ |
| `--compress-choice=zstd` | `…pre…` (no z) | `…prze…` ✗ | `…pre…` ✓ |
| `--compress-choice=zlibx` | `…pre…` (no z) | `…prze…` ✗ | `…pre…` ✓ |

Both the SSH builder (`invocation/builder.rs`) and the daemon builder (`flags.rs`, which gated on `== default_algorithm()` and mishandled zlibx) now emit `z` iff compression is on and the effective codec is plain zlib. Because `CompressionAlgorithm` folds `zlibx` onto `Zlib`, the raw `compress_choice_name` distinguishes it (zlibx rides `--new-compress`, no `z`).

Adds zstd + zlibx regression tests to both builders, and corrects `server_flag_string_includes_z_for_default_compression` (it set an explicit choice of `default_algorithm()` — which is **zstd**, not zlib — and wrongly asserted `z`; the true default is plain `-z`).

Host-validated (pinned 1.88): fmt + clippy clean, 26 compression tests pass. Found via a fresh upstream-3.4.4 `server_options()` audit.