### PR TITLE
fix(batch): skip uid/gid id-lists under --numeric-ids

### DIFF
--- a/crates/batch/src/lib.rs
+++ b/crates/batch/src/lib.rs
@@ -434,6 +434,18 @@ pub struct BatchConfig {
     /// when true, matching upstream `batch.c:write_filter_rules()` under
     /// `eol_nulls`.
     pub eol_nulls: bool,
+
+    /// Whether `--numeric-ids` was active for the batch invocation.
+    ///
+    /// Unlike the flags in [`BatchFlags`], numeric-ids is not recorded in the
+    /// batch stream flags (`batch.c:59-76` omits it). It is instead re-supplied
+    /// by the replay script's pass-through arguments, so it must be threaded in
+    /// from the current invocation. It gates the post-flist uid/gid id-list
+    /// region on both sides: the writer omits the id-lists and the reader must
+    /// not attempt to consume them, matching upstream `flist.c:2548`
+    /// (`numeric_ids <= 0 && !inc_recurse`) and `uidlist.c:465,473`
+    /// (`numeric_ids <= 0`).
+    pub numeric_ids: bool,
 }
 
 impl BatchConfig {
@@ -488,6 +500,7 @@ impl BatchConfig {
             operands: Vec::new(),
             active_flags: BatchFlags::default(),
             eol_nulls: false,
+            numeric_ids: false,
         }
     }
 
@@ -657,6 +670,28 @@ impl BatchConfig {
     /// ```
     pub const fn with_eol_nulls(mut self, eol_nulls: bool) -> Self {
         self.eol_nulls = eol_nulls;
+        self
+    }
+
+    /// Set whether `--numeric-ids` was active for the batch invocation.
+    ///
+    /// Gates the post-flist uid/gid id-list region: under `--numeric-ids`
+    /// upstream sends no id-lists (`flist.c:2548` requires `numeric_ids <= 0`),
+    /// so the writer omits them and the reader must not consume them
+    /// (`uidlist.c:465,473`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use batch::{BatchConfig, BatchMode};
+    ///
+    /// let config = BatchConfig::new(BatchMode::Read, "/tmp/batch".to_string(), 31)
+    ///     .with_numeric_ids(true);
+    ///
+    /// assert!(config.numeric_ids);
+    /// ```
+    pub const fn with_numeric_ids(mut self, numeric_ids: bool) -> Self {
+        self.numeric_ids = numeric_ids;
         self
     }
 

--- a/crates/batch/src/reader/flist.rs
+++ b/crates/batch/src/reader/flist.rs
@@ -80,6 +80,11 @@ impl BatchReader {
             )));
         }
 
+        // Captured before the mutable borrow of the batch file below. Unlike
+        // the stream flags, numeric_ids is not recorded in the batch header
+        // (batch.c:59-76); it is carried in from the --read-batch invocation.
+        let numeric_ids = self.config.numeric_ids;
+
         let header = self.header.as_ref().expect("header checked above");
         let flags = header.stream_flags;
 
@@ -160,10 +165,11 @@ impl BatchReader {
         // upstream: flist.c:2761-2763 - recv_id_list(f, flist) when !inc_recurse
         // The batch stream contains uid/gid name mapping lists after the flist
         // entries. We must consume them to keep the stream position correct for
-        // delta replay. Batch files don't record numeric_ids, but if the original
-        // transfer used --numeric-ids, no ID lists were sent and none are in the
-        // stream. Since the interop test default does NOT use --numeric-ids, we
-        // consume them when preserve_uid/gid is set.
+        // delta replay. numeric_ids is not recorded in the batch header, but the
+        // replay script re-supplies --numeric-ids from the original invocation.
+        // When it is set, the sender emits no ID lists (flist.c:2548 requires
+        // numeric_ids <= 0), so none are present in the stream and the reader
+        // must not attempt to consume them.
         if !inc_recurse {
             let id0_names = header
                 .compat_flags
@@ -174,13 +180,13 @@ impl BatchReader {
             let proto_ver = protocol_version.as_u8();
 
             // upstream: uidlist.c:465 - (preserve_uid || preserve_acls) && numeric_ids <= 0
-            if flags.preserve_uid || flags.preserve_acls {
+            if (flags.preserve_uid || flags.preserve_acls) && !numeric_ids {
                 let mut uid_list = IdList::new();
                 uid_list.read(reader, id0_names, proto_ver, |_| None)?;
             }
 
             // upstream: uidlist.c:473 - (preserve_gid || preserve_acls) && numeric_ids <= 0
-            if flags.preserve_gid || flags.preserve_acls {
+            if (flags.preserve_gid || flags.preserve_acls) && !numeric_ids {
                 let mut gid_list = IdList::new();
                 gid_list.read(reader, id0_names, proto_ver, |_| None)?;
             }

--- a/crates/batch/src/reader/tests.rs
+++ b/crates/batch/src/reader/tests.rs
@@ -533,6 +533,147 @@ mod flist_deserialization_tests {
         assert_eq!(reader.io_error(), 0);
     }
 
+    /// Under `--numeric-ids` the sender emits no post-flist id-lists
+    /// (upstream `flist.c:2548` requires `numeric_ids <= 0`), so the reader
+    /// must not try to consume them even though `preserve_uid`/`preserve_gid`
+    /// are set. Reading them would decode the following delta bytes as a
+    /// varint id-list and desync the stream. WHY: this guards the exact
+    /// upstream `uidlist.c:465,473` `numeric_ids <= 0` gate.
+    #[test]
+    fn numeric_ids_skips_id_list_reads() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("flist_numeric.batch");
+        let protocol_version = 31;
+
+        let write_config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            protocol_version,
+        );
+
+        let mut writer = BatchWriter::new(write_config).unwrap();
+        let flags = BatchFlags {
+            preserve_uid: true,
+            preserve_gid: true,
+            ..Default::default()
+        };
+        writer.write_header(flags).unwrap();
+
+        let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
+        let mut flist_writer = FileListWriter::new(protocol)
+            .with_preserve_uid(true)
+            .with_preserve_gid(true);
+
+        let mut entry = ProtocolFileEntry::new_file("alpha.txt".into(), 1024, 0o644);
+        entry.set_mtime(1_700_000_000, 0);
+        entry.set_uid(1000);
+        entry.set_gid(1000);
+
+        let mut buf = Vec::new();
+        flist_writer.write_entry(&mut buf, &entry).unwrap();
+        writer.write_data(&buf).unwrap();
+
+        let mut end_buf = Vec::new();
+        flist_writer.write_end(&mut end_buf, None).unwrap();
+        writer.write_data(&end_buf).unwrap();
+
+        // No id-lists follow (as under --numeric-ids); the next byte is a
+        // sentinel standing in for the delta stream.
+        writer.write_data(&[0xAB]).unwrap();
+        writer.finalize().unwrap();
+
+        let read_config = BatchConfig::new(
+            BatchMode::Read,
+            batch_path.to_string_lossy().to_string(),
+            protocol_version,
+        )
+        .with_numeric_ids(true);
+        let mut reader = BatchReader::new(read_config).unwrap();
+        reader.read_header().unwrap();
+
+        let read_entries = reader.read_protocol_flist().unwrap();
+        assert_eq!(read_entries.len(), 1);
+        assert_eq!(read_entries[0].name(), "alpha.txt");
+
+        // The sentinel must still be the next byte: the reader did not consume
+        // any id-list bytes.
+        let mut next = [0u8; 1];
+        reader.read_exact(&mut next).unwrap();
+        assert_eq!(next[0], 0xAB, "reader consumed bytes past the flist");
+    }
+
+    /// Without `--numeric-ids`, the sender emits empty uid/gid id-lists after
+    /// the flist (`uidlist.c:465,473` with `numeric_ids <= 0`), so the reader
+    /// must consume them to stay aligned for delta replay. WHY: proves the
+    /// `numeric_ids` gate does not regress the default id-list-consuming path.
+    #[test]
+    fn non_numeric_ids_consumes_id_lists() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("flist_non_numeric.batch");
+        let protocol_version = 31;
+
+        let write_config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            protocol_version,
+        );
+
+        let mut writer = BatchWriter::new(write_config).unwrap();
+        let flags = BatchFlags {
+            preserve_uid: true,
+            preserve_gid: true,
+            ..Default::default()
+        };
+        writer.write_header(flags).unwrap();
+
+        let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
+        let mut flist_writer = FileListWriter::new(protocol)
+            .with_preserve_uid(true)
+            .with_preserve_gid(true);
+
+        let mut entry = ProtocolFileEntry::new_file("alpha.txt".into(), 1024, 0o644);
+        entry.set_mtime(1_700_000_000, 0);
+        entry.set_uid(1000);
+        entry.set_gid(1000);
+
+        let mut buf = Vec::new();
+        flist_writer.write_entry(&mut buf, &entry).unwrap();
+        writer.write_data(&buf).unwrap();
+
+        let mut end_buf = Vec::new();
+        flist_writer.write_end(&mut end_buf, None).unwrap();
+        writer.write_data(&end_buf).unwrap();
+
+        // Empty uid and gid id-lists (terminator-only), then a delta sentinel.
+        let mut id_buf = Vec::new();
+        protocol::idlist::IdList::new()
+            .write(&mut id_buf, false, protocol_version as u8)
+            .unwrap();
+        protocol::idlist::IdList::new()
+            .write(&mut id_buf, false, protocol_version as u8)
+            .unwrap();
+        writer.write_data(&id_buf).unwrap();
+        writer.write_data(&[0xAB]).unwrap();
+        writer.finalize().unwrap();
+
+        let read_config = BatchConfig::new(
+            BatchMode::Read,
+            batch_path.to_string_lossy().to_string(),
+            protocol_version,
+        )
+        .with_numeric_ids(false);
+        let mut reader = BatchReader::new(read_config).unwrap();
+        reader.read_header().unwrap();
+
+        let read_entries = reader.read_protocol_flist().unwrap();
+        assert_eq!(read_entries.len(), 1);
+
+        // The id-list terminators were consumed, so the sentinel is next.
+        let mut next = [0u8; 1];
+        reader.read_exact(&mut next).unwrap();
+        assert_eq!(next[0], 0xAB, "reader did not consume the id-lists");
+    }
+
     /// Validates that `always_checksum` (--checksum / -c) is correctly wired
     /// to the flist reader. When this flag is set, each regular file entry
     /// in the flist carries a trailing checksum. If the reader doesn't consume

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -729,6 +729,10 @@ where
     // --numeric-ids) from raw_argv, eliding the filename operands. Capture the
     // raw argv and operands so the batch script generator can re-emit them.
     let batch_config = batch_config.map(|cfg| {
+        // upstream: flist.c:2548 - the writer omits the post-flist id-lists under
+        // --numeric-ids (numeric_ids is not a recorded stream flag), so carry it
+        // into the batch config for both write and read modes.
+        let cfg = cfg.with_numeric_ids(numeric_ids);
         if cfg.is_write_mode() {
             let replay_args: Vec<String> = std::env::args_os()
                 .map(|a| a.to_string_lossy().into_owned())

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -345,10 +345,13 @@ fn replay_batch(
 
     // upstream: batch.c:120 check_batch_flags() reconciles the active options
     // against the batch header during replay, so carry the current flag state
-    // into the reader.
+    // into the reader. numeric_ids is not a recorded stream flag (batch.c:59-76);
+    // it comes from the replay invocation and gates the post-flist id-list region
+    // (uidlist.c:465,473 `numeric_ids <= 0`).
     let replay_cfg = batch_cfg
         .clone()
-        .with_active_flags(config_batch_flags(config));
+        .with_active_flags(config_batch_flags(config))
+        .with_numeric_ids(config.numeric_ids());
 
     let result = engine::batch::replay::replay(&replay_cfg, &dest_root, config.verbosity().into())
         .map_err(|e| match e {

--- a/crates/engine/src/local_copy/context_impl/options/batch.rs
+++ b/crates/engine/src/local_copy/context_impl/options/batch.rs
@@ -89,17 +89,26 @@ impl<'a> CopyContext<'a> {
             None => return Ok(()),
         };
 
-        let (proto, compat_flags, preserve_uid, preserve_gid, preserve_acls) = {
+        let (proto, compat_flags, numeric_ids, preserve_uid, preserve_gid, preserve_acls) = {
             let cfg = batch_writer_arc.lock().expect("batch writer mutex poisoned");
             let flags = cfg.stream_flags();
             (
                 cfg.config().protocol_version,
                 cfg.config().compat_flags,
+                cfg.config().numeric_ids,
                 flags.preserve_uid,
                 flags.preserve_gid,
                 flags.preserve_acls,
             )
         };
+
+        // upstream: flist.c:2548 - `if (numeric_ids <= 0 && !inc_recurse)
+        // send_id_lists(f)`. Under --numeric-ids no id-lists are emitted, so the
+        // reader (reader/flist.rs) must find none. numeric_ids is not a stream
+        // flag; it is carried in the batch config from the invocation.
+        if numeric_ids {
+            return Ok(());
+        }
 
         // upstream: flist.c:2548 - skip send_id_lists() under INC_RECURSE.
         let inc_recurse = compat_flags


### PR DESCRIPTION
## Problem
The batch reader consumed post-flist uid/gid id-lists gated only on `preserve_uid/gid/acls`, never `numeric_ids`. Upstream `recv_id_list` (`uidlist.c:465,473`) reads them only when `numeric_ids <= 0`, and the sender (`flist.c:2548`) emits none under `--numeric-ids`. So a batch written with `--numeric-ids -og`/`-A` carries no id-lists — oc then read the following flist/delta bytes as varint id-lists and **desynced the whole stream**.

## Fix
`numeric_ids` is not a batch stream flag (`batch.c:59-76`); the replay `.sh` re-supplies it from the original args. Threaded it onto `BatchConfig` (via CLI + `replay_batch`) and gated **both** the reader and the writer (`write_batch_id_lists`) on `!numeric_ids`, so both sides stay symmetric.

## Verification
Empirical round-trip vs rsync 3.4.4: upstream `--write-batch --numeric-ids` → **oc reads it (exit 0, byte-identical result)**; oc `--write-batch --numeric-ids` → **upstream reads it (exit 0, byte-identical)**. Both were desyncing before. clippy `-D warnings` clean (batch/engine/core/cli), 227 batch tests pass, fmt clean.