### PR TITLE
fix(output): compute summary rate over a whole-second span

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -1,5 +1,6 @@
 use std::io::{self, Write};
 use std::path::Path;
+use std::time::Duration;
 
 use core::client::{
     ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind, ClientSummary,
@@ -668,6 +669,22 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
     Ok(())
 }
 
+/// Computes the summary transfer rate in bytes/sec.
+///
+/// Mirrors upstream `main.c:418-423` `bytes_per_sec_human_dnum()`:
+/// `(total_written + total_read) / (0.5 + (endtime - starttime))`, where
+/// `endtime`/`starttime` are whole-second `time_t` values captured with
+/// `time(NULL)` (main.c:141,327,1763). The wall-clock span is therefore
+/// truncated to whole seconds here so a transfer that runs 1.4 s divides by the
+/// same integer second count upstream would use, rather than a fractional span.
+/// The `0.5` floor keeps a sub-second transfer from dividing by zero, and the
+/// single wall-clock span avoids the summed per-file copy durations (which are
+/// ~0 for CoW/clonefile and would explode the rate).
+fn transfer_rate(sent: u64, received: u64, wall_clock: Duration) -> f64 {
+    let whole_seconds = wall_clock.as_secs() as f64;
+    (sent + received) as f64 / (0.5 + whole_seconds)
+}
+
 /// Emits the summary lines reported by verbose transfers.
 pub(crate) fn emit_totals<W: Write + ?Sized>(
     summary: &ClientSummary,
@@ -680,11 +697,7 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
     let sent = summary.bytes_sent();
     let received = summary.bytes_received();
     let total_size = summary.total_source_bytes();
-    // upstream main.c:418-423: rate = (written+read) / (0.5 + (endtime-starttime)),
-    // a single wall-clock span with a 0.5s floor - never the summed per-file copy
-    // durations (which are ~0 for CoW/clonefile and explode the rate).
-    let wall_seconds = summary.wall_clock_elapsed().as_secs_f64();
-    let rate = (sent + received) as f64 / (0.5 + wall_seconds);
+    let rate = transfer_rate(sent, received, summary.wall_clock_elapsed());
     let transmitted = sent.saturating_add(received);
     let speedup = if transmitted > 0 {
         total_size as f64 / transmitted as f64
@@ -1472,6 +1485,24 @@ mod tests {
         let both = render_summary(1, true, true);
         assert!(both.contains(" (BATCH ONLY)"), "{both:?}");
         assert!(!both.contains("(DRY RUN)"), "{both:?}");
+    }
+
+    #[test]
+    fn transfer_rate_uses_whole_second_denominator() {
+        // upstream: main.c:422 - rate = (written+read) / (0.5 + (endtime -
+        // starttime)), where endtime/starttime are whole-second time_t values
+        // (main.c:141,327,1763 `time(NULL)`). A 1.9 s wall span must truncate to
+        // 1 whole second, giving a denominator of 0.5 + 1 = 1.5 exactly like
+        // upstream - never 0.5 + 1.9. Dividing by the fractional span would
+        // report a rate below upstream's for any transfer crossing into a new
+        // whole second.
+        let rate = transfer_rate(3000, 0, Duration::from_millis(1900));
+        assert!((rate - 2000.0).abs() < 1e-9, "got {rate}");
+
+        // A sub-second span truncates to 0 whole seconds, so the denominator is
+        // the bare 0.5 floor (upstream's `0.5 + 0`).
+        let sub_second = transfer_rate(1000, 0, Duration::from_millis(400));
+        assert!((sub_second - 2000.0).abs() < 1e-9, "got {sub_second}");
     }
 
     #[test]

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -3,7 +3,7 @@
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use logging::{debug_log, info_log};
 
@@ -22,6 +22,20 @@ use super::handlers::{
 };
 use super::metadata::{compute_relative_paths, fetch_source_metadata};
 use super::types::{SourceMetadataResult, SourceProcessingContext};
+
+/// Returns the current time truncated to whole seconds since the Unix epoch.
+///
+/// Mirrors upstream's `time(NULL)` (main.c:327,1763), whose `time_t` result has
+/// whole-second resolution. The transfer rate uses the integer difference of
+/// two such marks (main.c:422), so the wall-clock span must be captured the same
+/// way. A clock that reads before the epoch (never expected in practice) yields
+/// `0` rather than panicking.
+fn whole_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since_epoch| since_epoch.as_secs())
+        .unwrap_or(0)
+}
 
 /// Entry point for copying all sources to the destination.
 ///
@@ -47,7 +61,9 @@ pub(crate) fn copy_sources(
             )
         })?;
 
-    let run_start = Instant::now();
+    // upstream: main.c:1763 `starttime = time(NULL)` - the transfer rate span
+    // is measured between two whole-second time_t marks, not a fractional clock.
+    let run_start_secs = whole_unix_seconds();
     let destination_root = plan.destination_spec().path().to_path_buf();
     let mut context = CopyContext::new(mode, options, handler, destination_root);
     context.set_multi_source(plan.sources().len() > 1);
@@ -269,11 +285,15 @@ pub(crate) fn copy_sources(
 
     match result {
         Ok(()) => {
-            // upstream main.c:418: the transfer rate uses a single wall-clock
-            // span, not the sum of per-file copy durations (which is ~0 for CoW).
+            // upstream main.c:327,422: the transfer rate uses `endtime -
+            // starttime`, the integer difference of two whole-second time_t
+            // marks - not the sum of per-file copy durations (~0 for CoW) and
+            // not a fractional clock. Capture the same whole-second span so a
+            // transfer crossing a second boundary reports the upstream rate.
+            let elapsed_secs = whole_unix_seconds().saturating_sub(run_start_secs);
             context
                 .summary_mut()
-                .record_wall_clock_elapsed(run_start.elapsed());
+                .record_wall_clock_elapsed(Duration::from_secs(elapsed_secs));
             Ok(context.into_outcome())
         }
         Err(error) => {


### PR DESCRIPTION
## Problem

Upstream reports the summary transfer rate as `(total_written + total_read) / (0.5 + (endtime - starttime))`, where `starttime`/`endtime` are whole-second `time_t` values from `time(NULL)` (`main.c:141,327,422,1763`). oc divided by a **fractional** wall-clock span (`Duration::as_secs_f64()`), so any transfer crossing into a new whole second reported a rate below upstream's.

## Fix

- **Local copy** (`orchestration.rs`): capture the span as the integer difference of two whole-second Unix-time marks - exactly upstream's `endtime - starttime` - making the local summary rate byte-for-byte identical to upstream.
- **Renderer** (`render.rs`): a small `transfer_rate()` helper truncates the span to whole seconds (`0.5 + span.as_secs()`). The remote/daemon path supplies elapsed time as a fractional `Duration`; flooring it drops the sub-second remainder that never matched upstream's integer span, moving it strictly closer. The `0.5`s floor still prevents a sub-second transfer from dividing by zero.

## Verification

Formula matches `main.c:418-423`; a 1.9 s span truncates to a `0.5 + 1` denominator like upstream, not `0.5 + 1.9`. New unit test `transfer_rate_uses_whole_second_denominator`. cli (254) and engine local-copy (3920) test groups pass; fmt + clippy clean.