### PR TITLE
fix(daemon): collapse whitespace in rsyncd.conf section names

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -31,6 +31,27 @@ fn normalize_param_name(name: &str) -> String {
         .to_ascii_lowercase()
 }
 
+/// Collapses a `[section]` header name the way upstream's config scanner does:
+/// leading and trailing whitespace is dropped and every internal whitespace run
+/// becomes exactly one space (0x20).
+///
+/// upstream: params.c:Section() - `EatWhitespace()` skips the run right after
+/// the '[', the `end`/`i` split drops the run before the ']', and the
+/// `isspace(c)` arm of the character switch writes a single ' ' per whitespace
+/// region before eating the rest of that region. `[my   module]` therefore
+/// defines the module named `my module`, which upstream loads without any
+/// warning and serves under exactly that single-spaced name.
+fn collapse_section_name(name: &str) -> String {
+    // upstream: params.c:Section() tests C `isspace()` on single bytes, which
+    // covers the same ASCII set as `normalize_param_name` (including the
+    // vertical tab that `char::is_ascii_whitespace` omits) and never matches a
+    // multi-byte character.
+    name.split([' ', '\t', '\n', '\x0B', '\x0C', '\r'])
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<&str>>()
+        .join(" ")
+}
+
 /// Parses the `rsyncd.conf` at `path` into module definitions and global settings.
 pub(crate) fn parse_config_modules(path: &Path) -> Result<ParsedConfigModules, DaemonError> {
     let mut stack = Vec::new();
@@ -81,7 +102,8 @@ fn parse_config_modules_inner(
                 let end = line.find(']').ok_or_else(|| {
                     config_parse_error(path, line_number, "unterminated module header")
                 })?;
-                let name = line[1..end].trim();
+                let collapsed = collapse_section_name(&line[1..end]);
+                let name = collapsed.as_str();
 
                 if name.is_empty() {
                     return Err(config_parse_error(
@@ -91,7 +113,7 @@ fn parse_config_modules_inner(
                     ));
                 }
 
-                ensure_valid_module_name(name)
+                ensure_valid_section_name(name)
                     .map_err(|msg| config_parse_error(path, line_number, msg))?;
 
                 let trailing = line[end + 1..].trim();

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -3318,4 +3318,125 @@ mod config_parsing_tests {
             "a module-level 'auth users' overrides the global default",
         );
     }
+
+    /// A section name keeps its internal whitespace, collapsed to one space per
+    /// run, because that is the name clients must send to reach the module.
+    ///
+    /// upstream: params.c:Section() - the `isspace(c)` arm writes a single ' '
+    /// per whitespace region and then eats the rest of that region, so
+    /// `[my   module]` is the module `my module`. Verified against rsync 3.4.4:
+    /// the daemon starts without a warning and lists the name as `my module`.
+    #[test]
+    fn parse_section_name_collapses_internal_whitespace_run() {
+        let dir = TempDir::new().expect("create temp dir");
+        let mpath = dir.path().join("data");
+        fs::create_dir(&mpath).expect("create module dir");
+
+        let config = format!("[my   module]\npath = {}\n", mpath.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(
+            result.modules[0].name, "my module",
+            "a whitespace run inside a section name collapses to exactly one space",
+        );
+    }
+
+    /// Whitespace between the brackets and the name is not part of the name.
+    ///
+    /// upstream: params.c:Section() - `EatWhitespace()` consumes the run after
+    /// the '[' and the `end`/`i` split drops the run before the ']'.
+    #[test]
+    fn parse_section_name_trims_surrounding_whitespace() {
+        let dir = TempDir::new().expect("create temp dir");
+        let mpath = dir.path().join("data");
+        fs::create_dir(&mpath).expect("create module dir");
+
+        let config = format!("[   spaced module \t ]\npath = {}\n", mpath.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(result.modules[0].name, "spaced module");
+    }
+
+    /// Tabs and mixed runs collapse just like plain spaces.
+    ///
+    /// upstream: params.c:Section() branches on C `isspace()`, which treats a
+    /// tab, a form feed, and a vertical tab exactly like a space, so the run is
+    /// replaced by a single 0x20 regardless of what it was made of.
+    #[test]
+    fn parse_section_name_collapses_tabs_and_mixed_runs() {
+        let dir = TempDir::new().expect("create temp dir");
+        let mpath = dir.path().join("data");
+        fs::create_dir(&mpath).expect("create module dir");
+
+        let config = format!("[a\t \x0Bb \x0C c]\npath = {}\n", mpath.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(result.modules[0].name, "a b c");
+    }
+
+    /// Collapsing is applied to the raw header text, never to a name that is
+    /// already free of whitespace.
+    ///
+    /// upstream: params.c:Section() copies every non-`isspace()` byte verbatim.
+    #[test]
+    fn collapse_section_name_matches_upstream_scanner() {
+        assert_eq!(collapse_section_name("my   module"), "my module");
+        assert_eq!(collapse_section_name("  padded  "), "padded");
+        assert_eq!(collapse_section_name("a\t\tb"), "a b");
+        assert_eq!(collapse_section_name("plain"), "plain");
+        assert_eq!(collapse_section_name("   "), "");
+    }
+
+    /// Collapsing must not turn an all-whitespace header into a nameless module.
+    ///
+    /// upstream: params.c:Section() rejects a zero-length name outright
+    /// ("Empty section name in config file."), and after collapsing `[   ]` has
+    /// exactly that.
+    #[test]
+    fn parse_whitespace_only_section_name_is_rejected() {
+        let file = write_config("[   ]\npath = /tmp\n");
+        let error = parse_config_modules(file.path()).expect_err("empty name is rejected");
+        assert!(
+            error.to_string().contains("module name must be non-empty"),
+            "unexpected error: {error}",
+        );
+    }
+
+    /// REGRESSION GUARD: module lookup stays byte-exact against the collapsed
+    /// name. Do not add whitespace-insensitive or case-insensitive matching.
+    ///
+    /// The collapse only changes how the `[section]` header is scanned; it does
+    /// not make the name fuzzy. Verified against rsync 3.4.4 with a module
+    /// declared as `[my   module]`: requesting `my module` transfers (exit 0)
+    /// while `mymodule`, `my   module`, `MY MODULE`, and `MyModule` each get
+    /// `@ERROR: Unknown module '<name>'` (exit 5). `strwiEQ` governs parameter
+    /// name matching (loadparm.c:282), never module lookup, which compares with
+    /// `strcmp` - mirrored by the `module.name == request` test in
+    /// `module_access/request.rs`.
+    #[test]
+    fn parse_section_name_lookup_stays_exact() {
+        let dir = TempDir::new().expect("create temp dir");
+        let mpath = dir.path().join("data");
+        fs::create_dir(&mpath).expect("create module dir");
+
+        let config = format!("[my   module]\npath = {}\n", mpath.display());
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+
+        let lookup = |request: &str| result.modules.iter().any(|module| module.name == request);
+
+        assert!(lookup("my module"), "the collapsed name must resolve");
+        for request in ["mymodule", "my   module", "MY MODULE", "MyModule"] {
+            assert!(
+                !lookup(request),
+                "'{request}' must not resolve to 'my module' - lookup is exact",
+            );
+        }
+    }
 }

--- a/crates/daemon/src/daemon/sections/module_parsing/errors.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/errors.rs
@@ -111,6 +111,29 @@ fn ensure_valid_module_name(name: &str) -> Result<(), &'static str> {
     Ok(())
 }
 
+/// Validates an already-collapsed `rsyncd.conf` `[section]` header name.
+///
+/// Deliberately separate from `ensure_valid_module_name`: the whitespace
+/// collapse that makes a single interior space legal lives in
+/// params.c:Section(), which upstream runs only while scanning a config-file
+/// section header. The daemon's CLI `NAME=PATH` specs never pass through that
+/// scanner, so they keep the stricter no-whitespace rule.
+///
+/// The caller must pass a name produced by `collapse_section_name`, so the only
+/// whitespace it can still hold is a single interior space. Path separators
+/// stay fatal exactly as they are for a CLI spec.
+fn ensure_valid_section_name(name: &str) -> Result<(), &'static str> {
+    if name.is_empty() {
+        return Err("module name must be non-empty and cannot contain whitespace");
+    }
+
+    if name.chars().any(|ch| ch == '/' || ch == '\\') {
+        return Err("module name cannot contain whitespace or path separators");
+    }
+
+    Ok(())
+}
+
 fn duplicate_argument(option: &str) -> DaemonError {
     config_error(format!("duplicate daemon argument '{option}'"))
 }


### PR DESCRIPTION
## Problem

`params.c:Section()` builds a section name by skipping the whitespace run after the `[`, dropping the run before the `]`, and writing **a single space per interior whitespace region** before eating the rest of that region:

```c
default:                        /* All else are a valid name chars.   */
  if( isspace( c ) )              /* One space per whitespace region. */
    { bufr[end] = ' '; i = end + 1; c = EatWhitespace( InFile ); }
  else
    { bufr[i++] = c; end = i; c = getc( InFile ); }
```

So `[my   module]` defines a module named `my module`, which upstream loads without warning and serves under exactly that name.

oc-rsync trimmed only the outside and then rejected any interior whitespace, so a configuration upstream serves made the daemon **refuse to start**.

## Fix

Collapse each interior whitespace run to one space when parsing a section header, then validate the collapsed name.

**Module lookup is untouched and stays exact.** This matters: upstream resolves only the collapsed spelling, so `mymodule` and `my   module` remain unknown modules. A regression test pins that explicitly, because loosening the lookup is the tempting follow-on mistake - an earlier reading of `loadparm.c` suggested `strwiEQ` made lookup whitespace-insensitive, and testing the real binary disproved it (`strwiEQ` governs *parameter* names, not module lookup).

Scope is limited to config-file section headers, matching where upstream's collapse lives. The daemon CLI's `NAME=PATH` form keeps its existing validation, and `/` stays fatal.

## Verification

A/B against **rsync 3.4.4 built from source**, both daemons answering the same client - identical in every case:

```
upstream listing: [my module      ]
  upstream  request "my module"    exit=0 : drwxrwxr-x  60 ... .
  upstream  request "mymodule"     exit=5 : @ERROR: Unknown module 'mymodule'
  upstream  request "my   module"  exit=5 : @ERROR: Unknown module 'my   module'

oc-rsync listing: [my module      ]
  oc-rsync  request "my module"    exit=0 : drwxrwxr-x  60 ... .
  oc-rsync  request "mymodule"     exit=5 : @ERROR: Unknown module 'mymodule'
  oc-rsync  request "my   module"  exit=5 : @ERROR: Unknown module 'my   module'
```

`cargo fmt --all --check`, `cargo clippy -p daemon --all-targets --all-features -D warnings`, and `cargo nextest run -p daemon --all-features` (1758 passed) are clean.

## Tests

Added: collapse of multi-space and tab/mixed runs, trimming inside the brackets, `[   ]` still rejected as empty, and the exact-lookup regression guard. The test diff deletes nothing - no existing assertion changed meaning.

## Note on `/`

An earlier draft made `/` in a section name warn-only. Testing the real binary showed that is wrong: `do_section` returning False aborts the per-connection `load_config(0)` with `RERR_SYNTAX`, so one `/` section makes the **entire config** unusable for every connection - including unrelated valid modules - while the daemon process stays up. Warning and registering the module would have made oc-rsync serve a module upstream refuses to serve, so that change was reverted. The remaining difference is only *when* the error surfaces (startup vs per-connection), tracked separately.
