### PR TITLE
fix(batch): compress the batch body and set the -z stream flag

### DIFF
--- a/crates/batch/src/format/flags.rs
+++ b/crates/batch/src/format/flags.rs
@@ -145,11 +145,11 @@ pub struct BatchFlags {
     pub xfer_dirs: bool,
     /// Bit 8: --compress (-z) [protocol >= 29] - upstream: batch.c:68 `&do_compression`
     ///
-    /// When true, the batch body contains compressed token data and the
-    /// reader must decompress using CPRES_ZLIB (upstream compat.c:194-195).
-    /// oc-rsync always writes `false` here because it records uncompressed
-    /// data, avoiding the upstream limitation where the batch format does
-    /// not record the actual compression algorithm.
+    /// When true, the batch body carries compressed token data and the reader
+    /// must decompress it. The codec is always zlib: upstream
+    /// `compat.c:414 getenv_nstr()` pins the compression list to "zlib" while
+    /// `write_batch` is set, and `compat.c:194-195 parse_compress_choice()`
+    /// resolves a bare `do_compression` to CPRES_ZLIB on `--read-batch`.
     pub do_compression: bool,
     /// Bit 9: --iconv [protocol >= 30] - upstream: batch.c:69 `&tweaked_iconv`
     pub iconv: bool,

--- a/crates/batch/src/tests.rs
+++ b/crates/batch/src/tests.rs
@@ -894,16 +894,13 @@ mod integration {
         assert_eq!(content, b"Hello, batch!");
     }
 
-    /// Verifies that batch files with `do_compression=true` flag store raw
-    /// (uncompressed) protocol data and can be read back correctly.
+    /// Verifies that [`BatchWriter::write_data`] stays a verbatim passthrough
+    /// even when the recorded flags carry `do_compression=true`.
     ///
-    /// PR #3051 fixed a bug where compression was applied to batch file data.
-    /// Batch files must always contain uncompressed data regardless of the
-    /// `do_compression` flag - that flag only records that the original
-    /// transfer used compression, so --read-batch knows to set the flag
-    /// when replaying. The actual batch file body is a raw tee of the
-    /// uncompressed protocol stream.
-    /// upstream: batch.c - batch file body is always uncompressed
+    /// Compression lives in the token encoder that produces the bytes handed
+    /// to the writer (upstream `token.c:send_deflated_token()`); the writer
+    /// itself is only the `batch_fd` tee from `io.c:read_buf()` and must never
+    /// re-encode what it is given.
     #[test]
     fn test_batch_roundtrip_with_compression_flag() {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/core/src/client/remote/batch_support.rs
+++ b/crates/core/src/client/remote/batch_support.rs
@@ -44,19 +44,14 @@ pub(crate) fn build_batch_context(
         preserve_hard_links: config.preserve_hard_links(),
         always_checksum: config.checksum(),
         xfer_dirs: config.dirs(),
-        // upstream tees raw (compressed) wire bytes to the batch file
-        // and sets do_compression=true in stream flags. On read-batch,
-        // upstream's parse_compress_choice() (compat.c:194-195) maps
-        // do_compression=1 to CPRES_ZLIB regardless of the actual
-        // algorithm used during write. This causes upstream to fail
-        // reading its own batch files when the original transfer
-        // auto-negotiated zstd (rsync 3.4.1 with SUPPORT_ZSTD).
-        //
-        // oc-rsync avoids this upstream limitation by capturing
-        // post-decompression data. Always false so replay reads
-        // uncompressed tokens correctly and batch files are portable
-        // across all compression backends.
-        do_compression: false,
+        // upstream: batch.c:68 - do_compression is stream-flag bit 8, set by
+        // batch.c:96-113 write_stream_flags() whenever the option is active.
+        // The recorder is attached to the multiplex layer, so it tees the raw
+        // (still compressed) wire bytes exactly like upstream's
+        // write_batch_monitor_in in io.c:read_buf(). The bit must therefore
+        // track the option, otherwise `--read-batch` would decode deflated
+        // tokens as plain ones.
+        do_compression: config.compress(),
         preserve_acls,
         preserve_xattrs,
         inplace: config.inplace(),
@@ -142,39 +137,13 @@ impl std::io::Write for BatchWriteAdapter {
 mod tests {
     use super::*;
 
-    /// Verifies that `build_batch_context` always sets `do_compression=false`,
-    /// even when the client configuration has compression enabled. oc-rsync
-    /// captures post-decompression data, so the batch file body is always
-    /// uncompressed. This avoids an upstream rsync 3.4.1 limitation where
-    /// batch files written with zstd compression are unreadable because
-    /// read-batch forces CPRES_ZLIB (upstream compat.c:194-195).
+    /// upstream: batch.c:68 puts `do_compression` at stream-flag bit 8 and
+    /// batch.c:96-113 `write_stream_flags()` sets every active flag. The SSH
+    /// and daemon recorders tee the multiplexed wire bytes, which under `-z`
+    /// are `token.c:send_deflated_token()` output, so the bit has to follow the
+    /// option or `--read-batch` would misparse those tokens.
     #[test]
-    fn batch_context_never_sets_do_compression() {
-        let config = ClientConfig::builder().compress(true).build();
-        let temp = tempfile::TempDir::new().unwrap();
-        let path = temp.path().join("test.batch");
-        let batch_cfg = engine::batch::BatchConfig::new(
-            engine::batch::BatchMode::Write,
-            path.to_string_lossy().to_string(),
-            31,
-        );
-        let writer = Arc::new(Mutex::new(BatchWriter::new(batch_cfg).unwrap()));
-        let ctx = build_batch_context(&config, writer);
-        assert!(
-            !ctx.flags.do_compression,
-            "do_compression must be false - oc-rsync captures uncompressed data"
-        );
-    }
-
-    /// Verifies do_compression is false for all compression-related configs.
-    ///
-    /// This documents that oc-rsync's batch design avoids the upstream rsync
-    /// 3.4.1 limitation where the batch format does not record which
-    /// compression algorithm was used. Upstream's read-batch always assumes
-    /// CPRES_ZLIB (compat.c:194-195), but the write-batch may have used
-    /// zstd, lz4, or zlibx - causing unreadable batch files.
-    #[test]
-    fn batch_context_do_compression_false_regardless_of_compress_config() {
+    fn batch_context_tracks_the_compress_option() {
         for compress_enabled in [true, false] {
             let config = ClientConfig::builder().compress(compress_enabled).build();
             let temp = tempfile::TempDir::new().unwrap();
@@ -186,9 +155,9 @@ mod tests {
             );
             let writer = Arc::new(Mutex::new(BatchWriter::new(batch_cfg).unwrap()));
             let ctx = build_batch_context(&config, writer);
-            assert!(
-                !ctx.flags.do_compression,
-                "do_compression must always be false (compress={compress_enabled})"
+            assert_eq!(
+                ctx.flags.do_compression, compress_enabled,
+                "bit 8 must mirror --compress (compress={compress_enabled})"
             );
         }
     }

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -96,17 +96,15 @@ fn config_batch_flags(config: &ClientConfig) -> engine::batch::BatchFlags {
         preserve_hard_links: config.preserve_hard_links(),
         always_checksum: config.checksum(),
         xfer_dirs: config.dirs(),
-        // upstream: batch.c:68 - do_compression is bit 8 in stream flags.
-        // Upstream tees the raw (pre-decompression) wire bytes to
-        // batch_fd via write_batch_monitor_in in io.c:read_buf(),
-        // so its batch files contain compressed tokens and the header
-        // says do_compression=true.
-        // oc-rsync captures post-decompression (uncompressed) data at
-        // the CompressedReader layer, so the batch body is always
-        // uncompressed. Setting do_compression=false ensures that both
-        // oc-rsync and upstream rsync replay the file without trying to
-        // decompress already-uncompressed tokens.
-        do_compression: false,
+        // upstream: batch.c:68 - do_compression is bit 8 in stream flags, set
+        // whenever compression is active (batch.c:96-113 write_stream_flags()
+        // gates the bit on protocol >= 29, which BatchFlags::to_bitmap applies).
+        // Upstream tees the raw wire bytes to batch_fd via
+        // write_batch_monitor_in in io.c:read_buf(), so a batch recorded under
+        // -z carries token.c:send_deflated_token() framing and the header must
+        // advertise it. The codec is always zlib: compat.c:414 getenv_nstr()
+        // pins the compression list to "zlib" while write_batch is set.
+        do_compression: config.compress(),
         // upstream: batch.c:69,101-103 - bit 9 records tweaked_iconv
         // (iconv_opt != NULL). --no-iconv and an unset --iconv both leave
         // iconv_opt NULL, so only an explicit charset request sets the bit.
@@ -454,30 +452,45 @@ mod tests {
         assert!(handle_batch_read(&batch_cfg, &config).is_none());
     }
 
-    /// Batch header must always have do_compression=false because oc-rsync
-    /// captures post-decompression (uncompressed) data in the batch file.
-    /// upstream tees pre-decompression data and sets do_compression=true,
-    /// but our approach avoids that complexity.
-    #[test]
-    fn write_batch_header_never_sets_do_compression() {
+    /// Reads back the stream flags recorded by `write_batch_header`.
+    fn recorded_flags(compress: bool, proto: i32) -> engine::batch::BatchFlags {
         let temp = tempfile::TempDir::new().unwrap();
         let path = temp.path().join("test.batch");
-        let batch_cfg = BatchConfig::new(BatchMode::Write, path.to_string_lossy().to_string(), 31)
-            .with_checksum_seed(1);
+        let batch_cfg =
+            BatchConfig::new(BatchMode::Write, path.to_string_lossy().to_string(), proto)
+                .with_checksum_seed(1);
 
         let writer_arc = create_batch_writer(&batch_cfg).unwrap();
-
-        let config = config_with_compress(true);
-        write_batch_header(&writer_arc, &config).unwrap();
+        write_batch_header(&writer_arc, &config_with_compress(compress)).unwrap();
         drop(writer_arc);
 
-        let read_cfg = BatchConfig::new(BatchMode::Read, path.to_string_lossy().to_string(), 31);
+        let read_cfg = BatchConfig::new(BatchMode::Read, path.to_string_lossy().to_string(), proto);
         let mut reader = engine::batch::BatchReader::new(read_cfg).unwrap();
-        let flags = reader.read_header().unwrap();
-        assert!(
-            !flags.do_compression,
-            "do_compression must be false - oc-rsync captures uncompressed data"
-        );
+        reader.read_header().unwrap()
+    }
+
+    /// upstream: batch.c:68 `&do_compression` occupies stream-flag bit 8 and
+    /// batch.c:96-113 `write_stream_flags()` sets it whenever the option is
+    /// active. A batch recorded under `-z` therefore has to advertise the bit
+    /// so `--read-batch` decodes the deflated tokens instead of plain ones.
+    #[test]
+    fn write_batch_header_sets_do_compression_under_compress() {
+        assert!(recorded_flags(true, 31).do_compression);
+    }
+
+    /// upstream: batch.c:96-113 - a flag that is off contributes no bit, so a
+    /// batch written without `-z` keeps bit 8 clear and its body stays in
+    /// `token.c:simple_send_token()` framing.
+    #[test]
+    fn write_batch_header_leaves_do_compression_clear_without_compress() {
+        assert!(!recorded_flags(false, 31).do_compression);
+    }
+
+    /// upstream: batch.c:124-125 - `flag_ptr[7]` is NULL below protocol 29, so
+    /// bits 7 and 8 do not exist in a proto-28 batch even with `-z` active.
+    #[test]
+    fn write_batch_header_omits_do_compression_below_protocol_29() {
+        assert!(!recorded_flags(true, 28).do_compression);
     }
 
     #[test]

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -253,6 +253,15 @@ pub(crate) struct CopyContext<'a> {
     /// NDX codec for writing file indices to the batch delta stream.
     /// Persists across files to maintain delta-encoding state (proto >= 30).
     batch_ndx_codec: Option<protocol::codec::NdxCodecEnum>,
+    /// Compressed-token encoder for the batch delta stream.
+    ///
+    /// `Some` exactly when `--write-batch` is combined with an active `-z`,
+    /// which is the same condition that sets stream-flag bit 8
+    /// (upstream: `batch.c:68 &do_compression`). The batch file is a tee of
+    /// the wire stream, so its tokens must carry the framing
+    /// `token.c:send_token()` would have produced. `None` keeps the plain
+    /// `token.c:simple_send_token()` framing byte-for-byte.
+    batch_token_encoder: Option<protocol::wire::CompressedTokenEncoder>,
     /// Reusable buffer for directory enumeration in `read_directory_entries_sorted`.
     ///
     /// Cleared and refilled at each directory level, avoiding a fresh heap

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -202,7 +202,11 @@ impl<'a> CopyContext<'a> {
                             LocalCopyError::io("copy file", destination, error)
                         })?;
                     }
-                    self.capture_batch_block_match(&matched, destination)?;
+                    self.write_batch_block_match_token(
+                        matched.descriptor().index() as u32,
+                        matched_bytes,
+                        destination,
+                    )?;
                     output_position = output_position.saturating_add(block_len as u64);
                 } else {
                     self.copy_matched_block(
@@ -307,7 +311,11 @@ impl<'a> CopyContext<'a> {
                         LocalCopyError::io("copy file", destination, error)
                     })?;
                 }
-                self.capture_batch_block_match(&matched, destination)?;
+                self.write_batch_block_match_token(
+                    matched.descriptor().index() as u32,
+                    matched_bytes,
+                    destination,
+                )?;
                 output_position = output_position.saturating_add(block_len as u64);
             } else {
                 self.copy_matched_block(
@@ -436,21 +444,9 @@ impl<'a> CopyContext<'a> {
 
         // Capture LITERAL operation to the batch delta buffer if active.
         // upstream: token.c:simple_send_token() - literals are written as
-        // write_int(length) + raw bytes, chunked to CHUNK_SIZE (32KB).
-        if let Some(delta_writer) = self.batch_delta_writer() {
-            let mut encoded = Vec::new();
-            protocol::wire::delta::write_token_literal(&mut encoded, chunk).map_err(|e| {
-                LocalCopyError::io(
-                    "encode batch literal token",
-                    destination.to_path_buf(),
-                    e,
-                )
-            })?;
-
-            delta_writer.write_all(&encoded).map_err(|e| {
-                LocalCopyError::io("write batch literal token", destination.to_path_buf(), e)
-            })?;
-        }
+        // write_int(length) + raw bytes, chunked to CHUNK_SIZE (32KB); under
+        // -z the batch tee records send_deflated_token()'s framing instead.
+        self.write_batch_literal_token(chunk, destination)?;
 
         let written = if sparse {
             write_sparse_chunk(writer, state, chunk, destination)?
@@ -479,34 +475,39 @@ impl<'a> CopyContext<'a> {
     /// Records a block-match token to the batch delta stream, if active.
     ///
     /// Mirrors upstream `token.c:simple_send_token()` which encodes a block
-    /// reference as `write_int(-(token+1))`.
+    /// reference as `write_int(-(token+1))`. Under `-z` the compressed encoder
+    /// additionally needs the matched bytes: `token.c:471-484` feeds them into
+    /// the deflate history so the receiver's dictionary stays in sync, so the
+    /// block is read back from `existing` (the basis) for that call only.
     fn capture_batch_block_match(
         &mut self,
+        existing: &mut fs::File,
         matched: &MatchedBlock<'_>,
         destination: &Path,
     ) -> Result<(), LocalCopyError> {
-        if let Some(delta_writer) = self.batch_delta_writer() {
-            let block_index = matched.descriptor().index();
+        if self.batch_delta_buf.is_none() {
+            return Ok(());
+        }
 
-            let mut encoded = Vec::new();
-            protocol::wire::delta::write_token_block_match(&mut encoded, block_index as u32)
-                .map_err(|e| {
-                    LocalCopyError::io(
-                        "encode batch block match token",
-                        destination.to_path_buf(),
-                        e,
-                    )
-                })?;
+        let block_index = matched.descriptor().index() as u32;
 
-            delta_writer.write_all(&encoded).map_err(|e| {
+        let mut see_data = Vec::new();
+        if self.batch_token_encoder.is_some() {
+            see_data.resize(matched.descriptor().len(), 0);
+            let basis_err = |e: io::Error| {
                 LocalCopyError::io(
-                    "write batch block match token",
+                    "read basis block for batch token history",
                     destination.to_path_buf(),
                     e,
                 )
-            })?;
+            };
+            existing
+                .seek(SeekFrom::Start(matched.offset()))
+                .map_err(basis_err)?;
+            existing.read_exact(&mut see_data).map_err(basis_err)?;
         }
-        Ok(())
+
+        self.write_batch_block_match_token(block_index, &see_data, destination)
     }
 
     /// Copies a matched basis block from `existing` to `writer` at the
@@ -526,7 +527,7 @@ impl<'a> CopyContext<'a> {
         let offset = matched.offset();
         let block_length = matched.descriptor().len();
 
-        self.capture_batch_block_match(&matched, destination)?;
+        self.capture_batch_block_match(existing, &matched, destination)?;
 
         // REFLINK-3/4: attempt a same-filesystem FICLONERANGE reflink before
         // falling back to the read+write copy loop. On a CoW filesystem this

--- a/crates/engine/src/local_copy/context_impl/options/batch.rs
+++ b/crates/engine/src/local_copy/context_impl/options/batch.rs
@@ -166,6 +166,92 @@ impl<'a> CopyContext<'a> {
         Ok(())
     }
 
+    /// Appends a literal token for the current file to the batch delta buffer.
+    ///
+    /// upstream: `token.c:1065 send_token()` dispatches on `do_compression`.
+    /// With `-z` (stream-flag bit 8, `batch.c:68`) the batch tee records
+    /// `send_deflated_token()` framing; without it, `simple_send_token()`'s
+    /// plain 4-byte length prefix. A no-op when batch mode is inactive.
+    pub(super) fn write_batch_literal_token(
+        &mut self,
+        chunk: &[u8],
+        path: &std::path::Path,
+    ) -> Result<(), crate::local_copy::LocalCopyError> {
+        let Some(delta_file) = self.batch_delta_buf.as_mut() else {
+            return Ok(());
+        };
+        match self.batch_token_encoder.as_mut() {
+            Some(encoder) => encoder.send_literal(delta_file, chunk),
+            None => protocol::wire::delta::write_token_literal(delta_file, chunk),
+        }
+        .map_err(|e| {
+            crate::local_copy::LocalCopyError::io(
+                "write batch literal token",
+                path.to_path_buf(),
+                e,
+            )
+        })
+    }
+
+    /// Appends a block-match token for the current file to the batch delta
+    /// buffer.
+    ///
+    /// upstream: `token.c:simple_send_token()` writes `write_int(-(token+1))`;
+    /// `token.c:send_deflated_token()` emits the run-length encoded form. Under
+    /// CPRES_ZLIB the sender must also feed the matched bytes into the deflate
+    /// history (`token.c:471-484`) so the receiver's inflate dictionary stays in
+    /// sync; `see_data` carries those bytes for that purpose.
+    pub(super) fn write_batch_block_match_token(
+        &mut self,
+        block_index: u32,
+        see_data: &[u8],
+        path: &std::path::Path,
+    ) -> Result<(), crate::local_copy::LocalCopyError> {
+        let Some(delta_file) = self.batch_delta_buf.as_mut() else {
+            return Ok(());
+        };
+        let result = match self.batch_token_encoder.as_mut() {
+            Some(encoder) => match encoder.send_block_match(delta_file, block_index) {
+                Ok(()) => encoder.see_token(see_data),
+                Err(e) => Err(e),
+            },
+            None => protocol::wire::delta::write_token_block_match(delta_file, block_index),
+        };
+        result.map_err(|e| {
+            crate::local_copy::LocalCopyError::io(
+                "write batch block match token",
+                path.to_path_buf(),
+                e,
+            )
+        })
+    }
+
+    /// Appends the end-of-file token for the current file to the batch delta
+    /// buffer, flushing any pending compressed output.
+    ///
+    /// upstream: `token.c:simple_send_token()` writes `write_int(0)`;
+    /// `token.c:468-470 send_deflated_token()` writes `END_FLAG` after draining
+    /// the deflate stream.
+    fn write_batch_token_end(
+        &mut self,
+        path: &std::path::Path,
+    ) -> Result<(), crate::local_copy::LocalCopyError> {
+        let Some(delta_file) = self.batch_delta_buf.as_mut() else {
+            return Ok(());
+        };
+        match self.batch_token_encoder.as_mut() {
+            Some(encoder) => encoder.finish(delta_file),
+            None => protocol::wire::delta::write_token_end(delta_file),
+        }
+        .map_err(|e| {
+            crate::local_copy::LocalCopyError::io(
+                "write batch token end marker",
+                path.to_path_buf(),
+                e,
+            )
+        })
+    }
+
     /// Writes the iflags + sum_head preamble for a file's delta data
     /// to the per-file batch delta buffer.
     ///
@@ -191,6 +277,13 @@ impl<'a> CopyContext<'a> {
 
         delta_file.get_mut().clear();
         delta_file.set_position(0);
+
+        // upstream: token.c:387 - send_deflated_token() reinitialises the
+        // deflate context at the start of every file, so the batch's per-file
+        // token streams stay independently decodable.
+        if let Some(encoder) = self.batch_token_encoder.as_mut() {
+            encoder.reset();
+        }
 
         // NDX is remapped to sorted order at flush time; record the
         // traversal index here.
@@ -259,27 +352,11 @@ impl<'a> CopyContext<'a> {
     ) -> Result<(), crate::local_copy::LocalCopyError> {
         use std::io::{Read, Write};
 
-        let delta_file = match self.batch_delta_buf.as_mut() {
-            Some(f) => f,
-            None => return Ok(()),
-        };
+        if self.batch_delta_buf.is_none() {
+            return Ok(());
+        }
 
-        // upstream: token.c - end-of-file marker is write_int(0)
-        let mut buf = Vec::with_capacity(4);
-        protocol::wire::delta::write_token_end(&mut buf).map_err(|e| {
-            crate::local_copy::LocalCopyError::io(
-                "write batch token end marker",
-                std::path::PathBuf::new(),
-                e,
-            )
-        })?;
-        delta_file.write_all(&buf).map_err(|e| {
-            crate::local_copy::LocalCopyError::io(
-                "write batch token end marker",
-                std::path::PathBuf::new(),
-                e,
-            )
-        })?;
+        self.write_batch_token_end(source)?;
 
         // upstream: match.c:370-411 - compute MD5 of source file content.
         // For MD5 (protocol >= 30), sum_init() ignores checksum_seed.
@@ -307,6 +384,9 @@ impl<'a> CopyContext<'a> {
                 hasher.update(&chunk[..n]);
             }
             hasher.finalize()
+        };
+        let Some(delta_file) = self.batch_delta_buf.as_mut() else {
+            return Ok(());
         };
         delta_file.write_all(&file_sum).map_err(|e| {
             crate::local_copy::LocalCopyError::io(
@@ -339,12 +419,9 @@ impl<'a> CopyContext<'a> {
         source: &std::path::Path,
         file_size: u64,
     ) -> Result<(), crate::local_copy::LocalCopyError> {
-        use std::io::Write;
-
-        let delta_file = match self.batch_delta_buf.as_mut() {
-            Some(_) => self.batch_delta_buf.as_mut().expect("batch_delta_buf is Some in this arm"),
-            None => return Ok(()),
-        };
+        if self.batch_delta_buf.is_none() {
+            return Ok(());
+        }
 
         let mut reader = std::fs::File::open(source).map_err(|e| {
             crate::local_copy::LocalCopyError::io(
@@ -372,22 +449,7 @@ impl<'a> CopyContext<'a> {
             }
             remaining = remaining.saturating_sub(n as u64);
 
-            let mut encoded = Vec::with_capacity(n + 4);
-            protocol::wire::delta::write_token_literal(&mut encoded, &buf[..n]).map_err(|e| {
-                crate::local_copy::LocalCopyError::io(
-                    "encode batch literal token",
-                    source.to_path_buf(),
-                    e,
-                )
-            })?;
-
-            delta_file.write_all(&encoded).map_err(|e| {
-                crate::local_copy::LocalCopyError::io(
-                    "write batch literal token",
-                    source.to_path_buf(),
-                    e,
-                )
-            })?;
+            self.write_batch_literal_token(&buf[..n], source)?;
         }
 
         Ok(())
@@ -534,16 +596,6 @@ impl<'a> CopyContext<'a> {
         }
 
         traversal_to_sorted
-    }
-
-    /// Returns a mutable reference to the batch delta buffer file.
-    ///
-    /// Used by `flush_literal_chunk` and `copy_matched_block` to redirect
-    /// token writes to the delta buffer instead of the batch writer.
-    pub(super) fn batch_delta_writer(
-        &mut self,
-    ) -> Option<&mut io::Cursor<Vec<u8>>> {
-        self.batch_delta_buf.as_mut()
     }
 
     /// Increments the batch flist index counter.

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -79,6 +79,28 @@ impl<'a> CopyContext<'a> {
                 .with_name_follows(true)
         });
 
+        // upstream: batch.c:68 - stream-flag bit 8 records `do_compression`, and
+        // the batch file is a tee of the wire stream, so a batch written under
+        // `-z` carries `token.c:send_deflated_token()` framing. The codec is
+        // always zlib: `compat.c:414 getenv_nstr()` forces the compression list
+        // to "zlib" whenever `write_batch` is set ("When writing a batch file,
+        // we always negotiate an old-style choice"), which is also what
+        // `compat.c:194-195 parse_compress_choice()` assumes on `--read-batch`.
+        let batch_token_encoder = options.get_batch_writer().and_then(|batch_writer_arc| {
+            if !options.compress_enabled() {
+                return None;
+            }
+            let proto_version = batch_writer_arc
+                .lock()
+                .expect("batch writer mutex poisoned")
+                .config()
+                .protocol_version;
+            Some(protocol::wire::CompressedTokenEncoder::new(
+                options.compression_level(),
+                proto_version as u32,
+            ))
+        });
+
         let adaptive_level = if options.compress_enabled() && options.adaptive_compress_enabled() {
             let initial = options.compression_level();
             let level_i32 = match initial {
@@ -151,6 +173,7 @@ impl<'a> CopyContext<'a> {
             batch_current_delta_idx: 0,
             batch_flist_index: 0,
             batch_ndx_codec,
+            batch_token_encoder,
             readdir_buf: Vec::new(),
             adaptive_level,
         }

--- a/crates/engine/tests/write_batch_compression.rs
+++ b/crates/engine/tests/write_batch_compression.rs
@@ -1,0 +1,244 @@
+//! `--write-batch` must honour `-z`.
+//!
+//! # Upstream Reference
+//!
+//! - `batch.c:59-76 flag_ptr[]` - `&do_compression` sits at stream-flag bit 8
+//!   (protocol >= 29), right after `&xfer_dirs`.
+//! - `batch.c:96-113 write_stream_flags()` - the bitmap of active flags is the
+//!   first `write_int()` in the batch file, so `-a` alone yields 0x9f and
+//!   `-az` yields 0x19f.
+//! - `io.c:read_buf()` - `write_batch_monitor_in` tees the wire bytes to
+//!   `batch_fd` before decompression, so a batch recorded under `-z` carries
+//!   `token.c:send_deflated_token()` framing rather than
+//!   `token.c:simple_send_token()`'s plain 4-byte length prefixes.
+//! - `batch.c:120-161 check_batch_flags()` - the reader reconciles the recorded
+//!   bitmap against the replay invocation, so both shapes must stay readable.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use batch::{BatchConfig, BatchFlags, BatchMode, BatchReader, BatchWriter};
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use protocol::CompatibilityFlags;
+use tempfile::tempdir;
+
+/// Negotiated protocol for every batch in this module. 32 is the newest
+/// version oc-rsync speaks and is well above the protocol-29 floor that gates
+/// stream-flag bit 8.
+const PROTOCOL: i32 = 32;
+
+/// Highly compressible payload, large enough to span several 32 KiB capture
+/// iterations so the deflate stream is exercised across internal flushes.
+fn payload() -> Vec<u8> {
+    b"the quick brown fox jumps over the lazy dog. "
+        .iter()
+        .copied()
+        .cycle()
+        .take(200_000)
+        .collect()
+}
+
+/// Builds the batch writer for a `-rl [-z] --only-write-batch` capture.
+///
+/// `compress` drives stream-flag bit 8 exactly as production does: both the
+/// header bit and the token framing derive from the single `--compress` state
+/// (upstream `batch.c:68 &do_compression`).
+fn make_writer(path: &Path, compress: bool) -> Arc<Mutex<BatchWriter>> {
+    let compat_flags = CompatibilityFlags::SAFE_FILE_LIST
+        | CompatibilityFlags::AVOID_XATTR_OPTIMIZATION
+        | CompatibilityFlags::CHECKSUM_SEED_FIX
+        | CompatibilityFlags::INPLACE_PARTIAL_DIR
+        | CompatibilityFlags::VARINT_FLIST_FLAGS;
+    let config = BatchConfig::new(
+        BatchMode::OnlyWrite,
+        path.to_string_lossy().into_owned(),
+        PROTOCOL,
+    )
+    .with_compat_flags(compat_flags.bits() as i32)
+    .with_checksum_seed(1);
+    let mut writer = BatchWriter::new(config).expect("create batch writer");
+    let flags = BatchFlags {
+        recurse: true,
+        preserve_links: true,
+        do_compression: compress,
+        ..Default::default()
+    };
+    writer.write_header(flags).expect("write batch header");
+    Arc::new(Mutex::new(writer))
+}
+
+/// Captures `source` into a batch file under `root`, with or without `-z`.
+///
+/// Returns the path of the finalised batch file.
+fn capture(root: &Path, source: &Path, compress: bool) -> PathBuf {
+    let batch_path = root.join(if compress {
+        "compressed.batch"
+    } else {
+        "plain.batch"
+    });
+    let dest = root.join("capture_dst");
+    fs::create_dir_all(&dest).expect("create capture dest");
+
+    let writer = make_writer(&batch_path, compress);
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .links(true)
+        .compress(compress)
+        .batch_writer(Some(Arc::clone(&writer)));
+
+    let mut src_os = source.to_path_buf().into_os_string();
+    src_os.push("/");
+    let operands = vec![src_os, dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    plan.execute_with_options(LocalCopyExecution::DryRun, options)
+        .expect("only-write-batch dry-run succeeds");
+
+    Arc::try_unwrap(writer)
+        .expect("writer uniquely owned")
+        .into_inner()
+        .expect("writer mutex not poisoned")
+        .finalize()
+        .expect("finalize batch writer");
+
+    batch_path
+}
+
+/// Returns the leading stream-flags word of a batch file.
+///
+/// upstream: `batch.c:113 write_int(fd, flags)` is the very first thing in the
+/// file, encoded little-endian.
+fn stream_flags_word(batch_path: &Path) -> i32 {
+    let bytes = fs::read(batch_path).expect("read batch file");
+    let head: [u8; 4] = bytes[..4].try_into().expect("batch file has a flags word");
+    i32::from_le_bytes(head)
+}
+
+/// Materialises a source tree holding one compressible file.
+fn make_source(root: &Path) -> (PathBuf, Vec<u8>) {
+    let source = root.join("src");
+    fs::create_dir_all(&source).expect("create source dir");
+    let body = payload();
+    fs::write(source.join("body.txt"), &body).expect("write payload");
+    (source, body)
+}
+
+/// Replays `batch_path` into a fresh directory under `root` and returns it.
+fn replay(root: &Path, batch_path: &Path, name: &str) -> PathBuf {
+    let dest = root.join(name);
+    fs::create_dir_all(&dest).expect("create replay dest");
+    let read_cfg = BatchConfig::new(
+        BatchMode::Read,
+        batch_path.to_string_lossy().into_owned(),
+        PROTOCOL,
+    );
+    batch::replay::replay(&read_cfg, &dest, 0).expect("replay succeeds");
+    dest
+}
+
+/// upstream: `batch.c:59-76` puts `&do_compression` at bit 8 and
+/// `batch.c:96-113 write_stream_flags()` sets a bit for every active flag, so a
+/// batch captured under `-z` must advertise bit 8 while one captured without it
+/// must leave the bit clear. Without the bit, `--read-batch` would decode
+/// deflated tokens with `simple_recv_token()` and reconstruct garbage.
+#[test]
+fn compress_drives_stream_flag_bit_8() {
+    let temp = tempdir().expect("tempdir");
+    let (source, _) = make_source(temp.path());
+
+    let compressed = capture(temp.path(), &source, true);
+    assert_ne!(
+        stream_flags_word(&compressed) & (1 << 8),
+        0,
+        "bit 8 must be set when compression is active"
+    );
+
+    let plain = capture(temp.path(), &source, false);
+    assert_eq!(
+        stream_flags_word(&plain) & (1 << 8),
+        0,
+        "bit 8 must stay clear without compression"
+    );
+}
+
+/// upstream: `io.c:read_buf()` tees the wire bytes before decompression, so a
+/// `-z` batch holds `token.c:send_deflated_token()` output. A batch that merely
+/// flipped bit 8 while still recording plain literals would be the same size as
+/// the payload and would fail this bound.
+#[test]
+fn compressed_batch_body_is_actually_deflated() {
+    let temp = tempdir().expect("tempdir");
+    let (source, body) = make_source(temp.path());
+
+    let compressed = capture(temp.path(), &source, true);
+    let compressed_len = fs::metadata(&compressed).expect("stat batch").len();
+    assert!(
+        compressed_len < body.len() as u64 / 4,
+        "a deflated batch of {} repetitive bytes must be far smaller; got {compressed_len}",
+        body.len()
+    );
+
+    let plain = capture(temp.path(), &source, false);
+    let plain_len = fs::metadata(&plain).expect("stat batch").len();
+    assert!(
+        plain_len > body.len() as u64,
+        "an uncompressed batch still carries every literal byte; got {plain_len}"
+    );
+}
+
+/// upstream: `batch.c:120-161 check_batch_flags()` reconciles bit 8 on read and
+/// `token.c:recv_deflated_token()` decodes the body, so a compressed batch must
+/// reproduce the source tree byte-for-byte.
+#[test]
+fn compressed_batch_round_trips_through_the_reader() {
+    let temp = tempdir().expect("tempdir");
+    let (source, body) = make_source(temp.path());
+
+    let batch_path = capture(temp.path(), &source, true);
+
+    let mut reader = BatchReader::new(BatchConfig::new(
+        BatchMode::Read,
+        batch_path.to_string_lossy().into_owned(),
+        PROTOCOL,
+    ))
+    .expect("open batch reader");
+    let flags = reader.read_header().expect("read batch header");
+    assert!(flags.do_compression, "header must record the -z state");
+    drop(reader);
+
+    let dest = replay(temp.path(), &batch_path, "replay_compressed");
+    assert_eq!(
+        fs::read(dest.join("body.txt")).expect("read replayed payload"),
+        body,
+        "compressed batch must reconstruct the source byte-for-byte"
+    );
+}
+
+/// upstream: `batch.c:96-113` writes a zero bit for an inactive flag, and
+/// `token.c:simple_recv_token()` stays the reader's plain path. This guards the
+/// backward-compatible shape: batches written before bit 8 was ever set (and
+/// every batch written without `-z`) must keep replaying unchanged.
+#[test]
+fn uncompressed_batch_still_round_trips() {
+    let temp = tempdir().expect("tempdir");
+    let (source, body) = make_source(temp.path());
+
+    let batch_path = capture(temp.path(), &source, false);
+
+    let mut reader = BatchReader::new(BatchConfig::new(
+        BatchMode::Read,
+        batch_path.to_string_lossy().into_owned(),
+        PROTOCOL,
+    ))
+    .expect("open batch reader");
+    let flags = reader.read_header().expect("read batch header");
+    assert!(!flags.do_compression, "header must leave bit 8 clear");
+    drop(reader);
+
+    let dest = replay(temp.path(), &batch_path, "replay_plain");
+    assert_eq!(
+        fs::read(dest.join("body.txt")).expect("read replayed payload"),
+        body,
+        "uncompressed batch must keep reconstructing the source byte-for-byte"
+    );
+}

--- a/crates/transfer/src/compressed_writer.rs
+++ b/crates/transfer/src/compressed_writer.rs
@@ -22,12 +22,9 @@ use compress::zstd::CountingZstdEncoder;
 /// applied on top of the multiplexed stream.
 ///
 /// Batch recording is handled by the inner `MultiplexWriter`, not here.
-/// Unlike upstream (which tees compressed wire bytes via `io.c:write_buf()`),
-/// oc-rsync records data at the pre-compression level and sets
-/// `do_compression: false` in the batch stream flags. This avoids an
-/// upstream rsync 3.4.1 limitation where the batch format does not record
-/// the compression algorithm, causing read-batch to force CPRES_ZLIB
-/// (compat.c:194-195) even when the original write used zstd.
+/// upstream: `io.c:write_buf()` tees compressed wire bytes to `batch_fd`, so
+/// the recorder sits below this layer and the batch header records
+/// `do_compression: true` (`batch.c:68`) for replay to decompress.
 pub struct CompressedWriter<W: Write> {
     /// Underlying writer, typically a `MultiplexWriter`.
     inner: W,


### PR DESCRIPTION
## Problem

`batch.c:59-75` maps stream-flag **bit 8** to `do_compression` (labelled `--compress (-z)`), and `batch.c:96-113` `write_stream_flags()` writes those bits as the first int of the batch file. A `-z` batch therefore announces compression and carries a compressed body.

oc-rsync hard-coded that bit to `false` and wrote the body uncompressed:

| | size | flags word |
|---|---|---|
| upstream, no `-z` | 200158 | `9f000000` |
| upstream, `-z` | **735** | `9f01`**`0000`** |
| oc-rsync, no `-z` | 200158 | `9f000000` |
| oc-rsync, `-z` | **200158** | `9f000000` |

The remote recorders were worse than merely wasteful: the SSH and daemon paths **already teed compressed bytes** at the multiplex layer while still clearing the flag, so a remote `-z --write-batch` wrote a batch whose body no reader could replay.

> Note: this repo's task list previously described the rule backwards - that upstream forces compression *off* for batches. The measurements above disprove that; upstream's `-z` batch is ~272x smaller.

## Fix

- Set bit 8 from the effective compression setting in both the local (`config_batch_flags`) and remote (`build_batch_context`) batch contexts. `BatchFlags::to_bitmap()` already gated bit 8 on protocol >= 29, matching `flag_ptr[7]=NULL`, so no gating was added.
- Route the local-copy capture path through a compressed token encoder when the bit is set. The plain path calls the identical token writers with identical arguments, so a batch written **without** `-z` stays byte-identical to before.
- Codec is zlib rather than the negotiated one, matching `compat.c:414 getenv_nstr()` - *"When writing a batch file, we always negotiate an old-style choice"* - which the local path already honoured in `run/mod.rs::apply_compression`.

The reader was **verified, not assumed**, to accept both shapes: `batch/src/replay/delta_phase.rs::CodecState::new` builds a decoder only when `flags.do_compression`, and `read_delta_tokens` falls back to the plain reader when it is `None`.

## Verification

Against **rsync 3.4.4 built from source**:

```
flags word   upstream 9f010000   oc-rsync 9f010000   (bit 8 set; was 9f000000)
-z body      upstream 735 bytes  oc-rsync 1326 bytes (was 200158, uncompressed)
no -z        unchanged, byte identical to before
```

All four read/write directions reproduce the source tree exactly:

```
upstream -> upstream   batch=814    exit 0  IDENTICAL
oc       -> oc         batch=1405   exit 0  IDENTICAL
upstream -> oc         batch=814    exit 0  IDENTICAL
oc       -> upstream   batch=1405   exit 0  IDENTICAL
```

The last row is the important one - upstream's `--read-batch` now decodes a compressed batch written by oc-rsync.

`cargo fmt --all --check`, `cargo clippy -p engine -p core -p batch -p transfer --all-targets --all-features -D warnings`, and `cargo nextest run -p engine -p batch -p core --all-features` (**7823 passed**) are clean.

## Known remaining difference

oc-rsync's compressed batch is larger than upstream's for the same input (1326 vs 735; 1405 vs 814). That is a compression-efficiency difference, not a format one - the flags word matches, the body decodes, and all four directions round-trip. Deliberately left for separate work rather than claimed as parity.

## Adjacent gap found, deliberately not fixed here

oc-rsync has no equivalent of `compat.c:414`'s write-batch pin on the **remote** name-string negotiation, so two oc peers can negotiate zstd for `-z --write-batch` and produce a batch upstream cannot read (oc's own reader auto-detects zstd, so oc->oc hides it). Tracked separately to keep this change scoped.
