### PR TITLE
fix(core): stop writing the remote dest under --only-write-batch

### DIFF
--- a/crates/core/src/client/config/client/arguments.rs
+++ b/crates/core/src/client/config/client/arguments.rs
@@ -66,6 +66,20 @@ impl ClientConfig {
         self.batch_config.as_ref()
     }
 
+    /// Reports whether `--only-write-batch` is in effect (upstream's
+    /// `write_batch < 0`).
+    ///
+    /// The batch is still recorded in full, but no destination is updated:
+    /// `main.c:1839` turns the flag into `dry_run = 1` and `sender.c:217`
+    /// points the token stream at the batch file instead of the wire.
+    #[doc(alias = "--only-write-batch")]
+    #[must_use]
+    pub fn only_write_batch(&self) -> bool {
+        self.batch_config
+            .as_ref()
+            .is_some_and(|cfg| !cfg.should_transfer())
+    }
+
     /// Returns `true` when the local client should emit the sender-side `<`
     /// itemize direction arrow (push over a remote shell or daemon).
     ///

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -700,6 +700,7 @@ fn build_server_config_for_generator(
         server_config.file_selection.files_from_path = Some(path);
         server_config.file_selection.from0 = plan.sender_from0;
     }
+    flags::apply_only_write_batch_for_sender(config, &mut server_config);
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -396,6 +396,31 @@ fn split_pattern_modifiers(raw: &str) -> (String, bool, bool) {
     (raw[start..end].to_owned(), anchored, directory_only)
 }
 
+/// Carries `--only-write-batch` onto a remote-shell PUSH sender's config.
+///
+/// Upstream binds `f_xfer` once per `send_files()` run from the global
+/// `write_batch` (`sender.c:217`); oc's sender reads the same decision off its
+/// in-process `ServerConfig`, which is parsed from the compact flag string and
+/// so never sees this long-form-only option. Without it the sender would keep
+/// streaming tokens at a remote receiver that `--only-write-batch=X` has just
+/// put into `dry_run` and which therefore reads none of them.
+///
+/// Scoped to the remote-shell sender on purpose: `server_options()` emits the
+/// placeholder inside its `am_sender` block, so a pull sender-server never sees
+/// it, and the daemon path deliberately strips client-only batch flags from the
+/// module argument list - its receiver stays live and must keep reading tokens.
+///
+/// # Upstream Reference
+///
+/// - `options.c:2850-2851` - `if (write_batch < 0) "--only-write-batch=X"`
+/// - `main.c:1839` - `if (write_batch < 0) dry_run = 1`
+pub(crate) fn apply_only_write_batch_for_sender(
+    config: &ClientConfig,
+    server_config: &mut ServerConfig,
+) {
+    server_config.flags.only_write_batch = config.only_write_batch();
+}
+
 /// Applies common server flags from client configuration to a server config.
 ///
 /// Sets the fields that are shared across both SSH and daemon transfer paths

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -413,6 +413,19 @@ impl<'a> RemoteInvocationBuilder<'a> {
             if self.config.force_replacements() {
                 args.push(OsString::from("--force"));
             }
+
+            // upstream: options.c:2850-2851 - `if (write_batch < 0) args[ac++] =
+            // "--only-write-batch=X"`. The literal `X` is upstream's own
+            // placeholder: the remote never opens a batch file, it only needs
+            // `write_batch < 0` so `main.c:1839` sets `dry_run = 1`. That leaves
+            // `do_xfers` at 1, so its generator still computes and sends real
+            // block checksums while the receiver writes nothing to the
+            // destination (receiver.c:811-817). The real batch is recorded by
+            // the local sender, which diverts the token stream into it rather
+            // than onto the wire (sender.c:217).
+            if self.config.only_write_batch() {
+                args.push(OsString::from("--only-write-batch=X"));
+            }
         }
 
         // upstream: options.c:2863-2864 - `--max-alloc=arg` is forwarded to

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -658,6 +658,67 @@ fn includes_delete_excluded_long_arg() {
     );
 }
 
+/// Builds a `ClientConfig` carrying the requested batch mode.
+fn config_with_batch_mode(mode: engine::batch::BatchMode) -> ClientConfig {
+    ClientConfig::builder()
+        .batch_config(Some(engine::batch::BatchConfig::new(
+            mode,
+            "/tmp/batch".to_owned(),
+            32,
+        )))
+        .build()
+}
+
+/// upstream: `options.c:2850-2851` - the sender half of `server_options()` emits
+/// the literal `--only-write-batch=X` placeholder. It is the only signal that
+/// puts the remote receiver into `dry_run` (`main.c:1839`), which is what stops
+/// it from updating the destination and from waiting on a token stream the
+/// sender is diverting into its batch file (`sender.c:217`). Without this
+/// argument a `--only-write-batch` push writes the remote destination.
+#[test]
+fn only_write_batch_sender_emits_placeholder_arg() {
+    let config = config_with_batch_mode(engine::batch::BatchMode::OnlyWrite);
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
+    let args = builder.build("/path");
+
+    assert!(
+        args.iter().any(|a| a == "--only-write-batch=X"),
+        "expected the --only-write-batch=X placeholder in args: {args:?}"
+    );
+}
+
+/// upstream: `options.c:2850-2851` sits inside the `if (am_sender)` block, so a
+/// PULL never forwards it. Leaking it would put the remote SENDER into dry-run
+/// and it would stop sending file data entirely.
+#[test]
+fn only_write_batch_is_not_forwarded_on_a_pull() {
+    let config = config_with_batch_mode(engine::batch::BatchMode::OnlyWrite);
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/path");
+
+    assert!(
+        !args.iter().any(|a| a == "--only-write-batch=X"),
+        "--only-write-batch=X must stay inside the am_sender block: {args:?}"
+    );
+}
+
+/// upstream gates the placeholder on `write_batch < 0`, so plain
+/// `--write-batch` (`write_batch > 0`) forwards nothing: that mode performs a
+/// real transfer AND records it, and the remote receiver must stay live.
+#[test]
+fn plain_write_batch_sender_emits_no_placeholder_arg() {
+    let config = config_with_batch_mode(engine::batch::BatchMode::Write);
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
+    let args = builder.build("/path");
+
+    assert!(
+        !args
+            .iter()
+            .any(|a| a.to_string_lossy().starts_with("--only-write-batch")),
+        "--write-batch must not put the remote receiver into dry-run: {args:?}"
+    );
+}
+
 #[test]
 fn includes_timeout_long_arg() {
     use std::num::NonZeroU64;

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -242,6 +242,7 @@ pub(in crate::client::remote) fn build_server_config_for_generator(
     server_config.flags.info_flags.out_format_active = config.render_out_format_locally();
 
     apply_files_from_for_sender(config, &mut server_config);
+    flags::apply_only_write_batch_for_sender(config, &mut server_config);
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
@@ -281,6 +282,43 @@ fn apply_files_from_for_sender(config: &ClientConfig, server_config: &mut Server
 mod tests {
     use super::*;
     use crate::client::config::ReferenceDirectoryKind;
+
+    /// Builds a `ClientConfig` carrying the requested batch mode.
+    fn config_with_batch_mode(mode: engine::batch::BatchMode) -> ClientConfig {
+        ClientConfig::builder()
+            .batch_config(Some(engine::batch::BatchConfig::new(
+                mode,
+                "/tmp/batch".to_owned(),
+                32,
+            )))
+            .build()
+    }
+
+    /// upstream `sender.c:217` binds `f_xfer` from the global `write_batch`
+    /// before the send loop starts. oc's sender reads that decision off its
+    /// in-process `ServerConfig`, which is parsed from the compact flag string
+    /// and never sees this long-form-only option, so the push builder has to
+    /// carry it explicitly. Without the flag the sender keeps streaming tokens
+    /// at a remote receiver that `--only-write-batch=X` just put into dry-run
+    /// and which reads none of them - the transfer stalls out at exit 12.
+    #[test]
+    fn generator_config_carries_only_write_batch() {
+        let config = config_with_batch_mode(engine::batch::BatchMode::OnlyWrite);
+        let server_config =
+            build_server_config_for_generator(&config, &["src".to_owned()]).unwrap();
+        assert!(server_config.flags.only_write_batch);
+    }
+
+    /// `--write-batch` (upstream `write_batch > 0`) performs a real transfer AND
+    /// records it, so the token stream must keep its wire route and only be teed
+    /// (`io.c:2282`). Diverting here would starve the live remote receiver.
+    #[test]
+    fn generator_config_leaves_plain_write_batch_on_the_wire() {
+        let config = config_with_batch_mode(engine::batch::BatchMode::Write);
+        let server_config =
+            build_server_config_for_generator(&config, &["src".to_owned()]).unwrap();
+        assert!(!server_config.flags.only_write_batch);
+    }
 
     /// On an ssh pull the local client IS the receiver, and the alt-dest args
     /// (--compare-dest / --copy-dest / --link-dest) are never sent over the wire

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -357,11 +357,7 @@ fn run_client_internal(
     // upstream: main.c:1841-1842 - `--only-write-batch` forces dry_run=1 so
     // that the transfer runs (populating the batch file) without creating the
     // destination directory or writing any files.
-    let is_only_write_batch = config
-        .batch_config()
-        .is_some_and(|bc| !bc.should_transfer());
-
-    let mode = if config.dry_run() || config.list_only() || is_only_write_batch {
+    let mode = if config.dry_run() || config.list_only() || config.only_write_batch() {
         LocalCopyExecution::DryRun
     } else {
         LocalCopyExecution::Apply

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -181,7 +181,6 @@ impl GeneratorContext {
     ///
     /// Returns the per-file `XattrList` with `XSTATE_TODO` entries marked for
     /// the indices the generator requested, ready to be passed to
-    /// [`Self::write_ndx_and_attrs`] or
     /// [`Self::write_ndx_iflags_and_xattr_response`]. Returns `None` when no
     /// xattr request is expected on the wire.
     ///
@@ -240,33 +239,6 @@ impl GeneratorContext {
         // matching entries and consumes the stream up to the 0 terminator.
         let _indices = protocol::xattr::recv_xattr_request(reader, &mut list)?;
         Ok(Some(list))
-    }
-
-    /// Writes NDX, iflags, optional xattr response, and sum_head for one file.
-    ///
-    /// Combines upstream's `write_ndx_and_attrs()` (NDX + iflags + optional
-    /// xattr_request body) with the immediately following `write_sum_head()`
-    /// call. When `xattr_response` is `Some` and the file has entries the
-    /// generator requested, the full xattr values are written between iflags
-    /// and sum_head, matching the byte order of upstream sender.c:442-443.
-    ///
-    /// # Upstream Reference
-    ///
-    /// - `sender.c:184-200` - `write_ndx_and_attrs()` body (calls
-    ///   `send_xattr_request(fname, file, f_out)` when ITEM_REPORT_XATTR set)
-    /// - `sender.c:442-443` - `write_ndx_and_attrs()` followed by
-    ///   `write_sum_head(f_xfer, s)`
-    pub(super) fn write_ndx_and_attrs<W: Write>(
-        &self,
-        writer: &mut W,
-        ndx_codec: &mut impl NdxCodec,
-        attrs: &NdxAttrs<'_>,
-        sum_head: &SumHead,
-        xattr_response: Option<&mut protocol::xattr::XattrList>,
-    ) -> io::Result<()> {
-        self.write_ndx_iflags_and_xattr_response(writer, ndx_codec, attrs, xattr_response)?;
-        sum_head.write(writer)?;
-        Ok(())
     }
 
     /// Writes NDX, iflags, and optional xattr response without a sum_head.

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -28,6 +28,71 @@ use super::super::{
 };
 use crate::delta_config::DeltaGeneratorConfig;
 use crate::receiver::SumHead;
+use crate::writer::{BatchRoute, MsgInfoSender};
+
+/// Scoped view of the sender's transfer stream, upstream's `f_xfer`.
+///
+/// upstream `sender.c:217` picks the destination of a file's sum head, tokens
+/// and trailing file checksum once per `send_files()` run:
+///
+/// ```c
+/// int f_xfer = write_batch < 0 ? batch_fd : f_out;
+/// ```
+///
+/// Under `--only-write-batch` that stream goes into the batch file *instead of*
+/// the wire, which is what lets the remote receiver run with `dry_run = 1`
+/// (`main.c:1839`) and never read a byte of delta. The NDX+attrs header
+/// (`sender.c:442`) always stays on the wire, so the divert is scoped to the
+/// payload and reverted on drop. Under `--write-batch` (or with no batch at
+/// all) the route is unchanged and the recorder keeps teeing (`io.c:2282`).
+struct XferSink<'w, W: Write + MsgInfoSender + ?Sized> {
+    writer: &'w mut W,
+    diverted: bool,
+}
+
+impl<'w, W: Write + MsgInfoSender + ?Sized> XferSink<'w, W> {
+    /// Borrows `writer`, diverting it into the batch when `divert` is set.
+    fn new(writer: &'w mut W, divert: bool) -> Self {
+        if divert {
+            writer.set_batch_route(BatchRoute::Divert);
+        }
+        Self {
+            writer,
+            diverted: divert,
+        }
+    }
+}
+
+impl<W: Write + MsgInfoSender + ?Sized> Write for XferSink<'_, W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.writer.write(buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.writer.write_vectored(bufs)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+}
+
+impl<W: Write + MsgInfoSender + ?Sized> Drop for XferSink<'_, W> {
+    fn drop(&mut self) {
+        if self.diverted {
+            self.writer.set_batch_route(BatchRoute::Tee);
+        }
+    }
+}
+
+/// Narrows a payload byte count to the part that actually reached the wire.
+///
+/// upstream: `io.c:2255-2258` - a `write_buf()` aimed at `batch_fd` takes the
+/// `safe_write()` shortcut and returns before `total_data_written += len`, so
+/// bytes diverted into the batch never count towards "sent N bytes".
+const fn sent_bytes(counted: u64, diverted: bool) -> u64 {
+    if diverted { 0 } else { counted }
+}
 
 /// Minimum source size before the opt-in parallel delta scan is considered.
 ///
@@ -76,6 +141,34 @@ fn open_source_mmap(path: &std::path::Path, use_noatime: bool) -> io::Result<fas
 }
 
 impl GeneratorContext {
+    /// Writes one file's NDX + iflags (+ optional xattr response) header and the
+    /// sum head that follows it.
+    ///
+    /// The two go to different destinations under `--only-write-batch`: the
+    /// header is what the receiver still reads (`receiver.c:811-817` logs the
+    /// item and moves on), while the sum head opens the payload stream and
+    /// therefore belongs to the batch. `divert` selects that split; when it is
+    /// `false` both land on the wire exactly as before.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:184-200` - `write_ndx_and_attrs()` body (calls
+    ///   `send_xattr_request(fname, file, f_out)` when ITEM_REPORT_XATTR set)
+    /// - `sender.c:442-443` - `write_ndx_and_attrs(f_out, ...)` followed by
+    ///   `write_sum_head(f_xfer, s)`
+    fn write_ndx_attrs_and_sum_head<W: Write + MsgInfoSender>(
+        &self,
+        writer: &mut W,
+        ndx_codec: &mut impl NdxCodec,
+        attrs: &NdxAttrs<'_>,
+        sum_head: &SumHead,
+        xattr_response: Option<&mut protocol::xattr::XattrList>,
+        divert: bool,
+    ) -> io::Result<()> {
+        self.write_ndx_iflags_and_xattr_response(writer, ndx_codec, attrs, xattr_response)?;
+        sum_head.write(&mut XferSink::new(writer, divert))
+    }
+
     /// Runs the main file transfer loop, reading NDX requests from receiver.
     ///
     /// This method processes file transfer requests in phases until all phases complete.
@@ -175,6 +268,16 @@ impl GeneratorContext {
         // stream stored at level 0, still deflated framing). The framing decision is
         // therefore one session-level constant, not a per-file boolean.
         let use_compression = token_encoder.is_some();
+
+        // upstream: sender.c:217 - `int f_xfer = write_batch < 0 ? batch_fd :
+        // f_out`. Under `--only-write-batch` the sum head, tokens and file
+        // checksum are recorded into the batch INSTEAD of being sent, so the
+        // remote receiver - which server_options() put into `dry_run` via the
+        // `--only-write-batch=X` placeholder (options.c:2850, main.c:1839) and
+        // which therefore reads no payload (receiver.c:811-817) - never has an
+        // unread stream backing up behind it. Constant for the whole run,
+        // exactly like upstream's single `f_xfer` binding.
+        let divert_xfer = self.config.flags.only_write_batch;
 
         // upstream: io.c:2244-2245 - separate read/write NDX state
         let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
@@ -600,7 +703,7 @@ impl GeneratorContext {
                     }
                 };
 
-                self.write_ndx_and_attrs(
+                self.write_ndx_attrs_and_sum_head(
                     &mut *writer,
                     &mut ndx_write_codec,
                     &NdxAttrs {
@@ -611,13 +714,17 @@ impl GeneratorContext {
                     },
                     &sum_head,
                     pending_xattr_response.as_mut(),
+                    divert_xfer,
                 )?;
 
                 let checksum_algorithm = self.get_checksum_algorithm();
                 let flength = sum_head.flength().min(file_size);
                 let append_verify = self.config.flags.append_verify;
                 let wire_bytes = {
-                    let mut cw = crate::writer::CountingWriter::new(&mut *writer);
+                    let mut cw = crate::writer::CountingWriter::new(XferSink::new(
+                        &mut *writer,
+                        divert_xfer,
+                    ));
                     let result = stream_append_transfer(
                         &mut cw,
                         source,
@@ -635,7 +742,7 @@ impl GeneratorContext {
                         &mut stream_buf,
                     )?;
                     cw.write_all(&result.checksum_buf[..result.checksum_len])?;
-                    cw.bytes_written()
+                    sent_bytes(cw.bytes_written(), divert_xfer)
                 };
                 bytes_sent += wire_bytes;
                 literal_data += file_size.saturating_sub(flength);
@@ -716,7 +823,7 @@ impl GeneratorContext {
                     )?,
                 };
 
-                self.write_ndx_and_attrs(
+                self.write_ndx_attrs_and_sum_head(
                     &mut *writer,
                     &mut ndx_write_codec,
                     &NdxAttrs {
@@ -727,6 +834,7 @@ impl GeneratorContext {
                     },
                     &sum_head,
                     pending_xattr_response.as_mut(),
+                    divert_xfer,
                 )?;
 
                 let checksum_algorithm = self.get_checksum_algorithm();
@@ -749,7 +857,10 @@ impl GeneratorContext {
                 // (reconstructed size) trips the testsuite's "delta did not
                 // engage" assertion on delta pushes.
                 let wire_bytes = {
-                    let mut cw = crate::writer::CountingWriter::new(&mut *writer);
+                    let mut cw = crate::writer::CountingWriter::new(XferSink::new(
+                        &mut *writer,
+                        divert_xfer,
+                    ));
                     let result = write_delta_with_inline_checksum(
                         &mut cw,
                         &wire_ops,
@@ -768,7 +879,7 @@ impl GeneratorContext {
                     cw.write_all(&result.checksum_buf[..result.checksum_len])?;
                     matched_data += result.matched_data;
                     literal_data += result.literal_data;
-                    cw.bytes_written()
+                    sent_bytes(cw.bytes_written(), divert_xfer)
                 };
                 bytes_sent += wire_bytes;
             } else {
@@ -786,7 +897,7 @@ impl GeneratorContext {
                     }
                 };
 
-                self.write_ndx_and_attrs(
+                self.write_ndx_attrs_and_sum_head(
                     &mut *writer,
                     &mut ndx_write_codec,
                     &NdxAttrs {
@@ -797,6 +908,7 @@ impl GeneratorContext {
                     },
                     &sum_head,
                     pending_xattr_response.as_mut(),
+                    divert_xfer,
                 )?;
 
                 let checksum_algorithm = self.get_checksum_algorithm();
@@ -826,7 +938,10 @@ impl GeneratorContext {
                     None::<super::super::delta::ServeFds>
                 };
                 let wire_bytes = {
-                    let mut cw = crate::writer::CountingWriter::new(&mut *writer);
+                    let mut cw = crate::writer::CountingWriter::new(XferSink::new(
+                        &mut *writer,
+                        divert_xfer,
+                    ));
                     let result = stream_whole_file_transfer(
                         &mut cw,
                         source,
@@ -843,7 +958,7 @@ impl GeneratorContext {
                         serve_fds,
                     )?;
                     cw.write_all(&result.checksum_buf[..result.checksum_len])?;
-                    cw.bytes_written()
+                    sent_bytes(cw.bytes_written(), divert_xfer)
                 };
                 bytes_sent += wire_bytes;
                 // Whole-file transfer: the entire body is sent as literal data

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -168,6 +168,16 @@ impl ReceiverContext {
         if self.config.flags.list_only {
             stats.list_only_entries = self.collect_list_only_entries();
             writer.flush()?;
+        } else if self.config.flags.only_write_batch {
+            // upstream: main.c:1839 `write_batch < 0` forces dry_run but leaves
+            // do_xfers = 1, so unlike a plain `-n` the generator still sends
+            // real block checksums and the sender expects a sum head per file
+            // (sender.c:442-443). Checked before `dry_run` because
+            // only-write-batch sets both flags; falling through to
+            // `run_dry_run_loop` would send a bare NDX+iflags request with no
+            // sum head, leaving the sender blocked on a read that never
+            // completes while this loop blocks on the echo.
+            self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
         } else if self.config.flags.dry_run {
             self.run_dry_run_loop(reader, writer, &files_to_transfer)?;
         } else {

--- a/crates/transfer/src/writer/mod.rs
+++ b/crates/transfer/src/writer/mod.rs
@@ -19,6 +19,7 @@ mod server;
 
 pub use self::counting::CountingWriter;
 pub use self::msg_info::MsgInfoSender;
+pub use self::multiplex::BatchRoute;
 pub use self::server::{ServerWriter, shutdown_send_side};
 
 #[cfg(test)]

--- a/crates/transfer/src/writer/msg_info.rs
+++ b/crates/transfer/src/writer/msg_info.rs
@@ -9,6 +9,7 @@ use std::io::{self, Write};
 use protocol::MessageCode;
 
 use super::counting::CountingWriter;
+use super::multiplex::BatchRoute;
 use super::server::ServerWriter;
 
 /// Trait for writers that can send `MSG_INFO` multiplexed messages.
@@ -104,6 +105,20 @@ pub trait MsgInfoSender {
     fn maybe_send_keepalive(&mut self) -> io::Result<bool> {
         Ok(false)
     }
+
+    /// Selects where a batch-recorded stream lands: teed alongside the wire, or
+    /// diverted into the batch instead of it.
+    ///
+    /// The sender flips to [`BatchRoute::Divert`] for the duration of a file's
+    /// sum head + token stream under `--only-write-batch`, then back to
+    /// [`BatchRoute::Tee`] so the NDX+attrs echo keeps reaching the receiver.
+    /// The default implementation is a no-op, matching [`Self::send_msg_info`];
+    /// writers with no batch recorder have nothing to route.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `sender.c:217` - `int f_xfer = write_batch < 0 ? batch_fd : f_out;`
+    fn set_batch_route(&mut self, _route: BatchRoute) {}
 }
 
 impl<W: Write> MsgInfoSender for ServerWriter<W> {
@@ -156,6 +171,12 @@ impl<W: Write> MsgInfoSender for ServerWriter<W> {
             Self::Plain(_) | Self::Taken => Ok(false),
         }
     }
+
+    fn set_batch_route(&mut self, route: BatchRoute) {
+        // Duplicating the inherent method's name here keeps the call at the
+        // sender unambiguous; the inherent method owns the variant match.
+        ServerWriter::set_batch_route(self, route);
+    }
 }
 
 impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
@@ -178,6 +199,10 @@ impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
     fn maybe_send_keepalive(&mut self) -> io::Result<bool> {
         (**self).maybe_send_keepalive()
     }
+
+    fn set_batch_route(&mut self, route: BatchRoute) {
+        (**self).set_batch_route(route);
+    }
 }
 
 impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
@@ -199,5 +224,9 @@ impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
 
     fn maybe_send_keepalive(&mut self) -> io::Result<bool> {
         self.inner_ref_mut().maybe_send_keepalive()
+    }
+
+    fn set_batch_route(&mut self, route: BatchRoute) {
+        self.inner_ref_mut().set_batch_route(route);
     }
 }

--- a/crates/transfer/src/writer/multiplex.rs
+++ b/crates/transfer/src/writer/multiplex.rs
@@ -10,6 +10,27 @@ use std::time::{Duration, Instant};
 
 use protocol::{MessageCode, MessageHeader};
 
+/// Destination selector for bytes written through a batch-recording writer.
+///
+/// Upstream keeps two distinct batch wirings and this enum names them:
+/// `--write-batch` tees every socket write into `batch_fd`
+/// (`io.c:2282 write_batch_monitor_out`), while `--only-write-batch` sends the
+/// token stream to `batch_fd` *instead of* the socket
+/// (`sender.c:217 f_xfer = write_batch < 0 ? batch_fd : f_out`).
+///
+/// # Upstream Reference
+///
+/// - `io.c:2281-2283` - `if (f == write_batch_monitor_out) safe_write(batch_fd, ...)`
+/// - `sender.c:217` - `int f_xfer = write_batch < 0 ? batch_fd : f_out;`
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BatchRoute {
+    /// Write to the wire and copy into the batch (upstream's tee monitor).
+    #[default]
+    Tee,
+    /// Write into the batch only, leaving the wire untouched.
+    Divert,
+}
+
 /// Writer that wraps data in multiplex `MSG_DATA` frames.
 ///
 /// Buffers writes to avoid sending tiny multiplex frames for every write call.
@@ -39,6 +60,9 @@ pub(crate) struct MultiplexWriter<W> {
     /// Optional recorder for batch mode - captures pre-mux data.
     /// upstream: `io.c` `write_batch_monitor_out` + `safe_write(batch_fd, buf, len)`
     pub(crate) batch_recorder: Option<Arc<Mutex<dyn Write + Send>>>,
+    /// Selects whether recorded bytes are also framed onto the wire.
+    /// upstream: `sender.c:217` `f_xfer = write_batch < 0 ? batch_fd : f_out`
+    pub(crate) batch_route: BatchRoute,
     /// Instant of the last actual write to `inner`, tracking upstream's
     /// `last_io_out`. A lull is measured from this point.
     last_io_out: Instant,
@@ -68,6 +92,7 @@ impl<W: Write> MultiplexWriter<W> {
             buffer_size: DEFAULT_BUFFER_SIZE,
             dirty: false,
             batch_recorder: None,
+            batch_route: BatchRoute::default(),
             last_io_out: Instant::now(),
             allowed_lull: None,
         }
@@ -129,6 +154,31 @@ impl<W: Write> MultiplexWriter<W> {
         Ok(true)
     }
 
+    /// Copies `chunks` into the attached batch recorder, reporting whether the
+    /// bytes have been consumed by the batch alone.
+    ///
+    /// A `true` return means the caller must skip the wire write entirely: the
+    /// batch file *is* the destination for this stream. Without a recorder
+    /// attached the route is irrelevant and nothing is ever dropped.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:2255-2258` - `write_buf()` with `f != iobuf.out_fd` bypasses the
+    ///   multiplex buffer and writes straight to the fd (here, the batch).
+    /// - `io.c:2281-2283` - the tee into `batch_fd` for `--write-batch`.
+    fn record_to_batch<'b>(&self, chunks: impl Iterator<Item = &'b [u8]>) -> io::Result<bool> {
+        let Some(recorder) = self.batch_recorder.as_ref() else {
+            return Ok(false);
+        };
+        let mut rec = recorder
+            .lock()
+            .map_err(|_| io::Error::other("batch recorder lock poisoned"))?;
+        for chunk in chunks {
+            rec.write_all(chunk)?;
+        }
+        Ok(self.batch_route == BatchRoute::Divert)
+    }
+
     /// Flushes the internal buffer by sending it as a `MSG_DATA` frame.
     fn flush_buffer(&mut self) -> io::Result<()> {
         if !self.buffer.is_empty() {
@@ -185,12 +235,10 @@ impl<W: Write> Write for MultiplexWriter<W> {
             return Ok(0);
         }
 
-        // upstream: io.c:write_buf() - tee pre-mux data to batch_fd
-        if let Some(ref recorder) = self.batch_recorder {
-            let mut rec = recorder
-                .lock()
-                .map_err(|_| io::Error::other("batch recorder lock poisoned"))?;
-            rec.write_all(buf)?;
+        // upstream: io.c:write_buf() - tee pre-mux data to batch_fd, or divert
+        // to it entirely when this stream is upstream's `f_xfer`.
+        if self.record_to_batch(std::iter::once(buf))? {
+            return Ok(buf.len());
         }
 
         if self.buffer.len() + buf.len() > self.buffer_size {
@@ -226,14 +274,10 @@ impl<W: Write> Write for MultiplexWriter<W> {
             return Ok(0);
         }
 
-        // upstream: io.c:write_buf() - tee pre-mux data to batch_fd
-        if let Some(ref recorder) = self.batch_recorder {
-            let mut rec = recorder
-                .lock()
-                .map_err(|_| io::Error::other("batch recorder lock poisoned"))?;
-            for buf in bufs {
-                rec.write_all(buf)?;
-            }
+        // upstream: io.c:write_buf() - tee pre-mux data to batch_fd, or divert
+        // to it entirely when this stream is upstream's `f_xfer`.
+        if self.record_to_batch(bufs.iter().map(|b| &b[..]))? {
+            return Ok(total_len);
         }
 
         // Fast path: if everything fits in remaining buffer space, copy all at once

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -13,7 +13,7 @@ use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::CompressionLevel;
 use protocol::MessageCode;
 
-use super::multiplex::MultiplexWriter;
+use super::multiplex::{BatchRoute, MultiplexWriter};
 use crate::compressed_writer::CompressedWriter;
 use crate::is_early_close_error;
 
@@ -338,6 +338,20 @@ impl<W: Write> ServerWriter<W> {
                 io::ErrorKind::InvalidInput,
                 "batch recorder requires multiplex mode",
             )),
+        }
+    }
+
+    /// Selects whether the attached batch recorder tees the stream or owns it.
+    ///
+    /// A no-op without an attached recorder (`Plain` / `Taken` can never carry
+    /// one), so the default transfer path stays byte-for-byte identical.
+    ///
+    /// upstream: `sender.c:217` - `f_xfer = write_batch < 0 ? batch_fd : f_out`
+    pub fn set_batch_route(&mut self, route: BatchRoute) {
+        match self {
+            Self::Multiplex(mux) => mux.batch_route = route,
+            Self::Compressed(compressed) => compressed.inner_mut().batch_route = route,
+            Self::Plain(_) | Self::Taken => {}
         }
     }
 

--- a/crates/transfer/src/writer/tests.rs
+++ b/crates/transfer/src/writer/tests.rs
@@ -7,7 +7,7 @@ use protocol::MessageCode;
 
 use super::counting::CountingWriter;
 use super::msg_info::MsgInfoSender;
-use super::multiplex::MultiplexWriter;
+use super::multiplex::{BatchRoute, MultiplexWriter};
 use super::server::ServerWriter;
 
 #[test]
@@ -611,6 +611,68 @@ fn multiplex_writer_no_recorder_still_works() {
     mux.flush().unwrap();
 
     assert!(!wire.is_empty());
+}
+
+/// upstream `sender.c:217` picks the token stream's destination:
+/// `f_xfer = write_batch < 0 ? batch_fd : f_out`. Under `--only-write-batch`
+/// the payload goes into the batch INSTEAD of the socket, which is what allows
+/// the remote receiver to run dry and read nothing. Teeing it as well would
+/// leave a stream nobody drains, stalling the transfer.
+#[test]
+fn batch_route_divert_writes_only_to_the_recorder() {
+    let mut wire = Vec::new();
+    let mut mux = MultiplexWriter::new(&mut wire);
+    let recorder_buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let recorder: Arc<Mutex<dyn Write + Send>> = recorder_buf.clone();
+    mux.batch_recorder = Some(recorder);
+
+    mux.write_all(b"header").unwrap();
+    mux.batch_route = BatchRoute::Divert;
+    mux.write_all(b"payload").unwrap();
+    let vectored = mux
+        .write_vectored(&[IoSlice::new(b"more"), IoSlice::new(b"tokens")])
+        .unwrap();
+    assert_eq!(
+        vectored, 10,
+        "a diverted vectored write consumes every byte"
+    );
+    mux.batch_route = BatchRoute::Tee;
+    mux.write_all(b"trailer").unwrap();
+    mux.flush().unwrap();
+
+    // The batch keeps the full stream in order: teed header, diverted payload,
+    // teed trailer - byte-identical to upstream's single batch_fd.
+    assert_eq!(
+        &*recorder_buf.lock().unwrap(),
+        b"headerpayloadmoretokenstrailer"
+    );
+    // The wire carries only the teed bytes, framed as MSG_DATA.
+    let mut framed = io::Cursor::new(&wire);
+    let mut on_wire = Vec::new();
+    while let Ok(frame) = protocol::recv_msg(&mut framed) {
+        assert_eq!(frame.code(), MessageCode::Data);
+        on_wire.extend_from_slice(frame.payload());
+    }
+    assert_eq!(
+        on_wire, b"headertrailer",
+        "diverted bytes must never reach the wire"
+    );
+}
+
+/// With no recorder attached the route is inert, so a stray `Divert` can never
+/// silently drop bytes on the floor.
+#[test]
+fn batch_route_divert_without_recorder_still_writes_the_wire() {
+    let mut wire = Vec::new();
+    let mut mux = MultiplexWriter::new(&mut wire);
+    mux.batch_route = BatchRoute::Divert;
+
+    mux.write_all(b"payload").unwrap();
+    mux.flush().unwrap();
+
+    let frame = protocol::recv_msg(&mut io::Cursor::new(&wire)).unwrap();
+    assert_eq!(frame.code(), MessageCode::Data);
+    assert_eq!(frame.payload(), b"payload");
 }
 
 #[test]

--- a/tests/only_write_batch_remote_push.rs
+++ b/tests/only_write_batch_remote_push.rs
@@ -1,0 +1,252 @@
+//! Regression tests for `--only-write-batch` on a remote-shell PUSH.
+//!
+//! `--only-write-batch` is documented as "like --write-batch but w/o updating
+//! destination". Upstream honours that on a remote push through two coupled
+//! mechanisms:
+//!
+//! ```c
+//! /* options.c:2850-2851, inside the am_sender block */
+//! if (write_batch < 0)
+//!     args[ac++] = "--only-write-batch=X";
+//!
+//! /* main.c:1839 - on the remote, the placeholder means write_batch < 0 */
+//! if (write_batch < 0)
+//!     dry_run = 1;
+//!
+//! /* sender.c:217 - the local sender records instead of sending */
+//! int f_xfer = write_batch < 0 ? batch_fd : f_out;
+//! ```
+//!
+//! The receiver therefore makes no destination updates (`receiver.c:811-817`
+//! logs the item and continues) and reads no payload, which is only safe
+//! because the sender diverted that payload into the batch file. Get one half
+//! without the other and the push either writes the destination or stalls on an
+//! unread token stream.
+//!
+//! The "remote" here is the oc-rsync binary itself, reached through a `--rsh`
+//! shim, so the whole push path is exercised: server-argument construction, the
+//! `--server` receiver's flag parsing, and the sender's stream routing.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Not Unix (the shim uses `/bin/sh`).
+
+#![cfg(unix)]
+
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(120);
+
+fn oc_rsync_binary() -> PathBuf {
+    if let Some(env_path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
+        let path = PathBuf::from(env_path);
+        if path.is_file() {
+            return path;
+        }
+    }
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    for profile in ["debug", "release", "dist"] {
+        let candidate = PathBuf::from(manifest_dir)
+            .join("target")
+            .join(profile)
+            .join("oc-rsync");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    PathBuf::from("oc-rsync")
+}
+
+/// Writes the `--rsh` shim.
+///
+/// oc-rsync invokes it with an SSH-style argv - `[<opts>..., <host>, <rsync
+/// path>, "--server", ...]`. The shim drops the options and the host, then
+/// execs the rest locally, giving a real two-process push over a pipe pair
+/// without needing an SSH server.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    let body = "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         # $1 is the host placeholder; the server command follows it.\n\
+         shift || true\n\
+         exec \"$@\"\n";
+    fs::write(&script, body).expect("write rsh shim");
+    let mut perms = fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).unwrap();
+    script
+}
+
+fn spawn_with_timeout(mut cmd: Command, timeout: Duration) -> Option<Output> {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().ok()? {
+            Some(_) => return child.wait_with_output().ok(),
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+/// Counts regular files anywhere under `dir` (absent dir counts as zero).
+fn count_files(dir: &Path) -> usize {
+    let mut count = 0usize;
+    let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let file_type = match entry.file_type() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+/// Lays out a source tree and returns `(tempdir, src, dest, batch)`.
+fn setup(name: &str) -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
+    let temp = tempfile::TempDir::new().expect("create temp dir");
+    let root = temp.path();
+    let src = root.join("src");
+    let dest = root.join("dest");
+    fs::create_dir_all(src.join("sub")).unwrap();
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(src.join("alpha.txt"), b"alpha payload for the batch\n").unwrap();
+    fs::write(src.join("sub/beta.txt"), vec![b'b'; 40_000]).unwrap();
+    let batch = root.join(format!("{name}.batch"));
+    (temp, src, dest, batch)
+}
+
+/// Runs a remote-shell push of `src/` into `dest/` with `batch_flag`.
+fn run_push(shim: &Path, binary: &Path, batch_flag: &str, src: &Path, dest: &Path) -> Output {
+    let mut cmd = Command::new(binary);
+    cmd.arg("-a")
+        .arg(batch_flag)
+        .arg("--rsh")
+        .arg(shim)
+        .arg("--rsync-path")
+        .arg(binary)
+        .arg(format!("{}/", src.display()))
+        .arg(format!("batchhost:{}/", dest.display()));
+    spawn_with_timeout(cmd, RUN_TIMEOUT).expect("push did not finish within the timeout")
+}
+
+/// The headline bug: a `--only-write-batch` push updated the remote
+/// destination. Upstream writes nothing there - `--only-write-batch=X` puts the
+/// remote receiver into `dry_run` (options.c:2850, main.c:1839) and the sender
+/// records the payload instead of transmitting it (sender.c:217).
+///
+/// Exit 0 is asserted separately from the file count because the two halves fail
+/// differently: forwarding the placeholder without diverting the stream leaves
+/// the remote refusing to read the tokens, which surfaces as exit 12.
+#[test]
+fn only_write_batch_push_leaves_the_destination_untouched() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let (temp, src, dest, batch) = setup("only");
+    let shim = write_rsh_shim(temp.path());
+
+    let output = run_push(
+        &shim,
+        &binary,
+        &format!("--only-write-batch={}", batch.display()),
+        &src,
+        &dest,
+    );
+
+    assert!(
+        output.status.success(),
+        "--only-write-batch push must exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        count_files(&dest),
+        0,
+        "--only-write-batch must not update the destination; found: {:?}",
+        fs::read_dir(&dest)
+            .map(|d| d.flatten().map(|e| e.path()).collect::<Vec<_>>())
+            .unwrap_or_default()
+    );
+    let recorded = fs::metadata(&batch).map(|m| m.len()).unwrap_or(0);
+    assert!(
+        recorded > 0,
+        "a non-empty batch file must still be produced at {}",
+        batch.display()
+    );
+}
+
+/// The divert is scoped to `--only-write-batch`. Plain `--write-batch`
+/// (upstream `write_batch > 0`) performs the transfer AND records it, so the
+/// shared recorder path must keep teeing onto the wire.
+#[test]
+fn write_batch_push_still_transfers_and_records() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let (temp, src, dest, batch) = setup("plain");
+    let shim = write_rsh_shim(temp.path());
+
+    let output = run_push(
+        &shim,
+        &binary,
+        &format!("--write-batch={}", batch.display()),
+        &src,
+        &dest,
+    );
+
+    assert!(
+        output.status.success(),
+        "--write-batch push must exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        count_files(&dest),
+        count_files(&src),
+        "--write-batch must still transfer every source file"
+    );
+    assert_eq!(
+        fs::read(dest.join("alpha.txt")).unwrap(),
+        fs::read(src.join("alpha.txt")).unwrap(),
+        "--write-batch destination content must match the source"
+    );
+    let recorded = fs::metadata(&batch).map(|m| m.len()).unwrap_or(0);
+    assert!(
+        recorded > 0,
+        "--write-batch must record a non-empty batch at {}",
+        batch.display()
+    );
+}

--- a/tests/only_write_batch_remote_push.rs
+++ b/tests/only_write_batch_remote_push.rs
@@ -34,9 +34,11 @@
 
 use std::env;
 use std::fs;
+use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use std::thread;
 use std::time::{Duration, Instant};
 
 const RUN_TIMEOUT: Duration = Duration::from_secs(120);
@@ -93,16 +95,38 @@ fn spawn_with_timeout(mut cmd: Command, timeout: Duration) -> Option<Output> {
         .stderr(Stdio::piped())
         .spawn()
         .ok()?;
+    // Drain both pipes on their own threads. Polling try_wait() while the pipes
+    // fill would deadlock: the child blocks writing into a full OS pipe buffer
+    // and therefore never exits. Draining also preserves the child's output so a
+    // real failure is reported instead of being swallowed by the timeout.
+    let mut child_stdout = child.stdout.take()?;
+    let mut child_stderr = child.stderr.take()?;
+    let stdout_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stdout.read_to_end(&mut buf);
+        buf
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stderr.read_to_end(&mut buf);
+        buf
+    });
     let deadline = Instant::now() + timeout;
     loop {
         match child.try_wait().ok()? {
-            Some(_) => return child.wait_with_output().ok(),
+            Some(status) => {
+                return Some(Output {
+                    status,
+                    stdout: stdout_reader.join().unwrap_or_default(),
+                    stderr: stderr_reader.join().unwrap_or_default(),
+                });
+            }
             None if Instant::now() >= deadline => {
                 let _ = child.kill();
                 let _ = child.wait();
                 return None;
             }
-            None => std::thread::sleep(Duration::from_millis(50)),
+            None => thread::sleep(Duration::from_millis(50)),
         }
     }
 }


### PR DESCRIPTION
## Summary
- --only-write-batch on a remote push updated the remote destination; upstream writes nothing (verified: upstream 0 files, oc 2)
- Emit the --only-write-batch=X placeholder in the sender's server args so the remote receiver runs dry (options.c:2850, main.c:1839)
- Divert the token stream into the batch instead of teeing it to the wire (sender.c:217 f_xfer = write_batch < 0 ? batch_fd : f_out), which also fixes the exit-12 stall once the remote stops reading tokens
- --write-batch (non-only) still transfers and records unchanged

## Test plan
- [ ] Remote push with --only-write-batch leaves the destination empty and exits 0
- [ ] A valid batch file is still produced
- [ ] --write-batch still transfers AND records (no regression to the shared path)
- [ ] Server args include --only-write-batch=X for the sender
- [ ] cargo fmt clean, clippy -D warnings clean, cargo check --workspace clean
