### PR TITLE
fix: MD5 block sum with checksum_seed==0 must hash data only

### DIFF
--- a/crates/checksums/src/strong/md5.rs
+++ b/crates/checksums/src/strong/md5.rs
@@ -382,7 +382,14 @@ impl StrongDigest for Md5 {
             pending_seed: None,
         };
 
-        if let Some(value) = seed.value {
+        // upstream: checksum.c:get_checksum2() guards the seed bytes with
+        // `if (checksum_seed)` in both the proper (30+) and legacy paths, so a
+        // zero seed hashes the data only. Match that (the MD4 arm already skips
+        // seed==0) - without it an oc<->upstream transfer with --checksum-seed=0
+        // computes different block sums and no blocks match.
+        if let Some(value) = seed.value
+            && value != 0
+        {
             if seed.proper_order {
                 // upstream: checksum.c:get_checksum2() - CHECKSUM_SEED_FIX (protocol 30+)
                 md5.update(&value.to_le_bytes());
@@ -508,6 +515,25 @@ mod tests {
             to_hex(&unseeded_digest),
             "Seeded hash should differ from unseeded"
         );
+    }
+
+    #[test]
+    fn md5_zero_seed_hashes_data_only() {
+        // upstream: checksum.c:get_checksum2() guards the seed with
+        // `if (checksum_seed)`, so a zero seed is equivalent to no seed in both
+        // orderings. A Some(0) Md5Seed must produce the unseeded digest.
+        let data = b"test data";
+        let unseeded = to_hex(&Md5::digest(data));
+
+        for seed in [Md5Seed::proper(0), Md5Seed::legacy(0)] {
+            let mut hasher = Md5::with_seed(seed);
+            hasher.update(data);
+            assert_eq!(
+                to_hex(&hasher.finalize()),
+                unseeded,
+                "zero seed must hash data only (== unseeded)"
+            );
+        }
     }
 
     #[test]

--- a/crates/checksums/tests/checksum_variants_upstream_compat.rs
+++ b/crates/checksums/tests/checksum_variants_upstream_compat.rs
@@ -453,7 +453,11 @@ fn md5_seed_legacy_order_is_suffix() {
 fn md5_seed_proper_vs_legacy_differ() {
     let data = b"checksum seed fix test";
 
-    for seed_value in [0, 1, -1, 0x7FFF_FFFF, -0x7FFF_FFFF, 0x1234_5678] {
+    // Seed 0 is excluded: upstream get_checksum2() guards the seed with
+    // `if (checksum_seed)`, so a zero seed places no bytes in either ordering
+    // and proper == legacy == unseeded (covered by md5_zero_seed_hashes_data_only).
+    // The proper-vs-legacy ordering only differs when there is a seed to place.
+    for seed_value in [1, -1, 0x7FFF_FFFF, -0x7FFF_FFFF, 0x1234_5678] {
         let proper = Md5::digest_with_seed(Md5Seed::proper(seed_value), data);
         let legacy = Md5::digest_with_seed(Md5Seed::legacy(seed_value), data);
 
@@ -477,16 +481,20 @@ fn md5_seed_none_equals_unseeded() {
 }
 
 #[test]
-fn md5_seed_zero_differs_from_none() {
+fn md5_seed_zero_equals_none() {
     let data = b"seed zero vs none";
 
     let none = Md5::digest_with_seed(Md5Seed::none(), data);
     let zero_proper = Md5::digest_with_seed(Md5Seed::proper(0), data);
+    let zero_legacy = Md5::digest_with_seed(Md5Seed::legacy(0), data);
 
-    // Seed value 0 should still hash the 4 zero bytes, differing from no seed
-    assert_ne!(
-        none, zero_proper,
-        "Seed value 0 should differ from no seed (4 zero bytes are hashed)"
+    // upstream: get_checksum2() guards the seed with `if (checksum_seed)`, so a
+    // zero seed places no bytes and hashes the data only - identical to no seed,
+    // in both proper and legacy orderings.
+    assert_eq!(none, zero_proper, "seed value 0 must equal no seed");
+    assert_eq!(
+        none, zero_legacy,
+        "seed value 0 must equal no seed (legacy)"
     );
 }
 
@@ -1223,7 +1231,10 @@ fn strategy_selector_different_seeds_different_results_for_seeded_algorithms() {
 fn md5_seeded_empty_data_produces_valid_digest() {
     let empty = b"";
 
-    for seed in [0_i32, 1, -1, i32::MAX, i32::MIN, 0x1234_5678] {
+    // Seed 0 excluded: it hashes no seed bytes (upstream `if (checksum_seed)`),
+    // so proper(0, "")/legacy(0, "") equal the unseeded empty digest - the
+    // "seeded differs from unseeded" assertion below only holds for a real seed.
+    for seed in [1_i32, -1, i32::MAX, i32::MIN, 0x1234_5678] {
         let proper = Md5::digest_with_seed(Md5Seed::proper(seed), empty);
         let legacy = Md5::digest_with_seed(Md5Seed::legacy(seed), empty);
 


### PR DESCRIPTION
Upstream `get_checksum2()` (checksum.c:342-354) guards the seed bytes with `if (checksum_seed)` in both the proper (protocol 30+) and legacy orderings, so a zero seed hashes the data only. oc's `Md5::with_seed` hashed the four zero seed-bytes for a `Some(0)` seed, while the **MD4** arm already special-cased `seed == 0` — an internal inconsistency.

Consequence: an oc↔upstream transfer with `--checksum-seed=0` computed different MD5 block strong-sums on the two ends, so no basis blocks matched (correct output, but a full literal re-transfer). oc↔oc was self-consistent, hiding it.

Fix: skip the seed bytes in `with_seed` when the value is 0, matching upstream's guard at the same (hashing) level — this covers every call site uniformly.

Also corrects three tests that encoded the old behavior: `md5_seed_zero_differs_from_none` → `md5_seed_zero_equals_none` (seed 0 == no seed), and removes the seed-0 case from the proper-vs-legacy-differ and seeded-empty-data tests (with seed 0 there is no seed to order, so proper == legacy == unseeded). Adds `md5_zero_seed_hashes_data_only`.

Host-validated (pinned 1.88): fmt + clippy clean; full checksums crate 1157 tests pass. Found via a fresh upstream-3.4.4 checksum audit.