### PR TITLE
fix(transfer): stop --dry-run creating destination directories

### DIFF
--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -92,7 +92,12 @@ impl ReceiverContext {
                 } else {
                     // upstream: generator.c:1454 - delete_item(fname, ...,
                     // DEL_FOR_DIR) removes the conflicting symlink before mkdir.
-                    fs::remove_file(dir_path)?;
+                    // upstream: syscall.c do_unlink() - `if (dry_run) return 0;`,
+                    // so delete_item() reports success without unlinking and the
+                    // caller still proceeds as if the destination became absent.
+                    if !self.config.flags.skip_dest_writes() {
+                        fs::remove_file(dir_path)?;
+                    }
                     Ok(DirDestination::ReplacedSymlink)
                 }
             }
@@ -597,11 +602,19 @@ impl ReceiverContext {
     /// `set_file_attrs` (`generator.c:1503`). Only returns `Err` for
     /// unrecoverable errors.
     ///
+    /// Under `--dry-run` / `--list-only` the destination is left untouched: no
+    /// `mkdir`, no symlink removal, no metadata. The classification, the
+    /// returned `iflags`, and the `is_new` flag that drives the caller's
+    /// created-directory tally are still computed, so a dry run reports exactly
+    /// what a real run would create.
+    ///
     /// # Upstream Reference
     ///
     /// - `generator.c:1432` - `recv_generator()` creates directories
     /// - `generator.c:1484-1487` - retry `mkdir` after `make_path()`
     /// - `generator.c:1480-1483` - `itemize()` before metadata application
+    /// - `syscall.c:1010-1016` - `do_mkdir()` is a no-op under `dry_run`, so
+    ///   `itemize()` and the receiver's `created_dirs` tally still run
     pub(in crate::receiver) fn create_directory_incremental(
         &self,
         dest_dir: &Path,
@@ -690,7 +703,16 @@ impl ReceiverContext {
         } else {
             self.existing_dir_iflags(entry, &dir_path)
         };
-        if is_new {
+        // upstream: syscall.c:1010-1016 - `do_mkdir()` (reached from
+        // `do_mkdir_at()`) returns 0 without touching the filesystem when
+        // `dry_run` is set, and `rsync.c:498-499 set_file_attrs()` returns early
+        // the same way, while `generator.c:1480-1483 itemize()` still runs above.
+        // A dry run therefore reports the directory it *would* create - itemize
+        // row and created-dir tally intact - without creating it. Placed after
+        // the classification and the `iflags` computation so both survive; an
+        // early return here would silence output upstream still prints.
+        let skip_dest_writes = self.config.flags.skip_dest_writes();
+        if is_new && !skip_dest_writes {
             #[cfg(unix)]
             let create_result = fast_io::mkdirat_via_sandbox_or_fallback(
                 sandbox,
@@ -736,9 +758,60 @@ impl ReceiverContext {
             }
         }
 
-        // Apply metadata (non-fatal errors)
-        // Skip the stat inside apply_metadata_from_file_entry: the
-        // directory was just created, so pass None to apply unconditionally.
+        // upstream: rsync.c:498-499 - `set_file_attrs()` returns early under
+        // dry_run, so no metadata, xattrs, or ACLs reach the destination.
+        if !skip_dest_writes {
+            self.apply_incremental_dir_metadata(
+                &dir_path,
+                entry,
+                metadata_opts,
+                is_new,
+                acl_cache,
+                acl_id_map,
+            );
+        }
+
+        // Under `-i`/`-vi` the itemize row already carries the directory name
+        // (upstream `-vi` uses `%i %n`), so the bare `-v` name is suppressed to
+        // avoid a duplicate line; only plain `-v` emits it.
+        if self.config.flags.verbose
+            && self.config.connection.client_mode
+            && !self.should_emit_itemize()
+        {
+            if relative_path.as_os_str() == "." {
+                info_log!(Name, 1, "./");
+            } else {
+                info_log!(Name, 1, "{}/", relative_path.display());
+            }
+        }
+
+        Ok(Some((is_new, iflags)))
+    }
+
+    /// Applies metadata, xattrs, and cached ACLs to one directory created or
+    /// reused by [`Self::create_directory_incremental`].
+    ///
+    /// Every failure is non-fatal and reported as a verbose warning, mirroring
+    /// upstream's `set_file_attrs()` error handling: the transfer continues with
+    /// the remaining entries.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1503` - `set_file_attrs()` after the directory mkdir
+    /// - `generator.c:1465` - `dest_mode(..., statret == 0)` keeps an existing
+    ///   directory's own permission bits when `--perms` is not in effect
+    /// - `generator.c:1512-1520` - transient `u+rwx` grant, undone by
+    ///   [`Self::touch_up_dirs`]
+    /// - `xattrs.c:set_xattr()` - xattrs are applied after metadata
+    fn apply_incremental_dir_metadata(
+        &self,
+        dir_path: &Path,
+        entry: &FileEntry,
+        metadata_opts: &MetadataOptions,
+        is_new: bool,
+        acl_cache: Option<&AclCache>,
+        acl_id_map: Option<&AclIdMapper>,
+    ) {
         // upstream: generator.c:1512-1520 - grant a transient u+rwx to a
         // read-only directory so files can be written into it; the real mode
         // is restored in touch_up_dirs.
@@ -764,10 +837,10 @@ impl ReceiverContext {
         let pre_transfer = if is_new {
             None
         } else {
-            fs::metadata(&dir_path).ok()
+            fs::metadata(dir_path).ok()
         };
         if let Err(e) = apply_metadata_with_pre_transfer_stat(
-            &dir_path,
+            dir_path,
             apply_entry,
             metadata_opts,
             None,
@@ -788,8 +861,7 @@ impl ReceiverContext {
                 .xattr_name_filter()
                 .map(|set| move |name: &str| set.xattr_name_allowed(name));
             let filter_ref = filter.as_ref().map(|f| f as &dyn Fn(&str) -> bool);
-            if let Err(e) =
-                metadata::apply_xattrs_from_list(&dir_path, xattr_list, true, filter_ref)
+            if let Err(e) = metadata::apply_xattrs_from_list(dir_path, xattr_list, true, filter_ref)
             {
                 if self.config.flags.verbose && self.config.connection.client_mode {
                     info_log!(
@@ -803,9 +875,7 @@ impl ReceiverContext {
             }
         }
 
-        // Apply cached ACLs after metadata (non-fatal errors)
-        if let Err(e) =
-            apply_acls_from_receiver_cache(&dir_path, entry, acl_cache, acl_id_map, true)
+        if let Err(e) = apply_acls_from_receiver_cache(dir_path, entry, acl_cache, acl_id_map, true)
         {
             if self.config.flags.verbose && self.config.connection.client_mode {
                 info_log!(
@@ -817,22 +887,6 @@ impl ReceiverContext {
                 );
             }
         }
-
-        // Under `-i`/`-vi` the itemize row already carries the directory name
-        // (upstream `-vi` uses `%i %n`), so the bare `-v` name is suppressed to
-        // avoid a duplicate line; only plain `-v` emits it.
-        if self.config.flags.verbose
-            && self.config.connection.client_mode
-            && !self.should_emit_itemize()
-        {
-            if relative_path.as_os_str() == "." {
-                info_log!(Name, 1, "./");
-            } else {
-                info_log!(Name, 1, "{}/", relative_path.display());
-            }
-        }
-
-        Ok(Some((is_new, iflags)))
     }
 
     /// Restores directory permissions and mtimes after all file transfers

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -511,4 +511,101 @@ mod itemize_order_tests {
             rows[3].1
         );
     }
+
+    /// A `--dry-run` receive must report the directory it *would* create without
+    /// creating it: no `mkdir` on the destination, but the `cd+++++++++` itemize
+    /// row and the created-directory tally are still produced.
+    ///
+    /// WHY all three assertions: upstream suppresses only the syscall, never the
+    /// reporting. `syscall.c:1010-1016 do_mkdir()` is `if (dry_run) return 0;`
+    /// and `rsync.c:498-499 set_file_attrs()` returns early, while
+    /// `generator.c:1480-1483 itemize()` and the receiver's `created_dirs`
+    /// counter (`receiver.c:732-737`) run unconditionally. Asserting only the
+    /// absent directory would let a future early-return silence output upstream
+    /// prints, trading one fidelity bug for another; asserting only the row
+    /// would let the mkdir come back.
+    ///
+    /// `create_directory_incremental` had no `skip_dest_writes()` guard at all,
+    /// unlike its non-incremental sibling `create_directories`, so a plain `-n`
+    /// on this driver (`incremental-flist`, the default feature set) mutated the
+    /// destination.
+    #[test]
+    fn dry_run_reports_the_directory_without_creating_it() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+
+        let hs = handshake();
+        let mut config = itemize_client_config();
+        config.flags.dry_run = true;
+        let mut ctx = ReceiverContext::new_for_test(&hs, config);
+        ctx.defer_itemize = true;
+        ctx.file_list = vec![
+            FileEntry::new_directory("newdir".into(), 0o755),
+            FileEntry::new_file("newdir/f1".into(), 5, 0o644),
+        ];
+
+        let opts = metadata::MetadataOptions::default();
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+        let mut stats = TransferStats::default();
+        let mut failed_dirs = FailedDirectories::new();
+
+        // Mirror the directory pass of `run_pipelined_incremental` exactly: the
+        // itemize row and the created tally are the caller's bookkeeping, so a
+        // guard placed too early in the callee is only observable from here.
+        for (flist_idx, file_entry) in ctx.file_list.clone().iter().enumerate() {
+            if !file_entry.is_dir() {
+                continue;
+            }
+            let result = ctx
+                .create_directory_incremental(
+                    dest,
+                    file_entry,
+                    &opts,
+                    &mut failed_dirs,
+                    None,
+                    None,
+                    #[cfg(unix)]
+                    None,
+                )
+                .expect("create_directory_incremental succeeds");
+            let Some((is_new, iflags_raw)) = result else {
+                panic!("a dry run must still classify the directory, not skip it");
+            };
+            if is_new {
+                stats.directories_created += 1;
+                ctx.record_created(file_entry.mode());
+            }
+            let iflags = crate::generator::ItemFlags::from_raw(iflags_raw);
+            let _ = ctx.emit_or_record_itemize(&mut writer, flist_idx, &iflags, file_entry);
+        }
+
+        assert!(
+            !dest.join("newdir").exists(),
+            "--dry-run must not create {} on the destination",
+            dest.join("newdir").display()
+        );
+
+        let rows: Vec<String> = ctx
+            .itemize_rows
+            .borrow()
+            .values()
+            .map(|lines| lines[0].clone())
+            .collect();
+        assert_eq!(rows.len(), 1, "exactly one directory row: {rows:?}");
+        assert!(
+            rows[0].starts_with("cd+++++++++") && rows[0].contains("newdir"),
+            "the -n itemize row for the would-be directory must survive: {:?}",
+            rows[0]
+        );
+
+        assert_eq!(
+            stats.directories_created, 1,
+            "--dry-run must still count the directory it would create"
+        );
+        assert_eq!(
+            ctx.created_stats.get().dirs,
+            1,
+            "the created-directories stat feeding \"Number of created files\" must survive"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`--dry-run` mutated the destination: every new source subdirectory was `mkdir`'d on the receiving side, its metadata/xattrs/ACLs applied, and a conflicting destination symlink unlinked.

`crates/transfer/src/receiver/directory/creation.rs::create_directory_incremental` had **no** `skip_dest_writes()` guard, unlike its non-incremental sibling `create_directories` (which early-returns at the top of the function). That function is the directory pass of `run_pipelined_incremental`, which is the driver whenever the `incremental-flist` feature is on - and `incremental-flist` is in `transfer`'s **default** feature set, so it is on for every real build and for any `--all-features` workspace test run.

The bug is invisible with the feature off: the root package declares `transfer = { default-features = false }`, so `cargo test -p bin` takes `run_pipelined`, whose guard has been correct all along.

## Measured before / after

Scenario: `-a -n -i --stats` over a remote-shell shim, source contains a new subdirectory `sub/`, destination exists and is empty. `oc-rsync` built with `--features transfer/incremental-flist`. Reference binary: upstream rsync 3.4.4, protocol 32.

### Directories created on disk

| run | dest tree after `-n` | exit |
|---|---|---|
| oc **before**, push | `dest/`, **`dest/sub/`** | 0 |
| oc **after**, push | `dest/` | 0 |
| upstream 3.4.4, push | `dest/` | 0 |
| oc **before**, pull | `dest/`, **`dest/sub/`** | 0 |
| oc **after**, pull | `dest/` | 0 |
| upstream 3.4.4, pull | `dest/` | 0 |

### Itemize rows and stats are preserved

The guard sits *after* the destination classification and the `iflags` computation, so nothing that upstream still prints is silenced. On a `-ni` pull the stdout is **byte-identical before and after** - only the on-disk side effect is gone:

```
oc BEFORE (incremental ON), -n -i pull      oc AFTER (incremental ON), -n -i pull
------------------------------------        ------------------------------------
.d..t...... ./                              .d..t...... ./
cd+++++++++ sub/                            cd+++++++++ sub/
Number of created files: 1 (dir: 1)         Number of created files: 1 (dir: 1)
dest tree: dest/, dest/sub/   <-- BUG       dest tree: dest/
exit=0                                      exit=0
```

`cd+++++++++ sub/` and `Number of created files: 1 (dir: 1)` both match upstream 3.4.4, which prints the same row and counts the same directory.

Push-direction stdout is likewise unchanged by this commit (`<f......... alpha.txt`, `<f......... sub/beta.txt`, `Number of created files: 0`, exit 0, before and after).

## Why the guard is placed where it is

Upstream suppresses only the syscall, never the reporting:

- `syscall.c:1010-1016` - `int do_mkdir(...) { if (dry_run) return 0; ... }`, reached through `do_mkdir_at()`
- `syscall.c` `do_unlink()` - same shape, so `delete_item(..., DEL_FOR_DIR)` reports success without unlinking and `recv_generator` proceeds as if the destination became absent
- `rsync.c:498-499` - `set_file_attrs()` returns 1 immediately under `dry_run`
- `generator.c:1480-1483` - `itemize()` runs *before* the mkdir, unconditionally
- `receiver.c:732-737` - `stats.created_dirs++` under the `iflags & ITEM_IS_NEW` guard, independent of `-i`

So the fix mirrors `create_directories`' *intent* (suppress destination writes) but not its *placement*: `create_directories` can early-return at the top because the non-incremental driver reconstructs the dry-run itemize rows separately in `record_dry_run_itemize`. The incremental driver has no such second pass - its dir rows and its `directories_created` / `created_stats` tally come straight out of this function's return value - so an early return here would silence output upstream prints, trading one fidelity bug for another. The guard therefore wraps the three mutating sites only:

1. `fs::remove_file` inside `classify_dir_destination` (shared helper; the other caller early-returns before reaching it, so behaviour there is unchanged)
2. the `mkdir` / `create_dir_all` block
3. the metadata + xattr + ACL application, extracted into a private `apply_incremental_dir_metadata` helper so it can be skipped as a unit rather than reindented

`--list-only` rides the same `skip_dest_writes()` predicate and stops writing the destination too.

## Test

`dry_run_reports_the_directory_without_creating_it` in `crates/transfer/src/receiver/transfer/pipelined_incremental.rs` - lives in the `transfer` crate, whose own default features include `incremental-flist`, so it always exercises the affected path. It mirrors the driver's directory pass and asserts all three properties:

1. the destination directory does **not** exist on disk;
2. the `cd+++++++++` itemize row **is** still recorded;
3. `directories_created` and `created_stats.dirs` still count it.

Asserting only (1) would let a future early-return silence the row undetected; asserting only (2)/(3) would let the mkdir come back. Verified the test fails on the pre-fix code (`--dry-run must not create .../newdir on the destination`) and passes after.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- `cargo test -p transfer --all-features` (lib + all integration targets) - green
- manual oc-vs-upstream-3.4.4 comparison above, both push and pull

## Related divergences found while here (not fixed, filed for follow-up)

Auditing the two dispatch ladders for the drift class that #6944 fixed turned up two **pre-existing** dry-run reporting gaps. Neither is a destination mutation and neither is introduced or changed by this commit:

1. `run_pipelined_incremental` never calls `record_dry_run_itemize`, so a `-ni` run on the incremental driver emits directory rows but no regular-file or symlink rows (`>f+++++++++ alpha.txt` is missing; upstream prints it). `run_pipelined` gets these from `record_dry_run_itemize`.
2. `run_pipelined` (feature off) prints the full row set but reports `Number of created files: 0` under `-n`; upstream reports `3 (reg: 2, dir: 1)`. The non-incremental dry-run path records itemize rows without the matching `record_created` calls.

Both ladders are also missing the `<f+++++++++` / created-file counts on a push dry run.
