### PR TITLE
refactor: fold the new-file itemize leg into itemize_existing_flags

### DIFF
--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -378,7 +378,7 @@ impl ReceiverContext {
                     // compensation still fires `cd+++++++++ ./` when the
                     // pre-flight mkdir created the root.
                     let raw = match pre_mkdir_meta.get(pos).and_then(Option::as_ref) {
-                        Some(meta) => self.itemize_existing_flags(entry, meta, 0),
+                        Some(meta) => self.itemize_existing_flags(entry, Some(meta), 0),
                         None => self.existing_dir_iflags(entry, dir_path),
                     };
                     crate::generator::ItemFlags::from_raw(raw)

--- a/crates/transfer/src/receiver/itemize.rs
+++ b/crates/transfer/src/receiver/itemize.rs
@@ -103,7 +103,9 @@ impl ReceiverContext {
         dir_path: &std::path::Path,
     ) -> u32 {
         match std::fs::metadata(dir_path) {
-            Ok(meta) => self.itemize_existing_flags(entry, &meta, 0),
+            Ok(meta) => self.itemize_existing_flags(entry, Some(&meta), 0),
+            // Not `None`: a failed stat is upstream's benign "no change"
+            // outcome here, not the `statret < 0` ITEM_IS_NEW leg.
             Err(_) => 0,
         }
     }
@@ -167,7 +169,7 @@ impl ReceiverContext {
                     // upstream: itemize() compares an existing dir's pre-apply
                     // stat and prints its name only when an attribute differs.
                     Ok(meta) if meta.is_dir() => crate::generator::ItemFlags::from_raw(
-                        self.itemize_existing_flags(entry, &meta, 0),
+                        self.itemize_existing_flags(entry, Some(&meta), 0),
                     )
                     .has_significant_flags(),
                     // Present but not a directory: upstream deletes it and

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -335,7 +335,7 @@ impl ReceiverContext {
                     // up-to-date file; the attr-comparison may still surface a
                     // metadata-only row (perms/owner/group differing while
                     // size+mtime match).
-                    let mut unchanged_iflags = self.itemize_existing_flags(entry, meta, 0);
+                    let mut unchanged_iflags = self.itemize_existing_flags(entry, Some(meta), 0);
                     // upstream: generator.c:566-572 - ITEM_REPORT_XATTR when the
                     // destination's xattrs differ from the sender's. Computed on
                     // the -X itemize path only (matching upstream's lazy
@@ -406,17 +406,11 @@ impl ReceiverContext {
             // changes against the pre-transfer destination. A non-existent dest
             // (statret < 0) is ITEM_IS_NEW; an existing one OR-s the per-attr
             // report bits onto ITEM_TRANSFER.
-            let base_iflags = match dest_meta {
-                Some(ref meta) => self.itemize_existing_flags(
-                    entry,
-                    meta,
-                    crate::generator::ItemFlags::ITEM_TRANSFER,
-                ),
-                None => {
-                    crate::generator::ItemFlags::ITEM_TRANSFER
-                        | crate::generator::ItemFlags::ITEM_IS_NEW
-                }
-            };
+            let base_iflags = self.itemize_existing_flags(
+                entry,
+                dest_meta.as_ref(),
+                crate::generator::ItemFlags::ITEM_TRANSFER,
+            );
             if base_iflags & crate::generator::ItemFlags::ITEM_IS_NEW != 0 {
                 // upstream: receiver.c:777-778 - a regular file being received
                 // whose destination was absent (ITEM_IS_NEW) bumps
@@ -601,15 +595,21 @@ impl ReceiverContext {
                     } else {
                         ItemFlags::ITEM_TRANSFER
                     };
-                    self.itemize_existing_flags(entry, &meta, base)
+                    self.itemize_existing_flags(entry, Some(&meta), base)
                 }
                 Err(_) => new_iflags(ItemFlags::ITEM_TRANSFER),
             }
         }
     }
 
-    /// Computes the attribute-comparison itemize flags for a destination file
-    /// that already exists, mirroring upstream `generator.c:515-556` `itemize()`.
+    /// Computes the itemize flags for `entry`, mirroring upstream `itemize()`
+    /// (`generator.c:511-579`).
+    ///
+    /// `dest_meta` models upstream's `statret`: `Some(meta)` is the
+    /// `statret >= 0` leg (`generator.c:515`) where the pre-transfer
+    /// destination stat is compared attribute by attribute, and `None` is the
+    /// `statret < 0` leg (`generator.c:573-578`) where the destination is
+    /// absent and the row is simply `ITEM_IS_NEW`.
     ///
     /// `base` is `ITEM_TRANSFER` for a file being transferred, or `0` for an
     /// up-to-date file (quick-check match). The returned raw flags OR `base`
@@ -624,11 +624,16 @@ impl ReceiverContext {
     pub(in crate::receiver) fn itemize_existing_flags(
         &self,
         entry: &FileEntry,
-        dest_meta: &fs::Metadata,
+        dest_meta: Option<&fs::Metadata>,
         base: u32,
     ) -> u32 {
         use crate::generator::ItemFlags;
         let mut iflags = base;
+        let Some(dest_meta) = dest_meta else {
+            // upstream: generator.c:578 - the `statret < 0` leg contributes only
+            // ITEM_IS_NEW; there is no destination stat to compare against.
+            return iflags | ItemFlags::ITEM_IS_NEW;
+        };
         // upstream: generator.c:521 - S_ISREG(file->mode) && F_LENGTH(file) != st_size
         if entry.is_file() && entry.size() != dest_meta.len() {
             iflags |= ItemFlags::ITEM_REPORT_SIZE;
@@ -668,8 +673,11 @@ impl ReceiverContext {
             {
                 iflags |= ItemFlags::ITEM_REPORT_ATIME;
             }
-            // upstream: generator.c:547-549 - preserve_perms && CHMOD_BITS differ
-            if self.config.flags.perms {
+            // upstream: generator.c:542-549 - `#ifndef CAN_CHMOD_SYMLINK` skips
+            // the whole perm compare for a symlink, because a platform without
+            // lchmod() can never change a symlink's own mode. Mirrors the same
+            // guard in engine's local-copy change-set detection.
+            if self.config.flags.perms && !entry.is_symlink() {
                 const CHMOD_BITS: u32 = 0o7777;
                 if (dest_meta.mode() & CHMOD_BITS) != (entry.mode() & CHMOD_BITS) {
                     iflags |= ItemFlags::ITEM_REPORT_PERMS;
@@ -995,7 +1003,7 @@ mod itemize_order_tests {
         with_u.flags.times = true;
         with_u.flags.atimes = true;
         let ctx = ReceiverContext::new_for_test(&hs, with_u);
-        let flags = ctx.itemize_existing_flags(&entry, &meta, 0);
+        let flags = ctx.itemize_existing_flags(&entry, Some(&meta), 0);
         assert!(
             flags & ItemFlags::ITEM_REPORT_ATIME != 0,
             "atime row missing under -U: {flags:#06x}"
@@ -1009,7 +1017,7 @@ mod itemize_order_tests {
         without_u.flags.times = true;
         without_u.flags.atimes = false;
         let ctx = ReceiverContext::new_for_test(&hs, without_u);
-        let flags = ctx.itemize_existing_flags(&entry, &meta, 0);
+        let flags = ctx.itemize_existing_flags(&entry, Some(&meta), 0);
         assert!(
             flags & ItemFlags::ITEM_REPORT_ATIME == 0,
             "atime row must be gated on --atimes: {flags:#06x}"


### PR DESCRIPTION
## Summary

Upstream's `itemize()` (`generator.c:511-579`) is a single function whose `statret >= 0` / `statret < 0` split is an internal `if`/`else`. oc's port, `ReceiverContext::itemize_existing_flags`, instead hoisted the `statret < 0` (new-file) leg up into the caller, hardcoding `ITEM_TRANSFER|ITEM_IS_NEW` at the candidate seed.

That divergence has costs: upstream's new-file xattr leg (`generator.c:574-576`) has nowhere to live, and `ITEM_IS_NEW` gets re-derived at individual call sites instead of once.

This changes `dest_meta` from `&fs::Metadata` to `Option<&fs::Metadata>`, so `None` models `statret < 0` and `ITEM_IS_NEW` is produced inside the function, matching upstream's shape.

## Details

- `itemize_existing_flags` takes `dest_meta: Option<&fs::Metadata>`; the `None` arm returns `base | ITEM_IS_NEW` (`generator.c:578`).
- The candidate seed's `match dest_meta { Some(..) => .., None => ITEM_TRANSFER|ITEM_IS_NEW }` collapses to a single call passing `dest_meta.as_ref()`.
- `existing_dir_iflags` and `verbose_dir_name_lines` keep their `Err(_) => 0` arms deliberately: a *failed stat* there is upstream's benign "no change" outcome, not the `statret < 0` new-file leg. Both stay on the `Some` path, with a comment recording why.
- Adds the symlink guard upstream applies to the perm compare (`generator.c:542-549`, `#ifndef CAN_CHMOD_SYMLINK`). It is unreachable today because symlinks take their own branch, but deriving `ITEM_IS_NEW` inside this function makes its absence a live hazard once the symlink path routes through here. This mirrors the identical guard already present in `engine`'s local-copy change-set detection (`plan/change_set/detection.rs:86,276`).

No behaviour change is intended at any call site.

## Verification

- `cargo nextest run -p transfer --all-features -E 'test(itemize)'` - 62/62 pass, including the `itemize_rows_match_upstream_3_4_4_golden` fidelity golden. The pre-existing `itemize_existing_flags_reports_atime_only_under_dash_u` assertions are unchanged (only the mechanical `&meta` -> `Some(&meta)` call adaptation).
- Full `-p transfer` suite in **both** feature configurations, since `run_pipelined` and `run_pipelined_incremental` take different routes through these call sites:
  - `--all-features` (incremental-flist on): 2502 passed, 3 skipped
  - default features (incremental-flist off): 2496 passed, 3 skipped
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- Real `-a -i` transfers over a tree with a symlink, a FIFO, an empty dir, and nested files, across five scenarios (fresh copy, mtime+perm change, no-op re-sync, `-n` dry run, `--existing`): output is byte-identical before vs. after, **and** byte-identical to upstream rsync 3.4.4.
