### PR TITLE
feat(core): render --out-format for symlink/device/fifo pulls

### DIFF
--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -62,7 +62,7 @@ impl ReceiverContext {
             return Ok(());
         }
 
-        for entry in &self.file_list {
+        for (flist_idx, entry) in self.file_list.iter().enumerate() {
             if !entry.is_symlink() {
                 continue;
             }
@@ -144,7 +144,7 @@ impl ReceiverContext {
                     }
                     // upstream: generator.c:1565 - symlink up-to-date, metadata only
                     let iflags = ItemFlags::from_raw(0);
-                    let _ = self.emit_itemize(writer, &iflags, entry);
+                    let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
                     // upstream: log.c log_item / send_directory NAME emissions
                     // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
@@ -328,7 +328,7 @@ impl ReceiverContext {
             }
             // upstream: generator.c:1594 - itemize new symlink after creation
             let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
-            let _ = self.emit_itemize(writer, &iflags, entry);
+            let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
             if !dest_existed {
                 // upstream: receiver.c:740-741 - a newly created symlink
                 // (destination was absent) bumps stats.created_symlinks.
@@ -369,7 +369,7 @@ impl ReceiverContext {
         // borrow of `self.file_list` never overlaps the mutable field write.
         let mut unsupported_skip = false;
 
-        for entry in &self.file_list {
+        for (flist_idx, entry) in self.file_list.iter().enumerate() {
             if !entry.is_symlink() {
                 continue;
             }
@@ -442,7 +442,7 @@ impl ReceiverContext {
                     }
                     // upstream: generator.c:1565 - symlink up-to-date, metadata only
                     let iflags = ItemFlags::from_raw(0);
-                    let _ = self.emit_itemize(writer, &iflags, entry);
+                    let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
                     // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
@@ -545,7 +545,7 @@ impl ReceiverContext {
             }
             // upstream: generator.c:1594 - itemize new symlink after creation
             let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
-            let _ = self.emit_itemize(writer, &iflags, entry);
+            let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
             if !dest_existed {
                 // upstream: receiver.c:740-741 - a newly created symlink
                 // (destination was absent) bumps stats.created_symlinks.
@@ -656,7 +656,7 @@ impl ReceiverContext {
         }
 
         // Protocol 30+: use HardlinkApplyTracker for leader/follower resolution.
-        // Take the tracker temporarily to avoid borrow conflicts with self.emit_itemize().
+        // Take the tracker temporarily to avoid borrow conflicts with itemize emission.
         if let Some(mut tracker) = self.hardlink_tracker.take() {
             // First pass: ensure all leaders are recorded in the tracker.
             // Leaders committed during pipelined transfer are already recorded;
@@ -789,7 +789,8 @@ impl ReceiverContext {
                             {
                                 // upstream: hlink.c - hardlink already correct, metadata only
                                 let iflags = ItemFlags::from_raw(0);
-                                let _ = self.emit_itemize(writer, &iflags, entry);
+                                let _ =
+                                    self.emit_itemize_indexed(writer, follower_ndx, &iflags, entry);
                                 // upstream: hlink.c:223 - "%s is uptodate"
                                 // emitted at INFO_GTE(NAME, 2) when the
                                 // destination already hard-links to the leader.
@@ -897,7 +898,7 @@ impl ReceiverContext {
                         | ItemFlags::ITEM_XNAME_FOLLOWS
                         | ItemFlags::ITEM_IS_NEW,
                 );
-                let _ = self.emit_itemize(writer, &iflags, entry);
+                let _ = self.emit_itemize_indexed(writer, follower_ndx, &iflags, entry);
                 // upstream: hlink.c:236 - "%s => %s" at INFO_GTE(NAME, 1)
                 // when a hardlink follower is linked to its leader.
                 info_log!(

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -69,7 +69,7 @@ impl ReceiverContext {
             return Ok(());
         }
 
-        for entry in &self.file_list {
+        for (flist_idx, entry) in self.file_list.iter().enumerate() {
             let is_device = entry.is_device();
             let is_special = entry.is_special();
             if is_device {
@@ -248,14 +248,14 @@ impl ReceiverContext {
             if up_to_date {
                 // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                 let iflags = ItemFlags::from_raw(0);
-                let _ = self.emit_itemize(writer, &iflags, entry);
+                let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
                 info_log!(Name, 2, "{} is uptodate", relative_path.display());
             } else {
                 // upstream: generator.c:1462 itemize() sets ITEM_IS_NEW when the
                 // receiver newly materialises the node via do_mknod().
                 let iflags =
                     ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
-                let _ = self.emit_itemize(writer, &iflags, entry);
+                let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
                 if !dest_existed {
                     // upstream: receiver.c:743-746 - a newly created device
                     // (created_devices) or FIFO/socket (created_specials),

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -438,6 +438,33 @@ impl ReceiverContext {
         }
     }
 
+    /// Emits itemize output for a symlink, device, special, or hardlink follower
+    /// while carrying its flist index, so a custom `--out-format` collects the
+    /// row in flist order alongside regular files.
+    ///
+    /// These file types reach the generator on the immediate (non-pipelined)
+    /// path, so [`emit_itemize`](Self::emit_itemize) alone cannot buffer them for
+    /// the flist-index-order drain and suppresses them. Threading the index here
+    /// lets [`record_itemize`](Self::record_itemize) key the event exactly as it
+    /// does for regular files. Upstream itemizes every file type from the single
+    /// `generate_files` walk (`generator.c:2329`), each with its own `ndx`, so a
+    /// device/FIFO/symlink row renders in the same order as its neighbours.
+    ///
+    /// Off a custom `--out-format` this defers to the unchanged immediate path.
+    pub(in crate::receiver) fn emit_itemize_indexed<W: crate::writer::MsgInfoSender + ?Sized>(
+        &self,
+        writer: &mut W,
+        flist_idx: usize,
+        iflags: &crate::generator::ItemFlags,
+        entry: &protocol::flist::FileEntry,
+    ) -> std::io::Result<()> {
+        if self.collect_out_format_events() {
+            self.record_itemize(flist_idx, iflags, entry);
+            return Ok(());
+        }
+        self.emit_itemize(writer, iflags, entry)
+    }
+
     /// Emits over-the-wire itemize records for every hardlink follower so a
     /// pushing client's sender renders the `hf...` / `=> leader` row.
     ///

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -256,6 +256,100 @@ fn out_format_inactive_uses_string_path() {
 }
 
 #[test]
+fn out_format_collects_symlink_via_indexed_emit() {
+    // A symlink reaches the generator on the immediate (non-pipelined) path, so
+    // it is itemized through `emit_itemize_indexed`. Under a custom `--out-format`
+    // the index is carried into the collect buffer instead of suppressing the row
+    // (the plain `emit_itemize` no-op), so a pulling client renders the template
+    // for the symlink in flist order alongside regular files - matching upstream's
+    // single generate_files walk (generator.c:2329).
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.info_flags.itemize = false;
+    config.flags.info_flags.out_format_active = true;
+    config.connection.client_mode = true;
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+    let mut writer = MockMsgInfoWriter::new();
+
+    let entry = FileEntry::new_symlink("mylink".into(), "target".into());
+    let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+
+    ctx.emit_itemize_indexed(&mut writer, 5, &iflags, &entry)
+        .unwrap();
+
+    // No immediate MSG_INFO string is written; the event is buffered instead.
+    assert!(writer.messages.is_empty());
+    assert!(ctx.itemize_rows.borrow().is_empty());
+    let rows = ctx.drain_event_rows();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row.name, std::path::Path::new("mylink"));
+    assert!(row.is_symlink);
+    assert_eq!(
+        row.symlink_target.as_deref(),
+        Some(std::path::Path::new("target"))
+    );
+    assert!(row.is_new);
+    // upstream log.c - a newly created symlink shows the `c` local-change glyph
+    // and the `L` symlink type; the row is the fixed 11-char `%i`.
+    assert_eq!(row.itemize.len(), 11);
+    assert!(row.itemize.starts_with("cL"), "itemize = {:?}", row.itemize);
+}
+
+#[test]
+fn out_format_collects_special_via_indexed_emit() {
+    // A FIFO (special) is created on the same immediate path as a symlink, so it
+    // must also flow through `emit_itemize_indexed` into the collect buffer under
+    // a custom `--out-format` rather than being dropped.
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.info_flags.itemize = false;
+    config.flags.info_flags.out_format_active = true;
+    config.connection.client_mode = true;
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+    let mut writer = MockMsgInfoWriter::new();
+
+    let entry = FileEntry::new_fifo("apipe".into(), 0o644);
+    let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+
+    ctx.emit_itemize_indexed(&mut writer, 2, &iflags, &entry)
+        .unwrap();
+
+    assert!(writer.messages.is_empty());
+    let rows = ctx.drain_event_rows();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row.name, std::path::Path::new("apipe"));
+    assert!(row.is_new);
+    // upstream log.c - a newly created special shows the `c` local-change glyph
+    // and the `S` special type.
+    assert_eq!(row.itemize.len(), 11);
+    assert!(row.itemize.starts_with("cS"), "itemize = {:?}", row.itemize);
+}
+
+#[test]
+fn out_format_inactive_indexed_emit_uses_immediate_path() {
+    // Off a custom `--out-format`, `emit_itemize_indexed` must behave exactly like
+    // the immediate `emit_itemize`: with `-i` on a server receiver it renders no
+    // client row (the row travels as wire iflags), and nothing is collected.
+    let handshake = test_handshake();
+    let config = receiver_config_with_itemize();
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+    let mut writer = MockMsgInfoWriter::new();
+
+    let entry = FileEntry::new_symlink("mylink".into(), "target".into());
+    let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+
+    ctx.emit_itemize_indexed(&mut writer, 1, &iflags, &entry)
+        .unwrap();
+
+    // Server-mode receiver writes no client-visible row and collects nothing.
+    assert!(writer.messages.is_empty());
+    assert!(ctx.drain_event_rows().is_empty());
+    assert!(ctx.itemize_rows.borrow().is_empty());
+}
+
+#[test]
 fn emit_itemize_skipped_without_itemize_flag() {
     let handshake = test_handshake();
     let mut config = test_config();


### PR DESCRIPTION
## Summary

Symlinks, devices, FIFOs, and hardlink followers reach the receiver's generator on the immediate (non-pipelined) itemize path, which carries no flist index. Under a custom `--out-format` the client buffers each logged entry as a metadata event keyed by flist index for an ordered drain, so the immediate path suppressed these file types entirely - a symlink or device row never reached the rendered template.

- Add `emit_itemize_indexed`, which threads the flist index so `record_itemize` buffers the event exactly as it does for regular files.
- Route the symlink, special, and hardlink-follower call sites through it (loops now `enumerate()` to supply the index).
- Off `--out-format` it defers to the unchanged immediate emit, so default `-i` behaviour is byte-identical.

Upstream itemizes every file type from the single `generate_files` walk (`generator.c:2329`), each with its own `ndx`, so these rows now render in flist order alongside regular files.

## Test plan

- Three new unit tests: symlink collects with `cL` glyph, FIFO with `cS`, and the off-out-format path defers to the immediate emit.
- `cargo fmt` + `cargo clippy -p transfer --all-targets --all-features -D warnings`: clean.
- Targeted nextest (transfer, all-features): 16 tests pass.
- Byte-exact vs rsync 3.4.1 (protocol 32) on a daemon pull of a regular file + symlink + FIFO under `--out-format='%i %n'`: identical output in flist order (`>f afile.txt`, `cL blink`, `cS cpipe`).