### PR TITLE
fix(core): itemize symlink/device/fifo in flist order under -i

### DIFF
--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -144,7 +144,7 @@ impl ReceiverContext {
                     }
                     // upstream: generator.c:1565 - symlink up-to-date, metadata only
                     let iflags = ItemFlags::from_raw(0);
-                    let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
+                    let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
                     // upstream: log.c log_item / send_directory NAME emissions
                     // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
@@ -328,7 +328,7 @@ impl ReceiverContext {
             }
             // upstream: generator.c:1594 - itemize new symlink after creation
             let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
-            let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
+            let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
             if !dest_existed {
                 // upstream: receiver.c:740-741 - a newly created symlink
                 // (destination was absent) bumps stats.created_symlinks.
@@ -442,7 +442,7 @@ impl ReceiverContext {
                     }
                     // upstream: generator.c:1565 - symlink up-to-date, metadata only
                     let iflags = ItemFlags::from_raw(0);
-                    let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
+                    let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
                     // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
@@ -545,7 +545,7 @@ impl ReceiverContext {
             }
             // upstream: generator.c:1594 - itemize new symlink after creation
             let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
-            let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
+            let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
             if !dest_existed {
                 // upstream: receiver.c:740-741 - a newly created symlink
                 // (destination was absent) bumps stats.created_symlinks.

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -248,14 +248,14 @@ impl ReceiverContext {
             if up_to_date {
                 // upstream: generator.c:1145 - "%s is uptodate" at INFO_GTE(NAME, 2)
                 let iflags = ItemFlags::from_raw(0);
-                let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
+                let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
                 info_log!(Name, 2, "{} is uptodate", relative_path.display());
             } else {
                 // upstream: generator.c:1462 itemize() sets ITEM_IS_NEW when the
                 // receiver newly materialises the node via do_mknod().
                 let iflags =
                     ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
-                let _ = self.emit_itemize_indexed(writer, flist_idx, &iflags, entry);
+                let _ = self.emit_or_record_itemize(writer, flist_idx, &iflags, entry);
                 if !dest_existed {
                     // upstream: receiver.c:743-746 - a newly created device
                     // (created_devices) or FIFO/socket (created_specials),

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -438,17 +438,22 @@ impl ReceiverContext {
         }
     }
 
-    /// Emits itemize output for a symlink, device, special, or hardlink follower
-    /// while carrying its flist index, so a custom `--out-format` collects the
-    /// row in flist order alongside regular files.
+    /// Emits a hardlink-follower itemize row while carrying its flist index, so a
+    /// custom `--out-format` collects the row in flist order alongside regular
+    /// files.
     ///
-    /// These file types reach the generator on the immediate (non-pipelined)
+    /// Hardlink followers reach the generator on the immediate (non-pipelined)
     /// path, so [`emit_itemize`](Self::emit_itemize) alone cannot buffer them for
     /// the flist-index-order drain and suppresses them. Threading the index here
     /// lets [`record_itemize`](Self::record_itemize) key the event exactly as it
-    /// does for regular files. Upstream itemizes every file type from the single
-    /// `generate_files` walk (`generator.c:2329`), each with its own `ndx`, so a
-    /// device/FIFO/symlink row renders in the same order as its neighbours.
+    /// does for regular files.
+    ///
+    /// Unlike symlinks and specials (which route through
+    /// [`emit_or_record_itemize`](Self::emit_or_record_itemize) so their default
+    /// `-i` rows also defer into flist order), a follower's default `-i` row keeps
+    /// the immediate path: its deferred string form cannot yet reproduce the
+    /// ` => leader` xname suffix, and its leader-selection order is a separate
+    /// divergence, so deferring it would change more than ordering.
     ///
     /// Off a custom `--out-format` this defers to the unchanged immediate path.
     pub(in crate::receiver) fn emit_itemize_indexed<W: crate::writer::MsgInfoSender + ?Sized>(

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -256,12 +256,11 @@ fn out_format_inactive_uses_string_path() {
 }
 
 #[test]
-fn out_format_collects_symlink_via_indexed_emit() {
-    // A symlink reaches the generator on the immediate (non-pipelined) path, so
-    // it is itemized through `emit_itemize_indexed`. Under a custom `--out-format`
-    // the index is carried into the collect buffer instead of suppressing the row
-    // (the plain `emit_itemize` no-op), so a pulling client renders the template
-    // for the symlink in flist order alongside regular files - matching upstream's
+fn out_format_collects_symlink() {
+    // A symlink is itemized through `emit_or_record_itemize` with its flist index.
+    // Under a custom `--out-format` the index is carried into the collect buffer
+    // instead of suppressing the row, so a pulling client renders the template for
+    // the symlink in flist order alongside regular files - matching upstream's
     // single generate_files walk (generator.c:2329).
     let handshake = test_handshake();
     let mut config = test_config();
@@ -274,7 +273,7 @@ fn out_format_collects_symlink_via_indexed_emit() {
     let entry = FileEntry::new_symlink("mylink".into(), "target".into());
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
-    ctx.emit_itemize_indexed(&mut writer, 5, &iflags, &entry)
+    ctx.emit_or_record_itemize(&mut writer, 5, &iflags, &entry)
         .unwrap();
 
     // No immediate MSG_INFO string is written; the event is buffered instead.
@@ -297,10 +296,10 @@ fn out_format_collects_symlink_via_indexed_emit() {
 }
 
 #[test]
-fn out_format_collects_special_via_indexed_emit() {
-    // A FIFO (special) is created on the same immediate path as a symlink, so it
-    // must also flow through `emit_itemize_indexed` into the collect buffer under
-    // a custom `--out-format` rather than being dropped.
+fn out_format_collects_special() {
+    // A FIFO (special) is created on the same immediate path as a symlink and also
+    // flows through `emit_or_record_itemize` into the collect buffer under a custom
+    // `--out-format` rather than being dropped.
     let handshake = test_handshake();
     let mut config = test_config();
     config.flags.info_flags.itemize = false;
@@ -312,7 +311,7 @@ fn out_format_collects_special_via_indexed_emit() {
     let entry = FileEntry::new_fifo("apipe".into(), 0o644);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
-    ctx.emit_itemize_indexed(&mut writer, 2, &iflags, &entry)
+    ctx.emit_or_record_itemize(&mut writer, 2, &iflags, &entry)
         .unwrap();
 
     assert!(writer.messages.is_empty());
@@ -328,16 +327,17 @@ fn out_format_collects_special_via_indexed_emit() {
 }
 
 #[test]
-fn out_format_inactive_indexed_emit_uses_immediate_path() {
-    // Off a custom `--out-format`, `emit_itemize_indexed` must behave exactly like
-    // the immediate `emit_itemize`: with `-i` on a server receiver it renders no
-    // client row (the row travels as wire iflags), and nothing is collected.
+fn indexed_emit_off_out_format_uses_immediate_path() {
+    // `emit_itemize_indexed` is the hardlink-follower path. Off a custom
+    // `--out-format` it must behave exactly like the immediate `emit_itemize`:
+    // with `-i` on a server receiver it renders no client row (the row travels as
+    // wire iflags) and collects nothing.
     let handshake = test_handshake();
     let config = receiver_config_with_itemize();
     let ctx = ReceiverContext::new_for_test(&handshake, config);
     let mut writer = MockMsgInfoWriter::new();
 
-    let entry = FileEntry::new_symlink("mylink".into(), "target".into());
+    let entry = FileEntry::new_file("leader.txt".into(), 10, 0o644);
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
     ctx.emit_itemize_indexed(&mut writer, 1, &iflags, &entry)
@@ -347,6 +347,42 @@ fn out_format_inactive_indexed_emit_uses_immediate_path() {
     assert!(writer.messages.is_empty());
     assert!(ctx.drain_event_rows().is_empty());
     assert!(ctx.itemize_rows.borrow().is_empty());
+}
+
+#[test]
+fn default_i_symlink_defers_into_flist_order_on_pull() {
+    // On a client-mode pull the receiver defers itemize rows (defer_itemize) and
+    // flushes them in flist-index order. A symlink created in the create_symlinks
+    // pass must join that deferred buffer keyed by its flist index - not emit
+    // immediately - so it interleaves with regular files exactly as upstream's
+    // single generate_files walk does (generator.c:2329). Regression for the bug
+    // where symlinks/specials printed before all regular files under `-i`.
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.info_flags.itemize = true;
+    config.connection.client_mode = true;
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.defer_itemize = true;
+    let mut writer = MockMsgInfoWriter::new();
+
+    let entry = FileEntry::new_symlink("blink".into(), "afile.txt".into());
+    let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
+
+    ctx.emit_or_record_itemize(&mut writer, 7, &iflags, &entry)
+        .unwrap();
+
+    // Nothing written immediately; the row is buffered for the ordered flush.
+    assert!(writer.messages.is_empty());
+    let buffered = ctx.itemize_rows.borrow();
+    let rows = buffered.get(&7).expect("row buffered at flist index 7");
+    assert_eq!(rows.len(), 1);
+    // The deferred string carries the `cL` glyph and the ` -> target` suffix.
+    assert!(rows[0].starts_with("cL"), "row = {:?}", rows[0]);
+    assert!(
+        rows[0].contains("blink -> afile.txt"),
+        "row = {:?}",
+        rows[0]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

On a pipelined client pull the receiver defers regular-file itemize rows and flushes them in flist-index order, but symlinks, devices, and FIFOs were emitted immediately during the `create_symlinks` / `create_specials` passes - before any regular-file row. That grouped every special file ahead of the regular files instead of interleaving them, diverging from upstream, which itemizes every file type from the single `generate_files` walk (`generator.c:2329`), each in flist order.

- Route the symlink and device/special call sites through the existing `emit_or_record_itemize`, which defers on `defer_itemize` so the rows join the same flist-index-ordered flush as regular files (and still collect under a custom `--out-format`).
- Off the deferred path (server receiver, non-pipelined sync) it falls back to the unchanged immediate emit.
- Hardlink followers keep the immediate `emit_itemize_indexed` path: their deferred string form cannot yet reproduce the ` => leader` xname suffix and their leader-selection order is a separate divergence, so deferring them would change more than ordering.

## Test plan

- New unit test `default_i_symlink_defers_into_flist_order_on_pull`; existing collection tests updated to the production path.
- `cargo fmt` + `cargo clippy -p transfer --all-targets --all-features -D warnings`: clean.
- Targeted nextest (transfer, all-features): 16 tests pass.
- Byte-exact vs rsync 3.4.1 (protocol 32) on a daemon pull of a regular file + symlink + FIFO: `-i` now matches upstream flist order (`>f afile`, `cL blink`, `cS cpipe`); the `--out-format` case is unchanged (still matches).

## Follow-up (out of scope)

Hardlink-follower `-i` rows have separate divergences vs upstream (leader selection and the missing ` => leader` xname suffix on the deferred/immediate path); tracked for a dedicated change.