### PR TITLE
test(core): assert real signal cleanup instead of simulating it

### DIFF
--- a/crates/core/tests/cleanup_manager.rs
+++ b/crates/core/tests/cleanup_manager.rs
@@ -1,0 +1,93 @@
+//! Unit coverage of [`CleanupManager`] itself.
+//!
+//! Deliberately named after what it exercises. These tests drive the manager
+//! API directly, so they say nothing about whether any signal ever reaches it -
+//! that contract belongs to `sigint_temp_cleanup.rs`, which delivers a real
+//! SIGINT to a real transfer.
+//!
+//! What is left here is the behaviour `signal_integration.rs` does not already
+//! cover: the selectivity of the sweep, and that an abort request does not
+//! bypass it.
+//!
+//! upstream: `cleanup.c:_exit_cleanup()` removes only the file it recorded,
+//! never a directory scan.
+
+#![cfg(unix)]
+
+use core::signal::{CleanupManager, ShutdownReason};
+use std::fs;
+use std::sync::Mutex;
+use tempfile::tempdir;
+
+/// `CleanupManager::global()` is process-wide and `reset_for_testing()` drains
+/// it, so two of these running concurrently would each clear the other's
+/// registrations and pass for the wrong reason.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+/// The sweep must remove exactly the registered paths. rsync's temps sit
+/// beside ordinary dotfiles such as `.rsync-filter`, and a cleanup that
+/// pattern-matched the directory instead of consulting its registry would eat
+/// user data.
+#[test]
+fn cleanup_removes_only_registered_paths() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let manager = CleanupManager::global();
+    manager.reset_for_testing();
+
+    let dest = tempdir().expect("create dest dir");
+    let sub = dest.path().join("subdir");
+    fs::create_dir(&sub).expect("create subdir");
+
+    let registered = [
+        dest.path().join(".root_file.dat.a1b2c3"),
+        sub.join(".nested_file.txt.d4e5f6"),
+        sub.join(".deep_file.log.789abc"),
+    ];
+    for path in &registered {
+        fs::write(path, b"partial transfer data").expect("write temp");
+        manager.register_temp_file(path.clone());
+    }
+
+    // Never registered: a user dotfile, and a completed transfer.
+    let filter_file = dest.path().join(".rsync-filter");
+    fs::write(&filter_file, b"- *.bak").expect("write filter");
+    let completed = dest.path().join("completed_transfer.dat");
+    fs::write(&completed, b"completed data").expect("write completed file");
+
+    manager.cleanup();
+
+    for path in &registered {
+        assert!(!path.exists(), "registered temp must be removed: {path:?}");
+    }
+    assert!(filter_file.exists(), ".rsync-filter must survive cleanup");
+    assert!(completed.exists(), "completed file must survive cleanup");
+    assert!(sub.exists(), "subdirectory must survive cleanup");
+}
+
+/// A second interrupt sets the abort flag for immediate termination. That must
+/// shorten the shutdown, not skip the sweep: upstream still runs
+/// `_exit_cleanup()` on the forced path, and an aborted client that left its
+/// temps behind is the orphan case this whole suite exists to prevent.
+#[test]
+fn cleanup_still_runs_after_an_abort_request() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let manager = CleanupManager::global();
+    manager.reset_for_testing();
+    core::signal::reset_for_testing();
+
+    let dest = tempdir().expect("create dest dir");
+    let temp_file = dest.path().join(".data.bin.abc123");
+    fs::write(&temp_file, b"partial").expect("write temp");
+    manager.register_temp_file(temp_file.clone());
+
+    core::signal::request_shutdown(ShutdownReason::Interrupted);
+    assert!(!core::signal::is_abort_requested());
+    core::signal::request_abort();
+    assert!(core::signal::is_abort_requested());
+
+    manager.cleanup();
+    assert!(
+        !temp_file.exists(),
+        "temp files must be cleaned up even on abort"
+    );
+}

--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -14,6 +14,8 @@ use std::fs;
 use std::io::{self, Read};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::ExitStatus;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -35,6 +37,8 @@ pub const UPSTREAM_3_0_9: &str = "target/interop/upstream-install/3.0.9/bin/rsyn
 pub const UPSTREAM_3_1_3: &str = "target/interop/upstream-install/3.1.3/bin/rsync";
 #[allow(dead_code)]
 pub const UPSTREAM_3_4_1: &str = "target/interop/upstream-install/3.4.1/bin/rsync";
+#[allow(dead_code)]
+pub const UPSTREAM_3_4_4: &str = "target/interop/upstream-install/3.4.4/bin/rsync";
 
 /// Selects which daemon binary to launch.
 #[allow(dead_code)]
@@ -303,8 +307,13 @@ pub fn require_upstream(binary_path: &str) {
 /// machine usually only has the packaged binary. Both are acceptable as long
 /// as the binary is genuinely upstream, which [`upstream_rsync`] verifies from
 /// `--version` rather than from the path it was found at.
+/// The reference version is 3.4.4; the harness build and the source-tree build
+/// come first so a machine with both uses the pinned one rather than whatever
+/// the package manager shipped.
 #[allow(dead_code)]
 const UPSTREAM_CANDIDATES: &[&str] = &[
+    UPSTREAM_3_4_4,
+    "target/interop/upstream-src/rsync-3.4.4/rsync",
     UPSTREAM_3_4_1,
     "/opt/homebrew/bin/rsync",
     "/usr/local/bin/rsync",
@@ -316,16 +325,20 @@ const UPSTREAM_CANDIDATES: &[&str] = &[
 ///
 /// A missing upstream binary must fail the test rather than silently return:
 /// a cross-implementation assertion that quietly asserts nothing is worse than
-/// no test at all. Verifying the `--version` banner also rules out an
-/// `oc-rsync` shim earlier on `PATH` masquerading as upstream.
+/// no test at all. The `--version` banner - not the path - decides, which is
+/// what rejects macOS's `/usr/bin/rsync` (`openrsync: protocol version 29`)
+/// and an `oc-rsync` shim earlier on `PATH` masquerading as upstream.
 #[allow(dead_code)]
 pub fn upstream_rsync() -> PathBuf {
+    let mut rejected = Vec::new();
     for candidate in UPSTREAM_CANDIDATES {
         let path = Path::new(candidate);
         if !path.exists() {
+            rejected.push(format!("{candidate} (absent)"));
             continue;
         }
         let Ok(output) = Command::new(path).arg("--version").output() else {
+            rejected.push(format!("{candidate} (--version failed)"));
             continue;
         };
         let banner = String::from_utf8_lossy(&output.stdout);
@@ -333,11 +346,12 @@ pub fn upstream_rsync() -> PathBuf {
         if first.starts_with("rsync  version") && first.contains("protocol version") {
             return path.to_path_buf();
         }
+        rejected.push(format!("{candidate} (not upstream: {first:?})"));
     }
     panic!(
         "no upstream rsync binary found; tried: {}. Build one with \
          `bash tools/ci/run_interop.sh` or install the packaged rsync.",
-        UPSTREAM_CANDIDATES.join(", ")
+        rejected.join(", ")
     );
 }
 
@@ -528,5 +542,226 @@ impl PipeDrain {
             self.stdout.join().unwrap_or_default(),
             self.stderr.join().unwrap_or_default(),
         )
+    }
+}
+
+/// Per-file payload size for the mid-transfer kill fixtures.
+///
+/// Comfortably larger than [`FORWARD_CAP`], so the transfer is structurally
+/// unable to finish before the proxy stalls.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub const TEST_FILE_SIZE: usize = 2 * 1024 * 1024;
+
+/// Daemon bytes [`CappingProxy`] forwards before stalling forever.
+///
+/// Large enough that the receiver has certainly opened its temp file and
+/// written literal data (which is what arms upstream's `cleanup_got_literal`
+/// gate, `cleanup.c:159`), small enough that no file is anywhere near
+/// complete.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub const FORWARD_CAP: u64 = 512 * 1024;
+
+/// How long to wait for the receiver to put bytes on disk before signalling.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub const PROGRESS_WAIT: Duration = Duration::from_secs(20);
+
+/// How long the client may take to exit after the signal.
+///
+/// Upstream exits in ~0.4 s, dominated by the deliberate `msleep(400)` in
+/// `rsync.c:694`. Anything in seconds here means the signal was not observed
+/// while the transfer was parked in a blocking transport read - which is the
+/// whole behaviour these fixtures exist to pin.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub const EXIT_WAIT: Duration = Duration::from_secs(10);
+
+/// rsync's exit code for SIGINT/SIGTERM/SIGHUP (`errcode.h` `RERR_SIGNAL`).
+#[cfg(unix)]
+#[allow(dead_code)]
+pub const RERR_SIGNAL: i32 = 20;
+
+/// Deterministic payload: a repeating byte pattern, so a retained partial can
+/// be checked to be a genuine prefix of the source rather than merely the
+/// right length.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub fn generate_test_data(size: usize) -> Vec<u8> {
+    let pattern: Vec<u8> = (0..=255u8).collect();
+    pattern.iter().copied().cycle().take(size).collect()
+}
+
+/// Whether a filename matches rsync's temp pattern `.name.XXXXXX`.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub fn is_temp_file_name(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix('.') else {
+        return false;
+    };
+    match rest.rfind('.') {
+        // The random suffix is exactly 6 alphanumeric characters.
+        Some(last_dot) => {
+            let suffix = &rest[last_dot + 1..];
+            suffix.len() == 6 && suffix.chars().all(|c| c.is_ascii_alphanumeric())
+        }
+        None => false,
+    }
+}
+
+/// Recursively collects every path under `dir` that looks like an rsync temp.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub fn find_temp_files(dir: &Path) -> Vec<PathBuf> {
+    let mut temps = Vec::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                temps.extend(find_temp_files(&path));
+            } else if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if is_temp_file_name(name) {
+                    temps.push(path);
+                }
+            }
+        }
+    }
+    temps
+}
+
+/// An oc-rsync daemon, a stalling [`CappingProxy`] in front of it, and a
+/// destination directory: everything a mid-transfer kill test needs.
+///
+/// The proxy is what makes the kill deterministic. `--bwlimit` cannot be used
+/// to open the window because upstream throttles socket *writes*
+/// (`io.c:861`), so on a daemon pull the limit belongs to the daemon and is
+/// inert client-side. Capping the forwarded bytes instead means the transfer
+/// cannot complete at all, so the signal can be gated on observed on-disk
+/// progress rather than on a timing guess.
+#[cfg(unix)]
+pub struct StalledTransfer {
+    daemon: TestDaemon,
+    proxy: CappingProxy,
+    dest: TempDir,
+}
+
+#[cfg(unix)]
+#[allow(dead_code)]
+impl StalledTransfer {
+    /// Starts the daemon and the proxy. Add payloads with [`Self::add_file`].
+    pub fn start() -> Self {
+        let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
+        let proxy =
+            CappingProxy::start(daemon.port(), FORWARD_CAP).expect("start byte-capping proxy");
+        Self {
+            daemon,
+            proxy,
+            dest: tempdir().expect("create dest dir"),
+        }
+    }
+
+    /// Publishes `name` in the module and returns the bytes written, so a
+    /// retained partial can be compared against the true source prefix.
+    pub fn add_file(&self, name: &str, size: usize) -> Vec<u8> {
+        let data = generate_test_data(size);
+        create_test_file(&self.daemon.module_path().join(name), &data);
+        data
+    }
+
+    /// The `rsync://` URL of the module, routed through the stalling proxy.
+    pub fn module_url(&self) -> String {
+        format!("rsync://127.0.0.1:{}/testmodule", self.proxy.port())
+    }
+
+    /// The destination directory the client writes into.
+    pub fn dest_path(&self) -> &Path {
+        self.dest.path()
+    }
+
+    /// Daemon log contents, for failure messages.
+    pub fn daemon_log(&self) -> String {
+        self.daemon
+            .log_contents()
+            .unwrap_or_else(|_| "(unavailable)".into())
+    }
+
+    /// Runs `client` with `args` plus the destination, waits for on-disk
+    /// progress, delivers `signal`, and asserts the client exits
+    /// [`RERR_SIGNAL`].
+    ///
+    /// upstream: `rsync.c:684 sig_int()` records the signal and lets the
+    /// normal I/O path shut the transfer down via
+    /// `cleanup.c:_exit_cleanup(RERR_SIGNAL)`.
+    pub fn interrupt(&self, client: &Path, args: &[&str], signal: libc::c_int) -> ExitStatus {
+        let mut child = Command::new(client)
+            .args(args)
+            .arg("--timeout=60")
+            .arg(self.dest_path().as_os_str())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn client");
+        let drain = PipeDrain::start(&mut child);
+
+        assert!(
+            wait_for_progress(self.dest_path(), PROGRESS_WAIT),
+            "client wrote nothing to {} within {PROGRESS_WAIT:?}; proxy forwarded {} bytes; \
+             daemon log: {}",
+            self.dest_path().display(),
+            self.proxy.forwarded(),
+            self.daemon_log()
+        );
+
+        let status = signal_and_wait(&mut child, signal);
+        let (_stdout, stderr) = drain.join();
+        assert!(
+            self.proxy.forwarded() <= FORWARD_CAP,
+            "proxy must not exceed its cap: forwarded {}",
+            self.proxy.forwarded()
+        );
+        assert_eq!(
+            status.code(),
+            Some(RERR_SIGNAL),
+            "interrupted transfer must exit {RERR_SIGNAL}; stderr: {stderr}"
+        );
+        // Give the retained rename a moment to land before the caller stats.
+        thread::sleep(Duration::from_millis(200));
+        status
+    }
+}
+
+/// Delivers `signal` to `child` and waits for it, failing the test if the
+/// child outlives [`EXIT_WAIT`].
+///
+/// The timeout is the load-bearing assertion: a client that sets its shutdown
+/// flag but never acts on it stays parked in the transport read forever, and
+/// this is what turns that into a red test instead of a hang.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub fn signal_and_wait(child: &mut Child, signal: libc::c_int) -> ExitStatus {
+    let pid = child.id();
+    // SAFETY: sending a signal to a child this process spawned and has not reaped.
+    let ret = unsafe { libc::kill(pid as libc::pid_t, signal) };
+    assert_eq!(ret, 0, "failed to send signal {signal} to child pid {pid}");
+
+    let deadline = Instant::now() + EXIT_WAIT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!(
+                        "client pid {pid} ignored signal {signal} for {EXIT_WAIT:?}: the shutdown \
+                         flag is set but nothing on the network path acted on it"
+                    );
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => panic!("error waiting for client pid {pid}: {e}"),
+        }
     }
 }

--- a/crates/core/tests/no_partial_temp_cleanup.rs
+++ b/crates/core/tests/no_partial_temp_cleanup.rs
@@ -6,10 +6,9 @@
 //! against is an orphaned temp file - the destination looks clean in a casual
 //! `ls` while a hidden partial silently consumes the disk.
 //!
-//! The transfer is made structurally unable to complete by interposing
-//! [`common::CappingProxy`], which forwards a bounded number of daemon bytes
-//! and then stalls with the connection open, so the interrupt can be gated on
-//! observed on-disk progress rather than on a sleep.
+//! The transfer is made structurally unable to complete by
+//! [`common::StalledTransfer`], so the interrupt is gated on observed on-disk
+//! progress rather than on a sleep.
 //!
 //! Upstream reference:
 //! - `cleanup.c:159-197` - retention gate and the unlink that follows it
@@ -20,186 +19,10 @@
 mod common;
 
 #[cfg(unix)]
-use common::{
-    CappingProxy, DaemonBinary, PipeDrain, TestDaemon, create_test_file, upstream_rsync,
-    wait_for_progress,
-};
+use common::{StalledTransfer, TEST_FILE_SIZE, find_temp_files, upstream_rsync};
 
 #[cfg(unix)]
 use std::fs;
-#[cfg(unix)]
-use std::path::{Path, PathBuf};
-#[cfg(unix)]
-use std::process::{Child, Command, ExitStatus, Stdio};
-#[cfg(unix)]
-use std::thread;
-#[cfg(unix)]
-use std::time::{Duration, Instant};
-
-#[cfg(unix)]
-use tempfile::{TempDir, tempdir};
-
-/// Per-file payload size. Comfortably larger than [`FORWARD_CAP`].
-#[cfg(unix)]
-const TEST_FILE_SIZE: usize = 2 * 1024 * 1024;
-
-/// Daemon bytes the proxy forwards before stalling forever.
-#[cfg(unix)]
-const FORWARD_CAP: u64 = 512 * 1024;
-
-/// How long to wait for the receiver to put bytes on disk before interrupting.
-#[cfg(unix)]
-const PROGRESS_WAIT: Duration = Duration::from_secs(20);
-
-/// How long the client may take to exit after SIGTERM.
-#[cfg(unix)]
-const EXIT_WAIT: Duration = Duration::from_secs(10);
-
-/// rsync's exit code for SIGINT/SIGTERM/SIGHUP (`errcode.h` `RERR_SIGNAL`).
-#[cfg(unix)]
-const RERR_SIGNAL: i32 = 20;
-
-/// Deterministic payload (repeating byte pattern).
-#[cfg(unix)]
-fn generate_test_data(size: usize) -> Vec<u8> {
-    let pattern: Vec<u8> = (0..=255u8).collect();
-    pattern.iter().copied().cycle().take(size).collect()
-}
-
-/// Sends SIGTERM and waits for the child, failing the test if it does not go.
-#[cfg(unix)]
-fn sigterm_and_wait(child: &mut Child) -> ExitStatus {
-    let pid = child.id();
-    // SAFETY: sending a signal to a child this process spawned and has not reaped.
-    let ret = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
-    assert_eq!(ret, 0, "failed to send SIGTERM to child pid {pid}");
-
-    let deadline = Instant::now() + EXIT_WAIT;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return status,
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    panic!(
-                        "client pid {pid} ignored SIGTERM for {EXIT_WAIT:?}: the shutdown flag \
-                         is set but nothing on the network path acted on it"
-                    );
-                }
-                thread::sleep(Duration::from_millis(20));
-            }
-            Err(e) => panic!("error waiting for client pid {pid}: {e}"),
-        }
-    }
-}
-
-/// Whether a filename matches rsync's temp pattern `.name.XXXXXX`.
-#[cfg(unix)]
-fn is_temp_file_name(name: &str) -> bool {
-    let Some(rest) = name.strip_prefix('.') else {
-        return false;
-    };
-    match rest.rfind('.') {
-        // The random suffix is exactly 6 alphanumeric characters.
-        Some(last_dot) => {
-            let suffix = &rest[last_dot + 1..];
-            suffix.len() == 6 && suffix.chars().all(|c| c.is_ascii_alphanumeric())
-        }
-        None => false,
-    }
-}
-
-/// Recursively collects every path under `dir` that looks like an rsync temp.
-#[cfg(unix)]
-fn find_temp_files(dir: &Path) -> Vec<PathBuf> {
-    let mut temps = Vec::new();
-    if let Ok(entries) = fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                temps.extend(find_temp_files(&path));
-            } else if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                if is_temp_file_name(name) {
-                    temps.push(path);
-                }
-            }
-        }
-    }
-    temps
-}
-
-/// A daemon, a stalling proxy in front of it, and a destination directory.
-#[cfg(unix)]
-struct StalledTransfer {
-    daemon: TestDaemon,
-    proxy: CappingProxy,
-    dest: TempDir,
-}
-
-#[cfg(unix)]
-impl StalledTransfer {
-    fn start() -> Self {
-        let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
-        let proxy =
-            CappingProxy::start(daemon.port(), FORWARD_CAP).expect("start byte-capping proxy");
-        Self {
-            daemon,
-            proxy,
-            dest: tempdir().expect("create dest dir"),
-        }
-    }
-
-    fn add_file(&self, name: &str, size: usize) {
-        create_test_file(
-            &self.daemon.module_path().join(name),
-            &generate_test_data(size),
-        );
-    }
-
-    fn module_url(&self) -> String {
-        format!("rsync://127.0.0.1:{}/testmodule", self.proxy.port())
-    }
-
-    fn dest_path(&self) -> &Path {
-        self.dest.path()
-    }
-
-    /// Runs `client` with `args`, waits for on-disk progress, sends SIGTERM,
-    /// and asserts the interrupted exit code.
-    fn interrupt(&self, client: &Path, args: &[String]) {
-        let mut child = Command::new(client)
-            .args(args)
-            .arg("--timeout=60")
-            .arg(self.dest_path().as_os_str())
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("spawn client");
-        let drain = PipeDrain::start(&mut child);
-
-        assert!(
-            wait_for_progress(self.dest_path(), PROGRESS_WAIT),
-            "client wrote nothing to {} within {PROGRESS_WAIT:?}; proxy forwarded {} bytes; \
-             daemon log: {}",
-            self.dest_path().display(),
-            self.proxy.forwarded(),
-            self.daemon
-                .log_contents()
-                .unwrap_or_else(|_| "(unavailable)".into())
-        );
-
-        let status = sigterm_and_wait(&mut child);
-        let (_stdout, stderr) = drain.join();
-        assert_eq!(
-            status.code(),
-            Some(RERR_SIGNAL),
-            "interrupted transfer must exit {RERR_SIGNAL}; stderr: {stderr}"
-        );
-        thread::sleep(Duration::from_millis(200));
-    }
-}
 
 /// Single file, no `--partial`: neither the destination nor the temp survives.
 #[cfg(unix)]
@@ -207,10 +30,8 @@ impl StalledTransfer {
 fn no_partial_single_file_no_residue_on_kill() {
     let fixture = StalledTransfer::start();
     fixture.add_file("large.bin", TEST_FILE_SIZE);
-    fixture.interrupt(
-        &test_support::oc_rsync_bin(),
-        &[format!("{}/large.bin", fixture.module_url())],
-    );
+    let url = format!("{}/large.bin", fixture.module_url());
+    fixture.interrupt(&test_support::oc_rsync_bin(), &[&url], libc::SIGTERM);
 
     assert!(
         !fixture.dest_path().join("large.bin").exists(),
@@ -238,10 +59,8 @@ fn no_partial_multi_file_no_residue_on_kill() {
     for (name, size) in &files {
         fixture.add_file(name, *size);
     }
-    fixture.interrupt(
-        &test_support::oc_rsync_bin(),
-        &["-r".to_string(), format!("{}/", fixture.module_url())],
-    );
+    let url = format!("{}/", fixture.module_url());
+    fixture.interrupt(&test_support::oc_rsync_bin(), &["-r", &url], libc::SIGTERM);
 
     let orphans = find_temp_files(fixture.dest_path());
     assert!(
@@ -271,10 +90,8 @@ fn no_partial_preserves_dirs_but_removes_temps() {
     for name in ["root.bin", "subdir/nested.bin", "subdir/deep/leaf.bin"] {
         fixture.add_file(name, TEST_FILE_SIZE);
     }
-    fixture.interrupt(
-        &test_support::oc_rsync_bin(),
-        &["-r".to_string(), format!("{}/", fixture.module_url())],
-    );
+    let url = format!("{}/", fixture.module_url());
+    fixture.interrupt(&test_support::oc_rsync_bin(), &["-r", &url], libc::SIGTERM);
 
     let orphans = find_temp_files(fixture.dest_path());
     assert!(
@@ -307,15 +124,13 @@ fn upstream_client_no_partial_cleans_up_on_kill() {
     let upstream = upstream_rsync();
     let fixture = StalledTransfer::start();
     fixture.add_file("large.bin", TEST_FILE_SIZE);
-    fixture.interrupt(&upstream, &[format!("{}/large.bin", fixture.module_url())]);
+    let url = format!("{}/large.bin", fixture.module_url());
+    fixture.interrupt(&upstream, &[&url], libc::SIGTERM);
 
     assert!(
         !fixture.dest_path().join("large.bin").exists(),
         "upstream without --partial must not leave a destination file; daemon log: {}",
-        fixture
-            .daemon
-            .log_contents()
-            .unwrap_or_else(|_| "(unavailable)".into())
+        fixture.daemon_log()
     );
     let orphans = find_temp_files(fixture.dest_path());
     assert!(
@@ -327,7 +142,7 @@ fn upstream_client_no_partial_cleans_up_on_kill() {
 #[cfg(unix)]
 #[cfg(test)]
 mod temp_file_pattern_tests {
-    use super::is_temp_file_name;
+    use crate::common::is_temp_file_name;
 
     /// The scanner must recognise the `.name.XXXXXX` shape rsync actually
     /// produces, including names that already contain dots.

--- a/crates/core/tests/partial_mid_transfer_kill.rs
+++ b/crates/core/tests/partial_mid_transfer_kill.rs
@@ -10,13 +10,9 @@
 //! | none | nothing (see `no_partial_temp_cleanup.rs`) |
 //! | `--partial-dir=DIR` | the partial bytes in `DIR`, nothing at the final path |
 //!
-//! The transfer is made structurally unable to complete by interposing
-//! [`common::CappingProxy`], which forwards a bounded number of daemon bytes
-//! and then stalls with the connection still open. That is what lets the kill
-//! be gated on observed on-disk progress instead of a timing guess, and it is
-//! why `--bwlimit` is not used: upstream throttles socket *writes*
-//! (`io.c:861`), so on a daemon pull the limit belongs to the daemon and is
-//! inert on the client side.
+//! The transfer is made structurally unable to complete by
+//! [`common::StalledTransfer`]; SIGINT delivery against the same fixture lives
+//! in `sigint_temp_cleanup.rs`.
 //!
 //! Upstream reference:
 //! - `rsync.c:684 sig_int()` - records the signal, `exit_cleanup(RERR_SIGNAL)`
@@ -29,169 +25,10 @@
 mod common;
 
 #[cfg(unix)]
-use common::{
-    CappingProxy, DaemonBinary, PipeDrain, TestDaemon, create_test_file, upstream_rsync,
-    wait_for_progress,
-};
+use common::{FORWARD_CAP, StalledTransfer, TEST_FILE_SIZE, upstream_rsync};
 
 #[cfg(unix)]
 use std::fs;
-#[cfg(unix)]
-use std::path::Path;
-#[cfg(unix)]
-use std::process::{Child, Command, ExitStatus, Stdio};
-#[cfg(unix)]
-use std::thread;
-#[cfg(unix)]
-use std::time::{Duration, Instant};
-
-#[cfg(unix)]
-use tempfile::{TempDir, tempdir};
-
-/// Size of the test file. Comfortably larger than [`FORWARD_CAP`] so the
-/// transfer cannot finish before the proxy stalls.
-#[cfg(unix)]
-const TEST_FILE_SIZE: usize = 2 * 1024 * 1024;
-
-/// Daemon bytes the proxy forwards before stalling forever.
-///
-/// Large enough that the receiver has certainly opened its temp file and
-/// written literal data (which is what arms upstream's `cleanup_got_literal`
-/// gate), small enough that the file is nowhere near complete.
-#[cfg(unix)]
-const FORWARD_CAP: u64 = 512 * 1024;
-
-/// How long to wait for the receiver to put bytes on disk before interrupting.
-#[cfg(unix)]
-const PROGRESS_WAIT: Duration = Duration::from_secs(20);
-
-/// How long the client may take to exit after SIGTERM.
-///
-/// Upstream exits in ~0.4 s, dominated by the deliberate `msleep(400)` in
-/// `rsync.c:694`. Anything in seconds here means the signal was not observed.
-#[cfg(unix)]
-const EXIT_WAIT: Duration = Duration::from_secs(10);
-
-/// rsync's exit code for SIGINT/SIGTERM/SIGHUP (`errcode.h` `RERR_SIGNAL`).
-#[cfg(unix)]
-const RERR_SIGNAL: i32 = 20;
-
-/// Deterministic payload: a repeating byte pattern, so a retained partial can
-/// be checked to be a genuine prefix of the source rather than merely the
-/// right length.
-#[cfg(unix)]
-fn generate_test_data(size: usize) -> Vec<u8> {
-    let pattern: Vec<u8> = (0..=255u8).collect();
-    pattern.iter().copied().cycle().take(size).collect()
-}
-
-/// A daemon, a stalling proxy in front of it, and a destination directory.
-#[cfg(unix)]
-struct StalledTransfer {
-    daemon: TestDaemon,
-    proxy: CappingProxy,
-    dest: TempDir,
-    data: Vec<u8>,
-}
-
-#[cfg(unix)]
-impl StalledTransfer {
-    fn start() -> Self {
-        let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
-        let data = generate_test_data(TEST_FILE_SIZE);
-        create_test_file(&daemon.module_path().join("large.bin"), &data);
-        let proxy =
-            CappingProxy::start(daemon.port(), FORWARD_CAP).expect("start byte-capping proxy");
-        Self {
-            daemon,
-            proxy,
-            dest: tempdir().expect("create dest dir"),
-            data,
-        }
-    }
-
-    fn source_url(&self) -> String {
-        format!(
-            "rsync://127.0.0.1:{}/testmodule/large.bin",
-            self.proxy.port()
-        )
-    }
-
-    fn dest_path(&self) -> &Path {
-        self.dest.path()
-    }
-
-    /// Runs `client` with `flags`, waits for on-disk progress, sends SIGTERM,
-    /// and returns the client's exit status.
-    fn interrupt(&self, client: &Path, flags: &[&str]) -> ExitStatus {
-        let mut child = Command::new(client)
-            .args(flags)
-            .arg("--timeout=60")
-            .arg(self.source_url())
-            .arg(self.dest_path().as_os_str())
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("spawn client");
-        let drain = PipeDrain::start(&mut child);
-
-        assert!(
-            wait_for_progress(self.dest_path(), PROGRESS_WAIT),
-            "client wrote nothing to {} within {PROGRESS_WAIT:?}; proxy forwarded {} bytes; \
-             daemon log: {}",
-            self.dest_path().display(),
-            self.proxy.forwarded(),
-            self.daemon
-                .log_contents()
-                .unwrap_or_else(|_| "(unavailable)".into())
-        );
-
-        let status = sigterm_and_wait(&mut child);
-        let (_stdout, stderr) = drain.join();
-        assert!(
-            self.proxy.forwarded() <= FORWARD_CAP,
-            "proxy must not exceed its cap: forwarded {}",
-            self.proxy.forwarded()
-        );
-        assert_eq!(
-            status.code(),
-            Some(RERR_SIGNAL),
-            "interrupted transfer must exit {RERR_SIGNAL}; stderr: {stderr}"
-        );
-        // Give the retained rename a moment to land before the caller stats.
-        thread::sleep(Duration::from_millis(200));
-        status
-    }
-}
-
-/// Sends SIGTERM and waits for the child, failing the test if it does not go.
-#[cfg(unix)]
-fn sigterm_and_wait(child: &mut Child) -> ExitStatus {
-    let pid = child.id();
-    // SAFETY: sending a signal to a child this process spawned and has not reaped.
-    let ret = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
-    assert_eq!(ret, 0, "failed to send SIGTERM to child pid {pid}");
-
-    let deadline = Instant::now() + EXIT_WAIT;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return status,
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    panic!(
-                        "client pid {pid} ignored SIGTERM for {EXIT_WAIT:?}: the shutdown flag \
-                         is set but nothing on the network path acted on it"
-                    );
-                }
-                thread::sleep(Duration::from_millis(20));
-            }
-            Err(e) => panic!("error waiting for client pid {pid}: {e}"),
-        }
-    }
-}
 
 /// `--partial` must leave the received prefix at the final destination path.
 ///
@@ -201,16 +38,19 @@ fn sigterm_and_wait(child: &mut Child) -> ExitStatus {
 #[test]
 fn partial_flag_retains_file_on_mid_transfer_kill() {
     let fixture = StalledTransfer::start();
-    fixture.interrupt(&test_support::oc_rsync_bin(), &["--partial"]);
+    let source = fixture.add_file("large.bin", TEST_FILE_SIZE);
+    let url = format!("{}/large.bin", fixture.module_url());
+    fixture.interrupt(
+        &test_support::oc_rsync_bin(),
+        &["--partial", &url],
+        libc::SIGTERM,
+    );
 
     let dest_file = fixture.dest_path().join("large.bin");
     assert!(
         dest_file.exists(),
         "--partial must leave the partial at the destination; daemon log: {}",
-        fixture
-            .daemon
-            .log_contents()
-            .unwrap_or_else(|_| "(unavailable)".into())
+        fixture.daemon_log()
     );
 
     let partial = fs::read(&dest_file).expect("read partial file");
@@ -222,7 +62,7 @@ fn partial_flag_retains_file_on_mid_transfer_kill() {
     );
     assert_eq!(
         &partial[..],
-        &fixture.data[..partial.len()],
+        &source[..partial.len()],
         "the retained partial must be a byte-exact prefix of the source"
     );
 }
@@ -236,7 +76,9 @@ fn partial_flag_retains_file_on_mid_transfer_kill() {
 #[test]
 fn no_partial_flag_cleans_up_on_mid_transfer_kill() {
     let fixture = StalledTransfer::start();
-    fixture.interrupt(&test_support::oc_rsync_bin(), &[]);
+    fixture.add_file("large.bin", TEST_FILE_SIZE);
+    let url = format!("{}/large.bin", fixture.module_url());
+    fixture.interrupt(&test_support::oc_rsync_bin(), &[&url], libc::SIGTERM);
 
     let leftovers: Vec<_> = fs::read_dir(fixture.dest_path())
         .expect("read dest dir")
@@ -260,9 +102,12 @@ fn no_partial_flag_cleans_up_on_mid_transfer_kill() {
 fn partial_dir_flag_retains_file_in_directory_on_kill() {
     let partial_dir_name = ".rsync-partial";
     let fixture = StalledTransfer::start();
+    let source = fixture.add_file("large.bin", TEST_FILE_SIZE);
+    let url = format!("{}/large.bin", fixture.module_url());
     fixture.interrupt(
         &test_support::oc_rsync_bin(),
-        &[&format!("--partial-dir={partial_dir_name}")],
+        &[&format!("--partial-dir={partial_dir_name}"), &url],
+        libc::SIGTERM,
     );
 
     let dest_file = fixture.dest_path().join("large.bin");
@@ -275,10 +120,7 @@ fn partial_dir_flag_retains_file_in_directory_on_kill() {
     assert!(
         partial_file.exists(),
         "--partial-dir={partial_dir_name} must hold the partial; daemon log: {}",
-        fixture
-            .daemon
-            .log_contents()
-            .unwrap_or_else(|_| "(unavailable)".into())
+        fixture.daemon_log()
     );
 
     let partial = fs::read(&partial_file).expect("read partial file");
@@ -290,7 +132,7 @@ fn partial_dir_flag_retains_file_in_directory_on_kill() {
     );
     assert_eq!(
         &partial[..],
-        &fixture.data[..partial.len()],
+        &source[..partial.len()],
         "the retained partial must be a byte-exact prefix of the source"
     );
 }
@@ -308,16 +150,15 @@ fn partial_dir_flag_retains_file_in_directory_on_kill() {
 fn upstream_client_partial_retains_file_on_kill() {
     let upstream = upstream_rsync();
     let fixture = StalledTransfer::start();
-    fixture.interrupt(&upstream, &["--partial"]);
+    let source = fixture.add_file("large.bin", TEST_FILE_SIZE);
+    let url = format!("{}/large.bin", fixture.module_url());
+    fixture.interrupt(&upstream, &["--partial", &url], libc::SIGTERM);
 
     let dest_file = fixture.dest_path().join("large.bin");
     assert!(
         dest_file.exists(),
         "upstream --partial must leave the partial at the destination; daemon log: {}",
-        fixture
-            .daemon
-            .log_contents()
-            .unwrap_or_else(|_| "(unavailable)".into())
+        fixture.daemon_log()
     );
 
     let partial = fs::read(&dest_file).expect("read partial file");
@@ -329,7 +170,7 @@ fn upstream_client_partial_retains_file_on_kill() {
     );
     assert_eq!(
         &partial[..],
-        &fixture.data[..partial.len()],
+        &source[..partial.len()],
         "the retained partial must be a byte-exact prefix of the source"
     );
 }

--- a/crates/core/tests/sigint_temp_cleanup.rs
+++ b/crates/core/tests/sigint_temp_cleanup.rs
@@ -1,266 +1,134 @@
-//! Tests for SIGINT temp file cleanup behavior.
+//! SIGINT during a real network transfer: exit code, cleanup, retention.
 //!
-//! Verifies that when SIGINT triggers a shutdown, the `CleanupManager` removes
-//! registered temporary files (`.XXXXXX` orphans), the correct exit code is
-//! returned, and no partial files remain in the destination directory.
+//! This file used to *simulate* an interrupt - it set the shutdown atomics by
+//! hand and called `CleanupManager::cleanup()` directly, so it stayed green
+//! with the entire signal path deleted. It now delivers SIGINT to a live
+//! `oc-rsync` client that is parked in a blocking read on a daemon socket, and
+//! asserts only what an outside observer can see: the process exits
+//! `RERR_SIGNAL` (20) within [`common::EXIT_WAIT`], and the destination is left
+//! exactly as upstream leaves it.
 //!
-//! These tests exercise the same code paths that real signal delivery uses -
-//! the signal handler sets atomic flags, then the main loop detects shutdown
-//! and invokes `CleanupManager::cleanup()`.
+//! The three failure modes this pins, all of which the simulated version
+//! missed:
+//! - the handler is installed but nothing on the network path polls the flag,
+//!   so the client runs to `--timeout` (caught by the exit deadline);
+//! - the flag is polled but the transfer is parked in `read()` and never
+//!   reaches a poll point (same deadline);
+//! - shutdown happens but the receiver's temp file is not registered, so a
+//!   `.name.XXXXXX` orphan survives (caught by the residue assertions).
+//!
+//! `partial_mid_transfer_kill.rs` and `no_partial_temp_cleanup.rs` cover the
+//! same contract under SIGTERM; unit coverage of `CleanupManager` itself lives
+//! in `cleanup_manager.rs` and `signal_integration.rs`.
+//!
+//! Upstream reference:
+//! - `rsync.c:684 sig_int()` - records the signal only
+//! - `io.c:750 got_kill_signal` - the I/O loop acts on it
+//! - `cleanup.c:159-197` - `cleanup_got_literal && keep_partial` retention,
+//!   otherwise unlink
 
-#![cfg(unix)]
+#[cfg(unix)]
+mod common;
 
-use core::exit_code::ExitCode;
-use core::signal::{CleanupManager, ShutdownReason};
+#[cfg(unix)]
+use common::{FORWARD_CAP, StalledTransfer, TEST_FILE_SIZE, find_temp_files};
+
+#[cfg(unix)]
 use std::fs;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use tempfile::tempdir;
 
-/// Simulates the SIGINT handler setting atomic flags, then the application
-/// detecting shutdown and running cleanup. Verifies that all registered
-/// temp files are removed.
+/// Default flags: SIGINT must leave neither the destination file nor the
+/// `.name.XXXXXX` temp the receiver was writing into.
+///
+/// upstream: `cleanup.c:194-197` unlinks `cleanup_fname` when `keep_partial`
+/// is unset.
+#[cfg(unix)]
 #[test]
-fn sigint_cleans_up_registered_temp_files() {
-    let manager = CleanupManager::global();
-    manager.reset_for_testing();
-    core::signal::reset_for_testing();
+fn sigint_removes_temp_orphans_from_destination() {
+    let fixture = StalledTransfer::start();
+    fixture.add_file("large.bin", TEST_FILE_SIZE);
+    let url = format!("{}/large.bin", fixture.module_url());
+    fixture.interrupt(&test_support::oc_rsync_bin(), &[&url], libc::SIGINT);
 
-    let dest = tempdir().expect("create dest dir");
-
-    // Create temp files mimicking rsync's `.filename.XXXXXX` pattern
-    let temp_names = [
-        ".largefile.dat.a1b2c3",
-        ".photo.jpg.d4e5f6",
-        ".backup.tar.gz.789abc",
-        ".document.pdf.def012",
-        ".video.mp4.345678",
-    ];
-
-    let temp_paths: Vec<PathBuf> = temp_names
-        .iter()
-        .map(|name| {
-            let path = dest.path().join(name);
-            fs::write(&path, vec![0u8; 4096]).expect("write temp file");
-            manager.register_temp_file(path.clone());
-            path
-        })
+    assert!(
+        !fixture.dest_path().join("large.bin").exists(),
+        "without --partial SIGINT must not leave a destination file; daemon log: {}",
+        fixture.daemon_log()
+    );
+    let leftovers: Vec<_> = fs::read_dir(fixture.dest_path())
+        .expect("read dest dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name())
         .collect();
+    assert!(
+        leftovers.is_empty(),
+        "SIGINT must leave the destination empty; found: {leftovers:?}"
+    );
+}
 
-    // Also create a completed (non-temp) file that should survive cleanup
-    let final_file = dest.path().join("completed_transfer.dat");
-    fs::write(&final_file, b"completed data").expect("write final file");
-
-    // Verify all temp files exist before signal
-    for path in &temp_paths {
-        assert!(
-            path.exists(),
-            "temp file should exist before signal: {path:?}"
-        );
+/// A nested pull: SIGINT keeps the directories the generator created but must
+/// remove every temp beneath them, at any depth.
+#[cfg(unix)]
+#[test]
+fn sigint_leaves_no_temp_orphans_in_nested_tree() {
+    let fixture = StalledTransfer::start();
+    for name in ["root.bin", "subdir/nested.bin", "subdir/deep/leaf.bin"] {
+        fixture.add_file(name, TEST_FILE_SIZE);
     }
-    assert!(final_file.exists());
+    let url = format!("{}/", fixture.module_url());
+    fixture.interrupt(&test_support::oc_rsync_bin(), &["-r", &url], libc::SIGINT);
 
-    // Simulate SIGINT: the signal handler sets the shutdown flag
-    core::signal::request_shutdown(ShutdownReason::Interrupted);
+    let orphans = find_temp_files(fixture.dest_path());
+    assert!(
+        orphans.is_empty(),
+        "SIGINT left temp file orphans in the tree: {orphans:?}"
+    );
+    for name in ["root.bin", "subdir/nested.bin", "subdir/deep/leaf.bin"] {
+        let dest_file = fixture.dest_path().join(name);
+        if dest_file.exists() {
+            let actual = fs::metadata(&dest_file).expect("stat").len() as usize;
+            assert_eq!(
+                actual, TEST_FILE_SIZE,
+                "{name} survived SIGINT at {actual} of {TEST_FILE_SIZE} bytes; without --partial \
+                 an incomplete file must be removed, not left looking finished"
+            );
+        }
+    }
+}
 
-    // Simulate the main loop detecting shutdown and running cleanup
-    assert!(core::signal::is_shutdown_requested());
+/// `--partial` flips the same path from unlink to retain: the bytes that made
+/// it must be at the final destination and be a genuine prefix of the source.
+///
+/// upstream: `cleanup.c:167-182` renames the temp onto `cleanup_new_fname`
+/// when `keep_partial` is set and literal data arrived.
+#[cfg(unix)]
+#[test]
+fn sigint_retains_partial_prefix_with_partial_flag() {
+    let fixture = StalledTransfer::start();
+    let source = fixture.add_file("large.bin", TEST_FILE_SIZE);
+    let url = format!("{}/large.bin", fixture.module_url());
+    fixture.interrupt(
+        &test_support::oc_rsync_bin(),
+        &["--partial", &url],
+        libc::SIGINT,
+    );
+
+    let dest_file = fixture.dest_path().join("large.bin");
+    assert!(
+        dest_file.exists(),
+        "--partial must leave the partial at the destination after SIGINT; daemon log: {}",
+        fixture.daemon_log()
+    );
+
+    let partial = fs::read(&dest_file).expect("read partial file");
+    assert!(!partial.is_empty(), "retained partial must not be empty");
+    assert!(
+        partial.len() < TEST_FILE_SIZE,
+        "the proxy caps the transfer at {FORWARD_CAP} bytes, so a complete \
+         {TEST_FILE_SIZE}-byte file means SIGINT was not what stopped it"
+    );
     assert_eq!(
-        core::signal::shutdown_reason(),
-        Some(ShutdownReason::Interrupted)
+        &partial[..],
+        &source[..partial.len()],
+        "the retained partial must be a byte-exact prefix of the source"
     );
-
-    manager.cleanup();
-
-    // All registered temp files should be removed
-    for path in &temp_paths {
-        assert!(
-            !path.exists(),
-            "temp file should be cleaned up after SIGINT: {path:?}"
-        );
-    }
-
-    // Completed file should survive - it was never registered
-    assert!(
-        final_file.exists(),
-        "completed file should not be removed by cleanup"
-    );
-
-    // Verify exit code maps correctly
-    assert_eq!(ShutdownReason::Interrupted.exit_code(), ExitCode::Signal);
-    assert_eq!(ExitCode::Signal.as_i32(), 20);
-}
-
-/// Verifies that a file unregistered before SIGINT (simulating a completed
-/// transfer) is not removed during cleanup.
-#[test]
-fn completed_transfer_survives_sigint_cleanup() {
-    let manager = CleanupManager::global();
-    manager.reset_for_testing();
-    core::signal::reset_for_testing();
-
-    let dest = tempdir().expect("create dest dir");
-
-    // Create three temp files representing in-progress transfers
-    let in_progress_1 = dest.path().join(".file_a.txt.abc123");
-    let in_progress_2 = dest.path().join(".file_b.txt.def456");
-    let completed = dest.path().join(".file_c.txt.ghi789");
-
-    for path in [&in_progress_1, &in_progress_2, &completed] {
-        fs::write(path, b"transfer data").expect("write temp");
-        manager.register_temp_file(path.clone());
-    }
-
-    // Simulate file_c completing its transfer - rename to final and unregister
-    let final_c = dest.path().join("file_c.txt");
-    fs::rename(&completed, &final_c).expect("rename to final");
-    manager.unregister_temp_file(&completed);
-
-    // Now SIGINT arrives
-    core::signal::request_shutdown(ShutdownReason::Interrupted);
-    manager.cleanup();
-
-    // In-progress temp files should be removed
-    assert!(
-        !in_progress_1.exists(),
-        "in-progress temp should be cleaned up"
-    );
-    assert!(
-        !in_progress_2.exists(),
-        "in-progress temp should be cleaned up"
-    );
-
-    // Completed file should survive (unregistered before cleanup)
-    assert!(
-        final_c.exists(),
-        "completed transfer should survive SIGINT cleanup"
-    );
-}
-
-/// Verifies that cleanup callbacks registered by the transfer engine run
-/// when SIGINT triggers cleanup, and that they execute before temp file
-/// removal (LIFO order).
-#[test]
-fn sigint_cleanup_runs_callbacks_before_file_removal() {
-    let manager = CleanupManager::global();
-    manager.reset_for_testing();
-    core::signal::reset_for_testing();
-
-    let dest = tempdir().expect("create dest dir");
-    let temp_file = dest.path().join(".transfer.dat.abc123");
-    fs::write(&temp_file, b"data").expect("write temp");
-    manager.register_temp_file(temp_file.clone());
-
-    let callback_order = Arc::new(AtomicUsize::new(0));
-
-    // Register a cleanup callback (simulating engine resource cleanup)
-    let order = Arc::clone(&callback_order);
-    manager.register_cleanup(Box::new(move || {
-        order.store(1, Ordering::SeqCst);
-    }));
-
-    // Simulate SIGINT
-    core::signal::request_shutdown(ShutdownReason::Interrupted);
-    manager.cleanup();
-
-    // Callback should have run
-    assert_eq!(callback_order.load(Ordering::SeqCst), 1);
-
-    // Temp file should be removed
-    assert!(!temp_file.exists());
-}
-
-/// Verifies that a second SIGINT sets the abort flag for immediate
-/// termination, while still allowing cleanup to proceed.
-#[test]
-fn double_sigint_sets_abort_flag() {
-    let manager = CleanupManager::global();
-    manager.reset_for_testing();
-    core::signal::reset_for_testing();
-
-    let dest = tempdir().expect("create dest dir");
-    let temp_file = dest.path().join(".data.bin.abc123");
-    fs::write(&temp_file, b"partial").expect("write temp");
-    manager.register_temp_file(temp_file.clone());
-
-    // First SIGINT - graceful shutdown
-    core::signal::request_shutdown(ShutdownReason::Interrupted);
-    assert!(core::signal::is_shutdown_requested());
-    assert!(!core::signal::is_abort_requested());
-
-    // Second SIGINT - immediate abort
-    core::signal::request_abort();
-    assert!(core::signal::is_abort_requested());
-
-    // Even on abort, cleanup should still remove temp files
-    manager.cleanup();
-    assert!(
-        !temp_file.exists(),
-        "temp files should be cleaned up even on abort"
-    );
-}
-
-/// Verifies that the destination directory contains no files matching
-/// rsync's temp file pattern after SIGINT cleanup. This is the key
-/// invariant: no `.XXXXXX` orphans left behind.
-#[test]
-fn no_temp_orphans_remain_after_sigint() {
-    let manager = CleanupManager::global();
-    manager.reset_for_testing();
-    core::signal::reset_for_testing();
-
-    let dest = tempdir().expect("create dest dir");
-
-    // Create a subdirectory structure with temp files at various levels
-    let sub = dest.path().join("subdir");
-    fs::create_dir(&sub).expect("create subdir");
-
-    let temps = vec![
-        dest.path().join(".root_file.dat.a1b2c3"),
-        sub.join(".nested_file.txt.d4e5f6"),
-        sub.join(".deep_file.log.789abc"),
-    ];
-
-    // Also create legitimate dot-files that should not be removed
-    let legit_dotfile = dest.path().join(".rsync-filter");
-    fs::write(&legit_dotfile, b"- *.bak").expect("write filter");
-
-    for path in &temps {
-        fs::write(path, b"partial transfer data").expect("write temp");
-        manager.register_temp_file(path.clone());
-    }
-
-    // Simulate SIGINT and cleanup
-    core::signal::request_shutdown(ShutdownReason::Interrupted);
-    manager.cleanup();
-
-    // No temp orphans should remain
-    for path in &temps {
-        assert!(!path.exists(), "temp orphan should be removed: {path:?}");
-    }
-
-    // Legitimate files should survive
-    assert!(
-        legit_dotfile.exists(),
-        ".rsync-filter should survive cleanup"
-    );
-    assert!(sub.exists(), "subdirectory should survive cleanup");
-}
-
-/// Verifies the full exit code path: SIGINT maps to `ExitCode::Signal` (20),
-/// matching upstream rsync behavior.
-#[test]
-fn sigint_exit_code_matches_upstream() {
-    // upstream: rsync exits with code 20 on SIGINT/SIGTERM/SIGHUP
-    let reason = ShutdownReason::Interrupted;
-    let code = reason.exit_code();
-    assert_eq!(code, ExitCode::Signal);
-    assert_eq!(code.as_i32(), 20);
-
-    // SIGTERM also maps to 20
-    assert_eq!(ShutdownReason::Terminated.exit_code().as_i32(), 20);
-
-    // SIGHUP also maps to 20
-    assert_eq!(ShutdownReason::HangUp.exit_code().as_i32(), 20);
 }

--- a/crates/core/tests/upstream_client_to_oc_daemon_interop.rs
+++ b/crates/core/tests/upstream_client_to_oc_daemon_interop.rs
@@ -38,7 +38,6 @@ use tempfile::tempdir;
 /// This is a smoke test to verify basic daemon functionality before
 /// running protocol-specific tests.
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn test_oc_daemon_starts_and_accepts_connections() {
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 
@@ -52,7 +51,6 @@ fn test_oc_daemon_starts_and_accepts_connections() {
 /// Verifies the daemon implements the @RSYNCD: protocol greeting correctly.
 /// Upstream reference: clientserver.c:125-144 (daemon greeting format)
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn test_oc_daemon_sends_protocol_greeting() {
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 
@@ -96,7 +94,6 @@ fn test_oc_daemon_sends_protocol_greeting() {
 ///
 /// Verifies that daemon process terminates cleanly when dropped.
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn test_oc_daemon_shutdown_cleanup() {
     let port;
 
@@ -660,7 +657,6 @@ fn test_module_listing_from_upstream_client() {
 /// This is similar to test_oc_daemon_sends_protocol_greeting but goes further
 /// into the handshake sequence.
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn test_manual_protocol_handshake_with_oc_daemon() {
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 

--- a/crates/core/tests/upstream_client_to_oc_daemon_interop.rs
+++ b/crates/core/tests/upstream_client_to_oc_daemon_interop.rs
@@ -24,10 +24,14 @@ use common::{
 };
 
 use std::fs;
+// Used only by the Unix-gated daemon tests below.
+#[cfg(unix)]
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::path::Path;
 use std::process::Command;
+// Used only by the Unix-gated daemon tests below.
+#[cfg(unix)]
 use std::thread;
 use std::time::Duration;
 
@@ -37,7 +41,10 @@ use tempfile::tempdir;
 ///
 /// This is a smoke test to verify basic daemon functionality before
 /// running protocol-specific tests.
+// The oc-rsync daemon is Unix-only by design: `--daemon` on Windows exits 1 with
+// "daemon mode is not supported on this platform" (daemon.rs:208).
 #[test]
+#[cfg(unix)]
 fn test_oc_daemon_starts_and_accepts_connections() {
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 
@@ -50,7 +57,10 @@ fn test_oc_daemon_starts_and_accepts_connections() {
 ///
 /// Verifies the daemon implements the @RSYNCD: protocol greeting correctly.
 /// Upstream reference: clientserver.c:125-144 (daemon greeting format)
+// The oc-rsync daemon is Unix-only by design: `--daemon` on Windows exits 1 with
+// "daemon mode is not supported on this platform" (daemon.rs:208).
 #[test]
+#[cfg(unix)]
 fn test_oc_daemon_sends_protocol_greeting() {
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 
@@ -93,7 +103,10 @@ fn test_oc_daemon_sends_protocol_greeting() {
 /// Test daemon shutdown and cleanup.
 ///
 /// Verifies that daemon process terminates cleanly when dropped.
+// The oc-rsync daemon is Unix-only by design: `--daemon` on Windows exits 1 with
+// "daemon mode is not supported on this platform" (daemon.rs:208).
 #[test]
+#[cfg(unix)]
 fn test_oc_daemon_shutdown_cleanup() {
     let port;
 
@@ -656,7 +669,10 @@ fn test_module_listing_from_upstream_client() {
 /// Verifies low-level protocol implementation directly.
 /// This is similar to test_oc_daemon_sends_protocol_greeting but goes further
 /// into the handshake sequence.
+// The oc-rsync daemon is Unix-only by design: `--daemon` on Windows exits 1 with
+// "daemon mode is not supported on this platform" (daemon.rs:208).
 #[test]
+#[cfg(unix)]
 fn test_manual_protocol_handshake_with_oc_daemon() {
     let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
 

--- a/crates/core/tests/uts_9_daemon_gzip_download_goodbye.rs
+++ b/crates/core/tests/uts_9_daemon_gzip_download_goodbye.rs
@@ -69,7 +69,6 @@ fn generate_test_data(size: usize) -> Vec<u8> {
 /// `cargo test -- --ignored` during interop validation.
 #[cfg(unix)]
 #[test]
-#[ignore = "requires oc-rsync binary"]
 fn daemon_download_with_zz_completes_without_connection_drop() {
     let oc_rsync = test_support::oc_rsync_bin();
 

--- a/crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs
+++ b/crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs
@@ -195,18 +195,22 @@ impl Fixture {
 /// closed` (or a non-zero exit) when the oc-rsync daemon-sender drops
 /// the trailing frame before flushing the goodbye exchange.
 ///
-/// Skips silently when `OC_RSYNC_UPSTREAM_COMPAT` is unset or the
-/// upstream rsync 3.4.4 binary is missing - this keeps the standard PR
-/// nextest cell costless and macOS/Windows cells green.
+/// Opting out is a decision, opting in is a promise. With
+/// `OC_RSYNC_UPSTREAM_COMPAT` unset the test skips, which keeps the standard
+/// PR nextest cell costless and the macOS/Windows cells green. Once it is set
+/// the test must never report green without having run: a missing upstream
+/// 3.4.4 binary is a setup error and fails loudly rather than returning.
 #[test]
 fn daemon_gzip_goodbye_does_not_truncate() {
     if !upstream_compat_enabled() {
         return;
     }
 
-    let Some(upstream) = require_upstream_rsync(UpstreamVersion::V3_4_4) else {
-        return;
-    };
+    let upstream = require_upstream_rsync(UpstreamVersion::V3_4_4).expect(
+        "OC_RSYNC_UPSTREAM_COMPAT=1 selected this test but upstream rsync 3.4.4 is not \
+         installed; build it with `bash tools/ci/run_interop.sh` or point \
+         OC_RSYNC_UPSTREAM_BIN_3_4_4 at it",
+    );
 
     let oc_rsync = test_support::oc_rsync_bin();
 


### PR DESCRIPTION
## What the old test actually covered

Nothing about signals.

`crates/core/tests/sigint_temp_cleanup.rs` was not `#[ignore]`d and passed on every
cell, so it read as live coverage of SIGINT. It never delivered a signal. Each test set
the shutdown atomics by hand:

```rust
core::signal::request_shutdown(ShutdownReason::Interrupted);
assert!(core::signal::is_shutdown_requested());
manager.cleanup();
```

`request_shutdown` is the same function the handler calls, so the test began *after*
everything that could go wrong had already gone right. It never spawned a process, so it
could not observe whether a handler was installed, whether anything polled the flag, or
whether a transfer parked in a blocking socket read ever reached a poll point. It was a
`CleanupManager` unit test wearing the name of an integration test - worse than no test,
because it occupied the slot where the real one would have gone.

Proof, not argument: the evidence below shows the old file passing 6/6 with the network
signal path deliberately removed.

## What the new test drives

A real SIGINT against a real transfer, asserting only what an outside observer sees.

`sigint_temp_cleanup.rs` now starts an `oc-rsync` daemon, interposes the byte-capping
proxy from `tests/common` so the transfer is structurally unable to finish, waits for
the receiver to put bytes on disk, sends `SIGINT` to the live client with `libc::kill`,
and asserts the process exits `RERR_SIGNAL` (20) within 10 s and leaves the destination
exactly as upstream leaves it:

| test | asserts |
|---|---|
| `sigint_removes_temp_orphans_from_destination` | no destination file, no `.name.XXXXXX` residue |
| `sigint_leaves_no_temp_orphans_in_nested_tree` | directories survive, no temp at any depth, no truncated file left looking finished |
| `sigint_retains_partial_prefix_with_partial_flag` | `--partial` keeps a byte-exact prefix of the source |

The 10 s exit deadline is the load-bearing assertion. `--timeout=60` means a client that
sets its flag but never acts on it cannot exit inside the window, so all three failure
modes the simulated version was blind to become red: handler installed but nothing
polls, flag polled but the transfer never leaves `read()`, or shutdown reached but the
temp was never registered.

`CleanupManager` unit coverage is kept, renamed honestly to
`crates/core/tests/cleanup_manager.rs`, holding only what `signal_integration.rs` does
not already assert: that the sweep is registry-driven rather than a directory scan (a
`.rsync-filter` beside the temps must survive), and that an abort request shortens the
shutdown without skipping the sweep. Both take a module `Mutex` - the previous file
called `reset_for_testing()` on a process-global registry from five tests that
`cargo test` runs concurrently.

## Also in this change

- `tests/common/mod.rs` grows the stalled-transfer fixture, parameterised by signal
  number, so the SIGTERM suites (`partial_mid_transfer_kill.rs`,
  `no_partial_temp_cleanup.rs`) and the new SIGINT suite share one definition instead of
  three near-copies.
- `upstream_rsync()` gains the two 3.4.4 build locations at the head of its candidate
  list (3.4.4 is the pinned reference; 3.4.1 must not be substituted silently) and now
  names every rejected candidate *with the reason*, so a wrong binary is diagnosable
  from the panic alone.

The vacuous early-returns previously at `partial_mid_transfer_kill.rs:328` and
`no_partial_temp_cleanup.rs:352` are already gone - #6961 replaced them with
`upstream_rsync()`, which panics rather than returning green. The two
cross-implementation tests keep their explicit `#[ignore]` opt-in, matching every other
upstream-requiring test in that directory: macOS ships openrsync at `/usr/bin/rsync`,
the banner check correctly rejects it, and a test that would then panic on the macOS
cell must be opted into rather than skipped from within.

## Break-and-revert evidence

A test that cannot be shown to fail is worthless. Every changed test was driven red by
breaking the behaviour it names, then the break was reverted.

**Experiment A - `upstream_rsync()` must fail loudly, not skip.** Candidate list
temporarily narrowed to the absent 3.4.4 path plus macOS openrsync:

```
thread 'upstream_client_no_partial_cleans_up_on_kill' panicked at crates/core/tests/common/mod.rs:343:5:
no upstream rsync binary found; tried: target/interop/upstream-install/3.4.4/bin/rsync (absent),
/usr/bin/rsync (not upstream: "openrsync: protocol version 29").
```

**Experiment B - `cleanup_manager.rs` must fail when the sweep stops unlinking.**
`CleanupState::cleanup_temp_files` reduced to `self.temp_files.clear()`:

```
test cleanup_removes_only_registered_paths ... FAILED
  registered temp must be removed: ".../.root_file.dat.a1b2c3"
test cleanup_still_runs_after_an_abort_request ... FAILED
  temp files must be cleaned up even on abort
test result: FAILED. 0 passed; 2 failed
```

**Experiment C - the whole point.** `core::signal::wake_blocked_io()` removed from the
client signal watcher in `crates/cli/src/frontend/mod.rs` - the network signal path put
back the way it was before #6961 - and the binary rebuilt. Old and new test files run
against the same broken binary:

```
Running tests/old_sigint_temp_cleanup.rs                <- the file this PR replaces
test completed_transfer_survives_sigint_cleanup ... ok
test double_sigint_sets_abort_flag ... ok
test no_temp_orphans_remain_after_sigint ... ok
test sigint_cleans_up_registered_temp_files ... ok
test sigint_cleanup_runs_callbacks_before_file_removal ... ok
test sigint_exit_code_matches_upstream ... ok
test result: ok. 6 passed; 0 failed

Running tests/sigint_temp_cleanup.rs                    <- this PR
test sigint_leaves_no_temp_orphans_in_nested_tree ... FAILED
test sigint_removes_temp_orphans_from_destination ... FAILED
test sigint_retains_partial_prefix_with_partial_flag ... FAILED
  client pid 24519 ignored signal 2 for 10s: the shutdown flag is set but nothing on
  the network path acted on it
test result: FAILED. 0 passed; 3 failed

Running tests/partial_mid_transfer_kill.rs
  client pid 20620 ignored signal 15 for 10s: ...
test result: FAILED. 0 passed; 3 failed; 1 ignored

Running tests/no_partial_temp_cleanup.rs
  client pid 20503 ignored signal 15 for 10s: ...
test result: FAILED. 2 passed; 3 failed; 1 ignored
  (the 2 passes are the pure temp-name pattern-matcher unit tests)
```

Six green over a deleted signal path, versus nine red. That is the entire delta.

**Experiment D - the residue assertions must bite on their own.** So Experiment C is not
the only thing holding these tests up, `retain_partial_file` in
`crates/transfer/src/disk_commit/process/commit.rs` was flipped so `PartialMode::None`
retains like `PartialMode::Partial`: the client still exits 20, promptly, but leaves a
file it should have unlinked.

```
test sigint_leaves_no_temp_orphans_in_nested_tree ... FAILED
test sigint_removes_temp_orphans_from_destination ... FAILED
  without --partial SIGINT must not leave a destination file
test sigint_retains_partial_prefix_with_partial_flag ... ok      <- correctly unaffected
test result: FAILED. 1 passed; 2 failed
```

The two residue tests fail and the retention test does not - exactly the selectivity a
targeted break should produce.

## After reverting every break

```
tests/cleanup_manager.rs            ok. 2 passed
tests/no_partial_temp_cleanup.rs    ok. 5 passed; 1 ignored
tests/partial_mid_transfer_kill.rs  ok. 3 passed; 1 ignored
tests/sigint_temp_cleanup.rs        ok. 3 passed
tests/signal_integration.rs         ok. 8 passed
```

Both `#[ignore]`d cross-implementation tests also pass when opted in against upstream
rsync 3.4.4 (`--ignored`: `upstream_client_partial_retains_file_on_kill` ok,
`upstream_client_no_partial_cleans_up_on_kill` ok).

`cargo fmt --all -- --check` clean. `cargo clippy -p core --all-features --all-targets
--no-deps -- -D warnings` clean.

## Sweep: other tests whose green signal is decoupled from their name

A workspace-wide sweep of 144 `#[ignore]` attributes and every early-returning test
helper turned up more of the same pattern. Fixed here, because they are the same class
as the bug above and were verified locally:

- **5 tests that never ran anywhere.** `#[ignore = "requires oc-rsync binary"]` dates
  from when the harness guessed at `target/{debug,release}/oc-rsync`.
  `test_support::oc_rsync_bin()` now resolves the profile Cargo is building into and
  panics when the binary is absent, and CI builds it for every test cell, so the reason
  is stale. Un-ignored in `upstream_client_to_oc_daemon_interop.rs` (4) and
  `uts_9_daemon_gzip_download_goodbye.rs` (1); all five pass.
- **`daemon_gzip_goodbye_does_not_truncate`** returned green twice - once for the
  deliberate `OC_RSYNC_UPSTREAM_COMPAT` opt-out, and again when the operator *had*
  opted in but the 3.4.4 binary was missing. The opt-out stays; the opt-in is now a
  promise. Verified all three ways: unset -> skips; set with no binary -> panics naming
  the override env var; set with `OC_RSYNC_UPSTREAM_BIN_3_4_4=/opt/homebrew/bin/rsync`
  -> runs and passes.

Left for a follow-up campaign, listed so they are not lost:

*Bodies that cannot fail* - `protocol/tests/protocol_v27_compat.rs:135,142` (comment-only
bodies); `protocol/tests/protocol_edge_cases.rs:130` (the only asserting branch is
`if input.len() == 4`, and no input has length 4 - dead code);
`protocol/tests/network_interruption.rs:604` (both match arms empty);
`fast_io/tests/io_uring_probe_fallback.rs:106` and `splice_integration.rs:206`
(`let _ = probe();`, name claims a value the body never checks);
`cli/tests/argument_defaults_special.rs:319`; `transfer/tests/buffer_pool_cross_crate.rs:76`;
`core/tests/exit_code_comprehensive.rs:1280`.

*Assertion behind an environment condition* -
`cli/tests/argument_defaults_special.rs:286,300`: the only `assert_eq!` sits inside
`if std::env::var("RSYNC_RSH").is_err()`, so the test passes with nothing executed on any
machine that has the variable set. Wants an `EnvGuard`.

*Stale `#[ignore]`, needs a run to confirm* -
`cli/tests/upstream_arg_fidelity.rs:726` ("invalid `--stderr` mode not rejected"; the
validation landed in #6518); `engine/src/local_copy/tests/execute_no_implied_dirs.rs:9`
("feature not fully implemented"; `implied_dirs` is wired through
`executor/directory/recursive/mod.rs:381` and three un-ignored siblings exercise it);
`cli/src/frontend/tests/exclude_lsh_matrix.rs:224,365` ("UTS-V3.B.F.14 pending"; the
filter behaviour now has non-ignored unit coverage in `filters/src/chain/tests.rs`).

*Structural, not a quick fix* - 19 tests in `upstream_client_to_oc_daemon_interop.rs`
plus ~70 more in `client_daemon_interop.rs` / `daemon_client_interop.rs` are ignored on
`require_upstream(UPSTREAM_3_4_1)`, a hardcoded `target/interop/upstream-install/...`
path that exists only under the interop harness. They cannot see the upstream 3.4.4
binary that `upstream_rsync()` finds. Migrating them is worthwhile but is a version
change (3.4.1 -> 3.4.4) across ~90 tests and belongs in its own PR.

Confirmed still valid and deliberately left alone: the ~90 upstream-binary opt-ins, the
root-required family, the kernel-capability gates (io_uring/SQPOLL, splice), the
resource-exhaustion guards, and the documented `#[ignore]`s that name a real open gap
(`spill_env_e2e.rs:218`, `pip_7_..._repro.rs:168`, `flist_wire_flags_rp28g.rs:146`).

## Windows: what un-ignoring those tests found

Un-ignoring the four daemon tests made them run on the Windows cell for the first time,
and one failed with a message that settles the question rather than raising it:

```
oc-rsync error: daemon mode is not supported on this platform;
run the oc-rsync daemon on a Unix-like system (code 1) at daemon.rs(208)
```

Daemon mode is Unix-only by design, so the four tests carry `#[cfg(unix)]` - the same
gate `test_pull_preserves_permissions` already uses two hundred lines below them. Their
`BufRead`/`BufReader`/`Write`/`std::thread` imports move behind the same gate; verified
by rebuilding the file with every `cfg(unix)` arm forced off, which is clean, and with
them on, which is clean and passes all five tests.

This is the cost of the whole exercise being worth paying: an `#[ignore]` had been
hiding not one but two facts - that the tests never ran, and that one of them could not
have run on Windows if it had.
