### PR TITLE
fix(daemon): rsyncd.conf parser parity with upstream

### DIFF
--- a/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/value_parsing.rs
@@ -215,6 +215,21 @@ pub(crate) fn apply_boolean_directive(
     }
 }
 
+/// Strips trailing `/` characters from a `P_PATH` value, keeping at least one
+/// character.
+///
+/// upstream: loadparm.c:443-449 `case P_PATH` - `while (len > 1 && ptr[len-1] ==
+/// '/') len--`, so `/srv/data/` is stored as `/srv/data`, `//` becomes `/`, and
+/// a bare `/` is left unchanged. Applied to the `path` and `temp dir` directives.
+pub(crate) fn strip_trailing_slashes(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut len = bytes.len();
+    while len > 1 && bytes[len - 1] == b'/' {
+        len -= 1;
+    }
+    value[..len].to_string()
+}
+
 /// Parses the leading integer of a config value the way C `atoi()` does.
 ///
 /// upstream: loadparm.c:431-433 stores `atoi(parmvalue)` for P_INTEGER

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -793,6 +793,16 @@ fn apply_global_directive(
                 state.module_defaults.dont_compress = Some(value.to_owned());
             }
         }
+        "tempdir" => {
+            // upstream: daemon-parm.txt marks `temp dir` P_LOCAL, so a value in
+            // the global section becomes the default every module inherits
+            // (loadparm.c init_section copies Vars.l). P_PATH: trailing slashes
+            // are stripped. Without this arm a global `temp dir` fell through to
+            // the unknown-directive warning and modules never inherited it.
+            if !value.is_empty() {
+                state.module_defaults.temp_dir = Some(strip_trailing_slashes(value));
+            }
+        }
         "readonly" => {
             if let Some(parsed) =
                 apply_boolean_directive(value, false, "read only", path, line_number)

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -14,17 +14,24 @@
 /// upstream: daemon-parm.txt `Globals:` - `parm_table[]` marks each of these
 /// `P_GLOBAL` (loadparm.c `parm_class`). Everything else is `P_LOCAL` and may
 /// be set per-module.
+///
+/// Entries are stored in the whitespace-folded, lowercase form produced by
+/// `normalize_param_name`, since `is_global_only_directive` is queried with an
+/// already-normalized key. Multi-word names (`daemon chroot`, `motd file`, ...)
+/// must appear without spaces or they would never match, and such a directive in
+/// a module section would fall through to the generic unknown-directive warning
+/// instead of the specific "Global parameter ... found in module section!" path.
 const GLOBAL_ONLY_DIRECTIVES: &[&str] = &[
     "address",
-    "daemon chroot",
-    "daemon gid",
-    "daemon uid",
-    "motd file",
-    "pid file",
-    "socket options",
-    "listen backlog",
+    "daemonchroot",
+    "daemongid",
+    "daemonuid",
+    "motdfile",
+    "pidfile",
+    "socketoptions",
+    "listenbacklog",
     "port",
-    "proxy protocol",
+    "proxyprotocol",
 ];
 
 /// Returns `true` when `key` names an upstream `P_GLOBAL` parameter that is
@@ -54,7 +61,11 @@ fn apply_module_directive(
                     "module path directive must not be empty",
                 ));
             }
-            builder.set_path(PathBuf::from(value), path, line_number)?;
+            builder.set_path(
+                PathBuf::from(strip_trailing_slashes(value)),
+                path,
+                line_number,
+            )?;
         }
         "comment" => {
             let comment = if value.is_empty() {
@@ -314,7 +325,7 @@ fn apply_module_directive(
             let dir = if value.is_empty() {
                 None
             } else {
-                Some(value.to_owned())
+                Some(strip_trailing_slashes(value))
             };
             builder.set_temp_dir(dir, path, line_number)?;
         }
@@ -436,12 +447,15 @@ fn apply_module_directive(
                     "'syslog facility' directive must not be empty",
                 ));
             }
-            // upstream: loadparm.c:456 `case P_ENUM` leaves the (inherited)
-            // value unchanged when the name matches no facility, so an
-            // unrecognised name silently falls back to the global/default
-            // facility rather than raising a config error.
+            // upstream: loadparm.c:456-467 `case P_ENUM` - a name that matches a
+            // facility is stored canonically; an unrecognised name that parses as
+            // a positive integer (`atoi(value) > 0`) is stored as that raw
+            // numeric facility; any other unrecognised name leaves the inherited
+            // value unchanged (no config error).
             if let Some(canonical) = logging_sink::canonical_syslog_facility(value) {
                 builder.set_syslog_facility(canonical.to_owned(), path, line_number)?;
+            } else if parse_atoi(value) > 0 {
+                builder.set_syslog_facility(value.to_owned(), path, line_number)?;
             }
         }
         _ if is_global_only_directive(key) => {

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -108,6 +108,17 @@ fn parse_config_modules_inner(
                     state.modules.push(finish_module_builder(builder, path, &state)?);
                 }
 
+                // upstream: loadparm.c:do_section:497-510 - a section named
+                // "global" (whitespace/case-insensitive via strwiEQ) returns to
+                // the daemon-wide global scope instead of defining a module:
+                // bInGlobalSection = True and no module is added, so directives
+                // that follow apply as global defaults. Leaving `current` as None
+                // routes them through the global dispatch path, exactly as the
+                // directives before the first `[module]` header are handled.
+                if normalize_param_name(name) == "global" {
+                    continue;
+                }
+
                 current = Some(ModuleDefinitionBuilder::new(name.to_owned(), line_number));
                 continue;
             }

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -110,6 +110,77 @@ mod config_parsing_tests {
         assert_eq!(result.modules[1].name, "mod2");
     }
 
+    #[test]
+    fn parse_global_section_returns_to_global_scope() {
+        // upstream loadparm.c:do_section:497-510 - a "[global]" header (case-
+        // insensitive) returns to global scope instead of defining a module, so
+        // only the real module is created and directives after it apply globally.
+        let dir = TempDir::new().expect("create temp dir");
+        let mpath = dir.path().join("data");
+        fs::create_dir(&mpath).expect("create module dir");
+        let config = format!("[Global]\ntimeout = 30\n[mod]\npath = {}\n", mpath.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules.len(), 1, "[global] must not create a module");
+        assert_eq!(result.modules[0].name, "mod");
+    }
+
+    #[test]
+    fn parse_global_temp_dir_inherited_by_module() {
+        // upstream: temp dir is P_LOCAL; a global value is the default every
+        // module inherits.
+        let dir = TempDir::new().expect("create temp dir");
+        let mpath = dir.path().join("data");
+        fs::create_dir(&mpath).expect("create module dir");
+        let config = format!("temp dir = /var/tmp\n[mod]\npath = {}\n", mpath.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].temp_dir.as_deref(), Some("/var/tmp"));
+    }
+
+    #[test]
+    fn parse_path_strips_trailing_slash() {
+        // upstream loadparm.c:443-449 P_PATH strips trailing '/'.
+        let dir = TempDir::new().expect("create temp dir");
+        let mpath = dir.path().join("data");
+        fs::create_dir(&mpath).expect("create module dir");
+        let config = format!("[mod]\npath = {}/\n", mpath.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].path, mpath, "trailing slash must be stripped");
+    }
+
+    #[test]
+    fn parse_syslog_facility_numeric_stored_raw() {
+        // upstream loadparm.c:456-467 P_ENUM - an unrecognised name that is a
+        // positive integer is stored as that raw numeric facility.
+        let dir = TempDir::new().expect("create temp dir");
+        let mpath = dir.path().join("data");
+        fs::create_dir(&mpath).expect("create module dir");
+        let config = format!(
+            "[mod]\npath = {}\nsyslog facility = 17\n",
+            mpath.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].syslog_facility.as_deref(), Some("17"));
+    }
+
+    #[test]
+    fn parse_syslog_facility_unknown_name_leaves_default() {
+        // upstream P_ENUM - an unrecognised non-numeric name leaves the inherited
+        // value unchanged (no config error).
+        let dir = TempDir::new().expect("create temp dir");
+        let mpath = dir.path().join("data");
+        fs::create_dir(&mpath).expect("create module dir");
+        let config = format!(
+            "[mod]\npath = {}\nsyslog facility = bogus\n",
+            mpath.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].syslog_facility, None);
+    }
 
     #[test]
     fn parse_unterminated_module_header() {
@@ -3021,6 +3092,12 @@ mod config_parsing_tests {
     // global-only, while representative P_LOCAL params - including the ones oc
     // currently accepts only in the global section (reverse lookup, lock file,
     // syslog tag, syslog facility) - are never treated as global-only.
+    //
+    // The parser always normalizes a directive key (folding whitespace, lower-
+    // casing) before classifying it, so this test feeds each name through
+    // `normalize_param_name` exactly as production does; a multi-word name like
+    // `daemon chroot` only ever reaches `is_global_only_directive` in its folded
+    // `daemonchroot` form.
     #[test]
     fn global_only_classification_matches_upstream_parm_table() {
         for global in [
@@ -3036,7 +3113,7 @@ mod config_parsing_tests {
             "proxy protocol",
         ] {
             assert!(
-                is_global_only_directive(global),
+                is_global_only_directive(&normalize_param_name(global)),
                 "'{global}' is P_GLOBAL in upstream daemon-parm.txt and must be global-only",
             );
         }
@@ -3053,7 +3130,7 @@ mod config_parsing_tests {
             "syslog facility",
         ] {
             assert!(
-                !is_global_only_directive(local),
+                !is_global_only_directive(&normalize_param_name(local)),
                 "'{local}' is P_LOCAL in upstream daemon-parm.txt and is valid per-module",
             );
         }


### PR DESCRIPTION
## Summary

Five `rsyncd.conf` parsing divergences vs upstream rsync 3.4.4, each mirroring the `loadparm.c` behavior:

- **`[global]` section header** returns to the daemon-wide global scope (`do_section:497-510`, whitespace/case-insensitive) instead of defining a phantom module named `global`. Directives after it apply as global defaults.
- **Global `temp dir`** is inherited as every module's default (P_LOCAL global default); previously a global `temp dir` fell through to the unknown-directive warning.
- **P_PATH trailing-slash stripping** for `path` and `temp dir` (`do_parameter:443-449`): `/srv/data/` is stored as `/srv/data`, keeping at least one character.
- **`syslog facility` numeric fallback**: a positive-integer value with no matching facility name is stored as that raw numeric facility (P_ENUM, `do_parameter:456-467`); an unknown non-numeric name leaves the inherited value unchanged.
- **`GLOBAL_ONLY_DIRECTIVES` normalization**: the table stores its multi-word entries whitespace-folded, so `daemon chroot`, `motd file`, etc. in a module section are correctly recognized as global-only instead of hitting the generic unknown-directive warning.

Deferred to follow-up PRs (tracked): module-name whitespace compression (needs a borrow→owned ripple), negative `max connections` disabling a module (type change), and duplicate-directive last-wins (touches many setters + a validation-reliance audit).

## Test plan

- New parser tests for `[global]` scope, global `temp dir` inheritance, path trailing-slash strip, and `syslog facility` numeric/unknown handling.
- Updated `global_only_classification_matches_upstream_parm_table` to feed keys through `normalize_param_name`, matching production classification (this test had encoded the pre-fix assumption).
- `cargo fmt` + `cargo clippy -p daemon --all-targets -D warnings`: clean.
- Full daemon crate nextest: 1664 passed, 0 failed.