### PR TITLE
fix(metadata): honor -XX and xattr filters on the sender

### DIFF
--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -1717,6 +1717,28 @@ fn xattrs_level_two_emits_doubled_xx() {
     );
 }
 
+// The doubled letter is only useful if the server half recovers the level from
+// it: the sender gates the `rsync.%FOO` fake-super store on `preserve_xattrs <
+// 2` (xattrs.c:262). Both the in-process server config and a remote peer are
+// built by re-parsing this same string, so a level that survives emission but
+// not parsing still leaves `-XX` behaving as `-X`.
+#[cfg(all(unix, feature = "xattr"))]
+#[test]
+fn xattrs_level_survives_the_flag_string_round_trip() {
+    use transfer::ParsedServerFlags;
+
+    for (level, expected) in [(1u8, 1u8), (2, 2)] {
+        let config = ClientConfig::builder().xattrs(level).build();
+        let flag_string = sender_flag_string(&config);
+        let parsed = ParsedServerFlags::parse(&flag_string).expect("flag string must parse");
+        assert!(parsed.xattrs, "level {level} must set the xattrs bool");
+        assert_eq!(
+            parsed.xattrs_level, expected,
+            "level {level} must round-trip through {flag_string}"
+        );
+    }
+}
+
 // upstream: options.c:2709-2710 - `if (cvs_exclude) argstr[x++] = 'C';`. The
 // letter is forwarded unconditionally (outside the am_sender block) so the
 // remote peer runs get_cvs_excludes() itself. WHY: without the letter, an

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -149,6 +149,8 @@ pub use device_size::device_readable_size;
 /// would otherwise escape the module root.
 pub mod symlink_munge;
 
+pub mod xattr_send;
+
 #[cfg(all(feature = "xattr", any(unix, windows)))]
 mod xattr;
 
@@ -281,6 +283,8 @@ pub use special::{
     create_device_node, create_device_node_from_parts, create_device_node_with_fake_super,
     create_fifo, create_fifo_node_from_parts, create_fifo_with_fake_super,
 };
+
+pub use xattr_send::XattrSendOptions;
 
 #[cfg(all(feature = "xattr", any(unix, windows)))]
 pub use xattr::{

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -21,6 +21,7 @@
 //! - `xattrs.c:64-68, 254-257` - permitted-namespace policy on Linux.
 
 use crate::error::MetadataError;
+use crate::xattr_send::XattrSendOptions;
 use protocol::xattr::XattrList;
 use std::collections::HashSet;
 use std::io;
@@ -96,20 +97,46 @@ fn map_xattr_error(context: &'static str, path: &Path, error: io::Error) -> Meta
     MetadataError::new(context, path, error)
 }
 
-/// Returns the byte-encoded xattr names present on `path`, filtered by
-/// [`is_xattr_permitted`].
+/// How [`list_attributes`] screens namespaces.
+///
+/// Upstream evaluates the namespace rule only as the `else` of the
+/// `x`-modifier filter rule, so the two are mutually exclusive
+/// (`xattrs.c:250-257`).
+#[derive(Clone, Copy)]
+enum NamespaceScreen {
+    /// Apply upstream's namespace rule with the given `user_only` value.
+    Apply { user_only: bool },
+    /// Skip the namespace rule: an `x`-modifier filter governs the selection
+    /// instead, exactly as upstream's `saw_xattr_filter` branch does.
+    Bypass,
+}
+
+/// Returns the byte-encoded xattr names present on `path`, screened per
+/// `screen` by [`is_xattr_permitted`].
 fn list_attributes(
     path: &Path,
     follow_symlinks: bool,
-    user_only: bool,
+    screen: NamespaceScreen,
 ) -> Result<Vec<Vec<u8>>, MetadataError> {
     let attrs = backend::list_attributes(path, follow_symlinks)
         .map_err(|error| map_xattr_error("list extended attributes", path, error))?;
     Ok(attrs
         .into_iter()
         .map(|name| backend::os_name_to_bytes(&name))
-        .filter(|bytes| is_xattr_permitted(&String::from_utf8_lossy(bytes), user_only))
+        .filter(|bytes| match screen {
+            NamespaceScreen::Apply { user_only } => {
+                is_xattr_permitted(&String::from_utf8_lossy(bytes), user_only)
+            }
+            NamespaceScreen::Bypass => true,
+        })
         .collect())
+}
+
+/// Shorthand for the receiver/local-copy namespace screen.
+fn receiver_screen() -> NamespaceScreen {
+    NamespaceScreen::Apply {
+        user_only: receiver_user_only(),
+    }
 }
 
 fn read_attribute(
@@ -138,11 +165,19 @@ fn remove_attribute(path: &Path, name: &[u8], follow_symlinks: bool) -> Result<(
 
 /// Reads xattr data from a file and returns it as a wire-format `XattrList`.
 ///
-/// Names are translated to wire format via `local_to_wire()`. Entries are
-/// sorted alphabetically by wire name, matching upstream rsync's
-/// `rsync_xal_get()` which sorts by name after collection. All values are
-/// stored as full data - abbreviation (checksum substitution for large values)
-/// is handled by the wire encoder at send time.
+/// Per attribute the selection reproduces `rsync_xal_get()` in upstream order:
+///
+/// 1. The `x`-modifier filter, if any, decides alone; otherwise the namespace
+///    rule applies. The two are mutually exclusive (`xattrs.c:250-257`).
+/// 2. The `rsync.%FOO` internal-attribute gate (`xattrs.c:260-267`): a sender
+///    below `-XX` drops them all, and `--fake-super` additionally drops the
+///    three store attributes at any level.
+/// 3. The surviving name is translated to wire format via `local_to_wire()`.
+///
+/// Entries are sorted alphabetically by wire name, matching upstream's qsort
+/// after collection. All values are stored as full data - abbreviation
+/// (checksum substitution for large values) is handled by the wire encoder at
+/// send time.
 ///
 /// # Upstream Reference
 ///
@@ -150,26 +185,55 @@ fn remove_attribute(path: &Path, name: &[u8], follow_symlinks: bool) -> Result<(
 /// - `xattrs.c:get_xattr()` - entry point called from `make_file()`
 pub fn read_xattrs_for_wire(
     path: &Path,
-    follow_symlinks: bool,
-    am_root: bool,
-    _checksum_seed: i32,
+    opts: &XattrSendOptions<'_>,
 ) -> Result<XattrList, MetadataError> {
-    use protocol::xattr::{XattrEntry, local_to_wire};
+    use protocol::xattr::{XattrEntry, is_fake_super_store_attr, is_rsync_internal, local_to_wire};
 
-    // upstream: xattrs.c:237 rsync_xal_get() - the sender sets user_only=0, so a
-    // non-root sender skips only the system.* namespace and still transmits
-    // user.*, security.* (e.g. SELinux labels), and trusted.* xattrs.
-    let attrs = list_attributes(path, follow_symlinks, false)?;
+    // upstream: xattrs.c:250-257 - the filter branch and the namespace branch
+    // are mutually exclusive, so a transfer carrying `x`-modifier rules never
+    // evaluates the namespace test at all.
+    let screen = if opts.filter.is_some() {
+        NamespaceScreen::Bypass
+    } else {
+        // upstream: xattrs.c:237 - the sender sets user_only=0, so a non-root
+        // sender skips only the system.* namespace and still transmits user.*,
+        // security.* (e.g. SELinux labels), and trusted.* xattrs.
+        NamespaceScreen::Apply { user_only: false }
+    };
+    let attrs = list_attributes(path, opts.follow_symlinks, screen)?;
     let mut entries = Vec::with_capacity(attrs.len());
 
     for name in &attrs {
-        // upstream: xattrs.c:509-528 - translate local name to wire format
-        let wire_name = match local_to_wire(name, am_root) {
+        let name_str = String::from_utf8_lossy(name);
+
+        // upstream: xattrs.c:250-252 - name_is_excluded(name, NAME_IS_XATTR,
+        // ALL_FILTERS) drops the attribute before it is ever read.
+        if let Some(filter) = opts.filter
+            && !filter(&name_str)
+        {
+            continue;
+        }
+
+        // upstream: xattrs.c:260-267 - no rsync.%FOO attribute is copied
+        // without two -X options, and the fake-super store attributes are
+        // never copied while --fake-super is active (am_root < 0), because
+        // they describe this side's store rather than the file's metadata.
+        if is_rsync_internal(&name_str)
+            && (opts.preserve_xattrs < 2
+                || (opts.fake_super && is_fake_super_store_attr(&name_str)))
+        {
+            continue;
+        }
+
+        // upstream: xattrs.c:509-528 - translate local name to wire format.
+        // `system.*` survives for a root sender, and also whenever a filter is
+        // present, since upstream then skips the namespace test entirely.
+        let wire_name = match local_to_wire(name, opts.am_root || opts.filter.is_some()) {
             Some(n) => n,
-            None => continue, // Filtered out (rsync internal, namespace issue)
+            None => continue, // Filtered out (namespace not exposable)
         };
 
-        let value = match read_attribute(path, name, follow_symlinks)? {
+        let value = match read_attribute(path, name, opts.follow_symlinks)? {
             Some(v) => v,
             None => continue,
         };
@@ -212,13 +276,13 @@ pub fn strip_source_xattrs(
     destination: &Path,
     follow_symlinks: bool,
 ) -> Result<(), MetadataError> {
-    let source_attrs = list_attributes(source, follow_symlinks, receiver_user_only())?;
+    let source_attrs = list_attributes(source, follow_symlinks, receiver_screen())?;
     if source_attrs.is_empty() {
         return Ok(());
     }
     let source_names: HashSet<Vec<u8>> = source_attrs.into_iter().collect();
 
-    for name in list_attributes(destination, follow_symlinks, receiver_user_only())? {
+    for name in list_attributes(destination, follow_symlinks, receiver_screen())? {
         if source_names.contains(&name) {
             remove_attribute(destination, &name, follow_symlinks)?;
         }
@@ -237,7 +301,7 @@ pub fn strip_source_xattrs(
 // upstream: xattrs.c xattrs_differ() via generator.c:468 unchanged_attrs()
 pub fn xattrs_match(a: &Path, b: &Path, follow_symlinks: bool) -> Result<bool, MetadataError> {
     let mut a_map: std::collections::BTreeMap<Vec<u8>, Vec<u8>> = std::collections::BTreeMap::new();
-    for name in list_attributes(a, follow_symlinks, receiver_user_only())? {
+    for name in list_attributes(a, follow_symlinks, receiver_screen())? {
         if protocol::xattr::is_rsync_internal(&String::from_utf8_lossy(&name)) {
             continue;
         }
@@ -247,7 +311,7 @@ pub fn xattrs_match(a: &Path, b: &Path, follow_symlinks: bool) -> Result<bool, M
     }
 
     let mut b_count = 0usize;
-    for name in list_attributes(b, follow_symlinks, receiver_user_only())? {
+    for name in list_attributes(b, follow_symlinks, receiver_screen())? {
         if protocol::xattr::is_rsync_internal(&String::from_utf8_lossy(&name)) {
             continue;
         }
@@ -278,7 +342,7 @@ pub fn sync_xattrs(
     follow_symlinks: bool,
     filter: Option<&dyn Fn(&str) -> bool>,
 ) -> Result<(), MetadataError> {
-    let source_attrs = list_attributes(source, follow_symlinks, receiver_user_only())?;
+    let source_attrs = list_attributes(source, follow_symlinks, receiver_screen())?;
     let mut retained: HashSet<Vec<u8>> = HashSet::with_capacity(source_attrs.len());
 
     for name in &source_attrs {
@@ -302,7 +366,7 @@ pub fn sync_xattrs(
         }
     }
 
-    let destination_attrs = list_attributes(destination, follow_symlinks, receiver_user_only())?;
+    let destination_attrs = list_attributes(destination, follow_symlinks, receiver_screen())?;
     for name in &destination_attrs {
         if retained.contains(name) {
             continue;
@@ -408,7 +472,7 @@ pub fn apply_xattrs_from_list(
     }
 
     // Remove destination xattrs not in the source list
-    let dest_attrs = list_attributes(destination, follow_symlinks, receiver_user_only())?;
+    let dest_attrs = list_attributes(destination, follow_symlinks, receiver_screen())?;
     for name in &dest_attrs {
         if !applied_names.contains(name) {
             let name_str = String::from_utf8_lossy(name);
@@ -457,6 +521,32 @@ mod tests {
         }
     }
 
+    /// Returns the local name of an `rsync.%<suffix>` internal attribute.
+    ///
+    /// Upstream's `RSYNC_PREFIX` is `user.rsync.` on Linux and `rsync.`
+    /// elsewhere (`xattrs.c:66-69`).
+    fn internal_xattr_name(suffix: &str) -> Vec<u8> {
+        #[cfg(target_os = "linux")]
+        {
+            format!("user.rsync.%{suffix}").into_bytes()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            format!("rsync.%{suffix}").into_bytes()
+        }
+    }
+
+    /// Reports whether the collected list carries the local name `name`.
+    ///
+    /// A non-Linux sender emits `user.`-prefixed wire names for anything not
+    /// already under `RSYNC_PREFIX` (`xattrs.c:518-530`), so the local name has
+    /// to be translated before the lookup.
+    fn wire_contains(list: &XattrList, name: &[u8]) -> bool {
+        let expected = protocol::xattr::local_to_wire(name, true)
+            .expect("test names are always representable on the wire");
+        list.entries().iter().any(|entry| entry.name() == expected)
+    }
+
     /// Returns the expected local xattr name for test entries.
     ///
     /// On Linux, names need the `user.` prefix. On other platforms (macOS,
@@ -484,7 +574,7 @@ mod tests {
             return;
         }
 
-        let attrs = list_attributes(&file, false, receiver_user_only()).expect("list attrs");
+        let attrs = list_attributes(&file, false, receiver_screen()).expect("list attrs");
         // May have system attributes, but should not error
         assert!(
             attrs
@@ -556,7 +646,7 @@ mod tests {
 
         strip_source_xattrs(&source, &dest, false).expect("strip");
 
-        let dest_attrs = list_attributes(&dest, false, receiver_user_only()).expect("list dest");
+        let dest_attrs = list_attributes(&dest, false, receiver_screen()).expect("list dest");
         assert!(
             !dest_attrs.contains(&shared),
             "source-originated attribute must be stripped from the destination"
@@ -566,8 +656,7 @@ mod tests {
             "filesystem-applied (dest-only) attribute must be preserved"
         );
         // The source is read-only input to the strip and must be untouched.
-        let source_attrs =
-            list_attributes(&source, false, receiver_user_only()).expect("list source");
+        let source_attrs = list_attributes(&source, false, receiver_screen()).expect("list source");
         assert!(source_attrs.contains(&shared), "source must be untouched");
     }
 
@@ -589,7 +678,7 @@ mod tests {
 
         strip_source_xattrs(&source, &dest, false).expect("strip with empty source");
 
-        let dest_attrs = list_attributes(&dest, false, receiver_user_only()).expect("list dest");
+        let dest_attrs = list_attributes(&dest, false, receiver_screen()).expect("list dest");
         assert!(
             dest_attrs.contains(&dest_only),
             "with no source attributes the destination is left untouched"
@@ -780,6 +869,220 @@ mod tests {
         );
     }
 
+    /// `-X` strips the fake-super store from the wire but `-XX` transmits it.
+    ///
+    /// This is the whole point of the doubled option: `--fake-super` writes a
+    /// file's real ownership and permissions into `rsync.%stat`, and only a
+    /// second `-X` moves that store to the peer so an unprivileged mirror can
+    /// be re-materialised later. Collapsing the level to a bool makes `-XX` a
+    /// silent synonym for `-X` while the help text still advertises the store.
+    ///
+    /// upstream: xattrs.c:261-263 - `if (name_len > RPRE_LEN && name[RPRE_LEN]
+    /// == '%' && HAS_PREFIX(name, RSYNC_PREFIX)) { if ((am_sender &&
+    /// preserve_xattrs < 2) ...) continue; }`
+    #[test]
+    fn sender_transmits_the_fake_super_store_only_at_level_two() {
+        let dir = tempdir().expect("create temp dir");
+        let file = dir.path().join("stored.txt");
+        fs::write(&file, "content").expect("write file");
+
+        if !xattrs_supported(&file) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        let stat_name = internal_xattr_name("stat");
+        // A plausible fake-super payload: `MODE UID,GID MAJOR:MINOR`, the
+        // format upstream's set_stat_xattr() writes.
+        if write_attribute(&file, &stat_name, b"100644 0,0 0:0", false).is_err() {
+            eprintln!("filesystem rejects rsync.% names, skipping test");
+            return;
+        }
+        let plain = test_xattr_name("keepme");
+        write_attribute(&file, &plain, b"v", false).expect("write plain attr");
+
+        let single = read_xattrs_for_wire(
+            &file,
+            &XattrSendOptions {
+                preserve_xattrs: 1,
+                ..XattrSendOptions::default()
+            },
+        )
+        .expect("read at level 1");
+        assert!(
+            !wire_contains(&single, &stat_name),
+            "a single -X must strip the fake-super store",
+        );
+        assert!(
+            wire_contains(&single, &plain),
+            "a single -X must still carry ordinary attributes",
+        );
+
+        let double = read_xattrs_for_wire(
+            &file,
+            &XattrSendOptions {
+                preserve_xattrs: 2,
+                ..XattrSendOptions::default()
+            },
+        )
+        .expect("read at level 2");
+        assert!(
+            wire_contains(&double, &stat_name),
+            "-XX must transmit the fake-super store, otherwise it is a no-op alias for -X",
+        );
+    }
+
+    /// `--fake-super` suppresses the three store attributes at any level.
+    ///
+    /// With `--fake-super` active the local `rsync.%stat` / `%aacl` / `%dacl`
+    /// describe *this* side's emulated ownership, not the file's own metadata,
+    /// so copying them onward would hand the peer a stale store. Other
+    /// `rsync.%` names are unaffected and remain governed by the level alone.
+    ///
+    /// upstream: xattrs.c:263-266 - `am_root < 0 && (strcmp(..., XSTAT_SUFFIX)
+    /// == 0 || ... XACC_ACL_SUFFIX ... || ... XDEF_ACL_SUFFIX ...)`, where
+    /// `am_root < 0` is what `set_fake_super()` sets.
+    #[test]
+    fn fake_super_drops_the_store_attrs_even_at_level_two() {
+        let dir = tempdir().expect("create temp dir");
+        let file = dir.path().join("faked.txt");
+        fs::write(&file, "content").expect("write file");
+
+        if !xattrs_supported(&file) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        let stat_name = internal_xattr_name("stat");
+        if write_attribute(&file, &stat_name, b"100644 0,0 0:0", false).is_err() {
+            eprintln!("filesystem rejects rsync.% names, skipping test");
+            return;
+        }
+        let aacl_name = internal_xattr_name("aacl");
+        write_attribute(&file, &aacl_name, b"acl", false).expect("write %aacl");
+        let dacl_name = internal_xattr_name("dacl");
+        write_attribute(&file, &dacl_name, b"acl", false).expect("write %dacl");
+        // Not one of the three store suffixes, so --fake-super leaves it alone.
+        let other_name = internal_xattr_name("other");
+        write_attribute(&file, &other_name, b"o", false).expect("write %other");
+
+        let list = read_xattrs_for_wire(
+            &file,
+            &XattrSendOptions {
+                preserve_xattrs: 2,
+                fake_super: true,
+                ..XattrSendOptions::default()
+            },
+        )
+        .expect("read under fake-super");
+
+        for name in [&stat_name, &aacl_name, &dacl_name] {
+            assert!(
+                !wire_contains(&list, name),
+                "--fake-super must suppress {} even at -XX",
+                String::from_utf8_lossy(name),
+            );
+        }
+        assert!(
+            wire_contains(&list, &other_name),
+            "--fake-super gates only %stat/%aacl/%dacl, not every rsync.% name",
+        );
+    }
+
+    /// An `x`-modifier filter screens the names the sender collects.
+    ///
+    /// upstream: xattrs.c:250-252 - `if (saw_xattr_filter) { if
+    /// (name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)) continue; }`
+    #[test]
+    fn sender_applies_the_xattr_name_filter() {
+        let dir = tempdir().expect("create temp dir");
+        let file = dir.path().join("filtered.txt");
+        fs::write(&file, "content").expect("write file");
+
+        if !xattrs_supported(&file) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        let dropped = test_xattr_name("foo");
+        let kept = test_xattr_name("bar");
+        write_attribute(&file, &dropped, b"d", false).expect("write foo");
+        write_attribute(&file, &kept, b"k", false).expect("write bar");
+
+        let dropped_str = String::from_utf8(dropped.clone()).expect("utf8 name");
+        let predicate = |name: &str| name != dropped_str;
+        let list = read_xattrs_for_wire(
+            &file,
+            &XattrSendOptions {
+                filter: Some(&predicate),
+                ..XattrSendOptions::default()
+            },
+        )
+        .expect("read with filter");
+
+        assert!(
+            !wire_contains(&list, &dropped),
+            "an excluded name must never be collected",
+        );
+        assert!(
+            wire_contains(&list, &kept),
+            "a name the filter admits must still be collected",
+        );
+    }
+
+    /// A filter replaces the namespace rule rather than stacking on top of it.
+    ///
+    /// Upstream's two branches are mutually exclusive: `if (saw_xattr_filter)
+    /// {...} else if (user_only ? ... : HAS_PREFIX(name, SYSTEM_PREFIX))
+    /// continue;` (xattrs.c:250-257). So with any `x`-modifier rule present a
+    /// `system.*` name that the namespace rule would have dropped is instead
+    /// judged by the filter alone. Screening on both would silently ignore an
+    /// admitting rule the user wrote.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_filter_bypasses_the_namespace_check() {
+        let dir = tempdir().expect("create temp dir");
+        let file = dir.path().join("ns.txt");
+        fs::write(&file, "content").expect("write file");
+
+        if !xattrs_supported(&file) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        // system.* is writable only with privileges (and only on filesystems
+        // that back it), so treat an unwritable name as "cannot exercise".
+        let system_name = b"system.test_ns".to_vec();
+        if write_attribute(&file, &system_name, b"s", false).is_err() {
+            eprintln!("cannot set a system.* xattr here, skipping test");
+            return;
+        }
+
+        // Without a filter the namespace rule drops it (xattrs.c:256).
+        let unfiltered =
+            read_xattrs_for_wire(&file, &XattrSendOptions::default()).expect("read without filter");
+        assert!(
+            !wire_contains(&unfiltered, &system_name),
+            "the namespace rule drops system.* for a non-root sender",
+        );
+
+        // With a filter that admits everything, the namespace rule is not
+        // evaluated at all and the name survives.
+        let admit_all = |_name: &str| true;
+        let filtered = read_xattrs_for_wire(
+            &file,
+            &XattrSendOptions {
+                filter: Some(&admit_all),
+                ..XattrSendOptions::default()
+            },
+        )
+        .expect("read with filter");
+        assert!(
+            wire_contains(&filtered, &system_name),
+            "an x-modifier filter replaces the namespace rule, it does not stack with it",
+        );
+    }
+
     // upstream: xattrs.c:297-299 assigns each xattr num = sorted_position + 1
     // (ascending). The receiver re-derives the identical 1-based ascending num
     // in receive order (protocol::xattr::cache `for num in 1..=count`). The
@@ -805,7 +1108,7 @@ mod tests {
         write_attribute(&file, &test_xattr_name("mmm"), b"m", false).expect("write mmm");
         write_attribute(&file, &test_xattr_name("zzz"), b"z", false).expect("write zzz");
 
-        let list = read_xattrs_for_wire(&file, false, false, 0).expect("read xattrs");
+        let list = read_xattrs_for_wire(&file, &XattrSendOptions::default()).expect("read xattrs");
         let entries = list.entries();
         assert!(entries.len() >= 3, "expected at least our three xattrs");
 

--- a/crates/metadata/src/xattr_send.rs
+++ b/crates/metadata/src/xattr_send.rs
@@ -1,0 +1,71 @@
+//! Collection options for reading a path's extended attributes into a
+//! wire-format `XattrList`.
+//!
+//! Upstream reads xattrs through a single function, `xattrs.c:rsync_xal_get()`,
+//! whose behaviour is steered by four globals: `am_sender`, `am_root`,
+//! `preserve_xattrs`, and `saw_xattr_filter`. This crate has no globals, so the
+//! same inputs travel as an explicit options record rather than a long
+//! positional parameter list.
+
+/// Inputs that steer sender-side xattr collection.
+///
+/// Mirrors the globals consulted by upstream `xattrs.c:rsync_xal_get()`
+/// (lines 231-300).
+///
+/// # Upstream Reference
+///
+/// - `xattrs.c:237` - `int user_only = am_sender ? 0 : !am_root;`
+/// - `xattrs.c:250-257` - the `x`-modifier filter branch and the namespace
+///   branch are mutually exclusive
+/// - `xattrs.c:260-267` - the `rsync.%FOO` internal-attribute gate
+#[derive(Clone, Copy)]
+pub struct XattrSendOptions<'a> {
+    /// Resolve a symlink before reading (`getxattr`) instead of reading the
+    /// link itself (`lgetxattr`).
+    pub follow_symlinks: bool,
+    /// Whether the reading process is privileged, which is what lets the
+    /// `system.*` namespace reach the wire.
+    pub am_root: bool,
+    /// Xattr preservation level: 1 for `-X`, 2 for `-XX`.
+    ///
+    /// Upstream gates the `rsync.%FOO` strip on `am_sender && preserve_xattrs
+    /// < 2`. There is no separate `am_sender` field here: a caller that is not
+    /// the sender (upstream's generator comparing the destination) passes level
+    /// 2, which reproduces `am_sender == 0` exactly, because the strip is the
+    /// only place the role is consulted.
+    pub preserve_xattrs: u8,
+    /// Whether `--fake-super` is active (upstream's `am_root < 0`).
+    ///
+    /// Independent of role: it suppresses the three fake-super store
+    /// attributes (`rsync.%stat`, `rsync.%aacl`, `rsync.%dacl`) even at
+    /// preservation level 2, because those describe the *local* fake-super
+    /// state rather than the file's own metadata.
+    pub fake_super: bool,
+    /// Optional `x`-modifier filter predicate. A name for which it returns
+    /// `false` is not collected.
+    ///
+    /// When this is `Some`, upstream skips the namespace test entirely
+    /// (`xattrs.c:250-257`: the namespace check is the `else` of the filter
+    /// check), so the filter alone decides.
+    pub filter: Option<&'a dyn Fn(&str) -> bool>,
+    /// Seed for the digest that abbreviates values over `MAX_FULL_DATUM`.
+    pub checksum_seed: i32,
+}
+
+impl Default for XattrSendOptions<'_> {
+    /// A plain single `-X` read: unprivileged, no fake-super, no filter.
+    ///
+    /// The level defaults to 1 rather than 0 so that a caller which forgets to
+    /// set it gets the conservative `-X` behaviour (strip `rsync.%FOO`) instead
+    /// of silently transmitting the fake-super store.
+    fn default() -> Self {
+        Self {
+            follow_symlinks: false,
+            am_root: false,
+            preserve_xattrs: 1,
+            fake_super: false,
+            filter: None,
+            checksum_seed: 0,
+        }
+    }
+}

--- a/crates/metadata/src/xattr_stub.rs
+++ b/crates/metadata/src/xattr_stub.rs
@@ -6,6 +6,7 @@
 //! can use the same API unconditionally.
 
 use crate::error::MetadataError;
+use crate::xattr_send::XattrSendOptions;
 use protocol::xattr::XattrList;
 use std::path::Path;
 use std::sync::Once;
@@ -60,9 +61,7 @@ pub fn strip_source_xattrs(
 /// On platforms without xattr support, returns an empty list.
 pub fn read_xattrs_for_wire(
     _path: &Path,
-    _follow_symlinks: bool,
-    _am_root: bool,
-    _checksum_seed: i32,
+    _opts: &XattrSendOptions<'_>,
 ) -> Result<XattrList, MetadataError> {
     Ok(XattrList::new())
 }
@@ -106,14 +105,21 @@ mod tests {
     #[test]
     fn read_xattrs_for_wire_returns_empty_list() {
         let path = Path::new("/nonexistent/file");
-        let result = read_xattrs_for_wire(path, false, false, 0).unwrap();
+        let result = read_xattrs_for_wire(path, &XattrSendOptions::default()).unwrap();
         assert!(result.is_empty());
     }
 
     #[test]
     fn read_xattrs_for_wire_as_root_returns_empty_list() {
         let path = Path::new("/nonexistent/file");
-        let result = read_xattrs_for_wire(path, true, true, 42).unwrap();
+        let opts = XattrSendOptions {
+            follow_symlinks: true,
+            am_root: true,
+            preserve_xattrs: 2,
+            checksum_seed: 42,
+            ..XattrSendOptions::default()
+        };
+        let result = read_xattrs_for_wire(path, &opts).unwrap();
         assert!(result.is_empty());
     }
 

--- a/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
+++ b/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
@@ -50,7 +50,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use metadata::read_xattrs_for_wire;
+use metadata::{XattrSendOptions, read_xattrs_for_wire};
 use tempfile::tempdir;
 
 /// Bare stream name written via the NTFS `path:streamname` path syntax.
@@ -157,7 +157,14 @@ fn read_stream_bytes(file: &Path, stream: &str) -> std::io::Result<Vec<u8>> {
 /// own enumeration path (FindFirstStreamW + FindNextStreamW) instead of
 /// trusting an isolated stream read.
 fn assert_wire_entry(path: &Path, wire_name: &[u8], expected: &[u8]) {
-    let list = read_xattrs_for_wire(path, false, true, 0).expect("read xattrs back");
+    let list = read_xattrs_for_wire(
+        path,
+        &XattrSendOptions {
+            am_root: true,
+            ..XattrSendOptions::default()
+        },
+    )
+    .expect("read xattrs back");
     let entry = list
         .iter()
         .find(|e| e.name() == wire_name)
@@ -290,7 +297,14 @@ fn ads_multi_stream_round_trips() {
     // rather than the seeding step. Both names round-trip through
     // `local_to_wire`, which prepends `user.` on non-Linux peers per
     // upstream xattrs.c:518-530.
-    let src_wire = read_xattrs_for_wire(&src_file, false, true, 0).expect("list source streams");
+    let src_wire = read_xattrs_for_wire(
+        &src_file,
+        &XattrSendOptions {
+            am_root: true,
+            ..XattrSendOptions::default()
+        },
+    )
+    .expect("list source streams");
     let src_names: Vec<String> = src_wire
         .iter()
         .map(|e| String::from_utf8_lossy(e.name()).into_owned())

--- a/crates/metadata/tests/windows_long_path_metadata.rs
+++ b/crates/metadata/tests/windows_long_path_metadata.rs
@@ -35,7 +35,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use metadata::windows::classify_path;
-use metadata::{apply_xattrs_from_list, read_dacl_sddl, read_xattrs_for_wire, write_dacl_sddl};
+use metadata::{
+    XattrSendOptions, apply_xattrs_from_list, read_dacl_sddl, read_xattrs_for_wire, write_dacl_sddl,
+};
 use protocol::xattr::{XattrEntry, XattrList};
 use tempfile::tempdir;
 
@@ -192,7 +194,8 @@ fn long_path_ads_round_trip() {
     // `xattr_windows::path_to_wide` feeding `FindFirstStreamW`. The wire
     // encoder prefixes the local stream name with `user.` on non-Linux
     // peers (matches upstream xattrs.c:518-530).
-    let wire = read_xattrs_for_wire(&file, false, false, 0).expect("read ADS on long path");
+    let wire =
+        read_xattrs_for_wire(&file, &XattrSendOptions::default()).expect("read ADS on long path");
     let expected_wire_name: &[u8] = b"user.Zone.Identifier";
     let entry = wire
         .iter()

--- a/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
+++ b/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
@@ -58,7 +58,7 @@ use std::path::Path;
 
 use metadata::apply_xattrs_from_list;
 #[cfg(unix)]
-use metadata::read_xattrs_for_wire;
+use metadata::{XattrSendOptions, read_xattrs_for_wire};
 use protocol::xattr::{XattrEntry, XattrList};
 use tempfile::tempdir;
 
@@ -141,7 +141,14 @@ fn xattrs_supported(path: &Path) -> bool {
 /// platform.
 #[cfg(unix)]
 fn read_back(path: &Path) -> Vec<(Vec<u8>, Vec<u8>)> {
-    let list = read_xattrs_for_wire(path, false, true, 0).expect("read xattrs back");
+    let list = read_xattrs_for_wire(
+        path,
+        &XattrSendOptions {
+            am_root: true,
+            ..XattrSendOptions::default()
+        },
+    )
+    .expect("read xattrs back");
     list.iter()
         .map(|entry| (entry.name().to_vec(), entry.datum().to_vec()))
         .collect()

--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -42,7 +42,10 @@ pub use cache::XattrCache;
 pub use diff::xattr_diff;
 pub use entry::{XattrEntry, XattrState};
 pub use list::XattrList;
-pub use prefix::{is_rsync_internal, local_to_wire, wire_to_local};
+pub use prefix::{
+    is_fake_super_store_attr, is_rsync_internal, local_to_wire, rsync_internal_suffix,
+    wire_to_local,
+};
 pub use wire::{
     RecvXattrResult, XattrDefinition, XattrSet, checksum_matches, read_xattr_definitions,
     recv_xattr, recv_xattr_request, recv_xattr_values, send_sender_xattr_response, send_xattr,

--- a/crates/protocol/src/xattr/prefix.rs
+++ b/crates/protocol/src/xattr/prefix.rs
@@ -41,13 +41,18 @@ use super::SYSTEM_PREFIX;
 
 /// Translates an xattr name from local format to wire format.
 ///
-/// On every platform the local name is emitted verbatim once it has
-/// passed the rsync-internal filter. This matches the upstream sender
-/// (`xattrs.c:send_xattr()`), which writes the bytes returned by
-/// `listxattr(2)` directly into the protocol stream. Upstream's only
+/// On every platform the local name is emitted verbatim. This matches the
+/// upstream sender (`xattrs.c:send_xattr()`), which writes the bytes returned
+/// by `listxattr(2)` directly into the protocol stream. Upstream's only
 /// transformation is the fake-super (`am_root < 0`) prefix strip; we do
 /// not model that here because the sender currently runs with
 /// `am_root = false` (see `transfer/generator/file_list/entry.rs`).
+///
+/// This function performs namespace and prefix translation only. The
+/// `rsync.%FOO` internal-attribute gate is *not* applied here: upstream
+/// evaluates it per attribute with the `-X` level, the role, and the
+/// fake-super state in hand (`xattrs.c:260-267`), so it belongs to the
+/// collection loop in `metadata::xattr::read_xattrs_for_wire`.
 ///
 /// Namespace filtering for non-root senders is performed earlier in
 /// `metadata::xattr::list_attributes` via `is_xattr_permitted`; this
@@ -58,26 +63,25 @@ use super::SYSTEM_PREFIX;
 /// # Arguments
 ///
 /// * `name` - Local xattr name
-/// * `am_root` - Whether the sender has root privileges (gates `system.*`)
+/// * `allow_system_namespace` - Whether `system.*` may reach the wire. True for
+///   a root caller, and also when an `x`-modifier filter is present, because
+///   upstream's namespace test is the `else` branch of the filter test and is
+///   therefore not evaluated at all when a filter governs the selection
+///   (`xattrs.c:250-257`).
 ///
 /// # Returns
 ///
 /// The wire-format name, or `None` if this xattr should be skipped.
-pub fn local_to_wire(name: &[u8], am_root: bool) -> Option<Vec<u8>> {
+pub fn local_to_wire(name: &[u8], allow_system_namespace: bool) -> Option<Vec<u8>> {
     let name_str = match std::str::from_utf8(name) {
         Ok(s) => s,
-        // Non-UTF8 names cannot be rsync-internal markers, so pass them
+        // Non-UTF8 names cannot carry an ASCII namespace prefix, so pass them
         // through verbatim.
         Err(_) => return Some(name.to_vec()),
     };
 
-    // upstream: xattrs.c:261-267 - rsync.%FOO internals are never sent.
-    if is_rsync_internal(name_str) {
-        return None;
-    }
-
     // upstream: xattrs.c:256 - non-root never exposes the system namespace.
-    if name_str.starts_with(SYSTEM_PREFIX) && !am_root {
+    if name_str.starts_with(SYSTEM_PREFIX) && !allow_system_namespace {
         return None;
     }
 
@@ -196,23 +200,46 @@ pub fn wire_to_local(wire_name: &[u8], am_root: bool) -> Option<Vec<u8>> {
     }
 }
 
+/// Returns the text following the `rsync.%` internal-attribute marker, or
+/// `None` when `name` is not an rsync internal attribute.
+///
+/// Both the Linux (`user.rsync.%`) and the non-Linux / wire (`rsync.%`)
+/// spellings are recognised. The returned suffix is what upstream compares
+/// against `XSTAT_SUFFIX` / `XACC_ACL_SUFFIX` / `XDEF_ACL_SUFFIX` to identify
+/// the three fake-super store attributes.
+///
+/// # Upstream Reference
+///
+/// `xattrs.c:261` - `name[RPRE_LEN] == '%' && HAS_PREFIX(name, RSYNC_PREFIX)`,
+/// then `xattrs.c:264-266` compares `name + RPRE_LEN + 1`.
+pub fn rsync_internal_suffix(name: &str) -> Option<&str> {
+    name.strip_prefix("user.rsync.%")
+        .or_else(|| name.strip_prefix("rsync.%"))
+}
+
+/// Reports whether `name` is one of the three fake-super store attributes.
+///
+/// Upstream drops `rsync.%stat`, `rsync.%aacl`, and `rsync.%dacl` whenever
+/// `--fake-super` is active (`am_root < 0`), regardless of role or `-X` level,
+/// because they describe the local fake-super store rather than the file's own
+/// metadata.
+///
+/// # Upstream Reference
+///
+/// `xattrs.c:263-266` - `am_root < 0 && (strcmp(..., XSTAT_SUFFIX) == 0 || ...)`
+pub fn is_fake_super_store_attr(name: &str) -> bool {
+    matches!(rsync_internal_suffix(name), Some("stat" | "aacl" | "dacl"))
+}
+
 /// Checks if an xattr name is an rsync internal attribute.
 ///
 /// Rsync internal attributes use the pattern `rsync.%suffix` or `user.rsync.%suffix`.
 /// These are used for storing metadata like stat info and ACLs (the fake-super
-/// `%stat`/`%aacl`/`%dacl` channel). Upstream never transfers them as -X data:
-/// the sender skips them (`xattrs.c:261-267`, `am_sender && preserve_xattrs < 2`),
-/// so a local copy must exclude them from both the copy and the delete pass.
+/// `%stat`/`%aacl`/`%dacl` channel). A sender transfers them only under `-XX`
+/// (`xattrs.c:261-267`, `am_sender && preserve_xattrs < 2`), and a local copy
+/// excludes them from both the copy and the delete pass.
 pub fn is_rsync_internal(name: &str) -> bool {
-    // Check for user.rsync.% pattern (Linux)
-    if let Some(suffix) = name.strip_prefix("user.rsync.") {
-        return suffix.starts_with('%');
-    }
-    // Check for rsync.% pattern (non-Linux or wire format)
-    if let Some(suffix) = name.strip_prefix("rsync.") {
-        return suffix.starts_with('%');
-    }
-    false
+    rsync_internal_suffix(name).is_some()
 }
 
 #[cfg(test)]
@@ -227,6 +254,30 @@ mod tests {
         assert!(!is_rsync_internal("user.rsync.normal"));
         assert!(!is_rsync_internal("rsync.normal"));
         assert!(!is_rsync_internal("user.foo"));
+    }
+
+    /// The suffix drives the `--fake-super` gate at `xattrs.c:264-266`, which
+    /// compares `name + RPRE_LEN + 1` against `stat`/`aacl`/`dacl`. Returning
+    /// the wrong slice would either leak the fake-super store under
+    /// `--fake-super` or drop an unrelated `rsync.%` name.
+    #[test]
+    fn rsync_internal_suffix_strips_both_spellings() {
+        assert_eq!(rsync_internal_suffix("user.rsync.%stat"), Some("stat"));
+        assert_eq!(rsync_internal_suffix("rsync.%dacl"), Some("dacl"));
+        assert_eq!(rsync_internal_suffix("user.rsync.normal"), None);
+        assert_eq!(rsync_internal_suffix("user.foo"), None);
+    }
+
+    /// Only the three store attributes are suppressed by `--fake-super`; any
+    /// other `rsync.%` name is governed by the `-X` level alone
+    /// (`xattrs.c:263-266`).
+    #[test]
+    fn fake_super_store_attrs_are_exactly_stat_aacl_dacl() {
+        assert!(is_fake_super_store_attr("user.rsync.%stat"));
+        assert!(is_fake_super_store_attr("user.rsync.%aacl"));
+        assert!(is_fake_super_store_attr("rsync.%dacl"));
+        assert!(!is_fake_super_store_attr("user.rsync.%other"));
+        assert!(!is_fake_super_store_attr("user.foo"));
     }
 
     #[test]
@@ -270,10 +321,17 @@ mod tests {
             assert_eq!(result, Some(b"user.rsync.system.foo".to_vec()));
         }
 
+        /// `local_to_wire` does namespace translation only. Whether an
+        /// `rsync.%FOO` name reaches the wire depends on the `-X` level, the
+        /// role, and `--fake-super` (`xattrs.c:260-267`), none of which this
+        /// function can see, so it must NOT drop the name on its own -
+        /// otherwise `-XX` can never transmit the fake-super store.
         #[test]
-        fn local_to_wire_skips_internal() {
-            let result = local_to_wire(b"user.rsync.%stat", false);
-            assert_eq!(result, None);
+        fn local_to_wire_leaves_the_internal_gate_to_the_caller() {
+            assert_eq!(
+                local_to_wire(b"user.rsync.%stat", false),
+                Some(b"user.rsync.%stat".to_vec()),
+            );
         }
 
         #[test]

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -123,8 +123,18 @@ pub struct ParsedServerFlags {
     pub hard_links: bool,
     /// Preserve ACLs (`A` flag, `--acls`).
     pub acls: bool,
-    /// Preserve extended attributes (`X` flag, `--xattrs`).
+    /// Preserve extended attributes (`X` flag, `--xattrs`). True when at least
+    /// one `X` is present; see [`xattrs_level`](Self::xattrs_level) for the count.
     pub xattrs: bool,
+    /// Count of `X` flags in the packed server flag string, capped at 2.
+    ///
+    /// Upstream keeps `preserve_xattrs` as a counter (`options.c:1877`
+    /// `preserve_xattrs++`) and doubles the compact letter for the remote
+    /// (`options.c:2699-2702`), so the level rides the flag string rather than
+    /// a side channel. `-XX` (level 2) transfers the `rsync.%FOO` fake-super
+    /// store; collapsing to the `xattrs` bool alone makes `-XX` behave
+    /// identically to `-X` (`xattrs.c:262`, `am_sender && preserve_xattrs < 2`).
+    pub xattrs_level: u8,
     /// Numeric IDs mode (long-form `--numeric-ids`, or daemon `numeric ids`).
     ///
     /// Not part of the compact flag string; set via long-form args, client
@@ -480,6 +490,7 @@ impl ParsedServerFlags {
         #[cfg(not(all(unix, feature = "xattr")))]
         if self.xattrs {
             self.xattrs = false;
+            self.xattrs_level = 0;
             cleared.push("xattrs");
         }
 
@@ -550,7 +561,14 @@ impl ParsedServerFlags {
             b'H' => self.hard_links = true,
             b'I' => self.ignore_times = true,
             b'A' => self.acls = true,
-            b'X' => self.xattrs = true,
+            // upstream: options.c:1877 `preserve_xattrs++` - the level is a
+            // count, doubled onto the wire as `-XX` by options.c:2699-2702.
+            b'X' => {
+                self.xattrs = true;
+                if self.xattrs_level < 2 {
+                    self.xattrs_level += 1;
+                }
+            }
             // upstream: 'n' = dry_run (!do_xfers), NOT numeric_ids.
             // numeric_ids is long-form only (options.c:2905 sends --numeric-ids).
             b'n' => self.dry_run = true,
@@ -689,6 +707,30 @@ mod tests {
     fn rejects_missing_leading_dash() {
         let result = ParsedServerFlags::parse("logDtpre");
         assert_eq!(result.unwrap_err(), ParseFlagError::MissingLeadingDash);
+    }
+
+    /// `-XX` must survive the flag string as a level, not collapse onto the
+    /// `xattrs` bool: the sender consults `preserve_xattrs < 2` to decide
+    /// whether the `rsync.%FOO` fake-super store reaches the wire
+    /// (`xattrs.c:262`). Losing the count here makes `-XX` a synonym for `-X`.
+    #[test]
+    fn xattrs_level_counts_doubled_x() {
+        assert_eq!(ParsedServerFlags::parse("-rlt").unwrap().xattrs_level, 0);
+
+        let single = ParsedServerFlags::parse("-rltX").unwrap();
+        assert!(single.xattrs);
+        assert_eq!(single.xattrs_level, 1);
+
+        let double = ParsedServerFlags::parse("-rltXX").unwrap();
+        assert!(double.xattrs);
+        assert_eq!(double.xattrs_level, 2);
+    }
+
+    /// Upstream caps the transmitted level at two letters (options.c:2699-2702),
+    /// so a peer that sends more must not overflow the counter.
+    #[test]
+    fn xattrs_level_saturates_at_two() {
+        assert_eq!(ParsedServerFlags::parse("-XXXX").unwrap().xattrs_level, 2);
     }
 
     #[test]

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -344,6 +344,9 @@ impl GeneratorContext {
     /// `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)`. Note that when
     /// this returns `Some`, upstream skips the namespace test entirely: the
     /// two branches at xattrs.c:250-257 are mutually exclusive.
+    /// Only the unix xattr-collection path consults this; gating the
+    /// definition to match its sole caller keeps Windows free of dead code.
+    #[cfg(unix)]
     pub(crate) fn xattr_name_filter(&self) -> Option<&::filters::FilterSet> {
         let global = self.filter_chain.global();
         global.has_xattr_rules().then_some(global)

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -333,6 +333,22 @@ impl GeneratorContext {
     }
 
     /// Creates a configured `FileListWriter` matching the current protocol and flags.
+    /// Returns the `x`-modifier xattr-name filter that screens which of a
+    /// source file's extended attributes are collected for the wire, or `None`
+    /// when the transfer carries no such rules.
+    ///
+    /// # Upstream Reference
+    ///
+    /// Mirrors upstream's `saw_xattr_filter` gate in `rsync_xal_get()`
+    /// (xattrs.c:250-252), which consults
+    /// `name_is_excluded(name, NAME_IS_XATTR, ALL_FILTERS)`. Note that when
+    /// this returns `Some`, upstream skips the namespace test entirely: the
+    /// two branches at xattrs.c:250-257 are mutually exclusive.
+    pub(crate) fn xattr_name_filter(&self) -> Option<&::filters::FilterSet> {
+        let global = self.filter_chain.global();
+        global.has_xattr_rules().then_some(global)
+    }
+
     pub(crate) fn build_flist_writer(&self) -> protocol::flist::FileListWriter {
         use crate::shared::ChecksumFactory;
 

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -348,12 +348,22 @@ impl GeneratorContext {
             if should_read {
                 // Follow symlinks only for non-symlink entries (lgetxattr for symlinks)
                 let follow = !file_type.is_symlink();
-                match metadata::read_xattrs_for_wire(
-                    full_path,
-                    follow,
-                    false, // am_root: sender on Linux non-root reads user.* only
-                    self.checksum_seed,
-                ) {
+                let xattr_filter = self.xattr_name_filter();
+                let predicate =
+                    xattr_filter.map(|set| move |name: &str| set.xattr_name_allowed(name));
+                let opts = metadata::XattrSendOptions {
+                    follow_symlinks: follow,
+                    // upstream: xattrs.c:237 - the sender sets user_only = 0 and
+                    // never claims root, so system.* stays local.
+                    am_root: false,
+                    // upstream: xattrs.c:262 - `am_sender && preserve_xattrs < 2`
+                    // strips the rsync.%FOO store; -XX transmits it.
+                    preserve_xattrs: self.config.flags.xattrs_level,
+                    fake_super: self.config.fake_super,
+                    filter: predicate.as_ref().map(|f| f as &dyn Fn(&str) -> bool),
+                    checksum_seed: self.checksum_seed,
+                };
+                match metadata::read_xattrs_for_wire(full_path, &opts) {
                     Ok(list) => {
                         if !list.is_empty() {
                             entry.set_xattr_list(list);

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -632,6 +632,9 @@ impl ReceiverContext {
         .with_preserve_hard_links(self.config.flags.hard_links)
         .with_preserve_acls(self.config.flags.acls)
         .with_preserve_xattrs(self.config.flags.xattrs)
+        // upstream: xattrs.c:849 - receive_xattr() keeps rsync.%FOO only at
+        // preserve_xattrs >= 2, so the level has to reach the reader.
+        .with_xattr_level(u32::from(self.config.flags.xattrs_level))
         .with_preserve_atimes(self.config.flags.atimes)
         .with_delete_missing_args(self.config.file_selection.delete_missing_args)
         .with_relative_paths(self.config.flags.relative);

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -654,12 +654,18 @@ impl ReceiverContext {
     /// pre-transfer destination. A sender with no xattrs differs exactly when
     /// the destination still carries some.
     pub(in crate::receiver) fn dest_xattrs_differ(&self, entry: &FileEntry, path: &Path) -> bool {
-        let dest = match metadata::read_xattrs_for_wire(
-            path,
-            false,
-            metadata::am_root(),
-            self.checksum_seed,
-        ) {
+        let opts = metadata::XattrSendOptions {
+            follow_symlinks: false,
+            am_root: metadata::am_root(),
+            // upstream: xattrs.c:262 - the strip is gated on `am_sender`, and
+            // the generator is not the sender, so nothing is stripped here.
+            // Level 2 reproduces that without a separate role field.
+            preserve_xattrs: 2,
+            fake_super: self.config.fake_super,
+            filter: None,
+            checksum_seed: self.checksum_seed,
+        };
+        let dest = match metadata::read_xattrs_for_wire(path, &opts) {
             Ok(list) => list,
             Err(_) => return false,
         };


### PR DESCRIPTION
## Summary
- The sender stripped every `rsync.%*` xattr unconditionally, so `-XX` behaved exactly like `-X` despite the help text advertising fake-super store transfer
- Thread the `preserve_xattrs` level from core through to the sender and gate the `rsync.%*` strip on level < 2, mirroring `xattrs.c:rsync_xal_get:260-267`
- Apply `x`-modifier `--filter` rules during sender-side collection (`xattrs.c:250-252`); when a filter is present the namespace check is bypassed, matching upstream's mutually-exclusive branches
- `--fake-super` still suppresses `%stat`/`%aacl`/`%dacl` at any level, mirroring upstream's `am_root < 0` gate

## Level plumbing: the compact flag string, not a new config field
The level did not need a new `ServerConfig` / `GeneratorContext` field. Upstream keeps `preserve_xattrs` as a counter (`options.c:1877` `preserve_xattrs++`) and doubles the compact letter for the peer (`options.c:2699-2702`); `build_server_flag_string` already emits `XX` at level 2, and *every* `ServerConfig` - the in-process half of a local transfer as well as a remote peer - is built by re-parsing that same string. So the level is recovered by counting `X` in `ParsedServerFlags`, exactly as `verbose_level` and `one_file_system` already do in the same match arm. That keeps one DRY mechanism for option propagation and adds no plumbing to `core`.

`read_xattrs_for_wire` takes an options struct rather than six positional parameters. The filter travels as `Option<&dyn Fn(&str) -> bool>`, matching the convention `apply_xattrs_from_list` and `sync_xattrs` already use, so `metadata` keeps its independence from the `filters` crate. There is no `am_sender` field: the role is consulted only by the `rsync.%` strip, so a non-sender caller (the generator comparing the destination) passes level 2 and reproduces `am_sender == 0` exactly.

## Receive side
`FileListReader::with_xattr_level` existed but was never called in production, pinning the receiver at level 1. It is now fed from the same parsed level, otherwise the receiver would drop the `rsync.%*` entries the sender had just started transmitting and `-XX` would still be a no-op end to end.

## Test plan
- [x] `-XX` keeps `rsync.%stat` on the wire; `-X` strips it
- [x] fake-super drops `%stat`/`%aacl`/`%dacl` even at level 2, and leaves other `rsync.%` names to the level
- [x] `--filter '-x user.foo'` omits it from the collected set; namespace check bypassed when a filter is present (a `system.*` name the namespace rule would drop is now governed by the filter)
- [x] `-XX` level survives the `build_server_flag_string` -> `ParsedServerFlags::parse` round trip
- [x] `cargo fmt` clean, `clippy --workspace -D warnings` clean, `cargo check --workspace --all-features --all-targets` clean
- [x] `cargo test -p metadata -p protocol -p transfer -p filters -p core` targeted suites green
