### PR TITLE
fix(core): gate created directory notice on %i out-format

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -214,6 +214,10 @@ fn apply_common_daemon_config(
     // drain and render these; keep the two wired together so a config that sets
     // this always has a draining driver.
     server_config.flags.info_flags.out_format_active = config.render_out_format_locally();
+    // upstream stdout_format_has_i - gates the receiver's `created directory`
+    // notice (main.c:807-808) on a dest-creating pull; see the SSH receiver
+    // builder. Set on both roles here; only the receiver consults it.
+    server_config.flags.info_flags.out_format_forwards_i = config.out_format_forwards_i();
 
     // upstream: numeric_ids and delete are --numeric-ids / --delete-* long-form args only.
     server_config.flags.numeric_ids = crate::server::NumericIds::from_client(config.numeric_ids());

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -182,6 +182,10 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
     // and renders these; a path that sets this without draining would suppress
     // the receiver's default output, so keep the two wired together.
     server_config.flags.info_flags.out_format_active = config.render_out_format_locally();
+    // upstream stdout_format_has_i - gates the receiver's `created directory`
+    // notice on a dest-creating pull (main.c:807-808). True under `-i` or a
+    // custom `--out-format` carrying `%i`; false for a `%i`-less template.
+    server_config.flags.info_flags.out_format_forwards_i = config.out_format_forwards_i();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
@@ -490,6 +494,21 @@ mod tests {
             build_server_config_for_receiver(&config, &["dest".to_owned()]).unwrap();
 
         assert!(server_config.write.write_devices);
+    }
+
+    /// upstream stdout_format_has_i gates the receiver's `created directory`
+    /// notice on a dest-creating pull. A custom `--out-format` carrying `%i`
+    /// sets it; the flag must reach the receiver's InfoFlags so the notice
+    /// fires without the `-i` flag (previously it was tied to `info_flags.itemize`).
+    #[test]
+    fn receiver_config_propagates_out_format_forwards_i() {
+        let with_i = ClientConfig::builder().out_format_forwards_i(true).build();
+        let sc = build_server_config_for_receiver(&with_i, &["dest".to_owned()]).unwrap();
+        assert!(sc.flags.info_flags.out_format_forwards_i);
+
+        let without = ClientConfig::builder().out_format_forwards_i(false).build();
+        let sc = build_server_config_for_receiver(&without, &["dest".to_owned()]).unwrap();
+        assert!(!sc.flags.info_flags.out_format_forwards_i);
     }
 
     /// On an ssh pull the local client IS the receiver and follows a

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -410,6 +410,16 @@ pub struct InfoFlags {
     /// mirroring upstream `log_item()` firing whenever `stdout_format` is set
     /// (log.c:822-823).
     pub out_format_active: bool,
+    /// The client's resolved per-file format carries the `%i` directive
+    /// (upstream `stdout_format_has_i`): true under `-i` with the default
+    /// `"%i %n%L"`, or a custom `--out-format` whose string contains `%i`, and
+    /// false for an explicit `--out-format` that omits `%i` even under `-i`.
+    ///
+    /// Gates the receiver's `created directory <dest>` notice, which upstream
+    /// prints on a dest-creating pull when `INFO_GTE(NAME,1) || stdout_format_has_i`
+    /// (main.c:807-808). Without this the notice was tied to the `-i` flag alone
+    /// and was dropped under a custom `%i`-bearing `--out-format`.
+    pub out_format_forwards_i: bool,
     /// Log format active (`L` info flag).
     pub log_format: bool,
     /// Statistics enabled (`s` info flag).

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -364,7 +364,15 @@ impl ReceiverContext {
             // notice for local-mode transfers via the local-copy summary, so
             // gating here on client_mode keeps the upstream itemize.test
             // golden satisfied without breaking SSH/daemon paths.
-            if self.config.flags.info_flags.itemize && self.config.connection.client_mode {
+            //
+            // The itemize half of the gate is `stdout_format_has_i`
+            // (`out_format_forwards_i`), not the `-i` flag: `-i` sets it via the
+            // default `"%i %n%L"` format, a custom `--out-format` carrying `%i`
+            // sets it without `-i`, and a `%i`-less `--out-format` clears it even
+            // under `-i` - matching upstream, which drops the notice there.
+            if self.config.flags.info_flags.out_format_forwards_i
+                && self.config.connection.client_mode
+            {
                 println!("created directory {}", dest_dir.display());
             }
         }


### PR DESCRIPTION
## Summary

- Gate the `created directory <path>` notice on `out_format_forwards_i` (upstream `stdout_format_has_i`) instead of the bare `-i` flag, matching upstream `log.c` behavior.
- Plumb `out_format_forwards_i` from `ClientConfig` through both SSH and daemon `ServerConfig` builders into `InfoFlags`.
- When `--out-format` includes `%i`, the receiver emits the notice; when it does not (e.g. `--out-format '%n'`), the notice is suppressed - exactly as upstream 3.4.4 does.

## Test plan

- New unit test `receiver_config_propagates_out_format_forwards_i` verifies SSH plumbing
- Targeted nextest: 259 tests pass (CLI `created directory` tests + new plumbing test)
- Byte-exact validation vs rsync 3.4.4 for SSH and daemon pulls to a fresh dest with `-i`, `[%i] %n (%l)`, and `%o %n` (6 cases, all match)