### PR TITLE
fix(transfer): stop --only-write-batch writing dest on a pull

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -153,6 +153,7 @@ pub(crate) fn build_server_config_for_receiver(
     // existing mode while the local copy executor honoured -E.
     server_config.flags.preserve_executability = config.preserve_executability();
 
+    flags::apply_only_write_batch_for_receiver(config, &mut server_config);
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
 }

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -649,6 +649,7 @@ fn build_server_config_for_receiver(
     // existing mode while the local copy executor honoured -E.
     server_config.flags.preserve_executability = config.preserve_executability();
 
+    flags::apply_only_write_batch_for_receiver(config, &mut server_config);
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
 }

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -421,6 +421,40 @@ pub(crate) fn apply_only_write_batch_for_sender(
     server_config.flags.only_write_batch = config.only_write_batch();
 }
 
+/// Carries `--only-write-batch` onto the LOCAL receiver's config on a PULL.
+///
+/// On a pull the local client IS the receiver, and upstream never forwards the
+/// option to the remote sender (`server_options()` emits the `X` placeholder
+/// inside its `am_sender` block, options.c:2850). Instead `main.c:1839` turns
+/// `write_batch < 0` into `dry_run = 1` on this side - suppressing every
+/// filesystem mutation via the `do_mkdir`/`do_open`/`do_unlink` guards - while
+/// `do_xfers` stays 1 (it was computed before that assignment), so the remote
+/// sender is an ordinary one that still streams sum head, delta and file
+/// checksum. The receiver logs the item and calls `discard_receive_data()` to
+/// drain that stream without writing anything (receiver.c:811-817).
+///
+/// Both flags are needed: `only_write_batch` selects the drain-and-discard loop
+/// (which is checked ahead of `dry_run` in the receiver's dispatch), and
+/// `dry_run` drives `TransferFlags::skip_dest_writes()` so no directory,
+/// symlink, special file or deletion is applied either. Without this the pull
+/// updated the destination in full, contradicting "like --write-batch but w/o
+/// updating destination".
+///
+/// # Upstream Reference
+///
+/// - `main.c:1839` - `if (write_batch < 0) dry_run = 1`
+/// - `options.c:2850-2851` - placeholder forwarded on a push only
+/// - `receiver.c:811-817` - log the item, `discard_receive_data()`, no write
+pub(crate) fn apply_only_write_batch_for_receiver(
+    config: &ClientConfig,
+    server_config: &mut ServerConfig,
+) {
+    if config.only_write_batch() {
+        server_config.flags.only_write_batch = true;
+        server_config.flags.dry_run = true;
+    }
+}
+
 /// Applies common server flags from client configuration to a server config.
 ///
 /// Sets the fields that are shared across both SSH and daemon transfer paths

--- a/crates/core/src/client/remote/ssh_transfer/server_config.rs
+++ b/crates/core/src/client/remote/ssh_transfer/server_config.rs
@@ -187,6 +187,7 @@ pub(in crate::client::remote) fn build_server_config_for_receiver(
     // custom `--out-format` carrying `%i`; false for a `%i`-less template.
     server_config.flags.info_flags.out_format_forwards_i = config.out_format_forwards_i();
 
+    flags::apply_only_write_batch_for_receiver(config, &mut server_config);
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
 }

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -641,18 +641,30 @@ impl ReceiverContext {
         Ok(())
     }
 
-    /// Server-receiver loop for `--only-write-batch=X` (upstream `write_batch
-    /// < 0`).
+    /// Receiver loop for `--only-write-batch=X` (upstream `write_batch < 0`).
     ///
     /// Unlike [`run_dry_run_loop`](Self::run_dry_run_loop), the generator sends
     /// REAL block checksums (a full sum head + signature per file), because
     /// upstream forces `dry_run = 1` only after `do_xfers` is computed
     /// (main.c:1839), so `do_xfers` stays 1 and the sender needs the checksums
-    /// to build its batch. The push sender writes each delta to its own batch
-    /// fd rather than the wire (sender.c:217 `f_xfer = write_batch < 0 ?
-    /// batch_fd : f_out`), so this loop reads only the bare NDX+attrs echo the
-    /// sender emits via `write_ndx_and_attrs(f_out, ...)` (sender.c:442) and
-    /// writes nothing to the destination.
+    /// to build its batch. Nothing is written to the destination either way -
+    /// upstream's `write_batch < 0` arm logs the item and `continue`s
+    /// (receiver.c:811-817) - but where the sender's delta goes differs by
+    /// direction, and so does what this loop must read back:
+    ///
+    /// - PUSH (this side is the remote server receiver, `am_server`): the
+    ///   client sender diverted its token stream into its own batch fd
+    ///   (sender.c:217 `f_xfer = write_batch < 0 ? batch_fd : f_out`), so only
+    ///   the bare NDX+attrs echo from `write_ndx_and_attrs(f_out, ...)`
+    ///   (sender.c:442) reaches the wire. Reading further would block forever.
+    /// - PULL (this side is the local client receiver, `!am_server`): upstream
+    ///   never forwards the flag to the remote sender (options.c:2850 sits in
+    ///   the `am_sender` block), so that sender is an ordinary one writing sum
+    ///   head + delta + file checksum onto the wire. Upstream drains it with
+    ///   `discard_receive_data()` (receiver.c:813-814); skipping the read would
+    ///   desync the connection - the next NDX read would parse delta bytes as a
+    ///   frame header. The batch is recorded by the local tee on the read side
+    ///   (io.c `write_batch_monitor_in`), so the stream must actually flow.
     ///
     /// Requests are sent one file at a time, flushing before each echo read, so
     /// there is no risk of a buffer-fill deadlock against a large signature.
@@ -661,7 +673,9 @@ impl ReceiverContext {
     ///
     /// - `main.c:1839` - `if (write_batch < 0) dry_run = 1` (do_xfers stays 1)
     /// - `sender.c:442-443` - `write_ndx_and_attrs(f_out); write_sum_head(f_xfer)`
-    /// - `receiver.c:811-817` - `write_batch < 0` path: log, no dest write
+    /// - `receiver.c:811-817` - `write_batch < 0`: log, `if (!am_server)`
+    ///   `discard_receive_data()`, no dest write
+    /// - `receiver.c:524-527` - `discard_receive_data()`
     pub(in crate::receiver) fn run_only_write_batch_loop<
         R: Read,
         W: Write + crate::writer::MsgInfoSender + ?Sized,
@@ -708,6 +722,28 @@ impl ReceiverContext {
             append_verify: self.config.flags.append_verify,
         };
 
+        // upstream: receiver.c:813 `if (!am_server) discard_receive_data(...)`.
+        // `client_mode` is oc's `!am_server`, so only a pull drains a delta.
+        let discard_sender_data = self.config.connection.client_mode;
+        // upstream: token.c keeps one decompression context for the whole
+        // session (the zstd DCtx must survive file boundaries), so build the
+        // reader once and `reset()` it per file.
+        let mut token_reader = if discard_sender_data {
+            Some(request_config.create_token_reader()?)
+        } else {
+            None
+        };
+        // upstream: receiver.c:515 - `receive_data()` always trails the token
+        // stream with `read_buf(f_in, sender_file_sum, xfer_sum_len)`, even on
+        // the discard path where there is nothing to verify against.
+        let discard_checksum_len = ChecksumVerifier::new(
+            self.negotiated_algorithms.as_ref(),
+            self.protocol,
+            self.checksum_seed,
+            self.compat_flags.as_ref(),
+        )
+        .digest_len();
+
         for &(file_idx, file_entry, ref file_path, base_iflags) in files_to_transfer {
             // upstream: generator.c:1961-1969 - compute the basis signature and
             // send a real sum head so the sender can diff against the receiver's
@@ -745,13 +781,11 @@ impl ReceiverContext {
             )?;
 
             // Flush before blocking on the echo so the sender has the full
-            // request. It reads the sum head, writes the delta into its own
-            // batch fd, and echoes only NDX+attrs back to us.
+            // request. On a push it reads the sum head, writes the delta into
+            // its own batch fd, and echoes only NDX+attrs back to us.
             writer.flush()?;
 
             // upstream: sender.c:442 - write_ndx_and_attrs(f_out, ...) echo.
-            // No delta follows (it went to the batch fd), so we stop here and
-            // write nothing to the destination.
             let (_echoed_ndx, _sender_attrs) =
                 crate::receiver::wire::SenderAttrs::read_with_codec_xattr(
                     reader,
@@ -759,6 +793,30 @@ impl ReceiverContext {
                     preserve_xattrs,
                     want_xattr_optim,
                 )?;
+
+            if let Some(token_reader) = token_reader.as_mut() {
+                // upstream: sender.c:443 write_sum_head(f_xfer, s) - on a pull
+                // `f_xfer == f_out`, so the sum head and the whole delta land
+                // on the wire and must be consumed to keep the sender in
+                // lockstep (receiver.c:813-814 discard_receive_data()).
+                let _echoed_sum_head = crate::receiver::wire::SumHead::read(reader)?;
+                token_reader.reset();
+                crate::delta_apply::discard_delta_stream(
+                    reader,
+                    token_reader,
+                    discard_checksum_len,
+                )?;
+            }
+
+            // upstream: receiver.c:812 log_item(FCLIENT, file, iflags, NULL) -
+            // the item is still logged even though nothing is written. Under
+            // `-i`/`-vi` the deferred itemize row already carries the name.
+            if self.config.flags.verbose
+                && self.config.connection.client_mode
+                && !self.should_emit_itemize()
+            {
+                info_log!(Name, 1, "{}", file_entry.path().display());
+            }
         }
 
         writer.flush()?;

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -188,9 +188,12 @@ impl ReceiverContext {
             // upstream: main.c:1839 `write_batch < 0` forces dry_run but leaves
             // do_xfers = 1, so unlike a plain `-n` the generator still sends
             // real block checksums while the receiver writes nothing to the
-            // destination and reads no delta data (the push sender records it
-            // into its own batch fd, sender.c:217). Checked before `dry_run`
-            // because only-write-batch sets both flags.
+            // destination (receiver.c:811-817). Checked before `dry_run`
+            // because only-write-batch sets both flags. A push receiver reads
+            // no delta (the client sender records it into its own batch fd,
+            // sender.c:217); a pull receiver drains the sender's delta via
+            // discard_receive_data() (receiver.c:813-814).
+            self.record_dry_run_itemize(&setup.dest_dir);
             self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
         } else if self.config.flags.dry_run {
             // upstream: recv_generator() itemizes every entry even under

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -176,7 +176,11 @@ impl ReceiverContext {
             // only-write-batch sets both flags; falling through to
             // `run_dry_run_loop` would send a bare NDX+iflags request with no
             // sum head, leaving the sender blocked on a read that never
-            // completes while this loop blocks on the echo.
+            // completes while this loop blocks on the echo. A push receiver
+            // reads no delta (the client sender diverted it into its own batch
+            // fd, sender.c:217); a pull receiver drains the remote sender's
+            // delta via discard_receive_data() (receiver.c:813-814).
+            self.record_dry_run_itemize(&setup.dest_dir);
             self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
         } else if self.config.flags.dry_run {
             self.run_dry_run_loop(reader, writer, &files_to_transfer)?;

--- a/tests/only_write_batch_remote_pull.rs
+++ b/tests/only_write_batch_remote_pull.rs
@@ -1,0 +1,312 @@
+//! Regression tests for `--only-write-batch` on a remote-shell PULL.
+//!
+//! A pull is not the mirror image of the push. Upstream never forwards the
+//! option to the remote side on a pull - the placeholder is emitted inside the
+//! `am_sender` block:
+//!
+//! ```c
+//! /* options.c:2850-2851, inside `if (am_sender)` */
+//! if (write_batch < 0)
+//!     args[ac++] = "--only-write-batch=X";
+//! ```
+//!
+//! so the remote sender is an ordinary one that streams sum head, delta tokens
+//! and the whole-file checksum onto the wire. What makes the destination stay
+//! untouched is the LOCAL receiver:
+//!
+//! ```c
+//! /* main.c:1839 - do_xfers was already computed, so it stays 1 */
+//! if (write_batch < 0)
+//!     dry_run = 1;
+//!
+//! /* receiver.c:811-817 */
+//! if (write_batch < 0) {
+//!     log_item(FCLIENT, file, iflags, NULL);
+//!     if (!am_server)
+//!         discard_receive_data(f_in, file);
+//!     ...
+//!     continue;
+//! }
+//! ```
+//!
+//! `discard_receive_data()` (receiver.c:524-527) drains the delta the sender is
+//! still writing. Going dry WITHOUT draining would desync the connection: the
+//! next NDX read would parse delta bytes as a frame header. Writing the
+//! destination anyway - what oc did before this fix - contradicts the
+//! documented "like --write-batch but w/o updating destination".
+//!
+//! The "remote" here is the oc-rsync binary itself, reached through a `--rsh`
+//! shim, so the whole pull path is exercised: server-argument construction, the
+//! `--server --sender` process, and the local receiver's discard loop.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Not Unix (the shim uses `/bin/sh`).
+
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    if built.is_file() {
+        return built;
+    }
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    for profile in ["debug", "release", "dist"] {
+        let candidate = PathBuf::from(manifest_dir)
+            .join("target")
+            .join(profile)
+            .join("oc-rsync");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    PathBuf::from("oc-rsync")
+}
+
+/// Writes the `--rsh` shim.
+///
+/// oc-rsync invokes it with an SSH-style argv - `[<opts>..., <host>, <rsync
+/// path>, "--server", "--sender", ...]`. The shim drops the options and the
+/// host, then execs the rest locally, giving a real two-process pull over a
+/// pipe pair without needing an SSH server.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    let body = "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         # $1 is the host placeholder; the server command follows it.\n\
+         shift || true\n\
+         exec \"$@\"\n";
+    fs::write(&script, body).expect("write rsh shim");
+    let mut perms = fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).unwrap();
+    script
+}
+
+fn spawn_with_timeout(mut cmd: Command, timeout: Duration) -> Option<Output> {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+    // Drain both pipes on their own threads. Polling try_wait() while the pipes
+    // fill would deadlock: the child blocks writing into a full OS pipe buffer
+    // and therefore never exits. Draining also preserves the child's output so a
+    // real failure is reported instead of being swallowed by the timeout.
+    let mut child_stdout = child.stdout.take()?;
+    let mut child_stderr = child.stderr.take()?;
+    let stdout_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stdout.read_to_end(&mut buf);
+        buf
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stderr.read_to_end(&mut buf);
+        buf
+    });
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().ok()? {
+            Some(status) => {
+                return Some(Output {
+                    status,
+                    stdout: stdout_reader.join().unwrap_or_default(),
+                    stderr: stderr_reader.join().unwrap_or_default(),
+                });
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            None => thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+/// Maps every regular file under `dir` to its bytes, keyed by relative path.
+fn file_tree(dir: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    let mut tree = BTreeMap::new();
+    let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file()
+                && let Ok(relative) = entry.path().strip_prefix(dir).map(Path::to_path_buf)
+                && let Ok(bytes) = fs::read(entry.path())
+            {
+                tree.insert(relative, bytes);
+            }
+        }
+    }
+    tree
+}
+
+/// Lays out a source tree and returns `(tempdir, src, dest, batch)`.
+fn setup(name: &str) -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
+    let temp = tempfile::TempDir::new().expect("create temp dir");
+    let root = temp.path();
+    let src = root.join("src");
+    let dest = root.join("dest");
+    fs::create_dir_all(src.join("sub")).unwrap();
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(src.join("alpha.txt"), b"alpha payload for the batch\n").unwrap();
+    // Larger than one token chunk so the discard loop spans several literal
+    // tokens rather than a single short read.
+    fs::write(src.join("sub/beta.txt"), vec![b'b'; 40_000]).unwrap();
+    let batch = root.join(format!("{name}.batch"));
+    (temp, src, dest, batch)
+}
+
+/// Runs a remote-shell pull of `src/` into `dest/` with `batch_flag`.
+fn run_pull(shim: &Path, binary: &Path, batch_flag: &str, src: &Path, dest: &Path) -> Output {
+    let mut cmd = Command::new(binary);
+    cmd.arg("-a")
+        .arg(batch_flag)
+        .arg("--rsh")
+        .arg(shim)
+        .arg("--rsync-path")
+        .arg(binary)
+        .arg(format!("batchhost:{}/", src.display()))
+        .arg(format!("{}/", dest.display()));
+    spawn_with_timeout(cmd, RUN_TIMEOUT).expect("pull did not finish within the timeout")
+}
+
+/// The headline bug: a `--only-write-batch` PULL updated the local destination.
+/// Upstream writes nothing there - `main.c:1839` puts the local receiver into
+/// `dry_run` and `receiver.c:813-814` drains the sender's stream with
+/// `discard_receive_data()` instead of applying it.
+///
+/// Exit 0 is asserted separately from the file count because the two halves fail
+/// differently: going dry without draining leaves the sender streaming tokens
+/// nobody reads, which surfaces as a protocol desync (exit 12) or a hang, not as
+/// a stray destination file.
+#[test]
+fn only_write_batch_pull_leaves_the_destination_untouched() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let (temp, src, dest, batch) = setup("only");
+    let shim = write_rsh_shim(temp.path());
+
+    let output = run_pull(
+        &shim,
+        &binary,
+        &format!("--only-write-batch={}", batch.display()),
+        &src,
+        &dest,
+    );
+
+    assert!(
+        output.status.success(),
+        "--only-write-batch pull must exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        file_tree(&dest).is_empty(),
+        "--only-write-batch must not update the destination; found: {:?}",
+        file_tree(&dest).keys().collect::<Vec<_>>()
+    );
+    let recorded = fs::metadata(&batch).map(|m| m.len()).unwrap_or(0);
+    assert!(
+        recorded > 0,
+        "a non-empty batch file must still be produced at {}",
+        batch.display()
+    );
+
+    // The point of recording is replay: the drained stream still had to reach
+    // the batch file in full, so `--read-batch` must reconstruct the source.
+    let replay_dest = temp.path().join("replay");
+    fs::create_dir_all(&replay_dest).unwrap();
+    let mut replay = Command::new(&binary);
+    replay
+        .arg("-a")
+        .arg(format!("--read-batch={}", batch.display()))
+        .arg(format!("{}/", replay_dest.display()));
+    let replay_output =
+        spawn_with_timeout(replay, RUN_TIMEOUT).expect("read-batch did not finish within timeout");
+    assert!(
+        replay_output.status.success(),
+        "--read-batch replay must exit 0, got {:?}\nstderr: {}",
+        replay_output.status.code(),
+        String::from_utf8_lossy(&replay_output.stderr)
+    );
+    assert_eq!(
+        file_tree(&replay_dest),
+        file_tree(&src),
+        "the batch recorded by a --only-write-batch pull must replay to the source tree"
+    );
+}
+
+/// The dry receive path is scoped to `--only-write-batch`. Plain
+/// `--write-batch` (upstream `write_batch > 0`) performs the transfer AND
+/// records it, so the pull receiver must keep applying every delta it drains.
+#[test]
+fn write_batch_pull_still_transfers_and_records() {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let (temp, src, dest, batch) = setup("plain");
+    let shim = write_rsh_shim(temp.path());
+
+    let output = run_pull(
+        &shim,
+        &binary,
+        &format!("--write-batch={}", batch.display()),
+        &src,
+        &dest,
+    );
+
+    assert!(
+        output.status.success(),
+        "--write-batch pull must exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        file_tree(&dest),
+        file_tree(&src),
+        "--write-batch must still transfer every source file"
+    );
+    let recorded = fs::metadata(&batch).map(|m| m.len()).unwrap_or(0);
+    assert!(
+        recorded > 0,
+        "--write-batch must record a non-empty batch at {}",
+        batch.display()
+    );
+}


### PR DESCRIPTION
## Problem

`--only-write-batch` is documented as "like `--write-batch` but w/o updating
destination". On a **pull** oc-rsync updated the destination in full.

Measured on Linux/aarch64 against a from-source upstream **rsync 3.4.4**
(protocol 32), pulling a 2-file tree over a `--rsh` shim:

| receiver | sender | dest files | exit | batch |
|---|---|---|---|---|
| upstream 3.4.4 | upstream 3.4.4 | **0** | 0 | 40268 B |
| oc **before** | oc | 2 | 0 | 40278 B |
| oc **before** | **upstream 3.4.4** | **2** | 0 | 40286 B |
| oc **after** | oc | **0** | 0 | 40274 B |
| oc **after** | **upstream 3.4.4** | **0** | 0 | 40282 B |

## Why the push fix did not cover this

The push side forwards `--only-write-batch=X` so the remote receiver goes dry,
and the local sender diverts its token stream into the batch fd
(`sender.c:217`). A pull works the other way round. `server_options()` emits
the placeholder inside its `am_sender` block, so a pull **never** forwards it:

```c
/* options.c:2850-2851, inside `if (am_sender)` */
if (write_batch < 0)
        args[ac++] = "--only-write-batch=X";
```

The remote sender therefore stays an ordinary one and keeps writing sum head,
delta tokens and the whole-file checksum onto the wire. What keeps the
destination untouched is the **local** receiver:

```c
/* main.c:1839 - do_xfers was already computed above, so it stays 1 */
if (write_batch < 0)
        dry_run = 1;

/* receiver.c:811-817 */
if (write_batch < 0) {
        log_item(FCLIENT, file, iflags, NULL);
        if (!am_server)
                discard_receive_data(f_in, file);
        if (inc_recurse)
                send_msg_success(fname, ndx);
        continue;
}

/* receiver.c:524-527 */
static void discard_receive_data(int f_in, struct file_struct *file)
{
        receive_data(f_in, NULL, -1, 0, NULL, -1, file, 0);
}
```

Simply setting `dry_run` without draining would be worse than the bug: the
sender keeps streaming tokens nobody reads, and the next NDX read parses delta
bytes as a frame header (protocol desync / hang).

## Change

`run_only_write_batch_loop` now branches on `client_mode` (oc's `!am_server`),
exactly like `receiver.c:813`:

- **push** (server receiver) - unchanged: the client sender already diverted
  its tokens into its own batch fd, so only the `write_ndx_and_attrs` echo is
  read (`sender.c:442`);
- **pull** (client receiver) - read the echoed sum head (`sender.c:443`, where
  `f_xfer == f_out`), then drain the token stream and the trailing file
  checksum through the existing `discard_delta_stream` helper (already modelled
  on `discard_receive_data`, `receiver.c:444-451` / `receiver.c:515`) and write
  nothing to disk. The batch is recorded by the read-side tee, upstream's
  `write_batch_monitor_in`, so the stream must actually flow.

The three pull receiver-config builders (remote shell, embedded ssh, daemon)
carry `only_write_batch` + `dry_run` onto the local receiver, mirroring
`main.c:1839`; `dry_run` drives `TransferFlags::skip_dest_writes()` so
directories, symlinks, special files and deletions are suppressed too - the
analogue of upstream's `syscall.c` dry-run guards. The per-item log line
(`receiver.c:812 log_item`) is preserved for `-v` and `-i`.

Both receiver dispatch ladders are wired: `run_pipelined` and
`run_pipelined_incremental`. `incremental-flist` is in `transfer`'s default
features but the root package sets `default-features = false`, so `-p bin`
builds the non-incremental ladder while CI's `--workspace --all-features`
builds the incremental one. Everything below was run with the feature ON as
well as OFF.

## Verification

- `--only-write-batch` pull, oc receiver <- real upstream 3.4.4 sender:
  destination empty, exit 0, 40282-byte batch produced (was 2 files).
- That batch replays with `--read-batch` to a tree byte-identical to the source.
- Plain `--write-batch` pull is untouched: 2 files transferred, content matches
  the source, batch still recorded - same as upstream 3.4.4 on both ends.
- New regression test `tests/only_write_batch_remote_pull.rs` (destination
  empty + exit 0 + replayable batch, plus the `--write-batch` no-regression
  case). Green on macOS/aarch64 with and without `incremental-flist`, and on
  Linux/aarch64 with `incremental-flist` on. It fails on the pre-fix tree with
  exactly the reported symptom (`found: ["alpha.txt", "sub/beta.txt"]`).
- `cargo fmt --all -- --check`, `cargo clippy -p core -p transfer -p bin
  --all-features --all-targets --no-deps -- -D warnings`, `cargo test -p
  transfer --all-features` (2481 passed), `cargo test -p core --all-features`.

## Notes for reviewers (pre-existing, not touched here)

- Replaying an oc-produced **remote-pull** batch with upstream 3.4.4
  `--read-batch` reconstructs the correct tree but exits 12 with "Invalid
  packet at end of run". This reproduces identically before and after this
  change and also with plain `--write-batch`, so it is an independent batch
  tail-format divergence on the remote-pull path (a local `--write-batch` batch
  replays under upstream with exit 0).
- `tests/only_write_batch_remote_push.rs` resolves the binary under test with a
  *runtime* `env::var_os("CARGO_BIN_EXE_oc-rsync")` lookup, which is a
  compile-time variable; when it is unset the helper silently falls back to
  whatever stale `target/debug/oc-rsync` is on disk. The new pull test uses
  `env!` instead. Worth fixing in the push test separately.
