### PR TITLE
fix(bandwidth): quantize --bwlimit to whole KiB

### DIFF
--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -91,16 +91,19 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
         return Err(BandwidthParseError::TooSmall);
     }
 
-    // upstream rounds bwlimit to whole KiB via `(size + 512) / 1024`; oc rounds
-    // to the granularity implied by the suffix (bytes/decimal/binary).
-    let alignment = parsed.unit;
-    let rounded = bytes
-        .checked_add(alignment / 2)
+    // upstream: options.c:1718 `bwlimit = (size + 512) / 1024` rounds the parsed
+    // byte rate to whole KiB, and every pacing calculation then uses that KiB
+    // value (io.c:2115,2120,2133). Quantize identically so a byte or decimal
+    // suffix paces at the same rate as upstream rather than at its exact parsed
+    // byte count: `1500B` -> 1 KiB (1024 B/s), `1MB` -> 977 KiB (1000448 B/s). A
+    // default `K` suffix is already a whole-KiB multiple, so it is unaffected.
+    // The `< 512` minimum is enforced above (as upstream's `parse_size_arg`
+    // floor), so `kib` is always >= 1 here and the result is never zero.
+    let kib = bytes
+        .checked_add(512)
         .ok_or(BandwidthParseError::TooLarge)?
-        / alignment;
-    let rounded_bytes = rounded
-        .checked_mul(alignment)
-        .ok_or(BandwidthParseError::TooLarge)?;
+        / 1024;
+    let rounded_bytes = kib.checked_mul(1024).ok_or(BandwidthParseError::TooLarge)?;
 
     let bytes_u64 = u64::try_from(rounded_bytes).map_err(|_| BandwidthParseError::TooLarge)?;
     NonZeroU64::new(bytes_u64)

--- a/crates/bandwidth/src/parse/tests/argument.rs
+++ b/crates/bandwidth/src/parse/tests/argument.rs
@@ -9,14 +9,33 @@ fn parse_bandwidth_accepts_binary_units() {
 
 #[test]
 fn parse_bandwidth_accepts_decimal_units() {
+    // 12 MB = 12_000_000 bytes (decimal), rounded to whole KiB for pacing
+    // (options.c:1718 `bwlimit = (size + 512) / 1024` -> 11_719 KiB).
     let limit = parse_bandwidth_argument("12MB").expect("parse succeeds");
-    assert_eq!(limit, NonZeroU64::new(12_000_000));
+    assert_eq!(limit, NonZeroU64::new(12_000_256));
+}
+
+#[test]
+fn parse_bandwidth_quantizes_effective_rate_to_whole_kib() {
+    // upstream: options.c:1718 `bwlimit = (size + 512) / 1024`, then every pacing
+    // calculation uses that whole-KiB value (io.c:2115,2120,2133). A byte or
+    // decimal suffix must therefore pace at the KiB-rounded rate, not its exact
+    // parsed byte count, or oc would throttle at a different speed than upstream.
+    // `1500B` -> 1 KiB, `1MB` -> 977 KiB.
+    let byte_rate = parse_bandwidth_argument("1500B").expect("parse succeeds");
+    assert_eq!(byte_rate, NonZeroU64::new(1024));
+
+    let mega = parse_bandwidth_argument("1MB").expect("parse succeeds");
+    assert_eq!(mega, NonZeroU64::new(977 * 1024));
+    assert_eq!(mega, NonZeroU64::new(1_000_448));
 }
 
 #[test]
 fn parse_bandwidth_accepts_explicit_byte_suffix() {
+    // A byte suffix skips the suffix multiplier; the accepted 512-byte floor
+    // then rounds up to the 1 KiB pacing rate (options.c:1718).
     let limit = parse_bandwidth_argument("512b").expect("parse succeeds");
-    assert_eq!(limit, NonZeroU64::new(512));
+    assert_eq!(limit, NonZeroU64::new(1024));
 
     let uppercase = parse_bandwidth_argument("512B").expect("parse succeeds");
     assert_eq!(uppercase, limit);
@@ -118,11 +137,13 @@ fn parse_bandwidth_accepts_leading_plus_sign() {
 
 #[test]
 fn parse_bandwidth_honours_postfix_adjustments_for_byte_suffix() {
+    // The +1/-1 adjustment applies exactly (601 / 599 bytes); both sub-KiB
+    // rates then round to the 1 KiB pacing floor (options.c:1718).
     let incremented = parse_bandwidth_argument("600b+1").expect("parse succeeds");
-    assert_eq!(incremented, NonZeroU64::new(601));
+    assert_eq!(incremented, NonZeroU64::new(1024));
 
     let decremented = parse_bandwidth_argument("600b-1").expect("parse succeeds");
-    assert_eq!(decremented, NonZeroU64::new(599));
+    assert_eq!(decremented, NonZeroU64::new(1024));
 }
 
 #[test]
@@ -292,9 +313,10 @@ fn parse_bandwidth_rejects_whitespace_only() {
 
 #[test]
 fn parse_bandwidth_boundary_minimum_value() {
-    // 512 bytes is the minimum allowed
+    // 512 bytes is the minimum accepted input; it rounds up to the 1 KiB pacing
+    // rate (options.c:1718).
     let at_minimum = parse_bandwidth_argument("512b").expect("parse succeeds");
-    assert_eq!(at_minimum, NonZeroU64::new(512));
+    assert_eq!(at_minimum, NonZeroU64::new(1024));
 
     // 511 bytes should be rejected
     let below_minimum = parse_bandwidth_argument("511b").unwrap_err();
@@ -326,14 +348,14 @@ fn parse_bandwidth_accepts_mixed_case_suffix() {
 
 #[test]
 fn parse_bandwidth_accepts_decimal_suffix_case_variations() {
-    // Decimal suffixes: KB, Kb, kB, kb should all be 1000-based
+    // Decimal suffixes: KB, Kb, kB, kb are all 1000-based (1000 bytes), then
+    // rounded to the 1 KiB pacing rate (options.c:1718 `(1000 + 512) / 1024`).
     let upper = parse_bandwidth_argument("1KB").expect("parse succeeds");
     let mixed1 = parse_bandwidth_argument("1Kb").expect("parse succeeds");
     let mixed2 = parse_bandwidth_argument("1kB").expect("parse succeeds");
     let lower = parse_bandwidth_argument("1kb").expect("parse succeeds");
 
-    // All should equal 1000 bytes
-    let expected = NonZeroU64::new(1000);
+    let expected = NonZeroU64::new(1024);
     assert_eq!(upper, expected);
     assert_eq!(mixed1, expected);
     assert_eq!(mixed2, expected);
@@ -430,9 +452,9 @@ fn parse_bandwidth_fractional_with_adjustment_edge_cases() {
     let at_half = parse_bandwidth_argument("0.5K").expect("parse succeeds");
     assert_eq!(at_half, NonZeroU64::new(1024));
 
-    // 512b = 512 bytes exactly at minimum (byte suffix has 1-byte alignment)
+    // 512b = 512 bytes (accepted floor), rounded to the 1 KiB pacing rate
     let at_min = parse_bandwidth_argument("512b").expect("parse succeeds");
-    assert_eq!(at_min, NonZeroU64::new(512));
+    assert_eq!(at_min, NonZeroU64::new(1024));
 
     // 512b-1 = 511 bytes, below minimum
     let below_min = parse_bandwidth_argument("512b-1").unwrap_err();
@@ -455,12 +477,13 @@ fn parse_bandwidth_handles_all_large_unit_suffixes_with_values() {
 
 #[test]
 fn parse_bandwidth_handles_decimal_b_variants() {
-    // Test decimal base variants (b suffix after K/M/G etc)
-    // GB = 1000^3 bytes
+    // Decimal base variants (b suffix after K/M/G etc), rounded to whole KiB for
+    // pacing (options.c:1718 `bwlimit = (size + 512) / 1024`).
+    // GB = 1000^3 bytes -> 976_563 KiB.
     let gb = parse_bandwidth_argument("1GB").expect("parse succeeds");
-    assert_eq!(gb, NonZeroU64::new(1_000_000_000));
+    assert_eq!(gb, NonZeroU64::new(1_000_000_512));
 
-    // TB = 1000^4 bytes
+    // TB = 1000^4 bytes, already an exact multiple of 1024, so it is unchanged.
     let tb = parse_bandwidth_argument("1TB").expect("parse succeeds");
     assert_eq!(tb, NonZeroU64::new(1_000_000_000_000));
 }
@@ -544,9 +567,10 @@ fn parse_bandwidth_rejects_exponent_after_trailing_decimal() {
 
 #[test]
 fn parse_bandwidth_handles_adjustment_boundary_at_minimum() {
-    // 513b-1 = 512b, exactly at minimum
+    // 513b-1 = 512 bytes, the accepted floor, which rounds to the 1 KiB pacing
+    // rate (options.c:1718).
     let result = parse_bandwidth_argument("513b-1").expect("parse succeeds");
-    assert_eq!(result, NonZeroU64::new(512));
+    assert_eq!(result, NonZeroU64::new(1024));
 }
 
 #[test]

--- a/crates/bandwidth/src/parse/tests/comprehensive_parsing.rs
+++ b/crates/bandwidth/src/parse/tests/comprehensive_parsing.rs
@@ -68,8 +68,9 @@ fn parse_bandwidth_argument_petabytes() {
 fn parse_bandwidth_argument_decimal_base_suffix() {
     // "kb" means decimal kilobytes (1000, not 1024)
     let result = parse_bandwidth_argument("10kb").unwrap();
-    // 10 * 1000 = 10000, rounded to nearest 1000 = 10000
-    assert_eq!(result, Some(nz(10000)));
+    // 10 * 1000 = 10000 bytes, rounded to whole KiB for pacing
+    // (options.c:1718 `(10000 + 512) / 1024` = 10 KiB).
+    assert_eq!(result, Some(nz(10240)));
 }
 
 #[test]
@@ -82,8 +83,9 @@ fn parse_bandwidth_argument_binary_suffix() {
 #[test]
 fn parse_bandwidth_argument_megabytes_decimal() {
     let result = parse_bandwidth_argument("5mb").unwrap();
-    // 5 * 1000000 = 5000000, rounded to nearest 1000 = 5000000
-    assert_eq!(result, Some(nz(5_000_000)));
+    // 5 * 1000000 = 5000000 bytes, rounded to whole KiB for pacing
+    // (options.c:1718 `(5000000 + 512) / 1024` = 4883 KiB).
+    assert_eq!(result, Some(nz(5_000_192)));
 }
 
 #[test]
@@ -100,8 +102,9 @@ fn parse_bandwidth_argument_mixed_case_suffixes() {
     let result = parse_bandwidth_argument("10KiB").unwrap();
     assert_eq!(result, Some(nz(10 * 1024)));
 
+    // 5 MB decimal = 5_000_000 bytes -> 4883 KiB pacing (options.c:1718).
     let result = parse_bandwidth_argument("5Mb").unwrap();
-    assert_eq!(result, Some(nz(5_000_000)));
+    assert_eq!(result, Some(nz(5_000_192)));
 }
 
 #[test]
@@ -190,9 +193,10 @@ fn parse_bandwidth_argument_too_small() {
 
 #[test]
 fn parse_bandwidth_argument_exactly_512_bytes() {
-    // Exactly 512 bytes should be accepted
+    // Exactly 512 bytes is accepted (upstream's floor) and rounds up to the
+    // 1 KiB pacing rate (options.c:1718).
     let result = parse_bandwidth_argument("512b").unwrap();
-    assert_eq!(result, Some(nz(512)));
+    assert_eq!(result, Some(nz(1024)));
 }
 
 #[test]
@@ -374,10 +378,11 @@ fn parse_bandwidth_limit_burst_too_small() {
 
 #[test]
 fn rounding_to_kilobyte_boundary() {
-    // 1500 bytes with 'b' suffix - no rounding since alignment is 1
+    // 1500 bytes with 'b' suffix skips the suffix multiplier, but the pacing
+    // rate is still rounded to whole KiB (options.c:1718 `(1500 + 512) / 1024`
+    // = 1 KiB).
     let result = parse_bandwidth_argument("1500b").unwrap();
-    // With 'b' suffix, alignment is 1, so result is 1500
-    assert_eq!(result, Some(nz(1500)));
+    assert_eq!(result, Some(nz(1024)));
 }
 
 #[test]
@@ -390,16 +395,17 @@ fn rounding_default_kilobyte() {
 
 #[test]
 fn rounding_decimal_base() {
-    // "kb" uses base 1000, rounds to 1000
+    // "kb" uses base 1000 (1500 * 1000 = 1_500_000 bytes), but the pacing rate
+    // is rounded to whole KiB (options.c:1718), so the result is a KiB multiple.
     let result = parse_bandwidth_argument("1500kb").unwrap();
-    // 1500 * 1000 = 1500000, rounded to nearest 1000
-    assert!(result.unwrap().get() % 1000 == 0);
+    assert!(result.unwrap().get() % 1024 == 0);
 }
 
 #[test]
 fn boundary_minimum_valid_512_bytes() {
+    // Accepted floor of 512 bytes rounds up to the 1 KiB pacing rate.
     let result = parse_bandwidth_argument("512b").unwrap();
-    assert_eq!(result, Some(nz(512)));
+    assert_eq!(result, Some(nz(1024)));
 }
 
 #[test]
@@ -410,9 +416,9 @@ fn boundary_511_bytes_too_small() {
 
 #[test]
 fn boundary_513_bytes_valid() {
+    // 513 bytes rounds to the 1 KiB pacing rate (options.c:1718).
     let result = parse_bandwidth_argument("513b").unwrap();
-    // With 'b' suffix, alignment is 1, so no rounding - result is 513
-    assert_eq!(result, Some(nz(513)));
+    assert_eq!(result, Some(nz(1024)));
 }
 
 #[test]

--- a/crates/bandwidth/src/parse/tests/edge_cases.rs
+++ b/crates/bandwidth/src/parse/tests/edge_cases.rs
@@ -61,26 +61,30 @@ mod size_suffixes {
     }
 
     #[test]
-    fn byte_suffix_uses_no_multiplier() {
-        // B/b suffix means raw bytes (no multiplier)
+    fn byte_suffix_quantizes_to_whole_kib() {
+        // B/b suffix means raw bytes (no multiplier), but upstream then rounds
+        // the rate to whole KiB (options.c:1718 `bwlimit = (size + 512) / 1024`)
+        // and paces on that. `1024b` is already 1 KiB; `512B` rounds up to 1 KiB.
         let result = parse_bandwidth_argument("1024b").expect("parse succeeds");
         assert_eq!(result, NonZeroU64::new(1024));
 
         let result = parse_bandwidth_argument("512B").expect("parse succeeds");
-        assert_eq!(result, NonZeroU64::new(512));
+        assert_eq!(result, NonZeroU64::new(1024));
     }
 
     #[test]
-    fn decimal_suffixes_use_1000_multiplier() {
-        // KB/MB/GB suffixes use 1000-based (decimal) multipliers
+    fn decimal_suffixes_quantize_to_whole_kib() {
+        // KB/MB/GB suffixes use 1000-based (decimal) multipliers, then upstream
+        // rounds the resulting byte rate to whole KiB and paces on that
+        // (options.c:1718 `bwlimit = (size + 512) / 1024`).
         let kb = parse_bandwidth_argument("1KB").expect("parse succeeds");
-        assert_eq!(kb, NonZeroU64::new(1000));
+        assert_eq!(kb, NonZeroU64::new(1024)); // (1000 + 512) / 1024 = 1 KiB
 
         let mb = parse_bandwidth_argument("1MB").expect("parse succeeds");
-        assert_eq!(mb, NonZeroU64::new(1_000_000));
+        assert_eq!(mb, NonZeroU64::new(1_000_448)); // 977 KiB
 
         let gb = parse_bandwidth_argument("1GB").expect("parse succeeds");
-        assert_eq!(gb, NonZeroU64::new(1_000_000_000));
+        assert_eq!(gb, NonZeroU64::new(1_000_000_512)); // 976_563 KiB
     }
 
     #[test]
@@ -147,12 +151,13 @@ mod rate_formats {
         let result = parse_bandwidth_argument("1K-1").expect("parse succeeds");
         assert_eq!(result, NonZeroU64::new(1024)); // Rounded, adjustment applied
 
-        // Byte suffix allows exact adjustment
+        // Byte suffix applies the exact +1/-1 adjustment (601 / 599 bytes),
+        // which then rounds to the 1 KiB pacing floor like every sub-KiB rate.
         let result = parse_bandwidth_argument("600b+1").expect("parse succeeds");
-        assert_eq!(result, NonZeroU64::new(601));
+        assert_eq!(result, NonZeroU64::new(1024));
 
         let result = parse_bandwidth_argument("600b-1").expect("parse succeeds");
-        assert_eq!(result, NonZeroU64::new(599));
+        assert_eq!(result, NonZeroU64::new(1024));
     }
 
     #[test]
@@ -623,21 +628,23 @@ mod case_sensitivity {
         let lower = parse_bandwidth_argument("512b").expect("parse succeeds");
         let upper = parse_bandwidth_argument("512B").expect("parse succeeds");
         assert_eq!(lower, upper);
-        assert_eq!(lower, NonZeroU64::new(512));
+        // 512 bytes rounds up to the 1 KiB pacing floor (options.c:1718).
+        assert_eq!(lower, NonZeroU64::new(1024));
     }
 
     #[test]
     fn decimal_suffix_all_case_variations() {
-        // KB, Kb, kB, kb all work
+        // KB, Kb, kB, kb all work: 1000-byte decimal rate, rounded to the 1 KiB
+        // pacing floor (options.c:1718 `bwlimit = (size + 512) / 1024`).
         let kb_upper = parse_bandwidth_argument("1KB").expect("parse succeeds");
         let kb_mixed1 = parse_bandwidth_argument("1Kb").expect("parse succeeds");
         let kb_mixed2 = parse_bandwidth_argument("1kB").expect("parse succeeds");
         let kb_lower = parse_bandwidth_argument("1kb").expect("parse succeeds");
 
-        assert_eq!(kb_upper, NonZeroU64::new(1000));
-        assert_eq!(kb_mixed1, NonZeroU64::new(1000));
-        assert_eq!(kb_mixed2, NonZeroU64::new(1000));
-        assert_eq!(kb_lower, NonZeroU64::new(1000));
+        assert_eq!(kb_upper, NonZeroU64::new(1024));
+        assert_eq!(kb_mixed1, NonZeroU64::new(1024));
+        assert_eq!(kb_mixed2, NonZeroU64::new(1024));
+        assert_eq!(kb_lower, NonZeroU64::new(1024));
     }
 
     #[test]
@@ -717,8 +724,10 @@ mod minimum_values {
 
     #[test]
     fn minimum_512_bytes_is_valid() {
+        // 512 bytes is upstream's accepted floor (parse_size_arg min), and it
+        // rounds up to the 1 KiB pacing rate (options.c:1718).
         let result = parse_bandwidth_argument("512b").expect("parse succeeds");
-        assert_eq!(result, NonZeroU64::new(512));
+        assert_eq!(result, NonZeroU64::new(1024));
     }
 
     #[test]
@@ -846,10 +855,11 @@ mod rounding {
     }
 
     #[test]
-    fn byte_suffix_no_rounding() {
-        // Byte suffix values are not rounded
+    fn byte_suffix_quantized_to_kib() {
+        // A byte suffix skips the suffix multiplier, but the final rate is still
+        // rounded to whole KiB for pacing: 513 bytes -> 1 KiB (options.c:1718).
         let result = parse_bandwidth_argument("513b").expect("parse succeeds");
-        assert_eq!(result, NonZeroU64::new(513));
+        assert_eq!(result, NonZeroU64::new(1024));
     }
 
     #[test]

--- a/crates/bandwidth/src/parse/tests/parser_edge_cases.rs
+++ b/crates/bandwidth/src/parse/tests/parser_edge_cases.rs
@@ -243,9 +243,10 @@ fn parse_b_suffix_bytes() {
 
 #[test]
 fn parse_kb_decimal_suffix() {
-    // 1KB = 1000 bytes (decimal, not binary)
+    // 1KB = 1000 bytes (decimal), rounded to the 1 KiB pacing rate
+    // (options.c:1718 `(1000 + 512) / 1024`).
     let result = parse_bandwidth_argument("1KB").unwrap();
-    assert_eq!(result, Some(NonZeroU64::new(1000).unwrap()));
+    assert_eq!(result, Some(NonZeroU64::new(1024).unwrap()));
 }
 
 #[test]
@@ -257,9 +258,10 @@ fn parse_kib_binary_suffix() {
 
 #[test]
 fn parse_mb_decimal() {
-    // 1MB = 1,000,000 bytes
+    // 1MB = 1,000,000 bytes (decimal), rounded to whole KiB for pacing
+    // (options.c:1718 -> 977 KiB).
     let result = parse_bandwidth_argument("1MB").unwrap();
-    assert_eq!(result, Some(NonZeroU64::new(1_000_000).unwrap()));
+    assert_eq!(result, Some(NonZeroU64::new(1_000_448).unwrap()));
 }
 
 #[test]
@@ -271,9 +273,10 @@ fn parse_mib_binary() {
 
 #[test]
 fn parse_gb_decimal() {
-    // 1GB = 1,000,000,000 bytes
+    // 1GB = 1,000,000,000 bytes (decimal), rounded to whole KiB for pacing
+    // (options.c:1718 -> 976_563 KiB).
     let result = parse_bandwidth_argument("1GB").unwrap();
-    assert_eq!(result, Some(NonZeroU64::new(1_000_000_000).unwrap()));
+    assert_eq!(result, Some(NonZeroU64::new(1_000_000_512).unwrap()));
 }
 
 #[test]
@@ -337,8 +340,9 @@ fn parse_below_minimum_512_bytes() {
 
 #[test]
 fn parse_exactly_minimum_512_bytes() {
+    // The 512-byte floor is accepted and rounds up to the 1 KiB pacing rate.
     let result = parse_bandwidth_argument("512B").unwrap();
-    assert_eq!(result, Some(NonZeroU64::new(512).unwrap()));
+    assert_eq!(result, Some(NonZeroU64::new(1024).unwrap()));
 }
 
 #[test]

--- a/crates/bandwidth/src/size_arg.rs
+++ b/crates/bandwidth/src/size_arg.rs
@@ -28,8 +28,9 @@ pub struct ParsedSize {
     /// Byte count after suffix scaling and the optional `+1`/`-1` adjustment.
     pub bytes: u128,
     /// Unit granularity implied by the suffix: `1` for a byte suffix, `1000`
-    /// for a decimal suffix (`KB`/`MB`/...), `1024` otherwise. Callers that
-    /// round to whole units (e.g. `--bwlimit`) use this; size limits ignore it.
+    /// for a decimal suffix (`KB`/`MB`/...), `1024` otherwise. Reported for
+    /// callers that need the suffix granularity; the byte-oriented size limits
+    /// and `--bwlimit` (which quantizes to whole KiB) do not consume it.
     pub unit: u128,
 }
 

--- a/crates/bandwidth/tests/bwlimit_comprehensive.rs
+++ b/crates/bandwidth/tests/bwlimit_comprehensive.rs
@@ -139,19 +139,21 @@ mod rate_with_k_suffix {
 
     #[test]
     fn bwlimit_1k_decimal_kb() {
-        // KB suffix uses decimal (1000) instead of binary (1024)
+        // KB suffix uses decimal (1000), then upstream rounds the rate to whole
+        // KiB for pacing (options.c:1718 `(1000 + 512) / 1024` = 1 KiB).
         let limit = parse_bandwidth_argument("1KB")
             .expect("parse succeeds")
             .expect("limit available");
-        assert_eq!(limit.get(), 1000);
+        assert_eq!(limit.get(), 1024);
     }
 
     #[test]
     fn bwlimit_10kb_decimal() {
+        // 10 KB decimal = 10_000 bytes -> 10 KiB pacing (options.c:1718).
         let limit = parse_bandwidth_argument("10KB")
             .expect("parse succeeds")
             .expect("limit available");
-        assert_eq!(limit.get(), 10 * 1000);
+        assert_eq!(limit.get(), 10 * 1024);
     }
 
     #[test]
@@ -217,18 +219,20 @@ mod rate_with_m_suffix {
 
     #[test]
     fn bwlimit_1mb_decimal() {
+        // 1 MB decimal = 1_000_000 bytes -> 977 KiB pacing (options.c:1718).
         let limit = parse_bandwidth_argument("1MB")
             .expect("parse succeeds")
             .expect("limit available");
-        assert_eq!(limit.get(), 1_000_000);
+        assert_eq!(limit.get(), 1_000_448);
     }
 
     #[test]
     fn bwlimit_10mb_decimal() {
+        // 10 MB decimal = 10_000_000 bytes -> 9766 KiB pacing (options.c:1718).
         let limit = parse_bandwidth_argument("10MB")
             .expect("parse succeeds")
             .expect("limit available");
-        assert_eq!(limit.get(), 10_000_000);
+        assert_eq!(limit.get(), 10_000_384);
     }
 
     #[test]
@@ -301,10 +305,12 @@ mod rate_with_g_suffix {
 
     #[test]
     fn bwlimit_1gb_decimal() {
+        // 1 GB decimal = 1_000_000_000 bytes -> 976_563 KiB pacing
+        // (options.c:1718).
         let limit = parse_bandwidth_argument("1GB")
             .expect("parse succeeds")
             .expect("limit available");
-        assert_eq!(limit.get(), 1_000_000_000);
+        assert_eq!(limit.get(), 1_000_000_512);
     }
 
     #[test]
@@ -426,11 +432,12 @@ mod very_low_rates {
 
     #[test]
     fn bwlimit_minimum_512_bytes() {
-        // Minimum allowed is 512 bytes/second
+        // 512 bytes is the accepted minimum input; upstream rounds it up to the
+        // 1 KiB pacing rate (options.c:1718 `(512 + 512) / 1024` = 1 KiB).
         let limit = parse_bandwidth_argument("512b")
             .expect("parse succeeds")
             .expect("limit available");
-        assert_eq!(limit.get(), 512);
+        assert_eq!(limit.get(), 1024);
     }
 
     #[test]

--- a/crates/bandwidth/tests/bwlimit_rate_limiting.rs
+++ b/crates/bandwidth/tests/bwlimit_rate_limiting.rs
@@ -30,10 +30,11 @@ fn within_tolerance(actual: Duration, expected: Duration, tolerance_percent: f64
 
 #[test]
 fn bwlimit_unit_bytes_explicit() {
+    // 512-byte floor rounds up to the 1 KiB pacing rate (options.c:1718).
     let limit = parse_bandwidth_argument("512b")
         .expect("parse succeeds")
         .expect("limit available");
-    assert_eq!(limit.get(), 512);
+    assert_eq!(limit.get(), 1024);
 }
 
 #[test]
@@ -46,10 +47,11 @@ fn bwlimit_unit_kilobytes_binary() {
 
 #[test]
 fn bwlimit_unit_kilobytes_decimal() {
+    // 1 KB decimal = 1000 bytes -> 1 KiB pacing (options.c:1718).
     let limit = parse_bandwidth_argument("1KB")
         .expect("parse succeeds")
         .expect("limit available");
-    assert_eq!(limit.get(), 1000);
+    assert_eq!(limit.get(), 1024);
 }
 
 #[test]
@@ -62,10 +64,11 @@ fn bwlimit_unit_megabytes_binary() {
 
 #[test]
 fn bwlimit_unit_megabytes_decimal() {
+    // 1 MB decimal = 1_000_000 bytes -> 977 KiB pacing (options.c:1718).
     let limit = parse_bandwidth_argument("1MB")
         .expect("parse succeeds")
         .expect("limit available");
-    assert_eq!(limit.get(), 1_000_000);
+    assert_eq!(limit.get(), 1_000_448);
 }
 
 #[test]
@@ -78,10 +81,11 @@ fn bwlimit_unit_gigabytes_binary() {
 
 #[test]
 fn bwlimit_unit_gigabytes_decimal() {
+    // 1 GB decimal = 1_000_000_000 bytes -> 976_563 KiB pacing (options.c:1718).
     let limit = parse_bandwidth_argument("1GB")
         .expect("parse succeeds")
         .expect("limit available");
-    assert_eq!(limit.get(), 1_000_000_000);
+    assert_eq!(limit.get(), 1_000_000_512);
 }
 
 #[test]
@@ -469,14 +473,15 @@ fn bwlimit_burst_affects_write_max() {
 
 #[test]
 fn bwlimit_minimum_rate_512_bytes() {
+    // The 512-byte floor rounds up to the 1 KiB pacing rate (options.c:1718).
     let limit = parse_bandwidth_argument("512b")
         .expect("parse succeeds")
         .expect("limit available");
-    assert_eq!(limit.get(), 512);
+    assert_eq!(limit.get(), 1024);
 
-    // Create limiter and verify it works
+    // Create limiter and verify it works: one KiB at 1 KiB/s takes one second.
     let mut limiter = BandwidthLimiter::new(limit);
-    let sleep = limiter.register(512);
+    let sleep = limiter.register(1024);
     assert_eq!(sleep.requested(), Duration::from_secs(1));
 }
 
@@ -577,8 +582,8 @@ fn bwlimit_fractional_value_with_decimal_suffix() {
     let limit = parse_bandwidth_argument("1.5MB")
         .expect("parse succeeds")
         .expect("limit available");
-    // 1.5 * 1,000,000 = 1,500,000
-    assert_eq!(limit.get(), 1_500_000);
+    // 1.5 * 1,000,000 = 1,500,000 bytes -> 1465 KiB pacing (options.c:1718).
+    assert_eq!(limit.get(), 1_500_160);
 }
 
 #[test]
@@ -638,11 +643,12 @@ fn bwlimit_simulated_large_file_transfer() {
 
 #[test]
 fn bwlimit_behavior_matches_upstream_semantics_byte_suffix() {
-    // Upstream rsync: 512b means exactly 512 bytes/second
+    // Upstream rsync: 512b is the accepted floor, rounded to 1 KiB/s pacing
+    // (options.c:1718 `bwlimit = (512 + 512) / 1024` = 1 KiB).
     let limit = parse_bandwidth_argument("512b")
         .expect("parse succeeds")
         .expect("limit available");
-    assert_eq!(limit.get(), 512);
+    assert_eq!(limit.get(), 1024);
 }
 
 #[test]
@@ -656,11 +662,12 @@ fn bwlimit_behavior_matches_upstream_semantics_k_suffix() {
 
 #[test]
 fn bwlimit_behavior_matches_upstream_semantics_kb_suffix() {
-    // Upstream rsync: KB suffix uses decimal kilobytes (1000)
+    // Upstream rsync: KB suffix uses decimal kilobytes (10 * 1000 bytes), then
+    // rounds the rate to whole KiB for pacing (options.c:1718 -> 10 KiB).
     let limit = parse_bandwidth_argument("10KB")
         .expect("parse succeeds")
         .expect("limit available");
-    assert_eq!(limit.get(), 10 * 1000);
+    assert_eq!(limit.get(), 10 * 1024);
 }
 
 #[test]
@@ -684,7 +691,8 @@ fn bwlimit_behavior_matches_upstream_semantics_zero_unlimited() {
 
 #[test]
 fn bwlimit_behavior_matches_upstream_semantics_minimum_512() {
-    // Upstream rsync: minimum is 512 bytes/second
+    // Upstream rsync: 512 bytes is the minimum accepted input (parse_size_arg
+    // floor), which it paces at 1 KiB/s after the KiB rounding.
     let at_min = parse_bandwidth_argument("512b").expect("parse succeeds");
     assert!(at_min.is_some());
 

--- a/crates/bandwidth/tests/comprehensive_coverage.rs
+++ b/crates/bandwidth/tests/comprehensive_coverage.rs
@@ -993,16 +993,20 @@ mod parsing_coverage {
 
     #[test]
     fn parse_various_units() {
+        // upstream: options.c:1718 quantizes --bwlimit to whole KiB via
+        // `bwlimit = (size + 512) / 1024`, so decimal-suffix and byte values
+        // round to the nearest 1024 multiple (binary suffixes are already
+        // whole-KiB multiples and stay unchanged).
         let cases: Vec<(&str, u64)> = vec![
-            ("512b", 512),
+            ("512b", 1024),
             ("1K", 1024),
-            ("1KB", 1000),
+            ("1KB", 1024),
             ("1KiB", 1024),
             ("1M", 1024 * 1024),
-            ("1MB", 1_000_000),
+            ("1MB", 1_000_448),
             ("1MiB", 1024 * 1024),
             ("1G", 1024 * 1024 * 1024),
-            ("1GB", 1_000_000_000),
+            ("1GB", 1_000_000_512),
         ];
 
         for (input, expected) in cases {
@@ -1019,11 +1023,14 @@ mod parsing_coverage {
 
     #[test]
     fn parse_fractional_values() {
+        // upstream: options.c:1718 rounds --bwlimit to the nearest whole KiB.
+        // Binary-suffix fractions land on exact 1024 multiples; decimal-suffix
+        // fractions quantize (0.5MB=500000 -> 488 KiB, 1.5MB=1500000 -> 1465 KiB).
         let cases: Vec<(&str, u64)> = vec![
             ("0.5M", 512 * 1024),
             ("1.5M", 1_572_864),
-            ("0.5MB", 500_000),
-            ("1.5MB", 1_500_000),
+            ("0.5MB", 499_712),
+            ("1.5MB", 1_500_160),
         ];
 
         for (input, expected) in cases {

--- a/crates/cli/src/frontend/tests/bwlimit.rs
+++ b/crates/cli/src/frontend/tests/bwlimit.rs
@@ -37,7 +37,9 @@ fn bwlimit_accepts_decimal_base_specifier() {
     let limit = parse_bandwidth_limit(OsStr::new("10KB"))
         .expect("parse succeeds")
         .expect("limit available");
-    assert_eq!(limit.bytes_per_second().get(), 10_000);
+    // upstream: options.c:1718 quantizes --bwlimit to whole KiB, so 10000 bytes
+    // rounds to 10 KiB (10240 B/s) rather than pacing at the exact decimal value.
+    assert_eq!(limit.bytes_per_second().get(), 10_240);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Upstream finalizes `--bwlimit` in `options.c:1718` as:

```c
bwlimit = (size + 512) / 1024;
```

The parsed byte value is rounded to the nearest whole KiB, and every pacing calculation (`io.c:2115,2120,2133`) then uses that KiB value. oc kept the parsed byte value at its suffix-unit resolution, so a byte- or decimal-suffix limit paced at a rate upstream never uses - e.g. `--bwlimit=1MB` paced at 1 000 000 B/s where upstream paces at 977 KiB = 1 000 448 B/s, and `--bwlimit=1500B` paced at 1500 B/s where upstream paces at 1 KiB = 1024 B/s.

## Fix

Quantize the finalized limit to whole KiB (`(bytes + 512) / 1024 * 1024`) at the single choke point every caller (CLI, daemon, remote-forward, local pacing) routes through - after the existing `0`=unlimited and 512-byte-minimum handling, so `kib >= 1` always and the result is never zero.

Binary-suffix limits (`K`, `KiB`, `MiB`, ...) were already whole-KiB multiples and are unchanged. Only decimal-suffix (base-1000) and byte-suffix values shift, to the upstream-correct rate. Test expectations across the bandwidth parse/limit suites are updated to the quantized values.

## Verification

Values checked against the `options.c:1718` formula: `512b`->1024, `1KB`->1024, `1MB`->1 000 448, `1GB`->1 000 000 512, `0.5MB`->499 712, `1.5MB`->1 500 160. Full `bandwidth` suite (1231 tests) passes; fmt + clippy clean.
