### PR TITLE
feat(core): render --out-format for daemon transfers

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -208,6 +208,12 @@ fn apply_common_daemon_config(
     server_config.connection.filter_rules = filter_rules;
 
     server_config.flags.verbose = config.verbosity() > 0;
+    // A custom `--out-format` makes the local sender/receiver emit one
+    // metadata-bearing itemize event per logged entry so the CLI renders the
+    // template (see InfoFlags::out_format_active). The daemon push/pull drivers
+    // drain and render these; keep the two wired together so a config that sets
+    // this always has a draining driver.
+    server_config.flags.info_flags.out_format_active = config.render_out_format_locally();
 
     // upstream: numeric_ids and delete are --numeric-ids / --delete-* long-form args only.
     server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -3,7 +3,6 @@
 //! Orchestrates the transfer lifecycle by configuring server infrastructure,
 //! establishing the handshake result, and delegating to `run_server_with_handshake`.
 
-use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
@@ -21,6 +20,7 @@ use crate::client::progress::ClientProgressObserver;
 use crate::client::remote::batch_support::{BatchContext, build_batch_recording};
 use crate::client::remote::flags;
 use crate::client::remote::implied_source::implied_source_args_for_pull;
+use crate::client::remote::itemize_sink::ItemizeEventSink;
 use crate::client::summary::ClientSummary;
 use crate::exit_code::ExitCode;
 use crate::message::Role;
@@ -111,6 +111,17 @@ pub(crate) fn run_pull_transfer(
     // adopt it and re-apply to the live socket. Build the re-apply hook from the
     // split socket halves; connect-program (pipe) transports yield None.
     let io_timeout_reapply = build_io_timeout_reapply(reader, writer);
+    // A custom `--out-format` makes the receiver buffer metadata events (it
+    // suppresses its own stdout); collect them for the CLI to render. Otherwise
+    // the receiver prints its own default `-v`/`-i` output and no callback is
+    // needed (mirrors the SSH pull driver).
+    let render_out_format = config.render_out_format_locally();
+    let mut itemize_sink = ItemizeEventSink::new(render_out_format);
+    let itemize: Option<&mut dyn crate::server::ItemizeCallback> = if render_out_format {
+        Some(&mut itemize_sink)
+    } else {
+        None
+    };
     let server_stats = crate::server::run_server_with_handshake_adopting(
         server_config,
         handshake,
@@ -119,7 +130,7 @@ pub(crate) fn run_pull_transfer(
         crate::server::ServerTransferHooks {
             progress,
             batch: batch_recording,
-            itemize: None,
+            itemize,
             io_timeout_reapply,
         },
     )
@@ -127,6 +138,10 @@ pub(crate) fn run_pull_transfer(
     let elapsed = start.elapsed();
 
     let mut summary = convert_server_stats_to_summary(server_stats, elapsed);
+    let events = itemize_sink.take_events();
+    if !events.is_empty() {
+        summary = summary.with_events(events);
+    }
     summary.set_protocol_version(protocol.as_u8());
     Ok(summary)
 }
@@ -187,13 +202,14 @@ pub(crate) fn run_push_transfer(
     // forwards oc's itemize.
     // upstream: sender.c:449 - plain `-v` (no `-i`) prints the bare `%n%L` name
     // per file too, so the callback must be wired whenever the sender has any
-    // client-visible per-file output, not only under `-i`.
-    let wants_client_output = config.itemize_changes() || config.verbosity() >= 1;
-    let stdout_handle = std::io::stdout();
-    let mut itemize_cb = move |line: &str| {
-        let mut out = stdout_handle.lock();
-        let _ = out.write_all(line.as_bytes());
-    };
+    // client-visible per-file output, not only under `-i`. A custom
+    // `--out-format` also wants the rows even without `-v`/`-i` so the client can
+    // render the template; the sink then collects metadata events instead of
+    // writing the default line (mirrors the SSH push driver).
+    let render_out_format = config.render_out_format_locally();
+    let wants_client_output =
+        config.itemize_changes() || config.verbosity() >= 1 || render_out_format;
+    let mut itemize_sink = ItemizeEventSink::new(render_out_format);
 
     let result = crate::server::run_server_with_handshake(
         server_config,
@@ -203,7 +219,7 @@ pub(crate) fn run_push_transfer(
         progress,
         batch_recording,
         if wants_client_output {
-            Some(&mut itemize_cb as &mut dyn crate::server::ItemizeCallback)
+            Some(&mut itemize_sink as &mut dyn crate::server::ItemizeCallback)
         } else {
             None
         },
@@ -213,6 +229,10 @@ pub(crate) fn run_push_transfer(
         Ok(server_stats) => {
             let elapsed = start.elapsed();
             let mut summary = convert_server_stats_to_summary(server_stats, elapsed);
+            let events = itemize_sink.take_events();
+            if !events.is_empty() {
+                summary = summary.with_events(events);
+            }
             summary.set_protocol_version(protocol.as_u8());
             Ok(summary)
         }

--- a/crates/core/src/client/remote/itemize_sink.rs
+++ b/crates/core/src/client/remote/itemize_sink.rs
@@ -1,0 +1,72 @@
+//! Client-visible itemize sink shared by the remote transports.
+//!
+//! On an SSH or daemon transfer the client's `--out-format` / `-v` / `-i` rows
+//! surface through a [`crate::server::ItemizeCallback`]. This sink routes each
+//! row to one of two destinations depending on whether a custom `--out-format`
+//! template is active.
+
+use std::io::Write;
+
+use super::super::summary::{ClientEvent, RemoteItemizeFields};
+
+/// Routes a transport's client-visible itemize rows to the right destination.
+///
+/// With a custom `--out-format` active (`collect`), each row is captured as a
+/// metadata-bearing [`ClientEvent`] so the CLI renders it through the same
+/// out-format path as a local transfer. Otherwise the server's pre-formatted
+/// line is written straight to stdout, preserving the default `-v`/`-i` output
+/// byte-for-byte (upstream `log_item(FCLIENT, ...)`).
+pub(crate) struct ItemizeEventSink {
+    collect: bool,
+    events: Vec<ClientEvent>,
+}
+
+impl ItemizeEventSink {
+    /// Creates a sink that collects events when `collect` is set, otherwise
+    /// writes each row's pre-formatted line to stdout.
+    pub(crate) const fn new(collect: bool) -> Self {
+        Self {
+            collect,
+            events: Vec::new(),
+        }
+    }
+
+    /// Takes the collected events, leaving the sink empty.
+    pub(crate) fn take_events(&mut self) -> Vec<ClientEvent> {
+        std::mem::take(&mut self.events)
+    }
+
+    fn write_line(line: &str) {
+        let mut out = std::io::stdout().lock();
+        let _ = out.write_all(line.as_bytes());
+    }
+}
+
+impl crate::server::ItemizeCallback for ItemizeEventSink {
+    fn on_itemize(&mut self, line: &str) {
+        Self::write_line(line);
+    }
+
+    fn on_itemize_row(&mut self, row: &crate::server::ItemizeRow<'_>) {
+        if self.collect {
+            self.events
+                .push(ClientEvent::from_remote_itemize(RemoteItemizeFields {
+                    relative_path: row.name.to_path_buf(),
+                    itemize: row.itemize.to_owned(),
+                    mode: row.mode,
+                    size: row.size,
+                    mtime: row.mtime,
+                    mtime_nsec: row.mtime_nsec,
+                    uid: row.uid,
+                    gid: row.gid,
+                    is_dir: row.is_dir,
+                    is_symlink: row.is_symlink,
+                    symlink_target: row.symlink_target.map(std::path::Path::to_path_buf),
+                    is_new: row.is_new,
+                    is_deletion: row.is_deletion,
+                }));
+        } else {
+            Self::write_line(row.line);
+        }
+    }
+}

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -34,6 +34,8 @@ pub(crate) mod flags;
 pub(crate) mod implied_source;
 /// Remote rsync `--server` invocation argument builder.
 pub mod invocation;
+/// Shared client-visible itemize sink for the remote transports.
+pub(crate) mod itemize_sink;
 /// `--info=`/`--debug=` server-argument construction (make_output_option).
 pub(crate) mod output_option;
 /// Remote-to-remote transfer via local proxy relay.

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -5,7 +5,7 @@
 //! server over the SSH pipes and reaps the remote child. This mirrors the flow
 //! in upstream `main.c:do_cmd()` / `main.c:client_run()`.
 
-use std::io::{BufReader, Write};
+use std::io::BufReader;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -20,12 +20,13 @@ use super::super::super::error::{
     ClientError, invalid_argument_error, invalid_argument_error_typed_with_role, remote_exit_error,
 };
 use super::super::super::progress::ClientProgressObserver;
-use super::super::super::summary::{ClientEvent, ClientSummary, RemoteItemizeFields};
+use super::super::super::summary::{ClientEvent, ClientSummary};
 use super::super::batch_support::{BatchContext, build_batch_context, build_batch_recording};
 use super::super::files_from_forwarding::read_local_files_from_for_forwarding;
 use super::super::flags;
 use super::super::implied_source::implied_source_args_for_pull;
 use super::super::invocation::{RemoteOperands, RemoteRole, TransferSpec, determine_transfer_role};
+use super::super::itemize_sink::ItemizeEventSink;
 use super::connection::build_ssh_connection;
 use super::exit_status::{
     convert_server_stats_to_summary, format_stderr_context, map_child_exit_status,
@@ -289,61 +290,6 @@ fn run_proxy_transfer(
     run_remote_to_remote_transfer(config, remote_sources, remote_dest)
 }
 
-/// Sink for the sender's client-visible itemize rows on an SSH push.
-///
-/// With a custom `--out-format` active (`collect`), each row is captured as a
-/// metadata-bearing [`ClientEvent`] so the CLI renders it through the same
-/// out-format path as a local transfer. Otherwise the server's pre-formatted
-/// line is written straight to stdout, preserving the default `-v`/`-i` output
-/// byte-for-byte (upstream `log_item(FCLIENT, ...)`).
-struct ItemizeEventSink {
-    collect: bool,
-    events: Vec<ClientEvent>,
-}
-
-impl ItemizeEventSink {
-    const fn new(collect: bool) -> Self {
-        Self {
-            collect,
-            events: Vec::new(),
-        }
-    }
-
-    fn write_line(line: &str) {
-        let mut out = std::io::stdout().lock();
-        let _ = out.write_all(line.as_bytes());
-    }
-}
-
-impl crate::server::ItemizeCallback for ItemizeEventSink {
-    fn on_itemize(&mut self, line: &str) {
-        Self::write_line(line);
-    }
-
-    fn on_itemize_row(&mut self, row: &crate::server::ItemizeRow<'_>) {
-        if self.collect {
-            self.events
-                .push(ClientEvent::from_remote_itemize(RemoteItemizeFields {
-                    relative_path: row.name.to_path_buf(),
-                    itemize: row.itemize.to_owned(),
-                    mode: row.mode,
-                    size: row.size,
-                    mtime: row.mtime,
-                    mtime_nsec: row.mtime_nsec,
-                    uid: row.uid,
-                    gid: row.gid,
-                    is_dir: row.is_dir,
-                    is_symlink: row.is_symlink,
-                    symlink_target: row.symlink_target.map(std::path::Path::to_path_buf),
-                    is_new: row.is_new,
-                    is_deletion: row.is_deletion,
-                }));
-        } else {
-            Self::write_line(row.line);
-        }
-    }
-}
-
 /// Runs server over an SSH connection using split read/write halves.
 ///
 /// This uses `SshConnection::split` to obtain separate reader and writer handles,
@@ -493,7 +439,7 @@ fn run_server_over_ssh_connection(
     // Close the writer to signal EOF so the remote process can exit.
     drop(writer);
 
-    let collected_events = std::mem::take(&mut itemize_sink.events);
+    let collected_events = itemize_sink.take_events();
 
     // upstream: main.c wait_process_with_flush() - wait for child and map status.
     let (child_exit_code, stderr_text) = match child_handle.wait_with_stderr() {


### PR DESCRIPTION
## Summary

Extends the remote `--out-format` rendering to the **daemon transport** — the counterpart of the SSH push (#6917) and pull (#6918) work. Previously:

- A daemon **push** wrote the server's default preformatted line straight to stdout via a plain `FnMut(&str)` sink, so a custom `--out-format` rendered the default `%i %n` format, not the user's template.
- A daemon **pull** passed no itemize callback at all, so `--out-format` was silently ignored.

## Approach

Both daemon drivers now route their client-visible rows through a shared `ItemizeEventSink`, extracted from the SSH driver into `remote/itemize_sink.rs` for reuse (DRY):

- With a custom `--out-format`, the sink captures each row as a metadata-bearing `ClientEvent` for the CLI's out-format renderer.
- Otherwise it writes the server's default line to stdout unchanged (byte-for-byte `-v`/`-i` output preserved).

`out_format_active` is set once in `apply_common_daemon_config`, so both the daemon generator (push) and receiver (pull) honour it — the generator emits rows via the existing gate (from the push work), and the receiver drains its buffered events into the callback (from the pull work). `wants_client_output` fires under a custom `--out-format` even without `-v`/`-i`.

## Verification

Against rsync 3.4.4 over a daemon connection, byte-for-byte identical output for both directions:

- **push**: `--out-format='%o %n'`, `--out-format='%n'`
- **pull**: `--out-format='%o %n'`, `-i`, `--out-format='[%i] %n (%l)'`

`cargo fmt`, `clippy --workspace --all-targets --all-features -D warnings`, and targeted nextest (core daemon/out_format/server_config, 320 tests) all pass.

## Follow-up (out of scope)

Upstream also prints `created directory <dest>` on a pull that creates the destination when itemize output is active (`INFO_GTE(NAME,1) || stdout_format_has_i`). oc's gate (`receiver/transfer/setup/context.rs`) currently checks only `info_flags.itemize`, so the notice is missing under a custom `--out-format` that carries `%i`. This is a shared receiver gate affecting both SSH and daemon pulls and will be fixed separately (needs `out_format_forwards_i` plumbed to the receiver's `InfoFlags`).
