### PR TITLE
test: resolve the test binary at compile time, not run time

### DIFF
--- a/tests/acl_xattr_roundtrip_linux.rs
+++ b/tests/acl_xattr_roundtrip_linux.rs
@@ -123,13 +123,7 @@ impl TestContext {
                 return None;
             }
         }
-        let oc_bin = match locate_oc_rsync() {
-            Some(p) => p,
-            None => {
-                skip("oc-rsync binary not located");
-                return None;
-            }
-        };
+        let oc_bin = locate_oc_rsync();
         let upstream_bin = match locate_upstream_rsync() {
             Some(p) => p,
             None => {

--- a/tests/acl_xattr_roundtrip_macos.rs
+++ b/tests/acl_xattr_roundtrip_macos.rs
@@ -123,13 +123,7 @@ impl TestContext {
             skip("xattr not on PATH (ship with macOS base; check PATH sanitisation)");
             return None;
         }
-        let oc_bin = match locate_oc_rsync() {
-            Some(p) => p,
-            None => {
-                skip("oc-rsync binary not located");
-                return None;
-            }
-        };
+        let oc_bin = locate_oc_rsync();
         let upstream_bin = match locate_upstream_rsync() {
             Some(p) => p,
             None => {

--- a/tests/cli_binaries.rs
+++ b/tests/cli_binaries.rs
@@ -269,8 +269,18 @@ fn binary_command(name: &str) -> Command {
 
 /// Locate a test binary built by Cargo.
 ///
-/// Resolution order:
-/// 1. `CARGO_BIN_EXE_<name>` environment variable set by Cargo.
+/// `PROGRAM_NAME` is the crate's own `[[bin]]` target, so Cargo hands its path
+/// to the compiler as `CARGO_BIN_EXE_oc-rsync`. That is a COMPILE-time
+/// variable and must be read with `env!`: at run time it is unset, and a
+/// `env::var_os` lookup would fall through to whatever stale
+/// `target/debug/oc-rsync` happens to be on disk.
+///
+/// The compatibility wrappers (`rsync`, `oc-rsyncd`, `rsyncd`) are not Cargo
+/// bin targets, so they keep the search-based resolution and stay optional.
+///
+/// Resolution order for the wrappers:
+/// 1. `CARGO_BIN_EXE_<name>` environment variable, when something in the
+///    harness exports one.
 /// 2. Walk upwards from the current executable looking for a `target`
 ///    directory and common `{debug,release}` subdirectories.
 /// 3. Fallback to a sibling of the current executable, stripping a trailing
@@ -280,6 +290,16 @@ fn binary_command(name: &str) -> Command {
 /// binaries (for example, `/usr/bin/rsync`) that do not match oc-rsync
 /// behaviour, which would make the tests environment-dependent.
 fn locate_binary(name: &str) -> Option<PathBuf> {
+    if name == PROGRAM_NAME {
+        let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+        assert!(
+            built.is_file(),
+            "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+            built.display()
+        );
+        return Some(built);
+    }
+
     let env_var = format!("CARGO_BIN_EXE_{name}");
     if let Some(path) = env::var_os(&env_var) {
         let path = PathBuf::from(path);

--- a/tests/delete_during_stream_error_1895.rs
+++ b/tests/delete_during_stream_error_1895.rs
@@ -41,24 +41,20 @@ const RUN_TIMEOUT: Duration = Duration::from_secs(60);
 /// stream dies well before clean completion.
 const STREAM_BYTE_CAP: u64 = 256;
 
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
 fn oc_rsync_binary() -> PathBuf {
-    if let Some(env_path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(env_path);
-        if path.is_file() {
-            return path;
-        }
-    }
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    for profile in ["debug", "release", "dist"] {
-        let candidate = PathBuf::from(manifest_dir)
-            .join("target")
-            .join(profile)
-            .join("oc-rsync");
-        if candidate.is_file() {
-            return candidate;
-        }
-    }
-    PathBuf::from("oc-rsync")
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Locate an upstream rsync binary, returning `None` if the test should skip.
@@ -210,10 +206,6 @@ fn delete_during_survives_sender_stream_truncation() {
         return;
     }
     let oc_rsync = oc_rsync_binary();
-    if !oc_rsync.is_file() {
-        eprintln!("skipping #1895 interop: oc-rsync binary not built");
-        return;
-    }
 
     let tmp = tempfile::tempdir().expect("create tempdir");
     let root = tmp.path();

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -40,7 +40,7 @@ use std::time::Duration;
 /// Uses a 60-second timeout to prevent CI hangs from stuck processes.
 fn run_rsync(args: &[&str]) -> Output {
     let _cmd = RsyncCommand::new();
-    let binary = locate_binary("oc-rsync").expect("oc-rsync binary must be available");
+    let binary = oc_rsync_binary();
 
     let mut command = Command::new(binary);
     command.args(args);
@@ -72,37 +72,20 @@ fn assert_exit_code(output: &Output, expected: ExitCode, context: &str) {
     }
 }
 
-/// Locate the oc-rsync binary for integration testing.
-fn locate_binary(name: &str) -> Option<PathBuf> {
-    let env_var = format!("CARGO_BIN_EXE_{name}");
-    if let Some(path) = std::env::var_os(&env_var) {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-
-    let binary_name = format!("{name}{}", std::env::consts::EXE_SUFFIX);
-    let current_exe = std::env::current_exe().ok()?;
-    let mut dir = current_exe.parent()?;
-
-    // Walk up, checking each ancestor (handles cross-compilation target dirs)
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-
-    for subdir in ["debug", "release"] {
-        let candidate = dir.join(subdir).join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-
-    None
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Tests that successful operations return exit code 0.

--- a/tests/inc_recurse_multi_segment_push_isi_d.rs
+++ b/tests/inc_recurse_multi_segment_push_isi_d.rs
@@ -71,7 +71,6 @@ mod integration;
 use integration::helpers::{TestDir, upstream_rsync_binary};
 
 use std::collections::BTreeMap;
-use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
@@ -103,36 +102,20 @@ const EXPECTED_FILE_COUNT: usize = 30;
 /// the snapshot shape explicitly.
 const EXPECTED_DIR_COUNT: usize = 6;
 
-/// Locate the oc-rsync binary built with the current feature set.
+/// Locates the binary under test.
 ///
-/// Prefers the Cargo-provided `CARGO_BIN_EXE_oc-rsync` env var so the
-/// binary used matches whatever feature flags the test run was launched
-/// with. Falls back to walking up from the test executable, matching
-/// the pattern in `inc_recurse_single_segment_push_isi_c.rs::locate_oc_rsync`.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn locate_oc_rsync() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Deterministic deep tree: three leaf directories, ten files each.
@@ -357,13 +340,7 @@ fn run_pipe_push(oc_bin: &Path, up_bin: &Path, src: &Path, dst: &Path) -> io::Re
 /// `bash tools/ci/run_interop.sh` to populate the tree.
 #[test]
 fn multi_segment_push_to_upstream_3_4_1_byte_identical() {
-    let oc_bin = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            eprintln!("skip: oc-rsync binary not located");
-            return;
-        }
-    };
+    let oc_bin = locate_oc_rsync();
     let up_bin = match upstream_rsync_binary("3.4.1") {
         Some(p) => p,
         None => {

--- a/tests/inc_recurse_sender_flist_io_error_isi_f.rs
+++ b/tests/inc_recurse_sender_flist_io_error_isi_f.rs
@@ -61,7 +61,6 @@ mod integration;
 use integration::helpers::{TestDir, upstream_rsync_binary};
 
 use std::collections::BTreeMap;
-use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::os::unix::fs::PermissionsExt;
@@ -99,36 +98,20 @@ const READABLE_DIRS: &[&str] = &["a/readable_one", "a/readable_two"];
 /// assertion can be added without rewriting the fixture.
 const FIXTURE_SIZES: &[usize] = &[0, 1, 64, 1024, 4097];
 
-/// Locate the oc-rsync binary built with the current feature set.
+/// Locates the binary under test.
 ///
-/// Prefers the Cargo-provided `CARGO_BIN_EXE_oc-rsync` env var so the
-/// binary used matches whatever feature flags the test run was launched
-/// with. Falls back to walking up from the test executable, matching
-/// the pattern in `inc_recurse_single_segment_push_isi_c.rs::locate_oc_rsync`.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn locate_oc_rsync() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Effective-UID probe used as a skip gate. Shells out to `id -u`
@@ -349,13 +332,7 @@ fn sender_inc_recurse_partial_walk_propagates_io_error() {
         return;
     }
 
-    let oc_bin = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            eprintln!("skip: oc-rsync binary not located");
-            return;
-        }
-    };
+    let oc_bin = locate_oc_rsync();
     let up_bin = match upstream_rsync_binary("3.4.1") {
         Some(p) => p,
         None => {

--- a/tests/inc_recurse_sender_fuzz_1863.rs
+++ b/tests/inc_recurse_sender_fuzz_1863.rs
@@ -292,30 +292,20 @@ fn diff_snapshots(src: &Snapshot, dst: &Snapshot) -> Vec<String> {
 // Binary discovery
 // ============================================================================
 
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn locate_oc_rsync() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Per-upstream-version capability string sent in `--server` mode.
@@ -567,13 +557,7 @@ fn seed_for_run() -> u64 {
 }
 
 fn run_until_budget(budget: Duration) {
-    let oc_bin = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            eprintln!("skip: oc-rsync binary not located");
-            return;
-        }
-    };
+    let oc_bin = locate_oc_rsync();
 
     let upstream_targets = discover_upstream_targets();
     if upstream_targets.is_empty() {

--- a/tests/inc_recurse_sender_wire_parity_isi_e.rs
+++ b/tests/inc_recurse_sender_wire_parity_isi_e.rs
@@ -66,7 +66,6 @@ mod integration;
 
 use integration::helpers::{TestDir, upstream_rsync_binary};
 
-use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
@@ -94,32 +93,20 @@ const FIXED_CHECKSUM_SEED: &str = "--checksum-seed=12345";
 const FIXTURE_MTIME_SECS: i64 = 1_700_000_000;
 const FIXTURE_MTIME_NSECS: u32 = 0;
 
-/// Locate the oc-rsync binary built with the current feature set.
-/// Same shape as ISI.c/ISI.d.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn locate_oc_rsync() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Apply the fixed mtime to every regular file in `root` recursively.
@@ -383,13 +370,7 @@ fn assert_wire_parity(label: &str, oc_bytes: &[u8], upstream_bytes: &[u8]) {
 /// matching the convention used by every other interop test under
 /// `tests/`.
 fn locate_binaries_or_skip() -> Option<(PathBuf, PathBuf)> {
-    let oc_bin = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            eprintln!("skip: oc-rsync binary not located");
-            return None;
-        }
-    };
+    let oc_bin = locate_oc_rsync();
     let up_bin = match upstream_rsync_binary("3.4.1") {
         Some(p) => p,
         None => {

--- a/tests/inc_recurse_single_segment_push_isi_c.rs
+++ b/tests/inc_recurse_single_segment_push_isi_c.rs
@@ -59,7 +59,6 @@ mod integration;
 use integration::helpers::{TestDir, upstream_rsync_binary};
 
 use std::collections::BTreeMap;
-use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
@@ -76,36 +75,20 @@ use transfer::setup::build_capability_string;
 /// Mirrors `flags_for_version("3.4.1")` in the sister fuzz harness.
 const UPSTREAM_FLAGS_341: &str = "-vlogDtprze.iLsfxCIvu";
 
-/// Locate the oc-rsync binary built with the current feature set.
+/// Locates the binary under test.
 ///
-/// Prefers the Cargo-provided `CARGO_BIN_EXE_oc-rsync` env var so the
-/// binary used matches whatever feature flags the test run was launched
-/// with. Falls back to walking up from the test executable, matching
-/// the pattern in `inc_recurse_sender_fuzz_1863.rs::locate_oc_rsync`.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn locate_oc_rsync() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Deterministic 10-file flat tree.
@@ -315,13 +298,7 @@ fn no_inc_recursive_override_suppresses_inc_recurse_bit() {
 /// `bash tools/ci/run_interop.sh` to populate the tree.
 #[test]
 fn single_segment_push_to_upstream_3_4_1_byte_identical() {
-    let oc_bin = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            eprintln!("skip: oc-rsync binary not located");
-            return;
-        }
-    };
+    let oc_bin = locate_oc_rsync();
     let up_bin = match upstream_rsync_binary("3.4.1") {
         Some(p) => p,
         None => {

--- a/tests/integration/acl_xattr_interop_harness.rs
+++ b/tests/integration/acl_xattr_interop_harness.rs
@@ -72,23 +72,20 @@ pub fn command_on_path(cmd: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Locate the oc-rsync binary built by cargo. Walks the standard places
-/// nextest exposes plus the workspace `target/{debug,release,dist}` layout.
-pub fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(env_path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(env_path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    for profile in ["debug", "release", "dist"] {
-        let candidate = manifest_dir.join("target").join(profile).join("oc-rsync");
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+pub fn locate_oc_rsync() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Locate an upstream rsync binary. Honours `OC_RSYNC_UPSTREAM`, then the

--- a/tests/integration/delete_event_order_harness.rs
+++ b/tests/integration/delete_event_order_harness.rs
@@ -177,14 +177,7 @@ pub fn run_pair_capture(
             ));
         }
     };
-    let oc_bin = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            return Ok(PairOutcome::Skipped(
-                "oc-rsync binary not located".to_string(),
-            ));
-        }
-    };
+    let oc_bin = locate_oc_rsync();
 
     let upstream = run_one_capture(scenario, &upstream_bin, delete_mode_flags, extra_flags)?;
     let oc_rsync = run_one_capture(scenario, &oc_bin, delete_mode_flags, extra_flags)?;
@@ -590,23 +583,20 @@ pub fn command_on_path(cmd: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Locate the oc-rsync binary built by cargo. Walks the standard places
-/// nextest exposes plus the workspace `target/{debug,release}` layout.
-pub fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(env_path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(env_path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    for profile in ["debug", "release", "dist"] {
-        let candidate = manifest_dir.join("target").join(profile).join("oc-rsync");
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+pub fn locate_oc_rsync() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Locate an upstream rsync binary. Honours `OC_RSYNC_UPSTREAM`, then the

--- a/tests/integration/helpers.rs
+++ b/tests/integration/helpers.rs
@@ -158,8 +158,7 @@ pub struct RsyncCommand {
 impl RsyncCommand {
     /// Create a new command for the oc-rsync binary.
     pub fn new() -> Self {
-        let binary = locate_binary("oc-rsync")
-            .expect("oc-rsync binary must be available for integration tests");
+        let binary = oc_rsync_binary();
         Self {
             binary,
             args: Vec::new(),
@@ -236,39 +235,20 @@ impl RsyncCommand {
     }
 }
 
-/// Locate the test binary.
-fn locate_binary(name: &str) -> Option<PathBuf> {
-    // Try CARGO_BIN_EXE_<name> first
-    let env_var = format!("CARGO_BIN_EXE_{name}");
-    if let Some(path) = env::var_os(&env_var) {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-
-    let binary_name = format!("{name}{}", std::env::consts::EXE_SUFFIX);
-    let current_exe = env::current_exe().ok()?;
-    let mut dir = current_exe.parent()?;
-
-    // Walk up, checking each ancestor (handles cross-compilation target dirs)
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-
-    // Check common locations under target/
-    for subdir in ["debug", "release"] {
-        let candidate = dir.join(subdir).join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-
-    None
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Get cargo target runner if configured.
@@ -464,7 +444,7 @@ impl ServerModeTest {
 
     /// Create a new server-mode test with explicit version specification.
     pub fn with_version(upstream_binary: &Path, version: &str) -> Option<Self> {
-        let oc_rsync_binary = locate_binary("oc-rsync")?;
+        let oc_rsync_binary = oc_rsync_binary();
         if !upstream_binary.is_file() {
             return None;
         }

--- a/tests/integration_rsync_protocol.rs
+++ b/tests/integration_rsync_protocol.rs
@@ -49,7 +49,7 @@ fn rsync_with_timeout(args: &[&str], timeout_secs: u64) -> std::process::Output 
     use std::process::{Command, Stdio};
     use std::time::Duration;
 
-    let binary = locate_oc_rsync().expect("oc-rsync binary must be available");
+    let binary = locate_oc_rsync();
 
     let mut child = Command::new(&binary)
         .args(args)
@@ -78,39 +78,20 @@ fn rsync_with_timeout(args: &[&str], timeout_secs: u64) -> std::process::Output 
         .expect("failed to collect oc-rsync output")
 }
 
-fn locate_oc_rsync() -> Option<std::path::PathBuf> {
-    use std::env;
-    use std::path::PathBuf;
-
-    // Try CARGO_BIN_EXE_oc-rsync first
-    if let Some(path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-
-    let binary_name = format!("oc-rsync{}", std::env::consts::EXE_SUFFIX);
-    let current_exe = env::current_exe().ok()?;
-    let mut dir = current_exe.parent()?;
-
-    // Walk up, checking each ancestor (handles cross-compilation target dirs)
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-
-    for subdir in ["debug", "release"] {
-        let candidate = dir.join(subdir).join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-
-    None
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn locate_oc_rsync() -> std::path::PathBuf {
+    let built = std::path::PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 #[test]

--- a/tests/live_interop_fuzz_1196.rs
+++ b/tests/live_interop_fuzz_1196.rs
@@ -400,30 +400,20 @@ fn upstream_binary() -> Option<PathBuf> {
     None
 }
 
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn locate_oc_rsync() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 // ============================================================================
@@ -623,13 +613,7 @@ fn seed_for_run() -> u64 {
 /// Run the fuzzer until the time budget elapses. Used by both the smoke and
 /// extended tiers; the only difference is the budget and tree shape mix.
 fn run_until_budget(budget: Duration, shapes: &[TreeShape]) {
-    let oc_bin = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            eprintln!("skip: oc-rsync binary not located");
-            return;
-        }
-    };
+    let oc_bin = locate_oc_rsync();
     let up_bin = match upstream_binary() {
         Some(p) => p,
         None => {

--- a/tests/only_write_batch_remote_pull.rs
+++ b/tests/only_write_batch_remote_pull.rs
@@ -63,20 +63,21 @@ const RUN_TIMEOUT: Duration = Duration::from_secs(120);
 /// silently testing a different build than the one just compiled.
 fn oc_rsync_binary() -> PathBuf {
     let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
-    if built.is_file() {
-        return built;
-    }
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    for profile in ["debug", "release", "dist"] {
-        let candidate = PathBuf::from(manifest_dir)
-            .join("target")
-            .join(profile)
-            .join("oc-rsync");
-        if candidate.is_file() {
-            return candidate;
-        }
-    }
-    PathBuf::from("oc-rsync")
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    let mode = fs::metadata(&built)
+        .expect("stat oc-rsync binary")
+        .permissions()
+        .mode();
+    assert!(
+        mode & 0o111 != 0,
+        "oc-rsync at {} is not executable (mode {mode:o})",
+        built.display()
+    );
+    built
 }
 
 /// Writes the `--rsh` shim.
@@ -214,10 +215,6 @@ fn run_pull(shim: &Path, binary: &Path, batch_flag: &str, src: &Path, dest: &Pat
 #[test]
 fn only_write_batch_pull_leaves_the_destination_untouched() {
     let binary = oc_rsync_binary();
-    if !binary.is_file() {
-        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
-        return;
-    }
     let (temp, src, dest, batch) = setup("only");
     let shim = write_rsh_shim(temp.path());
 
@@ -277,10 +274,6 @@ fn only_write_batch_pull_leaves_the_destination_untouched() {
 #[test]
 fn write_batch_pull_still_transfers_and_records() {
     let binary = oc_rsync_binary();
-    if !binary.is_file() {
-        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
-        return;
-    }
     let (temp, src, dest, batch) = setup("plain");
     let shim = write_rsh_shim(temp.path());
 

--- a/tests/only_write_batch_remote_push.rs
+++ b/tests/only_write_batch_remote_push.rs
@@ -32,7 +32,6 @@
 
 #![cfg(unix)]
 
-use std::env;
 use std::fs;
 use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
@@ -43,24 +42,29 @@ use std::time::{Duration, Instant};
 
 const RUN_TIMEOUT: Duration = Duration::from_secs(120);
 
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
 fn oc_rsync_binary() -> PathBuf {
-    if let Some(env_path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(env_path);
-        if path.is_file() {
-            return path;
-        }
-    }
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    for profile in ["debug", "release", "dist"] {
-        let candidate = PathBuf::from(manifest_dir)
-            .join("target")
-            .join(profile)
-            .join("oc-rsync");
-        if candidate.is_file() {
-            return candidate;
-        }
-    }
-    PathBuf::from("oc-rsync")
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    let mode = fs::metadata(&built)
+        .expect("stat oc-rsync binary")
+        .permissions()
+        .mode();
+    assert!(
+        mode & 0o111 != 0,
+        "oc-rsync at {} is not executable (mode {mode:o})",
+        built.display()
+    );
+    built
 }
 
 /// Writes the `--rsh` shim.
@@ -193,10 +197,6 @@ fn run_push(shim: &Path, binary: &Path, batch_flag: &str, src: &Path, dest: &Pat
 #[test]
 fn only_write_batch_push_leaves_the_destination_untouched() {
     let binary = oc_rsync_binary();
-    if !binary.is_file() {
-        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
-        return;
-    }
     let (temp, src, dest, batch) = setup("only");
     let shim = write_rsh_shim(temp.path());
 
@@ -236,10 +236,6 @@ fn only_write_batch_push_leaves_the_destination_untouched() {
 #[test]
 fn write_batch_push_still_transfers_and_records() {
     let binary = oc_rsync_binary();
-    if !binary.is_file() {
-        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
-        return;
-    }
     let (temp, src, dest, batch) = setup("plain");
     let shim = write_rsh_shim(temp.path());
 

--- a/tests/ssh_proxy_jump.rs
+++ b/tests/ssh_proxy_jump.rs
@@ -50,26 +50,20 @@ use tempfile::TempDir;
 /// after recording its argv, so any single test should finish in milliseconds.
 const RUN_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Resolve the oc-rsync binary path the same way other root-tests do
-/// (search the workspace `target/{debug,release,dist}` directories).
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
 fn oc_rsync_binary() -> PathBuf {
-    if let Some(env_path) = std::env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(env_path);
-        if path.is_file() {
-            return path;
-        }
-    }
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    for profile in ["debug", "release", "dist"] {
-        let path = PathBuf::from(manifest_dir)
-            .join("target")
-            .join(profile)
-            .join("oc-rsync");
-        if path.is_file() {
-            return path;
-        }
-    }
-    PathBuf::from("oc-rsync")
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Create a POSIX shell-script "ssh" wrapper inside `dir` that writes its

--- a/tests/ssh_push_throughput_regression_ssr1.rs
+++ b/tests/ssh_push_throughput_regression_ssr1.rs
@@ -96,25 +96,20 @@ const BUCKETS: &[(&str, usize)] = &[
     ("100MB", 100 * 1024 * 1024),
 ];
 
-/// Resolve the oc-rsync binary path the same way other root-level tests do.
-fn oc_rsync_binary() -> Option<PathBuf> {
-    if let Some(env_path) = std::env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(env_path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    for profile in ["release", "dist", "debug"] {
-        let path = PathBuf::from(manifest_dir)
-            .join("target")
-            .join(profile)
-            .join("oc-rsync");
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-    None
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Resolve the upstream rsync binary. Honours `UPSTREAM_RSYNC` when set,
@@ -274,10 +269,7 @@ fn median_push(binary: &Path, src: &Path, target: &str, dst: &Path) -> Option<Du
 #[test]
 #[ignore = "expensive (100MB SSH loopback); runs in nightly --run-ignored=only cell"]
 fn ssh_push_throughput_regression_ssr1() {
-    let Some(oc_rsync) = oc_rsync_binary() else {
-        eprintln!("SSR-1 skip: oc-rsync binary not found under target/{{release,dist,debug}}");
-        return;
-    };
+    let oc_rsync = oc_rsync_binary();
     let Some(upstream) = upstream_rsync_binary() else {
         eprintln!("SSR-1 skip: upstream rsync not on PATH (set UPSTREAM_RSYNC to override)");
         return;

--- a/tests/ssh_transport.rs
+++ b/tests/ssh_transport.rs
@@ -32,19 +32,20 @@ fn setup_test_directory() -> TempDir {
     temp_dir
 }
 
-/// Test helper to get the path to the oc-rsync binary.
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
 fn oc_rsync_binary() -> PathBuf {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    for profile in ["debug", "release", "dist"] {
-        let path = PathBuf::from(manifest_dir)
-            .join("target")
-            .join(profile)
-            .join("oc-rsync");
-        if path.exists() {
-            return path;
-        }
-    }
-    PathBuf::from("oc-rsync")
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
 }
 
 /// Returns `--rsync-path=<binary>` so the SSH remote side uses our binary.


### PR DESCRIPTION
## Why the runtime lookup silently fails

Every helper that located the binary under test started with:

```rust
if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") { ... }
```

`CARGO_BIN_EXE_<name>` is a **compile-time** variable. Cargo hands it to
rustc when it builds an integration test of the package that owns the
`[[bin]]` target; it is never placed in the environment of the running test
process. So the lookup returns `None` on every run, and control falls
through to the hand-rolled fallback underneath it - a scan of
`target/{debug,release,dist}/oc-rsync`, or a walk up from the test
executable.

Proved directly, from inside a test:

```
runtime env::var_os = None
compile-time env!   = ".../target/debug/oc-rsync"
```

The fallback is not merely redundant, it is wrong: it resolves whatever
`oc-rsync` is sitting on disk, which can be from an entirely different
revision. On a Linux host both `--only-write-batch` remote tests failed
against a binary from an old build, and the failure looked like a product
bug rather than a harness bug. One helper
(`ssh_push_throughput_regression_ssr1.rs`) searched `release` before
`debug`, so a stale release artifact won over the freshly built debug one.

### The second, worse layer

Most of these helpers returned `Option<PathBuf>` and callers did:

```rust
let oc_bin = match locate_oc_rsync() {
    Some(p) => p,
    None => { eprintln!("skip: oc-rsync binary not located"); return; }
};
```

Because the last fallback returned a bare relative `PathBuf::from("oc-rsync")`,
`is_file()` was false and the test skipped - and reported **ok**. A skip
that can never be satisfied is indistinguishable from a pass. Demonstrated
below: with the old code and no binary on disk, both batch tests "passed"
in 0.00s having executed nothing.

## The fix

Resolve with `env!("CARGO_BIN_EXE_oc-rsync")`, which Cargo guarantees points
at the artifact it just built, then assert loudly:

```rust
let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
assert!(
    built.is_file(),
    "oc-rsync binary missing at {}; refusing to fall back to a stale build",
    built.display()
);
```

The two `--only-write-batch` tests are `#![cfg(unix)]` and additionally
assert the executable bit. All search fallbacks and all unconditional
"binary not located" skips are removed; `Option` returns become plain
`PathBuf` and the call sites lose their skip arms.

Skips that remain are genuinely conditional and untouched: missing upstream
rsync (`target/interop/upstream-install/...`), missing `dd`/`setfacl`, no
SSH target, and the `OC_RSYNC_METADATA_INTEROP` gate.

## Files fixed

Compile-time resolution (`env!`) plus existence assertion:

- `tests/only_write_batch_remote_push.rs` (also asserts the executable bit)
- `tests/only_write_batch_remote_pull.rs` (already used `env!`; the stale
  `target/` fallback behind it is now gone, plus the executable-bit assertion)
- `tests/ssh_proxy_jump.rs`
- `tests/ssh_transport.rs` (had no env lookup at all - pure `target/` scan)
- `tests/ssh_push_throughput_regression_ssr1.rs` (searched `release` first)
- `tests/delete_during_stream_error_1895.rs`
- `tests/integration_rsync_protocol.rs`
- `tests/exit_codes.rs`
- `tests/cli_binaries.rs`
- `tests/inc_recurse_single_segment_push_isi_c.rs`
- `tests/inc_recurse_multi_segment_push_isi_d.rs`
- `tests/inc_recurse_sender_wire_parity_isi_e.rs`
- `tests/inc_recurse_sender_flist_io_error_isi_f.rs`
- `tests/inc_recurse_sender_fuzz_1863.rs`
- `tests/live_interop_fuzz_1196.rs`
- `tests/integration/helpers.rs`
- `tests/integration/delete_event_order_harness.rs`
- `tests/integration/acl_xattr_interop_harness.rs`

Call sites updated for the non-`Option` signatures:

- `tests/acl_xattr_roundtrip_linux.rs`
- `tests/acl_xattr_roundtrip_macos.rs`

`tests/cli_binaries.rs` is a partial case by design. It resolves four names:
`oc-rsync` plus the compatibility wrappers `rsync`, `oc-rsyncd`, `rsyncd`.
Only `oc-rsync` is a Cargo `[[bin]]` target, so only that name short-circuits
to `env!`; the wrappers keep the search-based resolution and stay optional.

## Deliberately not changed

`env!("CARGO_BIN_EXE_oc-rsync")` is a hard compile error outside the package
that declares the bin target. Verified with a throwaway test in `transfer`:

```
error: environment variable `CARGO_BIN_EXE_oc-rsync` not defined at compile time
 --> crates/transfer/tests/zz_probe_tmp.rs:1:17
```

So these keep their `target/` search - it is the only mechanism available to
them, and they carry the same stale-binary risk. Listing them rather than
changing them blind:

- `crates/transfer/tests/` - `uts_nextest_hardlinks_inc_recurse.rs`,
  `v61d_2_daemon_push_increcurse_perf_regression.rs`,
  `upstream_compat_daemon_gzip_goodbye.rs`, `delete_missing_args_files_from.rs`,
  `remove_source_files_local_copy.rs`, `uts_nextest_daemon_gzip_zz.rs`,
  `uts_15_e_daemon_pull_write_batch.rs`, `nxt_4_reverse_daemon_delta.rs`,
  `old_dirs_depth_limit.rs`, `delete_files_from_root_scope.rs`,
  `itemize_fidelity_golden.rs`, `uts_nextest_daemon_delete_stats.rs`,
  `daemon_total_transferred_size_stats.rs`
- `crates/core/tests/` - `partial_mid_transfer_kill.rs`,
  `no_partial_temp_cleanup.rs`, `uts_9_daemon_gzip_download_goodbye.rs`,
  `common/mod.rs` (hard-codes `target/release/oc-rsync` and
  `target/debug/oc-rsync`)
- `crates/metadata/tests/` - `windows_symlink_junction_transfer.rs`,
  `acl_root_root_interop.rs`, `windows_ads_xattrs_roundtrip.rs`
- `crates/engine/tests/delete_determinism_property.rs`
- `crates/cli/tests/upstream_arg_fidelity.rs`
- `crates/test-support/src/cli.rs` and `crates/test-support/src/lsh.rs` -
  library code, so `env!` is unavailable by construction. `lsh-stub` *is* a
  bin target of `test-support`, so `CARGO_BIN_EXE_lsh-stub` could be captured
  in `crates/test-support/tests/lsh_stub.rs` and injected into
  `LshRunnerStub::locate()`, but that changes a public API and is left for a
  separate change.

Closing these properly means either moving the affected tests into the `bin`
package or having each crate capture the path in a `build.rs`. Both are
larger than a test-infrastructure correctness fix.

`xtask/tests/main_cli.rs` already uses `env!("CARGO_BIN_EXE_xtask")` and needs
nothing. No benches resolve a binary.

## Proving the new failure mode is loud

The binary under test lives at `target/debug/oc-rsync`. Each run below uses
the already-compiled test executable directly, so cargo cannot quietly
rebuild the binary out from under the experiment.

**Old code, `target/debug/oc-rsync` moved aside** - silently green:

```
running 2 tests
test only_write_batch_push_leaves_the_destination_untouched ... ok
test write_batch_push_still_transfers_and_records ... ok

test result: ok. 2 passed; 0 failed; ... finished in 0.00s
```

Two "passing" tests that spawned no process at all. Note that this host also
has `/opt/homebrew/bin/oc-rsync` installed, so the last-resort bare
`PathBuf::from("oc-rsync")` could have reached an unrelated release build.

**New code, same binary moved aside** - loud, names the path:

```
test only_write_batch_push_leaves_the_destination_untouched ... FAILED
test write_batch_push_still_transfers_and_records ... FAILED

thread '...' panicked at tests/only_write_batch_remote_push.rs:54:5:
oc-rsync binary missing at .../target/debug/oc-rsync; refusing to fall back to a stale build

test result: FAILED. 0 passed; 2 failed; ...
```

**New code, `target/debug/oc-rsync` replaced by a non-executable file:**

```
thread '...' panicked at tests/only_write_batch_remote_push.rs:63:5:
oc-rsync at .../target/debug/oc-rsync is not executable (mode 100644)
```

The binary was restored afterwards and the suite re-run green.

## Validation

- `cargo test -p bin --all-features` across the 18 affected targets -
  all green (`only_write_batch_remote_{push,pull}`, `ssh_proxy_jump`,
  `ssh_transport`, `delete_during_stream_error_1895`,
  `integration_rsync_protocol`, `exit_codes`, `cli_binaries`,
  `integration_helpers`, `integration_basic`, `integration_daemon`,
  `integration_daemon_server`, `integration_links`,
  `delete_event_order_{after,excluded}`, `inc_recurse_sender_fuzz_1863`,
  `live_interop_fuzz_1196`, `acl_xattr_roundtrip_macos`).
- Linux-gated targets (`inc_recurse_*_isi_{c,d,e,f}`,
  `acl_xattr_roundtrip_linux`) cannot run on the dev host, so they were
  linted with their `cfg` temporarily widened to `unix` and came back clean
  under `-D warnings`; the gates were restored byte-for-byte.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`

No assertion or timeout was weakened.
