### PR TITLE
fix(transfer): frame sender diagnostics as MSG in server mode

### DIFF
--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -22,6 +22,7 @@ use protocol::wire::SignatureBlock;
 
 use super::GeneratorContext;
 use super::item_flags::ItemFlags;
+use crate::writer::MsgInfoSender;
 
 /// Per-file NDX + item-flags header that precedes a file's `sum_head` / delta
 /// payload on the wire.
@@ -339,6 +340,39 @@ impl GeneratorContext {
         Ok(())
     }
 
+    /// Emits a sender-side `FWARNING` diagnostic, framing it for the peer when
+    /// this process is the server.
+    ///
+    /// Upstream `rwrite()` sends the multiplexed frame *instead of* writing the
+    /// text to the server's own stderr (`send_msg(...); return;`), so a client
+    /// behind a daemon or SSH connection renders the line exactly once. Doing
+    /// both would duplicate it over SSH, where the server's stderr is already
+    /// forwarded. `text` carries its trailing newline, as upstream's payload
+    /// does.
+    ///
+    /// Below protocol 30 there is no `MSG_WARNING`, so `FWARNING` rides
+    /// `MSG_INFO` instead.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:330-346` - `am_server` sends the frame and returns
+    /// - `log.c:332-337` - `MSG_WARNING` -> `MSG_INFO` downgrade below protocol 30
+    fn emit_sender_warning<W: Write>(
+        &self,
+        writer: &mut super::super::writer::ServerWriter<W>,
+        text: &str,
+    ) -> io::Result<()> {
+        if self.config.connection.client_mode || !writer.is_multiplexed() {
+            eprint!("{text}");
+            return Ok(());
+        }
+        if self.protocol.supports_generator_messages() {
+            writer.send_msg_warning(text.as_bytes())
+        } else {
+            writer.send_msg_info(text.as_bytes())
+        }
+    }
+
     /// Records an I/O error, logs the appropriate warning/error, and sends
     /// MSG_NO_SEND for protocol >= 30.
     ///
@@ -362,15 +396,24 @@ impl GeneratorContext {
     ) -> io::Result<()> {
         if error.kind() == io::ErrorKind::NotFound {
             self.io_error |= super::io_error_flags::IOERR_VANISHED;
-            // upstream: sender.c:389 - rprintf(c, "file has vanished: %s\n", full_fname(...))
-            eprintln!("file has vanished: \"{path_display}\"");
+            // upstream: sender.c:387-390 - rprintf(c, "file has vanished: %s\n", full_fname(...)).
+            // `c` is FERROR only for a protocol < 28 daemon; oc's protocol floor
+            // is 28, so this is always FWARNING.
+            self.emit_sender_warning(writer, &format!("file has vanished: \"{path_display}\"\n"))?;
         } else {
             self.io_error |= super::io_error_flags::IOERR_GENERAL;
             // upstream: sender.c:393 - rsyserr(FERROR_XFER, errno, "send_files failed to open %s", ...)
-            eprintln!(
-                "rsync: [sender] send_files failed to open \"{path_display}\": {}",
+            let text = format!(
+                "rsync: [sender] send_files failed to open \"{path_display}\": {}\n",
                 engine::local_copy::upstream_io_error(error),
             );
+            // MSG_ERROR_XFER exists at every supported protocol, so it carries
+            // no downgrade (upstream log.c:332-337 only remaps MSG_WARNING).
+            if self.config.connection.client_mode || !writer.is_multiplexed() {
+                eprint!("{text}");
+            } else {
+                writer.send_msg_error_xfer(text.as_bytes())?;
+            }
         }
         if self.protocol.supports_generator_messages() {
             writer.send_no_send(ndx)?;
@@ -400,7 +443,10 @@ impl GeneratorContext {
         path_display: &str,
     ) -> io::Result<()> {
         // upstream: sender.c:422 - rprintf(FWARNING, "skipped diminished file: %s\n", ...)
-        eprintln!("skipped diminished file: \"{path_display}\"");
+        self.emit_sender_warning(
+            writer,
+            &format!("skipped diminished file: \"{path_display}\"\n"),
+        )?;
         if self.protocol.supports_generator_messages() {
             writer.send_no_send(ndx)?;
         }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -5437,3 +5437,150 @@ fn remove_source_files_mid_commit_teardown_retains_unconfirmed_sources() {
         "the two unconfirmed removals stay pending after the drop"
     );
 }
+
+/// Splits the bytes a multiplexed `ServerWriter` produced into `(code, payload)`
+/// pairs so a test can pin both the frame tag and its exact text.
+fn decode_mux_frames(buf: &[u8]) -> Vec<(protocol::MessageCode, Vec<u8>)> {
+    let mut frames = Vec::new();
+    let mut offset = 0;
+    while offset + 4 <= buf.len() {
+        let header = protocol::MessageHeader::decode(&buf[offset..offset + 4]).unwrap();
+        let start = offset + 4;
+        let end = start + header.payload_len_usize();
+        frames.push((header.code(), buf[start..end].to_vec()));
+        offset = end;
+    }
+    frames
+}
+
+/// Runs `record_open_failure` against a multiplexed server writer and returns
+/// the frames it produced.
+fn open_failure_frames(
+    protocol_version: u8,
+    client_mode: bool,
+    error: io::Error,
+) -> Vec<(protocol::MessageCode, Vec<u8>)> {
+    let handshake = test_handshake_with_protocol(protocol_version);
+    let mut config = test_config();
+    config.protocol = ProtocolVersion::try_from(protocol_version).unwrap();
+    config.connection.client_mode = client_mode;
+    let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+    let mut buf = Vec::new();
+    {
+        let mut writer = crate::writer::ServerWriter::new_plain(&mut buf)
+            .activate_multiplex()
+            .unwrap();
+        ctx.record_open_failure(&mut writer, 7, &error, "src/gone.txt")
+            .unwrap();
+    }
+    decode_mux_frames(&buf)
+}
+
+/// A daemon or SSH server has no stderr the client reads, so upstream's
+/// `rwrite()` (log.c:330-346) sends the vanished warning as a MSG frame
+/// *instead of* writing it locally. Without the frame the client never learns
+/// which file vanished.
+#[test]
+fn vanished_open_failure_frames_a_warning_in_server_mode() {
+    let frames = open_failure_frames(32, false, io::Error::from(io::ErrorKind::NotFound));
+    assert_eq!(
+        frames.len(),
+        2,
+        "the warning frame precedes MSG_NO_SEND: {frames:?}"
+    );
+    assert_eq!(frames[0].0, protocol::MessageCode::Warning);
+    assert_eq!(
+        frames[0].1, b"file has vanished: \"src/gone.txt\"\n",
+        "payload must be the upstream text including its trailing newline"
+    );
+    assert_eq!(
+        frames[1].0,
+        protocol::MessageCode::NoSend,
+        "the framed warning must not displace MSG_NO_SEND"
+    );
+}
+
+/// upstream log.c:332-337 - protocol < 30 has no MSG_WARNING, so FWARNING
+/// downgrades to MSG_INFO. Sending code 4 to a protocol-29 peer would abort it
+/// with an unknown-message error.
+#[test]
+fn vanished_open_failure_downgrades_to_info_below_protocol_30() {
+    let frames = open_failure_frames(29, false, io::Error::from(io::ErrorKind::NotFound));
+    assert_eq!(
+        frames.len(),
+        1,
+        "protocol 29 has no generator messages, so no MSG_NO_SEND: {frames:?}"
+    );
+    assert_eq!(frames[0].0, protocol::MessageCode::Info);
+    assert_eq!(frames[0].1, b"file has vanished: \"src/gone.txt\"\n");
+}
+
+/// upstream sender.c:393 uses `rsyserr(FERROR_XFER, ...)`, which the peer's
+/// `rwrite()` counts as a transfer error (exit 23). MSG_ERROR_XFER exists at
+/// every supported protocol, so it never downgrades.
+#[test]
+fn general_open_failure_frames_an_error_xfer_in_server_mode() {
+    let frames = open_failure_frames(32, false, io::Error::from(io::ErrorKind::PermissionDenied));
+    assert_eq!(frames.len(), 2, "error frame then MSG_NO_SEND: {frames:?}");
+    assert_eq!(frames[0].0, protocol::MessageCode::ErrorXfer);
+    let expected = format!(
+        "rsync: [sender] send_files failed to open \"src/gone.txt\": {}\n",
+        engine::local_copy::upstream_io_error(&io::Error::from(io::ErrorKind::PermissionDenied)),
+    );
+    assert_eq!(
+        String::from_utf8(frames[0].1.clone()).unwrap(),
+        expected,
+        "the framed text must stay byte-identical to the rsyserr rendering"
+    );
+    assert_eq!(frames[1].0, protocol::MessageCode::NoSend);
+}
+
+/// A client owns the terminal, so upstream's `!am_server` branch writes the
+/// text locally and frames nothing. Framing it as well would print twice.
+#[test]
+fn open_failure_emits_no_diagnostic_frame_in_client_mode() {
+    for error in [
+        io::Error::from(io::ErrorKind::NotFound),
+        io::Error::from(io::ErrorKind::PermissionDenied),
+    ] {
+        let frames = open_failure_frames(32, true, error);
+        assert_eq!(
+            frames.len(),
+            1,
+            "client mode writes stderr locally, leaving only MSG_NO_SEND: {frames:?}"
+        );
+        assert_eq!(frames[0].0, protocol::MessageCode::NoSend);
+    }
+}
+
+/// upstream sender.c:422 - the diminished skip is an FWARNING, so a server
+/// frames it for the client exactly like the vanished warning.
+#[test]
+fn diminished_skip_frames_a_warning_in_server_mode() {
+    let handshake = test_handshake();
+    let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());
+    let mut buf = Vec::new();
+    {
+        let mut writer = crate::writer::ServerWriter::new_plain(&mut buf)
+            .activate_multiplex()
+            .unwrap();
+        ctx.record_diminished_skip(&mut writer, 4, "src/shrunk.bin")
+            .unwrap();
+    }
+    let frames = decode_mux_frames(&buf);
+    assert_eq!(
+        frames.len(),
+        2,
+        "warning frame then MSG_NO_SEND: {frames:?}"
+    );
+    assert_eq!(frames[0].0, protocol::MessageCode::Warning);
+    assert_eq!(
+        frames[0].1,
+        b"skipped diminished file: \"src/shrunk.bin\"\n"
+    );
+    assert_eq!(frames[1].0, protocol::MessageCode::NoSend);
+    assert_eq!(
+        ctx.io_error, 0,
+        "a diminished skip sets no io_error bit (upstream sender.c:421-429)"
+    );
+}

--- a/crates/transfer/src/writer/msg_info.rs
+++ b/crates/transfer/src/writer/msg_info.rs
@@ -48,6 +48,24 @@ pub trait MsgInfoSender {
         Ok(())
     }
 
+    /// Sends a `MSG_WARNING` frame through the multiplexed output stream.
+    ///
+    /// Mirrors upstream `rprintf(FWARNING, ...)` from a server-side sender: the
+    /// text is framed instead of being written to the local stderr, so a client
+    /// on the far end of a daemon or SSH connection renders it. Callers must
+    /// downgrade to [`Self::send_msg_info`] below protocol 30, matching
+    /// `log.c:332-337`.
+    ///
+    /// The default implementation is a no-op, matching [`Self::send_msg_info`].
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:330-346` - `rwrite()` sends `MSG_WARNING` when `am_server`
+    /// - `log.c:332-337` - `protocol_version < 30` maps `MSG_WARNING` to `MSG_INFO`
+    fn send_msg_warning(&mut self, _data: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
+
     /// Sends a `MSG_DELETED` frame carrying the raw name of a deleted entry.
     ///
     /// A server generator emits one frame per deletion so the client renders the
@@ -125,6 +143,14 @@ impl<W: Write> MsgInfoSender for ServerWriter<W> {
         }
     }
 
+    fn send_msg_warning(&mut self, data: &[u8]) -> io::Result<()> {
+        if self.is_multiplexed() {
+            self.send_message(MessageCode::Warning, data)
+        } else {
+            Ok(())
+        }
+    }
+
     fn send_msg_deleted(&mut self, data: &[u8]) -> io::Result<()> {
         // upstream: log.c:866-869 - the MSG_DELETED path only exists on a
         // multiplexed server stream; plain mode never reaches this branch.
@@ -167,6 +193,10 @@ impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
         (**self).send_msg_error_xfer(data)
     }
 
+    fn send_msg_warning(&mut self, data: &[u8]) -> io::Result<()> {
+        (**self).send_msg_warning(data)
+    }
+
     fn send_msg_deleted(&mut self, data: &[u8]) -> io::Result<()> {
         (**self).send_msg_deleted(data)
     }
@@ -187,6 +217,10 @@ impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
 
     fn send_msg_error_xfer(&mut self, data: &[u8]) -> io::Result<()> {
         self.inner_ref_mut().send_msg_error_xfer(data)
+    }
+
+    fn send_msg_warning(&mut self, data: &[u8]) -> io::Result<()> {
+        self.inner_ref_mut().send_msg_warning(data)
     }
 
     fn send_msg_deleted(&mut self, data: &[u8]) -> io::Result<()> {


### PR DESCRIPTION
## Summary
- Sender vanished/open-failed/diminished diagnostics now travel as multiplexed MSG frames in server mode, mirroring log.c:rwrite:330-346
- Warning frames downgrade to Info below protocol 30; ErrorXfer is unchanged at all protocols
- The local stderr write is replaced (not duplicated) when am_server, matching upstream's send_msg-and-return, so SSH transfers do not print twice
- Daemon pulls previously had no side channel, so clients never saw this text

## Test plan
- [ ] Warning/Info frame emitted for a vanished file, per protocol version
- [ ] ErrorXfer frame emitted for a general open failure with upstream-exact text
- [ ] Warning frame emitted for a diminished skip
- [ ] Client mode still writes stderr and emits no frame
- [ ] cargo fmt clean, cargo clippy -D warnings clean
