### PR TITLE
fix(daemon): encode MSG_ERROR_EXIT payload as little-endian

### DIFF
--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -478,8 +478,9 @@ fn handle_binary_session_internal(
         HANDSHAKE_ERROR_PAYLOAD.as_bytes().to_vec(),
     )?
     .encode_into_writer(&mut frames)?;
+    // upstream: io.c:send_msg_int — SIVAL is little-endian
     let exit_code = u32::try_from(FEATURE_UNAVAILABLE_EXIT_CODE).unwrap_or_default();
-    MessageFrame::new(MessageCode::ErrorExit, exit_code.to_be_bytes().to_vec())?
+    MessageFrame::new(MessageCode::ErrorExit, exit_code.to_le_bytes().to_vec())?
         .encode_into_writer(&mut frames)?;
     write_limited(&mut stream, &mut limiter, &frames)?;
     stream.flush()?;

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -185,6 +185,7 @@ include!("tests/chunks/module_peer_hostname_skips_lookup_when_disabled.rs");
 include!("tests/chunks/module_peer_hostname_uses_override.rs");
 include!("tests/chunks/module_without_bwlimit_inherits_daemon_cap.rs");
 include!("tests/chunks/module_without_bwlimit_preserves_daemon_cap.rs");
+include!("tests/chunks/msg_error_exit_payload_uses_little_endian_encoding.rs");
 include!("tests/chunks/oc_help_flag_renders_branded_snapshot.rs");
 include!("tests/chunks/oc_version_flag_renders_report.rs");
 include!("tests/chunks/parse_auth_user_list_trims_and_deduplicates_case_insensitively.rs");

--- a/crates/daemon/src/tests/chunks/msg_error_exit_payload_uses_little_endian_encoding.rs
+++ b/crates/daemon/src/tests/chunks/msg_error_exit_payload_uses_little_endian_encoding.rs
@@ -1,0 +1,31 @@
+/// Validates that MSG_ERROR_EXIT payloads are encoded as little-endian,
+/// matching upstream SIVAL encoding (io.c:send_msg_int:1060).
+///
+/// A big-endian payload causes an upstream client to read exit code 1 as
+/// 0x01000000 via IVAL (little-endian decode). After the 8-bit exit mask
+/// that becomes 0 - a daemon rejection silently surfaces as success.
+#[test]
+fn msg_error_exit_payload_uses_little_endian_encoding() {
+    let exit_code: u32 = 1;
+    let payload = exit_code.to_le_bytes();
+    assert_eq!(
+        payload,
+        [0x01, 0x00, 0x00, 0x00],
+        "exit code 1 must encode as LE [01,00,00,00], not BE [00,00,00,01]",
+    );
+
+    // Round-trip through MessageFrame to confirm the payload is preserved.
+    let frame = protocol::MessageFrame::new(
+        protocol::MessageCode::ErrorExit,
+        payload.to_vec(),
+    )
+    .expect("valid frame");
+    let mut buf = Vec::new();
+    frame.encode_into_writer(&mut buf).expect("encode");
+    // The payload occupies the last 4 bytes of the encoded frame.
+    assert_eq!(
+        &buf[buf.len() - 4..],
+        &[0x01, 0x00, 0x00, 0x00],
+        "MessageFrame must preserve the little-endian exit-code payload",
+    );
+}


### PR DESCRIPTION
## Summary
- Fix MSG_ERROR_EXIT payload encoding from big-endian to little-endian to match upstream SIVAL encoding (io.c:1060)
- A daemon rejection was surfacing as exit 0 instead of exit 1 to upstream clients

## Test plan
- [x] Unit test confirms little-endian encoding
- [x] cargo fmt clean
- [x] cargo clippy -D warnings clean