### PR TITLE
fix(cli): match upstream --out-format %u/%g/%N and unknown-code handling

### DIFF
--- a/crates/cli/src/frontend/out_format/parser.rs
+++ b/crates/cli/src/frontend/out_format/parser.rs
@@ -16,17 +16,24 @@ use super::tokens::{
 
 /// Parses the optional modifiers preceding a placeholder letter: apostrophes
 /// (humanization), an optional `-` (left align), and a digit run (width).
-fn parse_placeholder_format(chars: &mut Peekable<Chars<'_>>) -> PlaceholderFormat {
+///
+/// Every consumed modifier char is appended to `raw` so the caller can
+/// reproduce the escape verbatim when the trailing letter turns out to be
+/// unrecognized (upstream emits such an escape literally).
+fn parse_placeholder_format(
+    chars: &mut Peekable<Chars<'_>>,
+    raw: &mut String,
+) -> PlaceholderFormat {
     let mut apostrophes = 0usize;
     while matches!(chars.peek(), Some('\'')) {
         apostrophes += 1;
-        chars.next();
+        raw.push(chars.next().expect("peeked apostrophe"));
     }
 
     let mut align = PlaceholderAlignment::Right;
     if matches!(chars.peek(), Some('-')) {
         align = PlaceholderAlignment::Left;
-        chars.next();
+        raw.push(chars.next().expect("peeked '-'"));
     }
 
     let mut width_value: usize = 0;
@@ -37,7 +44,7 @@ fn parse_placeholder_format(chars: &mut Peekable<Chars<'_>>) -> PlaceholderForma
             width_value = width_value
                 .saturating_mul(10)
                 .saturating_add(digit as usize);
-            chars.next();
+            raw.push(chars.next().expect("peeked digit"));
         } else {
             break;
         }
@@ -45,7 +52,7 @@ fn parse_placeholder_format(chars: &mut Peekable<Chars<'_>>) -> PlaceholderForma
 
     while matches!(chars.peek(), Some('\'')) {
         apostrophes += 1;
-        chars.next();
+        raw.push(chars.next().expect("peeked apostrophe"));
     }
 
     let width = if saw_width {
@@ -81,7 +88,8 @@ pub(crate) fn parse_out_format(value: &OsStr) -> Result<OutFormat, Message> {
             continue;
         }
 
-        let format_spec = parse_placeholder_format(&mut chars);
+        let mut raw = String::from("%");
+        let format_spec = parse_placeholder_format(&mut chars, &mut raw);
         let Some(next) = chars.next() else {
             return Err(
                 rsync_error!(1, "--out-format value may not end with '%'").with_role(Role::Client)
@@ -93,13 +101,14 @@ pub(crate) fn parse_out_format(value: &OsStr) -> Result<OutFormat, Message> {
             continue;
         }
 
-        if !literal.is_empty() {
-            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
-        }
-
+        // upstream log.c:756 - a `%` escape whose letter has no case (and `%u`
+        // off-daemon, where `auth_user` is empty) leaves `n` NULL and is copied
+        // through verbatim. `%u` is the daemon auth user (handled by the daemon
+        // log formatter), never the file owner; `%g`/`%N` are not upstream
+        // codes. Emit any such escape literally instead of resolving an
+        // oc-specific owner/group/symlink placeholder or rejecting the format.
         let placeholder = match next {
             'n' => OutFormatPlaceholder::FileName,
-            'N' => OutFormatPlaceholder::FileNameWithSymlinkTarget,
             'f' => OutFormatPlaceholder::FullPath,
             'i' => OutFormatPlaceholder::ItemizedChanges,
             'l' => OutFormatPlaceholder::FileLength,
@@ -110,8 +119,6 @@ pub(crate) fn parse_out_format(value: &OsStr) -> Result<OutFormat, Message> {
             'B' => OutFormatPlaceholder::PermissionString,
             'L' => OutFormatPlaceholder::SymlinkTarget,
             't' => OutFormatPlaceholder::CurrentTime,
-            'u' => OutFormatPlaceholder::OwnerName,
-            'g' => OutFormatPlaceholder::GroupName,
             'U' => OutFormatPlaceholder::OwnerUid,
             'G' => OutFormatPlaceholder::OwnerGid,
             'p' => OutFormatPlaceholder::ProcessId,
@@ -121,13 +128,15 @@ pub(crate) fn parse_out_format(value: &OsStr) -> Result<OutFormat, Message> {
             'P' => OutFormatPlaceholder::ModulePath,
             'C' => OutFormatPlaceholder::FullChecksum,
             other => {
-                return Err(rsync_error!(
-                    1,
-                    format!("unsupported --out-format placeholder '%{other}'"),
-                )
-                .with_role(Role::Client));
+                raw.push(other);
+                literal.push_str(&raw);
+                continue;
             }
         };
+
+        if !literal.is_empty() {
+            tokens.push(OutFormatToken::Literal(std::mem::take(&mut literal)));
+        }
 
         tokens.push(OutFormatToken::Placeholder(PlaceholderToken::new(
             placeholder,
@@ -412,15 +421,15 @@ mod tests {
     }
 
     #[test]
-    fn parse_out_format_unsupported_placeholder_error() {
-        let result = parse_out_format(&os("%z"));
-        assert!(result.is_err());
+    fn parse_out_format_unrecognized_placeholder_is_literal() {
+        // upstream log.c:756 copies an unrecognized %escape through verbatim.
+        assert_single_literal("%z", "%z");
     }
 
     #[test]
     fn parse_placeholder_format_no_modifiers() {
         let mut chars = "n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.width(), None);
         assert_eq!(format.align(), PlaceholderAlignment::Right);
         assert_eq!(format.humanize(), HumanizeMode::None);
@@ -429,14 +438,14 @@ mod tests {
     #[test]
     fn parse_placeholder_format_width_only() {
         let mut chars = "15n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.width(), Some(15));
     }
 
     #[test]
     fn parse_placeholder_format_left_align_and_width() {
         let mut chars = "-20n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.width(), Some(20));
         assert_eq!(format.align(), PlaceholderAlignment::Left);
     }
@@ -444,7 +453,7 @@ mod tests {
     #[test]
     fn parse_placeholder_format_apostrophe_before_width() {
         let mut chars = "'10n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.width(), Some(10));
         assert_eq!(format.humanize(), HumanizeMode::Separator);
     }
@@ -452,7 +461,7 @@ mod tests {
     #[test]
     fn parse_placeholder_format_apostrophe_after_width() {
         let mut chars = "10'n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.width(), Some(10));
         assert_eq!(format.humanize(), HumanizeMode::Separator);
     }
@@ -460,7 +469,7 @@ mod tests {
     #[test]
     fn parse_placeholder_format_width_clamped() {
         let mut chars = "99999n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         // Width should be clamped to MAX_PLACEHOLDER_WIDTH
         assert!(format.width().unwrap() <= MAX_PLACEHOLDER_WIDTH);
     }
@@ -468,21 +477,21 @@ mod tests {
     #[test]
     fn parse_placeholder_format_zero_width() {
         let mut chars = "0n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.width(), Some(0));
     }
 
     #[test]
     fn parse_placeholder_format_two_apostrophes() {
         let mut chars = "''n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.humanize(), HumanizeMode::DecimalUnits);
     }
 
     #[test]
     fn parse_placeholder_format_three_apostrophes() {
         let mut chars = "'''n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.humanize(), HumanizeMode::BinaryUnits);
     }
 
@@ -490,7 +499,7 @@ mod tests {
     fn parse_placeholder_format_four_apostrophes() {
         // 4+ apostrophes should still be BinaryUnits
         let mut chars = "''''n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.humanize(), HumanizeMode::BinaryUnits);
     }
 
@@ -526,6 +535,16 @@ mod tests {
         }
     }
 
+    fn assert_single_literal(input: &str, expected: &str) {
+        let format = parse_out_format(&os(input)).unwrap_or_else(|_| panic!("parse {input}"));
+        let tokens: Vec<_> = format.tokens().collect();
+        assert_eq!(tokens.len(), 1, "expected 1 token for {input}");
+        match &tokens[0] {
+            OutFormatToken::Literal(text) => assert_eq!(text, expected, "for {input}"),
+            other => panic!("expected literal for {input}, got {other:?}"),
+        }
+    }
+
     #[test]
     fn parse_token_content_filename() {
         assert_single_placeholder("%n", OutFormatPlaceholder::FileName);
@@ -533,7 +552,8 @@ mod tests {
 
     #[test]
     fn parse_token_content_filename_with_symlink_target() {
-        assert_single_placeholder("%N", OutFormatPlaceholder::FileNameWithSymlinkTarget);
+        // upstream has no %N code; it passes through literally.
+        assert_single_literal("%N", "%N");
     }
 
     #[test]
@@ -588,12 +608,14 @@ mod tests {
 
     #[test]
     fn parse_token_content_owner_name() {
-        assert_single_placeholder("%u", OutFormatPlaceholder::OwnerName);
+        // %u is the daemon auth user; off-daemon it passes through literally.
+        assert_single_literal("%u", "%u");
     }
 
     #[test]
     fn parse_token_content_group_name() {
-        assert_single_placeholder("%g", OutFormatPlaceholder::GroupName);
+        // upstream has no %g code; it passes through literally.
+        assert_single_literal("%g", "%g");
     }
 
     #[test]
@@ -698,7 +720,7 @@ mod tests {
     #[test]
     fn parse_placeholder_format_apostrophe_before_and_after_width() {
         let mut chars = "'10'n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.width(), Some(10));
         // 1 apostrophe before + 1 after = 2 total = DecimalUnits
         assert_eq!(format.humanize(), HumanizeMode::DecimalUnits);
@@ -707,24 +729,21 @@ mod tests {
     #[test]
     fn parse_placeholder_format_two_before_one_after_width() {
         let mut chars = "''10'n".chars().peekable();
-        let format = parse_placeholder_format(&mut chars);
+        let format = parse_placeholder_format(&mut chars, &mut String::new());
         assert_eq!(format.width(), Some(10));
         // 2 apostrophes before + 1 after = 3 total = BinaryUnits
         assert_eq!(format.humanize(), HumanizeMode::BinaryUnits);
     }
 
     #[test]
-    fn parse_out_format_unsupported_placeholder_includes_letter_in_error() {
-        let err = parse_out_format(&os("%z")).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("%z"), "error should mention '%z', got: {msg}",);
+    fn parse_out_format_unrecognized_placeholder_keeps_modifiers() {
+        // The whole escape, including modifiers, is preserved verbatim.
+        assert_single_literal("%-10z", "%-10z");
     }
 
     #[test]
-    fn parse_out_format_unsupported_uppercase_placeholder_includes_letter() {
-        let err = parse_out_format(&os("%Q")).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("%Q"), "error should mention '%Q', got: {msg}",);
+    fn parse_out_format_unrecognized_uppercase_placeholder_is_literal() {
+        assert_single_literal("%Q", "%Q");
     }
 
     #[test]

--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -8,7 +8,7 @@
 use std::time::SystemTime;
 
 use crate::frontend::escape::escape_path;
-use crate::{LIST_TIMESTAMP_FORMAT, describe_event_kind, format_list_permissions, platform};
+use crate::{LIST_TIMESTAMP_FORMAT, describe_event_kind, format_list_permissions};
 use core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
 
 use crate::frontend::out_format::tokens::{
@@ -51,17 +51,6 @@ pub(super) fn render_placeholder_value(
     let allow_8bit = context.eight_bit_output;
     match spec.kind {
         OutFormatPlaceholder::FileName => Some(render_path(event, true, allow_8bit)),
-        OutFormatPlaceholder::FileNameWithSymlinkTarget => {
-            let mut rendered = render_path(event, true, allow_8bit);
-            if let Some(target) = event
-                .metadata()
-                .and_then(ClientEntryMetadata::symlink_target)
-            {
-                rendered.extend_from_slice(symlink_target_connector(event).as_bytes());
-                rendered.extend_from_slice(&escape_path(target, allow_8bit));
-            }
-            Some(rendered)
-        }
         OutFormatPlaceholder::FullPath => Some(render_path(event, false, allow_8bit)),
         OutFormatPlaceholder::ItemizedChanges => {
             Some(format_itemized_changes(event, context.is_sender).into_bytes())
@@ -114,8 +103,6 @@ pub(super) fn render_placeholder_value(
                 .map(|width| vec![b' '; 4 + width.min(MAX_PLACEHOLDER_WIDTH)]),
         },
         OutFormatPlaceholder::CurrentTime => Some(format_current_timestamp().into_bytes()),
-        OutFormatPlaceholder::OwnerName => Some(format_owner_name(event.metadata()).into_bytes()),
-        OutFormatPlaceholder::GroupName => Some(format_group_name(event.metadata()).into_bytes()),
         OutFormatPlaceholder::OwnerUid => Some(
             event
                 .metadata()
@@ -262,28 +249,6 @@ fn format_out_format_permissions(metadata: Option<&ClientEntryMetadata>) -> Stri
         .unwrap_or_else(|| "---------".to_owned())
 }
 
-/// Resolves the owner name for a uid, falling back to the numeric string.
-fn format_owner_name(metadata: Option<&ClientEntryMetadata>) -> String {
-    metadata
-        .and_then(ClientEntryMetadata::uid)
-        .map_or_else(|| "0".to_owned(), resolve_user_name)
-}
-
-/// Resolves the group name for a gid, falling back to the numeric string.
-fn format_group_name(metadata: Option<&ClientEntryMetadata>) -> String {
-    metadata
-        .and_then(ClientEntryMetadata::gid)
-        .map_or_else(|| "0".to_owned(), resolve_group_name)
-}
-
-fn resolve_user_name(uid: u32) -> String {
-    platform::display_user_name(uid).unwrap_or_else(|| uid.to_string())
-}
-
-fn resolve_group_name(gid: u32) -> String {
-    platform::display_group_name(gid).unwrap_or_else(|| gid.to_string())
-}
-
 /// Formats the current wall-clock time using the list timestamp format.
 fn format_current_timestamp() -> String {
     let now = crate::frontend::local_time::to_local(SystemTime::now());
@@ -320,16 +285,6 @@ mod tests {
     #[test]
     fn format_out_format_permissions_none() {
         assert_eq!(format_out_format_permissions(None), "---------");
-    }
-
-    #[test]
-    fn format_owner_name_none() {
-        assert_eq!(format_owner_name(None), "0");
-    }
-
-    #[test]
-    fn format_group_name_none() {
-        assert_eq!(format_group_name(None), "0");
     }
 
     #[test]

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -60,7 +60,6 @@ impl PlaceholderToken {
 #[derive(Clone, Copy, Debug)]
 pub(super) enum OutFormatPlaceholder {
     FileName,
-    FileNameWithSymlinkTarget,
     FullPath,
     ItemizedChanges,
     FileLength,
@@ -71,8 +70,6 @@ pub(super) enum OutFormatPlaceholder {
     PermissionString,
     CurrentTime,
     SymlinkTarget,
-    OwnerName,
-    GroupName,
     OwnerUid,
     OwnerGid,
     ProcessId,

--- a/crates/cli/src/frontend/tests/out/acceptance.rs
+++ b/crates/cli/src/frontend/tests/out/acceptance.rs
@@ -11,9 +11,11 @@ fn out_format_argument_accepts_supported_placeholders() {
 }
 
 #[test]
-fn out_format_argument_rejects_unknown_placeholders() {
-    let error = parse_out_format(OsStr::new("%z")).unwrap_err();
-    assert!(error.to_string().contains("unsupported --out-format"));
+fn out_format_argument_passes_unknown_placeholders_through_literally() {
+    // upstream log.c:756 copies an unrecognized %escape through verbatim rather
+    // than rejecting the format string.
+    let format = parse_out_format(OsStr::new("%z")).expect("parse out-format");
+    assert!(!format.is_empty());
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/out/custom_format.rs
+++ b/crates/cli/src/frontend/tests/out/custom_format.rs
@@ -606,25 +606,20 @@ fn out_format_rejects_trailing_percent() {
 }
 
 #[test]
-fn out_format_rejects_unsupported_placeholder() {
-    let error = parse_out_format(OsStr::new("%z")).unwrap_err();
-    assert!(
-        error
-            .to_string()
-            .contains("unsupported --out-format placeholder")
-    );
+fn out_format_passes_unsupported_placeholder_through_literally() {
+    // upstream log.c:756 copies an unrecognized %escape through verbatim.
+    let format = parse_out_format(OsStr::new("%z")).expect("parse out-format");
+    assert!(!format.is_empty());
 }
 
 #[test]
-fn out_format_rejects_invalid_placeholders() {
-    let invalid_placeholders = vec!["%x", "%y", "%Q", "%@", "%#", "%$"];
+fn out_format_passes_unrecognized_placeholders_through_literally() {
+    let unrecognized = vec!["%x", "%y", "%Q", "%@", "%#", "%$"];
 
-    for placeholder in invalid_placeholders {
-        let error = parse_out_format(OsStr::new(placeholder)).unwrap_err();
-        assert!(
-            error.to_string().contains("unsupported --out-format"),
-            "Expected error for {placeholder}, got: {error}"
-        );
+    for placeholder in unrecognized {
+        let format = parse_out_format(OsStr::new(placeholder))
+            .unwrap_or_else(|error| panic!("expected literal passthrough for {placeholder}, got: {error}"));
+        assert!(!format.is_empty(), "expected a literal token for {placeholder}");
     }
 }
 

--- a/crates/cli/src/frontend/tests/out/custom_format.rs
+++ b/crates/cli/src/frontend/tests/out/custom_format.rs
@@ -617,9 +617,13 @@ fn out_format_passes_unrecognized_placeholders_through_literally() {
     let unrecognized = vec!["%x", "%y", "%Q", "%@", "%#", "%$"];
 
     for placeholder in unrecognized {
-        let format = parse_out_format(OsStr::new(placeholder))
-            .unwrap_or_else(|error| panic!("expected literal passthrough for {placeholder}, got: {error}"));
-        assert!(!format.is_empty(), "expected a literal token for {placeholder}");
+        let format = parse_out_format(OsStr::new(placeholder)).unwrap_or_else(|error| {
+            panic!("expected literal passthrough for {placeholder}, got: {error}")
+        });
+        assert!(
+            !format.is_empty(),
+            "expected a literal token for {placeholder}"
+        );
     }
 }
 

--- a/crates/cli/src/frontend/tests/out/identity.rs
+++ b/crates/cli/src/frontend/tests/out/identity.rs
@@ -3,7 +3,6 @@ use core::client::run_client;
 use std::fs;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use tempfile::tempdir;
-use uzers::{get_group_by_gid, get_user_by_uid, gid_t, uid_t};
 
 #[test]
 fn out_format_renders_permission_and_identity_placeholders() {
@@ -17,14 +16,6 @@ fn out_format_renders_permission_and_identity_placeholders() {
 
     let expected_uid = fs::metadata(&source).expect("source metadata").uid();
     let expected_gid = fs::metadata(&source).expect("source metadata").gid();
-    let expected_user = get_user_by_uid(expected_uid as uid_t).map_or_else(
-        || expected_uid.to_string(),
-        |user| user.name().to_string_lossy().into_owned(),
-    );
-    let expected_group = get_group_by_gid(expected_gid as gid_t).map_or_else(
-        || expected_gid.to_string(),
-        |group| group.name().to_string_lossy().into_owned(),
-    );
 
     let mut permissions = fs::metadata(&source)
         .expect("source metadata")
@@ -83,16 +74,18 @@ fn out_format_renders_permission_and_identity_placeholders() {
     assert_eq!(output, format!("{expected_gid}\n").as_bytes());
 
     output.clear();
+    // %u is the daemon auth user; off-daemon (client) it renders literally.
     parse_out_format(OsStr::new("%u"))
         .expect("parse %u")
         .render(event, &OutFormatContext::default(), &mut output)
         .expect("render %u");
-    assert_eq!(output, format!("{expected_user}\n").as_bytes());
+    assert_eq!(output, b"%u\n");
 
     output.clear();
+    // upstream has no %g code; it renders literally.
     parse_out_format(OsStr::new("%g"))
         .expect("parse %g")
         .render(event, &OutFormatContext::default(), &mut output)
         .expect("render %g");
-    assert_eq!(output, format!("{expected_group}\n").as_bytes());
+    assert_eq!(output, b"%g\n");
 }

--- a/crates/cli/src/frontend/tests/out/symlink.rs
+++ b/crates/cli/src/frontend/tests/out/symlink.rs
@@ -74,10 +74,12 @@ fn out_format_renders_combined_name_and_target_placeholder() {
         .expect("symlink event present");
 
     let mut output = Vec::new();
+    // upstream has no %N code (it uses %n for the name and %L for the ` -> `
+    // target); %N therefore renders literally.
     parse_out_format(OsStr::new("%N"))
         .expect("parse %N")
         .render(event, &OutFormatContext::default(), &mut output)
         .expect("render %N");
 
-    assert_eq!(output, b"src/link.txt -> file.txt\n");
+    assert_eq!(output, b"%N\n");
 }

--- a/crates/cli/src/platform.rs
+++ b/crates/cli/src/platform.rs
@@ -1,10 +1,7 @@
 //! Platform-specific helpers for user and group identity lookups.
 
 #[cfg(unix)]
-use uzers::{
-    get_group_by_gid, get_group_by_name, get_user_by_name, get_user_by_uid, gid_t as UsersGid,
-    uid_t as UsersUid,
-};
+use uzers::{get_group_by_name, get_user_by_name, gid_t as UsersGid, uid_t as UsersUid};
 
 #[cfg(unix)]
 #[allow(non_camel_case_types)]
@@ -32,19 +29,6 @@ pub(crate) const fn supports_group_name_lookup() -> bool {
 }
 
 #[cfg(unix)]
-fn to_owned<C>(value: C) -> Option<String>
-where
-    C: AsRef<std::ffi::OsStr>,
-{
-    let value = value.as_ref();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_string_lossy().into_owned())
-    }
-}
-
-#[cfg(unix)]
 #[inline]
 pub(crate) fn lookup_user_by_name(name: &str) -> Option<uid_t> {
     get_user_by_name(name).map(|user| user.uid())
@@ -68,30 +52,6 @@ pub(crate) fn lookup_group_by_name(_name: &str) -> Option<gid_t> {
     None
 }
 
-#[cfg(unix)]
-#[inline]
-pub(crate) fn display_user_name(uid: u32) -> Option<String> {
-    get_user_by_uid(uid as uid_t).and_then(|user| to_owned(user.name()))
-}
-
-#[cfg(not(unix))]
-#[inline]
-pub(crate) fn display_user_name(_uid: u32) -> Option<String> {
-    None
-}
-
-#[cfg(unix)]
-#[inline]
-pub(crate) fn display_group_name(gid: u32) -> Option<String> {
-    get_group_by_gid(gid as gid_t).and_then(|group| to_owned(group.name()))
-}
-
-#[cfg(not(unix))]
-#[inline]
-pub(crate) fn display_group_name(_gid: u32) -> Option<String> {
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,14 +72,12 @@ mod tests {
         let user = get_user_by_uid(uid).expect("current user should exist");
         let name = user.name().to_string_lossy().into_owned();
         assert_eq!(lookup_user_by_name(&name), Some(uid));
-        assert_eq!(display_user_name(uid), Some(name));
     }
 
     #[cfg(not(unix))]
     #[test]
     fn user_lookup_returns_none_on_non_unix() {
         assert_eq!(lookup_user_by_name("any"), None);
-        assert_eq!(display_user_name(0), None);
     }
 
     #[cfg(unix)]
@@ -129,13 +87,11 @@ mod tests {
         let group = get_group_by_gid(gid).expect("current group should exist");
         let name = group.name().to_string_lossy().into_owned();
         assert_eq!(lookup_group_by_name(&name), Some(gid));
-        assert_eq!(display_group_name(gid), Some(name));
     }
 
     #[cfg(not(unix))]
     #[test]
     fn group_lookup_returns_none_on_non_unix() {
         assert_eq!(lookup_group_by_name("any"), None);
-        assert_eq!(display_group_name(0), None);
     }
 }


### PR DESCRIPTION
The client `--out-format` parser diverged from upstream in three ways: it mapped `%u` to the file **owner name**, `%g` to the **group name**, and `%N` to filename-plus-symlink-target, and it **rejected** any other unrecognized `%escape`. Upstream rsync (`log.c`) does none of this:
- `%u` is the **daemon auth user** — empty on the client, where `log.c:756` (`if (!n) continue`) copies the escape through **verbatim**.
- There is **no `%g` and no `%N`** code.
- An unrecognized escape is emitted **literally**, never rejected.

## Fix

Drop the `%u`=owner, `%g`, and `%N` placeholder mappings and emit any unrecognized escape — including its modifiers — literally. `%U` (uid) and `%G` (gid) are unchanged, and the daemon log formatter (`daemon/sections/log_format.rs`) already renders `%u` as the authenticated user. The owner/group name lookup helpers (`format_owner_name`, `format_group_name`, `display_user_name`, `display_group_name`) that only backed the removed placeholders are deleted.

## Verification (vs rsync 3.4.4)

`--out-format="u=[%u] g=[%g] N=[%N] z=[%z]"`:

| | output |
|---|---|
| upstream | `u=[%u] g=[%g] N=[%N] z=[%z]` |
| oc-rsync | `u=[%u] g=[%g] N=[%N] z=[%z]` |

Byte-identical. All 1096 cli out-format/parser/placeholder/platform tests pass; clippy clean. Implements the strict-fidelity decision for the `%u` divergence.