### PR TITLE
feat(core): render --out-format %f full source path on a push

### DIFF
--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -5,6 +5,7 @@
 //! Maps each `OutFormatPlaceholder` variant to its rendered string value
 //! by inspecting the event, its metadata, and the rendering context.
 
+use std::path::Path;
 use std::time::SystemTime;
 
 use crate::frontend::escape::escape_path;
@@ -50,8 +51,8 @@ pub(super) fn render_placeholder_value(
 ) -> Option<Vec<u8>> {
     let allow_8bit = context.eight_bit_output;
     match spec.kind {
-        OutFormatPlaceholder::FileName => Some(render_path(event, true, allow_8bit)),
-        OutFormatPlaceholder::FullPath => Some(render_path(event, false, allow_8bit)),
+        OutFormatPlaceholder::FileName => Some(render_name(event, allow_8bit)),
+        OutFormatPlaceholder::FullPath => Some(render_full_path(event, allow_8bit)),
         OutFormatPlaceholder::ItemizedChanges => Some(match event.itemize_override() {
             // A remote transfer supplies the sender's already-correct 11-char
             // itemize string; a local event derives it from its change set.
@@ -199,26 +200,32 @@ fn transfer_byte_count(event: &ClientEvent, is_sender: bool, want_checksum: bool
     }
 }
 
-/// Renders the path from an event as raw bytes, optionally appending a trailing
-/// slash for directories.
-fn render_path(event: &ClientEvent, ensure_trailing_slash: bool, allow_8bit: bool) -> Vec<u8> {
-    let mut rendered = escape_path(event.relative_path(), allow_8bit);
-    // upstream: flist.c / log.c - itemize and out-format paths use POSIX
-    // forward-slash separators regardless of host OS. Normalize Windows
-    // native backslashes here at the rendering boundary; storage retains
-    // the platform-native form.
+/// Escapes a path to raw output bytes, normalizing Windows separators.
+///
+/// upstream: flist.c / log.c - itemize and out-format paths use POSIX
+/// forward-slash separators regardless of host OS. Storage retains the
+/// platform-native form; this normalizes only at the rendering boundary.
+fn escape_render_path(path: &Path, allow_8bit: bool) -> Vec<u8> {
+    let rendered = escape_path(path, allow_8bit);
     #[cfg(windows)]
-    {
-        for byte in rendered.iter_mut() {
+    let rendered = {
+        let mut bytes = rendered;
+        for byte in bytes.iter_mut() {
             if *byte == b'\\' {
                 *byte = b'/';
             }
         }
-    }
-    if ensure_trailing_slash
-        && rendered.last() != Some(&b'/')
+        bytes
+    };
+    rendered
+}
+
+/// Renders `%n`: the transfer-relative name, with a trailing slash for a
+/// directory (upstream `log.c:639-640`).
+fn render_name(event: &ClientEvent, allow_8bit: bool) -> Vec<u8> {
+    let mut rendered = escape_render_path(event.relative_path(), allow_8bit);
+    if rendered.last() != Some(&b'/')
         && event.metadata().map(ClientEntryMetadata::kind).map_or_else(
-            // upstream: log.c:639-640 - %n appends `/` for any directory entry.
             // `EntryDeleted` rows carry no metadata snapshot, so fall back to the
             // record's directory bit (set by the engine cleanup pass) alongside
             // the freshly-created-directory case.
@@ -227,6 +234,23 @@ fn render_path(event: &ClientEvent, ensure_trailing_slash: bool, allow_8bit: boo
         )
     {
         rendered.push(b'/');
+    }
+    rendered
+}
+
+/// Renders `%f`: on a push the full source-side path the sender supplied
+/// (upstream `pathjoin(F_PATHNAME(file), f_name(file))` with a single leading
+/// `/` stripped, `log.c`), otherwise the transfer-relative name. Unlike `%n`, no
+/// trailing slash is appended for directories.
+fn render_full_path(event: &ClientEvent, allow_8bit: bool) -> Vec<u8> {
+    let path = match event.source_prefix() {
+        Some(prefix) => prefix,
+        None => event.relative_path(),
+    };
+    let mut rendered = escape_render_path(path, allow_8bit);
+    // upstream: log.c `%f` strips a single leading '/' from the joined path.
+    if rendered.first() == Some(&b'/') {
+        rendered.remove(0);
     }
     rendered
 }

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use core::client::{ClientEntryKind, ClientEvent, ClientEventKind};
+use core::client::{ClientEntryKind, ClientEvent, ClientEventKind, RemoteItemizeFields};
 use engine::local_copy::{LocalCopyChangeSet, TimeChange};
 
 use crate::frontend::out_format::parser::parse_out_format;
@@ -1396,6 +1396,50 @@ fn render_percent_f_no_trailing_slash_for_directory() {
         !rendered.trim().ends_with('/'),
         "%%f should not add trailing slash: {rendered:?}"
     );
+}
+
+/// Builds a remote push event whose sender supplied a full source path.
+fn remote_event_with_source_prefix(relative: &str, source_prefix: Option<&str>) -> ClientEvent {
+    ClientEvent::from_remote_itemize(RemoteItemizeFields {
+        relative_path: PathBuf::from(relative),
+        source_prefix: source_prefix.map(PathBuf::from),
+        itemize: ">f+++++++++".to_owned(),
+        mode: 0o100_644,
+        size: 4,
+        mtime: 1_700_000_000,
+        mtime_nsec: 0,
+        uid: None,
+        gid: None,
+        is_dir: false,
+        is_symlink: false,
+        symlink_target: None,
+        is_new: true,
+        is_deletion: false,
+    })
+}
+
+#[test]
+fn render_percent_f_uses_push_source_prefix() {
+    // upstream log.c: on a push `%f` is pathjoin(F_PATHNAME, f_name); the sender
+    // supplies the full source path while `%n` stays transfer-relative.
+    let event = remote_event_with_source_prefix("afile.txt", Some("srcroot/docs/afile.txt"));
+    assert_eq!(render_format("%f", &event), "srcroot/docs/afile.txt\n");
+    assert_eq!(render_format("%n", &event), "afile.txt\n");
+}
+
+#[test]
+fn render_percent_f_strips_single_leading_slash() {
+    // upstream log.c: `%f` strips a single leading '/' from the joined path.
+    let event = remote_event_with_source_prefix("afile.txt", Some("/abs/docs/afile.txt"));
+    assert_eq!(render_format("%f", &event), "abs/docs/afile.txt\n");
+}
+
+#[test]
+fn render_percent_f_falls_back_to_relative_without_source_prefix() {
+    // On a pull the sender supplies no source path, so `%f` is the relative name
+    // (upstream's else branch: just f_name, no F_PATHNAME join).
+    let event = remote_event_with_source_prefix("docs/afile.txt", None);
+    assert_eq!(render_format("%f", &event), "docs/afile.txt\n");
 }
 
 #[test]

--- a/crates/core/src/client/remote/itemize_sink.rs
+++ b/crates/core/src/client/remote/itemize_sink.rs
@@ -52,6 +52,7 @@ impl crate::server::ItemizeCallback for ItemizeEventSink {
             self.events
                 .push(ClientEvent::from_remote_itemize(RemoteItemizeFields {
                     relative_path: row.name.to_path_buf(),
+                    source_prefix: row.source_prefix.map(std::path::Path::to_path_buf),
                     itemize: row.itemize.to_owned(),
                     mode: row.mode,
                     size: row.size,

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -122,6 +122,10 @@ pub struct ClientEvent {
     /// no `LocalCopyChangeSet`, so it carries the sender's already-correct
     /// 11-character itemize string here for the renderer to emit verbatim.
     precomputed_itemize: Option<String>,
+    /// Full source-side path supplied by a remote push sender, for the `%f`
+    /// placeholder (upstream `F_PATHNAME` joined with the name). `None` on a pull
+    /// or local copy, where `%f` falls back to [`Self::relative_path`].
+    source_prefix: Option<PathBuf>,
 }
 
 impl ClientEvent {
@@ -217,6 +221,7 @@ impl ClientEvent {
             hardlink_uptodate,
             is_directory,
             precomputed_itemize: None,
+            source_prefix: None,
         }
     }
 
@@ -242,6 +247,7 @@ impl ClientEvent {
             hardlink_uptodate: false,
             is_directory: false,
             precomputed_itemize: None,
+            source_prefix: None,
         }
     }
 
@@ -281,6 +287,7 @@ impl ClientEvent {
             hardlink_uptodate: false,
             is_directory,
             precomputed_itemize: None,
+            source_prefix: None,
         }
     }
 
@@ -318,6 +325,7 @@ impl ClientEvent {
             hardlink_uptodate: false,
             is_directory: fields.is_dir,
             precomputed_itemize: Some(fields.itemize),
+            source_prefix: fields.source_prefix,
         }
     }
 
@@ -325,6 +333,13 @@ impl ClientEvent {
     #[must_use]
     pub fn relative_path(&self) -> &Path {
         &self.relative_path
+    }
+
+    /// Returns the full source-side path for the `%f` placeholder, when a remote
+    /// push sender supplied one. `None` on a pull or local copy.
+    #[must_use]
+    pub fn source_prefix(&self) -> Option<&Path> {
+        self.source_prefix.as_deref()
     }
 
     /// Returns the action recorded by this event.
@@ -467,6 +482,7 @@ impl ClientEvent {
             hardlink_uptodate: false,
             is_directory: false,
             precomputed_itemize: None,
+            source_prefix: None,
         }
     }
 
@@ -530,6 +546,7 @@ mod tests {
     fn from_remote_itemize_carries_override_and_metadata() {
         let event = ClientEvent::from_remote_itemize(RemoteItemizeFields {
             relative_path: PathBuf::from("sub/f.txt"),
+            source_prefix: Some(PathBuf::from("srcroot/docs/sub/f.txt")),
             itemize: ">f+++++++++".to_owned(),
             mode: 0o100_644,
             size: 42,
@@ -545,6 +562,11 @@ mod tests {
         });
         assert_eq!(event.itemize_override(), Some(">f+++++++++"));
         assert_eq!(event.relative_path(), Path::new("sub/f.txt"));
+        // A push sender's full source path rides along for the `%f` placeholder.
+        assert_eq!(
+            event.source_prefix(),
+            Some(Path::new("srcroot/docs/sub/f.txt"))
+        );
         assert!(event.was_created());
         assert!(matches!(event.kind(), ClientEventKind::DataCopied));
         let metadata = event.metadata().expect("metadata present");
@@ -556,6 +578,7 @@ mod tests {
     fn from_remote_itemize_deletion_maps_to_entry_deleted() {
         let event = ClientEvent::from_remote_itemize(RemoteItemizeFields {
             relative_path: PathBuf::from("gone.txt"),
+            source_prefix: None,
             itemize: "*deleting  ".to_owned(),
             mode: 0o100_644,
             size: 0,

--- a/crates/core/src/client/summary/metadata.rs
+++ b/crates/core/src/client/summary/metadata.rs
@@ -54,6 +54,10 @@ pub struct ListOnlyEntryFields {
 pub struct RemoteItemizeFields {
     /// Transfer-relative path of the entry.
     pub relative_path: PathBuf,
+    /// Full source-side path (upstream `F_PATHNAME` joined with the name), set
+    /// only on a push where the local side is the sender. Renders the `%f`
+    /// placeholder; `None` on a pull, where `%f` falls back to `relative_path`.
+    pub source_prefix: Option<PathBuf>,
     /// The 11-character `%i` itemize string computed by the sender.
     pub itemize: String,
     /// POSIX mode bits (type + permissions).

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -463,6 +463,30 @@ impl GeneratorContext {
         join_source_path(&self.source_bases[ndx], self.file_list[ndx].path())
     }
 
+    /// Returns the full source path for entry `ndx` for the `%f` out-format
+    /// placeholder, mirroring upstream `log.c` `pathjoin(F_PATHNAME(file),
+    /// f_name(file))`.
+    ///
+    /// `source_bases` is populated only by the sender's local walk
+    /// ([`push_file_item`](Self::push_file_item)); on a pull the flist arrives over
+    /// the wire and the array is empty, so this returns `None` and `%f` falls back
+    /// to the transfer-relative name - matching upstream, where `%f` only joins
+    /// `F_PATHNAME(file)` when `am_sender`.
+    ///
+    /// This is a literal component join, distinct from
+    /// [`reconstruct_source_path`](Self::reconstruct_source_path): the latter
+    /// collapses a `.` transfer-root name to the bare base so it opens the same
+    /// inode, whereas upstream `%f` keeps the `.` (rendering `<base>/.`), so the
+    /// join here must not special-case it.
+    pub(crate) fn source_prefix_for(&self, ndx: usize) -> Option<PathBuf> {
+        if ndx >= self.source_bases.len() {
+            return None;
+        }
+        let mut path = self.source_bases[ndx].to_path_buf();
+        path.extend(self.file_list[ndx].path().components());
+        Some(path)
+    }
+
     /// Clears both the file list and the source-base array.
     ///
     /// This method maintains the invariant that both arrays are cleared together

--- a/crates/transfer/src/generator/itemize.rs
+++ b/crates/transfer/src/generator/itemize.rs
@@ -28,12 +28,14 @@ pub(crate) fn build_itemize_row<'a>(
     iflags: &ItemFlags,
     line: &'a str,
     itemize: &'a str,
+    source_prefix: Option<&'a std::path::Path>,
 ) -> ItemizeRow<'a> {
     let raw = iflags.raw();
     ItemizeRow {
         line,
         itemize,
         name: entry.path().as_path(),
+        source_prefix,
         size: entry.size(),
         mtime: entry.mtime(),
         mtime_nsec: entry.mtime_nsec(),

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -483,7 +483,17 @@ impl GeneratorContext {
                 // entry metadata) so a client rendering a custom `--out-format`
                 // can rebuild a rich event; the default impl prints `line`.
                 let itemize = super::itemize::format_iflags(iflags, entry, true, &ctx);
-                let row = super::itemize::build_itemize_row(entry, iflags, &line, &itemize);
+                // upstream: log.c `%f` joins F_PATHNAME(file) with the name on a
+                // push (am_sender); source_prefix_for supplies the equivalent full
+                // source path, or None off the sender path (falls back to %n).
+                let source_prefix = self.source_prefix_for(ndx);
+                let row = super::itemize::build_itemize_row(
+                    entry,
+                    iflags,
+                    &line,
+                    &itemize,
+                    source_prefix.as_deref(),
+                );
                 cb.on_itemize_row(&row);
             }
             Ok(())
@@ -581,7 +591,14 @@ impl GeneratorContext {
             // mixing `%i` with other codes renders the correct itemize string.
             let ctx = self.itemize_context();
             let itemize = super::itemize::format_iflags(iflags, entry, true, &ctx);
-            let row = super::itemize::build_itemize_row(entry, iflags, &line, &itemize);
+            let source_prefix = self.source_prefix_for(ndx);
+            let row = super::itemize::build_itemize_row(
+                entry,
+                iflags,
+                &line,
+                &itemize,
+                source_prefix.as_deref(),
+            );
             cb.on_itemize_row(&row);
         }
         Ok(())

--- a/crates/transfer/src/progress.rs
+++ b/crates/transfer/src/progress.rs
@@ -94,6 +94,10 @@ pub struct ItemizeRow<'a> {
     pub itemize: &'a str,
     /// Transfer-relative path of the entry.
     pub name: &'a std::path::Path,
+    /// Full source-side path of the entry (upstream `F_PATHNAME` joined with the
+    /// file name), set only on a push where the local side is the sender. Renders
+    /// the `%f` placeholder; `None` on a pull, where `%f` falls back to `name`.
+    pub source_prefix: Option<&'a std::path::Path>,
     /// File length in bytes.
     pub size: u64,
     /// Modification time, whole seconds since the Unix epoch.
@@ -134,6 +138,8 @@ pub struct OwnedItemizeRow {
     pub itemize: String,
     /// Owned copy of [`ItemizeRow::name`].
     pub name: std::path::PathBuf,
+    /// Owned copy of [`ItemizeRow::source_prefix`].
+    pub source_prefix: Option<std::path::PathBuf>,
     /// See [`ItemizeRow::size`].
     pub size: u64,
     /// See [`ItemizeRow::mtime`].
@@ -166,6 +172,7 @@ impl OwnedItemizeRow {
             line: &self.line,
             itemize: &self.itemize,
             name: &self.name,
+            source_prefix: self.source_prefix.as_deref(),
             size: self.size,
             mtime: self.mtime,
             mtime_nsec: self.mtime_nsec,

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -368,6 +368,10 @@ impl ReceiverContext {
             line,
             itemize,
             name: entry.path().to_path_buf(),
+            // upstream log.c: `%f` only joins F_PATHNAME when am_sender. On a pull
+            // the local client is the receiver, so `%f` is the relative name (==
+            // `%n` minus a directory's trailing slash) - no source prefix.
+            source_prefix: None,
             size: entry.size(),
             mtime: entry.mtime(),
             mtime_nsec: entry.mtime_nsec(),

--- a/xtask/src/commands/validate/checks/mod.rs
+++ b/xtask/src/commands/validate/checks/mod.rs
@@ -30,6 +30,7 @@ mod metadata;
 mod mkpath;
 mod modify_window;
 mod one_file_system;
+mod out_format;
 mod progress;
 mod protected_regular;
 mod prune_empty_dirs;
@@ -84,6 +85,7 @@ pub fn all() -> Vec<Box<dyn Check>> {
         Box::new(progress::Progress),
         Box::new(verbosity::Verbosity),
         Box::new(itemize::Itemize),
+        Box::new(out_format::OutFormat),
         Box::new(dry_run::DryRun),
         Box::new(banner::Banner),
         Box::new(stats::Stats),

--- a/xtask/src/commands/validate/checks/out_format.rs
+++ b/xtask/src/commands/validate/checks/out_format.rs
@@ -1,0 +1,225 @@
+//! `--out-format` stdout parity: oc renders each template byte-for-byte like
+//! upstream rsync.
+//!
+//! Covers two directions. On a *pull* the client is the receiver and renders the
+//! itemize/name templates (`%i`, `%n`, `%L`, `%o`). On a *push* the client is the
+//! sender, which is the only side that expands `%f` to the full source path
+//! (upstream `log.c` joins `F_PATHNAME` only when `am_sender`); the local-copy
+//! path does not thread the source prefix, so `%f` is exercised over the remote
+//! push transports only. Upstream is the ground truth for every template.
+
+use std::path::Path;
+
+use crate::commands::validate::support;
+use crate::commands::validate::transport::{Transport, pull_into, push_into};
+use crate::commands::validate::{Check, CheckOutcome, ValidateCtx};
+
+/// The `--out-format` byte-parity check.
+pub struct OutFormat;
+
+/// Templates the receiving client renders on a pull. Chosen to be deterministic
+/// across implementations: no per-file byte counts (`%b`/`%c`) or timestamps.
+const PULL_TEMPLATES: &[&str] = &["%i %n%L", "%o %n"];
+
+/// Templates the sending client renders on a push. `%f` is the sender-only full
+/// source path this exercises; `%n` stays transfer-relative alongside it.
+const PUSH_TEMPLATES: &[&str] = &["%f", "%i %f (%n)"];
+
+/// Recursive, metadata-preserving, numeric ids - a stable itemize surface.
+const BASE_FLAGS: &[&str] = &["-rlpt", "--numeric-ids"];
+
+impl Check for OutFormat {
+    fn name(&self) -> &'static str {
+        "out_format"
+    }
+
+    fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
+        let root = ctx.work.join("out_format");
+        let src = root.join("src");
+        if let Err(e) = support::build_backdated_tree(&src) {
+            return vec![CheckOutcome::skip(self.name(), "fixture", e)];
+        }
+
+        ctx.transports
+            .iter()
+            .flat_map(|&t| self.cell(ctx, t, &root))
+            .collect()
+    }
+}
+
+impl OutFormat {
+    fn cell(&self, ctx: &ValidateCtx, transport: Transport, root: &Path) -> Vec<CheckOutcome> {
+        let label = transport.label();
+        if transport.needs_ssh() && !support::ssh_ready() {
+            return vec![CheckOutcome::skip(
+                self.name(),
+                label,
+                "no sshd on localhost:22",
+            )];
+        }
+        let src = root.join("src");
+
+        let mut outcomes: Vec<CheckOutcome> = PULL_TEMPLATES
+            .iter()
+            .map(|tmpl| self.compare(ctx, transport, &src, root, tmpl, Direction::Pull))
+            .collect();
+
+        // `%f` full-path is sender-only and unwired on the local-copy path, so
+        // only the remote push transports carry the fix.
+        if transport != Transport::Local {
+            outcomes.extend(
+                PUSH_TEMPLATES
+                    .iter()
+                    .map(|tmpl| self.compare(ctx, transport, &src, root, tmpl, Direction::Push)),
+            );
+        }
+        outcomes
+    }
+
+    fn compare(
+        &self,
+        ctx: &ValidateCtx,
+        transport: Transport,
+        src: &Path,
+        root: &Path,
+        template: &str,
+        direction: Direction,
+    ) -> CheckOutcome {
+        let label = format!("{}::{}::{template}", transport.label(), direction.label());
+        let flags: Vec<String> = BASE_FLAGS
+            .iter()
+            .map(|s| (*s).to_string())
+            .chain(std::iter::once(format!("--out-format={template}")))
+            .collect();
+        let oc_dst = root.join(format!("oc-{}-{}", transport.label(), direction.label()));
+        let up_dst = root.join(format!("up-{}-{}", transport.label(), direction.label()));
+
+        let run_one = |client: &Path, dst: &Path| match direction {
+            Direction::Pull => {
+                pull_into(transport, client, ctx.upstream, src, dst, &flags, ctx.work)
+            }
+            Direction::Push => {
+                push_into(transport, client, ctx.upstream, src, dst, &flags, ctx.work)
+            }
+        };
+
+        let up = match run_one(ctx.upstream, &up_dst) {
+            Ok(out) if out.status.success() => out,
+            other => {
+                return crate::commands::validate::comparison::classify_failure(
+                    self.name(),
+                    label.as_str(),
+                    "upstream",
+                    other,
+                );
+            }
+        };
+        let oc = match run_one(ctx.oc, &oc_dst) {
+            Ok(out) if out.status.success() => out,
+            other => {
+                return crate::commands::validate::comparison::classify_failure(
+                    self.name(),
+                    label.as_str(),
+                    "oc",
+                    other,
+                );
+            }
+        };
+
+        let up_text = String::from_utf8_lossy(&up.stdout);
+        let oc_text = String::from_utf8_lossy(&oc.stdout);
+        let up_lines = out_format_lines(&up_text);
+        let oc_lines = out_format_lines(&oc_text);
+
+        if ctx.verbose {
+            eprintln!(
+                "[out_format/{label}] oc {} lines, upstream {} lines",
+                oc_lines.len(),
+                up_lines.len()
+            );
+        }
+
+        // Genuine-result guard: an empty render means the transfer produced no
+        // per-file rows, so there is nothing to compare.
+        if up_lines.is_empty() {
+            return CheckOutcome::skip(self.name(), label.as_str(), "no upstream out-format rows");
+        }
+        if oc_lines != up_lines {
+            let first_diff = oc_lines
+                .iter()
+                .zip(up_lines.iter())
+                .find(|(o, u)| o != u)
+                .map_or_else(
+                    || {
+                        format!(
+                            "row count differs (oc {} vs {})",
+                            oc_lines.len(),
+                            up_lines.len()
+                        )
+                    },
+                    |(o, u)| format!("oc {o:?} != upstream {u:?}"),
+                );
+            return CheckOutcome::fail(self.name(), label.as_str(), first_diff);
+        }
+        CheckOutcome::pass(self.name(), label.as_str())
+    }
+}
+
+/// Transfer direction under test.
+#[derive(Clone, Copy)]
+enum Direction {
+    Pull,
+    Push,
+}
+
+impl Direction {
+    const fn label(self) -> &'static str {
+        match self {
+            Direction::Pull => "pull",
+            Direction::Push => "push",
+        }
+    }
+}
+
+/// Keep only the per-file `--out-format` rows, dropping the trailing transfer
+/// summary (`sent ...`, `total size ...`, `speedup`) and blank lines so the
+/// byte comparison is not perturbed by counters that legitimately differ.
+fn out_format_lines(stdout: &str) -> Vec<&str> {
+    stdout
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| {
+            !line.is_empty()
+                && !line.starts_with("sent ")
+                && !line.starts_with("total size ")
+                && !line.contains("speedup is")
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::out_format_lines;
+
+    #[test]
+    fn filters_summary_and_blank_lines() {
+        let out = ">f+++++++++ a.txt\n\
+                   cd+++++++++ sub/\n\
+                   \n\
+                   sent 100 bytes  received 20 bytes  240.00 bytes/sec\n\
+                   total size is 12  speedup is 0.10\n";
+        assert_eq!(
+            out_format_lines(out),
+            vec![">f+++++++++ a.txt", "cd+++++++++ sub/"]
+        );
+    }
+
+    #[test]
+    fn keeps_full_source_path_rows() {
+        let out = "srcroot/docs/a.txt\nsrcroot/docs/sub/b.txt\n";
+        assert_eq!(
+            out_format_lines(out),
+            vec!["srcroot/docs/a.txt", "srcroot/docs/sub/b.txt"]
+        );
+    }
+}

--- a/xtask/src/commands/validate/checks/verbosity.rs
+++ b/xtask/src/commands/validate/checks/verbosity.rs
@@ -44,7 +44,11 @@ impl Check for Verbosity {
     fn run(&self, ctx: &ValidateCtx) -> Vec<CheckOutcome> {
         let root = ctx.work.join("verbosity");
         let src = root.join("src");
-        if let Err(e) = build_fixture(&src) {
+        // Shared fixture backdates the src root too, so the top `./` itemize row
+        // is deterministic; a local copy that stamped only the entries left the
+        // root at "now", racing the freshly-created dst root and intermittently
+        // dropping `./` from one client's output.
+        if let Err(e) = support::build_backdated_tree(&src) {
             return vec![CheckOutcome::skip(self.name(), "fixture", e)];
         }
         let expected = support::entry_count(&src);
@@ -195,33 +199,6 @@ fn is_summary_line(line: &str) -> bool {
     ];
     let lower = line.to_ascii_lowercase();
     PREFIXES.iter().any(|prefix| lower.starts_with(prefix))
-}
-
-/// Build the verbosity fixture. Idempotent: removes any prior tree first.
-///
-/// A couple of top-level files plus a subdirectory holding one file. Mtimes are
-/// backdated so the quick-check makes the same transfer decisions on every run.
-fn build_fixture(src: &Path) -> Result<(), String> {
-    if src.exists() {
-        std::fs::remove_dir_all(src).map_err(|e| e.to_string())?;
-    }
-    let sub = src.join("sub");
-    std::fs::create_dir_all(&sub).map_err(|e| e.to_string())?;
-
-    std::fs::write(src.join("a.txt"), b"alpha").map_err(|e| e.to_string())?;
-    std::fs::write(src.join("b.txt"), b"bravo").map_err(|e| e.to_string())?;
-    std::fs::write(sub.join("c.txt"), b"charlie").map_err(|e| e.to_string())?;
-
-    // Backdate mtimes so the quick-check does not skip anything under test.
-    for entry in support::rel_entries(src) {
-        let path = src.join(&entry);
-        support::capture(
-            "touch",
-            &["-h", "-d", "@1614830767", &path.to_string_lossy()],
-        )
-        .map_err(|e| e.to_string())?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/xtask/src/commands/validate/transport.rs
+++ b/xtask/src/commands/validate/transport.rs
@@ -122,6 +122,52 @@ pub fn pull_into(
     run(cmd)
 }
 
+/// Push `src/` into `dst` with the client under test as the *sender*, over one
+/// transport. The remote *receiver* is always upstream rsync (via `--rsync-path`
+/// for ssh/russh, an upstream writable `--daemon` module for `rsync://`), so only
+/// the client sender varies between two runs of a cell. This is the direction
+/// that exercises sender-only rendering such as `--out-format` `%f`.
+pub fn push_into(
+    transport: Transport,
+    client: &Path,
+    upstream: &Path,
+    src: &Path,
+    dst: &Path,
+    flags: &[String],
+    work: &Path,
+) -> TaskResult<Output> {
+    reset_dir(dst)?;
+    let src_arg = format!("{}/", src.display());
+    let mut cmd = Command::new(client);
+    cmd.args(flags);
+
+    match transport {
+        Transport::Local => {
+            cmd.arg(&src_arg).arg(format!("{}/", dst.display()));
+        }
+        Transport::SshSubprocess => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg("-e")
+                .arg("ssh -o BatchMode=yes -o StrictHostKeyChecking=no")
+                .arg(&src_arg)
+                .arg(format!("localhost:{}/", dst.display()));
+        }
+        Transport::Russh => {
+            cmd.arg(format!("--rsync-path={}", upstream.display()))
+                .arg(&src_arg)
+                .arg(format!("ssh://localhost{}/", dst.display()));
+        }
+        Transport::Daemon => {
+            let daemon = DaemonHandle::start_writable(upstream, dst, work)?;
+            cmd.arg(&src_arg).arg(daemon.module_url());
+            let out = run(cmd)?;
+            drop(daemon);
+            return Ok(out);
+        }
+    }
+    run(cmd)
+}
+
 /// Run a prepared command, capturing combined output.
 fn run(mut cmd: Command) -> TaskResult<Output> {
     cmd.output()
@@ -149,13 +195,34 @@ pub struct DaemonHandle {
 }
 
 impl DaemonHandle {
-    /// Start `daemon_bin --daemon` exporting `export_dir` (read-only, no chroot)
+    /// Start `daemon_bin --daemon` exporting `export_dir` read-only (no chroot)
     /// on a free loopback port. Waits until the port accepts connections.
     pub fn start(daemon_bin: &Path, export_dir: &Path, work: &Path) -> TaskResult<DaemonHandle> {
+        Self::start_with(daemon_bin, export_dir, work, true)
+    }
+
+    /// Start a daemon exporting `export_dir` writable, so a client can push into
+    /// the module. Used by [`push_into`] to route an rsync:// push at an upstream
+    /// receiver.
+    pub fn start_writable(
+        daemon_bin: &Path,
+        export_dir: &Path,
+        work: &Path,
+    ) -> TaskResult<DaemonHandle> {
+        Self::start_with(daemon_bin, export_dir, work, false)
+    }
+
+    fn start_with(
+        daemon_bin: &Path,
+        export_dir: &Path,
+        work: &Path,
+        read_only: bool,
+    ) -> TaskResult<DaemonHandle> {
         let port = free_port()?;
         let conf = work.join(format!("rsyncd-{port}.conf"));
+        let read_only = if read_only { "true" } else { "false" };
         let body = format!(
-            "use chroot = no\nport = {port}\n[m]\n    path = {}\n    read only = true\n    numeric ids = yes\n",
+            "use chroot = no\nport = {port}\n[m]\n    path = {}\n    read only = {read_only}\n    numeric ids = yes\n",
             export_dir.display()
         );
         std::fs::write(&conf, body)


### PR DESCRIPTION
## Summary

Upstream `log.c` renders `%f` as `pathjoin(F_PATHNAME(file), f_name(file))` with a single leading slash stripped, but only when `am_sender` - so on a push `%f` shows the full source-side path (e.g. `srcroot/docs/afile.txt`) while oc rendered just the transfer-relative name (`afile.txt`). On a pull `%f` is the relative name, which oc already matched.

Thread a per-event `source_prefix` from the sender's generator (which already records the source-argument base per entry) up to the CLI renderer:

- `ItemizeRow`/`OwnedItemizeRow` carry `source_prefix`; `build_itemize_row` fills it from `GeneratorContext::source_prefix_for(ndx)`, a bounds-guarded literal `pathjoin` (`F_PATHNAME` + `f_name`). It mirrors upstream exactly, including keeping the `.` transfer-root name so the root renders `<base>/.` - distinct from `reconstruct_source_path`, which collapses `.` to open the same inode. Empty on a pull (`source_bases` unpopulated), so `%f` falls back to the relative name.
- `RemoteItemizeFields` and `ClientEvent` gain `source_prefix`; the receiver's event builder leaves it `None` (pull renders the relative name).
- The renderer splits `%n` (`render_name`, relative + dir trailing slash) from `%f` (`render_full_path`, `source_prefix` with one leading slash stripped, no trailing slash), sharing `escape_render_path`.

Also adds an `out_format` check to the drop-in validation harness (`xtask validate`) that compares `--out-format` stdout byte-for-byte against upstream over every transport, for both pull (`%i %n%L`, `%o %n`) and push (`%f`, `%i %f (%n)`). A new `transport::push_into` plus a writable-daemon variant let a cell run the client under test as the sender against an upstream receiver.

## Test plan

- New CLI tests: `%f` uses the push source prefix, strips a single leading slash, and falls back to the relative name without a prefix; `from_remote_itemize` carries `source_prefix`.
- New harness `out_format` check + `out_format_lines` unit tests.
- `cargo fmt` + `cargo clippy -p cli -p core -p transfer -p xtask --all-targets --all-features -D warnings`: clean.
- Targeted nextest (cli/core/transfer/xtask): pass, including the `source_base` reconstruct round-trip (unchanged).
- Byte-exact vs rsync 3.4.1 (protocol 32): the `out_format` check passes all four daemon cells (`%f`, `%i %f (%n)` including the transfer-root `.` row, and the pull templates); a standalone push/pull comparison matches too.