### PR TITLE
fix(filters): honor source position between global rules and dir-merge

### DIFF
--- a/crates/filters/src/chain/config.rs
+++ b/crates/filters/src/chain/config.rs
@@ -62,6 +62,19 @@ pub struct DirMergeConfig {
     /// any whitespace with each token parsed as its own rule, rather than one
     /// rule per line.
     word_split: bool,
+    /// Number of order-bearing global rules that preceded this `dir-merge`
+    /// directive in the source rule stream.
+    ///
+    /// upstream: exclude.c:1046-1050 - `check_filter()` walks one list and
+    /// consults a `FILTRULE_PERDIR_MERGE` entry at its own position, so a global
+    /// rule defined before the directive is checked before the merge file's
+    /// rules and one defined after is checked afterwards. This index records
+    /// that position (measured in the same units as `CompiledRule::order`) so
+    /// the chain can interleave global rules and this scope by source order.
+    /// Defaults to `0` (directive precedes all global rules), which reproduces
+    /// the historical "per-directory scope always overrides global" behaviour
+    /// for callers that do not record a position.
+    directive_order: usize,
 }
 
 impl DirMergeConfig {
@@ -83,7 +96,29 @@ impl DirMergeConfig {
             no_prefixes: false,
             no_prefixes_include: false,
             word_split: false,
+            directive_order: 0,
         }
+    }
+
+    /// Records the source-stream position of this `dir-merge` directive.
+    ///
+    /// `order` is the count of order-bearing global rules (include/exclude/
+    /// protect/risk) that preceded the directive, matching the units of
+    /// `CompiledRule::order`. Global rules with a smaller order are checked
+    /// before this scope's rules; those with an equal-or-greater order are
+    /// checked after. Mirrors upstream `exclude.c:1046-1050`, where a
+    /// `FILTRULE_PERDIR_MERGE` entry is consulted at its own list position.
+    #[must_use]
+    pub const fn with_directive_order(mut self, order: usize) -> Self {
+        self.directive_order = order;
+        self
+    }
+
+    /// Returns the source-stream position recorded by
+    /// [`with_directive_order`](Self::with_directive_order).
+    #[must_use]
+    pub(super) const fn directive_order(&self) -> usize {
+        self.directive_order
     }
 
     /// Sets whether rules from this merge file are inherited by subdirectories.

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -204,9 +204,14 @@ impl FilterChain {
 
     /// Returns `true` if the path should be included in the transfer.
     ///
-    /// Evaluates per-directory scopes from innermost to outermost, then
-    /// global rules. First matching rule wins. Paths that match no rule
-    /// are included by default.
+    /// Global rules and per-directory scopes are interleaved by source order:
+    /// a global rule defined before a `dir-merge` directive is consulted before
+    /// that scope's rules, and one defined after is consulted afterwards
+    /// (`directive_order` records the split). Within one merge config, scopes
+    /// are evaluated innermost-to-outermost. First matching rule wins; paths
+    /// that match no rule are included by default. Mirrors upstream
+    /// `exclude.c:check_filter()` walking one list and recursing into a
+    /// `FILTRULE_PERDIR_MERGE` entry at its own position.
     ///
     /// This is the traversal-driven sender entry point: synthetic
     /// `pattern/**` descendant matchers (produced for anchored excludes
@@ -223,25 +228,64 @@ impl FilterChain {
     /// `is_dir` should be `true` when the path refers to a directory.
     #[must_use]
     pub fn allows(&self, path: &Path, is_dir: bool) -> bool {
+        // upstream: exclude.c:1046-1050 check_filter() walks one list and
+        // consults a FILTRULE_PERDIR_MERGE entry at its own position. A global
+        // rule defined BEFORE the dir-merge directive (smaller order than the
+        // directive's recorded position) therefore wins over the merge file's
+        // rules; one defined at or after the directive loses to them. Compare
+        // the winning scope's directive position against the global first-match
+        // order to reproduce that interleaving.
+        match self.best_scope(path, is_dir, false) {
+            Some(scope)
+                if self
+                    .global
+                    .transfer_match_order_during_traversal(path, is_dir)
+                    .is_none_or(|global_order| scope.directive_order <= global_order) =>
+            {
+                scope.filter_set.allows_during_traversal(path, is_dir)
+            }
+            _ => self.global.allows_during_traversal(path, is_dir),
+        }
+    }
+
+    /// Selects the per-directory scope whose rules win under upstream's
+    /// source-ordered first-match, or `None` when no applicable scope matches.
+    ///
+    /// Scopes are scanned innermost-first. Among matching scopes the one with
+    /// the smallest [`directive_order`](DirScope::directive_order) wins: an
+    /// earlier `dir-merge` directive sits earlier in upstream's single rule
+    /// list. Ties (scopes of the same merge config across nested directories)
+    /// keep the innermost, preserving upstream's local-before-inherited order
+    /// within one mergelist.
+    fn best_scope(&self, path: &Path, is_dir: bool, deletion: bool) -> Option<&DirScope> {
+        let mut best: Option<&DirScope> = None;
         for scope in self.scopes.iter().rev() {
-            if !self.scope_applies_here(scope) {
+            if !self.scope_applies_here(scope) || scope.filter_set.is_empty() {
                 continue;
             }
-            if !scope.filter_set.is_empty()
-                && scope_has_transfer_match(&scope.filter_set, path, is_dir)
-            {
-                return scope.filter_set.allows_during_traversal(path, is_dir);
+            let matched = if deletion {
+                scope_has_deletion_match(&scope.filter_set, path, is_dir)
+            } else {
+                scope_has_transfer_match(&scope.filter_set, path, is_dir)
+            };
+            if !matched {
+                continue;
+            }
+            match best {
+                Some(current) if current.directive_order <= scope.directive_order => {}
+                _ => best = Some(scope),
             }
         }
-
-        self.global.allows_during_traversal(path, is_dir)
+        best
     }
 
     /// Returns `true` if deleting the path on the receiver is permitted.
     ///
-    /// Evaluates per-directory scopes from innermost to outermost, then
-    /// global rules. A path may be deleted when it is included by
-    /// receiver-side rules and no protect rule matches.
+    /// Global rules and per-directory scopes are interleaved by source order
+    /// exactly as in [`allows`](Self::allows): a global rule before a
+    /// `dir-merge` directive wins over the merge file's rules, one after loses.
+    /// A path may be deleted when the deciding rule includes it (or leaves it
+    /// unmatched) and no protect rule matches.
     ///
     /// Non-inheriting scopes follow the same depth-restricted lookup as
     /// [`allows`](Self::allows).
@@ -253,31 +297,33 @@ impl FilterChain {
         // still protects it). Mirror that by OR-ing in the
         // "excluded-removed" decision whenever `delete_excluded` is set, on
         // whichever scope (or the global set) decides the path.
-        let result = (|| {
-            for scope in self.scopes.iter().rev() {
-                if !self.scope_applies_here(scope) {
-                    continue;
-                }
-                if !scope.filter_set.is_empty()
-                    && scope_has_deletion_match(&scope.filter_set, path, is_dir)
-                {
-                    let base = scope
-                        .filter_set
-                        .allows_deletion_during_traversal(path, is_dir);
-                    return base
-                        || (self.delete_excluded
-                            && scope
-                                .filter_set
-                                .allows_deletion_when_excluded_removed(path, is_dir));
-                }
-            }
-
-            let base = self.global.allows_deletion(path, is_dir);
-            base || (self.delete_excluded
-                && self
+        // upstream: exclude.c:1046-1050 - as on the transfer path, a global rule
+        // preceding the dir-merge directive wins over the merge file's rules. The
+        // scope decides only when its directive position is at or before the
+        // global deletion first-match order.
+        let result = match self.best_scope(path, is_dir, true) {
+            Some(scope)
+                if self
                     .global
-                    .allows_deletion_when_excluded_removed(path, is_dir))
-        })();
+                    .deletion_match_order_during_traversal(path, is_dir)
+                    .is_none_or(|global_order| scope.directive_order <= global_order) =>
+            {
+                let base = scope
+                    .filter_set
+                    .allows_deletion_during_traversal(path, is_dir);
+                base || (self.delete_excluded
+                    && scope
+                        .filter_set
+                        .allows_deletion_when_excluded_removed(path, is_dir))
+            }
+            _ => {
+                let base = self.global.allows_deletion(path, is_dir);
+                base || (self.delete_excluded
+                    && self
+                        .global
+                        .allows_deletion_when_excluded_removed(path, is_dir))
+            }
+        };
 
         logging::debug_log!(
             Filter,
@@ -476,6 +522,7 @@ impl FilterChain {
             // Capture before the mutable-borrow clear below drops the `config`
             // reference into `self.merge_configs`.
             let config_inherits = config.inherits();
+            let config_directive_order = config.directive_order();
 
             let filter_set = match FilterSet::from_rules(modified_rules) {
                 Ok(set) => set,
@@ -505,6 +552,7 @@ impl FilterChain {
                     filter_set,
                     inherits: config_inherits,
                     config_index: Some(config_index),
+                    directive_order: config_directive_order,
                 });
                 pushed_count += 1;
             }
@@ -664,6 +712,8 @@ impl FilterChain {
             .merge_configs
             .iter()
             .position(|c| c.filename() == descriptor.filename);
+        let directive_order =
+            config_index.map_or(0, |index| self.merge_configs[index].directive_order());
 
         // upstream: exclude.c:1248-1254 - `:C` implies FILTRULE_NO_INHERIT,
         // so the loaded rules apply only to the directory containing the
@@ -674,6 +724,7 @@ impl FilterChain {
             filter_set,
             inherits: !descriptor.no_inherit,
             config_index,
+            directive_order,
         });
         Ok(1)
     }
@@ -792,6 +843,7 @@ impl FilterChain {
                 filter_set,
                 inherits: true,
                 config_index: None,
+                directive_order: 0,
             });
         }
         DirFilterGuard {

--- a/crates/filters/src/chain/scope.rs
+++ b/crates/filters/src/chain/scope.rs
@@ -35,6 +35,14 @@ pub(super) struct DirScope {
     /// the scopes of the same `config_index` (`exclude.c:pop_filter_list()`
     /// operates on one `listp`).
     pub(super) config_index: Option<usize>,
+    /// Source-stream position of the `dir-merge` directive that produced this
+    /// scope (see [`DirMergeConfig`](super::DirMergeConfig)). All scopes of one
+    /// merge config share this value; the chain uses it to decide whether a
+    /// global rule (compared by `CompiledRule::order`) is checked before or
+    /// after this scope, mirroring upstream `check_filter()` consulting a
+    /// `FILTRULE_PERDIR_MERGE` entry at its own list position
+    /// (exclude.c:1046-1050).
+    pub(super) directive_order: usize,
 }
 
 /// An ancestor scope removed from the stack by a `!` (clear-list) rule.

--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -723,6 +723,7 @@ fn filter_chain_non_inheriting_scope_falls_through_to_outer_inherited() {
         filter_set: inner_set,
         inherits: false,
         config_index: None,
+        directive_order: 0,
     });
 
     // At depth 2 with a no-inherit inner scope that does not match

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -231,6 +231,67 @@ impl FilterSetInner {
         decision
     }
 
+    /// Returns the `order` of the sender-side include/exclude rule that wins a
+    /// traversal transfer check, or `None` when no rule matches.
+    ///
+    /// This exposes the source-stream position of the rule
+    /// [`allows_during_traversal`](crate::FilterSet::allows_during_traversal)
+    /// acts on, so the per-directory chain can interleave a `dir-merge` scope
+    /// against global rules by source order. Descendant matchers are suppressed
+    /// (`check_descendants == false`), matching the traversal transfer path.
+    ///
+    /// upstream: exclude.c:1046-1050 check_filter()
+    pub(crate) fn transfer_match_order(&self, path: &Path, is_dir: bool) -> Option<usize> {
+        first_matching_rule(
+            &self.include_exclude,
+            path,
+            is_dir,
+            |rule| rule.applies_to_sender,
+            true,
+            false,
+            false,
+        )
+        .map(|rule| rule.order)
+    }
+
+    /// Returns the `order` of the receiver-side rule that decides a traversal
+    /// deletion check, or `None` when no rule matches.
+    ///
+    /// The winner is the earlier (by `order`) of the include/exclude and
+    /// protect/risk first-matches, reproducing the single-list first-match that
+    /// upstream `check_filter()` performs and that
+    /// [`deletion_first_match_deletable`] resolves the verdict from. Used by the
+    /// chain to interleave a `dir-merge` scope against global rules by source
+    /// order on the deletion path.
+    ///
+    /// upstream: exclude.c:1038 check_filter()
+    pub(crate) fn deletion_match_order(&self, path: &Path, is_dir: bool) -> Option<usize> {
+        let include_exclude = first_matching_rule(
+            &self.include_exclude,
+            path,
+            is_dir,
+            |rule| rule.applies_to_receiver,
+            true,
+            false,
+            true,
+        );
+        let protect_risk = first_matching_rule(
+            &self.protect_risk,
+            path,
+            is_dir,
+            |rule| rule.applies_to_receiver,
+            true,
+            false,
+            true,
+        );
+        match (include_exclude, protect_risk) {
+            (Some(ie), Some(pr)) => Some(ie.order.min(pr.order)),
+            (Some(ie), None) => Some(ie.order),
+            (None, Some(pr)) => Some(pr.order),
+            (None, None) => None,
+        }
+    }
+
     /// Returns `true` when any rule in this set (in the supplied direction)
     /// matches the path.
     ///

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -242,6 +242,35 @@ impl FilterSet {
             .has_matching_rule(path, is_dir, DecisionContext::Deletion)
     }
 
+    /// Returns the source-stream `order` of the sender-side rule that decides a
+    /// traversal transfer check, or `None` when no rule matches.
+    ///
+    /// The per-directory [`FilterChain`](crate::FilterChain) uses this to
+    /// interleave a `dir-merge` scope against these global rules by source
+    /// order, mirroring upstream `check_filter()` (exclude.c:1046-1050).
+    #[must_use]
+    pub(crate) fn transfer_match_order_during_traversal(
+        &self,
+        path: &Path,
+        is_dir: bool,
+    ) -> Option<usize> {
+        self.inner.transfer_match_order(path, is_dir)
+    }
+
+    /// Returns the source-stream `order` of the receiver-side rule that decides
+    /// a traversal deletion check, or `None` when no rule matches.
+    ///
+    /// Counterpart of [`Self::transfer_match_order_during_traversal`] for the
+    /// deletion path.
+    #[must_use]
+    pub(crate) fn deletion_match_order_during_traversal(
+        &self,
+        path: &Path,
+        is_dir: bool,
+    ) -> Option<usize> {
+        self.inner.deletion_match_order(path, is_dir)
+    }
+
     /// Returns `true` when a directory is excluded by a non-directory-specific rule.
     ///
     /// This is used by `--prune-empty-dirs` to decide whether to still descend

--- a/crates/filters/tests/dir_merge_global_source_order.rs
+++ b/crates/filters/tests/dir_merge_global_source_order.rs
@@ -1,0 +1,111 @@
+//! Source-order interleaving of global rules and a `dir-merge` scope.
+//!
+//! upstream: exclude.c:1043-1064 `check_filter()` walks ONE rule list and,
+//! on reaching a `FILTRULE_PERDIR_MERGE` entry, recurses into that entry's
+//! mergelist AT THAT POSITION, returning on the first match. A global rule
+//! defined BEFORE the `dir-merge` directive therefore wins over rules loaded
+//! from the per-directory merge file, and one defined AFTER loses to them.
+//!
+//! Concretely, for `--filter='- *.tmp' --filter='dir-merge .rsf'` where a
+//! subdirectory's `.rsf` contains `+ keep.tmp`, upstream EXCLUDES `keep.tmp`
+//! (the global `- *.tmp` precedes the directive). Reversing the two makes the
+//! per-directory `+ keep.tmp` win. `DirMergeConfig::with_directive_order`
+//! records the directive's position so the chain reproduces both outcomes.
+
+use std::fs;
+use std::path::Path;
+
+use filters::{DirMergeConfig, FilterChain, FilterRule, FilterSet};
+use tempfile::TempDir;
+
+/// Builds `root/sub/.rsf` containing `+ keep.tmp` and returns the temp dir.
+fn setup() -> TempDir {
+    let root = TempDir::new().unwrap();
+    let sub = root.path().join("sub");
+    fs::create_dir(&sub).unwrap();
+    fs::write(sub.join(".rsf"), "+ keep.tmp\n").unwrap();
+    root
+}
+
+/// A global `- *.tmp` written BEFORE the `dir-merge .rsf` directive
+/// (directive_order = 1) wins: `keep.tmp` stays excluded despite the per-dir
+/// `+ keep.tmp`, matching upstream's single-list first-match.
+#[test]
+fn global_exclude_before_dir_merge_wins_over_per_dir_include() {
+    let root = setup();
+    let global = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).unwrap();
+    let mut chain = FilterChain::new(global);
+    chain.add_merge_config(DirMergeConfig::new(".rsf").with_directive_order(1));
+
+    let guard = chain.enter_directory(&root.path().join("sub")).unwrap();
+    assert_eq!(chain.scope_depth(), 1, "the .rsf scope must be active");
+
+    // Transfer: the global `- *.tmp` (order 0) precedes the directive (position
+    // 1), so it decides before the per-dir `+ keep.tmp` - keep.tmp is excluded.
+    assert!(
+        !chain.allows(Path::new("keep.tmp"), false),
+        "global `- *.tmp` before the dir-merge directive must exclude keep.tmp",
+    );
+    // A .tmp the merge file does not mention is excluded in either ordering.
+    assert!(!chain.allows(Path::new("drop.tmp"), false));
+    // A non-.tmp file matches no rule and is included by default.
+    assert!(chain.allows(Path::new("notes.txt"), false));
+
+    // Deletion mirrors the transfer verdict: the global exclude protects
+    // keep.tmp from the receiver's delete pass.
+    assert!(
+        !chain.allows_deletion(Path::new("keep.tmp"), false),
+        "global exclude before the directive must protect keep.tmp from deletion",
+    );
+
+    chain.leave_directory(guard);
+}
+
+/// The same rules with the `dir-merge .rsf` directive written FIRST
+/// (directive_order = 0): the per-directory `+ keep.tmp` now precedes the
+/// global `- *.tmp` and wins, so keep.tmp is included.
+#[test]
+fn per_dir_include_before_global_exclude_wins() {
+    let root = setup();
+    let global = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).unwrap();
+    let mut chain = FilterChain::new(global);
+    chain.add_merge_config(DirMergeConfig::new(".rsf").with_directive_order(0));
+
+    let guard = chain.enter_directory(&root.path().join("sub")).unwrap();
+
+    // Transfer: the directive sits at position 0, ahead of the global exclude,
+    // so the per-dir `+ keep.tmp` is the first match - keep.tmp is included.
+    assert!(
+        chain.allows(Path::new("keep.tmp"), false),
+        "dir-merge before the global exclude must let `+ keep.tmp` win",
+    );
+    // The merge file only excepts keep.tmp; other .tmp files stay excluded.
+    assert!(!chain.allows(Path::new("drop.tmp"), false));
+    assert!(chain.allows(Path::new("notes.txt"), false));
+
+    // Deletion: the per-dir include makes keep.tmp deletable, matching upstream.
+    assert!(
+        chain.allows_deletion(Path::new("keep.tmp"), false),
+        "per-dir `+ keep.tmp` before the global exclude must make keep.tmp deletable",
+    );
+
+    chain.leave_directory(guard);
+}
+
+/// Regression guard for the default: a chain built without recording a
+/// directive position keeps the historical "per-directory scope overrides
+/// global" behaviour (directive_order defaults to 0).
+#[test]
+fn default_directive_order_keeps_per_dir_override() {
+    let root = setup();
+    let global = FilterSet::from_rules([FilterRule::exclude("*.tmp")]).unwrap();
+    let mut chain = FilterChain::new(global);
+    chain.add_merge_config(DirMergeConfig::new(".rsf"));
+
+    let guard = chain.enter_directory(&root.path().join("sub")).unwrap();
+    assert!(
+        chain.allows(Path::new("keep.tmp"), false),
+        "with no recorded directive position the per-dir include still wins",
+    );
+    chain.leave_directory(guard);
+}

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -27,7 +27,7 @@ use protocol::filters::{FilterRuleWireFormat, RuleType, read_filter_list};
 use crate::role_trailer::error_location;
 
 use super::GeneratorContext;
-use ::filters::FilterRule;
+use ::filters::{FilterAction, FilterRule};
 
 /// A resolved `--files-from` entry split into a walk base and a full path.
 ///
@@ -443,7 +443,16 @@ impl GeneratorContext {
                     // upstream: exclude.c - dir-merge rules register a per-directory
                     // merge file that is read during walk_path(). The FilterChain
                     // handles reading and scoping.
-                    let config = wire_rule_to_dir_merge_config(wire_rule, cvs_perishable);
+                    //
+                    // upstream: exclude.c:1046-1050 - check_filter() consults the
+                    // FILTRULE_PERDIR_MERGE entry at its own list position, so
+                    // record how many order-bearing global rules precede this
+                    // directive (matching FilterSet::from_rules' `order` count)
+                    // so the chain checks earlier global rules before the merge
+                    // file's rules and later ones after.
+                    let directive_order = rules.iter().filter(|r| is_order_bearing(r)).count();
+                    let config = wire_rule_to_dir_merge_config(wire_rule, cvs_perishable)
+                        .with_directive_order(directive_order);
                     merge_configs.push(config);
                     continue;
                 }
@@ -493,6 +502,24 @@ impl GeneratorContext {
 
         Ok((filter_set, merge_configs))
     }
+}
+
+/// Reports whether a parsed rule receives a source-order stamp in
+/// [`FilterSet::from_rules`](filters::FilterSet::from_rules).
+///
+/// Only include/exclude and protect/risk rules that are not xattr-name rules
+/// increment the `order` counter there; clear, merge, and dir-merge directives
+/// do not. Counting the same set here keeps a `dir-merge` directive's recorded
+/// position aligned with `CompiledRule::order`.
+fn is_order_bearing(rule: &FilterRule) -> bool {
+    !rule.is_xattr_only()
+        && matches!(
+            rule.action(),
+            FilterAction::Include
+                | FilterAction::Exclude
+                | FilterAction::Protect
+                | FilterAction::Risk
+        )
 }
 
 /// Reassembles the pattern body with leading/trailing `/` modifiers re-applied.


### PR DESCRIPTION
## Problem
Upstream `check_filter()` (`exclude.c:1043-1064`) walks one list and recurses into a per-dir merge at the `dir-merge`/`:` directive's **source position**, so a global rule written *before* the directive wins over the merge file's rules. oc's `FilterChain` always evaluated every per-dir scope before the flat global set → per-dir always overrode global regardless of directive position.

## Fix
Stamp each dir-merge scope with `directive_order` (count of order-bearing global rules preceding it, in `CompiledRule::order` units). Transfer and deletion decisions pick the matching scope with the smallest `directive_order` and let it win only when `directive_order <= global_match_order`; otherwise the earlier global rule decides — reproducing upstream's single-list first-match-wins. Local-before-inherited ordering among per-dir files is preserved. **`directive_order` defaults to 0**, so any chain built without a recorded position is byte-identical to prior behavior; only the wire/generator path records real positions (safety by construction).

## Verification
Empirical over SSH vs rsync 3.4.4, both orderings:
- `--filter='- *.tmp' --filter='dir-merge .rsf'` (`+ keep.tmp` in .rsf): **`sub/notes.txt` only** — keep.tmp excluded (global first wins). oc used to *include* keep.tmp; now matches upstream.
- `--filter='dir-merge .rsf' --filter='- *.tmp'`: **`sub/keep.tmp sub/notes.txt`** — keep.tmp included (merge first wins). Matches upstream.

1424 filters tests pass (incl. new both-orderings + default-regression test); clippy `-D warnings` clean on filters + transfer.

Note: the separate local-copy `FilterProgram` engine has the same class of gap (local `src/ dst/` copies) and remains a follow-up.