### PR TITLE
chore(lint): enforce clippy::unwrap_used in production code

### DIFF
--- a/crates/engine/src/concurrent_delta/work_queue/drain.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/drain.rs
@@ -93,14 +93,21 @@ impl WorkQueueReceiver {
                         std::hash::Hash::hash(&id, &mut hasher);
                         std::hash::Hasher::finish(&hasher) as usize
                     });
-                    shards[idx % num_shards].lock().unwrap().push(result);
+                    shards[idx % num_shards]
+                        .lock()
+                        .expect("delta-drain shard mutex poisoned")
+                        .push(result);
                 });
             }
         });
 
         shards
             .into_iter()
-            .flat_map(|shard| shard.into_inner().unwrap())
+            .flat_map(|shard| {
+                shard
+                    .into_inner()
+                    .expect("delta-drain shard mutex poisoned")
+            })
             .collect()
     }
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), deny(unsafe_code))]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 //! Transfer engine - delta pipeline, local-copy executor, and sparse I/O.
 //!

--- a/crates/engine/src/local_copy/context_impl/options/batch.rs
+++ b/crates/engine/src/local_copy/context_impl/options/batch.rs
@@ -54,7 +54,7 @@ impl<'a> CopyContext<'a> {
             Some(w) => w.clone(),
             None => return Ok(()),
         };
-        let mut writer_guard = batch_writer_arc.lock().unwrap();
+        let mut writer_guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
         writer_guard.write_data(&buf).map_err(|e| {
             crate::local_copy::LocalCopyError::io(
                 "write batch flist end marker",
@@ -90,7 +90,7 @@ impl<'a> CopyContext<'a> {
         };
 
         let (proto, compat_flags, preserve_uid, preserve_gid, preserve_acls) = {
-            let cfg = batch_writer_arc.lock().unwrap();
+            let cfg = batch_writer_arc.lock().expect("batch writer mutex poisoned");
             let flags = cfg.stream_flags();
             (
                 cfg.config().protocol_version,
@@ -145,7 +145,7 @@ impl<'a> CopyContext<'a> {
             })?;
         }
 
-        let mut writer_guard = batch_writer_arc.lock().unwrap();
+        let mut writer_guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
         writer_guard.write_data(&buf).map_err(|e| {
             crate::local_copy::LocalCopyError::io(
                 "write batch id lists",
@@ -189,8 +189,8 @@ impl<'a> CopyContext<'a> {
 
         // upstream: rsync.c:383 - write iflags (u16 LE) for protocol >= 29.
         // ITEM_TRANSFER (0x8000) indicates delta data follows.
-        let batch_writer_arc = self.options.get_batch_writer().unwrap().clone();
-        let proto = batch_writer_arc.lock().unwrap().config().protocol_version;
+        let batch_writer_arc = self.options.get_batch_writer().expect("batch writer set on the write-batch path").clone();
+        let proto = batch_writer_arc.lock().expect("batch writer mutex poisoned").config().protocol_version;
         if proto >= 29 {
             const ITEM_TRANSFER: u16 = 0x8000;
             delta_file
@@ -333,7 +333,7 @@ impl<'a> CopyContext<'a> {
         use std::io::Write;
 
         let delta_file = match self.batch_delta_buf.as_mut() {
-            Some(_) => self.batch_delta_buf.as_mut().unwrap(),
+            Some(_) => self.batch_delta_buf.as_mut().expect("batch_delta_buf is Some in this arm"),
             None => return Ok(()),
         };
 
@@ -447,7 +447,7 @@ impl<'a> CopyContext<'a> {
                     )
                 },
             )?;
-            let mut writer_guard = batch_writer_arc.lock().unwrap();
+            let mut writer_guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
             writer_guard.write_data(&ndx_buf).map_err(|e| {
                 crate::local_copy::LocalCopyError::io(
                     "write batch NDX",
@@ -472,7 +472,7 @@ impl<'a> CopyContext<'a> {
         // protocol >= 29, max_phase=2, so recv_files needs 3 NDX_DONEs
         // to break (phase 0->1->2->3, breaks when phase > max_phase).
         // For protocol < 29, max_phase=1, needs 2 NDX_DONEs.
-        let proto = batch_writer_arc.lock().unwrap().config().protocol_version;
+        let proto = batch_writer_arc.lock().expect("batch writer mutex poisoned").config().protocol_version;
         let ndx_done_count = if proto >= 29 { 3 } else { 2 };
 
         for _ in 0..ndx_done_count {
@@ -484,7 +484,7 @@ impl<'a> CopyContext<'a> {
                     e,
                 )
             })?;
-            let mut writer_guard = batch_writer_arc.lock().unwrap();
+            let mut writer_guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
             writer_guard.write_data(&done_buf).map_err(|e| {
                 crate::local_copy::LocalCopyError::io(
                     "write batch NDX_DONE",

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -40,14 +40,14 @@ impl<'a> CopyContext<'a> {
             .map(|_| std::io::Cursor::new(Vec::new()));
 
         let batch_ndx_codec = options.get_batch_writer().map(|batch_writer_arc| {
-            let guard = batch_writer_arc.lock().unwrap();
+            let guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
             let proto_version = guard.config().protocol_version;
             drop(guard);
             protocol::codec::NdxCodecEnum::new(proto_version as u8)
         });
 
         let batch_flist_writer = options.get_batch_writer().map(|batch_writer_arc| {
-            let guard = batch_writer_arc.lock().unwrap();
+            let guard = batch_writer_arc.lock().expect("batch writer mutex poisoned");
             let proto_version = guard.config().protocol_version;
             let compat_flags_val = guard.config().compat_flags;
             drop(guard);

--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -224,7 +224,11 @@ pub(crate) fn parse_filter_directive_line(
     };
 
     if keyword.len() == 1 {
-        let shorthand = keyword.chars().next().unwrap().to_ascii_lowercase();
+        let shorthand = keyword
+            .chars()
+            .next()
+            .expect("keyword has exactly one char")
+            .to_ascii_lowercase();
         match shorthand {
             'p' => {
                 if !keyword_modifiers.is_empty() {

--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -643,7 +643,9 @@ fn plan_directory_entries_with_prefetch<'a>(
                     }
                     Err(_) if context.copy_links_enabled() => {
                         // Re-fetch to get the actual error for reporting
-                        return Err(follow_symlink_metadata(entry.path.as_path()).unwrap_err());
+                        return Err(follow_symlink_metadata(entry.path.as_path()).expect_err(
+                            "metadata re-fetch of a just-failed symlink path fails again",
+                        ));
                     }
                     Err(_) => {}
                 }

--- a/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
@@ -159,8 +159,13 @@ pub(crate) fn capture_batch_file_entry(
         LocalCopyError::io("encode batch flist entry", relative_path.to_path_buf(), e)
     })?;
 
-    let batch_writer_arc = context.batch_writer().unwrap().clone();
-    let mut writer_guard = batch_writer_arc.lock().unwrap();
+    let batch_writer_arc = context
+        .batch_writer()
+        .expect("batch writer set on the write-batch path")
+        .clone();
+    let mut writer_guard = batch_writer_arc
+        .lock()
+        .expect("batch writer mutex poisoned");
     writer_guard.write_data(&buf).map_err(|e| {
         LocalCopyError::io(
             "write batch file entry",

--- a/crates/protocol/src/flist/dir_tree.rs
+++ b/crates/protocol/src/flist/dir_tree.rs
@@ -132,7 +132,9 @@ impl DirectoryTree {
             self.nodes[actual_parent].first_child = Some(node_idx);
         } else {
             // Walk to last sibling
-            let mut sibling = self.nodes[actual_parent].first_child.unwrap();
+            let mut sibling = self.nodes[actual_parent]
+                .first_child
+                .expect("parent has a first child during sibling walk");
             while let Some(next) = self.nodes[sibling].next_sibling {
                 sibling = next;
             }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -80,6 +80,7 @@
 #![deny(unsafe_code)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// ACL (Access Control List) wire protocol encoding and decoding.

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -376,7 +376,10 @@ pub(in crate::disk_commit) fn process_file(
                 let metadata_error = if outcome.delayed_path.is_some() {
                     // upstream: receiver.c:1047 - finish_transfer(partialptr, ...)
                     // applies metadata to the staged partial file.
-                    let staged = outcome.delayed_path.as_ref().unwrap();
+                    let staged = outcome
+                        .delayed_path
+                        .as_ref()
+                        .expect("delayed_path is Some on the staged-partial path");
                     apply_file_metadata(staged, &begin, config)
                 } else if needs_rename && !outcome.was_copy {
                     pre_meta_error
@@ -568,7 +571,10 @@ pub(in crate::disk_commit) fn process_whole_file(
     }
 
     let metadata_error = if outcome.delayed_path.is_some() {
-        let staged = outcome.delayed_path.as_ref().unwrap();
+        let staged = outcome
+            .delayed_path
+            .as_ref()
+            .expect("delayed_path checked is_some above");
         apply_file_metadata(staged, &begin, config)
     } else if needs_rename && !outcome.was_copy {
         pre_meta_error

--- a/crates/transfer/src/generator/file_list/inc_recurse.rs
+++ b/crates/transfer/src/generator/file_list/inc_recurse.rs
@@ -166,10 +166,16 @@ impl GeneratorContext {
 
         // Place initial entries first (move, not clone).
         for tagged in &initial_entries {
-            self.file_list
-                .push(file_entries[tagged.file_idx].take().unwrap());
-            self.source_bases
-                .push(bases[tagged.file_idx].take().unwrap());
+            self.file_list.push(
+                file_entries[tagged.file_idx]
+                    .take()
+                    .expect("flist entry present at its tagged index"),
+            );
+            self.source_bases.push(
+                bases[tagged.file_idx]
+                    .take()
+                    .expect("source base present at its tagged index"),
+            );
         }
         self.incremental.initial_segment_count = Some(initial_entries.len());
 
@@ -214,10 +220,16 @@ impl GeneratorContext {
 
             for child in &seg.children {
                 let child_flat = self.file_list.len();
-                self.file_list
-                    .push(file_entries[child.file_idx].take().unwrap());
-                self.source_bases
-                    .push(bases[child.file_idx].take().unwrap());
+                self.file_list.push(
+                    file_entries[child.file_idx]
+                        .take()
+                        .expect("flist entry present at its tagged index"),
+                );
+                self.source_bases.push(
+                    bases[child.file_idx]
+                        .take()
+                        .expect("source base present at its tagged index"),
+                );
 
                 if let Some(child_nid) = child.node_id {
                     node_to_wire[child_nid] = wire_dir_ndx;

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -314,7 +314,7 @@ impl GeneratorContext {
 
         if let Some(entries) = dir_read {
             // Safety: dir_path is always Some when dir_read is Some
-            let dir_path = dir_path.unwrap();
+            let dir_path = dir_path.expect("dir_path is Some whenever dir_read is Some");
 
             // upstream: exclude.c:push_local_filters() - read per-directory
             // merge files when entering a subdirectory during recursive walk.

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! Transfer coordination between sender, receiver, and generator roles.
 //!

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -131,7 +131,8 @@ impl ReceiverContext {
                 // upstream: receiver.c:711-716 - check_filter(&daemon_filter_list, ...)
                 // rejects daemon-excluded files before accepting transfer data.
                 if has_daemon_filters {
-                    let filters = daemon_filters.unwrap();
+                    let filters =
+                        daemon_filters.expect("daemon_filters is Some when has_daemon_filters");
                     let name = e.name();
                     if name != "." && !filters.allows(Path::new(name), false) {
                         stats.files_skipped += 1;
@@ -139,7 +140,7 @@ impl ReceiverContext {
                     }
                 }
                 if has_failed_dirs {
-                    let fd = failed_dirs.unwrap();
+                    let fd = failed_dirs.expect("failed_dirs is Some when has_failed_dirs");
                     if let Some(failed_parent) = fd.failed_ancestor(e.name()) {
                         if verbose_client {
                             info_log!(


### PR DESCRIPTION
## Problem

engine, transfer, and protocol had no lint guarding against `unwrap()` in production paths. A stray unwrap can reach shipping code and panic on an unexpected state, and there was nothing in CI to stop a new one from landing.

(Note: an earlier estimate of ~2,140 production unwraps conflated test code — the true non-test, non-doc count in these three crates is **27**, and none decode untrusted wire/parse input. The real residual risk is mutex-poison in the batch-writer / delta-drain paths.)

## Change

- Enable `clippy::unwrap_used` in the three crates, scoped to the non-test build via `#![cfg_attr(not(test), warn(clippy::unwrap_used))]` — matching the existing `#![cfg_attr(not(test), deny(unsafe_code))]` idiom. Unit tests, integration crates, and benches keep using `unwrap()`. CI's `-D warnings` promotes it to an error, so new production unwraps fail the build.
- Convert the 27 existing production unwraps to `.expect("<invariant>")`:
  - The ~12 `lock().unwrap()` / `into_inner().unwrap()` sites (batch-writer, delta-drain) keep fail-loud behaviour — a poisoned mutex still panics, now with a diagnostic, rather than recovering into a possibly-corrupt batch.
  - The rest document a locally-provable invariant (guarded `is_some`, freshly built `Option` vec, one-char keyword, tree-walk).

No behaviour change: `expect` is `unwrap` with a message.

## Verification

`cargo clippy -p protocol -p transfer -p engine --all-targets --all-features --no-deps -- -D warnings` is clean (no `unwrap_used`, no collateral lints). fmt clean. 1443 tests across the touched modules pass.