### PR TITLE
fix(transfer): render daemon paths relative to the module root

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -80,6 +80,13 @@ fn apply_module_transfer_directives(module: &ModuleDefinition, cfg: &mut ServerC
     // error or warning. Record the name so the transfer layer reproduces it.
     cfg.connection.daemon_module = Some(module.name.clone());
 
+    // upstream: clientserver.c:864,993 - `module_chdir` is the normalized
+    // module path and the server `chdir()`s into it before serving, which is
+    // why `full_fname()` (util1.c:1285) only ever prints the part of a path
+    // below `module_dirlen`. oc-rsync keeps absolute paths, so record the root
+    // and let the transfer layer strip it.
+    cfg.connection.daemon_module_root = Some(module.path.clone());
+
     // upstream: clientserver.c:1111-1112
     if module.ignore_errors {
         cfg.deletion.ignore_errors = true;

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -13,17 +13,27 @@ use super::filter_program::{
 /// `"<strerror> (<errno>)"` (upstream `log.c:473` `": %s (%d)"`), rather than
 /// Rust's `std::io::Error` `Display`, which renders `" (os error <errno>)"`.
 /// Errors without an OS errno fall back to the `Display` string verbatim.
+///
+/// An [`io::Error`] built with [`io::Error::new`] around a custom payload
+/// reports no `raw_os_error()` even when the payload forwards the platform
+/// error's `Display`, so the trailing `" (os error N)"` is recovered from the
+/// rendered text as well. Without that, wrapping an error anywhere in the I/O
+/// stack would silently drop the errno upstream always prints.
 #[must_use]
 pub fn upstream_io_error(error: &io::Error) -> String {
-    match error.raw_os_error() {
-        Some(code) => {
-            let full = error.to_string();
-            let strerror = full
-                .strip_suffix(&format!(" (os error {code})"))
-                .unwrap_or(full.as_str());
-            format!("{strerror} ({code})")
-        }
-        None => error.to_string(),
+    let full = error.to_string();
+    if let Some(code) = error.raw_os_error() {
+        let strerror = full
+            .strip_suffix(&format!(" (os error {code})"))
+            .unwrap_or(full.as_str());
+        return format!("{strerror} ({code})");
+    }
+    match full.rsplit_once(" (os error ") {
+        Some((strerror, tail)) => match tail.strip_suffix(')') {
+            Some(code) if code.parse::<i32>().is_ok() => format!("{strerror} ({code})"),
+            _ => full,
+        },
+        None => full,
     }
 }
 
@@ -435,6 +445,40 @@ impl LocalCopyArgumentError {
 mod tests {
     use super::*;
     use std::io::ErrorKind;
+
+    /// upstream `rsyserr()` prints `"%s (%d)"` (log.c:473). An `io::Error`
+    /// built around a custom payload reports no `raw_os_error()`, so the errno
+    /// must still be recovered from the rendered text - otherwise wrapping an
+    /// error anywhere in the I/O stack silently drops it from the message.
+    #[test]
+    fn upstream_io_error_recovers_errno_from_a_wrapped_error() {
+        #[derive(Debug)]
+        struct Wrapper(io::Error);
+        impl std::fmt::Display for Wrapper {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+        impl std::error::Error for Wrapper {}
+
+        let raw = io::Error::from_raw_os_error(13);
+        let expected = upstream_io_error(&raw);
+        assert_eq!(expected, "Permission denied (13)");
+
+        let wrapped = io::Error::new(raw.kind(), Wrapper(io::Error::from_raw_os_error(13)));
+        assert_eq!(wrapped.raw_os_error(), None);
+        assert_eq!(upstream_io_error(&wrapped), expected);
+    }
+
+    /// A message that merely mentions the phrase, with no errno, is left alone.
+    #[test]
+    fn upstream_io_error_leaves_a_non_os_message_verbatim() {
+        let error = io::Error::other("no ftruncate for over-long pre-alloc");
+        assert_eq!(
+            upstream_io_error(&error),
+            "no ftruncate for over-long pre-alloc"
+        );
+    }
 
     #[test]
     fn local_copy_error_missing_operands() {

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -461,9 +461,14 @@ mod tests {
         }
         impl std::error::Error for Wrapper {}
 
+        // The strerror text is the platform's, so pin the shape (a trailing
+        // ` (13)` and no ` (os error 13)`) rather than the wording.
         let raw = io::Error::from_raw_os_error(13);
         let expected = upstream_io_error(&raw);
-        assert_eq!(expected, "Permission denied (13)");
+        assert!(
+            expected.ends_with(" (13)") && !expected.contains("os error"),
+            "rsyserr shape is `<strerror> (<errno>)`: {expected}"
+        );
 
         let wrapped = io::Error::new(raw.kind(), Wrapper(io::Error::from_raw_os_error(13)));
         assert_eq!(wrapped.raw_os_error(), None);

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -7,6 +7,7 @@ pub use builder::ServerConfigBuilder;
 pub use error::BuilderError;
 
 use std::ffi::OsString;
+use std::path::PathBuf;
 use std::time::SystemTime;
 
 use compress::zlib::CompressionLevel;
@@ -168,6 +169,22 @@ pub struct ConnectionConfig {
     /// - `clientserver.c:769` - `module_id = i` in `rsync_module()`.
     /// - `util1.c:1290` - `if (module_id >= 0)` in `full_fname()`.
     pub daemon_module: Option<String>,
+    /// Absolute on-disk root of the daemon module this server process serves.
+    ///
+    /// Mirrors upstream's `module_dir`/`module_dirlen` pair: the daemon
+    /// `chdir()`s here before serving, so every path it later reports is
+    /// rendered relative to this root and the server's real filesystem layout
+    /// never reaches the client. oc-rsync does not `chdir()`, so the root is
+    /// carried explicitly and stripped by
+    /// [`crate::full_fname::full_fname`]. `None` outside a daemon server
+    /// process, alongside [`daemon_module`](Self::daemon_module).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:864` - `module_chdir = normalize_path(module_dir, ..)`
+    /// - `clientserver.c:993` - `change_dir(module_chdir, CD_NORMAL)`
+    /// - `util1.c:1285` - `p1 = curr_dir + module_dirlen`
+    pub daemon_module_root: Option<PathBuf>,
     /// Filter rules to send to remote daemon (client_mode only).
     pub filter_rules: Vec<FilterRuleWireFormat>,
     /// Optional filename encoding converter for `--iconv` support.

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -209,6 +209,18 @@ pub struct DiskCommitConfig {
     /// - `util1.c:1290` - `if (module_id >= 0)` in `full_fname()`.
     /// - `receiver.c:297` - `rsyserr(FERROR_XFER, errno, "mkstemp %s failed", ...)`
     pub daemon_module: Option<String>,
+    /// Absolute on-disk root of the daemon module this server process serves.
+    ///
+    /// Paired with [`daemon_module`](Self::daemon_module) and
+    /// [`dest_dir`](Self::dest_dir) it lets the `mkstemp` diagnostic render its
+    /// path module-relative, the way a chdir'ed upstream daemon does, instead
+    /// of leaking the server's filesystem layout.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:993` - `change_dir(module_chdir, CD_NORMAL)`
+    /// - `util1.c:1285` - `p1 = curr_dir + module_dirlen`
+    pub daemon_module_root: Option<PathBuf>,
 }
 
 impl Default for DiskCommitConfig {
@@ -235,6 +247,7 @@ impl Default for DiskCommitConfig {
             delay_updates: false,
             append_verify: false,
             daemon_module: None,
+            daemon_module_root: None,
         }
     }
 }

--- a/crates/transfer/src/full_fname.rs
+++ b/crates/transfer/src/full_fname.rs
@@ -15,6 +15,35 @@
 //! `not creating new %s "%s"` at `generator.c:1380`) never gain it, so they must
 //! keep formatting their own quotes.
 //!
+//! # Module-relative rendering
+//!
+//! A daemon server `chdir()`s into the module root (`clientserver.c:993`
+//! `change_dir(module_chdir, CD_NORMAL)`), so every path it later handles is
+//! *relative* to that root and the absolute server-side location never reaches
+//! the client. `full_fname()` re-attaches only the part of `curr_dir` that lies
+//! below the module root:
+//!
+//! ```c
+//! if (*fn == '/')
+//!         p1 = p2 = "";
+//! else {
+//!         p1 = curr_dir + module_dirlen;
+//!         for (p2 = p1; *p2 == '/'; p2++) {}
+//!         if (*p2)
+//!                 p2 = "/";
+//! }
+//! ```
+//!
+//! With `curr_dir` at the module root `p1` is empty and the rendered name is
+//! the bare relative path (`"denied"`); with `curr_dir` one level down `p1` is
+//! `/sub`, `p2` collapses to `/`, and the render is module-root anchored
+//! (`"/sub/denied2"`). Both forms were captured from rsync 3.4.4 serving a
+//! module; neither ever contains the daemon's real filesystem prefix.
+//!
+//! oc-rsync never `chdir()`s - it carries absolute paths throughout - so
+//! [`DaemonPaths`] supplies the two directories upstream keeps in globals and
+//! the helper recovers upstream's relative `fn` by stripping `curr_dir`.
+//!
 //! # Upstream Reference
 //!
 //! - `util1.c:1273` - `full_fname()`; the `module_id >= 0` branch selects
@@ -22,26 +51,90 @@
 //! - `clientserver.c:769` - `module_id = i` is the only assignment that makes
 //!   `module_id >= 0`, so the suffix appears exactly when the process is a
 //!   daemon server that has selected a module.
+//! - `clientserver.c:864,993` - `module_dirlen` is the length of the
+//!   normalized module path and the server `chdir()`s there before serving.
 
 use std::fmt::Write as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// Renders `fname` the way upstream `full_fname()` does: double quoted, with
-/// ` (in MODULE)` appended after the closing quote when serving a daemon
-/// module.
+/// The daemon path context upstream keeps in globals, as seen by
+/// [`full_fname`].
 ///
-/// `module` is `None` for client and non-daemon server processes, mirroring
-/// upstream's `module_id < 0`.
-///
-/// Upstream additionally rewrites a relative name into `curr_dir` +
-/// `module_dirlen` form. Inside a daemon module that prefix is always empty,
-/// which is the only context where the suffix applies, so this helper renders
-/// the name it is given.
+/// `module` is upstream's `lp_name(module_id)`, `module_root` is `module_dir`
+/// (whose length is `module_dirlen`), and `curr_dir` is the directory upstream
+/// has `chdir()`ed into - the receiver's destination, or the sender's per-arg
+/// `dir` from the `flist.c:2338-2349` split. Absent for client and non-daemon
+/// server processes, mirroring upstream's `module_id < 0`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DaemonPaths<'a> {
+    /// Module name appended as ` (in MODULE)`. upstream: `lp_name(module_id)`.
+    pub module: &'a str,
+    /// Absolute module root. upstream: `module_dir` / `module_dirlen`.
+    pub module_root: &'a Path,
+    /// Absolute directory the server is serving from. upstream: `curr_dir`.
+    pub curr_dir: &'a Path,
+}
+
+impl DaemonPaths<'_> {
+    /// Rewrites an absolute server-side path into the module-relative form
+    /// upstream renders, or returns `None` when the path lies outside the
+    /// served tree.
+    ///
+    /// `None` makes the caller fall back to the path as given, matching
+    /// upstream's `*fn == '/'` branch: an absolute `fn` gets no prefix and is
+    /// printed verbatim.
+    fn relativize(&self, path: &Path) -> Option<PathBuf> {
+        // upstream's `fn` is relative to `curr_dir`, so recover it first.
+        let tail = path.strip_prefix(self.curr_dir).ok()?;
+        // upstream: `p1 = curr_dir + module_dirlen` - the part of the working
+        // directory below the module root.
+        let p1 = self.curr_dir.strip_prefix(self.module_root).ok()?;
+        // A DOTDIR source arg leaves `fn` as ".", never empty.
+        let tail = if tail.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            tail
+        };
+        if p1.as_os_str().is_empty() {
+            // upstream: p1 == "" and p2 == "" - the bare relative name.
+            return Some(tail.to_path_buf());
+        }
+        // upstream: p1 == "/sub" and p2 == "/" - module-root anchored.
+        Some(Path::new("/").join(p1).join(tail))
+    }
+}
+
+/// Renders `fname` the way upstream `full_fname()` does: double quoted,
+/// rewritten relative to the daemon module root, and with ` (in MODULE)`
+/// appended after the closing quote when serving a daemon module.
 ///
 /// # Upstream Reference
 ///
 /// - `util1.c:1296` - `asprintf(&result, "\"%s%s%s\"%s%s%s", ...)`
-pub(crate) fn full_fname(fname: &str, module: Option<&str>) -> String {
+pub(crate) fn full_fname(fname: &str, daemon: Option<DaemonPaths<'_>>) -> String {
+    match daemon {
+        Some(paths) => match paths.relativize(Path::new(fname)) {
+            Some(rendered) => quote(&rendered.display().to_string(), Some(paths.module)),
+            None => quote(fname, Some(paths.module)),
+        },
+        None => quote(fname, None),
+    }
+}
+
+/// [`full_fname`] for a [`Path`], using the platform's lossy display form.
+pub(crate) fn full_fname_path(path: &Path, daemon: Option<DaemonPaths<'_>>) -> String {
+    match daemon {
+        Some(paths) => {
+            let rendered = paths.relativize(path);
+            let shown = rendered.as_deref().unwrap_or(path);
+            quote(&shown.display().to_string(), Some(paths.module))
+        }
+        None => quote(&path.display().to_string(), None),
+    }
+}
+
+/// Formats the quoted name plus the optional ` (in MODULE)` suffix.
+fn quote(fname: &str, module: Option<&str>) -> String {
     let mut out = String::with_capacity(fname.len() + 2);
     out.push('"');
     out.push_str(fname);
@@ -52,15 +145,18 @@ pub(crate) fn full_fname(fname: &str, module: Option<&str>) -> String {
     out
 }
 
-/// [`full_fname`] for a [`Path`], using the platform's lossy display form.
-pub(crate) fn full_fname_path(path: &Path, module: Option<&str>) -> String {
-    full_fname(&path.display().to_string(), module)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{full_fname, full_fname_path};
+    use super::{DaemonPaths, full_fname, full_fname_path};
     use std::path::Path;
+
+    fn paths<'a>(module_root: &'a str, curr_dir: &'a str) -> DaemonPaths<'a> {
+        DaemonPaths {
+            module: "mymod",
+            module_root: Path::new(module_root),
+            curr_dir: Path::new(curr_dir),
+        }
+    }
 
     #[test]
     fn quotes_without_module_outside_daemon() {
@@ -68,12 +164,63 @@ mod tests {
     }
 
     #[test]
+    fn non_daemon_path_is_left_absolute() {
+        // A client or SSH server process has `module_id < 0`: upstream neither
+        // strips a prefix nor appends a suffix, so the absolute path a local
+        // or SSH run reports must stay byte-identical.
+        assert_eq!(
+            full_fname_path(Path::new("/tmp/src/denied.txt"), None),
+            "\"/tmp/src/denied.txt\""
+        );
+    }
+
+    #[test]
     fn appends_module_suffix_after_closing_quote() {
         // Ground truth captured from upstream rsync 3.4.4 serving module
         // `mymod`: `send_files failed to open "sub/denied.txt" (in mymod)`.
         assert_eq!(
-            full_fname("sub/denied.txt", Some("mymod")),
+            full_fname_path(
+                Path::new("/srv/mod/sub/denied.txt"),
+                Some(paths("/srv/mod", "/srv/mod"))
+            ),
             "\"sub/denied.txt\" (in mymod)"
+        );
+    }
+
+    #[test]
+    fn curr_dir_below_module_root_anchors_with_a_leading_slash() {
+        // Ground truth, rsync 3.4.4 daemon, `rsync -r rsync://h:p/mod/sub/`:
+        //   rsync: [sender] opendir "/sub/denied2" (in mod) failed: ...
+        // upstream: p1 = curr_dir + module_dirlen = "/sub", p2 = "/".
+        assert_eq!(
+            full_fname_path(
+                Path::new("/srv/mod/sub/denied2"),
+                Some(paths("/srv/mod", "/srv/mod/sub"))
+            ),
+            "\"/sub/denied2\" (in mymod)"
+        );
+    }
+
+    #[test]
+    fn path_at_curr_dir_renders_as_dot() {
+        // upstream's DOTDIR_NAME arg leaves `fn` as ".", never the empty
+        // string (flist.c:2312-2322).
+        assert_eq!(
+            full_fname_path(Path::new("/srv/mod"), Some(paths("/srv/mod", "/srv/mod"))),
+            "\".\" (in mymod)"
+        );
+    }
+
+    #[test]
+    fn path_outside_the_served_tree_stays_verbatim() {
+        // upstream: `*fn == '/'` selects `p1 = p2 = ""`, so an absolute name
+        // is printed as-is with the module suffix still attached.
+        assert_eq!(
+            full_fname_path(
+                Path::new("/etc/passwd"),
+                Some(paths("/srv/mod", "/srv/mod"))
+            ),
+            "\"/etc/passwd\" (in mymod)"
         );
     }
 
@@ -81,14 +228,27 @@ mod tests {
     fn empty_module_name_still_renders_upstream_shape() {
         // upstream: lp_name() can return an empty string only for a malformed
         // config; `module_id >= 0` still selects the suffix branch.
-        assert_eq!(full_fname("f", Some("")), "\"f\" (in )");
+        assert_eq!(
+            full_fname(
+                "/srv/mod/f",
+                Some(DaemonPaths {
+                    module: "",
+                    module_root: Path::new("/srv/mod"),
+                    curr_dir: Path::new("/srv/mod"),
+                })
+            ),
+            "\"f\" (in )"
+        );
     }
 
     #[test]
     fn path_variant_matches_string_variant() {
         assert_eq!(
-            full_fname_path(Path::new("a/b"), Some("mod")),
-            full_fname("a/b", Some("mod"))
+            full_fname_path(
+                Path::new("/srv/mod/a/b"),
+                Some(paths("/srv/mod", "/srv/mod"))
+            ),
+            full_fname("/srv/mod/a/b", Some(paths("/srv/mod", "/srv/mod")))
         );
     }
 }

--- a/crates/transfer/src/full_fname.rs
+++ b/crates/transfer/src/full_fname.rs
@@ -55,7 +55,7 @@
 //!   normalized module path and the server `chdir()`s there before serving.
 
 use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// The daemon path context upstream keeps in globals, as seen by
 /// [`full_fname`].
@@ -83,25 +83,41 @@ impl DaemonPaths<'_> {
     /// `None` makes the caller fall back to the path as given, matching
     /// upstream's `*fn == '/'` branch: an absolute `fn` gets no prefix and is
     /// printed verbatim.
-    fn relativize(&self, path: &Path) -> Option<PathBuf> {
+    fn relativize(&self, path: &Path) -> Option<String> {
         // upstream's `fn` is relative to `curr_dir`, so recover it first.
-        let tail = path.strip_prefix(self.curr_dir).ok()?;
+        let tail = slash_join(path.strip_prefix(self.curr_dir).ok()?);
         // upstream: `p1 = curr_dir + module_dirlen` - the part of the working
         // directory below the module root.
-        let p1 = self.curr_dir.strip_prefix(self.module_root).ok()?;
+        let p1 = slash_join(self.curr_dir.strip_prefix(self.module_root).ok()?);
         // A DOTDIR source arg leaves `fn` as ".", never empty.
-        let tail = if tail.as_os_str().is_empty() {
-            Path::new(".")
+        let tail = if tail.is_empty() {
+            ".".to_owned()
         } else {
             tail
         };
-        if p1.as_os_str().is_empty() {
+        if p1.is_empty() {
             // upstream: p1 == "" and p2 == "" - the bare relative name.
-            return Some(tail.to_path_buf());
+            return Some(tail);
         }
         // upstream: p1 == "/sub" and p2 == "/" - module-root anchored.
-        Some(Path::new("/").join(p1).join(tail))
+        Some(format!("/{p1}/{tail}"))
     }
+}
+
+/// Renders a relative path with `/` separators.
+///
+/// The module-relative name upstream prints is the same `/`-separated name it
+/// puts on the wire, never a host-native one, so the separator must not follow
+/// the platform the daemon happens to run on.
+fn slash_join(relative: &Path) -> String {
+    let mut out = String::new();
+    for component in relative.components() {
+        if !out.is_empty() {
+            out.push('/');
+        }
+        out.push_str(&component.as_os_str().to_string_lossy());
+    }
+    out
 }
 
 /// Renders `fname` the way upstream `full_fname()` does: double quoted,
@@ -114,7 +130,7 @@ impl DaemonPaths<'_> {
 pub(crate) fn full_fname(fname: &str, daemon: Option<DaemonPaths<'_>>) -> String {
     match daemon {
         Some(paths) => match paths.relativize(Path::new(fname)) {
-            Some(rendered) => quote(&rendered.display().to_string(), Some(paths.module)),
+            Some(rendered) => quote(&rendered, Some(paths.module)),
             None => quote(fname, Some(paths.module)),
         },
         None => quote(fname, None),
@@ -124,11 +140,10 @@ pub(crate) fn full_fname(fname: &str, daemon: Option<DaemonPaths<'_>>) -> String
 /// [`full_fname`] for a [`Path`], using the platform's lossy display form.
 pub(crate) fn full_fname_path(path: &Path, daemon: Option<DaemonPaths<'_>>) -> String {
     match daemon {
-        Some(paths) => {
-            let rendered = paths.relativize(path);
-            let shown = rendered.as_deref().unwrap_or(path);
-            quote(&shown.display().to_string(), Some(paths.module))
-        }
+        Some(paths) => match paths.relativize(path) {
+            Some(rendered) => quote(&rendered, Some(paths.module)),
+            None => quote(&path.display().to_string(), Some(paths.module)),
+        },
         None => quote(&path.display().to_string(), None),
     }
 }
@@ -238,6 +253,30 @@ mod tests {
                 })
             ),
             "\"f\" (in )"
+        );
+    }
+
+    /// The module-relative name is the same `/`-separated name rsync puts on
+    /// the wire, so it must not pick up the host separator when the daemon
+    /// runs on Windows. Built with `PathBuf::join` so the input carries the
+    /// platform's own separator.
+    #[test]
+    fn rendered_name_uses_slash_separators_on_every_platform() {
+        use std::path::PathBuf;
+
+        let root = PathBuf::from("/srv/mod");
+        let curr = root.join("sub");
+        let path = curr.join("deep").join("denied.txt");
+        assert_eq!(
+            full_fname_path(
+                &path,
+                Some(DaemonPaths {
+                    module: "mymod",
+                    module_root: &root,
+                    curr_dir: &curr,
+                })
+            ),
+            "\"/sub/deep/denied.txt\" (in mymod)"
         );
     }
 

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -140,6 +140,15 @@ pub struct GeneratorContext {
     /// Different operations have different overhead profiles: CPU-bound signature
     /// computation benefits from parallelism at lower counts than I/O-bound stat calls.
     pub(crate) parallel_thresholds: crate::parallel_io::ParallelThresholds,
+    /// Directory the sender is serving from, i.e. upstream's `curr_dir`.
+    ///
+    /// Upstream's sender `push_dir()`s into the `dir` half of each positional's
+    /// `dir`/`fn` split (flist.c:2338-2349) before walking it, and
+    /// `full_fname()` renders every diagnostic path relative to that directory.
+    /// oc-rsync never `chdir()`s, so the same directory - the walk `base` - is
+    /// recorded here as each source entry is walked and consumed by
+    /// [`daemon_paths`](Self::daemon_paths).
+    pub(crate) curr_dir: Option<PathBuf>,
     /// Transfer pipeline FSM tracking the current protocol phase.
     ///
     /// Enforces the linear phase progression through the transfer lifecycle.
@@ -150,15 +159,27 @@ pub struct GeneratorContext {
 }
 
 impl GeneratorContext {
-    /// Returns the daemon module name gating the ` (in MODULE)` suffix that
-    /// [`crate::full_fname::full_fname`] appends to quoted paths, or `None`
+    /// Returns the daemon path context that makes
+    /// [`crate::full_fname::full_fname`] render a quoted path the way upstream
+    /// does - module-relative, with the ` (in MODULE)` suffix - or `None`
     /// outside a daemon server process.
+    ///
+    /// The module root falls back to the module itself as `curr_dir` until the
+    /// walk records one, matching a server that has only `chdir()`ed into the
+    /// module root (`clientserver.c:993`) and not yet into a source argument.
     ///
     /// # Upstream Reference
     ///
-    /// - `util1.c:1290` - `if (module_id >= 0)` in `full_fname()`.
-    pub(crate) fn daemon_module(&self) -> Option<&str> {
-        self.config.connection.daemon_module.as_deref()
+    /// - `util1.c:1285-1290` - `p1 = curr_dir + module_dirlen` and
+    ///   `if (module_id >= 0)` in `full_fname()`.
+    pub(crate) fn daemon_paths(&self) -> Option<crate::full_fname::DaemonPaths<'_>> {
+        let module = self.config.connection.daemon_module.as_deref()?;
+        let module_root = self.config.connection.daemon_module_root.as_deref()?;
+        Some(crate::full_fname::DaemonPaths {
+            module,
+            module_root,
+            curr_dir: self.curr_dir.as_deref().unwrap_or(module_root),
+        })
     }
 
     /// Creates a new generator context from a completed handshake and server config.
@@ -206,6 +227,7 @@ impl GeneratorContext {
             delete_stats: DeleteStats::new(),
             flist_send_stats: super::FlistSendStats::default(),
             parallel_thresholds: crate::parallel_io::ParallelThresholds::default(),
+            curr_dir: None,
             pipeline,
         }
     }

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -82,6 +82,11 @@ impl GeneratorContext {
         // exclude.c add_rule XFLG_ANCHORED2ABS). Idempotent across source
         // entries; `base` is the same root for the whole walk.
         self.filter_chain.set_transfer_root(base.to_path_buf());
+        // upstream: flist.c:2411 `push_dir(dir, 0)` - the sender chdir's into
+        // the `dir` half of the positional's `dir`/`fn` split before walking
+        // it, which is the `curr_dir` every `full_fname()` in the walk renders
+        // against (util1.c:1285). `base` is that same directory.
+        self.curr_dir = Some(base.to_path_buf());
         // upstream: flist.c:2425 - link_stat() once, then pass &st to
         // send_file_name(). Reuse the metadata to avoid a redundant stat
         // inside walk_path_with_metadata.
@@ -122,7 +127,7 @@ impl GeneratorContext {
                         // upstream: flist.c:2433 - rsyserr(FERROR_XFER, ...)
                         let text = format!(
                             "rsync: [sender] link_stat {} failed: {}\n",
-                            full_fname_path(path, self.daemon_module()),
+                            full_fname_path(path, self.daemon_paths()),
                             engine::local_copy::upstream_io_error(&e),
                         );
                         self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
@@ -296,7 +301,7 @@ impl GeneratorContext {
                     // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                     let text = format!(
                         "rsync: [sender] opendir {} failed: {}\n",
-                        full_fname_path(&path, self.daemon_module()),
+                        full_fname_path(&path, self.daemon_paths()),
                         engine::local_copy::upstream_io_error(&e),
                     );
                     self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
@@ -396,7 +401,7 @@ impl GeneratorContext {
                 // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                 let text = format!(
                     "rsync: [sender] opendir {} failed: {}\n",
-                    full_fname_path(dir_path, self.daemon_module()),
+                    full_fname_path(dir_path, self.daemon_paths()),
                     engine::local_copy::upstream_io_error(&e),
                 );
                 self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
@@ -425,7 +430,7 @@ impl GeneratorContext {
                     // upstream: flist.c:1924 - rsyserr(FERROR_XFER, errno, "readdir(%s)", ...)
                     let text = format!(
                         "rsync: [sender] readdir({}): {}\n",
-                        full_fname_path(dir_path, self.daemon_module()),
+                        full_fname_path(dir_path, self.daemon_paths()),
                         engine::local_copy::upstream_io_error(&e),
                     );
                     self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
@@ -520,7 +525,7 @@ impl GeneratorContext {
     /// types: the vanished notice is an `FWARNING`, the stat failure an
     /// `FERROR_XFER`.
     fn log_stat_error(&mut self, path: &Path, e: &io::Error) {
-        let fname = full_fname_path(path, self.daemon_module());
+        let fname = full_fname_path(path, self.daemon_paths());
         let (kind, text) = if e.kind() == io::ErrorKind::NotFound {
             // upstream: flist.c:1314-1318 - rprintf(FWARNING, "file has vanished: %s\n", ...)
             (
@@ -669,28 +674,51 @@ mod rsyserr_wording_tests {
     }
 
     /// The same lines rendered from a daemon server process must carry
-    /// upstream's ` (in MODULE)` suffix outside the closing quote, because
-    /// upstream builds the path with `full_fname()` and `module_id >= 0`
-    /// there. Ground truth captured from rsync 3.4.4 serving module `mymod`:
-    /// `send_files failed to open "sub/denied.txt" (in mymod): ...`.
+    /// upstream's ` (in MODULE)` suffix outside the closing quote and name the
+    /// path relative to the module root, because upstream builds the path with
+    /// `full_fname()` after `chdir()`ing into the module (`clientserver.c:993`)
+    /// and `module_id >= 0`. Ground truth captured from rsync 3.4.4 serving
+    /// module `mod` rooted at `/tmp/modrel/mod`:
+    /// `rsync: [sender] opendir "denied" (in mod) failed: Permission denied (13)`.
     #[test]
     fn rsyserr_wording_carries_daemon_module_suffix() {
-        use crate::full_fname::full_fname_path;
+        use crate::full_fname::{DaemonPaths, full_fname_path};
         use std::path::Path;
 
-        let quoted = full_fname_path(Path::new("/p"), Some("mymod"));
-        assert_eq!(quoted, "\"/p\" (in mymod)");
+        let daemon = DaemonPaths {
+            module: "mymod",
+            module_root: Path::new("/srv/mod"),
+            curr_dir: Path::new("/srv/mod"),
+        };
+        let quoted = full_fname_path(Path::new("/srv/mod/p"), Some(daemon));
+        assert_eq!(quoted, "\"p\" (in mymod)");
         assert_eq!(
             format!("rsync: [sender] link_stat {quoted} failed: No such file or directory (2)"),
-            "rsync: [sender] link_stat \"/p\" (in mymod) failed: No such file or directory (2)",
+            "rsync: [sender] link_stat \"p\" (in mymod) failed: No such file or directory (2)",
         );
         assert_eq!(
             format!("rsync: [sender] readdir({quoted}): Input/output error (5)"),
-            "rsync: [sender] readdir(\"/p\" (in mymod)): Input/output error (5)",
+            "rsync: [sender] readdir(\"p\" (in mymod)): Input/output error (5)",
         );
         assert_eq!(
             format!("file has vanished: {quoted}"),
-            "file has vanished: \"/p\" (in mymod)",
+            "file has vanished: \"p\" (in mymod)",
+        );
+    }
+
+    /// A client or SSH server process (`module_id < 0`) must keep the absolute
+    /// path it has always printed: upstream neither strips a prefix nor
+    /// appends a suffix there, so a local or SSH run's stderr is unchanged.
+    #[test]
+    fn rsyserr_wording_outside_a_daemon_stays_absolute() {
+        use crate::full_fname::full_fname_path;
+        use std::path::Path;
+
+        let quoted = full_fname_path(Path::new("/srv/mod/p"), None);
+        assert_eq!(quoted, "\"/srv/mod/p\"");
+        assert_eq!(
+            format!("rsync: [sender] opendir {quoted} failed: Permission denied (13)"),
+            "rsync: [sender] opendir \"/srv/mod/p\" failed: Permission denied (13)",
         );
     }
 }

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -414,7 +414,7 @@ impl GeneratorContext {
         error: &io::Error,
         path_display: &str,
     ) -> io::Result<()> {
-        let fname = crate::full_fname::full_fname(path_display, self.daemon_module());
+        let fname = crate::full_fname::full_fname(path_display, self.daemon_paths());
         if error.kind() == io::ErrorKind::NotFound {
             self.io_error |= super::io_error_flags::IOERR_VANISHED;
             // upstream: sender.c:387-390 - rprintf(c, "file has vanished: %s\n", full_fname(...)).
@@ -462,7 +462,7 @@ impl GeneratorContext {
         self.io_error |= super::io_error_flags::IOERR_GENERAL;
         let text = format!(
             "rsync: [sender] read errors mapping {}: {}\n",
-            crate::full_fname::full_fname(path_display, self.daemon_module()),
+            crate::full_fname::full_fname(path_display, self.daemon_paths()),
             engine::local_copy::upstream_io_error(error),
         );
         self.emit_sender_diagnostic(writer, SenderDiagnostic::ErrorXfer, &text)
@@ -496,7 +496,7 @@ impl GeneratorContext {
             SenderDiagnostic::Warning,
             &format!(
                 "skipped diminished file: {}\n",
-                crate::full_fname::full_fname(path_display, self.daemon_module()),
+                crate::full_fname::full_fname(path_display, self.daemon_paths()),
             ),
         )?;
         if self.protocol.supports_generator_messages() {

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -5585,14 +5585,18 @@ fn diminished_skip_frames_a_warning_in_server_mode() {
     );
 }
 
-/// Walks `base` recursively as a daemon module server and returns the frames
-/// the queued file-list diagnostics produce on a multiplexed writer.
+/// Walks `base` recursively as a daemon module server rooted at `module_root`
+/// and returns the frames the queued file-list diagnostics produce on a
+/// multiplexed writer.
 ///
 /// `client_mode` selects upstream's `!am_server` branch (log.c:330), where the
-/// text goes to the local terminal and nothing is framed.
+/// text goes to the local terminal and nothing is framed. `module_root` is
+/// upstream's `module_dir`; a `None` root models a non-daemon server, whose
+/// `module_id < 0` leaves the absolute path untouched.
 #[cfg(unix)]
 fn flist_walk_frames(
     base: &Path,
+    module_root: Option<&Path>,
     client_mode: bool,
 ) -> (Vec<(protocol::MessageCode, Vec<u8>)>, i32) {
     let handshake = test_handshake();
@@ -5600,9 +5604,16 @@ fn flist_walk_frames(
     config.args = vec![OsString::from(base)];
     config.flags.recursive = true;
     config.connection.client_mode = client_mode;
-    config.connection.daemon_module = Some("mymod".to_owned());
+    if let Some(root) = module_root {
+        config.connection.daemon_module = Some("mymod".to_owned());
+        config.connection.daemon_module_root = Some(root.to_path_buf());
+    }
     let mut ctx = GeneratorContext::new_for_test(&handshake, config);
-    build_file_list_for(&mut ctx, base);
+    // A daemon hands the sender a trailing-slash source for `rsync://h/mod/`
+    // and `rsync://h/mod/sub/` alike (path_resolution.rs preserves it), which
+    // is what puts upstream's `curr_dir` at that directory (flist.c:2312-2322
+    // DOTDIR_NAME -> `push_dir(dir)`).
+    build_file_list_for_contents(&mut ctx, base);
 
     let mut buf = Vec::new();
     {
@@ -5643,7 +5654,7 @@ fn flist_opendir_failure_frames_an_error_xfer_in_server_mode() {
     let temp = TempDir::new().unwrap();
     let denied = unreadable_subdir(temp.path());
 
-    let (frames, io_error) = flist_walk_frames(temp.path(), false);
+    let (frames, io_error) = flist_walk_frames(temp.path(), Some(temp.path()), false);
     restore_subdir(&denied);
 
     assert_eq!(frames.len(), 1, "one opendir diagnostic: {frames:?}");
@@ -5654,17 +5665,70 @@ fn flist_opendir_failure_frames_an_error_xfer_in_server_mode() {
     );
     assert_eq!(
         String::from_utf8(frames[0].1.clone()).unwrap(),
-        format!(
-            "rsync: [sender] opendir \"{}\" (in mymod) failed: Permission denied (13)\n",
-            denied.display()
-        ),
-        "the framed text must stay byte-identical to the rsyserr rendering, \
-         daemon module suffix and trailing newline included"
+        "rsync: [sender] opendir \"denied\" (in mymod) failed: Permission denied (13)\n",
+        "the framed text must stay byte-identical to the rsyserr rendering: \
+         module-relative path, daemon module suffix and trailing newline"
     );
     assert_eq!(
         io_error,
         super::io_error_flags::IOERR_GENERAL,
         "upstream flist.c:1877 sets IOERR_GENERAL, which lands the run on exit 23"
+    );
+}
+
+/// A client that asked for a sub-path of the module (`rsync://h/mymod/sub/`)
+/// leaves upstream's `curr_dir` one level below `module_dir`, so `p1` is
+/// `/sub` and `p2` collapses to `/` (util1.c:1285-1291). Ground truth,
+/// rsync 3.4.4 daemon, module `mod` at `/tmp/modrel/mod`:
+///
+/// ```text
+/// rsync: [sender] opendir "/sub/denied2" (in mod) failed: Permission denied (13)
+/// ```
+///
+/// The daemon's own `/tmp/modrel/mod` prefix never appears on the wire.
+#[cfg(unix)]
+#[test]
+fn flist_opendir_failure_anchors_a_sub_path_at_the_module_root() {
+    let temp = TempDir::new().unwrap();
+    let sub = temp.path().join("sub");
+    fs::create_dir(&sub).unwrap();
+    let denied = unreadable_subdir(&sub);
+
+    let (frames, _io_error) = flist_walk_frames(&sub, Some(temp.path()), false);
+    restore_subdir(&denied);
+
+    assert_eq!(frames.len(), 1, "one opendir diagnostic: {frames:?}");
+    assert_eq!(
+        String::from_utf8(frames[0].1.clone()).unwrap(),
+        "rsync: [sender] opendir \"/sub/denied\" (in mymod) failed: Permission denied (13)\n"
+    );
+    assert!(
+        !String::from_utf8(frames[0].1.clone())
+            .unwrap()
+            .contains(&temp.path().display().to_string()),
+        "the daemon's filesystem layout must not reach the client"
+    );
+}
+
+/// Without a module (`module_id < 0`) upstream neither strips a prefix nor
+/// appends a suffix, so an SSH server's diagnostic keeps the absolute path it
+/// has always printed. This is the regression pin for the non-daemon output.
+#[cfg(unix)]
+#[test]
+fn flist_opendir_failure_stays_absolute_outside_a_daemon_module() {
+    let temp = TempDir::new().unwrap();
+    let denied = unreadable_subdir(temp.path());
+
+    let (frames, _io_error) = flist_walk_frames(temp.path(), None, false);
+    restore_subdir(&denied);
+
+    assert_eq!(frames.len(), 1, "one opendir diagnostic: {frames:?}");
+    assert_eq!(
+        String::from_utf8(frames[0].1.clone()).unwrap(),
+        format!(
+            "rsync: [sender] opendir \"{}\" failed: Permission denied (13)\n",
+            denied.display()
+        )
     );
 }
 
@@ -5677,7 +5741,7 @@ fn flist_opendir_failure_emits_no_frame_in_client_mode() {
     let temp = TempDir::new().unwrap();
     let denied = unreadable_subdir(temp.path());
 
-    let (frames, io_error) = flist_walk_frames(temp.path(), true);
+    let (frames, io_error) = flist_walk_frames(temp.path(), Some(temp.path()), true);
     restore_subdir(&denied);
 
     assert!(

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -117,6 +117,14 @@ pub struct PipelinedReceiver {
     ///
     /// upstream: util1.c:1290 - `if (module_id >= 0)` in `full_fname()`.
     daemon_module: Option<String>,
+    /// Module root and destination directory, i.e. upstream's `module_dir` and
+    /// the `curr_dir` the receiver `chdir()`ed into (`main.c:815`
+    /// `change_dir(dest_path, ..)`). Together they make the `mkstemp` failure
+    /// name its temp file relative to the module root.
+    ///
+    /// upstream: util1.c:1285 - `p1 = curr_dir + module_dirlen`.
+    daemon_module_root: Option<PathBuf>,
+    dest_dir: Option<PathBuf>,
 }
 
 /// Selects the upstream verification-failure `keptstr` wording for a file.
@@ -147,6 +155,8 @@ impl PipelinedReceiver {
     pub fn new(config: DiskCommitConfig) -> io::Result<Self> {
         let partial_mode = config.partial_mode.clone();
         let daemon_module = config.daemon_module.clone();
+        let daemon_module_root = config.daemon_module_root.clone();
+        let dest_dir = config.dest_dir.clone();
         let h = spawn_disk_thread(config)?;
         Ok(Self {
             file_tx: h.file_tx,
@@ -163,7 +173,42 @@ impl PipelinedReceiver {
             success_indices: Vec::new(),
             partial_mode,
             daemon_module,
+            daemon_module_root,
+            dest_dir,
         })
+    }
+
+    /// Returns the daemon path context `full_fname()` renders against, or
+    /// `None` outside a daemon server process (upstream `module_id < 0`).
+    fn daemon_paths(&self) -> Option<crate::full_fname::DaemonPaths<'_>> {
+        let module = self.daemon_module.as_deref()?;
+        let module_root = self.daemon_module_root.as_deref()?;
+        Some(crate::full_fname::DaemonPaths {
+            module,
+            module_root,
+            curr_dir: self.dest_dir.as_deref().unwrap_or(module_root),
+        })
+    }
+
+    /// Formats the receiver's temp-file creation failure the way upstream does.
+    ///
+    /// Upstream names the temp file it tried to create, not the destination it
+    /// would eventually have been renamed to, so a denied write into a module
+    /// reads `mkstemp ".new.txt.a2dBeL" (in romod) failed` - never the
+    /// server's absolute path. The attempted name rides along on the error
+    /// from [`crate::temp_guard::open_tmpfile`]; `dest` is the fallback for an
+    /// error raised anywhere else in the commit.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:297` - `rsyserr(FERROR_XFER, errno, "mkstemp %s failed",
+    ///   full_fname(fnametmp))`
+    fn mkstemp_failure(&self, dest: &std::path::Path, error: &io::Error) -> String {
+        let named = crate::temp_guard::attempted_temp_path(error).unwrap_or(dest);
+        format!(
+            "rsync: [receiver] mkstemp {} failed: Permission denied (13)",
+            full_fname_path(named, self.daemon_paths()),
+        )
     }
 
     /// Returns a reference to the channel sender for `FileMessage` items.
@@ -239,20 +284,12 @@ impl PipelinedReceiver {
                     if is_permission_error(&e) {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
                         // upstream: receiver.c:297 - rsyserr(FERROR_XFER, errno,
-                        // "mkstemp %s failed", full_fname(fnametmp)); full_fname()
-                        // wraps the path in double quotes and appends
-                        // " (in MODULE)" when serving a daemon module
-                        // (util1.c:1273). Emitting this as FERROR_XFER (not
-                        // FINFO) makes the peer's rwrite() set got_xfer_error,
-                        // so the run exits 23 (RERR_PARTIAL) instead of 0 when
-                        // the output mkstemp() was denied.
-                        self.warnings.push((
-                            MessageCode::ErrorXfer,
-                            format!(
-                                "rsync: [receiver] mkstemp {} failed: Permission denied (13)",
-                                full_fname_path(&path, self.daemon_module.as_deref()),
-                            ),
-                        ));
+                        // "mkstemp %s failed", full_fname(fnametmp)). Emitting
+                        // this as FERROR_XFER (not FINFO) makes the peer's
+                        // rwrite() set got_xfer_error, so the run exits 23
+                        // (RERR_PARTIAL) instead of 0 when mkstemp() was denied.
+                        let message = self.mkstemp_failure(&path, &e);
+                        self.warnings.push((MessageCode::ErrorXfer, message));
                         meta_errors.push((path, e.to_string()));
                         self.permission_error_count += 1;
                     } else {
@@ -308,20 +345,12 @@ impl PipelinedReceiver {
                     if is_permission_error(&e) {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
                         // upstream: receiver.c:297 - rsyserr(FERROR_XFER, errno,
-                        // "mkstemp %s failed", full_fname(fnametmp)); full_fname()
-                        // wraps the path in double quotes and appends
-                        // " (in MODULE)" when serving a daemon module
-                        // (util1.c:1273). Emitting this as FERROR_XFER (not
-                        // FINFO) makes the peer's rwrite() set got_xfer_error,
-                        // so the run exits 23 (RERR_PARTIAL) instead of 0 when
-                        // the output mkstemp() was denied.
-                        self.warnings.push((
-                            MessageCode::ErrorXfer,
-                            format!(
-                                "rsync: [receiver] mkstemp {} failed: Permission denied (13)",
-                                full_fname_path(&path, self.daemon_module.as_deref()),
-                            ),
-                        ));
+                        // "mkstemp %s failed", full_fname(fnametmp)). Emitting
+                        // this as FERROR_XFER (not FINFO) makes the peer's
+                        // rwrite() set got_xfer_error, so the run exits 23
+                        // (RERR_PARTIAL) instead of 0 when mkstemp() was denied.
+                        let message = self.mkstemp_failure(&path, &e);
+                        self.warnings.push((MessageCode::ErrorXfer, message));
                         meta_errors.push((path, e.to_string()));
                         self.permission_error_count += 1;
                     } else {
@@ -1161,13 +1190,21 @@ mod tests {
             MessageCode::ErrorXfer,
             "output-open failure must be MSG_ERROR_XFER so the peer exits 23"
         );
+        // Outside a daemon module upstream's module_id is -1 and module_dirlen
+        // is 0, so full_fname() neither strips a prefix nor appends a suffix:
+        // the absolute temp path stays exactly as a local or SSH run prints it
+        // (util1.c:1285-1290).
+        let expected_prefix = format!(
+            "rsync: [receiver] mkstemp \"{}/.denied.dat.",
+            readonly_dir.display()
+        );
         assert!(
-            warnings[0].1.contains("mkstemp"),
-            "message should mirror upstream receiver.c:297 \"mkstemp %s failed\": {}",
+            warnings[0].1.starts_with(&expected_prefix)
+                && warnings[0].1.ends_with("\" failed: Permission denied (13)"),
+            "message should mirror upstream receiver.c:297 \"mkstemp %s failed\" \
+             with the absolute temp name: {}",
             warnings[0].1
         );
-        // Outside a daemon module upstream's module_id is -1, so full_fname()
-        // emits the bare quoted path with no suffix (util1.c:1290).
         assert!(
             !warnings[0].1.contains(" (in "),
             "non-daemon run must not carry a module suffix: {}",
@@ -1178,30 +1215,19 @@ mod tests {
         drop(pr);
     }
 
-    /// Serving a daemon module, upstream's `full_fname()` appends
-    /// ` (in MODULE)` after the closing quote, so the receiver's `mkstemp`
-    /// failure names the module the client asked for. Without it a client
-    /// syncing several modules cannot tell which one refused the write.
-    ///
-    /// upstream: util1.c:1290 `if (module_id >= 0)` inside `full_fname()`,
-    /// reached from receiver.c:297 `rsyserr(..., "mkstemp %s failed", ...)`.
+    /// Drives one denied `mkstemp` through the disk thread and returns the
+    /// single queued warning, with the module context the daemon would supply.
     #[cfg(unix)]
-    #[test]
-    fn output_open_failure_names_daemon_module() {
-        use std::os::unix::fs::PermissionsExt;
-
-        if std::env::var("USER").is_ok_and(|u| u == "root") {
-            return;
-        }
-
-        let dir = test_support::create_tempdir();
-        let readonly_dir = dir.path().join("readonly");
-        std::fs::create_dir(&readonly_dir).unwrap();
-        std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o555)).unwrap();
-
+    fn denied_mkstemp_warning(
+        readonly_dir: &std::path::Path,
+        daemon_module_root: Option<PathBuf>,
+        dest_dir: Option<PathBuf>,
+    ) -> String {
         let file_path = readonly_dir.join("denied.dat");
         let mut pr = PipelinedReceiver::new(DiskCommitConfig {
             daemon_module: Some("mymod".to_string()),
+            daemon_module_root,
+            dest_dir,
             ..DiskCommitConfig::default()
         })
         .unwrap();
@@ -1225,24 +1251,80 @@ mod tests {
         pr.note_commit_sent(
             [0u8; ChecksumVerifier::MAX_DIGEST_LEN],
             0,
-            file_path.clone(),
+            file_path,
             0,
             false,
         );
 
         let (_bytes, _errors) = pr.drain_all_results().unwrap();
-        let warnings = pr.drain_warnings();
+        let mut warnings = pr.drain_warnings();
         assert_eq!(warnings.len(), 1);
-        assert_eq!(
-            warnings[0].1,
-            format!(
-                "rsync: [receiver] mkstemp \"{}\" (in mymod) failed: Permission denied (13)",
-                file_path.display()
-            ),
+        drop(pr);
+        warnings.remove(0).1
+    }
+
+    /// Serving a daemon module, upstream's `full_fname()` appends
+    /// ` (in MODULE)` after the closing quote and renders the path relative to
+    /// the module root, so the receiver's `mkstemp` failure names the module
+    /// the client asked for and never the server's real filesystem layout.
+    /// It also names the *temp* file, not the destination it would have been
+    /// renamed to.
+    ///
+    /// Ground truth, rsync 3.4.4 daemon, module `romod` at `/tmp/modrel/romod`,
+    /// `rsync -r src/new.txt rsync://h:p/romod/`:
+    ///
+    /// ```text
+    /// rsync: [receiver] mkstemp ".new.txt.a2dBeL" (in romod) failed: Permission denied (13)
+    /// ```
+    ///
+    /// upstream: util1.c:1285-1290 inside `full_fname()`, reached from
+    /// receiver.c:297 `rsyserr(..., "mkstemp %s failed", full_fname(fnametmp))`.
+    #[cfg(unix)]
+    #[test]
+    fn output_open_failure_names_daemon_module() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if std::env::var("USER").is_ok_and(|u| u == "root") {
+            return;
+        }
+
+        let dir = test_support::create_tempdir();
+        let readonly_dir = dir.path().join("readonly");
+        std::fs::create_dir(&readonly_dir).unwrap();
+        std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o555)).unwrap();
+
+        // The client pushed into the module root itself: upstream's curr_dir
+        // equals module_dir, so p1 is empty and the temp name is bare.
+        let at_root = denied_mkstemp_warning(
+            &readonly_dir,
+            Some(readonly_dir.clone()),
+            Some(readonly_dir.clone()),
+        );
+        assert!(
+            at_root.starts_with("rsync: [receiver] mkstemp \".denied.dat.")
+                && at_root.ends_with("\" (in mymod) failed: Permission denied (13)"),
+            "module-root push must name the bare temp file: {at_root}"
+        );
+
+        // The client pushed into `readonly/` under the module root: upstream's
+        // p1 is `/readonly` and p2 collapses to `/`, so the render is anchored
+        // at the module root with a leading slash.
+        let in_subdir = denied_mkstemp_warning(
+            &readonly_dir,
+            Some(dir.path().to_path_buf()),
+            Some(readonly_dir.clone()),
+        );
+        assert!(
+            in_subdir.starts_with("rsync: [receiver] mkstemp \"/readonly/.denied.dat.")
+                && in_subdir.ends_with("\" (in mymod) failed: Permission denied (13)"),
+            "sub-directory push must anchor at the module root: {in_subdir}"
+        );
+        assert!(
+            !in_subdir.contains(&dir.path().display().to_string()),
+            "the server's absolute path must never reach the client: {in_subdir}"
         );
 
         let _ = std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o755));
-        drop(pr);
     }
 
     /// Pins the WARNING wording to upstream `receiver.c:965-968` verbatim.

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -209,6 +209,7 @@ impl ReceiverContext {
             delay_updates: self.config.write.delay_updates,
             append_verify: self.config.flags.append_verify && !is_redo_pass,
             daemon_module: self.config.connection.daemon_module.clone(),
+            daemon_module_root: self.config.connection.daemon_module_root.clone(),
             ..DiskCommitConfig::default()
         };
         let mut pipelined_receiver = PipelinedReceiver::new(disk_config)?;

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -10,11 +10,53 @@
 //! - `receiver.c:get_tmpname()` - temp file path construction
 //! - `receiver.c:open_tmpfile()` → `syscall.c:do_mkstemp()` - atomic creation
 
+use std::fmt;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::sync::Arc;
+
+/// Payload attached to a failed [`open_tmpfile`] so the caller can name the
+/// temp file the `mkstemp` attempt used.
+///
+/// Upstream reports the temp name, not the final destination:
+/// `rsyserr(FERROR_XFER, errno, "mkstemp %s failed", full_fname(fnametmp))`
+/// (receiver.c:297). The disk-commit thread hands the failure back as a plain
+/// [`io::Error`], so the attempted name rides along inside it and is recovered
+/// with [`attempted_temp_path`].
+///
+/// [`fmt::Display`] forwards to the underlying error verbatim, so a wrapped
+/// error still renders exactly like the unwrapped one.
+#[derive(Debug)]
+struct TempOpenError {
+    temp_path: PathBuf,
+    source: io::Error,
+}
+
+impl fmt::Display for TempOpenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.source, f)
+    }
+}
+
+impl std::error::Error for TempOpenError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+/// Returns the temp-file name a failed [`open_tmpfile`] attempted, when `error`
+/// came from that call.
+///
+/// `None` for every other error, so callers fall back to whatever name they
+/// already have.
+pub fn attempted_temp_path(error: &io::Error) -> Option<&Path> {
+    error
+        .get_ref()?
+        .downcast_ref::<TempOpenError>()
+        .map(|e| e.temp_path.as_path())
+}
 
 /// Length of the random suffix including the leading dot: `.XXXXXX` = 7 bytes.
 const TMPNAME_SUFFIX_LEN: usize = 7;
@@ -217,7 +259,18 @@ fn open_tmpfile_inner(
                 // surface the ENOENT verbatim to match upstream.
                 return Err(io::Error::new(e.kind(), e.to_string()));
             }
-            Err(e) => return Err(e),
+            // Carry the attempted name so the receiver's diagnostic can print
+            // `fnametmp` the way receiver.c:297 does. The wrapper keeps both
+            // `kind()` and the Display text of the original error.
+            Err(e) => {
+                return Err(io::Error::new(
+                    e.kind(),
+                    TempOpenError {
+                        temp_path: concrete_path,
+                        source: e,
+                    },
+                ));
+            }
         }
     }
 
@@ -591,6 +644,54 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    /// upstream names `fnametmp`, not the destination, in the `mkstemp %s
+    /// failed` diagnostic (receiver.c:297), so a failed open must hand the
+    /// attempted `.name.XXXXXX` back to the caller while keeping the error's
+    /// `kind()` and rendered text untouched.
+    #[cfg(unix)]
+    #[test]
+    fn failed_open_reports_the_attempted_temp_name() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if std::env::var("USER").is_ok_and(|u| u == "root") {
+            return;
+        }
+
+        let dir = tempdir().expect("create temp dir");
+        let readonly = dir.path().join("readonly");
+        fs::create_dir(&readonly).expect("create dir");
+        fs::set_permissions(&readonly, PermissionsExt::from_mode(0o555)).expect("chmod");
+
+        let dest = readonly.join("new.txt");
+        let error = open_tmpfile(&dest, None).expect_err("read-only dir must deny the create");
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            error.to_string(),
+            io::Error::from_raw_os_error(libc::EACCES).to_string(),
+            "the wrapper must render exactly like the error it carries"
+        );
+        let attempted = attempted_temp_path(&error).expect("temp name attached");
+        assert_eq!(attempted.parent(), Some(readonly.as_path()));
+        let name = attempted
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("temp name");
+        assert!(
+            name.starts_with(".new.txt.") && name.len() == ".new.txt.".len() + 6,
+            "upstream get_tmpname() shape `.<name>.XXXXXX`: {name}"
+        );
+
+        let _ = fs::set_permissions(&readonly, PermissionsExt::from_mode(0o755));
+    }
+
+    /// Every other error carries no temp name, so callers fall back to the
+    /// path they already have.
+    #[test]
+    fn unrelated_errors_carry_no_temp_name() {
+        assert!(attempted_temp_path(&io::Error::from_raw_os_error(2)).is_none());
+    }
 
     #[test]
     fn temp_file_deleted_on_drop() {


### PR DESCRIPTION
## Problem

A daemon serving a module printed **absolute server paths** in its diagnostics. Upstream never does: `rsync_module()` `chdir()`s into the module root (`clientserver.c:993` `change_dir(module_chdir, CD_NORMAL)`), so every path it later handles is relative, and `util1.c:full_fname()` re-attaches only the part of `curr_dir` that lies below `module_dirlen`:

```c
if (*fn == '/')
        p1 = p2 = "";
else {
        p1 = curr_dir + module_dirlen;
        for (p2 = p1; *p2 == '/'; p2++) {}
        if (*p2)
                p2 = "/";
}
...
asprintf(&result, "\"%s%s%s\"%s%s%s", p1, p2, fn, m1, m2, m3);
```

With `curr_dir` at the module root `p1` is empty and the render is the bare relative name; one level down `p1` is `/sub` and `p2` collapses to `/`, giving a module-root-anchored `"/sub/..."`. Either way the daemon's real filesystem layout never reaches the client - deliberately.

Two sites showed the divergence:

* the receiver's `mkstemp` failure, which additionally named the **final destination** where `receiver.c:297` names `fnametmp`:
  `rsyserr(FERROR_XFER, errno, "mkstemp %s failed", full_fname(fnametmp))`
* the sender's `opendir`/`link_stat`/`readdir` diagnostics from the file-list walk.

## Fix

The rewrite lives in the shared `full_fname` helper, so every daemon diagnostic that routes through it is corrected at once instead of site by site. The helper now takes the two directories upstream keeps in globals:

* `module_root` - upstream's `module_dir`/`module_dirlen`, recorded when the daemon selects a module.
* `curr_dir` - the directory being served. The sender records it as it walks each positional's `dir`/`fn` split (`flist.c:2338-2349`, which oc already mirrors in `non_relative_walk_base`); the receiver uses its destination directory (`main.c:815`).

A path outside the served tree falls back to being printed verbatim, matching upstream's `*fn == '/'` branch.

Separately, the temp name the failed `mkstemp` attempted now rides along on the open error, so the receiver names it the way `receiver.c:297` does. The wrapper's `Display` forwards to the error it carries; `upstream_io_error()` gained a fallback so a wrapped error still renders its errno as `(13)` rather than `(os error 13)`.

## Captures

Ground truth from upstream **rsync 3.4.4** (protocol 32, `~/upstream-build/rsync-3.4.4/rsync`) serving modules `mod` (at `/tmp/modrel/mod`) and `romod` (at `/tmp/modrel/romod`):

```
### pull module root  (rsync -r rsync://h:8873/mod/ out)
rsync: [sender] opendir "denied" (in mod) failed: Permission denied (13)
rsync: [sender] opendir "sub/denied2" (in mod) failed: Permission denied (13)
### pull a sub-path   (rsync -r rsync://h:8873/mod/sub/ out)
rsync: [sender] opendir "/sub/denied2" (in mod) failed: Permission denied (13)
### push, read-only module dir  (rsync -r src/new.txt rsync://h:8873/romod/)
rsync: [receiver] mkstemp ".new.txt.a2dBeL" (in romod) failed: Permission denied (13)
### push into a sub-path        (rsync -r src/new.txt rsync://h:8873/romod/rosub/)
rsync: [receiver] mkstemp "/rosub/.new.txt.gjkpjn" (in romod) failed: Permission denied (13)
```

**oc-rsync before** (same scenarios, module rooted at `/tmp/occap/...`):

```
rsync: [sender] opendir "/tmp/occap/mod/denied" (in mod) failed: Permission denied (13)
rsync: [sender] opendir "/tmp/occap/mod/sub/denied2" (in mod) failed: Permission denied (13)
rsync: [sender] opendir "/tmp/occap/mod/sub/denied2" (in mod) failed: Permission denied (13)
rsync: [receiver] mkstemp "/tmp/occap/romod/new.txt" (in romod) failed: Permission denied (13)
rsync: [receiver] mkstemp "/tmp/occap/romod/rosub/new.txt" (in romod) failed: Permission denied (13)
```

**oc-rsync after**:

```
rsync: [sender] opendir "denied" (in mod) failed: Permission denied (13)
rsync: [sender] opendir "sub/denied2" (in mod) failed: Permission denied (13)
rsync: [sender] opendir "/sub/denied2" (in mod) failed: Permission denied (13)
rsync: [receiver] mkstemp ".new.txt.YmDmEP" (in romod) failed: Permission denied (13)
rsync: [receiver] mkstemp "/rosub/.new.txt.nxyLic" (in romod) failed: Permission denied (13)
```

A third diagnostic family from the same helper, `send_files failed to open` (`sender.c:393`), was checked the same way. Upstream 3.4.4:

```
### pull module root
rsync: [sender] send_files failed to open "top_secret.txt" (in mod): Permission denied (13)
rsync: [sender] send_files failed to open "sub/secret.txt" (in mod): Permission denied (13)
### pull sub/
rsync: [sender] send_files failed to open "/sub/secret.txt" (in mod): Permission denied (13)
```

oc-rsync before / after, `rsync://h/mod/sub/`:

```
- rsync: [sender] send_files failed to open "/tmp/sendfail/mod/sub/secret.txt" (in mod): Permission denied (13)
+ rsync: [sender] send_files failed to open "/sub/secret.txt" (in mod): Permission denied (13)
```

Byte-identical to upstream, including the leading-slash anchoring when the client asks for a sub-path of the module. The six-character `mkstemp` suffix is random per attempt in both implementations.

Upstream was captured on Linux from a real 3.4.4 daemon; oc-rsync before/after was captured on macOS from a real oc-rsync daemon running the identical scenarios. These messages are pure string formatting with no platform-dependent input, and the Linux host's disk was at 98% so building there would have risked other work on it.

## Non-daemon output is unchanged

Outside a daemon module upstream has `module_id < 0` and `module_dirlen == 0`: nothing is stripped and no suffix is appended. The helper keeps that path byte-identical, and three tests pin it - `full_fname::tests::non_daemon_path_is_left_absolute`, `generator::tests::flist_opendir_failure_stays_absolute_outside_a_daemon_module`, and the existing non-daemon `mkstemp` test, which now also asserts the absolute temp name.

## Tests

* `full_fname` unit tests for the module-root, sub-path, at-`curr_dir`, outside-the-tree and no-module renders.
* `generator::tests::flist_opendir_failure_*` - sender diagnostic framed over the wire, module-relative at the module root, anchored for a sub-path, absolute without a module.
* `pipeline::receiver::tests::output_open_failure_names_daemon_module` - the `mkstemp` line names the temp file, in both the module-root and sub-directory forms, and asserts the server's absolute path never appears.
* `temp_guard::tests::failed_open_reports_the_attempted_temp_name` - the attempted `.name.XXXXXX` is recoverable and the error's `kind()`/`Display` are untouched.
* `upstream_io_error` regression tests for the wrapped-error errno fallback.

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` are clean; `transfer` (2164), `engine` and `daemon` lib suites pass locally.
