### PR TITLE
fix(core): stop forwarding --munge-links to the remote server

### DIFF
--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -580,9 +580,11 @@ impl<'a> RemoteInvocationBuilder<'a> {
         if self.config.safe_links() {
             args.push(OsString::from("--safe-links"));
         }
-        if self.config.munge_links() {
-            args.push(OsString::from("--munge-links"));
-        }
+        // upstream: `--munge-links` is deliberately absent from server_options()
+        // (options.c) - it is a local-side option applied where the symlink is
+        // written (options.c:2254 gates it on `!am_daemon`), so the remote is
+        // never told about it. Forwarding it made oc's server invocation differ
+        // from upstream's for every `--munge-links` transfer.
 
         // upstream: options.c:2905-2906 - --numeric-ids is long-form only.
         if self.config.numeric_ids() {

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -2449,13 +2449,16 @@ fn includes_safe_links_long_arg() {
     );
 }
 
+/// upstream: `--munge-links` never appears in `server_options()` (options.c) -
+/// it is applied locally where the symlink is written and is gated on
+/// `!am_daemon` (options.c:2254), so the remote is never told about it.
 #[test]
-fn includes_munge_links_long_arg() {
+fn omits_munge_links_long_arg() {
     let config = ClientConfig::builder().munge_links(true).build();
     let args = build_sender_args(&config);
     assert!(
-        args.iter().any(|a| a == "--munge-links"),
-        "expected --munge-links in args: {args:?}"
+        !args.iter().any(|a| a == "--munge-links"),
+        "--munge-links must not be forwarded to the remote: {args:?}"
     );
 }
 
@@ -3134,7 +3137,6 @@ fn all_flags_enabled_produces_valid_invocation() {
         "--inplace",
         "--copy-unsafe-links",
         "--safe-links",
-        "--munge-links",
         "--size-only",
         "--ignore-existing",
         "--existing",
@@ -3152,6 +3154,14 @@ fn all_flags_enabled_produces_valid_invocation() {
             "all-flags test: missing {expected} in args: {args:?}"
         );
     }
+
+    // upstream: `--munge-links` is absent from server_options() entirely - it is
+    // applied locally where the symlink is written (options.c:2254, gated on
+    // !am_daemon), so it must never reach the remote.
+    assert!(
+        !args.iter().any(|a| a == "--munge-links"),
+        "all-flags test: --munge-links must not be forwarded to the remote: {args:?}"
+    );
 
     // upstream: options.c:2825,2852-2853 - the super flag is forwarded only in
     // the am_sender branch (to a remote receiver), so a remote-sender (pull)


### PR DESCRIPTION
## Summary

`--munge-links` never appears in upstream's `server_options()` (`options.c`): it is a local-side option applied where the symlink is written, gated on `!am_daemon` (`options.c:2254`), so the remote peer is never told about it.

oc appended `--munge-links` to every remote invocation that enabled it, so the server argument vector diverged from upstream's for those transfers.

## Verification

Captured the argv each client hands the remote shell, against **rsync 3.4.4** (built from source, protocol 32):

```
upstream:    rsync --server -logDtpre.iLsfxCIvu . /dst/
oc (before): rsync --server -logDtpre.iLsfxCIvu --munge-links . /dst/
oc (after):  rsync --server -logDtpre.iLsfxCIvu . /dst/
```

## Test plan

- The test that asserted the flag was forwarded (`includes_munge_links_long_arg`) is inverted to `omits_munge_links_long_arg`; the all-flags invocation test gains the same negative assertion. Both cite the upstream rationale.
- `--munge-links` stays in `UPSTREAM_SERVER_LONG_ARGS` because that list tracks what upstream's `--server` mode *accepts*, not what the client sends.
- `cargo fmt --all -- --check` + `cargo clippy -p core --all-targets --all-features -D warnings`: clean.
- `cargo nextest run -p core --all-features`: **2685 passed**, 0 failed.