### PR TITLE
fix(transfer): report dry-run rows and counts like upstream

### DIFF
--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -10,6 +10,7 @@
 //! - `generator.c:954` - `try_dests_reg()` for reference directory handling
 //! - `generator.c:624` - `quick_check_ok()` evaluation order
 
+use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -25,6 +26,27 @@ use crate::receiver::quick_check::{
 };
 use crate::receiver::stats::{ListOnlyEntry, TransferStats};
 use crate::receiver::{ReceiverContext, apply_acls_from_receiver_cache};
+
+/// One entry as a `--dry-run` reports it: its flist index, the file-list entry,
+/// and the itemize flags a real run would have carried for it.
+///
+/// upstream: `generator.c:581-600` - `itemize()` writes `write_ndx(ndx)` plus
+/// the `iflags` shortint for every entry whose flags are significant, so a
+/// dry-run plan is exactly "the entries upstream would put on the wire".
+pub(in crate::receiver) type DryRunItem<'a> = (usize, &'a FileEntry, u32);
+
+/// Counts the directories a `--dry-run` plan would create, for the summary's
+/// `directories_created` field.
+///
+/// upstream: `receiver.c:736-738` - `stats.created_dirs++` under
+/// `iflags & ITEM_IS_NEW`, which runs whether or not the mkdir happened.
+pub(in crate::receiver) fn new_dir_count(plan: &[DryRunItem<'_>]) -> u64 {
+    plan.iter()
+        .filter(|(_, entry, iflags)| {
+            entry.is_dir() && iflags & crate::generator::ItemFlags::ITEM_IS_NEW != 0
+        })
+        .count() as u64
+}
 
 impl ReceiverContext {
     /// Snapshots every active file-list entry for `--list-only` rendering.
@@ -422,38 +444,54 @@ impl ReceiverContext {
         files_to_transfer
     }
 
-    /// Records the deferred itemize rows for a `--dry-run` receive, one per
-    /// file-list entry in flist-index order.
+    /// Reports a `--dry-run` receive and returns the items whose NDX + iflags
+    /// still have to cross the wire, in flist-index order.
     ///
-    /// Upstream runs the identical `recv_generator()` per-entry loop under
-    /// `--dry-run`; only the data transfer and the filesystem mutation are
-    /// suppressed (`set_file_attrs()` returns early when `dry_run`, rsync.c;
-    /// `do_mkdir`/`do_open` sit behind `if (!do_xfers) goto notify_others`).
-    /// The `itemize()` call itself always runs, so `-ni` prints a row for every
-    /// entry (`>f+++++++++`, `cd+++++++++`, `cL+++++++++`, ...). oc's shipped
-    /// remote receive path (`run_pipelined`) instead early-returns out of the
-    /// directory-creation and candidate passes when `skip_dest_writes()` is set,
-    /// so no itemize row was ever recorded on a network dry run. This read-only
-    /// pass restores the rows without writing anything to the destination.
+    /// This is the single dry-run reporting pass shared by both receiver
+    /// drivers (`run_pipelined` and `run_pipelined_incremental`). Upstream runs
+    /// the identical `recv_generator()` per-entry loop under `--dry-run`; only
+    /// the data transfer and the filesystem mutation are suppressed
+    /// (`set_file_attrs()` returns early when `dry_run`, rsync.c:498-499;
+    /// `do_mkdir`/`do_unlink` are `if (dry_run) return 0;`, syscall.c:1010-1016).
+    /// The `itemize()` call and the receiver's `created_files` tally always run,
+    /// so `-ni` prints a row for every changing entry (`>f+++++++++`,
+    /// `cd+++++++++`, `cL+++++++++`, ...) and `--stats` reports the counts a real
+    /// run would produce. oc's remote receive paths early-return out of the
+    /// directory-creation, symlink, and candidate passes when
+    /// `skip_dest_writes()` is set, so this read-only pass is the only place the
+    /// rows and tallies are produced. Nothing is written to the destination.
     ///
     /// Recording (not immediate emission) keeps the rows interleaved in
     /// flist-index order via the deferred flush (`flush_itemize_rows`), matching
-    /// upstream's single flist-index-order walk. `record_itemize` already gates
-    /// on `should_emit_itemize() && client_mode`, so this is a no-op for a plain
-    /// `-n` (no `-i`) and for a server-mode receiver (a push dry run, whose rows
-    /// travel as wire iflags and are printed by the client's sender).
+    /// upstream's single flist-index-order walk. `record_itemize` gates on
+    /// `should_emit_itemize() && client_mode`, so it is a no-op for a plain `-n`
+    /// (no `-i`) and for a server-mode receiver (a push dry run, whose rows
+    /// travel as wire iflags and are printed by the client's sender); the
+    /// created-file tally is deliberately outside that gate because upstream
+    /// counts it in the receiver regardless of `-i` (receiver.c:733-746).
+    ///
+    /// `candidates` is the regular-file candidate list from
+    /// [`Self::build_files_to_transfer`]; a regular file it dropped (daemon
+    /// filter, `--max-size`/`--min-size`) is neither reported nor requested,
+    /// mirroring upstream's `goto cleanup` before `notify_others`. Hard-link
+    /// followers are reported but never requested - the candidate pass excludes
+    /// them because upstream services them through `finish_hard_link()`.
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:1481-1483` - directory `itemize()` (runs under dry-run).
+    /// - `generator.c:1480-1483` - directory `itemize()` (runs under dry-run).
     /// - `generator.c:1935-1947` - regular-file `itemize()` at `notify_others`,
     ///   reached even when `!do_xfers`.
     /// - `generator.c:1594` / `generator.c:1462` - symlink / special `itemize()`.
-    /// - `rsync.c` `set_file_attrs()` - `if (dry_run) return 1;` (no mutation).
-    pub(in crate::receiver) fn record_dry_run_itemize(&self, dest_dir: &Path) {
-        if !self.should_emit_itemize() || !self.config.connection.client_mode {
-            return;
-        }
+    /// - `generator.c:581-600` - `itemize()` writes NDX + iflags for every entry
+    ///   whose flags are significant, transfer or not.
+    /// - `receiver.c:732-746` / `sender.c:293-309` - `ITEM_IS_NEW` bumps
+    ///   `stats.created_files` plus the per-type counter.
+    pub(in crate::receiver) fn plan_dry_run<'a>(
+        &'a self,
+        dest_dir: &Path,
+        candidates: &[(usize, &'a FileEntry, PathBuf, u32)],
+    ) -> Vec<DryRunItem<'a>> {
         let preserve_times = self.config.flags.times && !self.config.flags.ignore_times;
         let size_only = self.config.file_selection.size_only;
         let modify_window = self.config.file_selection.modify_window;
@@ -462,23 +500,37 @@ impl ReceiverContext {
         } else {
             None
         };
+        let requestable: HashSet<usize> = candidates.iter().map(|&(idx, ..)| idx).collect();
+        let mut plan = Vec::with_capacity(candidates.len());
         for (idx, entry) in self.file_list.iter().enumerate() {
+            let is_candidate = !entry.is_file() || requestable.contains(&idx);
+            if !is_candidate && !is_hardlink_follower(entry) {
+                continue;
+            }
             let rel = entry.path();
             let dest_path = if rel.as_os_str() == "." {
                 dest_dir.to_path_buf()
             } else {
                 dest_dir.join(rel)
             };
-            let iflags = crate::generator::ItemFlags::from_raw(self.dry_run_entry_iflags(
+            let raw = self.dry_run_entry_iflags(
                 entry,
                 &dest_path,
                 preserve_times,
                 size_only,
                 always_checksum,
                 modify_window,
-            ));
+            );
+            let iflags = crate::generator::ItemFlags::from_raw(raw);
             self.record_itemize(idx, &iflags, entry);
+            if raw & crate::generator::ItemFlags::ITEM_IS_NEW != 0 {
+                self.record_created(entry.mode());
+            }
+            if is_candidate && iflags.has_significant_flags() {
+                plan.push((idx, entry, raw));
+            }
         }
+        plan
     }
 
     /// Computes the itemize flags a single entry would carry on a `--dry-run`
@@ -855,6 +907,7 @@ impl ReceiverContext {
 #[cfg(test)]
 mod itemize_order_tests {
     use std::ffi::OsString;
+    use std::path::Path;
 
     use protocol::ProtocolVersion;
     use protocol::flist::FileEntry;
@@ -1060,23 +1113,70 @@ mod itemize_order_tests {
         );
     }
 
-    /// A `--dry-run` remote pull must itemize every file-list entry, matching
-    /// upstream's per-entry `itemize()` which runs even when `!do_xfers`. The
-    /// shipped receive path early-returns out of the directory-creation and
-    /// candidate passes under `skip_dest_writes()`, so before the fix `-ni`
-    /// printed zero itemize lines over the network. `record_dry_run_itemize`
-    /// records one deferred row per entry (in flist-index order) without writing
-    /// anything to the destination.
+    /// The wire plan as `(flist index, iflags)` pairs.
+    type PlanFlags = Vec<(usize, u32)>;
+    /// The recorded itemize rows as `(flist index, rendered line)` pairs.
+    type Rows = Vec<(usize, String)>;
+
+    /// Runs the dry-run candidate + reporting passes exactly as both receiver
+    /// drivers do, and returns the wire plan alongside the recorded rows.
+    fn dry_run_pass(ctx: &ReceiverContext, dest: &Path) -> (PlanFlags, Rows) {
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+        let mut stats = TransferStats::default();
+        let mut metadata_errors = Vec::new();
+        let candidates = ctx.build_files_to_transfer(
+            &mut writer,
+            dest,
+            &metadata::MetadataOptions::default(),
+            None,
+            &mut metadata_errors,
+            &mut stats,
+            None,
+            None,
+        );
+        let plan = ctx.plan_dry_run(dest, &candidates);
+        let rows = ctx
+            .itemize_rows
+            .borrow()
+            .iter()
+            .map(|(idx, lines)| (*idx, lines[0].clone()))
+            .collect();
+        (
+            plan.into_iter()
+                .map(|(idx, _, iflags)| (idx, iflags))
+                .collect(),
+            rows,
+        )
+    }
+
+    /// A `--dry-run` receive must itemize every changing file-list entry, count
+    /// every entry it would create, and put the same NDX + iflags on the wire a
+    /// real run would - all without touching the destination.
     ///
-    /// upstream: generator.c:1481-1483 / :1935-1947 / :1594 - itemize() under
-    /// dry-run; rsync.c set_file_attrs() returns early when dry_run (no mutation).
+    /// Upstream gates only the mutations: `do_mkdir` is `if (dry_run) return 0;`
+    /// (syscall.c:1010-1016) and `set_file_attrs()` returns early (rsync.c:498),
+    /// while `itemize()` (generator.c:1480-1483) and `stats.created_files++`
+    /// (receiver.c:732-746) run unconditionally. oc's receive paths early-return
+    /// out of the directory-creation, symlink, and candidate passes under
+    /// `skip_dest_writes()`, so this shared pass is the only producer of all
+    /// three - and it is shared precisely so the two drivers cannot answer
+    /// differently.
+    ///
+    /// The `iflags` assertion is the load-bearing one for a PUSH: those exact
+    /// bits are what the peer sender renders. Sending a bare `ITEM_TRANSFER`
+    /// (what shipped) turned `>f+++++++++` into `<f.........` and left the
+    /// peer's created-file tally at zero.
     #[test]
-    fn dry_run_itemize_records_a_row_per_entry_without_writing() {
+    fn dry_run_plan_reports_rows_counts_and_wire_flags_without_writing() {
+        use crate::generator::ItemFlags;
+
         let dir = test_support::create_tempdir();
         let dest = dir.path();
 
         let hs = handshake();
-        let mut ctx = ReceiverContext::new_for_test(&hs, itemize_client_config());
+        let mut config = itemize_client_config();
+        config.flags.dry_run = true;
+        let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.defer_itemize = true;
         ctx.file_list = vec![
             FileEntry::new_directory("d".into(), 0o755),  // idx 0
@@ -1085,14 +1185,7 @@ mod itemize_order_tests {
         ];
 
         // Read-only pass against an empty destination: every entry is new.
-        ctx.record_dry_run_itemize(dest);
-
-        let rows: Vec<(usize, String)> = ctx
-            .itemize_rows
-            .borrow()
-            .iter()
-            .map(|(idx, lines)| (*idx, lines[0].clone()))
-            .collect();
+        let (plan, rows) = dry_run_pass(&ctx, dest);
 
         let keys: Vec<usize> = rows.iter().map(|(idx, _)| *idx).collect();
         assert_eq!(
@@ -1116,6 +1209,24 @@ mod itemize_order_tests {
             rows[2].1
         );
 
+        assert_eq!(
+            plan,
+            vec![
+                (0, ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW),
+                (1, ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW),
+                (2, ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW),
+            ],
+            "the wire plan must carry the directory and symlink too, each with \
+             the itemize flags a real run would have sent"
+        );
+
+        // upstream: receiver.c:732-746 - created_files counts every ITEM_IS_NEW
+        // entry; reg is the derived remainder (3 - 1 dir - 1 link = 1).
+        let created = ctx.created_stats.get();
+        assert_eq!(created.files, 3, "created_files");
+        assert_eq!(created.dirs, 1, "created_dirs");
+        assert_eq!(created.symlinks, 1, "created_symlinks");
+
         // The pass writes nothing: the destination stays empty.
         let entries: Vec<_> = std::fs::read_dir(dest)
             .expect("dest readable")
@@ -1127,27 +1238,73 @@ mod itemize_order_tests {
         );
     }
 
-    /// Without `-i`, the dry-run itemize pass records nothing (the bare `-v`
-    /// name path handles verbose output instead), and a server-mode receiver
-    /// (a push dry run) records nothing here either - its rows travel as wire
-    /// iflags printed by the client's sender.
+    /// Without `-i` the pass records no row - the bare `-v` name path handles
+    /// verbose output instead - but it must still count what it would create
+    /// and still plan the wire request.
+    ///
+    /// Upstream's `stats.created_files++` sits outside the itemize gate
+    /// (receiver.c:733 runs for every `ITEM_IS_NEW`, whether or not
+    /// `stdout_format_has_i`), so `-n --stats` without `-i` reports the same
+    /// "Number of created files" as `-ni --stats`. Folding the tally into the
+    /// `-i` gate is the easy mistake this pins.
     #[test]
-    fn dry_run_itemize_is_noop_without_itemize_flag() {
+    fn dry_run_plan_counts_creations_without_the_itemize_flag() {
         let dir = test_support::create_tempdir();
         let dest = dir.path();
 
         let hs = handshake();
         let mut config = itemize_client_config();
         config.flags.info_flags.itemize = false;
+        config.flags.dry_run = true;
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.defer_itemize = true;
         ctx.file_list = vec![FileEntry::new_file("f".into(), 1, 0o644)];
 
-        ctx.record_dry_run_itemize(dest);
+        let (plan, rows) = dry_run_pass(&ctx, dest);
 
-        assert!(
-            ctx.itemize_rows.borrow().is_empty(),
-            "no itemize rows recorded without -i"
+        assert!(rows.is_empty(), "no itemize rows recorded without -i");
+        assert_eq!(plan.len(), 1, "the file is still requested over the wire");
+        assert_eq!(
+            ctx.created_stats.get().files,
+            1,
+            "the created-file tally is independent of the -i gate"
+        );
+    }
+
+    /// A server-mode receiver (the remote end of a PUSH) records no local row -
+    /// upstream's `log.c:822` gates the `FCLIENT` write on `!am_server` and the
+    /// client's sender prints instead - but it must still classify every entry,
+    /// because those classifications ARE the push's output once they cross the
+    /// wire as iflags.
+    #[test]
+    fn dry_run_plan_on_a_server_receiver_still_classifies_for_the_wire() {
+        use crate::generator::ItemFlags;
+
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+
+        let hs = handshake();
+        let mut config = itemize_client_config();
+        config.flags.dry_run = true;
+        config.connection.client_mode = false;
+        let mut ctx = ReceiverContext::new_for_test(&hs, config);
+        ctx.defer_itemize = true;
+        ctx.file_list = vec![
+            FileEntry::new_directory("d".into(), 0o755),
+            FileEntry::new_file("d/f1".into(), 5, 0o644),
+        ];
+
+        let (plan, rows) = dry_run_pass(&ctx, dest);
+
+        assert!(rows.is_empty(), "a server receiver prints no row itself");
+        assert_eq!(
+            plan,
+            vec![
+                (0, ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW),
+                (1, ItemFlags::ITEM_TRANSFER | ItemFlags::ITEM_IS_NEW),
+            ],
+            "the client sender renders `cd+++++++++` / `<f+++++++++` from exactly \
+             these bits, so they must survive the server-mode row suppression"
         );
     }
 }

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -560,9 +560,23 @@ impl ReceiverContext {
     /// Dry-run transfer loop: sends NDX requests without data transfer.
     ///
     /// Mirrors upstream generator.c behavior during `!do_xfers`: sends NDX and
-    /// iflags for each file candidate, reads the echoed NDX+iflags from the
-    /// sender. No sum head or file data is exchanged. This allows the sender to
-    /// log each file name for verbose output.
+    /// iflags for each planned item, reads the echoed NDX+iflags from the
+    /// sender. No sum head or file data is exchanged. This is what makes a push
+    /// dry run print anything at all: on a push this side is the server
+    /// receiver, its rows never reach the user's terminal directly, and the
+    /// client sender renders them from exactly these iflags.
+    ///
+    /// The plan carries non-transfer items too - a new directory, a new symlink,
+    /// an attribute-only regular-file change - because upstream's `itemize()`
+    /// writes NDX + iflags for every entry with significant flags, not just the
+    /// ones with `ITEM_TRANSFER` (generator.c:581-600), and the peer's
+    /// `send_files()` echoes both kinds (sender.c:292-310 for non-transfer,
+    /// sender.c:347-350 for `!do_xfers` transfers).
+    ///
+    /// Returns `(transfer_items, transferred_size)` - upstream bumps
+    /// `stats.xferred_files` and `stats.total_transferred_size` before the
+    /// `if (!do_xfers)` continue (receiver.c:781-784), so a dry run reports the
+    /// same "Number of regular files transferred" as the real run would.
     ///
     /// upstream: generator.c:1858-1959 - `!do_xfers` path sends write_ndx() then
     /// goto cleanup, skipping write_sum_head(). sender.c:394-399 - `!do_xfers`
@@ -574,13 +588,15 @@ impl ReceiverContext {
         &self,
         reader: &mut crate::reader::ServerReader<R>,
         writer: &mut W,
-        files_to_transfer: &[(usize, &FileEntry, PathBuf, u32)],
-    ) -> io::Result<()> {
-        if files_to_transfer.is_empty() {
+        plan: &[super::candidates::DryRunItem<'_>],
+    ) -> io::Result<(usize, u64)> {
+        if plan.is_empty() {
             writer.flush()?;
-            return Ok(());
+            return Ok((0, 0));
         }
 
+        let mut transfer_items = 0usize;
+        let mut transferred_size = 0u64;
         let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
         let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
         let write_iflags = self.protocol.supports_iflags();
@@ -593,19 +609,28 @@ impl ReceiverContext {
         // upstream: io.c perform_io() flushes output via select() while waiting
         // for input. We flush once before blocking on each response read, but
         // only when needed (the multiplex dirty-flag skips redundant syscalls).
-        for &(file_idx, file_entry, _, base_iflags) in files_to_transfer {
+        for &(file_idx, file_entry, item_iflags) in plan {
+            let needs_transfer = item_iflags & crate::generator::ItemFlags::ITEM_TRANSFER != 0;
+            if needs_transfer {
+                // upstream: receiver.c:783-784 - xferred_files and
+                // total_transferred_size are summed before the `!do_xfers`
+                // continue, so a dry run reports what the real run would move.
+                transfer_items += 1;
+                transferred_size += file_entry.size();
+            }
+
             // upstream: generator.c:1938 - write_ndx(f_out, ndx)
             let wire_ndx = self.flat_to_wire_ndx(file_idx);
             ndx_write_codec.write_ndx(&mut *writer, wire_ndx)?;
 
-            // upstream: generator.c:1937-1947 - iflags carry the full itemize
-            // bits (ITEM_TRANSFER plus the pre-transfer attribute diff, incl.
-            // ITEM_IS_NEW for a new dest) so the sender prints the right glyph
-            // (e.g. `<f+++++++++` for a new file) even in a dry run.
+            // upstream: generator.c:1937-1947 then itemize() at 581-600 - the
+            // iflags shortint carries the full itemize bits computed against the
+            // pre-transfer destination (ITEM_IS_NEW for an absent one, the
+            // attribute diff for an existing one). Sending a bare ITEM_TRANSFER
+            // here made every pushed file render as `<f.........` instead of
+            // `<f+++++++++` and left the peer's created-file tally at zero.
             if write_iflags {
-                use crate::receiver::wire::SenderAttrs;
-                let iflags = ((base_iflags & 0xFFFF) as u16) | SenderAttrs::ITEM_TRANSFER;
-                writer.write_all(&iflags.to_le_bytes())?;
+                writer.write_all(&((item_iflags & 0xFFFF) as u16).to_le_bytes())?;
             }
 
             // Flush before blocking on the sender's echo. The multiplex
@@ -629,7 +654,11 @@ impl ReceiverContext {
             // so emit the "updated" line at the post-decision point to
             // match upstream wire order. Under `-i`/`-vi` the itemize row
             // already carries the name, so the bare name is suppressed.
-            if self.config.flags.verbose
+            // Transfer items only: a directory's `-v` name line is produced by
+            // the deferred `verbose_dir_lines` buffer, so naming it here too
+            // would double it.
+            if needs_transfer
+                && self.config.flags.verbose
                 && self.config.connection.client_mode
                 && !self.should_emit_itemize()
             {
@@ -638,7 +667,7 @@ impl ReceiverContext {
         }
 
         writer.flush()?;
-        Ok(())
+        Ok((transfer_items, transferred_size))
     }
 
     /// Receiver loop for `--only-write-batch=X` (upstream `write_batch < 0`).

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -195,7 +195,10 @@ impl ReceiverContext {
             // no delta (the client sender records it into its own batch fd,
             // sender.c:217); a pull receiver drains the sender's delta via
             // discard_receive_data() (receiver.c:813-814).
-            let _ = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
+            // Same shared reporting pass as the plain dry run below; only the
+            // wire loop differs (real block checksums, no plan).
+            let plan = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
+            stats.directories_created = new_dir_count(&plan);
             self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
         } else if self.config.flags.dry_run {
             // upstream: recv_generator() itemizes every entry and the receiver

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -16,6 +16,8 @@ use crate::pipeline::PipelineConfig;
 use crate::receiver::stats::TransferStats;
 use crate::receiver::{REDO_CHECKSUM_LENGTH, ReceiverContext};
 
+use super::candidates::new_dir_count;
+
 impl ReceiverContext {
     /// Runs the pipelined receiver transfer loop.
     ///
@@ -193,17 +195,21 @@ impl ReceiverContext {
             // no delta (the client sender records it into its own batch fd,
             // sender.c:217); a pull receiver drains the sender's delta via
             // discard_receive_data() (receiver.c:813-814).
-            self.record_dry_run_itemize(&setup.dest_dir);
+            let _ = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
             self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
         } else if self.config.flags.dry_run {
-            // upstream: recv_generator() itemizes every entry even under
-            // --dry-run (only the data transfer and filesystem mutation are
-            // skipped). The directory-creation and candidate passes above
-            // early-return under skip_dest_writes(), so record the deferred
-            // itemize rows here in flist-index order; flush_itemize_rows below
-            // drains them. Read-only: nothing is written to the destination.
-            self.record_dry_run_itemize(&setup.dest_dir);
-            self.run_dry_run_loop(reader, writer, &files_to_transfer)?;
+            // upstream: recv_generator() itemizes every entry and the receiver
+            // tallies every ITEM_IS_NEW even under --dry-run (only the data
+            // transfer and filesystem mutation are skipped). The
+            // directory-creation, symlink, and candidate passes above
+            // early-return under skip_dest_writes(), so plan_dry_run is the one
+            // place the rows and created-file counts are produced - shared with
+            // run_pipelined_incremental so the two drivers cannot drift.
+            // Read-only: nothing is written to the destination.
+            let plan = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
+            stats.directories_created = new_dir_count(&plan);
+            (files_transferred, transferred_file_size) =
+                self.run_dry_run_loop(reader, writer, &plan)?;
         } else {
             let total_files = files_to_transfer.len();
             let redo_config = pipeline_config.clone();

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -208,7 +208,10 @@ impl ReceiverContext {
             // reads no delta (the client sender diverted it into its own batch
             // fd, sender.c:217); a pull receiver drains the remote sender's
             // delta via discard_receive_data() (receiver.c:813-814).
-            let _ = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
+            // Same shared reporting pass as the plain dry run below; only the
+            // wire loop differs (real block checksums, no plan).
+            let plan = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
+            stats.directories_created = new_dir_count(&plan);
             self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
         } else if self.config.flags.dry_run {
             // The same shared dry-run pass `run_pipelined` uses. This driver

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -8,13 +8,15 @@
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
 
-use logging::{PhaseTimer, debug_log};
+use logging::{PhaseTimer, debug_log, info_log};
 use protocol::codec::create_ndx_codec;
 use protocol::flist::FileEntry;
 
 use crate::pipeline::PipelineConfig;
 use crate::receiver::stats::TransferStats;
 use crate::receiver::{REDO_CHECKSUM_LENGTH, ReceiverContext};
+
+use super::candidates::new_dir_count;
 
 impl ReceiverContext {
     /// Runs the receiver with incremental directory creation and failed-dir tracking.
@@ -66,8 +68,34 @@ impl ReceiverContext {
         // upstream: generator.c:1329-1338 - make_path() for relative_paths
         self.ensure_relative_parents(&setup.dest_dir);
 
+        // A dry run reports its directories from the shared `plan_dry_run` pass
+        // below, exactly like `run_pipelined`. Running this walk too would
+        // record every directory row and created-dir tally twice; it creates
+        // nothing under `skip_dest_writes()` anyway (#6947). `--list-only` does
+        // not set `dry_run`, so its walk is untouched. Only the plain-`-v` name
+        // lines the walk emits as a side effect (creation.rs:777-786) are
+        // reproduced here, since `plan_dry_run` deals in itemize rows.
+        let walk_dirs = !self.config.flags.dry_run;
+        if !walk_dirs
+            && self.config.flags.verbose
+            && self.config.connection.client_mode
+            && !self.should_emit_itemize()
+        {
+            for rel in self
+                .file_list
+                .iter()
+                .filter(|entry| entry.is_dir())
+                .map(protocol::flist::FileEntry::path)
+            {
+                if rel.as_os_str() == "." {
+                    info_log!(Name, 1, "./");
+                } else {
+                    info_log!(Name, 1, "{}/", rel.display());
+                }
+            }
+        }
         for (flist_idx, file_entry) in self.file_list.iter().enumerate() {
-            if file_entry.is_dir() {
+            if walk_dirs && file_entry.is_dir() {
                 let result = self.create_directory_incremental(
                     &setup.dest_dir,
                     file_entry,
@@ -180,10 +208,17 @@ impl ReceiverContext {
             // reads no delta (the client sender diverted it into its own batch
             // fd, sender.c:217); a pull receiver drains the remote sender's
             // delta via discard_receive_data() (receiver.c:813-814).
-            self.record_dry_run_itemize(&setup.dest_dir);
+            let _ = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
             self.run_only_write_batch_loop(reader, writer, &files_to_transfer, &setup)?;
         } else if self.config.flags.dry_run {
-            self.run_dry_run_loop(reader, writer, &files_to_transfer)?;
+            // The same shared dry-run pass `run_pipelined` uses. This driver
+            // previously produced only the directory rows its creation walk
+            // emitted as a side effect - no regular-file or symlink row at all -
+            // because it never had a reporting pass of its own.
+            let plan = self.plan_dry_run(&setup.dest_dir, &files_to_transfer);
+            stats.directories_created = new_dir_count(&plan);
+            (files_transferred, transferred_file_size) =
+                self.run_dry_run_loop(reader, writer, &plan)?;
         } else {
             let total_files = files_to_transfer.len();
             let redo_config = pipeline_config.clone();

--- a/tests/dry_run_itemize_stats_remote.rs
+++ b/tests/dry_run_itemize_stats_remote.rs
@@ -1,0 +1,339 @@
+//! `--dry-run` reporting fidelity over a remote shell, in both directions.
+//!
+//! Upstream suppresses only the *mutations* under `-n`, never the reporting:
+//!
+//! ```c
+//! /* syscall.c:1010-1016 */
+//! int do_mkdir(const char *path, mode_t mode) { if (dry_run) return 0; ... }
+//! /* rsync.c:498-499 */
+//! if (dry_run) return 1;                 /* set_file_attrs() */
+//!
+//! /* generator.c:1480-1483 - runs whether or not the mkdir happened */
+//! if (itemizing && f_out != -1)
+//!     itemize(fnamecmp, file, ndx, statret, &sx, statret ? ITEM_LOCAL_CHANGE : 0, 0, NULL);
+//!
+//! /* receiver.c:732-746 - and so does the created-file tally */
+//! if (iflags & ITEM_IS_NEW) {
+//!     stats.created_files++;
+//!     ... else if (S_ISDIR(file->mode)) stats.created_dirs++; ...
+//! }
+//! ```
+//!
+//! So `-ni --stats` must print exactly the rows and counts a real run would
+//! produce, while leaving the destination byte-for-byte untouched. Verified
+//! against rsync 3.4.4 (protocol 32) on the same tree:
+//!
+//! ```text
+//! $ rsync -a -n -i --stats src/ host:dest/
+//! <f+++++++++ alpha.txt
+//! <f+++++++++ beta.txt
+//! cL+++++++++ link -> alpha.txt
+//! cd+++++++++ sub/
+//! <f+++++++++ sub/gamma.txt
+//! Number of created files: 5 (reg: 3, dir: 1, link: 1)
+//! Number of regular files transferred: 3
+//! Total transferred file size: 40 bytes
+//! ```
+//!
+//! WHY this lives at the binary level rather than in a receiver unit test: the
+//! receiver has two drivers, `run_pipelined` and `run_pipelined_incremental`,
+//! picked by the `incremental-flist` feature. A unit test compiles one of them;
+//! this file compiles whichever the build selected, so the default build and
+//! CI's `--all-features` build each assert the same expectations against a
+//! different driver. Three separate bugs have already come from those two
+//! ladders drifting apart, and every one of them was invisible to a test that
+//! exercised only the shared helper.
+//!
+//! The "remote" is the oc-rsync binary itself behind a `--rsh` shim, so both
+//! roles run for real: on a push the rows are computed by the *server*
+//! receiver, put on the wire as iflags, and rendered by the client sender; on a
+//! pull the client receiver renders them itself.
+//!
+//! Skip conditions (test passes with a printed reason):
+//! - Not Unix (the shim uses `/bin/sh`).
+
+#![cfg(unix)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// The itemize rows rsync 3.4.4 prints for [`setup`]'s tree, in flist order.
+///
+/// `%c` is the direction glyph: `<` when the client is the sender (push), `>`
+/// when it is the receiver (pull). The symlink and directory rows carry `c`
+/// (locally created) in both directions.
+fn expected_rows(direction: char) -> Vec<String> {
+    vec![
+        format!("{direction}f+++++++++ alpha.txt"),
+        format!("{direction}f+++++++++ beta.txt"),
+        "cL+++++++++ link -> alpha.txt".to_owned(),
+        "cd+++++++++ sub/".to_owned(),
+        format!("{direction}f+++++++++ sub/gamma.txt"),
+    ]
+}
+
+/// Locates the binary under test.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`, not `env::var_os`: at run time it is unset and the lookup would fall
+/// through to whatever stale `target/debug/oc-rsync` happens to be on disk -
+/// silently testing a different build than the one just compiled.
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    if built.is_file() {
+        return built;
+    }
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    for profile in ["debug", "release", "dist"] {
+        let candidate = PathBuf::from(manifest_dir)
+            .join("target")
+            .join(profile)
+            .join("oc-rsync");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    PathBuf::from("oc-rsync")
+}
+
+/// Writes the `--rsh` shim.
+///
+/// oc-rsync invokes it with an SSH-style argv - `[<opts>..., <host>, <rsync
+/// path>, "--server", ...]`. The shim drops the options and the host, then
+/// execs the rest locally, giving a real two-process transfer over a pipe pair
+/// without needing an SSH server.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    let body = "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         # $1 is the host placeholder; the server command follows it.\n\
+         shift || true\n\
+         exec \"$@\"\n";
+    fs::write(&script, body).expect("write rsh shim");
+    let mut perms = fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).unwrap();
+    script
+}
+
+fn spawn_with_timeout(mut cmd: Command, timeout: Duration) -> Option<Output> {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+    // Drain both pipes on their own threads. Polling try_wait() while the pipes
+    // fill would deadlock: the child blocks writing into a full OS pipe buffer
+    // and therefore never exits. Draining also preserves the child's output so a
+    // real failure is reported instead of being swallowed by the timeout.
+    let mut child_stdout = child.stdout.take()?;
+    let mut child_stderr = child.stderr.take()?;
+    let stdout_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stdout.read_to_end(&mut buf);
+        buf
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stderr.read_to_end(&mut buf);
+        buf
+    });
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().ok()? {
+            Some(status) => {
+                return Some(Output {
+                    status,
+                    stdout: stdout_reader.join().unwrap_or_default(),
+                    stderr: stderr_reader.join().unwrap_or_default(),
+                });
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            None => thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+/// Every path under `dir`, relative and sorted - the destination fingerprint
+/// that must stay empty across a dry run.
+fn tree_paths(dir: &Path) -> BTreeSet<PathBuf> {
+    let mut paths = BTreeSet::new();
+    let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                stack.push(entry.path());
+            }
+            if let Ok(relative) = entry.path().strip_prefix(dir).map(Path::to_path_buf) {
+                paths.insert(relative);
+            }
+        }
+    }
+    paths
+}
+
+/// Lays out the source tree and an empty destination: two new regular files, a
+/// new subdirectory holding a third, and a new symlink - one of every entry
+/// kind the "Number of created files" breakdown reports separately.
+fn setup() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let temp = tempfile::TempDir::new().expect("create temp dir");
+    let root = temp.path();
+    let src = root.join("src");
+    let dest = root.join("dest");
+    fs::create_dir_all(src.join("sub")).unwrap();
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(src.join("alpha.txt"), b"alpha contents\n").unwrap();
+    fs::write(src.join("beta.txt"), b"beta contents here\n").unwrap();
+    fs::write(src.join("sub/gamma.txt"), b"gamma\n").unwrap();
+    std::os::unix::fs::symlink("alpha.txt", src.join("link")).unwrap();
+    (temp, src, dest)
+}
+
+/// Runs `-a -n -i --stats` over the shim in the requested direction.
+fn run_dry_run(shim: &Path, binary: &Path, src: &Path, dest: &Path, push: bool) -> Output {
+    let (from, to) = if push {
+        (
+            format!("{}/", src.display()),
+            format!("dryhost:{}/", dest.display()),
+        )
+    } else {
+        (
+            format!("dryhost:{}/", src.display()),
+            format!("{}/", dest.display()),
+        )
+    };
+    let mut cmd = Command::new(binary);
+    cmd.arg("-a")
+        .arg("-n")
+        .arg("-i")
+        .arg("--stats")
+        .arg("--rsh")
+        .arg(shim)
+        .arg("--rsync-path")
+        .arg(binary)
+        .arg(from)
+        .arg(to);
+    spawn_with_timeout(cmd, RUN_TIMEOUT).expect("dry run did not finish within the timeout")
+}
+
+/// Extracts the itemize rows: every line before the blank line that opens the
+/// `--stats` block.
+fn itemize_rows(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .take_while(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Returns the value part of a `--stats` line, e.g. `5 (reg: 3, dir: 1, link: 1)`.
+fn stat_line<'a>(stdout: &'a str, prefix: &str) -> &'a str {
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix(prefix))
+        .unwrap_or_else(|| panic!("missing {prefix:?} in --stats output:\n{stdout}"))
+        .trim()
+}
+
+/// Asserts one direction end to end: the rows, the itemized counts, and an
+/// untouched destination.
+///
+/// All three are asserted together on purpose. Rows without counts is the state
+/// the non-incremental driver shipped in (`Number of created files: 0` beside a
+/// full row set); counts without rows is what the incremental driver shipped
+/// (directory rows only, no regular-file or symlink row); and either fix is
+/// trivially "achievable" by letting the dry run create the destination, which
+/// is the bug the previous fix removed. Only the three together pin the
+/// behaviour to upstream's.
+fn assert_dry_run_fidelity(push: bool) {
+    let binary = oc_rsync_binary();
+    if !binary.is_file() {
+        eprintln!("skip: oc-rsync binary not built at {}", binary.display());
+        return;
+    }
+    let (temp, src, dest) = setup();
+    let shim = write_rsh_shim(temp.path());
+
+    let output = run_dry_run(&shim, &binary, &src, &dest, push);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let label = if push { "push" } else { "pull" };
+
+    assert!(
+        output.status.success(),
+        "{label} dry run must exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(
+        itemize_rows(&stdout),
+        expected_rows(if push { '<' } else { '>' }),
+        "{label} -ni rows must match rsync 3.4.4\nfull stdout:\n{stdout}"
+    );
+
+    // upstream: main.c:431 output_itemized_counts("Number of created files").
+    // The dir sub-count is 1, not 2: the transfer root `.` already exists, so
+    // only `sub/` is new.
+    assert_eq!(
+        stat_line(&stdout, "Number of created files:"),
+        "5 (reg: 3, dir: 1, link: 1)",
+        "{label} created-file breakdown\nfull stdout:\n{stdout}"
+    );
+    // upstream: receiver.c:781-784 / sender.c:341-343 - xferred_files and
+    // total_transferred_size are summed before the `!do_xfers` continue.
+    assert_eq!(
+        stat_line(&stdout, "Number of regular files transferred:"),
+        "3",
+        "{label} transferred-file count\nfull stdout:\n{stdout}"
+    );
+    assert_eq!(
+        stat_line(&stdout, "Total transferred file size:"),
+        "40 bytes",
+        "{label} transferred size\nfull stdout:\n{stdout}"
+    );
+
+    assert!(
+        tree_paths(&dest).is_empty(),
+        "{label} dry run must not touch the destination; found: {:?}",
+        tree_paths(&dest)
+    );
+}
+
+/// PUSH: the rows are produced by the remote *server* receiver and travel as
+/// wire iflags, so a wrong iflags word is the only thing that can break them.
+/// Sending a bare `ITEM_TRANSFER` rendered every new file as `<f.........` and
+/// dropped the directory and symlink rows entirely, because the receiver only
+/// ever requested regular files.
+#[test]
+fn dry_run_push_reports_rows_and_counts_like_upstream() {
+    assert_dry_run_fidelity(true);
+}
+
+/// PULL: the rows are rendered locally by the client receiver, so this pins the
+/// receiver's own reporting pass - the half that was silent on the incremental
+/// driver and uncounted on the non-incremental one.
+#[test]
+fn dry_run_pull_reports_rows_and_counts_like_upstream() {
+    assert_dry_run_fidelity(false);
+}


### PR DESCRIPTION
## Problem

Upstream suppresses only the *mutations* under `--dry-run`, never the reporting:

```c
/* syscall.c:1010-1016 */  int do_mkdir(...)  { if (dry_run) return 0; ... }
/* rsync.c:498-499     */  if (dry_run) return 1;          /* set_file_attrs() */

/* generator.c:1480-1483 - runs whether or not the mkdir happened */
if (itemizing && f_out != -1)
        itemize(fnamecmp, file, ndx, statret, &sx, statret ? ITEM_LOCAL_CHANGE : 0, 0, NULL);

/* receiver.c:732-746 - and so does the created-file tally */
if (iflags & ITEM_IS_NEW) {
        stats.created_files++;
        ... else if (S_ISDIR(file->mode)) stats.created_dirs++; ...
}
```

`-n` must therefore print exactly the rows and counts a real run would produce. oc printed
three different things instead, depending on which receiver driver the build selected:

| | `-ni` rows | `Number of created files` |
|---|---|---|
| `run_pipelined_incremental` (feature on) | directory rows only | dir sub-count only |
| `run_pipelined` (feature off) | full set (pull) | `0` |
| both, on a **push** | `<f.........`, no dir/link rows | `0` |

The push case is the wire half: the receiver sent a bare `ITEM_TRANSFER` word for regular
files only, so the peer sender - which is what actually renders a push's output - had
nothing else to render from.

## Verification against rsync 3.4.4 (protocol 32)

Source tree: two new regular files, a new subdirectory holding a third, a new symlink;
empty destination. Transport is a real remote shell in both directions.

### PUSH - `rsync -a -n -i --stats src/ host:dest/`

rsync 3.4.4:

```
<f+++++++++ alpha.txt
<f+++++++++ beta.txt
cL+++++++++ link -> alpha.txt
cd+++++++++ sub/
<f+++++++++ sub/gamma.txt

Number of created files: 5 (reg: 3, dir: 1, link: 1)
Number of regular files transferred: 3
Total transferred file size: 40 bytes
```

oc BEFORE (identical with the feature on and off):

```
<f......... alpha.txt
<f......... beta.txt
<f......... sub/gamma.txt

Number of created files: 0
Number of regular files transferred: 3
Total transferred file size: 40 bytes
```

oc AFTER (identical with the feature on and off) - matches 3.4.4 above line for line.

### PULL - `rsync -a -n -i --stats host:src/ dest/`

rsync 3.4.4:

```
>f+++++++++ alpha.txt
>f+++++++++ beta.txt
cL+++++++++ link -> alpha.txt
cd+++++++++ sub/
>f+++++++++ sub/gamma.txt

Number of created files: 5 (reg: 3, dir: 1, link: 1)
Number of regular files transferred: 3
Total transferred file size: 40 bytes
```

oc BEFORE, feature OFF - right rows, wrong counts:

```
>f+++++++++ alpha.txt
>f+++++++++ beta.txt
cL+++++++++ link -> alpha.txt
cd+++++++++ sub/
>f+++++++++ sub/gamma.txt

Number of created files: 0
Number of regular files transferred: 0
Total transferred file size: 0 bytes
```

oc BEFORE, feature ON - one row, one count:

```
cd+++++++++ sub/

Number of created files: 1 (dir: 1)
Number of regular files transferred: 0
Total transferred file size: 0 bytes
```

oc AFTER (identical with the feature on and off) - matches 3.4.4 above line for line.

The destination is empty after every run, before and after.

### Partially-updated tree (regression check for over-reporting)

Same tree, but `dest/alpha.txt` is already up to date, `dest/beta.txt` differs, `dest/sub/`
exists with an older mtime, `dest/link` is absent. rsync 3.4.4, push and pull:

```
Xf.st...... beta.txt          # X = '<' on a push, '>' on a pull
cL+++++++++ link -> alpha.txt
.d..t...... sub/
Xf+++++++++ sub/gamma.txt
Number of created files: 2 (reg: 1, link: 1)
Number of regular files transferred: 2
Total transferred file size: 25 bytes
```

Before, a push printed `<f.........` for all three regular files including the up-to-date
one, no directory or symlink row, and `created files: 0`; a pull printed the right rows but
`created files: 0` / `transferred: 0`. After, both directions and both feature settings
match the block above exactly - the up-to-date file is correctly silent (upstream's
`goto cleanup` before `notify_others`), and the attribute-only directory row survives.

### Residual differences (pre-existing, not touched here)

`Total bytes sent`/`received`, `File list size`, and the `File list generation/transfer time`
lines still differ from upstream on remote transfers, and a *local* `-n` still reports
`Literal data: 40 bytes` where upstream reports `0`. Plain `-nv` name lines are also still
ordered differently from upstream (`sending incremental file list` prints after the names).
None of these are dry-run specific and none are made worse by this change; they are separate
accounting/ordering gaps.

## Approach: converged, not patched separately

The two drivers were converged onto a single dry-run path rather than fixed twice. This is
the third bug caused by them drifting (a missing `only_write_batch` arm, a missing
`skip_dest_writes()` guard, and now the reporting gaps), so removing the class of defect was
the goal.

- New `plan_dry_run()` (candidates.rs) is the one dry-run pass: it classifies every file-list
  entry against the pre-transfer destination with the existing `dry_run_entry_iflags`,
  records the itemize row *and* the created-file tally, and returns the `(ndx, entry, iflags)`
  plan the wire needs. The created tally is deliberately outside the `-i` gate because
  upstream counts it regardless (`receiver.c:733`), so `-n --stats` without `-i` reports the
  same numbers.
- `run_dry_run_loop()` now takes that plan instead of the regular-file candidate list. It
  sends the real iflags word and includes non-transfer items, because upstream's `itemize()`
  writes `write_ndx` + the iflags shortint for **every** entry whose flags are significant
  (`generator.c:581-600`), and both `send_files()` arms echo it back
  (`sender.c:292-310`, `sender.c:347-350`). It returns the transferred-file count and size
  that upstream sums before the `if (!do_xfers)` continue (`receiver.c:781-784`).
- Both drivers now call `plan_dry_run` + `run_dry_run_loop` identically. `--only-write-batch`
  (which also sets `dry_run`) shares the same reporting pass.
- The incremental driver's directory walk is skipped under `dry_run` so it cannot
  double-report. The `skip_dest_writes()` guard added in #6947 stays exactly where it is,
  after the destination classification and the iflags computation - the walk is still the
  reporting source for every non-dry-run receive, and its unit test still exercises it
  directly. `--list-only` does not set `dry_run`, so its walk is untouched. The plain-`-v`
  directory name lines the walk emitted as a side effect are reproduced in the dry-run
  branch so `-nv` output is unchanged.

## Tests

- `tests/dry_run_itemize_stats_remote.rs` (new): drives a real two-process push and pull
  through an `--rsh` shim and asserts the itemize rows, `Number of created files`,
  `Number of regular files transferred`, `Total transferred file size`, **and** an untouched
  destination. It lives at the binary level on purpose: the default build and CI's
  `--all-features` build select different receiver drivers, so the same file asserts the same
  expectations against both. Verified to fail on the parent commit
  (`left: ["<f......... alpha.txt", ...]`) and pass on this one, with the feature on and off.
  The child is spawned with both pipes drained on their own threads - polling `try_wait()`
  without draining deadlocks once a pipe buffer fills.
- `candidates.rs` unit tests: rewritten around `plan_dry_run` to also assert the created-file
  breakdown and the exact wire iflags, plus two new cases - the tally survives without `-i`,
  and a server-mode (push) receiver still classifies for the wire while recording no local row.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features --no-deps
-- -D warnings`, and `cargo clippy --workspace --all-targets --no-deps` are clean.
`cargo test -p transfer` passes with `incremental-flist` on (2470) and off (2133), as do
`only_write_batch_remote_{push,pull}`, `batch_only_write_no_dest_dir`, `size_filter_tests`,
`size_only_tests`, `integration_basic`, `integration_links`, `integration_filters`, and
`integration_rsync_protocol`.
