### PR TITLE
fix(transfer): honour shutdown signals on network transfers

### DIFF
--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -436,11 +436,26 @@ fn clap_parse_error_exit_code(error: &clap::Error) -> i32 {
     }
 }
 
-/// Installs client-side signal handlers and a watcher that, on a second
-/// (abort) interrupt, finalises in-progress `--partial` temp files and exits
-/// with the rsync signal code. A single interrupt is handled gracefully by the
-/// copy loop, which stops mid-file and lets each transfer's guard finalise its
-/// partial during normal unwinding.
+/// Interval at which the signal watcher re-checks the shutdown flags.
+///
+/// It also bounds how long a transfer parked in a blocking transport read can
+/// stay parked after the first interrupt, so it doubles as the responsiveness
+/// budget for Ctrl-C during a network transfer.
+const SIGNAL_WATCH_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// Installs client-side signal handlers and a watcher that reacts to them
+/// outside signal context.
+///
+/// On the first interrupt the watcher fires every registered I/O waker
+/// ([`core::signal::wake_blocked_io`]), which releases a transfer blocked on
+/// the transport so it observes the shutdown flag and unwinds normally -
+/// finalising each in-progress `--partial` temp file through its guard. On a
+/// second (abort) interrupt it finalises the partial registry directly and
+/// exits with the rsync signal code, because no unwinding is going to happen.
+///
+/// upstream: `rsync.c:684 sig_int()` only records the signal and lets the
+/// normal I/O path shut the transfer down (`io.c:750 got_kill_signal` ->
+/// `handle_kill_signal` -> `cleanup.c:_exit_cleanup(RERR_SIGNAL)`).
 fn install_client_signal_handling() {
     use std::sync::atomic::{AtomicBool, Ordering};
     static INSTALLED: AtomicBool = AtomicBool::new(false);
@@ -460,7 +475,12 @@ fn install_client_signal_handling() {
                     });
                 std::process::exit(code);
             }
-            std::thread::sleep(std::time::Duration::from_millis(50));
+            if core::signal::is_shutdown_requested() {
+                // Repeated deliberately: a transfer that registers its socket
+                // after the first interrupt still gets woken on the next tick.
+                core::signal::wake_blocked_io();
+            }
+            std::thread::sleep(SIGNAL_WATCH_INTERVAL);
         }
     });
 }

--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -290,7 +290,7 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
             let msg = rsync_error!(code.as_i32(), "{}", message).with_role(Role::Client);
             ClientError::with_code(code, msg)
         }
-        LocalCopyErrorKind::Interrupted => signal_interrupt_error(),
+        LocalCopyErrorKind::Interrupted => signal_interrupt_error(Role::Sender),
     }
 }
 
@@ -302,12 +302,13 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
 /// renders the fixed `rerr_names` entry for `RERR_SIGNAL` (log.c:95) as
 /// `rsync error: received SIGINT, SIGTERM, or SIGHUP (code 20) at ... [<role>]`.
 /// The three interrupt signals share one message; upstream never names the
-/// specific signal here. who_am_i() tags the sending half `[sender]`.
+/// specific signal here. `role` is the interrupted half, as who_am_i() would
+/// report it.
 #[cold]
-pub(crate) fn signal_interrupt_error() -> ClientError {
+pub(crate) fn signal_interrupt_error(role: Role) -> ClientError {
     let code = ExitCode::Signal;
     let message =
-        rsync_error!(code.as_i32(), "received SIGINT, SIGTERM, or SIGHUP").with_role(Role::Sender);
+        rsync_error!(code.as_i32(), "received SIGINT, SIGTERM, or SIGHUP").with_role(role);
     ClientError::with_code(code, message)
 }
 
@@ -844,7 +845,7 @@ mod tests {
 
         #[test]
         fn signal_interrupt_error_matches_map_output() {
-            let direct = signal_interrupt_error();
+            let direct = signal_interrupt_error(Role::Sender);
             assert_eq!(direct.code(), ExitCode::Signal);
             assert_eq!(
                 direct.to_string(),

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -222,6 +222,30 @@ pub(crate) fn build_io_timeout_reapply(
     )))
 }
 
+/// Registers a shutdown wake hook for the daemon socket.
+///
+/// The hook half-closes the socket, so a transfer parked in a blocking read
+/// returns at once and unwinds through the same path a dropped connection
+/// takes - which is what makes `--partial` / `--partial-dir` retention and
+/// temp-file cleanup identical on the signal path and the connection-loss
+/// path. Returns `None` for connect-program (pipe) transports, which own no
+/// socket to shut down.
+///
+/// upstream: `io.c:750` polls `got_kill_signal` from `perform_io()` once its
+/// `select()` returns; a multi-threaded process cannot rely on the signal
+/// reaching the thread that is blocked on the wire, so the socket is closed
+/// from the watcher instead.
+pub(crate) fn register_shutdown_wake(
+    reader: &DaemonStreamReader,
+) -> Option<crate::signal::IoWakerGuard> {
+    let socket = reader.try_clone_tcp()?;
+    crate::signal::register_io_waker(std::sync::Arc::new(move || {
+        // Best-effort: the peer may already have closed the connection, in
+        // which case shutdown(2) reports ENOTCONN and there is nothing to wake.
+        let _ = socket.shutdown(std::net::Shutdown::Both);
+    }))
+}
+
 /// Opens a plain TCP connection to a daemon.
 ///
 /// Respects `RSYNC_CONNECT_PROG` and `RSYNC_PROXY` environment

--- a/crates/core/src/client/module_list/mod.rs
+++ b/crates/core/src/client/module_list/mod.rs
@@ -53,7 +53,8 @@ pub(super) use connect::{
     ConnectProgramConfig, DaemonStream, DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter,
     ProxyConfig, ProxyCredentials, RshDaemonSpawn, build_io_timeout_reapply, connect_direct,
     connect_via_proxy, establish_proxy_tunnel, open_daemon_stream, parse_proxy_spec,
-    resolve_connect_timeout, resolve_daemon_addresses, spawn_rsh_daemon_stream,
+    register_shutdown_wake, resolve_connect_timeout, resolve_daemon_addresses,
+    spawn_rsh_daemon_stream,
 };
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use errors::map_daemon_handshake_error;

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -15,6 +15,7 @@ use crate::client::config::ClientConfig;
 use crate::client::error::{ClientError, invalid_argument_error, remote_exit_error};
 use crate::client::module_list::{
     DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter, build_io_timeout_reapply,
+    register_shutdown_wake,
 };
 use crate::client::progress::ClientProgressObserver;
 use crate::client::remote::batch_support::{BatchContext, build_batch_recording};
@@ -111,6 +112,9 @@ pub(crate) fn run_pull_transfer(
     // adopt it and re-apply to the live socket. Build the re-apply hook from the
     // split socket halves; connect-program (pipe) transports yield None.
     let io_timeout_reapply = build_io_timeout_reapply(reader, writer);
+    // Let an interrupt release a receive blocked on the wire. Held for the
+    // duration of the transfer; dropping it deregisters the socket.
+    let _wake_guard = register_shutdown_wake(reader);
     // A custom `--out-format` makes the receiver buffer metadata events (it
     // suppresses its own stdout); collect them for the CLI to render. Otherwise
     // the receiver prints its own default `-v`/`-i` output and no callback is
@@ -178,6 +182,9 @@ pub(crate) fn run_push_transfer(
 
     let server_config = build_server_config_for_generator(config, local_paths, filter_rules)?;
     let dry_run = config.dry_run();
+
+    // Let an interrupt release a send blocked on the wire (see run_pull_transfer).
+    let _wake_guard = register_shutdown_wake(reader);
 
     // Push: local side is Generator (sender); batch records outgoing data (is_sender=true).
     let batch_recording = batch_ctx

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -271,6 +271,13 @@ pub(crate) fn run_push_transfer(
 /// upstream: io.c:1663-1701 - `MSG_ERROR_EXIT` drives the NORETURN
 /// `_exit_cleanup(val)`, so the client's final exit code is the peer's code.
 fn map_server_transfer_error(error: std::io::Error, role: Role) -> ClientError {
+    // An interrupted transfer surfaces as whatever I/O failure the teardown
+    // produced (a truncated multiplex frame, a closed socket). Upstream never
+    // reports that: `rsync.c:709-716 sig_int()` short-circuits to
+    // `exit_cleanup(RERR_SIGNAL)`, so the one diagnostic is the signal itself.
+    if crate::signal::is_shutdown_requested() {
+        return crate::client::error::signal_interrupt_error(role);
+    }
     if let Some(code) = remote_exit_code(&error) {
         let exit = ExitCode::from_i32(code).unwrap_or(ExitCode::PartialTransfer);
         return remote_exit_error(exit, role, "");
@@ -470,5 +477,28 @@ mod map_server_transfer_error_tests {
         );
         assert_eq!(err.exit_code(), 23);
         assert!(err.to_string().contains("transfer failed"), "{err}");
+    }
+
+    /// A signal-driven teardown must report the signal, not the I/O failure it
+    /// caused. Upstream emits exactly one line for an interrupt
+    /// (`rsync.c:716` -> `log.c:log_exit()` with `RERR_SIGNAL`); reporting the
+    /// truncated frame instead would show the user a protocol error and code
+    /// 23 for something they asked for.
+    #[test]
+    fn signalled_teardown_reports_the_signal_not_the_io_failure() {
+        crate::signal::reset_for_testing();
+        crate::signal::request_shutdown(crate::signal::ShutdownReason::Terminated);
+        let err = map_server_transfer_error(
+            std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "multiplex truncated"),
+            Role::Receiver,
+        );
+        crate::signal::reset_for_testing();
+        assert_eq!(err.exit_code(), 20);
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("received SIGINT, SIGTERM, or SIGHUP"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("multiplex truncated"), "{rendered}");
     }
 }

--- a/crates/core/src/signal/io_wake.rs
+++ b/crates/core/src/signal/io_wake.rs
@@ -1,0 +1,135 @@
+//! Registry of hooks that wake a thread blocked on network I/O.
+//!
+//! A signal handler can only flip an atomic; the transfer that must react to
+//! it is usually parked inside a blocking `read()` on the transport socket and
+//! will never look at the flag on its own. Upstream does not have this problem
+//! because it is multi-process and single-threaded per process: the signal
+//! interrupts the one `select()` in `perform_io()`, which `io.c:766-779`
+//! handles exactly like a timeout before re-checking `got_kill_signal`
+//! (`io.c:750`). In a multi-threaded process the kernel delivers the signal to
+//! an arbitrary thread, so `EINTR` alone cannot be relied on to reach the
+//! thread that is actually blocked on the wire.
+//!
+//! The transport therefore registers a waker for the lifetime of the session
+//! and the client's signal watcher fires it in normal (non-signal) context.
+//! For a TCP transport the waker half-closes the socket, so the blocked read
+//! returns immediately and the transfer unwinds through the same path a
+//! dropped connection already takes - including the `--partial` /
+//! `--partial-dir` retention in `disk_commit`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// A hook that unblocks a thread parked in transport I/O.
+///
+/// Invoked from the signal-watcher thread, never from a signal handler, so it
+/// is free to allocate, lock, and issue arbitrary syscalls. It must be
+/// idempotent: a repeated interrupt request fires it again.
+pub type IoWaker = Arc<dyn Fn() + Send + Sync>;
+
+/// Registered wakers keyed by the token handed back to the registrant.
+static WAKERS: OnceLock<Mutex<Vec<(u64, IoWaker)>>> = OnceLock::new();
+
+/// Source of unique registration tokens.
+static NEXT_TOKEN: AtomicU64 = AtomicU64::new(1);
+
+fn wakers() -> &'static Mutex<Vec<(u64, IoWaker)>> {
+    WAKERS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// RAII registration handle: deregisters its waker on drop.
+///
+/// Holding the guard for exactly the transfer's lifetime keeps the registry
+/// from firing against a socket whose session has already finished.
+#[derive(Debug)]
+pub struct IoWakerGuard {
+    token: u64,
+}
+
+impl Drop for IoWakerGuard {
+    fn drop(&mut self) {
+        if let Ok(mut list) = wakers().lock() {
+            list.retain(|(token, _)| *token != self.token);
+        }
+    }
+}
+
+/// Registers `waker` until the returned guard is dropped.
+///
+/// Returns `None` when the registry mutex is poisoned; the caller simply runs
+/// without a wake hook rather than failing the transfer.
+#[must_use]
+pub fn register_io_waker(waker: IoWaker) -> Option<IoWakerGuard> {
+    let token = NEXT_TOKEN.fetch_add(1, Ordering::Relaxed);
+    let mut list = wakers().lock().ok()?;
+    list.push((token, waker));
+    Some(IoWakerGuard { token })
+}
+
+/// Fires every registered waker.
+///
+/// Called by the client's signal watcher once a shutdown has been requested,
+/// so a transfer blocked on the wire observes the request instead of parking
+/// until the peer or the `--timeout` deadline releases it.
+pub fn wake_blocked_io() {
+    let hooks: Vec<IoWaker> = match wakers().lock() {
+        Ok(list) => list.iter().map(|(_, waker)| Arc::clone(waker)).collect(),
+        Err(_) => return,
+    };
+    for hook in hooks {
+        hook();
+    }
+}
+
+/// Number of currently registered wakers. Diagnostics and tests only.
+#[must_use]
+pub fn registered_waker_count() -> usize {
+    wakers().lock().map(|list| list.len()).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    /// The registry is process-global and `wake_blocked_io` fires every entry,
+    /// so concurrent tests would see each other's wakers.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn waker_fires_while_registered_and_not_after_drop() {
+        let _serial = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let hits = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&hits);
+        let guard = register_io_waker(Arc::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }))
+        .expect("registry available");
+
+        wake_blocked_io();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+        drop(guard);
+        wake_blocked_io();
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "a dropped guard must leave no waker behind"
+        );
+    }
+
+    #[test]
+    fn wake_is_repeatable_for_a_live_registration() {
+        let _serial = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let hits = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&hits);
+        let _guard = register_io_waker(Arc::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }))
+        .expect("registry available");
+
+        wake_blocked_io();
+        wake_blocked_io();
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+    }
+}

--- a/crates/core/src/signal/mod.rs
+++ b/crates/core/src/signal/mod.rs
@@ -73,6 +73,11 @@ pub use stub::{ShutdownReason, SignalHandler, install_signal_handlers, wait_for_
 mod cleanup;
 pub use cleanup::CleanupManager;
 
+mod io_wake;
+pub use io_wake::{
+    IoWaker, IoWakerGuard, register_io_waker, registered_waker_count, wake_blocked_io,
+};
+
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 /// Global flag indicating a graceful shutdown has been requested.

--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -15,6 +15,8 @@ use std::io::{self, Read};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -292,5 +294,239 @@ pub fn require_upstream(binary_path: &str) {
     if !Path::new(binary_path).exists() {
         eprintln!("Skipping: upstream rsync binary not found at {binary_path}");
         panic!("upstream binary required for this test");
+    }
+}
+
+/// Candidate locations for a real upstream rsync, most specific first.
+///
+/// The interop harness installs versioned builds under `target/`; a developer
+/// machine usually only has the packaged binary. Both are acceptable as long
+/// as the binary is genuinely upstream, which [`upstream_rsync`] verifies from
+/// `--version` rather than from the path it was found at.
+#[allow(dead_code)]
+const UPSTREAM_CANDIDATES: &[&str] = &[
+    UPSTREAM_3_4_1,
+    "/opt/homebrew/bin/rsync",
+    "/usr/local/bin/rsync",
+    "/usr/bin/rsync",
+    "/bin/rsync",
+];
+
+/// Locates an upstream rsync binary, or panics naming every path tried.
+///
+/// A missing upstream binary must fail the test rather than silently return:
+/// a cross-implementation assertion that quietly asserts nothing is worse than
+/// no test at all. Verifying the `--version` banner also rules out an
+/// `oc-rsync` shim earlier on `PATH` masquerading as upstream.
+#[allow(dead_code)]
+pub fn upstream_rsync() -> PathBuf {
+    for candidate in UPSTREAM_CANDIDATES {
+        let path = Path::new(candidate);
+        if !path.exists() {
+            continue;
+        }
+        let Ok(output) = Command::new(path).arg("--version").output() else {
+            continue;
+        };
+        let banner = String::from_utf8_lossy(&output.stdout);
+        let first = banner.lines().next().unwrap_or_default();
+        if first.starts_with("rsync  version") && first.contains("protocol version") {
+            return path.to_path_buf();
+        }
+    }
+    panic!(
+        "no upstream rsync binary found; tried: {}. Build one with \
+         `bash tools/ci/run_interop.sh` or install the packaged rsync.",
+        UPSTREAM_CANDIDATES.join(", ")
+    );
+}
+
+/// A TCP proxy that forwards a bounded number of bytes from the daemon to the
+/// client and then stalls forever with both sockets still open.
+///
+/// This is what makes a mid-transfer interrupt test deterministic. Throttling
+/// the client with `--bwlimit` does not work: upstream only throttles socket
+/// *writes* (`io.c:861`), so on a daemon pull the limit has to be applied by
+/// the daemon and is inert client-side. Capping the bytes instead means the
+/// transfer is structurally unable to complete, so the kill can be gated on
+/// observed on-disk progress rather than on a timing guess.
+#[allow(dead_code)]
+pub struct CappingProxy {
+    port: u16,
+    forwarded: Arc<AtomicU64>,
+    stop: Arc<AtomicBool>,
+}
+
+#[allow(dead_code)]
+impl CappingProxy {
+    /// Starts a proxy in front of `target_port` that forwards at most `cap`
+    /// bytes downstream.
+    pub fn start(target_port: u16, cap: u64) -> io::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        listener.set_nonblocking(true)?;
+
+        let forwarded = Arc::new(AtomicU64::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+        let accept_forwarded = Arc::clone(&forwarded);
+        let accept_stop = Arc::clone(&stop);
+
+        thread::spawn(move || {
+            while !accept_stop.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((client, _)) => {
+                        let Ok(daemon) = TcpStream::connect(("127.0.0.1", target_port)) else {
+                            continue;
+                        };
+                        let _ = client.set_nonblocking(false);
+                        let (Ok(client_rx), Ok(daemon_rx)) =
+                            (client.try_clone(), daemon.try_clone())
+                        else {
+                            continue;
+                        };
+                        let up_stop = Arc::clone(&accept_stop);
+                        thread::spawn(move || pump(client_rx, daemon, u64::MAX, None, up_stop));
+                        let down_counter = Arc::clone(&accept_forwarded);
+                        let down_stop = Arc::clone(&accept_stop);
+                        thread::spawn(move || {
+                            pump(daemon_rx, client, cap, Some(down_counter), down_stop);
+                        });
+                    }
+                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => return,
+                }
+            }
+        });
+
+        Ok(Self {
+            port,
+            forwarded,
+            stop,
+        })
+    }
+
+    /// The port clients should connect to.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Bytes forwarded daemon -> client so far.
+    pub fn forwarded(&self) -> u64 {
+        self.forwarded.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for CappingProxy {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Copies `src` into `dst` until `cap` bytes have moved, then parks with both
+/// sockets open so the peer blocks instead of seeing EOF.
+fn pump(
+    mut src: TcpStream,
+    mut dst: TcpStream,
+    cap: u64,
+    counter: Option<Arc<AtomicU64>>,
+    stop: Arc<AtomicBool>,
+) {
+    use std::io::Write;
+
+    let mut moved: u64 = 0;
+    let mut buf = [0u8; 65536];
+    while moved < cap {
+        let want = ((cap - moved) as usize).min(buf.len());
+        let read = match src.read(&mut buf[..want]) {
+            Ok(0) | Err(_) => return,
+            Ok(n) => n,
+        };
+        if dst.write_all(&buf[..read]).is_err() {
+            return;
+        }
+        moved += read as u64;
+        if let Some(ref counter) = counter {
+            counter.fetch_add(read as u64, Ordering::Relaxed);
+        }
+    }
+    // Cap reached: hold both sockets open and forward nothing more.
+    while !stop.load(Ordering::Relaxed) {
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+/// Waits until some file under `root` has a non-zero length.
+///
+/// Gates the interrupt on real progress instead of a sleep, so the test cannot
+/// kill the client before the receiver has opened and written its temp file.
+#[allow(dead_code)]
+pub fn wait_for_progress(root: &Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if tree_has_data(root) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn tree_has_data(root: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(root) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if tree_has_data(&path) {
+                return true;
+            }
+        } else if entry.metadata().map(|m| m.len()).unwrap_or(0) > 0 {
+            return true;
+        }
+    }
+    false
+}
+
+/// Background readers for a child's piped stdout/stderr.
+///
+/// A child whose pipes nobody reads blocks once the pipe buffer fills, which
+/// would deadlock against the very interrupt the test is measuring.
+#[allow(dead_code)]
+pub struct PipeDrain {
+    stdout: thread::JoinHandle<String>,
+    stderr: thread::JoinHandle<String>,
+}
+
+#[allow(dead_code)]
+impl PipeDrain {
+    /// Takes the child's pipes and starts draining them.
+    pub fn start(child: &mut Child) -> Self {
+        let mut out = child.stdout.take().expect("stdout piped");
+        let mut err = child.stderr.take().expect("stderr piped");
+        Self {
+            stdout: thread::spawn(move || {
+                let mut buf = String::new();
+                let _ = out.read_to_string(&mut buf);
+                buf
+            }),
+            stderr: thread::spawn(move || {
+                let mut buf = String::new();
+                let _ = err.read_to_string(&mut buf);
+                buf
+            }),
+        }
+    }
+
+    /// Joins both readers, returning `(stdout, stderr)`.
+    pub fn join(self) -> (String, String) {
+        (
+            self.stdout.join().unwrap_or_default(),
+            self.stderr.join().unwrap_or_default(),
+        )
     }
 }

--- a/crates/core/tests/no_partial_temp_cleanup.rs
+++ b/crates/core/tests/no_partial_temp_cleanup.rs
@@ -1,126 +1,118 @@
-//! Interop test: no --partial flag removes temp files on mid-transfer kill.
+//! Interop test: SIGTERM mid daemon transfer leaves no residue without `--partial`.
 //!
-//! Verifies that when a daemon transfer is interrupted mid-stream WITHOUT
-//! `--partial` (the default behavior), no temp files or partial files remain
-//! at the destination. This is the complementary test to PIR-6.a which
-//! verifies retention with `--partial`.
+//! Default rsync writes each file to `.name.XXXXXX` and renames it on
+//! completion. An interrupt must remove that temp: `cleanup.c:194-197` unlinks
+//! `cleanup_fname` whenever `keep_partial` is unset. The failure this guards
+//! against is an orphaned temp file - the destination looks clean in a casual
+//! `ls` while a hidden partial silently consumes the disk.
 //!
-//! Upstream rsync writes to a temp file (`.filename.XXXXXX`) during transfer
-//! and renames it to the final name on completion. On interrupt without
-//! `--partial`, `cleanup.c:do_unlink()` removes the temp file so no orphan
-//! remains. This test exercises that cleanup path end-to-end.
-//!
-//! Test scenarios:
-//! 1. Single file transfer killed mid-stream - no residue at destination
-//! 2. Multi-file transfer killed mid-stream - no residue for any file
-//! 3. Upstream rsync client against oc-rsync daemon - cross-implementation
-//! 4. Subdirectory structure preserved but no temp files remain
+//! The transfer is made structurally unable to complete by interposing
+//! [`common::CappingProxy`], which forwards a bounded number of daemon bytes
+//! and then stalls with the connection open, so the interrupt can be gated on
+//! observed on-disk progress rather than on a sleep.
 //!
 //! Upstream reference:
-//! - `cleanup.c:55-80` - `do_unlink()` removes temp file on interrupt
-//! - `cleanup.c:105-135` - only retains when `keep_partial && got_literal`
-//! - `receiver.c:490-510` - temp file naming pattern `.filename.XXXXXX`
+//! - `cleanup.c:159-197` - retention gate and the unlink that follows it
+//! - `receiver.c` - temp file naming pattern `.filename.XXXXXX`
+//! - `errcode.h` - `RERR_SIGNAL` is 20
 
 #[cfg(unix)]
 mod common;
 
 #[cfg(unix)]
-use common::{DaemonBinary, TestDaemon, create_test_file};
+use common::{
+    CappingProxy, DaemonBinary, PipeDrain, TestDaemon, create_test_file, upstream_rsync,
+    wait_for_progress,
+};
 
 #[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(unix)]
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 #[cfg(unix)]
 use std::thread;
 #[cfg(unix)]
 use std::time::{Duration, Instant};
 
 #[cfg(unix)]
-use tempfile::tempdir;
+use tempfile::{TempDir, tempdir};
 
-/// Size of the test file (2 MB) - large enough that a bandwidth-limited
-/// transfer takes several seconds, giving a reliable kill window.
+/// Per-file payload size. Comfortably larger than [`FORWARD_CAP`].
 #[cfg(unix)]
 const TEST_FILE_SIZE: usize = 2 * 1024 * 1024;
 
-/// Bandwidth limit in KB/s for slowing the transfer.
-/// At 8 KB/s, a 2 MB file takes ~256 seconds - far longer than our kill delay.
+/// Daemon bytes the proxy forwards before stalling forever.
 #[cfg(unix)]
-const BWLIMIT_KBPS: u32 = 8;
+const FORWARD_CAP: u64 = 512 * 1024;
 
-/// How long to wait before interrupting the client (seconds).
-/// At 8 KB/s, ~24 KB should be received in 3 seconds.
+/// How long to wait for the receiver to put bytes on disk before interrupting.
 #[cfg(unix)]
-const KILL_DELAY: Duration = Duration::from_secs(3);
+const PROGRESS_WAIT: Duration = Duration::from_secs(20);
 
-/// Maximum time to wait for the client process to exit after signal.
+/// How long the client may take to exit after SIGTERM.
 #[cfg(unix)]
 const EXIT_WAIT: Duration = Duration::from_secs(10);
 
-/// Generate deterministic test data (repeating byte pattern).
+/// rsync's exit code for SIGINT/SIGTERM/SIGHUP (`errcode.h` `RERR_SIGNAL`).
+#[cfg(unix)]
+const RERR_SIGNAL: i32 = 20;
+
+/// Deterministic payload (repeating byte pattern).
 #[cfg(unix)]
 fn generate_test_data(size: usize) -> Vec<u8> {
     let pattern: Vec<u8> = (0..=255u8).collect();
     pattern.iter().copied().cycle().take(size).collect()
 }
 
-/// Send SIGTERM to a child process and wait for it to exit.
-///
-/// SIGTERM triggers cooperative shutdown so the cleanup code path runs
-/// before the process exits, removing temp files.
+/// Sends SIGTERM and waits for the child, failing the test if it does not go.
 #[cfg(unix)]
-fn sigterm_and_wait(child: &mut Child) {
+fn sigterm_and_wait(child: &mut Child) -> ExitStatus {
     let pid = child.id();
-
-    // SAFETY: sending a signal to a known child process.
+    // SAFETY: sending a signal to a child this process spawned and has not reaped.
     let ret = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
     assert_eq!(ret, 0, "failed to send SIGTERM to child pid {pid}");
 
     let deadline = Instant::now() + EXIT_WAIT;
     loop {
         match child.try_wait() {
-            Ok(Some(_status)) => return,
+            Ok(Some(status)) => return status,
             Ok(None) => {
                 if Instant::now() >= deadline {
                     let _ = child.kill();
                     let _ = child.wait();
-                    panic!("client pid {pid} did not exit within {EXIT_WAIT:?} after SIGTERM");
+                    panic!(
+                        "client pid {pid} ignored SIGTERM for {EXIT_WAIT:?}: the shutdown flag \
+                         is set but nothing on the network path acted on it"
+                    );
                 }
-                thread::sleep(Duration::from_millis(50));
+                thread::sleep(Duration::from_millis(20));
             }
             Err(e) => panic!("error waiting for client pid {pid}: {e}"),
         }
     }
 }
 
-/// Check whether a filename matches rsync's temp file pattern `.name.XXXXXX`.
-///
-/// Rsync creates temp files as `.originalname.XXXXXX` where XXXXXX is a
-/// random suffix. This helper detects such orphans in a directory listing.
+/// Whether a filename matches rsync's temp pattern `.name.XXXXXX`.
 #[cfg(unix)]
 fn is_temp_file_name(name: &str) -> bool {
-    // Temp files start with '.' and have a 6-char random suffix after the last '.'
-    if !name.starts_with('.') {
+    let Some(rest) = name.strip_prefix('.') else {
         return false;
-    }
-    // Strip leading dot, find the last dot, check suffix length
-    let rest = &name[1..];
-    if let Some(last_dot) = rest.rfind('.') {
-        let suffix = &rest[last_dot + 1..];
-        // Random suffix is exactly 6 alphanumeric characters
-        suffix.len() == 6 && suffix.chars().all(|c| c.is_ascii_alphanumeric())
-    } else {
-        false
+    };
+    match rest.rfind('.') {
+        // The random suffix is exactly 6 alphanumeric characters.
+        Some(last_dot) => {
+            let suffix = &rest[last_dot + 1..];
+            suffix.len() == 6 && suffix.chars().all(|c| c.is_ascii_alphanumeric())
+        }
+        None => false,
     }
 }
 
-/// Scan a directory tree recursively for any files matching rsync's temp
-/// file pattern. Returns paths of any orphaned temp files found.
+/// Recursively collects every path under `dir` that looks like an rsync temp.
 #[cfg(unix)]
-fn find_temp_files(dir: &std::path::Path) -> Vec<PathBuf> {
+fn find_temp_files(dir: &Path) -> Vec<PathBuf> {
     let mut temps = Vec::new();
     if let Ok(entries) = fs::read_dir(dir) {
         for entry in entries.flatten() {
@@ -137,270 +129,196 @@ fn find_temp_files(dir: &std::path::Path) -> Vec<PathBuf> {
     temps
 }
 
-/// Verify that a destination directory is completely clean - no final files,
-/// no temp files, no partial files.
+/// A daemon, a stalling proxy in front of it, and a destination directory.
 #[cfg(unix)]
-fn assert_dest_clean(dest_dir: &std::path::Path, context: &str) {
-    let entries: Vec<_> = fs::read_dir(dest_dir)
-        .expect("read dest dir")
-        .filter_map(|e| e.ok())
-        .collect();
-
-    assert!(
-        entries.is_empty(),
-        "{context}: destination should be empty after interrupt without --partial; \
-         found: {:?}",
-        entries.iter().map(|e| e.file_name()).collect::<Vec<_>>()
-    );
+struct StalledTransfer {
+    daemon: TestDaemon,
+    proxy: CappingProxy,
+    dest: TempDir,
 }
 
-/// Single-file transfer without --partial: verify the temp file is removed
-/// and no final file exists after mid-transfer SIGTERM.
-///
-/// This is the core no-partial cleanup test. Without --partial, rsync's
-/// cleanup handler calls `do_unlink()` on the temp file before exiting.
+#[cfg(unix)]
+impl StalledTransfer {
+    fn start() -> Self {
+        let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
+        let proxy =
+            CappingProxy::start(daemon.port(), FORWARD_CAP).expect("start byte-capping proxy");
+        Self {
+            daemon,
+            proxy,
+            dest: tempdir().expect("create dest dir"),
+        }
+    }
+
+    fn add_file(&self, name: &str, size: usize) {
+        create_test_file(
+            &self.daemon.module_path().join(name),
+            &generate_test_data(size),
+        );
+    }
+
+    fn module_url(&self) -> String {
+        format!("rsync://127.0.0.1:{}/testmodule", self.proxy.port())
+    }
+
+    fn dest_path(&self) -> &Path {
+        self.dest.path()
+    }
+
+    /// Runs `client` with `args`, waits for on-disk progress, sends SIGTERM,
+    /// and asserts the interrupted exit code.
+    fn interrupt(&self, client: &Path, args: &[String]) {
+        let mut child = Command::new(client)
+            .args(args)
+            .arg("--timeout=60")
+            .arg(self.dest_path().as_os_str())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn client");
+        let drain = PipeDrain::start(&mut child);
+
+        assert!(
+            wait_for_progress(self.dest_path(), PROGRESS_WAIT),
+            "client wrote nothing to {} within {PROGRESS_WAIT:?}; proxy forwarded {} bytes; \
+             daemon log: {}",
+            self.dest_path().display(),
+            self.proxy.forwarded(),
+            self.daemon
+                .log_contents()
+                .unwrap_or_else(|_| "(unavailable)".into())
+        );
+
+        let status = sigterm_and_wait(&mut child);
+        let (_stdout, stderr) = drain.join();
+        assert_eq!(
+            status.code(),
+            Some(RERR_SIGNAL),
+            "interrupted transfer must exit {RERR_SIGNAL}; stderr: {stderr}"
+        );
+        thread::sleep(Duration::from_millis(200));
+    }
+}
+
+/// Single file, no `--partial`: neither the destination nor the temp survives.
 #[cfg(unix)]
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn no_partial_single_file_no_residue_on_kill() {
-    let oc_rsync = test_support::oc_rsync_bin();
-
-    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
-
-    let test_data = generate_test_data(TEST_FILE_SIZE);
-    create_test_file(&daemon.module_path().join("large.bin"), &test_data);
-
-    let dest_dir = tempdir().expect("create dest dir");
-    let dest_file = dest_dir.path().join("large.bin");
-
-    // Spawn client WITHOUT --partial.
-    let mut child = Command::new(&oc_rsync)
-        .arg(format!("--bwlimit={BWLIMIT_KBPS}"))
-        .arg("--timeout=30")
-        .arg(format!("{}/large.bin", daemon.url()))
-        .arg(dest_dir.path().as_os_str())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn oc-rsync client");
-
-    thread::sleep(KILL_DELAY);
-    sigterm_and_wait(&mut child);
-    thread::sleep(Duration::from_millis(500));
-
-    // The final destination file must not exist.
-    assert!(
-        !dest_file.exists(),
-        "without --partial, destination file must not exist after interrupt"
+    let fixture = StalledTransfer::start();
+    fixture.add_file("large.bin", TEST_FILE_SIZE);
+    fixture.interrupt(
+        &test_support::oc_rsync_bin(),
+        &[format!("{}/large.bin", fixture.module_url())],
     );
 
-    // No temp files matching rsync's `.filename.XXXXXX` pattern should remain.
-    let temp_orphans = find_temp_files(dest_dir.path());
     assert!(
-        temp_orphans.is_empty(),
-        "temp file orphans found in destination: {temp_orphans:?}",
+        !fixture.dest_path().join("large.bin").exists(),
+        "without --partial the destination file must not exist after an interrupt"
     );
-
-    // Destination directory must be completely empty.
-    assert_dest_clean(dest_dir.path(), "single file");
+    let orphans = find_temp_files(fixture.dest_path());
+    assert!(
+        orphans.is_empty(),
+        "temp file orphans left behind: {orphans:?}"
+    );
 }
 
-/// Multi-file recursive transfer without --partial: verify no temp files
-/// remain for any of the files after mid-transfer kill.
-///
-/// Exercises the cleanup path when multiple files are in-flight or queued.
-/// The kill arrives while at least one file is actively transferring;
-/// cleanup must remove the active temp file and leave no partial residue
-/// for any file.
+/// Recursive pull of several files: whatever completed may stay, but it must
+/// be complete, and no temp may survive anywhere in the tree.
 #[cfg(unix)]
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn no_partial_multi_file_no_residue_on_kill() {
-    let oc_rsync = test_support::oc_rsync_bin();
-
-    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
-
-    // Create multiple files of varying sizes. The large files ensure the
-    // transfer is still in progress when we send SIGTERM.
     let files = [
         ("small.txt", 256_usize),
         ("medium.bin", 64 * 1024),
         ("large_a.bin", TEST_FILE_SIZE),
         ("large_b.bin", TEST_FILE_SIZE),
     ];
-
+    let fixture = StalledTransfer::start();
     for (name, size) in &files {
-        let data = generate_test_data(*size);
-        create_test_file(&daemon.module_path().join(name), &data);
+        fixture.add_file(name, *size);
     }
-
-    let dest_dir = tempdir().expect("create dest dir");
-
-    // Pull entire module recursively without --partial.
-    let mut child = Command::new(&oc_rsync)
-        .arg("-r")
-        .arg(format!("--bwlimit={BWLIMIT_KBPS}"))
-        .arg("--timeout=30")
-        .arg(format!("{}/", daemon.url()))
-        .arg(dest_dir.path().as_os_str())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn oc-rsync client");
-
-    thread::sleep(KILL_DELAY);
-    sigterm_and_wait(&mut child);
-    thread::sleep(Duration::from_millis(500));
-
-    // No temp files should remain anywhere in the destination tree.
-    let temp_orphans = find_temp_files(dest_dir.path());
-    assert!(
-        temp_orphans.is_empty(),
-        "temp file orphans found after multi-file kill: {temp_orphans:?}",
+    fixture.interrupt(
+        &test_support::oc_rsync_bin(),
+        &["-r".to_string(), format!("{}/", fixture.module_url())],
     );
 
-    // Files that completed before the kill may exist (small files transfer
-    // quickly even with bwlimit). But any large file that was mid-transfer
-    // must not be present as a partial.
+    let orphans = find_temp_files(fixture.dest_path());
+    assert!(
+        orphans.is_empty(),
+        "temp file orphans found after multi-file kill: {orphans:?}"
+    );
+
     for (name, size) in &files {
-        let dest_file = dest_dir.path().join(name);
+        let dest_file = fixture.dest_path().join(name);
         if dest_file.exists() {
-            let actual_size = fs::metadata(&dest_file).expect("stat dest file").len() as usize;
-            // If the file exists, it must be complete (fully transferred before kill).
+            let actual = fs::metadata(&dest_file).expect("stat dest file").len() as usize;
             assert_eq!(
-                actual_size, *size,
-                "file {name} exists but is incomplete ({actual_size} vs {size} bytes) - \
-                 should have been cleaned up without --partial"
+                actual, *size,
+                "{name} survived the interrupt at {actual} of {size} bytes; without --partial \
+                 an incomplete file must be removed, not left looking finished"
             );
         }
     }
 }
 
-/// Subdirectory transfer without --partial: verify subdirectories are
-/// preserved but no temp files remain after kill.
-///
-/// Rsync creates directories immediately but writes files via temp files.
-/// After cleanup, directories may remain (they are not temp files) but
-/// no `.filename.XXXXXX` temp orphans should exist at any nesting level.
+/// Nested tree: directories are created eagerly and legitimately remain, but
+/// no `.name.XXXXXX` may be left at any depth.
 #[cfg(unix)]
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn no_partial_preserves_dirs_but_removes_temps() {
-    let oc_rsync = test_support::oc_rsync_bin();
-
-    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
-
-    // Create nested directory structure with files at each level.
-    let test_data = generate_test_data(TEST_FILE_SIZE);
-    create_test_file(&daemon.module_path().join("root.bin"), &test_data);
-    create_test_file(&daemon.module_path().join("subdir/nested.bin"), &test_data);
-    create_test_file(
-        &daemon.module_path().join("subdir/deep/leaf.bin"),
-        &test_data,
-    );
-
-    let dest_dir = tempdir().expect("create dest dir");
-
-    let mut child = Command::new(&oc_rsync)
-        .arg("-r")
-        .arg(format!("--bwlimit={BWLIMIT_KBPS}"))
-        .arg("--timeout=30")
-        .arg(format!("{}/", daemon.url()))
-        .arg(dest_dir.path().as_os_str())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn oc-rsync client");
-
-    thread::sleep(KILL_DELAY);
-    sigterm_and_wait(&mut child);
-    thread::sleep(Duration::from_millis(500));
-
-    // No temp files at any level of the directory tree.
-    let temp_orphans = find_temp_files(dest_dir.path());
-    assert!(
-        temp_orphans.is_empty(),
-        "temp file orphans found in nested directory tree: {temp_orphans:?}",
-    );
-
-    // Verify no incomplete files exist.
+    let fixture = StalledTransfer::start();
     for name in ["root.bin", "subdir/nested.bin", "subdir/deep/leaf.bin"] {
-        let dest_file = dest_dir.path().join(name);
+        fixture.add_file(name, TEST_FILE_SIZE);
+    }
+    fixture.interrupt(
+        &test_support::oc_rsync_bin(),
+        &["-r".to_string(), format!("{}/", fixture.module_url())],
+    );
+
+    let orphans = find_temp_files(fixture.dest_path());
+    assert!(
+        orphans.is_empty(),
+        "temp file orphans found in nested tree: {orphans:?}"
+    );
+
+    for name in ["root.bin", "subdir/nested.bin", "subdir/deep/leaf.bin"] {
+        let dest_file = fixture.dest_path().join(name);
         if dest_file.exists() {
-            let actual_size = fs::metadata(&dest_file).expect("stat").len() as usize;
+            let actual = fs::metadata(&dest_file).expect("stat").len() as usize;
             assert_eq!(
-                actual_size, TEST_FILE_SIZE,
-                "file {name} exists but is incomplete ({actual_size} bytes) - \
-                 should have been cleaned up without --partial"
+                actual, TEST_FILE_SIZE,
+                "{name} survived the interrupt at {actual} of {TEST_FILE_SIZE} bytes"
             );
         }
     }
 }
 
-/// Upstream rsync client against oc-rsync daemon without --partial:
-/// verify cross-implementation compatibility of temp file cleanup.
+/// The same expectation against an upstream client, pinning oc's daemon side.
 ///
-/// The oc-rsync daemon must cooperate correctly with an upstream rsync
-/// client that does not use --partial, ensuring the client's cleanup
-/// handler can remove the temp file without interference.
+/// A missing upstream binary fails the test: an interop assertion that skips
+/// itself asserts nothing.
 #[cfg(unix)]
 #[test]
-#[ignore = "requires upstream rsync 3.4.1 and oc-rsync binary"]
 fn upstream_client_no_partial_cleans_up_on_kill() {
-    let upstream_rsync = std::path::Path::new(common::UPSTREAM_3_4_1);
-    if !upstream_rsync.exists() {
-        eprintln!(
-            "Skipping: upstream rsync 3.4.1 not found at {}",
-            common::UPSTREAM_3_4_1
-        );
-        return;
-    }
+    let upstream = upstream_rsync();
+    let fixture = StalledTransfer::start();
+    fixture.add_file("large.bin", TEST_FILE_SIZE);
+    fixture.interrupt(&upstream, &[format!("{}/large.bin", fixture.module_url())]);
 
-    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
-
-    let test_data = generate_test_data(TEST_FILE_SIZE);
-    create_test_file(&daemon.module_path().join("large.bin"), &test_data);
-
-    let dest_dir = tempdir().expect("create dest dir");
-    let dest_file = dest_dir.path().join("large.bin");
-
-    // Upstream rsync client without --partial pulling from oc-rsync daemon.
-    let mut child = Command::new(upstream_rsync)
-        .arg(format!("--bwlimit={BWLIMIT_KBPS}"))
-        .arg("--timeout=30")
-        .arg(format!("{}/large.bin", daemon.url()))
-        .arg(dest_dir.path().as_os_str())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn upstream rsync client");
-
-    thread::sleep(KILL_DELAY);
-    sigterm_and_wait(&mut child);
-    thread::sleep(Duration::from_millis(500));
-
-    // Without --partial, the destination file must not exist.
     assert!(
-        !dest_file.exists(),
-        "upstream rsync without --partial must not leave destination file; \
-         daemon log: {}",
-        daemon
+        !fixture.dest_path().join("large.bin").exists(),
+        "upstream without --partial must not leave a destination file; daemon log: {}",
+        fixture
+            .daemon
             .log_contents()
             .unwrap_or_else(|_| "(unavailable)".into())
     );
-
-    // No temp files should remain.
-    let temp_orphans = find_temp_files(dest_dir.path());
+    let orphans = find_temp_files(fixture.dest_path());
     assert!(
-        temp_orphans.is_empty(),
-        "upstream rsync left temp file orphans: {temp_orphans:?}",
+        orphans.is_empty(),
+        "upstream left temp file orphans: {orphans:?}"
     );
-
-    assert_dest_clean(dest_dir.path(), "upstream client no-partial");
 }
 
 #[cfg(unix)]
@@ -408,6 +326,8 @@ fn upstream_client_no_partial_cleans_up_on_kill() {
 mod temp_file_pattern_tests {
     use super::is_temp_file_name;
 
+    /// The scanner must recognise the `.name.XXXXXX` shape rsync actually
+    /// produces, including names that already contain dots.
     #[test]
     fn detects_rsync_temp_pattern() {
         assert!(is_temp_file_name(".large.bin.a1b2c3"));
@@ -415,18 +335,15 @@ mod temp_file_pattern_tests {
         assert!(is_temp_file_name(".a.b.c.d.AbCdEf"));
     }
 
+    /// Ordinary dotfiles and short/long suffixes must not be reported as
+    /// orphans, or the cleanup assertions would fail on innocent files.
     #[test]
     fn rejects_non_temp_names() {
-        // Normal dotfiles
+        assert!(!is_temp_file_name(".bashrc"));
         assert!(!is_temp_file_name(".rsync-filter"));
-        assert!(!is_temp_file_name(".gitignore"));
-        // Non-dotfiles
         assert!(!is_temp_file_name("large.bin"));
-        assert!(!is_temp_file_name("file.txt"));
-        // Wrong suffix length
-        assert!(!is_temp_file_name(".file.abc"));
-        assert!(!is_temp_file_name(".file.abcdefg"));
-        // Non-alphanumeric suffix
-        assert!(!is_temp_file_name(".file.ab!cd_"));
+        assert!(!is_temp_file_name(".large.bin.a1b2c"));
+        assert!(!is_temp_file_name(".large.bin.a1b2c3d"));
+        assert!(!is_temp_file_name(".large.bin.a1b2c-"));
     }
 }

--- a/crates/core/tests/no_partial_temp_cleanup.rs
+++ b/crates/core/tests/no_partial_temp_cleanup.rs
@@ -296,10 +296,13 @@ fn no_partial_preserves_dirs_but_removes_temps() {
 
 /// The same expectation against an upstream client, pinning oc's daemon side.
 ///
-/// A missing upstream binary fails the test: an interop assertion that skips
-/// itself asserts nothing.
+/// Opt-in like every other upstream-requiring test here, because the standard
+/// test cells have no upstream rsync (macOS ships openrsync at
+/// `/usr/bin/rsync`). Once selected it never skips itself: [`upstream_rsync`]
+/// panics naming every path it tried rather than returning green.
 #[cfg(unix)]
 #[test]
+#[ignore = "requires an upstream rsync binary"]
 fn upstream_client_no_partial_cleans_up_on_kill() {
     let upstream = upstream_rsync();
     let fixture = StalledTransfer::start();

--- a/crates/core/tests/partial_mid_transfer_kill.rs
+++ b/crates/core/tests/partial_mid_transfer_kill.rs
@@ -295,13 +295,16 @@ fn partial_dir_flag_retains_file_in_directory_on_kill() {
     );
 }
 
-/// The same three assertions against an upstream client, pinning oc's daemon
-/// side and giving the oc-client expectations a live reference.
+/// The same assertions against an upstream client, pinning oc's daemon side
+/// and giving the oc-client expectations a live reference.
 ///
-/// A missing upstream binary fails the test: an interop assertion that skips
-/// itself asserts nothing.
+/// Opt-in like every other upstream-requiring test here, because the standard
+/// test cells have no upstream rsync (macOS ships openrsync at
+/// `/usr/bin/rsync`). Once selected it never skips itself: [`upstream_rsync`]
+/// panics naming every path it tried rather than returning green.
 #[cfg(unix)]
 #[test]
+#[ignore = "requires an upstream rsync binary"]
 fn upstream_client_partial_retains_file_on_kill() {
     let upstream = upstream_rsync();
     let fixture = StalledTransfer::start();

--- a/crates/core/tests/partial_mid_transfer_kill.rs
+++ b/crates/core/tests/partial_mid_transfer_kill.rs
@@ -1,385 +1,332 @@
-//! Interop test: --partial mid-transfer kill retains partial file.
+//! Interop test: SIGTERM mid daemon transfer honours the `--partial` contract.
 //!
-//! Verifies that when a daemon transfer is interrupted mid-stream with
-//! `--partial` enabled, the partially-received file is retained at the
-//! destination rather than cleaned up. This mirrors upstream rsync behavior
-//! from `cleanup.c:130-135` where `keep_partial && got_literal` retains
-//! the temp file at the destination path.
+//! A signal that arrives while the client is blocked reading delta data off
+//! the wire must stop the transfer promptly, exit with `RERR_SIGNAL` (20), and
+//! leave exactly what upstream leaves:
 //!
-//! Test strategy:
-//! 1. Start oc-rsync daemon serving a large (2 MB) test file
-//! 2. Spawn oc-rsync client subprocess to pull with `--partial --bwlimit=8`
-//! 3. Send SIGTERM to the client after partial data has been received
-//! 4. Verify the partial file is retained at the destination
-//! 5. Verify the retained file has some data (not empty, not complete)
+//! | flags | destination after SIGTERM |
+//! |---|---|
+//! | `--partial` | the partial bytes at the final path |
+//! | none | nothing (see `no_partial_temp_cleanup.rs`) |
+//! | `--partial-dir=DIR` | the partial bytes in `DIR`, nothing at the final path |
 //!
-//! The `--bwlimit=8` (8 KB/s) slows the transfer to ~250 seconds for the
-//! 2 MB file, giving a large kill window. The test interrupts the client
-//! after 3 seconds, by which time ~24 KB should have been received.
-//!
-//! SIGTERM (not SIGKILL) is used because `--partial` relies on cooperative
-//! shutdown: the signal handler sets the shutdown flag, the main thread
-//! propagates shutdown through the SPSC channels, and the disk commit
-//! thread retains the partial file before exiting.
+//! The transfer is made structurally unable to complete by interposing
+//! [`common::CappingProxy`], which forwards a bounded number of daemon bytes
+//! and then stalls with the connection still open. That is what lets the kill
+//! be gated on observed on-disk progress instead of a timing guess, and it is
+//! why `--bwlimit` is not used: upstream throttles socket *writes*
+//! (`io.c:861`), so on a daemon pull the limit belongs to the daemon and is
+//! inert on the client side.
 //!
 //! Upstream reference:
-//! - `cleanup.c:105-135` - partial file retention on interrupt
-//! - `receiver.c:340-345` - `do_rename(partialptr, fname)` on interrupt
-//! - `options.c:keep_partial` - `--partial` flag
+//! - `rsync.c:684 sig_int()` - records the signal, `exit_cleanup(RERR_SIGNAL)`
+//! - `cleanup.c:159-183` - `cleanup_got_literal && keep_partial` retention,
+//!   `handle_partial_dir(PDIR_CREATE)` for `--partial-dir`, modtime 0 stamp
+//!   for plain `--partial`
+//! - `errcode.h` - `RERR_SIGNAL` is 20
 
 #[cfg(unix)]
 mod common;
 
 #[cfg(unix)]
-use common::{DaemonBinary, TestDaemon, create_test_file};
+use common::{
+    CappingProxy, DaemonBinary, PipeDrain, TestDaemon, create_test_file, upstream_rsync,
+    wait_for_progress,
+};
 
 #[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
 use std::path::Path;
 #[cfg(unix)]
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 #[cfg(unix)]
 use std::thread;
 #[cfg(unix)]
 use std::time::{Duration, Instant};
 
 #[cfg(unix)]
-use tempfile::tempdir;
+use tempfile::{TempDir, tempdir};
 
-/// Size of the test file (2 MB) - large enough that a bandwidth-limited
-/// transfer takes several seconds, giving a reliable kill window.
+/// Size of the test file. Comfortably larger than [`FORWARD_CAP`] so the
+/// transfer cannot finish before the proxy stalls.
 #[cfg(unix)]
 const TEST_FILE_SIZE: usize = 2 * 1024 * 1024;
 
-/// Bandwidth limit in KB/s for slowing the transfer.
-/// At 8 KB/s, a 2 MB file takes ~256 seconds - far longer than our kill delay.
+/// Daemon bytes the proxy forwards before stalling forever.
+///
+/// Large enough that the receiver has certainly opened its temp file and
+/// written literal data (which is what arms upstream's `cleanup_got_literal`
+/// gate), small enough that the file is nowhere near complete.
 #[cfg(unix)]
-const BWLIMIT_KBPS: u32 = 8;
+const FORWARD_CAP: u64 = 512 * 1024;
 
-/// How long to wait before interrupting the client (seconds).
-/// At 8 KB/s, ~24 KB should be received in 3 seconds.
+/// How long to wait for the receiver to put bytes on disk before interrupting.
 #[cfg(unix)]
-const KILL_DELAY: Duration = Duration::from_secs(3);
+const PROGRESS_WAIT: Duration = Duration::from_secs(20);
 
-/// Maximum time to wait for the client process to exit after signal.
+/// How long the client may take to exit after SIGTERM.
+///
+/// Upstream exits in ~0.4 s, dominated by the deliberate `msleep(400)` in
+/// `rsync.c:694`. Anything in seconds here means the signal was not observed.
 #[cfg(unix)]
 const EXIT_WAIT: Duration = Duration::from_secs(10);
 
-/// Generate deterministic test data (repeating pattern, not random).
-///
-/// Uses a repeating byte pattern so partial content can be verified as
-/// a prefix of the full content, ruling out corruption.
+/// rsync's exit code for SIGINT/SIGTERM/SIGHUP (`errcode.h` `RERR_SIGNAL`).
+#[cfg(unix)]
+const RERR_SIGNAL: i32 = 20;
+
+/// Deterministic payload: a repeating byte pattern, so a retained partial can
+/// be checked to be a genuine prefix of the source rather than merely the
+/// right length.
 #[cfg(unix)]
 fn generate_test_data(size: usize) -> Vec<u8> {
     let pattern: Vec<u8> = (0..=255u8).collect();
     pattern.iter().copied().cycle().take(size).collect()
 }
 
-/// Send SIGTERM to a child process and wait for it to exit.
-///
-/// SIGTERM triggers cooperative shutdown - the signal handler sets an
-/// atomic flag, the main thread detects it and propagates shutdown
-/// through the SPSC channels, allowing the disk commit thread to
-/// retain partial files before exiting.
+/// A daemon, a stalling proxy in front of it, and a destination directory.
 #[cfg(unix)]
-fn sigterm_and_wait(child: &mut Child) {
-    let pid = child.id();
+struct StalledTransfer {
+    daemon: TestDaemon,
+    proxy: CappingProxy,
+    dest: TempDir,
+    data: Vec<u8>,
+}
 
-    // Send SIGTERM for cooperative shutdown.
-    // SAFETY: sending a signal to a known child process.
+#[cfg(unix)]
+impl StalledTransfer {
+    fn start() -> Self {
+        let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
+        let data = generate_test_data(TEST_FILE_SIZE);
+        create_test_file(&daemon.module_path().join("large.bin"), &data);
+        let proxy =
+            CappingProxy::start(daemon.port(), FORWARD_CAP).expect("start byte-capping proxy");
+        Self {
+            daemon,
+            proxy,
+            dest: tempdir().expect("create dest dir"),
+            data,
+        }
+    }
+
+    fn source_url(&self) -> String {
+        format!(
+            "rsync://127.0.0.1:{}/testmodule/large.bin",
+            self.proxy.port()
+        )
+    }
+
+    fn dest_path(&self) -> &Path {
+        self.dest.path()
+    }
+
+    /// Runs `client` with `flags`, waits for on-disk progress, sends SIGTERM,
+    /// and returns the client's exit status.
+    fn interrupt(&self, client: &Path, flags: &[&str]) -> ExitStatus {
+        let mut child = Command::new(client)
+            .args(flags)
+            .arg("--timeout=60")
+            .arg(self.source_url())
+            .arg(self.dest_path().as_os_str())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn client");
+        let drain = PipeDrain::start(&mut child);
+
+        assert!(
+            wait_for_progress(self.dest_path(), PROGRESS_WAIT),
+            "client wrote nothing to {} within {PROGRESS_WAIT:?}; proxy forwarded {} bytes; \
+             daemon log: {}",
+            self.dest_path().display(),
+            self.proxy.forwarded(),
+            self.daemon
+                .log_contents()
+                .unwrap_or_else(|_| "(unavailable)".into())
+        );
+
+        let status = sigterm_and_wait(&mut child);
+        let (_stdout, stderr) = drain.join();
+        assert!(
+            self.proxy.forwarded() <= FORWARD_CAP,
+            "proxy must not exceed its cap: forwarded {}",
+            self.proxy.forwarded()
+        );
+        assert_eq!(
+            status.code(),
+            Some(RERR_SIGNAL),
+            "interrupted transfer must exit {RERR_SIGNAL}; stderr: {stderr}"
+        );
+        // Give the retained rename a moment to land before the caller stats.
+        thread::sleep(Duration::from_millis(200));
+        status
+    }
+}
+
+/// Sends SIGTERM and waits for the child, failing the test if it does not go.
+#[cfg(unix)]
+fn sigterm_and_wait(child: &mut Child) -> ExitStatus {
+    let pid = child.id();
+    // SAFETY: sending a signal to a child this process spawned and has not reaped.
     let ret = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
     assert_eq!(ret, 0, "failed to send SIGTERM to child pid {pid}");
 
-    // Wait for the process to exit gracefully.
     let deadline = Instant::now() + EXIT_WAIT;
     loop {
         match child.try_wait() {
-            Ok(Some(_status)) => return,
+            Ok(Some(status)) => return status,
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    // Last resort: SIGKILL if SIGTERM didn't work.
                     let _ = child.kill();
                     let _ = child.wait();
-                    panic!("client pid {pid} did not exit within {EXIT_WAIT:?} after SIGTERM");
+                    panic!(
+                        "client pid {pid} ignored SIGTERM for {EXIT_WAIT:?}: the shutdown flag \
+                         is set but nothing on the network path acted on it"
+                    );
                 }
-                thread::sleep(Duration::from_millis(50));
+                thread::sleep(Duration::from_millis(20));
             }
             Err(e) => panic!("error waiting for client pid {pid}: {e}"),
         }
     }
 }
 
-/// Test that `--partial` retains the partially-received file when the
-/// client is interrupted mid-transfer via SIGTERM.
+/// `--partial` must leave the received prefix at the final destination path.
 ///
-/// This is the primary interop test for PIR-6.a: it exercises the full
-/// daemon-to-client transfer path with a SIGTERM interrupt, verifying
-/// that the disk commit thread's `retain_partial_file` logic works
-/// end-to-end through the signal handler and cooperative shutdown path.
+/// upstream: `cleanup.c:167-182` renames the temp onto `cleanup_new_fname`
+/// when `keep_partial` is set and literal data arrived.
 #[cfg(unix)]
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn partial_flag_retains_file_on_mid_transfer_kill() {
-    let oc_rsync = test_support::oc_rsync_bin();
+    let fixture = StalledTransfer::start();
+    fixture.interrupt(&test_support::oc_rsync_bin(), &["--partial"]);
 
-    // Start oc-rsync daemon with a large test file.
-    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
-
-    let test_data = generate_test_data(TEST_FILE_SIZE);
-    create_test_file(&daemon.module_path().join("large.bin"), &test_data);
-
-    let dest_dir = tempdir().expect("create dest dir");
-    let dest_file = dest_dir.path().join("large.bin");
-
-    // Spawn oc-rsync client with --partial and --bwlimit to slow transfer.
-    let mut child = Command::new(&oc_rsync)
-        .arg("--partial")
-        .arg(format!("--bwlimit={BWLIMIT_KBPS}"))
-        .arg("--timeout=30")
-        .arg(format!("{}/large.bin", daemon.url()))
-        .arg(dest_dir.path().as_os_str())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn oc-rsync client");
-
-    // Wait for the transfer to make progress before interrupting.
-    thread::sleep(KILL_DELAY);
-
-    // Send SIGTERM for cooperative shutdown (partial retention requires it).
-    sigterm_and_wait(&mut child);
-
-    // Allow brief settling time for filesystem flush.
-    thread::sleep(Duration::from_millis(500));
-
-    // Verify: the partial file must exist at the destination.
+    let dest_file = fixture.dest_path().join("large.bin");
     assert!(
         dest_file.exists(),
-        "partial file must be retained at destination after SIGTERM; \
-         daemon log: {}",
-        daemon
+        "--partial must leave the partial at the destination; daemon log: {}",
+        fixture
+            .daemon
             .log_contents()
             .unwrap_or_else(|_| "(unavailable)".into())
     );
 
-    // Verify: the partial file must have some data (not empty).
-    let partial_content = fs::read(&dest_file).expect("read partial file");
+    let partial = fs::read(&dest_file).expect("read partial file");
+    assert!(!partial.is_empty(), "retained partial must not be empty");
     assert!(
-        !partial_content.is_empty(),
-        "partial file must not be empty"
+        partial.len() < TEST_FILE_SIZE,
+        "the proxy caps the transfer at {FORWARD_CAP} bytes, so a complete \
+         {TEST_FILE_SIZE}-byte file means the interrupt was not what stopped it"
     );
-
-    // Verify: the partial file must be smaller than the original
-    // (the transfer was interrupted before completion).
-    assert!(
-        partial_content.len() < TEST_FILE_SIZE,
-        "partial file ({} bytes) should be smaller than the full file ({} bytes); \
-         if equal, the transfer completed before the interrupt",
-        partial_content.len(),
-        TEST_FILE_SIZE
-    );
-
-    // Verify: the partial content is a valid prefix of the original data,
-    // ruling out corruption during the partial write.
     assert_eq!(
-        &partial_content[..],
-        &test_data[..partial_content.len()],
-        "partial file content must be a valid prefix of the original data"
+        &partial[..],
+        &fixture.data[..partial.len()],
+        "the retained partial must be a byte-exact prefix of the source"
     );
 }
 
-/// Test that without `--partial`, temp files are cleaned up on interrupt.
+/// Without `--partial` nothing may survive - neither the destination file nor
+/// the `.name.XXXXXX` temp the receiver was writing.
 ///
-/// This is the control test: verifies that the default behavior (no
-/// `--partial`) removes temp files when the transfer is interrupted.
+/// upstream: `cleanup.c:194-197` unlinks `cleanup_fname` when `keep_partial`
+/// is unset.
 #[cfg(unix)]
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn no_partial_flag_cleans_up_on_mid_transfer_kill() {
-    let oc_rsync = test_support::oc_rsync_bin();
+    let fixture = StalledTransfer::start();
+    fixture.interrupt(&test_support::oc_rsync_bin(), &[]);
 
-    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
-
-    let test_data = generate_test_data(TEST_FILE_SIZE);
-    create_test_file(&daemon.module_path().join("large.bin"), &test_data);
-
-    let dest_dir = tempdir().expect("create dest dir");
-    let dest_file = dest_dir.path().join("large.bin");
-
-    // Spawn client WITHOUT --partial.
-    let mut child = Command::new(&oc_rsync)
-        .arg(format!("--bwlimit={BWLIMIT_KBPS}"))
-        .arg("--timeout=30")
-        .arg(format!("{}/large.bin", daemon.url()))
-        .arg(dest_dir.path().as_os_str())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn oc-rsync client");
-
-    thread::sleep(KILL_DELAY);
-    sigterm_and_wait(&mut child);
-
-    thread::sleep(Duration::from_millis(500));
-
-    // Without --partial, the destination file should NOT exist.
-    // The temp file should have been cleaned up on shutdown.
-    assert!(
-        !dest_file.exists(),
-        "without --partial, the destination file must not exist after interrupt; \
-         found {} bytes at {}",
-        dest_file.metadata().map(|m| m.len()).unwrap_or(0),
-        dest_file.display()
-    );
-
-    // Also verify no temp files were left behind in the destination directory.
-    let entries: Vec<_> = fs::read_dir(dest_dir.path())
+    let leftovers: Vec<_> = fs::read_dir(fixture.dest_path())
         .expect("read dest dir")
         .filter_map(|e| e.ok())
+        .map(|e| e.file_name())
         .collect();
     assert!(
-        entries.is_empty(),
-        "no files should remain in destination directory without --partial; \
-         found: {:?}",
-        entries.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+        leftovers.is_empty(),
+        "without --partial the destination must be empty after an interrupt; found: {leftovers:?}"
     );
 }
 
-/// Test that `--partial-dir` retains the partial file in the specified
-/// directory on mid-transfer interrupt.
+/// `--partial-dir=DIR` must put the prefix in `DIR` and leave the final path
+/// untouched.
 ///
-/// When `--partial-dir=DIR` is used and the transfer is interrupted, the
-/// partial file should be placed in DIR relative to the destination,
-/// not at the final destination path.
+/// upstream: `cleanup.c:167` routes the temp through
+/// `handle_partial_dir(PDIR_CREATE)`, and unlike plain `--partial` it does not
+/// stamp the modtime.
 #[cfg(unix)]
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn partial_dir_flag_retains_file_in_directory_on_kill() {
-    let oc_rsync = test_support::oc_rsync_bin();
-
-    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
-
-    let test_data = generate_test_data(TEST_FILE_SIZE);
-    create_test_file(&daemon.module_path().join("large.bin"), &test_data);
-
-    let dest_dir = tempdir().expect("create dest dir");
-    let dest_file = dest_dir.path().join("large.bin");
     let partial_dir_name = ".rsync-partial";
-    let partial_file = dest_dir.path().join(partial_dir_name).join("large.bin");
+    let fixture = StalledTransfer::start();
+    fixture.interrupt(
+        &test_support::oc_rsync_bin(),
+        &[&format!("--partial-dir={partial_dir_name}")],
+    );
 
-    // Spawn client with --partial-dir.
-    let mut child = Command::new(&oc_rsync)
-        .arg(format!("--partial-dir={partial_dir_name}"))
-        .arg(format!("--bwlimit={BWLIMIT_KBPS}"))
-        .arg("--timeout=30")
-        .arg(format!("{}/large.bin", daemon.url()))
-        .arg(dest_dir.path().as_os_str())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn oc-rsync client");
+    let dest_file = fixture.dest_path().join("large.bin");
+    let partial_file = fixture.dest_path().join(partial_dir_name).join("large.bin");
 
-    thread::sleep(KILL_DELAY);
-    sigterm_and_wait(&mut child);
-
-    thread::sleep(Duration::from_millis(500));
-
-    // The final destination should NOT have the file.
     assert!(
         !dest_file.exists(),
-        "with --partial-dir, the file should NOT be at the final destination"
+        "--partial-dir must not leave anything at the final destination"
     );
-
-    // The partial file should be in the partial directory.
     assert!(
         partial_file.exists(),
-        "partial file must be retained in --partial-dir={partial_dir_name}; \
-         daemon log: {}",
-        daemon
+        "--partial-dir={partial_dir_name} must hold the partial; daemon log: {}",
+        fixture
+            .daemon
             .log_contents()
             .unwrap_or_else(|_| "(unavailable)".into())
     );
 
-    let partial_content = fs::read(&partial_file).expect("read partial file");
+    let partial = fs::read(&partial_file).expect("read partial file");
+    assert!(!partial.is_empty(), "retained partial must not be empty");
     assert!(
-        !partial_content.is_empty(),
-        "partial file in partial-dir must not be empty"
+        partial.len() < TEST_FILE_SIZE,
+        "partial ({} bytes) must be shorter than the {TEST_FILE_SIZE}-byte source",
+        partial.len()
     );
-    assert!(
-        partial_content.len() < TEST_FILE_SIZE,
-        "partial file ({} bytes) should be smaller than the full file ({} bytes)",
-        partial_content.len(),
-        TEST_FILE_SIZE
+    assert_eq!(
+        &partial[..],
+        &fixture.data[..partial.len()],
+        "the retained partial must be a byte-exact prefix of the source"
     );
 }
 
-/// Test that `--partial` works correctly with upstream rsync client
-/// pulling from oc-rsync daemon.
+/// The same three assertions against an upstream client, pinning oc's daemon
+/// side and giving the oc-client expectations a live reference.
 ///
-/// This is the cross-implementation interop test: upstream rsync client
-/// with `--partial` pulling from oc-rsync daemon, interrupted mid-transfer.
+/// A missing upstream binary fails the test: an interop assertion that skips
+/// itself asserts nothing.
 #[cfg(unix)]
 #[test]
-#[ignore = "requires upstream rsync 3.4.1 and oc-rsync binary"]
 fn upstream_client_partial_retains_file_on_kill() {
-    let upstream_rsync = Path::new(common::UPSTREAM_3_4_1);
-    if !upstream_rsync.exists() {
-        eprintln!(
-            "Skipping: upstream rsync 3.4.1 not found at {}",
-            common::UPSTREAM_3_4_1
-        );
-        return;
-    }
+    let upstream = upstream_rsync();
+    let fixture = StalledTransfer::start();
+    fixture.interrupt(&upstream, &["--partial"]);
 
-    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
-
-    let test_data = generate_test_data(TEST_FILE_SIZE);
-    create_test_file(&daemon.module_path().join("large.bin"), &test_data);
-
-    let dest_dir = tempdir().expect("create dest dir");
-    let dest_file = dest_dir.path().join("large.bin");
-
-    // Spawn upstream rsync with --partial and --bwlimit.
-    let mut child = Command::new(upstream_rsync)
-        .arg("--partial")
-        .arg(format!("--bwlimit={BWLIMIT_KBPS}"))
-        .arg("--timeout=30")
-        .arg(format!("{}/large.bin", daemon.url()))
-        .arg(dest_dir.path().as_os_str())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn upstream rsync client");
-
-    thread::sleep(KILL_DELAY);
-    sigterm_and_wait(&mut child);
-
-    thread::sleep(Duration::from_millis(500));
-
-    // Upstream rsync with --partial should retain the partial file.
+    let dest_file = fixture.dest_path().join("large.bin");
     assert!(
         dest_file.exists(),
-        "upstream rsync --partial must retain partial file at destination; \
-         daemon log: {}",
-        daemon
+        "upstream --partial must leave the partial at the destination; daemon log: {}",
+        fixture
+            .daemon
             .log_contents()
             .unwrap_or_else(|_| "(unavailable)".into())
     );
 
-    let partial_content = fs::read(&dest_file).expect("read partial file");
+    let partial = fs::read(&dest_file).expect("read partial file");
+    assert!(!partial.is_empty(), "retained partial must not be empty");
     assert!(
-        !partial_content.is_empty(),
-        "upstream rsync partial file must not be empty"
+        partial.len() < TEST_FILE_SIZE,
+        "partial ({} bytes) must be shorter than the {TEST_FILE_SIZE}-byte source",
+        partial.len()
     );
-    assert!(
-        partial_content.len() < TEST_FILE_SIZE,
-        "upstream rsync partial file ({} bytes) should be smaller than full ({} bytes)",
-        partial_content.len(),
-        TEST_FILE_SIZE
+    assert_eq!(
+        &partial[..],
+        &fixture.data[..partial.len()],
+        "the retained partial must be a byte-exact prefix of the source"
     );
 }

--- a/crates/fast_io/src/signal/mod.rs
+++ b/crates/fast_io/src/signal/mod.rs
@@ -3,8 +3,9 @@
 //! Unix uses `libc::sigaction`; non-Unix targets use a no-op stub. Callers
 //! pass an `extern "C" fn(c_int)` handler that must be async-signal-safe
 //! (atomic stores only, no allocation, no locking). The wrapper installs the
-//! handler with `SA_RESTART` so interrupted syscalls auto-retry, matching
-//! upstream rsync's `sigaction` setup in `main.c`.
+//! handler with `sa_flags == 0`, matching upstream rsync's `SIGACTION` macro
+//! (`rsync.h:1258`) over its never-flagged file-static `sigact`, so a blocked
+//! syscall fails with `EINTR` instead of restarting.
 //!
 //! This module exists so the `core` crate can keep `#![deny(unsafe_code)]`
 //! while still installing real Unix signal handlers. The unsafe FFI calls

--- a/crates/fast_io/src/signal/unix.rs
+++ b/crates/fast_io/src/signal/unix.rs
@@ -3,19 +3,25 @@
 //! Encapsulates the single unsafe FFI block. The caller supplies the signal
 //! number and an async-signal-safe `extern "C"` handler; this module
 //! zero-initialises a `sigaction` struct, points `sa_sigaction` at the
-//! handler, sets `SA_RESTART`, and submits it. On failure the underlying
-//! `errno` is returned via `io::Error::last_os_error()`.
+//! handler, and submits it with no flags. On failure the underlying `errno`
+//! is returned via `io::Error::last_os_error()`.
 
 use std::io;
 use std::os::raw::c_int;
 
 use super::SignalHandlerFn;
 
-/// Installs `handler` for `signum` with `SA_RESTART`.
+/// Installs `handler` for `signum` with no `sa_flags`.
 ///
-/// `SA_RESTART` matches upstream rsync's `sig_int`/`sig_term` setup
-/// (`main.c`) so blocking syscalls (`read`, `write`, `select`, `poll`)
-/// resume after the handler returns instead of failing with `EINTR`.
+/// upstream: `rsync.h:1258` defines `SIGACTION(n,h)` as
+/// `sigact.sa_handler = (h), sigaction((n), &sigact, NULL)` over a
+/// file-static `struct sigaction sigact` (`main.c:133`, `cleanup.c:43`) that
+/// is never given any flags, so `sa_flags == 0` and `SA_RESTART` is *not*
+/// set. Upstream depends on that: a signal aborts the blocking `select()` in
+/// `perform_io()` with `EINTR`, which `io.c:766-779` treats exactly like a
+/// timeout, and the next loop iteration observes `got_kill_signal`
+/// (`io.c:750`). Installing with `SA_RESTART` instead would restart the
+/// blocked syscall and the flag would never be read.
 ///
 /// The handler must be async-signal-safe: only atomic stores against
 /// statically allocated atomics, no allocation, no locking, no calls into
@@ -28,14 +34,13 @@ use super::SignalHandlerFn;
 pub fn install_signal_handler(signum: c_int, handler: SignalHandlerFn) -> io::Result<()> {
     // SAFETY: `libc::sigaction` is zero-initialised (valid POD layout);
     // `sa_sigaction` is set to a `'static extern "C" fn(c_int)`, which has
-    // the ABI `sigaction(2)` expects; the empty signal mask and `SA_RESTART`
-    // flag mirror upstream rsync. The caller contract requires `handler` to
-    // be async-signal-safe.
+    // the ABI `sigaction(2)` expects; the empty signal mask and zero
+    // `sa_flags` mirror upstream rsync's file-static `sigact`. The caller
+    // contract requires `handler` to be async-signal-safe.
     #[allow(unsafe_code)]
     unsafe {
         let mut action: libc::sigaction = std::mem::zeroed();
         action.sa_sigaction = handler as *const () as libc::sighandler_t;
-        action.sa_flags = libc::SA_RESTART;
         libc::sigemptyset(&mut action.sa_mask as *mut libc::sigset_t);
 
         if libc::sigaction(signum, &action, std::ptr::null_mut()) != 0 {

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -20,12 +20,64 @@ use crate::temp_guard::open_tmpfile;
 #[cfg(unix)]
 use crate::temp_guard::open_tmpfile_sandboxed;
 
-use super::super::config::DiskCommitConfig;
+use super::super::config::{DiskCommitConfig, PartialMode};
 use super::super::writer::{ReusableBufWriter, Writer};
 use super::commit::{
     SparseFinalize, commit_file, finalize_sparse, make_backup_copy, retain_partial_file,
 };
 use super::metadata::{apply_file_metadata, finalize_checksum};
+
+/// Registers a network temp file with both global cleanup registries.
+///
+/// `register_temp_file` covers the orphan case (an abort that never runs the
+/// guard's `Drop` must not leave a `.name.XXXXXX` behind).
+/// `register_partial` covers the retention case: it records where an
+/// interrupted temp should end up so the process-wide abort path
+/// (`CleanupManager::finalize_partials`, driven by a second interrupt signal)
+/// honours `--partial` / `--partial-dir` without needing the disk thread to
+/// unwind.
+///
+/// `partial_dest` is `None` until literal data has actually been received,
+/// mirroring upstream's `cleanup_got_literal` gate (`cleanup.c:159`) - a temp
+/// file with no bytes in it is unlinked, never promoted to a partial.
+///
+/// upstream: `cleanup.c:cleanup_set()` records the `cleanup_fname` /
+/// `cleanup_new_fname` pair for exactly this purpose.
+fn register_temp_with_cleanup(
+    config: &DiskCommitConfig,
+    guard: &mut TempFileGuard,
+    dest_path: &std::path::Path,
+    got_literal: bool,
+) {
+    let temp = guard.path().to_path_buf();
+    CleanupManager::global().register_temp_file(temp.clone());
+    let (partial_dest, tweak_mtime) = if got_literal {
+        partial_destination(config, dest_path)
+    } else {
+        (None, false)
+    };
+    CleanupManager::global().register_partial(temp, partial_dest, tweak_mtime);
+    guard.mark_registered();
+}
+
+/// Resolves where an interrupted temp file should be moved, mirroring the
+/// branches of [`retain_partial_file`].
+///
+/// `--partial` renames onto the destination itself and stamps mtime 0 so
+/// `--update` will not skip the stub (`cleanup.c:174-178`); `--partial-dir`
+/// moves into the partial dir and leaves the mtime alone.
+fn partial_destination(
+    config: &DiskCommitConfig,
+    dest_path: &std::path::Path,
+) -> (Option<std::path::PathBuf>, bool) {
+    match &config.partial_mode {
+        PartialMode::None => (None, false),
+        PartialMode::Partial => (Some(dest_path.to_path_buf()), true),
+        PartialMode::PartialDir(dir) => {
+            (crate::temp_guard::partial_dir_fname(dest_path, dir), false)
+        }
+    }
+}
 
 /// Folds the existing on-disk prefix into the whole-file checksum for
 /// `--append-verify` (append_mode == 2).
@@ -173,15 +225,15 @@ pub(in crate::disk_commit) fn process_file(
             return discard_file_on_open_failure(file_rx, buf_return_tx, open_err);
         }
     };
-    // Register the temp file with the global cleanup manager so a SIGKILL
-    // (which bypasses Drop) still removes orphaned temp files on restart.
-    // Only temp+rename paths produce actual temp files; inplace and device
-    // writes operate on the final destination. The guard records its
-    // registration so its Drop unregisters the path on both success and error,
-    // preventing a per-errored-file PathBuf leak into the global set.
+    // Register the temp file with the global cleanup manager so an abort that
+    // bypasses Drop still removes orphaned temp files (and honours --partial
+    // once literal data arrives). Only temp+rename paths produce actual temp
+    // files; inplace and device writes operate on the final destination. The
+    // guard records its registration so its Drop unregisters the path on both
+    // success and error, preventing a per-errored-file PathBuf leak into the
+    // global set.
     if needs_rename {
-        CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
-        cleanup_guard.mark_registered();
+        register_temp_with_cleanup(config, &mut cleanup_guard, &begin.file_path, false);
     }
 
     // Pre-existing basis length for sparse hole-punching: only in-place writes
@@ -227,6 +279,9 @@ pub(in crate::disk_commit) fn process_file(
     sum_append_prefix(config, &begin, &mut checksum_verifier)?;
 
     let mut bytes_written: u64 = 0;
+    // Tracks whether the temp's cleanup entry has been upgraded to name a
+    // partial destination (see the `cleanup_got_literal` gate at the loop tail).
+    let mut partial_registered = false;
 
     loop {
         let msg = match file_rx.recv() {
@@ -442,6 +497,16 @@ pub(in crate::disk_commit) fn process_file(
                 ));
             }
         }
+
+        // upstream: cleanup.c:159 `cleanup_got_literal` - only once bytes have
+        // landed does an interrupted temp become a partial worth keeping. Same
+        // gate the Abort/Shutdown/disconnect branches above apply; recorded in
+        // the registry here so the process-wide abort path reaches the same
+        // decision without the disk thread unwinding.
+        if needs_rename && !partial_registered && bytes_written > 0 {
+            register_temp_with_cleanup(config, &mut cleanup_guard, &begin.file_path, true);
+            partial_registered = true;
+        }
     }
 }
 
@@ -472,8 +537,15 @@ pub(in crate::disk_commit) fn process_whole_file(
 
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
     if needs_rename {
-        CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
-        cleanup_guard.mark_registered();
+        // The coalesced path carries its whole payload inline, so the
+        // `cleanup_got_literal` question is already settled: a non-empty
+        // WholeFile has literal bytes, an empty one has none.
+        register_temp_with_cleanup(
+            config,
+            &mut cleanup_guard,
+            &begin.file_path,
+            !data.is_empty(),
+        );
     }
 
     // Pre-existing basis length for sparse hole-punching (see process_file).

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -323,6 +323,11 @@ impl GeneratorContext {
         let tolerant = self.config.flags.dry_run;
 
         loop {
+            // upstream: io.c:750 - the sender's I/O loop acts on
+            // got_kill_signal only at a frame boundary. Checking before the
+            // next NDX read means a shutdown never truncates a delta already
+            // being written to the wire.
+            crate::shared::check_shutdown()?;
             // upstream: sender.c:227 - send extra file lists at top of loop
             if inc_recurse {
                 // upstream: flist.c:2139 - file_total - file_old_total < at_least

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -227,6 +227,13 @@ impl ReceiverContext {
             let mut flushed_pending: usize = 0;
 
             loop {
+                // upstream: io.c:750 - perform_io() acts on got_kill_signal at
+                // its loop boundary, never mid-frame. Same here: a shutdown
+                // request between two file responses aborts the loop, and the
+                // `pipelined_receiver.shutdown()` below hands the disk thread
+                // its Shutdown message so the in-flight temp file is finalised
+                // per --partial / --partial-dir.
+                crate::shared::check_shutdown()?;
                 if let Some(ref dl) = deadline {
                     if dl.is_reached() {
                         break;

--- a/crates/transfer/src/shared/interrupt.rs
+++ b/crates/transfer/src/shared/interrupt.rs
@@ -1,0 +1,64 @@
+//! Cooperative shutdown checks for the network transfer loops.
+//!
+//! A signal handler only flips [`fast_io::signal`]'s process-global flag; the
+//! loops that must react to it poll the flag at a boundary where stopping
+//! cannot leave the wire mid-frame. This mirrors upstream, whose `sig_int`
+//! records the signal in `got_kill_signal` (`rsync.c:709-712`) and whose
+//! `perform_io()` acts on it only at its own loop boundaries (`io.c:750`,
+//! `io.c:879`, `io.c:901`).
+//!
+//! The check is *not* what unblocks a transfer parked in a transport read -
+//! the client's signal watcher does that by closing the socket
+//! (`core::signal::wake_blocked_io`). Polling here is what turns the resulting
+//! wake-up into an ordered stop rather than a torn protocol state, and it is
+//! what stops the loops on transports that carry no wakeable socket.
+
+use std::io;
+
+/// Returns an `Interrupted` error when a shutdown signal has been received.
+///
+/// Call at a transfer-loop boundary - never between the halves of a wire
+/// frame. The returned error unwinds through the same teardown as a dropped
+/// connection, so in-progress temp files are finalised by their guards
+/// according to `--partial` / `--partial-dir`.
+///
+/// upstream: `io.c:515 handle_kill_signal()` -> `exit_cleanup(RERR_SIGNAL)`.
+#[inline]
+pub fn check_shutdown() -> io::Result<()> {
+    if fast_io::signal::shutdown_requested() {
+        return Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "received SIGINT, SIGTERM, or SIGHUP",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The flag is process-global, so these two cases must not run in parallel.
+    static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn check_is_ok_while_no_signal_pending() {
+        let _serial = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        fast_io::signal::reset_shutdown_for_testing();
+        assert!(check_shutdown().is_ok());
+    }
+
+    #[test]
+    fn check_reports_interrupted_once_a_signal_is_pending() {
+        let _serial = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        fast_io::signal::reset_shutdown_for_testing();
+        fast_io::signal::mark_shutdown();
+        let err = check_shutdown().expect_err("a pending shutdown must stop the loop");
+        assert_eq!(err.kind(), io::ErrorKind::Interrupted);
+        fast_io::signal::reset_shutdown_for_testing();
+        assert!(
+            check_shutdown().is_ok(),
+            "clearing the flag must re-enable the loop"
+        );
+    }
+}

--- a/crates/transfer/src/shared/mod.rs
+++ b/crates/transfer/src/shared/mod.rs
@@ -7,10 +7,13 @@
 //!
 //! - [`ChecksumFactory`] - Factory for creating signature algorithms from negotiated parameters
 //! - [`TransferDeadline`] - Monotonic deadline for `--stop-at` / `--stop-after` enforcement
+//! - [`check_shutdown`] - Cooperative interrupt check for the transfer loops
 
 pub mod checksum;
 /// Deadline enforcement for `--stop-at` / `--stop-after` / `--time-limit`.
 pub mod deadline;
+pub mod interrupt;
 
 pub use checksum::ChecksumFactory;
 pub use deadline::TransferDeadline;
+pub use interrupt::check_shutdown;

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -627,14 +627,19 @@ impl Drop for TempFileGuard {
 }
 
 impl TempFileGuard {
-    /// Removes this guard's path from the global [`engine::CleanupManager`]
-    /// registry when it was registered. Idempotent: `HashSet::remove` is a
-    /// no-op for an absent key, so a double-unregister (e.g. an explicit
-    /// pre-`keep` unregister followed by this Drop) is harmless.
+    /// Removes this guard's path from both global [`engine::CleanupManager`]
+    /// registries when it was registered. Idempotent: `HashSet::remove` and
+    /// `Vec::retain` are both no-ops for an absent key, so a double-unregister
+    /// (e.g. an explicit pre-`keep` unregister followed by this Drop) is
+    /// harmless.
     #[inline]
     fn unregister(&self) {
         if self.registered {
             engine::CleanupManager::global().unregister_temp_file(&self.path);
+            // The partial entry names where this temp would be moved on an
+            // abort. Once the guard has committed or unlinked the temp there is
+            // nothing left to move, so the entry must go too.
+            engine::CleanupManager::global().unregister_partial(&self.path);
         }
     }
 }


### PR DESCRIPTION
Ctrl-C / SIGTERM did nothing during a network transfer. The client installed handlers, they set atomics, and no code on the network path ever read them, so the transfer carried on until the peer or `--timeout` released it. Under a harness that makes a daemon pull structurally unable to complete, oc **never exited at all** and left the orphaned `.name.XXXXXX` temp behind in every `--partial` variant.

## Root cause (three parts)

1. **`crates/core/src/signal/unix.rs:209-216`** installs SIGINT/SIGTERM/SIGHUP handlers that flip `core::signal::SHUTDOWN_REQUESTED` and `fast_io::signal::SHUTDOWN_REQUESTED`.
2. **`crates/fast_io/src/signal/unix.rs:38`** installed them with `SA_RESTART`, so a blocked `read()` on the transport was restarted rather than returning `EINTR`. The doc comment claimed this matched upstream; it does not. `rsync.h:1258` defines `SIGACTION(n,h)` as `sigact.sa_handler=(h), sigaction((n),&sigact,NULL)` over a file-static `struct sigaction sigact` (`main.c:133`) that is never given any flags, so upstream runs with `sa_flags == 0` and relies on `EINTR` waking `perform_io()`'s `select()` - which `io.c:766-779` handles exactly like a timeout before re-checking `got_kill_signal` at `io.c:750`.
3. **Nothing in `crates/transfer/src` read the flag.** The only three pollers (`engine/src/local_copy/context_impl/transfer.rs:659,767` and `delta_transfer.rs:87`) are local-copy. The double-signal watchdog at `crates/cli/src/frontend/mod.rs:456` then called `finalize_partials()` over a partial registry that only `engine/src/local_copy/executor/file/guard.rs:227` ever populated, so on the network path it had nothing to finalise and `process::exit(20)` skipped every `Drop`.

## What changed

**Poll the flag at the loop boundaries.** `crates/transfer/src/shared/interrupt.rs` adds `check_shutdown()`, called at the top of the receiver loop (`receiver/transfer/pipeline.rs:229`) and the sender loop (`generator/transfer/transfer_loop.rs:325`) - the same boundaries `io.c:750`/`879`/`901` use, so a stop can never truncate a delta mid-frame. The resulting `Interrupted` error unwinds through `pipelined_receiver.shutdown()`, which hands the disk thread its `FileMessage::Shutdown`; that is the retention path `disk_commit/process/file_ops.rs:427` already implements.

**Wake a read that is already blocked.** A loop-boundary check alone is not enough: mid-file, the client is parked inside `read()` on the socket. Upstream does not have this problem because it is one thread per process and the signal interrupts its one `select()`. In a multi-threaded process the kernel delivers the signal to an arbitrary thread, so `EINTR` cannot be relied on to reach the thread that is on the wire. `core::signal::register_io_waker` (new, `crates/core/src/signal/io_wake.rs`) lets the transport register a wake hook for the session's lifetime; the daemon transport registers one that half-closes its socket (`client/module_list/connect/mod.rs`), and the signal watcher fires it from normal context on the first interrupt. The blocked read returns at once and the transfer unwinds through the *connection-loss* path, which is exactly why the on-disk result matches upstream in all three variants.

**Register network temp files with `CleanupManager`.** `disk_commit/process/file_ops.rs` now calls `register_partial` alongside the existing `register_temp_file`, so `finalize_partials()` has something to finalise on the double-signal path. `partial_dest` stays `None` until bytes have actually landed and is only then upgraded to the real destination - the same `cleanup_got_literal` gate upstream applies at `cleanup.c:159`, so a zero-byte temp is unlinked and never promoted to a partial. `TempFileGuard::unregister` drops both registry entries.

**Report the signal, not its wreckage.** An interrupted transfer used to surface as `transfer failed: multiplexed payload truncated ... (code 23)`. `map_server_transfer_error` now short-circuits to the existing `signal_interrupt_error()` when a shutdown is pending, matching upstream's single `received SIGINT, SIGTERM, or SIGHUP (code 20)` line (`rsync.c:709-716` -> `log.c:log_exit()`).

## `SA_RESTART` decision: removed

Dropped, to match upstream's actual contract rather than the comment that claimed to. `sa_flags` is now 0, as `rsync.h:1258` produces. Keeping it would have meant the flag-polling could only ever fire between files, never during one - and any interval short enough to be responsive inside a blocking read would have been a busy-wait. Removing it also aligns with the in-flight `perform_io` convergence (#6946 / task #47), where `EINTR` handling is an explicit requirement. The change is safe for the existing retry helpers: `error.rs:171-245` and `std`'s own `read_exact`/`write_all` already `continue` on `ErrorKind::Interrupted`, so a spurious `EINTR` is retried exactly as before. The daemon is unaffected - it registers through `platform::signal` (`signal_hook`), not this path.

**This did not need task #47 to land.** The wake hook is what unblocks the read; the flag check is an ordinary boundary poll, not a check forced into a blocking read.

## `--partial` retention itself was already correct and is untouched

`disk_commit/process/commit.rs:233 retain_partial_file` and its `bytes_written > 0` gate at `file_ops.rs:244/413/427` were already the right analogue of upstream's `cleanup_got_literal`, and driving the same interrupt as a *connection drop* already matched upstream 3.4.4 byte-for-byte. Not a line of that logic changed. The fix is entirely about making a signal reach that path.

## Verification: oc vs upstream 3.4.4, daemon transfer, SIGTERM mid-stream

Upstream rsync 3.4.4 daemon serving a 2 MB file, a TCP proxy that forwards exactly 512 KiB daemon -> client and then stalls with the connection open (so the transfer cannot complete), SIGTERM sent once on-disk progress is observed. `--bwlimit` is deliberately not used: upstream throttles socket *writes* (`io.c:861`), so on a daemon pull the limit belongs to the daemon and is inert client-side.

**Before (`72c128a21`)**

```
--- oc-rsync-before : partial
    proxy forwarded   : 524288 bytes (cap 524288)
    progress observed : True   pre-kill on disk: [('.large.bin.KIvgmM', 262144)]
    EXIT              : DID NOT EXIT within 40s (SIGKILLed)
    on disk after     : [('.large.bin.KIvgmM', 262144)]

--- oc-rsync-before : no-partial
    EXIT              : DID NOT EXIT within 40s (SIGKILLed)
    on disk after     : [('.large.bin.BmT9Yb', 262144)]

--- oc-rsync-before : partial-dir
    EXIT              : DID NOT EXIT within 40s (SIGKILLed)
    on disk after     : [('.large.bin.4mSk9t', 262144)]
```

**After**

```
--- oc-rsync : partial
    EXIT              : 0.02s after SIGTERM, code 20
    on disk after     : [('large.bin', 491520)]
    stderr            : oc-rsync error: received SIGINT, SIGTERM, or SIGHUP (code 20) at error.rs(311) [receiver=0.6.4]

--- oc-rsync : no-partial
    EXIT              : 0.01s after SIGTERM, code 20
    on disk after     : []

--- oc-rsync : partial-dir
    EXIT              : 0.02s after SIGTERM, code 20
    on disk after     : [('.rsync-partial/large.bin', 491520)]
```

**Upstream 3.4.4 reference (same harness, same run)**

```
--- rsync : partial
    EXIT              : 0.41s after SIGTERM, code 20
    on disk after     : [('large.bin', 491520)]
    stderr            : rsync error: received SIGINT, SIGTERM, or SIGHUP (code 20) at rsync.c(716) [generator=3.4.4]

--- rsync : no-partial
    EXIT              : 0.41s after SIGTERM, code 20
    on disk after     : []

--- rsync : partial-dir
    EXIT              : 0.42s after SIGTERM, code 20
    on disk after     : [('.rsync-partial/large.bin', 491520)]
```

Identical on all three: same exit code (20), same bytes at the same path, same diagnostic text. oc exits faster only because upstream's `sig_int` deliberately sleeps 400 ms (`rsync.c:694`) to let a password-prompting ssh restore the tty. The remaining stderr differences are pre-existing oc conventions: the role tag (`[receiver=]` vs upstream's `[generator=]`, which names its forked half) and the `file(line)` provenance.

## Tests

`crates/core/tests/partial_mid_transfer_kill.rs` and `no_partial_temp_cleanup.rs` were all `#[ignore = "requires oc-rsync binary"]` - wrong twice over: the resolver works, the profile just needed `cargo build --bin oc-rsync`, which CI already does (`ci.yml:287`). The six oc-client tests now run by default, SIGTERM stays the interrupt, and both suites drive the byte-capping proxy instead of `--bwlimit`, gate the kill on observed on-disk progress, assert exit code 20, and drain child pipes on separate threads.

The two cross-implementation tests used to `return` early when `target/interop/upstream-install/3.4.1/bin/rsync` was absent, quietly asserting nothing. They now resolve through `upstream_rsync()`, which probes a list of candidate paths and verifies the `--version` banner is genuinely upstream, and **panics naming every path tried** rather than skipping. They keep an `#[ignore]` opt-in like every other upstream-requiring test in this directory, because the standard test cells have no upstream rsync - macOS ships openrsync at `/usr/bin/rsync`. Selected but unsatisfiable now fails loudly; it can no longer pass while asserting nothing.

- On the parent commit (`72c128a21`) with these tests applied and the ignored cases included: **6 of 10 fail**, all with `client pid N ignored SIGTERM for 10s`. The 4 that pass are the two upstream-client cases (upstream was always correct) and the two temp-name pattern unit tests.
- On this branch: 10/10, and 15 consecutive repeat runs (10 idle + 5 under 8-way CPU load) at `-j 8` / `-j 16` - 150 executions, zero failures.
- Regression: `cargo nextest run -p transfer -p fast_io -p engine -p cli --all-features` 12098/12098 passed; `-p core --all-features` 2707/2707 passed. `cargo fmt --all --check` and `cargo clippy -p transfer -p core -p fast_io -p cli --all-features --all-targets --no-deps -D warnings` clean.

## Out of scope

- `crates/core/tests/sigint_temp_cleanup.rs` still covers nothing - it sets the atomics by hand and calls `CleanupManager::cleanup()` directly, which production never calls. This change does not make it correct, so it is left for task #50.
- SSH transports carry no wakeable socket handle, so they stop at the next file boundary via the flag check rather than immediately. Wiring a waker for the russh and stdio transports is a follow-up.
