### PR TITLE
fix(transfer): frame flist-walk errors as MSG in server mode

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -108,6 +108,15 @@ pub struct GeneratorContext {
     /// I/O error flags accumulated during file list building and transfer.
     /// Uses [`io_error_flags`] constants (IOERR_GENERAL, IOERR_VANISHED, etc.).
     pub(crate) io_error: i32,
+    /// Diagnostics raised by the file-list walk, paired with the upstream log
+    /// class that decides how a server frames them.
+    ///
+    /// The walk runs before any writer is in scope, so the text is held here
+    /// and drained by
+    /// [`flush_flist_diagnostics`](Self::flush_flist_diagnostics) once the
+    /// orchestrator can reach the wire. Each entry already carries its trailing
+    /// newline, matching upstream's `rwrite()` payload.
+    pub(crate) pending_flist_diagnostics: Vec<(super::protocol_io::SenderDiagnostic, String)>,
     /// Flat file-list indices whose `--remove-source-files` unlink is deferred
     /// until the peer confirms the commit via `MSG_SUCCESS`. Empty and unused
     /// unless `--remove-source-files` is active.
@@ -191,6 +200,7 @@ impl GeneratorContext {
             uid_list: IdList::new(),
             gid_list: IdList::new(),
             io_error: 0,
+            pending_flist_diagnostics: Vec::new(),
             pending_source_removals: super::pending_removal::PendingSourceRemovals::default(),
             incremental: IncrementalState::new(initial_ndx_start),
             delete_stats: DeleteStats::new(),
@@ -589,6 +599,21 @@ impl GeneratorContext {
         } else {
             self.add_io_error(io_error_flags::IOERR_GENERAL);
         }
+    }
+
+    /// Queues a file-list-walk diagnostic for delivery by
+    /// [`flush_flist_diagnostics`](Self::flush_flist_diagnostics).
+    ///
+    /// The walk cannot reach the transfer writer, so writing here instead of to
+    /// stderr is what lets a daemon or SSH server forward the line to the
+    /// client the way upstream's `rwrite()` does. `text` must carry its
+    /// trailing newline.
+    pub(crate) fn queue_flist_diagnostic(
+        &mut self,
+        kind: super::protocol_io::SenderDiagnostic,
+        text: String,
+    ) {
+        self.pending_flist_diagnostics.push((kind, text));
     }
 
     /// Returns the current I/O error flags.

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -21,6 +21,7 @@ use crate::role_trailer::error_location;
 
 use super::super::GeneratorContext;
 use super::super::io_error_flags;
+use super::super::protocol_io::SenderDiagnostic;
 use super::batch_stat::{StatResult, batch_stat_dir_entries};
 
 impl GeneratorContext {
@@ -118,11 +119,13 @@ impl GeneratorContext {
                     _ => {
                         // FFV-4: emit the correct error message and error flag
                         // for a source that never existed at flist build time.
-                        eprintln!(
-                            "rsync: [sender] link_stat {} failed: {}",
+                        // upstream: flist.c:2433 - rsyserr(FERROR_XFER, ...)
+                        let text = format!(
+                            "rsync: [sender] link_stat {} failed: {}\n",
                             full_fname_path(path, self.daemon_module()),
                             engine::local_copy::upstream_io_error(&e),
                         );
+                        self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
                         self.add_io_error(io_error_flags::IOERR_GENERAL);
                         Ok(false)
                     }
@@ -265,11 +268,12 @@ impl GeneratorContext {
             Ok(e) => e,
             Err(e) => {
                 // upstream: flist.c - rsyserr for make_file() failures
-                eprintln!(
-                    "rsync: [sender] make_file failed for \"{}\": {}",
+                let text = format!(
+                    "rsync: [sender] make_file failed for \"{}\": {}\n",
                     path.display(),
                     engine::local_copy::upstream_io_error(&e),
                 );
+                self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
                 self.add_io_error(io_error_flags::IOERR_GENERAL);
                 return Ok(());
             }
@@ -290,11 +294,12 @@ impl GeneratorContext {
                 Ok(entries) => Some(entries),
                 Err(e) => {
                     // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
-                    eprintln!(
-                        "rsync: [sender] opendir {} failed: {}",
+                    let text = format!(
+                        "rsync: [sender] opendir {} failed: {}\n",
                         full_fname_path(&path, self.daemon_module()),
                         engine::local_copy::upstream_io_error(&e),
                     );
+                    self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
                     self.record_io_error(&e);
                     None
                 }
@@ -389,11 +394,12 @@ impl GeneratorContext {
             Ok(entries) => self.process_dir_entries_batched(base, dir_path, entries),
             Err(e) => {
                 // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
-                eprintln!(
-                    "rsync: [sender] opendir {} failed: {}",
+                let text = format!(
+                    "rsync: [sender] opendir {} failed: {}\n",
                     full_fname_path(dir_path, self.daemon_module()),
                     engine::local_copy::upstream_io_error(&e),
                 );
+                self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
                 self.record_io_error(&e);
                 Ok(())
             }
@@ -417,11 +423,12 @@ impl GeneratorContext {
                 Ok(de) => child_paths.push(de.path()),
                 Err(e) => {
                     // upstream: flist.c:1924 - rsyserr(FERROR_XFER, errno, "readdir(%s)", ...)
-                    eprintln!(
-                        "rsync: [sender] readdir({}): {}",
+                    let text = format!(
+                        "rsync: [sender] readdir({}): {}\n",
                         full_fname_path(dir_path, self.daemon_module()),
                         engine::local_copy::upstream_io_error(&e),
                     );
+                    self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
                     self.record_io_error(&e);
                 }
             }
@@ -508,19 +515,29 @@ impl GeneratorContext {
     /// Logs a stat failure with the appropriate upstream error format.
     ///
     /// Distinguishes between vanished files (ENOENT) and general stat errors,
-    /// matching upstream `flist.c:1286-1294` error reporting.
-    fn log_stat_error(&self, path: &Path, e: &io::Error) {
+    /// matching upstream `flist.c:1286-1294` error reporting. The two cases
+    /// carry different log classes upstream, so they queue different frame
+    /// types: the vanished notice is an `FWARNING`, the stat failure an
+    /// `FERROR_XFER`.
+    fn log_stat_error(&mut self, path: &Path, e: &io::Error) {
         let fname = full_fname_path(path, self.daemon_module());
-        if e.kind() == io::ErrorKind::NotFound {
-            // upstream: flist.c:1317 - rprintf(c, "file has vanished: %s\n", full_fname(...))
-            eprintln!("file has vanished: {fname}");
+        let (kind, text) = if e.kind() == io::ErrorKind::NotFound {
+            // upstream: flist.c:1314-1318 - rprintf(FWARNING, "file has vanished: %s\n", ...)
+            (
+                SenderDiagnostic::Warning,
+                format!("file has vanished: {fname}\n"),
+            )
         } else {
             // upstream: flist.c:1846 - rsyserr(FERROR_XFER, errno, "link_stat %s failed", ...)
-            eprintln!(
-                "rsync: [sender] link_stat {fname} failed: {}",
-                engine::local_copy::upstream_io_error(e),
-            );
-        }
+            (
+                SenderDiagnostic::ErrorXfer,
+                format!(
+                    "rsync: [sender] link_stat {fname} failed: {}\n",
+                    engine::local_copy::upstream_io_error(e),
+                ),
+            )
+        };
+        self.queue_flist_diagnostic(kind, text);
     }
 
     /// Resolves symlink metadata following upstream `flist.c:readlink_stat()`.

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -33,6 +33,25 @@ use crate::writer::MsgInfoSender;
 /// them as a single parameter object keeps the two writer methods below at a
 /// manageable arity and prevents the four fields from drifting apart at call
 /// sites.
+/// Log class of a sender-side diagnostic, mirroring upstream's `enum logcode`.
+///
+/// The class selects the multiplexed message code a server frames the text
+/// with; [`GeneratorContext::emit_sender_diagnostic`] owns that mapping.
+///
+/// # Upstream Reference
+///
+/// - `log.c:309-328` - `rwrite()` maps `FWARNING` / `FERROR_XFER` to stderr
+/// - `log.c:330-340` - `am_server` re-sends the same code as a `MSG_*` frame
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SenderDiagnostic {
+    /// Upstream `FWARNING`. Downgrades to `MSG_INFO` below protocol 30, which
+    /// has no `MSG_WARNING` (`log.c:332-337`).
+    Warning,
+    /// Upstream `FERROR_XFER`. `MSG_ERROR_XFER` exists at every supported
+    /// protocol, so it never downgrades.
+    ErrorXfer,
+}
+
 pub(super) struct NdxAttrs<'a> {
     /// Wire NDX of the file (diff-encoded by the NDX codec).
     pub ndx: i32,
@@ -312,8 +331,8 @@ impl GeneratorContext {
         Ok(())
     }
 
-    /// Emits a sender-side `FWARNING` diagnostic, framing it for the peer when
-    /// this process is the server.
+    /// Emits a sender-side diagnostic, framing it for the peer when this
+    /// process is the server.
     ///
     /// Upstream `rwrite()` sends the multiplexed frame *instead of* writing the
     /// text to the server's own stderr (`send_msg(...); return;`), so a client
@@ -322,27 +341,56 @@ impl GeneratorContext {
     /// forwarded. `text` carries its trailing newline, as upstream's payload
     /// does.
     ///
-    /// Below protocol 30 there is no `MSG_WARNING`, so `FWARNING` rides
-    /// `MSG_INFO` instead.
+    /// This is the single place the server-vs-client and the protocol-30
+    /// downgrade rules are applied; every sender diagnostic - per-file
+    /// (`sender.c`) and file-list walk (`flist.c`) alike - routes through here.
     ///
     /// # Upstream Reference
     ///
     /// - `log.c:330-346` - `am_server` sends the frame and returns
     /// - `log.c:332-337` - `MSG_WARNING` -> `MSG_INFO` downgrade below protocol 30
-    fn emit_sender_warning<W: Write>(
+    pub(super) fn emit_sender_diagnostic<W: Write>(
         &self,
         writer: &mut super::super::writer::ServerWriter<W>,
+        kind: SenderDiagnostic,
         text: &str,
     ) -> io::Result<()> {
         if self.config.connection.client_mode || !writer.is_multiplexed() {
             eprint!("{text}");
             return Ok(());
         }
-        if self.protocol.supports_generator_messages() {
-            writer.send_msg_warning(text.as_bytes())
-        } else {
-            writer.send_msg_info(text.as_bytes())
+        match kind {
+            SenderDiagnostic::Warning if !self.protocol.supports_generator_messages() => {
+                writer.send_msg_info(text.as_bytes())
+            }
+            SenderDiagnostic::Warning => writer.send_msg_warning(text.as_bytes()),
+            SenderDiagnostic::ErrorXfer => writer.send_msg_error_xfer(text.as_bytes()),
         }
+    }
+
+    /// Delivers the diagnostics that the file-list walk queued while no writer
+    /// was in scope.
+    ///
+    /// Upstream reports these inline from `send_file_list()` because `rwrite()`
+    /// reaches `f_out` directly. oc builds the whole list in memory before
+    /// `send_file_list()` writes a byte, so draining the queue here - after the
+    /// walk, before the list - puts the frames on the wire in the same order a
+    /// peer would have seen them.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:1846`, `flist.c:2433` - `link_stat %s failed` (FERROR_XFER)
+    /// - `flist.c:1878` - `opendir %s failed` (FERROR_XFER)
+    /// - `flist.c:1924` - `readdir(%s)` (FERROR_XFER)
+    /// - `flist.c:1317` - `file has vanished: %s` (FWARNING)
+    pub(super) fn flush_flist_diagnostics<W: Write>(
+        &mut self,
+        writer: &mut super::super::writer::ServerWriter<W>,
+    ) -> io::Result<()> {
+        for (kind, text) in std::mem::take(&mut self.pending_flist_diagnostics) {
+            self.emit_sender_diagnostic(writer, kind, &text)?;
+        }
+        Ok(())
     }
 
     /// Records an I/O error, logs the appropriate warning/error, and sends
@@ -373,7 +421,11 @@ impl GeneratorContext {
             // `c` is FERROR only for a protocol < 28 daemon; oc's protocol floor
             // is 28, so this is always FWARNING. `fname` is already quoted and
             // carries the daemon module suffix (util1.c:1273 full_fname).
-            self.emit_sender_warning(writer, &format!("file has vanished: {fname}\n"))?;
+            self.emit_sender_diagnostic(
+                writer,
+                SenderDiagnostic::Warning,
+                &format!("file has vanished: {fname}\n"),
+            )?;
         } else {
             self.io_error |= super::io_error_flags::IOERR_GENERAL;
             // upstream: sender.c:393 - rsyserr(FERROR_XFER, errno, "send_files failed to open %s", ...)
@@ -381,13 +433,7 @@ impl GeneratorContext {
                 "rsync: [sender] send_files failed to open {fname}: {}\n",
                 engine::local_copy::upstream_io_error(error),
             );
-            // MSG_ERROR_XFER exists at every supported protocol, so it carries
-            // no downgrade (upstream log.c:332-337 only remaps MSG_WARNING).
-            if self.config.connection.client_mode || !writer.is_multiplexed() {
-                eprint!("{text}");
-            } else {
-                writer.send_msg_error_xfer(text.as_bytes())?;
-            }
+            self.emit_sender_diagnostic(writer, SenderDiagnostic::ErrorXfer, &text)?;
         }
         if self.protocol.supports_generator_messages() {
             writer.send_no_send(ndx)?;
@@ -419,12 +465,7 @@ impl GeneratorContext {
             crate::full_fname::full_fname(path_display, self.daemon_module()),
             engine::local_copy::upstream_io_error(error),
         );
-        if self.config.connection.client_mode || !writer.is_multiplexed() {
-            eprint!("{text}");
-        } else {
-            writer.send_msg_error_xfer(text.as_bytes())?;
-        }
-        Ok(())
+        self.emit_sender_diagnostic(writer, SenderDiagnostic::ErrorXfer, &text)
     }
 
     /// Skips a source that has shrunk below its file-list length in append
@@ -450,8 +491,9 @@ impl GeneratorContext {
     ) -> io::Result<()> {
         // upstream: sender.c:422 - rprintf(FWARNING, "skipped diminished file: %s\n", ...)
         // full_fname quotes the path and appends the daemon module suffix.
-        self.emit_sender_warning(
+        self.emit_sender_diagnostic(
             writer,
+            SenderDiagnostic::Warning,
             &format!(
                 "skipped diminished file: {}\n",
                 crate::full_fname::full_fname(path_display, self.daemon_module()),

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -5584,3 +5584,146 @@ fn diminished_skip_frames_a_warning_in_server_mode() {
         "a diminished skip sets no io_error bit (upstream sender.c:421-429)"
     );
 }
+
+/// Walks `base` recursively as a daemon module server and returns the frames
+/// the queued file-list diagnostics produce on a multiplexed writer.
+///
+/// `client_mode` selects upstream's `!am_server` branch (log.c:330), where the
+/// text goes to the local terminal and nothing is framed.
+#[cfg(unix)]
+fn flist_walk_frames(
+    base: &Path,
+    client_mode: bool,
+) -> (Vec<(protocol::MessageCode, Vec<u8>)>, i32) {
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.args = vec![OsString::from(base)];
+    config.flags.recursive = true;
+    config.connection.client_mode = client_mode;
+    config.connection.daemon_module = Some("mymod".to_owned());
+    let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+    build_file_list_for(&mut ctx, base);
+
+    let mut buf = Vec::new();
+    {
+        let mut writer = crate::writer::ServerWriter::new_plain(&mut buf)
+            .activate_multiplex()
+            .unwrap();
+        ctx.flush_flist_diagnostics(&mut writer).unwrap();
+    }
+    (decode_mux_frames(&buf), ctx.io_error)
+}
+
+/// Creates `<dir>/denied` with mode 000 so the recursive walk's `read_dir`
+/// fails with EACCES, and returns its path.
+#[cfg(unix)]
+fn unreadable_subdir(dir: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let denied = dir.join("denied");
+    fs::create_dir(&denied).unwrap();
+    fs::set_permissions(&denied, fs::Permissions::from_mode(0o000)).unwrap();
+    denied
+}
+
+/// Restores traversal permission so `TempDir::drop` can remove the tree.
+#[cfg(unix)]
+fn restore_subdir(denied: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(denied, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+/// upstream flist.c:1878 - `rsyserr(FERROR_XFER, errno, "opendir %s failed",
+/// full_fname(fbuf))`, and `rwrite()` (log.c:330-340) re-sends an `am_server`
+/// diagnostic as a MSG frame instead of writing it to the server's own stderr.
+/// A daemon's stderr goes to its log, not to the client, so without the frame
+/// the client sees a bare exit 23 and no reason for it.
+#[cfg(unix)]
+#[test]
+fn flist_opendir_failure_frames_an_error_xfer_in_server_mode() {
+    let temp = TempDir::new().unwrap();
+    let denied = unreadable_subdir(temp.path());
+
+    let (frames, io_error) = flist_walk_frames(temp.path(), false);
+    restore_subdir(&denied);
+
+    assert_eq!(frames.len(), 1, "one opendir diagnostic: {frames:?}");
+    assert_eq!(
+        frames[0].0,
+        protocol::MessageCode::ErrorXfer,
+        "FERROR_XFER never downgrades, so it frames as MSG_ERROR_XFER"
+    );
+    assert_eq!(
+        String::from_utf8(frames[0].1.clone()).unwrap(),
+        format!(
+            "rsync: [sender] opendir \"{}\" (in mymod) failed: Permission denied (13)\n",
+            denied.display()
+        ),
+        "the framed text must stay byte-identical to the rsyserr rendering, \
+         daemon module suffix and trailing newline included"
+    );
+    assert_eq!(
+        io_error,
+        super::io_error_flags::IOERR_GENERAL,
+        "upstream flist.c:1877 sets IOERR_GENERAL, which lands the run on exit 23"
+    );
+}
+
+/// A client owns the terminal, so upstream's `!am_server` branch writes the
+/// text locally and frames nothing. Framing it as well would double-print over
+/// SSH, where the server's stderr already reaches the user.
+#[cfg(unix)]
+#[test]
+fn flist_opendir_failure_emits_no_frame_in_client_mode() {
+    let temp = TempDir::new().unwrap();
+    let denied = unreadable_subdir(temp.path());
+
+    let (frames, io_error) = flist_walk_frames(temp.path(), true);
+    restore_subdir(&denied);
+
+    assert!(
+        frames.is_empty(),
+        "client mode writes stderr locally and frames nothing: {frames:?}"
+    );
+    assert_eq!(
+        io_error,
+        super::io_error_flags::IOERR_GENERAL,
+        "the transport choice must not change the exit-code accounting"
+    );
+}
+
+/// upstream log.c:332-337 - protocol < 30 has no MSG_WARNING, so the FWARNING
+/// the walk raises for a vanished entry (flist.c:1314-1318) must ride MSG_INFO.
+/// Sending code 4 to a protocol-29 peer would abort it with an unknown-message
+/// error.
+#[test]
+fn flist_vanished_warning_downgrades_to_info_below_protocol_30() {
+    for (protocol_version, expected) in [
+        (29u8, protocol::MessageCode::Info),
+        (32u8, protocol::MessageCode::Warning),
+    ] {
+        let handshake = test_handshake_with_protocol(protocol_version);
+        let mut config = test_config();
+        config.protocol = ProtocolVersion::try_from(protocol_version).unwrap();
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+        ctx.queue_flist_diagnostic(
+            super::protocol_io::SenderDiagnostic::Warning,
+            "file has vanished: \"src/gone.txt\"\n".to_owned(),
+        );
+
+        let mut buf = Vec::new();
+        {
+            let mut writer = crate::writer::ServerWriter::new_plain(&mut buf)
+                .activate_multiplex()
+                .unwrap();
+            ctx.flush_flist_diagnostics(&mut writer).unwrap();
+        }
+        let frames = decode_mux_frames(&buf);
+        assert_eq!(frames.len(), 1, "protocol {protocol_version}: {frames:?}");
+        assert_eq!(frames[0].0, expected, "protocol {protocol_version}");
+        assert_eq!(frames[0].1, b"file has vanished: \"src/gone.txt\"\n");
+        assert!(
+            ctx.pending_flist_diagnostics.is_empty(),
+            "the flush must drain the queue so a later flush cannot repeat it"
+        );
+    }
+}

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -81,13 +81,20 @@ impl GeneratorContext {
         // upstream: flist.c:2227 - send_file_list()
         let file_count = {
             let _t = PhaseTimer::new("file-list-build-send");
-            if files_from_entries.is_empty() {
-                self.build_file_list(paths)?;
+            let build = if files_from_entries.is_empty() {
+                self.build_file_list(paths)
             } else {
                 // upstream: flist.c:2240-2244 - argv[0] is the base for --files-from
                 let base_dir = paths.first().cloned().unwrap_or_else(|| PathBuf::from("."));
-                self.build_file_list_with_base(&base_dir, &files_from_entries)?;
-            }
+                self.build_file_list_with_base(&base_dir, &files_from_entries)
+            };
+            // upstream reports walk failures from inside send_file_list() via
+            // rwrite(), which reaches f_out directly. oc has no writer during
+            // the walk, so the queued lines go out here - still before the
+            // first file-list byte, and before an aborted walk propagates, so
+            // the client learns why either way.
+            self.flush_flist_diagnostics(writer)?;
+            build?;
             self.partition_file_list_for_inc_recurse();
             self.send_file_list(writer)?
         };


### PR DESCRIPTION
## Problem

The generator's file-list walk reported its failures with `eprintln!`. In a
daemon or SSH server those bytes go to the server's own stderr, not to the
client, so pulling a module with an unreadable directory gave the user a bare
exit 23 and no reason for it.

## Upstream

Upstream reports the same conditions through `rwrite()`, which - when
`am_server` - re-sends the text as a multiplexed frame *instead of* writing it
to the server's stderr (`log.c:330-340`, `send_msg(...); return;`).

| upstream site | message | logcode | frame |
|---|---|---|---|
| `flist.c:1846` (`interpret_stat_error`) | `link_stat %s failed` | `FERROR_XFER` | `MSG_ERROR_XFER` |
| `flist.c:2433` (`send_file_list` arg loop) | `link_stat %s failed` | `FERROR_XFER` | `MSG_ERROR_XFER` |
| `flist.c:1878` (`send_directory`) | `opendir %s failed` | `FERROR_XFER` | `MSG_ERROR_XFER` |
| `flist.c:1924` (`send_directory`) | `readdir(%s)` | `FERROR_XFER` | `MSG_ERROR_XFER` |
| `flist.c:1317` (`make_file`) | `file has vanished: %s` | `FWARNING` | `MSG_WARNING` |

`MSG_WARNING` does not exist below protocol 30, where `log.c:332-337` remaps it
to `MSG_INFO`. `MSG_ERROR_XFER` is valid at every supported protocol and never
downgrades.

## Change

The walk has no writer in scope - oc builds the whole list in memory before
`send_file_list()` writes a byte - so each diagnostic is queued with its
upstream log class and drained by the orchestrator immediately after the walk,
still ahead of the first file-list byte. An aborted walk flushes before the
error propagates, so the client learns why either way.

The drain goes through the same helper #6940 introduced for the per-file sender
diagnostics, generalised from `emit_sender_warning` to `emit_sender_diagnostic`
so both policies live in exactly one place:

- the protocol-30 `MSG_WARNING` -> `MSG_INFO` downgrade, and
- framing *instead of*, not in addition to, the local stderr write - which is
  what keeps the line from printing twice over SSH, where the server's stderr
  already reaches the user and oc's client also renders received frames.

Message text is unchanged; #6942 already routes these through `full_fname`.

## Verified against rsync 3.4.4

Daemon module `mymod` containing `sub/` at mode 000, pulled with the real
upstream 3.4.4 client (protocol 32), release builds from a clean checkout of
this branch and its parent.

**upstream 3.4.4 daemon (ground truth)** - client exit 23:

```
rsync: [sender] opendir "sub" (in mymod) failed: Permission denied (13)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1876) [generator=3.4.4]
```

**oc before** - client exit 23, client stderr has no explanation; the line
landed on the daemon's stderr instead:

```
client stderr:
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1876) [generator=3.4.4]

daemon stderr:
rsync: [sender] opendir "<ROOT>/mod/sub" (in mymod) failed: Permission denied (13)
```

**oc after** - client exit 23, the line reaches the client in upstream's
position, and the daemon's stderr is now empty (replace, not duplicate):

```
client stderr:
rsync: [sender] opendir "<ROOT>/mod/sub" (in mymod) failed: Permission denied (13)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1876) [generator=3.4.4]

daemon stderr:
(empty)
```

SSH double-print guard, upstream 3.4.4 client pulling from this branch as the
remote server (`--rsync-path`): the line appears exactly once, byte-identical
before and after, exit 23 both.

## Tests

`crates/transfer/src/generator/tests.rs`, following the #6940 conventions:

- `flist_opendir_failure_frames_an_error_xfer_in_server_mode` - walks a real
  mode-000 subdirectory as a daemon module server and pins the frame code to
  `MSG_ERROR_XFER` and the payload to the exact rsyserr rendering, daemon
  module suffix and trailing newline included, plus `IOERR_GENERAL`.
- `flist_opendir_failure_emits_no_frame_in_client_mode` - the same walk in
  client mode frames nothing, so nothing double-prints over SSH.
- `flist_vanished_warning_downgrades_to_info_below_protocol_30` - `FWARNING`
  rides `MSG_INFO` at protocol 29 and `MSG_WARNING` at 32, and the flush drains
  the queue.

## Out of scope

Two divergences visible in the captures above are pre-existing and untouched
here:

- oc renders the absolute path (`"<ROOT>/mod/sub"`) where a daemon upstream
  renders the module-relative one (`"sub"`), because upstream `chdir`s into the
  module root before the walk.
- upstream also writes the line to the daemon's log file (`log.c:294-301`,
  `logit()` runs before the `am_server` frame branch); oc writes it to the log
  neither before this change nor after.

Also unrelated: oc's client still enters its receive loop after an empty file
list where upstream stops (`main.c:1379-1391`).
