### PR TITLE
fix(filters): evaluate deletion as one first-match-wins pass

### DIFF
--- a/crates/engine/src/local_copy/filter_program/segments.rs
+++ b/crates/engine/src/local_copy/filter_program/segments.rs
@@ -15,16 +15,26 @@ use logging::debug_log;
 pub(crate) struct FilterSegment {
     include_exclude: Vec<CompiledRule>,
     protect_risk: Vec<CompiledRule>,
+    /// Running source-definition counter stamped onto each compiled rule so the
+    /// deletion decision can merge the two chains back into the single
+    /// first-match-wins pass upstream `check_filter()` performs (exclude.c:1038).
+    next_order: usize,
 }
 
 impl FilterSegment {
     pub(crate) fn push_rule(&mut self, rule: FilterRule) -> Result<(), super::FilterProgramError> {
         match rule.action() {
             FilterAction::Include | FilterAction::Exclude => {
-                self.include_exclude.push(CompiledRule::new(rule)?);
+                let mut compiled = CompiledRule::new(rule)?;
+                compiled.order = self.next_order;
+                self.next_order += 1;
+                self.include_exclude.push(compiled);
             }
             FilterAction::Protect | FilterAction::Risk => {
-                self.protect_risk.push(CompiledRule::new(rule)?);
+                let mut compiled = CompiledRule::new(rule)?;
+                compiled.order = self.next_order;
+                self.next_order += 1;
+                self.protect_risk.push(compiled);
             }
             FilterAction::Clear => {
                 debug_assert!(
@@ -160,6 +170,38 @@ impl FilterSegment {
                 }
             }
         }
+
+        // upstream: exclude.c:1038 check_filter() walks ONE list first-match-wins
+        // and returns `ent->rflags & FILTRULE_INCLUDE ? 1 : -1`. oc partitions
+        // that list into the include/exclude and protect/risk chains, so the two
+        // decisions above latch independently and would let a protect override an
+        // earlier include (or vice versa) regardless of source order. Merge the
+        // two receiver-side first-matches back into a single source-ordered pass:
+        // the earlier-defined rule (by `order`) decides. Include/risk makes the
+        // entry deletable, exclude/protect protects it. Latched globally so a
+        // later segment cannot override the first match (upstream returns on it).
+        if for_deletion && !outcome.deletion_decided() {
+            let ie_hit = self
+                .include_exclude
+                .iter()
+                .find(|rule| rule.applies_to_receiver && rule_matches(rule, path, is_dir));
+            let pr_hit = self
+                .protect_risk
+                .iter()
+                .find(|rule| rule.applies_to_receiver && rule_matches(rule, path, is_dir));
+            let winner = match (ie_hit, pr_hit) {
+                (Some(ie), Some(pr)) => Some(if ie.order <= pr.order { ie } else { pr }),
+                (Some(ie), None) => Some(ie),
+                (None, Some(pr)) => Some(pr),
+                (None, None) => None,
+            };
+            if let Some(rule) = winner {
+                outcome.decide_deletion(matches!(
+                    rule.action,
+                    FilterAction::Include | FilterAction::Risk
+                ));
+            }
+        }
     }
 }
 
@@ -227,6 +269,12 @@ pub(crate) struct FilterOutcome {
     protected: bool,
     protection_decided: bool,
     excluded_for_delete_excluded: bool,
+    /// Unified deletion verdict: the include-flag of the single first-matching
+    /// rule across BOTH chains in source order, mirroring upstream
+    /// `check_filter()` (exclude.c:1060 `rflags & FILTRULE_INCLUDE ? 1 : -1`).
+    /// Latched once decided so later segments cannot override it.
+    deletion_deletable: bool,
+    deletion_decided: bool,
 }
 
 impl FilterOutcome {
@@ -237,6 +285,8 @@ impl FilterOutcome {
             protected: false,
             protection_decided: false,
             excluded_for_delete_excluded: false,
+            deletion_deletable: true,
+            deletion_decided: false,
         }
     }
 
@@ -244,8 +294,20 @@ impl FilterOutcome {
         self.transfer_allowed
     }
 
+    /// Whether the receiver may delete this entry.
+    ///
+    /// upstream `check_filter()` is a single first-match-wins pass over the
+    /// whole rule list; oc splits it into two chains, so [`FilterSegment::apply`]
+    /// merges their first receiver-side matches by source order into
+    /// [`Self::deletion_deletable`]. When any rule matched, that unified verdict
+    /// is authoritative; with no match at all we fall back to the split
+    /// `transfer_allowed && !protected` (which is likewise deletable by default).
     pub(crate) const fn allows_deletion(self) -> bool {
-        self.transfer_allowed && !self.protected
+        if self.deletion_decided {
+            self.deletion_deletable
+        } else {
+            self.transfer_allowed && !self.protected
+        }
     }
 
     pub(crate) const fn allows_deletion_when_excluded_removed(self) -> bool {
@@ -258,6 +320,16 @@ impl FilterOutcome {
 
     const fn protection_decided(self) -> bool {
         self.protection_decided
+    }
+
+    const fn deletion_decided(self) -> bool {
+        self.deletion_decided
+    }
+
+    /// Latches the unified deletion verdict from the first matching rule.
+    const fn decide_deletion(&mut self, deletable: bool) {
+        self.deletion_deletable = deletable;
+        self.deletion_decided = true;
     }
 
     const fn decide_transfer(&mut self) {
@@ -309,6 +381,11 @@ struct CompiledRule {
     /// upstream: exclude.c:906 - `ret_match = ex->rflags & FILTRULE_NEGATE ? 0 : 1`.
     /// When set, the rule fires on paths that do NOT match the pattern.
     negate: bool,
+    /// Source-definition order within the owning segment, assigned by
+    /// [`FilterSegment::push_rule`]. Lets the deletion decision merge the
+    /// include/exclude and protect/risk chains back into the single
+    /// first-match-wins pass upstream `check_filter()` runs (exclude.c:1038).
+    order: usize,
 }
 
 impl CompiledRule {
@@ -386,6 +463,7 @@ impl CompiledRule {
             applies_to_receiver,
             negate,
             pattern,
+            order: 0,
         })
     }
 

--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -188,6 +188,7 @@ impl CompiledRule {
             applies_to_receiver,
             perishable,
             negate,
+            order: 0,
         })
     }
 }

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -41,6 +41,15 @@ pub(crate) struct CompiledRule {
     pub(crate) applies_to_receiver: bool,
     pub(crate) perishable: bool,
     pub(crate) negate: bool,
+    /// Source-definition order across the whole rule stream, assigned by
+    /// [`FilterSet::from_rules`](crate::FilterSet::from_rules). Upstream keeps
+    /// every rule in one list and `check_filter()` walks it first-match-wins
+    /// (exclude.c:1038); oc partitions include/exclude and protect/risk into
+    /// separate chains, so this index lets the deletion decision merge the two
+    /// first-matches back into a single source-ordered pass. Zero for rules
+    /// built outside `from_rules` (per-dir implied includes), which never mix
+    /// the two chains against one path.
+    pub(crate) order: usize,
 }
 
 impl CompiledRule {

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -212,6 +212,22 @@ impl FilterSetInner {
             }
         }
 
+        // upstream: exclude.c:1038 check_filter() walks ONE list first-match-wins
+        // and returns `ent->rflags & FILTRULE_INCLUDE ? 1 : -1`. oc partitions
+        // that list into the include/exclude and protect/risk chains, so combine
+        // their two receiver-side first-matches back into a single source-ordered
+        // pass: the earlier-defined rule decides. An include/risk (`+`/`R`) makes
+        // the entry deletable, an exclude/protect (`-`/`P`) protects it, and no
+        // match at all leaves it deletable (check_filter returns 0). This is the
+        // authoritative deletion verdict; the split `transfer_allowed && !protected`
+        // fallback stays only for decisions produced outside the Deletion context.
+        if for_deletion {
+            decision.deletion_override = Some(deletion_first_match_deletable(
+                transfer_rule,
+                protection_rule,
+            ));
+        }
+
         decision
     }
 
@@ -343,6 +359,34 @@ where
     })
 }
 
+/// Merges the include/exclude and protect/risk first-matches into the single
+/// source-ordered verdict upstream's `check_filter()` produces for deletion.
+///
+/// Upstream keeps every rule in one list and returns on the first match with
+/// `rflags & FILTRULE_INCLUDE ? 1 : -1` (exclude.c:1060). oc splits the list
+/// into two chains, so the earlier-defined of the two first-matches (by
+/// [`CompiledRule::order`]) is the one upstream would have hit first. A rule
+/// carrying the include flag (`+` include or `R` risk) makes the entry
+/// deletable; an exclude (`-`) or protect (`P`) protects it. When neither chain
+/// matches, `check_filter` returns 0 and the entry is deletable by default.
+///
+/// upstream: exclude.c:check_filter()
+fn deletion_first_match_deletable(
+    include_exclude: Option<&CompiledRule>,
+    protect_risk: Option<&CompiledRule>,
+) -> bool {
+    let winner = match (include_exclude, protect_risk) {
+        (Some(ie), Some(pr)) => Some(if ie.order <= pr.order { ie } else { pr }),
+        (Some(ie), None) => Some(ie),
+        (None, Some(pr)) => Some(pr),
+        (None, None) => None,
+    };
+    match winner {
+        None => true,
+        Some(rule) => matches!(rule.action, FilterAction::Include | FilterAction::Risk),
+    }
+}
+
 /// Resolves the winning include/exclude rule for a single-path Transfer query,
 /// gating the synthetic descendant matchers by upstream's subtree-pruning rule.
 ///
@@ -441,6 +485,12 @@ pub(crate) struct FilterDecision {
     transfer_allowed: bool,
     protected: bool,
     excluded_for_delete_excluded: bool,
+    /// Unified deletion verdict for decisions produced in the
+    /// [`Deletion`](DecisionContext::Deletion) context, computed as a single
+    /// source-ordered first-match over both rule chains (upstream
+    /// `check_filter()`). `None` for Transfer-context decisions, where deletion
+    /// is not queried and `allows_deletion` falls back to the split formula.
+    deletion_override: Option<bool>,
 }
 
 impl FilterDecision {
@@ -451,10 +501,18 @@ impl FilterDecision {
 
     /// Returns `true` if the path may be deleted on the receiver.
     ///
-    /// Deletion requires both that the path is included (not excluded by
-    /// receiver-side rules) and that no protect rule matches.
+    /// For decisions produced in the Deletion context this is the unified
+    /// source-ordered first-match verdict ([`deletion_override`]), matching
+    /// upstream `check_filter()`. The split `transfer_allowed && !protected`
+    /// formula remains only as the fallback for decisions built in other
+    /// contexts, where `deletion_override` is unset.
+    ///
+    /// [`deletion_override`]: FilterDecision::deletion_override
     pub(crate) const fn allows_deletion(self) -> bool {
-        self.transfer_allowed && !self.protected
+        match self.deletion_override {
+            Some(deletable) => deletable,
+            None => self.transfer_allowed && !self.protected,
+        }
     }
 
     /// Returns `true` if the path may be removed during `--delete-excluded`.
@@ -482,6 +540,7 @@ impl Default for FilterDecision {
             transfer_allowed: true,
             protected: false,
             excluded_for_delete_excluded: false,
+            deletion_override: None,
         }
     }
 }
@@ -521,6 +580,7 @@ mod tests {
             transfer_allowed: false,
             protected: false,
             excluded_for_delete_excluded: false,
+            deletion_override: None,
         };
         assert!(!decision.allows_transfer());
         assert!(!decision.allows_deletion());
@@ -532,6 +592,7 @@ mod tests {
             transfer_allowed: false,
             protected: false,
             excluded_for_delete_excluded: true,
+            deletion_override: None,
         };
         assert!(decision.allows_deletion_when_excluded_removed());
     }
@@ -542,6 +603,7 @@ mod tests {
             transfer_allowed: false,
             protected: true,
             excluded_for_delete_excluded: true,
+            deletion_override: None,
         };
         assert!(!decision.allows_deletion_when_excluded_removed());
     }

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -88,6 +88,12 @@ impl FilterSet {
         let mut include_exclude = Vec::new();
         let mut protect_risk = Vec::new();
         let mut xattr = Vec::new();
+        // upstream: exclude.c keeps every rule in one list that check_filter()
+        // walks first-match-wins. We partition into two chains for matching but
+        // stamp each compiled rule with its position in the original stream so
+        // the deletion decision can merge the two first-matches back into a
+        // single source-ordered pass.
+        let mut order = 0usize;
 
         for rule in rules.into_iter() {
             // upstream: exclude.c:914 rule_matches() - an `x`-modifier rule
@@ -102,10 +108,16 @@ impl FilterSet {
             }
             match rule.action {
                 FilterAction::Include | FilterAction::Exclude => {
-                    include_exclude.push(CompiledRule::new(rule)?);
+                    let mut compiled = CompiledRule::new(rule)?;
+                    compiled.order = order;
+                    order += 1;
+                    include_exclude.push(compiled);
                 }
                 FilterAction::Protect | FilterAction::Risk => {
-                    protect_risk.push(CompiledRule::new(rule)?);
+                    let mut compiled = CompiledRule::new(rule)?;
+                    compiled.order = order;
+                    order += 1;
+                    protect_risk.push(compiled);
                 }
                 FilterAction::Clear => {
                     apply_clear_rule(

--- a/crates/filters/tests/complex_combinations.rs
+++ b/crates/filters/tests/complex_combinations.rs
@@ -163,9 +163,11 @@ fn included_but_at_risk() {
     // Temp files included for transfer
     assert!(set.allows(Path::new("temp/scratch.txt"), false));
 
-    // protect("*") matches first (first-match-wins), so still protected
-    // For risk to override, it must come before protect
-    assert!(!set.allows_deletion(Path::new("temp/scratch.txt"), false));
+    // upstream: exclude.c:check_filter() is one first-match-wins pass; the
+    // leading `+ temp/**` matches first and returns include, so the entry is
+    // deletable - the later protect is never reached (and `*` would not match
+    // the multi-segment path anyway).
+    assert!(set.allows_deletion(Path::new("temp/scratch.txt"), false));
 
     // Other files protected
     assert!(!set.allows_deletion(Path::new("important.txt"), false));
@@ -436,8 +438,10 @@ fn rust_project_filter() {
     assert!(set.allows(Path::new("Cargo.toml"), false));
     assert!(set.allows(Path::new("Cargo.lock"), false));
 
-    // Cargo.lock protected
-    assert!(!set.allows_deletion(Path::new("Cargo.lock"), false));
+    // upstream: `+ /Cargo.lock` matches first in check_filter()'s single pass
+    // and returns include, so the entry is deletable; the trailing
+    // `P Cargo.lock` never runs.
+    assert!(set.allows_deletion(Path::new("Cargo.lock"), false));
 
     // Source files included via src/** rule
     assert!(set.allows(Path::new("src/main.rs"), false));
@@ -515,8 +519,10 @@ fn javascript_project_filter() {
     assert!(!set.allows(Path::new(".env.local"), false));
     assert!(!set.allows(Path::new(".env"), false));
 
-    // Lock file protected
-    assert!(!set.allows_deletion(Path::new("package-lock.json"), false));
+    // upstream: `+ package-lock.json` matches first in check_filter()'s single
+    // pass and returns include, so the entry is deletable; the trailing
+    // `P package-lock.json` is never reached.
+    assert!(set.allows_deletion(Path::new("package-lock.json"), false));
 }
 
 /// Verifies monorepo filter pattern.

--- a/crates/filters/tests/exclude_from_file_parsing.rs
+++ b/crates/filters/tests/exclude_from_file_parsing.rs
@@ -1052,8 +1052,10 @@ mod integration_tests {
         assert!(set.allows(Path::new("Cargo.toml"), false));
         assert!(set.allows(Path::new("Cargo.lock"), false));
 
-        // Cargo.lock protected from deletion
-        assert!(!set.allows_deletion(Path::new("Cargo.lock"), false));
+        // upstream: `+ Cargo.lock` matches first in check_filter()'s single
+        // pass and returns include, so Cargo.lock is deletable; the following
+        // `P Cargo.lock` is never reached.
+        assert!(set.allows_deletion(Path::new("Cargo.lock"), false));
 
         // Other files excluded
         assert!(!set.allows(Path::new("README.md"), false));

--- a/crates/filters/tests/protect_risk_rules.rs
+++ b/crates/filters/tests/protect_risk_rules.rs
@@ -192,8 +192,40 @@ fn included_protected_file() {
     // File is included for transfer (include matches first)
     assert!(set.allows(Path::new("config.yaml"), false));
 
-    // And protected from deletion
-    assert!(!set.allows_deletion(Path::new("config.yaml"), false));
+    // upstream: check_filter() is one first-match-wins pass; the leading
+    // `+ config.yaml` matches first and returns include, so the entry is
+    // deletable - the trailing `P config.yaml` is unreachable.
+    assert!(set.allows_deletion(Path::new("config.yaml"), false));
+}
+
+/// Deletion resolves include/exclude and protect/risk in a single
+/// source-ordered first-match-wins pass, exactly like upstream
+/// `exclude.c:check_filter()` (`ent->rflags & FILTRULE_INCLUDE ? 1 : -1`).
+/// Whichever rule is written first decides - the rule *kind* does not grant
+/// priority. Verified against rsync 3.4.4: `+ foo` / `- *` / `P foo` with
+/// `--delete` deletes `foo` (include wins) and keeps `other` (exclude
+/// protects); moving `P foo` ahead of `+ foo` keeps `foo` instead.
+#[test]
+fn deletion_first_match_wins_across_include_and_protect() {
+    // Include before protect: the include is first, so `foo` is deletable.
+    let include_first = FilterSet::from_rules([
+        FilterRule::include("foo"),
+        FilterRule::exclude("*"),
+        FilterRule::protect("foo"),
+    ])
+    .unwrap();
+    assert!(include_first.allows_deletion(Path::new("foo"), false));
+    // A sibling with no include falls to `- *` and is protected from deletion.
+    assert!(!include_first.allows_deletion(Path::new("other"), false));
+
+    // Protect before include: the protect is first, so `foo` is protected.
+    let protect_first = FilterSet::from_rules([
+        FilterRule::protect("foo"),
+        FilterRule::include("foo"),
+        FilterRule::exclude("*"),
+    ])
+    .unwrap();
+    assert!(!protect_first.allows_deletion(Path::new("foo"), false));
 }
 
 /// Verifies protect rules are receiver-side only by default.

--- a/crates/filters/tests/rule_evaluation_order.rs
+++ b/crates/filters/tests/rule_evaluation_order.rs
@@ -287,9 +287,11 @@ fn order_matters_per_category() {
     // Transfer: include matches first, all .tmp allowed
     assert!(set.allows(Path::new("keep.tmp"), false));
     assert!(set.allows(Path::new("other.tmp"), false));
-    // Deletion: include allows transfer, protect matches first for protection
-    assert!(!set.allows_deletion(Path::new("keep.tmp"), false));
-    assert!(!set.allows_deletion(Path::new("other.tmp"), false));
+    // Deletion: upstream check_filter() is one first-match-wins pass across all
+    // rule kinds; `+ *.tmp` matches first and returns include, so both entries
+    // are deletable - the later `P *.tmp` / `R keep.tmp` never run.
+    assert!(set.allows_deletion(Path::new("keep.tmp"), false));
+    assert!(set.allows_deletion(Path::new("other.tmp"), false));
 }
 
 /// Verifies order matters for overlapping wildcard patterns.


### PR DESCRIPTION
## Problem

Upstream `exclude.c:check_filter()` keeps every filter rule in one list and walks it first-match-wins, returning `ent->rflags & FILTRULE_INCLUDE ? 1 : -1` on the first matching rule. oc splits rules into two chains (include/exclude and protect/risk) and evaluated the deletion decision as **two independent first-match passes** combined with `transfer_allowed && !protected`.

That combination is order-insensitive across the two rule kinds: a `protect`/`risk` rule could override an earlier `include`/`exclude` (and vice versa) no matter which was written first. So `+ foo` followed by `P foo` incorrectly protected `foo` from `--delete`, where upstream deletes it (the include matches first).

## Fix

- Stamp each compiled rule with its source-definition order.
- For the deletion decision, merge the two chains' receiver-side first-matches back into a single source-ordered verdict: the earlier-defined rule wins; an include/risk makes the entry deletable, an exclude/protect protects it; no match leaves it deletable (upstream returns 0).
- Applied in both filter evaluators: `FilterSet` (remote/daemon receiver path) and the local-copy `FilterProgram`/`FilterOutcome`. The transfer decision and `--delete-excluded` path are unchanged.

## Verification

Validated against `rsync 3.4.4` (protocol 32) with `--delete`:

| rules | upstream | oc (after) |
|---|---|---|
| `+ foo` `- *` `P foo` | `foo` deleted, sibling kept | match |
| `P foo` `+ foo` `- *` | `foo` kept | match |
| `R foo` `P *` | `foo` deleted | match |
| `P foo` / `- foo` / `+ *` | as upstream | match |

All six orderings match byte-for-byte. Six unit tests that encoded the old two-pass behaviour are corrected to the upstream-observed result, and a positive regression test pins both orderings. Full `filters` suite (1421) and engine filter/deletion tests (751) pass; fmt + clippy clean.
