### PR TITLE
refactor(io): buffer the wire and reserve multiplex headers in place

### DIFF
--- a/crates/protocol/src/iobuf/input.rs
+++ b/crates/protocol/src/iobuf/input.rs
@@ -1,0 +1,172 @@
+use std::io::{self, Read};
+
+use super::round_up_1024;
+
+/// Upstream's raw input buffer size.
+///
+/// upstream: `io.c:1401` `alloc_xbuf(&iobuf.in, ROUND_UP_1024(IO_BUFFER_SIZE))`
+/// with `IO_BUFFER_SIZE = 32*1024` (`rsync.h:160`). Never reallocated
+/// (io.c:579 "We never resize the circular input buffer."); a request larger
+/// than the buffer is a fatal protocol error, never a growth.
+pub const IN_BUFFER_SIZE: usize = 32 * 1024;
+
+/// Circular input buffer sitting *beneath* the multiplex demultiplexer.
+///
+/// Mirrors upstream's `iobuf.in` (`xbuf`, io.c:91-100): `pos` is the offset of
+/// the next unread byte, `len` the number of readable bytes, and the region
+/// wraps around a fixed `size`. The allocation happens once and never grows, so
+/// steady-state memory is bounded no matter what a peer sends.
+///
+/// Nothing above this type knows the wire exists: the decoders read from the
+/// demultiplexer, the demultiplexer reads from here, and only this type touches
+/// the descriptor - which is the layering upstream enforces with
+/// `assert(fd != iobuf.in_fd)` in `safe_read()` (io.c:243).
+pub struct InBuf {
+    buf: Vec<u8>,
+    pos: usize,
+    len: usize,
+}
+
+impl InBuf {
+    /// Allocates a fixed-size circular input buffer.
+    ///
+    /// `capacity` is rounded up to a whole number of 1024-byte units, matching
+    /// upstream's `ROUND_UP_1024` allocation discipline.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buf: vec![0u8; round_up_1024(capacity)],
+            pos: 0,
+            len: 0,
+        }
+    }
+
+    /// Returns the fixed circular size. This never changes for the lifetime of
+    /// the buffer (io.c:579).
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Returns the number of bytes currently readable.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` when no bytes are buffered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the longest contiguous readable run starting at `pos`.
+    ///
+    /// A wrapped buffer serves its head first; the caller drains it, and the
+    /// tail becomes contiguous on the next call.
+    #[must_use]
+    pub fn readable(&self) -> &[u8] {
+        let end = (self.pos + self.len).min(self.capacity());
+        &self.buf[self.pos..end]
+    }
+
+    /// Marks `n` readable bytes as consumed, wrapping `pos`.
+    ///
+    /// upstream: io.c:565-573 - an emptied buffer rewinds to offset 0 so the
+    /// next fill gets the whole span contiguously.
+    pub fn consume(&mut self, n: usize) {
+        debug_assert!(n <= self.len, "consuming more than is buffered");
+        self.pos += n;
+        self.len -= n;
+        if self.pos >= self.capacity() {
+            self.pos -= self.capacity();
+        }
+        if self.len == 0 {
+            self.pos = 0;
+        }
+    }
+
+    /// Reads once from `reader` into the largest contiguous free span.
+    ///
+    /// Returns the number of bytes buffered, `0` on EOF. The buffer is never
+    /// resized to make room; when it is full this is a no-op returning `0`,
+    /// which is the point at which upstream's `perform_io` would instead be
+    /// draining output (io.c:664-672 only selects for read when there is free
+    /// space).
+    pub fn fill<R: Read + ?Sized>(&mut self, reader: &mut R) -> io::Result<usize> {
+        let size = self.capacity();
+        if self.len == size {
+            return Ok(0);
+        }
+        let mut end = self.pos + self.len;
+        if end >= size {
+            end -= size;
+        }
+        let limit = if end >= self.pos { size } else { self.pos };
+        let n = reader.read(&mut self.buf[end..limit])?;
+        self.len += n;
+        Ok(n)
+    }
+}
+
+/// [`Read`] adapter that funnels a transfer descriptor through an [`InBuf`].
+///
+/// This is the seam the multiplex demultiplexer sits on: it replaces a
+/// `std::io::BufReader` whose capacity was free to differ from upstream's with
+/// a buffer of exactly `IO_BUFFER_SIZE` that can never grow.
+pub struct IoBufReader<R> {
+    inner: R,
+    buf: InBuf,
+}
+
+impl<R: Read> IoBufReader<R> {
+    /// Wraps `inner` in a fixed 32 KiB input buffer (upstream io.c:1401).
+    #[must_use]
+    pub fn new(inner: R) -> Self {
+        Self::with_capacity(IN_BUFFER_SIZE, inner)
+    }
+
+    /// Wraps `inner` in a fixed input buffer of `capacity` bytes.
+    #[must_use]
+    pub fn with_capacity(capacity: usize, inner: R) -> Self {
+        Self {
+            inner,
+            buf: InBuf::new(capacity),
+        }
+    }
+
+    /// Returns a mutable reference to the wrapped reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Consumes the adapter, returning the wrapped reader.
+    ///
+    /// Any bytes still buffered are discarded, so this is only valid once the
+    /// buffer is drained.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<R: Read> Read for IoBufReader<R> {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        if self.buf.is_empty() {
+            // A request at least as large as the buffer gains nothing from
+            // staging: hand the caller's slice straight to the descriptor, the
+            // same short-circuit `std::io::BufReader` makes.
+            if out.len() >= self.buf.capacity() {
+                return self.inner.read(out);
+            }
+            if self.buf.fill(&mut self.inner)? == 0 {
+                return Ok(0);
+            }
+        }
+
+        let readable = self.buf.readable();
+        let n = readable.len().min(out.len());
+        out[..n].copy_from_slice(&readable[..n]);
+        self.buf.consume(n);
+        Ok(n)
+    }
+}

--- a/crates/protocol/src/iobuf/mod.rs
+++ b/crates/protocol/src/iobuf/mod.rs
@@ -1,0 +1,45 @@
+//! Fixed-size wire buffers mirroring upstream rsync's `iobuf` (io.c:91-100).
+//!
+//! Upstream keeps exactly two circular buffers on the transfer descriptor and
+//! **never resizes either of them**: the input buffer is `IO_BUFFER_SIZE`
+//! (32 KiB, io.c:1401) and the output buffer is twice that (64 KiB, io.c:1382).
+//! The comments at io.c:579 (`"We never resize the circular input buffer."`)
+//! and io.c:594 (the same for the output buffer) are load-bearing: a request
+//! that cannot fit is a fatal protocol error, never a reallocation.
+//!
+//! Two upstream properties are reproduced here because they are what keeps a
+//! multiplexed stream from tearing:
+//!
+//! * The 4-byte `MSG_DATA` header is **reserved in place** inside the output
+//!   buffer when multiplexing starts (io.c:2461-2462) and **back-filled at
+//!   flush time** (io.c:687-688). Header and payload are therefore adjacent
+//!   bytes of one buffer before any syscall runs, so no control frame can be
+//!   scheduled between them and no partial write can expose a header without
+//!   its payload.
+//! * Appending bytes that fit performs **no I/O at all** (io.c:2255-2284):
+//!   `write_buf()` only reaches `perform_io()` when `out.len + len > out.size`.
+//!
+//! Upstream does *not* promise one `write()` per frame - a short write may
+//! split anywhere, including mid-header, and resumes from `out->pos`
+//! (io.c:838-877). [`OutBuf`] reproduces exactly that: the drain loop is
+//! restartable and a failed drain leaves `pos`/`len` describing precisely what
+//! is still owed to the wire.
+
+mod input;
+mod out;
+
+#[cfg(test)]
+mod tests;
+
+pub use input::{IN_BUFFER_SIZE, InBuf, IoBufReader};
+pub use out::{OUT_BUFFER_SIZE, OutBuf};
+
+/// Rounds `size` up to a whole number of 1024-byte units.
+///
+/// upstream: `rsync.h` `ROUND_UP_1024()`. Every I/O buffer is allocated in
+/// 1024-byte units so the low byte of `size` is always zero, which is what lets
+/// [`OutBuf`] borrow that byte as the "size was temporarily reduced" marker
+/// (io.c:129-136 `IOBUF_WAS_REDUCED` / `IOBUF_RESTORE_SIZE`).
+pub(crate) const fn round_up_1024(size: usize) -> usize {
+    size.div_ceil(1024) * 1024
+}

--- a/crates/protocol/src/iobuf/out.rs
+++ b/crates/protocol/src/iobuf/out.rs
@@ -1,0 +1,321 @@
+use std::io::{self, Write};
+
+use crate::envelope::{HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageCode, MessageHeader};
+
+use super::round_up_1024;
+
+/// The `MSG_DATA` tag byte pre-shifted into its wire position.
+///
+/// Built through [`MessageHeader`] so the tag encoding has exactly one
+/// definition, and folded at compile time so the back-fill in [`OutBuf::flush`]
+/// is the infallible `tag | length` OR that upstream writes with `SIVAL`
+/// (io.c:687-688).
+const DATA_HEADER_TAG: u32 = match MessageHeader::new(MessageCode::Data, 0) {
+    Ok(header) => header.encode_raw(),
+    Err(_) => panic!("a zero-length MSG_DATA header is always representable"),
+};
+
+/// Upstream's raw output buffer size.
+///
+/// upstream: `io.c:1382` `alloc_xbuf(&iobuf.out, ROUND_UP_1024(IO_BUFFER_SIZE * 2))`
+/// with `IO_BUFFER_SIZE = 32*1024` (`rsync.h:160`). Never reallocated
+/// (io.c:594 "We never resize the circular output buffer.").
+pub const OUT_BUFFER_SIZE: usize = 64 * 1024;
+
+/// Circular output buffer with an in-place `MSG_DATA` header reservation.
+///
+/// Mirrors upstream's `iobuf.out` (`xbuf` in `rsync.h:1096-1101`, driven by
+/// `io.c:write_buf()` and the drain block at io.c:838-877):
+///
+/// * `pos` is the offset of the next byte owed to the wire, `len` the number of
+///   buffered bytes, and both wrap around `size`.
+/// * When multiplexing is active, `out_empty_len` is 4 and the first four bytes
+///   of the buffered run are a *reserved* `MSG_DATA` header. "Empty" therefore
+///   means `len == 4`, not `len == 0` - the pervasive off-by-4 that upstream
+///   spells `out_empty_len` (io.c:2457).
+/// * The header is back-filled only at flush time (io.c:687-688), so header and
+///   payload are contiguous bytes of one buffer before any syscall runs.
+///
+/// The buffer is allocated once and never grows. `size` may be *temporarily
+/// reduced* so a 4-byte header never straddles the physical end of the buffer
+/// (io.c:480-513 `reduce_iobuf_size` / `restore_iobuf_size`); because every
+/// allocation is a whole number of 1024-byte units, the low byte of `size` is
+/// free to act as the "was reduced" marker (io.c:129-136).
+pub struct OutBuf {
+    buf: Vec<u8>,
+    pos: usize,
+    len: usize,
+    /// Current (possibly temporarily reduced) circular size.
+    size: usize,
+    /// 0 when raw, 4 once multiplexing reserves a `MSG_DATA` header.
+    /// upstream: `io.c:2457` `iobuf.out_empty_len = 4`.
+    out_empty_len: usize,
+    /// Offset of the reserved `MSG_DATA` header inside `buf`.
+    /// upstream: `iobuf.raw_data_header_pos`.
+    raw_data_header_pos: usize,
+    /// End (as an unwrapped `pos + len`) of the run currently being flushed, or
+    /// 0 when no flush is in progress. upstream: `iobuf.raw_flushing_ends_before`,
+    /// which "can point off the end of the iobuf.out buffer for a while, for
+    /// easier subtracting" (io.c:684-685).
+    flush_ends_before: usize,
+}
+
+impl OutBuf {
+    /// Allocates a raw (non-multiplexed) output buffer able to hold
+    /// `data_capacity` payload bytes plus one reserved multiplex header.
+    ///
+    /// The allocation is rounded up to a whole number of 1024-byte units so the
+    /// low byte of `size` stays free for the reduced-size marker.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data_capacity` could produce a payload beyond the 24-bit
+    /// multiplex length limit; that would make the header back-fill fallible,
+    /// which upstream's `SIVAL` is not.
+    #[must_use]
+    pub fn new(data_capacity: usize) -> Self {
+        let size = round_up_1024(data_capacity + HEADER_LEN);
+        assert!(
+            size - HEADER_LEN <= MAX_PAYLOAD_LENGTH as usize,
+            "output buffer capacity exceeds the 24-bit multiplex payload limit"
+        );
+        Self {
+            buf: vec![0u8; size],
+            pos: 0,
+            len: 0,
+            size,
+            out_empty_len: 0,
+            raw_data_header_pos: 0,
+            flush_ends_before: 0,
+        }
+    }
+
+    /// Reserves the first `MSG_DATA` header in place, activating multiplexing.
+    ///
+    /// upstream: `io.c:2455-2462` `io_start_multiplex_out()` - after a full
+    /// flush it sets `out_empty_len = 4`, records `raw_data_header_pos` and
+    /// bumps `out.len` by 4 without writing anything.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not empty; upstream reaches this only after
+    /// `io_flush(FULL_FLUSH)`.
+    pub fn start_multiplex(&mut self) {
+        assert!(
+            self.len == 0 && self.out_empty_len == 0,
+            "multiplexing must start on an empty raw buffer"
+        );
+        self.pos = 0;
+        self.out_empty_len = HEADER_LEN;
+        self.raw_data_header_pos = 0;
+        self.len = HEADER_LEN;
+    }
+
+    /// Returns the number of payload bytes buffered, excluding any reserved
+    /// header. upstream: `out.len - out_empty_len`.
+    #[must_use]
+    pub fn data_len(&self) -> usize {
+        self.len - self.out_empty_len
+    }
+
+    /// Returns `true` when nothing but a reserved header is buffered.
+    ///
+    /// upstream: `out.len == out_empty_len` (io.c:681, io.c:1472). This is the
+    /// only correct emptiness test on a multiplexed buffer.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len == self.out_empty_len
+    }
+
+    /// Returns the payload bytes this buffer can hold between flushes.
+    #[must_use]
+    pub fn data_capacity(&self) -> usize {
+        self.size - self.out_empty_len
+    }
+
+    /// Appends `data` to the buffered run without performing any I/O.
+    ///
+    /// This is the memcpy half of upstream `write_buf()` (io.c:2266-2279),
+    /// including the split copy that wraps the circular end. Requirement 13 of
+    /// the port - "a write whose bytes fit performs no I/O at all" - is a
+    /// property of this function having no writer argument at all.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data` does not fit; upstream's caller guarantees room by
+    /// draining first (io.c:2263-2264), and so must ours.
+    pub fn push(&mut self, data: &[u8]) {
+        assert!(
+            self.len + data.len() <= self.size,
+            "OutBuf::push overflow: caller must flush before appending"
+        );
+
+        let mut pos = self.pos + self.len;
+        if pos >= self.size {
+            pos -= self.size;
+        }
+
+        // upstream: io.c:2270-2276 - split the copy when it wraps the end.
+        if pos >= self.pos {
+            let contiguous = self.size - pos;
+            if contiguous < data.len() {
+                self.buf[pos..pos + contiguous].copy_from_slice(&data[..contiguous]);
+                self.buf[..data.len() - contiguous].copy_from_slice(&data[contiguous..]);
+                self.len += data.len();
+                return;
+            }
+        }
+
+        self.buf[pos..pos + data.len()].copy_from_slice(data);
+        self.len += data.len();
+    }
+
+    /// Back-fills the reserved header and reserves the next one.
+    ///
+    /// upstream: io.c:682-708. The header records everything buffered since the
+    /// last flush (`out.len - 4`), the run being flushed is pinned by
+    /// `flush_ends_before`, and a fresh 4-byte header is reserved immediately
+    /// after it - reducing the buffer's size first if those four bytes would
+    /// straddle the physical end.
+    fn begin_flush(&mut self) {
+        if !self.is_multiplexed() {
+            return;
+        }
+
+        self.flush_ends_before = self.pos + self.len;
+
+        // upstream: io.c:687-688 - SIVAL(buf + raw_data_header_pos, 0,
+        // ((MPLEX_BASE + MSG_DATA) << 24) + out.len - 4).
+        let raw = DATA_HEADER_TAG | (self.len - HEADER_LEN) as u32;
+        // The reserved slot never straddles the end: begin_flush relocates it.
+        self.buf[self.raw_data_header_pos..self.raw_data_header_pos + HEADER_LEN]
+            .copy_from_slice(&raw.to_le_bytes());
+
+        // upstream: io.c:695-707 - reserve room for the next MSG_DATA header.
+        let mut next = self.flush_ends_before;
+        if next >= self.size {
+            next -= self.size;
+        } else if next + HEADER_LEN > self.size {
+            self.reduce_size(next);
+            next = 0;
+        }
+        self.raw_data_header_pos = next;
+        // upstream: "Yes, it is possible for this to make len > size for a while."
+        self.len += HEADER_LEN;
+    }
+
+    /// Writes one contiguous run to `writer` and accounts for what left.
+    ///
+    /// Mirrors upstream's single `write()` inside `perform_io` (io.c:838-877):
+    /// at most one contiguous span is offered, `pos`/`len` advance by exactly
+    /// the accepted byte count, and `EINTR` is reported as a zero-byte write
+    /// rather than an error (io.c:840-841). Any other error leaves `pos`/`len`
+    /// describing precisely what is still owed, so the caller may retry without
+    /// ever re-sending or dropping a byte.
+    fn drain_once<W: Write + ?Sized>(&mut self, writer: &mut W) -> io::Result<usize> {
+        let mut want = if self.flush_ends_before != 0 {
+            self.flush_ends_before - self.pos
+        } else {
+            self.len
+        };
+        if self.pos + want > self.size {
+            want = self.size - self.pos;
+        }
+        if want == 0 {
+            // Unreachable: `flush` only drains while `!is_empty()`, and both
+            // emptiness and the end of the pinned run are reached on the same
+            // byte. Surfacing it beats spinning if that invariant ever breaks.
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "multiplex output buffer has no drainable run",
+            ));
+        }
+
+        let n = match writer.write(&self.buf[self.pos..self.pos + want]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write buffered multiplex output",
+                ));
+            }
+            Ok(n) => n,
+            // upstream: io.c:840-841 - EINTR is n = 0, not an error.
+            Err(ref err) if err.kind() == io::ErrorKind::Interrupted => 0,
+            Err(err) => return Err(err),
+        };
+
+        // upstream: io.c:869-877 - advance pos with wrap, then len; reaching
+        // out_empty_len rewinds the buffer and relocates the reserved header.
+        self.pos += n;
+        if self.pos == self.size {
+            if self.flush_ends_before != 0 {
+                self.flush_ends_before -= self.size;
+            }
+            self.pos = 0;
+            self.restore_size();
+        } else if self.pos == self.flush_ends_before {
+            self.flush_ends_before = 0;
+        }
+
+        self.len -= n;
+        if self.len == self.out_empty_len {
+            self.pos = 0;
+            self.restore_size();
+            if self.is_multiplexed() {
+                self.raw_data_header_pos = 0;
+            }
+        }
+
+        Ok(n)
+    }
+
+    /// Drains everything buffered, back-filling the `MSG_DATA` header first.
+    ///
+    /// upstream: `io_flush(FULL_FLUSH)` (io.c:2136-2147) driving `perform_io`.
+    /// The header is written into the buffer *before* the first syscall, so a
+    /// short write can split the frame anywhere - including mid-header, exactly
+    /// as upstream's can - without ever exposing a header whose payload is not
+    /// already queued behind it in the same buffer. Re-entering after a failed
+    /// drain resumes at `pos`; the header is not back-filled twice.
+    ///
+    /// Bytes appended while a run was stalled become their own `MSG_DATA`
+    /// frame, exactly as upstream's next pass through the fd-selection test
+    /// (io.c:680-708) pins a fresh run behind the reserved header.
+    pub fn flush<W: Write + ?Sized>(&mut self, writer: &mut W) -> io::Result<()> {
+        loop {
+            if self.flush_ends_before == 0 {
+                if self.is_empty() {
+                    return Ok(());
+                }
+                self.begin_flush();
+            }
+            self.drain_once(writer)?;
+        }
+    }
+
+    /// Returns whether a `MSG_DATA` header slot is reserved.
+    fn is_multiplexed(&self) -> bool {
+        self.out_empty_len != 0
+    }
+
+    /// upstream: `io.c:480-495 reduce_iobuf_size()`.
+    fn reduce_size(&mut self, new_size: usize) {
+        if new_size < self.size {
+            self.size = new_size;
+        }
+    }
+
+    /// upstream: `io.c:497-513 restore_iobuf_size()` - the low byte of a
+    /// 1024-aligned size is non-zero only while the size is reduced.
+    fn restore_size(&mut self) {
+        if self.size & 0xFF != 0 {
+            self.size = (self.size | 0xFF) + 1;
+        }
+    }
+
+    /// Test hook: the current circular offsets (`pos`, `len`, `size`).
+    #[cfg(test)]
+    pub(super) fn cursors(&self) -> (usize, usize, usize) {
+        (self.pos, self.len, self.size)
+    }
+}

--- a/crates/protocol/src/iobuf/tests.rs
+++ b/crates/protocol/src/iobuf/tests.rs
@@ -1,0 +1,371 @@
+//! Tests for the fixed-size wire buffers.
+//!
+//! The invariants under test are upstream's, not ours: a reserved header that
+//! is back-filled in place, a circular drain that resumes exactly where a short
+//! write stopped, and buffers that never grow.
+
+use std::io::{self, Read, Write};
+
+use super::{IN_BUFFER_SIZE, InBuf, IoBufReader, OUT_BUFFER_SIZE, OutBuf, round_up_1024};
+use crate::envelope::{HEADER_LEN, MessageCode, MessageHeader};
+
+/// Writer that accepts at most `chunk` bytes per call and records every call.
+///
+/// Short writes are what tear a frame that is not contiguous in one buffer, so
+/// every drain test runs through one of these rather than a `Vec`.
+struct ChunkedWriter {
+    sink: Vec<u8>,
+    chunk: usize,
+    calls: Vec<usize>,
+}
+
+impl ChunkedWriter {
+    fn new(chunk: usize) -> Self {
+        Self {
+            sink: Vec::new(),
+            chunk,
+            calls: Vec::new(),
+        }
+    }
+}
+
+impl Write for ChunkedWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = buf.len().min(self.chunk);
+        self.sink.extend_from_slice(&buf[..n]);
+        self.calls.push(n);
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Writer that stalls with `WouldBlock` once `budget` bytes have been accepted.
+///
+/// Models a non-blocking descriptor filling its socket buffer at an arbitrary
+/// offset - including mid-header and mid-payload.
+struct StallingWriter {
+    sink: Vec<u8>,
+    budget: usize,
+    stalled: bool,
+}
+
+impl StallingWriter {
+    fn new(budget: usize) -> Self {
+        Self {
+            sink: Vec::new(),
+            budget,
+            stalled: false,
+        }
+    }
+}
+
+impl Write for StallingWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.budget == 0 {
+            self.stalled = true;
+            return Err(io::Error::new(io::ErrorKind::WouldBlock, "socket full"));
+        }
+        let n = buf.len().min(self.budget);
+        self.sink.extend_from_slice(&buf[..n]);
+        self.budget -= n;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn data_frame(payload: &[u8]) -> Vec<u8> {
+    let header = MessageHeader::new(MessageCode::Data, payload.len() as u32).unwrap();
+    let mut out = Vec::from(header.encode());
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Upstream allocates every I/O buffer in whole 1024-byte units so the low byte
+/// of `size` is free to mark a temporarily reduced buffer (io.c:129-136).
+#[test]
+fn buffer_sizes_match_upstream() {
+    assert_eq!(IN_BUFFER_SIZE, 32 * 1024, "upstream io.c:1401");
+    assert_eq!(OUT_BUFFER_SIZE, 64 * 1024, "upstream io.c:1382");
+    assert_eq!(round_up_1024(1), 1024);
+    assert_eq!(round_up_1024(1024), 1024);
+    assert_eq!(round_up_1024(1025), 2048);
+    assert_eq!(OUT_BUFFER_SIZE & 0xFF, 0, "low byte must stay free");
+}
+
+/// "Empty" on a multiplexed buffer means `len == 4`, not `len == 0`: the
+/// reserved header occupies the first four bytes (upstream `out_empty_len`,
+/// io.c:2457). Getting this wrong flushes a bodiless header on every idle poll.
+#[test]
+fn reserved_header_makes_empty_mean_four() {
+    let mut out = OutBuf::new(1024);
+    assert!(out.is_empty());
+    out.start_multiplex();
+
+    let (pos, len, _) = out.cursors();
+    assert_eq!(
+        (pos, len),
+        (0, HEADER_LEN),
+        "header reserved, nothing written"
+    );
+    assert!(out.is_empty(), "a reserved header is still an empty buffer");
+    assert_eq!(out.data_len(), 0);
+
+    out.push(b"x");
+    assert!(!out.is_empty());
+    assert_eq!(out.data_len(), 1);
+}
+
+/// Appending bytes that fit must perform no I/O whatsoever - upstream's
+/// `write_buf` only reaches `perform_io` when `out.len + len > out.size`
+/// (io.c:2263-2264). `push` takes no writer at all, so this is structural; the
+/// test pins that the flush that follows is a single frame, not one per push.
+#[test]
+fn buffered_writes_do_no_io_until_flush() {
+    let mut out = OutBuf::new(1024);
+    out.start_multiplex();
+    for _ in 0..16 {
+        out.push(b"abcd");
+    }
+
+    let mut writer = ChunkedWriter::new(usize::MAX);
+    out.flush(&mut writer).unwrap();
+
+    assert_eq!(writer.calls.len(), 1, "one write for sixteen appends");
+    assert_eq!(writer.sink, data_frame(&b"abcd".repeat(16)));
+    assert!(out.is_empty());
+}
+
+/// The header is back-filled inside the buffer before any syscall, so a writer
+/// that accepts one byte at a time still emits the frame in order and never
+/// exposes a header whose payload is not already queued behind it.
+#[test]
+fn short_writes_never_tear_the_frame() {
+    let mut out = OutBuf::new(1024);
+    out.start_multiplex();
+    out.push(b"hello world");
+
+    let mut writer = ChunkedWriter::new(1);
+    out.flush(&mut writer).unwrap();
+
+    assert_eq!(writer.sink, data_frame(b"hello world"));
+    assert!(writer.calls.iter().all(|&n| n == 1), "byte-at-a-time drain");
+}
+
+/// A stall mid-header and a stall mid-payload must both leave the buffer
+/// describing exactly what is still owed, so the retry resumes on the very next
+/// byte. Upstream gets this from `out->pos` surviving a partial write
+/// (io.c:869-877); a header written by a separate `write_all` cannot.
+#[test]
+fn stall_at_any_offset_resumes_without_loss() {
+    let payload = b"the quick brown fox";
+    let expected = data_frame(payload);
+
+    for stall_at in 0..expected.len() {
+        let mut out = OutBuf::new(1024);
+        out.start_multiplex();
+        out.push(payload);
+
+        let mut writer = StallingWriter::new(stall_at);
+        let err = out.flush(&mut writer).expect_err("must stall");
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+        assert_eq!(
+            writer.sink.len(),
+            stall_at,
+            "exactly the accepted prefix reached the wire"
+        );
+        assert_eq!(writer.sink, expected[..stall_at], "prefix is in order");
+
+        // The retry drains the remainder; nothing is re-sent or dropped.
+        writer.budget = usize::MAX;
+        out.flush(&mut writer).unwrap();
+        assert_eq!(writer.sink, expected, "resumed exactly at the stall point");
+        assert!(out.is_empty());
+    }
+}
+
+/// Golden bytes for a flush that wraps the circular end.
+///
+/// This is the case reserve-in-place is easy to get subtly wrong. A stalled
+/// run leaves `pos` part-way through the buffer; the bytes appended behind it
+/// split around the physical end (upstream io.c:2270-2276), the reserved header
+/// for that second frame sits immediately in front of them, and the drain has
+/// to stop at the end, rewind `pos` to 0 and continue (io.c:864-877). The wire
+/// must still show two well-formed frames, in order, with nothing re-sent.
+#[test]
+fn flush_wrapping_the_circular_end_is_byte_exact() {
+    // 1 KiB circular buffer: 1020 payload bytes plus the reserved header.
+    let mut out = OutBuf::new(1020);
+    out.start_multiplex();
+
+    let first: Vec<u8> = (0..900u16).map(|i| i as u8).collect();
+    out.push(&first);
+
+    // Stall after 800 of the 904 frame bytes: pos = 800, 104 still owed.
+    let mut writer = StallingWriter::new(800);
+    assert_eq!(
+        out.flush(&mut writer).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+    assert_eq!(out.cursors().0, 800, "the run resumes from here");
+
+    // Appending now writes past the physical end and wraps to offset 0, behind
+    // a reserved header that lands at 904.
+    let second: Vec<u8> = (0..200u16).map(|i| (i * 7) as u8).collect();
+    out.push(&second);
+
+    writer.budget = usize::MAX;
+    out.flush(&mut writer).unwrap();
+
+    let mut expected = data_frame(&first);
+    expected.extend_from_slice(&data_frame(&second));
+    assert_eq!(writer.sink, expected, "golden wire bytes across the wrap");
+
+    // A fully drained buffer rewinds and re-reserves at offset 0
+    // (upstream io.c:872-877).
+    assert_eq!(out.cursors(), (0, HEADER_LEN, 1024));
+    assert!(out.is_empty());
+}
+
+/// A reserved header that would straddle the physical end forces upstream's
+/// temporary size reduction (io.c:699-705): the buffer shrinks so the header
+/// goes to offset 0 instead, and the size is restored the moment `pos` wraps
+/// (io.c:497-513). The low byte of the size is the marker, which only works
+/// because every allocation is 1024-aligned.
+#[test]
+fn header_that_would_straddle_the_end_reduces_the_size() {
+    let mut out = OutBuf::new(1020);
+    out.start_multiplex();
+
+    // 1018 payload bytes put the next header slot at 1022, four bytes of which
+    // will not fit before the end of the 1024-byte buffer.
+    let payload: Vec<u8> = (0..1018u16).map(|i| (i * 11) as u8).collect();
+    out.push(&payload);
+
+    let mut writer = StallingWriter::new(0);
+    assert_eq!(
+        out.flush(&mut writer).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+    assert_eq!(out.cursors().2, 1022, "size temporarily reduced");
+
+    writer.budget = usize::MAX;
+    out.flush(&mut writer).unwrap();
+    assert_eq!(writer.sink, data_frame(&payload));
+    assert_eq!(out.cursors(), (0, HEADER_LEN, 1024), "size restored");
+
+    // The buffer keeps working after the restore.
+    out.push(b"after");
+    out.flush(&mut writer).unwrap();
+    let mut expected = data_frame(&payload);
+    expected.extend_from_slice(&data_frame(b"after"));
+    assert_eq!(writer.sink, expected);
+}
+
+/// A raw (non-multiplexed) buffer writes exactly the bytes pushed - no header,
+/// and `out_empty_len` stays 0.
+#[test]
+fn raw_buffer_writes_no_header() {
+    let mut out = OutBuf::new(1024);
+    out.push(b"plain");
+    assert_eq!(out.data_len(), 5);
+    let mut writer = ChunkedWriter::new(usize::MAX);
+    out.flush(&mut writer).unwrap();
+    assert_eq!(writer.sink, b"plain");
+    assert!(out.is_empty());
+}
+
+/// Flushing an empty buffer is a no-op: no keepalive-sized bodiless frame, no
+/// syscall. upstream `io_flush` returns immediately when `out.len` is already
+/// `out_empty_len`.
+#[test]
+fn flushing_an_empty_buffer_writes_nothing() {
+    let mut out = OutBuf::new(1024);
+    out.start_multiplex();
+    let mut writer = ChunkedWriter::new(usize::MAX);
+    out.flush(&mut writer).unwrap();
+    assert!(writer.sink.is_empty());
+    assert!(writer.calls.is_empty());
+}
+
+/// The input buffer is fixed for its whole lifetime (io.c:579) and wraps rather
+/// than compacting.
+#[test]
+fn input_buffer_is_fixed_and_circular() {
+    let mut buf = InBuf::new(1024);
+    assert_eq!(buf.capacity(), 1024);
+
+    let source: Vec<u8> = (0..1024u16).map(|i| i as u8).collect();
+    let mut reader = &source[..];
+    assert_eq!(buf.fill(&mut reader).unwrap(), 1024);
+    assert_eq!(buf.len(), 1024);
+    assert_eq!(
+        buf.fill(&mut reader).unwrap(),
+        0,
+        "a full buffer never grows"
+    );
+    assert_eq!(buf.capacity(), 1024, "never resized");
+
+    buf.consume(1000);
+    assert_eq!(buf.len(), 24);
+    assert_eq!(buf.readable(), &source[1000..]);
+
+    // Refilling now wraps: the free span is [0, 1000).
+    let more: Vec<u8> = (0..100u8).map(|i| i.wrapping_add(200)).collect();
+    let mut reader = &more[..];
+    assert_eq!(buf.fill(&mut reader).unwrap(), 100);
+    assert_eq!(buf.len(), 124);
+    assert_eq!(buf.readable(), &source[1000..], "head served first");
+    buf.consume(24);
+    assert_eq!(buf.readable(), &more[..], "then the wrapped tail");
+    buf.consume(100);
+    assert!(buf.is_empty());
+}
+
+/// Reader that yields one byte per call, so the adapter's buffering is the only
+/// thing keeping syscall count sane.
+struct DribbleReader<'a> {
+    data: &'a [u8],
+}
+
+impl Read for DribbleReader<'_> {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        if self.data.is_empty() || out.is_empty() {
+            return Ok(0);
+        }
+        out[0] = self.data[0];
+        self.data = &self.data[1..];
+        Ok(1)
+    }
+}
+
+/// The `Read` adapter delivers the stream unchanged regardless of how the
+/// underlying descriptor fragments it.
+#[test]
+fn iobuf_reader_delivers_the_stream_unchanged() {
+    let source: Vec<u8> = (0..5000u16).map(|i| (i * 3) as u8).collect();
+    let mut reader = IoBufReader::with_capacity(1024, DribbleReader { data: &source });
+    let mut got = Vec::new();
+    reader.read_to_end(&mut got).unwrap();
+    assert_eq!(got, source);
+}
+
+/// A request at least as large as the buffer bypasses staging, matching
+/// `std::io::BufReader`; the bytes delivered must be identical either way.
+#[test]
+fn iobuf_reader_bypasses_for_large_requests() {
+    let source: Vec<u8> = (0..4096u16).map(|i| i as u8).collect();
+    let mut reader = IoBufReader::with_capacity(1024, &source[..]);
+    let mut out = vec![0u8; 4096];
+    let n = reader.read(&mut out).unwrap();
+    assert_eq!(
+        n, 4096,
+        "the whole slice is served straight from the source"
+    );
+    assert_eq!(out, source);
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -132,6 +132,7 @@ pub mod fnamecmp;
 pub mod iconv;
 /// UID/GID mapping lists for name-based ownership transfer.
 pub mod idlist;
+pub mod iobuf;
 mod legacy;
 /// Process-global `--max-alloc` allocation ceiling shared by wire decoders.
 pub mod max_alloc;
@@ -195,8 +196,8 @@ pub use multiplex::MultiplexCodec;
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-transfer")))]
 pub use multiplex::recv_msg_into_async;
 pub use multiplex::{
-    BorrowedMessageFrame, BorrowedMessageFrames, MessageFrame, MplexReader, MplexWriter, recv_msg,
-    recv_msg_into, send_frame, send_keepalive, send_msg, send_msgs_vectored,
+    BorrowedMessageFrame, BorrowedMessageFrames, FrameReader, MessageFrame, MplexReader,
+    MplexWriter, recv_msg, recv_msg_into, send_frame, send_keepalive, send_msg, send_msgs_vectored,
 };
 pub use negotiation::{
     BufferedPrefixTooSmall, ChecksumAlgorithm, CompressionAlgorithm, NegotiationConfig,

--- a/crates/protocol/src/multiplex/helpers.rs
+++ b/crates/protocol/src/multiplex/helpers.rs
@@ -98,24 +98,49 @@ pub(super) fn read_payload<R: Read>(reader: &mut R, len: usize) -> io::Result<Ve
 /// `false` for the empty-payload fast path (buffer left empty). This is the
 /// shared buffer-preparation seam used by both the blocking and async payload
 /// readers so their reuse, allocation, and length semantics stay identical.
-#[allow(unsafe_code)]
 pub(super) fn prepare_payload_buffer(buffer: &mut Vec<u8>, len: usize) -> io::Result<bool> {
-    buffer.clear();
+    stage_payload_buffer(buffer, len, 0)?;
+    Ok(len != 0)
+}
 
-    if len == 0 {
-        return Ok(false);
+/// Sizes `buffer` to exactly `len` bytes while preserving its first `valid`
+/// bytes, ready to be filled from `valid` onwards.
+///
+/// This is the resumable counterpart of [`prepare_payload_buffer`]: a frame
+/// read that stalls part-way truncates `buffer` to the bytes it actually
+/// received (so no uninitialised byte is ever observable), and the retry calls
+/// this to re-open the tail. Capacity survives a `truncate`, so re-staging
+/// never reallocates.
+#[allow(unsafe_code)]
+pub(super) fn stage_payload_buffer(
+    buffer: &mut Vec<u8>,
+    len: usize,
+    valid: usize,
+) -> io::Result<()> {
+    debug_assert!(valid <= len, "more valid bytes than the payload holds");
+    buffer.truncate(valid);
+
+    if len == valid {
+        return Ok(());
     }
 
     reserve_payload(buffer, len)?;
-    // SAFETY: `reserve_payload` ensures `capacity >= len`. Callers fill
-    // `buffer[0..len]` before any byte is exposed, and truncate to the
-    // only-written prefix on short read or error, so no uninitialized memory
-    // escapes.
+    // SAFETY: `reserve_payload` ensures `capacity >= len`. Only `buffer[..valid]`
+    // is ever read by anyone; the caller fills `buffer[valid..len]` before
+    // advancing its valid count, and truncates back to that count on any error.
     unsafe { buffer.set_len(len) };
 
-    Ok(true)
+    Ok(())
 }
 
+/// Fills `buffer` with exactly `len` payload bytes, retrying only `EINTR`.
+///
+/// This is the stateless reader used by [`recv_msg`](super::recv_msg) and
+/// [`recv_msg_into`](super::recv_msg_into): a frame is read start to finish in
+/// one call, so a reader that stalls part-way has nowhere to record its
+/// progress and the partial bytes are lost. Any caller that must survive a
+/// mid-frame stall - the transfer demultiplexer above all - uses
+/// [`FrameReader`](super::FrameReader), which keeps that progress across calls.
 pub(super) fn read_payload_into<R: Read>(
     reader: &mut R,
     buffer: &mut Vec<u8>,

--- a/crates/protocol/src/multiplex/io/frame_reader.rs
+++ b/crates/protocol/src/multiplex/io/frame_reader.rs
@@ -1,0 +1,257 @@
+use std::io::{self, Read};
+
+use logging::debug_log;
+
+use crate::envelope::{HEADER_LEN, MessageCode};
+
+use super::super::helpers::{
+    decode_header, stage_payload_buffer, truncated_frame_error, truncated_payload_error,
+};
+
+/// Resumable decoder for one multiplex frame at a time.
+///
+/// [`recv_msg_into`](super::recv::recv_msg_into) reads a frame with a single
+/// `read_exact` pair and therefore cannot survive a reader that stops
+/// mid-frame: the partial bytes are dropped and the error propagates, leaving
+/// the demultiplexer's next call to resynchronise on whatever byte follows.
+/// That is a desync, not a recoverable error.
+///
+/// This decoder keeps the frame's progress - how much of the 4-byte header and
+/// how much of the payload has landed - across calls. A reader that returns
+/// [`io::ErrorKind::WouldBlock`] (or any transient error) part-way through a
+/// frame leaves the state intact, so the very next call resumes at the exact
+/// byte where the stall happened. `EINTR` is retried inline, matching upstream
+/// `perform_io`, which treats `EINTR`/`EAGAIN` alike as "zero bytes moved, not
+/// an error" (io.c:800-808).
+///
+/// Upstream needs no such state machine because its decoders never touch the
+/// descriptor: `read_buf()` copies out of the circular `iobuf.in`, and the sole
+/// reader is `perform_io` (io.c:789). This type is the equivalent guarantee for
+/// a `std::io::Read` stack, where the frame boundary and the syscall boundary
+/// are not the same thing.
+#[derive(Debug, Default)]
+pub struct FrameReader {
+    header: [u8; HEADER_LEN],
+    header_read: usize,
+    /// `Some` once the header has been decoded and the payload is in progress.
+    code: Option<MessageCode>,
+    payload_len: usize,
+    payload_read: usize,
+}
+
+impl FrameReader {
+    /// Creates a decoder positioned at a frame boundary.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` while a frame is partially read.
+    ///
+    /// A caller must not reuse `buffer` for anything else while this holds: the
+    /// bytes already received live there and the next call resumes into them.
+    #[must_use]
+    pub fn in_progress(&self) -> bool {
+        self.header_read != 0 || self.code.is_some()
+    }
+
+    /// Reads the next complete frame, resuming any frame left partially read.
+    ///
+    /// On success `buffer` holds exactly the payload and the frame's code is
+    /// returned. On a transient error the frame's progress is retained and the
+    /// call may simply be repeated. End-of-stream part-way through a frame is
+    /// reported as a truncation, matching the existing readers.
+    pub fn read_frame<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        buffer: &mut Vec<u8>,
+    ) -> io::Result<MessageCode> {
+        let code = match self.code {
+            // Resuming after a stall: the previous call truncated `buffer` to
+            // the bytes it had actually received so no uninitialised byte was
+            // ever observable. Re-stage the tail before reading into it.
+            Some(code) => {
+                stage_payload_buffer(buffer, self.payload_len, self.payload_read)?;
+                code
+            }
+            None => {
+                while self.header_read < HEADER_LEN {
+                    match reader.read(&mut self.header[self.header_read..]) {
+                        Ok(0) => {
+                            return Err(truncated_frame_error(HEADER_LEN, self.header_read));
+                        }
+                        Ok(n) => self.header_read += n,
+                        Err(ref err) if err.kind() == io::ErrorKind::Interrupted => {}
+                        Err(err) => return Err(err),
+                    }
+                }
+
+                let header = decode_header(&self.header)?;
+                let len = header.payload_len_usize();
+                debug_log!(Io, 3, "mux recv: code={:?} len={}", header.code(), len);
+                stage_payload_buffer(buffer, len, 0)?;
+                self.code = Some(header.code());
+                self.payload_len = len;
+                self.payload_read = 0;
+                header.code()
+            }
+        };
+
+        while self.payload_read < self.payload_len {
+            match reader.read(&mut buffer[self.payload_read..]) {
+                Ok(0) => {
+                    let got = self.payload_read;
+                    buffer.truncate(got);
+                    return Err(truncated_payload_error(self.payload_len, got));
+                }
+                Ok(n) => self.payload_read += n,
+                Err(ref err) if err.kind() == io::ErrorKind::Interrupted => {}
+                Err(err) => {
+                    buffer.truncate(self.payload_read);
+                    return Err(err);
+                }
+            }
+        }
+
+        self.code = None;
+        self.header_read = 0;
+        Ok(code)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::MessageHeader;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Reader that hands back one byte per call and reports `WouldBlock` once a
+    /// shared budget is exhausted, so a stall can be placed at every byte
+    /// offset of a frame - including inside the 4-byte header.
+    struct StallingDribble {
+        data: Vec<u8>,
+        pos: usize,
+        budget: Arc<AtomicUsize>,
+    }
+
+    impl Read for StallingDribble {
+        fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+            if self.budget.load(Ordering::SeqCst) == 0 {
+                return Err(io::Error::new(io::ErrorKind::WouldBlock, "stalled"));
+            }
+            if self.pos >= self.data.len() || out.is_empty() {
+                return Ok(0);
+            }
+            out[0] = self.data[self.pos];
+            self.pos += 1;
+            self.budget.fetch_sub(1, Ordering::SeqCst);
+            Ok(1)
+        }
+    }
+
+    fn frame(code: MessageCode, payload: &[u8]) -> Vec<u8> {
+        let header = MessageHeader::new(code, payload.len() as u32).unwrap();
+        let mut out = Vec::from(header.encode());
+        out.extend_from_slice(payload);
+        out
+    }
+
+    /// A stall at any offset - mid-header or mid-payload - must be resumable.
+    /// The pre-existing `read_exact` pair dropped the bytes it had already
+    /// received, so the retry resynchronised on the middle of the frame.
+    #[test]
+    fn stall_at_any_offset_resumes_the_same_frame() {
+        let payload: Vec<u8> = (0..64u8).collect();
+        let wire = frame(MessageCode::Data, &payload);
+
+        for stall_at in 0..wire.len() {
+            let budget = Arc::new(AtomicUsize::new(stall_at));
+            let mut reader = StallingDribble {
+                data: wire.clone(),
+                pos: 0,
+                budget: Arc::clone(&budget),
+            };
+            let mut frames = FrameReader::new();
+            let mut buffer = Vec::new();
+
+            let err = frames
+                .read_frame(&mut reader, &mut buffer)
+                .expect_err("must stall");
+            assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+            assert_eq!(
+                frames.in_progress(),
+                stall_at > 0,
+                "a stall past the first byte must retain the frame's progress; \
+                 a stall before it leaves us at a frame boundary"
+            );
+            assert!(
+                buffer.len() <= payload.len(),
+                "only received bytes are observable"
+            );
+
+            budget.store(usize::MAX, Ordering::SeqCst);
+            let code = frames
+                .read_frame(&mut reader, &mut buffer)
+                .expect("resumes from the stall point");
+            assert_eq!(code, MessageCode::Data);
+            assert_eq!(buffer, payload, "stalled at offset {stall_at}");
+            assert!(!frames.in_progress());
+        }
+    }
+
+    /// Consecutive frames decode independently once the first completes.
+    #[test]
+    fn consecutive_frames_decode_in_order() {
+        let mut wire = frame(MessageCode::Data, b"first");
+        wire.extend_from_slice(&frame(MessageCode::Info, b"note"));
+        wire.extend_from_slice(&frame(MessageCode::Data, b""));
+
+        let budget = Arc::new(AtomicUsize::new(usize::MAX));
+        let mut reader = StallingDribble {
+            data: wire,
+            pos: 0,
+            budget,
+        };
+        let mut frames = FrameReader::new();
+        let mut buffer = Vec::new();
+
+        assert_eq!(
+            frames.read_frame(&mut reader, &mut buffer).unwrap(),
+            MessageCode::Data
+        );
+        assert_eq!(buffer, b"first");
+        assert_eq!(
+            frames.read_frame(&mut reader, &mut buffer).unwrap(),
+            MessageCode::Info
+        );
+        assert_eq!(buffer, b"note");
+        assert_eq!(
+            frames.read_frame(&mut reader, &mut buffer).unwrap(),
+            MessageCode::Data
+        );
+        assert!(buffer.is_empty(), "an empty payload clears the buffer");
+    }
+
+    /// End of stream part-way through a frame stays a truncation error, and the
+    /// bytes actually received remain observable - never uninitialised memory.
+    #[test]
+    fn eof_mid_payload_truncates_to_what_arrived() {
+        let mut wire = frame(MessageCode::Data, b"abcdefgh");
+        wire.truncate(4 + 3);
+        let budget = Arc::new(AtomicUsize::new(usize::MAX));
+        let mut reader = StallingDribble {
+            data: wire,
+            pos: 0,
+            budget,
+        };
+        let mut frames = FrameReader::new();
+        let mut buffer = Vec::new();
+
+        let err = frames
+            .read_frame(&mut reader, &mut buffer)
+            .expect_err("truncated frame");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert_eq!(buffer, b"abc");
+    }
+}

--- a/crates/protocol/src/multiplex/io/mod.rs
+++ b/crates/protocol/src/multiplex/io/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "tokio-transfer")]
 mod async_recv;
+mod frame_reader;
 mod recv;
 mod send;
 
@@ -10,5 +11,6 @@ mod tests;
 
 #[cfg(feature = "tokio-transfer")]
 pub use async_recv::recv_msg_into_async;
+pub use frame_reader::FrameReader;
 pub use recv::{recv_msg, recv_msg_into};
 pub use send::{send_frame, send_keepalive, send_msg, send_msgs_vectored};

--- a/crates/protocol/src/multiplex/mod.rs
+++ b/crates/protocol/src/multiplex/mod.rs
@@ -35,6 +35,8 @@ pub use codec::MultiplexCodec;
 pub use frame::MessageFrame;
 #[cfg(feature = "tokio-transfer")]
 pub use io::recv_msg_into_async;
-pub use io::{recv_msg, recv_msg_into, send_frame, send_keepalive, send_msg, send_msgs_vectored};
+pub use io::{
+    FrameReader, recv_msg, recv_msg_into, send_frame, send_keepalive, send_msg, send_msgs_vectored,
+};
 pub use reader::MplexReader;
 pub use writer::MplexWriter;

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -731,15 +731,17 @@ pub fn run_server_with_handshake_adopting<W: Write>(
     // Flush raw-mode data before wrapping in multiplexed writer.
     stdout.flush()?;
 
-    // upstream: io.c iobuf.in is 32KB circular; BufReader serves the same role,
-    // batching small reads (4-byte multiplex headers) into fewer recvfrom syscalls.
+    // upstream: io.c:1401 iobuf.in is a fixed 32KB circular buffer that is never
+    // resized (io.c:579). IoBufReader is that buffer, and it sits beneath the
+    // multiplex demuxer so no decoder ever touches the descriptor - the layering
+    // upstream enforces with `assert(fd != iobuf.in_fd)` (io.c:243).
     // The CountingReader wraps the raw transport (below the multiplex demuxer and
     // token decompression) so the running total reflects compressed wire bytes,
     // matching upstream's `stats.total_read` (io.c:820).
     let counting_stdin = reader::CountingReader::new(chained_stdin);
     let bytes_received_counter = counting_stdin.counter();
     let mut reader =
-        reader::ServerReader::new_plain(io::BufReader::with_capacity(64 * 1024, counting_stdin));
+        reader::ServerReader::new_plain(protocol::iobuf::IoBufReader::new(counting_stdin));
 
     // upstream: io.c:1551-1561 - only the client receiver adopts a
     // daemon-advertised MSG_IO_TIMEOUT (`am_server || am_generator` treat it as

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -127,6 +127,12 @@ impl DeletedRender {
 ///   otherwise forwards to the generator.
 pub(crate) struct MultiplexReader<R> {
     inner: R,
+    /// Resumable frame decoder. It keeps a partially received frame's progress
+    /// across calls, so a reader that stops mid-frame is retried rather than
+    /// dropping the bytes already in `buffer` and resynchronising on the wrong
+    /// byte. upstream needs no equivalent because its decoders never touch the
+    /// descriptor (io.c:789 is the sole `read()`).
+    frames: protocol::FrameReader,
     pub(super) buffer: Vec<u8>,
     pub(super) pos: usize,
     /// Accumulated I/O error flags from `MSG_IO_ERROR` messages.
@@ -243,6 +249,7 @@ impl<R> MultiplexReader<R> {
     pub(super) fn new(inner: R) -> Self {
         Self {
             inner,
+            frames: protocol::FrameReader::new(),
             buffer: Vec::with_capacity(MULTIPLEX_READER_BUFFER_CAPACITY),
             pos: 0,
             batch_recorder: None,
@@ -661,6 +668,20 @@ impl<R> MultiplexReader<R> {
 }
 
 impl<R: Read> MultiplexReader<R> {
+    /// Reads the next multiplex frame into `buffer`, resuming one that a
+    /// previous call left partially received.
+    ///
+    /// The frame's progress lives in `frames`, not in this call, so a reader
+    /// that stalls part-way through a header or a payload is retried from the
+    /// exact byte it stopped on. Before this existed the partial bytes were
+    /// discarded and the error propagated, which resynchronised the
+    /// demultiplexer on the middle of a frame.
+    fn next_frame(&mut self) -> io::Result<protocol::MessageCode> {
+        let code = self.frames.read_frame(&mut self.inner, &mut self.buffer)?;
+        self.pos = 0;
+        Ok(code)
+    }
+
     /// Attempts to borrow exactly `len` bytes from the internal frame buffer.
     ///
     /// Returns `Some(&[u8])` if the current frame buffer has at least `len` bytes
@@ -684,12 +705,11 @@ impl<R: Read> MultiplexReader<R> {
     /// reach the batch file, leaving `--write-batch` outputs from daemon and
     /// SSH transfers missing their delta payloads.
     pub(super) fn try_borrow_exact(&mut self, len: usize) -> io::Result<Option<&[u8]>> {
-        if self.pos >= self.buffer.len() {
+        // A frame left partially received owns `buffer`; its bytes are not
+        // deliverable payload until the frame completes.
+        if self.frames.in_progress() || self.pos >= self.buffer.len() {
             loop {
-                self.buffer.clear();
-                self.pos = 0;
-
-                let code = protocol::recv_msg_into(&mut self.inner, &mut self.buffer)?;
+                let code = self.next_frame()?;
 
                 if self.dispatch_message(code) {
                     break;
@@ -772,16 +792,15 @@ impl<R> MultiplexReader<R> {
 
 impl<R: Read> Read for MultiplexReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if self.pos < self.buffer.len() {
+        // A frame left partially received owns `buffer`; its bytes are not
+        // deliverable payload until the frame completes.
+        if !self.frames.in_progress() && self.pos < self.buffer.len() {
             return self.drain_buffered(buf);
         }
 
         // Loop until we get a MSG_DATA message
         loop {
-            self.buffer.clear();
-            self.pos = 0;
-
-            let code = protocol::recv_msg_into(&mut self.inner, &mut self.buffer)?;
+            let code = self.next_frame()?;
 
             if self.dispatch_message(code) {
                 // upstream: io.c io_start_multiplex_out() sends a length-0
@@ -1070,5 +1089,112 @@ mod success_dispatch_tests {
             reader.dispatch_message_with(protocol::MessageCode::Success, &mut RealSink);
         }
         assert_eq!(reader.take_success_indices(), vec![1, 5, 9]);
+    }
+}
+
+/// Tests for the demultiplexer's resumption across a stalled read.
+///
+/// A reader that stops part-way through a frame must not cost the bytes it has
+/// already delivered: dropping them makes the next call resynchronise on the
+/// middle of a frame, which is a silent desync rather than a recoverable error.
+#[cfg(test)]
+mod resume_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Reader that yields one byte per call and reports `WouldBlock` once a
+    /// shared budget runs out, so the stall can be placed at any byte offset.
+    struct StallingDribble {
+        data: Vec<u8>,
+        pos: usize,
+        budget: Arc<AtomicUsize>,
+    }
+
+    impl Read for StallingDribble {
+        fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+            if self.budget.load(Ordering::SeqCst) == 0 {
+                return Err(io::Error::new(io::ErrorKind::WouldBlock, "stalled"));
+            }
+            if self.pos >= self.data.len() || out.is_empty() {
+                return Ok(0);
+            }
+            out[0] = self.data[self.pos];
+            self.pos += 1;
+            self.budget.fetch_sub(1, Ordering::SeqCst);
+            Ok(1)
+        }
+    }
+
+    fn frame(payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        protocol::send_msg(&mut out, protocol::MessageCode::Data, payload).unwrap();
+        out
+    }
+
+    /// Whatever offset the wire stalls at, the demultiplexer resumes on the
+    /// exact byte it stopped on and delivers the concatenated payloads
+    /// unchanged - no byte duplicated, dropped, or reinterpreted as a header.
+    #[test]
+    fn stall_at_any_offset_resumes_without_desync() {
+        let first: Vec<u8> = (0..100u16).map(|i| (i * 3) as u8).collect();
+        let second: Vec<u8> = (0..37u16).map(|i| (i * 11 + 1) as u8).collect();
+        let mut wire = frame(&first);
+        wire.extend_from_slice(&frame(&second));
+
+        let mut expected = first.clone();
+        expected.extend_from_slice(&second);
+
+        for stall_at in 0..wire.len() {
+            let budget = Arc::new(AtomicUsize::new(stall_at));
+            let mut reader = MultiplexReader::new(StallingDribble {
+                data: wire.clone(),
+                pos: 0,
+                budget: Arc::clone(&budget),
+            });
+
+            let mut got = Vec::new();
+            let mut chunk = [0u8; 16];
+            let mut released = false;
+            loop {
+                match reader.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => got.extend_from_slice(&chunk[..n]),
+                    Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => {
+                        assert!(!released, "the stall must happen at most once");
+                        released = true;
+                        budget.store(usize::MAX, Ordering::SeqCst);
+                    }
+                    // Running out of wire at a frame boundary ends the stream,
+                    // exactly as it did before the decoder became resumable.
+                    Err(ref err) if err.kind() == io::ErrorKind::UnexpectedEof => break,
+                    Err(err) => panic!("stalled at {stall_at}: {err}"),
+                }
+            }
+
+            assert_eq!(got, expected, "stalled at offset {stall_at}");
+        }
+    }
+
+    /// A stall inside the payload must not let the partially received bytes
+    /// escape as delivered data; only a completed frame is deliverable.
+    #[test]
+    fn partial_payload_is_never_delivered_early() {
+        let payload: Vec<u8> = (0..64u8).collect();
+        let wire = frame(&payload);
+        // Stop six bytes into the payload.
+        let budget = Arc::new(AtomicUsize::new(protocol::MESSAGE_HEADER_LEN + 6));
+        let mut reader = MultiplexReader::new(StallingDribble {
+            data: wire,
+            pos: 0,
+            budget: Arc::clone(&budget),
+        });
+
+        let mut chunk = [0u8; 64];
+        let err = reader.read(&mut chunk).expect_err("must stall");
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+
+        budget.store(usize::MAX, Ordering::SeqCst);
+        let n = reader.read(&mut chunk).unwrap();
+        assert_eq!(&chunk[..n], &payload[..], "the whole frame lands at once");
     }
 }

--- a/crates/transfer/src/writer/multiplex.rs
+++ b/crates/transfer/src/writer/multiplex.rs
@@ -3,12 +3,19 @@
 //! Mirrors upstream rsync's buffering behavior in `io.c` where a single buffer
 //! accumulates data before flushing to the socket. Uses 64KB buffer size to
 //! compensate for frame headers and batch approximately 2 wire chunks per flush.
+//!
+//! The frame header is reserved *inside* that buffer and back-filled at flush
+//! time (upstream io.c:2461-2462 and io.c:687-688), so a header and its payload
+//! are adjacent bytes of one buffer before any syscall runs. Nothing can be
+//! scheduled between them and no partial write can leave a header on the wire
+//! without its payload queued behind it.
 
 use std::io::{self, IoSlice, Write};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use protocol::{MessageCode, MessageHeader};
+use protocol::iobuf::OutBuf;
+use protocol::{MESSAGE_HEADER_LEN, MessageCode, MessageHeader};
 
 /// Destination selector for bytes written through a batch-recording writer.
 ///
@@ -49,9 +56,16 @@ pub enum BatchRoute {
 /// tees data before multiplex framing is applied.
 pub(crate) struct MultiplexWriter<W> {
     inner: W,
-    buffer: Vec<u8>,
-    /// Buffer size matching upstream rsync's IO_BUFFER_SIZE pattern.
+    /// Circular output buffer whose first four bytes are the reserved
+    /// `MSG_DATA` header. upstream: `iobuf.out` (io.c:91-100).
+    buffer: OutBuf,
+    /// Payload bytes buffered before a flush is forced. Matches upstream's
+    /// `IO_BUFFER_SIZE`-derived output sizing pattern.
     buffer_size: usize,
+    /// Reusable staging area for control frames, which upstream builds
+    /// header-and-payload in one shot (io.c:965-1058 `send_msg`), and for the
+    /// oversized `MSG_DATA` frames that do not fit the circular buffer.
+    scratch: Vec<u8>,
     /// True when data has been written to `inner` since the last successful
     /// `inner.flush()`. Prevents redundant flush syscalls on transfer hot
     /// paths where `flush()` is called per-iteration but many iterations
@@ -77,6 +91,13 @@ pub(crate) struct MultiplexWriter<W> {
 /// Default buffer size - 64KB to batch ~2 wire chunks per flush.
 const DEFAULT_BUFFER_SIZE: usize = 64 * 1024;
 
+/// Capacity the control-frame staging buffer is allowed to retain.
+///
+/// A single oversized frame must not pin its staging allocation for the rest of
+/// the run; upstream keeps steady-state memory bounded by never growing its
+/// buffers at all (io.c:579, io.c:594).
+const SCRATCH_RETAIN: usize = DEFAULT_BUFFER_SIZE + MESSAGE_HEADER_LEN;
+
 impl<W: Write> MultiplexWriter<W> {
     /// Creates a new multiplex writer with 64KB buffering.
     ///
@@ -86,10 +107,15 @@ impl<W: Write> MultiplexWriter<W> {
     /// `MSG_DATA` frame headers (4 bytes per frame) and to batch ~2 wire chunks
     /// per flush for better syscall efficiency.
     pub(crate) fn new(inner: W) -> Self {
+        let mut buffer = OutBuf::new(DEFAULT_BUFFER_SIZE);
+        // upstream: io.c:2455-2462 io_start_multiplex_out() reserves the first
+        // MSG_DATA header before a single payload byte is buffered.
+        buffer.start_multiplex();
         Self {
             inner,
-            buffer: Vec::with_capacity(DEFAULT_BUFFER_SIZE),
+            buffer,
             buffer_size: DEFAULT_BUFFER_SIZE,
+            scratch: Vec::new(),
             dirty: false,
             batch_recorder: None,
             batch_route: BatchRoute::default(),
@@ -137,6 +163,8 @@ impl<W: Write> MultiplexWriter<W> {
 
         // upstream: io.c:1476-1479 - pending output is flushed rather than
         // emitting a keepalive; the flush itself is the I/O that resets the lull.
+        // "Empty" here is `out.len == out_empty_len`, not `len == 0`: the
+        // reserved header occupies the first four bytes (io.c:1472).
         if !self.buffer.is_empty() {
             self.flush_buffer()?;
             self.inner.flush()?;
@@ -147,7 +175,7 @@ impl<W: Write> MultiplexWriter<W> {
 
         // upstream: io.c:1472-1473 - only at a frame boundary, emit an empty
         // MSG_DATA that the peer absorbs as a no-op keepalive.
-        protocol::send_msg(&mut self.inner, MessageCode::Data, &[])?;
+        self.write_frame(MessageCode::Data, 0, std::iter::empty())?;
         self.inner.flush()?;
         self.dirty = false;
         self.last_io_out = Instant::now();
@@ -180,13 +208,48 @@ impl<W: Write> MultiplexWriter<W> {
     }
 
     /// Flushes the internal buffer by sending it as a `MSG_DATA` frame.
+    ///
+    /// The header is back-filled into the four bytes reserved at the front of
+    /// the buffered run (upstream io.c:687-688) and the whole frame leaves
+    /// through one drain loop, so a short write can never separate the header
+    /// from its payload.
     fn flush_buffer(&mut self) -> io::Result<()> {
         if !self.buffer.is_empty() {
-            let code = MessageCode::Data;
-            protocol::send_msg(&mut self.inner, code, &self.buffer)?;
-            self.buffer.clear();
+            self.buffer.flush(&mut self.inner)?;
             self.dirty = true;
             self.last_io_out = Instant::now();
+        }
+        Ok(())
+    }
+
+    /// Writes one frame whose header and payload are staged contiguously.
+    ///
+    /// upstream: `send_msg()` (io.c:965-1058) builds every non-`MSG_DATA` frame
+    /// header-then-payload in one shot inside `iobuf.msg`; the same treatment is
+    /// applied to a `MSG_DATA` payload too large for the circular buffer, which
+    /// would otherwise be the one place a header and its body could be split
+    /// across two `write_all` calls.
+    fn write_frame<'b>(
+        &mut self,
+        code: MessageCode,
+        payload_len: usize,
+        chunks: impl Iterator<Item = &'b [u8]>,
+    ) -> io::Result<()> {
+        let len = u32::try_from(payload_len)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "payload length overflow"))?;
+        let header = MessageHeader::new(code, len)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+        self.scratch.clear();
+        self.scratch.reserve(MESSAGE_HEADER_LEN + payload_len);
+        self.scratch.extend_from_slice(&header.encode());
+        for chunk in chunks {
+            self.scratch.extend_from_slice(chunk);
+        }
+        self.inner.write_all(&self.scratch)?;
+
+        if self.scratch.capacity() > SCRATCH_RETAIN {
+            self.scratch = Vec::new();
         }
         Ok(())
     }
@@ -205,7 +268,7 @@ impl<W: Write> MultiplexWriter<W> {
     /// still flush immediately.
     pub(crate) fn send_message(&mut self, code: MessageCode, payload: &[u8]) -> io::Result<()> {
         self.flush_buffer()?;
-        protocol::send_msg(&mut self.inner, code, payload)?;
+        self.write_frame(code, payload.len(), std::iter::once(payload))?;
         self.dirty = true;
         self.last_io_out = Instant::now();
         if code.requires_immediate_flush() {
@@ -241,32 +304,34 @@ impl<W: Write> Write for MultiplexWriter<W> {
             return Ok(buf.len());
         }
 
-        if self.buffer.len() + buf.len() > self.buffer_size {
+        if self.buffer.data_len() + buf.len() > self.buffer_size {
             self.flush_buffer()?;
         }
 
-        // If buf fills or exceeds the buffer, send directly as a MSG_DATA frame.
-        // This bypasses one copy (into the internal buffer) for bulk data,
-        // matching upstream rsync's behavior of flushing iobuf_out when full.
+        // A payload that cannot fit the circular buffer is staged contiguously
+        // and sent as its own MSG_DATA frame. upstream splits such a write into
+        // buffer-sized chunks instead (io.c:2242-2253 write_bigbuf); keeping the
+        // single frame preserves the bytes already on the wire while still
+        // guaranteeing the header and payload leave together.
         if buf.len() >= self.buffer_size {
-            let code = MessageCode::Data;
-            protocol::send_msg(&mut self.inner, code, buf)?;
+            self.write_frame(MessageCode::Data, buf.len(), std::iter::once(buf))?;
             self.dirty = true;
             self.last_io_out = Instant::now();
             return Ok(buf.len());
         }
 
-        self.buffer.extend_from_slice(buf);
+        // upstream: io.c:2263-2264 write_buf() reaches perform_io() only when
+        // the bytes do not fit, so a write that fits costs no syscall at all.
+        self.buffer.push(buf);
         Ok(buf.len())
     }
 
-    /// Writes multiple buffers using vectored I/O to reduce syscall overhead.
+    /// Writes multiple buffers, batching them into the internal buffer.
     ///
-    /// Small writes are batched into the internal buffer. When the total data
-    /// exceeds the buffer size, a `MSG_DATA` frame is written directly to the
-    /// inner writer without an intermediate allocation - the header is written
-    /// first, then each slice sequentially. This mirrors upstream rsync's
-    /// `writefd_unbuffered()` pattern in `io.c`.
+    /// Small writes are copied into the circular buffer and cost no syscall.
+    /// When the total exceeds the buffer size the slices are staged contiguously
+    /// behind their `MSG_DATA` header and written once, so the frame can never
+    /// be split across two `write_all` calls.
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let total_len: usize = bufs.iter().map(|b| b.len()).sum();
 
@@ -281,9 +346,9 @@ impl<W: Write> Write for MultiplexWriter<W> {
         }
 
         // Fast path: if everything fits in remaining buffer space, copy all at once
-        if self.buffer.len() + total_len <= self.buffer_size {
+        if self.buffer.data_len() + total_len <= self.buffer_size {
             for buf in bufs {
-                self.buffer.extend_from_slice(buf);
+                self.buffer.push(buf);
             }
             return Ok(total_len);
         }
@@ -292,19 +357,10 @@ impl<W: Write> Write for MultiplexWriter<W> {
 
         if total_len <= self.buffer_size {
             for buf in bufs {
-                self.buffer.extend_from_slice(buf);
+                self.buffer.push(buf);
             }
         } else {
-            // Large vectored write: send MSG_DATA frame directly to inner writer.
-            // Writes header + each slice sequentially, avoiding an intermediate
-            // Vec allocation.
-            let header = MessageHeader::new(MessageCode::Data, total_len as u32)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-            let header_bytes = header.encode();
-            self.inner.write_all(&header_bytes)?;
-            for buf in bufs {
-                self.inner.write_all(buf)?;
-            }
+            self.write_frame(MessageCode::Data, total_len, bufs.iter().map(|b| &b[..]))?;
             self.dirty = true;
             self.last_io_out = Instant::now();
         }
@@ -411,6 +467,192 @@ mod keepalive_tests {
         assert!(
             !w.maybe_send_keepalive().unwrap(),
             "second call must not fire until the lull elapses again"
+        );
+    }
+}
+
+/// Tests for the framing guarantees the reserved-header buffer provides.
+///
+/// The contract under test is upstream's, from io.c: the `MSG_DATA` header is
+/// back-filled inside the buffer before any syscall (io.c:687-688), a write
+/// that fits does no I/O (io.c:2255-2284), and nothing can be scheduled between
+/// a header and the end of its payload.
+#[cfg(test)]
+mod framing_tests {
+    use super::*;
+    use protocol::{MESSAGE_HEADER_LEN, MessageHeader};
+
+    /// Writer that records every accepted span and refuses everything past a
+    /// byte budget, modelling a socket buffer filling at an arbitrary offset.
+    struct StallingWriter {
+        sink: Vec<u8>,
+        budget: usize,
+        writes: usize,
+    }
+
+    impl StallingWriter {
+        fn new(budget: usize) -> Self {
+            Self {
+                sink: Vec::new(),
+                budget,
+                writes: 0,
+            }
+        }
+    }
+
+    impl Write for StallingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if self.budget == 0 {
+                return Err(io::Error::new(io::ErrorKind::WouldBlock, "socket full"));
+            }
+            let n = buf.len().min(self.budget);
+            self.sink.extend_from_slice(&buf[..n]);
+            self.budget -= n;
+            self.writes += 1;
+            Ok(n)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Decodes a complete multiplex stream into `(code, payload)` pairs,
+    /// failing if any frame is torn.
+    fn parse_frames(mut wire: &[u8]) -> Vec<(MessageCode, Vec<u8>)> {
+        let mut frames = Vec::new();
+        while !wire.is_empty() {
+            assert!(
+                wire.len() >= MESSAGE_HEADER_LEN,
+                "trailing bytes are not a whole header: {} left",
+                wire.len()
+            );
+            let header = MessageHeader::decode(&wire[..MESSAGE_HEADER_LEN]).expect("valid header");
+            let len = header.payload_len_usize();
+            let end = MESSAGE_HEADER_LEN + len;
+            assert!(
+                wire.len() >= end,
+                "frame claims {len} payload bytes but only {} follow the header",
+                wire.len() - MESSAGE_HEADER_LEN
+            );
+            frames.push((header.code(), wire[MESSAGE_HEADER_LEN..end].to_vec()));
+            wire = &wire[end..];
+        }
+        frames
+    }
+
+    /// Requirement 13: a write whose bytes fit performs no I/O at all, so N
+    /// small writes cost exactly one underlying write at flush, not N.
+    /// upstream: io.c:2263-2264 - `write_buf()` reaches `perform_io()` only when
+    /// `out.len + len > out.size`.
+    #[test]
+    fn small_writes_cost_one_underlying_write_at_flush() {
+        let mut writer = MultiplexWriter::new(StallingWriter::new(usize::MAX));
+        for i in 0..64u8 {
+            writer.write_all(&[i; 8]).unwrap();
+        }
+        assert_eq!(writer.inner.writes, 0, "buffered writes issue no I/O");
+
+        writer.flush().unwrap();
+        assert_eq!(writer.inner.writes, 1, "one write for sixty-four appends");
+
+        let expected: Vec<u8> = (0..64u8).flat_map(|i| [i; 8]).collect();
+        assert_eq!(
+            parse_frames(&writer.inner.sink),
+            vec![(MessageCode::Data, expected)]
+        );
+    }
+
+    /// A stall at any byte offset of a frame must leave the wire holding an
+    /// in-order prefix and nothing else; resuming completes the same frame with
+    /// no byte re-sent or lost, and a control frame queued afterwards still
+    /// lands strictly after the payload it followed.
+    #[test]
+    fn stall_at_any_offset_never_tears_a_frame() {
+        let payload: Vec<u8> = (0..96u16).map(|i| (i * 5) as u8).collect();
+        let frame_len = MESSAGE_HEADER_LEN + payload.len();
+
+        for stall_at in 0..frame_len {
+            let mut writer = MultiplexWriter::new(StallingWriter::new(stall_at));
+            writer.write_all(&payload).unwrap();
+
+            let err = writer.flush().expect_err("the flush must stall");
+            assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+            assert_eq!(
+                writer.inner.sink.len(),
+                stall_at,
+                "only the accepted prefix reached the wire"
+            );
+
+            writer.inner.budget = usize::MAX;
+            writer.flush().unwrap();
+            writer.send_message(MessageCode::Info, b"after").unwrap();
+
+            assert_eq!(
+                parse_frames(&writer.inner.sink),
+                vec![
+                    (MessageCode::Data, payload.clone()),
+                    (MessageCode::Info, b"after".to_vec()),
+                ],
+                "stalled at offset {stall_at}"
+            );
+        }
+    }
+
+    /// A control frame is never scheduled between a `MSG_DATA` header and the
+    /// end of its payload: buffered data is flushed as a complete frame first.
+    /// upstream keeps `MSG_*` in a separate buffer for exactly this reason
+    /// (io.c:680-681 puts the in-progress raw run first).
+    #[test]
+    fn control_frame_never_splits_a_data_payload() {
+        let mut writer = MultiplexWriter::new(StallingWriter::new(usize::MAX));
+        writer.write_all(b"data-one").unwrap();
+        writer.send_message(MessageCode::Info, b"info").unwrap();
+        writer.write_all(b"data-two").unwrap();
+        writer.send_message(MessageCode::Error, b"err").unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(
+            parse_frames(&writer.inner.sink),
+            vec![
+                (MessageCode::Data, b"data-one".to_vec()),
+                (MessageCode::Info, b"info".to_vec()),
+                (MessageCode::Data, b"data-two".to_vec()),
+                (MessageCode::Error, b"err".to_vec()),
+            ]
+        );
+    }
+
+    /// A payload too large for the circular buffer is staged contiguously and
+    /// still leaves as one intact frame, header included.
+    #[test]
+    fn oversized_payload_stays_one_intact_frame() {
+        let payload = vec![0xA5u8; DEFAULT_BUFFER_SIZE + 1024];
+        let mut writer = MultiplexWriter::new(StallingWriter::new(usize::MAX));
+        writer.write_all(b"lead").unwrap();
+        writer.write_all(&payload).unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(
+            parse_frames(&writer.inner.sink),
+            vec![
+                (MessageCode::Data, b"lead".to_vec()),
+                (MessageCode::Data, payload),
+            ]
+        );
+    }
+
+    /// The oversized-frame staging buffer must not stay resident: upstream keeps
+    /// steady-state memory bounded by never growing its buffers (io.c:579, 594).
+    #[test]
+    fn oversized_staging_buffer_is_released() {
+        let mut writer = MultiplexWriter::new(StallingWriter::new(usize::MAX));
+        writer
+            .write_all(&vec![7u8; DEFAULT_BUFFER_SIZE * 4])
+            .unwrap();
+        assert!(
+            writer.scratch.capacity() <= SCRATCH_RETAIN,
+            "a one-off large frame must not pin its staging allocation"
         );
     }
 }


### PR DESCRIPTION
Phase 1 of converging the I/O core on upstream rsync 3.4.4 (#6946). It is
**wire-neutral**: framing decisions, buffer thresholds, message ordering and
byte output are all unchanged. What changes is the *mechanism* underneath, so
the three ways the current stack can corrupt or desync a stream stop being
possible by construction.

## Upstream mechanisms reproduced

| Upstream | Behaviour |
|---|---|
| `io.c:2461-2462` | The 4-byte `MSG_DATA` header is **reserved in place** inside the output buffer when multiplexing starts (`raw_data_header_pos = out.pos + out.len; out.len += 4;`). |
| `io.c:687-688` | It is **back-filled at flush time** (`SIVAL(... + out.len - 4)`), so header and payload are adjacent bytes of one buffer before any syscall. |
| `io.c:2255-2284` | `write_buf()` reaches `perform_io()` **only** when `out.len + len > out.size`, so a write that fits does no I/O at all. |
| `io.c:579` / `io.c:594` | "We never resize the circular input buffer." / the same for the output buffer. Both are allocated once; an oversize request is a protocol error, never a growth. |
| `io.c:838-877` | The drain writes one contiguous span, advances `pos`/`len` with wrap, and resumes from `out->pos`. Upstream does **not** promise one `write()` per frame - a short write may split anywhere, including mid-header. |
| `io.c:480-513` | A header that would straddle the physical end temporarily reduces the buffer's size; the low byte of a 1024-aligned size is the "was reduced" marker (`io.c:129-136`). |

New `protocol::iobuf` holds `OutBuf` (circular, reserved header, resumable
drain) and `InBuf`/`IoBufReader` (fixed 32 KiB, never resized). New
`protocol::FrameReader` is a resumable multiplex frame decoder.

## Corruption hazards fixed

1. **Torn `MSG_DATA` frame on the wire** - `crates/transfer/src/writer/multiplex.rs:301-307`
   wrote the frame header and then each payload slice as *separate* `write_all`
   calls. A failure between them leaves a header on the wire whose payload never
   follows. The header now lives inside the buffer and leaves through the same
   drain loop; the one payload too large to buffer is staged contiguously before
   a single write.
2. **A control frame scheduled inside a `MSG_DATA` payload** - same call site.
   Once a header has been written but its body has not, any `send_message()`
   would land in the middle of the payload the receiver is still counting.
   Upstream prevents this structurally by keeping `MSG_*` in a separate buffer
   and putting the in-progress raw run first in the fd-selection test
   (`io.c:680-681`).
3. **Demultiplexer desync on a partial frame** -
   `crates/protocol/src/multiplex/helpers.rs:119-145` (`read_payload_into`)
   retried only `Interrupted`, so a partial frame plus any transient error
   propagated as fatal *and discarded the bytes already received*. The retry
   then resynchronised on the middle of a frame. `FrameReader` keeps the frame's
   progress across calls and resumes on the exact byte it stopped on.

The `out_empty_len` trap is handled by the type: `OutBuf::is_empty()` is
`len == out_empty_len` (4 when multiplexed), never `len == 0`, so an idle
keepalive poll cannot flush a bodiless header.

## Wire-neutrality evidence

Both builds (this branch and `master`) ran the same transfers through a tee'ing
`rsh` wrapper with a fixed `--checksum-seed`, capturing every byte in both
directions. All streams compare byte-identical:

```
IDENTICAL: delta-push     (c2s 492789 / s2c 19748)   -a -i --delete --stats
IDENTICAL: delta-pull     (c2s 19745  / s2c 492804)  -a -i --delete --stats
IDENTICAL: compress-push  (c2s 480623 / s2c 19766)   -a -z --stats
IDENTICAL: compress-pull  (c2s 19758  / s2c 480658)  -a -z --stats
IDENTICAL: checksum-push  (c2s 493462 / s2c 19741)   -a -c -i --stats
IDENTICAL: whole-push     (c2s 6078274 / s2c 151)    -a -W --stats
IDENTICAL: verbose-pull   (c2s / s2c)                -avv --stats
```

Interop against upstream rsync **3.4.4** (protocol 32) on Linux/aarch64: oc
client to upstream server, upstream client to oc server, upstream 3.4.4 pull
from and push to an oc daemon - all succeed with matching trees.

## Buffer sizing note

`OutBuf` is allocated as `ROUND_UP_1024(data_capacity + 4)`, so the existing
64 KiB payload threshold is preserved exactly rather than becoming 65532 bytes.
Adopting upstream's literal `out.size = 64 KiB` would shift frame boundaries by
four bytes, which is a wire change and therefore belongs to Phase 2 alongside
`write_bigbuf` chunking.

## Deferred to Phase 2

- `perform_io`, the single `select` loop, and the interleaved drain
  (`io.c:882-889`) - the actual anti-deadlock mechanism.
- Setting the descriptors non-blocking (`main.c:1259-1260`, `1292-1295`). They
  stay blocking here, which is what keeps this phase wire-neutral.
- The separate `msg` buffer and its non-sender-only doubling
  (`io.c:992-1002`); with no `msg` buffer in this phase there is no asymmetry to
  implement yet.
- `write_bigbuf` chunking (`io.c:2242-2253`), which would remove the single
  remaining oversized-frame staging path.
- `DrainingReader`, the drain thread and `should_arm_delta_drain` are untouched;
  they stay load-bearing until Phase 2's core proves the same interleaving
  guarantee.
- Timeout and keepalive behaviour is unchanged.

## Tests

- `protocol::iobuf` - golden bytes for a flush that wraps the circular end,
  the temporary size reduction for a straddling header, a stall at every byte
  offset of a frame resuming without loss, and buffers proven never to resize.
- `protocol::FrameReader` - a stall at every offset (mid-header and mid-payload)
  resumes the same frame; EOF mid-payload still truncates to what arrived.
- `transfer::writer::multiplex` - N small writes cost exactly one underlying
  write at flush; a stall at any offset never tears a frame; a control frame
  never splits a data payload; an oversized payload stays one intact frame.
- `transfer::reader::multiplex` - a one-byte-at-a-time reader stalling at every
  offset of a two-frame stream resumes without desync.

`cargo test -p protocol`, `cargo test -p transfer`, `cargo test -p daemon` and
`cargo test -p core` are green, plus `cargo fmt --all -- --check` and
`cargo clippy --workspace --all-features --all-targets`.
