### PR TITLE
fix(transfer): report transfer errors via MSG_ERROR_XFER

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -48,7 +48,7 @@ pub(super) fn convert_server_stats_to_summary(
         ServerStats::Generator(_) => Vec::new(),
     };
 
-    let (local_summary, io_error, error_count) = match stats {
+    let (local_summary, io_error, got_xfer_error) = match stats {
         ServerStats::Receiver(ref transfer_stats) => {
             // Daemon-pull: local side ran the receiver and its `--delete`
             // sweep. The per-type counters live on `delete_stats`.
@@ -71,7 +71,7 @@ pub(super) fn convert_server_stats_to_summary(
                     specials: transfer_stats.num_specials,
                 },
             );
-            (s, transfer_stats.io_error, transfer_stats.error_count)
+            (s, transfer_stats.io_error, transfer_stats.got_xfer_error)
         }
         ServerStats::Generator(ref generator_stats) => {
             // Daemon-upload: local side ran the sender/generator. The remote
@@ -97,7 +97,7 @@ pub(super) fn convert_server_stats_to_summary(
                     specials: generator_stats.num_specials,
                 },
             );
-            (s, generator_stats.io_error, 0u32)
+            (s, generator_stats.io_error, generator_stats.got_xfer_error)
         }
     };
 
@@ -110,8 +110,11 @@ pub(super) fn convert_server_stats_to_summary(
     let exit_code = io_error_flags::to_exit_code(io_error);
     if exit_code != 0 {
         summary.set_io_error_exit_code(exit_code);
-    } else if error_count > 0 {
-        // Remote sender reported errors via MSG_ERROR - treat as RERR_PARTIAL (23).
+    } else if got_xfer_error {
+        // upstream: cleanup.c:217-218 - `io_error & IOERR_GENERAL ||
+        // got_xfer_error` lifts a zero exit to RERR_PARTIAL. This is the only
+        // arm a missing source argument reaches, since `flist.c:2431` withholds
+        // IOERR_GENERAL for ENOENT.
         summary.set_io_error_exit_code(23);
     }
 

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -26,7 +26,7 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
     use engine::local_copy::LocalCopySummary;
     use transfer::io_error_flags;
 
-    let (local_summary, io_error, error_count) = match stats {
+    let (local_summary, io_error, got_xfer_error) = match stats {
         ServerStats::Receiver(ref transfer_stats) => {
             // SSH-pull: local side ran the receiver and its `--delete` sweep.
             let s = LocalCopySummary::from_receiver_stats(
@@ -48,7 +48,7 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
                     specials: transfer_stats.num_specials,
                 },
             );
-            (s, transfer_stats.io_error, transfer_stats.error_count)
+            (s, transfer_stats.io_error, transfer_stats.got_xfer_error)
         }
         ServerStats::Generator(ref generator_stats) => {
             // SSH-push: local side ran the sender/generator; the remote
@@ -72,7 +72,7 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
                     specials: generator_stats.num_specials,
                 },
             );
-            (s, generator_stats.io_error, 0u32)
+            (s, generator_stats.io_error, generator_stats.got_xfer_error)
         }
     };
 
@@ -82,8 +82,11 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
     let exit_code = io_error_flags::to_exit_code(io_error);
     if exit_code != 0 {
         summary.set_io_error_exit_code(exit_code);
-    } else if error_count > 0 {
-        // Remote sender reported errors via MSG_ERROR - treat as RERR_PARTIAL.
+    } else if got_xfer_error {
+        // upstream: cleanup.c:217-218 - `io_error & IOERR_GENERAL ||
+        // got_xfer_error` lifts a zero exit to RERR_PARTIAL. This is the only
+        // arm a missing source argument reaches, since `flist.c:2431` withholds
+        // IOERR_GENERAL for ENOENT.
         summary.set_io_error_exit_code(23);
     }
 

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -108,6 +108,18 @@ pub struct GeneratorContext {
     /// I/O error flags accumulated during file list building and transfer.
     /// Uses [`io_error_flags`] constants (IOERR_GENERAL, IOERR_VANISHED, etc.).
     pub(crate) io_error: i32,
+    /// Set once any `FERROR_XFER` diagnostic has been raised by this side or
+    /// received from the peer.
+    ///
+    /// Distinct from [`Self::io_error`]: `io_error` is a wire field the sender
+    /// hands the receiver to inhibit deletions, whereas this flag never leaves
+    /// the process and only decides the final exit code.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:310-311` - `case FERROR_XFER: got_xfer_error = 1;`
+    /// - `cleanup.c:217-218` - `got_xfer_error` maps a zero exit to `RERR_PARTIAL`
+    pub(crate) got_xfer_error: bool,
     /// Diagnostics raised by the file-list walk, paired with the upstream log
     /// class that decides how a server frames them.
     ///
@@ -221,6 +233,7 @@ impl GeneratorContext {
             uid_list: IdList::new(),
             gid_list: IdList::new(),
             io_error: 0,
+            got_xfer_error: false,
             pending_flist_diagnostics: Vec::new(),
             pending_source_removals: super::pending_removal::PendingSourceRemovals::default(),
             incremental: IncrementalState::new(initial_ndx_start),
@@ -642,6 +655,16 @@ impl GeneratorContext {
     #[must_use]
     pub const fn io_error(&self) -> i32 {
         self.io_error
+    }
+
+    /// Returns whether any `FERROR_XFER` diagnostic has been seen.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:310-311` - `case FERROR_XFER: got_xfer_error = 1;`
+    #[must_use]
+    pub const fn got_xfer_error(&self) -> bool {
+        self.got_xfer_error
     }
 
     /// Returns the checksum algorithm to use for file transfer checksums.

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -120,10 +120,16 @@ impl GeneratorContext {
                         self.emit_delete_sentinel(base, path)?;
                         Ok(true)
                     }
-                    // upstream: flist.c:1846 - default: link_stat failed + IOERR_GENERAL
+                    // upstream: flist.c:2428-2436 - default: link_stat failed.
                     _ => {
-                        // FFV-4: emit the correct error message and error flag
-                        // for a source that never existed at flist build time.
+                        // upstream: flist.c:2431 - `if (errno != ENOENT)` guards
+                        // the `io_error |= IOERR_GENERAL`, so a source that
+                        // never existed deliberately leaves io_error clear: that
+                        // bit travels to the receiver and would inhibit its
+                        // deletions, and upstream only wants that "if we might
+                        // be omitting an existing file". The exit code comes
+                        // from got_xfer_error instead, set by the FERROR_XFER
+                        // below on both this side and the peer (log.c:310-311).
                         // upstream: flist.c:2433 - rsyserr(FERROR_XFER, ...)
                         let text = format!(
                             "rsync: [sender] link_stat {} failed: {}\n",
@@ -131,7 +137,6 @@ impl GeneratorContext {
                             engine::local_copy::upstream_io_error(&e),
                         );
                         self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
-                        self.add_io_error(io_error_flags::IOERR_GENERAL);
                         Ok(false)
                     }
                 }

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -349,12 +349,18 @@ impl GeneratorContext {
     ///
     /// - `log.c:330-346` - `am_server` sends the frame and returns
     /// - `log.c:332-337` - `MSG_WARNING` -> `MSG_INFO` downgrade below protocol 30
+    /// - `log.c:310-311` - `case FERROR_XFER: got_xfer_error = 1;`, set before
+    ///   the frame is handed to the peer and regardless of server-vs-client, so
+    ///   a sender that only *reports* the error still exits `RERR_PARTIAL`
     pub(super) fn emit_sender_diagnostic<W: Write>(
-        &self,
+        &mut self,
         writer: &mut super::super::writer::ServerWriter<W>,
         kind: SenderDiagnostic,
         text: &str,
     ) -> io::Result<()> {
+        if kind == SenderDiagnostic::ErrorXfer {
+            self.got_xfer_error = true;
+        }
         if self.config.connection.client_mode || !writer.is_multiplexed() {
             eprint!("{text}");
             return Ok(());

--- a/crates/transfer/src/generator/stats.rs
+++ b/crates/transfer/src/generator/stats.rs
@@ -186,6 +186,19 @@ pub struct GeneratorStats {
     ///
     /// - `main.c:1338-1345`: `log_exit()` maps `io_error` to `RERR_VANISHED` (24).
     pub io_error: i32,
+    /// Upstream's `got_xfer_error`: a per-file transfer error was reported by
+    /// this sender or by the peer via `MSG_ERROR_XFER`.
+    ///
+    /// Unlike `io_error` this carries no wire meaning; it only forces a zero
+    /// exit code up to `RERR_PARTIAL` (23). A missing source argument is the
+    /// case that needs it, because `flist.c:2431` deliberately withholds
+    /// `IOERR_GENERAL` for `ENOENT`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:310-311`: `case FERROR_XFER: got_xfer_error = 1;`
+    /// - `cleanup.c:217-218`: `io_error & IOERR_GENERAL || got_xfer_error` -> 23
+    pub got_xfer_error: bool,
 }
 
 /// Returns `true` when the I/O error indicates an early connection close.

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3888,7 +3888,8 @@ mod files_from {
 
     #[test]
     fn build_file_list_with_base_skips_missing_files() {
-        // FFV-4: default mode emits link_stat error and sets IOERR_GENERAL (exit 23).
+        // Default mode emits the link_stat FERROR_XFER and leaves io_error
+        // clear; the exit code comes from got_xfer_error (upstream flist.c:2431).
         let temp_dir = TempDir::new().unwrap();
         let src = temp_dir.path().join("src");
         std::fs::create_dir_all(&src).unwrap();
@@ -3917,17 +3918,40 @@ mod files_from {
             "no implied root . for a non-anchored list"
         );
 
-        // upstream: flist.c:1846 - ENOENT for a --files-from entry that never
-        // existed should set IOERR_GENERAL (exit 23), not IOERR_VANISHED (exit 24).
-        assert_ne!(
-            ctx.io_error() & io_error_flags::IOERR_GENERAL,
-            0,
-            "missing source should set IOERR_GENERAL"
-        );
+        // upstream: flist.c:2431 - `if (errno != ENOENT) io_error |=
+        // IOERR_GENERAL`. A --files-from entry that never existed takes the
+        // ENOENT arm, so no io_error bit is raised at all: that bit reaches the
+        // receiver (flist.c:2553) and would inhibit its deletions, which
+        // upstream only wants "if we might be omitting an existing file".
+        // Ground truth, rsync 3.4.4, `--files-from` naming a missing entry:
+        // `link_stat ... failed` on stderr and exit 23, with the peer's
+        // deletions still performed.
         assert_eq!(
-            ctx.io_error() & io_error_flags::IOERR_VANISHED,
+            ctx.io_error(),
             0,
-            "missing source should NOT set IOERR_VANISHED"
+            "ENOENT must leave the wire-visible io_error clear"
+        );
+        // upstream: log.c:310-311 - the FERROR_XFER the walk queued is what
+        // sets got_xfer_error, and cleanup.c:217-218 turns that into exit 23.
+        // Set when the queued diagnostic is framed, mirroring `rwrite()`.
+        let mut buf = Vec::new();
+        {
+            let mut writer = crate::writer::ServerWriter::new_plain(&mut buf)
+                .activate_multiplex()
+                .unwrap();
+            ctx.flush_flist_diagnostics(&mut writer).unwrap();
+        }
+        let frames = decode_mux_frames(&buf);
+        assert_eq!(frames.len(), 1, "one link_stat diagnostic: {frames:?}");
+        assert_eq!(
+            frames[0].0,
+            protocol::MessageCode::ErrorXfer,
+            "the missing arg must ride MSG_ERROR_XFER - it is the peer's only \
+             evidence, since io_error stays clear"
+        );
+        assert!(
+            ctx.got_xfer_error(),
+            "framing FERROR_XFER must set got_xfer_error (exit 23)"
         );
     }
 
@@ -4126,8 +4150,12 @@ mod files_from {
     }
 
     #[test]
-    fn build_file_list_default_missing_source_sets_general_error() {
-        // FFV-4 for build_file_list: default mode emits IOERR_GENERAL, not VANISHED.
+    fn build_file_list_default_missing_source_reports_via_error_xfer_only() {
+        // upstream: flist.c:2428-2436 - a top-level source that never existed
+        // takes the `errno == ENOENT` path, which reports FERROR_XFER but skips
+        // `io_error |= IOERR_GENERAL` so the bit the receiver reads (and would
+        // inhibit its deletions on) stays clear. Exit 23 comes from
+        // got_xfer_error instead (log.c:310-311, cleanup.c:217-218).
         let temp_dir = TempDir::new().unwrap();
         let missing = temp_dir.path().join("nonexistent.txt");
 
@@ -4137,15 +4165,31 @@ mod files_from {
 
         ctx.build_file_list(&[missing]).unwrap();
 
-        assert_ne!(
-            ctx.io_error() & io_error_flags::IOERR_GENERAL,
-            0,
-            "default mode should set IOERR_GENERAL for missing source"
-        );
         assert_eq!(
-            ctx.io_error() & io_error_flags::IOERR_VANISHED,
+            ctx.io_error(),
             0,
-            "default mode should NOT set IOERR_VANISHED for top-level missing source"
+            "ENOENT must raise no io_error bit at all - neither IOERR_GENERAL \
+             nor IOERR_VANISHED, which is reserved for a file that vanished \
+             mid-scan (flist.c:1839-1847)"
+        );
+
+        let mut buf = Vec::new();
+        {
+            let mut writer = crate::writer::ServerWriter::new_plain(&mut buf)
+                .activate_multiplex()
+                .unwrap();
+            ctx.flush_flist_diagnostics(&mut writer).unwrap();
+        }
+        let frames = decode_mux_frames(&buf);
+        assert_eq!(frames.len(), 1, "one link_stat diagnostic: {frames:?}");
+        assert_eq!(
+            frames[0].0,
+            protocol::MessageCode::ErrorXfer,
+            "the frame is the peer's only evidence of the missing source"
+        );
+        assert!(
+            ctx.got_xfer_error(),
+            "framing FERROR_XFER must set got_xfer_error (exit 23)"
         );
     }
 

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -148,6 +148,7 @@ impl GeneratorContext {
                 ),
                 flist_first_byte_latency: self.timing.flist_first_byte_latency,
                 io_error: self.io_error,
+                got_xfer_error: self.got_xfer_error,
                 ..GeneratorStats::default()
             });
         }
@@ -352,14 +353,15 @@ impl GeneratorContext {
             .advance_to(TransferPhase::Complete)
             .map_err(crate::fsm_error)?;
 
-        // upstream: log.c:311 - each MSG_ERROR_XFER the peer sends sets
-        // got_xfer_error on receipt; main.c:1635 then _exit(RERR_PARTIAL).
-        // The receiver emits MSG_ERROR_XFER when it cannot open a file's output
-        // (e.g. mkstemp() denied by a read-only destination dir) and discards
-        // the delta. Fold that into io_error so this sender/generator reports
-        // exit 23 instead of a false success.
+        // upstream: log.c:310-311 - each MSG_ERROR_XFER the peer sends sets
+        // got_xfer_error on receipt; cleanup.c:217-218 then reports
+        // RERR_PARTIAL. The receiver emits MSG_ERROR_XFER when it cannot open a
+        // file's output (e.g. mkstemp() denied by a read-only destination dir)
+        // and discards the delta. Recorded as got_xfer_error rather than an
+        // io_error bit: io_error is a wire field with its own meaning for the
+        // peer, and by this point it has already been sent.
         if reader.xfer_error_count() > 0 {
-            self.add_io_error(super::super::io_error_flags::IOERR_GENERAL);
+            self.got_xfer_error = true;
         }
 
         // upstream: handle_stats() reports stats.total_size (main.c:351
@@ -390,6 +392,7 @@ impl GeneratorContext {
             delete_stats: self.delete_stats,
             created_stats: transfer_result.created_stats,
             io_error: self.io_error,
+            got_xfer_error: self.got_xfer_error,
         })
     }
 }

--- a/crates/transfer/src/receiver/stats.rs
+++ b/crates/transfer/src/receiver/stats.rs
@@ -123,12 +123,20 @@ pub struct TransferStats {
     ///
     /// - `flist.c:2553`: `write_int(f, ignore_errors ? 0 : io_error);`
     pub io_error: i32,
-    /// Number of `MSG_ERROR` messages received from the remote sender.
+    /// Upstream's `got_xfer_error`: at least one `MSG_ERROR_XFER` frame arrived
+    /// from the peer.
     ///
-    /// When the sender encounters per-file errors it sends `MSG_ERROR` frames
-    /// that the receiver tallies here. A non-zero count causes the exit code
-    /// to report a partial transfer (`RERR_PARTIAL`, exit 23).
-    pub error_count: u32,
+    /// This is the only thing that reports a missing source argument: upstream
+    /// deliberately leaves `io_error` clear for `ENOENT` (`flist.c:2431`), so
+    /// the sender's `FERROR_XFER` frame is the sole carrier of the failure and
+    /// this flag is what turns it into exit 23.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:1660`: `MSG_ERROR_XFER` -> `rwrite(FERROR_XFER, ...)`
+    /// - `log.c:310-311`: `case FERROR_XFER: got_xfer_error = 1;`
+    /// - `cleanup.c:217-218`: `io_error & IOERR_GENERAL || got_xfer_error` -> 23
+    pub got_xfer_error: bool,
 
     // Incremental mode statistics
     /// Total entries received from wire (incremental mode).

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -160,7 +160,7 @@ fn transfer_stats_has_incremental_fields() {
         total_source_bytes: 0,
         metadata_errors: vec![],
         io_error: 0,
-        error_count: 0,
+        got_xfer_error: false,
         entries_received: 100,
         directories_created: 10,
         directories_failed: 2,

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -17,6 +17,8 @@
 //!   from deletion.
 //! - [`proto_io_error`] - protocol 28/29 trailing `io_error` int after
 //!   the file-list end marker.
+//! - [`xfer_error`] - `got_xfer_error`: a `MSG_ERROR_XFER` frame on an empty
+//!   file list is the only report a missing source argument produces.
 //! - [`ndx_convert`] - `flat_to_wire_ndx` / `wire_to_flat_ndx` counters
 //!   and round-trip coverage.
 //! - [`dedup`] - receiver duplicate-clean pass (`flist_sort_and_clean` step 2)
@@ -50,6 +52,7 @@ mod missing_args_sentinel;
 mod ndx_convert;
 mod proto_io_error;
 mod wire_attrs;
+mod xfer_error;
 
 use std::io::Cursor;
 

--- a/crates/transfer/src/receiver/tests/file_list/xfer_error.rs
+++ b/crates/transfer/src/receiver/tests/file_list/xfer_error.rs
@@ -1,0 +1,100 @@
+//! `got_xfer_error`: a `MSG_ERROR_XFER` frame is the only report a missing
+//! source argument produces.
+//!
+//! Upstream's sender deliberately withholds `IOERR_GENERAL` when `link_stat()`
+//! fails with `ENOENT` (`flist.c:2428-2436`):
+//!
+//! ```c
+//! if (errno != ENOENT || missing_args == 0) {
+//!         /* This is a transfer error, but inhibit deletion
+//!          * only if we might be omitting an existing file. */
+//!         if (errno != ENOENT)
+//!                 io_error |= IOERR_GENERAL;
+//!         rsyserr(FERROR_XFER, errno, "link_stat %s failed", full_fname(fbuf));
+//!         continue;
+//! }
+//! ```
+//!
+//! The `io_error` word the receiver reads off the wire therefore stays clear,
+//! and the file list arrives empty. The `FERROR_XFER` the sender framed is the
+//! sole evidence of the failure: `read_a_msg` hands `MSG_ERROR_XFER` to
+//! `rwrite` (`io.c:1660`), which sets `got_xfer_error` (`log.c:310-311`), and
+//! `cleanup.c:217-218` lifts the zero exit to `RERR_PARTIAL`.
+//!
+//! These tests pin that chain at the receiver seam: identical wire streams that
+//! differ only by the presence of the frame must differ only by the flag, with
+//! `io_error` clear in both.
+
+use std::io::Cursor;
+
+use crate::reader::ServerReader;
+use crate::transfer_state::TransferPhase;
+
+use super::super::super::ReceiverContext;
+use super::super::support::{test_config, test_handshake};
+
+/// The text upstream 3.4.4 frames for `rsync://host/data/nope`, captured from
+/// a real daemon pull.
+const LINK_STAT_TEXT: &[u8] =
+    b"rsync: [sender] link_stat \"nope\" (in data) failed: No such file or directory (2)\n";
+
+/// Drives a client receiver over a multiplexed stream carrying an empty file
+/// list, optionally preceded by one `MSG_ERROR_XFER` frame, and returns the
+/// resulting `(got_xfer_error, io_error)`.
+fn empty_flist_run(with_error_xfer: bool) -> (bool, i32) {
+    let mut wire = Vec::new();
+    if with_error_xfer {
+        protocol::send_msg(&mut wire, protocol::MessageCode::ErrorXfer, LINK_STAT_TEXT).unwrap();
+    }
+    // Protocol 32 file list: a bare 0x00 end marker and nothing else. No
+    // MSG_IO_ERROR frame, exactly as upstream's ENOENT arm leaves it.
+    protocol::send_msg(&mut wire, protocol::MessageCode::Data, &[0x00]).unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.connection.client_mode = true;
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.pipeline
+        .advance_through(TransferPhase::DeltaTransfer)
+        .unwrap();
+
+    let mut reader = ServerReader::new_plain(Cursor::new(wire))
+        .activate_multiplex()
+        .unwrap();
+    let count = ctx.receive_file_list(&mut reader).unwrap();
+    assert_eq!(count, 0, "a missing source argument yields an empty list");
+
+    let mut writer: Vec<u8> = Vec::new();
+    let stats = ctx
+        .finish_empty_client_flist(&mut reader, &mut writer)
+        .unwrap();
+    (stats.got_xfer_error, stats.io_error)
+}
+
+/// upstream: `io.c:1660` -> `log.c:310-311`. Receipt of the frame, not any
+/// `io_error` bit, is what must make the run report a partial transfer.
+#[test]
+fn error_xfer_frame_on_an_empty_flist_sets_got_xfer_error() {
+    let (got_xfer_error, io_error) = empty_flist_run(true);
+    assert!(
+        got_xfer_error,
+        "MSG_ERROR_XFER must set got_xfer_error so the run exits 23"
+    );
+    assert_eq!(
+        io_error, 0,
+        "upstream flist.c:2431 withholds IOERR_GENERAL for ENOENT, so the exit \
+         code must not come from an io_error bit"
+    );
+}
+
+/// The control: the same empty list without the frame is a legitimately empty
+/// transfer (every source filtered out), which upstream exits 0 on.
+#[test]
+fn empty_flist_without_an_error_xfer_frame_leaves_got_xfer_error_clear() {
+    let (got_xfer_error, io_error) = empty_flist_run(false);
+    assert!(
+        !got_xfer_error,
+        "a clean empty list must not be reported as a partial transfer"
+    );
+    assert_eq!(io_error, 0, "no error was reported on the wire");
+}

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -132,6 +132,11 @@ impl ReceiverContext {
             io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
                 | self.flist_io_error
                 | reader.take_io_error(),
+            // upstream: log.c:310-311 - an empty list is exactly what a missing
+            // source argument produces, and `flist.c:2431` leaves io_error clear
+            // for it, so the MSG_ERROR_XFER frames read while draining the list
+            // are the only evidence the run must exit 23.
+            got_xfer_error: reader.xfer_error_count() > 0,
             ..TransferStats::default()
         })
     }

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -370,6 +370,11 @@ impl ReceiverContext {
         // alone only skips the file and carries no exit-code bits.
         stats.io_error |= reader.take_io_error();
 
+        // upstream: log.c:310-311 - every MSG_ERROR_XFER read off the wire sets
+        // got_xfer_error, the only report an ENOENT source argument produces
+        // (flist.c:2431 withholds IOERR_GENERAL for it).
+        stats.got_xfer_error = reader.xfer_error_count() > 0;
+
         let total_source_bytes: u64 = self.total_source_size();
 
         stats.files_transferred = files_transferred;

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -399,6 +399,11 @@ impl ReceiverContext {
         // alone only skips the file and carries no exit-code bits.
         stats.io_error |= reader.take_io_error();
 
+        // upstream: log.c:310-311 - every MSG_ERROR_XFER read off the wire sets
+        // got_xfer_error, the only report an ENOENT source argument produces
+        // (flist.c:2431 withholds IOERR_GENERAL for it).
+        stats.got_xfer_error = reader.xfer_error_count() > 0;
+
         Ok(stats)
     }
 }

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -634,7 +634,10 @@ impl ReceiverContext {
             io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
                 | self.flist_io_error
                 | sender_io_error,
-            error_count: 0,
+            // upstream: log.c:310-311 - every MSG_ERROR_XFER the sender framed
+            // sets got_xfer_error on receipt, which is what reports a source
+            // that failed to be listed (flist.c:2431 leaves io_error clear).
+            got_xfer_error: reader.xfer_error_count() > 0,
             entries_received: 0,
             directories_created: 0,
             directories_failed: 0,

--- a/crates/transfer/tests/incremental_transfer.rs
+++ b/crates/transfer/tests/incremental_transfer.rs
@@ -29,7 +29,7 @@ fn transfer_stats_incremental_fields_exist() {
         total_source_bytes: 5000,
         metadata_errors: vec![],
         io_error: 0,
-        error_count: 0,
+        got_xfer_error: false,
         entries_received: 10,
         directories_created: 3,
         directories_failed: 1,

--- a/tests/missing_source_arg_exits_partial.rs
+++ b/tests/missing_source_arg_exits_partial.rs
@@ -1,0 +1,355 @@
+//! Regression: a missing source argument must exit 23, driven by `MSG_ERROR_XFER`.
+//!
+//! Upstream's sender treats a source path that never existed as a transfer
+//! error but deliberately keeps `io_error` clear for it (`flist.c:2428-2436`):
+//!
+//! ```c
+//! if (errno != ENOENT || missing_args == 0) {
+//!         /* This is a transfer error, but inhibit deletion
+//!          * only if we might be omitting an existing file. */
+//!         if (errno != ENOENT)
+//!                 io_error |= IOERR_GENERAL;
+//!         rsyserr(FERROR_XFER, errno, "link_stat %s failed", full_fname(fbuf));
+//!         continue;
+//! }
+//! ```
+//!
+//! `io_error` is a wire field the receiver reads to decide whether to inhibit
+//! its deletions, so upstream refuses to raise it here. That leaves the framed
+//! `FERROR_XFER` as the *only* carrier of the failure: the peer's `read_a_msg`
+//! routes `MSG_ERROR_XFER` to `rwrite` (`io.c:1660`), which sets
+//! `got_xfer_error` (`log.c:310-311`), and `cleanup.c:217-218` turns that into
+//! `RERR_PARTIAL`.
+//!
+//! Two coupled defects hid in that gap and had to be fixed together:
+//!
+//! 1. oc had no `got_xfer_error`, so a received `MSG_ERROR_XFER` changed
+//!    nothing. Against a real upstream daemon - whose `io_error` is provably
+//!    clear here - our client exited 0.
+//! 2. oc's sender raised `IOERR_GENERAL` for `ENOENT` anyway, which is what
+//!    made an oc-to-oc pull *look* correct. Removing it alone would have turned
+//!    that pair from accidentally right into plainly wrong.
+//!
+//! The upstream-sender legs below are what pin the mechanism rather than the
+//! number: upstream sends no `io_error` bit for this case, so a client that
+//! exits 23 against it can only have got there through the frame.
+//!
+//! SSH masks the divergence - the child process's own exit status rescues the
+//! client - so every leg here runs over a daemon.
+
+use std::fs;
+use std::io::Read;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// Upstream `RERR_PARTIAL`: some files were not transferred (`errcode.h`).
+const RERR_PARTIAL: i32 = 23;
+
+/// Wall-clock budget for one client run. Nothing is transferred in these
+/// scenarios, so anything near this bound is a hang, not slowness.
+const CLIENT_DEADLINE: Duration = Duration::from_secs(45);
+
+/// How long to wait for a spawned daemon to bind its listening socket.
+const DAEMON_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Path to the binary under test, resolved by Cargo at compile time so a stale
+/// build in `target/` can never be picked up by a directory scan.
+fn oc_rsync_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_oc-rsync")
+}
+
+/// Locates an upstream rsync 3.x binary, if one is installed.
+///
+/// Candidates, in order: an explicit `OC_RSYNC_UPSTREAM_RSYNC` override, the
+/// binaries the interop harness installs under `target/interop`, then whatever
+/// `rsync` is on `PATH`. Each must self-identify as `rsync version 3.x`, which
+/// rejects the `openrsync` shim macOS ships as `/usr/bin/rsync`.
+///
+/// Returns `None` when nothing suitable exists; the caller skips those legs
+/// rather than failing, since an upstream binary is an external resource.
+fn upstream_rsync() -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(explicit) = std::env::var_os("OC_RSYNC_UPSTREAM_RSYNC") {
+        candidates.push(PathBuf::from(explicit));
+    }
+    for version in ["3.4.4", "3.4.1", "3.1.3"] {
+        candidates.push(PathBuf::from(format!(
+            "target/interop/upstream-install/{version}/bin/rsync"
+        )));
+    }
+    candidates.push(PathBuf::from("rsync"));
+
+    candidates.into_iter().find(|candidate| {
+        Command::new(candidate)
+            .arg("--version")
+            .output()
+            .ok()
+            .and_then(|out| String::from_utf8(out.stdout).ok())
+            .is_some_and(|text| {
+                text.lines()
+                    .next()
+                    .is_some_and(|line| line.starts_with("rsync") && line.contains(" version 3."))
+            })
+    })
+}
+
+/// Reserves an ephemeral port by binding it and immediately releasing it.
+fn allocate_port() -> u16 {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+/// One end of a child's stdio, boxed so both pipes share a drain loop.
+enum Pipe {
+    Out(std::process::ChildStdout),
+    Err(std::process::ChildStderr),
+}
+
+impl Pipe {
+    fn into_reader(self) -> Box<dyn Read> {
+        match self {
+            Self::Out(out) => Box::new(out),
+            Self::Err(err) => Box::new(err),
+        }
+    }
+}
+
+/// Takes both of a child's pipes, if present.
+fn take_pipes(child: &mut Child) -> [Option<Pipe>; 2] {
+    [
+        child.stdout.take().map(Pipe::Out),
+        child.stderr.take().map(Pipe::Err),
+    ]
+}
+
+/// A spawned rsync daemon serving one writable module, stdio drained
+/// continuously so a full pipe buffer can never masquerade as a hang.
+struct Daemon {
+    child: Child,
+    port: u16,
+}
+
+impl Daemon {
+    fn spawn(binary: &Path, config: &Path) -> Self {
+        let port = allocate_port();
+        let mut child = Command::new(binary)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--config")
+            .arg(config)
+            .arg("--port")
+            .arg(port.to_string())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn rsync daemon");
+
+        for pipe in take_pipes(&mut child) {
+            let Some(pipe) = pipe else { continue };
+            thread::spawn(move || {
+                let mut sink = Vec::new();
+                let _ = pipe.into_reader().read_to_end(&mut sink);
+            });
+        }
+
+        let daemon = Self { child, port };
+        daemon.wait_until_listening();
+        daemon
+    }
+
+    /// Polls the listening socket until the daemon accepts connections.
+    fn wait_until_listening(&self) {
+        let target = SocketAddr::from((Ipv4Addr::LOCALHOST, self.port));
+        let deadline = Instant::now() + DAEMON_READY_TIMEOUT;
+        while Instant::now() < deadline {
+            if TcpStream::connect_timeout(&target, Duration::from_millis(250)).is_ok() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        panic!("daemon did not start listening on port {}", self.port);
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("rsync://127.0.0.1:{}/mod/{path}", self.port)
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Writes a writable single-module daemon config serving `module_root`, so the
+/// same daemon serves both the pull and the push leg.
+fn write_config(dir: &Path, module_root: &Path) -> PathBuf {
+    let config = dir.join("rsyncd.conf");
+    fs::write(
+        &config,
+        format!(
+            "use chroot = no\n[mod]\n    path = {}\n    read only = no\n",
+            module_root.display()
+        ),
+    )
+    .expect("write daemon config");
+    config
+}
+
+/// Outcome of one bounded client run.
+struct ClientRun {
+    code: i32,
+    output: String,
+}
+
+/// Runs one client to completion and returns its exit code and combined output,
+/// failing the test if it does not finish inside [`CLIENT_DEADLINE`].
+///
+/// Both child pipes are drained on their own threads while we poll. Polling
+/// `try_wait()` without draining deadlocks the moment the child fills a pipe
+/// buffer, which would hang this harness for a reason unrelated to the bug
+/// under test.
+fn run_client_bounded(binary: &Path, args: &[String], label: &str) -> ClientRun {
+    let mut child = Command::new(binary)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rsync client");
+
+    let (tx, rx) = mpsc::channel::<String>();
+    for pipe in take_pipes(&mut child) {
+        let Some(pipe) = pipe else { continue };
+        let tx = tx.clone();
+        thread::spawn(move || {
+            let mut text = String::new();
+            let _ = pipe.into_reader().read_to_string(&mut text);
+            let _ = tx.send(text);
+        });
+    }
+    drop(tx);
+
+    let deadline = Instant::now() + CLIENT_DEADLINE;
+    let status = loop {
+        match child.try_wait().expect("poll client") {
+            Some(status) => break status,
+            None => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!("{label}: client did not finish within {CLIENT_DEADLINE:?}");
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+        }
+    };
+
+    let output: String = rx.iter().collect();
+    eprintln!("{label} client output:\n{output}");
+
+    let code = status
+        .code()
+        .unwrap_or_else(|| panic!("{label}: client terminated by signal instead of exiting"));
+    ClientRun { code, output }
+}
+
+/// Every peer role the matrix is run for: always our own binary, plus a real
+/// upstream rsync when one is installed. Both matter - an oc-to-oc pair shares
+/// any divergence between the two halves of this fix and so cannot detect it.
+fn peers() -> Vec<(String, PathBuf)> {
+    let mut peers = vec![("oc-rsync".to_owned(), PathBuf::from(oc_rsync_binary()))];
+    match upstream_rsync() {
+        Some(upstream) => peers.push(("upstream-rsync".to_owned(), upstream)),
+        None => eprintln!("skip upstream legs: no rsync 3.x binary available"),
+    }
+    peers
+}
+
+/// Creates a populated module root plus an empty destination.
+fn fixture() -> (TempDir, PathBuf, PathBuf) {
+    let root = TempDir::new().expect("tempdir");
+    let module_root = root.path().join("src");
+    let dest = root.path().join("dest");
+    fs::create_dir_all(&module_root).expect("create module root");
+    fs::create_dir_all(&dest).expect("create dest");
+    fs::write(module_root.join("present.txt"), b"ok\n").expect("write present.txt");
+    (root, module_root, dest)
+}
+
+/// Asserts the one thing every leg must show: the upstream `link_stat` line,
+/// reported exactly once, and `RERR_PARTIAL`.
+fn assert_partial_transfer(run: &ClientRun, label: &str) {
+    assert_eq!(
+        run.code, RERR_PARTIAL,
+        "{label}: a missing source argument must exit {RERR_PARTIAL} \
+         (upstream cleanup.c:217-218 via got_xfer_error), got {}",
+        run.code
+    );
+    let reports = run.output.matches("link_stat").count();
+    assert_eq!(
+        reports, 1,
+        "{label}: upstream rsyserr()s the failure once (flist.c:2433); \
+         reporting it through both a MSG_ERROR_XFER frame and an io_error bit \
+         would surface it twice"
+    );
+}
+
+/// Pull leg: the daemon is the sender, so the `link_stat` failure happens on
+/// the far side and only `MSG_ERROR_XFER` can carry it back. This is the cell
+/// that exited 0 before `got_xfer_error` existed.
+#[test]
+fn daemon_pull_of_a_missing_path_exits_partial() {
+    let (root, module_root, dest) = fixture();
+    let config = write_config(root.path(), &module_root);
+
+    for (sender_name, sender) in peers() {
+        let daemon = Daemon::spawn(&sender, &config);
+        for (client_name, client) in peers() {
+            let label = format!("pull: {client_name} client -> {sender_name} daemon");
+            let args = vec![
+                "-a".to_owned(),
+                daemon.url("no-such-entry"),
+                format!("{}/", dest.display()),
+            ];
+            let run = run_client_bounded(&client, &args, &label);
+            assert_partial_transfer(&run, &label);
+        }
+    }
+}
+
+/// Push leg: the local sender raises the error itself. Upstream's `rwrite()`
+/// sets `got_xfer_error` on the emitting side too (`log.c:310-311` runs before
+/// the `am_server` frame-and-return), so a client that only *reports* the
+/// failure still exits 23 - without the `io_error` bit that used to stand in
+/// for it here.
+#[test]
+fn daemon_push_of_a_missing_path_exits_partial() {
+    let (root, module_root, _dest) = fixture();
+    let config = write_config(root.path(), &module_root);
+    let missing = root.path().join("no-such-source");
+
+    for (receiver_name, receiver) in peers() {
+        let daemon = Daemon::spawn(&receiver, &config);
+        for (client_name, client) in peers() {
+            let label = format!("push: {client_name} client -> {receiver_name} daemon");
+            let args = vec![
+                "-a".to_owned(),
+                missing.display().to_string(),
+                daemon.url(""),
+            ];
+            let run = run_client_bounded(&client, &args, &label);
+            assert_partial_transfer(&run, &label);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A missing (`ENOENT`) source argument exited **0** against a real upstream daemon, where upstream 3.4.4 exits **23**.

Upstream's sender treats the failure as a transfer error but deliberately withholds the `io_error` bit for `ENOENT` (`flist.c:2428-2436`):

```c
if (errno != ENOENT || missing_args == 0) {
        /* This is a transfer error, but inhibit deletion
         * only if we might be omitting an existing file. */
        if (errno != ENOENT)                       /* flist.c:2431 */
                io_error |= IOERR_GENERAL;
        rsyserr(FERROR_XFER, errno, "link_stat %s failed", full_fname(fbuf));
        continue;
}
```

That guard is deliberate: `io_error` is a wire field the receiver reads and uses to skip its deletion pass (`generator.c:298`, "IO error encountered -- skipping file deletion"), so raising it here would have a side effect upstream does not want.

The framed `FERROR_XFER` is therefore the *only* carrier of the failure, and `got_xfer_error` is the mechanism that turns it into an exit code:

| step | upstream |
|------|----------|
| sender frames the error | `flist.c:2433` `rsyserr(FERROR_XFER, ...)` -> `log.c:330-346` `send_msg(MSG_ERROR_XFER, ...)` |
| emitting side records it | `log.c:310-311` `case FERROR_XFER: got_xfer_error = 1;` (runs *before* the `am_server` frame-and-return, so a client that only reports the error is covered too) |
| peer receives the frame | `io.c:1660` `case MSG_ERROR_XFER: ... rwrite((enum logcode)tag, ...)` -> `log.c:310-311` again |
| flag becomes the exit code | `cleanup.c:217-218` `if (io_error & IOERR_GENERAL \|\| got_xfer_error) exit_code = RERR_PARTIAL;` (also `main.c:1630`) |

oc had no `got_xfer_error`, so nothing turned that frame into a non-zero exit.

## Two coupled defects, fixed together

**A - `got_xfer_error` was not implemented.** A received `MSG_ERROR_XFER` incremented a reader counter that only the generator role consumed; the receiver role dropped it, and neither role recorded a locally *emitted* `FERROR_XFER`.

**B - oc's sender raised `IOERR_GENERAL` for `ENOENT`.** `walk.rs` called `add_io_error(IOERR_GENERAL)` on the missing-argument path, contradicting `flist.c:2431`. That bit is what made an oc-to-oc pull exit 23 - the wrong mechanism compensating for the missing one - and it also travelled to the peer, where upstream would have used it to inhibit deletions.

They are inseparable:

* **A without B** - the failure would be reported twice, through both the frame and an `io_error` bit oc has no business setting.
* **B without A** - the oc-to-oc pull goes from accidentally right to plainly wrong (exit 0), which is the state the branch passes through mid-change and never ships.

## Change

* `GeneratorContext` gains `got_xfer_error`, set in `emit_sender_diagnostic` - the single funnel every sender `FERROR_XFER` already routes through, so this mirrors `rwrite()` exactly - and set when the peer's reader reports `MSG_ERROR_XFER`.
* `GeneratorStats` and `TransferStats` carry the flag (`TransferStats.error_count`, which was hardcoded to `0` and never populated, is replaced by it).
* Both receiver drivers, the sync driver, and the empty-file-list early return populate it from `reader.xfer_error_count()`.
* The daemon and SSH summary conversions map it to exit 23, exactly where `cleanup.c:217-218` does.
* The `ENOENT` arm of the file-list walk no longer raises `IOERR_GENERAL`.

The receiver dispatch ladder differs by the `transfer/incremental-flist` feature (`run_pipelined_incremental` vs `run_pipelined`), so both drivers were changed and the integration test was run with the feature **on and off**; the exit-code path is identical in both, since a missing argument yields an empty list and both drivers return through `finish_empty_client_flist`.

## Peer matrix - captured against rsync 3.4.4 (protocol 32)

Reference binary: `target/interop/upstream-src/rsync-3.4.4/rsync`, `rsync version 3.4.4 protocol version 32`.

### Before (daemon pull, missing remote arg)

```
----- up client -> up daemon -----
rsync: [sender] link_stat "nope" (in data) failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1876) [Receiver=3.4.4]
EXIT=23
----- oc client -> up daemon -----
rsync: [sender] link_stat "nope" (in data) failed: No such file or directory (2)
EXIT=0          <-- the bug
----- up client -> oc daemon -----
rsync: [sender] link_stat "nope" (in data) failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1876) [Receiver=3.4.4]
EXIT=23
----- oc client -> oc daemon -----
rsync: [sender] link_stat "nope" (in data) failed: No such file or directory (2)
EXIT=23         <-- accidentally right, via the io_error bit of defect B
```

### After - all 20 cells

```
########## DAEMON PULL (missing remote arg) ##########
up client -> up daemon    EXIT=23
oc client -> up daemon    EXIT=23
up client -> oc daemon    EXIT=23
oc client -> oc daemon    EXIT=23

########## DAEMON PUSH (missing local arg) ##########
up client -> up daemon    EXIT=23
oc client -> up daemon    EXIT=23
up client -> oc daemon    EXIT=23
oc client -> oc daemon    EXIT=23

########## SSH PULL (missing remote arg) ##########
up client -> up server    EXIT=23
oc client -> up server    EXIT=23
up client -> oc server    EXIT=23
oc client -> oc server    EXIT=23

########## SSH PUSH (missing local arg) ##########
up client -> up server    EXIT=23
oc client -> up server    EXIT=23
up client -> oc server    EXIT=23
oc client -> oc server    EXIT=23

########## LOCAL (no protocol) ##########
up local                  EXIT=23
oc local                  EXIT=23
```

Full stderr for the daemon legs after the change (one report per run, no duplication):

```
----- oc client -> up daemon (pull) -----
rsync: [sender] link_stat "nope" (in data) failed: No such file or directory (2)
EXIT=23
----- oc client -> oc daemon (pull) -----
rsync: [sender] link_stat "nope" (in data) failed: No such file or directory (2)
EXIT=23
----- up client -> oc daemon (pull) -----
rsync: [sender] link_stat "nope" (in data) failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1876) [Receiver=3.4.4]
EXIT=23
----- oc client -> up daemon (push) -----
rsync: [sender] link_stat "<tmp>/nolocal" failed: No such file or directory (2)
EXIT=23
```

The `oc client -> upstream daemon` cell is what pins the mechanism rather than the number: upstream provably sends **no** `io_error` bit for this case, so a client that exits 23 against it can only have got there through `MSG_ERROR_XFER`.

SSH masks the divergence - the child process's own exit status rescues the client either way - which is why every regression test below runs over a daemon.

## Tests

* `tests/missing_source_arg_exits_partial.rs` - daemon pull and daemon push, every combination of our binary and a real upstream 3.x binary on both ends (upstream legs skipped, with a note, when no upstream binary is installed). Asserts exit 23 **and** that the `link_stat` failure is reported exactly once, which is what would break if the frame and an `io_error` bit both fired. Verified to fail (`got 0`) when the `got_xfer_error` plumbing is removed. Passes with `transfer/incremental-flist` on and off.
* `crates/transfer/src/receiver/tests/file_list/xfer_error.rs` - two identical multiplexed wire streams differing only by the presence of one `MSG_ERROR_XFER` frame; asserts the flag follows the frame and `io_error` stays 0 in both. This is the mechanism assertion at the receiver seam.
* `crates/transfer/src/generator/tests.rs` - the two existing missing-source tests asserted `IOERR_GENERAL`, citing `flist.c:1846`. That citation was wrong: `flist.c:1839-1847` (`interpret_stat_error`) is the *mid-scan vanish* path, which reports `file has vanished` and `IOERR_VANISHED`. A source that never existed goes through `flist.c:2428-2436`. Confirmed against the real binary - `--files-from` naming a missing entry prints `link_stat ... failed` and exits 23 with the peer's deletions still performed. Both tests now assert `io_error == 0`, exactly one `MSG_ERROR_XFER` frame, and `got_xfer_error`.

Checks run: `cargo fmt --all -- --check`; `cargo clippy -p transfer -p core --all-features --all-targets --no-deps -D warnings`; `cargo nextest run -p transfer -p core --all-features` (5197 passed); `cargo nextest run -p cli -p daemon --all-features` (5472 passed, 1 pre-existing local-timezone failure in `format_list_timestamp_epoch_returns_epoch`, passes under `TZ=UTC`); the related root integration binaries (`exit_codes`, `daemon_sender_per_file_error_no_hang`, `client_empty_flist_skips_recv_loop`, `inc_recurse_sender_flist_io_error_isi_f`) all green.

## Deliberately out of scope

Pulling a module with a server-side `exclude` was re-checked against upstream and is unaffected (all four peer combinations exit 0, matching upstream). Pushing into such a module exposes a separate, pre-existing divergence - our daemon receiver silently skips the refused file instead of raising `ERROR: daemon refused to receive ...` (`generator.c:1281-1283`), so it exits 0 where upstream exits 23. That is a receiver-side gap, not an exit-code plumbing one, and is left for its own change.
