### PR TITLE
fix(filters): honor merge-file modifiers on a plain merge

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
@@ -54,15 +54,18 @@ pub(super) fn split_short_rule_modifiers(text: &str) -> (&str, &str) {
 
 /// Splits a `.`/`:` merge directive's text into `(modifiers, pattern)`. Only
 /// recognised modifier bytes are consumed; the first unrecognised byte or
-/// separator ends the modifier run. `allow_extended` additionally accepts the
-/// dir-merge-only `e`/`n` modifiers.
-pub(super) fn split_short_merge_modifiers(text: &str, allow_extended: bool) -> (&str, &str) {
+/// separator ends the modifier run.
+///
+/// upstream: exclude.c:1256-1264 - the `e` and `n` modifiers are guarded solely
+/// by `FILTRULE_MERGE_FILE`, which `parse_rule_tok` sets for a plain merge (`.`,
+/// exclude.c:1186) as well as a dir-merge (`:`), so both directives accept them.
+pub(super) fn split_short_merge_modifiers(text: &str) -> (&str, &str) {
     if text.is_empty() {
         return ("", "");
     }
 
     if let Some(rest) = text.strip_prefix(',') {
-        let (modifiers, remainder) = split_short_merge_modifiers(rest, allow_extended);
+        let (modifiers, remainder) = split_short_merge_modifiers(rest);
         if modifiers.is_empty() {
             return ("", remainder);
         }
@@ -82,10 +85,10 @@ pub(super) fn split_short_merge_modifiers(text: &str, allow_extended: bool) -> (
         }
 
         let lower = ch.to_ascii_lowercase();
-        let base_modifier = matches!(lower, '+' | '-' | 'c' | 'w' | 's' | 'r' | 'p' | '/');
-        let extended_modifier = matches!(lower, 'e' | 'n');
-
-        if base_modifier || (allow_extended && extended_modifier) {
+        if matches!(
+            lower,
+            '+' | '-' | 'c' | 'w' | 's' | 'r' | 'p' | '/' | 'e' | 'n'
+        ) {
             end = idx + ch.len_utf8();
             continue;
         }
@@ -180,44 +183,40 @@ mod tests {
 
     #[test]
     fn split_short_merge_modifiers_empty() {
-        assert_eq!(split_short_merge_modifiers("", false), ("", ""));
-        assert_eq!(split_short_merge_modifiers("", true), ("", ""));
+        assert_eq!(split_short_merge_modifiers(""), ("", ""));
     }
 
     #[test]
     fn split_short_merge_modifiers_base() {
-        let (mods, rem) = split_short_merge_modifiers("+-cs pattern", false);
+        let (mods, rem) = split_short_merge_modifiers("+-cs pattern");
         assert_eq!(mods, "+-cs");
         assert_eq!(rem, "pattern");
     }
 
     #[test]
-    fn split_short_merge_modifiers_extended_disabled() {
-        // 'e' and 'n' not recognized without extended
-        let (mods, rem) = split_short_merge_modifiers("ce pattern", false);
-        assert_eq!(mods, "c");
-        assert_eq!(rem, "e pattern");
-    }
+    fn split_short_merge_modifiers_accepts_e_and_n() {
+        // upstream exclude.c:1256-1264 gates `e`/`n` on FILTRULE_MERGE_FILE,
+        // which a plain merge (`.`) sets too, so they are modifiers for both
+        // merge forms. Previously `e` ended the run, so `.e FILE` mis-parsed as
+        // the file name "e FILE".
+        let (mods, rem) = split_short_merge_modifiers("ce pattern");
+        assert_eq!(mods, "ce");
+        assert_eq!(rem, "pattern");
 
-    #[test]
-    fn split_short_merge_modifiers_extended_enabled() {
-        let (mods, rem) = split_short_merge_modifiers("cen pattern", true);
+        let (mods, rem) = split_short_merge_modifiers("cen pattern");
         assert_eq!(mods, "cen");
         assert_eq!(rem, "pattern");
     }
 
     #[test]
     fn split_short_merge_modifiers_whitespace_start() {
-        assert_eq!(
-            split_short_merge_modifiers(" pattern", false),
-            ("", "pattern")
-        );
+        assert_eq!(split_short_merge_modifiers(" pattern"), ("", "pattern"));
     }
 
     #[test]
     fn split_short_merge_modifiers_comma_prefix() {
         // 'p' is a valid modifier, so it's extracted
-        let (mods, rem) = split_short_merge_modifiers(",pattern", false);
+        let (mods, rem) = split_short_merge_modifiers(",pattern");
         assert_eq!(mods, "p");
         assert_eq!(rem, "attern");
     }
@@ -225,7 +224,7 @@ mod tests {
     #[test]
     fn split_short_merge_modifiers_comma_only_non_modifier() {
         // 'x' is not a valid modifier
-        let (mods, rem) = split_short_merge_modifiers(",xyz", false);
+        let (mods, rem) = split_short_merge_modifiers(",xyz");
         assert_eq!(mods, "");
         assert_eq!(rem, "xyz");
     }

--- a/crates/cli/src/frontend/filter_rules/parsing/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/merge.rs
@@ -8,15 +8,20 @@ use super::super::directive::{FilterDirective, MergeDirective};
 use super::helpers::split_short_merge_modifiers;
 
 /// Parses the modifier characters that follow a `.`/`:` merge directive into
-/// `DirMergeOptions`. `allow_extended` enables the dir-merge-only modifiers
-/// (`e`, `n`). Returns the options and whether `C` implied `.cvsignore`.
-/// Modifiers are matched case-sensitively to mirror upstream.
+/// `DirMergeOptions`. `is_dir_merge` selects the per-directory (`:`) defaults;
+/// the modifier set itself is identical for both directives. Returns the options
+/// and whether `C` implied `.cvsignore`. Modifiers are matched case-sensitively
+/// to mirror upstream.
+///
+/// upstream: exclude.c:1256-1264 - `e` (FILTRULE_EXCLUDE_SELF) and `n`
+/// (FILTRULE_NO_INHERIT) are guarded only by `FILTRULE_MERGE_FILE`, which is set
+/// for a plain merge (`.`) as well as a dir-merge (`:`), so both accept them.
 pub(crate) fn parse_merge_modifiers(
     modifiers: &str,
     directive: &str,
-    allow_extended: bool,
+    is_dir_merge: bool,
 ) -> Result<(DirMergeOptions, bool), Message> {
-    let mut options = if allow_extended {
+    let mut options = if is_dir_merge {
         DirMergeOptions::default()
     } else {
         DirMergeOptions::default().allow_list_clearing(true)
@@ -79,34 +84,10 @@ pub(crate) fn parse_merge_modifiers(
                 assume_cvsignore = true;
             }
             'e' => {
-                if allow_extended {
-                    options = options.exclude_filter_file(true);
-                } else {
-                    let message = rsync_error!(
-                        1,
-                        format!(
-                            "filter merge directive '{directive}' uses unsupported modifier '{}'",
-                            modifier
-                        )
-                    )
-                    .with_role(Role::Client);
-                    return Err(message);
-                }
+                options = options.exclude_filter_file(true);
             }
             'n' => {
-                if allow_extended {
-                    options = options.inherit(false);
-                } else {
-                    let message = rsync_error!(
-                        1,
-                        format!(
-                            "filter merge directive '{directive}' uses unsupported modifier '{}'",
-                            modifier
-                        )
-                    )
-                    .with_role(Role::Client);
-                    return Err(message);
-                }
+                options = options.inherit(false);
             }
             'w' => {
                 options = options.use_whitespace().allow_comments(false);
@@ -138,7 +119,7 @@ pub(crate) fn parse_merge_modifiers(
     }
 
     options = options.with_enforced_kind(enforced);
-    if !allow_extended && !options.list_clear_allowed() {
+    if !is_dir_merge && !options.list_clear_allowed() {
         options = options.allow_list_clearing(true);
     }
     Ok((options, assume_cvsignore))
@@ -150,15 +131,15 @@ pub(crate) fn parse_merge_modifiers(
 pub(super) fn parse_short_merge_directive(text: &str) -> Option<Result<FilterDirective, Message>> {
     let mut chars = text.chars();
     let first = chars.next()?;
-    let (allow_extended, label) = match first {
+    let (is_dir_merge, label) = match first {
         '.' => (false, "merge"),
         ':' => (true, "dir-merge"),
         _ => return None,
     };
 
     let remainder = chars.as_str();
-    let (modifiers, rest) = split_short_merge_modifiers(remainder, allow_extended);
-    let (options, assume_cvsignore) = match parse_merge_modifiers(modifiers, text, allow_extended) {
+    let (modifiers, rest) = split_short_merge_modifiers(remainder);
+    let (options, assume_cvsignore) = match parse_merge_modifiers(modifiers, text, is_dir_merge) {
         Ok(result) => result,
         Err(error) => return Some(Err(error)),
     };
@@ -167,7 +148,7 @@ pub(super) fn parse_short_merge_directive(text: &str) -> Option<Result<FilterDir
     let pattern = if pattern.is_empty() {
         if assume_cvsignore {
             ".cvsignore"
-        } else if allow_extended {
+        } else if is_dir_merge {
             let message = rsync_error!(
                 1,
                 format!("filter rule '{text}' is missing a file name after '{label}'")
@@ -186,7 +167,7 @@ pub(super) fn parse_short_merge_directive(text: &str) -> Option<Result<FilterDir
         pattern
     };
 
-    if allow_extended {
+    if is_dir_merge {
         let rule = FilterRuleSpec::dir_merge(pattern.to_owned(), options);
         return Some(Ok(FilterDirective::Rule(rule)));
     }
@@ -256,27 +237,46 @@ mod tests {
     }
 
     #[test]
-    fn parse_merge_modifiers_exclude_self_extended() {
+    fn parse_merge_modifiers_exclude_self_dir_merge() {
         let (options, _) = parse_merge_modifiers("e", ":e file", true).unwrap();
         assert!(options.excludes_self());
     }
 
     #[test]
-    fn parse_merge_modifiers_exclude_self_not_extended() {
-        let result = parse_merge_modifiers("e", ".e file", false);
-        assert!(result.is_err());
+    fn parse_merge_modifiers_exclude_self_plain_merge() {
+        // upstream exclude.c:1256-1259 guards `e` only by FILTRULE_MERGE_FILE,
+        // which a plain merge (`.`) sets too, so `.e FILE` is valid.
+        let (options, _) = parse_merge_modifiers("e", ".e file", false).unwrap();
+        assert!(options.excludes_self());
     }
 
     #[test]
-    fn parse_merge_modifiers_no_inherit_extended() {
+    fn parse_merge_modifiers_no_inherit_dir_merge() {
         let (options, _) = parse_merge_modifiers("n", ":n file", true).unwrap();
         assert!(!options.inherit_rules());
     }
 
     #[test]
-    fn parse_merge_modifiers_no_inherit_not_extended() {
-        let result = parse_merge_modifiers("n", ".n file", false);
-        assert!(result.is_err());
+    fn parse_merge_modifiers_no_inherit_plain_merge() {
+        // upstream exclude.c:1260-1264 guards `n` the same way as `e`.
+        let (options, _) = parse_merge_modifiers("n", ".n file", false).unwrap();
+        assert!(!options.inherit_rules());
+    }
+
+    #[test]
+    fn parse_short_plain_merge_accepts_exclude_self_modifier() {
+        // Regression: `.e FILE` previously mis-split, treating `e` as part of
+        // the file name ("e FILE") instead of as a modifier.
+        let directive = parse_short_merge_directive(".e rules")
+            .expect("recognized")
+            .expect("parses");
+        match directive {
+            FilterDirective::Merge(merge) => {
+                assert_eq!(merge.source(), std::ffi::OsStr::new("rules"));
+                assert!(merge.options().excludes_self());
+            }
+            other => panic!("expected a merge directive, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -384,11 +384,6 @@ impl ShortFormAction {
         }
     }
 
-    /// Whether this action supports modifiers.
-    const fn supports_mods(self) -> bool {
-        !matches!(self, Self::Merge)
-    }
-
     /// Whether this action is a merge-file rule (`.`/`:`/`merge`/`dir-merge`).
     ///
     /// upstream: `FILTRULE_MERGE_FILE` covers both plain and per-directory
@@ -461,12 +456,13 @@ fn try_parse_short_form(
         return Ok(None);
     }
 
+    // upstream: exclude.c:1214-1287 `parse_rule_tok` applies the parsed modifiers
+    // to every rule prefix, including a plain merge (`.`): the merge-file
+    // modifiers are gated on `FILTRULE_MERGE_FILE`, which `.` sets (exclude.c:1186)
+    // just as `:` does. Dropping them for `.` silently ignored `C`, `w`, `n`, `e`,
+    // side restrictions and anchoring on plain merges.
     let rule = action.to_rule(pattern);
-    Ok(Some(if action.supports_mods() {
-        mods.apply(rule)
-    } else {
-        rule
-    }))
+    Ok(Some(mods.apply(rule)))
 }
 
 /// Returns true for the characters upstream `isspace()` treats as whitespace in
@@ -535,11 +531,7 @@ fn try_parse_long_form(
                     line_num,
                 )?;
                 let rule = action.to_rule(pattern);
-                return Ok(Some(if action.supports_mods() {
-                    mods.apply(rule)
-                } else {
-                    rule
-                }));
+                return Ok(Some(mods.apply(rule)));
             }
             // upstream: rule_strcmp accepts isspace/`_` as terminating
             // separators; exactly one is consumed and the remainder is the


### PR DESCRIPTION
## Summary

Upstream gates the merge-file modifiers on `FILTRULE_MERGE_FILE`, which `parse_rule_tok` sets for a plain merge (`.`, `exclude.c:1186`) exactly as it does for a dir-merge (`:`). Both directives accept the same modifier set, and `e` (`FILTRULE_EXCLUDE_SELF`) / `n` (`FILTRULE_NO_INHERIT`) are valid on either (`exclude.c:1256-1264`).

oc treated `e`/`n` as dir-merge-only behind an `allow_extended` flag, causing three defects:

- The short-form splitter stopped the modifier run at `e`, so `.e FILE` mis-parsed as the file name `"e FILE"` and failed with a read error.
- `merge,n FILE` was rejected outright as an unsupported modifier.
- The `filters` library parsed a plain merge's modifiers and then **dropped** them (`supports_mods` excluded `Merge`), silently ignoring `C`, `w`, `n`, `e`, side restrictions and anchoring.

The flag conflated two orthogonal concerns - *which directive is being parsed* vs *which modifiers are legal*. Modifier acceptance is now uniform; the remaining per-directive behaviour (dir-merge defaults, list clearing, rule construction) is carried by a flag renamed `is_dir_merge` to say what it actually selects. `supports_mods` became an always-true distinction once the modifier set was unified, so it is removed and both call sites apply the modifiers.

## Test plan

- Verified against **rsync 3.4.4** (built from source, protocol 32): `--filter='.e FILE'` and `--filter='merge,n FILE'` now produce the same destination tree as upstream (both previously failed in oc).
- Rewrote the three tests that encoded the old behaviour (`split_short_merge_modifiers_extended_disabled` asserted the `.e` mis-split; the two `*_not_extended` tests asserted the rejections) and added a regression test for `.e FILE` parsing to a merge directive with `excludes_self`.
- `cargo fmt --all -- --check` + `cargo clippy -p cli -p filters --all-targets --all-features -D warnings`: clean.
- `cargo nextest run -p filters -p cli --all-features`: **5141 passed**, 0 failed.