### PR TITLE
feat(transfer): itemize xattr changes on remote --xattrs transfers

### DIFF
--- a/crates/protocol/src/xattr/diff.rs
+++ b/crates/protocol/src/xattr/diff.rs
@@ -1,0 +1,171 @@
+//! Extended-attribute set comparison for itemized change reporting.
+//!
+//! Ports upstream rsync's `xattrs.c:xattr_diff()` so the generator can flag an
+//! up-to-date file whose extended attributes differ from the sender's
+//! (`ITEM_REPORT_XATTR`, the `x` column of `--itemize-changes`).
+
+use std::cmp::Ordering;
+
+use crate::xattr::wire::checksum_matches;
+use crate::xattr::{MAX_FULL_DATUM, XattrList};
+
+/// Returns `true` when the sender's extended-attribute list differs from the
+/// receiver's on-disk attributes.
+///
+/// Mirrors upstream `xattrs.c:xattr_diff()`. `sender` is the flist xattr list as
+/// received: values longer than [`MAX_FULL_DATUM`] carry a checksum rather than
+/// the full datum (the abbreviation protocol). `receiver` holds the
+/// destination's current attributes with full values, as produced by
+/// `metadata::read_xattrs_for_wire`. Both lists must be sorted by name (the
+/// receiver sorts on read; the sender sorts before transmit).
+///
+/// The comparison walks the two sorted lists in lockstep. A differing entry
+/// count means the sets differ. For a shared name, a value at or below
+/// `MAX_FULL_DATUM` is compared byte-for-byte, while a larger value is compared
+/// by checksum against the receiver's full datum - exactly upstream's split at
+/// `MAX_FULL_DATUM` (`xattrs.c:584-594`). The `find_all` bookkeeping upstream
+/// uses to mark entries for on-demand request does not affect the returned
+/// "do they differ" answer, so this stops at the first mismatch.
+#[must_use]
+pub fn xattr_diff(sender: &XattrList, receiver: &XattrList, checksum_seed: i32) -> bool {
+    let snd = sender.entries();
+    let rec = receiver.entries();
+
+    // upstream: xattrs.c:574-576 - a differing count means the lists differ.
+    if snd.len() != rec.len() {
+        return true;
+    }
+
+    let (mut si, mut ri) = (0usize, 0usize);
+    while si < snd.len() {
+        let s = &snd[si];
+        // upstream: xattrs.c:581 - cmp < 0 means the sender has a name the
+        // receiver lacks (rec exhausted counts as sender-smaller).
+        let cmp = if ri < rec.len() {
+            s.name().cmp(rec[ri].name())
+        } else {
+            Ordering::Less
+        };
+
+        let same = if cmp == Ordering::Equal {
+            let r = &rec[ri];
+            if s.datum_len() > MAX_FULL_DATUM {
+                // upstream: xattrs.c:584-587 - large values compare by checksum.
+                s.datum_len() == r.datum_len()
+                    && checksum_matches(s.datum(), r.datum(), checksum_seed)
+            } else {
+                // upstream: xattrs.c:591-594 - small values compare byte-for-byte.
+                s.datum_len() == r.datum_len() && s.datum() == r.datum()
+            }
+        } else {
+            false
+        };
+
+        if !same {
+            return true;
+        }
+
+        if cmp != Ordering::Greater {
+            si += 1;
+        }
+        if cmp != Ordering::Less {
+            ri += 1;
+        }
+    }
+
+    // With equal counts and a full sender walk the receiver is also exhausted;
+    // the check mirrors upstream's trailing `if (rec_cnt) xattrs_equal = 0`.
+    ri < rec.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::xattr::wire::compute_xattr_checksum;
+    use crate::xattr::{XattrEntry, XattrList};
+
+    fn list(entries: Vec<XattrEntry>) -> XattrList {
+        XattrList::with_entries(entries)
+    }
+
+    fn full(name: &str, value: &[u8]) -> XattrEntry {
+        XattrEntry::new(name.as_bytes().to_vec(), value.to_vec())
+    }
+
+    #[test]
+    fn identical_small_values_do_not_differ() {
+        let a = list(vec![full("user.a", b"x"), full("user.b", b"yy")]);
+        let b = list(vec![full("user.a", b"x"), full("user.b", b"yy")]);
+        assert!(!xattr_diff(&a, &b, 0));
+    }
+
+    #[test]
+    fn differing_small_value_differs() {
+        let a = list(vec![full("user.a", b"x")]);
+        let b = list(vec![full("user.a", b"z")]);
+        assert!(xattr_diff(&a, &b, 0));
+    }
+
+    #[test]
+    fn differing_count_differs() {
+        let a = list(vec![full("user.a", b"x"), full("user.b", b"y")]);
+        let b = list(vec![full("user.a", b"x")]);
+        assert!(xattr_diff(&a, &b, 0));
+        assert!(xattr_diff(&b, &a, 0));
+    }
+
+    #[test]
+    fn differing_name_same_count_differs() {
+        let a = list(vec![full("user.a", b"x")]);
+        let b = list(vec![full("user.c", b"x")]);
+        assert!(xattr_diff(&a, &b, 0));
+    }
+
+    #[test]
+    fn empty_lists_do_not_differ() {
+        assert!(!xattr_diff(&list(vec![]), &list(vec![]), 0));
+    }
+
+    #[test]
+    fn large_value_matching_checksum_does_not_differ() {
+        // A value beyond MAX_FULL_DATUM: the sender carries only its checksum,
+        // the receiver the full datum. Matching content must not report a diff.
+        let big = vec![7u8; MAX_FULL_DATUM + 40];
+        let checksum = compute_xattr_checksum(&big, 0).to_vec();
+        let sender = list(vec![XattrEntry::abbreviated(
+            b"user.big".to_vec(),
+            checksum,
+            big.len(),
+        )]);
+        let receiver = list(vec![full("user.big", &big)]);
+        assert!(!xattr_diff(&sender, &receiver, 0));
+    }
+
+    #[test]
+    fn large_value_differing_content_differs() {
+        let sender_val = vec![7u8; MAX_FULL_DATUM + 40];
+        let receiver_val = vec![9u8; MAX_FULL_DATUM + 40];
+        let checksum = compute_xattr_checksum(&sender_val, 0).to_vec();
+        let sender = list(vec![XattrEntry::abbreviated(
+            b"user.big".to_vec(),
+            checksum,
+            sender_val.len(),
+        )]);
+        let receiver = list(vec![full("user.big", &receiver_val)]);
+        assert!(xattr_diff(&sender, &receiver, 0));
+    }
+
+    #[test]
+    fn large_value_differing_length_differs() {
+        let sender_val = vec![7u8; MAX_FULL_DATUM + 40];
+        let receiver_val = vec![7u8; MAX_FULL_DATUM + 41];
+        let checksum = compute_xattr_checksum(&sender_val, 0).to_vec();
+        let sender = list(vec![XattrEntry::abbreviated(
+            b"user.big".to_vec(),
+            checksum,
+            sender_val.len(),
+        )]);
+        let receiver = list(vec![full("user.big", &receiver_val)]);
+        assert!(xattr_diff(&sender, &receiver, 0));
+    }
+}

--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -32,12 +32,14 @@
 //! - Upstream rsync 3.4.4 `xattrs.c`
 
 mod cache;
+mod diff;
 mod entry;
 mod list;
 mod prefix;
 mod wire;
 
 pub use cache::XattrCache;
+pub use diff::xattr_diff;
 pub use entry::{XattrEntry, XattrState};
 pub use list::XattrList;
 pub use prefix::{is_rsync_internal, local_to_wire, wire_to_local};

--- a/crates/protocol/src/xattr/wire/encode.rs
+++ b/crates/protocol/src/xattr/wire/encode.rs
@@ -224,7 +224,7 @@ pub fn send_sender_xattr_response<W: Write>(
 /// - `xattrs.c:275-281` - `sum_init(xattr_sum_nni, checksum_seed)` over the datum.
 /// - `checksum.c:588-597` - `sum_init()` `CSUM_MD5` case: `md5_begin()`, no seed.
 /// - `compat.c:824-825` - `xattr_sum_nni` / `xattr_sum_len` fixed to md5 (16 bytes).
-pub(super) fn compute_xattr_checksum(
+pub(crate) fn compute_xattr_checksum(
     data: &[u8],
     checksum_seed: i32,
 ) -> [u8; MAX_XATTR_DIGEST_LEN] {

--- a/crates/protocol/src/xattr/wire/mod.rs
+++ b/crates/protocol/src/xattr/wire/mod.rs
@@ -18,5 +18,7 @@ mod tests;
 pub use decode::{
     checksum_matches, read_xattr_definitions, recv_xattr, recv_xattr_request, recv_xattr_values,
 };
+#[cfg(test)]
+pub(crate) use encode::compute_xattr_checksum;
 pub use encode::{send_sender_xattr_response, send_xattr, send_xattr_request, send_xattr_values};
 pub use types::{RecvXattrResult, XattrDefinition, XattrSet};

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -313,7 +313,14 @@ impl ReceiverContext {
                     // up-to-date file; the attr-comparison may still surface a
                     // metadata-only row (perms/owner/group differing while
                     // size+mtime match).
-                    let unchanged_iflags = self.itemize_existing_flags(entry, meta, 0);
+                    let mut unchanged_iflags = self.itemize_existing_flags(entry, meta, 0);
+                    // upstream: generator.c:566-572 - ITEM_REPORT_XATTR when the
+                    // destination's xattrs differ from the sender's. Computed on
+                    // the -X itemize path only (matching upstream's lazy
+                    // get_xattr) and before the apply below overwrites them.
+                    if emit_itemize && has_xattrs && self.dest_xattrs_differ(entry, &file_path) {
+                        unchanged_iflags |= crate::generator::ItemFlags::ITEM_REPORT_XATTR;
+                    }
                     self.apply_no_change_metadata(
                         writer,
                         idx,
@@ -634,6 +641,32 @@ impl ReceiverContext {
             }
         }
         iflags
+    }
+
+    /// Whether the destination's extended attributes differ from the sender's,
+    /// for the `ITEM_REPORT_XATTR` (`x`) itemize column.
+    ///
+    /// Mirrors upstream `generator.c:566-572`: with `preserve_xattrs` it reads
+    /// the destination's current xattrs (`get_xattr`) and compares them against
+    /// the received flist list (`xattr_diff`). Callers gate this on the `-X`
+    /// itemize path so the extra read matches upstream's lazy `get_xattr`, and
+    /// invoke it before applying the sender's xattrs so the comparison sees the
+    /// pre-transfer destination. A sender with no xattrs differs exactly when
+    /// the destination still carries some.
+    pub(in crate::receiver) fn dest_xattrs_differ(&self, entry: &FileEntry, path: &Path) -> bool {
+        let dest = match metadata::read_xattrs_for_wire(
+            path,
+            false,
+            metadata::am_root(),
+            self.checksum_seed,
+        ) {
+            Ok(list) => list,
+            Err(_) => return false,
+        };
+        match self.resolve_xattr_list(entry) {
+            Some(sender) => protocol::xattr::xattr_diff(&sender, &dest, self.checksum_seed),
+            None => !dest.is_empty(),
+        }
     }
 
     /// Emits the upstream size-bound SKIP notice for a candidate whose flist


### PR DESCRIPTION
An up-to-date file whose extended attributes differed from the sender's produced **no itemize row** on a remote `-a -X --itemize-changes` transfer. Upstream `generator.c:566-572` reads the destination's xattrs (`get_xattr`) and, when they differ from the received list (`xattr_diff`), sets `ITEM_REPORT_XATTR` — the `x` column — so the row prints `.f........x`.

## Fix

Adds `protocol::xattr::xattr_diff`, a faithful port of `xattrs.c:xattr_diff()`: a lockstep walk of the two name-sorted lists where a value ≤ `MAX_FULL_DATUM` (32) is compared byte-for-byte and a larger value is compared **by checksum** (the sender transmits only a checksum for large values, via the abbreviation protocol). The receiver wires it in on the up-to-date path, gated on `-X` and the itemize level so the extra `get_xattr` read matches upstream's lazy read, and runs it **before** applying the sender's xattrs so the comparison sees the pre-transfer destination.

## Verification (vs rsync 3.4.4 over SSH, all pairings)

| scenario | upstream | oc-rsync |
|---|---|---|
| xattr-only diff `-a -X -i` | `.f........x` | same (oc↔oc, oc↔up, up↔oc) |
| large (>32B) xattr diff `-X` | `.f........x` | same (checksum path) |
| identical xattrs `-X` | (no row) | same |
| xattr diff, no `-X` | (no row) | same |

Byte-identical in every pairing — proving it's a genuine fix on both oc's client and server sides. Adds `xattr_diff` unit tests (small/large/count/name/length); 90 transfer + 224 protocol lib tests pass; clippy clean.

Part of the remote-itemize family alongside the atime fix (#6912); ACL itemize (the `a` column) is tracked separately.