### PR TITLE
feat(core): render --out-format for SSH pull transfers

### DIFF
--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -203,13 +203,22 @@ fn run_pull_transfer(
     let progress: Option<&mut dyn TransferProgressCallback> = adapter
         .as_mut()
         .map(|a| a as &mut dyn TransferProgressCallback);
-    // Pull renders per-file output through the receiver, not this generator
-    // callback, so client-side out-format collection is a later increment.
-    let (server_stats, negotiated_protocol, _events) =
-        run_server_over_ssh_connection(server_config, connection, progress, batch_ctx, false)?;
+    // A custom `--out-format` makes the receiver buffer metadata events that the
+    // CLI renders; otherwise the receiver prints its own default `-v`/`-i` output
+    // to stdout and no events are collected.
+    let (server_stats, negotiated_protocol, events) = run_server_over_ssh_connection(
+        server_config,
+        connection,
+        progress,
+        batch_ctx,
+        config.render_out_format_locally(),
+    )?;
     let elapsed = start.elapsed();
 
     let mut summary = convert_server_stats_to_summary(server_stats, elapsed);
+    if !events.is_empty() {
+        summary = summary.with_events(events);
+    }
     summary.set_protocol_version(negotiated_protocol);
     Ok(summary)
 }
@@ -450,13 +459,21 @@ fn run_server_over_ssh_connection(
     // the iflags the remote receiver's generator writes over the wire,
     // generator.c:583-599) or, under plain `-v`, the bare `%n%L` name. The
     // remote generator never forwards either itself (log.c:822 gates FCLIENT on
-    // `!am_server`). On a pull the local side is the receiver, which prints via
-    // receiver::emit_itemize / emit_name, so no sender callback is needed there.
-    // A custom `--out-format` also wants the per-file rows even without `-v`/`-i`
-    // so the client can render them; otherwise honor the plain verbose/itemize
-    // gates (upstream: sender.c:215 `itemizing = stdout_format_has_i`).
-    let wants_client_output = config.role == ServerRole::Generator
-        && (config.flags.info_flags.itemize || config.flags.verbose || render_out_format_locally);
+    // `!am_server`). A custom `--out-format` also wants the per-file rows even
+    // without `-v`/`-i` so the client can render them; otherwise honor the plain
+    // verbose/itemize gates (upstream: sender.c:215 `itemizing =
+    // stdout_format_has_i`).
+    //
+    // On a pull the local side is the receiver, which prints its own default
+    // `-v`/`-i` output to stdout and needs no callback - EXCEPT under a custom
+    // `--out-format`, where it buffers metadata events the CLI renders, drained
+    // into this callback after the receive loop (transfer/lib.rs receiver branch).
+    let wants_client_output = match config.role {
+        ServerRole::Generator => {
+            config.flags.info_flags.itemize || config.flags.verbose || render_out_format_locally
+        }
+        ServerRole::Receiver => render_out_format_locally,
+    };
     let mut itemize_sink = ItemizeEventSink::new(render_out_format_locally);
 
     let transfer_result = crate::server::run_server_with_handshake(

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -175,6 +175,14 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
     // mode while the local copy executor honoured -E.
     server_config.flags.preserve_executability = config.preserve_executability();
 
+    // A custom `--out-format` makes the local receiver buffer a metadata event
+    // per logged entry (instead of writing its own itemize string) so the client
+    // can render the template - the pull counterpart of the sender-side flag set
+    // for a push (see InfoFlags::out_format_active). The SSH pull driver drains
+    // and renders these; a path that sets this without draining would suppress
+    // the receiver's default output, so keep the two wired together.
+    server_config.flags.info_flags.out_format_active = config.render_out_format_locally();
+
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
 }

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -194,7 +194,9 @@ pub use pipeline::{
     DEFAULT_PIPELINE_WINDOW, MAX_PIPELINE_WINDOW, MIN_PIPELINE_WINDOW, PendingTransfer,
     PipelineConfig, PipelineState,
 };
-pub use progress::{ItemizeCallback, ItemizeRow, TransferProgressCallback, TransferProgressEvent};
+pub use progress::{
+    ItemizeCallback, ItemizeRow, OwnedItemizeRow, TransferProgressCallback, TransferProgressEvent,
+};
 pub use transfer_state::{InvalidTransition, TransferPhase, TransferPipeline};
 
 /// Batch recording configuration for protocol stream teeing.
@@ -899,6 +901,17 @@ pub fn run_server_with_handshake_adopting<W: Write>(
             // wire bytes, not the post-decompression literal byte total.
             stats.bytes_received =
                 bytes_received_counter.load(std::sync::atomic::Ordering::Relaxed);
+
+            // A custom `--out-format` on a pull buffered its per-file rows as
+            // metadata events (the receiver suppressed its own stdout). Hand each
+            // one to the client callback in flist-index order so the CLI renders
+            // the user's template - mirroring how the push sender feeds the same
+            // callback. No-op unless the client set `out_format_active`.
+            if let Some(cb) = itemize {
+                for row in ctx.drain_event_rows() {
+                    cb.on_itemize_row(&row.as_row());
+                }
+            }
 
             Ok(ServerStats::Receiver(stats))
         }

--- a/crates/transfer/src/progress.rs
+++ b/crates/transfer/src/progress.rs
@@ -117,3 +117,66 @@ pub struct ItemizeRow<'a> {
     /// Whether the row reports a deletion (`ITEM_DELETED`).
     pub is_deletion: bool,
 }
+
+/// Owned counterpart of [`ItemizeRow`] for buffering a client-visible row until
+/// the end of a transfer.
+///
+/// A pulling client's receiver renders its itemize rows in flist-index order and
+/// only flushes them after the transfer loop finishes (see the receiver's
+/// `event_rows` buffer). The borrowed [`ItemizeRow`] cannot outlive the
+/// per-entry `FileEntry`, so the owned fields are copied here and re-borrowed via
+/// [`OwnedItemizeRow::as_row`] when the callback is finally invoked.
+#[derive(Debug, Clone)]
+pub struct OwnedItemizeRow {
+    /// Owned copy of [`ItemizeRow::line`].
+    pub line: String,
+    /// Owned copy of [`ItemizeRow::itemize`].
+    pub itemize: String,
+    /// Owned copy of [`ItemizeRow::name`].
+    pub name: std::path::PathBuf,
+    /// See [`ItemizeRow::size`].
+    pub size: u64,
+    /// See [`ItemizeRow::mtime`].
+    pub mtime: i64,
+    /// See [`ItemizeRow::mtime_nsec`].
+    pub mtime_nsec: u32,
+    /// See [`ItemizeRow::mode`].
+    pub mode: u32,
+    /// See [`ItemizeRow::uid`].
+    pub uid: Option<u32>,
+    /// See [`ItemizeRow::gid`].
+    pub gid: Option<u32>,
+    /// See [`ItemizeRow::is_dir`].
+    pub is_dir: bool,
+    /// See [`ItemizeRow::is_symlink`].
+    pub is_symlink: bool,
+    /// Owned copy of [`ItemizeRow::symlink_target`].
+    pub symlink_target: Option<std::path::PathBuf>,
+    /// See [`ItemizeRow::is_new`].
+    pub is_new: bool,
+    /// See [`ItemizeRow::is_deletion`].
+    pub is_deletion: bool,
+}
+
+impl OwnedItemizeRow {
+    /// Borrows the owned fields into an [`ItemizeRow`] for a callback invocation.
+    #[must_use]
+    pub fn as_row(&self) -> ItemizeRow<'_> {
+        ItemizeRow {
+            line: &self.line,
+            itemize: &self.itemize,
+            name: &self.name,
+            size: self.size,
+            mtime: self.mtime,
+            mtime_nsec: self.mtime_nsec,
+            mode: self.mode,
+            uid: self.uid,
+            gid: self.gid,
+            is_dir: self.is_dir,
+            is_symlink: self.is_symlink,
+            symlink_target: self.symlink_target.as_deref(),
+            is_new: self.is_new,
+            is_deletion: self.is_deletion,
+        }
+    }
+}

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -289,6 +289,17 @@ pub struct ReceiverContext {
     /// redo re-itemizing an entry. `RefCell` suffices: every emit site runs on
     /// the main driver thread (rayon workers never touch this).
     pub(in crate::receiver) itemize_rows: RefCell<BTreeMap<usize, Vec<String>>>,
+    /// Metadata-bearing itemize rows keyed by flist index, collected instead of
+    /// [`Self::itemize_rows`] when a custom `--out-format` is active on a pulling
+    /// client (`info_flags.out_format_active` and `client_mode`). Drained in
+    /// ascending key order after the transfer by the SSH/daemon driver, which
+    /// hands each row to the client `ItemizeCallback` so the CLI renders the
+    /// user's template - the receiver's own stdout string path is suppressed in
+    /// this mode. Upstream renders `--out-format` inline via `log_item`; oc-rsync
+    /// routes the raw fields to the CLI's out-format layer to preserve crate
+    /// layering (`cli -> core -> transfer`).
+    pub(in crate::receiver) event_rows:
+        RefCell<BTreeMap<usize, Vec<crate::progress::OwnedItemizeRow>>>,
     /// When set, plain `-v` (name-only, no `-i`) client-mode file names are
     /// emitted in flist-index order as each file is reached in the transfer
     /// loop - interleaved with `--progress` - instead of being buffered in the
@@ -420,6 +431,7 @@ impl ReceiverContext {
             hardlink_lookahead_target: 500,
             defer_itemize: false,
             itemize_rows: RefCell::new(BTreeMap::new()),
+            event_rows: RefCell::new(BTreeMap::new()),
             interleave_names: false,
             name_rows: RefCell::new(BTreeMap::new()),
             names_to_stderr: false,

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -17,7 +17,12 @@ impl ReceiverContext {
     /// and the push row is printed by the client's sender instead.
     #[must_use]
     pub(in crate::receiver) const fn should_emit_itemize(&self) -> bool {
-        self.config.flags.info_flags.itemize
+        // A custom `--out-format` on a pull also drives one client-visible row
+        // per logged entry (upstream `log_item` fires whenever `stdout_format`
+        // is set, log.c:822), so the same itemize call sites must run; the row
+        // is then collected as an event rather than written as a string (see
+        // [`Self::record_itemize`] / [`Self::collect_out_format_events`]).
+        self.config.flags.info_flags.itemize || self.collect_out_format_events()
     }
 
     /// Classifies the received file list into the per-type counts the pulling
@@ -252,6 +257,29 @@ impl ReceiverContext {
         iflags: &crate::generator::ItemFlags,
         entry: &protocol::flist::FileEntry,
     ) -> Option<String> {
+        let effective_iflags = self.itemize_effective_flags(iflags, entry)?;
+        let ctx = self.itemize_context();
+        Some(crate::generator::itemize::format_itemize_line(
+            &effective_iflags,
+            entry,
+            self.itemize_is_sender(),
+            &ctx,
+            None,
+        ))
+    }
+
+    /// Applies the created-root override and the significance gate to raw item
+    /// flags, returning the effective flags to render or `None` when the entry
+    /// is unchanged and unchanged rows are not requested.
+    ///
+    /// Shared by [`Self::render_itemize_line`] (default string output) and
+    /// [`Self::build_event_row`] (custom `--out-format` events) so both apply an
+    /// identical gate and glyph.
+    fn itemize_effective_flags(
+        &self,
+        iflags: &crate::generator::ItemFlags,
+        entry: &protocol::flist::FileEntry,
+    ) -> Option<crate::generator::ItemFlags> {
         // upstream: main.c:803-805 - when the receiver pre-flight-mkdirs the
         // destination root, `flist->files[0]->flags |= FLAG_DIR_CREATED`. The
         // generator's `itemize()` then sees `statret < 0` for the root entry,
@@ -273,7 +301,7 @@ impl ReceiverContext {
         if !is_created_root_dir && !show_unchanged && !iflags.has_significant_flags() {
             return None;
         }
-        let effective_iflags = if is_created_root_dir {
+        Some(if is_created_root_dir {
             // upstream: generator.c:1480-1483 + generator.c:573-579 - a root that
             // the pre-flight mkdir created this run is itemize()'d with
             // `statret < 0`, which takes the `else` branch and ORs
@@ -288,27 +316,81 @@ impl ReceiverContext {
             )
         } else {
             *iflags
-        };
+        })
+    }
+
+    /// Direction of the `%i` glyph for this receiver.
+    ///
+    /// upstream: log.c:707-710 - the direction glyph is `<` when
+    /// `!local_server && *op == 's'` (this side's peer is the sender's client)
+    /// and `>` otherwise. `op` is `am_sender ? "send" : "recv"` (log.c:820), and
+    /// the client-visible itemize is always produced by the non-`am_server`
+    /// side. A server-mode receiver is only ever the remote end of a push (the
+    /// client is the sender), so it renders `<`; a client-mode receiver is a
+    /// local pull and renders `>`.
+    const fn itemize_is_sender(&self) -> bool {
+        !self.config.connection.client_mode
+    }
+
+    /// Whether a custom `--out-format` should collect metadata-bearing events
+    /// for the CLI to render instead of writing the receiver's own itemize
+    /// string to stdout. True only on a pulling client (`client_mode`) with
+    /// `info_flags.out_format_active` set.
+    pub(in crate::receiver) const fn collect_out_format_events(&self) -> bool {
+        self.config.flags.info_flags.out_format_active && self.config.connection.client_mode
+    }
+
+    /// Builds the owned metadata row for a custom `--out-format` event, applying
+    /// the same significance gate and `%i` glyph as [`Self::render_itemize_line`].
+    ///
+    /// The receiver-side generator computes iflags locally rather than reading
+    /// them off the wire, so no alternate-basis xname is available; the
+    /// hard-link ` => leader` suffix is owned by the push sender renderer.
+    fn build_event_row(
+        &self,
+        iflags: &crate::generator::ItemFlags,
+        entry: &protocol::flist::FileEntry,
+    ) -> Option<crate::progress::OwnedItemizeRow> {
+        let effective_iflags = self.itemize_effective_flags(iflags, entry)?;
         let ctx = self.itemize_context();
-        // upstream: log.c:707-710 - the direction glyph is `<` when
-        // `!local_server && *op == 's'` (this side's peer is the sender's
-        // client) and `>` otherwise. `op` is `am_sender ? "send" : "recv"`
-        // (log.c:820), and the client-visible itemize is always produced by the
-        // non-`am_server` side. A server-mode receiver is only ever the remote
-        // end of a push (the client is the sender), so it renders `<`; a
-        // client-mode receiver is a local pull and renders `>`.
-        let is_sender = !self.config.connection.client_mode;
-        // The receiver-side generator computes iflags locally rather than reading
-        // them off the wire, so no alternate-basis xname is available here; the
-        // hard-link ` => leader` suffix is owned by the push sender renderer
-        // (generator/transfer/transfer_loop.rs::maybe_emit_itemize).
-        Some(crate::generator::itemize::format_itemize_line(
+        let is_sender = self.itemize_is_sender();
+        let line = crate::generator::itemize::format_itemize_line(
             &effective_iflags,
             entry,
             is_sender,
             &ctx,
             None,
-        ))
+        );
+        let itemize =
+            crate::generator::itemize::format_iflags(&effective_iflags, entry, is_sender, &ctx);
+        let raw = effective_iflags.raw();
+        Some(crate::progress::OwnedItemizeRow {
+            line,
+            itemize,
+            name: entry.path().to_path_buf(),
+            size: entry.size(),
+            mtime: entry.mtime(),
+            mtime_nsec: entry.mtime_nsec(),
+            mode: entry.mode(),
+            uid: entry.uid(),
+            gid: entry.gid(),
+            is_dir: entry.is_dir(),
+            is_symlink: entry.is_symlink(),
+            symlink_target: entry.link_target().cloned(),
+            is_new: raw & crate::generator::ItemFlags::ITEM_IS_NEW != 0,
+            is_deletion: raw & crate::generator::ItemFlags::ITEM_DELETED != 0,
+        })
+    }
+
+    /// Drains every buffered `--out-format` event row in ascending flist-index
+    /// order (the same order [`Self::flush_itemize_rows`] uses for strings).
+    /// Called once by the client driver after the transfer, which hands each row
+    /// to the `ItemizeCallback` so the CLI renders the user's template.
+    pub(crate) fn drain_event_rows(&self) -> Vec<crate::progress::OwnedItemizeRow> {
+        std::mem::take(&mut *self.event_rows.borrow_mut())
+            .into_values()
+            .flatten()
+            .collect()
     }
 
     /// Emits itemize output for a file entry to the client-visible sink.
@@ -335,6 +417,15 @@ impl ReceiverContext {
         entry: &protocol::flist::FileEntry,
     ) -> std::io::Result<()> {
         if !self.should_emit_itemize() {
+            return Ok(());
+        }
+        // A custom `--out-format` renders through the CLI from collected events
+        // (see [`Self::collect_out_format_events`]); the receiver's own default
+        // string must not also reach stdout. This immediate path carries no
+        // flist index, so device/FIFO/hardlink-follower rows are suppressed
+        // rather than collected - they already produced no client-visible row
+        // without `-i`, so no default output is lost.
+        if self.collect_out_format_events() {
             return Ok(());
         }
         let Some(line) = self.render_itemize_line(iflags, entry) else {
@@ -462,7 +553,7 @@ impl ReceiverContext {
         iflags: &crate::generator::ItemFlags,
         entry: &protocol::flist::FileEntry,
     ) -> std::io::Result<()> {
-        if self.defer_itemize {
+        if self.defer_itemize || self.collect_out_format_events() {
             self.record_itemize(flist_idx, iflags, entry);
             Ok(())
         } else {
@@ -486,7 +577,23 @@ impl ReceiverContext {
         iflags: &crate::generator::ItemFlags,
         entry: &protocol::flist::FileEntry,
     ) {
-        if !self.should_emit_itemize() || !self.config.connection.client_mode {
+        if !self.config.connection.client_mode {
+            return;
+        }
+        // Custom `--out-format`: buffer the metadata-bearing event instead of the
+        // rendered default string (mutually exclusive - the string path is
+        // suppressed so the CLI renders the user's template from these events).
+        if self.collect_out_format_events() {
+            if let Some(row) = self.build_event_row(iflags, entry) {
+                self.event_rows
+                    .borrow_mut()
+                    .entry(flist_idx)
+                    .or_default()
+                    .push(row);
+            }
+            return;
+        }
+        if !self.should_emit_itemize() {
             return;
         }
         if let Some(line) = self.render_itemize_line(iflags, entry) {
@@ -529,6 +636,13 @@ impl ReceiverContext {
     /// off the client.
     fn emit_name_line(&self, line: &str) -> std::io::Result<()> {
         use std::io::Write as _;
+        // Under a custom `--out-format`, upstream logs exactly one templated line
+        // per entry via `log_item`; the plain `-v` name would double it. The
+        // per-entry line is produced from collected events instead (see
+        // [`Self::collect_out_format_events`]).
+        if self.collect_out_format_events() {
+            return Ok(());
+        }
         if self.names_to_stderr {
             std::io::stderr().write_all(line.as_bytes())
         } else {

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -197,6 +197,65 @@ fn emit_itemize_client_mode_uses_stdout_not_msg_info() {
 }
 
 #[test]
+fn out_format_collects_events_and_suppresses_string_path() {
+    // A pulling client with a custom `--out-format` (out_format_active, no `-i`)
+    // buffers a metadata-bearing event per logged entry instead of writing its
+    // own itemize string, so the CLI can render the user's template. The default
+    // string buffer stays empty and the drained event carries the raw fields
+    // plus the client-direction (`>`) `%i` glyph.
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.info_flags.itemize = false;
+    config.flags.info_flags.out_format_active = true;
+    config.connection.client_mode = true;
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let entry = FileEntry::new_file("docs/readme.txt".into(), 1024, 0o644);
+    let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
+
+    ctx.record_itemize(3, &iflags, &entry);
+
+    // String path suppressed; event path populated.
+    assert!(ctx.itemize_rows.borrow().is_empty());
+    let rows = ctx.drain_event_rows();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row.name, std::path::Path::new("docs/readme.txt"));
+    assert_eq!(row.size, 1024);
+    // Full mode (type + perms) is carried so the CLI can render `%B`/`%M`.
+    assert_eq!(row.mode, 0o100_644);
+    assert_eq!(row.mode & 0o777, 0o644);
+    assert!(row.is_new);
+    assert!(!row.is_dir);
+    // upstream log.c:707-710 - a client-mode (pull) receiver renders the `>`
+    // receive-direction glyph; the string is the fixed 11-char `%i`.
+    assert_eq!(row.itemize.len(), 11);
+    assert!(row.itemize.starts_with(">f"), "itemize = {:?}", row.itemize);
+    // Drain is idempotent (buffer taken).
+    assert!(ctx.drain_event_rows().is_empty());
+}
+
+#[test]
+fn out_format_inactive_uses_string_path() {
+    // Without out_format_active the pull receiver keeps its default behaviour:
+    // `-i` rows buffer as strings and no events are collected.
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.info_flags.itemize = true;
+    config.flags.info_flags.out_format_active = false;
+    config.connection.client_mode = true;
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let entry = FileEntry::new_file("test.txt".into(), 100, 0o644);
+    let iflags = ItemFlags::from_raw(ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW);
+
+    ctx.record_itemize(0, &iflags, &entry);
+
+    assert!(ctx.drain_event_rows().is_empty());
+    assert_eq!(ctx.itemize_rows.borrow().len(), 1);
+}
+
+#[test]
 fn emit_itemize_skipped_without_itemize_flag() {
     let handshake = test_handshake();
     let mut config = test_config();


### PR DESCRIPTION
## Summary

On an SSH pull the local receiver renders per-file output to its own stdout, so a custom `--out-format` template was silently ignored: the receiver emitted its default `%i %n` rows (or nothing) while the CLI's out-format layer got an empty event set. A pull with `--out-format='%o %n'` therefore printed nothing, where upstream prints one templated line per file. This is the pull counterpart of the earlier push fix.

## Approach

The receiver now buffers a metadata-bearing event per logged entry (keyed by flist index — the same ordering its string rows already use) whenever `InfoFlags::out_format_active` is set on a pulling client, suppressing its own stdout string path. The SSH pull driver drains these events after the receive loop and feeds them to the client `ItemizeCallback`, so the CLI renders the user's template through the existing out-format path.

This mirrors upstream's **data flow** (per-file fields → the client-visible log line) but not its inline `log_item` rendering, preserving oc-rsync's crate layering (`cli → core → transfer`) — the receiver cannot depend on the CLI's out-format renderer.

- `should_emit_itemize()` fires under `out_format_active` too, so every itemize call site runs (mirroring upstream gating `log_item` on `stdout_format`); the plain `-v` name path is suppressed in this mode so the template line is not doubled.
- New `OwnedItemizeRow` (owned mirror of `ItemizeRow`) buffers rows until end-of-transfer; `drain_event_rows` yields them in flist order.

## Scope

Deferred file/directory/symlink rows are collected (the common case). The immediate device/FIFO/hardlink-follower itemize path carries no flist index and is left for a follow-up — it produced no client-visible row without `-i`, so no default output is lost.

## Verification

Against rsync 3.4.4 (protocol 32) over SSH pull, byte-for-byte identical output for:

- `--out-format='%o %n'`, `--out-format='%n'`, `--out-format='[%i] %n (%l)'`
- `-i` (unchanged), and an archive-mode delta re-sync (only the changed file logged)

`cargo fmt`, `cargo clippy --workspace --all-targets --all-features -D warnings`, and targeted nextest (transfer, cli out_format, core server_config/summary/events) all pass, including two new receiver tests covering the collect-vs-string paths.

## Follow-ups (out of scope)

SSH pull is increment 2; the daemon transport (same seam) and the device/FIFO/hardlink-follower rows remain.
