### PR TITLE
fix(flist): silence aarch64-only unnecessary_cast on st_nlink

### DIFF
--- a/crates/flist/src/batched_stat/types.rs
+++ b/crates/flist/src/batched_stat/types.rs
@@ -52,6 +52,11 @@ impl FstatResult {
         let rdev = stat_buf.st_rdev;
         #[cfg(not(target_os = "linux"))]
         let rdev: u64 = stat_buf.st_rdev.try_into().unwrap_or_default();
+        // st_nlink is u32 on aarch64 Linux (the cast is a no-op there) but u64 on
+        // x86_64 Linux and u16 on macOS, so `as u32` is required for portability;
+        // it only looks redundant on aarch64.
+        #[allow(clippy::unnecessary_cast)]
+        let nlink = stat_buf.st_nlink as u32;
         Self {
             mode: to_u32(stat_buf.st_mode),
             size: stat_buf.st_size as u64,
@@ -60,7 +65,7 @@ impl FstatResult {
             uid: stat_buf.st_uid,
             gid: stat_buf.st_gid,
             ino: stat_buf.st_ino,
-            nlink: stat_buf.st_nlink as u32,
+            nlink,
             rdev_major: rdev_major(rdev),
             rdev_minor: rdev_minor(rdev),
         }


### PR DESCRIPTION
`stat_buf.st_nlink as u32` trips `clippy::unnecessary_cast` on **aarch64 Linux** (where `st_nlink` is already `u32`), but the cast is required on x86_64 Linux (`u64`) and macOS (`u16`). The CI `fmt + clippy` job runs only on x86_64, so this aarch64-only lint is invisible in CI yet fails a local clippy run on an aarch64 host.

Extract the field to a `let` with a scoped `#[allow(clippy::unnecessary_cast)]` and a comment on the per-platform `st_nlink` width, mirroring the adjacent cfg-guarded `rdev` handling. Behaviour unchanged.

Verified: clippy `--all-targets --all-features -- -D warnings` clean on `flist` (aarch64); 565 flist tests pass; fmt clean.