### PR TITLE
fix(metadata): honour user_only on the generator xattr diff

### DIFF
--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -284,7 +284,7 @@ pub use special::{
     create_fifo, create_fifo_node_from_parts, create_fifo_with_fake_super,
 };
 
-pub use xattr_send::XattrSendOptions;
+pub use xattr_send::{XattrRole, XattrSendOptions};
 
 #[cfg(all(feature = "xattr", any(unix, windows)))]
 pub use xattr::{

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -43,11 +43,11 @@ fn is_root() -> bool {
 /// Returns upstream's `user_only` value for the receiver/local xattr paths.
 ///
 /// upstream: xattrs.c:237 `int user_only = am_sender ? 0 : !am_root;` - the
-/// sender never restricts to the user namespace (see [`read_xattrs_for_wire`],
-/// which passes `user_only = false`); every receiver-side or local-copy path
-/// restricts a non-root process to the `user.*` namespace, matching upstream's
-/// non-root receiver behaviour (`xattrs.c:830` allows a non-root process to
-/// store only the user namespace).
+/// sender never restricts to the user namespace (see
+/// [`XattrRole::user_only`](crate::xattr_send::XattrRole::user_only)); every
+/// receiver-side or local-copy path restricts a non-root process to the
+/// `user.*` namespace, matching upstream's non-root receiver behaviour
+/// (`xattrs.c:830` allows a non-root process to store only the user namespace).
 fn receiver_user_only() -> bool {
     #[cfg(target_os = "linux")]
     {
@@ -168,7 +168,9 @@ fn remove_attribute(path: &Path, name: &[u8], follow_symlinks: bool) -> Result<(
 /// Per attribute the selection reproduces `rsync_xal_get()` in upstream order:
 ///
 /// 1. The `x`-modifier filter, if any, decides alone; otherwise the namespace
-///    rule applies. The two are mutually exclusive (`xattrs.c:250-257`).
+///    rule applies. The two are mutually exclusive (`xattrs.c:250-257`). The
+///    namespace rule keys on `user_only` (`xattrs.c:237`), which is `0` for
+///    the sender and `!am_root` for the generator.
 /// 2. The `rsync.%FOO` internal-attribute gate (`xattrs.c:260-267`): a sender
 ///    below `-XX` drops them all, and `--fake-super` additionally drops the
 ///    three store attributes at any level.
@@ -195,10 +197,14 @@ pub fn read_xattrs_for_wire(
     let screen = if opts.filter.is_some() {
         NamespaceScreen::Bypass
     } else {
-        // upstream: xattrs.c:237 - the sender sets user_only=0, so a non-root
+        // upstream: xattrs.c:237 - `user_only = am_sender ? 0 : !am_root`. The
         // sender skips only the system.* namespace and still transmits user.*,
-        // security.* (e.g. SELinux labels), and trusted.* xattrs.
-        NamespaceScreen::Apply { user_only: false }
+        // security.* (e.g. SELinux labels), and trusted.*; a non-root
+        // generator reading the destination to diff it keeps user.* alone, so
+        // a namespace it could never store cannot flip the itemize `x` column.
+        NamespaceScreen::Apply {
+            user_only: opts.user_only(),
+        }
     };
     let attrs = list_attributes(path, opts.follow_symlinks, screen)?;
     let mut entries = Vec::with_capacity(attrs.len());
@@ -219,7 +225,7 @@ pub fn read_xattrs_for_wire(
         // never copied while --fake-super is active (am_root < 0), because
         // they describe this side's store rather than the file's metadata.
         if is_rsync_internal(&name_str)
-            && (opts.preserve_xattrs < 2
+            && ((opts.role.is_sender() && opts.preserve_xattrs < 2)
                 || (opts.fake_super && is_fake_super_store_attr(&name_str)))
         {
             continue;
@@ -505,6 +511,7 @@ fn is_reserved_sddl_xattr(name: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::xattr_send::XattrRole;
     use protocol::xattr::XattrEntry;
     use std::fs;
     use tempfile::tempdir;
@@ -905,7 +912,7 @@ mod tests {
             &file,
             &XattrSendOptions {
                 preserve_xattrs: 1,
-                ..XattrSendOptions::default()
+                ..XattrSendOptions::new(XattrRole::Sender)
             },
         )
         .expect("read at level 1");
@@ -922,7 +929,7 @@ mod tests {
             &file,
             &XattrSendOptions {
                 preserve_xattrs: 2,
-                ..XattrSendOptions::default()
+                ..XattrSendOptions::new(XattrRole::Sender)
             },
         )
         .expect("read at level 2");
@@ -971,7 +978,7 @@ mod tests {
             &XattrSendOptions {
                 preserve_xattrs: 2,
                 fake_super: true,
-                ..XattrSendOptions::default()
+                ..XattrSendOptions::new(XattrRole::Sender)
             },
         )
         .expect("read under fake-super");
@@ -986,6 +993,103 @@ mod tests {
         assert!(
             wire_contains(&list, &other_name),
             "--fake-super gates only %stat/%aacl/%dacl, not every rsync.% name",
+        );
+    }
+
+    /// The generator keeps `rsync.%FOO` at a single `-X`, the sender does not.
+    ///
+    /// Upstream's strip is `am_sender && preserve_xattrs < 2`, so the role is
+    /// load-bearing: the generator reads the destination to diff it, and a
+    /// destination that already carries the store must compare equal to a
+    /// sender list that carries it too. Dropping it on the generator side
+    /// would make every `-XX` re-run report a phantom `x` change.
+    ///
+    /// upstream: xattrs.c:262 - `if ((am_sender && preserve_xattrs < 2) ...)`
+    #[test]
+    fn generator_keeps_the_rsync_store_at_a_single_x() {
+        let dir = tempdir().expect("create temp dir");
+        let file = dir.path().join("dest.txt");
+        fs::write(&file, "content").expect("write file");
+
+        if !xattrs_supported(&file) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        let stat_name = internal_xattr_name("stat");
+        if write_attribute(&file, &stat_name, b"100644 0,0 0:0", false).is_err() {
+            eprintln!("filesystem rejects rsync.% names, skipping test");
+            return;
+        }
+
+        let generator = read_xattrs_for_wire(
+            &file,
+            &XattrSendOptions {
+                preserve_xattrs: 1,
+                ..XattrSendOptions::new(XattrRole::Generator)
+            },
+        )
+        .expect("read as the generator");
+        assert!(
+            wire_contains(&generator, &stat_name),
+            "the rsync.% strip is gated on am_sender, so the generator keeps it",
+        );
+
+        let sender = read_xattrs_for_wire(
+            &file,
+            &XattrSendOptions {
+                preserve_xattrs: 1,
+                ..XattrSendOptions::new(XattrRole::Sender)
+            },
+        )
+        .expect("read as the sender");
+        assert!(
+            !wire_contains(&sender, &stat_name),
+            "the sender must still strip the store below -XX",
+        );
+    }
+
+    /// A non-root generator screens away every namespace it could not store.
+    ///
+    /// This is what keeps the itemize `x` column honest: upstream's non-root
+    /// receiver can only write `user.*` (`xattrs.c:830`), so comparing a
+    /// `security.*` or `trusted.*` name it will never touch would report a
+    /// change that upstream does not report and that no transfer could ever
+    /// settle. The sender is exempt at any privilege level, which is why the
+    /// role - not `am_root` alone - decides.
+    ///
+    /// upstream: xattrs.c:237 - `int user_only = am_sender ? 0 : !am_root;`
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn non_root_generator_screens_out_non_user_namespaces() {
+        let cases = [
+            "user.mine",
+            "security.selinux",
+            "trusted.overlay.opaque",
+            "system.posix_acl_access",
+        ];
+
+        let permitted = |role: XattrRole, am_root: bool| {
+            cases
+                .into_iter()
+                .filter(|name| is_xattr_permitted(name, role.user_only(am_root)))
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(
+            permitted(XattrRole::Generator, false),
+            vec!["user.mine"],
+            "a non-root generator diffs the user namespace alone",
+        );
+        assert_eq!(
+            permitted(XattrRole::Generator, true),
+            vec!["user.mine", "security.selinux", "trusted.overlay.opaque"],
+            "a root generator regains everything but system.*",
+        );
+        assert_eq!(
+            permitted(XattrRole::Sender, false),
+            vec!["user.mine", "security.selinux", "trusted.overlay.opaque"],
+            "am_sender pins user_only to 0, so an unprivileged sender is unchanged",
         );
     }
 
@@ -1015,7 +1119,7 @@ mod tests {
             &file,
             &XattrSendOptions {
                 filter: Some(&predicate),
-                ..XattrSendOptions::default()
+                ..XattrSendOptions::new(XattrRole::Sender)
             },
         )
         .expect("read with filter");
@@ -1059,8 +1163,8 @@ mod tests {
         }
 
         // Without a filter the namespace rule drops it (xattrs.c:256).
-        let unfiltered =
-            read_xattrs_for_wire(&file, &XattrSendOptions::default()).expect("read without filter");
+        let unfiltered = read_xattrs_for_wire(&file, &XattrSendOptions::new(XattrRole::Sender))
+            .expect("read without filter");
         assert!(
             !wire_contains(&unfiltered, &system_name),
             "the namespace rule drops system.* for a non-root sender",
@@ -1073,7 +1177,7 @@ mod tests {
             &file,
             &XattrSendOptions {
                 filter: Some(&admit_all),
-                ..XattrSendOptions::default()
+                ..XattrSendOptions::new(XattrRole::Sender)
             },
         )
         .expect("read with filter");
@@ -1108,7 +1212,8 @@ mod tests {
         write_attribute(&file, &test_xattr_name("mmm"), b"m", false).expect("write mmm");
         write_attribute(&file, &test_xattr_name("zzz"), b"z", false).expect("write zzz");
 
-        let list = read_xattrs_for_wire(&file, &XattrSendOptions::default()).expect("read xattrs");
+        let list = read_xattrs_for_wire(&file, &XattrSendOptions::new(XattrRole::Sender))
+            .expect("read xattrs");
         let entries = list.entries();
         assert!(entries.len() >= 3, "expected at least our three xattrs");
 

--- a/crates/metadata/src/xattr_send.rs
+++ b/crates/metadata/src/xattr_send.rs
@@ -7,7 +7,48 @@
 //! same inputs travel as an explicit options record rather than a long
 //! positional parameter list.
 
-/// Inputs that steer sender-side xattr collection.
+/// Which side of the transfer is collecting the attributes.
+///
+/// Upstream reads this from the `am_sender` global in two places:
+/// `xattrs.c:237` (`user_only`) and `xattrs.c:262` (the `rsync.%FOO` strip).
+/// Both consult the role, so it cannot be folded into another field.
+///
+/// The enum deliberately has no `Default`: the two roles select different
+/// namespaces for a non-root process, so a call site that omits the role would
+/// silently collect the wrong set of attributes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum XattrRole {
+    /// Upstream's `am_sender != 0`: the file-list builder describing a source
+    /// file to the peer.
+    Sender,
+    /// Upstream's `am_sender == 0`: the generator reading the destination in
+    /// order to diff it against the sender's list, and every other
+    /// receiver-side read.
+    Generator,
+}
+
+impl XattrRole {
+    /// Upstream's `user_only` for this role at the given privilege level.
+    ///
+    /// upstream: `xattrs.c:237` - `int user_only = am_sender ? 0 : !am_root;`
+    /// The sender never restricts to the `user.*` namespace; a non-root
+    /// generator always does.
+    #[must_use]
+    pub fn user_only(self, am_root: bool) -> bool {
+        match self {
+            Self::Sender => false,
+            Self::Generator => !am_root,
+        }
+    }
+
+    /// Whether this role is upstream's `am_sender`.
+    #[must_use]
+    pub fn is_sender(self) -> bool {
+        matches!(self, Self::Sender)
+    }
+}
+
+/// Inputs that steer xattr collection for the wire.
 ///
 /// Mirrors the globals consulted by upstream `xattrs.c:rsync_xal_get()`
 /// (lines 231-300).
@@ -20,19 +61,21 @@
 /// - `xattrs.c:260-267` - the `rsync.%FOO` internal-attribute gate
 #[derive(Clone, Copy)]
 pub struct XattrSendOptions<'a> {
+    /// Which side is reading (upstream's `am_sender`).
+    pub role: XattrRole,
     /// Resolve a symlink before reading (`getxattr`) instead of reading the
     /// link itself (`lgetxattr`).
     pub follow_symlinks: bool,
-    /// Whether the reading process is privileged, which is what lets the
-    /// `system.*` namespace reach the wire.
+    /// Whether the reading process is privileged (upstream's `am_root`).
+    ///
+    /// It decides two things: whether a generator read is confined to the
+    /// `user.*` namespace (`xattrs.c:237`), and whether the `system.*`
+    /// namespace can reach the wire at all.
     pub am_root: bool,
     /// Xattr preservation level: 1 for `-X`, 2 for `-XX`.
     ///
     /// Upstream gates the `rsync.%FOO` strip on `am_sender && preserve_xattrs
-    /// < 2`. There is no separate `am_sender` field here: a caller that is not
-    /// the sender (upstream's generator comparing the destination) passes level
-    /// 2, which reproduces `am_sender == 0` exactly, because the strip is the
-    /// only place the role is consulted.
+    /// < 2`, so this only matters for [`XattrRole::Sender`].
     pub preserve_xattrs: u8,
     /// Whether `--fake-super` is active (upstream's `am_root < 0`).
     ///
@@ -52,14 +95,21 @@ pub struct XattrSendOptions<'a> {
     pub checksum_seed: i32,
 }
 
-impl Default for XattrSendOptions<'_> {
-    /// A plain single `-X` read: unprivileged, no fake-super, no filter.
+impl XattrSendOptions<'_> {
+    /// Base options for `role`: a plain single `-X` read by an unprivileged
+    /// process, with no fake-super and no filter.
     ///
-    /// The level defaults to 1 rather than 0 so that a caller which forgets to
-    /// set it gets the conservative `-X` behaviour (strip `rsync.%FOO`) instead
-    /// of silently transmitting the fake-super store.
-    fn default() -> Self {
+    /// Intended as the tail of a struct-update expression so that every call
+    /// site names its role. There is deliberately no `Default`, because the
+    /// role has no safe default.
+    ///
+    /// The level starts at 1 rather than 0 so that a caller which does not set
+    /// it gets the conservative `-X` behaviour (strip `rsync.%FOO`) instead of
+    /// silently transmitting the fake-super store.
+    #[must_use]
+    pub fn new(role: XattrRole) -> Self {
         Self {
+            role,
             follow_symlinks: false,
             am_root: false,
             preserve_xattrs: 1,
@@ -67,5 +117,58 @@ impl Default for XattrSendOptions<'_> {
             filter: None,
             checksum_seed: 0,
         }
+    }
+
+    /// Upstream's `user_only` for these options (`xattrs.c:237`).
+    #[must_use]
+    pub fn user_only(&self) -> bool {
+        self.role.user_only(self.am_root)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{XattrRole, XattrSendOptions};
+
+    /// `user_only` is a function of the role first and privilege second.
+    ///
+    /// Reading it off `am_root` alone would confine an unprivileged *sender*
+    /// to `user.*` and drop SELinux labels from the wire; reading it off the
+    /// role alone would let a root generator ignore namespaces it can store.
+    ///
+    /// upstream: xattrs.c:237 - `int user_only = am_sender ? 0 : !am_root;`
+    #[test]
+    fn user_only_mirrors_the_upstream_ternary() {
+        assert!(!XattrRole::Sender.user_only(false));
+        assert!(!XattrRole::Sender.user_only(true));
+        assert!(XattrRole::Generator.user_only(false));
+        assert!(!XattrRole::Generator.user_only(true));
+    }
+
+    /// The options record derives `user_only` from the fields it carries, so a
+    /// call site cannot set the privilege level and forget the role.
+    #[test]
+    fn options_derive_user_only_from_role_and_privilege() {
+        let generator = XattrSendOptions::new(XattrRole::Generator);
+        assert!(generator.user_only(), "unprivileged generator");
+        assert!(
+            !XattrSendOptions {
+                am_root: true,
+                ..generator
+            }
+            .user_only(),
+            "root generator",
+        );
+        assert!(!XattrSendOptions::new(XattrRole::Sender).user_only());
+    }
+
+    /// The role also drives the `rsync.%FOO` strip, which is why it is a field
+    /// rather than something inferred from the preservation level.
+    ///
+    /// upstream: xattrs.c:262 - `am_sender && preserve_xattrs < 2`
+    #[test]
+    fn is_sender_reports_the_upstream_am_sender_global() {
+        assert!(XattrRole::Sender.is_sender());
+        assert!(!XattrRole::Generator.is_sender());
     }
 }

--- a/crates/metadata/src/xattr_stub.rs
+++ b/crates/metadata/src/xattr_stub.rs
@@ -83,6 +83,7 @@ pub fn apply_xattrs_from_list(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::xattr_send::XattrRole;
     use std::path::Path;
 
     #[test]
@@ -105,7 +106,7 @@ mod tests {
     #[test]
     fn read_xattrs_for_wire_returns_empty_list() {
         let path = Path::new("/nonexistent/file");
-        let result = read_xattrs_for_wire(path, &XattrSendOptions::default()).unwrap();
+        let result = read_xattrs_for_wire(path, &XattrSendOptions::new(XattrRole::Sender)).unwrap();
         assert!(result.is_empty());
     }
 
@@ -117,7 +118,7 @@ mod tests {
             am_root: true,
             preserve_xattrs: 2,
             checksum_seed: 42,
-            ..XattrSendOptions::default()
+            ..XattrSendOptions::new(XattrRole::Sender)
         };
         let result = read_xattrs_for_wire(path, &opts).unwrap();
         assert!(result.is_empty());

--- a/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
+++ b/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
@@ -50,7 +50,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use metadata::{XattrSendOptions, read_xattrs_for_wire};
+use metadata::{XattrRole, XattrSendOptions, read_xattrs_for_wire};
 use tempfile::tempdir;
 
 /// Bare stream name written via the NTFS `path:streamname` path syntax.
@@ -131,7 +131,7 @@ fn assert_wire_entry(path: &Path, wire_name: &[u8], expected: &[u8]) {
         path,
         &XattrSendOptions {
             am_root: true,
-            ..XattrSendOptions::default()
+            ..XattrSendOptions::new(XattrRole::Sender)
         },
     )
     .expect("read xattrs back");
@@ -265,7 +265,7 @@ fn ads_multi_stream_round_trips() {
         &src_file,
         &XattrSendOptions {
             am_root: true,
-            ..XattrSendOptions::default()
+            ..XattrSendOptions::new(XattrRole::Sender)
         },
     )
     .expect("list source streams");

--- a/crates/metadata/tests/windows_long_path_metadata.rs
+++ b/crates/metadata/tests/windows_long_path_metadata.rs
@@ -36,7 +36,8 @@ use std::path::{Path, PathBuf};
 
 use metadata::windows::classify_path;
 use metadata::{
-    XattrSendOptions, apply_xattrs_from_list, read_dacl_sddl, read_xattrs_for_wire, write_dacl_sddl,
+    XattrRole, XattrSendOptions, apply_xattrs_from_list, read_dacl_sddl, read_xattrs_for_wire,
+    write_dacl_sddl,
 };
 use protocol::xattr::{XattrEntry, XattrList};
 use tempfile::tempdir;
@@ -194,8 +195,8 @@ fn long_path_ads_round_trip() {
     // `xattr_windows::path_to_wide` feeding `FindFirstStreamW`. The wire
     // encoder prefixes the local stream name with `user.` on non-Linux
     // peers (matches upstream xattrs.c:518-530).
-    let wire =
-        read_xattrs_for_wire(&file, &XattrSendOptions::default()).expect("read ADS on long path");
+    let wire = read_xattrs_for_wire(&file, &XattrSendOptions::new(XattrRole::Sender))
+        .expect("read ADS on long path");
     let expected_wire_name: &[u8] = b"user.Zone.Identifier";
     let entry = wire
         .iter()

--- a/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
+++ b/crates/metadata/tests/windows_to_linux_acl_roundtrip.rs
@@ -58,7 +58,7 @@ use std::path::Path;
 
 use metadata::apply_xattrs_from_list;
 #[cfg(unix)]
-use metadata::{XattrSendOptions, read_xattrs_for_wire};
+use metadata::{XattrRole, XattrSendOptions, read_xattrs_for_wire};
 use protocol::xattr::{XattrEntry, XattrList};
 use tempfile::tempdir;
 
@@ -145,7 +145,7 @@ fn read_back(path: &Path) -> Vec<(Vec<u8>, Vec<u8>)> {
         path,
         &XattrSendOptions {
             am_root: true,
-            ..XattrSendOptions::default()
+            ..XattrSendOptions::new(XattrRole::Sender)
         },
     )
     .expect("read xattrs back");

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -352,8 +352,10 @@ impl GeneratorContext {
                 let predicate =
                     xattr_filter.map(|set| move |name: &str| set.xattr_name_allowed(name));
                 let opts = metadata::XattrSendOptions {
+                    role: metadata::XattrRole::Sender,
                     follow_symlinks: follow,
-                    // upstream: xattrs.c:237 - the sender sets user_only = 0 and
+                    // upstream: xattrs.c:237 - `am_sender` forces user_only = 0,
+                    // so the sender transmits every namespace but system.*, and
                     // never claims root, so system.* stays local.
                     am_root: false,
                     // upstream: xattrs.c:262 - `am_sender && preserve_xattrs < 2`

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -707,12 +707,16 @@ impl ReceiverContext {
     /// the destination still carries some.
     pub(in crate::receiver) fn dest_xattrs_differ(&self, entry: &FileEntry, path: &Path) -> bool {
         let opts = metadata::XattrSendOptions {
+            role: metadata::XattrRole::Generator,
             follow_symlinks: false,
+            // upstream: xattrs.c:237 - `user_only = am_sender ? 0 : !am_root`,
+            // so a non-root generator sees only the `user.*` namespace here. A
+            // `security.*` or `trusted.*` difference it could never store must
+            // not raise the itemize `x` column.
             am_root: metadata::am_root(),
-            // upstream: xattrs.c:262 - the strip is gated on `am_sender`, and
-            // the generator is not the sender, so nothing is stripped here.
-            // Level 2 reproduces that without a separate role field.
-            preserve_xattrs: 2,
+            // upstream: xattrs.c:262 - the strip is gated on `am_sender`, so
+            // the generator keeps rsync.%FOO at either level.
+            preserve_xattrs: self.config.flags.xattrs_level,
             fake_super: self.config.fake_super,
             filter: None,
             checksum_seed: self.checksum_seed,


### PR DESCRIPTION
## Problem

Upstream computes the xattr namespace restriction once, from the role:

```c
/* xattrs.c:237, in rsync_xal_get() */
int user_only = am_sender ? 0 : !am_root;
```

`read_xattrs_for_wire` hardcoded `user_only = false` for every caller, including
`dest_xattrs_differ` - the generator path that reads the destination and feeds
`xattr_diff` for the itemize `x` column. A non-root receiver therefore compared
`security.*` and `trusted.*` names that upstream's generator never looks at, so a
destination-only attribute in one of those namespaces raised an `x` that upstream
does not raise and that no transfer could ever settle (the receiver cannot store
those namespaces at all - `xattrs.c:829-831`).

The `#6943` options record deliberately left this open: it folded the role into
`preserve_xattrs: 2` on the grounds that `xattrs.c:262` was the only place the
role was consulted. `xattrs.c:237` is the second place, and it is the one that
changes what gets compared.

## Change

- `XattrSendOptions` gains `role: XattrRole` (`Sender` / `Generator`), mirroring
  upstream's `am_sender`. `XattrRole::user_only(am_root)` is `xattrs.c:237`
  verbatim.
- The namespace screen now uses that value; the `rsync.%FOO` strip is gated on
  `role.is_sender() && preserve_xattrs < 2`, so the generator no longer needs the
  `preserve_xattrs: 2` stand-in and passes its real `-X`/`-XX` level.
- `Default` is gone. The role has no safe default - a call site that omitted it
  would silently collect the wrong namespace set - so `XattrSendOptions::new(role)`
  forces every construction to name it. Both production call sites
  (`generator/file_list/entry/create.rs` = `Sender`,
  `receiver/transfer/candidates.rs` = `Generator`) name the field directly.

Upstream evaluation order is preserved exactly: `user_only` is computed first, the
filter branch and the namespace branch stay mutually exclusive (a present filter
bypasses the namespace test entirely, `xattrs.c:250-257`), and the `rsync.%` strip
stays last (`xattrs.c:260-267`).

## Verification against rsync 3.4.4

Linux, ext4, unprivileged receiver (uid 1000), reference binary built from source
(`rsync version 3.4.4 protocol version 32`). `trusted.*` needs `CAP_SYS_ADMIN` to
set, so the destination-only attribute is `security.extra`, written with `sudo
setfattr` while file ownership stays with the unprivileged user.

Source and destination hold identical content, identical mtime, and an identical
`user.same`. Only the destination carries `security.extra`. Pull over SSH, so the
non-root receiver runs locally:

```
$ rsync -a -X -i -e ssh localhost:$BASE/src/ $BASE/dst/
--- src: user.same="shared"
--- dst: security.extra="destonly" user.same="shared"
```

| binary | itemize |
|---|---|
| upstream 3.4.4 | *(no output)* |
| oc-rsync before | `.f........x f` |
| oc-rsync after | *(no output)* |

Two controls, same harness, all three binaries agreeing before and after:

- genuine `user.*` value difference -> `.f........x real` from upstream, before,
  and after (the fix does not mute real changes)
- `security.*` present on the **source** only -> no output from any of the three;
  upstream's receiver strips non-`user.*` names out of the sender's list on the
  wire (`xattrs.c:829-831`) and oc already matched that half

## Batch replay

`crates/batch/src/reader/flist.rs:126` does **not** need the role dimension.
`flags.preserve_xattrs` there is a wire-decoding flag: it tells `FileListReader`
whether the recorded flist carries xattr data, mirroring upstream `batch.c:71`
(`&preserve_xattrs` in `flag_ptr[]`), which likewise collapses upstream's `int`
level to a single bit in the batch header. `user_only` is never recorded in a
batch - upstream recomputes it from `am_sender`/`am_root` in the replaying
process - and batch replay reaches the destination read through the same
`dest_xattrs_differ`, so it inherits this fix. Nothing to change.

## Adjacent divergence, not fixed here

`dest_xattrs_differ` passes `filter: None`, so an `x`-modifier filter does not
reach the generator's destination read. Upstream's `saw_xattr_filter` is global
and would bypass the namespace test on that read too (`xattrs.c:250-257`).
Pre-existing and untouched by this change; recorded separately.

## Tests

- `XattrRole::user_only` covers the full `xattrs.c:237` matrix (both roles x both
  privilege levels).
- `non_root_generator_screens_out_non_user_namespaces` (Linux) asserts a non-root
  generator keeps `user.*` alone, a root generator regains everything but
  `system.*`, and an unprivileged sender is unchanged.
- `generator_keeps_the_rsync_store_at_a_single_x` asserts the role-gated
  `rsync.%FOO` strip in both directions.
- The `#6943` tests stay green: `-XX` keeps `rsync.%stat`, `-X` strips it,
  fake-super drops the three store suffixes at any level, and a filter bypasses
  the namespace check.

Validated with `transfer`'s `incremental-flist` feature both on and off, plus
`cargo fmt --all -- --check`, `cargo clippy -p metadata -p transfer --all-features
--all-targets --no-deps -D warnings`, `cargo check --workspace --all-features
--all-targets`, and `cargo test -p transfer --all-features --lib` (2174 passed).
On the Linux host `cargo test --release -p metadata --all-features --lib` reports
483 passed with one pre-existing failure,
`apply::tests::no_perms_new_file_from_entry_gets_umask_masked_source_mode`, which
fails identically on the base commit under that host's `umask 002`.
