### PR TITLE
test(engine): make the reorder spill precondition deterministic

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer/tests.rs
+++ b/crates/engine/src/concurrent_delta/consumer/tests.rs
@@ -565,11 +565,44 @@ fn metrics_drain_batch_histogram_accumulates() {
 
 // ---- SpillableReorderBuffer wiring tests (task #1884) ----
 
+/// Blocks until the consumer's live telemetry reports that the reorder
+/// buffer has spilled. Callers withhold the head-of-line item until this
+/// returns, so the spill precondition is established rather than raced
+/// against a fixed sleep on a loaded machine.
+///
+/// Both spill counters are polled so that a regression in either plumbing
+/// path fails on the assertion naming it instead of stalling until the
+/// deadline.
+///
+/// # Panics
+///
+/// Panics once the deadline elapses: with the head withheld, no contiguous
+/// run can drain, so the buffer's byte usage only grows and a timeout means
+/// the spill telemetry never reached [`DeltaConsumer::stats`].
+fn await_spill(consumer: &DeltaConsumer) {
+    const SPILL_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
+    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(1);
+
+    let deadline = std::time::Instant::now() + SPILL_WAIT;
+    loop {
+        let stats = consumer.stats();
+        if stats.spill_events > 0 || stats.spill_activations > 0 {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "no spill observed within {SPILL_WAIT:?} while the head-of-line item \
+             was withheld against a tight byte threshold"
+        );
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
 /// Drives a 1000-item workload through the spill-enabled consumer with
-/// a deliberately delayed head-of-line item so the reorder buffer fills
-/// up before any contiguous run can be drained. A tight 1 KiB byte
-/// budget guarantees the spill machinery engages while delivery remains
-/// strictly in submission order.
+/// a withheld head-of-line item so the reorder buffer fills up before any
+/// contiguous run can be drained. A tight 1 KiB byte budget guarantees the
+/// spill machinery engages while delivery remains strictly in submission
+/// order.
 #[test]
 fn spillable_consumer_preserves_order_under_pressure() {
     const COUNT: u32 = 1000;
@@ -577,29 +610,27 @@ fn spillable_consumer_preserves_order_under_pressure() {
     const THRESHOLD: u64 = 1024;
 
     let (tx, rx) = work_queue::bounded_with_capacity(COUNT as usize);
-
-    // Send sequences 1..COUNT first so the reorder buffer fills with
-    // out-of-order items, then send seq 0 last so the head is missing
-    // until the very end. Memory pressure exceeds the threshold long
-    // before delivery becomes possible, forcing repeated spills.
-    let producer = std::thread::spawn(move || {
-        for seq in 1..COUNT {
-            let work =
-                DeltaWork::whole_file(seq, PathBuf::from("/dst"), 64).with_sequence(u64::from(seq));
-            tx.send(work).unwrap();
-        }
-        // Small pause to let the reorder thread build up the buffer
-        // before the head-of-line item unblocks the drain.
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        tx.send(DeltaWork::whole_file(0u32, PathBuf::from("/dst"), 64).with_sequence(0))
-            .unwrap();
-    });
-
     let cfg = ConcurrentDeltaConfig::with_spill_threshold(THRESHOLD);
     let consumer = DeltaConsumer::spawn_with_config(rx, COUNT as usize, cfg);
+
+    // Send sequences 1..COUNT first so the reorder buffer fills with
+    // out-of-order items; the queue is bounded at COUNT so no send blocks.
+    // Seq 0 is held back until the telemetry confirms the byte budget was
+    // exceeded, so the spill happens before delivery can begin.
+    for seq in 1..COUNT {
+        let work =
+            DeltaWork::whole_file(seq, PathBuf::from("/dst"), 64).with_sequence(u64::from(seq));
+        tx.send(work).unwrap();
+    }
+
+    await_spill(&consumer);
+
+    tx.send(DeltaWork::whole_file(0u32, PathBuf::from("/dst"), 64).with_sequence(0))
+        .unwrap();
+    drop(tx);
+
     let results: Vec<DeltaResult> = consumer.iter().collect();
     let stats = consumer.stats();
-    producer.join().unwrap();
 
     assert_eq!(results.len(), COUNT as usize, "all items must be delivered");
     for (i, r) in results.iter().enumerate() {

--- a/crates/engine/tests/rob_2_3_reorder_buffer_telemetry.rs
+++ b/crates/engine/tests/rob_2_3_reorder_buffer_telemetry.rs
@@ -24,6 +24,7 @@
 
 use std::io::{self, Write};
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use engine::concurrent_delta::{
     ConcurrentDeltaConfig, DeltaChunk, DeltaConsumer, DeltaWork, ParallelDeltaApplier, work_queue,
@@ -39,6 +40,39 @@ impl Write for NullSink {
     }
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+/// Blocks until the consumer's live telemetry reports that the reorder
+/// buffer has spilled, so the caller releases the head-of-line item with
+/// the spill precondition already established instead of hoping a sleep
+/// outran the pipeline.
+///
+/// Both counters are polled: whichever one is still wired lets a broken
+/// plumbing path fail fast on the assertion that names it, rather than
+/// stalling until the deadline.
+///
+/// # Panics
+///
+/// Panics once `SPILL_WAIT` elapses with neither counter advancing - with
+/// the head withheld the buffer's byte usage only grows, so a timeout means
+/// the telemetry never reached [`DeltaConsumer::stats`].
+fn await_spill(consumer: &DeltaConsumer) {
+    const SPILL_WAIT: Duration = Duration::from_secs(30);
+    const POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+    let deadline = Instant::now() + SPILL_WAIT;
+    loop {
+        let stats = consumer.stats();
+        if stats.spill_events > 0 || stats.spill_activations > 0 {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no spill observed within {SPILL_WAIT:?} while the head-of-line item \
+             was withheld against a tight byte threshold"
+        );
+        std::thread::sleep(POLL_INTERVAL);
     }
 }
 
@@ -125,38 +159,45 @@ fn in_order_submission_never_increments_saturation_counter() {
 }
 
 /// Drives a [`DeltaConsumer`] backed by a spillable reorder buffer with a
-/// deliberately delayed head-of-line item and a tight 1 KiB byte
-/// threshold, mirroring the pattern in the consumer-side spill regression
+/// withheld head-of-line item and a tight 1 KiB byte threshold, mirroring
+/// the pattern in the consumer-side spill regression
 /// (`spillable_consumer_preserves_order_under_pressure`). The new
 /// [`engine::concurrent_delta::DeltaConsumerStats::spill_activations`]
 /// counter must be non-zero by the time the consumer drains, proving that
 /// ROB-2's granularity-invariant activation counter is observable through
 /// the public consumer-side API.
+///
+/// The spill precondition is established, not raced: seq 0 is released only
+/// after the live [`DeltaConsumer::stats`] snapshot proves the byte budget
+/// was already exceeded. Without the head, no contiguous run can drain, so
+/// the buffer's byte usage only grows and the spill is guaranteed rather
+/// than timing-dependent.
 #[test]
 fn delta_consumer_stats_exposes_spill_activations() {
     const COUNT: u32 = 1000;
     const THRESHOLD: u64 = 1024;
 
     let (tx, rx) = work_queue::bounded_with_capacity(COUNT as usize);
-
-    // Sequences 1..COUNT first, then seq 0 last - the head stays missing
-    // long enough to overflow the byte budget and force repeated spills.
-    let producer = std::thread::spawn(move || {
-        for seq in 1..COUNT {
-            let work =
-                DeltaWork::whole_file(seq, PathBuf::from("/dst"), 64).with_sequence(u64::from(seq));
-            tx.send(work).expect("send out-of-order item");
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        tx.send(DeltaWork::whole_file(0u32, PathBuf::from("/dst"), 64).with_sequence(0))
-            .expect("send head-of-line item");
-    });
-
     let cfg = ConcurrentDeltaConfig::with_spill_threshold(THRESHOLD);
     let consumer = DeltaConsumer::spawn_with_config(rx, COUNT as usize, cfg);
+
+    // Sequences 1..COUNT with the head withheld. The queue is bounded at
+    // COUNT so these sends never block, and the reorder buffer cannot
+    // deliver anything while seq 0 is missing.
+    for seq in 1..COUNT {
+        let work =
+            DeltaWork::whole_file(seq, PathBuf::from("/dst"), 64).with_sequence(u64::from(seq));
+        tx.send(work).expect("send out-of-order item");
+    }
+
+    await_spill(&consumer);
+
+    tx.send(DeltaWork::whole_file(0u32, PathBuf::from("/dst"), 64).with_sequence(0))
+        .expect("send head-of-line item");
+    drop(tx);
+
     let delivered: usize = consumer.iter().count();
     let stats = consumer.stats();
-    producer.join().expect("producer join");
     consumer.join().expect("consumer join");
 
     assert_eq!(
@@ -165,8 +206,8 @@ fn delta_consumer_stats_exposes_spill_activations() {
     );
     assert!(
         stats.spill_events > 0,
-        "ROB-2 prerequisite: tight threshold must produce spill events; \
-         got spill_events={}",
+        "ROB-2 prerequisite: the spill observed before the head was released \
+         must still be visible after the drain; got spill_events={}",
         stats.spill_events
     );
     assert!(


### PR DESCRIPTION
## Pre-existing flake

`engine::delta_consumer_stats_exposes_spill_activations` fails intermittently in
the non-required `nextest (beta)` cell. It is not caused by any current change:
the identical failure (same test, same line, same message) appeared on a
docs-only PR, #6867 - run `29956587509`, job `nextest (beta)` `89047688587`
(2026-07-22). A sweep of all 285 completed `ci.yml` runs between 07-17 and 07-26
found three `nextest (beta)` failures; two are this test. It gets no retries -
the `.config/nextest.toml` overrides cover only
`package(daemon) | test(execute_sparse) | binary_id(~integration_daemon)` and
`test(test_ssh)`.

## The failing assert was the prerequisite, not the subject

```
crates/engine/tests/rob_2_3_reorder_buffer_telemetry.rs:166:5
ROB-2 prerequisite: tight threshold must produce spill events; got spill_events=0
```

Line 166 was `assert!(stats.spill_events > 0)`, the setup check that the tight
1 KiB byte budget had engaged the spill machinery at all. The test exists to pin
`DeltaConsumerStats::spill_activations` (ROB-2 plumbing), and it was dying before
it ever evaluated that assertion.

The setup sent 999 out-of-order items, slept 50 ms, then sent seq 0. Nothing
enforced that the byte budget was crossed within those 50 ms. When the reorder
thread is starved on a loaded runner, seq 0's result reaches the buffer while
fewer than ~20 items (~52 bytes each vs the 1 KiB threshold) are resident: the
head is present, the buffer drains in submission order, memory never grows, and
no spill happens. The 50 ms sleep only widened the window; it never closed it.

## Determinism mechanism

The precondition is now established rather than raced:

* the consumer is spawned first, and the out-of-order items are sent from the
  test thread - the work queue is bounded at `COUNT`, so no send blocks, and the
  result channel is unbounded, so the reorder thread never needs the test thread
  to drain;
* the head-of-line item is released only after the live `DeltaConsumer::stats`
  snapshot reports a spill, polled at 1 ms under a bounded 30 s deadline. With
  the head withheld, no contiguous run can drain, so the buffer's byte usage only
  grows and the spill is structurally guaranteed;
* both `spill_events` and `spill_activations` are polled, so a regression in
  either publishing path breaks the wait immediately and fails on the assertion
  that names it instead of stalling until the deadline;
* the `spill_activations` assertions are unchanged, and no sleep, retry, or
  `#[ignore]` was added.

`spillable_consumer_preserves_order_under_pressure` in
`crates/engine/src/concurrent_delta/consumer/tests.rs` had the same 50 ms
head-of-line pattern behind the same `spill_events > 0` assertion and is fixed
the same way. The remaining `force_insert_*` tests in that file also sleep before
releasing the head, but their preconditions have a large structural margin (a
ring of 2 or 4 against 24-200 items forces an insert on the first overflow rather
than after a byte budget accumulates), so they are left alone.

## Evidence

Repeat runs on macOS/aarch64, release of the head gated on telemetry:

* 200 iterations of each test unloaded - 0 failures;
* 200 iterations of each test with 24 spinning processes on 10 cores - 0 failures;
* 250 iterations of each test with 24 spinning processes, `--test-threads 8` -
  0 failures.

Total 650 runs per test, 450 of them under ~2.4x CPU oversubscription. The
integration test also got faster: 0.01 s versus 0.05 s+ for the sleep.

Regression detection, verified by temporarily breaking the product-side
telemetry in `consumer/loops.rs` and reverting:

* `publish_spill_activations` neutered - test goes red in 0.04 s on its own
  subject: `ROB-2 plumbing must surface at least one spill activation through
  DeltaConsumerStats; got spill_activations=0 (spill_events=90)`;
* `publish_spill_events` neutered - test goes red in 0.01 s on the
  `spill_events` assertion, and the unit test goes red in 0.01 s with
  `1 KiB budget against 1000 items must trigger spills, got 0`.

Neither break hit the 30 s deadline, confirming the dual-counter poll keeps
failures fast and specific.

Local validation: `cargo fmt --all -- --check`, `cargo clippy -p engine
--all-features --all-targets --no-deps -- -D warnings`, plus the three tests in
`rob_2_3_reorder_buffer_telemetry` and all 32 `concurrent_delta::consumer::tests`.
