### PR TITLE
fix(daemon): stop the sender hanging on a per-file error

### DIFF
--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -104,6 +104,47 @@ impl GeneratorContext {
             .advance_to(TransferPhase::DeltaTransfer)
             .map_err(crate::fsm_error)?;
 
+        // upstream: main.c:968-974 do_server_sender() -
+        //   flist = send_file_list(f_out, argc, argv);
+        //   if (!flist || flist->used == 0) { io_end_buffering_in(0); exit_cleanup(0); }
+        //
+        // An empty file list means every requested path failed to be listed
+        // (missing source, unreadable directory, everything filtered out). The
+        // peer's client_run() mirrors this: with an empty list it skips do_recv()
+        // entirely (main.c:1379-1391), so it never sends an ndx, never sends
+        // NDX_DONE, and never joins the goodbye handshake - it just reports the
+        // io_error we already sent and waits in noop_io_until_death() for our FIN.
+        // Entering send_files() here would block forever reading an ndx the peer
+        // is never going to write. Returning now lets the caller tear the
+        // connection down, which is what releases the peer.
+        //
+        // Server-side only, exactly as upstream: a client-mode sender (push)
+        // runs send_files() unconditionally from client_run() (main.c:1343).
+        if file_count == 0 && !self.config.connection.client_mode {
+            // upstream: exit_cleanup(0) -> io_flush(FULL_FLUSH) before _exit.
+            writer.flush_all_pending()?;
+            self.pipeline
+                .advance_to(TransferPhase::Finalization)
+                .map_err(crate::fsm_error)?;
+            self.pipeline
+                .advance_to(TransferPhase::Complete)
+                .map_err(crate::fsm_error)?;
+            return Ok(GeneratorStats {
+                files_listed: 0,
+                flist_buildtime_ms: calculate_duration_ms(
+                    self.timing.flist_build_start,
+                    self.timing.flist_build_end,
+                ),
+                flist_xfertime_ms: calculate_duration_ms(
+                    self.timing.flist_xfer_start,
+                    self.timing.flist_xfer_end,
+                ),
+                flist_first_byte_latency: self.timing.flist_first_byte_latency,
+                io_error: self.io_error,
+                ..GeneratorStats::default()
+            });
+        }
+
         // INC_RECURSE sub-lists are sent lazily inside the loop via
         // SegmentScheduler, matching upstream sender.c:227,261 cadence.
         let transfer_result = {

--- a/src/bin/oc-rsync.rs
+++ b/src/bin/oc-rsync.rs
@@ -42,7 +42,14 @@ fn main() -> ExitCode {
     #[cfg(all(target_os = "windows", target_env = "gnu"))]
     windows_gnu_eh::force_link();
 
-    let mut stdout = io::stdout().lock();
-    let mut stderr = io::stderr().lock();
+    // Do NOT hold `StdoutLock`/`StderrLock` here. Both are process-wide
+    // reentrant locks owned by the acquiring thread. In TCP-daemon mode `main`
+    // parks in the accept loop for the process lifetime while each session runs
+    // on a spawned worker thread; a worker's first `println!`/`eprintln!` would
+    // then block forever on a lock `main` never releases. `Stdout`/`Stderr`
+    // themselves implement `Write` and lock per write call, which is what the
+    // daemon workers need.
+    let mut stdout = io::stdout();
+    let mut stderr = io::stderr();
     client::run_with(env::args_os(), &mut stdout, &mut stderr)
 }

--- a/tests/daemon_sender_per_file_error_no_hang.rs
+++ b/tests/daemon_sender_per_file_error_no_hang.rs
@@ -1,0 +1,408 @@
+//! Regression: a daemon sender must never hang on a per-file/per-path error.
+//!
+//! Upstream reports the failure, keeps going, and finishes with
+//! `RERR_PARTIAL` (23). Two independent daemon-only defects used to turn that
+//! into an unbounded hang, and each one hid behind the other:
+//!
+//! 1. `main()` held the process-wide `StdoutLock`/`StderrLock` for the whole
+//!    program. In TCP-daemon mode `main` then parked in the accept loop still
+//!    holding them while every session ran on a spawned worker thread, so the
+//!    first `eprintln!` on a worker - for example the `opendir` failure raised
+//!    from the flist walk - blocked forever on a lock that was never released.
+//! 2. The server sender entered `send_files()` even when the file list came
+//!    out empty. Upstream bails out first (`main.c:968-974`), because a peer
+//!    that received an empty list skips `do_recv()` entirely
+//!    (`main.c:1379-1391`): it never writes an ndx, so the sender's next
+//!    `read_ndx()` blocked until the peer's I/O timeout.
+//!
+//! Neither defect is reachable from a unit test: both need a real daemon
+//! process whose sessions run on worker threads while `main` is elsewhere. So
+//! these tests drive the shipped `oc-rsync` binary as both the daemon and the
+//! client, over a real socket, and assert that each trigger finishes inside a
+//! bounded deadline with exit code 23.
+//!
+//! One test per trigger, so a regression in either defect is reported on its
+//! own rather than being masked by whichever hang happens to fire first:
+//! - unreadable source file - `chmod 000` file, fails inside `send_files`.
+//! - unreadable source directory - `chmod 000` directory, fails inside the
+//!   flist walk, which is where the stdio-lock deadlock fired.
+//! - missing requested path - absent path, yields an empty file list, which is
+//!   where the `send_files` deadlock fired.
+//!
+//! Each trigger is pulled twice: once by our own client, and once by an
+//! upstream `rsync` client when a real 3.x binary is available. Both legs
+//! matter. Our client keeps reading after an empty file list, so only the
+//! upstream client - which skips its receive loop entirely and then waits in
+//! `noop_io_until_death()` for our FIN - exposes the second deadlock. Driving
+//! only our own binary would let a symmetric divergence hide the bug.
+//!
+//! Unix-only: the fault injection is POSIX DAC (`chmod 000`), which root
+//! bypasses and Windows does not implement the same way. The two permission
+//! triggers opt out under root; the missing-path trigger always runs.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Read};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// Upstream `RERR_PARTIAL`: some files were not transferred (`errcode.h`).
+const RERR_PARTIAL: i32 = 23;
+
+/// Wall-clock budget for one client run. The transfers here move a handful of
+/// tiny files, so anything approaching this bound is a hang, not slowness. It
+/// is deliberately well under upstream's own 60 s `noop_io_until_death()`
+/// fallback timeout, so a wedged daemon fails the assertion instead of being
+/// rescued by the peer's timeout.
+const CLIENT_DEADLINE: Duration = Duration::from_secs(45);
+
+/// How long to wait for the spawned daemon to bind its listening socket.
+const DAEMON_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Path to the binary under test, resolved by Cargo for integration tests.
+fn oc_rsync_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_oc-rsync")
+}
+
+/// Locates an upstream rsync 3.x client to pull with, if one is installed.
+///
+/// Candidates, in order: an explicit `OC_RSYNC_UPSTREAM_RSYNC` override, the
+/// binaries the interop harness installs under `target/interop`, then whatever
+/// `rsync` is on `PATH`. Each candidate must self-identify as `rsync version
+/// 3.x`, which rejects the `openrsync` shim macOS ships as `/usr/bin/rsync`
+/// (protocol 29, different client semantics).
+///
+/// Returns `None` when nothing suitable exists, in which case the caller skips
+/// that leg rather than failing - an upstream binary is an external resource.
+fn upstream_rsync_client() -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(explicit) = std::env::var_os("OC_RSYNC_UPSTREAM_RSYNC") {
+        candidates.push(PathBuf::from(explicit));
+    }
+    for version in ["3.4.4", "3.4.1", "3.1.3"] {
+        candidates.push(PathBuf::from(format!(
+            "target/interop/upstream-install/{version}/bin/rsync"
+        )));
+    }
+    candidates.push(PathBuf::from("rsync"));
+
+    candidates.into_iter().find(|candidate| {
+        Command::new(candidate)
+            .arg("--version")
+            .output()
+            .ok()
+            .and_then(|out| String::from_utf8(out.stdout).ok())
+            .is_some_and(|text| {
+                text.lines()
+                    .next()
+                    .is_some_and(|line| line.starts_with("rsync") && line.contains(" version 3."))
+            })
+    })
+}
+
+/// Reserves an ephemeral port by binding it and immediately releasing it.
+fn allocate_port() -> u16 {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+/// One end of a child's stdio, boxed so both pipes share a drain loop.
+enum Pipe {
+    Out(std::process::ChildStdout),
+    Err(std::process::ChildStderr),
+}
+
+impl Pipe {
+    fn into_reader(self) -> Box<dyn Read> {
+        match self {
+            Self::Out(out) => Box::new(out),
+            Self::Err(err) => Box::new(err),
+        }
+    }
+}
+
+/// A spawned `oc-rsync --daemon` process whose stdio is drained continuously.
+///
+/// Draining is not optional: an undrained pipe wedges the daemon once the OS
+/// buffer fills, which would masquerade as the very hang under test.
+struct Daemon {
+    child: Child,
+    port: u16,
+}
+
+impl Daemon {
+    fn spawn(config: &Path) -> Self {
+        let port = allocate_port();
+        let mut child = Command::new(oc_rsync_binary())
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--config")
+            .arg(config)
+            .arg("--port")
+            .arg(port.to_string())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn oc-rsync daemon");
+
+        for pipe in [
+            child.stdout.take().map(Pipe::Out),
+            child.stderr.take().map(Pipe::Err),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            thread::spawn(move || {
+                let mut sink = Vec::new();
+                let _ = pipe.into_reader().read_to_end(&mut sink);
+            });
+        }
+
+        let daemon = Self { child, port };
+        daemon.wait_until_listening();
+        daemon
+    }
+
+    /// Polls the listening socket until the daemon accepts connections.
+    fn wait_until_listening(&self) {
+        let target = SocketAddr::from((Ipv4Addr::LOCALHOST, self.port));
+        let deadline = Instant::now() + DAEMON_READY_TIMEOUT;
+        while Instant::now() < deadline {
+            if TcpStream::connect_timeout(&target, Duration::from_millis(250)).is_ok() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        panic!("daemon did not start listening on port {}", self.port);
+    }
+
+    fn url(&self, module: &str, path: &str) -> String {
+        format!("rsync://127.0.0.1:{}/{module}/{path}", self.port)
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Restores `0o755` on the poisoned paths so `TempDir` cleanup can succeed
+/// even when the test body panics.
+struct PermissionRestorer(Vec<PathBuf>);
+
+impl Drop for PermissionRestorer {
+    fn drop(&mut self) {
+        for path in &self.0 {
+            let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o755));
+        }
+    }
+}
+
+/// True when the effective uid is 0, which bypasses the DAC checks the two
+/// permission triggers rely on.
+fn running_as_root() -> bool {
+    // `id -u` keeps this test-only probe free of a libc dependency.
+    Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .is_some_and(|s| s.trim() == "0")
+}
+
+/// A read-only single-module daemon serving `module_root`.
+struct Fixture {
+    _root: TempDir,
+    daemon: Daemon,
+    dest: PathBuf,
+}
+
+impl Fixture {
+    fn new(root: TempDir, module: &str, module_root: &Path) -> Self {
+        let config = root.path().join("oc-rsyncd.conf");
+        fs::write(
+            &config,
+            format!(
+                "use chroot = no\n[{module}]\n    path = {}\n    read only = yes\n",
+                module_root.display()
+            ),
+        )
+        .expect("write daemon config");
+
+        let dest = root.path().join("dest");
+        fs::create_dir_all(&dest).expect("create dest");
+
+        Self {
+            daemon: Daemon::spawn(&config),
+            dest,
+            _root: root,
+        }
+    }
+}
+
+/// Runs one client pull and returns its exit code, failing the test if it does
+/// not finish inside [`CLIENT_DEADLINE`].
+///
+/// Both child pipes are drained on their own threads while we wait. Polling
+/// `try_wait()` without draining deadlocks the moment the child fills a pipe
+/// buffer, which would hang this harness for a reason unrelated to the bug
+/// under test.
+fn run_client_bounded(
+    client: &Path,
+    fixture: &Fixture,
+    module: &str,
+    path: &str,
+    label: &str,
+) -> i32 {
+    let mut child = Command::new(client)
+        .arg("-a")
+        .arg(fixture.daemon.url(module, path))
+        .arg(&fixture.dest)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn oc-rsync client");
+
+    let (tx, rx) = mpsc::channel::<(&'static str, String)>();
+    for (name, pipe) in [
+        ("stdout", child.stdout.take().map(Pipe::Out)),
+        ("stderr", child.stderr.take().map(Pipe::Err)),
+    ] {
+        let Some(pipe) = pipe else { continue };
+        let tx = tx.clone();
+        thread::spawn(move || {
+            let mut text = String::new();
+            for line in BufReader::new(pipe.into_reader())
+                .lines()
+                .map_while(Result::ok)
+            {
+                text.push_str(&line);
+                text.push('\n');
+            }
+            let _ = tx.send((name, text));
+        });
+    }
+    drop(tx);
+
+    let deadline = Instant::now() + CLIENT_DEADLINE;
+    let status = loop {
+        match child.try_wait().expect("poll client") {
+            Some(status) => break status,
+            None => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!(
+                        "{label}: daemon sender hung - client did not finish within {CLIENT_DEADLINE:?}"
+                    );
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+        }
+    };
+
+    for (name, text) in rx {
+        if !text.is_empty() {
+            eprintln!("{label} client {name}:\n{text}");
+        }
+    }
+
+    status
+        .code()
+        .unwrap_or_else(|| panic!("{label}: client terminated by signal instead of exiting"))
+}
+
+/// Pulls `module/path` with our client and, when available, with an upstream
+/// rsync client, asserting each run ends bounded with `RERR_PARTIAL`.
+fn assert_bounded_partial_transfer(fixture: &Fixture, module: &str, path: &str, label: &str) {
+    let mut clients: Vec<(String, PathBuf)> =
+        vec![("oc-rsync".to_owned(), PathBuf::from(oc_rsync_binary()))];
+    match upstream_rsync_client() {
+        Some(upstream) => clients.push(("upstream-rsync".to_owned(), upstream)),
+        None => eprintln!("skip upstream leg for {label}: no rsync 3.x client available"),
+    }
+
+    for (name, client) in clients {
+        let leg = format!("{label} via {name}");
+        let _ = fs::remove_dir_all(&fixture.dest);
+        fs::create_dir_all(&fixture.dest).expect("create dest");
+        let code = run_client_bounded(&client, fixture, module, path, &leg);
+        assert_eq!(
+            code, RERR_PARTIAL,
+            "{leg}: expected upstream RERR_PARTIAL after a per-file error, got {code}"
+        );
+    }
+}
+
+#[test]
+fn unreadable_source_file_reports_partial_transfer_without_hanging() {
+    // upstream: sender.c:383-400 reports the open failure, sends MSG_NO_SEND,
+    // and continues with the next ndx.
+    if running_as_root() {
+        eprintln!("skip: root bypasses the chmod 000 read denial");
+        return;
+    }
+
+    let root = TempDir::new().expect("tempdir");
+    let module_root = root.path().join("src");
+    fs::create_dir_all(&module_root).expect("create module root");
+    fs::write(module_root.join("good.txt"), b"ok\n").expect("write good.txt");
+    let bad = module_root.join("bad.txt");
+    fs::write(&bad, b"bad\n").expect("write bad.txt");
+    let _restore = PermissionRestorer(vec![bad.clone()]);
+    fs::set_permissions(&bad, fs::Permissions::from_mode(0o000)).expect("chmod 000 bad.txt");
+
+    let fixture = Fixture::new(root, "mod", &module_root);
+    assert_bounded_partial_transfer(&fixture, "mod", "", "unreadable-file");
+}
+
+#[test]
+fn unreadable_source_directory_reports_partial_transfer_without_hanging() {
+    // Deadlock 1: the flist walk's `eprintln!` for the failed directory ran on
+    // a daemon worker thread and blocked on the `StderrLock` that `main` held
+    // in the accept loop.
+    if running_as_root() {
+        eprintln!("skip: root bypasses the chmod 000 traversal denial");
+        return;
+    }
+
+    let root = TempDir::new().expect("tempdir");
+    let module_root = root.path().join("src");
+    let locked = module_root.join("locked");
+    fs::create_dir_all(&locked).expect("create module root");
+    fs::write(module_root.join("good.txt"), b"ok\n").expect("write good.txt");
+    fs::write(locked.join("inner.txt"), b"inner\n").expect("write inner.txt");
+    let _restore = PermissionRestorer(vec![locked.clone()]);
+    fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).expect("chmod 000 locked");
+
+    let fixture = Fixture::new(root, "mod", &module_root);
+    assert_bounded_partial_transfer(&fixture, "mod", "", "unreadable-dir");
+}
+
+#[test]
+fn missing_requested_path_reports_partial_transfer_without_hanging() {
+    // Deadlock 2: the requested path does not exist, so the file list is empty
+    // and the peer never enters its receive loop. upstream main.c:968-974
+    // returns from the server sender instead of calling send_files().
+    let root = TempDir::new().expect("tempdir");
+    let module_root = root.path().join("src");
+    fs::create_dir_all(&module_root).expect("create module root");
+    fs::write(module_root.join("good.txt"), b"ok\n").expect("write good.txt");
+
+    let fixture = Fixture::new(root, "mod", &module_root);
+    assert_bounded_partial_transfer(&fixture, "mod", "no-such-entry", "missing-path");
+}


### PR DESCRIPTION
## Summary

A daemon sender that hit a per-file or per-path error hung forever instead of reporting it, continuing, and exiting 23 the way upstream does. **There were two stacked deadlocks**, and fixing either one alone still left a hang.

### Deadlock 1 - process-wide stdio lock (`src/bin/oc-rsync.rs`)

`main` took `io::stdout().lock()` and `io::stderr().lock()` and held both `StdoutLock`/`StderrLock` for the lifetime of the process. In TCP-daemon mode `main` then parks in the accept loop **still holding them**, while every session runs on a spawned worker thread. The first `println!`/`eprintln!` on a worker therefore blocked on a reentrant lock that was never released. Sampling a hung daemon caught it exactly there:

```
transfer::generator::file_list::walk::walk_path_with_metadata
  -> std::io::stdio::_eprint
    -> std::io::stdio::Stderr::lock
      -> _pthread_mutex_firstfit_lock_wait     (FOREVER)
```

Fix: use `io::stdout()` / `io::stderr()`. Both implement `Write` and lock per write call; `client::run_with<I, Out: Write, Err: Write>` accepts them unchanged. 122 `eprintln!`/`println!` sites are reachable from a daemon session and `stdout` was equally poisoned, so daemon-side `--out-format`/itemize would have wedged identically.

### Deadlock 2 - server sender entered `send_files()` on an empty file list (`crates/transfer/src/generator/transfer/orchestrator.rs`)

Upstream returns before `send_files()` when the file list came out empty:

```c
/* main.c:968-974 do_server_sender() */
flist = send_file_list(f_out,argc,argv);
if (!flist || flist->used == 0) {
        /* Make sure input buffering is off so we can't hang in noop_io_until_death(). */
        io_end_buffering_in(0);
        exit_cleanup(0);
}
```

It has to, because the peer mirrors it: a client handed an empty list skips `do_recv()` entirely (`main.c:1379-1391`), so it never writes an ndx, never sends `NDX_DONE`, and never joins the goodbye handshake. It reports the `io_error` already carried in the flist end marker and then sits in `noop_io_until_death()` waiting for our FIN. We instead called `send_files()` and blocked in `read_ndx()` on a byte the peer was never going to write. Sampling a hung daemon after fixing deadlock 1:

```
generator::transfer::orchestrator::run -> run_transfer_loop -> read_ndx
 -> ServerReader::read -> ... -> daemon::DrainingReader::read
  -> mpsc::Receiver::recv -> thread::park             (FOREVER)
```

Fix: mirror the upstream bail-out on the server side. A client-mode push still calls `send_files()` unconditionally, exactly as upstream does at `main.c:1343`.

## Before / after

Real `oc-rsync --daemon` on a loopback port, pulled by upstream rsync 3.4.4, `timeout 30`; 124 = still hanging, 23 = upstream's `RERR_PARTIAL`.

| Trigger | before | fix 1 only | both fixes | upstream 3.4.4 |
|---|---|---|---|---|
| unreadable source file (`chmod 000` file) | 23 | 23 | **23** | 23 |
| unreadable source directory (`chmod 000` dir) | **124** | 23 | **23** | 23 |
| missing requested path | **124** | **124** | **23** | 23 |

Both deadlocks are real and independent: the directory trigger needs fix 1, the missing-path trigger needs fix 2, and only both together clear all three.

## On `daemon::DrainingReader`

`DrainingReader` and its `daemon-delta-drain` thread looked like the obvious suspect for deadlock 2 - it is where the hung stack parks, and it is a daemon-only indirection with no upstream counterpart. It is not the cause, and it is load-bearing:

- **Ruled out empirically.** With the delta drain disabled entirely, so the daemon session reads the socket clone directly, the missing-path trigger still hangs identically (exit 124). At hang time the drain thread was alive and healthy in its `recvfrom` poll loop, and the peer was alive in `noop_io_until_death()`. The park was a correct blocking read of a socket on which the peer had, correctly, stopped speaking. Removing the layer would not have fixed anything here.
- **What it bears.** It was added for the full-duplex write-write wedge on the daemon's single socket: our delta path writes a batch of requests and then blocks reading the reply with no interleaved drain, so once both ~128 KB kernel buffers fill neither direction can move. SSH/stdio does not wedge because each direction has its own pipe buffer to a separate process.
- **How upstream avoids needing it.** Upstream is not simply "reading the socket directly": it sets **both fds non-blocking** (`main.c:1259-1260` `start_server`, `main.c:1293-1294` `client_run`) and drives all I/O through `perform_io()`'s `select()` loop, which drains readable input whenever it is trying to write - `io.c:881-888`, *"We need to help prevent deadlock by doing what reading we can whenever we are here trying to write."* `DrainingReader` is our stand-in for that interleaving guarantee.

So the divergence is real, but converging on the upstream shape means porting `perform_io` - non-blocking fds plus a single select-driven full-duplex loop across the transfer crate - not deleting a wrapper. That is a redesign, out of scope for a hang fix, and tracked in #6946. Nothing in this PR touches the drain layer.

## Test

`tests/daemon_sender_per_file_error_no_hang.rs`, one test per trigger so a regression in either deadlock is reported on its own instead of being masked by whichever hang fires first. Each test spawns the real `oc-rsync` binary as a daemon on an ephemeral port and pulls the module, asserting the client exits 23 inside a bounded deadline (the client is SIGKILLed and the test panics if it overruns).

Neither deadlock is reachable from a unit test: both need a real daemon process whose sessions run on worker threads while `main` is elsewhere.

Each trigger is pulled twice - by our own client, and by an upstream rsync 3.x client when one is installed. Both legs are needed: our client keeps reading after an empty file list, so only the upstream client, which skips its receive loop and then waits for our FIN, exposes deadlock 2. Driving only our own binary would let that symmetric divergence hide the bug. The upstream probe rejects the `openrsync` shim macOS ships as `/usr/bin/rsync` and skips the leg with a message when no rsync 3.x is present.

Verified the test fails on the parent commit (directory + missing-path triggers time out) and with fix 1 alone (missing-path times out via the upstream leg), and passes with both.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets --no-deps -D warnings`
- `cargo test -p transfer --all-features` (2136 lib tests), `cargo test -p daemon --all-features --lib`
- `cargo test --test exit_codes --test integration_daemon --test integration_rsync_protocol --test integration_server_delta`
- `cargo test --test daemon_sender_per_file_error_no_hang`

## Out of scope

Two upstream-fidelity gaps surfaced while confirming the exit codes and are left for separate PRs:

- The daemon reports the failed `opendir` on its own stderr instead of forwarding it to the client as a multiplexed error, so the client sees exit 23 with no message for the unreadable-directory trigger.
- Our client, unlike upstream's, still enters its receive loop after an empty file list and reports `failed to fill whole buffer` instead of printing the summary and stopping (`main.c:1379-1391`).
