### PR TITLE
test: resolve oc-rsync path without a stale target scan

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -39,17 +39,38 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        # `needs_bin` marks rows that need `oc-rsync` built before the test
+        # step. A package-scoped `cargo nextest run` never builds it - only
+        # `--workspace` pulls in the root `bin` package that owns the
+        # `[[bin]]` - and the tests that spawn it resolve exactly one path
+        # (`<target>/<profile>/oc-rsync`, baked in from `OUT_DIR`), so an
+        # unbuilt binary is a hard failure or, for the `require_binary`
+        # ports, a permanent self-skip.
+        #
+        # The flag is set per selected *crate*, not per currently-failing
+        # test: `cli`, `core`, `engine`, `metadata` and `transfer` are the
+        # crates whose test targets reference the resolver, so any row
+        # selecting one of them is true. Deciding per test would leave rows
+        # that only pass because their bin-spawning tests are `#[ignore]`d,
+        # env-gated or filtered out - one edit away from breaking. Re-derive
+        # with:
+        #   grep -rl 'oc_rsync_bin\|workspace_bin\|require_binary\|OcRsyncCliRunner' crates/
         row:
           - name: async
             args: "-p daemon -p core -p protocol -p engine --features async"
+            needs_bin: true
           - name: tracing
             args: "-p daemon -p core -p engine --features tracing"
+            needs_bin: true
           - name: serde
             args: "-p logging -p protocol -p flist --features serde"
+            needs_bin: false
           - name: concurrent-sessions
             args: "-p daemon --features concurrent-sessions"
+            needs_bin: false
           - name: iconv
             args: "-p protocol -p transfer -p engine -p core -p cli -p daemon --features iconv"
+            needs_bin: true
 
     env:
       CARGO_TERM_COLOR: always
@@ -98,6 +119,18 @@ jobs:
           Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
           & "$cargoBin\cargo-nextest.exe" --version
 
+      # Built at the default feature set, which is both necessary and
+      # sufficient. Necessary: the root `bin` package declares no `tracing`,
+      # `serde`, `concurrent-sessions` or `incremental-flist` feature, so
+      # forwarding a row's `--features` would be a hard error. Sufficient:
+      # every feature these rows do exercise end-to-end through the binary
+      # (iconv, zstd, lz4, io_uring, and incremental-flist via `transfer`'s
+      # own defaults) is already on by default. The profile is unchanged, so
+      # the binary lands in exactly the directory the resolver derives.
+      - name: Build oc-rsync (for subprocess integration tests)
+        if: matrix.row.needs_bin
+        run: cargo build --locked -p bin --bin oc-rsync
+
       - name: Test (${{ matrix.row.name }})
         run: cargo nextest run --locked --profile ci ${{ matrix.row.args }}
 
@@ -122,6 +155,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Same `needs_bin` rule as the cross-OS matrix above: true for any row
+        # selecting `cli`, `core`, `engine`, `metadata` or `transfer`. The
+        # `default-features` row is `--workspace`, which already builds the
+        # root `bin` package, so it stays false.
         include:
           # PFF-6: Verify the default-features build compiles and passes
           # tests. The main CI test job uses --all-features which may mask
@@ -129,36 +166,47 @@ jobs:
           - name: default-features
             args: "--workspace"
             apt: ""
+            needs_bin: false
           - name: parallel
             args: "-p checksums -p flist --features parallel"
             apt: ""
+            needs_bin: false
           - name: incremental-flist
             args: "-p transfer --features incremental-flist"
             apt: ""
+            needs_bin: true
           - name: compression
             args: "-p compress -p protocol -p engine -p transfer --features zstd,lz4"
             apt: ""
+            needs_bin: true
           - name: io_uring
             args: "-p transfer -p fast_io --features io_uring"
             apt: ""
+            needs_bin: true
           - name: copy_file_range
             args: "-p fast_io --features copy_file_range"
             apt: ""
+            needs_bin: false
           - name: landlock
             args: "-p fast_io --features landlock"
             apt: ""
+            needs_bin: false
           - name: openssl
             args: "-p checksums --features openssl"
             apt: "libssl-dev pkg-config"
+            needs_bin: false
           - name: openssl-vendored
             args: "-p checksums --features openssl-vendored"
             apt: "pkg-config"
+            needs_bin: false
           - name: zlib-ng
             args: "-p compress -p protocol --features zlib-ng"
             apt: "zlib1g-dev"
+            needs_bin: false
           - name: zlib-rs
             args: "-p compress -p protocol --no-default-features --features zlib-rs"
             apt: ""
+            needs_bin: false
 
     env:
       CARGO_TERM_COLOR: always
@@ -212,6 +260,10 @@ jobs:
           Invoke-WebRequest -UseBasicParsing -Uri 'https://get.nexte.st/latest/windows' -OutFile $zip
           Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
           & "$cargoBin\cargo-nextest.exe" --version
+
+      - name: Build oc-rsync (for subprocess integration tests)
+        if: matrix.needs_bin
+        run: cargo build --locked -p bin --bin oc-rsync
 
       - name: Test (${{ matrix.name }})
         run: cargo nextest run --locked --profile ci ${{ matrix.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,15 @@ jobs:
           Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
           & "$cargoBin\cargo-nextest.exe" --version
 
+      # The steps below select individual packages, so Cargo never builds the
+      # `oc-rsync` binary as a side effect the way a `--workspace` run does.
+      # Integration tests that spawn the binary resolve exactly one path -
+      # `<target>/<profile>/oc-rsync` - and abort when it is absent, so it has
+      # to be built explicitly here. Default features match what the binary
+      # ships with.
+      - name: Build oc-rsync (for subprocess integration tests)
+        run: cargo build --locked -p bin --bin oc-rsync
+
       - name: Test
         run: |
           # Run Windows-specific crates only (core, engine, cli have platform code)
@@ -601,6 +610,12 @@ jobs:
         with:
           tool: cargo-nextest
 
+      # `core`, `engine`, `cli` and `metadata` all own tests that spawn the
+      # `oc-rsync` binary, and a package-scoped run never builds it. See the
+      # note on the Windows job above.
+      - name: Build oc-rsync (for subprocess integration tests)
+        run: rustup run ${{ matrix.toolchain }} cargo build --locked -p bin --bin oc-rsync
+
       # Invoke through `rustup run` to bypass the cargo proxy shim, which on
       # macOS GitHub runners can resolve to rustup-init directly and fail with
       # `error: unexpected argument 'build' found` when rust-toolchain.toml
@@ -842,6 +857,13 @@ jobs:
       # test under `#[cfg(feature = "dg-stress")]` is compiled in.
       - name: Build engine (--features dg-stress)
         run: cargo build --locked -p engine --tests --features dg-stress
+
+      # `engine` owns a test that spawns the `oc-rsync` binary. It is filtered
+      # out of the run below today, but a package-scoped selection never builds
+      # the binary, so build it here rather than leaving the cell one filter
+      # edit away from a hard failure. See the note on the Windows job above.
+      - name: Build oc-rsync (for subprocess integration tests)
+        run: cargo build --locked -p bin --bin oc-rsync
 
       # Run only the stress test. `--no-tests=pass` keeps the cell green if
       # the test ever gets renamed or moved (the filter would match zero

--- a/.github/workflows/reorder-spill-regression.yml
+++ b/.github/workflows/reorder-spill-regression.yml
@@ -83,6 +83,13 @@ jobs:
           mkdir -p "$WORK/results"
           echo "WORK=$WORK" >> "$GITHUB_OUTPUT"
 
+      # `engine` owns a test that spawns the `oc-rsync` binary. It is filtered
+      # out of the run below today, but a package-scoped `-p engine` selection
+      # never builds the binary, so build it here rather than leaving the cell
+      # one filter edit away from a hard failure.
+      - name: Build oc-rsync (for subprocess integration tests)
+        run: cargo build --locked -p bin --bin oc-rsync
+
       - name: Run reorder-buffer spill regression tests
         env:
           WORK: ${{ steps.prep.outputs.WORK }}

--- a/.github/workflows/windows-nightly-long-path.yml
+++ b/.github/workflows/windows-nightly-long-path.yml
@@ -105,6 +105,13 @@ jobs:
       # already covered by the WCI-2 IOCP cell. Both ACL and ADS
       # surfaces require the corresponding feature flags to be active
       # at compile time.
+      # `metadata` owns tests that spawn `oc-rsync.exe` as a subprocess. They
+      # are filtered out of the run below today, but a package-scoped `-p
+      # metadata` selection never builds the binary, so build it here rather
+      # than leaving the cell one filter edit away from a hard failure.
+      - name: Build oc-rsync (for subprocess integration tests)
+        run: cargo build --locked -p bin --bin oc-rsync
+
       - name: Run metadata long-path round-trip tests
         run: cargo nextest run --locked -p metadata --features acl,xattr --no-fail-fast -E 'test(long_path_)'
 

--- a/.github/workflows/windows-nightly-ntfs-acl.yml
+++ b/.github/workflows/windows-nightly-ntfs-acl.yml
@@ -130,6 +130,13 @@ jobs:
       # covers DACL read, SDDL read/write, the read-only NTFS
       # attribute path, the `--copy-as` privilege probe, and the
       # stat-cache read-only metadata branch.
+      # The unfiltered metadata run includes the junction-transfer cases,
+      # which spawn `oc-rsync.exe` as a subprocess. A package-scoped
+      # `-p metadata` run never builds it, and the tests resolve exactly one
+      # path and abort when it is absent, so build it here.
+      - name: Build oc-rsync (for subprocess integration tests)
+        run: cargo build --locked -p bin --bin oc-rsync
+
       - name: Run metadata-crate Windows ACL tests
         run: cargo nextest run --locked -p metadata --features acl --no-fail-fast
 

--- a/.github/workflows/windows-nightly-reparse-symlinks.yml
+++ b/.github/workflows/windows-nightly-reparse-symlinks.yml
@@ -130,6 +130,13 @@ jobs:
       # this nightly cell. The synthetic-buffer unit tests still run
       # successfully and surface any regression in the reparse parser
       # logic, which is the load-bearing classifier.
+      # The two `windows_symlink_junction_transfer.rs` cases spawn
+      # `oc-rsync.exe` as a subprocess. A package-scoped `-p metadata` run
+      # never builds it, and the tests resolve exactly one path and abort
+      # when it is absent, so build it here.
+      - name: Build oc-rsync (for subprocess integration tests)
+        run: cargo build --locked -p bin --bin oc-rsync
+
       - name: Run metadata reparse + symlink Windows tests
         run: cargo nextest run --locked -p metadata --no-fail-fast -E 'test(reparse) or test(symlink) or test(junction) or test(mount_point)'
 

--- a/.github/workflows/windows-nightly-xattr-ads.yml
+++ b/.github/workflows/windows-nightly-xattr-ads.yml
@@ -86,6 +86,13 @@ jobs:
           Expand-Archive -Force -Path $zip -DestinationPath $cargoBin
           & "$cargoBin\cargo-nextest.exe" --version
 
+      # Both ADS round-trip tests spawn `oc-rsync.exe` as a subprocess. A
+      # package-scoped `-p metadata` run never builds it, and the tests
+      # resolve exactly one path and abort when it is absent, so build it
+      # here. Default features carry the xattr backend under test.
+      - name: Build oc-rsync (for subprocess integration tests)
+        run: cargo build --locked -p bin --bin oc-rsync
+
       # Filter targets the metadata-crate ADS coverage. The test names
       # `ads_zone_identifier_round_trips_through_xattrs` and
       # `ads_multi_stream_round_trips` in

--- a/crates/cli/tests/upstream_arg_fidelity.rs
+++ b/crates/cli/tests/upstream_arg_fidelity.rs
@@ -685,32 +685,12 @@ fn temp_dir_short_equals_value_is_accepted() {
 // upstream-correct outcome. They run only under `--ignored` (never in the
 // default CI test set) and require `cargo build --release --bin oc-rsync`.
 
-/// Locates the `oc-rsync` binary (defined in the workspace-root package, so
-/// `CARGO_BIN_EXE_oc-rsync` is not set for this crate's tests).
-fn oc_binary() -> std::path::PathBuf {
-    if let Some(explicit) = std::env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        return explicit.into();
-    }
-    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let root = manifest
-        .parent()
-        .and_then(std::path::Path::parent)
-        .expect("crates/cli lives two levels below the workspace root");
-    for profile in ["release", "debug"] {
-        let candidate = root.join("target").join(profile).join("oc-rsync");
-        if candidate.exists() {
-            return candidate;
-        }
-    }
-    panic!("oc-rsync binary not found; run `cargo build --release --bin oc-rsync` first");
-}
-
 /// Runs `oc-rsync -n <args...> <tmp-src>/ <tmp-dst>/` over empty temp dirs so
 /// only argument handling (not I/O) determines the exit status.
 fn run_oc(args: &[&str]) -> std::process::ExitStatus {
     let src = tempfile::tempdir().expect("tempdir src");
     let dst = tempfile::tempdir().expect("tempdir dst");
-    std::process::Command::new(oc_binary())
+    std::process::Command::new(test_support::oc_rsync_bin())
         .arg("-n")
         .args(args)
         .arg(format!("{}/", src.path().display()))

--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -34,24 +34,24 @@ pub const UPSTREAM_3_1_3: &str = "target/interop/upstream-install/3.1.3/bin/rsyn
 #[allow(dead_code)]
 pub const UPSTREAM_3_4_1: &str = "target/interop/upstream-install/3.4.1/bin/rsync";
 
-/// oc-rsync binary paths for daemon testing.
-#[allow(dead_code)]
-const OC_RSYNC_RELEASE: &str = "target/release/oc-rsync";
-#[allow(dead_code)]
-const OC_RSYNC_DEBUG: &str = "target/debug/oc-rsync";
-
 /// Selects which daemon binary to launch.
 #[allow(dead_code)]
 pub enum DaemonBinary {
     /// Upstream rsync binary at a specific path.
     Upstream(&'static str),
-    /// oc-rsync binary (auto-selects release or debug).
+    /// The `oc-rsync` binary built by the current Cargo invocation.
     OcRsync,
 }
 
 impl DaemonBinary {
     /// Resolve to an actual binary path.
-    fn resolve(&self) -> io::Result<&str> {
+    ///
+    /// The oc-rsync arm goes through [`test_support::oc_rsync_bin`], which
+    /// knows the profile directory Cargo is building into. The previous
+    /// `target/{release,debug}/oc-rsync` probe was both cwd-relative and
+    /// profile-guessing, so it could launch a daemon from a different
+    /// revision than the one under test.
+    fn resolve(&self) -> io::Result<PathBuf> {
         match self {
             DaemonBinary::Upstream(path) => {
                 if !Path::new(path).exists() {
@@ -60,22 +60,9 @@ impl DaemonBinary {
                         format!("upstream rsync binary not found at: {path}"),
                     ));
                 }
-                Ok(path)
+                Ok(PathBuf::from(path))
             }
-            DaemonBinary::OcRsync => {
-                if Path::new(OC_RSYNC_RELEASE).exists() {
-                    Ok(OC_RSYNC_RELEASE)
-                } else if Path::new(OC_RSYNC_DEBUG).exists() {
-                    Ok(OC_RSYNC_DEBUG)
-                } else {
-                    Err(io::Error::new(
-                        io::ErrorKind::NotFound,
-                        format!(
-                            "oc-rsync binary not found at {OC_RSYNC_RELEASE} or {OC_RSYNC_DEBUG}",
-                        ),
-                    ))
-                }
-            }
+            DaemonBinary::OcRsync => Ok(test_support::oc_rsync_bin()),
         }
     }
 

--- a/crates/core/tests/no_partial_temp_cleanup.rs
+++ b/crates/core/tests/no_partial_temp_cleanup.rs
@@ -28,8 +28,6 @@ mod common;
 use common::{DaemonBinary, TestDaemon, create_test_file};
 
 #[cfg(unix)]
-use std::env;
-#[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
 use std::path::PathBuf;
@@ -61,38 +59,6 @@ const KILL_DELAY: Duration = Duration::from_secs(3);
 /// Maximum time to wait for the client process to exit after signal.
 #[cfg(unix)]
 const EXIT_WAIT: Duration = Duration::from_secs(10);
-
-/// Locate the oc-rsync binary for subprocess spawning.
-#[cfg(unix)]
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-
-    let binary_name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    let current_exe = env::current_exe().ok()?;
-    let mut dir = current_exe.parent()?;
-
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-
-    for subdir in ["debug", "release"] {
-        let candidate = dir.join(subdir).join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-
-    None
-}
 
 /// Generate deterministic test data (repeating byte pattern).
 #[cfg(unix)]
@@ -197,13 +163,7 @@ fn assert_dest_clean(dest_dir: &std::path::Path, context: &str) {
 #[test]
 #[ignore = "requires oc-rsync binary"]
 fn no_partial_single_file_no_residue_on_kill() {
-    let oc_rsync = match locate_oc_rsync() {
-        Some(path) => path,
-        None => {
-            eprintln!("Skipping: oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc_rsync = test_support::oc_rsync_bin();
 
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 
@@ -257,13 +217,7 @@ fn no_partial_single_file_no_residue_on_kill() {
 #[test]
 #[ignore = "requires oc-rsync binary"]
 fn no_partial_multi_file_no_residue_on_kill() {
-    let oc_rsync = match locate_oc_rsync() {
-        Some(path) => path,
-        None => {
-            eprintln!("Skipping: oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc_rsync = test_support::oc_rsync_bin();
 
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 
@@ -334,13 +288,7 @@ fn no_partial_multi_file_no_residue_on_kill() {
 #[test]
 #[ignore = "requires oc-rsync binary"]
 fn no_partial_preserves_dirs_but_removes_temps() {
-    let oc_rsync = match locate_oc_rsync() {
-        Some(path) => path,
-        None => {
-            eprintln!("Skipping: oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc_rsync = test_support::oc_rsync_bin();
 
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 

--- a/crates/core/tests/partial_mid_transfer_kill.rs
+++ b/crates/core/tests/partial_mid_transfer_kill.rs
@@ -34,11 +34,9 @@ mod common;
 use common::{DaemonBinary, TestDaemon, create_test_file};
 
 #[cfg(unix)]
-use std::env;
-#[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
-use std::path::{Path, PathBuf};
+use std::path::Path;
 #[cfg(unix)]
 use std::process::{Child, Command, Stdio};
 #[cfg(unix)]
@@ -67,41 +65,6 @@ const KILL_DELAY: Duration = Duration::from_secs(3);
 /// Maximum time to wait for the client process to exit after signal.
 #[cfg(unix)]
 const EXIT_WAIT: Duration = Duration::from_secs(10);
-
-/// Locate the oc-rsync binary for subprocess spawning.
-#[cfg(unix)]
-fn locate_oc_rsync() -> Option<PathBuf> {
-    // Try CARGO_BIN_EXE_oc-rsync first (set by cargo test)
-    if let Some(path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-
-    let binary_name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    let current_exe = env::current_exe().ok()?;
-    let mut dir = current_exe.parent()?;
-
-    // Walk up to target/, checking each ancestor
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-
-    // Check common locations under target/
-    for subdir in ["debug", "release"] {
-        let candidate = dir.join(subdir).join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-
-    None
-}
 
 /// Generate deterministic test data (repeating pattern, not random).
 ///
@@ -158,13 +121,7 @@ fn sigterm_and_wait(child: &mut Child) {
 #[test]
 #[ignore = "requires oc-rsync binary"]
 fn partial_flag_retains_file_on_mid_transfer_kill() {
-    let oc_rsync = match locate_oc_rsync() {
-        Some(path) => path,
-        None => {
-            eprintln!("Skipping: oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc_rsync = test_support::oc_rsync_bin();
 
     // Start oc-rsync daemon with a large test file.
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
@@ -241,13 +198,7 @@ fn partial_flag_retains_file_on_mid_transfer_kill() {
 #[test]
 #[ignore = "requires oc-rsync binary"]
 fn no_partial_flag_cleans_up_on_mid_transfer_kill() {
-    let oc_rsync = match locate_oc_rsync() {
-        Some(path) => path,
-        None => {
-            eprintln!("Skipping: oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc_rsync = test_support::oc_rsync_bin();
 
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 
@@ -307,13 +258,7 @@ fn no_partial_flag_cleans_up_on_mid_transfer_kill() {
 #[test]
 #[ignore = "requires oc-rsync binary"]
 fn partial_dir_flag_retains_file_in_directory_on_kill() {
-    let oc_rsync = match locate_oc_rsync() {
-        Some(path) => path,
-        None => {
-            eprintln!("Skipping: oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc_rsync = test_support::oc_rsync_bin();
 
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 

--- a/crates/core/tests/uts_9_daemon_gzip_download_goodbye.rs
+++ b/crates/core/tests/uts_9_daemon_gzip_download_goodbye.rs
@@ -39,11 +39,7 @@ mod common;
 use common::{DaemonBinary, TestDaemon, create_test_file};
 
 #[cfg(unix)]
-use std::env;
-#[cfg(unix)]
 use std::fs;
-#[cfg(unix)]
-use std::path::PathBuf;
 #[cfg(unix)]
 use std::process::Command;
 
@@ -55,40 +51,6 @@ use tempfile::tempdir;
 /// test fast on CI runners.
 #[cfg(unix)]
 const TEST_FILE_SIZE: usize = 700 * 1024;
-
-/// Locate the oc-rsync binary for subprocess spawning. Mirrors the helper in
-/// `partial_mid_transfer_kill.rs`; kept inline to avoid touching shared
-/// `common::mod` from a regression test added late in the cycle.
-#[cfg(unix)]
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-
-    let binary_name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    let current_exe = env::current_exe().ok()?;
-    let mut dir = current_exe.parent()?;
-
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-
-    for subdir in ["debug", "release"] {
-        let candidate = dir.join(subdir).join(&binary_name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-
-    None
-}
 
 /// Deterministic byte pattern so the destination can be compared
 /// byte-for-byte without storing the full payload in the test binary.
@@ -109,13 +71,7 @@ fn generate_test_data(size: usize) -> Vec<u8> {
 #[test]
 #[ignore = "requires oc-rsync binary"]
 fn daemon_download_with_zz_completes_without_connection_drop() {
-    let oc_rsync = match locate_oc_rsync() {
-        Some(path) => path,
-        None => {
-            eprintln!("Skipping: oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc_rsync = test_support::oc_rsync_bin();
 
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 

--- a/crates/engine/tests/delete_determinism_property.rs
+++ b/crates/engine/tests/delete_determinism_property.rs
@@ -20,7 +20,9 @@
 //! - `OC_RSYNC_DELETE_INTEROP` is unset (the DDP-E live emitter has not
 //!   landed yet, so the determinism guarantee is not in force).
 //! - `strace` is not available on `PATH`.
-//! - The `oc-rsync` binary cannot be located.
+//!
+//! A missing `oc-rsync` binary is NOT a skip condition: once the gate and
+//! `strace` are satisfied the test fails loudly, naming the path it expected.
 //!
 //! # Upstream Reference
 //!
@@ -203,8 +205,12 @@ struct TestContext {
 impl TestContext {
     fn try_new() -> Option<Self> {
         env::var_os(GATE_ENV)?;
-        let oc_rsync = locate_oc_rsync()?;
+        // strace first: its absence is a legitimate host-capability skip.
+        // The binary is then required, not probed - once the gate and strace
+        // are satisfied there is no reason for this test to pass without
+        // spawning oc-rsync.
         let strace = locate_strace()?;
+        let oc_rsync = test_support::oc_rsync_bin();
         Some(Self { oc_rsync, strace })
     }
 
@@ -397,35 +403,6 @@ fn run_directory_keys(map: &BTreeMap<PathBuf, Vec<UnlinkEvent>>) -> Vec<&Path> {
 // ---------------------------------------------------------------------------
 // Binary discovery
 // ---------------------------------------------------------------------------
-
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(env_path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let path = PathBuf::from(env_path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-    if let Some(env_path) = env::var_os("OC_RSYNC_BIN") {
-        let path = PathBuf::from(env_path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-
-    // Walk up from the engine crate manifest dir to the workspace target.
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let mut cursor = manifest_dir.as_path();
-    while let Some(parent) = cursor.parent() {
-        for profile in ["debug", "release", "dist"] {
-            let candidate = parent.join("target").join(profile).join("oc-rsync");
-            if candidate.is_file() {
-                return Some(candidate);
-            }
-        }
-        cursor = parent;
-    }
-    None
-}
 
 fn locate_strace() -> Option<PathBuf> {
     if let Some(env_path) = env::var_os("OC_RSYNC_STRACE") {

--- a/crates/metadata/tests/acl_root_root_interop.rs
+++ b/crates/metadata/tests/acl_root_root_interop.rs
@@ -30,9 +30,11 @@
 //! - An upstream `rsync` binary cannot be located (the `OC_RSYNC_UPSTREAM`
 //!   env var, then `target/interop/upstream-install/<ver>/bin/rsync`, then
 //!   `command -v rsync`).
-//! - The `oc-rsync` binary cannot be located.
 //! - The backing filesystem refuses POSIX ACL writes (no `acl` mount
 //!   option on `/tmp` is the common case; skip rather than fail).
+//!
+//! A missing `oc-rsync` binary is NOT a skip condition: it fails the test
+//! loudly, naming the path that was expected.
 //!
 //! ## Companion: ACL-2.b non-root unmappable-id leg
 //!
@@ -87,34 +89,6 @@ fn skip(reason: &str) {
 /// `crates/metadata/tests/acl_handling.rs:1172`.
 fn is_root() -> bool {
     rustix::process::geteuid().as_raw() == 0
-}
-
-/// Locate the oc-rsync binary built by cargo for this workspace.
-///
-/// Order:
-/// 1. `CARGO_BIN_EXE_oc-rsync` (set automatically by cargo for tests in
-///    the binary's owning package; metadata tests do not get this for
-///    free so we treat it as best-effort).
-/// 2. `target/{release,debug,dist}/oc-rsync` relative to the workspace
-///    root (one directory above `CARGO_MANIFEST_DIR` which is the
-///    `metadata` crate dir).
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(env_path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(env_path);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    // crates/metadata -> workspace root is two parents up.
-    let workspace_root = manifest_dir.parent()?.parent()?;
-    for profile in ["release", "debug", "dist"] {
-        let candidate = workspace_root.join("target").join(profile).join("oc-rsync");
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
 }
 
 /// Locate an upstream rsync binary.
@@ -443,10 +417,7 @@ impl Harness {
             skip("requires root (geteuid() != 0); root-to-root invariant cannot be exercised");
             return None;
         }
-        let Some(oc_bin) = locate_oc_rsync() else {
-            skip("oc-rsync binary not located; build it before running this test");
-            return None;
-        };
+        let oc_bin = test_support::oc_rsync_bin();
         let Some(upstream_bin) = locate_upstream_rsync() else {
             skip(
                 "upstream rsync not located (set OC_RSYNC_UPSTREAM, populate \
@@ -645,10 +616,7 @@ impl NonRootHarness {
             ));
             return None;
         }
-        let Some(oc_bin) = locate_oc_rsync() else {
-            skip("oc-rsync binary not located; build it before running this test");
-            return None;
-        };
+        let oc_bin = test_support::oc_rsync_bin();
         let Some(upstream_bin) = locate_upstream_rsync() else {
             skip(
                 "upstream rsync not located (set OC_RSYNC_UPSTREAM, populate \
@@ -777,10 +745,7 @@ impl ReverseHarness {
             ));
             return None;
         }
-        let Some(oc_bin) = locate_oc_rsync() else {
-            skip("oc-rsync binary not located; build it before running this test");
-            return None;
-        };
+        let oc_bin = test_support::oc_rsync_bin();
         let Some(upstream_bin) = locate_upstream_rsync() else {
             skip(
                 "upstream rsync not located (set OC_RSYNC_UPSTREAM, populate \

--- a/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
+++ b/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
@@ -39,13 +39,13 @@
 //! - The backing scratch volume does not support ADS (FAT32, exFAT, or
 //!   a non-NTFS mount). Probed by attempting to write a sentinel stream
 //!   to a temp file; failure means the volume rejects ADS.
-//! - The `oc-rsync` binary cannot be located via `CARGO_BIN_EXE_oc-rsync`
-//!   or `target/{release,debug,dist}/oc-rsync.exe` relative to the
-//!   workspace root.
+//!
+//! A missing `oc-rsync.exe` is NOT a skip condition. It is resolved through
+//! [`test_support::oc_rsync_bin`], which panics naming the path it expected,
+//! so neither test can report success without spawning the binary.
 
 #![cfg(all(target_os = "windows", feature = "xattr"))]
 
-use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -89,36 +89,6 @@ fn ads_path(base: &Path, stream: &str) -> PathBuf {
     s.push(":");
     s.push(stream);
     PathBuf::from(s)
-}
-
-/// Locate the oc-rsync binary built for this workspace.
-///
-/// Order:
-/// 1. `CARGO_BIN_EXE_oc-rsync` (set automatically by cargo for tests in
-///    the binary's owning package; metadata tests do not get this for
-///    free so we treat it as best-effort).
-/// 2. `target/{release,debug,dist}/oc-rsync.exe` relative to the
-///    workspace root (two directories above `CARGO_MANIFEST_DIR` which
-///    is the `metadata` crate dir).
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(env_path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(env_path);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir.parent()?.parent()?;
-    for profile in ["release", "debug", "dist"] {
-        let candidate = workspace_root
-            .join("target")
-            .join(profile)
-            .join("oc-rsync.exe");
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
 }
 
 /// Probes whether the volume behind `file` supports ADS. Writes a
@@ -221,13 +191,7 @@ fn ads_zone_identifier_round_trips_through_xattrs() {
     )
     .expect("seed Zone.Identifier on source");
 
-    let oc_rsync = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            skip("oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc_rsync = test_support::oc_rsync_bin();
 
     let src_arg = format!("{}\\", src.display());
     let dst_arg = format!("{}\\", dst.display());
@@ -318,13 +282,7 @@ fn ads_multi_stream_round_trips() {
         "source missing user.oc_rsync_test_stream: {src_names:?}",
     );
 
-    let oc_rsync = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            skip("oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc_rsync = test_support::oc_rsync_bin();
 
     let src_arg = format!("{}\\", src.display());
     let dst_arg = format!("{}\\", dst.display());

--- a/crates/metadata/tests/windows_symlink_junction_transfer.rs
+++ b/crates/metadata/tests/windows_symlink_junction_transfer.rs
@@ -26,13 +26,11 @@
 //!   suite stays green on stock GitHub-hosted `windows-latest` runners
 //!   (which run as a non-admin user with developer mode disabled).
 //! - `mklink /j` works without elevation on Windows 10+, so the junction
-//!   test runs unconditionally; it skips only if the `oc-rsync.exe` binary
-//!   cannot be located.
-//! - The `oc-rsync.exe` binary location is probed through
-//!   `CARGO_BIN_EXE_oc-rsync` (set by cargo when tests live in the binary's
-//!   owning package; the metadata crate is not the binary's owner so this
-//!   is best-effort) and falls back to `target/{release,debug,dist}/oc-rsync.exe`
-//!   relative to the workspace root.
+//!   test runs unconditionally.
+//!
+//! A missing `oc-rsync.exe` is NOT a skip condition. It is resolved through
+//! [`test_support::oc_rsync_bin`], which panics naming the path it expected,
+//! so neither test can report success without spawning the binary.
 //!
 //! ## CI wire-up
 //!
@@ -55,7 +53,6 @@
 
 #![cfg(target_os = "windows")]
 
-use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -138,36 +135,6 @@ impl Drop for JunctionFixture {
     }
 }
 
-/// Locate the `oc-rsync.exe` binary built for this workspace.
-///
-/// Order:
-/// 1. `CARGO_BIN_EXE_oc-rsync` (set by cargo for tests living in the
-///    binary's owning package; metadata tests do not get this for free, so
-///    this branch is best-effort).
-/// 2. `target/{release,debug,dist}/oc-rsync.exe` relative to the workspace
-///    root, walked from `CARGO_MANIFEST_DIR` (the metadata crate
-///    directory) up to the workspace root.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(env_path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(env_path);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir.parent()?.parent()?;
-    for profile in ["release", "debug", "dist"] {
-        let candidate = workspace_root
-            .join("target")
-            .join(profile)
-            .join("oc-rsync.exe");
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
-
 /// Logs a skip reason and returns cleanly. Matches the convention in
 /// `windows_ads_xattrs_roundtrip.rs`.
 fn skip(reason: &str) {
@@ -233,13 +200,7 @@ fn dir_symlink_push_preserves_link() {
         }
     };
 
-    let oc = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            skip("oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc = test_support::oc_rsync_bin();
 
     run_oc_rsync_push(&oc, &src, &dst);
 
@@ -300,13 +261,7 @@ fn junction_push_preserves_junction() {
         }
     };
 
-    let oc = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            skip("oc-rsync binary not found");
-            return;
-        }
-    };
+    let oc = test_support::oc_rsync_bin();
 
     run_oc_rsync_push(&oc, &src, &dst);
 

--- a/crates/test-support/build.rs
+++ b/crates/test-support/build.rs
@@ -1,0 +1,34 @@
+//! Bakes the Cargo profile output directory into `test-support`.
+//!
+//! `CARGO_BIN_EXE_oc-rsync` is only handed to the compiler for targets of the
+//! package that declares the `oc-rsync` `[[bin]]`, so `env!` is a hard compile
+//! error in every other package. `OUT_DIR`, by contrast, is given to every
+//! build script, and Cargo lays it out as
+//! `<target-dir>/[<triple>/]<profile>/build/<pkg>-<hash>/out`. Its fourth
+//! ancestor is therefore the exact profile directory that the current Cargo
+//! invocation links workspace binaries into - including custom profiles,
+//! cross-compilation triples, and relocated target directories such as
+//! `cargo llvm-cov`'s.
+//!
+//! Emitting that one directory gives dependent crates a Cargo-provided,
+//! compile-time anchor, replacing hand-rolled `target/{debug,release,dist}`
+//! probing that can silently select a binary from a different revision.
+
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let out_dir = PathBuf::from(
+        std::env::var_os("OUT_DIR").expect("OUT_DIR is always set for build scripts"),
+    );
+    let profile_dir = out_dir
+        .ancestors()
+        .nth(3)
+        .unwrap_or_else(|| panic!("unexpected OUT_DIR layout: {}", out_dir.display()));
+
+    println!(
+        "cargo:rustc-env=OC_RSYNC_TARGET_PROFILE_DIR={}",
+        profile_dir.display()
+    );
+}

--- a/crates/test-support/src/bin_path.rs
+++ b/crates/test-support/src/bin_path.rs
@@ -1,0 +1,138 @@
+//! Single resolver for workspace binaries under test.
+//!
+//! Every integration test that shells out to `oc-rsync` must run the binary
+//! Cargo just built, never one left over from an earlier revision. The
+//! package that declares the `oc-rsync` `[[bin]]` can say
+//! `env!("CARGO_BIN_EXE_oc-rsync")`; every other package cannot - that is a
+//! hard compile error. Those crates used to hand-roll a scan of
+//! `target/{debug,release,dist}`, or walk up from `CARGO_MANIFEST_DIR`, which
+//! resolves whatever happens to be on disk.
+//!
+//! This module replaces the scan with one Cargo-provided anchor: `build.rs`
+//! derives the active profile directory from `OUT_DIR` and bakes it in as
+//! `OC_RSYNC_TARGET_PROFILE_DIR`. Exactly one candidate path is ever
+//! considered, and [`workspace_bin`] panics naming that path when it is
+//! absent or not executable. There is no second candidate to fall back to and
+//! no `Option` for a caller to turn into a silent skip.
+
+use std::path::{Path, PathBuf};
+
+/// The profile directory of the current Cargo invocation.
+///
+/// This is `<target-dir>/[<triple>/]<profile>` - the directory Cargo links
+/// workspace binaries into - captured at compile time by this crate's
+/// `build.rs`. It tracks custom profiles, cross-compilation triples and
+/// relocated target directories, so no runtime probing is needed.
+#[must_use]
+pub fn target_profile_dir() -> &'static Path {
+    Path::new(env!("OC_RSYNC_TARGET_PROFILE_DIR"))
+}
+
+/// The single path a workspace binary named `name` can occupy.
+///
+/// Returns the candidate whether or not it exists, for callers that need to
+/// report or probe it (see [`workspace_bin`] and
+/// [`crate::locate_workspace_binary`]).
+#[must_use]
+pub fn workspace_bin_path(name: &str) -> PathBuf {
+    target_profile_dir().join(format!("{name}{}", std::env::consts::EXE_SUFFIX))
+}
+
+/// Resolve a workspace binary, panicking loudly if it is not usable.
+///
+/// # Panics
+///
+/// Panics naming the exact path when the binary is missing, is not a regular
+/// file, or (on Unix) is not executable. Failing here is deliberate: a helper
+/// that returned `None` would let callers print `skip:` and return, and a skip
+/// that can never be satisfied is indistinguishable from a pass.
+#[must_use]
+pub fn workspace_bin(name: &str) -> PathBuf {
+    let candidate = workspace_bin_path(name);
+    assert!(
+        candidate.is_file(),
+        "{name} binary missing at {}; refusing to fall back to a stale build \
+         (run `cargo build --bin {name}` for this profile first)",
+        candidate.display()
+    );
+    assert_executable(&candidate);
+    candidate
+}
+
+/// Resolve the `oc-rsync` binary built by the current Cargo invocation.
+///
+/// # Panics
+///
+/// See [`workspace_bin`].
+#[must_use]
+pub fn oc_rsync_bin() -> PathBuf {
+    workspace_bin("oc-rsync")
+}
+
+/// Assert the resolved path carries an execute bit.
+///
+/// A present-but-unexecutable file would otherwise surface as an opaque
+/// `Permission denied` from `Command::spawn` deep inside a test body.
+#[cfg(unix)]
+fn assert_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = std::fs::metadata(path)
+        .unwrap_or_else(|e| panic!("stat {}: {e}", path.display()))
+        .permissions()
+        .mode();
+    assert!(
+        mode & 0o111 != 0,
+        "{} exists but is not executable (mode {mode:o})",
+        path.display()
+    );
+}
+
+/// No-op on platforms without POSIX permission bits.
+#[cfg(not(unix))]
+fn assert_executable(_path: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_dir_is_the_directory_holding_this_test_executable() {
+        // Why: the whole mechanism rests on build.rs deriving the same
+        // profile directory that the test harness is linked into. If those
+        // ever diverge, every consumer would resolve a binary from a
+        // different profile - exactly the stale-build hazard this replaces.
+        let exe = std::env::current_exe().expect("current_exe");
+        // `.../<profile>/deps/<test-bin>` -> `.../<profile>`.
+        let from_exe = exe
+            .parent()
+            .and_then(Path::parent)
+            .expect("test executable lives under <profile>/deps");
+        assert_eq!(
+            std::fs::canonicalize(from_exe).expect("canonicalize exe profile dir"),
+            std::fs::canonicalize(target_profile_dir()).expect("canonicalize baked profile dir"),
+        );
+    }
+
+    #[test]
+    fn candidate_path_is_a_direct_child_of_the_profile_dir() {
+        // Why: pins the layout contract consumers rely on. A binary nested
+        // any deeper would mean build.rs picked the wrong ancestor.
+        let p = workspace_bin_path("oc-rsync");
+        assert_eq!(p.parent(), Some(target_profile_dir()));
+        assert!(
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("oc-rsync"))
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "refusing to fall back to a stale build")]
+    fn missing_binary_panics_naming_the_path() {
+        // Why: this is the guarantee the resolver exists for. A missing
+        // binary must abort the test loudly, never yield None for a caller
+        // to convert into a vacuous skip.
+        let _ = workspace_bin("definitely-not-built-xyzzy");
+    }
+}

--- a/crates/test-support/src/cli.rs
+++ b/crates/test-support/src/cli.rs
@@ -38,8 +38,8 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// the run never completed cleanly.
 #[derive(Debug)]
 pub enum RunnerError {
-    /// The `oc-rsync` binary could not be found in `target/{debug,release}/`
-    /// and `CARGO_BIN_EXE_oc-rsync` was unset or pointed at a missing file.
+    /// The `oc-rsync` binary was not present at the one path it can occupy
+    /// for this Cargo profile (see [`crate::workspace_bin_path`]).
     BinaryNotFound,
     /// The OS failed to spawn the child process.
     Spawn(std::io::Error),
@@ -59,7 +59,8 @@ impl std::fmt::Display for RunnerError {
         match self {
             RunnerError::BinaryNotFound => write!(
                 f,
-                "oc-rsync binary not found (set CARGO_BIN_EXE_oc-rsync or build the workspace)"
+                "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+                crate::bin_path::workspace_bin_path("oc-rsync").display()
             ),
             RunnerError::Spawn(e) => write!(f, "failed to spawn oc-rsync: {e}"),
             RunnerError::Wait(e) => write!(f, "failed to collect child output: {e}"),
@@ -72,22 +73,6 @@ impl std::fmt::Display for RunnerError {
 }
 
 impl std::error::Error for RunnerError {}
-
-/// Locate the `oc-rsync` binary.
-///
-/// Prefers Cargo's `CARGO_BIN_EXE_oc-rsync` (set for integration tests of a
-/// crate that depends on the `oc-rsync` bin target) and falls back to
-/// [`locate_workspace_binary`] which walks the enclosing profile directory.
-#[must_use]
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    locate_workspace_binary("oc-rsync")
-}
 
 /// Builder + executor for a single `oc-rsync` invocation.
 ///
@@ -121,7 +106,7 @@ impl OcRsyncCliRunner {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            binary: locate_oc_rsync(),
+            binary: locate_workspace_binary("oc-rsync"),
             args: Vec::new(),
             env: BTreeMap::new(),
             env_clear: false,

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -5,6 +5,7 @@
 //! This crate provides helpers that multiple test suites need, avoiding
 //! duplicated retry logic and setup boilerplate across crates.
 
+pub mod bin_path;
 pub mod cli;
 pub mod daemon_port;
 pub mod dir_diff;
@@ -12,6 +13,7 @@ pub mod lsh;
 pub mod skip;
 pub mod upstream_compat;
 
+pub use bin_path::{oc_rsync_bin, target_profile_dir, workspace_bin, workspace_bin_path};
 pub use cli::{CliOutput, OcRsyncCliRunner, RunnerError};
 pub use daemon_port::{daemon_listen_port, spawn_daemon_on_free_port};
 pub use dir_diff::{DirDiff, DirDiffEntry, DirDiffError, DirDiffMismatch, DirDiffOptions};

--- a/crates/test-support/src/lsh.rs
+++ b/crates/test-support/src/lsh.rs
@@ -5,10 +5,10 @@
 //! test can drive oc-rsync's remote-shell code paths locally. The path feeds
 //! either `--rsh <path>` on the argv or `RSYNC_RSH=<path>` in the environment.
 //!
-//! Resolution prefers Cargo's `CARGO_BIN_EXE_lsh-stub` (set when a crate's
-//! integration tests depend on `test-support`'s bin target) and falls back to
-//! [`crate::locate_workspace_binary`]. Missing binary is a loud typed error,
-//! not a silent skip; gate on [`crate::require_binary`] to self-skip.
+//! Resolution goes through [`crate::locate_workspace_binary`], which considers
+//! the single path the stub can occupy for the current Cargo profile. A
+//! missing binary is a loud typed error naming that path, not a silent skip;
+//! gate on [`crate::require_binary`] to self-skip.
 //!
 //! Unix-only: the stub itself depends on `sh`/`sudo`, and the remote-shell
 //! ports that consume it are `#[cfg(unix)]` (design section 5.4).
@@ -23,8 +23,8 @@ pub const LSH_STUB_BIN: &str = "lsh-stub";
 /// Error raised when the `lsh-stub` helper cannot be located.
 #[derive(Debug)]
 pub enum LshError {
-    /// The `lsh-stub` binary was not found via `CARGO_BIN_EXE_lsh-stub` nor in
-    /// `target/{debug,release}/`. Build the workspace (or the `test-support`
+    /// The `lsh-stub` binary was not present at the one path it can occupy for
+    /// the current Cargo profile. Build the workspace (or the `test-support`
     /// bin target) before running remote-shell ports.
     StubNotFound,
 }
@@ -34,7 +34,8 @@ impl std::fmt::Display for LshError {
         match self {
             LshError::StubNotFound => write!(
                 f,
-                "lsh-stub binary not found (set CARGO_BIN_EXE_lsh-stub or build test-support)"
+                "lsh-stub binary missing at {}; refusing to fall back to a stale build",
+                crate::bin_path::workspace_bin_path(LSH_STUB_BIN).display()
             ),
         }
     }
@@ -57,11 +58,7 @@ impl LshRunnerStub {
     /// Returns [`LshError::StubNotFound`] if the helper is not built, so the
     /// failure is loud rather than a silently-skipped remote-shell leg.
     pub fn locate() -> Result<Self, LshError> {
-        let path = std::env::var_os("CARGO_BIN_EXE_lsh-stub")
-            .map(PathBuf::from)
-            .filter(|p| p.is_file())
-            .or_else(|| locate_workspace_binary(LSH_STUB_BIN))
-            .ok_or(LshError::StubNotFound)?;
+        let path = locate_workspace_binary(LSH_STUB_BIN).ok_or(LshError::StubNotFound)?;
         Ok(Self { path })
     }
 
@@ -85,12 +82,18 @@ mod tests {
 
     #[test]
     fn locate_finds_the_built_stub_or_reports_loudly() {
-        // Why: the stub is a workspace [[bin]], so under `cargo test`
-        // CARGO_BIN_EXE_lsh-stub is set and locate() must succeed and return a
-        // real file. If it is somehow unbuilt the error must be the dedicated
-        // StubNotFound variant, never a silent None - Rule 12.
+        // Why: resolution must yield the single profile-dir path and nothing
+        // else, and a miss must be the dedicated StubNotFound variant rather
+        // than a silent None - Rule 12. The Err arm asserts that path really
+        // is absent, so the arm cannot pass vacuously.
+        let expected = crate::bin_path::workspace_bin_path(LSH_STUB_BIN);
         match LshRunnerStub::locate() {
             Ok(stub) => {
+                assert_eq!(
+                    stub.path(),
+                    expected,
+                    "resolution must not reach outside the current profile dir"
+                );
                 assert!(
                     stub.path().is_file(),
                     "located stub path must be a real file: {}",
@@ -101,11 +104,10 @@ mod tests {
                 assert_eq!(stub.rsh_env_value(), stub.path().as_os_str());
             }
             Err(LshError::StubNotFound) => {
-                // Acceptable only when the bin genuinely is not built; the
-                // env var proves whether cargo wired it.
                 assert!(
-                    std::env::var_os("CARGO_BIN_EXE_lsh-stub").is_none(),
-                    "CARGO_BIN_EXE_lsh-stub was set yet locate() failed"
+                    !expected.is_file(),
+                    "locate() reported StubNotFound yet {} exists",
+                    expected.display()
                 );
             }
         }

--- a/crates/test-support/src/skip.rs
+++ b/crates/test-support/src/skip.rs
@@ -26,44 +26,37 @@ pub fn require_unix() -> bool {
     }
 }
 
-/// Locate a workspace binary in `target/{debug,release}/`.
+/// Locate a workspace binary built by the current Cargo invocation.
 ///
-/// Resolution walks up from the current test executable to the enclosing
-/// `debug` or `release` profile directory and probes for `name` (with the
-/// platform executable suffix). Returns the first match, preferring the
-/// profile the test itself was built under.
+/// Exactly one path is considered: `name` inside
+/// [`crate::target_profile_dir`], the profile directory this crate's
+/// `build.rs` captured from `OUT_DIR`. There is deliberately no probe of a
+/// sibling profile - resolving a `debug` binary for a `release` test run is
+/// how a stale build silently ends up under test.
+///
+/// Returns `None` only when that one path does not exist, which callers must
+/// treat as "not built", never as "use something else".
 #[must_use]
 pub fn locate_workspace_binary(name: &str) -> Option<PathBuf> {
-    let exe = std::env::current_exe().ok()?;
-    // `.../target/<profile>/deps/<test-bin>` -> `.../target/<profile>`.
-    let profile_dir = exe.parent()?.parent()?;
-    let candidate = profile_dir.join(exe_name(name));
-    if candidate.is_file() {
-        return Some(candidate);
-    }
-
-    // Fall back to the sibling profile so a release test can still find a
-    // debug-built helper binary and vice versa.
-    let target_dir = profile_dir.parent()?;
-    for profile in ["debug", "release"] {
-        let candidate = target_dir.join(profile).join(exe_name(name));
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+    let candidate = crate::bin_path::workspace_bin_path(name);
+    candidate.is_file().then_some(candidate)
 }
 
 /// Skip unless the workspace binary `name` is present.
 ///
-/// Wraps [`locate_workspace_binary`] with the self-skip convention: prints a
-/// reason and returns `false` when the binary is not built.
+/// Wraps [`locate_workspace_binary`] with the self-skip convention: prints the
+/// exact path that was probed and returns `false` when the binary is not
+/// built. Tests that must never be allowed to self-skip should call
+/// [`crate::workspace_bin`] instead, which panics.
 #[must_use]
 pub fn require_binary(name: &str) -> bool {
     if locate_workspace_binary(name).is_some() {
         true
     } else {
-        eprintln!("Skipping upstream-compat test: workspace binary '{name}' not built");
+        eprintln!(
+            "Skipping upstream-compat test: workspace binary '{name}' not built at {}",
+            crate::bin_path::workspace_bin_path(name).display()
+        );
         false
     }
 }
@@ -167,5 +160,16 @@ mod tests {
         // there is always at least the deps dir. A missing-name lookup must
         // return None rather than panic.
         assert!(locate_workspace_binary("definitely-not-built-xyzzy").is_none());
+    }
+
+    #[test]
+    fn locate_workspace_binary_considers_exactly_one_path() {
+        // Why: any second candidate is a route to a binary from another
+        // profile - i.e. another revision. When resolution succeeds it must
+        // be the single profile-dir path, never a sibling-profile match.
+        let name = "lsh-stub";
+        if let Some(found) = locate_workspace_binary(name) {
+            assert_eq!(found, crate::bin_path::workspace_bin_path(name));
+        }
     }
 }

--- a/crates/transfer/tests/daemon_total_transferred_size_stats.rs
+++ b/crates/transfer/tests/daemon_total_transferred_size_stats.rs
@@ -50,7 +50,6 @@
 
 #![cfg(unix)]
 
-use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -68,33 +67,6 @@ const FILE_SIZES: [usize; 3] = [300, 150, 70];
 /// `Total transferred file size` line for a fresh (all-new) destination.
 fn expected_transferred_size() -> usize {
     FILE_SIZES.iter().sum()
-}
-
-/// Locate the workspace `oc-rsync` binary the test runner built.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
 }
 
 /// Write an `rsyncd.conf` exposing a single module. `use chroot = false` lets
@@ -237,10 +209,7 @@ impl DaemonScratch {
 /// so all three files transfer and the summed length is deterministic.
 #[test]
 fn daemon_push_reports_total_transferred_file_size() {
-    let Some(oc_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let oc_bin = test_support::oc_rsync_bin();
     let Some(scratch) = DaemonScratch::new() else {
         eprintln!("skipping: tempdir or test port allocation failed");
         return;
@@ -296,10 +265,7 @@ fn daemon_push_reports_total_transferred_file_size() {
 /// the client summary. Regression guard for the opposite direction.
 #[test]
 fn daemon_pull_reports_total_transferred_file_size() {
-    let Some(oc_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let oc_bin = test_support::oc_rsync_bin();
     let Some(scratch) = DaemonScratch::new() else {
         eprintln!("skipping: tempdir or test port allocation failed");
         return;

--- a/crates/transfer/tests/delay_updates_daemon_pull.rs
+++ b/crates/transfer/tests/delay_updates_daemon_pull.rs
@@ -180,10 +180,7 @@ impl Scratch {
 /// staging dir is never touched and survives.
 #[test]
 fn daemon_pull_delay_updates_stages_through_tmp_dir() {
-    let Some(oc_bin) = test_support::locate_workspace_binary("oc-rsync") else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let oc_bin = test_support::oc_rsync_bin();
     let Some(scratch) = Scratch::new() else {
         eprintln!("skipping: tempdir allocation failed");
         return;

--- a/crates/transfer/tests/delete_files_from_root_scope.rs
+++ b/crates/transfer/tests/delete_files_from_root_scope.rs
@@ -16,49 +16,17 @@
 //! - `flist.c:2239` - `int flags = recurse ? FLAG_CONTENT_DIR : 0;` (the root is
 //!   a content dir only for a recursive transfer).
 
-use std::env;
 use std::fs;
-use std::path::PathBuf;
 use std::process::Command;
 
 use tempfile::tempdir;
-
-/// Locates the workspace `oc-rsync` binary the test runner built.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// `--delete --files-from`: a stale destination-root file that is absent from
 /// the file list must survive, because the `--files-from` root is not a content
 /// directory and upstream never delete-scans it.
 #[test]
 fn files_from_delete_preserves_stale_dest_root_file() {
-    let Some(oc) = locate_oc_rsync() else {
-        eprintln!("oc-rsync binary not found; skipping");
-        return;
-    };
+    let oc = test_support::oc_rsync_bin();
 
     let tmp = tempdir().unwrap();
     let root = tmp.path();
@@ -98,10 +66,7 @@ fn files_from_delete_preserves_stale_dest_root_file() {
 /// normal delete pass.
 #[test]
 fn recursive_delete_still_removes_stale_dest_root_file() {
-    let Some(oc) = locate_oc_rsync() else {
-        eprintln!("oc-rsync binary not found; skipping");
-        return;
-    };
+    let oc = test_support::oc_rsync_bin();
 
     let tmp = tempdir().unwrap();
     let root = tmp.path();

--- a/crates/transfer/tests/delete_missing_args_files_from.rs
+++ b/crates/transfer/tests/delete_missing_args_files_from.rs
@@ -20,44 +20,11 @@
 //! - `options.c:765` / `options.c:768` - `--delete-missing-args` and
 //!   `--ignore-missing-args` flag definitions.
 
-use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
 use tempfile::tempdir;
-
-/// Locates the workspace `oc-rsync` binary the test runner built.
-///
-/// Mirrors the lookup logic in
-/// `tests/remove_source_files_local_copy.rs`: prefer Cargo's
-/// `CARGO_BIN_EXE_oc-rsync` when set, otherwise walk up from the test
-/// executable until a `target/` directory is found.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// Builds the upstream-shaped fixture: a source directory with `keep.txt`
 /// present, a `files-from` list referencing both `keep.txt` and a vanished
@@ -106,10 +73,7 @@ fn build_fixture() -> Fixture {
 /// pins the production fix from UTS-19 / UTS-DD-files-from.3.
 #[test]
 fn delete_missing_args_files_from_removes_vanished_destination() {
-    let Some(rsync_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let rsync_bin = test_support::oc_rsync_bin();
 
     let fx = build_fixture();
     let source_arg = {
@@ -152,10 +116,7 @@ fn delete_missing_args_files_from_removes_vanished_destination() {
 /// sentinel entirely (`flist.c:2436-2437`).
 #[test]
 fn ignore_missing_args_files_from_preserves_destination() {
-    let Some(rsync_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let rsync_bin = test_support::oc_rsync_bin();
 
     let fx = build_fixture();
     let source_arg = {

--- a/crates/transfer/tests/itemize_fidelity_golden.rs
+++ b/crates/transfer/tests/itemize_fidelity_golden.rs
@@ -26,10 +26,9 @@
 
 #![cfg(unix)]
 
-use std::env;
 use std::fs;
 use std::os::unix::fs::{PermissionsExt, symlink};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use filetime::{FileTime, set_file_times, set_symlink_file_times};
@@ -38,37 +37,6 @@ use filetime::{FileTime, set_file_times, set_symlink_file_times};
 const T1: i64 = 1_577_836_800;
 /// 2023-06-06 12:00:00 UTC.
 const T2: i64 = 1_686_052_800;
-
-/// Locates the workspace `oc-rsync` binary the test runner built.
-///
-/// Prefers Cargo's `CARGO_BIN_EXE_oc-rsync`, otherwise walks up from the test
-/// executable until a `target/` directory is found (mirrors the lookup in the
-/// sibling integration tests).
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// Whole-second `FileTime` for a POSIX epoch second.
 fn ft(secs: i64) -> FileTime {
@@ -354,10 +322,7 @@ const SCENARIOS: &[Scenario] = &[
 
 #[test]
 fn itemize_rows_match_upstream_3_4_4_golden() {
-    let Some(bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let bin = test_support::oc_rsync_bin();
     for scenario in SCENARIOS {
         run_scenario(&bin, scenario);
     }

--- a/crates/transfer/tests/nxt_4_reverse_daemon_delta.rs
+++ b/crates/transfer/tests/nxt_4_reverse_daemon_delta.rs
@@ -56,14 +56,14 @@
 //!
 //! # Skip semantics
 //!
-//! Self-skips (prints `skipping:` and returns) when the workspace `oc-rsync`
-//! binary cannot be located, a loopback port cannot be allocated, or the daemon
-//! does not start within the daemon boot timeout. Non-zero exit,
-//! a diverged destination, or zero `Matched data` are real regressions.
+//! Self-skips (prints `skipping:` and returns) when a loopback port cannot be
+//! allocated or the daemon does not start within the daemon boot timeout. A
+//! missing workspace `oc-rsync` binary fails loudly instead, naming the path
+//! that was expected. Non-zero exit, a diverged destination, or zero
+//! `Matched data` are real regressions.
 
 #![cfg(unix)]
 
-use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -74,33 +74,6 @@ use tempfile::{TempDir, tempdir};
 /// Size of the delta-bearing payload. Large enough to span many signature
 /// blocks so the preserved outer thirds yield multiple Copy tokens.
 const PAYLOAD_LEN: usize = 64 * 1024;
-
-/// Locate the workspace `oc-rsync` binary the test runner built.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// Write an `rsyncd.conf` exposing one read-only module rooted at
 /// `module_root`. Binds loopback only and sets no `hosts allow` line, avoiding
@@ -309,10 +282,7 @@ impl DaemonScratch {
 /// daemon-sender generated a Copy/Literal token stream the client applied.
 #[test]
 fn reverse_daemon_delta_reconstructs_via_copy_tokens() {
-    let Some(oc_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let oc_bin = test_support::oc_rsync_bin();
     let Some(scratch) = DaemonScratch::new() else {
         eprintln!("skipping: tempdir or test port allocation failed");
         return;

--- a/crates/transfer/tests/old_dirs_depth_limit.rs
+++ b/crates/transfer/tests/old_dirs_depth_limit.rs
@@ -28,37 +28,9 @@
 //! dst/f0
 //! ```
 
-use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-
-/// Locates the workspace `oc-rsync` binary the test runner built.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// Builds `src/{f0, a/f1, a/b/f2}` under `root` and returns the source dir.
 fn build_three_level_tree(root: &std::path::Path) -> PathBuf {
@@ -75,10 +47,7 @@ fn build_three_level_tree(root: &std::path::Path) -> PathBuf {
 /// depth-2 files never transfer while the top-level file does.
 #[test]
 fn old_dirs_transfers_only_top_level() {
-    let Some(rsync_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let rsync_bin = test_support::oc_rsync_bin();
 
     let tmp = tempfile::tempdir().expect("create tempdir");
     let src = build_three_level_tree(tmp.path());
@@ -138,10 +107,7 @@ fn old_dirs_transfers_only_top_level() {
 /// pins the decoupling of `--old-dirs` from `--no-mkpath`.
 #[test]
 fn no_mkpath_still_copies_full_tree() {
-    let Some(rsync_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let rsync_bin = test_support::oc_rsync_bin();
 
     let tmp = tempfile::tempdir().expect("create tempdir");
     let src = build_three_level_tree(tmp.path());

--- a/crates/transfer/tests/remove_source_files_local_copy.rs
+++ b/crates/transfer/tests/remove_source_files_local_copy.rs
@@ -17,54 +17,17 @@
 //!   `--remove-source-files` forwarding to the server-side sender
 //! - `testsuite/delete.test` - end-to-end coverage
 
-use std::env;
 use std::fs;
-use std::path::PathBuf;
 use std::process::Command;
 
 use tempfile::tempdir;
-
-/// Locates the workspace `oc-rsync` binary the test runner built.
-///
-/// Mirrors the lookup logic in
-/// `tests/v61d_2_daemon_push_increcurse_perf_regression.rs`: prefer
-/// Cargo's `CARGO_BIN_EXE_oc-rsync` when it is set, otherwise walk up
-/// from the test executable until a `target/` directory is found.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// `--remove-source-files` removes every transferred file from the source
 /// tree (including nested entries) while leaving the directory layout
 /// behind, mirroring upstream `successful_send()`.
 #[test]
 fn remove_source_files_unlinks_transferred_files() {
-    let Some(rsync_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let rsync_bin = test_support::oc_rsync_bin();
 
     let tmp = tempdir().expect("create tempdir");
     let from = tmp.path().join("from");
@@ -134,10 +97,7 @@ fn remove_source_files_unlinks_transferred_files() {
 /// combined with the global `do_xfers` gate).
 #[test]
 fn remove_source_files_dry_run_preserves_source() {
-    let Some(rsync_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let rsync_bin = test_support::oc_rsync_bin();
 
     let tmp = tempdir().expect("create tempdir");
     let from = tmp.path().join("from");

--- a/crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs
+++ b/crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs
@@ -27,7 +27,7 @@
 //!
 //! # Gating
 //!
-//! The test self-skips on three conditions:
+//! The test self-skips on two conditions:
 //!
 //! 1. `OC_RSYNC_UPSTREAM_COMPAT` env var is not `1` - the standard PR
 //!    nextest cell does not set this, so the test no-ops in well under
@@ -36,10 +36,9 @@
 //!    `target/interop/upstream-install/3.4.4/bin/rsync` (run
 //!    `tools/ci/run_interop.sh` to build it). The `OC_RSYNC_UPSTREAM_BIN_3_4_4`
 //!    env var overrides the path.
-//! 3. The oc-rsync binary cannot be located via `CARGO_BIN_EXE_oc-rsync`
-//!    or by walking up from the current test executable. CI builds it
-//!    before invoking nextest, so this only trips in pathological local
-//!    setups.
+//!
+//! A missing oc-rsync binary is NOT a skip condition: it fails the test
+//! loudly, naming the path that was expected.
 //!
 //! The test is `#[cfg(unix)]` because the daemon TCP layer assumes
 //! POSIX socket semantics. Windows daemon coverage lives in the daemon
@@ -47,7 +46,6 @@
 
 #![cfg(unix)]
 
-use std::env;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -63,33 +61,6 @@ const COMPRESSIBLE_BYTES: usize = 512 * 1024;
 /// Incompressible tail keeps total wire bytes above the cutoff after
 /// compression engages.
 const INCOMPRESSIBLE_BYTES: usize = 512 * 1024;
-
-/// Locate the workspace `oc-rsync` binary the test runner built.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// RAII guard that kills the oc-rsync daemon on drop so a panicking
 /// assertion does not leave a dangling listener.
@@ -237,10 +208,7 @@ fn daemon_gzip_goodbye_does_not_truncate() {
         return;
     };
 
-    let Some(oc_rsync) = locate_oc_rsync() else {
-        eprintln!("Skipping: oc-rsync binary not located via CARGO_BIN_EXE_oc-rsync or target/");
-        return;
-    };
+    let oc_rsync = test_support::oc_rsync_bin();
 
     let fixture = match Fixture::start(&oc_rsync) {
         Ok(f) => f,

--- a/crates/transfer/tests/uts_15_e_daemon_pull_write_batch.rs
+++ b/crates/transfer/tests/uts_15_e_daemon_pull_write_batch.rs
@@ -56,14 +56,14 @@
 //!
 //! The test self-skips (prints `skipping:` and returns) when:
 //!
-//! - The workspace `oc-rsync` binary cannot be located (e.g., when this
-//!   file is built outside a `cargo nextest` invocation).
 //! - A loopback TCP port cannot be allocated.
 //! - The daemon fails to start accepting connections within the daemon boot
 //!   timeout.
 //!
 //! Hard failures (non-zero exit, missing destination files, empty batch
-//! file, failed replay) are real regressions.
+//! file, failed replay) are real regressions. A missing workspace
+//! `oc-rsync` binary is also a hard failure, naming the path that was
+//! expected, so the test can never pass without spawning the binary.
 //!
 //! # Upstream References
 //!
@@ -78,46 +78,12 @@
 
 #![cfg(unix)]
 
-use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 
 use tempfile::{TempDir, tempdir};
-
-/// Locate the workspace `oc-rsync` binary the test runner built.
-///
-/// Prefers `CARGO_BIN_EXE_oc-rsync` when set; otherwise walks up from
-/// the test executable until a `target/` directory is found, then probes
-/// the `debug/` and `release/` subdirectories. Mirrors the lookup used
-/// by sibling integration tests (`uts_nextest_daemon_delete_stats.rs`,
-/// `v61d_2_daemon_push_increcurse_perf_regression.rs`).
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// Write an `rsyncd.conf` exposing one read-only module rooted at
 /// `module_root`. Read-only matches the pull-only shape this test
@@ -317,10 +283,7 @@ impl DaemonScratch {
 /// client-side argv along with the daemon-bound argv strip.
 #[test]
 fn daemon_pull_write_batch_records_and_replays() {
-    let Some(oc_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let oc_bin = test_support::oc_rsync_bin();
     let Some(scratch) = DaemonScratch::new() else {
         eprintln!("skipping: tempdir or test port allocation failed");
         return;

--- a/crates/transfer/tests/uts_nextest_daemon_delete_stats.rs
+++ b/crates/transfer/tests/uts_nextest_daemon_delete_stats.rs
@@ -85,47 +85,12 @@
 
 #![cfg(unix)]
 
-use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 
 use tempfile::{TempDir, tempdir};
-
-/// Locate the workspace `oc-rsync` binary the test runner built.
-///
-/// Prefers Cargo's injected `CARGO_BIN_EXE_oc-rsync` when set; otherwise
-/// walks up from the test executable until a `target/` directory is
-/// found, mirroring the lookup used by sibling integration tests
-/// (`v61d_2_daemon_push_increcurse_perf_regression.rs`,
-/// `uts_nextest_chdir_symlink_race.rs`,
-/// `uts_9_daemon_gzip_download_goodbye.rs`).
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// Write an `rsyncd.conf` exposing a single read-write module.
 ///
@@ -329,10 +294,7 @@ impl DaemonScratch {
 ///    `Number of deleted files: 1`.
 #[test]
 fn daemon_push_emits_ndx_del_stats_and_reports_count() {
-    let Some(oc_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let oc_bin = test_support::oc_rsync_bin();
     let Some(scratch) = DaemonScratch::new() else {
         eprintln!("skipping: tempdir or test port allocation failed");
         return;
@@ -401,10 +363,7 @@ fn daemon_push_emits_ndx_del_stats_and_reports_count() {
 ///    `Number of deleted files: 1`.
 #[test]
 fn daemon_pull_emits_ndx_del_stats_and_reports_count() {
-    let Some(oc_bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let oc_bin = test_support::oc_rsync_bin();
     let Some(scratch) = DaemonScratch::new() else {
         eprintln!("skipping: tempdir or test port allocation failed");
         return;

--- a/crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs
+++ b/crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs
@@ -72,7 +72,6 @@
 
 #![cfg(unix)]
 
-use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
@@ -91,39 +90,6 @@ use tempfile::{TempDir, tempdir};
 /// deterministic PRNG stream. Total source size is ~1 MB.
 const COMPRESSIBLE_BYTES: usize = 512 * 1024;
 const INCOMPRESSIBLE_BYTES: usize = 512 * 1024;
-
-/// Locate the workspace `oc-rsync` binary the test runner built.
-///
-/// Mirrors the sibling helper used by
-/// `uts_nextest_hardlinks_inc_recurse.rs` and
-/// `v61d_2_daemon_push_increcurse_perf_regression.rs`: prefer the cargo
-/// injection, otherwise walk up from the test executable until a
-/// `target/` directory is found.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// Guard that kills the oc-rsync daemon on drop. Mirrors the pattern from
 /// `v61d_2_daemon_push_increcurse_perf_regression.rs` and keeps a
@@ -273,14 +239,14 @@ struct GzipDaemonFixture {
 }
 
 impl GzipDaemonFixture {
-    /// Spin up the daemon. Returns `Ok(Some)` on success; `Ok(None)` if
-    /// the oc-rsync binary is missing (the test then logs and skips
-    /// rather than failing - the same pattern the sibling nextest tests
-    /// use for binary-absent environments).
-    fn start() -> io::Result<Option<Self>> {
-        let Some(bin) = locate_oc_rsync() else {
-            return Ok(None);
-        };
+    /// Spin up the daemon.
+    ///
+    /// The binary is resolved with [`test_support::oc_rsync_bin`], which
+    /// panics naming the path it expected rather than reporting "absent" for
+    /// the caller to turn into a vacuous skip; `Err` is reserved for a genuine
+    /// spawn or fixture-setup failure.
+    fn start() -> io::Result<Self> {
+        let bin = test_support::oc_rsync_bin();
         let workdir = tempdir()?;
         let module_root = workdir.path().join("module");
         fs::create_dir_all(&module_root)?;
@@ -291,12 +257,12 @@ impl GzipDaemonFixture {
 
         let (daemon, port) = spawn_oc_rsync_daemon(&bin, &config_path)?;
 
-        Ok(Some(Self {
+        Ok(Self {
             _workdir: workdir,
             module_root,
             port,
             _daemon: daemon,
-        }))
+        })
     }
 
     /// Module-local path for fixture authoring (used by the download
@@ -323,9 +289,7 @@ impl GzipDaemonFixture {
 /// `time_push` helper but emits the full `Output` since both direction
 /// tests need to inspect stderr for the goodbye signature.
 fn run_client(args: &[&std::ffi::OsStr]) -> io::Result<std::process::Output> {
-    let bin = locate_oc_rsync().ok_or_else(|| {
-        io::Error::other("oc-rsync binary not found via CARGO_BIN_EXE_oc-rsync or target/")
-    })?;
+    let bin = test_support::oc_rsync_bin();
     Command::new(bin)
         .args(args)
         .stdin(Stdio::null())
@@ -359,11 +323,7 @@ fn read_all(path: &Path) -> Vec<u8> {
 #[test]
 fn daemon_gzip_zz_download_byte_identical() {
     let fixture = match GzipDaemonFixture::start() {
-        Ok(Some(f)) => f,
-        Ok(None) => {
-            eprintln!("skip: oc-rsync binary not located");
-            return;
-        }
+        Ok(f) => f,
         Err(e) => {
             eprintln!("skip: could not start oc-rsync daemon: {e}");
             return;
@@ -448,11 +408,7 @@ fn daemon_gzip_zz_download_byte_identical() {
 #[test]
 fn daemon_gzip_zz_upload_byte_identical() {
     let fixture = match GzipDaemonFixture::start() {
-        Ok(Some(f)) => f,
-        Ok(None) => {
-            eprintln!("skip: oc-rsync binary not located");
-            return;
-        }
+        Ok(f) => f,
         Err(e) => {
             eprintln!("skip: could not start oc-rsync daemon: {e}");
             return;
@@ -530,11 +486,7 @@ fn daemon_gzip_zz_upload_byte_identical() {
 #[test]
 fn daemon_gzip_z_vs_zz_negotiation() {
     let fixture = match GzipDaemonFixture::start() {
-        Ok(Some(f)) => f,
-        Ok(None) => {
-            eprintln!("skip: oc-rsync binary not located");
-            return;
-        }
+        Ok(f) => f,
         Err(e) => {
             eprintln!("skip: could not start oc-rsync daemon: {e}");
             return;
@@ -617,16 +569,9 @@ fn daemon_gzip_z_vs_zz_negotiation() {
 /// exclusively own the port.
 #[test]
 fn second_daemon_on_the_same_port_is_refused_no_co_bind() {
-    let Some(bin) = locate_oc_rsync() else {
-        eprintln!("skip: oc-rsync binary not located");
-        return;
-    };
+    let bin = test_support::oc_rsync_bin();
     let fixture = match GzipDaemonFixture::start() {
-        Ok(Some(f)) => f,
-        Ok(None) => {
-            eprintln!("skip: oc-rsync binary not located");
-            return;
-        }
+        Ok(f) => f,
         Err(e) => {
             eprintln!("skip: could not start oc-rsync daemon: {e}");
             return;
@@ -705,18 +650,11 @@ fn second_daemon_on_the_same_port_is_refused_no_co_bind() {
 /// is deterministic.
 #[test]
 fn concurrent_fixtures_get_distinct_ports_and_do_not_cross_talk() {
-    if locate_oc_rsync().is_none() {
-        eprintln!("skip: oc-rsync binary not located");
-        return;
-    }
-
     const FIXTURES: usize = 6;
     let handles: Vec<_> = (0..FIXTURES)
         .map(|idx| {
             thread::spawn(move || {
-                let fixture = GzipDaemonFixture::start()
-                    .expect("start fixture")
-                    .expect("oc-rsync binary present");
+                let fixture = GzipDaemonFixture::start().expect("start fixture");
 
                 // A payload unique to this fixture so a cross-talk landing is
                 // detectable by content, not just presence.
@@ -796,10 +734,7 @@ fn concurrent_fixtures_get_distinct_ports_and_do_not_cross_talk() {
 /// codec framing and the pull round-trips byte-identically.
 #[test]
 fn daemon_dont_compress_suffix_keeps_codec_framing() {
-    let Some(bin) = locate_oc_rsync() else {
-        eprintln!("skip: oc-rsync binary not located");
-        return;
-    };
+    let bin = test_support::oc_rsync_bin();
 
     let workdir = tempdir().expect("workdir");
     let module_root = workdir.path().join("module");

--- a/crates/transfer/tests/uts_nextest_hardlinks_inc_recurse.rs
+++ b/crates/transfer/tests/uts_nextest_hardlinks_inc_recurse.rs
@@ -63,47 +63,12 @@
 
 #![cfg(unix)]
 
-use std::env;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use tempfile::{TempDir, tempdir};
-
-/// Locate the workspace `oc-rsync` binary the test runner built.
-///
-/// Prefers Cargo's injected `CARGO_BIN_EXE_oc-rsync` when set; otherwise
-/// walks up from the test executable until a `target/` directory is
-/// found. Mirrors the lookup used by sibling integration tests
-/// (`delete_missing_args_files_from.rs`,
-/// `remove_source_files_local_copy.rs`,
-/// `v61d_2_daemon_push_increcurse_perf_regression.rs`).
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
 
 /// Returns the inode number of `path`. Used to assert hardlink sharing at
 /// the destination.
@@ -168,10 +133,7 @@ fn trailing_slash(dir: &Path) -> std::ffi::OsString {
 /// 4. All four files have the source's byte payload.
 #[test]
 fn flat_hardlink_pair_survives_inc_recurse_roundtrip() {
-    let Some(bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let bin = test_support::oc_rsync_bin();
 
     let root: TempDir = tempdir().expect("tempdir");
     let fromdir = root.path().join("from");
@@ -287,10 +249,7 @@ fn flat_hardlink_pair_survives_inc_recurse_roundtrip() {
 /// 4. All touch-files exist at the destination.
 #[test]
 fn deep_subdir_hardlink_survives_inc_recurse_roundtrip() {
-    let Some(bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let bin = test_support::oc_rsync_bin();
 
     let root: TempDir = tempdir().expect("tempdir");
     let fromdir = root.path().join("from");
@@ -400,10 +359,7 @@ fn deep_subdir_hardlink_survives_inc_recurse_roundtrip() {
 ///    members link to the shared `todir/` basis inode).
 #[test]
 fn link_dest_inherits_hardlinks_from_basis() {
-    let Some(bin) = locate_oc_rsync() else {
-        eprintln!("skipping: oc-rsync binary not found in target/");
-        return;
-    };
+    let bin = test_support::oc_rsync_bin();
 
     let root: TempDir = tempdir().expect("tempdir");
     let fromdir = root.path().join("from");

--- a/crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs
+++ b/crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs
@@ -47,7 +47,6 @@
 
 #![cfg(all(unix, not(target_os = "macos")))]
 
-use std::env;
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};

--- a/crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs
+++ b/crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs
@@ -81,38 +81,6 @@ const FILES_PER_DIR: usize = 64;
 /// on the same machine for sub-second push transfers).
 const MAX_SLOWDOWN_RATIO: f64 = 5.0;
 
-/// Locate the `oc-rsync` binary the test runner built.
-///
-/// Cargo injects `CARGO_BIN_EXE_oc-rsync` when the integration test sees
-/// the workspace binary as a dev-dependency; for the `transfer` crate
-/// that injection is not guaranteed, so fall back to walking the
-/// `target/` tree, mirroring `tests/inc_recurse_single_segment_push_isi_c.rs`.
-fn locate_oc_rsync() -> Option<PathBuf> {
-    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
-        let p = PathBuf::from(p);
-        if p.is_file() {
-            return Some(p);
-        }
-    }
-    let exe = env::current_exe().ok()?;
-    let mut dir = exe.parent()?;
-    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
-    while !dir.ends_with("target") {
-        let candidate = dir.join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-    for sub in ["debug", "release"] {
-        let candidate = dir.join(sub).join(&name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
-
 /// Locate the upstream rsync binary for the requested version.
 ///
 /// Looks under `target/interop/upstream-install/<version>/bin/rsync`,
@@ -271,13 +239,7 @@ fn time_push(sender_bin: &Path, src: &Path, port: u16) -> io::Result<Duration> {
 /// gets a quick-check head start from leftover destination files.
 #[test]
 fn daemon_push_under_inc_recurse_stays_within_5x_of_upstream_sender_baseline() {
-    let oc_bin = match locate_oc_rsync() {
-        Some(p) => p,
-        None => {
-            eprintln!("skip: oc-rsync binary not located");
-            return;
-        }
-    };
+    let oc_bin = test_support::oc_rsync_bin();
     let up_bin = match upstream_rsync_binary("3.4.1") {
         Some(p) => p,
         None => {


### PR DESCRIPTION
Follow-up to #6950, which fixed the helpers inside the `bin` package. The
remaining ~20 helpers live in `crates/*/tests` and could not use the same fix:
`env!("CARGO_BIN_EXE_oc-rsync")` is a **hard compile error** outside the package
that declares the `[[bin]]`. They kept resolving the binary by hand:

- a scan of `target/{debug,release,dist}`,
- a walk up from `CARGO_MANIFEST_DIR` or from `current_exe()`,
- and, in `crates/core/tests/common/mod.rs`, a cwd-relative
  `"target/release/oc-rsync"` string literal.

Both hazards from #6950 were still live. A scan can exercise a binary from an
entirely different revision, and most of these helpers returned `Option` so the
caller printed `skip:` and returned - a skip that can never be satisfied is
indistinguishable from a pass.

## Mechanism

**A single shared resolver in `test-support`, anchored on `OUT_DIR`.**

`crates/test-support/build.rs` derives the active profile directory from
`OUT_DIR` and emits it as `OC_RSYNC_TARGET_PROFILE_DIR`. Cargo hands `OUT_DIR`
to *every* build script (no `[[bin]]`-ownership restriction) and lays it out as
`<target-dir>/[<triple>/]<profile>/build/<pkg>-<hash>/out`, so its fourth
ancestor is exactly the directory Cargo links workspace binaries into. That
tracks custom profiles, cross-compilation triples, and relocated target
directories such as `cargo llvm-cov`'s, with no runtime probing.

`crates/test-support/src/bin_path.rs` exposes:

- `target_profile_dir()` - the baked directory,
- `workspace_bin_path(name)` - the single candidate path,
- `workspace_bin(name)` / `oc_rsync_bin()` - resolve or **panic**, naming the
  exact path and, on Unix, asserting the execute bit.

Exactly one path is ever considered. There is no second candidate to fall back
to and no `Option` for a caller to turn into a silent skip. A unit test pins
that the baked directory equals the one the test harness itself is linked into,
so build.rs and the runtime can never drift apart.

### Options rejected

- **(b) move the tests into the `bin` package.** This is the only option with a
  hard Cargo guarantee that the binary is *built* before the test runs, but it
  means relocating 20 files across 5 crates, changing which crate's features and
  dev-dependencies apply, renaming every nextest target, and losing access to
  the crates' own library APIs. Disproportionate for the failure being closed.
- **(d) `CARGO_TARGET_TMPDIR`.** Verified empirically: it is `<target-dir>/tmp`,
  *not* `<target-dir>/<profile>/tmp`. It identifies the target directory but not
  the profile, so it would have reintroduced a `debug`-vs-`release` guess -
  precisely the fallback being removed.
- **(c) a resolver taking the path as an argument.** The argument would have to
  originate from `env!("CARGO_BIN_EXE_oc-rsync")`, which is illegal in every one
  of these crates. There is nowhere legal to call it from.
- **(a) per-crate `build.rs`.** Same mechanism as what shipped, but duplicated
  five times. One `build.rs` on `test-support` serves all consumers, since every
  crate in a single Cargo invocation shares the profile directory.

`locate_workspace_binary` also loses its sibling-profile probe: serving a
`debug` binary to a `release` test run is how a stale build gets under test.

## Files fixed

Mechanism (new / reworked):

- `crates/test-support/build.rs` (new)
- `crates/test-support/src/bin_path.rs` (new)
- `crates/test-support/src/lib.rs` - re-exports
- `crates/test-support/src/skip.rs` - `locate_workspace_binary` now considers
  one path; `require_binary` names it
- `crates/test-support/src/cli.rs` - dropped the always-`None` runtime
  `CARGO_BIN_EXE_oc-rsync` lookup; `RunnerError::BinaryNotFound` now names the path
- `crates/test-support/src/lsh.rs` - same for `lsh-stub`; its unit test no
  longer has a vacuously-true `Err` arm

Helpers replaced (each dropped a hand-rolled resolver and its skip branches):

- `crates/cli/tests/upstream_arg_fidelity.rs`
- `crates/core/tests/common/mod.rs` (the cwd-relative `target/release` literal)
- `crates/core/tests/no_partial_temp_cleanup.rs`
- `crates/core/tests/partial_mid_transfer_kill.rs`
- `crates/core/tests/uts_9_daemon_gzip_download_goodbye.rs`
- `crates/engine/tests/delete_determinism_property.rs`
- `crates/metadata/tests/acl_root_root_interop.rs`
- `crates/metadata/tests/windows_ads_xattrs_roundtrip.rs`
- `crates/metadata/tests/windows_symlink_junction_transfer.rs`
- `crates/transfer/tests/daemon_total_transferred_size_stats.rs`
- `crates/transfer/tests/delay_updates_daemon_pull.rs`
- `crates/transfer/tests/delete_files_from_root_scope.rs`
- `crates/transfer/tests/delete_missing_args_files_from.rs`
- `crates/transfer/tests/itemize_fidelity_golden.rs`
- `crates/transfer/tests/nxt_4_reverse_daemon_delta.rs`
- `crates/transfer/tests/old_dirs_depth_limit.rs`
- `crates/transfer/tests/remove_source_files_local_copy.rs`
- `crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs`
- `crates/transfer/tests/uts_15_e_daemon_pull_write_batch.rs`
- `crates/transfer/tests/uts_nextest_daemon_delete_stats.rs`
- `crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs`
- `crates/transfer/tests/uts_nextest_hardlinks_inc_recurse.rs`
- `crates/transfer/tests/v61d_2_daemon_push_increcurse_perf_regression.rs`

Net: 330 insertions, 1001 deletions. Module docs that advertised "skips when the
binary cannot be located" were corrected in the same files. No assertion,
timeout, or `#[cfg]` gate was weakened; unrelated skip conditions (upstream rsync
absent, `strace` absent, daemon boot timeout, port allocation, ADS unsupported,
`mklink` unavailable, non-root) were all preserved.

## Stale-binary experiment

Host has `/opt/homebrew/bin/oc-rsync` on `PATH` - the exact bare-name fallback
target #6950 warns about.

**1. Binary moved aside, test binaries re-run without rebuilding:**

```
$ mv target/debug/oc-rsync target/debug/oc-rsync.stashed
$ ./target/debug/deps/itemize_fidelity_golden-708c851075ffde5b

running 1 test
test itemize_rows_match_upstream_3_4_4_golden ... FAILED

thread 'itemize_rows_match_upstream_3_4_4_golden' panicked at
crates/test-support/src/bin_path.rs:52:5:
oc-rsync binary missing at /Users/.../target/debug/oc-rsync; refusing to fall
back to a stale build (run `cargo build --bin oc-rsync` for this profile first)

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured
```

Same loud failure, naming the same path, from
`uts_nextest_hardlinks_inc_recurse` (3/3 failed), `delay_updates_daemon_pull`
(1/1), and `core/uts_9_daemon_gzip_download_goodbye` (1/1). None of them reached
the on-`PATH` Homebrew build. Before this change these helpers would have
scanned, missed, and returned `None`, and the callers would have printed
`skipping: oc-rsync binary not found in target/` and reported **ok**.

**2. Execute bit cleared (binary present but unusable):**

```
$ chmod -x target/debug/oc-rsync
thread '...' panicked at crates/test-support/src/bin_path.rs:84:5:
/Users/.../target/debug/oc-rsync exists but is not executable (mode 100644)
```

**3. Restored:**

```
$ chmod +x target/debug/oc-rsync
test itemize_rows_match_upstream_3_4_4_golden ... ok
test result: ok. 1 passed; 0 failed
```

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - clean
- All 23 affected test targets run green (transfer x13, core x4, engine, cli,
  metadata, test-support). The two Windows-gated metadata tests were
  type-checked on the host by temporarily relaxing their `#![cfg]` gate: clean,
  no warnings, gate restored.

## Deliberately out of scope

`require_binary("oc-rsync")` keeps its self-skip convention at ~50 call sites in
`crates/transfer/tests/uts_*.rs`. A targeted `cargo test -p transfer` genuinely
does not build the `oc-rsync` bin (the dependency would be circular), so those
ports would become unrunnable outside a workspace build. They are no longer
silent about it - the skip line now names the exact path probed - and under
`cargo nextest run --workspace` the bin is always built, so the skip never
fires in CI. Converting them to hard failures is a separate change.

Separately: `crates/core/tests/partial_mid_transfer_kill.rs` has three
`#[ignore = "requires oc-rsync binary"]` tests that were previously unrunnable
(the cwd-relative `target/release/oc-rsync` literal never resolved). With
resolution fixed they do run, and they fail on timing-sensitive assertions
("transfer completed before the interrupt") on a fast debug build. They remain
`#[ignore]`d - un-ignoring them needs a real fix to the interrupt timing, not a
resolution fix.
