### PR TITLE
fix(engine): surface swallowed EACCES during recursive delete as exit 23

### DIFF
--- a/crates/engine/src/delete/emitter/fs.rs
+++ b/crates/engine/src/delete/emitter/fs.rs
@@ -33,7 +33,7 @@ use std::sync::Mutex;
 use std::ffi::OsStr;
 
 #[cfg(unix)]
-use fast_io::UnlinkFlags;
+use fast_io::{UnlinkFlags, UnlinkResidue};
 
 use super::super::DeleteEntryKind;
 use crate::util::poison::lock_or_recover;
@@ -144,8 +144,18 @@ pub trait DeleteFs: std::fmt::Debug {
     /// per-entry descent refuses to follow a symlink at the leaf
     /// (`O_DIRECTORY | O_NOFOLLOW`) and the final
     /// `unlinkat(AT_REMOVEDIR)` is anchored on `parent_fd`.
+    ///
+    /// Returns an [`UnlinkResidue`] so the emitter can mirror upstream's
+    /// post-peel exit-code decision: `not_empty` drives the "cannot delete
+    /// non-empty directory" notice, `had_errors` drives `io_error |=
+    /// IOERR_GENERAL` (exit 23) when the descent stepped over a genuine
+    /// child failure.
     #[cfg(unix)]
-    fn remove_dir_all_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()>;
+    fn remove_dir_all_at(
+        &self,
+        parent_fd: BorrowedFd<'_>,
+        name: &OsStr,
+    ) -> io::Result<UnlinkResidue>;
 }
 
 /// Production [`DeleteFs`] implementation backed by `std::fs` (path
@@ -212,7 +222,11 @@ impl DeleteFs for RealDeleteFs {
     }
 
     #[cfg(unix)]
-    fn remove_dir_all_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+    fn remove_dir_all_at(
+        &self,
+        parent_fd: BorrowedFd<'_>,
+        name: &OsStr,
+    ) -> io::Result<UnlinkResidue> {
         // SEC-1.s carrier: drives the recursive peel directly off
         // `parent_fd` with O_DIRECTORY | O_NOFOLLOW so a symlink at the
         // root is refused and the kernel anchors every per-entry
@@ -275,7 +289,11 @@ impl<F: DeleteFs + ?Sized> DeleteFs for &F {
     }
 
     #[cfg(unix)]
-    fn remove_dir_all_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+    fn remove_dir_all_at(
+        &self,
+        parent_fd: BorrowedFd<'_>,
+        name: &OsStr,
+    ) -> io::Result<UnlinkResidue> {
         (*self).remove_dir_all_at(parent_fd, name)
     }
 }
@@ -396,8 +414,12 @@ impl DeleteFs for RecordingDeleteFs {
     }
 
     #[cfg(unix)]
-    fn remove_dir_all_at(&self, _parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+    fn remove_dir_all_at(
+        &self,
+        _parent_fd: BorrowedFd<'_>,
+        name: &OsStr,
+    ) -> io::Result<UnlinkResidue> {
         self.record(Path::new(name), DeleteEntryKind::Dir);
-        Ok(())
+        Ok(UnlinkResidue::default())
     }
 }

--- a/crates/engine/src/delete/emitter/mod.rs
+++ b/crates/engine/src/delete/emitter/mod.rs
@@ -308,12 +308,12 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     ///
     /// # Errors
     ///
-    /// Surfaces an [`io::Error`] only on a fatal classification (see
-    /// `Self::is_fatal_error`) or when
-    /// [`EmitterErrorPolicy::continue_on_error`] is `false` and a
-    /// non-fatal failure occurs. Non-fatal failures under the default
-    /// policy set [`Self::io_error`] and the drain continues, matching
-    /// upstream `delete.c:178-207`.
+    /// Surfaces an [`io::Error`] only when
+    /// [`EmitterErrorPolicy::continue_on_error`] is `false` and a per-entry
+    /// failure occurs. Under the default policy every failure other than
+    /// ENOENT and dir-ENOTEMPTY sets [`Self::io_error`] and the drain
+    /// continues, matching upstream `delete.c:86-210` which never aborts the
+    /// pass on a per-entry errno.
     pub fn emit_all(&mut self) -> io::Result<()> {
         loop {
             let dir = match self.pending.take() {
@@ -450,12 +450,13 @@ impl<F: DeleteFs> DeleteEmitter<F> {
                     );
                     return Ok(());
                 }
-                if Self::is_fatal_error(&err) {
-                    // Fatal: abort the drain. Upstream maps these to
-                    // RERR_PARTIAL via `rsyserr(FERROR_XFER, ...)` plus
-                    // `exit_cleanup` in `delete.c:201-205`.
-                    return Err(err);
-                }
+                // upstream: delete.c:86-210 `delete_dir_contents` /
+                // `delete_item` never abort the pass on a per-entry errno.
+                // Every failure other than ENOENT (idempotent) and
+                // dir-ENOTEMPTY (DR_NOT_EMPTY) is logged via FERROR_XFER,
+                // sets `io_error |= IOERR_GENERAL`, and the pass keeps
+                // deleting siblings. Record the non-fatal error and continue
+                // under the default `continue_on_error` policy.
                 self.record_nonfatal(&err);
                 if !self.policy.continue_on_error {
                     return Err(err);
@@ -558,7 +559,27 @@ impl<F: DeleteFs> DeleteEmitter<F> {
                     }
                 } else {
                     match parent_fd {
-                        Some(fd) => self.fs.remove_dir_all_at(fd, leaf),
+                        Some(fd) => {
+                            // Sandbox-anchored recursive peel. The descent
+                            // steps over per-child errors (upstream
+                            // `delete_dir_contents`), so it reports the
+                            // outcome instead of aborting: `had_errors`
+                            // means a genuine child unlink/rmdir failure was
+                            // logged and skipped, which upstream reflects as
+                            // `io_error |= IOERR_GENERAL` (exit 23). A
+                            // residual `not_empty` alone stays benign - it is
+                            // re-surfaced as ENOTEMPTY so `run_entry` prints
+                            // the "cannot delete non-empty directory" notice.
+                            let residue = self.fs.remove_dir_all_at(fd, leaf)?;
+                            if residue.had_errors && !self.policy.ignore_errors {
+                                self.io_error |= IOERR_GENERAL;
+                            }
+                            if residue.not_empty {
+                                Err(io::Error::from(io::ErrorKind::DirectoryNotEmpty))
+                            } else {
+                                Ok(())
+                            }
+                        }
                         None => self.fs.remove_dir_all(path),
                     }
                 }
@@ -597,18 +618,6 @@ impl<F: DeleteFs> DeleteEmitter<F> {
         } else {
             self.io_error |= IOERR_GENERAL;
         }
-    }
-
-    /// Classifies an error as fatal. Fatal classifications abort the
-    /// drain and surface to the caller verbatim.
-    ///
-    /// Upstream treats `EPERM` and `EACCES` on the destination as
-    /// fatal-class errors during the delete pass: they signal the
-    /// receiver cannot make progress and the run should exit with
-    /// `RERR_PARTIAL` immediately rather than spinning through the rest
-    /// of the plan (see `delete.c:201-205` rsyserr + `cleanup_and_exit`).
-    fn is_fatal_error(err: &io::Error) -> bool {
-        matches!(err.kind(), io::ErrorKind::PermissionDenied)
     }
 
     fn increment_stat(stats: &mut DeleteStats, kind: DeleteEntryKind) {

--- a/crates/engine/src/delete/emitter/policy.rs
+++ b/crates/engine/src/delete/emitter/policy.rs
@@ -36,9 +36,9 @@ pub(super) const IOERR_VANISHED_ONLY: i32 = 1 << 1;
 ///   suppressed by `ignore_errors`) and moves on to the next entry. When
 ///   `false`, the first non-fatal failure also stops the drain.
 ///
-/// Fatal classifications (see `DeleteEmitter::is_fatal_error`) always
-/// abort the drain regardless of these flags so the caller can surface
-/// the failure with a non-zero exit code.
+/// The emitter never aborts the pass on a per-entry errno on its own
+/// (mirroring upstream `delete.c:86-210`); only `continue_on_error: false`
+/// turns the first failure into an aborting error.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct EmitterErrorPolicy {
     /// Suppress the `io_error` flag for non-fatal failures.

--- a/crates/engine/src/delete/emitter/tests/error_policy.rs
+++ b/crates/engine/src/delete/emitter/tests/error_policy.rs
@@ -194,9 +194,12 @@ fn nonfatal_error_in_middle_keeps_draining_and_sets_io_error() {
 }
 
 #[test]
-fn fatal_eperm_aborts_drain_and_returns_err() {
-    // EPERM on the destination is fatal under upstream's policy:
-    // the drain must stop and the caller must surface the error.
+fn eperm_is_nonfatal_and_continues() {
+    // EPERM on a destination entry is NOT fatal: upstream
+    // (delete.c:86-210) logs FERROR_XFER, sets io_error |= IOERR_GENERAL,
+    // and keeps deleting the remaining siblings. The drain must therefore
+    // process `third`, record IOERR_GENERAL, and finish without surfacing
+    // an aborting error.
     let fs = ScriptedDeleteFs::new().fail("d/second", io::ErrorKind::PermissionDenied);
     let plans = DeletePlanMap::new();
     plans.insert(plan(
@@ -211,10 +214,9 @@ fn fatal_eperm_aborts_drain_and_returns_err() {
     cursor.observe_segment(PathBuf::from("d"), &[]);
 
     let mut emitter = DeleteEmitter::new(fs, plans, cursor);
-    let err = emitter
+    emitter
         .emit_all()
-        .expect_err("fatal classification aborts drain");
-    assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        .expect("EPERM is non-fatal and the drain continues");
 
     let paths: Vec<PathBuf> = emitter
         .fs()
@@ -222,9 +224,15 @@ fn fatal_eperm_aborts_drain_and_returns_err() {
         .iter()
         .map(|e| e.path.clone())
         .collect();
-    // `third` is never reached because the drain aborted.
-    assert_eq!(paths, vec![PathBuf::from("d/first")]);
-    assert_eq!(emitter.stats().files, 1);
+    // `second` errored before the recording branch; `first` and `third`
+    // both succeeded because the drain did not abort.
+    assert_eq!(
+        paths,
+        vec![PathBuf::from("d/first"), PathBuf::from("d/third")]
+    );
+    assert_eq!(emitter.io_error(), IOERR_GENERAL);
+    assert_eq!(emitter.exit_code(), EMITTER_PARTIAL_EXIT_CODE);
+    assert_eq!(emitter.stats().files, 2);
 }
 
 #[test]

--- a/crates/engine/src/delete/emitter/tests/mod.rs
+++ b/crates/engine/src/delete/emitter/tests/mod.rs
@@ -54,6 +54,11 @@ pub(super) fn dir_child(parent: &str, name: &str) -> FileEntry {
 pub(super) struct ScriptedDeleteFs {
     inner: RecordingDeleteFs,
     rules: Mutex<Vec<(PathBuf, io::ErrorKind)>>,
+    /// Scripted [`UnlinkResidue`] values returned by `remove_dir_all_at`,
+    /// keyed on the leaf name, so tests can model a recursive peel that
+    /// stepped over a child error or left the root non-empty.
+    #[cfg(unix)]
+    peel: Mutex<Vec<(PathBuf, fast_io::UnlinkResidue)>>,
 }
 
 impl ScriptedDeleteFs {
@@ -64,6 +69,22 @@ impl ScriptedDeleteFs {
     pub(super) fn fail(self, path: &str, kind: io::ErrorKind) -> Self {
         lock_or_recover(&self.rules).push((PathBuf::from(path), kind));
         self
+    }
+
+    /// Scripts the [`UnlinkResidue`](fast_io::UnlinkResidue) the next
+    /// `remove_dir_all_at` call against `name` returns, modelling a
+    /// recursive peel outcome.
+    #[cfg(unix)]
+    pub(super) fn peel(self, name: &str, residue: fast_io::UnlinkResidue) -> Self {
+        lock_or_recover(&self.peel).push((PathBuf::from(name), residue));
+        self
+    }
+
+    #[cfg(unix)]
+    fn maybe_peel(&self, name: &Path) -> Option<fast_io::UnlinkResidue> {
+        let mut peel = lock_or_recover(&self.peel);
+        let position = peel.iter().position(|(p, _)| p == name)?;
+        Some(peel.remove(position).1)
     }
 
     pub(super) fn events(&self) -> Vec<DeleteEvent> {
@@ -162,10 +183,15 @@ impl DeleteFs for ScriptedDeleteFs {
     }
 
     #[cfg(unix)]
-    fn remove_dir_all_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+    fn remove_dir_all_at(
+        &self,
+        parent_fd: BorrowedFd<'_>,
+        name: &OsStr,
+    ) -> io::Result<fast_io::UnlinkResidue> {
         if let Some(err) = self.maybe_fail(Path::new(name)) {
             return Err(err);
         }
-        self.inner.remove_dir_all_at(parent_fd, name)
+        let residue = self.inner.remove_dir_all_at(parent_fd, name)?;
+        Ok(self.maybe_peel(Path::new(name)).unwrap_or(residue))
     }
 }

--- a/crates/engine/src/delete/emitter/tests/sandbox.rs
+++ b/crates/engine/src/delete/emitter/tests/sandbox.rs
@@ -210,3 +210,85 @@ fn sandbox_with_missing_plan_directory_falls_back_to_path_dispatch() {
     assert_eq!(emitter.stats().files, 0);
     assert_ne!(emitter.io_error(), 0);
 }
+
+#[test]
+fn peel_stepped_over_child_error_sets_io_error_exit_23() {
+    // A directory whose recursive peel stepped over a genuine child error
+    // (an EACCES the walker logged and skipped, upstream FERROR_XFER) must
+    // set io_error and map to RERR_PARTIAL (23), even though the pass kept
+    // going. The scripted residue models the walker's report: the root is
+    // left non-empty because the un-removable child survived.
+    use super::super::EMITTER_PARTIAL_EXIT_CODE;
+    use super::ScriptedDeleteFs;
+    use fast_io::UnlinkResidue;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir(tmp.path().join("d")).expect("mkdir d");
+
+    // rmdir_at yields ENOTEMPTY (no nested plan), so the emitter peels via
+    // remove_dir_all_at, which returns a residue reporting a stepped-over
+    // child error plus a surviving (non-empty) root.
+    let fs = ScriptedDeleteFs::new()
+        .fail("locked", std::io::ErrorKind::DirectoryNotEmpty)
+        .peel(
+            "locked",
+            UnlinkResidue {
+                not_empty: true,
+                had_errors: true,
+            },
+        );
+    let plans = DeletePlanMap::new();
+    plans.insert(plan("d", vec![entry("locked", DeleteEntryKind::Dir)]));
+    let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+    cursor.observe_segment(PathBuf::from("d"), &[]);
+
+    let mut emitter = DeleteEmitter::new(fs, plans, cursor).with_sandbox(sandbox_for(tmp.path()));
+    emitter.emit_all().expect("stepped-over error is non-fatal");
+
+    assert_ne!(
+        emitter.io_error(),
+        0,
+        "a genuine swallowed error must set io_error"
+    );
+    assert_eq!(emitter.exit_code(), EMITTER_PARTIAL_EXIT_CODE);
+    // The surviving directory is not counted as deleted.
+    assert_eq!(emitter.stats().dirs, 0);
+}
+
+#[test]
+fn peel_non_empty_without_error_stays_exit_0() {
+    // A directory left non-empty with NO stepped-over child error - the
+    // legitimate case where content was moved to --backup, filtered, or
+    // protected - is upstream DR_NOT_EMPTY: the notice prints but the run
+    // stays exit 0. The residue reports not_empty without had_errors.
+    use super::ScriptedDeleteFs;
+    use fast_io::UnlinkResidue;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir(tmp.path().join("d")).expect("mkdir d");
+
+    let fs = ScriptedDeleteFs::new()
+        .fail("kept", std::io::ErrorKind::DirectoryNotEmpty)
+        .peel(
+            "kept",
+            UnlinkResidue {
+                not_empty: true,
+                had_errors: false,
+            },
+        );
+    let plans = DeletePlanMap::new();
+    plans.insert(plan("d", vec![entry("kept", DeleteEntryKind::Dir)]));
+    let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+    cursor.observe_segment(PathBuf::from("d"), &[]);
+
+    let mut emitter = DeleteEmitter::new(fs, plans, cursor).with_sandbox(sandbox_for(tmp.path()));
+    emitter.emit_all().expect("non-empty dir is benign");
+
+    assert_eq!(
+        emitter.io_error(),
+        0,
+        "a backup-emptied / filtered non-empty dir must not set io_error"
+    );
+    assert_eq!(emitter.exit_code(), 0);
+    assert_eq!(emitter.stats().dirs, 0);
+}

--- a/crates/engine/src/delete/parallel_consumer.rs
+++ b/crates/engine/src/delete/parallel_consumer.rs
@@ -293,11 +293,11 @@ impl<F: DeleteFs + Sync + Send + 'static> ParallelDeleteEmitter<F> {
     ///
     /// # Errors
     ///
-    /// Surfaces a fatal [`io::Error`] when the [`EmitterErrorPolicy`]
-    /// classifies a dispatch failure as fatal (mirrors
-    /// [`super::emitter::DeleteEmitter::emit_all`] behaviour). Non-fatal
-    /// errors accumulate into the returned outcome's `io_error` bitmask
-    /// and the drain continues.
+    /// Surfaces an [`io::Error`] only when
+    /// [`EmitterErrorPolicy::continue_on_error`] is `false` and a dispatch
+    /// fails (mirrors [`super::emitter::DeleteEmitter::emit_all`]). Under the
+    /// default policy every per-entry failure accumulates into the returned
+    /// outcome's `io_error` bitmask and the drain continues.
     pub fn run(self) -> io::Result<ParallelDrainOutcome<F>> {
         #[cfg(unix)]
         let consumer_sandbox = self.sandbox.clone();
@@ -466,22 +466,31 @@ fn dispatch_cohort<F: DeleteFs + Sync + Send>(
     let parent_fd = parent_handle.as_ref().map(std::os::fd::AsFd::as_fd);
 
     #[cfg(unix)]
-    let results: Vec<io::Result<DeleteEntryKind>> = ops
+    let results: Vec<io::Result<(DeleteEntryKind, bool)>> = ops
         .par_iter()
         .map(|op| dispatch_one(fs.as_ref(), op, parent_fd))
         .collect();
     #[cfg(not(unix))]
-    let results: Vec<io::Result<DeleteEntryKind>> = ops
+    let results: Vec<io::Result<(DeleteEntryKind, bool)>> = ops
         .par_iter()
         .map(|op| dispatch_one(fs.as_ref(), op))
         .collect();
     for result in results {
         match result {
-            Ok(kind) => increment_stat(&mut summary.stats, kind),
-            Err(err) => {
-                if is_fatal_error(&err) {
-                    return Err(err);
+            Ok((kind, had_errors)) => {
+                increment_stat(&mut summary.stats, kind);
+                if had_errors && !policy.ignore_errors {
+                    // A recursive peel stepped over a genuine child error
+                    // (upstream FERROR_XFER + `io_error |= IOERR_GENERAL`);
+                    // record it so the run exits 23 while the pass keeps
+                    // deleting siblings.
+                    summary.io_error |= IOERR_GENERAL;
                 }
+            }
+            Err(err) => {
+                // upstream: delete.c:86-210 never aborts the pass on a
+                // per-entry errno; record it and keep going under the
+                // default continue-on-error policy.
                 accumulate_nonfatal(&mut summary.io_error, policy, &err);
                 if !policy.continue_on_error {
                     return Err(err);
@@ -497,38 +506,42 @@ fn dispatch_cohort<F: DeleteFs + Sync + Send>(
 /// otherwise. `op.leaf` is the single-component leaf name anchored against
 /// `parent_fd`; `op.path` is the absolute reconstruction used by the
 /// fallback.
+///
+/// Returns the op's kind paired with whether a recursive peel stepped over
+/// a genuine child error (`had_errors`). Only the directory path can raise
+/// the flag; every other kind reports `false`.
 #[cfg(unix)]
 fn dispatch_one<F: DeleteFs>(
     fs: &F,
     op: &DeleteOperation,
     parent_fd: Option<std::os::fd::BorrowedFd<'_>>,
-) -> io::Result<DeleteEntryKind> {
+) -> io::Result<(DeleteEntryKind, bool)> {
     let leaf = op.leaf.as_os_str();
-    let outcome = match (op.kind, parent_fd) {
-        (DeleteEntryKind::File, Some(fd)) => fs.unlink_file_at(fd, leaf),
-        (DeleteEntryKind::Symlink, Some(fd)) => fs.unlink_symlink_at(fd, leaf),
-        (DeleteEntryKind::Device, Some(fd)) => fs.unlink_device_at(fd, leaf),
-        (DeleteEntryKind::Special, Some(fd)) => fs.unlink_special_at(fd, leaf),
+    let had_errors = match (op.kind, parent_fd) {
+        (DeleteEntryKind::File, Some(fd)) => fs.unlink_file_at(fd, leaf).map(|()| false),
+        (DeleteEntryKind::Symlink, Some(fd)) => fs.unlink_symlink_at(fd, leaf).map(|()| false),
+        (DeleteEntryKind::Device, Some(fd)) => fs.unlink_device_at(fd, leaf).map(|()| false),
+        (DeleteEntryKind::Special, Some(fd)) => fs.unlink_special_at(fd, leaf).map(|()| false),
         (DeleteEntryKind::Dir, Some(fd)) => dispatch_dir_at(fs, fd, leaf),
-        (DeleteEntryKind::File, None) => fs.unlink_file(&op.path),
-        (DeleteEntryKind::Symlink, None) => fs.unlink_symlink(&op.path),
-        (DeleteEntryKind::Device, None) => fs.unlink_device(&op.path),
-        (DeleteEntryKind::Special, None) => fs.unlink_special(&op.path),
-        (DeleteEntryKind::Dir, None) => dispatch_dir(fs, &op.path),
-    };
-    outcome.map(|()| op.kind)
+        (DeleteEntryKind::File, None) => fs.unlink_file(&op.path).map(|()| false),
+        (DeleteEntryKind::Symlink, None) => fs.unlink_symlink(&op.path).map(|()| false),
+        (DeleteEntryKind::Device, None) => fs.unlink_device(&op.path).map(|()| false),
+        (DeleteEntryKind::Special, None) => fs.unlink_special(&op.path).map(|()| false),
+        (DeleteEntryKind::Dir, None) => dispatch_dir(fs, &op.path).map(|()| false),
+    }?;
+    Ok((op.kind, had_errors))
 }
 
 #[cfg(not(unix))]
-fn dispatch_one<F: DeleteFs>(fs: &F, op: &DeleteOperation) -> io::Result<DeleteEntryKind> {
-    let outcome = match op.kind {
-        DeleteEntryKind::File => fs.unlink_file(&op.path),
-        DeleteEntryKind::Dir => dispatch_dir(fs, &op.path),
-        DeleteEntryKind::Symlink => fs.unlink_symlink(&op.path),
-        DeleteEntryKind::Device => fs.unlink_device(&op.path),
-        DeleteEntryKind::Special => fs.unlink_special(&op.path),
+fn dispatch_one<F: DeleteFs>(fs: &F, op: &DeleteOperation) -> io::Result<(DeleteEntryKind, bool)> {
+    match op.kind {
+        DeleteEntryKind::File => fs.unlink_file(&op.path)?,
+        DeleteEntryKind::Dir => dispatch_dir(fs, &op.path)?,
+        DeleteEntryKind::Symlink => fs.unlink_symlink(&op.path)?,
+        DeleteEntryKind::Device => fs.unlink_device(&op.path)?,
+        DeleteEntryKind::Special => fs.unlink_special(&op.path)?,
     };
-    outcome.map(|()| op.kind)
+    Ok((op.kind, false))
 }
 
 fn dispatch_dir<F: DeleteFs>(fs: &F, path: &std::path::Path) -> io::Result<()> {
@@ -541,26 +554,24 @@ fn dispatch_dir<F: DeleteFs>(fs: &F, path: &std::path::Path) -> io::Result<()> {
 
 /// Dirfd-anchored directory removal: `rmdir_at` first, then the recursive
 /// `remove_dir_all_at` peel on `ENOTEMPTY`, mirroring the path-based
-/// [`dispatch_dir`] but anchored against `parent_fd`.
+/// [`dispatch_dir`] but anchored against `parent_fd`. Returns whether the
+/// peel stepped over a genuine child error; a residual non-empty root
+/// without such an error stays benign (upstream `DR_NOT_EMPTY`).
 #[cfg(unix)]
 fn dispatch_dir_at<F: DeleteFs>(
     fs: &F,
     parent_fd: std::os::fd::BorrowedFd<'_>,
     leaf: &std::ffi::OsStr,
-) -> io::Result<()> {
+) -> io::Result<bool> {
     match fs.rmdir_at(parent_fd, leaf) {
-        Ok(()) => Ok(()),
-        Err(err) if is_not_empty(&err) => fs.remove_dir_all_at(parent_fd, leaf),
+        Ok(()) => Ok(false),
+        Err(err) if is_not_empty(&err) => Ok(fs.remove_dir_all_at(parent_fd, leaf)?.had_errors),
         Err(err) => Err(err),
     }
 }
 
 fn is_not_empty(err: &io::Error) -> bool {
     matches!(err.kind(), io::ErrorKind::DirectoryNotEmpty)
-}
-
-fn is_fatal_error(err: &io::Error) -> bool {
-    matches!(err.kind(), io::ErrorKind::PermissionDenied)
 }
 
 /// Mirrors [`super::emitter::policy`] `IOERR_GENERAL` (bit 0) so the
@@ -935,7 +946,7 @@ mod tests {
                 &self,
                 _parent_fd: std::os::fd::BorrowedFd<'_>,
                 _name: &std::ffi::OsStr,
-            ) -> io::Result<()> {
+            ) -> io::Result<fast_io::UnlinkResidue> {
                 unreachable!()
             }
         }

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -200,6 +200,14 @@ pub(crate) struct CopyContext<'a> {
     /// sets `got_xfer_error` without aborting the transfer.
     // upstream: sender.c:131-182 successful_send(); log.c:311 got_xfer_error
     sender_remove_error: bool,
+    /// Set when the delete emitter reported a genuine swallowed unlink/rmdir
+    /// error during the recursive peel (an `EACCES` and friends the walker
+    /// logged and stepped over). The pass keeps deleting the rest of the
+    /// tree, but this flag drives the final `RERR_PARTIAL` (exit 23) exit
+    /// code, mirroring upstream `delete.c:86-210` where each such
+    /// `rsyserr(FERROR_XFER, ...)` sets `io_error |= IOERR_GENERAL` without
+    /// aborting the pass.
+    delete_io_error: bool,
     /// `true` when the active plan carries more than one source operand.
     /// Used to switch `--delete-during` to a deferred sweep so the per-source
     /// keep lists can be merged before any extraneous unlink fires; upstream

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -141,6 +141,7 @@ impl<'a> CopyContext<'a> {
             iconv_conversion_error: false,
             unsupported_operation_skipped: false,
             sender_remove_error: false,
+            delete_io_error: false,
             multi_source: false,
             verified_parents: HashMap::new(),
             batch_flist_writer,
@@ -1358,6 +1359,25 @@ impl<'a> CopyContext<'a> {
     /// even though every other entry was copied.
     pub(super) const fn sender_remove_error_occurred(&self) -> bool {
         self.sender_remove_error
+    }
+
+    /// Records that the delete emitter stepped over a genuine unlink/rmdir
+    /// error during a recursive peel. The pass still deletes the rest of the
+    /// tree; this flag only forces the final `RERR_PARTIAL` (exit 23) exit
+    /// code.
+    ///
+    /// upstream: `delete.c:86-210` - `delete_dir_contents` / `delete_item`
+    /// log each un-removable entry via `rsyserr(FERROR_XFER, ...)` and set
+    /// `io_error |= IOERR_GENERAL`; `main.c` then exits `RERR_PARTIAL`.
+    pub(super) fn record_delete_io_error(&mut self) {
+        self.delete_io_error = true;
+    }
+
+    /// Reports whether a swallowed delete-pass error must force
+    /// `RERR_PARTIAL` (exit 23). `--ignore-errors` suppresses it, matching
+    /// upstream where the flag clears `IOERR_GENERAL` for the delete pass.
+    pub(super) const fn io_error_requires_partial_exit(&self) -> bool {
+        self.delete_io_error && !self.options.ignore_errors_enabled()
     }
 
     /// Reports whether deletions should proceed despite I/O errors.

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -23,7 +23,8 @@ use std::sync::Arc;
 const PARALLEL_DELETION_MATCH_THRESHOLD: usize = 64;
 
 use crate::delete::{
-    DeleteContext, DeleteEntry, DeleteEntryKind, DeleteFs, DeletePlan, DeletePlanMap, RealDeleteFs,
+    DeleteContext, DeleteEntry, DeleteEntryKind, DeleteFs, DeletePlan, DeletePlanMap,
+    EMITTER_PARTIAL_EXIT_CODE, RealDeleteFs,
 };
 use crate::local_copy::{CopyContext, LocalCopyAction, LocalCopyError, LocalCopyRecord};
 
@@ -277,9 +278,17 @@ where
     apply_delete_side_effects(context, destination, relative, &plan)?;
 
     if !context.mode().is_dry_run() {
-        let _outcome = ctx.emit_one(fs).map_err(|error| {
+        let outcome = ctx.emit_one(fs).map_err(|error| {
             LocalCopyError::io("emit delete plan", destination.to_path_buf(), error)
         })?;
+        // The emitter never aborts on a per-entry errno; a swallowed
+        // unlink/rmdir error surfaces as exit code 23 in the outcome. Fold
+        // it into the copy context so the run finishes RERR_PARTIAL while the
+        // pass keeps deleting the rest of the tree (upstream delete.c:86-210
+        // FERROR_XFER + `io_error |= IOERR_GENERAL`).
+        if outcome.exit_code == EMITTER_PARTIAL_EXIT_CODE {
+            context.record_delete_io_error();
+        }
     }
 
     Ok(())

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -279,6 +279,14 @@ pub(crate) fn copy_sources(
             if context.sender_remove_error_occurred() {
                 return Err(LocalCopyError::partial_transfer());
             }
+            // upstream: delete.c:86-210 - the delete pass logs each
+            // un-removable entry via `rsyserr(FERROR_XFER, ...)` and sets
+            // `io_error |= IOERR_GENERAL` without aborting; main.c then exits
+            // RERR_PARTIAL (23). The per-entry notice was already printed by
+            // the emitter, so surface only the summary error here.
+            if context.io_error_requires_partial_exit() {
+                return Err(LocalCopyError::partial_transfer());
+            }
             Ok(())
         })()
     };

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
@@ -60,7 +60,7 @@ pub use open::{
 pub use read_dir::{DirEntryView, EntryKind, ReadDirOutcome, read_dir_via_sandbox_or_fallback};
 pub use rename::{renameat, renameat_via_sandbox_or_fallback};
 pub use unlink::{
-    UnlinkFlags, recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback,
+    UnlinkFlags, UnlinkResidue, recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback,
     unlink_via_sandbox_or_fallback, unlinkat,
 };
 

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
@@ -69,6 +69,30 @@ impl UnlinkFlags {
     }
 }
 
+/// Outcome of a recursive `unlinkat` descent, mirroring upstream
+/// `delete.c`'s `delete_dir_contents` return contract (`delete.c:86-210`).
+///
+/// The descent never aborts on a per-child failure - it logs the entry and
+/// steps over it - so these two flags let the caller reconstruct the
+/// exit-code decision upstream makes after the pass finishes:
+///
+/// - `not_empty` mirrors `DR_NOT_EMPTY`: the final `rmdir` on the descent
+///   root reported `ENOTEMPTY`, so entries survived the peel (a stepped-over
+///   child error, a concurrent writer, or filtered/protected content the
+///   caller deliberately left in place). On its own this is benign (exit 0).
+/// - `had_errors` mirrors `rsyserr(FERROR_XFER, ...)` + `io_error |=
+///   IOERR_GENERAL`: the descent stepped over at least one genuine child
+///   unlink/rmdir error (`EACCES` and friends). The pass still deletes the
+///   remaining siblings, but the run must finish `RERR_PARTIAL` (23).
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct UnlinkResidue {
+    /// The final `rmdir` on the descent root reported `ENOTEMPTY`: entries
+    /// survived the peel.
+    pub not_empty: bool,
+    /// A genuine child unlink/rmdir error was logged and stepped over.
+    pub had_errors: bool,
+}
+
 /// Issue `unlinkat(dirfd, name, flags)`.
 ///
 /// The leaf is resolved relative to `dirfd` and is **not** followed if
@@ -221,14 +245,30 @@ pub fn recursive_unlinkat_via_sandbox_or_fallback(
     if let Some(sandbox) = sandbox
         && let Some(leaf) = single_component_leaf(dest_dir, relative_path, target_path)
     {
-        return recursive_unlinkat(sandbox.current_dirfd(), leaf);
+        return recursive_unlinkat(sandbox.current_dirfd(), leaf)
+            .and_then(residue_to_legacy_result);
     }
     if let ParentAnchor::Anchored { dirfd, name } =
         anchor_parent(sandbox, dest_dir, relative_path, target_path)?
     {
-        return recursive_unlinkat(dirfd.as_fd(), name);
+        return recursive_unlinkat(dirfd.as_fd(), name).and_then(residue_to_legacy_result);
     }
     remove_dir_all_with_uid_write_fix(target_path)
+}
+
+/// Collapses a recursive-descent [`UnlinkResidue`] back to the historical
+/// `io::Result<()>` contract the receiver call sites expect: a residual
+/// non-empty root surfaces as `ENOTEMPTY` (upstream `DR_NOT_EMPTY`), matching
+/// the pre-[`UnlinkResidue`] behaviour exactly. The stepped-over-error flag is
+/// dropped here because those callers do not yet consume it; the local-copy
+/// delete emitter consumes it through the dirfd-anchored
+/// [`recursive_unlinkat`] entry point instead.
+fn residue_to_legacy_result(residue: UnlinkResidue) -> io::Result<()> {
+    if residue.not_empty {
+        Err(io::Error::from_raw_os_error(libc::ENOTEMPTY))
+    } else {
+        Ok(())
+    }
 }
 
 /// Path-based sibling of the dirfd-anchored recursive removal above, used
@@ -302,14 +342,20 @@ fn fix_uid_write_recursive(path: &Path) {
 /// fallback based on whether the supplied sandbox can resolve the
 /// leaf as a single component.
 ///
+/// Returns an [`UnlinkResidue`] describing whether the root was left
+/// non-empty (`ENOTEMPTY` on the final `rmdir`) and whether any genuine
+/// child unlink/rmdir error was logged and stepped over, so the caller can
+/// mirror upstream's post-pass exit-code decision.
+///
 /// # Errors
 ///
-/// Surfaces the same error set as
-/// [`recursive_unlinkat_via_sandbox_or_fallback`]: `ENOENT` on the
-/// descent root is folded into `Ok(())`, `ELOOP` is returned for a
-/// symlink at the root or a hardlink cycle, and `ENOTEMPTY` is surfaced
-/// when an `EACCES` skip left residual entries behind.
-pub fn recursive_unlinkat(parent_dirfd: BorrowedFd<'_>, leaf: &OsStr) -> io::Result<()> {
+/// Only hard failures that abort the descent propagate as `Err`: a symlink
+/// at the root or a hardlink cycle (`ELOOP`), a non-directory root
+/// (`ENOTDIR`), or an unexpected `openat`/`fstatat`/`rmdir` errno. `ENOENT`
+/// on the descent root is folded into a clean [`UnlinkResidue`], and a
+/// residual `ENOTEMPTY` on the final `rmdir` is reported via
+/// [`UnlinkResidue::not_empty`] rather than as an error.
+pub fn recursive_unlinkat(parent_dirfd: BorrowedFd<'_>, leaf: &OsStr) -> io::Result<UnlinkResidue> {
     let mut visited: std::collections::HashSet<(u64, u64)> = std::collections::HashSet::new();
     recursive_unlinkat_inner(parent_dirfd, leaf, &mut visited)
 }
@@ -350,7 +396,7 @@ fn recursive_unlinkat_inner(
     parent_dirfd: BorrowedFd<'_>,
     leaf: &OsStr,
     visited: &mut std::collections::HashSet<(u64, u64)>,
-) -> io::Result<()> {
+) -> io::Result<UnlinkResidue> {
     // Step 1: open the descent root with O_DIRECTORY | O_NOFOLLOW so a
     // symlink at the leaf is refused (`ELOOP`) rather than followed.
     let listing_handle = match openat(
@@ -360,7 +406,9 @@ fn recursive_unlinkat_inner(
         0,
     ) {
         Ok(file) => file,
-        Err(err) if err.raw_os_error() == Some(libc::ENOENT) => return Ok(()),
+        Err(err) if err.raw_os_error() == Some(libc::ENOENT) => {
+            return Ok(UnlinkResidue::default());
+        }
         Err(err) => return Err(err),
     };
 
@@ -410,6 +458,7 @@ fn recursive_unlinkat_inner(
         0,
     )?;
     let dirfd = std::os::fd::AsFd::as_fd(&dir_handle);
+    let mut had_errors = false;
     for name in entries {
         if name.as_bytes() == b"." || name.as_bytes() == b".." {
             continue;
@@ -420,9 +469,9 @@ fn recursive_unlinkat_inner(
             Err(err) => return Err(err),
         };
         if child_meta.is_dir() {
-            recursive_unlinkat_inner(dirfd, &name, visited)?;
+            had_errors |= recursive_unlinkat_inner(dirfd, &name, visited)?.had_errors;
         } else {
-            unlink_child_entry(dirfd, &name)?;
+            had_errors |= unlink_child_entry(dirfd, &name)?;
         }
     }
 
@@ -431,15 +480,22 @@ fn recursive_unlinkat_inner(
     // while the target is still open through a separate fd.
     drop(dir_handle);
 
-    // Step 5: rmdir the now-empty directory. ENOENT is idempotent
-    // success (matches upstream `delete_item` line 201-206); any other
-    // error - including ENOTEMPTY when EACCES skips left residual
-    // entries behind - propagates verbatim.
-    match unlinkat(parent_dirfd, leaf, UnlinkFlags::Dir) {
-        Ok(()) => Ok(()),
-        Err(err) if err.raw_os_error() == Some(libc::ENOENT) => Ok(()),
-        Err(err) => Err(err),
-    }
+    // Step 5: rmdir the now-empty directory. ENOENT is idempotent success
+    // (matches upstream `delete_item` line 201-206). ENOTEMPTY means an
+    // entry survived the peel - a stepped-over `EACCES`, a concurrent
+    // writer, or filtered content - and is reported via
+    // `UnlinkResidue::not_empty` (upstream `DR_NOT_EMPTY`) rather than as an
+    // error; any other errno aborts the descent verbatim.
+    let not_empty = match unlinkat(parent_dirfd, leaf, UnlinkFlags::Dir) {
+        Ok(()) => false,
+        Err(err) if err.raw_os_error() == Some(libc::ENOENT) => false,
+        Err(err) if matches!(err.raw_os_error(), Some(libc::ENOTEMPTY | libc::EEXIST)) => true,
+        Err(err) => return Err(err),
+    };
+    Ok(UnlinkResidue {
+        not_empty,
+        had_errors,
+    })
 }
 
 /// Remove a single non-directory child entry, retrying the TOCTOU
@@ -448,13 +504,19 @@ fn recursive_unlinkat_inner(
 /// elsewhere). `EACCES` is logged and stepped over per upstream
 /// `delete.c:48-176`; `ENOENT` is treated as idempotent success since
 /// the entry already vanished.
-fn unlink_child_entry(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+///
+/// Returns `Ok(true)` when a genuine child error (`EACCES`) was logged and
+/// stepped over, so the caller can raise [`UnlinkResidue::had_errors`] and
+/// mirror upstream's `FERROR_XFER` + `io_error |= IOERR_GENERAL` while the
+/// descent keeps deleting siblings. `Ok(false)` covers a clean unlink, an
+/// already-vanished entry, and the benign classify-vs-act TOCTOU race.
+fn unlink_child_entry(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<bool> {
     match unlinkat(dirfd, name, UnlinkFlags::File) {
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(false),
         Err(err) => match err.raw_os_error() {
-            Some(libc::ENOENT) => Ok(()),
+            Some(libc::ENOENT) => Ok(false),
             Some(libc::EISDIR | libc::EPERM) => match unlinkat(dirfd, name, UnlinkFlags::Dir) {
-                Ok(()) => Ok(()),
+                Ok(()) => Ok(false),
                 Err(retry) => match retry.raw_os_error() {
                     Some(libc::ENOENT | libc::ENOTEMPTY) => {
                         tracing::debug!(
@@ -463,7 +525,7 @@ fn unlink_child_entry(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
                             os_error = retry.raw_os_error(),
                             "recursive_unlinkat: classify-vs-act race left entry unremovable, stepping over"
                         );
-                        Ok(())
+                        Ok(false)
                     }
                     _ => Err(retry),
                 },
@@ -474,7 +536,7 @@ fn unlink_child_entry(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
                     name = ?name,
                     "recursive_unlinkat: EACCES on child entry, stepping over per upstream"
                 );
-                Ok(())
+                Ok(true)
             }
             _ => Err(err),
         },

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -79,10 +79,10 @@ pub mod at_syscalls;
 mod tests;
 
 pub use at_syscalls::{
-    AtMetadata, DirEntryView, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags, fchmodat,
-    fchmodat_via_sandbox_or_fallback, fchownat, fchownat_via_sandbox_or_fallback, fstatat_nofollow,
-    linkat, linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
-    mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
+    AtMetadata, DirEntryView, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags, UnlinkResidue,
+    fchmodat, fchmodat_via_sandbox_or_fallback, fchownat, fchownat_via_sandbox_or_fallback,
+    fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback,
+    mkdirat, mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
     read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
     recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
     renameat_via_sandbox_or_fallback, secure_chmod_at, secure_chown_at, secure_utimes_at,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -350,14 +350,15 @@ pub use gcd::{GcdQueue, GcdReader, GcdWriter};
 #[cfg(unix)]
 pub use dir_sandbox::{
     AtMetadata, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,
-    fchmodat, fchmodat_via_sandbox_or_fallback, fchownat, fchownat_via_sandbox_or_fallback,
-    fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback,
-    mkdirat, mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
-    read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
-    recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
-    renameat_via_sandbox_or_fallback, secure_chmod_at, secure_chown_at, secure_utimes_at,
-    symlinkat, symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
-    utimensat, utimensat_via_sandbox_or_fallback,
+    UnlinkResidue, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
+    fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
+    lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
+    openat_via_sandbox_or_fallback, read_dir_via_sandbox_or_fallback, readlinkat,
+    readlinkat_via_sandbox_or_fallback, recursive_unlinkat,
+    recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
+    secure_chmod_at, secure_chown_at, secure_utimes_at, symlinkat,
+    symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
+    utimensat_via_sandbox_or_fallback,
 };
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, IoUringRequirement, KernelVersion, LinkatRequirement, PbufRingRequirement,


### PR DESCRIPTION
The recursive-unlink descent in the directory sandbox logged and **stepped over** a child `EACCES`/`EPERM` but returned `Ok(())`, hiding the error from the delete emitter. The final `rmdir` then saw `ENOTEMPTY` and treated the directory as benignly non-empty. Result: a `--delete` pass over a subtree containing a root-owned unwritable directory deleted every reachable sibling but **exited 0** — upstream exits **23**.

## Fix

`recursive_unlinkat` now returns `UnlinkResidue { not_empty, had_errors }`:
- `had_errors` — the descent stepped over a genuine child unlink/rmdir error.
- `not_empty` — the final `rmdir` hit `ENOTEMPTY` with no error (benign on its own: a dir kept by `--backup`, a filter, or `--protect`).

`unlink_child_entry` returns `Ok(true)` instead of hiding `EACCES` as `Ok(())`; the walker OR-folds child `had_errors` and captures `not_empty` from its own final `rmdir`. The receiver-path wrapper collapses residue back to the legacy `Result` (`not_empty → ENOTEMPTY`, drops `had_errors`) so `deletion.rs` / `missing_args.rs` and the SEC-1.x fail-loud path stay byte-identical.

`is_fatal_error` is removed — `EACCES`/`EPERM` now record `io_error` and continue, matching upstream `delete.c:delete_dir_contents` (continues on all errnos except `ENOENT`/`ENOTEMPTY`). The emitter sets `io_error |= IOERR_GENERAL` only when `had_errors` (honoring `--ignore-errors`) and re-surfaces `not_empty` as `DirectoryNotEmpty` so the existing notice still prints.

Local-copy exit wiring folds a `DrainOutcome` exit 23 into a **dedicated** `record_delete_io_error` flag (not `record_io_error`, which also gates the delete pass and would wrongly block later directories). `io_error` fires only on a genuinely swallowed error, never on a directory left non-empty by `--backup`/filter/protect — so the `backup_delete_*` cases stay exit 0.

## Verification

Against **rsync 3.4.4** (aarch64):

| scenario | upstream | oc-rsync |
|---|---|---|
| `--delete` over tree w/ root-owned 0555 subdir | `exit=23 sibling=GONE secret=PRESENT` | `exit=23 sibling=GONE secret=PRESENT` |
| `--delete --backup` over tree | `exit=0` | `exit=0` |

Byte-identical both ways. clippy clean (engine, fast_io); 132 targeted tests pass including all `backup_delete_*`.