### PR TITLE
ci: make Windows GNU cross-check mingw-w64 install resilient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,7 +525,7 @@ jobs:
     name: Windows GNU cross-check
     runs-on: ubuntu-latest
     needs: lint
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -536,8 +536,26 @@ jobs:
         with:
           targets: x86_64-pc-windows-gnu
 
+      # The ubuntu-latest image ships mingw-w64, so the apt install is normally a
+      # no-op. Skip it when the cross-linker is already present; otherwise bound
+      # each apt call and retry so a stalled mirror cannot hang the whole job to
+      # the timeout (previously apt-get would wedge past 15 minutes and cancel).
       - name: Install mingw-w64
-        run: sudo apt-get update && sudo apt-get install -y mingw-w64
+        run: |
+          if command -v x86_64-w64-mingw32-gcc >/dev/null 2>&1; then
+            echo "mingw-w64 already present: $(x86_64-w64-mingw32-gcc --version | head -1)"
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            if timeout 180 sudo apt-get update \
+              && timeout 180 sudo apt-get install -y --no-install-recommends mingw-w64; then
+              exit 0
+            fi
+            echo "mingw-w64 install attempt ${attempt} failed; retrying in 15s" >&2
+            sleep 15
+          done
+          echo "mingw-w64 install failed after 3 attempts" >&2
+          exit 1
 
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2


### PR DESCRIPTION
## Problem

The `windows-gnu-cross-check` job installs mingw-w64 via a bare `sudo apt-get update && sudo apt-get install -y mingw-w64` with no timeout or retry. When an apt mirror stalls, the step wedges and the entire job hits its 15-minute `timeout-minutes` and is cancelled. This failed identically on two consecutive runs of #6895, so it is a persistent infrastructure fragility that blocks PRs regardless of their contents (the `Check compilation` step never even runs).

## Fix

- The `ubuntu-latest` runner image already ships mingw-w64, so skip the apt install when `x86_64-w64-mingw32-gcc` is already on PATH (the normal case) - eliminating the flaky apt call outright.
- When the cross-linker is genuinely missing, bound each apt call to 180s via `timeout` and retry up to three times, so a stalled mirror can no longer hang the job to its timeout.
- Fail loudly (`exit 1`) if the toolchain cannot be installed after retries - no silent skip.
- Bump the job timeout 15 -> 20 min for worst-case retry headroom.

This job's own run of the fixed step validates the change.