### PR TITLE
chore(lint): enforce clippy::unwrap_used in core

### DIFF
--- a/crates/core/src/client/module_list/connect/proxy.rs
+++ b/crates/core/src/client/module_list/connect/proxy.rs
@@ -172,7 +172,9 @@ pub(crate) fn parse_proxy_spec(spec: &str) -> Result<ProxyConfig, ClientError> {
         let (userinfo, host_part) = spec.split_at(idx);
 
         let mut segments = userinfo.splitn(2, ':');
-        let username = segments.next().unwrap();
+        let username = segments
+            .next()
+            .expect("splitn always yields at least one segment");
         let password = segments.next().ok_or_else(|| {
             proxy_configuration_error("invalid proxy specification: should be USER:PASS@HOST:PORT")
         })?;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 /// Shared daemon authentication helpers.
 pub mod auth;


### PR DESCRIPTION
Extends the production `unwrap()` guard (established for engine/transfer/protocol in #6900) to the `core` orchestration crate.

`core` already avoids `unwrap()` on fallible paths, so there is exactly **one** production site: the proxy `USER:PASS` parser's `splitn(2, ':').next()`, which always yields at least one segment. Converted to `.expect()` documenting that invariant, and added `#![cfg_attr(not(test), warn(clippy::unwrap_used))]` (scoped to the non-test build, matching the existing `cfg_attr(not(test), deny(unsafe_code))` idiom) so CI's `-D warnings` blocks new production unwraps.

Verified: clippy `--all-targets --all-features -- -D warnings` clean on core; fmt clean. No behaviour change.