### PR TITLE
fix(transfer): honor prefer_rename in network backup paths

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -11,7 +11,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use engine::{
-    CleanupManager, compute_backup_path, trace_make_backup_copy, trace_make_backup_rename,
+    CleanupManager, compute_backup_path, trace_make_backup_copy, trace_make_backup_hlink,
+    trace_make_backup_rename,
 };
 
 use crate::pipeline::messages::{BackupNotice, BeginMessage};
@@ -594,6 +595,61 @@ fn backup_rename_sandboxed(
     backup_rename_or_copy(old_path, new_path)
 }
 
+/// Issues the backup hard link, dirfd-anchoring the backup endpoint against the
+/// receiver's destination sandbox when the backup name is a single component
+/// under `dest_dir` (SEC-1.h shape, same as the hardlink-follower create).
+///
+/// Under `cfg(test)` the [`ForceExdev`] guard makes this report a cross-device
+/// error, matching a real `--backup-dir` on another mount where `link(2)` fails
+/// with `EXDEV` before `rename(2)` does.
+fn backup_hardlink_syscall(
+    config: &DiskCommitConfig,
+    old_path: &Path,
+    new_path: &Path,
+) -> io::Result<()> {
+    #[cfg(test)]
+    if force_exdev_active() {
+        return Err(simulated_cross_device_error());
+    }
+    #[cfg(unix)]
+    if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref()) {
+        return fast_io::linkat_via_sandbox_or_fallback(
+            Some(sandbox.as_ref()),
+            old_path,
+            dest_dir,
+            new_path.strip_prefix(dest_dir).unwrap_or(new_path),
+            new_path,
+        );
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = config;
+    }
+    fast_io::hard_link(old_path, new_path)
+}
+
+/// Upstream's hard-link tier of `link_or_rename()` with `prefer_rename = 0`.
+///
+/// Returns `true` when the pre-image was duplicated into the backup area as a
+/// second link - upstream's `ret == 2`, which leaves the original in place for
+/// the temp->destination rename to replace. Any failure returns `false` so the
+/// caller falls through to the unchanged rename/copy tier.
+///
+/// upstream: `backup.c:200-207` - `do_link_at` success traces HLINK and returns
+/// 2; a link failure on a regular file falls through to `do_rename_at`.
+/// upstream: `backup.c:246-255` `make_backup()` - an `EEXIST`/`EISDIR` collision
+/// deletes the stale backup entry and retries `link_or_rename` once.
+fn backup_hardlink_tier(config: &DiskCommitConfig, old_path: &Path, new_path: &Path) -> bool {
+    match backup_hardlink_syscall(config, old_path, new_path) {
+        Ok(()) => true,
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+            fs::remove_file(new_path).is_ok()
+                && backup_hardlink_syscall(config, old_path, new_path).is_ok()
+        }
+        Err(_) => false,
+    }
+}
+
 /// SEC-1.j: create the `--backup-dir` parent, dirfd-anchoring the leaf `mkdir`
 /// against the receiver's destination sandbox when possible.
 ///
@@ -633,10 +689,14 @@ fn create_dir_all_sandboxed(_config: &DiskCommitConfig, parent: &Path) -> io::Re
 
 /// Creates a backup of the destination file before overwriting.
 ///
-/// Mirrors upstream `backup.c:make_backup()` which renames the existing file
-/// to the backup path. Parent directories are created if needed when using
-/// `--backup-dir`. On success, emits the upstream `--debug=BACKUP` RENAME
-/// notice (`backup.c:216-217`) and returns a [`BackupNotice`] carrying the
+/// Mirrors upstream `backup.c:make_backup()`, called from `rsync.c:739`
+/// `finish_transfer()` as `make_backup(fname, False)`: `link_or_rename()` tries
+/// `do_link_at` first (HLINK, upstream `ret == 2`, the original stays in place
+/// for the temp->destination rename to replace) and only falls back to
+/// `do_rename_at` (RENAME) or the cross-device copy tier (COPY) when the link
+/// cannot be made. Parent directories are created if needed when using
+/// `--backup-dir`. On success, emits the matching `--debug=BACKUP` mechanism
+/// notice (`backup.c:201-202`/`:216-217`/`:284`) and returns a [`BackupNotice`] carrying the
 /// destination-relative paths so the main thread can emit upstream's
 /// `INFO_GTE(BACKUP, 1)` line (`backup.c:352`). The disk thread cannot emit
 /// the info line directly because its thread-local [`logging::VerbosityConfig`]
@@ -664,6 +724,21 @@ pub(super) fn make_backup(
         }
     }
 
+    // upstream: backup.c:191-207 - `prefer_rename` is False here (rsync.c:739),
+    // so `do_link_at` runs first. The tier is limited to a regular pre-image:
+    // upstream gates symlinks and specials on CAN_HARDLINK_SYMLINK /
+    // CAN_HARDLINK_SPECIAL (backup.c:192-199), and this commit path only ever
+    // replaces a regular destination anyway.
+    let is_regular = fs::symlink_metadata(file_path).is_ok_and(|m| m.is_file());
+    if is_regular && backup_hardlink_tier(config, file_path, &backup_path) {
+        // upstream: backup.c:201-202 - DEBUG_GTE(BACKUP, 1) HLINK success. The
+        // original is deliberately left in place (upstream returns 2 and
+        // finish_transfer does not redirect fnamecmp); the temp->destination
+        // rename that follows replaces it.
+        trace_make_backup_hlink(&file_path.display().to_string());
+        return Ok(Some(backup_notice(backup_config, file_path, &backup_path)));
+    }
+
     let was_copy = backup_rename_sandboxed(config, file_path, &backup_path)?;
     if was_copy {
         // upstream: backup.c:284 - DEBUG_GTE(BACKUP, 1) "make_backup: COPY %s
@@ -674,23 +749,31 @@ pub(super) fn make_backup(
         // branch of link_or_rename.
         trace_make_backup_rename(&file_path.display().to_string());
     }
-    // upstream: backup.c:352 - INFO_GTE(BACKUP, 1) fires on success label for
-    // every successful backup. Paths are displayed relative to the destination
-    // root to match upstream test assertions (testsuite/backup.test). The
-    // actual `info_log!` emission happens on the main thread; see
-    // `crate::pipeline::receiver::emit_backup_notice`.
-    let file_rel = file_path
-        .strip_prefix(&backup_config.dest_dir)
-        .unwrap_or(file_path)
-        .to_path_buf();
-    let backup_rel = backup_path
-        .strip_prefix(&backup_config.dest_dir)
-        .unwrap_or(&backup_path)
-        .to_path_buf();
-    Ok(Some(BackupNotice {
-        original: file_rel,
-        backup: backup_rel,
-    }))
+    Ok(Some(backup_notice(backup_config, file_path, &backup_path)))
+}
+
+/// Builds the destination-relative [`BackupNotice`] for a completed backup.
+///
+/// upstream: `backup.c:352` - INFO_GTE(BACKUP, 1) fires on the `success:` label
+/// for every successful backup, whichever mechanism ran. Paths are displayed
+/// relative to the destination root to match upstream test assertions
+/// (`testsuite/backup.test`). The actual `info_log!` emission happens on the
+/// main thread; see `crate::pipeline::receiver::emit_backup_notice`.
+fn backup_notice(
+    backup_config: &BackupConfig,
+    file_path: &Path,
+    backup_path: &Path,
+) -> BackupNotice {
+    BackupNotice {
+        original: file_path
+            .strip_prefix(&backup_config.dest_dir)
+            .unwrap_or(file_path)
+            .to_path_buf(),
+        backup: backup_path
+            .strip_prefix(&backup_config.dest_dir)
+            .unwrap_or(backup_path)
+            .to_path_buf(),
+    }
 }
 
 /// Copies the destination's pre-transfer contents aside to the backup path,

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -348,11 +348,70 @@ fn make_backup_returns_destination_relative_notice() {
         .expect("notice produced when an existing file is backed up");
 
     let backup_path = file_path.with_extension("bin~");
-    assert!(backup_path.exists(), "backup file must exist after rename");
-    assert!(!file_path.exists(), "original file must be renamed away");
+    assert!(
+        backup_path.exists(),
+        "backup file must exist after the backup"
+    );
+    // upstream: backup.c:201-206 - the hard-link tier returns 2 and rsync.c:741
+    // leaves `fname` alone; the temp->destination rename replaces it afterwards.
+    assert!(
+        file_path.exists(),
+        "the hard-link tier must leave the original in place (upstream ok == 2)"
+    );
 
     assert_eq!(notice.original, PathBuf::from("payload.bin"));
     assert_eq!(notice.backup, PathBuf::from("payload.bin~"));
+}
+
+/// Verifies the network regular-file basis backup takes upstream's hard-link
+/// tier and emits `make_backup: HLINK`, not `RENAME`.
+///
+/// `finish_transfer` calls `make_backup(fname, False)` (rsync.c:739), so
+/// `link_or_rename` tries `do_link_at` before `do_rename_at` and reports HLINK
+/// (backup.c:201-202). Inode identity cannot discriminate the two mechanisms -
+/// a same-filesystem rename and a hard link both leave the pre-image inode at
+/// the backup name - so the trace text is the assertion.
+#[test]
+fn make_backup_regular_file_traces_hlink() {
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+    use std::ffi::OsString;
+
+    let mut verbosity = VerbosityConfig::default();
+    verbosity.debug.backup = 1;
+    init(verbosity);
+    let _ = drain_events();
+
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("payload.bin");
+    fs::write(&file_path, b"pre-image").unwrap();
+
+    let config = BackupConfig {
+        dest_dir: dir.path().to_path_buf(),
+        backup_dir: None,
+        suffix: OsString::from("~"),
+    };
+    make_backup(&file_path, &config, &DiskCommitConfig::default())
+        .expect("make_backup succeeds")
+        .expect("notice produced when an existing file is backed up");
+
+    let traces: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Backup,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        traces.contains(&format!(
+            "make_backup: HLINK {} successful.",
+            file_path.display()
+        )),
+        "regular-file basis backup must trace HLINK, got {traces:?}"
+    );
 }
 
 /// Verifies `make_backup` succeeds when the backup path is on a different

--- a/crates/transfer/src/receiver/directory/backup.rs
+++ b/crates/transfer/src/receiver/directory/backup.rs
@@ -59,18 +59,35 @@ enum BackupPlacement {
     CopiedNode,
 }
 
-/// Places `existing` into `backup_path`, mirroring upstream `link_or_rename`
-/// with `prefer_rename = 0`: hard-link first, rename on fallback.
+/// Places `existing` into `backup_path`, mirroring upstream `link_or_rename`.
 ///
+/// With `prefer_rename = false` the hard-link tier runs first and the rename is
+/// the fallback; with `prefer_rename = true` the whole link tier is skipped and
+/// the entry is renamed straight into the backup area.
+///
+/// upstream: `backup.c:191` - `if (!prefer_rename)` gates the entire
+/// `do_link_at` tier, so `make_backup(fbuf, True)` (the `--delete` caller,
+/// `delete.c:167`) goes directly to `do_rename_at` and reports RENAME.
 /// upstream: `backup.c:200-219` - `do_link_at` then `do_rename_at`. A
 /// pre-existing backup (`EEXIST`) is removed and the link retried
 /// (`backup.c:247-256`).
 #[cfg(any(unix, windows))]
-fn place_existing_backup(existing: &Path, backup_path: &Path) -> io::Result<BackupPlacement> {
+fn place_existing_backup(
+    existing: &Path,
+    backup_path: &Path,
+    prefer_rename: bool,
+) -> io::Result<BackupPlacement> {
     if let Some(parent) = backup_path.parent() {
         if !parent.exists() {
             fs::create_dir_all(parent)?;
         }
+    }
+
+    // upstream: backup.c:191 - the caller's `prefer_rename` suppresses the
+    // hard-link tier entirely. Renaming is atomic, so the victim never exists
+    // under two names the way a link+unlink pair would leave it.
+    if prefer_rename {
+        return rename_or_copy_existing(existing, backup_path);
     }
 
     match fast_io::hard_link(existing, backup_path) {
@@ -196,7 +213,9 @@ pub(in crate::receiver::directory) fn is_backup_file(name: &OsStr, suffix: &str)
 /// Moves `existing` into its computed backup location, emits the trace, and
 /// clears the original path so the caller need not unlink again.
 ///
-/// Shared by the pre-replace and pre-delete backup callers. Only the hard-link
+/// Shared by the pre-replace and pre-delete backup callers, which differ only
+/// in `prefer_rename`: `generator.c:2018` passes `False` (hard-link first)
+/// while `delete.c:167` passes `True` (rename only). Only the hard-link
 /// placement leaves the original behind (upstream's copy tier, `ok == 2`); the
 /// rename and cross-device copy tiers already free the path.
 ///
@@ -210,9 +229,10 @@ fn place_report_and_clear(
     backup_dir: Option<&Path>,
     suffix: &OsStr,
     sandbox: Option<&fast_io::DirSandbox>,
+    prefer_rename: bool,
 ) -> io::Result<()> {
     let backup_path = engine::compute_backup_path(dest_dir, existing, None, backup_dir, suffix);
-    let placement = place_existing_backup(existing, &backup_path)?;
+    let placement = place_existing_backup(existing, &backup_path, prefer_rename)?;
     report_backup(&placement, existing, &backup_path, dest_dir);
     if matches!(placement, BackupPlacement::Hardlinked) {
         // upstream: delete.c:169-170 - the hard-link tier is upstream's `ok == 2`
@@ -237,9 +257,10 @@ fn place_report_and_clear(
     dest_dir: &Path,
     backup_dir: Option<&Path>,
     suffix: &OsStr,
+    prefer_rename: bool,
 ) -> io::Result<()> {
     let backup_path = engine::compute_backup_path(dest_dir, existing, None, backup_dir, suffix);
-    let placement = place_existing_backup(existing, &backup_path)?;
+    let placement = place_existing_backup(existing, &backup_path, prefer_rename)?;
     report_backup(&placement, existing, &backup_path, dest_dir);
     if matches!(placement, BackupPlacement::Hardlinked) {
         let _ = fs::remove_file(existing);
@@ -286,6 +307,9 @@ pub(in crate::receiver::directory) fn backup_victim(
     if fs::symlink_metadata(existing).is_err() {
         return Ok(false);
     }
+    // upstream: delete.c:167 - `make_backup(fbuf, True)`. The delete pass is the
+    // `prefer_rename` caller: the victim is renamed into the backup area, so the
+    // RENAME trace is emitted and no second link ever exists.
     place_report_and_clear(
         existing,
         relative_path,
@@ -293,6 +317,7 @@ pub(in crate::receiver::directory) fn backup_victim(
         backup_dir,
         OsStr::new(suffix),
         sandbox,
+        true,
     )?;
     Ok(true)
 }
@@ -319,7 +344,8 @@ pub(in crate::receiver::directory) fn backup_victim(
     if fs::symlink_metadata(existing).is_err() {
         return Ok(false);
     }
-    place_report_and_clear(existing, dest_dir, backup_dir, OsStr::new(suffix))?;
+    // upstream: delete.c:167 - `make_backup(fbuf, True)`, the rename-only caller.
+    place_report_and_clear(existing, dest_dir, backup_dir, OsStr::new(suffix), true)?;
     Ok(true)
 }
 
@@ -416,6 +442,8 @@ impl ReceiverContext {
             return Ok(false);
         }
 
+        // upstream: generator.c:2018 - `make_backup(fname, False)`, so the
+        // hard-link tier runs first for a symlink/special replacement.
         place_report_and_clear(
             existing,
             relative_path,
@@ -423,6 +451,7 @@ impl ReceiverContext {
             self.config.backup_dir.as_deref().map(Path::new),
             OsStr::new(self.config.effective_backup_suffix()),
             sandbox,
+            false,
         )?;
         Ok(true)
     }
@@ -443,11 +472,13 @@ impl ReceiverContext {
             return Ok(false);
         }
 
+        // upstream: generator.c:2018 - `make_backup(fname, False)`.
         place_report_and_clear(
             existing,
             dest_dir,
             self.config.backup_dir.as_deref().map(Path::new),
             OsStr::new(self.config.effective_backup_suffix()),
+            false,
         )?;
         Ok(true)
     }
@@ -496,7 +527,7 @@ mod tests {
         let backup = dir.path().join("link~");
         std::os::unix::fs::symlink("original/target", &link).unwrap();
 
-        let placement = place_existing_backup(&link, &backup).unwrap();
+        let placement = place_existing_backup(&link, &backup, false).unwrap();
 
         // On Linux `link(2)` does not dereference a symlink source, so the
         // backup is taken via hard-link and the HLINK trace is guaranteed.
@@ -552,11 +583,99 @@ mod tests {
         // mkfifo via metadata's safe wrapper needs no privilege.
         metadata::create_fifo_node_from_parts(&fifo, 0o644, false, false).unwrap();
 
-        place_existing_backup(&fifo, &backup).unwrap();
+        place_existing_backup(&fifo, &backup, false).unwrap();
 
         assert!(
             fs::symlink_metadata(&backup).unwrap().file_type().is_fifo(),
             "backup of a FIFO must itself be a FIFO"
+        );
+    }
+
+    /// The `--backup --delete` caller passes `prefer_rename = true`, so the
+    /// hard-link tier must be skipped entirely and the victim renamed into the
+    /// backup area: the mechanism is RENAME, the trace says RENAME, and the
+    /// original path is already free (no link+unlink window).
+    ///
+    /// Inode identity does not discriminate here - a same-filesystem rename and
+    /// a hard link both leave the pre-image inode at the backup name - so the
+    /// assertion is on the emitted mechanism, which is the observable upstream
+    /// difference (`make_backup: RENAME` vs `make_backup: HLINK`).
+    ///
+    /// upstream: delete.c:167 `make_backup(fbuf, True)` -> backup.c:191
+    /// `if (!prefer_rename)` skips `do_link_at`, so `do_rename_at` reports
+    /// "make_backup: RENAME %s successful." (backup.c:216-217).
+    #[test]
+    fn prefer_rename_skips_hard_link_tier() {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.backup = 1;
+        init(cfg);
+        let _ = drain_events();
+
+        let dir = tempfile::tempdir().unwrap();
+        let victim = dir.path().join("extraneous");
+        let backup = dir.path().join("extraneous~");
+        fs::write(&victim, b"victim payload").unwrap();
+
+        let placement = place_existing_backup(&victim, &backup, true).unwrap();
+
+        assert!(
+            matches!(placement, BackupPlacement::Renamed),
+            "prefer_rename must take the RENAME branch, never HLINK"
+        );
+        assert!(
+            fs::symlink_metadata(&victim).is_err(),
+            "the rename must free the victim path outright"
+        );
+        assert_eq!(fs::read(&backup).unwrap(), b"victim payload");
+
+        report_backup(&placement, &victim, &backup, dir.path());
+        assert!(
+            backup_debug_messages().contains(&format!(
+                "make_backup: RENAME {} successful.",
+                victim.display()
+            )),
+            "the delete-pass backup must trace RENAME, not HLINK"
+        );
+    }
+
+    /// Control for [`prefer_rename_skips_hard_link_tier`]: the same fixture with
+    /// `prefer_rename = false` (the `generator.c:2018` pre-replace caller) takes
+    /// the hard-link tier instead, proving the flag - not the file type or the
+    /// filesystem - is what selects the mechanism.
+    ///
+    /// upstream: backup.c:201-202 - `do_link_at` success emits
+    /// "make_backup: HLINK %s successful." and returns 2, leaving the original
+    /// in place for the caller to replace.
+    #[test]
+    fn hard_link_tier_traces_hlink_for_regular_file() {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.backup = 1;
+        init(cfg);
+        let _ = drain_events();
+
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("regular");
+        let backup = dir.path().join("regular~");
+        fs::write(&file, b"pre-image").unwrap();
+
+        let placement = place_existing_backup(&file, &backup, false).unwrap();
+
+        assert!(
+            matches!(placement, BackupPlacement::Hardlinked),
+            "a same-filesystem regular file must hard-link (HLINK branch)"
+        );
+        assert!(
+            fs::symlink_metadata(&file).is_ok(),
+            "the hard-link tier must leave the original in place (upstream ok == 2)"
+        );
+
+        report_backup(&placement, &file, &backup, dir.path());
+        assert!(
+            backup_debug_messages().contains(&format!(
+                "make_backup: HLINK {} successful.",
+                file.display()
+            )),
+            "the pre-replace backup must trace HLINK"
         );
     }
 
@@ -624,7 +743,7 @@ mod tests {
         let backup = dir.path().join("l~");
         std::os::unix::fs::symlink("t", &link).unwrap();
 
-        let placement = place_existing_backup(&link, &backup).unwrap();
+        let placement = place_existing_backup(&link, &backup, false).unwrap();
         report_backup(&placement, &link, &backup, dir.path());
 
         assert!(


### PR DESCRIPTION
## Summary
- Network backup paths ignored upstream's prefer_rename parameter in both directions (backup.c:link_or_rename:185-221)
- Regular-file basis backup now tries a hard link first and emits HLINK (upstream rsync.c:739 make_backup(fname, False))
- --backup --delete now renames directly and emits RENAME, skipping the hard-link tier (upstream delete.c:165 make_backup(fbuf, True))
- Removes a non-atomic hard-link+unlink window in the delete path

## Test plan
- [x] Trace asserts HLINK for a network regular-file basis backup
- [x] Trace asserts RENAME for --backup --delete
- [x] cargo fmt clean, cargo clippy -D warnings clean

## Notes
- `place_report_and_clear` in `receiver/directory/backup.rs` has two callers, not just the delete pass. `backup_victim` (`delete.c:167`) now passes `prefer_rename = true`; `ReceiverContext::backup_existing_before_replace` is the pre-replace symlink/FIFO/device path reached from `generator.c:2018 atomic_create()`, which upstream calls as `make_backup(fname, False)`, so it passes `false` and keeps the existing hard-link-first behaviour.
- The new hard-link tier in `disk_commit/process/commit.rs` is guarded to a regular pre-image, mirroring upstream's `CAN_HARDLINK_SYMLINK` / `CAN_HARDLINK_SPECIAL` bail-outs at `backup.c:192-199`. A `--write-devices` destination (the only non-regular case this commit path can see) keeps the previous rename tier unchanged.
- On `EEXIST` the tier deletes the stale backup entry and retries the link once (`backup.c:246-255`); any other link failure falls through to the untouched rename/cross-device-copy tier.
- The backup hard link is dirfd-anchored via `fast_io::linkat_via_sandbox_or_fallback` when the backup name is a single component under the destination root, matching the SEC-1 shape already used by `backup_rename_sandboxed`.
- `ForceExdev` now also forces the hard link to report `EXDEV`, so `make_backup_cross_device_uses_copy_fallback` still reaches the copy tier - which is what a real `--backup-dir` on another mount does, since `link(2)` fails cross-device before `rename(2)` does.
- Assertions are on the emitted `--debug=BACKUP` mechanism trace. Inode identity is not a discriminator: for a same-filesystem regular file both HLINK and RENAME leave the same pre-image inode at the backup name.
- Existing pin `make_backup_returns_destination_relative_notice` was updated: the original now survives the backup (upstream `ok == 2`), and the following temp -> destination rename replaces it.
