### PR TITLE
fix(transfer): append daemon module suffix to quoted paths

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -73,6 +73,13 @@ fn clamped_verbose_level(flag_string: &str) -> u8 {
 ///   `NumericIds::DaemonForced`, distinct from the client's explicit
 ///   `NumericIds::Explicit` which also drops the wire list.
 fn apply_module_transfer_directives(module: &ModuleDefinition, cfg: &mut ServerConfig) {
+    // upstream: clientserver.c:769 `module_id = i` - selecting a module makes
+    // `module_id >= 0` for the rest of the server process, and that is the sole
+    // condition under which `full_fname()` (util1.c:1290) appends
+    // ` (in MODULE)` after the closing quote of every path it renders into an
+    // error or warning. Record the name so the transfer layer reproduces it.
+    cfg.connection.daemon_module = Some(module.name.clone());
+
     // upstream: clientserver.c:1111-1112
     if module.ignore_errors {
         cfg.deletion.ignore_errors = true;

--- a/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
@@ -189,3 +189,38 @@ mod clamped_verbosity_tests {
         .expect("clamp thread");
     }
 }
+
+#[cfg(test)]
+mod daemon_module_suffix_tests {
+    use super::{ModuleDefinition, ServerConfig, apply_module_transfer_directives};
+
+    /// Selecting a module is what makes upstream's `module_id >= 0`, and that
+    /// is the only condition under which `full_fname()` appends
+    /// ` (in MODULE)` to a quoted path. Recording the name here is what lets a
+    /// daemon-side `send_files failed to open` / `mkstemp failed` line name the
+    /// module the client asked for, exactly as upstream 3.4.4 does.
+    ///
+    /// upstream: clientserver.c:769 `module_id = i`; util1.c:1290
+    /// `if (module_id >= 0)`.
+    #[test]
+    fn module_selection_records_name_for_full_fname() {
+        let module = ModuleDefinition {
+            name: "mymod".to_string(),
+            ..ModuleDefinition::default()
+        };
+        let mut cfg = ServerConfig::default();
+        assert_eq!(cfg.connection.daemon_module, None);
+
+        apply_module_transfer_directives(&module, &mut cfg);
+
+        assert_eq!(cfg.connection.daemon_module.as_deref(), Some("mymod"));
+    }
+
+    /// A `ServerConfig` that never passed through module selection stays at
+    /// upstream's `module_id < 0`, so no suffix is rendered. This is the SSH
+    /// `--server` and client-side shape.
+    #[test]
+    fn config_without_module_selection_has_no_module_name() {
+        assert_eq!(ServerConfig::default().connection.daemon_module, None);
+    }
+}

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -155,6 +155,19 @@ pub struct ConnectionConfig {
     pub client_mode: bool,
     /// Indicates the transfer is over a daemon (rsync://) connection.
     pub is_daemon_connection: bool,
+    /// Name of the daemon module this server process is serving, when any.
+    ///
+    /// Mirrors upstream's `module_id` global: it is set exactly once, when the
+    /// daemon selects a module for the connection, and gates the ` (in MODULE)`
+    /// suffix that `full_fname()` appends to every quoted path in an error or
+    /// warning. `None` for clients and for non-daemon (SSH) server processes,
+    /// matching upstream's `module_id < 0`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:769` - `module_id = i` in `rsync_module()`.
+    /// - `util1.c:1290` - `if (module_id >= 0)` in `full_fname()`.
+    pub daemon_module: Option<String>,
     /// Filter rules to send to remote daemon (client_mode only).
     pub filter_rules: Vec<FilterRuleWireFormat>,
     /// Optional filename encoding converter for `--iconv` support.

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -198,6 +198,17 @@ pub struct DiskCommitConfig {
     ///
     /// - `receiver.c:357-373` - `if (append_mode == 2 && mapbuf)` prefix `sum_update`
     pub append_verify: bool,
+    /// Name of the daemon module this server process is serving, when any.
+    ///
+    /// Only used to render diagnostics: upstream's `full_fname()` appends
+    /// ` (in MODULE)` after the closing quote of every path it quotes while
+    /// `module_id >= 0`, which covers the receiver's `mkstemp %s failed` line.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `util1.c:1290` - `if (module_id >= 0)` in `full_fname()`.
+    /// - `receiver.c:297` - `rsyserr(FERROR_XFER, errno, "mkstemp %s failed", ...)`
+    pub daemon_module: Option<String>,
 }
 
 impl Default for DiskCommitConfig {
@@ -223,6 +234,7 @@ impl Default for DiskCommitConfig {
             partial_mode: PartialMode::None,
             delay_updates: false,
             append_verify: false,
+            daemon_module: None,
         }
     }
 }

--- a/crates/transfer/src/full_fname.rs
+++ b/crates/transfer/src/full_fname.rs
@@ -1,0 +1,94 @@
+//! Quoted path rendering for diagnostic messages.
+//!
+//! Upstream rsync funnels every path that appears inside an error or warning
+//! through `full_fname()`, which wraps the name in double quotes and, when the
+//! process is serving a daemon module, appends ` (in MODULE)` *after* the
+//! closing quote. A daemon-side open failure therefore reads:
+//!
+//! ```text
+//! rsync: [sender] send_files failed to open "sub/denied.txt" (in mymod): Permission denied (13)
+//! ```
+//!
+//! Only the message sites that upstream routes through `full_fname()` carry the
+//! suffix. Sites that hard-code the quotes around a plain `%s` (for example
+//! `copying unsafe symlink "%s" -> "%s"` at `flist.c:229`, or
+//! `not creating new %s "%s"` at `generator.c:1380`) never gain it, so they must
+//! keep formatting their own quotes.
+//!
+//! # Upstream Reference
+//!
+//! - `util1.c:1273` - `full_fname()`; the `module_id >= 0` branch selects
+//!   `" (in "`, `lp_name(module_id)`, `")"`.
+//! - `clientserver.c:769` - `module_id = i` is the only assignment that makes
+//!   `module_id >= 0`, so the suffix appears exactly when the process is a
+//!   daemon server that has selected a module.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+/// Renders `fname` the way upstream `full_fname()` does: double quoted, with
+/// ` (in MODULE)` appended after the closing quote when serving a daemon
+/// module.
+///
+/// `module` is `None` for client and non-daemon server processes, mirroring
+/// upstream's `module_id < 0`.
+///
+/// Upstream additionally rewrites a relative name into `curr_dir` +
+/// `module_dirlen` form. Inside a daemon module that prefix is always empty,
+/// which is the only context where the suffix applies, so this helper renders
+/// the name it is given.
+///
+/// # Upstream Reference
+///
+/// - `util1.c:1296` - `asprintf(&result, "\"%s%s%s\"%s%s%s", ...)`
+pub(crate) fn full_fname(fname: &str, module: Option<&str>) -> String {
+    let mut out = String::with_capacity(fname.len() + 2);
+    out.push('"');
+    out.push_str(fname);
+    out.push('"');
+    if let Some(module) = module {
+        let _ = write!(out, " (in {module})");
+    }
+    out
+}
+
+/// [`full_fname`] for a [`Path`], using the platform's lossy display form.
+pub(crate) fn full_fname_path(path: &Path, module: Option<&str>) -> String {
+    full_fname(&path.display().to_string(), module)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{full_fname, full_fname_path};
+    use std::path::Path;
+
+    #[test]
+    fn quotes_without_module_outside_daemon() {
+        assert_eq!(full_fname("sub/denied.txt", None), "\"sub/denied.txt\"");
+    }
+
+    #[test]
+    fn appends_module_suffix_after_closing_quote() {
+        // Ground truth captured from upstream rsync 3.4.4 serving module
+        // `mymod`: `send_files failed to open "sub/denied.txt" (in mymod)`.
+        assert_eq!(
+            full_fname("sub/denied.txt", Some("mymod")),
+            "\"sub/denied.txt\" (in mymod)"
+        );
+    }
+
+    #[test]
+    fn empty_module_name_still_renders_upstream_shape() {
+        // upstream: lp_name() can return an empty string only for a malformed
+        // config; `module_id >= 0` still selects the suffix branch.
+        assert_eq!(full_fname("f", Some("")), "\"f\" (in )");
+    }
+
+    #[test]
+    fn path_variant_matches_string_variant() {
+        assert_eq!(
+            full_fname_path(Path::new("a/b"), Some("mod")),
+            full_fname("a/b", Some("mod"))
+        );
+    }
+}

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -141,6 +141,17 @@ pub struct GeneratorContext {
 }
 
 impl GeneratorContext {
+    /// Returns the daemon module name gating the ` (in MODULE)` suffix that
+    /// [`crate::full_fname::full_fname`] appends to quoted paths, or `None`
+    /// outside a daemon server process.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `util1.c:1290` - `if (module_id >= 0)` in `full_fname()`.
+    pub(crate) fn daemon_module(&self) -> Option<&str> {
+        self.config.connection.daemon_module.as_deref()
+    }
+
     /// Creates a new generator context from a completed handshake and server config.
     ///
     /// Initializes protocol state, INC_RECURSE NDX offset, and empty file list.

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 
 use logging::info_log;
 
+use crate::full_fname::full_fname_path;
 use crate::role_trailer::error_location;
 
 use super::super::GeneratorContext;
@@ -118,8 +119,8 @@ impl GeneratorContext {
                         // FFV-4: emit the correct error message and error flag
                         // for a source that never existed at flist build time.
                         eprintln!(
-                            "rsync: [sender] link_stat \"{}\" failed: {}",
-                            path.display(),
+                            "rsync: [sender] link_stat {} failed: {}",
+                            full_fname_path(path, self.daemon_module()),
                             engine::local_copy::upstream_io_error(&e),
                         );
                         self.add_io_error(io_error_flags::IOERR_GENERAL);
@@ -290,8 +291,8 @@ impl GeneratorContext {
                 Err(e) => {
                     // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                     eprintln!(
-                        "rsync: [sender] opendir \"{}\" failed: {}",
-                        path.display(),
+                        "rsync: [sender] opendir {} failed: {}",
+                        full_fname_path(&path, self.daemon_module()),
                         engine::local_copy::upstream_io_error(&e),
                     );
                     self.record_io_error(&e);
@@ -389,8 +390,8 @@ impl GeneratorContext {
             Err(e) => {
                 // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                 eprintln!(
-                    "rsync: [sender] opendir \"{}\" failed: {}",
-                    dir_path.display(),
+                    "rsync: [sender] opendir {} failed: {}",
+                    full_fname_path(dir_path, self.daemon_module()),
                     engine::local_copy::upstream_io_error(&e),
                 );
                 self.record_io_error(&e);
@@ -417,8 +418,8 @@ impl GeneratorContext {
                 Err(e) => {
                     // upstream: flist.c:1924 - rsyserr(FERROR_XFER, errno, "readdir(%s)", ...)
                     eprintln!(
-                        "rsync: [sender] readdir(\"{}\"): {}",
-                        dir_path.display(),
+                        "rsync: [sender] readdir({}): {}",
+                        full_fname_path(dir_path, self.daemon_module()),
                         engine::local_copy::upstream_io_error(&e),
                     );
                     self.record_io_error(&e);
@@ -509,14 +510,14 @@ impl GeneratorContext {
     /// Distinguishes between vanished files (ENOENT) and general stat errors,
     /// matching upstream `flist.c:1286-1294` error reporting.
     fn log_stat_error(&self, path: &Path, e: &io::Error) {
+        let fname = full_fname_path(path, self.daemon_module());
         if e.kind() == io::ErrorKind::NotFound {
             // upstream: flist.c:1317 - rprintf(c, "file has vanished: %s\n", full_fname(...))
-            eprintln!("file has vanished: \"{}\"", path.display());
+            eprintln!("file has vanished: {fname}");
         } else {
             // upstream: flist.c:1846 - rsyserr(FERROR_XFER, errno, "link_stat %s failed", ...)
             eprintln!(
-                "rsync: [sender] link_stat \"{}\" failed: {}",
-                path.display(),
+                "rsync: [sender] link_stat {fname} failed: {}",
                 engine::local_copy::upstream_io_error(e),
             );
         }
@@ -648,6 +649,32 @@ mod rsyserr_wording_tests {
                 "template {template:?} did not match upstream wording"
             );
         }
+    }
+
+    /// The same lines rendered from a daemon server process must carry
+    /// upstream's ` (in MODULE)` suffix outside the closing quote, because
+    /// upstream builds the path with `full_fname()` and `module_id >= 0`
+    /// there. Ground truth captured from rsync 3.4.4 serving module `mymod`:
+    /// `send_files failed to open "sub/denied.txt" (in mymod): ...`.
+    #[test]
+    fn rsyserr_wording_carries_daemon_module_suffix() {
+        use crate::full_fname::full_fname_path;
+        use std::path::Path;
+
+        let quoted = full_fname_path(Path::new("/p"), Some("mymod"));
+        assert_eq!(quoted, "\"/p\" (in mymod)");
+        assert_eq!(
+            format!("rsync: [sender] link_stat {quoted} failed: No such file or directory (2)"),
+            "rsync: [sender] link_stat \"/p\" (in mymod) failed: No such file or directory (2)",
+        );
+        assert_eq!(
+            format!("rsync: [sender] readdir({quoted}): Input/output error (5)"),
+            "rsync: [sender] readdir(\"/p\" (in mymod)): Input/output error (5)",
+        );
+        assert_eq!(
+            format!("file has vanished: {quoted}"),
+            "file has vanished: \"/p\" (in mymod)",
+        );
     }
 }
 

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -360,15 +360,16 @@ impl GeneratorContext {
         error: &io::Error,
         path_display: &str,
     ) -> io::Result<()> {
+        let fname = crate::full_fname::full_fname(path_display, self.daemon_module());
         if error.kind() == io::ErrorKind::NotFound {
             self.io_error |= super::io_error_flags::IOERR_VANISHED;
             // upstream: sender.c:389 - rprintf(c, "file has vanished: %s\n", full_fname(...))
-            eprintln!("file has vanished: \"{path_display}\"");
+            eprintln!("file has vanished: {fname}");
         } else {
             self.io_error |= super::io_error_flags::IOERR_GENERAL;
             // upstream: sender.c:393 - rsyserr(FERROR_XFER, errno, "send_files failed to open %s", ...)
             eprintln!(
-                "rsync: [sender] send_files failed to open \"{path_display}\": {}",
+                "rsync: [sender] send_files failed to open {fname}: {}",
                 engine::local_copy::upstream_io_error(error),
             );
         }
@@ -400,7 +401,10 @@ impl GeneratorContext {
         path_display: &str,
     ) -> io::Result<()> {
         // upstream: sender.c:422 - rprintf(FWARNING, "skipped diminished file: %s\n", ...)
-        eprintln!("skipped diminished file: \"{path_display}\"");
+        eprintln!(
+            "skipped diminished file: {}",
+            crate::full_fname::full_fname(path_display, self.daemon_module()),
+        );
         if self.protocol.supports_generator_messages() {
             writer.send_no_send(ndx)?;
         }

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -128,6 +128,7 @@ pub mod delta_config;
 pub mod delta_transfer;
 pub mod error;
 pub mod flags;
+pub(crate) mod full_fname;
 pub mod generator;
 pub mod handshake;
 mod reader;

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -23,6 +23,7 @@ use crate::pipeline::spsc::{self, TryRecvError};
 
 use crate::delta_apply::ChecksumVerifier;
 use crate::disk_commit::{DiskCommitConfig, PartialMode, spawn_disk_thread};
+use crate::full_fname::full_fname_path;
 use crate::pipeline::messages::{CommitResult, FileMessage};
 
 /// Expected checksum for a pending file, used for deferred verification.
@@ -110,6 +111,12 @@ pub struct PipelinedReceiver {
     ///
     /// upstream: receiver.c:1073-1078 - `keep_partial`/`partial_dir` gating.
     partial_mode: PartialMode,
+    /// Daemon module served by this process, captured from the disk-commit
+    /// config. Gates the ` (in MODULE)` suffix that `full_fname()` appends to
+    /// the quoted path in the `mkstemp` failure line.
+    ///
+    /// upstream: util1.c:1290 - `if (module_id >= 0)` in `full_fname()`.
+    daemon_module: Option<String>,
 }
 
 /// Selects the upstream verification-failure `keptstr` wording for a file.
@@ -139,6 +146,7 @@ impl PipelinedReceiver {
     /// commit thread cannot be spawned (typically `EAGAIN`/`RLIMIT_NPROC`).
     pub fn new(config: DiskCommitConfig) -> io::Result<Self> {
         let partial_mode = config.partial_mode.clone();
+        let daemon_module = config.daemon_module.clone();
         let h = spawn_disk_thread(config)?;
         Ok(Self {
             file_tx: h.file_tx,
@@ -154,6 +162,7 @@ impl PipelinedReceiver {
             delayed_updates: Vec::new(),
             success_indices: Vec::new(),
             partial_mode,
+            daemon_module,
         })
     }
 
@@ -231,15 +240,17 @@ impl PipelinedReceiver {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
                         // upstream: receiver.c:297 - rsyserr(FERROR_XFER, errno,
                         // "mkstemp %s failed", full_fname(fnametmp)); full_fname()
-                        // wraps the path in double quotes (util1.c:1228). Emitting
-                        // this as FERROR_XFER (not FINFO) makes the peer's rwrite()
-                        // set got_xfer_error, so the run exits 23 (RERR_PARTIAL)
-                        // instead of 0 when the output mkstemp() was denied.
+                        // wraps the path in double quotes and appends
+                        // " (in MODULE)" when serving a daemon module
+                        // (util1.c:1273). Emitting this as FERROR_XFER (not
+                        // FINFO) makes the peer's rwrite() set got_xfer_error,
+                        // so the run exits 23 (RERR_PARTIAL) instead of 0 when
+                        // the output mkstemp() was denied.
                         self.warnings.push((
                             MessageCode::ErrorXfer,
                             format!(
-                                "rsync: [receiver] mkstemp \"{}\" failed: Permission denied (13)",
-                                path.display(),
+                                "rsync: [receiver] mkstemp {} failed: Permission denied (13)",
+                                full_fname_path(&path, self.daemon_module.as_deref()),
                             ),
                         ));
                         meta_errors.push((path, e.to_string()));
@@ -298,15 +309,17 @@ impl PipelinedReceiver {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
                         // upstream: receiver.c:297 - rsyserr(FERROR_XFER, errno,
                         // "mkstemp %s failed", full_fname(fnametmp)); full_fname()
-                        // wraps the path in double quotes (util1.c:1228). Emitting
-                        // this as FERROR_XFER (not FINFO) makes the peer's rwrite()
-                        // set got_xfer_error, so the run exits 23 (RERR_PARTIAL)
-                        // instead of 0 when the output mkstemp() was denied.
+                        // wraps the path in double quotes and appends
+                        // " (in MODULE)" when serving a daemon module
+                        // (util1.c:1273). Emitting this as FERROR_XFER (not
+                        // FINFO) makes the peer's rwrite() set got_xfer_error,
+                        // so the run exits 23 (RERR_PARTIAL) instead of 0 when
+                        // the output mkstemp() was denied.
                         self.warnings.push((
                             MessageCode::ErrorXfer,
                             format!(
-                                "rsync: [receiver] mkstemp \"{}\" failed: Permission denied (13)",
-                                path.display(),
+                                "rsync: [receiver] mkstemp {} failed: Permission denied (13)",
+                                full_fname_path(&path, self.daemon_module.as_deref()),
                             ),
                         ));
                         meta_errors.push((path, e.to_string()));
@@ -1152,6 +1165,80 @@ mod tests {
             warnings[0].1.contains("mkstemp"),
             "message should mirror upstream receiver.c:297 \"mkstemp %s failed\": {}",
             warnings[0].1
+        );
+        // Outside a daemon module upstream's module_id is -1, so full_fname()
+        // emits the bare quoted path with no suffix (util1.c:1290).
+        assert!(
+            !warnings[0].1.contains(" (in "),
+            "non-daemon run must not carry a module suffix: {}",
+            warnings[0].1
+        );
+
+        let _ = std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o755));
+        drop(pr);
+    }
+
+    /// Serving a daemon module, upstream's `full_fname()` appends
+    /// ` (in MODULE)` after the closing quote, so the receiver's `mkstemp`
+    /// failure names the module the client asked for. Without it a client
+    /// syncing several modules cannot tell which one refused the write.
+    ///
+    /// upstream: util1.c:1290 `if (module_id >= 0)` inside `full_fname()`,
+    /// reached from receiver.c:297 `rsyserr(..., "mkstemp %s failed", ...)`.
+    #[cfg(unix)]
+    #[test]
+    fn output_open_failure_names_daemon_module() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if std::env::var("USER").is_ok_and(|u| u == "root") {
+            return;
+        }
+
+        let dir = test_support::create_tempdir();
+        let readonly_dir = dir.path().join("readonly");
+        std::fs::create_dir(&readonly_dir).unwrap();
+        std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o555)).unwrap();
+
+        let file_path = readonly_dir.join("denied.dat");
+        let mut pr = PipelinedReceiver::new(DiskCommitConfig {
+            daemon_module: Some("mymod".to_string()),
+            ..DiskCommitConfig::default()
+        })
+        .unwrap();
+
+        pr.file_sender()
+            .send(FileMessage::WholeFile {
+                begin: Box::new(BeginMessage {
+                    file_path: file_path.clone(),
+                    target_size: 9,
+                    file_entry_index: 0,
+                    checksum_verifier: None,
+                    is_device_target: false,
+                    is_inplace: false,
+                    append_offset: 0,
+                    xattr_list: None,
+                }),
+                data: b"test data".to_vec(),
+                expected_checksum: Default::default(),
+            })
+            .unwrap();
+        pr.note_commit_sent(
+            [0u8; ChecksumVerifier::MAX_DIGEST_LEN],
+            0,
+            file_path.clone(),
+            0,
+            false,
+        );
+
+        let (_bytes, _errors) = pr.drain_all_results().unwrap();
+        let warnings = pr.drain_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].1,
+            format!(
+                "rsync: [receiver] mkstemp \"{}\" (in mymod) failed: Permission denied (13)",
+                file_path.display()
+            ),
         );
 
         let _ = std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o755));

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -208,6 +208,7 @@ impl ReceiverContext {
             partial_mode,
             delay_updates: self.config.write.delay_updates,
             append_verify: self.config.flags.append_verify && !is_redo_pass,
+            daemon_module: self.config.connection.daemon_module.clone(),
             ..DiskCommitConfig::default()
         };
         let mut pipelined_receiver = PipelinedReceiver::new(disk_config)?;


### PR DESCRIPTION
## Problem

Upstream rsync funnels every path that appears inside an error or warning through `full_fname()` (`util1.c:1273`). It wraps the name in double quotes and, while the process is serving a daemon module, appends ` (in MODULE)` **after** the closing quote:

```c
if (module_id >= 0) {
        m1 = " (in ";
        m2 = lp_name(module_id);
        m3 = ")";
} else
        m1 = m2 = m3 = "";

if (asprintf(&result, "\"%s%s%s\"%s%s%s", p1, p2, fn, m1, m2, m3) < 0)
```

`module_id` is set exactly once, at `clientserver.c:769` in `rsync_module()`, so the suffix appears precisely when the process is a daemon server that has selected a module - never for clients or SSH `--server` processes.

oc-rsync quoted the path but never emitted the suffix, so every daemon-context diagnostic embedding a path diverged from upstream text.

## Change

- New shared `full_fname` helper (`crates/transfer/src/full_fname.rs`) mirroring upstream's format.
- `ConnectionConfig::daemon_module` records the selected module name - the analogue of upstream's `module_id` global. It is set in `apply_module_transfer_directives()` when the daemon selects a module, and stays `None` everywhere else.
- The receiver's disk-commit pipeline carries the same name via `DiskCommitConfig::daemon_module`.

Only the sites upstream builds with `full_fname()` were routed through the helper:

| upstream | message |
|---|---|
| `flist.c:1846`, `flist.c:2433` | `link_stat %s failed` |
| `flist.c:1878` | `opendir %s failed` |
| `flist.c:1924` | `readdir(%s)` |
| `flist.c:1317`, `sender.c:389` | `file has vanished: %s` |
| `sender.c:394` | `send_files failed to open %s` |
| `sender.c:422` | `skipped diminished file: %s` |
| `receiver.c:297` | `mkstemp %s failed` |

Sites where upstream hard-codes the quotes around a plain `%s` are deliberately left alone, because upstream never appends the suffix there: `copying unsafe symlink` (`flist.c:229`), `ignoring unsafe symlink` (`generator.c:1567`), `not creating new %s` (`generator.c:1380`), and `sender failed to %s %s` (`sender.c:176`, which upstream does not even quote).

Non-daemon output is byte-identical - the suffix is gated on the module name being present.

## Verification

Ground truth captured from a real upstream rsync 3.4.4 binary (protocol 32, built from source) running as a daemon with module `mymod` / `wmod`:

```
rsync: [sender] send_files failed to open "sub/denied.txt" (in mymod): Permission denied (13)
rsync: [sender] opendir "locked" (in mymod) failed: Permission denied (13)
rsync: [sender] link_stat "nosuchfile" (in mymod) failed: No such file or directory (2)
rsync: [receiver] mkstemp ".new.txt.ZMtoBd" (in wmod) failed: Permission denied (13)
```

Confirming the suffix sits outside the closing quote.

The patched build was then exercised live as a daemon against an upstream 3.4.4 client pushing into a read-only module root:

```
before:  rsync: [receiver] mkstemp "/tmp/.../mod/new.txt" failed: Permission denied (13)
after:   rsync: [receiver] mkstemp "/tmp/.../mod/new.txt" (in wmod) failed: Permission denied (13)
```

Tests: unit coverage for the helper (suffix present / absent / empty module name), a daemon-context wording test pinning the rendered sender lines, an end-to-end `PipelinedReceiver` test asserting the full `mkstemp` line with and without a module, and a daemon test proving module selection records the name. `cargo test -p transfer --all-features` (2469 passed) and `cargo test -p daemon --all-features --lib` (1392 passed) are green; `cargo fmt --all -- --check` and `cargo clippy -p transfer -p daemon --all-features --all-targets --no-deps -D warnings` are clean.

## Out of scope (observed while verifying, filed for follow-up)

1. The oc daemon **sender** hangs instead of reporting a per-file error - an unreadable source file, an unreadable directory, or a missing requested path all stall the transfer until the client's io timeout. Reproduced identically on v0.6.3, so it predates this change and is not introduced here. These messages are correct once emitted, but the daemon sender currently cannot reach them.
2. At `receiver.c:297` upstream names the module-relative **temp** file (`.new.txt.ZMtoBd`); oc names the absolute final path. That is the `curr_dir + module_dirlen` half of `full_fname()`, which oc has no analogue for.
3. `sender failed to re-lstat`/`to remove` (`crates/transfer/src/generator/transfer/transfer_loop.rs`) quote the path, but upstream `sender.c:176` does not quote it at all.
