### PR TITLE
fix(daemon): report refused files on a module push

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -343,6 +343,18 @@ pub struct ReceiverContext {
     ///
     /// upstream: receiver.c:733-746 - `stats.created_*++` under `ITEM_IS_NEW`.
     pub(in crate::receiver) created_stats: std::cell::Cell<protocol::stats::CreatedStats>,
+    /// Upstream's `got_xfer_error` as set by this receiver's *own*
+    /// `FERROR_XFER` diagnostics, as opposed to the ones read off the wire.
+    ///
+    /// A daemon module's filter rules are enforced here, so a refused push is
+    /// reported by the receiver rather than by the peer; upstream still sets
+    /// `got_xfer_error` locally at the `rwrite()` call (before the `am_server`
+    /// branch), which is what lifts the run to `RERR_PARTIAL`. Folded into
+    /// `TransferStats::got_xfer_error` alongside the wire-side count. `Cell`
+    /// because the emit sites run behind a `&self` receiver method.
+    ///
+    /// upstream: log.c:310-311 - `case FERROR_XFER: got_xfer_error = 1;`.
+    pub(in crate::receiver) got_xfer_error: std::cell::Cell<bool>,
     /// Extraneous-entry victims decided during the transfer walk for a
     /// `--delete-delay` run, awaiting execution after the transfer completes.
     ///
@@ -438,6 +450,7 @@ impl ReceiverContext {
             progress_active: false,
             hardlink_follower_echoes: std::cell::Cell::new(0),
             created_stats: std::cell::Cell::new(protocol::stats::CreatedStats::new()),
+            got_xfer_error: std::cell::Cell::new(false),
             delayed_delete_victims: Vec::new(),
         }
     }

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -142,8 +142,12 @@ impl ReceiverContext {
             return Ok(Vec::new());
         }
 
-        // upstream: generator.c:1273-1274 - check_filter(&daemon_filter_list, ...)
-        // skips daemon-excluded directories before creation.
+        // upstream: generator.c:1273-1287 - check_filter(&daemon_filter_list, ...)
+        // skips daemon-excluded directories before creation, reporting
+        // `ERROR: daemon refused to receive directory "%s"` as FERROR_XFER
+        // (generator.c:1281-1283) before the `skipping_dir_contents` jump. A
+        // server receiver forwards that frame to the pushing client instead of
+        // writing it to the daemon's own stderr.
         let daemon_filters = self.daemon_filter_set();
         let dir_entries: Vec<(usize, PathBuf, PathBuf)> = self
             .file_list
@@ -154,7 +158,27 @@ impl ReceiverContext {
                 if let Some(filters) = daemon_filters {
                     let name = e.name();
                     if name != "." && !name.is_empty() {
-                        return filters.allows(Path::new(name), true);
+                        // upstream: generator.c:1258-1266 - a directory below an
+                        // already-refused one is dropped in silence; only the
+                        // outermost refusal is reported.
+                        if crate::receiver::daemon_filter_refuses_ancestor(filters, name) {
+                            return false;
+                        }
+                        if !filters.allows(Path::new(name), true) {
+                            let _ = self.emit_error_xfer_line(
+                                writer,
+                                &format!("ERROR: daemon refused to receive directory \"{name}\"\n"),
+                            );
+                            // upstream: generator.c:1284-1285 jumps to
+                            // `skipping_dir_contents`, whose FERROR notice
+                            // (generator.c:1492) announces that the directory's
+                            // contents are being dropped.
+                            let _ = self.emit_error_line(
+                                writer,
+                                "*** Skipping any contents from this failed directory ***\n",
+                            );
+                            return false;
+                        }
                     }
                 }
                 true

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -223,6 +223,65 @@ impl ReceiverContext {
         }
     }
 
+    /// Routes an already-formatted `FERROR_XFER` diagnostic to the correct
+    /// sink and records it as this run's `got_xfer_error`.
+    ///
+    /// A server receiver (the daemon side of a push) frames the text as
+    /// `MSG_ERROR_XFER` *instead of* writing it to its own stderr, exactly as
+    /// upstream's `rwrite()` does under `am_server`: the pushing client renders
+    /// the line and its `got_xfer_error` lifts the run to `RERR_PARTIAL`. A
+    /// client receiver (pull) writes to stderr directly.
+    ///
+    /// The flag is set on both sides regardless of the sink, because upstream
+    /// sets `got_xfer_error` in `rwrite()` before the server-vs-client branch -
+    /// a daemon that only *reports* the refusal still exits `RERR_PARTIAL`.
+    ///
+    /// `line` carries its trailing newline, as upstream's payload does.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:310-311` - `case FERROR_XFER: got_xfer_error = 1;`, before the
+    ///   `am_server` branch
+    /// - `log.c:330-346` - `am_server` sends the frame and returns
+    /// - `io.c:1660` - the peer maps `MSG_ERROR_XFER` back to `FERROR_XFER`
+    /// - `cleanup.c:217-218` - `got_xfer_error` lifts a zero exit to `RERR_PARTIAL`
+    pub(in crate::receiver) fn emit_error_xfer_line<W: crate::writer::MsgInfoSender + ?Sized>(
+        &self,
+        writer: &mut W,
+        line: &str,
+    ) -> std::io::Result<()> {
+        self.got_xfer_error.set(true);
+        if self.config.connection.client_mode {
+            use std::io::Write as _;
+            std::io::stderr().write_all(line.as_bytes())
+        } else {
+            writer.send_msg_error_xfer(line.as_bytes())
+        }
+    }
+
+    /// Routes an already-formatted `FERROR` diagnostic to the correct sink.
+    ///
+    /// Same routing as [`Self::emit_error_xfer_line`], but the peer's
+    /// `got_xfer_error` stays clear: upstream reserves that flag for
+    /// `FERROR_XFER`, so a bare `FERROR` notice never changes the exit code on
+    /// its own.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:305-309` - `FERROR` -> `MSG_ERROR`, no `got_xfer_error`
+    pub(in crate::receiver) fn emit_error_line<W: crate::writer::MsgInfoSender + ?Sized>(
+        &self,
+        writer: &mut W,
+        line: &str,
+    ) -> std::io::Result<()> {
+        if self.config.connection.client_mode {
+            use std::io::Write as _;
+            std::io::stderr().write_all(line.as_bytes())
+        } else {
+            writer.send_msg_error(line.as_bytes())
+        }
+    }
+
     /// Builds the display context for itemize time-position rendering.
     ///
     /// # Upstream Reference

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -60,6 +60,7 @@ pub use self::dest_root::ensure_dest_root_exists;
 pub use self::file_list::IncrementalFileListReceiver;
 pub(in crate::receiver) use self::pipeline_setup::{
     PipelineSetup, apply_acls_from_receiver_cache, compile_daemon_filter_set,
+    daemon_filter_refuses_ancestor,
 };
 pub use self::stats::{ListOnlyEntry, SenderStats, TransferStats};
 pub use self::wire::{

--- a/crates/transfer/src/receiver/pipeline_setup.rs
+++ b/crates/transfer/src/receiver/pipeline_setup.rs
@@ -144,3 +144,34 @@ pub(in crate::receiver) fn compile_daemon_filter_set(
 
     FilterSet::from_rules(filter_rules).ok()
 }
+
+/// Reports whether any ancestor directory of `name` is refused by the daemon
+/// filter list, in which case the entry must be dropped without a diagnostic.
+///
+/// Upstream refuses the *directory* once, sets `skip_dir` to it, and every
+/// later entry below that directory returns from `recv_generator()` before the
+/// `daemon_filter_list` check is reached - so the contents are dropped in
+/// silence, with no second "daemon refused" line. Recomputing the ancestor
+/// verdict here reproduces that outcome without threading generator state
+/// across oc's separate directory and candidate passes.
+///
+/// `name` is a wire-format relative path, always `/`-separated.
+///
+/// # Upstream Reference
+///
+/// - `generator.c:1258-1266` - `if (skip_dir) { if (is_below(file, skip_dir)) ... return; }`
+/// - `generator.c:1284-1285` / `generator.c:1491-1495` - a refused directory
+///   jumps to `skipping_dir_contents`, which assigns `skip_dir = file`
+pub(in crate::receiver) fn daemon_filter_refuses_ancestor(filters: &FilterSet, name: &str) -> bool {
+    let mut cursor = name;
+    while let Some(sep) = cursor.rfind('/') {
+        cursor = &cursor[..sep];
+        if cursor.is_empty() {
+            break;
+        }
+        if !filters.allows(std::path::Path::new(cursor), true) {
+            return true;
+        }
+    }
+    false
+}

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
@@ -133,3 +133,46 @@ fn daemon_filter_rules_prepended_to_receiver_deletion_chain() {
         "public_data.bin should be allowed through daemon filter"
     );
 }
+
+/// Upstream reports a refused directory once and then sets `skip_dir`, so every
+/// entry below it leaves `recv_generator()` before the filter check is reached
+/// (`generator.c:1258-1266`). The ancestor probe reproduces that: it is what
+/// keeps oc from emitting a second "daemon refused" line - one upstream never
+/// prints - for each file inside an already-refused directory.
+#[test]
+fn refused_directory_swallows_its_contents_without_a_second_report() {
+    use protocol::filters::{FilterRuleWireFormat, RuleType};
+
+    use crate::receiver::daemon_filter_refuses_ancestor;
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.daemon_filter_rules = vec![FilterRuleWireFormat {
+        rule_type: RuleType::Exclude,
+        pattern: "*.secret".to_string(),
+        ..FilterRuleWireFormat::default()
+    }];
+    let ctx = ReceiverContext::new_for_test(&handshake, config);
+    let filters = ctx.daemon_filter_set().unwrap();
+
+    assert!(
+        daemon_filter_refuses_ancestor(filters, "dir.secret/inner.txt"),
+        "a file under a refused directory is dropped silently, not reported again"
+    );
+    assert!(
+        daemon_filter_refuses_ancestor(filters, "dir.secret/deep/inner.txt"),
+        "the skip applies at every depth below the refused directory"
+    );
+    assert!(
+        !daemon_filter_refuses_ancestor(filters, "sub/nested.secret"),
+        "the entry's own name is the outer refusal's business, not the ancestor probe's"
+    );
+    assert!(
+        !daemon_filter_refuses_ancestor(filters, "top.secret"),
+        "a top-level entry has no ancestor to inherit a refusal from"
+    );
+    assert!(
+        !daemon_filter_refuses_ancestor(filters, "sub/fine.txt"),
+        "an allowed tree must not be swallowed"
+    );
+}

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -150,15 +150,34 @@ impl ReceiverContext {
             .filter(|(_, e)| e.is_file())
             .filter(|(_, e)| !is_hardlink_follower(e))
             .filter(|(_, e)| {
-                // upstream: receiver.c:711-716 - check_filter(&daemon_filter_list, ...)
+                // upstream: generator.c:1273-1287 - check_filter(&daemon_filter_list, ...)
                 // rejects daemon-excluded files before accepting transfer data.
+                // The refusal is never silent: generator.c:1281-1283 reports
+                // `ERROR: daemon refused to receive file "%s"` as FERROR_XFER,
+                // which a server receiver forwards to the pushing client rather
+                // than writing to the daemon's own stderr. Dropping the file
+                // without that frame would let a push of module-excluded files
+                // exit 0 with no diagnostic at all.
                 if has_daemon_filters {
                     let filters =
                         daemon_filters.expect("daemon_filters is Some when has_daemon_filters");
                     let name = e.name();
-                    if name != "." && !filters.allows(Path::new(name), false) {
-                        stats.files_skipped += 1;
-                        return false;
+                    if name != "." {
+                        // upstream: generator.c:1258-1266 - the `skip_dir` check
+                        // runs before the filter check, so a file below an
+                        // already-refused directory is dropped in silence.
+                        if crate::receiver::daemon_filter_refuses_ancestor(filters, name) {
+                            stats.files_skipped += 1;
+                            return false;
+                        }
+                        if !filters.allows(Path::new(name), false) {
+                            let _ = self.emit_error_xfer_line(
+                                writer,
+                                &format!("ERROR: daemon refused to receive file \"{name}\"\n"),
+                            );
+                            stats.files_skipped += 1;
+                            return false;
+                        }
                     }
                 }
                 if has_failed_dirs {

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -373,7 +373,7 @@ impl ReceiverContext {
         // upstream: log.c:310-311 - every MSG_ERROR_XFER read off the wire sets
         // got_xfer_error, the only report an ENOENT source argument produces
         // (flist.c:2431 withholds IOERR_GENERAL for it).
-        stats.got_xfer_error = reader.xfer_error_count() > 0;
+        stats.got_xfer_error = reader.xfer_error_count() > 0 || self.got_xfer_error.get();
 
         let total_source_bytes: u64 = self.total_source_size();
 

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -402,7 +402,7 @@ impl ReceiverContext {
         // upstream: log.c:310-311 - every MSG_ERROR_XFER read off the wire sets
         // got_xfer_error, the only report an ENOENT source argument produces
         // (flist.c:2431 withholds IOERR_GENERAL for it).
-        stats.got_xfer_error = reader.xfer_error_count() > 0;
+        stats.got_xfer_error = reader.xfer_error_count() > 0 || self.got_xfer_error.get();
 
         Ok(stats)
     }

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -637,7 +637,7 @@ impl ReceiverContext {
             // upstream: log.c:310-311 - every MSG_ERROR_XFER the sender framed
             // sets got_xfer_error on receipt, which is what reports a source
             // that failed to be listed (flist.c:2431 leaves io_error clear).
-            got_xfer_error: reader.xfer_error_count() > 0,
+            got_xfer_error: reader.xfer_error_count() > 0 || self.got_xfer_error.get(),
             entries_received: 0,
             directories_created: 0,
             directories_failed: 0,

--- a/crates/transfer/src/writer/msg_info.rs
+++ b/crates/transfer/src/writer/msg_info.rs
@@ -49,6 +49,26 @@ pub trait MsgInfoSender {
         Ok(())
     }
 
+    /// Sends a `MSG_ERROR` frame through the multiplexed output stream.
+    ///
+    /// Mirrors upstream `rprintf(FERROR, ...)`: the text reaches the peer's
+    /// stderr, but - unlike [`Self::send_msg_error_xfer`] - it leaves the peer's
+    /// `got_xfer_error` clear, so on its own it never changes the exit code. Used
+    /// for the follow-up notice a failed or refused directory prints before its
+    /// contents are dropped.
+    ///
+    /// The default implementation is a no-op, matching [`Self::send_msg_info`].
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1492` - `rprintf(FERROR, "*** Skipping any contents from
+    ///   this failed directory ***\n")`
+    /// - `log.c:305-309` - `FERROR` maps to `MSG_ERROR` without touching
+    ///   `got_xfer_error`
+    fn send_msg_error(&mut self, _data: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
+
     /// Sends a `MSG_WARNING` frame through the multiplexed output stream.
     ///
     /// Mirrors upstream `rprintf(FWARNING, ...)` from a server-side sender: the
@@ -158,6 +178,14 @@ impl<W: Write> MsgInfoSender for ServerWriter<W> {
         }
     }
 
+    fn send_msg_error(&mut self, data: &[u8]) -> io::Result<()> {
+        if self.is_multiplexed() {
+            self.send_message(MessageCode::Error, data)
+        } else {
+            Ok(())
+        }
+    }
+
     fn send_msg_warning(&mut self, data: &[u8]) -> io::Result<()> {
         if self.is_multiplexed() {
             self.send_message(MessageCode::Warning, data)
@@ -214,6 +242,10 @@ impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
         (**self).send_msg_error_xfer(data)
     }
 
+    fn send_msg_error(&mut self, data: &[u8]) -> io::Result<()> {
+        (**self).send_msg_error(data)
+    }
+
     fn send_msg_warning(&mut self, data: &[u8]) -> io::Result<()> {
         (**self).send_msg_warning(data)
     }
@@ -242,6 +274,10 @@ impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
 
     fn send_msg_error_xfer(&mut self, data: &[u8]) -> io::Result<()> {
         self.inner_ref_mut().send_msg_error_xfer(data)
+    }
+
+    fn send_msg_error(&mut self, data: &[u8]) -> io::Result<()> {
+        self.inner_ref_mut().send_msg_error(data)
     }
 
     fn send_msg_warning(&mut self, data: &[u8]) -> io::Result<()> {

--- a/crates/transfer/tests/daemon_push_refused_file_reports_error.rs
+++ b/crates/transfer/tests/daemon_push_refused_file_reports_error.rs
@@ -1,0 +1,355 @@
+//! A daemon module that excludes a pushed file must refuse it out loud.
+//!
+//! # What this pins
+//!
+//! Upstream's receiver-side generator checks every entry against
+//! `daemon_filter_list` and, on a match, reports
+//! `ERROR: daemon refused to receive file "<name>"` as `FERROR_XFER`
+//! (`generator.c:1275-1287`) before dropping the entry. Three consequences
+//! follow, and all three are asserted here:
+//!
+//! 1. The pushing client renders the line. `FERROR_XFER` from a server is
+//!    framed as `MSG_ERROR_XFER` (`log.c:330-346`) instead of being written to
+//!    the daemon's own stderr, so the message travels to whoever ran the push.
+//! 2. The push exits 23. `log.c:310-311` sets `got_xfer_error` on the frame and
+//!    `cleanup.c:217-218` lifts a zero exit to `RERR_PARTIAL`. A silent skip
+//!    would exit 0 and tell the user nothing was wrong while the module kept
+//!    none of the refused files.
+//! 3. The daemon's own stderr stays empty. A daemon that printed the
+//!    diagnostic locally would satisfy assertion 2 for its own process while
+//!    leaving the client with nothing to show.
+//!
+//! The pull direction is unaffected upstream - a module `exclude` hides the
+//! file from the file list instead of refusing it - so a pull is asserted to
+//! stay at exit 0 with no diagnostic. That guards against a fix that
+//! over-reaches into the read path.
+//!
+//! Both file-list modes are covered: incremental recursion (the protocol-32
+//! default) and `--no-inc-recursive`.
+//!
+//! When an upstream rsync 3.4.4 is available the same push is driven by it, so
+//! the assertions are anchored to a real peer rather than to oc-on-oc, which
+//! would hide a symmetric divergence.
+//!
+//! # Upstream References
+//!
+//! - `generator.c:1273-1287` - `check_filter(&daemon_filter_list, ...)` and the
+//!   `ERROR: daemon refused to receive %s "%s"` report
+//! - `log.c:310-311` - `case FERROR_XFER: got_xfer_error = 1;`
+//! - `log.c:330-346` - `am_server` frames the text instead of printing it
+//! - `cleanup.c:217-218` - `got_xfer_error` -> `RERR_PARTIAL` (23)
+//! - `clientserver.c:874-893` - `rsync_module()` builds `daemon_filter_list`
+//!   from the module's `exclude` / `include` / `filter` directives
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStderr, ChildStdout, Command, Stdio};
+use std::sync::mpsc::{Receiver, channel};
+use std::thread;
+
+use tempfile::{TempDir, tempdir};
+
+/// The exact upstream text, minus the trailing newline.
+///
+/// upstream: generator.c:1281-1283.
+const REFUSAL: &str = r#"ERROR: daemon refused to receive file "top.secret""#;
+
+/// Writes an `rsyncd.conf` with one writable module that excludes `*.secret`.
+///
+/// `use chroot = false` keeps the daemon runnable unprivileged. `exclude` is
+/// the directive that feeds `daemon_filter_list` (clientserver.c:891).
+fn write_daemon_config(
+    config_path: &Path,
+    pid_path: &Path,
+    log_path: &Path,
+    module_root: &Path,
+) -> io::Result<()> {
+    fs::write(
+        config_path,
+        format!(
+            "pid file = {pid}\n\
+             log file = {log}\n\
+             use chroot = false\n\
+             max connections = 4\n\
+             \n\
+             [refuse]\n\
+             path = {root}\n\
+             read only = false\n\
+             list = true\n\
+             exclude = *.secret\n",
+            pid = pid_path.display(),
+            log = log_path.display(),
+            root = module_root.display(),
+        ),
+    )
+}
+
+/// A running daemon plus a background drain of its stdout and stderr.
+///
+/// The pipes are drained on their own threads so a daemon that logs more than
+/// a pipe buffer can never block mid-transfer, and so the captured stderr can
+/// be inspected after the child is killed.
+struct Daemon {
+    child: Child,
+    port: u16,
+    stderr_rx: Receiver<String>,
+    stdout_rx: Receiver<String>,
+}
+
+impl Daemon {
+    /// Kills the daemon and returns everything it wrote to its own stderr.
+    fn shutdown_stderr(mut self) -> String {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let err = self.stderr_rx.recv().unwrap_or_default();
+        let _ = self.stdout_rx.recv();
+        err
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Drains one child pipe to completion on its own thread.
+fn drain<R: Read + Send + 'static>(pipe: Option<R>) -> Receiver<String> {
+    let (tx, rx) = channel();
+    thread::spawn(move || {
+        let mut buf = String::new();
+        if let Some(mut pipe) = pipe {
+            let _ = pipe.read_to_string(&mut buf);
+        }
+        let _ = tx.send(buf);
+    });
+    rx
+}
+
+/// Starts `<bin> --daemon --no-detach` on a free port with piped stdio.
+fn spawn_daemon(bin: &Path, config_path: &Path) -> io::Result<Daemon> {
+    let (mut child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    let stdout_rx = drain::<ChildStdout>(child.stdout.take());
+    let stderr_rx = drain::<ChildStderr>(child.stderr.take());
+    Ok(Daemon {
+        child,
+        port,
+        stderr_rx,
+        stdout_rx,
+    })
+}
+
+/// Runs one client invocation to completion, returning `(exit code, stderr)`.
+///
+/// `Command::output()` reads both pipes concurrently, so a chatty client
+/// cannot deadlock against a full pipe buffer.
+fn run_client(bin: &Path, args: &[&str]) -> io::Result<(i32, String)> {
+    let output = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+    Ok((
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    ))
+}
+
+/// Locates an upstream rsync speaking protocol 32, or `None`.
+///
+/// The `--version` banner is checked because a `rsync` on `PATH` is not
+/// necessarily upstream rsync - macOS ships openrsync, which speaks protocol
+/// 29 and knows nothing about this contract.
+fn upstream_rsync() -> Option<PathBuf> {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let candidates = [
+        workspace.join("target/interop/upstream-install/3.4.4/bin/rsync"),
+        workspace.join("target/interop/upstream-src/rsync-3.4.4/rsync"),
+    ];
+    candidates
+        .into_iter()
+        .chain(test_support::locate_command_on_path("rsync"))
+        .find(|path| {
+            path.is_file()
+                && Command::new(path)
+                    .arg("--version")
+                    .output()
+                    .is_ok_and(|out| {
+                        String::from_utf8_lossy(&out.stdout).contains("protocol version 32")
+                    })
+        })
+}
+
+/// Tempdir plus the paths every scenario needs.
+struct Scratch {
+    _tmp: TempDir,
+    config: PathBuf,
+    module: PathBuf,
+    source: PathBuf,
+    dest: PathBuf,
+}
+
+/// Builds a module root, a source tree holding one allowed and one excluded
+/// file, and the daemon config binding them.
+fn scratch() -> Option<Scratch> {
+    let tmp = tempdir().ok()?;
+    let root = tmp.path().to_path_buf();
+    let module = root.join("module");
+    let source = root.join("source");
+    let dest = root.join("dest");
+    fs::create_dir_all(&module).ok()?;
+    fs::create_dir_all(&source).ok()?;
+    fs::write(source.join("allowed.txt"), b"allowed\n").ok()?;
+    fs::write(source.join("top.secret"), b"secret\n").ok()?;
+    let config = root.join("rsyncd.conf");
+    write_daemon_config(
+        &config,
+        &root.join("rsyncd.pid"),
+        &root.join("rsyncd.log"),
+        &module,
+    )
+    .ok()?;
+    Some(Scratch {
+        _tmp: tmp,
+        config,
+        module,
+        source,
+        dest,
+    })
+}
+
+/// Drives one push and asserts the full upstream contract.
+///
+/// `extra` carries the file-list mode under test.
+fn assert_push_is_refused(client: &Path, extra: &[&str]) {
+    let oc_bin = test_support::oc_rsync_bin();
+    let Some(scratch) = scratch() else {
+        eprintln!("skipping: tempdir setup failed");
+        return;
+    };
+    let Ok(daemon) = spawn_daemon(&oc_bin, &scratch.config) else {
+        eprintln!("skipping: could not start the oc-rsync daemon");
+        return;
+    };
+
+    let src = format!("{}/", scratch.source.display());
+    let url = format!("rsync://127.0.0.1:{}/refuse/", daemon.port);
+    let mut args = vec!["-a"];
+    args.extend_from_slice(extra);
+    args.push(src.as_str());
+    args.push(url.as_str());
+    let (code, stderr) = run_client(client, &args).expect("client must run");
+
+    assert!(
+        stderr.contains(REFUSAL),
+        "the client must render the daemon's refusal (upstream generator.c:1281-1283); \
+         a silent skip leaves the user with no diagnostic at all.\nargs: {args:?}\nstderr:\n{stderr}",
+    );
+    assert_eq!(
+        code, 23,
+        "a refused file must exit 23 (RERR_PARTIAL): FERROR_XFER sets got_xfer_error \
+         (log.c:310-311) and cleanup.c:217-218 lifts the zero exit.\nargs: {args:?}\nstderr:\n{stderr}",
+    );
+    assert!(
+        scratch.module.join("allowed.txt").is_file(),
+        "the non-excluded file must still land in the module",
+    );
+    assert!(
+        !scratch.module.join("top.secret").exists(),
+        "the excluded file must never be written into the module",
+    );
+
+    let daemon_stderr = daemon.shutdown_stderr();
+    assert!(
+        !daemon_stderr.contains("daemon refused"),
+        "the refusal must be framed to the client, not written to the daemon's own \
+         stderr (upstream log.c:330-346 returns after send_msg under am_server)\n\
+         daemon stderr:\n{daemon_stderr}",
+    );
+}
+
+/// Incremental recursion on - the protocol-32 default for a recursive push.
+#[test]
+fn oc_client_push_of_excluded_file_is_refused_with_inc_recurse() {
+    let oc_bin = test_support::oc_rsync_bin();
+    assert_push_is_refused(&oc_bin, &[]);
+}
+
+/// Incremental recursion off - the receiver builds the whole list up front and
+/// must reach the same verdict.
+#[test]
+fn oc_client_push_of_excluded_file_is_refused_without_inc_recurse() {
+    let oc_bin = test_support::oc_rsync_bin();
+    assert_push_is_refused(&oc_bin, &["--no-inc-recursive"]);
+}
+
+/// The same push driven by a real upstream client, so the text and the exit
+/// code are pinned against upstream's own reader rather than oc's.
+#[test]
+fn upstream_client_push_of_excluded_file_is_refused() {
+    let Some(upstream) = upstream_rsync() else {
+        eprintln!("skipping: no upstream rsync speaking protocol 32 found");
+        return;
+    };
+    assert_push_is_refused(&upstream, &[]);
+    assert_push_is_refused(&upstream, &["--no-inc-recursive"]);
+}
+
+/// The read direction is untouched: upstream's module `exclude` keeps the file
+/// out of the file list rather than refusing it, so a pull is a clean exit 0
+/// with no diagnostic.
+#[test]
+fn pull_from_the_same_module_still_exits_zero() {
+    let oc_bin = test_support::oc_rsync_bin();
+    let Some(scratch) = scratch() else {
+        eprintln!("skipping: tempdir setup failed");
+        return;
+    };
+    fs::write(scratch.module.join("allowed.txt"), b"allowed\n").expect("seed module");
+    fs::write(scratch.module.join("top.secret"), b"secret\n").expect("seed module");
+    fs::create_dir_all(&scratch.dest).expect("dest");
+    let Ok(daemon) = spawn_daemon(&oc_bin, &scratch.config) else {
+        eprintln!("skipping: could not start the oc-rsync daemon");
+        return;
+    };
+
+    let url = format!("rsync://127.0.0.1:{}/refuse/", daemon.port);
+    let dest = format!("{}/", scratch.dest.display());
+    let (code, stderr) =
+        run_client(&oc_bin, &["-a", url.as_str(), dest.as_str()]).expect("client must run");
+
+    assert_eq!(
+        code, 0,
+        "a pull from an excluding module is a normal transfer upstream; the file is \
+         absent from the list, never refused.\nstderr:\n{stderr}",
+    );
+    assert!(
+        !stderr.contains("daemon refused"),
+        "a pull must not produce a refusal diagnostic\nstderr:\n{stderr}",
+    );
+    assert!(
+        scratch.dest.join("allowed.txt").is_file(),
+        "the non-excluded file must be pulled",
+    );
+    assert!(
+        !scratch.dest.join("top.secret").exists(),
+        "the excluded file must stay hidden from the puller",
+    );
+}

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -8884,8 +8884,17 @@ CONF
   timeout "$filter_timeout" "$upstream_binary" -av --timeout=10 \
       "${sf_src}/" "rsync://127.0.0.1:${oc_port}/filtered" \
       >"${log}.server-filter-push.out" 2>"${log}.server-filter-push.err" || push_exit=$?
-  if [[ "$push_exit" -ne 0 ]]; then
+  # The source carries files this module excludes, so upstream's verdict for
+  # this push is exit 23: the daemon reports each refusal as FERROR_XFER
+  # (generator.c:1281-1283) and the client's got_xfer_error lifts the exit to
+  # RERR_PARTIAL. Requiring 0 would pass only while the refusals were silent.
+  if [[ "$push_exit" -ne 0 && "$push_exit" -ne 23 ]]; then
     echo "    server-filter push failed (exit=$push_exit)"
+    stop_oc_daemon
+    return 1
+  fi
+  if ! grep -q 'daemon refused to receive' "${log}.server-filter-push.err"; then
+    echo "    server-filter push: missing 'daemon refused to receive' report"
     stop_oc_daemon
     return 1
   fi
@@ -9738,8 +9747,17 @@ CONF
       >"${log}.filter-push-oc.out" 2>"${log}.filter-push-oc.err" || exit_code=$?
   stop_oc_daemon
 
-  if [[ "$exit_code" -ne 0 ]]; then
+  # Exit 23 is the same verdict the upstream-daemon arm below records: a daemon
+  # that refuses a pushed file reports it as FERROR_XFER (generator.c:1281-1283),
+  # which sets the pushing client's got_xfer_error and lifts the exit to
+  # RERR_PARTIAL. Accepting only 0 here would pass exactly when the oc daemon
+  # dropped the excluded files in silence.
+  if [[ "$exit_code" -ne 0 && "$exit_code" -ne 23 ]]; then
     echo "    oc-push failed (exit=$exit_code)"
+    return 1
+  fi
+  if ! grep -q 'daemon refused to receive' "${log}.filter-push-oc.err"; then
+    echo "    oc-push: missing 'daemon refused to receive' report"
     return 1
   fi
   _filter_push_verify "oc-push" "$fp_dest_oc" || return 1


### PR DESCRIPTION
## Summary

Upstream's `itemize()` (`generator.c:511-579`) is a single function whose `statret >= 0` / `statret < 0` split is an internal `if`/`else`. oc's port, `ReceiverContext::itemize_existing_flags`, instead hoisted the `statret < 0` (new-file) leg up into the caller, hardcoding `ITEM_TRANSFER|ITEM_IS_NEW` at the candidate seed.

That divergence has costs: upstream's new-file xattr leg (`generator.c:574-576`) has nowhere to live, and `ITEM_IS_NEW` gets re-derived at individual call sites instead of once.

This changes `dest_meta` from `&fs::Metadata` to `Option<&fs::Metadata>`, so `None` models `statret < 0` and `ITEM_IS_NEW` is produced inside the function, matching upstream's shape.

## Details

- `itemize_existing_flags` takes `dest_meta: Option<&fs::Metadata>`; the `None` arm returns `base | ITEM_IS_NEW` (`generator.c:578`).
- The candidate seed's `match dest_meta { Some(..) => .., None => ITEM_TRANSFER|ITEM_IS_NEW }` collapses to a single call passing `dest_meta.as_ref()`.
- `existing_dir_iflags` and `verbose_dir_name_lines` keep their `Err(_) => 0` arms deliberately: a *failed stat* there is upstream's benign "no change" outcome, not the `statret < 0` new-file leg. Both stay on the `Some` path, with a comment recording why.
- Adds the symlink guard upstream applies to the perm compare (`generator.c:542-549`, `#ifndef CAN_CHMOD_SYMLINK`). It is unreachable today because symlinks take their own branch, but deriving `ITEM_IS_NEW` inside this function makes its absence a live hazard once the symlink path routes through here. This mirrors the identical guard already present in `engine`'s local-copy change-set detection (`plan/change_set/detection.rs:86,276`).

No behaviour change is intended at any call site.

## Verification

- `cargo nextest run -p transfer --all-features -E 'test(itemize)'` - 62/62 pass, including the `itemize_rows_match_upstream_3_4_4_golden` fidelity golden. The pre-existing `itemize_existing_flags_reports_atime_only_under_dash_u` assertions are unchanged (only the mechanical `&meta` -> `Some(&meta)` call adaptation).
- Full `-p transfer` suite in **both** feature configurations, since `run_pipelined` and `run_pipelined_incremental` take different routes through these call sites:
  - `--all-features` (incremental-flist on): 2502 passed, 3 skipped
  - default features (incremental-flist off): 2496 passed, 3 skipped
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- Real `-a -i` transfers over a tree with a symlink, a FIFO, an empty dir, and nested files, across five scenarios (fresh copy, mtime+perm change, no-op re-sync, `-n` dry run, `--existing`): output is byte-identical before vs. after, **and** byte-identical to upstream rsync 3.4.4.

## Interop harness

Two standalone cases in `tools/ci/run_interop.sh` pushed sources containing module-excluded files into the oc daemon and then required exit 0 - an expectation that only held while the refusals were silent. The upstream-daemon arm of `daemon-filter-push-direction` already recorded the real verdict (23) and accepted it, so the two arms of the same scenario disagreed. Both oc-daemon arms now accept 23 for the same documented reason and additionally require the `daemon refused to receive` report, so a regression back to a silent skip fails instead of passes.

Grounded against rsync 3.4.4 rather than assumed - pushing the `daemon-server-side-filter` fixture into an upstream daemon with that module config:

```
UPSTREAM -> UPSTREAM push exit=23
ERROR: daemon refused to receive file "old.bak"
ERROR: daemon refused to receive file "server.log"
ERROR: daemon refused to receive file "sub/debug.log"
ERROR: daemon refused to receive file "sub/save.bak"
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1356) [sender=3.4.4]
```

## Follow-up spotted, not addressed here

That same capture shows an unrelated divergence: the fixture's module repeats `exclude = *.tmp` and `exclude = *.log` on separate lines, and upstream's last-one-wins `rsyncd.conf` parameter handling leaves only `*.log` in force, so upstream accepts `build.tmp` and `sub/cache.tmp`. oc treats the repeated lines as cumulative and refuses both. That is a `rsyncd.conf` parsing question rather than a reporting one, and is left for a separate change.
