### PR TITLE
fix(engine): itemize atime-only change with the u glyph on local copy

### DIFF
--- a/crates/engine/src/local_copy/plan/change_set/detection.rs
+++ b/crates/engine/src/local_copy/plan/change_set/detection.rs
@@ -88,6 +88,30 @@ impl LocalCopyChangeSet {
         // follows the link, so a symlink's own perms cannot be changed and
         // upstream rsync never reports ITEM_REPORT_PERMS for them.
         let is_symlink = metadata.file_type().is_symlink();
+
+        // upstream: generator.c:531-533 - itemize() sets ITEM_REPORT_ATIME when
+        // `atimes_ndx` (`-U`) is active for a non-dir, non-symlink whose access
+        // time differs from the destination. same_time() is called with a zero
+        // nanosecond component for both sides (F_ATIME(file) and st_atime), so
+        // this is a whole-second comparison honouring `--modify-window`. The
+        // `for_file` constructor only ever handles regular files and symlinks,
+        // so `!is_symlink` matches upstream's `!S_ISLNK` guard; a fresh
+        // destination is instead covered by the ITEM_IS_NEW `+` fill.
+        #[cfg(unix)]
+        if !is_symlink
+            && metadata_options.atimes()
+            && destination_previously_existed
+            && let Some(existing_metadata) = existing
+            && !modify_window.same_time(
+                metadata_access_secs(metadata),
+                0,
+                metadata_access_secs(existing_metadata),
+                0,
+            )
+        {
+            change_set = change_set.with_access_time_changed(true);
+        }
+
         if !is_symlink
             && metadata_options.permissions()
             && permissions_changed(metadata, existing, destination_previously_existed)
@@ -459,6 +483,16 @@ fn group_changed(
 /// Extracts the modification time from filesystem metadata.
 fn metadata_modified_time(metadata: &fs::Metadata) -> Option<SystemTime> {
     metadata.modified().ok()
+}
+
+/// Extracts the whole-second access time from filesystem metadata.
+///
+/// upstream: generator.c:532 compares `st_atime` via `same_time(..., 0, ..., 0)`
+/// - a zero nanosecond component on both sides - so only whole seconds matter.
+#[cfg(unix)]
+fn metadata_access_secs(metadata: &fs::Metadata) -> i64 {
+    use std::os::unix::fs::MetadataExt;
+    metadata.atime()
 }
 
 /// Extracts the Unix permission mode from filesystem metadata.

--- a/crates/engine/src/local_copy/plan/change_set/tests.rs
+++ b/crates/engine/src/local_copy/plan/change_set/tests.rs
@@ -1030,3 +1030,72 @@ fn for_recreated_device_no_change_when_content_and_time_match() {
     assert_eq!(change_set.time_change(), None);
     assert!(!change_set.has_any_change());
 }
+
+/// upstream: generator.c:531-533 - with `-U` (`atimes_ndx`), an up-to-date
+/// regular file (size+mtime match, quick-check skips the data transfer) whose
+/// access time differs from the destination lights `ITEM_REPORT_ATIME`. The
+/// change surfaces `access_time_changed`, which the itemize renderer maps to
+/// the `u` glyph and which `has_any_change()` uses to stop suppressing the
+/// otherwise metadata-only row. Without this, oc applies the atime but prints
+/// no `.f......u..` line, diverging from upstream's observable output.
+#[cfg(unix)]
+#[test]
+fn for_file_atimes_differing_access_time_sets_u_glyph() {
+    use filetime::{FileTime, set_file_atime, set_file_mtime};
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src = temp.path().join("src");
+    let dst = temp.path().join("dst");
+    fs::write(&src, b"same").expect("write src");
+    fs::write(&dst, b"same").expect("write dst");
+
+    // Identical size and mtime: the transfer is quick-check skipped.
+    let mtime = FileTime::from_unix_time(1_600_000_000, 0);
+    set_file_mtime(&src, mtime).expect("set src mtime");
+    set_file_mtime(&dst, mtime).expect("set dst mtime");
+    // Access times differ by whole seconds.
+    set_file_atime(&src, FileTime::from_unix_time(1_600_000_500, 0)).expect("set src atime");
+    set_file_atime(&dst, FileTime::from_unix_time(1_600_000_100, 0)).expect("set dst atime");
+
+    let src_meta = fs::metadata(&src).expect("src meta");
+    let dst_meta = fs::metadata(&dst).expect("dst meta");
+
+    let options = MetadataOptions::new()
+        .preserve_times(true)
+        .preserve_atimes(true);
+    let change_set = LocalCopyChangeSet::for_file(
+        &src_meta,
+        Some(&dst_meta),
+        &options,
+        true,
+        false,
+        false,
+        false,
+        ModifyWindow::ZERO,
+    );
+
+    assert!(
+        change_set.access_time_changed(),
+        "differing atime under -U must set access_time_changed (the `u` glyph)"
+    );
+    assert!(
+        change_set.has_any_change(),
+        "the atime-only change must surface a row instead of being suppressed"
+    );
+
+    // Without -U the same differing atime is ignored, matching upstream's
+    // `atimes_ndx` gate: no `u` glyph, no row.
+    let no_u = MetadataOptions::new().preserve_times(true);
+    let change_set = LocalCopyChangeSet::for_file(
+        &src_meta,
+        Some(&dst_meta),
+        &no_u,
+        true,
+        false,
+        false,
+        false,
+        ModifyWindow::ZERO,
+    );
+    assert!(!change_set.access_time_changed());
+    assert!(!change_set.has_any_change());
+}


### PR DESCRIPTION
## Problem
For a quick-check-skipped local file whose data matches but whose atime differs under `--atimes`, upstream emits `.f......u..` (the `u` column), but oc emitted **no itemize row** — even though it already applied the atime to disk. `LocalCopyChangeSet` detection compared size/mtime/perms/owner/group/acl/xattr but **never atime**, so `access_time_changed` stayed false, `has_any_change()` returned false, and the row was suppressed. (The prior attempt edited the receiver/network `itemize_existing_flags`, which a local copy never reaches — this is the local-copy engine path.)

## Fix
Add the atime comparison to `for_file_with_checksum` (unix): under `--atimes`, dest exists, non-symlink, source vs dest atime differ (whole-second, mirroring `generator.c:531-533` `same_time(F_ATIME(file), 0, st_atime, 0)` under `atimes_ndx`), set `access_time_changed`. The render side already maps it to `u`. crtime left untouched (no reliable cross-platform helper).

## Verification
Empirical vs rsync 3.4.4: `-a -U --itemize-changes` on a same-data, atime-differing file — upstream and oc both now print `.f......u.. a.txt` (oc printed nothing before). engine clippy `-D warnings` clean; new detection test.

Note: the remote/receiver path (`candidates.rs itemize_existing_flags`) has the same atime-omission for a remote `-U` transfer — a separate follow-up.