### PR TITLE
fix(protocol): validate fallback checksum against env list

### DIFF
--- a/crates/protocol/src/negotiation/capabilities/env_list.rs
+++ b/crates/protocol/src/negotiation/capabilities/env_list.rs
@@ -110,16 +110,81 @@ pub(super) fn validate_compress_choice(choice: &str) -> io::Result<()> {
     validate_choice(COMPRESS_LIST_ENV, "compress", choice, resolve_compression)
 }
 
-/// Shared refusal check for both choice kinds.
+/// Refuses the forced fallback default checksum on the non-negotiated path when
+/// `RSYNC_CHECKSUM_LIST` excludes it.
 ///
-/// Reuses [`parse_env`] with `is_server = true` (only the server validates) so
-/// the env list is parsed exactly once, with the same `&` split, tokenising,
-/// alias canonicalisation and de-duplication used to build the advertised list -
-/// no separate parse. When the variable is unset or empty, [`parse_env`] returns
-/// `None` and the choice is accepted. Otherwise the forced canonical name must
-/// appear in the parsed candidate set (an empty set - the `INVALID` sentinel -
-/// never contains it, so a value whose names were all unrecognised refuses every
-/// choice, matching upstream).
+/// upstream: `compat.c:541-555 negotiate_the_strings` - when the peer is too old
+/// to negotiate (`do_negotiated_strings == 0`) and no `--checksum-choice` is
+/// forced, `send_negotiate_str` still parses the env list into `nno->saw`, then
+/// `recv_negotiate_str` runs `parse_negotiate_str` with the prefilled default
+/// (`"md5"` for protocol >= 30, else `"md4"`). When `saw` lacks the default the
+/// parse fails and upstream aborts with `RERR_UNSUPPORTED` (`compat.c:406`).
+/// Unlike [`validate_checksum_choice`] this runs on both sides, so pass the
+/// caller's `is_server`; the `&` split then selects the caller's half.
+pub(super) fn validate_default_checksum(default: &str, is_server: bool) -> io::Result<()> {
+    validate_default(
+        CHECKSUM_LIST_ENV,
+        "checksum",
+        default,
+        is_server,
+        resolve_checksum,
+    )
+}
+
+/// Refuses the forced fallback default `zlib` compression on the non-negotiated
+/// path when `RSYNC_COMPRESS_LIST` excludes it.
+///
+/// The compression counterpart of [`validate_default_checksum`], mirroring the
+/// `valid_compressions.saw` / `"zlib"` prefill branch (`compat.c:557-564`). Only
+/// reached when compression is active (`do_compression`), matching upstream's
+/// gate on `send_negotiate_str` at `compat.c:544`.
+pub(super) fn validate_default_compress(default: &str, is_server: bool) -> io::Result<()> {
+    validate_default(
+        COMPRESS_LIST_ENV,
+        "compress",
+        default,
+        is_server,
+        resolve_compression,
+    )
+}
+
+/// Membership of a single algorithm in the env-parsed candidate list.
+enum EnvMembership {
+    /// The variable is unset or all-whitespace - no restriction applies.
+    Unset,
+    /// The variable restricts the list and the algorithm is a member.
+    Present,
+    /// The variable restricts the list and the algorithm is absent.
+    Absent,
+}
+
+/// Parses the env list once and reports whether `algo` survives it.
+///
+/// Shared by the forced-choice refusal ([`validate_choice`]) and the
+/// fallback-default refusal ([`validate_default`]) so both use the identical
+/// `&`-split, tokenising, alias canonicalisation and de-duplication from
+/// [`parse_env`] - the single source of truth for the candidate set. An empty
+/// set (the `INVALID` sentinel) never contains `algo`, so a value whose names
+/// were all unrecognised reports [`EnvMembership::Absent`], matching upstream.
+fn env_membership(
+    key: &str,
+    is_server: bool,
+    algo: &str,
+    resolve: impl Fn(&str) -> Option<&'static str>,
+) -> EnvMembership {
+    match parse_env(key, is_server, resolve) {
+        None => EnvMembership::Unset,
+        Some(env) if env.candidates.contains(&algo) => EnvMembership::Present,
+        Some(_) => EnvMembership::Absent,
+    }
+}
+
+/// Shared refusal check for both forced-choice kinds.
+///
+/// Only the server validates a forced `--checksum-choice`/`--compress-choice`,
+/// so it always parses with `is_server = true`. When the variable is unset or
+/// empty the choice is accepted; otherwise the forced canonical name must be a
+/// member of the parsed candidate set.
 ///
 /// On refusal, emits the byte-exact upstream message and fails with an
 /// [`io::ErrorKind::Unsupported`] error, which the core exit-code mapper turns
@@ -131,24 +196,42 @@ fn validate_choice(
     choice: &str,
     resolve: impl Fn(&str) -> Option<&'static str>,
 ) -> io::Result<()> {
-    // upstream: compat.c:432-433 - an unset or all-whitespace list_str returns
-    // early, leaving the choice unvalidated (accepted).
-    let Some(env) = parse_env(key, true, resolve) else {
-        return Ok(());
-    };
-
-    // upstream: compat.c:445 - saw[num] must be set for the forced choice(s).
-    if env.candidates.contains(&choice) {
-        return Ok(());
+    // upstream: compat.c:432-445 - unset/blank accepts; saw[num] must be set.
+    match env_membership(key, true, choice, resolve) {
+        EnvMembership::Unset | EnvMembership::Present => Ok(()),
+        // upstream: compat.c:446-448 rprintf(FERROR, "Your --%s-choice value
+        // (%s) was refused by the server.\n", ...). The trailing newline is
+        // added by the diagnostic layer, not embedded in the message.
+        EnvMembership::Absent => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("Your --{kind}-choice value ({choice}) was refused by the server."),
+        )),
     }
+}
 
-    // upstream: compat.c:446-448 rprintf(FERROR, "Your --%s-choice value (%s)
-    // was refused by the server.\n", ...). The trailing newline is added by the
-    // diagnostic layer, not embedded in the message, matching oc convention.
-    Err(io::Error::new(
-        io::ErrorKind::Unsupported,
-        format!("Your --{kind}-choice value ({choice}) was refused by the server."),
-    ))
+/// Refuses the prefilled fallback default that upstream validates in
+/// `recv_negotiate_str` when the env list excludes it.
+///
+/// A no-op when the variable is unset or the default is a member. On refusal,
+/// emits upstream's `recv_negotiate_str` wording (`compat.c:387` "Failed to
+/// negotiate a %s choice.", where `%s` is the nno `type`, `"checksum"` or
+/// `"compress"`) with [`io::ErrorKind::Unsupported`], which the core exit-code
+/// mapper turns into `RERR_UNSUPPORTED` (exit 4), matching
+/// `exit_cleanup(RERR_UNSUPPORTED)` at `compat.c:406`.
+fn validate_default(
+    key: &str,
+    kind: &str,
+    default: &str,
+    is_server: bool,
+    resolve: impl Fn(&str) -> Option<&'static str>,
+) -> io::Result<()> {
+    match env_membership(key, is_server, default, resolve) {
+        EnvMembership::Unset | EnvMembership::Present => Ok(()),
+        EnvMembership::Absent => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("Failed to negotiate a {kind} choice."),
+        )),
+    }
 }
 
 /// Resolves a checksum name to its canonical wire spelling, or `None` when the

--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -191,6 +191,15 @@ pub fn negotiate_capabilities_with_override(
         // version, so the server still validates a forced choice against the env
         // list. No vstring exchange runs here, so ordering is irrelevant.
         validate_forced_choices(is_server, checksum_override, compression_override)?;
+        // upstream: negotiate_the_strings still runs for legacy protocols; the
+        // prefilled default is "md4" (compat.c:553) here.
+        validate_fallback_defaults(
+            is_server,
+            ChecksumAlgorithm::MD4,
+            send_compression,
+            checksum_override,
+            compression_override,
+        )?;
         // When user forced a checksum on a legacy protocol, honour it directly
         // since there is no wire negotiation to perform.
         let checksum = checksum_override.unwrap_or(ChecksumAlgorithm::MD4);
@@ -224,6 +233,18 @@ pub fn negotiate_capabilities_with_override(
         // do_negotiated_strings == 0, so the server validates a forced choice
         // against the env list. No vstring exchange runs, so ordering is moot.
         validate_forced_choices(is_server, checksum_override, compression_override)?;
+        // upstream: negotiate_the_strings runs even when do_negotiated_strings
+        // == 0 - send_negotiate_str populates the env-restricted saw list and
+        // recv_negotiate_str validates the prefilled "md5" default against it
+        // (compat.c:550-554), aborting with RERR_UNSUPPORTED when the operator's
+        // env excludes it. Without a forced choice this is the only env check.
+        validate_fallback_defaults(
+            is_server,
+            ChecksumAlgorithm::MD5,
+            send_compression,
+            checksum_override,
+            compression_override,
+        )?;
         // Use protocol 30+ defaults without sending or reading anything.
         // upstream: compat.c:194 - when -z is active but no vstring negotiation,
         // parse_compress_choice() defaults to CPRES_ZLIB.
@@ -467,6 +488,41 @@ fn validate_forced_choices(
     }
     if let Some(forced) = compression_override {
         env_list::validate_compress_choice(forced.as_str())?;
+    }
+    Ok(())
+}
+
+/// Refuses the forced fallback default checksum/compression on the
+/// non-negotiated path when `RSYNC_CHECKSUM_LIST`/`RSYNC_COMPRESS_LIST` excludes
+/// it.
+///
+/// upstream: `compat.c:541-565 negotiate_the_strings` - when the peer cannot
+/// negotiate (legacy protocol or missing 'v' capability), `send_negotiate_str`
+/// still parses the env list into `nno->saw` for each category that was not
+/// forced, then `recv_negotiate_str` validates the prefilled default against it:
+/// `"md5"`/`"md4"` for the checksum (`compat.c:553`) and `"zlib"` for
+/// compression (`compat.c:563`). A default absent from the operator's env list
+/// aborts with `RERR_UNSUPPORTED`. This runs on both peers (the `&` split
+/// selects the caller's half via `is_server`), and only for a category with no
+/// forced override - a forced choice skips `send_negotiate_str`, leaving `saw`
+/// NULL so `recv_negotiate_str` is not called; [`validate_forced_choices`]
+/// covers that case instead. Compression is gated on `send_compression`,
+/// matching upstream's `do_compression` guard at `compat.c:544`.
+///
+/// A strict no-op when neither variable is set: [`env_list`] returns early,
+/// leaving the common (default) path unchanged.
+fn validate_fallback_defaults(
+    is_server: bool,
+    checksum_default: ChecksumAlgorithm,
+    send_compression: bool,
+    checksum_override: Option<ChecksumAlgorithm>,
+    compression_override: Option<CompressionAlgorithm>,
+) -> io::Result<()> {
+    if checksum_override.is_none() {
+        env_list::validate_default_checksum(checksum_default.as_str(), is_server)?;
+    }
+    if send_compression && compression_override.is_none() {
+        env_list::validate_default_compress(CompressionAlgorithm::Zlib.as_str(), is_server)?;
     }
     Ok(())
 }

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -3563,4 +3563,158 @@ mod env_list_overrides {
 
         assert_eq!(result.checksum, ChecksumAlgorithm::MD5);
     }
+
+    // -- fallback-default validation on the non-negotiated path --
+    //
+    // upstream compat.c:541-565: even when the peer cannot negotiate strings,
+    // negotiate_the_strings populates the env-restricted saw list and validates
+    // the prefilled "md5"/"md4"/"zlib" default against it, aborting with
+    // RERR_UNSUPPORTED when the operator's env excludes the default.
+
+    // (a) Unit: env unset - the fallback default is accepted (strict no-op that
+    // guards the common case). upstream: getenv_nstr returns NULL, saw stays the
+    // built-in default order, which always contains md5/md4/zlib.
+    #[test]
+    fn validate_default_accepts_when_env_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::remove(CHECKSUM_ENV);
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+        env_list::validate_default_checksum("md5", false).expect("unset env accepts md5");
+        env_list::validate_default_checksum("md5", true).expect("unset env accepts md5");
+        env_list::validate_default_checksum("md4", true).expect("unset env accepts md4");
+        env_list::validate_default_compress("zlib", true).expect("unset env accepts zlib");
+    }
+
+    // (b) Unit: env includes the default - accepted.
+    #[test]
+    fn validate_default_accepts_when_default_in_list() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("xxh3 md5"));
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zlib zlibx"));
+        env_list::validate_default_checksum("md5", true).expect("md5 is in the list");
+        env_list::validate_default_compress("zlib", true).expect("zlib is in the list");
+    }
+
+    // (c) Unit: env excludes the default - refused with upstream's
+    // recv_negotiate_str wording and ErrorKind::Unsupported (exit 4 in core).
+    #[test]
+    fn validate_default_refuses_checksum_when_excluded() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("xxh3 xxh128"));
+        let err = env_list::validate_default_checksum("md5", true).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        assert_eq!(err.to_string(), "Failed to negotiate a checksum choice.");
+    }
+
+    #[test]
+    fn validate_default_refuses_compress_when_excluded() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zstd"));
+        let err = env_list::validate_default_compress("zlib", true).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        assert_eq!(err.to_string(), "Failed to negotiate a compress choice.");
+    }
+
+    /// Drives the non-negotiated branch (`do_negotiation = false`, peer lacks
+    /// the 'v' capability). No wire I/O runs, so an empty stdin suffices.
+    fn negotiate_nonego(is_server: bool, send_compression: bool) -> io::Result<NegotiationResult> {
+        let protocol = ProtocolVersion::try_from(31).unwrap();
+        let mut stdin = &b""[..];
+        let mut stdout = Vec::new();
+        negotiate_capabilities_with_override(
+            protocol,
+            &mut stdin,
+            &mut stdout,
+            &NegotiationConfig {
+                do_negotiation: false,
+                send_compression,
+                is_daemon_mode: false,
+                is_server,
+                checksum_override: None,
+                compression_override: None,
+                compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
+            },
+        )
+    }
+
+    // (d) End-to-end common case: env unset, non-negotiated path returns the
+    // md5 default unchanged. This is the strict no-op regression guard.
+    #[test]
+    fn nonego_returns_md5_default_when_env_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::remove(CHECKSUM_ENV);
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+        let result = negotiate_nonego(true, false).expect("unset env is a no-op");
+        assert_eq!(result.checksum, ChecksumAlgorithm::MD5);
+        assert_eq!(result.compression, CompressionAlgorithm::None);
+    }
+
+    // (e) End-to-end: server env excludes md5 + no forced choice + non-negotiated
+    // path aborts with RERR_UNSUPPORTED (exit 4), where before it proceeded with
+    // md5. WHY this matters: an operator RSYNC_CHECKSUM_LIST restriction must be
+    // honoured against an old peer exactly as upstream honours it.
+    #[test]
+    fn nonego_refuses_md5_default_when_env_excludes_it() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("xxh3 xxh128"));
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+        let err = negotiate_nonego(true, false).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        assert_eq!(err.to_string(), "Failed to negotiate a checksum choice.");
+    }
+
+    // (f) End-to-end: env includes md5 - the default is returned.
+    #[test]
+    fn nonego_returns_md5_default_when_env_includes_it() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("md5 xxh3"));
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+        let result = negotiate_nonego(true, false).expect("md5 is in the list");
+        assert_eq!(result.checksum, ChecksumAlgorithm::MD5);
+    }
+
+    // (g) End-to-end compress: with -z active, a server env excluding zlib aborts
+    // the non-negotiated path.
+    #[test]
+    fn nonego_refuses_zlib_default_when_env_excludes_it() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::remove(CHECKSUM_ENV);
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zstd"));
+        let err = negotiate_nonego(true, true).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        assert_eq!(err.to_string(), "Failed to negotiate a compress choice.");
+    }
+
+    // (h) End-to-end compress: env includes zlib - the default is returned.
+    #[test]
+    fn nonego_returns_zlib_default_when_env_includes_it() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::remove(CHECKSUM_ENV);
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zlib zlibx"));
+        let result = negotiate_nonego(true, true).expect("zlib is in the list");
+        assert_eq!(result.compression, CompressionAlgorithm::Zlib);
+    }
+
+    // (i) A compress-list restriction that excludes zlib does NOT abort when
+    // compression is off (send_compression = false): upstream gates the compress
+    // recv on do_compression (compat.c:544), so no validation runs.
+    #[test]
+    fn nonego_ignores_compress_env_when_compression_off() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::remove(CHECKSUM_ENV);
+        let _cp = EnvGuard::set(COMPRESS_ENV, OsStr::new("zstd"));
+        negotiate_nonego(true, false).expect("compress env is not checked when -z is off");
+    }
+
+    // (j) The check runs on the client too (upstream negotiate_the_strings is not
+    // am_server-gated): a client whose env excludes md5 aborts against an old
+    // peer just like the server.
+    #[test]
+    fn nonego_refuses_md5_default_on_client_side() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _cs = EnvGuard::set(CHECKSUM_ENV, OsStr::new("xxh3"));
+        let _cp = EnvGuard::remove(COMPRESS_ENV);
+        let err = negotiate_nonego(false, false).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+    }
 }


### PR DESCRIPTION
## Summary
- On the non-negotiated path (peer lacks the 'v' capability), validate the forced default checksum/compress algorithm against RSYNC_CHECKSUM_LIST / RSYNC_COMPRESS_LIST, mirroring upstream compat.c:547-565 / recv_negotiate_str
- Previously the default md5/zlib was returned without env validation, so oc proceeded where upstream aborts with RERR_UNSUPPORTED
- Strict no-op when no env restriction is set

## Test plan
- [ ] env unset: default unchanged (no-op)
- [ ] env excludes default + non-negotiated: exit 4
- [ ] env includes default: default returned
- [ ] cargo fmt clean, cargo clippy -D warnings clean, targeted protocol tests pass
