### PR TITLE
fix(transfer): stop the client receiving after an empty file list

### DIFF
--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -68,6 +68,74 @@ impl ReceiverContext {
         }
     }
 
+    /// True when this receiver is a *client* that was handed an empty file
+    /// list, i.e. every requested source path failed to be listed (missing
+    /// source, unreadable directory, everything filtered out).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:1383-1392` - `client_run()` gates the entire receive on
+    ///   `if (flist && flist->used > 0)`. With no entries it takes the `else`
+    ///   arm (`handle_stats(-1); output_summary();`) and returns without ever
+    ///   calling `do_recv()`.
+    /// - `main.c:968-974` - the peer sender bailed out at
+    ///   `if (!flist || flist->used == 0) exit_cleanup(0)` (mirrored in
+    ///   `generator::transfer::orchestrator`), so it never reads an ndx, never
+    ///   writes its stats trailer, and never joins the goodbye handshake.
+    ///
+    /// Client-side only, exactly as upstream: `do_server_recv()` has no such
+    /// gate and calls `do_recv()` unconditionally (`main.c:1201-1245`).
+    pub(in crate::receiver) const fn is_empty_client_flist(&self, file_count: usize) -> bool {
+        file_count == 0 && self.config.connection.client_mode
+    }
+
+    /// Ends a client receive that was handed an empty file list, without
+    /// entering the transfer loop or the finalization exchange.
+    ///
+    /// Mirrors the `else` arm of `main.c:1389-1392`: no ndx is written, no
+    /// stats trailer is read, and the goodbye handshake is skipped, because the
+    /// peer sender already exited. Reading for any of them would block until
+    /// the connection died, which is how this surfaced - the client reported
+    /// `failed to fill whole buffer` (exit 12) instead of the summary.
+    ///
+    /// The returned stats carry every `io_error` bit the sender managed to
+    /// deliver before it exited, from both wire encodings upstream uses:
+    ///
+    /// - the file-list end marker, when the peer negotiated a safe incremental
+    ///   file list (`flist.c:2508-2517` -> `write_end_of_flist(f, 1)`), and
+    /// - a `MSG_IO_ERROR` frame otherwise (`flist.c:2553-2555`), which arrives
+    ///   interleaved with the list itself and has therefore already been folded
+    ///   into the reader by the time the list ends - exactly how upstream's
+    ///   global `io_error` picks it up before `client_run()` tests the list.
+    ///
+    /// `cleanup.c:217-218` turns `IOERR_GENERAL` into exit 23 (`RERR_PARTIAL`),
+    /// while a genuinely empty-but-clean list still exits 0. Byte counters stay
+    /// at whatever this process itself observed, matching `handle_stats(-1)`,
+    /// which skips the wire read for `f < 0 && !am_sender` (`main.c:362-363`).
+    pub(in crate::receiver) fn finish_empty_client_flist<R: Read, W: Write + ?Sized>(
+        &mut self,
+        reader: &mut crate::reader::ServerReader<R>,
+        writer: &mut W,
+    ) -> io::Result<TransferStats> {
+        // upstream: exit_cleanup() -> io_flush(FULL_FLUSH); nothing more is
+        // written to the peer after this point.
+        writer.flush()?;
+
+        self.pipeline
+            .advance_to(crate::transfer_state::TransferPhase::Finalization)
+            .map_err(crate::fsm_error)?;
+        self.pipeline
+            .advance_to(crate::transfer_state::TransferPhase::Complete)
+            .map_err(crate::fsm_error)?;
+
+        Ok(TransferStats {
+            io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
+                | self.flist_io_error
+                | reader.take_io_error(),
+            ..TransferStats::default()
+        })
+    }
+
     /// Finalizes a completed transfer's delayed updates and hardlink followers,
     /// in the order upstream mandates.
     ///

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -62,6 +62,15 @@ impl ReceiverContext {
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
 
+        // upstream: main.c:1383-1392 - a client handed an empty list skips
+        // do_recv() entirely and reports the io_error the end marker carried.
+        // Checked before the sub-list fetch below because upstream's own
+        // `if (inc_recurse && file_total == 1) recv_additional_file_list()`
+        // (main.c:1380-1381) cannot fire with a file_total of 0 either.
+        if self.is_empty_client_flist(file_count) {
+            return self.finish_empty_client_flist(reader, writer);
+        }
+
         // Materialize any INC_RECURSE sub-list segments the setup no longer
         // drains, so the batched candidate build below sees the complete list.
         // No-op without INC_RECURSE (`flist_eof` is already set, so no wire read

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -46,6 +46,15 @@ impl ReceiverContext {
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
 
+        // upstream: main.c:1383-1392 - a client handed an empty list skips
+        // do_recv() entirely and reports the io_error the end marker carried.
+        // Checked before the sub-list fetch below because upstream's own
+        // `if (inc_recurse && file_total == 1) recv_additional_file_list()`
+        // (main.c:1380-1381) cannot fire with a file_total of 0 either.
+        if self.is_empty_client_flist(file_count) {
+            return self.finish_empty_client_flist(reader, writer);
+        }
+
         // Materialize any INC_RECURSE sub-list segments the setup no longer
         // drains. No-op without INC_RECURSE (`flist_eof` already set).
         // upstream: generator.c:2299-2368 fetches sub-lists on demand.

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -324,24 +324,34 @@ impl ReceiverContext {
         // no `MSG_*` frame is emitted on the wire, matching upstream's
         // `get_local_name()` which calls `do_mkdir()` directly against the
         // local filesystem.
-        let created_dest_root = ensure_dest_root_exists(
-            &dest_dir,
-            file_count,
-            trailing_slash,
-            self.config.flags.skip_dest_writes(),
-            self.config.flags.mkpath,
-        )
-        .map_err(|e| {
-            io::Error::new(
-                e.kind(),
-                format!(
-                    "failed to create destination root {}: {e} {}{}",
-                    dest_dir.display(),
-                    crate::role_trailer::error_location!(),
-                    crate::role_trailer::receiver()
-                ),
+        // upstream: main.c:1383-1388 - `get_local_name()`, and with it the
+        // pre-flight mkdir at main.c:778-792, lives inside the non-empty-list
+        // arm of client_run(). A client handed an empty list must not create
+        // the destination directory: `rsync host:/missing /new/` leaves
+        // `/new/` absent. `do_server_recv()` calls `get_local_name()`
+        // unconditionally (main.c:1212-1213), so the gate is client-side only.
+        let created_dest_root = if self.is_empty_client_flist(file_count) {
+            false
+        } else {
+            ensure_dest_root_exists(
+                &dest_dir,
+                file_count,
+                trailing_slash,
+                self.config.flags.skip_dest_writes(),
+                self.config.flags.mkpath,
             )
-        })?;
+            .map_err(|e| {
+                io::Error::new(
+                    e.kind(),
+                    format!(
+                        "failed to create destination root {}: {e} {}{}",
+                        dest_dir.display(),
+                        crate::role_trailer::error_location!(),
+                        crate::role_trailer::receiver()
+                    ),
+                )
+            })?
+        };
         // upstream: main.c:794-796 - record whether the pre-flight mkdir
         // created the dest root so the root entry's itemize row can OR in
         // ITEM_IS_NEW (cd+++++++++ ./) only when it was actually created.

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -47,6 +47,15 @@ impl ReceiverContext {
         let (mut reader, file_count, setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
 
+        // upstream: main.c:1383-1392 - a client handed an empty list skips
+        // do_recv() entirely and reports the io_error the end marker carried.
+        // Same gate as the two pipelined drivers; `setup_transfer` already
+        // suppressed the pre-flight dest-root mkdir for this case, so entering
+        // the loop here would leave the two halves inconsistent.
+        if self.is_empty_client_flist(file_count) {
+            return self.finish_empty_client_flist(reader, writer);
+        }
+
         let PipelineSetup {
             dest_dir,
             metadata_opts,

--- a/tests/client_empty_flist_skips_recv_loop.rs
+++ b/tests/client_empty_flist_skips_recv_loop.rs
@@ -49,6 +49,11 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 /// Upstream `RERR_PARTIAL`: some files were not transferred (`errcode.h`).
+///
+/// Only the unreadable-source leg expects this code, and that leg is Unix-only
+/// (its trigger is a POSIX permission bit), so on Windows the constant has no
+/// use and `-D warnings` would reject it as dead code.
+#[cfg(unix)]
 const RERR_PARTIAL: i32 = 23;
 
 /// Wall-clock budget for one client run. Nothing is transferred in these

--- a/tests/client_empty_flist_skips_recv_loop.rs
+++ b/tests/client_empty_flist_skips_recv_loop.rs
@@ -1,0 +1,413 @@
+//! Regression: a client handed an empty file list must not enter its receive loop.
+//!
+//! upstream `main.c:1379-1391` `client_run()`:
+//!
+//! ```c
+//! flist = recv_file_list(f_in, -1);
+//! if (inc_recurse && file_total == 1)
+//!         recv_additional_file_list(f_in);
+//! if (flist && flist->used > 0) {
+//!         ...
+//!         exit_code2 = do_recv(f_in, f_out, local_name);
+//! } else {
+//!         handle_stats(-1);
+//!         output_summary();
+//! }
+//! ```
+//!
+//! With no entries the client skips `do_recv()` entirely: it never writes an
+//! ndx, never reads the sender's stats trailer (`handle_stats(-1)` short-circuits
+//! on `f < 0 && !am_sender`, `main.c:362-363`), and never joins the goodbye
+//! handshake. It prints the summary and exits on the `io_error` the sender packed
+//! into the file-list end marker - 23 (`RERR_PARTIAL`) when a source path failed
+//! to list, 0 when the list is legitimately empty.
+//!
+//! Our client used to keep reading, so the peer's FIN surfaced as
+//! `transfer failed: failed to fill whole buffer` with no summary at all, and the
+//! clean-empty-list case exited 23 where upstream exits 0. That asymmetry also
+//! masked the server-side twin of this bug (`main.c:968-974`): an oc-to-oc test
+//! could not tell a sender that wrongly entered `send_files()` from a healthy
+//! one, because our client blocked either way.
+//!
+//! Both receiver drivers are exercised: `run_pipelined_incremental` when the
+//! `transfer/incremental-flist` feature is on (CI's `--all-features` build) and
+//! `run_pipelined` when it is off (the shipped binary's default). The gate lives
+//! in each driver, so the assertions below must hold in both builds.
+//!
+//! Driving the real binary over a real socket is required: the empty-list path is
+//! defined by what the two processes do and do not read off the wire.
+
+use std::fs;
+use std::io::Read;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// Upstream `RERR_PARTIAL`: some files were not transferred (`errcode.h`).
+const RERR_PARTIAL: i32 = 23;
+
+/// Wall-clock budget for one client run. Nothing is transferred in these
+/// scenarios, so anything near this bound is the hang under test, not slowness.
+const CLIENT_DEADLINE: Duration = Duration::from_secs(45);
+
+/// How long to wait for a spawned daemon to bind its listening socket.
+const DAEMON_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Path to the binary under test, resolved by Cargo at compile time so a stale
+/// build in `target/` can never be picked up by a directory scan.
+fn oc_rsync_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_oc-rsync")
+}
+
+/// Locates an upstream rsync 3.x binary to run as a second sender, if installed.
+///
+/// Candidates, in order: an explicit `OC_RSYNC_UPSTREAM_RSYNC` override, the
+/// binaries the interop harness installs under `target/interop`, then whatever
+/// `rsync` is on `PATH`. Each must self-identify as `rsync version 3.x`, which
+/// rejects the `openrsync` shim macOS ships as `/usr/bin/rsync`.
+///
+/// Returns `None` when nothing suitable exists; the caller skips that leg rather
+/// than failing, since an upstream binary is an external resource.
+fn upstream_rsync() -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(explicit) = std::env::var_os("OC_RSYNC_UPSTREAM_RSYNC") {
+        candidates.push(PathBuf::from(explicit));
+    }
+    for version in ["3.4.4", "3.4.1", "3.1.3"] {
+        candidates.push(PathBuf::from(format!(
+            "target/interop/upstream-install/{version}/bin/rsync"
+        )));
+    }
+    candidates.push(PathBuf::from("rsync"));
+
+    candidates.into_iter().find(|candidate| {
+        Command::new(candidate)
+            .arg("--version")
+            .output()
+            .ok()
+            .and_then(|out| String::from_utf8(out.stdout).ok())
+            .is_some_and(|text| {
+                text.lines()
+                    .next()
+                    .is_some_and(|line| line.starts_with("rsync") && line.contains(" version 3."))
+            })
+    })
+}
+
+/// Reserves an ephemeral port by binding it and immediately releasing it.
+fn allocate_port() -> u16 {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+/// One end of a child's stdio, boxed so both pipes share a drain loop.
+enum Pipe {
+    Out(std::process::ChildStdout),
+    Err(std::process::ChildStderr),
+}
+
+impl Pipe {
+    fn into_reader(self) -> Box<dyn Read> {
+        match self {
+            Self::Out(out) => Box::new(out),
+            Self::Err(err) => Box::new(err),
+        }
+    }
+}
+
+/// Takes both of a child's pipes, if present, tagged for reporting.
+fn take_pipes(child: &mut Child) -> [(&'static str, Option<Pipe>); 2] {
+    [
+        ("stdout", child.stdout.take().map(Pipe::Out)),
+        ("stderr", child.stderr.take().map(Pipe::Err)),
+    ]
+}
+
+/// A spawned read-only rsync daemon serving one module, stdio drained
+/// continuously so a full pipe buffer can never masquerade as the hang under
+/// test.
+struct Daemon {
+    child: Child,
+    port: u16,
+}
+
+impl Daemon {
+    fn spawn(binary: &Path, config: &Path) -> Self {
+        let port = allocate_port();
+        let mut child = Command::new(binary)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--config")
+            .arg(config)
+            .arg("--port")
+            .arg(port.to_string())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn rsync daemon");
+
+        for (_, pipe) in take_pipes(&mut child) {
+            let Some(pipe) = pipe else { continue };
+            thread::spawn(move || {
+                let mut sink = Vec::new();
+                let _ = pipe.into_reader().read_to_end(&mut sink);
+            });
+        }
+
+        let daemon = Self { child, port };
+        daemon.wait_until_listening();
+        daemon
+    }
+
+    /// Polls the listening socket until the daemon accepts connections.
+    fn wait_until_listening(&self) {
+        let target = SocketAddr::from((Ipv4Addr::LOCALHOST, self.port));
+        let deadline = Instant::now() + DAEMON_READY_TIMEOUT;
+        while Instant::now() < deadline {
+            if TcpStream::connect_timeout(&target, Duration::from_millis(250)).is_ok() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        panic!("daemon did not start listening on port {}", self.port);
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("rsync://127.0.0.1:{}/mod/{path}", self.port)
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Writes a read-only single-module daemon config serving `module_root`.
+fn write_config(dir: &Path, module_root: &Path) -> PathBuf {
+    let config = dir.join("rsyncd.conf");
+    fs::write(
+        &config,
+        format!(
+            "use chroot = no\n[mod]\n    path = {}\n    read only = yes\n",
+            module_root.display()
+        ),
+    )
+    .expect("write daemon config");
+    config
+}
+
+/// Outcome of one bounded client run.
+struct ClientRun {
+    code: i32,
+    output: String,
+}
+
+impl ClientRun {
+    /// The `sent N bytes  received N bytes  R bytes/sec` line upstream prints
+    /// from `output_summary()` (`main.c:460-465`).
+    fn has_summary(&self) -> bool {
+        self.output.contains("sent ") && self.output.contains("bytes/sec")
+    }
+}
+
+/// Runs one client pull to completion and returns its exit code and combined
+/// output, failing the test if it does not finish inside [`CLIENT_DEADLINE`].
+///
+/// Both child pipes are drained on their own threads while we poll. Polling
+/// `try_wait()` without draining deadlocks the moment the child fills a pipe
+/// buffer, which would hang this harness for a reason unrelated to the bug under
+/// test.
+fn run_client_bounded(args: &[String], label: &str) -> ClientRun {
+    let mut child = Command::new(oc_rsync_binary())
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn oc-rsync client");
+
+    let (tx, rx) = mpsc::channel::<String>();
+    for (_, pipe) in take_pipes(&mut child) {
+        let Some(pipe) = pipe else { continue };
+        let tx = tx.clone();
+        thread::spawn(move || {
+            let mut text = String::new();
+            let _ = pipe.into_reader().read_to_string(&mut text);
+            let _ = tx.send(text);
+        });
+    }
+    drop(tx);
+
+    let deadline = Instant::now() + CLIENT_DEADLINE;
+    let status = loop {
+        match child.try_wait().expect("poll client") {
+            Some(status) => break status,
+            None => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!(
+                        "{label}: client did not finish within {CLIENT_DEADLINE:?} \
+                         (it re-entered the receive loop on an empty file list)"
+                    );
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+        }
+    };
+
+    let output: String = rx.iter().collect();
+    eprintln!("{label} client output:\n{output}");
+
+    let code = status
+        .code()
+        .unwrap_or_else(|| panic!("{label}: client terminated by signal instead of exiting"));
+    ClientRun { code, output }
+}
+
+/// Every sender the client is pulled against: always our own daemon, plus a real
+/// upstream daemon when one is installed. Both legs matter - an oc-to-oc pair can
+/// hide a divergence that both sides share.
+fn senders() -> Vec<(String, PathBuf)> {
+    let mut senders = vec![("oc-rsync".to_owned(), PathBuf::from(oc_rsync_binary()))];
+    match upstream_rsync() {
+        Some(upstream) => senders.push(("upstream-rsync".to_owned(), upstream)),
+        None => eprintln!("skip upstream sender leg: no rsync 3.x binary available"),
+    }
+    senders
+}
+
+/// Asserts one client run ended the way upstream's empty-list arm does: bounded,
+/// with the summary on stdout, no destination root created, and `expected_code`.
+fn assert_empty_list_run(run: &ClientRun, dest: &Path, expected_code: i32, label: &str) {
+    assert!(
+        !run.output.contains("failed to fill whole buffer"),
+        "{label}: client kept reading after an empty file list instead of \
+         skipping do_recv() (upstream main.c:1383-1392)"
+    );
+    assert!(
+        run.has_summary(),
+        "{label}: upstream's empty-list arm still runs output_summary() \
+         (main.c:1391); got:\n{}",
+        run.output
+    );
+    assert!(
+        !dest.exists(),
+        "{label}: upstream never reaches get_local_name() on an empty list, so \
+         the pre-flight mkdir at main.c:778-792 must not run"
+    );
+    assert_eq!(
+        run.code, expected_code,
+        "{label}: wrong exit code for an empty file list; got:\n{}",
+        run.output
+    );
+}
+
+/// Builds a module holding one readable file plus one unreadable directory, and
+/// returns the temp root together with the module root.
+fn module_with_locked_dir(locked: bool) -> (TempDir, PathBuf) {
+    let root = TempDir::new().expect("tempdir");
+    let module_root = root.path().join("src");
+    let inner = module_root.join("locked");
+    fs::create_dir_all(&inner).expect("create module root");
+    fs::write(module_root.join("good.txt"), b"ok\n").expect("write good.txt");
+    fs::write(inner.join("inner.txt"), b"inner\n").expect("write inner.txt");
+    if locked {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&inner, fs::Permissions::from_mode(0o000)).expect("chmod 000");
+        }
+    }
+    (root, module_root)
+}
+
+/// A source path the sender cannot stat for a reason other than `ENOENT` yields
+/// an empty file list whose end marker carries `IOERR_GENERAL`
+/// (`flist.c:2427-2434` -> `flist.c:2508-2517`). Upstream prints the summary and
+/// exits 23 (`cleanup.c:217-218`) without ever creating the destination root.
+///
+/// Unix-only: the fault is POSIX DAC (`chmod 000`), which root bypasses.
+#[cfg(unix)]
+#[test]
+fn unreadable_source_path_prints_summary_and_exits_partial() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // `id -u` keeps this test-only probe free of a libc dependency.
+    let is_root = Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .is_some_and(|s| s.trim() == "0");
+    if is_root {
+        eprintln!("skip: root bypasses the chmod 000 traversal denial");
+        return;
+    }
+
+    for (name, sender) in senders() {
+        let (root, module_root) = module_with_locked_dir(true);
+        let config = write_config(root.path(), &module_root);
+        let daemon = Daemon::spawn(&sender, &config);
+
+        // Trailing separator so the destination would be pre-created if the
+        // empty-list gate were missing: `ensure_dest_root_exists` only fires for
+        // a multi-file or trailing-slash operand.
+        let dest = root.path().join("dest");
+        let dest_arg = format!("{}{}", dest.display(), std::path::MAIN_SEPARATOR);
+        let label = format!("unreadable-path via {name}");
+        let run = run_client_bounded(
+            &["-av".to_owned(), daemon.url("locked/inner.txt"), dest_arg],
+            &label,
+        );
+
+        // Restore before the assertions so a failure still leaves a removable
+        // temp tree behind.
+        let _ = fs::set_permissions(
+            module_root.join("locked"),
+            fs::Permissions::from_mode(0o755),
+        );
+        assert_empty_list_run(&run, &dest, RERR_PARTIAL, &label);
+    }
+}
+
+/// A source that every filter rule excludes yields an empty file list with *no*
+/// io_error, so upstream prints the summary and exits 0. This is the leg that
+/// pins the exit code down: our client used to report a transfer failure here
+/// purely because its blocked read failed, turning a clean no-op into an error.
+///
+/// Runs on every platform - the trigger is a filter rule, not a permission bit -
+/// so it is the Windows guard for this path as well.
+#[test]
+fn fully_excluded_source_prints_summary_and_exits_zero() {
+    for (name, sender) in senders() {
+        let (root, module_root) = module_with_locked_dir(false);
+        let config = write_config(root.path(), &module_root);
+        let daemon = Daemon::spawn(&sender, &config);
+
+        let dest = root.path().join("dest");
+        let dest_arg = format!("{}{}", dest.display(), std::path::MAIN_SEPARATOR);
+        let label = format!("fully-excluded via {name}");
+        let run = run_client_bounded(
+            &[
+                "-av".to_owned(),
+                "--exclude=good.txt".to_owned(),
+                daemon.url("good.txt"),
+                dest_arg,
+            ],
+            &label,
+        );
+
+        assert_empty_list_run(&run, &dest, 0, &label);
+    }
+}


### PR DESCRIPTION
## The gap

`main.c:1379-1391` `client_run()` gates the whole receive on the size of the list it just read:

```c
flist = recv_file_list(f_in, -1);
if (inc_recurse && file_total == 1)
        recv_additional_file_list(f_in);

if (flist && flist->used > 0) {
        local_name = get_local_name(flist, argv[0]);
        check_alt_basis_dirs();
        exit_code2 = do_recv(f_in, f_out, local_name);
} else {
        handle_stats(-1);
        output_summary();
}
```

Handed an empty list the client skips `do_recv()` entirely. It never writes an ndx, never reads the sender's stats trailer (`handle_stats(-1)` short-circuits on `f < 0 && !am_sender`, `main.c:362-363`), and never joins the goodbye handshake. It prints the summary and exits on whatever `io_error` the sender delivered: 23 (`RERR_PARTIAL`, `cleanup.c:217-218`) when a source path could not be listed, 0 when the list is legitimately empty.

Our client entered its receive loop regardless. The peer had already exited, so the first blocked read surfaced as `transfer failed: failed to fill whole buffer` (or `Connection reset by peer`) with no summary at all - and an empty-but-clean list reported a transfer failure where upstream exits 0.

The gate also governs the destination root: `get_local_name()`, and with it the pre-flight `do_mkdir()` at `main.c:778-792`, lives inside the non-empty arm, so `rsync host:/missing /new/` leaves `/new/` absent. We created it.

## The change

Mirror the upstream gate in both receiver drivers (`run_pipelined` and `run_pipelined_incremental`, the `transfer/incremental-flist` fork) immediately after `setup_transfer`, before the INC_RECURSE sub-list fetch - upstream's own `if (inc_recurse && file_total == 1) recv_additional_file_list()` cannot fire at a `file_total` of 0 either. The shared `finish_empty_client_flist` flushes, walks the FSM straight to `Finalization` -> `Complete`, and returns stats carrying the `io_error` from both wire encodings upstream uses (the end-of-flist varint under a safe incremental file list, `flist.c:2508-2517`, and an interleaved `MSG_IO_ERROR` frame otherwise, `flist.c:2553-2555`).

Client-side only, exactly as upstream: `do_server_recv()` has no such gate and calls `do_recv()` unconditionally (`main.c:1201-1245`). This is the receive-side twin of #6945, which mirrored `main.c:968-974` on the server sender.

## Why this matters beyond the wrong message

This asymmetry symmetrically masked the server-side empty-flist deadlock fixed in #6945. Because our client kept reading, an oc-to-oc test could not distinguish a sender that wrongly entered `send_files()` from a healthy one - both ended in a blocked client. That is why #6945's regression test has to pull with a real upstream client. With this gate in place the blind spot is gone: an oc client now stops on an empty list exactly where an upstream client does, so an oc-to-oc pull is a valid probe of the sender's behaviour again.

## Verified against real upstream rsync 3.4.4 (protocol 32)

Full matrix, both senders x both triggers, on Linux. `unreadable` = a path the sender cannot stat for a reason other than `ENOENT` (empty list, `IOERR_GENERAL` in the end marker); `excluded` = every entry filtered out (empty list, no io_error).

**Before**

```
# sender=upstream-3.4.4  client=oc  case=unreadable
receiving incremental file list
rsync: [sender] change_dir "locked" (in mod) failed: Permission denied (13)
oc-rsync error: transfer failed: Connection reset by peer (os error 104) (code 23) at error.rs(181) [client=0.6.4]
EXIT=23   DEST_CREATED

# sender=upstream-3.4.4  client=oc  case=excluded
receiving incremental file list
oc-rsync error: transfer failed: Connection reset by peer (os error 104) (code 23) at error.rs(181) [client=0.6.4]
EXIT=23   DEST_CREATED

# sender=oc  client=oc  case=unreadable
receiving incremental file list
rsync: [sender] link_stat "/tmp/fin/src/locked/inner.txt" (in mod) failed: Permission denied (13)
oc-rsync error: transfer failed: failed to fill whole buffer (code 23) at error.rs(181) [client=0.6.4]
EXIT=23   DEST_CREATED

# sender=oc  client=oc  case=excluded
receiving incremental file list
oc-rsync error: transfer failed: failed to fill whole buffer (code 23) at error.rs(181) [client=0.6.4]
EXIT=23   DEST_CREATED
```

**Upstream 3.4.4 reference**

```
# sender=upstream-3.4.4  client=upstream-3.4.4  case=unreadable
receiving incremental file list
rsync: [sender] change_dir "locked" (in mod) failed: Permission denied (13)

sent 8 bytes  received 88 bytes  192.00 bytes/sec
total size is 0  speedup is 0.00
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1876) [Receiver=3.4.4]
EXIT=23   DEST_NOT_CREATED

# sender=upstream-3.4.4  client=upstream-3.4.4  case=excluded
receiving incremental file list

sent 22 bytes  received 8 bytes  60.00 bytes/sec
total size is 0  speedup is 0.00
EXIT=0    DEST_NOT_CREATED
```

**After**

```
# sender=upstream-3.4.4  client=oc  case=unreadable
receiving incremental file list
rsync: [sender] change_dir "locked" (in mod) failed: Permission denied (13)

sent 0 bytes  received 98 bytes  196.00 bytes/sec
total size is 0  speedup is 0.00
EXIT=23   DEST_NOT_CREATED

# sender=upstream-3.4.4  client=oc  case=excluded
receiving incremental file list

sent 0 bytes  received 18 bytes  36.00 bytes/sec
total size is 0  speedup is 0.00
EXIT=0    DEST_NOT_CREATED

# sender=oc  client=oc  case=unreadable
receiving incremental file list
rsync: [sender] link_stat "/tmp/fin/src/locked/inner.txt" (in mod) failed: Permission denied (13)

sent 0 bytes  received 116 bytes  232.00 bytes/sec
total size is 0  speedup is 0.00
EXIT=23   DEST_NOT_CREATED

# sender=oc  client=oc  case=excluded
receiving incremental file list

sent 0 bytes  received 14 bytes  28.00 bytes/sec
total size is 0  speedup is 0.00
EXIT=0    DEST_NOT_CREATED
```

Structure, ordering, blank line, summary lines, exit code and destination behaviour now match upstream against both senders. The same holds over SSH (`--rsync-path` to upstream 3.4.4 and to our own binary).

## Known divergences left in the captures (pre-existing, not touched here)

Each was reproduced on `master` and on unrelated non-empty transfers, so none is introduced or made reachable by this change:

1. **Summary byte counts.** `sent 0` vs upstream's `sent 8`/`sent 22`. A plain successful pull diverges the same way today (`sent 43 received 124` upstream vs `sent 24 received 162` ours), so the counters, not this path, are the gap.
2. **No `rsync error: ... (code N) at ...` trailer** when the exit code comes from `io_error`. Reproduced on master with a normal pull through an unreadable subdirectory (non-empty list, exit 23, no trailer).
3. **`got_xfer_error` is not implemented.** Upstream turns a received `MSG_ERROR_XFER` frame into exit 23 (`log.c` -> `cleanup.c:217`). A missing (`ENOENT`) source arg sets *no* io_error on the sender (`flist.c:2431` `if (errno != ENOENT)`), so upstream's 23 for that case comes purely from `got_xfer_error`. Ours exits 0 - identically before and after this change, and identically with a non-empty list. That is why the regression test triggers the empty list with `EACCES` and with a filter rule rather than with `ENOENT`: those two pin the exit code down through mechanisms we do implement.
4. **Our sender sets `io_error` for an `ENOENT` arg** where upstream deliberately does not (`flist.c:2427-2434`). Server-side, unrelated to the receive path.

## Tests

`tests/client_empty_flist_skips_recv_loop.rs` drives the shipped binary as both daemon and client over a real socket - the empty-list path is defined by what the two processes do and do not read off the wire, so it is not reachable from a unit test. Each trigger is pulled from our own daemon and, when a real `rsync` 3.x is installed, from an upstream daemon too, so an oc-to-oc pair cannot hide a shared divergence.

- `unreadable_source_path_prints_summary_and_exits_partial` (unix, skipped as root) - empty list with `IOERR_GENERAL` in the end marker: bounded, summary printed, exit 23, destination root not created.
- `fully_excluded_source_prints_summary_and_exits_zero` (all platforms) - empty list with no io_error: bounded, summary printed, exit 0, destination root not created.

Both fail on the parent commit (`has_summary` assertion) and pass here. The child's stdout and stderr are drained on their own threads while `try_wait()` is polled, and the binary is resolved with `env!("CARGO_BIN_EXE_oc-rsync")` rather than a `target/` scan.

Run with `transfer/incremental-flist` **on** (CI's `--workspace --all-features` build, `run_pipelined_incremental`) and **off** (the shipped binary's default, `run_pipelined`); the gate lives in each driver. Also green: `transfer` lib (2147), `daemon_sender_per_file_error_no_hang`, `integration_daemon`, `integration_daemon_server`, `integration_basic`, `exit_codes`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings`.
